### PR TITLE
refactor: Simplify and decouple NFS read/write/commit handlers

### DIFF
--- a/internal/protocol/nfs/v3/handlers/utils.go
+++ b/internal/protocol/nfs/v3/handlers/utils.go
@@ -1,9 +1,33 @@
 package handlers
 
+import (
+	"github.com/marmos91/dittofs/internal/protocol/nfs/types"
+	"github.com/marmos91/dittofs/pkg/store/metadata"
+)
+
 // safeAdd performs checked addition of two uint64 values.
 // Returns the sum and a boolean indicating whether overflow occurred.
 func safeAdd(a, b uint64) (uint64, bool) {
 	sum := a + b
 	overflow := sum < a // If sum wrapped around, it will be less than a
 	return sum, overflow
+}
+
+// buildWccAttr builds WCC (Weak Cache Consistency) attributes from FileAttr.
+// Used in WRITE, COMMIT, and other procedures to help clients detect concurrent modifications.
+//
+// WCC data consists of file attributes before and after an operation, allowing clients
+// to invalidate their caches if the file changed unexpectedly.
+func buildWccAttr(attr *metadata.FileAttr) *types.WccAttr {
+	return &types.WccAttr{
+		Size: attr.Size,
+		Mtime: types.TimeVal{
+			Seconds:  uint32(attr.Mtime.Unix()),
+			Nseconds: uint32(attr.Mtime.Nanosecond()),
+		},
+		Ctime: types.TimeVal{
+			Seconds:  uint32(attr.Ctime.Unix()),
+			Nseconds: uint32(attr.Ctime.Nanosecond()),
+		},
+	}
 }


### PR DESCRIPTION
## Summary

Major refactoring of READ, WRITE, and COMMIT NFS handlers to reduce complexity and improve maintainability.

## Changes

### Code Reduction
- **Main handler functions**: Reduced by 56% (1,321 → 579 lines)
- **READ handler**: 454 → 190 lines (58% reduction)
- **WRITE handler**: 358 → 180 lines (50% reduction)
- **COMMIT handler**: 509 → 146 lines (71% reduction)

### Complexity Improvements
- **Nesting depth**: Reduced from 6-7 levels to 2-3 levels
- Extracted focused helper functions with single responsibilities
- Centralized duplicated code (cache population, error handling)
- Created shared `buildWccAttr()` utility in utils.go

### Architecture Improvements
- Removed S3-specific logic from COMMIT handler
- COMMIT now uses generic `IncrementalWriteStore` interface
- Storage strategy decisions delegated to content store implementations
- Better separation of concerns (protocol layer vs storage layer)

## Extracted Helper Functions

### READ Handler
- `tryReadFromCache()` - Unified cache lookup (write cache → read cache)
- `readFromContentStoreWithReadAt()` - Efficient range reads
- `readFromContentStoreSequential()` - Fallback for non-ReadAt stores
- `seekToOffset()` - Handle seekable vs non-seekable readers
- `populateReadCacheFromRead()` - Centralized cache population

### WRITE Handler
- `buildWccAttr()` - Shared WCC attribute builder (moved to utils.go)
- `buildWriteErrorResponse()` - Consistent error response creation
- `writeToStorage()` - Cache vs direct write strategy
- `populateReadCacheAfterWrite()` - Read cache population for sync mode

### COMMIT Handler
- `flushCacheToContentStore()` - Implementation-agnostic dispatcher
- `flushIncremental()` - For IncrementalWriteStore implementations
- `flushNonIncremental()` - For filesystem/memory stores
- `populateReadCacheAfterCommit()` - Centralized cache population