### PR TITLE
fix(smb): advertise implemented filesystem capabilities in FileFsAttributeInformation

### DIFF
--- a/internal/protocol/smb/v2/handlers/query_info.go
+++ b/internal/protocol/smb/v2/handlers/query_info.go
@@ -558,7 +558,7 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 	case 5: // FileFsAttributeInformation [MS-FSCC] 2.5.1
 		fsName := []byte{'N', 0, 'T', 0, 'F', 0, 'S', 0} // "NTFS" in UTF-16LE
 		info := make([]byte, 12+len(fsName))
-		binary.LittleEndian.PutUint32(info[0:4], 0x00000003) // FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES
+		binary.LittleEndian.PutUint32(info[0:4], 0x0000008F) // FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES | FILE_UNICODE_ON_DISK | FILE_PERSISTENT_ACLS | FILE_SUPPORTS_REPARSE_POINTS
 		binary.LittleEndian.PutUint32(info[4:8], 255)
 		binary.LittleEndian.PutUint32(info[8:12], uint32(len(fsName)))
 		copy(info[12:], fsName)


### PR DESCRIPTION
## Summary
- Update `FileFsAttributeInformation` flags from `0x03` to `0x8F` to advertise capabilities DittoFS already implements
- Adds `FILE_UNICODE_ON_DISK` (0x04), `FILE_PERSISTENT_ACLS` (0x08), and `FILE_SUPPORTS_REPARSE_POINTS` (0x80)
- Windows clients use these flags to enable UI elements like the Security tab and symlink resolution

Part of #141

Closes #142