### PR TITLE
fix(168): fix dfs server compilation on Windows

### DIFF
--- a/cmd/dfs/commands/daemon_unix.go
+++ b/cmd/dfs/commands/daemon_unix.go
@@ -1,0 +1,98 @@
+//go:build !windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// isProcessRunning reads a PID from the given file and checks whether
+// that process is still alive. Returns the PID and true if running,
+// or 0 and false otherwise.
+func isProcessRunning(pidPath string) (int, bool) {
+	pidData, err := os.ReadFile(pidPath)
+	if err != nil {
+		return 0, false
+	}
+
+	var pid int
+	if _, err := fmt.Sscanf(string(pidData), "%d", &pid); err != nil {
+		return 0, false
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return 0, false
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		return 0, false
+	}
+
+	return pid, true
+}
+
+// startDaemon starts the server as a background daemon process.
+func startDaemon() error {
+	stateDir := GetDefaultStateDir()
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	pidPath := pidFile
+	if pidPath == "" {
+		pidPath = filepath.Join(stateDir, "dittofs.pid")
+	}
+
+	if pid, running := isProcessRunning(pidPath); running {
+		return fmt.Errorf("DittoFS is already running (PID %d)\nUse 'dfs stop' to stop the running instance", pid)
+	}
+	_ = os.Remove(pidPath)
+
+	logPath := logFile
+	if logPath == "" {
+		logPath = filepath.Join(stateDir, "dittofs.log")
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	daemonArgs := []string{"start", "--foreground", "--pid-file", pidPath}
+	if GetConfigFile() != "" {
+		daemonArgs = append(daemonArgs, "--config", GetConfigFile())
+	}
+
+	cmd := exec.Command(executable, daemonArgs...)
+
+	logFileHandle, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+
+	cmd.Stdout = logFileHandle
+	cmd.Stderr = logFileHandle
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = logFileHandle.Close()
+		return fmt.Errorf("failed to start daemon: %w", err)
+	}
+
+	_ = logFileHandle.Close()
+
+	fmt.Printf("DittoFS started in background (PID %d)\n", cmd.Process.Pid)
+	fmt.Printf("  PID file: %s\n", pidPath)
+	fmt.Printf("  Log file: %s\n", logPath)
+	fmt.Println("\nUse 'dfs stop' to stop the server")
+	fmt.Println("Use 'dfs status' to check server status")
+
+	return nil
+}

--- a/cmd/dfs/commands/daemon_windows.go
+++ b/cmd/dfs/commands/daemon_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package commands
+
+import "fmt"
+
+// startDaemon is not supported on Windows.
+// Use --foreground flag to run the server in the foreground.
+func startDaemon() error {
+	return fmt.Errorf("daemon mode is not supported on Windows, use --foreground")
+}

--- a/cmd/dfs/commands/stop_unix.go
+++ b/cmd/dfs/commands/stop_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// stopProcess sends the appropriate signal to stop the DittoFS server process.
+func stopProcess(process *os.Process, pid int, force bool) error {
+	sig, name := syscall.SIGTERM, "SIGTERM"
+	if force {
+		sig, name = syscall.SIGKILL, "SIGKILL"
+	}
+
+	fmt.Printf("Sending %s to process %d...\n", name, pid)
+
+	err := process.Signal(sig)
+	if err == os.ErrProcessDone {
+		return errProcessDone
+	}
+	if err != nil {
+		return fmt.Errorf("failed to send signal: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/dfs/commands/stop_windows.go
+++ b/cmd/dfs/commands/stop_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+)
+
+// stopProcess terminates the DittoFS server process on Windows.
+// Force mode uses process.Kill(); graceful mode sends os.Interrupt.
+func stopProcess(process *os.Process, pid int, force bool) error {
+	var err error
+	if force {
+		fmt.Printf("Killing process %d...\n", pid)
+		err = process.Kill()
+	} else {
+		fmt.Printf("Sending interrupt to process %d...\n", pid)
+		err = process.Signal(os.Interrupt)
+	}
+
+	if err == os.ErrProcessDone {
+		return errProcessDone
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stop process: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cache/wal/mmap_windows.go
+++ b/pkg/cache/wal/mmap_windows.go
@@ -28,8 +28,13 @@ func (p *MmapPersister) Sync() error {
 	return ErrUnsupportedPlatform
 }
 
+// AppendBlockUploaded is not supported on Windows.
+func (p *MmapPersister) AppendBlockUploaded(_ string, _, _ uint32) error {
+	return ErrUnsupportedPlatform
+}
+
 // Recover is not supported on Windows.
-func (p *MmapPersister) Recover() ([]BlockWriteEntry, error) {
+func (p *MmapPersister) Recover() (*RecoveryResult, error) {
 	return nil, ErrUnsupportedPlatform
 }
 


### PR DESCRIPTION
## Summary

- Fix outdated WAL Windows stub: update `Recover()` return type to `*RecoveryResult` and add missing `AppendBlockUploaded()` method
- Extract `startDaemon()` into platform-specific files (`daemon_unix.go`, `daemon_windows.go`) to avoid `syscall.SysProcAttr{Setsid: true}` on Windows
- Extract stop command signal handling into platform-specific files (`stop_unix.go`, `stop_windows.go`) to avoid `syscall.SIGKILL` on Windows

## Test plan

- [x] `go build ./cmd/dfs/` succeeds on Windows, Linux, and macOS
- [x] `go build ./cmd/dfsctl/` succeeds on all platforms
- [x] `go vet ./cmd/dfs/... ./pkg/cache/wal/...` passes on Windows
- [ ] `dfs start --foreground` runs the server on Windows
- [ ] `dfs start` (daemon mode) returns a clear error on Windows
- [ ] `dfs stop` terminates the server on Windows

Closes #168