### PR TITLE
fix(169): replace hardcoded Unix paths for Windows compatibility

### DIFF
--- a/cmd/dfs/commands/util.go
+++ b/cmd/dfs/commands/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/config"
@@ -24,11 +25,24 @@ func InitLogger(cfg *config.Config) error {
 
 // GetDefaultStateDir returns the default state directory path.
 func GetDefaultStateDir() string {
+	if runtime.GOOS == "windows" {
+		// On Windows, use %LOCALAPPDATA%\dittofs
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData != "" {
+			return filepath.Join(localAppData, "dittofs")
+		}
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return filepath.Join(os.TempDir(), "dittofs")
+		}
+		return filepath.Join(homeDir, "AppData", "Local", "dittofs")
+	}
+
 	stateDir := os.Getenv("XDG_STATE_HOME")
 	if stateDir == "" {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return "/tmp"
+			return filepath.Join(os.TempDir(), "dittofs")
 		}
 		stateDir = filepath.Join(homeDir, ".local", "state")
 	}

--- a/internal/cli/credentials/store.go
+++ b/internal/cli/credentials/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -101,14 +102,28 @@ func NewStore() (*Store, error) {
 
 // getConfigPath returns the path to the config file.
 func getConfigPath() (string, error) {
-	// Use XDG_CONFIG_HOME if set, otherwise ~/.config
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine home directory: %w", err)
+	var configHome string
+
+	if runtime.GOOS == "windows" {
+		// On Windows, use %APPDATA%\dfsctl
+		configHome = os.Getenv("APPDATA")
+		if configHome == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("cannot determine home directory: %w", err)
+			}
+			configHome = filepath.Join(home, "AppData", "Roaming")
 		}
-		configHome = filepath.Join(home, ".config")
+	} else {
+		// On Unix, use XDG_CONFIG_HOME or ~/.config
+		configHome = os.Getenv("XDG_CONFIG_HOME")
+		if configHome == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("cannot determine home directory: %w", err)
+			}
+			configHome = filepath.Join(home, ".config")
+		}
 	}
 
 	return filepath.Join(configHome, DefaultConfigDir, ConfigFileName), nil

--- a/internal/cli/credentials/store_test.go
+++ b/internal/cli/credentials/store_test.go
@@ -3,12 +3,25 @@ package credentials
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// setTestConfigHome sets the appropriate env var for config home based on OS.
+// On Windows it sets APPDATA, on Unix it sets XDG_CONFIG_HOME.
+// t.Setenv automatically restores the original value when the test completes.
+func setTestConfigHome(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", dir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", dir)
+	}
+}
 
 func TestContextIsExpired(t *testing.T) {
 	tests := []struct {
@@ -60,10 +73,8 @@ func TestStoreOperations(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// Set XDG_CONFIG_HOME to temp directory
-	oldXDG := os.Getenv("XDG_CONFIG_HOME")
-	_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer func() { _ = os.Setenv("XDG_CONFIG_HOME", oldXDG) }()
+	// Set config home to temp directory (APPDATA on Windows, XDG_CONFIG_HOME on Unix)
+	setTestConfigHome(t, tmpDir)
 
 	// Create store
 	store, err := NewStore()
@@ -144,9 +155,7 @@ func TestStoreUpdateTokens(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	oldXDG := os.Getenv("XDG_CONFIG_HOME")
-	_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer func() { _ = os.Setenv("XDG_CONFIG_HOME", oldXDG) }()
+	setTestConfigHome(t, tmpDir)
 
 	store, err := NewStore()
 	require.NoError(t, err)
@@ -180,9 +189,7 @@ func TestStoreClearCurrentContext(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	oldXDG := os.Getenv("XDG_CONFIG_HOME")
-	_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer func() { _ = os.Setenv("XDG_CONFIG_HOME", oldXDG) }()
+	setTestConfigHome(t, tmpDir)
 
 	store, err := NewStore()
 	require.NoError(t, err)
@@ -219,9 +226,7 @@ func TestStorePreferences(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	oldXDG := os.Getenv("XDG_CONFIG_HOME")
-	_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer func() { _ = os.Setenv("XDG_CONFIG_HOME", oldXDG) }()
+	setTestConfigHome(t, tmpDir)
 
 	store, err := NewStore()
 	require.NoError(t, err)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -211,7 +213,7 @@ func GetDefaultConfig() *Config {
 			Type: store.DatabaseTypeSQLite, // Default to SQLite for single-node
 		},
 		Cache: CacheConfig{
-			Path: "/tmp/dittofs-cache",
+			Path: filepath.Join(os.TempDir(), "dittofs-cache"),
 			Size: bytesize.ByteSize(bytesize.GiB), // 1 GiB
 		},
 		Admin: AdminConfig{


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp` fallback with `os.TempDir()` in `GetDefaultStateDir()`
- Use `%LOCALAPPDATA%\dittofs` as default state directory on Windows
- Use `filepath.Join(os.TempDir(), "dittofs-cache")` for default cache path in `GetDefaultConfig()`
- Use `%APPDATA%\dfsctl` for credential storage on Windows instead of `~/.config/dfsctl`
- Update credential store tests with cross-platform config home helper

## Test plan

- [x] Credential store tests pass on Windows
- [ ] Verify `GetDefaultStateDir()` returns correct path on Linux/macOS
- [ ] Verify credential config path uses XDG convention on Linux/macOS
- [ ] Verify default cache path uses system temp dir on both platforms

Closes #169