### PR TITLE
feat(170): Add Windows mount/unmount/list-mounts support

### DIFF
--- a/cmd/dfsctl/commands/share/list_mounts.go
+++ b/cmd/dfsctl/commands/share/list_mounts.go
@@ -2,9 +2,6 @@ package share
 
 import (
 	"fmt"
-	"os/exec"
-	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -32,27 +29,17 @@ Examples:
 	RunE: runListMounts,
 }
 
-// Note: listMountsCmd is added in share.go init()
-
-// MountInfo represents information about a mounted share
+// MountInfo represents information about a mounted share.
 type MountInfo struct {
 	Source     string
 	MountPoint string
 	Protocol   string
-	Options    string
 }
 
 func runListMounts(cmd *cobra.Command, args []string) error {
-	// Validate platform
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-		return fmt.Errorf("unsupported platform: %s\nHint: Supported platforms are macOS and Linux", runtime.GOOS)
-	}
-
-	// Get optional share filter
 	var shareFilter string
 	if len(args) > 0 {
 		shareFilter = args[0]
-		// Normalize share filter - ensure it starts with /
 		if !strings.HasPrefix(shareFilter, "/") {
 			shareFilter = "/" + shareFilter
 		}
@@ -63,13 +50,12 @@ func runListMounts(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Filter by share if specified
 	if shareFilter != "" {
-		filtered := make([]MountInfo, 0)
+		var filtered []MountInfo
 		for _, m := range mounts {
-			// Check if source contains the share path
-			// Source format: localhost:/share or //localhost/share
-			if strings.Contains(m.Source, ":"+shareFilter) || strings.HasSuffix(m.Source, shareFilter) {
+			if strings.Contains(m.Source, ":"+shareFilter) ||
+				strings.HasSuffix(m.Source, shareFilter) ||
+				strings.HasSuffix(m.Source, strings.ReplaceAll(shareFilter, "/", "\\")) {
 				filtered = append(filtered, m)
 			}
 		}
@@ -92,79 +78,4 @@ func runListMounts(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func getDittoFSMounts() ([]MountInfo, error) {
-	cmd := exec.Command("mount")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list mounts: %w", err)
-	}
-
-	var mounts []MountInfo
-	lines := strings.Split(string(output), "\n")
-
-	// Patterns for DittoFS mounts (NFS and SMB from localhost).
-	//
-	// These regular expressions parse the output of the `mount` command, which differs
-	// by platform. They assume the following output formats:
-	//
-	//   macOS/BSD (no explicit "type" keyword):
-	//     NFS: localhost:/export        on /private/tmp/nfs (nfs, ...)
-	//     SMB: //user@localhost/share   on /private/tmp/smb (smbfs, ...)
-	//
-	//   Linux (explicit "type" keyword):
-	//     NFS: localhost:/export        on /mnt/nfs type nfs (...)
-	//     SMB: //localhost/share        on /mnt/smb type cifs (...)
-	//
-	// Key assumptions:
-	//   - Source appears at line start, mount point follows " on "
-	//   - Filesystem type is in parentheses (macOS) or after "type" (Linux)
-	//   - Only mounts from "localhost" are considered DittoFS candidates
-	//
-	// If mount output format changes across OS versions, these patterns may need updates.
-
-	nfsPattern := regexp.MustCompile(`^localhost:(/\S+)\s+on\s+(\S+)\s+.*\((nfs|type nfs)`)
-	smbPattern := regexp.MustCompile(`^//[^@]*@?localhost[:/](\S+)\s+on\s+(\S+)\s+.*\((smbfs|cifs|type cifs)`)
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		// Check for NFS mount from localhost
-		if matches := nfsPattern.FindStringSubmatch(line); matches != nil {
-			mounts = append(mounts, MountInfo{
-				Source:     "localhost:" + matches[1],
-				MountPoint: matches[2],
-				Protocol:   "NFS",
-			})
-			continue
-		}
-
-		// Check for SMB mount from localhost
-		if matches := smbPattern.FindStringSubmatch(line); matches != nil {
-			mounts = append(mounts, MountInfo{
-				Source:     "//localhost/" + matches[1],
-				MountPoint: matches[2],
-				Protocol:   "SMB",
-			})
-			continue
-		}
-
-		// Also check for direct localhost mounts (without protocol prefix detection)
-		if strings.Contains(line, "localhost") && (strings.Contains(line, "(nfs") || strings.Contains(line, "type nfs")) {
-			parts := strings.Fields(line)
-			if len(parts) >= 3 && parts[1] == "on" {
-				mounts = append(mounts, MountInfo{
-					Source:     parts[0],
-					MountPoint: parts[2],
-					Protocol:   "NFS",
-				})
-			}
-		}
-	}
-
-	return mounts, nil
 }

--- a/cmd/dfsctl/commands/share/list_mounts_unix.go
+++ b/cmd/dfsctl/commands/share/list_mounts_unix.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package share
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// Patterns for DittoFS mounts (NFS and SMB from localhost).
+//
+// These regular expressions parse the output of the `mount` command, which differs
+// by platform. They assume the following output formats:
+//
+//	macOS/BSD (no explicit "type" keyword):
+//	  NFS: localhost:/export        on /private/tmp/nfs (nfs, ...)
+//	  SMB: //user@localhost/share   on /private/tmp/smb (smbfs, ...)
+//
+//	Linux (explicit "type" keyword):
+//	  NFS: localhost:/export        on /mnt/nfs type nfs (...)
+//	  SMB: //localhost/share        on /mnt/smb type cifs (...)
+//
+// Key assumptions:
+//   - Source appears at line start, mount point follows " on "
+//   - Filesystem type is in parentheses (macOS) or after "type" (Linux)
+//   - Only mounts from "localhost" are considered DittoFS candidates
+//
+// If mount output format changes across OS versions, these patterns may need updates.
+var (
+	nfsPattern = regexp.MustCompile(`^localhost:(/\S+)\s+on\s+(\S+)\s+.*\((nfs|type nfs)`)
+	smbPattern = regexp.MustCompile(`^//[^@]*@?localhost[:/](\S+)\s+on\s+(\S+)\s+.*\((smbfs|cifs|type cifs)`)
+)
+
+func getDittoFSMounts() ([]MountInfo, error) {
+	cmd := exec.Command("mount")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list mounts: %w", err)
+	}
+
+	var mounts []MountInfo
+
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, "localhost") {
+			continue
+		}
+
+		if matches := nfsPattern.FindStringSubmatch(line); matches != nil {
+			mounts = append(mounts, MountInfo{
+				Source:     "localhost:" + matches[1],
+				MountPoint: matches[2],
+				Protocol:   "NFS",
+			})
+			continue
+		}
+
+		if matches := smbPattern.FindStringSubmatch(line); matches != nil {
+			mounts = append(mounts, MountInfo{
+				Source:     "//localhost/" + matches[1],
+				MountPoint: matches[2],
+				Protocol:   "SMB",
+			})
+			continue
+		}
+
+		// Fallback: catch localhost NFS mounts that don't match the strict regex
+		// (e.g., unusual mount output formatting on some distros)
+		if strings.Contains(line, "(nfs") || strings.Contains(line, "type nfs") {
+			parts := strings.Fields(line)
+			if len(parts) >= 3 && parts[1] == "on" {
+				mounts = append(mounts, MountInfo{
+					Source:     parts[0],
+					MountPoint: parts[2],
+					Protocol:   "NFS",
+				})
+			}
+		}
+	}
+
+	return mounts, nil
+}

--- a/cmd/dfsctl/commands/share/list_mounts_windows.go
+++ b/cmd/dfsctl/commands/share/list_mounts_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package share
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func getDittoFSMounts() ([]MountInfo, error) {
+	cmd := exec.Command("net", "use")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list mounts: %w", err)
+	}
+
+	var mounts []MountInfo
+	lines := strings.Split(string(output), "\n")
+
+	// Only entries with \\localhost\ in 'net use' output are considered DittoFS candidates.
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "Status") {
+			continue
+		}
+
+		if !strings.Contains(strings.ToLower(line), `\\localhost\`) {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+
+		// The status field may be empty, so find drive letter and UNC path by pattern.
+		var local, remote string
+		for _, field := range fields {
+			if len(field) == 2 && field[1] == ':' {
+				local = field
+			}
+			if strings.HasPrefix(field, `\\`) {
+				remote = field
+			}
+		}
+
+		if remote == "" {
+			continue
+		}
+
+		mounts = append(mounts, MountInfo{
+			Source:     remote,
+			MountPoint: local,
+			Protocol:   "SMB",
+		})
+	}
+
+	return mounts, nil
+}

--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -3,8 +3,6 @@ package share
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
@@ -17,10 +15,6 @@ import (
 const (
 	defaultNFSPort = 12049
 	defaultSMBPort = 12445
-
-	// Default file/dir modes: 0777 on macOS (can't set owner), 0755 on Linux (uid/gid works)
-	defaultModeDarwin = "0777"
-	defaultModeLinux  = "0755"
 )
 
 var (
@@ -58,12 +52,13 @@ Examples:
   # Mount to user directory without sudo (macOS only, recommended)
   mkdir -p ~/mnt/dittofs && dfsctl share mount --protocol smb /export ~/mnt/dittofs
 
-Note: Mount commands typically require sudo/root privileges.
+Note: Mount commands typically require sudo/root privileges on Unix systems.
 
 Platform differences for SMB with sudo:
   - Linux: Mount owner set to your user via uid/gid options (default mode 0755)
   - macOS: Mount owned by root (uid/gid removed in Catalina), default mode 0777
-  - macOS alternative: mount to ~/mnt without sudo for user-owned mount`,
+  - macOS alternative: mount to ~/mnt without sudo for user-owned mount
+  - Windows: Uses 'net use' to map network drives (e.g., dfsctl share mount --protocol smb /export Z:)`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("requires share path and mount point\n\nUsage: dfsctl share mount [share] [mountpoint] --protocol <nfs|smb>\n\nExample: dfsctl share mount --protocol nfs /export /mnt/dittofs")
@@ -88,18 +83,10 @@ func init() {
 	_ = mountCmd.MarkFlagRequired("protocol")
 }
 
-func getDefaultModeForPlatform() (mode, help string) {
-	if runtime.GOOS == "darwin" {
-		return defaultModeDarwin, "File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported)"
-	}
-	return defaultModeLinux, "File permissions for SMB mount (octal)"
-}
-
 func runMount(cmd *cobra.Command, args []string) error {
 	sharePath := args[0]
 	mountPoint := args[1]
 
-	// Validate protocol
 	protocol := strings.ToLower(mountProtocol)
 	if protocol != "nfs" && protocol != "smb" {
 		return fmt.Errorf("invalid protocol '%s': must be 'nfs' or 'smb'\nHint: Use --protocol nfs or --protocol smb", mountProtocol)
@@ -117,13 +104,11 @@ func runMount(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get authenticated client to fetch adapter ports
 	client, err := cmdutil.GetAuthenticatedClient()
 	if err != nil {
 		return fmt.Errorf("failed to get authenticated client: %w\nHint: Run 'dfsctl login' first", err)
 	}
 
-	// Fetch adapter info to get port
 	adapters, err := client.ListAdapters()
 	if err != nil {
 		return fmt.Errorf("failed to list adapters: %w\nHint: Is the DittoFS server running?", err)
@@ -132,62 +117,9 @@ func runMount(cmd *cobra.Command, args []string) error {
 	switch protocol {
 	case "nfs":
 		return mountNFS(sharePath, mountPoint, adapters)
-	case "smb":
-		return mountSMB(sharePath, mountPoint, adapters)
 	default:
-		return fmt.Errorf("unsupported protocol: %s", protocol)
+		return mountSMB(sharePath, mountPoint, adapters)
 	}
-}
-
-func validatePlatform() error {
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-		return fmt.Errorf("unsupported platform: %s\nHint: Supported platforms are macOS and Linux", runtime.GOOS)
-	}
-	return nil
-}
-
-func checkMountPrivileges(mountPoint, protocol, sharePath string) error {
-	if os.Geteuid() == 0 {
-		return nil
-	}
-
-	// On macOS, mounting to user's home directory works without sudo
-	if runtime.GOOS == "darwin" {
-		if homeDir, _ := os.UserHomeDir(); homeDir != "" && strings.HasPrefix(mountPoint, homeDir) {
-			return nil
-		}
-	}
-
-	hint := fmt.Sprintf("Run with sudo: sudo dfsctl share mount --protocol %s %s %s", protocol, sharePath, mountPoint)
-	if runtime.GOOS == "darwin" {
-		hint += fmt.Sprintf("\nOr mount to your home directory: dfsctl share mount --protocol %s %s ~/mnt/share", protocol, sharePath)
-	}
-	return fmt.Errorf("mount requires root privileges (or mount to home directory on macOS)\nHint: %s", hint)
-}
-
-func validateMountPoint(mountPoint string) error {
-	info, err := os.Stat(mountPoint)
-	if os.IsNotExist(err) {
-		return fmt.Errorf("mount point does not exist: %s\nHint: Create the directory first with 'mkdir %s'", mountPoint, mountPoint)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to access mount point: %w", err)
-	}
-
-	if !info.IsDir() {
-		return fmt.Errorf("mount point is not a directory: %s\nHint: Specify a directory path as the mount point", mountPoint)
-	}
-
-	// Check if directory is empty
-	entries, err := os.ReadDir(mountPoint)
-	if err != nil {
-		return fmt.Errorf("failed to read mount point directory: %w", err)
-	}
-	if len(entries) > 0 {
-		return fmt.Errorf("mount point is not empty: %s\nHint: Use an empty directory as the mount point", mountPoint)
-	}
-
-	return nil
 }
 
 func getAdapterPort(adapters []apiclient.Adapter, protocol string, defaultPort int) int {
@@ -197,56 +129,6 @@ func getAdapterPort(adapters []apiclient.Adapter, protocol string, defaultPort i
 		}
 	}
 	return defaultPort
-}
-
-func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
-	port := getAdapterPort(adapters, "nfs", defaultNFSPort)
-
-	// actimeo=0 disables attribute caching for immediate visibility of changes
-	mountOptions := fmt.Sprintf("nfsvers=3,tcp,port=%d,mountport=%d,actimeo=0", port, port)
-
-	// Add platform-specific options
-	if runtime.GOOS == "darwin" {
-		mountOptions += ",resvport"
-	} else {
-		mountOptions += ",nolock"
-	}
-
-	source := fmt.Sprintf("localhost:%s", sharePath)
-	cmd := exec.Command("mount", "-t", "nfs", "-o", mountOptions, source, mountPoint)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return formatMountError(err, string(output), "NFS", port)
-	}
-
-	fmt.Printf("Mounted %s at %s (NFS)\n", sharePath, mountPoint)
-	return nil
-}
-
-func mountSMB(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
-	port := getAdapterPort(adapters, "smb", defaultSMBPort)
-
-	username, err := resolveSMBUsername()
-	if err != nil {
-		return err
-	}
-
-	password, err := resolveSMBPassword(username)
-	if err != nil {
-		return err
-	}
-
-	shareName := strings.TrimPrefix(sharePath, "/")
-	cmd := buildSMBMountCommand(username, password, port, shareName, mountPoint)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return formatMountError(err, string(output), "SMB", port)
-	}
-
-	fmt.Printf("Mounted %s at %s (SMB)\n", sharePath, mountPoint)
-	return nil
 }
 
 func resolveSMBUsername() (string, error) {
@@ -282,85 +164,36 @@ func resolveSMBPassword(username string) (string, error) {
 	return password, nil
 }
 
-func buildSMBMountCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
-	if runtime.GOOS == "darwin" {
-		return buildDarwinSMBCommand(username, password, port, shareName, mountPoint)
-	}
-	return buildLinuxSMBCommand(username, password, port, shareName, mountPoint)
-}
-
-func buildDarwinSMBCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
-	// macOS: mount_smbfs -f MODE -d MODE //USER:PASS@localhost:PORT/SHARE MOUNTPOINT
-	// Note: Modern macOS (Ventura+) removed -u/-g options for setting owner.
-	// Files will be owned by root when mounted with sudo.
-	// Default is 0777 to allow all users to write to the mounted share.
-	smbURL := fmt.Sprintf("//%s:%s@localhost:%d/%s", username, password, port, shareName)
-	args := []string{"-f", mountFileMode, "-d", mountDirMode, smbURL, mountPoint}
-
-	// macOS security restriction: only the mount owner can access files,
-	// regardless of Unix permissions (Apple's "works as intended" behavior).
-	// When running with sudo, we use "sudo -u <original_user>" to mount as
-	// that user instead of root, so they can actually access the mounted files.
-	// See: https://discussions.apple.com/thread/4927134
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		return exec.Command("sudo", append([]string{"-u", sudoUser, "mount_smbfs"}, args...)...)
-	}
-	return exec.Command("mount_smbfs", args...)
-}
-
-func buildLinuxSMBCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
-	// Linux: mount -t cifs //localhost/SHARE MOUNTPOINT -o port=PORT,username=USER,password=PASS,vers=2.1,uid=UID,gid=GID
-	// When running with sudo, set uid/gid to the original user (not root)
-	mountOpts := fmt.Sprintf("port=%d,username=%s,password=%s,vers=2.1", port, username, password)
-
-	if sudoUID := os.Getenv("SUDO_UID"); sudoUID != "" {
-		mountOpts += ",uid=" + sudoUID
-	}
-	if sudoGID := os.Getenv("SUDO_GID"); sudoGID != "" {
-		mountOpts += ",gid=" + sudoGID
-	}
-
-	return exec.Command("mount", "-t", "cifs",
-		fmt.Sprintf("//localhost/%s", shareName),
-		mountPoint,
-		"-o", mountOpts)
-}
-
 func formatMountError(err error, output, protocol string, port int) error {
-	outputLower := strings.ToLower(output)
-	errStr := strings.ToLower(err.Error())
+	combined := strings.ToLower(output + " " + err.Error())
 
-	// Check for common error patterns
-	if strings.Contains(outputLower, "connection refused") || strings.Contains(errStr, "connection refused") {
-		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Is the %s adapter running? Check with 'dfsctl adapter list'", err, output, protocol)
+	// Match known error patterns to user-friendly hints.
+	hints := []struct {
+		keywords []string
+		hint     string
+	}{
+		{[]string{"connection refused"}, fmt.Sprintf("Is the %s adapter running? Check with 'dfsctl adapter list'", protocol)},
+		{[]string{"not found", "no such file", "does not exist"}, "Does the share exist? Check with 'dfsctl share list'"},
+		{[]string{"permission denied", "operation not permitted"}, "Mount commands may require sudo privileges"},
+		{[]string{"already mounted", "busy"}, "The mount point may already be in use. Check with 'mount' command"},
+		{[]string{"authentication", "login", "access denied"}, "Check your credentials with 'dfsctl login'"},
 	}
 
-	if strings.Contains(outputLower, "not found") || strings.Contains(outputLower, "no such file") ||
-		strings.Contains(outputLower, "does not exist") {
-		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Does the share exist? Check with 'dfsctl share list'", err, output)
+	for _, h := range hints {
+		for _, kw := range h.keywords {
+			if strings.Contains(combined, kw) {
+				return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: %s", err, output, h.hint)
+			}
+		}
 	}
 
-	if strings.Contains(outputLower, "permission denied") || strings.Contains(outputLower, "operation not permitted") ||
-		strings.Contains(errStr, "permission denied") {
-		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Mount commands may require sudo privileges", err, output)
-	}
-
-	if strings.Contains(outputLower, "already mounted") || strings.Contains(outputLower, "busy") {
-		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: The mount point may already be in use. Check with 'mount' command", err, output)
-	}
-
-	if strings.Contains(outputLower, "authentication") || strings.Contains(outputLower, "login") ||
-		strings.Contains(outputLower, "access denied") {
-		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Check your credentials with 'dfsctl login'", err, output)
-	}
-
-	if strings.Contains(outputLower, "broken pipe") || strings.Contains(outputLower, "connection reset") {
+	// Broken pipe / connection reset has protocol-specific hints.
+	if strings.Contains(combined, "broken pipe") || strings.Contains(combined, "connection reset") {
 		if protocol == "SMB" {
 			return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: This often indicates wrong password or authentication failure. Verify your credentials and try again", err, output)
 		}
 		return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Server closed the connection unexpectedly. Check %s adapter logs with 'dittofs logs'", err, output, protocol)
 	}
 
-	// Generic error
 	return fmt.Errorf("mount failed: %w\nOutput: %s\nHint: Server may be running on port %d. Check with 'dfsctl adapter list'", err, output, port)
 }

--- a/cmd/dfsctl/commands/share/mount_unix.go
+++ b/cmd/dfsctl/commands/share/mount_unix.go
@@ -1,0 +1,174 @@
+//go:build !windows
+
+package share
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+const (
+	// Default file/dir modes: 0777 on macOS (can't set owner), 0755 on Linux (uid/gid works)
+	defaultModeDarwin = "0777"
+	defaultModeLinux  = "0755"
+)
+
+func getDefaultModeForPlatform() (mode, help string) {
+	if runtime.GOOS == "darwin" {
+		return defaultModeDarwin, "File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported)"
+	}
+	return defaultModeLinux, "File permissions for SMB mount (octal)"
+}
+
+func validatePlatform() error {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return fmt.Errorf("unsupported platform: %s\nHint: Supported platforms are macOS, Linux, and Windows", runtime.GOOS)
+	}
+	return nil
+}
+
+func checkMountPrivileges(mountPoint, protocol, sharePath string) error {
+	if os.Geteuid() == 0 {
+		return nil
+	}
+
+	if runtime.GOOS == "darwin" {
+		// On macOS, mounting to user's home directory works without sudo
+		if homeDir, _ := os.UserHomeDir(); homeDir != "" && strings.HasPrefix(mountPoint, homeDir) {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"mount requires root privileges (or mount to home directory on macOS)\nHint: Run with sudo: sudo dfsctl share mount --protocol %s %s %s\n"+
+				"Or mount to your home directory: dfsctl share mount --protocol %s %s ~/mnt/share",
+			protocol, sharePath, mountPoint, protocol, sharePath,
+		)
+	}
+
+	return fmt.Errorf(
+		"mount requires root privileges\nHint: Run with sudo: sudo dfsctl share mount --protocol %s %s %s",
+		protocol, sharePath, mountPoint,
+	)
+}
+
+func validateMountPoint(mountPoint string) error {
+	info, err := os.Stat(mountPoint)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("mount point does not exist: %s\nHint: Create the directory first with 'mkdir %s'", mountPoint, mountPoint)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access mount point: %w", err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("mount point is not a directory: %s\nHint: Specify a directory path as the mount point", mountPoint)
+	}
+
+	entries, err := os.ReadDir(mountPoint)
+	if err != nil {
+		return fmt.Errorf("failed to read mount point directory: %w", err)
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("mount point is not empty: %s\nHint: Use an empty directory as the mount point", mountPoint)
+	}
+
+	return nil
+}
+
+func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
+	port := getAdapterPort(adapters, "nfs", defaultNFSPort)
+
+	// actimeo=0 disables attribute caching for immediate visibility of changes
+	mountOptions := fmt.Sprintf("nfsvers=3,tcp,port=%d,mountport=%d,actimeo=0", port, port)
+
+	if runtime.GOOS == "darwin" {
+		mountOptions += ",resvport"
+	} else {
+		mountOptions += ",nolock"
+	}
+
+	source := fmt.Sprintf("localhost:%s", sharePath)
+	cmd := exec.Command("mount", "-t", "nfs", "-o", mountOptions, source, mountPoint)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return formatMountError(err, string(output), "NFS", port)
+	}
+
+	fmt.Printf("Mounted %s at %s (NFS)\n", sharePath, mountPoint)
+	return nil
+}
+
+func mountSMB(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
+	port := getAdapterPort(adapters, "smb", defaultSMBPort)
+
+	username, err := resolveSMBUsername()
+	if err != nil {
+		return err
+	}
+
+	password, err := resolveSMBPassword(username)
+	if err != nil {
+		return err
+	}
+
+	shareName := strings.TrimPrefix(sharePath, "/")
+	cmd := buildSMBMountCommand(username, password, port, shareName, mountPoint)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return formatMountError(err, string(output), "SMB", port)
+	}
+
+	fmt.Printf("Mounted %s at %s (SMB)\n", sharePath, mountPoint)
+	return nil
+}
+
+func buildSMBMountCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
+	if runtime.GOOS == "darwin" {
+		return buildDarwinSMBCommand(username, password, port, shareName, mountPoint)
+	}
+	return buildLinuxSMBCommand(username, password, port, shareName, mountPoint)
+}
+
+func buildDarwinSMBCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
+	// macOS: mount_smbfs -f MODE -d MODE //USER:PASS@localhost:PORT/SHARE MOUNTPOINT
+	// Note: Modern macOS (Ventura+) removed -u/-g options for setting owner.
+	// Files will be owned by root when mounted with sudo.
+	// Default is 0777 to allow all users to write to the mounted share.
+	smbURL := fmt.Sprintf("//%s:%s@localhost:%d/%s", username, password, port, shareName)
+	args := []string{"-f", mountFileMode, "-d", mountDirMode, smbURL, mountPoint}
+
+	// macOS security restriction: only the mount owner can access files,
+	// regardless of Unix permissions (Apple's "works as intended" behavior).
+	// When running with sudo, we use "sudo -u <original_user>" to mount as
+	// that user instead of root, so they can actually access the mounted files.
+	// See: https://discussions.apple.com/thread/4927134
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		return exec.Command("sudo", append([]string{"-u", sudoUser, "mount_smbfs"}, args...)...)
+	}
+	return exec.Command("mount_smbfs", args...)
+}
+
+func buildLinuxSMBCommand(username, password string, port int, shareName, mountPoint string) *exec.Cmd {
+	// Linux: mount -t cifs //localhost/SHARE MOUNTPOINT -o port=PORT,username=USER,password=PASS,vers=2.1,uid=UID,gid=GID
+	// When running with sudo, set uid/gid to the original user (not root)
+	mountOpts := fmt.Sprintf("port=%d,username=%s,password=%s,vers=2.1", port, username, password)
+
+	if sudoUID := os.Getenv("SUDO_UID"); sudoUID != "" {
+		mountOpts += ",uid=" + sudoUID
+	}
+	if sudoGID := os.Getenv("SUDO_GID"); sudoGID != "" {
+		mountOpts += ",gid=" + sudoGID
+	}
+
+	return exec.Command("mount", "-t", "cifs",
+		fmt.Sprintf("//localhost/%s", shareName),
+		mountPoint,
+		"-o", mountOpts)
+}

--- a/cmd/dfsctl/commands/share/mount_windows.go
+++ b/cmd/dfsctl/commands/share/mount_windows.go
@@ -1,0 +1,156 @@
+//go:build windows
+
+package share
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+const defaultNFSPortStandard = 2049
+
+func getDefaultModeForPlatform() (mode, help string) {
+	return "", "File permissions (not applicable on Windows)"
+}
+
+func validatePlatform() error {
+	return nil
+}
+
+func checkMountPrivileges(mountPoint, protocol, sharePath string) error {
+	// net use does not require elevated privileges for standard drive mappings
+	return nil
+}
+
+func validateMountPoint(mountPoint string) error {
+	// Accept drive letters like Z:
+	if len(mountPoint) == 2 && mountPoint[1] == ':' {
+		letter := mountPoint[0]
+		if (letter >= 'A' && letter <= 'Z') || (letter >= 'a' && letter <= 'z') {
+			return nil
+		}
+		return fmt.Errorf("invalid drive letter: %s\nHint: Use a drive letter like Z: or a directory path", mountPoint)
+	}
+
+	info, err := os.Stat(mountPoint)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("mount point does not exist: %s\nHint: Use a drive letter (e.g., Z:) or create the directory first", mountPoint)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access mount point: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("mount point is not a directory: %s\nHint: Specify a directory path or drive letter as the mount point", mountPoint)
+	}
+
+	return nil
+}
+
+func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
+	port := getAdapterPort(adapters, "nfs", defaultNFSPort)
+
+	fmt.Println(`Note: NFS mounting on Windows requires the 'Client for NFS' feature to be installed.
+
+To enable it:
+  1. Open 'Turn Windows features on or off' (Win+R > optionalfeatures.exe)
+  2. Expand 'Services for NFS' and check 'Client for NFS'
+  3. Click OK and restart your computer if prompted
+
+Alternatively, install via PowerShell (run as Administrator):
+  Enable-WindowsOptionalFeature -FeatureName ServicesForNFS-ClientOnly -Online
+
+For more details, see:
+  https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mount
+  https://learn.microsoft.com/en-us/windows-server/storage/nfs/deploy-nfs`)
+
+	// The Windows NFS mount command does NOT support specifying a custom port via -o options.
+	// Supported -o options are: rsize, wsize, timeout, retry, mtype, lang, fileaccess, anon,
+	// nolock, casesensitive, sec. There is no port option.
+	// See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mount
+	//
+	// If the NFS adapter is on a non-standard port, the user must either:
+	//   1. Configure the NFS adapter to use the standard port (2049)
+	//   2. Set up port forwarding from 2049 to the actual port
+	if port != defaultNFSPortStandard {
+		return fmt.Errorf(
+			"the Windows NFS client does not support mounting from a custom port (server is using port %d)\n\n"+
+				"The Windows 'mount' command only connects to the standard NFS port (2049).\n"+
+				"To resolve this, either:\n\n"+
+				"  1. Configure the NFS adapter to use port 2049 (requires Administrator on the server):\n"+
+				"     dfsctl adapter edit nfs --config '{\"port\": 2049}'\n\n"+
+				"  2. Set up port forwarding from 2049 to %d (requires Administrator):\n"+
+				"     netsh interface portproxy add v4tov4 listenport=2049 listenaddress=127.0.0.1 connectport=%d connectaddress=127.0.0.1\n\n"+
+				"     Then retry the mount command.",
+			port, port, port,
+		)
+	}
+
+	source := fmt.Sprintf("\\\\localhost%s", strings.ReplaceAll(sharePath, "/", "\\"))
+	cmd := exec.Command("mount",
+		"-o", "mtype=hard,nolock",
+		source,
+		mountPoint,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return formatMountError(err, string(output), "NFS", port)
+	}
+
+	fmt.Printf("Mounted %s at %s (NFS)\n", sharePath, mountPoint)
+	return nil
+}
+
+func mountSMB(sharePath, mountPoint string, adapters []apiclient.Adapter) error {
+	port := getAdapterPort(adapters, "smb", defaultSMBPort)
+
+	username, err := resolveSMBUsername()
+	if err != nil {
+		return err
+	}
+
+	password, err := resolveSMBPassword(username)
+	if err != nil {
+		return err
+	}
+
+	shareName := strings.TrimPrefix(sharePath, "/")
+	uncPath := fmt.Sprintf("\\\\localhost\\%s", shareName)
+
+	args := []string{"use", mountPoint, uncPath, fmt.Sprintf("/user:%s", username), password}
+
+	// The standard 'net use' command does not support custom SMB ports.
+	// Windows Insider builds (25992+) added /TCPPORT: support to net use.
+	// See: https://techcommunity.microsoft.com/blog/filecab/smb-alternative-ports-now-supported-in-windows-insider/3974509
+	if port != 445 {
+		fmt.Printf("Note: Server is using non-standard SMB port %d.\n", port)
+		fmt.Printf("Attempting 'net use' with /TCPPORT:%d (requires Windows 11 Insider Build 25992+ or Windows Server 2025+).\n\n", port)
+		args = append(args, fmt.Sprintf("/TCPPORT:%d", port))
+	}
+
+	cmd := exec.Command("net", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if port != 445 {
+			return fmt.Errorf(
+				"mount failed: %w\nOutput: %s\n\n"+
+					"The /TCPPORT flag requires Windows 11 Insider Build 25992+ or Windows Server 2025+.\n"+
+					"On older Windows versions, you can either:\n\n"+
+					"  1. Configure the SMB adapter to use port 445 (requires Administrator on the server):\n"+
+					"     dfsctl adapter edit smb --config '{\"port\": 445}'\n\n"+
+					"  2. Set up port forwarding from 445 to %d (requires Administrator):\n"+
+					"     netsh interface portproxy add v4tov4 listenport=445 listenaddress=127.0.0.1 connectport=%d connectaddress=127.0.0.1\n"+
+					"     Then retry: dfsctl share mount --protocol smb %s %s",
+				err, output, port, port, sharePath, mountPoint,
+			)
+		}
+		return formatMountError(err, string(output), "SMB", port)
+	}
+
+	fmt.Printf("Mounted %s at %s (SMB)\n", sharePath, mountPoint)
+	return nil
+}

--- a/cmd/dfsctl/commands/share/unmount.go
+++ b/cmd/dfsctl/commands/share/unmount.go
@@ -2,18 +2,12 @@ package share
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	unmountForce bool
-)
+var unmountForce bool
 
 var unmountCmd = &cobra.Command{
 	Use:   "unmount [mountpoint]",
@@ -27,7 +21,10 @@ Examples:
   # Force unmount if busy
   dfsctl share unmount --force /mnt/dittofs
 
-Note: Unmount commands typically require sudo/root privileges.`,
+  # Windows: unmount a mapped drive
+  dfsctl share unmount Z:
+
+Note: Unmount commands typically require sudo/root privileges on Unix systems.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return fmt.Errorf("requires mount point path\n\nUsage: dfsctl share unmount [mountpoint]\n\nExample: dfsctl share unmount /mnt/dittofs")
@@ -47,35 +44,18 @@ func init() {
 func runUnmount(cmd *cobra.Command, args []string) error {
 	mountPoint := args[0]
 
-	// Validate platform
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-		return fmt.Errorf("unsupported platform: %s\nHint: Supported platforms are macOS and Linux", runtime.GOOS)
+	if err := validateUnmountPoint(mountPoint); err != nil {
+		return err
 	}
 
-	// Validate mount point exists
-	info, err := os.Stat(mountPoint)
-	if os.IsNotExist(err) {
-		return fmt.Errorf("mount point does not exist: %s\nHint: Check the path is correct", mountPoint)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to access mount point: %w", err)
-	}
-
-	if !info.IsDir() {
-		return fmt.Errorf("mount point is not a directory: %s", mountPoint)
-	}
-
-	// Check if it's actually mounted
 	if !isMountPoint(mountPoint) {
 		return fmt.Errorf("path is not a mount point: %s\nHint: The path does not appear to be a mounted filesystem", mountPoint)
 	}
 
-	// Check for root privileges (required for unmount)
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("unmount requires root privileges\nHint: Run with sudo: sudo dfsctl share unmount %s", mountPoint)
+	if err := checkUnmountPrivileges(mountPoint); err != nil {
+		return err
 	}
 
-	// Perform unmount
 	if err := performUnmount(mountPoint, unmountForce); err != nil {
 		return err
 	}
@@ -84,97 +64,25 @@ func runUnmount(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func isMountPoint(path string) bool {
-	// Use mount command to check if path is mounted
-	cmd := exec.Command("mount")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	// Normalize the path for comparison
-	normalizedPath := strings.TrimSuffix(path, "/")
-
-	// Also get the real path (resolve symlinks) for comparison.
-	// Common symlink scenarios across platforms:
-	// - macOS: /tmp -> /private/tmp, /var -> /private/var
-	// - Linux: /var/run -> /run on some distributions
-	// Mount output shows the resolved path, so we check both.
-	realPath := normalizedPath
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		realPath = strings.TrimSuffix(resolved, "/")
-	}
-
-	// Check if either path appears in mount output
-	// Mount output format varies by OS:
-	// macOS: /dev/disk1 on /path (type)
-	// Linux: /dev/sda1 on /path type ext4 (options)
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		// Look for " on /path " or " on /path\t" patterns
-		// Check both the original path and the resolved real path
-		for _, checkPath := range []string{normalizedPath, realPath} {
-			if strings.Contains(line, " on "+checkPath+" ") ||
-				strings.Contains(line, " on "+checkPath+"\t") ||
-				strings.HasSuffix(line, " on "+checkPath) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func performUnmount(mountPoint string, force bool) error {
-	var cmd *exec.Cmd
-
-	switch runtime.GOOS {
-	case "darwin":
-		if force {
-			cmd = exec.Command("diskutil", "unmount", "force", mountPoint)
-		} else {
-			cmd = exec.Command("diskutil", "unmount", mountPoint)
-		}
-	case "linux":
-		if force {
-			cmd = exec.Command("umount", "-f", mountPoint)
-		} else {
-			cmd = exec.Command("umount", mountPoint)
-		}
-	}
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return formatUnmountError(err, string(output), force)
-	}
-
-	return nil
-}
-
 func formatUnmountError(err error, output string, forceAttempted bool) error {
-	outputLower := strings.ToLower(output)
-	errStr := strings.ToLower(err.Error())
+	combined := strings.ToLower(output + " " + err.Error())
 
-	// Check for common error patterns
-	if strings.Contains(outputLower, "not currently mounted") ||
-		strings.Contains(outputLower, "not mounted") ||
-		strings.Contains(outputLower, "no mount point") {
+	if strings.Contains(combined, "not currently mounted") ||
+		strings.Contains(combined, "not mounted") ||
+		strings.Contains(combined, "no mount point") {
 		return fmt.Errorf("unmount failed: %w\nOutput: %s\nHint: The path does not appear to be a mount point", err, output)
 	}
 
-	if strings.Contains(outputLower, "busy") || strings.Contains(outputLower, "resource busy") ||
-		strings.Contains(outputLower, "device is busy") || strings.Contains(errStr, "busy") {
+	if strings.Contains(combined, "busy") {
 		if forceAttempted {
 			return fmt.Errorf("unmount failed: %w\nOutput: %s\nHint: Some process is using the mount. Check with 'lsof +D %s'", err, output, output)
 		}
 		return fmt.Errorf("unmount failed: %w\nOutput: %s\nHint: Files may be in use. Close applications and try again, or use --force", err, output)
 	}
 
-	if strings.Contains(outputLower, "permission denied") || strings.Contains(outputLower, "operation not permitted") ||
-		strings.Contains(errStr, "permission denied") {
+	if strings.Contains(combined, "permission denied") || strings.Contains(combined, "operation not permitted") {
 		return fmt.Errorf("unmount failed: %w\nOutput: %s\nHint: Unmount may require sudo privileges", err, output)
 	}
 
-	// Generic error
 	return fmt.Errorf("unmount failed: %w\nOutput: %s", err, output)
 }

--- a/cmd/dfsctl/commands/share/unmount_unix.go
+++ b/cmd/dfsctl/commands/share/unmount_unix.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package share
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func validateUnmountPoint(mountPoint string) error {
+	info, err := os.Stat(mountPoint)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("mount point does not exist: %s\nHint: Check the path is correct", mountPoint)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access mount point: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("mount point is not a directory: %s", mountPoint)
+	}
+	return nil
+}
+
+func checkUnmountPrivileges(mountPoint string) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("unmount requires root privileges\nHint: Run with sudo: sudo dfsctl share unmount %s", mountPoint)
+	}
+	return nil
+}
+
+func isMountPoint(path string) bool {
+	cmd := exec.Command("mount")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	normalizedPath := strings.TrimSuffix(path, "/")
+
+	// Resolve symlinks for comparison since mount output shows resolved paths.
+	// Common cases: macOS /tmp -> /private/tmp, Linux /var/run -> /run.
+	pathsToCheck := []string{normalizedPath}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		if resolved := strings.TrimSuffix(resolved, "/"); resolved != normalizedPath {
+			pathsToCheck = append(pathsToCheck, resolved)
+		}
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		for _, checkPath := range pathsToCheck {
+			if strings.Contains(line, " on "+checkPath+" ") ||
+				strings.Contains(line, " on "+checkPath+"\t") ||
+				strings.HasSuffix(line, " on "+checkPath) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func performUnmount(mountPoint string, force bool) error {
+	var cmd *exec.Cmd
+
+	if runtime.GOOS == "darwin" {
+		args := []string{"unmount"}
+		if force {
+			args = append(args, "force")
+		}
+		args = append(args, mountPoint)
+		cmd = exec.Command("diskutil", args...)
+	} else {
+		args := []string{}
+		if force {
+			args = append(args, "-f")
+		}
+		args = append(args, mountPoint)
+		cmd = exec.Command("umount", args...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return formatUnmountError(err, string(output), force)
+	}
+
+	return nil
+}

--- a/cmd/dfsctl/commands/share/unmount_windows.go
+++ b/cmd/dfsctl/commands/share/unmount_windows.go
@@ -1,0 +1,76 @@
+//go:build windows
+
+package share
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func validateUnmountPoint(mountPoint string) error {
+	// Drive letters (e.g. Z:) may fail os.Stat when the remote server is
+	// unreachable, but they are still valid unmount targets. Skip the stat
+	// check for drive letters and let isMountPoint handle validation.
+	if len(mountPoint) == 2 && mountPoint[1] == ':' {
+		return nil
+	}
+
+	info, err := os.Stat(mountPoint)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("mount point does not exist: %s\nHint: Check the path is correct", mountPoint)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access mount point: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("mount point is not a directory: %s", mountPoint)
+	}
+	return nil
+}
+
+func checkUnmountPrivileges(mountPoint string) error {
+	// net use /delete does not require elevated privileges
+	return nil
+}
+
+func isMountPoint(path string) bool {
+	cmd := exec.Command("net", "use")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	normalizedPath := strings.ToUpper(strings.TrimSuffix(path, "\\"))
+
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		for _, field := range fields {
+			if strings.ToUpper(field) == normalizedPath {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func performUnmount(mountPoint string, force bool) error {
+	args := []string{"use", mountPoint, "/delete"}
+	if force {
+		args = append(args, "/y")
+	}
+
+	cmd := exec.Command("net", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return formatUnmountError(err, string(output), force)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Split platform-specific code from `mount.go`, `unmount.go`, and `list_mounts.go` into `//go:build`-tagged files (`_unix.go` / `_windows.go`) so `dfsctl` mount commands compile and work on Windows
- Windows SMB mount uses `net use` (port 445), with `/TCPPORT:` for custom ports on supported builds (Windows 11 Insider 25992+ / Server 2025+)
- Windows NFS mount uses the Windows `mount` command (requires Client for NFS feature); prints setup instructions and links to Microsoft docs
- Windows unmount uses `net use /delete` (`/y` for force)
- Windows list-mounts parses `net use` output for `\localhost\` entries
- Port limitations documented with actionable fallbacks (adapter reconfiguration or `netsh portproxy` forwarding)

## Test plan

- [x] `go build ./cmd/dfsctl/...` passes on Windows (native)
- [x] `GOOS=linux go build ./cmd/dfsctl/...` cross-compiles cleanly
- [x] `GOOS=darwin go build ./cmd/dfsctl/...` cross-compiles cleanly
- [x] `go vet ./cmd/dfsctl/...` passes
- [x] `go test ./cmd/dfsctl/...` passes
- [ ] Manual test on Windows: `dfsctl share mount --protocol smb /export Z:`
- [ ] Manual test on Windows: `dfsctl share unmount Z:`
- [ ] Manual test on Windows: `dfsctl share list-mounts`

Closes #170