### PR TITLE
feat(171): add Windows build targets to GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
   operator:
     name: Build Operator Image

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -338,8 +338,11 @@ release:
     # macOS (Intel)
     curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
 
-    # Windows (x86_64) — download and extract the .zip
-    # https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Windows_x86_64.zip
+    # Windows (x86_64)
+    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Windows_x86_64.zip" -OutFile dfs.zip; Expand-Archive dfs.zip -DestinationPath .; Remove-Item dfs.zip
+
+    # Windows (arm64)
+    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Windows_arm64.zip" -OutFile dfs.zip; Expand-Archive dfs.zip -DestinationPath .; Remove-Item dfs.zip
 
     # dfsctl (client CLI)
     # Linux (x86_64)
@@ -351,8 +354,11 @@ release:
     # macOS (Intel)
     curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
 
-    # Windows (x86_64) — download and extract the .zip
-    # https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Windows_x86_64.zip
+    # Windows (x86_64)
+    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Windows_x86_64.zip" -OutFile dfsctl.zip; Expand-Archive dfsctl.zip -DestinationPath .; Remove-Item dfsctl.zip
+
+    # Windows (arm64)
+    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Windows_arm64.zip" -OutFile dfsctl.zip; Expand-Archive dfsctl.zip -DestinationPath .; Remove-Item dfsctl.zip
     ```
 
     **Docker:**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -113,6 +113,46 @@ If the `HOMEBREW_TAP_TOKEN` needs to be rotated:
 2. Update the `HOMEBREW_TAP_TOKEN` secret in `marmos91/dittofs` repository settings
 3. The old token is invalidated automatically when the new PAT is created with the same name
 
+## Scoop Bucket (Windows)
+
+Releases automatically publish Scoop manifests to [`marmos91/scoop-bucket`](https://github.com/marmos91/scoop-bucket). Users can install via:
+
+```powershell
+scoop bucket add dittofs https://github.com/marmos91/scoop-bucket
+scoop install dfs       # Server daemon
+scoop install dfsctl    # Client CLI
+```
+
+### How It Works
+
+GoReleaser's `scoops` section generates JSON manifest files and pushes them to the bucket repository on each non-prerelease tag push. The `skip_upload: auto` setting prevents prerelease versions from being published.
+
+### Prerequisites
+
+1. **Bucket repository**: `marmos91/scoop-bucket` must exist on GitHub
+2. **Personal Access Token**: A fine-grained token scoped to `marmos91/scoop-bucket` with Contents read+write permission, stored as `SCOOP_BUCKET_TOKEN` in the `marmos91/dittofs` repository secrets
+
+### Local Testing
+
+```bash
+# Set a dummy token for local testing
+export SCOOP_BUCKET_TOKEN=dummy
+
+goreleaser release --snapshot --clean
+
+# Verify generated manifests
+cat dist/scoop/dfs.json
+cat dist/scoop/dfsctl.json
+```
+
+### Token Rotation
+
+If the `SCOOP_BUCKET_TOKEN` needs to be rotated:
+
+1. Create a new fine-grained PAT at https://github.com/settings/tokens scoped to `marmos91/scoop-bucket` (Contents: read+write)
+2. Update the `SCOOP_BUCKET_TOKEN` secret in `marmos91/dittofs` repository settings
+3. The old token is invalidated automatically when the new PAT is created with the same name
+
 ## Delete a Tag
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `windows` to `goos` for both `dfs` and `dfsctl` builds (amd64 + arm64)
- Use `.zip` format for Windows archives instead of `.tar.gz`
- Add Scoop bucket manifests for Windows package distribution
- Update release notes with Windows install instructions (Scoop + binary download)

Closes #171

## Test plan
- [ ] `goreleaser build --snapshot` produces Windows binaries (`dfs.exe`, `dfsctl.exe`)
- [ ] Windows archives use `.zip` format
- [ ] Scoop manifest is correctly generated on release