### PR TITLE
feat(171): add Windows build targets to GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -321,7 +321,7 @@ release:
 
     **Scoop (Windows):**
     ```powershell
-    scoop bucket add dittofs https://github.com/marmos91/scoop-bucket
+    scoop bucket add marmos91 https://github.com/marmos91/scoop-bucket
     scoop install dfs       # Server daemon
     scoop install dfsctl    # Client CLI
     ```


### PR DESCRIPTION
## Summary
- Add `windows` (amd64 + arm64) to `goos` for both `dfs` and `dfsctl` builds
- Use `.zip` format for Windows archives instead of `.tar.gz`
- Add Scoop bucket manifests for Windows package distribution (`marmos91/scoop-bucket`)
- Wire `SCOOP_BUCKET_TOKEN` into the release workflow
- Update release notes with Scoop install and PowerShell download instructions
- Document Scoop bucket setup in `RELEASING.md`

Closes #171

## Test plan
- [ ] `goreleaser build --snapshot` produces Windows binaries (`dfs.exe`, `dfsctl.exe`)
- [ ] Windows archives use `.zip` format
- [ ] Scoop manifest is correctly generated on release