### PR TITLE
ci: add Windows build and test workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,37 @@
+name: Windows Build
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  build-windows:
+    name: Windows Build & Test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Build dfs
+        run: go build -v ./cmd/dfs/
+
+      - name: Build dfsctl
+        run: go build -v ./cmd/dfsctl/
+
+      - name: Run unit tests
+        run: go test -short -v ./...


### PR DESCRIPTION
## Summary

- Add new GitHub Actions workflow (`windows-build.yml`) that runs on `windows-latest`
- Builds both `dfs` and `dfsctl` binaries on Windows
- Runs unit tests with `-short` flag to skip integration tests requiring Linux/macOS infrastructure

Closes #173

## Test plan

- [ ] Verify the workflow triggers on PRs targeting `develop` and `main`
- [ ] Confirm both `dfs` and `dfsctl` compile on `windows-latest`
- [ ] Confirm unit tests pass with `-short` flag on Windows