### PR TITLE
fix(adapter): register break callbacks for dynamically added shares

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -395,22 +395,14 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	// When the shared LockManager recalls a delegation (e.g., due to an SMB
 	// write conflicting with an NFS delegation), the handler translates the
 	// recall into a CB_RECALL sent via the NFS backchannel.
-	// Deduplicate: multiple shares may reference the same LockManager instance.
 	breakHandler := v4state.NewNFSBreakHandler(v4StateManager)
 	registeredLockManagers := make(map[lock.LockManager]struct{})
-	for _, shareName := range rt.ListShares() {
-		if lockMgr := metadataService.GetLockManagerForShare(shareName); lockMgr != nil {
-			if _, already := registeredLockManagers[lockMgr]; already {
-				continue
-			}
-			lockMgr.RegisterBreakCallbacks(breakHandler)
-			registeredLockManagers[lockMgr] = struct{}{}
-		}
-	}
-
-	// Register break callbacks for shares added dynamically after startup.
 	var breakRegMu sync.Mutex
-	rt.OnShareChange(func(shares []string) {
+
+	// registerBreakCallbacks registers break callbacks for any shares whose
+	// LockManagers have not been seen yet. Deduplicate: multiple shares may
+	// reference the same LockManager instance.
+	registerBreakCallbacks := func(shares []string) {
 		breakRegMu.Lock()
 		defer breakRegMu.Unlock()
 		for _, shareName := range shares {
@@ -422,7 +414,13 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 				registeredLockManagers[lockMgr] = struct{}{}
 			}
 		}
-	})
+	}
+
+	// Register for existing shares at startup.
+	registerBreakCallbacks(rt.ListShares())
+
+	// Register for shares added dynamically after startup.
+	rt.OnShareChange(registerBreakCallbacks)
 
 	// Apply live NFS adapter settings from SettingsWatcher.
 	// The SettingsWatcher polls DB every 10s and provides atomic pointer swap

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -170,16 +170,12 @@ func (s *Adapter) SetRuntime(rtAny any) {
 		// The notifier is nil until the transport layer is wired (see TODO above).
 		breakHandler := smblease.NewSMBBreakHandler(leaseMgr, nil)
 		registeredBreakLMs := make(map[lock.LockManager]struct{})
-		for _, shareName := range rt.ListShares() {
-			if lockMgr := metaSvc.GetLockManagerForShare(shareName); lockMgr != nil {
-				lockMgr.RegisterBreakCallbacks(breakHandler)
-				registeredBreakLMs[lockMgr] = struct{}{}
-			}
-		}
-
-		// Register break callbacks for shares added dynamically after startup.
 		var breakRegMu sync.Mutex
-		rt.OnShareChange(func(shares []string) {
+
+		// registerBreakCallbacks registers break callbacks for any shares whose
+		// LockManagers have not been seen yet. Deduplicate: multiple shares may
+		// reference the same LockManager instance.
+		registerBreakCallbacks := func(shares []string) {
 			breakRegMu.Lock()
 			defer breakRegMu.Unlock()
 			for _, shareName := range shares {
@@ -191,7 +187,13 @@ func (s *Adapter) SetRuntime(rtAny any) {
 					registeredBreakLMs[lockMgr] = struct{}{}
 				}
 			}
-		})
+		}
+
+		// Register for existing shares at startup.
+		registerBreakCallbacks(rt.ListShares())
+
+		// Register for shares added dynamically after startup.
+		rt.OnShareChange(registerBreakCallbacks)
 
 		logger.Debug("SMB adapter: LeaseManager wired with per-share LockManagers")
 	}


### PR DESCRIPTION
## Summary
- Shares created at runtime via `dfsctl share create` after adapters start were missing oplock/lease break callback wiring
- Added `OnShareChange` callback in both SMB and NFS adapters to register break callbacks on new shares' LockManagers
- Uses deduplication map to avoid double-registration when shares are re-announced

## Test plan
- [ ] Verify `OnShareChange` callback fires when a new share is created at runtime
- [ ] Verify break callbacks are registered for the new share's LockManager
- [ ] Verify no double-registration occurs for existing shares
- [ ] Run `go test ./pkg/adapter/smb/... ./pkg/adapter/nfs/...`

Closes #235