### PR TITLE
docs: improve quickstart with admin password and cache guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,19 +145,45 @@ go build -o dfs cmd/dfs/main.go
 # Initialize configuration (creates ~/.config/dfs/config.yaml)
 ./dfs init
 
-# Start server (note the admin password printed on first start)
+# Start server (see "First Run & Admin Password" section below)
 ./dfs start
 ```
+
+### First Run & Admin Password
+
+On first start, DittoFS creates an `admin` user automatically. The password is handled in one of two ways:
+
+**Option 1: Auto-generated password (default)**
+
+```bash
+./dfs start
+# Output:
+# *** IMPORTANT: Admin user created with password: aBcDeFgHiJkLmNoPqRsTuVwX ***
+# Please save this password. It will not be shown again.
+```
+
+The generated password is printed **only once**. If you lose it, you'll need to delete the database and restart.
+The admin account is created with `MustChangePassword` enabled, so you'll be prompted to set a new password on first login via `dfsctl`.
+
+**Option 2: Pre-set password via environment variable**
+
+Set `DITTOFS_ADMIN_INITIAL_PASSWORD` before the first start to choose your own admin password:
+
+```bash
+DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password ./dfs start
+```
+
+When using the environment variable, `MustChangePassword` is **not** enabled, so the password is ready to use as-is. This is especially useful for Docker, Kubernetes, and CI/CD environments where you can't read interactive output.
 
 ### NFS Quickstart
 
 Get an NFS share running in under a minute:
 
 ```bash
-# 1. Start the server (first run prints admin password)
+# 1. Start the server (see "First Run & Admin Password" above)
 ./dfs start
 
-# 2. Login and change admin password
+# 2. Login (use the password from first start output or DITTOFS_ADMIN_INITIAL_PASSWORD)
 ./dfsctl login --server http://localhost:8080 --username admin
 ./dfsctl user change-password
 
@@ -339,13 +365,14 @@ docker pull marmos91c/dittofs:latest
 mkdir -p ~/.config/dittofs
 docker run --rm -v ~/.config/dittofs:/config marmos91c/dittofs:latest init --config /config/config.yaml
 
-# Run DittoFS
+# Run DittoFS (set admin password via env var for Docker)
 docker run -d \
   --name dittofs \
   -p 12049:12049 \
   -p 12445:12445 \
   -p 8080:8080 \
   -p 9090:9090 \
+  -e DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password \
   -v ~/.config/dittofs/config.yaml:/config/config.yaml:ro \
   -v dittofs-metadata:/data/metadata \
   -v dittofs-content:/data/content \
@@ -355,8 +382,8 @@ docker run -d \
 # Check health
 curl http://localhost:8080/health
 
-# View logs
-docker logs -f dittofs
+# View logs (if no DITTOFS_ADMIN_INITIAL_PASSWORD was set, the auto-generated password appears here)
+docker logs dittofs | head -20
 ```
 
 **Available Tags:**
@@ -631,8 +658,39 @@ controlplane:
 
 cache:
   path: /var/lib/dfs/cache
-  size: "1Gi"
+  size: "1Gi"               # supports: "512MB", "2Gi", "4GB", etc.
 ```
+
+### Cache
+
+DittoFS uses a **mandatory write-through cache** backed by a WAL (Write-Ahead Log) for crash recovery. All file writes pass through the cache before being flushed asynchronously to the configured payload store (S3, filesystem, etc.).
+
+**How it works:**
+1. **Write**: Data is written to in-memory 4MB block buffers and journaled to the WAL on disk
+2. **Flush**: Blocks are uploaded asynchronously to the payload store in the background
+3. **Evict**: After a successful upload, cache blocks become evictable under memory pressure (LRU)
+4. **Recovery**: On crash/restart, the WAL replays uncommitted writes automatically
+
+**Key points:**
+- The `path` is **required** - the cache creates a `cache.dat` WAL file in this directory
+- Default `path` is `$TMPDIR/dittofs-cache` (e.g., `/tmp/dittofs-cache`) - fine for development, but use a persistent path for production
+- Default `size` is `1Gi` - increase for workloads with large files or many concurrent writers
+- All shares use the same global cache
+- Dirty (unflushed) blocks cannot be evicted, providing backpressure when the payload store is slower than the write rate
+
+**Sizing guidance:**
+- **Development/testing**: `512Mi` to `1Gi` (default)
+- **General use**: `2Gi` to `4Gi`
+- **Heavy write workloads** (large files, S3 backend): `4Gi` to `16Gi`
+
+```yaml
+# Production example
+cache:
+  path: /var/lib/dfs/cache   # Use a persistent directory (not /tmp)
+  size: "4Gi"
+```
+
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md#6-cache-configuration) for full details.
 
 ### Runtime Management (CLI)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -244,29 +244,72 @@ controlplane:
 
 ### 6. Cache Configuration
 
-DittoFS uses a WAL-backed (Write-Ahead Log) cache for all file operations. The cache is mandatory for crash recovery and performance.
+DittoFS uses a **mandatory WAL-backed cache** for all file content operations. Every write passes through the cache before being flushed asynchronously to the payload store (S3, filesystem, etc.). The WAL (Write-Ahead Log) ensures data durability: on crash or restart, uncommitted writes are replayed automatically from the WAL file on disk.
 
 ```yaml
 cache:
   # Directory path for the cache WAL file (required)
+  # The cache creates a cache.dat file in this directory
+  # Default: $TMPDIR/dittofs-cache (e.g., /tmp/dittofs-cache)
   path: "/var/lib/dfs/cache"
-  # Maximum cache size (supports human-readable formats: "1GB", "512MB", "10Gi")
+
+  # Maximum cache size (supports human-readable formats)
+  # Accepts: "512MB", "1GB", "1Gi", "4Gi", "16Gi", etc.
+  # Default: 1Gi
   size: "1Gi"
 ```
+
+**How the cache works:**
+
+```
+Client WRITE ──► Cache (4MB block buffers + WAL on disk)
+                    │
+                    ▼
+              Offloader (async background flush)
+                    │
+                    ▼
+              Payload Store (S3, filesystem, memory)
+```
+
+1. **Write**: Incoming data is buffered in 4MB in-memory block buffers and simultaneously journaled to the WAL on disk (via mmap) for durability
+2. **Flush**: The offloader uploads complete blocks to the payload store asynchronously in the background
+3. **Evict**: After a block is successfully uploaded, it becomes evictable. Under memory pressure, the least-recently-used uploaded blocks are freed first
+4. **Backpressure**: Dirty (unflushed) blocks cannot be evicted. If the cache fills with dirty data (e.g., payload store is slow), writes will block until space is freed. A separate pending-data limit (512MB default) prevents OOM even with large cache sizes
+5. **Recovery**: On crash or restart, the WAL replays uncommitted writes, so no data is lost
 
 **Cache Features:**
 
 - **WAL Persistence**: All writes are logged to disk via mmap for crash recovery
-- **LRU Eviction**: Least-recently-used entries are evicted when cache is full
+- **LRU Eviction**: Least-recently-used uploaded entries are evicted when cache is full
 - **Dirty Protection**: Entries with unflushed data cannot be evicted
-- **Chunk/Slice/Block Model**: Efficient storage model for large files
+- **Backpressure**: Writes block when pending data exceeds limits, preventing OOM
+- **Deduplication**: Blocks are content-addressed (SHA-256); identical blocks are stored once
+- **Global**: All shares use the same cache instance
 
 **Configuration Options:**
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `path` | Yes | Directory for cache WAL file |
-| `size` | No | Maximum cache size (default: 1GB) |
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `path` | Yes | `$TMPDIR/dittofs-cache` | Directory for the cache WAL file. Use a persistent path for production (not `/tmp`) |
+| `size` | No | `1Gi` | Maximum cache size. Accepts human-readable formats: `512MB`, `1Gi`, `4GB`, etc. |
+
+**Environment variable overrides:**
+
+```bash
+export DITTOFS_CACHE_PATH=/var/lib/dfs/cache
+export DITTOFS_CACHE_SIZE=4Gi
+```
+
+**Sizing guidance:**
+
+| Use Case | Recommended Size | Notes |
+|----------|-----------------|-------|
+| Development/testing | `512Mi` – `1Gi` | Default is fine |
+| General use | `2Gi` – `4Gi` | Good for mixed read/write |
+| Heavy writes / S3 backend | `4Gi` – `16Gi` | More cache absorbs upload latency |
+| Large file workloads (>100MB files) | `8Gi`+ | Prevents excessive eviction churn |
+
+> **Tip**: If you see `ErrCacheFull` errors or slow write throughput, increase `size`. If using an S3 payload store, a larger cache helps absorb the higher upload latency.
 
 ### 7. Metadata Configuration
 
@@ -781,6 +824,15 @@ Override configuration using environment variables with the `DITTOFS_` prefix:
 - Use uppercase
 - Replace dots with underscores
 - Nested paths use underscores
+
+**Special Variables** (not config overrides):
+
+```bash
+# Set the initial admin password on first start (instead of auto-generating one)
+export DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password
+```
+
+> **Note**: `DITTOFS_ADMIN_INITIAL_PASSWORD` is only used during the very first server start when the admin user is created. It has no effect on subsequent starts. When set, the admin account's `MustChangePassword` flag is not enabled.
 
 **Examples**:
 


### PR DESCRIPTION
## Summary

- Add a dedicated **"First Run & Admin Password"** section to the README explaining the two password flows (auto-generated vs `DITTOFS_ADMIN_INITIAL_PASSWORD` env var)
- Add a **"Cache"** section to the README with architecture overview, key points, and sizing guidance
- Expand the cache configuration section in `docs/CONFIGURATION.md` with data flow diagram, backpressure/recovery explanation, env var overrides, and sizing table
- Document `DITTOFS_ADMIN_INITIAL_PASSWORD` in `docs/CONFIGURATION.md` under environment variables
- Update Docker examples to pass admin password via `-e` flag

## Test plan

- [ ] Verify README renders correctly on GitHub (sections, code blocks, tables)
- [ ] Verify CONFIGURATION.md renders correctly (ASCII diagram, tables)
- [ ] Confirm no broken anchor links (`#6-cache-configuration`, `#first-run--admin-password`)