### PR TITLE
fix(operator): disable Percona backups when unconfigured and correct binary path

### DIFF
--- a/k8s/dittofs-operator/pkg/percona/percona.go
+++ b/k8s/dittofs-operator/pkg/percona/percona.go
@@ -101,9 +101,9 @@ func BuildPerconaPGClusterSpec(ds *dittoiov1alpha1.DittoServer) (pgv2.PerconaPGC
 		spec.InstanceSets[0].DataVolumeClaimSpec.StorageClassName = cfg.StorageClassName
 	}
 
-	// Configure backups: explicitly disable unless configured.
+	// Configure backups: explicitly disable unless backups are configured and enabled.
 	// Percona defaults backups to enabled (IsEnabled returns true when Enabled is nil),
-	// so we must set Enabled=false when no backup repos are configured.
+	// so we must set Enabled=false when backups are not configured or are disabled.
 	if cfg.Backup != nil && cfg.Backup.Enabled {
 		spec.Backups = buildBackupsSpec(ds.Name, cfg.Backup)
 	} else {


### PR DESCRIPTION
## Summary

- Explicitly disable Percona backups when not configured (prevents nil pointer crash in operator v2.8.x)
- Correct binary path from `/app/dittofs` to `/app/dfs` to match goreleaser image layout

## Closes

Closes #228

## Test plan

- [x] `go test ./...` in `k8s/dittofs-operator/` — all tests pass
- [x] `go vet ./...` — zero issues
- [x] `golangci-lint run` — zero issues