### PR TITLE
docs: phase 41 block state enum planning

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -539,7 +539,7 @@ v3.8 (33-40.5) -> v4.0 (41-49) -> v4.1 (50-56) -> v4.2 (57-62)
 | 38. Durable Handles | v3.8 | 3/3 | Complete | 2026-03-02 |
 | 39. Cross-Protocol Integration and Documentation | v3.8 | 3/3 | Complete | 2026-03-02 |
 | 40. SMB3 Conformance Testing | v3.8 | 6/6 | Complete | 2026-03-02 |
-| 41. Block State Enum and ListFileBlocks | 2/2 | Complete   | 2026-03-09 | - |
+| 41. Block State Enum and ListFileBlocks | 2/2 | Complete    | 2026-03-09 | - |
 | 42. Legacy Cleanup | v4.0 | 0/? | Not started | - |
 | 43. Local-Only Block Management | v4.0 | 0/? | Not started | - |
 | 44. Data Model and API/CLI | v4.0 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: BlockStore Unification Refactor
-status: executing
+status: completed
 stopped_at: Completed 41-02-PLAN.md (Phase 41 complete)
-last_updated: "2026-03-09T12:30:23Z"
+last_updated: "2026-03-09T12:36:09.172Z"
 last_activity: 2026-03-09 — Phase 41 Plan 02 complete (ListFileBlocks + conformance tests)
 progress:
   total_phases: 22
-  completed_phases: 1
-  total_plans: 2
-  completed_plans: 2
+  completed_phases: 2
+  total_plans: 4
+  completed_plans: 4
   percent: 67
 ---
 


### PR DESCRIPTION
## Summary
- Phase 41 planning and execution docs for block state enum rename + ListFileBlocks query
- Code changes already landed in feat/cache-rewrite via squashed commits; this PR adds the planning trail

## Test plan
- [x] No code changes — docs only