### PR TITLE
fix(s3): restore credentials and path-style from remote store config

### DIFF
--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -938,12 +938,12 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 		prefix, _ := config["prefix"].(string)
 		accessKey, _ := config["access_key_id"].(string)
 		secretKey, _ := config["secret_access_key"].(string)
-		forcePathStyle, _ := config["force_path_style"].(bool)
-
 		// When a custom endpoint is set (MinIO, Synology, etc.), default to
 		// path-style addressing — virtual-hosted style rarely works on
-		// non-AWS S3-compatible services. This matches v0.8.x behaviour.
-		if endpoint != "" && !forcePathStyle {
+		// non-AWS S3-compatible services. This matches v0.8.x behavior.
+		// Only override when the key is absent; honor explicit false.
+		forcePathStyle, hasPathStyle := config["force_path_style"].(bool)
+		if endpoint != "" && !hasPathStyle {
 			forcePathStyle = true
 		}
 


### PR DESCRIPTION
## Summary

- **S3 credentials regression in v0.9.0**: The blockstore refactor dropped `access_key_id` and `secret_access_key` when constructing the S3 remote store from the config map, causing all S3 uploads to fail with `403 AccessDenied`
- **Path-style addressing regression**: Custom endpoints (MinIO, Synology, etc.) no longer defaulted to path-style addressing, breaking non-AWS S3-compatible services

## Root Cause

In `CreateRemoteStoreFromConfig`, the config map keys `access_key_id` and `secret_access_key` were not being read and passed to `remotes3.Config`. The AWS SDK fell back to its default credential chain (env vars / IAM roles), which aren't available in typical self-hosted setups.

Additionally, v0.8.x automatically enabled path-style addressing when a custom endpoint was set. This behavior was lost in the refactor, requiring users to explicitly set `force_path_style: true`.

## Test plan

- [ ] Configure S3 remote store with `access_key_id` and `secret_access_key` — verify uploads succeed
- [ ] Configure S3 remote store with custom endpoint — verify path-style is auto-enabled
- [ ] Verify AWS S3 (no custom endpoint) still uses virtual-hosted style by default