### PR TITLE
fix: expand tilde in user-provided filesystem paths

### DIFF
--- a/internal/pathutil/expand.go
+++ b/internal/pathutil/expand.go
@@ -1,0 +1,23 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath expands a leading ~ in a file path to the user's home directory.
+// If the path is exactly "~" or starts with "~/", the ~ is replaced with the
+// home directory. All other paths are returned unchanged.
+func ExpandPath(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, path[1:]), nil
+}

--- a/internal/pathutil/expand_test.go
+++ b/internal/pathutil/expand_test.go
@@ -1,0 +1,68 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "tilde slash prefix",
+			path: "~/foo/bar",
+			want: filepath.Join(home, "foo/bar"),
+		},
+		{
+			name: "tilde only",
+			path: "~",
+			want: home,
+		},
+		{
+			name: "absolute path unchanged",
+			path: "/absolute/path",
+			want: "/absolute/path",
+		},
+		{
+			name: "relative path unchanged",
+			path: "relative/path",
+			want: "relative/path",
+		},
+		{
+			name: "empty string unchanged",
+			path: "",
+			want: "",
+		},
+		{
+			name: "tilde in middle unchanged",
+			path: "/foo/~/bar",
+			want: "/foo/~/bar",
+		},
+		{
+			name: "tilde without slash unchanged",
+			path: "~user/foo",
+			want: "~user/foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandPath(tt.path)
+			if err != nil {
+				t.Fatalf("ExpandPath(%q) returned error: %v", tt.path, err)
+			}
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -66,6 +67,10 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 			if !ok || dbPath == "" {
 				return nil, errors.New("badger metadata store requires path as string")
 			}
+		}
+		dbPath, err = pathutil.ExpandPath(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand path %q: %w", dbPath, err)
 		}
 		return badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	"github.com/marmos91/dittofs/pkg/blockstore/local"
@@ -950,8 +951,12 @@ func CreateLocalStoreFromConfig(
 		if !ok || basePath == "" {
 			return nil, errors.New("fs local store requires path in config")
 		}
+		expanded, err := pathutil.ExpandPath(basePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand path %q: %w", basePath, err)
+		}
 		sanitized := sanitizeShareName(shareName)
-		blockDir := filepath.Join(basePath, "shares", sanitized, "blocks")
+		blockDir := filepath.Join(expanded, "shares", sanitized, "blocks")
 		if err := os.MkdirAll(blockDir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create block store directory: %w", err)
 		}

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -16,6 +16,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
+	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
@@ -164,6 +165,11 @@ func New(config *Config) (*GORMStore, error) {
 	var dialector gorm.Dialector
 	switch config.Type {
 	case DatabaseTypeSQLite:
+		expanded, err := pathutil.ExpandPath(config.SQLite.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand database path %q: %w", config.SQLite.Path, err)
+		}
+		config.SQLite.Path = expanded
 		// Ensure parent directory exists for SQLite
 		if err := os.MkdirAll(filepath.Dir(config.SQLite.Path), 0755); err != nil {
 			return nil, fmt.Errorf("failed to create database directory: %w", err)


### PR DESCRIPTION
## Summary

- Adds `internal/pathutil.ExpandPath` helper that replaces a leading `~` with the user's home directory
- Calls `ExpandPath` at the three server-side store creation points where paths are used to create directories:
  - Local block store (fs) in `pkg/controlplane/runtime/shares/service.go`
  - Badger metadata store in `pkg/controlplane/runtime/init.go`
  - SQLite control plane database in `pkg/controlplane/store/gorm.go`

Closes #282

## Test plan

- [x] Unit tests for `ExpandPath` covering: `~/foo`, `~`, `/absolute`, `relative`, empty string, tilde-in-middle, `~user/foo`
- [x] `go test ./internal/pathutil/...` passes
- [x] `go test ./pkg/controlplane/runtime/...` passes
- [x] `go test ./pkg/controlplane/store/...` passes
- [x] `go vet ./...` clean
- [x] Both binaries compile (`go build ./cmd/dfs/` and `go build ./cmd/dfsctl/`)