### PR TITLE
feat(api): support groups field in create user request

### DIFF
--- a/internal/controlplane/api/handlers/users.go
+++ b/internal/controlplane/api/handlers/users.go
@@ -3,10 +3,8 @@ package handlers
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/controlplane/api/auth"
 	"github.com/marmos91/dittofs/internal/controlplane/api/middleware"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -94,35 +92,30 @@ func (h *UserHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Create user
-	// Only admin users require password change on first login
-	mustChangePassword := role == models.RoleAdmin
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
 	user := &models.User{
-		ID:                 uuid.New().String(),
 		Username:           req.Username,
 		PasswordHash:       passwordHash,
 		NTHash:             ntHashHex,
-		Enabled:            true,
-		MustChangePassword: mustChangePassword,
+		Enabled:            enabled,
+		MustChangePassword: role == models.RoleAdmin,
 		Role:               string(role),
+		UID:                req.UID,
 		DisplayName:        req.DisplayName,
 		Email:              req.Email,
-		CreatedAt:          time.Now(),
 	}
 
-	// Override enabled if explicitly set
-	if req.Enabled != nil {
-		user.Enabled = *req.Enabled
-	}
-
-	// Set UID if provided
-	if req.UID != nil {
-		user.UID = req.UID
-	}
-
-	if _, err := h.store.CreateUser(r.Context(), user); err != nil {
+	if _, err := h.store.CreateUserWithGroups(r.Context(), user, req.Groups); err != nil {
 		if errors.Is(err, models.ErrDuplicateUser) {
 			Conflict(w, "User already exists")
+			return
+		}
+		if errors.Is(err, models.ErrGroupNotFound) {
+			BadRequest(w, "One or more specified groups do not exist")
 			return
 		}
 		InternalServerError(w, "Failed to create user")

--- a/internal/controlplane/api/handlers/users_test.go
+++ b/internal/controlplane/api/handlers/users_test.go
@@ -132,6 +132,63 @@ func TestUserHandler_Create(t *testing.T) {
 	}
 }
 
+func TestUserHandler_Create_WithGroups(t *testing.T) {
+	cpStore, _, handler := setupUserTest(t)
+	ctx := context.Background()
+
+	// Create groups first
+	cpStore.CreateGroup(ctx, &models.Group{Name: "devs"})
+	cpStore.CreateGroup(ctx, &models.Group{Name: "ops"})
+
+	t.Run("creates user with groups", func(t *testing.T) {
+		body, _ := json.Marshal(CreateUserRequest{
+			Username: "groupuser",
+			Password: "password123",
+			Groups:   []string{"devs", "ops"},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.Create(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("Create() status = %d, want %d, body = %s", w.Code, http.StatusCreated, w.Body.String())
+		}
+
+		var resp UserResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(resp.Groups) != 2 {
+			t.Errorf("expected 2 groups in response, got %d: %v", len(resp.Groups), resp.Groups)
+		}
+	})
+
+	t.Run("fails with nonexistent group", func(t *testing.T) {
+		body, _ := json.Marshal(CreateUserRequest{
+			Username: "failuser",
+			Password: "password123",
+			Groups:   []string{"devs", "nonexistent"},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.Create(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Create() status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+
+		// Verify user was not created (transaction rolled back)
+		_, err := cpStore.GetUser(ctx, "failuser")
+		if err == nil {
+			t.Error("expected user not to exist after failed group assignment")
+		}
+	})
+}
+
 func TestUserHandler_Create_Duplicate(t *testing.T) {
 	cpStore, _, handler := setupUserTest(t)
 	ctx := context.Background()

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -47,6 +47,12 @@ type UserStore interface {
 	// Returns models.ErrDuplicateUser if a user with the same username exists.
 	CreateUser(ctx context.Context, user *models.User) (string, error)
 
+	// CreateUserWithGroups creates a new user and assigns them to the specified groups
+	// in a single transaction. If any group name doesn't exist, the transaction is
+	// rolled back and models.ErrGroupNotFound is returned (the user is not created).
+	// Returns models.ErrDuplicateUser if a user with the same username exists.
+	CreateUserWithGroups(ctx context.Context, user *models.User, groupNames []string) (string, error)
+
 	// UpdateUser updates an existing user.
 	// Returns models.ErrUserNotFound if the user doesn't exist.
 	UpdateUser(ctx context.Context, user *models.User) error

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -377,6 +377,79 @@ func TestUserGroupMembership(t *testing.T) {
 	})
 }
 
+func TestCreateUserWithGroups(t *testing.T) {
+	s := createTestStore(t)
+	defer s.Close()
+	ctx := context.Background()
+
+	// Create groups
+	s.CreateGroup(ctx, &models.Group{Name: "devs"})
+	s.CreateGroup(ctx, &models.Group{Name: "ops"})
+
+	t.Run("creates user with groups atomically", func(t *testing.T) {
+		user := &models.User{Username: "alice", PasswordHash: "hash", Role: "user"}
+		id, err := s.CreateUserWithGroups(ctx, user, []string{"devs", "ops"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == "" {
+			t.Error("expected non-empty ID")
+		}
+
+		groups, err := s.GetUserGroups(ctx, "alice")
+		if err != nil {
+			t.Fatalf("failed to get user groups: %v", err)
+		}
+		if len(groups) != 2 {
+			t.Errorf("expected 2 groups, got %d", len(groups))
+		}
+		names := map[string]bool{}
+		for _, g := range groups {
+			names[g.Name] = true
+		}
+		if !names["devs"] || !names["ops"] {
+			t.Errorf("expected groups devs and ops, got %v", names)
+		}
+	})
+
+	t.Run("fails if group does not exist", func(t *testing.T) {
+		user := &models.User{Username: "bob", PasswordHash: "hash", Role: "user"}
+		_, err := s.CreateUserWithGroups(ctx, user, []string{"devs", "nonexistent"})
+		if !errors.Is(err, models.ErrGroupNotFound) {
+			t.Errorf("expected ErrGroupNotFound, got %v", err)
+		}
+
+		// User should NOT have been created
+		_, err = s.GetUser(ctx, "bob")
+		if !errors.Is(err, models.ErrUserNotFound) {
+			t.Errorf("expected ErrUserNotFound (rollback), got %v", err)
+		}
+	})
+
+	t.Run("fails on duplicate user", func(t *testing.T) {
+		user := &models.User{Username: "alice", PasswordHash: "hash", Role: "user"}
+		_, err := s.CreateUserWithGroups(ctx, user, []string{"devs"})
+		if !errors.Is(err, models.ErrDuplicateUser) {
+			t.Errorf("expected ErrDuplicateUser, got %v", err)
+		}
+	})
+
+	t.Run("empty groups creates user without groups", func(t *testing.T) {
+		user := &models.User{Username: "charlie", PasswordHash: "hash", Role: "user"}
+		id, err := s.CreateUserWithGroups(ctx, user, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == "" {
+			t.Error("expected non-empty ID")
+		}
+		groups, _ := s.GetUserGroups(ctx, "charlie")
+		if len(groups) != 0 {
+			t.Errorf("expected 0 groups, got %d", len(groups))
+		}
+	})
+}
+
 func TestShareOperations(t *testing.T) {
 	store := createTestStore(t)
 	defer store.Close()

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 
@@ -32,6 +33,56 @@ func (s *GORMStore) ListUsers(ctx context.Context) ([]*models.User, error) {
 func (s *GORMStore) CreateUser(ctx context.Context, user *models.User) (string, error) {
 	user.CreatedAt = time.Now()
 	return createWithID(s.db, ctx, user, func(u *models.User, id string) { u.ID = id }, user.ID, models.ErrDuplicateUser)
+}
+
+func (s *GORMStore) CreateUserWithGroups(ctx context.Context, user *models.User, groupNames []string) (string, error) {
+	if len(groupNames) == 0 {
+		return s.CreateUser(ctx, user)
+	}
+
+	user.CreatedAt = time.Now()
+	if user.ID == "" {
+		user.ID = uuid.New().String()
+	}
+
+	// Deduplicate group names
+	seen := make(map[string]struct{}, len(groupNames))
+	unique := make([]string, 0, len(groupNames))
+	for _, name := range groupNames {
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			unique = append(unique, name)
+		}
+	}
+
+	var groups []models.Group
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		groups = make([]models.Group, 0, len(unique))
+		for _, name := range unique {
+			var group models.Group
+			if err := tx.Where("name = ?", name).First(&group).Error; err != nil {
+				return fmt.Errorf("group %q: %w", name, models.ErrGroupNotFound)
+			}
+			groups = append(groups, group)
+		}
+
+		if err := tx.Create(user).Error; err != nil {
+			if isUniqueConstraintError(err) {
+				return models.ErrDuplicateUser
+			}
+			return err
+		}
+
+		return tx.Model(user).Association("Groups").Append(&groups)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Back-populate for the caller (GORM's Append doesn't update the in-memory struct)
+	user.Groups = groups
+
+	return user.ID, nil
 }
 
 func (s *GORMStore) UpdateUser(ctx context.Context, user *models.User) error {


### PR DESCRIPTION
## Summary

- Accept an optional `groups` field (string array) in `POST /api/v1/users` to atomically create a user and assign group memberships in a single database transaction
- If any specified group doesn't exist, the request fails with `400 Bad Request` and the user is not created
- Deduplicates group names to prevent join-table constraint errors
- The CLI (`dfsctl user create --groups`) already supported sending the field — the server now processes it

## Test plan

- [x] Store-level integration tests: atomic creation, rollback on missing group, duplicate user, empty groups
- [x] Handler-level integration tests: successful creation with groups in response, failure on nonexistent group
- [x] Full `go test ./...` passes
- [x] `go build ./...` passes

Closes #297