### PR TITLE
feat(api): expose created_at and last_login across API resources

### DIFF
--- a/cmd/dfsctl/commands/group/get.go
+++ b/cmd/dfsctl/commands/group/get.go
@@ -55,6 +55,7 @@ func (gl SingleGroupList) Rows() [][]string {
 		{"GID", gidStr},
 		{"Description", description},
 		{"Members", members},
+		{"Created", g.CreatedAt.Format("2006-01-02 15:04:05")},
 	}
 }
 

--- a/cmd/dfsctl/commands/user/get.go
+++ b/cmd/dfsctl/commands/user/get.go
@@ -47,6 +47,11 @@ func (ul SingleUserList) Rows() [][]string {
 		uidStr = fmt.Sprintf("%d", *u.UID)
 	}
 
+	lastLogin := "Never"
+	if u.LastLogin != nil {
+		lastLogin = u.LastLogin.Format("2006-01-02 15:04:05")
+	}
+
 	return [][]string{
 		{"ID", u.ID},
 		{"Username", u.Username},
@@ -57,6 +62,8 @@ func (ul SingleUserList) Rows() [][]string {
 		{"Groups", groups},
 		{"Enabled", cmdutil.BoolToYesNo(u.Enabled)},
 		{"Must Change Password", cmdutil.BoolToYesNo(u.MustChangePassword)},
+		{"Created", u.CreatedAt.Format("2006-01-02 15:04:05")},
+		{"Last Login", lastLogin},
 	}
 }
 

--- a/internal/controlplane/api/handlers/auth.go
+++ b/internal/controlplane/api/handlers/auth.go
@@ -44,15 +44,17 @@ type LoginResponse struct {
 
 // UserResponse is a sanitized user representation for API responses.
 type UserResponse struct {
-	ID                 string   `json:"id"`
-	Username           string   `json:"username"`
-	DisplayName        string   `json:"display_name,omitempty"`
-	Email              string   `json:"email,omitempty"`
-	Role               string   `json:"role"`
-	UID                *uint32  `json:"uid,omitempty"`
-	Groups             []string `json:"groups,omitempty"`
-	Enabled            bool     `json:"enabled"`
-	MustChangePassword bool     `json:"must_change_password"`
+	ID                 string     `json:"id"`
+	Username           string     `json:"username"`
+	DisplayName        string     `json:"display_name,omitempty"`
+	Email              string     `json:"email,omitempty"`
+	Role               string     `json:"role"`
+	UID                *uint32    `json:"uid,omitempty"`
+	Groups             []string   `json:"groups,omitempty"`
+	Enabled            bool       `json:"enabled"`
+	MustChangePassword bool       `json:"must_change_password"`
+	CreatedAt          time.Time  `json:"created_at"`
+	LastLogin          *time.Time `json:"last_login,omitempty"`
 }
 
 // RefreshRequest is the request body for POST /api/v1/auth/refresh.
@@ -96,8 +98,11 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update last login time (non-critical, log error for debugging)
-	if err := h.store.UpdateLastLogin(r.Context(), user.Username, time.Now()); err != nil {
+	now := time.Now()
+	if err := h.store.UpdateLastLogin(r.Context(), user.Username, now); err != nil {
 		logger.WarnCtx(r.Context(), "failed to update last login time", "username", user.Username, "error", err)
+	} else {
+		user.LastLogin = &now
 	}
 
 	// Build response
@@ -209,5 +214,7 @@ func userToResponse(user *models.User) UserResponse {
 		Groups:             user.GetGroupNames(),
 		Enabled:            user.Enabled,
 		MustChangePassword: user.MustChangePassword,
+		CreatedAt:          user.CreatedAt,
+		LastLogin:          user.LastLogin,
 	}
 }

--- a/pkg/apiclient/adapters.go
+++ b/pkg/apiclient/adapters.go
@@ -2,14 +2,16 @@ package apiclient
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // Adapter represents a protocol adapter configuration.
 type Adapter struct {
-	Type    string          `json:"type"`
-	Port    int             `json:"port"`
-	Enabled bool            `json:"enabled"`
-	Config  json.RawMessage `json:"config,omitempty"`
+	Type      string          `json:"type"`
+	Port      int             `json:"port"`
+	Enabled   bool            `json:"enabled"`
+	Config    json.RawMessage `json:"config,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
 }
 
 // CreateAdapterRequest is the request to create an adapter.

--- a/pkg/apiclient/groups.go
+++ b/pkg/apiclient/groups.go
@@ -1,12 +1,15 @@
 package apiclient
 
+import "time"
+
 // Group represents a group in the system.
 type Group struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	GID         *uint32  `json:"gid,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Members     []string `json:"members,omitempty"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	GID         *uint32   `json:"gid,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Members     []string  `json:"members,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // CreateGroupRequest is the request to create a group.

--- a/pkg/apiclient/stores.go
+++ b/pkg/apiclient/stores.go
@@ -3,23 +3,26 @@ package apiclient
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // MetadataStore represents a metadata store configuration.
 type MetadataStore struct {
-	ID     string          `json:"id"`
-	Name   string          `json:"name"`
-	Type   string          `json:"type"`
-	Config json.RawMessage `json:"config,omitempty"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Type      string          `json:"type"`
+	Config    json.RawMessage `json:"config,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
 }
 
 // BlockStore represents a block store configuration.
 type BlockStore struct {
-	ID     string          `json:"id"`
-	Name   string          `json:"name"`
-	Kind   string          `json:"kind"`
-	Type   string          `json:"type"`
-	Config json.RawMessage `json:"config,omitempty"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Kind      string          `json:"kind"`
+	Type      string          `json:"type"`
+	Config    json.RawMessage `json:"config,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
 }
 
 // CreateStoreRequest is the request to create a metadata or block store.

--- a/pkg/apiclient/users.go
+++ b/pkg/apiclient/users.go
@@ -17,8 +17,8 @@ type User struct {
 	Enabled            bool              `json:"enabled"`
 	MustChangePassword bool              `json:"must_change_password"`
 	SharePermissions   map[string]string `json:"share_permissions,omitempty"`
-	CreatedAt          time.Time         `json:"created_at,omitempty"`
-	UpdatedAt          time.Time         `json:"updated_at,omitempty"`
+	CreatedAt          time.Time         `json:"created_at"`
+	LastLogin          *time.Time        `json:"last_login,omitempty"`
 }
 
 // CreateUserRequest is the request to create a user.

--- a/pkg/controlplane/store/helpers.go
+++ b/pkg/controlplane/store/helpers.go
@@ -70,6 +70,19 @@ func createWithID[T any](db *gorm.DB, ctx context.Context, entity *T, idSetter f
 	return id, nil
 }
 
+// dedup returns a new slice with duplicate strings removed, preserving order.
+func dedup(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 // deleteByField deletes records of type T matching field=value.
 // Returns notFoundErr if no rows were affected.
 //

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,25 +46,25 @@ func (s *GORMStore) CreateUserWithGroups(ctx context.Context, user *models.User,
 		user.ID = uuid.New().String()
 	}
 
-	// Deduplicate group names
-	seen := make(map[string]struct{}, len(groupNames))
-	unique := make([]string, 0, len(groupNames))
-	for _, name := range groupNames {
-		if _, ok := seen[name]; !ok {
-			seen[name] = struct{}{}
-			unique = append(unique, name)
-		}
-	}
+	unique := dedup(groupNames)
 
 	var groups []models.Group
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		groups = make([]models.Group, 0, len(unique))
-		for _, name := range unique {
-			var group models.Group
-			if err := tx.Where("name = ?", name).First(&group).Error; err != nil {
-				return fmt.Errorf("group %q: %w", name, models.ErrGroupNotFound)
+		if err := tx.Where("name IN ?", unique).Find(&groups).Error; err != nil {
+			return err
+		}
+		if len(groups) != len(unique) {
+			found := make(map[string]struct{}, len(groups))
+			for _, g := range groups {
+				found[g.Name] = struct{}{}
 			}
-			groups = append(groups, group)
+			var missing []string
+			for _, name := range unique {
+				if _, ok := found[name]; !ok {
+					missing = append(missing, name)
+				}
+			}
+			return fmt.Errorf("groups not found: %s: %w", strings.Join(missing, ", "), models.ErrGroupNotFound)
 		}
 
 		if err := tx.Create(user).Error; err != nil {
@@ -79,9 +80,8 @@ func (s *GORMStore) CreateUserWithGroups(ctx context.Context, user *models.User,
 		return "", err
 	}
 
-	// Back-populate for the caller (GORM's Append doesn't update the in-memory struct)
+	// Back-populate for the caller (GORM's Append doesn't reliably update in-memory)
 	user.Groups = groups
-
 	return user.ID, nil
 }
 


### PR DESCRIPTION
## Summary

- Add `created_at` field to `Group`, `BlockStore`, `MetadataStore`, and `Adapter` apiclient structs (handlers already returned it — clients were silently dropping it)
- Add `created_at` and `last_login` to `UserResponse` and wire through `userToResponse`
- Fix login handler to update `last_login` in-memory after DB write so the login response reflects the current session
- Update `dfsctl user get` and `dfsctl group get` CLI commands to display timestamps in table output
- Remove stale `UpdatedAt` field from `apiclient.User` (server never emitted it)
- Improve `CreateUserWithGroups` error to identify which specific groups were not found

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — zero failures
- [x] Integration tests for user creation with groups pass
- [x] Login handler tests pass

Closes #301