### PR TITLE
fix(smb): correct lease state constants and fix break notification delivery

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -568,7 +568,7 @@ v3.8 (33-40.5) -> v4.2 (57-62) -> v4.0 (41-49) -> v4.3 (49.1-49.3) -> v4.7 (63-6
 | 69. SMB Protocol Foundation | 3/3 | Complete   | 2026-03-20 | - |
 | 70. Storage Observability and Quotas | 3/3 | Complete    | 2026-03-21 | - |
 | 71. Operational Visibility | v0.10.0 | 1/2 | In Progress|  |
-| 72. WPTS Conformance Push | v0.10.0 | 0/? | Not started | - |
+| 72. WPTS Conformance Push | v0.10.0 | 1/2 | In Progress|  |
 | 73. Trash and Soft-Delete | v0.10.0 | 0/? | Complete    | 2026-03-24 |
 | 74. SMB Multi-Channel | v0.10.0 | 0/? | Not started | - |
 | 75. Manual Verification v0.10.0 | v0.10.0 | 0/? | Not started | - |

--- a/.planning/debug/bvt-directory-leasing-cross-key-hang.md
+++ b/.planning/debug/bvt-directory-leasing-cross-key-hang.md
@@ -1,0 +1,69 @@
+---
+status: awaiting_human_verify
+trigger: "BVT_DirectoryLeasing_LeaseBreakOnMultiClients still fails in Linux WPTS CI post-Plan-01 with System.TimeoutException — Plan 01 fix targeted wrong path"
+created: 2026-04-07
+updated: 2026-04-09
+---
+
+## Current Focus
+
+hypothesis: ROOT CAUSE CONFIRMED via code reading. The cross-key conflict path in `requestLeaseImpl` (leases.go:279) calls `WaitForBreakCompletion` with a hardcoded 35s timeout. In the WPTS test scenario, **the test orchestrates Client1's ACK only AFTER Client2's CREATE returns** — so Client2's CREATE blocks the test's main goroutine, the test never drives Client1 to ack, and the wait deadlocks the test for 35s. WPTS client gives up at 8s → System.TimeoutException. The exact same async-vs-sync deadlock is documented at `internal/adapter/smb/lease/manager.go:389` (`BreakHandleLeasesOnOpenAsync`): "blocking would deadlock: the other client needs this CREATE's response before it processes the break."
+test: Write a Go unit test mirroring `TestRequestLease_CrossKeyConflict` (line 205) but with a callback that NEVER acks. Measure how long Client2's RequestLease blocks. Bound it with t.Deadline / per-test timeout to assert <1s.
+expecting: On unmodified code the test hangs for 35s. After fix it returns in <100ms.
+next_action: Write the failing test, run it (RED), apply the fix (drop the wait — the breaking lease is already correctly handled by `OpLocksConflict` which treats Breaking leases as having their BreakToState — see oplock.go:229-233), run again (GREEN).
+
+## Symptoms
+
+expected: Client2's CREATE on existing dir with new lease key returns within ~1s with downgraded lease; WPTS observes lease break on Client1 and test passes within 8s deadline.
+actual: Client2's CREATE hangs ≥8s; WPTS CreateOpenFromClient throws System.TimeoutException; server eventually closes the connection.
+errors: System.TimeoutException at LeasingExtendedTest.CreateOpenFromClient (DirectoryLeasingExtendedTest.cs:799) called from BVT_DirectoryLeasing_LeaseBreakOnMultiClients (line 180).
+reproduction: Code-level only — write a Go unit test on Manager.RequestLease with two clients, same dir handle, different lease keys, R|H each, break ack never sent.
+started: Pre-Plan-01 (already in KNOWN_FAILURES.md as Expected). Plan 01 attempted fix in wrong functions.
+
+## Eliminated
+
+- hypothesis: Hang is in BreakParentHandleLeasesOnCreate / BreakParentReadLeasesOnModify
+  evidence: Per prior audit + 72-postfix-ci.txt: WPTS test opens existing directory twice, no FileCreated/FileOverwritten/FileSuperseded, so the parent-break block in create.go:1007 is skipped entirely. Also no "CREATE: parent directory Handle lease break failed" log line in dittofs.log for the failing run.
+  timestamp: 2026-04-07 (prior audit)
+
+## Evidence
+
+- timestamp: 2026-04-07
+  checked: 72-postfix-ci.txt server-side dittofs.log excerpt (line 76868)
+  found: "RequestLease: cross-key conflict, initiating break ... existingState=RW requestedState=RW breakToState=R"
+  implication: The CI log says existingState=RW (has Write bit). leases.go:230 computes breakTo = state &^ Write → R. Therefore the break IS dispatched (not skipped at line 235), and the 35s wait at line 279 IS reached.
+
+- timestamp: 2026-04-07
+  checked: leases.go:211-291 cross-key conflict path
+  found: After dispatchOpLockBreak, code calls WaitForBreakCompletion with ctx.WithTimeout(ctx, 35*time.Second). 35s >> WPTS 8s test-step deadline.
+  implication: If client never acks within 8s, Client2's RequestLease blocks for 35s, client gives up at 8s, test fails. This is the hang site.
+
+- timestamp: 2026-04-07
+  checked: 72-postfix-ci.txt log paraphrase ambiguity (existingState=RW vs pure R|H)
+  found: The CI log paraphrase says existingState=RW. The test "BVT_DirectoryLeasing_LeaseBreakOnMultiClients" by name and convention typically uses R|H (READ|HANDLE) leases on directories — Write isn't valid on directory leases anyway. Need to verify whether the log was paraphrased or whether something in the lease pipeline transforms R|H to RW (unlikely).
+  implication: There's residual ambiguity. Either (a) the log was paraphrased and the real existingState is RH, in which case breakTo = RH &^ W = RH (no change), and the cross-key block exits at line 235 WITHOUT dispatching a break — meaning the hang is somewhere else; OR (b) the log is verbatim and existingState really is RW somehow. Option (a) is more consistent with directory R|H semantics. Need code reading + repro to disambiguate.
+
+## Resolution
+
+root_cause: requestLeaseImpl (pkg/metadata/lock/leases.go:279) called WaitForBreakCompletion with a 35s hardcoded timeout after dispatching a cross-key lease break. In multi-client scenarios where a single test driver orchestrates both clients, the existing client (Client1) cannot ack until the new opener's (Client2) CREATE returns — but Client2 is parked inside this wait. Pure deadlock. WPTS BVT client times out at ~8s with System.TimeoutException. Plan 01's BreakParentHandleLeasesOnCreate / BreakParentReadLeasesOnModify fix is correct but unrelated: that path is only hit on FileCreated/FileOverwritten/FileSuperseded, while the WPTS test opens an existing directory twice.
+
+fix: Drop the WaitForBreakCompletion call in requestLeaseImpl entirely. The dispatchOpLockBreak above it is already synchronous (LEASE_BREAK_NOTIFICATION is on the wire by the time it returns), satisfying MS-SMB2 3.3.4.7 ordering. The existing breaking lease stays in unifiedLocks with Breaking=true and BreakToState set, and OpLocksConflict (oplock.go:229-233) already evaluates conflicts against BreakToState in that case — so bestGrantableState computes the correct downgraded grant for the new opener immediately, without waiting for the ack. This mirrors the documented async pattern at internal/adapter/smb/lease/manager.go:389 (BreakHandleLeasesOnOpenAsync), whose comment explicitly calls out "blocking would deadlock: the other client needs this CREATE's response before it processes the break".
+
+Note on the prior log evidence: 72-postfix-ci.txt's "existingState=RW requestedState=RW breakToState=R" log line is consistent with the actual server log format (notifier.go:85, leases.go:244) and matches the in-tree directory-lease semantics — directories CAN hold RW (TestRequestLease_DirectoryState_RW asserts this; valid dir states are None/R/RW per oplock.go:191). The WPTS test therefore really does request RW directory leases and the cross-key conflict path really is hit. The wire-trace lines (22:11:22.193 etc.) showing "READ|HANDLE → READ" are paraphrased commentary, not raw log lines. Treat the [DEBUG] lines as authoritative.
+
+verification:
+- New unit test TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck asserts RequestLease returns within 1s when the existing client never acks. RED before fix (1.00s timeout fired), GREEN after fix (0.00s).
+- TestAcknowledgeLeaseBreak_CompletesBreak updated to use assert.Eventually for the async ack-to-None landing (previously relied on the synchronous wait to make ack ordering deterministic). Passes.
+- Full pkg/metadata/lock/... test suite passes (with -race).
+- Full internal/adapter/smb/... test suite passes (no regressions).
+- Full pkg/metadata/... test suite passes.
+- go vet ./pkg/metadata/lock/... clean.
+- WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients verification requires Linux CI (Windows SUT not available locally) — pending human-verify checkpoint.
+
+files_changed:
+  - pkg/metadata/lock/leases.go (drop WaitForBreakCompletion in cross-key path)
+  - pkg/metadata/lock/leases_test.go (RED-then-GREEN test + Eventually for ack)
+
+commits:
+  - 87ddabfa test(72-01): add red test for cross-key lease conflict deadlock
+  - ede32b1f fix(72-01): drop blocking ack-wait in cross-key lease conflict path

--- a/.planning/phases/72-wpts-conformance-push/72-01-PLAN.md
+++ b/.planning/phases/72-wpts-conformance-push/72-01-PLAN.md
@@ -1,0 +1,309 @@
+---
+phase: 72
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/adapter/smb/lease/manager.go
+  - internal/adapter/smb/lease/manager_test.go
+autonomous: false
+requirements: [WPTS-03, WPTS-04]
+supersedes: 72-03 (renumbered after PR #323 closed Plan 02's scope)
+must_haves:
+  truths:
+    - "BreakParentHandleLeasesOnCreate waits for break ack (or bounded timeout) before returning"
+    - "BreakParentReadLeasesOnModify waits for break ack (or bounded timeout) before returning"
+    - "Triggering CREATE's session is excluded from the wait — no self-deadlock"
+    - "BVT_DirectoryLeasing_LeaseBreakOnMultiClients passes in Linux CI for 5 consecutive runs (flake gate)"
+    - "No regressions in BreakHandleLeasesOnOpen or other lease tests"
+  artifacts:
+    - path: "internal/adapter/smb/lease/manager.go"
+      provides: "BreakParentHandleLeasesOnCreate + BreakParentReadLeasesOnModify with bounded WaitForBreakCompletion"
+      contains: "WaitForBreakCompletion"
+    - path: "internal/adapter/smb/lease/manager_test.go"
+      provides: "Wave 0 unit tests covering ack-wait and exclude-triggering-client behavior"
+      contains: "TestBreakParentHandleLeasesOnCreate_WaitsForAck"
+  key_links:
+    - from: "create.go:1003-1020 (parent break dispatch on CREATE)"
+      to: "BreakParentHandleLeasesOnCreate / BreakParentReadLeasesOnModify"
+      via: "synchronous wait-for-ack"
+      pattern: "WaitForBreakCompletion"
+---
+
+<objective>
+Fix `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` by making parent-directory lease break delivery deterministic.
+
+Purpose: `BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify` currently dispatch breaks asynchronously and return immediately. The triggering CREATE returns to client A before client B's `LEASE_BREAK_ACK` arrives, so when WPTS observes B's lease state next, it may still see the pre-break state. Per MS-SMB2 3.3.4.7, when the break has `SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED` set, the server must wait. The fix is to call `WaitForBreakCompletion` with a bounded timeout — the same pattern already proven in `BreakHandleLeasesOnOpen` (`lease/manager.go:351-376`). Self-deadlock is impossible because `excludeClientID` excludes the triggering CREATE's session from the breakable set.
+
+Output: 3 unit tests added (Wave 0), 2 surgical edits in `manager.go`, and a 5-consecutive-run flake gate verification in Linux CI.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/phases/72-wpts-conformance-push/72-CONTEXT.md
+@.planning/phases/72-wpts-conformance-push/72-RESEARCH.md
+@.planning/phases/72-wpts-conformance-push/72-VALIDATION.md
+@.planning/phases/72-wpts-conformance-push/72-baseline-ci.txt
+
+## Branch reminder
+Work happens on `fix/phase-72-wpts-trailing-fixes` (off develop), NOT on the worktree-issue-324-smb-idmap branch.
+
+## Pattern reference (from RESEARCH.md Q3)
+The proven ack-wait pattern is in `BreakHandleLeasesOnOpen` at `lease/manager.go:351-376`:
+```go
+// (illustrative; read the actual code first)
+if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+    return err
+}
+return lockMgr.WaitForBreakCompletion(ctx, handleKey)
+```
+
+## Self-deadlock safety
+- `breakOpLocks` (manager.go:1485-1497) honors `excludeOwner.ClientID`
+- `BreakParentHandleLeasesOnCreate` is called with `excludeClientID = "smb:{triggeringSession}"`
+- Therefore the triggering session's own parent-dir lease (if any) is NOT in the toBreak set
+- Therefore the wait never blocks on its own session — only on OTHER clients' acks
+- `WaitForBreakCompletion` falls through to `forceCompleteBreaks` on ctx cancellation (auto-downgrade), so a timeout always yields a deterministic post-break state
+
+## Recommended timeout
+Researcher recommendation: 5 seconds. Use `context.WithTimeout(ctx, 5*time.Second)` derived from the CREATE's request context. If `lease/manager.go` already defines a `leaseBreakWaitTimeout` constant (or similar), reuse it.
+</context>
+
+<threat_model>
+## Trust Boundaries
+| Boundary | Description |
+|----------|-------------|
+| client→SMB server | Client A's CREATE triggers breaks against client B's directory lease; server must deliver and wait for ack before completing A's CREATE |
+
+## STRIDE Threat Register
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-72-05 | Tampering (state) | parent directory lease state | mitigate | Wait for ack ensures B's lease state is consistent with A's observation when CREATE returns |
+| T-72-06 | Denial of Service | malicious/slow client B blocks A's CREATE | mitigate | Bounded 5s timeout + `forceCompleteBreaks` auto-downgrade prevents indefinite block |
+| T-72-07 | Elevation (cache staleness) | stale Handle cache across clients | mitigate | Deterministic break delivery before A's CREATE completes prevents B from continuing to act on a stale Handle lease |
+</threat_model>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Wave 0 — Add 3 unit tests for parent-break ack-wait (RED)</name>
+  <files>
+    internal/adapter/smb/lease/manager_test.go
+  </files>
+  <read_first>
+    - internal/adapter/smb/lease/manager.go (lines 351-460 — existing BreakHandleLeasesOnOpen pattern AND the buggy BreakParentHandleLeasesOnCreate at 440-451 AND BreakParentReadLeasesOnModify)
+    - internal/adapter/smb/lease/manager_test.go (existing test conventions, fakes, helpers)
+    - pkg/metadata/lock/manager.go (around 1308 — BreakHandleLeasesForSMBOpen, around 1382-1497 — WaitForBreakCompletion + breakOpLocks excludeOwner handling)
+    - .planning/phases/72-wpts-conformance-push/72-RESEARCH.md (Q3 — full execution trace)
+  </read_first>
+  <behavior>
+    - **Test 1: `TestBreakParentHandleLeasesOnCreate_WaitsForAck`** — Set up two fake clients A and B. B holds a Handle lease on a parent directory. A triggers `BreakParentHandleLeasesOnCreate(ctx, parentHandle, shareName, "smb:A")`. Use a fake `lockMgr` that records calls. Assert that after `BreakHandleLeasesForSMBOpen` is called, `WaitForBreakCompletion` is ALSO called with the same handleKey, and the call happens BEFORE `BreakParentHandleLeasesOnCreate` returns.
+    - **Test 2: `TestBreakParentReadLeasesOnModify_WaitsForAck`** — Same shape but for `BreakParentReadLeasesOnModify`. Assert `WaitForBreakCompletion` is called with the corresponding handleKey before return.
+    - **Test 3: `TestBreakParentHandle_ExcludesTriggeringClient`** — Set up a scenario where A also has a parent-dir lease. Call `BreakParentHandleLeasesOnCreate(ctx, parentHandle, shareName, "smb:A")`. Inspect the `excludeOwner` argument passed into `BreakHandleLeasesForSMBOpen`. Assert `excludeOwner.ClientID == "smb:A"`. Then assert that `WaitForBreakCompletion` does NOT block waiting for A's session — use a fake whose `WaitForBreakCompletion` returns immediately if the only outstanding break is excluded, and assert the function does not deadlock (use `time.AfterFunc` watchdog with 1s budget that fails the test).
+    - All 3 tests use the existing fake/mock conventions in `manager_test.go`. If a `fakeLockManager` already exists, extend it with a `WaitForBreakCompletionCalls []FileHandleKey` recorder. If not, create one minimal to these tests.
+  </behavior>
+  <action>
+    Add the three test functions to `internal/adapter/smb/lease/manager_test.go`. Run BEFORE Task 2 to confirm RED:
+
+    ```
+    go test ./internal/adapter/smb/lease/... -run 'TestBreakParentHandleLeasesOnCreate_WaitsForAck|TestBreakParentReadLeasesOnModify_WaitsForAck|TestBreakParentHandle_ExcludesTriggeringClient' -v
+    ```
+
+    Expected: the two `_WaitsForAck` tests FAIL (because the unmodified code doesn't call WaitForBreakCompletion). The `_ExcludesTriggeringClient` test should pass for the excludeOwner half (already correct in current code) but FAIL on the deadlock-watchdog half if it tries to assert wait happens — adjust the test so that the no-deadlock assertion is meaningful only after Task 2 wires the wait. If both halves pass on unmodified code, the test isn't testing the right thing — revise.
+
+    Concretely, the cleanup test pattern from Plan 02 applies: each test must demonstrably FAIL on unmodified `manager.go` to prove it catches the bug, then PASS after Task 2.
+
+    Commit the failing tests as a single commit:
+    `test(smb): add unit tests for parent lease break ack-wait determinism`
+    GPG/SSH-signed. No Claude Code mention.
+  </action>
+  <verify>
+    <automated>go test ./internal/adapter/smb/lease/... -run 'TestBreakParentHandleLeasesOnCreate_WaitsForAck|TestBreakParentReadLeasesOnModify_WaitsForAck' -v 2>&1 | tee /tmp/72-03-01.log; grep -qE 'FAIL.*TestBreakParentHandleLeasesOnCreate_WaitsForAck' /tmp/72-03-01.log && grep -qE 'FAIL.*TestBreakParentReadLeasesOnModify_WaitsForAck' /tmp/72-03-01.log</automated>
+  </verify>
+  <acceptance_criteria>
+    - 3 new test functions exist in `internal/adapter/smb/lease/manager_test.go`
+    - Both `_WaitsForAck` tests are RED on unmodified `manager.go` (verified by running BEFORE Task 2)
+    - `TestBreakParentHandle_ExcludesTriggeringClient` asserts `excludeOwner.ClientID` matches the triggering session
+    - Tests committed (GPG/SSH-signed, no Claude Code mention)
+  </acceptance_criteria>
+  <done>3 tests committed; the 2 ack-wait tests demonstrably RED on unmodified code.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add bounded WaitForBreakCompletion to both parent-break functions (GREEN)</name>
+  <files>
+    internal/adapter/smb/lease/manager.go
+  </files>
+  <read_first>
+    - internal/adapter/smb/lease/manager.go (READ THE FULL CURRENT BreakParentHandleLeasesOnCreate AND BreakParentReadLeasesOnModify before editing — line numbers in research are approximate)
+    - internal/adapter/smb/lease/manager.go (lines 351-380 — the BreakHandleLeasesOnOpen ack-wait pattern to mirror)
+    - .planning/phases/72-wpts-conformance-push/72-RESEARCH.md (Q3 — full proposed edit, deadlock safety analysis)
+  </read_first>
+  <behavior>
+    - Both `_WaitsForAck` tests from Task 1 must pass.
+    - `TestBreakParentHandle_ExcludesTriggeringClient` continues to pass.
+    - All existing tests in `internal/adapter/smb/lease/...` continue to pass.
+    - `BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify` each call `WaitForBreakCompletion` exactly once with a bounded context derived from the caller's ctx.
+  </behavior>
+  <action>
+    Open `internal/adapter/smb/lease/manager.go`. Locate `BreakParentHandleLeasesOnCreate` (around line 440-451 per research; verify by reading first). The current implementation calls `lockMgr.BreakHandleLeasesForSMBOpen(...)` and returns. Note the comment at lines 437-439 explaining "does NOT wait" — this comment must be REMOVED or REPLACED, since the new behavior IS to wait.
+
+    Make this edit (illustrative — adapt to the actual current code shape after reading):
+
+    **Before** (current — does not wait):
+    ```go
+    func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
+        ctx context.Context,
+        parentHandle lock.FileHandle,
+        shareName string,
+        excludeClientID string,
+    ) error {
+        // This does NOT wait for the break to complete. The parent directory
+        // break is an informational notification.
+        lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+        if lockMgr == nil {
+            return nil
+        }
+        return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner)
+    }
+    ```
+
+    **After**:
+    ```go
+    func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
+        ctx context.Context,
+        parentHandle lock.FileHandle,
+        shareName string,
+        excludeClientID string,
+    ) error {
+        // Wait for the parent directory break to complete (or timeout). Per
+        // MS-SMB2 3.3.4.7 the server must wait for LEASE_BREAK_ACK when
+        // SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED is set. Self-deadlock is
+        // impossible because excludeClientID removes the triggering CREATE's
+        // own session from breakOpLocks (see manager.go breakOpLocks honoring
+        // excludeOwner.ClientID). Required by WPTS BVT
+        // BVT_DirectoryLeasing_LeaseBreakOnMultiClients.
+        lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+        if lockMgr == nil {
+            return nil
+        }
+        if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+            return err
+        }
+        waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+        defer cancel()
+        return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+    }
+    ```
+
+    Apply the SAME structural edit to `BreakParentReadLeasesOnModify`.
+
+    Add a package-level constant near the top of the file (if no equivalent constant already exists — search first):
+    ```go
+    // parentLeaseBreakWaitTimeout bounds how long a CREATE/MODIFY waits for
+    // other clients to acknowledge a parent-directory lease break. On expiry,
+    // WaitForBreakCompletion's forceCompleteBreaks path auto-downgrades the
+    // lease state, yielding a deterministic post-break view.
+    const parentLeaseBreakWaitTimeout = 5 * time.Second
+    ```
+
+    If `time` is not already imported in this file, add it to the import block.
+
+    Run:
+    ```
+    go fmt ./...
+    go vet ./internal/adapter/smb/lease/...
+    go test ./internal/adapter/smb/lease/... -v
+    go test ./internal/adapter/smb/...
+    ```
+
+    All tests must pass. If `BreakHandleLeasesOnOpen` had an existing test that asserts the old async-only behavior of the parent functions, that test must be updated — but per research the old behavior was a bug, so any such test should be revised to match the new contract.
+
+    Commit message: `fix(smb): wait for parent lease break ack to make multi-client breaks deterministic`
+    Body should reference the BVT test and MS-SMB2 3.3.4.7. GPG/SSH-signed. No Claude Code mention.
+  </action>
+  <verify>
+    <automated>go test ./internal/adapter/smb/lease/... -run 'TestBreakParentHandleLeasesOnCreate_WaitsForAck|TestBreakParentReadLeasesOnModify_WaitsForAck|TestBreakParentHandle_ExcludesTriggeringClient' -v && go test ./internal/adapter/smb/... && grep -c 'WaitForBreakCompletion' internal/adapter/smb/lease/manager.go</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n 'WaitForBreakCompletion' internal/adapter/smb/lease/manager.go` returns AT LEAST 3 matches (existing one in BreakHandleLeasesOnOpen + 2 new in the parent functions). Document the exact line numbers in the commit body.
+    - Both new parent functions call `context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)` and pass the derived ctx to `WaitForBreakCompletion`
+    - The "does NOT wait" comment is removed/replaced
+    - `parentLeaseBreakWaitTimeout` constant defined (or existing equivalent reused)
+    - All 3 Wave 0 tests pass
+    - `go test ./internal/adapter/smb/...` passes
+    - `go vet ./internal/adapter/smb/lease/...` clean
+    - Commit GPG/SSH-signed, no Claude Code mention
+  </acceptance_criteria>
+  <done>Both parent-break functions wait for ack with bounded timeout; tests green; no regressions.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: 5-run flake gate — verify lease fix in Linux CI</name>
+  <files>(none — CI runs only)</files>
+  <read_first>
+    - .planning/phases/72-wpts-conformance-push/72-baseline-ci.txt
+    - .planning/phases/72-wpts-conformance-push/72-VALIDATION.md (sampling rate — flake gate requirement)
+  </read_first>
+  <action>
+    The lease test is historically flaky. To prove the determinism fix actually eliminated the flake (rather than just improved odds), trigger 5 consecutive Linux CI WPTS BVT runs against the post-fix branch and confirm `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` passes in EACH ONE.
+
+    Concrete steps:
+    1. Push the branch (or confirm it's already pushed): `git push origin fix/phase-72-wpts-trailing-fixes`
+    2. Trigger 5 runs (back-to-back is fine, parallel is fine if CI supports it):
+       ```
+       for i in 1 2 3 4 5; do gh workflow run smb-conformance.yml --ref fix/phase-72-wpts-trailing-fixes; sleep 5; done
+       ```
+       Or use the workflow's manual dispatch UI 5 times if `gh workflow run` is not the right command. Confirm the actual workflow name first.
+    3. Wait for all 5 runs to complete: `gh run list --workflow smb-conformance.yml --branch fix/phase-72-wpts-trailing-fixes --limit 5`
+    4. For each run, confirm `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` is in the PASS column
+    5. Record all 5 run URLs in this checkpoint's resume notes for Plan 04 to consume
+
+    If ANY of the 5 runs shows the lease test failing → the fix is insufficient and Plan 03 must be reopened with deeper investigation before Plan 04 proceeds. Do not paper over a 4/5 result.
+  </action>
+  <verify>
+    <automated>echo "Manual 5-run flake gate — see resume notes for run URLs"</automated>
+  </verify>
+  <acceptance_criteria>
+    - 5 Linux CI WPTS BVT runs completed against the post-fix branch
+    - `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` PASS in all 5 runs (5/5, not 4/5)
+    - No new test failures introduced compared to `72-baseline-ci.txt` in any of the 5 runs
+    - All 5 run URLs recorded for Plan 04
+  </acceptance_criteria>
+  <done>5/5 PASS confirmed; flake gate passed.</done>
+  <how-to-verify>
+    1. Open each of the 5 recorded run URLs
+    2. In each, search for `LeaseBreakOnMultiClients` — must show PASS
+    3. Compare each run's pass/known/new/skipped to the baseline — only allowed delta is the 1-2 fixed target tests moving FAIL→PASS
+  </how-to-verify>
+  <resume-signal>Type "lease 5/5 pass" with the 5 run URLs, or describe issues</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- Wave 0 lease tests added BEFORE the fix and proven RED
+- 2 functions modified to call `WaitForBreakCompletion` with bounded timeout
+- Self-deadlock impossibility documented in code comment AND verified by exclude-client test
+- All `internal/adapter/smb/lease/...` tests pass
+- 5/5 Linux CI WPTS BVT runs show the lease test PASSING
+</verification>
+
+<success_criteria>
+- `internal/adapter/smb/lease/manager.go` contains `parentLeaseBreakWaitTimeout` constant (or equivalent)
+- Both `BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify` call `WaitForBreakCompletion`
+- The "does NOT wait" stale comment is gone
+- `internal/adapter/smb/lease/manager_test.go` contains 3 new test functions
+- 5/5 Linux CI runs show `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` PASS
+- 2 GPG/SSH-signed commits on `fix/phase-72-wpts-trailing-fixes` (test + fix)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/72-wpts-conformance-push/72-03-SUMMARY.md` with the diff, the test names, the 5 Linux CI run URLs, and the 5/5 PASS confirmation.
+</output>

--- a/.planning/phases/72-wpts-conformance-push/72-01-SUMMARY.md
+++ b/.planning/phases/72-wpts-conformance-push/72-01-SUMMARY.md
@@ -1,0 +1,201 @@
+---
+phase: 72
+plan: 01
+subsystem: smb/lease
+tags: [smb, lease, wpts, conformance, ms-smb2]
+requires: []
+provides:
+  - "BreakParentHandleLeasesOnCreate waits for LEASE_BREAK_ACK with bounded timeout"
+  - "BreakParentReadLeasesOnModify waits for LEASE_BREAK_ACK with bounded timeout"
+  - "parentLeaseBreakWaitTimeout (5s) constant"
+affects:
+  - internal/adapter/smb/v2/handlers/create.go (callers benefit from deterministic break delivery)
+tech-stack:
+  added: []
+  patterns:
+    - "Bounded ack-wait via context.WithTimeout + WaitForBreakCompletion (mirrors BreakHandleLeasesOnOpen)"
+    - "Self-deadlock prevention via excludeOwner.ClientID (triggering session removed from breakable set)"
+key-files:
+  created:
+    - internal/adapter/smb/lease/manager_test.go
+  modified:
+    - internal/adapter/smb/lease/manager.go
+decisions:
+  - "Use 5s bounded timeout per researcher recommendation; on expiry forceCompleteBreaks auto-downgrades the lease state for a deterministic post-break view"
+  - "Self-deadlock impossibility is documented in code AND verified by TestBreakParentHandle_ExcludesTriggeringClient"
+  - "Test fake embeds lock.LockManager interface; only the 3 methods exercised by these tests are implemented (others would panic if accidentally invoked)"
+metrics:
+  duration: ~25min
+  completed: 2026-04-07
+  tasks_completed: 2/3
+  tasks_pending: 1 (CI flake gate — see Pending section)
+---
+
+# Phase 72 Plan 01: Lease Break Ack-Wait Fix Summary
+
+Fix `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` flake by making
+parent-directory lease break delivery deterministic via bounded
+`WaitForBreakCompletion` ack-wait, mirroring the proven
+`BreakHandleLeasesOnOpen` pattern.
+
+## What changed
+
+Two parent-directory break helpers in `internal/adapter/smb/lease/manager.go`
+previously dispatched `BreakHandleLeasesForSMBOpen` /
+`BreakReadLeasesForParentDir` and returned immediately. Per MS-SMB2 3.3.4.7
+the server must wait for `LEASE_BREAK_ACK` when the break is sent with
+`SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED` set, otherwise the triggering
+CREATE returns to client A before client B's ack arrives and WPTS observes
+a stale pre-break view.
+
+Both functions now wait via:
+
+```go
+if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+    return err
+}
+waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+defer cancel()
+return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+```
+
+`parentLeaseBreakWaitTimeout = 5 * time.Second`. On expiry,
+`WaitForBreakCompletion` falls through to `forceCompleteBreaks`, which
+auto-downgrades the lease state — so even a malicious/slow client B cannot
+indefinitely block client A's CREATE, and the post-break view is always
+deterministic.
+
+Self-deadlock is impossible: `excludeClientID` is forwarded as
+`excludeOwner.ClientID` into `BreakHandleLeasesForSMBOpen`, and the
+underlying `breakOpLocks` honors `excludeOwner.ClientID` to remove the
+triggering CREATE's own session from the `toBreak` set. The test
+`TestBreakParentHandle_ExcludesTriggeringClient` verifies both halves of
+this contract: the exclude is wired AND the wait does not deadlock the
+caller (it returns within the caller's context deadline).
+
+Stale comment "This does NOT wait for the break to complete..." removed
+and replaced with the new MS-SMB2 3.3.4.7 contract documentation.
+
+## Tasks completed
+
+| # | Task | Commit | Files |
+|---|------|--------|-------|
+| 1 | Wave 0 — RED tests for parent-break ack-wait | `a2dfaac1` | `internal/adapter/smb/lease/manager_test.go` |
+| 2 | GREEN — bounded WaitForBreakCompletion in both parent functions | `0b7b71dc` | `internal/adapter/smb/lease/manager.go` |
+
+## Tests added
+
+All three live in `internal/adapter/smb/lease/manager_test.go`:
+
+1. **`TestBreakParentHandleLeasesOnCreate_WaitsForAck`** — RED on
+   unmodified code (verified before Task 2). Asserts
+   `BreakHandleLeasesForSMBOpen` is called, then `WaitForBreakCompletion`
+   is called with the same handleKey, then the function returns.
+2. **`TestBreakParentReadLeasesOnModify_WaitsForAck`** — Same shape for
+   `BreakReadLeasesForParentDir` + `WaitForBreakCompletion`.
+3. **`TestBreakParentHandle_ExcludesTriggeringClient`** — Asserts
+   `excludeOwner.ClientID == "smb:A"` is forwarded into
+   `BreakHandleLeasesForSMBOpen`, AND that
+   `BreakParentHandleLeasesOnCreate` does not block forever when the
+   underlying `WaitForBreakCompletion` is artificially stuck — a 200ms
+   caller context deadline must be honored (proves no deadlock). A 2s
+   watchdog fails the test if the call hangs.
+
+The fake `fakeLockManager` embeds the `lock.LockManager` interface and
+implements only the three methods exercised here
+(`BreakHandleLeasesForSMBOpen`, `BreakReadLeasesForParentDir`,
+`WaitForBreakCompletion`); any other unintended call would panic at
+runtime, surfacing accidental coupling in future test changes.
+
+### Test verification log
+
+Before fix (Task 1, RED):
+
+```
+--- FAIL: TestBreakParentHandleLeasesOnCreate_WaitsForAck (0.00s)
+    manager_test.go:106: WaitForBreakCompletion call count = 0, want 1
+--- FAIL: TestBreakParentReadLeasesOnModify_WaitsForAck (0.00s)
+    manager_test.go:150: WaitForBreakCompletion call count = 0, want 1
+--- FAIL: TestBreakParentHandle_ExcludesTriggeringClient (0.00s)
+    manager_test.go:220: WaitForBreakCompletion call count = 0, want 1
+```
+
+After fix (Task 2, GREEN):
+
+```
+--- PASS: TestBreakParentHandleLeasesOnCreate_WaitsForAck (0.00s)
+--- PASS: TestBreakParentReadLeasesOnModify_WaitsForAck (0.00s)
+--- PASS: TestBreakParentHandle_ExcludesTriggeringClient (0.20s)
+PASS
+ok      github.com/marmos91/dittofs/internal/adapter/smb/lease  0.603s
+```
+
+Full SMB suite regression check:
+
+```
+ok    github.com/marmos91/dittofs/internal/adapter/smb           0.655s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/auth      1.051s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/encryption 1.621s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/header    2.577s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/kdf       1.314s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/lease     0.414s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/rpc       1.903s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/session   2.967s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/signing   2.177s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/smbenc    2.861s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/types     3.139s
+ok    github.com/marmos91/dittofs/internal/adapter/smb/v2/handlers 4.345s
+```
+
+No regressions.
+
+## WaitForBreakCompletion call sites in lease/manager.go
+
+`grep -nc 'WaitForBreakCompletion' internal/adapter/smb/lease/manager.go` → 5 matches:
+
+1. Existing call in `BreakHandleLeasesOnOpen` (line ~375) — pre-existing
+2. New call in `BreakParentHandleLeasesOnCreate`
+3. New call in `BreakParentReadLeasesOnModify`
+4. Two stub references in `manager_test.go` are in a separate file
+   (the 5 above are all within `manager.go` — they include the
+   constant doc-comment reference and the body call)
+
+Acceptance criterion was "≥3 matches"; satisfied.
+
+## Deviations from Plan
+
+None — Tasks 1 and 2 executed exactly as written.
+
+The plan's `manager_test.go` reference assumed the file already
+existed; it did not, so the file was created from scratch. The
+`fakeLockManager` was built minimal-to-the-tests as the plan
+permits ("If a `fakeLockManager` already exists, extend it... If
+not, create one minimal to these tests").
+
+## Pending: Task 3 — 5-run CI flake gate
+
+Task 3 is a `checkpoint:human-verify` gate that requires triggering 5
+consecutive Linux CI WPTS BVT runs against this branch and confirming
+`BVT_DirectoryLeasing_LeaseBreakOnMultiClients` PASS in all 5. This is
+NOT something a code-execution agent can complete in a worktree — it
+requires:
+
+1. Pushing the branch to origin
+2. Triggering 5 workflow runs via `gh workflow run smb-conformance.yml`
+3. Waiting for completion and inspecting per-run results
+4. Recording the 5 run URLs for Plan 02 to consume
+
+The orchestrator should treat this as a checkpoint after the worktree
+agents merge and surface it to the user. Acceptance criterion is 5/5
+PASS — a 4/5 result reopens Plan 01.
+
+## Self-Check: PASSED
+
+- `internal/adapter/smb/lease/manager.go`: FOUND (modified)
+- `internal/adapter/smb/lease/manager_test.go`: FOUND (created)
+- Commit `a2dfaac1`: FOUND
+- Commit `0b7b71dc`: FOUND
+- `parentLeaseBreakWaitTimeout` constant: present
+- Both parent functions call `WaitForBreakCompletion` with bounded ctx: verified
+- Stale "does NOT wait" comment: removed
+- All 3 new tests PASS, no SMB regressions: verified

--- a/.planning/phases/72-wpts-conformance-push/72-02-PLAN.md
+++ b/.planning/phases/72-wpts-conformance-push/72-02-PLAN.md
@@ -1,0 +1,393 @@
+---
+phase: 72
+plan: 02
+type: execute
+wave: 2
+depends_on: [72-01]
+files_modified:
+  - test/smb-conformance/KNOWN_FAILURES.md
+  - .planning/ROADMAP.md
+  - .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt
+  - .planning/phases/72-wpts-conformance-push/72-SUMMARY.md
+autonomous: false
+requirements: [WPTS-03, WPTS-04]
+supersedes: 72-04 (renumbered after PR #323 closed Plan 02's scope)
+must_haves:
+  truths:
+    - "Final Linux CI WPTS BVT run shows BVT_DirectoryLeasing_LeaseBreakOnMultiClients PASS, 0 new regressions, fixable known failures reduced from 4 to 3"
+    - "KNOWN_FAILURES.md header count, table row count (Expected + Permanent), and footer grand total all agree"
+    - "3 deferred timestamp tests labeled as Expected with structured 'blocked on cross-protocol POSIX timestamp phase' reason"
+    - "Phase 72 marked [x] in ROADMAP.md with descope note crediting BOTH PR #323 (ChangeNotify) and this branch (lease ack-wait)"
+    - "Phase 72 SUMMARY.md committed; PR opened or ready to open"
+  artifacts:
+    - path: "test/smb-conformance/KNOWN_FAILURES.md"
+      provides: "Reconciled known-failure baseline with consistent counts and labeled deferred tests"
+      contains: "blocked on cross-protocol POSIX timestamp phase"
+    - path: ".planning/ROADMAP.md"
+      provides: "Phase 72 marked [x] with descope note"
+      contains: "Phase 72: WPTS Conformance Push"
+    - path: ".planning/phases/72-wpts-conformance-push/72-postfix-ci.txt"
+      provides: "Authoritative post-fix Linux CI WPTS BVT result"
+    - path: ".planning/phases/72-wpts-conformance-push/72-SUMMARY.md"
+      provides: "Phase 72 phase-level summary"
+      contains: "absorbed by Phase 73"
+  key_links:
+    - from: "BVT_DirectoryLeasing_LeaseBreakOnMultiClients (current Expected entry on develop)"
+      to: "removed from KNOWN_FAILURES.md after post-fix CI confirms PASS"
+      via: "Plan 01 lease ack-wait fix verified by Linux CI"
+      pattern: "LeaseBreakOnMultiClients"
+---
+
+<objective>
+Verify the lease fix from Plan 01 in Linux CI, reconcile `KNOWN_FAILURES.md` (header / table / footer counts), label the 3 deferred timestamp tests with a structured reason, mark Phase 72 done in `ROADMAP.md` with an honest descope note, and open the PR.
+
+Purpose: Phase 72's exit criteria (D-10) require the verification sweep to actually happen — the lease fix confirmed in authoritative Linux CI, no regressions, the multi-source count discrepancy in `KNOWN_FAILURES.md` resolved, and the 3 deferred tests clearly labeled. The user explicitly flagged the count discrepancy as the reason a sweep is mandatory; sloppy bookkeeping is not acceptable.
+
+Output: 1 final CI run captured, KNOWN_FAILURES.md fully reconciled, ROADMAP.md updated with descope note, Phase 72 SUMMARY committed, PR opened against develop.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/72-wpts-conformance-push/72-CONTEXT.md
+@.planning/phases/72-wpts-conformance-push/72-RESEARCH.md
+@.planning/phases/72-wpts-conformance-push/72-VALIDATION.md
+@.planning/phases/72-wpts-conformance-push/72-01-SUMMARY.md
+@test/smb-conformance/KNOWN_FAILURES.md
+
+## Branch reminder
+This work happens on `fix/phase-72-wpts-trailing-fixes` (off `develop`). Final commit on this branch.
+
+## Phase descope context (CRITICAL)
+Phase 72's roadmap entry (line 161 area + lines 302-312) over-promises. Phase 73 absorbed the original ChangeNotify / negotiate / leasing scope. Then **PR #323** (`914291cb`, "fix(smb): close last ChangeNotify failure + harden empty-buffer encoders") shipped the ChangeNotify CLOSE cleanup fix that this phase originally planned as Plan 02. PR #323 used a different and better fix than the researcher's branch-condition theory:
+- Real bug 1: wire ordering — `close.go` was firing notify cleanup BEFORE the CLOSE response reached the dispatcher. Violates MS-SMB2 3.3.4.1 ("CHANGE_NOTIFY responses MUST be the last responses sent for the FileId"). Fix: introduced `SMBHandlerContext.PostSend` hook so cleanup runs strictly after the CLOSE response is on the wire.
+- Real bug 2: empty variable-section padding — `ChangeNotifyResponse.Encode` emitted only the 8-byte fixed portion when buffer was empty, but `StructureSize=9` per MS-SMB2 2.2.36 means "8-byte fixed + ≥1 byte variable section". WPTS silently drops short responses. Same class fixed in 4 other encoders (Read, Ioctl, QueryDir, QueryInfo).
+- PR #323 also removed `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` from `KNOWN_FAILURES.md` (Expected: 5 → 4).
+
+So Phase 72 = PR #323 (already shipped on develop) + Plan 01 (lease ack-wait fix on `fix/phase-72-wpts-trailing-fixes`) + this plan (verification + reconciliation + mark-done).
+
+## Reconciliation context (from RESEARCH.md Q1 + post-#323 verification)
+Current state of `test/smb-conformance/KNOWN_FAILURES.md` on `origin/develop`:
+- **Header (around line 16):** `Current baseline (Phase 73): 58 known failures (53 permanent + 5 expected)` — STALE (predates PR #323)
+- **Footer grand total:** `Grand total known failures: 42 tests (38 permanent + 4 expected)` — internally adds to 42 but actual table count is 39 permanent + 4 expected = 43. The footer is also stale.
+- **Actual table count on develop:** 4 Expected rows + 39 Permanent rows = 43 known failures
+- The `Permanent` count drift (38 vs 39) needs investigation: Task 2 will reconcile by counting the table directly and aligning header/footer to the actual count.
+
+After Plan 01 lands (lease fix verified in CI), expected state:
+- 4 Expected rows → 3 (the 3 timestamp deferred tests)
+- 39 Permanent rows → 39 (unchanged unless CI surfaces a regression)
+- Total: 42 = 39 permanent + 3 expected
+- All three count sources (header, table, footer) MUST agree
+
+Per RESEARCH.md Q4: keep `Expected` status (do NOT add a new `Deferred` status); use structured "blocked on cross-protocol POSIX timestamp phase" reason text for the 3 timestamp tests.
+
+## Descope note (D-11)
+Phase 72's roadmap entry over-promises (ChangeNotify implementation, negotiate fixes, leasing edge cases, ≤45 known target). Phase 73 + PR #323 absorbed all of that. Phase 72's actual delivered scope is the 1 lease ack-wait fix + verification sweep. SUMMARY.md, the roadmap mark-done note, and the PR body must clearly state this.
+</context>
+
+<threat_model>
+## Trust Boundaries
+| Boundary | Description |
+|----------|-------------|
+| (none) | Plan 02 is documentation/CI only — no code change, no protocol surface touched |
+
+## STRIDE Threat Register
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-72-08 | Tampering | KNOWN_FAILURES.md count | mitigate | Automated count consistency check (header vs table vs footer) gates this plan |
+| T-72-09 | Repudiation | "tests pass" claim without evidence | mitigate | Linux CI run URL captured in 72-postfix-ci.txt as immutable evidence |
+</threat_model>
+
+<tasks>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 1: Final Linux CI WPTS BVT sweep — capture post-Plan-01 authoritative result</name>
+  <files>
+    .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt
+  </files>
+  <read_first>
+    - .planning/phases/72-wpts-conformance-push/72-01-SUMMARY.md (lease fix + 5/5 CI run URLs from Plan 01)
+    - test/smb-conformance/KNOWN_FAILURES.md (current baseline counts)
+  </read_first>
+  <action>
+    Trigger one final Linux CI WPTS BVT run on the post-fix branch and capture the authoritative result for Phase 72.
+
+    Concrete steps:
+    1. Confirm `fix/phase-72-wpts-trailing-fixes` is at the latest fix commit (Plan 01 lease fix merged)
+    2. `gh workflow run smb-conformance.yml --ref fix/phase-72-wpts-trailing-fixes`
+    3. `gh run watch` until completion
+    4. Download artifacts and assemble `.planning/phases/72-wpts-conformance-push/72-postfix-ci.txt` containing:
+       - Header comment with the run URL and the git SHA
+       - Full PASS/KNOWN/NEW/SKIPPED totals from `parse-results.sh`
+       - Status line for `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` (must show PASS)
+       - Status lines for the 3 deferred timestamp tests (must show FAIL — they remain Expected)
+       - A diff section vs current `develop` baseline listing every test whose status changed (allowed: 1 FAIL→PASS for the lease test; forbidden: any PASS→FAIL or new entries not in `KNOWN_FAILURES.md`)
+
+    Acceptance: Post-fix CI run shows EXACTLY 1 test moved from FAIL/known to PASS (the lease test); 0 new failures; 0 PASS→FAIL regressions.
+  </action>
+  <verify>
+    <automated>test -s .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt && grep -q 'PASS' .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt && grep -q 'LeaseBreakOnMultiClients' .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt</automated>
+  </verify>
+  <acceptance_criteria>
+    - `72-postfix-ci.txt` exists, contains run URL + git SHA + totals + per-target status
+    - `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` shows PASS in the Linux CI post-fix result
+    - Diff vs develop baseline shows only allowed deltas (1 fixed target, 0 regressions)
+    - The 3 deferred timestamp tests still appear (still expected failures, will be relabeled in Task 2)
+  </acceptance_criteria>
+  <done>Final authoritative Linux CI result captured; lease test PASS; 0 regressions.</done>
+  <how-to-verify>
+    1. Open the post-fix run URL
+    2. Confirm runner OS = Linux x86_64
+    3. Confirm `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` shows PASS
+    4. Run a structural diff vs develop's WPTS BVT result and confirm only the allowed deltas exist
+  </how-to-verify>
+  <resume-signal>Type "postfix sweep clean" with the run URL, or describe regressions</resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 2: Reconcile KNOWN_FAILURES.md (counts + deferred labeling)</name>
+  <files>
+    test/smb-conformance/KNOWN_FAILURES.md
+  </files>
+  <read_first>
+    - test/smb-conformance/KNOWN_FAILURES.md (FULL FILE — read it all before editing; line numbers are approximate and the file has multiple count statements that must all agree)
+    - .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt (authoritative numbers from Task 1)
+    - .planning/phases/72-wpts-conformance-push/72-RESEARCH.md (Q1 reconciliation analysis + Q4 deferred labeling recommendation)
+  </read_first>
+  <action>
+    Edit `test/smb-conformance/KNOWN_FAILURES.md` to fully reconcile counts and labels. Make these specific edits:
+
+    **Step 0: Count the actual table rows BEFORE editing.**
+    Run:
+    ```bash
+    EXP=$(grep -c '| Expected |' test/smb-conformance/KNOWN_FAILURES.md)
+    PERM=$(grep -c '| Permanent |' test/smb-conformance/KNOWN_FAILURES.md)
+    echo "pre-edit: expected=$EXP permanent=$PERM total=$((EXP+PERM))"
+    ```
+    Record these numbers. Compare against the post-fix CI numbers in `72-postfix-ci.txt`. The Expected count should equal the number of expected failures in CI; the Permanent count should equal the number of permanent failures in CI. If they disagree, fix the table to match CI before adjusting headers.
+
+    **Edit 1: Header total (around line 16).**
+    Find the line `Current baseline (Phase 73): 58 known failures (53 permanent + 5 expected)` (or whatever the current text is) and replace with:
+    ```
+    Current baseline (Phase 72): N known failures (P permanent + E expected)
+    ```
+    where N, P, E are the actual post-fix counts from Task 1's CI result. After Plan 01 fixes the lease test, expect approximately `42 known failures (39 permanent + 3 expected)` — but use the actual numbers from `72-postfix-ci.txt`, not these computed defaults.
+
+    **Edit 2: Remove the lease test entry from the Expected table.**
+    Remove the row for `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`. (The ChangeNotify entry was already removed by PR #323.) Quote the removed row in the commit body for traceability.
+
+    **Edit 3: Relabel the 3 deferred timestamp test rows (per RESEARCH.md Q4).**
+    For each of:
+    - `Algorithm_NotingFileModified_Dir_LastAccessTime`
+    - `FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime`
+    - `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime`
+
+    Update the Reason column (3rd column) to (use the EXACT text):
+    - LastAccessTime row: `Directory LastAccessTime auto-update on child file modification — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)`
+    - ChangeTime row: `Directory ChangeTime freeze not enforced during child operations — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)`
+    - LastWriteTime row: `Directory LastWriteTime not auto-updated after unfreeze — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)`
+
+    Status column stays `Expected` (do NOT add a `Deferred` status — see RESEARCH Q4 for rationale).
+
+    **Edit 4: Category breakdown table (look for "Remaining Expected Failure Categories").**
+    - Old expected category sum should be 4 (3 timestamp + 1 leasing); new should be 3 (just the 3 timestamp tests).
+    - Update the row count for `Timestamp` to 3, with reason `Blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)`.
+    - Remove the `Leasing` row entirely from the Expected category breakdown.
+    - Remove any stale `ChangeNotify` row if still present (PR #323 should have removed it; double-check).
+
+    **Edit 5: Footer grand total.**
+    Find the line `Grand total known failures: ...` and replace with the actual numbers from Task 1:
+    ```
+    Grand total known failures: N tests (P permanent + E expected)
+    ```
+    where N, P, E match the header in Edit 1 exactly.
+
+    **Edit 6: Add Phase 72 changelog entry.**
+    Append to the changelog section (find the most recent entry — Phase 73 — and add a Phase 72 entry above it per existing chronological-newest-first style):
+    ```
+    ## Phase 72 (YYYY-MM-DD) — descope: trailing 1 SMB-only fixable BVT failure + reconciliation
+
+    Phase 72's original scope (ChangeNotify implementation, negotiate fixes, leasing edge cases, ≤45 target) was absorbed by Phase 73 + PR #323. This entry covers the trailing fix that closed out the BVT fixable list:
+
+    - Fixed: BVT_DirectoryLeasing_LeaseBreakOnMultiClients (BreakParentHandleLeasesOnCreate + BreakParentReadLeasesOnModify now call WaitForBreakCompletion with a bounded timeout, ending the parent-directory lease break race)
+    - Reconciled: header/table/footer counts now agree
+    - Relabeled: 3 directory timestamp tests now carry structured "blocked on cross-protocol POSIX timestamp phase" reason
+    - PR #323 (already on develop) closed the BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close test via wire-ordering fix + variable-section padding fix; this entry is documented for Phase 72 traceability
+    ```
+    Replace `YYYY-MM-DD` with today's date.
+
+    **Cross-check after editing:**
+    Before committing, run the count consistency check:
+    ```bash
+    EXP=$(grep -c '| Expected |' test/smb-conformance/KNOWN_FAILURES.md)
+    PERM=$(grep -c '| Permanent |' test/smb-conformance/KNOWN_FAILURES.md)
+    TOTAL=$((EXP+PERM))
+    HEADER=$(grep -oE '[0-9]+ known failures' test/smb-conformance/KNOWN_FAILURES.md | head -1 | grep -oE '[0-9]+')
+    FOOTER=$(grep -oE 'Grand total known failures: [0-9]+' test/smb-conformance/KNOWN_FAILURES.md | grep -oE '[0-9]+')
+    echo "table: $TOTAL ($EXP exp + $PERM perm) | header: $HEADER | footer: $FOOTER"
+    [ "$TOTAL" = "$HEADER" ] && [ "$TOTAL" = "$FOOTER" ] && echo OK || echo MISMATCH
+    ```
+    The output MUST print `OK`. If `MISMATCH`, fix the file before committing.
+
+    Commit message: `docs(smb-conformance): reconcile KNOWN_FAILURES counts and label deferred timestamp tests`
+    GPG/SSH-signed. No Claude Code mention.
+  </action>
+  <verify>
+    <automated>EXP=$(grep -c '| Expected |' test/smb-conformance/KNOWN_FAILURES.md); PERM=$(grep -c '| Permanent |' test/smb-conformance/KNOWN_FAILURES.md); TOTAL=$((EXP+PERM)); HEADER=$(grep -oE '[0-9]+ known failures' test/smb-conformance/KNOWN_FAILURES.md | head -1 | grep -oE '[0-9]+'); FOOTER=$(grep -oE 'Grand total known failures: [0-9]+' test/smb-conformance/KNOWN_FAILURES.md | grep -oE '[0-9]+'); echo "table=$TOTAL ($EXP+$PERM) header=$HEADER footer=$FOOTER"; [ "$TOTAL" = "$HEADER" ] && [ "$TOTAL" = "$FOOTER" ] && grep -q 'blocked on cross-protocol POSIX timestamp phase' test/smb-conformance/KNOWN_FAILURES.md && ! grep -q 'BVT_DirectoryLeasing_LeaseBreakOnMultiClients' test/smb-conformance/KNOWN_FAILURES.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c` table-row count for Expected + Permanent equals header total equals footer grand total (all three numbers identical)
+    - `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` is NOT present in the file
+    - `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` is NOT present in the file (PR #323 already removed it; verify)
+    - All 3 timestamp test rows contain the exact phrase `blocked on cross-protocol POSIX timestamp phase`
+    - Phase 72 changelog entry appended with descope acknowledgement crediting PR #323
+    - Status legend unchanged (still Expected/Permanent only — no new Deferred status)
+    - Commit GPG/SSH-signed, no Claude Code mention
+  </acceptance_criteria>
+  <done>KNOWN_FAILURES.md fully reconciled; all 3 counts agree; deferred tests labeled.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Mark Phase 72 done in ROADMAP.md with descope note</name>
+  <files>
+    .planning/ROADMAP.md
+  </files>
+  <read_first>
+    - .planning/ROADMAP.md (FULL — locate Phase 72 line 161 area AND the detailed Phase 72 entry around line 302)
+    - .planning/phases/72-wpts-conformance-push/72-CONTEXT.md (D-11, D-12)
+    - .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt (proof of completion)
+  </read_first>
+  <action>
+    Make 2 edits to `.planning/ROADMAP.md`:
+
+    **Edit 1: Line 161 area (the phase listing line).**
+    - **Old:** `- [ ] **Phase 72: WPTS Conformance Push** - ChangeNotify implementation, negotiate/encryption fixes, leasing edge cases, known failure reduction`
+    - **New:** `- [x] **Phase 72: WPTS Conformance Push** - DESCOPED: original scope absorbed by Phase 73 + PR #323 (ChangeNotify CLOSE wire ordering fix); this phase closed the trailing 1 SMB-only fixable BVT failure (directory lease break ack-wait determinism) + reconciled KNOWN_FAILURES.md counts ✅ YYYY-MM-DD`
+
+    Replace `YYYY-MM-DD` with today's date.
+
+    **Edit 2: The detailed Phase 72 entry around line 302-312.**
+    Append a new section at the end of the existing entry (do NOT rewrite the historical Goal/Success Criteria — D-11 says no rewrite):
+    ```
+    **Actual delivered scope (descope note, YYYY-MM-DD):** Phase 73 + PR #323 absorbed the original scope (ChangeNotify implementation, negotiate fixes, leasing edge cases, ≤45 known target — Phase 73 reached 43; PR #323 closed the last BVT ChangeNotify failure). Phase 72 closed out the trailing 1 SMB-only fixable BVT failure:
+      - `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` — fixed via bounded `WaitForBreakCompletion` calls in `BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify` (`internal/adapter/smb/lease/manager.go`), ending the parent-directory lease break race that was producing CI flakes
+      - PR #323 (already on develop) closed `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` via wire-ordering fix (`SMBHandlerContext.PostSend`) + variable-section padding fix (`WriteVariableSection` helper); documented here for Phase 72 traceability
+      - Reconciled `test/smb-conformance/KNOWN_FAILURES.md`: header/table/footer counts now agree; 3 directory timestamp tests relabeled with "blocked on cross-protocol POSIX timestamp phase" reason
+      - Linux CI WPTS BVT post-fix: 1 fixed target, 0 regressions, lease test verified across 5 consecutive runs (Plan 01 flake gate)
+    **Plans**: 2 plans (72-01 lease ack-wait fix, 72-02 verification sweep + reconciliation)
+    ```
+
+    Replace `YYYY-MM-DD` with today's date.
+
+    Run `git diff .planning/ROADMAP.md` and inspect.
+
+    Commit message: `docs(roadmap): mark Phase 72 done with descope note`
+    GPG/SSH-signed. No Claude Code mention.
+  </action>
+  <verify>
+    <automated>grep -q '\[x\] \*\*Phase 72: WPTS Conformance Push\*\*' .planning/ROADMAP.md && grep -q 'DESCOPED' .planning/ROADMAP.md && grep -q 'PR #323' .planning/ROADMAP.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - Phase 72 listing line is `[x]` (checked) and contains `DESCOPED`
+    - Detailed Phase 72 entry has an `Actual delivered scope (descope note, ...)` section
+    - The descope note credits BOTH PR #323 (ChangeNotify) and this branch (lease ack-wait)
+    - The descope note mentions the lease test by its full BVT name
+    - Plans count is `2 plans` listed
+    - Commit GPG/SSH-signed, no Claude Code mention
+  </acceptance_criteria>
+  <done>ROADMAP.md reflects actual delivered Phase 72 scope.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Phase 72 SUMMARY.md + open PR</name>
+  <files>
+    .planning/phases/72-wpts-conformance-push/72-SUMMARY.md
+  </files>
+  <read_first>
+    - .planning/phases/72-wpts-conformance-push/72-01-SUMMARY.md
+    - .planning/phases/72-wpts-conformance-push/72-postfix-ci.txt
+    - test/smb-conformance/KNOWN_FAILURES.md (post-reconciliation)
+    - .planning/phases/72-wpts-conformance-push/72-CONTEXT.md (D-11 — descope honesty)
+  </read_first>
+  <action>
+    Create `.planning/phases/72-wpts-conformance-push/72-SUMMARY.md` containing:
+
+    1. **Header:** Phase 72 — WPTS Conformance Push (descoped)
+    2. **TL;DR:** 1 paragraph honestly stating that Phase 73 + PR #323 absorbed the original scope; Phase 72 closed the trailing 1 lease fix + reconciled the KNOWN_FAILURES baseline.
+    3. **Delivered:**
+       - 2-call lease break ack-wait fix (file:line, before/after, MS-SMB2 reference) — Plan 01
+       - KNOWN_FAILURES.md reconciliation (header/table/footer all agree) — Plan 02
+       - 3 deferred timestamp tests relabeled — Plan 02
+    4. **Inherited from PR #323 (already on develop):**
+       - ChangeNotify CLOSE wire-ordering fix via SMBHandlerContext.PostSend
+       - Variable-section padding helper applied to 5 encoders (ChangeNotify + Read + Ioctl + QueryDir + QueryInfo)
+       - BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close removed from KNOWN_FAILURES
+    5. **Verification:**
+       - Plan 01: Linux CI lease 5/5 flake gate run URLs
+       - Plan 02 Task 1: Linux CI final post-fix sweep run URL
+       - Mac+QEMU diff: documented as non-authoritative per D-10a (or skipped — note explicitly)
+    6. **Numbers (Linux CI authoritative):**
+       - Pre-Phase-72 (current develop): from `72-postfix-ci.txt` baseline section
+       - Post-Phase-72: from `72-postfix-ci.txt` post-fix totals
+       - Delta: +1 pass, -1 known, 0 new
+    7. **Out of scope (deferred):**
+       - 3 directory timestamp tests — blocked on cross-protocol POSIX timestamp phase
+       - 38+ permanent failures (VHD, SWN, SQoS, DFS, NamedPipe) — out of scope
+       - smbtorture failure reduction — separate phase
+    8. **Files modified on this branch:**
+       - `internal/adapter/smb/lease/manager.go` (2 functions + bounded timeout constant)
+       - `internal/adapter/smb/lease/manager_test.go` (3 new tests)
+       - `test/smb-conformance/KNOWN_FAILURES.md` (reconciliation + changelog entry)
+       - `.planning/ROADMAP.md` (Phase 72 mark-done with descope note)
+       - `.planning/phases/72-wpts-conformance-push/*` (CONTEXT, RESEARCH, VALIDATION, plans, summaries)
+
+    Commit: `docs(phase-72): add SUMMARY for descoped trailing fixes phase` (GPG/SSH-signed, no Claude Code mention).
+
+    Then open the PR (or wait for user — `checkpoint:human-action` if PR opening is gated). Use `gh pr create --base develop --head fix/phase-72-wpts-trailing-fixes`. PR title: `Phase 72: trailing WPTS BVT fix (lease break ack-wait) + KNOWN_FAILURES reconciliation`. PR body MUST clearly state the descope per D-11 and explicitly credit PR #323 for the ChangeNotify half.
+  </action>
+  <verify>
+    <automated>test -f .planning/phases/72-wpts-conformance-push/72-SUMMARY.md && grep -q 'descoped' .planning/phases/72-wpts-conformance-push/72-SUMMARY.md && grep -q 'PR #323' .planning/phases/72-wpts-conformance-push/72-SUMMARY.md && grep -q 'absorbed the original scope\|absorbed by Phase 73' .planning/phases/72-wpts-conformance-push/72-SUMMARY.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `72-SUMMARY.md` exists
+    - SUMMARY contains the descope statement (Phase 73 + PR #323 absorbed original scope)
+    - SUMMARY explicitly credits PR #323 in its own "Inherited from PR #323" section
+    - SUMMARY references both plan SUMMARYs (72-01, 72-02) and the post-fix CI run URL
+    - SUMMARY includes pre/post numbers from `72-postfix-ci.txt`
+    - SUMMARY lists every modified file
+    - Commit GPG/SSH-signed, no Claude Code mention
+    - PR opened against `develop` (or, if gated, the user is told to open it manually with the prepared title/body)
+  </acceptance_criteria>
+  <done>Phase 72 fully documented; PR opened or ready to open; phase complete.</done>
+</task>
+
+</tasks>
+
+<verification>
+- Final Linux CI WPTS BVT run shows lease test PASS, 0 regressions
+- KNOWN_FAILURES.md header/table/footer counts agree
+- 3 deferred timestamp tests labeled with structured reason (still Expected status, no new Deferred status added)
+- ROADMAP.md Phase 72 marked [x] with descope note crediting both PR #323 and this branch
+- Phase 72 SUMMARY.md committed
+- PR opened against develop with descope-acknowledging body
+</verification>
+
+<success_criteria>
+- Both plans (72-01 lease fix, 72-02 sweep + reconciliation) complete
+- Linux CI authoritative post-fix result shows fixable known failures reduced by 1 (the lease test)
+- 0 new test failures introduced compared to current develop baseline
+- KNOWN_FAILURES.md count consistency check passes (header == table == footer)
+- 3 timestamp tests carry the exact "blocked on cross-protocol POSIX timestamp phase" phrase
+- ROADMAP.md Phase 72 is `[x]` with the descope note
+- All commits on `fix/phase-72-wpts-trailing-fixes` are GPG/SSH-signed and contain no Claude Code mention
+</success_criteria>
+
+<output>
+Plan 02 produces the final Phase 72 SUMMARY at `.planning/phases/72-wpts-conformance-push/72-SUMMARY.md` and a per-plan summary at `.planning/phases/72-wpts-conformance-push/72-02-SUMMARY.md` covering the sweep itself (the latter can be lightweight; the phase-level SUMMARY is the authoritative document).
+</output>

--- a/.planning/phases/72-wpts-conformance-push/72-CONTEXT.md
+++ b/.planning/phases/72-wpts-conformance-push/72-CONTEXT.md
@@ -1,0 +1,134 @@
+# Phase 72: WPTS Conformance Push - Context
+
+**Gathered:** 2026-04-07
+**Revised:** 2026-04-07 (post-#323 supersession)
+**Status:** Ready for planning (slim 2-plan phase)
+
+<supersession_note>
+## Supersession history
+
+This CONTEXT.md was originally written assuming 5 fixable WPTS BVT failures remained on develop. Between writing the context and starting execution, **PR #323 (`914291cb`, "fix(smb): close last ChangeNotify failure + harden empty-buffer encoders")** landed on develop and shipped a fix for `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` — Plan 02's entire original scope.
+
+PR #323's fix was different from (and better than) the researcher's branch-condition theory in 72-RESEARCH.md:
+- Real bug 1: wire ordering — `close.go` was firing the notify cleanup BEFORE the CLOSE response reached the dispatcher, violating MS-SMB2 3.3.4.1. Fix: introduced `SMBHandlerContext.PostSend` hook so cleanup runs strictly after the CLOSE response is on the wire.
+- Real bug 2: empty variable-section padding — `ChangeNotifyResponse.Encode` (and 4 other encoders) emitted only the fixed portion when buffer was empty, but `StructureSize=N` per MS-SMB2 means "(N-1) fixed + ≥1 byte variable section". WPTS silently drops short responses. Same class of bug fixed in Read, Ioctl, QueryDir, QueryInfo encoders.
+
+PR #323 also removed `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` from `KNOWN_FAILURES.md`. Current state on develop: 4 fixable expected failures (3 timestamp deferred + 1 lease flake).
+
+**Revised Phase 72 scope is now 1 fix + reconciliation:** the lease break ack-wait fix + the verification sweep that closes out the BVT fixable list. Phase 72 plan structure was reduced from 4 plans to 2:
+- Plan 01 (was 03): Lease break ack-wait fix in `BreakParentHandleLeasesOnCreate` + `BreakParentReadLeasesOnModify`
+- Plan 02 (was 04): Verification sweep + KNOWN_FAILURES.md reconciliation + ROADMAP mark-done + SUMMARY/PR
+
+The original Plans 01 (baselines) and 02 (ChangeNotify fix) were deleted as superseded by current develop state and PR #323. The relevant sections of 72-RESEARCH.md (Plan 02 ChangeNotify analysis) are now historical context only — the lease analysis (Plan 01) remains valid and accurate against current develop.
+
+**The decisions D-01 through D-12 below were authored against the pre-#323 reality and are preserved verbatim for traceability. Where they reference "5 fixable failures" or "2 SMB-only fixable failures", read as "1 fixable failure" post-#323. Where they reference Plan 02's ChangeNotify fix, read as "shipped by PR #323, not by Phase 72". The lease break decisions (D-03 through D-06) are unaffected.**
+</supersession_note>
+
+<domain>
+## Phase Boundary (revised post-#323)
+
+Close out the last 1 SMB-only fixable WPTS BVT failure and reconcile the conformance baseline. The original Phase 72 scope (ChangeNotify, negotiate, leasing, ≤45 known) was rolled into Phase 73 and exceeded; PR #323 then closed the last ChangeNotify failure. This phase is the trailing cleanup of the lease break race + the bookkeeping sweep.
+
+**In scope (revised):**
+1. `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` — directory lease break race (root cause fix, not quarantine)
+2. Verification sweep: run WPTS BVT in Linux CI on the post-fix branch, reconcile the count discrepancy in `test/smb-conformance/KNOWN_FAILURES.md` (header still says 58 from Phase 73 era, footer says 42 but table actually has 43), refresh changelog
+3. ROADMAP mark-done with descope note crediting both PR #323 and this branch
+
+**Inherited from PR #323 (already on develop, NOT this branch's work):**
+- `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` — fixed via wire-ordering + variable-section padding
+- 4 other encoders hardened against empty-buffer bug class (Read, Ioctl, QueryDir, QueryInfo)
+
+**Out of scope (deferred):**
+- 3 directory timestamp tests (`Algorithm_NotingFileModified_Dir_LastAccessTime`, `…Timestamp_MinusOne_Dir_ChangeTime`, `…Timestamp_MinusTwo_Dir_LastWriteTime`) — require metadata-service-level directory timestamp propagation that affects all protocols. Belongs in a dedicated cross-protocol timestamp phase.
+- All 38+ permanent failures (VHD, SWN, SQoS, DFS, NamedPipe) — genuinely unimplemented features, not Phase 72 work.
+- smbtorture failure reduction — separate test suite, not Phase 72's gate.
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Scope and Targets
+- **D-01:** Phase 72 narrowed to 2 SMB-only fixable failures + verification sweep. The original "≤45 known" target is already met (currently 43); this phase pushes to **41 known fixable failures** (5 → 3) and reconciles the count discrepancy.
+- **D-02:** 3 directory timestamp tests are explicitly **deferred**, not failed. They require metadata-service work and will be picked up in a future cross-protocol timestamp phase. Mark as `Deferred` (new status, distinct from `Expected` and `Permanent`) in `KNOWN_FAILURES.md`, or keep as `Expected` with a clear "blocked on metadata-service work" note — researcher to choose based on existing conventions.
+
+### Lease Break Flake (`BVT_DirectoryLeasing_LeaseBreakOnMultiClients`)
+- **D-03:** **Root-cause fix**, not quarantine and not test-side retry. The user's preference is to make break delivery deterministic before the WPTS test polls.
+- **D-04:** Investigation starts at `internal/adapter/smb/v2/handlers/create.go:1003-1020` (parent directory Handle/Read lease break dispatch on CREATE) and `internal/adapter/smb/lease/manager.go:411` (multi-client break path). The race is most likely between async break dispatch and the test's subsequent CREATE/QUERY observing the broken state. Researcher must identify whether the race is in (a) break message wire send, (b) client ack handling, or (c) server-side handle state visibility.
+- **D-05:** Acceptable fix shapes (researcher picks based on the actual race):
+  - Synchronous break dispatch on the CREATE→break path (block until break sent or timeout)
+  - Wait-for-ack with bounded timeout before completing the triggering CREATE
+  - State barrier so subsequent observations see the post-break state regardless of break delivery latency
+- **D-06:** Adding `time.Sleep` or unconditional waits is **not acceptable**. The fix must be deterministic with respect to a real protocol event.
+
+### ChangeNotify CLOSE Cleanup (`BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close`)
+- **D-07:** The CLOSE→cleanup code path already exists at `internal/adapter/smb/v2/handlers/close.go:358-383` (calls `NotifyRegistry.Unregister` then dispatches `STATUS_NOTIFY_CLEANUP` via `AsyncCallback`). The bug is in **wire format / dispatch path**, not in detection. Per `KNOWN_FAILURES.md` line 128: "CLOSE notify cleanup response format needs debugging".
+- **D-08:** Researcher must capture the actual WPTS expectation by running the failing test against the current server with verbose logging, comparing wire bytes against MS-SMB2 3.3.5.16.1. Most likely culprits to investigate:
+  - Whether `STATUS_NOTIFY_CLEANUP` should be delivered as an async response (using the AsyncId from the prior interim response) or as a sync response on the original MessageID
+  - Whether the `OutputBufferLength` field must be 0 vs absent vs a properly framed empty buffer
+  - Whether signing/encryption headers on the cleanup response match the session state at CLOSE time (not at CHANGE_NOTIFY arrival time)
+- **D-09:** The fix must preserve the existing `AsyncCallback` plumbing — do not refactor `NotifyRegistry` to remove async dispatch. Other ChangeNotify tests passing depend on the current async path.
+
+### Verification Sweep
+- **D-10:** Phase exit requires:
+  1. Both target tests passing in WPTS BVT
+  2. Zero new failures introduced (193+ passing tests maintained per memory; researcher to confirm current pass count by running the suite)
+  3. `test/smb-conformance/KNOWN_FAILURES.md` updated with: (a) reconciled total count (header and table agree), (b) changelog entry for Phase 72, (c) updated category breakdown, (d) the 3 deferred timestamp tests clearly labeled
+- **D-10a:** **CI vs local-host discrepancy is real and must be accounted for.** WPTS BVT results differ between Linux CI and the developer's macOS host running Docker under QEMU emulation. The QEMU layer introduces timing and (likely) syscall-translation differences that produce different pass/fail sets. The reconciled `KNOWN_FAILURES.md` baseline is **Linux CI**, not local. When investigating either target failure, reproduce against Linux CI semantics — local Mac+QEMU repro is a hint, not a verdict. If a test passes locally but fails in CI (or vice versa), CI wins. Researcher should document any Mac+QEMU-only failures separately so they don't pollute the canonical baseline.
+- **D-11:** No changes to ROADMAP.md success criteria. Phase 72's roadmap entry already over-specifies the original ChangeNotify/negotiate/leasing work — that's all done. The PR description and SUMMARY.md should clarify that Phase 72 was descoped because Phase 73 absorbed the original scope.
+- **D-12:** Mark Phase 72 as `[x]` complete in ROADMAP.md only after the verification sweep passes.
+</decisions>
+
+<specifics>
+## User Preferences and Constraints
+
+- **No quarantining flakes.** The user explicitly chose root-cause fix over the cheaper quarantine option for the lease break race. Apply this preference if researcher discovers other test-infrastructure-style suppressions are needed — push back and ask first.
+- **Honest counts.** The KNOWN_FAILURES.md header/table discrepancy bothered the user enough to make the sweep mandatory. When updating the file, both numbers must match and both must reflect the actual test run.
+- **Don't retroactively rewrite history.** Phase 73 already did the bulk of WPTS work; Phase 72's CONTEXT/PLAN/SUMMARY should acknowledge that, not pretend Phase 72 did it from scratch.
+- **Worktree note:** This phase is being planned in `worktree-issue-324-smb-idmap` (an unrelated SMB identity-mapping branch). Planning artifacts are committed here, but the actual fix work should happen on a Phase 72 branch off `develop`, not on the idmap branch.
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+**MS-SMB2 Spec Sections:**
+- [MS-SMB2] 3.3.5.16.1 — CHANGE_NOTIFY processing including CLOSE→STATUS_NOTIFY_CLEANUP requirement
+- [MS-SMB2] 3.3.5.15 — CHANGE_NOTIFY request validation
+- [MS-SMB2] 2.2.35 — CHANGE_NOTIFY Response wire format
+- [MS-SMB2] 3.3.4.6 — Server lease break processing (multi-client fan-out semantics)
+
+**Source files (current implementation):**
+- `internal/adapter/smb/v2/handlers/change_notify.go` — CHANGE_NOTIFY handler, NotifyRegistry, completion filter constants, NotifyRmdir cleanup precedent (lines 644-680)
+- `internal/adapter/smb/v2/handlers/close.go:358-383` — CLOSE→pending notify cleanup path (current bug location)
+- `internal/adapter/smb/v2/handlers/create.go:1003-1020` — parent directory lease break dispatch on CREATE (likely race location)
+- `internal/adapter/smb/lease/manager.go:411` — multi-client break helper (referenced in code comment as the path that enables `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`)
+- `internal/adapter/smb/v2/handlers/result.go` — Async response framing (AsyncId, AsyncCallback signature)
+
+**Test infrastructure:**
+- `test/smb-conformance/KNOWN_FAILURES.md` — source of truth for expected failures and pass counts
+- `test/smb-conformance/README.md` — how to run WPTS BVT and parse results
+- `test/smb-conformance/baseline-results.md` — current baseline run
+
+**Prior phase context (must read before planning):**
+- `.planning/phases/73-smb-conformance-deep-dive/73-CONTEXT.md` — D-01 through D-04 explain the Phase 73 prioritization that left these 2 items
+- `.planning/phases/73-smb-conformance-deep-dive/73-01-PLAN.md` and `73-01-SUMMARY.md` — ChangeNotify completion work (ADS stream, ChangeSecurity, ServerReceiveSmb2Close *attempted*)
+- `.planning/phases/73-smb-conformance-deep-dive/73-04-PLAN.md` and `73-04-SUMMARY.md` — DH/lease state machine fixes
+</canonical_refs>
+
+<deferred>
+## Deferred Ideas (not Phase 72)
+
+- **Directory timestamp propagation across protocols** (3 WPTS failures + similar NFS gaps). Needs metadata-service-level work touching `pkg/metadata/file_modify.go` and all store implementations. Should be its own phase under a "cross-protocol POSIX timestamp conformance" theme.
+- **smbtorture failure reduction.** Per memory, smbtorture is at ~438 known failures after Phase 73. Phase 72's gate is WPTS BVT only. A separate phase can target smbtorture once WPTS is locked at ≤43.
+- **NamedPipe FSA tests** (2 permanent failures). Would require running WPTS with SSH access to the SUT, which is unavailable in Docker CI. Out of scope unless CI infrastructure changes.
+- **Phase numbering housekeeping.** Phase 72's roadmap entry now over-promises relative to its actual scope. A future roadmap-edit pass should rewrite Phase 72's success criteria to match what was actually delivered (this phase) and what Phase 73 absorbed.
+</deferred>
+
+<open_questions>
+## Open Questions for Researcher
+
+1. **Current WPTS BVT pass count.** Memory says 193 passing as of 2026-03-19, but the latest KNOWN_FAILURES.md changelog is Phase 73 (2026-03-24) and shows the file totals 43 known failures while the header says 58. Run the suite and report: pass / known / new / skipped, plus reconcile the discrepancy. This is the baseline Phase 72 must preserve.
+2. **ServerReceiveSmb2Close test expectation.** Capture the WPTS test's actual wire-level expectation for the CLOSE→cleanup response. Is it expecting the cleanup on the original sync MessageID, on the AsyncId from a prior interim, or as a fresh frame? The MS-SMB2 spec is permissive here; WPTS may be stricter.
+3. **Directory lease break race surface.** Does the race appear in the parent-Handle break path, the multi-client fan-out, or both? `internal/adapter/smb/lease/manager.go:411` is the entry point. Trace what happens between the triggering CREATE and the test's next observation, identify where determinism is lost.
+4. **Naming for deferred status.** Does `KNOWN_FAILURES.md` already have a precedent for distinguishing "blocked on cross-protocol work" from generic `Expected`? If yes, use that. If no, propose adding a `Deferred` status or use `Expected` with a structured reason field.
+5. **Linux CI vs Mac+QEMU result delta.** Run the WPTS BVT suite in **both** environments (Linux CI runner and the developer's macOS host running Docker via QEMU) and produce a diff: which tests pass in one but fail in the other? This delta is the QEMU-emulation noise floor and must be characterized before either target failure is debugged. Without it, a "fix" verified locally may regress in CI or vice versa. Document the diff in the phase research output so the planner knows which environment is authoritative for each test.
+</open_questions>

--- a/.planning/phases/72-wpts-conformance-push/72-RESEARCH.md
+++ b/.planning/phases/72-wpts-conformance-push/72-RESEARCH.md
@@ -1,0 +1,532 @@
+# Phase 72: WPTS Conformance Push - Research
+
+**Researched:** 2026-04-07
+**Domain:** SMB2 protocol conformance (CHANGE_NOTIFY wire format, directory lease break determinism)
+**Confidence:** HIGH on bug locations and fix shapes; LOW on live WPTS pass counts (could not run suite in this session — see Environment Availability)
+**Scope:** 2 SMB-only fixable WPTS BVT failures + verification sweep. Phase 73 already absorbed the original "ChangeNotify / negotiate / leasing edge cases" roadmap scope.
+
+## Summary
+
+Both target failures have concrete, verified root causes in the current codebase.
+
+1. **`BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close`** — the CLOSE→cleanup path at `close.go:365-383` correctly detects a pending watcher and dispatches `STATUS_NOTIFY_CLEANUP` through `AsyncCallback`, but `SendAsyncChangeNotifyResponse` at `internal/adapter/smb/response.go:512` selects the response body shape using `status.IsError()`. `StatusNotifyCleanup = 0x0000010B` has severity bits 00 (success-severity), so `IsError()` returns **false** and the code encodes the success-format body (8-byte `ChangeNotifyResponse` with `OutputBufferOffset=0, OutputBufferLength=0`). Samba, by contrast, routes any non-`NT_STATUS_OK` notify completion (including `NT_STATUS_NOTIFY_CLEANUP`) through the error body path — the 9-byte SMB2 error body. WPTS expects the Samba/Windows behavior. **Fix: in `SendAsyncChangeNotifyResponse`, branch on `status != StatusSuccess` instead of `status.IsError()`**, mirroring Samba's `!NT_STATUS_IS_OK(error_code)` check in `change_notify_reply()`. The same fix automatically repairs the `STATUS_NOTIFY_ENUM_DIR` path (same class of status, same bug, not currently exercised by BVT).
+
+2. **`BVT_DirectoryLeasing_LeaseBreakOnMultiClients`** — the race is in `BreakParentHandleLeasesOnCreate` at `internal/adapter/smb/lease/manager.go:440-451`. The function calls `lockMgr.BreakHandleLeasesForSMBOpen` but **explicitly does not wait** for break completion (comment at lines 437-439: *"This does NOT wait for the break to complete. The parent directory break is an informational notification."*). The break dispatch through `SMBBreakHandler.OnOpLockBreak` → `transportNotifier.SendLeaseBreak` is synchronous on the wire (writes bytes to the other client's TCP socket via `WriteNetBIOSFrame` under `WriteMu`), but there is no wait for the client's `LEASE_BREAK_ACK`. Flags on the outgoing break are set to `SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED` when the current state includes W or H (line 96 of `lease_notifier.go`), so the MS-SMB2 3.3.4.7 contract requires the server to wait for the ack before advancing state visible to other observers. The triggering CREATE returns to client A, client A's test harness proceeds to its next observation, and the other client (B) may not yet have its lease in the broken state from the WPTS test's POV. **Fix: call `lockMgr.WaitForBreakCompletion(ctx, parentHandleKey)` inside `BreakParentHandleLeasesOnCreate` (and `BreakParentReadLeasesOnModify`) with a bounded context timeout.** This is the `BreakHandleLeasesOnOpen` pattern (line 375) applied to the parent-directory-break case. It is **not** a deadlock risk here because the triggering client is excluded via `excludeClientID`, so the lock manager never waits on the same session that is currently holding the CREATE flow. `WaitForBreakCompletion` has built-in auto-downgrade on context cancellation (`forceCompleteBreaks`, manager.go:1393), which gives deterministic post-break state whether the ack arrives or the timeout fires.
+
+**Primary recommendation:** Two surgical edits (`response.go:512` branch condition; add bounded `WaitForBreakCompletion` in `BreakParentHandleLeasesOnCreate` + `BreakParentReadLeasesOnModify`). No refactors. No `time.Sleep`. No quarantine. Then run the full WPTS BVT in **Linux CI** (ubuntu-latest, native x86_64) and reconcile `KNOWN_FAILURES.md` (header says 58, table totals 43 — see §"Honest Counts Reconciliation" below).
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01:** Phase 72 is narrowed to 2 SMB-only fixable failures + verification sweep. Target: **5 → 3 fixable known failures** (the 3 remaining are the deferred directory-timestamp tests).
+- **D-02:** The 3 directory timestamp tests (`Algorithm_NotingFileModified_Dir_LastAccessTime`, `…Timestamp_MinusOne_Dir_ChangeTime`, `…Timestamp_MinusTwo_Dir_LastWriteTime`) are **deferred**, not failed. Researcher to choose labeling (`Deferred` new status vs `Expected` with structured reason). See Q4 below.
+- **D-03:** Root-cause fix for the lease break race. No quarantine, no test-side retry.
+- **D-04:** Investigation starts at `create.go:1003-1020` and `lease/manager.go:411`.
+- **D-05:** Acceptable fix shapes: synchronous break dispatch, wait-for-ack, or state-barrier. Researcher picks based on actual race.
+- **D-06:** `time.Sleep` and unconditional waits are **not acceptable**.
+- **D-07:** CLOSE→cleanup code path already exists; bug is in wire format / dispatch, not detection. `KNOWN_FAILURES.md:128`: *"CLOSE notify cleanup response format needs debugging"*.
+- **D-08:** Capture actual WPTS wire expectation by running against current server with verbose logging and comparing to MS-SMB2 3.3.5.16.1.
+- **D-09:** Preserve the existing `AsyncCallback` plumbing. Do not refactor `NotifyRegistry` to remove async dispatch.
+- **D-10:** Phase exit = both target tests passing, zero new regressions, `KNOWN_FAILURES.md` reconciled (header ↔ table agreement, changelog entry, category breakdown, 3 deferred tests clearly labeled).
+- **D-10a:** **Linux CI is authoritative** over Mac+QEMU. CI wins on disagreements. Mac+QEMU-only failures must be documented separately.
+- **D-11:** No changes to ROADMAP.md success criteria. PR description and SUMMARY.md must clarify that Phase 72 was descoped because Phase 73 absorbed the original scope.
+- **D-12:** Mark Phase 72 `[x]` in ROADMAP.md only after verification sweep passes.
+
+### Claude's Discretion
+- Choice of fix shape for the lease break race (D-05 options).
+- Choice of `Deferred` status label vs `Expected`+structured reason in `KNOWN_FAILURES.md`.
+- Debugging approach for capturing WPTS wire expectation.
+
+### Deferred Ideas (OUT OF SCOPE)
+- Directory timestamp propagation across protocols (belongs in a dedicated cross-protocol POSIX timestamp phase).
+- smbtorture failure reduction (separate suite, separate phase).
+- NamedPipe FSA tests (require SSH to SUT, unavailable in Docker CI).
+- Phase numbering housekeeping / ROADMAP success-criteria rewrite for Phase 72.
+
+## Project Constraints (from CLAUDE.md)
+
+- Compare SMB implementation against Samba reference (https://github.com/samba-team/samba) — applied for both bugs in this research.
+- Commit messages: no Claude Code mention, no Co-Authored-By lines. GPG/SSH-signed commits. Use `git commit -S`.
+- `go fmt ./...` and `go vet ./...` before committing.
+- Unit tests: `go test ./...` (fast, no sudo).
+- Worktree note: this phase is being planned in `worktree-issue-324-smb-idmap` but the actual fix branch should be off `develop`, not the idmap branch.
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| WPTS-01 | WPTS BVT ChangeNotify tests pass | `response.go:512` branch fix + verification run |
+| WPTS-02 | WPTS BVT Leasing tests pass | `BreakParentHandleLeasesOnCreate` ack-wait fix + verification run |
+| WPTS-03 | WPTS BVT pass count maintained or improved | Full-suite verification in Linux CI |
+| WPTS-04 | `KNOWN_FAILURES.md` reconciled (header ↔ table) | Sweep task produces consistent totals and deferred-status labeling |
+
+All four requirements are marked as complete in `.planning/REQUIREMENTS.md` from the Phase 72–73 rollup, but the two target BVT tests still live in `KNOWN_FAILURES.md:95,128`. This phase closes the last gap.
+
+## Answers to Open Questions
+
+### Q1: Current WPTS BVT pass count — and the 43-vs-58 discrepancy
+
+**Status: PARTIAL — could not run WPTS BVT in this session.** Docker is available on the research host but is `aarch64` Docker Desktop (the Mac+QEMU scenario the user described). Running a full BVT is ~10 min and produces QEMU-emulation results that the user has explicitly declared non-authoritative (D-10a). Running it in Linux CI requires a PR/push and consumes a CI budget. The planner must schedule both runs as explicit Wave 0 tasks.
+
+**What I can reconcile from source of truth (`KNOWN_FAILURES.md`):**
+
+Counting the table rows at `test/smb-conformance/KNOWN_FAILURES.md:85-128`, the actual table contents are:
+
+| Status | Count | Tests |
+|--------|-------|-------|
+| Expected (fixable) | 5 | 3 Timestamp + 1 ChangeNotify (`ServerReceiveSmb2Close`) + 1 Leasing (`LeaseBreakOnMultiClients`) |
+| Permanent | 38 | 26 VHD/RSVD + 6 SWN + 3 SQoS + 2 DFS + 2 NamedPipe |
+| **Total** | **43** | — |
+
+The header at line 16 says `58 known failures (53 permanent + 5 expected)` — **that is wrong**. The actual table row count is 43. Line 165 in the same file even says `Grand total known failures: 43 tests (38 permanent + 5 expected)` — which is internally consistent with the table. The error is confined to line 16 and line 149 (`Total permanently out-of-scope: 38 tests` is correct, but line 16 claims 53 permanent).
+
+**Root cause of the header/footer mismatch:** Phase 73 Plan 01's `73-01-SUMMARY.md:87-92` documents a KNOWN_FAILURES count correction (was 52+13=65, became 53+12=65), but subsequent Phase 73 plans removed more tests (ADS stream, ChangeSecurity, freeze-thaw, DH reconnect) without updating the header. The header drifted. Line 165 was updated correctly; line 16 and line 143's "Current baseline (Phase 73)" line were not.
+
+**Historical memory cross-check:** The 2026-03-19 auto-memory note says "193 pass / 73 known / 0 new / 69 skipped". That snapshot predates Phase 73's 2026-03-24 closing plans which removed another ~30 tests from the known list. If 193 were passing and ~30 have since been removed from the known-failures table, current pass count should be approximately **223 passing / 43 known / 69 skipped**, assuming no regressions. **[ASSUMED]** — must be confirmed by actual run.
+
+**Planner action required (Wave 0 task):** Schedule a Linux CI run of WPTS BVT and record the exact numbers from `parse-results.sh` output before any code change. This is the baseline Phase 72 must preserve.
+
+### Q2: ServerReceiveSmb2Close wire-level expectation — RESOLVED
+
+**Evidence from source (`internal/adapter/smb/response.go:492-533`):**
+
+```go
+func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, response *handlers.ChangeNotifyResponse, connInfo *ConnInfo) error {
+    status := response.GetStatus()
+    // ...build async header with FlagAsync, matching AsyncId...
+    var body []byte
+    if status.IsError() {               // <-- BUG: StatusNotifyCleanup is NOT an error
+        body = MakeErrorBody()          //      This branch not taken for 0x0000010B
+        // ...
+    } else {
+        var err error
+        body, err = response.Encode()   // <-- Taken. Produces 8-byte success body with
+        if err != nil { return ... }    //     OutputBufferOffset=0, OutputBufferLength=0
+        // ...
+    }
+    return SendMessage(respHeader, body, connInfo)
+}
+```
+
+**Verification of severity:** `types/status.go:145`: `StatusNotifyCleanup Status = 0x0000010B`. `IsError()` at line 302: `return (uint32(s) & 0xC0000000) == 0xC0000000`. For `0x0000010B`, the upper two bits are 00 (severity 0 = Success). `IsError()` returns **false**. `IsWarning()` returns **false**. Neither branch of the Samba-style "is non-OK?" logic is triggered. [VERIFIED: source read]
+
+**Samba reference behavior:** [CITED: samba-team/samba source3/smbd/notify.c via WebFetch]. Samba's `change_notify_reply()` uses `!NT_STATUS_IS_OK(error_code)` — any non-success NTSTATUS including `NT_STATUS_NOTIFY_CLEANUP` takes the error-body path, invoked as `reply_fn(req, error_code, NULL, 0)`. The response then goes through Samba's generic error body path (9-byte SMB2 error body per MS-SMB2 2.2.2), not the CHANGE_NOTIFY success structure. The cancel path `smbd_notify_cancel_by_map()` calls this same `change_notify_reply(smbreq, notify_status, 0, NULL, map->req->reply_fn)` with `notify_status = NT_STATUS_NOTIFY_CLEANUP`.
+
+**WPTS expectation:** WPTS tests Samba and Windows behavior. Both produce the 9-byte error body with status `STATUS_NOTIFY_CLEANUP` in the header. DittoFS produces an 8-byte success-format body — the structure parses differently (4 extra bytes, different field layout) and WPTS's response validator rejects it. [ASSUMED — confirmed logically from Samba + severity analysis, needs a WPTS wire capture to lock in HIGH confidence].
+
+**Secondary observation:** Our `ChangeNotifyResponse.Encode()` at `change_notify.go:380-395` writes 8 bytes when `bufLen == 0`, but `StructureSize=9` by SMB2 convention implies a fixed 8-byte header plus at least 1 byte of variable body (LSB of StructureSize = variable). Samba's success-path code (`source3/smbd/smb2_notify.c`, `smbd_smb2_request_notify_done`) writes `SSVAL(outbody.data, 0x00, 0x08 + 1)` then writes an 8-byte fixed body — matching our format. So the success-path encoding is correct; the bug is only that **the wrong branch** is taken for `STATUS_NOTIFY_CLEANUP`. [VERIFIED: Samba code via WebFetch]
+
+**Fix shape (recommended):** Replace the branch condition in `response.go:512` with `if status != types.StatusSuccess`. This mirrors Samba exactly and fixes both `STATUS_NOTIFY_CLEANUP` and `STATUS_NOTIFY_ENUM_DIR` (latter not BVT-exercised but the same class of bug).
+
+**Alternative fix:** Explicitly list both statuses: `if status == types.StatusNotifyCleanup || status == types.StatusNotifyEnumDir || status.IsError() || status.IsWarning()`. More verbose, less robust to future additions. Not recommended.
+
+**Not needed:** Changes to `Encode()`. Changes to `close.go:358-383`. Changes to `NotifyRegistry`. Changes to the AsyncId/MessageID plumbing — the test uses the matching `AsyncId` from the interim `STATUS_PENDING` response, which the current code correctly threads through `PendingNotify.AsyncId`.
+
+### Q3: Directory lease break race surface — RESOLVED
+
+**Execution trace from source:**
+
+1. Client A issues CREATE in a directory. Handler at `create.go:1007-1018` checks it's a create/overwrite/supersede, then calls:
+   - `BreakParentHandleLeasesOnCreate` (line 1011) — async, does not wait
+   - `BreakParentReadLeasesOnModify` (line 1015) — async, does not wait
+2. `BreakParentHandleLeasesOnCreate` at `lease/manager.go:440-451` calls `lockMgr.BreakHandleLeasesForSMBOpen(parentHandleKey, excludeOwner)` with `excludeOwner.ClientID = "smb:{sessionID_A}"`.
+3. `BreakHandleLeasesForSMBOpen` at `pkg/metadata/lock/manager.go:1308` calls `breakOpLocks`, which:
+   - Finds client B's Handle lease on the parent directory.
+   - Sets `lock.Lease.Breaking = true`, computes `BreakToState = RWH &^ H = RW`.
+   - Advances epoch.
+   - Releases `lm.mu`.
+   - Calls `lm.dispatchOpLockBreak(handleKey, clonedLock, breakToState)` → `SMBBreakHandler.OnOpLockBreak` → `transportNotifier.SendLeaseBreak`.
+4. `SendLeaseBreak` at `lease_notifier.go:59-128` builds the 44-byte `LEASE_BREAK_NOTIFICATION` body with `flags = SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED` (line 96-98, because current state has W or H), then synchronously writes it to client B's TCP socket via `WriteNetBIOSFrame`.
+5. `BreakParentHandleLeasesOnCreate` returns without calling `WaitForBreakCompletion`. CREATE returns to client A.
+6. WPTS test proceeds to its next observation — typically a re-CREATE or QUERY from client A against the directory, OR a probe of client B's lease state.
+
+**Where determinism is lost:** Between step 4 (bytes on the wire) and the arrival of client B's `LEASE_BREAK_ACK`. The server's internal state transition from `Breaking → Broken` happens only when client B acknowledges via `LEASE_BREAK_ACK`, OR when `forceCompleteBreaks` auto-downgrades after a timeout. In the current code, nothing waits. The `lease.Breaking = true` flag is set (step 3), but the actual `BreakToState` transition is not committed. If WPTS inspects `LeaseState` on the server side via the next protocol operation, it may still see the pre-break state. If WPTS tests client B's observed state via a separate query, there is additionally the kernel-scheduler window between TCP write and client-B read — but that window is also bounded by `LEASE_BREAK_ACK` completion because the test harness sends the ack as soon as it parses the break.
+
+**Fix shape (recommended):** In `BreakParentHandleLeasesOnCreate` (and `BreakParentReadLeasesOnModify`), call `lockMgr.WaitForBreakCompletion(ctx, handleKey)` after `BreakHandleLeasesForSMBOpen` returns. Use a bounded context timeout derived from `ctx` (the CREATE's request context). Pattern already proven in `BreakHandleLeasesOnOpen` at `lease/manager.go:351-376`:
+
+```go
+// Proposed edit (illustrative)
+func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
+    ctx context.Context,
+    parentHandle lock.FileHandle,
+    shareName string,
+    excludeClientID string,
+) error {
+    lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+    if lockMgr == nil { return nil }
+    if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+        return err
+    }
+    // NEW: wait for ack or timeout. Safe from self-deadlock because excludeClientID
+    // excludes the current CREATE's session from breakOpLocks.
+    waitCtx, cancel := context.WithTimeout(ctx, leaseBreakWaitTimeout)
+    defer cancel()
+    return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+}
+```
+
+**Deadlock safety analysis:** The concern that blocked the original author ("blocking would deadlock: the other client needs this CREATE's response before it processes the break" — see comment at `lease/manager.go:380-381`) applies to `BreakHandleLeasesOnOpenAsync` for **file** opens where client A's own lease on the file is being broken. In that case, A's CREATE is holding the break request and cannot also wait for its own ack. For **parent directory** breaks, `excludeClientID` ensures A's own parent-dir leases (if any) are not selected for breaking; only other clients' leases are in the `toBreak` list. A waits for their acks. No cycle. [VERIFIED: `breakOpLocks` at manager.go:1485-1497 honors `excludeOwner.ClientID`]
+
+**Timeout value:** `WaitForBreakCompletion` already falls through to `forceCompleteBreaks` on ctx cancellation (manager.go:1382), which auto-commits the break-to state. So a short bounded timeout (e.g., 5-10 seconds, matching MS-SMB2's typical 35s lease break wait divided for responsiveness) gives deterministic post-break state even under client misbehavior. Recommend: **5 seconds** as a starting value. Existing pattern `lockMgr.WaitForBreakCompletion(ctx, ...)` uses the caller's ctx directly in `BreakHandleLeasesOnOpen`; follow that pattern if CREATE's ctx already has a reasonable deadline, otherwise add a derived timeout.
+
+**Planner must also apply the same fix to `BreakParentReadLeasesOnModify`** — same call site, same race, same safety analysis.
+
+**Not needed:** Changes to `transportNotifier.SendLeaseBreak`. Changes to `SMBBreakHandler`. Changes to `breakOpLocks`. Changes to the LEASE_BREAK_ACK handler. Changes to the multi-client fan-out logic — the fan-out is already correct (it iterates and breaks each matching lock).
+
+### Q4: Naming for deferred status
+
+**Evidence from `KNOWN_FAILURES.md:130-135` (Status Legend):**
+
+```
+| Status | Meaning |
+| **Expected** | Known failure, fix planned in a future phase |
+| **Permanent** | Feature intentionally not implemented (out of scope) |
+```
+
+No `Deferred` precedent exists. The existing `Expected` status already means "fix planned in a future phase" — which is exactly what the 3 directory-timestamp tests are: fix planned in the cross-protocol POSIX timestamp phase (currently unscheduled).
+
+**Recommendation: Keep `Expected` status and add a structured "Blocked On" note.** Adding a new `Deferred` status requires updating the legend, updating `parse-results.sh` (if it has hard-coded status validation), and touching CI. For a single-phase labeling problem, reusing `Expected` with clearer Reason text is strictly less invasive and matches D-11 ("no changes to ROADMAP.md", stay narrow).
+
+**Concrete text for the 3 timestamp rows** (Reason column):
+
+> Directory LastAccessTime auto-update on child file modification — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)
+
+> Directory ChangeTime freeze not enforced during child operations — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)
+
+> Directory LastWriteTime not auto-updated after unfreeze — blocked on cross-protocol POSIX timestamp phase (metadata-service-level work)
+
+The existing "Remaining Expected Failure Categories" table at line 151-159 should add a note row: `Timestamp | 3 | Blocked on cross-protocol POSIX timestamp phase`.
+
+**If the planner prefers a new `Deferred` status anyway:** cheap to add (1 new legend row, update the 3 Reason cells, grep `parse-results.sh` for hardcoded `Expected|Permanent` string matching and update). Not recommended — adds ongoing maintenance cost for a 3-row naming improvement.
+
+### Q5: Linux CI vs Mac+QEMU result delta
+
+**Status: NOT CAPTURED — requires running the suite in both environments, which this research session did not attempt.** The reason: Mac+QEMU produces the user's non-authoritative results (D-10a), and Linux CI requires a push to a PR branch. Both runs must be scheduled by the planner.
+
+**Environmental evidence collected:**
+
+| Environment | Host Arch | Docker Arch | Notes |
+|-------------|-----------|-------------|-------|
+| Research host (macOS) | arm64 | aarch64 Docker Desktop | Runs amd64 WPTS TestClient binary under QEMU translation. Matches the user's "local Mac+QEMU" description. |
+| CI (`smb-conformance.yml:54`) | — | `ubuntu-latest` x86_64 | Native Linux, no QEMU. Authoritative per D-10a. |
+
+[VERIFIED: `.github/workflows/smb-conformance.yml` line 54 = `runs-on: ubuntu-latest`; research host `docker info | grep Architecture` = `aarch64`]
+
+**What the planner must schedule:**
+
+1. **Wave 0 — Baseline capture, before any code change:**
+   - Run WPTS BVT in Linux CI on an unchanged branch (or use the latest `develop` artifact). Record `parse-results.sh` output: `PASS / KNOWN / FAIL / SKIP`.
+   - Run WPTS BVT locally on Mac+QEMU against the same commit. Record the same numbers.
+   - Diff the two. Any test that is `PASS`-in-CI but `KNOWN`-in-QEMU (or vice versa) is the QEMU noise floor. This set must be documented in the phase SUMMARY and not pollute `KNOWN_FAILURES.md`.
+   - Expected outcome based on historical noise: the directory-timestamp tests and lease-break flake are most QEMU-sensitive. BVT's hot loops with short client-side timeouts (often < 100 ms) can trip purely on QEMU instruction translation overhead; tests that work locally may be stable or flaky in CI depending on runner load.
+2. **Per-fix verification:** Each target fix (CLOSE cleanup, lease break ack-wait) must be verified in Linux CI. Local Mac+QEMU verification is a **hint**, not a verdict (D-10a).
+3. **Final verification sweep (phase exit gate):** Linux CI must show both target tests PASS and zero new FAILs. The QEMU-only delta captured in step 1 is allowed to remain — document it in SUMMARY.md.
+
+**Recommended execution order:** CI baseline first → fix CLOSE cleanup → CI verify → fix lease break → CI verify → final sweep. Do not debug multiple fixes against a dirty baseline; each target test has a different failure mode and interleaving them makes attribution impossible.
+
+## Architecture Patterns
+
+### Pattern 1: Non-success async response body selection
+
+The current `SendAsyncChangeNotifyResponse` uses `status.IsError()` to choose between error body (9 bytes) and structured success body. This fails for `STATUS_NOTIFY_CLEANUP` (severity 00 = success) and `STATUS_NOTIFY_ENUM_DIR` (same severity).
+
+**Correct pattern (Samba-aligned):**
+
+```go
+// In SendAsyncChangeNotifyResponse:
+if status != types.StatusSuccess {
+    body = MakeErrorBody()  // 9-byte SMB2 error body
+} else {
+    body, err = response.Encode()  // structured success body
+    if err != nil { return ... }
+}
+```
+
+This also makes `SendAsyncCompletionResponse` (line 547) and `SendAsyncChangeNotifyResponse` consistent: the former already uses `(status.IsError() || status.IsWarning()) && exclusions` logic at line 560-563. Consider consolidating — but out of scope for Phase 72.
+
+### Pattern 2: Break dispatch with ack-wait for cross-client breaks
+
+Existing pattern at `lease/manager.go:351-376` (`BreakHandleLeasesOnOpen`):
+
+```go
+if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+    return err
+}
+return lockMgr.WaitForBreakCompletion(ctx, handleKey)
+```
+
+Apply the same pattern to `BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify`. The async variant (`BreakHandleLeasesOnOpenAsync`) stays unchanged — its deadlock rationale is file-open-specific and genuine.
+
+### Anti-Patterns to Avoid
+
+- **Adding `time.Sleep(...)` anywhere to "let the break settle."** Forbidden by D-06. `WaitForBreakCompletion` is the deterministic path.
+- **Quarantining the tests.** Forbidden by D-03 and the project-wide "no flakes" preference (72-CONTEXT.md specifics section).
+- **Refactoring `NotifyRegistry` to remove async dispatch.** Forbidden by D-09 — other ChangeNotify tests depend on the current async path.
+- **Changing `ChangeNotifyResponse.Encode()` to match the error format for cleanup.** Don't — the success encoding is correct per Samba. Only the branch selection is wrong.
+- **Touching `SMBBreakHandler.OnOpLockBreak` or `transportNotifier.SendLeaseBreak`.** They already dispatch synchronously on the wire. The fix is at the caller (`BreakParentHandleLeasesOnCreate`), not the dispatcher.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Wait for lease break ack | New wait channel, per-site polling, `time.Sleep` | `lockMgr.WaitForBreakCompletion(ctx, handleKey)` | Already exists, channel-based, context-aware, has timeout-driven force-complete fallback |
+| Error body for non-success notify status | Custom empty-buffer Encode path | `MakeErrorBody()` (`response.go:689`) | Already exists as the 9-byte SMB2 error body |
+| Detect non-error success-severity statuses | New method on Status | `status != types.StatusSuccess` | Single comparison matches Samba's `!NT_STATUS_IS_OK` semantics |
+
+## Common Pitfalls
+
+### Pitfall 1: Status severity bits lie about "is this an error?"
+
+**What goes wrong:** NTSTATUS values like `STATUS_NOTIFY_CLEANUP` (0x0000010B) and `STATUS_NOTIFY_ENUM_DIR` (0x0000010C) have severity 00 (Success). `IsError()` returns false. But Windows/Samba/WPTS treat them as "terminal non-OK" statuses that use the error body format.
+
+**Why it happens:** MS-ERRREF assigns severity bits based on NT component convention, not wire-format body selection. Wire-format body selection is an independent Samba/Windows design choice documented in `change_notify_reply()` code, not in any MS spec text directly.
+
+**How to avoid:** Use `status != StatusSuccess` for "do I send an error body?" decisions, matching `!NT_STATUS_IS_OK` — the Samba reference.
+
+**Warning signs:** Wireshark capture shows the server's response body is 8 bytes where it should be 9; WPTS logs `expected response size: 9, actual: 8` or similar; a ChangeNotify completion test with a non-success terminal status fails while vanilla data-notify tests pass.
+
+### Pitfall 2: "Informational" parent break that isn't
+
+**What goes wrong:** A comment in `BreakParentHandleLeasesOnCreate` says "This does NOT wait for the break to complete. The parent directory break is an informational notification." The comment justifies not calling `WaitForBreakCompletion`, but the outgoing break carries `SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED` (because the current state has H), which per MS-SMB2 3.3.4.7 means the server is supposed to wait for the ack.
+
+**Why it happens:** Confusing cross-client parent-dir breaks (safe to wait — no self-dependency) with same-client self-breaks on a file the client is opening (unsafe to wait — deadlock).
+
+**How to avoid:** If `excludeClientID` excludes the triggering client, waiting is safe. The flag `ACK_REQUIRED` tells you WPTS is watching for the ack — respect it.
+
+**Warning signs:** Flaky lease break tests that pass in isolation but fail under load; tests that pass when `WriteMu` contention is low but fail when concurrent connections exist; CI flakes the user is tempted to quarantine.
+
+### Pitfall 3: QEMU noise floor creeping into KNOWN_FAILURES.md
+
+**What goes wrong:** A developer runs WPTS BVT locally on Mac+QEMU, sees some tests flake, adds them to `KNOWN_FAILURES.md` as `Expected`, commits. The next CI run shows those tests pass — now the table has false known-failures, and the honest-counts invariant is corrupted.
+
+**Why it happens:** QEMU user-mode translation of amd64 binaries on arm64 host introduces multi-millisecond stalls. WPTS BVT has hot loops with tight per-operation deadlines. Timing-sensitive tests (leases, oplocks, change notify) are the first to diverge.
+
+**How to avoid:** Only Linux CI results update `KNOWN_FAILURES.md`. Mac+QEMU results are hints for debugging. Document the CI-vs-QEMU delta in the phase SUMMARY.md so future developers understand which tests are QEMU-sensitive.
+
+## Runtime State Inventory
+
+**Not applicable.** This is a bug-fix phase. No rename, no refactor, no migration. The 2 fixes are contained to:
+- `internal/adapter/smb/response.go` (1 branch condition)
+- `internal/adapter/smb/lease/manager.go` (2 functions: `BreakParentHandleLeasesOnCreate`, `BreakParentReadLeasesOnModify`)
+- `test/smb-conformance/KNOWN_FAILURES.md` (baseline reconciliation)
+
+No stored data, live service config, OS-registered state, secrets, or build artifacts are affected.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Go toolchain | Building `dfs` and running unit tests | ✓ | `go version` not probed — assume matches project `go.mod` | — |
+| Docker | Running WPTS BVT locally | ✓ (aarch64 Docker Desktop) | 29.2.1 | — |
+| `xmlstarlet` | Parsing WPTS `.trx` results | unknown (not probed) | — | `parse-results.sh` will fail loudly; install via `brew install xmlstarlet` |
+| Native x86_64 Linux | Authoritative WPTS BVT runs (D-10a) | ✗ on research host | — | GitHub Actions `ubuntu-latest` runner via CI push |
+| `make`, `bash` | Test harness | ✓ | — | — |
+
+**Missing dependencies with fallback:** Linux CI is the fallback for local Mac+QEMU non-authority. The planner must schedule CI runs explicitly (no WPTS verification can skip CI).
+
+**Missing dependencies with no fallback:** None for the fix itself (both fixes are pure Go edits). Verification is fully dependent on Linux CI.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Go `testing` (unit) + WPTS BVT (integration, in Docker, runs x86 MSTest binary) |
+| Unit test config | none — uses `go test ./...` defaults |
+| WPTS config | `test/smb-conformance/run.sh`, `ptfconfig/*.template` |
+| Quick run command (unit) | `go test ./internal/adapter/smb/...` |
+| Full suite command (unit) | `go test ./...` |
+| WPTS target-test command | `./test/smb-conformance/run.sh --profile memory --filter "TestCategory=BVT&Name=BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close\|BVT_DirectoryLeasing_LeaseBreakOnMultiClients"` (syntax: verify against WPTS filter grammar — MSTest uses `|` for OR in test filters) |
+| WPTS full BVT | `./test/smb-conformance/run.sh --profile memory --category BVT` |
+| Phase gate | WPTS BVT full run in Linux CI: both target tests PASS, zero new FAILs, all others unchanged |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| WPTS-01 | CLOSE on watched dir sends properly-framed STATUS_NOTIFY_CLEANUP | wpts-bvt | `./test/smb-conformance/run.sh --profile memory` + `parse-results.sh` check for `BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close` in PASS set | ✅ (test exists in WPTS; currently on KNOWN_FAILURES list) |
+| WPTS-02 | Parent dir Handle lease break deterministically observable by next op | wpts-bvt | `./test/smb-conformance/run.sh --profile memory` + PASS check for `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` | ✅ |
+| WPTS-01 (unit) | `SendAsyncChangeNotifyResponse` uses error body for non-success statuses | unit | New test in `internal/adapter/smb/response_test.go`: assert `SendAsyncChangeNotifyResponse` with `StatusNotifyCleanup` writes 9-byte error body (inspect via a mock `ConnInfo`) | ❌ Wave 0 — test does not exist yet |
+| WPTS-02 (unit) | `BreakParentHandleLeasesOnCreate` calls `WaitForBreakCompletion` | unit | New test in `internal/adapter/smb/lease/manager_test.go`: assert the function blocks until break resolves (use existing mock lockMgr pattern from `delegation_manager_test.go:266`) | ❌ Wave 0 |
+| WPTS-03 | No regressions in any other WPTS BVT test | wpts-bvt | Full `parse-results.sh` output: all non-target KNOWN tests still in KNOWN set, all PASS still PASS | ✅ |
+| WPTS-04 | KNOWN_FAILURES.md header count == table row count | manual/grep | `grep -c '^| BVT\|^| Algorithm\|^| FileInfo' test/smb-conformance/KNOWN_FAILURES.md` must match header `X known failures` number | ❌ Wave 0 — no automated check exists |
+
+### Sampling Rate
+
+- **Per task commit:** `go test ./internal/adapter/smb/...` (fast, ~5-10s)
+- **Per wave merge:** `go test ./... -race` (full unit suite, ~30-60s)
+- **Phase gate:** Full WPTS BVT in **Linux CI** (10 min); both target tests PASS; zero new FAILs; `parse-results.sh` baseline matches pre-phase expectations within CI-vs-QEMU delta documented in Wave 0
+
+### Wave 0 Gaps
+
+- [ ] Unit test for `SendAsyncChangeNotifyResponse` with `StatusNotifyCleanup` (asserts 9-byte error body)
+- [ ] Unit test for `SendAsyncChangeNotifyResponse` with `StatusNotifyEnumDir` (same bug class)
+- [ ] Unit test for `BreakParentHandleLeasesOnCreate` that verifies `WaitForBreakCompletion` is called and respects a bounded timeout (mock lockMgr with controllable break state)
+- [ ] Unit test for `BreakParentReadLeasesOnModify` (same pattern)
+- [ ] Baseline WPTS BVT run in Linux CI on unchanged `develop` to record pre-phase PASS/KNOWN/FAIL/SKIP counts
+- [ ] Baseline WPTS BVT run on local Mac+QEMU on the same commit to capture the CI-vs-QEMU delta for documentation
+- [ ] Verification: `KNOWN_FAILURES.md` header count reconciliation script (can be a one-liner `awk`/`grep` in CI, or an inline manual check — not a full framework install)
+
+## Security Domain
+
+Not applicable to this phase. No authentication, no authorization, no crypto, no input validation changes. Both fixes are protocol state-machine corrections (wire format branch + break ack-wait). No ASVS categories engaged. `security_enforcement` key is not set in `.planning/config.json`, but per convention absence = enabled; this phase has no security surface to enforce.
+
+## Code Examples
+
+### Fix 1: `response.go` branch condition
+
+```go
+// Source: internal/adapter/smb/response.go:492-533 — current buggy branch
+// Fix: replace status.IsError() with status != types.StatusSuccess
+
+// Current (bug):
+if status.IsError() {
+    body = MakeErrorBody()
+} else {
+    body, err = response.Encode()
+    if err != nil { ... }
+}
+
+// Proposed:
+if status != types.StatusSuccess {
+    body = MakeErrorBody()
+    logger.Debug("Sending async CHANGE_NOTIFY non-success response (error body format)",
+        "sessionID", sessionID, "messageID", messageID,
+        "asyncId", asyncId, "status", status.String())
+} else {
+    body, err = response.Encode()
+    if err != nil { return fmt.Errorf("encode change notify response: %w", err) }
+    logger.Debug("Sending async CHANGE_NOTIFY success response",
+        "sessionID", sessionID, "messageID", messageID,
+        "asyncId", asyncId, "bufferLen", len(response.Buffer))
+}
+```
+
+### Fix 2: `lease/manager.go` — `BreakParentHandleLeasesOnCreate`
+
+```go
+// Source: internal/adapter/smb/lease/manager.go:440-451 — current async-only behavior
+// Fix: add bounded WaitForBreakCompletion after BreakHandleLeasesForSMBOpen
+
+const parentLeaseBreakWaitTimeout = 5 * time.Second // tunable; matches typical client ack latency
+
+func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
+    ctx context.Context,
+    parentHandle lock.FileHandle,
+    shareName string,
+    excludeClientID string,
+) error {
+    lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+    if lockMgr == nil {
+        return nil
+    }
+    if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+        return err
+    }
+    // Wait for client acks (or auto-downgrade on timeout) so subsequent observations
+    // see the post-break state deterministically. Safe from self-deadlock: excludeClientID
+    // ensures the triggering client's own leases (if any) are not in the break set.
+    waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+    defer cancel()
+    return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+}
+```
+
+Apply the analogous change to `BreakParentReadLeasesOnModify` (same file, same structure).
+
+### Reference: Samba's notify cleanup path
+
+```c
+// Source: samba-team/samba source3/smbd/notify.c — change_notify_reply()
+// Verified via WebFetch 2026-04-07
+
+// smbd_notify_cancel_by_map() invocation:
+change_notify_reply(smbreq, notify_status,  // notify_status = NT_STATUS_NOTIFY_CLEANUP
+                    0, NULL, map->req->reply_fn);
+
+// Inside change_notify_reply():
+if (!NT_STATUS_IS_OK(error_code)) {
+    reply_fn(req, error_code, NULL, 0);  // <-- takes error body path
+    return;
+}
+// Success path follows (formats OutputBufferOffset / OutputBufferLength / buffer)
+```
+
+The `!NT_STATUS_IS_OK(error_code)` check matches our proposed `status != types.StatusSuccess`.
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `IsError()` severity-bit check for body format selection | `status != StatusSuccess` (matches `!NT_STATUS_IS_OK`) | This phase | Fixes `STATUS_NOTIFY_CLEANUP` and `STATUS_NOTIFY_ENUM_DIR` response framing |
+| "Informational" parent-dir break with no wait | Bounded `WaitForBreakCompletion` after `BreakHandleLeasesForSMBOpen` | This phase | Deterministic post-break state for `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` and any future multi-client directory lease tests |
+| `KNOWN_FAILURES.md` header count drift | Sweep task enforces header ↔ table ↔ category sum consistency | This phase | Honest counts; passes user's "honest counts" invariant |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | WPTS test strictness expects the 9-byte error body for `STATUS_NOTIFY_CLEANUP` rather than the 8-byte success body | §Q2 fix | If WPTS actually accepts the success body, our fix won't change pass count. Mitigation: verify with a single CI run of the target test against the fix; if still FAIL, capture wire dump and compare to a Samba reference run. |
+| A2 | Current WPTS BVT pass count is approximately 223 / 43 known / 69 skipped | §Q1 reconciliation | Baseline may differ. Mitigation: Wave 0 CI baseline run captures the real number. |
+| A3 | 5-second `WaitForBreakCompletion` timeout is adequate for WPTS client ack latency | §Fix 2 code example | If clients routinely exceed 5s, the force-complete fallback still produces deterministic state, but may cause intermittent test failures where WPTS expects the break to be fully acknowledged vs auto-committed. Mitigation: use caller's CREATE ctx directly (matches `BreakHandleLeasesOnOpen`), which inherits WPTS's own operation timeout. |
+| A4 | `Expected` status with "Blocked On" Reason text is acceptable to the user over a new `Deferred` status | §Q4 | User may explicitly prefer a distinct label. CONTEXT.md D-02 leaves this to researcher discretion. |
+| A5 | `STATUS_NOTIFY_ENUM_DIR` path is not BVT-exercised but has the same bug | §Summary + Fix 1 | Not load-bearing — the proposed fix covers both statuses regardless. |
+| A6 | Phase 73 removed ~30 tests from the KNOWN_FAILURES table between 2026-03-19 (memory snapshot at 73 known) and 2026-03-24 (current table at 43) | §Q1 historical cross-check | Pass-count math is approximate. Wave 0 baseline corrects any drift. |
+
+**Assumed claims must be validated in Wave 0 before the planner locks implementation tasks.** A1 and A3 are the highest-risk: A1 is the core fix premise, A3 controls a user-visible timeout value.
+
+## Open Questions
+
+All 5 open questions from CONTEXT.md are answered above. Residual unknowns:
+
+1. **Exact WPTS wire expectation for `ServerReceiveSmb2Close`** — I am HIGH confidence on the fix based on Samba's source and severity analysis, but the definitive verification is a WPTS run against the fix. If the test still fails, the next step is capturing the WPTS expected vs actual bytes from the `.trx` error message and tcpdump.
+   - **How to handle:** Wave 0 includes "capture baseline WPTS wire dump of the failing test" as a debug artifact; wave that applies fix compares post-fix wire bytes.
+2. **Whether `leaseBreakWaitTimeout` should inherit from CREATE ctx (unbounded-by-us, bounded by WPTS client) or be a hardcoded derivation** — leaning toward inheriting ctx directly per `BreakHandleLeasesOnOpen` precedent.
+   - **How to handle:** Planner picks; recommendation is "inherit ctx, no new timeout constant" as the simplest matching pattern.
+3. **Does any Mac+QEMU-only failure class need a separate tracking file?** — Depends on how many QEMU-only flakes Wave 0 surfaces. If <5, inline in SUMMARY.md. If ≥5, create `test/smb-conformance/QEMU_DELTA.md`.
+   - **How to handle:** Defer to Wave 0 result.
+
+## Sources
+
+### Primary (HIGH confidence)
+- `internal/adapter/smb/response.go:492-533, 689-693` — `SendAsyncChangeNotifyResponse`, `MakeErrorBody` [VERIFIED: source read]
+- `internal/adapter/smb/v2/handlers/change_notify.go:120-170, 370-395, 580-683` — `PendingNotify`, `Encode`, `sendAndUnregister`, `NotifyRmdir` [VERIFIED]
+- `internal/adapter/smb/v2/handlers/close.go:358-400` — CLOSE cleanup dispatch [VERIFIED]
+- `internal/adapter/smb/v2/handlers/create.go:994-1018` — parent break call sites [VERIFIED]
+- `internal/adapter/smb/lease/manager.go:340-451` — `BreakHandleLeasesOnOpen` (sync), `BreakHandleLeasesOnOpenAsync`, `BreakParentHandleLeasesOnCreate`, `BreakParentReadLeasesOnModify` [VERIFIED]
+- `internal/adapter/smb/lease/notifier.go:30-103` — `SMBBreakHandler.OnOpLockBreak` sync dispatch [VERIFIED]
+- `pkg/adapter/smb/lease_notifier.go:59-128` — `transportNotifier.SendLeaseBreak` with `ACK_REQUIRED` flag [VERIFIED]
+- `pkg/metadata/lock/manager.go:1293-1535, 1342-1459` — `BreakHandleLeasesForSMBOpen`, `breakOpLocks`, `WaitForBreakCompletion`, `forceCompleteBreaks` [VERIFIED]
+- `internal/adapter/smb/types/status.go:143-320` — `StatusNotifyCleanup = 0x0000010B`, `IsError`, `IsWarning`, `Severity` [VERIFIED]
+- `test/smb-conformance/KNOWN_FAILURES.md:12-170` — header/table discrepancy and status legend [VERIFIED]
+- `test/smb-conformance/README.md:33-108` — run flow and status classification [VERIFIED]
+- `.github/workflows/smb-conformance.yml:54` — `runs-on: ubuntu-latest` confirming Linux CI x86_64 [VERIFIED]
+- `.planning/phases/73-smb-conformance-deep-dive/73-01-SUMMARY.md:81,100` — Phase 73's incorrect claim that CLOSE cleanup was already functional [VERIFIED]
+- `.planning/phases/73-smb-conformance-deep-dive/73-VERIFICATION.md:73,87` — Phase 73 recorded the status value as 0x0000010B (correcting the plan's 0x0000010C), but did not verify the wire format end-to-end [VERIFIED]
+
+### Secondary (MEDIUM confidence)
+- [MS-SMB2] 2.2.23.2 LEASE_BREAK_NOTIFICATION (flag semantics, `ACK_REQUIRED`) [CITED: linked from code comments]
+- [MS-SMB2] 2.2.35 CHANGE_NOTIFY Response (StructureSize=9, variable body) [CITED]
+- [MS-SMB2] 3.3.4.7 server-to-client notifications, ack wait semantics [CITED]
+- [MS-SMB2] 3.3.5.9 parent directory lease break semantics on CREATE [CITED: code comment at create.go:998]
+- [MS-SMB2] 3.3.5.16.1 CHANGE_NOTIFY processing, cleanup on handle close [CITED: code comment at close.go:367]
+- Samba `source3/smbd/notify.c` — `change_notify_reply()` error-body branch on `!NT_STATUS_IS_OK` [CITED: WebFetch]
+- Samba `source3/smbd/smb2_notify.c` — success path writes StructureSize=9 (`0x08 + 1`), confirms our encoding is not the bug [CITED: WebFetch]
+
+### Tertiary (LOW confidence)
+- Historical pass count of 193 from auto-memory snapshot 2026-03-19 — superseded by Phase 73 removals; must be re-measured [ASSUMED]
+
+## Metadata
+
+**Confidence breakdown:**
+- Bug localization (both fixes): HIGH — both root causes confirmed by source reads and cross-referenced against Samba
+- Fix shape correctness: HIGH for CLOSE cleanup (matches Samba 1:1), HIGH for lease break (matches existing in-tree pattern)
+- WPTS will accept the fix: MEDIUM — A1 and A3 assumptions carry some risk; first CI run validates
+- Current pass counts: LOW — not measured in session
+- CI-vs-QEMU delta: LOW — not measured in session, must be Wave 0
+- KNOWN_FAILURES.md reconciliation correctness: HIGH — counted rows directly
+
+**Research date:** 2026-04-07
+**Valid until:** 2026-05-07 (30 days; SMB protocol is stable, but WPTS test set and `develop` branch state evolves; if Phase 72 doesn't start within this window, re-verify current BVT baseline)
+
+## RESEARCH COMPLETE

--- a/.planning/phases/72-wpts-conformance-push/72-VALIDATION.md
+++ b/.planning/phases/72-wpts-conformance-push/72-VALIDATION.md
@@ -1,0 +1,90 @@
+---
+phase: 72
+slug: wpts-conformance-push
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-04-07
+---
+
+# Phase 72 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Go `testing` (unit) + WPTS BVT (integration, in Docker, runs x86 MSTest binary) |
+| **Config file** | `test/smb-conformance/run.sh`, `test/smb-conformance/KNOWN_FAILURES.md` |
+| **Quick run command** | `go test ./internal/adapter/smb/...` |
+| **Full suite command** | `cd test/smb-conformance && ./run.sh` (Linux CI authoritative) |
+| **Estimated runtime** | Unit: ~30s; WPTS BVT: ~25 min |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `go test ./internal/adapter/smb/lease/... ./internal/adapter/smb/v2/handlers/...` (≤ 30s)
+- **After every plan wave:** Run full unit suite `go test ./...` and a focused WPTS BVT subset for the touched test names
+- **Before `/gsd-verify-work`:** Full WPTS BVT must be green in **Linux CI** (not Mac+QEMU). Mac+QEMU diff documented but non-authoritative per D-10a.
+- **Max feedback latency:** 30 seconds for unit gate; ~25 min for full WPTS BVT (gated to wave boundary)
+
+---
+
+## Per-Task Verification Map (revised post-#323)
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 72-01-01 | 01 | 0 | WPTS-03 | — | `BreakParentHandleLeasesOnCreate` calls `WaitForBreakCompletion` with bounded timeout | unit | `go test ./internal/adapter/smb/lease -run TestBreakParentHandleLeasesOnCreate_WaitsForAck` | ❌ W0 | ⬜ pending |
+| 72-01-02 | 01 | 0 | WPTS-03 | — | `BreakParentReadLeasesOnModify` calls `WaitForBreakCompletion` with bounded timeout | unit | `go test ./internal/adapter/smb/lease -run TestBreakParentReadLeasesOnModify_WaitsForAck` | ❌ W0 | ⬜ pending |
+| 72-01-03 | 01 | 0 | WPTS-03 | — | Excluded client (triggering CREATE) is not waited on (no self-deadlock) | unit | `go test ./internal/adapter/smb/lease -run TestBreakParentHandle_ExcludesTriggeringClient` | ❌ W0 | ⬜ pending |
+| 72-01-04 | 01 | 1 | WPTS-03 | — | `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` passes in Linux CI 5 consecutive runs (no flake) | integration | `gh workflow run smb-conformance.yml` (filtered, x5) | ✅ | ⬜ pending |
+| 72-02-01 | 02 | 2 | WPTS-04 | — | Linux CI WPTS BVT post-fix: 0 new failures, lease test PASS | integration | `gh workflow run smb-conformance.yml` | ✅ | ⬜ pending |
+| 72-02-02 | 02 | 2 | WPTS-04 | T-72-08 | `KNOWN_FAILURES.md` header count == table count == footer count | manual | `grep -c` consistency check | ✅ | ⬜ pending |
+| 72-02-03 | 02 | 2 | WPTS-04 | — | 3 deferred timestamp tests labeled with structured "blocked on cross-protocol POSIX timestamp phase" reason | manual | grep + visual review | ✅ | ⬜ pending |
+| 72-02-04 | 02 | 2 | WPTS-04 | — | ROADMAP.md Phase 72 marked `[x]` with descope note crediting both PR #323 and this branch | manual | grep + visual review | ✅ | ⬜ pending |
+| 72-02-05 | 02 | 2 | WPTS-04 | T-72-09 | Phase 72 SUMMARY.md committed; PR opened | manual | file exists + `gh pr view` | ✅ | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `internal/adapter/smb/lease/manager_test.go` — add `TestBreakParentHandleLeasesOnCreate_WaitsForAck`, `TestBreakParentReadLeasesOnModify_WaitsForAck`, `TestBreakParentHandle_ExcludesTriggeringClient`
+- [ ] Branch `fix/phase-72-wpts-trailing-fixes` cut off `origin/develop` (already done — this worktree)
+- [ ] No CI baseline capture needed: PR #323 already shipped Plan 02's original ChangeNotify scope, and Plan 02 (formerly 04) gates on a single post-fix CI run in its own task
+
+**Removed from Wave 0 (post-#323 supersession):**
+- ~~`response_test.go` TestSendAsyncChangeNotifyResponse_Cleanup~~ — superseded by PR #323's regression tests in `close_notify_test.go` and `smbenc/writer_test.go`
+- ~~`close_test.go` TestClose_PendingNotify_Cleanup~~ — superseded by PR #323's regression tests
+- ~~Pre-fix Linux CI baseline~~ — current `develop` IS the baseline; #323 already moved the baseline forward
+- ~~Mac+QEMU baseline~~ — non-authoritative per D-10a; not worth the developer-time cost for a 1-bug phase
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| WPTS BVT pass count and known-failure list match `KNOWN_FAILURES.md` post-fix | WPTS-04 | WPTS BVT runs in Docker against MSTest binary; result parsing handled by `parse-results.sh`, not Go test framework | Run `cd test/smb-conformance && ./run.sh` in Linux CI; compare output against `KNOWN_FAILURES.md`; verify 0 new entries needed |
+| Mac+QEMU diff vs Linux CI documented as noise floor | D-10a | QEMU emulation differences are environmental, not protocol-correctness | After both runs complete, diff results, list any tests that pass in one and fail in the other in `72-SUMMARY.md` |
+| `KNOWN_FAILURES.md` header/table reconciliation | D-10 | Cross-section count consistency check | `grep -c "^|" test/smb-conformance/KNOWN_FAILURES.md` rows vs header count vs category breakdown — all three must agree |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s for unit gate
+- [ ] `nyquist_compliant: true` set in frontmatter
+- [ ] Linux CI baseline captured before any code change
+- [ ] Both target tests pass in Linux CI for 5 consecutive runs (lease test specifically — flake gate)
+
+**Approval:** pending

--- a/.planning/phases/72-wpts-conformance-push/72-postfix-ci.txt
+++ b/.planning/phases/72-wpts-conformance-push/72-postfix-ci.txt
@@ -1,0 +1,135 @@
+# Phase 72 Post-Fix Linux CI WPTS BVT Result — GATE FAILURE
+
+Run URL: https://github.com/marmos91/dittofs/actions/runs/24106439910 (cancelled, superseded)
+Run URL: https://github.com/marmos91/dittofs/actions/runs/24106442860 (cancelled, superseded)
+Run URL: https://github.com/marmos91/dittofs/actions/runs/24106445657 (cancelled, superseded)
+Run URL: https://github.com/marmos91/dittofs/actions/runs/24106448660 (cancelled, superseded)
+Run URL (authoritative): https://github.com/marmos91/dittofs/actions/runs/24106451238
+Git SHA: 360a3f85bb3bf02647eb0ef81fead00892ef4cff
+Branch: fix/phase-72-wpts-trailing-fixes
+Runner: ubuntu-latest (Linux x86_64)
+Workflow: smb-conformance.yml
+WPTS BVT job ID: 70330772206
+Job conclusion: success (but see gate-failure note below)
+
+## Gate-failure note
+The WPTS BVT job is reported as `success` because `parse-results.sh`
+treats BVT_DirectoryLeasing_LeaseBreakOnMultiClients as an Expected
+failure in `test/smb-conformance/KNOWN_FAILURES.md`. The raw TRX shows
+the test still FAILS with System.TimeoutException — Plan 01's bounded
+WaitForBreakCompletion fix did NOT resolve the race in Linux CI.
+
+Phase 72 Plan 02 flake gate requires 5/5 PASS on this specific test.
+Actual: 0/1 PASS (did not trigger remaining 4 runs — GitHub Actions
+concurrency group cancelled runs 1-4 in favor of run 5; gate fails
+on a single confirmed failure).
+
+## BVT_DirectoryLeasing_LeaseBreakOnMultiClients raw result
+Status: Failed
+Duration: 00:00:08.1554549
+StartTime: 2026-04-07T22:11:22.1316939+00:00
+EndTime:   2026-04-07T22:11:30.2879734+00:00
+Exception: System.TimeoutException: The operation has timed out.
+Stack (relevant frames):
+  at LeasingExtendedTest.CreateOpenFromClient(...) in DirectoryLeasingExtendedTest.cs:line 799
+  at LeasingExtendedTest.BVT_DirectoryLeasing_LeaseBreakOnMultiClients() in DirectoryLeasingExtendedTest.cs:line 180
+
+## Wire-level trace (from dittofs.log inside TRX)
+22:11:22.193 [TestStep] Client1 sends CREATE with lease READ|HANDLE caching
+22:11:22.194 C CREATE, DesiredAccess=GENERIC_READ, ShareAccess=(RW)
+22:11:22.196 R CREATE, FileId={ ...0x4e096a845db82de3 }
+22:11:22.197 Client1 CREATE succeeded (STATUS_SUCCESS)
+22:11:22.197 [TestStep] Client2 sends CREATE with lease READ|HANDLE caching
+22:11:22.211 C NEGOTIATE (Client2)
+22:11:22.212 C CREATE (Client2), DesiredAccess=GENERIC_READ, ShareAccess=(RW)
+22:11:22.214 R Lease Break NOTIFICATION → Client1 (READ|HANDLE -> READ)
+<<< 8 seconds of silence — Client2 CREATE response never arrives >>>
+22:11:30.221 [Comment] CreateOpenFromClient timed out
+22:11:30.221 Test teardown: negotiate/tree connect/delete directory
+22:11:30.237 [TestFailed]
+
+## Diagnosis
+Server dispatched the lease break notification at 22:11:22.214 and
+then parked Client2's CREATE waiting on WaitForBreakCompletion. The
+5s bounded timeout (`parentLeaseBreakWaitTimeout`) should have fired
+at ~22:11:27.2 and forceCompleteBreaks should have unblocked the
+CREATE. Instead the CREATE response never reached Client2 — the
+client's own 8s timeout fired first.
+
+Two plausible root causes:
+  1. WaitForBreakCompletion honors the forced completion but the
+     CREATE handler holds a second lock that the forced-complete path
+     doesn't release.
+  2. The 5s timeout is longer than WPTS client's CREATE timeout
+     (looks like ~8s total but initial ack-timer may be shorter), so
+     even a well-behaved bounded wait pushes past the client budget.
+
+Either way Plan 01's fix as currently shipped does NOT satisfy the
+WPTS BVT determinism requirement in Linux CI. The fix must either
+(a) complete the CREATE synchronously as soon as the lease break
+is queued (not wait for ack at all for the triggering session) or
+(b) use a much shorter timeout (e.g., 500ms) and prove the forced
+completion path actually releases the CREATE handler.
+
+## Flake gate result: FAIL
+Gate requires 5/5 PASS on BVT_DirectoryLeasing_LeaseBreakOnMultiClients.
+Run 5 (24106451238) shows the test still failing with the same
+TimeoutException symptom reported on develop before Plan 01.
+
+Plan 01 must be reopened with a revised fix before Plan 02's
+reconciliation + mark-done steps can proceed. PR will NOT be opened.
+
+## Server-side trace (dittofs.log)
+Key log line: line 76872 of dittofs.log
+  22:11:22 [DEBUG] SMBBreakHandler: dispatching lease break notification
+           leaseKey=17fed12115af524eb9e993458aecd72e sessionID=650
+           currentState=RW breakToState=R epoch=2
+  22:11:22 [DEBUG] Sending LEASE_BREAK_NOTIFICATION sessionID=650
+           newState=R epoch=2 ackRequired=true
+  <<< no further log entries for Client2's CREATE handler >>>
+  22:11:30 [DEBUG] SMB connection closed by client address=127.0.0.1:60150
+           (Client2's connection closed on timeout)
+
+No "CREATE: parent directory Handle lease break failed" log line
+appeared for this test, which means the hang is NOT in
+BreakParentHandleLeasesOnCreate (the code path Plan 01 fixed).
+
+Diagnosis (revised): the lease break is initiated from
+`RequestLease` at line 76868:
+  [DEBUG] RequestLease: cross-key conflict, initiating break
+          existingKey=17fed12115af524eb9e993458aecd72e
+          requestedKey=07571a7609fbd147876b235bed0aedf5
+          existingState=RW requestedState=RW breakToState=R
+
+This is a CROSS-KEY lease conflict in `RequestLease`, NOT a
+parent-directory handle-lease break. The hang is in the `RequestLease`
+code path, NOT in `BreakParentHandleLeasesOnCreate` /
+`BreakParentReadLeasesOnModify`.
+
+**Plan 01's fix targeted the wrong functions.** The researcher's
+analysis in 72-RESEARCH.md identified parent-directory lease breaks as
+the race site, but the actual WPTS test exercises the cross-key
+RequestLease path where two clients hold the same directory open with
+different lease keys. Plan 01's `WaitForBreakCompletion` additions to
+`BreakParentHandleLeasesOnCreate` + `BreakParentReadLeasesOnModify` are
+unreached by this test.
+
+The real fix must target the `RequestLease` cross-key conflict
+handler (`internal/adapter/smb/lease/manager.go` — find the site that
+logs "RequestLease: cross-key conflict, initiating break"). That code
+must either:
+  1. Wait for the LEASE_BREAK_ACK before completing the new CREATE,
+     with a bounded timeout that's shorter than the WPTS client
+     deadline (observed ~8s; use <5s with a generous safety margin
+     so the CREATE response arrives before the client gives up), OR
+  2. Return the new CREATE immediately with the pre-break lease state
+     visible, and rely on a subsequent notification path to reconcile.
+
+Given WPTS expects (per test name and assertions) to observe the
+broken state before Client1's disconnect, option 1 is the correct fix.
+
+## Gate result: FAIL — Plan 01 diagnosis incorrect, fix must be revised
+Do NOT mark Phase 72 done. Do NOT open PR. Do NOT reconcile
+KNOWN_FAILURES.md (the entry must remain until a working fix lands).
+Plan 01 must be reopened with corrected diagnosis targeting
+`RequestLease` cross-key conflict path.

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -111,7 +111,7 @@ func (lm *LeaseManager) RequestLease(
 	//
 	// Pre-registering is safe: if the grant fails or returns None, we
 	// remove the entry below.
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	lm.sessionMap[keyHex] = sessionID
 	lm.leaseShare[keyHex] = shareName
@@ -156,7 +156,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	acknowledgedState uint32,
 	epoch uint16,
 ) error {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -202,7 +202,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 // ReleaseLease delegates to the shared LockManager and removes the session mapping.
 func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -268,7 +268,7 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 
 // GetLeaseState delegates to the shared LockManager.
 func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]
@@ -286,7 +286,7 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	sid, ok := lm.sessionMap[fmt.Sprintf("%x", leaseKey)]
+	sid, ok := lm.sessionMap[hex.EncodeToString(leaseKey[:])]
 	return sid, ok
 }
 
@@ -294,7 +294,7 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 // Used during durable handle reconnect to associate the existing lease with
 // the new session for break notification routing.
 func (lm *LeaseManager) UpdateSessionForLease(leaseKey [16]byte, sessionID uint64) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 	lm.sessionMap[keyHex] = sessionID
@@ -524,7 +524,7 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 // Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
 // epoch from the RqLs create context.
 func (lm *LeaseManager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -394,8 +394,13 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		exclude = excludeOwner[0]
 	}
 
-	// Break Handle leases (RWH -> RW, RH -> R)
-	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+	// Strip Write from leases that have Handle caching (RWH -> RH).
+	// This sends one notification that matches what clients expect:
+	// "flush dirty data" (Write strip). The Handle bit is preserved so
+	// the client can close cached handles in its ack response.
+	// After the ack, the lease is at RH (no Write, no Breaking), and
+	// Step 8a can independently strip Handle if needed.
+	if err := lockMgr.BreakWriteOnHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
 		return err
 	}
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -124,7 +124,6 @@ func (lm *LeaseManager) RequestLease(
 		requestedState, isDirectory,
 	)
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
-		// Grant failed — remove pre-registered session mapping
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
 		delete(lm.leaseShare, keyHex)
@@ -132,7 +131,8 @@ func (lm *LeaseManager) RequestLease(
 		return 0, 0, err
 	}
 
-	// If lease was denied (None) without error, remove pre-registered mapping.
+	// Remove pre-registered mapping if the lease was denied (None state means
+	// the LockManager rejected the request without an error code).
 	if grantedState == lock.LeaseStateNone {
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
@@ -427,87 +427,6 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	}
 
 	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
-}
-
-// BreakDirectoryLeasesOnOpenAsync dispatches Handle AND Write lease break
-// notifications for a directory open without waiting for acknowledgment.
-//
-// Per MS-SMB2 3.3.5.9: when a new open conflicts with existing directory
-// leases, both Handle caching (cached directory handles) and Write caching
-// (cached directory content changes) must be broken so other clients receive
-// LEASE_BREAK_NOTIFICATION before the share mode check. This is required by
-// BVT_DirectoryLeasing_LeaseBreakOnMultiClients where Client3's DELETE access
-// must trigger a Write-lease break notification even when no Handle leases
-// exist.
-//
-// The break is async (fire-and-forget) to avoid deadlock — the other client
-// needs this CREATE's response before it can process the break notification.
-//
-// This method dispatches break notifications directly via the adapter-level
-// session map + notifier, bypassing the LockManager's callback chain. The
-// LockManager callbacks route through dispatchOpLockBreak → registered
-// BreakCallbacks, which may not have the session mapping yet for leases that
-// were registered on a different callback instance. Sending directly from
-// the LeaseManager avoids this routing gap.
-func (lm *LeaseManager) BreakDirectoryLeasesOnOpenAsync(
-	fileHandle lock.FileHandle,
-	shareName string,
-	excludeOwner ...*lock.LockOwner,
-) error {
-	lockMgr := lm.resolveLockManager(shareName)
-	if lockMgr == nil {
-		return nil
-	}
-
-	handleKey := string(fileHandle)
-
-	var exclude *lock.LockOwner
-	if len(excludeOwner) > 0 {
-		exclude = excludeOwner[0]
-	}
-
-	// Break Handle leases via LockManager (RWH -> RW, RH -> R)
-	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
-		return err
-	}
-
-	// For Write leases: use GetWriteLeasesToBreak to identify leases that need
-	// breaking, then dispatch notifications directly via the adapter's session
-	// map and notifier. This ensures the notification reaches the right SMB
-	// session even when the LockManager's callback chain can't resolve it.
-	toBreak := lockMgr.GetWriteLeasesToBreak(handleKey, exclude)
-	for _, entry := range toBreak {
-		leaseKey := entry.LeaseKey
-		breakTo := entry.BreakToState
-		currentState := entry.CurrentState
-
-		sessionID, found := lm.GetSessionForLease(leaseKey)
-		if !found {
-			logger.Debug("BreakDirectoryLeasesOnOpenAsync: no session for lease, skipping",
-				"leaseKey", fmt.Sprintf("%x", leaseKey),
-				"handleKey", handleKey)
-			continue
-		}
-
-		notifier := lm.GetNotifier()
-		if notifier == nil {
-			continue
-		}
-
-		logger.Debug("BreakDirectoryLeasesOnOpenAsync: dispatching write lease break",
-			"leaseKey", fmt.Sprintf("%x", leaseKey),
-			"sessionID", sessionID,
-			"currentState", lock.LeaseStateToString(currentState),
-			"breakToState", lock.LeaseStateToString(breakTo))
-
-		if err := notifier.SendLeaseBreak(sessionID, leaseKey, currentState, breakTo, entry.Epoch); err != nil {
-			logger.Warn("BreakDirectoryLeasesOnOpenAsync: failed to send break",
-				"leaseKey", fmt.Sprintf("%x", leaseKey),
-				"error", err)
-		}
-	}
-
-	return nil
 }
 
 // BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -15,10 +15,21 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// parentLeaseBreakWaitTimeout bounds how long a CREATE/MODIFY waits for other
+// clients to acknowledge a parent-directory lease break. On expiry,
+// WaitForBreakCompletion's forceCompleteBreaks path auto-downgrades the lease
+// state, yielding a deterministic post-break view.
+//
+// Required by WPTS BVT BVT_DirectoryLeasing_LeaseBreakOnMultiClients and
+// MS-SMB2 3.3.4.7 (server must wait for LEASE_BREAK_ACK when
+// SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED is set).
+const parentLeaseBreakWaitTimeout = 5 * time.Second
 
 // LockManagerResolver resolves the LockManager for a given share name.
 // This allows the LeaseManager to work across multiple shares without
@@ -90,6 +101,22 @@ func (lm *LeaseManager) RequestLease(
 		return lock.LeaseStateNone, 0, fmt.Errorf("no lock manager for share %q", shareName)
 	}
 
+	// Pre-register the session mapping BEFORE creating the lease in the
+	// LockManager. The LockManager's RequestLease may trigger cross-key
+	// conflict breaks, which dispatch through breakOpLocks → SMBBreakHandler.
+	// If the session mapping isn't set yet, the break notification can't be
+	// routed to the correct SMB client. Similarly, another goroutine's
+	// BreakHandleLeasesOnOpenAsync may fire between the LockManager grant
+	// and the session map update, causing a "no session" miss.
+	//
+	// Pre-registering is safe: if the grant fails or returns None, we
+	// remove the entry below.
+	keyHex := fmt.Sprintf("%x", leaseKey)
+	lm.mu.Lock()
+	lm.sessionMap[keyHex] = sessionID
+	lm.leaseShare[keyHex] = shareName
+	lm.mu.Unlock()
+
 	// Delegate to shared LockManager
 	grantedState, epoch, err = lockMgr.RequestLease(
 		ctx, fileHandle, leaseKey, parentLeaseKey,
@@ -97,18 +124,19 @@ func (lm *LeaseManager) RequestLease(
 		requestedState, isDirectory,
 	)
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
+		// Grant failed — remove pre-registered session mapping
+		lm.mu.Lock()
+		delete(lm.sessionMap, keyHex)
+		delete(lm.leaseShare, keyHex)
+		lm.mu.Unlock()
 		return 0, 0, err
 	}
 
-	// Record session mapping if lease was granted (or is in breaking state).
-	// For ErrLeaseBreakInProgress, grantedState contains the current breaking
-	// state which is non-None — we still need the session map entry for
-	// break-notification routing.
-	if grantedState != lock.LeaseStateNone {
-		keyHex := fmt.Sprintf("%x", leaseKey)
+	// If lease was denied (None) without error, remove pre-registered mapping.
+	if grantedState == lock.LeaseStateNone {
 		lm.mu.Lock()
-		lm.sessionMap[keyHex] = sessionID
-		lm.leaseShare[keyHex] = shareName
+		delete(lm.sessionMap, keyHex)
+		delete(lm.leaseShare, keyHex)
 		lm.mu.Unlock()
 	}
 
@@ -401,6 +429,87 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
 }
 
+// BreakDirectoryLeasesOnOpenAsync dispatches Handle AND Write lease break
+// notifications for a directory open without waiting for acknowledgment.
+//
+// Per MS-SMB2 3.3.5.9: when a new open conflicts with existing directory
+// leases, both Handle caching (cached directory handles) and Write caching
+// (cached directory content changes) must be broken so other clients receive
+// LEASE_BREAK_NOTIFICATION before the share mode check. This is required by
+// BVT_DirectoryLeasing_LeaseBreakOnMultiClients where Client3's DELETE access
+// must trigger a Write-lease break notification even when no Handle leases
+// exist.
+//
+// The break is async (fire-and-forget) to avoid deadlock — the other client
+// needs this CREATE's response before it can process the break notification.
+//
+// This method dispatches break notifications directly via the adapter-level
+// session map + notifier, bypassing the LockManager's callback chain. The
+// LockManager callbacks route through dispatchOpLockBreak → registered
+// BreakCallbacks, which may not have the session mapping yet for leases that
+// were registered on a different callback instance. Sending directly from
+// the LeaseManager avoids this routing gap.
+func (lm *LeaseManager) BreakDirectoryLeasesOnOpenAsync(
+	fileHandle lock.FileHandle,
+	shareName string,
+	excludeOwner ...*lock.LockOwner,
+) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	handleKey := string(fileHandle)
+
+	var exclude *lock.LockOwner
+	if len(excludeOwner) > 0 {
+		exclude = excludeOwner[0]
+	}
+
+	// Break Handle leases via LockManager (RWH -> RW, RH -> R)
+	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+		return err
+	}
+
+	// For Write leases: use GetWriteLeasesToBreak to identify leases that need
+	// breaking, then dispatch notifications directly via the adapter's session
+	// map and notifier. This ensures the notification reaches the right SMB
+	// session even when the LockManager's callback chain can't resolve it.
+	toBreak := lockMgr.GetWriteLeasesToBreak(handleKey, exclude)
+	for _, entry := range toBreak {
+		leaseKey := entry.LeaseKey
+		breakTo := entry.BreakToState
+		currentState := entry.CurrentState
+
+		sessionID, found := lm.GetSessionForLease(leaseKey)
+		if !found {
+			logger.Debug("BreakDirectoryLeasesOnOpenAsync: no session for lease, skipping",
+				"leaseKey", fmt.Sprintf("%x", leaseKey),
+				"handleKey", handleKey)
+			continue
+		}
+
+		notifier := lm.GetNotifier()
+		if notifier == nil {
+			continue
+		}
+
+		logger.Debug("BreakDirectoryLeasesOnOpenAsync: dispatching write lease break",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"sessionID", sessionID,
+			"currentState", lock.LeaseStateToString(currentState),
+			"breakToState", lock.LeaseStateToString(breakTo))
+
+		if err := notifier.SendLeaseBreak(sessionID, leaseKey, currentState, breakTo, entry.Epoch); err != nil {
+			logger.Warn("BreakDirectoryLeasesOnOpenAsync: failed to send break",
+				"leaseKey", fmt.Sprintf("%x", leaseKey),
+				"error", err)
+		}
+	}
+
+	return nil
+}
+
 // BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory
 // when a file is created, overwritten, or superseded inside it.
 //
@@ -434,11 +543,20 @@ func (lm *LeaseManager) resolveParentBreakArgs(
 // BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory
 // when a child is created, overwritten, or superseded (RH -> R, RWH -> RW).
 //
-// This does NOT wait for the break to complete. The parent directory break is
-// an informational notification: the file creation has already committed, and
-// the other client just needs to invalidate its cached directory handle.
+// Per MS-SMB2 3.3.4.7, the server MUST wait for LEASE_BREAK_ACK when the break
+// is sent with SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED set, before completing
+// the triggering CREATE. The wait is bounded by parentLeaseBreakWaitTimeout;
+// on expiry, WaitForBreakCompletion's forceCompleteBreaks path auto-downgrades
+// the lease state so the post-break view is deterministic.
+//
+// Self-deadlock is impossible because excludeClientID removes the triggering
+// CREATE's own session from the breakable set: breakOpLocks (manager.go) honors
+// excludeOwner.ClientID so the triggering session's parent-dir lease (if any)
+// is never in the toBreak set, and the wait only blocks on OTHER clients' acks.
+//
+// Required by WPTS BVT BVT_DirectoryLeasing_LeaseBreakOnMultiClients.
 func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
-	_ context.Context,
+	ctx context.Context,
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
@@ -447,7 +565,12 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	if lockMgr == nil {
 		return nil
 	}
-	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner)
+	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+	defer cancel()
+	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
 // BreakParentReadLeasesOnModify breaks Read leases on a parent directory
@@ -455,8 +578,13 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 // Per MS-FSA 2.1.5.14: changes to directory contents invalidate Read caching,
 // so clients holding R or RW leases on the directory must be notified.
 // Breaks to None (full revocation of Read caching).
+//
+// Per MS-SMB2 3.3.4.7, the server waits for LEASE_BREAK_ACK before completing
+// the triggering operation; the wait is bounded by parentLeaseBreakWaitTimeout
+// and self-deadlock is prevented by excludeClientID (see
+// BreakParentHandleLeasesOnCreate for the full rationale).
 func (lm *LeaseManager) BreakParentReadLeasesOnModify(
-	_ context.Context,
+	ctx context.Context,
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
@@ -465,7 +593,12 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 	if lockMgr == nil {
 		return nil
 	}
-	return lockMgr.BreakReadLeasesForParentDir(handleKey, excludeOwner)
+	if err := lockMgr.BreakReadLeasesForParentDir(handleKey, excludeOwner); err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+	defer cancel()
+	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
 // SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey.

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -1,0 +1,222 @@
+package lease
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// fakeLockManager is a minimal recording fake for lock.LockManager. It embeds
+// the interface so any method we don't need is implicitly nil and will panic
+// if a test path unexpectedly calls it.
+type fakeLockManager struct {
+	lock.LockManager // embedded interface; unimplemented methods will panic if called
+
+	mu sync.Mutex
+
+	breakHandleCalls           []breakCall
+	breakReadCalls             []breakCall
+	waitForBreakCompletionKeys []string
+	// callOrder records the relative order of all observed calls so tests can
+	// assert that BreakHandleLeasesForSMBOpen / BreakReadLeasesForParentDir
+	// happen BEFORE WaitForBreakCompletion returns.
+	callOrder []string
+
+	// waitBlock, if non-nil, blocks WaitForBreakCompletion until closed
+	// (used to assert no-deadlock behavior in the exclude-triggering-client test).
+	waitBlock chan struct{}
+}
+
+type breakCall struct {
+	HandleKey    string
+	ExcludeOwner *lock.LockOwner
+}
+
+func (f *fakeLockManager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *lock.LockOwner) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.breakHandleCalls = append(f.breakHandleCalls, breakCall{HandleKey: handleKey, ExcludeOwner: excludeOwner})
+	f.callOrder = append(f.callOrder, "BreakHandleLeasesForSMBOpen")
+	return nil
+}
+
+func (f *fakeLockManager) BreakReadLeasesForParentDir(handleKey string, excludeOwner *lock.LockOwner) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.breakReadCalls = append(f.breakReadCalls, breakCall{HandleKey: handleKey, ExcludeOwner: excludeOwner})
+	f.callOrder = append(f.callOrder, "BreakReadLeasesForParentDir")
+	return nil
+}
+
+func (f *fakeLockManager) WaitForBreakCompletion(ctx context.Context, handleKey string) error {
+	f.mu.Lock()
+	f.waitForBreakCompletionKeys = append(f.waitForBreakCompletionKeys, handleKey)
+	f.callOrder = append(f.callOrder, "WaitForBreakCompletion")
+	wb := f.waitBlock
+	f.mu.Unlock()
+	if wb != nil {
+		select {
+		case <-wb:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// fakeResolver returns the same fakeLockManager for any share name.
+type fakeResolver struct {
+	mgr lock.LockManager
+}
+
+func (r *fakeResolver) GetLockManagerForShare(_ string) lock.LockManager {
+	return r.mgr
+}
+
+// TestBreakParentHandleLeasesOnCreate_WaitsForAck asserts that
+// BreakParentHandleLeasesOnCreate calls WaitForBreakCompletion AFTER
+// BreakHandleLeasesForSMBOpen and BEFORE returning. Per MS-SMB2 3.3.4.7, the
+// server must wait for LEASE_BREAK_ACK before completing the triggering CREATE.
+func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentHandle := lock.FileHandle("parent-dir-handle")
+	if err := lm.BreakParentHandleLeasesOnCreate(context.Background(), parentHandle, "share1", "smb:A"); err != nil {
+		t.Fatalf("BreakParentHandleLeasesOnCreate returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakHandleLeasesForSMBOpen call count = %d, want 1", got)
+	}
+	if fake.breakHandleCalls[0].HandleKey != string(parentHandle) {
+		t.Errorf("BreakHandleLeasesForSMBOpen handleKey = %q, want %q",
+			fake.breakHandleCalls[0].HandleKey, string(parentHandle))
+	}
+
+	if got := len(fake.waitForBreakCompletionKeys); got != 1 {
+		t.Fatalf("WaitForBreakCompletion call count = %d, want 1 (parent break must wait for ack per MS-SMB2 3.3.4.7)", got)
+	}
+	if fake.waitForBreakCompletionKeys[0] != string(parentHandle) {
+		t.Errorf("WaitForBreakCompletion handleKey = %q, want %q",
+			fake.waitForBreakCompletionKeys[0], string(parentHandle))
+	}
+
+	// Order: break must come before wait.
+	if len(fake.callOrder) < 2 {
+		t.Fatalf("expected at least 2 calls in order, got %v", fake.callOrder)
+	}
+	if fake.callOrder[0] != "BreakHandleLeasesForSMBOpen" {
+		t.Errorf("first call = %q, want BreakHandleLeasesForSMBOpen", fake.callOrder[0])
+	}
+	if fake.callOrder[1] != "WaitForBreakCompletion" {
+		t.Errorf("second call = %q, want WaitForBreakCompletion", fake.callOrder[1])
+	}
+}
+
+// TestBreakParentReadLeasesOnModify_WaitsForAck asserts the same ack-wait
+// guarantee for BreakParentReadLeasesOnModify.
+func TestBreakParentReadLeasesOnModify_WaitsForAck(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentHandle := lock.FileHandle("parent-dir-handle-2")
+	if err := lm.BreakParentReadLeasesOnModify(context.Background(), parentHandle, "share1", "smb:A"); err != nil {
+		t.Fatalf("BreakParentReadLeasesOnModify returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakReadCalls); got != 1 {
+		t.Fatalf("BreakReadLeasesForParentDir call count = %d, want 1", got)
+	}
+	if fake.breakReadCalls[0].HandleKey != string(parentHandle) {
+		t.Errorf("BreakReadLeasesForParentDir handleKey = %q, want %q",
+			fake.breakReadCalls[0].HandleKey, string(parentHandle))
+	}
+
+	if got := len(fake.waitForBreakCompletionKeys); got != 1 {
+		t.Fatalf("WaitForBreakCompletion call count = %d, want 1 (parent break must wait for ack per MS-SMB2 3.3.4.7)", got)
+	}
+	if fake.waitForBreakCompletionKeys[0] != string(parentHandle) {
+		t.Errorf("WaitForBreakCompletion handleKey = %q, want %q",
+			fake.waitForBreakCompletionKeys[0], string(parentHandle))
+	}
+
+	if len(fake.callOrder) < 2 {
+		t.Fatalf("expected at least 2 calls in order, got %v", fake.callOrder)
+	}
+	if fake.callOrder[0] != "BreakReadLeasesForParentDir" {
+		t.Errorf("first call = %q, want BreakReadLeasesForParentDir", fake.callOrder[0])
+	}
+	if fake.callOrder[1] != "WaitForBreakCompletion" {
+		t.Errorf("second call = %q, want WaitForBreakCompletion", fake.callOrder[1])
+	}
+}
+
+// TestBreakParentHandle_ExcludesTriggeringClient asserts that the triggering
+// CREATE's clientID is forwarded as the excludeOwner so that the triggering
+// session's own parent-dir lease (if any) is NOT in the breakable set, and
+// that the function honours its caller's context cancellation rather than
+// blocking forever — proving the wait cannot deadlock the triggering CREATE.
+func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
+	t.Parallel()
+
+	// waitBlock simulates an outstanding break that never gets acked. With a
+	// bounded context the call must return when the context expires, NOT
+	// deadlock indefinitely.
+	fake := &fakeLockManager{
+		waitBlock: make(chan struct{}),
+	}
+	defer close(fake.waitBlock)
+
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	// Use a short caller-side timeout to bound the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- lm.BreakParentHandleLeasesOnCreate(ctx, lock.FileHandle("parent"), "share1", "smb:A")
+	}()
+
+	select {
+	case <-done:
+		// Returned (either nil or ctx.DeadlineExceeded). Both are acceptable —
+		// what we are asserting is that the call does NOT block forever.
+	case <-time.After(2 * time.Second):
+		t.Fatal("BreakParentHandleLeasesOnCreate deadlocked: did not return within 2s of caller context expiry")
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.breakHandleCalls) != 1 {
+		t.Fatalf("BreakHandleLeasesForSMBOpen call count = %d, want 1", len(fake.breakHandleCalls))
+	}
+	excludeOwner := fake.breakHandleCalls[0].ExcludeOwner
+	if excludeOwner == nil {
+		t.Fatal("excludeOwner is nil; the triggering client's session must be excluded from the breakable set")
+	}
+	if excludeOwner.ClientID != "smb:A" {
+		t.Errorf("excludeOwner.ClientID = %q, want %q", excludeOwner.ClientID, "smb:A")
+	}
+
+	// And we must have actually attempted to wait — proving the new contract
+	// is wired (rather than the test passing trivially against unmodified code).
+	if len(fake.waitForBreakCompletionKeys) != 1 {
+		t.Fatalf("WaitForBreakCompletion call count = %d, want 1", len(fake.waitForBreakCompletionKeys))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -852,25 +852,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	if fileExists {
 		existingHandle, handleErr := metadata.EncodeFileHandle(existingFile)
 		if handleErr == nil {
-			// Step 10: Break Handle leases before share mode check.
+			// Step 10: Break Handle leases on directories before share mode check.
 			// Per MS-SMB2 3.3.5.9.8: stat-only opens (FILE_READ_ATTRIBUTES
 			// only) do NOT break existing leases.
-			// For files: wait for break to complete so share mode check is
-			// accurate (clients close cached handles during the break).
-			// For directories: dispatch the break but do NOT wait. Directory
-			// opens never conflict on share modes, and blocking here would
-			// deadlock when the other client needs this CREATE's response
-			// before it can process the break notification.
-			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) {
+			//
+			// For directories: dispatch Handle-break async (fire-and-forget).
+			// Directory Handle breaks notify clients to release cached dir handles.
+			// Step 8a (BreakConflictingOplocksOnOpen) is skipped for directories,
+			// so this is the only break opportunity.
+			//
+			// For files: do NOT break Handle here. Step 8a dispatches the Write
+			// break via BreakConflictingOplocksOnOpen. If we break Handle first,
+			// the lease is marked Breaking and Step 8a skips the Write break —
+			// but clients need the Write break to flush dirty data. The Handle
+			// break is folded into the eventual lease downgrade (RWH → R after
+			// Write + Handle strips).
+			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) && existingFile.Type == metadata.FileTypeDirectory {
 				lockFileHandle := lock.FileHandle(existingHandle)
-				if existingFile.Type == metadata.FileTypeDirectory {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-						logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
-					}
-				} else {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-						logger.Debug("CREATE: handle lease break failed", "error", breakErr)
-					}
+				if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+					logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
 				}
 			}
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -852,25 +852,29 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	if fileExists {
 		existingHandle, handleErr := metadata.EncodeFileHandle(existingFile)
 		if handleErr == nil {
-			// Step 10: Break Handle leases on directories before share mode check.
-			// Per MS-SMB2 3.3.5.9.8: stat-only opens (FILE_READ_ATTRIBUTES
-			// only) do NOT break existing leases.
+			// Step 10: Break Handle leases before share mode check.
+			// Per MS-SMB2 3.3.5.9 Step 10: if any existing open has a lease
+			// with Handle caching, break it so the client can close cached
+			// handles before the share mode check.
+			// Per MS-SMB2 3.3.5.9.8: stat-only opens do NOT break leases.
 			//
-			// For directories: dispatch Handle-break async (fire-and-forget).
-			// Directory Handle breaks notify clients to release cached dir handles.
-			// Step 8a (BreakConflictingOplocksOnOpen) is skipped for directories,
-			// so this is the only break opportunity.
+			// For files: synchronous wait for Handle break ack. After the
+			// client acks (closing the cached handle), the share mode check
+			// runs with updated state. Step 8a then strips Write if needed.
 			//
-			// For files: do NOT break Handle here. Step 8a dispatches the Write
-			// break via BreakConflictingOplocksOnOpen. If we break Handle first,
-			// the lease is marked Breaking and Step 8a skips the Write break —
-			// but clients need the Write break to flush dirty data. The Handle
-			// break is folded into the eventual lease downgrade (RWH → R after
-			// Write + Handle strips).
-			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) && existingFile.Type == metadata.FileTypeDirectory {
+			// For directories: async (fire-and-forget). Directory opens use
+			// a single-threaded test driver where the client can't ack until
+			// this CREATE returns — waiting would deadlock.
+			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) {
 				lockFileHandle := lock.FileHandle(existingHandle)
-				if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-					logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
+				if existingFile.Type == metadata.FileTypeDirectory {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+						logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
+					}
+				} else {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+						logger.Debug("CREATE: handle lease break failed", "error", breakErr)
+					}
 				}
 			}
 

--- a/internal/adapter/smb/v2/handlers/lease_context_test.go
+++ b/internal/adapter/smb/v2/handlers/lease_context_test.go
@@ -47,7 +47,7 @@ func TestDecodeLeaseCreateContext(t *testing.T) {
 				for i := 0; i < 16; i++ {
 					buf[i] = byte(i + 10)
 				}
-				// LeaseState = RW (0x03)
+				// LeaseState = RW (0x05)
 				binary.LittleEndian.PutUint32(buf[16:20], lock.LeaseStateRead|lock.LeaseStateWrite)
 				// Epoch = 5
 				binary.LittleEndian.PutUint16(buf[48:50], 5)

--- a/pkg/metadata/lock/directory_test.go
+++ b/pkg/metadata/lock/directory_test.go
@@ -41,10 +41,10 @@ func TestOnDirChange_BreaksDirectoryLeases(t *testing.T) {
 		},
 	})
 
-	// Grant directory lease (RH requested -> downgraded to R since Handle not valid for dirs)
+	// Grant directory lease (RH is valid for directories)
 	state, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), leaseKey, parentKey, "owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
 	require.NoError(t, err)
-	assert.Equal(t, LeaseStateRead, state)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
 
 	// Simulate directory change from a different client
 	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2")

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -268,23 +268,35 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 			// can mutate the live *UnifiedLock while the callback reads it.
 			lockSnapshot := lock.Clone()
 
-			// Release lock before dispatching break callbacks
+			// Release lock before dispatching break callbacks. The dispatch
+			// itself is synchronous: by the time dispatchOpLockBreak returns,
+			// the LEASE_BREAK_NOTIFICATION is already on the wire to the
+			// existing client (see internal/adapter/smb/lease/notifier.go,
+			// SMBBreakHandler.OnOpLockBreak which calls SendLeaseBreak inline).
+			// Per MS-SMB2 3.3.4.7 the notification ordering requirement is
+			// therefore satisfied without further synchronization.
 			lm.mu.Unlock()
 			lm.dispatchOpLockBreak(handleKey, lockSnapshot, breakTo)
 
-			// Per MS-SMB2 3.3.5.9: The server MUST wait for the break to
-			// complete (or timeout) before returning to the caller, so that
-			// the second opener's response is not sent before the first
-			// client receives the OPLOCK_BREAK_NOTIFICATION.
-			breakCtx, cancel := context.WithTimeout(ctx, 35*time.Second)
-			err := lm.WaitForBreakCompletion(breakCtx, handleKey)
-			cancel() // cancel immediately, not deferred — avoid context leak
-			if err != nil {
-				logger.Debug("RequestLease: break wait completed with error",
-					"fileHandle", handleKey,
-					"error", err)
-			}
-
+			// Do NOT wait for the LEASE_BREAK_ACK before returning to the
+			// second opener. Waiting here causes a fatal deadlock in
+			// multi-client scenarios such as WPTS
+			// BVT_DirectoryLeasing_LeaseBreakOnMultiClients: the test (and
+			// in general any single-threaded client driver) only sends the
+			// ack from the first client AFTER the second client's CREATE
+			// returns. Blocking the second CREATE on that ack prevents the
+			// ack from ever being sent, and the wait either burns the
+			// client's CREATE timeout or runs out our own bounded deadline
+			// for nothing.
+			//
+			// The breaking lease remains in unifiedLocks with Breaking=true
+			// and BreakToState set; OpLocksConflict (oplock.go:229-233)
+			// already evaluates conflicts against BreakToState in that case,
+			// so bestGrantableState below computes the correct downgraded
+			// grant for the new opener without needing the ack to land
+			// first. The same async-dispatch pattern is used by
+			// internal/adapter/smb/lease/manager.go BreakHandleLeasesOnOpenAsync,
+			// whose comment explicitly documents this deadlock.
 			breakDispatched = true
 			break
 		}

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -81,12 +81,12 @@ func TestRequestLease_GrantDirectoryLeaseRH(t *testing.T) {
 	leaseKey := [16]byte{1, 2, 3}
 	parentKey := [16]byte{}
 
-	// RH requested on directory -> Handle is not valid for directories,
-	// so bestGrantableState downgrades to R.
+	// RH is now valid for directories (Handle caching lets clients cache
+	// directory handles; breaks notify when other clients need access).
 	state, epoch, err := mgr.RequestLease(ctx, FileHandle("dir1"), leaseKey, parentKey, "owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
 
 	require.NoError(t, err)
-	assert.Equal(t, LeaseStateRead, state, "RH should be downgraded to R for directories")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state, "RH should be granted as-is for directories")
 	assert.Equal(t, uint16(1), epoch)
 }
 
@@ -98,13 +98,12 @@ func TestRequestLease_DirectoryState_RW(t *testing.T) {
 	leaseKey := [16]byte{1, 2, 3}
 	parentKey := [16]byte{}
 
-	// Per MS-SMB2 3.3.5.9: directories CAN hold Write (W) caching leases.
-	// Write caching on a directory means the client can cache directory
-	// content changes. Both Windows Server and Samba grant RW on directories.
+	// Directories do not support Write (W) caching. Requesting RW on a
+	// directory should downgrade to R (strip W).
 	state, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), leaseKey, parentKey, "owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite, true)
 
 	require.NoError(t, err)
-	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state, "should grant RW as-is for directory")
+	assert.Equal(t, LeaseStateRead, state, "RW on directory should downgrade to R (W not valid for dirs)")
 }
 
 func TestRequestLease_DirectoryState_RWH(t *testing.T) {
@@ -115,12 +114,12 @@ func TestRequestLease_DirectoryState_RWH(t *testing.T) {
 	leaseKey := [16]byte{1, 2, 3}
 	parentKey := [16]byte{}
 
-	// Per MS-SMB2 3.3.5.9: directories support R and RW but NOT Handle caching.
-	// RWH requested on a directory is downgraded to RW.
+	// Directories do not support Write (W) caching. Requesting RWH on a
+	// directory should downgrade to RH (strip W).
 	state, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), leaseKey, parentKey, "owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
 
 	require.NoError(t, err)
-	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state, "RWH should be downgraded to RW for directory")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state, "RWH on directory should downgrade to RH (W not valid for dirs)")
 }
 
 func TestRequestLease_SameKeyUpgrade_R_to_RW(t *testing.T) {
@@ -307,16 +306,22 @@ func TestAcknowledgeLeaseBreak_CompletesBreak(t *testing.T) {
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state)
 
 	// Request from key2 triggers break on key1. The break callback
-	// acknowledges to None, removing key1's lease entirely. After the
-	// break completes, key2's R lease should be granted.
+	// acknowledges to None asynchronously, eventually removing key1's
+	// lease entirely. RequestLease no longer blocks waiting for the ack
+	// (see TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck for the
+	// rationale), so key2's grant is computed against the BreakToState
+	// snapshot (R after stripping W) and key1's removal happens slightly
+	// later when the async ack lands.
 	state, _, err = mgr.RequestLease(ctx, FileHandle("file1"), key2, parentKey, "owner2", "client2", "/share", LeaseStateRead, false)
 	require.NoError(t, err)
 	assert.Equal(t, LeaseStateRead, state, "should grant R lease after break removes existing")
 	assert.True(t, breakCalled, "break callback should have been called")
 
-	// key1's lease should be removed (acknowledged to None)
-	_, _, found := mgr.GetLeaseState(ctx, key1)
-	assert.False(t, found, "key1 lease should be removed after ack to None")
+	// key1's lease should be removed once the async ack-to-None lands.
+	assert.Eventually(t, func() bool {
+		_, _, found := mgr.GetLeaseState(ctx, key1)
+		return !found
+	}, time.Second, time.Millisecond, "key1 lease should be removed after ack to None")
 }
 
 func TestAcknowledgeLeaseBreak_ToReadState(t *testing.T) {
@@ -615,10 +620,9 @@ func TestDowngradeCandidates_DirectoryRWH(t *testing.T) {
 	t.Parallel()
 
 	candidates := downgradeCandidates(LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
-	// For directory: RWH (invalid), RH (invalid, strip W), RW (valid, strip H), R (valid, strip both)
-	// Only valid directory states are included: RW, R
+	// For directory: RWH (invalid), RH (valid, strip W), RW (invalid, strip H), R (valid, strip both)
 	assert.Equal(t, []uint32{
-		LeaseStateRead | LeaseStateWrite,
+		LeaseStateRead | LeaseStateHandle,
 		LeaseStateRead,
 	}, candidates)
 }
@@ -627,9 +631,9 @@ func TestDowngradeCandidates_DirectoryRH(t *testing.T) {
 	t.Parallel()
 
 	candidates := downgradeCandidates(LeaseStateRead|LeaseStateHandle, true)
-	// RH (invalid for dir) -> strip W = RH (invalid), strip H = R (valid), strip both = R
-	// Only valid: R
+	// RH (valid for dir), strip W = RH (dedup), strip H = R (valid), strip both = R (dedup)
 	assert.Equal(t, []uint32{
+		LeaseStateRead | LeaseStateHandle,
 		LeaseStateRead,
 	}, candidates)
 }
@@ -702,8 +706,10 @@ func TestBestGrantableState_DirectoryRWH_DowngradeCascade(t *testing.T) {
 		{Lease: &OpLock{LeaseKey: otherKey, LeaseState: LeaseStateRead | LeaseStateWrite | LeaseStateHandle}},
 	}
 
-	// Directory candidates for RWH: [RW, R] (Handle not valid for dirs)
-	// RW: requested W conflicts with existing R/W -> skip
+	// Directory candidates for RWH: [RWH, RW, RH, R] (Handle now valid for dirs)
+	// RWH: W conflicts with existing W -> skip
+	// RW: W conflicts with existing W -> skip
+	// RH: existing W conflicts with requested R -> skip
 	// R: existing W conflicts with requested R -> skip
 	// All candidates conflict -> None
 	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
@@ -765,4 +771,80 @@ func TestRequestLease_SameKeyBreaking_ReturnsBreakInProgress(t *testing.T) {
 	assert.ErrorIs(t, err, ErrLeaseBreakInProgress)
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state, "should return current lease state")
 	assert.Equal(t, uint16(2), epoch, "should return current epoch")
+}
+
+// TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck verifies that the
+// second opener's RequestLease does NOT block waiting for the first client's
+// LEASE_BREAK_ACK. This is the WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients
+// scenario: the test orchestrates Client1's ack only AFTER Client2's CREATE
+// returns. If RequestLease blocks Client2 waiting for an ack that the test
+// will only drive after Client2 returns, the test deadlocks until the WPTS
+// client-side ~8s timeout fires (System.TimeoutException).
+//
+// The internal break dispatch is synchronous (the LEASE_BREAK_NOTIFICATION
+// is on the wire before this call returns), and OpLocksConflict already
+// treats a Breaking lease as having its BreakToState (oplock.go:229-233),
+// so bestGrantableState computes the correct downgraded grant without
+// needing to wait for the ack. See also internal/adapter/smb/lease/manager.go
+// BreakHandleLeasesOnOpenAsync, which documents the same deadlock pattern
+// for directory opens: "blocking would deadlock: the other client needs
+// this CREATE's response before it processes the break."
+func TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0}
+	key2 := [16]byte{2, 0, 0, 0}
+	parentKey := [16]byte{}
+
+	// Register a break callback that records the break but NEVER acks.
+	// This simulates a slow/non-cooperating client (or, in the WPTS test
+	// case, a client that the test harness has not yet driven to ack).
+	var breakCalled bool
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, breakToState uint32) {
+			breakCalled = true
+			// Intentionally do NOT call AcknowledgeLeaseBreak.
+		},
+	})
+
+	// Client1 takes RW file lease. We use a file (not directory) because
+	// RW is no longer valid for directories after the lease constant swap.
+	// The test's purpose is verifying the cross-key path doesn't deadlock.
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, parentKey,
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state)
+
+	// Client2 requests RW on the same file with a different key.
+	// This must trigger a cross-key conflict, dispatch a break (which is
+	// never acked), and then return promptly with a downgraded grant.
+	//
+	// The test asserts the call returns within 1s. Without the fix, the
+	// 35s WaitForBreakCompletion in leases.go blocks here for the full
+	// timeout, exceeding the 1s budget.
+	type result struct {
+		state uint32
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, _, e := mgr.RequestLease(ctx, FileHandle("file1"), key2, parentKey,
+			"owner2", "client2", "/share", LeaseStateRead|LeaseStateWrite, false)
+		done <- result{s, e}
+	}()
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		// After break-to-R, Client2 should get R (RW conflict resolved).
+		assert.Equal(t, LeaseStateRead, r.state,
+			"Client2 should get R after Client1's RW is broken-to-R")
+		assert.True(t, breakCalled, "break callback must have fired")
+	case <-time.After(1 * time.Second):
+		t.Fatalf("RequestLease blocked >1s waiting for ack that never comes — "+
+			"this is the WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients "+
+			"deadlock. breakCalled=%v", breakCalled)
+	}
 }

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -321,7 +322,7 @@ func TestAcknowledgeLeaseBreak_CompletesBreak(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		_, _, found := mgr.GetLeaseState(ctx, key1)
 		return !found
-	}, time.Second, time.Millisecond, "key1 lease should be removed after ack to None")
+	}, 3*time.Second, 10*time.Millisecond, "key1 lease should be removed after ack to None")
 }
 
 func TestAcknowledgeLeaseBreak_ToReadState(t *testing.T) {
@@ -804,10 +805,10 @@ func TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck(t *testing.T) {
 	// Register a break callback that records the break but NEVER acks.
 	// This simulates a slow/non-cooperating client (or, in the WPTS test
 	// case, a client that the test harness has not yet driven to ack).
-	var breakCalled bool
+	var breakCalled atomic.Bool
 	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
 		onOpLockBreak: func(handleKey string, lock *UnifiedLock, breakToState uint32) {
-			breakCalled = true
+			breakCalled.Store(true)
 			// Intentionally do NOT call AcknowledgeLeaseBreak.
 		},
 	})
@@ -844,10 +845,10 @@ func TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck(t *testing.T) {
 		// After break-to-R, Client2 should get R (RW conflict resolved).
 		assert.Equal(t, LeaseStateRead, r.state,
 			"Client2 should get R after Client1's RW is broken-to-R")
-		assert.True(t, breakCalled, "break callback must have fired")
-	case <-time.After(1 * time.Second):
-		t.Fatalf("RequestLease blocked >1s waiting for ack that never comes — "+
+		assert.True(t, breakCalled.Load(), "break callback must have fired")
+	case <-time.After(3 * time.Second):
+		t.Fatalf("RequestLease blocked >3s waiting for ack that never comes — "+
 			"this is the WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients "+
-			"deadlock. breakCalled=%v", breakCalled)
+			"deadlock. breakCalled=%v", breakCalled.Load())
 	}
 }

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -706,9 +706,7 @@ func TestBestGrantableState_DirectoryRWH_DowngradeCascade(t *testing.T) {
 		{Lease: &OpLock{LeaseKey: otherKey, LeaseState: LeaseStateRead | LeaseStateWrite | LeaseStateHandle}},
 	}
 
-	// Directory candidates for RWH: [RWH, RW, RH, R] (Handle now valid for dirs)
-	// RWH: W conflicts with existing W -> skip
-	// RW: W conflicts with existing W -> skip
+	// Directory candidates for RWH: [RH, R] (W invalid for dirs, so RWH and RW skipped)
 	// RH: existing W conflicts with requested R -> skip
 	// R: existing W conflicts with requested R -> skip
 	// All candidates conflict -> None
@@ -775,11 +773,16 @@ func TestRequestLease_SameKeyBreaking_ReturnsBreakInProgress(t *testing.T) {
 
 // TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck verifies that the
 // second opener's RequestLease does NOT block waiting for the first client's
-// LEASE_BREAK_ACK. This is the WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients
-// scenario: the test orchestrates Client1's ack only AFTER Client2's CREATE
-// returns. If RequestLease blocks Client2 waiting for an ack that the test
-// will only drive after Client2 returns, the test deadlocks until the WPTS
-// client-side ~8s timeout fires (System.TimeoutException).
+// LEASE_BREAK_ACK. This is the core invariant behind the WPTS
+// BVT_DirectoryLeasing_LeaseBreakOnMultiClients scenario: the test
+// orchestrates Client1's ack only AFTER Client2's CREATE returns. If
+// RequestLease blocks Client2 waiting for an ack that the test will only
+// drive after Client2 returns, the call deadlocks until the WPTS client-side
+// ~8s timeout fires (System.TimeoutException).
+//
+// The test uses a file lease (RW) because Write caching is not valid for
+// directories after the lease constant swap. The cross-key non-blocking
+// guarantee applies to both file and directory leases.
 //
 // The internal break dispatch is synchronous (the LEASE_BREAK_NOTIFICATION
 // is on the wire before this call returns), and OpLocksConflict already

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,12 +185,6 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
-	// GetWriteLeasesToBreak identifies Write leases that need breaking,
-	// marks them as Breaking in the lock state, and returns the info needed
-	// for the caller to dispatch notifications directly. Used by the SMB
-	// adapter to send break notifications via the adapter-level session map.
-	GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo
-
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
@@ -1300,59 +1294,6 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
 		return lease.HasWrite()
 	})
-}
-
-// LeaseBreakInfo holds the information needed to dispatch a lease break
-// notification at the adapter level (bypassing the LockManager callback chain).
-type LeaseBreakInfo struct {
-	LeaseKey     [16]byte
-	CurrentState uint32
-	BreakToState uint32
-	Epoch        uint16
-}
-
-// GetWriteLeasesToBreak identifies Write leases that need breaking, marks them
-// as Breaking in the lock state, and returns info for the caller to dispatch
-// break notifications directly. This avoids the LockManager's dispatchOpLockBreak
-// callback chain, letting the adapter route notifications through its own session
-// map.
-func (lm *Manager) GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo {
-	lm.mu.Lock()
-	defer lm.mu.Unlock()
-
-	locks := lm.unifiedLocks[handleKey]
-	var result []LeaseBreakInfo
-
-	for _, l := range locks {
-		if l.Lease == nil || l.Lease.Breaking || !l.Lease.HasWrite() {
-			continue
-		}
-		if excludeOwner != nil {
-			if l.Owner.OwnerID == excludeOwner.OwnerID ||
-				(excludeOwner.ClientID != "" && l.Owner.ClientID == excludeOwner.ClientID) {
-				continue
-			}
-			if excludeOwner.ExcludeLeaseKey != ([16]byte{}) &&
-				l.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
-				continue
-			}
-		}
-
-		breakTo := l.Lease.LeaseState &^ LeaseStateWrite
-		l.Lease.Breaking = true
-		l.Lease.BreakToState = breakTo
-		l.Lease.BreakStarted = time.Now()
-		advanceEpoch(l.Lease)
-
-		result = append(result, LeaseBreakInfo{
-			LeaseKey:     l.Lease.LeaseKey,
-			CurrentState: l.Lease.LeaseState,
-			BreakToState: breakTo,
-			Epoch:        l.Lease.Epoch,
-		})
-	}
-
-	return result
 }
 
 // BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE that may

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,6 +185,12 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
+	// GetWriteLeasesToBreak identifies Write leases that need breaking,
+	// marks them as Breaking in the lock state, and returns the info needed
+	// for the caller to dispatch notifications directly. Used by the SMB
+	// adapter to send break notifications via the adapter-level session map.
+	GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo
+
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
@@ -1294,6 +1300,59 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
 		return lease.HasWrite()
 	})
+}
+
+// LeaseBreakInfo holds the information needed to dispatch a lease break
+// notification at the adapter level (bypassing the LockManager callback chain).
+type LeaseBreakInfo struct {
+	LeaseKey     [16]byte
+	CurrentState uint32
+	BreakToState uint32
+	Epoch        uint16
+}
+
+// GetWriteLeasesToBreak identifies Write leases that need breaking, marks them
+// as Breaking in the lock state, and returns info for the caller to dispatch
+// break notifications directly. This avoids the LockManager's dispatchOpLockBreak
+// callback chain, letting the adapter route notifications through its own session
+// map.
+func (lm *Manager) GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	locks := lm.unifiedLocks[handleKey]
+	var result []LeaseBreakInfo
+
+	for _, l := range locks {
+		if l.Lease == nil || l.Lease.Breaking || !l.Lease.HasWrite() {
+			continue
+		}
+		if excludeOwner != nil {
+			if l.Owner.OwnerID == excludeOwner.OwnerID ||
+				(excludeOwner.ClientID != "" && l.Owner.ClientID == excludeOwner.ClientID) {
+				continue
+			}
+			if excludeOwner.ExcludeLeaseKey != ([16]byte{}) &&
+				l.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
+				continue
+			}
+		}
+
+		breakTo := l.Lease.LeaseState &^ LeaseStateWrite
+		l.Lease.Breaking = true
+		l.Lease.BreakToState = breakTo
+		l.Lease.BreakStarted = time.Now()
+		advanceEpoch(l.Lease)
+
+		result = append(result, LeaseBreakInfo{
+			LeaseKey:     l.Lease.LeaseKey,
+			CurrentState: l.Lease.LeaseState,
+			BreakToState: breakTo,
+			Epoch:        l.Lease.Epoch,
+		})
+	}
+
+	return result
 }
 
 // BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE that may

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,6 +185,10 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
+	// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have
+	// Handle caching (RWH → RH). Only targets leases with both W and H.
+	BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
+
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
@@ -1308,6 +1312,23 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 func (lm *Manager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripHandle, func(lease *OpLock) bool {
 		return lease.HasHandle()
+	})
+}
+
+// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have Handle
+// caching. Per MS-SMB2 3.3.5.9 Step 10: before the share mode check, leases
+// with Handle caching must be broken so clients close cached handles. The break
+// strips Write (not Handle) so clients see "RWH → RH" and flush dirty data
+// while preserving Handle for the share mode resolution window.
+//
+// This targets only leases WITH Handle caching:
+//   - RWH -> RH (has Handle → strip Write)
+//   - RH  -> not broken (has Handle but no Write to strip)
+//   - RW  -> not broken (no Handle → not a cached-handle concern)
+//   - R   -> not broken
+func (lm *Manager) BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
+	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
+		return lease.HasHandle() && lease.HasWrite()
 	})
 }
 

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -65,9 +65,9 @@ var ValidFileLeaseStates = []uint32{
 // When RW is requested, bestGrantableState will downgrade to R.
 // Valid combinations: None, R, RH
 var ValidDirectoryLeaseStates = []uint32{
-	LeaseStateNone,                      // 0x00 - No caching
-	LeaseStateRead,                      // 0x01 - Read only
-	LeaseStateRead | LeaseStateHandle,   // 0x03 - Read + Handle
+	LeaseStateNone,                    // 0x00 - No caching
+	LeaseStateRead,                    // 0x01 - Read only
+	LeaseStateRead | LeaseStateHandle, // 0x03 - Read + Handle
 }
 
 // OpLock holds SMB2/3 lease-specific state.

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -23,14 +23,14 @@ const (
 	// Multiple clients can hold Read leases simultaneously.
 	LeaseStateRead uint32 = 0x01
 
+	// LeaseStateHandle (SMB2_LEASE_HANDLE_CACHING) permits caching open handles.
+	// Client can delay close operations until another client needs access.
+	LeaseStateHandle uint32 = 0x02
+
 	// LeaseStateWrite (SMB2_LEASE_WRITE_CACHING) permits caching writes.
 	// Only one client can hold a Write lease; requires exclusive access.
 	// Client with Write lease has dirty data that must be flushed on break.
-	LeaseStateWrite uint32 = 0x02
-
-	// LeaseStateHandle (SMB2_LEASE_HANDLE_CACHING) permits caching open handles.
-	// Client can delay close operations until another client needs access.
-	LeaseStateHandle uint32 = 0x04
+	LeaseStateWrite uint32 = 0x04
 )
 
 // Sentinel values for breakOpLocks break-to state computation.
@@ -48,26 +48,26 @@ const (
 
 // ValidFileLeaseStates contains all valid lease state combinations for files.
 // Per MS-SMB2: Write and Handle alone are not valid; they require Read.
-// Valid combinations: None, R, RW, RH, RWH
+// Valid combinations: None, R, RH, RW, RWH
 var ValidFileLeaseStates = []uint32{
 	LeaseStateNone,                                      // 0x00 - No caching
 	LeaseStateRead,                                      // 0x01 - Read only
-	LeaseStateRead | LeaseStateWrite,                    // 0x03 - Read + Write
-	LeaseStateRead | LeaseStateHandle,                   // 0x05 - Read + Handle
+	LeaseStateRead | LeaseStateHandle,                   // 0x03 - Read + Handle
+	LeaseStateRead | LeaseStateWrite,                    // 0x05 - Read + Write
 	LeaseStateRead | LeaseStateWrite | LeaseStateHandle, // 0x07 - Full (RWH)
 }
 
 // ValidDirectoryLeaseStates contains valid lease state combinations for directories.
-// Per MS-SMB2 3.3.5.9: directories support Read and Write caching but NOT Handle
-// caching. The Handle bit is meaningless for directories because Handle caching
-// protects delayed close semantics which don't apply to directory opens.
-// When RWH is requested, bestGrantableState will downgrade to RW.
-// When RH is requested, bestGrantableState will downgrade to R.
-// Valid combinations: None, R, RW
+// Per MS-SMB2 3.3.5.9: directories support Read and Handle caching but NOT
+// Write caching. Write caching requires exclusive access semantics that don't
+// apply to directory opens.
+// When RWH is requested, bestGrantableState will downgrade to RH.
+// When RW is requested, bestGrantableState will downgrade to R.
+// Valid combinations: None, R, RH
 var ValidDirectoryLeaseStates = []uint32{
-	LeaseStateNone,                   // 0x00 - No caching
-	LeaseStateRead,                   // 0x01 - Read only
-	LeaseStateRead | LeaseStateWrite, // 0x03 - Read + Write
+	LeaseStateNone,                      // 0x00 - No caching
+	LeaseStateRead,                      // 0x01 - Read only
+	LeaseStateRead | LeaseStateHandle,   // 0x03 - Read + Handle
 }
 
 // OpLock holds SMB2/3 lease-specific state.
@@ -123,7 +123,7 @@ type OpLock struct {
 
 	// IsDirectory indicates this lease is on a directory.
 	// When true, valid lease states are restricted to ValidDirectoryLeaseStates
-	// (None, R, RW). Handle caching is not valid for directories.
+	// (None, R, RH).
 	IsDirectory bool
 }
 
@@ -186,8 +186,8 @@ func IsValidFileLeaseState(state uint32) bool {
 
 // IsValidDirectoryLeaseState returns true if the state is a valid lease combination for directories.
 //
-// Valid directory states: None, R, RW
-// Invalid: W alone, H alone, WH, RH, RWH (Handle not valid for directories)
+// Valid directory states: None, R, RH
+// Invalid: W alone, H alone, WH, RW, RWH (Write not valid for directories)
 func IsValidDirectoryLeaseState(state uint32) bool {
 	return slices.Contains(ValidDirectoryLeaseStates, state)
 }

--- a/pkg/metadata/lock/oplock_test.go
+++ b/pkg/metadata/lock/oplock_test.go
@@ -15,21 +15,21 @@ import (
 func TestLeaseStateConstants(t *testing.T) {
 	t.Parallel()
 
-	// Verify MS-SMB2 spec values
+	// Verify MS-SMB2 2.2.13.2.8 spec values
 	assert.Equal(t, uint32(0x00), LeaseStateNone, "None should be 0x00")
 	assert.Equal(t, uint32(0x01), LeaseStateRead, "Read should be 0x01")
-	assert.Equal(t, uint32(0x02), LeaseStateWrite, "Write should be 0x02")
-	assert.Equal(t, uint32(0x04), LeaseStateHandle, "Handle should be 0x04")
+	assert.Equal(t, uint32(0x02), LeaseStateHandle, "Handle should be 0x02")
+	assert.Equal(t, uint32(0x04), LeaseStateWrite, "Write should be 0x04")
 }
 
 func TestLeaseStateCombinations(t *testing.T) {
 	t.Parallel()
 
-	// RW = Read | Write = 0x03
-	assert.Equal(t, uint32(0x03), LeaseStateRead|LeaseStateWrite)
+	// RH = Read | Handle = 0x03
+	assert.Equal(t, uint32(0x03), LeaseStateRead|LeaseStateHandle)
 
-	// RH = Read | Handle = 0x05
-	assert.Equal(t, uint32(0x05), LeaseStateRead|LeaseStateHandle)
+	// RW = Read | Write = 0x05
+	assert.Equal(t, uint32(0x05), LeaseStateRead|LeaseStateWrite)
 
 	// RWH = Read | Write | Handle = 0x07
 	assert.Equal(t, uint32(0x07), LeaseStateRead|LeaseStateWrite|LeaseStateHandle)
@@ -206,7 +206,7 @@ func TestIsValidDirectoryLeaseState(t *testing.T) {
 	}{
 		{LeaseStateNone, "None"},
 		{LeaseStateRead, "R"},
-		{LeaseStateRead | LeaseStateWrite, "RW"},
+		{LeaseStateRead | LeaseStateHandle, "RH"},
 	}
 
 	for _, tc := range validStates {
@@ -219,11 +219,11 @@ func TestIsValidDirectoryLeaseState(t *testing.T) {
 		state uint32
 		name  string
 	}{
+		{LeaseStateRead | LeaseStateWrite, "RW"},
+		{LeaseStateRead | LeaseStateWrite | LeaseStateHandle, "RWH"},
 		{LeaseStateWrite, "W"},
 		{LeaseStateHandle, "H"},
 		{LeaseStateWrite | LeaseStateHandle, "WH"},
-		{LeaseStateRead | LeaseStateHandle, "RH"},
-		{LeaseStateRead | LeaseStateWrite | LeaseStateHandle, "RWH"},
 	}
 
 	for _, tc := range invalidStates {

--- a/pkg/metadata/lock/store_test.go
+++ b/pkg/metadata/lock/store_test.go
@@ -158,7 +158,7 @@ func TestFromPersistedLock_Lease(t *testing.T) {
 		AcquiredAt:   time.Date(2026, 2, 5, 16, 0, 0, 0, time.UTC),
 		ServerEpoch:  20,
 		LeaseKey:     leaseKey,
-		LeaseState:   0x05, // RH
+		LeaseState:   0x05, // RW
 		LeaseEpoch:   55,
 		BreakToState: 0x01, // R
 		Breaking:     true,


### PR DESCRIPTION
## Summary

- **Swap LeaseStateWrite/Handle constants** to match MS-SMB2 2.2.13.2.8: Handle=0x02, Write=0x04 (were incorrectly swapped). This is the root cause — all other fixes flow from it.
- **Remove 35s blocking ack-wait** in cross-key lease conflict path (`requestLeaseImpl`). The synchronous wait deadlocked WPTS single-driver tests where Client1 can't ack until Client2's CREATE returns.
- **Pre-register session map before LockManager grant** to close a race where `breakOpLocks` fires between lease creation and session mapping, causing "no session" notification failures.
- **Bound parent directory lease break wait** to 5s (`BreakParentHandleLeasesOnCreate`/`BreakParentReadLeasesOnModify`) per MS-SMB2 3.3.4.7.
- **Restrict pre-share-mode Handle break to directories only** — for files, Step 8a's Write break is the primary mechanism.
- **Remove dead code**: `BreakDirectoryLeasesOnOpenAsync`, `GetWriteLeasesToBreak`, `LeaseBreakInfo` (superseded workarounds).

### Context

`BVT_DirectoryLeasing_LeaseBreakOnMultiClients` was listed as Expected failure in KNOWN_FAILURES. Investigation revealed the constants swap caused the server to interpret Handle-caching requests as Write-caching internally (and vice versa), making all Handle/Write break logic operate on the wrong wire bits. The cross-key deadlock and session map race were secondary issues exposed during the fix.

### WPTS CI result (pre-cleanup, same code)

- `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`: **Passed**
- `BVT_Leasing_FileLeasingV1`: **Passed**
- `BVT_Leasing_FileLeasingV2`: **Passed**
- Zero new leasing regressions

## Test plan

- [ ] `go test -race ./pkg/metadata/lock/...` passes
- [ ] `go test -race ./internal/adapter/smb/...` passes
- [ ] WPTS BVT CI: `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` passes
- [ ] WPTS BVT CI: `BVT_Leasing_FileLeasingV1` and `V2` pass
- [ ] WPTS BVT CI: zero new failures vs develop baseline
- [ ] smbtorture CI: no regressions