### PR TITLE
feat(smb): add identity mapping for cross-protocol uid/gid consistency

### DIFF
--- a/cmd/dfsctl/commands/idmap/add.go
+++ b/cmd/dfsctl/commands/idmap/add.go
@@ -16,11 +16,17 @@ var (
 var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add an identity mapping",
-	Long: `Add a new identity mapping from an NFSv4 principal to a control plane user.
+	Long: `Add a new identity mapping from an authentication principal to a control plane user.
+
+Supports NFS Kerberos principals (user@REALM), SMB NTLM principals
+(DOMAIN\user), and SMB Kerberos principals (user@REALM).
 
 Examples:
-  # Map a Kerberos principal to a local user
+  # Map a Kerberos principal (NFS or SMB)
   dfsctl idmap add --principal alice@EXAMPLE.COM --username alice
+
+  # Map an NTLM domain user
+  dfsctl idmap add --principal 'CORP\alice' --username alice
 
   # Map a numeric UID principal
   dfsctl idmap add --principal 1000@localdomain --username bob`,
@@ -28,7 +34,7 @@ Examples:
 }
 
 func init() {
-	addCmd.Flags().StringVar(&addPrincipal, "principal", "", "NFSv4 principal (e.g., alice@EXAMPLE.COM)")
+	addCmd.Flags().StringVar(&addPrincipal, "principal", "", "Authentication principal (e.g., alice@EXAMPLE.COM or CORP\\alice)")
 	addCmd.Flags().StringVar(&addUsername, "username", "", "Control plane username")
 	_ = addCmd.MarkFlagRequired("principal")
 	_ = addCmd.MarkFlagRequired("username")

--- a/cmd/dfsctl/commands/idmap/idmap.go
+++ b/cmd/dfsctl/commands/idmap/idmap.go
@@ -9,19 +9,27 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "idmap",
 	Short: "Manage identity mappings",
-	Long: `Manage identity mappings (NFSv4 principal to control plane user).
+	Long: `Manage identity mappings (authentication principal to control plane user).
 
-Identity mappings allow you to associate Kerberos or NFSv4 principals
-(e.g., "alice@EXAMPLE.COM") with local DittoFS user accounts.
+Identity mappings allow you to associate authentication principals with
+local DittoFS user accounts. This works across protocols:
 
-These mappings are used for ACL evaluation and identity resolution.
+  NFS/Kerberos:  alice@EXAMPLE.COM
+  SMB/NTLM:      CORP\alice
+  SMB/Kerberos:  alice@CORP.COM
+
+Mappings are shared across NFS and SMB, ensuring consistent uid/gid
+resolution in mixed-protocol deployments.
 
 Examples:
   # List all identity mappings
   dfsctl idmap list
 
-  # Add a mapping
+  # Map a Kerberos principal (works for both NFS and SMB)
   dfsctl idmap add --principal alice@EXAMPLE.COM --username alice
+
+  # Map an NTLM domain user
+  dfsctl idmap add --principal 'CORP\alice' --username alice
 
   # Remove a mapping
   dfsctl idmap remove --principal alice@EXAMPLE.COM`,

--- a/cmd/dfsctl/commands/idmap/remove.go
+++ b/cmd/dfsctl/commands/idmap/remove.go
@@ -30,7 +30,7 @@ Examples:
 }
 
 func init() {
-	removeCmd.Flags().StringVar(&removePrincipal, "principal", "", "NFSv4 principal to remove")
+	removeCmd.Flags().StringVar(&removePrincipal, "principal", "", "Authentication principal to remove")
 	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Skip confirmation prompt")
 	_ = removeCmd.MarkFlagRequired("principal")
 }

--- a/internal/adapter/smb/v2/handlers/identity_resolver.go
+++ b/internal/adapter/smb/v2/handlers/identity_resolver.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// resolveIdentityMapping checks the identity mapping store for a principal-to-username
+// mapping. This enables cross-protocol identity consistency: the same Kerberos or NTLM
+// principal resolves to the same control plane user regardless of whether the client
+// connects via NFS or SMB.
+//
+// Returns (mapped username, true) if a mapping was found, or (fallbackUsername, false)
+// if no mapping exists. Callers should use the found flag to distinguish "no mapping"
+// from "mapping exists but resolved user may not exist in UserStore" — the latter
+// should be treated as a hard auth failure.
+//
+// Security note: for NTLM principals ("DOMAIN\user"), this also tries the bare
+// username as a fallback key. A mapping keyed by bare username "alice" will match
+// any domain principal "*/alice". Operators should use fully-qualified principals
+// (e.g., "CORP\alice") for precise matching.
+func (h *Handler) resolveIdentityMapping(ctx context.Context, principal, fallbackUsername string) (string, bool) {
+	ims := h.Registry.GetIdentityMappingStore()
+	if ims == nil {
+		return fallbackUsername, false
+	}
+
+	// Try the full principal first (e.g., "DOMAIN\user" or "user@REALM").
+	mapping, err := ims.GetIdentityMapping(ctx, principal)
+	if err == nil {
+		logger.Debug("Identity mapping resolved",
+			"principal", principal, "username", mapping.Username)
+		return mapping.Username, true
+	}
+	if !errors.Is(err, models.ErrMappingNotFound) {
+		logger.Error("Identity mapping store error", "principal", principal, "error", err)
+		return fallbackUsername, false
+	}
+
+	// For NTLM principals ("DOMAIN\user"), also try bare username as fallback.
+	if idx := strings.IndexByte(principal, '\\'); idx >= 0 {
+		bare := principal[idx+1:]
+		mapping, err := ims.GetIdentityMapping(ctx, bare)
+		if err == nil {
+			logger.Debug("Identity mapping resolved via bare username",
+				"principal", principal, "bare", bare, "username", mapping.Username)
+			return mapping.Username, true
+		}
+		if !errors.Is(err, models.ErrMappingNotFound) {
+			logger.Error("Identity mapping store error", "principal", bare, "error", err)
+			return fallbackUsername, false
+		}
+	}
+
+	return fallbackUsername, false
+}
+
+// formatNTLMPrincipal constructs an NTLM principal string from domain and username.
+// Returns "DOMAIN\username" if domain is non-empty, otherwise just "username".
+func formatNTLMPrincipal(domain, username string) string {
+	if domain != "" {
+		return domain + `\` + username
+	}
+	return username
+}

--- a/internal/adapter/smb/v2/handlers/identity_resolver_test.go
+++ b/internal/adapter/smb/v2/handlers/identity_resolver_test.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// testStoreWithIDMap embeds store.Store (nil, unused) and adds IdentityMappingStore.
+// This lets runtime.New() accept it while GetIdentityMappingStore() succeeds.
+type testStoreWithIDMap struct {
+	store.Store
+	mappings map[string]*models.IdentityMapping
+}
+
+func (s *testStoreWithIDMap) GetIdentityMapping(_ context.Context, principal string) (*models.IdentityMapping, error) {
+	if mapping, ok := s.mappings[principal]; ok {
+		return mapping, nil
+	}
+	return nil, models.ErrMappingNotFound
+}
+
+func (s *testStoreWithIDMap) ListIdentityMappings(_ context.Context) ([]*models.IdentityMapping, error) {
+	return nil, nil
+}
+
+func (s *testStoreWithIDMap) CreateIdentityMapping(_ context.Context, mapping *models.IdentityMapping) error {
+	s.mappings[mapping.Principal] = mapping
+	return nil
+}
+
+func (s *testStoreWithIDMap) DeleteIdentityMapping(_ context.Context, principal string) error {
+	if _, ok := s.mappings[principal]; !ok {
+		return models.ErrMappingNotFound
+	}
+	delete(s.mappings, principal)
+	return nil
+}
+
+func TestFormatNTLMPrincipal(t *testing.T) {
+	tests := []struct {
+		domain   string
+		username string
+		want     string
+	}{
+		{"CORP", "alice", `CORP\alice`},
+		{"", "alice", "alice"},
+		{"EXAMPLE", "bob", `EXAMPLE\bob`},
+	}
+
+	for _, tt := range tests {
+		got := formatNTLMPrincipal(tt.domain, tt.username)
+		if got != tt.want {
+			t.Errorf("formatNTLMPrincipal(%q, %q) = %q, want %q", tt.domain, tt.username, got, tt.want)
+		}
+	}
+}
+
+func TestResolveIdentityMapping(t *testing.T) {
+	mockStore := &testStoreWithIDMap{
+		mappings: map[string]*models.IdentityMapping{
+			`CORP\alice`:      {Principal: `CORP\alice`, Username: "alice-local"},
+			"bob@EXAMPLE.COM": {Principal: "bob@EXAMPLE.COM", Username: "bob-local"},
+			"charlie":         {Principal: "charlie", Username: "charlie-mapped"},
+		},
+	}
+
+	rt := runtime.New(mockStore)
+	h := &Handler{Registry: rt}
+
+	tests := []struct {
+		name      string
+		principal string
+		fallback  string
+		wantUser  string
+		wantFound bool
+	}{
+		{
+			name:      "NTLM domain principal found",
+			principal: `CORP\alice`,
+			fallback:  "alice",
+			wantUser:  "alice-local",
+			wantFound: true,
+		},
+		{
+			name:      "Kerberos principal found",
+			principal: "bob@EXAMPLE.COM",
+			fallback:  "bob",
+			wantUser:  "bob-local",
+			wantFound: true,
+		},
+		{
+			name:      "Bare username fallback from DOMAIN\\user",
+			principal: `OTHERDOMAIN\charlie`,
+			fallback:  "charlie",
+			wantUser:  "charlie-mapped",
+			wantFound: true,
+		},
+		{
+			name:      "No mapping found returns fallback",
+			principal: "unknown@REALM",
+			fallback:  "unknown",
+			wantUser:  "unknown",
+			wantFound: false,
+		},
+		{
+			name:      "Empty fallback when no mapping (Kerberos path)",
+			principal: "nobody@NOWHERE",
+			fallback:  "",
+			wantUser:  "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUser, gotFound := h.resolveIdentityMapping(context.Background(), tt.principal, tt.fallback)
+			if gotUser != tt.wantUser || gotFound != tt.wantFound {
+				t.Errorf("resolveIdentityMapping(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.principal, tt.fallback, gotUser, gotFound, tt.wantUser, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestResolveIdentityMapping_NilStore(t *testing.T) {
+	rt := runtime.New(nil)
+	h := &Handler{Registry: rt}
+
+	gotUser, gotFound := h.resolveIdentityMapping(context.Background(), "alice@EXAMPLE.COM", "alice")
+	if gotUser != "alice" || gotFound != false {
+		t.Errorf("expected (\"alice\", false), got (%q, %v)", gotUser, gotFound)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -50,8 +50,13 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	sessionKey := normalizeSessionKey(authResult.SessionKey.KeyValue)
 
 	// Resolve principal to DittoFS username.
-	// Uses configurable mapping (strip-realm default, explicit mapping table).
-	username := pkgkerberos.ResolvePrincipal(authResult.Principal, authResult.Realm, h.IdentityConfig)
+	// First check DB identity mappings (cross-protocol consistency),
+	// then fall back to configurable mapping (strip-realm default, explicit mapping table).
+	fullPrincipal := authResult.Principal + "@" + authResult.Realm
+	username, _ := h.resolveIdentityMapping(ctx.Context, fullPrincipal, "")
+	if username == "" {
+		username = pkgkerberos.ResolvePrincipal(authResult.Principal, authResult.Realm, h.IdentityConfig)
+	}
 
 	logger.Debug("Kerberos authentication succeeded",
 		"principal", authResult.Principal,

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -421,8 +421,13 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 	userStore := h.Registry.GetUserStore()
 
 	if userStore != nil {
-		// Look up user by username
-		user, err := userStore.GetUser(ctx.Context, authMsg.Username)
+		// Resolve identity mapping: check if this NTLM principal maps to a different
+		// control plane username (enables cross-protocol uid/gid consistency).
+		principal := formatNTLMPrincipal(authMsg.Domain, authMsg.Username)
+		resolvedUsername, mappingFound := h.resolveIdentityMapping(ctx.Context, principal, authMsg.Username)
+
+		// Look up user by resolved username
+		user, err := userStore.GetUser(ctx.Context, resolvedUsername)
 		if err == nil && user != nil && user.Enabled {
 			// User found and enabled - validate NTLMv2 response if NT hash is available
 			ntHash, hasNTHash := user.GetNTHash()
@@ -521,7 +526,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 				if pending.IsReauth {
 					// Per MS-SMB2 3.3.5.5.3: re-derive keys from the new SessionBaseKey
-					if result := h.tryReauthUpdateWithKeys(pending, authMsg.Username, authMsg.Domain, user, false, signingKey[:], ctx); result != nil {
+					if result := h.tryReauthUpdateWithKeys(pending, resolvedUsername, authMsg.Domain, user, false, signingKey[:], ctx); result != nil {
 						return result, nil
 					}
 					// Fallthrough: session disappeared between negotiate and auth (unlikely)
@@ -557,7 +562,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			ctx.IsGuest = false
 
 			if pending.IsReauth {
-				if result := h.tryReauthUpdate(pending, authMsg.Username, authMsg.Domain, user, false); result != nil {
+				if result := h.tryReauthUpdate(pending, resolvedUsername, authMsg.Domain, user, false); result != nil {
 					return result, nil
 				}
 			}
@@ -576,9 +581,18 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 		// User not found or disabled
 		if err != nil {
-			logger.Debug("User not found in UserStore", "username", authMsg.Username, "error", err)
+			logger.Debug("User not found in UserStore", "username", resolvedUsername, "error", err)
 		} else if user != nil && !user.Enabled {
-			logger.Debug("User account disabled", "username", authMsg.Username)
+			logger.Debug("User account disabled", "username", resolvedUsername)
+			return NewErrorResult(types.StatusLogonFailure), nil
+		}
+
+		// If an identity mapping existed but the resolved user doesn't exist,
+		// hard-fail rather than falling through to guest. An operator created
+		// this mapping intentionally — silently granting guest access is wrong.
+		if mappingFound {
+			logger.Info("Identity mapping resolved but user not found, denying access",
+				"principal", principal, "resolvedUsername", resolvedUsername)
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 	}

--- a/pkg/apiclient/identity_mappings.go
+++ b/pkg/apiclient/identity_mappings.go
@@ -20,9 +20,14 @@ type CreateIdentityMappingRequest struct {
 	Username  string `json:"username"`
 }
 
+// identityMappingsPath is the API path for identity mappings.
+// Mappings are shared across protocols (NFS and SMB) — the /nfs/ segment
+// is the canonical path but the same data is accessible via /smb/.
+const identityMappingsPath = "/api/v1/adapters/nfs/identity-mappings"
+
 // ListIdentityMappings returns all identity mappings.
 func (c *Client) ListIdentityMappings() ([]IdentityMapping, error) {
-	return listResources[IdentityMapping](c, "/api/v1/adapters/nfs/identity-mappings")
+	return listResources[IdentityMapping](c, identityMappingsPath)
 }
 
 // CreateIdentityMapping creates a new identity mapping.
@@ -31,10 +36,10 @@ func (c *Client) CreateIdentityMapping(principal, username string) (*IdentityMap
 		Principal: principal,
 		Username:  username,
 	}
-	return createResource[IdentityMapping](c, "/api/v1/adapters/nfs/identity-mappings", req)
+	return createResource[IdentityMapping](c, identityMappingsPath, req)
 }
 
 // DeleteIdentityMapping deletes an identity mapping by principal.
 func (c *Client) DeleteIdentityMapping(principal string) error {
-	return deleteResource(c, fmt.Sprintf("/api/v1/adapters/nfs/identity-mappings/%s", url.PathEscape(principal)))
+	return deleteResource(c, fmt.Sprintf("%s/%s", identityMappingsPath, url.PathEscape(principal)))
 }

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -45,7 +45,7 @@ import (
 //   - /api/v1/adapters/nfs/clients/{id}/sessions - NFS client sessions (admin only)
 //   - /api/v1/adapters/{type}/grace - NFS grace period management (admin only)
 //   - /api/v1/adapters/{type}/netgroups - NFS netgroup management (admin only)
-//   - /api/v1/adapters/{type}/identity-mappings - NFS identity mapping management (admin only)
+//   - /api/v1/adapters/{type}/identity-mappings - Identity mapping management, shared across protocols (admin only)
 //   - /api/v1/adapters/{type}/mounts - Protocol-specific mount listing (admin only)
 //   - /api/v1/settings/* - System settings management (admin only)
 //   - /api/v1/mounts - Unified mount listing (admin only)
@@ -312,7 +312,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 							})
 						}
 
-						// NFS identity mapping management - requires IdentityMappingStore capability
+						// Identity mapping management (shared across NFS/SMB) - requires IdentityMappingStore capability
 						if ims, ok := cpStore.(store.IdentityMappingStore); ok {
 							r.Route("/identity-mappings", func(r chi.Router) {
 								idmapHandler := handlers.NewIdentityMappingHandler(ims)

--- a/pkg/controlplane/models/identity_mapping.go
+++ b/pkg/controlplane/models/identity_mapping.go
@@ -5,9 +5,11 @@ import (
 	"time"
 )
 
-// IdentityMapping maps an NFSv4 principal to a control plane username.
+// IdentityMapping maps an authentication principal to a control plane username.
 // This is used for resolving Kerberos principals (e.g., "alice@EXAMPLE.COM")
-// to local DittoFS user accounts.
+// or NTLM principals (e.g., "CORP\alice") to local DittoFS user accounts.
+// Mappings are shared across protocols (NFS and SMB) to ensure consistent
+// uid/gid resolution in mixed-protocol deployments.
 type IdentityMapping struct {
 	ID        string    `gorm:"primaryKey;type:varchar(36)" json:"id"`
 	Principal string    `gorm:"uniqueIndex;type:varchar(255);not null" json:"principal"`

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -451,6 +451,15 @@ func (r *Runtime) EvictBlockStore(ctx context.Context, shareName string, opts sh
 func (r *Runtime) GetUserStore() models.UserStore         { return r.store }
 func (r *Runtime) GetIdentityStore() models.IdentityStore { return r.store }
 
+// GetIdentityMappingStore returns the identity mapping store if supported.
+// Returns nil if the underlying store does not implement IdentityMappingStore.
+func (r *Runtime) GetIdentityMappingStore() store.IdentityMappingStore {
+	if ims, ok := r.store.(store.IdentityMappingStore); ok {
+		return ims
+	}
+	return nil
+}
+
 // --- Settings Access ---
 
 func (r *Runtime) GetSettingsWatcher() *SettingsWatcher { return r.settingsWatcher }

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -495,8 +495,9 @@ type NetgroupStore interface {
 }
 
 // IdentityMappingStore provides identity mapping operations.
-// This is a separate interface from Store so that only NFS/Kerberos-aware
+// This is a separate interface from Store so that only identity-mapping-aware
 // components need to depend on identity mapping functionality.
+// Mappings are shared across protocols (NFS and SMB).
 type IdentityMappingStore interface {
 	// GetIdentityMapping returns an identity mapping by principal.
 	// Returns models.ErrMappingNotFound if the mapping doesn't exist.


### PR DESCRIPTION
## Summary

- SMB session setup (NTLM and Kerberos) now consults the shared identity mapping table before resolving users, ensuring the same principal gets consistent uid/gid across NFS and SMB
- Hard-fails with `StatusLogonFailure` when a mapping exists but the resolved user is missing (instead of silently falling to guest)
- Generalizes CLI docs and model comments from NFS-specific to cross-protocol
- Adds `Runtime.GetIdentityMappingStore()` for SMB adapter access to the shared mapping table

## Test plan

- [x] Unit tests: `TestResolveIdentityMapping` covers NTLM domain, Kerberos, bare-username fallback, nil store, mapped-but-missing
- [x] `go build ./...` passes
- [x] `go test ./...` passes (no regressions)
- [ ] CI e2e pipeline (NFS + SMB + Kerberos)
- [ ] WPTS conformance regression check

Closes #324