### PR TITLE
fix(smb): wrap AP-REP with standard Kerberos OID for MIT interop (#335)

### DIFF
--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -15,12 +15,6 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// GSS-API krb5 mechanism token IDs per RFC 1964 Section 1.1.
-const (
-	gssTokenIDAPReq uint16 = 0x0100 // AP-REQ (context establishment)
-	gssTokenIDAPRep uint16 = 0x0200 // AP-REP (mutual authentication reply)
-)
-
 // apOptionsMutualRequired is the bit mask for mutual authentication in AP-Options.
 // Per RFC 4120, AP-Options bit 2 is MUTUAL-REQUIRED. In ASN.1 BIT STRING encoding
 // (MSB first), bit 2 maps to 0x20 in the first byte.
@@ -131,7 +125,7 @@ func (v *Krb5Verifier) VerifyToken(gssToken []byte) (*VerifiedContext, error) {
 			logger.Debug("Failed to build AP-REP (non-fatal)", "error", buildErr)
 		} else {
 			// NFS-specific: wrap raw AP-REP in GSS-API token (0x60 + OID + 0x0200)
-			apRepToken = wrapGSSToken(rawAPRep, gssTokenIDAPRep)
+			apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
 			logger.Debug("Built GSS-wrapped AP-REP token (mutual auth required)",
 				"raw_len", len(rawAPRep),
 				"wrapped_len", len(apRepToken),
@@ -218,59 +212,13 @@ func extractAPReq(token []byte) ([]byte, error) {
 	}
 
 	tokenID := (uint16(token[offset]) << 8) | uint16(token[offset+1])
-	if tokenID != gssTokenIDAPReq {
-		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (expected 0x%04x for AP-REQ)", tokenID, gssTokenIDAPReq)
+	if tokenID != kerbauth.GSSTokenIDAPReq {
+		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (expected 0x%04x for AP-REQ)", tokenID, kerbauth.GSSTokenIDAPReq)
 	}
 	offset += 2
 
 	// Everything after the token ID is the raw AP-REQ (ASN.1 APPLICATION 14)
 	return token[offset:], nil
-}
-
-// wrapGSSToken wraps a Kerberos message in a GSS-API MechToken.
-//
-// Format: 0x60 [ASN.1 length] [OID tag] [OID length] [OID bytes] [token ID] [inner token]
-//
-// The OID is 1.2.840.113554.1.2.2 (krb5 mechanism).
-// The token ID identifies the inner token type (0x0100 = AP-REQ, 0x0200 = AP-REP, etc.).
-func wrapGSSToken(innerToken []byte, tokenID uint16) []byte {
-	// KRB5 OID: 1.2.840.113554.1.2.2 = 06 09 2a 86 48 86 f7 12 01 02 02
-	krb5OID := []byte{0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02}
-
-	// Token ID (2 bytes, big-endian)
-	tokenIDBytes := []byte{byte(tokenID >> 8), byte(tokenID & 0xFF)}
-
-	// Inner content: OID + token ID + inner token
-	innerContent := make([]byte, 0, len(krb5OID)+len(tokenIDBytes)+len(innerToken))
-	innerContent = append(innerContent, krb5OID...)
-	innerContent = append(innerContent, tokenIDBytes...)
-	innerContent = append(innerContent, innerToken...)
-
-	// Encode the length in ASN.1 format
-	lengthBytes := encodeASN1Length(len(innerContent))
-
-	// Build final token: 0x60 [length] [content]
-	result := make([]byte, 0, 1+len(lengthBytes)+len(innerContent))
-	result = append(result, 0x60) // Application tag
-	result = append(result, lengthBytes...)
-	result = append(result, innerContent...)
-
-	return result
-}
-
-// encodeASN1Length encodes a length value in ASN.1 format.
-func encodeASN1Length(length int) []byte {
-	if length < 128 {
-		return []byte{byte(length)}
-	}
-
-	// Long form
-	var lengthBytes []byte
-	for length > 0 {
-		lengthBytes = append([]byte{byte(length & 0xFF)}, lengthBytes...)
-		length >>= 8
-	}
-	return append([]byte{byte(0x80 | len(lengthBytes))}, lengthBytes...)
 }
 
 // parseASN1Length parses an ASN.1 length field.

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -8,13 +8,10 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
 	pkgkerberos "github.com/marmos91/dittofs/pkg/auth/kerberos"
 )
-
-// gssKrb5TokenIDAPReq is the 2-byte token identifier for Kerberos AP-REQ
-// inside a GSS-API initial context token (RFC 1964 Section 1.1).
-const gssKrb5TokenIDAPReq = 0x0100
 
 // handleKerberosAuth handles Kerberos authentication via SPNEGO.
 // Validates the AP-REQ, normalizes the session key to 16 bytes for SMB3 KDF,
@@ -41,6 +38,7 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	// The SPNEGO MechToken is a GSS-API initial context token (RFC 2743
 	// Section 3.1) wrapping the Kerberos AP-REQ. KerberosService.Authenticate
 	// expects a raw AP-REQ, so we need to strip the GSS-API wrapper first.
+	logKrb5Dump("incoming mechToken", mechToken)
 	apReqBytes, err := extractAPReqFromGSSToken(mechToken)
 	if err != nil {
 		logger.Info("Failed to extract AP-REQ from GSS token", "error", err)
@@ -128,26 +126,37 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		"signingEnabled", sess.ShouldSign(),
 		"encryptData", sess.ShouldEncrypt())
 
-	// Build mutual auth AP-REP via shared service for SPNEGO accept-complete response.
-	// Use the ticket session key for AP-REP encryption per RFC 4120 (not the context
-	// key which may be the subkey). Clients decrypt AP-REP with the ticket session key.
-	//
-	// TODO(#335): the current AP-REP format is not accepted by MIT Kerberos
-	// clients (Samba, smbtorture, smbclient) — they report GSS_S_DEFECTIVE_TOKEN
-	// during gss_init_sec_context continuation. The server-side Kerberos auth
-	// itself works (AP-REQ verification, identity mapping, session creation,
-	// signing), but mutual auth verification on the client fails.
-	ticketSessionKey := authResult.APReq.Ticket.DecryptedEncPart.Key
-	apRepToken, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
-	if err != nil {
-		logger.Debug("Failed to build AP-REP for mutual auth", "error", err)
-		// Fall back to accept-complete without AP-REP (still functional).
-		apRepToken = nil
-	}
-
 	// Match the client's Kerberos OID in the SPNEGO response.
 	// Windows clients using the MS OID expect to see it echoed back.
 	responseOID := clientKerberosOID(parsedToken)
+
+	// Build mutual auth AP-REP and wrap it in a GSS-API InitialContextToken
+	// (RFC 2743 Section 3.1) for the SPNEGO accept-complete response:
+	//
+	//   0x60 [len] 0x06 <oid-len> <oid-bytes> 0x02 0x00 <AP-REP>
+	//
+	// AP-REP encryption uses the ticket session key per RFC 4120 (not the
+	// context subkey), which is what clients decrypt with.
+	//
+	// CRITICAL: the OID inside this wrapper must be the standard RFC 4121
+	// Kerberos V5 OID (1.2.840.113554.1.2.2), even when the client advertised
+	// the MS legacy OID (1.2.840.48018.1.2.2) in SPNEGO mechTypes. MIT's
+	// krb5_gss and Heimdal only recognize the standard OID internally, so
+	// echoing the MS OID here causes them to reject the token with
+	// GSS_S_DEFECTIVE_TOKEN (issue #335). Windows SSPI accepts both. The
+	// outer SPNEGO supportedMech (responseOID) still mirrors the client's
+	// choice for negTokenResp compatibility.
+	ticketSessionKey := authResult.APReq.Ticket.DecryptedEncPart.Key
+	rawAPRep, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
+	var apRepToken []byte
+	if err != nil {
+		logger.Debug("Failed to build AP-REP for mutual auth", "error", err)
+		// Fall back to accept-complete without AP-REP (still functional).
+	} else {
+		logKrb5Dump("raw AP-REP (pre-wrap)", rawAPRep)
+		apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
+		logKrb5Dump("wrapped AP-REP (GSS)", apRepToken)
+	}
 
 	// Handle SPNEGO mechListMIC for downgrade protection.
 	// If the client sent a mechListMIC, verify it.
@@ -278,8 +287,8 @@ func extractAPReqFromGSSToken(token []byte) ([]byte, error) {
 
 	// Token ID (RFC 1964 Section 1.1). Must be 0x0100 for AP-REQ.
 	tokenID := uint16(body[2+oidLen])<<8 | uint16(body[2+oidLen+1])
-	if tokenID != gssKrb5TokenIDAPReq {
-		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (want 0x%04x for AP-REQ)", tokenID, gssKrb5TokenIDAPReq)
+	if tokenID != kerbauth.GSSTokenIDAPReq {
+		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (want 0x%04x for AP-REQ)", tokenID, kerbauth.GSSTokenIDAPReq)
 	}
 
 	return body[apReqStart:], nil
@@ -333,4 +342,21 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 		return types.SMB2SessionFlagEncryptData
 	}
 	return 0
+}
+
+// logKrb5Dump emits a hex dump of a Kerberos-related byte blob at debug level.
+// Used when diagnosing interop issues with MIT clients — inspecting the exact
+// wire bytes is the fastest way to isolate framing bugs (see issue #335).
+// Safe to leave enabled: only fires under DEBUG and caps the hex to 512 bytes.
+func logKrb5Dump(label string, b []byte) {
+	const maxHex = 512
+	n := len(b)
+	if n > maxHex {
+		b = b[:maxHex]
+	}
+	logger.Debug("krb5 hex dump",
+		"label", label,
+		"len", n,
+		"hex", fmt.Sprintf("%x", b),
+	)
 }

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -349,6 +349,9 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 // wire bytes is the fastest way to isolate framing bugs (see issue #335).
 // Safe to leave enabled: only fires under DEBUG and caps the hex to 512 bytes.
 func logKrb5Dump(label string, b []byte) {
+	if !logger.IsDebugEnabled() {
+		return
+	}
 	const maxHex = 512
 	n := len(b)
 	if n > maxHex {

--- a/internal/adapter/smb/v2/handlers/kerberos_auth_test.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth_test.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/spnego"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 )
 
 // =============================================================================
@@ -124,6 +127,124 @@ func TestClientKerberosOID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := clientKerberosOID(tt.parsed); !got.Equal(tt.want) {
 				t.Errorf("clientKerberosOID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// SPNEGO ResponseToken framing — issue #335 regression lock-in
+// =============================================================================
+
+// TestSPNEGOResponseTokenWrapping proves the exact wire format handleKerberosAuth
+// sends back to MIT Kerberos clients. This is the regression guard for issue #335.
+//
+// There are TWO layers of OID selection and they are NOT the same:
+//
+//  1. SPNEGO NegTokenResp.supportedMech — echoes whichever OID the client
+//     advertised in mechTypes (clientKerberosOID picks MS if offered, for
+//     Windows/SSPI interop).
+//
+//  2. The OID inside the GSS-API InitialContextToken wrapper that contains
+//     the AP-REP — MUST always be the standard RFC 4121 OID
+//     (1.2.840.113554.1.2.2), regardless of what SPNEGO negotiated. MIT's
+//     krb5_gss and Heimdal only recognize this OID internally when parsing
+//     mech tokens; sending the MS OID here causes g_verify_token_header to
+//     reject the response with GSS_S_DEFECTIVE_TOKEN.
+//
+// Windows SSPI accepts the standard OID in both layers, so using it inside
+// the wrapper is the safe universal choice.
+func TestSPNEGOResponseTokenWrapping(t *testing.T) {
+	// Fake raw AP-REP — shape doesn't matter, we assert byte equality.
+	// Using the real 0x6F APPLICATION 15 tag to mimic gokrb5's output.
+	rawAPRep := append([]byte{0x6F, 0x1F}, bytes.Repeat([]byte{0xA5}, 31)...)
+
+	// Both the StandardOnly and MSPreferred cases must wrap the AP-REP with
+	// the standard Kerberos V5 OID inside the GSS envelope. Only the outer
+	// SPNEGO supportedMech differs.
+	cases := []struct {
+		name             string
+		spnegoOuterOID   asn1.ObjectIdentifier
+		wantInnerOIDFull []byte // always standard; this is the invariant
+	}{
+		{
+			name:             "ClientAdvertisedStandardOnly",
+			spnegoOuterOID:   auth.OIDKerberosV5,
+			wantInnerOIDFull: kerbauth.KerberosV5OIDBytes,
+		},
+		{
+			name:             "ClientAdvertisedMSLegacy",
+			spnegoOuterOID:   auth.OIDMSKerberosV5,
+			wantInnerOIDFull: kerbauth.KerberosV5OIDBytes, // still standard inside!
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Replicate handleKerberosAuth's AP-REP wrapping step verbatim:
+			// the inner OID is hardcoded to the standard Kerberos V5 OID so
+			// MIT-based clients accept the token.
+			wrapped := kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
+
+			// The outer SPNEGO layer still echoes whichever OID the client
+			// preferred, via clientKerberosOID.
+			spnegoBytes, err := auth.BuildAcceptCompleteWithMIC(tc.spnegoOuterOID, wrapped, nil)
+			if err != nil {
+				t.Fatalf("BuildAcceptCompleteWithMIC: %v", err)
+			}
+
+			var resp spnego.NegTokenResp
+			if err := resp.Unmarshal(spnegoBytes); err != nil {
+				t.Fatalf("parse NegTokenResp: %v", err)
+			}
+			if !resp.SupportedMech.Equal(tc.spnegoOuterOID) {
+				t.Fatalf("outer supportedMech = %v, want %v (outer layer must echo client preference)",
+					resp.SupportedMech, tc.spnegoOuterOID)
+			}
+
+			// --- ResponseToken framing assertions -----------------------------
+
+			rt := resp.ResponseToken
+			if len(rt) == 0 {
+				t.Fatal("ResponseToken is empty — AP-REP was not included")
+			}
+			if rt[0] != 0x60 {
+				t.Fatalf("ResponseToken[0] = 0x%02x, want 0x60 (GSS-API InitialContextToken tag — issue #335)", rt[0])
+			}
+
+			// Short form length (wrapped is well under 128 bytes).
+			declaredLen := int(rt[1])
+			if 2+declaredLen != len(rt) {
+				t.Fatalf("length mismatch: declared %d, actual body %d", declaredLen, len(rt)-2)
+			}
+
+			// OID block: 0x06 <len> <value>
+			if rt[2] != 0x06 {
+				t.Fatalf("inner OID tag = 0x%02x, want 0x06", rt[2])
+			}
+			innerOIDLen := int(rt[3])
+			innerOIDFull := rt[2 : 2+2+innerOIDLen] // tag+length+value
+			if !bytes.Equal(innerOIDFull, tc.wantInnerOIDFull) {
+				t.Fatalf("inner GSS OID must always be standard Kerberos V5 (issue #335)\n  got:  % x\n  want: % x",
+					innerOIDFull, tc.wantInnerOIDFull)
+			}
+			// Sanity check: byte at offset 7 inside the OID distinguishes
+			// standard (0x86) from MS (0x82). Must be 0x86.
+			if rt[2+5] != 0x86 {
+				t.Fatalf("inner OID family marker = 0x%02x, want 0x86 (standard Kerberos V5). "+
+					"0x82 would indicate the MS OID leaked into the inner wrapper — MIT will reject.", rt[2+5])
+			}
+
+			// Token ID (2 bytes, big-endian 0x0200 for AP-REP).
+			tokIDOff := 2 + 2 + innerOIDLen
+			if rt[tokIDOff] != 0x02 || rt[tokIDOff+1] != 0x00 {
+				t.Fatalf("tokenID = 0x%02x%02x, want 0x0200 (AP-REP)", rt[tokIDOff], rt[tokIDOff+1])
+			}
+
+			// Body: must be the exact raw AP-REP we passed in.
+			body := rt[tokIDOff+2:]
+			if !bytes.Equal(body, rawAPRep) {
+				t.Fatalf("embedded AP-REP mismatch\n  got:  % x\n  want: % x", body, rawAPRep)
 			}
 		})
 	}

--- a/internal/adapter/smb/v2/handlers/kerberos_auth_test.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth_test.go
@@ -228,8 +228,8 @@ func TestSPNEGOResponseTokenWrapping(t *testing.T) {
 				t.Fatalf("inner GSS OID must always be standard Kerberos V5 (issue #335)\n  got:  % x\n  want: % x",
 					innerOIDFull, tc.wantInnerOIDFull)
 			}
-			// Sanity check: byte at offset 7 inside the OID distinguishes
-			// standard (0x86) from MS (0x82). Must be 0x86.
+			// Sanity check: OID DER index 5 (wrapped offset 2+5=7) is 0x86
+			// for standard and 0x82 for MS. Must be 0x86.
 			if rt[2+5] != 0x86 {
 				t.Fatalf("inner OID family marker = 0x%02x, want 0x86 (standard Kerberos V5). "+
 					"0x82 would indicate the MS OID leaked into the inner wrapper — MIT will reject.", rt[2+5])

--- a/internal/auth/kerberos/gsswrap.go
+++ b/internal/auth/kerberos/gsswrap.go
@@ -1,0 +1,90 @@
+package kerberos
+
+// GSS-API initial context token framing helpers.
+//
+// Both the NFS RPCSEC_GSS path and the SMB SPNEGO path need to hand MIT
+// Kerberos clients a Kerberos protocol message wrapped in the RFC 2743
+// Section 3.1 InitialContextToken envelope:
+//
+//	0x60 [ASN.1 length] [OID tag] [OID length] [OID bytes] [tokenID] [inner]
+//
+// MIT's krb5_gss_init_sec_context (and gss_accept_sec_context) calls
+// g_verify_token_header on the received context token, which requires this
+// wrapper for both initial and subsequent context tokens — despite RFC 4121
+// Section 4.1 suggesting subsequent tokens may skip the [APPLICATION 0]
+// wrapper. Empirically, MIT clients reject bare "tokenID || message" bytes
+// with GSS_S_DEFECTIVE_TOKEN (see issue #335), so every GSS-API context
+// token we emit goes through this wrapper.
+
+// Token identifiers for Kerberos context establishment tokens
+// (RFC 4121 Section 4.1, expressed in big-endian order).
+const (
+	// GSSTokenIDAPReq is the 2-byte token identifier for KRB_AP_REQ.
+	GSSTokenIDAPReq uint16 = 0x0100
+
+	// GSSTokenIDAPRep is the 2-byte token identifier for KRB_AP_REP.
+	GSSTokenIDAPRep uint16 = 0x0200
+
+	// GSSTokenIDKRBError is the 2-byte token identifier for KRB_ERROR.
+	GSSTokenIDKRBError uint16 = 0x0300
+)
+
+// Pre-encoded DER OID bytes (tag 0x06 + length + value) for the Kerberos V5
+// mechanism OIDs. Callers pick the one that matches the mechanism negotiated
+// at the outer layer (SPNEGO supportedMech, RPCSEC_GSS mechanism).
+var (
+	// KerberosV5OIDBytes is the DER-encoded OID 1.2.840.113554.1.2.2
+	// (standard Kerberos V5 mechanism, RFC 4121).
+	KerberosV5OIDBytes = []byte{
+		0x06, 0x09,
+		0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02,
+	}
+
+	// MSKerberosV5OIDBytes is the DER-encoded OID 1.2.840.48018.1.2.2
+	// (Microsoft Kerberos V5 mechanism). Echoed back when a Windows / SSPI
+	// client advertises this OID in SPNEGO negotiation.
+	MSKerberosV5OIDBytes = []byte{
+		0x06, 0x09,
+		0x2a, 0x86, 0x48, 0x82, 0xf7, 0x12, 0x01, 0x02, 0x02,
+	}
+)
+
+// WrapGSSToken wraps a Kerberos message (e.g. AP-REQ, AP-REP, KRB-ERROR) in a
+// GSS-API InitialContextToken envelope per RFC 2743 Section 3.1.
+//
+// oidBytes must be the full DER encoding of the mechanism OID including the
+// 0x06 tag and length prefix (see KerberosV5OIDBytes / MSKerberosV5OIDBytes).
+// tokenID is the 2-byte Kerberos token identifier (GSSTokenIDAPReq / APRep /
+// KRBError). innerToken is the already-encoded Kerberos message.
+func WrapGSSToken(innerToken []byte, oidBytes []byte, tokenID uint16) []byte {
+	innerLen := len(oidBytes) + 2 + len(innerToken) // +2 for tokenID
+	lengthBytes := encodeASN1Length(innerLen)
+
+	result := make([]byte, 0, 1+len(lengthBytes)+innerLen)
+	result = append(result, 0x60) // [APPLICATION 0] IMPLICIT SEQUENCE
+	result = append(result, lengthBytes...)
+	result = append(result, oidBytes...)
+	result = append(result, byte(tokenID>>8), byte(tokenID))
+	result = append(result, innerToken...)
+	return result
+}
+
+// encodeASN1Length encodes a non-negative length value in ASN.1 BER/DER form.
+// Uses short form for lengths < 128, long form otherwise.
+func encodeASN1Length(length int) []byte {
+	if length < 128 {
+		return []byte{byte(length)}
+	}
+	// Long form: count significant bytes, then emit big-endian.
+	n := 0
+	for v := length; v > 0; v >>= 8 {
+		n++
+	}
+	out := make([]byte, 1+n)
+	out[0] = 0x80 | byte(n)
+	for i := n; i > 0; i-- {
+		out[i] = byte(length)
+		length >>= 8
+	}
+	return out
+}

--- a/internal/auth/kerberos/gsswrap_test.go
+++ b/internal/auth/kerberos/gsswrap_test.go
@@ -65,11 +65,10 @@ func TestWrapGSSToken_MSOID(t *testing.T) {
 	if !bytes.Equal(wrapped[2:2+len(MSKerberosV5OIDBytes)], MSKerberosV5OIDBytes) {
 		t.Fatalf("MS OID not echoed: got % x", wrapped[2:2+len(MSKerberosV5OIDBytes)])
 	}
-	// Byte offset 4 in the MS OID DER (0x82) must distinguish it from the
-	// standard OID (which has 0x86 at the same position). Guards against
-	// accidentally swapping the two constants.
+	// DER index 5 within the OID (wrapped offset 2+5=7) is 0x82 for the MS
+	// OID and 0x86 for the standard OID. Guards against swapping the constants.
 	if wrapped[2+5] != 0x82 {
-		t.Fatalf("expected MS OID marker 0x82 at offset 7, got 0x%02x", wrapped[2+5])
+		t.Fatalf("expected MS OID marker 0x82 at wrapped offset 7 (OID DER index 5), got 0x%02x", wrapped[2+5])
 	}
 }
 

--- a/internal/auth/kerberos/gsswrap_test.go
+++ b/internal/auth/kerberos/gsswrap_test.go
@@ -1,0 +1,142 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestWrapGSSToken_ShortForm verifies the wrapper produces a correct
+// RFC 2743 Section 3.1 InitialContextToken envelope with short-form length.
+func TestWrapGSSToken_ShortForm(t *testing.T) {
+	inner := []byte{0x6F, 0x05, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE} // fake AP-REP
+	wrapped := WrapGSSToken(inner, KerberosV5OIDBytes, GSSTokenIDAPRep)
+
+	// Expected layout (short form length):
+	//   0x60 <len> 0x06 0x09 <9-byte OID> 0x02 0x00 <inner 7 bytes>
+	// totalInner = 11 (OID) + 2 (tokID) + 7 (inner) = 20 bytes
+	want := []byte{
+		0x60, 0x14,
+		0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02,
+		0x02, 0x00,
+		0x6F, 0x05, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE,
+	}
+	if !bytes.Equal(wrapped, want) {
+		t.Fatalf("short-form wrap mismatch\n  got:  % x\n  want: % x", wrapped, want)
+	}
+}
+
+// TestWrapGSSToken_LongForm verifies long-form ASN.1 length encoding for
+// inner tokens larger than 127 bytes (common for real AP-REPs with AES keys).
+func TestWrapGSSToken_LongForm(t *testing.T) {
+	inner := bytes.Repeat([]byte{0xAB}, 200)
+	wrapped := WrapGSSToken(inner, KerberosV5OIDBytes, GSSTokenIDAPRep)
+
+	if wrapped[0] != 0x60 {
+		t.Fatalf("outer tag: got 0x%02x, want 0x60", wrapped[0])
+	}
+	// Inner content = 11 (OID DER) + 2 (tokID) + 200 (body) = 213 bytes
+	// Long form: 0x81 0xD5
+	if wrapped[1] != 0x81 {
+		t.Fatalf("length form byte: got 0x%02x, want 0x81 (long form, 1 length octet)", wrapped[1])
+	}
+	if wrapped[2] != 0xD5 {
+		t.Fatalf("length value: got 0x%02x, want 0xD5 (213)", wrapped[2])
+	}
+
+	// OID block starts at offset 3, token ID at offset 3+11=14, body at 16.
+	if !bytes.Equal(wrapped[3:14], KerberosV5OIDBytes) {
+		t.Fatalf("OID mismatch: got % x", wrapped[3:14])
+	}
+	if !bytes.Equal(wrapped[14:16], []byte{0x02, 0x00}) {
+		t.Fatalf("tokenID: got % x, want 02 00", wrapped[14:16])
+	}
+	if !bytes.Equal(wrapped[16:], inner) {
+		t.Fatalf("inner body mismatch")
+	}
+}
+
+// TestWrapGSSToken_MSOID ensures the Microsoft Kerberos V5 OID is emitted
+// unchanged (this is what Windows / SSPI clients advertise in SPNEGO).
+func TestWrapGSSToken_MSOID(t *testing.T) {
+	inner := []byte{0x00}
+	wrapped := WrapGSSToken(inner, MSKerberosV5OIDBytes, GSSTokenIDAPReq)
+
+	// OID block starts at offset 2 (short-form length).
+	if !bytes.Equal(wrapped[2:2+len(MSKerberosV5OIDBytes)], MSKerberosV5OIDBytes) {
+		t.Fatalf("MS OID not echoed: got % x", wrapped[2:2+len(MSKerberosV5OIDBytes)])
+	}
+	// Byte offset 4 in the MS OID DER (0x82) must distinguish it from the
+	// standard OID (which has 0x86 at the same position). Guards against
+	// accidentally swapping the two constants.
+	if wrapped[2+5] != 0x82 {
+		t.Fatalf("expected MS OID marker 0x82 at offset 7, got 0x%02x", wrapped[2+5])
+	}
+}
+
+// TestWrapGSSToken_TokenIDs verifies all three valid Kerberos token IDs
+// are encoded big-endian as RFC 4121 Section 4.1 requires.
+func TestWrapGSSToken_TokenIDs(t *testing.T) {
+	cases := []struct {
+		name string
+		id   uint16
+		want []byte
+	}{
+		{"AP-REQ", GSSTokenIDAPReq, []byte{0x01, 0x00}},
+		{"AP-REP", GSSTokenIDAPRep, []byte{0x02, 0x00}},
+		{"KRB-ERROR", GSSTokenIDKRBError, []byte{0x03, 0x00}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := WrapGSSToken([]byte{0xFF}, KerberosV5OIDBytes, tc.id)
+			// tokenID sits right after the 11-byte OID DER (offset 2+11=13).
+			got := wrapped[13:15]
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("tokenID for %s: got % x, want % x", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapGSSToken_RoundTripThroughExtractor proves NFS's existing AP-REQ
+// extractor can parse a token we wrap with GSSTokenIDAPReq. This locks in
+// the contract that WrapGSSToken is inverse of parseGSSInitialContextToken.
+func TestWrapGSSToken_RoundTripThroughExtractor(t *testing.T) {
+	inner := []byte("fake-ap-req-body")
+	wrapped := WrapGSSToken(inner, KerberosV5OIDBytes, GSSTokenIDAPReq)
+
+	// Mini parser mirroring NFS framework.go / SMB extractAPReqFromGSSToken.
+	if wrapped[0] != 0x60 {
+		t.Fatalf("outer tag 0x%02x", wrapped[0])
+	}
+	n := int(wrapped[1]) // short form (inner < 128)
+	body := wrapped[2 : 2+n]
+	if body[0] != 0x06 {
+		t.Fatalf("inner OID tag 0x%02x", body[0])
+	}
+	oidLen := int(body[1])
+	bodyInner := body[2+oidLen+2:] // skip OID tag+len+value + 2-byte tokID
+	if !bytes.Equal(bodyInner, inner) {
+		t.Fatalf("extracted inner mismatch\n  got:  % x\n  want: % x", bodyInner, inner)
+	}
+}
+
+func TestEncodeASN1Length(t *testing.T) {
+	cases := []struct {
+		in   int
+		want []byte
+	}{
+		{0, []byte{0x00}},
+		{127, []byte{0x7F}},
+		{128, []byte{0x81, 0x80}},
+		{255, []byte{0x81, 0xFF}},
+		{256, []byte{0x82, 0x01, 0x00}},
+		{65535, []byte{0x82, 0xFF, 0xFF}},
+		{65536, []byte{0x83, 0x01, 0x00, 0x00}},
+	}
+	for _, tc := range cases {
+		got := encodeASN1Length(tc.in)
+		if !bytes.Equal(got, tc.want) {
+			t.Errorf("encodeASN1Length(%d) = % x, want % x", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -1,9 +1,14 @@
 package kerberos
 
 import (
-	"encoding/asn1"
 	"fmt"
 
+	// gokrb5 uses gofork's asn1 package, not the Go stdlib, because stdlib's
+	// encoding/asn1 has known bugs with Kerberos types (GeneralizedTime
+	// fractional-second handling, optional field tagging). Marshalling gokrb5
+	// structs with stdlib asn1 produces DER bytes that MIT Kerberos clients
+	// reject as malformed. See issue #335.
+	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
 	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/messages"

--- a/test/smb-conformance/docker-compose.yml
+++ b/test/smb-conformance/docker-compose.yml
@@ -103,6 +103,11 @@ services:
     network_mode: "service:dittofs"
     environment:
       - KRB5_CONFIG=/keytabs/krb5.conf
+      # KRB5_TRACE=/dev/stderr surfaces MIT's internal Kerberos state machine
+      # (AS/TGS exchanges, AP-REQ construction, AP-REP verification) into the
+      # smbtorture container stdout. Essential for debugging mutual-auth
+      # rejections — without it gss_init_sec_context failures look opaque.
+      - KRB5_TRACE=/dev/stderr
     volumes:
       - kdc-keytabs:/keytabs:ro
     entrypoint: ["smbtorture"]


### PR DESCRIPTION
## Summary

Fixes #335 — SMB Kerberos clients based on MIT (Samba `smbtorture`, `smbclient`) were rejecting the server's AP-REP during `gss_init_sec_context` mutual-auth continuation with `GSS_S_DEFECTIVE_TOKEN`, causing all Kerberos session setups to fail.

Two bugs in the response token:

1. **Missing GSS-API envelope.** `handleKerberosAuth` was placing the raw `0x6F`-tagged AP-REP directly into SPNEGO's `ResponseToken`. MIT's `g_verify_token_header` requires the full RFC 2743 §3.1 `InitialContextToken` wrapper even on subsequent context tokens:

   ```
   0x60 [len] 0x06 <oid-len> <oid-bytes> 0x02 0x00 <AP-REP>
   ```

2. **Wrong OID inside the wrapper.** When the client advertised the Microsoft legacy Kerberos V5 OID (`1.2.840.48018.1.2.2`) in SPNEGO `mechTypes`, we echoed it back inside the GSS envelope too. MIT's `krb5_gss` and Heimdal only recognize the standard RFC 4121 OID (`1.2.840.113554.1.2.2`) internally — the MS OID is a SPNEGO negotiation-layer concept only. The outer SPNEGO `supportedMech` still mirrors the client's preference for Windows/SSPI compatibility; the inner GSS wrapper is now always standard.

## Changes

- **New** `internal/auth/kerberos/gsswrap.go` — shared `WrapGSSToken`, pre-encoded OID constants (`KerberosV5OIDBytes`, `MSKerberosV5OIDBytes`), token-ID constants.
- **Migrate** `internal/adapter/nfs/rpc/gss/framework.go` from its local copy of the wrapper to the shared helper. Net −56 lines.
- **Switch** `internal/auth/kerberos/service.go` from stdlib `encoding/asn1` to `github.com/jcmturner/gofork/encoding/asn1`. gokrb5 uses the fork because stdlib has known bugs with Kerberos ASN.1 types — marshalling gokrb5 structs with stdlib is a latent bug waiting to bite the next interop issue.
- **Fix** `internal/adapter/smb/v2/handlers/kerberos_auth.go` — wrap AP-REP via `kerbauth.WrapGSSToken` with the **standard** Kerberos OID always, keep `logKrb5Dump` as permanent diagnostic infra.
- **Enable** `KRB5_TRACE=/dev/stderr` on the `smbtorture-kerberos` docker-compose service for future GSS debugging.

## Why NFS didn't hit this

NFS's RPCSEC_GSS mutual-auth path was already calling the equivalent of `WrapGSSToken` (just as a local private function). It already hardcoded the standard OID because RPCSEC_GSS has no MS OID story. The bug was SMB-specific because of the SPNEGO OID echo logic.

## Regression test

`TestSPNEGOResponseTokenWrapping` in `kerberos_auth_test.go` encodes the two-layer OID invariant:

- Outer SPNEGO `supportedMech` mirrors client preference (standard or MS).
- Inner GSS wrapper OID is **always** the standard RFC 4121 OID, with a byte-level assertion on offset 7 (`0x86` standard vs `0x82` MS) to catch anyone ever swapping them back.

Plus 5 unit tests on `WrapGSSToken` itself (short/long form DER, both OIDs, all three token IDs, round-trip through NFS's extractor).

## E2E validation

```
./test/smb-conformance/smbtorture/run.sh --kerberos --filter smb2.connect --verbose
```

**`smb2.connect --kerberos` PASSES** against MIT via Samba smbtorture. Pre-fix, zero Kerberos session setups completed at all.

Broader `smb2.session` suite results with this fix: **6 pass / 46 fail / 19 skip** (up from 0/0/0). The remaining failures are a mix of:
- **5 genuine Kerberos-specific bugs** (ticket expiration handling, reauth key re-init, disconnected-session error code) — filed as separate follow-up issues.
- **~40 pre-existing NTLM gaps** (SMB3 session bind, AES-256 encryption, anonymous auth) that should be promoted to a Kerberos `KNOWN_FAILURES.md` bucket.

## Test plan

- [x] `go test ./internal/auth/kerberos/...` (new helper + tests)
- [x] `go test ./internal/adapter/nfs/rpc/gss/...` (migration preserves behavior)
- [x] `go test ./internal/adapter/smb/v2/handlers/...` (regression test)
- [x] `go test ./...` (full suite, no unrelated regressions)
- [x] `go vet ./...`
- [x] E2E: `./run.sh --kerberos --filter smb2.connect --verbose` → PASS
- [ ] CI: smbtorture-kerberos job (currently `continue-on-error: true` from #336 — will flip to strict in a follow-up once the Kerberos `KNOWN_FAILURES.md` bucket lands)

## Follow-up issues filed

- NFS Kerberos integration test broken on `develop` (pre-existing `decodeOpaqueToken` contract mismatch)
- NFS Kerberos: no real-client (`sec=krb5` kernel mount) coverage — structural blindspot that would have caught this bug in NFS too
- SMB Kerberos: classify the 46 `smb2.session` failures into a `KNOWN_FAILURES_KERBEROS.md` bucket and fix the ~5 genuine bugs (expire*, reauth4/5, reconnect1/2)