### PR TITLE
feat: Linux native packages and curl install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Install Linux packaging tools
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev createrepo-c
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -49,6 +52,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+
+      - name: Publish Linux repositories
+        if: success()
+        run: ./scripts/publish-linux-repos.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Upload packages to S3
+        if: success()
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          for ext in deb rpm pkg.tar.zst; do
+            for f in dist/*."${ext}"; do
+              [ -f "$f" ] || continue
+              aws s3 cp "$f" "s3://${S3_BUCKET:-dittofs-binaries}/${VERSION}/$(basename "$f")" \
+                --endpoint-url "${S3_ENDPOINT:-https://s3.cubbit.eu}" \
+                --acl public-read
+            done
+          done
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   operator:
     name: Build Operator Image

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -347,7 +347,7 @@ release:
 
     **Quick install (macOS / Linux):**
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+    curl -fsSL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/install.sh | sh
     ```
 
     **Homebrew (macOS/Linux):**

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -122,6 +122,39 @@ archives:
       - README.md
       - LICENSE
 
+# Native Linux packages (deb, rpm, archlinux)
+nfpms:
+  - id: dfs
+    ids: [dfs]
+    package_name: dfs
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: Marco Moschettini
+    homepage: https://github.com/marmos91/dittofs
+    maintainer: Marco Moschettini <marco@marmos91.dev>
+    description: DittoFS server daemon — modular virtual filesystem with pluggable storage backends
+    license: MIT
+    formats: [deb, rpm, archlinux]
+    bindir: /usr/local/bin
+    contents:
+      - src: packaging/dfs.service
+        dst: /usr/lib/systemd/system/dfs.service
+    scripts:
+      postinstall: packaging/postinstall.sh
+      preremove: packaging/preremove.sh
+      postremove: packaging/postremove.sh
+
+  - id: dfsctl
+    ids: [dfsctl]
+    package_name: dfsctl
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: Marco Moschettini
+    homepage: https://github.com/marmos91/dittofs
+    maintainer: Marco Moschettini <marco@marmos91.dev>
+    description: DittoFS CLI client — remote management for DittoFS servers
+    license: MIT
+    formats: [deb, rpm, archlinux]
+    bindir: /usr/local/bin
+
 checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
@@ -312,11 +345,37 @@ release:
 
     ### Installation
 
+    **Quick install (macOS / Linux):**
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+    ```
+
     **Homebrew (macOS/Linux):**
     ```bash
     brew tap marmos91/tap
     brew install marmos91/tap/dfs      # Server daemon
     brew install marmos91/tap/dfsctl   # Client CLI
+    ```
+
+    **Debian/Ubuntu (APT):**
+    ```bash
+    echo "deb https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
+    sudo apt update && sudo apt install dfs
+    sudo systemctl enable --now dfs
+    ```
+
+    **RHEL/Fedora (YUM):**
+    ```bash
+    sudo curl -fsSLo /etc/yum.repos.d/dfs.repo https://s3.cubbit.eu/dittofs-binaries/rpm/dfs.repo
+    sudo yum install dfs
+    sudo systemctl enable --now dfs
+    ```
+
+    **Arch Linux:**
+    ```bash
+    curl -fsSLO https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_amd64.pkg.tar.zst
+    sudo pacman -U dfs_{{ .Version }}_amd64.pkg.tar.zst
+    sudo systemctl enable --now dfs
     ```
 
     **Scoop (Windows):**
@@ -326,47 +385,8 @@ release:
     scoop install dfsctl    # Client CLI
     ```
 
-    **Binary Download:**
-    ```bash
-    # dfs (server daemon)
-    # Linux (x86_64)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
-
-    # macOS (Apple Silicon)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
-
-    # macOS (Intel)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
-
-    # Windows (x86_64)
-    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Windows_x86_64.zip" -OutFile dfs.zip; Expand-Archive dfs.zip -DestinationPath .; Remove-Item dfs.zip
-
-    # Windows (arm64)
-    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Windows_arm64.zip" -OutFile dfs.zip; Expand-Archive dfs.zip -DestinationPath .; Remove-Item dfs.zip
-
-    # dfsctl (client CLI)
-    # Linux (x86_64)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
-
-    # macOS (Apple Silicon)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
-
-    # macOS (Intel)
-    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
-
-    # Windows (x86_64)
-    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Windows_x86_64.zip" -OutFile dfsctl.zip; Expand-Archive dfsctl.zip -DestinationPath .; Remove-Item dfsctl.zip
-
-    # Windows (arm64)
-    Invoke-WebRequest -Uri "https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Windows_arm64.zip" -OutFile dfsctl.zip; Expand-Archive dfsctl.zip -DestinationPath .; Remove-Item dfsctl.zip
-    ```
-
     **Docker:**
     ```bash
-    # Pull the latest image
-    docker pull marmos91c/dittofs:{{ .Tag }}
-
-    # Run with a config file
     docker run -d \
       -p 12049:12049 \
       -p 12445:12445 \
@@ -375,6 +395,17 @@ release:
       -v dittofs-data:/data \
       marmos91c/dittofs:{{ .Tag }}
     ```
+
+    **Binary Download:**
+    ```bash
+    # dfs (server daemon)
+    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfs_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
+
+    # dfsctl (client CLI)
+    curl -sfL https://github.com/marmos91/dittofs/releases/download/{{ .Tag }}/dfsctl_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
+    ```
+  extra_files:
+    - glob: scripts/install.sh
 
   footer: |
     ---

--- a/README.md
+++ b/README.md
@@ -70,12 +70,62 @@ dfs init && dfs start
 nix develop github:marmos91/dittofs
 ```
 
+#### Quick Install (macOS / Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+```
+
 #### Using Homebrew
 
 ```bash
 brew tap marmos91/tap
 brew install marmos91/tap/dfs      # Server daemon
 brew install marmos91/tap/dfsctl   # Client CLI
+```
+
+#### Debian / Ubuntu (APT)
+
+```bash
+echo "deb https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
+sudo apt update && sudo apt install dfs
+sudo systemctl enable --now dfs
+```
+
+#### RHEL / Fedora (YUM)
+
+```bash
+sudo curl -fsSLo /etc/yum.repos.d/dfs.repo https://s3.cubbit.eu/dittofs-binaries/rpm/dfs.repo
+sudo yum install dfs
+sudo systemctl enable --now dfs
+```
+
+#### Arch Linux
+
+```bash
+# Download the latest .pkg.tar.zst from GitHub Releases
+sudo pacman -U dfs_<version>_amd64.pkg.tar.zst
+sudo systemctl enable --now dfs
+```
+
+#### Docker
+
+```bash
+docker run -d \
+  -p 12049:12049 \
+  -p 12445:12445 \
+  -p 8080:8080 \
+  -v /path/to/config.yaml:/config/config.yaml:ro \
+  -v dittofs-data:/data \
+  marmos91c/dittofs:latest
+```
+
+#### Scoop (Windows)
+
+```powershell
+scoop bucket add marmos91 https://github.com/marmos91/scoop-bucket
+scoop install dfs       # Server daemon
+scoop install dfsctl    # Client CLI
 ```
 
 #### Build from Source

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ nix develop github:marmos91/dittofs
 #### Quick Install (macOS / Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+curl -fsSL https://github.com/marmos91/dittofs/releases/latest/download/install.sh | sh
 ```
 
 #### Using Homebrew

--- a/packaging/dfs.service
+++ b/packaging/dfs.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=DittoFS - Modular Virtual Filesystem
+Documentation=https://github.com/marmos91/dittofs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/dfs start --foreground
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  systemctl daemon-reload
+fi

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  systemctl daemon-reload
+fi

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+  exit 0
+fi
+
+# Skip on upgrade (deb passes "upgrade", rpm passes $1=1)
+case "${1:-}" in
+  upgrade|1) exit 0 ;;
+esac
+
+if systemctl is-active --quiet dfs 2>/dev/null; then
+  systemctl stop dfs || true
+fi
+if systemctl is-enabled --quiet dfs 2>/dev/null; then
+  systemctl disable dfs || true
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Install DittoFS (dfs + dfsctl) binaries
-# Usage: curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+# Usage: curl -fsSL https://github.com/marmos91/dittofs/releases/latest/download/install.sh | sh
 set -e
 
 REPO="marmos91/dittofs"
@@ -37,10 +37,11 @@ case "$OS" in
   windows) ARCHIVE_OS="Windows" ;;
 esac
 
-# Get latest version from GitHub API
+# Get latest version via GitHub redirect (avoids API rate limits)
 echo "Detecting latest version..."
-VERSION=$(curl -sfL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-if [ -z "$VERSION" ]; then
+LATEST_URL=$(curl -fsSI "https://github.com/${REPO}/releases/latest" 2>/dev/null | tr -d '\r' | awk 'BEGIN { IGNORECASE = 1 } /^location: / { print $2 }' | tail -n 1)
+VERSION=$(printf '%s\n' "$LATEST_URL" | sed -E 's#.*/tag/([^/?]+).*#\1#')
+if [ -z "$VERSION" ] || [ "$VERSION" = "$LATEST_URL" ]; then
   echo "Error: could not determine latest version"
   exit 1
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Install DittoFS (dfs + dfsctl) binaries
+# Usage: curl -fsSL https://raw.githubusercontent.com/marmos91/dittofs/develop/scripts/install.sh | sh
+set -e
+
+REPO="marmos91/dittofs"
+INSTALL_DIR="/usr/local/bin"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  darwin|linux) ;;
+  mingw*|msys*|cygwin*) OS="windows" ;;
+  *) echo "Error: unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  armv7*) ARCH="armv7" ;;
+  *) echo "Error: unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Map arch for archive name template (goreleaser uses x86_64/arm64/armv7)
+case "$ARCH" in
+  amd64) ARCHIVE_ARCH="x86_64" ;;
+  arm64) ARCHIVE_ARCH="arm64" ;;
+  armv7) ARCHIVE_ARCH="armv7" ;;
+esac
+
+# Map OS for archive name template (goreleaser uses title case)
+case "$OS" in
+  linux) ARCHIVE_OS="Linux" ;;
+  darwin) ARCHIVE_OS="Darwin" ;;
+  windows) ARCHIVE_OS="Windows" ;;
+esac
+
+# Get latest version from GitHub API
+echo "Detecting latest version..."
+VERSION=$(curl -sfL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+if [ -z "$VERSION" ]; then
+  echo "Error: could not determine latest version"
+  exit 1
+fi
+VERSION_NUM="${VERSION#v}"
+
+echo "Installing DittoFS $VERSION for $OS/$ARCH..."
+
+# Suggest native packages on supported Linux distros
+if [ "$OS" = "linux" ]; then
+  PKG_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+  if command -v dpkg >/dev/null 2>&1; then
+    PKG_FILE="dfs_${VERSION_NUM}_${ARCH}.deb"
+    PKG_INSTALL="sudo dpkg -i ${PKG_FILE}"
+  elif command -v rpm >/dev/null 2>&1; then
+    PKG_FILE="dfs_${VERSION_NUM}_${ARCH}.rpm"
+    PKG_INSTALL="sudo rpm -i ${PKG_FILE}"
+  elif command -v pacman >/dev/null 2>&1; then
+    PKG_FILE="dfs_${VERSION_NUM}_${ARCH}.pkg.tar.zst"
+    PKG_INSTALL="sudo pacman -U ${PKG_FILE}"
+  fi
+  if [ -n "${PKG_FILE:-}" ]; then
+    echo ""
+    echo "Tip: native package available (includes systemd service). Install with:"
+    echo "  curl -fsSLO ${PKG_URL}/${PKG_FILE}"
+    echo "  ${PKG_INSTALL}"
+    echo ""
+    echo "Continuing with binary install..."
+  fi
+fi
+
+# Determine archive format
+if [ "$OS" = "windows" ]; then
+  EXT="zip"
+else
+  EXT="tar.gz"
+fi
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Download checksums first
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
+echo "Downloading checksums..."
+curl -sfL -o "$TMP_DIR/checksums.txt" "$CHECKSUMS_URL" || { echo "Error: checksums download failed"; exit 1; }
+
+# Install both dfs and dfsctl
+for BINARY in dfs dfsctl; do
+  ARCHIVE="${BINARY}_${VERSION_NUM}_${ARCHIVE_OS}_${ARCHIVE_ARCH}.${EXT}"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+
+  echo "Downloading ${BINARY}..."
+  curl -sfL -o "$TMP_DIR/$ARCHIVE" "$URL" || { echo "Error: download failed for ${BINARY}"; exit 1; }
+
+  # Verify checksum
+  echo "Verifying checksum for ${BINARY}..."
+  EXPECTED=$(awk -v f="$ARCHIVE" '$2 == f {print $1}' "$TMP_DIR/checksums.txt")
+  if [ -z "$EXPECTED" ]; then
+    echo "Error: checksum not found for $ARCHIVE"
+    exit 1
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum "$TMP_DIR/$ARCHIVE" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 "$TMP_DIR/$ARCHIVE" | awk '{print $1}')
+  else
+    echo "Error: no sha256 tool found (sha256sum or shasum required)"
+    exit 1
+  fi
+
+  if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "Error: checksum mismatch for ${BINARY}"
+    echo "  expected: $EXPECTED"
+    echo "  actual:   $ACTUAL"
+    exit 1
+  fi
+  echo "Checksum verified."
+
+  # Extract
+  EXTRACT_DIR="$TMP_DIR/${BINARY}_extract"
+  mkdir -p "$EXTRACT_DIR"
+  if [ "$EXT" = "tar.gz" ]; then
+    tar xzf "$TMP_DIR/$ARCHIVE" -C "$EXTRACT_DIR"
+  else
+    unzip -q "$TMP_DIR/$ARCHIVE" -d "$EXTRACT_DIR"
+  fi
+
+  # Install binary
+  if [ -w "$INSTALL_DIR" ]; then
+    install -m 755 "$EXTRACT_DIR/$BINARY" "$INSTALL_DIR/$BINARY"
+  else
+    echo "Installing ${BINARY} to $INSTALL_DIR (requires sudo)..."
+    sudo install -m 755 "$EXTRACT_DIR/$BINARY" "$INSTALL_DIR/$BINARY"
+  fi
+
+  echo "${BINARY} installed."
+done
+
+echo ""
+echo "DittoFS $VERSION installed to $INSTALL_DIR"
+echo "  dfs    - Server daemon"
+echo "  dfsctl - Client CLI"
+echo ""
+echo "Get started:"
+echo "  dfs init && dfs start"
+echo "  dfsctl login --server http://localhost:8080 --username admin"

--- a/scripts/publish-linux-repos.sh
+++ b/scripts/publish-linux-repos.sh
@@ -19,8 +19,7 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 s3_sync() {
   aws s3 sync "$1" "s3://${S3_BUCKET}/$2" \
     --endpoint-url "$S3_ENDPOINT" \
-    --acl public-read \
-    --delete
+    --acl public-read
 }
 
 # ── APT repository ──────────────────────────────────────────────────────────
@@ -66,13 +65,18 @@ RELEASE
     done
   } >> Release
 
-  # GPG sign if key is available
+  # GPG sign if key is available (isolated keyring)
   if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
-    echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
-    gpg --batch --yes --armor --detach-sign -o Release.gpg Release
-    gpg --batch --yes --armor --clearsign -o InRelease Release
-    # Export public key for users
-    gpg --batch --yes --armor --export > "${APT_DIR}/dittofs.gpg.key"
+    (
+      GNUPGHOME="${WORK_DIR}/gnupg"
+      export GNUPGHOME
+      mkdir -p "${GNUPGHOME}"
+      chmod 700 "${GNUPGHOME}"
+      echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
+      gpg --batch --yes --armor --detach-sign -o Release.gpg Release
+      gpg --batch --yes --armor --clearsign -o InRelease Release
+      gpg --batch --yes --armor --export > "${APT_DIR}/dittofs.gpg.key"
+    )
   fi
 
   cd "${WORK_DIR}"

--- a/scripts/publish-linux-repos.sh
+++ b/scripts/publish-linux-repos.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# Publish APT and YUM repositories to S3.
+# Called from CI after GoReleaser produces .deb and .rpm artifacts in dist/.
+#
+# Required env vars:
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (S3 credentials)
+#
+# Optional env vars:
+#   GPG_PRIVATE_KEY — if set, APT Release file is GPG-signed (InRelease)
+#   S3_BUCKET       — defaults to dittofs-binaries
+#   S3_ENDPOINT     — defaults to https://s3.cubbit.eu
+set -e
+
+S3_BUCKET="${S3_BUCKET:-dittofs-binaries}"
+S3_ENDPOINT="${S3_ENDPOINT:-https://s3.cubbit.eu}"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+s3_sync() {
+  aws s3 sync "$1" "s3://${S3_BUCKET}/$2" \
+    --endpoint-url "$S3_ENDPOINT" \
+    --acl public-read \
+    --delete
+}
+
+# ── APT repository ──────────────────────────────────────────────────────────
+
+APT_DIR="${WORK_DIR}/apt"
+mkdir -p "${APT_DIR}/pool" "${APT_DIR}/dists/stable/main/binary-amd64" "${APT_DIR}/dists/stable/main/binary-arm64"
+
+# Copy .deb artifacts into pool
+cp dist/*.deb "${APT_DIR}/pool/" 2>/dev/null || true
+
+DEB_COUNT=$(find "${APT_DIR}/pool" -name '*.deb' | wc -l)
+if [ "$DEB_COUNT" -eq 0 ]; then
+  echo "No .deb files found in dist/, skipping APT repo"
+else
+  echo "Building APT repo with ${DEB_COUNT} packages..."
+
+  # Generate Packages files per architecture
+  cd "${APT_DIR}"
+  for arch in amd64 arm64; do
+    dpkg-scanpackages --arch "$arch" pool > "dists/stable/main/binary-${arch}/Packages"
+    gzip -k "dists/stable/main/binary-${arch}/Packages"
+  done
+
+  # Generate Release file
+  cd "${APT_DIR}/dists/stable"
+  cat > Release <<RELEASE
+Origin: DittoFS
+Label: DittoFS
+Suite: stable
+Codename: stable
+Architectures: amd64 arm64
+Components: main
+Description: DittoFS APT repository
+RELEASE
+
+  # Append checksums
+  {
+    echo "SHA256:"
+    find main -type f \( -name 'Packages' -o -name 'Packages.gz' \) | sort | while read -r f; do
+      size=$(wc -c < "$f" | tr -d ' ')
+      hash=$(sha256sum "$f" | awk '{print $1}')
+      printf ' %s %s %s\n' "$hash" "$size" "$f"
+    done
+  } >> Release
+
+  # GPG sign if key is available
+  if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
+    echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
+    gpg --batch --yes --armor --detach-sign -o Release.gpg Release
+    gpg --batch --yes --armor --clearsign -o InRelease Release
+    # Export public key for users
+    gpg --batch --yes --armor --export > "${APT_DIR}/dittofs.gpg.key"
+  fi
+
+  cd "${WORK_DIR}"
+  echo "Uploading APT repo to s3://${S3_BUCKET}/apt/ ..."
+  s3_sync "${APT_DIR}/" "apt/"
+  echo "APT repo published."
+fi
+
+# ── YUM repository ──────────────────────────────────────────────────────────
+
+RPM_DIR="${WORK_DIR}/rpm"
+mkdir -p "${RPM_DIR}/packages"
+
+# Copy .rpm artifacts
+cp dist/*.rpm "${RPM_DIR}/packages/" 2>/dev/null || true
+
+RPM_COUNT=$(find "${RPM_DIR}/packages" -name '*.rpm' | wc -l)
+if [ "$RPM_COUNT" -eq 0 ]; then
+  echo "No .rpm files found in dist/, skipping YUM repo"
+else
+  echo "Building YUM repo with ${RPM_COUNT} packages..."
+
+  createrepo_c "${RPM_DIR}" 2>/dev/null || createrepo "${RPM_DIR}"
+
+  # Generate .repo file for easy user setup
+  cat > "${RPM_DIR}/dfs.repo" <<REPO
+[dfs]
+name=DittoFS
+baseurl=https://s3.cubbit.eu/${S3_BUCKET}/rpm
+enabled=1
+gpgcheck=0
+REPO
+
+  echo "Uploading YUM repo to s3://${S3_BUCKET}/rpm/ ..."
+  s3_sync "${RPM_DIR}/" "rpm/"
+  echo "YUM repo published."
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Add Linux native packages (deb, rpm, archlinux) via nFPM in GoReleaser for both `dfs` and `dfsctl`
- Add systemd service unit (`dfs.service`) and packaging lifecycle scripts (postinstall, preremove, postremove)
- Add `scripts/install.sh` — curl-based installer that auto-detects OS/arch, downloads from GitHub Releases, verifies sha256 checksums, and installs both `dfs` and `dfsctl`
- Add `scripts/publish-linux-repos.sh` — builds and publishes APT and YUM repositories to S3
- Update release workflow with Linux packaging tools and S3 publish steps
- Update release notes header with APT/YUM/Arch/curl install instructions
- Update README with all installation methods (curl, Homebrew, APT, YUM, Arch, Docker, Scoop)

Closes #342

## Test plan
- [x] Run `goreleaser check` — passes with only pre-existing deprecation warnings
- [x] Run `goreleaser release --snapshot --clean` to verify nFPM packages are generated
- [x] Verify `.deb` installs on Ubuntu/Debian with `dpkg -i` and systemd service loads
- [x] Verify `.rpm` installs on Fedora/RHEL with `rpm -i`
- [x] Verify `.pkg.tar.zst` installs on Arch with `pacman -U`
- [x] Test `scripts/install.sh` on macOS and Linux
- [ ] Verify release workflow runs end-to-end on next tag push