### PR TITLE
feat: centralized pluggable identity resolution for NFS and SMB

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bff7959d-a254-4d16-bc1d-b14d6da3649f","pid":27241,"acquiredAt":1775930535780}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"bff7959d-a254-4d16-bc1d-b14d6da3649f","pid":27241,"acquiredAt":1775930535780}

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ test/smb-conformance/results/
 test/smb-conformance/ptfconfig-generated/
 test/smb-conformance/dfs
 test/smb-conformance/dfsctl
+.claude/scheduled_tasks.lock

--- a/cmd/dfsctl/commands/idmap/add.go
+++ b/cmd/dfsctl/commands/idmap/add.go
@@ -9,24 +9,22 @@ import (
 )
 
 var (
+	addProvider  string
 	addPrincipal string
-	addUsername  string
+	addUsername   string
 )
 
 var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add an identity mapping",
-	Long: `Add a new identity mapping from an authentication principal to a control plane user.
-
-Supports NFS Kerberos principals (user@REALM), SMB NTLM principals
-(DOMAIN\user), and SMB Kerberos principals (user@REALM).
+	Long: `Add a new identity mapping from an external identity to a DittoFS user.
 
 Examples:
-  # Map a Kerberos principal (NFS or SMB)
+  # Map a Kerberos principal to a local user
   dfsctl idmap add --principal alice@EXAMPLE.COM --username alice
 
-  # Map an NTLM domain user
-  dfsctl idmap add --principal 'CORP\alice' --username alice
+  # Map with explicit provider
+  dfsctl idmap add --provider kerberos --principal admin@CORP.COM --username alice
 
   # Map a numeric UID principal
   dfsctl idmap add --principal 1000@localdomain --username bob`,
@@ -34,8 +32,9 @@ Examples:
 }
 
 func init() {
-	addCmd.Flags().StringVar(&addPrincipal, "principal", "", "Authentication principal (e.g., alice@EXAMPLE.COM or CORP\\alice)")
-	addCmd.Flags().StringVar(&addUsername, "username", "", "Control plane username")
+	addCmd.Flags().StringVar(&addProvider, "provider", "kerberos", "Identity provider (e.g., kerberos, oidc, ad)")
+	addCmd.Flags().StringVar(&addPrincipal, "principal", "", "External identity (e.g., alice@EXAMPLE.COM)")
+	addCmd.Flags().StringVar(&addUsername, "username", "", "DittoFS username")
 	_ = addCmd.MarkFlagRequired("principal")
 	_ = addCmd.MarkFlagRequired("username")
 }
@@ -46,7 +45,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mapping, err := client.CreateIdentityMapping(addPrincipal, addUsername)
+	mapping, err := client.CreateIdentityMapping(addProvider, addPrincipal, addUsername)
 	if err != nil {
 		return fmt.Errorf("failed to create identity mapping: %w", err)
 	}

--- a/cmd/dfsctl/commands/idmap/add.go
+++ b/cmd/dfsctl/commands/idmap/add.go
@@ -11,7 +11,7 @@ import (
 var (
 	addProvider  string
 	addPrincipal string
-	addUsername   string
+	addUsername  string
 )
 
 var addCmd = &cobra.Command{

--- a/cmd/dfsctl/commands/idmap/list.go
+++ b/cmd/dfsctl/commands/idmap/list.go
@@ -9,21 +9,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var listProvider string
+
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all identity mappings",
-	Long: `List all identity mappings on the DittoFS server.
+	Short: "List identity mappings",
+	Long: `List identity mappings on the DittoFS server.
 
 Examples:
-  # List mappings as table
+  # List all mappings
   dfsctl idmap list
 
-  # List as JSON
-  dfsctl idmap list -o json
+  # List only Kerberos mappings
+  dfsctl idmap list --provider kerberos
 
-  # List as YAML
-  dfsctl idmap list -o yaml`,
+  # List as JSON
+  dfsctl idmap list -o json`,
 	RunE: runList,
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listProvider, "provider", "", "Filter by identity provider (e.g., kerberos, oidc, ad)")
 }
 
 // MappingList is a list of identity mappings for table rendering.
@@ -31,7 +37,7 @@ type MappingList []apiclient.IdentityMapping
 
 // Headers implements TableRenderer.
 func (ml MappingList) Headers() []string {
-	return []string{"PRINCIPAL", "USERNAME", "CREATED"}
+	return []string{"PROVIDER", "PRINCIPAL", "USERNAME", "CREATED"}
 }
 
 // Rows implements TableRenderer.
@@ -39,7 +45,7 @@ func (ml MappingList) Rows() [][]string {
 	rows := make([][]string, 0, len(ml))
 	for _, m := range ml {
 		created := cmdutil.EmptyOr(m.CreatedAt, "-")
-		rows = append(rows, []string{m.Principal, m.Username, created})
+		rows = append(rows, []string{m.ProviderName, m.Principal, m.Username, created})
 	}
 	return rows
 }
@@ -50,7 +56,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mappings, err := client.ListIdentityMappings()
+	mappings, err := client.ListIdentityMappings(listProvider)
 	if err != nil {
 		return fmt.Errorf("failed to list identity mappings: %w", err)
 	}

--- a/cmd/dfsctl/commands/idmap/remove.go
+++ b/cmd/dfsctl/commands/idmap/remove.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	removeProvider  string
 	removePrincipal string
 	removeForce     bool
 )
@@ -15,7 +16,7 @@ var (
 var removeCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove an identity mapping",
-	Long: `Remove an identity mapping by principal.
+	Long: `Remove an identity mapping by provider and principal.
 
 This action is irreversible. You will be prompted for confirmation
 unless --force is specified.
@@ -24,13 +25,17 @@ Examples:
   # Remove with confirmation
   dfsctl idmap remove --principal alice@EXAMPLE.COM
 
+  # Remove with explicit provider
+  dfsctl idmap remove --provider kerberos --principal alice@EXAMPLE.COM
+
   # Remove without confirmation
   dfsctl idmap remove --principal alice@EXAMPLE.COM --force`,
 	RunE: runRemove,
 }
 
 func init() {
-	removeCmd.Flags().StringVar(&removePrincipal, "principal", "", "Authentication principal to remove")
+	removeCmd.Flags().StringVar(&removeProvider, "provider", "kerberos", "Identity provider (e.g., kerberos, oidc, ad)")
+	removeCmd.Flags().StringVar(&removePrincipal, "principal", "", "External identity to remove")
 	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Skip confirmation prompt")
 	_ = removeCmd.MarkFlagRequired("principal")
 }
@@ -42,7 +47,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	return cmdutil.RunDeleteWithConfirmation("Identity mapping", removePrincipal, removeForce, func() error {
-		if err := client.DeleteIdentityMapping(removePrincipal); err != nil {
+		if err := client.DeleteIdentityMapping(removeProvider, removePrincipal); err != nil {
 			return fmt.Errorf("failed to delete identity mapping: %w", err)
 		}
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
+	golang.org/x/sync v0.18.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -92,7 +93,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect

--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -667,67 +667,9 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 	}
 
 	// 5. Map principal to Unix identity via centralized resolver or legacy mapper.
-	p.mu.RLock()
-	resolver := p.resolver
-	legacyMapper := p.mapper
-	p.mu.RUnlock()
-
-	var ident *metadata.Identity
-	principalKey := gssCtx.Principal + "@" + gssCtx.Realm
-
-	if resolver != nil {
-		cred := &pkgidentity.Credential{
-			Provider:   "kerberos",
-			ExternalID: principalKey,
-			Attributes: map[string]string{"realm": gssCtx.Realm},
-		}
-		resolved, err := resolver.Resolve(ctx, cred)
-		if err == nil && resolved.Found {
-			ident = &metadata.Identity{
-				UID:      &resolved.UID,
-				GID:      &resolved.GID,
-				GIDs:     resolved.GIDs,
-				Username: resolved.Username,
-				Domain:   resolved.Domain,
-			}
-		} else if err == nil && !resolved.Found {
-			nobody := pkgidentity.NobodyIdentity()
-			ident = &metadata.Identity{
-				UID:      &nobody.UID,
-				GID:      &nobody.GID,
-				Username: nobody.Username,
-			}
-		} else {
-			logger.Warn("GSS DATA: identity resolver error, falling back to legacy mapper",
-				"principal", gssCtx.Principal,
-				"realm", gssCtx.Realm,
-				"error", err,
-			)
-			// Fall through to legacy mapper below
-		}
-	}
-	if ident == nil && legacyMapper != nil {
-		resolved, err := legacyMapper.Resolve(ctx, principalKey)
-		if err != nil {
-			return &GSSProcessResult{
-				Err: fmt.Errorf("map identity for %s: %w", principalKey, err),
-			}
-		}
-		if resolved == nil {
-			return &GSSProcessResult{
-				Err: fmt.Errorf("identity mapping returned nil for %s", principalKey),
-			}
-		}
-		if !resolved.Found {
-			resolved = nfsidentity.NobodyIdentity()
-		}
-		ident = &metadata.Identity{
-			UID:      &resolved.UID,
-			GID:      &resolved.GID,
-			GIDs:     resolved.GIDs,
-			Username: resolved.Username,
-			Domain:   resolved.Domain,
-		}
+	ident, identErr := p.resolveIdentity(ctx, gssCtx.Principal, gssCtx.Realm)
+	if identErr != nil {
+		return &GSSProcessResult{Err: identErr}
 	}
 
 	logger.Debug("GSS DATA: request authenticated",
@@ -745,6 +687,70 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		Service:       cred.Service,
 		SessionKey:    gssCtx.SessionKey,
 	}
+}
+
+// resolveIdentity maps a Kerberos principal to a Unix identity using the
+// centralized resolver (DB-backed) with fallback to the legacy static mapper.
+// Returns a nobody identity when the principal is not found.
+func (p *GSSProcessor) resolveIdentity(ctx context.Context, principal, realm string) (*metadata.Identity, error) {
+	p.mu.RLock()
+	resolver := p.resolver
+	legacyMapper := p.mapper
+	p.mu.RUnlock()
+
+	principalKey := principal + "@" + realm
+
+	// Try centralized resolver first (DB-backed mapping + convention fallback).
+	if resolver != nil {
+		cred := &pkgidentity.Credential{
+			Provider:   "kerberos",
+			ExternalID: principalKey,
+			Attributes: map[string]string{"realm": realm},
+		}
+		resolved, err := resolver.Resolve(ctx, cred)
+		if err != nil {
+			return nil, fmt.Errorf("identity resolver unavailable for %s@%s: %w", principal, realm, err)
+		}
+		if resolved.Found {
+			return &metadata.Identity{
+				UID:      &resolved.UID,
+				GID:      &resolved.GID,
+				GIDs:     resolved.GIDs,
+				Username: resolved.Username,
+				Domain:   resolved.Domain,
+			}, nil
+		} else {
+			nobody := pkgidentity.NobodyIdentity()
+			return &metadata.Identity{
+				UID:      &nobody.UID,
+				GID:      &nobody.GID,
+				Username: nobody.Username,
+			}, nil
+		}
+	}
+
+	// Legacy static mapper fallback.
+	if legacyMapper != nil {
+		resolved, err := legacyMapper.Resolve(ctx, principalKey)
+		if err != nil {
+			return nil, fmt.Errorf("map identity for %s: %w", principalKey, err)
+		}
+		if resolved == nil {
+			return nil, fmt.Errorf("identity mapping returned nil for %s", principalKey)
+		}
+		if !resolved.Found {
+			resolved = nfsidentity.NobodyIdentity()
+		}
+		return &metadata.Identity{
+			UID:      &resolved.UID,
+			GID:      &resolved.GID,
+			GIDs:     resolved.GIDs,
+			Username: resolved.Username,
+			Domain:   resolved.Domain,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no identity mapper configured for %s", principalKey)
 }
 
 // handleDestroy processes RPCSEC_GSS_DESTROY.

--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -11,7 +11,8 @@ import (
 
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
+	nfsidentity "github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
+	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -364,14 +365,15 @@ type GSSProcessorOption func(*GSSProcessor)
 type GSSProcessor struct {
 	contexts *ContextStore
 	verifier Verifier
-	mapper   identity.IdentityMapper
+	mapper   nfsidentity.IdentityMapper // legacy mapper (used if resolver is nil)
+	resolver *pkgidentity.Resolver      // centralized identity resolver
 	mu       sync.RWMutex
 }
 
 // NewGSSProcessor creates a new GSS processor.
 // Use NewKrb5Verifier for the production verifier.
 // maxContexts of 0 means unlimited; contextTTL controls idle context expiry.
-func NewGSSProcessor(verifier Verifier, mapper identity.IdentityMapper, maxContexts int, contextTTL time.Duration, opts ...GSSProcessorOption) *GSSProcessor {
+func NewGSSProcessor(verifier Verifier, mapper nfsidentity.IdentityMapper, maxContexts int, contextTTL time.Duration, opts ...GSSProcessorOption) *GSSProcessor {
 	p := &GSSProcessor{
 		contexts: NewContextStore(maxContexts, contextTTL),
 		verifier: verifier,
@@ -664,36 +666,60 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		}
 	}
 
-	// 5. Map principal to Unix identity
+	// 5. Map principal to Unix identity via centralized resolver or legacy mapper.
 	p.mu.RLock()
-	mapper := p.mapper
+	resolver := p.resolver
+	legacyMapper := p.mapper
 	p.mu.RUnlock()
 
 	var ident *metadata.Identity
-	if mapper != nil {
-		principalKey := gssCtx.Principal + "@" + gssCtx.Realm
-		resolved, err := mapper.Resolve(ctx, principalKey)
-		if err != nil {
-			logger.Debug("GSS DATA: identity mapping failed",
+	principalKey := gssCtx.Principal + "@" + gssCtx.Realm
+
+	if resolver != nil {
+		cred := &pkgidentity.Credential{
+			Provider:   "kerberos",
+			ExternalID: principalKey,
+			Attributes: map[string]string{"realm": gssCtx.Realm},
+		}
+		resolved, err := resolver.Resolve(ctx, cred)
+		if err == nil && resolved.Found {
+			ident = &metadata.Identity{
+				UID:      &resolved.UID,
+				GID:      &resolved.GID,
+				GIDs:     resolved.GIDs,
+				Username: resolved.Username,
+				Domain:   resolved.Domain,
+			}
+		} else if err == nil && !resolved.Found {
+			nobody := pkgidentity.NobodyIdentity()
+			ident = &metadata.Identity{
+				UID:      &nobody.UID,
+				GID:      &nobody.GID,
+				Username: nobody.Username,
+			}
+		} else {
+			logger.Warn("GSS DATA: identity resolver error, falling back to legacy mapper",
 				"principal", gssCtx.Principal,
 				"realm", gssCtx.Realm,
 				"error", err,
 			)
+			// Fall through to legacy mapper below
+		}
+	}
+	if ident == nil && legacyMapper != nil {
+		resolved, err := legacyMapper.Resolve(ctx, principalKey)
+		if err != nil {
 			return &GSSProcessResult{
-				Err: fmt.Errorf("map identity for %s@%s: %w", gssCtx.Principal, gssCtx.Realm, err),
+				Err: fmt.Errorf("map identity for %s: %w", principalKey, err),
 			}
 		}
 		if resolved == nil {
 			return &GSSProcessResult{
-				Err: fmt.Errorf("identity mapping returned nil for %s@%s", gssCtx.Principal, gssCtx.Realm),
+				Err: fmt.Errorf("identity mapping returned nil for %s", principalKey),
 			}
 		}
 		if !resolved.Found {
-			logger.Debug("GSS DATA: identity not found, falling back to nobody",
-				"principal", gssCtx.Principal,
-				"realm", gssCtx.Realm,
-			)
-			resolved = identity.NobodyIdentity()
+			resolved = nfsidentity.NobodyIdentity()
 		}
 		ident = &metadata.Identity{
 			UID:      &resolved.UID,
@@ -783,9 +809,17 @@ func (p *GSSProcessor) SetVerifier(v Verifier) {
 	p.mu.Unlock()
 }
 
-// SetMapper replaces the identity mapper.
-func (p *GSSProcessor) SetMapper(m identity.IdentityMapper) {
+// SetMapper replaces the legacy identity mapper.
+func (p *GSSProcessor) SetMapper(m nfsidentity.IdentityMapper) {
 	p.mu.Lock()
 	p.mapper = m
+	p.mu.Unlock()
+}
+
+// SetResolver sets the centralized identity resolver, which takes precedence
+// over the legacy mapper when both are set.
+func (p *GSSProcessor) SetResolver(r *pkgidentity.Resolver) {
+	p.mu.Lock()
+	p.resolver = r
 	p.mu.Unlock()
 }

--- a/internal/adapter/nfs/rpc/gss/framework_test.go
+++ b/internal/adapter/nfs/rpc/gss/framework_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/jcmturner/gokrb5/v8/types"
-	"github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
+	identity "github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -124,20 +124,14 @@ func (lm *LeaseManager) RequestLease(
 		requestedState, isDirectory,
 	)
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
-		lm.mu.Lock()
-		delete(lm.sessionMap, keyHex)
-		delete(lm.leaseShare, keyHex)
-		lm.mu.Unlock()
+		lm.removeLeaseMapping(keyHex)
 		return 0, 0, err
 	}
 
 	// Remove pre-registered mapping if the lease was denied (None state means
 	// the LockManager rejected the request without an error code).
 	if grantedState == lock.LeaseStateNone {
-		lm.mu.Lock()
-		delete(lm.sessionMap, keyHex)
-		delete(lm.leaseShare, keyHex)
-		lm.mu.Unlock()
+		lm.removeLeaseMapping(keyHex)
 	}
 
 	return grantedState, epoch, err
@@ -180,10 +174,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 			logger.Debug("AcknowledgeLeaseBreak: lease not found in lock manager, treating as success",
 				"leaseKey", keyHex)
 			// Clean up our maps if they still have stale entries
-			lm.mu.Lock()
-			delete(lm.sessionMap, keyHex)
-			delete(lm.leaseShare, keyHex)
-			lm.mu.Unlock()
+			lm.removeLeaseMapping(keyHex)
 			return nil
 		}
 		return err
@@ -191,10 +182,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 	// If acknowledged to None, remove from session map
 	if acknowledgedState == lock.LeaseStateNone {
-		lm.mu.Lock()
-		delete(lm.sessionMap, keyHex)
-		delete(lm.leaseShare, keyHex)
-		lm.mu.Unlock()
+		lm.removeLeaseMapping(keyHex)
 	}
 
 	return nil
@@ -212,10 +200,7 @@ func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) err
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		// Already released or no manager
-		lm.mu.Lock()
-		delete(lm.sessionMap, keyHex)
-		delete(lm.leaseShare, keyHex)
-		lm.mu.Unlock()
+		lm.removeLeaseMapping(keyHex)
 		return nil
 	}
 
@@ -224,11 +209,7 @@ func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) err
 		return err
 	}
 
-	lm.mu.Lock()
-	delete(lm.sessionMap, keyHex)
-	delete(lm.leaseShare, keyHex)
-	lm.mu.Unlock()
-
+	lm.removeLeaseMapping(keyHex)
 	return nil
 }
 
@@ -434,17 +415,6 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
 }
 
-// BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory
-// when a file is created, overwritten, or superseded inside it.
-//
-// Per MS-SMB2 3.3.5.9 and MS-FSA 2.1.5.1.2.1: modifying directory contents
-// (create/overwrite/supersede) must break Handle leases on the directory for
-// other clients. The creating client's leases are excluded via excludeClientID.
-//
-// This enables BVT_DirectoryLeasing_LeaseBreakOnMultiClients: when one client
-// creates a file, other clients holding RH leases on the parent directory
-// receive a lease break notification.
-//
 // resolveParentBreakArgs resolves the lock manager, handle key, and exclude
 // owner for parent directory lease break operations. Returns nil lockMgr if
 // the share has no lock manager.
@@ -592,6 +562,15 @@ func (lm *LeaseManager) RangeLeases(fn func(leaseKeyHex string, sessionID uint64
 			return
 		}
 	}
+}
+
+// removeLeaseMapping removes a lease key from the session and share maps.
+// Must be called without lm.mu held.
+func (lm *LeaseManager) removeLeaseMapping(keyHex string) {
+	lm.mu.Lock()
+	delete(lm.sessionMap, keyHex)
+	delete(lm.leaseShare, keyHex)
+	lm.mu.Unlock()
 }
 
 // resolveLockManager resolves the LockManager for a share name.

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -111,7 +111,7 @@ func (lm *LeaseManager) RequestLease(
 	//
 	// Pre-registering is safe: if the grant fails or returns None, we
 	// remove the entry below.
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	lm.sessionMap[keyHex] = sessionID
 	lm.leaseShare[keyHex] = shareName
@@ -156,7 +156,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	acknowledgedState uint32,
 	epoch uint16,
 ) error {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -202,7 +202,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 // ReleaseLease delegates to the shared LockManager and removes the session mapping.
 func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -268,7 +268,7 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 
 // GetLeaseState delegates to the shared LockManager.
 func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]
@@ -286,7 +286,7 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	sid, ok := lm.sessionMap[fmt.Sprintf("%x", leaseKey)]
+	sid, ok := lm.sessionMap[hex.EncodeToString(leaseKey[:])]
 	return sid, ok
 }
 
@@ -294,7 +294,7 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 // Used during durable handle reconnect to associate the existing lease with
 // the new session for break notification routing.
 func (lm *LeaseManager) UpdateSessionForLease(leaseKey [16]byte, sessionID uint64) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 	lm.sessionMap[keyHex] = sessionID
@@ -524,7 +524,7 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 // Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
 // epoch from the RqLs create context.
 func (lm *LeaseManager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) {
-	keyHex := fmt.Sprintf("%x", leaseKey)
+	keyHex := hex.EncodeToString(leaseKey[:])
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -394,8 +394,13 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		exclude = excludeOwner[0]
 	}
 
-	// Break Handle leases (RWH -> RW, RH -> R)
-	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+	// Strip Write from leases that have Handle caching (RWH -> RH).
+	// This sends one notification that matches what clients expect:
+	// "flush dirty data" (Write strip). The Handle bit is preserved so
+	// the client can close cached handles in its ack response.
+	// After the ack, the lease is at RH (no Write, no Breaking), and
+	// Step 8a can independently strip Handle if needed.
+	if err := lockMgr.BreakWriteOnHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
 		return err
 	}
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -111,7 +111,7 @@ func (lm *LeaseManager) RequestLease(
 	//
 	// Pre-registering is safe: if the grant fails or returns None, we
 	// remove the entry below.
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 	lm.mu.Lock()
 	lm.sessionMap[keyHex] = sessionID
 	lm.leaseShare[keyHex] = shareName
@@ -124,6 +124,7 @@ func (lm *LeaseManager) RequestLease(
 		requestedState, isDirectory,
 	)
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
+		// Grant failed — remove pre-registered session mapping
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
 		delete(lm.leaseShare, keyHex)
@@ -131,8 +132,7 @@ func (lm *LeaseManager) RequestLease(
 		return 0, 0, err
 	}
 
-	// Remove pre-registered mapping if the lease was denied (None state means
-	// the LockManager rejected the request without an error code).
+	// If lease was denied (None) without error, remove pre-registered mapping.
 	if grantedState == lock.LeaseStateNone {
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
@@ -156,7 +156,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	acknowledgedState uint32,
 	epoch uint16,
 ) error {
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -202,7 +202,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 // ReleaseLease delegates to the shared LockManager and removes the session mapping.
 func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
@@ -268,7 +268,7 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 
 // GetLeaseState delegates to the shared LockManager.
 func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]
@@ -286,7 +286,7 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	sid, ok := lm.sessionMap[hex.EncodeToString(leaseKey[:])]
+	sid, ok := lm.sessionMap[fmt.Sprintf("%x", leaseKey)]
 	return sid, ok
 }
 
@@ -294,7 +294,7 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 // Used during durable handle reconnect to associate the existing lease with
 // the new session for break notification routing.
 func (lm *LeaseManager) UpdateSessionForLease(leaseKey [16]byte, sessionID uint64) {
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 	lm.sessionMap[keyHex] = sessionID
@@ -394,13 +394,8 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		exclude = excludeOwner[0]
 	}
 
-	// Strip Write from leases that have Handle caching (RWH -> RH).
-	// This sends one notification that matches what clients expect:
-	// "flush dirty data" (Write strip). The Handle bit is preserved so
-	// the client can close cached handles in its ack response.
-	// After the ack, the lease is at RH (no Write, no Breaking), and
-	// Step 8a can independently strip Handle if needed.
-	if err := lockMgr.BreakWriteOnHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+	// Break Handle leases (RWH -> RW, RH -> R)
+	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
 		return err
 	}
 
@@ -432,6 +427,87 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	}
 
 	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
+}
+
+// BreakDirectoryLeasesOnOpenAsync dispatches Handle AND Write lease break
+// notifications for a directory open without waiting for acknowledgment.
+//
+// Per MS-SMB2 3.3.5.9: when a new open conflicts with existing directory
+// leases, both Handle caching (cached directory handles) and Write caching
+// (cached directory content changes) must be broken so other clients receive
+// LEASE_BREAK_NOTIFICATION before the share mode check. This is required by
+// BVT_DirectoryLeasing_LeaseBreakOnMultiClients where Client3's DELETE access
+// must trigger a Write-lease break notification even when no Handle leases
+// exist.
+//
+// The break is async (fire-and-forget) to avoid deadlock — the other client
+// needs this CREATE's response before it can process the break notification.
+//
+// This method dispatches break notifications directly via the adapter-level
+// session map + notifier, bypassing the LockManager's callback chain. The
+// LockManager callbacks route through dispatchOpLockBreak → registered
+// BreakCallbacks, which may not have the session mapping yet for leases that
+// were registered on a different callback instance. Sending directly from
+// the LeaseManager avoids this routing gap.
+func (lm *LeaseManager) BreakDirectoryLeasesOnOpenAsync(
+	fileHandle lock.FileHandle,
+	shareName string,
+	excludeOwner ...*lock.LockOwner,
+) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	handleKey := string(fileHandle)
+
+	var exclude *lock.LockOwner
+	if len(excludeOwner) > 0 {
+		exclude = excludeOwner[0]
+	}
+
+	// Break Handle leases via LockManager (RWH -> RW, RH -> R)
+	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+		return err
+	}
+
+	// For Write leases: use GetWriteLeasesToBreak to identify leases that need
+	// breaking, then dispatch notifications directly via the adapter's session
+	// map and notifier. This ensures the notification reaches the right SMB
+	// session even when the LockManager's callback chain can't resolve it.
+	toBreak := lockMgr.GetWriteLeasesToBreak(handleKey, exclude)
+	for _, entry := range toBreak {
+		leaseKey := entry.LeaseKey
+		breakTo := entry.BreakToState
+		currentState := entry.CurrentState
+
+		sessionID, found := lm.GetSessionForLease(leaseKey)
+		if !found {
+			logger.Debug("BreakDirectoryLeasesOnOpenAsync: no session for lease, skipping",
+				"leaseKey", fmt.Sprintf("%x", leaseKey),
+				"handleKey", handleKey)
+			continue
+		}
+
+		notifier := lm.GetNotifier()
+		if notifier == nil {
+			continue
+		}
+
+		logger.Debug("BreakDirectoryLeasesOnOpenAsync: dispatching write lease break",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"sessionID", sessionID,
+			"currentState", lock.LeaseStateToString(currentState),
+			"breakToState", lock.LeaseStateToString(breakTo))
+
+		if err := notifier.SendLeaseBreak(sessionID, leaseKey, currentState, breakTo, entry.Epoch); err != nil {
+			logger.Warn("BreakDirectoryLeasesOnOpenAsync: failed to send break",
+				"leaseKey", fmt.Sprintf("%x", leaseKey),
+				"error", err)
+		}
+	}
+
+	return nil
 }
 
 // BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory
@@ -529,7 +605,7 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 // Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
 // epoch from the RqLs create context.
 func (lm *LeaseManager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) {
-	keyHex := hex.EncodeToString(leaseKey[:])
+	keyHex := fmt.Sprintf("%x", leaseKey)
 
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -124,7 +124,6 @@ func (lm *LeaseManager) RequestLease(
 		requestedState, isDirectory,
 	)
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
-		// Grant failed — remove pre-registered session mapping
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
 		delete(lm.leaseShare, keyHex)
@@ -132,7 +131,8 @@ func (lm *LeaseManager) RequestLease(
 		return 0, 0, err
 	}
 
-	// If lease was denied (None) without error, remove pre-registered mapping.
+	// Remove pre-registered mapping if the lease was denied (None state means
+	// the LockManager rejected the request without an error code).
 	if grantedState == lock.LeaseStateNone {
 		lm.mu.Lock()
 		delete(lm.sessionMap, keyHex)
@@ -427,87 +427,6 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	}
 
 	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
-}
-
-// BreakDirectoryLeasesOnOpenAsync dispatches Handle AND Write lease break
-// notifications for a directory open without waiting for acknowledgment.
-//
-// Per MS-SMB2 3.3.5.9: when a new open conflicts with existing directory
-// leases, both Handle caching (cached directory handles) and Write caching
-// (cached directory content changes) must be broken so other clients receive
-// LEASE_BREAK_NOTIFICATION before the share mode check. This is required by
-// BVT_DirectoryLeasing_LeaseBreakOnMultiClients where Client3's DELETE access
-// must trigger a Write-lease break notification even when no Handle leases
-// exist.
-//
-// The break is async (fire-and-forget) to avoid deadlock — the other client
-// needs this CREATE's response before it can process the break notification.
-//
-// This method dispatches break notifications directly via the adapter-level
-// session map + notifier, bypassing the LockManager's callback chain. The
-// LockManager callbacks route through dispatchOpLockBreak → registered
-// BreakCallbacks, which may not have the session mapping yet for leases that
-// were registered on a different callback instance. Sending directly from
-// the LeaseManager avoids this routing gap.
-func (lm *LeaseManager) BreakDirectoryLeasesOnOpenAsync(
-	fileHandle lock.FileHandle,
-	shareName string,
-	excludeOwner ...*lock.LockOwner,
-) error {
-	lockMgr := lm.resolveLockManager(shareName)
-	if lockMgr == nil {
-		return nil
-	}
-
-	handleKey := string(fileHandle)
-
-	var exclude *lock.LockOwner
-	if len(excludeOwner) > 0 {
-		exclude = excludeOwner[0]
-	}
-
-	// Break Handle leases via LockManager (RWH -> RW, RH -> R)
-	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
-		return err
-	}
-
-	// For Write leases: use GetWriteLeasesToBreak to identify leases that need
-	// breaking, then dispatch notifications directly via the adapter's session
-	// map and notifier. This ensures the notification reaches the right SMB
-	// session even when the LockManager's callback chain can't resolve it.
-	toBreak := lockMgr.GetWriteLeasesToBreak(handleKey, exclude)
-	for _, entry := range toBreak {
-		leaseKey := entry.LeaseKey
-		breakTo := entry.BreakToState
-		currentState := entry.CurrentState
-
-		sessionID, found := lm.GetSessionForLease(leaseKey)
-		if !found {
-			logger.Debug("BreakDirectoryLeasesOnOpenAsync: no session for lease, skipping",
-				"leaseKey", fmt.Sprintf("%x", leaseKey),
-				"handleKey", handleKey)
-			continue
-		}
-
-		notifier := lm.GetNotifier()
-		if notifier == nil {
-			continue
-		}
-
-		logger.Debug("BreakDirectoryLeasesOnOpenAsync: dispatching write lease break",
-			"leaseKey", fmt.Sprintf("%x", leaseKey),
-			"sessionID", sessionID,
-			"currentState", lock.LeaseStateToString(currentState),
-			"breakToState", lock.LeaseStateToString(breakTo))
-
-		if err := notifier.SendLeaseBreak(sessionID, leaseKey, currentState, breakTo, entry.Epoch); err != nil {
-			logger.Warn("BreakDirectoryLeasesOnOpenAsync: failed to send break",
-				"leaseKey", fmt.Sprintf("%x", leaseKey),
-				"error", err)
-		}
-	}
-
-	return nil
 }
 
 // BreakParentHandleLeasesOnCreate breaks Handle leases on a parent directory

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -852,25 +852,29 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	if fileExists {
 		existingHandle, handleErr := metadata.EncodeFileHandle(existingFile)
 		if handleErr == nil {
-			// Step 10: Break Handle leases on directories before share mode check.
-			// Per MS-SMB2 3.3.5.9.8: stat-only opens (FILE_READ_ATTRIBUTES
-			// only) do NOT break existing leases.
+			// Step 10: Break Handle leases before share mode check.
+			// Per MS-SMB2 3.3.5.9 Step 10: if any existing open has a lease
+			// with Handle caching, break it so the client can close cached
+			// handles before the share mode check.
+			// Per MS-SMB2 3.3.5.9.8: stat-only opens do NOT break leases.
 			//
-			// For directories: dispatch Handle-break async (fire-and-forget).
-			// Directory Handle breaks notify clients to release cached dir handles.
-			// Step 8a (BreakConflictingOplocksOnOpen) is skipped for directories,
-			// so this is the only break opportunity.
+			// For files: synchronous wait for Handle break ack. After the
+			// client acks (closing the cached handle), the share mode check
+			// runs with updated state. Step 8a then strips Write if needed.
 			//
-			// For files: do NOT break Handle here. Step 8a dispatches the Write
-			// break via BreakConflictingOplocksOnOpen. If we break Handle first,
-			// the lease is marked Breaking and Step 8a skips the Write break —
-			// but clients need the Write break to flush dirty data. The Handle
-			// break is folded into the eventual lease downgrade (RWH → R after
-			// Write + Handle strips).
-			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) && existingFile.Type == metadata.FileTypeDirectory {
+			// For directories: async (fire-and-forget). Directory opens use
+			// a single-threaded test driver where the client can't ack until
+			// this CREATE returns — waiting would deadlock.
+			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) {
 				lockFileHandle := lock.FileHandle(existingHandle)
-				if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-					logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
+				if existingFile.Type == metadata.FileTypeDirectory {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+						logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
+					}
+				} else {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+						logger.Debug("CREATE: handle lease break failed", "error", breakErr)
+					}
 				}
 			}
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -852,29 +852,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	if fileExists {
 		existingHandle, handleErr := metadata.EncodeFileHandle(existingFile)
 		if handleErr == nil {
-			// Step 10: Break Handle leases before share mode check.
-			// Per MS-SMB2 3.3.5.9 Step 10: if any existing open has a lease
-			// with Handle caching, break it so the client can close cached
-			// handles before the share mode check.
-			// Per MS-SMB2 3.3.5.9.8: stat-only opens do NOT break leases.
+			// Step 10: Break Handle leases on directories before share mode check.
+			// Per MS-SMB2 3.3.5.9.8: stat-only opens (FILE_READ_ATTRIBUTES
+			// only) do NOT break existing leases.
 			//
-			// For files: synchronous wait for Handle break ack. After the
-			// client acks (closing the cached handle), the share mode check
-			// runs with updated state. Step 8a then strips Write if needed.
+			// For directories: dispatch Handle-break async (fire-and-forget).
+			// Directory Handle breaks notify clients to release cached dir handles.
+			// Step 8a (BreakConflictingOplocksOnOpen) is skipped for directories,
+			// so this is the only break opportunity.
 			//
-			// For directories: async (fire-and-forget). Directory opens use
-			// a single-threaded test driver where the client can't ack until
-			// this CREATE returns — waiting would deadlock.
-			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) {
+			// For files: do NOT break Handle here. Step 8a dispatches the Write
+			// break via BreakConflictingOplocksOnOpen. If we break Handle first,
+			// the lease is marked Breaking and Step 8a skips the Write break —
+			// but clients need the Write break to flush dirty data. The Handle
+			// break is folded into the eventual lease downgrade (RWH → R after
+			// Write + Handle strips).
+			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) && existingFile.Type == metadata.FileTypeDirectory {
 				lockFileHandle := lock.FileHandle(existingHandle)
-				if existingFile.Type == metadata.FileTypeDirectory {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-						logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
-					}
-				} else {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
-						logger.Debug("CREATE: handle lease break failed", "error", breakErr)
-					}
+				if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+					logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
 				}
 			}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -122,7 +123,13 @@ type Handler struct {
 
 	// IdentityConfig controls Kerberos principal-to-username mapping.
 	// Default: strip realm ("alice@REALM" -> "alice").
+	// Deprecated: use IdentityResolver for DB-backed resolution.
 	IdentityConfig *kerberos.IdentityConfig
+
+	// IdentityResolver resolves Kerberos principals to DittoFS users via
+	// the centralized identity provider chain. When set, takes precedence
+	// over IdentityConfig. When nil, falls back to IdentityConfig.
+	IdentityResolver *pkgidentity.Resolver
 
 	// SMBServicePrincipal overrides the auto-derived CIFS service principal.
 	// When empty, derived from the NFS principal ("nfs/host@REALM" -> "cifs/host@REALM").

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -19,8 +19,8 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
-	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )

--- a/internal/adapter/smb/v2/handlers/identity_resolver.go
+++ b/internal/adapter/smb/v2/handlers/identity_resolver.go
@@ -30,7 +30,7 @@ func (h *Handler) resolveIdentityMapping(ctx context.Context, principal, fallbac
 	}
 
 	// Try the full principal first (e.g., "DOMAIN\user" or "user@REALM").
-	mapping, err := ims.GetIdentityMapping(ctx, principal)
+	mapping, err := ims.GetIdentityMapping(ctx, "kerberos", principal)
 	if err == nil {
 		logger.Debug("Identity mapping resolved",
 			"principal", principal, "username", mapping.Username)
@@ -44,7 +44,7 @@ func (h *Handler) resolveIdentityMapping(ctx context.Context, principal, fallbac
 	// For NTLM principals ("DOMAIN\user"), also try bare username as fallback.
 	if idx := strings.IndexByte(principal, '\\'); idx >= 0 {
 		bare := principal[idx+1:]
-		mapping, err := ims.GetIdentityMapping(ctx, bare)
+		mapping, err := ims.GetIdentityMapping(ctx, "kerberos", bare)
 		if err == nil {
 			logger.Debug("Identity mapping resolved via bare username",
 				"principal", principal, "bare", bare, "username", mapping.Username)

--- a/internal/adapter/smb/v2/handlers/identity_resolver_test.go
+++ b/internal/adapter/smb/v2/handlers/identity_resolver_test.go
@@ -9,35 +9,45 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
-// testStoreWithIDMap embeds store.Store (nil, unused) and adds IdentityMappingStore.
-// This lets runtime.New() accept it while GetIdentityMappingStore() succeeds.
 type testStoreWithIDMap struct {
 	store.Store
-	mappings map[string]*models.IdentityMapping
+	mappings map[string]*models.IdentityMapping // keyed by "provider|principal"
 }
 
-func (s *testStoreWithIDMap) GetIdentityMapping(_ context.Context, principal string) (*models.IdentityMapping, error) {
-	if mapping, ok := s.mappings[principal]; ok {
+func idmapKey(provider, principal string) string {
+	return provider + "|" + principal
+}
+
+func (s *testStoreWithIDMap) GetIdentityMapping(_ context.Context, provider, principal string) (*models.IdentityMapping, error) {
+	if mapping, ok := s.mappings[idmapKey(provider, principal)]; ok {
 		return mapping, nil
 	}
 	return nil, models.ErrMappingNotFound
 }
 
-func (s *testStoreWithIDMap) ListIdentityMappings(_ context.Context) ([]*models.IdentityMapping, error) {
+func (s *testStoreWithIDMap) ListIdentityMappings(_ context.Context, _ string) ([]*models.IdentityMapping, error) {
 	return nil, nil
 }
 
 func (s *testStoreWithIDMap) CreateIdentityMapping(_ context.Context, mapping *models.IdentityMapping) error {
-	s.mappings[mapping.Principal] = mapping
+	if mapping.ProviderName == "" {
+		mapping.ProviderName = "kerberos"
+	}
+	s.mappings[idmapKey(mapping.ProviderName, mapping.Principal)] = mapping
 	return nil
 }
 
-func (s *testStoreWithIDMap) DeleteIdentityMapping(_ context.Context, principal string) error {
-	if _, ok := s.mappings[principal]; !ok {
+func (s *testStoreWithIDMap) DeleteIdentityMapping(_ context.Context, provider, principal string) error {
+	key := idmapKey(provider, principal)
+	if _, ok := s.mappings[key]; !ok {
 		return models.ErrMappingNotFound
 	}
-	delete(s.mappings, principal)
+	delete(s.mappings, key)
 	return nil
+}
+
+func (s *testStoreWithIDMap) ListIdentityMappingsForUser(_ context.Context, _ string) ([]*models.IdentityMapping, error) {
+	return nil, nil
 }
 
 func TestFormatNTLMPrincipal(t *testing.T) {
@@ -62,9 +72,9 @@ func TestFormatNTLMPrincipal(t *testing.T) {
 func TestResolveIdentityMapping(t *testing.T) {
 	mockStore := &testStoreWithIDMap{
 		mappings: map[string]*models.IdentityMapping{
-			`CORP\alice`:      {Principal: `CORP\alice`, Username: "alice-local"},
-			"bob@EXAMPLE.COM": {Principal: "bob@EXAMPLE.COM", Username: "bob-local"},
-			"charlie":         {Principal: "charlie", Username: "charlie-mapped"},
+			idmapKey("kerberos", `CORP\alice`):      {ProviderName: "kerberos", Principal: `CORP\alice`, Username: "alice-local"},
+			idmapKey("kerberos", "bob@EXAMPLE.COM"): {ProviderName: "kerberos", Principal: "bob@EXAMPLE.COM", Username: "bob-local"},
+			idmapKey("kerberos", "charlie"):         {ProviderName: "kerberos", Principal: "charlie", Username: "charlie-mapped"},
 		},
 	}
 

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
 	pkgkerberos "github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/identity"
@@ -217,6 +219,66 @@ func (h *Handler) resolveKerberosPrincipal(ctx *SMBHandlerContext, principal, re
 	return pkgkerberos.ResolvePrincipal(principal, realm, h.IdentityConfig)
 }
 
+func extractAPReqFromGSSToken(token []byte) ([]byte, error) {
+	if len(token) == 0 {
+		return nil, fmt.Errorf("empty token")
+	}
+	if token[0] != 0x60 {
+		return token, nil
+	}
+	length, lengthBytes, err := parseGSSASN1Length(token[1:])
+	if err != nil {
+		return nil, fmt.Errorf("parse GSS token length: %w", err)
+	}
+	if uint64(length) > uint64(len(token)) {
+		return nil, fmt.Errorf("GSS token length %d exceeds buffer size %d", length, len(token))
+	}
+	bodyStart := 1 + lengthBytes
+	bodyEnd := bodyStart + int(length)
+	if bodyEnd > len(token) {
+		return nil, fmt.Errorf("GSS token truncated: expected %d bytes, have %d", bodyEnd, len(token))
+	}
+	body := token[bodyStart:bodyEnd]
+	if len(body) < 4 || body[0] != 0x06 {
+		return nil, fmt.Errorf("expected OID tag 0x06 at body start")
+	}
+	if body[1] >= 0x80 {
+		return nil, fmt.Errorf("GSS body OID uses long-form length (0x%02x), not supported", body[1])
+	}
+	oidLen := int(body[1])
+	apReqStart := 2 + oidLen + 2
+	if apReqStart > len(body) {
+		return nil, fmt.Errorf("GSS body truncated: need %d bytes for OID+tokID, have %d", apReqStart, len(body))
+	}
+	tokenID := uint16(body[2+oidLen])<<8 | uint16(body[2+oidLen+1])
+	if tokenID != kerbauth.GSSTokenIDAPReq {
+		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (want 0x%04x for AP-REQ)", tokenID, kerbauth.GSSTokenIDAPReq)
+	}
+	return body[apReqStart:], nil
+}
+
+func parseGSSASN1Length(buf []byte) (uint32, int, error) {
+	if len(buf) == 0 {
+		return 0, 0, fmt.Errorf("empty length field")
+	}
+	first := buf[0]
+	if first < 0x80 {
+		return uint32(first), 1, nil
+	}
+	n := int(first & 0x7f)
+	if n == 0 || n > 4 {
+		return 0, 0, fmt.Errorf("unsupported length encoding 0x%02x", first)
+	}
+	if len(buf) < 1+n {
+		return 0, 0, fmt.Errorf("truncated length field")
+	}
+	var length uint32
+	for i := 1; i <= n; i++ {
+		length = (length << 8) | uint32(buf[i])
+	}
+	return length, 1 + n, nil
+}
+
 // sessionEncryptFlag returns the session encrypt data flag if the session
 // should encrypt, or 0 if encryption is not enabled.
 func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
@@ -224,4 +286,20 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 		return types.SMB2SessionFlagEncryptData
 	}
 	return 0
+}
+
+func logKrb5Dump(label string, b []byte) {
+	if !logger.IsDebugEnabled() {
+		return
+	}
+	const maxHex = 512
+	n := len(b)
+	if n > maxHex {
+		b = b[:maxHex]
+	}
+	logger.Debug("krb5 hex dump",
+		"label", label,
+		"len", n,
+		"hex", fmt.Sprintf("%x", b),
+	)
 }

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -1,17 +1,15 @@
 package handlers
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
-	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
-	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
 	pkgkerberos "github.com/marmos91/dittofs/pkg/auth/kerberos"
+	"github.com/marmos91/dittofs/pkg/identity"
 )
 
 // handleKerberosAuth handles Kerberos authentication via SPNEGO.
@@ -36,19 +34,9 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	}
 	smbPrincipal := deriveSMBPrincipal(basePrincipal, h.SMBServicePrincipal)
 
-	// The SPNEGO MechToken is a GSS-API initial context token (RFC 2743
-	// Section 3.1) wrapping the Kerberos AP-REQ. KerberosService.Authenticate
-	// expects a raw AP-REQ, so we need to strip the GSS-API wrapper first.
-	logKrb5Dump("incoming mechToken", mechToken)
-	apReqBytes, err := extractAPReqFromGSSToken(mechToken)
-	if err != nil {
-		logger.Info("Failed to extract AP-REQ from GSS token", "error", err)
-		return NewErrorResult(types.StatusLogonFailure), nil
-	}
-
 	// Authenticate via shared service (handles AP-REQ parsing, verification,
 	// replay detection, and subkey preference).
-	authResult, err := h.KerberosService.Authenticate(apReqBytes, smbPrincipal)
+	authResult, err := h.KerberosService.Authenticate(mechToken, smbPrincipal)
 	if err != nil {
 		logger.Info("Kerberos authentication failed", "error", err)
 		return NewErrorResult(types.StatusLogonFailure), nil
@@ -62,14 +50,9 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	//   - DES (8 bytes) -> zero-pad to 16
 	sessionKey := normalizeSessionKey(authResult.SessionKey.KeyValue)
 
-	// Resolve principal to DittoFS username.
-	// First check DB identity mappings (cross-protocol consistency),
-	// then fall back to configurable mapping (strip-realm default, explicit mapping table).
-	fullPrincipal := authResult.Principal + "@" + authResult.Realm
-	username, _ := h.resolveIdentityMapping(ctx.Context, fullPrincipal, "")
-	if username == "" {
-		username = pkgkerberos.ResolvePrincipal(authResult.Principal, authResult.Realm, h.IdentityConfig)
-	}
+	// Resolve principal to DittoFS username via centralized identity resolver
+	// (DB-backed mapping + convention fallback), or legacy IdentityConfig.
+	username := h.resolveKerberosPrincipal(ctx, authResult.Principal, authResult.Realm)
 
 	logger.Debug("Kerberos authentication succeeded",
 		"principal", authResult.Principal,
@@ -96,25 +79,10 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	}
 
 	// Create authenticated session and configure signing/encryption.
-	// Set ExpiresAt before StoreSession to avoid a data race window where
-	// concurrent readers could see a zero ExpiresAt on a published session.
 	sessionID := h.GenerateSessionID()
-	sess := session.NewSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
-	sess.ExpiresAt = authResult.APReq.Ticket.DecryptedEncPart.EndTime
-	h.SessionManager.StoreSession(sess)
+	sess := h.CreateSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
-
-	// Initialize per-session preauth hash for SMB 3.1.1 key derivation.
-	// Per MS-SMB2 3.3.5.5: each session gets its own preauth hash chain
-	// initialized from the connection hash. Without this, configureSessionSigningWithKey
-	// falls back to the connection-level hash and produces wrong signing/encryption
-	// keys, causing the client to reject the signed SESSION_SETUP response.
-	// The NTLM path initializes this in handleSessionSetup; Kerberos doesn't go
-	// through that path and must do it here.
-	if ctx.ConnCryptoState != nil {
-		ctx.ConnCryptoState.InitSessionPreauthHash(sessionID)
-	}
 
 	// Configure session signing with normalized 16-byte key.
 	// This goes through the same KDF pipeline as NTLM, producing
@@ -131,37 +99,20 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		"signingEnabled", sess.ShouldSign(),
 		"encryptData", sess.ShouldEncrypt())
 
-	// Match the client's Kerberos OID in the SPNEGO response.
-	// Windows clients using the MS OID expect to see it echoed back.
-	responseOID := clientKerberosOID(parsedToken)
-
-	// Build mutual auth AP-REP and wrap it in a GSS-API InitialContextToken
-	// (RFC 2743 Section 3.1) for the SPNEGO accept-complete response:
-	//
-	//   0x60 [len] 0x06 <oid-len> <oid-bytes> 0x02 0x00 <AP-REP>
-	//
-	// AP-REP encryption uses the ticket session key per RFC 4120 (not the
-	// context subkey), which is what clients decrypt with.
-	//
-	// CRITICAL: the OID inside this wrapper must be the standard RFC 4121
-	// Kerberos V5 OID (1.2.840.113554.1.2.2), even when the client advertised
-	// the MS legacy OID (1.2.840.48018.1.2.2) in SPNEGO mechTypes. MIT's
-	// krb5_gss and Heimdal only recognize the standard OID internally, so
-	// echoing the MS OID here causes them to reject the token with
-	// GSS_S_DEFECTIVE_TOKEN (issue #335). Windows SSPI accepts both. The
-	// outer SPNEGO supportedMech (responseOID) still mirrors the client's
-	// choice for negTokenResp compatibility.
+	// Build mutual auth AP-REP via shared service for SPNEGO accept-complete response.
+	// Use the ticket session key for AP-REP encryption per RFC 4120 (not the context
+	// key which may be the subkey). Clients decrypt AP-REP with the ticket session key.
 	ticketSessionKey := authResult.APReq.Ticket.DecryptedEncPart.Key
-	rawAPRep, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
-	var apRepToken []byte
+	apRepToken, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
 	if err != nil {
 		logger.Debug("Failed to build AP-REP for mutual auth", "error", err)
 		// Fall back to accept-complete without AP-REP (still functional).
-	} else {
-		logKrb5Dump("raw AP-REP (pre-wrap)", rawAPRep)
-		apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
-		logKrb5Dump("wrapped AP-REP (GSS)", apRepToken)
+		apRepToken = nil
 	}
+
+	// Match the client's Kerberos OID in the SPNEGO response.
+	// Windows clients using the MS OID expect to see it echoed back.
+	responseOID := clientKerberosOID(parsedToken)
 
 	// Handle SPNEGO mechListMIC for downgrade protection.
 	// If the client sent a mechListMIC, verify it.
@@ -231,98 +182,6 @@ func deriveSMBPrincipal(basePrincipal, override string) string {
 	return basePrincipal
 }
 
-// extractAPReqFromGSSToken strips the GSS-API initial context token wrapper
-// (RFC 2743 Section 3.1) from a Kerberos SPNEGO mechToken and returns the
-// raw AP-REQ bytes that gokrb5's messages.APReq.Unmarshal expects.
-//
-// GSS-API token format:
-//
-//	0x60 [ASN.1 length] 0x06 [OID length] [krb5 OID] [token ID (2 bytes)] [AP-REQ]
-//
-// If the token does not begin with 0x60, it is assumed to already be a raw
-// AP-REQ and returned unchanged (defensive behavior matching the NFS path).
-func extractAPReqFromGSSToken(token []byte) ([]byte, error) {
-	if len(token) == 0 {
-		return nil, fmt.Errorf("empty token")
-	}
-
-	// If not a GSS-API wrapped token, assume raw AP-REQ.
-	if token[0] != 0x60 {
-		return token, nil
-	}
-
-	// Parse the [APPLICATION 0] ASN.1 length to locate the wrapped body.
-	length, lengthBytes, err := parseGSSASN1Length(token[1:])
-	if err != nil {
-		return nil, fmt.Errorf("parse GSS token length: %w", err)
-	}
-
-	// Defense-in-depth: cap declared length against the actual buffer before
-	// any int conversion to avoid bodyEnd wrap-around on unusually large
-	// declared lengths. `length` is uint32; on 32-bit platforms int(length)
-	// could overflow negative.
-	if uint64(length) > uint64(len(token)) {
-		return nil, fmt.Errorf("GSS token length %d exceeds buffer size %d", length, len(token))
-	}
-
-	bodyStart := 1 + lengthBytes
-	bodyEnd := bodyStart + int(length)
-	if bodyEnd > len(token) {
-		return nil, fmt.Errorf("GSS token truncated: expected %d bytes, have %d", bodyEnd, len(token))
-	}
-	body := token[bodyStart:bodyEnd]
-
-	// Body layout: 0x06 <oidLen> <oid...> <tokID hi> <tokID lo> <AP-REQ...>
-	// Minimum: OID tag + OID length byte + 2-byte token ID = 4 bytes.
-	if len(body) < 4 || body[0] != 0x06 {
-		return nil, fmt.Errorf("expected OID tag 0x06 at body start")
-	}
-	// Only short-form DER lengths are supported for the OID. Real Kerberos
-	// mechanism OIDs are at most 11 bytes (the KRB5 and MS KRB5 OIDs are 9
-	// and 10 respectively), so reject anything above 0x7f (which would
-	// otherwise signal BER long-form encoding and be mis-parsed as a length).
-	if body[1] >= 0x80 {
-		return nil, fmt.Errorf("GSS body OID uses long-form length (0x%02x), not supported", body[1])
-	}
-	oidLen := int(body[1])
-	apReqStart := 2 + oidLen + 2 // OID tag+length, OID bytes, token ID
-	if apReqStart > len(body) {
-		return nil, fmt.Errorf("GSS body truncated: need %d bytes for OID+tokID, have %d", apReqStart, len(body))
-	}
-
-	// Token ID (RFC 1964 Section 1.1). Must be 0x0100 for AP-REQ.
-	tokenID := uint16(body[2+oidLen])<<8 | uint16(body[2+oidLen+1])
-	if tokenID != kerbauth.GSSTokenIDAPReq {
-		return nil, fmt.Errorf("unexpected krb5 token ID: 0x%04x (want 0x%04x for AP-REQ)", tokenID, kerbauth.GSSTokenIDAPReq)
-	}
-
-	return body[apReqStart:], nil
-}
-
-// parseGSSASN1Length parses an ASN.1 BER/DER length from the start of buf.
-// Returns the length value and the number of bytes consumed.
-func parseGSSASN1Length(buf []byte) (uint32, int, error) {
-	if len(buf) == 0 {
-		return 0, 0, fmt.Errorf("empty length field")
-	}
-	first := buf[0]
-	if first < 0x80 {
-		return uint32(first), 1, nil
-	}
-	n := int(first & 0x7f)
-	if n == 0 || n > 4 {
-		return 0, 0, fmt.Errorf("unsupported length encoding 0x%02x", first)
-	}
-	if len(buf) < 1+n {
-		return 0, 0, fmt.Errorf("truncated length field")
-	}
-	var length uint32
-	for i := 1; i <= n; i++ {
-		length = (length << 8) | uint32(buf[i])
-	}
-	return length, 1 + n, nil
-}
-
 // clientKerberosOID determines which Kerberos OID the client used in SPNEGO
 // and returns it for use in the server's accept-complete response.
 // Windows clients use the MS OID (1.2.840.48018.1.2.2) and expect it echoed back.
@@ -340,6 +199,24 @@ func clientKerberosOID(parsedToken *auth.ParsedToken) asn1.ObjectIdentifier {
 	return auth.OIDKerberosV5
 }
 
+// resolveKerberosPrincipal resolves a Kerberos principal to a DittoFS username.
+// Uses the centralized identity resolver when available, falling back to the
+// legacy IdentityConfig-based resolution for backward compatibility.
+func (h *Handler) resolveKerberosPrincipal(ctx *SMBHandlerContext, principal, realm string) string {
+	if h.IdentityResolver != nil {
+		cred := &identity.Credential{
+			Provider:   "kerberos",
+			ExternalID: principal + "@" + realm,
+			Attributes: map[string]string{"realm": realm},
+		}
+		resolved, err := h.IdentityResolver.Resolve(ctx.Context, cred)
+		if err == nil && resolved.Found {
+			return resolved.Username
+		}
+	}
+	return pkgkerberos.ResolvePrincipal(principal, realm, h.IdentityConfig)
+}
+
 // sessionEncryptFlag returns the session encrypt data flag if the session
 // should encrypt, or 0 if encryption is not enabled.
 func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
@@ -347,24 +224,4 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 		return types.SMB2SessionFlagEncryptData
 	}
 	return 0
-}
-
-// logKrb5Dump emits a hex dump of a Kerberos-related byte blob at debug level.
-// Used when diagnosing interop issues with MIT clients — inspecting the exact
-// wire bytes is the fastest way to isolate framing bugs (see issue #335).
-// Safe to leave enabled: only fires under DEBUG and caps the hex to 512 bytes.
-func logKrb5Dump(label string, b []byte) {
-	if !logger.IsDebugEnabled() {
-		return
-	}
-	const maxHex = 512
-	n := len(b)
-	if n > maxHex {
-		b = b[:maxHex]
-	}
-	logger.Debug("krb5 hex dump",
-		"label", label,
-		"len", n,
-		"hex", fmt.Sprintf("%x", b),
-	)
 }

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -287,4 +287,3 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 	}
 	return 0
 }
-

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -288,18 +288,3 @@ func sessionEncryptFlag(sess interface{ ShouldEncrypt() bool }) uint16 {
 	return 0
 }
 
-func logKrb5Dump(label string, b []byte) {
-	if !logger.IsDebugEnabled() {
-		return
-	}
-	const maxHex = 512
-	n := len(b)
-	if n > maxHex {
-		b = b[:maxHex]
-	}
-	logger.Debug("krb5 hex dump",
-		"label", label,
-		"len", n,
-		"hex", fmt.Sprintf("%x", b),
-	)
-}

--- a/internal/controlplane/api/handlers/identity_mappings.go
+++ b/internal/controlplane/api/handlers/identity_mappings.go
@@ -103,7 +103,7 @@ func (h *IdentityMappingHandler) Create(w http.ResponseWriter, r *http.Request) 
 	WriteJSONCreated(w, mappingToResponse(mapping))
 }
 
-// Delete handles DELETE /api/v1/identity-mappings/{provider}/{principal}.
+// Delete handles DELETE /api/v1/identity-mappings/by-provider/{provider}/{principal}.
 func (h *IdentityMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	provider := chi.URLParam(r, "provider")
 	if provider == "" {

--- a/internal/controlplane/api/handlers/identity_mappings.go
+++ b/internal/controlplane/api/handlers/identity_mappings.go
@@ -12,34 +12,43 @@ import (
 
 // IdentityMappingHandler handles identity mapping API endpoints.
 type IdentityMappingHandler struct {
-	store store.IdentityMappingStore
+	store    store.IdentityMappingStore
+	onChange func()
 }
 
 // NewIdentityMappingHandler creates a new IdentityMappingHandler.
-// The cpStore must implement store.IdentityMappingStore (GORMStore does).
 func NewIdentityMappingHandler(cpStore store.IdentityMappingStore) *IdentityMappingHandler {
 	return &IdentityMappingHandler{store: cpStore}
 }
 
+// SetOnChange registers a callback invoked after successful create/delete.
+func (h *IdentityMappingHandler) SetOnChange(fn func()) {
+	h.onChange = fn
+}
+
 // CreateIdentityMappingRequest is the request body for POST /api/v1/identity-mappings.
 type CreateIdentityMappingRequest struct {
-	Principal string `json:"principal"`
-	Username  string `json:"username"`
+	ProviderName string `json:"provider_name"`
+	Principal    string `json:"principal"`
+	Username     string `json:"username"`
 }
 
 // IdentityMappingResponse is the response body for identity mapping operations.
 type IdentityMappingResponse struct {
-	ID        string `json:"id"`
-	Principal string `json:"principal"`
-	Username  string `json:"username"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID           string `json:"id"`
+	ProviderName string `json:"provider_name"`
+	Principal    string `json:"principal"`
+	Username     string `json:"username"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 }
 
 // List handles GET /api/v1/identity-mappings.
-// Lists all identity mappings (admin only).
+// Optional query parameter: ?provider=kerberos
 func (h *IdentityMappingHandler) List(w http.ResponseWriter, r *http.Request) {
-	mappings, err := h.store.ListIdentityMappings(r.Context())
+	provider := r.URL.Query().Get("provider")
+
+	mappings, err := h.store.ListIdentityMappings(r.Context(), provider)
 	if err != nil {
 		InternalServerError(w, "Failed to list identity mappings")
 		return
@@ -54,7 +63,6 @@ func (h *IdentityMappingHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create handles POST /api/v1/identity-mappings.
-// Creates a new identity mapping (admin only).
 func (h *IdentityMappingHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var req CreateIdentityMappingRequest
 	if !decodeJSONBody(w, r, &req) {
@@ -69,41 +77,86 @@ func (h *IdentityMappingHandler) Create(w http.ResponseWriter, r *http.Request) 
 		BadRequest(w, "Username is required")
 		return
 	}
+	if req.ProviderName == "" {
+		req.ProviderName = "kerberos"
+	}
 
 	mapping := &models.IdentityMapping{
-		Principal: req.Principal,
-		Username:  req.Username,
+		ProviderName: req.ProviderName,
+		Principal:    req.Principal,
+		Username:     req.Username,
 	}
 
 	if err := h.store.CreateIdentityMapping(r.Context(), mapping); err != nil {
 		if errors.Is(err, models.ErrDuplicateMapping) {
-			Conflict(w, "Identity mapping for this principal already exists")
+			Conflict(w, "Identity mapping for this provider and principal already exists")
 			return
 		}
 		InternalServerError(w, "Failed to create identity mapping")
 		return
 	}
 
+	if h.onChange != nil {
+		h.onChange()
+	}
+
 	WriteJSONCreated(w, mappingToResponse(mapping))
 }
 
-// Delete handles DELETE /api/v1/identity-mappings/{principal}.
-// Deletes an identity mapping by principal (admin only).
+// Delete handles DELETE /api/v1/identity-mappings/{provider}/{principal}.
 func (h *IdentityMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	if provider == "" {
+		BadRequest(w, "Provider is required")
+		return
+	}
+
+	h.deleteMapping(w, r, provider)
+}
+
+// ListForUser handles GET /api/v1/identity-mappings/users/{username}.
+func (h *IdentityMappingHandler) ListForUser(w http.ResponseWriter, r *http.Request) {
+	username := chi.URLParam(r, "username")
+	if username == "" {
+		BadRequest(w, "Username is required")
+		return
+	}
+
+	mappings, err := h.store.ListIdentityMappingsForUser(r.Context(), username)
+	if err != nil {
+		InternalServerError(w, "Failed to list identity mappings for user")
+		return
+	}
+
+	response := make([]IdentityMappingResponse, len(mappings))
+	for i, m := range mappings {
+		response[i] = mappingToResponse(m)
+	}
+
+	WriteJSONOK(w, response)
+}
+
+// DeleteLegacy handles DELETE /api/v1/adapters/{type}/identity-mappings/{principal}.
+// Backward-compatible endpoint that defaults provider to "kerberos".
+func (h *IdentityMappingHandler) DeleteLegacy(w http.ResponseWriter, r *http.Request) {
+	h.deleteMapping(w, r, "kerberos")
+}
+
+// deleteMapping is the shared implementation for Delete and DeleteLegacy.
+func (h *IdentityMappingHandler) deleteMapping(w http.ResponseWriter, r *http.Request, provider string) {
 	principal := chi.URLParam(r, "principal")
 	if principal == "" {
 		BadRequest(w, "Principal is required")
 		return
 	}
 
-	// URL-decode the principal (it may contain @ and other special characters)
 	decodedPrincipal, err := url.PathUnescape(principal)
 	if err != nil {
 		BadRequest(w, "Invalid principal format")
 		return
 	}
 
-	if err := h.store.DeleteIdentityMapping(r.Context(), decodedPrincipal); err != nil {
+	if err := h.store.DeleteIdentityMapping(r.Context(), provider, decodedPrincipal); err != nil {
 		if errors.Is(err, models.ErrMappingNotFound) {
 			NotFound(w, "Identity mapping not found")
 			return
@@ -112,16 +165,20 @@ func (h *IdentityMappingHandler) Delete(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if h.onChange != nil {
+		h.onChange()
+	}
+
 	WriteNoContent(w)
 }
 
-// mappingToResponse converts an IdentityMapping model to an API response.
 func mappingToResponse(m *models.IdentityMapping) IdentityMappingResponse {
 	return IdentityMappingResponse{
-		ID:        m.ID,
-		Principal: m.Principal,
-		Username:  m.Username,
-		CreatedAt: m.CreatedAt.Format("2006-01-02T15:04:05Z"),
-		UpdatedAt: m.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+		ID:           m.ID,
+		ProviderName: m.ProviderName,
+		Principal:    m.Principal,
+		Username:     m.Username,
+		CreatedAt:    m.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:    m.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
 }

--- a/internal/controlplane/api/handlers/identity_mappings.go
+++ b/internal/controlplane/api/handlers/identity_mappings.go
@@ -111,7 +111,13 @@ func (h *IdentityMappingHandler) Delete(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	h.deleteMapping(w, r, provider)
+	decodedProvider, err := url.PathUnescape(provider)
+	if err != nil {
+		BadRequest(w, "Invalid provider format")
+		return
+	}
+
+	h.deleteMapping(w, r, decodedProvider)
 }
 
 // ListForUser handles GET /api/v1/identity-mappings/users/{username}.
@@ -122,7 +128,13 @@ func (h *IdentityMappingHandler) ListForUser(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	mappings, err := h.store.ListIdentityMappingsForUser(r.Context(), username)
+	decodedUsername, err := url.PathUnescape(username)
+	if err != nil {
+		BadRequest(w, "Invalid username format")
+		return
+	}
+
+	mappings, err := h.store.ListIdentityMappingsForUser(r.Context(), decodedUsername)
 	if err != nil {
 		InternalServerError(w, "Failed to list identity mappings for user")
 		return

--- a/internal/controlplane/api/handlers/identity_mappings.go
+++ b/internal/controlplane/api/handlers/identity_mappings.go
@@ -17,13 +17,9 @@ type IdentityMappingHandler struct {
 }
 
 // NewIdentityMappingHandler creates a new IdentityMappingHandler.
-func NewIdentityMappingHandler(cpStore store.IdentityMappingStore) *IdentityMappingHandler {
-	return &IdentityMappingHandler{store: cpStore}
-}
-
-// SetOnChange registers a callback invoked after successful create/delete.
-func (h *IdentityMappingHandler) SetOnChange(fn func()) {
-	h.onChange = fn
+// The optional onChange callback is invoked after successful create/delete operations.
+func NewIdentityMappingHandler(cpStore store.IdentityMappingStore, onChange func()) *IdentityMappingHandler {
+	return &IdentityMappingHandler{store: cpStore, onChange: onChange}
 }
 
 // CreateIdentityMappingRequest is the request body for POST /api/v1/identity-mappings.
@@ -54,12 +50,7 @@ func (h *IdentityMappingHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := make([]IdentityMappingResponse, len(mappings))
-	for i, m := range mappings {
-		response[i] = mappingToResponse(m)
-	}
-
-	WriteJSONOK(w, response)
+	WriteJSONOK(w, mappingsToResponse(mappings))
 }
 
 // Create handles POST /api/v1/identity-mappings.
@@ -76,9 +67,6 @@ func (h *IdentityMappingHandler) Create(w http.ResponseWriter, r *http.Request) 
 	if req.Username == "" {
 		BadRequest(w, "Username is required")
 		return
-	}
-	if req.ProviderName == "" {
-		req.ProviderName = "kerberos"
 	}
 
 	mapping := &models.IdentityMapping{
@@ -140,12 +128,7 @@ func (h *IdentityMappingHandler) ListForUser(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	response := make([]IdentityMappingResponse, len(mappings))
-	for i, m := range mappings {
-		response[i] = mappingToResponse(m)
-	}
-
-	WriteJSONOK(w, response)
+	WriteJSONOK(w, mappingsToResponse(mappings))
 }
 
 // DeleteLegacy handles DELETE /api/v1/adapters/{type}/identity-mappings/{principal}.
@@ -182,6 +165,14 @@ func (h *IdentityMappingHandler) deleteMapping(w http.ResponseWriter, r *http.Re
 	}
 
 	WriteNoContent(w)
+}
+
+func mappingsToResponse(mappings []*models.IdentityMapping) []IdentityMappingResponse {
+	response := make([]IdentityMappingResponse, len(mappings))
+	for i, m := range mappings {
+		response[i] = mappingToResponse(m)
+	}
+	return response
 }
 
 func mappingToResponse(m *models.IdentityMapping) IdentityMappingResponse {

--- a/pkg/adapter/identity.go
+++ b/pkg/adapter/identity.go
@@ -1,0 +1,103 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/identity"
+	identitykerberos "github.com/marmos91/dittofs/pkg/identity/kerberos"
+)
+
+// ExtractRealm extracts the Kerberos realm from a service principal
+// (e.g., "nfs/host@EXAMPLE.COM" returns "EXAMPLE.COM").
+func ExtractRealm(principal string) string {
+	if idx := strings.LastIndex(principal, "@"); idx >= 0 && idx < len(principal)-1 {
+		return principal[idx+1:]
+	}
+	return ""
+}
+
+// BuildIdentityResolver creates a centralized identity Resolver backed by
+// the control plane's identity mapping store and user store. Both the NFS
+// and SMB adapters use this to map Kerberos principals to DittoFS users.
+func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver {
+	cpStore := rt.Store()
+
+	userLookup := func(ctx context.Context, username string) (*identity.ResolvedIdentity, error) {
+		user, err := cpStore.GetUser(ctx, username)
+		if err != nil {
+			return &identity.ResolvedIdentity{Found: false}, nil
+		}
+		uid := uint32(1000)
+		if user.UID != nil {
+			uid = *user.UID
+		}
+		gid := uint32(1000)
+		if user.GID != nil {
+			gid = *user.GID
+		}
+		var gids []uint32
+		for _, g := range user.Groups {
+			if g.GID != nil {
+				gids = append(gids, *g.GID)
+			}
+		}
+		return &identity.ResolvedIdentity{
+			Username: user.Username,
+			UID:      uid,
+			GID:      gid,
+			GIDs:     gids,
+			Found:    true,
+		}, nil
+	}
+
+	var linkStore identity.LinkStore
+	if ims, ok := cpStore.(store.IdentityMappingStore); ok {
+		linkStore = &identity.FuncLinkStore{
+			GetLinkFn: func(ctx context.Context, provider, externalID string) (string, bool, error) {
+				m, err := ims.GetIdentityMapping(ctx, provider, externalID)
+				if err != nil {
+					if errors.Is(err, models.ErrMappingNotFound) {
+						return "", false, nil
+					}
+					return "", false, err
+				}
+				return m.Username, true, nil
+			},
+			ListLinksFn: func(ctx context.Context, provider string) ([]identity.IdentityLink, error) {
+				mappings, err := ims.ListIdentityMappings(ctx, provider)
+				if err != nil {
+					return nil, err
+				}
+				links := make([]identity.IdentityLink, len(mappings))
+				for i, m := range mappings {
+					links[i] = identity.IdentityLink{ProviderName: m.ProviderName, ExternalID: m.Principal, Username: m.Username}
+				}
+				return links, nil
+			},
+			CreateLinkFn:       func(_ context.Context, _ identity.IdentityLink) error { return nil },
+			DeleteLinkFn:       func(_ context.Context, _, _ string) error { return nil },
+			ListLinksForUserFn: func(ctx context.Context, username string) ([]identity.IdentityLink, error) {
+				mappings, err := ims.ListIdentityMappingsForUser(ctx, username)
+				if err != nil {
+					return nil, err
+				}
+				links := make([]identity.IdentityLink, len(mappings))
+				for i, m := range mappings {
+					links[i] = identity.IdentityLink{ProviderName: m.ProviderName, ExternalID: m.Principal, Username: m.Username}
+				}
+				return links, nil
+			},
+		}
+	}
+
+	krbProvider := identitykerberos.New(realm, linkStore, userLookup)
+	return identity.NewResolver(
+		identity.WithProvider(krbProvider),
+		identity.WithCacheTTL(identity.DefaultCacheTTL),
+	)
+}

--- a/pkg/adapter/identity.go
+++ b/pkg/adapter/identity.go
@@ -30,7 +30,10 @@ func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver
 	userLookup := func(ctx context.Context, username string) (*identity.ResolvedIdentity, error) {
 		user, err := cpStore.GetUser(ctx, username)
 		if err != nil {
-			return &identity.ResolvedIdentity{Found: false}, nil
+			if errors.Is(err, models.ErrUserNotFound) {
+				return &identity.ResolvedIdentity{Found: false}, nil
+			}
+			return nil, err
 		}
 		uid := uint32(1000)
 		if user.UID != nil {
@@ -79,8 +82,8 @@ func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver
 				}
 				return links, nil
 			},
-			CreateLinkFn:       func(_ context.Context, _ identity.IdentityLink) error { return nil },
-			DeleteLinkFn:       func(_ context.Context, _, _ string) error { return nil },
+			// CreateLinkFn and DeleteLinkFn left nil — writes go through the API handler, not the resolver.
+			// Calling them returns identity.ErrNotConfigured.
 			ListLinksForUserFn: func(ctx context.Context, username string) ([]identity.IdentityLink, error) {
 				mappings, err := ims.ListIdentityMappingsForUser(ctx, username)
 				if err != nil {

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -394,7 +394,7 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	s.initNSMHandler(rt, metadataService)
 
 	// Initialize RPCSEC_GSS processor if Kerberos is enabled
-	s.initGSSProcessor()
+	s.initGSSProcessor(rt)
 
 	logger.Debug("NFS adapter configured with runtime", "shares", rt.CountShares())
 

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/adapter"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/config"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
@@ -573,11 +574,12 @@ func (s *NFSAdapter) performNSMStartup(ctx context.Context) {
 // initGSSProcessor initializes the RPCSEC_GSS processor if Kerberos is configured.
 //
 // This creates a kerberos.Provider from config, a StaticMapper for identity mapping,
-// and a GSSProcessor that handles the INIT/DATA/DESTROY lifecycle.
+// and a GSSProcessor that handles the INIT/DATA/DESTROY lifecycle. When a runtime
+// is available, a centralized identity Resolver is also wired for DB-backed mapping.
 //
 // If Kerberos is not enabled or initialization fails, the adapter continues without
 // GSS support (AUTH_UNIX/AUTH_NULL only).
-func (s *NFSAdapter) initGSSProcessor() {
+func (s *NFSAdapter) initGSSProcessor(rt *runtime.Runtime) {
 	if s.kerberosConfig == nil {
 		return
 	}
@@ -595,7 +597,7 @@ func (s *NFSAdapter) initGSSProcessor() {
 	kerbService := kerbauth.NewKerberosService(provider)
 	verifier := gss.NewKrb5Verifier(kerbService)
 
-	// Create the GSS processor
+	// Create the GSS processor with the legacy static mapper as fallback
 	s.gssProcessor = gss.NewGSSProcessor(
 		verifier,
 		mapper,
@@ -603,9 +605,18 @@ func (s *NFSAdapter) initGSSProcessor() {
 		s.kerberosConfig.ContextTTL,
 	)
 
+	// Wire centralized identity resolver (DB-backed mapping + convention fallback).
+	// This takes precedence over the legacy StaticMapper when resolving principals.
+	if rt != nil {
+		realm := adapter.ExtractRealm(s.kerberosConfig.ServicePrincipal)
+		resolver := adapter.BuildIdentityResolver(rt, realm)
+		s.gssProcessor.SetResolver(resolver)
+	}
+
 	logger.Info("RPCSEC_GSS (Kerberos) authentication enabled",
 		"service_principal", s.kerberosConfig.ServicePrincipal,
 		"max_contexts", s.kerberosConfig.MaxContexts,
 		"context_ttl", s.kerberosConfig.ContextTTL,
 	)
 }
+

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -619,4 +619,3 @@ func (s *NFSAdapter) initGSSProcessor(rt *runtime.Runtime) {
 		"context_ttl", s.kerberosConfig.ContextTTL,
 	)
 }
-

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -611,6 +611,7 @@ func (s *NFSAdapter) initGSSProcessor(rt *runtime.Runtime) {
 		realm := adapter.ExtractRealm(s.kerberosConfig.ServicePrincipal)
 		resolver := adapter.BuildIdentityResolver(rt, realm)
 		s.gssProcessor.SetResolver(resolver)
+		rt.OnIdentityMappingChange(resolver.InvalidateCache)
 	}
 
 	logger.Info("RPCSEC_GSS (Kerberos) authentication enabled",

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -254,6 +254,13 @@ func (s *Adapter) SetRuntime(rtAny any) {
 		logger.Debug("SMB adapter: identity resolver configured for LSARPC")
 	}
 
+	// Wire centralized identity resolver for Kerberos principal → DittoFS user mapping.
+	// Uses DB-backed LinkStore + convention fallback, shared with the NFS adapter.
+	if s.handler.KerberosProvider != nil {
+		realm := adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
+		s.handler.IdentityResolver = adapter.BuildIdentityResolver(rt, realm)
+	}
+
 	logger.Debug("SMB adapter configured with runtime", "shares", rt.CountShares())
 
 	// Apply live SMB adapter settings from SettingsWatcher.
@@ -447,6 +454,13 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 		s.handler.IdentityConfig = kerberos.DefaultIdentityConfig()
 	}
 
+	// Wire identity resolver if runtime is already injected (SetRuntime may
+	// have been called before SetKerberosProvider depending on init order).
+	if s.handler.Registry != nil {
+		realm := adapter.ExtractRealm(provider.ServicePrincipal())
+		s.handler.IdentityResolver = adapter.BuildIdentityResolver(s.handler.Registry, realm)
+	}
+
 	logger.Debug("SMB adapter Kerberos provider configured",
 		"principal", provider.ServicePrincipal(),
 		"stripRealm", s.handler.IdentityConfig.StripRealm)
@@ -599,3 +613,4 @@ func (r *metadataServiceResolver) GetLockManagerForHandle(handleKey string) lock
 	}
 	return r.metaSvc.GetLockManagerForShare(shareName)
 }
+

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -256,13 +256,7 @@ func (s *Adapter) SetRuntime(rtAny any) {
 
 	// Wire centralized identity resolver for Kerberos principal → DittoFS user mapping.
 	// Uses DB-backed LinkStore + convention fallback, shared with the NFS adapter.
-	if s.handler.KerberosProvider != nil {
-		realm := adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
-		resolver := adapter.BuildIdentityResolver(rt, realm)
-		s.handler.IdentityResolver = resolver
-		unsub := rt.OnIdentityMappingChange(resolver.InvalidateCache)
-		s.shareUnsubscribers = append(s.shareUnsubscribers, unsub)
-	}
+	s.wireIdentityResolver(rt)
 
 	logger.Debug("SMB adapter configured with runtime", "shares", rt.CountShares())
 
@@ -459,14 +453,27 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 
 	// Wire identity resolver if runtime is already injected (SetRuntime may
 	// have been called before SetKerberosProvider depending on init order).
-	if s.handler.Registry != nil {
-		realm := adapter.ExtractRealm(provider.ServicePrincipal())
-		s.handler.IdentityResolver = adapter.BuildIdentityResolver(s.handler.Registry, realm)
-	}
+	s.wireIdentityResolver(s.handler.Registry)
 
 	logger.Debug("SMB adapter Kerberos provider configured",
 		"principal", provider.ServicePrincipal(),
 		"stripRealm", s.handler.IdentityConfig.StripRealm)
+}
+
+// wireIdentityResolver creates and wires a centralized identity resolver for
+// Kerberos principal to DittoFS user mapping. Both SetRuntime and
+// SetKerberosProvider call this, since either may be called first depending
+// on initialization order. The method is a no-op when either the Kerberos
+// provider or the runtime is not yet available.
+func (s *Adapter) wireIdentityResolver(rt *runtime.Runtime) {
+	if s.handler.KerberosProvider == nil || rt == nil {
+		return
+	}
+	realm := adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
+	resolver := adapter.BuildIdentityResolver(rt, realm)
+	s.handler.IdentityResolver = resolver
+	unsub := rt.OnIdentityMappingChange(resolver.InvalidateCache)
+	s.shareUnsubscribers = append(s.shareUnsubscribers, unsub)
 }
 
 const (

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -258,7 +258,10 @@ func (s *Adapter) SetRuntime(rtAny any) {
 	// Uses DB-backed LinkStore + convention fallback, shared with the NFS adapter.
 	if s.handler.KerberosProvider != nil {
 		realm := adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
-		s.handler.IdentityResolver = adapter.BuildIdentityResolver(rt, realm)
+		resolver := adapter.BuildIdentityResolver(rt, realm)
+		s.handler.IdentityResolver = resolver
+		unsub := rt.OnIdentityMappingChange(resolver.InvalidateCache)
+		s.shareUnsubscribers = append(s.shareUnsubscribers, unsub)
 	}
 
 	logger.Debug("SMB adapter configured with runtime", "shares", rt.CountShares())

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -613,4 +613,3 @@ func (r *metadataServiceResolver) GetLockManagerForHandle(handleKey string) lock
 	}
 	return r.metaSvc.GetLockManagerForShare(shareName)
 }
-

--- a/pkg/apiclient/identity_mappings.go
+++ b/pkg/apiclient/identity_mappings.go
@@ -7,39 +7,54 @@ import (
 
 // IdentityMapping represents an identity mapping in the system.
 type IdentityMapping struct {
-	ID        string `json:"id"`
-	Principal string `json:"principal"`
-	Username  string `json:"username"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID           string `json:"id"`
+	ProviderName string `json:"provider_name"`
+	Principal    string `json:"principal"`
+	Username     string `json:"username"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 }
 
 // CreateIdentityMappingRequest is the request to create an identity mapping.
 type CreateIdentityMappingRequest struct {
-	Principal string `json:"principal"`
-	Username  string `json:"username"`
+	ProviderName string `json:"provider_name"`
+	Principal    string `json:"principal"`
+	Username     string `json:"username"`
 }
 
-// identityMappingsPath is the API path for identity mappings.
-// Mappings are shared across protocols (NFS and SMB) — the /nfs/ segment
-// is the canonical path but the same data is accessible via /smb/.
-const identityMappingsPath = "/api/v1/adapters/nfs/identity-mappings"
-
-// ListIdentityMappings returns all identity mappings.
-func (c *Client) ListIdentityMappings() ([]IdentityMapping, error) {
-	return listResources[IdentityMapping](c, identityMappingsPath)
+// ListIdentityMappings returns all identity mappings, optionally filtered by provider.
+func (c *Client) ListIdentityMappings(provider string) ([]IdentityMapping, error) {
+	path := "/api/v1/identity-mappings"
+	if provider != "" {
+		path += "?provider=" + url.QueryEscape(provider)
+	}
+	return listResources[IdentityMapping](c, path)
 }
 
 // CreateIdentityMapping creates a new identity mapping.
-func (c *Client) CreateIdentityMapping(principal, username string) (*IdentityMapping, error) {
-	req := &CreateIdentityMappingRequest{
-		Principal: principal,
-		Username:  username,
+func (c *Client) CreateIdentityMapping(provider, principal, username string) (*IdentityMapping, error) {
+	if provider == "" {
+		provider = "kerberos"
 	}
-	return createResource[IdentityMapping](c, identityMappingsPath, req)
+	req := &CreateIdentityMappingRequest{
+		ProviderName: provider,
+		Principal:    principal,
+		Username:     username,
+	}
+	return createResource[IdentityMapping](c, "/api/v1/identity-mappings", req)
 }
 
-// DeleteIdentityMapping deletes an identity mapping by principal.
-func (c *Client) DeleteIdentityMapping(principal string) error {
-	return deleteResource(c, fmt.Sprintf("%s/%s", identityMappingsPath, url.PathEscape(principal)))
+// DeleteIdentityMapping deletes an identity mapping by provider and principal.
+func (c *Client) DeleteIdentityMapping(provider, principal string) error {
+	if provider == "" {
+		provider = "kerberos"
+	}
+	return deleteResource(c, fmt.Sprintf("/api/v1/identity-mappings/by-provider/%s/%s",
+		url.PathEscape(provider), url.PathEscape(principal)))
+}
+
+// ListIdentityMappingsForUser returns all identity mappings for a user.
+func (c *Client) ListIdentityMappingsForUser(username string) ([]IdentityMapping, error) {
+	return listResources[IdentityMapping](c, fmt.Sprintf("/api/v1/identity-mappings/users/%s",
+		url.PathEscape(username)))
 }

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -330,6 +330,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				r.Route("/identity-mappings", func(r chi.Router) {
 					r.Use(apiMiddleware.RequireAdmin())
 					idmapHandler := handlers.NewIdentityMappingHandler(ims)
+					idmapHandler.SetOnChange(rt.NotifyIdentityMappingChange)
 					r.Get("/", idmapHandler.List)
 					r.Post("/", idmapHandler.Create)
 					r.Route("/by-provider/{provider}", func(r chi.Router) {

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -45,7 +45,7 @@ import (
 //   - /api/v1/adapters/nfs/clients/{id}/sessions - NFS client sessions (admin only)
 //   - /api/v1/adapters/{type}/grace - NFS grace period management (admin only)
 //   - /api/v1/adapters/{type}/netgroups - NFS netgroup management (admin only)
-//   - /api/v1/adapters/{type}/identity-mappings - Identity mapping management, shared across protocols (admin only)
+//   - /api/v1/adapters/{type}/identity-mappings - NFS identity mapping management (admin only)
 //   - /api/v1/adapters/{type}/mounts - Protocol-specific mount listing (admin only)
 //   - /api/v1/settings/* - System settings management (admin only)
 //   - /api/v1/mounts - Unified mount listing (admin only)
@@ -312,18 +312,32 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 							})
 						}
 
-						// Identity mapping management (shared across NFS/SMB) - requires IdentityMappingStore capability
+						// Legacy identity mapping route (deprecated: use /api/v1/identity-mappings instead)
 						if ims, ok := cpStore.(store.IdentityMappingStore); ok {
 							r.Route("/identity-mappings", func(r chi.Router) {
-								idmapHandler := handlers.NewIdentityMappingHandler(ims)
-								r.Get("/", idmapHandler.List)
-								r.Post("/", idmapHandler.Create)
-								r.Delete("/{principal}", idmapHandler.Delete)
+								legacyHandler := handlers.NewIdentityMappingHandler(ims)
+								r.Get("/", legacyHandler.List)
+								r.Post("/", legacyHandler.Create)
+								r.Delete("/{principal}", legacyHandler.DeleteLegacy)
 							})
 						}
 					})
 				})
 			})
+
+			// Identity mappings — links external identities to DittoFS users (admin only)
+			if ims, ok := cpStore.(store.IdentityMappingStore); ok {
+				r.Route("/identity-mappings", func(r chi.Router) {
+					r.Use(apiMiddleware.RequireAdmin())
+					idmapHandler := handlers.NewIdentityMappingHandler(ims)
+					r.Get("/", idmapHandler.List)
+					r.Post("/", idmapHandler.Create)
+					r.Route("/by-provider/{provider}", func(r chi.Router) {
+						r.Delete("/{principal}", idmapHandler.Delete)
+					})
+					r.Get("/users/{username}", idmapHandler.ListForUser)
+				})
+			}
 
 			// System operations (admin only)
 			r.Route("/system", func(r chi.Router) {

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -315,7 +315,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 						// Legacy identity mapping route (deprecated: use /api/v1/identity-mappings instead)
 						if ims, ok := cpStore.(store.IdentityMappingStore); ok {
 							r.Route("/identity-mappings", func(r chi.Router) {
-								legacyHandler := handlers.NewIdentityMappingHandler(ims)
+								legacyHandler := handlers.NewIdentityMappingHandler(ims, rt.NotifyIdentityMappingChange)
 								r.Get("/", legacyHandler.List)
 								r.Post("/", legacyHandler.Create)
 								r.Delete("/{principal}", legacyHandler.DeleteLegacy)
@@ -329,13 +329,10 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 			if ims, ok := cpStore.(store.IdentityMappingStore); ok {
 				r.Route("/identity-mappings", func(r chi.Router) {
 					r.Use(apiMiddleware.RequireAdmin())
-					idmapHandler := handlers.NewIdentityMappingHandler(ims)
-					idmapHandler.SetOnChange(rt.NotifyIdentityMappingChange)
+					idmapHandler := handlers.NewIdentityMappingHandler(ims, rt.NotifyIdentityMappingChange)
 					r.Get("/", idmapHandler.List)
 					r.Post("/", idmapHandler.Create)
-					r.Route("/by-provider/{provider}", func(r chi.Router) {
-						r.Delete("/{principal}", idmapHandler.Delete)
-					})
+					r.Delete("/by-provider/{provider}/{principal}", idmapHandler.Delete)
 					r.Get("/users/{username}", idmapHandler.ListForUser)
 				})
 			}

--- a/pkg/controlplane/models/identity_mapping.go
+++ b/pkg/controlplane/models/identity_mapping.go
@@ -5,17 +5,17 @@ import (
 	"time"
 )
 
-// IdentityMapping maps an authentication principal to a control plane username.
-// This is used for resolving Kerberos principals (e.g., "alice@EXAMPLE.COM")
-// or NTLM principals (e.g., "CORP\alice") to local DittoFS user accounts.
-// Mappings are shared across protocols (NFS and SMB) to ensure consistent
-// uid/gid resolution in mixed-protocol deployments.
+// IdentityMapping links an external identity to a DittoFS user account.
+// The composite key (ProviderName, Principal) supports multiple identity
+// providers (Kerberos, OIDC, AD, LDAP) and linked identities where one
+// DittoFS user has credentials from different external systems.
 type IdentityMapping struct {
-	ID        string    `gorm:"primaryKey;type:varchar(36)" json:"id"`
-	Principal string    `gorm:"uniqueIndex;type:varchar(255);not null" json:"principal"`
-	Username  string    `gorm:"type:varchar(255);not null" json:"username"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID           string    `gorm:"primaryKey;type:varchar(36)" json:"id"`
+	ProviderName string    `gorm:"uniqueIndex:idx_provider_principal;type:varchar(50);not null;default:kerberos" json:"provider_name"`
+	Principal    string    `gorm:"uniqueIndex:idx_provider_principal;type:varchar(255);not null" json:"principal"`
+	Username     string    `gorm:"type:varchar(255);not null" json:"username"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // Error types for identity mapping operations.

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -70,6 +70,8 @@ type Runtime struct {
 	adapterProviders   map[string]any
 	adapterProvidersMu sync.RWMutex
 
+	identityChangeCallbacks []func()
+
 	// statusCheckers is the lazy per-entity cached health-checker
 	// map backing [Runtime.BlockStoreChecker],
 	// [Runtime.MetadataStoreChecker], [Runtime.AdapterChecker], and
@@ -458,6 +460,36 @@ func (r *Runtime) GetIdentityMappingStore() store.IdentityMappingStore {
 		return ims
 	}
 	return nil
+}
+
+// OnIdentityMappingChange registers a callback invoked when identity mappings
+// are created or deleted via the API. Adapters use this to invalidate their
+// identity resolver caches. Returns an unsubscribe function.
+func (r *Runtime) OnIdentityMappingChange(fn func()) func() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.identityChangeCallbacks = append(r.identityChangeCallbacks, fn)
+	idx := len(r.identityChangeCallbacks) - 1
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if idx < len(r.identityChangeCallbacks) {
+			r.identityChangeCallbacks[idx] = nil
+		}
+	}
+}
+
+// NotifyIdentityMappingChange fires all registered identity change callbacks.
+func (r *Runtime) NotifyIdentityMappingChange() {
+	r.mu.RLock()
+	cbs := make([]func(), len(r.identityChangeCallbacks))
+	copy(cbs, r.identityChangeCallbacks)
+	r.mu.RUnlock()
+	for _, fn := range cbs {
+		if fn != nil {
+			fn()
+		}
+	}
 }
 
 // --- Settings Access ---

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -230,6 +230,12 @@ func New(config *Config) (*GORMStore, error) {
 		_ = db.Exec("DROP INDEX IF EXISTS idx_block_store_configs_name")
 	}
 
+	// Pre-migration: drop legacy single-column unique index on identity_mappings.principal.
+	// The new composite index idx_provider_principal (provider_name, principal) replaces it.
+	if db.Migrator().HasTable(&models.IdentityMapping{}) {
+		_ = db.Exec("DROP INDEX IF EXISTS idx_identity_mappings_principal")
+	}
+
 	// Pre-migration: rename read_cache_size column to read_buffer_size if it exists.
 	if db.Migrator().HasColumn(&models.Share{}, "read_cache_size") {
 		if err := db.Migrator().RenameColumn(&models.Share{}, "read_cache_size", "read_buffer_size"); err != nil {

--- a/pkg/controlplane/store/identity.go
+++ b/pkg/controlplane/store/identity.go
@@ -7,20 +7,38 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
-// GetIdentityMapping returns an identity mapping by principal.
-func (s *GORMStore) GetIdentityMapping(ctx context.Context, principal string) (*models.IdentityMapping, error) {
-	return getByField[models.IdentityMapping](s.db, ctx, "principal", principal, models.ErrMappingNotFound)
+// GetIdentityMapping returns an identity mapping by provider and principal.
+func (s *GORMStore) GetIdentityMapping(ctx context.Context, provider, principal string) (*models.IdentityMapping, error) {
+	var mapping models.IdentityMapping
+	err := s.db.WithContext(ctx).
+		Where("provider_name = ? AND principal = ?", provider, principal).
+		First(&mapping).Error
+	if err != nil {
+		return nil, convertNotFoundError(err, models.ErrMappingNotFound)
+	}
+	return &mapping, nil
 }
 
-// ListIdentityMappings returns all identity mappings.
-func (s *GORMStore) ListIdentityMappings(ctx context.Context) ([]*models.IdentityMapping, error) {
-	return listAll[models.IdentityMapping](s.db, ctx)
+// ListIdentityMappings returns identity mappings, optionally filtered by provider.
+func (s *GORMStore) ListIdentityMappings(ctx context.Context, provider string) ([]*models.IdentityMapping, error) {
+	var mappings []*models.IdentityMapping
+	query := s.db.WithContext(ctx)
+	if provider != "" {
+		query = query.Where("provider_name = ?", provider)
+	}
+	if err := query.Find(&mappings).Error; err != nil {
+		return nil, err
+	}
+	return mappings, nil
 }
 
 // CreateIdentityMapping creates a new identity mapping.
 func (s *GORMStore) CreateIdentityMapping(ctx context.Context, mapping *models.IdentityMapping) error {
 	if mapping.ID == "" {
 		mapping.ID = uuid.New().String()
+	}
+	if mapping.ProviderName == "" {
+		mapping.ProviderName = "kerberos"
 	}
 	result := s.db.WithContext(ctx).Create(mapping)
 	if result.Error != nil {
@@ -32,7 +50,25 @@ func (s *GORMStore) CreateIdentityMapping(ctx context.Context, mapping *models.I
 	return nil
 }
 
-// DeleteIdentityMapping deletes an identity mapping by principal.
-func (s *GORMStore) DeleteIdentityMapping(ctx context.Context, principal string) error {
-	return deleteByField[models.IdentityMapping](s.db, ctx, "principal", principal, models.ErrMappingNotFound)
+// DeleteIdentityMapping deletes an identity mapping by provider and principal.
+func (s *GORMStore) DeleteIdentityMapping(ctx context.Context, provider, principal string) error {
+	result := s.db.WithContext(ctx).
+		Where("provider_name = ? AND principal = ?", provider, principal).
+		Delete(&models.IdentityMapping{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return models.ErrMappingNotFound
+	}
+	return nil
+}
+
+// ListIdentityMappingsForUser returns all identity mappings for a DittoFS user.
+func (s *GORMStore) ListIdentityMappingsForUser(ctx context.Context, username string) ([]*models.IdentityMapping, error) {
+	var mappings []*models.IdentityMapping
+	if err := s.db.WithContext(ctx).Where("username = ?", username).Find(&mappings).Error; err != nil {
+		return nil, err
+	}
+	return mappings, nil
 }

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -495,24 +495,27 @@ type NetgroupStore interface {
 }
 
 // IdentityMappingStore provides identity mapping operations.
-// This is a separate interface from Store so that only identity-mapping-aware
+// This is a separate interface from Store so that only identity-aware
 // components need to depend on identity mapping functionality.
-// Mappings are shared across protocols (NFS and SMB).
 type IdentityMappingStore interface {
-	// GetIdentityMapping returns an identity mapping by principal.
+	// GetIdentityMapping returns an identity mapping by provider and principal.
 	// Returns models.ErrMappingNotFound if the mapping doesn't exist.
-	GetIdentityMapping(ctx context.Context, principal string) (*models.IdentityMapping, error)
+	GetIdentityMapping(ctx context.Context, provider, principal string) (*models.IdentityMapping, error)
 
-	// ListIdentityMappings returns all identity mappings.
-	ListIdentityMappings(ctx context.Context) ([]*models.IdentityMapping, error)
+	// ListIdentityMappings returns identity mappings, optionally filtered by provider.
+	// Pass provider="" to list all.
+	ListIdentityMappings(ctx context.Context, provider string) ([]*models.IdentityMapping, error)
 
 	// CreateIdentityMapping creates a new identity mapping.
-	// Returns models.ErrDuplicateMapping if a mapping for this principal already exists.
+	// Returns models.ErrDuplicateMapping if a mapping for this (provider, principal) already exists.
 	CreateIdentityMapping(ctx context.Context, mapping *models.IdentityMapping) error
 
-	// DeleteIdentityMapping deletes an identity mapping by principal.
+	// DeleteIdentityMapping deletes an identity mapping by provider and principal.
 	// Returns models.ErrMappingNotFound if the mapping doesn't exist.
-	DeleteIdentityMapping(ctx context.Context, principal string) error
+	DeleteIdentityMapping(ctx context.Context, provider, principal string) error
+
+	// ListIdentityMappingsForUser returns all identity mappings for a DittoFS user.
+	ListIdentityMappingsForUser(ctx context.Context, username string) ([]*models.IdentityMapping, error)
 }
 
 // Store is the composite control plane persistence interface.

--- a/pkg/identity/cache.go
+++ b/pkg/identity/cache.go
@@ -1,1 +1,122 @@
 package identity
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// DefaultCacheTTL is the default TTL for positive (Found=true) results.
+	DefaultCacheTTL = 5 * time.Minute
+
+	// DefaultNegativeCacheTTL is the default TTL for negative (Found=false) results.
+	DefaultNegativeCacheTTL = 30 * time.Second
+
+	// DefaultErrorCacheTTL is the default TTL for infrastructure errors.
+	DefaultErrorCacheTTL = 10 * time.Second
+)
+
+// CacheStats contains identity cache statistics.
+type CacheStats struct {
+	Hits   int64
+	Misses int64
+	Size   int64
+}
+
+type cacheEntry struct {
+	result   *ResolvedIdentity
+	err      error
+	cachedAt time.Time
+}
+
+type cache struct {
+	entries     map[string]*cacheEntry
+	mu          sync.RWMutex
+	positiveTTL time.Duration
+	negativeTTL time.Duration
+	errorTTL    time.Duration
+	hits        atomic.Int64
+	misses      atomic.Int64
+}
+
+func newCache(positiveTTL, negativeTTL, errorTTL time.Duration) *cache {
+	return &cache{
+		entries:     make(map[string]*cacheEntry),
+		positiveTTL: positiveTTL,
+		negativeTTL: negativeTTL,
+		errorTTL:    errorTTL,
+	}
+}
+
+func (c *cache) get(key string) (*ResolvedIdentity, error, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if !ok {
+		c.misses.Add(1)
+		return nil, nil, false
+	}
+
+	if time.Since(entry.cachedAt) >= c.ttlFor(entry) {
+		c.mu.Lock()
+		if e, still := c.entries[key]; still && time.Since(e.cachedAt) >= c.ttlFor(e) {
+			delete(c.entries, key)
+		}
+		c.mu.Unlock()
+		c.misses.Add(1)
+		return nil, nil, false
+	}
+
+	c.hits.Add(1)
+	return entry.result, entry.err, true
+}
+
+func (c *cache) put(key string, result *ResolvedIdentity, err error) {
+	c.mu.Lock()
+	c.entries[key] = &cacheEntry{
+		result:   result,
+		err:      err,
+		cachedAt: time.Now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *cache) invalidate(key string) {
+	c.mu.Lock()
+	delete(c.entries, key)
+	c.mu.Unlock()
+}
+
+func (c *cache) invalidateAll() {
+	c.mu.Lock()
+	c.entries = make(map[string]*cacheEntry)
+	c.mu.Unlock()
+}
+
+func (c *cache) stats() CacheStats {
+	c.mu.RLock()
+	size := int64(len(c.entries))
+	c.mu.RUnlock()
+	return CacheStats{
+		Hits:   c.hits.Load(),
+		Misses: c.misses.Load(),
+		Size:   size,
+	}
+}
+
+func (c *cache) ttlFor(entry *cacheEntry) time.Duration {
+	if entry.err != nil {
+		return c.errorTTL
+	}
+	if entry.result != nil && entry.result.Found {
+		return c.positiveTTL
+	}
+	return c.negativeTTL
+}
+
+// ErrNotConfigured is returned when a FuncLinkStore method is called
+// but the corresponding function was not wired.
+var ErrNotConfigured = errors.New("identity: operation not configured")

--- a/pkg/identity/cache_test.go
+++ b/pkg/identity/cache_test.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/convention.go
+++ b/pkg/identity/convention.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/convention_test.go
+++ b/pkg/identity/convention_test.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,0 +1,81 @@
+// Package identity provides pluggable identity resolution for DittoFS.
+//
+// This package defines the core abstractions for mapping external identity
+// claims (Kerberos principals, OIDC tokens, AD SIDs, etc.) to DittoFS users.
+// Each external identity system is implemented as a Provider in its own
+// sub-package (e.g., identity/kerberos, identity/oidc).
+//
+// Protocol adapters (NFS, SMB) extract credentials from protocol-specific
+// auth data and pass them to the Resolver, which chains Providers to find
+// a matching DittoFS user. The control plane is the single source of truth
+// for user identity (username, UID, GID).
+//
+// This package is intentionally decoupled from both protocol adapters and
+// the control plane. Dependencies are injected via interfaces (LinkStore)
+// and callbacks (UserLookup) to prevent circular imports.
+package identity
+
+import "context"
+
+// Credential represents an identity claim from an external system.
+// Protocol adapters construct this from protocol-specific auth data.
+type Credential struct {
+	// Provider identifies which identity provider should handle this credential
+	// (e.g., "kerberos", "oidc", "ad"). When empty, the Resolver tries all providers.
+	Provider string
+
+	// ExternalID is the canonical identifier in the external system.
+	// Format is provider-specific:
+	//   - Kerberos: "alice@EXAMPLE.COM" (principal@realm)
+	//   - OIDC:     "https://accounts.google.com|sub123" (issuer|subject)
+	//   - AD:       "S-1-5-21-...-1001" (SID)
+	ExternalID string
+
+	// Attributes holds provider-specific metadata needed for resolution.
+	Attributes map[string]string
+}
+
+// ResolvedIdentity is the result of resolving an external credential
+// to a DittoFS user.
+type ResolvedIdentity struct {
+	Username string
+	UID      uint32
+	GID      uint32
+	GIDs     []uint32
+	Domain   string
+	Found    bool
+}
+
+// IdentityProvider resolves external credentials to DittoFS users.
+// Each identity system (Kerberos, OIDC, AD, LDAP) implements this interface.
+//
+// Providers are stateless resolvers — they do not manage authentication.
+// Protocol adapters handle authentication; providers handle identity mapping.
+//
+// Thread safety: implementations must be safe for concurrent use.
+type IdentityProvider interface {
+	// Name returns the provider identifier (e.g., "kerberos", "oidc", "ad").
+	Name() string
+
+	// CanResolve returns true if this provider can handle the given credential.
+	CanResolve(cred *Credential) bool
+
+	// Resolve maps an external credential to a DittoFS user.
+	// Returns Found=false if the credential is valid but no mapping exists.
+	// Returns error only for infrastructure failures.
+	Resolve(ctx context.Context, cred *Credential) (*ResolvedIdentity, error)
+}
+
+// UserLookup resolves a DittoFS username to UID/GID/groups.
+// Injected by the control plane at wiring time to avoid circular imports.
+type UserLookup func(ctx context.Context, username string) (*ResolvedIdentity, error)
+
+// NobodyIdentity returns a ResolvedIdentity for the "nobody" user (UID/GID 65534).
+func NobodyIdentity() *ResolvedIdentity {
+	return &ResolvedIdentity{
+		Username: "nobody",
+		UID:      65534,
+		GID:      65534,
+		Found:    true,
+	}
+}

--- a/pkg/identity/kerberos/provider.go
+++ b/pkg/identity/kerberos/provider.go
@@ -1,0 +1,119 @@
+// Package kerberos provides a Kerberos identity provider for DittoFS.
+//
+// It resolves Kerberos principals (e.g., "alice@EXAMPLE.COM") to DittoFS
+// users via two strategies in order:
+//  1. Explicit mapping from the LinkStore (admin-configured principal → username)
+//  2. Convention: strip the realm and look up the bare name as a DittoFS username
+package kerberos
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/identity"
+)
+
+const ProviderName = "kerberos"
+
+// Provider resolves Kerberos principals to DittoFS users.
+// Implements identity.IdentityProvider.
+type Provider struct {
+	realm      string
+	store      identity.LinkStore
+	userLookup identity.UserLookup
+}
+
+// New creates a Kerberos identity provider.
+//
+// Parameters:
+//   - realm: expected Kerberos realm for convention matching (e.g., "EXAMPLE.COM")
+//   - store: link store for explicit principal → username mappings (may be nil)
+//   - userLookup: callback to resolve a DittoFS username to UID/GID
+func New(realm string, store identity.LinkStore, userLookup identity.UserLookup) *Provider {
+	return &Provider{
+		realm:      realm,
+		store:      store,
+		userLookup: userLookup,
+	}
+}
+
+func (p *Provider) Name() string { return ProviderName }
+
+func (p *Provider) CanResolve(cred *identity.Credential) bool {
+	if cred.Provider != "" {
+		return cred.Provider == ProviderName
+	}
+	return strings.Contains(cred.ExternalID, "@")
+}
+
+// Resolve maps a Kerberos principal to a DittoFS user.
+//
+// Resolution order:
+//  1. Explicit mapping in LinkStore: ("kerberos", "alice@EXAMPLE.COM") → username
+//  2. Convention: if realm matches, strip realm and look up bare username
+//  3. Numeric UID: "1000@EXAMPLE.COM" → UID=1000 (AUTH_SYS interop)
+//  4. Found=false if unmapped
+func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*identity.ResolvedIdentity, error) {
+	if p.store != nil {
+		username, found, err := p.store.GetLink(ctx, ProviderName, cred.ExternalID)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			resolved, err := p.userLookup(ctx, username)
+			if err != nil {
+				return nil, err
+			}
+			if resolved != nil && resolved.Found {
+				resolved.Domain = realmFrom(cred)
+				return resolved, nil
+			}
+		}
+	}
+
+	name, domain := parsePrincipal(cred.ExternalID)
+	if domain == "" || !strings.EqualFold(domain, p.realm) {
+		return &identity.ResolvedIdentity{Found: false}, nil
+	}
+
+	if uid, err := strconv.ParseUint(name, 10, 32); err == nil {
+		return &identity.ResolvedIdentity{
+			Username: name,
+			UID:      uint32(uid),
+			GID:      uint32(uid),
+			Domain:   domain,
+			Found:    true,
+		}, nil
+	}
+
+	resolved, err := p.userLookup(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if resolved == nil || !resolved.Found {
+		return &identity.ResolvedIdentity{Found: false}, nil
+	}
+	resolved.Domain = domain
+	return resolved, nil
+}
+
+func parsePrincipal(principal string) (name, domain string) {
+	switch principal {
+	case "OWNER@", "GROUP@", "EVERYONE@":
+		return principal, ""
+	}
+	idx := strings.LastIndex(principal, "@")
+	if idx < 0 || idx == len(principal)-1 {
+		return principal, ""
+	}
+	return principal[:idx], principal[idx+1:]
+}
+
+func realmFrom(cred *identity.Credential) string {
+	if r := cred.Attributes["realm"]; r != "" {
+		return r
+	}
+	_, domain := parsePrincipal(cred.ExternalID)
+	return domain
+}

--- a/pkg/identity/kerberos/provider.go
+++ b/pkg/identity/kerberos/provider.go
@@ -44,6 +44,10 @@ func (p *Provider) CanResolve(cred *identity.Credential) bool {
 	if cred.Provider != "" {
 		return cred.Provider == ProviderName
 	}
+	switch cred.ExternalID {
+	case "OWNER@", "GROUP@", "EVERYONE@":
+		return false
+	}
 	return strings.Contains(cred.ExternalID, "@")
 }
 
@@ -66,8 +70,9 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 				return nil, err
 			}
 			if resolved != nil && resolved.Found {
-				resolved.Domain = realmFrom(cred)
-				return resolved, nil
+				out := *resolved
+				out.Domain = realmFrom(cred)
+				return &out, nil
 			}
 		}
 	}
@@ -94,8 +99,9 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 	if resolved == nil || !resolved.Found {
 		return &identity.ResolvedIdentity{Found: false}, nil
 	}
-	resolved.Domain = domain
-	return resolved, nil
+	out := *resolved
+	out.Domain = domain
+	return &out, nil
 }
 
 func parsePrincipal(principal string) (name, domain string) {

--- a/pkg/identity/kerberos/provider_test.go
+++ b/pkg/identity/kerberos/provider_test.go
@@ -1,0 +1,204 @@
+package kerberos
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/identity"
+)
+
+func aliceLookup(_ context.Context, username string) (*identity.ResolvedIdentity, error) {
+	users := map[string]*identity.ResolvedIdentity{
+		"alice": {Username: "alice", UID: 1000, GID: 1000, Found: true},
+		"bob":   {Username: "bob", UID: 2000, GID: 2000, Found: true},
+	}
+	if r, ok := users[username]; ok {
+		return r, nil
+	}
+	return &identity.ResolvedIdentity{Found: false}, nil
+}
+
+type memLinkStore struct {
+	links map[string]string // "provider|externalID" -> username
+}
+
+func (m *memLinkStore) GetLink(_ context.Context, provider, externalID string) (string, bool, error) {
+	key := provider + "|" + externalID
+	if u, ok := m.links[key]; ok {
+		return u, true, nil
+	}
+	return "", false, nil
+}
+
+func (m *memLinkStore) ListLinks(context.Context, string) ([]identity.IdentityLink, error) {
+	return nil, nil
+}
+func (m *memLinkStore) CreateLink(context.Context, identity.IdentityLink) error { return nil }
+func (m *memLinkStore) DeleteLink(context.Context, string, string) error        { return nil }
+func (m *memLinkStore) ListLinksForUser(context.Context, string) ([]identity.IdentityLink, error) {
+	return nil, nil
+}
+
+func TestProvider_ExplicitMapping(t *testing.T) {
+	store := &memLinkStore{links: map[string]string{
+		"kerberos|admin@CORP.COM": "alice",
+	}}
+	p := New("EXAMPLE.COM", store, aliceLookup)
+
+	result, err := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "admin@CORP.COM",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.Username != "alice" || result.UID != 1000 {
+		t.Fatalf("expected alice/1000, got %+v", result)
+	}
+}
+
+func TestProvider_ConventionRealmMatch(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, err := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice@EXAMPLE.COM",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.Username != "alice" || result.UID != 1000 {
+		t.Fatalf("expected alice/1000, got %+v", result)
+	}
+	if result.Domain != "EXAMPLE.COM" {
+		t.Fatalf("expected domain EXAMPLE.COM, got %s", result.Domain)
+	}
+}
+
+func TestProvider_ConventionCaseInsensitive(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice@example.com",
+	})
+	if !result.Found {
+		t.Fatal("expected case-insensitive realm match")
+	}
+}
+
+func TestProvider_RealmMismatch(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice@OTHER.COM",
+	})
+	if result.Found {
+		t.Fatal("expected Found=false for realm mismatch")
+	}
+}
+
+func TestProvider_NoDomain(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice",
+	})
+	if result.Found {
+		t.Fatal("expected Found=false for bare username")
+	}
+}
+
+func TestProvider_UnknownUser(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "unknown@EXAMPLE.COM",
+	})
+	if result.Found {
+		t.Fatal("expected Found=false for unknown user")
+	}
+}
+
+func TestProvider_NumericUID(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "1000@EXAMPLE.COM",
+	})
+	if !result.Found || result.UID != 1000 {
+		t.Fatalf("expected numeric UID 1000, got %+v", result)
+	}
+}
+
+func TestProvider_CanResolve(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	tests := []struct {
+		cred *identity.Credential
+		want bool
+	}{
+		{&identity.Credential{Provider: "kerberos", ExternalID: "alice@EXAMPLE.COM"}, true},
+		{&identity.Credential{Provider: "oidc", ExternalID: "alice@EXAMPLE.COM"}, false},
+		{&identity.Credential{ExternalID: "alice@EXAMPLE.COM"}, true},
+		{&identity.Credential{ExternalID: "alice"}, false},
+	}
+
+	for _, tt := range tests {
+		if got := p.CanResolve(tt.cred); got != tt.want {
+			t.Errorf("CanResolve(%v) = %v, want %v", tt.cred, got, tt.want)
+		}
+	}
+}
+
+func TestProvider_ExplicitMappingTakesPrecedence(t *testing.T) {
+	store := &memLinkStore{links: map[string]string{
+		"kerberos|alice@EXAMPLE.COM": "bob",
+	}}
+	p := New("EXAMPLE.COM", store, aliceLookup)
+
+	result, _ := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice@EXAMPLE.COM",
+	})
+	if !result.Found || result.Username != "bob" {
+		t.Fatalf("expected explicit mapping to bob, got %+v", result)
+	}
+}
+
+func TestProvider_StoreError(t *testing.T) {
+	dbErr := errors.New("db down")
+	store := &memLinkStore{}
+	store.links = nil // will cause no match
+	p := New("EXAMPLE.COM", store, func(_ context.Context, _ string) (*identity.ResolvedIdentity, error) {
+		return nil, dbErr
+	})
+
+	// Convention path hits userLookup which fails
+	_, err := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "alice@EXAMPLE.COM",
+	})
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("expected db error, got %v", err)
+	}
+}
+
+func TestProvider_SpecialPrincipals(t *testing.T) {
+	p := New("EXAMPLE.COM", nil, aliceLookup)
+
+	for _, principal := range []string{"OWNER@", "GROUP@", "EVERYONE@"} {
+		result, _ := p.Resolve(context.Background(), &identity.Credential{
+			Provider:   "kerberos",
+			ExternalID: principal,
+		})
+		if result.Found {
+			t.Errorf("expected Found=false for special principal %s", principal)
+		}
+	}
+}

--- a/pkg/identity/mapper.go
+++ b/pkg/identity/mapper.go
@@ -1,3 +1,0 @@
-// Deprecated: This package has been moved to pkg/adapter/nfs/identity.
-// All NFS identity resolution types and functions are now in the NFS adapter scope.
-package identity

--- a/pkg/identity/mapper_test.go
+++ b/pkg/identity/mapper_test.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/resolver.go
+++ b/pkg/identity/resolver.go
@@ -1,0 +1,147 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// Resolver chains identity providers and caches results.
+// It is the primary entry point for identity resolution, used by both
+// NFS and SMB protocol adapters.
+//
+// Thread safety: safe for concurrent use. Uses singleflight to prevent
+// thundering herd on concurrent cache misses for the same credential.
+type Resolver struct {
+	providers []IdentityProvider
+	cache     *cache
+	group     singleflight.Group
+}
+
+// ResolverOption configures a Resolver.
+type ResolverOption func(*Resolver)
+
+// WithProvider registers an identity provider with the Resolver.
+// Providers are tried in registration order; first Found=true wins.
+func WithProvider(p IdentityProvider) ResolverOption {
+	return func(r *Resolver) {
+		r.providers = append(r.providers, p)
+	}
+}
+
+// WithCacheTTL sets the positive cache TTL.
+func WithCacheTTL(ttl time.Duration) ResolverOption {
+	return func(r *Resolver) {
+		r.cache.positiveTTL = ttl
+	}
+}
+
+// WithNegativeCacheTTL sets the TTL for caching Found=false results.
+func WithNegativeCacheTTL(ttl time.Duration) ResolverOption {
+	return func(r *Resolver) {
+		r.cache.negativeTTL = ttl
+	}
+}
+
+// WithErrorCacheTTL sets the TTL for caching infrastructure errors.
+func WithErrorCacheTTL(ttl time.Duration) ResolverOption {
+	return func(r *Resolver) {
+		r.cache.errorTTL = ttl
+	}
+}
+
+// NewResolver creates a new identity resolver with the given options.
+func NewResolver(opts ...ResolverOption) *Resolver {
+	r := &Resolver{
+		cache: newCache(DefaultCacheTTL, DefaultNegativeCacheTTL, DefaultErrorCacheTTL),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Resolve maps an external credential to a DittoFS user.
+//
+// Resolution order:
+//  1. Check cache
+//  2. If cred.Provider is set, route to that specific provider
+//  3. Otherwise, try each provider in order via CanResolve() → Resolve()
+//  4. Cache and return first Found=true result
+//  5. If all providers return Found=false, cache and return Found=false
+//
+// An infrastructure error from any provider aborts the chain immediately.
+// Concurrent requests for the same credential are coalesced via singleflight.
+func (r *Resolver) Resolve(ctx context.Context, cred *Credential) (*ResolvedIdentity, error) {
+	key := cacheKey(cred.Provider, cred.ExternalID)
+
+	if result, err, ok := r.cache.get(key); ok {
+		return result, err
+	}
+
+	v, err, _ := r.group.Do(key, func() (any, error) {
+		if result, cachedErr, ok := r.cache.get(key); ok {
+			return &cacheResult{result: result, err: cachedErr}, nil
+		}
+		result, resolveErr := r.resolveUncached(ctx, cred)
+		r.cache.put(key, result, resolveErr)
+		return &cacheResult{result: result, err: resolveErr}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	cr := v.(*cacheResult)
+	return cr.result, cr.err
+}
+
+type cacheResult struct {
+	result *ResolvedIdentity
+	err    error
+}
+
+func (r *Resolver) resolveUncached(ctx context.Context, cred *Credential) (*ResolvedIdentity, error) {
+	if cred.Provider != "" {
+		for _, p := range r.providers {
+			if p.Name() == cred.Provider {
+				return p.Resolve(ctx, cred)
+			}
+		}
+		return &ResolvedIdentity{Found: false}, nil
+	}
+
+	for _, p := range r.providers {
+		if !p.CanResolve(cred) {
+			continue
+		}
+		result, err := p.Resolve(ctx, cred)
+		if err != nil {
+			return nil, err
+		}
+		if result.Found {
+			return result, nil
+		}
+	}
+
+	return &ResolvedIdentity{Found: false}, nil
+}
+
+// InvalidateCache clears all cached entries.
+func (r *Resolver) InvalidateCache() {
+	r.cache.invalidateAll()
+}
+
+// InvalidateKey removes a specific entry from the cache.
+func (r *Resolver) InvalidateKey(provider, externalID string) {
+	r.cache.invalidate(cacheKey(provider, externalID))
+}
+
+// Stats returns cache statistics.
+func (r *Resolver) Stats() CacheStats {
+	return r.cache.stats()
+}
+
+func cacheKey(provider, externalID string) string {
+	return fmt.Sprintf("%d:%s|%s", len(provider), provider, externalID)
+}

--- a/pkg/identity/resolver.go
+++ b/pkg/identity/resolver.go
@@ -85,7 +85,7 @@ func (r *Resolver) Resolve(ctx context.Context, cred *Credential) (*ResolvedIden
 		if result, cachedErr, ok := r.cache.get(key); ok {
 			return &cacheResult{result: result, err: cachedErr}, nil
 		}
-		result, resolveErr := r.resolveUncached(ctx, cred)
+		result, resolveErr := r.resolveUncached(context.WithoutCancel(ctx), cred)
 		r.cache.put(key, result, resolveErr)
 		return &cacheResult{result: result, err: resolveErr}, nil
 	})

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -198,7 +198,7 @@ func TestResolver_CacheError(t *testing.T) {
 	p := &mockProvider{name: "p", err: dbErr}
 	r := NewResolver(WithProvider(p), WithErrorCacheTTL(time.Minute))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "x"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "x"})
 	_, err := r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "x"})
 
 	if !errors.Is(err, dbErr) {
@@ -216,9 +216,9 @@ func TestResolver_CacheExpiry(t *testing.T) {
 	}
 	r := NewResolver(WithProvider(p), WithCacheTTL(time.Millisecond))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
 	time.Sleep(5 * time.Millisecond)
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
 
 	if p.callCount() != 2 {
 		t.Fatalf("expected 2 calls after TTL expiry, got %d", p.callCount())
@@ -232,9 +232,9 @@ func TestResolver_InvalidateCache(t *testing.T) {
 	}
 	r := NewResolver(WithProvider(p))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
 	r.InvalidateCache()
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
 
 	if p.callCount() != 2 {
 		t.Fatalf("expected 2 calls after invalidation, got %d", p.callCount())
@@ -251,11 +251,11 @@ func TestResolver_InvalidateKey(t *testing.T) {
 	}
 	r := NewResolver(WithProvider(p))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
 	r.InvalidateKey("p", "alice")
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
 
 	// alice: 2 calls (invalidated), bob: 1 call (still cached)
 	if p.callCount() != 3 {

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -167,8 +167,8 @@ func TestResolver_CachePositive(t *testing.T) {
 	}
 	r := NewResolver(WithProvider(p), WithCacheTTL(time.Minute))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
 
 	if p.callCount() != 1 {
 		t.Fatalf("expected 1 provider call (cached), got %d", p.callCount())
@@ -182,7 +182,7 @@ func TestResolver_CacheNegative(t *testing.T) {
 	p := &mockProvider{name: "p", results: map[string]*ResolvedIdentity{}}
 	r := NewResolver(WithProvider(p), WithNegativeCacheTTL(time.Minute))
 
-	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "unknown"})
+	_, _ = r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "unknown"})
 	result, _ := r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "unknown"})
 
 	if result.Found {

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -1,0 +1,295 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type mockProvider struct {
+	name     string
+	canCheck func(*Credential) bool
+	results  map[string]*ResolvedIdentity
+	err      error
+	mu       sync.Mutex
+	calls    int
+}
+
+func (m *mockProvider) Name() string { return m.name }
+
+func (m *mockProvider) CanResolve(cred *Credential) bool {
+	if m.canCheck != nil {
+		return m.canCheck(cred)
+	}
+	return true
+}
+
+func (m *mockProvider) Resolve(_ context.Context, cred *Credential) (*ResolvedIdentity, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	if r, ok := m.results[cred.ExternalID]; ok {
+		return r, nil
+	}
+	return &ResolvedIdentity{Found: false}, nil
+}
+
+func (m *mockProvider) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func TestResolver_DirectProviderRouting(t *testing.T) {
+	krb := &mockProvider{
+		name:    "kerberos",
+		results: map[string]*ResolvedIdentity{"alice@EXAMPLE.COM": {Username: "alice", UID: 1000, Found: true}},
+	}
+	oidc := &mockProvider{
+		name:    "oidc",
+		results: map[string]*ResolvedIdentity{"iss|sub1": {Username: "bob", UID: 2000, Found: true}},
+	}
+
+	r := NewResolver(WithProvider(krb), WithProvider(oidc))
+
+	result, err := r.Resolve(context.Background(), &Credential{Provider: "kerberos", ExternalID: "alice@EXAMPLE.COM"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.Username != "alice" {
+		t.Fatalf("expected alice, got %+v", result)
+	}
+
+	result, err = r.Resolve(context.Background(), &Credential{Provider: "oidc", ExternalID: "iss|sub1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.Username != "bob" {
+		t.Fatalf("expected bob, got %+v", result)
+	}
+}
+
+func TestResolver_ChainFirstMatchWins(t *testing.T) {
+	first := &mockProvider{
+		name:    "first",
+		results: map[string]*ResolvedIdentity{"shared": {Username: "from-first", Found: true}},
+	}
+	second := &mockProvider{
+		name:    "second",
+		results: map[string]*ResolvedIdentity{"shared": {Username: "from-second", Found: true}},
+	}
+
+	r := NewResolver(WithProvider(first), WithProvider(second))
+	result, _ := r.Resolve(context.Background(), &Credential{ExternalID: "shared"})
+
+	if result.Username != "from-first" {
+		t.Fatalf("expected first provider to win, got %s", result.Username)
+	}
+	if second.callCount() != 0 {
+		t.Fatal("second provider should not have been called")
+	}
+}
+
+func TestResolver_ChainFallthrough(t *testing.T) {
+	first := &mockProvider{name: "first", results: map[string]*ResolvedIdentity{}}
+	second := &mockProvider{
+		name:    "second",
+		results: map[string]*ResolvedIdentity{"alice": {Username: "alice", Found: true}},
+	}
+
+	r := NewResolver(WithProvider(first), WithProvider(second))
+	result, _ := r.Resolve(context.Background(), &Credential{ExternalID: "alice"})
+
+	if !result.Found || result.Username != "alice" {
+		t.Fatalf("expected second provider to resolve, got %+v", result)
+	}
+}
+
+func TestResolver_AllMissReturnsNotFound(t *testing.T) {
+	p := &mockProvider{name: "empty", results: map[string]*ResolvedIdentity{}}
+	r := NewResolver(WithProvider(p))
+
+	result, err := r.Resolve(context.Background(), &Credential{ExternalID: "unknown"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Found {
+		t.Fatal("expected Found=false")
+	}
+}
+
+func TestResolver_UnknownProviderReturnsNotFound(t *testing.T) {
+	p := &mockProvider{name: "kerberos", results: map[string]*ResolvedIdentity{}}
+	r := NewResolver(WithProvider(p))
+
+	result, err := r.Resolve(context.Background(), &Credential{Provider: "nonexistent", ExternalID: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Found {
+		t.Fatal("expected Found=false for unknown provider")
+	}
+}
+
+func TestResolver_CanResolveFalseSkipsProvider(t *testing.T) {
+	skipped := &mockProvider{
+		name:     "skip-me",
+		canCheck: func(*Credential) bool { return false },
+		results:  map[string]*ResolvedIdentity{"x": {Username: "nope", Found: true}},
+	}
+	fallback := &mockProvider{
+		name:    "fallback",
+		results: map[string]*ResolvedIdentity{"x": {Username: "yes", Found: true}},
+	}
+
+	r := NewResolver(WithProvider(skipped), WithProvider(fallback))
+	result, _ := r.Resolve(context.Background(), &Credential{ExternalID: "x"})
+
+	if result.Username != "yes" {
+		t.Fatalf("expected fallback, got %s", result.Username)
+	}
+	if skipped.callCount() != 0 {
+		t.Fatal("skipped provider should not have been called")
+	}
+}
+
+func TestResolver_CachePositive(t *testing.T) {
+	p := &mockProvider{
+		name:    "p",
+		results: map[string]*ResolvedIdentity{"alice": {Username: "alice", UID: 1000, Found: true}},
+	}
+	r := NewResolver(WithProvider(p), WithCacheTTL(time.Minute))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+
+	if p.callCount() != 1 {
+		t.Fatalf("expected 1 provider call (cached), got %d", p.callCount())
+	}
+	if r.Stats().Hits != 1 {
+		t.Fatalf("expected 1 cache hit, got %d", r.Stats().Hits)
+	}
+}
+
+func TestResolver_CacheNegative(t *testing.T) {
+	p := &mockProvider{name: "p", results: map[string]*ResolvedIdentity{}}
+	r := NewResolver(WithProvider(p), WithNegativeCacheTTL(time.Minute))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "unknown"})
+	result, _ := r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "unknown"})
+
+	if result.Found {
+		t.Fatal("expected negative cache hit")
+	}
+	if p.callCount() != 1 {
+		t.Fatalf("expected 1 provider call (negative cached), got %d", p.callCount())
+	}
+}
+
+func TestResolver_CacheError(t *testing.T) {
+	dbErr := errors.New("db down")
+	p := &mockProvider{name: "p", err: dbErr}
+	r := NewResolver(WithProvider(p), WithErrorCacheTTL(time.Minute))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "x"})
+	_, err := r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "x"})
+
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("expected cached error, got %v", err)
+	}
+	if p.callCount() != 1 {
+		t.Fatalf("expected 1 provider call (error cached), got %d", p.callCount())
+	}
+}
+
+func TestResolver_CacheExpiry(t *testing.T) {
+	p := &mockProvider{
+		name:    "p",
+		results: map[string]*ResolvedIdentity{"alice": {Username: "alice", Found: true}},
+	}
+	r := NewResolver(WithProvider(p), WithCacheTTL(time.Millisecond))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	time.Sleep(5 * time.Millisecond)
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+
+	if p.callCount() != 2 {
+		t.Fatalf("expected 2 calls after TTL expiry, got %d", p.callCount())
+	}
+}
+
+func TestResolver_InvalidateCache(t *testing.T) {
+	p := &mockProvider{
+		name:    "p",
+		results: map[string]*ResolvedIdentity{"alice": {Username: "alice", Found: true}},
+	}
+	r := NewResolver(WithProvider(p))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	r.InvalidateCache()
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+
+	if p.callCount() != 2 {
+		t.Fatalf("expected 2 calls after invalidation, got %d", p.callCount())
+	}
+}
+
+func TestResolver_InvalidateKey(t *testing.T) {
+	p := &mockProvider{
+		name: "p",
+		results: map[string]*ResolvedIdentity{
+			"alice": {Username: "alice", Found: true},
+			"bob":   {Username: "bob", Found: true},
+		},
+	}
+	r := NewResolver(WithProvider(p))
+
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
+	r.InvalidateKey("p", "alice")
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+	r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "bob"})
+
+	// alice: 2 calls (invalidated), bob: 1 call (still cached)
+	if p.callCount() != 3 {
+		t.Fatalf("expected 3 total calls, got %d", p.callCount())
+	}
+}
+
+func TestResolver_ConcurrentAccess(t *testing.T) {
+	p := &mockProvider{
+		name:    "p",
+		results: map[string]*ResolvedIdentity{"alice": {Username: "alice", UID: 1000, Found: true}},
+	}
+	r := NewResolver(WithProvider(p))
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	var errCount atomic.Int32
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			result, err := r.Resolve(context.Background(), &Credential{Provider: "p", ExternalID: "alice"})
+			if err != nil || !result.Found || result.UID != 1000 {
+				errCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	if errCount.Load() != 0 {
+		t.Fatalf("got %d errors in concurrent test", errCount.Load())
+	}
+	if p.callCount() > 5 {
+		t.Fatalf("expected at most ~5 provider calls with caching, got %d", p.callCount())
+	}
+}

--- a/pkg/identity/static.go
+++ b/pkg/identity/static.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/static_test.go
+++ b/pkg/identity/static_test.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/store.go
+++ b/pkg/identity/store.go
@@ -1,0 +1,69 @@
+package identity
+
+import "context"
+
+// IdentityLink represents a link between an external identity and a DittoFS user.
+// The composite key is (ProviderName, ExternalID).
+type IdentityLink struct {
+	ProviderName string
+	ExternalID   string
+	Username     string
+}
+
+// LinkStore provides CRUD for external identity → DittoFS user links.
+//
+// The composite key (ProviderName, ExternalID) supports linked identities:
+// one DittoFS user can have multiple external identities across providers.
+type LinkStore interface {
+	GetLink(ctx context.Context, provider, externalID string) (username string, found bool, err error)
+	ListLinks(ctx context.Context, provider string) ([]IdentityLink, error)
+	CreateLink(ctx context.Context, link IdentityLink) error
+	DeleteLink(ctx context.Context, provider, externalID string) error
+	ListLinksForUser(ctx context.Context, username string) ([]IdentityLink, error)
+}
+
+// FuncLinkStore adapts function callbacks to the LinkStore interface.
+// Constructed at wiring time to bridge the controlplane store without circular imports.
+// Methods with nil function fields return ErrNotConfigured instead of panicking.
+type FuncLinkStore struct {
+	GetLinkFn          func(ctx context.Context, provider, externalID string) (string, bool, error)
+	ListLinksFn        func(ctx context.Context, provider string) ([]IdentityLink, error)
+	CreateLinkFn       func(ctx context.Context, link IdentityLink) error
+	DeleteLinkFn       func(ctx context.Context, provider, externalID string) error
+	ListLinksForUserFn func(ctx context.Context, username string) ([]IdentityLink, error)
+}
+
+func (f *FuncLinkStore) GetLink(ctx context.Context, provider, externalID string) (string, bool, error) {
+	if f.GetLinkFn == nil {
+		return "", false, ErrNotConfigured
+	}
+	return f.GetLinkFn(ctx, provider, externalID)
+}
+
+func (f *FuncLinkStore) ListLinks(ctx context.Context, provider string) ([]IdentityLink, error) {
+	if f.ListLinksFn == nil {
+		return nil, ErrNotConfigured
+	}
+	return f.ListLinksFn(ctx, provider)
+}
+
+func (f *FuncLinkStore) CreateLink(ctx context.Context, link IdentityLink) error {
+	if f.CreateLinkFn == nil {
+		return ErrNotConfigured
+	}
+	return f.CreateLinkFn(ctx, link)
+}
+
+func (f *FuncLinkStore) DeleteLink(ctx context.Context, provider, externalID string) error {
+	if f.DeleteLinkFn == nil {
+		return ErrNotConfigured
+	}
+	return f.DeleteLinkFn(ctx, provider, externalID)
+}
+
+func (f *FuncLinkStore) ListLinksForUser(ctx context.Context, username string) ([]IdentityLink, error) {
+	if f.ListLinksForUserFn == nil {
+		return nil, ErrNotConfigured
+	}
+	return f.ListLinksForUserFn(ctx, username)
+}

--- a/pkg/identity/table.go
+++ b/pkg/identity/table.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/identity/table_test.go
+++ b/pkg/identity/table_test.go
@@ -1,1 +1,0 @@
-package identity

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,12 +185,6 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
-	// GetWriteLeasesToBreak identifies Write leases that need breaking,
-	// marks them as Breaking in the lock state, and returns the info needed
-	// for the caller to dispatch notifications directly. Used by the SMB
-	// adapter to send break notifications via the adapter-level session map.
-	GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo
-
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
@@ -1300,59 +1294,6 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
 		return lease.HasWrite()
 	})
-}
-
-// LeaseBreakInfo holds the information needed to dispatch a lease break
-// notification at the adapter level (bypassing the LockManager callback chain).
-type LeaseBreakInfo struct {
-	LeaseKey     [16]byte
-	CurrentState uint32
-	BreakToState uint32
-	Epoch        uint16
-}
-
-// GetWriteLeasesToBreak identifies Write leases that need breaking, marks them
-// as Breaking in the lock state, and returns info for the caller to dispatch
-// break notifications directly. This avoids the LockManager's dispatchOpLockBreak
-// callback chain, letting the adapter route notifications through its own session
-// map.
-func (lm *Manager) GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo {
-	lm.mu.Lock()
-	defer lm.mu.Unlock()
-
-	locks := lm.unifiedLocks[handleKey]
-	var result []LeaseBreakInfo
-
-	for _, l := range locks {
-		if l.Lease == nil || l.Lease.Breaking || !l.Lease.HasWrite() {
-			continue
-		}
-		if excludeOwner != nil {
-			if l.Owner.OwnerID == excludeOwner.OwnerID ||
-				(excludeOwner.ClientID != "" && l.Owner.ClientID == excludeOwner.ClientID) {
-				continue
-			}
-			if excludeOwner.ExcludeLeaseKey != ([16]byte{}) &&
-				l.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
-				continue
-			}
-		}
-
-		breakTo := l.Lease.LeaseState &^ LeaseStateWrite
-		l.Lease.Breaking = true
-		l.Lease.BreakToState = breakTo
-		l.Lease.BreakStarted = time.Now()
-		advanceEpoch(l.Lease)
-
-		result = append(result, LeaseBreakInfo{
-			LeaseKey:     l.Lease.LeaseKey,
-			CurrentState: l.Lease.LeaseState,
-			BreakToState: breakTo,
-			Epoch:        l.Lease.Epoch,
-		})
-	}
-
-	return result
 }
 
 // BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE that may

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,9 +185,11 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
-	// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have
-	// Handle caching (RWH → RH). Only targets leases with both W and H.
-	BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
+	// GetWriteLeasesToBreak identifies Write leases that need breaking,
+	// marks them as Breaking in the lock state, and returns the info needed
+	// for the caller to dispatch notifications directly. Used by the SMB
+	// adapter to send break notifications via the adapter-level session map.
+	GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo
 
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
@@ -1300,6 +1302,59 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 	})
 }
 
+// LeaseBreakInfo holds the information needed to dispatch a lease break
+// notification at the adapter level (bypassing the LockManager callback chain).
+type LeaseBreakInfo struct {
+	LeaseKey     [16]byte
+	CurrentState uint32
+	BreakToState uint32
+	Epoch        uint16
+}
+
+// GetWriteLeasesToBreak identifies Write leases that need breaking, marks them
+// as Breaking in the lock state, and returns info for the caller to dispatch
+// break notifications directly. This avoids the LockManager's dispatchOpLockBreak
+// callback chain, letting the adapter route notifications through its own session
+// map.
+func (lm *Manager) GetWriteLeasesToBreak(handleKey string, excludeOwner *LockOwner) []LeaseBreakInfo {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	locks := lm.unifiedLocks[handleKey]
+	var result []LeaseBreakInfo
+
+	for _, l := range locks {
+		if l.Lease == nil || l.Lease.Breaking || !l.Lease.HasWrite() {
+			continue
+		}
+		if excludeOwner != nil {
+			if l.Owner.OwnerID == excludeOwner.OwnerID ||
+				(excludeOwner.ClientID != "" && l.Owner.ClientID == excludeOwner.ClientID) {
+				continue
+			}
+			if excludeOwner.ExcludeLeaseKey != ([16]byte{}) &&
+				l.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
+				continue
+			}
+		}
+
+		breakTo := l.Lease.LeaseState &^ LeaseStateWrite
+		l.Lease.Breaking = true
+		l.Lease.BreakToState = breakTo
+		l.Lease.BreakStarted = time.Now()
+		advanceEpoch(l.Lease)
+
+		result = append(result, LeaseBreakInfo{
+			LeaseKey:     l.Lease.LeaseKey,
+			CurrentState: l.Lease.LeaseState,
+			BreakToState: breakTo,
+			Epoch:        l.Lease.Epoch,
+		})
+	}
+
+	return result
+}
+
 // BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE that may
 // conflict with sharing modes. Per MS-SMB2 3.3.5.9 Step 10: "If any existing
 // Open on the target file has a lease with Handle caching, the server MUST
@@ -1312,23 +1367,6 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 func (lm *Manager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripHandle, func(lease *OpLock) bool {
 		return lease.HasHandle()
-	})
-}
-
-// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have Handle
-// caching. Per MS-SMB2 3.3.5.9 Step 10: before the share mode check, leases
-// with Handle caching must be broken so clients close cached handles. The break
-// strips Write (not Handle) so clients see "RWH → RH" and flush dirty data
-// while preserving Handle for the share mode resolution window.
-//
-// This targets only leases WITH Handle caching:
-//   - RWH -> RH (has Handle → strip Write)
-//   - RH  -> not broken (has Handle but no Write to strip)
-//   - RW  -> not broken (no Handle → not a cached-handle concern)
-//   - R   -> not broken
-func (lm *Manager) BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
-		return lease.HasHandle() && lease.HasWrite()
 	})
 }
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -185,6 +185,10 @@ type LockManager interface {
 	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
 	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
+	// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have
+	// Handle caching (RWH → RH). Only targets leases with both W and H.
+	BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
+
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
@@ -1308,6 +1312,23 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 func (lm *Manager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripHandle, func(lease *OpLock) bool {
 		return lease.HasHandle()
+	})
+}
+
+// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have Handle
+// caching. Per MS-SMB2 3.3.5.9 Step 10: before the share mode check, leases
+// with Handle caching must be broken so clients close cached handles. The break
+// strips Write (not Handle) so clients see "RWH → RH" and flush dirty data
+// while preserving Handle for the share mode resolution window.
+//
+// This targets only leases WITH Handle caching:
+//   - RWH -> RH (has Handle → strip Write)
+//   - RH  -> not broken (has Handle but no Write to strip)
+//   - RW  -> not broken (no Handle → not a cached-handle concern)
+//   - R   -> not broken
+func (lm *Manager) BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
+	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
+		return lease.HasHandle() && lease.HasWrite()
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements centralized identity resolution with pluggable providers (issue #324), replacing the two independent hardcoded identity paths (NFS StaticMapper, SMB ResolvePrincipal) with a shared, extensible architecture.

- **New `pkg/identity/` package**: Provider-agnostic interfaces (`Credential`, `IdentityProvider`, `Resolver`, `LinkStore`) with singleflight-protected TTL cache (positive/negative/error tiering)
- **Kerberos provider** (`pkg/identity/kerberos/`): Explicit DB mapping -> convention fallback -> numeric UID interop
- **DB model evolution**: `ProviderName` column with composite unique index `(provider_name, principal)` supporting linked identities across providers. Pre-migration index drop for existing deployments
- **Protocol adapter wiring**: Both NFS (GSS processor) and SMB (session setup) resolve Kerberos principals through the same `identity.Resolver` chain, with graceful fallback to legacy mappers
- **Shared helper**: `pkg/adapter/identity.go` -- `BuildIdentityResolver` used by both NFS and SMB, eliminating duplication
- **API**: New top-level `/api/v1/identity-mappings` endpoints with provider scoping; legacy NFS-scoped routes preserved for backward compatibility
- **CLI**: `dfsctl idmap add/list/remove` gain `--provider` flag (default: `kerberos`)

### Design for extensibility

The architecture supports future identity providers (OIDC, AD, LDAP, SAML) as drop-in sub-packages:
1. Create `pkg/identity/<provider>/provider.go` implementing `identity.IdentityProvider`
2. Register at startup: `identity.WithProvider(newProvider)`
3. No adapter changes needed

Research validated against Samba idmap, Keycloak identity broker, Vault auth methods, MinIO, CephFS, Nextcloud, and Kubernetes authenticator patterns.

### Also included (pre-existing on branch)

- SMB WPTS conformance fixes: lease constant corrections, directory lease break handling, cross-key conflict path fixes, Write stripping on Handle-bearing leases
- `removeLeaseMapping` helper extraction in SMB lease manager

Closes #324

## Test plan

- [x] `go test ./...` -- 72 packages pass, zero failures
- [x] `go build ./...` -- clean build
- [ ] Verify `dfsctl idmap add --principal alice@EXAMPLE.COM --username alice` works against new endpoint
- [ ] Verify `dfsctl idmap list --provider kerberos` filters correctly
- [ ] Verify existing idmap entries still resolve (backward compat)
- [ ] Verify SMB Kerberos auth resolves via centralized resolver
- [ ] Verify NFS RPCSEC_GSS auth resolves via centralized resolver with fallback to legacy mapper