### PR TITLE
Add GPG signing for APT repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -359,7 +359,7 @@ release:
 
     **Debian/Ubuntu (APT):**
     ```bash
-    curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
+    curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor --yes | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
     echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
     sudo apt update && sudo apt install dfs
     sudo systemctl enable --now dfs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -359,7 +359,7 @@ release:
 
     **Debian/Ubuntu (APT):**
     ```bash
-    curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/dittofs.gpg
+    curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
     echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
     sudo apt update && sudo apt install dfs
     sudo systemctl enable --now dfs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -359,7 +359,8 @@ release:
 
     **Debian/Ubuntu (APT):**
     ```bash
-    echo "deb https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
+    curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/dittofs.gpg
+    echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
     sudo apt update && sudo apt install dfs
     sudo systemctl enable --now dfs
     ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ brew install marmos91/tap/dfsctl   # Client CLI
 #### Debian / Ubuntu (APT)
 
 ```bash
-curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
+curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor --yes | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
 sudo apt update && sudo apt install dfs
 sudo systemctl enable --now dfs

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ brew install marmos91/tap/dfsctl   # Client CLI
 #### Debian / Ubuntu (APT)
 
 ```bash
-curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/dittofs.gpg
+curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
 sudo apt update && sudo apt install dfs
 sudo systemctl enable --now dfs

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ brew install marmos91/tap/dfsctl   # Client CLI
 #### Debian / Ubuntu (APT)
 
 ```bash
-echo "deb https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
+curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/dittofs.gpg
+echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" | sudo tee /etc/apt/sources.list.d/dfs.list
 sudo apt update && sudo apt install dfs
 sudo systemctl enable --now dfs
 ```

--- a/scripts/publish-linux-repos.sh
+++ b/scripts/publish-linux-repos.sh
@@ -68,16 +68,21 @@ RELEASE
 
   # GPG sign if key is available (isolated keyring)
   if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
-    (
+    if ! (
+      set -e
       GNUPGHOME="${WORK_DIR}/gnupg"
       export GNUPGHOME
       mkdir -p "${GNUPGHOME}"
       chmod 700 "${GNUPGHOME}"
-      echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
+      printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --import
+      KEY_FP=$(gpg --batch --with-colons --list-keys 2>/dev/null | awk -F: '/^fpr/{print $10; exit}')
       gpg --batch --yes --armor --detach-sign -o Release.gpg Release
       gpg --batch --yes --armor --clearsign -o InRelease Release
-      gpg --batch --yes --armor --export > "${APT_DIR}/dittofs.gpg.key"
-    )
+      gpg --batch --yes --armor --export "$KEY_FP" > "${APT_DIR}/dittofs.gpg.key"
+    ); then
+      echo "ERROR: GPG signing failed" >&2
+      exit 1
+    fi
   fi
 
   cd "${WORK_DIR}"
@@ -106,7 +111,7 @@ else
   cat > "${RPM_DIR}/dfs.repo" <<REPO
 [dfs]
 name=DittoFS
-baseurl=https://s3.cubbit.eu/${S3_BUCKET}/rpm
+baseurl=${S3_ENDPOINT}/${S3_BUCKET}/rpm
 enabled=1
 gpgcheck=0
 REPO

--- a/scripts/publish-linux-repos.sh
+++ b/scripts/publish-linux-repos.sh
@@ -50,6 +50,7 @@ Origin: DittoFS
 Label: DittoFS
 Suite: stable
 Codename: stable
+Date: $(date -Ru)
 Architectures: amd64 arm64
 Components: main
 Description: DittoFS APT repository

--- a/scripts/publish-linux-repos.sh
+++ b/scripts/publish-linux-repos.sh
@@ -50,7 +50,7 @@ Origin: DittoFS
 Label: DittoFS
 Suite: stable
 Codename: stable
-Date: $(date -Ru)
+Date: $(LC_ALL=C date -Ru)
 Architectures: amd64 arm64
 Components: main
 Description: DittoFS APT repository


### PR DESCRIPTION
## Summary

- Add Date field to APT Release file (fixes apt warning)
- Update APT install instructions with GPG keyring setup (`signed-by`)
- GPG_PRIVATE_KEY secret already configured

## Test plan

- [ ] Next release triggers signing in publish-linux-repos.sh
- [ ] `dittofs.gpg.key` is published to S3
- [ ] APT install works without `[trusted=yes]`