### PR TITLE
fix(release): skip :latest Docker tag for pre-release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: "~> v2.11"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,14 @@ jobs:
 
       - name: Get version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          TAGS="marmos91c/dittofs-operator:${VERSION}"
+          if [[ "${VERSION}" != *-* ]]; then
+            TAGS="${TAGS},marmos91c/dittofs-operator:latest"
+          fi
+          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -119,9 +126,7 @@ jobs:
           file: ./k8s/dittofs-operator/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            marmos91c/dittofs-operator:${{ steps.version.outputs.VERSION }}
-            marmos91c/dittofs-operator:latest
+          tags: ${{ steps.version.outputs.TAGS }}
           labels: |
             org.opencontainers.image.title=DittoFS Operator
             org.opencontainers.image.description=Kubernetes operator for DittoFS


### PR DESCRIPTION
## Summary

- Pre-release tags (e.g., v1.0.0-rc1) no longer overwrite `:latest` Docker tag
- Skip `:latest`, `vMajor`, and `vMajor.Minor` manifests for pre-releases via GoReleaser `.Prerelease` template guard
- Compute operator image tags as comma-separated string to avoid blank tag line
- Pin GoReleaser to `~> v2.11` to guarantee empty `name_template` manifest skipping

Closes #313

## Test plan

- [ ] Verify stable release tags still produce `:latest` manifest
- [ ] Verify pre-release tags (e.g., `v0.12.0-rc.1`) skip `:latest`
- [ ] Verify operator image tags are correct for both cases