### PR TITLE
feat(release): add cosign keyless OIDC signing for release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # Required for cosign keyless OIDC signing
 
     steps:
       - name: Checkout code
@@ -38,6 +41,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Install Linux packaging tools
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev createrepo-c

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,6 +159,17 @@ checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
 
+# Cosign keyless signing via GitHub Actions OIDC
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - "sign-blob"
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
@@ -417,6 +428,18 @@ release:
 
     ```bash
     sha256sum -c checksums.txt
+    ```
+
+    ### Verifying Signatures
+
+    Release checksums are signed with [Sigstore cosign](https://docs.sigstore.dev/) using keyless OIDC:
+
+    ```bash
+    cosign verify-blob \
+      --bundle checksums.txt.sigstore.json \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity-regexp '^https://github\.com/marmos91/dittofs/\.github/workflows/release\.yml@refs/tags/' \
+      checksums.txt
     ```
 
     ### Docker Images


### PR DESCRIPTION
## Summary

- Sign release checksums with Sigstore cosign using GitHub Actions OIDC identity
- Add `signs` section to `.goreleaser.yml` for checksum blob signing
- Add `id-token: write` permission for OIDC token acquisition
- Install cosign via `sigstore/cosign-installer@v3` in release workflow
- Add signature verification instructions to release notes footer

Closes #311

## Test plan

- [ ] Verify cosign is installed before GoReleaser runs
- [ ] Verify `id-token: write` permission is present
- [ ] Verify `checksums.txt.sig` and `checksums.txt.pem` are uploaded to release
- [ ] Verify `cosign verify-blob` command in release notes works