### PR TITLE
fix(ci): harden release workflow with least-privilege and post-upload verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     tags:
       - 'v*.*.*'  # Triggers on version tags like v1.0.0, v0.1.0, etc.
 
-permissions:
-  contents: write  # Required for creating releases
+permissions: {}
 
 jobs:
   release:
@@ -15,6 +14,9 @@ jobs:
     permissions:
       contents: write
       id-token: write  # Required for cosign keyless OIDC signing
+    env:
+      S3_BUCKET: dittofs-binaries
+      S3_ENDPOINT: https://s3.cubbit.eu
 
     steps:
       - name: Checkout code
@@ -28,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -60,7 +62,6 @@ jobs:
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
       - name: Publish Linux repositories
-        if: success()
         run: ./scripts/publish-linux-repos.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,24 +69,98 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Upload packages to S3
-        if: success()
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          for ext in deb rpm pkg.tar.zst; do
-            for f in dist/*."${ext}"; do
-              [ -f "$f" ] || continue
-              aws s3 cp "$f" "s3://${S3_BUCKET:-dittofs-binaries}/${VERSION}/$(basename "$f")" \
-                --endpoint-url "${S3_ENDPOINT:-https://s3.cubbit.eu}" \
-                --acl public-read
-            done
+
+          shopt -s nullglob
+          ARTIFACTS=(dist/*.deb dist/*.rpm dist/*.pkg.tar.zst)
+          if [ ${#ARTIFACTS[@]} -eq 0 ]; then
+            echo "::error::No Linux packages found in dist/"
+            exit 1
+          fi
+          echo "Uploading ${#ARTIFACTS[@]} packages:"
+          printf '  %s\n' "${ARTIFACTS[@]}"
+
+          for f in "${ARTIFACTS[@]}"; do
+            aws s3 cp "$f" "s3://${S3_BUCKET}/${VERSION}/$(basename "$f")" \
+              --endpoint-url "${S3_ENDPOINT}" \
+              --acl public-read
           done
+
+          # Upload version marker for install script auto-detection (skip pre-releases)
+          if [[ "${VERSION}" != *-* ]]; then
+            echo "${VERSION}" | aws s3 cp - "s3://${S3_BUCKET}/latest" \
+              --endpoint-url "${S3_ENDPOINT}" \
+              --acl public-read \
+              --content-type "text/plain"
+          fi
+
+          # Upload install script to bucket root (always latest)
+          if [ -f scripts/install.sh ]; then
+            aws s3 cp scripts/install.sh "s3://${S3_BUCKET}/install.sh" \
+              --endpoint-url "${S3_ENDPOINT}" \
+              --acl public-read \
+              --content-type "text/plain"
+          fi
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Verify uploaded artifacts are publicly accessible
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          BASE="${S3_ENDPOINT}/${S3_BUCKET}"
+          FAILED=0
+
+          check_url() {
+            local url="$1" level="${2:-error}"
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" -I "$url")
+            if [ "$code" != "200" ]; then
+              echo "::${level}::${url} returned HTTP ${code} (expected 200)"
+              [ "$level" = "error" ] && FAILED=1
+            else
+              echo "ok  $url"
+            fi
+          }
+
+          # Verify Linux packages
+          shopt -s nullglob
+          ARTIFACTS=(dist/*.deb dist/*.rpm dist/*.pkg.tar.zst)
+          if [ ${#ARTIFACTS[@]} -eq 0 ]; then
+            echo "::error::No Linux packages found in dist/ — nothing to verify"
+            exit 1
+          fi
+          for f in "${ARTIFACTS[@]}"; do
+            check_url "${BASE}/${VERSION}/$(basename "$f")"
+          done
+
+          # Verify additional required files
+          check_url "${BASE}/install.sh"
+          if [[ "${VERSION}" != *-* ]]; then
+            check_url "${BASE}/latest"
+          fi
+
+          # Verify APT repo
+          for path in apt/dists/stable/Release apt/dists/stable/InRelease apt/dittofs.gpg.key; do
+            check_url "${BASE}/${path}" warning
+          done
+
+          # Verify YUM repo
+          for path in rpm/repodata/repomd.xml rpm/dfs.repo; do
+            check_url "${BASE}/${path}" warning
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more release artifacts are not publicly accessible — check bucket ACLs"
+            exit 1
+          fi
+
   operator:
     name: Build Operator Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -94,7 +169,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.25.x"
+          go-version-file: k8s/dittofs-operator/go.mod
 
       - name: Get version from tag
         id: version

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,10 +26,14 @@ DittoFS uses [Semantic Versioning](https://semver.org/) and automated releases v
    ```
 
 4. **GitHub Actions automatically**:
-   - Runs tests
    - Builds binaries for Linux, macOS, Windows (amd64, arm64, arm)
-   - Generates checksums
+   - Generates checksums and signs them with Sigstore cosign (keyless OIDC)
    - Creates GitHub Release with artifacts
+   - Builds multi-arch Docker images via `dockers_v2` (amd64 + arm64)
+   - Publishes Homebrew casks and Scoop manifests
+   - Publishes Linux packages (deb, rpm, archlinux) to APT/YUM repos
+   - Uploads packages and version marker to S3
+   - Verifies all uploaded artifacts are publicly accessible
 
 5. **Verify** at https://github.com/marmos91/dittofs/releases
 
@@ -62,9 +66,21 @@ git merge hotfix/v1.2.4
 git push origin main
 ```
 
+## Verifying Signatures
+
+Release checksums are signed with [Sigstore cosign](https://docs.sigstore.dev/) using keyless OIDC via GitHub Actions:
+
+```bash
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github\.com/marmos91/dittofs/\.github/workflows/release\.yml@refs/tags/' \
+  checksums.txt
+```
+
 ## Homebrew Tap
 
-Releases automatically publish Homebrew formulae to [`marmos91/homebrew-tap`](https://github.com/marmos91/homebrew-tap). Users can install via:
+Releases automatically publish Homebrew casks to [`marmos91/homebrew-tap`](https://github.com/marmos91/homebrew-tap). Users can install via:
 
 ```bash
 brew tap marmos91/tap
@@ -74,16 +90,15 @@ brew install marmos91/tap/dfsctl   # Client CLI
 
 ### How It Works
 
-GoReleaser's `brews` section generates Ruby formula files and pushes them to the tap repository on each non-prerelease tag push. The `skip_upload: auto` setting prevents prerelease versions (e.g., `v1.0.0-beta.1`) from being published to the tap.
+GoReleaser's `homebrew_casks` section generates cask files and pushes them to the tap repository on each non-prerelease tag push. The `skip_upload: auto` setting prevents prerelease versions (e.g., `v1.0.0-beta.1`) from being published to the tap.
 
-Each formula:
+Each cask:
 - Downloads the correct archive for the user's OS/architecture
 - Installs the binary to `$(brew --prefix)/bin`
-- Generates shell completions (bash, zsh, fish) via `generate_completions_from_executable`
 
 ### Prerequisites
 
-1. **Tap repository**: `marmos91/homebrew-tap` must exist on GitHub with a `Formula/` directory
+1. **Tap repository**: `marmos91/homebrew-tap` must exist on GitHub with a `Casks/` directory
 2. **Personal Access Token**: A fine-grained token scoped to `marmos91/homebrew-tap` with Contents read+write permission, stored as `HOMEBREW_TAP_TOKEN` in the `marmos91/dittofs` repository secrets
 
 ### Local Testing
@@ -99,10 +114,6 @@ goreleaser release --snapshot --clean
 # Verify archives
 ls dist/dfs_*
 ls dist/dfsctl_*
-
-# Verify generated formulae
-cat dist/homebrew/Formula/dfs.rb
-cat dist/homebrew/Formula/dfsctl.rb
 ```
 
 ### Token Rotation


### PR DESCRIPTION
## Summary

Align the dittofs release workflow with dittofs-pro conventions:

- **Least-privilege permissions**: Set workflow-level `permissions: {}` and scope `contents: write` / `id-token: write` only to the `release` job; operator job gets `contents: read`
- **Dynamic Go version**: Use `go-version-file: go.mod` instead of hardcoded `"1.25.x"` — no workflow updates needed when upgrading Go
- **Artifact existence check**: Fail loudly if no Linux packages found in `dist/` after GoReleaser runs
- **Version marker**: Upload `latest` file to S3 bucket root for install script auto-detection
- **Install script sync**: Copy `scripts/install.sh` to bucket root on every release
- **Post-upload verification**: Smoke test that all uploaded packages, APT repo, and YUM repo are publicly accessible
- **Cleanup**: Remove redundant `if: success()` conditions

## Test plan

- [ ] Verify release job has `contents: write` + `id-token: write`
- [ ] Verify operator job has `contents: read` only
- [ ] Verify Go version is read from `go.mod`
- [ ] Verify verification step checks correct S3 paths