### PR TITLE
feat(blockstore): add CopyBlock to RemoteStore interface

### DIFF
--- a/pkg/blockstore/remote/memory/store.go
+++ b/pkg/blockstore/remote/memory/store.go
@@ -94,6 +94,26 @@ func (s *Store) ReadBlockRange(_ context.Context, blockKey string, offset, lengt
 	return result, nil
 }
 
+// CopyBlock copies a block from srcKey to dstKey in memory.
+func (s *Store) CopyBlock(_ context.Context, srcKey, dstKey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return blockstore.ErrStoreClosed
+	}
+
+	data, ok := s.blocks[srcKey]
+	if !ok {
+		return blockstore.ErrBlockNotFound
+	}
+
+	copied := make([]byte, len(data))
+	copy(copied, data)
+	s.blocks[dstKey] = copied
+	return nil
+}
+
 // DeleteBlock removes a single block from memory.
 func (s *Store) DeleteBlock(_ context.Context, blockKey string) error {
 	s.mu.Lock()

--- a/pkg/blockstore/remote/memory/store_test.go
+++ b/pkg/blockstore/remote/memory/store_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote/remotetest"
 )
 
 func TestStore_WriteAndRead(t *testing.T) {
@@ -253,6 +255,14 @@ func TestStore_BlockCount(t *testing.T) {
 	if s.BlockCount() != 2 {
 		t.Errorf("BlockCount returned %d, want 2", s.BlockCount())
 	}
+}
+
+// TestConformanceSuite runs the full RemoteStore conformance suite against the
+// in-memory store. This ensures all interface methods are exercised on CI.
+func TestConformanceSuite(t *testing.T) {
+	remotetest.RunSuite(t, func(t *testing.T) remote.RemoteStore {
+		return New()
+	})
 }
 
 func TestStore_TotalSize(t *testing.T) {

--- a/pkg/blockstore/remote/remote.go
+++ b/pkg/blockstore/remote/remote.go
@@ -30,6 +30,12 @@ type RemoteStore interface {
 	// ListByPrefix lists all block keys matching the prefix.
 	ListByPrefix(ctx context.Context, prefix string) ([]string, error)
 
+	// CopyBlock copies a block from srcKey to dstKey using server-side copy
+	// when the backend supports it (e.g., S3 CopyObject). Falls back to
+	// read-then-write for backends without native copy.
+	// Returns blockstore.ErrBlockNotFound if the source block does not exist.
+	CopyBlock(ctx context.Context, srcKey, dstKey string) error
+
 	// Close releases resources held by the store.
 	Close() error
 

--- a/pkg/blockstore/remote/remotetest/suite.go
+++ b/pkg/blockstore/remote/remotetest/suite.go
@@ -3,8 +3,10 @@ package remotetest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/blockstore/remote"
 	"github.com/marmos91/dittofs/pkg/health"
 )
@@ -22,6 +24,8 @@ func RunSuite(t *testing.T, factory Factory) {
 	t.Run("ListByPrefix", func(t *testing.T) { testListByPrefix(t, factory) })
 	t.Run("HealthCheck", func(t *testing.T) { testHealthCheck(t, factory) })
 	t.Run("HealthcheckReport", func(t *testing.T) { testHealthcheckReport(t, factory) })
+	t.Run("CopyBlock", func(t *testing.T) { testCopyBlock(t, factory) })
+	t.Run("CopyBlockNotFound", func(t *testing.T) { testCopyBlockNotFound(t, factory) })
 	t.Run("ClosedOperations", func(t *testing.T) { testClosedOperations(t, factory) })
 	t.Run("DataIsolation", func(t *testing.T) { testDataIsolation(t, factory) })
 }
@@ -206,6 +210,58 @@ func testClosedOperations(t *testing.T, factory Factory) {
 
 	if _, err := store.ReadBlock(ctx, "key"); err == nil {
 		t.Error("ReadBlock should fail after Close")
+	}
+
+	if err := store.CopyBlock(ctx, "src", "dst"); err == nil {
+		t.Error("CopyBlock should fail after Close")
+	}
+}
+
+func testCopyBlock(t *testing.T, factory Factory) {
+	store := factory(t)
+	ctx := context.Background()
+
+	data := []byte("source content")
+	srcKey := "src/block-0"
+	dstKey := "dst/block-0"
+
+	if err := store.WriteBlock(ctx, srcKey, data); err != nil {
+		t.Fatalf("WriteBlock failed: %v", err)
+	}
+
+	if err := store.CopyBlock(ctx, srcKey, dstKey); err != nil {
+		t.Fatalf("CopyBlock failed: %v", err)
+	}
+
+	// Verify destination has the same data
+	read, err := store.ReadBlock(ctx, dstKey)
+	if err != nil {
+		t.Fatalf("ReadBlock on destination failed: %v", err)
+	}
+	if !bytes.Equal(read, data) {
+		t.Fatalf("destination data = %q, want %q", read, data)
+	}
+
+	// Verify source is unchanged
+	read, err = store.ReadBlock(ctx, srcKey)
+	if err != nil {
+		t.Fatalf("ReadBlock on source failed: %v", err)
+	}
+	if !bytes.Equal(read, data) {
+		t.Fatalf("source data changed after copy: got %q, want %q", read, data)
+	}
+}
+
+func testCopyBlockNotFound(t *testing.T, factory Factory) {
+	store := factory(t)
+	ctx := context.Background()
+
+	err := store.CopyBlock(ctx, "nonexistent/block-0", "dst/block-0")
+	if err == nil {
+		t.Fatal("CopyBlock should fail for nonexistent source")
+	}
+	if !errors.Is(err, blockstore.ErrBlockNotFound) {
+		t.Fatalf("CopyBlock error = %v, want blockstore.ErrBlockNotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Promote `CopyBlock(ctx, srcKey, dstKey) error` from a concrete method on S3 store to a required method on the `RemoteStore` interface
- Implement `CopyBlock` on memory remote store (byte copy for testing)
- S3 store already has `CopyBlock` using S3 `CopyObject` — no changes needed
- Add `CopyBlock` and `CopyBlockNotFound` conformance tests to `remotetest` suite

## Context

Foundation for #353. This is the first of two PRs:
1. **This PR**: Add `CopyBlock` to `RemoteStore` interface (enables engine-level copy)
2. **Follow-up PR**: Add `CopyPayload` to `blockstore.Store` / engine interface (depends on this)

The S3 store's `CopyBlock` uses `CopyObject` for zero-data-transfer server-side copy. The memory store implements it as a byte copy. Future remote store implementations (GCS, Azure Blob) can use their native copy APIs.

## Test plan
- [x] `go test ./...` — all existing tests pass
- [x] New conformance tests: `CopyBlock`, `CopyBlockNotFound`
- [x] S3 store compile-time interface check passes

Partial #353