### PR TITLE
feat(blockstore): add CopyPayload to Store interface and engine

### DIFF
--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -246,6 +246,69 @@ func (bs *BlockStore) Delete(ctx context.Context, payloadID string) error {
 	return bs.syncer.Delete(ctx, payloadID)
 }
 
+// CopyPayload duplicates all blocks from srcPayloadID to dstPayloadID.
+//
+// For each source block, data is read from the local store (falling back to
+// remote download on miss) and written to the destination's local store.
+// If a remote store is configured, blocks are also copied server-side
+// (e.g., S3 CopyObject) to avoid redundant uploads.
+//
+// Returns the number of blocks copied and any error encountered.
+func (bs *BlockStore) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string) (int, error) {
+	// Get the source file size to determine the block range.
+	srcSize, err := bs.GetSize(ctx, srcPayloadID)
+	if err != nil {
+		return 0, fmt.Errorf("get source size: %w", err)
+	}
+	if srcSize == 0 {
+		return 0, nil
+	}
+
+	// Truncate destination to source size so trailing blocks from a previously
+	// larger payload are removed and the destination is an exact copy.
+	if err := bs.Truncate(ctx, dstPayloadID, srcSize); err != nil {
+		return 0, fmt.Errorf("truncate dest to source size: %w", err)
+	}
+
+	totalBlocks := (srcSize + blockstore.BlockSize - 1) / blockstore.BlockSize
+	buf := make([]byte, blockstore.BlockSize)
+	copied := 0
+
+	for blockIdx := uint64(0); blockIdx < totalBlocks; blockIdx++ {
+		offset := blockIdx * blockstore.BlockSize
+		readLen := min(srcSize-offset, blockstore.BlockSize)
+
+		// Read source block (local with remote fallback)
+		data := buf[:readLen]
+		n, readErr := bs.ReadAt(ctx, srcPayloadID, data, offset)
+		if readErr != nil {
+			return copied, fmt.Errorf("read source block %d: %w", blockIdx, readErr)
+		}
+		data = data[:n]
+
+		// Write to destination via BlockStore.WriteAt (not local.WriteAt directly)
+		// so the read buffer is invalidated for affected blocks.
+		if err := bs.WriteAt(ctx, dstPayloadID, data, offset); err != nil {
+			return copied, fmt.Errorf("write dest block %d: %w", blockIdx, err)
+		}
+
+		// Copy in remote store using server-side copy (avoids re-upload)
+		if bs.remote != nil {
+			srcKey := blockstore.FormatStoreKey(srcPayloadID, blockIdx)
+			dstKey := blockstore.FormatStoreKey(dstPayloadID, blockIdx)
+			if copyErr := bs.remote.CopyBlock(ctx, srcKey, dstKey); copyErr != nil {
+				// Non-fatal: the syncer will upload from local store eventually
+				logger.Debug("CopyPayload: remote copy failed (syncer will upload)",
+					"srcKey", srcKey, "dstKey", dstKey, "error", copyErr)
+			}
+		}
+
+		copied++
+	}
+
+	return copied, nil
+}
+
 // Flush ensures all dirty data for a payload is persisted.
 // After flush, auto-promotes block data into the read buffer if the file fits
 // within the budget (data is in OS page cache, so the read is essentially free).

--- a/pkg/blockstore/engine/engine_test.go
+++ b/pkg/blockstore/engine/engine_test.go
@@ -596,3 +596,64 @@ func TestReadAtSubBlockOffset(t *testing.T) {
 		t.Fatalf("sub-block read mismatch: got %q, want %q", subBuf, expected)
 	}
 }
+
+// TestCopyPayload_LocalOnly verifies CopyPayload duplicates data between payloads.
+func TestCopyPayload_LocalOnly(t *testing.T) {
+	bs := newTestEngine(t, 0, 0)
+	ctx := context.Background()
+
+	srcPayload := "src-file"
+	dstPayload := "dst-file"
+	data := []byte("hello world, this is test data for copy payload")
+
+	// Write source data
+	if err := bs.WriteAt(ctx, srcPayload, data, 0); err != nil {
+		t.Fatalf("WriteAt failed: %v", err)
+	}
+
+	// Copy payload
+	copied, err := bs.CopyPayload(ctx, srcPayload, dstPayload)
+	if err != nil {
+		t.Fatalf("CopyPayload failed: %v", err)
+	}
+	if copied != 1 {
+		t.Fatalf("CopyPayload returned %d blocks, expected 1", copied)
+	}
+
+	// Read back from destination
+	buf := make([]byte, len(data))
+	n, err := bs.ReadAt(ctx, dstPayload, buf, 0)
+	if err != nil {
+		t.Fatalf("ReadAt on dest failed: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("ReadAt returned %d bytes, expected %d", n, len(data))
+	}
+	if string(buf) != string(data) {
+		t.Fatalf("dest data = %q, want %q", buf, data)
+	}
+
+	// Verify source is unchanged
+	srcBuf := make([]byte, len(data))
+	_, err = bs.ReadAt(ctx, srcPayload, srcBuf, 0)
+	if err != nil {
+		t.Fatalf("ReadAt on src failed: %v", err)
+	}
+	if string(srcBuf) != string(data) {
+		t.Fatalf("source data changed: got %q, want %q", srcBuf, data)
+	}
+}
+
+// TestCopyPayload_EmptySource verifies CopyPayload handles empty source gracefully.
+func TestCopyPayload_EmptySource(t *testing.T) {
+	bs := newTestEngine(t, 0, 0)
+	ctx := context.Background()
+
+	copied, err := bs.CopyPayload(ctx, "nonexistent", "dst")
+	if err != nil {
+		t.Fatalf("CopyPayload should succeed for empty source, got: %v", err)
+	}
+	if copied != 0 {
+		t.Fatalf("CopyPayload returned %d blocks, expected 0", copied)
+	}
+}

--- a/pkg/blockstore/store.go
+++ b/pkg/blockstore/store.go
@@ -77,6 +77,12 @@ type Writer interface {
 
 	// Delete removes all data for a payload.
 	Delete(ctx context.Context, payloadID string) error
+
+	// CopyPayload duplicates all blocks from srcPayloadID to dstPayloadID.
+	// For remote-backed stores this leverages server-side copy (e.g., S3 CopyObject)
+	// to avoid data transfer. Local blocks are copied via read+write.
+	// Returns the number of blocks copied and any error encountered.
+	CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string) (int, error)
 }
 
 // Flusher defines flush/sync operations on the block store.


### PR DESCRIPTION
## Summary

- Add `CopyPayload(ctx, srcPayloadID, dstPayloadID) (int, error)` to `blockstore.Writer` interface
- Implement on `engine.BlockStore`: reads source blocks (local with remote fallback), writes to destination local store, copies in remote via `CopyBlock` (S3 server-side copy)
- Gracefully handles remote copy failures (syncer will upload from local store eventually)

## Dependency chain

This PR depends on #356 (`CopyBlock` on `RemoteStore` interface):

```
develop
  └── #356 feat/blockstore-copy-payload  (CopyBlock on RemoteStore)
        └── #357 feat/blockstore-copy-payload-engine  (CopyPayload on Store) ← this PR
```

Merge #356 first, then rebase this onto develop.

## Test plan
- [x] `go test ./...` — all existing tests pass
- [x] `TestCopyPayload_LocalOnly` — verifies data duplication between payloads
- [x] `TestCopyPayload_EmptySource` — verifies graceful handling of nonexistent source

Closes #353