### PR TITLE
test(smb): mark smb2.scan.find as flaky

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -793,6 +793,7 @@ iterates all QUERY_DIRECTORY information classes. Both hit unimplemented classes
 |-----------|----------|--------|-------|
 | smb2.scan.scan | Scan | Full operation scan hits unimplemented info classes | - |
 | smb2.scan.setinfo | Scan | Flaky in CI (rare connection-disconnect signature mismatch on brute-force level enumeration) | - |
+| smb2.scan.find | Scan | Flaky in CI (signature verification race during rapid QUERY_DIRECTORY enumeration) | #362 |
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Add `smb2.scan.find` to KNOWN_FAILURES.md as flaky.

## Context

Signature verification race causes intermittent CI failures during the test's rapid QUERY_DIRECTORY enumeration. Test previously passed consistently but has become flaky recently, failing on unrelated PRs (#356 merge to develop, #357 checks).

Already-flaky siblings: `scan.setinfo` (same root cause pattern).

Tracked in #362.