### PR TITLE
test(api): fix flaky TestAPIServer_Lifecycle on Windows CI (#373)

### DIFF
--- a/pkg/controlplane/api/server_test.go
+++ b/pkg/controlplane/api/server_test.go
@@ -3,12 +3,44 @@ package api
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
+
+// waitForServerReady waits for the API server to either accept TCP connections
+// on `addr` or fail to start. It races a TCP-dial poll against the server's
+// errChan so a Start failure (bind error, etc.) surfaces immediately rather
+// than as a generic listener timeout — and so the dial loop doesn't spuriously
+// succeed against an unrelated process already listening on `addr`.
+//
+// Calls t.Fatalf on Start error, dial timeout, or unexpected nil from Start
+// (Start returns nil only on graceful shutdown, which hasn't happened yet).
+func waitForServerReady(t *testing.T, addr string, errChan <-chan error, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+
+		select {
+		case startErr := <-errChan:
+			t.Fatalf("server.Start returned before listener was reachable: %v", startErr)
+		case <-deadline:
+			t.Fatalf("server did not start listening on %s within %s", addr, timeout)
+		case <-tick.C:
+		}
+	}
+}
 
 // testSetup creates control plane store and APIConfig for testing.
 func testSetup(t *testing.T, port int) (store.Store, APIConfig) {
@@ -58,8 +90,9 @@ func TestAPIServer_Lifecycle(t *testing.T) {
 		errChan <- server.Start(ctx)
 	}()
 
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the server's listener accepts connections — racing against
+	// errChan so a bind failure surfaces as a real error, not a vague timeout.
+	waitForServerReady(t, fmt.Sprintf("localhost:%d", cfg.Port), errChan, 5*time.Second)
 
 	// Make request to health endpoint
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", cfg.Port))
@@ -138,12 +171,12 @@ func TestAPIServer_HealthEndpoint_NoRuntime(t *testing.T) {
 	defer cancel()
 
 	// Start server in background
+	errChan := make(chan error, 1)
 	go func() {
-		_ = server.Start(ctx)
+		errChan <- server.Start(ctx)
 	}()
 
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
+	waitForServerReady(t, fmt.Sprintf("localhost:%d", cfg.Port), errChan, 5*time.Second)
 
 	// Test liveness endpoint (should always be OK)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", cfg.Port))
@@ -180,12 +213,12 @@ func TestAPIServer_RootRedirectsToHealth(t *testing.T) {
 	defer cancel()
 
 	// Start server in background
+	errChan := make(chan error, 1)
 	go func() {
-		_ = server.Start(ctx)
+		errChan <- server.Start(ctx)
 	}()
 
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
+	waitForServerReady(t, fmt.Sprintf("localhost:%d", cfg.Port), errChan, 5*time.Second)
 
 	// Create a client that doesn't follow redirects
 	client := &http.Client{


### PR DESCRIPTION
## Summary

Fixes the Windows CI flake in `TestAPIServer_Lifecycle` (and two sibling tests with the same race pattern) by replacing fixed sleeps with a TCP-dial poll that also observes the server's start error channel.

## #371 (NTLMSSP mechListMIC) — reverted, needs deeper work

I attempted #371 in this PR too, but the mechListMIC bytes we emit don't match what Samba's gensec verifier computes. **Result:** every SPNEGO/NTLM session-setup failed with `NTLMSSP NTLM2 packet check failed due to invalid signature`, dropping smbtorture from ~193 passes to 0. Reverted in `c15dc4b3`.

Suspected causes (not yet pinned down):
- We re-marshal `mechTypes` via gokrb5's `asn1.Marshal` instead of carrying the **original NegTokenInit wire bytes**. Even a one-byte DER difference makes the HMAC diverge.
- A second NTLMSSP signing primitive (extended NTLM2 sealing state, per-message wrap over the MIC, or a `NEGOTIATE_SIGN`-conditional path) may be missing.

The helper `ComputeNTLMSSPMechListMIC` and unit tests in `c15dc4b3` were also rolled back to keep this PR scope-clean. #371 stays open.

## Changes (this PR after revert)

- `pkg/controlplane/api/server_test.go`: replace 100ms fixed sleeps in `TestAPIServer_Lifecycle`, `TestAPIServer_HealthEndpoint_NoRuntime`, and `TestAPIServer_RootRedirectsToHealth` with `waitForServerReady` — TCP-dial loop that races against the server's `errChan` so a bind error surfaces immediately rather than as a generic listener timeout.

## Test plan

- [x] `go test -race ./pkg/controlplane/api/` — 4 of 5 tests pass; `TestAPIServer_Lifecycle` fails locally only because Docker on my machine occupies port 18080 (CI runners are clean)
- [x] Failure mode under port-bind error is now informative (`API server failed: listen tcp :18080: bind: address already in use`) instead of a vague timeout
- [ ] CI: Windows Build, Unit, E2E, Integration, Lint
- [ ] CI: smbtorture/memory matches develop baseline (no regression after revert)

Closes #373