### PR TITLE
fix(smb): NTLMSSP mechListMIC with correct SEALKEY truncation (#371)

### DIFF
--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -829,3 +829,110 @@ func DeriveSigningKey(sessionBaseKey [16]byte, flags NegotiateFlag, encryptedKey
 
 	return exportedSessionKey
 }
+
+// NTLMSSP key-derivation magic constants (MS-NLMP 3.4.5.2 + 3.4.5.3).
+// The trailing NUL is part of each constant.
+const (
+	serverSignMagic = "session key to server-to-client signing key magic constant\x00"
+	serverSealMagic = "session key to server-to-client sealing key magic constant\x00"
+)
+
+// NTLMSSPMechListMICDebug holds the intermediate values computed during a
+// ComputeNTLMSSPMechListMIC call. Populated only when callers pass a non-nil
+// pointer; used for diagnosing why a peer rejects the emitted signature.
+type NTLMSSPMechListMICDebug struct {
+	SigningKey      [16]byte
+	SealingKey      [16]byte
+	HMACOutputFull  [16]byte // full 16-byte HMAC-MD5 digest
+	HMACChecksum    [8]byte  // first 8 bytes pre-seal
+	SealKeystreamHi [8]byte  // first 8 bytes of fresh RC4(SealingKey) keystream
+	SealedChecksum  [8]byte  // post-seal 8 bytes (what goes on the wire)
+	MIC             [16]byte // final on-wire signature
+}
+
+// ComputeNTLMSSPMechListMIC computes an NTLMSSP v2 message signature over the
+// SPNEGO mechList bytes for downgrade protection per RFC 4178.
+//
+// Signature layout (MS-NLMP 2.2.2.9.1, extended session security v2):
+//
+//	Version  (4 bytes, LE) = 0x00000001
+//	Checksum (8 bytes)     = see below
+//	SeqNum   (4 bytes, LE) = 0x00000000  (fixed for SPNEGO MIC)
+//
+// Without KEY_EXCH: Checksum = HMAC_MD5(ServerSigningKey, SeqNum=0 || mechList)[:8]
+// With KEY_EXCH:    Checksum = RC4(ServerSealingKey, HMAC...)  -- fresh cipher
+//
+// Key derivations (MS-NLMP 3.4.5.2 + 3.4.5.3):
+//
+//	ServerSigningKey = MD5(ExportedSessionKey || serverSignMagic)
+//	ServerSealingKey = MD5(ExportedSessionKey || serverSealMagic)
+//
+// If dbg is non-nil it is populated with intermediates for diagnosis.
+func ComputeNTLMSSPMechListMIC(exportedSessionKey [16]byte, mechListBytes []byte, flags NegotiateFlag, dbg *NTLMSSPMechListMICDebug) []byte {
+	h := md5.New()
+	h.Write(exportedSessionKey[:])
+	h.Write([]byte(serverSignMagic))
+	var signKey [16]byte
+	copy(signKey[:], h.Sum(nil))
+
+	mac := hmac.New(md5.New, signKey[:])
+	var seqNum [4]byte
+	mac.Write(seqNum[:])
+	mac.Write(mechListBytes)
+	fullHMAC := mac.Sum(nil)
+
+	checksum := make([]byte, 8)
+	copy(checksum, fullHMAC[:8])
+
+	var sealKey [16]byte
+	var keystream [8]byte
+
+	if flags&FlagKeyExch != 0 {
+		// Per MS-NLMP 3.4.5.3 SEALKEY, the sealing key's INPUT to MD5 is
+		// the ExportedSessionKey truncated based on negotiated strength.
+		// Samba's smbtorture client does NOT negotiate NEGOTIATE_128 or _56,
+		// so it falls into the 40-bit branch (first 5 bytes of ExportedSessionKey).
+		// Using the full 16 bytes here is the cause of the mechListMIC mismatch.
+		var sealInput []byte
+		switch {
+		case flags&Flag128 != 0:
+			sealInput = exportedSessionKey[:16]
+		case flags&Flag56 != 0:
+			sealInput = exportedSessionKey[:7]
+		default:
+			sealInput = exportedSessionKey[:5]
+		}
+
+		sh := md5.New()
+		sh.Write(sealInput)
+		sh.Write([]byte(serverSealMagic))
+		copy(sealKey[:], sh.Sum(nil))
+
+		if cipher, err := rc4.NewCipher(sealKey[:]); err == nil {
+			// Capture the leading keystream for diagnosis (XOR of zeros == keystream).
+			cipher.XORKeyStream(keystream[:], make([]byte, 8))
+			// Fresh cipher for the actual seal.
+			cipher2, _ := rc4.NewCipher(sealKey[:])
+			sealed := make([]byte, 8)
+			cipher2.XORKeyStream(sealed, checksum)
+			checksum = sealed
+		}
+	}
+
+	mic := make([]byte, 16)
+	binary.LittleEndian.PutUint32(mic[0:4], 0x00000001)
+	copy(mic[4:12], checksum)
+	// SeqNum = 0 (not XOR'd; matches Samba wire format).
+
+	if dbg != nil {
+		dbg.SigningKey = signKey
+		dbg.SealingKey = sealKey
+		copy(dbg.HMACOutputFull[:], fullHMAC)
+		copy(dbg.HMACChecksum[:], fullHMAC[:8])
+		dbg.SealKeystreamHi = keystream
+		copy(dbg.SealedChecksum[:], checksum)
+		copy(dbg.MIC[:], mic)
+	}
+
+	return mic
+}

--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -865,7 +865,15 @@ type NTLMSSPMechListMICDebug struct {
 // Key derivations (MS-NLMP 3.4.5.2 + 3.4.5.3):
 //
 //	ServerSigningKey = MD5(ExportedSessionKey || serverSignMagic)
-//	ServerSealingKey = MD5(ExportedSessionKey || serverSealMagic)
+//
+// The sealing-key *input* to MD5 is truncated by the negotiated strength —
+// Samba's libcli/smb2 does NOT advertise NEGOTIATE_128, so the 40-bit
+// branch is what's exercised in the wild. Using the full key for the
+// 40/56-bit cases is the bug the previous attempt at #371 had:
+//
+//	NEGOTIATE_128: ServerSealingKey = MD5(ExportedSessionKey        || serverSealMagic)
+//	NEGOTIATE_56:  ServerSealingKey = MD5(ExportedSessionKey[:7]    || serverSealMagic)
+//	(neither):     ServerSealingKey = MD5(ExportedSessionKey[:5]    || serverSealMagic)
 //
 // If dbg is non-nil it is populated with intermediates for diagnosis.
 func ComputeNTLMSSPMechListMIC(exportedSessionKey [16]byte, mechListBytes []byte, flags NegotiateFlag, dbg *NTLMSSPMechListMICDebug) []byte {

--- a/internal/adapter/smb/auth/ntlm_mechlistmic_test.go
+++ b/internal/adapter/smb/auth/ntlm_mechlistmic_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5" //nolint:gosec // MD5 is required for NTLM protocol testing
+	"crypto/rc4" //nolint:gosec // RC4 required to reproduce NTLMSSP seal in the oracle
+	"encoding/binary"
+	"testing"
+)
+
+// TestComputeNTLMSSPMechListMIC exercises ComputeNTLMSSPMechListMIC against
+// an independent first-principles reconstruction of MS-NLMP 3.4.5.2 (SIGNKEY),
+// 3.4.5.3 (SEALKEY), 3.4.4.2 (NTLM2 signature with/without KEY_EXCH), and
+// 2.2.2.9.1 (NTLMSSP_MESSAGE_SIGNATURE layout).
+//
+// It covers all four variants of the sealing-key derivation (no KEY_EXCH,
+// 40-bit truncation, 56-bit truncation, 128-bit full-key) — the first
+// attempt at #371 failed because we always used the full 16 bytes; Samba's
+// smbtorture client does not advertise NEGOTIATE_128 and falls into the
+// 40-bit branch.
+func TestComputeNTLMSSPMechListMIC(t *testing.T) {
+	exportedSessionKey := [16]byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+	}
+	// DER SEQUENCE OF OID with just the NTLMSSP OID — matches what a minimal
+	// Windows / Samba SPNEGO NegTokenInit carries.
+	mechListBytes := []byte{
+		0x30, 0x0c, 0x06, 0x0a,
+		0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0a,
+	}
+
+	// Common HMAC input: SigningKey is always derived from the full
+	// ExportedSessionKey regardless of the seal-key truncation mode.
+	signMD5 := md5.New()
+	signMD5.Write(exportedSessionKey[:])
+	signMD5.Write([]byte(serverSignMagic))
+	expectedSignKey := signMD5.Sum(nil)
+	mac := hmac.New(md5.New, expectedSignKey)
+	mac.Write([]byte{0, 0, 0, 0})
+	mac.Write(mechListBytes)
+	hmacChecksum := mac.Sum(nil)[:8]
+
+	sealedWith := func(sealInput []byte) []byte {
+		sh := md5.New()
+		sh.Write(sealInput)
+		sh.Write([]byte(serverSealMagic))
+		sealKey := sh.Sum(nil)
+		cipher, err := rc4.NewCipher(sealKey)
+		if err != nil {
+			t.Fatalf("rc4 init: %v", err)
+		}
+		sealed := make([]byte, 8)
+		cipher.XORKeyStream(sealed, hmacChecksum)
+		return sealed
+	}
+
+	pack := func(checksum []byte) []byte {
+		out := make([]byte, 16)
+		binary.LittleEndian.PutUint32(out[0:4], 1)
+		copy(out[4:12], checksum)
+		return out
+	}
+
+	cases := []struct {
+		name         string
+		flags        NegotiateFlag
+		wantChecksum []byte
+	}{
+		{
+			name:         "NoKeyExch_PlainHMAC",
+			flags:        FlagNTLM,
+			wantChecksum: hmacChecksum,
+		},
+		{
+			name:         "KeyExch_40bit_FirstBranch",
+			flags:        FlagNTLM | FlagKeyExch,
+			wantChecksum: sealedWith(exportedSessionKey[:5]),
+		},
+		{
+			name:         "KeyExch_56bit",
+			flags:        FlagNTLM | FlagKeyExch | Flag56,
+			wantChecksum: sealedWith(exportedSessionKey[:7]),
+		},
+		{
+			name:         "KeyExch_128bit",
+			flags:        FlagNTLM | FlagKeyExch | Flag128,
+			wantChecksum: sealedWith(exportedSessionKey[:16]),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := pack(tc.wantChecksum)
+			got := ComputeNTLMSSPMechListMIC(exportedSessionKey, mechListBytes, tc.flags, nil)
+			if len(got) != 16 {
+				t.Fatalf("expected 16-byte signature, got %d", len(got))
+			}
+			if !bytes.Equal(got, expected) {
+				t.Errorf("mechListMIC mismatch\nexpected %x\n     got %x", expected, got)
+			}
+			if ver := binary.LittleEndian.Uint32(got[0:4]); ver != 1 {
+				t.Errorf("Version = 0x%08x, want 0x00000001", ver)
+			}
+			if seq := binary.LittleEndian.Uint32(got[12:16]); seq != 0 {
+				t.Errorf("SeqNum = 0x%08x, want 0x00000000", seq)
+			}
+		})
+	}
+
+	// Sealing must actually cover mechListBytes — guards against no-op bugs.
+	t.Run("MICCoversInput", func(t *testing.T) {
+		flags := FlagNTLM | FlagKeyExch
+		a := ComputeNTLMSSPMechListMIC(exportedSessionKey, mechListBytes, flags, nil)
+		b := ComputeNTLMSSPMechListMIC(exportedSessionKey, append([]byte{0xff}, mechListBytes...), flags, nil)
+		if bytes.Equal(a[4:12], b[4:12]) {
+			t.Error("checksum did not change when mechListBytes changed")
+		}
+	})
+
+	// Debug struct gets populated with all intermediates when provided.
+	t.Run("DebugStructPopulated", func(t *testing.T) {
+		var dbg NTLMSSPMechListMICDebug
+		mic := ComputeNTLMSSPMechListMIC(exportedSessionKey, mechListBytes, FlagNTLM|FlagKeyExch, &dbg)
+		if !bytes.Equal(dbg.MIC[:], mic) {
+			t.Error("dbg.MIC does not match returned mic")
+		}
+		if !bytes.Equal(dbg.SigningKey[:], expectedSignKey) {
+			t.Errorf("dbg.SigningKey = %x, want %x", dbg.SigningKey, expectedSignKey)
+		}
+		if dbg.HMACChecksum == [8]byte{} {
+			t.Error("dbg.HMACChecksum is zero")
+		}
+	})
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -191,6 +191,11 @@ type PendingAuth struct {
 	ServerChallenge [8]byte // Random challenge sent in Type 2 message
 	UsedSPNEGO      bool    // Whether client used SPNEGO wrapping
 	IsReauth        bool    // True when re-authenticating an existing session
+	// MechListBytes: DER-encoded SEQUENCE OF OID from the NegTokenInit's
+	// mechTypes field, needed to compute the SPNEGO mechListMIC in the
+	// final accept-completed response (MS-NLMP 3.4.5.2 + 2.2.2.9.1).
+	// Nil for clients that send raw NTLM without SPNEGO wrapping.
+	MechListBytes []byte
 }
 
 // TreeConnection represents an active tree connection mapping a client

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -206,7 +206,7 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	}
 
 	// Extract NTLM token (unwrap SPNEGO if needed)
-	ntlmToken, isWrapped := extractNTLMToken(req.SecurityBuffer)
+	ntlmToken, isWrapped, mechListBytes := extractNTLMToken(req.SecurityBuffer)
 
 	// Process NTLM message
 	if auth.IsValid(ntlmToken) {
@@ -223,7 +223,7 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 		switch msgType {
 		case auth.Negotiate:
-			return h.handleNTLMNegotiate(ctx, isWrapped)
+			return h.handleNTLMNegotiate(ctx, isWrapped, mechListBytes)
 		case auth.Authenticate:
 			// Type 3 without prior Type 1/2 exchange — protocol violation per MS-SMB2 3.3.5.5
 			logger.Debug("SESSION_SETUP: TYPE_3 without pending auth, rejecting")
@@ -237,10 +237,14 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 // extractNTLMToken extracts the NTLM token from a security buffer.
 // Handles both raw NTLM and SPNEGO-wrapped tokens.
-// Returns the token and whether it was wrapped in SPNEGO.
-func extractNTLMToken(securityBuffer []byte) ([]byte, bool) {
+//
+// Returns: (token, wasSPNEGOWrapped, mechListBytes).
+// mechListBytes is the DER SEQUENCE OF OID from the NegTokenInit (nil for
+// raw NTLM, NegTokenResp messages, or when SPNEGO parse falls back to the
+// raw signature scan).
+func extractNTLMToken(securityBuffer []byte) ([]byte, bool, []byte) {
 	if len(securityBuffer) == 0 {
-		return securityBuffer, false
+		return securityBuffer, false, nil
 	}
 
 	// Check if this might be SPNEGO-wrapped (GSSAPI or NegTokenResp)
@@ -252,24 +256,24 @@ func extractNTLMToken(securityBuffer []byte) ([]byte, bool) {
 			// Some clients send NegTokenResp formats that gokrb5 can't parse,
 			// but the NTLM token is still embedded in the ASN.1 structure.
 			if token := findNTLMSSP(securityBuffer); token != nil {
-				return token, true
+				return token, true, nil
 			}
-			return securityBuffer, false
+			return securityBuffer, false, nil
 		}
 
 		// Check if NTLM is offered
 		if parsed.Type == auth.TokenTypeInit && !parsed.HasNTLM() {
 			logger.Debug("SPNEGO token does not offer NTLM")
-			return securityBuffer, false
+			return securityBuffer, false, nil
 		}
 
 		if len(parsed.MechToken) > 0 {
-			return parsed.MechToken, true
+			return parsed.MechToken, true, parsed.MechListBytes
 		}
 	}
 
 	// Already raw NTLM (or unknown format)
-	return securityBuffer, false
+	return securityBuffer, false, nil
 }
 
 // ntlmsspSignature is the NTLMSSP signature that starts every NTLM message.
@@ -294,7 +298,7 @@ func findNTLMSSP(data []byte) []byte {
 //
 // The client will respond with Type 3 (AUTHENTICATE) which completes
 // the handshake in completeNTLMAuth().
-func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool) (*HandlerResult, error) {
+func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, mechListBytes []byte) (*HandlerResult, error) {
 	// Reuse existing session ID for re-authentication, otherwise generate new
 	sessionID := ctx.SessionID
 	isReauth := false
@@ -329,6 +333,7 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool) (
 		ServerChallenge: serverChallenge,
 		UsedSPNEGO:      usedSPNEGO,
 		IsReauth:        isReauth,
+		MechListBytes:   mechListBytes,
 	}
 	h.StorePendingAuth(pending)
 
@@ -389,7 +394,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 	h.DeletePendingAuth(ctx.SessionID)
 
 	// Extract NTLM token (unwrap SPNEGO if needed)
-	ntlmToken, _ := extractNTLMToken(securityBuffer)
+	ntlmToken, _, _ := extractNTLMToken(securityBuffer)
 
 	// Parse the AUTHENTICATE message to extract username and domain
 	authMsg, err := auth.ParseAuthenticate(ntlmToken)
@@ -528,7 +533,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 				if pending.IsReauth {
 					// Per MS-SMB2 3.3.5.5.3: re-derive keys from the new SessionBaseKey
-					if result := h.tryReauthUpdateWithKeys(pending, resolvedUsername, authMsg.Domain, user, false, signingKey[:], ctx); result != nil {
+					if result := h.tryReauthUpdateWithKeys(pending, resolvedUsername, authMsg.Domain, user, false, signingKey[:], authMsg.NegotiateFlags, ctx); result != nil {
 						return result, nil
 					}
 					// Fallthrough: session disappeared between negotiate and auth (unlikely)
@@ -549,7 +554,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 					"signingEnabled", sess.ShouldSign(),
 					"encryptData", sess.ShouldEncrypt())
 
-				return h.buildAuthenticatedResponse(pending.UsedSPNEGO, sess.ShouldEncrypt()), nil
+				return h.buildAuthenticatedResponse(pending, signingKey[:], authMsg.NegotiateFlags, sess.ShouldEncrypt()), nil
 			}
 
 			// SECURITY: User exists but no valid NT hash configured.
@@ -578,7 +583,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				"domain", sess.Domain,
 				"isGuest", sess.IsGuest)
 
-			return h.buildAuthenticatedResponse(pending.UsedSPNEGO, false), nil
+			return h.buildAuthenticatedResponse(pending, nil, authMsg.NegotiateFlags, false), nil
 		}
 
 		// User not found or disabled
@@ -826,15 +831,26 @@ func (h *Handler) buildSessionSetupResponse(
 }
 
 // buildAuthenticatedResponse builds a SESSION_SETUP success response for an
-// authenticated (non-guest) user. If the client used SPNEGO wrapping, the
-// response includes an accept-completed token to finalize the GSSAPI context.
-// When encryptData is true, SessionFlagEncryptData (0x0004) is set in the
-// response to signal that the session requires encryption (SMB 3.x).
-func (h *Handler) buildAuthenticatedResponse(usedSPNEGO bool, encryptData bool) *HandlerResult {
+// authenticated (non-guest) user. When the client used SPNEGO wrapping and
+// we have both the original mechList bytes and an ExportedSessionKey, the
+// response carries an accept-completed NegTokenResp with an NTLMSSP v2
+// mechListMIC (MS-NLMP 2.2.2.9.1 / RFC 4178). Per RFC 4178 §4.2.2 the
+// supportedMech field is only valid in the first server reply, so it is
+// omitted here — matches Samba's wire format.
+//
+// When the key is absent (no-NT-hash transitional path or reauth without
+// key re-derivation) we emit an accept-completed without a MIC.
+func (h *Handler) buildAuthenticatedResponse(pending *PendingAuth, exportedSessionKey []byte, negFlags auth.NegotiateFlag, encryptData bool) *HandlerResult {
 	var acceptToken []byte
-	if usedSPNEGO {
+	if pending != nil && pending.UsedSPNEGO {
+		var mic []byte
+		if len(pending.MechListBytes) > 0 && len(exportedSessionKey) == 16 {
+			var key [16]byte
+			copy(key[:], exportedSessionKey)
+			mic = auth.ComputeNTLMSSPMechListMIC(key, pending.MechListBytes, negFlags, nil)
+		}
 		var err error
-		acceptToken, err = auth.BuildAcceptComplete(auth.OIDNTLMSSP, nil)
+		acceptToken, err = auth.BuildAcceptCompleteWithMIC(nil, nil, mic)
 		if err != nil {
 			logger.Debug("Failed to build SPNEGO accept token", "error", err)
 		}
@@ -875,7 +891,8 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 		"signingEnabled", existingSess.ShouldSign(),
 		"encryptData", existingSess.ShouldEncrypt())
 
-	return h.buildAuthenticatedResponse(pending.UsedSPNEGO, existingSess.ShouldEncrypt())
+	// Prior keys retained, no new ExportedSessionKey available.
+	return h.buildAuthenticatedResponse(pending, nil, 0, existingSess.ShouldEncrypt())
 }
 
 // tryReauthUpdateWithKeys updates an existing session's identity and re-derives
@@ -885,7 +902,7 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 // preserved.
 // Returns a non-nil *HandlerResult if the session was found and updated,
 // or nil if the session no longer exists (caller should fall through).
-func (h *Handler) tryReauthUpdateWithKeys(pending *PendingAuth, username, domain string, user *models.User, isGuest bool, signingKey []byte, ctx *SMBHandlerContext) *HandlerResult {
+func (h *Handler) tryReauthUpdateWithKeys(pending *PendingAuth, username, domain string, user *models.User, isGuest bool, signingKey []byte, negFlags auth.NegotiateFlag, ctx *SMBHandlerContext) *HandlerResult {
 	existingSess, ok := h.GetSession(pending.SessionID)
 	if !ok {
 		return nil
@@ -910,7 +927,7 @@ func (h *Handler) tryReauthUpdateWithKeys(pending *PendingAuth, username, domain
 		"signingEnabled", existingSess.ShouldSign(),
 		"encryptData", existingSess.ShouldEncrypt())
 
-	return h.buildAuthenticatedResponse(pending.UsedSPNEGO, existingSess.ShouldEncrypt())
+	return h.buildAuthenticatedResponse(pending, signingKey, negFlags, existingSess.ShouldEncrypt())
 }
 
 // checkGuestPolicy enforces guest session prerequisites.

--- a/internal/adapter/smb/v2/handlers/session_setup_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_test.go
@@ -1045,3 +1045,126 @@ func TestSessionSetupConstants(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// buildAuthenticatedResponse MIC emission tests
+// =============================================================================
+
+// extractSecurityBuffer pulls the security buffer out of a SESSION_SETUP
+// response body written by buildSessionSetupResponse. Layout per MS-SMB2 2.2.6.
+func extractSecurityBuffer(t *testing.T, data []byte) []byte {
+	t.Helper()
+	if len(data) < 8 {
+		t.Fatalf("response body too short: %d bytes", len(data))
+	}
+	secBufLen := binary.LittleEndian.Uint16(data[6:8])
+	if secBufLen == 0 {
+		return nil
+	}
+	if len(data) < 8+int(secBufLen) {
+		t.Fatalf("truncated security buffer: need %d, have %d", 8+secBufLen, len(data))
+	}
+	return data[8 : 8+secBufLen]
+}
+
+// TestBuildAuthenticatedResponse_MICEmission asserts that when the client
+// used SPNEGO and we have the mechList + ExportedSessionKey, the final
+// accept-completed NegTokenResp includes a valid 16-byte mechListMIC and
+// omits the superfluous SupportedMech field (RFC 4178 §4.2.2 + MS-NLMP
+// 2.2.2.9.1). Guards the wiring added for #371.
+func TestBuildAuthenticatedResponse_MICEmission(t *testing.T) {
+	mechListBytes := []byte{
+		0x30, 0x0c, 0x06, 0x0a,
+		0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0a,
+	}
+	exportedSessionKey := []byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+	}
+
+	t.Run("EmitsMICAndOmitsSupportedMech", func(t *testing.T) {
+		h := NewHandler()
+		pending := &PendingAuth{
+			SessionID:     1,
+			UsedSPNEGO:    true,
+			MechListBytes: mechListBytes,
+		}
+
+		result := h.buildAuthenticatedResponse(pending, exportedSessionKey, auth.FlagNTLM|auth.FlagKeyExch, false)
+
+		if result.Status != types.StatusSuccess {
+			t.Fatalf("Status = 0x%x, want STATUS_SUCCESS", result.Status)
+		}
+
+		secBuf := extractSecurityBuffer(t, result.Data)
+		if len(secBuf) == 0 {
+			t.Fatal("response carries no security buffer")
+		}
+
+		var resp gokrbspnego.NegTokenResp
+		if err := resp.Unmarshal(secBuf); err != nil {
+			t.Fatalf("unmarshal NegTokenResp: %v", err)
+		}
+
+		if resp.NegState != asn1.Enumerated(auth.NegStateAcceptCompleted) {
+			t.Errorf("NegState = %d, want accept-completed (0)", resp.NegState)
+		}
+		if len(resp.MechListMIC) != 16 {
+			t.Errorf("MechListMIC length = %d, want 16", len(resp.MechListMIC))
+		}
+		if resp.MechListMIC[0] != 0x01 {
+			t.Errorf("MechListMIC Version[0] = 0x%x, want 0x01 (NTLMSSP_SIGN_VERSION)", resp.MechListMIC[0])
+		}
+		// SeqNum field (bytes 12-15) must be zero for SPNEGO MIC.
+		for i := 12; i < 16; i++ {
+			if resp.MechListMIC[i] != 0 {
+				t.Errorf("MechListMIC SeqNum[%d] = 0x%x, want 0", i-12, resp.MechListMIC[i])
+			}
+		}
+		// RFC 4178 §4.2.2: SupportedMech is only valid in the first server
+		// reply. accept-completed is the final reply — must be absent.
+		if len(resp.SupportedMech) != 0 {
+			t.Errorf("SupportedMech should be absent, got %v", resp.SupportedMech)
+		}
+	})
+
+	t.Run("NoMICWhenKeyAbsent", func(t *testing.T) {
+		h := NewHandler()
+		pending := &PendingAuth{
+			SessionID:     2,
+			UsedSPNEGO:    true,
+			MechListBytes: mechListBytes,
+		}
+
+		// No-NT-hash path: caller passes nil exportedSessionKey.
+		result := h.buildAuthenticatedResponse(pending, nil, auth.FlagNTLM|auth.FlagKeyExch, false)
+
+		secBuf := extractSecurityBuffer(t, result.Data)
+		var resp gokrbspnego.NegTokenResp
+		if err := resp.Unmarshal(secBuf); err != nil {
+			t.Fatalf("unmarshal NegTokenResp: %v", err)
+		}
+		if len(resp.MechListMIC) != 0 {
+			t.Errorf("MechListMIC should be empty when key is nil, got %d bytes", len(resp.MechListMIC))
+		}
+		if resp.NegState != asn1.Enumerated(auth.NegStateAcceptCompleted) {
+			t.Errorf("NegState = %d, want accept-completed (0)", resp.NegState)
+		}
+	})
+
+	t.Run("NoSPNEGOEnvelopeWhenRawNTLM", func(t *testing.T) {
+		h := NewHandler()
+		pending := &PendingAuth{
+			SessionID:     3,
+			UsedSPNEGO:    false,
+			MechListBytes: mechListBytes,
+		}
+
+		result := h.buildAuthenticatedResponse(pending, exportedSessionKey, auth.FlagNTLM|auth.FlagKeyExch, false)
+
+		secBuf := extractSecurityBuffer(t, result.Data)
+		if len(secBuf) != 0 {
+			t.Errorf("raw-NTLM session should carry empty security buffer, got %d bytes", len(secBuf))
+		}
+	})
+}

--- a/internal/adapter/smb/v2/handlers/session_setup_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_test.go
@@ -457,7 +457,7 @@ func TestBuildSessionSetupResponse(t *testing.T) {
 func TestExtractNTLMToken(t *testing.T) {
 	t.Run("PassesThroughRawNTLM", func(t *testing.T) {
 		ntlmMsg := validNTLMNegotiateMessage()
-		result, isWrapped := extractNTLMToken(ntlmMsg)
+		result, isWrapped, mechList := extractNTLMToken(ntlmMsg)
 
 		if !auth.IsValid(result) {
 			t.Error("Should pass through raw NTLM unchanged")
@@ -465,25 +465,31 @@ func TestExtractNTLMToken(t *testing.T) {
 		if isWrapped {
 			t.Error("Raw NTLM should not be marked as wrapped")
 		}
+		if mechList != nil {
+			t.Error("Raw NTLM should yield nil mechListBytes")
+		}
 	})
 
 	t.Run("ExtractsFromSPNEGO", func(t *testing.T) {
 		ntlmMsg := validNTLMNegotiateMessage()
 		spnegoMsg := wrapInSPNEGO(ntlmMsg)
-		result, _ := extractNTLMToken(spnegoMsg)
+		result, _, mechList := extractNTLMToken(spnegoMsg)
 
 		if !auth.IsValid(result) {
 			t.Error("Should extract NTLM from SPNEGO")
 		}
+		if len(mechList) == 0 {
+			t.Error("SPNEGO NegTokenInit should yield non-empty mechListBytes")
+		}
 	})
 
 	t.Run("ReturnsEmptyForEmpty", func(t *testing.T) {
-		result, _ := extractNTLMToken(nil)
+		result, _, _ := extractNTLMToken(nil)
 		if len(result) != 0 {
 			t.Error("Should return empty for nil input")
 		}
 
-		result, _ = extractNTLMToken([]byte{})
+		result, _, _ = extractNTLMToken([]byte{})
 		if len(result) != 0 {
 			t.Error("Should return empty for empty input")
 		}


### PR DESCRIPTION
## Summary

Fixes #371 — DittoFS now emits a valid NTLMSSP v2 mechListMIC in the SPNEGO accept-completed response, unblocking Samba clients that insist on RFC 4178 downgrade protection (smbtorture \`smb2.bench.session-setup\` and any tight SESSION_SETUP loop).

## The one weird trick

Previous attempt (PR #375, reverted in c15dc4b3) emitted a MIC that Samba clients rejected with \`NTLMSSP NTLM2 packet check failed due to invalid signature\`. Local pcap diff + Samba \`--debuglevel=10\` client trace revealed the cause:

**Samba's \`smbtorture\` libcli/smb2 does NOT set \`NTLMSSP_NEGOTIATE_128\`.** Per MS-NLMP 3.4.5.3 SEALKEY, with no 128/56 flag set, the sealing-key input is the **first 5 bytes** of ExportedSessionKey (40-bit sealing mode). My previous code used the full 16 bytes. With the truncation applied correctly, the MIC matches.

## What's in this PR

**Production code** (\`ntlm.go\`, \`session_setup.go\`, \`handler.go\`):
- \`ComputeNTLMSSPMechListMIC(exportedSessionKey, mechListBytes, flags, dbg)\` — full MS-NLMP 3.4.5.2 + 3.4.5.3 + 3.4.4.2 + 2.2.2.9.1 implementation with all four SEALKEY variants (no KEY_EXCH, 40/56/128-bit).
- \`PendingAuth.MechListBytes\` — stashed during Type 1, consumed in Type 3 (same session).
- \`extractNTLMToken\` now returns the mechListBytes from the parsed NegTokenInit alongside the NTLM token.
- \`buildAuthenticatedResponse\` and \`tryReauthUpdateWithKeys\` take \`exportedSessionKey\` + \`NegotiateFlags\` so they can call the helper.
- Drop the superfluous \`SupportedMech\` on accept-completed (RFC 4178 §4.2.2 — Samba reference capture confirms absence).

**Test** (\`ntlm_mechlistmic_test.go\`):
- First-principles oracle: recomputes expected bytes from MS-NLMP primitives and compares to helper output.
- 4 subcases for each SEALKEY variant.
- Input-coverage guard (changing mechListBytes changes checksum).
- Debug-struct-populated check.

## Local verification

Ran against a Samba smbtorture client over Docker compose harness:

| Test | Before | After |
|---|---|---|
| \`smb2.connect\` | pass | ✅ pass |
| \`smb2.scan.find\` | pass (ex-#362) | ✅ pass |
| \`smb2.scan.setinfo\` | pass (ex-#362) | ✅ pass |
| \`smb2.session-require-signing.bug15397\` | ? | ✅ pass |
| \`smb2.bench.session-setup\` | fail (INVALID_NETWORK_RESPONSE) | ⚠️ partial — MIC verifies, but 4-connection concurrent loop still hits INVALID_NETWORK_RESPONSE on some iterations |

## bench.session-setup remaining failure

Our MIC now verifies cleanly on single-connection flows (\`smb2.connect\` with \`--debuglevel=10\` shows no \"BAD SIG NTLM2\"). \`bench.session-setup\` opens 4 concurrent connections and rapidly loops LOGOFF → SESSION_SETUP; some iterations still fail with \`NT_STATUS_INVALID_NETWORK_RESPONSE\`. Likely a separate server-side race on concurrent SESSION_SETUP+LOGOFF state (PendingAuth lifecycle, preauth hash state, etc.). Keeping \`smb2.bench.session-setup\` in KNOWN_FAILURES and will file a follow-up issue if CI confirms this is the only remaining gap.

## Test plan

- [x] Unit tests green (\`go test -race ./internal/adapter/smb/...\`)
- [x] gofmt / go vet clean
- [x] Local smbtorture: scan/connect/signing tests pass
- [ ] CI: smbtorture/memory — expect no regression + possibly some formerly-known-failure tests now passing
- [ ] CI: WPTS BVT/memory — should stay green
- [ ] CI: Unit/E2E/Integration/Windows/Lint