### PR TITLE
fix(controlplane): scope block store name uniqueness by kind (#376)

### DIFF
--- a/pkg/controlplane/models/stores.go
+++ b/pkg/controlplane/models/stores.go
@@ -65,8 +65,8 @@ const (
 // to distinguish local (disk-backed) from remote (S3, etc.) block stores.
 type BlockStoreConfig struct {
 	ID        string         `gorm:"primaryKey;size:36" json:"id"`
-	Name      string         `gorm:"uniqueIndex;not null;size:255" json:"name"`
-	Kind      BlockStoreKind `gorm:"not null;size:10;index" json:"kind"`
+	Name      string         `gorm:"uniqueIndex:idx_block_store_name_kind,priority:1;not null;size:255" json:"name"`
+	Kind      BlockStoreKind `gorm:"uniqueIndex:idx_block_store_name_kind,priority:2;not null;size:10;index" json:"kind"`
 	Type      string         `gorm:"not null;size:50" json:"type"` // fs, memory, s3
 	Config    string         `gorm:"type:text" json:"-"`           // JSON blob for type-specific config
 	CreatedAt time.Time      `gorm:"autoCreateTime" json:"created_at"`

--- a/pkg/controlplane/store/block.go
+++ b/pkg/controlplane/store/block.go
@@ -84,10 +84,9 @@ func (s *GORMStore) DeleteBlockStore(ctx context.Context, name string, kind mode
 	})
 }
 
-func (s *GORMStore) GetSharesByBlockStore(ctx context.Context, storeName string) ([]*models.Share, error) {
-	// Find block store by name (could be local or remote)
+func (s *GORMStore) GetSharesByBlockStore(ctx context.Context, storeName string, kind models.BlockStoreKind) ([]*models.Share, error) {
 	var store models.BlockStoreConfig
-	if err := s.db.WithContext(ctx).Where("name = ?", storeName).First(&store).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("name = ? AND kind = ?", storeName, kind).First(&store).Error; err != nil {
 		return nil, convertNotFoundError(err, models.ErrStoreNotFound)
 	}
 

--- a/pkg/controlplane/store/block_test.go
+++ b/pkg/controlplane/store/block_test.go
@@ -109,6 +109,15 @@ func TestBlockStoreOperations(t *testing.T) {
 		if gotRemote.Type != "s3" {
 			t.Errorf("remote default: expected type 's3', got %q", gotRemote.Type)
 		}
+
+		// Deleting one kind must not affect the other (regression guard against
+		// a future change reverting DeleteBlockStore to filter by name alone).
+		if err := store.DeleteBlockStore(ctx, "default", models.BlockStoreKindLocal); err != nil {
+			t.Fatalf("delete local default: %v", err)
+		}
+		if _, err := store.GetBlockStore(ctx, "default", models.BlockStoreKindRemote); err != nil {
+			t.Errorf("remote default should survive local deletion: %v", err)
+		}
 	})
 
 	t.Run("get block store by name and kind", func(t *testing.T) {

--- a/pkg/controlplane/store/block_test.go
+++ b/pkg/controlplane/store/block_test.go
@@ -72,6 +72,45 @@ func TestBlockStoreOperations(t *testing.T) {
 		}
 	})
 
+	// Regression for #376: WPTS BVT bootstrap creates a local and remote
+	// block store both named "default"; uniqueness must be scoped by (name, kind).
+	t.Run("same name across local and remote kinds succeeds", func(t *testing.T) {
+		local := &models.BlockStoreConfig{
+			Name: "default",
+			Kind: models.BlockStoreKindLocal,
+			Type: "memory",
+		}
+		if _, err := store.CreateBlockStore(ctx, local); err != nil {
+			t.Fatalf("create local 'default': %v", err)
+		}
+
+		remote := &models.BlockStoreConfig{
+			Name:   "default",
+			Kind:   models.BlockStoreKindRemote,
+			Type:   "s3",
+			Config: `{"bucket":"x"}`,
+		}
+		if _, err := store.CreateBlockStore(ctx, remote); err != nil {
+			t.Fatalf("create remote 'default' should succeed alongside local: %v", err)
+		}
+
+		gotLocal, err := store.GetBlockStore(ctx, "default", models.BlockStoreKindLocal)
+		if err != nil {
+			t.Fatalf("get local default: %v", err)
+		}
+		if gotLocal.Type != "memory" {
+			t.Errorf("local default: expected type 'memory', got %q", gotLocal.Type)
+		}
+
+		gotRemote, err := store.GetBlockStore(ctx, "default", models.BlockStoreKindRemote)
+		if err != nil {
+			t.Fatalf("get remote default: %v", err)
+		}
+		if gotRemote.Type != "s3" {
+			t.Errorf("remote default: expected type 's3', got %q", gotRemote.Type)
+		}
+	})
+
 	t.Run("get block store by name and kind", func(t *testing.T) {
 		bs, err := store.GetBlockStore(ctx, "test-local-fs", models.BlockStoreKindLocal)
 		if err != nil {
@@ -294,7 +333,7 @@ func TestShareBlockStore(t *testing.T) {
 	})
 
 	t.Run("get shares by block store", func(t *testing.T) {
-		shares, err := store.GetSharesByBlockStore(ctx, "share-local")
+		shares, err := store.GetSharesByBlockStore(ctx, "share-local", models.BlockStoreKindLocal)
 		if err != nil {
 			t.Fatalf("failed to get shares by block store: %v", err)
 		}
@@ -304,7 +343,7 @@ func TestShareBlockStore(t *testing.T) {
 	})
 
 	t.Run("get shares by remote block store", func(t *testing.T) {
-		shares, err := store.GetSharesByBlockStore(ctx, "share-remote")
+		shares, err := store.GetSharesByBlockStore(ctx, "share-remote", models.BlockStoreKindRemote)
 		if err != nil {
 			t.Fatalf("failed to get shares by block store: %v", err)
 		}

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -228,8 +228,14 @@ func New(config *Config) (*GORMStore, error) {
 	// AutoMigrate creates the new composite index idx_block_store_name_kind on (name, kind)
 	// but does not drop pre-existing ones, which would prevent having a local and remote
 	// store with the same name. Idempotent via IF EXISTS; safe to run on fresh installs.
-	_ = db.Exec("DROP INDEX IF EXISTS idx_payload_stores_name")
-	_ = db.Exec("DROP INDEX IF EXISTS idx_block_store_configs_name")
+	// Errors here (permissions, dialect mismatch) would silently re-introduce the original
+	// 409 conflict on bootstrap, so surface them.
+	if err := db.Exec("DROP INDEX IF EXISTS idx_payload_stores_name").Error; err != nil {
+		return nil, fmt.Errorf("failed to drop legacy idx_payload_stores_name: %w", err)
+	}
+	if err := db.Exec("DROP INDEX IF EXISTS idx_block_store_configs_name").Error; err != nil {
+		return nil, fmt.Errorf("failed to drop legacy idx_block_store_configs_name: %w", err)
+	}
 
 	// Pre-migration: drop legacy single-column unique index on identity_mappings.principal.
 	// The new composite index idx_provider_principal (provider_name, principal) replaces it.

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -222,13 +222,14 @@ func New(config *Config) (*GORMStore, error) {
 		if err := db.Exec("UPDATE block_store_configs SET kind = 'remote'").Error; err != nil {
 			return nil, fmt.Errorf("failed to set default kind: %w", err)
 		}
-		// Drop the old unique index on name alone (from legacy table).
-		// AutoMigrate will create the new composite index idx_block_store_name_kind
-		// on (name, kind), but won't drop the old one, which would prevent having
-		// a local and remote store with the same name.
-		_ = db.Exec("DROP INDEX IF EXISTS idx_payload_stores_name")
-		_ = db.Exec("DROP INDEX IF EXISTS idx_block_store_configs_name")
 	}
+
+	// Pre-migration: drop legacy single-column unique index on block_store_configs.name.
+	// AutoMigrate creates the new composite index idx_block_store_name_kind on (name, kind)
+	// but does not drop pre-existing ones, which would prevent having a local and remote
+	// store with the same name. Idempotent via IF EXISTS; safe to run on fresh installs.
+	_ = db.Exec("DROP INDEX IF EXISTS idx_payload_stores_name")
+	_ = db.Exec("DROP INDEX IF EXISTS idx_block_store_configs_name")
 
 	// Pre-migration: drop legacy single-column unique index on identity_mappings.principal.
 	// The new composite index idx_provider_principal (provider_name, principal) replaces it.

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -330,9 +330,9 @@ type BlockStoreConfigStore interface {
 	// Returns models.ErrStoreInUse if the store is referenced by any shares.
 	DeleteBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) error
 
-	// GetSharesByBlockStore returns all shares using the given block store (by name).
+	// GetSharesByBlockStore returns all shares using the given block store (by name and kind).
 	// Checks both local_block_store_id and remote_block_store_id references.
-	GetSharesByBlockStore(ctx context.Context, storeName string) ([]*models.Share, error)
+	GetSharesByBlockStore(ctx context.Context, storeName string, kind models.BlockStoreKind) ([]*models.Share, error)
 }
 
 // BackupStore provides backup repo, record, and job CRUD operations.


### PR DESCRIPTION
## Summary

- Closes #376. WPTS BVT `*-s3` profiles failed bootstrap with HTTP 409 when the harness created a remote block store named `default` after a local one with the same name.
- Replaces the standalone `uniqueIndex` on `BlockStoreConfig.Name` with a composite `(name, kind)` — completing the half-finished migration that was already documented in `gorm.go` (the comment said the composite index would be created, but the GORM tag hadn't been updated).
- Makes the legacy `idx_block_store_configs_name` `DROP INDEX IF EXISTS` unconditional so fresh installs migrate cleanly (previously it only ran when migrating from the legacy `payload_stores` table).
- `GetSharesByBlockStore` now takes a `kind` to match every other read path. Only test callers needed updating (no production callers).

## Migration safety

The old constraint (unique `name`) is strictly stricter than the new one (unique `name+kind`), so no existing data can violate the new index. GORM uses `CREATE UNIQUE INDEX` (not `ADD CONSTRAINT`) on both SQLite and PostgreSQL, so `DROP INDEX IF EXISTS` is the correct idiom on both backends.

## Test plan

- [x] `go test ./pkg/controlplane/...` (no build tag) — green
- [x] `go test -tags=integration -run TestBlockStoreOperations ./pkg/controlplane/store/...` — green; new sub-test `same name across local and remote kinds succeeds` covers the #376 scenario, including a delete-one/verify-other guard
- [x] `go build ./...` — clean
- [ ] CI: `WPTS BVT / badger-s3` and `WPTS BVT / postgres-s3` should reach test execution (not bootstrap 409)