### PR TITLE
fix(dfsctl): reject empty tokens from login and refresh

### DIFF
--- a/cmd/dfsctl/cmdutil/util.go
+++ b/cmd/dfsctl/cmdutil/util.go
@@ -70,6 +70,12 @@ func GetAuthenticatedClient() (*apiclient.Client, error) {
 			return nil, fmt.Errorf("session expired. Run 'dfsctl login' to re-authenticate")
 		}
 
+		// If either token is missing, UpdateTokens would overwrite the stored
+		// refresh token with "" and poison the next refresh cycle.
+		if newTokens == nil || newTokens.AccessToken == "" || newTokens.RefreshToken == "" {
+			return nil, fmt.Errorf("token refresh succeeded but server returned incomplete tokens; run 'dfsctl login' to re-authenticate")
+		}
+
 		// Save new tokens
 		if err := store.UpdateTokens(newTokens.AccessToken, newTokens.RefreshToken, newTokens.ExpiresAt); err != nil {
 			return nil, fmt.Errorf("failed to save refreshed tokens: %w", err)

--- a/cmd/dfsctl/cmdutil/util_test.go
+++ b/cmd/dfsctl/cmdutil/util_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -247,10 +248,16 @@ func TestIsVerbose(t *testing.T) {
 }
 
 // seedExpiredContext writes a config.json with one expired-but-refreshable
-// context pointing at serverURL, using an isolated XDG_CONFIG_HOME.
+// context pointing at serverURL, using an isolated config dir. credentials.Store
+// reads APPDATA on Windows and XDG_CONFIG_HOME elsewhere.
 func seedExpiredContext(t *testing.T, serverURL string) {
 	t.Helper()
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", dir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", dir)
+	}
 	store, err := credentials.NewStore()
 	if err != nil {
 		t.Fatalf("new store: %v", err)

--- a/cmd/dfsctl/cmdutil/util_test.go
+++ b/cmd/dfsctl/cmdutil/util_test.go
@@ -2,9 +2,16 @@ package cmdutil
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/marmos91/dittofs/internal/cli/credentials"
 	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/apiclient"
 )
 
 func TestParseCommaSeparatedList(t *testing.T) {
@@ -236,5 +243,97 @@ func TestIsVerbose(t *testing.T) {
 	Flags.Verbose = false
 	if IsVerbose() {
 		t.Error("IsVerbose() = true, want false")
+	}
+}
+
+// seedExpiredContext writes a config.json with one expired-but-refreshable
+// context pointing at serverURL, using an isolated XDG_CONFIG_HOME.
+func seedExpiredContext(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	store, err := credentials.NewStore()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ctx := &credentials.Context{
+		ServerURL:    serverURL,
+		Username:     "admin",
+		AccessToken:  "stale-access",
+		RefreshToken: "valid-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	}
+	if err := store.SetContext("test-ctx", ctx); err != nil {
+		t.Fatalf("set context: %v", err)
+	}
+	if err := store.UseContext("test-ctx"); err != nil {
+		t.Fatalf("use context: %v", err)
+	}
+}
+
+// newRefreshServer answers /api/v1/auth/refresh with the given response.
+func newRefreshServer(t *testing.T, resp apiclient.TokenResponse) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/refresh" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// clearGlobalFlags prevents state bleed between tests that mutate Flags.
+func clearGlobalFlags(t *testing.T) {
+	t.Helper()
+	orig := *Flags
+	Flags.ServerURL = ""
+	Flags.Token = ""
+	t.Cleanup(func() { *Flags = orig })
+}
+
+func TestGetAuthenticatedClient_RefreshRejectsEmptyRefreshToken(t *testing.T) {
+	// Server refreshes access but omits the new refresh token — if we let this
+	// through, store.UpdateTokens would wipe out the caller's existing refresh.
+	server := newRefreshServer(t, apiclient.TokenResponse{
+		AccessToken:  "new-access",
+		RefreshToken: "",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	defer server.Close()
+
+	clearGlobalFlags(t)
+	seedExpiredContext(t, server.URL)
+
+	_, err := GetAuthenticatedClient()
+	if err == nil {
+		t.Fatal("expected error when refresh returns empty refresh_token, got nil")
+	}
+	if !strings.Contains(err.Error(), "incomplete tokens") {
+		t.Errorf("error should mention incomplete tokens, got: %v", err)
+	}
+}
+
+func TestGetAuthenticatedClient_RefreshRejectsEmptyAccessToken(t *testing.T) {
+	server := newRefreshServer(t, apiclient.TokenResponse{
+		AccessToken:  "",
+		RefreshToken: "new-refresh",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+	})
+	defer server.Close()
+
+	clearGlobalFlags(t)
+	seedExpiredContext(t, server.URL)
+
+	_, err := GetAuthenticatedClient()
+	if err == nil {
+		t.Fatal("expected error when refresh returns empty access_token, got nil")
+	}
+	if !strings.Contains(err.Error(), "incomplete tokens") {
+		t.Errorf("error should mention incomplete tokens, got: %v", err)
 	}
 }

--- a/cmd/dfsctl/commands/login.go
+++ b/cmd/dfsctl/commands/login.go
@@ -93,6 +93,19 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
+	// Guard against empty tokens — a server that omits them from the response
+	// body would cause every later command to fail with "no access token".
+	if tokens == nil {
+		return fmt.Errorf("login succeeded but server returned an empty response body")
+	}
+	if tokens.AccessToken == "" || tokens.RefreshToken == "" {
+		return fmt.Errorf(
+			"login succeeded but server returned no tokens (access=%t, refresh=%t); "+
+				"the server may be misconfigured or returning a stripped response",
+			tokens.AccessToken != "", tokens.RefreshToken != "",
+		)
+	}
+
 	// Determine context name
 	contextName := loginContextName
 	if contextName == "" {

--- a/cmd/dfsctl/commands/login_test.go
+++ b/cmd/dfsctl/commands/login_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -45,12 +46,17 @@ func withLoginFlags(t *testing.T, server, username, password string) {
 	})
 }
 
-// withIsolatedConfig redirects XDG_CONFIG_HOME to a temp dir so the test
-// doesn't touch the real ~/.config/dfsctl/config.json.
+// withIsolatedConfig redirects the config home to a temp dir so the test
+// doesn't touch the real config. credentials.Store reads APPDATA on Windows
+// and XDG_CONFIG_HOME elsewhere, so set the right one for the current OS.
 func withIsolatedConfig(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", dir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", dir)
+	}
 	return dir
 }
 

--- a/cmd/dfsctl/commands/login_test.go
+++ b/cmd/dfsctl/commands/login_test.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+// newTokenServer returns an httptest server that answers login with the given
+// TokenResponse. Tests use it to simulate servers that strip tokens from the
+// body (e.g. a misconfigured dfs-pro middleware).
+func newTokenServer(t *testing.T, resp apiclient.TokenResponse) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/login" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// withLoginFlags sets the package-level flag vars for runLogin and restores
+// them on cleanup. runLogin reads these directly instead of cobra args.
+func withLoginFlags(t *testing.T, server, username, password string) {
+	t.Helper()
+	origServer, origUser, origPass, origCtx := loginServer, loginUsername, loginPassword, loginContextName
+	loginServer = server
+	loginUsername = username
+	loginPassword = password
+	loginContextName = "test-ctx"
+	t.Cleanup(func() {
+		loginServer = origServer
+		loginUsername = origUser
+		loginPassword = origPass
+		loginContextName = origCtx
+	})
+}
+
+// withIsolatedConfig redirects XDG_CONFIG_HOME to a temp dir so the test
+// doesn't touch the real ~/.config/dfsctl/config.json.
+func withIsolatedConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+func TestLoginRejectsEmptyAccessToken(t *testing.T) {
+	server := newTokenServer(t, apiclient.TokenResponse{
+		AccessToken:  "",
+		RefreshToken: "refresh-xyz",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+	})
+	defer server.Close()
+
+	cfgDir := withIsolatedConfig(t)
+	withLoginFlags(t, server.URL, "admin", "password123")
+
+	err := runLogin(loginCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when server returns empty access token, got nil")
+	}
+	if !strings.Contains(err.Error(), "no tokens") {
+		t.Errorf("error should mention missing tokens, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cfgDir, "dfsctl", "config.json")); err == nil {
+		t.Error("config file should not be written when tokens are empty")
+	}
+}
+
+func TestLoginRejectsEmptyRefreshToken(t *testing.T) {
+	server := newTokenServer(t, apiclient.TokenResponse{
+		AccessToken:  "access-abc",
+		RefreshToken: "",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+	})
+	defer server.Close()
+
+	cfgDir := withIsolatedConfig(t)
+	withLoginFlags(t, server.URL, "admin", "password123")
+
+	err := runLogin(loginCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when server returns empty refresh token, got nil")
+	}
+	if !strings.Contains(err.Error(), "no tokens") {
+		t.Errorf("error should mention missing tokens, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cfgDir, "dfsctl", "config.json")); err == nil {
+		t.Error("config file should not be written when tokens are empty")
+	}
+}
+
+func TestLoginSavesContextOnSuccess(t *testing.T) {
+	server := newTokenServer(t, apiclient.TokenResponse{
+		AccessToken:  "access-abc",
+		RefreshToken: "refresh-xyz",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+	})
+	defer server.Close()
+
+	cfgDir := withIsolatedConfig(t)
+	withLoginFlags(t, server.URL, "admin", "password123")
+
+	if err := runLogin(loginCmd, nil); err != nil {
+		t.Fatalf("login should succeed with valid tokens, got: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "dfsctl", "config.json"))
+	if err != nil {
+		t.Fatalf("config file should be written on success: %v", err)
+	}
+
+	var cfg struct {
+		CurrentContext string `json:"current_context"`
+		Contexts       map[string]struct {
+			ServerURL    string `json:"server_url"`
+			Username     string `json:"username"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"contexts"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("config.json is not valid JSON: %v\n%s", err, data)
+	}
+
+	if cfg.CurrentContext != "test-ctx" {
+		t.Errorf("current_context = %q, want %q", cfg.CurrentContext, "test-ctx")
+	}
+	got, ok := cfg.Contexts["test-ctx"]
+	if !ok {
+		t.Fatalf("context %q not found in config: %+v", "test-ctx", cfg.Contexts)
+	}
+	if got.AccessToken != "access-abc" {
+		t.Errorf("access_token = %q, want %q", got.AccessToken, "access-abc")
+	}
+	if got.RefreshToken != "refresh-xyz" {
+		t.Errorf("refresh_token = %q, want %q", got.RefreshToken, "refresh-xyz")
+	}
+	if got.Username != "admin" {
+		t.Errorf("username = %q, want %q", got.Username, "admin")
+	}
+	if got.ServerURL != server.URL {
+		t.Errorf("server_url = %q, want %q", got.ServerURL, server.URL)
+	}
+}


### PR DESCRIPTION
## Summary

Defensive CLI-side fix for the bug reported in dittofs-pro #112. `dfsctl login` previously trusted the server response blindly: if the body arrived without `access_token` or `refresh_token` (for example against a misconfigured dfs-pro whose middleware stripped them), dfsctl happily persisted an empty context. Every follow-up command then died with the misleading `"no access token. Run 'dfsctl login' first"`.

- Guard `runLogin` so it fails loudly with a descriptive error when either token is empty, instead of writing a broken context to `~/.config/dfsctl/config.json`.
- Mirror the guard in `GetAuthenticatedClient` so an incomplete refresh response does not overwrite the stored refresh token with `""` and poison subsequent refresh cycles.
- Split the `tokens == nil` branch into its own clearer message.

## Test plan

- [x] `go test ./cmd/dfsctl/... ./pkg/apiclient/...` passes
- [x] `go test -race ./cmd/dfsctl/... ./pkg/apiclient/...` passes
- [x] New `TestLoginRejectsEmptyAccessToken` / `TestLoginRejectsEmptyRefreshToken` assert no config file is written when tokens are empty
- [x] `TestLoginSavesContextOnSuccess` parses `config.json` and asserts field-level values
- [x] New `TestGetAuthenticatedClient_RefreshRejects*` cover both empty-access and empty-refresh cases on the refresh path