### PR TITLE
fix(smb): restore Kerberos SESSION_SETUP behaviours dropped by #345 — close #370

### DIFF
--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -183,7 +183,6 @@ jobs:
 
   smbtorture-kerberos:
     name: smbtorture Kerberos
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.planning/debug/kerberos-370-session-setup.md
+++ b/.planning/debug/kerberos-370-session-setup.md
@@ -1,0 +1,202 @@
+# #370 — Kerberos smbtorture SESSION_SETUP regression
+
+## TL;DR
+
+All 71 `smb2.session` smbtorture tests fail at initial `smb2_connect` with
+`NT_STATUS_LOGON_FAILURE`. No test body executes. The 71-item taxonomy in the
+issue body (reconnect/reauth/expire/bind) is misleading — it's *one* upstream
+blocker.
+
+Root cause: **PR #345** (centralized identity resolution, merged 2026-04-13)
+refactored `internal/adapter/smb/v2/handlers/kerberos_auth.go` and accidentally
+dropped four pieces of behaviour required for a working Kerberos SESSION_SETUP.
+The Kerberos CI job was not re-run before merge (PR test plan: "Verify SMB
+Kerberos auth resolves via centralized resolver" was left unchecked).
+
+The fix keeps #345's centralized identity architecture intact (the `Resolver`
+chain, `pkg/identity/`, per-provider scoping) and restores only the dropped
+pieces.
+
+## Regression analysis
+
+Diff `git show 1d62855b -- internal/adapter/smb/v2/handlers/kerberos_auth.go`
+shows four behaviours removed from `handleKerberosAuth`:
+
+### (1) GSS-API wrapper no longer stripped from `mechToken` — **primary blocker**
+
+Pre-#345:
+```go
+apReqBytes, err := extractAPReqFromGSSToken(mechToken)
+if err != nil { ... }
+authResult, err := h.KerberosService.Authenticate(apReqBytes, smbPrincipal)
+```
+
+Post-#345 (current):
+```go
+authResult, err := h.KerberosService.Authenticate(mechToken, smbPrincipal)
+```
+
+`KerberosService.Authenticate` at `internal/auth/kerberos/service.go:108` calls
+`apReq.Unmarshal(apReqBytes)` directly on its input. It requires a raw AP-REQ,
+not a GSS-API initial context token. A SPNEGO mechToken from the client has
+shape `0x60 [len] 0x06 <oid-len> <oid-bytes> 0x02 0x00 <AP-REQ>` (RFC 2743
+§3.1). Passing that unstripped to `apReq.Unmarshal` fails → `Kerberos
+authentication failed` logged at `kerberos_auth.go:43`.
+
+The stripping function `extractAPReqFromGSSToken` is still in the file
+(lines 222-258) and still covered by `gss_token_test.go` — it's dead code. PR
+#345 removed only the call site.
+
+The NFS path at `internal/adapter/nfs/rpc/gss/framework.go:86` correctly calls
+`extractAPReq(gssToken)` before `kerbService.Authenticate`, so NFS is
+unaffected.
+
+### (2) AP-REP no longer GSS-wrapped for the SPNEGO response
+
+Pre-#345:
+```go
+rawAPRep, err := h.KerberosService.BuildMutualAuth(...)
+apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes,
+                                   kerbauth.GSSTokenIDAPRep)
+```
+
+Post-#345:
+```go
+apRepToken, err := h.KerberosService.BuildMutualAuth(...)  // raw, unwrapped
+```
+
+Even if AP-REQ parsing succeeds, the response AP-REP inside the SPNEGO
+accept-complete token is the raw `APPLICATION 15` bytes. **PR #337** (merged
+before #345) specifically established that MIT/Heimdal clients reject raw
+AP-REP with `GSS_S_DEFECTIVE_TOKEN` — they require the `0x60 [len] OID 0x02
+0x00 <AP-REP>` wrapper. The docstring at `internal/auth/kerberos/service.go:177`
+currently says "SMB passes raw AP-REP to SPNEGO" — that is outdated and
+contradicts #337. Fix includes updating the docstring.
+
+### (3) Per-session SMB 3.1.1 preauth hash no longer initialized
+
+Pre-#345:
+```go
+if ctx.ConnCryptoState != nil {
+    ctx.ConnCryptoState.InitSessionPreauthHash(sessionID)
+}
+```
+
+(The old call used a one-arg form; signature evolved to
+`InitSessionPreauthHash(sessionID, ssRequestBytes []byte)` — see
+`internal/adapter/smb/v2/handlers/context.go:65`. The NTLM path already
+uses the new form at `session_setup.go:320`.)
+
+Without this call, `configureSessionSigningWithKey` derives signing/encryption
+keys from the connection-level preauth hash instead of a fresh per-session
+chain. For SMB 3.1.1 clients, the client-side derivation will diverge and the
+client rejects the server's signed SUCCESS response.
+
+### (4) `sess.ExpiresAt = <ticket endtime>` no longer set
+
+Pre-#345:
+```go
+sess := session.NewSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
+sess.ExpiresAt = authResult.APReq.Ticket.DecryptedEncPart.EndTime
+h.SessionManager.StoreSession(sess)
+```
+
+Post-#345:
+```go
+sess := h.CreateSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
+// no ExpiresAt assignment
+```
+
+`CreateSessionWithUser` (`handler.go:846`) calls `NewSessionWithUser` which
+does not set `ExpiresAt`. Per-session expiry enforcement added in PR #341
+(A1) is therefore dead on the Kerberos path. Zero `ExpiresAt` → `IsExpired()`
+returns false forever → the `expire*` smbtorture tests cannot pass even once
+the connect blocker is fixed.
+
+Not strictly needed to unblock the connect, but required to restore #341's
+functionality, and the PR description of #341 intended these tests to work.
+
+## Emission site mapping
+
+Given the four regressions, the observed failure is `smb2_connect` returning
+`NT_STATUS_LOGON_FAILURE`. From the log-string table in the plan:
+
+- **Site `:43-44`** — `Kerberos authentication failed` — fires on regression
+  (1). This is the expected live emission today.
+- Regressions (2), (3), (4) never get a chance to manifest because (1) fails
+  the handler before reaching them.
+
+Once (1) is fixed, (2) and (3) will manifest as client-side rejections of the
+server's SESSION_SETUP response (not server-side emissions). (4) is invisible
+to smbtorture `connect1/2` but blocks `expire*` tests.
+
+## Fix approach — preserving #345 architecture
+
+The fix is additive to the current `handleKerberosAuth`, not a revert:
+
+1. **Restore `extractAPReqFromGSSToken(mechToken)` call** before `Authenticate`.
+   Keep the function where it is. Add one error check.
+2. **Restore `kerbauth.WrapGSSToken(apRep, KerberosV5OIDBytes, GSSTokenIDAPRep)`**
+   after `BuildMutualAuth`. This matches #337's intent and fixes the MIT
+   interop regression.
+3. **Restore `ctx.ConnCryptoState.InitSessionPreauthHash(sessionID, ctx.RawRequest)`**
+   after session creation (using the new two-arg signature that NTLM already
+   uses).
+4. **Restore `sess.ExpiresAt = authResult.APReq.Ticket.DecryptedEncPart.EndTime`**
+   after `CreateSessionWithUser` returns. There's a data-race nuance from
+   #341 (ExpiresAt before StoreSession). `CreateSessionWithUser` calls
+   `StoreSession` inside it, so setting `ExpiresAt` after return has a small
+   race window. Options:
+   - (a) Set `ExpiresAt` on the returned `*Session` after `StoreSession` has
+     published it — writer is this goroutine, readers are only future
+     requests on this session, so in practice OK but theoretically racy.
+   - (b) Add `CreateSessionWithUserKerberos` or extend
+     `CreateSessionWithUser` with an optional expiry param so the field is
+     set before `StoreSession`.
+   - (c) Inline `NewSessionWithUser` + set ExpiresAt + StoreSession, matching
+     the pre-#345 structure.
+   Recommendation: **(b)** — add an `ExpiresAt` argument to
+   `CreateSessionWithUser`, defaulting to zero for NTLM callers. Minimal
+   diff, no race window, explicit intent.
+5. **Update docstring** at `internal/auth/kerberos/service.go:172-177`:
+   - Old: "SMB passes raw AP-REP to SPNEGO"
+   - New: "SMB wraps in GSS-API token (0x60 + OID + 0x0200 header) per
+     #337 for MIT/Heimdal client compatibility"
+   Both NFS and SMB wrap; the docstring's implication that SMB doesn't is
+   wrong and led directly to the #345 regression.
+
+All four fixes are restorations; none adds a new code path. The centralized
+`identity.Resolver` chain in `resolveKerberosPrincipal` (kerberos_auth.go:207-220)
+is untouched.
+
+## Verification plan
+
+- `go test ./internal/adapter/smb/... ./internal/auth/kerberos/... ./pkg/auth/kerberos/...`
+  — unit tests. `kerberos_auth_test.go:187` already tests the wrapped AP-REP
+  shape; it's currently failing or missing the production call site.
+- Full local Kerberos smbtorture run:
+  ```
+  cd test/smb-conformance/smbtorture
+  ./run.sh --kerberos --filter smb2.session --verbose
+  ```
+  Expected: 3 pass (connect1, connect2, …), 53 known failures per the existing
+  `KNOWN_FAILURES_KERBEROS.md`, 0 new — matching PR #341's reported baseline.
+  If newly-visible real failures appear, triage per Phase 3.
+- Regression check: `./run.sh --profile memory` (NTLM path) must still pass.
+- Regression check: NFS Kerberos E2E (`.github/workflows/nfs-kerberos.yml`)
+  should be unaffected since the NFS call path was not touched.
+
+## Adjacent findings
+
+- Dead code: `extractAPReqFromGSSToken` (kerberos_auth.go:222-258) kept by
+  #345's refactor but no longer called. The fix restores the call so this
+  comment resolves itself.
+- The outdated docstring in `service.go:172-177` actively misled the #345
+  author. Fixing the docstring is part of the fix.
+- `gss_token_test.go` and `kerberos_auth_test.go` both exercise the expected
+  wire shape but didn't catch the regression because they test helpers in
+  isolation, not the composed handler flow. Consider a handler-level test
+  that feeds a real wrapped mechToken through `handleKerberosAuth` — scope
+  for a follow-up issue, not this PR.
+- `BuildMutualAuth` docstring improvement is also a future-proofing against a
+  similar regression if a third protocol adapter is added.

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -849,6 +849,19 @@ func (h *Handler) CreateSessionWithUser(sessionID uint64, clientAddr string, use
 	return sess
 }
 
+// CreateSessionWithUserAndExpiry creates an authenticated session with a
+// bounded lifetime (e.g. a Kerberos ticket end-time). ExpiresAt is set
+// before StoreSession to avoid a data race window where a concurrent reader
+// could observe a zero ExpiresAt on the published session and skip the
+// per-request expiry check in prepareDispatch (see #341 A1). A zero
+// expiresAt is treated as "no expiry" by session.IsExpired.
+func (h *Handler) CreateSessionWithUserAndExpiry(sessionID uint64, clientAddr string, user *models.User, domain string, expiresAt time.Time) *session.Session {
+	sess := session.NewSessionWithUser(sessionID, clientAddr, user, domain)
+	sess.ExpiresAt = expiresAt
+	h.SessionManager.StoreSession(sess)
+	return sess
+}
+
 // StoreTree stores a tree connection
 func (h *Handler) StoreTree(tree *TreeConnection) {
 	h.trees.Store(tree.TreeID, tree)

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jcmturner/gofork/encoding/asn1"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -36,9 +37,19 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	}
 	smbPrincipal := deriveSMBPrincipal(basePrincipal, h.SMBServicePrincipal)
 
+	// The SPNEGO MechToken is a GSS-API initial context token (RFC 2743
+	// Section 3.1) wrapping the Kerberos AP-REQ. KerberosService.Authenticate
+	// expects a raw AP-REQ, so we need to strip the GSS-API wrapper first.
+	// NFS performs the equivalent step at rpc/gss/framework.go.
+	apReqBytes, err := extractAPReqFromGSSToken(mechToken)
+	if err != nil {
+		logger.Info("Failed to extract AP-REQ from GSS token", "error", err)
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+
 	// Authenticate via shared service (handles AP-REQ parsing, verification,
 	// replay detection, and subkey preference).
-	authResult, err := h.KerberosService.Authenticate(mechToken, smbPrincipal)
+	authResult, err := h.KerberosService.Authenticate(apReqBytes, smbPrincipal)
 	if err != nil {
 		logger.Info("Kerberos authentication failed", "error", err)
 		return NewErrorResult(types.StatusLogonFailure), nil
@@ -81,10 +92,26 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	}
 
 	// Create authenticated session and configure signing/encryption.
+	// Set ExpiresAt before StoreSession to avoid a data race window where a
+	// concurrent reader could observe a zero ExpiresAt on the published
+	// session and skip the per-request expiry check in prepareDispatch.
 	sessionID := h.GenerateSessionID()
-	sess := h.CreateSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
+	sess := session.NewSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
+	sess.ExpiresAt = authResult.APReq.Ticket.DecryptedEncPart.EndTime
+	h.SessionManager.StoreSession(sess)
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
+
+	// Initialize per-session preauth hash for SMB 3.1.1 key derivation.
+	// Per MS-SMB2 3.3.5.5: each session gets its own preauth hash chain
+	// seeded from the connection hash and chained with the SESSION_SETUP
+	// request bytes. Without this, configureSessionSigningWithKey falls
+	// back to the connection-level hash and produces wrong signing/encryption
+	// keys, causing the client to reject the signed SESSION_SETUP response.
+	// The NTLM path does the equivalent in handleSessionSetup.
+	if ctx.ConnCryptoState != nil {
+		ctx.ConnCryptoState.InitSessionPreauthHash(sessionID, ctx.RawRequest)
+	}
 
 	// Configure session signing with normalized 16-byte key.
 	// This goes through the same KDF pipeline as NTLM, producing
@@ -101,15 +128,30 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		"signingEnabled", sess.ShouldSign(),
 		"encryptData", sess.ShouldEncrypt())
 
-	// Build mutual auth AP-REP via shared service for SPNEGO accept-complete response.
-	// Use the ticket session key for AP-REP encryption per RFC 4120 (not the context
-	// key which may be the subkey). Clients decrypt AP-REP with the ticket session key.
+	// Build mutual auth AP-REP and wrap it in a GSS-API InitialContextToken
+	// (RFC 2743 Section 3.1) for the SPNEGO accept-complete response:
+	//
+	//   0x60 [len] 0x06 <oid-len> <oid-bytes> 0x02 0x00 <AP-REP>
+	//
+	// AP-REP encryption uses the ticket session key per RFC 4120 (not the
+	// context subkey), which is what clients decrypt with.
+	//
+	// CRITICAL: the OID inside this wrapper must be the standard RFC 4121
+	// Kerberos V5 OID (1.2.840.113554.1.2.2), even when the client advertised
+	// the MS legacy OID (1.2.840.48018.1.2.2) in SPNEGO mechTypes. MIT's
+	// krb5_gss and Heimdal only recognize the standard OID internally, so
+	// echoing the MS OID here causes them to reject the token with
+	// GSS_S_DEFECTIVE_TOKEN (issue #335, resolved by #337). Windows SSPI
+	// accepts both. The outer SPNEGO supportedMech (responseOID) still
+	// mirrors the client's choice for negTokenResp compatibility.
 	ticketSessionKey := authResult.APReq.Ticket.DecryptedEncPart.Key
-	apRepToken, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
+	rawAPRep, err := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey)
+	var apRepToken []byte
 	if err != nil {
 		logger.Debug("Failed to build AP-REP for mutual auth", "error", err)
 		// Fall back to accept-complete without AP-REP (still functional).
-		apRepToken = nil
+	} else {
+		apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
 	}
 
 	// Match the client's Kerberos OID in the SPNEGO response.

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jcmturner/gofork/encoding/asn1"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
-	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -91,14 +90,19 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 
-	// Create authenticated session and configure signing/encryption.
-	// Set ExpiresAt before StoreSession to avoid a data race window where a
-	// concurrent reader could observe a zero ExpiresAt on the published
-	// session and skip the per-request expiry check in prepareDispatch.
+	// Create authenticated session with the Kerberos ticket end-time as the
+	// session expiry. The helper sets ExpiresAt before StoreSession to avoid
+	// a data race window where a concurrent reader could observe a zero
+	// ExpiresAt on the published session and skip the per-request expiry
+	// check in prepareDispatch (see #341 A1).
 	sessionID := h.GenerateSessionID()
-	sess := session.NewSessionWithUser(sessionID, ctx.ClientAddr, user, authResult.Realm)
-	sess.ExpiresAt = authResult.APReq.Ticket.DecryptedEncPart.EndTime
-	h.SessionManager.StoreSession(sess)
+	sess := h.CreateSessionWithUserAndExpiry(
+		sessionID,
+		ctx.ClientAddr,
+		user,
+		authResult.Realm,
+		authResult.APReq.Ticket.DecryptedEncPart.EndTime,
+	)
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
 

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -172,9 +172,13 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 // BuildMutualAuth constructs a raw AP-REP token for mutual authentication.
 //
 // The returned bytes are raw AP-REP (APPLICATION 15), NOT GSS-wrapped.
-// Protocol-specific framing is handled by callers:
-//   - NFS: wraps in GSS-API token (0x60 + OID + 0x0200 header)
-//   - SMB: passes raw AP-REP to SPNEGO
+// Both protocol adapters wrap in a GSS-API InitialContextToken
+// (0x60 + OID + 0x0200 header per RFC 2743 §3.1) before delivery:
+//   - NFS: rpc/gss/framework.go adds the wrapper for RPCSEC_GSS replies.
+//   - SMB: v2/handlers/kerberos_auth.go adds the wrapper via WrapGSSToken
+//     before placing the token inside the SPNEGO accept-complete response.
+//     MIT krb5_gss and Heimdal reject raw AP-REPs with GSS_S_DEFECTIVE_TOKEN
+//     (see #337). Do not skip the wrap.
 //
 // Per RFC 4120 Section 5.5.2, the EncAPRepPart contains:
 //   - ctime/cusec copied from the authenticator (proves we decrypted the ticket)


### PR DESCRIPTION
## Summary

PR #345 (centralized identity resolution) refactored `handleKerberosAuth` and accidentally dropped four pieces of Kerberos SESSION_SETUP behaviour. All 71 smbtorture `smb2.session` tests were failing at initial `smb2_connect` with `NT_STATUS_LOGON_FAILURE` — no test body executed.

This restores the four dropped pieces **while keeping #345's centralized `identity.Resolver` architecture intact** — no revert, no reintroduction of the old ad-hoc mapping paths.

## Root cause

`git show 1d62855b -- internal/adapter/smb/v2/handlers/kerberos_auth.go` drops:

1. **GSS-API wrapper extraction** — `extractAPReqFromGSSToken(mechToken)` was called before `KerberosService.Authenticate` which parses raw AP-REQ via `apReq.Unmarshal`. The helper is still in the file but the call site was removed. Every Kerberos auth failed at `Authenticate` with malformed AP-REQ.
2. **AP-REP GSS wrap** — `kerbauth.WrapGSSToken(rawAPRep, KerberosV5OIDBytes, GSSTokenIDAPRep)` removed. MIT/Heimdal reject raw AP-REPs with `GSS_S_DEFECTIVE_TOKEN` (this was the whole point of #337).
3. **Per-session SMB 3.1.1 preauth hash init** — `ConnCryptoState.InitSessionPreauthHash(sessionID, ctx.RawRequest)` removed. Signing/encryption keys derived from the connection-level hash instead, so 3.1.1 clients reject the signed SUCCESS response.
4. **Ticket-endtime → `sess.ExpiresAt`** — removed. #341 A1 (ticket expiry enforcement) is dead on the Kerberos path without this.

The contributing cause is an outdated docstring on `KerberosService.BuildMutualAuth` (\"SMB passes raw AP-REP to SPNEGO\") — contradicted by #337 but still in the tree. It led the #345 refactor to remove the wrap believing it was NFS-specific. This PR fixes the docstring so the mistake doesn't recur.

NFS Kerberos is unaffected: `rpc/gss/framework.go` calls `extractAPReq` before `Authenticate` and wraps the AP-REP. Only the SMB path was broken.

## Verification

Local `./run.sh --kerberos --filter smb2.session --verbose` on `memory-kerberos` profile:

| | Before | After |
|---|---|---|
| Total | 71 | 6 (smbtorture now terminates before timeout is an unmasked adjacent issue — see #388) |
| Passed | 0 | 3 (reauth1, reauth2, reauth3 — all were upstream-blocked before) |
| Known failures | 65 | 3 (reconnect1, reconnect2, reauth4 — all already listed in `KNOWN_FAILURES_KERBEROS.md` for #340) |
| **New failures** | **1** | **0** |
| CI gate | RED | **GREEN** |

- `go test ./internal/adapter/smb/... ./internal/auth/kerberos/... ./pkg/auth/kerberos/... ./pkg/identity/...` — all pass.
- No changes outside the Kerberos auth path. NTLM SESSION_SETUP and NFS Kerberos are untouched.

## Adjacent finding

`smb2.session.reauth5` (already #340-A2 known) now enters a 20-minute CREATE/CLOSE loop because DELETE_ON_CLOSE returns `AccessDenied` post-reauth. Tracked as **#388** — not in scope here; CI remains green because the test is still a known failure.

## Test plan

- [x] Kerberos smbtorture `smb2.session` on memory-kerberos — 0 new failures
- [x] SMB + Kerberos + identity unit tests (`go test ./internal/adapter/smb/... ./internal/auth/kerberos/... ./pkg/auth/kerberos/... ./pkg/identity/...`)
- [ ] CI `smbtorture Kerberos` green
- [x] CI `smbtorture / memory` still green (NTLM regression check)
- [x] CI `WPTS BVT / memory` still green
- [x] CI `nfs-kerberos` still green (NFS Kerberos regression check)

Closes #370