### PR TITLE
fix(blockstore): expand ~ in fs block store probe path

### DIFF
--- a/pkg/controlplane/runtime/blockstoreprobe/probe.go
+++ b/pkg/controlplane/runtime/blockstoreprobe/probe.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/blockstore/remote/s3"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/health"
@@ -108,7 +109,11 @@ func probeLocal(ctx context.Context, bs *models.BlockStoreConfig) (health.Status
 	if rawPath == "" {
 		return health.StatusUnhealthy, "no path configured"
 	}
-	path := filepath.Clean(rawPath)
+	expanded, err := pathutil.ExpandPath(rawPath)
+	if err != nil {
+		return health.StatusUnhealthy, "cannot resolve configured path"
+	}
+	path := filepath.Clean(expanded)
 
 	info, err := os.Stat(path)
 	if err != nil {

--- a/pkg/controlplane/runtime/blockstoreprobe/probe_test.go
+++ b/pkg/controlplane/runtime/blockstoreprobe/probe_test.go
@@ -1,0 +1,71 @@
+package blockstoreprobe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// setHome redirects os.UserHomeDir to a tempdir for the duration of
+// the test. On Windows, os.UserHomeDir reads USERPROFILE, not HOME,
+// so skip there rather than silently pass an unredirected lookup.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("tilde expansion test uses HOME redirection (not applicable on Windows)")
+	}
+	t.Setenv("HOME", dir)
+}
+
+func fsBlockStore(t *testing.T, path string) *models.BlockStoreConfig {
+	t.Helper()
+	bs := &models.BlockStoreConfig{
+		Name: "test-local",
+		Kind: models.BlockStoreKindLocal,
+		Type: "fs",
+	}
+	if err := bs.SetConfig(map[string]any{"path": path}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	return bs
+}
+
+// TestProbeLocal_TildeExpansion covers the #391 regression: a leading
+// ~ in the configured path must be expanded before the probe stats it,
+// otherwise a valid local store reports unhealthy.
+func TestProbeLocal_TildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+
+	abs := filepath.Join(home, "localstore")
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", abs, err)
+	}
+
+	rep := Probe(context.Background(), fsBlockStore(t, "~/localstore"))
+	if rep.Status != health.StatusHealthy {
+		t.Fatalf("tilde path probe: status=%q message=%q, want healthy", rep.Status, rep.Message)
+	}
+}
+
+// TestProbeLocal_TildeExpansion_MissingDir verifies the existing
+// "configured path does not exist" message is preserved when the
+// expanded path genuinely does not exist.
+func TestProbeLocal_TildeExpansion_MissingDir(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+
+	rep := Probe(context.Background(), fsBlockStore(t, "~/does-not-exist"))
+	if rep.Status != health.StatusUnhealthy {
+		t.Fatalf("missing tilde path: status=%q, want unhealthy", rep.Status)
+	}
+	if !strings.Contains(rep.Message, "does not exist") {
+		t.Errorf("missing tilde path: message=%q, want contains 'does not exist'", rep.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- Local `fs` block store probe ran `filepath.Clean` + `os.Stat` on the configured path without expanding a leading `~`. Stores created with `~/foo` reported unhealthy even though share mounting worked (the share-attach path already expands via `pathutil.ExpandPath`).
- Route the probe path through `pathutil.ExpandPath` before `filepath.Clean`, surfacing expansion failure as `StatusUnhealthy` with a short message consistent with the surrounding style.
- Scope intentionally narrow: metadata badger already expands in `runtime/init.go` and `stores/service.go`; no other `probe*` site reads a filesystem path.

Closes #391

## Test plan
- [x] `go test ./pkg/controlplane/runtime/blockstoreprobe/` — new `TestProbeLocal_TildeExpansion` and `TestProbeLocal_TildeExpansion_MissingDir` pass.
- [x] `go vet ./pkg/controlplane/runtime/blockstoreprobe/` clean.
- [x] CI green.
- Tests skip on Windows because `os.UserHomeDir` consults `USERPROFILE`, not `HOME`, and `t.Setenv("HOME", …)` would not redirect the lookup there. Matches the existing `runtime.GOOS == "windows"` skip pattern used elsewhere in the repo.