### PR TITLE
fix(api): auto-create fs block store base dir on create — close #390

### DIFF
--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -121,6 +121,13 @@ func (h *BlockStoreHandler) Create(w http.ResponseWriter, r *http.Request) {
 		CreatedAt: time.Now(),
 	}
 
+	// Validate (and materialise the fs base path) before persisting so a
+	// saved config is never one that would fail on attach.
+	if err := runtime.ValidateBlockStoreConfig(kind, req.Type, bs); err != nil {
+		BadRequest(w, "Invalid block store config: "+err.Error())
+		return
+	}
+
 	if _, err := h.store.CreateBlockStore(r.Context(), bs); err != nil {
 		if errors.Is(err, models.ErrDuplicateStore) {
 			Conflict(w, "Block store already exists")
@@ -240,6 +247,16 @@ func (h *BlockStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Config != nil {
 		bs.Config = *req.Config
+		bs.ParsedConfig = nil
+	}
+
+	// Re-validate on any type/config change so a no-op PUT does not
+	// re-touch the filesystem, mirroring Create's pre-persist check.
+	if req.Type != nil || req.Config != nil {
+		if err := runtime.ValidateBlockStoreConfig(bs.Kind, bs.Type, bs); err != nil {
+			BadRequest(w, "Invalid block store config: "+err.Error())
+			return
+		}
 	}
 
 	if err := h.store.UpdateBlockStore(r.Context(), bs); err != nil {

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	stdruntime "runtime"
 	"testing"
 	"time"
 
@@ -226,6 +227,74 @@ func TestBlockStoreHandler_Create_FS_RelativePath(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Create(relative path) status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestBlockStoreHandler_Create_FS_TildePath is the dittofs-pro #110 / dittofs
+// #391 regression: a ~-prefixed path must be expanded before the IsAbs guard,
+// so users configuring "~/foo" in the UI are not rejected.
+func TestBlockStoreHandler_Create_FS_TildePath(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("tilde expansion test uses HOME redirection (not applicable on Windows)")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, handler := setupBlockStoreTest(t)
+
+	body, _ := json.Marshal(CreateBlockStoreRequest{
+		Name:   "tilde-path",
+		Type:   "fs",
+		Config: `{"path":"~/localstore"}`,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKind(req, "local")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Create(~/localstore) status = %d, want %d, body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	expanded := filepath.Join(home, "localstore")
+	if info, err := os.Stat(expanded); err != nil {
+		t.Fatalf("Expected expanded path %s created, stat failed: %v", expanded, err)
+	} else if !info.IsDir() {
+		t.Errorf("Expected %s to be a directory", expanded)
+	}
+}
+
+func TestBlockStoreHandler_Create_S3_MissingCredentials(t *testing.T) {
+	_, handler := setupBlockStoreTest(t)
+
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{"missing bucket", `{"access_key_id":"k","secret_access_key":"s"}`},
+		{"missing access_key_id", `{"bucket":"b","secret_access_key":"s"}`},
+		{"missing secret_access_key", `{"bucket":"b","access_key_id":"k"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(CreateBlockStoreRequest{
+				Name:   "s3-" + tt.name,
+				Type:   "s3",
+				Config: tt.config,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/remote", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withBlockStoreKind(req, "remote")
+			w := httptest.NewRecorder()
+
+			handler.Create(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("Create(%s) status = %d, want %d, body = %s", tt.name, w.Code, http.StatusBadRequest, w.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -56,8 +58,9 @@ func TestBlockStoreHandler_Create(t *testing.T) {
 	_, handler := setupBlockStoreTest(t)
 
 	body, _ := json.Marshal(CreateBlockStoreRequest{
-		Name: "test-local-store",
-		Type: "fs",
+		Name:   "test-local-store",
+		Type:   "fs",
+		Config: `{"path":"` + t.TempDir() + `"}`,
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -133,6 +136,127 @@ func TestBlockStoreHandler_Create_TypeKindMismatch(t *testing.T) {
 				t.Errorf("Create(%s) status = %d, want %d, body = %s", tt.name, w.Code, http.StatusBadRequest, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestBlockStoreHandler_Create_FS_AutoCreatesBaseDir(t *testing.T) {
+	_, handler := setupBlockStoreTest(t)
+
+	// Path does not exist yet; Create must materialise it.
+	basePath := filepath.Join(t.TempDir(), "fresh", "store")
+
+	body, _ := json.Marshal(CreateBlockStoreRequest{
+		Name:   "auto-mkdir",
+		Type:   "fs",
+		Config: `{"path":"` + basePath + `"}`,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKind(req, "local")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Create() status = %d, want %d, body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	info, err := os.Stat(basePath)
+	if err != nil {
+		t.Fatalf("Expected base dir created at %s, stat failed: %v", basePath, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("Expected %s to be a directory", basePath)
+	}
+}
+
+func TestBlockStoreHandler_Create_FS_MissingPath(t *testing.T) {
+	_, handler := setupBlockStoreTest(t)
+
+	body, _ := json.Marshal(CreateBlockStoreRequest{
+		Name: "no-path",
+		Type: "fs",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKind(req, "local")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Create(no path) status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+func TestBlockStoreHandler_Create_FS_UncreatablePath(t *testing.T) {
+	_, handler := setupBlockStoreTest(t)
+
+	// /dev/null is a char device, MkdirAll under it must fail.
+	body, _ := json.Marshal(CreateBlockStoreRequest{
+		Name:   "bad-path",
+		Type:   "fs",
+		Config: `{"path":"/dev/null/cannot-create"}`,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKind(req, "local")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Create(uncreatable path) status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+func TestBlockStoreHandler_Create_FS_RelativePath(t *testing.T) {
+	_, handler := setupBlockStoreTest(t)
+
+	body, _ := json.Marshal(CreateBlockStoreRequest{
+		Name:   "rel-path",
+		Type:   "fs",
+		Config: `{"path":"relative/dir"}`,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/block/local", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKind(req, "local")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Create(relative path) status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+func TestBlockStoreHandler_Update_FS_RevalidatesPath(t *testing.T) {
+	cpStore, handler := setupBlockStoreTest(t)
+	ctx := context.Background()
+
+	initialPath := t.TempDir()
+	bs := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "revalidate", Kind: models.BlockStoreKindLocal, Type: "fs",
+		Config:    `{"path":"` + initialPath + `"}`,
+		CreatedAt: time.Now(),
+	}
+	cpStore.CreateBlockStore(ctx, bs)
+
+	// Path does not exist yet; Update must materialise it.
+	newPath := filepath.Join(t.TempDir(), "moved", "store")
+	newConfig := `{"path":"` + newPath + `"}`
+	body, _ := json.Marshal(UpdateBlockStoreRequest{Config: &newConfig})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/store/block/local/revalidate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBlockStoreKindAndName(req, "local", "revalidate")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Update() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("Expected new path %s created by Update, stat failed: %v", newPath, err)
 	}
 }
 

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -33,7 +33,14 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 		case "memory":
 			return nil
 		case "fs":
-			basePath, _ := config["path"].(string)
+			rawPath, exists := config["path"]
+			if !exists {
+				return errors.New("fs local block store requires path in config")
+			}
+			basePath, ok := rawPath.(string)
+			if !ok {
+				return errors.New("fs local block store path must be a string")
+			}
 			if basePath == "" {
 				return errors.New("fs local block store requires path in config")
 			}
@@ -60,8 +67,17 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 		case "memory":
 			return nil
 		case "s3":
-			if bucket, _ := config["bucket"].(string); bucket == "" {
+			bucket, ok := config["bucket"].(string)
+			if !ok || bucket == "" {
 				return errors.New("s3 remote block store requires bucket in config")
+			}
+			accessKeyID, ok := config["access_key_id"].(string)
+			if !ok || accessKeyID == "" {
+				return errors.New("s3 remote block store requires access_key_id in config")
+			}
+			secretAccessKey, ok := config["secret_access_key"].(string)
+			if !ok || secretAccessKey == "" {
+				return errors.New("s3 remote block store requires secret_access_key in config")
 			}
 			return nil
 		default:

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/marmos91/dittofs/internal/pathutil"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// ValidateBlockStoreConfig validates a block store config at configuration
+// time and ensures any backing directory exists, mirroring the
+// "instantiate before persisting" pattern used by metadata stores so
+// handlers can reject bad config up-front instead of failing at attach.
+//
+// fs stores layer per-share subdirectories on top of the configured base
+// path at share-attach time, so only the base path is materialised here.
+// Remote stores are validated structurally only — reachability is left to
+// the runtime health probe.
+func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg interface {
+	GetConfig() (map[string]any, error)
+}) error {
+	config, err := cfg.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	switch kind {
+	case models.BlockStoreKindLocal:
+		switch storeType {
+		case "memory":
+			return nil
+		case "fs":
+			basePath, _ := config["path"].(string)
+			if basePath == "" {
+				return errors.New("fs local block store requires path in config")
+			}
+			expanded, err := pathutil.ExpandPath(basePath)
+			if err != nil {
+				return fmt.Errorf("failed to expand path %q: %w", basePath, err)
+			}
+			// Reject relative paths so MkdirAll cannot resolve against the
+			// server's CWD, which would silently create directories in
+			// unexpected locations.
+			if !filepath.IsAbs(expanded) {
+				return fmt.Errorf("fs local block store path must be absolute, got %q", basePath)
+			}
+			if err := os.MkdirAll(expanded, 0755); err != nil {
+				return fmt.Errorf("failed to create block store directory %q: %w", expanded, err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("unsupported local block store type: %s", storeType)
+		}
+
+	case models.BlockStoreKindRemote:
+		switch storeType {
+		case "memory":
+			return nil
+		case "s3":
+			if bucket, _ := config["bucket"].(string); bucket == "" {
+				return errors.New("s3 remote block store requires bucket in config")
+			}
+			return nil
+		default:
+			return fmt.Errorf("unsupported remote block store type: %s", storeType)
+		}
+
+	default:
+		return fmt.Errorf("unsupported block store kind: %s", kind)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1184,6 +1184,13 @@ func CreateLocalStoreFromConfig(
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand path %q: %w", basePath, err)
 		}
+		// Defense-in-depth: ValidateBlockStoreConfig rejects relative paths at
+		// create/update time, but pre-existing or out-of-band configs could
+		// still carry them. Guard here so filepath.Join doesn't resolve
+		// against the server's CWD.
+		if !filepath.IsAbs(expanded) {
+			return nil, fmt.Errorf("fs local store path must be absolute, got %q", basePath)
+		}
 		sanitized := sanitizeShareName(shareName)
 		blockDir := filepath.Join(expanded, "shares", sanitized, "blocks")
 		if err := os.MkdirAll(blockDir, 0755); err != nil {


### PR DESCRIPTION
## Summary

- Mirrors the metadata "instantiate-before-persist" pattern for block stores: a new `runtime.ValidateBlockStoreConfig` runs at config-create/update time, and for `fs` it expands the path and `os.MkdirAll`s the base directory.
- Wires the validator into `BlockStoreHandler.Create` and `BlockStoreHandler.Update` so a saved config is never one that would fail at share-attach.
- Rejects relative `fs` paths up-front so `MkdirAll` cannot resolve against the server CWD.
- Per-share subdirectories are still created at attach time by `CreateLocalStoreFromConfig`; this only ensures the base path is materialised.

Closes #390 (and unblocks marmos91/dittofs-pro#111).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -tags integration ./internal/controlplane/api/handlers/... ./pkg/controlplane/runtime/...`
- New tests:
  - `TestBlockStoreHandler_Create_FS_AutoCreatesBaseDir` — POST with non-existent path → 201, dir is created on disk.
  - `TestBlockStoreHandler_Create_FS_MissingPath` — POST without `path` → 400.
  - `TestBlockStoreHandler_Create_FS_RelativePath` — relative path → 400.
  - `TestBlockStoreHandler_Create_FS_UncreatablePath` — `/dev/null/...` → 400.
  - `TestBlockStoreHandler_Update_FS_RevalidatesPath` — PUT new non-existent path → 200, dir created.