### PR TITLE
fix(smb): async credit accounting for IPC notify and pipe reads — close #399

### DIFF
--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -66,6 +66,36 @@ type ConnInfo struct {
 	// Set during NEGOTIATE based on negotiated dialect.
 	// When false, CreditCharge payload validation is skipped (SMB 2.0.2 compat).
 	SupportsMultiCredit bool
+
+	// asyncPendingCount tracks outstanding async operations (CHANGE_NOTIFY + pipe READs)
+	// for this connection. Per MS-SMB2 §3.3.5.2.5, when this reaches MaxAsyncCredits,
+	// further async requests must return STATUS_INSUFFICIENT_RESOURCES.
+	asyncPendingCount atomic.Int32
+}
+
+// MaxAsyncCredits is the maximum number of outstanding async operations per
+// connection per MS-SMB2 §3.3.5.2.5 (Connection.MaxAsyncCredits default = 512).
+const MaxAsyncCredits = 512
+
+// TryReserveAsync atomically checks and reserves one async slot on the connection.
+// Returns false when the connection is at MaxAsyncCredits; the caller must
+// return STATUS_INSUFFICIENT_RESOURCES without registering an async operation.
+func (c *ConnInfo) TryReserveAsync() bool {
+	for {
+		cur := c.asyncPendingCount.Load()
+		if cur >= MaxAsyncCredits {
+			return false
+		}
+		if c.asyncPendingCount.CompareAndSwap(cur, cur+1) {
+			return true
+		}
+	}
+}
+
+// ReleaseAsync decrements the async slot counter. Must be called exactly once
+// when a pending async operation delivers its final response (any status).
+func (c *ConnInfo) ReleaseAsync() {
+	c.asyncPendingCount.Add(-1)
 }
 
 // SessionTracker provides callbacks for session lifecycle tracking.

--- a/internal/adapter/smb/helpers.go
+++ b/internal/adapter/smb/helpers.go
@@ -97,6 +97,17 @@ func handleRequest[Req smbRequest, Resp smbResponse](
 
 	status := resp.GetStatus()
 
+	// STATUS_PENDING is an async interim response. Propagate the AsyncId if the
+	// response carries one (e.g. a pending named-pipe READ). The body is omitted
+	// here; buildResponseHeaderAndBody supplies MakeErrorBody() for STATUS_PENDING.
+	if status == types.StatusPending {
+		type asyncIdCarrier interface{ GetAsyncId() uint64 }
+		if ar, ok := any(resp).(asyncIdCarrier); ok {
+			return &HandlerResult{Status: status, AsyncId: ar.GetAsyncId()}, nil
+		}
+		return &HandlerResult{Status: status}, nil
+	}
+
 	// Skip encoding whenever buildResponseHeaderAndBody will substitute
 	// MakeErrorBody() on the way out — that is, for every error status and
 	// for warning statuses other than StatusBufferOverflow. Only

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -103,9 +103,23 @@ func ProcessSingleRequest(
 		return SendErrorResponse(reqHeader, errStatus, connInfo)
 	}
 
+	// Wire async slot accounting for max_async_credits enforcement (MS-SMB2 §3.3.5.2.5).
+	handlerCtx.TryReserveAsync = connInfo.TryReserveAsync
+	handlerCtx.ReleaseAsync = connInfo.ReleaseAsync
+
 	// For CHANGE_NOTIFY, set up async callback so notifications can be sent
 	if reqHeader.Command == types.SMB2ChangeNotify && asyncNotifyCallback != nil {
 		handlerCtx.AsyncNotifyCallback = asyncNotifyCallback
+	}
+
+	// For READ commands, provide the async pipe-read completion callback so that
+	// handlePipeRead can pend reads on empty named pipes (MS-SMB2 §3.3.5.12).
+	if reqHeader.Command == types.SMB2Read {
+		ci := connInfo // capture for closure
+		handlerCtx.AsyncPipeReadCallback = func(sessionID, messageID, asyncId uint64, status types.Status, data []byte) error {
+			ci.ReleaseAsync()
+			return SendAsyncCompletionResponse(sessionID, messageID, asyncId, types.SMB2Read, status, encodeReadResponseBody(data), ci)
+		}
 	}
 
 	// For CANCEL, pass the request's AsyncId so the handler can identify
@@ -263,10 +277,23 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 		return &HandlerResult{Status: errStatus, Data: MakeErrorBody()}, fileID, handlerCtx
 	}
 
+	// Wire async slot accounting for max_async_credits enforcement (MS-SMB2 §3.3.5.2.5).
+	handlerCtx.TryReserveAsync = connInfo.TryReserveAsync
+	handlerCtx.ReleaseAsync = connInfo.ReleaseAsync
+
 	// For CHANGE_NOTIFY in compound, wire the async callback so notifications
 	// can be sent separately from the compound response.
 	if reqHeader.Command == types.SMB2ChangeNotify && asyncNotifyCallback != nil {
 		handlerCtx.AsyncNotifyCallback = asyncNotifyCallback
+	}
+
+	// For READ commands, wire the async pipe-read completion callback.
+	if reqHeader.Command == types.SMB2Read {
+		ci := connInfo
+		handlerCtx.AsyncPipeReadCallback = func(sessionID, messageID, asyncId uint64, status types.Status, data []byte) error {
+			ci.ReleaseAsync()
+			return SendAsyncCompletionResponse(sessionID, messageID, asyncId, types.SMB2Read, status, encodeReadResponseBody(data), ci)
+		}
 	}
 
 	// For CANCEL, pass the request's AsyncId so the handler can identify
@@ -606,6 +633,10 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWri
 // a pending request is cancelled (STATUS_CANCELLED).
 // The asyncId must match the one sent in the interim STATUS_PENDING response.
 func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, response *handlers.ChangeNotifyResponse, connInfo *ConnInfo) error {
+	// Release the async slot reserved when the CHANGE_NOTIFY was first pended.
+	// This must happen exactly once per operation, regardless of outcome.
+	connInfo.ReleaseAsync()
+
 	status := response.GetStatus()
 
 	// Build async response header with matching AsyncId.
@@ -710,6 +741,29 @@ func SendAsyncCompletionResponse(sessionID uint64, messageID uint64, asyncId uin
 		"asyncId", asyncId)
 
 	return SendMessage(respHeader, body, connInfo)
+}
+
+// encodeReadResponseBody encodes a READ response body for async pipe-read completion.
+// Format per MS-SMB2 §2.2.20: StructureSize(2) + DataOffset(1) + Reserved(1) +
+// DataLength(4) + DataRemaining(4) + Reserved2(4) + Data(variable).
+// DataOffset 0x50 = 80 = SMB2 header (64) + READ response fixed header (16).
+func encodeReadResponseBody(data []byte) []byte {
+	dataLen := len(data)
+	buf := make([]byte, 16+max(dataLen, 1))
+	buf[0] = 17   // StructureSize low byte
+	buf[1] = 0    // StructureSize high byte
+	buf[2] = 0x50 // DataOffset
+	buf[3] = 0    // Reserved
+	buf[4] = byte(dataLen)
+	buf[5] = byte(dataLen >> 8)
+	buf[6] = byte(dataLen >> 16)
+	buf[7] = byte(dataLen >> 24)
+	// DataRemaining (4 bytes) = 0
+	// Reserved2 (4 bytes) = 0
+	if dataLen > 0 {
+		copy(buf[16:], data)
+	}
+	return buf
 }
 
 // HandleSMB1Negotiate handles legacy SMB1 NEGOTIATE requests by responding with

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -153,7 +153,16 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// ========================================================================
 
 	if openFile.IsPipe {
-		// Clean up pipe state
+		// Cancel any pending async READ before closing the pipe.
+		if h.PipeReadRegistry != nil {
+			if pending := h.PipeReadRegistry.UnregisterByFileID(req.FileID); pending != nil && pending.Callback != nil {
+				go func(pr *PendingPipeRead) {
+					if err := pr.Callback(pr.SessionID, pr.MessageID, pr.AsyncId, types.StatusCancelled, nil); err != nil {
+						logger.Warn("CLOSE: failed to cancel pending pipe READ", "asyncId", pr.AsyncId, "error", err)
+					}
+				}(pending)
+			}
+		}
 		h.PipeManager.ClosePipe(req.FileID)
 		h.DeleteOpenFile(req.FileID)
 

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -124,6 +124,19 @@ type SMBHandlerContext struct {
 	// If nil, notifications are logged but not sent.
 	AsyncNotifyCallback AsyncResponseCallback
 
+	// AsyncPipeReadCallback delivers the final async READ response for a pending
+	// named-pipe read. Set by the dispatch layer for SMB2Read commands.
+	AsyncPipeReadCallback AsyncPipeReadCallback
+
+	// TryReserveAsync checks and atomically reserves one async connection slot.
+	// Returns false when the connection is at max_async_credits (512); the caller
+	// must return STATUS_INSUFFICIENT_RESOURCES without registering the operation.
+	TryReserveAsync func() bool
+
+	// ReleaseAsync releases a previously reserved async slot. Called by the
+	// handler when registration fails after a successful TryReserveAsync call.
+	ReleaseAsync func()
+
 	// RequestAsyncId is the AsyncId from the request header when FlagAsync is set.
 	// Used by CANCEL to identify which async operation to cancel.
 	RequestAsyncId uint64

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -61,6 +61,9 @@ type Handler struct {
 	NotifyRegistry *NotifyRegistry
 	nextAsyncId    atomic.Uint64
 
+	// Named-pipe async READ tracking
+	PipeReadRegistry *PipeReadRegistry
+
 	// Pending blocking lock operations (messageID -> cancel func).
 	// Used by CANCEL to interrupt blocking lock requests.
 	pendingLocks sync.Map
@@ -339,6 +342,7 @@ func NewHandlerWithSessionManager(sessionManager *session.Manager) *Handler {
 		SessionManager:          sessionManager,
 		PipeManager:             rpc.NewPipeManager(),
 		NotifyRegistry:          NewNotifyRegistry(),
+		PipeReadRegistry:        NewPipeReadRegistry(),
 		MaxTransactSize:         1048576, // 1MB (supports large directory listings; increases per-request memory)
 		MaxReadSize:             1048576, // 1MB
 		MaxWriteSize:            1048576, // 1MB
@@ -487,6 +491,14 @@ func (h *Handler) closeFilesWithFilter(
 
 		// Handle pipe close
 		if openFile.IsPipe {
+			// Complete any pending async READ with STATUS_CANCELLED before closing.
+			if h.PipeReadRegistry != nil {
+				if pending := h.PipeReadRegistry.UnregisterByFileID(openFile.FileID); pending != nil {
+					if pending.Callback != nil {
+						go pending.Callback(pending.SessionID, pending.MessageID, pending.AsyncId, types.StatusCancelled, nil)
+					}
+				}
+			}
 			h.PipeManager.ClosePipe(openFile.FileID)
 			toDelete = append(toDelete, openFile.FileID)
 			closed++
@@ -679,6 +691,13 @@ func (h *Handler) releaseSessionLeasesAndNotifies(ctx context.Context, sessionID
 	}
 	if h.NotifyRegistry != nil {
 		h.NotifyRegistry.UnregisterAllForSession(sessionID)
+	}
+	if h.PipeReadRegistry != nil {
+		for _, pending := range h.PipeReadRegistry.UnregisterAllForSession(sessionID) {
+			if pending.Callback != nil {
+				go pending.Callback(pending.SessionID, pending.MessageID, pending.AsyncId, types.StatusCancelled, nil)
+			}
+		}
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -495,7 +495,11 @@ func (h *Handler) closeFilesWithFilter(
 			if h.PipeReadRegistry != nil {
 				if pending := h.PipeReadRegistry.UnregisterByFileID(openFile.FileID); pending != nil {
 					if pending.Callback != nil {
-						go pending.Callback(pending.SessionID, pending.MessageID, pending.AsyncId, types.StatusCancelled, nil)
+						go func(pr *PendingPipeRead) {
+							if err := pr.Callback(pr.SessionID, pr.MessageID, pr.AsyncId, types.StatusCancelled, nil); err != nil {
+								logger.Warn("pipe close: failed to cancel pending READ", "asyncId", pr.AsyncId, "error", err)
+							}
+						}(pending)
 					}
 				}
 			}
@@ -695,7 +699,11 @@ func (h *Handler) releaseSessionLeasesAndNotifies(ctx context.Context, sessionID
 	if h.PipeReadRegistry != nil {
 		for _, pending := range h.PipeReadRegistry.UnregisterAllForSession(sessionID) {
 			if pending.Callback != nil {
-				go pending.Callback(pending.SessionID, pending.MessageID, pending.AsyncId, types.StatusCancelled, nil)
+				go func(pr *PendingPipeRead) {
+					if err := pr.Callback(pr.SessionID, pr.MessageID, pr.AsyncId, types.StatusCancelled, nil); err != nil {
+						logger.Warn("session cleanup: failed to cancel pending pipe READ", "asyncId", pr.AsyncId, "error", err)
+					}
+				}(pending)
 			}
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/v2/handlers/pipe_read_registry.go
@@ -61,7 +61,11 @@ func (r *PipeReadRegistry) Register(p *PendingPipeRead) {
 	r.mu.Unlock()
 
 	if displaced != nil && displaced.Callback != nil {
-		go displaced.Callback(displaced.SessionID, displaced.MessageID, displaced.AsyncId, types.StatusCancelled, nil)
+		go func(pr *PendingPipeRead) {
+			if err := pr.Callback(pr.SessionID, pr.MessageID, pr.AsyncId, types.StatusCancelled, nil); err != nil {
+				logger.Warn("PipeReadRegistry: failed to cancel displaced READ", "asyncId", pr.AsyncId, "error", err)
+			}
+		}(displaced)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/v2/handlers/pipe_read_registry.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"sync"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// AsyncPipeReadCallback delivers the final async READ response for a pending
+// named-pipe read. data is the raw pipe bytes (nil on cancellation/error).
+type AsyncPipeReadCallback func(sessionID, messageID, asyncId uint64, status types.Status, data []byte) error
+
+// PendingPipeRead tracks a named-pipe READ that is waiting for data.
+// Created when handlePipeRead finds no data available and returns STATUS_PENDING.
+type PendingPipeRead struct {
+	FileID    [16]byte
+	SessionID uint64
+	MessageID uint64
+	AsyncId   uint64
+	MaxLen    int
+	Callback  AsyncPipeReadCallback
+}
+
+// PipeReadRegistry tracks outstanding async pipe READ operations.
+// Each named-pipe handle can have at most one pending read at a time.
+// Thread-safe; all methods acquire the mutex.
+type PipeReadRegistry struct {
+	mu          sync.Mutex
+	byFileID    map[[16]byte]*PendingPipeRead
+	byMessageID map[uint64]*PendingPipeRead
+	byAsyncId   map[uint64]*PendingPipeRead
+}
+
+// NewPipeReadRegistry creates an empty registry.
+func NewPipeReadRegistry() *PipeReadRegistry {
+	return &PipeReadRegistry{
+		byFileID:    make(map[[16]byte]*PendingPipeRead),
+		byMessageID: make(map[uint64]*PendingPipeRead),
+		byAsyncId:   make(map[uint64]*PendingPipeRead),
+	}
+}
+
+// Register adds a pending pipe read. If another pending read already exists
+// for the same FileID, it is replaced (the old entry is completed first via
+// its callback with STATUS_CANCELLED to avoid leaking async slots).
+func (r *PipeReadRegistry) Register(p *PendingPipeRead) {
+	r.mu.Lock()
+	var displaced *PendingPipeRead
+	if old, ok := r.byFileID[p.FileID]; ok {
+		displaced = old
+		delete(r.byMessageID, old.MessageID)
+		delete(r.byAsyncId, old.AsyncId)
+		logger.Warn("PipeReadRegistry: replacing existing pending read",
+			"fileID", p.FileID,
+			"oldAsyncId", old.AsyncId)
+	}
+	r.byFileID[p.FileID] = p
+	r.byMessageID[p.MessageID] = p
+	r.byAsyncId[p.AsyncId] = p
+	r.mu.Unlock()
+
+	if displaced != nil && displaced.Callback != nil {
+		go displaced.Callback(displaced.SessionID, displaced.MessageID, displaced.AsyncId, types.StatusCancelled, nil)
+	}
+}
+
+// removeLocked deletes p from all three indexes. Caller must hold r.mu.
+func (r *PipeReadRegistry) removeLocked(p *PendingPipeRead) {
+	delete(r.byFileID, p.FileID)
+	delete(r.byMessageID, p.MessageID)
+	delete(r.byAsyncId, p.AsyncId)
+}
+
+// UnregisterByFileID removes and returns the pending read for the given FileID.
+// Returns nil if none is registered.
+func (r *PipeReadRegistry) UnregisterByFileID(fileID [16]byte) *PendingPipeRead {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byFileID[fileID]
+	if !ok {
+		return nil
+	}
+	r.removeLocked(p)
+	return p
+}
+
+// UnregisterByMessageID removes and returns the pending read with the given MessageID.
+// Returns nil if none is registered.
+func (r *PipeReadRegistry) UnregisterByMessageID(messageID uint64) *PendingPipeRead {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byMessageID[messageID]
+	if !ok {
+		return nil
+	}
+	r.removeLocked(p)
+	return p
+}
+
+// UnregisterByAsyncId removes and returns the pending read with the given AsyncId.
+// Returns nil if none is registered.
+func (r *PipeReadRegistry) UnregisterByAsyncId(asyncId uint64) *PendingPipeRead {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byAsyncId[asyncId]
+	if !ok {
+		return nil
+	}
+	r.removeLocked(p)
+	return p
+}
+
+// UnregisterAllForSession removes and returns all pending reads for the given session.
+func (r *PipeReadRegistry) UnregisterAllForSession(sessionID uint64) []*PendingPipeRead {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var result []*PendingPipeRead
+	for _, p := range r.byFileID {
+		if p.SessionID != sessionID {
+			continue
+		}
+		r.removeLocked(p)
+		result = append(result, p)
+	}
+	return result
+}

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -69,7 +69,15 @@ type ReadResponse struct {
 	// DataRemaining indicates bytes remaining to be read.
 	// 0 means this is the last chunk of the read operation.
 	DataRemaining uint32
+
+	// AsyncId is non-zero for async interim responses (STATUS_PENDING on named pipes).
+	// Propagated via the asyncIdCarrier interface in helpers.go handleRequest.
+	AsyncId uint64
 }
+
+// GetAsyncId implements the asyncIdCarrier interface used by helpers.go
+// handleRequest to propagate STATUS_PENDING async interim responses.
+func (r *ReadResponse) GetAsyncId() uint64 { return r.AsyncId }
 
 // ============================================================================
 // Encoding and Decoding
@@ -316,10 +324,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 10: Calculate read range
 	// ========================================================================
 
-	readEnd := req.Offset + uint64(req.Length)
-	if readEnd > fileSize {
-		readEnd = fileSize
-	}
+	readEnd := min(req.Offset+uint64(req.Length), fileSize)
 	actualLength := uint32(readEnd - req.Offset)
 
 	// Per MS-SMB2: if actual bytes available < MinimumCount, return EOF.
@@ -409,10 +414,7 @@ func (h *Handler) handleSymlinkRead(
 	}
 
 	// Calculate read range
-	readEnd := req.Offset + uint64(req.Length)
-	if readEnd > fileSize {
-		readEnd = fileSize
-	}
+	readEnd := min(req.Offset+uint64(req.Length), fileSize)
 
 	// Extract the requested portion
 	data := mfsymlinkData[req.Offset:readEnd]
@@ -449,13 +451,33 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 	// Read buffered RPC response
 	data := pipe.ProcessRead(int(req.Length))
 	if len(data) == 0 {
-		// No data available - this could be normal if WRITE hasn't happened yet
-		logger.Debug("READ: no data available in pipe", "pipeName", openFile.PipeName)
+		// No data available — pend the read as async per MS-SMB2 §3.3.5.12.
+		// When the client's subsequent WRITE produces data, handlePipeWrite
+		// completes this pending read via PipeReadRegistry.
+		logger.Debug("READ: no data in pipe, pending async", "pipeName", openFile.PipeName)
+
+		if ctx.TryReserveAsync == nil || !ctx.TryReserveAsync() {
+			logger.Debug("READ: max_async_credits reached, rejecting pipe read",
+				"pipeName", openFile.PipeName)
+			return &ReadResponse{
+				SMBResponseBase: SMBResponseBase{Status: types.StatusInsufficientResources},
+			}, nil
+		}
+
+		asyncId := h.generateAsyncId()
+		pending := &PendingPipeRead{
+			FileID:    req.FileID,
+			SessionID: ctx.SessionID,
+			MessageID: ctx.MessageID,
+			AsyncId:   asyncId,
+			MaxLen:    int(req.Length),
+			Callback:  ctx.AsyncPipeReadCallback,
+		}
+		h.PipeReadRegistry.Register(pending)
+
 		return &ReadResponse{
-			SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
-			DataOffset:      0x50,
-			Data:            []byte{},
-			DataRemaining:   0,
+			SMBResponseBase: SMBResponseBase{Status: types.StatusPending},
+			AsyncId:         asyncId,
 		}, nil
 	}
 

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -456,6 +456,13 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 		// completes this pending read via PipeReadRegistry.
 		logger.Debug("READ: no data in pipe, pending async", "pipeName", openFile.PipeName)
 
+		if h.PipeReadRegistry == nil || ctx.AsyncPipeReadCallback == nil {
+			logger.Warn("READ: async pipe read not supported (registry or callback missing)",
+				"pipeName", openFile.PipeName)
+			return &ReadResponse{
+				SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported},
+			}, nil
+		}
 		if ctx.TryReserveAsync == nil || !ctx.TryReserveAsync() {
 			logger.Debug("READ: max_async_credits reached, rejecting pipe read",
 				"pipeName", openFile.PipeName)

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -188,12 +188,11 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 	// We check both CHANGE_NOTIFY and blocking LOCK requests.
 	cancelledSomething := false
 
-	// Try to cancel a pending CHANGE_NOTIFY request
+	// Try to cancel a pending CHANGE_NOTIFY request.
+	// Per [MS-SMB2] 3.3.5.16: If SMB2_FLAGS_ASYNC_COMMAND is set, look up by
+	// AsyncId; otherwise by MessageID.
 	if h.NotifyRegistry != nil {
 		var cancelled *PendingNotify
-
-		// Per [MS-SMB2] 3.3.5.16: If SMB2_FLAGS_ASYNC_COMMAND is set,
-		// look up by AsyncId; otherwise by MessageID.
 		if ctx.RequestAsyncId != 0 {
 			cancelled = h.NotifyRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
 		} else {
@@ -218,6 +217,31 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 						"messageID", cancelled.MessageID,
 						"error", err)
 				}
+			}
+		}
+	}
+
+	// Try to cancel a pending async pipe READ.
+	if h.PipeReadRegistry != nil {
+		var pendingRead *PendingPipeRead
+		if ctx.RequestAsyncId != 0 {
+			pendingRead = h.PipeReadRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
+		} else {
+			pendingRead = h.PipeReadRegistry.UnregisterByMessageID(ctx.MessageID)
+		}
+		if pendingRead != nil {
+			cancelledSomething = true
+			logger.Debug("CANCEL: cancelled pending pipe READ",
+				"asyncId", pendingRead.AsyncId,
+				"messageID", pendingRead.MessageID)
+			if pendingRead.Callback != nil {
+				go func(pr *PendingPipeRead) {
+					if err := pr.Callback(pr.SessionID, pr.MessageID, pr.AsyncId, types.StatusCancelled, nil); err != nil {
+						logger.Warn("CANCEL: failed to send STATUS_CANCELLED for pipe READ",
+							"messageID", pr.MessageID,
+							"error", err)
+					}
+				}(pendingRead)
 			}
 		}
 	}
@@ -337,7 +361,16 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		AsyncCallback:    ctx.AsyncNotifyCallback,
 	}
 
+	// Per MS-SMB2 §3.3.5.2.5: enforce max_async_credits before going async.
+	if ctx.TryReserveAsync == nil || !ctx.TryReserveAsync() {
+		logger.Debug("CHANGE_NOTIFY: max_async_credits reached",
+			"path", watchPath,
+			"sessionID", ctx.SessionID)
+		return NewErrorResult(types.StatusInsufficientResources), nil
+	}
+
 	if err := h.NotifyRegistry.Register(notify); err != nil {
+		ctx.ReleaseAsync()
 		logger.Warn("CHANGE_NOTIFY: rejected — too many pending watches",
 			"path", watchPath,
 			"sessionID", ctx.SessionID)

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -109,9 +109,7 @@ func DecodeWriteRequest(body []byte) (*WriteRequest, error) {
 		dataStart := int(req.DataOffset) - 64
 
 		// Clamp to valid range - data can't start before byte 48 (after fixed fields)
-		if dataStart < 48 {
-			dataStart = 48
-		}
+		dataStart = max(dataStart, 48)
 
 		// Try to extract data from calculated offset
 		if dataStart+int(req.Length) <= len(body) {
@@ -458,6 +456,23 @@ func (h *Handler) handlePipeWrite(ctx *SMBHandlerContext, req *WriteRequest, ope
 	if err != nil {
 		logger.Warn("WRITE: pipe write failed", "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
+	}
+
+	// Complete any pending async READ for this pipe handle.
+	// The WRITE produced response data in ReadBuffer; deliver it now.
+	if h.PipeReadRegistry != nil {
+		if pending := h.PipeReadRegistry.UnregisterByFileID(req.FileID); pending != nil {
+			data := pipe.ProcessRead(pending.MaxLen)
+			if pending.Callback != nil {
+				go func() {
+					if err := pending.Callback(pending.SessionID, pending.MessageID, pending.AsyncId, types.StatusSuccess, data); err != nil {
+						logger.Warn("WRITE: failed to complete pending pipe READ",
+							"asyncId", pending.AsyncId,
+							"error", err)
+					}
+				}()
+			}
+		}
 	}
 
 	logger.Debug("WRITE to pipe successful",


### PR DESCRIPTION
## Summary

Implements per-connection async credit enforcement (MS-SMB2 §3.3.5.2.5) for CHANGE_NOTIFY and named-pipe READ operations, and adds `PipeReadRegistry` to track outstanding async pipe READs.

**Problem:** CHANGE_NOTIFY and named-pipe READs could queue unbounded async slots, and named-pipe READs had no mechanism to pend and complete asynchronously when no data was available.

## Changes

### Async credit accounting (`conn_types.go`)
- Add `TryReserveAsync` / `ReleaseAsync` on `ConnInfo` using an atomic counter
- Enforce `MaxAsyncCredits = 512` per MS-SMB2 §3.3.5.2.5; return `STATUS_INSUFFICIENT_RESOURCES` when limit reached

### Dispatch wiring (`response.go`, `helpers.go`)
- Wire `TryReserveAsync` / `ReleaseAsync` into `SMBHandlerContext` for both single and compound request paths
- Wire `AsyncPipeReadCallback` for SMB2 READ commands so `handlePipeRead` can pend on empty named pipes

### Named-pipe async READ (`read.go`, `handler.go`, `stub_handlers.go`)
- `handlePipeRead` returns `STATUS_PENDING` + async interim response when pipe buffer is empty, reserving an async slot via `TryReserveAsync`
- `handlePipeWrite` completes any pending read via `PipeReadRegistry` after processing RPC data
- CANCEL handler drains `PipeReadRegistry` and fires completion callback in a goroutine (was synchronous, risking read-loop stall)
- Session cleanup and file close drain the registry and release slots exactly once

### `PipeReadRegistry` (`pipe_read_registry.go`, new)
- Tracks `PendingPipeRead` entries by FileID, MessageID, and AsyncId
- `Register` displaces an existing entry for the same FileID by cancelling it outside the mutex lock (fixes credit accounting race at the `MaxAsyncCredits` boundary)
- Extracted `removeLocked` helper to consolidate three-map deletion

### Read/write cleanup (`read.go`, `write.go`)
- Replace manual `if x > y { x = y }` with `min`/`max` builtins

## Verification

- `go build ./...` — clean
- `go vet ./internal/adapter/smb/...` — clean
- `go test ./internal/adapter/smb/v2/handlers/... -count=1` — PASS