### PR TITLE
fix(smb): cap async credits at MaxAsyncCredits-1 to match Samba

### DIFF
--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -73,8 +73,11 @@ type ConnInfo struct {
 	asyncPendingCount atomic.Int32
 }
 
-// MaxAsyncCredits is the maximum number of outstanding async operations per
-// connection per MS-SMB2 §3.3.5.2.5 (Connection.MaxAsyncCredits default = 512).
+// MaxAsyncCredits is the advertised/configured max_async_credits value per
+// MS-SMB2 §3.3.5.2.5 (Connection.MaxAsyncCredits default = 512). The
+// enforced cap on outstanding async operations is MaxAsyncCredits-1 — see
+// TryReserveAsync — matching Samba behaviour so one slot stays free for
+// synchronous work and CANCEL.
 const MaxAsyncCredits = 512
 
 // TryReserveAsync atomically checks and reserves one async slot on the connection.

--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -78,12 +78,15 @@ type ConnInfo struct {
 const MaxAsyncCredits = 512
 
 // TryReserveAsync atomically checks and reserves one async slot on the connection.
-// Returns false when the connection is at MaxAsyncCredits; the caller must
-// return STATUS_INSUFFICIENT_RESOURCES without registering an async operation.
+// Returns false when the connection has MaxAsyncCredits-1 slots outstanding; the
+// caller must return STATUS_INSUFFICIENT_RESOURCES without registering an async
+// operation. Samba (source3/smbd/smb2_server.c) caps outstanding async ops at
+// max_async_credits-1 so one slot stays free for synchronous work and CANCEL;
+// smbtorture smb2.credits.*_max_async_credits asserts this behavior.
 func (c *ConnInfo) TryReserveAsync() bool {
 	for {
 		cur := c.asyncPendingCount.Load()
-		if cur >= MaxAsyncCredits {
+		if cur >= MaxAsyncCredits-1 {
 			return false
 		}
 		if c.asyncPendingCount.CompareAndSwap(cur, cur+1) {

--- a/internal/adapter/smb/conn_types_test.go
+++ b/internal/adapter/smb/conn_types_test.go
@@ -1,0 +1,29 @@
+package smb
+
+import "testing"
+
+// TestTryReserveAsync_CapsAtMaxMinusOne verifies the per-connection async slot
+// cap matches Samba behavior: outstanding ops max at MaxAsyncCredits-1 (511 when
+// MaxAsyncCredits=512). Smbtorture smb2.credits.*_max_async_credits asserts
+// num_status_pending == max_async_credits - 1 (credits.c:641, :1281).
+func TestTryReserveAsync_CapsAtMaxMinusOne(t *testing.T) {
+	c := &ConnInfo{}
+
+	for i := range MaxAsyncCredits - 1 {
+		if !c.TryReserveAsync() {
+			t.Fatalf("TryReserveAsync returned false at i=%d; want true for all i<MaxAsyncCredits-1", i)
+		}
+	}
+
+	if c.TryReserveAsync() {
+		t.Fatalf("TryReserveAsync returned true at cap; want false (outstanding=%d)", c.asyncPendingCount.Load())
+	}
+	if got := c.asyncPendingCount.Load(); got != MaxAsyncCredits-1 {
+		t.Fatalf("asyncPendingCount=%d, want %d", got, MaxAsyncCredits-1)
+	}
+
+	c.ReleaseAsync()
+	if !c.TryReserveAsync() {
+		t.Fatalf("TryReserveAsync returned false after ReleaseAsync; want true")
+	}
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -205,35 +205,20 @@ DittoFS implements file leases (Phase 37) but not directory leases.
 | smb2.dirlease.v2_request | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.v2_request_parent | Directory Leases | Directory leases not implemented | - |
 
-### Credit Management (IPC Async Subset Not Implemented)
+### Credit Management (Multi-Channel Subset Not Implemented)
 
-Credit grant arithmetic is correct post-#378: `session_setup_credits_granted`,
-`single_req_credits_granted`, and `skipped_mid` all pass, and the `cur_credits`
-assertion at `credits.c:460` (previously `granted 529, expected 514`) now
-succeeds on every `*_ipc_max_async_credits` variant. The subsuite no longer
-aborts via talloc panic, so all entries below are reachable.
+Credit grant arithmetic and the `max_async_credits` cap are both correct
+post-#399 follow-up: `ipc_max_data_zero`, `1conn_ipc_max_async_credits`,
+`2conn_ipc_max_async_credits`, and `1conn_notify_max_async_credits` all pass.
 
-The remaining failures are two independent gaps in the IPC/named-pipe path,
-not credit arithmetic:
-
-1. **Named-pipe async READ never pends.** On an empty pipe the server returns
-   `STATUS_SUCCESS` instead of going async with `STATUS_PENDING`. Samba
-   handles this in `source3/smbd/smb2_read.c` via the `read_nowait` /
-   `STATUS_PENDING` path.
-2. **`max_async_credits` cap not enforced.** Once a client has
-   `max_async_credits` (default 512) outstanding async operations, further
-   async requests must return `STATUS_INSUFFICIENT_RESOURCES` per MS-SMB2
-   3.3.5.2.5. DittoFS lets all requests pend.
+The remaining failures all require multi-channel session binding (MS-SMB2
+§3.3.5.5.2) and are tracked under #361.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.credits.1conn_ipc_max_async_credits | Credits | Named-pipe async READ returns OK without pending; `max_async_credits` cap not enforced | #399 |
-| smb2.credits.2conn_ipc_max_async_credits | Credits | Named-pipe async READ returns OK without pending; `max_async_credits` cap not enforced | #399 |
 | smb2.credits.multichannel_ipc_max_async_credits | Credits | Multi-channel not implemented (second-connection CREATE disconnects) | #361 |
-| smb2.credits.1conn_notify_max_async_credits | Credits | Server does not cap async ops at `max_async_credits` (all 514 reads pend, test expects 511 pending + 3 INSUFFICIENT_RESOURCES) | #399 |
-| smb2.credits.2conn_notify_max_async_credits | Credits | Server does not cap async ops at `max_async_credits`; multi-connection async credit coordination not implemented | #399 |
-| smb2.credits.multichannel_max_async_credits | Credits | Multi-channel not implemented (blocks session bind) | #361 |
-| smb2.credits.ipc_max_data_zero | Credits | Named-pipe async READ returns OK without pending on IPC$ | #399 |
+| smb2.credits.2conn_notify_max_async_credits | Credits | Multi-channel not implemented (second connection disconnects mid-test) | #361 |
+| smb2.credits.multichannel_max_async_credits | Credits | Multi-channel not implemented (session bind returns ACCESS_DENIED) | #361 |
 
 ### Directory Operations (Advanced Queries Not Implemented)
 


### PR DESCRIPTION
## Summary

- Cap per-connection outstanding async ops at `MaxAsyncCredits - 1` (511) instead of `MaxAsyncCredits` (512), matching Samba's behavior (`source3/smbd/smb2_server.c`) and smbtorture expectations (`credits.c:641`, `:1281`).
- Samba reserves one slot below the advertised max so synchronous work and CANCEL always have a credit available.
- Follow-up to #399 — the async credit accounting landed in #401 but enforced the cap one slot too high.

## Impact on smbtorture `smb2.credits`

Before: 3 PASS / 7 FAIL. After: **7 PASS / 3 FAIL**.

Flipped FAIL → PASS:
- `smb2.credits.ipc_max_data_zero`
- `smb2.credits.1conn_ipc_max_async_credits`
- `smb2.credits.2conn_ipc_max_async_credits`
- `smb2.credits.1conn_notify_max_async_credits`

Remaining 3 failures (`multichannel_ipc_max_async_credits`, `multichannel_max_async_credits`, `2conn_notify_max_async_credits`) all require multi-channel session binding and are scoped to #361. `KNOWN_FAILURES.md` updated to reflect the new state.

## Test plan

- [x] `go test ./internal/adapter/smb/...` passes (new `TestTryReserveAsync_CapsAtMaxMinusOne`)
- [x] `smb2.credits` subsuite: 7 PASS / 3 FAIL (all remaining failures are #361 multi-channel)
- [ ] CI: full smbtorture sweep on other subsuites to confirm no regression