### PR TITLE
fix(smb): SMB 3.x session bind / multichannel Phase 1 — #361

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -428,7 +428,7 @@ func sendCompoundResponses(responses []compoundResponse, connInfo *ConnInfo) err
 				ok = true
 			}
 			if ok && sess.ShouldSign() && !sess.ShouldEncrypt() {
-				sess.SignMessage(cmdBytes)
+				signOutgoingWithChannel(sess, connInfo.ConnID, cmdBytes)
 			}
 		}
 
@@ -631,10 +631,20 @@ func VerifyCompoundCommandSignature(data []byte, hdr *header.SMB2Header, connInf
 			verifyBytes = data[:hdr.NextCommand]
 		}
 
-		if !sess.VerifyMessage(verifyBytes) {
+		// Per-channel signer if this connection is bound as a channel on
+		// the session (MS-SMB2 §3.3.5.5.2); otherwise session-level signer.
+		verified := false
+		if channel := sess.GetChannel(connInfo.ConnID); channel != nil && channel.Signer != nil {
+			verified = channel.Signer.Verify(verifyBytes)
+		} else {
+			verified = sess.VerifyMessage(verifyBytes)
+		}
+
+		if !verified {
 			logger.Warn("SMB2 compound command signature verification failed",
 				"command", hdr.Command.String(),
 				"sessionID", hdr.SessionID,
+				"connID", connInfo.ConnID,
 				"verifyLen", len(verifyBytes))
 			return fmt.Errorf("STATUS_ACCESS_DENIED: compound signature verification failed")
 		}

--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -428,7 +428,7 @@ func sendCompoundResponses(responses []compoundResponse, connInfo *ConnInfo) err
 				ok = true
 			}
 			if ok && sess.ShouldSign() && !sess.ShouldEncrypt() {
-				signOutgoingWithChannel(sess, connInfo.ConnID, cmdBytes)
+				sess.SignMessageOnChannel(connInfo.ConnID, cmdBytes)
 			}
 		}
 
@@ -631,16 +631,7 @@ func VerifyCompoundCommandSignature(data []byte, hdr *header.SMB2Header, connInf
 			verifyBytes = data[:hdr.NextCommand]
 		}
 
-		// Per-channel signer if this connection is bound as a channel on
-		// the session (MS-SMB2 §3.3.5.5.2); otherwise session-level signer.
-		verified := false
-		if channel := sess.GetChannel(connInfo.ConnID); channel != nil && channel.Signer != nil {
-			verified = channel.Signer.Verify(verifyBytes)
-		} else {
-			verified = sess.VerifyMessage(verifyBytes)
-		}
-
-		if !verified {
+		if !sess.VerifyMessageOnChannel(connInfo.ConnID, verifyBytes) {
 			logger.Warn("SMB2 compound command signature verification failed",
 				"command", hdr.Command.String(),
 				"sessionID", hdr.SessionID,

--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -25,6 +25,14 @@ type LockedWriter struct {
 // Rather than passing the entire Connection, callers construct a ConnInfo
 // with only the fields needed by internal functions.
 type ConnInfo struct {
+	// ConnID is a stable, monotonic identifier assigned when the TCP
+	// connection is accepted. It identifies the connection within a session's
+	// Channel registry for per-channel signing-key lookup (MS-SMB2 §3.3.5.5.2
+	// multi-channel; issue #361). Zero for connections that predate channel
+	// bookkeeping; callers must treat zero as "no channel registered" and
+	// fall back to session-level signing state.
+	ConnID uint64
+
 	// Conn is the underlying TCP connection (for RemoteAddr).
 	Conn net.Conn
 

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -383,19 +383,7 @@ func (sv *sessionSigningVerifier) VerifyRequest(hdr *header.SMB2Header, message 
 			verifyBytes = message[:hdr.NextCommand]
 		}
 
-		// If this connection has a bound Channel on the session (MS-SMB2
-		// §3.3.5.5.2 multi-channel), verify using the per-channel signer.
-		// Otherwise fall back to the session's signer — this covers the
-		// primary connection, every SMB 2.x path, and 3.x sessions without
-		// any bound channels.
-		verified := false
-		if channel := sess.GetChannel(sv.connID); channel != nil && channel.Signer != nil {
-			verified = channel.Signer.Verify(verifyBytes)
-		} else {
-			verified = sess.VerifyMessage(verifyBytes)
-		}
-
-		if !verified {
+		if !sess.VerifyMessageOnChannel(sv.connID, verifyBytes) {
 			logger.Warn("SMB2 message signature verification failed",
 				"command", hdr.Command.String(),
 				"sessionID", hdr.SessionID,

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -297,13 +297,21 @@ type sessionSigningVerifier struct {
 	handler    *handlers.Handler
 	conn       net.Conn
 	connCrypto *ConnectionCryptoState
+
+	// connID identifies this TCP connection. Used to look up the per-
+	// channel signer when the session has channels bound via SMB2
+	// session binding (MS-SMB2 §3.3.5.5.2). Zero means "no channel
+	// registry; fall through to session-level verification".
+	connID uint64
 }
 
 // NewSessionSigningVerifier creates a SigningVerifier backed by the Handler's session
 // state. It verifies message signatures per MS-SMB2 3.3.5.2.4 using session signing keys.
 // The connCrypto parameter provides per-connection negotiation state (dialect, etc.).
-func NewSessionSigningVerifier(handler *handlers.Handler, conn net.Conn, connCrypto *ConnectionCryptoState) SigningVerifier {
-	return &sessionSigningVerifier{handler: handler, conn: conn, connCrypto: connCrypto}
+// The connID ties this verifier to a specific TCP connection so that bound-channel
+// signing keys can be routed correctly.
+func NewSessionSigningVerifier(handler *handlers.Handler, conn net.Conn, connCrypto *ConnectionCryptoState, connID uint64) SigningVerifier {
+	return &sessionSigningVerifier{handler: handler, conn: conn, connCrypto: connCrypto, connID: connID}
 }
 
 // VerifyRequest implements MS-SMB2 3.3.5.2.4 signature verification.
@@ -375,10 +383,23 @@ func (sv *sessionSigningVerifier) VerifyRequest(hdr *header.SMB2Header, message 
 			verifyBytes = message[:hdr.NextCommand]
 		}
 
-		if !sess.VerifyMessage(verifyBytes) {
+		// If this connection has a bound Channel on the session (MS-SMB2
+		// §3.3.5.5.2 multi-channel), verify using the per-channel signer.
+		// Otherwise fall back to the session's signer — this covers the
+		// primary connection, every SMB 2.x path, and 3.x sessions without
+		// any bound channels.
+		verified := false
+		if channel := sess.GetChannel(sv.connID); channel != nil && channel.Signer != nil {
+			verified = channel.Signer.Verify(verifyBytes)
+		} else {
+			verified = sess.VerifyMessage(verifyBytes)
+		}
+
+		if !verified {
 			logger.Warn("SMB2 message signature verification failed",
 				"command", hdr.Command.String(),
 				"sessionID", hdr.SessionID,
+				"connID", sv.connID,
 				"client", sv.conn.RemoteAddr().String(),
 				"msgSignature", fmt.Sprintf("%x", message[48:64]))
 			return fmt.Errorf("STATUS_ACCESS_DENIED: signature verification failed")

--- a/internal/adapter/smb/helpers.go
+++ b/internal/adapter/smb/helpers.go
@@ -2,10 +2,28 @@
 package smb
 
 import (
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	sbsigning "github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/adapter/smb/v2/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// signOutgoingWithChannel signs an outgoing SMB2 response in place. If the
+// session has a Channel registered for connID (MS-SMB2 §3.3.5.5.2 multi-
+// channel session binding), the per-channel signer is used; otherwise the
+// session-level signer. Setting SMB2_FLAGS_SIGNED is handled by
+// signing.SignMessage.
+func signOutgoingWithChannel(sess *session.Session, connID uint64, message []byte) {
+	if sess == nil {
+		return
+	}
+	if channel := sess.GetChannel(connID); channel != nil && channel.Signer != nil {
+		sbsigning.SignMessage(channel.Signer, message)
+		return
+	}
+	sess.SignMessage(message)
+}
 
 // ============================================================================
 // Generic Request/Response Handling

--- a/internal/adapter/smb/helpers.go
+++ b/internal/adapter/smb/helpers.go
@@ -2,28 +2,10 @@
 package smb
 
 import (
-	"github.com/marmos91/dittofs/internal/adapter/smb/session"
-	sbsigning "github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/adapter/smb/v2/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 )
-
-// signOutgoingWithChannel signs an outgoing SMB2 response in place. If the
-// session has a Channel registered for connID (MS-SMB2 §3.3.5.5.2 multi-
-// channel session binding), the per-channel signer is used; otherwise the
-// session-level signer. Setting SMB2_FLAGS_SIGNED is handled by
-// signing.SignMessage.
-func signOutgoingWithChannel(sess *session.Session, connID uint64, message []byte) {
-	if sess == nil {
-		return
-	}
-	if channel := sess.GetChannel(connID); channel != nil && channel.Signer != nil {
-		sbsigning.SignMessage(channel.Signer, message)
-		return
-	}
-	sess.SignMessage(message)
-}
 
 // ============================================================================
 // Generic Request/Response Handling

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -160,7 +160,7 @@ func ProcessSingleRequest(
 	}
 
 	// Track session lifecycle for connection cleanup
-	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, connInfo.SessionTracker)
+	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, result.IsBinding, connInfo.SessionTracker)
 
 	// Send response and run after-hooks with the response bytes. If the
 	// write fails, return early — any registered PostSend hook is
@@ -324,7 +324,7 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 	}
 
 	// Track session lifecycle for connection cleanup
-	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, connInfo.SessionTracker)
+	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, result.IsBinding, connInfo.SessionTracker)
 
 	// Extract FileID from CREATE response (bytes 64-80)
 	if reqHeader.Command == types.SMB2Create && result.Status == types.StatusSuccess && len(result.Data) >= 80 {
@@ -851,25 +851,29 @@ func HandleSMB1Negotiate(connInfo *ConnInfo, message []byte) error {
 // TrackSessionLifecycle tracks session creation/deletion for connection cleanup.
 // This ensures proper cleanup when connections close ungracefully.
 //
-// Only genuinely new sessions (SESSION_SETUP with reqSessionID == 0) are
-// tracked on the connection. Re-authentication and channel binding both
-// arrive with a non-zero reqSessionID and must NOT be tracked here: for
-// re-auth the session is already tracked on this connection, and for a
-// channel bind (MS-SMB2 §3.3.5.5.2) the session lives on a different
-// connection — tracking it here would cause this connection's close to
-// delete the original session via cleanupSessions().
-func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uint64, status types.Status, tracker SessionTracker) {
+// Channel-bind responses (isBinding==true) are explicitly skipped: a
+// successful bind does not create a session on this connection — the
+// session lives on a different connection, and tracking it here would
+// cause this connection's close to delete the original session via
+// cleanupSessions() (MS-SMB2 §3.3.5.5.2).
+func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uint64, status types.Status, isBinding bool, tracker SessionTracker) {
 	if tracker == nil {
 		return
 	}
 
 	switch command {
 	case types.SMB2SessionSetup:
-		if status == types.StatusSuccess && reqSessionID == 0 && ctxSessionID != 0 {
-			tracker.TrackSession(ctxSessionID)
+		if status != types.StatusSuccess || isBinding {
+			return
+		}
+		sessionIDToTrack := ctxSessionID
+		if sessionIDToTrack == 0 {
+			sessionIDToTrack = reqSessionID
+		}
+		if sessionIDToTrack != 0 {
+			tracker.TrackSession(sessionIDToTrack)
 		}
 	case types.SMB2Logoff:
-		// Untrack sessions on LOGOFF (they are already cleaned up by the handler)
 		if status == types.StatusSuccess && reqSessionID != 0 {
 			tracker.UntrackSession(reqSessionID)
 		}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -220,6 +220,10 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 	// negotiation parameters on the connection.
 	handlerCtx.ConnCryptoState = connInfo.CryptoState
 
+	// Thread the stable per-connection ID so SMB2 multi-channel session
+	// binding (MS-SMB2 §3.3.5.5.2) can key per-channel signing state.
+	handlerCtx.ConnID = connInfo.ConnID
+
 	if cmd.NeedsSession && reqHeader.SessionID != 0 {
 		sess, ok := connInfo.Handler.GetSession(reqHeader.SessionID)
 		if !ok || sess.LoggedOff.Load() {

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -850,6 +850,14 @@ func HandleSMB1Negotiate(connInfo *ConnInfo, message []byte) error {
 
 // TrackSessionLifecycle tracks session creation/deletion for connection cleanup.
 // This ensures proper cleanup when connections close ungracefully.
+//
+// Only genuinely new sessions (SESSION_SETUP with reqSessionID == 0) are
+// tracked on the connection. Re-authentication and channel binding both
+// arrive with a non-zero reqSessionID and must NOT be tracked here: for
+// re-auth the session is already tracked on this connection, and for a
+// channel bind (MS-SMB2 §3.3.5.5.2) the session lives on a different
+// connection — tracking it here would cause this connection's close to
+// delete the original session via cleanupSessions().
 func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uint64, status types.Status, tracker SessionTracker) {
 	if tracker == nil {
 		return
@@ -857,15 +865,8 @@ func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uin
 
 	switch command {
 	case types.SMB2SessionSetup:
-		// Track newly created sessions on successful SESSION_SETUP completion.
-		if status == types.StatusSuccess {
-			sessionIDToTrack := ctxSessionID
-			if sessionIDToTrack == 0 {
-				sessionIDToTrack = reqSessionID
-			}
-			if sessionIDToTrack != 0 {
-				tracker.TrackSession(sessionIDToTrack)
-			}
+		if status == types.StatusSuccess && reqSessionID == 0 && ctxSessionID != 0 {
+			tracker.TrackSession(ctxSessionID)
 		}
 	case types.SMB2Logoff:
 		// Untrack sessions on LOGOFF (they are already cleaned up by the handler)

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -577,7 +577,7 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWri
 				return writeErr
 			}
 			if sess.ShouldSign() {
-				sess.SignMessage(smbPayload)
+				signOutgoingWithChannel(sess, connInfo.ConnID, smbPayload)
 				// Sync signature back so callers that re-encode the header see
 				// the real signature. Flag-level mutations from signing (setting
 				// SMB2_FLAGS_SIGNED) exist only on smbPayload — the preauth chain

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -579,7 +579,7 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWri
 				return writeErr
 			}
 			if sess.ShouldSign() {
-				signOutgoingWithChannel(sess, connInfo.ConnID, smbPayload)
+				sess.SignMessageOnChannel(connInfo.ConnID, smbPayload)
 				// Sync signature back so callers that re-encode the header see
 				// the real signature. Flag-level mutations from signing (setting
 				// SMB2_FLAGS_SIGNED) exist only on smbPayload — the preauth chain

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -541,20 +541,18 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWri
 	if hdr.SessionID != 0 {
 		sess, ok := connInfo.Handler.GetSession(hdr.SessionID)
 		if ok {
-			// Per MS-SMB2 3.3.5.5.3: the initial SESSION_SETUP response that
-			// establishes a NEW session MUST NOT be encrypted. The client has not
-			// yet derived encryption keys at this point — it needs the unencrypted
-			// response to complete key derivation. Only sign the response instead.
-			//
-			// For re-authentication (SESSION_SETUP on an existing session), the
-			// client already has encryption keys, so the response MUST be encrypted.
-			// We distinguish the two cases via sess.NewlyCreated, which is true only
-			// for sessions just created during this SESSION_SETUP exchange.
-			isNewSessionSetup := hdr.Command == types.SMB2SessionSetup && hdr.Status == types.StatusSuccess && sess.NewlyCreated
-			if isNewSessionSetup {
+			// Per MS-SMB2 3.3.5.5.3 and 3.3.5.5.2: SESSION_SETUP SUCCESS
+			// responses MUST be signed and MUST NOT be encrypted, in all three
+			// cases: new session (client has no encryption keys yet), re-auth,
+			// and channel bind (client must validate Channel.SigningKey from the
+			// plaintext response before treating the channel as bound). Windows
+			// clients reject an encrypted bind SUCCESS with
+			// STATUS_INVALID_PARAMETER — see issue #361.
+			isSessionSetupSuccess := hdr.Command == types.SMB2SessionSetup && hdr.Status == types.StatusSuccess
+			if isSessionSetupSuccess && sess.NewlyCreated {
 				sess.NewlyCreated = false // Clear so subsequent messages get encrypted
 			}
-			if sess.ShouldEncrypt() && connInfo.EncryptionMiddleware != nil && !isNewSessionSetup {
+			if sess.ShouldEncrypt() && connInfo.EncryptionMiddleware != nil && !isSessionSetupSuccess {
 				// Run pre-write hook on the PLAINTEXT bytes — the preauth chain
 				// hashes plaintext on both sides, not the encrypted wire form.
 				if preWrite != nil {

--- a/internal/adapter/smb/session/channel.go
+++ b/internal/adapter/smb/session/channel.go
@@ -97,4 +97,3 @@ func (s *Session) ListChannels() []*Channel {
 	})
 	return out
 }
-

--- a/internal/adapter/smb/session/channel.go
+++ b/internal/adapter/smb/session/channel.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// Channel represents a TCP connection bound to an SMB session via
+// SESSION_SETUP with SMB2_SESSION_FLAG_BINDING (MS-SMB2 §3.3.5.5.2).
+//
+// In Phase 1 only bound (secondary) connections register a Channel. The
+// original connection that established the session continues to use the
+// session-level Signer via the dispatch fallback. This keeps the change
+// surface-area narrow; a future refactor may register every connection as a
+// Channel and remove the fallback.
+//
+// All channels on a session share the session key and session identity, but
+// each bound channel derives its own signing key from the session key via the
+// dialect-specific KDF (MS-SMB2 §3.1.4.2). The per-channel signing key is used
+// to verify signatures on requests arriving on that connection.
+//
+// Samba reference: smbXsrv_channel_global0 in source3/smbd/smbXsrv_session.c —
+// each entry holds a signing_algo, encryption_cipher, and signing_key that
+// overrides the session-level defaults for that connection.
+type Channel struct {
+	// ConnID is a stable per-connection identifier assigned when the TCP
+	// connection is accepted. Used to look up the channel when verifying a
+	// request's signature.
+	ConnID uint64
+
+	// RemoteAddr is the client address for this channel's TCP connection.
+	RemoteAddr string
+
+	// Dialect is the SMB2 dialect negotiated on this channel. Per §3.3.5.5.2
+	// all channels on a session must share the same dialect.
+	Dialect types.Dialect
+
+	// SigningAlgo is the negotiated signing algorithm ID for this channel.
+	SigningAlgo uint16
+
+	// SigningKey is the 16-byte per-channel signing key derived from the
+	// session key. See DeriveChannelSigningKey.
+	SigningKey []byte
+
+	// Signer is the signing/verification implementation built from SigningKey.
+	Signer signing.Signer
+
+	// PreauthHash is the per-channel preauth integrity hash (SHA-512, 64 bytes)
+	// carried forward from the NEGOTIATE response on this connection plus the
+	// binding SESSION_SETUP messages. Only meaningful for SMB 3.1.1; unused for
+	// 3.0 / 3.0.2.
+	PreauthHash [64]byte
+
+	// BoundAt is the time the channel was registered on the session.
+	BoundAt time.Time
+}
+
+// AddChannel registers a channel on the session, keyed by ConnID. A subsequent
+// AddChannel with the same ConnID replaces the prior entry — callers must not
+// rely on deduplication since MS-SMB2 explicitly rejects binding an already-
+// bound connection at the handler layer (§3.3.5.5.2).
+func (s *Session) AddChannel(c *Channel) {
+	if c == nil {
+		return
+	}
+	if c.BoundAt.IsZero() {
+		c.BoundAt = time.Now()
+	}
+	s.channels.Store(c.ConnID, c)
+}
+
+// GetChannel returns the channel for the given ConnID, or nil if none is
+// registered. Safe for concurrent use.
+func (s *Session) GetChannel(connID uint64) *Channel {
+	v, ok := s.channels.Load(connID)
+	if !ok {
+		return nil
+	}
+	return v.(*Channel)
+}
+
+// RemoveChannel unregisters a channel. Called when the TCP connection closes.
+func (s *Session) RemoveChannel(connID uint64) {
+	s.channels.Delete(connID)
+}
+
+// ListChannels returns a snapshot of all channels currently bound to the
+// session. Used for break-notification fan-out in the lease/oplock layer.
+// Order is not guaranteed.
+func (s *Session) ListChannels() []*Channel {
+	var out []*Channel
+	s.channels.Range(func(_, v any) bool {
+		out = append(out, v.(*Channel))
+		return true
+	})
+	return out
+}
+

--- a/internal/adapter/smb/session/channel_keys_test.go
+++ b/internal/adapter/smb/session/channel_keys_test.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// TestDeriveChannelSigningKey_MatchesDeriveAllKeys_SMB30 verifies that the
+// channel-signing-key helper produces the same bytes as the whole-session
+// DeriveAllKeys path for SMB 3.0 (where there is no preauth hash). This is
+// effectively a contract check: a bound channel using the session's preauth
+// hash must land on the same signing key DeriveAllKeys would derive.
+func TestDeriveChannelSigningKey_MatchesDeriveAllKeys_SMB30(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x42}, 16)
+
+	cs := DeriveAllKeys(sessionKey, types.Dialect0300, [64]byte{}, 0, 0)
+
+	channelKey, err := DeriveChannelSigningKey(sessionKey, types.Dialect0300, [64]byte{})
+	if err != nil {
+		t.Fatalf("DeriveChannelSigningKey: %v", err)
+	}
+	if !bytes.Equal(channelKey, cs.SigningKey) {
+		t.Fatalf("channel key differs from session key for same inputs:\n channel=%x\n session=%x", channelKey, cs.SigningKey)
+	}
+}
+
+// TestDeriveChannelSigningKey_DistinctForDifferentPreauth verifies that
+// SMB 3.1.1 produces a different signing key for different preauth hashes.
+// This is the core property that makes per-channel signing meaningful — a
+// bound channel's preauth hash diverges from the primary's after NEGOTIATE.
+func TestDeriveChannelSigningKey_DistinctForDifferentPreauth(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x10}, 16)
+	var primaryHash, boundHash [64]byte
+	for i := range primaryHash {
+		primaryHash[i] = byte(i)
+		boundHash[i] = byte(255 - i)
+	}
+
+	primaryKey, err := DeriveChannelSigningKey(sessionKey, types.Dialect0311, primaryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundKey, err := DeriveChannelSigningKey(sessionKey, types.Dialect0311, boundHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(primaryKey, boundKey) {
+		t.Fatalf("signing keys collide for different preauth hashes; primary=bound=%x", primaryKey)
+	}
+	if len(boundKey) != 16 {
+		t.Fatalf("signing key length=%d, want 16", len(boundKey))
+	}
+}
+
+func TestDeriveChannelSigningKey_RejectsSMB2x(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	if _, err := DeriveChannelSigningKey(sessionKey, types.Dialect0210, [64]byte{}); err == nil {
+		t.Fatal("expected error for SMB 2.1 dialect, got nil")
+	}
+	if _, err := DeriveChannelSigningKey(sessionKey, types.Dialect0202, [64]byte{}); err == nil {
+		t.Fatal("expected error for SMB 2.0.2 dialect, got nil")
+	}
+}
+
+func TestDeriveChannelSigningKey_RejectsEmptySessionKey(t *testing.T) {
+	if _, err := DeriveChannelSigningKey(nil, types.Dialect0311, [64]byte{}); err == nil {
+		t.Fatal("expected error for empty session key, got nil")
+	}
+}

--- a/internal/adapter/smb/session/channel_test.go
+++ b/internal/adapter/smb/session/channel_test.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+func TestSession_AddGetRemoveChannel(t *testing.T) {
+	s := NewSession(42, "127.0.0.1:1234", false, "alice", "WORKGROUP")
+
+	if got := s.GetChannel(100); got != nil {
+		t.Fatalf("GetChannel on empty session returned %+v, want nil", got)
+	}
+
+	ch := &Channel{
+		ConnID:     100,
+		RemoteAddr: "10.0.0.1:4455",
+		Dialect:    types.Dialect0311,
+		SigningKey: make([]byte, 16),
+	}
+	s.AddChannel(ch)
+
+	got := s.GetChannel(100)
+	if got == nil {
+		t.Fatal("GetChannel after AddChannel returned nil")
+	}
+	if got.ConnID != 100 || got.RemoteAddr != "10.0.0.1:4455" {
+		t.Fatalf("channel fields not preserved: %+v", got)
+	}
+	if got.BoundAt.IsZero() {
+		t.Fatal("AddChannel did not stamp BoundAt when zero")
+	}
+
+	s.RemoveChannel(100)
+	if got := s.GetChannel(100); got != nil {
+		t.Fatalf("GetChannel after RemoveChannel returned %+v, want nil", got)
+	}
+}
+
+func TestSession_AddChannel_PreservesExplicitBoundAt(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	when := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	s.AddChannel(&Channel{ConnID: 1, BoundAt: when})
+
+	got := s.GetChannel(1)
+	if !got.BoundAt.Equal(when) {
+		t.Fatalf("BoundAt=%v, want %v (AddChannel should not overwrite explicit value)", got.BoundAt, when)
+	}
+}
+
+func TestSession_AddChannel_NilIsNoop(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	s.AddChannel(nil) // must not panic
+	if got := s.ListChannels(); len(got) != 0 {
+		t.Fatalf("ListChannels after nil AddChannel = %d, want 0", len(got))
+	}
+}
+
+func TestSession_ListChannels(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	for _, id := range []uint64{10, 20, 30} {
+		s.AddChannel(&Channel{ConnID: id})
+	}
+
+	got := s.ListChannels()
+	if len(got) != 3 {
+		t.Fatalf("ListChannels len=%d, want 3", len(got))
+	}
+
+	seen := make(map[uint64]bool)
+	for _, c := range got {
+		seen[c.ConnID] = true
+	}
+	for _, id := range []uint64{10, 20, 30} {
+		if !seen[id] {
+			t.Fatalf("ListChannels missing ConnID=%d; got=%+v", id, got)
+		}
+	}
+}
+
+func TestSession_AddChannel_ReplaceSameConnID(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	s.AddChannel(&Channel{ConnID: 7, RemoteAddr: "first"})
+	s.AddChannel(&Channel{ConnID: 7, RemoteAddr: "second"})
+
+	got := s.GetChannel(7)
+	if got == nil || got.RemoteAddr != "second" {
+		t.Fatalf("second AddChannel did not replace first: got=%+v", got)
+	}
+	if l := s.ListChannels(); len(l) != 1 {
+		t.Fatalf("ListChannels len=%d, want 1 after same-ConnID replacement", len(l))
+	}
+}

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -24,12 +24,13 @@ type SessionCryptoState struct {
 	Signer signing.Signer
 
 	// SessionKey is the raw session key from NTLM/Kerberos authentication,
-	// before any SP800-108 KDF derivation. Retained on the session so that
-	// SMB2_SESSION_FLAG_BINDING requests on a later connection can derive
-	// per-channel signing keys from the same input (MS-SMB2 §3.1.4.2,
-	// §3.3.5.5.2). For SMB 2.x this is the same material as SigningKey, but
-	// for 3.x SigningKey is a KDF output — only SessionKey is the raw input
-	// needed for per-channel derivation. Zeroed by Destroy.
+	// before any SP800-108 KDF derivation. For SMB 2.x this is the same
+	// underlying material as SigningKey; for 3.x SigningKey is a KDF output
+	// derived from this raw input. Zeroed by Destroy.
+	//
+	// Per MS-SMB2 §3.3.5.5.2, channel signing keys for a bound connection
+	// are derived from the session key produced by the binding handshake's
+	// own authentication exchange, not this field — see completeSessionBind.
 	SessionKey []byte
 
 	// SigningKey is the signing key bytes actually used by Signer.
@@ -130,9 +131,12 @@ func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byt
 // DeriveChannelSigningKey derives a per-channel signing key for a connection
 // bound via SMB2_SESSION_FLAG_BINDING (MS-SMB2 §3.1.4.2 and §3.3.5.5.2).
 //
-// The input session key is the session-wide key established by the original
-// authentication. The output is a channel-specific 16-byte signing key used
-// to verify signatures on requests arriving over the bound connection.
+// The input sessionKey is the session key produced by the authentication
+// exchange associated with the channel being established — for a bound
+// channel this is the binding handshake's own session key, not the original
+// session key (MS-SMB2 §3.3.5.5.2; Samba smb2_sesssetup.c:633-643). The
+// output is a channel-specific 16-byte signing key used to verify
+// signatures on requests arriving over the bound connection.
 //
 // Label/context rules (matching Samba libcli/smb/smb2_signing.c:38-84):
 //   - SMB 3.1.1 (Dialect0311): label "SMBSigningKey\0", context = the

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -23,7 +23,16 @@ type SessionCryptoState struct {
 	// For 2.x: HMACSigner, for 3.0+: CMACSigner or GMACSigner.
 	Signer signing.Signer
 
-	// SigningKey is the raw signing key bytes.
+	// SessionKey is the raw session key from NTLM/Kerberos authentication,
+	// before any SP800-108 KDF derivation. Retained on the session so that
+	// SMB2_SESSION_FLAG_BINDING requests on a later connection can derive
+	// per-channel signing keys from the same input (MS-SMB2 §3.1.4.2,
+	// §3.3.5.5.2). For SMB 2.x this is the same material as SigningKey, but
+	// for 3.x SigningKey is a KDF output — only SessionKey is the raw input
+	// needed for per-channel derivation. Zeroed by Destroy.
+	SessionKey []byte
+
+	// SigningKey is the signing key bytes actually used by Signer.
 	// For 2.x: copy of the raw session key (signer handles normalization).
 	// For 3.x: KDF-derived 16-byte signing key.
 	SigningKey []byte
@@ -84,6 +93,8 @@ type SessionCryptoState struct {
 //   - signingAlgId: the negotiated signing algorithm ID
 func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byte, cipherId uint16, signingAlgId uint16) *SessionCryptoState {
 	cs := &SessionCryptoState{}
+	cs.SessionKey = make([]byte, len(sessionKey))
+	copy(cs.SessionKey, sessionKey)
 
 	if dialect < types.Dialect0300 {
 		// SMB 2.x: direct HMAC-SHA256 from session key, no KDF
@@ -179,6 +190,7 @@ func (cs *SessionCryptoState) Destroy() {
 	if cs == nil {
 		return
 	}
+	clear(cs.SessionKey)
 	clear(cs.SigningKey)
 	clear(cs.EncryptionKey)
 	clear(cs.DecryptionKey)

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -116,6 +116,32 @@ func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byt
 	return cs
 }
 
+// DeriveChannelSigningKey derives a per-channel signing key for a connection
+// bound via SMB2_SESSION_FLAG_BINDING (MS-SMB2 §3.1.4.2 and §3.3.5.5.2).
+//
+// The input session key is the session-wide key established by the original
+// authentication. The output is a channel-specific 16-byte signing key used
+// to verify signatures on requests arriving over the bound connection.
+//
+// Label/context rules (matching Samba libcli/smb/smb2_signing.c:38-84):
+//   - SMB 3.1.1 (Dialect0311): label "SMBSigningKey\0", context = the
+//     channel's own preauth integrity hash (64 bytes).
+//   - SMB 3.0 / 3.0.2: label "SMB2AESCMAC\0", context = "SmbSign\0" (the
+//     preauth hash is ignored — SMB 3.0 has no preauth).
+//
+// Returns an error if the dialect is SMB 2.x (binding requires 3.0+) or the
+// session key is empty.
+func DeriveChannelSigningKey(sessionKey []byte, dialect types.Dialect, preauthHash [64]byte) ([]byte, error) {
+	if dialect < types.Dialect0300 {
+		return nil, fmt.Errorf("session binding requires SMB 3.0+, got dialect 0x%04x", uint16(dialect))
+	}
+	if len(sessionKey) == 0 {
+		return nil, errors.New("empty session key")
+	}
+	label, context := kdf.LabelAndContext(kdf.SigningKeyPurpose, dialect, preauthHash)
+	return kdf.DeriveKey(sessionKey, label, context, 128), nil
+}
+
 // CreateEncryptors creates Encryptor and Decryptor instances from the derived keys.
 //
 // Key direction (from CLIENT perspective):

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -105,13 +105,13 @@ type Session struct {
 	// mu protects credit mutation operations
 	mu sync.Mutex
 
-	// channels holds every TCP connection bound to this session, keyed by
-	// ConnID. The primary connection is registered when the session is
-	// created (see NewSession / NewSessionWithUser); additional channels are
-	// added by SESSION_SETUP with SMB2_SESSION_FLAG_BINDING per MS-SMB2
-	// §3.3.5.5.2. All channels share the session key but each derives its
-	// own signing key. Access via AddChannel / GetChannel / RemoveChannel /
-	// ListChannels (channel.go).
+	// channels holds TCP connections explicitly bound to this session, keyed
+	// by ConnID. In Phase 1 only secondary (bound) connections are
+	// registered via SESSION_SETUP with SMB2_SESSION_FLAG_BINDING per
+	// MS-SMB2 §3.3.5.5.2; the original connection continues to use the
+	// session-level Signer via the dispatch fallback. All channels share
+	// the session key but each derives its own signing key. Access via
+	// AddChannel / GetChannel / RemoveChannel / ListChannels (channel.go).
 	channels sync.Map
 }
 

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -348,6 +348,18 @@ func (s *Session) SignMessage(message []byte) {
 	}
 }
 
+// SignMessageOnChannel signs an outgoing SMB2 message using the per-channel
+// signer when connID is bound via SMB2 session binding (MS-SMB2 §3.3.5.5.2),
+// and the session-level signer otherwise. Safe to call when the session does
+// not have signing enabled — it becomes a no-op.
+func (s *Session) SignMessageOnChannel(connID uint64, message []byte) {
+	if ch := s.GetChannel(connID); ch != nil && ch.Signer != nil {
+		signing.SignMessage(ch.Signer, message)
+		return
+	}
+	s.SignMessage(message)
+}
+
 // VerifyMessage verifies the signature of an SMB2 message.
 // Returns true if the signature is valid or if signing is not enabled.
 func (s *Session) VerifyMessage(message []byte) bool {
@@ -355,4 +367,14 @@ func (s *Session) VerifyMessage(message []byte) bool {
 		return true
 	}
 	return s.CryptoState.Signer.Verify(message)
+}
+
+// VerifyMessageOnChannel verifies an incoming message's signature against the
+// per-channel signing key if connID is bound via SMB2 session binding
+// (MS-SMB2 §3.3.5.5.2); otherwise falls back to the session-level key.
+func (s *Session) VerifyMessageOnChannel(connID uint64, message []byte) bool {
+	if ch := s.GetChannel(connID); ch != nil && ch.Signer != nil {
+		return ch.Signer.Verify(message)
+	}
+	return s.VerifyMessage(message)
 }

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -104,6 +104,15 @@ type Session struct {
 
 	// mu protects credit mutation operations
 	mu sync.Mutex
+
+	// channels holds every TCP connection bound to this session, keyed by
+	// ConnID. The primary connection is registered when the session is
+	// created (see NewSession / NewSessionWithUser); additional channels are
+	// added by SESSION_SETUP with SMB2_SESSION_FLAG_BINDING per MS-SMB2
+	// §3.3.5.5.2. All channels share the session key but each derives its
+	// own signing key. Access via AddChannel / GetChannel / RemoveChannel /
+	// ListChannels (channel.go).
+	channels sync.Map
 }
 
 // Credits tracks credit accounting for a session.

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -84,6 +84,13 @@ type SMBHandlerContext struct {
 	// ClientAddr is the remote address of the client
 	ClientAddr string
 
+	// ConnID identifies the TCP connection carrying this request. Used by
+	// SMB2 multi-channel session binding (MS-SMB2 §3.3.5.5.2) to key the
+	// Channel registry on a bound session and to route request-signature
+	// verification through the channel's signing key. Populated from
+	// ConnInfo.ConnID by prepareDispatch.
+	ConnID uint64
+
 	// SessionID from the request (0 before SESSION_SETUP completes)
 	SessionID uint64
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -194,6 +194,13 @@ type PendingAuth struct {
 	ServerChallenge [8]byte // Random challenge sent in Type 2 message
 	UsedSPNEGO      bool    // Whether client used SPNEGO wrapping
 	IsReauth        bool    // True when re-authenticating an existing session
+	// IsBinding is true when this pending auth is driving an SMB2 session
+	// bind (SESSION_SETUP with SMB2_SESSION_FLAG_BINDING). In that case
+	// BindingSessionID holds the existing session the client is binding to
+	// and auth completion must register the connection as an additional
+	// channel rather than creating a new session. MS-SMB2 §3.3.5.5.2.
+	IsBinding        bool
+	BindingSessionID uint64
 	// MechListBytes: DER-encoded SEQUENCE OF OID from the NegTokenInit's
 	// mechTypes field, needed to compute the SPNEGO mechListMIC in the
 	// final accept-completed response (MS-NLMP 3.4.5.2 + 2.2.2.9.1).

--- a/internal/adapter/smb/v2/handlers/negotiate.go
+++ b/internal/adapter/smb/v2/handlers/negotiate.go
@@ -306,11 +306,11 @@ func (h *Handler) buildCapabilities(dialect types.Dialect) types.Capabilities {
 		return types.CapLeasing | types.CapLargeMTU
 
 	case types.Dialect0300, types.Dialect0302, types.Dialect0311:
-		// SMB 3.x: CapLeasing | CapLargeMTU | [CapDirectoryLeasing] | [CapEncryption]
+		// SMB 3.x: CapLeasing | CapLargeMTU | CapMultiChannel | [CapDirectoryLeasing] | [CapEncryption]
 		// While 3.1.1 uses negotiate contexts for cipher selection, Windows servers
 		// still advertise GLOBAL_CAP_ENCRYPTION in the capabilities field when
 		// encryption is supported. WPTS tests expect this flag to be set.
-		caps := types.CapLeasing | types.CapLargeMTU
+		caps := types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel
 		if h.DirectoryLeasingEnabled {
 			caps |= types.CapDirectoryLeasing
 		}

--- a/internal/adapter/smb/v2/handlers/negotiate_test.go
+++ b/internal/adapter/smb/v2/handlers/negotiate_test.go
@@ -607,9 +607,9 @@ func TestNegotiate_SMB300(t *testing.T) {
 		t.Errorf("DialectRevision = 0x%04x, expected 0x0300", dialectRevision)
 	}
 
-	// SMB 3.0 should advertise CapLeasing | CapLargeMTU | CapDirectoryLeasing
+	// SMB 3.0 should advertise CapLeasing | CapLargeMTU | CapMultiChannel | CapDirectoryLeasing
 	caps := binary.LittleEndian.Uint32(result.Data[24:28])
-	expectedCaps := uint32(types.CapLeasing | types.CapLargeMTU | types.CapDirectoryLeasing)
+	expectedCaps := uint32(types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel | types.CapDirectoryLeasing)
 	if caps != expectedCaps {
 		t.Errorf("Capabilities = 0x%08x, expected 0x%08x", caps, expectedCaps)
 	}
@@ -820,14 +820,14 @@ func TestNegotiate_CapabilityGating(t *testing.T) {
 			name:            "SMB300_WithDirLeasing",
 			dialects:        []uint16{0x0300},
 			expectedDialect: 0x0300,
-			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapDirectoryLeasing,
+			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel | types.CapDirectoryLeasing,
 			dirLeasing:      true,
 		},
 		{
 			name:            "SMB300_WithEncryption",
 			dialects:        []uint16{0x0300},
 			expectedDialect: 0x0300,
-			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapDirectoryLeasing | types.CapEncryption,
+			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel | types.CapDirectoryLeasing | types.CapEncryption,
 			encryption:      true,
 			dirLeasing:      true,
 		},
@@ -835,7 +835,7 @@ func TestNegotiate_CapabilityGating(t *testing.T) {
 			name:            "SMB302_WithEncryption",
 			dialects:        []uint16{0x0302},
 			expectedDialect: 0x0302,
-			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapDirectoryLeasing | types.CapEncryption,
+			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel | types.CapDirectoryLeasing | types.CapEncryption,
 			encryption:      true,
 			dirLeasing:      true,
 		},
@@ -843,7 +843,7 @@ func TestNegotiate_CapabilityGating(t *testing.T) {
 			name:            "SMB311_NoCapsEncryption",
 			dialects:        []uint16{0x0311},
 			expectedDialect: 0x0311,
-			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapDirectoryLeasing,
+			expectedCaps:    types.CapLeasing | types.CapLargeMTU | types.CapMultiChannel | types.CapDirectoryLeasing,
 			dirLeasing:      true,
 		},
 	}

--- a/internal/adapter/smb/v2/handlers/result.go
+++ b/internal/adapter/smb/v2/handlers/result.go
@@ -78,6 +78,13 @@ type HandlerResult struct {
 	// responses (STATUS_PENDING) and async completion responses.
 	// [MS-SMB2] Section 2.2.1.2
 	AsyncId uint64
+
+	// IsBinding is true when this result completes an SMB2 session bind
+	// (MS-SMB2 §3.3.5.5.2). The response dispatch layer must NOT treat a
+	// successful bind response as session-creation on the bound connection:
+	// the session lives on a different connection, and tracking it here
+	// would cause this connection's close to delete the original session.
+	IsBinding bool
 }
 
 // NewResult creates a new handler result with the given status and data.

--- a/internal/adapter/smb/v2/handlers/session_bind_test.go
+++ b/internal/adapter/smb/v2/handlers/session_bind_test.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// buildBindRequestBody builds a SESSION_SETUP request body with the binding
+// flag set. Otherwise identical to buildSessionSetupRequestBody.
+func buildBindRequestBody() []byte {
+	body := buildSessionSetupRequestBody(nil)
+	body[sessionSetupFlagsOffset] = SMB2_SESSION_FLAG_BINDING
+	// Zero PreviousSessionID explicitly so parsing matches the test scenario.
+	binary.LittleEndian.PutUint64(body[16:24], 0)
+	return body
+}
+
+func TestSessionSetup_BindRejectsZeroSessionID(t *testing.T) {
+	h := NewHandler()
+	ctx := newTestContext(0) // SessionID=0
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status=0x%x, want StatusInvalidParameter (0x%x)", result.Status, types.StatusInvalidParameter)
+	}
+}
+
+func TestSessionSetup_BindRejectsMissingSession(t *testing.T) {
+	h := NewHandler()
+	ctx := newTestContext(99999) // session does not exist
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusUserSessionDeleted {
+		t.Fatalf("status=0x%x, want StatusUserSessionDeleted (0x%x)", result.Status, types.StatusUserSessionDeleted)
+	}
+}
+
+func TestSessionSetup_BindRejectsDialectBelow300(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0210} // SMB 2.1
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusRequestNotAccepted {
+		t.Fatalf("status=0x%x, want StatusRequestNotAccepted (0x%x)", result.Status, types.StatusRequestNotAccepted)
+	}
+}
+
+func TestSessionSetup_BindRejectsGuestSession(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", true, "", "") // guest
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusNotSupported {
+		t.Fatalf("status=0x%x, want StatusNotSupported (0x%x)", result.Status, types.StatusNotSupported)
+	}
+}
+
+func TestSessionSetup_BindRejectsNullSession(t *testing.T) {
+	h := NewHandler()
+	// Create a null session: no username, not guest.
+	sess := h.CreateSession("127.0.0.1:1", false, "", "")
+	if !sess.IsNull {
+		t.Fatalf("expected sess.IsNull=true")
+	}
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusNotSupported {
+		t.Fatalf("status=0x%x, want StatusNotSupported (0x%x)", result.Status, types.StatusNotSupported)
+	}
+}
+
+// TestSessionSetup_Bind_InvalidWithoutNTLM verifies that a bind request on
+// any SMB 3.x dialect reaches handleNTLMNegotiateBinding (past the dialect
+// gate) and rejects with StatusInvalidParameter when no NTLM TYPE_1 token
+// is present. Covers both 3.0 and 3.1.1 since they share the code path
+// after the dialect branch; a full NTLM handshake test requires user-store
+// setup and is covered by the smbtorture flow.
+func TestSessionSetup_Bind_InvalidWithoutNTLM(t *testing.T) {
+	for _, dialect := range []types.Dialect{types.Dialect0300, types.Dialect0302, types.Dialect0311} {
+		t.Run(dialect.String(), func(t *testing.T) {
+			h := NewHandler()
+			sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+			ctx := newTestContext(sess.SessionID)
+			ctx.ConnCryptoState = &mockCryptoState{dialect: dialect}
+
+			result, err := h.SessionSetup(ctx, buildBindRequestBody())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Status != types.StatusInvalidParameter {
+				t.Fatalf("status=0x%x, want StatusInvalidParameter (no NTLM token in bind req)", result.Status)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
 	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -28,6 +29,12 @@ const (
 	sessionSetupFixedSize               = 24 // Fixed part size (without buffer)
 	sessionSetupMinSize                 = 25 // Minimum request size (per spec)
 )
+
+// SMB2_SESSION_FLAG_BINDING is set in SESSION_SETUP request Flags byte to
+// indicate the client is binding a new TCP channel to an existing session.
+// Server-side handling per MS-SMB2 §3.3.5.5.2. Request-only; the success
+// response does not echo this flag.
+const SMB2_SESSION_FLAG_BINDING = 0x01
 
 // SESSION_SETUP response structure offsets [MS-SMB2] 2.2.6
 const (
@@ -141,7 +148,16 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	logger.Debug("SESSION_SETUP request",
 		"securityBufferLength", len(req.SecurityBuffer),
 		"previousSessionID", req.PreviousSessionID,
-		"contextSessionID", ctx.SessionID)
+		"contextSessionID", ctx.SessionID,
+		"flags", fmt.Sprintf("0x%02x", req.Flags))
+
+	// Session binding (MS-SMB2 §3.3.5.5.2). A binding request must be
+	// validated before the pending-auth / re-auth branches below — an
+	// otherwise-valid SessionID with SMB2_SESSION_FLAG_BINDING should be
+	// routed as a bind, not as a re-auth of the existing session.
+	if req.Flags&SMB2_SESSION_FLAG_BINDING != 0 {
+		return h.handleSessionBind(ctx, req)
+	}
 
 	// Check if this is a continuation of pending authentication
 	if ctx.SessionID != 0 {
@@ -287,6 +303,309 @@ func findNTLMSSP(data []byte) []byte {
 		return data[i:]
 	}
 	return nil
+}
+
+// handleSessionBind validates and routes an SMB2 SESSION_SETUP request with
+// SMB2_SESSION_FLAG_BINDING — the client is attempting to bind a new TCP
+// connection to an existing session as an additional channel (MS-SMB2
+// §3.3.5.5.2).
+//
+// Validation order mirrors Samba source3/smbd/smb2_sesssetup.c:715-867. Each
+// check fails fast with the spec-mandated NT_STATUS:
+//
+//  1. ctx.SessionID != 0                         → STATUS_INVALID_PARAMETER
+//  2. session exists                             → STATUS_USER_SESSION_DELETED
+//  3. connection dialect ≥ SMB 3.0               → STATUS_REQUEST_NOT_ACCEPTED
+//  4. session dialect matches connection dialect → STATUS_INVALID_PARAMETER
+//  5. session is not guest / anonymous           → STATUS_NOT_SUPPORTED
+//
+// On success the auth-completion branch (commit 4 of #361 Phase 1) derives a
+// per-channel signing key from the existing session key and registers the
+// connection on session.Channels. This commit lands only the validation
+// scaffolding: if every check passes, the handler currently returns
+// STATUS_NOT_SUPPORTED with a log marker — the auth-completion routing lands
+// in a follow-up commit within this branch so that partial work does not
+// produce a silently-wrong wire response.
+func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupRequest) (*HandlerResult, error) {
+	// 1. SessionID must be non-zero (can't bind to "no session").
+	if ctx.SessionID == 0 {
+		logger.Debug("SESSION_SETUP bind: SessionID is zero")
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// 2. Session must exist.
+	sess, ok := h.GetSession(ctx.SessionID)
+	if !ok {
+		logger.Debug("SESSION_SETUP bind: no such session", "sessionID", ctx.SessionID)
+		return NewErrorResult(types.StatusUserSessionDeleted), nil
+	}
+
+	// 3. Connection dialect must be SMB 3.0+.
+	var connDialect types.Dialect
+	if ctx.ConnCryptoState != nil {
+		connDialect = ctx.ConnCryptoState.GetDialect()
+	}
+	if connDialect < types.Dialect0300 {
+		logger.Info("SESSION_SETUP bind rejected: dialect below SMB 3.0",
+			"sessionID", ctx.SessionID,
+			"dialect", fmt.Sprintf("0x%04x", uint16(connDialect)))
+		return NewErrorResult(types.StatusRequestNotAccepted), nil
+	}
+
+	// 4. Per §3.3.5.5.2 bullet: the session's dialect MUST equal the
+	// connection's. DittoFS does not yet record per-session dialect; today
+	// every live session is on the same dialect as the connection that
+	// established it. Cross-dialect sessions are impossible with single-
+	// connection-per-session, so this check becomes meaningful only once
+	// a session outlives its first connection (Phase 2+). Stubbed as pass
+	// with a comment to revisit when Session.Dialect lands.
+	_ = sess // intentional: full dialect-match enforcement deferred
+
+	// 5. Session must not be guest / anonymous. Binding a channel onto an
+	// unauthenticated session leaks into NOT_SUPPORTED territory per spec.
+	if sess.IsGuest || sess.IsNull {
+		logger.Info("SESSION_SETUP bind rejected: session is guest/anonymous",
+			"sessionID", ctx.SessionID,
+			"isGuest", sess.IsGuest,
+			"isNull", sess.IsNull)
+		return NewErrorResult(types.StatusNotSupported), nil
+	}
+
+	// If a binding PendingAuth already exists for this session, this is
+	// the TYPE_3 of an in-flight bind — route to completeNTLMAuth, which
+	// branches on pending.IsBinding and calls completeSessionBind.
+	if pending, ok := h.GetPendingAuth(ctx.SessionID); ok && pending.IsBinding {
+		return h.completeNTLMAuth(ctx, req.SecurityBuffer)
+	}
+
+	// First binding request (TYPE_1). For SMB 3.1.1, initialize a per-
+	// channel preauth integrity hash chain on THIS connection keyed by
+	// the bound SessionID (MS-SMB2 §3.3.5.5.2 + §3.1.4.2). The
+	// ConnectionCryptoState holding this entry is per-TCP-connection, so
+	// using the real SessionID does not collide with the primary
+	// connection's (already-deleted) entry. The SESSION_SETUP before/after
+	// hooks (sessionPreauthBeforeHook / sessionPreauthAfterHook) will then
+	// chain the TYPE_2 response and TYPE_3 request bytes into this same
+	// entry; completeSessionBind reads the finalized hash and derives the
+	// per-channel signing key with it.
+	//
+	// For 3.0 / 3.0.2 the preauth hash is unused by DeriveChannelSigningKey
+	// (fixed "SmbSign" KDF context), so the init is a no-op cost that keeps
+	// the two paths symmetric.
+	if connDialect >= types.Dialect0300 && ctx.ConnCryptoState != nil {
+		ctx.ConnCryptoState.InitSessionPreauthHash(ctx.SessionID, ctx.RawRequest)
+	}
+
+	return h.handleNTLMNegotiateBinding(ctx, req)
+}
+
+// handleNTLMNegotiateBinding initiates an NTLM handshake for a session bind
+// (SMB2_SESSION_FLAG_BINDING). Unlike handleNTLMNegotiate this does NOT
+// classify the request as re-authentication — the existing session's
+// identity and keys are retained. On success it returns an NTLM TYPE_2
+// CHALLENGE with STATUS_MORE_PROCESSING_REQUIRED; the client's TYPE_3 will
+// be routed to completeNTLMAuth via the normal pending-auth branch.
+func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *SessionSetupRequest) (*HandlerResult, error) {
+	// Extract NTLM token (unwrap SPNEGO if needed). The TYPE_1 must be
+	// present for a binding request; empty security buffer is invalid.
+	ntlmToken, usedSPNEGO, mechListBytes := extractNTLMToken(req.SecurityBuffer)
+	if !auth.IsValid(ntlmToken) || auth.GetMessageType(ntlmToken) != auth.Negotiate {
+		logger.Debug("SESSION_SETUP bind: missing or invalid NTLM NEGOTIATE token",
+			"sessionID", ctx.SessionID)
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Build TYPE_2 CHALLENGE
+	challengeMsg, serverChallenge := auth.BuildChallenge()
+
+	pending := &PendingAuth{
+		SessionID:        ctx.SessionID, // bound session's ID
+		ClientAddr:       ctx.ClientAddr,
+		CreatedAt:        time.Now(),
+		ServerChallenge:  serverChallenge,
+		UsedSPNEGO:       usedSPNEGO,
+		IsReauth:         false,
+		IsBinding:        true,
+		BindingSessionID: ctx.SessionID,
+		MechListBytes:    mechListBytes,
+	}
+	h.StorePendingAuth(pending)
+
+	logger.Debug("SESSION_SETUP bind: stored binding PendingAuth",
+		"sessionID", ctx.SessionID,
+		"serverChallenge", fmt.Sprintf("%x", serverChallenge),
+		"spnegoWrapped", usedSPNEGO)
+
+	// Wrap challenge in SPNEGO if the client did.
+	securityBuffer := challengeMsg
+	if usedSPNEGO {
+		spnegoResp, err := auth.BuildAcceptIncomplete(auth.OIDNTLMSSP, challengeMsg)
+		if err == nil {
+			securityBuffer = spnegoResp
+		}
+	}
+
+	return h.buildSessionSetupResponse(
+		types.StatusMoreProcessingRequired,
+		0, // no session flags on an interim response
+		securityBuffer,
+	), nil
+}
+
+// completeSessionBind finalizes an SMB2 session bind after NTLM auth proved
+// identity on the new connection. Instead of creating a new session (normal
+// completeNTLMAuth path), it registers a session.Channel on the existing
+// session with a per-channel signing key derived from the ORIGINAL session's
+// raw session key (MS-SMB2 §3.1.4.2 / §3.3.5.5.2, Samba source3/smbd/
+// smb2_sesssetup.c:635-643).
+//
+// Preconditions enforced by callers (handleSessionBind → handleNTLMNegotiateBinding
+// → completeNTLMAuth): pending.IsBinding = true; connection dialect is SMB 3.0
+// or 3.0.2 (3.1.1 rejected at handleSessionBind); NTLMv2 validation already
+// succeeded.
+//
+// Returns a non-nil *HandlerResult with the appropriate status. Never returns
+// nil.
+func (h *Handler) completeSessionBind(
+	ctx *SMBHandlerContext,
+	pending *PendingAuth,
+	authUser *models.User,
+	authDomain string,
+	bindSessionKey []byte,
+	bindNegFlags auth.NegotiateFlag,
+) *HandlerResult {
+	sess, ok := h.GetSession(pending.BindingSessionID)
+	if !ok {
+		// Session disappeared between TYPE_1 validation and TYPE_3 arrival.
+		logger.Info("SESSION_SETUP bind: target session vanished",
+			"sessionID", pending.BindingSessionID)
+		return NewErrorResult(types.StatusUserSessionDeleted)
+	}
+
+	// Verify the re-authenticated identity matches the existing session's
+	// user (MS-SMB2 §3.3.5.5.2: "If the user represented by
+	// Session.SecurityContext is not the same as the user authenticated by
+	// the security subsystem, the server MUST return STATUS_ACCESS_DENIED").
+	if authUser == nil || sess.User == nil || authUser.Username != sess.User.Username {
+		sessUser := "<nil>"
+		if sess.User != nil {
+			sessUser = sess.User.Username
+		}
+		authUserName := "<nil>"
+		if authUser != nil {
+			authUserName = authUser.Username
+		}
+		logger.Info("SESSION_SETUP bind: identity mismatch",
+			"sessionID", pending.BindingSessionID,
+			"sessionUser", sessUser,
+			"bindUser", authUserName,
+			"domain", authDomain)
+		return NewErrorResult(types.StatusAccessDenied)
+	}
+
+	// Per MS-SMB2 §3.3.5.5.2, Channel.SigningKey is derived from the session
+	// key produced by THIS binding's authentication exchange — not the
+	// original session's. Samba reference: smb2_sesssetup.c:633-637 passes
+	// `session_info->session_key` from the bind's own GENSEC context. NTLM
+	// derives a fresh ExportedSessionKey per handshake (KEY_EXCH randomizes
+	// it), so using sess.CryptoState.SessionKey here diverges from the
+	// client's channel key → SUCCESS signature fails → client reports
+	// NT_STATUS_INVALID_PARAMETER.
+	if len(bindSessionKey) == 0 {
+		logger.Warn("SESSION_SETUP bind: no bind session key from auth",
+			"sessionID", pending.BindingSessionID)
+		return NewErrorResult(types.StatusAccessDenied)
+	}
+
+	// Determine the new channel's dialect and signing algorithm.
+	connDialect := types.Dialect0300
+	var signingAlgId uint16
+	if ctx.ConnCryptoState != nil {
+		connDialect = ctx.ConnCryptoState.GetDialect()
+		signingAlgId = ctx.ConnCryptoState.GetSigningAlgorithmId()
+	}
+
+	// For SMB 3.1.1 the channel's preauth integrity hash is the KDF context
+	// for the per-channel signing key (MS-SMB2 §3.1.4.2). It was initialized
+	// from this connection's post-NEGOTIATE hash in handleSessionBind and
+	// chained with TYPE_2 response + TYPE_3 request bytes by the
+	// sessionPreauthBeforeHook / sessionPreauthAfterHook using this session's
+	// ID on this connection's ConnectionCryptoState.
+	//
+	// For SMB 3.0 / 3.0.2 the preauth hash is unused by DeriveChannelSigningKey
+	// (fixed "SmbSign" context) — pass zero bytes.
+	var preauthHash [64]byte
+	if connDialect == types.Dialect0311 && ctx.ConnCryptoState != nil {
+		preauthHash = ctx.ConnCryptoState.GetSessionPreauthHash(pending.BindingSessionID)
+	}
+
+	channelSigningKey, err := session.DeriveChannelSigningKey(
+		bindSessionKey,
+		connDialect,
+		preauthHash,
+	)
+	if err != nil {
+		logger.Warn("SESSION_SETUP bind: channel key derivation failed",
+			"sessionID", pending.BindingSessionID,
+			"error", err)
+		return NewErrorResult(types.StatusInvalidParameter)
+	}
+	channelSigner := signing.NewSigner(connDialect, signingAlgId, channelSigningKey)
+
+	channel := &session.Channel{
+		ConnID:      ctx.ConnID,
+		RemoteAddr:  ctx.ClientAddr,
+		Dialect:     connDialect,
+		SigningAlgo: signingAlgId,
+		SigningKey:  channelSigningKey,
+		Signer:      channelSigner,
+		PreauthHash: preauthHash,
+	}
+	sess.AddChannel(channel)
+
+	// Drop the binding preauth hash entry — it was scoped to the handshake
+	// and keeping it would corrupt any future handshake that reused the
+	// same SessionID key on this connection.
+	if ctx.ConnCryptoState != nil {
+		ctx.ConnCryptoState.DeleteSessionPreauthHash(pending.BindingSessionID)
+	}
+
+	logger.Info("SESSION_SETUP bind: channel registered",
+		"sessionID", pending.BindingSessionID,
+		"connID", channel.ConnID,
+		"dialect", fmt.Sprintf("0x%04x", uint16(connDialect)),
+		"totalChannels", len(sess.ListChannels()))
+
+	// Binding response matches existing session's encrypt-data state per
+	// §3.3.5.5. No SMB2_SESSION_FLAG_BINDING in response (request-only flag;
+	// Samba does not set it on the response either).
+	var sessionFlags uint16
+	if sess.ShouldEncrypt() {
+		sessionFlags |= types.SMB2SessionFlagEncryptData
+	}
+
+	// If the client used SPNEGO, the SUCCESS response MUST carry an
+	// accept-complete NegTokenResp (with mechListMIC when the bind's
+	// ExportedSessionKey is available). Without it the client's gensec
+	// finalization fails with NT_STATUS_INVALID_PARAMETER. Mirrors the
+	// non-binding path's buildAuthenticatedResponse.
+	var acceptToken []byte
+	if pending.UsedSPNEGO {
+		var mic []byte
+		if len(pending.MechListBytes) > 0 && len(bindSessionKey) == 16 {
+			var key [16]byte
+			copy(key[:], bindSessionKey)
+			mic = auth.ComputeNTLMSSPMechListMIC(key, pending.MechListBytes, bindNegFlags, nil)
+		}
+		tok, err := auth.BuildAcceptCompleteWithMIC(nil, nil, mic)
+		if err != nil {
+			logger.Debug("SESSION_SETUP bind: failed to build SPNEGO accept token", "error", err)
+		} else {
+			acceptToken = tok
+		}
+	}
+
+	return h.buildSessionSetupResponse(types.StatusSuccess, sessionFlags, acceptToken)
 }
 
 // handleNTLMNegotiate handles NTLM Type 1 (NEGOTIATE) message.
@@ -530,6 +849,16 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 				// Authentication successful with validated credentials
 				ctx.IsGuest = false
+
+				// Session bind (MS-SMB2 §3.3.5.5.2): the client has proved
+				// identity on a new TCP connection. Register a Channel on
+				// the existing session using a signing key derived from the
+				// session key produced by THIS binding's NTLM exchange.
+				// Samba reference: smb2_sesssetup.c:633-637 passes
+				// session_info->session_key from the bind's GENSEC context.
+				if pending.IsBinding {
+					return h.completeSessionBind(ctx, pending, user, authMsg.Domain, signingKey[:], authMsg.NegotiateFlags), nil
+				}
 
 				if pending.IsReauth {
 					// Per MS-SMB2 3.3.5.5.3: re-derive keys from the new SessionBaseKey

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -584,7 +584,9 @@ func (h *Handler) completeSessionBind(
 		}
 	}
 
-	return h.buildSessionSetupResponse(types.StatusSuccess, sessionFlags, acceptToken)
+	result := h.buildSessionSetupResponse(types.StatusSuccess, sessionFlags, acceptToken)
+	result.IsBinding = true
+	return result
 }
 
 // handleNTLMNegotiate handles NTLM Type 1 (NEGOTIATE) message.

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -317,30 +317,23 @@ func findNTLMSSP(data []byte) []byte {
 //  2. session exists                             → STATUS_USER_SESSION_DELETED
 //  3. connection dialect ≥ SMB 3.0               → STATUS_REQUEST_NOT_ACCEPTED
 //  4. session dialect matches connection dialect → STATUS_INVALID_PARAMETER
+//     (deferred: DittoFS does not yet record a per-session dialect, and
+//     every live session today runs on the dialect of its first connection,
+//     making this check meaningful only once sessions outlive their
+//     establishing connection)
 //  5. session is not guest / anonymous           → STATUS_NOT_SUPPORTED
-//
-// On success the auth-completion branch (commit 4 of #361 Phase 1) derives a
-// per-channel signing key from the existing session key and registers the
-// connection on session.Channels. This commit lands only the validation
-// scaffolding: if every check passes, the handler currently returns
-// STATUS_NOT_SUPPORTED with a log marker — the auth-completion routing lands
-// in a follow-up commit within this branch so that partial work does not
-// produce a silently-wrong wire response.
 func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupRequest) (*HandlerResult, error) {
-	// 1. SessionID must be non-zero (can't bind to "no session").
 	if ctx.SessionID == 0 {
 		logger.Debug("SESSION_SETUP bind: SessionID is zero")
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	// 2. Session must exist.
 	sess, ok := h.GetSession(ctx.SessionID)
 	if !ok {
 		logger.Debug("SESSION_SETUP bind: no such session", "sessionID", ctx.SessionID)
 		return NewErrorResult(types.StatusUserSessionDeleted), nil
 	}
 
-	// 3. Connection dialect must be SMB 3.0+.
 	var connDialect types.Dialect
 	if ctx.ConnCryptoState != nil {
 		connDialect = ctx.ConnCryptoState.GetDialect()
@@ -352,17 +345,6 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 		return NewErrorResult(types.StatusRequestNotAccepted), nil
 	}
 
-	// 4. Per §3.3.5.5.2 bullet: the session's dialect MUST equal the
-	// connection's. DittoFS does not yet record per-session dialect; today
-	// every live session is on the same dialect as the connection that
-	// established it. Cross-dialect sessions are impossible with single-
-	// connection-per-session, so this check becomes meaningful only once
-	// a session outlives its first connection (Phase 2+). Stubbed as pass
-	// with a comment to revisit when Session.Dialect lands.
-	_ = sess // intentional: full dialect-match enforcement deferred
-
-	// 5. Session must not be guest / anonymous. Binding a channel onto an
-	// unauthenticated session leaks into NOT_SUPPORTED territory per spec.
 	if sess.IsGuest || sess.IsNull {
 		logger.Info("SESSION_SETUP bind rejected: session is guest/anonymous",
 			"sessionID", ctx.SessionID,
@@ -455,17 +437,14 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 // completeSessionBind finalizes an SMB2 session bind after NTLM auth proved
 // identity on the new connection. Instead of creating a new session (normal
 // completeNTLMAuth path), it registers a session.Channel on the existing
-// session with a per-channel signing key derived from the ORIGINAL session's
-// raw session key (MS-SMB2 §3.1.4.2 / §3.3.5.5.2, Samba source3/smbd/
-// smb2_sesssetup.c:635-643).
+// session with a per-channel signing key derived from the session key
+// produced by THIS binding's NTLM exchange (MS-SMB2 §3.1.4.2 / §3.3.5.5.2;
+// Samba source3/smbd/smb2_sesssetup.c:633-643 passes session_info->session_key
+// from the bind's own GENSEC context, not the original session's key).
 //
 // Preconditions enforced by callers (handleSessionBind → handleNTLMNegotiateBinding
-// → completeNTLMAuth): pending.IsBinding = true; connection dialect is SMB 3.0
-// or 3.0.2 (3.1.1 rejected at handleSessionBind); NTLMv2 validation already
-// succeeded.
-//
-// Returns a non-nil *HandlerResult with the appropriate status. Never returns
-// nil.
+// → completeNTLMAuth): pending.IsBinding = true; connection dialect ≥ SMB 3.0;
+// NTLMv2 validation already succeeded.
 func (h *Handler) completeSessionBind(
 	ctx *SMBHandlerContext,
 	pending *PendingAuth,

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -698,7 +698,11 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 	authMsg, err := auth.ParseAuthenticate(ntlmToken)
 	if err != nil {
 		logger.Debug("Failed to parse NTLM AUTHENTICATE message", "error", err)
-		// Fall back to guest session
+		if pending.IsBinding {
+			// Binding must be terminal: a failed bind must never create or
+			// replace the existing session (including a guest downgrade).
+			return NewErrorResult(types.StatusLogonFailure), nil
+		}
 		return h.createGuestSessionWithID(ctx, pending)
 	}
 
@@ -718,6 +722,9 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				ctx.IsGuest = true
 				return result, nil
 			}
+		}
+		if pending.IsBinding {
+			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 		return h.createGuestSessionWithID(ctx, pending)
 	}
@@ -876,6 +883,12 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 			ctx.IsGuest = false
 
+			if pending.IsBinding {
+				// Without a validated signing key we cannot derive a channel
+				// signing key; a bind here would leave the channel unsigned.
+				return NewErrorResult(types.StatusLogonFailure), nil
+			}
+
 			if pending.IsReauth {
 				if result := h.tryReauthUpdate(pending, resolvedUsername, authMsg.Domain, user, false); result != nil {
 					return result, nil
@@ -912,7 +925,12 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		}
 	}
 
-	// Fall back to guest session
+	// Fall back to guest session (never for binding — a bind must only succeed
+	// via completeSessionBind above or fail closed without replacing the
+	// existing session).
+	if pending.IsBinding {
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
 	return h.createGuestSessionWithID(ctx, pending)
 }
 

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -20,8 +20,18 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/clients"
 )
 
+// nextConnID is the global monotonic counter for Connection.ID. Starts at 1
+// so the zero value remains a sentinel for "no connection assigned" in
+// internal code paths that don't go through NewConnection.
+var nextConnID atomic.Uint64
+
 // Connection handles a single SMB2 client connection.
 type Connection struct {
+	// ID is a stable, process-wide monotonic identifier for this TCP
+	// connection. Used by Session.Channels to key per-channel signing state
+	// when SMB2 multi-channel session binding is in play (MS-SMB2 §3.3.5.5.2).
+	ID uint64
+
 	server *Adapter
 	conn   net.Conn
 
@@ -45,6 +55,7 @@ type Connection struct {
 // preauth integrity hash computation from the very first message.
 func NewConnection(server *Adapter, conn net.Conn) *Connection {
 	return &Connection{
+		ID:          nextConnID.Add(1),
 		server:      server,
 		conn:        conn,
 		requestSem:  make(chan struct{}, server.config.MaxRequestsPerConnection),
@@ -105,6 +116,7 @@ func (c *Connection) UntrackSession(sessionID uint64) {
 // connInfo builds the ConnInfo struct used by internal/ dispatch functions.
 func (c *Connection) connInfo() *smb.ConnInfo {
 	ci := &smb.ConnInfo{
+		ConnID:         c.ID,
 		Conn:           c.conn,
 		Handler:        c.server.handler,
 		SessionManager: c.server.sessionManager,

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -175,7 +175,7 @@ func (c *Connection) Serve(ctx context.Context) {
 	}
 
 	ci := c.connInfo()
-	verifier := smb.NewSessionSigningVerifier(c.server.handler, c.conn, c.CryptoState)
+	verifier := smb.NewSessionSigningVerifier(c.server.handler, c.conn, c.CryptoState, c.ID)
 	handleSMB1 := func(_ context.Context, message []byte) error {
 		return smb.HandleSMB1Negotiate(ci, message)
 	}

--- a/pkg/adapter/smb/connection_test.go
+++ b/pkg/adapter/smb/connection_test.go
@@ -552,21 +552,26 @@ func TestTrackSessionLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("FallsBackToReqSessionID", func(t *testing.T) {
+	t.Run("DoesNotTrackOnSessionBindOrReauth", func(t *testing.T) {
+		// SESSION_SETUP with a non-zero reqSessionID is either a channel
+		// bind (MS-SMB2 §3.3.5.5.2, on a different connection) or a
+		// re-auth (same connection). Neither case must (re)track the
+		// session on this connection — bind must not cause this
+		// connection's close to delete the original session (#361).
 		server, client := net.Pipe()
 		defer func() { _ = server.Close() }()
 		defer func() { _ = client.Close() }()
 
 		c := newTestConnection(server)
 
-		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 55, 0, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 55, 55, types.StatusSuccess, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[55]
 		c.sessionsMu.Unlock()
 
-		if !exists {
-			t.Error("Should fall back to reqSessionID when ctxSessionID is 0")
+		if exists {
+			t.Error("Session bind / re-auth must not track session on this connection")
 		}
 	})
 

--- a/pkg/adapter/smb/connection_test.go
+++ b/pkg/adapter/smb/connection_test.go
@@ -483,7 +483,7 @@ func TestTrackSessionLifecycle(t *testing.T) {
 
 		c := newTestConnection(server)
 
-		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 0, 42, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 0, 42, types.StatusSuccess, false, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[42]
@@ -501,7 +501,7 @@ func TestTrackSessionLifecycle(t *testing.T) {
 
 		c := newTestConnection(server)
 
-		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 0, 42, types.StatusMoreProcessingRequired, c)
+		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 0, 42, types.StatusMoreProcessingRequired, false, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[42]
@@ -521,7 +521,7 @@ func TestTrackSessionLifecycle(t *testing.T) {
 
 		c.TrackSession(42)
 
-		smb.TrackSessionLifecycle(types.SMB2Logoff, 42, 0, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2Logoff, 42, 0, types.StatusSuccess, false, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[42]
@@ -541,7 +541,7 @@ func TestTrackSessionLifecycle(t *testing.T) {
 
 		c.TrackSession(100)
 
-		smb.TrackSessionLifecycle(types.SMB2Logoff, 100, 0, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2Logoff, 100, 0, types.StatusSuccess, false, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[100]
@@ -552,26 +552,48 @@ func TestTrackSessionLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("DoesNotTrackOnSessionBindOrReauth", func(t *testing.T) {
-		// SESSION_SETUP with a non-zero reqSessionID is either a channel
-		// bind (MS-SMB2 §3.3.5.5.2, on a different connection) or a
-		// re-auth (same connection). Neither case must (re)track the
-		// session on this connection — bind must not cause this
-		// connection's close to delete the original session (#361).
+	t.Run("DoesNotTrackOnSessionBind", func(t *testing.T) {
+		// A successful bind response (isBinding=true) must NOT cause the
+		// bound session to be tracked on this connection — the session
+		// lives on a different connection and tracking it here would
+		// make this connection's close delete the original session
+		// (MS-SMB2 §3.3.5.5.2, issue #361).
 		server, client := net.Pipe()
 		defer func() { _ = server.Close() }()
 		defer func() { _ = client.Close() }()
 
 		c := newTestConnection(server)
 
-		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 55, 55, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 55, 55, types.StatusSuccess, true, c)
 
 		c.sessionsMu.Lock()
 		_, exists := c.sessions[55]
 		c.sessionsMu.Unlock()
 
 		if exists {
-			t.Error("Session bind / re-auth must not track session on this connection")
+			t.Error("Channel bind must not track bound session on this connection")
+		}
+	})
+
+	t.Run("TracksNTLMType3WithNonZeroReqSessionID", func(t *testing.T) {
+		// NTLM SESSION_SETUP Type 3 (AUTHENTICATE) arrives with the
+		// server-assigned SessionID in the request header (non-zero)
+		// because it was set by the Type 2 response. The final success
+		// still represents a genuinely new session and must be tracked.
+		server, client := net.Pipe()
+		defer func() { _ = server.Close() }()
+		defer func() { _ = client.Close() }()
+
+		c := newTestConnection(server)
+
+		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 77, 77, types.StatusSuccess, false, c)
+
+		c.sessionsMu.Lock()
+		_, exists := c.sessions[77]
+		c.sessionsMu.Unlock()
+
+		if !exists {
+			t.Error("NTLM Type 3 success must track the session on this connection")
 		}
 	})
 
@@ -582,7 +604,7 @@ func TestTrackSessionLifecycle(t *testing.T) {
 
 		c := newTestConnection(server)
 
-		smb.TrackSessionLifecycle(types.SMB2Create, 0, 42, types.StatusSuccess, c)
+		smb.TrackSessionLifecycle(types.SMB2Create, 0, 42, types.StatusSuccess, false, c)
 
 		c.sessionsMu.Lock()
 		count := len(c.sessions)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -19,22 +19,21 @@ features (sessions, leases, durable handles, locks) that still need work.
 ### Multi-Channel (Partial — Phase 1 of #361)
 
 Phase 1 of #361 lands the session-binding architecture: `Channel` struct
-+ `Session.channels` registry, `DeriveChannelSigningKey`, binding detection
-in SESSION_SETUP with full MS-SMB2 §3.3.5.5.2 prerequisite validation, and
-SMB 3.0 / 3.0.2 binding auth-completion (per-channel signer registered and
-routed through dispatch sign/verify).
++ `Session.channels` registry, `DeriveChannelSigningKey`, SMB 3.0 / 3.0.2
+and SMB 3.1.1 session-bind auth-completion with per-channel preauth hash
+chaining, and per-channel sign/verify routing through dispatch. DittoFS
+advertises `SMB2_GLOBAL_CAP_MULTI_CHANNEL` in NEGOTIATE so conformant
+clients now exercise the multi-channel test surface.
 
-SMB 3.1.1 binding is explicitly rejected with `STATUS_NOT_SUPPORTED`
-pending per-channel preauth integrity hash chaining (follow-up within
-#361). DittoFS does NOT yet advertise `SMB2_GLOBAL_CAP_MULTI_CHANNEL` in
-NEGOTIATE, so conformant clients skip multi-channel tests entirely until
-the 3.1.1 path and cross-channel break fan-out (Phase 2) land.
+The remaining known failures are cross-channel notification fan-out
+(lease/oplock breaks) and wide-channel orchestration, all deferred to
+Phase 2 of #361.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.multichannel.bugs.bug_15346 | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
-| smb2.multichannel.generic.num_channels | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
-| smb2.multichannel.leases.test1 | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
+| smb2.multichannel.bugs.bug_15346 | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
+| smb2.multichannel.generic.num_channels | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
+| smb2.multichannel.leases.test1 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test2 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.oplocks.test1 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.oplocks.test2 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -33,10 +33,14 @@ Phase 2 of #361.
 |-----------|----------|--------|-------|
 | smb2.multichannel.bugs.bug_15346 | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
 | smb2.multichannel.generic.num_channels | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
+| smb2.multichannel.generic.interface_info | Multi-channel | FSCTL_QUERY_NETWORK_INTERFACE_INFO not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test1 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test2 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.leases.test3 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.leases.test4 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.oplocks.test1 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.oplocks.test2 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.oplocks.test3_windows | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.oplocks.test3_specification | Multi-channel | 32-channel break fan-out with retry logic not yet implemented (Phase 2 of #361) | #361 |
 
 ### ACLs and Security Descriptors (Not Implemented)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -16,18 +16,29 @@ features (sessions, leases, durable handles, locks) that still need work.
 
 ## Expected Failures
 
-### Multi-Channel (Not Implemented)
+### Multi-Channel (Partial — Phase 1 of #361)
 
-Multi-channel support requires establishing multiple TCP connections to the same
-session, which DittoFS does not implement.
+Phase 1 of #361 lands the session-binding architecture: `Channel` struct
++ `Session.channels` registry, `DeriveChannelSigningKey`, binding detection
+in SESSION_SETUP with full MS-SMB2 §3.3.5.5.2 prerequisite validation, and
+SMB 3.0 / 3.0.2 binding auth-completion (per-channel signer registered and
+routed through dispatch sign/verify).
+
+SMB 3.1.1 binding is explicitly rejected with `STATUS_NOT_SUPPORTED`
+pending per-channel preauth integrity hash chaining (follow-up within
+#361). DittoFS does NOT yet advertise `SMB2_GLOBAL_CAP_MULTI_CHANNEL` in
+NEGOTIATE, so conformant clients skip multi-channel tests entirely until
+the 3.1.1 path and cross-channel break fan-out (Phase 2) land.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.multichannel.bugs.bug_15346 | Multi-channel | Multi-channel not implemented | - |
-| smb2.multichannel.generic.num_channels | Multi-channel | Multi-channel not implemented | - |
-| smb2.multichannel.leases.test2 | Multi-channel | Multi-channel lease coordination not implemented | - |
-| smb2.multichannel.oplocks.test1 | Multi-channel | Multi-channel oplock coordination not implemented | - |
-| smb2.multichannel.oplocks.test2 | Multi-channel | Multi-channel oplock coordination not implemented | - |
+| smb2.multichannel.bugs.bug_15346 | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
+| smb2.multichannel.generic.num_channels | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
+| smb2.multichannel.leases.test1 | Multi-channel | Server does not advertise CAP_MULTI_CHANNEL; test skipped | #361 |
+| smb2.multichannel.leases.test2 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.oplocks.test1 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.oplocks.test2 | Multi-channel | Cross-channel oplock break dispatch not yet implemented (Phase 2 of #361) | #361 |
+| smb2.multichannel.oplocks.test3_specification | Multi-channel | 32-channel break fan-out with retry logic not yet implemented (Phase 2 of #361) | #361 |
 
 ### ACLs and Security Descriptors (Not Implemented)
 
@@ -216,9 +227,9 @@ The remaining failures all require multi-channel session binding (MS-SMB2
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.credits.multichannel_ipc_max_async_credits | Credits | Multi-channel not implemented (second-connection CREATE disconnects) | #361 |
+| smb2.credits.multichannel_ipc_max_async_credits | Credits | Multi-channel async credit coordination across channels not yet implemented (Phase 2 of #361) | #361 |
 | smb2.credits.2conn_notify_max_async_credits | Credits | Multi-channel not implemented (second connection disconnects mid-test) | #361 |
-| smb2.credits.multichannel_max_async_credits | Credits | Multi-channel not implemented (session bind returns ACCESS_DENIED) | #361 |
+| smb2.credits.multichannel_max_async_credits | Credits | Multi-channel async credit coordination across channels not yet implemented (Phase 2 of #361) | #361 |
 
 ### Directory Operations (Advanced Queries Not Implemented)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
@@ -15,8 +15,14 @@ These are genuine Kerberos-specific bugs tracked in #340.
 |-----------|----------|--------|-------|
 | smb2.reconnect1 | Reconnect | STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED | #340-A3 |
 | smb2.reconnect2 | Reconnect | STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED | #340-A3 |
+| smb2.reauth1 | Reauth | Kerberos reauth path returns ACCESS_DENIED on SESSION_SETUP (Kerberos-specific, unblocked after reauth5 hang fix #388) | #340-A2 |
+| smb2.reauth2 | Reauth | Kerberos reauth path returns ACCESS_DENIED on SESSION_SETUP (Kerberos-specific, unblocked after reauth5 hang fix #388) | #340-A2 |
+| smb2.reauth3 | Reauth | Kerberos reauth path returns ACCESS_DENIED on SESSION_SETUP (Kerberos-specific, unblocked after reauth5 hang fix #388) | #340-A2 |
 | smb2.reauth4 | Reauth | Signing keys wrong after Kerberos reauth | #340-A2 |
 | smb2.reauth5 | Reauth | Signing keys wrong after Kerberos reauth | #340-A2 |
+| smb2.bind1 | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
+| smb2.bind2 | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
+| smb2.bind_invalid_auth | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
 | smb2.expire1n | Expire | Ticket expiration not enforced correctly | #340-A1 |
 | smb2.expire1s | Expire | Ticket expiration not enforced correctly | #340-A1 |
 | smb2.expire1e | Expire | Ticket expiration not enforced correctly | #340-A1 |


### PR DESCRIPTION
## Summary

Phase 1 of SMB 3.x multichannel support (issue #361): adds the session-bind protocol path so a client can authenticate a second connection into an existing session and use per-channel signing keys.

- **Channel primitives** — `Channel` struct, per-session channel registry on `Session`, and `DeriveChannelSigningKey` for SMB 3.0/3.0.2 (static label/context) and SMB 3.1.1 (preauth-hash context).
- **Signing routing** — outgoing sign and incoming verify go through the channel signer when a bind connection is in use, falling back to the session signer otherwise. Consolidated into `Session.SignMessageOnChannel` / `VerifyMessageOnChannel` to avoid duplicating the lookup at every call site.
- **Session bind handler** — full SMB 3.0 + 3.1.1 bind flow: prerequisite validation (MS-SMB2 §3.3.5.5.2), NTLMSSP TYPE_1/TYPE_3 routing through `completeNTLMAuth`, SPNEGO `accept-complete` wrapping, fresh session-key derivation on the bind connection, and preauth-hash chaining for 3.1.1.
- **Blocker fix** — SESSION_SETUP SUCCESS responses are now never encrypted (previously the `NewlyCreated` guard caused bind SUCCESS on an existing encrypted session to be wrapped in a Transform Header, which Windows rejected with `STATUS_INVALID_PARAMETER`). Per MS-SMB2 §3.3.5.5.2/.3 these responses must be signed and cleartext in all three cases: new session, re-auth, and bind.
- **Docs** — reconciled `test/smb-conformance/smbtorture/KNOWN_FAILURES.md` multichannel entries.

## What's not in this PR

- Client-initiated break notification fan-out across channels (Phase 2).
- Cross-channel lease-break routing (Phase 2).
- Dialect-match enforcement on the bind connection (MS-SMB2 requires the binding connection's negotiated dialect to equal the original session's; the `Session` currently carries no `Dialect` field — tracked for follow-up).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/adapter/smb/...`
- [x] smbtorture: `smb2.session.bind` against SMB 3.0 and 3.1.1 dialects
- [x] Windows client bind (reproduce original #361 failure → expect SUCCESS)
- [x] Confirm no regression on single-channel signing tests