### PR TITLE
fix(backup/fs): auto-create repo root directory on New

### DIFF
--- a/pkg/backup/destination/fs/store.go
+++ b/pkg/backup/destination/fs/store.go
@@ -81,8 +81,15 @@ func New(ctx context.Context, repo *models.BackupRepo) (destination.Destination,
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(cfg.Path, 0700); err != nil {
+	if err := os.MkdirAll(cfg.Path, dirMode); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return nil, fmt.Errorf("%w: mkdir %s: %v", destination.ErrIncompatibleConfig, cfg.Path, err)
+		}
 		return nil, fmt.Errorf("%w: mkdir %s: %v", destination.ErrDestinationUnavailable, cfg.Path, err)
+	}
+	// Defense against process umask: explicit chmod after MkdirAll.
+	if err := os.Chmod(cfg.Path, dirMode); err != nil {
+		return nil, fmt.Errorf("%w: chmod %s: %v", destination.ErrDestinationUnavailable, cfg.Path, err)
 	}
 	s := &Store{
 		root:          cfg.Path,

--- a/pkg/backup/destination/fs/store.go
+++ b/pkg/backup/destination/fs/store.go
@@ -1,6 +1,6 @@
 // Package fs implements the local-filesystem Destination driver per
 // Phase 3 CONTEXT.md D-03 (atomic-rename publish) and D-14 (0600 files /
-// 0700 dirs, no chown, pre-created repo root, remote-FS warning).
+// 0700 dirs, no chown, auto-created repo root, remote-FS warning).
 //
 // A backup is published by writing payload.bin and manifest.yaml under
 // <repo-root>/<id>.tmp/, fsyncing both files + the tmp dir, and then
@@ -59,7 +59,7 @@ const (
 // Field names mirror D-12 exactly: path (required, absolute), grace_window
 // (optional Go duration string; defaults to 24h when absent).
 type Config struct {
-	Path        string        // required, absolute directory, pre-created by operator
+	Path        string        // required, absolute directory; auto-created by New if absent
 	GraceWindow time.Duration // D-06, defaults to defaultGraceWindow when zero
 }
 
@@ -81,6 +81,10 @@ func New(ctx context.Context, repo *models.BackupRepo) (destination.Destination,
 	if err != nil {
 		return nil, err
 	}
+	// Reject paths that exist but are not directories before attempting mkdir.
+	if fi, err := os.Stat(cfg.Path); err == nil && !fi.IsDir() {
+		return nil, fmt.Errorf("%w: %s is not a directory", destination.ErrIncompatibleConfig, cfg.Path)
+	}
 	if err := os.MkdirAll(cfg.Path, dirMode); err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("%w: mkdir %s: %v", destination.ErrIncompatibleConfig, cfg.Path, err)
@@ -89,6 +93,9 @@ func New(ctx context.Context, repo *models.BackupRepo) (destination.Destination,
 	}
 	// Defense against process umask: explicit chmod after MkdirAll.
 	if err := os.Chmod(cfg.Path, dirMode); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return nil, fmt.Errorf("%w: chmod %s: %v", destination.ErrIncompatibleConfig, cfg.Path, err)
+		}
 		return nil, fmt.Errorf("%w: chmod %s: %v", destination.ErrDestinationUnavailable, cfg.Path, err)
 	}
 	s := &Store{

--- a/pkg/backup/destination/fs/store.go
+++ b/pkg/backup/destination/fs/store.go
@@ -81,6 +81,9 @@ func New(ctx context.Context, repo *models.BackupRepo) (destination.Destination,
 	if err != nil {
 		return nil, err
 	}
+	if err := os.MkdirAll(cfg.Path, 0700); err != nil {
+		return nil, fmt.Errorf("%w: mkdir %s: %v", destination.ErrDestinationUnavailable, cfg.Path, err)
+	}
 	s := &Store{
 		root:          cfg.Path,
 		graceWindow:   cfg.GraceWindow,

--- a/pkg/backup/destination/fs/store_test.go
+++ b/pkg/backup/destination/fs/store_test.go
@@ -268,13 +268,16 @@ func TestFSStore_ValidateConfig(t *testing.T) {
 
 	// Uncreateable path (EACCES on non-writable parent): New must return
 	// ErrIncompatibleConfig, not a retryable error.
-	noWrite := filepath.Join(dir, "no-write")
-	require.NoError(t, os.Mkdir(noWrite, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(noWrite, 0o700) })
-	repo2 := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
-	require.NoError(t, repo2.SetConfig(map[string]any{"path": filepath.Join(noWrite, "dittofs-test")}))
-	_, err2 := fs.New(context.Background(), repo2)
-	require.ErrorIs(t, err2, destination.ErrIncompatibleConfig)
+	// Windows does not honour Unix chmod bits — skip this sub-case there.
+	if runtime.GOOS != "windows" {
+		noWrite := filepath.Join(dir, "no-write")
+		require.NoError(t, os.Mkdir(noWrite, 0o500))
+		t.Cleanup(func() { _ = os.Chmod(noWrite, 0o700) })
+		repo2 := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
+		require.NoError(t, repo2.SetConfig(map[string]any{"path": filepath.Join(noWrite, "dittofs-test")}))
+		_, err2 := fs.New(context.Background(), repo2)
+		require.ErrorIs(t, err2, destination.ErrIncompatibleConfig)
+	}
 
 	// Not-a-directory path: New must return ErrIncompatibleConfig.
 	file := filepath.Join(dir, "not-a-dir")

--- a/pkg/backup/destination/fs/store_test.go
+++ b/pkg/backup/destination/fs/store_test.go
@@ -255,10 +255,9 @@ func TestFSStore_OrphanSweep_On_New(t *testing.T) {
 	require.NoError(t, err, "fresh tmp must be preserved")
 }
 
-// TestFSStore_ValidateConfig drives the happy path + two rejection
-// branches (non-existent path, not-a-directory). The remote-FS warning
-// path is not asserted here — detectFilesystemType is a best-effort
-// platform probe and has no unit-test hook.
+// TestFSStore_ValidateConfig drives the happy path + rejection branches.
+// The remote-FS warning path is not asserted here — detectFilesystemType
+// is a best-effort platform probe and has no unit-test hook.
 func TestFSStore_ValidateConfig(t *testing.T) {
 	dir := t.TempDir()
 	repo := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
@@ -267,25 +266,43 @@ func TestFSStore_ValidateConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, s.ValidateConfig(context.Background()))
 
-	// Non-existent path: New must still construct (sweep no-ops on
-	// ReadDir failure) but ValidateConfig must reject.
+	// Uncreateable path (EACCES on non-writable parent): New must return
+	// ErrIncompatibleConfig, not a retryable error.
+	noWrite := filepath.Join(dir, "no-write")
+	require.NoError(t, os.Mkdir(noWrite, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(noWrite, 0o700) })
 	repo2 := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
-	require.NoError(t, repo2.SetConfig(map[string]any{"path": "/definitely/does/not/exist/dittofs-test"}))
-	s2, _ := fs.New(context.Background(), repo2)
-	if s2 != nil {
-		vErr := s2.ValidateConfig(context.Background())
-		require.ErrorIs(t, vErr, destination.ErrIncompatibleConfig)
-	}
+	require.NoError(t, repo2.SetConfig(map[string]any{"path": filepath.Join(noWrite, "dittofs-test")}))
+	_, err2 := fs.New(context.Background(), repo2)
+	require.ErrorIs(t, err2, destination.ErrIncompatibleConfig)
 
-	// Not-a-directory path.
+	// Not-a-directory path: New must return ErrIncompatibleConfig.
 	file := filepath.Join(dir, "not-a-dir")
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
 	repo3 := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
 	require.NoError(t, repo3.SetConfig(map[string]any{"path": file}))
-	s3, err3 := fs.New(context.Background(), repo3)
-	if err3 == nil && s3 != nil {
-		require.ErrorIs(t, s3.ValidateConfig(context.Background()), destination.ErrIncompatibleConfig)
+	_, err3 := fs.New(context.Background(), repo3)
+	require.ErrorIs(t, err3, destination.ErrIncompatibleConfig)
+}
+
+// TestFSStore_New_AutoCreatesRoot verifies that New creates a missing repo
+// root directory with mode 0700.
+func TestFSStore_New_AutoCreatesRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission model not applicable")
 	}
+	base := t.TempDir()
+	root := filepath.Join(base, "auto", "created")
+	repo := &models.BackupRepo{ID: "r", Kind: models.BackupRepoKindLocal}
+	require.NoError(t, repo.SetConfig(map[string]any{"path": root}))
+	s, err := fs.New(context.Background(), repo)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	fi, err := os.Stat(root)
+	require.NoError(t, err)
+	require.True(t, fi.IsDir())
+	require.Equal(t, os.FileMode(0o700), fi.Mode().Perm())
 }
 
 // TestFSStore_DuplicateID_Rejected confirms the double-publish guard.


### PR DESCRIPTION
## Summary

- Calls `os.MkdirAll` in `New()` before constructing the `Store`, so a missing repo root is created automatically on first use instead of failing the first backup job with `destination unavailable`
- Uses the existing `dirMode` constant (0700) for consistency with all other directory creation in the file
- Adds explicit `os.Chmod` after `MkdirAll` to defend against process umask (matches the pattern used throughout `PutBackup`)
- Wraps `EACCES`/`EPERM` failures as `ErrIncompatibleConfig` (permanent operator error, should not retry) vs transient I/O failures as `ErrDestinationUnavailable`

Closes #405

## Test plan

- [ ] Create a backup repo with a non-existent `path`, trigger a backup — job should succeed and the directory should be created with mode `0700`
- [ ] Create a backup repo pointing at a path where the process has no write permission — `New()` should return `ErrIncompatibleConfig`
- [ ] Existing unit tests pass: `go test ./pkg/backup/destination/fs/...`