### PR TITLE
feat(smb): implement FSCTL_QUERY_NETWORK_INTERFACE_INFO — #361

### DIFF
--- a/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
@@ -19,24 +19,25 @@ var ioctlDispatch map[uint32]IOCTLHandler
 
 func init() {
 	ioctlDispatch = map[uint32]IOCTLHandler{
-		FsctlValidateNegotiateInfo: (*Handler).handleValidateNegotiateInfo,
-		FsctlGetReparsePoint:       (*Handler).handleGetReparsePoint,
-		FsctlPipeTransceive:        (*Handler).handlePipeTransceive,
-		FsctlGetNtfsVolumeData:     (*Handler).handleGetNtfsVolumeData,
-		FsctlReadFileUsnData:       (*Handler).handleReadFileUsnData,
-		FsctlSrvEnumerateSnapshots: (*Handler).handleEnumerateSnapshots,
-		FsctlIsPathnameValid:       (*Handler).handleIsPathnameValid,
-		FsctlGetCompression:        (*Handler).handleGetCompression,
-		FsctlSetCompression:        (*Handler).handleSetCompression,
-		FsctlGetIntegrityInfo:      (*Handler).handleGetIntegrityInfo,
-		FsctlSetIntegrityInfo:      (*Handler).handleSetIntegrityInfo,
-		FsctlGetObjectID:           (*Handler).handleGetObjectID,
-		FsctlCreateOrGetObjectID:   (*Handler).handleCreateOrGetObjectID,
-		FsctlMarkHandle:            (*Handler).handleMarkHandle,
-		FsctlQueryFileRegions:      (*Handler).handleQueryFileRegions,
-		FsctlSrvRequestResumeKey:   (*Handler).handleSrvRequestResumeKey,
-		FsctlSrvCopyChunk:          (*Handler).handleSrvCopyChunk,
-		FsctlSrvCopyChunkWrite:     (*Handler).handleSrvCopyChunk,
+		FsctlValidateNegotiateInfo:  (*Handler).handleValidateNegotiateInfo,
+		FsctlGetReparsePoint:        (*Handler).handleGetReparsePoint,
+		FsctlPipeTransceive:         (*Handler).handlePipeTransceive,
+		FsctlGetNtfsVolumeData:      (*Handler).handleGetNtfsVolumeData,
+		FsctlReadFileUsnData:        (*Handler).handleReadFileUsnData,
+		FsctlSrvEnumerateSnapshots:  (*Handler).handleEnumerateSnapshots,
+		FsctlIsPathnameValid:        (*Handler).handleIsPathnameValid,
+		FsctlGetCompression:         (*Handler).handleGetCompression,
+		FsctlSetCompression:         (*Handler).handleSetCompression,
+		FsctlGetIntegrityInfo:       (*Handler).handleGetIntegrityInfo,
+		FsctlSetIntegrityInfo:       (*Handler).handleSetIntegrityInfo,
+		FsctlGetObjectID:            (*Handler).handleGetObjectID,
+		FsctlCreateOrGetObjectID:    (*Handler).handleCreateOrGetObjectID,
+		FsctlMarkHandle:             (*Handler).handleMarkHandle,
+		FsctlQueryFileRegions:       (*Handler).handleQueryFileRegions,
+		FsctlSrvRequestResumeKey:    (*Handler).handleSrvRequestResumeKey,
+		FsctlSrvCopyChunk:           (*Handler).handleSrvCopyChunk,
+		FsctlSrvCopyChunkWrite:      (*Handler).handleSrvCopyChunk,
+		FsctlQueryNetworkInterfInfo: (*Handler).handleQueryNetworkInterfaceInfo,
 	}
 }
 
@@ -89,7 +90,7 @@ func (h *Handler) Ioctl(ctx *SMBHandlerContext, body []byte) (*HandlerResult, er
 // and do not require an open file handle.
 func ioctlNoHandleFSCTL(ctlCode uint32) bool {
 	switch ctlCode {
-	case FsctlValidateNegotiateInfo, FsctlPipeTransceive:
+	case FsctlValidateNegotiateInfo, FsctlPipeTransceive, FsctlQueryNetworkInterfInfo:
 		return true
 	default:
 		return false

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
@@ -161,10 +161,10 @@ func encodeNetworkInterfaceInfoList(entries []networkInterfaceEntry) []byte {
 //
 // SOCKADDR_IN (IPv4, 16 used bytes, padded to 128):
 //
-//	 0  Family   u16   0x0002
-//	 2  Port     u16   0 (unused for interface enumeration)
-//	 4  IPv4     4B    address bytes (network order)
-//	 8  Reserved 8B    zero
+//	0  Family   u16   0x0002
+//	2  Port     u16   0 (unused for interface enumeration)
+//	4  IPv4     4B    address bytes (network order)
+//	8  Reserved 8B    zero
 //
 // SOCKADDR_IN6 (IPv6, 28 used bytes, padded to 128):
 //

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
@@ -100,6 +100,10 @@ func collectNetworkInterfaceEntries() []networkInterfaceEntry {
 		}
 		addrs, err := iface.Addrs()
 		if err != nil {
+			logger.Debug("IOCTL network interface address enumeration failed",
+				"interface_name", iface.Name,
+				"interface_index", iface.Index,
+				"error", err)
 			continue
 		}
 		for _, addr := range addrs {

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// Conservative placeholder advertised in NETWORK_INTERFACE_INFO.LinkSpeed.
+// Clients use this only as a hint for per-channel allocation, not correctness
+// (MS-SMB2 §3.2.5.14.11). Reporting an honest link speed would require
+// platform-specific code (e.g. /sys/class/net on Linux) for marginal benefit,
+// especially under containerized deployments where the host NIC speed is not
+// the effective bandwidth anyway. Samba falls back to this same value when
+// the kernel cannot report a speed.
+const networkInterfaceLinkSpeedBps uint64 = 1_000_000_000
+
+// MS-SMB2 §2.2.32.5.1 — family values (stored in SockAddr_Storage[0:2]).
+const (
+	sockAddrFamilyINet  uint16 = 0x0002
+	sockAddrFamilyINet6 uint16 = 0x0017
+)
+
+// Per MS-SMB2 §2.2.32.5, each NETWORK_INTERFACE_INFO entry is 152 bytes:
+// Next(4) + IfIndex(4) + Capability(4) + Reserved(4) + LinkSpeed(8) +
+// SockAddr_Storage(128).
+const networkInterfaceInfoEntrySize = 152
+
+// handleQueryNetworkInterfaceInfo responds to FSCTL_QUERY_NETWORK_INTERFACE_INFO
+// (MS-SMB2 §2.2.32.5). The request uses the all-0xFF FileID sentinel and
+// carries no meaningful input; the response is a linked list of
+// NETWORK_INTERFACE_INFO entries describing the server's usable addresses.
+//
+// Each entry carries (offset-within-entry):
+//
+//	 0  Next              u32   Offset in bytes to the next entry; 0 marks the last.
+//	 4  IfIndex           u32   Interface index.
+//	 8  Capability        u32   Bitmask (RSS/RDMA). We report 0 (neither).
+//	12  Reserved          u32   Must be 0.
+//	16  LinkSpeed         u64   Advertised speed in bits/sec.
+//	24  SockAddr_Storage  128B  family | data | padding per family rules.
+//
+// IPv6 link-local addresses are skipped: they require the interface index to
+// be meaningful in a SOCKADDR_IN6 scope_id, and DittoFS is not advertising
+// scoped addresses. Loopback is also skipped — a client that reached the
+// server via an external address cannot usefully open a second channel to
+// 127.0.0.1.
+func (h *Handler) handleQueryNetworkInterfaceInfo(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	// MS-SMB2 §3.3.5.15.13: FileID must be the all-0xFF sentinel.
+	if !bytes.Equal(fileID[:], allFFFileID) {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	entries := collectNetworkInterfaceEntries()
+	logger.Debug("IOCTL FSCTL_QUERY_NETWORK_INTERFACE_INFO",
+		"interfaces", len(entries))
+	// MS-SMB2 §3.3.5.15.13: if the server cannot report usable interfaces
+	// (enumeration failed, or only loopback/link-local exist), return
+	// STATUS_NOT_SUPPORTED so the client cleanly falls back to single-
+	// channel instead of parsing a zero-entry list.
+	if len(entries) == 0 {
+		return NewErrorResult(types.StatusNotSupported), nil
+	}
+
+	output := encodeNetworkInterfaceInfoList(entries)
+	resp := buildIoctlResponse(FsctlQueryNetworkInterfInfo, fileID, output)
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// networkInterfaceEntry is the parsed subset of a host interface address we
+// need to emit a NETWORK_INTERFACE_INFO.
+type networkInterfaceEntry struct {
+	IfIndex uint32
+	IP      net.IP
+}
+
+// collectNetworkInterfaceEntries walks host interfaces and returns one entry
+// per usable unicast address. Errors from Interfaces() / Addrs() are logged
+// and skipped — returning an empty list is preferable to failing the IOCTL.
+func collectNetworkInterfaceEntries() []networkInterfaceEntry {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		logger.Debug("IOCTL network interface enumeration failed",
+			"error", err)
+		return nil
+	}
+
+	var out []networkInterfaceEntry
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip := ipFromAddr(addr)
+			// Skip link-local: we cannot emit a meaningful scope_id in the
+			// SOCKADDR_IN6 we serialize.
+			if ip == nil || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			out = append(out, networkInterfaceEntry{
+				IfIndex: uint32(iface.Index),
+				IP:      ip,
+			})
+		}
+	}
+	return out
+}
+
+// ipFromAddr narrows net.Addr (returned by net.Interface.Addrs) to a usable
+// net.IP. Addresses on Linux/Darwin come as *net.IPNet; we accept *net.IPAddr
+// defensively too.
+func ipFromAddr(a net.Addr) net.IP {
+	switch v := a.(type) {
+	case *net.IPNet:
+		return v.IP
+	case *net.IPAddr:
+		return v.IP
+	}
+	return nil
+}
+
+// encodeNetworkInterfaceInfoList serializes entries per MS-SMB2 §2.2.32.5.
+// Entries are laid out sequentially; each entry's Next field is the offset to
+// the start of the following entry (152 bytes), or 0 on the last.
+func encodeNetworkInterfaceInfoList(entries []networkInterfaceEntry) []byte {
+	if len(entries) == 0 {
+		return nil
+	}
+	w := smbenc.NewWriter(len(entries) * networkInterfaceInfoEntrySize)
+	for i, e := range entries {
+		var next uint32
+		if i < len(entries)-1 {
+			next = networkInterfaceInfoEntrySize
+		}
+		w.WriteUint32(next)
+		w.WriteUint32(e.IfIndex)
+		w.WriteUint32(0) // Capability — no RSS/RDMA advertised
+		w.WriteUint32(0) // Reserved
+		w.WriteUint64(networkInterfaceLinkSpeedBps)
+		w.WriteBytes(encodeSockAddrStorage(e.IP))
+	}
+	return w.Bytes()
+}
+
+// encodeSockAddrStorage serializes a SOCKADDR_STORAGE per MS-SMB2 §2.2.32.5.1
+// into a fixed 128-byte buffer. Integer header fields (Family, Port,
+// FlowInfo, ScopeId) are little-endian on the wire per SMB2 convention; IP
+// address bytes are already network order in net.IP and copied verbatim.
+//
+// SOCKADDR_IN (IPv4, 16 used bytes, padded to 128):
+//
+//	 0  Family   u16   0x0002
+//	 2  Port     u16   0 (unused for interface enumeration)
+//	 4  IPv4     4B    address bytes (network order)
+//	 8  Reserved 8B    zero
+//
+// SOCKADDR_IN6 (IPv6, 28 used bytes, padded to 128):
+//
+//	 0  Family     u16  0x0017
+//	 2  Port       u16  0
+//	 4  FlowInfo   u32  0
+//	 8  IPv6       16B  address bytes (network order)
+//	24  ScopeId    u32  0 (link-local skipped upstream)
+func encodeSockAddrStorage(ip net.IP) []byte {
+	buf := make([]byte, 128)
+	if v4 := ip.To4(); v4 != nil {
+		binary.LittleEndian.PutUint16(buf[0:2], sockAddrFamilyINet)
+		copy(buf[4:8], v4)
+		return buf
+	}
+	v6 := ip.To16()
+	if v6 == nil {
+		return buf
+	}
+	binary.LittleEndian.PutUint16(buf[0:2], sockAddrFamilyINet6)
+	copy(buf[8:24], v6)
+	return buf
+}

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+func TestEncodeNetworkInterfaceInfoList_Empty(t *testing.T) {
+	got := encodeNetworkInterfaceInfoList(nil)
+	if got != nil {
+		t.Fatalf("expected nil output for empty list, got %d bytes", len(got))
+	}
+}
+
+func TestEncodeNetworkInterfaceInfoList_IPv4(t *testing.T) {
+	entries := []networkInterfaceEntry{{
+		IfIndex: 3,
+		IP:      net.ParseIP("192.0.2.5").To4(),
+	}}
+
+	got := encodeNetworkInterfaceInfoList(entries)
+	if len(got) != networkInterfaceInfoEntrySize {
+		t.Fatalf("expected %d bytes, got %d", networkInterfaceInfoEntrySize, len(got))
+	}
+
+	if next := binary.LittleEndian.Uint32(got[0:4]); next != 0 {
+		t.Errorf("Next on only/last entry: got %d, want 0", next)
+	}
+	if idx := binary.LittleEndian.Uint32(got[4:8]); idx != 3 {
+		t.Errorf("IfIndex: got %d, want 3", idx)
+	}
+	if cap := binary.LittleEndian.Uint32(got[8:12]); cap != 0 {
+		t.Errorf("Capability: got 0x%x, want 0", cap)
+	}
+	if linkSpeed := binary.LittleEndian.Uint64(got[16:24]); linkSpeed != networkInterfaceLinkSpeedBps {
+		t.Errorf("LinkSpeed: got %d, want %d", linkSpeed, networkInterfaceLinkSpeedBps)
+	}
+
+	sockAddr := got[24:152]
+	family := binary.LittleEndian.Uint16(sockAddr[0:2])
+	if family != sockAddrFamilyINet {
+		t.Errorf("SockAddr family: got 0x%04x, want 0x%04x (AF_INET)", family, sockAddrFamilyINet)
+	}
+	wantV4 := []byte{192, 0, 2, 5}
+	if got := sockAddr[4:8]; !bytes.Equal(got, wantV4) {
+		t.Errorf("IPv4 bytes: got %v, want %v", got, wantV4)
+	}
+}
+
+func TestEncodeNetworkInterfaceInfoList_IPv6(t *testing.T) {
+	entries := []networkInterfaceEntry{{
+		IfIndex: 7,
+		IP:      net.ParseIP("2001:db8::1"),
+	}}
+
+	got := encodeNetworkInterfaceInfoList(entries)
+	if len(got) != networkInterfaceInfoEntrySize {
+		t.Fatalf("expected %d bytes, got %d", networkInterfaceInfoEntrySize, len(got))
+	}
+
+	sockAddr := got[24:152]
+	family := binary.LittleEndian.Uint16(sockAddr[0:2])
+	if family != sockAddrFamilyINet6 {
+		t.Errorf("SockAddr family: got 0x%04x, want 0x%04x (AF_INET6)", family, sockAddrFamilyINet6)
+	}
+	wantV6 := net.ParseIP("2001:db8::1").To16()
+	if got := sockAddr[8:24]; !bytes.Equal(got, wantV6) {
+		t.Errorf("IPv6 bytes: got %v, want %v", got, wantV6)
+	}
+}
+
+func TestEncodeNetworkInterfaceInfoList_MultipleEntriesChained(t *testing.T) {
+	entries := []networkInterfaceEntry{
+		{IfIndex: 1, IP: net.ParseIP("192.0.2.1").To4()},
+		{IfIndex: 2, IP: net.ParseIP("192.0.2.2").To4()},
+		{IfIndex: 3, IP: net.ParseIP("2001:db8::3")},
+	}
+
+	got := encodeNetworkInterfaceInfoList(entries)
+	if want := networkInterfaceInfoEntrySize * len(entries); len(got) != want {
+		t.Fatalf("expected %d bytes, got %d", want, len(got))
+	}
+
+	for i := range entries {
+		off := i * networkInterfaceInfoEntrySize
+		next := binary.LittleEndian.Uint32(got[off : off+4])
+		if i < len(entries)-1 {
+			if next != networkInterfaceInfoEntrySize {
+				t.Errorf("entry %d Next: got %d, want %d", i, next, networkInterfaceInfoEntrySize)
+			}
+		} else if next != 0 {
+			t.Errorf("last entry Next: got %d, want 0", next)
+		}
+	}
+}
+
+func TestCollectNetworkInterfaceEntries_SkipsLoopback(t *testing.T) {
+	entries := collectNetworkInterfaceEntries()
+	for _, e := range entries {
+		if e.IP.IsLoopback() {
+			t.Errorf("loopback address leaked into entries: %v", e.IP)
+		}
+		if e.IP.IsLinkLocalUnicast() {
+			t.Errorf("link-local address leaked into entries: %v", e.IP)
+		}
+	}
+}
+
+// buildQueryNetworkInterfaceInfoRequest builds a 24-byte IOCTL request body
+// with the given FileID — the minimal input the handler parses.
+func buildQueryNetworkInterfaceInfoRequest(fileID []byte) []byte {
+	w := smbenc.NewWriter(24)
+	w.WriteUint16(57)
+	w.WriteUint16(0)
+	w.WriteUint32(FsctlQueryNetworkInterfInfo)
+	w.WriteBytes(fileID)
+	return w.Bytes()
+}
+
+func TestHandleQueryNetworkInterfaceInfo_RejectsNonSentinelFileID(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	badFileID := make([]byte, 16) // all zero — not the 0xFF sentinel
+	body := buildQueryNetworkInterfaceInfoRequest(badFileID)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter for non-sentinel FileID, got %v", result.Status)
+	}
+}
+
+func TestHandleQueryNetworkInterfaceInfo_ShortBodyInvalidParameter(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	// Truncated body (< 24 bytes) — parseIoctlFileID must fail.
+	body := make([]byte, 8)
+	binary.LittleEndian.PutUint32(body[4:8], FsctlQueryNetworkInterfInfo)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter for truncated body, got %v", result.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/ioctl_validate_negotiate_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_validate_negotiate_test.go
@@ -398,25 +398,24 @@ func TestIoctlDispatchTable_RoutesCorrectly(t *testing.T) {
 	}
 
 	// FSCTL_QUERY_NETWORK_INTERFACE_INFO now dispatches to a real handler.
-	// Request layout: StructureSize(2) Reserved(2) CtlCode(4) FileId(16 sentinel).
+	// Assert on a behavior UNIQUE to the handler — not a status value the
+	// generic "unknown IOCTL" path could also produce. A non-sentinel FileID
+	// must yield StatusInvalidParameter per MS-SMB2 §3.3.5.15.13; the
+	// generic path would return StatusNotSupported. This asserts dispatch
+	// routing independent of host interface enumerability.
 	w2 := smbenc.NewWriter(24)
 	w2.WriteUint16(57)
 	w2.WriteUint16(0)
 	w2.WriteUint32(FsctlQueryNetworkInterfInfo)
-	w2.WriteBytes(bytes.Repeat([]byte{0xFF}, 16))
+	w2.WriteBytes(make([]byte, 16)) // zero FileID — not the 0xFF sentinel
 	body2 := w2.Bytes()
 
 	result2, err := h.Ioctl(ctx, body2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// This test verifies dispatch only: the handler accepts either
-	// StatusSuccess (interfaces enumerable) or StatusNotSupported (sandboxed
-	// runner with no non-loopback interface). What we must NOT see is
-	// StatusNotSupported for an UNKNOWN IOCTL — that would indicate the
-	// dispatch table is missing the entry.
-	if result2.Status != types.StatusSuccess && result2.Status != types.StatusNotSupported {
-		t.Errorf("expected StatusSuccess or StatusNotSupported for FSCTL_QUERY_NETWORK_INTERFACE_INFO, got %v", result2.Status)
+	if result2.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter for non-sentinel FileID (proves dispatch routed to handler), got %v", result2.Status)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/ioctl_validate_negotiate_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_validate_negotiate_test.go
@@ -397,20 +397,26 @@ func TestIoctlDispatchTable_RoutesCorrectly(t *testing.T) {
 		t.Errorf("expected StatusNotSupported for unknown IOCTL, got %v", result.Status)
 	}
 
-	// Test that known IOCTL code FSCTL_QUERY_NETWORK_INTERFACE_INFO returns StatusNotSupported
-	w2 := smbenc.NewWriter(16)
+	// FSCTL_QUERY_NETWORK_INTERFACE_INFO now dispatches to a real handler.
+	// Request layout: StructureSize(2) Reserved(2) CtlCode(4) FileId(16 sentinel).
+	w2 := smbenc.NewWriter(24)
 	w2.WriteUint16(57)
 	w2.WriteUint16(0)
-	w2.WriteUint32(FsctlQueryNetworkInterfInfo) // Known but unsupported
-	w2.WriteBytes(make([]byte, 4))
+	w2.WriteUint32(FsctlQueryNetworkInterfInfo)
+	w2.WriteBytes(bytes.Repeat([]byte{0xFF}, 16))
 	body2 := w2.Bytes()
 
 	result2, err := h.Ioctl(ctx, body2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result2.Status != types.StatusNotSupported {
-		t.Errorf("expected StatusNotSupported for FSCTL_QUERY_NETWORK_INTERFACE_INFO, got %v", result2.Status)
+	// This test verifies dispatch only: the handler accepts either
+	// StatusSuccess (interfaces enumerable) or StatusNotSupported (sandboxed
+	// runner with no non-loopback interface). What we must NOT see is
+	// StatusNotSupported for an UNKNOWN IOCTL — that would indicate the
+	// dispatch table is missing the entry.
+	if result2.Status != types.StatusSuccess && result2.Status != types.StatusNotSupported {
+		t.Errorf("expected StatusSuccess or StatusNotSupported for FSCTL_QUERY_NETWORK_INTERFACE_INFO, got %v", result2.Status)
 	}
 }
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -33,7 +33,6 @@ Phase 2 of #361.
 |-----------|----------|--------|-------|
 | smb2.multichannel.bugs.bug_15346 | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
 | smb2.multichannel.generic.num_channels | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
-| smb2.multichannel.generic.interface_info | Multi-channel | FSCTL_QUERY_NETWORK_INTERFACE_INFO not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test1 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test2 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test3 | Multi-channel | Cross-channel lease break dispatch not yet implemented (Phase 2 of #361) | #361 |


### PR DESCRIPTION
## Summary

Phase 2 PR 1 of #361 (multi-channel). Implement `FSCTL_QUERY_NETWORK_INTERFACE_INFO` (MS-SMB2 §2.2.32.5) so clients can enumerate the server's interfaces before opening additional channels. Unblocks \`smb2.multichannel.generic.interface_info\` in smbtorture.

**Key points:**
- Enumerates host interfaces via \`net.InterfaceAddrs()\`, skipping loopback and IPv6 link-local.
- Emits a linked \`NETWORK_INTERFACE_INFO\` list per MS-SMB2 §2.2.32.5: one entry per usable unicast address with \`IfIndex\`, \`Capability=0\` (no RSS/RDMA advertised), \`LinkSpeed=1 Gbps\`, and a \`SOCKADDR_IN\`/\`IN6\` embedded in the 128-byte \`SockAddr_Storage\`.
- \`LinkSpeed\` is advisory only (MS-SMB2 §3.2.5.14.11). 1 Gbps matches Samba's fallback; dynamic detection would need platform-specific code for negligible real-world benefit (especially under container deployments where the host NIC speed is not the effective bandwidth).
- Enforces the all-0xFF \`FileID\` sentinel per MS-SMB2 §3.3.5.15.13 — non-sentinel values return \`STATUS_INVALID_PARAMETER\`.
- Returns \`STATUS_NOT_SUPPORTED\` when no enumerable interfaces exist (sandboxed runners), so clients cleanly fall back to single-channel rather than parsing a zero-entry list.

## Not in this PR

- Cross-channel lease/oplock break fan-out — Phase 2 PR 2 (upcoming).
- Wide-channel coordination and \`test3_specification\` 32-channel retry logic — Phase 2 PR 3.
- Bind-address filtering (Docker bridge / VPN tunnel addresses may be advertised). Noted as a follow-up; practical impact depends on deployment topology.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/adapter/smb/v2/handlers/...\`
- [x] smbtorture \`smb2.multichannel.generic.interface_info\` — PASS locally (memory profile)
- [ ] CI will rerun the full smbtorture + WPTS BVT + Kerberos matrices