### PR TITLE
ci: auto-close issues referenced in commits pushed to main

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -31,8 +31,10 @@ jobs:
 
           # Force-push (release rebase) leaves BEFORE as the old tip; the
           # range BEFORE..AFTER still enumerates every newly-reachable commit.
-          # On first push to a branch BEFORE is all zeros — fall back to AFTER alone.
-          if [[ "$BEFORE" =~ ^0+$ ]]; then
+          # On first push to a branch BEFORE is all zeros; after a force-push
+          # rebase BEFORE may be unreachable (old tip GC'd or not fetched).
+          # Fall back to walking AFTER alone in either case.
+          if [[ "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
             RANGE="$AFTER"
           else
             RANGE="$BEFORE..$AFTER"

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,54 @@
+name: Close linked issues on main
+
+# Closes issues referenced with "Closes #N" / "Fixes #N" / "Resolves #N"
+# in any commit pushed to main. GitHub's built-in auto-close only fires
+# when a PR merges into the default branch; since we merge PRs into
+# develop and only rebase main at release time, this workflow handles
+# the close on release instead.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Close referenced issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+
+          # Force-push (release rebase) leaves BEFORE as the old tip; the
+          # range BEFORE..AFTER still enumerates every newly-reachable commit.
+          # On first push to a branch BEFORE is all zeros — fall back to AFTER alone.
+          if [[ "$BEFORE" =~ ^0+$ ]]; then
+            RANGE="$AFTER"
+          else
+            RANGE="$BEFORE..$AFTER"
+          fi
+
+          git log --format=%B "$RANGE" \
+            | grep -oiE '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))[[:space:]]+#[0-9]+' \
+            | grep -oE '#[0-9]+' \
+            | sort -u \
+            | while read -r ref; do
+                num="${ref#\#}"
+                state=$(gh issue view "$num" --json state -q .state 2>/dev/null || echo "MISSING")
+                if [[ "$state" == "OPEN" ]]; then
+                  echo "Closing #$num"
+                  gh issue close "$num" --comment "Closed by release commit on \`main\` (${GITHUB_SHA:0:7})." || true
+                else
+                  echo "Skipping #$num (state=$state)"
+                fi
+              done

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -39,15 +39,14 @@ jobs:
           fi
 
           git log --format=%B "$RANGE" \
-            | grep -oiE '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))[[:space:]]+#[0-9]+' \
-            | grep -oE '#[0-9]+' \
+            | grep -oiE '(close[ds]?|fix(e[ds])?|resolve[ds]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
             | sort -u \
-            | while read -r ref; do
-                num="${ref#\#}"
+            | while read -r num; do
                 state=$(gh issue view "$num" --json state -q .state 2>/dev/null || echo "MISSING")
                 if [[ "$state" == "OPEN" ]]; then
                   echo "Closing #$num"
-                  gh issue close "$num" --comment "Closed by release commit on \`main\` (${GITHUB_SHA:0:7})." || true
+                  gh issue close "$num" --comment "Closed by release commit on \`main\` (${GITHUB_SHA:0:7})."
                 else
                   echo "Skipping #$num (state=$state)"
                 fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/close-linked-issues.yml` — a lightweight workflow that scans commits pushed to `main` for `Closes #N` / `Fixes #N` / `Resolves #N` keywords (and their tense variants) and closes those issues via `gh issue close`.

## Why

GitHub's built-in auto-close only fires when a PR merges into the default branch. In this repo:
- PRs merge into `develop`
- `main` is rebased from `develop` at release time and tagged
- So linked issues never close automatically (e.g. #405 had to be closed by hand after v0.14.0 shipped)

Keeping `main` as the default branch (so repo visitors see the stable README) means we need something else to handle the close-on-release flow. This workflow is that something.

## Behavior

- Triggers on `push` to `main`.
- Walks the push range (`BEFORE..AFTER`), with fallbacks for first-push-to-branch (zero SHA) and force-push where `BEFORE` is unreachable.
- Matches the standard GitHub keyword set (`close[ds]?`, `fix(e[ds])?`, `resolve[ds]?`) followed by `#N`.
- Only closes issues currently in `OPEN` state — idempotent across release rebases.
- Posts a short comment linking the close to the release SHA.

## Test plan

- [x] Merge this PR to develop
- [x] Next release rebase that touches `main` with a commit containing `Closes #X` should close #X automatically
- [x] Rerun (idempotency): re-push to main with the same commit; already-closed issue skipped, no duplicate comment

🔒 Permissions scoped to `issues: write` + `contents: read`. Uses the built-in `github.token` — no PAT.