### PR TITLE
fix(backup): validate destination + reject duplicate repos — #409

### DIFF
--- a/internal/controlplane/api/handlers/backup_repos.go
+++ b/internal/controlplane/api/handlers/backup_repos.go
@@ -400,8 +400,11 @@ func (h *BackupHandler) checkRepoDestinationCollision(ctx context.Context, repo 
 		if other == nil || other.ID == repo.ID || other.Kind != repo.Kind {
 			continue
 		}
-		// Bad config on either side — let ValidateConfig surface it later.
-		if collision, _ := sameDestination(repo, other); collision {
+		collision, err := sameDestination(repo, other)
+		if err != nil {
+			return fmt.Errorf("compare destination with repo %q: %w", other.Name, err)
+		}
+		if collision {
 			return fmt.Errorf("%w: destination already used by repo %q",
 				destination.ErrIncompatibleConfig, other.Name)
 		}
@@ -443,17 +446,36 @@ func sameDestination(a, b *models.BackupRepo) (bool, error) {
 }
 
 // resolveLocalPath returns a canonical form of p for collision comparison:
-// absolute + symlinks resolved when possible (catches /tmp vs /private/tmp
-// on macOS), else falls back to filepath.Clean(Abs(...)) for paths that
-// don't yet exist. Returns the raw input on Abs failure so two identical
-// bad inputs still match.
+// absolute + symlinks resolved (catches /tmp vs /private/tmp on macOS).
+// If the leaf doesn't exist yet — common at repo-create time —
+// EvalSymlinks on the full path fails, so we walk up to the nearest
+// existing ancestor, resolve that, and rejoin the unresolved suffix so
+// non-existent paths still canonicalize consistently. Returns the
+// cleaned input on Abs failure so two identical bad inputs still match.
 func resolveLocalPath(p string) string {
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		return filepath.Clean(p)
 	}
 	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
+		return filepath.Clean(resolved)
+	}
+	current := abs
+	var suffix []string
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			out := resolved
+			for i := len(suffix) - 1; i >= 0; i-- {
+				out = filepath.Join(out, suffix[i])
+			}
+			return filepath.Clean(out)
+		}
 	}
 	return filepath.Clean(abs)
 }

--- a/internal/controlplane/api/handlers/backup_repos.go
+++ b/internal/controlplane/api/handlers/backup_repos.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/backup/destination"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
@@ -70,6 +73,10 @@ func (h *BackupHandler) CreateRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.EncryptionKeyRef != nil {
 		repo.EncryptionKeyRef = *req.EncryptionKeyRef
+	}
+
+	if !h.validateRepoDestination(w, r.Context(), repo) {
+		return
 	}
 
 	id, err := h.store.CreateBackupRepo(r.Context(), repo)
@@ -200,6 +207,10 @@ func (h *BackupHandler) PatchRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.EncryptionKeyRef != nil {
 		repo.EncryptionKeyRef = *req.EncryptionKeyRef
+	}
+
+	if !h.validateRepoDestination(w, r.Context(), repo) {
+		return
 	}
 
 	if err := h.store.UpdateBackupRepo(r.Context(), repo); err != nil {
@@ -338,6 +349,113 @@ func (h *BackupHandler) purgeRepoArchives(ctx context.Context, repo *models.Back
 		}
 	}
 	return failed, nil
+}
+
+// validateRepoDestination probes the repo config before persist (D-12/D-13):
+// cross-repo collision (same local path or same s3 bucket+prefix) then a
+// driver-level ValidateConfig via destFactory. Writes 422 on
+// ErrIncompatibleConfig, 500 on anything else, and returns false when the
+// response has been written. destFactory==nil skips the driver probe.
+func (h *BackupHandler) validateRepoDestination(w http.ResponseWriter, ctx context.Context, repo *models.BackupRepo) bool {
+	writeErr := func(op string, err error) bool {
+		if errors.Is(err, destination.ErrIncompatibleConfig) {
+			UnprocessableEntity(w, err.Error())
+			return false
+		}
+		logger.Error(op, "repo", repo.Name, "error", err)
+		InternalServerError(w, "Failed to validate repo configuration")
+		return false
+	}
+
+	if err := h.checkRepoDestinationCollision(ctx, repo); err != nil {
+		return writeErr("Repo collision check failed", err)
+	}
+	if h.destFactory == nil {
+		return true
+	}
+	dst, err := h.destFactory(ctx, repo)
+	if err != nil {
+		return writeErr("Build destination for validation failed", err)
+	}
+	defer func() {
+		if cerr := dst.Close(); cerr != nil {
+			logger.Warn("Destination close after validation", "repo", repo.Name, "error", cerr)
+		}
+	}()
+	if err := dst.ValidateConfig(ctx); err != nil {
+		return writeErr("ValidateConfig failed", err)
+	}
+	return true
+}
+
+// checkRepoDestinationCollision rejects repos sharing a destination with
+// an existing row. Self (same ID) is skipped so PATCH of an unchanged
+// path still succeeds.
+func (h *BackupHandler) checkRepoDestinationCollision(ctx context.Context, repo *models.BackupRepo) error {
+	existing, err := h.store.ListAllBackupRepos(ctx)
+	if err != nil {
+		return fmt.Errorf("list repos: %w", err)
+	}
+	for _, other := range existing {
+		if other == nil || other.ID == repo.ID || other.Kind != repo.Kind {
+			continue
+		}
+		// Bad config on either side — let ValidateConfig surface it later.
+		if collision, _ := sameDestination(repo, other); collision {
+			return fmt.Errorf("%w: destination already used by repo %q",
+				destination.ErrIncompatibleConfig, other.Name)
+		}
+	}
+	return nil
+}
+
+// sameDestination reports whether `a` and `b` point at the same backing
+// location: resolved absolute path (local) or (bucket, normalized-prefix) (s3).
+func sameDestination(a, b *models.BackupRepo) (bool, error) {
+	cfgA, err := a.GetConfig()
+	if err != nil {
+		return false, err
+	}
+	cfgB, err := b.GetConfig()
+	if err != nil {
+		return false, err
+	}
+	switch a.Kind {
+	case models.BackupRepoKindLocal:
+		pa, _ := cfgA["path"].(string)
+		pb, _ := cfgB["path"].(string)
+		if pa == "" || pb == "" {
+			return false, nil
+		}
+		return resolveLocalPath(pa) == resolveLocalPath(pb), nil
+	case models.BackupRepoKindS3:
+		ba, _ := cfgA["bucket"].(string)
+		bb, _ := cfgB["bucket"].(string)
+		if ba == "" || bb == "" || ba != bb {
+			return false, nil
+		}
+		pa, _ := cfgA["prefix"].(string)
+		pb, _ := cfgB["prefix"].(string)
+		return strings.Trim(pa, "/") == strings.Trim(pb, "/"), nil
+	default:
+		return false, nil
+	}
+}
+
+// resolveLocalPath returns a canonical form of p for collision comparison:
+// absolute + symlinks resolved when possible (catches /tmp vs /private/tmp
+// on macOS), else falls back to filepath.Clean(Abs(...)) for paths that
+// don't yet exist. Returns the raw input on Abs failure so two identical
+// bad inputs still match.
+func resolveLocalPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 // resolveMetadataStore writes a problem + returns ok=false on lookup error,

--- a/internal/controlplane/api/handlers/backup_repos_test.go
+++ b/internal/controlplane/api/handlers/backup_repos_test.go
@@ -5,10 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/backup/destination"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/storebackups"
 )
@@ -135,8 +139,10 @@ func TestDeleteRepo_Default_RemovesRow(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 type fakeDest struct {
-	deletes map[string]error // id -> error to return
-	closed  bool
+	deletes     map[string]error // id -> error to return
+	validateErr error
+	closed      bool
+	validated   int
 }
 
 func (d *fakeDest) Delete(_ context.Context, id string) error {
@@ -144,6 +150,10 @@ func (d *fakeDest) Delete(_ context.Context, id string) error {
 		return err
 	}
 	return nil
+}
+func (d *fakeDest) ValidateConfig(_ context.Context) error {
+	d.validated++
+	return d.validateErr
 }
 func (d *fakeDest) Close() error { d.closed = true; return nil }
 
@@ -185,3 +195,183 @@ func TestDeleteRepo_PurgeArchives_CascadesDestination(t *testing.T) {
 		t.Errorf("Destination.Close should have been called")
 	}
 }
+
+// -----------------------------------------------------------------------------
+// #409 — ValidateConfig wiring + cross-repo collision detection
+// -----------------------------------------------------------------------------
+
+func TestCreateRepo_DuplicateLocalPath_Returns422(t *testing.T) {
+	storeFake, _ := seedStoreWithRepo(0)
+	// Seed an existing local repo at /tmp/shared.
+	existing := &models.BackupRepo{
+		ID: "repo-existing", Name: "existing", Kind: models.BackupRepoKindLocal,
+		TargetID: "store-1", TargetKind: "metadata",
+	}
+	if err := existing.SetConfig(map[string]any{"path": "/tmp/shared"}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	storeFake.repos = append(storeFake.repos, existing)
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	body := []byte(`{"name":"dup","kind":"local","config":{"path":"/tmp/shared"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+	// Repo row must not be created.
+	if len(storeFake.repos) != 1 {
+		t.Errorf("repo persisted despite collision; repos=%d", len(storeFake.repos))
+	}
+}
+
+func TestCreateRepo_DuplicateLocalPathViaSymlink_Returns422(t *testing.T) {
+	// Different lexical paths that EvalSymlinks resolves to the same target
+	// must collide. Cover the /tmp → /private/tmp macOS case and the
+	// general "two paths, one inode" case.
+	realDir := t.TempDir()
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	storeFake, _ := seedStoreWithRepo(0)
+	existing := &models.BackupRepo{
+		ID: "repo-existing", Name: "existing", Kind: models.BackupRepoKindLocal,
+		TargetID: "store-1", TargetKind: "metadata",
+	}
+	if err := existing.SetConfig(map[string]any{"path": realDir}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	storeFake.repos = append(storeFake.repos, existing)
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	body := []byte(fmt.Sprintf(`{"name":"dup","kind":"local","config":{"path":%q}}`, linkDir))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCreateRepo_DuplicateS3BucketPrefix_Returns422(t *testing.T) {
+	storeFake, _ := seedStoreWithRepo(0)
+	existing := &models.BackupRepo{
+		ID: "repo-existing", Name: "existing", Kind: models.BackupRepoKindS3,
+		TargetID: "store-1", TargetKind: "metadata",
+	}
+	if err := existing.SetConfig(map[string]any{"bucket": "b1", "prefix": "backups/"}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	storeFake.repos = append(storeFake.repos, existing)
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	// Same bucket + prefix (with normalization) → 422.
+	body := []byte(`{"name":"dup","kind":"s3","config":{"bucket":"b1","prefix":"/backups"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCreateRepo_ValidateConfigFails_Returns422(t *testing.T) {
+	storeFake, _ := seedStoreWithRepo(0)
+	dest := &fakeDest{validateErr: fmt.Errorf("%w: bucket not found", destination.ErrIncompatibleConfig)}
+	factory := func(_ context.Context, _ *models.BackupRepo) (BackupDestinationDeleter, error) {
+		return dest, nil
+	}
+	h := NewBackupHandler(storeFake, &fakeBackupService{}, factory)
+
+	body := []byte(`{"name":"new","kind":"local","config":{"path":"/tmp/new"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+	if dest.validated != 1 {
+		t.Errorf("ValidateConfig call count = %d, want 1", dest.validated)
+	}
+	if !dest.closed {
+		t.Errorf("destination not closed after validation")
+	}
+	if len(storeFake.repos) != 0 {
+		t.Errorf("repo persisted despite ValidateConfig failure; repos=%d", len(storeFake.repos))
+	}
+}
+
+func TestCreateRepo_ValidateConfigSucceeds_Returns201(t *testing.T) {
+	storeFake, _ := seedStoreWithRepo(0)
+	dest := &fakeDest{}
+	factory := func(_ context.Context, _ *models.BackupRepo) (BackupDestinationDeleter, error) {
+		return dest, nil
+	}
+	h := NewBackupHandler(storeFake, &fakeBackupService{}, factory)
+
+	body := []byte(`{"name":"new","kind":"local","config":{"path":"/tmp/new"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	if dest.validated != 1 {
+		t.Errorf("ValidateConfig call count = %d, want 1", dest.validated)
+	}
+}
+
+func TestPatchRepo_OntoAnotherRepoPath_Returns422(t *testing.T) {
+	storeFake, repos := seedStoreWithRepo(2)
+	// repos[0]=primary (/tmp/a), repos[1]=repo1 (/tmp/b).
+	if err := repos[0].SetConfig(map[string]any{"path": "/tmp/a"}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := repos[1].SetConfig(map[string]any{"path": "/tmp/b"}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	body := []byte(`{"config":{"path":"/tmp/b"}}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/store/metadata/fast-meta/repos/primary", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta", "repo": "primary"})
+	rr := httptest.NewRecorder()
+	h.PatchRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPatchRepo_KeepsOwnPath_Returns200(t *testing.T) {
+	storeFake, repos := seedStoreWithRepo(1)
+	if err := repos[0].SetConfig(map[string]any{"path": "/tmp/a"}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	// Same path — must not self-collide.
+	body := []byte(`{"config":{"path":"/tmp/a"}, "keep_count": 5}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/store/metadata/fast-meta/repos/primary", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta", "repo": "primary"})
+	rr := httptest.NewRecorder()
+	h.PatchRepo(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+

--- a/internal/controlplane/api/handlers/backup_repos_test.go
+++ b/internal/controlplane/api/handlers/backup_repos_test.go
@@ -260,6 +260,42 @@ func TestCreateRepo_DuplicateLocalPathViaSymlink_Returns422(t *testing.T) {
 	}
 }
 
+func TestCreateRepo_DuplicateLocalPathViaSymlinkLeafMissing_Returns422(t *testing.T) {
+	// Variant of the symlink case where the leaf doesn't exist yet —
+	// e.g. the operator is about to create /tmp/new-repo. EvalSymlinks
+	// fails on the full path, so resolveLocalPath must walk up to the
+	// first existing ancestor (here: the symlink target) and rejoin the
+	// suffix. Without the walk-up, this collision slips through.
+	realDir := t.TempDir()
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	leafReal := filepath.Join(realDir, "new-repo")
+	leafLink := filepath.Join(linkDir, "new-repo")
+
+	storeFake, _ := seedStoreWithRepo(0)
+	existing := &models.BackupRepo{
+		ID: "repo-existing", Name: "existing", Kind: models.BackupRepoKindLocal,
+		TargetID: "store-1", TargetKind: "metadata",
+	}
+	if err := existing.SetConfig(map[string]any{"path": leafReal}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	storeFake.repos = append(storeFake.repos, existing)
+	h := newTestHandler(storeFake, &fakeBackupService{})
+
+	body := []byte(fmt.Sprintf(`{"name":"dup","kind":"local","config":{"path":%q}}`, leafLink))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/store/metadata/fast-meta/repos", bytes.NewReader(body))
+	req = withRouteParams(req, map[string]string{"name": "fast-meta"})
+	rr := httptest.NewRecorder()
+	h.CreateRepo(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestCreateRepo_DuplicateS3BucketPrefix_Returns422(t *testing.T) {
 	storeFake, _ := seedStoreWithRepo(0)
 	existing := &models.BackupRepo{

--- a/internal/controlplane/api/handlers/backup_repos_test.go
+++ b/internal/controlplane/api/handlers/backup_repos_test.go
@@ -374,4 +374,3 @@ func TestPatchRepo_KeepsOwnPath_Returns200(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
 }
-

--- a/internal/controlplane/api/handlers/backups.go
+++ b/internal/controlplane/api/handlers/backups.go
@@ -42,10 +42,12 @@ type BackupService interface {
 }
 
 // BackupDestinationDeleter is the narrow interface over a destination
-// driver's Delete method used by DeleteRepo(?purge_archives=true). Kept
-// local so tests can stub it without importing pkg/backup/destination.
+// driver used by DeleteRepo(?purge_archives=true) (Delete/Close) and
+// CreateRepo / PatchRepo (ValidateConfig, D-12/D-13). Kept local so tests
+// can stub it without importing pkg/backup/destination.
 type BackupDestinationDeleter interface {
 	Delete(ctx context.Context, id string) error
+	ValidateConfig(ctx context.Context) error
 	Close() error
 }
 


### PR DESCRIPTION
## Summary

Closes #409. `destination.ValidateConfig` was never called at repo create/update time, so two backup repos could silently point at the same local path or same S3 bucket+prefix — causing retention to cross-delete archives and `List` to return manifests from both repos.

- Add `ValidateConfig(ctx)` to the handler-local `BackupDestinationDeleter` interface so the factory result can be probed.
- `CreateRepo` / `PatchRepo` now, before persisting:
  1. Cross-repo collision check via `ListAllBackupRepos` — rejects another repo with the same resolved local path (`filepath.Abs` + `EvalSymlinks`, catching `/tmp` vs `/private/tmp`) or the same bucket + trimmed prefix. PATCH skips self so unchanged paths pass.
  2. `dst.ValidateConfig(ctx)` via the injected `destFactory`.
- `destination.ErrIncompatibleConfig` → **422 Unprocessable Entity**; other errors → 500.
- Driver validation is skipped when `destFactory` is nil (degraded start / tests not exercising this path).

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New handler tests: duplicate local path (direct + symlink), duplicate s3 bucket+prefix, `ValidateConfig` failure → 422, success → 201, PATCH onto sibling path → 422, PATCH keeping own path → 200
- [ ] Manual repro from the issue: `POST` two local repos on `/tmp/same-path` → second returns 422