### PR TITLE
smb: wide/many-channel coordination — closes Phase 2 of #361

### DIFF
--- a/internal/adapter/smb/session/channel.go
+++ b/internal/adapter/smb/session/channel.go
@@ -73,43 +73,73 @@ type Channel struct {
 	Transport ChannelTransport
 }
 
-// AddChannel registers a channel on the session, keyed by ConnID. A subsequent
-// AddChannel with the same ConnID replaces the prior entry — callers must not
-// rely on deduplication since MS-SMB2 explicitly rejects binding an already-
-// bound connection at the handler layer (§3.3.5.5.2).
-func (s *Session) AddChannel(c *Channel) {
+// MaxChannelsPerSession is the spec-mandated upper bound on the number of
+// concurrent channels bound to a single SMB session. MS-SMB2 §3.3.5.5.2
+// requires the server to reject further binds once the per-session channel
+// table is full; Windows and Samba enforce 32 (`smbXsrv_client.max_channels`),
+// and smb2.multichannel.generic.num_channels asserts the 33rd bind is
+// rejected with STATUS_INSUFFICIENT_RESOURCES.
+const MaxChannelsPerSession = 32
+
+// AddChannel registers a channel on the session, keyed by ConnID. Returns
+// true on success, false when the per-session channel cap would be exceeded.
+//
+// A replacement of an existing ConnID (which callers must not rely on per the
+// §3.3.5.5.2 language "server MUST return STATUS_REQUEST_NOT_ACCEPTED if the
+// connection is already bound to the session") does not count against the cap:
+// it's the same slot.
+//
+// The count-and-insert are held under channelsMu to keep the cap race-free
+// under concurrent binds — see smb2.multichannel.bugs.bug_15346.
+func (s *Session) AddChannel(c *Channel) bool {
 	if c == nil {
-		return
+		return false
 	}
 	if c.BoundAt.IsZero() {
 		c.BoundAt = time.Now()
 	}
-	s.channels.Store(c.ConnID, c)
+	s.channelsMu.Lock()
+	defer s.channelsMu.Unlock()
+	if _, replacing := s.channels[c.ConnID]; !replacing {
+		if len(s.channels) >= MaxChannelsPerSession {
+			return false
+		}
+	}
+	s.channels[c.ConnID] = c
+	return true
 }
 
 // GetChannel returns the channel for the given ConnID, or nil if none is
 // registered. Safe for concurrent use.
 func (s *Session) GetChannel(connID uint64) *Channel {
-	v, ok := s.channels.Load(connID)
-	if !ok {
-		return nil
-	}
-	return v.(*Channel)
+	s.channelsMu.RLock()
+	defer s.channelsMu.RUnlock()
+	return s.channels[connID]
 }
 
 // RemoveChannel unregisters a channel. Called when the TCP connection closes.
 func (s *Session) RemoveChannel(connID uint64) {
-	s.channels.Delete(connID)
+	s.channelsMu.Lock()
+	defer s.channelsMu.Unlock()
+	delete(s.channels, connID)
 }
 
 // ListChannels returns a snapshot of all channels currently bound to the
 // session. Used for break-notification fan-out in the lease/oplock layer.
 // Order is not guaranteed.
 func (s *Session) ListChannels() []*Channel {
-	var out []*Channel
-	s.channels.Range(func(_, v any) bool {
-		out = append(out, v.(*Channel))
-		return true
-	})
+	s.channelsMu.RLock()
+	defer s.channelsMu.RUnlock()
+	out := make([]*Channel, 0, len(s.channels))
+	for _, c := range s.channels {
+		out = append(out, c)
+	}
 	return out
+}
+
+// ChannelCount returns the current number of channels bound to the session.
+func (s *Session) ChannelCount() int {
+	s.channelsMu.RLock()
+	defer s.channelsMu.RUnlock()
+	return len(s.channels)
 }

--- a/internal/adapter/smb/session/channel_test.go
+++ b/internal/adapter/smb/session/channel_test.go
@@ -141,8 +141,10 @@ func TestSession_AddChannel_ReplaceDoesNotCountAgainstCap(t *testing.T) {
 }
 
 // TestSession_AddChannel_ConcurrentCap stresses concurrent binds far in excess
-// of the cap and verifies exactly MaxChannelsPerSession succeed. Guards against
-// the race that smb2.multichannel.bugs.bug_15346 targets at the channel layer.
+// of the cap and verifies exactly MaxChannelsPerSession succeed — guarding the
+// atomicity of the count-and-insert under concurrent AddChannel calls. A naive
+// sync.Map-backed registry with a "len() < cap then Store" sequence would
+// admit more than MaxChannelsPerSession under race.
 func TestSession_AddChannel_ConcurrentCap(t *testing.T) {
 	s := NewSession(1, "", false, "", "")
 

--- a/internal/adapter/smb/session/channel_test.go
+++ b/internal/adapter/smb/session/channel_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -91,5 +93,77 @@ func TestSession_AddChannel_ReplaceSameConnID(t *testing.T) {
 	}
 	if l := s.ListChannels(); len(l) != 1 {
 		t.Fatalf("ListChannels len=%d, want 1 after same-ConnID replacement", len(l))
+	}
+}
+
+// TestSession_AddChannel_CapReject verifies the per-session channel cap
+// (MS-SMB2 §3.3.5.5.2 / smb2.multichannel.generic.num_channels): channels 1..N
+// where N = MaxChannelsPerSession must succeed, channel N+1 must fail.
+func TestSession_AddChannel_CapReject(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	for i := 0; i < MaxChannelsPerSession; i++ {
+		if !s.AddChannel(&Channel{ConnID: uint64(i + 1)}) {
+			t.Fatalf("AddChannel #%d rejected unexpectedly", i+1)
+		}
+	}
+	if s.AddChannel(&Channel{ConnID: uint64(MaxChannelsPerSession + 1)}) {
+		t.Fatalf("AddChannel past cap (%d) succeeded; must be rejected",
+			MaxChannelsPerSession)
+	}
+	if got := s.ChannelCount(); got != MaxChannelsPerSession {
+		t.Fatalf("ChannelCount=%d, want %d", got, MaxChannelsPerSession)
+	}
+
+	// Removing a slot must free capacity for a new channel.
+	s.RemoveChannel(1)
+	if !s.AddChannel(&Channel{ConnID: 999}) {
+		t.Fatalf("AddChannel after RemoveChannel rejected; cap slot should free")
+	}
+}
+
+// TestSession_AddChannel_ReplaceDoesNotCountAgainstCap verifies that updating
+// an already-registered ConnID does not consume an additional slot.
+func TestSession_AddChannel_ReplaceDoesNotCountAgainstCap(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+	for i := 0; i < MaxChannelsPerSession; i++ {
+		if !s.AddChannel(&Channel{ConnID: uint64(i + 1)}) {
+			t.Fatalf("AddChannel #%d rejected unexpectedly", i+1)
+		}
+	}
+	// Re-adding an existing ConnID with updated state must succeed even at cap.
+	if !s.AddChannel(&Channel{ConnID: 1, RemoteAddr: "updated"}) {
+		t.Fatal("replacing existing ConnID was rejected at cap; it should not count")
+	}
+	got := s.GetChannel(1)
+	if got == nil || got.RemoteAddr != "updated" {
+		t.Fatalf("replacement did not take effect: %+v", got)
+	}
+}
+
+// TestSession_AddChannel_ConcurrentCap stresses concurrent binds far in excess
+// of the cap and verifies exactly MaxChannelsPerSession succeed. Guards against
+// the race that smb2.multichannel.bugs.bug_15346 targets at the channel layer.
+func TestSession_AddChannel_ConcurrentCap(t *testing.T) {
+	s := NewSession(1, "", false, "", "")
+
+	const totalAttempts = 200
+	var accepted atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < totalAttempts; i++ {
+		wg.Add(1)
+		go func(id uint64) {
+			defer wg.Done()
+			if s.AddChannel(&Channel{ConnID: id}) {
+				accepted.Add(1)
+			}
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+
+	if got := accepted.Load(); got != int64(MaxChannelsPerSession) {
+		t.Fatalf("accepted=%d, want exactly %d", got, MaxChannelsPerSession)
+	}
+	if got := s.ChannelCount(); got != MaxChannelsPerSession {
+		t.Fatalf("ChannelCount=%d, want %d", got, MaxChannelsPerSession)
 	}
 }

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -112,7 +112,12 @@ type Session struct {
 	// session-level Signer via the dispatch fallback. All channels share
 	// the session key but each derives its own signing key. Access via
 	// AddChannel / GetChannel / RemoveChannel / ListChannels (channel.go).
-	channels sync.Map
+	//
+	// A plain map + RWMutex (rather than sync.Map) is used so the cap
+	// enforcement in AddChannel — "count < MaxChannelsPerSession, then
+	// insert" — is atomic under concurrent binds.
+	channelsMu sync.RWMutex
+	channels   map[uint64]*Channel
 }
 
 // Credits tracks credit accounting for a session.
@@ -149,6 +154,7 @@ func NewSession(sessionID uint64, clientAddr string, isGuest bool, username, dom
 		Domain:       domain,
 		CryptoState:  &SessionCryptoState{},
 		NewlyCreated: true,
+		channels:     make(map[uint64]*Channel),
 	}
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s
@@ -168,6 +174,7 @@ func NewSessionWithUser(sessionID uint64, clientAddr string, user *models.User, 
 		User:         user,
 		CryptoState:  &SessionCryptoState{},
 		NewlyCreated: true,
+		channels:     make(map[uint64]*Channel),
 	}
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -913,13 +913,15 @@ func (h *Handler) StoreOpenFile(file *OpenFile) {
 	h.files.Store(string(file.FileID[:]), file)
 }
 
-// pendingAuthKey is the composite key for pendingAuth lookups. It combines the
-// target SessionID (0 for an initial handshake, the bound session for a bind,
-// or the existing session for re-auth) with the carrying ConnID so that
-// concurrent SESSION_SETUPs on the same session from different TCP connections
-// do not clobber each other. Without per-connection keying, the regression
-// guarded by smb2.multichannel.bugs.bug_15346 fails (Samba bug 15346): parallel
-// binds race on a single slot and the TYPE_3 of one channel picks up the
+// pendingAuthKey is the composite key for pendingAuth lookups. SessionID is
+// the session the handshake targets — the server-generated ID for an initial
+// NTLM NEGOTIATE, the bound session for a bind, or the existing session for
+// re-auth — and is the ID the client carries in the TYPE_3 header. ConnID
+// disambiguates concurrent handshakes on the same SessionID so that parallel
+// SESSION_SETUPs from different TCP connections do not clobber each other.
+// Without per-connection keying, the regression guarded by
+// smb2.multichannel.bugs.bug_15346 fails (Samba bug 15346): parallel binds
+// race on a single slot and the TYPE_3 of one channel picks up the
 // ServerChallenge of another.
 type pendingAuthKey struct {
 	SessionID uint64

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -40,8 +40,11 @@ type Handler struct {
 	// Session management (unified with credit tracking)
 	SessionManager *session.Manager
 
-	// Pending auth sessions (mid-handshake)
-	pendingAuth sync.Map // sessionID -> *PendingAuth
+	// Pending auth sessions (mid-handshake). Keyed by pendingAuthKey so that
+	// concurrent SESSION_SETUPs on the same session from different connections
+	// (e.g. multiple parallel channel binds, MS-SMB2 §3.3.5.5.2) do not clobber
+	// each other's TYPE_2 challenge / ServerChallenge. See Samba bug 15346.
+	pendingAuth sync.Map // pendingAuthKey -> *PendingAuth
 
 	// Tree connections
 	trees      sync.Map // treeID -> *TreeConnection
@@ -201,6 +204,10 @@ type PendingAuth struct {
 	// channel rather than creating a new session. MS-SMB2 §3.3.5.5.2.
 	IsBinding        bool
 	BindingSessionID uint64
+	// ConnID is the TCP connection carrying this authentication. Pending auth
+	// is keyed by (SessionID, ConnID) so concurrent binds on the same session
+	// from different connections (MS-SMB2 §3.3.5.5.2) do not collide.
+	ConnID uint64
 	// MechListBytes: DER-encoded SEQUENCE OF OID from the NegTokenInit's
 	// mechTypes field, needed to compute the SPNEGO mechListMIC in the
 	// final accept-completed response (MS-NLMP 3.4.5.2 + 2.2.2.9.1).
@@ -741,8 +748,8 @@ func (h *Handler) CleanupSession(ctx context.Context, sessionID uint64, isDiscon
 	// 3. Delete all tree connections
 	treesDeleted := h.DeleteAllTreesForSession(sessionID)
 
-	// 4. Clean up any pending auth state
-	h.DeletePendingAuth(sessionID)
+	// 4. Clean up any pending auth state (all channels)
+	h.DeleteAllPendingAuthForSession(sessionID)
 
 	// 5. Delete the session itself
 	h.DeleteSession(sessionID)
@@ -906,23 +913,49 @@ func (h *Handler) StoreOpenFile(file *OpenFile) {
 	h.files.Store(string(file.FileID[:]), file)
 }
 
-// StorePendingAuth stores a pending authentication
-func (h *Handler) StorePendingAuth(pending *PendingAuth) {
-	h.pendingAuth.Store(pending.SessionID, pending)
+// pendingAuthKey is the composite key for pendingAuth lookups. It combines the
+// target SessionID (0 for an initial handshake, the bound session for a bind,
+// or the existing session for re-auth) with the carrying ConnID so that
+// concurrent SESSION_SETUPs on the same session from different TCP connections
+// do not clobber each other. Without per-connection keying, the regression
+// guarded by smb2.multichannel.bugs.bug_15346 fails (Samba bug 15346): parallel
+// binds race on a single slot and the TYPE_3 of one channel picks up the
+// ServerChallenge of another.
+type pendingAuthKey struct {
+	SessionID uint64
+	ConnID    uint64
 }
 
-// GetPendingAuth retrieves a pending authentication by session ID
-func (h *Handler) GetPendingAuth(sessionID uint64) (*PendingAuth, bool) {
-	v, ok := h.pendingAuth.Load(sessionID)
+// StorePendingAuth stores a pending authentication. pending.SessionID and
+// pending.ConnID together form the lookup key.
+func (h *Handler) StorePendingAuth(pending *PendingAuth) {
+	h.pendingAuth.Store(pendingAuthKey{pending.SessionID, pending.ConnID}, pending)
+}
+
+// GetPendingAuth retrieves a pending authentication by (sessionID, connID).
+func (h *Handler) GetPendingAuth(sessionID, connID uint64) (*PendingAuth, bool) {
+	v, ok := h.pendingAuth.Load(pendingAuthKey{sessionID, connID})
 	if !ok {
 		return nil, false
 	}
 	return v.(*PendingAuth), true
 }
 
-// DeletePendingAuth removes a pending authentication
-func (h *Handler) DeletePendingAuth(sessionID uint64) {
-	h.pendingAuth.Delete(sessionID)
+// DeletePendingAuth removes a pending authentication for a specific connection.
+func (h *Handler) DeletePendingAuth(sessionID, connID uint64) {
+	h.pendingAuth.Delete(pendingAuthKey{sessionID, connID})
+}
+
+// DeleteAllPendingAuthForSession removes every pending-auth record associated
+// with sessionID, regardless of connection. Used on session teardown (LOGOFF,
+// connection cleanup) to invalidate any in-flight binds for the session.
+func (h *Handler) DeleteAllPendingAuthForSession(sessionID uint64) {
+	h.pendingAuth.Range(func(k, _ any) bool {
+		if key, ok := k.(pendingAuthKey); ok && key.SessionID == sessionID {
+			h.pendingAuth.Delete(key)
+		}
+		return true
+	})
 }
 
 // checkShareModeConflict checks if opening a file with the given access and sharing

--- a/internal/adapter/smb/v2/handlers/handler_test.go
+++ b/internal/adapter/smb/v2/handlers/handler_test.go
@@ -197,13 +197,14 @@ func TestPendingAuthStorage(t *testing.T) {
 
 		pending := &PendingAuth{
 			SessionID:  1,
+			ConnID:     10,
 			ClientAddr: "127.0.0.1:12345",
 			CreatedAt:  time.Now(),
 		}
 
 		h.StorePendingAuth(pending)
 
-		retrieved, ok := h.GetPendingAuth(1)
+		retrieved, ok := h.GetPendingAuth(1, 10)
 		if !ok {
 			t.Fatal("PendingAuth not found")
 		}
@@ -219,7 +220,7 @@ func TestPendingAuthStorage(t *testing.T) {
 	t.Run("GetNonexistentPendingAuth", func(t *testing.T) {
 		h := NewHandler()
 
-		pending, ok := h.GetPendingAuth(99999)
+		pending, ok := h.GetPendingAuth(99999, 0)
 		if ok {
 			t.Error("Should not find nonexistent pending auth")
 		}
@@ -231,14 +232,63 @@ func TestPendingAuthStorage(t *testing.T) {
 	t.Run("DeletePendingAuth", func(t *testing.T) {
 		h := NewHandler()
 
-		pending := &PendingAuth{SessionID: 1}
+		pending := &PendingAuth{SessionID: 1, ConnID: 7}
 		h.StorePendingAuth(pending)
 
-		h.DeletePendingAuth(1)
+		h.DeletePendingAuth(1, 7)
 
-		_, ok := h.GetPendingAuth(1)
+		_, ok := h.GetPendingAuth(1, 7)
 		if ok {
 			t.Error("PendingAuth should be deleted")
+		}
+	})
+
+	t.Run("CompositeKey", func(t *testing.T) {
+		// Two connections binding to the same session must each get their own
+		// pending-auth slot. Keyed by (SessionID, ConnID) — see Samba bug 15346
+		// and smb2.multichannel.bugs.bug_15346.
+		h := NewHandler()
+
+		p1 := &PendingAuth{SessionID: 42, ConnID: 1, ServerChallenge: [8]byte{1, 1, 1, 1, 1, 1, 1, 1}}
+		p2 := &PendingAuth{SessionID: 42, ConnID: 2, ServerChallenge: [8]byte{2, 2, 2, 2, 2, 2, 2, 2}}
+		h.StorePendingAuth(p1)
+		h.StorePendingAuth(p2)
+
+		got1, ok1 := h.GetPendingAuth(42, 1)
+		got2, ok2 := h.GetPendingAuth(42, 2)
+		if !ok1 || !ok2 {
+			t.Fatal("both pending auths should exist")
+		}
+		if got1.ServerChallenge == got2.ServerChallenge {
+			t.Error("distinct ConnIDs must not share a ServerChallenge slot")
+		}
+
+		h.DeletePendingAuth(42, 1)
+		if _, ok := h.GetPendingAuth(42, 1); ok {
+			t.Error("(42,1) should be deleted")
+		}
+		if _, ok := h.GetPendingAuth(42, 2); !ok {
+			t.Error("(42,2) must survive deletion of (42,1)")
+		}
+	})
+
+	t.Run("DeleteAllPendingAuthForSession", func(t *testing.T) {
+		h := NewHandler()
+
+		h.StorePendingAuth(&PendingAuth{SessionID: 100, ConnID: 1})
+		h.StorePendingAuth(&PendingAuth{SessionID: 100, ConnID: 2})
+		h.StorePendingAuth(&PendingAuth{SessionID: 200, ConnID: 1})
+
+		h.DeleteAllPendingAuthForSession(100)
+
+		if _, ok := h.GetPendingAuth(100, 1); ok {
+			t.Error("(100,1) should be gone")
+		}
+		if _, ok := h.GetPendingAuth(100, 2); ok {
+			t.Error("(100,2) should be gone")
+		}
+		if _, ok := h.GetPendingAuth(200, 1); !ok {
+			t.Error("(200,1) must survive — different session")
 		}
 	})
 }
@@ -464,6 +514,7 @@ func TestConcurrentPendingAuthOperations(t *testing.T) {
 			defer wg.Done()
 			pending := &PendingAuth{
 				SessionID:  id,
+				ConnID:     id,
 				ClientAddr: "127.0.0.1:12345",
 				CreatedAt:  time.Now(),
 			}
@@ -471,7 +522,7 @@ func TestConcurrentPendingAuthOperations(t *testing.T) {
 
 			// Simulate auth completion
 			time.Sleep(time.Millisecond)
-			h.DeletePendingAuth(id)
+			h.DeletePendingAuth(id, id)
 		}(uint64(i))
 	}
 
@@ -569,10 +620,10 @@ func TestConcurrentMixedOperations(t *testing.T) {
 				return
 			default:
 				id := h.GenerateSessionID()
-				pending := &PendingAuth{SessionID: id}
+				pending := &PendingAuth{SessionID: id, ConnID: id}
 				h.StorePendingAuth(pending)
-				h.GetPendingAuth(id)
-				h.DeletePendingAuth(id)
+				h.GetPendingAuth(id, id)
+				h.DeletePendingAuth(id, id)
 			}
 		}
 	}()

--- a/internal/adapter/smb/v2/handlers/logoff.go
+++ b/internal/adapter/smb/v2/handlers/logoff.go
@@ -190,7 +190,7 @@ func (h *Handler) Logoff(ctx *SMBHandlerContext, req *LogoffRequest) (*LogoffRes
 	h.releaseSessionLeasesAndNotifies(ctx.Context, ctx.SessionID)
 
 	treesDeleted := h.DeleteAllTreesForSession(ctx.SessionID)
-	h.DeletePendingAuth(ctx.SessionID)
+	h.DeleteAllPendingAuthForSession(ctx.SessionID)
 
 	logger.Debug("Logoff: partial cleanup done",
 		"sessionID", ctx.SessionID,

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -542,7 +542,16 @@ func (h *Handler) completeSessionBind(
 		PreauthHash: preauthHash,
 		Transport:   ctx.ConnTransport,
 	}
-	sess.AddChannel(channel)
+	if !sess.AddChannel(channel) {
+		// MS-SMB2 §3.3.5.5.2: reject the bind once the per-session channel
+		// table is full. Windows/Samba cap at 32; see
+		// smb2.multichannel.generic.num_channels.
+		logger.Info("SESSION_SETUP bind rejected: channel cap reached",
+			"sessionID", pending.BindingSessionID,
+			"cap", session.MaxChannelsPerSession,
+			"connID", channel.ConnID)
+		return NewErrorResult(types.StatusInsufficientResources)
+	}
 
 	// Drop the binding preauth hash entry — it was scoped to the handshake
 	// and keeping it would corrupt any future handshake that reused the

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -161,7 +161,7 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	// Check if this is a continuation of pending authentication
 	if ctx.SessionID != 0 {
-		if _, ok := h.GetPendingAuth(ctx.SessionID); ok {
+		if _, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID); ok {
 			return h.completeNTLMAuth(ctx, req.SecurityBuffer)
 		}
 
@@ -356,7 +356,7 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 	// If a binding PendingAuth already exists for this session, this is
 	// the TYPE_3 of an in-flight bind — route to completeNTLMAuth, which
 	// branches on pending.IsBinding and calls completeSessionBind.
-	if pending, ok := h.GetPendingAuth(ctx.SessionID); ok && pending.IsBinding {
+	if pending, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID); ok && pending.IsBinding {
 		return h.completeNTLMAuth(ctx, req.SecurityBuffer)
 	}
 
@@ -402,6 +402,7 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 
 	pending := &PendingAuth{
 		SessionID:        ctx.SessionID, // bound session's ID
+		ConnID:           ctx.ConnID,
 		ClientAddr:       ctx.ClientAddr,
 		CreatedAt:        time.Now(),
 		ServerChallenge:  serverChallenge,
@@ -629,6 +630,7 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 	// Include the server challenge for NTLMv2 validation in completeNTLMAuth
 	pending := &PendingAuth{
 		SessionID:       sessionID,
+		ConnID:          ctx.ConnID,
 		ClientAddr:      ctx.ClientAddr,
 		CreatedAt:       time.Now(),
 		ServerChallenge: serverChallenge,
@@ -685,14 +687,16 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 //  8. Cleaning up the pending authentication state
 func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte) (*HandlerResult, error) {
 	// Get and validate pending auth
-	pending, ok := h.GetPendingAuth(ctx.SessionID)
+	pending, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID)
 	if !ok {
-		logger.Debug("No pending auth for session", "sessionID", ctx.SessionID)
+		logger.Debug("No pending auth for session",
+			"sessionID", ctx.SessionID,
+			"connID", ctx.ConnID)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
 	// Remove pending auth (handshake complete)
-	h.DeletePendingAuth(ctx.SessionID)
+	h.DeletePendingAuth(ctx.SessionID, ctx.ConnID)
 
 	// Extract NTLM token (unwrap SPNEGO if needed)
 	ntlmToken, _, _ := extractNTLMToken(securityBuffer)

--- a/internal/adapter/smb/v2/handlers/session_setup_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_test.go
@@ -211,7 +211,7 @@ func TestSessionSetup(t *testing.T) {
 		}
 
 		// Pending auth should be stored
-		_, ok := h.GetPendingAuth(ctx.SessionID)
+		_, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID)
 		if !ok {
 			t.Error("PendingAuth should be stored")
 		}
@@ -338,7 +338,7 @@ func TestSessionSetup_FullHandshake(t *testing.T) {
 		}
 
 		// Verify pending auth was removed
-		_, ok = h.GetPendingAuth(sessionID)
+		_, ok = h.GetPendingAuth(sessionID, ctx2.ConnID)
 		if ok {
 			t.Error("PendingAuth should be removed after AUTHENTICATE")
 		}

--- a/internal/adapter/smb/v2/handlers/state_debug.go
+++ b/internal/adapter/smb/v2/handlers/state_debug.go
@@ -220,13 +220,17 @@ func (h *Handler) AuditSessionCleanup(sessionID uint64) int {
 		return true
 	})
 
-	// Check pending auth
-	if _, ok := h.pendingAuth.Load(sessionID); ok {
-		leaked++
-		logger.Warn("LEAKED pending auth after session cleanup",
-			"sessionID", sessionID,
-		)
-	}
+	// Check pending auth (any channel for this session)
+	h.pendingAuth.Range(func(k, _ any) bool {
+		if key, ok := k.(pendingAuthKey); ok && key.SessionID == sessionID {
+			leaked++
+			logger.Warn("LEAKED pending auth after session cleanup",
+				"sessionID", sessionID,
+				"connID", key.ConnID,
+			)
+		}
+		return true
+	})
 
 	// Check sessions in SessionManager
 	if _, ok := h.SessionManager.GetSession(sessionID); ok {

--- a/pkg/adapter/smb/lease_notifier.go
+++ b/pkg/adapter/smb/lease_notifier.go
@@ -240,11 +240,18 @@ func (t *connRegistryTracker) TrackSession(sessionID uint64) {
 	if !ok {
 		return
 	}
-	sess.AddChannel(&session.Channel{
+	// Primary-channel registration. The cap (§3.3.5.5.2) is enforced at the
+	// SESSION_SETUP bind path; the primary channel always gets a slot and, if
+	// already present with this ConnID, AddChannel updates in place.
+	if !sess.AddChannel(&session.Channel{
 		ConnID:     t.connInfo.ConnID,
 		RemoteAddr: t.connInfo.Conn.RemoteAddr().String(),
 		Transport:  t.connInfo,
-	})
+	}) {
+		logger.Warn("primary channel registration hit cap",
+			"sessionID", sessionID,
+			"connID", t.connInfo.ConnID)
+	}
 }
 
 // UntrackSession removes a session from the connection, deregisters its

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -25,14 +25,15 @@ chaining, and per-channel sign/verify routing through dispatch. DittoFS
 advertises `SMB2_GLOBAL_CAP_MULTI_CHANNEL` in NEGOTIATE so conformant
 clients now exercise the multi-channel test surface.
 
-The remaining known failures are cross-channel notification fan-out
-(lease/oplock breaks) and wide-channel orchestration, all deferred to
-Phase 2 of #361.
+Phase 2 landed break fan-out (#408). Phase 2.3 landed the per-session
+32-channel cap and fixed a concurrent-bind race on the PendingAuth slot
+(Samba bug 15346 class) — `bug_15346` and `generic.num_channels` now pass.
+The remaining known failures are pre-existing lease-break `new_epoch`
+drift, Samba-internal test-harness FSCTL requirements, and cross-channel
+async credit coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.multichannel.bugs.bug_15346 | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
-| smb2.multichannel.generic.num_channels | Multi-channel | Wide multi-channel coordination (Phase 2 of #361) | #361 |
 | smb2.multichannel.leases.test1 | Multi-channel | Pre-existing lease break new_epoch mismatch, surfaced once interface enumeration works — not a Phase 2 fan-out issue | - |
 | smb2.multichannel.leases.test2 | Multi-channel | Pre-existing lease break new_epoch mismatch — not a Phase 2 fan-out issue | - |
 | smb2.multichannel.leases.test3 | Multi-channel | Pre-existing lease break new_epoch mismatch — not a Phase 2 fan-out issue | - |


### PR DESCRIPTION
## Summary

Closes the two remaining wide/many-channel conformance gaps from #361 Phase 2:

- `smb2.multichannel.bugs.bug_15346` — concurrent bind across 31 connections
- `smb2.multichannel.generic.num_channels` — 32-channel cap + 33rd rejected

After PR #404 (Phase 1 session binding) and #408 (break fan-out), these were the only multichannel coordination tests still KNOWN. This PR flips both to PASS.

## Two root causes, two commits

**`fix(smb): key pending auth by (session, conn)`** — `pendingAuth` was keyed by `SessionID` alone, so concurrent TYPE_1 SESSION_SETUPs on the same session from different TCP connections collided on a single slot. Under parallel binds the TYPE_3 of one connection could pick up the `ServerChallenge` of another (signature mismatch or silent identity swap). MS-SMB2 §3.3.5.5.2 places the authentication context per-connection (`Session.ChannelList[connection].AuthenticationContext`); Samba keeps `smbXsrv_session_auth0` per-channel. Keying by `(SessionID, ConnID)` closes the race.

**`feat(smb): cap channels at 32 per session`** — `Session.AddChannel` accepted unlimited binds. Added `MaxChannelsPerSession = 32` (matches Samba's `smbXsrv_client.max_channels`); backed the channel registry with a plain map + RWMutex so the count-and-insert is atomic under concurrent binds; rejected overflow with `STATUS_INSUFFICIENT_RESOURCES` at the bind handler.

## Verification

- `go test -race ./...` — clean (new tests cover the cap, replace-doesn't-count-against-cap, concurrent-cap-under-200-goroutines, composite PendingAuth key, and session-wide cleanup sweep).
- Full smbtorture memory profile — **160 PASS / 240 KNOWN / 0 new failures**. Both target tests now PASS.

## KNOWN_FAILURES.md

Removed `smb2.multichannel.bugs.bug_15346` and `smb2.multichannel.generic.num_channels`. Header note updated to reflect the current state (break fan-out + cap + race-free bind all landed; remaining known failures are pre-existing lease `new_epoch` drift, Samba-internal FSCTL requirements, and cross-channel async credits).

## Out of scope

- Cross-channel async credit coordination (`credits.multichannel_*`, `2conn_notify_max_async_credits`) — per-channel grant + per-session reconciliation for async ops. Track as a follow-up.
- Lease-break `new_epoch` mismatch on `multichannel.leases.test1-4` — pre-existing, should be its own issue.

## Test plan

- [x] `go test -race ./...`
- [x] `cd test/smb-conformance/smbtorture && ./run.sh` — 0 new failures
- [x] CI green on PR