### PR TITLE
feat(backup): typed error codes on endpoints and records

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -316,6 +316,43 @@ Phase 4 retention (count / age / pin) operates **only** on published backups (ma
 
 Warnings do not reject. DittoFS emits them at WARN on `ValidateConfig`; operators can decide to override.
 
+## HTTP error responses
+
+Backup endpoints (`/backups`, `/backups/{id}/cancel`, `/restore`, `/repos`) return
+RFC 7807 `application/problem+json` bodies with a stable `code` field for
+machine-readable classification. Pair `code` with the HTTP status for UI
+dispatch; `hint` is an operator-facing fallback. Persisted `BackupRecord` and
+`BackupJob` rows carry the same value under `error_code`.
+
+| `code`                            | HTTP | Meaning                                                                                     |
+| --------------------------------- | ---- | ------------------------------------------------------------------------------------------- |
+| `destination_permission_denied`   | 403  | EACCES on a local path, S3 `AccessDenied` / `Forbidden` at the driver or on `HeadBucket`    |
+| `destination_not_found`           | 404  | Missing bucket, non-existent parent directory, incompatible destination config              |
+| `destination_no_space`            | 507  | `ENOSPC` while writing a local archive                                                      |
+| `destination_unreachable`         | 502  | Network timeout, DNS lookup failure, S3 5xx, S3 throttling                                  |
+| `destination_credentials_invalid` | 401  | S3 `InvalidAccessKeyId` / `SignatureDoesNotMatch`, missing or malformed encryption key ref  |
+| `destination_path_conflict`       | 422  | Two repos collide on the same local path (after resolving symlinks) or same S3 bucket+prefix |
+| `source_unavailable`              | 503  | Metadata store read failed, or post-publish DB persistence failed                           |
+| `backup_already_running`          | 409  | A run is already in flight on the repo; `running_job_id` is included in the body            |
+| `restore_precondition_failed`     | 409  | Target store still has enabled shares; `enabled_shares` is included in the body             |
+| `internal`                        | 500  | Uncategorized failure; consult server logs                                                  |
+
+Example body:
+
+```json
+{
+  "type": "about:blank",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "open /var/backups/repo: permission denied",
+  "code": "destination_permission_denied",
+  "hint": "ensure the DittoFS process user can write to the backup destination"
+}
+```
+
+Codes are additive — new ones may be introduced in minor releases. Clients
+should fall back to dispatching on HTTP status when an unknown code is seen.
+
 ## What this release does NOT include
 
 - **External KMS or SSE-S3 / SSE-KMS pass-through** — operator-supplied raw 32-byte keys only. A future "External KMS" milestone will add Vault and AWS KMS key wrapping.

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -327,7 +327,8 @@ dispatch; `hint` is an operator-facing fallback. Persisted `BackupRecord` and
 | `code`                            | HTTP | Meaning                                                                                     |
 | --------------------------------- | ---- | ------------------------------------------------------------------------------------------- |
 | `destination_permission_denied`   | 403  | EACCES on a local path, S3 `AccessDenied` / `Forbidden` at the driver or on `HeadBucket`    |
-| `destination_not_found`           | 404  | Missing bucket, non-existent parent directory, incompatible destination config              |
+| `destination_not_found`           | 404  | Missing bucket, non-existent parent directory (runtime path)                                |
+| `destination_config_invalid`      | 422  | Pre-persist ValidateConfig failure on repo create/patch (bad bucket, unwritable path, …)    |
 | `destination_no_space`            | 507  | `ENOSPC` while writing a local archive                                                      |
 | `destination_unreachable`         | 502  | Network timeout, DNS lookup failure, S3 5xx, S3 throttling                                  |
 | `destination_credentials_invalid` | 401  | S3 `InvalidAccessKeyId` / `SignatureDoesNotMatch`, missing or malformed encryption key ref  |

--- a/internal/controlplane/api/handlers/backup_jobs.go
+++ b/internal/controlplane/api/handlers/backup_jobs.go
@@ -151,7 +151,7 @@ func (h *BackupHandler) CancelJob(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		logger.Error("Cancel backup job failed", "job_id", id, "error", err)
-		InternalServerError(w, "Failed to cancel backup job")
+		WriteClassifiedBackupError(w, err)
 		return
 	}
 

--- a/internal/controlplane/api/handlers/backup_repos.go
+++ b/internal/controlplane/api/handlers/backup_repos.go
@@ -361,13 +361,17 @@ func (h *BackupHandler) validateRepoDestination(w http.ResponseWriter, ctx conte
 	writeErr := func(op string, err error) bool {
 		var be *bkperrors.BackupError
 		if errors.As(err, &be) {
+			detail := err.Error()
+			if be.Err != nil {
+				detail = be.Err.Error()
+			}
 			status, title := statusForBackupCode(be.Code)
-			WriteBackupProblem(w, status, title, err.Error(), be.Code, be.Hint)
+			WriteBackupProblem(w, status, title, detail, be.Code, be.Hint)
 			return false
 		}
 		if errors.Is(err, destination.ErrIncompatibleConfig) {
 			WriteBackupProblem(w, http.StatusUnprocessableEntity, "Unprocessable Entity",
-				err.Error(), bkperrors.CodeDestinationNotFound, "")
+				err.Error(), bkperrors.CodeDestinationConfigInvalid, "")
 			return false
 		}
 		logger.Error(op, "repo", repo.Name, "error", err)

--- a/internal/controlplane/api/handlers/backup_repos.go
+++ b/internal/controlplane/api/handlers/backup_repos.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/backup/destination"
+	bkperrors "github.com/marmos91/dittofs/pkg/backup/errors"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
@@ -358,8 +359,15 @@ func (h *BackupHandler) purgeRepoArchives(ctx context.Context, repo *models.Back
 // response has been written. destFactory==nil skips the driver probe.
 func (h *BackupHandler) validateRepoDestination(w http.ResponseWriter, ctx context.Context, repo *models.BackupRepo) bool {
 	writeErr := func(op string, err error) bool {
+		var be *bkperrors.BackupError
+		if errors.As(err, &be) {
+			status, title := statusForBackupCode(be.Code)
+			WriteBackupProblem(w, status, title, err.Error(), be.Code, be.Hint)
+			return false
+		}
 		if errors.Is(err, destination.ErrIncompatibleConfig) {
-			UnprocessableEntity(w, err.Error())
+			WriteBackupProblem(w, http.StatusUnprocessableEntity, "Unprocessable Entity",
+				err.Error(), bkperrors.CodeDestinationNotFound, "")
 			return false
 		}
 		logger.Error(op, "repo", repo.Name, "error", err)
@@ -405,8 +413,9 @@ func (h *BackupHandler) checkRepoDestinationCollision(ctx context.Context, repo 
 			return fmt.Errorf("compare destination with repo %q: %w", other.Name, err)
 		}
 		if collision {
-			return fmt.Errorf("%w: destination already used by repo %q",
-				destination.ErrIncompatibleConfig, other.Name)
+			return bkperrors.New(bkperrors.CodeDestinationPathConflict,
+				fmt.Errorf("%w: destination already used by repo %q",
+					destination.ErrIncompatibleConfig, other.Name))
 		}
 	}
 	return nil

--- a/internal/controlplane/api/handlers/backups.go
+++ b/internal/controlplane/api/handlers/backups.go
@@ -137,6 +137,7 @@ type BackupRecordResponse struct {
 	SHA256       string    `json:"sha256"`
 	StoreID      string    `json:"store_id"`
 	Error        string    `json:"error,omitempty"`
+	ErrorCode    string    `json:"error_code,omitempty"`
 }
 
 // BackupJobResponse is the wire shape for a BackupJob row.
@@ -149,6 +150,7 @@ type BackupJobResponse struct {
 	StartedAt      *time.Time `json:"started_at,omitempty"`
 	FinishedAt     *time.Time `json:"finished_at,omitempty"`
 	Error          string     `json:"error,omitempty"`
+	ErrorCode      string     `json:"error_code,omitempty"`
 	Progress       int        `json:"progress"`
 }
 
@@ -292,7 +294,7 @@ func (h *BackupHandler) writeBackupError(w http.ResponseWriter, ctx context.Cont
 		BadRequest(w, err.Error())
 	default:
 		logger.Error("Backup run failed", "repo_id", repoID, "error", err)
-		InternalServerError(w, "Backup run failed")
+		WriteClassifiedBackupError(w, err)
 	}
 }
 
@@ -552,7 +554,7 @@ func (h *BackupHandler) writeRestoreError(w http.ResponseWriter, err error) {
 		NotFound(w, err.Error())
 	default:
 		logger.Error("Restore run failed", "error", err)
-		InternalServerError(w, "Restore run failed")
+		WriteClassifiedBackupError(w, err)
 	}
 }
 
@@ -658,6 +660,7 @@ func recordToResponse(r *models.BackupRecord) *BackupRecordResponse {
 		SHA256:       r.SHA256,
 		StoreID:      r.StoreID,
 		Error:        r.Error,
+		ErrorCode:    r.ErrorCode,
 	}
 }
 
@@ -682,6 +685,7 @@ func jobToResponse(j *models.BackupJob) *BackupJobResponse {
 		StartedAt:      j.StartedAt,
 		FinishedAt:     j.FinishedAt,
 		Error:          j.Error,
+		ErrorCode:      j.ErrorCode,
 		Progress:       j.Progress,
 	}
 }

--- a/internal/controlplane/api/handlers/problem.go
+++ b/internal/controlplane/api/handlers/problem.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	bkperrors "github.com/marmos91/dittofs/pkg/backup/errors"
 )
 
 // Problem represents an RFC 7807 "problem details" response.
@@ -25,6 +27,15 @@ type Problem struct {
 
 	// Instance is a URI reference that identifies the specific occurrence.
 	Instance string `json:"instance,omitempty"`
+
+	// Code is a stable, machine-readable error taxonomy value (#414).
+	// Clients dispatch i18n / UI hints on this field without parsing Detail.
+	Code string `json:"code,omitempty"`
+
+	// Hint is a short operator-facing string paired with Code. Clients
+	// typically localize via Code, but Hint is a useful fallback for CLI
+	// output and log readers.
+	Hint string `json:"hint,omitempty"`
 }
 
 // ContentTypeProblemJSON is the Content-Type for RFC 7807 problem responses.
@@ -130,12 +141,15 @@ type RestorePreconditionFailedProblem struct {
 // with the running BackupJob ID (D-13). Paired with the
 // storebackups.ErrBackupAlreadyRunning sentinel in the handler layer.
 func WriteBackupAlreadyRunningProblem(w http.ResponseWriter, runningJobID string) {
+	code := bkperrors.CodeBackupAlreadyRunning
 	p := &BackupAlreadyRunningProblem{
 		Problem: Problem{
 			Type:   "about:blank",
 			Title:  "Conflict",
 			Status: http.StatusConflict,
 			Detail: "backup already running",
+			Code:   string(code),
+			Hint:   bkperrors.HintFor(code),
 		},
 		RunningJobID: runningJobID,
 	}
@@ -146,16 +160,77 @@ func WriteBackupAlreadyRunningProblem(w http.ResponseWriter, runningJobID string
 // body with the enabled_shares list (D-29). Detail text reports the count
 // so the CLI can render a short summary without reflowing the list.
 func WriteRestorePreconditionFailedProblem(w http.ResponseWriter, enabledShares []string) {
+	code := bkperrors.CodeRestorePreconditionFailed
 	p := &RestorePreconditionFailedProblem{
 		Problem: Problem{
 			Type:   "about:blank",
 			Title:  "Restore precondition failed",
 			Status: http.StatusConflict,
 			Detail: fmt.Sprintf("%d share(s) still enabled", len(enabledShares)),
+			Code:   string(code),
+			Hint:   bkperrors.HintFor(code),
 		},
 		EnabledShares: enabledShares,
 	}
 	writeProblemJSON(w, http.StatusConflict, p)
+}
+
+// WriteBackupProblem emits an RFC 7807 problem body that includes a
+// machine-readable code plus hint (#414). Prefer this over WriteProblem
+// on any backup / restore error path so clients get a stable taxonomy.
+func WriteBackupProblem(w http.ResponseWriter, status int, title, detail string, code bkperrors.Code, hint string) {
+	if hint == "" {
+		hint = bkperrors.HintFor(code)
+	}
+	p := &Problem{
+		Type:   "about:blank",
+		Title:  title,
+		Status: status,
+		Detail: detail,
+		Code:   string(code),
+		Hint:   hint,
+	}
+	writeProblemJSON(w, status, p)
+}
+
+// statusForBackupCode maps a classified backup error code to the HTTP
+// status that best conveys it to clients (#414).
+func statusForBackupCode(code bkperrors.Code) (int, string) {
+	switch code {
+	case bkperrors.CodeDestinationPermissionDenied:
+		return http.StatusForbidden, "Forbidden"
+	case bkperrors.CodeDestinationNotFound:
+		return http.StatusNotFound, "Not Found"
+	case bkperrors.CodeDestinationNoSpace:
+		return http.StatusInsufficientStorage, "Insufficient Storage"
+	case bkperrors.CodeDestinationUnreachable:
+		return http.StatusBadGateway, "Bad Gateway"
+	case bkperrors.CodeDestinationCredentialsInvalid:
+		return http.StatusUnauthorized, "Unauthorized"
+	case bkperrors.CodeDestinationPathConflict:
+		return http.StatusUnprocessableEntity, "Unprocessable Entity"
+	case bkperrors.CodeSourceUnavailable:
+		return http.StatusServiceUnavailable, "Service Unavailable"
+	case bkperrors.CodeBackupAlreadyRunning, bkperrors.CodeRestorePreconditionFailed:
+		return http.StatusConflict, "Conflict"
+	}
+	return http.StatusInternalServerError, "Internal Server Error"
+}
+
+// WriteClassifiedBackupError classifies err and emits the matching
+// problem+json body. The default fallback is 500 + code=internal.
+func WriteClassifiedBackupError(w http.ResponseWriter, err error) {
+	be := bkperrors.Classify(err)
+	if be == nil {
+		InternalServerError(w, "unexpected error")
+		return
+	}
+	status, title := statusForBackupCode(be.Code)
+	detail := ""
+	if be.Err != nil {
+		detail = be.Err.Error()
+	}
+	WriteBackupProblem(w, status, title, detail, be.Code, be.Hint)
 }
 
 // writeProblemJSON serializes a typed problem variant using the RFC 7807

--- a/internal/controlplane/api/handlers/problem.go
+++ b/internal/controlplane/api/handlers/problem.go
@@ -207,7 +207,8 @@ func statusForBackupCode(code bkperrors.Code) (int, string) {
 		return http.StatusBadGateway, "Bad Gateway"
 	case bkperrors.CodeDestinationCredentialsInvalid:
 		return http.StatusUnauthorized, "Unauthorized"
-	case bkperrors.CodeDestinationPathConflict:
+	case bkperrors.CodeDestinationPathConflict,
+		bkperrors.CodeDestinationConfigInvalid:
 		return http.StatusUnprocessableEntity, "Unprocessable Entity"
 	case bkperrors.CodeSourceUnavailable:
 		return http.StatusServiceUnavailable, "Service Unavailable"
@@ -222,7 +223,8 @@ func statusForBackupCode(code bkperrors.Code) (int, string) {
 func WriteClassifiedBackupError(w http.ResponseWriter, err error) {
 	be := bkperrors.Classify(err)
 	if be == nil {
-		InternalServerError(w, "unexpected error")
+		WriteBackupProblem(w, http.StatusInternalServerError, "Internal Server Error",
+			"unexpected error", bkperrors.CodeInternal, "")
 		return
 	}
 	status, title := statusForBackupCode(be.Code)

--- a/pkg/backup/errors/errors.go
+++ b/pkg/backup/errors/errors.go
@@ -28,6 +28,7 @@ const (
 	CodeDestinationUnreachable        Code = "destination_unreachable"
 	CodeDestinationCredentialsInvalid Code = "destination_credentials_invalid"
 	CodeDestinationPathConflict       Code = "destination_path_conflict"
+	CodeDestinationConfigInvalid      Code = "destination_config_invalid"
 	CodeSourceUnavailable             Code = "source_unavailable"
 	CodeBackupAlreadyRunning          Code = "backup_already_running"
 	CodeRestorePreconditionFailed     Code = "restore_precondition_failed"
@@ -147,6 +148,8 @@ func HintFor(code Code) string {
 		return "re-enter the S3 credentials for this backup repo"
 	case CodeDestinationPathConflict:
 		return "this destination path is already used by another backup repo or block store"
+	case CodeDestinationConfigInvalid:
+		return "check the destination config (path writable, bucket name valid, required fields set)"
 	case CodeSourceUnavailable:
 		return "the metadata store could not be read; check that it is running and healthy"
 	case CodeBackupAlreadyRunning:

--- a/pkg/backup/errors/errors.go
+++ b/pkg/backup/errors/errors.go
@@ -1,0 +1,160 @@
+// Package errors defines the stable, machine-readable error taxonomy
+// surfaced by backup endpoints (#414). Callers classify an arbitrary error
+// into a fixed Code enum and attach a short operator-facing hint.
+//
+// The wire values are the JSON source of truth and must never be renumbered
+// or renamed — the Pro UI keys i18n strings off them. Adding new codes is
+// always safe; removing or renaming is not.
+package errors
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"syscall"
+
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/marmos91/dittofs/pkg/backup/destination"
+)
+
+// Code is the stable wire value for a classified backup error.
+type Code string
+
+const (
+	CodeDestinationPermissionDenied   Code = "destination_permission_denied"
+	CodeDestinationNotFound           Code = "destination_not_found"
+	CodeDestinationNoSpace            Code = "destination_no_space"
+	CodeDestinationUnreachable        Code = "destination_unreachable"
+	CodeDestinationCredentialsInvalid Code = "destination_credentials_invalid"
+	CodeDestinationPathConflict       Code = "destination_path_conflict"
+	CodeSourceUnavailable             Code = "source_unavailable"
+	CodeBackupAlreadyRunning          Code = "backup_already_running"
+	CodeRestorePreconditionFailed     Code = "restore_precondition_failed"
+	CodeInternal                      Code = "internal"
+)
+
+// BackupError carries a classified code plus the original error so
+// errors.Is / errors.As continue to match the wrapped sentinels.
+type BackupError struct {
+	Code Code
+	Hint string
+	Err  error
+}
+
+func (e *BackupError) Error() string {
+	if e.Err == nil {
+		return string(e.Code)
+	}
+	return e.Err.Error()
+}
+
+func (e *BackupError) Unwrap() error { return e.Err }
+
+// New wraps err with an explicit code (use when the caller already knows
+// the classification, e.g. the path-conflict validator).
+func New(code Code, err error) *BackupError {
+	return &BackupError{Code: code, Hint: HintFor(code), Err: err}
+}
+
+// Classify inspects err (and anything it wraps) and returns a BackupError
+// whose Code best describes the failure. Returns nil when err is nil.
+//
+// If err already carries a *BackupError in its chain, that classification
+// wins — Classify is idempotent.
+func Classify(err error) *BackupError {
+	if err == nil {
+		return nil
+	}
+	var existing *BackupError
+	if errors.As(err, &existing) {
+		return existing
+	}
+
+	// S3 / smithy typed codes first — the S3 destination joins its own
+	// sentinel with the original SDK error, so credential vs. permission
+	// vs. bucket-not-found are distinguishable via the API error code even
+	// after the sentinel is attached.
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		switch ae.ErrorCode() {
+		case "InvalidAccessKeyId", "SignatureDoesNotMatch", "InvalidSecurityToken",
+			"InvalidClientTokenId", "ExpiredToken", "TokenRefreshRequired":
+			return New(CodeDestinationCredentialsInvalid, err)
+		case "NoSuchBucket", "NoSuchKey", "NotFound":
+			return New(CodeDestinationNotFound, err)
+		case "AccessDenied", "Forbidden":
+			return New(CodeDestinationPermissionDenied, err)
+		}
+	}
+
+	// Filesystem-class: disk full beats permission beats not-found because
+	// ENOSPC is the most actionable for an operator.
+	if errors.Is(err, syscall.ENOSPC) {
+		return New(CodeDestinationNoSpace, err)
+	}
+	if errors.Is(err, destination.ErrPermissionDenied) || errors.Is(err, fs.ErrPermission) {
+		return New(CodeDestinationPermissionDenied, err)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return New(CodeDestinationNotFound, err)
+	}
+
+	// Destination sentinels (after fs-specific checks so an ENOSPC wrapped
+	// in ErrDestinationUnavailable still classifies as no_space).
+	if errors.Is(err, destination.ErrDestinationUnavailable) ||
+		errors.Is(err, destination.ErrDestinationThrottled) {
+		return New(CodeDestinationUnreachable, err)
+	}
+	if errors.Is(err, destination.ErrIncompatibleConfig) {
+		return New(CodeDestinationNotFound, err)
+	}
+	// Encryption-key misconfiguration is an operator-actionable credential
+	// problem, not an internal failure.
+	if errors.Is(err, destination.ErrEncryptionKeyMissing) ||
+		errors.Is(err, destination.ErrInvalidKeyMaterial) {
+		return New(CodeDestinationCredentialsInvalid, err)
+	}
+
+	// Network-class (DNS, timeouts) — after sentinels so S3 classifier's
+	// joined ErrDestinationUnavailable wins when present.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return New(CodeDestinationUnreachable, err)
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return New(CodeDestinationUnreachable, err)
+	}
+
+	return New(CodeInternal, err)
+}
+
+// HintFor returns a short, English, operator-facing hint for a code.
+// The Pro UI localizes via the code itself; this value is a developer /
+// CLI fallback and a hint for log readers.
+func HintFor(code Code) string {
+	switch code {
+	case CodeDestinationPermissionDenied:
+		return "ensure the DittoFS process user can write to the backup destination"
+	case CodeDestinationNotFound:
+		return "check that the destination bucket or directory exists"
+	case CodeDestinationNoSpace:
+		return "free up disk space at the backup destination or choose a different path"
+	case CodeDestinationUnreachable:
+		return "check network connectivity and DNS resolution to the backup destination"
+	case CodeDestinationCredentialsInvalid:
+		return "re-enter the S3 credentials for this backup repo"
+	case CodeDestinationPathConflict:
+		return "this destination path is already used by another backup repo or block store"
+	case CodeSourceUnavailable:
+		return "the metadata store could not be read; check that it is running and healthy"
+	case CodeBackupAlreadyRunning:
+		return "wait for the in-flight backup to finish, or cancel it before retrying"
+	case CodeRestorePreconditionFailed:
+		return "disable the listed shares on the target store before retrying restore"
+	case CodeInternal:
+		return "unexpected internal failure; check server logs for details"
+	}
+	return ""
+}

--- a/pkg/backup/errors/errors_test.go
+++ b/pkg/backup/errors/errors_test.go
@@ -1,0 +1,96 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"syscall"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/marmos91/dittofs/pkg/backup/destination"
+)
+
+type fakeAPIError struct {
+	code string
+	msg  string
+}
+
+func (e *fakeAPIError) Error() string                 { return e.msg }
+func (e *fakeAPIError) ErrorCode() string             { return e.code }
+func (e *fakeAPIError) ErrorMessage() string          { return e.msg }
+func (e *fakeAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+func TestClassify_NilReturnsNil(t *testing.T) {
+	if got := Classify(nil); got != nil {
+		t.Fatalf("Classify(nil) = %v, want nil", got)
+	}
+}
+
+func TestClassify_Taxonomy(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want Code
+	}{
+		{"invalid-access-key", &fakeAPIError{code: "InvalidAccessKeyId"}, CodeDestinationCredentialsInvalid},
+		{"signature-mismatch", &fakeAPIError{code: "SignatureDoesNotMatch"}, CodeDestinationCredentialsInvalid},
+		{"no-such-bucket", &fakeAPIError{code: "NoSuchBucket"}, CodeDestinationNotFound},
+		{"access-denied-smithy", &fakeAPIError{code: "AccessDenied"}, CodeDestinationPermissionDenied},
+		{"enospc", &fs.PathError{Op: "write", Path: "/x", Err: syscall.ENOSPC}, CodeDestinationNoSpace},
+		{"fs-permission", &fs.PathError{Op: "open", Path: "/x", Err: fs.ErrPermission}, CodeDestinationPermissionDenied},
+		{"fs-not-exist", &fs.PathError{Op: "open", Path: "/x", Err: fs.ErrNotExist}, CodeDestinationNotFound},
+		{"destination-permission", destination.ErrPermissionDenied, CodeDestinationPermissionDenied},
+		{"destination-unavailable", destination.ErrDestinationUnavailable, CodeDestinationUnreachable},
+		{"destination-throttled", destination.ErrDestinationThrottled, CodeDestinationUnreachable},
+		{"destination-incompatible", destination.ErrIncompatibleConfig, CodeDestinationNotFound},
+		{"dns-error", &net.DNSError{Err: "nxdomain", Name: "example.invalid"}, CodeDestinationUnreachable},
+		{"opaque", errors.New("something weird"), CodeInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Classify(tc.err)
+			if got == nil {
+				t.Fatalf("Classify(%v) = nil, want %s", tc.err, tc.want)
+			}
+			if got.Code != tc.want {
+				t.Fatalf("Classify(%v).Code = %s, want %s", tc.err, got.Code, tc.want)
+			}
+			// Unwrap chain preserves the original sentinel.
+			if !errors.Is(got, tc.err) {
+				t.Fatalf("errors.Is(classified, original) = false; chain broken")
+			}
+		})
+	}
+}
+
+func TestClassify_Idempotent(t *testing.T) {
+	be := New(CodeDestinationPathConflict, errors.New("collide"))
+	wrapped := fmt.Errorf("wrapping: %w", be)
+	got := Classify(wrapped)
+	if got.Code != CodeDestinationPathConflict {
+		t.Fatalf("Classify preserved code = %s, want %s", got.Code, CodeDestinationPathConflict)
+	}
+}
+
+func TestHintFor_AllCodesCovered(t *testing.T) {
+	codes := []Code{
+		CodeDestinationPermissionDenied,
+		CodeDestinationNotFound,
+		CodeDestinationNoSpace,
+		CodeDestinationUnreachable,
+		CodeDestinationCredentialsInvalid,
+		CodeDestinationPathConflict,
+		CodeSourceUnavailable,
+		CodeBackupAlreadyRunning,
+		CodeRestorePreconditionFailed,
+		CodeInternal,
+	}
+	for _, c := range codes {
+		if HintFor(c) == "" {
+			t.Errorf("HintFor(%s) returned empty string", c)
+		}
+	}
+}

--- a/pkg/backup/errors/errors_test.go
+++ b/pkg/backup/errors/errors_test.go
@@ -83,6 +83,7 @@ func TestHintFor_AllCodesCovered(t *testing.T) {
 		CodeDestinationUnreachable,
 		CodeDestinationCredentialsInvalid,
 		CodeDestinationPathConflict,
+		CodeDestinationConfigInvalid,
 		CodeSourceUnavailable,
 		CodeBackupAlreadyRunning,
 		CodeRestorePreconditionFailed,

--- a/pkg/backup/executor/executor.go
+++ b/pkg/backup/executor/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/backup"
 	"github.com/marmos91/dittofs/pkg/backup/destination"
+	bkperrors "github.com/marmos91/dittofs/pkg/backup/errors"
 	"github.com/marmos91/dittofs/pkg/backup/manifest"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
@@ -250,12 +251,14 @@ func (e *Executor) RunBackup(
 			errors.Is(runErr, backup.ErrBackupAborted) {
 			status = models.BackupStatusInterrupted
 		}
+		errCode := string(bkperrors.Classify(runErr).Code)
 		if upErr := e.store.UpdateBackupJob(ctx, &models.BackupJob{
 			ID:         jobID,
 			Status:     status,
 			StartedAt:  &startedAt,
 			FinishedAt: &finishedAt,
 			Error:      runErr.Error(),
+			ErrorCode:  errCode,
 		}); upErr != nil {
 			logger.Warn("Failed to mark backup job terminal state",
 				"job_id", jobID, "intended_status", status, "update_error", upErr)
@@ -264,16 +267,13 @@ func (e *Executor) RunBackup(
 			"repo_id", repo.ID,
 			"job_id", jobID,
 			"status", status,
+			"error_code", errCode,
 			"error", runErr,
 		)
-		// Surface the job so Phase-6 callers can report job.ID even on
-		// failure. The job struct has been populated with the terminal-state
-		// fields via the UpdateBackupJob above; mirror those onto our
-		// return-value copy so the caller sees a consistent view even
-		// without a follow-up read.
 		job.Status = status
 		job.FinishedAt = &finishedAt
 		job.Error = runErr.Error()
+		job.ErrorCode = errCode
 		return nil, job, runErr
 	}
 
@@ -296,12 +296,14 @@ func (e *Executor) RunBackup(
 		// discrepancy in job logs. Phase 5 orphan sweep will NOT delete the
 		// archive because manifest.yaml is present (published invariant).
 		errMsg := fmt.Sprintf("archive published but record persist failed: %v", err)
+		errCode := string(bkperrors.CodeSourceUnavailable)
 		if upErr := e.store.UpdateBackupJob(ctx, &models.BackupJob{
 			ID:         jobID,
 			Status:     models.BackupStatusFailed,
 			StartedAt:  &startedAt,
 			FinishedAt: &finishedAt,
 			Error:      errMsg,
+			ErrorCode:  errCode,
 		}); upErr != nil {
 			logger.Warn("Failed to mark backup job failed after record persist failure",
 				"job_id", jobID, "update_error", upErr)
@@ -315,6 +317,7 @@ func (e *Executor) RunBackup(
 		job.Status = models.BackupStatusFailed
 		job.FinishedAt = &finishedAt
 		job.Error = errMsg
+		job.ErrorCode = errCode
 		return nil, job, fmt.Errorf("create backup record: %w", err)
 	}
 

--- a/pkg/backup/restore/restore.go
+++ b/pkg/backup/restore/restore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/backup"
 	"github.com/marmos91/dittofs/pkg/backup/destination"
+	bkperrors "github.com/marmos91/dittofs/pkg/backup/errors"
 	"github.com/marmos91/dittofs/pkg/backup/manifest"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
@@ -248,6 +249,7 @@ func (e *Executor) RunRestore(ctx context.Context, p Params, opts ...RunRestoreO
 			finalJob.Status = models.BackupStatusInterrupted
 		}
 		finalJob.Error = err.Error()
+		finalJob.ErrorCode = string(bkperrors.Classify(err).Code)
 		if upErr := e.store.UpdateBackupJob(context.Background(), finalJob); upErr != nil {
 			logger.Warn("Failed to mark restore job terminal state",
 				"job_id", jobID, "intended_status", finalJob.Status, "update_error", upErr)

--- a/pkg/controlplane/models/backup.go
+++ b/pkg/controlplane/models/backup.go
@@ -137,8 +137,9 @@ type BackupRecord struct {
 	SHA256       string       `gorm:"size:64" json:"sha256"`
 	// StoreID is a snapshot of the source metadata store ID at backup time.
 	// Used as a guard against restoring into the wrong (or a renamed) store.
-	StoreID string `gorm:"size:36" json:"store_id"`
-	Error   string `gorm:"type:text" json:"error,omitempty"`
+	StoreID   string `gorm:"size:36" json:"store_id"`
+	Error     string `gorm:"type:text" json:"error,omitempty"`
+	ErrorCode string `gorm:"size:48;index" json:"error_code,omitempty"`
 
 	// Relationships
 	Repo BackupRepo `gorm:"foreignKey:RepoID" json:"repo,omitzero"`
@@ -162,6 +163,7 @@ type BackupJob struct {
 	StartedAt      *time.Time   `json:"started_at,omitempty"`
 	FinishedAt     *time.Time   `json:"finished_at,omitempty"`
 	Error          string       `gorm:"type:text" json:"error,omitempty"`
+	ErrorCode      string       `gorm:"size:48;index" json:"error_code,omitempty"`
 	Progress       int          `json:"progress"` // 0-100
 
 	// Relationships

--- a/pkg/controlplane/store/backup.go
+++ b/pkg/controlplane/store/backup.go
@@ -197,6 +197,7 @@ func (s *GORMStore) UpdateBackupRecord(ctx context.Context, rec *models.BackupRe
 			"manifest_path": rec.ManifestPath,
 			"sha256":        rec.SHA256,
 			"error":         rec.Error,
+			"error_code":    rec.ErrorCode,
 		})
 	if result.Error != nil {
 		return result.Error
@@ -352,6 +353,7 @@ func (s *GORMStore) UpdateBackupJob(ctx context.Context, job *models.BackupJob) 
 			"started_at":       job.StartedAt,
 			"finished_at":      job.FinishedAt,
 			"error":            job.Error,
+			"error_code":       job.ErrorCode,
 			"progress":         job.Progress,
 			"backup_record_id": job.BackupRecordID,
 		})


### PR DESCRIPTION
Closes #414.

## Summary
- Adds a stable backup error taxonomy in `pkg/backup/errors` with a `Classify(err) → {Code, Hint, Err}` entry point covering destination permission / credentials / not-found / no-space / unreachable, path conflict, source-unavailable, and internal.
- Extends the RFC 7807 `Problem` struct with `code` + `hint` fields; routes default-arm error paths of `TriggerBackup`, `Restore`, `CancelJob`, and repo-destination validation through a classified writer. Existing typed responses (`backup_already_running`, `restore_precondition_failed`) also carry a `code`.
- Adds an `ErrorCode` column to `BackupRecord` and `BackupJob` (GORM AutoMigrate) and exposes it on the response shapes; executor + restore populate it on failure paths.
- Documents the full taxonomy + example body in `docs/BACKUP.md`.

Existing HTTP statuses are preserved — path conflicts stay at 422, already-running at 409, etc. Codes are purely additive on the wire.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/backup/... ./internal/controlplane/api/handlers/...`
- [x] New unit tests in `pkg/backup/errors` cover every code, nil input, idempotency, and smithy / fs / net / destination sentinel chains.
- [x] Manual: trigger a backup with bad S3 credentials → expect HTTP 401 + `code=destination_credentials_invalid`.
- [x] Manual: verify `error_code` column populates after a failed run (`sqlite3 state.db 'SELECT id, status, error_code FROM backup_jobs ...'`).