### PR TITLE
smb: multichannel lease break new_epoch drift — closes #417

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -50,7 +50,14 @@ type LeaseManager struct {
 	notifier   LeaseBreakNotifier
 	sessionMap map[string]uint64 // hex(leaseKey) -> sessionID
 	leaseShare map[string]string // hex(leaseKey) -> shareName (for resolution)
-	mu         sync.RWMutex
+	// leaseV2 records whether each lease was granted from an
+	// SMB2_CREATE_REQUEST_LEASE_V2 context. Per MS-SMB2 §2.2.23.2 the
+	// NewEpoch field of a break notification MUST be zero for V1 leases;
+	// for V2 leases it carries the incremented lease epoch. Sending a
+	// non-zero NewEpoch on a V1 break trips the client (#417 root cause
+	// for smb2.multichannel.leases.test1-3).
+	leaseV2 map[string]bool // hex(leaseKey) -> true iff V2 lease
+	mu      sync.RWMutex
 }
 
 // NewLeaseManager creates a new SMB LeaseManager.
@@ -65,6 +72,7 @@ func NewLeaseManager(resolver LockManagerResolver, notifier LeaseBreakNotifier) 
 		notifier:   notifier,
 		sessionMap: make(map[string]uint64),
 		leaseShare: make(map[string]string),
+		leaseV2:    make(map[string]bool),
 	}
 }
 
@@ -570,7 +578,30 @@ func (lm *LeaseManager) removeLeaseMapping(keyHex string) {
 	lm.mu.Lock()
 	delete(lm.sessionMap, keyHex)
 	delete(lm.leaseShare, keyHex)
+	delete(lm.leaseV2, keyHex)
 	lm.mu.Unlock()
+}
+
+// MarkLeaseV2 records that the lease with the given key was granted from an
+// SMB2_CREATE_REQUEST_LEASE_V2 context. Callers must invoke this after a
+// successful RequestLease whenever the originating create context was V2 so
+// that subsequent break notifications carry the epoch per MS-SMB2 §2.2.23.2.
+// Leases not marked are treated as V1 and get NewEpoch = 0 on break.
+func (lm *LeaseManager) MarkLeaseV2(leaseKey [16]byte) {
+	keyHex := hex.EncodeToString(leaseKey[:])
+	lm.mu.Lock()
+	lm.leaseV2[keyHex] = true
+	lm.mu.Unlock()
+}
+
+// IsV2 reports whether the lease was granted from a V2 create context.
+// Returns false for unknown keys (safe default: treat as V1 and send
+// NewEpoch = 0 rather than leak a non-zero epoch).
+func (lm *LeaseManager) IsV2(leaseKey [16]byte) bool {
+	keyHex := hex.EncodeToString(leaseKey[:])
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	return lm.leaseV2[keyHex]
 }
 
 // resolveLockManager resolves the LockManager for a share name.

--- a/internal/adapter/smb/lease/notifier.go
+++ b/internal/adapter/smb/lease/notifier.go
@@ -78,9 +78,15 @@ func (h *SMBBreakHandler) OnOpLockBreak(handleKey string, ul *lock.UnifiedLock, 
 		}
 	}
 
-	// Use the current lease epoch for V2 break notifications. The LockManager
-	// already advanced the epoch when initiating the break.
-	newEpoch := ul.Lease.Epoch
+	// Per MS-SMB2 §2.2.23.2: NewEpoch is the V2 lease epoch; for V1 leases
+	// it MUST be set to zero. The LeaseManager records which leases were
+	// granted from a V2 create context. Unknown keys default to V1 (safe:
+	// zero is always valid and avoids leaking stale epochs to V1 clients).
+	var newEpoch uint16
+	if h.leaseManager.IsV2(ul.Lease.LeaseKey) {
+		// LockManager already advanced the epoch when initiating the break.
+		newEpoch = ul.Lease.Epoch
+	}
 
 	logger.Debug("SMBBreakHandler: dispatching lease break notification",
 		"leaseKey", fmt.Sprintf("%x", ul.Lease.LeaseKey),

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -616,7 +616,15 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 								Data: leaseResp.Encode(),
 							})
 						}
+						// Re-mark V2 regardless of whether the client repeated
+						// RqLs on this reconnect. Lease-backed durable handles
+						// require SMB 3.0+ (MS-SMB2 §3.3.5.9.7 / §3.3.5.9.12),
+						// and SMB 3.x leases are always V2-context. Without
+						// this, an omitted-RqLs reconnect would leave the
+						// lease untracked and subsequent breaks would send
+						// NewEpoch = 0 even though the lease is V2 (#417).
 						if grantedState != lock.LeaseStateNone {
+							h.LeaseManager.MarkLeaseV2(restored.LeaseKey)
 							restored.OplockLevel = OplockLevelLease
 						}
 					}

--- a/internal/adapter/smb/v2/handlers/lease_context.go
+++ b/internal/adapter/smb/v2/handlers/lease_context.go
@@ -390,7 +390,12 @@ func ProcessLeaseCreateContext(
 	// Seed server state to max(current, client+1) so re-opens with the same
 	// key pick up the client's evolving view while still advancing past any
 	// server-side increments the client hasn't seen yet (e.g. prior breaks).
-	if !isV1 && grantedState != lock.LeaseStateNone {
+	//
+	// Gate on err == nil: on ErrLeaseBreakInProgress the LockManager returns
+	// the breaking lease's current state/epoch read-only and explicitly must
+	// not be mutated. Advancing its epoch here would drift the state that
+	// the in-flight break ACK will re-persist.
+	if !isV1 && err == nil && grantedState != lock.LeaseStateNone {
 		nextEpoch := leaseReq.Epoch + 1
 		if nextEpoch > epoch {
 			leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, nextEpoch)
@@ -399,8 +404,10 @@ func ProcessLeaseCreateContext(
 	}
 
 	// Record V1/V2 so break notifications carry NewEpoch correctly
-	// (MS-SMB2 §2.2.23.2 — V1 breaks MUST send NewEpoch = 0).
-	if !isV1 && grantedState != lock.LeaseStateNone {
+	// (MS-SMB2 §2.2.23.2 — V1 breaks MUST send NewEpoch = 0). ACK-in-progress
+	// (ErrLeaseBreakInProgress) responses reference an already-tracked lease
+	// — skip re-marking to avoid racing the in-flight state transition.
+	if !isV1 && err == nil && grantedState != lock.LeaseStateNone {
 		leaseMgr.MarkLeaseV2(leaseReq.LeaseKey)
 	}
 

--- a/internal/adapter/smb/v2/handlers/lease_context.go
+++ b/internal/adapter/smb/v2/handlers/lease_context.go
@@ -384,14 +384,24 @@ func ProcessLeaseCreateContext(
 		epoch = 0
 	}
 
-	// Per MS-SMB2 3.3.5.9: For V2 lease requests, the server should track
-	// the client's epoch from the RqLs create context. Initialize the epoch
-	// to max(current, client) so re-opens with the same key pick up the
-	// client's evolving epoch value. This covers both first grants (epoch==1)
-	// and subsequent re-opens or upgrades.
-	if !isV1 && leaseReq.Epoch > 0 && grantedState != lock.LeaseStateNone && leaseReq.Epoch > epoch {
-		leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, leaseReq.Epoch)
-		epoch = leaseReq.Epoch
+	// Per MS-SMB2 3.3.5.9.8: a V2 lease grant is a state change that MUST
+	// advance Epoch by 1 over the client's requested value — unconditionally,
+	// including a first-grant Epoch=0 (server must respond with Epoch=1).
+	// Seed server state to max(current, client+1) so re-opens with the same
+	// key pick up the client's evolving view while still advancing past any
+	// server-side increments the client hasn't seen yet (e.g. prior breaks).
+	if !isV1 && grantedState != lock.LeaseStateNone {
+		nextEpoch := leaseReq.Epoch + 1
+		if nextEpoch > epoch {
+			leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, nextEpoch)
+			epoch = nextEpoch
+		}
+	}
+
+	// Record V1/V2 so break notifications carry NewEpoch correctly
+	// (MS-SMB2 §2.2.23.2 — V1 breaks MUST send NewEpoch = 0).
+	if !isV1 && grantedState != lock.LeaseStateNone {
+		leaseMgr.MarkLeaseV2(leaseReq.LeaseKey)
 	}
 
 	// Build response context.

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -58,7 +58,14 @@ func isValidUpgrade(currentState, requestedState uint32) bool {
 }
 
 // advanceEpoch increments the epoch counter on a lease.
-// Called on every state change: grant, break initiate, break ack, upgrade.
+// Called on every state change: grant, break initiate, upgrade.
+//
+// Break ACK is NOT a state change: MS-SMB2 §3.3.4.7 specifies that the
+// server sets NewEpoch = Epoch + 1 and commits Epoch = Epoch + 1 when
+// the break notification is dispatched. The subsequent ACK confirms a
+// transition already announced and counted; advancing again on ACK
+// drifts the server one past what the client tracks and trips V2 lease
+// verification on any subsequent break (see #417).
 func advanceEpoch(lease *OpLock) {
 	lease.Epoch++
 }
@@ -505,12 +512,14 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		return nil
 	}
 
-	// Update lease state
+	// Update lease state. Do NOT advance Epoch here: the state change was
+	// already counted when the break notification was dispatched per MS-SMB2
+	// §3.3.4.7 ("NewEpoch = Epoch + 1 ... Epoch = Epoch + 1"). Advancing on
+	// ACK drifts the server one past the client (#417).
 	lock.Lease.LeaseState = acknowledgedState
 	lock.Lease.Breaking = false
 	lock.Lease.BreakToState = 0
 	lock.Lease.BreakStarted = time.Time{}
-	advanceEpoch(lock.Lease)
 
 	// Update lock type based on new state
 	lock.Type = lockTypeForLeaseState(acknowledgedState)

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -545,6 +545,95 @@ func TestEpoch_IncrementOnUpgrade(t *testing.T) {
 	assert.Equal(t, uint16(3), epoch3)
 }
 
+// epochForLease returns the current Epoch of the lease with the given key.
+// Helper for the epoch-accounting tests below.
+func epochForLease(t *testing.T, mgr *Manager, key [16]byte) uint16 {
+	t.Helper()
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	_, lock, _ := mgr.findLeaseByKey(key)
+	if lock == nil || lock.Lease == nil {
+		t.Fatalf("no lease found for key %x", key)
+	}
+	return lock.Lease.Epoch
+}
+
+// setBreaking drives the lease into the Breaking state without going through
+// RequestLease (which would block on the break). Mirrors
+// TestAcknowledgeLeaseBreak_ToReadState's setup and bumps the epoch exactly
+// like RequestLease does at the real break-initiation site.
+func setBreaking(t *testing.T, mgr *Manager, key [16]byte, breakTo uint32) {
+	t.Helper()
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	for _, locks := range mgr.unifiedLocks {
+		for _, lock := range locks {
+			if lock.Lease != nil && lock.Lease.LeaseKey == key {
+				lock.Lease.Breaking = true
+				lock.Lease.BreakToState = breakTo
+				lock.Lease.BreakStarted = time.Now()
+				advanceEpoch(lock.Lease) // matches RequestLease at leases.go:256
+				return
+			}
+		}
+	}
+	t.Fatalf("no lease with key %x to mark breaking", key)
+}
+
+// TestEpoch_BreakPlusAck_SingleIncrement verifies MS-SMB2 §3.3.4.7: a break
+// (notification + subsequent ACK) advances Epoch exactly once — not twice.
+// The break-initiation increment is the state change announced on the wire;
+// the ACK confirms that change and must not add a second increment. See #417.
+func TestEpoch_BreakPlusAck_SingleIncrement(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key := [16]byte{1, 0, 0, 0}
+
+	// Grant RWH. Epoch = 1.
+	_, epochGrant, err := mgr.RequestLease(ctx, FileHandle("file1"), key, [16]byte{}, "owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.Equal(t, uint16(1), epochGrant)
+
+	// Break initiated (RWH → RH). Epoch must advance to 2 — this is what the
+	// notification carries as NewEpoch.
+	setBreaking(t, mgr, key, LeaseStateRead|LeaseStateHandle)
+	require.Equal(t, uint16(2), epochForLease(t, mgr, key),
+		"break initiation must advance epoch to grant + 1")
+
+	// ACK. Epoch must stay at 2: the state change was already counted.
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead|LeaseStateHandle, 2))
+	assert.Equal(t, uint16(2), epochForLease(t, mgr, key),
+		"ACK must not advance epoch — would drift one past the client (#417)")
+}
+
+// TestEpoch_TwoBreakCycles_TwoIncrements verifies the per-break accounting
+// across consecutive break/ACK pairs. After grant + two breaks, Epoch must be
+// grant + 2 (not grant + 4, which is the pre-fix double-increment behavior).
+func TestEpoch_TwoBreakCycles_TwoIncrements(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key := [16]byte{2, 0, 0, 0}
+
+	_, epochGrant, err := mgr.RequestLease(ctx, FileHandle("file2"), key, [16]byte{}, "owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.Equal(t, uint16(1), epochGrant)
+
+	// Cycle 1: break RWH → RH, ACK.
+	setBreaking(t, mgr, key, LeaseStateRead|LeaseStateHandle)
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead|LeaseStateHandle, 2))
+	require.Equal(t, uint16(2), epochForLease(t, mgr, key))
+
+	// Cycle 2: break RH → R, ACK. One more increment expected.
+	setBreaking(t, mgr, key, LeaseStateRead)
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead, 3))
+	assert.Equal(t, uint16(3), epochForLease(t, mgr, key),
+		"two break/ack cycles must yield exactly two increments total")
+}
+
 // ============================================================================
 // testBreakCallbacks helper
 // ============================================================================

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -34,10 +34,9 @@ async credit coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.multichannel.leases.test1 | Multi-channel | Pre-existing lease break new_epoch mismatch, surfaced once interface enumeration works — not a Phase 2 fan-out issue | - |
-| smb2.multichannel.leases.test2 | Multi-channel | Pre-existing lease break new_epoch mismatch — not a Phase 2 fan-out issue | - |
-| smb2.multichannel.leases.test3 | Multi-channel | Pre-existing lease break new_epoch mismatch — not a Phase 2 fan-out issue | - |
-| smb2.multichannel.leases.test4 | Multi-channel | Pre-existing lease break new_epoch mismatch — not a Phase 2 fan-out issue | - |
+| smb2.multichannel.leases.test2 | Multi-channel | Requires torture_block_tcp_transport (Samba-internal test-harness operation) to simulate a blocked channel — not implementable | - |
+| smb2.multichannel.leases.test3 | Multi-channel | Spurious lease break on uncontested open — separate bug from #417 epoch drift | - |
+| smb2.multichannel.leases.test4 | Multi-channel | Requires torture_block_tcp_transport (Samba-internal test-harness operation) — not implementable | - |
 | smb2.multichannel.oplocks.test2 | Multi-channel | Requires FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT (Samba test-harness FSCTL) to simulate connection failure — not implementable | - |
 | smb2.multichannel.oplocks.test3_windows | Multi-channel | Requires FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT to block TCP transport — not implementable | - |
 | smb2.multichannel.oplocks.test3_specification | Multi-channel | Requires FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT + 32-channel coordination — not implementable | - |


### PR DESCRIPTION
## Summary

Closes #417. Two protocol bugs in V2 lease accounting that together cause smbtorture's `smb2.multichannel.leases` suite (and any V1-lease break-notification recipient) to see incorrect `NewEpoch` values. Both bugs were pre-existing; PR #408's working break fan-out just surfaced them.

## Two commits, two distinct bugs

**`fix(smb): advance lease epoch once per break, not twice`** — `AcknowledgeLeaseBreak` was calling `advanceEpoch` a second time after break-initiation already advanced it. MS-SMB2 §3.3.4.7 specifies `NewEpoch = Epoch + 1` for a break, with the server committing `Epoch = Epoch + 1` at that moment. The ACK confirms a state change already announced and counted; it is not itself a new state change. Without the fix, every break+ack cycle drifts the server one past what the client tracks, so the next break carries `NewEpoch` two greater than expected.

**`fix(smb): send NewEpoch=0 on V1 lease breaks, advance grant epoch`**
- **V1 `NewEpoch`** (MS-SMB2 §2.2.23.2): V1 lease breaks MUST send `NewEpoch = 0`. DittoFS had no V1/V2 distinction on `OpLock`, so it leaked the server-tracked epoch on V1 breaks — which is what `multichannel.leases.test1` asserted against. Fix: track V1/V2 in a new `LeaseManager.leaseV2` map; `MarkLeaseV2` on every successful V2 grant path (`ProcessLeaseCreateContext` + durable reconnect); `OnOpLockBreak` consults `IsV2` and zeroes `NewEpoch` for V1. Durable reconnect re-marks V2 even when the client omits `RqLs` — lease-backed durable handles require SMB 3.x, which is always V2.
- **Grant epoch + 1** (MS-SMB2 §3.3.5.9.8): a V2 grant is a state change that MUST advance Epoch by 1 over the client's requested value. DittoFS echoed the client's value unchanged. This is what `multichannel.leases.test4`'s first assertion caught.

## Conformance status

| Test | Before | After |
|---|---|---|
| `smb2.multichannel.leases.test1` | KNOWN | **PASS** |
| `smb2.multichannel.leases.test2` | KNOWN | KNOWN — reason updated: requires `torture_block_tcp_transport` (Samba-internal) |
| `smb2.multichannel.leases.test3` | KNOWN | KNOWN — reason updated: spurious break on uncontested open, separate bug |
| `smb2.multichannel.leases.test4` | KNOWN | KNOWN — reason updated: requires `torture_block_tcp_transport`; epoch assertion passes but test fails on the next step |

Full smbtorture memory: **163 PASS / 232 KNOWN / 0 new failures** (from 160 / 240 / 0 pre-fix).

## Verification

- [x] `go test -race ./...` clean, including new unit tests that pin the single-increment accounting per break cycle
- [x] `cd test/smb-conformance/smbtorture && ./run.sh` — 0 new failures
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI green on PR

## KNOWN_FAILURES.md

Removed `smb2.multichannel.leases.test1`. Replaced the three other leases entries with their true (non-epoch-related) reasons.

## Out of scope

- `smb2.multichannel.leases.test3` spurious break — will file as a separate issue if conformance work resumes in that area.
- Cross-channel async credits (#416) — separate scope.
- Non-lease directory oplocks, traditional oplock epochs, etc. — unchanged.

## Test plan

- [x] Unit: `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/lease/... ./internal/adapter/smb/v2/handlers/...`
- [x] Conformance: full smbtorture memory sweep, 0 new failures
- [ ] CI green (unit / integration / e2e / smbtorture memory / smbtorture Kerberos / Windows / WPTS BVT)