### PR TITLE
fix(smb): scope NotifyRegistry MessageID index by ConnID — close #416

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -139,6 +139,13 @@ type PendingNotify struct {
 	// Request identification
 	FileID    [16]byte
 	SessionID uint64
+	// ConnID is the stable per-TCP-connection identifier on which this
+	// CHANGE_NOTIFY arrived. Needed alongside MessageID because SMB2 scopes
+	// MessageID to a single connection — two independent sessions on two
+	// TCP connections will routinely pick the same MessageID values, and
+	// keying the registry by MessageID alone silently evicts the earlier
+	// pending notify when the later one registers (issue #416).
+	ConnID    uint64
 	MessageID uint64
 	AsyncId   uint64 // Unique async ID for interim/final response correlation
 
@@ -162,20 +169,31 @@ type PendingNotify struct {
 // matching watchers and delivers async responses via AsyncCallback.
 // Thread-safe: all operations are protected by a read-write mutex.
 type NotifyRegistry struct {
-	mu          sync.RWMutex
-	pending     map[string][]*PendingNotify // path -> pending requests
-	byFileID    map[string]*PendingNotify   // fileID string -> pending request
-	byMessageID map[uint64]*PendingNotify   // messageID -> pending request (for CANCEL)
-	byAsyncId   map[uint64]*PendingNotify   // asyncId -> pending request (for async CANCEL)
+	mu       sync.RWMutex
+	pending  map[string][]*PendingNotify // path -> pending requests
+	byFileID map[string]*PendingNotify   // fileID string -> pending request
+	// byMsgKey is keyed by (ConnID, MessageID) because MessageID is scoped
+	// per TCP connection in SMB2. Keying by MessageID alone conflates
+	// independent pending notifies from different connections and silently
+	// evicts them on Register (issue #416).
+	byMsgKey  map[notifyMsgKey]*PendingNotify
+	byAsyncId map[uint64]*PendingNotify // asyncId -> pending request (for async CANCEL)
+}
+
+// notifyMsgKey identifies a pending notify by the tuple that uniquely names
+// an SMB2 request: the per-connection ID plus the per-connection MessageID.
+type notifyMsgKey struct {
+	ConnID    uint64
+	MessageID uint64
 }
 
 // NewNotifyRegistry creates a new notify registry.
 func NewNotifyRegistry() *NotifyRegistry {
 	return &NotifyRegistry{
-		pending:     make(map[string][]*PendingNotify),
-		byFileID:    make(map[string]*PendingNotify),
-		byMessageID: make(map[uint64]*PendingNotify),
-		byAsyncId:   make(map[uint64]*PendingNotify),
+		pending:   make(map[string][]*PendingNotify),
+		byFileID:  make(map[string]*PendingNotify),
+		byMsgKey:  make(map[notifyMsgKey]*PendingNotify),
+		byAsyncId: make(map[uint64]*PendingNotify),
 	}
 }
 
@@ -202,16 +220,21 @@ func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 		return ErrTooManyWatches
 	}
 
-	// Clean up any existing entry with the same MessageID to prevent orphans
-	// in byFileID/pending (a misbehaving client may reuse MessageIDs).
-	if oldByMsg, ok := r.byMessageID[notify.MessageID]; ok {
+	// Clean up any existing entry from the same (ConnID, MessageID) slot
+	// with a different FileID. SMB2 MessageIDs are unique per connection,
+	// so a same-connection collision means the client reused a MessageID
+	// — a client bug we defensively recover from. Cross-connection
+	// duplicates MUST NOT fall into this branch: they represent distinct
+	// pending requests on independent TCP connections (issue #416).
+	msgKey := notifyMsgKey{ConnID: notify.ConnID, MessageID: notify.MessageID}
+	if oldByMsg, ok := r.byMsgKey[msgKey]; ok {
 		if string(oldByMsg.FileID[:]) != string(notify.FileID[:]) {
 			r.unregisterLocked(oldByMsg)
 		}
 	}
 
 	r.byFileID[string(notify.FileID[:])] = notify
-	r.byMessageID[notify.MessageID] = notify
+	r.byMsgKey[msgKey] = notify
 	r.byAsyncId[notify.AsyncId] = notify
 	r.pending[notify.WatchPath] = append(r.pending[notify.WatchPath], notify)
 
@@ -238,14 +261,16 @@ func (r *NotifyRegistry) Unregister(fileID [16]byte) *PendingNotify {
 	return r.unregisterLocked(notify)
 }
 
-// UnregisterByMessageID removes a pending notification by MessageID.
-// Called by CANCEL to cancel a pending CHANGE_NOTIFY request.
-// Returns the removed PendingNotify, or nil if not found.
-func (r *NotifyRegistry) UnregisterByMessageID(messageID uint64) *PendingNotify {
+// UnregisterByMessageID removes a pending notification by (ConnID, MessageID).
+// Called by CANCEL when SMB2_FLAGS_ASYNC_COMMAND is not set on the cancel
+// request (spec requires the server to match the original request's
+// MessageID on its connection). Returns the removed PendingNotify, or nil
+// if not found.
+func (r *NotifyRegistry) UnregisterByMessageID(connID, messageID uint64) *PendingNotify {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	notify, ok := r.byMessageID[messageID]
+	notify, ok := r.byMsgKey[notifyMsgKey{ConnID: connID, MessageID: messageID}]
 	if !ok {
 		return nil
 	}
@@ -273,7 +298,7 @@ func (r *NotifyRegistry) UnregisterByAsyncId(asyncId uint64) *PendingNotify {
 func (r *NotifyRegistry) unregisterLocked(notify *PendingNotify) *PendingNotify {
 	fileIDKey := string(notify.FileID[:])
 	delete(r.byFileID, fileIDKey)
-	delete(r.byMessageID, notify.MessageID)
+	delete(r.byMsgKey, notifyMsgKey{ConnID: notify.ConnID, MessageID: notify.MessageID})
 	delete(r.byAsyncId, notify.AsyncId)
 
 	// Remove from pending path list

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -55,12 +55,96 @@ func TestNotifyRegistry_RegisterAndUnregister(t *testing.T) {
 	}
 }
 
+// TestNotifyRegistry_Register_CrossConnectionMessageIDNoEvict is a regression
+// test for issue #416. Before the fix, the registry keyed byMessageID
+// globally: when a second TCP connection registered a CHANGE_NOTIFY with
+// the same MessageID value as a live pending notify on another connection
+// (common because MessageID is per-connection), Register silently
+// unregistered the first one. The client on the first connection then hung
+// — no final response, CANCEL couldn't find the entry, connection
+// eventually dropped. After the fix, (ConnID, MessageID) is the key.
+func TestNotifyRegistry_Register_CrossConnectionMessageIDNoEvict(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	a := &PendingNotify{
+		FileID:           [16]byte{0xA},
+		SessionID:        100,
+		ConnID:           1,
+		MessageID:        521,
+		AsyncId:          3600,
+		WatchPath:        "/testdir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+	}
+	b := &PendingNotify{
+		FileID:           [16]byte{0xB},
+		SessionID:        200,
+		ConnID:           2,
+		MessageID:        521, // same MessageID, different ConnID
+		AsyncId:          3605,
+		WatchPath:        "/testdir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+	}
+	mustRegister(t, r, a)
+	mustRegister(t, r, b)
+
+	// Both must still be resolvable — B's Register must NOT have evicted A.
+	if got := r.UnregisterByAsyncId(3600); got == nil || got.AsyncId != 3600 {
+		t.Fatalf("A (asyncId=3600) missing after B registered with same MessageID on a different ConnID")
+	}
+	if got := r.UnregisterByAsyncId(3605); got == nil || got.AsyncId != 3605 {
+		t.Fatalf("B (asyncId=3605) missing")
+	}
+}
+
+// TestNotifyRegistry_UnregisterByMessageID_DisambiguatesByConnID verifies the
+// CANCEL-by-MessageID path scopes its lookup to the requesting connection,
+// so two pending notifies sharing a MessageID across two TCP connections
+// can each be cancelled independently.
+func TestNotifyRegistry_UnregisterByMessageID_DisambiguatesByConnID(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	a := &PendingNotify{
+		FileID:           [16]byte{0xA},
+		SessionID:        100,
+		ConnID:           1,
+		MessageID:        521,
+		AsyncId:          1,
+		WatchPath:        "/d",
+		ShareName:        "s",
+		CompletionFilter: FileNotifyChangeFileName,
+	}
+	b := &PendingNotify{
+		FileID:           [16]byte{0xB},
+		SessionID:        200,
+		ConnID:           2,
+		MessageID:        521,
+		AsyncId:          2,
+		WatchPath:        "/d",
+		ShareName:        "s",
+		CompletionFilter: FileNotifyChangeFileName,
+	}
+	mustRegister(t, r, a)
+	mustRegister(t, r, b)
+
+	got := r.UnregisterByMessageID(1, 521)
+	if got == nil || got.AsyncId != 1 {
+		t.Fatalf("UnregisterByMessageID(connID=1) returned %+v, want A", got)
+	}
+	// B must still be there.
+	if got := r.UnregisterByMessageID(2, 521); got == nil || got.AsyncId != 2 {
+		t.Fatalf("UnregisterByMessageID(connID=2) returned %+v, want B", got)
+	}
+}
+
 func TestNotifyRegistry_UnregisterByMessageID(t *testing.T) {
 	r := NewNotifyRegistry()
 
 	notify := &PendingNotify{
 		FileID:           [16]byte{1},
 		SessionID:        100,
+		ConnID:           7,
 		MessageID:        42,
 		AsyncId:          99,
 		WatchPath:        "/dir",
@@ -69,8 +153,8 @@ func TestNotifyRegistry_UnregisterByMessageID(t *testing.T) {
 	}
 	mustRegister(t, r, notify)
 
-	// Unregister by message ID
-	removed := r.UnregisterByMessageID(42)
+	// Unregister by (ConnID, MessageID)
+	removed := r.UnregisterByMessageID(7, 42)
 	if removed == nil {
 		t.Fatal("expected non-nil removed notify")
 	}
@@ -79,7 +163,7 @@ func TestNotifyRegistry_UnregisterByMessageID(t *testing.T) {
 	}
 
 	// Should not find it again
-	removed = r.UnregisterByMessageID(42)
+	removed = r.UnregisterByMessageID(7, 42)
 	if removed != nil {
 		t.Error("expected nil on second unregister")
 	}

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -196,7 +196,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 		if ctx.RequestAsyncId != 0 {
 			cancelled = h.NotifyRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
 		} else {
-			cancelled = h.NotifyRegistry.UnregisterByMessageID(ctx.MessageID)
+			cancelled = h.NotifyRegistry.UnregisterByMessageID(ctx.ConnID, ctx.MessageID)
 		}
 
 		if cancelled != nil {
@@ -351,6 +351,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	notify := &PendingNotify{
 		FileID:           req.FileID,
 		SessionID:        ctx.SessionID,
+		ConnID:           ctx.ConnID,
 		MessageID:        ctx.MessageID,
 		AsyncId:          asyncId,
 		WatchPath:        watchPath,

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -217,20 +217,16 @@ DittoFS implements file leases (Phase 37) but not directory leases.
 | smb2.dirlease.v2_request | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.v2_request_parent | Directory Leases | Directory leases not implemented | - |
 
-### Credit Management (Multi-Channel Subset Not Implemented)
+### Credit Management
 
-Credit grant arithmetic and the `max_async_credits` cap are both correct
-post-#399 follow-up: `ipc_max_data_zero`, `1conn_ipc_max_async_credits`,
-`2conn_ipc_max_async_credits`, and `1conn_notify_max_async_credits` all pass.
-
-The remaining failures all require multi-channel session binding (MS-SMB2
-§3.3.5.5.2) and are tracked under #361.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.credits.multichannel_ipc_max_async_credits | Credits | Multi-channel async credit coordination across channels not yet implemented (Phase 2 of #361) | #361 |
-| smb2.credits.2conn_notify_max_async_credits | Credits | Multi-channel not implemented (second connection disconnects mid-test) | #361 |
-| smb2.credits.multichannel_max_async_credits | Credits | Multi-channel async credit coordination across channels not yet implemented (Phase 2 of #361) | #361 |
+Credit grant arithmetic and the `max_async_credits` cap are correct post-#399
+and post-#416: the full `smb2.credits` subsuite (10 tests) passes. Samba
+enforces the 511-slot cap **per TCP connection** —
+`source4/torture/smb2/credits.c:1346` asserts
+`num_status_pending == 511` per tree — which DittoFS's per-`ConnInfo`
+counter already matched. The `2conn_notify_max_async_credits` failure that
+remained here was a cross-connection MessageID collision in
+`NotifyRegistry`, fixed in #416.
 
 ### Directory Operations (Advanced Queries Not Implemented)
 


### PR DESCRIPTION
## Summary

Fixes `smb2.credits.2conn_notify_max_async_credits` by keying
`NotifyRegistry.byMessageID` on `(ConnID, MessageID)` instead of `MessageID`
alone. SMB2 MessageIDs are per-TCP-connection, so the old global key
silently evicted the earlier pending CHANGE_NOTIFY whenever two
connections happened to pick the same value.

Full investigation & data in #416; summary:

- Test failure symptom was `NT_STATUS_CONNECTION_DISCONNECTED` after a 60-s client timeout.
- Root cause traced in logs: sess 18 registers `messageID=521`, sess 19 registers `messageID=521` with a different FileID → `Register()` silently calls `unregisterLocked` on sess 18's entry. Sess 18's pending request is orphaned, CANCEL can't find it.
- The two `multichannel_*_max_async_credits` entries in `KNOWN_FAILURES.md` were already passing — Samba enforces the 511-slot async-credit cap **per connection** (verified against `source4/torture/smb2/credits.c:1346`), which DittoFS's per-`ConnInfo` counter already matched. Second commit updates the doc.

## Changes

- `NotifyRegistry.byMessageID` → `byMsgKey` keyed by `(ConnID, MessageID)`.
- `PendingNotify.ConnID` added; populated from `ctx.ConnID` in the CHANGE_NOTIFY handler.
- `UnregisterByMessageID(connID, messageID uint64)` — existing CANCEL caller updated.
- Regression tests: cross-connection MessageID must NOT evict on Register; `UnregisterByMessageID` disambiguates by ConnID.
- `KNOWN_FAILURES.md`: credits subsuite rewritten, all 10 tests now pass.

## Test plan

- [x] `go test -race ./internal/adapter/smb/...` green
- [x] `go test -race ./pkg/adapter/smb/...` green
- [x] smbtorture `smb2.credits` — 10/10 pass (was 9/10 with `2conn_notify_max_async_credits` failing)
- [x] Regression tests added for the cross-connection collision
- [ ] Reviewer: full smb2 regression sweep before merge (local run skipped — `smb2.notify.*` suite contains pre-existing flakes unrelated to this change)

## Related

- Closes #416
- No interaction with #361 multichannel Phase 1 / Phase 2 (those landed separately)