### PR TITLE
fix(smb): scope lease break delivery and inline non-ack downgrades — #429

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -31,6 +31,17 @@ import (
 // SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED is set).
 const parentLeaseBreakWaitTimeout = 5 * time.Second
 
+// handleLeaseBreakWaitTimeout bounds how long a CREATE waits for the existing
+// lease holder to acknowledge a Handle-strip break before falling back to
+// forceCompleteBreaks (auto-downgrade) and proceeding to the share-mode check.
+//
+// Without a bound, the wait inherits the auth context which only cancels on
+// session disconnect — non-acking clients hang the conflicting open for as
+// long as the test harness tolerates. Samba bounds this at ~32 s
+// (2× OPLOCK_BREAK_TIMEOUT, schedule_defer_open in source3/smbd/open.c); we
+// use the same 5 s as the parent break for consistency.
+const handleLeaseBreakWaitTimeout = 5 * time.Second
+
 // LockManagerResolver resolves the LockManager for a given share name.
 // This allows the LeaseManager to work across multiple shares without
 // holding a reference to a specific share's LockManager.
@@ -393,8 +404,12 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		return err
 	}
 
-	// Wait for break to complete before caller re-checks share modes
-	return lockMgr.WaitForBreakCompletion(ctx, handleKey)
+	// Wait for break to complete (bounded) before caller re-checks share
+	// modes. On timeout, forceCompleteBreaks auto-downgrades the lease so
+	// the share-mode check runs against a deterministic post-break state.
+	waitCtx, cancel := context.WithTimeout(ctx, handleLeaseBreakWaitTimeout)
+	defer cancel()
+	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
 // BreakHandleLeasesOnOpenAsync dispatches Handle lease break notifications

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -431,6 +431,19 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		return err
 	}
 
+	// Same-key reopen while the opener's own lease is mid-break: skip the
+	// wait. Per MS-SMB2 3.3.5.9.8 the CREATE response MUST carry
+	// SMB2_LEASE_FLAG_BREAK_IN_PROGRESS whenever the lease is in Breaking
+	// state, and ProcessLeaseCreateContext reads that state from RequestLease.
+	// If we wait here, WaitForBreakCompletion's timeout path
+	// (forceCompleteBreaks) clears Breaking before the read, dropping the
+	// flag — matches smbtorture smb2.lease.breaking1/2/.. and
+	// duplicate_create/duplicate_open expectations.
+	if exclude != nil && exclude.ExcludeLeaseKey != ([16]byte{}) &&
+		lockMgr.HasBreakingLeaseForKey(handleKey, exclude.ExcludeLeaseKey) {
+		return nil
+	}
+
 	waitCtx, cancel := context.WithTimeout(ctx, handleLeaseBreakWaitTimeout)
 	defer cancel()
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -366,20 +366,29 @@ func (lm *LeaseManager) BreakConflictingOplocksOnOpen(
 	return lockMgr.CheckAndBreakLeasesForSMBOpen(handleKey, exclude)
 }
 
-// BreakHandleLeasesOnOpen breaks Handle leases before share mode conflict check.
-// Per MS-SMB2 3.3.5.9 Step 10: "If any existing Open on the target file has a
-// lease with Handle caching, the server MUST initiate a lease break to remove
-// Handle caching." This must happen BEFORE the share mode conflict check so that
-// clients relinquish cached handles, avoiding spurious SHARING_VIOLATION errors.
+// BreakHandleLeasesOnOpen breaks leases before the share-mode conflict check
+// for an SMB CREATE on a file, per MS-SMB2 3.3.4.7 and Samba
+// `source3/smbd/open.c::delay_for_oplock_fn`:
 //
-// After breaking, the caller should wait for break completion and then re-check
-// share mode conflicts.
+//   - hasSharingViolation == true → strip Handle (keep Read + Write). The
+//     existing holder must release cached open handles so the new opener can
+//     proceed; writes stay cached because the holder will close the handle
+//     anyway.
+//   - hasSharingViolation == false → strip Write (keep Read + Handle). The
+//     holder flushes dirty data but may keep cached handles, and the new
+//     opener coexists.
+//
+// After breaking, the caller waits for completion and re-runs the share-mode
+// check. On timeout, forceCompleteBreaks auto-downgrades the lease so the
+// re-check runs against a deterministic post-break state.
+//
 // excludeOwner is optional and can contain ExcludeLeaseKey to prevent
 // breaking same-key leases (nobreakself per MS-SMB2).
 func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 	ctx context.Context,
 	fileHandle lock.FileHandle,
 	shareName string,
+	hasSharingViolation bool,
 	excludeOwner ...*lock.LockOwner,
 ) error {
 	lockMgr := lm.resolveLockManager(shareName)
@@ -394,33 +403,27 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		exclude = excludeOwner[0]
 	}
 
-	// Strip Write from leases that have Handle caching (RWH -> RH).
-	// This sends one notification that matches what clients expect:
-	// "flush dirty data" (Write strip). The Handle bit is preserved so
-	// the client can close cached handles in its ack response.
-	// After the ack, the lease is at RH (no Write, no Breaking), and
-	// Step 8a can independently strip Handle if needed.
-	if err := lockMgr.BreakWriteOnHandleLeasesForSMBOpen(handleKey, exclude); err != nil {
+	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, hasSharingViolation); err != nil {
 		return err
 	}
 
-	// Wait for break to complete (bounded) before caller re-checks share
-	// modes. On timeout, forceCompleteBreaks auto-downgrades the lease so
-	// the share-mode check runs against a deterministic post-break state.
 	waitCtx, cancel := context.WithTimeout(ctx, handleLeaseBreakWaitTimeout)
 	defer cancel()
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
-// BreakHandleLeasesOnOpenAsync dispatches Handle lease break notifications
-// without waiting for acknowledgment. Used for directory opens where share
-// mode conflicts are not a concern and blocking would deadlock: the other
-// client needs this CREATE's response before it processes the break.
+// BreakHandleLeasesOnOpenAsync dispatches lease break notifications without
+// waiting for acknowledgment. Used for directory opens where blocking would
+// deadlock the single-threaded test driver: the other client only acks after
+// this CREATE returns.
+//
+// Break-to semantics match BreakHandleLeasesOnOpen (see that doc comment).
 // excludeOwner is optional and can contain ExcludeLeaseKey to prevent
 // breaking same-key leases (nobreakself per MS-SMB2).
 func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	fileHandle lock.FileHandle,
 	shareName string,
+	hasSharingViolation bool,
 	excludeOwner ...*lock.LockOwner,
 ) error {
 	lockMgr := lm.resolveLockManager(shareName)
@@ -435,7 +438,7 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 		exclude = excludeOwner[0]
 	}
 
-	return lockMgr.BreakHandleLeasesForSMBOpen(handleKey, exclude)
+	return lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, hasSharingViolation)
 }
 
 // resolveParentBreakArgs resolves the lock manager, handle key, and exclude
@@ -482,7 +485,14 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	if lockMgr == nil {
 		return nil
 	}
-	if err := lockMgr.BreakHandleLeasesForSMBOpen(handleKey, excludeOwner); err != nil {
+	// Parent directory Handle-lease break on child create: strip Handle
+	// (not Write) so cached entries are invalidated. Pass
+	// hasSharingViolation=true to BreakLeasesOnOpenConflict because that
+	// selects the Handle-strip mask; semantically this is MS-FSA 2.1.5.14
+	// (child-set change invalidates directory Handle caching), not a
+	// share-mode violation, but the break-to matrix collapses to the same
+	// strip-H outcome.
+	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, true); err != nil {
 		return err
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -441,6 +441,38 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	return lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, hasSharingViolation)
 }
 
+// BreakFileHandleLeasesOnDelete strips Handle caching from all leases on a
+// file that is about to be unlinked (RH → R, RWH → RW). Per MS-FSA 2.1.5.1.5
+// and Samba: deleting a file invalidates Handle caching for every other open
+// (the reopen path no longer exists), but Read and Write remain valid for as
+// long as the in-flight handles stay alive.
+//
+// Async dispatch: the break is triggered from the close/TDIS/LOGOFF/disconnect
+// teardown path, where the lease holder is a DIFFERENT session on the same
+// transport. Waiting for the ACK here would deadlock the in-flight SMB
+// request; the holder acks on its own transport after we return.
+//
+// Required by smbtorture smb2.lease.initial_delete_tdis / logoff / disconnect.
+func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
+	fileHandle lock.FileHandle,
+	shareName string,
+	excludeOwner ...*lock.LockOwner,
+) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	var exclude *lock.LockOwner
+	if len(excludeOwner) > 0 {
+		exclude = excludeOwner[0]
+	}
+	// hasSharingViolation=true selects the strip-Handle mask via
+	// ComputeLeaseBreakTo; the triggering "conflict" here is the unlink,
+	// not a share-mode violation, but the break-to outcome is identical.
+	return lockMgr.BreakLeasesOnOpenConflict(string(fileHandle), exclude, true)
+}
+
 // resolveParentBreakArgs resolves the lock manager, handle key, and exclude
 // owner for parent directory lease break operations. Returns nil lockMgr if
 // the share has no lock manager.

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -431,17 +431,16 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		return err
 	}
 
-	// Same-key reopen while the opener's own lease is mid-break: must not
-	// wait, or WaitForBreakCompletion's forceCompleteBreaks fallback clears
-	// Breaking before ProcessLeaseCreateContext reads it, dropping
-	// SMB2_LEASE_FLAG_BREAK_IN_PROGRESS (MS-SMB2 3.3.5.9.8).
-	if exclude != nil && exclude.ExcludeLeaseKey != ([16]byte{}) &&
-		lockMgr.HasBreakingLeaseForKey(handleKey, exclude.ExcludeLeaseKey) {
-		return nil
-	}
-
 	waitCtx, cancel := context.WithTimeout(ctx, handleLeaseBreakWaitTimeout)
 	defer cancel()
+
+	// A same-key reopen must still wait for any OTHER breaking leases on
+	// this handle to drain (MS-SMB2 3.3.4.7), but it must not force-complete
+	// the opener's own Breaking lease — RequestLease needs to observe it and
+	// emit SMB2_LEASE_FLAG_BREAK_IN_PROGRESS per MS-SMB2 3.3.5.9.8.
+	if exclude != nil && exclude.ExcludeLeaseKey != ([16]byte{}) {
+		return lockMgr.WaitForBreakCompletionExceptKey(waitCtx, handleKey, exclude.ExcludeLeaseKey)
+	}
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -431,14 +431,10 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpen(
 		return err
 	}
 
-	// Same-key reopen while the opener's own lease is mid-break: skip the
-	// wait. Per MS-SMB2 3.3.5.9.8 the CREATE response MUST carry
-	// SMB2_LEASE_FLAG_BREAK_IN_PROGRESS whenever the lease is in Breaking
-	// state, and ProcessLeaseCreateContext reads that state from RequestLease.
-	// If we wait here, WaitForBreakCompletion's timeout path
-	// (forceCompleteBreaks) clears Breaking before the read, dropping the
-	// flag — matches smbtorture smb2.lease.breaking1/2/.. and
-	// duplicate_create/duplicate_open expectations.
+	// Same-key reopen while the opener's own lease is mid-break: must not
+	// wait, or WaitForBreakCompletion's forceCompleteBreaks fallback clears
+	// Breaking before ProcessLeaseCreateContext reads it, dropping
+	// SMB2_LEASE_FLAG_BREAK_IN_PROGRESS (MS-SMB2 3.3.5.9.8).
 	if exclude != nil && exclude.ExcludeLeaseKey != ([16]byte{}) &&
 		lockMgr.HasBreakingLeaseForKey(handleKey, exclude.ExcludeLeaseKey) {
 		return nil

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -232,6 +232,30 @@ func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) err
 	return nil
 }
 
+// ReleaseLeaseForHandle releases lease records only under a specific handleKey
+// bucket. Used by CLOSE so that opens on OTHER files sharing the same
+// LeaseKey constant (typical in smbtorture, which reuses fixed LEASE1/LEASE2
+// macros across tests) retain their records. The session/share mappings are
+// only torn down when the last record for the key is gone.
+func (lm *LeaseManager) ReleaseLeaseForHandle(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, shareName string) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	if err := lockMgr.ReleaseLeaseForHandle(ctx, string(fileHandle), leaseKey); err != nil {
+		return err
+	}
+
+	// Only drop session/share mappings if no lease records remain anywhere for
+	// this key — otherwise a concurrent open on a different file would lose
+	// break-dispatch routing.
+	if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
+		lm.removeLeaseMapping(hex.EncodeToString(leaseKey[:]))
+	}
+	return nil
+}
+
 // ReleaseSessionLeases releases all leases owned by a session.
 // This is called during session cleanup (LOGOFF / connection close).
 func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint64) error {

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -21,7 +21,7 @@ type fakeLockManager struct {
 	breakReadCalls             []breakCall
 	waitForBreakCompletionKeys []string
 	// callOrder records the relative order of all observed calls so tests can
-	// assert that BreakHandleLeasesForSMBOpen / BreakReadLeasesForParentDir
+	// assert that BreakLeasesOnOpenConflict / BreakReadLeasesForParentDir
 	// happen BEFORE WaitForBreakCompletion returns.
 	callOrder []string
 
@@ -31,15 +31,20 @@ type fakeLockManager struct {
 }
 
 type breakCall struct {
-	HandleKey    string
-	ExcludeOwner *lock.LockOwner
+	HandleKey           string
+	ExcludeOwner        *lock.LockOwner
+	HasSharingViolation bool
 }
 
-func (f *fakeLockManager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *lock.LockOwner) error {
+func (f *fakeLockManager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *lock.LockOwner, hasSharingViolation bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.breakHandleCalls = append(f.breakHandleCalls, breakCall{HandleKey: handleKey, ExcludeOwner: excludeOwner})
-	f.callOrder = append(f.callOrder, "BreakHandleLeasesForSMBOpen")
+	f.breakHandleCalls = append(f.breakHandleCalls, breakCall{
+		HandleKey:           handleKey,
+		ExcludeOwner:        excludeOwner,
+		HasSharingViolation: hasSharingViolation,
+	})
+	f.callOrder = append(f.callOrder, "BreakLeasesOnOpenConflict")
 	return nil
 }
 
@@ -78,8 +83,10 @@ func (r *fakeResolver) GetLockManagerForShare(_ string) lock.LockManager {
 
 // TestBreakParentHandleLeasesOnCreate_WaitsForAck asserts that
 // BreakParentHandleLeasesOnCreate calls WaitForBreakCompletion AFTER
-// BreakHandleLeasesForSMBOpen and BEFORE returning. Per MS-SMB2 3.3.4.7, the
+// BreakLeasesOnOpenConflict and BEFORE returning. Per MS-SMB2 3.3.4.7, the
 // server must wait for LEASE_BREAK_ACK before completing the triggering CREATE.
+// The parent-dir break uses hasSharingViolation=true to select the Handle-strip
+// mask (MS-FSA 2.1.5.14: child-set change invalidates directory Handle cache).
 func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 	t.Parallel()
 
@@ -95,11 +102,14 @@ func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 	defer fake.mu.Unlock()
 
 	if got := len(fake.breakHandleCalls); got != 1 {
-		t.Fatalf("BreakHandleLeasesForSMBOpen call count = %d, want 1", got)
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", got)
 	}
 	if fake.breakHandleCalls[0].HandleKey != string(parentHandle) {
-		t.Errorf("BreakHandleLeasesForSMBOpen handleKey = %q, want %q",
+		t.Errorf("BreakLeasesOnOpenConflict handleKey = %q, want %q",
 			fake.breakHandleCalls[0].HandleKey, string(parentHandle))
+	}
+	if !fake.breakHandleCalls[0].HasSharingViolation {
+		t.Errorf("parent-dir Handle break must pass hasSharingViolation=true (strip Handle mask); got false")
 	}
 
 	if got := len(fake.waitForBreakCompletionKeys); got != 1 {
@@ -114,8 +124,8 @@ func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 	if len(fake.callOrder) < 2 {
 		t.Fatalf("expected at least 2 calls in order, got %v", fake.callOrder)
 	}
-	if fake.callOrder[0] != "BreakHandleLeasesForSMBOpen" {
-		t.Errorf("first call = %q, want BreakHandleLeasesForSMBOpen", fake.callOrder[0])
+	if fake.callOrder[0] != "BreakLeasesOnOpenConflict" {
+		t.Errorf("first call = %q, want BreakLeasesOnOpenConflict", fake.callOrder[0])
 	}
 	if fake.callOrder[1] != "WaitForBreakCompletion" {
 		t.Errorf("second call = %q, want WaitForBreakCompletion", fake.callOrder[1])
@@ -204,7 +214,7 @@ func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
 	defer fake.mu.Unlock()
 
 	if len(fake.breakHandleCalls) != 1 {
-		t.Fatalf("BreakHandleLeasesForSMBOpen call count = %d, want 1", len(fake.breakHandleCalls))
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", len(fake.breakHandleCalls))
 	}
 	excludeOwner := fake.breakHandleCalls[0].ExcludeOwner
 	if excludeOwner == nil {

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/mfsymlink"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // ============================================================================
@@ -349,26 +351,37 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 		leaseKey := openFile.LeaseKey
 
 		if leaseKey != ([16]byte{}) {
-			// Check if any other open shares this lease key
-			hasOtherOpen := false
+			// Check if any other open on the SAME FILE shares this lease key.
+			// Two opens on the same file share one lease record (requestLeaseImpl
+			// upgrades in place). Different files with the same key are separate
+			// records in distinct handleKey buckets and must not be disturbed.
+			hasOtherOpenSameFile := false
 			h.files.Range(func(key, value any) bool {
 				other := value.(*OpenFile)
-				if other.FileID != openFile.FileID && other.LeaseKey == leaseKey {
-					hasOtherOpen = true
-					return false // stop iteration
+				if other.FileID == openFile.FileID {
+					return true // skip self
+				}
+				if other.LeaseKey != leaseKey {
+					return true
+				}
+				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+					hasOtherOpenSameFile = true
+					return false
 				}
 				return true
 			})
 
-			if !hasOtherOpen {
-				// Last handle with this lease key - release the lease
-				if err := h.LeaseManager.ReleaseLease(ctx.Context, leaseKey); err != nil {
+			if !hasOtherOpenSameFile {
+				// Last open on this file with this lease key — release only
+				// this handle's lease record. Other files sharing the key
+				// (smbtorture reuses LEASE1/LEASE2 across tests) keep theirs.
+				if err := h.LeaseManager.ReleaseLeaseForHandle(ctx.Context, lock.FileHandle(openFile.MetadataHandle), leaseKey, openFile.ShareName); err != nil {
 					logger.Debug("CLOSE: failed to release lease",
 						"path", openFile.Path,
 						"leaseKey", fmt.Sprintf("%x", leaseKey),
 						"error", err)
 				} else {
-					logger.Debug("CLOSE: released lease (last handle closed)",
+					logger.Debug("CLOSE: released lease (last open on this file)",
 						"path", openFile.Path,
 						"leaseKey", fmt.Sprintf("%x", leaseKey))
 				}
@@ -377,7 +390,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					h.LeaseManager.UnregisterOplockFileID(leaseKey)
 				}
 			} else {
-				logger.Debug("CLOSE: lease handle closed (other opens share lease key)",
+				logger.Debug("CLOSE: lease handle closed (other opens share lease key on same file)",
 					"path", openFile.Path)
 			}
 		}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -860,27 +860,33 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	if fileExists {
 		existingHandle, handleErr := metadata.EncodeFileHandle(existingFile)
 		if handleErr == nil {
-			// Step 10: Break Handle leases before share mode check.
-			// Per MS-SMB2 3.3.5.9 Step 10: if any existing open has a lease
-			// with Handle caching, break it so the client can close cached
-			// handles before the share mode check.
+			// Step 10: Break leases before share mode check.
+			// Per MS-SMB2 3.3.4.7 and Samba delay_for_oplock_fn, the break
+			// target depends on whether this open sharing-conflicts with an
+			// existing one:
+			//   - violation → strip Handle (holder releases cached handles)
+			//   - no violation → strip Write (holder flushes dirty data)
 			// Per MS-SMB2 3.3.5.9.8: stat-only opens do NOT break leases.
 			//
-			// For files: synchronous wait for Handle break ack. After the
-			// client acks (closing the cached handle), the share mode check
-			// runs with updated state. Step 8a then strips Write if needed.
+			// The share-mode check runs against current opens before the
+			// break; it is re-run after the break to decide the final CREATE
+			// outcome. A violation pre-break selects the Handle-strip path
+			// so the holder can close cached handles in its ack; if so, the
+			// post-break re-check may clear the violation.
 			//
-			// For directories: async (fire-and-forget). Directory opens use
-			// a single-threaded test driver where the client can't ack until
-			// this CREATE returns — waiting would deadlock.
+			// For files: synchronous wait for break ack. For directories:
+			// async (fire-and-forget). Directory opens use a single-threaded
+			// test driver where the client can't ack until this CREATE
+			// returns — waiting would deadlock.
+			hasSharingViolation := h.checkShareModeConflict(existingHandle, req.DesiredAccess, req.ShareAccess, filename)
 			if h.LeaseManager != nil && !isStatOnlyOpen(req.DesiredAccess) {
 				lockFileHandle := lock.FileHandle(existingHandle)
 				if existingFile.Type == metadata.FileTypeDirectory {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, tree.ShareName, hasSharingViolation, excludeOwner); breakErr != nil {
 						logger.Debug("CREATE: directory handle lease break failed", "error", breakErr)
 					}
 				} else {
-					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, excludeOwner); breakErr != nil {
+					if breakErr := h.LeaseManager.BreakHandleLeasesOnOpen(authCtx.Context, lockFileHandle, tree.ShareName, hasSharingViolation, excludeOwner); breakErr != nil {
 						logger.Debug("CREATE: handle lease break failed", "error", breakErr)
 					}
 				}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -602,23 +602,59 @@ func (h *Handler) closeFilesWithFilter(
 	return closed
 }
 
-// handleDeleteOnClose performs the delete operation for files marked with delete-on-close.
+// handleDeleteOnClose performs the delete operation for files marked with
+// delete-on-close during session/tree/connection teardown.
+//
+// Two lease breaks fire around the delete:
+//
+//  1. Before the unlink, strip Handle from other sessions' leases on the
+//     file being deleted (RH → R, RWH → RW). The file is going away, so
+//     Handle caching becomes stale. Required by
+//     smb2.lease.initial_delete_tdis / logoff / disconnect.
+//
+//  2. After the unlink, break the parent directory's Handle and Read leases
+//     (content change). Matches the explicit CLOSE path at close.go:334.
+//
+// Both breaks are async: the triggering SMB request (TDIS / LOGOFF / CLOSE /
+// transport close) is on tree2/session2, while the lease holder is on a
+// different session/tree on the same transport. Waiting for an ACK here
+// would deadlock — the holder can only ack after the triggering request
+// returns.
 func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session, openFile *OpenFile, caller string) {
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	metaSvc := h.Registry.GetMetadataService()
 
+	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
+		// Exclude the closing session: its leases on this file are about to
+		// be released anyway, and firing self-breaks creates spurious
+		// notifications that leak into later tests (observed regressing
+		// smb2.lease.v1_bug15148 to count=2).
+		excludeOwner := &lock.LockOwner{ClientID: fmt.Sprintf("smb:%d", openFile.SessionID)}
+		if breakErr := h.LeaseManager.BreakFileHandleLeasesOnDelete(lockFileHandle, openFile.ShareName, excludeOwner); breakErr != nil {
+			logger.Debug(caller+": file Handle lease break on delete failed", "path", openFile.Path, "error", breakErr)
+		}
+	}
+
+	var deleted bool
 	if openFile.IsDirectory {
 		if err := metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
 			logger.Debug(caller+": failed to delete directory", "path", openFile.Path, "error", err)
 		} else {
 			logger.Debug(caller+": directory deleted", "path", openFile.Path)
+			deleted = true
 		}
 	} else {
 		if _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
 			logger.Debug(caller+": failed to delete file", "path", openFile.Path, "error", err)
 		} else {
 			logger.Debug(caller+": file deleted", "path", openFile.Path)
+			deleted = true
 		}
+	}
+
+	if deleted {
+		h.breakParentDirLeasesForContentChange(authCtx, openFile)
 	}
 }
 

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -571,6 +571,44 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 	return nil
 }
 
+// ReleaseLeaseForHandle removes lease records matching leaseKey from a single
+// handleKey bucket. Unlike ReleaseLease, this does NOT touch records on other
+// handles that happen to share the same key.
+//
+// The same LeaseKey constant can appear on different files (different
+// handleKey buckets) — typical for smbtorture which uses fixed LEASE1/LEASE2
+// macros across tests. Releasing one open on file A must not erase the lease
+// record for a concurrent open on file B; otherwise stale records accumulate
+// on the surviving file and break ACK lookup / break-to matching.
+func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey string, leaseKey [16]byte) error {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	locks := lm.unifiedLocks[handleKey]
+	if len(locks) == 0 {
+		return nil
+	}
+
+	var remaining []*UnifiedLock
+	for _, lock := range locks {
+		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
+			if lm.lockStore != nil {
+				_ = lm.lockStore.DeleteLock(ctx, lock.ID)
+			}
+			continue
+		}
+		remaining = append(remaining, lock)
+	}
+
+	if len(remaining) == 0 {
+		delete(lm.unifiedLocks, handleKey)
+	} else {
+		lm.unifiedLocks[handleKey] = remaining
+	}
+
+	return nil
+}
+
 // GetLeaseState returns the current state and epoch for a lease key.
 func (lm *Manager) getLeaseStateImpl(_ context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	lm.mu.RLock()

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -231,10 +231,13 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 		}
 
 		if OpLocksConflict(lock.Lease, requested) {
-			// Compute break-to state: strip only the Write bit from the
-			// existing lease, preserving Read and Handle. Per MS-SMB2
-			// 3.3.5.9.8/3.3.5.9.11, RWH breaks to RH, RW breaks to R.
-			breakTo := lock.Lease.LeaseState &^ LeaseStateWrite
+			// Compute break-to state via ComputeLeaseBreakTo per MS-SMB2
+			// 3.3.4.7 and Samba delay_for_oplock_fn. RequestLease runs only
+			// after the new opener's CREATE has already passed share-mode
+			// resolution (STATUS_SHARING_VIOLATION would have returned
+			// before RqLs processing), so hasSharingViolation is always
+			// false here — strip Write, keep Read + Handle. RWH→RH, RW→R.
+			breakTo := ComputeLeaseBreakTo(lock.Lease.LeaseState, false)
 
 			// If existing lease has no Write bit, the break is a no-op
 			// (e.g., existing=R, breakTo=R). In this case, don't dispatch

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -452,6 +452,36 @@ func TestReleaseLease_NonexistentKey(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestReleaseLeaseForHandle_ScopedToSingleBucket covers the fix in 249fd668:
+// smbtorture reuses fixed LEASE1/LEASE2 keys across tests, so the same
+// LeaseKey can live under two distinct handleKey buckets at the same time.
+// Releasing one bucket must not erase the other — otherwise stale records
+// accumulate on the surviving file and break ACK lookup.
+func TestReleaseLeaseForHandle_ScopedToSingleBucket(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	leaseKey := [16]byte{1, 2, 3}
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("/share:fileA"), leaseKey, [16]byte{}, "ownerA", "client", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("/share:fileB"), leaseKey, [16]byte{}, "ownerB", "client", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+
+	// Release only fileA's bucket.
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "/share:fileA", leaseKey))
+
+	// fileA's bucket should be gone; fileB's lease record must survive.
+	mgr.mu.RLock()
+	_, aStillThere := mgr.unifiedLocks["/share:fileA"]
+	bBucket := mgr.unifiedLocks["/share:fileB"]
+	mgr.mu.RUnlock()
+	assert.False(t, aStillThere, "fileA bucket should be removed when emptied")
+	require.Len(t, bBucket, 1, "fileB bucket must survive intact")
+	assert.Equal(t, leaseKey, bBucket[0].Lease.LeaseKey)
+}
+
 // ============================================================================
 // GetLeaseState Tests
 // ============================================================================

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -207,6 +207,12 @@ type LockManager interface {
 	// or the context is cancelled.
 	WaitForBreakCompletion(ctx context.Context, handleKey string) error
 
+	// HasBreakingLeaseForKey reports whether any lease on handleKey is both
+	// keyed on leaseKey and in Breaking state. The SMB CREATE path uses this
+	// to skip the break-completion wait on same-key reopens so the response
+	// can carry SMB2_LEASE_FLAG_BREAK_IN_PROGRESS per MS-SMB2 3.3.5.9.8.
+	HasBreakingLeaseForKey(handleKey string, leaseKey [16]byte) bool
+
 	// ========================================================================
 	// Break Callbacks
 	// ========================================================================
@@ -1379,6 +1385,23 @@ func (lm *Manager) CheckAndBreakCachingForDelete(handleKey string, excludeOwner 
 	return nil
 }
 
+// HasBreakingLeaseForKey reports whether any lease on handleKey has
+// LeaseKey == leaseKey AND Breaking == true. Used by the SMB CREATE path
+// to decide whether to skip WaitForBreakCompletion when the opener's own
+// lease is already mid-break: per MS-SMB2 3.3.5.9.8 the same-key reopener
+// must observe Breaking=true (and receive SMB2_LEASE_FLAG_BREAK_IN_PROGRESS
+// in its response), which forceCompleteBreaks would otherwise clear.
+func (lm *Manager) HasBreakingLeaseForKey(handleKey string, leaseKey [16]byte) bool {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == leaseKey && l.Lease.Breaking {
+			return true
+		}
+	}
+	return false
+}
+
 // WaitForBreakCompletion blocks until all breaking locks on a file resolve
 // or the context is cancelled. Multiple goroutines may wait concurrently;
 // signalBreakWait uses close() to broadcast to all waiters.
@@ -1518,6 +1541,7 @@ func (lm *Manager) breakOpLocks(
 		breakToState uint32
 	}
 	var toBreak []breakEntry
+	var toRemove []*UnifiedLock
 	for _, lock := range locks {
 		if lock.Lease == nil {
 			continue
@@ -1538,24 +1562,73 @@ func (lm *Manager) breakOpLocks(
 		if lock.Lease.Breaking {
 			continue
 		}
-		if shouldBreak(lock.Lease) {
-			// Compute per-lease break-to state
-			targetState := breakToState
-			switch targetState {
-			case BreakToStripWrite:
-				// Strip only the Write bit, preserve Read and Handle.
-				// Per MS-SMB2 3.3.5.9: RWH -> RH, RW -> R.
-				targetState = lock.Lease.LeaseState &^ LeaseStateWrite
-			case BreakToStripHandle:
-				// Strip only the Handle bit, preserve Read and Write.
-				// Per MS-SMB2 3.3.5.9 Step 10: RWH -> RW, RH -> R.
-				targetState = lock.Lease.LeaseState &^ LeaseStateHandle
-			}
+		if !shouldBreak(lock.Lease) {
+			continue
+		}
+
+		// Compute per-lease break-to state
+		targetState := breakToState
+		switch targetState {
+		case BreakToStripWrite:
+			// Strip only the Write bit, preserve Read and Handle.
+			// Per MS-SMB2 3.3.5.9: RWH -> RH, RW -> R.
+			targetState = lock.Lease.LeaseState &^ LeaseStateWrite
+		case BreakToStripHandle:
+			// Strip only the Handle bit, preserve Read and Write.
+			// Per MS-SMB2 3.3.5.9 Step 10: RWH -> RW, RH -> R.
+			targetState = lock.Lease.LeaseState &^ LeaseStateHandle
+		}
+
+		// Per MS-SMB2 2.2.23.2 / transportNotifier.SendLeaseBreak: a break
+		// carries SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED iff the current
+		// state contains Write or Handle. Read-only breaks (e.g. R→None on
+		// WRITE) get no AckRequired flag, so the client never responds;
+		// leaving the lease in Breaking=true would permanently block
+		// same-key reopens (nobreakself) until the 5s wait + forceComplete
+		// path fires. Downgrade inline instead, matching the state the
+		// client observes immediately.
+		ackRequired := (lock.Lease.LeaseState & (LeaseStateWrite | LeaseStateHandle)) != 0
+
+		advanceEpoch(lock.Lease)
+		if ackRequired {
 			lock.Lease.Breaking = true
 			lock.Lease.BreakToState = targetState
 			lock.Lease.BreakStarted = time.Now()
-			advanceEpoch(lock.Lease)
-			toBreak = append(toBreak, breakEntry{lock: lock, breakToState: targetState})
+		} else if targetState == LeaseStateNone {
+			toRemove = append(toRemove, lock)
+		} else {
+			lock.Lease.LeaseState = targetState
+			lock.Type = lockTypeForLeaseState(targetState)
+			if lm.lockStore != nil {
+				pl := ToPersistedLock(lock, 0)
+				_ = lm.lockStore.PutLock(context.Background(), pl)
+			}
+		}
+		toBreak = append(toBreak, breakEntry{lock: lock, breakToState: targetState})
+	}
+	if len(toRemove) > 0 {
+		current := lm.unifiedLocks[handleKey]
+		kept := current[:0]
+		for _, l := range current {
+			drop := false
+			for _, r := range toRemove {
+				if l == r {
+					drop = true
+					break
+				}
+			}
+			if !drop {
+				kept = append(kept, l)
+				continue
+			}
+			if lm.lockStore != nil {
+				_ = lm.lockStore.DeleteLock(context.Background(), l.ID)
+			}
+		}
+		if len(kept) == 0 {
+			delete(lm.unifiedLocks, handleKey)
+		} else {
+			lm.unifiedLocks[handleKey] = kept
 		}
 	}
 	// Clone locks before releasing mu so that dispatchOpLockBreak receives

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -122,8 +122,16 @@ type LockManager interface {
 	AcknowledgeLeaseBreak(ctx context.Context, leaseKey [16]byte,
 		acknowledgedState uint32, epoch uint16) error
 
-	// ReleaseLease releases all lease state for the given lease key.
+	// ReleaseLease releases ALL lease state for the given lease key across
+	// every handleKey bucket. Callers with per-handle scope should prefer
+	// ReleaseLeaseForHandle — see its doc for why this matters under
+	// smbtorture's fixed LEASE1/LEASE2 key pattern.
 	ReleaseLease(ctx context.Context, leaseKey [16]byte) error
+
+	// ReleaseLeaseForHandle removes lease records matching leaseKey from a
+	// single handleKey bucket only. Use this on CLOSE so that concurrent
+	// opens on OTHER files sharing the same LeaseKey keep their records.
+	ReleaseLeaseForHandle(ctx context.Context, handleKey string, leaseKey [16]byte) error
 
 	// ReclaimLease reclaims a lease during grace period (both SMB and NFS).
 	// Returns the reclaimed lock or error if lease doesn't exist or directory deleted.
@@ -780,6 +788,12 @@ func (lm *Manager) ReclaimLease(ctx context.Context, leaseKey [16]byte,
 	return lm.reclaimLeaseImpl(ctx, leaseKey, requestedState, isDirectory)
 }
 
+// ReleaseLeaseForHandle removes lease records matching leaseKey from a
+// single handleKey bucket only. See releaseLeaseForHandleImpl for details.
+func (lm *Manager) ReleaseLeaseForHandle(ctx context.Context, handleKey string, leaseKey [16]byte) error {
+	return lm.releaseLeaseForHandleImpl(ctx, handleKey, leaseKey)
+}
+
 // GetLeaseState returns the current state and epoch for a lease key.
 func (lm *Manager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	return lm.getLeaseStateImpl(ctx, leaseKey)
@@ -794,15 +808,29 @@ func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	_, lock, _ := lm.findLeaseByKey(leaseKey)
-	if lock == nil || lock.Lease == nil {
-		return false
+	// Update every lease record matching leaseKey, not just the first found.
+	// Stale records from prior tests (same LEASE1 constant across smbtorture
+	// tests) or from multiple opens by different clients can coexist in
+	// lm.unifiedLocks under different handleKey buckets. findLeaseByKey's
+	// map-iteration order is non-deterministic, so scoping to the first
+	// match can miss the lease that RequestLease just granted — leaving it
+	// at Epoch=1 (createAndGrantLease default) while the response to the
+	// client carries the higher requested epoch. Subsequent break
+	// notifications then dispatch with Epoch=2 instead of requestedEpoch+2,
+	// regressing smbtorture V2 tests (break_twice, breaking*, v2_breaking3).
+	found := false
+	for _, locks := range lm.unifiedLocks {
+		for _, lock := range locks {
+			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
+				continue
+			}
+			if epoch >= lock.Lease.Epoch {
+				lock.Lease.Epoch = epoch
+			}
+			found = true
+		}
 	}
-
-	if epoch >= lock.Lease.Epoch {
-		lock.Lease.Epoch = epoch
-	}
-	return true
+	return found
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -180,14 +180,13 @@ type LockManager interface {
 	// preserving Read and Handle (RWH -> RH, RW -> R).
 	CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
-	// BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE.
-	// Per MS-SMB2 3.3.5.9 Step 10: Handle leases must be broken before
-	// share mode conflict check. Strips only the Handle bit (RWH -> RW, RH -> R).
-	BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
-
-	// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have
-	// Handle caching (RWH → RH). Only targets leases with both W and H.
-	BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
+	// BreakLeasesOnOpenConflict breaks existing leases before an SMB CREATE
+	// proceeds, per MS-SMB2 3.3.4.7 and Samba `source3/smbd/open.c::delay_for_oplock_fn`.
+	// The bit stripped depends on whether the new open conflicts on share mode:
+	//   - Sharing violation → strip Handle (keep Read + Write).
+	//   - No sharing violation → strip Write (keep Read + Handle).
+	// Each per-lease target state is computed via ComputeLeaseBreakTo.
+	BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, hasSharingViolation bool) error
 
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
@@ -1300,35 +1299,27 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 	})
 }
 
-// BreakHandleLeasesForSMBOpen breaks Handle leases for an SMB CREATE that may
-// conflict with sharing modes. Per MS-SMB2 3.3.5.9 Step 10: "If any existing
-// Open on the target file has a lease with Handle caching, the server MUST
-// initiate a lease break [...] to remove Handle caching."
+// BreakLeasesOnOpenConflict breaks leases held by other clients when an SMB
+// CREATE arrives. Per MS-SMB2 3.3.4.7 and Samba
+// `source3/smbd/open.c::delay_for_oplock_fn`:
 //
-// The break strips the Handle bit, preserving Read and Write:
-//   - RWH -> RW
-//   - RH  -> R
-//   - R   -> not broken (no Handle to strip)
-func (lm *Manager) BreakHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripHandle, func(lease *OpLock) bool {
-		return lease.HasHandle()
-	})
-}
-
-// BreakWriteOnHandleLeasesForSMBOpen strips Write from leases that have Handle
-// caching. Per MS-SMB2 3.3.5.9 Step 10: before the share mode check, leases
-// with Handle caching must be broken so clients close cached handles. The break
-// strips Write (not Handle) so clients see "RWH → RH" and flush dirty data
-// while preserving Handle for the share mode resolution window.
+//   - hasSharingViolation == true → strip Handle (keep Read + Write). The
+//     existing holder must release cached open handles; dirty writes stay
+//     cached because the holder will close the handle anyway.
+//     (RWH → RW, RH → R)
+//   - hasSharingViolation == false → strip Write (keep Read + Handle). The
+//     existing holder flushes dirty data while keeping cached handles.
+//     (RWH → RH, RW → R)
 //
-// This targets only leases WITH Handle caching:
-//   - RWH -> RH (has Handle → strip Write)
-//   - RH  -> not broken (has Handle but no Write to strip)
-//   - RW  -> not broken (no Handle → not a cached-handle concern)
-//   - R   -> not broken
-func (lm *Manager) BreakWriteOnHandleLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
-		return lease.HasHandle() && lease.HasWrite()
+// Per-lease target state is computed via ComputeLeaseBreakTo. A lease is
+// broken only when the computed target differs from its current state.
+func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, hasSharingViolation bool) error {
+	sentinel := BreakToStripWrite
+	if hasSharingViolation {
+		sentinel = BreakToStripHandle
+	}
+	return lm.breakOpLocks(handleKey, excludeOwner, sentinel, func(lease *OpLock) bool {
+		return ComputeLeaseBreakTo(lease.LeaseState, hasSharingViolation) != lease.LeaseState
 	})
 }
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -207,11 +207,13 @@ type LockManager interface {
 	// or the context is cancelled.
 	WaitForBreakCompletion(ctx context.Context, handleKey string) error
 
-	// HasBreakingLeaseForKey reports whether any lease on handleKey is both
-	// keyed on leaseKey and in Breaking state. The SMB CREATE path uses this
-	// to skip the break-completion wait on same-key reopens so the response
-	// can carry SMB2_LEASE_FLAG_BREAK_IN_PROGRESS per MS-SMB2 3.3.5.9.8.
-	HasBreakingLeaseForKey(handleKey string, leaseKey [16]byte) bool
+	// WaitForBreakCompletionExceptKey is WaitForBreakCompletion scoped to
+	// ignore any breaking lease keyed on exceptKey. The SMB CREATE path uses
+	// this on same-key reopens: MS-SMB2 3.3.5.9.8 requires the opener to
+	// observe Breaking=true on its own key (to emit
+	// SMB2_LEASE_FLAG_BREAK_IN_PROGRESS), which forceCompleteBreaks would
+	// otherwise clear, while other-key breaks still need to drain first.
+	WaitForBreakCompletionExceptKey(ctx context.Context, handleKey string, exceptKey [16]byte) error
 
 	// ========================================================================
 	// Break Callbacks
@@ -1385,21 +1387,47 @@ func (lm *Manager) CheckAndBreakCachingForDelete(handleKey string, excludeOwner 
 	return nil
 }
 
-// HasBreakingLeaseForKey reports whether any lease on handleKey has
-// LeaseKey == leaseKey AND Breaking == true. Used by the SMB CREATE path
-// to decide whether to skip WaitForBreakCompletion when the opener's own
-// lease is already mid-break: per MS-SMB2 3.3.5.9.8 the same-key reopener
-// must observe Breaking=true (and receive SMB2_LEASE_FLAG_BREAK_IN_PROGRESS
-// in its response), which forceCompleteBreaks would otherwise clear.
-func (lm *Manager) HasBreakingLeaseForKey(handleKey string, leaseKey [16]byte) bool {
-	lm.mu.RLock()
-	defer lm.mu.RUnlock()
-	for _, l := range lm.unifiedLocks[handleKey] {
-		if l.Lease != nil && l.Lease.LeaseKey == leaseKey && l.Lease.Breaking {
-			return true
+// WaitForBreakCompletionExceptKey is WaitForBreakCompletion scoped to ignore
+// any breaking lease whose LeaseKey matches exceptKey. Used by the SMB CREATE
+// path on a same-key reopen: MS-SMB2 3.3.5.9.8 requires the opener to observe
+// Breaking=true on its own key (to emit SMB2_LEASE_FLAG_BREAK_IN_PROGRESS),
+// which forceCompleteBreaks would otherwise clear — but any other-key breaks
+// still need to drain before the CREATE proceeds (MS-SMB2 3.3.4.7). On
+// timeout, own-key is preserved and only other-key leases are force-completed.
+func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKey string, exceptKey [16]byte) error {
+	for {
+		lm.mu.Lock()
+		hasOther := false
+		for _, l := range lm.unifiedLocks[handleKey] {
+			if l.Lease != nil && l.Lease.Breaking && l.Lease.LeaseKey != exceptKey {
+				hasOther = true
+				break
+			}
+			if l.Delegation != nil && l.Delegation.Breaking {
+				hasOther = true
+				break
+			}
+		}
+		if !hasOther {
+			lm.mu.Unlock()
+			return nil
+		}
+
+		ch, ok := lm.breakWaitChans[handleKey]
+		if !ok {
+			ch = make(chan struct{})
+			lm.breakWaitChans[handleKey] = ch
+		}
+		lm.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			lm.forceCompleteBreaksExceptKey(handleKey, exceptKey)
+			return ctx.Err()
+		case <-ch:
+			continue
 		}
 	}
-	return false
 }
 
 // WaitForBreakCompletion blocks until all breaking locks on a file resolve
@@ -1454,25 +1482,30 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 // BreakToState, as if the client had acknowledged. Called when the break
 // wait times out. Leases breaking to None are removed entirely.
 func (lm *Manager) forceCompleteBreaks(handleKey string) {
+	lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
+}
+
+// forceCompleteBreaksExceptKey is forceCompleteBreaks that leaves any lease
+// keyed on exceptKey untouched. Zero exceptKey means "no exclusion" (same
+// semantics as forceCompleteBreaks).
+func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]byte) {
 	lm.mu.Lock()
 	locks := lm.unifiedLocks[handleKey]
 
 	var remaining []*UnifiedLock
 	modified := false
 	for _, l := range locks {
-		if l.Lease != nil && l.Lease.Breaking {
+		if l.Lease != nil && l.Lease.Breaking && l.Lease.LeaseKey != exceptKey {
 			modified = true
 			if l.Lease.BreakToState == LeaseStateNone {
-				// Remove entirely
 				if lm.lockStore != nil {
 					_ = lm.lockStore.DeleteLock(context.Background(), l.ID)
 				}
 				logger.Debug("forceCompleteBreaks: removed lease (break-to None)",
 					"handleKey", handleKey,
 					"leaseKey", fmt.Sprintf("%x", l.Lease.LeaseKey))
-				continue // skip adding to remaining
+				continue
 			}
-			// Downgrade to break-to state
 			l.Lease.LeaseState = l.Lease.BreakToState
 			l.Lease.Breaking = false
 			l.Lease.BreakToState = 0

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1578,14 +1578,19 @@ func (lm *Manager) breakOpLocks(
 			targetState = lock.Lease.LeaseState &^ LeaseStateHandle
 		}
 
-		// Per MS-SMB2 2.2.23.2, the break carries ACK_REQUIRED iff the
-		// current state holds Write or Handle. Without ACK_REQUIRED the
-		// client never responds, so leaving Breaking=true would block
-		// same-key reopens (nobreakself) until forceCompleteBreaks fires.
-		// Downgrade inline for those cases.
-		ackRequired := (lock.Lease.LeaseState & (LeaseStateWrite | LeaseStateHandle)) != 0
+		// Per MS-SMB2 3.3.4.7, a break is ack-required iff the current state
+		// is NOT pure Read. Without ACK_REQUIRED the client never responds,
+		// so leaving Breaking=true would block same-key reopens (nobreakself)
+		// until forceCompleteBreaks fires — downgrade inline for those cases.
+		ackRequired := lock.Lease.LeaseState != LeaseStateRead
 
+		// Advance the lease epoch on the live record first so the snapshot
+		// that feeds dispatchOpLockBreak carries the new epoch (NewEpoch per
+		// MS-SMB2 2.2.23.2), then snapshot while LeaseState still holds the
+		// pre-break value for the notification's CurrentLeaseState field.
 		advanceEpoch(lock.Lease)
+		snapshot := lock.Clone()
+
 		switch {
 		case ackRequired:
 			lock.Lease.Breaking = true
@@ -1606,7 +1611,7 @@ func (lm *Manager) breakOpLocks(
 			}
 			kept = append(kept, lock)
 		}
-		toBreak = append(toBreak, breakEntry{lock: lock, breakToState: targetState})
+		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
 	}
 	if removed {
 		if len(kept) == 0 {
@@ -1614,13 +1619,6 @@ func (lm *Manager) breakOpLocks(
 		} else {
 			lm.unifiedLocks[handleKey] = kept
 		}
-	}
-	// Clone locks before releasing mu so that dispatchOpLockBreak receives
-	// snapshots. Without this, concurrent AcknowledgeLeaseBreak can mutate
-	// the live *UnifiedLock while the break callback reads it.
-	// This matches the pattern in requestLeaseImpl (leases.go).
-	for i := range toBreak {
-		toBreak[i].lock = toBreak[i].lock.Clone()
 	}
 	lm.mu.Unlock()
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1541,14 +1541,17 @@ func (lm *Manager) breakOpLocks(
 		breakToState uint32
 	}
 	var toBreak []breakEntry
-	var toRemove []*UnifiedLock
+	kept := locks[:0]
+	removed := false
 	for _, lock := range locks {
 		if lock.Lease == nil {
+			kept = append(kept, lock)
 			continue
 		}
 		if excludeOwner != nil {
 			if lock.Owner.OwnerID == excludeOwner.OwnerID ||
 				(excludeOwner.ClientID != "" && lock.Owner.ClientID == excludeOwner.ClientID) {
+				kept = append(kept, lock)
 				continue
 			}
 			// Per MS-SMB2 3.3.5.9: opens with the same lease key must not
@@ -1556,75 +1559,56 @@ func (lm *Manager) breakOpLocks(
 			// open's LeaseKey, no break is required").
 			if excludeOwner.ExcludeLeaseKey != ([16]byte{}) &&
 				lock.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
+				kept = append(kept, lock)
 				continue
 			}
 		}
-		if lock.Lease.Breaking {
-			continue
-		}
-		if !shouldBreak(lock.Lease) {
+		if lock.Lease.Breaking || !shouldBreak(lock.Lease) {
+			kept = append(kept, lock)
 			continue
 		}
 
-		// Compute per-lease break-to state
 		targetState := breakToState
 		switch targetState {
 		case BreakToStripWrite:
-			// Strip only the Write bit, preserve Read and Handle.
 			// Per MS-SMB2 3.3.5.9: RWH -> RH, RW -> R.
 			targetState = lock.Lease.LeaseState &^ LeaseStateWrite
 		case BreakToStripHandle:
-			// Strip only the Handle bit, preserve Read and Write.
 			// Per MS-SMB2 3.3.5.9 Step 10: RWH -> RW, RH -> R.
 			targetState = lock.Lease.LeaseState &^ LeaseStateHandle
 		}
 
-		// Per MS-SMB2 2.2.23.2 / transportNotifier.SendLeaseBreak: a break
-		// carries SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED iff the current
-		// state contains Write or Handle. Read-only breaks (e.g. R→None on
-		// WRITE) get no AckRequired flag, so the client never responds;
-		// leaving the lease in Breaking=true would permanently block
-		// same-key reopens (nobreakself) until the 5s wait + forceComplete
-		// path fires. Downgrade inline instead, matching the state the
-		// client observes immediately.
+		// Per MS-SMB2 2.2.23.2, the break carries ACK_REQUIRED iff the
+		// current state holds Write or Handle. Without ACK_REQUIRED the
+		// client never responds, so leaving Breaking=true would block
+		// same-key reopens (nobreakself) until forceCompleteBreaks fires.
+		// Downgrade inline for those cases.
 		ackRequired := (lock.Lease.LeaseState & (LeaseStateWrite | LeaseStateHandle)) != 0
 
 		advanceEpoch(lock.Lease)
-		if ackRequired {
+		switch {
+		case ackRequired:
 			lock.Lease.Breaking = true
 			lock.Lease.BreakToState = targetState
 			lock.Lease.BreakStarted = time.Now()
-		} else if targetState == LeaseStateNone {
-			toRemove = append(toRemove, lock)
-		} else {
+			kept = append(kept, lock)
+		case targetState == LeaseStateNone:
+			if lm.lockStore != nil {
+				_ = lm.lockStore.DeleteLock(context.Background(), lock.ID)
+			}
+			removed = true
+		default:
 			lock.Lease.LeaseState = targetState
 			lock.Type = lockTypeForLeaseState(targetState)
 			if lm.lockStore != nil {
 				pl := ToPersistedLock(lock, 0)
 				_ = lm.lockStore.PutLock(context.Background(), pl)
 			}
+			kept = append(kept, lock)
 		}
 		toBreak = append(toBreak, breakEntry{lock: lock, breakToState: targetState})
 	}
-	if len(toRemove) > 0 {
-		current := lm.unifiedLocks[handleKey]
-		kept := current[:0]
-		for _, l := range current {
-			drop := false
-			for _, r := range toRemove {
-				if l == r {
-					drop = true
-					break
-				}
-			}
-			if !drop {
-				kept = append(kept, l)
-				continue
-			}
-			if lm.lockStore != nil {
-				_ = lm.lockStore.DeleteLock(context.Background(), l.ID)
-			}
-		}
+	if removed {
 		if len(kept) == 0 {
 			delete(lm.unifiedLocks, handleKey)
 		} else {

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1087,3 +1087,50 @@ func TestMergeLocks_DifferentOwners(t *testing.T) {
 		t.Fatalf("Expected 2 locks (different owners), got %d", len(result))
 	}
 }
+
+// TestSetLeaseEpoch_UpdatesAllMatchingRecords covers the broadened behavior
+// added with the #429 lease work: the same LeaseKey can appear under
+// different handleKey buckets (smbtorture reuses fixed LEASE1/LEASE2 macros),
+// and SetLeaseEpoch must update every record so subsequent break
+// notifications dispatch with the right NewEpoch regardless of which record
+// findLeaseByKey happens to return.
+func TestSetLeaseEpoch_UpdatesAllMatchingRecords(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	leaseKey := [16]byte{0xaa, 0xbb, 0xcc}
+
+	lm.mu.Lock()
+	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
+	}
+	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
+	}
+	lm.mu.Unlock()
+
+	if !lm.SetLeaseEpoch(leaseKey, 7) {
+		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
+	}
+
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	for _, handle := range []string{"/share:fileA", "/share:fileB"} {
+		locks := lm.unifiedLocks[handle]
+		if len(locks) != 1 {
+			t.Fatalf("%s: expected 1 record, got %d", handle, len(locks))
+		}
+		if got := locks[0].Lease.Epoch; got != 7 {
+			t.Errorf("%s: Epoch = %d, want 7", handle, got)
+		}
+	}
+}
+
+func TestSetLeaseEpoch_ReturnsFalseForUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	if lm.SetLeaseEpoch([16]byte{0xff, 0xee}, 5) {
+		t.Fatalf("SetLeaseEpoch returned true for unknown key")
+	}
+}

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -46,6 +46,33 @@ const (
 	BreakToStripHandle uint32 = 0xFFFFFFFE
 )
 
+// ComputeLeaseBreakTo returns the new lease state for a break triggered by a
+// conflicting SMB open. The bit stripped depends on whether the new open
+// conflicts with the existing open on share mode.
+//
+// Per MS-SMB2 3.3.4.7 and Samba `source3/smbd/open.c::delay_for_oplock_fn`:
+//   - Sharing violation → strip Handle (keep Read + Write). The existing holder
+//     must release its cached open handles so the new opener can proceed;
+//     writes stay cached because the holder will close the handle anyway.
+//   - No sharing violation → strip Write (keep Read + Handle). The existing
+//     holder must flush dirty data but may keep cached handles, and the new
+//     opener will coexist.
+//
+// Examples:
+//
+//	existing=RWH, violation=true  → RW  (strip H)
+//	existing=RWH, violation=false → RH  (strip W)
+//	existing=RH,  violation=true  → R   (strip H)
+//	existing=RW,  violation=false → R   (strip W)
+//	existing=R,   violation=*     → R   (no-op, nothing to strip)
+func ComputeLeaseBreakTo(existingState uint32, hasSharingViolation bool) uint32 {
+	mask := LeaseStateWrite
+	if hasSharingViolation {
+		mask = LeaseStateHandle
+	}
+	return existingState &^ mask
+}
+
 // ValidFileLeaseStates contains all valid lease state combinations for files.
 // Per MS-SMB2: Write and Handle alone are not valid; they require Read.
 // Valid combinations: None, R, RH, RW, RWH

--- a/pkg/metadata/lock/oplock_test.go
+++ b/pkg/metadata/lock/oplock_test.go
@@ -276,6 +276,52 @@ func TestOpLock_Clone_Nil(t *testing.T) {
 }
 
 // ============================================================================
+// ComputeLeaseBreakTo Matrix Tests
+// ============================================================================
+
+// TestComputeLeaseBreakTo_Matrix covers every valid existing-state row × both
+// sharing-violation outcomes. Mirrors Samba delay_for_oplock_fn semantics per
+// MS-SMB2 3.3.4.7.
+func TestComputeLeaseBreakTo_Matrix(t *testing.T) {
+	t.Parallel()
+
+	R := LeaseStateRead
+	W := LeaseStateWrite
+	H := LeaseStateHandle
+
+	tests := []struct {
+		name          string
+		existing      uint32
+		hasViolation  bool
+		expectedBreak uint32
+	}{
+		// No violation → strip Write, keep Handle.
+		{"None/noViolation", LeaseStateNone, false, LeaseStateNone},
+		{"R/noViolation", R, false, R},
+		{"RH/noViolation", R | H, false, R | H},
+		{"RW/noViolation", R | W, false, R},
+		{"RWH/noViolation", R | W | H, false, R | H},
+
+		// Violation → strip Handle, keep Write.
+		{"None/violation", LeaseStateNone, true, LeaseStateNone},
+		{"R/violation", R, true, R},
+		{"RH/violation", R | H, true, R},
+		{"RW/violation", R | W, true, R | W},
+		{"RWH/violation", R | W | H, true, R | W},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeLeaseBreakTo(tc.existing, tc.hasViolation)
+			assert.Equalf(t, tc.expectedBreak, got,
+				"ComputeLeaseBreakTo(%s, violation=%v) = %s, want %s",
+				LeaseStateToString(tc.existing), tc.hasViolation,
+				LeaseStateToString(got), LeaseStateToString(tc.expectedBreak))
+		})
+	}
+}
+
+// ============================================================================
 // Lease Conflict Detection Tests
 // ============================================================================
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-24 (Bound Handle lease break wait — lease subsuite runnable; #429 cluster 42→36 after 2-run confirmation)
+Last updated: 2026-04-24 (Phase 2 matrix + delete-pending file-lease break — #429 cluster 36→33 after 2-run confirmation)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -516,9 +516,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
 | smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | #429 |
 | smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
-| smb2.lease.initial_delete_tdis | Leases | Lease + delete on tree disconnect not fully working | #429 |
-| smb2.lease.initial_delete_logoff | Leases | Lease + delete on logoff not fully working | #429 |
-| smb2.lease.initial_delete_disconnect | Leases | Lease + delete on disconnect not fully working | #429 |
 | smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
 | smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
 | smb2.lease.break_twice | Leases | Double lease break not fully working | #429 |
@@ -738,6 +735,34 @@ incomplete delayed-write and timestamp freeze/unfreeze logic.
 | smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
+
+### 2026-04-24 — #429 Phase 2 matrix + delete-pending file-lease break
+
+`fix(smb): compute lease break-to by sharing-violation — #429`
+(commit `5c781938`) collapsed `BreakHandleLeasesForSMBOpen` +
+`BreakWriteOnHandleLeasesForSMBOpen` into
+`BreakLeasesOnOpenConflict(handleKey, excludeOwner, hasSharingViolation)`,
+selecting the strip mask per MS-SMB2 3.3.4.7 and Samba
+`source3/smbd/open.c::delay_for_oplock_fn` (violation → strip Handle;
+no violation → strip Write). Matrix now passes `break_twice`'s
+RWH→RW acks and `v2_complex2`'s RWH→RH, though both still fail on
+downstream assertions tracked below.
+
+A follow-up commit wired the file's own Handle-strip break into
+`handleDeleteOnClose` (the teardown path that runs for
+TDIS/LOGOFF/DISCONNECT-triggered deletes) and into
+`BreakFileHandleLeasesOnDelete` on the lease manager. The closing
+session is passed as `excludeOwner` so the break only fires against
+OTHER holders — self-breaks were leaking into the next test's
+`lease_break_info.count` and regressing `v1_bug15148`.
+
+Confirmed 2× stable:
+
+- `smb2.lease.initial_delete_tdis`
+- `smb2.lease.initial_delete_logoff`
+- `smb2.lease.initial_delete_disconnect`
+
+**#429 lease cluster: 36 → 33 tests remaining.**
 
 ### 2026-04-24 — Lease subsuite unblocked + 6 #429 collapses
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-24 (Phase 2 matrix + delete-pending file-lease break — #429 cluster 36→33 after 2-run confirmation)
+Last updated: 2026-04-24 (Handle-scoped lease release — #429 cluster 33→31 after 2-run confirmation)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -509,7 +509,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.breaking5 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.breaking6 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
-| smb2.lease.complex1 | Leases | Complex lease scenario not fully working | #429 |
 | smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
 | smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
 | smb2.lease.timeout-disconnect | Leases | Lease timeout on disconnect not fully working | #429 |
@@ -518,7 +517,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
 | smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
 | smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
-| smb2.lease.break_twice | Leases | Double lease break not fully working | #429 |
 | smb2.lease.v2_breaking3 | Leases V2 | Lease V2 breaking state handling not fully working | #429 |
 | smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | #429 |
 | smb2.lease.v2_epoch2 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
@@ -735,6 +733,46 @@ incomplete delayed-write and timestamp freeze/unfreeze logic.
 | smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
+
+### 2026-04-24 — Handle-scoped lease release fixes stale-record accumulation
+
+smbtorture reuses fixed `LEASE1`/`LEASE2` constants across every test in the
+`smb2.lease` subsuite. When a test closed its last handle, DittoFS's
+`ReleaseLease(leaseKey)` removed every record matching the key across all
+handleKey buckets — including records for opens on OTHER files that happened
+to share the same constant. Worse, the `hasOtherOpen` check gating the
+release compared by FileID alone, so any concurrent open anywhere with the
+same key skipped the release entirely, leaving the current handle's record
+orphaned in `unifiedLocks`.
+
+The orphaned records accumulated across tests. By the time `break_twice`
+ran, three `LEASE1` records sat in the same file's bucket (two from prior
+tests where cleanup was skipped, one freshly granted). Every cross-key break
+therefore dispatched three times, and `findLeaseByKey`-based lookups
+(`SetLeaseEpoch`, `AcknowledgeLeaseBreak`) routinely returned the wrong
+record — producing the `new_epoch got 0x2 should 0x13` and
+`acknowledged state RW exceeds break-to state RH` signatures.
+
+Fix:
+
+- `pkg/metadata/lock` gains `ReleaseLeaseForHandle(ctx, handleKey, leaseKey)`
+  that removes only records in one bucket, leaving other buckets intact.
+- `SetLeaseEpoch` now iterates every record matching the key and updates
+  each one, so V2 grant-epoch tracking works even when stale records
+  briefly coexist.
+- `internal/adapter/smb/lease` adds a corresponding `ReleaseLeaseForHandle`
+  that only tears down the session/share mapping once the last record for
+  the key is actually gone.
+- `internal/adapter/smb/v2/handlers/close.go` scopes `hasOtherOpen` to opens
+  on the SAME file (matches `MetadataHandle`, not just `FileID`) and always
+  releases this handle's record — other files keep theirs.
+
+Confirmed 2× stable — 2 additional tests now pass:
+
+- `smb2.lease.break_twice`
+- `smb2.lease.complex1`
+
+**#429 lease cluster: 33 → 31 tests remaining.**
 
 ### 2026-04-24 — #429 Phase 2 matrix + delete-pending file-lease break
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-24 (Pruned 20 collapsed entries against post-#418 baseline; closed #435; chipped #431 by 1)
+Last updated: 2026-04-24 (Bound Handle lease break wait — lease subsuite runnable; #429 cluster 42→36 after 2-run confirmation)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -494,7 +494,6 @@ incomplete break notification delivery and multi-client coordination.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.lease.request | Leases | Lease request handling not fully working | #429 |
-| smb2.lease.nobreakself | Leases | Lease self-break suppression not fully working | #429 |
 | smb2.lease.statopen | Leases | Lease + stat open interaction not fully working | #429 |
 | smb2.lease.statopen4 | Leases | Lease + stat open interaction not fully working | #429 |
 | smb2.lease.upgrade | Leases | Lease upgrade not fully working | #429 |
@@ -517,7 +516,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
 | smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | #429 |
 | smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
-| smb2.lease.v1_bug15148 | Leases | Lease V1 edge case not fully working | #429 |
 | smb2.lease.initial_delete_tdis | Leases | Lease + delete on tree disconnect not fully working | #429 |
 | smb2.lease.initial_delete_logoff | Leases | Lease + delete on logoff not fully working | #429 |
 | smb2.lease.initial_delete_disconnect | Leases | Lease + delete on disconnect not fully working | #429 |
@@ -525,15 +523,11 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
 | smb2.lease.break_twice | Leases | Double lease break not fully working | #429 |
 | smb2.lease.v2_breaking3 | Leases V2 | Lease V2 breaking state handling not fully working | #429 |
-| smb2.lease.v2_flags_breaking | Leases V2 | Lease V2 flags during break not fully working | #429 |
 | smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | #429 |
-| smb2.lease.v2_epoch1 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
 | smb2.lease.v2_epoch2 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
 | smb2.lease.v2_epoch3 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
-| smb2.lease.v2_complex2 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
 | smb2.lease.v2_rename | Leases V2 | Lease V2 rename interaction not fully working | #429 |
-| smb2.lease.v2_bug15148 | Leases V2 | Lease V2 edge case not fully working | #429 |
 | smb2.lease.v2_rename_target_overwrite | Leases V2 | Lease V2 rename target overwrite not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)
@@ -744,6 +738,33 @@ incomplete delayed-write and timestamp freeze/unfreeze logic.
 | smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
+
+### 2026-04-24 — Lease subsuite unblocked + 6 #429 collapses
+
+`fix(smb): bound Handle lease break wait on CREATE — #429`
+(commit `931ed6f1`) added a 5 s timeout to `BreakHandleLeasesOnOpen`'s
+wait, mirroring the existing `parentLeaseBreakWaitTimeout`. Without it,
+`WaitForBreakCompletion` inherited the auth context (which only cancels
+on session disconnect), so any non-acking client hung the conflicting
+CREATE indefinitely. `lease.break_twice` alone hung 57 minutes,
+consuming the entire suite-level smbtorture timeout and leaving the rest
+of the lease subsuite untested.
+
+With the bound, the lease subsuite now runs end-to-end in ~14 minutes.
+Surfaced 6 lease tests as stably passing across 2 confirmation runs:
+
+- `smb2.lease.nobreakself`
+- `smb2.lease.v2_flags_breaking`
+- `smb2.lease.v2_epoch1`
+- `smb2.lease.v2_complex2`
+- `smb2.lease.v1_bug15148`
+- `smb2.lease.v2_bug15148`
+
+Most were already correct post-#418 but masked by the unrunnable suite.
+**#429 lease cluster: 42 → 36 tests remaining.**
+
+A 3rd confirmation run is queued; if any test flips back, it will be
+re-added to KNOWN_FAILURES with annotation.
 
 ### 2026-04-24 — Prune 20 collapsed entries after post-#418 baseline
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-17 (Reconcile credits subsuite after #378 grant fix — 3 tests now pass, 4 reclassified, subsuite no longer aborts)
+Last updated: 2026-04-23 (Filed tracking issues for fix-candidate clusters: #429 leases, #430 byte-range locks, #431 DH V1, #432 DH V2, #433 rename, #434 timestamps, #435 charset, #436 multichannel.leases.test3)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -35,7 +35,7 @@ async credit coordination.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.multichannel.leases.test2 | Multi-channel | Requires torture_block_tcp_transport (Samba-internal test-harness operation) to simulate a blocked channel — not implementable | - |
-| smb2.multichannel.leases.test3 | Multi-channel | Spurious lease break on uncontested open — separate bug from #417 epoch drift | - |
+| smb2.multichannel.leases.test3 | Multi-channel | Spurious lease break on uncontested open — separate bug from #417 epoch drift | #436 |
 | smb2.multichannel.leases.test4 | Multi-channel | Requires torture_block_tcp_transport (Samba-internal test-harness operation) — not implementable | - |
 | smb2.multichannel.oplocks.test2 | Multi-channel | Requires FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT (Samba test-harness FSCTL) to simulate connection failure — not implementable | - |
 | smb2.multichannel.oplocks.test3_windows | Multi-channel | Requires FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT to block TCP transport — not implementable | - |
@@ -451,7 +451,7 @@ Newly reachable after compound and protocol improvements.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.charset.Testing | Character set | Unicode surrogate pair handling not implemented | - |
+| smb2.charset.Testing | Character set | Unicode surrogate pair handling not implemented | #435 |
 
 ### Delete-on-Close OVERWRITE_IF (Fix Candidate)
 
@@ -468,19 +468,19 @@ still fail due to incomplete reconnect and lease coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-open.open-lease | Durable handles V1 | Durable open with lease not fully working | - |
-| smb2.durable-open.reopen1a | Durable handles V1 | Durable reopen not fully working | - |
-| smb2.durable-open.reopen1a-lease | Durable handles V1 | Durable reopen with lease not fully working | - |
-| smb2.durable-open.reopen2 | Durable handles V1 | Durable reopen not fully working | - |
-| smb2.durable-open.reopen2-lease | Durable handles V1 | Durable reopen with lease not fully working | - |
-| smb2.durable-open.reopen2-lease-v2 | Durable handles V1 | Durable reopen with lease V2 not fully working | - |
-| smb2.durable-open.reopen2a | Durable handles V1 | Durable reopen not fully working | - |
-| smb2.durable-open.reopen4 | Durable handles V1 | Durable reopen not fully working | - |
-| smb2.durable-open.delete_on_close1 | Durable handles V1 | Durable DOC not fully working | - |
-| smb2.durable-open.delete_on_close2 | Durable handles V1 | Durable DOC not fully working | - |
-| smb2.durable-open.file-position | Durable handles V1 | Durable file position not fully working | - |
-| smb2.durable-open.lock-oplock | Durable handles V1 | Durable lock + oplock not fully working | - |
-| smb2.durable-open.lock-lease | Durable handles V1 | Durable lock + lease not fully working | - |
+| smb2.durable-open.open-lease | Durable handles V1 | Durable open with lease not fully working | #431 |
+| smb2.durable-open.reopen1a | Durable handles V1 | Durable reopen not fully working | #431 |
+| smb2.durable-open.reopen1a-lease | Durable handles V1 | Durable reopen with lease not fully working | #431 |
+| smb2.durable-open.reopen2 | Durable handles V1 | Durable reopen not fully working | #431 |
+| smb2.durable-open.reopen2-lease | Durable handles V1 | Durable reopen with lease not fully working | #431 |
+| smb2.durable-open.reopen2-lease-v2 | Durable handles V1 | Durable reopen with lease V2 not fully working | #431 |
+| smb2.durable-open.reopen2a | Durable handles V1 | Durable reopen not fully working | #431 |
+| smb2.durable-open.reopen4 | Durable handles V1 | Durable reopen not fully working | #431 |
+| smb2.durable-open.delete_on_close1 | Durable handles V1 | Durable DOC not fully working | #431 |
+| smb2.durable-open.delete_on_close2 | Durable handles V1 | Durable DOC not fully working | #431 |
+| smb2.durable-open.file-position | Durable handles V1 | Durable file position not fully working | #431 |
+| smb2.durable-open.lock-oplock | Durable handles V1 | Durable lock + oplock not fully working | #431 |
+| smb2.durable-open.lock-lease | Durable handles V1 | Durable lock + lease not fully working | #431 |
 
 ### Durable Handles V2 (Fix Candidate)
 
@@ -489,38 +489,38 @@ still fail due to incomplete reconnect, lease coordination, and persistence.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-v2-open.create-blob | Durable handles V2 | DH2Q create context blob validation | - |
-| smb2.durable-v2-open.open-oplock | Durable handles V2 | DH2 open with oplock not fully working | - |
-| smb2.durable-v2-open.open-lease | Durable handles V2 | DH2 open with lease not fully working | - |
-| smb2.durable-v2-open.reopen1 | Durable handles V2 | DH2 reopen not fully working | - |
-| smb2.durable-v2-open.reopen1a | Durable handles V2 | DH2 reopen not fully working | - |
-| smb2.durable-v2-open.reopen1a-lease | Durable handles V2 | DH2 reopen with lease not fully working | - |
-| smb2.durable-v2-open.reopen2 | Durable handles V2 | DH2 reopen not fully working | - |
-| smb2.durable-v2-open.reopen2b | Durable handles V2 | DH2 reopen not fully working | - |
-| smb2.durable-v2-open.reopen2-lease | Durable handles V2 | DH2 reopen with lease not fully working | - |
-| smb2.durable-v2-open.reopen2-lease-v2 | Durable handles V2 | DH2 reopen with lease V2 not fully working | - |
-| smb2.durable-v2-open.durable-v2-setinfo | Durable handles V2 | DH2 setinfo not fully working | - |
-| smb2.durable-v2-open.lock-oplock | Durable handles V2 | DH2 lock with oplock not fully working | - |
-| smb2.durable-v2-open.lock-lease | Durable handles V2 | DH2 lock with lease not fully working | - |
-| smb2.durable-v2-open.lock-noW-lease | Durable handles V2 | DH2 lock without write lease not fully working | - |
-| smb2.durable-v2-open.stat-and-lease | Durable handles V2 | DH2 stat + lease interaction not fully working | - |
-| smb2.durable-v2-open.nonstat-and-lease | Durable handles V2 | DH2 non-stat + lease interaction not fully working | - |
-| smb2.durable-v2-open.statRH-and-lease | Durable handles V2 | DH2 stat-RH + lease interaction not fully working | - |
-| smb2.durable-v2-open.two-same-lease | Durable handles V2 | DH2 two handles same lease not fully working | - |
-| smb2.durable-v2-open.two-different-lease | Durable handles V2 | DH2 two handles different leases not fully working | - |
-| smb2.durable-v2-open.keep-disconnected-rh-with-stat-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | - |
-| smb2.durable-v2-open.keep-disconnected-rh-with-rh-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | - |
-| smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | - |
-| smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | - |
-| smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open | Durable handles V2 | DH2 disconnected handle purge not fully working | - |
-| smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open | Durable handles V2 | DH2 disconnected handle purge not fully working | - |
-| smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open | Durable handles V2 | DH2 disconnected handle purge not fully working | - |
-| smb2.durable-v2-open.purge-disconnected-rh-with-write | Durable handles V2 | DH2 disconnected handle purge not fully working | - |
-| smb2.durable-v2-open.purge-disconnected-rh-with-rename | Durable handles V2 | DH2 disconnected handle purge not fully working | - |
-| smb2.durable-v2-open.app-instance | Durable handles V2 | App instance ID not fully working | - |
-| smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Persistent handles not implemented | - |
-| smb2.durable-v2-open.persistent-open-lease | Durable handles V2 | Persistent handles not implemented | - |
-| smb2.durable-v2-delay.durable_v2_reconnect_delay | Durable handles V2 | DH2 reconnect delay not fully working | - |
+| smb2.durable-v2-open.create-blob | Durable handles V2 | DH2Q create context blob validation | #432 |
+| smb2.durable-v2-open.open-oplock | Durable handles V2 | DH2 open with oplock not fully working | #432 |
+| smb2.durable-v2-open.open-lease | Durable handles V2 | DH2 open with lease not fully working | #432 |
+| smb2.durable-v2-open.reopen1 | Durable handles V2 | DH2 reopen not fully working | #432 |
+| smb2.durable-v2-open.reopen1a | Durable handles V2 | DH2 reopen not fully working | #432 |
+| smb2.durable-v2-open.reopen1a-lease | Durable handles V2 | DH2 reopen with lease not fully working | #432 |
+| smb2.durable-v2-open.reopen2 | Durable handles V2 | DH2 reopen not fully working | #432 |
+| smb2.durable-v2-open.reopen2b | Durable handles V2 | DH2 reopen not fully working | #432 |
+| smb2.durable-v2-open.reopen2-lease | Durable handles V2 | DH2 reopen with lease not fully working | #432 |
+| smb2.durable-v2-open.reopen2-lease-v2 | Durable handles V2 | DH2 reopen with lease V2 not fully working | #432 |
+| smb2.durable-v2-open.durable-v2-setinfo | Durable handles V2 | DH2 setinfo not fully working | #432 |
+| smb2.durable-v2-open.lock-oplock | Durable handles V2 | DH2 lock with oplock not fully working | #432 |
+| smb2.durable-v2-open.lock-lease | Durable handles V2 | DH2 lock with lease not fully working | #432 |
+| smb2.durable-v2-open.lock-noW-lease | Durable handles V2 | DH2 lock without write lease not fully working | #432 |
+| smb2.durable-v2-open.stat-and-lease | Durable handles V2 | DH2 stat + lease interaction not fully working | #432 |
+| smb2.durable-v2-open.nonstat-and-lease | Durable handles V2 | DH2 non-stat + lease interaction not fully working | #432 |
+| smb2.durable-v2-open.statRH-and-lease | Durable handles V2 | DH2 stat-RH + lease interaction not fully working | #432 |
+| smb2.durable-v2-open.two-same-lease | Durable handles V2 | DH2 two handles same lease not fully working | #432 |
+| smb2.durable-v2-open.two-different-lease | Durable handles V2 | DH2 two handles different leases not fully working | #432 |
+| smb2.durable-v2-open.keep-disconnected-rh-with-stat-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | #432 |
+| smb2.durable-v2-open.keep-disconnected-rh-with-rh-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | #432 |
+| smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | #432 |
+| smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open | Durable handles V2 | DH2 disconnected handle preservation not fully working | #432 |
+| smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open | Durable handles V2 | DH2 disconnected handle purge not fully working | #432 |
+| smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open | Durable handles V2 | DH2 disconnected handle purge not fully working | #432 |
+| smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open | Durable handles V2 | DH2 disconnected handle purge not fully working | #432 |
+| smb2.durable-v2-open.purge-disconnected-rh-with-write | Durable handles V2 | DH2 disconnected handle purge not fully working | #432 |
+| smb2.durable-v2-open.purge-disconnected-rh-with-rename | Durable handles V2 | DH2 disconnected handle purge not fully working | #432 |
+| smb2.durable-v2-open.app-instance | Durable handles V2 | App instance ID not fully working | #432 |
+| smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Persistent handles not implemented | #432 |
+| smb2.durable-v2-open.persistent-open-lease | Durable handles V2 | Persistent handles not implemented | #432 |
+| smb2.durable-v2-delay.durable_v2_reconnect_delay | Durable handles V2 | DH2 reconnect delay not fully working | #432 |
 
 ### Leases (Fix Candidate)
 
@@ -529,48 +529,48 @@ incomplete break notification delivery and multi-client coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.lease.request | Leases | Lease request handling not fully working | - |
-| smb2.lease.nobreakself | Leases | Lease self-break suppression not fully working | - |
-| smb2.lease.statopen | Leases | Lease + stat open interaction not fully working | - |
-| smb2.lease.statopen4 | Leases | Lease + stat open interaction not fully working | - |
-| smb2.lease.upgrade | Leases | Lease upgrade not fully working | - |
-| smb2.lease.upgrade2 | Leases | Lease upgrade not fully working | - |
-| smb2.lease.upgrade3 | Leases | Lease upgrade not fully working | - |
-| smb2.lease.break | Leases | Lease break notification not fully working | - |
-| smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | - |
-| smb2.lease.multibreak | Leases | Multi-client lease break not fully working | - |
-| smb2.lease.breaking1 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.breaking2 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.breaking3 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.breaking4 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.breaking5 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.breaking6 | Leases | Lease breaking state handling not fully working | - |
-| smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | - |
-| smb2.lease.complex1 | Leases | Complex lease scenario not fully working | - |
-| smb2.lease.timeout | Leases | Lease timeout handling not fully working | - |
-| smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | - |
-| smb2.lease.timeout-disconnect | Leases | Lease timeout on disconnect not fully working | - |
-| smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | - |
-| smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | - |
-| smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | - |
-| smb2.lease.v1_bug15148 | Leases | Lease V1 edge case not fully working | - |
-| smb2.lease.initial_delete_tdis | Leases | Lease + delete on tree disconnect not fully working | - |
-| smb2.lease.initial_delete_logoff | Leases | Lease + delete on logoff not fully working | - |
-| smb2.lease.initial_delete_disconnect | Leases | Lease + delete on disconnect not fully working | - |
-| smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | - |
-| smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | - |
-| smb2.lease.break_twice | Leases | Double lease break not fully working | - |
-| smb2.lease.v2_breaking3 | Leases V2 | Lease V2 breaking state handling not fully working | - |
-| smb2.lease.v2_flags_breaking | Leases V2 | Lease V2 flags during break not fully working | - |
-| smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | - |
-| smb2.lease.v2_epoch1 | Leases V2 | Lease V2 epoch tracking not fully working | - |
-| smb2.lease.v2_epoch2 | Leases V2 | Lease V2 epoch tracking not fully working | - |
-| smb2.lease.v2_epoch3 | Leases V2 | Lease V2 epoch tracking not fully working | - |
-| smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | - |
-| smb2.lease.v2_complex2 | Leases V2 | Lease V2 complex scenario not fully working | - |
-| smb2.lease.v2_rename | Leases V2 | Lease V2 rename interaction not fully working | - |
-| smb2.lease.v2_bug15148 | Leases V2 | Lease V2 edge case not fully working | - |
-| smb2.lease.v2_rename_target_overwrite | Leases V2 | Lease V2 rename target overwrite not fully working | - |
+| smb2.lease.request | Leases | Lease request handling not fully working | #429 |
+| smb2.lease.nobreakself | Leases | Lease self-break suppression not fully working | #429 |
+| smb2.lease.statopen | Leases | Lease + stat open interaction not fully working | #429 |
+| smb2.lease.statopen4 | Leases | Lease + stat open interaction not fully working | #429 |
+| smb2.lease.upgrade | Leases | Lease upgrade not fully working | #429 |
+| smb2.lease.upgrade2 | Leases | Lease upgrade not fully working | #429 |
+| smb2.lease.upgrade3 | Leases | Lease upgrade not fully working | #429 |
+| smb2.lease.break | Leases | Lease break notification not fully working | #429 |
+| smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | #429 |
+| smb2.lease.multibreak | Leases | Multi-client lease break not fully working | #429 |
+| smb2.lease.breaking1 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.breaking2 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.breaking3 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.breaking4 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.breaking5 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.breaking6 | Leases | Lease breaking state handling not fully working | #429 |
+| smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
+| smb2.lease.complex1 | Leases | Complex lease scenario not fully working | #429 |
+| smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
+| smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
+| smb2.lease.timeout-disconnect | Leases | Lease timeout on disconnect not fully working | #429 |
+| smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
+| smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | #429 |
+| smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
+| smb2.lease.v1_bug15148 | Leases | Lease V1 edge case not fully working | #429 |
+| smb2.lease.initial_delete_tdis | Leases | Lease + delete on tree disconnect not fully working | #429 |
+| smb2.lease.initial_delete_logoff | Leases | Lease + delete on logoff not fully working | #429 |
+| smb2.lease.initial_delete_disconnect | Leases | Lease + delete on disconnect not fully working | #429 |
+| smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
+| smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
+| smb2.lease.break_twice | Leases | Double lease break not fully working | #429 |
+| smb2.lease.v2_breaking3 | Leases V2 | Lease V2 breaking state handling not fully working | #429 |
+| smb2.lease.v2_flags_breaking | Leases V2 | Lease V2 flags during break not fully working | #429 |
+| smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | #429 |
+| smb2.lease.v2_epoch1 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
+| smb2.lease.v2_epoch2 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
+| smb2.lease.v2_epoch3 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
+| smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
+| smb2.lease.v2_complex2 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
+| smb2.lease.v2_rename | Leases V2 | Lease V2 rename interaction not fully working | #429 |
+| smb2.lease.v2_bug15148 | Leases V2 | Lease V2 edge case not fully working | #429 |
+| smb2.lease.v2_rename_target_overwrite | Leases V2 | Lease V2 rename target overwrite not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)
 
@@ -579,25 +579,25 @@ fail due to incomplete lock contention and async lock handling.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.lock.valid-request | Locks | Lock request validation not fully working | - |
-| smb2.lock.auto-unlock | Locks | Auto-unlock on close not fully working | - |
-| smb2.lock.lock | Locks | Basic lock operation not fully working | - |
-| smb2.lock.cancel | Locks | Lock cancel not fully working | - |
-| smb2.lock.errorcode | Locks | Lock error codes not fully working | - |
-| smb2.lock.zerobytelength | Locks | Zero-length lock not fully working | - |
-| smb2.lock.unlock | Locks | Unlock operation not fully working | - |
-| smb2.lock.multiple-unlock | Locks | Multiple unlock not fully working | - |
-| smb2.lock.stacking | Locks | Lock stacking not fully working | - |
-| smb2.lock.range | Locks | Lock range validation not fully working | - |
-| smb2.lock.overlap | Locks | Overlapping locks not fully working | - |
-| smb2.lock.replay_broken_windows | Locks | Lock replay not fully working | - |
-| smb2.lock.replay_smb3_specification_durable | Locks | Lock replay with durable handles not fully working | - |
-| smb2.lock.replay_smb3_specification_multi | Locks | Lock replay with multi-channel not fully working | - |
-| smb2.lock.cancel-logoff | Locks | Lock cancel on logoff not fully working | - |
-| smb2.lock.cancel-tdis | Locks | Blocking lock deadlocks dispatch goroutine (needs async LOCK with interim response) | - |
-| smb2.lock.async | Locks | Blocking lock deadlocks dispatch goroutine (needs async LOCK with interim response) | - |
-| smb2.lock.open-brlock-deadlock | Locks | Open + byte-range lock deadlock detection not working | - |
-| smb2.lock.ctdb-delrec-deadlock | Locks | CTDB delete record deadlock not working | - |
+| smb2.lock.valid-request | Locks | Lock request validation not fully working | #430 |
+| smb2.lock.auto-unlock | Locks | Auto-unlock on close not fully working | #430 |
+| smb2.lock.lock | Locks | Basic lock operation not fully working | #430 |
+| smb2.lock.cancel | Locks | Lock cancel not fully working | #430 |
+| smb2.lock.errorcode | Locks | Lock error codes not fully working | #430 |
+| smb2.lock.zerobytelength | Locks | Zero-length lock not fully working | #430 |
+| smb2.lock.unlock | Locks | Unlock operation not fully working | #430 |
+| smb2.lock.multiple-unlock | Locks | Multiple unlock not fully working | #430 |
+| smb2.lock.stacking | Locks | Lock stacking not fully working | #430 |
+| smb2.lock.range | Locks | Lock range validation not fully working | #430 |
+| smb2.lock.overlap | Locks | Overlapping locks not fully working | #430 |
+| smb2.lock.replay_broken_windows | Locks | Lock replay not fully working | #430 |
+| smb2.lock.replay_smb3_specification_durable | Locks | Lock replay with durable handles not fully working | #430 |
+| smb2.lock.replay_smb3_specification_multi | Locks | Lock replay with multi-channel not fully working | #430 |
+| smb2.lock.cancel-logoff | Locks | Lock cancel on logoff not fully working | #430 |
+| smb2.lock.cancel-tdis | Locks | Blocking lock deadlocks dispatch goroutine (needs async LOCK with interim response) | #430 |
+| smb2.lock.async | Locks | Blocking lock deadlocks dispatch goroutine (needs async LOCK with interim response) | #430 |
+| smb2.lock.open-brlock-deadlock | Locks | Open + byte-range lock deadlock detection not working | #430 |
+| smb2.lock.ctdb-delrec-deadlock | Locks | CTDB delete record deadlock not working | #430 |
 
 ### Rename (Fix Candidate)
 
@@ -606,10 +606,10 @@ share mode enforcement during rename.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.rename.share_delete_and_delete_access | Rename | Share delete + delete access rename not working | - |
-| smb2.rename.no_share_delete_but_delete_access | Rename | Rename share mode enforcement not working | - |
-| smb2.rename.no_share_delete_no_delete_access | Rename | Rename share mode enforcement not working | - |
-| smb2.rename.rename_dir_openfile | Rename | Rename directory with open file not working | - |
+| smb2.rename.share_delete_and_delete_access | Rename | Share delete + delete access rename not working | #433 |
+| smb2.rename.no_share_delete_but_delete_access | Rename | Rename share mode enforcement not working | #433 |
+| smb2.rename.no_share_delete_no_delete_access | Rename | Rename share mode enforcement not working | #433 |
+| smb2.rename.rename_dir_openfile | Rename | Rename directory with open file not working | #433 |
 
 ### Sessions (Remaining)
 
@@ -773,13 +773,35 @@ incomplete delayed-write and timestamp freeze/unfreeze logic.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.timestamps.delayed-2write | Timestamps | Delayed write timestamp update not working | - |
-| smb2.timestamps.delayed-write-vs-flush | Timestamps | Delayed write vs flush timestamp not working | - |
-| smb2.timestamps.delayed-write-vs-setbasic | Timestamps | Delayed write vs setbasic timestamp not working | - |
-| smb2.timestamps.delayed-write-vs-seteof | Timestamps | Delayed write vs seteof timestamp not working | - |
-| smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | - |
+| smb2.timestamps.delayed-2write | Timestamps | Delayed write timestamp update not working | #434 |
+| smb2.timestamps.delayed-write-vs-flush | Timestamps | Delayed write vs flush timestamp not working | #434 |
+| smb2.timestamps.delayed-write-vs-setbasic | Timestamps | Delayed write vs setbasic timestamp not working | #434 |
+| smb2.timestamps.delayed-write-vs-seteof | Timestamps | Delayed write vs seteof timestamp not working | #434 |
+| smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
+
+### 2026-04-23 — File tracking issues for fix-candidate clusters
+
+Previously all "Fix Candidate" sections had their `Issue` column set to `-`
+because no GH issue was tracking them. Filed eight issues so each fixable
+test cluster has a home to land work against:
+
+- **#429** — Leases (umbrella, 42 tests): break delivery + multi-client
+  coordination + V2 epoch edge cases that remain after #417.
+- **#430** — Byte-Range Locks (19 tests): async LOCK with interim response,
+  contention + deadlock detection, replay.
+- **#431** — Durable Handles V1 (13 tests): reconnect + lease coordination.
+- **#432** — Durable Handles V2 (33 tests): reopen, disconnected-handle
+  preservation/purge, app-instance, persistent-open flagged as separate
+  feature work.
+- **#433** — Rename (4 tests): share-mode enforcement during rename.
+- **#434** — Timestamps (5 tests): delayed-write + freeze/thaw.
+- **#435** — Charset (1 test): unicode surrogate pair handling.
+- **#436** — `multichannel.leases.test3` spurious lease break on uncontested
+  open (split out of #417 / PR #418 follow-up).
+
+No test reclassifications or pass/fail transitions — pure issue tracking.
 
 ### 2026-04-17 — Reconcile credits subsuite after #378 grant fix (close #397)
 The #378 credit-grant cap (commit `191e683e`) resolved both arms of #397: the

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -330,6 +330,7 @@ Advanced delete-on-close permission checks and edge cases. Basic DOC works
 |-----------|----------|--------|-------|
 | smb2.delete-on-close-perms.CREATE | Delete on close | DOC permission check not implemented | - |
 | smb2.delete-on-close-perms.CREATE_IF | Delete on close | DOC permission check not implemented | - |
+| smb2.delete-on-close-perms.OVERWRITE_IF | Delete on close | OVERWRITE_IF returns OBJECT_NAME_COLLISION instead of ACCESS_DENIED for DOC permission check | - |
 | smb2.delete-on-close-perms.READONLY | Delete on close | DOC on read-only files not implemented | - |
 | smb2.delete-on-close-perms.FIND_and_set_DOC | Delete on close | Cascade from the CREATE/CREATE_IF/OVERWRITE_IF Existing DOC failures above: those subtests leak `test_dir/test_create.dat` that `smb2_deltree` can't recover from, so `torture_smb2_testdir` reopens a non-empty `test_dir` and the final CLOSE correctly returns DIRECTORY_NOT_EMPTY. Pre-#388 the unlink error was silently swallowed by CLOSE so the test "passed" by accident. Will self-resolve once the upstream DOC permission checks are implemented. | - |
 
@@ -385,6 +386,10 @@ Benchmark tests require multi-client coordination and stress scenarios.
 Unicode and character set edge cases (partial surrogates, wide-A collision) are
 tracked as fix candidates in baseline-results.md rather than known failures,
 since basic charset support works.
+
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| smb2.charset.Testing | Character set | Unicode surrogate pair / wide-A handling not implemented | #435 |
 
 ### Name Mangling (Not Implemented)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-23 (Filed tracking issues for fix-candidate clusters: #429 leases, #430 byte-range locks, #431 DH V1, #432 DH V2, #433 rename, #434 timestamps, #435 charset, #436 multichannel.leases.test3)
+Last updated: 2026-04-24 (Pruned 20 collapsed entries against post-#418 baseline; closed #435; chipped #431 by 1)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -215,7 +215,6 @@ DittoFS implements file leases (Phase 37) but not directory leases.
 | smb2.dirlease.unlink_same_initial_and_close | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.unlink_same_set_and_close | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.v2_request | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.v2_request_parent | Directory Leases | Directory leases not implemented | - |
 
 ### Credit Management
 
@@ -236,13 +235,9 @@ handling) are not fully implemented.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.dir.1kfiles_rename | Directory | Large directory rename not implemented | - |
-| smb2.dir.file-index | Directory | File index tracking not implemented | - |
 | smb2.dir.fixed | Directory | Fixed-size directory entries not implemented | - |
-| smb2.dir.large-files | Directory | Large directory operations not implemented | - |
-| smb2.dir.many | Directory | Large directory operations not implemented | - |
 | smb2.dir.modify | Directory | Directory modify during enumeration not implemented | - |
 | smb2.dir.one | Directory | Single-entry directory query not implemented | - |
-| smb2.dir.sorted | Directory | Sorted directory results not implemented | - |
 
 ### File Attributes (Limited Support)
 
@@ -265,7 +260,6 @@ files, create blobs) are not implemented. Basic create operations pass.
 |-----------|----------|--------|-------|
 | smb2.create.acldir | Create | ACL-based directory create not implemented | - |
 | smb2.create.aclfile | Create | ACL-based file create not implemented | - |
-| smb2.create.bench-path-contention-shared | Create | Path contention benchmark not implemented | - |
 | smb2.create.blob | Create | Create context blobs not fully implemented | - |
 | smb2.create.gentest | Create | Generic create test (impersonation) not implemented | - |
 | smb2.create.impersonation | Create | Impersonation levels not implemented | - |
@@ -294,7 +288,6 @@ checks, and ACL-based access control.
 |-----------|----------|--------|-------|
 | smb2.getinfo.complex | Query Info | Complex getinfo not implemented | - |
 | smb2.getinfo.getinfo_access | Query Info | Access-based getinfo not implemented | - |
-| smb2.getinfo.granted | Query Info | Granted access info not implemented | - |
 | smb2.getinfo.normalized | Query Info | Normalized name info not implemented | - |
 | smb2.getinfo.qfile_buffercheck | Query Info | Buffer check validation not implemented | - |
 | smb2.getinfo.qfs_buffercheck | Query Info | FS buffer check not implemented | - |
@@ -319,7 +312,6 @@ failures require DACL enforcement or full async I/O support.
 | smb2.compound_async.rename_non_compound_no_async | Compound | Non-compound rename async check | - |
 | smb2.compound_async.rename_same_srcdst_non_compound_no_async | Compound | Same src/dst rename async check | - |
 | smb2.compound_async.write_write | Compound | Async write+write compound not implemented | - |
-| smb2.compound_find.compound_find_close | Compound | Compound find+close sequence | - |
 
 ### Share Modes and Deny (Advanced Scenarios)
 
@@ -327,11 +319,7 @@ Advanced share mode enforcement and deny mode scenarios.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.sharemode.access-sharemode | Share modes | Advanced share mode enforcement not implemented | - |
 | smb2.sharemode.bug14375 | Share modes | Share mode edge case not implemented | - |
-| smb2.sharemode.sharemode-access | Share modes | Share mode access check not implemented | - |
-| smb2.deny.deny1 | Deny modes | Deny mode enforcement not implemented | - |
-| smb2.deny.deny2 | Deny modes | Deny mode enforcement not implemented | - |
 
 ### Delete-on-Close (Advanced Semantics)
 
@@ -343,7 +331,6 @@ Advanced delete-on-close permission checks and edge cases. Basic DOC works
 | smb2.delete-on-close-perms.CREATE | Delete on close | DOC permission check not implemented | - |
 | smb2.delete-on-close-perms.CREATE_IF | Delete on close | DOC permission check not implemented | - |
 | smb2.delete-on-close-perms.READONLY | Delete on close | DOC on read-only files not implemented | - |
-| smb2.delete-on-close-perms.OVERWRITE_IF | Delete on close | OVERWRITE_IF returns OBJECT_NAME_COLLISION instead of ACCESS_DENIED for DOC permission check | - |
 | smb2.delete-on-close-perms.FIND_and_set_DOC | Delete on close | Cascade from the CREATE/CREATE_IF/OVERWRITE_IF Existing DOC failures above: those subtests leak `test_dir/test_create.dat` that `smb2_deltree` can't recover from, so `torture_smb2_testdir` reopens a non-empty `test_dir` and the final CLOSE correctly returns DIRECTORY_NOT_EMPTY. Pre-#388 the unlink error was silently swallowed by CLOSE so the test "passed" by accident. Will self-resolve once the upstream DOC permission checks are implemented. | - |
 
 ### File IDs (Different Handle Scheme)
@@ -356,8 +343,6 @@ implemented.
 |-----------|----------|--------|-------|
 | smb2.fileid.fileid | File IDs | Stable file ID not implemented | - |
 | smb2.fileid.fileid-dir | File IDs | Stable directory file ID not implemented | - |
-| smb2.fileid.unique | File IDs | Unique file ID guarantee not implemented | - |
-| smb2.fileid.unique-dir | File IDs | Unique directory file ID not implemented | - |
 
 ### Maximum Allowed Access (Partial)
 
@@ -393,10 +378,7 @@ Benchmark tests require multi-client coordination and stress scenarios.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.bench.echo | Benchmarks | Multi-client echo benchmark | - |
 | smb2.bench.oplock1 | Benchmarks | Multi-client oplock benchmark | - |
-| smb2.bench.path-contention-shared | Benchmarks | Multi-client path contention | - |
-| smb2.bench.read | Benchmarks | Multi-client read benchmark | - |
 
 ### Character Set (Edge Cases)
 
@@ -444,23 +426,6 @@ Session signing edge cases requiring multi-channel binding.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 
-### Character Set Edge Cases (Fix Candidate)
-
-Unicode and character set edge cases (partial surrogates, wide-A collision).
-Newly reachable after compound and protocol improvements.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.charset.Testing | Character set | Unicode surrogate pair handling not implemented | #435 |
-
-### Delete-on-Close OVERWRITE_IF (Fix Candidate)
-
-Delete-on-close with OVERWRITE_IF disposition needs additional enforcement.
-Newly reachable after access control improvements.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-
 ### Durable Handles V1 (Fix Candidate)
 
 Durable handle V1 open/reopen operations partially implemented but tests
@@ -468,7 +433,6 @@ still fail due to incomplete reconnect and lease coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-open.open-lease | Durable handles V1 | Durable open with lease not fully working | #431 |
 | smb2.durable-open.reopen1a | Durable handles V1 | Durable reopen not fully working | #431 |
 | smb2.durable-open.reopen1a-lease | Durable handles V1 | Durable reopen with lease not fully working | #431 |
 | smb2.durable-open.reopen2 | Durable handles V1 | Durable reopen not fully working | #431 |
@@ -780,6 +744,46 @@ incomplete delayed-write and timestamp freeze/unfreeze logic.
 | smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
+
+### 2026-04-24 — Prune 20 collapsed entries after post-#418 baseline
+
+Full smbtorture suite baseline against current `develop` (run
+`smbtorture-2026-04-23_224339`) confirmed 22 previously-known failures now
+pass. Pruned 20 of them (kept `smb2.create.mkdir-dup` and
+`smb2.ioctl.network_interface_info` since their own reason text flags them
+as flaky — single-run greens are insufficient evidence to remove).
+
+Pruned entries:
+
+- **Benchmarks**: `bench.echo`, `bench.path-contention-shared`, `bench.read`
+- **Compound**: `compound_find.compound_find_close`
+- **Create**: `create.bench-path-contention-shared`
+- **Delete-on-Close**: `delete-on-close-perms.OVERWRITE_IF`
+- **Deny modes**: `deny.deny1`, `deny.deny2`
+- **Directory**: `dir.file-index`, `dir.large-files`, `dir.many`,
+  `dir.sorted`
+- **Directory leases**: `dirlease.v2_request_parent`
+- **Durable V1** (chips #431): `durable-open.open-lease`
+- **File IDs**: `fileid.unique`, `fileid.unique-dir`
+- **Query Info**: `getinfo.granted`
+- **Share modes**: `sharemode.access-sharemode`,
+  `sharemode.sharemode-access`
+
+Two empty fix-candidate section headers are removed:
+
+- **Charset Edge Cases (Fix Candidate)**: only entry was `charset.Testing`.
+  **Closes #435.**
+- **Delete-on-Close OVERWRITE_IF (Fix Candidate)**: a placeholder header
+  whose table was already empty (no entries had ever been filed under it).
+
+Stats vs prior baseline (`smbtorture-2026-04-22_162101`, pre-#418):
+160 PASS / 240 KNOWN / 0 NEW → 168 PASS / 233 KNOWN / 0 NEW.
+
+Note: the `smb2.lease.*` subsuite hit the smbtorture per-suite timeout in
+this run because `lease.break_twice` alone took 57 minutes (DittoFS
+hangs the conflicting open instead of returning `STATUS_SHARING_VIOLATION`).
+This is the next target for #429 work; baseline data for the lease cluster
+is incomplete until that bug is resolved.
 
 ### 2026-04-23 — File tracking issues for fix-candidate clusters
 


### PR DESCRIPTION
## Summary

Targets #429 (SMB lease umbrella). Fixes how lease breaks are dispatched, persisted, and observed on same-key reopen so that our semantics match MS-SMB2 and Samba more closely. **Zero net change** in the smbtorture `smb2.lease` tally (13 PASS / 31 FAIL / 1 SKIP, 2× stable) — these commits tighten the infrastructure so the next batch of fixes (async `STATUS_PENDING` CREATE) can land cleanly.

## Commits

- `ea94c968` / `29a1b353` / `b1dc143a` — doc/KNOWN_FAILURES maintenance
- `931ed6f1` — bound `BreakHandleLeasesOnOpen` wait at 5s with `forceCompleteBreaks` fallback
- `5c781938` — Phase 2 matrix: compute lease break-to by sharing-violation (Samba `delay_for_oplock_fn` rule)
- `f12cc4f0` — break file Handle leases on delete-pending close (fixes `initial_delete_tdis/logoff/disconnect`)
- `249fd668` — scope lease release to one handle bucket (fixes `break_twice`, `complex1`)
- `0b036979` — downgrade read-only lease breaks inline (R→None / R→R bypass Breaking=true since the client doesn't ack per MS-SMB2 3.3.4.7)
- `3598d119` — skip `WaitForBreakCompletion` on same-key reopen when own lease is breaking (preserves `SMB2_LEASE_FLAG_BREAK_IN_PROGRESS` per MS-SMB2 3.3.5.9.8)
- `3eded7a5` — refactor `breakOpLocks` removal into a single pass
- `5aff2300` — review follow-up: snapshot pre-break state for the wire notification, advance epoch first so `NewEpoch` is correct

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...`
- [x] smbtorture `smb2.lease` full suite: 13 PASS / 31 FAIL / 1 SKIP, stable across 2 runs (same as baseline before this branch)
- [x] Spot-checked: `break_twice`, `complex1`, `initial_delete_*`, `nobreakself`, `v2_complex2`, `v2_bug15148` all still pass with the new inline-downgrade + snapshot logic

## Known follow-ups (not in this PR)

These were surfaced by the code review pass and are worth tracking but are out of scope:

1. **`breakOpLocks` ack-required arm does not persist `Breaking=true` via `lockStore.PutLock`.** Pre-existing asymmetry with `requestLeaseImpl` (leases.go:268-274). Server restart mid-break would lose the breaking state. Low priority — in-memory store is the only store implementation we exercise today.
2. **TOCTOU race between `BreakLeasesOnOpenConflict` and `HasBreakingLeaseForKey`** in `BreakHandleLeasesOnOpen`. The lock is released between the two calls; a concurrent ack/force-complete could flip `Breaking=false` in the window, losing the `BREAK_IN_PROGRESS` flag. Narrow window; single-threaded smbtorture doesn't hit it. Fix would be to have `BreakLeasesOnOpenConflict` return a bool for "own-key still breaking" so the check happens under the same `lm.mu` hold.
3. **SMB2 `STATUS_PENDING` interim responses for blocked CREATEs.** Needed to pass `breaking1..6` + `duplicate_create` + `duplicate_open` (~8 tests). Infrastructure exists for `CHANGE_NOTIFY` (see `response.go:455-487`, `compound.go:28-29`); needs plumbing into the CREATE handler. This is the next substantive milestone toward closing #429.

## Related

Unblocks further work on #429. Does not affect #430-#436.