### PR TITLE
fix(smb): map lease-break-ack errors to spec NTSTATUS codes — #441

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -187,12 +186,12 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 	err := lockMgr.AcknowledgeLeaseBreak(ctx, leaseKey, acknowledgedState, epoch)
 	if err != nil {
-		// If the underlying lock manager says "no lease found", the lease was
-		// released between our map lookup and the ack call. Treat as success.
-		if strings.Contains(err.Error(), "no lease found") {
+		// Lease released between our map lookup and the ack call (CLOSE beat
+		// the ack). Per MS-SMB2 3.3.5.22.2 the desired state is already
+		// achieved — treat as success and reap stale wrapper-side mappings.
+		if errors.Is(err, lock.ErrLeaseAckNotFound) {
 			logger.Debug("AcknowledgeLeaseBreak: lease not found in lock manager, treating as success",
 				"leaseKey", keyHex)
-			// Clean up our maps if they still have stale entries
 			lm.removeLeaseMapping(keyHex)
 			return nil
 		}

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -54,6 +54,11 @@ const (
 
 	// Error codes (severity = 11, both high bits set)
 
+	// StatusUnsuccessful indicates the request failed for unspecified reasons.
+	// Used for lease-break ACKs that have no matching break in progress
+	// (per MS-SMB2 3.3.5.22.2).
+	StatusUnsuccessful Status = 0xC0000001
+
 	// StatusInvalidInfoClass indicates an invalid information class was requested.
 	StatusInvalidInfoClass Status = 0xC0000003
 

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -203,6 +203,8 @@ func (s Status) String() string {
 	switch s {
 	case StatusSuccess:
 		return "STATUS_SUCCESS"
+	case StatusUnsuccessful:
+		return "STATUS_UNSUCCESSFUL"
 	case StatusPending:
 		return "STATUS_PENDING"
 	case StatusMoreProcessingRequired:

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -457,6 +457,23 @@ func (h *Handler) OplockBreak(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 	return h.handleOplockBreakAck(ctx, body)
 }
 
+// mapLeaseAckErr maps an AcknowledgeLeaseBreak error to its SMB2 status code
+// per MS-SMB2 3.3.5.22.2 (lease) and 3.3.5.22.1 (traditional oplock, which is
+// internally backed by a synthetic lease). Unknown errors default to
+// STATUS_INVALID_PARAMETER.
+func mapLeaseAckErr(err error) types.Status {
+	switch {
+	case errors.Is(err, lock.ErrAcknowledgedStateExceedsBreakTo):
+		return types.StatusRequestNotAccepted
+	case errors.Is(err, lock.ErrLeaseAckNotBreaking):
+		return types.StatusUnsuccessful
+	case errors.Is(err, lock.ErrLeaseAckNotFound):
+		return types.StatusObjectNameNotFound
+	default:
+		return types.StatusInvalidParameter
+	}
+}
+
 // handleLeaseBreakAck handles an SMB2 Lease Break Acknowledgment [MS-SMB2] 2.2.24.2.
 func (h *Handler) handleLeaseBreakAck(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	ack, err := DecodeLeaseBreakAcknowledgment(body)
@@ -478,13 +495,7 @@ func (h *Handler) handleLeaseBreakAck(ctx *SMBHandlerContext, body []byte) (*Han
 		logger.Warn("LEASE_BREAK_ACK: acknowledgment failed",
 			"leaseKey", fmt.Sprintf("%x", ack.LeaseKey),
 			"error", err)
-		switch {
-		case errors.Is(err, lock.ErrAcknowledgedStateExceedsBreakTo):
-			return NewErrorResult(types.StatusRequestNotAccepted), nil
-		case errors.Is(err, lock.ErrLeaseAckNoBreak):
-			return NewErrorResult(types.StatusUnsuccessful), nil
-		}
-		return NewErrorResult(types.StatusInvalidParameter), nil
+		return NewErrorResult(mapLeaseAckErr(err)), nil
 	}
 
 	// Build lease break response
@@ -542,7 +553,7 @@ func (h *Handler) handleOplockBreakAck(ctx *SMBHandlerContext, body []byte) (*Ha
 		logger.Warn("OPLOCK_BREAK_ACK: acknowledgment failed",
 			"fileID", fmt.Sprintf("%x", ack.FileID),
 			"error", err)
-		return NewErrorResult(types.StatusInvalidParameter), nil
+		return NewErrorResult(mapLeaseAckErr(err)), nil
 	}
 
 	// Update the oplock level on the open file

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"unicode/utf16"
 
@@ -477,6 +478,12 @@ func (h *Handler) handleLeaseBreakAck(ctx *SMBHandlerContext, body []byte) (*Han
 		logger.Warn("LEASE_BREAK_ACK: acknowledgment failed",
 			"leaseKey", fmt.Sprintf("%x", ack.LeaseKey),
 			"error", err)
+		switch {
+		case errors.Is(err, lock.ErrAcknowledgedStateExceedsBreakTo):
+			return NewErrorResult(types.StatusRequestNotAccepted), nil
+		case errors.Is(err, lock.ErrLeaseAckNoBreak):
+			return NewErrorResult(types.StatusUnsuccessful), nil
+		}
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -37,12 +37,17 @@ var ErrInvalidLeaseState = errors.New("invalid lease state")
 // STATUS_REQUEST_NOT_ACCEPTED.
 var ErrAcknowledgedStateExceedsBreakTo = errors.New("acknowledged state exceeds break-to state")
 
-// ErrLeaseAckNoBreak is returned by AcknowledgeLeaseBreak when the lease
-// either does not exist or is not in the Breaking state (e.g., the client
-// acks a break that did not require acknowledgment, or re-acks an already
-// completed break). Per MS-SMB2 3.3.5.22.2, the caller must return
-// STATUS_UNSUCCESSFUL.
-var ErrLeaseAckNoBreak = errors.New("lease not in breaking state")
+// ErrLeaseAckNotFound is returned by AcknowledgeLeaseBreak when no lease
+// exists for the given lease key (e.g., the client sent CLOSE before the
+// ack and the lease was released). The SMB wrapper treats this as a no-op
+// success; if it surfaces to the wire it maps to STATUS_OBJECT_NAME_NOT_FOUND.
+var ErrLeaseAckNotFound = errors.New("no lease for key")
+
+// ErrLeaseAckNotBreaking is returned by AcknowledgeLeaseBreak when the lease
+// exists but is not in the Breaking state (e.g., the client acks a break that
+// did not require acknowledgment, or re-acks an already-completed break).
+// Per MS-SMB2 3.3.5.22.2, the caller must return STATUS_UNSUCCESSFUL.
+var ErrLeaseAckNotBreaking = errors.New("lease not in breaking state")
 
 // validUpgrades defines allowed lease state upgrade transitions.
 // A lease can only be upgraded (more permissions), never downgraded via RequestLease.
@@ -488,18 +493,19 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	handleKey, lock, idx := lm.findLeaseByKey(leaseKey)
 	if lock == nil {
-		return fmt.Errorf("%w: no lease for key", ErrLeaseAckNoBreak)
+		return ErrLeaseAckNotFound
 	}
 
 	if !lock.Lease.Breaking {
-		return fmt.Errorf("%w: lease is not breaking", ErrLeaseAckNoBreak)
+		return ErrLeaseAckNotBreaking
 	}
 
 	// Validate epoch if provided (V2 staleness check).
 	// The epoch was already advanced during break initiation, so the client
 	// should echo the current epoch value from the break notification.
 	if epoch != 0 && lock.Lease.Epoch != epoch {
-		return fmt.Errorf("stale epoch: expected %d, got %d", lock.Lease.Epoch, epoch)
+		return fmt.Errorf("%w: stale epoch (expected %d, got %d)",
+			ErrAcknowledgedStateExceedsBreakTo, lock.Lease.Epoch, epoch)
 	}
 
 	// Client cannot claim bits not offered (bitwise subset check).

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -31,6 +31,19 @@ var ErrLeaseBreakInProgress = errors.New("lease break in progress")
 // Read). Per MS-SMB2 3.3.5.9.8, the caller must return STATUS_INVALID_PARAMETER.
 var ErrInvalidLeaseState = errors.New("invalid lease state")
 
+// ErrAcknowledgedStateExceedsBreakTo is returned by AcknowledgeLeaseBreak when
+// the client acknowledges with a state containing bits not present in the
+// server's BreakToState. Per MS-SMB2 3.3.5.22.2, the caller must return
+// STATUS_REQUEST_NOT_ACCEPTED.
+var ErrAcknowledgedStateExceedsBreakTo = errors.New("acknowledged state exceeds break-to state")
+
+// ErrLeaseAckNoBreak is returned by AcknowledgeLeaseBreak when the lease
+// either does not exist or is not in the Breaking state (e.g., the client
+// acks a break that did not require acknowledgment, or re-acks an already
+// completed break). Per MS-SMB2 3.3.5.22.2, the caller must return
+// STATUS_UNSUCCESSFUL.
+var ErrLeaseAckNoBreak = errors.New("lease not in breaking state")
+
 // validUpgrades defines allowed lease state upgrade transitions.
 // A lease can only be upgraded (more permissions), never downgraded via RequestLease.
 // Downgrade happens only through lease break.
@@ -475,11 +488,11 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	handleKey, lock, idx := lm.findLeaseByKey(leaseKey)
 	if lock == nil {
-		return fmt.Errorf("no lease found with key %x", leaseKey)
+		return fmt.Errorf("%w: no lease for key", ErrLeaseAckNoBreak)
 	}
 
 	if !lock.Lease.Breaking {
-		return fmt.Errorf("lease %x is not in breaking state", leaseKey)
+		return fmt.Errorf("%w: lease is not breaking", ErrLeaseAckNoBreak)
 	}
 
 	// Validate epoch if provided (V2 staleness check).
@@ -489,9 +502,11 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		return fmt.Errorf("stale epoch: expected %d, got %d", lock.Lease.Epoch, epoch)
 	}
 
-	// Client cannot claim bits not offered (bitwise subset check)
+	// Client cannot claim bits not offered (bitwise subset check).
+	// Per MS-SMB2 3.3.5.22.2, this must surface as STATUS_REQUEST_NOT_ACCEPTED.
 	if acknowledgedState & ^lock.Lease.BreakToState != 0 {
-		return fmt.Errorf("acknowledged state %s exceeds break-to state %s",
+		return fmt.Errorf("%w: %s exceeds break-to %s",
+			ErrAcknowledgedStateExceedsBreakTo,
 			LeaseStateToString(acknowledgedState),
 			LeaseStateToString(lock.Lease.BreakToState))
 	}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -504,8 +504,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 	// The epoch was already advanced during break initiation, so the client
 	// should echo the current epoch value from the break notification.
 	if epoch != 0 && lock.Lease.Epoch != epoch {
-		return fmt.Errorf("%w: stale epoch (expected %d, got %d)",
-			ErrAcknowledgedStateExceedsBreakTo, lock.Lease.Epoch, epoch)
+		return fmt.Errorf("stale epoch: expected %d, got %d", lock.Lease.Epoch, epoch)
 	}
 
 	// Client cannot claim bits not offered (bitwise subset check).


### PR DESCRIPTION
Closes #441.

## Summary

Per MS-SMB2 3.3.5.22.2, the SMB2 LEASE_BREAK_ACK validator must return:

| Condition | NTSTATUS |
| --- | --- |
| Acknowledged state has bits outside server's `BreakToState` | `STATUS_REQUEST_NOT_ACCEPTED` |
| Lease exists but is not in the Breaking state | `STATUS_UNSUCCESSFUL` |
| Lease record not found at all | `STATUS_OBJECT_NAME_NOT_FOUND` |

Previously DittoFS returned `STATUS_INVALID_PARAMETER` for all three. This PR introduces three sentinel errors in `pkg/metadata/lock` (`ErrAcknowledgedStateExceedsBreakTo`, `ErrLeaseAckNotBreaking`, `ErrLeaseAckNotFound`), wires them through the SMB handler via a single `mapLeaseAckErr` helper, and applies the same mapping to the traditional `OPLOCK_BREAK_ACK` path (which shares the underlying lease-ack codepath).

The lease-ack-after-CLOSE silent-success guard in `internal/adapter/smb/lease/manager.go` was previously matching the underlying error text via `strings.Contains` — that's now `errors.Is(err, lock.ErrLeaseAckNotFound)`, eliminating a silent regression risk on future error-message edits.

## Files

- `pkg/metadata/lock/leases.go` — three new sentinels + `%w` wrapping
- `internal/adapter/smb/v2/handlers/stub_handlers.go` — `mapLeaseAckErr` helper applied to lease + oplock ack paths
- `internal/adapter/smb/lease/manager.go` — `errors.Is` replaces `strings.Contains` on the CLOSE-race no-op path
- `internal/adapter/smb/types/status.go` — `StatusUnsuccessful = 0xC0000001` constant + `String()` mapping

## Scope note (smbtorture)

This PR closes the spec-mapping bug tracked by #441 but does **not** flip the 5 `smb2.lease.breaking*` torture tests green on its own. Those tests also exercise disposition-aware `ComputeLeaseBreakTo` (e.g. `OVERWRITE` must break to `NONE`, not strip just `W`), which is a deeper behavioral fix tracked separately in **#445**. PR #444 is a prerequisite for that work.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/metadata/lock/... ./internal/adapter/smb/...` green
- [x] smbtorture `smb2.lease`: 16 passers (no regression vs `0d5d1079` baseline)
- [ ] (Reviewer) Confirm spec mapping in MS-SMB2 3.3.5.22.2 matches the implementation