### PR TITLE
fix(smb): reject CREATE with duplicate create-context tags — #442

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -278,7 +278,10 @@ func decodeCreateContexts(buf []byte) ([]CreateContext, error) {
 	// Windows rejects duplicate create-context tags with STATUS_INVALID_PARAMETER
 	// (smbtorture smb2.lease.duplicate_create / duplicate_open). MS-SMB2
 	// §2.2.13.2 implies each tag is single-occurrence by design; the explicit
-	// MUST is not stated in §3.3.5.9.
+	// MUST is not stated in §3.3.5.9. Track the first tag in firstSeen and
+	// only allocate the map on the second context to keep the common 0/1-tag
+	// path allocation-free.
+	var firstSeen string
 	var seen map[string]struct{}
 	offset := 0
 
@@ -347,13 +350,20 @@ func decodeCreateContexts(buf []byte) ([]CreateContext, error) {
 		}
 
 		if name != "" {
-			if _, dup := seen[name]; dup {
-				return nil, fmt.Errorf("duplicate create context tag: %q", name)
+			switch {
+			case firstSeen == "":
+				firstSeen = name
+			case seen == nil:
+				if name == firstSeen {
+					return nil, fmt.Errorf("duplicate create context tag: %q", name)
+				}
+				seen = map[string]struct{}{firstSeen: {}, name: {}}
+			default:
+				if _, dup := seen[name]; dup {
+					return nil, fmt.Errorf("duplicate create context tag: %q", name)
+				}
+				seen[name] = struct{}{}
 			}
-			if seen == nil {
-				seen = make(map[string]struct{})
-			}
-			seen[name] = struct{}{}
 			contexts = append(contexts, CreateContext{
 				Name: name,
 				Data: data,

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -275,6 +275,11 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 //	16      var   Buffer          Name (padded) + Data
 func decodeCreateContexts(buf []byte) ([]CreateContext, error) {
 	var contexts []CreateContext
+	// Windows rejects duplicate create-context tags with STATUS_INVALID_PARAMETER
+	// (smbtorture smb2.lease.duplicate_create / duplicate_open). MS-SMB2
+	// §2.2.13.2 implies each tag is single-occurrence by design; the explicit
+	// MUST is not stated in §3.3.5.9.
+	var seen map[string]struct{}
 	offset := 0
 
 	for offset < len(buf) {
@@ -342,6 +347,13 @@ func decodeCreateContexts(buf []byte) ([]CreateContext, error) {
 		}
 
 		if name != "" {
+			if _, dup := seen[name]; dup {
+				return nil, fmt.Errorf("duplicate create context tag: %q", name)
+			}
+			if seen == nil {
+				seen = make(map[string]struct{})
+			}
+			seen[name] = struct{}{}
 			contexts = append(contexts, CreateContext{
 				Name: name,
 				Data: data,

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -1010,6 +1010,18 @@ func TestCreate_CreateContextBlobValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("DuplicateTagRejected", func(t *testing.T) {
+		ctxs := []CreateContext{
+			{Name: "MxAc", Data: nil},
+			{Name: "MxAc", Data: nil},
+		}
+		buf, _, _ := EncodeCreateContexts(ctxs)
+		_, err := decodeCreateContexts(buf)
+		if err == nil {
+			t.Error("Expected error for duplicate create context tag")
+		}
+	})
+
 	t.Run("DecodeCreateRequest_MalformedContextReturnsError", func(t *testing.T) {
 		body := buildCreateRequestBody("test.txt", types.FileOpenIf, 0)
 


### PR DESCRIPTION
Closes #442.

## Summary

Windows rejects SMB2 CREATE requests carrying duplicate create-context tags with `STATUS_INVALID_PARAMETER`. smbtorture's `smb2.lease.duplicate_create` and `smb2.lease.duplicate_open` assert that behavior. DittoFS previously accepted duplicates (the existing `FindCreateContext` returns the first match and silently ignores the rest), so both tests failed with `Incorrect status NT_STATUS_OK`.

This PR adds duplicate-tag detection inside `decodeCreateContexts`. The check runs in the existing parse loop with a lazy-allocated `map[string]struct{}` so the common (zero or single context) paths stay allocation-free. Decode errors already map to `STATUS_INVALID_PARAMETER` via the `handleCreate` dispatch fallback.

## Files

- `internal/adapter/smb/v2/handlers/create.go` — duplicate-tag detection inside the parse loop
- `internal/adapter/smb/v2/handlers/create_test.go` — `DuplicateTagRejected` subtest under `TestCreate_CreateContextBlobValidation`

## Spec note

The explicit MUST is not stated in MS-SMB2 §3.3.5.9; §2.2.13.2 implies single-occurrence by design. The check is empirically grounded against Windows behavior and the smbtorture assertions; the inline comment is honest about that.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/adapter/smb/v2/handlers/... -run TestCreate_CreateContextBlobValidation` — new `DuplicateTagRejected` subtest green
- [ ] (Reviewer / CI) smbtorture `smb2.lease.duplicate_create` + `smb2.lease.duplicate_open` flip to PASS