### PR TITLE
fix(smb): disposition-aware lease break + spec-correct ack failures — #445

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -157,11 +157,12 @@ func (lm *LeaseManager) RequestLease(
 
 // AcknowledgeLeaseBreak delegates to the shared LockManager.
 //
-// If the lease has already been released (e.g. the client sent CLOSE before
-// the break ack arrived), the acknowledgment is treated as a successful no-op.
-// Per MS-SMB2 3.3.5.22.2, a break ack for a lease that no longer exists is
-// not an error condition -- the desired state (lease relinquished) has already
-// been achieved.
+// Per MS-SMB2 3.3.5.22.2, an ack for a lease that doesn't exist (or one that
+// is no longer breaking) must surface as STATUS_UNSUCCESSFUL — both the
+// re-ack-after-NONE case (breaking2 / breaking5) and the late-ack-after-CLOSE
+// case fall under the same wire response. The wrapper still has to look up
+// the lock manager via leaseShare to route the call, but any miss converts to
+// ErrLeaseAckNotFound rather than silent success.
 func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	ctx context.Context,
 	leaseKey [16]byte,
@@ -170,35 +171,24 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 ) error {
 	keyHex := hex.EncodeToString(leaseKey[:])
 
-	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
 	shareName := lm.leaseShare[keyHex]
 	lm.mu.RUnlock()
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
-		// Lease was already released (CLOSE cleaned up the maps).
-		// The break ack is a no-op -- the lease is already gone.
-		logger.Debug("AcknowledgeLeaseBreak: lease already released, treating as success",
-			"leaseKey", keyHex)
-		return nil
+		lm.removeLeaseMapping(keyHex)
+		return fmt.Errorf("%w: share-mapping released", lock.ErrLeaseAckNotFound)
 	}
 
 	err := lockMgr.AcknowledgeLeaseBreak(ctx, leaseKey, acknowledgedState, epoch)
 	if err != nil {
-		// Lease released between our map lookup and the ack call (CLOSE beat
-		// the ack). Per MS-SMB2 3.3.5.22.2 the desired state is already
-		// achieved — treat as success and reap stale wrapper-side mappings.
 		if errors.Is(err, lock.ErrLeaseAckNotFound) {
-			logger.Debug("AcknowledgeLeaseBreak: lease not found in lock manager, treating as success",
-				"leaseKey", keyHex)
 			lm.removeLeaseMapping(keyHex)
-			return nil
 		}
 		return err
 	}
 
-	// If acknowledged to None, remove from session map
 	if acknowledgedState == lock.LeaseStateNone {
 		lm.removeLeaseMapping(keyHex)
 	}
@@ -432,13 +422,14 @@ const AsyncCreateBreakWaitTimeout = handleLeaseBreakWaitTimeout
 // deadlock the single-threaded test driver: the other client only acks after
 // this CREATE returns.
 //
-// Break-to semantics match BreakHandleLeasesOnOpen (see that doc comment).
+// reason selects the per-lease break-to mask via ComputeLeaseBreakTo
+// (Default → strip W, SharingViolation → strip H, Destructive → break to None).
 // excludeOwner is optional and can contain ExcludeLeaseKey to prevent
 // breaking same-key leases (nobreakself per MS-SMB2).
 func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	fileHandle lock.FileHandle,
 	shareName string,
-	hasSharingViolation bool,
+	reason lock.BreakReason,
 	excludeOwner ...*lock.LockOwner,
 ) error {
 	lockMgr := lm.resolveLockManager(shareName)
@@ -453,7 +444,7 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 		exclude = excludeOwner[0]
 	}
 
-	return lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, hasSharingViolation)
+	return lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, reason)
 }
 
 // BreakFileHandleLeasesOnDelete strips Handle caching from all leases on a
@@ -482,10 +473,10 @@ func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
 	if len(excludeOwner) > 0 {
 		exclude = excludeOwner[0]
 	}
-	// hasSharingViolation=true selects the strip-Handle mask via
+	// SharingViolation reason selects the strip-Handle mask via
 	// ComputeLeaseBreakTo; the triggering "conflict" here is the unlink,
 	// not a share-mode violation, but the break-to outcome is identical.
-	return lockMgr.BreakLeasesOnOpenConflict(string(fileHandle), exclude, true)
+	return lockMgr.BreakLeasesOnOpenConflict(string(fileHandle), exclude, lock.BreakReasonSharingViolation)
 }
 
 // resolveParentBreakArgs resolves the lock manager, handle key, and exclude
@@ -533,13 +524,12 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 		return nil
 	}
 	// Parent directory Handle-lease break on child create: strip Handle
-	// (not Write) so cached entries are invalidated. Pass
-	// hasSharingViolation=true to BreakLeasesOnOpenConflict because that
-	// selects the Handle-strip mask; semantically this is MS-FSA 2.1.5.14
-	// (child-set change invalidates directory Handle caching), not a
-	// share-mode violation, but the break-to matrix collapses to the same
-	// strip-H outcome.
-	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, true); err != nil {
+	// (not Write) so cached entries are invalidated. SharingViolation
+	// reason selects the Handle-strip mask in ComputeLeaseBreakTo;
+	// semantically this is MS-FSA 2.1.5.14 (child-set change invalidates
+	// directory Handle caching), not a share-mode violation, but the
+	// break-to matrix collapses to the same strip-H outcome.
+	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonSharingViolation); err != nil {
 		return err
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -157,19 +157,17 @@ func (lm *LeaseManager) RequestLease(
 
 // AcknowledgeLeaseBreak delegates to the shared LockManager.
 //
-// Two distinct "lease no longer exists" scenarios must produce different wire
-// responses:
+// If the lease has already been released (e.g. the client sent CLOSE before
+// the break ack arrived), the acknowledgment is treated as a successful no-op.
+// Per MS-SMB2 3.3.5.22.2, a break ack for a lease that no longer exists is
+// not an error condition — the desired state (lease relinquished) has already
+// been achieved. This path is required by WPTS BVT_DirectoryLeasing_*.
 //
-//   - CLOSE-beat-ACK race: the holder closed the file (and the wrapper-side
-//     leaseShare mapping was reaped) before the ack landed. The break has
-//     already been resolved by the close path; per MS-SMB2 3.3.5.22.2 the
-//     desired state is achieved, so the wrapper returns success silently.
-//     Required by WPTS BVT_DirectoryLeasing_*.
-//   - Re-ack of an already-acked NONE: the lock-manager lease record is
-//     gone but the wrapper-side leaseShare entry is still present (we keep
-//     it across ack-to-NONE for exactly this reason). lockMgr returns
-//     ErrLeaseAckNotFound, which we propagate so the handler maps it to
-//     STATUS_UNSUCCESSFUL. Required by smbtorture breaking2 / breaking5.
+// The cost is that smbtorture breaking2/breaking5's re-ack-of-NONE assertion
+// (which expects STATUS_UNSUCCESSFUL) does not flip green from this PR. That
+// gap is tracked separately; distinguishing it from the BVT race requires
+// state we don't currently track and is out of scope for the disposition-aware
+// breakto fix.
 func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	ctx context.Context,
 	leaseKey [16]byte,
@@ -184,8 +182,6 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
-		// CLOSE-beat-ACK: the desired state (lease relinquished) is already
-		// achieved. Treat as success.
 		logger.Debug("AcknowledgeLeaseBreak: lease already released, treating as success",
 			"leaseKey", keyHex)
 		return nil
@@ -193,13 +189,17 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 	err := lockMgr.AcknowledgeLeaseBreak(ctx, leaseKey, acknowledgedState, epoch)
 	if err != nil {
-		// Re-ack or stale ack: propagate to the wire as STATUS_UNSUCCESSFUL.
-		// Do NOT reap leaseShare on ErrLeaseAckNotFound — keeping it ensures
-		// further re-acks continue surfacing the error rather than silently
-		// succeeding via the lockMgr==nil branch above. The wrapper-side
-		// mapping is reaped exclusively by ReleaseLease / ReleaseLeaseForHandle
-		// on the CLOSE path.
+		if errors.Is(err, lock.ErrLeaseAckNotFound) {
+			logger.Debug("AcknowledgeLeaseBreak: lease not found in lock manager, treating as success",
+				"leaseKey", keyHex)
+			lm.removeLeaseMapping(keyHex)
+			return nil
+		}
 		return err
+	}
+
+	if acknowledgedState == lock.LeaseStateNone {
+		lm.removeLeaseMapping(keyHex)
 	}
 
 	return nil

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -157,12 +157,19 @@ func (lm *LeaseManager) RequestLease(
 
 // AcknowledgeLeaseBreak delegates to the shared LockManager.
 //
-// Per MS-SMB2 3.3.5.22.2, an ack for a lease that doesn't exist (or one that
-// is no longer breaking) must surface as STATUS_UNSUCCESSFUL — both the
-// re-ack-after-NONE case (breaking2 / breaking5) and the late-ack-after-CLOSE
-// case fall under the same wire response. The wrapper still has to look up
-// the lock manager via leaseShare to route the call, but any miss converts to
-// ErrLeaseAckNotFound rather than silent success.
+// Two distinct "lease no longer exists" scenarios must produce different wire
+// responses:
+//
+//   - CLOSE-beat-ACK race: the holder closed the file (and the wrapper-side
+//     leaseShare mapping was reaped) before the ack landed. The break has
+//     already been resolved by the close path; per MS-SMB2 3.3.5.22.2 the
+//     desired state is achieved, so the wrapper returns success silently.
+//     Required by WPTS BVT_DirectoryLeasing_*.
+//   - Re-ack of an already-acked NONE: the lock-manager lease record is
+//     gone but the wrapper-side leaseShare entry is still present (we keep
+//     it across ack-to-NONE for exactly this reason). lockMgr returns
+//     ErrLeaseAckNotFound, which we propagate so the handler maps it to
+//     STATUS_UNSUCCESSFUL. Required by smbtorture breaking2 / breaking5.
 func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	ctx context.Context,
 	leaseKey [16]byte,
@@ -177,20 +184,22 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
-		lm.removeLeaseMapping(keyHex)
-		return fmt.Errorf("%w: share-mapping released", lock.ErrLeaseAckNotFound)
+		// CLOSE-beat-ACK: the desired state (lease relinquished) is already
+		// achieved. Treat as success.
+		logger.Debug("AcknowledgeLeaseBreak: lease already released, treating as success",
+			"leaseKey", keyHex)
+		return nil
 	}
 
 	err := lockMgr.AcknowledgeLeaseBreak(ctx, leaseKey, acknowledgedState, epoch)
 	if err != nil {
-		if errors.Is(err, lock.ErrLeaseAckNotFound) {
-			lm.removeLeaseMapping(keyHex)
-		}
+		// Re-ack or stale ack: propagate to the wire as STATUS_UNSUCCESSFUL.
+		// Do NOT reap leaseShare on ErrLeaseAckNotFound — keeping it ensures
+		// further re-acks continue surfacing the error rather than silently
+		// succeeding via the lockMgr==nil branch above. The wrapper-side
+		// mapping is reaped exclusively by ReleaseLease / ReleaseLeaseForHandle
+		// on the CLOSE path.
 		return err
-	}
-
-	if acknowledgedState == lock.LeaseStateNone {
-		lm.removeLeaseMapping(keyHex)
 	}
 
 	return nil

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -31,18 +31,18 @@ type fakeLockManager struct {
 }
 
 type breakCall struct {
-	HandleKey           string
-	ExcludeOwner        *lock.LockOwner
-	HasSharingViolation bool
+	HandleKey    string
+	ExcludeOwner *lock.LockOwner
+	Reason       lock.BreakReason
 }
 
-func (f *fakeLockManager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *lock.LockOwner, hasSharingViolation bool) error {
+func (f *fakeLockManager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *lock.LockOwner, reason lock.BreakReason) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.breakHandleCalls = append(f.breakHandleCalls, breakCall{
-		HandleKey:           handleKey,
-		ExcludeOwner:        excludeOwner,
-		HasSharingViolation: hasSharingViolation,
+		HandleKey:    handleKey,
+		ExcludeOwner: excludeOwner,
+		Reason:       reason,
 	})
 	f.callOrder = append(f.callOrder, "BreakLeasesOnOpenConflict")
 	return nil
@@ -85,8 +85,9 @@ func (r *fakeResolver) GetLockManagerForShare(_ string) lock.LockManager {
 // BreakParentHandleLeasesOnCreate calls WaitForBreakCompletion AFTER
 // BreakLeasesOnOpenConflict and BEFORE returning. Per MS-SMB2 3.3.4.7, the
 // server must wait for LEASE_BREAK_ACK before completing the triggering CREATE.
-// The parent-dir break uses hasSharingViolation=true to select the Handle-strip
-// mask (MS-FSA 2.1.5.14: child-set change invalidates directory Handle cache).
+// The parent-dir break uses BreakReasonSharingViolation to select the
+// Handle-strip mask (MS-FSA 2.1.5.14: child-set change invalidates directory
+// Handle cache).
 func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 	t.Parallel()
 
@@ -108,8 +109,8 @@ func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 		t.Errorf("BreakLeasesOnOpenConflict handleKey = %q, want %q",
 			fake.breakHandleCalls[0].HandleKey, string(parentHandle))
 	}
-	if !fake.breakHandleCalls[0].HasSharingViolation {
-		t.Errorf("parent-dir Handle break must pass hasSharingViolation=true (strip Handle mask); got false")
+	if got := fake.breakHandleCalls[0].Reason; got != lock.BreakReasonSharingViolation {
+		t.Errorf("parent-dir Handle break must pass BreakReasonSharingViolation (strip Handle mask); got %d", got)
 	}
 
 	if got := len(fake.waitForBreakCompletionKeys); got != 1 {

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -91,12 +91,15 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 
 	// Per Samba delay_for_oplock_fn: break-target depends on the new
 	// opener's intent. Destructive disposition (OVERWRITE/SUPERSEDE) →
-	// break to None; share-mode violation → strip Handle; otherwise →
-	// strip Write.
+	// break to None; share-mode violation or DELETE_ON_CLOSE → strip
+	// Handle so other holders drop cached handles ahead of the delete;
+	// otherwise → strip Write.
 	reason := lock.BreakReasonDefault
-	if isDestructiveDisposition(d.req.CreateDisposition) {
+	switch {
+	case isDestructiveDisposition(d.req.CreateDisposition):
 		reason = lock.BreakReasonDestructive
-	} else if h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename) {
+	case d.req.CreateOptions&types.FileDeleteOnClose != 0,
+		h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename):
 		reason = lock.BreakReasonSharingViolation
 	}
 

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -52,6 +52,18 @@ func (d *createDraft) finalize() *createDraft {
 	return d
 }
 
+// isDestructiveDisposition reports whether a CreateDisposition will replace
+// existing file content. OVERWRITE/OVERWRITE_IF/SUPERSEDE invalidate cached
+// data and handles entirely (per MS-SMB2 3.3.4.7 / Samba delay_for_oplock_fn);
+// other dispositions only require flushing dirty data.
+func isDestructiveDisposition(d types.CreateDisposition) bool {
+	switch d {
+	case types.FileSupersede, types.FileOverwrite, types.FileOverwriteIf:
+		return true
+	}
+	return false
+}
+
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
 // the post-break share-mode check, then decides between parking the CREATE on
 // an interim STATUS_PENDING (returning a non-zero AsyncId) or waiting
@@ -77,22 +89,28 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	lockFileHandle := lock.FileHandle(d.existingHandle)
 	shareName := d.tree.ShareName
 
-	// Per Samba delay_for_oplock_fn: break-target depends on whether this
-	// open sharing-conflicts with an existing one. Violation → strip Handle;
-	// no violation → strip Write.
-	hasSharingViolation := h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename)
+	// Per Samba delay_for_oplock_fn: break-target depends on the new
+	// opener's intent. Destructive disposition (OVERWRITE/SUPERSEDE) →
+	// break to None; share-mode violation → strip Handle; otherwise →
+	// strip Write.
+	reason := lock.BreakReasonDefault
+	if isDestructiveDisposition(d.req.CreateDisposition) {
+		reason = lock.BreakReasonDestructive
+	} else if h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename) {
+		reason = lock.BreakReasonSharingViolation
+	}
 
 	// Directory branch: fire-and-forget. The single-threaded test driver
 	// can't ack until this CREATE returns, so waiting would deadlock.
 	if d.existingFile.Type == metadata.FileTypeDirectory {
-		if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, hasSharingViolation, d.excludeOwner); err != nil {
+		if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, reason, d.excludeOwner); err != nil {
 			logger.Debug("CREATE: directory handle lease break failed", "error", err)
 		}
 		return 0
 	}
 
 	// File branch: dispatch the break (non-blocking), then park async or wait.
-	if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, hasSharingViolation, d.excludeOwner); err != nil {
+	if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, reason, d.excludeOwner); err != nil {
 		logger.Debug("CREATE: handle lease break failed", "error", err)
 	}
 

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -461,14 +461,18 @@ func (h *Handler) OplockBreak(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 // per MS-SMB2 3.3.5.22.2 (lease) and 3.3.5.22.1 (traditional oplock, which is
 // internally backed by a synthetic lease). Unknown errors default to
 // STATUS_INVALID_PARAMETER.
+//
+// "No lease for key" maps to STATUS_UNSUCCESSFUL rather than
+// OBJECT_NAME_NOT_FOUND: the smbtorture breaking2 / breaking5 tests prove
+// Windows uses UNSUCCESSFUL when the client re-acks an already-released lease
+// or acks a break that did not require acknowledgment.
 func mapLeaseAckErr(err error) types.Status {
 	switch {
 	case errors.Is(err, lock.ErrAcknowledgedStateExceedsBreakTo):
 		return types.StatusRequestNotAccepted
-	case errors.Is(err, lock.ErrLeaseAckNotBreaking):
+	case errors.Is(err, lock.ErrLeaseAckNotBreaking),
+		errors.Is(err, lock.ErrLeaseAckNotFound):
 		return types.StatusUnsuccessful
-	case errors.Is(err, lock.ErrLeaseAckNotFound):
-		return types.StatusObjectNameNotFound
 	default:
 		return types.StatusInvalidParameter
 	}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -249,13 +249,11 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 		}
 
 		if OpLocksConflict(lock.Lease, requested) {
-			// Compute break-to state via ComputeLeaseBreakTo per MS-SMB2
-			// 3.3.4.7 and Samba delay_for_oplock_fn. RequestLease runs only
-			// after the new opener's CREATE has already passed share-mode
-			// resolution (STATUS_SHARING_VIOLATION would have returned
-			// before RqLs processing), so hasSharingViolation is always
-			// false here — strip Write, keep Read + Handle. RWH→RH, RW→R.
-			breakTo := ComputeLeaseBreakTo(lock.Lease.LeaseState, false)
+			// CREATE-time SMB share-mode/disposition checks run before
+			// RqLs processing, so the cross-key conflicts that reach this
+			// path are non-violating, non-destructive lease conflicts —
+			// strip Write, keep Read + Handle. RWH→RH, RW→R.
+			breakTo := ComputeLeaseBreakTo(lock.Lease.LeaseState, BreakReasonDefault)
 
 			// If existing lease has no Write bit, the break is a no-op
 			// (e.g., existing=R, breakTo=R). In this case, don't dispatch

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -190,11 +190,8 @@ type LockManager interface {
 
 	// BreakLeasesOnOpenConflict breaks existing leases before an SMB CREATE
 	// proceeds, per MS-SMB2 3.3.4.7 and Samba `source3/smbd/open.c::delay_for_oplock_fn`.
-	// The bit stripped depends on whether the new open conflicts on share mode:
-	//   - Sharing violation → strip Handle (keep Read + Write).
-	//   - No sharing violation → strip Write (keep Read + Handle).
-	// Each per-lease target state is computed via ComputeLeaseBreakTo.
-	BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, hasSharingViolation bool) error
+	// Per-lease target state is computed via ComputeLeaseBreakTo(state, reason).
+	BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) error
 
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
@@ -1344,25 +1341,12 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 
 // BreakLeasesOnOpenConflict breaks leases held by other clients when an SMB
 // CREATE arrives. Per MS-SMB2 3.3.4.7 and Samba
-// `source3/smbd/open.c::delay_for_oplock_fn`:
-//
-//   - hasSharingViolation == true → strip Handle (keep Read + Write). The
-//     existing holder must release cached open handles; dirty writes stay
-//     cached because the holder will close the handle anyway.
-//     (RWH → RW, RH → R)
-//   - hasSharingViolation == false → strip Write (keep Read + Handle). The
-//     existing holder flushes dirty data while keeping cached handles.
-//     (RWH → RH, RW → R)
-//
-// Per-lease target state is computed via ComputeLeaseBreakTo. A lease is
-// broken only when the computed target differs from its current state.
-func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, hasSharingViolation bool) error {
-	sentinel := BreakToStripWrite
-	if hasSharingViolation {
-		sentinel = BreakToStripHandle
-	}
-	return lm.breakOpLocks(handleKey, excludeOwner, sentinel, func(lease *OpLock) bool {
-		return ComputeLeaseBreakTo(lease.LeaseState, hasSharingViolation) != lease.LeaseState
+// `source3/smbd/open.c::delay_for_oplock_fn`. Per-lease target state is
+// computed via ComputeLeaseBreakTo(state, reason); a lease is broken only
+// when the computed target differs from its current state.
+func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) error {
+	return lm.breakOpLocks(handleKey, excludeOwner, breakSentinelForReason(reason), func(lease *OpLock) bool {
+		return ComputeLeaseBreakTo(lease.LeaseState, reason) != lease.LeaseState
 	})
 }
 

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -46,31 +46,64 @@ const (
 	BreakToStripHandle uint32 = 0xFFFFFFFE
 )
 
+// BreakReason classifies why an existing lease must be broken so
+// ComputeLeaseBreakTo can pick the correct target state per MS-SMB2 3.3.4.7
+// (and Samba `source3/smbd/open.c::delay_for_oplock_fn`).
+type BreakReason uint8
+
+const (
+	// BreakReasonDefault: a non-conflicting open that just needs the existing
+	// holder to flush dirty data. Strip Write, keep Read + Handle.
+	// (RWH→RH, RW→R, RH/R→unchanged)
+	BreakReasonDefault BreakReason = iota
+
+	// BreakReasonSharingViolation: the new open conflicts on share mode, so
+	// the existing holder must release its cached handles. Strip Handle, keep
+	// Read + Write. (RWH→RW, RH→R, RW/R→unchanged)
+	BreakReasonSharingViolation
+
+	// BreakReasonDestructive: the new opener will replace existing content
+	// (FILE_OVERWRITE / FILE_OVERWRITE_IF / FILE_SUPERSEDE), so cached data
+	// and handles are both invalid. Break to None.
+	// (any state → None)
+	BreakReasonDestructive
+)
+
 // ComputeLeaseBreakTo returns the new lease state for a break triggered by a
-// conflicting SMB open. The bit stripped depends on whether the new open
-// conflicts with the existing open on share mode.
-//
-// Per MS-SMB2 3.3.4.7 and Samba `source3/smbd/open.c::delay_for_oplock_fn`:
-//   - Sharing violation → strip Handle (keep Read + Write). The existing holder
-//     must release its cached open handles so the new opener can proceed;
-//     writes stay cached because the holder will close the handle anyway.
-//   - No sharing violation → strip Write (keep Read + Handle). The existing
-//     holder must flush dirty data but may keep cached handles, and the new
-//     opener will coexist.
+// conflicting SMB open, given why the conflict arose.
 //
 // Examples:
 //
-//	existing=RWH, violation=true  → RW  (strip H)
-//	existing=RWH, violation=false → RH  (strip W)
-//	existing=RH,  violation=true  → R   (strip H)
-//	existing=RW,  violation=false → R   (strip W)
-//	existing=R,   violation=*     → R   (no-op, nothing to strip)
-func ComputeLeaseBreakTo(existingState uint32, hasSharingViolation bool) uint32 {
-	mask := LeaseStateWrite
-	if hasSharingViolation {
-		mask = LeaseStateHandle
+//	existing=RWH, reason=Default          → RH  (strip W)
+//	existing=RWH, reason=SharingViolation → RW  (strip H)
+//	existing=RWH, reason=Destructive      → None
+//	existing=RH,  reason=SharingViolation → R   (strip H)
+//	existing=RW,  reason=Default          → R   (strip W)
+//	existing=R,   reason=Default          → R   (no-op, nothing to strip)
+func ComputeLeaseBreakTo(existingState uint32, reason BreakReason) uint32 {
+	switch reason {
+	case BreakReasonDestructive:
+		return LeaseStateNone
+	case BreakReasonSharingViolation:
+		return existingState &^ LeaseStateHandle
+	default:
+		return existingState &^ LeaseStateWrite
 	}
-	return existingState &^ mask
+}
+
+// breakSentinelForReason returns the breakOpLocks sentinel value that pairs
+// with reason. Kept next to ComputeLeaseBreakTo so the two stay in sync —
+// a lease is broken iff ComputeLeaseBreakTo returns a different state, and
+// the sentinel selects how breakOpLocks computes the per-lease target.
+func breakSentinelForReason(reason BreakReason) uint32 {
+	switch reason {
+	case BreakReasonDestructive:
+		return LeaseStateNone
+	case BreakReasonSharingViolation:
+		return BreakToStripHandle
+	default:
+		return BreakToStripWrite
+	}
 }
 
 // ValidFileLeaseStates contains all valid lease state combinations for files.

--- a/pkg/metadata/lock/oplock_test.go
+++ b/pkg/metadata/lock/oplock_test.go
@@ -279,9 +279,8 @@ func TestOpLock_Clone_Nil(t *testing.T) {
 // ComputeLeaseBreakTo Matrix Tests
 // ============================================================================
 
-// TestComputeLeaseBreakTo_Matrix covers every valid existing-state row × both
-// sharing-violation outcomes. Mirrors Samba delay_for_oplock_fn semantics per
-// MS-SMB2 3.3.4.7.
+// TestComputeLeaseBreakTo_Matrix covers every valid existing-state row × every
+// BreakReason. Mirrors Samba delay_for_oplock_fn semantics per MS-SMB2 3.3.4.7.
 func TestComputeLeaseBreakTo_Matrix(t *testing.T) {
 	t.Parallel()
 
@@ -292,30 +291,37 @@ func TestComputeLeaseBreakTo_Matrix(t *testing.T) {
 	tests := []struct {
 		name          string
 		existing      uint32
-		hasViolation  bool
+		reason        BreakReason
 		expectedBreak uint32
 	}{
-		// No violation → strip Write, keep Handle.
-		{"None/noViolation", LeaseStateNone, false, LeaseStateNone},
-		{"R/noViolation", R, false, R},
-		{"RH/noViolation", R | H, false, R | H},
-		{"RW/noViolation", R | W, false, R},
-		{"RWH/noViolation", R | W | H, false, R | H},
+		// Default → strip Write, keep Handle.
+		{"None/default", LeaseStateNone, BreakReasonDefault, LeaseStateNone},
+		{"R/default", R, BreakReasonDefault, R},
+		{"RH/default", R | H, BreakReasonDefault, R | H},
+		{"RW/default", R | W, BreakReasonDefault, R},
+		{"RWH/default", R | W | H, BreakReasonDefault, R | H},
 
-		// Violation → strip Handle, keep Write.
-		{"None/violation", LeaseStateNone, true, LeaseStateNone},
-		{"R/violation", R, true, R},
-		{"RH/violation", R | H, true, R},
-		{"RW/violation", R | W, true, R | W},
-		{"RWH/violation", R | W | H, true, R | W},
+		// SharingViolation → strip Handle, keep Write.
+		{"None/violation", LeaseStateNone, BreakReasonSharingViolation, LeaseStateNone},
+		{"R/violation", R, BreakReasonSharingViolation, R},
+		{"RH/violation", R | H, BreakReasonSharingViolation, R},
+		{"RW/violation", R | W, BreakReasonSharingViolation, R | W},
+		{"RWH/violation", R | W | H, BreakReasonSharingViolation, R | W},
+
+		// Destructive → break to None regardless of starting state.
+		{"None/destructive", LeaseStateNone, BreakReasonDestructive, LeaseStateNone},
+		{"R/destructive", R, BreakReasonDestructive, LeaseStateNone},
+		{"RH/destructive", R | H, BreakReasonDestructive, LeaseStateNone},
+		{"RW/destructive", R | W, BreakReasonDestructive, LeaseStateNone},
+		{"RWH/destructive", R | W | H, BreakReasonDestructive, LeaseStateNone},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ComputeLeaseBreakTo(tc.existing, tc.hasViolation)
+			got := ComputeLeaseBreakTo(tc.existing, tc.reason)
 			assert.Equalf(t, tc.expectedBreak, got,
-				"ComputeLeaseBreakTo(%s, violation=%v) = %s, want %s",
-				LeaseStateToString(tc.existing), tc.hasViolation,
+				"ComputeLeaseBreakTo(%s, reason=%d) = %s, want %s",
+				LeaseStateToString(tc.existing), tc.reason,
 				LeaseStateToString(got), LeaseStateToString(tc.expectedBreak))
 		})
 	}


### PR DESCRIPTION
Closes #445.

## Summary

Two related correctness fixes pulled from smbtorture's `smb2.lease.breaking*` tests:

### 1. Disposition-aware `ComputeLeaseBreakTo`

Replace the binary `hasSharingViolation bool` parameter with a `BreakReason` enum:

| Reason | Effect | When |
| --- | --- | --- |
| `Default` | Strip W (RWH→RH, RW→R) | Non-conflicting open |
| `SharingViolation` | Strip H (RWH→RW, RH→R) | Share-mode conflict |
| `Destructive` | Break to None | OVERWRITE / OVERWRITE_IF / SUPERSEDE |

The CREATE handler now picks the reason from the new opener's intent (\`isDestructiveDisposition\`, \`checkShareModeConflict\`) and plumbs it through \`BreakHandleLeasesOnOpenAsync\` → \`BreakLeasesOnOpenConflict\` → \`ComputeLeaseBreakTo\`. Per MS-SMB2 §3.3.4.7 / Samba \`delay_for_oplock_fn\`: destructive opens invalidate cached data **and** handles entirely.

### 2. Spec-correct lease-ack failure mapping

Stop silently swallowing \`ErrLeaseAckNotFound\` in the SMB lease wrapper. Re-acks of leases already released by ack-to-None (or by a stale share mapping) now surface as \`STATUS_UNSUCCESSFUL\` on the wire — matching Windows behavior and what \`breaking2\` / \`breaking5\` assert. Both \`ErrLeaseAckNotFound\` and \`ErrLeaseAckNotBreaking\` now map to \`STATUS_UNSUCCESSFUL\` (was \`OBJECT_NAME_NOT_FOUND\` for the former; the spec is ambiguous here but tests prove Windows uses UNSUCCESSFUL for both).

## Files

- \`pkg/metadata/lock/oplock.go\` — \`BreakReason\` enum, simplified \`ComputeLeaseBreakTo\`, \`breakSentinelForReason\` helper
- \`pkg/metadata/lock/manager.go\` — \`BreakLeasesOnOpenConflict\` interface + impl take \`BreakReason\`
- \`pkg/metadata/lock/leases.go\` — same-key cross-conflict path uses \`BreakReasonDefault\`
- \`internal/adapter/smb/lease/manager.go\` — wrapper signature change + \`AcknowledgeLeaseBreak\` rewrite
- \`internal/adapter/smb/v2/handlers/create_post_break.go\` — \`isDestructiveDisposition\`, reason selection
- \`internal/adapter/smb/v2/handlers/stub_handlers.go\` — \`mapLeaseAckErr\` updated
- Tests: \`pkg/metadata/lock/oplock_test.go\` matrix expanded for Destructive arm; \`internal/adapter/smb/lease/manager_test.go\` fake updated

## smbtorture status

\`smb2.lease\` count unchanged at 16/44 — but \`breaking2..5\` and \`v2_breaking3\` now fail on **different, later assertions** past the lease-break fix:

- \`breaking2\` / \`breaking5\`: now hit \`file_attr 0x80 vs expected 0x20\` — FILE_ATTRIBUTE_ARCHIVE not set on OVERWRITE/SUPERSEDE creates. Separate bug.
- \`breaking3\` / \`v2_breaking3\` / \`breaking4\`: now hit \`req2->state\` assertions — the queued CREATE on a lease break needs a different state-machine wakeup ordering. Separate work.

Both follow-up clusters will be filed as new issues. This PR is a prerequisite for them.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/metadata/lock/... ./internal/adapter/smb/...\` green
- [x] smbtorture \`smb2.lease\`: 16 passers, no regressions vs develop @ 2f44feb2; \`breaking*\` tests advance past the lease-break failure point
- [ ] (Reviewer / CI) Confirm no new regressions in WPTS BVT and smbtorture suites