### PR TITLE
fix(smb): force FILE_ATTRIBUTE_ARCHIVE on OVERWRITE/SUPERSEDE — #448

### DIFF
--- a/internal/adapter/smb/v2/handlers/converters_test.go
+++ b/internal/adapter/smb/v2/handlers/converters_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -112,5 +113,33 @@ func TestFileAttrToSMBAttributes_Directory(t *testing.T) {
 
 	if attrs&0x10 == 0 { // FileAttributeDirectory = 0x10
 		t.Error("Directory should have Directory attribute")
+	}
+}
+
+// TestSMBModeFromAttrs_OverwriteForcesArchive locks down the contract that
+// overwriteFile relies on: per MS-FSA 2.1.5.1.2.1, OVERWRITE/SUPERSEDE always
+// sets FILE_ATTRIBUTE_ARCHIVE on the post-overwrite metadata, so the mode
+// produced from the request attrs OR'd with ARCHIVE must round-trip to a
+// FileAttr whose SMB attrs include ARCHIVE — even when the client only sent
+// FILE_ATTRIBUTE_NORMAL (the case smbtorture breaking2/breaking5 exercises).
+func TestSMBModeFromAttrs_OverwriteForcesArchive(t *testing.T) {
+	cases := []struct {
+		name    string
+		reqAttr types.FileAttributes
+	}{
+		{"client sent zero", 0},
+		{"client sent NORMAL", types.FileAttributeNormal},
+		{"client sent HIDDEN", types.FileAttributeHidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forced := tc.reqAttr | types.FileAttributeArchive
+			mode := SMBModeFromAttrs(forced, false)
+			attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode}
+			got := FileAttrToSMBAttributes(attr)
+			if got&types.FileAttributeArchive == 0 {
+				t.Errorf("ARCHIVE missing from round-trip attrs 0x%x (mode 0x%x)", got, mode)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1244,14 +1244,14 @@ func (h *Handler) overwriteFile(
 		Size: &zeroSize,
 	}
 
-	// Per MS-FSA 2.1.5.1.1: OVERWRITE/SUPERSEDE should apply FileAttributes
-	// from the request. Preserve modeDOSCompressed from existing metadata since
-	// compression state is controlled only via FSCTL_SET_COMPRESSION.
-	if req.FileAttributes != 0 {
-		mode := SMBModeFromAttrs(req.FileAttributes, existingFile.Type == metadata.FileTypeDirectory)
-		mode |= existingFile.Mode & modeDOSCompressed
-		setAttrs.Mode = &mode
-	}
+	// Per MS-FSA 2.1.5.1.2.1: OVERWRITE/SUPERSEDE forces FILE_ATTRIBUTE_ARCHIVE
+	// on the post-overwrite metadata regardless of what the client sent — the
+	// data is "needs backup" again. Apply the requested attributes plus ARCHIVE,
+	// and preserve modeDOSCompressed (controlled only via FSCTL_SET_COMPRESSION).
+	attrs := req.FileAttributes | types.FileAttributeArchive
+	mode := SMBModeFromAttrs(attrs, existingFile.Type == metadata.FileTypeDirectory)
+	mode |= existingFile.Mode & modeDOSCompressed
+	setAttrs.Mode = &mode
 
 	metaSvc := h.Registry.GetMetadataService()
 	err = metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs)


### PR DESCRIPTION
Closes #448.

## Summary

- Per MS-FSA 2.1.5.1.2.1, opening an existing file with `FILE_OVERWRITE` / `FILE_OVERWRITE_IF` / `FILE_SUPERSEDE` must mark the post-overwrite metadata with `FILE_ATTRIBUTE_ARCHIVE`, regardless of what the client sent in `CreateRequest.FileAttributes`.
- `overwriteFile` previously only updated attributes when `req.FileAttributes != 0`, and even then it took the request value verbatim — clients sending 0 or `FILE_ATTRIBUTE_NORMAL` ended up with the existing mode (often `modeDOSExplicit` set, `modeDOSArchive` clear), so the response returned `FileAttributes=0x80` (NORMAL) instead of `0x20` (ARCHIVE).
- OR `FILE_ATTRIBUTE_ARCHIVE` into the request attrs unconditionally before deriving the mode, and run the `SetFileAttributes` path for every overwrite/supersede. `modeDOSCompressed` continues to be preserved from the existing file (compression is governed only by `FSCTL_SET_COMPRESSION`).

## Expected smbtorture impact

This unblocks the `out.file_attr` assertion at `source4/torture/smb2/lease.c:2590` (breaking2) and `:3233` (breaking5). Both tests will then advance to the queued-CREATE state-machine timing failure, which is the separately-scoped #449.

## Test plan

- [x] `go test ./internal/adapter/smb/...` (new `TestSMBModeFromAttrs_OverwriteForcesArchive` covers zero / NORMAL / HIDDEN client inputs)
- [x] `go vet ./...`, `go build ./...`
- [ ] Re-run smbtorture `smb2.lease` against the branch to confirm `breaking2`/`breaking5` move past the file-attr assertion (will report failure mode that surfaces, expected to be #449).

## References

- MS-FSA §2.1.5.1.2.1 — Open of an existing file with overwrite/supersede
- MS-FSCC §2.6 — File attributes
- `source4/torture/smb2/lease.c::test_lease_breaking2` / `test_lease_breaking5`