### PR TITLE
fix(smb): progressive lease break + delay-mask park predicate — close #449

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -400,6 +400,21 @@ func (lm *LeaseManager) HasOtherBreakingLeases(fileHandle lock.FileHandle, share
 	return lockMgr.HasOtherBreakingLeases(string(fileHandle), excludeKey)
 }
 
+// AnyHolderHasLeaseBits reports whether any lease on fileHandle except
+// excludeKey currently has any bit in mask set. Non-blocking. Used by the SMB
+// CREATE post-break park decision: per Samba `delay_for_oplock_fn`, a CREATE
+// delays only when the existing holder's lease type intersects the delay_mask
+// (W for non-violation/destructive, H for sharing-violation). Without that
+// bit, the new opener proceeds inline while the holder is notified
+// asynchronously. Returns false when no LockManager is bound for the share.
+func (lm *LeaseManager) AnyHolderHasLeaseBits(fileHandle lock.FileHandle, shareName string, excludeKey [16]byte, mask uint32) bool {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return false
+	}
+	return lockMgr.AnyHolderHasLeaseBits(string(fileHandle), excludeKey, mask)
+}
+
 // WaitForOtherKeyBreaks waits on ctx for all breaks on fileHandle other than
 // excludeKey to drain. The caller controls the cancellation context — the
 // SMB CREATE async-park path passes a context whose lifetime is bound to

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -103,6 +103,29 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		reason = lock.BreakReasonSharingViolation
 	}
 
+	var waitExceptKey [16]byte
+	if d.excludeOwner != nil {
+		waitExceptKey = d.excludeOwner.ExcludeLeaseKey
+	}
+
+	// Snapshot the per-reason delay-mask intersection BEFORE dispatching.
+	// Per Samba `delay_for_oplock_fn` (source3/smbd/open.c lines 2458, 2577):
+	//   - sharing violation              → delay_mask = SMB2_LEASE_HANDLE
+	//   - non-violation (default/destr)  → delay_mask = SMB2_LEASE_WRITE
+	// A CREATE only delays for a lease break when the existing holder's lease
+	// type intersects the delay_mask. Without an intersecting bit, the break
+	// is informational and the new opener proceeds inline while the holder is
+	// notified asynchronously (smbtorture breaking4 contract). With the bit
+	// set, dirty/cached state must be flushed before the new opener can see
+	// consistent post-break state (timeout-disconnect / breaking3 contract).
+	var delayMask uint32
+	if reason == lock.BreakReasonSharingViolation {
+		delayMask = lock.LeaseStateHandle
+	} else {
+		delayMask = lock.LeaseStateWrite
+	}
+	needsParkForFlush := h.LeaseManager.AnyHolderHasLeaseBits(lockFileHandle, shareName, waitExceptKey, delayMask)
+
 	// Directory branch: fire-and-forget. The single-threaded test driver
 	// can't ack until this CREATE returns, so waiting would deadlock.
 	if d.existingFile.Type == metadata.FileTypeDirectory {
@@ -112,14 +135,17 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		return 0
 	}
 
-	// File branch: dispatch the break (non-blocking), then park async or wait.
+	// File branch: dispatch the break (non-blocking), then decide between
+	// inline completion (no W to flush), async park, or sync wait.
 	if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, reason, d.excludeOwner); err != nil {
 		logger.Debug("CREATE: handle lease break failed", "error", err)
 	}
 
-	var waitExceptKey [16]byte
-	if d.excludeOwner != nil {
-		waitExceptKey = d.excludeOwner.ExcludeLeaseKey
+	// No conflicting holder has the W bit ⇒ no flush required. Let the CREATE
+	// complete inline. The break notification still went out so the holder
+	// invalidates its caches; we just don't block on its ACK.
+	if !needsParkForFlush {
+		return 0
 	}
 
 	// Async park is only safe when this CREATE is the last op in its message

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -141,9 +141,10 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		logger.Debug("CREATE: handle lease break failed", "error", err)
 	}
 
-	// No conflicting holder has the W bit ⇒ no flush required. Let the CREATE
-	// complete inline. The break notification still went out so the holder
-	// invalidates its caches; we just don't block on its ACK.
+	// No conflicting holder intersects the per-reason delay_mask (W for
+	// non-violation/destructive, H for sharing-violation) ⇒ no wait needed.
+	// Let the CREATE complete inline. The break notification still went out
+	// so the holder invalidates its caches; we just don't block on its ACK.
 	if !needsParkForFlush {
 		return 0
 	}

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -149,6 +149,7 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 		if lock.Lease != nil && lock.Lease.IsDirectory && !lock.Lease.Breaking {
 			lock.Lease.Breaking = true
 			lock.Lease.BreakToState = LeaseStateNone
+			lock.Lease.BreakingToRequired = LeaseStateNone
 			lock.Lease.BreakStarted = time.Now()
 			advanceEpoch(lock.Lease)
 			leasesToBreak = append(leasesToBreak, lock)

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -102,6 +102,16 @@ func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int)
 	return "", nil, -1
 }
 
+// removeLeaseAtLocked deletes the lease at index idx from unifiedLocks[handleKey],
+// removing the bucket entirely when it becomes empty. Caller must hold lm.mu.
+func (lm *Manager) removeLeaseAtLocked(handleKey string, idx int) {
+	locks := lm.unifiedLocks[handleKey]
+	lm.unifiedLocks[handleKey] = append(locks[:idx], locks[idx+1:]...)
+	if len(lm.unifiedLocks[handleKey]) == 0 {
+		delete(lm.unifiedLocks, handleKey)
+	}
+}
+
 // RequestLease requests a new or upgraded lease on a file or directory.
 //
 // For new leases, the granted state may be less than requested if conflicts exist.
@@ -126,12 +136,34 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 		return LeaseStateNone, 0, ErrInvalidLeaseState
 	}
 
-	// None is always granted trivially
+	handleKey := string(fileHandle)
+
+	// LeaseStateNone probe: clients (and smbtorture breaking4) issue empty-state
+	// requests to query the current lease without taking new caching rights. If
+	// a same-key lease is already in Breaking state, surface ErrLeaseBreakInProgress
+	// so the CREATE response carries SMB2_LEASE_FLAG_BREAK_IN_PROGRESS with the
+	// pre-break LeaseState. Otherwise grant trivially.
 	if requestedState == LeaseStateNone {
+		lm.mu.Lock()
+		for _, lock := range lm.unifiedLocks[handleKey] {
+			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
+				continue
+			}
+			if lock.Lease.Breaking {
+				currentState := lock.Lease.LeaseState
+				epoch := lock.Lease.Epoch
+				lm.mu.Unlock()
+				logger.Debug("RequestLease: None-probe on breaking same-key lease, surfacing break-in-progress",
+					"fileHandle", handleKey,
+					"currentState", LeaseStateToString(currentState),
+					"epoch", epoch)
+				return currentState, epoch, ErrLeaseBreakInProgress
+			}
+			break
+		}
+		lm.mu.Unlock()
 		return LeaseStateNone, 0, nil
 	}
-
-	handleKey := string(fileHandle)
 
 	// Check recently-broken cache for directories
 	if isDirectory && lm.recentlyBroken != nil && lm.recentlyBroken.IsRecentlyBroken(handleKey) {
@@ -278,6 +310,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 			// Mark lease as breaking before dispatching callbacks
 			lock.Lease.Breaking = true
 			lock.Lease.BreakToState = breakTo
+			lock.Lease.BreakingToRequired = breakTo
 			lock.Lease.BreakStarted = time.Now()
 			advanceEpoch(lock.Lease)
 
@@ -516,11 +549,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	// If acknowledging to None, remove the lease entirely
 	if acknowledgedState == LeaseStateNone {
-		locks := lm.unifiedLocks[handleKey]
-		lm.unifiedLocks[handleKey] = append(locks[:idx], locks[idx+1:]...)
-		if len(lm.unifiedLocks[handleKey]) == 0 {
-			delete(lm.unifiedLocks, handleKey)
-		}
+		lm.removeLeaseAtLocked(handleKey, idx)
 
 		// Remove from persistent store
 		if lm.lockStore != nil {
@@ -544,6 +573,71 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	// Update lock type based on new state
 	lock.Type = lockTypeForLeaseState(acknowledgedState)
+
+	// Progressive multi-stage break: if the cumulative final target
+	// (BreakingToRequired) is stricter than what the client just
+	// acknowledged, dispatch the next stage. Mirrors Samba
+	// `downgrade_lease` (source3/smbd/smb2_oplock.c lines 569-586): if the
+	// acked state still has W or H, the next target keeps R as an
+	// intermediate; otherwise drop straight to the cumulative required.
+	//
+	// This produces the smbtorture breaking3 / v2_breaking3 wire shape:
+	//   ack RWH→RH  ⇒ next target = R  ⇒ wire: RH→R
+	//   ack RH→R    ⇒ next target = 0  ⇒ wire: R→""
+	if acknowledgedState != LeaseStateNone &&
+		acknowledgedState&^lock.Lease.BreakingToRequired != 0 {
+		nextTarget := nextProgressiveBreakTarget(acknowledgedState, lock.Lease.BreakingToRequired)
+		snapshot, removed := lm.applyBreakStageLocked(lock, nextTarget)
+		if removed {
+			lm.removeLeaseAtLocked(handleKey, idx)
+		}
+
+		// Persist the next-stage state BEFORE releasing lm.mu so the durable
+		// store reflects Breaking=true / BreakToState=nextTarget. Otherwise a
+		// crash between the ACK-clear (Breaking=false written above) and the
+		// next-stage-set would lose the second progressive stage on restart,
+		// leaving parked CREATEs to wait until the scanner timeout.
+		if !removed && lm.lockStore != nil {
+			pl := ToPersistedLock(lock, 0)
+			_ = lm.lockStore.PutLock(ctx, pl)
+		}
+
+		logger.Debug("AcknowledgeLeaseBreak: progressive break next stage",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"ackedState", LeaseStateToString(acknowledgedState),
+			"required", LeaseStateToString(lock.Lease.BreakingToRequired),
+			"nextTarget", LeaseStateToString(nextTarget),
+			"epoch", lock.Lease.Epoch)
+
+		// Release lm.mu before dispatching to avoid deadlock with the
+		// SMB transport callback (mirrors breakOpLocks pattern).
+		lm.mu.Unlock()
+		lm.dispatchOpLockBreak(handleKey, snapshot, nextTarget)
+		lm.mu.Lock()
+
+		// Re-validate: a concurrent CLOSE / release / timeout could have
+		// removed the lease during the dispatch window. The `lock` pointer
+		// may now reference an orphaned UnifiedLock — read fields off the
+		// re-found record (or signal waiters and return when gone).
+		_, currentLock, _ := lm.findLeaseByKey(leaseKey)
+		if currentLock == nil {
+			lm.signalBreakWaitLocked(handleKey)
+			return nil
+		}
+
+		// Do NOT signal waiters: the break is still in progress (or just
+		// completed inline via fire-and-forget downgrade, in which case
+		// the inline path already updated state and the next stage will
+		// not arrive — fall through and signal once we've fully drained).
+		if removed || nextTarget == currentLock.Lease.LeaseState {
+			lm.signalBreakWaitLocked(handleKey)
+		}
+		return nil
+	}
+
+	// Reached BreakingToRequired (or full release): mirror invariant
+	// "BreakingToRequired == LeaseState when not Breaking" and signal.
+	lock.Lease.BreakingToRequired = acknowledgedState
 
 	// Persist updated state
 	if lm.lockStore != nil {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -610,10 +610,16 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 			"epoch", lock.Lease.Epoch)
 
 		// Release lm.mu before dispatching to avoid deadlock with the
-		// SMB transport callback (mirrors breakOpLocks pattern).
-		lm.mu.Unlock()
-		lm.dispatchOpLockBreak(handleKey, snapshot, nextTarget)
-		lm.mu.Lock()
+		// SMB transport callback (mirrors breakOpLocks pattern). Wrap in a
+		// closure with a deferred re-Lock so the surrounding function's
+		// `defer lm.mu.Unlock()` always sees the mutex held — without this,
+		// a panic inside dispatchOpLockBreak would unwind through an
+		// unlocked mutex and the outer defer would double-unlock.
+		func() {
+			lm.mu.Unlock()
+			defer lm.mu.Lock()
+			lm.dispatchOpLockBreak(handleKey, snapshot, nextTarget)
+		}()
 
 		// Re-validate: a concurrent CLOSE / release / timeout could have
 		// removed the lease during the dispatch window. The `lock` pointer

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -344,6 +345,7 @@ func TestAcknowledgeLeaseBreak_ToReadState(t *testing.T) {
 			if lock.Lease != nil && lock.Lease.LeaseKey == key1 {
 				lock.Lease.Breaking = true
 				lock.Lease.BreakToState = LeaseStateRead
+				lock.Lease.BreakingToRequired = LeaseStateRead
 				lock.Lease.BreakStarted = time.Now()
 			}
 		}
@@ -601,6 +603,7 @@ func setBreaking(t *testing.T, mgr *Manager, key [16]byte, breakTo uint32) {
 			if lock.Lease != nil && lock.Lease.LeaseKey == key {
 				lock.Lease.Breaking = true
 				lock.Lease.BreakToState = breakTo
+				lock.Lease.BreakingToRequired = breakTo
 				lock.Lease.BreakStarted = time.Now()
 				advanceEpoch(lock.Lease) // matches RequestLease at leases.go:256
 				return
@@ -970,4 +973,260 @@ func TestRequestLease_CrossKeyConflict_DoesNotBlockOnAck(t *testing.T) {
 			"this is the WPTS BVT_DirectoryLeasing_LeaseBreakOnMultiClients "+
 			"deadlock. breakCalled=%v", breakCalled.Load())
 	}
+}
+
+// ============================================================================
+// Progressive multi-stage lease-break tests (issue #449)
+// ============================================================================
+//
+// These exercise the smbtorture smb2.lease.breaking3 / v2_breaking3 wire
+// shape: when a fresh break is in flight and a stricter conflicting open
+// arrives, the cumulative final target (BreakingToRequired) is AND-merged
+// without dispatching a new notification; on each subsequent ACK the
+// next progressive stage is dispatched (RH→R then R→"") until LeaseState
+// reaches BreakingToRequired.
+
+// recordBreakNotifications collects break-to states in order, returning a
+// callback registration suitable for testBreakCallbacks.
+func recordBreakNotifications() (cb *testBreakCallbacks, breaks *[]uint32, mu *sync.Mutex) {
+	var muLocal sync.Mutex
+	var seen []uint32
+	cb = &testBreakCallbacks{
+		onOpLockBreak: func(_ string, _ *UnifiedLock, breakToState uint32) {
+			muLocal.Lock()
+			seen = append(seen, breakToState)
+			muLocal.Unlock()
+		},
+	}
+	return cb, &seen, &muLocal
+}
+
+func snapshotBreaks(mu *sync.Mutex, breaks *[]uint32) []uint32 {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]uint32, len(*breaks))
+	copy(out, *breaks)
+	return out
+}
+
+// TestProgressiveLeaseBreak_RWH_AndMerge_ToNone exercises the breaking3 wire
+// shape end-to-end: RWH lease, default opener (strip W), then a destructive
+// opener AND-merges the cumulative target down to None. Each ACK drives the
+// next progressive stage; req2/req3-equivalent waiters are tracked via
+// signalBreakWait and only released when LeaseState reaches BreakingToRequired.
+func TestProgressiveLeaseBreak_RWH_AndMerge_ToNone(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	cb, breaks, breakMu := recordBreakNotifications()
+	mgr.RegisterBreakCallbacks(cb)
+
+	ctx := context.Background()
+	key1 := [16]byte{0xA1}
+	handleKey := "file-449"
+
+	// Grant RWH directly to seed the test (skip RequestLease's grant path
+	// which itself doesn't trigger breaks on first grant anyway).
+	_, _, err := mgr.RequestLease(ctx, FileHandle(handleKey), key1, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// Stage 1: a default opener arrives (strip W). RWH→RH dispatched.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-default", ClientID: "client-default",
+	}, BreakReasonDefault))
+
+	got := snapshotBreaks(breakMu, breaks)
+	require.Len(t, got, 1, "stage 1: exactly one notification dispatched")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, got[0],
+		"stage 1: RWH→RH (strip W)")
+
+	// Lease should now be Breaking with BreakToState=RH and BreakingToRequired=RH.
+	mgr.mu.Lock()
+	_, lock, _ := mgr.findLeaseByKey(key1)
+	require.NotNil(t, lock)
+	assert.True(t, lock.Lease.Breaking)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, lock.Lease.BreakToState)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, lock.Lease.BreakingToRequired)
+	mgr.mu.Unlock()
+
+	// Stage 2: a destructive opener arrives mid-stage → AND-merge.
+	// BreakingToRequired = RH & 0 = 0. No new notification.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-destr", ClientID: "client-destr",
+	}, BreakReasonDestructive))
+
+	got = snapshotBreaks(breakMu, breaks)
+	require.Len(t, got, 1, "stage 2: AND-merge must NOT dispatch a new notification")
+
+	mgr.mu.Lock()
+	_, lock, _ = mgr.findLeaseByKey(key1)
+	require.NotNil(t, lock)
+	assert.Equal(t, uint32(0), lock.Lease.BreakingToRequired,
+		"AND-merge must tighten BreakingToRequired to 0 (None)")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, lock.Lease.BreakToState,
+		"BreakToState (in-flight) is unchanged by AND-merge")
+	mgr.mu.Unlock()
+
+	// Stage 3: client ACKs RWH→RH. Re-eval finds acked state has H bit ⇒
+	// next target = required(0) | R = R. Dispatch RH→R.
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx,
+		key1, LeaseStateRead|LeaseStateHandle, 0))
+
+	got = snapshotBreaks(breakMu, breaks)
+	require.Len(t, got, 2, "stage 3: ACK RWH→RH triggers RH→R notification")
+	assert.Equal(t, LeaseStateRead, got[1], "stage 3: target = R")
+
+	mgr.mu.Lock()
+	_, lock, _ = mgr.findLeaseByKey(key1)
+	require.NotNil(t, lock)
+	assert.True(t, lock.Lease.Breaking,
+		"lease still Breaking after partial ACK with stricter required")
+	assert.Equal(t, LeaseStateRead, lock.Lease.BreakToState)
+	assert.Equal(t, uint32(0), lock.Lease.BreakingToRequired)
+	mgr.mu.Unlock()
+
+	// Stage 4: client ACKs RH→R. Re-eval finds acked state has neither W nor
+	// H ⇒ next target = required(0) = 0. Dispatch R→"" (fire-and-forget,
+	// inline downgrade). Lease removed.
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead, 0))
+
+	got = snapshotBreaks(breakMu, breaks)
+	require.Len(t, got, 3, "stage 4: ACK RH→R triggers R→\"\" notification")
+	assert.Equal(t, LeaseStateNone, got[2], "stage 4: target = None")
+
+	_, _, found := mgr.GetLeaseState(ctx, key1)
+	assert.False(t, found, "stage 4: lease removed after final stage")
+}
+
+// TestProgressiveLeaseBreak_NoSpuriousAfterReachingRequired confirms that a
+// single-shot break (no concurrent AND-merge) does NOT trigger a second
+// progressive stage when the client ACKs to the offered state. This is the
+// breaking4-style invariant — fresh dispatch stays single-shot.
+func TestProgressiveLeaseBreak_NoSpuriousAfterReachingRequired(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	cb, breaks, breakMu := recordBreakNotifications()
+	mgr.RegisterBreakCallbacks(cb)
+
+	ctx := context.Background()
+	key1 := [16]byte{0xB1}
+	handleKey := "file-449-noprog"
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle(handleKey), key1, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-default", ClientID: "client-default",
+	}, BreakReasonDefault))
+	require.Len(t, snapshotBreaks(breakMu, breaks), 1)
+
+	// Client ACKs to the offered state. No concurrent break has tightened
+	// BreakingToRequired ⇒ no second stage dispatched.
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx,
+		key1, LeaseStateRead|LeaseStateHandle, 0))
+
+	assert.Len(t, snapshotBreaks(breakMu, breaks), 1,
+		"single-shot break must not trigger a second progressive stage")
+
+	mgr.mu.Lock()
+	_, lock, _ := mgr.findLeaseByKey(key1)
+	require.NotNil(t, lock)
+	assert.False(t, lock.Lease.Breaking, "Breaking cleared after final ACK")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, lock.Lease.LeaseState)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, lock.Lease.BreakingToRequired,
+		"BreakingToRequired equals LeaseState when not Breaking (invariant)")
+	mgr.mu.Unlock()
+}
+
+// TestForceCompleteBreaks_DrainsToBreakingToRequired confirms that a non-acking
+// client triggers the timeout path which drains to the cumulative final
+// target, not the in-flight intermediate. Otherwise a non-ack would leave
+// the lease parked at e.g. RH when a later destructive opener had AND-merged
+// the target down to None.
+func TestForceCompleteBreaks_DrainsToBreakingToRequired(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	cb, _, _ := recordBreakNotifications()
+	mgr.RegisterBreakCallbacks(cb)
+
+	ctx := context.Background()
+	key1 := [16]byte{0xC1}
+	handleKey := "file-449-force"
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle(handleKey), key1, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// First break: RWH→RH (BreakingToRequired=RH).
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-default", ClientID: "client-default",
+	}, BreakReasonDefault))
+
+	// AND-merge tighter target: BreakingToRequired=0.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-destr", ClientID: "client-destr",
+	}, BreakReasonDestructive))
+
+	// Force-complete should drain to BreakingToRequired (= 0), removing the
+	// lease entirely. Pre-fix this drained to BreakToState (= RH), leaving
+	// the lease at RH which would block the destructive opener.
+	mgr.forceCompleteBreaks(handleKey)
+
+	_, _, found := mgr.GetLeaseState(ctx, key1)
+	assert.False(t, found, "force-complete must drain to None (BreakingToRequired), not RH (BreakToState)")
+}
+
+// TestAnyHolderHasLeaseBits covers the cross-key per-bit query that gates the
+// SMB CREATE post-break park decision (#449). Mirrors Samba `delay_for_oplock_fn`:
+//   - sharing violation              → mask = HANDLE (park if any holder has H)
+//   - non-violation/default/destruct → mask = WRITE  (park if any holder has W)
+func TestAnyHolderHasLeaseBits(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	keyRH := [16]byte{0xD1}
+	keyRW := [16]byte{0xD2}
+	keyR := [16]byte{0xD3}
+
+	// Empty: no holders.
+	assert.False(t, mgr.AnyHolderHasLeaseBits("absent", [16]byte{}, LeaseStateWrite))
+
+	// Grant RH (no W). W-mask must report false; H-mask must report true.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("h-rh"), keyRH, [16]byte{},
+		"o1", "c1", "/share", LeaseStateRead|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.False(t, mgr.AnyHolderHasLeaseBits("h-rh", [16]byte{}, LeaseStateWrite),
+		"RH lease has no W ⇒ W-mask reports false (breaking4: no flush, no park)")
+	assert.True(t, mgr.AnyHolderHasLeaseBits("h-rh", [16]byte{}, LeaseStateHandle),
+		"RH lease has H ⇒ H-mask reports true (sharing-violation: must park)")
+
+	// Grant RW. W-mask reports true.
+	_, _, err = mgr.RequestLease(ctx, FileHandle("h-rw"), keyRW, [16]byte{},
+		"o2", "c2", "/share", LeaseStateRead|LeaseStateWrite, false)
+	require.NoError(t, err)
+	assert.True(t, mgr.AnyHolderHasLeaseBits("h-rw", [16]byte{}, LeaseStateWrite),
+		"RW lease has W ⇒ W-mask reports true")
+
+	// Exclusion: same key excluded ⇒ false.
+	assert.False(t, mgr.AnyHolderHasLeaseBits("h-rw", keyRW, LeaseStateWrite),
+		"excluding the only W holder must report false")
+
+	// Empty mask is a no-op short-circuit.
+	assert.False(t, mgr.AnyHolderHasLeaseBits("h-rw", [16]byte{}, 0))
+
+	// Multiple R-only holders: neither W nor H mask matches.
+	_, _, err = mgr.RequestLease(ctx, FileHandle("h-mixed"), keyR, [16]byte{},
+		"o3", "c3", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	keyMix := [16]byte{0xD4}
+	_, _, err = mgr.RequestLease(ctx, FileHandle("h-mixed"), keyMix, [16]byte{},
+		"o4", "c4", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	assert.False(t, mgr.AnyHolderHasLeaseBits("h-mixed", [16]byte{}, LeaseStateWrite))
+	assert.False(t, mgr.AnyHolderHasLeaseBits("h-mixed", [16]byte{}, LeaseStateHandle))
 }

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -219,6 +219,17 @@ type LockManager interface {
 	// interim and resumes from a goroutine. Zero exceptKey means "match any".
 	HasOtherBreakingLeases(handleKey string, exceptKey [16]byte) bool
 
+	// AnyHolderHasLeaseBits reports whether any lease on handleKey (excluding
+	// exceptKey) currently has any bit in mask set. Non-blocking peek used by
+	// the SMB CREATE post-break park decision: per Samba `delay_for_oplock_fn`
+	// (source3/smbd/open.c line 2458), a CREATE delays only if the existing
+	// holder's lease type intersects the delay_mask, where:
+	//   - sharing violation         → mask = SMB2_LEASE_HANDLE
+	//   - non-violation (default,
+	//     overwrite, destructive)   → mask = SMB2_LEASE_WRITE
+	// Zero exceptKey means "match any".
+	AnyHolderHasLeaseBits(handleKey string, exceptKey [16]byte, mask uint32) bool
+
 	// ========================================================================
 	// Break Callbacks
 	// ========================================================================
@@ -1421,6 +1432,32 @@ func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKe
 	}
 }
 
+// AnyHolderHasLeaseBits reports whether any lease on handleKey (other than
+// exceptKey) currently has any bit in mask set. Non-blocking. Used by the SMB
+// CREATE post-break park decision per Samba `delay_for_oplock_fn`: a new opener
+// only needs to wait for the in-flight break ACK when the existing holder's
+// lease type intersects the delay_mask. Zero exceptKey means "no exclusion".
+func (lm *Manager) AnyHolderHasLeaseBits(handleKey string, exceptKey [16]byte, mask uint32) bool {
+	if mask == 0 {
+		return false
+	}
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	hasExclusion := exceptKey != ([16]byte{})
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease == nil {
+			continue
+		}
+		if hasExclusion && l.Lease.LeaseKey == exceptKey {
+			continue
+		}
+		if l.Lease.LeaseState&mask != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // HasOtherBreakingLeases reports whether any lease (other than exceptKey) or
 // any delegation on handleKey is currently Breaking. Non-blocking. Used by the
 // SMB CREATE async-park path to decide whether to emit STATUS_PENDING and
@@ -1492,8 +1529,9 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 }
 
 // forceCompleteBreaks auto-downgrades all breaking leases on a file to their
-// BreakToState, as if the client had acknowledged. Called when the break
-// wait times out. Leases breaking to None are removed entirely.
+// cumulative final target, as if the client had acknowledged every progressive
+// stage. Called when the break wait times out. Leases whose final target is
+// None are removed entirely.
 func (lm *Manager) forceCompleteBreaks(handleKey string) {
 	lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
 }
@@ -1501,6 +1539,12 @@ func (lm *Manager) forceCompleteBreaks(handleKey string) {
 // forceCompleteBreaksExceptKey is forceCompleteBreaks that leaves any lease
 // keyed on exceptKey untouched. Zero exceptKey means "no exclusion" (same
 // semantics as forceCompleteBreaks).
+//
+// Drains to BreakingToRequired (the cumulative final target across any
+// concurrent breaks that AND-merged during the in-flight stage) rather than
+// the in-flight BreakToState — otherwise a non-acking client could leave the
+// lease parked at an intermediate state that the post-ACK re-eval would
+// normally have progressed past.
 func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]byte) {
 	lm.mu.Lock()
 	locks := lm.unifiedLocks[handleKey]
@@ -1510,7 +1554,8 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 	for _, l := range locks {
 		if l.Lease != nil && l.Lease.Breaking && l.Lease.LeaseKey != exceptKey {
 			modified = true
-			if l.Lease.BreakToState == LeaseStateNone {
+			finalTarget := l.Lease.BreakingToRequired
+			if finalTarget == LeaseStateNone {
 				if lm.lockStore != nil {
 					_ = lm.lockStore.DeleteLock(context.Background(), l.ID)
 				}
@@ -1519,7 +1564,8 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 					"leaseKey", fmt.Sprintf("%x", l.Lease.LeaseKey))
 				continue
 			}
-			l.Lease.LeaseState = l.Lease.BreakToState
+			l.Lease.LeaseState = finalTarget
+			l.Lease.BreakingToRequired = finalTarget
 			l.Lease.Breaking = false
 			l.Lease.BreakToState = 0
 			l.Lease.BreakStarted = time.Time{}
@@ -1573,6 +1619,13 @@ func (lm *Manager) signalBreakWaitLocked(handleKey string) {
 // breakToState is the target state for the break. Pass BreakToStripWrite
 // to compute the per-lease break-to state by stripping the Write bit from
 // each lease's current state (preserving Read and Handle).
+//
+// Concurrent-break behavior: when a lease is already Breaking, the new
+// target is AND-merged into BreakingToRequired (cumulative final target)
+// without dispatching a new notification or advancing the epoch. This
+// mirrors Samba `process_oplock_break_message` lines 956-965; the next
+// progressive stage is dispatched from acknowledgeLeaseBreakImpl after the
+// in-flight ACK arrives.
 func (lm *Manager) breakOpLocks(
 	handleKey string,
 	excludeOwner *LockOwner,
@@ -1609,52 +1662,38 @@ func (lm *Manager) breakOpLocks(
 				continue
 			}
 		}
-		if lock.Lease.Breaking || !shouldBreak(lock.Lease) {
+		if !shouldBreak(lock.Lease) {
 			kept = append(kept, lock)
 			continue
 		}
 
-		targetState := breakToState
-		switch targetState {
-		case BreakToStripWrite:
-			// Per MS-SMB2 3.3.5.9: RWH -> RH, RW -> R.
-			targetState = lock.Lease.LeaseState &^ LeaseStateWrite
-		case BreakToStripHandle:
-			// Per MS-SMB2 3.3.5.9 Step 10: RWH -> RW, RH -> R.
-			targetState = lock.Lease.LeaseState &^ LeaseStateHandle
-		}
+		targetState := computeFreshTarget(lock.Lease.LeaseState, breakToState)
 
-		// Per MS-SMB2 3.3.4.7, a break is ack-required iff the current state
-		// is NOT pure Read. Without ACK_REQUIRED the client never responds,
-		// so leaving Breaking=true would block same-key reopens (nobreakself)
-		// until forceCompleteBreaks fires — downgrade inline for those cases.
-		ackRequired := lock.Lease.LeaseState != LeaseStateRead
-
-		// Advance the lease epoch on the live record first so the snapshot
-		// that feeds dispatchOpLockBreak carries the new epoch (NewEpoch per
-		// MS-SMB2 2.2.23.2), then snapshot while LeaseState still holds the
-		// pre-break value for the notification's CurrentLeaseState field.
-		advanceEpoch(lock.Lease)
-		snapshot := lock.Clone()
-
-		switch {
-		case ackRequired:
-			lock.Lease.Breaking = true
-			lock.Lease.BreakToState = targetState
-			lock.Lease.BreakStarted = time.Now()
-			kept = append(kept, lock)
-		case targetState == LeaseStateNone:
-			if lm.lockStore != nil {
-				_ = lm.lockStore.DeleteLock(context.Background(), lock.ID)
-			}
-			removed = true
-		default:
-			lock.Lease.LeaseState = targetState
-			lock.Type = lockTypeForLeaseState(targetState)
+		if lock.Lease.Breaking {
+			// Concurrent break: AND-merge the new opener's target into the
+			// cumulative final target. No notification, no epoch bump
+			// (Samba intentionally skips the bump per its inline comment).
+			// The next progressive stage will be dispatched on ACK.
+			lock.Lease.BreakingToRequired &= targetState
 			if lm.lockStore != nil {
 				pl := ToPersistedLock(lock, 0)
 				_ = lm.lockStore.PutLock(context.Background(), pl)
 			}
+			kept = append(kept, lock)
+			continue
+		}
+
+		// Fresh dispatch: BreakingToRequired starts at this opener's target.
+		// Subsequent concurrent breaks may tighten it via the AND-merge above.
+		// Advance the epoch here so the dispatched notification's NewEpoch is
+		// pre-bumped (per MS-SMB2 2.2.23.2). Post-ACK progressive stages do
+		// NOT advance — the multi-stage progression is one logical break.
+		lock.Lease.BreakingToRequired = targetState
+		advanceEpoch(lock.Lease)
+		snapshot, wasRemoved := lm.applyBreakStageLocked(lock, targetState)
+		if wasRemoved {
+			removed = true
+		} else {
 			kept = append(kept, lock)
 		}
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
@@ -1673,6 +1712,72 @@ func (lm *Manager) breakOpLocks(
 	}
 
 	return nil
+}
+
+// computeFreshTarget resolves a breakOpLocks sentinel against the current
+// lease state, returning the actual per-lease target. Direct state values
+// pass through unchanged.
+func computeFreshTarget(currentState, sentinel uint32) uint32 {
+	switch sentinel {
+	case BreakToStripWrite:
+		// Per MS-SMB2 3.3.5.9: RWH -> RH, RW -> R.
+		return currentState &^ LeaseStateWrite
+	case BreakToStripHandle:
+		// Per MS-SMB2 3.3.5.9 Step 10: RWH -> RW, RH -> R.
+		return currentState &^ LeaseStateHandle
+	}
+	return sentinel
+}
+
+// applyBreakStageLocked performs a single break stage on lock targeting
+// `target`. Caller must hold lm.mu, must have already set
+// lock.Lease.BreakingToRequired appropriately, and is responsible for
+// dispatching the returned snapshot via dispatchOpLockBreak after releasing
+// lm.mu.
+//
+// Returns the snapshot (always non-nil) and a removed flag that's true when
+// the lease was deleted from unifiedLocks (target == None and !ackRequired).
+//
+// Per MS-SMB2 3.3.4.7, a break is ack-required iff the current state is NOT
+// pure Read. Without ACK_REQUIRED the client never responds, so leaving
+// Breaking=true would block same-key reopens — instead we resolve inline.
+func (lm *Manager) applyBreakStageLocked(lock *UnifiedLock, target uint32) (*UnifiedLock, bool) {
+	ackRequired := lock.Lease.LeaseState != LeaseStateRead
+
+	// Snapshot while LeaseState still holds the pre-break value for
+	// CurrentLeaseState in the notification. Caller is responsible for
+	// advancing the epoch on fresh dispatch (per MS-SMB2 2.2.23.2). Progressive
+	// next-stage dispatch from a post-ACK re-eval does NOT advance epoch — the
+	// multi-stage break is one continuous progression and Samba's
+	// `downgrade_lease` (source3/smbd/smb2_oplock.c line 607) reuses the
+	// existing epoch unchanged for each intermediate stage.
+	snapshot := lock.Clone()
+
+	if ackRequired {
+		lock.Lease.Breaking = true
+		lock.Lease.BreakToState = target
+		lock.Lease.BreakStarted = time.Now()
+		return snapshot, false
+	}
+
+	// Fire-and-forget downgrade: client won't ACK (current state is pure R).
+	lock.Lease.Breaking = false
+	lock.Lease.BreakToState = 0
+	lock.Lease.BreakStarted = time.Time{}
+	if target == LeaseStateNone {
+		if lm.lockStore != nil {
+			_ = lm.lockStore.DeleteLock(context.Background(), lock.ID)
+		}
+		return snapshot, true
+	}
+	lock.Lease.LeaseState = target
+	lock.Lease.BreakingToRequired = target
+	lock.Type = lockTypeForLeaseState(target)
+	if lm.lockStore != nil {
+		pl := ToPersistedLock(lock, 0)
+		_ = lm.lockStore.PutLock(context.Background(), pl)
+	}
+	return snapshot, false
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1695,6 +1695,16 @@ func (lm *Manager) breakOpLocks(
 			removed = true
 		} else {
 			kept = append(kept, lock)
+			// Persist the in-flight Breaking state so a crash/restart
+			// preserves the break-in-progress and parked CREATEs aren't
+			// stranded waiting for a notification that was already sent
+			// over the wire. applyBreakStageLocked only persists the
+			// fire-and-forget downgrade path; the ack-required path
+			// (which is the common case) is persisted here.
+			if lm.lockStore != nil {
+				pl := ToPersistedLock(lock, 0)
+				_ = lm.lockStore.PutLock(context.Background(), pl)
+			}
 		}
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
 	}

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -153,9 +153,21 @@ type OpLock struct {
 	// Use HasRead(), HasWrite(), HasHandle() to check individual flags.
 	LeaseState uint32
 
-	// BreakToState is the target state during an active break.
-	// Zero if no break is in progress.
+	// BreakToState is the target state of the IN-FLIGHT break notification
+	// (Samba `breaking_to_requested`). Zero if no break is in progress. Used
+	// to validate ACKs: an ACK that claims state outside this mask is rejected
+	// with STATUS_REQUEST_NOT_ACCEPTED. May be a multi-stage intermediate
+	// (e.g. RH→R while the cumulative final target is None).
 	BreakToState uint32
+
+	// BreakingToRequired is the cumulative FINAL break-to target across all
+	// conflicting opens that arrived while this lease was Breaking (Samba
+	// `breaking_to_required`, source3/smbd/smb2_oplock.c). May be stricter
+	// (smaller bitmask) than BreakToState. On each ACK, if LeaseState still
+	// has bits beyond BreakingToRequired, the next progressive stage is
+	// dispatched via nextProgressiveBreakTarget. Zero only when there is no
+	// active break or when the target is full release.
+	BreakingToRequired uint32
 
 	// Breaking indicates a lease break is in progress awaiting acknowledgment.
 	// When true, the client has been notified and must acknowledge.
@@ -258,16 +270,35 @@ func (l *OpLock) Clone() *OpLock {
 		return nil
 	}
 	return &OpLock{
-		LeaseKey:       l.LeaseKey, // Fixed-size array, copied by value
-		LeaseState:     l.LeaseState,
-		BreakToState:   l.BreakToState,
-		Breaking:       l.Breaking,
-		Epoch:          l.Epoch,
-		BreakStarted:   l.BreakStarted,
-		Reclaim:        l.Reclaim,
-		ParentLeaseKey: l.ParentLeaseKey, // Fixed-size array, copied by value
-		IsDirectory:    l.IsDirectory,
+		LeaseKey:           l.LeaseKey, // Fixed-size array, copied by value
+		LeaseState:         l.LeaseState,
+		BreakToState:       l.BreakToState,
+		BreakingToRequired: l.BreakingToRequired,
+		Breaking:           l.Breaking,
+		Epoch:              l.Epoch,
+		BreakStarted:       l.BreakStarted,
+		Reclaim:            l.Reclaim,
+		ParentLeaseKey:     l.ParentLeaseKey, // Fixed-size array, copied by value
+		IsDirectory:        l.IsDirectory,
 	}
+}
+
+// nextProgressiveBreakTarget computes the next break-to target after a client
+// has acknowledged a partial break. Mirrors Samba's behavior in
+// source3/smbd/smb2_oplock.c::downgrade_lease lines 569-586: when the
+// acknowledged state still has W or H, the next stage keeps R as an
+// intermediate; otherwise drop straight to required.
+//
+// Produces the wire sequence smbtorture asserts for breaking3/v2_breaking3:
+//
+//	ack RWH→RH (has H)  → next = required(0) | R = R   ⇒ wire: RH→R
+//	ack RH→R   (no W/H) → next = required(0)            ⇒ wire: R→""
+func nextProgressiveBreakTarget(ackedState, required uint32) uint32 {
+	next := required
+	if ackedState&(LeaseStateWrite|LeaseStateHandle) != 0 {
+		next |= LeaseStateRead
+	}
+	return next
 }
 
 // OpLocksConflict checks if two leases on the same file conflict.
@@ -286,10 +317,14 @@ func OpLocksConflict(existing, requested *OpLock) bool {
 		return false
 	}
 
-	// If existing lease is breaking, treat as having BreakToState
+	// If existing lease is breaking, treat as having its cumulative final
+	// target (BreakingToRequired) rather than the in-flight intermediate
+	// (BreakToState). Otherwise a same-handle reopen arriving mid-stage
+	// could re-dispatch a redundant strip-W against an RH that is heading
+	// to None.
 	existingState := existing.LeaseState
 	if existing.Breaking {
-		existingState = existing.BreakToState
+		existingState = existing.BreakingToRequired
 	}
 
 	// Check Write conflicts

--- a/pkg/metadata/lock/oplock_test.go
+++ b/pkg/metadata/lock/oplock_test.go
@@ -387,19 +387,21 @@ func TestOpLocksConflict_BreakingLease(t *testing.T) {
 	key1 := [16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	key2 := [16]byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
-	// Breaking lease - should use BreakToState for conflict check
+	// Breaking lease — conflict check uses BreakingToRequired (cumulative final
+	// target) rather than BreakToState (in-flight intermediate). Otherwise a
+	// concurrent reopen mid-stage could re-evaluate against the wrong target.
 	existing := &OpLock{
-		LeaseKey:     key1,
-		LeaseState:   LeaseStateRead | LeaseStateWrite, // Currently has RW
-		BreakToState: LeaseStateRead,                   // Breaking to R
-		Breaking:     true,
+		LeaseKey:           key1,
+		LeaseState:         LeaseStateRead | LeaseStateWrite, // Currently has RW
+		BreakToState:       LeaseStateRead,                   // In-flight target R
+		BreakingToRequired: LeaseStateRead,                   // Cumulative final R
+		Breaking:           true,
 	}
 	requested := &OpLock{LeaseKey: key2, LeaseState: LeaseStateRead | LeaseStateWrite}
 
-	// After break completes, existing will be R only - no conflict with new RW
-	// But during break, we use BreakToState (R) for conflict check
-	// R doesn't conflict with RW request's Read component, but RW request has Write
-	// which conflicts with any existing read (need exclusive)
+	// After break completes, existing will be R only — no conflict with new RW's
+	// Read component, but the requested RW has Write which conflicts with any
+	// existing Read (Write requires exclusive).
 	assert.True(t, OpLocksConflict(existing, requested), "Write request conflicts with Read lease")
 }
 
@@ -608,4 +610,39 @@ func TestIsUnifiedLockConflicting_SameOwner(t *testing.T) {
 
 	// Same owner - never conflicts
 	assert.False(t, IsUnifiedLockConflicting(lock1, lock2))
+}
+
+// TestNextProgressiveBreakTarget_Matrix verifies the helper that drives the
+// post-ACK progressive lease-break dispatcher (#449). Mirrors Samba
+// `downgrade_lease` (source3/smbd/smb2_oplock.c lines 569-586): when the
+// acknowledged state still has W or H, the next stage keeps R as an
+// intermediate; otherwise drop straight to required.
+func TestNextProgressiveBreakTarget_Matrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ackedState uint32
+		required   uint32
+		want       uint32
+	}{
+		// breaking3 wire shape: required = 0 throughout the multi-stage drain.
+		{"ack RH→R intermediate (acked has H)", LeaseStateRead | LeaseStateHandle, 0, LeaseStateRead},
+		{"ack R→\"\" final stage (acked is pure R)", LeaseStateRead, 0, 0},
+		// Acked state still has W: keep R as intermediate.
+		{"ack RW→R intermediate (acked has W)", LeaseStateRead | LeaseStateWrite, 0, LeaseStateRead},
+		{"ack RWH→R intermediate (acked has both)", LeaseStateRead | LeaseStateWrite | LeaseStateHandle, 0, LeaseStateRead},
+		// Required=R: acked above R passes through, acked at R returns R.
+		{"required=R, acked=RH → R", LeaseStateRead | LeaseStateHandle, LeaseStateRead, LeaseStateRead},
+		{"required=R, acked=R → R", LeaseStateRead, LeaseStateRead, LeaseStateRead},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextProgressiveBreakTarget(tc.ackedState, tc.required)
+			assert.Equal(t, tc.want, got,
+				"acked=%s required=%s",
+				LeaseStateToString(tc.ackedState),
+				LeaseStateToString(tc.required))
+		})
+	}
 }

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -83,7 +83,9 @@ type PersistedLock struct {
 	// BreakingToRequired is the cumulative final break-to target
 	// (Samba `breaking_to_required`). May be stricter than BreakToState
 	// when concurrent breaks AND-merged a tighter target during an
-	// in-flight stage. 0 if no break in progress.
+	// in-flight stage. Note that 0 is also a valid final target
+	// (break-to None lease state), so callers must consult Breaking
+	// and/or BreakToState to distinguish that from "no break in progress".
 	BreakingToRequired uint32 `json:"breaking_to_required,omitempty"`
 
 	// Breaking indicates a lease break is in progress awaiting acknowledgment.
@@ -390,6 +392,20 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 			ParentLeaseKey:     parentLeaseKey,
 			IsDirectory:        pl.IsDirectory,
 			// BreakStarted is runtime-only, not persisted
+		}
+		// Backwards compat: locks persisted before BreakingToRequired existed
+		// have BreakingToRequired==0. The zero value is ambiguous (could mean
+		// "break-to None" for an active break, or "no break" otherwise).
+		// Restore the invariant: when not breaking, BreakingToRequired tracks
+		// LeaseState; when breaking, it defaults to BreakToState (the in-flight
+		// target) since older records didn't track a stricter cumulative
+		// target.
+		if el.Lease.BreakingToRequired == 0 {
+			if el.Lease.Breaking {
+				el.Lease.BreakingToRequired = el.Lease.BreakToState
+			} else {
+				el.Lease.BreakingToRequired = el.Lease.LeaseState
+			}
 		}
 	}
 

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -75,9 +75,16 @@ type PersistedLock struct {
 	// 0 for byte-range locks.
 	LeaseEpoch uint16 `json:"lease_epoch,omitempty"`
 
-	// BreakToState is the target state during an active lease break.
+	// BreakToState is the in-flight notification's break-to target
+	// (Samba `breaking_to_requested`). Used for ACK validation.
 	// 0 if no break in progress.
 	BreakToState uint32 `json:"break_to_state,omitempty"`
+
+	// BreakingToRequired is the cumulative final break-to target
+	// (Samba `breaking_to_required`). May be stricter than BreakToState
+	// when concurrent breaks AND-merged a tighter target during an
+	// in-flight stage. 0 if no break in progress.
+	BreakingToRequired uint32 `json:"breaking_to_required,omitempty"`
 
 	// Breaking indicates a lease break is in progress awaiting acknowledgment.
 	// False for byte-range locks.
@@ -311,6 +318,7 @@ func ToPersistedLock(lock *UnifiedLock, epoch uint64) *PersistedLock {
 		pl.LeaseState = lock.Lease.LeaseState
 		pl.LeaseEpoch = lock.Lease.Epoch
 		pl.BreakToState = lock.Lease.BreakToState
+		pl.BreakingToRequired = lock.Lease.BreakingToRequired
 		pl.Breaking = lock.Lease.Breaking
 		pl.IsDirectory = lock.Lease.IsDirectory
 
@@ -373,13 +381,14 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 		}
 
 		el.Lease = &OpLock{
-			LeaseKey:       leaseKey,
-			LeaseState:     pl.LeaseState,
-			Epoch:          pl.LeaseEpoch,
-			BreakToState:   pl.BreakToState,
-			Breaking:       pl.Breaking,
-			ParentLeaseKey: parentLeaseKey,
-			IsDirectory:    pl.IsDirectory,
+			LeaseKey:           leaseKey,
+			LeaseState:         pl.LeaseState,
+			Epoch:              pl.LeaseEpoch,
+			BreakToState:       pl.BreakToState,
+			BreakingToRequired: pl.BreakingToRequired,
+			Breaking:           pl.Breaking,
+			ParentLeaseKey:     parentLeaseKey,
+			IsDirectory:        pl.IsDirectory,
 			// BreakStarted is runtime-only, not persisted
 		}
 	}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -511,20 +511,16 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.multibreak | Leases | Multi-client lease break not fully working | #429 |
 | smb2.lease.breaking1 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.breaking2 | Leases | Lease breaking state handling not fully working | #429 |
-| smb2.lease.breaking3 | Leases | Lease breaking state handling not fully working | #429 |
-| smb2.lease.breaking4 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.breaking5 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.breaking6 | Leases | Lease breaking state handling not fully working | #429 |
 | smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
 | smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
 | smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
-| smb2.lease.timeout-disconnect | Leases | Lease timeout on disconnect not fully working | #429 |
 | smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
 | smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | #429 |
 | smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
 | smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
 | smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
-| smb2.lease.v2_breaking3 | Leases V2 | Lease V2 breaking state handling not fully working | #429 |
 | smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | #429 |
 | smb2.lease.v2_epoch2 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |
 | smb2.lease.v2_epoch3 | Leases V2 | Lease V2 epoch tracking not fully working | #429 |


### PR DESCRIPTION
## Summary

Closes #449. Two distinct bugs in the SMB lease-break state machine, both rooted in the lock manager:

- **breaking4** (DittoFS over-parks): a CREATE was parked for any in-flight break, regardless of whether the holder had the Write (or Handle) bit. Per Samba `delay_for_oplock_fn` (`source3/smbd/open.c:2458`, `:2577`), park iff existing lease intersects `delay_mask` (W for non-violation/destructive, H for sharing-violation).

- **breaking3 / v2_breaking3** (DittoFS unparks too early; no progressive multi-stage breaks): the lock manager dispatched one notification per break and never re-evaluated after the ACK. The wire contract is three sequential notifications (`RWH→RH → RH→R → R→""`), each ack-required, with parked CREATEs releasing only after the final ACK.

## Changes

### Commit 1 — lock manager: progressive break + cumulative target tracking

- New `OpLock.BreakingToRequired` (mirrors Samba `breaking_to_required`); existing `BreakToState` plays Samba `breaking_to_requested` role (in-flight target, ACK validation). Persisted in `PersistedLock` for restart safety.
- `breakOpLocks` AND-merges concurrent breaks into `BreakingToRequired` without a new notification or epoch bump (matches `process_oplock_break_message` lines 956–965; Samba intentionally skips the bump).
- `acknowledgeLeaseBreakImpl` re-evaluates after each ACK: if the acked state still has bits beyond `BreakingToRequired`, dispatch the next stage. Strip rule mirrors `downgrade_lease` lines 569–586 — keep R as intermediate iff acked state still has W or H, else go straight to required.
- `applyBreakStageLocked` factors out the per-stage mutate-and-snapshot logic shared by fresh dispatch and post-ACK re-eval. Fresh dispatch advances epoch; progressive stages do not (one logical break = one epoch bump, per Samba).
- `forceCompleteBreaksExceptKey` drains to `BreakingToRequired` so a non-acking client doesn't park the lease at an intermediate.
- `OpLocksConflict` reads `BreakingToRequired` (final target) when Breaking, not `BreakToState` (in-flight intermediate).
- Empty-state lease probe surfaces `ErrLeaseBreakInProgress` when a same-key lease is mid-break (breaking4 line 3110 contract: `CHECK_LEASE(io3, "RH", true, LEASE1, BREAK_IN_PROGRESS)`).
- Progressive next stage persists `Breaking=true` + `BreakToState=nextTarget` before releasing `lm.mu`, and re-validates the lease after re-locking (concurrent CLOSE during dispatch window otherwise risks a hung waiter).

### Commit 2 — SMB handler: delay-mask park predicate

- `LockManager.AnyHolderHasLeaseBits(handleKey, exceptKey, mask)` returns whether any non-excluded lease has the requested bits set.
- `LeaseManager` wrapper forwards to the per-share lock manager.
- `breakAndMaybeParkCreate` computes `delayMask` from `BreakReason` (SharingViolation → H, default/destructive → W) and queries `AnyHolderHasLeaseBits` BEFORE the break dispatch. If the intersection is empty, the CREATE proceeds inline.

## smbtorture results

Verified locally against the `memory` profile:

| test | before | after |
|---|---|---|
| `smb2.lease.breaking3` | FAIL | **PASS** |
| `smb2.lease.v2_breaking3` | FAIL | **PASS** |
| `smb2.lease.breaking4` | FAIL | **PASS** |
| `smb2.lease.timeout-disconnect` | FAIL | **PASS** |
| `smb2.lease.breaking1` | PASS | PASS |
| `smb2.lease.breaking6` | PASS | PASS |
| `smb2.lease.nobreakself` | PASS | PASS |
| `smb2.lease.statopen2` | PASS | PASS |
| `smb2.lease.complex1` | PASS | PASS |
| `smb2.lease.initial_delete_tdis` | PASS | PASS |

`KNOWN_FAILURES.md`: removed `breaking3`, `breaking4`, `v2_breaking3`, `timeout-disconnect`.

## Test plan

- [x] `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...` — all green
- [x] `go test -race ./...` — full suite green
- [x] New unit tests:
  - `TestProgressiveLeaseBreak_RWH_AndMerge_ToNone` — full breaking3 wire shape
  - `TestProgressiveLeaseBreak_NoSpuriousAfterReachingRequired` — single-shot break stays single-shot
  - `TestForceCompleteBreaks_DrainsToBreakingToRequired` — timeout drains to cumulative target
  - `TestAnyHolderHasLeaseBits` — H/W mask coverage
  - `TestNextProgressiveBreakTarget_Matrix` — Samba R-as-intermediate rule
- [x] smbtorture `smb2.lease.{breaking3,v2_breaking3,breaking4,timeout-disconnect}` — PASS
- [x] No regressions in spot-checked previously-passing lease tests
- [x] go vet, gofmt clean
- [ ] CI: WPTS BVT directory-leasing suite (must remain green; CLOSE-beat-ACK silent success path from #447 untouched)
- [ ] CI: NFS regression — lock manager change touches the shared `signalBreakWaitLocked` path; no semantic change to delegation, but verify

## Spec / reference

- MS-SMB2 §3.3.4.7 — Object Store Lease Break Algorithm
- MS-SMB2 §2.2.23.2 — NewEpoch on break notification
- Samba `source3/smbd/open.c::delay_for_oplock_fn` — delay_mask predicate
- Samba `source3/smbd/smb2_oplock.c::downgrade_lease` — progressive next-stage target rule
- Samba `source3/smbd/smb2_oplock.c::process_oplock_break_message` — concurrent-break AND-merge

## Plan / investigation

- `.planning/debug/449-queued-create-state-machine.md` — investigation
- `.planning/debug/449-fix-plan.md` — fix design (refined post-Samba-source review)