### PR TITLE
fix(smb): reject cross-file lease key reuse with INVALID_PARAMETER (#429)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -299,7 +299,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				file.Type == metadata.FileTypeDirectory,
 			)
 			if err != nil {
-				if errors.Is(err, lock.ErrInvalidLeaseState) {
+				if errors.Is(err, lock.ErrInvalidLeaseState) || errors.Is(err, lock.ErrLeaseKeyInUse) {
 					return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
 				}
 				logger.Debug("CREATE: lease context processing failed", "error", err)

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -300,6 +300,20 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			)
 			if err != nil {
 				if errors.Is(err, lock.ErrInvalidLeaseState) || errors.Is(err, lock.ErrLeaseKeyInUse) {
+					// Roll back the open we already performed at Step 7. Without
+					// this, a CREATE_NEW that fails the lease_match check leaves
+					// an orphaned inode in the metadata store with no handle
+					// referencing it. Samba's open path closes the fd on
+					// lease_match failure for the same reason. Rollback only
+					// applies to FileCreated; FileOpened reuses an existing
+					// file we did not create, and FileOverwritten/FileSuperseded
+					// would lose user data — leave those intact.
+					if createAction == types.FileCreated {
+						if _, delErr := metaSvc.RemoveFile(authCtx, parentHandle, baseName); delErr != nil {
+							logger.Warn("CREATE: failed to roll back orphaned file after lease rejection",
+								"name", baseName, "error", delErr)
+						}
+					}
 					return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
 				}
 				logger.Debug("CREATE: lease context processing failed", "error", err)

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -300,23 +300,38 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			)
 			if err != nil {
 				if errors.Is(err, lock.ErrInvalidLeaseState) || errors.Is(err, lock.ErrLeaseKeyInUse) {
-					// Roll back the open we already performed at Step 7. Without
-					// this, a CREATE_NEW that fails the lease_match check leaves
-					// an orphaned inode in the metadata store with no handle
-					// referencing it. Samba's open path closes the fd on
-					// lease_match failure for the same reason. Rollback only
-					// applies to FileCreated; FileOpened reuses an existing
-					// file we did not create, and FileOverwritten/FileSuperseded
-					// would lose user data — leave those intact.
-					if createAction == types.FileCreated {
+					// Step 7 already executed the open. The cleanup here depends
+					// on what that open did:
+					//   - FileCreated: roll back the orphan inode so a CREATE_NEW
+					//     that failed lease_match doesn't leave a metadata entry
+					//     no client can reach. Samba's open path closes the fd
+					//     for the same reason.
+					//   - FileOverwritten / FileSuperseded: the prior file's
+					//     content was already truncated. Returning
+					//     STATUS_INVALID_PARAMETER would tell the client the
+					//     CREATE failed while the data is gone — unrecoverable.
+					//     Complete the CREATE with no lease instead; the data
+					//     loss is committed, but the client at least gets a
+					//     working handle.
+					//   - FileOpened: nothing destructive happened, fail safely.
+					switch createAction {
+					case types.FileCreated:
 						if _, delErr := metaSvc.RemoveFile(authCtx, parentHandle, baseName); delErr != nil {
 							logger.Warn("CREATE: failed to roll back orphaned file after lease rejection",
 								"name", baseName, "error", delErr)
 						}
+						return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
+					case types.FileOverwritten, types.FileSuperseded:
+						logger.Warn("CREATE: lease request rejected after destructive open; completing CREATE without lease",
+							"name", baseName, "createAction", createAction, "error", err)
+						leaseResponse = nil
+						grantedOplock = OplockLevelNone
+					default:
+						return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
 					}
-					return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
+				} else {
+					logger.Debug("CREATE: lease context processing failed", "error", err)
 				}
-				logger.Debug("CREATE: lease context processing failed", "error", err)
 			}
 			if leaseResponse != nil {
 				grantedOplock = OplockLevelLease

--- a/internal/adapter/smb/v2/handlers/lease_context.go
+++ b/internal/adapter/smb/v2/handlers/lease_context.go
@@ -373,10 +373,12 @@ func ProcessLeaseCreateContext(
 	var responseFlags uint32
 	if errors.Is(err, lock.ErrLeaseBreakInProgress) {
 		responseFlags = smbenc.LeaseResponseFlagBreakInProgress
-	} else if errors.Is(err, lock.ErrInvalidLeaseState) {
-		// Per MS-SMB2 3.3.5.9.8: Invalid lease states (e.g., Write without
-		// Read, Handle without Read) must fail the CREATE with
-		// STATUS_INVALID_PARAMETER. Propagate the error to the caller.
+	} else if errors.Is(err, lock.ErrInvalidLeaseState) || errors.Is(err, lock.ErrLeaseKeyInUse) {
+		// Per MS-SMB2 3.3.5.9.8: Invalid lease states (Write without Read,
+		// Handle without Read) and a lease key already bound to another file
+		// (Samba lease_match) must fail the CREATE with
+		// STATUS_INVALID_PARAMETER. Propagate the error to the caller, which
+		// short-circuits before any open is granted.
 		return nil, err
 	} else if err != nil {
 		logger.Debug("ProcessLeaseCreateContext: lease request failed", "error", err)

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -49,6 +49,13 @@ var ErrLeaseAckNotFound = errors.New("no lease for key")
 // Per MS-SMB2 3.3.5.22.2, the caller must return STATUS_UNSUCCESSFUL.
 var ErrLeaseAckNotBreaking = errors.New("lease not in breaking state")
 
+// ErrLeaseKeyInUse is returned by RequestLease when the supplied lease key is
+// already bound to a record on a different file (different handleKey bucket).
+// Per MS-SMB2 3.3.5.9.8 and Samba's source3/smbd/smb2_lease.c::lease_match,
+// a lease key MUST be unique across files for a given client; reusing a key
+// across files MUST fail with STATUS_INVALID_PARAMETER.
+var ErrLeaseKeyInUse = errors.New("lease key already in use on another file")
+
 // validUpgrades defines allowed lease state upgrade transitions.
 // A lease can only be upgraded (more permissions), never downgraded via RequestLease.
 // Downgrade happens only through lease break.
@@ -114,6 +121,25 @@ func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int)
 	return "", nil, -1
 }
 
+// hasLeaseKeyOnOtherFile reports whether leaseKey is bound to a lease record
+// on a handleKey other than excludeHandleKey. Lease records persisted at
+// LeaseState=None after ack-to-None still count as bound: per MS-SMB2
+// 3.3.5.9.8 the binding lasts until CLOSE removes the record.
+// Must be called with lm.mu held (read or write).
+func (lm *Manager) hasLeaseKeyOnOtherFile(leaseKey [16]byte, excludeHandleKey string) bool {
+	for handleKey, locks := range lm.unifiedLocks {
+		if handleKey == excludeHandleKey {
+			continue
+		}
+		for _, lock := range locks {
+			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // RequestLease requests a new or upgraded lease on a file or directory.
 //
 // For new leases, the granted state may be less than requested if conflicts exist.
@@ -139,6 +165,25 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 	}
 
 	handleKey := string(fileHandle)
+
+	// Cross-file lease key uniqueness (MS-SMB2 3.3.5.9.8 / Samba lease_match).
+	// A lease key bound to a record on a different file MUST fail the request
+	// with STATUS_INVALID_PARAMETER. Applied uniformly to probe and grant paths
+	// before any other reject path so the error never gets masked by a silent
+	// deny (NLM conflict, recently-broken cache, downgrade-no-op, etc.).
+	// Same-file reopen (h1a/h1b in smbtorture breaking2) is preserved because
+	// it lands in the same handleKey bucket; ack-to-None records persist on
+	// the original handleKey until CLOSE and still count as bindings here.
+	lm.mu.RLock()
+	conflict := lm.hasLeaseKeyOnOtherFile(leaseKey, handleKey)
+	lm.mu.RUnlock()
+	if conflict {
+		logger.Debug("RequestLease: lease key already bound to another file",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"fileHandle", handleKey,
+			"requestedState", LeaseStateToString(requestedState))
+		return LeaseStateNone, 0, ErrLeaseKeyInUse
+	}
 
 	// LeaseStateNone probe: clients (and smbtorture breaking4 / upgrade2)
 	// issue empty-state requests to query the current lease without taking

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -122,19 +122,30 @@ func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int)
 }
 
 // hasLeaseKeyOnOtherFile reports whether leaseKey is bound to a lease record
-// on a handleKey other than excludeHandleKey. Lease records persisted at
-// LeaseState=None after ack-to-None still count as bound: per MS-SMB2
-// 3.3.5.9.8 the binding lasts until CLOSE removes the record.
+// owned by clientID on a handleKey other than excludeHandleKey. Lease records
+// persisted at LeaseState=None after ack-to-None still count as bound: per
+// MS-SMB2 3.3.5.9.8 the binding lasts until CLOSE removes the record.
+//
+// Lease key uniqueness is per-(ClientGuid, LeaseKey) — two unrelated clients
+// may legitimately reuse the same numeric LeaseKey on different files
+// (smbtorture's fixed LEASE1/LEASE2 macros across separate connections, for
+// example). The clientID filter prevents a foreign client's binding from
+// causing a spurious INVALID_PARAMETER on the requesting client's CREATE.
+//
 // Must be called with lm.mu held (read or write).
-func (lm *Manager) hasLeaseKeyOnOtherFile(leaseKey [16]byte, excludeHandleKey string) bool {
+func (lm *Manager) hasLeaseKeyOnOtherFile(leaseKey [16]byte, excludeHandleKey, clientID string) bool {
 	for handleKey, locks := range lm.unifiedLocks {
 		if handleKey == excludeHandleKey {
 			continue
 		}
 		for _, lock := range locks {
-			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
-				return true
+			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
+				continue
 			}
+			if lock.Owner.ClientID != clientID {
+				continue
+			}
+			return true
 		}
 	}
 	return false
@@ -165,25 +176,6 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 	}
 
 	handleKey := string(fileHandle)
-
-	// Cross-file lease key uniqueness (MS-SMB2 3.3.5.9.8 / Samba lease_match).
-	// A lease key bound to a record on a different file MUST fail the request
-	// with STATUS_INVALID_PARAMETER. Applied uniformly to probe and grant paths
-	// before any other reject path so the error never gets masked by a silent
-	// deny (NLM conflict, recently-broken cache, downgrade-no-op, etc.).
-	// Same-file reopen (h1a/h1b in smbtorture breaking2) is preserved because
-	// it lands in the same handleKey bucket; ack-to-None records persist on
-	// the original handleKey until CLOSE and still count as bindings here.
-	lm.mu.RLock()
-	conflict := lm.hasLeaseKeyOnOtherFile(leaseKey, handleKey)
-	lm.mu.RUnlock()
-	if conflict {
-		logger.Debug("RequestLease: lease key already bound to another file",
-			"leaseKey", fmt.Sprintf("%x", leaseKey),
-			"fileHandle", handleKey,
-			"requestedState", LeaseStateToString(requestedState))
-		return LeaseStateNone, 0, ErrLeaseKeyInUse
-	}
 
 	// LeaseStateNone probe: clients (and smbtorture breaking4 / upgrade2)
 	// issue empty-state requests to query the current lease without taking
@@ -233,6 +225,31 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 	}
 
 	lm.mu.Lock()
+
+	// Cross-(client, file) lease key uniqueness (MS-SMB2 3.3.5.9.8 / Samba
+	// lease_match in source3/smbd/smb2_lease.c). A lease key bound by THIS
+	// CLIENT to a record on a different file MUST fail the request with
+	// STATUS_INVALID_PARAMETER. The check runs inside the write lock so that
+	// uniqueness and grant are atomic — a downgrade-then-Lock split would
+	// open a TOCTOU window where a concurrent CLOSE turns the rejection into
+	// a false-positive, and where two parallel grants on different files
+	// could both observe "no conflict" and create duplicate records.
+	//
+	// Skipped on None probes: zero-state requests are pure state queries that
+	// cannot acquire caching rights and are not subject to lease_match.
+	// Same-file reopen (h1a/h1b in smbtorture breaking2) lands in the same
+	// handleKey bucket and is allowed; ack-to-None records persisted under
+	// the original handleKey still count as bindings here (handle-bound
+	// lifetime, PR #452).
+	if requestedState != LeaseStateNone && lm.hasLeaseKeyOnOtherFile(leaseKey, handleKey, clientID) {
+		lm.mu.Unlock()
+		logger.Debug("RequestLease: lease key already bound to another file for this client",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"fileHandle", handleKey,
+			"clientID", clientID,
+			"requestedState", LeaseStateToString(requestedState))
+		return LeaseStateNone, 0, ErrLeaseKeyInUse
+	}
 
 	locks := lm.unifiedLocks[handleKey]
 

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -126,11 +126,17 @@ func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int)
 // persisted at LeaseState=None after ack-to-None still count as bound: per
 // MS-SMB2 3.3.5.9.8 the binding lasts until CLOSE removes the record.
 //
-// Lease key uniqueness is per-(ClientGuid, LeaseKey) — two unrelated clients
-// may legitimately reuse the same numeric LeaseKey on different files
-// (smbtorture's fixed LEASE1/LEASE2 macros across separate connections, for
-// example). The clientID filter prevents a foreign client's binding from
-// causing a spurious INVALID_PARAMETER on the requesting client's CREATE.
+// Spec scoping is per-(ClientGuid, LeaseKey). The SMB adapter currently
+// derives clientID from the per-session SessionID ("smb:%d"), not the
+// negotiated SMB ClientGuid, so the rejection fires across opens within a
+// single session but NOT across sessions of the same ClientGuid (e.g.
+// multichannel binds, where two channels of the same client get distinct
+// session IDs). This matches the repo's existing ClientID concept (used by
+// NLM lock conflict detection and lock owner tracking) and is sufficient
+// for the smbtorture single-session duplicate_create / duplicate_open
+// cases. Tightening to true ClientGuid scoping is tracked under the
+// multichannel Phase 2 work (#361) where ClientGuid threading is needed
+// for cross-channel break fan-out anyway.
 //
 // Must be called with lm.mu held (read or write).
 func (lm *Manager) hasLeaseKeyOnOtherFile(leaseKey [16]byte, excludeHandleKey, clientID string) bool {

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -277,6 +277,94 @@ func TestRequestLease_InvalidFileState(t *testing.T) {
 	assert.Equal(t, LeaseStateNone, state, "Write alone should be invalid")
 }
 
+// TestRequestLease_DuplicateKeyDifferentFile_Rejected: per MS-SMB2 3.3.5.9.8 /
+// Samba lease_match, a lease key bound to a record on file1 must NOT be
+// grantable on file2. Covers smbtorture smb2.lease.duplicate_create.
+func TestRequestLease_DuplicateKeyDifferentFile_Rejected(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+	parentKey := [16]byte{}
+
+	// Grant LEASE1 on file1.
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
+
+	// Same key on file2 must be rejected.
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.ErrorIs(t, err, ErrLeaseKeyInUse)
+	assert.Equal(t, LeaseStateNone, state)
+
+	// None probe on file2 with the same key must also reject (key is bound
+	// elsewhere, no matter the requested state).
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateNone, false)
+	require.ErrorIs(t, err, ErrLeaseKeyInUse)
+	assert.Equal(t, LeaseStateNone, state)
+}
+
+// TestRequestLease_DuplicateKey_AfterFile1Released_Allowed: once file1's lease
+// record is released (handle CLOSE), the same key MUST be grantable on file2.
+func TestRequestLease_DuplicateKey_AfterFile1Released_Allowed(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	leaseKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	parentKey := [16]byte{}
+
+	// Grant LEASE1 on file1, then release the record (CLOSE).
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "file1", leaseKey))
+
+	// Same key on file2 should now succeed.
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
+}
+
+// TestRequestLease_SameKeySameFile_StillWorks: same key on the same file is a
+// reopen / upgrade, not a cross-file violation. Regression guard for
+// smbtorture breaking2 / breaking4 / nobreakself.
+func TestRequestLease_SameKeySameFile_StillWorks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	leaseKey := [16]byte{0x11, 0x22}
+	parentKey := [16]byte{}
+
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"owner1", "client1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead, state)
+
+	// Same key, same file, upgrade R → RH.
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
+
+	// Same key, same file, no-op (same state).
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
+}
+
 // ============================================================================
 // AcknowledgeLeaseBreak Tests
 // ============================================================================
@@ -474,25 +562,29 @@ func TestReleaseLease_NonexistentKey(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestReleaseLeaseForHandle_ScopedToSingleBucket covers the fix in 249fd668:
-// smbtorture reuses fixed LEASE1/LEASE2 keys across tests, so the same
-// LeaseKey can live under two distinct handleKey buckets at the same time.
-// Releasing one bucket must not erase the other — otherwise stale records
-// accumulate on the surviving file and break ACK lookup.
+// TestReleaseLeaseForHandle_ScopedToSingleBucket: ReleaseLeaseForHandle must
+// only touch the handleKey it is given — releasing fileA must not delete or
+// alter records on fileB. Originally written for the smbtorture cross-test
+// key-reuse scenario (fix 249fd668). After round 3 closed cross-file lease
+// keys (ErrLeaseKeyInUse, MS-SMB2 3.3.5.9.8), the bucket scoping invariant is
+// still required: keys may be reused across files only after the previous
+// holder's CLOSE, and the per-handle release path must not cascade. Use two
+// distinct keys to set up the multi-bucket state legitimately.
 func TestReleaseLeaseForHandle_ScopedToSingleBucket(t *testing.T) {
 	t.Parallel()
 
 	mgr := NewManager()
 	ctx := context.Background()
-	leaseKey := [16]byte{1, 2, 3}
+	keyA := [16]byte{1, 2, 3}
+	keyB := [16]byte{4, 5, 6}
 
-	_, _, err := mgr.RequestLease(ctx, FileHandle("/share:fileA"), leaseKey, [16]byte{}, "ownerA", "client", "/share", LeaseStateRead, false)
+	_, _, err := mgr.RequestLease(ctx, FileHandle("/share:fileA"), keyA, [16]byte{}, "ownerA", "client", "/share", LeaseStateRead, false)
 	require.NoError(t, err)
-	_, _, err = mgr.RequestLease(ctx, FileHandle("/share:fileB"), leaseKey, [16]byte{}, "ownerB", "client", "/share", LeaseStateRead, false)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("/share:fileB"), keyB, [16]byte{}, "ownerB", "client", "/share", LeaseStateRead, false)
 	require.NoError(t, err)
 
-	// Release only fileA's bucket.
-	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "/share:fileA", leaseKey))
+	// Release only fileA's bucket (by its own key).
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "/share:fileA", keyA))
 
 	// fileA's bucket should be gone; fileB's lease record must survive.
 	mgr.mu.RLock()
@@ -501,7 +593,7 @@ func TestReleaseLeaseForHandle_ScopedToSingleBucket(t *testing.T) {
 	mgr.mu.RUnlock()
 	assert.False(t, aStillThere, "fileA bucket should be removed when emptied")
 	require.Len(t, bBucket, 1, "fileB bucket must survive intact")
-	assert.Equal(t, leaseKey, bBucket[0].Lease.LeaseKey)
+	assert.Equal(t, keyB, bBucket[0].Lease.LeaseKey)
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -295,20 +295,48 @@ func TestRequestLease_DuplicateKeyDifferentFile_Rejected(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
 
-	// Same key on file2 must be rejected.
+	// Same client, same key, different file must be rejected.
 	state, _, err = mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
 		"owner1", "client1", "/share",
 		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
 	require.ErrorIs(t, err, ErrLeaseKeyInUse)
 	assert.Equal(t, LeaseStateNone, state)
 
-	// None probe on file2 with the same key must also reject (key is bound
-	// elsewhere, no matter the requested state).
+	// None probe on file2 with the same key is a state query, not a grant
+	// request — it must NOT trip the lease_match check (Samba behavior).
+	// No same-key record on file2's bucket exists, so it returns None silently.
 	state, _, err = mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
 		"owner1", "client1", "/share",
 		LeaseStateNone, false)
-	require.ErrorIs(t, err, ErrLeaseKeyInUse)
+	require.NoError(t, err)
 	assert.Equal(t, LeaseStateNone, state)
+}
+
+// TestRequestLease_DuplicateKeyDifferentClient_Allowed: lease key uniqueness
+// is per-(ClientGuid, LeaseKey). Two unrelated clients reusing the same
+// numeric LeaseKey on different files must both succeed — smbtorture's fixed
+// LEASE1/LEASE2 macros across separate connections rely on this.
+func TestRequestLease_DuplicateKeyDifferentClient_Allowed(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+	parentKey := [16]byte{}
+
+	// Client A grants on file1.
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), leaseKey, parentKey,
+		"ownerA", "clientA", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
+
+	// Client B reuses the same numeric key on file2 — must be allowed.
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file2"), leaseKey, parentKey,
+		"ownerB", "clientB", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
 }
 
 // TestRequestLease_DuplicateKey_AfterFile1Released_Allowed: once file1's lease

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -511,8 +511,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
 | smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
 | smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
-| smb2.lease.duplicate_create | Leases | Duplicate lease create not fully working | #429 |
-| smb2.lease.duplicate_open | Leases | Duplicate lease open not fully working | #429 |
 | smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
 | smb2.lease.lease-epoch | Leases | Lease epoch tracking not fully working | #429 |
 | smb2.lease.v2_flags_parentkey | Leases V2 | Lease V2 parent key flags not fully working | #429 |


### PR DESCRIPTION
## Summary

Implements MS-SMB2 §3.3.5.9.8 / Samba `lease_match` (`source3/smbd/smb2_lease.c`):
a lease key bound by a client to a record on file1 must not be grantable on file2.
Reusing a lease key across files for the **same** ClientGuid fails the CREATE
with `STATUS_INVALID_PARAMETER`. Cross-client reuse and same-file reopen remain
allowed.

- Adds `lock.ErrLeaseKeyInUse` sentinel; mapped to `STATUS_INVALID_PARAMETER` in
  both `ProcessLeaseCreateContext` callsites.
- Check runs inside `requestLeaseImpl`'s existing write-lock region (atomic
  with the grant — no TOCTOU, mirrors Samba's `lease_match` under
  `share_mode_lock`). Scoped to `Owner.ClientID`. Skipped on `LeaseStateNone`
  probes (state queries, not grants).
- `create_post_break.go` rolls back the just-created inode via
  `metaSvc.RemoveFile` when the lease check rejects after Step 7
  (`FileCreated` only — `FileOpened`/OVERWRITE/SUPERSEDE preserve user data).

Two commits:
1. `e51e1483` — initial implementation
2. `146630e8` — review follow-ups (ClientGuid scoping, TOCTOU fix, None-probe
   ordering, orphan cleanup) addressing findings from 5 parallel code reviews.

Closes round 3 of the lease cluster work tracked under #429.

## Conformance impact

`smbtorture smb2.lease`: **26 → 28 PASS** (memory profile, dperson/samba reference baseline).

| Test | Before | After |
| --- | --- | --- |
| `smb2.lease.duplicate_create` | FAIL (STATUS_OK) | PASS |
| `smb2.lease.duplicate_open` | FAIL (STATUS_OK) | PASS |

No regressions on `breaking2-6`, `upgrade1-3`, `statopen2-3`, `nobreakself`,
`break_twice`, `multibreak`, `break`, `timeout-disconnect`. Per-test diff
verified via direct comparison of with/without runs (only the two target
tests flipped; no other test changed outcome).

## Test plan

- [x] `go test -race ./pkg/metadata/lock/...`
- [x] `go test -race ./internal/adapter/smb/...`
- [x] `go vet ./...`
- [x] smbtorture `smb2.lease` filter — 28 PASS, 16 FAIL, exact diff confirms only target tests flipped
- [x] Three new unit tests:
  - `TestRequestLease_DuplicateKeyDifferentFile_Rejected` (same client + key + different file → `ErrLeaseKeyInUse`; None probe still returns None silently)
  - `TestRequestLease_DuplicateKey_AfterFile1Released_Allowed` (release + reuse on different file → success)
  - `TestRequestLease_SameKeySameFile_StillWorks` (same key + same file = reopen / upgrade)
  - `TestRequestLease_DuplicateKeyDifferentClient_Allowed` (different ClientGuid + same key → success — spec compliance)

## Deferred follow-ups (filed as known gaps, not blockers)

- After-restart persistence visibility: `hasLeaseKeyOnOtherFile` consults the
  in-memory `unifiedLocks` only. Records reclaimed lazily during the grace
  period are not visible until the reclaim CREATE arrives. Not exploitable in
  conformance tests; tracked for a follow-up that consults `lockStore` (or
  eager-loads at startup).
- `releaseLeaseForHandleImpl` swallows `lockStore.DeleteLock` errors silently
  (`_ = ...`). Worth a separate PR to log + handle ghost records on restart.