### PR TITLE
fix(smb): round 5 lease cluster — rename family (#429)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -492,6 +492,57 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 	return lockMgr.BreakLeasesOnOpenConflict(handleKey, exclude, reason)
 }
 
+// BreakLeasesOnRename dispatches lease break notifications on the source
+// (and optionally destination) file before a SET_INFO FileRenameInformation
+// applies to metadata. Per MS-FSA §2.1.5.14.10 and Samba
+// `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`, rename participates in the
+// same break processing as CREATE: any concurrent open whose Handle caching
+// would be invalidated by the rename must be notified first.
+//
+// The renamer's own lease (renamerLeaseKey) is excluded so a same-key rename
+// produces no self-break. Exclusion is by lease key only — NOT by ClientID —
+// because a single client may hold two distinct leases on the same file (one
+// per handle, smbtorture rename_wait LEASE1=h1 / LEASE2=h2 case); a client
+// scoped exclusion would skip both and miss the required break.
+//
+// Source file leases break with BreakReasonSharingViolation (strip H,
+// preserve R+W): smbtorture rename_wait expects RH→R, v2_rename_target_overwrite
+// expects RWH→RW. Destination file leases (if dstHandle is non-empty AND
+// isOverwrite=true) break the same way; the destination's holder is by
+// definition someone other than the renamer, so no exclusion is applied there.
+//
+// Dispatch is fire-and-forget: this method does NOT wait for ACK. Callers that
+// must park the request behind the break (smbtorture rename_wait) check
+// HasOtherBreakingLeases on the source handle and route to
+// WaitForOtherKeyBreaks. This mirrors the round-3 / round-4 CREATE async-park
+// pattern in create_post_break.go and avoids the multi-client deadlock
+// documented on BreakHandleLeasesOnOpenAsync.
+func (lm *LeaseManager) BreakLeasesOnRename(
+	srcHandle lock.FileHandle,
+	dstHandle lock.FileHandle,
+	shareName string,
+	renamerLeaseKey [16]byte,
+	isOverwrite bool,
+) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	srcExclude := &lock.LockOwner{ExcludeLeaseKey: renamerLeaseKey}
+	if err := lockMgr.BreakLeasesOnOpenConflict(string(srcHandle), srcExclude, lock.BreakReasonSharingViolation); err != nil {
+		return err
+	}
+
+	if isOverwrite && dstHandle != "" && dstHandle != srcHandle {
+		if err := lockMgr.BreakLeasesOnOpenConflict(string(dstHandle), nil, lock.BreakReasonSharingViolation); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // BreakFileHandleLeasesOnDelete strips Handle caching from all leases on a
 // file that is about to be unlinked (RH → R, RWH → RW). Per MS-FSA 2.1.5.1.5
 // and Samba: deleting a file invalidates Handle caching for every other open

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -293,3 +293,147 @@ func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
 		t.Fatalf("WaitForBreakCompletion call count = %d, want 1", len(fake.waitForBreakCompletionKeys))
 	}
 }
+
+// TestBreakLeasesOnRename_SrcOnly_StripHandle: a non-overwrite rename
+// dispatches exactly one break on the source handle with
+// BreakReasonSharingViolation (strip H). Per smbtorture rename_wait the
+// non-renamer's RH must be downgraded to R; per v2_rename the renamer's own
+// lease must NOT be touched. Verified by ExcludeLeaseKey scoping.
+func TestBreakLeasesOnRename_SrcOnly_StripHandle(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	srcHandle := lock.FileHandle("src-handle")
+	renamerKey := [16]byte{0x11, 0x22, 0x33}
+
+	if err := lm.BreakLeasesOnRename(srcHandle, "", "share1", renamerKey, false); err != nil {
+		t.Fatalf("BreakLeasesOnRename returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1 (src only)", got)
+	}
+	got := fake.breakHandleCalls[0]
+	if got.HandleKey != string(srcHandle) {
+		t.Errorf("handleKey = %q, want %q", got.HandleKey, string(srcHandle))
+	}
+	if got.Reason != lock.BreakReasonSharingViolation {
+		t.Errorf("reason = %d, want BreakReasonSharingViolation (strip H)", got.Reason)
+	}
+	if got.ExcludeOwner == nil {
+		t.Fatal("ExcludeOwner is nil; renamer's own lease key must be excluded")
+	}
+	if got.ExcludeOwner.ExcludeLeaseKey != renamerKey {
+		t.Errorf("ExcludeLeaseKey = %x, want %x", got.ExcludeOwner.ExcludeLeaseKey, renamerKey)
+	}
+	// MUST NOT scope by ClientID — a single client may hold two distinct
+	// leases on the same file (smbtorture rename_wait LEASE1=h1 / LEASE2=h2);
+	// ClientID-scoped exclusion would skip both.
+	if got.ExcludeOwner.ClientID != "" {
+		t.Errorf("ExcludeOwner.ClientID = %q, must be empty (rename exclusion is by lease key only)", got.ExcludeOwner.ClientID)
+	}
+
+	// Fire-and-forget: rename dispatch must NOT call WaitForBreakCompletion
+	// inline. The set_info handler routes the wait through the round-4 async
+	// park path so the request appears as STATUS_PENDING to the client.
+	if len(fake.waitForBreakCompletionKeys) != 0 {
+		t.Errorf("WaitForBreakCompletion called %d times; want 0 (rename break is fire-and-forget; caller routes the wait)",
+			len(fake.waitForBreakCompletionKeys))
+	}
+}
+
+// TestBreakLeasesOnRename_OverwriteBreaksBoth: an overwrite rename onto a
+// non-empty destination dispatches breaks on BOTH source AND destination.
+// Per smbtorture v2_rename_target_overwrite the dst's RWH must break to RW
+// (strip H). The destination break is unscoped — the dst's lease holder is by
+// definition someone other than the renamer.
+func TestBreakLeasesOnRename_OverwriteBreaksBoth(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	srcHandle := lock.FileHandle("src-handle")
+	dstHandle := lock.FileHandle("dst-handle")
+	renamerKey := [16]byte{0xAA}
+
+	if err := lm.BreakLeasesOnRename(srcHandle, dstHandle, "share1", renamerKey, true); err != nil {
+		t.Fatalf("BreakLeasesOnRename returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 2 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 2 (src + dst)", got)
+	}
+
+	// Order is src first, then dst — matches the rename code path order.
+	if fake.breakHandleCalls[0].HandleKey != string(srcHandle) {
+		t.Errorf("first break handleKey = %q, want %q (src)", fake.breakHandleCalls[0].HandleKey, string(srcHandle))
+	}
+	if fake.breakHandleCalls[1].HandleKey != string(dstHandle) {
+		t.Errorf("second break handleKey = %q, want %q (dst)", fake.breakHandleCalls[1].HandleKey, string(dstHandle))
+	}
+	if fake.breakHandleCalls[1].Reason != lock.BreakReasonSharingViolation {
+		t.Errorf("dst break reason = %d, want BreakReasonSharingViolation", fake.breakHandleCalls[1].Reason)
+	}
+	// Destination break must NOT carry the renamer's lease key as exclusion —
+	// the dst's lease is by definition held by someone other than the renamer.
+	if fake.breakHandleCalls[1].ExcludeOwner != nil {
+		t.Errorf("dst break excludeOwner = %+v, want nil (no exclusion on cross-file destination)", fake.breakHandleCalls[1].ExcludeOwner)
+	}
+}
+
+// TestBreakLeasesOnRename_NonOverwrite_NoDstBreak: when isOverwrite=false the
+// destination is NOT broken even if a dstHandle is supplied. (Defensive: caller
+// usually passes an empty dstHandle when not overwriting; this test guards
+// against a future refactor introducing a stray break on a name that may not
+// exist.)
+func TestBreakLeasesOnRename_NonOverwrite_NoDstBreak(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	if err := lm.BreakLeasesOnRename(lock.FileHandle("src"), lock.FileHandle("dst"), "share1", [16]byte{}, false); err != nil {
+		t.Fatalf("BreakLeasesOnRename returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1 (src only when !isOverwrite)", got)
+	}
+	if fake.breakHandleCalls[0].HandleKey != "src" {
+		t.Errorf("handleKey = %q, want \"src\"", fake.breakHandleCalls[0].HandleKey)
+	}
+}
+
+// TestBreakLeasesOnRename_SameSrcDst_NoDstBreak: a self-rename (src==dst)
+// dispatches only one break — never two on the same handle. Guards against an
+// accidental double-break that would advance the epoch twice.
+func TestBreakLeasesOnRename_SameSrcDst_NoDstBreak(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	h := lock.FileHandle("self")
+	if err := lm.BreakLeasesOnRename(h, h, "share1", [16]byte{}, true); err != nil {
+		t.Fatalf("BreakLeasesOnRename returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1 (self-rename src==dst)", got)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1192,6 +1192,44 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return conflict
 }
 
+// snapshotOpenChildren returns the metadata handles of every open file whose
+// ParentHandle equals dirHandle. Caller must read h.files only once; iterating
+// twice could observe inconsistent open state across a concurrent CLOSE.
+func (h *Handler) snapshotOpenChildren(dirHandle metadata.FileHandle) []metadata.FileHandle {
+	var children []metadata.FileHandle
+	h.files.Range(func(_, value any) bool {
+		of := value.(*OpenFile)
+		if len(of.ParentHandle) == 0 || len(of.MetadataHandle) == 0 {
+			return true
+		}
+		if !bytes.Equal(of.ParentHandle, dirHandle) {
+			return true
+		}
+		children = append(children, of.MetadataHandle)
+		return true
+	})
+	return children
+}
+
+// anyOpenChild reports whether any open file currently has ParentHandle ==
+// dirHandle. Cheaper than snapshotOpenChildren when only the boolean is
+// needed (post-break recheck in the directory-rename path).
+func (h *Handler) anyOpenChild(dirHandle metadata.FileHandle) bool {
+	open := false
+	h.files.Range(func(_, value any) bool {
+		of := value.(*OpenFile)
+		if len(of.ParentHandle) == 0 {
+			return true
+		}
+		if !bytes.Equal(of.ParentHandle, dirHandle) {
+			return true
+		}
+		open = true
+		return false
+	})
+	return open
+}
+
 // hasOpenHandleOnFile reports whether any open file handle (other than the
 // renamer's own handle) currently references targetMeta. Used by the
 // SET_INFO FileRenameInformation handler to enforce MS-FSA §2.1.5.14.10

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1192,6 +1192,38 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return conflict
 }
 
+// hasOpenHandleOnFile reports whether any open file handle (other than the
+// renamer's own handle) currently references targetMeta. Used by the
+// SET_INFO FileRenameInformation handler to enforce MS-FSA §2.1.5.14.10
+// "rename overwrite onto an open file" — once any H-lease on the destination
+// has been broken to RW, the destination's open handle still blocks the
+// overwrite and must surface as STATUS_ACCESS_DENIED.
+//
+// excludeFileID is the rename's own SMB FileID (the source handle). It is
+// excluded from the conflict check so a self-rename via the only handle on
+// targetMeta is allowed (degenerate case; matches Samba behavior).
+func (h *Handler) hasOpenHandleOnFile(targetMeta metadata.FileHandle, excludeFileID [16]byte) bool {
+	if len(targetMeta) == 0 {
+		return false
+	}
+	conflict := false
+	h.files.Range(func(_, value any) bool {
+		other := value.(*OpenFile)
+		if other.FileID == excludeFileID {
+			return true
+		}
+		if len(other.MetadataHandle) == 0 {
+			return true
+		}
+		if !bytes.Equal(other.MetadataHandle, targetMeta) {
+			return true
+		}
+		conflict = true
+		return false
+	})
+	return conflict
+}
+
 // hasReadAccess reports whether the given access mask includes read access.
 // Checks FILE_READ_DATA, GENERIC_READ, GENERIC_ALL, and MAXIMUM_ALLOWED.
 func hasReadAccess(access uint32) bool {

--- a/internal/adapter/smb/v2/handlers/lease_context.go
+++ b/internal/adapter/smb/v2/handlers/lease_context.go
@@ -433,13 +433,30 @@ func ProcessLeaseCreateContext(
 	// blob with an epoch field — the epoch is not echoed because the V1
 	// response format has no epoch slot.
 	if !responseIsV1 && err == nil {
-		if grantedState != lock.LeaseStateNone {
+		// None-state probe: client requests state=0 to query the current lease
+		// without taking new caching rights (smbtorture upgrade2 / breaking4 /
+		// v2_rename use this to re-read after a break or rename). MS-SMB2
+		// §2.2.14.2.11 requires the epoch to advance only on a granted state
+		// CHANGE; a None-probe never changes state, so we MUST echo the
+		// lease's current epoch verbatim — neither advancing past it nor
+		// taking the client's requested value (which is itself the current
+		// epoch and would drift the server one ahead per round-trip).
+		//
+		// Without this guard, every same-key None-probe SetLeaseEpoch's
+		// to leaseReq.Epoch+1 and accumulates: smbtorture v2_rename re-opens
+		// fname_dst (None-probe) → epoch drifts 0x4712→0x4713; later re-open
+		// of fname after rename-back → drifts again, lease.c:4299 fails
+		// 0x4714 ≠ expected 0x4713.
+		switch {
+		case leaseReq.LeaseState == lock.LeaseStateNone:
+			// epoch already holds the lease's current value from RequestLease.
+		case grantedState != lock.LeaseStateNone:
 			nextEpoch := leaseReq.Epoch + 1
 			if nextEpoch > epoch {
 				leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, nextEpoch)
 				epoch = nextEpoch
 			}
-		} else {
+		default:
 			epoch = leaseReq.Epoch
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/lease_context_test.go
+++ b/internal/adapter/smb/v2/handlers/lease_context_test.go
@@ -1,11 +1,34 @@
 package handlers
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// staticLockResolver is a test resolver that returns the same Manager for any
+// share name. Used by lease-context tests that exercise ProcessLeaseCreateContext.
+type staticLockResolver struct {
+	mgr lock.LockManager
+}
+
+func (r *staticLockResolver) GetLockManagerForShare(_ string) lock.LockManager {
+	return r.mgr
+}
+
+// encodeV2LeaseContext writes a 52-byte SMB2_CREATE_REQUEST_LEASE_V2 payload
+// matching the wire layout in DecodeLeaseCreateContext (LeaseKey 16 / State 4 /
+// Flags 4 / LeaseDuration 8 / ParentLeaseKey 16 / Epoch 2 / Reserved 2).
+func encodeV2LeaseContext(leaseKey [16]byte, state uint32, epoch uint16) []byte {
+	buf := make([]byte, LeaseV2ContextSize)
+	copy(buf[0:16], leaseKey[:])
+	binary.LittleEndian.PutUint32(buf[16:20], state)
+	binary.LittleEndian.PutUint16(buf[48:50], epoch)
+	return buf
+}
 
 // TestDecodeLeaseCreateContext tests parsing of SMB2_CREATE_REQUEST_LEASE_V2 contexts.
 func TestDecodeLeaseCreateContext(t *testing.T) {
@@ -323,5 +346,68 @@ func TestLeaseResponseContextEncode(t *testing.T) {
 		if encoded[i] != expected[i] {
 			t.Errorf("byte %d: encoded = %d, expected = %d", i, encoded[i], expected[i])
 		}
+	}
+}
+
+// TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch covers the
+// smbtorture v2_rename failure cascade at lease.c:4299. After a CREATE granted
+// LEASE1=RWH at epoch=0x4712, a subsequent same-key None-state probe MUST
+// return that lease unchanged with epoch=0x4712. The pre-fix code advanced to
+// 0x4713 because the V2 epoch-resolution branch unconditionally bumped to
+// max(currentEpoch, requestedEpoch+1) for any non-None grant, including the
+// no-op None-probe path. Per MS-SMB2 §2.2.14.2.11 the epoch advances ONLY on
+// granted state changes — a None-probe is by definition not a state change.
+func TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+	fileHandle := lock.FileHandle("file-handle-1")
+	const sessionID = uint64(42)
+	const clientID = "smb:42"
+	const initialEpoch uint16 = 0x4711
+
+	// First CREATE: grant RWH with requested epoch 0x4711 → response epoch 0x4712.
+	initial := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle, initialEpoch)
+	resp1, err := ProcessLeaseCreateContext(ctx, leaseMgr, initial, fileHandle, sessionID, clientID, shareName, false)
+	if err != nil {
+		t.Fatalf("first CREATE returned error: %v", err)
+	}
+	if resp1.LeaseState != lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle {
+		t.Fatalf("first CREATE granted state = 0x%x, want RWH (0x07)", resp1.LeaseState)
+	}
+	if resp1.Epoch != initialEpoch+1 {
+		t.Fatalf("first CREATE response epoch = 0x%x, want 0x%x (req+1)", resp1.Epoch, initialEpoch+1)
+	}
+	grantedEpoch := resp1.Epoch
+
+	// Same-key None-state probe at the granted epoch — must echo the lease's
+	// current epoch verbatim (no state change → no advance).
+	probe := encodeV2LeaseContext(leaseKey, lock.LeaseStateNone, grantedEpoch)
+	resp2, err := ProcessLeaseCreateContext(ctx, leaseMgr, probe, fileHandle, sessionID, clientID, shareName, false)
+	if err != nil {
+		t.Fatalf("None-probe returned error: %v", err)
+	}
+	if resp2.LeaseState != lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle {
+		t.Errorf("None-probe returned state = 0x%x, want RWH (0x07) — None-probe must echo existing state",
+			resp2.LeaseState)
+	}
+	if resp2.Epoch != grantedEpoch {
+		t.Errorf("None-probe response epoch = 0x%x, want 0x%x — None-probe is not a state change and MUST NOT advance epoch (smbtorture v2_rename lease.c:4299)",
+			resp2.Epoch, grantedEpoch)
+	}
+
+	// Server-side tracking should also remain unchanged.
+	_, persistedEpoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	if !found {
+		t.Fatal("lease record disappeared after None-probe")
+	}
+	if persistedEpoch != grantedEpoch {
+		t.Errorf("server-side epoch after None-probe = 0x%x, want 0x%x (no advance)",
+			persistedEpoch, grantedEpoch)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -630,6 +632,44 @@ func (h *Handler) setFileInfoFromStore(
 		if len(openFile.ParentHandle) == 0 {
 			logger.Debug("SET_INFO: cannot rename root directory", "path", openFile.Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
+		}
+
+		// Pre-rename lease break: per MS-FSA §2.1.5.14.10 + Samba
+		// `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`, dispatch breaks on
+		// any other-key lease holder of the source file before applying the
+		// rename. Sync wait (mirrors BreakParentHandleLeasesOnCreate) — rename
+		// is not in the compound-CREATE hot path so we don't need the round-4
+		// async-park machinery; the bounded WaitForOtherKeyBreaks deadline
+		// auto-downgrades non-acking holders identically to that path.
+		//
+		// Renamer's own lease (openFile.LeaseKey, zero for non-leased opens)
+		// is excluded by lease key only — NOT by ClientID — because a single
+		// client may hold two distinct leases on the same file (smbtorture
+		// rename_wait LEASE1=h1 / LEASE2=h2); a ClientID exclusion would skip
+		// the second lease and deadlock the rename behind a never-acked break
+		// that was never sent.
+		//
+		// Destination break is deferred — overwrite handling lives in #433
+		// follow-up. C3 covers source-file break + parking only, which flips
+		// smbtorture rename_wait + v2_rename.
+		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			srcMetaHandle := lock.FileHandle(openFile.MetadataHandle)
+			if err := h.LeaseManager.BreakLeasesOnRename(
+				srcMetaHandle,
+				lock.FileHandle(""),
+				openFile.ShareName,
+				openFile.LeaseKey,
+				false, // overwrite handling lands in a follow-up commit
+			); err != nil {
+				logger.Debug("SET_INFO: rename lease break dispatch failed", "error", err)
+			}
+			waitCtx, cancelWait := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+			if waitErr := h.LeaseManager.WaitForOtherKeyBreaks(
+				waitCtx, srcMetaHandle, openFile.ShareName, openFile.LeaseKey,
+			); waitErr != nil {
+				logger.Debug("SET_INFO: rename break wait completed", "error", waitErr)
+			}
+			cancelWait()
 		}
 
 		// Save old path info for notification before modification

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -636,11 +636,12 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Pre-rename lease break: per MS-FSA §2.1.5.14.10 + Samba
 		// `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`, dispatch breaks on
-		// any other-key lease holder of the source file before applying the
-		// rename. Sync wait (mirrors BreakParentHandleLeasesOnCreate) — rename
-		// is not in the compound-CREATE hot path so we don't need the round-4
-		// async-park machinery; the bounded WaitForOtherKeyBreaks deadline
-		// auto-downgrades non-acking holders identically to that path.
+		// any other-key lease holder of the source file (and, on overwrite,
+		// the destination too) before applying the rename. Sync wait (mirrors
+		// BreakParentHandleLeasesOnCreate) — rename is not in the compound-
+		// CREATE hot path, so we don't need the round-4 async-park machinery;
+		// the bounded WaitForOtherKeyBreaks deadline auto-downgrades non-
+		// acking holders identically to that path.
 		//
 		// Renamer's own lease (openFile.LeaseKey, zero for non-leased opens)
 		// is excluded by lease key only — NOT by ClientID — because a single
@@ -649,17 +650,33 @@ func (h *Handler) setFileInfoFromStore(
 		// the second lease and deadlock the rename behind a never-acked break
 		// that was never sent.
 		//
-		// Destination break is deferred — overwrite handling lives in #433
-		// follow-up. C3 covers source-file break + parking only, which flips
-		// smbtorture rename_wait + v2_rename.
+		// Destination handling: when ReplaceIfExists=true and the destination
+		// exists, dispatch the dst H-lease break (RWH→RW). Even after that
+		// break drains, ANY open handle on dst blocks the overwrite per
+		// MS-FSA §2.1.5.14.10 — surface STATUS_ACCESS_DENIED. The dst close
+		// path (smbtorture v2_rename_target_overwrite Phase 3) clears the
+		// open and the post-wait recheck then proceeds to the rename.
+		isOverwrite := renameInfo.ReplaceIfExists
+		metaSvc := h.Registry.GetMetadataService()
+		var dstMetaHandle metadata.FileHandle
+		if isOverwrite {
+			dstFile, lookupErr := metaSvc.Lookup(authCtx, toDir, toName)
+			if lookupErr == nil && dstFile != nil {
+				if encoded, encErr := metadata.EncodeFileHandle(dstFile); encErr == nil {
+					dstMetaHandle = encoded
+				}
+			}
+		}
+
 		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 			srcMetaHandle := lock.FileHandle(openFile.MetadataHandle)
+			dstLockHandle := lock.FileHandle(dstMetaHandle) // empty when no dst
 			if err := h.LeaseManager.BreakLeasesOnRename(
 				srcMetaHandle,
-				lock.FileHandle(""),
+				dstLockHandle,
 				openFile.ShareName,
 				openFile.LeaseKey,
-				false, // overwrite handling lands in a follow-up commit
+				isOverwrite,
 			); err != nil {
 				logger.Debug("SET_INFO: rename lease break dispatch failed", "error", err)
 			}
@@ -667,9 +684,33 @@ func (h *Handler) setFileInfoFromStore(
 			if waitErr := h.LeaseManager.WaitForOtherKeyBreaks(
 				waitCtx, srcMetaHandle, openFile.ShareName, openFile.LeaseKey,
 			); waitErr != nil {
-				logger.Debug("SET_INFO: rename break wait completed", "error", waitErr)
+				logger.Debug("SET_INFO: rename src break wait completed", "error", waitErr)
 			}
 			cancelWait()
+
+			if isOverwrite && len(dstMetaHandle) > 0 && srcMetaHandle != dstLockHandle {
+				dstWaitCtx, cancelDst := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+				// Zero exception key — dst's lease holder is by definition
+				// someone other than the renamer.
+				if waitErr := h.LeaseManager.WaitForOtherKeyBreaks(
+					dstWaitCtx, dstLockHandle, openFile.ShareName, [16]byte{},
+				); waitErr != nil {
+					logger.Debug("SET_INFO: rename dst break wait completed", "error", waitErr)
+				}
+				cancelDst()
+			}
+		}
+
+		// Post-break: any open handle on dst (other than the renamer's own
+		// FileID) blocks the overwrite. The H-lease break above stripped
+		// caching rights, but did NOT close the underlying handle — the
+		// holder must do that itself (smbtorture v2_rename_target_overwrite
+		// Phase 1 / Phase 2: ACK leaves dst open ⇒ ACCESS_DENIED).
+		if isOverwrite && len(dstMetaHandle) > 0 && h.hasOpenHandleOnFile(dstMetaHandle, openFile.FileID) {
+			logger.Debug("SET_INFO: rename overwrite blocked by open handle on destination",
+				"src", openFile.Path,
+				"dst", newPath)
+			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
 		// Save old path info for notification before modification
@@ -682,7 +723,6 @@ func (h *Handler) setFileInfoFromStore(
 		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
 		// Perform the rename/move
-		metaSvc := h.Registry.GetMetadataService()
 		err = metaSvc.Move(authCtx, openFile.ParentHandle, openFile.FileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -713,6 +713,41 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
+		// Directory rename: break H-leases on every open child file (RH→R
+		// strip-H) and wait for each break to drain. After the wait, ANY
+		// remaining open child blocks the parent rename per MS-FSA §2.1.5.14
+		// (smbtorture rename_dir_openfile: 8 sub-cases all hinge on whether
+		// every H-leased child closes-on-break or stays open after ACK).
+		// Children without an H-lease are no-op'd by ComputeLeaseBreakTo and
+		// stay open → fall through to the open-child recheck below, which
+		// produces the immediate ACCESS_DENIED for the "no-hleases" case.
+		if openFile.IsDirectory && h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			children := h.snapshotOpenChildren(openFile.MetadataHandle)
+			for _, child := range children {
+				if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(
+					lock.FileHandle(child), openFile.ShareName, lock.BreakReasonSharingViolation,
+				); err != nil {
+					logger.Debug("SET_INFO: dir-rename child break dispatch failed",
+						"child", string(child), "error", err)
+				}
+			}
+			for _, child := range children {
+				waitCtx, cancelChild := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+				if err := h.LeaseManager.WaitForOtherKeyBreaks(
+					waitCtx, lock.FileHandle(child), openFile.ShareName, [16]byte{},
+				); err != nil {
+					logger.Debug("SET_INFO: dir-rename child break wait completed",
+						"child", string(child), "error", err)
+				}
+				cancelChild()
+			}
+			if h.anyOpenChild(openFile.MetadataHandle) {
+				logger.Debug("SET_INFO: dir rename blocked by open child",
+					"dir", openFile.Path)
+				return setInfoStatus(types.StatusAccessDenied), nil
+			}
+		}
+
 		// Save old path info for notification before modification
 		oldPath := openFile.Path
 		oldFileName := openFile.FileName

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -507,11 +507,7 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
 | smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
 | smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
-| smb2.lease.rename_wait | Leases | Lease + rename wait not fully working | #429 |
-| smb2.lease.rename_dir_openfile | Leases | Lease + directory rename with open file not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
-| smb2.lease.v2_rename | Leases V2 | Lease V2 rename interaction not fully working | #429 |
-| smb2.lease.v2_rename_target_overwrite | Leases V2 | Lease V2 rename target overwrite not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)
 


### PR DESCRIPTION
## Summary

Round 5 of the SMB lease cluster work (#429): wires the rename path into the lease/oplock layer. Four target tests flipped to PASS — `smbtorture smb2.lease 32 → 36`.

| Test | Bug | Commit |
|---|---|---|
| `smb2.lease.rename_wait` | rename did not park behind outstanding H-lease break | C3 |
| `smb2.lease.v2_rename` | rename broke renamer's own lease + V2 epoch advanced on no-op None-probe | C2 + C3 |
| `smb2.lease.v2_rename_target_overwrite` | overwrite skipped dst H-lease break and dst open-handle check | C4 |
| `smb2.lease.rename_dir_openfile` | directory rename did not fan out child lease breaks | C5 |

Pairs naturally with #433 — the destination open-handle check in C4 subsumes its share-mode-on-destination ask.

## Spec basis

- **MS-FSA §2.1.5.14.10** — rename participates in the same break processing as CREATE; replacement requires destination's H-lease break and rejects open-handle conflicts.
- **MS-SMB2 §2.2.14.2.11** — V2 lease epoch advances only on granted state changes; same-key None-state probes are not state changes.
- **Samba `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`** — canonical reference for rename break-and-park semantics.

## Commits (6 signed)

1. `feat(smb/lease): BreakLeasesOnRename — strip-H break with own-key exclusion` — orchestrator API + unit tests. ExcludeLeaseKey scoping (NOT ClientID) so two leases on the same file by one client are handled correctly.
2. `fix(smb): V2 lease epoch must not advance on None-state probe` — surgical guard in `lease_context.go`. Per-MS-SMB2 §2.2.14.2.11: epoch increments only on state change. Unit-test `TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch` guards against drift.
3. `fix(smb): rename dispatches lease break + sync wait on source` — wires C1 into `set_info.go` SET_INFO FileRenameInformation path. Sync wait via `WaitForOtherKeyBreaks` (mirrors `BreakParentHandleLeasesOnCreate`) — bounded by `AsyncCreateBreakWaitTimeout`, no async-park machinery.
4. `fix(smb): rename overwrite breaks dst H-lease + denies on open handle` — destination Lookup + dst H-lease break (RWH→RW) + post-break open-handle re-check → ACCESS_DENIED. Adds `hasOpenHandleOnFile` helper.
5. `fix(smb): directory rename fans H-lease breaks to open children` — adds `snapshotOpenChildren` / `anyOpenChild` helpers; per-child `BreakHandleLeasesOnOpenAsync(SharingViolation)` + per-child wait + post-wait open-child recheck. Covers all 8 `rename_dir_openfile` sub-cases.
6. `test(smb): KNOWN_FAILURES — round 5 lease rename family (4 flips)` — removes the 4 newly-passing entries.

## Verification

- `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...` — all pass.
- `smbtorture smb2.lease` — 36/45 PASS (was 32/45). All 4 round-5 targets flip; no regressions on previously-passing tests.
- The 8 tests reported as "new failures" by the runner are pre-existing failures (`smb2.lease.{request,statopen,statopen4,oplock,lock1,v2_complex1,timeout,unlink}`); the runner does name-mismatch comparison (long-form `smb2.lease.X` in KNOWN_FAILURES vs short-form `smb2.X` in run output). Round-4 baseline showed the same "0 known / 12 new failures" reporting artifact.
- `smb2.rename` suite was attempted but the docker container recreate dropped the in-memory admin password before tests started; not retried. `smb2.rename.rename_dir_openfile` (under #433) likely flips per the C5 logic but is unverified.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] `smbtorture smb2.lease` re-run on develop after merge confirms 36/45
- [ ] Spot-check `smb2.rename` once docker bring-up issue is resolved

## Residual #429 known failures (8)

`v2_complex1`, `timeout`, `unlink`, `request`, `oplock`, `lock1`, `statopen`, `statopen4`. Each is a different facet (stat family, NLM family, complex multi-stage break) and warrants its own investigation in a future round.

## Architectural debt unchanged from round 4

SMB2 byte-range locks still in-memory only (not pushed to `lockStore.PutLock`); lease V1/V2 version sticky on first grant. Neither was in scope for round 5; both remain tracked in the round-5 anchor memory.