### PR TITLE
fix(smb): round 7 lease — unlink (#429)

### DIFF
--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -437,3 +437,55 @@ func TestBreakLeasesOnRename_SameSrcDst_NoDstBreak(t *testing.T) {
 		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1 (self-rename src==dst)", got)
 	}
 }
+
+// TestBreakFileHandleLeasesOnDelete_StripsHandleAndExcludesSetterKey verifies
+// the contract used by SET_INFO FileDispositionInformation (set_info.go) and
+// the session/tree teardown DOC path (handler.go::handleDeleteOnClose):
+//
+//   - the break is dispatched against the file's own handle key (not the parent),
+//   - reason = BreakReasonSharingViolation so ComputeLeaseBreakTo strips Handle
+//     (RH→R, RWH→RW) per MS-SMB2 3.3.5.9 / Samba delay_for_oplock_fn,
+//   - the setter's own LeaseKey is excluded so MS-SMB2 nobreakself holds.
+//
+// Required by smbtorture smb2.lease.unlink (the SetDelete-on-close on h2 must
+// dispatch a break to LEASE1 on h1, not to h2's own LEASE2).
+func TestBreakFileHandleLeasesOnDelete_StripsHandleAndExcludesSetterKey(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	fileHandle := lock.FileHandle("file-unlink")
+	setterKey := [16]byte{0x77, 0x88}
+
+	if err := lm.BreakFileHandleLeasesOnDelete(
+		fileHandle, "share1", &lock.LockOwner{ExcludeLeaseKey: setterKey},
+	); err != nil {
+		t.Fatalf("BreakFileHandleLeasesOnDelete returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", got)
+	}
+	got := fake.breakHandleCalls[0]
+	if got.HandleKey != string(fileHandle) {
+		t.Errorf("handleKey = %q, want %q (file's own handle, not parent)", got.HandleKey, string(fileHandle))
+	}
+	if got.Reason != lock.BreakReasonSharingViolation {
+		t.Errorf("reason = %d, want BreakReasonSharingViolation (strip H mask)", got.Reason)
+	}
+	if got.ExcludeOwner == nil || got.ExcludeOwner.ExcludeLeaseKey != setterKey {
+		t.Errorf("ExcludeOwner = %+v, want ExcludeLeaseKey = %x", got.ExcludeOwner, setterKey)
+	}
+
+	// Fire-and-forget: matches the SET_INFO disposition contract — the holder
+	// acks on its own transport. Inline waiting would deadlock on a
+	// single-threaded test driver.
+	if len(fake.waitForBreakCompletionKeys) != 0 {
+		t.Errorf("WaitForBreakCompletion called %d times; want 0 (delete-disposition break is fire-and-forget)",
+			len(fake.waitForBreakCompletionKeys))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -857,6 +857,10 @@ func (h *Handler) setFileInfoFromStore(
 			deletePending = buffer[0] != 0
 		}
 
+		// Capture pre-state to suppress redundant break dispatches when the
+		// disposition is reaffirmed (deletePending stays true).
+		wasDeletePending := openFile.DeletePending
+
 		// Validate we have parent info for deletion
 		if deletePending && len(openFile.ParentHandle) == 0 {
 			logger.Debug("SET_INFO: cannot delete root directory", "path", openFile.Path)
@@ -883,6 +887,28 @@ func (h *Handler) setFileInfoFromStore(
 						return setInfoStatus(types.StatusCannotDelete), nil
 					}
 				}
+			}
+		}
+
+		// Per MS-FSA 2.1.5.14.3 / Samba source3/smbd/smb2_setinfo.c
+		// (smbd_smb2_setinfo_lease_break_fsp_check): when delete disposition
+		// is *being set* on a non-directory file, strip Handle caching from
+		// every other holder's lease (RH -> R, RWH -> RW). The file is on
+		// its way out, so cached handles cannot be reopened. Excluding by
+		// our own LeaseKey honors the MS-SMB2 3.3.5.9 nobreakself rule.
+		// Required by smbtorture smb2.lease.unlink.
+		if deletePending && !openFile.IsDirectory && !wasDeletePending &&
+			h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
+			var excludeOwner *lock.LockOwner
+			if openFile.LeaseKey != ([16]byte{}) {
+				excludeOwner = &lock.LockOwner{ExcludeLeaseKey: openFile.LeaseKey}
+			}
+			if breakErr := h.LeaseManager.BreakFileHandleLeasesOnDelete(
+				lockFileHandle, openFile.ShareName, excludeOwner,
+			); breakErr != nil {
+				logger.Debug("SET_INFO: delete-disposition handle lease break failed",
+					"path", openFile.Path, "error", breakErr)
 			}
 		}
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -504,7 +504,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | #429 |
 | smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
 | smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
-| smb2.lease.unlink | Leases | Lease + unlink interaction not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)


### PR DESCRIPTION
## Root cause

`set_info.go`'s `FileDispositionInformation` / `FileDispositionInformationEx` arm flipped `openFile.DeletePending` and persisted, but never broke Handle leases held by other clients on the same file. Per **MS-FSA §2.1.5.14.3** and Samba `source3/smbd/smb2_setinfo.c::smbd_smb2_setinfo_lease_break_fsp_check` (lines ~552–599 of upstream master), setting delete-disposition to true MUST strip Handle caching (RH→R, RWH→RW) from every other holder's lease — the file is on its way out, so cached handles cannot be reopened. As a result, smbtorture `smb2.lease.unlink` saw `lease_break_info.count = 0` at `source4/torture/smb2/lease.c:4795` after Client2 issued SetInfo(DOC) on h2 (LEASE2): the test expected a single break dispatched to LEASE1 on h1.

## Citations

- MS-FSA §2.1.5.14.3 — Server Requests Setting of File Information (FileDispositionInformation).
- MS-SMB2 §3.3.5.9 — nobreakself rule (excluding the setter's own lease key from break candidates).
- Samba: `source3/smbd/smb2_setinfo.c:552-599` — `smbd_smb2_setinfo_lease_break_fsp_check` invokes `delay_for_handle_lease_break_send` on `SMB_FILE_DISPOSITION_INFORMATION` when `delete_on_close == true`.
- smbtorture: `source4/torture/smb2/lease.c:4933-5063` (`test_lease_unlink`); failure at line 4795 in our matrix maps to the test's check at `lease.c:5050`.

## Files touched

- `internal/adapter/smb/v2/handlers/set_info.go` — dispatch `BreakFileHandleLeasesOnDelete` after access checks succeed and only on the deletePending=false → true transition; exclude the setter's `LeaseKey`.
- `internal/adapter/smb/lease/manager_test.go` — new test `TestBreakFileHandleLeasesOnDelete_StripsHandleAndExcludesSetterKey` pinning the contract: file's own handle key, `BreakReasonSharingViolation` (strip H), `ExcludeLeaseKey` honored, fire-and-forget (no inline wait).
- `test/smb-conformance/smbtorture/KNOWN_FAILURES.md` — remove `smb2.lease.unlink` row.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/smb/... ./pkg/metadata/... -race`
- [x] New unit test `TestBreakFileHandleLeasesOnDelete_StripsHandleAndExcludesSetterKey` passes.
- [ ] Live `smbtorture smb2.lease` run (skipped locally — Docker unavailable in this worktree; reviewer/CI to confirm `unlink` flips PASS and other lease tests do not regress).