### PR TITLE
fix(smb): round 7 lease — timeout (#429)

### DIFF
--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1572,12 +1572,12 @@ func TestProgressiveLeaseBreak_NoSpuriousAfterReachingRequired(t *testing.T) {
 	mgr.mu.Unlock()
 }
 
-// TestForceCompleteBreaks_DrainsToBreakingToRequired confirms that a non-acking
-// client triggers the timeout path which drains to the cumulative final
-// target, not the in-flight intermediate. Otherwise a non-ack would leave
-// the lease parked at e.g. RH when a later destructive opener had AND-merged
-// the target down to None.
-func TestForceCompleteBreaks_DrainsToBreakingToRequired(t *testing.T) {
+// TestForceCompleteBreaks_DrainsToNone_AndMerged confirms that a non-acking
+// client triggers the timeout path which force-revokes the lease to None.
+// Mirrors Samba lease_timeout_handler (source3/smbd/smb2_oplock.c) which
+// always calls downgrade_lease(..., SMB2_LEASE_NONE) regardless of the
+// cumulative break target.
+func TestForceCompleteBreaks_DrainsToNone_AndMerged(t *testing.T) {
 	t.Parallel()
 
 	mgr := NewManager()
@@ -1602,16 +1602,66 @@ func TestForceCompleteBreaks_DrainsToBreakingToRequired(t *testing.T) {
 		OwnerID: "owner-destr", ClientID: "client-destr",
 	}, BreakReasonDestructive))
 
-	// Force-complete should drain to BreakingToRequired (= 0), keeping the
-	// record at LeaseState=None (handle-bound lifetime). Pre-fix this drained
-	// to BreakToState (= RH), leaving the lease at RH which would block the
-	// destructive opener.
+	// Force-complete revokes to None, keeping the record alive at
+	// LeaseState=None (handle-bound lifetime).
 	mgr.forceCompleteBreaks(handleKey)
 
 	state, _, found := mgr.GetLeaseState(ctx, key1)
 	require.True(t, found, "force-complete keeps the record alive until CLOSE")
 	assert.Equal(t, LeaseStateNone, state,
-		"force-complete must drain to None (BreakingToRequired), not RH (BreakToState)")
+		"force-complete must revoke to None per Samba lease_timeout_handler")
+}
+
+// TestForceCompleteBreaks_DrainsToNone_SingleBreak pins the
+// smb2.lease.timeout scenario: a single RWH lease is broken to RH (the
+// in-flight intermediate), the client never acks, and the wait times out.
+// Per Samba lease_timeout_handler, the lease must be force-revoked to None
+// — not parked at the cumulative BreakingToRequired (RH). Otherwise a probe
+// of the original lease key returns RH instead of the spec-mandated empty
+// state, and any subsequent IO that would conflict with R or H sends
+// spurious break notifications.
+func TestForceCompleteBreaks_DrainsToNone_SingleBreak(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	cb, _, _ := recordBreakNotifications()
+	mgr.RegisterBreakCallbacks(cb)
+
+	ctx := context.Background()
+	key1 := [16]byte{0xD1}
+	handleKey := "file-timeout-single"
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle(handleKey), key1, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// Single break from RWH: BreakingToRequired=RH (Read+Handle preserved).
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(handleKey, &LockOwner{
+		OwnerID: "owner-default", ClientID: "client-default",
+	}, BreakReasonDefault))
+
+	// Sanity: BreakingToRequired is RH, not None.
+	mgr.mu.Lock()
+	var observedReq uint32
+	for _, l := range mgr.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == key1 {
+			observedReq = l.Lease.BreakingToRequired
+			break
+		}
+	}
+	mgr.mu.Unlock()
+	require.Equal(t, LeaseStateRead|LeaseStateHandle, observedReq,
+		"precondition: single default-reason break sets BreakingToRequired=RH")
+
+	// Client doesn't ACK; the wait times out → force-complete fires.
+	mgr.forceCompleteBreaks(handleKey)
+
+	state, _, found := mgr.GetLeaseState(ctx, key1)
+	require.True(t, found, "force-complete keeps the record alive until CLOSE")
+	assert.Equal(t, LeaseStateNone, state,
+		"force-complete on timeout revokes to None per Samba lease_timeout_handler — "+
+			"NOT to the BreakingToRequired intermediate (RH). Otherwise smb2.lease.timeout "+
+			"probe returns 0x3 instead of 0x0 and subsequent IO triggers spurious breaks.")
 }
 
 // TestAnyHolderHasLeaseBits covers the cross-key per-bit query that gates the

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1528,11 +1528,10 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 	}
 }
 
-// forceCompleteBreaks auto-downgrades all breaking leases on a file to their
-// cumulative final target, as if the client had acknowledged every progressive
-// stage. Called when the break wait times out. Records whose final target is
-// None are kept alive at LeaseState=None (handle-bound lifetime) so a later
-// unsolicited ack surfaces as ErrLeaseAckNotBreaking → STATUS_UNSUCCESSFUL.
+// forceCompleteBreaks force-revokes all breaking leases on a file to None when
+// the break wait times out. Records are kept alive at LeaseState=None
+// (handle-bound lifetime) so a later unsolicited ack surfaces as
+// ErrLeaseAckNotBreaking → STATUS_UNSUCCESSFUL.
 func (lm *Manager) forceCompleteBreaks(handleKey string) {
 	lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
 }
@@ -1541,11 +1540,14 @@ func (lm *Manager) forceCompleteBreaks(handleKey string) {
 // keyed on exceptKey untouched. Zero exceptKey means "no exclusion" (same
 // semantics as forceCompleteBreaks).
 //
-// Drains to BreakingToRequired (the cumulative final target across any
-// concurrent breaks that AND-merged during the in-flight stage) rather than
-// the in-flight BreakToState — otherwise a non-acking client could leave the
-// lease parked at an intermediate state that the post-ACK re-eval would
-// normally have progressed past.
+// Forces breaking leases to None, mirroring Samba's lease_timeout_handler
+// (source3/smbd/smb2_oplock.c) which calls
+// `downgrade_lease(..., SMB2_LEASE_NONE)` regardless of the in-flight or
+// cumulative break target. A non-acking client must not be allowed to retain
+// any lease bits past the timeout — otherwise a later opener observes stale
+// state (smb2.lease.timeout: probe of original lease key returns RH instead
+// of the spec-mandated empty state) and stale R/H rights would generate
+// spurious break notifications on subsequent IO.
 func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]byte) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
@@ -1556,10 +1558,10 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 			continue
 		}
 		modified = true
-		// Auto-downgrade in place. For finalTarget=None keep the record
-		// alive at LeaseState=None (handle-bound lifetime) so a later
-		// unsolicited or duplicate ack surfaces as ErrLeaseAckNotBreaking
-		// → STATUS_UNSUCCESSFUL. Same rationale as applyBreakStageLocked.
+		// Force-revoke to None and keep the record alive at LeaseState=None
+		// (handle-bound lifetime) so a later unsolicited or duplicate ack
+		// surfaces as ErrLeaseAckNotBreaking → STATUS_UNSUCCESSFUL. Same
+		// rationale as applyBreakStageLocked.
 		//
 		// Do NOT advance Epoch: this is the timeout/internal completion
 		// path for an already-dispatched break. Per MS-SMB2 §3.3.4.7 the
@@ -1567,9 +1569,8 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 		// was already advanced when the in-flight break started). Bumping
 		// it here would invalidate any straggling client ack still echoing
 		// the original epoch.
-		finalTarget := l.Lease.BreakingToRequired
-		l.Lease.LeaseState = finalTarget
-		l.Lease.BreakingToRequired = finalTarget
+		l.Lease.LeaseState = LeaseStateNone
+		l.Lease.BreakingToRequired = LeaseStateNone
 		l.Lease.Breaking = false
 		l.Lease.BreakToState = 0
 		l.Lease.BreakStarted = time.Time{}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -503,7 +503,6 @@ incomplete break notification delivery and multi-client coordination.
 | smb2.lease.request | Leases | Lease request handling not fully working | #429 |
 | smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | #429 |
 | smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
-| smb2.lease.timeout | Leases | Lease timeout handling not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)


### PR DESCRIPTION
## Root cause

`Manager.forceCompleteBreaks` (the synchronous timeout fallback called from `WaitForBreakCompletion` when a CREATE/MODIFY waits past `handleLeaseBreakWaitTimeout` for a non-acking lease holder) drained breaking leases to `BreakingToRequired` — the cumulative final target across any concurrent breaks. For the `smb2.lease.timeout` scenario (single RWH lease, single break to RH, client skips ACK), `BreakingToRequired` is RH, so the lease stayed parked at RH instead of being revoked. The test's two failure points — the post-timeout probe of `LEASE1` returning `0x3` instead of `0x0`, and a spurious break notification on a later cross-handle write — both stem from the leftover R+H bits.

## Fix

Force breaking leases to `LeaseStateNone` on timeout, matching Samba's `lease_timeout_handler` (`source3/smbd/smb2_oplock.c`) which calls `downgrade_lease(..., SMB2_LEASE_NONE)` regardless of the in-flight or cumulative break target. Records are still kept alive at `LeaseState=None` (handle-bound lifetime) so a late client ACK surfaces as `ErrLeaseAckNotBreaking` → `STATUS_UNSUCCESSFUL` (per the test's expected ACK-after-timeout behavior).

## Citations

- Samba `source3/smbd/smb2_oplock.c::lease_timeout_handler` — `downgrade_lease(..., SMB2_LEASE_NONE)`
- smbtorture `source4/torture/smb2/lease.c::test_lease_timeout` — expected `LEASE1` post-timeout state is `""` (empty), `LEASE2` gets RH after the wait expires, ACK after timeout returns `NT_STATUS_UNSUCCESSFUL`
- MS-SMB2 §3.3.5.22.2 — receiver behavior on `LEASE_BREAK_ACKNOWLEDGMENT`; timeout fallback is implementation-defined, Samba is the canonical reference

## Files touched

- `pkg/metadata/lock/manager.go` — `forceCompleteBreaksExceptKey` now sets `LeaseState = BreakingToRequired = LeaseStateNone`
- `pkg/metadata/lock/leases_test.go` — rename `TestForceCompleteBreaks_DrainsToBreakingToRequired` → `_DrainsToNone_AndMerged`; add `TestForceCompleteBreaks_DrainsToNone_SingleBreak` pinning the smb2.lease.timeout scenario
- `test/smb-conformance/smbtorture/KNOWN_FAILURES.md` — drop `smb2.lease.timeout`

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...`
- [x] Two rounds of code review with zero new HIGH/MEDIUM findings (early exit per round-7 protocol)
- [ ] Live smbtorture verification — skipped due to local Docker congestion; final verification before merge