### PR TITLE
fix(smb): round 7 lease — lock1 (#429)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -409,6 +409,34 @@ func (lm *LeaseManager) BreakConflictingOplocksOnOpen(
 	return lockMgr.CheckAndBreakLeasesForSMBOpen(handleKey, exclude)
 }
 
+// BreakLeasesOnByteRangeLock breaks every lease (other than the locker's own
+// lease key) holding Read caching to None when an SMB byte-range LOCK is
+// acquired. Per MS-SMB2 3.3.5.14 and Samba
+// `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default`, a BRL
+// invalidates remote read caches: another client must now observe writes
+// from the locking client. Unlike CREATE breaks (strip W, preserve R+H),
+// this is full revocation to None. The locker's own lease is preserved via
+// excludeOwner.ExcludeLeaseKey ("nobreakself").
+func (lm *LeaseManager) BreakLeasesOnByteRangeLock(
+	fileHandle lock.FileHandle,
+	shareName string,
+	excludeOwner ...*lock.LockOwner,
+) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+
+	handleKey := string(fileHandle)
+
+	var exclude *lock.LockOwner
+	if len(excludeOwner) > 0 {
+		exclude = excludeOwner[0]
+	}
+
+	return lockMgr.BreakLeasesForByteRangeLock(handleKey, exclude)
+}
+
 // HasOtherBreakingLeases reports whether any lease on fileHandle except excludeKey
 // is currently Breaking. Non-blocking. Used by the SMB CREATE async-park path
 // to decide whether to emit STATUS_PENDING after dispatching the break.

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -215,19 +215,35 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	}
 
 	// ========================================================================
-	// Break Batch/Exclusive oplocks before acquiring locks
+	// Break read-caching leases on other clients before acquiring locks
 	// ========================================================================
 	//
-	// Per MS-SMB2 3.3.5.14: Before processing byte-range lock requests,
-	// the server MUST break any Batch or Exclusive oplocks held on the file
-	// by other clients. The requesting client's own lease is excluded.
+	// Per MS-SMB2 3.3.5.14 (Receiving an SMB2 LOCK Request) and Samba
+	// `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default`:
+	// granting a byte-range lock invalidates remote read caching, so every
+	// lease (other than the locker's own, by lease key) that holds Read
+	// caching must be broken to None — full revocation, not "strip W".
+	// The break is fire-and-forget; the lock acquisition itself does not
+	// wait for ACKs.
+	//
+	// Skip the break when every element is an unlock: Samba's
+	// contend_level2_oplocks_begin is called from brl_lock only, not
+	// brl_unlock. Releasing a lock cannot invalidate any remote read cache.
 
-	if h.LeaseManager != nil {
+	hasLockElement := false
+	for _, e := range req.Locks {
+		if (e.Flags & SMB2LockFlagUnlock) == 0 {
+			hasLockElement = true
+			break
+		}
+	}
+
+	if hasLockElement && h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
-		if breakErr := h.LeaseManager.BreakConflictingOplocksOnOpen(lockFileHandle, openFile.ShareName, &lock.LockOwner{
+		if breakErr := h.LeaseManager.BreakLeasesOnByteRangeLock(lockFileHandle, openFile.ShareName, &lock.LockOwner{
 			ExcludeLeaseKey: openFile.LeaseKey,
 		}); breakErr != nil {
-			logger.Debug("LOCK: oplock break failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+			logger.Debug("LOCK: lease break failed (non-fatal)", "path", openFile.Path, "error", breakErr)
 		}
 	}
 

--- a/pkg/metadata/lock/byte_range_lock_break_test.go
+++ b/pkg/metadata/lock/byte_range_lock_break_test.go
@@ -1,0 +1,185 @@
+package lock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBreakLeasesForByteRangeLock_BreaksOtherKeyReadLeasesToNone pins down the
+// smbtorture smb2.lease.lock1 wire shape: when a byte-range lock is acquired
+// on an open holding LEASE1, every OTHER lease (different lease key) that
+// holds Read caching must be broken to None — including same-client_guid
+// leases (LEASE2) and different-client leases (LEASE3) — while the locker's
+// own lease (LEASE1) is preserved.
+//
+// Per MS-SMB2 3.3.5.14 and Samba
+// `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default` +
+// `do_break_lease_to_none`. Pre-fix the SMB Lock handler called
+// CheckAndBreakLeasesForSMBOpen which only stripped the Write bit, so RH
+// leases were never broken — failing lock1's
+// `CHECK_VAL(lease_break_info.count, 2)` assertion.
+func TestBreakLeasesForByteRangeLock_BreaksOtherKeyReadLeasesToNone(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const handleKey = "locktest.dat"
+	lease1 := [16]byte{0x01}
+	lease2 := [16]byte{0x02}
+	lease3 := [16]byte{0x03}
+
+	// Three RH leases on the same file: LEASE1 on tree1a (client_guid C1),
+	// LEASE2 on tree1b (same client_guid C1, different lease key), LEASE3 on
+	// tree2 (different client_guid C2).
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-lease1",
+		Owner: LockOwner{OwnerID: "smb:s1:f1", ClientID: "client-C1"},
+		Lease: &OpLock{LeaseKey: lease1, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-lease2",
+		Owner: LockOwner{OwnerID: "smb:s2:f2", ClientID: "client-C1"},
+		Lease: &OpLock{LeaseKey: lease2, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-lease3",
+		Owner: LockOwner{OwnerID: "smb:s3:f3", ClientID: "client-C2"},
+		Lease: &OpLock{LeaseKey: lease3, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+
+	// Acquire BRL on the LEASE1 handle.
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(handleKey, &LockOwner{
+		ExcludeLeaseKey: lease1,
+	}))
+
+	breaks := cb.getOpLockBreaks()
+	require.Len(t, breaks, 2,
+		"BRL must break exactly the two other-key Read leases (LEASE2, LEASE3) to None")
+
+	for _, ev := range breaks {
+		assert.Equal(t, LeaseStateNone, ev.breakToState,
+			"BRL break target must be None (full revocation), not strip-W")
+		assert.NotEqual(t, "smb:s1:f1", ev.ownerID,
+			"locker's own lease (LEASE1) must not be broken (nobreakself)")
+	}
+}
+
+// TestBreakLeasesForByteRangeLock_SkipsLeasesWithoutRead asserts that leases
+// without any Read bit (None — e.g., already drained) are not re-notified.
+// This matches Samba's `(current_state & SMB2_LEASE_READ) == 0` early return.
+func TestBreakLeasesForByteRangeLock_SkipsLeasesWithoutRead(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const handleKey = "locktest2.dat"
+	leaseLocker := [16]byte{0xA1}
+	leaseDrained := [16]byte{0xA2}
+
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-locker",
+		Owner: LockOwner{OwnerID: "smb:locker"},
+		Lease: &OpLock{LeaseKey: leaseLocker, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-drained",
+		Owner: LockOwner{OwnerID: "smb:drained"},
+		Lease: &OpLock{LeaseKey: leaseDrained, LeaseState: LeaseStateNone},
+	}))
+
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(handleKey, &LockOwner{
+		ExcludeLeaseKey: leaseLocker,
+	}))
+
+	assert.Empty(t, cb.getOpLockBreaks(),
+		"None-state leases (drained) must not be re-broken — no Read cache to invalidate")
+}
+
+// TestBreakLeasesForByteRangeLock_TightensInFlightBreakToNone asserts that
+// when a BRL is acquired on a file whose other-key lease is already in a
+// Breaking state (e.g., RWH→RH dispatched but not yet ACKed), the cumulative
+// final target (BreakingToRequired) is AND-merged down to None. No second
+// notification is dispatched — the next progressive stage will fire on ACK.
+// This matches the breakOpLocks contract used by every other break path.
+func TestBreakLeasesForByteRangeLock_TightensInFlightBreakToNone(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const handleKey = "locktest4.dat"
+	leaseLocker := [16]byte{0xC1}
+	leaseOther := [16]byte{0xC2}
+
+	// Locker's own lease (preserved).
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-locker",
+		Owner: LockOwner{OwnerID: "smb:locker"},
+		Lease: &OpLock{LeaseKey: leaseLocker, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+	// Other-key lease already in Breaking state with RH as the in-flight
+	// target. Pre-fix, the BRL break could have left BreakingToRequired at RH.
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-other",
+		Owner: LockOwner{OwnerID: "smb:other"},
+		Lease: &OpLock{
+			LeaseKey:           leaseOther,
+			LeaseState:         LeaseStateRead | LeaseStateWrite | LeaseStateHandle,
+			BreakToState:       LeaseStateRead | LeaseStateHandle,
+			BreakingToRequired: LeaseStateRead | LeaseStateHandle,
+			Breaking:           true,
+		},
+	}))
+
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(handleKey, &LockOwner{
+		ExcludeLeaseKey: leaseLocker,
+	}))
+
+	// AND-merge: no new notification (Breaking suppressed dispatch).
+	assert.Empty(t, cb.getOpLockBreaks(),
+		"AND-merge of in-flight break must not dispatch a fresh notification")
+
+	// Verify BreakingToRequired tightened to None.
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	_, ul, _ := lm.findLeaseByKey(leaseOther)
+	require.NotNil(t, ul)
+	assert.Equal(t, uint32(0), ul.Lease.BreakingToRequired,
+		"BRL must AND-merge BreakingToRequired down to None")
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, ul.Lease.BreakToState,
+		"in-flight BreakToState (intermediate stage) must be unchanged")
+}
+
+// TestBreakLeasesForByteRangeLock_ExcludesLockerByLeaseKey covers the
+// "nobreakself" invariant: a different open with the same lease key
+// (e.g., a same-key reopen) is excluded. Mirrors Samba `smb2_lease_equal`.
+func TestBreakLeasesForByteRangeLock_ExcludesLockerByLeaseKey(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const handleKey = "locktest3.dat"
+	sharedKey := [16]byte{0xB1}
+
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:    "ul-h1",
+		Owner: LockOwner{OwnerID: "smb:h1"},
+		Lease: &OpLock{LeaseKey: sharedKey, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(handleKey, &LockOwner{
+		ExcludeLeaseKey: sharedKey,
+	}))
+
+	assert.Empty(t, cb.getOpLockBreaks(),
+		"locker's own lease key must be excluded (nobreakself)")
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -188,6 +188,22 @@ type LockManager interface {
 	// preserving Read and Handle (RWH -> RH, RW -> R).
 	CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error
 
+	// BreakLeasesForByteRangeLock breaks every other-key lease that holds
+	// Read caching to None. Per MS-SMB2 3.3.5.14 and Samba
+	// `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default`,
+	// acquiring a byte-range lock invalidates remote read caches because
+	// another client may now read different data from the locked range.
+	// Unlike SMB CREATE breaks (which strip only the Write bit), this is a
+	// full revocation:
+	//   - RWH -> None
+	//   - RW  -> None
+	//   - RH  -> None
+	//   - R   -> None
+	// Leases without Read caching (None, W-only) are not broken: they cannot
+	// be caching reads. The locker's own lease must be excluded via
+	// excludeOwner.ExcludeLeaseKey ("nobreakself" per MS-SMB2 3.3.5.9).
+	BreakLeasesForByteRangeLock(handleKey string, excludeOwner *LockOwner) error
+
 	// BreakLeasesOnOpenConflict breaks existing leases before an SMB CREATE
 	// proceeds, per MS-SMB2 3.3.4.7 and Samba `source3/smbd/open.c::delay_for_oplock_fn`.
 	// Per-lease target state is computed via ComputeLeaseBreakTo(state, reason).
@@ -1347,6 +1363,30 @@ func (lm *Manager) CheckAndBreakCachingForRead(handleKey string, excludeOwner *L
 func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
 	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
 		return lease.HasWrite()
+	})
+}
+
+// BreakLeasesForByteRangeLock breaks every other-key lease that holds Read
+// caching to None when an SMB byte-range lock is acquired.
+//
+// Per MS-SMB2 3.3.5.14 (Receiving an SMB2 LOCK Request) and Samba
+// `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default`
+// (lines 1391-1467) + `do_break_lease_to_none` (lines 1155-1206):
+// when a byte-range lock is granted on an open, every other lease holder
+// whose state has Read caching must be broken to None — Read caching
+// becomes invalid because the locking client may now write data the
+// remote cache can no longer observe.
+//
+// The locker's own lease (typically same lease key, possibly a same-key
+// secondary handle) is excluded via excludeOwner.ExcludeLeaseKey, mirroring
+// Samba's `smb2_lease_equal` no-self-break check.
+//
+// Leases without Read caching (None, or Write-only, which the protocol
+// disallows in practice) are skipped: there is no read cache to flush.
+// The break target is None — full revocation — not "strip W" or "strip H".
+func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *LockOwner) error {
+	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, func(lease *OpLock) bool {
+		return lease.HasRead()
 	})
 }
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -501,7 +501,6 @@ incomplete break notification delivery and multi-client coordination.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | #429 |
-| smb2.lease.lock1 | Leases | Lease + lock interaction not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)


### PR DESCRIPTION
## Root cause

`internal/adapter/smb/v2/handlers/lock.go::Lock` was calling `BreakConflictingOplocksOnOpen` → `Manager.CheckAndBreakLeasesForSMBOpen`, whose semantics are correct for SMB **CREATE** (strip W, preserve R+H) but wrong for SMB byte-range **LOCK**. Per MS-SMB2 3.3.5.14 and Samba `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default` (lines 1391-1467) + `do_break_lease_to_none` (lines 1155-1206), acquiring a byte-range lock invalidates **remote read caches**: every other-key lease holder whose state has Read caching must be broken to **None** (full revocation), because the locking client may now write data the remote cache cannot observe. Tests `smb2.lease.lock1` LEASE2/LEASE3 (both RH) were never broken because the predicate `HasWrite()` skipped them.

## Files touched

- `pkg/metadata/lock/manager.go` — added `LockManager.BreakLeasesForByteRangeLock(handleKey, excludeOwner)`: predicate `lease.HasRead()`, break-to `LeaseStateNone`. Reuses the existing `breakOpLocks` machinery (epoch advance, AND-merge with in-flight breaks, persistence).
- `internal/adapter/smb/lease/manager.go` — added `LeaseManager.BreakLeasesOnByteRangeLock` wrapper mirroring the existing `BreakConflictingOplocksOnOpen` shape.
- `internal/adapter/smb/v2/handlers/lock.go` — Lock handler now calls the new helper instead of the CREATE-shaped one. Pre-loop guard: skip the break entirely when every element is an unlock (Samba's `contend_level2_oplocks_begin` is invoked from `brl_lock` only, never `brl_unlock`).
- `pkg/metadata/lock/byte_range_lock_break_test.go` — new unit test file pinning the behavior with four scenarios:
  - 3-lease lock1 wire shape (LEASE1 preserved, LEASE2 + LEASE3 break to None)
  - leases without Read are skipped
  - in-flight Breaking lease gets `BreakingToRequired` AND-merged to None without re-dispatch
  - locker's own lease key is excluded ("nobreakself")
- `test/smb-conformance/smbtorture/KNOWN_FAILURES.md` — removed the `smb2.lease.lock1` row.

## Spec / Samba citations

- MS-SMB2 §3.3.5.14 (Receiving an SMB2 LOCK Request) — server breaks contending caches before granting the lock.
- MS-FSA §2.1.5.7 — exclusive byte-range lock invalidates read-cache validity on remote handles.
- Samba `source3/smbd/smb2_oplock.c::contend_level2_oplocks_begin_default` lines 1391-1467 — walks all leases, breaks those with `SMB2_LEASE_READ` to None.
- Samba `do_break_lease_to_none` lines 1155-1206 — predicate `if ((current_state & SMB2_LEASE_READ) == 0) return false;` and `our_own = smb2_lease_equal(...)` no-self-break.

## Before/after smbtorture

Not run locally — Docker not available in this worktree. Expected to flip `smb2.lease.lock1` to PASS based on the test's three CHECK assertions:
1. `CHECK_VAL(lease_break_info.count, 2)` after `LOCK h1` — exactly LEASE2 + LEASE3 broken.
2. After lock, LEASE1 stays at RH, LEASE2/LEASE3 read back as None.
3. After `LOCK h3`, `CHECK_BREAK_INFO("RH", "", LEASE1)` — LEASE1 broken from RH to None.

All three follow directly from the new helper's semantics; pinned by unit tests.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/adapter/smb/... ./pkg/metadata/... -race -count=1` — all pass
- [x] New unit tests exercise the lock1 wire shape, in-flight break tightening, and self-exclusion
- [ ] Live smbtorture `smb2.lease.lock1` PASS against DittoFS (deferred — needs Docker)
- [ ] Adjacent suite regression: `smb2.lease` parent suite stays at 38 + 1 = 39 PASS (deferred)

## Notes

- Round-4 architectural debt about persisting BRLs via `lockStore.PutLock` is **not** required for lock1 — that test does no restart and reads lease state inline. Tracking remains under the round-4 follow-up.
- The fire-and-forget break path is identical to Samba's: no `WaitForBreakCompletion` is called from the Lock handler. Clients observe the lease break notification asynchronously after the LOCK reply.