### PR TITLE
fix(smb): round 7 lease — oplock cross-tier rules (#429)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -125,6 +125,50 @@ func (lm *LeaseManager) RequestLease(
 	requestedState uint32,
 	isDirectory bool,
 ) (grantedState uint32, epoch uint16, err error) {
+	return lm.requestLeaseInternal(ctx, fileHandle, leaseKey, parentLeaseKey,
+		sessionID, ownerID, clientID, shareName, requestedState, isDirectory, false)
+}
+
+// RequestLeaseAsOplock is the traditional-oplock variant of RequestLease.
+// CREATE handlers route LEVEL_II / Exclusive / Batch oplock requests through
+// this method (under a synthetic lease key derived from the FileID) so the
+// underlying lock manager tags the resulting record `IsTraditionalOplock`
+// and can apply the MS-SMB2 §3.3.5.9 cross-tier rules during subsequent
+// grants. See `bestGrantableState` in `pkg/metadata/lock/leases.go`.
+func (lm *LeaseManager) RequestLeaseAsOplock(
+	ctx context.Context,
+	fileHandle lock.FileHandle,
+	leaseKey [16]byte,
+	parentLeaseKey [16]byte,
+	sessionID uint64,
+	ownerID string,
+	clientID string,
+	shareName string,
+	requestedState uint32,
+	isDirectory bool,
+) (grantedState uint32, epoch uint16, err error) {
+	return lm.requestLeaseInternal(ctx, fileHandle, leaseKey, parentLeaseKey,
+		sessionID, ownerID, clientID, shareName, requestedState, isDirectory, true)
+}
+
+// requestLeaseInternal is the shared body of RequestLease /
+// RequestLeaseAsOplock; the only behavior change between the two is which
+// underlying Manager method we dispatch to so the new record gets the
+// correct IsTraditionalOplock tag and the cross-tier rules in
+// bestGrantableState see the right requestor tier.
+func (lm *LeaseManager) requestLeaseInternal(
+	ctx context.Context,
+	fileHandle lock.FileHandle,
+	leaseKey [16]byte,
+	parentLeaseKey [16]byte,
+	sessionID uint64,
+	ownerID string,
+	clientID string,
+	shareName string,
+	requestedState uint32,
+	isDirectory bool,
+	isTraditionalOplock bool,
+) (grantedState uint32, epoch uint16, err error) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return lock.LeaseStateNone, 0, fmt.Errorf("no lock manager for share %q", shareName)
@@ -146,12 +190,25 @@ func (lm *LeaseManager) RequestLease(
 	lm.leaseShare[keyHex] = shareName
 	lm.mu.Unlock()
 
-	// Delegate to shared LockManager
-	grantedState, epoch, err = lockMgr.RequestLease(
-		ctx, fileHandle, leaseKey, parentLeaseKey,
-		ownerID, clientID, shareName,
-		requestedState, isDirectory,
-	)
+	// Dispatch to the appropriate Manager method so the new record's
+	// IsTraditionalOplock tag is set correctly. The LockManager interface
+	// deliberately stays narrow (no oplock variant): when the configured
+	// store is a *lock.Manager (the only production impl) and this is a
+	// traditional-oplock request, call the tagged method; otherwise fall
+	// through to the plain interface call so test doubles keep working.
+	if mgr, ok := lockMgr.(*lock.Manager); ok && isTraditionalOplock {
+		grantedState, epoch, err = mgr.RequestLeaseAsOplock(
+			ctx, fileHandle, leaseKey, parentLeaseKey,
+			ownerID, clientID, shareName,
+			requestedState, isDirectory,
+		)
+	} else {
+		grantedState, epoch, err = lockMgr.RequestLease(
+			ctx, fileHandle, leaseKey, parentLeaseKey,
+			ownerID, clientID, shareName,
+			requestedState, isDirectory,
+		)
+	}
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
 		lm.removeLeaseMapping(keyHex)
 		return 0, 0, err

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -689,7 +689,12 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						syntheticKey := generateSyntheticLeaseKey(smbFileID)
 						ownerID := fmt.Sprintf("smb:oplock:%x", smbFileID)
 						clientID := fmt.Sprintf("smb:%d", ctx.SessionID)
-						grantedState, _, leaseErr := h.LeaseManager.RequestLease(
+						// Reconnect path for a previously-granted traditional
+						// oplock. Re-tag IsTraditionalOplock so the cross-tier
+						// rules in bestGrantableState continue to apply for
+						// concurrent real-lease grants (matches Samba's
+						// post-reclaim share_mode_entry op_type semantics).
+						grantedState, _, leaseErr := h.LeaseManager.RequestLeaseAsOplock(
 							authCtx.Context,
 							lockFileHandle,
 							syntheticKey,

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -362,7 +362,11 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			lockFileHandle := lock.FileHandle(fileHandle)
 			ownerID := fmt.Sprintf("smb:oplock:%x", smbFileID)
 			clientID := fmt.Sprintf("smb:%d", ctx.SessionID)
-			grantedState, _, err := h.LeaseManager.RequestLease(
+			// RequestLeaseAsOplock tags the new record IsTraditionalOplock=true
+			// so MS-SMB2 §3.3.5.9 cross-tier rules apply on subsequent grants
+			// (Samba `state.got_handle_lease` / `state.got_oplock`). See
+			// `pkg/metadata/lock/leases.go::bestGrantableState`.
+			grantedState, _, err := h.LeaseManager.RequestLeaseAsOplock(
 				authCtx.Context,
 				lockFileHandle,
 				syntheticKey,

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -226,6 +226,26 @@ func (lm *Manager) hasPersistedLeaseKeyOnOtherFile(ctx context.Context, leaseKey
 func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
 	parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
 	requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error) {
+	return lm.requestLeaseImplWithMode(ctx, fileHandle, leaseKey, parentLeaseKey,
+		ownerID, clientID, shareName, requestedState, isDirectory, false)
+}
+
+// requestLeaseImplWithMode is the underlying lease-grant implementation with
+// the additional `isTraditionalOplock` flag distinguishing real SMB2.1+ leases
+// from synthetic-key records modeling traditional oplocks (LEVEL_II/Exclusive/
+// Batch). The flag is consumed by `bestGrantableState` to apply the MS-SMB2
+// §3.3.5.9 cross-tier rules:
+//
+//   - traditional-oplock requestor + any other-key holder with H bit → NONE
+//     (Samba `state.got_handle_lease` in `delay_for_oplock_fn`)
+//   - real-lease requestor + any other-key traditional-oplock holder → strip H
+//     (Samba `state.got_oplock`)
+//
+// And it propagates the flag onto the new record via `createAndGrantLease`
+// so subsequent grants can detect it.
+func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
+	parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
+	requestedState uint32, isDirectory bool, isTraditionalOplock bool) (grantedState uint32, epoch uint16, err error) {
 
 	// Coerce no-Read caching combinations (W=0x04, H=0x02, HW=0x06) to
 	// LeaseState=None and grant successfully. Per Samba
@@ -563,7 +583,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 	}
 	// lm.mu is held here (either from initial Lock or re-Lock after break)
 
-	grantState := bestGrantableState(locks, leaseKey, requestedState, isDirectory)
+	grantState := bestGrantableState(locks, leaseKey, requestedState, isDirectory, isTraditionalOplock)
 	if grantState == LeaseStateNone {
 		lm.mu.Unlock()
 		logger.Debug("RequestLease: no compatible state after conflict resolution",
@@ -574,7 +594,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 
 	granted, epoch := lm.createAndGrantLease(ctx, handleKey, fileHandle,
 		leaseKey, parentLeaseKey, ownerID, clientID, shareName,
-		grantState, isDirectory)
+		grantState, isDirectory, isTraditionalOplock)
 	lm.mu.Unlock()
 
 	logger.Debug("RequestLease: granted lease",
@@ -593,17 +613,69 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, 
 // state first, then progressively lower states per MS-SMB2 3.3.5.9:
 // requested -> strip W -> strip H -> R only -> None.
 //
+// `isTraditionalOplock` distinguishes the requestor's tier (real lease vs.
+// synthetic-key traditional oplock). Per MS-SMB2 §3.3.5.9 and Samba
+// `source3/smbd/open.c::grant_fsp_oplock_type` (lines 2663-2680):
+//
+//   - traditional-oplock requestor + any other-key holder with H bit
+//     => NONE (Samba `state.got_handle_lease`).
+//   - real-lease requestor + any other-key traditional-oplock holder
+//     => strip H from the candidate before conflict check (Samba
+//     `state.got_oplock`).
+//
+// The H bit in an existing holder is read from BreakingToRequired when
+// the holder is mid-break (so a still-flushing RWH that is heading to RH
+// keeps its H presence visible until ack lands), otherwise from
+// LeaseState — same convention as `OpLocksConflict`.
+//
 // Precondition: caller must hold lm.mu (read or write). The locks slice is
 // read from lm.unifiedLocks[handleKey] under that lock, so no concurrent
 // mutation can occur while this function iterates.
-func bestGrantableState(locks []*UnifiedLock, leaseKey [16]byte, requestedState uint32, isDirectory bool) uint32 {
+func bestGrantableState(locks []*UnifiedLock, leaseKey [16]byte, requestedState uint32, isDirectory bool, isTraditionalOplock bool) uint32 {
+	// Cross-tier pre-pass: scan once for the two sentinels Samba tracks in
+	// `delay_for_oplock_fn` (got_handle_lease, got_oplock). Reading
+	// effectiveLeaseState here keeps the post-break view consistent with
+	// OpLocksConflict — a holder breaking to RH still counts as having H.
+	var otherHasHandle, otherIsTradOplock bool
+	for _, lock := range locks {
+		if lock.Lease == nil || lock.Lease.LeaseKey == leaseKey {
+			continue
+		}
+		state := lock.Lease.LeaseState
+		if lock.Lease.Breaking {
+			state = lock.Lease.BreakingToRequired
+		}
+		if state&LeaseStateHandle != 0 {
+			otherHasHandle = true
+		}
+		if lock.Lease.IsTraditionalOplock {
+			otherIsTradOplock = true
+		}
+	}
+
+	// Rule 1: traditional-oplock requestor against any H-holder => NONE.
+	if isTraditionalOplock && otherHasHandle {
+		return LeaseStateNone
+	}
+
+	// Rule 2 mask: real-lease requestor against any traditional-oplock holder
+	// must have H stripped from each candidate before the conflict check.
+	// Loop-invariant so compute once.
+	var stripMask uint32
+	if !isTraditionalOplock && otherIsTradOplock {
+		stripMask = LeaseStateHandle
+	}
+
 	candidates := downgradeCandidates(requestedState, isDirectory)
 
 outer:
 	for _, candidate := range candidates {
+		effective := candidate &^ stripMask
+		// Stripping may collapse to a state already tried; dedup is
+		// unnecessary because the grant is idempotent.
 		tempLease := &OpLock{
 			LeaseKey:   leaseKey,
-			LeaseState: candidate,
+			LeaseState: effective,
 		}
 		for _, lock := range locks {
 			if lock.Lease == nil || lock.Lease.LeaseKey == leaseKey {
@@ -613,7 +685,9 @@ outer:
 				continue outer
 			}
 		}
-		return candidate
+		// effective may differ from candidate (H stripped); return what
+		// was actually granted so the caller persists the post-strip state.
+		return effective
 	}
 	return LeaseStateNone
 }
@@ -662,6 +736,7 @@ func (lm *Manager) createAndGrantLease(
 	ownerID, clientID, shareName string,
 	requestedState uint32,
 	isDirectory bool,
+	isTraditionalOplock bool,
 ) (uint32, uint16) {
 	newLock := &UnifiedLock{
 		ID: uuid.New().String(),
@@ -676,11 +751,12 @@ func (lm *Manager) createAndGrantLease(
 		Type:       lockTypeForLeaseState(requestedState),
 		AcquiredAt: time.Now(),
 		Lease: &OpLock{
-			LeaseKey:       leaseKey,
-			LeaseState:     requestedState,
-			ParentLeaseKey: parentLeaseKey,
-			IsDirectory:    isDirectory,
-			Epoch:          1, // New leases start at epoch 1
+			LeaseKey:            leaseKey,
+			LeaseState:          requestedState,
+			ParentLeaseKey:      parentLeaseKey,
+			IsDirectory:         isDirectory,
+			IsTraditionalOplock: isTraditionalOplock,
+			Epoch:               1, // New leases start at epoch 1
 		},
 	}
 

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1255,7 +1255,7 @@ func TestBestGrantableState_NoConflicts(t *testing.T) {
 
 	// Empty lock set - full request granted
 	key := [16]byte{1}
-	state := bestGrantableState(nil, key, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	state := bestGrantableState(nil, key, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false, false)
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
 }
 
@@ -1271,7 +1271,7 @@ func TestBestGrantableState_FileRWH_DowngradesWithExistingR(t *testing.T) {
 
 	// RWH: Write conflicts with existing Read -> skip
 	// RH: Handle doesn't conflict with Read -> grant RH
-	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false, false)
 	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
 }
 
@@ -1287,7 +1287,7 @@ func TestBestGrantableState_FileRWH_DowngradesToRH(t *testing.T) {
 
 	// RWH: Write conflicts with existing Read -> skip
 	// RH: no conflict -> grant RH
-	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false, false)
 	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
 }
 
@@ -1300,7 +1300,7 @@ func TestBestGrantableState_SameKeyIgnored(t *testing.T) {
 		{Lease: &OpLock{LeaseKey: sameKey, LeaseState: LeaseStateRead | LeaseStateWrite}},
 	}
 
-	state := bestGrantableState(locks, sameKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	state := bestGrantableState(locks, sameKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false, false)
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
 }
 
@@ -1318,7 +1318,7 @@ func TestBestGrantableState_DirectoryRWH_DowngradeCascade(t *testing.T) {
 	// RH: existing W conflicts with requested R -> skip
 	// R: existing W conflicts with requested R -> skip
 	// All candidates conflict -> None
-	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true, false)
 	assert.Equal(t, LeaseStateNone, state)
 }
 
@@ -1336,7 +1336,7 @@ func TestBestGrantableState_AllConflict_ReturnsNone(t *testing.T) {
 	// RW: W conflicts with existing R/W -> skip
 	// R: existing W conflicts with requested R -> skip
 	// All candidates conflict -> None
-	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite, false)
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateWrite, false, false)
 	assert.Equal(t, LeaseStateNone, state)
 }
 
@@ -1769,4 +1769,171 @@ func TestAnyHolderHasLeaseBits(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, mgr.AnyHolderHasLeaseBits("h-mixed", [16]byte{}, LeaseStateWrite))
 	assert.False(t, mgr.AnyHolderHasLeaseBits("h-mixed", [16]byte{}, LeaseStateHandle))
+}
+
+// ============================================================================
+// Cross-Tier Grant Rules (smbtorture smb2.lease.oplock)
+// ============================================================================
+//
+// MS-SMB2 §3.3.5.9 / Samba `source3/smbd/open.c::grant_fsp_oplock_type`
+// (lines 2663-2680) defines two cross-tier rules between SMB2.1+ leases and
+// traditional oplocks (LEVEL_II / Exclusive / Batch). DittoFS models both
+// tiers as lease records (synthetic-key for traditional oplocks) tagged via
+// IsTraditionalOplock; bestGrantableState applies the rules.
+//
+// Coverage matches the smbtorture smb2.lease.oplock test matrix
+// (oplock_results / oplock_results_2 in source4/torture/smb2/lease.c).
+
+// Loop 1: traditional-oplock requestor against existing real-lease holder.
+// `state.got_handle_lease` ⇒ requestor downgraded to NONE iff existing has H.
+
+func TestBestGrantableState_TradOplockRequest_AgainstRH_ReturnsNone(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors oplock_results row {"RH", "s", "RH", ""}: existing real lease
+	// holds RH; new traditional LEVEL_II opener (synthetic key, R) must be
+	// granted NONE because existing has the Handle bit.
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{LeaseKey: otherKey, LeaseState: LeaseStateRead | LeaseStateHandle}},
+	}
+	state := bestGrantableState(locks, requestKey, LeaseStateRead, false, true)
+	assert.Equal(t, LeaseStateNone, state, "trad-oplock contender vs RH lease ⇒ NONE")
+}
+
+func TestBestGrantableState_TradOplockRequest_AgainstR_GrantsR(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors oplock_results row {"R", "s", "R", "s"}: existing real lease
+	// holds R; LEVEL_II contender is granted R (mapping back to s on the
+	// wire). H bit is absent ⇒ rule does not fire.
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{LeaseKey: otherKey, LeaseState: LeaseStateRead}},
+	}
+	state := bestGrantableState(locks, requestKey, LeaseStateRead, false, true)
+	assert.Equal(t, LeaseStateRead, state, "trad-oplock contender vs R lease ⇒ R")
+}
+
+func TestBestGrantableState_TradOplockRequest_AgainstBreakingRWH_ReturnsNone(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors oplock_results row {"RHW", "s", "RH", ""}: existing RWH lease
+	// is breaking to RH. The H bit must still register as present on the
+	// holder during the break, so the trad-oplock contender gets NONE.
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{
+			LeaseKey:           otherKey,
+			LeaseState:         LeaseStateRead | LeaseStateWrite | LeaseStateHandle,
+			Breaking:           true,
+			BreakingToRequired: LeaseStateRead | LeaseStateHandle,
+		}},
+	}
+	state := bestGrantableState(locks, requestKey, LeaseStateRead, false, true)
+	assert.Equal(t, LeaseStateNone, state, "trad-oplock vs RWH→RH (breaking) ⇒ NONE")
+}
+
+// Loop 2: real-lease requestor against existing traditional-oplock holder.
+// `state.got_oplock` ⇒ H bit stripped from grant.
+
+func TestBestGrantableState_LeaseRequest_AgainstTradOplockR_StripsHandle(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors oplock_results_2 row {"s", "RH", "s", "R"}: held LEVEL_II
+	// (synthetic R, IsTraditionalOplock=true); new lease request RH must be
+	// granted R (Handle stripped).
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{
+			LeaseKey:            otherKey,
+			LeaseState:          LeaseStateRead,
+			IsTraditionalOplock: true,
+		}},
+	}
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateHandle, false, false)
+	assert.Equal(t, LeaseStateRead, state, "RH lease vs LEVEL_II oplock ⇒ R (H stripped)")
+}
+
+func TestBestGrantableState_LeaseRequest_AgainstTradOplockR_RHW_StripsHandle(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors oplock_results_2 row {"s", "RHW", "s", "R"}: held LEVEL_II
+	// (synthetic R); request RHW. The full RHW conflicts on W vs existing
+	// R; the strip-W candidate is RH; the trad-oplock rule then strips H,
+	// giving R.
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{
+			LeaseKey:            otherKey,
+			LeaseState:          LeaseStateRead,
+			IsTraditionalOplock: true,
+		}},
+	}
+	state := bestGrantableState(locks, requestKey,
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false, false)
+	assert.Equal(t, LeaseStateRead, state,
+		"RHW lease vs LEVEL_II oplock ⇒ R (W conflicts, then H stripped)")
+}
+
+func TestBestGrantableState_LeaseRequest_AgainstRealLeaseR_KeepsHandle(t *testing.T) {
+	t.Parallel()
+
+	// Sanity check: when the existing holder is a *real* lease (not a
+	// traditional oplock), Handle is NOT stripped — the cross-tier rule
+	// fires only for traditional-oplock holders.
+	otherKey := [16]byte{2}
+	requestKey := [16]byte{1}
+	locks := []*UnifiedLock{
+		{Lease: &OpLock{LeaseKey: otherKey, LeaseState: LeaseStateRead}},
+	}
+	state := bestGrantableState(locks, requestKey, LeaseStateRead|LeaseStateHandle, false, false)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state,
+		"RH lease vs real R lease ⇒ RH (no strip)")
+}
+
+func TestRequestLeaseAsOplock_TagsIsTraditionalOplock(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+
+	syntheticKey := [16]byte{0xAA}
+	_, _, err := mgr.RequestLeaseAsOplock(ctx, FileHandle("h1"), syntheticKey, [16]byte{},
+		"smb:oplock:abc", "smb:1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+
+	// Inspect the stored record's flag.
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	locks := mgr.unifiedLocks["h1"]
+	require.Len(t, locks, 1)
+	require.NotNil(t, locks[0].Lease)
+	assert.True(t, locks[0].Lease.IsTraditionalOplock,
+		"RequestLeaseAsOplock must tag IsTraditionalOplock=true")
+}
+
+func TestRequestLease_DoesNotTagIsTraditionalOplock(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+
+	leaseKey := [16]byte{0xBB}
+	_, _, err := mgr.RequestLease(ctx, FileHandle("h1"), leaseKey, [16]byte{},
+		"smb:lease:abc", "smb:1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	locks := mgr.unifiedLocks["h1"]
+	require.Len(t, locks, 1)
+	require.NotNil(t, locks[0].Lease)
+	assert.False(t, locks[0].Lease.IsTraditionalOplock,
+		"RequestLease must NOT tag IsTraditionalOplock")
 }

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -810,6 +810,21 @@ func (lm *Manager) RequestLease(ctx context.Context, fileHandle FileHandle, leas
 	return lm.requestLeaseImpl(ctx, fileHandle, leaseKey, parentLeaseKey, ownerID, clientID, shareName, requestedState, isDirectory)
 }
 
+// RequestLeaseAsOplock is the traditional-oplock variant of RequestLease.
+// The SMB adapter calls this when a CREATE arrives with a non-Lease
+// OplockLevel (LEVEL_II / Exclusive / Batch); the new record is tagged
+// `IsTraditionalOplock=true` so subsequent grants observe the cross-tier
+// rules described in `bestGrantableState`. All other parameters and
+// semantics match `RequestLease`.
+//
+// Reference: MS-SMB2 §3.3.5.9 / Samba `source3/smbd/open.c::grant_fsp_oplock_type`.
+func (lm *Manager) RequestLeaseAsOplock(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
+	parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
+	requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error) {
+	return lm.requestLeaseImplWithMode(ctx, fileHandle, leaseKey, parentLeaseKey,
+		ownerID, clientID, shareName, requestedState, isDirectory, true)
+}
+
 // AcknowledgeLeaseBreak processes a client's lease break acknowledgment.
 func (lm *Manager) AcknowledgeLeaseBreak(ctx context.Context, leaseKey [16]byte,
 	acknowledgedState uint32, epoch uint16) error {

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -197,6 +197,27 @@ type OpLock struct {
 	// When true, valid lease states are restricted to ValidDirectoryLeaseStates
 	// (None, R, RH).
 	IsDirectory bool
+
+	// IsTraditionalOplock indicates this record models a traditional SMB
+	// oplock (LEVEL_II / Exclusive / Batch) rather than an SMB2.1+ lease.
+	// The SMB adapter creates such records under a *synthetic* lease key
+	// derived from the SMB2 FileID so the lock manager can use a single
+	// caching-rights datatype for both tiers (Samba `op_type`).
+	//
+	// The flag exists because MS-SMB2 §3.3.5.9 imposes cross-tier rules
+	// during CREATE-time grant computation that cannot be expressed in
+	// pure R/W/H state alone:
+	//
+	//   - A traditional-oplock requestor MUST be granted NONE if any
+	//     existing lease holder includes Handle caching (Samba
+	//     `state.got_handle_lease` in `delay_for_oplock_fn`).
+	//   - A real-lease requestor MUST have its Handle bit stripped if
+	//     any existing entry is a traditional oplock (Samba
+	//     `state.got_oplock`).
+	//
+	// `bestGrantableState` consults this field on existing entries to
+	// apply both rules.
+	IsTraditionalOplock bool
 }
 
 // HasRead returns true if the lease includes Read caching permission.
@@ -270,16 +291,17 @@ func (l *OpLock) Clone() *OpLock {
 		return nil
 	}
 	return &OpLock{
-		LeaseKey:           l.LeaseKey, // Fixed-size array, copied by value
-		LeaseState:         l.LeaseState,
-		BreakToState:       l.BreakToState,
-		BreakingToRequired: l.BreakingToRequired,
-		Breaking:           l.Breaking,
-		Epoch:              l.Epoch,
-		BreakStarted:       l.BreakStarted,
-		Reclaim:            l.Reclaim,
-		ParentLeaseKey:     l.ParentLeaseKey, // Fixed-size array, copied by value
-		IsDirectory:        l.IsDirectory,
+		LeaseKey:            l.LeaseKey, // Fixed-size array, copied by value
+		LeaseState:          l.LeaseState,
+		BreakToState:        l.BreakToState,
+		BreakingToRequired:  l.BreakingToRequired,
+		Breaking:            l.Breaking,
+		Epoch:               l.Epoch,
+		BreakStarted:        l.BreakStarted,
+		Reclaim:             l.Reclaim,
+		ParentLeaseKey:      l.ParentLeaseKey, // Fixed-size array, copied by value
+		IsDirectory:         l.IsDirectory,
+		IsTraditionalOplock: l.IsTraditionalOplock,
 	}
 }
 

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -102,6 +102,14 @@ type PersistedLock struct {
 	// False for byte-range locks and file leases/delegations.
 	IsDirectory bool `json:"is_directory,omitempty"`
 
+	// IsTraditionalOplock indicates this lease record actually models a
+	// traditional SMB oplock (LEVEL_II / Exclusive / Batch). See
+	// `OpLock.IsTraditionalOplock` for cross-tier grant rule semantics.
+	// Persisted so post-restart reclaim preserves the tier distinction
+	// — a reclaimed traditional oplock must continue to apply MS-SMB2
+	// §3.3.5.9 cross-tier rules against any concurrent real-lease grant.
+	IsTraditionalOplock bool `json:"is_traditional_oplock,omitempty"`
+
 	// ========================================================================
 	// Delegation Fields (omitempty for non-delegation locks)
 	// ========================================================================
@@ -323,6 +331,7 @@ func ToPersistedLock(lock *UnifiedLock, epoch uint64) *PersistedLock {
 		pl.BreakingToRequired = lock.Lease.BreakingToRequired
 		pl.Breaking = lock.Lease.Breaking
 		pl.IsDirectory = lock.Lease.IsDirectory
+		pl.IsTraditionalOplock = lock.Lease.IsTraditionalOplock
 
 		// Only set ParentLeaseKey when non-zero so omitempty works for V1 leases
 		if lock.Lease.ParentLeaseKey != [16]byte{} {
@@ -383,14 +392,15 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 		}
 
 		el.Lease = &OpLock{
-			LeaseKey:           leaseKey,
-			LeaseState:         pl.LeaseState,
-			Epoch:              pl.LeaseEpoch,
-			BreakToState:       pl.BreakToState,
-			BreakingToRequired: pl.BreakingToRequired,
-			Breaking:           pl.Breaking,
-			ParentLeaseKey:     parentLeaseKey,
-			IsDirectory:        pl.IsDirectory,
+			LeaseKey:            leaseKey,
+			LeaseState:          pl.LeaseState,
+			Epoch:               pl.LeaseEpoch,
+			BreakToState:        pl.BreakToState,
+			BreakingToRequired:  pl.BreakingToRequired,
+			Breaking:            pl.Breaking,
+			ParentLeaseKey:      parentLeaseKey,
+			IsDirectory:         pl.IsDirectory,
+			IsTraditionalOplock: pl.IsTraditionalOplock,
 			// BreakStarted is runtime-only, not persisted
 		}
 		// Backwards compat: locks persisted before BreakingToRequired existed

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -500,7 +500,6 @@ incomplete break notification delivery and multi-client coordination.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.lease.oplock | Leases | Lease + oplock interaction not fully working | #429 |
 | smb2.lease.v2_complex1 | Leases V2 | Lease V2 complex scenario not fully working | #429 |
 
 ### Byte-Range Locks (Fix Candidate)


### PR DESCRIPTION
## Summary

Apply MS-SMB2 §3.3.5.9 cross-tier rules between SMB2.1+ leases and traditional oplocks (LEVEL_II / Exclusive / Batch). Closes the \`smb2.lease.oplock\` smbtorture failure under #429.

## Root cause

DittoFS already modeled both tiers via a single lease record (synthetic-key for traditional oplocks), but \`bestGrantableState\` treated all holders uniformly. Per Samba \`source3/smbd/open.c::grant_fsp_oplock_type\` (L2663-2680), two tier-aware rules apply at grant time:

1. **Rule 1** (Samba \`state.got_handle_lease\`): traditional-oplock requestor + any other-key holder with H bit ⇒ NONE.
2. **Rule 2** (Samba \`state.got_oplock\`): real-lease requestor + any other-key traditional-oplock holder ⇒ strip H from each candidate before the conflict check.

The smbtorture \`oplock_results\` / \`oplock_results_2\` matrices in \`source4/torture/smb2/lease.c\` directly assert these.

## Implementation

- \`OpLock.IsTraditionalOplock\` flag (and \`PersistedLock.IsTraditionalOplock\` for post-restart reclaim) tags records modeling traditional oplocks.
- \`bestGrantableState\` does a one-pass scan of existing holders to compute \`otherHasHandle\` and \`otherIsTradOplock\` sentinels, then applies both rules.
- New \`RequestLeaseAsOplock\` on both \`lock.Manager\` and \`lease.LeaseManager\` so CREATE paths set the tag at grant time. The narrow \`LockManager\` interface is unchanged; the adapter type-asserts to \`*lock.Manager\` for the tagged variant and falls back to plain \`RequestLease\` for test doubles.
- Reconnect path (durable) and synthetic-oplock CREATE path both route through the new method.

## Files

- \`pkg/metadata/lock/oplock.go\` — \`IsTraditionalOplock\` field + \`Clone\`
- \`pkg/metadata/lock/leases.go\` — \`requestLeaseImplWithMode\`, cross-tier prepass in \`bestGrantableState\`
- \`pkg/metadata/lock/manager.go\` — public \`RequestLeaseAsOplock\`
- \`pkg/metadata/lock/store.go\` — persist / restore tag
- \`pkg/metadata/lock/leases_test.go\` — 6 new tests covering both rules + tagging
- \`internal/adapter/smb/lease/manager.go\` — adapter \`RequestLeaseAsOplock\` wrapper
- \`internal/adapter/smb/v2/handlers/{create.go, create_post_break.go}\` — route synthetic-oplock CREATE through new method
- \`test/smb-conformance/smbtorture/KNOWN_FAILURES.md\` — drop \`smb2.lease.oplock\` row

## Test plan

- [x] \`go test ./internal/adapter/smb/... ./pkg/metadata/... -race -count=1\` — green
- [ ] Live smbtorture verification — deferred (Docker congestion in agent env); the human will run \`./run.sh --filter smb2.lease\` before merge
- [x] Commit signed (G)

## Spec citations

- MS-SMB2 §3.3.5.9 Open Processing
- Samba \`source3/smbd/open.c::grant_fsp_oplock_type\` (L2663-2680)
- smbtorture \`source4/torture/smb2/lease.c\` \`oplock_results\` / \`oplock_results_2\` matrices