### PR TITLE
fix(smb): HIDDEN/SYSTEM attribute round-trip and overwrite mismatch check (refs #476)

### DIFF
--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -35,6 +35,10 @@ const (
 	// explicitly set. Only meaningful when modeDOSExplicit is also set.
 	modeDOSArchive = uint32(0x20000)
 
+	// modeDOSSystem tracks the DOS SYSTEM bit when DOS attributes have been
+	// explicitly set. Only meaningful when modeDOSExplicit is also set.
+	modeDOSSystem = uint32(0x80000)
+
 	// modeDOSCompressed tracks whether FSCTL_SET_COMPRESSION has been applied
 	// to a file or directory. When set, FILE_ATTRIBUTE_COMPRESSED (0x0800) is
 	// included in the SMB file attributes returned by GETINFO queries.
@@ -143,8 +147,15 @@ func fileAttrToSMBAttributesInternal(attr *metadata.FileAttr, hidden bool) types
 		attrs |= types.FileAttributeCompressed
 	}
 
-	// Set hidden attribute
-	if hidden {
+	// Per MS-FSCC 2.6: FILE_ATTRIBUTE_SYSTEM is stored in modeDOSSystem.
+	if attr.Mode&modeDOSSystem != 0 {
+		attrs |= types.FileAttributeSystem
+	}
+
+	// Per MS-FSCC 2.6: FILE_ATTRIBUTE_HIDDEN is set when either the caller
+	// explicitly passed hidden=true (dot-prefix detection) or when the metadata
+	// Hidden flag was set via a prior SET_INFO FileBasicInformation call.
+	if hidden || attr.Hidden {
 		attrs |= types.FileAttributeHidden
 	}
 
@@ -457,12 +468,15 @@ func SMBModeFromAttrs(attrs types.FileAttributes, isDirectory bool) uint32 {
 		mode &= ^uint32(0222) // Remove write bits
 	}
 
-	// Track that DOS attributes were explicitly set, and whether ARCHIVE is included.
+	// Track that DOS attributes were explicitly set, and which optional bits are set.
 	// This allows fileAttrToSMBAttributesInternal to return exactly the attributes
 	// the client set, rather than unconditionally adding ARCHIVE for regular files.
 	mode |= modeDOSExplicit
 	if attrs&types.FileAttributeArchive != 0 {
 		mode |= modeDOSArchive
+	}
+	if attrs&types.FileAttributeSystem != 0 {
+		mode |= modeDOSSystem
 	}
 
 	return mode

--- a/internal/adapter/smb/v2/handlers/converters_test.go
+++ b/internal/adapter/smb/v2/handlers/converters_test.go
@@ -116,6 +116,31 @@ func TestFileAttrToSMBAttributes_Directory(t *testing.T) {
 	}
 }
 
+func TestFileAttrToSMBAttributes_SystemBitRoundTrip(t *testing.T) {
+	mode := SMBModeFromAttrs(types.FileAttributeSystem|types.FileAttributeArchive, false)
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode}
+	got := FileAttrToSMBAttributes(attr)
+	if got&types.FileAttributeSystem == 0 {
+		t.Errorf("SYSTEM missing after round-trip: attrs=0x%x mode=0x%x", got, mode)
+	}
+}
+
+func TestFileAttrToSMBAttributesWithName_HiddenByMetadata(t *testing.T) {
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Hidden: true}
+	got := FileAttrToSMBAttributesWithName(attr, "normalname")
+	if got&types.FileAttributeHidden == 0 {
+		t.Errorf("HIDDEN missing when attr.Hidden=true, attrs=0x%x", got)
+	}
+}
+
+func TestFileAttrToSMBAttributesWithName_HiddenByDotPrefix(t *testing.T) {
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Hidden: false}
+	got := FileAttrToSMBAttributesWithName(attr, ".dotfile")
+	if got&types.FileAttributeHidden == 0 {
+		t.Errorf("HIDDEN missing for dot-prefix file, attrs=0x%x", got)
+	}
+}
+
 // TestSMBModeFromAttrs_OverwriteForcesArchive locks down the contract that
 // overwriteFile relies on: per MS-FSA 2.1.5.1.2.1, OVERWRITE/SUPERSEDE always
 // sets FILE_ATTRIBUTE_ARCHIVE on the post-overwrite metadata, so the mode

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -859,15 +859,27 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		}
 	}
 
-	// Per MS-FSA 2.1.5.1.2.1: Overwrite/supersede of a read-only file is
-	// not allowed. Return STATUS_ACCESS_DENIED.
+	// Per MS-FSA 2.1.5.1.2.1: Overwrite/supersede attribute mismatch rules.
+	// READONLY, HIDDEN, and SYSTEM on the existing file require the new request
+	// to include those same attributes, otherwise STATUS_ACCESS_DENIED.
 	if fileExists && existingFile.Type != metadata.FileTypeDirectory {
 		if createAction == types.FileOverwritten || createAction == types.FileSuperseded {
-			attrs := FileAttrToSMBAttributes(&existingFile.FileAttr)
-			if attrs&types.FileAttributeReadonly != 0 {
+			existingAttrs := FileAttrToSMBAttributes(&existingFile.FileAttr)
+			if existingAttrs&types.FileAttributeReadonly != 0 {
 				logger.Debug("CREATE: cannot overwrite read-only file",
 					"path", filename,
 					"action", createAction)
+				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
+			}
+			// Per MS-FSA 2.1.5.1.2.2: Hidden and System flags must be preserved.
+			if existingAttrs&types.FileAttributeHidden != 0 && req.FileAttributes&types.FileAttributeHidden == 0 {
+				logger.Debug("CREATE: attribute mismatch — existing hidden, request not hidden",
+					"path", filename)
+				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
+			}
+			if existingAttrs&types.FileAttributeSystem != 0 && req.FileAttributes&types.FileAttributeSystem == 0 {
+				logger.Debug("CREATE: attribute mismatch — existing system, request not system",
+					"path", filename)
 				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 			}
 		}
@@ -1189,7 +1201,8 @@ func (h *Handler) createNewFile(
 ) (*metadata.File, metadata.FileHandle, error) {
 	// Build file attributes
 	fileAttr := &metadata.FileAttr{
-		Mode: SMBModeFromAttrs(req.FileAttributes, isDirectory),
+		Mode:   SMBModeFromAttrs(req.FileAttributes, isDirectory),
+		Hidden: req.FileAttributes&types.FileAttributeHidden != 0,
 	}
 
 	// Set owner from auth context
@@ -1265,6 +1278,8 @@ func (h *Handler) overwriteFile(
 	mode := SMBModeFromAttrs(attrs, existingFile.Type == metadata.FileTypeDirectory)
 	mode |= existingFile.Mode & modeDOSCompressed
 	setAttrs.Mode = &mode
+	hiddenVal := req.FileAttributes&types.FileAttributeHidden != 0
+	setAttrs.Hidden = &hiddenVal
 
 	metaSvc := h.Registry.GetMetadataService()
 	err = metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs)

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -860,11 +860,11 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Per MS-FSA 2.1.5.1.2.1: Overwrite/supersede attribute mismatch rules.
-	// READONLY, HIDDEN, and SYSTEM on the existing file require the new request
-	// to include those same attributes, otherwise STATUS_ACCESS_DENIED.
+	// READONLY on the existing file denies the overwrite entirely.
+	// HIDDEN and SYSTEM must be present in the request if set on the existing file.
 	if fileExists && existingFile.Type != metadata.FileTypeDirectory {
 		if createAction == types.FileOverwritten || createAction == types.FileSuperseded {
-			existingAttrs := FileAttrToSMBAttributes(&existingFile.FileAttr)
+			existingAttrs := FileAttrToSMBAttributesWithName(&existingFile.FileAttr, baseName)
 			if existingAttrs&types.FileAttributeReadonly != 0 {
 				logger.Debug("CREATE: cannot overwrite read-only file",
 					"path", filename,

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -305,6 +305,10 @@ func (h *Handler) setFileInfoFromStore(
 				mode |= curFile.Mode & modeDOSCompressed
 			}
 			setAttrs.Mode = &mode
+			// Per MS-FSCC 2.6: propagate FILE_ATTRIBUTE_HIDDEN into the metadata
+			// Hidden field so QUERY_INFO and QUERY_DIRECTORY round-trip correctly.
+			hiddenVal := fileAttrs&types.FileAttributeHidden != 0
+			setAttrs.Hidden = &hiddenVal
 		}
 
 		// Per MS-FSA 2.1.5.14.2: Handle timestamp freeze/unfreeze sentinels.

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -293,6 +293,11 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		modified = true
 	}
 
+	if attrs.Hidden != nil {
+		file.Hidden = *attrs.Hidden
+		modified = true
+	}
+
 	// Auto-update ctime when attributes change, unless explicitly set
 	if modified {
 		if attrs.Ctime == nil {

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -231,8 +231,9 @@ func DefaultMode(fileType FileType) uint32 {
 
 // modeMask defines the valid mode bits: Unix permissions (bits 0-11) plus
 // two persistent SMB adapter bits:
-//   0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
-//   0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was explicitly set
+//
+//	0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
+//	0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was explicitly set
 //
 // modeDOSExplicit (0x10000) and modeDOSArchive (0x20000) are intentionally
 // excluded: they are only set via SET_INFO which bypasses ApplyModeDefault,

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -230,13 +230,15 @@ func DefaultMode(fileType FileType) uint32 {
 }
 
 // modeMask defines the valid mode bits: Unix permissions (bits 0-11) plus
-// Bits 16-19 are used by the SMB adapter to persist DOS attribute state:
+// two persistent SMB adapter bits:
+//   0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
+//   0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was explicitly set
 //
-//	0x10000 modeDOSExplicit   — attributes were explicitly set via SET_INFO
-//	0x20000 modeDOSArchive    — FILE_ATTRIBUTE_ARCHIVE was explicitly set
-//	0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
-//	0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was set
-const modeMask = uint32(0o7777) | 0xF0000 // Unix perm bits + all 4 DOS high bits
+// modeDOSExplicit (0x10000) and modeDOSArchive (0x20000) are intentionally
+// excluded: they are only set via SET_INFO which bypasses ApplyModeDefault,
+// so they must not be preserved through CREATE defaults (which would suppress
+// the automatic ARCHIVE bit for regular files).
+const modeMask = uint32(0o7777) | 0x40000 | 0x80000 // Unix perms + Compressed + System
 
 // ApplyModeDefault applies the default mode if the provided mode is 0.
 // Masks to valid bits (Unix permissions + extended DOS flags) to prevent

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -231,10 +231,11 @@ func DefaultMode(fileType FileType) uint32 {
 
 // modeMask defines the valid mode bits: Unix permissions (bits 0-11) plus
 // Bits 16-19 are used by the SMB adapter to persist DOS attribute state:
-//   0x10000 modeDOSExplicit   — attributes were explicitly set via SET_INFO
-//   0x20000 modeDOSArchive    — FILE_ATTRIBUTE_ARCHIVE was explicitly set
-//   0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
-//   0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was set
+//
+//	0x10000 modeDOSExplicit   — attributes were explicitly set via SET_INFO
+//	0x20000 modeDOSArchive    — FILE_ATTRIBUTE_ARCHIVE was explicitly set
+//	0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
+//	0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was set
 const modeMask = uint32(0o7777) | 0xF0000 // Unix perm bits + all 4 DOS high bits
 
 // ApplyModeDefault applies the default mode if the provided mode is 0.

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -230,11 +230,12 @@ func DefaultMode(fileType FileType) uint32 {
 }
 
 // modeMask defines the valid mode bits: Unix permissions (bits 0-11) plus
-// modeDOSCompressed (bit 18, 0x40000) used by the SMB adapter to persist
-// FSCTL_SET_COMPRESSION state. modeDOSExplicit and modeDOSArchive (bits 16-17)
-// are intentionally NOT preserved here — they are set via explicit SET_INFO
-// calls that bypass ApplyModeDefault.
-const modeMask = uint32(0o7777) | 0x40000 // 0x00040FFF
+// Bits 16-19 are used by the SMB adapter to persist DOS attribute state:
+//   0x10000 modeDOSExplicit   — attributes were explicitly set via SET_INFO
+//   0x20000 modeDOSArchive    — FILE_ATTRIBUTE_ARCHIVE was explicitly set
+//   0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
+//   0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was set
+const modeMask = uint32(0o7777) | 0xF0000 // Unix perm bits + all 4 DOS high bits
 
 // ApplyModeDefault applies the default mode if the provided mode is 0.
 // Masks to valid bits (Unix permissions + extended DOS flags) to prevent


### PR DESCRIPTION
Implement full HIDDEN and SYSTEM attribute persistence so smbtorture smb2.dosmode, smb2.async_dosmode, smb2.openattr, and smb2.winattr can pass.

## Root cause

DittoFS stored READONLY via Unix permission bits and ARCHIVE via `modeDOSArchive`, but had no persistence for HIDDEN or SYSTEM attributes:
- `FILE_ATTRIBUTE_HIDDEN` was only detected from the filename (dot-prefix) — SET_INFO with HIDDEN was silently dropped
- `FILE_ATTRIBUTE_SYSTEM` had no storage at all

## Changes

**converters.go**
- New `modeDOSSystem` bit (0x80000) in the Mode field persists SYSTEM across handle cycles
- `fileAttrToSMBAttributesInternal`: returns SYSTEM when `modeDOSSystem` is set; returns HIDDEN when `hidden || attr.Hidden` (fixes `FileAttrToFileBasicInfo` which passes `hidden=false`)
- `SMBModeFromAttrs`: encodes SYSTEM bit into `modeDOSSystem`

**set_info.go**
- When `FileBasicInformation.FileAttributes != 0`, propagate `FILE_ATTRIBUTE_HIDDEN` into `SetAttrs.Hidden` so the metadata `Hidden` field is updated on every SET_INFO call

**create.go**
- `createNewFile`: initialise `fileAttr.Hidden` from `req.FileAttributes & FileAttributeHidden`
- `overwriteFile`: set `SetAttrs.Hidden` from request attributes after truncate
- OVERWRITE/SUPERSEDE: return `STATUS_ACCESS_DENIED` when existing file carries HIDDEN or SYSTEM and new request omits them (MS-FSA §2.1.5.1.2.2)

## Tests expected to flip
- `smb2.dosmode`
- `smb2.async_dosmode`
- `smb2.openattr`
- `smb2.winattr`

Refs: #476