### PR TITLE
fix(smb): walk back DOC permission tests from KNOWN_FAILURES (#475)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -214,6 +214,14 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
 			}
 		}
+		// New file with READONLY+DOC is impossible per MS-FSA 2.1.5.1.2.1: the
+		// resulting file would be marked DOC and READONLY simultaneously, but
+		// READONLY blocks the eventual unlink. Reject up-front so we don't
+		// create an undeletable orphan.
+		if !fileExists && req.FileAttributes&types.FileAttributeReadonly != 0 {
+			logger.Debug("CREATE: delete-on-close on new read-only file", "path", filename)
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
+		}
 	}
 
 	// Step 7: Perform create/open.

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -214,12 +214,13 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
 			}
 		}
-		// New file with READONLY+DOC is impossible per MS-FSA 2.1.5.1.2.1: the
-		// resulting file would be marked DOC and READONLY simultaneously, but
-		// READONLY blocks the eventual unlink. Reject up-front so we don't
-		// create an undeletable orphan.
-		if !fileExists && req.FileAttributes&types.FileAttributeReadonly != 0 {
-			logger.Debug("CREATE: delete-on-close on new read-only file", "path", filename)
+		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.2.1: the resulting file
+		// would be marked DOC and READONLY simultaneously, but READONLY blocks
+		// the eventual unlink. Fires for any disposition that propagates the
+		// requested attributes (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF)
+		// — Samba's open_match_attributes equivalent.
+		if req.FileAttributes&types.FileAttributeReadonly != 0 {
+			logger.Debug("CREATE: delete-on-close with read-only attribute in request", "path", filename)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -216,11 +216,19 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.2.1: the resulting file
 		// would be marked DOC and READONLY simultaneously, but READONLY blocks
-		// the eventual unlink. Fires for any disposition that propagates the
-		// requested attributes (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF)
-		// — Samba's open_match_attributes equivalent.
-		if req.FileAttributes&types.FileAttributeReadonly != 0 {
-			logger.Debug("CREATE: delete-on-close with read-only attribute in request", "path", filename)
+		// the eventual unlink. Only fires when req.FileAttributes actually
+		// propagates to the resulting file — dispositions that create or
+		// rewrite (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF). For
+		// FILE_OPEN / FILE_OPEN_IF on an existing file the request attrs are
+		// ignored and the disk attrs apply; that path is covered by the
+		// existing-file arm above.
+		propagatesReqAttrs := createAction == types.FileCreated ||
+			createAction == types.FileOverwritten ||
+			createAction == types.FileSuperseded
+		if propagatesReqAttrs && req.FileAttributes&types.FileAttributeReadonly != 0 {
+			logger.Debug("CREATE: delete-on-close with read-only attribute in request",
+				"path", filename,
+				"createAction", createAction)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
 		}
 	}


### PR DESCRIPTION
## Summary

Targets #475. Three spec-correct guard fixes for `FILE_DELETE_ON_CLOSE` + `FILE_ATTRIBUTE_READONLY` interactions per MS-FSA 2.1.5.1.2.1, but does **not** flip the 5 smbtorture `delete-on-close-perms.*` tests — those depend on parent-directory ACL enforcement that DittoFS doesn't yet implement (the tests set a restrictive SD on `test_dir` and expect CREATE inside it to return `ACCESS_DENIED`; we currently allow the CREATE and return `OBJECT_NAME_COLLISION` because the parent-SD path doesn't gate creation).

The KNOWN_FAILURES walkback originally proposed by this PR was incorrect and has been replaced with these guards. The 5 entries stay in KNOWN_FAILURES until parent-directory SD enforcement lands separately.

## Commits

1. **`fix(smb): reject DOC on new read-only files`** — adds the missing `!fileExists` arm so `CREATE` with `READONLY` + DOC returns `STATUS_CANNOT_DELETE` before creating an undeletable orphan.
2. **`fix(smb): broaden DOC+READONLY rejection to overwrite paths`** — extends to all dispositions that propagate `req.FileAttributes` (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF). Existing-file disk-attrs arm above continues to handle the OPEN path.
3. **`fix(smb): gate DOC+READONLY rejection by createAction`** — restricts the request-attrs branch to `createAction ∈ {FileCreated, FileOverwritten, FileSuperseded}` so `FILE_OPEN` / `FILE_OPEN_IF` on existing files don't get false `CANNOT_DELETE` from a stray READONLY bit in `req.FileAttributes`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...` — passing
- [x] CI smbtorture/memory: no new failures (the 3 rename failures are the develop-side regression fixed in PR #497)
- [ ] Future: parent-dir SD enforcement at CREATE → flips the 5 `delete-on-close-perms` subtests, file separate issue

## References

- MS-FSA 2.1.5.1.2.1
- Samba `source3/smbd/open.c::open_match_attributes`