### PR TITLE
fix(smb): enforce parent-directory share-mode on rename (#496)

### DIFF
--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1243,6 +1243,39 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return conflict
 }
 
+// checkParentDirRenameConflict probes the parent directory's open list as if
+// the rename were issuing an internal open with DesiredAccess ⊇ {DELETE,
+// FILE_ADD_FILE} and ShareAccess = 0 (per MS-FSA 2.1.5.14.11.3 and Samba's
+// rename_internals_fsp). An existing parent-directory open conflicts if it
+// (a) lacks FILE_SHARE_DELETE — denying the rename's DELETE access — or
+// (b) already holds DELETE access — incompatible with the rename's
+// ShareAccess=0. Returns true if a conflict is found.
+func (h *Handler) checkParentDirRenameConflict(renameFile *OpenFile) bool {
+	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
+	if len(renameFile.ParentHandle) == 0 {
+		return false
+	}
+	conflict := false
+	h.files.Range(func(_, value any) bool {
+		other := value.(*OpenFile)
+		if other.FileID == renameFile.FileID {
+			return true
+		}
+		if len(other.MetadataHandle) == 0 {
+			return true
+		}
+		if !bytes.Equal(other.MetadataHandle, renameFile.ParentHandle) {
+			return true
+		}
+		if other.ShareAccess&fileShareDelete == 0 || hasDeleteAccess(other.DesiredAccess) {
+			conflict = true
+			return false
+		}
+		return true
+	})
+	return conflict
+}
+
 // snapshotOpenChildren returns the metadata handles of every open file whose
 // ParentHandle equals dirHandle. Caller must read h.files only once; iterating
 // twice could observe inconsistent open state across a concurrent CLOSE.

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1243,15 +1243,17 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return conflict
 }
 
-// checkParentDirRenameConflict probes the destination directory's open list
-// as if the rename were issuing an internal open with DesiredAccess ⊇ {DELETE,
-// FILE_ADD_FILE} and ShareAccess = 0 (per MS-FSA 2.1.5.14.11.3 and Samba's
-// smbd_smb2_setinfo_rename_dst_parent_check). An existing destination-parent
-// open conflicts if it (a) lacks FILE_SHARE_DELETE — denying the rename's
-// DELETE access — or (b) already holds DELETE access — incompatible with the
-// rename's ShareAccess=0. The renamer's own handle is excluded by FileID.
-// Caller passes the destination parent handle (same as source parent for
-// same-directory rename). Returns true if a conflict is found.
+// checkParentDirRenameConflict applies the destination-parent share-mode
+// rule from MS-FSA 2.1.5.14.11.3 / Samba smbd_smb2_setinfo_rename_dst_parent_check.
+// Rename takes an implicit DELETE-bearing access on the destination parent
+// without granting share-delete; only the DELETE vs FILE_SHARE_DELETE pair
+// matters for the conflict (the ADD_FILE bit doesn't interact with the
+// share-mode word, so we don't probe write/share-write). An existing
+// destination-parent open conflicts when it (a) lacks FILE_SHARE_DELETE —
+// denying the rename's DELETE access — or (b) already holds DELETE access —
+// incompatible with the rename's ShareAccess=0. The renamer's own handle
+// is excluded by FileID. Caller passes the destination parent handle (same
+// as source parent for same-directory rename). Returns true on conflict.
 func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent metadata.FileHandle) bool {
 	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
 	if len(dstParent) == 0 {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1271,6 +1271,15 @@ func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent
 		if !bytes.Equal(other.MetadataHandle, dstParent) {
 			return true
 		}
+		// Stat-only opens (READ_ATTRIBUTES / WRITE_ATTRIBUTES / SYNCHRONIZE /
+		// READ_CONTROL only) impose no share-mode constraint per MS-SMB2
+		// §3.3.5.9.8 + Samba `is_lease_stat_open`. smbtorture rename.msword
+		// opens the parent dir stat-only with ShareAccess=0 and expects the
+		// rename to succeed; without this filter the lack of FILE_SHARE_DELETE
+		// would falsely trip the conflict.
+		if isStatOnlyOpen(other.DesiredAccess) {
+			return true
+		}
 		if other.ShareAccess&fileShareDelete == 0 || hasDeleteAccess(other.DesiredAccess) {
 			conflict = true
 			return false

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1243,28 +1243,30 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return conflict
 }
 
-// checkParentDirRenameConflict probes the parent directory's open list as if
-// the rename were issuing an internal open with DesiredAccess ⊇ {DELETE,
+// checkParentDirRenameConflict probes the destination directory's open list
+// as if the rename were issuing an internal open with DesiredAccess ⊇ {DELETE,
 // FILE_ADD_FILE} and ShareAccess = 0 (per MS-FSA 2.1.5.14.11.3 and Samba's
-// rename_internals_fsp). An existing parent-directory open conflicts if it
-// (a) lacks FILE_SHARE_DELETE — denying the rename's DELETE access — or
-// (b) already holds DELETE access — incompatible with the rename's
-// ShareAccess=0. Returns true if a conflict is found.
-func (h *Handler) checkParentDirRenameConflict(renameFile *OpenFile) bool {
+// smbd_smb2_setinfo_rename_dst_parent_check). An existing destination-parent
+// open conflicts if it (a) lacks FILE_SHARE_DELETE — denying the rename's
+// DELETE access — or (b) already holds DELETE access — incompatible with the
+// rename's ShareAccess=0. The renamer's own handle is excluded by FileID.
+// Caller passes the destination parent handle (same as source parent for
+// same-directory rename). Returns true if a conflict is found.
+func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent metadata.FileHandle) bool {
 	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
-	if len(renameFile.ParentHandle) == 0 {
+	if len(dstParent) == 0 {
 		return false
 	}
 	conflict := false
 	h.files.Range(func(_, value any) bool {
 		other := value.(*OpenFile)
-		if other.FileID == renameFile.FileID {
+		if other.FileID == renamerFileID {
 			return true
 		}
 		if len(other.MetadataHandle) == 0 {
 			return true
 		}
-		if !bytes.Equal(other.MetadataHandle, renameFile.ParentHandle) {
+		if !bytes.Equal(other.MetadataHandle, dstParent) {
 			return true
 		}
 		if other.ShareAccess&fileShareDelete == 0 || hasDeleteAccess(other.DesiredAccess) {

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -483,18 +483,10 @@ func (h *Handler) setFileInfoFromStore(
 		// Per MS-FSA 2.1.5.14.10: Before renaming, check that no other open
 		// handle on the same file conflicts with the rename. Specifically,
 		// all other opens must have FILE_SHARE_DELETE (0x04) in ShareAccess.
+		// (Destination-parent share-mode probe runs further below, after toDir
+		// is resolved and the stream-rename early return has been ruled out.)
 		if conflict := h.checkShareDeleteConflict(openFile); conflict {
 			logger.Debug("SET_INFO: rename blocked by sharing violation",
-				"path", openFile.Path,
-				"fileID", fmt.Sprintf("%x", openFile.FileID))
-			return setInfoStatus(types.StatusSharingViolation), nil
-		}
-		// Per MS-FSA 2.1.5.14.11.3: rename also takes an implicit open on the
-		// parent directory with DELETE+FILE_ADD_FILE access and ShareAccess=0.
-		// Any existing parent-dir open that lacks FILE_SHARE_DELETE or holds
-		// DELETE access conflicts — must report STATUS_SHARING_VIOLATION.
-		if conflict := h.checkParentDirRenameConflict(openFile); conflict {
-			logger.Debug("SET_INFO: rename blocked by parent-dir sharing violation",
 				"path", openFile.Path,
 				"fileID", fmt.Sprintf("%x", openFile.FileID))
 			return setInfoStatus(types.StatusSharingViolation), nil
@@ -633,6 +625,20 @@ func (h *Handler) setFileInfoFromStore(
 		if len(openFile.ParentHandle) == 0 {
 			logger.Debug("SET_INFO: cannot rename root directory", "path", openFile.Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
+		}
+
+		// Per MS-FSA 2.1.5.14.11.3 / Samba smbd_smb2_setinfo_rename_dst_parent_check:
+		// rename takes an implicit open on the destination parent directory
+		// with DELETE+FILE_ADD_FILE and ShareAccess=0. Any existing open of
+		// that directory that lacks FILE_SHARE_DELETE or holds DELETE access
+		// conflicts. Stream renames don't traverse the directory layer and
+		// returned earlier above; we're past that branch here.
+		if conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir); conflict {
+			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
+				"path", openFile.Path,
+				"toDir", fmt.Sprintf("%x", toDir),
+				"fileID", fmt.Sprintf("%x", openFile.FileID))
+			return setInfoStatus(types.StatusSharingViolation), nil
 		}
 
 		// Pre-rename lease break: per MS-FSA §2.1.5.14.10 + Samba

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -489,6 +489,16 @@ func (h *Handler) setFileInfoFromStore(
 				"fileID", fmt.Sprintf("%x", openFile.FileID))
 			return setInfoStatus(types.StatusSharingViolation), nil
 		}
+		// Per MS-FSA 2.1.5.14.11.3: rename also takes an implicit open on the
+		// parent directory with DELETE+FILE_ADD_FILE access and ShareAccess=0.
+		// Any existing parent-dir open that lacks FILE_SHARE_DELETE or holds
+		// DELETE access conflicts — must report STATUS_SHARING_VIOLATION.
+		if conflict := h.checkParentDirRenameConflict(openFile); conflict {
+			logger.Debug("SET_INFO: rename blocked by parent-dir sharing violation",
+				"path", openFile.Path,
+				"fileID", fmt.Sprintf("%x", openFile.FileID))
+			return setInfoStatus(types.StatusSharingViolation), nil
+		}
 
 		// Normalize path separators (Windows uses backslash, we use forward slash)
 		newPath := strings.ReplaceAll(renameInfo.FileName, "\\", "/")


### PR DESCRIPTION
## Summary

Closes #496. Flips three smbtorture failures from `OK` to `SHARING_VIOLATION`:

- `smb2.rename.share_delete_and_delete_access`
- `smb2.rename.no_share_delete_but_delete_access`
- `smb2.rename.no_share_delete_no_delete_access`

Control `smb2.rename.share_delete_no_delete_access` keeps passing.

## Root cause

MS-FSA §2.1.5.14.11.3 / Samba `smbd_smb2_setinfo_rename_dst_parent_check`: rename takes an implicit DELETE-bearing access on the **destination** parent directory with `ShareAccess=0`. DittoFS only probed the source-file open list, so opens of the destination parent directory were never checked. For same-directory renames source==destination, so the targeted smbtorture cases all use `openFile.ParentHandle` as both — but the spec rule is about the destination parent.

## Fix

`checkParentDirRenameConflict` (handler.go) iterates `h.files` for handles whose `MetadataHandle == dstParent` and reports a conflict if any such handle either lacks `FILE_SHARE_DELETE` or holds `DELETE` access. Invoked from SET_INFO `FileRenameInformation` after `toDir` (destination parent) is resolved and after the stream-rename early-return — stream renames don't traverse the directory layer per MS-FSA §2.1.5.15.12.1.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...` — passing
- [ ] CI smbtorture/memory: 3 rename tests flip to PASS, no regressions
- [ ] After CI confirms, walk back any KNOWN_FAILURES entries (none currently — these were untracked)

## References

- Samba `source3/smbd/smb2_setinfo.c::smbd_smb2_setinfo_rename_dst_parent_check`
- Samba `source3/smbd/reply.c::rename_internals_fsp`
- Samba `source4/torture/smb2/rename.c` lines 413/540/680/804