### PR TITLE
feat(smb): SID-aware Identity for ACL evaluation (refs #500, #499)

### DIFF
--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -125,6 +125,13 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		authCtx.Identity.UID = &uid
 		authCtx.Identity.GID = &gid
 		authCtx.Identity.Username = user.Username
+		if user.SID != "" {
+			sid := user.SID
+			authCtx.Identity.SID = &sid
+		}
+		if len(user.GroupSIDs) > 0 {
+			authCtx.Identity.GroupSIDs = append([]string(nil), user.GroupSIDs...)
+		}
 	}
 
 	// Set share-level permission flags

--- a/internal/adapter/smb/v2/handlers/auth_helper_test.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func TestBuildAuthContextFromUser_PopulatesSID(t *testing.T) {
+	uid := uint32(1001)
+	user := &models.User{
+		ID:        "user-1",
+		Username:  "alice",
+		UID:       &uid,
+		SID:       "S-1-5-21-1-2-3-2001",
+		GroupSIDs: []string{"S-1-5-21-1-2-3-513"},
+	}
+	ctx := &SMBHandlerContext{
+		Context: context.Background(),
+		User:    user,
+	}
+
+	authCtx := BuildAuthContextFromUser(ctx, user)
+	if authCtx == nil || authCtx.Identity == nil {
+		t.Fatal("nil Identity")
+	}
+	if authCtx.Identity.SID == nil {
+		t.Fatalf("Identity.SID is nil, want %q", user.SID)
+	}
+	if got := *authCtx.Identity.SID; got != user.SID {
+		t.Errorf("Identity.SID = %q, want %q", got, user.SID)
+	}
+	if len(authCtx.Identity.GroupSIDs) != 1 || authCtx.Identity.GroupSIDs[0] != user.GroupSIDs[0] {
+		t.Errorf("Identity.GroupSIDs = %v, want %v", authCtx.Identity.GroupSIDs, user.GroupSIDs)
+	}
+}
+
+func TestBuildAuthContextFromUser_NoSIDLeavesIdentityEmpty(t *testing.T) {
+	uid := uint32(1001)
+	user := &models.User{ID: "user-2", Username: "bob", UID: &uid}
+	ctx := &SMBHandlerContext{Context: context.Background(), User: user}
+
+	authCtx := BuildAuthContextFromUser(ctx, user)
+	if authCtx.Identity.SID != nil {
+		t.Errorf("Identity.SID = %v, want nil for user without SID", *authCtx.Identity.SID)
+	}
+	if len(authCtx.Identity.GroupSIDs) != 0 {
+		t.Errorf("Identity.GroupSIDs = %v, want empty", authCtx.Identity.GroupSIDs)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -712,3 +712,45 @@ func TestBuildSD_SpecialSIDs(t *testing.T) {
 		t.Errorf("Second ACE SID = %s, want S-1-5-32-544 (Administrators)", sid.FormatSID(aceSID2))
 	}
 }
+
+// TestParseSecurityDescriptor_PreservesSIDForm asserts that an SD ACE keyed
+// to a well-known SID (S-1-5-32-544 / "ADMINISTRATORS@") for which the parse
+// path has no POSIX mapping is preserved as ACE.Who="sid:S-1-5-32-544". This
+// is the round-trip side of P2-3 — non-mappable SIDs must reach the ACL
+// evaluator with the "sid:" prefix so SID-aware matching works.
+func TestParseSecurityDescriptor_PreservesSIDForm(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{
+					{
+						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+						Flag:       0,
+						AccessMask: 0x001F01FF,
+						Who:        acl.SpecialAdministrators,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := BuildSecurityDescriptor(file, 0)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	_, _, parsedACL, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	if parsedACL == nil || len(parsedACL.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %#v", parsedACL)
+	}
+	got := parsedACL.ACEs[0].Who
+	want := "sid:S-1-5-32-544"
+	if got != want {
+		t.Errorf("ACE.Who = %q, want %q", got, want)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -754,3 +754,65 @@ func TestParseSecurityDescriptor_PreservesSIDForm(t *testing.T) {
 		t.Errorf("ACE.Who = %q, want %q", got, want)
 	}
 }
+
+// TestSecurityDescriptor_SIDFormRoundTrip asserts that a non-POSIX-mappable SID
+// preserved as ACE.Who="sid:..." after parse can be re-encoded by
+// BuildSecurityDescriptor without drift. Regression for the round-trip break
+// flagged on PR #506: PrincipalToSID must honor the "sid:" prefix.
+func TestSecurityDescriptor_SIDFormRoundTrip(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{
+					{
+						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+						Flag:       0,
+						AccessMask: 0x001F01FF,
+						Who:        acl.SpecialAdministrators,
+					},
+				},
+			},
+		},
+	}
+
+	data1, err := BuildSecurityDescriptor(file, 0)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor pass 1: %v", err)
+	}
+	_, _, parsed1, err := ParseSecurityDescriptor(data1)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor pass 1: %v", err)
+	}
+	if parsed1 == nil || len(parsed1.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE after parse 1, got %#v", parsed1)
+	}
+	if got := parsed1.ACEs[0].Who; got != "sid:S-1-5-32-544" {
+		t.Fatalf("parse 1 Who = %q, want %q", got, "sid:S-1-5-32-544")
+	}
+
+	// Re-encode using the parsed ACL (Who = "sid:S-1-5-32-544"). This is the
+	// path Copilot flagged: PrincipalToSID must strip the prefix and produce
+	// the same SID, not a hash-based domain SID.
+	file2 := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL:  parsed1,
+		},
+	}
+	data2, err := BuildSecurityDescriptor(file2, 0)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor pass 2: %v", err)
+	}
+	_, _, parsed2, err := ParseSecurityDescriptor(data2)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor pass 2: %v", err)
+	}
+	if got := parsed2.ACEs[0].Who; got != "sid:S-1-5-32-544" {
+		t.Errorf("round-trip Who = %q, want %q (PrincipalToSID likely missing sid: handling)", got, "sid:S-1-5-32-544")
+	}
+}

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -164,6 +164,8 @@ func (m *SIDMapper) IsDomainSID(s *SID) bool {
 //   - "OWNER@": UserSID(fileOwnerUID)
 //   - "GROUP@": GroupSID(fileOwnerGID)
 //   - "EVERYONE@": WellKnownEveryone (S-1-1-0)
+//   - "sid:<canonical SID>": preserved verbatim (round-trip from SIDToPrincipal
+//     for principals without a POSIX mapping)
 //   - "{uid}@domain": UserSID(uid) if uid is numeric
 //   - Otherwise: hash-based UserSID as fallback
 func (m *SIDMapper) PrincipalToSID(who string, fileOwnerUID, fileOwnerGID uint32) *SID {
@@ -175,6 +177,17 @@ func (m *SIDMapper) PrincipalToSID(who string, fileOwnerUID, fileOwnerGID uint32
 	case acl.SpecialEveryone:
 		return WellKnownEveryone
 	default:
+		// Honor "sid:<canonical SID>" round-trip form produced by SIDToPrincipal
+		// for principals with no POSIX mapping. Stripping and re-parsing the
+		// canonical form preserves the original SID end-to-end across SD
+		// parse/build cycles.
+		if strings.HasPrefix(who, "sid:") {
+			if parsed, err := ParseSIDString(who[len("sid:"):]); err == nil {
+				return parsed
+			}
+			// Fall through to hash-based fallback if the embedded string is invalid.
+		}
+
 		// Try to extract a numeric UID from "1000@localdomain" format
 		if idx := strings.Index(who, "@"); idx > 0 {
 			if uid, err := strconv.ParseUint(who[:idx], 10, 32); err == nil {

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -202,7 +202,8 @@ func (m *SIDMapper) PrincipalToSID(who string, fileOwnerUID, fileOwnerGID uint32
 //   - Well-known SIDs are mapped directly (S-1-1-0 -> "EVERYONE@")
 //   - Domain user SIDs extract UID and format as "{uid}@localdomain"
 //   - Domain group SIDs extract GID and format as "{gid}@localdomain"
-//   - Unknown SIDs return their string representation
+//   - Otherwise the SID is preserved as "sid:<canonical SID>" so the ACL
+//     evaluator can match it against EvaluateContext.SID / GroupSIDs.
 func (m *SIDMapper) SIDToPrincipal(s *SID) string {
 	// Check well-known SIDs first
 	sidStr := FormatSID(s)
@@ -225,7 +226,7 @@ func (m *SIDMapper) SIDToPrincipal(s *SID) string {
 		return fmt.Sprintf("%d@localdomain", gid)
 	}
 
-	return sidStr
+	return "sid:" + sidStr
 }
 
 // makeDomainSID constructs a full domain SID with the machine sub-authorities and the given RID.

--- a/pkg/auth/sid/sid_test.go
+++ b/pkg/auth/sid/sid_test.go
@@ -471,3 +471,22 @@ func TestWellKnownSIDFormats(t *testing.T) {
 		}
 	}
 }
+
+func TestPrincipalToSID_SIDPrefixRoundTrip(t *testing.T) {
+	m := NewSIDMapper(100, 200, 300)
+	cases := []string{
+		"S-1-5-32-544",        // BUILTIN\Administrators
+		"S-1-5-21-9-9-9-9999", // Foreign domain SID
+	}
+	for _, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			got := m.PrincipalToSID("sid:"+want, 0, 0)
+			if got == nil {
+				t.Fatalf("PrincipalToSID(\"sid:%s\") returned nil", want)
+			}
+			if FormatSID(got) != want {
+				t.Errorf("round-trip: got %q, want %q", FormatSID(got), want)
+			}
+		})
+	}
+}

--- a/pkg/auth/sid/sid_test.go
+++ b/pkg/auth/sid/sid_test.go
@@ -396,7 +396,8 @@ func TestSIDToPrincipal(t *testing.T) {
 		{"CreatorGroup", "S-1-3-1", "GROUP@"},
 		{"DomainUser1000", "S-1-5-21-100-200-300-3000", "1000@localdomain"},
 		{"DomainGroup1000", "S-1-5-21-100-200-300-3001", "1000@localdomain"},
-		{"UnknownSID", "S-1-5-32-544", "S-1-5-32-544"},
+		{"UnknownSID", "S-1-5-32-544", "sid:S-1-5-32-544"},
+		{"UnmappableDomainSID", "S-1-5-21-9-9-9-9999", "sid:S-1-5-21-9-9-9-9999"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controlplane/models/user.go
+++ b/pkg/controlplane/models/user.go
@@ -43,6 +43,17 @@ type User struct {
 	CreatedAt          time.Time  `gorm:"autoCreateTime" json:"created_at"`
 	LastLogin          *time.Time `json:"last_login,omitempty"`
 
+	// SID is the user's Windows Security Identifier, populated from
+	// Kerberos PAC, NTLMSSP session info, or local ID resolution.
+	// Empty when no source is wired. In-memory only for now — persistent
+	// storage of Windows identity is a follow-up.
+	SID string `gorm:"-" json:"sid,omitempty"`
+
+	// GroupSIDs is the list of Windows group SIDs for the user, populated
+	// alongside SID. In-memory only for now — gorm-excluded until a
+	// persistence strategy (JSON column or join table) is chosen.
+	GroupSIDs []string `gorm:"-" json:"group_sids,omitempty"`
+
 	// Many-to-many relationship with groups
 	Groups []Group `gorm:"many2many:user_groups;" json:"groups,omitempty"`
 

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -1,5 +1,10 @@
 package acl
 
+import (
+	"slices"
+	"strings"
+)
+
 // EvaluateContext carries the requestor's identity and the file's
 // owner/group for dynamic OWNER@/GROUP@/EVERYONE@ resolution.
 type EvaluateContext struct {
@@ -9,6 +14,14 @@ type EvaluateContext struct {
 	GIDs         []uint32 // Requestor's supplementary GIDs
 	FileOwnerUID uint32   // File's owner UID (for OWNER@ resolution)
 	FileOwnerGID uint32   // File's owning group GID (for GROUP@ resolution)
+
+	// SID is the requester's Windows SID in canonical string form
+	// (e.g. "S-1-5-21-A-B-C-RID"). Empty when the session is POSIX-only.
+	SID string
+
+	// GroupSIDs is the requester's group SIDs.
+	// Empty when the session is POSIX-only.
+	GroupSIDs []string
 }
 
 // Evaluate implements the NFSv4 ACL evaluation algorithm per RFC 7530
@@ -102,6 +115,15 @@ func aceMatchesWho(ace *ACE, evalCtx *EvaluateContext) bool {
 		return true
 
 	default:
+		// SID-form ACE (set by SD parse): "sid:<canonical SID>".
+		if strings.HasPrefix(ace.Who, "sid:") {
+			target := ace.Who[len("sid:"):]
+			if evalCtx.SID != "" && evalCtx.SID == target {
+				return true
+			}
+			return slices.Contains(evalCtx.GroupSIDs, target)
+		}
+		// Legacy/string match (numeric uid, named principal).
 		return ace.Who == evalCtx.Who
 	}
 }

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -349,6 +349,54 @@ func TestEvaluate_ComplexACL(t *testing.T) {
 	}
 }
 
+func TestAceMatchesWho_SIDForm(t *testing.T) {
+	cases := []struct {
+		name     string
+		aceWho   string
+		ctxSID   string
+		ctxGSIDs []string
+		want     bool
+	}{
+		{
+			name:   "exact_user_sid_match",
+			aceWho: "sid:S-1-5-21-1-2-3-1001",
+			ctxSID: "S-1-5-21-1-2-3-1001",
+			want:   true,
+		},
+		{
+			name:   "user_sid_mismatch",
+			aceWho: "sid:S-1-5-21-1-2-3-1001",
+			ctxSID: "S-1-5-21-1-2-3-9999",
+			want:   false,
+		},
+		{
+			name:     "group_sid_match_via_groupSIDs",
+			aceWho:   "sid:S-1-5-21-1-2-3-513",
+			ctxSID:   "S-1-5-21-1-2-3-1001",
+			ctxGSIDs: []string{"S-1-5-21-1-2-3-513"},
+			want:     true,
+		},
+		{
+			name:   "missing_ctx_sid",
+			aceWho: "sid:S-1-5-21-1-2-3-1001",
+			ctxSID: "",
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ace := &ACE{Who: tc.aceWho, Type: ACE4_ACCESS_ALLOWED_ACE_TYPE}
+			ctx := &EvaluateContext{SID: tc.ctxSID, GroupSIDs: tc.ctxGSIDs}
+			got := aceMatchesWho(ace, ctx)
+			if got != tc.want {
+				t.Errorf("aceMatchesWho(%q, SID=%q, GroupSIDs=%v) = %v, want %v",
+					tc.aceWho, tc.ctxSID, tc.ctxGSIDs, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEvaluate_DenyDoesNotAffectAlreadyDecidedBits(t *testing.T) {
 	// ALLOW read first, then DENY read: the bit is already decided as allowed.
 	a := &ACL{

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -376,6 +376,11 @@ func evaluateACLPermissions(
 		evalCtx.Who = identity.Username
 	}
 
+	if identity.SID != nil {
+		evalCtx.SID = *identity.SID
+	}
+	evalCtx.GroupSIDs = identity.GroupSIDs
+
 	return evaluateWithACL(file.ACL, evalCtx, requested, shareOpts)
 }
 

--- a/pkg/metadata/auth_permissions_sid_test.go
+++ b/pkg/metadata/auth_permissions_sid_test.go
@@ -1,0 +1,41 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+func TestCalculatePermissions_SIDDenyACE(t *testing.T) {
+	// File owned by uid 1001 with mode 0o777 (anyone-writable in POSIX terms).
+	// SD denies WriteData for the requester's SID, then allows everything for
+	// EVERYONE. SID-form deny ACE must win — POSIX bits cannot express it.
+	uid := uint32(1001)
+	denyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:S-1-5-21-1-2-3-2001",
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	file := &File{
+		FileAttr: FileAttr{UID: 1001, GID: 1001, Mode: 0o777, ACL: denyACL},
+	}
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	id := &Identity{
+		UID: &uid,
+		SID: &requesterSID,
+	}
+
+	got := calculatePermissions(file, id, nil, PermissionWrite)
+	if got&PermissionWrite != 0 {
+		t.Fatalf("expected write denied via SID-form deny ACE, got 0x%x", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the SMB ACL/SID identity plan. Threads the Windows SID through DittoFS's metadata Identity so SID-form ACEs (parsed from SMB SD writes) match the authenticated requester. Foundation for Phase 1 (parent-dir DACL evaluation in CREATE).

No smbtorture flips expected from this PR alone — it's plumbing. Tests start flipping once Phase 1 lands on top.

## Changes

- `pkg/metadata/acl/evaluate.go`: add `EvaluateContext.SID` + `GroupSIDs`; new SID-form arm in `aceMatchesWho` (uses `slices.Contains` per codebase idiom).
- `pkg/metadata/auth_permissions.go`: forward `Identity.SID` / `Identity.GroupSIDs` into the authenticated-path `EvaluateContext`. New test `TestCalculatePermissions_SIDDenyACE` proves a SID-form deny ACE wins over an `EVERYONE@` allow on a 0o777 file.
- `pkg/auth/sid/mapper.go`: `SIDToPrincipal` now returns `"sid:<canonical SID>"` for unmapped SIDs (was raw `S-1-...`). Well-known and POSIX-mappable paths unchanged. Round-trip handler test asserts `ParseSecurityDescriptor` preserves the prefix.
- `pkg/controlplane/models/user.go`: `User` gains `SID string` + `GroupSIDs []string` (`gorm:"-"`, in-memory only — population from PAC/NTLMSSP is a follow-up).
- `internal/adapter/smb/v2/handlers/auth_helper.go`: `BuildAuthContextFromUser` copies user SID/GroupSIDs into the metadata Identity (defensive copy + value capture).

## Tracking

- Parent: #499
- This phase: #500
- Plan: `docs/superpowers/plans/2026-05-06-smb-acl-sid-identity.md`

## Test plan

- [x] `go test ./pkg/metadata/acl/...`
- [x] `go test ./pkg/metadata/...`
- [x] `go test ./pkg/auth/sid/...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...`
- [x] `go test ./pkg/controlplane/...`
- [x] `go build ./...`
- [ ] CI smbtorture/memory: no regressions (no test flips expected; this is foundation).

## Notes for reviewers

- `gorm:"-"` on the new `User.SID` / `GroupSIDs` is deliberate — codebase has no `StringSlice`/JSON-column helper today. AutoMigrate skips these fields, so no schema change. PAC/NTLMSSP sourcing is the follow-up that decides JSON column vs join table.
- `json:"sid,omitempty"` exposes the SID over the REST API. If we'd rather not leak identity material via `dfsctl user show`, switch to `json:"-"` in a follow-up.
- Self-review and a code-quality pass were applied per phase task; minors deferred to follow-up.