### PR TITLE
feat(smb): wire parent-directory DACL into CREATE (refs #501, #499)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -809,6 +809,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// ========================================================================
 
 	metaSvc := h.Registry.GetMetadataService()
+
+	// Pre-disposition parent-DACL gate: any non-pure-OPEN disposition mutates
+	// the parent directory's contents (creating, overwriting, or superseding a
+	// child). MS-FSA 2.1.5.1.1 + MS-SMB2 §3.3.5.9 require parent-write
+	// permission to be evaluated before failing on disposition collisions, so
+	// a deny ACE on the parent surfaces as ACCESS_DENIED rather than
+	// OBJECT_NAME_COLLISION / DELETE_PENDING. FILE_OPEN is the only pure-open
+	// disposition; everything else (CREATE, CREATE_IF, OVERWRITE,
+	// OVERWRITE_IF, SUPERSEDE) is gated.
+	if req.CreateDisposition != types.FileOpen {
+		if err := metaSvc.CheckParentWriteAccess(authCtx, parentHandle); err != nil {
+			logger.Debug("CREATE: parent DACL denies write",
+				"path", filename,
+				"disposition", req.CreateDisposition,
+				"error", err)
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
+		}
+	}
+
 	existingFile, lookupErr := metaSvc.Lookup(authCtx, parentHandle, baseName)
 	fileExists := (lookupErr == nil)
 

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -24,6 +24,22 @@ type EvaluateContext struct {
 	GroupSIDs []string
 }
 
+// HasExplicitDeny reports whether the ACL contains any explicit DENY ACE.
+// Allow-only ACLs are additive and may safely coexist with a share-level
+// write grant; an ACL with a DENY ACE encodes intent that POSIX bits
+// cannot express and must take precedence.
+func HasExplicitDeny(a *ACL) bool {
+	if a == nil {
+		return false
+	}
+	for i := range a.ACEs {
+		if a.ACEs[i].Type == ACE4_ACCESS_DENIED_ACE_TYPE {
+			return true
+		}
+	}
+	return false
+}
+
 // Evaluate implements the NFSv4 ACL evaluation algorithm per RFC 7530
 // Section 6.2.1. It processes ACEs sequentially and returns true only
 // if ALL requested permission bits are explicitly allowed.

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -410,3 +410,35 @@ func TestEvaluate_DenyDoesNotAffectAlreadyDecidedBits(t *testing.T) {
 		t.Error("expected READ_DATA to be allowed (decided by first ACE)")
 	}
 }
+
+func TestHasExplicitDeny(t *testing.T) {
+	t.Run("nil ACL returns false", func(t *testing.T) {
+		if HasExplicitDeny(nil) {
+			t.Error("expected HasExplicitDeny(nil) == false")
+		}
+	})
+
+	t.Run("allow-only ACL returns false", func(t *testing.T) {
+		a := &ACL{
+			ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: SpecialEveryone, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: SpecialOwner, AccessMask: 0xFFFFFFFF},
+			},
+		}
+		if HasExplicitDeny(a) {
+			t.Error("expected HasExplicitDeny on allow-only ACL == false")
+		}
+	})
+
+	t.Run("ACL with one DENY ACE returns true", func(t *testing.T) {
+		a := &ACL{
+			ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: SpecialEveryone, AccessMask: ACE4_READ_DATA},
+				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, Who: "sid:S-1-5-21-1-2-3-2001", AccessMask: ACE4_WRITE_DATA},
+			},
+		}
+		if !HasExplicitDeny(a) {
+			t.Error("expected HasExplicitDeny on ACL containing a DENY ACE == true")
+		}
+	})
+}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -441,6 +441,18 @@ func (s *MetadataService) checkWritePermission(ctx *AuthContext, handle FileHand
 	return s.checkPermission(ctx, handle, PermissionWrite, "write permission denied")
 }
 
+// CheckParentWriteAccess verifies the caller may add or remove a child entry
+// in the given directory. It is the public, protocol-facing entry point that
+// SMB / NFS handlers call before attempting an entry-creating or
+// entry-replacing CREATE so that ACL-based denial surfaces as ACCESS_DENIED
+// rather than OBJECT_NAME_COLLISION / DELETE_PENDING.
+//
+// The check is exactly POSIX WRITE on the parent directory; ACL evaluation
+// runs through the same code path as in-process write checks.
+func (s *MetadataService) CheckParentWriteAccess(ctx *AuthContext, parentHandle FileHandle) error {
+	return s.checkWritePermission(ctx, parentHandle)
+}
+
 // checkDeletePermission checks permission to unlink an entry from a parent directory.
 //
 // Two rules, in order:

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -242,14 +242,16 @@ func (s *MetadataService) checkFilePermissions(ctx *AuthContext, handle FileHand
 	}
 
 	// Share-level write permission bypass:
-	// If the user has share-level write permission (ctx.ShareWritable), grant write-
-	// related permissions on files in the share, bypassing file-level Unix permission
-	// checks. This allows authenticated users with share write access to create/modify
-	// files even if the file's Unix permissions would normally deny access.
+	// If the user has share-level write permission (ctx.ShareWritable) AND the
+	// file has no explicit ACL, grant write-related permissions, bypassing
+	// file-level Unix permission checks. Files with an explicit ACL always go
+	// through ACL evaluation so deny ACEs honored on Windows clients (smbtorture
+	// acls.DENY1, delete-on-close-perms.*) are not silently overridden by the
+	// share-level grant.
 	//
-	// Note: ShareReadOnly takes precedence - if the share is read-only for this user,
-	// write permission is denied regardless of ShareWritable.
-	if ctx.ShareWritable && !ctx.ShareReadOnly {
+	// Note: ShareReadOnly takes precedence - if the share is read-only for this
+	// user, write permission is denied regardless of ShareWritable.
+	if ctx.ShareWritable && !ctx.ShareReadOnly && file.ACL == nil {
 		// Only grant write-related permissions via the share-level bypass.
 		// Read permissions still go through normal calculatePermissions checks.
 		writePerms := requested & (PermissionWrite | PermissionDelete)

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -242,16 +242,27 @@ func (s *MetadataService) checkFilePermissions(ctx *AuthContext, handle FileHand
 	}
 
 	// Share-level write permission bypass:
-	// If the user has share-level write permission (ctx.ShareWritable) AND the
-	// file has no explicit ACL, grant write-related permissions, bypassing
-	// file-level Unix permission checks. Files with an explicit ACL always go
-	// through ACL evaluation so deny ACEs honored on Windows clients (smbtorture
-	// acls.DENY1, delete-on-close-perms.*) are not silently overridden by the
-	// share-level grant.
+	// If the user has share-level write permission (ctx.ShareWritable) and the
+	// file's ACL does not contain an explicit DENY ACE, grant write-related
+	// permissions, bypassing file-level Unix permission checks.
+	//
+	// Bypass remains in effect when:
+	//   - the file has no ACL at all, or
+	//   - the file's ACL is allow-only (no DENY ACE present).
+	// Allow-only ACLs are additive: they only add grants on top of POSIX bits,
+	// so the share-level write grant should still apply. Concretely this keeps
+	// smbtorture stream-inherit-perms (which appends one ALLOW ACE to the
+	// synthesized DACL) and create.multi (which works against allow-only
+	// share-root SDs) passing.
+	//
+	// Bypass disabled only when an explicit DENY ACE is present: a DENY ACE
+	// encodes intent that POSIX bits / share-level grants cannot express and
+	// must take precedence (load-bearing for smbtorture acls.DENY1 and
+	// delete-on-close-perms.*).
 	//
 	// Note: ShareReadOnly takes precedence - if the share is read-only for this
 	// user, write permission is denied regardless of ShareWritable.
-	if ctx.ShareWritable && !ctx.ShareReadOnly && file.ACL == nil {
+	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
 		// Only grant write-related permissions via the share-level bypass.
 		// Read permissions still go through normal calculatePermissions checks.
 		writePerms := requested & (PermissionWrite | PermissionDelete)

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -63,4 +63,53 @@ func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
 	}
 }
 
+// TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass asserts that when
+// a file carries an explicit ACL containing only ALLOW ACEs (no DENY), the
+// share-level ShareWritable bypass continues to grant write. This covers
+// smbtorture stream-inherit-perms (where SET_INFO Security appends one ALLOW
+// ACE to the synthesized DACL) and create.multi (allow-only SD on share root).
+func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Allow-only ACL: a single ALLOW ACE for EVERYONE@ with broad mask.
+	// This mirrors what smbtorture stream-inherit-perms ends up with after
+	// SET_INFO Security adds an explicit ALLOW ACE: a DACL flagged as
+	// SMB-explicit but containing zero DENY ACEs.
+	allowOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "allow_only.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o755,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  allowOnlyACL,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+	authCtx.ShareWritable = true
+	authCtx.ShareReadOnly = false
+
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
+	require.NoError(t, err)
+	want := metadata.PermissionWrite | metadata.PermissionDelete
+	if got&want != want {
+		t.Errorf("expected share-level write+delete bypass on allow-only ACL, got 0x%x", got)
+	}
+}
+
 func strPtr(s string) *string { return &s }

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -1,0 +1,66 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckPermissions_ACLDenyOverridesShareWritable asserts that when a file
+// carries an explicit ACL with a SID-form deny-write ACE for the requester,
+// the share-level ShareWritable bypass does NOT grant write. Without this
+// gate, smbtorture acls.DENY1 + delete-on-close-perms.* fail because the
+// share short-circuit always wins over file-level intent.
+func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Create a regular file under the root with an explicit ACL that denies
+	// WriteData|AppendData for the requester's SID, then allows everything to
+	// EVERYONE@. POSIX bits would grant writes; the deny ACE must win.
+	deniedACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA | acl.ACE4_DELETE,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  deniedACL,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Build an AuthContext with ShareWritable = true (smbtorture's typical
+	// session has a writable share permission). Identity carries the SID so
+	// SID-form ACE matching can fire.
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+	authCtx.ShareWritable = true
+	authCtx.ShareReadOnly = false
+
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
+	require.NoError(t, err)
+	if got&metadata.PermissionWrite != 0 || got&metadata.PermissionDelete != 0 {
+		t.Errorf("expected write+delete denied via SID-form deny ACE on writable share, got 0x%x", got)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/pkg/metadata/auth_permissions_parent_check_test.go
+++ b/pkg/metadata/auth_permissions_parent_check_test.go
@@ -1,0 +1,77 @@
+package metadata_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied asserts that
+// CheckParentWriteAccess (the public wrapper SMB CREATE calls) returns an
+// ErrAccessDenied StoreError when the parent directory's ACL denies WRITE
+// for the requester's SID, even on a writable share.
+func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Create a directory under root with an explicit ACL that denies write to
+	// the requester's SID. Note: the directory itself, not a child file,
+	// carries the ACL — that's the parent-of-CREATE we want to block.
+	denyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "denied-dir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  denyACL,
+		})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	sid := requesterSID
+	authCtx.Identity.SID = &sid
+	authCtx.ShareWritable = true
+	authCtx.ShareReadOnly = false
+
+	err = f.service.CheckParentWriteAccess(authCtx, dirHandle)
+	if err == nil {
+		t.Fatalf("CheckParentWriteAccess returned nil, want ErrAccessDenied")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+		t.Fatalf("CheckParentWriteAccess err = %v, want StoreError{Code: ErrAccessDenied}", err)
+	}
+}
+
+// TestCheckParentWriteAccess_NoACLAllowsAdd asserts the POSIX-only happy path
+// is unchanged (parent has no explicit ACL; ShareWritable bypass still
+// applies because the P1-1 gate only fires when an ACL is present).
+func TestCheckParentWriteAccess_NoACLAllowsAdd(t *testing.T) {
+	f := newTestFixture(t)
+	authCtx := f.authContext(1001, 1001)
+	authCtx.ShareWritable = true
+	if err := f.service.CheckParentWriteAccess(authCtx, f.rootHandle); err != nil {
+		t.Fatalf("CheckParentWriteAccess on POSIX-only writable parent err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the SMB ACL/SID identity plan. Two correctness changes, no smbtorture flips.

1. The `ShareWritable` short-circuit in `pkg/metadata/auth_permissions.go::checkFilePermissions` now disables only when the file's ACL contains an explicit DENY ACE (`acl.HasExplicitDeny`). Allow-only ACLs are additive — share-level write grant remains in effect (avoids regressing `stream-inherit-perms`, `create.multi`). SID-form deny ACEs (foundation case) still win because they're DENY.
2. New public `(*MetadataService).CheckParentWriteAccess` is invoked from the SMB CREATE handler before disposition resolution for any non-pure-OPEN disposition (CREATE / CREATE_IF / OVERWRITE / OVERWRITE_IF / SUPERSEDE). A parent-directory DACL deny now surfaces as `STATUS_ACCESS_DENIED`, matching MS-FSA 2.1.5.1.1 / MS-SMB2 §3.3.5.9.

Builds on PR #506 (P2 SID-aware Identity).

## smbtorture impact

CI confirms **0 new failures, 0 flips**. The plan's "expected flip" list (delete-on-close-perms.*, acls.DENY1, etc.) was too optimistic — those tests block on different code paths:
- `acls.DENY1`: SET_INFO Security parser rejects the SD with `STATUS_INVALID_PARAMETER` (P3 territory: SD control flags).
- `acls.OVERWRITE_READ_ONLY_FILE`: read-only attribute attribute check, not parent ACL.
- `acls.ACCESSBASED`: requires a `hideunread` test share not configured.
- `delete-on-close-perms.*`: returns `OBJECT_NAME_COLLISION` instead of `OK` — delete-on-close unlink visibility timing, unrelated to parent ACL.

P1 still ships as a correctness foundation: ACL precedence over share grant for explicit DENY, plus parent-DACL early gate. Subsequent phases (P3, P5) flip the smbtorture tests above. **No KNOWN_FAILURES walkback in this PR.**

## Tracking

- Parent: #499
- This phase: #501
- Plan: `docs/superpowers/plans/2026-05-06-smb-acl-sid-identity.md`

## Test plan

- [x] `go test ./pkg/metadata/...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...`
- [x] `go build ./...`
- [x] CI: smbtorture/memory + Kerberos + WPTS BVT all green; 0 new failures.

## Notes

- 3 commits: gate on explicit DENY, `CheckParentWriteAccess` wrapper + CREATE wire, gate refinement (replaces `file.ACL == nil` with `!HasExplicitDeny` after CI surfaced the regressions).
- POSIX-only files unaffected — happy-path test in `auth_permissions_parent_check_test.go` confirms `ShareWritable` still grants write on parents without an explicit ACL.
- Allow-only ACL test in `auth_permissions_acl_short_circuit_test.go` locks down the regression fix.