### PR TITLE
feat(acl): CREATOR_OWNER/CREATOR_GROUP substitution at inherit (refs #504, #499)

### DIFF
--- a/internal/adapter/smb/v2/handlers/security.go
+++ b/internal/adapter/smb/v2/handlers/security.go
@@ -274,6 +274,10 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 		return sid.WellKnownEveryone
 	case acl.SpecialOwnerRights:
 		return sid.WellKnownOwnerRights
+	case acl.SpecialCreatorOwner:
+		return sid.WellKnownCreatorOwner
+	case acl.SpecialCreatorGroup:
+		return sid.WellKnownCreatorGroup
 	case acl.SpecialSystem:
 		return sid.WellKnownSystem
 	case acl.SpecialAdministrators:

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -165,6 +165,10 @@ func (m *SIDMapper) IsDomainSID(s *SID) bool {
 //   - "GROUP@": GroupSID(fileOwnerGID)
 //   - "EVERYONE@": WellKnownEveryone (S-1-1-0)
 //   - "OwnerRights@": WellKnownOwnerRights (S-1-3-4)
+//   - "CreatorOwner@": WellKnownCreatorOwner (S-1-3-0) — inheritable
+//     placeholder per MS-DTYP §2.5.3.4
+//   - "CreatorGroup@": WellKnownCreatorGroup (S-1-3-1) — inheritable
+//     placeholder per MS-DTYP §2.5.3.4
 //   - "sid:<canonical SID>": preserved verbatim (round-trip from SIDToPrincipal
 //     for principals without a POSIX mapping)
 //   - "{uid}@domain": UserSID(uid) if uid is numeric
@@ -179,6 +183,10 @@ func (m *SIDMapper) PrincipalToSID(who string, fileOwnerUID, fileOwnerGID uint32
 		return WellKnownEveryone
 	case acl.SpecialOwnerRights:
 		return WellKnownOwnerRights
+	case acl.SpecialCreatorOwner:
+		return WellKnownCreatorOwner
+	case acl.SpecialCreatorGroup:
+		return WellKnownCreatorGroup
 	default:
 		// Honor "sid:<canonical SID>" round-trip form produced by SIDToPrincipal
 		// for principals with no POSIX mapping. Stripping and re-parsing the
@@ -216,7 +224,10 @@ func (m *SIDMapper) PrincipalToSID(who string, fileOwnerUID, fileOwnerGID uint32
 //
 // Mapping rules:
 //   - Well-known SIDs are mapped directly (S-1-1-0 -> "EVERYONE@",
-//     S-1-3-0 -> "OWNER@", S-1-3-1 -> "GROUP@", S-1-3-4 -> "OwnerRights@")
+//     S-1-3-0 -> "CreatorOwner@", S-1-3-1 -> "CreatorGroup@",
+//     S-1-3-4 -> "OwnerRights@"). CREATOR_OWNER / CREATOR_GROUP are
+//     inheritable placeholders per MS-DTYP §2.5.3.4 — distinct from
+//     NFSv4 OWNER@/GROUP@ which resolve to the file's current owner.
 //   - Domain user SIDs extract UID and format as "{uid}@localdomain"
 //   - Domain group SIDs extract GID and format as "{gid}@localdomain"
 //   - Otherwise the SID is preserved as "sid:<canonical SID>" so the ACL
@@ -228,9 +239,9 @@ func (m *SIDMapper) SIDToPrincipal(s *SID) string {
 	case "S-1-1-0":
 		return acl.SpecialEveryone
 	case "S-1-3-0":
-		return acl.SpecialOwner
+		return acl.SpecialCreatorOwner
 	case "S-1-3-1":
-		return acl.SpecialGroup
+		return acl.SpecialCreatorGroup
 	case "S-1-3-4":
 		return acl.SpecialOwnerRights
 	}

--- a/pkg/auth/sid/sid_test.go
+++ b/pkg/auth/sid/sid_test.go
@@ -363,6 +363,8 @@ func TestPrincipalToSID(t *testing.T) {
 		{"GroupAt", "GROUP@", 1000, 1001, "S-1-5-21-100-200-300-3003", false},
 		{"EveryoneAt", "EVERYONE@", 0, 0, "S-1-1-0", false},
 		{"OwnerRightsAt", "OwnerRights@", 0, 0, "S-1-3-4", false},
+		{"CreatorOwnerAt", "CreatorOwner@", 0, 0, "S-1-3-0", false},
+		{"CreatorGroupAt", "CreatorGroup@", 0, 0, "S-1-3-1", false},
 		{"NumericUID", "501@localdomain", 0, 0, "S-1-5-21-100-200-300-2002", false},
 		{"NamedPrincipal", "alice@EXAMPLE.COM", 0, 0, "S-1-5-21-100-200-300-", true},
 		{"RootOwner", "OWNER@", 0, 0, "S-1-5-32-544", false},
@@ -393,8 +395,8 @@ func TestSIDToPrincipal(t *testing.T) {
 		wantPrinc string
 	}{
 		{"Everyone", "S-1-1-0", "EVERYONE@"},
-		{"CreatorOwner", "S-1-3-0", "OWNER@"},
-		{"CreatorGroup", "S-1-3-1", "GROUP@"},
+		{"CreatorOwner", "S-1-3-0", "CreatorOwner@"},
+		{"CreatorGroup", "S-1-3-1", "CreatorGroup@"},
 		{"OwnerRights", "S-1-3-4", "OwnerRights@"},
 		{"DomainUser1000", "S-1-5-21-100-200-300-3000", "1000@localdomain"},
 		{"DomainGroup1000", "S-1-5-21-100-200-300-3001", "1000@localdomain"},

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -1,11 +1,54 @@
 package acl
 
+import "fmt"
+
 // inheritanceMask covers all inheritance-related ACE flags.
 const inheritanceMask = ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE |
 	ACE4_NO_PROPAGATE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
 
+// Creator captures the identity of the principal creating a new file or
+// directory at inherit time. It is used to substitute CREATOR_OWNER /
+// CREATOR_GROUP placeholders in a parent's inheritable ACEs with the
+// concrete creator identity (frozen at creation time, per MS-DTYP §2.5.3.4).
+//
+// SID may be empty when no Windows identity is known (e.g. anonymous
+// NFS-only create): in that case the substitution falls back to the
+// POSIX form "<id>@localdomain" produced by SIDMapper.SIDToPrincipal.
+type Creator struct {
+	UID uint32
+	GID uint32
+	// SID is the creator's Windows user SID. Used for BOTH CreatorOwner@
+	// and CreatorGroup@ substitution because the AuthContext carries a
+	// single per-creator identifier today — no separate primary-group SID
+	// is plumbed. If a future phase introduces a group SID, add a
+	// GroupSID field and split the CreatorGroup branch in
+	// substituteCreator accordingly.
+	SID string
+}
+
+// substituteCreator returns the resolved Who string for an ACE whose
+// principal is one of SpecialCreatorOwner / SpecialCreatorGroup.
+// Returns the original who unchanged for any other principal.
+func substituteCreator(who string, creator Creator) string {
+	switch who {
+	case SpecialCreatorOwner:
+		if creator.SID != "" {
+			return "sid:" + creator.SID
+		}
+		return fmt.Sprintf("%d@localdomain", creator.UID)
+	case SpecialCreatorGroup:
+		if creator.SID != "" {
+			return "sid:" + creator.SID
+		}
+		return fmt.Sprintf("%d@localdomain", creator.GID)
+	default:
+		return who
+	}
+}
+
 // ComputeInheritedACL computes the ACL to set on a newly created file or
-// directory based on its parent's ACL per RFC 7530 Section 6.4.3.
+// directory based on its parent's ACL per RFC 7530 Section 6.4.3 and
+// MS-DTYP §2.5.3.4 (CREATOR_OWNER / CREATOR_GROUP substitution).
 //
 // For files:
 //   - Include ACEs with FILE_INHERIT flag
@@ -18,8 +61,12 @@ const inheritanceMask = ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE |
 //   - If NO_PROPAGATE_INHERIT: clear all inheritance flags (stop propagation)
 //   - If INHERIT_ONLY on parent: clear INHERIT_ONLY on child (ACE now applies)
 //
+// In both cases, any ACE whose Who is SpecialCreatorOwner or
+// SpecialCreatorGroup is rewritten in place with the creator's frozen
+// identity (sid:<SID> when known, otherwise "<uid|gid>@localdomain").
+//
 // Returns nil if parentACL is nil or no ACEs are inheritable.
-func ComputeInheritedACL(parentACL *ACL, isDirectory bool) *ACL {
+func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL {
 	if parentACL == nil {
 		return nil
 	}
@@ -52,6 +99,10 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool) *ACL {
 			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
 		}
 
+		// MS-DTYP §2.5.3.4: substitute CREATOR_OWNER / CREATOR_GROUP
+		// placeholders with the creator's frozen identity.
+		newACE.Who = substituteCreator(newACE.Who, creator)
+
 		inherited = append(inherited, newACE)
 	}
 
@@ -71,8 +122,8 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool) *ACL {
 //
 // The result maintains canonical ordering: explicit ACEs first, then inherited.
 // Returns nil if both newly computed and existing explicit ACEs are empty.
-func PropagateACL(parentACL *ACL, existingACL *ACL, isDirectory bool) *ACL {
-	newInherited := ComputeInheritedACL(parentACL, isDirectory)
+func PropagateACL(parentACL *ACL, existingACL *ACL, isDirectory bool, creator Creator) *ACL {
+	newInherited := ComputeInheritedACL(parentACL, isDirectory, creator)
 
 	if existingACL == nil {
 		return newInherited

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -12,7 +12,7 @@ func TestComputeInheritedACL_FileInheritOnChildFile(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, false)
+	result := ComputeInheritedACL(parentACL, false, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result for file with FILE_INHERIT parent ACE")
@@ -46,7 +46,7 @@ func TestComputeInheritedACL_DirectoryInheritOnChildDir(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, true)
+	result := ComputeInheritedACL(parentACL, true, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result for directory with DIRECTORY_INHERIT parent ACE")
@@ -75,7 +75,7 @@ func TestComputeInheritedACL_NoPropagateStopsInheritance(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, true)
+	result := ComputeInheritedACL(parentACL, true, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
@@ -106,7 +106,7 @@ func TestComputeInheritedACL_InheritOnlyClearedOnChild(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, true)
+	result := ComputeInheritedACL(parentACL, true, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
@@ -127,12 +127,12 @@ func TestComputeInheritedACL_InheritOnlyClearedOnChild(t *testing.T) {
 }
 
 func TestComputeInheritedACL_NilParent(t *testing.T) {
-	result := ComputeInheritedACL(nil, false)
+	result := ComputeInheritedACL(nil, false, Creator{})
 	if result != nil {
 		t.Error("expected nil result for nil parent ACL")
 	}
 
-	result = ComputeInheritedACL(nil, true)
+	result = ComputeInheritedACL(nil, true, Creator{})
 	if result != nil {
 		t.Error("expected nil result for nil parent ACL (directory)")
 	}
@@ -148,12 +148,12 @@ func TestComputeInheritedACL_NoInheritableACEs(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, false)
+	result := ComputeInheritedACL(parentACL, false, Creator{})
 	if result != nil {
 		t.Error("expected nil for file when no FILE_INHERIT flag")
 	}
 
-	result = ComputeInheritedACL(parentACL, true)
+	result = ComputeInheritedACL(parentACL, true, Creator{})
 	if result != nil {
 		t.Error("expected nil for directory when no DIRECTORY_INHERIT flag")
 	}
@@ -182,7 +182,7 @@ func TestComputeInheritedACL_MixedInheritFlags(t *testing.T) {
 	}}
 
 	// File child: should get ACE 0 (FILE_INHERIT) and ACE 2 (both).
-	fileResult := ComputeInheritedACL(parentACL, false)
+	fileResult := ComputeInheritedACL(parentACL, false, Creator{})
 	if fileResult == nil {
 		t.Fatal("expected non-nil result for file")
 	}
@@ -197,7 +197,7 @@ func TestComputeInheritedACL_MixedInheritFlags(t *testing.T) {
 	}
 
 	// Directory child: should get ACE 1 (DIRECTORY_INHERIT) and ACE 2 (both).
-	dirResult := ComputeInheritedACL(parentACL, true)
+	dirResult := ComputeInheritedACL(parentACL, true, Creator{})
 	if dirResult == nil {
 		t.Fatal("expected non-nil result for directory")
 	}
@@ -224,7 +224,7 @@ func TestComputeInheritedACL_FileInheritClearsAllFlags(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, false)
+	result := ComputeInheritedACL(parentACL, false, Creator{})
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -247,7 +247,7 @@ func TestComputeInheritedACL_PreservesDenyType(t *testing.T) {
 		},
 	}}
 
-	result := ComputeInheritedACL(parentACL, false)
+	result := ComputeInheritedACL(parentACL, false, Creator{})
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -278,7 +278,7 @@ func TestPropagateACL_ReplacesInheritedKeepsExplicit(t *testing.T) {
 		},
 	}}
 
-	result := PropagateACL(newParentACL, existingACL, false)
+	result := PropagateACL(newParentACL, existingACL, false, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
@@ -314,7 +314,7 @@ func TestPropagateACL_NilExisting(t *testing.T) {
 		},
 	}}
 
-	result := PropagateACL(parentACL, nil, false)
+	result := PropagateACL(parentACL, nil, false, Creator{})
 	if result == nil {
 		t.Fatal("expected non-nil result when existing is nil")
 	}
@@ -329,7 +329,7 @@ func TestPropagateACL_NilParent(t *testing.T) {
 		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: ACE4_INHERITED_ACE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
 	}}
 
-	result := PropagateACL(nil, existingACL, false)
+	result := PropagateACL(nil, existingACL, false, Creator{})
 
 	// Should keep only explicit ACEs (inherited removed since parent is nil).
 	if result == nil {
@@ -344,7 +344,7 @@ func TestPropagateACL_NilParent(t *testing.T) {
 }
 
 func TestPropagateACL_BothNil(t *testing.T) {
-	result := PropagateACL(nil, nil, false)
+	result := PropagateACL(nil, nil, false, Creator{})
 	if result != nil {
 		t.Error("expected nil result when both parent and existing are nil")
 	}
@@ -362,9 +362,123 @@ func TestPropagateACL_AllInheritedReplaced(t *testing.T) {
 	}}
 
 	// For a file, the DIRECTORY_INHERIT ACE is not inherited.
-	result := PropagateACL(newParentACL, existingACL, false)
+	result := PropagateACL(newParentACL, existingACL, false, Creator{})
 	if result != nil {
 		t.Error("expected nil result when all inherited ACEs removed and no new ones")
+	}
+}
+
+func TestComputeInheritedACL_CreatorOwnerSubstitution_POSIX(t *testing.T) {
+	// Parent has a CREATOR_OWNER inheritable placeholder ACE. When inherited
+	// onto a file with no Windows SID known, it should resolve to the POSIX
+	// form "<uid>@localdomain" frozen at create time.
+	parentACL := &ACL{ACEs: []ACE{
+		{
+			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+			Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
+			AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA,
+			Who:        SpecialCreatorOwner,
+		},
+	}}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %d", len(result.ACEs))
+	}
+
+	ace := result.ACEs[0]
+	if ace.Who != "1001@localdomain" {
+		t.Errorf("expected Who=1001@localdomain, got %q", ace.Who)
+	}
+	if !ace.IsInherited() {
+		t.Error("expected INHERITED_ACE flag set")
+	}
+	if ace.IsInheritOnly() {
+		t.Error("expected INHERIT_ONLY cleared on file child")
+	}
+}
+
+func TestComputeInheritedACL_CreatorOwnerSubstitution_SID(t *testing.T) {
+	// Same scenario but creator has a Windows SID — substitution uses sid:<SID>.
+	parentACL := &ACL{ACEs: []ACE{
+		{
+			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+			Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
+			AccessMask: ACE4_READ_DATA,
+			Who:        SpecialCreatorOwner,
+		},
+	}}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001, SID: "S-1-5-21-1-2-3-2001"})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %d", len(result.ACEs))
+	}
+
+	ace := result.ACEs[0]
+	if ace.Who != "sid:S-1-5-21-1-2-3-2001" {
+		t.Errorf("expected Who=sid:S-1-5-21-1-2-3-2001, got %q", ace.Who)
+	}
+	if !ace.IsInherited() {
+		t.Error("expected INHERITED_ACE flag set")
+	}
+}
+
+func TestComputeInheritedACL_CreatorGroupSubstitution_POSIX(t *testing.T) {
+	parentACL := &ACL{ACEs: []ACE{
+		{
+			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+			Flag:       ACE4_FILE_INHERIT_ACE,
+			AccessMask: ACE4_READ_DATA,
+			Who:        SpecialCreatorGroup,
+		},
+	}}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001, GID: 2002})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %d", len(result.ACEs))
+	}
+
+	ace := result.ACEs[0]
+	if ace.Who != "2002@localdomain" {
+		t.Errorf("expected Who=2002@localdomain (creator GID), got %q", ace.Who)
+	}
+}
+
+func TestComputeInheritedACL_CreatorGroupSubstitution_SID(t *testing.T) {
+	parentACL := &ACL{ACEs: []ACE{
+		{
+			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+			Flag:       ACE4_FILE_INHERIT_ACE,
+			AccessMask: ACE4_READ_DATA,
+			Who:        SpecialCreatorGroup,
+		},
+	}}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001, GID: 2002, SID: "S-1-5-21-1-2-3-2001"})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	ace := result.ACEs[0]
+	// Group substitution uses creator.SID for Windows form when available.
+	// Per plan: "SpecialCreatorGroup → creator.GID/SID" — the SID branch
+	// embeds the creator's SID. The same SID is used because the SD only
+	// carries one identifier per creator (no separate group SID is plumbed).
+	if ace.Who != "sid:S-1-5-21-1-2-3-2001" {
+		t.Errorf("expected Who=sid:S-1-5-21-1-2-3-2001, got %q", ace.Who)
 	}
 }
 
@@ -383,7 +497,7 @@ func TestPropagateACL_Directory(t *testing.T) {
 		},
 	}}
 
-	result := PropagateACL(newParentACL, existingACL, true)
+	result := PropagateACL(newParentACL, existingACL, true, Creator{})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -83,6 +83,24 @@ const (
 	SpecialEveryone = "EVERYONE@"
 )
 
+// CREATOR placeholder principals per MS-DTYP §2.5.3.4.
+//
+// On the wire these correspond to S-1-3-0 (CREATOR_OWNER) and S-1-3-1
+// (CREATOR_GROUP). They are only meaningful as inheritable placeholders
+// in a parent directory's DACL: when an ACE bearing one of these
+// principals is inherited onto a child, the inherit-time logic
+// substitutes the placeholder with the creator's frozen identity (the
+// requester's UID/GID/SID at create time). Once substituted, the
+// resulting ACE no longer references the placeholder.
+//
+// These are deliberately distinct from SpecialOwner/SpecialGroup
+// (NFSv4 OWNER@/GROUP@) which resolve dynamically to the file's
+// CURRENT owner — CREATOR_* freezes the identity at creation time.
+const (
+	SpecialCreatorOwner = "CreatorOwner@"
+	SpecialCreatorGroup = "CreatorGroup@"
+)
+
 // Well-known SID special identifiers for Windows interop.
 // The SMB translator converts these to binary SIDs (S-1-5-18 and S-1-5-32-544).
 const (

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -281,10 +281,26 @@ func (s *MetadataService) createEntry(
 	}
 	newFile.Nlink = GetInitialLinkCount(fileType)
 
-	// Inherit ACL from parent if parent has one
+	// Inherit ACL from parent if parent has one. CREATOR_OWNER / CREATOR_GROUP
+	// placeholders are substituted with the requester's frozen identity per
+	// MS-DTYP §2.5.3.4. For anonymous creates (no UID/GID on the identity)
+	// we pass a zero Creator, which substitutes "0@localdomain" — acceptable
+	// for the rare anonymous-into-CREATOR_OWNER-DACL case.
 	if parent.ACL != nil {
 		isDir := fileType == FileTypeDirectory
-		inherited := acl.ComputeInheritedACL(parent.ACL, isDir)
+		var creator acl.Creator
+		if ctx != nil && ctx.Identity != nil {
+			if ctx.Identity.UID != nil {
+				creator.UID = *ctx.Identity.UID
+			}
+			if ctx.Identity.GID != nil {
+				creator.GID = *ctx.Identity.GID
+			}
+			if ctx.Identity.SID != nil {
+				creator.SID = *ctx.Identity.SID
+			}
+		}
+		inherited := acl.ComputeInheritedACL(parent.ACL, isDir, creator)
 		newFile.ACL = inherited
 	}
 


### PR DESCRIPTION
## Summary

Phase 4 of the SMB ACL/SID identity plan. Per MS-DTYP §2.5.3.4, S-1-3-0 (CREATOR_OWNER) and S-1-3-1 (CREATOR_GROUP) ACEs on a parent directory's DACL are placeholders for the creator's identity, substituted when the ACE is inherited onto a child. DittoFS previously conflated them with NFSv4 OWNER@/GROUP@ — propagating dynamic "current owner" semantics instead of the frozen-creator one.

## Changes

- New `acl.SpecialCreatorOwner = "CreatorOwner@"` / `acl.SpecialCreatorGroup = "CreatorGroup@"` principals (distinct from NFSv4 OWNER@/GROUP@).
- New `acl.Creator{UID, GID, SID}` struct passed to `ComputeInheritedACL` / `PropagateACL`.
- `substituteCreator` helper rewrites placeholder ACE.Who at inherit time: `"sid:<sid>"` when a Windows SID is known, else `"<uid>@localdomain"` POSIX fallback.
- `pkg/auth/sid/mapper.go`: S-1-3-0/1 ↔ CreatorOwner@/CreatorGroup@. NFSv4 OWNER@/GROUP@ → dynamic SID resolution paths preserved (still used for evaluation-time owner matching).
- `internal/adapter/smb/v2/handlers/security.go::principalToSID`: new shortcuts for the two CREATOR principals.
- `pkg/metadata/file_create.go`: plumbs creator from `ctx.Identity` (nil-safe).

Builds on PR #506 (P2), #507 (P1), #508 (P3).

## smbtorture expectation

Plan targets `acls.CREATOR` and `acls.INHERITANCE`. Both block on the parser `STATUS_INVALID_PARAMETER` issue surfaced in P3 (SET_INFO Security rejection), so they likely won't flip on P4 alone. CI will confirm; no KNOWN_FAILURES walkback unless CI proves a flip.

## Tracking

- Parent: #499
- This phase: #504
- Plan: `docs/superpowers/plans/2026-05-06-smb-acl-sid-identity.md`

## Test plan

- [x] `go test ./pkg/metadata/acl/...`
- [x] `go test ./pkg/auth/sid/...`
- [x] `go test ./pkg/metadata/...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...`
- [x] `go build ./...`
- [ ] CI smbtorture/memory — verify no regressions; check flip status.

## Notes for reviewers

- Single signed commit. Spec + code-quality review applied; one Important from reviewer (doc comment on `Creator.SID` explaining single-field overload for both Owner/Group substitution) resolved by amend before push.
- `Creator.SID` overload: only one user SID is plumbed through the AuthContext today (no separate primary-group SID). Both CREATOR_OWNER and CREATOR_GROUP substitution use the same field; documented inline on the struct.
- Anonymous identity → zero `Creator{}`. CreatorOwner/Group ACEs in that case substitute to `0@localdomain`. Acceptable today; future work if anonymous-CREATOR scenarios matter.