### PR TITLE
fix(acl): accept non-canonical DACLs on SET_INFO Security

### DIFF
--- a/internal/adapter/smb/v2/handlers/security_setinfo_regression_test.go
+++ b/internal/adapter/smb/v2/handlers/security_setinfo_regression_test.go
@@ -1,0 +1,240 @@
+// Regression tests for smbtorture acls.DENY1 / INHERITFLAGS / CREATOR /
+// INHERITANCE SET_INFO Security paths. The Samba tests build SDs via
+// security_descriptor_dacl_create() then SETINFO; DittoFS previously
+// returned STATUS_INVALID_PARAMETER for DENY1 / INHERITFLAGS because
+// ValidateACL rejected ACE arrays that were not in Windows canonical
+// presentation order (explicit DENY before explicit ALLOW, etc.).
+//
+// Per MS-DTYP §2.4.5 the ACL wire layout is an unordered ACE array;
+// canonical order is a UI convention, not a wire requirement. Windows
+// and Samba accept non-canonical DACLs on SET_INFO Security, and the
+// evaluator walks the array in stored order so semantics remain
+// deterministic. These tests construct raw self-relative SD bytes that
+// mirror what Samba emits on the wire (per MS-DTYP §2.4.6 layout),
+// feed them to ParseSecurityDescriptor, and assert both parse and
+// ValidateACL accept the result.
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// buildSID returns the binary encoding of a SID built from authority + subauths.
+func buildSID(t *testing.T, sidStr string) []byte {
+	t.Helper()
+	s, err := sid.ParseSIDString(sidStr)
+	if err != nil {
+		t.Fatalf("ParseSIDString(%q): %v", sidStr, err)
+	}
+	var buf bytes.Buffer
+	sid.EncodeSID(&buf, s)
+	return buf.Bytes()
+}
+
+// buildACE builds a single ACE (type + flags + size + mask + sid).
+func buildACE(aceType, aceFlags uint8, accessMask uint32, sidBytes []byte) []byte {
+	var buf bytes.Buffer
+	aceSize := uint16(8 + len(sidBytes))
+	buf.WriteByte(aceType)
+	buf.WriteByte(aceFlags)
+	writeUint16ToBuf(&buf, aceSize)
+	writeUint32ToBuf(&buf, accessMask)
+	buf.Write(sidBytes)
+	return buf.Bytes()
+}
+
+// buildRawDACL builds a DACL: AclRev(1) + Sbz1(1) + AclSize(2) + AceCount(2) + Sbz2(2) + ACEs.
+func buildRawDACL(aceCount uint16, aces []byte) []byte {
+	var buf bytes.Buffer
+	aclSize := uint16(8 + len(aces))
+	buf.WriteByte(2) // AclRevision = ACL_REVISION (2)
+	buf.WriteByte(0) // Sbz1
+	writeUint16ToBuf(&buf, aclSize)
+	writeUint16ToBuf(&buf, aceCount)
+	writeUint16ToBuf(&buf, 0) // Sbz2
+	buf.Write(aces)
+	return buf.Bytes()
+}
+
+// buildSelfRelativeSD assembles a self-relative SD per MS-DTYP §2.4.6.
+// Layout: Header(20) + DACL + Owner + Group.
+//
+// Pass nil for ownerSID / groupSID to indicate "absent" (offset=0).
+// Pass nil for dacl to indicate no DACL.
+func buildSelfRelativeSD(t *testing.T, control uint16, ownerSID, groupSID, daclBytes []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+
+	// Header
+	buf.WriteByte(1) // Revision
+	buf.WriteByte(0) // Sbz1
+	writeUint16ToBuf(&buf, control|0x8000)
+
+	// Offsets — fill in after we know layout
+	// Order on wire: DACL after header, Owner after DACL, Group after Owner.
+	offsetDACL := uint32(0)
+	offsetOwner := uint32(0)
+	offsetGroup := uint32(0)
+	offsetSACL := uint32(0)
+
+	cursor := uint32(20)
+	if daclBytes != nil {
+		offsetDACL = cursor
+		cursor += uint32(len(daclBytes))
+	}
+	if ownerSID != nil {
+		offsetOwner = cursor
+		cursor += uint32(len(ownerSID))
+	}
+	if groupSID != nil {
+		offsetGroup = cursor
+	}
+
+	writeUint32ToBuf(&buf, offsetOwner)
+	writeUint32ToBuf(&buf, offsetGroup)
+	writeUint32ToBuf(&buf, offsetSACL)
+	writeUint32ToBuf(&buf, offsetDACL)
+
+	if daclBytes != nil {
+		buf.Write(daclBytes)
+	}
+	if ownerSID != nil {
+		buf.Write(ownerSID)
+	}
+	if groupSID != nil {
+		buf.Write(groupSID)
+	}
+	return buf.Bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Test cases: one per failing smbtorture test.
+// ---------------------------------------------------------------------------
+
+// TestSetInfoRepro_DENY1 mirrors source4/torture/smb2/acls.c::test_deny1.
+// SD has 2 ACEs (ALLOW + DENY) for owner_sid. owner present, group NULL,
+// SACL absent. SD type=0x8004 (self-rel | DACL_PRESENT).
+func TestSetInfoRepro_DENY1(t *testing.T) {
+	owner := buildSID(t, "S-1-5-21-1000-1000-1000-500") // arbitrary user-style SID
+
+	const (
+		secRightsFileRead uint32 = 0x00120089
+		secFileWriteData  uint32 = 0x00000002
+	)
+
+	ace1 := buildACE(0x00, 0x00, secRightsFileRead|secFileWriteData, owner) // ALLOW
+	ace2 := buildACE(0x01, 0x00, secFileWriteData, owner)                   // DENY
+
+	dacl := buildRawDACL(2, append(ace1, ace2...))
+	sd := buildSelfRelativeSD(t, 0x0004, owner, nil, dacl)
+
+	t.Logf("DENY1 SD: %d bytes, hex=% x", len(sd), sd)
+	ownerUID, ownerGID, fileACL, err := ParseSecurityDescriptor(sd)
+	if err != nil {
+		t.Errorf("DENY1 ParseSecurityDescriptor REJECTED: %v", err)
+		return
+	}
+	t.Logf("DENY1 OK: ownerUID=%v ownerGID=%v acl=%v", ownerUID, ownerGID, fileACL)
+	// Downstream: SetFileAttributes calls acl.ValidateACL.
+	if err := acl.ValidateACL(fileACL); err != nil {
+		t.Errorf("DENY1 ValidateACL REJECTED (this is the real rejection path -> ErrInvalidArgument -> StatusInvalidParameter): %v", err)
+	}
+}
+
+// TestSetInfoRepro_INHERITFLAGS mirrors test_inheritance_flags.
+// SD has 2 ACEs (owner_sid + SID_WORLD) with OI|CI flags. owner=NULL,
+// group=NULL. SD type varies: 0x8004 plus combos of
+// DACL_AUTO_INHERITED(0x0400), DACL_AUTO_INHERIT_REQ(0x0100),
+// DACL_PROTECTED(0x1000).
+func TestSetInfoRepro_INHERITFLAGS(t *testing.T) {
+	owner := buildSID(t, "S-1-5-21-1000-1000-1000-500")
+	world := buildSID(t, "S-1-1-0")
+
+	const (
+		secFileWriteData uint32 = 0x00000002
+		secStdWriteDAC   uint32 = 0x00040000
+		secFileAll       uint32 = 0x001F01FF
+		secStdAll        uint32 = 0x001F0000
+		oi               uint8  = 0x01
+		ci               uint8  = 0x02
+	)
+
+	// i=15: all set bits — AUTO_INHERITED | AUTO_INHERIT_REQ | PROTECTED | INHERITED ACE flag
+	ace1 := buildACE(0x00, oi|ci|0x10 /* INHERITED_ACE */, secFileWriteData|secStdWriteDAC, owner)
+	ace2 := buildACE(0x00, 0x00, secFileAll|secStdAll, world)
+	dacl := buildRawDACL(2, append(ace1, ace2...))
+
+	control := uint16(0x0004 | 0x0400 | 0x0100 | 0x1000) // DACL_PRESENT | AUTO_INH | AUTO_INH_REQ | PROTECTED
+	sd := buildSelfRelativeSD(t, control, nil, nil, dacl)
+
+	t.Logf("INHERITFLAGS SD: %d bytes, control=0x%04x, hex=% x", len(sd), control, sd)
+	ownerUID, ownerGID, fileACL, err := ParseSecurityDescriptor(sd)
+	if err != nil {
+		t.Errorf("INHERITFLAGS ParseSecurityDescriptor REJECTED: %v", err)
+		return
+	}
+	t.Logf("INHERITFLAGS OK: ownerUID=%v ownerGID=%v acl protected=%v autoinh=%v",
+		ownerUID, ownerGID, fileACL.Protected, fileACL.AutoInherited)
+	if err := acl.ValidateACL(fileACL); err != nil {
+		t.Errorf("INHERITFLAGS ValidateACL REJECTED: %v", err)
+	}
+}
+
+// TestSetInfoRepro_CREATOR mirrors test_creator_sid first SET_INFO.
+// SD has 1 ACE for SID_CREATOR_OWNER (S-1-3-0). owner=NULL, group=NULL.
+func TestSetInfoRepro_CREATOR(t *testing.T) {
+	creator := buildSID(t, "S-1-3-0")
+	const (
+		secRightsFileRead uint32 = 0x00120089
+		secStdAll         uint32 = 0x001F0000
+	)
+	ace := buildACE(0x00, 0x00, secRightsFileRead|secStdAll, creator)
+	dacl := buildRawDACL(1, ace)
+	sd := buildSelfRelativeSD(t, 0x0004, nil, nil, dacl)
+
+	t.Logf("CREATOR SD: %d bytes, hex=% x", len(sd), sd)
+	ownerUID, ownerGID, fileACL, err := ParseSecurityDescriptor(sd)
+	if err != nil {
+		t.Errorf("CREATOR ParseSecurityDescriptor REJECTED: %v", err)
+		return
+	}
+	t.Logf("CREATOR OK: ownerUID=%v ownerGID=%v acl=%+v", ownerUID, ownerGID, fileACL)
+	if err := acl.ValidateACL(fileACL); err != nil {
+		t.Errorf("CREATOR ValidateACL REJECTED: %v", err)
+	}
+}
+
+// TestSetInfoRepro_INHERITANCE mirrors test_inheritance.
+// SD has 2 ACEs (SID_CREATOR_OWNER + SID_WORLD). owner=NULL, group=NULL.
+func TestSetInfoRepro_INHERITANCE(t *testing.T) {
+	creator := buildSID(t, "S-1-3-0")
+	world := buildSID(t, "S-1-1-0")
+
+	const (
+		secFileWriteData uint32 = 0x00000002
+		secFileAll       uint32 = 0x001F01FF
+		secStdAll        uint32 = 0x001F0000
+		oi               uint8  = 0x01
+	)
+
+	// Variant with OI flag (most interesting; test iterates flag combos).
+	ace1 := buildACE(0x00, oi, secFileWriteData, creator)
+	ace2 := buildACE(0x00, 0x00, secFileAll|secStdAll, world)
+	dacl := buildRawDACL(2, append(ace1, ace2...))
+	sd := buildSelfRelativeSD(t, 0x0004, nil, nil, dacl)
+
+	t.Logf("INHERITANCE SD: %d bytes, hex=% x", len(sd), sd)
+	ownerUID, ownerGID, fileACL, err := ParseSecurityDescriptor(sd)
+	if err != nil {
+		t.Errorf("INHERITANCE ParseSecurityDescriptor REJECTED: %v", err)
+		return
+	}
+	t.Logf("INHERITANCE OK: ownerUID=%v ownerGID=%v acl=%+v", ownerUID, ownerGID, fileACL)
+	if err := acl.ValidateACL(fileACL); err != nil {
+		t.Errorf("INHERITANCE ValidateACL REJECTED: %v", err)
+	}
+}

--- a/pkg/metadata/acl/validate.go
+++ b/pkg/metadata/acl/validate.go
@@ -15,19 +15,26 @@ var (
 	// ErrACEEmptyWho is returned when an ACE has an empty Who field.
 	ErrACEEmptyWho = errors.New("ACE has empty Who field")
 
-	// ErrACLNotCanonical is returned when ACEs are not in canonical order.
+	// ErrACLNotCanonical is the documented sentinel for "ACL is not in
+	// canonical (Windows-presentation) order". ValidateACL no longer
+	// returns this error — it is retained for callers that wish to
+	// classify ACLs for normalization/display purposes via aceBucket.
 	ErrACLNotCanonical = errors.New("ACL is not in canonical order")
 )
 
 // ValidateACL validates an entire ACL, checking:
 //  1. ACE count does not exceed MaxACECount (128)
 //  2. Each individual ACE is valid (type, who)
-//  3. ACEs are in strict Windows canonical order:
-//     Bucket 1: Explicit DENY (no INHERITED_ACE, type == DENIED)
-//     Bucket 2: Explicit ALLOW (no INHERITED_ACE, type == ALLOWED)
-//     Bucket 3: Inherited DENY (INHERITED_ACE, type == DENIED)
-//     Bucket 4: Inherited ALLOW (INHERITED_ACE, type == ALLOWED)
-//     AUDIT/ALARM ACEs can appear anywhere.
+//
+// ACE ordering is NOT validated. Per MS-DTYP §2.4.5 the ACL layout is
+// an unordered array of ACEs; canonical order (explicit DENY before
+// explicit ALLOW, etc.) is a presentation convention (Windows ACL
+// editor) and not a wire requirement. Samba and Windows both accept
+// non-canonical DACLs on SET_INFO Security; smbtorture acls.DENY1
+// explicitly relies on this (trailing DENY ACE that does not override
+// granted permissions). Access evaluation walks the ACE array in
+// stored order (RFC 7530 §6.2.1 / MS-DTYP §2.5.3.2), so non-canonical
+// ACLs evaluate deterministically.
 func ValidateACL(a *ACL) error {
 	if a == nil {
 		return nil
@@ -37,28 +44,10 @@ func ValidateACL(a *ACL) error {
 		return fmt.Errorf("%w: %d ACEs (maximum %d)", ErrACETooMany, len(a.ACEs), MaxACECount)
 	}
 
-	// Validate individual ACEs and check canonical ordering.
-	lastBucket := 0
-
 	for i := range a.ACEs {
-		ace := &a.ACEs[i]
-
-		if err := ValidateACE(ace); err != nil {
+		if err := ValidateACE(&a.ACEs[i]); err != nil {
 			return fmt.Errorf("ACE %d: %w", i, err)
 		}
-
-		// AUDIT and ALARM ACEs can appear anywhere; they don't affect
-		// access decisions, so they are not subject to canonical ordering.
-		if ace.Type == ACE4_SYSTEM_AUDIT_ACE_TYPE || ace.Type == ACE4_SYSTEM_ALARM_ACE_TYPE {
-			continue
-		}
-
-		bucket := aceBucket(ace)
-		if bucket < lastBucket {
-			return fmt.Errorf("%w: ACE %d (bucket %d) appears after ACE in bucket %d",
-				ErrACLNotCanonical, i, bucket, lastBucket)
-		}
-		lastBucket = bucket
 	}
 
 	return nil
@@ -73,29 +62,4 @@ func ValidateACE(ace *ACE) error {
 		return ErrACEEmptyWho
 	}
 	return nil
-}
-
-// aceBucket returns the canonical ordering bucket for an ACE.
-// Bucket 1: Explicit DENY
-// Bucket 2: Explicit ALLOW
-// Bucket 3: Inherited DENY
-// Bucket 4: Inherited ALLOW
-func aceBucket(ace *ACE) int {
-	inherited := ace.Flag&ACE4_INHERITED_ACE != 0
-
-	// Base bucket: explicit DENY=1/ALLOW=2, inherited DENY=3/ALLOW=4
-	base := 0
-	if inherited {
-		base = 2
-	}
-
-	switch ace.Type {
-	case ACE4_ACCESS_DENIED_ACE_TYPE:
-		return base + 1
-	case ACE4_ACCESS_ALLOWED_ACE_TYPE:
-		return base + 2
-	default:
-		// AUDIT/ALARM should not reach here; treat as bucket 0 (anywhere).
-		return 0
-	}
 }

--- a/pkg/metadata/acl/validate_test.go
+++ b/pkg/metadata/acl/validate_test.go
@@ -25,13 +25,17 @@ func TestValidateACL_ValidCanonicalOrder(t *testing.T) {
 	}
 }
 
-func TestValidateACL_OutOfOrder(t *testing.T) {
+func TestValidateACL_AcceptsNonCanonicalOrder(t *testing.T) {
+	// Per MS-DTYP §2.4.5 + smbtorture acls.DENY1: non-canonical orderings
+	// must be accepted. Canonical order is a Windows ACL-editor presentation
+	// convention, not a wire requirement. The evaluator walks ACEs in array
+	// order (RFC 7530 §6.2.1) so semantics remain deterministic.
 	tests := []struct {
 		name string
 		aces []ACE
 	}{
 		{
-			name: "explicit allow before explicit deny",
+			name: "explicit allow before explicit deny (acls.DENY1 shape)",
 			aces: []ACE{
 				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
 				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: "alice@example.com"},
@@ -45,7 +49,7 @@ func TestValidateACL_OutOfOrder(t *testing.T) {
 			},
 		},
 		{
-			name: "inherited allow before inherited deny",
+			name: "inherited allow before inherited deny (acls.INHERITFLAGS shape)",
 			aces: []ACE{
 				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: ACE4_INHERITED_ACE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
 				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, Flag: ACE4_INHERITED_ACE, AccessMask: ACE4_WRITE_DATA, Who: "alice@example.com"},
@@ -56,12 +60,8 @@ func TestValidateACL_OutOfOrder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &ACL{ACEs: tt.aces}
-			err := ValidateACL(a)
-			if err == nil {
-				t.Error("expected validation error for out-of-order ACL")
-			}
-			if !errors.Is(err, ErrACLNotCanonical) {
-				t.Errorf("expected ErrACLNotCanonical, got: %v", err)
+			if err := ValidateACL(a); err != nil {
+				t.Fatalf("ValidateACL non-canonical = %v, want nil", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`ValidateACL` rejected ACE arrays not in canonical Windows-presentation order (explicit DENY → explicit ALLOW → inherited DENY → inherited ALLOW), returning `ErrACLNotCanonical`. `file_modify.go::SetFileAttributes` mapped that to `ErrInvalidArgument` → `STATUS_INVALID_PARAMETER` on the wire.

Per MS-DTYP §2.4.5, the ACL wire layout is an unordered array of ACEs; canonical order is a UI/presentation convention (Windows ACL editor), not a wire requirement. Windows and Samba both accept non-canonical input on SET_INFO Security. `smbtorture acls.DENY1` explicitly relies on this: it sets ALLOW(owner, read|write) followed by DENY(owner, write_data) and expects the trailing DENY NOT to override the granted permissions ("Shows on Windows that trailing DENY entries don't override granted permissions").

DittoFS's evaluator already walks ACEs in array order (RFC 7530 §6.2.1 / MS-DTYP §2.5.3.2) so non-canonical ACLs evaluate deterministically — the validator's reject was the only thing blocking these tests.

## Changes

- `pkg/metadata/acl/validate.go`: drop the bucket-order check from `ValidateACL`. Keep ACE count cap + per-ACE field validation. Remove unused `aceBucket` helper. Doc comment now cites MS-DTYP + Samba behavior.
- `pkg/metadata/acl/validate_test.go`: replace `TestValidateACL_OutOfOrder` (which asserted rejection) with `TestValidateACL_AcceptsNonCanonicalOrder` (asserts acceptance, including the DENY1 shape).
- `internal/adapter/smb/v2/handlers/security_setinfo_regression_test.go`: hand-builds raw SDs matching `acls.DENY1`, `INHERITFLAGS`, `CREATOR`, `INHERITANCE` and asserts our parse+validate path accepts all four.

## Expected smbtorture flips (CI will confirm)

- `smb2.acls.DENY1`
- `smb2.acls.INHERITFLAGS`
- `smb2.acls_non_canonical.flags`
- Possibly `smb2.acls.INHERITANCE`, `smb2.acls.CREATOR` (parse+validate now pass; downstream evaluation may still gate).

Off-plan fix — investigation triggered by 4 phases of zero flips. Roots out the real blocker for the entire `smb2.acls.*` cluster.

## Test plan

- [x] `go test ./pkg/metadata/acl/...`
- [x] `go test ./pkg/metadata/...`
- [x] `go test ./internal/adapter/smb/v2/handlers/...`
- [x] `go build ./...`
- [ ] CI smbtorture/memory — flips listed tests; no regressions on canonical-DACL paths.

Refs #499