### PR TITLE
feat(smb): MaxAccess from SD when ACL present (P5)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -970,14 +971,49 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	return h.completeCreateAfterBreak(ctx, draft), nil
 }
 
-// computeMaximalAccess computes the maximal access mask for a file based on
-// POSIX permissions and the requesting user's identity.
+// maxAccessProbeBits is the set of MS-DTYP access-right bits probed against
+// a file's DACL when computing the MxAc create-context response. Per
+// MS-SMB2 §2.2.13.2, MaximalAccess must reflect actual security descriptor
+// evaluation — each bit is OR'd into the result iff the ACL explicitly
+// grants it to the requester. The set covers every individual file/dir
+// right defined as an ACE4_* constant in pkg/metadata/acl/types.go
+// (NFSv4 mask bits share their bit positions with the equivalent
+// Windows access rights, so the resulting mask is directly usable on the
+// SMB2 wire).
+var maxAccessProbeBits = [...]uint32{
+	acl.ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
+	acl.ACE4_WRITE_DATA,
+	acl.ACE4_APPEND_DATA,
+	acl.ACE4_READ_NAMED_ATTRS,
+	acl.ACE4_WRITE_NAMED_ATTRS,
+	acl.ACE4_EXECUTE,
+	acl.ACE4_DELETE_CHILD,
+	acl.ACE4_READ_ATTRIBUTES,
+	acl.ACE4_WRITE_ATTRIBUTES,
+	acl.ACE4_DELETE,
+	acl.ACE4_READ_ACL,
+	acl.ACE4_WRITE_ACL,
+	acl.ACE4_WRITE_OWNER,
+	acl.ACE4_SYNCHRONIZE,
+}
+
+// computeMaximalAccess computes the maximal access mask for a file used in
+// the MxAc create-context response.
 //
-// For the file owner, GENERIC_ALL (0x001F01FF) is granted.
-// For other users, access is computed from the file's mode bits:
-//   - Read permission:    0x00120089 (FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
-//   - Write permission:   0x00120116 (FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA | FILE_WRITE_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
-//   - Execute permission: 0x001200A0 (FILE_EXECUTE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
+// When the file carries an explicit DACL (file.ACL != nil), each individual
+// MS-DTYP access-right bit is probed against the ACL via acl.Evaluate using
+// an EvaluateContext built from authCtx.Identity (mirroring
+// metadata.evaluateACLPermissions). The owner short-circuit is intentionally
+// NOT applied on the ACL path: MS-SMB2 §2.2.13.2 requires the MxAc reply to
+// reflect SD evaluation, and an owner can legitimately be restricted by an
+// OWNER_RIGHTS ACE (MS-DTYP §2.5.3).
+//
+// When file.ACL is nil, the legacy POSIX path is preserved verbatim:
+//   - Owner: GENERIC_ALL (0x001F01FF).
+//   - Other users: mapped from mode bits.
+//     Read permission:    0x00120089 (FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
+//     Write permission:   0x00120116 (FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA | FILE_WRITE_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
+//     Execute permission: 0x001200A0 (FILE_EXECUTE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE)
 func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) uint32 {
 	const (
 		genericAll    uint32 = 0x001F01FF
@@ -985,6 +1021,23 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 		writeAccess   uint32 = 0x00120116
 		executeAccess uint32 = 0x001200A0
 	)
+
+	// ACL-aware path: probe each defined access-right bit against the SD.
+	// No owner short-circuit — the DACL may legitimately restrict the owner.
+	if file.ACL != nil {
+		evalCtx := buildMaxAccessEvalContext(file, authCtx)
+		// Root bypass mirrors metadata.evaluateACLPermissions for consistency.
+		if authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
+			return genericAll
+		}
+		var granted uint32
+		for _, bit := range maxAccessProbeBits {
+			if acl.Evaluate(file.ACL, evalCtx, bit) {
+				granted |= bit
+			}
+		}
+		return granted
+	}
 
 	// Check if the requesting user is the file owner
 	if authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == file.UID {
@@ -1032,6 +1085,48 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 	}
 
 	return access
+}
+
+// buildMaxAccessEvalContext constructs an acl.EvaluateContext for the
+// requester from authCtx.Identity. Mirrors metadata.evaluateACLPermissions
+// so the MxAc reply stays consistent with permission checks performed on
+// subsequent operations against the same handle.
+//
+// Anonymous (no Identity or no UID) sessions produce a context with only
+// the file's owner UID/GID populated, so DENY/ALLOW ACEs targeting
+// EVERYONE@ still match while OWNER@/GROUP@ comparisons fall through.
+func buildMaxAccessEvalContext(file *metadata.File, authCtx *metadata.AuthContext) *acl.EvaluateContext {
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		return &acl.EvaluateContext{
+			FileOwnerUID: file.UID,
+			FileOwnerGID: file.GID,
+		}
+	}
+
+	identity := authCtx.Identity
+	evalCtx := &acl.EvaluateContext{
+		UID:          *identity.UID,
+		GIDs:         identity.GIDs,
+		FileOwnerUID: file.UID,
+		FileOwnerGID: file.GID,
+	}
+	if identity.GID != nil {
+		evalCtx.GID = *identity.GID
+	}
+
+	switch {
+	case identity.Username != "" && identity.Domain != "":
+		evalCtx.Who = identity.Username + "@" + identity.Domain
+	case identity.Username != "":
+		evalCtx.Who = identity.Username
+	}
+
+	if identity.SID != nil {
+		evalCtx.SID = *identity.SID
+	}
+	evalCtx.GroupSIDs = identity.GroupSIDs
+
+	return evalCtx
 }
 
 // ============================================================================

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -975,11 +975,13 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 // a file's DACL when computing the MxAc create-context response. Per
 // MS-SMB2 §2.2.13.2, MaximalAccess must reflect actual security descriptor
 // evaluation — each bit is OR'd into the result iff the ACL explicitly
-// grants it to the requester. The set covers every individual file/dir
-// right defined as an ACE4_* constant in pkg/metadata/acl/types.go
-// (NFSv4 mask bits share their bit positions with the equivalent
-// Windows access rights, so the resulting mask is directly usable on the
-// SMB2 wire).
+// grants it to the requester. The set covers every ACE4_* file/dir right
+// that has a Windows access-mask analog per MS-DTYP §2.4.3; NFSv4 mask
+// bits share their bit positions with the equivalent Windows rights, so
+// the resulting mask is directly usable on the SMB2 wire. The NFSv4-only
+// retention bits (ACE4_WRITE_RETENTION = 0x200, ACE4_WRITE_RETENTION_HOLD
+// = 0x400) are intentionally excluded because they have no representation
+// in SMB access masks.
 var maxAccessProbeBits = [...]uint32{
 	acl.ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
 	acl.ACE4_WRITE_DATA,
@@ -1025,11 +1027,13 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 	// ACL-aware path: probe each defined access-right bit against the SD.
 	// No owner short-circuit — the DACL may legitimately restrict the owner.
 	if file.ACL != nil {
-		evalCtx := buildMaxAccessEvalContext(file, authCtx)
 		// Root bypass mirrors metadata.evaluateACLPermissions for consistency.
+		// Hoisted above evalCtx construction to avoid the allocation on the
+		// root-admin hot path.
 		if authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
 			return genericAll
 		}
+		evalCtx := buildMaxAccessEvalContext(file, authCtx)
 		var granted uint32
 		for _, bit := range maxAccessProbeBits {
 			if acl.Evaluate(file.ACL, evalCtx, bit) {

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1097,8 +1097,13 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 // subsequent operations against the same handle.
 //
 // Anonymous (no Identity or no UID) sessions produce a context with only
-// the file's owner UID/GID populated, so DENY/ALLOW ACEs targeting
-// EVERYONE@ still match while OWNER@/GROUP@ comparisons fall through.
+// the file's owner UID/GID populated. EVERYONE@ ACEs still match. Note that
+// OWNER@/GROUP@ will spuriously match when the file is owned by uid/gid 0
+// (the zero-value default in the returned context); this matches the legacy
+// behavior of metadata.evaluateACLPermissions and is acceptable today because
+// anonymous SMB sessions are not granted access at the share level. Tracked
+// as a future hardening item: use a sentinel UID/GID that cannot collide
+// with a real owner.
 func buildMaxAccessEvalContext(file *metadata.File, authCtx *metadata.AuthContext) *acl.EvaluateContext {
 	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
 		return &acl.EvaluateContext{

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
@@ -678,6 +679,136 @@ func TestHandleCreate_MxAcContext(t *testing.T) {
 		maxAccess := binary.LittleEndian.Uint32(mxAcResp[4:8])
 		if maxAccess != 0x001F01FF {
 			t.Errorf("MaximalAccess = 0x%08x, expected 0x001F01FF", maxAccess)
+		}
+	})
+}
+
+// TestHandleCreate_MxAcContext_ACL verifies that computeMaximalAccess returns
+// SD-evaluated rights when the file carries an explicit DACL (MS-SMB2
+// §2.2.13.2). The POSIX path is preserved verbatim when file.ACL == nil and
+// is exercised by TestHandleCreate_MxAcContext above; here we cover the new
+// ACL-aware branch.
+func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
+	mkOwnerCtx := func() *metadata.AuthContext {
+		uid := uint32(1000)
+		gid := uint32(1000)
+		return &metadata.AuthContext{
+			Context: context.Background(),
+			Identity: &metadata.Identity{
+				UID: &uid,
+				GID: &gid,
+			},
+		}
+	}
+
+	t.Run("DenyACEClearsWriteBits", func(t *testing.T) {
+		// File owned by uid=1000, mode=0700 would yield GENERIC_ALL via the
+		// POSIX path. The DACL denies WRITE_DATA|APPEND_DATA to the owner
+		// before granting "all rights" — DENY-first ordering must clear those
+		// bits from the MxAc reply (no owner short-circuit on the ACL path).
+		authCtx := mkOwnerCtx()
+		file := &metadata.File{
+			FileAttr: metadata.FileAttr{
+				UID:  1000,
+				GID:  1000,
+				Mode: 0700,
+				ACL: &acl.ACL{
+					ACEs: []acl.ACE{
+						{
+							Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+							Who:        acl.SpecialOwner,
+							AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA,
+						},
+						{
+							Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+							Who:        acl.SpecialOwner,
+							AccessMask: 0x001F01FF,
+						},
+					},
+				},
+			},
+		}
+
+		access := computeMaximalAccess(file, authCtx)
+		if access&acl.ACE4_WRITE_DATA != 0 {
+			t.Errorf("ACE4_WRITE_DATA must be cleared, got 0x%08x", access)
+		}
+		if access&acl.ACE4_APPEND_DATA != 0 {
+			t.Errorf("ACE4_APPEND_DATA must be cleared, got 0x%08x", access)
+		}
+		// At minimum, READ_DATA should still be granted by the ALLOW ACE.
+		if access&acl.ACE4_READ_DATA == 0 {
+			t.Errorf("ACE4_READ_DATA must be granted by allow-all ACE, got 0x%08x", access)
+		}
+		// And the owner short-circuit must NOT fire: GENERIC_ALL would have
+		// the write bits set, which we just verified are not.
+		if access == 0x001F01FF {
+			t.Errorf("MxAc returned GENERIC_ALL (0x001F01FF); owner short-circuit leaked onto ACL path")
+		}
+	})
+
+	t.Run("AllowOnlyACEGrantsExactlyListedBits", func(t *testing.T) {
+		// Single ALLOW ACE granting exactly READ_DATA|READ_ATTRIBUTES|
+		// READ_ACL|SYNCHRONIZE — no extra bits should leak in from POSIX mode.
+		authCtx := mkOwnerCtx()
+		want := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+		file := &metadata.File{
+			FileAttr: metadata.FileAttr{
+				UID:  1000,
+				GID:  1000,
+				Mode: 0700,
+				ACL: &acl.ACL{
+					ACEs: []acl.ACE{
+						{
+							Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+							Who:        acl.SpecialOwner,
+							AccessMask: want,
+						},
+					},
+				},
+			},
+		}
+
+		access := computeMaximalAccess(file, authCtx)
+		if access != want {
+			t.Errorf("MxAc = 0x%08x, expected exactly 0x%08x", access, want)
+		}
+	})
+
+	t.Run("EmptyACLDeniesAllProbedBits", func(t *testing.T) {
+		// An ACL with zero ACEs decides no bits — Evaluate returns false for
+		// every probe and the granted mask must be zero.
+		authCtx := mkOwnerCtx()
+		file := &metadata.File{
+			FileAttr: metadata.FileAttr{
+				UID:  1000,
+				GID:  1000,
+				Mode: 0755,
+				ACL:  &acl.ACL{},
+			},
+		}
+
+		access := computeMaximalAccess(file, authCtx)
+		if access != 0 {
+			t.Errorf("Empty ACL must deny all bits, got 0x%08x", access)
+		}
+	})
+
+	t.Run("NilACLFallsBackToPOSIX", func(t *testing.T) {
+		// Regression guard: file.ACL == nil must preserve the legacy owner
+		// short-circuit returning GENERIC_ALL.
+		authCtx := mkOwnerCtx()
+		file := &metadata.File{
+			FileAttr: metadata.FileAttr{
+				UID:  1000,
+				GID:  1000,
+				Mode: 0755,
+			},
+		}
+
+		access := computeMaximalAccess(file, authCtx)
+		if access != 0x001F01FF {
+			t.Errorf("POSIX fallback owner access = 0x%08x, expected 0x001F01FF", access)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Phase 5 of the SMB ACL/SID identity plan. Replaces the POSIX-only `computeMaximalAccess` with an SD-aware probe when `file.ACL != nil`, per MS-SMB2 §2.2.13.2. POSIX path preserved as fallback for ACL-less files.

- New `if file.ACL != nil` branch in `computeMaximalAccess` probes each MS-DTYP file/dir access right via `acl.Evaluate`; OR'd granted bits become the MxAc response.
- `buildMaxAccessEvalContext` constructs the evaluation context, mirroring `metadata.evaluateACLPermissions` (UID/GID/GIDs/Who/SID/GroupSIDs, anonymous fallback).
- Owner short-circuit deliberately gated to the POSIX branch — owner rights now come from the SD when one exists (matches Windows semantics; required for `acls.DENY1`).
- Root (UID 0) bypass preserved; hoisted above context construction.
- 14-bit `maxAccessProbeBits` covers every ACE4_* bit with a Windows analog per MS-DTYP §2.4.3; NFSv4-only retention bits intentionally excluded.

Refs #502, #499.

## Test plan

- [x] `go fmt ./...` / `go vet ./...` clean
- [x] `go test ./internal/adapter/smb/v2/handlers/...` — handler suite green incl. four new `TestHandleCreate_MxAcContext_ACL` subtests (deny-write, allow-only, empty, nil fallback)
- [x] `go test -race ./internal/adapter/smb/v2/handlers/...` green
- [x] `go test ./pkg/metadata/acl/...` green
- [x] CI smbtorture: expect flips on `acls.DENY1` (MxAc assertion `0x16008B`) and `acls.MXAC-NOT-GRANTED`; partial `acls.DYNAMIC`. KNOWN_FAILURES.md walkback in a follow-up commit only after CI confirms.

## Follow-ups (separate issues, not this PR)

- Extract shared `acl.EvalContextFromIdentity` helper to retire the parallel context builder duplicated against `metadata.evaluateACLPermissions`.