### PR TITLE
fix(smb): canonicalize SE_DACL_AUTO_INHERITED per MS-DTYP §2.5.3.4.2 (P6-2)

### DIFF
--- a/internal/adapter/smb/v2/handlers/security.go
+++ b/internal/adapter/smb/v2/handlers/security.go
@@ -36,11 +36,12 @@ const (
 
 // Security Descriptor control flags per MS-DTYP Section 2.4.6.
 const (
-	seSelfRelative      = 0x8000
-	seDACLPresent       = 0x0004
-	seSACLPresent       = 0x0010
-	seDACLAutoInherited = 0x0400
-	seDACLProtected     = 0x1000
+	seSelfRelative       = 0x8000
+	seDACLPresent        = 0x0004
+	seSACLPresent        = 0x0010
+	seDACLAutoInheritReq = 0x0100 // SE_DACL_AUTO_INHERIT_REQ — client requests inheritance computation
+	seDACLAutoInherited  = 0x0400
+	seDACLProtected      = 0x1000
 )
 
 // ACE type constants for Windows ACEs per MS-DTYP Section 2.4.4.1.
@@ -177,20 +178,16 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 		control |= seSACLPresent
 	}
 
-	// Round-trip SE_DACL_AUTO_INHERITED from the parsed ACL (MS-DTYP §2.4.6).
-	// Parse path captures the Control bit into fileACL.AutoInherited; emit it directly here.
+	// Round-trip SE_DACL_AUTO_INHERITED from the parsed ACL (MS-DTYP §2.4.6,
+	// §2.5.3.4.2). The SD-level Control bit and per-ACE
+	// SEC_ACE_FLAG_INHERITED_ACE are independent fields per MS-DTYP §2.4.4.2,
+	// so AutoInherited is the sole driver here. Parse-side canonicalization
+	// (mirroring Samba source3/smbd/smb2_nttrans.c::canonicalize_inheritance_bits)
+	// ensures AutoInherited reflects only client SETs of (AUTO_INHERITED &&
+	// AUTO_INHERIT_REQ).
 	if fileACL != nil {
 		if fileACL.AutoInherited {
 			control |= seDACLAutoInherited
-		} else {
-			// Fallback for ACLs persisted before SE_DACL_AUTO_INHERITED was captured:
-			// infer the Control bit when any ACE carries INHERITED_ACE.
-			for _, ace := range fileACL.ACEs {
-				if ace.Flag&acl.ACE4_INHERITED_ACE != 0 {
-					control |= seDACLAutoInherited
-					break
-				}
-			}
 		}
 		if fileACL.Protected {
 			control |= seDACLProtected
@@ -420,16 +417,22 @@ func ParseSecurityDescriptor(data []byte) (ownerUID *uint32, ownerGID *uint32, f
 	}
 
 	// Surface SD Control flags onto the ACL so SE_DACL_PROTECTED and
-	// SE_DACL_AUTO_INHERITED round-trip through SET_INFO Security. The build
-	// path re-emits SE_DACL_PROTECTED from ACL.Protected and
-	// SE_DACL_AUTO_INHERITED from ACL.AutoInherited (with a legacy fallback
-	// to the per-ACE INHERITED_ACE flag for ACLs persisted before this field
-	// was captured).
+	// SE_DACL_AUTO_INHERITED round-trip through SET_INFO Security.
+	//
+	// Apply MS-DTYP §2.5.3.4.2 canonicalization mirroring Samba
+	// source3/smbd/smb2_nttrans.c::canonicalize_inheritance_bits. The
+	// AUTO_INHERIT_REQ bit is a request flag — server processes it and never
+	// echoes it back. AUTO_INHERITED is persisted only when the client SETs
+	// BOTH AUTO_INHERITED and AUTO_INHERIT_REQ; otherwise it is cleared. A
+	// per-share toggle to disable this canonicalization (Samba's "acl flag
+	// inherited canonicalization = no") is tracked in #514.
 	if fileACL != nil {
 		if control&seDACLProtected != 0 {
 			fileACL.Protected = true
 		}
-		if control&seDACLAutoInherited != 0 {
+		autoInheritReq := control&seDACLAutoInheritReq != 0
+		autoInherited := control&seDACLAutoInherited != 0
+		if autoInheritReq && autoInherited {
 			fileACL.AutoInherited = true
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -1130,7 +1130,8 @@ func TestParseSD_AutoInheritedCanonicalization(t *testing.T) {
 		{"perACE_inherited_only", false, false, false, true, false, false, false},
 		{"perACE_with_protected", false, false, true, true, false, true, false},
 		{"auto_and_req_with_perACE", true, true, false, true, true, false, true},
-		{"perACE_inherited_no_sd_bits", false, false, false, true, false, false, false},
+		{"auto_and_protected_no_req", true, false, true, false, false, true, false},
+		{"all_four_bits", true, true, true, true, true, true, true},
 	}
 
 	for _, tc := range cases {

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -1070,8 +1070,9 @@ func TestBuildSD_AutoInherited_NotSet(t *testing.T) {
 
 // makeAutoInheritSD hand-crafts a self-relative SD whose Control word has the
 // given high bits OR'd in (in addition to seSelfRelative|seDACLPresent), and
-// embeds an empty DACL plus a single non-inherited ALLOW-EVERYONE ACE so the
-// inheritance matrix can also assert independence from per-ACE flags.
+// embeds a single ALLOW-EVERYONE ACE optionally marked with the wire
+// INHERITED_ACE flag so the inheritance matrix can assert independence from
+// per-ACE flags.
 func makeAutoInheritSD(t *testing.T, extraControl uint16, perACEInherited bool) []byte {
 	t.Helper()
 	// Layout: header(20) + DACL header(8) + ACE(8 + everyone SID).

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/binary"
 	"os"
 	"testing"
@@ -276,15 +277,20 @@ func TestBuildSD_SACL_NotRequested(t *testing.T) {
 	}
 }
 
-// TestBuildSD_AutoInherited verifies SE_DACL_AUTO_INHERITED is set when
-// ACEs have INHERITED_ACE flag.
-func TestBuildSD_AutoInherited(t *testing.T) {
+// TestBuildSD_AutoInherited_PerACEFlagNotEnough verifies the P6-2 invariant:
+// per MS-DTYP §2.4.6 / §2.4.4.2 the SD-level SE_DACL_AUTO_INHERITED Control
+// bit and the per-ACE SEC_ACE_FLAG_INHERITED_ACE are independent fields, so
+// per-ACE INHERITED_ACE flags alone do NOT imply the Control bit. (Inverse of
+// the legacy fallback removed in P6-2; the bit must come from
+// acl.ACL.AutoInherited, which itself reflects parse-side canonicalization.)
+func TestBuildSD_AutoInherited_PerACEFlagNotEnough(t *testing.T) {
 	file := &metadata.File{
 		FileAttr: metadata.FileAttr{
 			UID:  1000,
 			GID:  1000,
 			Mode: 0o755,
 			ACL: &acl.ACL{
+				AutoInherited: false,
 				ACEs: []acl.ACE{
 					{
 						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
@@ -303,8 +309,8 @@ func TestBuildSD_AutoInherited(t *testing.T) {
 	}
 
 	control := binary.LittleEndian.Uint16(data[2:4])
-	if control&seDACLAutoInherited == 0 {
-		t.Error("SE_DACL_AUTO_INHERITED not set when ACEs have INHERITED_ACE flag")
+	if control&seDACLAutoInherited != 0 {
+		t.Error("SE_DACL_AUTO_INHERITED set from per-ACE INHERITED_ACE alone (legacy fallback should be removed)")
 	}
 }
 
@@ -818,40 +824,35 @@ func TestSecurityDescriptor_SIDFormRoundTrip(t *testing.T) {
 }
 
 // TestParseSecurityDescriptor_CapturesControlFlags asserts that an SD whose
-// Control field carries SE_DACL_PROTECTED + SE_DACL_AUTO_INHERITED yields an
-// ACL with both flags set after parse. The build path already emits these
-// flags; this locks down the symmetric parse direction so SET_INFO Security
-// can persist the client's intent for inheritance behavior.
+// Control field carries SE_DACL_PROTECTED + (SE_DACL_AUTO_INHERITED &
+// SE_DACL_AUTO_INHERIT_REQ) yields an ACL with both flags set after parse.
+// Per MS-DTYP §2.5.3.4.2 / Samba canonicalize_inheritance_bits, AutoInherited
+// is only captured when BOTH AUTO_INHERITED and AUTO_INHERIT_REQ are set by
+// the client.
 func TestParseSecurityDescriptor_CapturesControlFlags(t *testing.T) {
-	// Build an SD whose source ACL is Protected + AutoInherited. The build
-	// path emits seDACLProtected + seDACLAutoInherited; we then parse it
-	// back and assert both flags survive.
-	file := &metadata.File{
-		FileAttr: metadata.FileAttr{
-			UID:  1000,
-			GID:  1000,
-			Mode: 0o755,
-			ACL: &acl.ACL{
-				Protected:     true,
-				AutoInherited: true,
-				ACEs: []acl.ACE{
-					{
-						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
-						Flag:       acl.ACE4_INHERITED_ACE,
-						AccessMask: 0x001F01FF,
-						Who:        acl.SpecialEveryone,
-					},
-				},
-			},
-		},
-	}
+	// Hand-craft a self-relative SD with Control =
+	// seSelfRelative|seDACLPresent|seDACLProtected|seDACLAutoInherited|seDACLAutoInheritReq.
+	// Build path doesn't emit AUTO_INHERIT_REQ, so we cannot use it here.
+	const (
+		hdrSize = 20
+		aclSize = 8
+	)
+	buf := make([]byte, hdrSize+aclSize)
+	buf[0] = 1 // Revision
+	buf[1] = 0 // Sbz1
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(seSelfRelative|seDACLPresent|seDACLProtected|seDACLAutoInherited|seDACLAutoInheritReq))
+	binary.LittleEndian.PutUint32(buf[4:8], 0)         // offsetOwner
+	binary.LittleEndian.PutUint32(buf[8:12], 0)        // offsetGroup
+	binary.LittleEndian.PutUint32(buf[12:16], 0)       // offsetSACL
+	binary.LittleEndian.PutUint32(buf[16:20], hdrSize) // offsetDACL
+	// Empty DACL
+	buf[20] = 2 // AclRevision
+	buf[21] = 0
+	binary.LittleEndian.PutUint16(buf[22:24], aclSize)
+	binary.LittleEndian.PutUint16(buf[24:26], 0)
+	binary.LittleEndian.PutUint16(buf[26:28], 0)
 
-	data, err := BuildSecurityDescriptor(file, 0)
-	if err != nil {
-		t.Fatalf("BuildSecurityDescriptor: %v", err)
-	}
-
-	_, _, parsed, err := ParseSecurityDescriptor(data)
+	_, _, parsed, err := ParseSecurityDescriptor(buf)
 	if err != nil {
 		t.Fatalf("ParseSecurityDescriptor: %v", err)
 	}
@@ -862,7 +863,7 @@ func TestParseSecurityDescriptor_CapturesControlFlags(t *testing.T) {
 		t.Error("Protected = false, want true")
 	}
 	if !parsed.AutoInherited {
-		t.Error("AutoInherited = false, want true")
+		t.Error("AutoInherited = false, want true (both AUTO_INHERITED and AUTO_INHERIT_REQ set)")
 	}
 }
 
@@ -983,36 +984,22 @@ func TestBuildSD_AutoInherited_FromACLField(t *testing.T) {
 	}
 }
 
-// TestBuildSD_AutoInherited_RoundTrip verifies the full parse+build round trip
-// for SE_DACL_AUTO_INHERITED. Build an SD from ACL{AutoInherited:true}, parse
-// it back (parse path captures the Control bit), then re-build. The re-built
-// SD must still carry SE_DACL_AUTO_INHERITED in its Control word.
+// TestBuildSD_AutoInherited_RoundTrip verifies the full client→parse→build
+// round trip for SE_DACL_AUTO_INHERITED. A client SET_INFO carrying both
+// AUTO_INHERITED and AUTO_INHERIT_REQ is parsed (canonicalization captures the
+// bit), the ACL is then re-built via BuildSecurityDescriptor, and the re-built
+// SD must still carry SE_DACL_AUTO_INHERITED. AUTO_INHERIT_REQ is a one-way
+// client request — server never echoes it back, mirroring Samba
+// canonicalize_inheritance_bits.
 func TestBuildSD_AutoInherited_RoundTrip(t *testing.T) {
-	file := &metadata.File{
-		FileAttr: metadata.FileAttr{
-			UID:  1000,
-			GID:  1000,
-			Mode: 0o755,
-			ACL: &acl.ACL{
-				AutoInherited: true,
-				ACEs: []acl.ACE{
-					{
-						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
-						Flag:       0, // no per-ACE inherited flag
-						AccessMask: 0x001F01FF,
-						Who:        acl.SpecialOwner,
-					},
-				},
-			},
-		},
-	}
+	// Hand-craft the inbound client SD with both AUTO_INHERITED and
+	// AUTO_INHERIT_REQ in the Control word. Build path won't emit
+	// AUTO_INHERIT_REQ on its own. Include a non-inherited ACE so the
+	// build-side `len(ACEs) > 0` guard preserves the parsed ACL (zero-ACE
+	// DACLs are intentionally replaced by mode synthesis).
+	clientSD := makeAutoInheritSD(t, seDACLAutoInherited|seDACLAutoInheritReq, false)
 
-	data1, err := BuildSecurityDescriptor(file, 0)
-	if err != nil {
-		t.Fatalf("BuildSecurityDescriptor (initial): %v", err)
-	}
-
-	_, _, parsed, err := ParseSecurityDescriptor(data1)
+	_, _, parsed, err := ParseSecurityDescriptor(clientSD)
 	if err != nil {
 		t.Fatalf("ParseSecurityDescriptor: %v", err)
 	}
@@ -1020,7 +1007,7 @@ func TestBuildSD_AutoInherited_RoundTrip(t *testing.T) {
 		t.Fatal("parsed ACL is nil")
 	}
 	if !parsed.AutoInherited {
-		t.Fatal("parsed.AutoInherited = false; parse path failed to capture flag")
+		t.Fatal("parsed.AutoInherited = false; canonicalization failed to capture flag")
 	}
 
 	// Re-build from the parsed ACL and assert the Control bit survives.
@@ -1040,6 +1027,10 @@ func TestBuildSD_AutoInherited_RoundTrip(t *testing.T) {
 	control := binary.LittleEndian.Uint16(data2[2:4])
 	if control&seDACLAutoInherited == 0 {
 		t.Error("SE_DACL_AUTO_INHERITED dropped on re-build from parsed ACL")
+	}
+	// Per Samba canonicalize_inheritance_bits, AUTO_INHERIT_REQ is never echoed back.
+	if control&seDACLAutoInheritReq != 0 {
+		t.Error("SE_DACL_AUTO_INHERIT_REQ was echoed back in build output (must not be)")
 	}
 }
 
@@ -1074,5 +1065,127 @@ func TestBuildSD_AutoInherited_NotSet(t *testing.T) {
 	control := binary.LittleEndian.Uint16(data[2:4])
 	if control&seDACLAutoInherited != 0 {
 		t.Error("SE_DACL_AUTO_INHERITED set when ACL.AutoInherited=false and no ACE carries INHERITED_ACE")
+	}
+}
+
+// makeAutoInheritSD hand-crafts a self-relative SD whose Control word has the
+// given high bits OR'd in (in addition to seSelfRelative|seDACLPresent), and
+// embeds an empty DACL plus a single non-inherited ALLOW-EVERYONE ACE so the
+// inheritance matrix can also assert independence from per-ACE flags.
+func makeAutoInheritSD(t *testing.T, extraControl uint16, perACEInherited bool) []byte {
+	t.Helper()
+	// Layout: header(20) + DACL header(8) + ACE(8 + everyone SID).
+	everyoneSID := sid.WellKnownEveryone
+	sidLen := sid.SIDSize(everyoneSID)
+	aceLen := aceHeaderSize + sidLen
+	daclLen := aclHeaderSize + aceLen
+	totalLen := sdHeaderSize + daclLen
+	buf := make([]byte, totalLen)
+	// SD header
+	buf[0] = 1 // Revision
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(seSelfRelative|seDACLPresent)|extraControl)
+	binary.LittleEndian.PutUint32(buf[16:20], sdHeaderSize)
+	// DACL header
+	buf[20] = 2
+	binary.LittleEndian.PutUint16(buf[22:24], uint16(daclLen))
+	binary.LittleEndian.PutUint16(buf[24:26], 1) // AceCount=1
+	// ACE
+	aceOff := sdHeaderSize + aclHeaderSize
+	buf[aceOff] = accessAllowedACEType
+	if perACEInherited {
+		buf[aceOff+1] = 0x10 // Windows INHERITED_ACE wire bit
+	}
+	binary.LittleEndian.PutUint16(buf[aceOff+2:aceOff+4], uint16(aceLen))
+	binary.LittleEndian.PutUint32(buf[aceOff+4:aceOff+8], 0x001F01FF)
+	var sidBuf bytes.Buffer
+	sid.EncodeSID(&sidBuf, everyoneSID)
+	copy(buf[aceOff+aceHeaderSize:], sidBuf.Bytes())
+	return buf
+}
+
+// TestParseSD_AutoInheritedCanonicalization is the 4-bit matrix mirroring
+// smbtorture's acls.INHERITFLAGS / acls_non_canonical.flags expectations.
+// Per Samba canonicalize_inheritance_bits (MS-DTYP §2.5.3.4.2), the
+// server captures SE_DACL_AUTO_INHERITED on the persisted ACL ONLY when the
+// client sets both AUTO_INHERITED and AUTO_INHERIT_REQ. The per-ACE
+// SEC_ACE_FLAG_INHERITED_ACE is independent and never escalates the SD bit.
+func TestParseSD_AutoInheritedCanonicalization(t *testing.T) {
+	cases := []struct {
+		name                 string
+		autoInherited        bool
+		autoInheritReq       bool
+		protected            bool
+		perACEInherited      bool
+		wantACLAutoInherit   bool
+		wantACLProtected     bool
+		wantBuildAutoInherit bool
+	}{
+		{"none", false, false, false, false, false, false, false},
+		{"auto_only", true, false, false, false, false, false, false},
+		{"req_only", false, true, false, false, false, false, false},
+		{"auto_and_req", true, true, false, false, true, false, true},
+		{"protected_only", false, false, true, false, false, true, false},
+		{"all_no_perace", true, true, true, false, true, true, true},
+		{"perACE_inherited_only", false, false, false, true, false, false, false},
+		{"perACE_with_protected", false, false, true, true, false, true, false},
+		{"auto_and_req_with_perACE", true, true, false, true, true, false, true},
+		{"perACE_inherited_no_sd_bits", false, false, false, true, false, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ctrl uint16
+			if tc.autoInherited {
+				ctrl |= seDACLAutoInherited
+			}
+			if tc.autoInheritReq {
+				ctrl |= seDACLAutoInheritReq
+			}
+			if tc.protected {
+				ctrl |= seDACLProtected
+			}
+			sd := makeAutoInheritSD(t, ctrl, tc.perACEInherited)
+
+			_, _, parsed, err := ParseSecurityDescriptor(sd)
+			if err != nil {
+				t.Fatalf("ParseSecurityDescriptor: %v", err)
+			}
+			if parsed == nil {
+				t.Fatal("parsed ACL is nil")
+			}
+			if parsed.AutoInherited != tc.wantACLAutoInherit {
+				t.Errorf("parsed.AutoInherited = %v, want %v", parsed.AutoInherited, tc.wantACLAutoInherit)
+			}
+			if parsed.Protected != tc.wantACLProtected {
+				t.Errorf("parsed.Protected = %v, want %v", parsed.Protected, tc.wantACLProtected)
+			}
+
+			// Re-build and verify Control bits round-trip correctly.
+			file := &metadata.File{
+				FileAttr: metadata.FileAttr{
+					UID:  1000,
+					GID:  1000,
+					Mode: 0o755,
+					ACL:  parsed,
+				},
+			}
+			rebuilt, err := BuildSecurityDescriptor(file, 0)
+			if err != nil {
+				t.Fatalf("BuildSecurityDescriptor: %v", err)
+			}
+			rebuiltCtrl := binary.LittleEndian.Uint16(rebuilt[2:4])
+			gotAuto := rebuiltCtrl&seDACLAutoInherited != 0
+			if gotAuto != tc.wantBuildAutoInherit {
+				t.Errorf("re-build SE_DACL_AUTO_INHERITED = %v, want %v", gotAuto, tc.wantBuildAutoInherit)
+			}
+			gotProtected := rebuiltCtrl&seDACLProtected != 0
+			if gotProtected != tc.wantACLProtected {
+				t.Errorf("re-build SE_DACL_PROTECTED = %v, want %v", gotProtected, tc.wantACLProtected)
+			}
+			// AUTO_INHERIT_REQ must never be echoed back on build.
+			if rebuiltCtrl&seDACLAutoInheritReq != 0 {
+				t.Error("re-build echoed SE_DACL_AUTO_INHERIT_REQ (must not)")
+			}
+		})
 	}
 }

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -65,6 +65,12 @@ func substituteCreator(who string, creator Creator) string {
 // SpecialCreatorGroup is rewritten in place with the creator's frozen
 // identity (sid:<SID> when known, otherwise "<uid|gid>@localdomain").
 //
+// Per MS-DTYP §2.5.3.4.2, when the parent SD has SE_DACL_AUTO_INHERITED set,
+// the computed child SD also has SE_DACL_AUTO_INHERITED set (mirrors Samba
+// source3/smbd/posix_acls.c::set_inherited_sd). SE_DACL_PROTECTED is a
+// per-SD property that BLOCKS inheritance from upstream and is never itself
+// inherited onto the child.
+//
 // Returns nil if parentACL is nil or no ACEs are inheritable.
 func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL {
 	if parentACL == nil {
@@ -110,7 +116,16 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		return nil
 	}
 
-	return &ACL{ACEs: inherited}
+	result := &ACL{ACEs: inherited}
+	// Per MS-DTYP §2.5.3.4.2, when a parent has SE_DACL_AUTO_INHERITED set,
+	// children created under it inherit that bit on their own SD. Mirrors
+	// Samba source3/smbd/posix_acls.c::set_inherited_sd. Protected is a
+	// per-SD property that blocks inheritance from upstream; it is never
+	// itself inherited.
+	if parentACL.AutoInherited {
+		result.AutoInherited = true
+	}
+	return result
 }
 
 // PropagateACL replaces the inherited ACEs of an existing ACL with newly
@@ -121,6 +136,11 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 // (those without the INHERITED_ACE flag) are kept intact.
 //
 // The result maintains canonical ordering: explicit ACEs first, then inherited.
+// Per MS-DTYP §2.5.3.4.2 (matching ComputeInheritedACL), the parent's
+// SE_DACL_AUTO_INHERITED bit propagates onto the recomputed child SD;
+// SE_DACL_PROTECTED is never inherited. Mirrors Samba
+// source3/smbd/posix_acls.c::set_inherited_sd.
+//
 // Returns nil if both newly computed and existing explicit ACEs are empty.
 func PropagateACL(parentACL *ACL, existingACL *ACL, isDirectory bool, creator Creator) *ACL {
 	newInherited := ComputeInheritedACL(parentACL, isDirectory, creator)
@@ -150,5 +170,12 @@ func PropagateACL(parentACL *ACL, existingACL *ACL, isDirectory bool, creator Cr
 	combined = append(combined, explicit...)
 	combined = append(combined, inheritedACEs...)
 
-	return &ACL{ACEs: combined}
+	result := &ACL{ACEs: combined}
+	// MS-DTYP §2.5.3.4.2: SE_DACL_AUTO_INHERITED propagates from parent to
+	// child on the child's recomputed SD. Protected is per-SD and never
+	// inherited. See ComputeInheritedACL for spec/Samba references.
+	if parentACL != nil && parentACL.AutoInherited {
+		result.AutoInherited = true
+	}
+	return result
 }

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -482,6 +482,138 @@ func TestComputeInheritedACL_CreatorGroupSubstitution_SID(t *testing.T) {
 	}
 }
 
+func TestComputeInheritedACL_AutoInheritedPropagation(t *testing.T) {
+	// Parent SD has SE_DACL_AUTO_INHERITED set + an inheritable ACE.
+	// Per MS-DTYP §2.5.3.4.2, the computed child SD must also have
+	// SE_DACL_AUTO_INHERITED set (Samba parity: set_inherited_sd).
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: 0xFF,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.AutoInherited {
+		t.Error("expected AutoInherited=true propagated from parent")
+	}
+}
+
+func TestComputeInheritedACL_ParentNotAutoInherited_ChildNotAutoInherited(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: false,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: 0xFF,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.AutoInherited {
+		t.Error("expected AutoInherited=false when parent has it cleared")
+	}
+}
+
+func TestComputeInheritedACL_ProtectedNotPropagated(t *testing.T) {
+	// Parent has Protected + AutoInherited set. Only AutoInherited
+	// propagates; Protected is per-SD and blocks inheritance, never
+	// itself inherited onto the child.
+	parentACL := &ACL{
+		Protected:     true,
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: 0xFF,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Protected {
+		t.Error("expected Protected=false on child (Protected is per-SD, never inherited)")
+	}
+	if !result.AutoInherited {
+		t.Error("expected AutoInherited=true on child")
+	}
+}
+
+func TestPropagateACL_AutoInheritedPropagation(t *testing.T) {
+	// PropagateACL must also propagate AutoInherited from parent onto
+	// the recomputed combined child SD.
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: 0xFF,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+	existingACL := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: "alice@example.com"},
+		},
+	}
+
+	result := PropagateACL(parentACL, existingACL, false, Creator{})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.AutoInherited {
+		t.Error("expected AutoInherited=true propagated through PropagateACL")
+	}
+}
+
+func TestComputeInheritedACL_ParentAutoInheritedButNoInheritableACEs_ReturnsNil(t *testing.T) {
+	// Parent has AutoInherited set but no inheritable ACEs. Existing
+	// semantics: return nil ("no ACL to set on child" — child gets a
+	// synthesized SD per existing creation path). The AutoInherited bit
+	// does not synthesize an empty ACL.
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       0, // no inherit flags
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+	if result != nil {
+		t.Errorf("expected nil when no inheritable ACEs even if parent has AutoInherited, got %+v", result)
+	}
+}
+
 func TestPropagateACL_Directory(t *testing.T) {
 	existingACL := &ACL{ACEs: []ACE{
 		{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_DELETE, Who: "bob@example.com"},

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -63,6 +63,7 @@ descriptors, and owner rights are not implemented.
 | smb2.acls.OWNER-RIGHTS-DENY | ACLs | Owner rights deny not implemented | - |
 | smb2.acls.OWNER-RIGHTS-DENY1 | ACLs | Owner rights deny not implemented | - |
 | smb2.acls.SDFLAGSVSCHOWN | ACLs | SD flags vs chown not implemented | - |
+| smb2.acls_non_canonical.flags | ACLs | Requires per-share canonicalization toggle (#514) | - |
 | smb2.sdread | Security descriptors | Security descriptor read not implemented | - |
 | smb2.secleak | Security descriptors | Security descriptor leak test not implemented | - |
 

--- a/test/smb-conformance/smbtorture/baseline-results.md
+++ b/test/smb-conformance/smbtorture/baseline-results.md
@@ -24,7 +24,7 @@
 | Sub-Suite | Pass | Fail | Skip | Total | Pass Rate |
 |-----------|------|------|------|-------|-----------|
 | smb2.acls | 0 | 14 | 0 | 14 | 0% |
-| smb2.acls_non_canonical | 1 | 0 | 0 | 1 | 100% |
+| smb2.acls_non_canonical | 0 | 1 | 0 | 1 | 0% |
 | smb2.async_dosmode | 0 | 1 | 0 | 1 | 0% |
 | smb2.bench | 0 | 5 | 0 | 5 | 0% |
 | smb2.change_notify_disabled | 0 | 1 | 0 | 1 | 0% |
@@ -270,6 +270,9 @@ Complete list of all 372 failing tests for reference.
 - smb2.acls.OWNER-RIGHTS-DENY
 - smb2.acls.OWNER-RIGHTS-DENY1
 - smb2.acls.SDFLAGSVSCHOWN
+
+### smb2.acls_non_canonical (1 failure)
+- smb2.acls_non_canonical.flags
 
 ### smb2.async_dosmode (1 failure)
 - smb2.async_dosmode


### PR DESCRIPTION
## Summary

Phase 6-2 of the SMB ACL plan. Apply MS-DTYP `canonicalize_inheritance_bits` semantics in `ParseSecurityDescriptor` and delete the per-ACE `INHERITED_ACE` fallback added by P6-1.

- **Parse**: `acl.ACL.AutoInherited = (control & AUTO_INHERIT_REQ != 0) && (control & AUTO_INHERITED != 0)`. The `AUTO_INHERIT_REQ` bit is a request flag — server processes it and never echoes it back. Mirrors Samba `source3/smbd/smb2_nttrans.c::canonicalize_inheritance_bits`.
- **Build**: `acl.ACL.AutoInherited` is now the sole driver of `SE_DACL_AUTO_INHERITED`. P6-1's per-ACE fallback was incorrect — the SD-level Control bit (§2.4.6) and per-ACE `SEC_ACE_FLAG_INHERITED_ACE` (§2.4.4.2) are independent fields.
- **Protected**: unchanged.
- New constant `seDACLAutoInheritReq = 0x0100`.

Tests: rewrote `TestParseSecurityDescriptor_CapturesControlFlags`, `TestBuildSD_AutoInherited_RoundTrip`; renamed `TestBuildSD_AutoInherited` → `TestBuildSD_AutoInherited_PerACEFlagNotEnough` with inverted assertion (regression guard for the deleted fallback). Added 10-case 4-bit matrix `TestParseSD_AutoInheritedCanonicalization`.

Refs #505, #514, #499.

## Expected smbtorture deltas

- ✅ `smb2.acls.INHERITFLAGS` should flip FAIL → PASS (canonicalization matches test expectation).
- ❌ `smb2.acls_non_canonical.flags` should flip PASS → FAIL (test asserts Samba-specific `acl flag inherited canonicalization = no` share-extension behavior). Tracked under **#514** for per-share toggle work. KNOWN_FAILURES walkback adds it back with that reference.

Net flip count: 0. Behavior is now Windows-spec-compliant; non-canonical preserve-verbatim mode becomes opt-in via #514.

## Test plan

- [x] `go fmt ./...` / `go vet ./...` clean
- [x] `go test ./internal/adapter/smb/v2/handlers/...` green (incl. 4 new + 3 rewritten + 10-case matrix)
- [x] `go test -race ./internal/adapter/smb/v2/handlers/...` green
- [x] `go test ./pkg/metadata/acl/...` green
- [ ] CI smbtorture: confirm INHERITFLAGS PASS + acls_non_canonical.flags FAIL; only then walkback KNOWN_FAILURES in a follow-up commit.

## Out of scope

- Per-share canonicalization toggle (`acl flag inherited canonicalization = no`) — #514.
- `acls.DENY1` / `acls.MXAC-NOT-GRANTED` eval-layer gaps — #512.