### PR TITLE
fix(smb): DACL inheritance correctness — bugs A/C/G (#521)

### DIFF
--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -53,13 +53,18 @@ func substituteCreator(who string, creator Creator) string {
 // For files:
 //   - Include ACEs with FILE_INHERIT flag
 //   - Clear ALL inheritance flags (files don't propagate further)
-//   - Add INHERITED_ACE flag
 //
 // For directories:
 //   - Include ACEs with DIRECTORY_INHERIT flag
-//   - Add INHERITED_ACE flag
 //   - If NO_PROPAGATE_INHERIT: clear all inheritance flags (stop propagation)
 //   - If INHERIT_ONLY on parent: clear INHERIT_ONLY on child (ACE now applies)
+//
+// The ACE4_INHERITED_ACE bit on the resulting child ACE is conditional, per
+// MS-DTYP §2.5.3.4.2 and Samba libcli/security/create_descriptor.c
+// (calculate_inherited_from_parent): the bit is set iff the parent SD has
+// SE_DACL_AUTO_INHERITED (i.e. parentACL.AutoInherited) OR the source
+// parent ACE itself already carries ACE4_INHERITED_ACE (meaning it was
+// inherited from upstream — that fact survives propagation to the child).
 //
 // In both cases, any ACE whose Who is SpecialCreatorOwner or
 // SpecialCreatorGroup is rewritten in place with the creator's frozen
@@ -92,7 +97,14 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		}
 
 		newACE := *ace
-		newACE.Flag |= ACE4_INHERITED_ACE
+		// MS-DTYP §2.5.3.4.2 / Samba calculate_inherited_from_parent: the
+		// INHERITED_ACE bit on the child is conditional. It is set when
+		// the parent ACE already carries it (already-inherited fact
+		// survives propagation) OR the parent SD has AUTO_INHERITED set
+		// (parent is configured to mark its inherited children). Strip
+		// any pre-existing bit first so we apply the rule cleanly.
+		preservedInheritedACE := newACE.Flag & ACE4_INHERITED_ACE
+		newACE.Flag &^= ACE4_INHERITED_ACE
 
 		if !isDirectory {
 			// Files don't propagate further: clear all inheritance flags.
@@ -103,6 +115,10 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		} else if ace.Flag&ACE4_INHERIT_ONLY_ACE != 0 {
 			// INHERIT_ONLY on parent: clear so ACE applies on this child.
 			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
+		}
+
+		if preservedInheritedACE != 0 || parentACL.AutoInherited {
+			newACE.Flag |= ACE4_INHERITED_ACE
 		}
 
 		// MS-DTYP §2.5.3.4: substitute CREATOR_OWNER / CREATOR_GROUP

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -51,20 +51,26 @@ func substituteCreator(who string, creator Creator) string {
 // MS-DTYP §2.5.3.4 (CREATOR_OWNER / CREATOR_GROUP substitution).
 //
 // For files:
-//   - Include ACEs with FILE_INHERIT flag
+//   - Include ACEs with FILE_INHERIT (OI) flag
 //   - Clear ALL inheritance flags (files don't propagate further)
 //
-// For directories:
-//   - Include ACEs with DIRECTORY_INHERIT flag
-//   - If NO_PROPAGATE_INHERIT: clear all inheritance flags (stop propagation)
-//   - If INHERIT_ONLY on parent: clear INHERIT_ONLY on child (ACE now applies)
+// For directories (matches Samba libcli/security/create_descriptor.c
+// calculate_inherited_from_parent and MS-DTYP §2.5.3.4.1):
+//   - Drop ACEs with no OI and no CI (not inheritable to anything).
+//   - With NO_PROPAGATE_INHERIT: clear all inheritance flags so the ACE
+//     applies at this dir but does not propagate further; if the parent
+//     ACE has OI only (no CI), the ACE does not apply at the directory
+//     itself and is dropped entirely.
+//   - With CI: ACE applies at the dir; clear INHERIT_ONLY.
+//   - With OI only: ACE does NOT apply at this dir but must propagate to
+//     file grandchildren — emit on the child as OI|INHERIT_ONLY.
 //
 // The ACE4_INHERITED_ACE bit on the resulting child ACE is conditional, per
-// MS-DTYP §2.5.3.4.2 and Samba libcli/security/create_descriptor.c
-// (calculate_inherited_from_parent): the bit is set iff the parent SD has
-// SE_DACL_AUTO_INHERITED (i.e. parentACL.AutoInherited) OR the source
-// parent ACE itself already carries ACE4_INHERITED_ACE (meaning it was
-// inherited from upstream — that fact survives propagation to the child).
+// MS-DTYP §2.5.3.4.2 and Samba calculate_inherited_from_parent: the bit
+// is set iff the parent SD has SE_DACL_AUTO_INHERITED (i.e.
+// parentACL.AutoInherited) OR the source parent ACE itself already
+// carries ACE4_INHERITED_ACE (meaning it was inherited from upstream —
+// that fact survives propagation to the child).
 //
 // In both cases, any ACE whose Who is SpecialCreatorOwner or
 // SpecialCreatorGroup is rewritten in place with the creator's frozen
@@ -82,17 +88,21 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		return nil
 	}
 
-	inheritFlag := uint32(ACE4_FILE_INHERIT_ACE)
-	if isDirectory {
-		inheritFlag = ACE4_DIRECTORY_INHERIT_ACE
-	}
-
 	var inherited []ACE
 
 	for i := range parentACL.ACEs {
 		ace := &parentACL.ACEs[i]
 
-		if ace.Flag&inheritFlag == 0 {
+		hasOI := ace.Flag&ACE4_FILE_INHERIT_ACE != 0
+		hasCI := ace.Flag&ACE4_DIRECTORY_INHERIT_ACE != 0
+		hasNP := ace.Flag&ACE4_NO_PROPAGATE_INHERIT_ACE != 0
+
+		if !isDirectory && !hasOI {
+			// Files only inherit OI-bearing ACEs.
+			continue
+		}
+		if isDirectory && !hasOI && !hasCI {
+			// Dir children only inherit OI- or CI-bearing ACEs.
 			continue
 		}
 
@@ -107,14 +117,30 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		newACE.Flag &^= ACE4_INHERITED_ACE
 
 		if !isDirectory {
-			// Files don't propagate further: clear all inheritance flags.
+			// Files are leaves: clear ALL inheritance flags.
 			newACE.Flag &^= inheritanceMask
-		} else if ace.Flag&ACE4_NO_PROPAGATE_INHERIT_ACE != 0 {
-			// NO_PROPAGATE: stop propagation to grandchildren.
+		} else if hasNP {
+			// NO_PROPAGATE: stop propagation to grandchildren. ACE
+			// applies at this dir only when it carries CI; an
+			// OI-only-with-NP parent ACE has no effect on the dir
+			// child (per Samba calculate_inherited_from_parent /
+			// smbtorture test_inheritance row 5).
+			if !hasCI {
+				continue
+			}
 			newACE.Flag &^= inheritanceMask
-		} else if ace.Flag&ACE4_INHERIT_ONLY_ACE != 0 {
-			// INHERIT_ONLY on parent: clear so ACE applies on this child.
+		} else if hasCI {
+			// CI (with or without OI) applies at this dir; clear
+			// INHERIT_ONLY so the ACE is effective here. OI is
+			// preserved when present so file grandchildren still
+			// inherit.
 			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
+		} else {
+			// OI only (no CI, no NP): ACE does not apply at this dir
+			// but must propagate to file grandchildren. Emit with
+			// OI|INHERIT_ONLY; clear NP/CI noise.
+			newACE.Flag &^= inheritanceMask
+			newACE.Flag |= ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
 		}
 
 		if preservedInheritedACE != 0 || parentACL.AutoInherited {

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -1,6 +1,9 @@
 package acl
 
-import "fmt"
+import (
+	"fmt"
+	"log/slog"
+)
 
 // inheritanceMask covers all inheritance-related ACE flags.
 const inheritanceMask = ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE |
@@ -76,6 +79,19 @@ func substituteCreator(who string, creator Creator) string {
 // SpecialCreatorGroup is rewritten in place with the creator's frozen
 // identity (sid:<SID> when known, otherwise "<uid|gid>@localdomain").
 //
+// CREATOR dual-emission on directory children (mirrors Samba
+// libcli/security/create_descriptor.c::calculate_inherited_from_parent):
+// when the parent ACE has CONTAINER_INHERIT (CI) and a CREATOR_OWNER /
+// CREATOR_GROUP principal, two child ACEs are emitted to the directory:
+//  1. The resolved ACE (principal substituted to the new directory's
+//     owner/group, inheritance flags propagated per the rules above).
+//  2. A preserved CREATOR ACE with CI|INHERIT_ONLY (plus OI if the parent
+//     had it) so grandchild directories still substitute against their
+//     own owner/group rather than receiving an already-resolved ACE.
+//
+// File children are leaves: no dual-emission — the resolved ACE is the
+// only one emitted (any inheritance to deeper levels is moot).
+//
 // Per MS-DTYP §2.5.3.4.2, when the parent SD has SE_DACL_AUTO_INHERITED set,
 // the computed child SD also has SE_DACL_AUTO_INHERITED set (mirrors Samba
 // source3/smbd/posix_acls.c::set_inherited_sd). SE_DACL_PROTECTED is a
@@ -149,9 +165,46 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 
 		// MS-DTYP §2.5.3.4: substitute CREATOR_OWNER / CREATOR_GROUP
 		// placeholders with the creator's frozen identity.
-		newACE.Who = substituteCreator(newACE.Who, creator)
+		originalWho := ace.Who
+		isCreator := originalWho == SpecialCreatorOwner || originalWho == SpecialCreatorGroup
+		newACE.Who = substituteCreator(originalWho, creator)
 
 		inherited = append(inherited, newACE)
+
+		// Dual-emit on directory children when parent ACE carried a
+		// CREATOR principal AND CONTAINER_INHERIT. Mirrors Samba
+		// calculate_inherited_from_parent: keep the original CREATOR ACE
+		// with CI|INHERIT_ONLY (preserving OI when present) so grandchild
+		// directories continue to substitute against THEIR own creator
+		// instead of inheriting the already-resolved owner/group.
+		//
+		// Skipped on:
+		//   - files (leaves)
+		//   - parent ACE without CI (no need to reach grandchild dirs)
+		//   - NO_PROPAGATE (Samba stops propagation in that branch)
+		if isDirectory && isCreator && hasCI && !hasNP {
+			if len(inherited) >= MaxACECount {
+				slog.Debug("acl.ComputeInheritedACL: skipping preserved CREATOR ACE — MaxACECount reached",
+					"max", MaxACECount, "principal", originalWho)
+				continue
+			}
+			preserved := *ace
+			preserved.Who = originalWho
+			preserved.Flag &^= inheritanceMask
+			preserved.Flag |= ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
+			if hasOI {
+				preserved.Flag |= ACE4_FILE_INHERIT_ACE
+			}
+			// INHERITED_ACE conditional: same rule as the resolved ACE
+			// (Bug A — PR 2). The preserved ACE was produced by the
+			// inheritance computation; it must carry the bit whenever
+			// the resolved sibling does.
+			preserved.Flag &^= ACE4_INHERITED_ACE
+			if (ace.Flag&ACE4_INHERITED_ACE) != 0 || parentACL.AutoInherited {
+				preserved.Flag |= ACE4_INHERITED_ACE
+			}
+			inherited = append(inherited, preserved)
+		}
 	}
 
 	if len(inherited) == 0 {

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -122,6 +122,18 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 			continue
 		}
 
+		// Cap enforcement (FIFO truncation, mirrors Samba behavior under
+		// pressure): never produce a child ACL exceeding MaxACECount.
+		// Check BEFORE appending the resolved ACE because the prior
+		// iteration may have already dual-emitted, leaving the result at
+		// capacity. Earlier parent ACEs take precedence over later ones.
+		if len(inherited) >= MaxACECount {
+			slog.Debug("acl.ComputeInheritedACL: MaxACECount reached — truncating remaining parent ACEs",
+				"max", MaxACECount, "produced", len(inherited),
+				"remaining_parent_aces", len(parentACL.ACEs)-i)
+			break
+		}
+
 		newACE := *ace
 		// MS-DTYP §2.5.3.4.2 / Samba calculate_inherited_from_parent: the
 		// INHERITED_ACE bit on the child is conditional. It is set when
@@ -183,9 +195,17 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		//   - parent ACE without CI (no need to reach grandchild dirs)
 		//   - NO_PROPAGATE (Samba stops propagation in that branch)
 		if isDirectory && isCreator && hasCI && !hasNP {
+			// Budget check: dual-emit needs one extra slot. The resolved
+			// ACE was already appended above; we now want to also add the
+			// preserved CREATOR. If there is no room left, drop the
+			// preserved one (resolved already inherits — losing the
+			// preserved version only weakens grandchild substitution, not
+			// the immediate child's effective permissions). FIFO
+			// truncation: prefer earlier parent ACEs over later ones.
 			if len(inherited) >= MaxACECount {
-				slog.Debug("acl.ComputeInheritedACL: skipping preserved CREATOR ACE — MaxACECount reached",
-					"max", MaxACECount, "principal", originalWho)
+				slog.Debug("acl.ComputeInheritedACL: dropping preserved CREATOR ACE — MaxACECount reached",
+					"max", MaxACECount, "produced", len(inherited),
+					"principal", originalWho)
 				continue
 			}
 			preserved := *ace

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -90,9 +90,11 @@ func substituteCreator(who string, creator Creator) string {
 //     This is the OI-only-on-dir-child case (smbtorture row 1).
 //
 // The ACE4_INHERITED_ACE bit on every emitted child ACE is conditional,
-// per MS-DTYP §2.5.3.4.2 and Samba calculate_inherited_from_parent:
-// set iff parentACL.AutoInherited OR the source parent ACE already
-// carried ACE4_INHERITED_ACE.
+// per MS-DTYP §2.5.3.4.2 and Samba calculate_inherited_from_parent: set
+// iff parentACL.AutoInherited (after canonicalization). The parent ACE's
+// own pre-existing INHERITED_ACE bit is NOT propagated independently —
+// that was over-broad and broke smbtorture INHERITFLAGS rows where
+// parent.AutoInherited is false but the parent ACE pre-carried the bit.
 //
 // NO_PROPAGATE on the parent strips OI/CI/NP from any emitted ACE so
 // further inheritance stops at this child.
@@ -138,12 +140,18 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 			break
 		}
 
-		// MS-DTYP §2.5.3.4.2 / Samba calculate_inherited_from_parent: the
-		// INHERITED_ACE bit on the child is conditional — set when the
-		// parent ACE already carries it OR the parent SD has
-		// AUTO_INHERITED set.
+		// MS-DTYP §2.5.3.4.2 / Samba calculate_inherited_from_parent
+		// (libcli/security/create_descriptor.c): the INHERITED_ACE bit on
+		// the child is set ONLY when the parent SD has AUTO_INHERITED set
+		// (after canonicalization). Samba's torture tflags table makes
+		// this explicit — the child gets INHERITED_ACE iff both
+		// AUTO_INHERITED and AUTO_INHERIT_REQ were set on the parent SD,
+		// which canonicalize down to parent.AutoInherited. The parent
+		// ACE's pre-existing INHERITED_ACE bit is NOT propagated
+		// independently; that was over-broad and caused smbtorture
+		// INHERITFLAGS rows i ∈ {8,9,10,12,13,14} to fail.
 		inheritedBit := uint32(0)
-		if (ace.Flag&ACE4_INHERITED_ACE) != 0 || parentACL.AutoInherited {
+		if parentACL.AutoInherited {
 			inheritedBit = ACE4_INHERITED_ACE
 		}
 
@@ -196,14 +204,31 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 		}
 
 		if applies && !expandACE {
-			// Case 2: single ACE with original principal, OI/CI preserved,
-			// INHERIT_ONLY cleared, NP clears propagation.
+			// Case 2: single ACE with original principal.
+			//
+			// Samba `calculate_inherited_from_parent`:
+			//   - NO_PROPAGATE on parent ACE → child gets ALL inheritance
+			//     bits (OI/CI/NP/IO) stripped. NP says "do not propagate
+			//     further", which is enforced by removing every
+			//     inheritance flag from the child ACE. smbtorture
+			//     INHERITANCE rows 6/7/14/15 (NP+CI shapes on dir child)
+			//     require flag=0 (only INHERITED_ACE remains via
+			//     inheritedBit below).
+			//   - File child → no propagation possible; strip all
+			//     inheritance bits.
+			//   - Otherwise (dir child, NP unset) → preserve OI/CI/NP on
+			//     parent ACE so grandchildren still inherit; clear
+			//     INHERIT_ONLY because the ACE is effective at this dir.
 			newACE := *ace
-			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
-			newACE.Flag &^= ACE4_INHERITED_ACE
-			if !isDirectory || hasNP {
+			switch {
+			case hasNP:
 				newACE.Flag &^= inheritanceMask
+			case !isDirectory:
+				newACE.Flag &^= inheritanceMask
+			default:
+				newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
 			}
+			newACE.Flag &^= ACE4_INHERITED_ACE
 			newACE.Flag |= inheritedBit
 			inherited = append(inherited, newACE)
 			continue

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -172,6 +172,16 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 			if !isDirectory {
 				continue
 			}
+			// NO_PROPAGATE on parent ACE stops further propagation entirely.
+			// Samba `calculate_inherited_from_parent` does not emit a
+			// preserved CREATOR ACE when NP is set — there is nothing to
+			// propagate to. Without this skip we would emit a CREATOR_OWNER
+			// ACE with all inheritance bits cleared, which Windows clients
+			// see as garbage. smbtorture INHERITANCE rows 6/7/14/15
+			// (NP|CI on CREATOR_OWNER) require single-ACE output.
+			if hasNP {
+				continue
+			}
 			// Cap check before preserved emission.
 			if len(inherited) >= MaxACECount {
 				slog.Debug("acl.ComputeInheritedACL: dropping preserved CREATOR ACE — MaxACECount reached",
@@ -190,13 +200,6 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 				preserved.Flag |= ACE4_DIRECTORY_INHERIT_ACE
 			}
 			preserved.Flag |= ACE4_INHERIT_ONLY_ACE
-			// NO_PROPAGATE: stop further propagation by clearing OI/CI/NP.
-			// (NB: hasNP && hasCI is the only NP path that reaches here for
-			// dir children; resolved-only emission below handles
-			// NP|OI-only and other shapes.)
-			if hasNP {
-				preserved.Flag &^= inheritanceMask
-			}
 			preserved.Flag &^= ACE4_INHERITED_ACE
 			preserved.Flag |= inheritedBit
 			inherited = append(inherited, preserved)

--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -53,44 +53,49 @@ func substituteCreator(who string, creator Creator) string {
 // directory based on its parent's ACL per RFC 7530 Section 6.4.3 and
 // MS-DTYP §2.5.3.4 (CREATOR_OWNER / CREATOR_GROUP substitution).
 //
-// For files:
-//   - Include ACEs with FILE_INHERIT (OI) flag
-//   - Clear ALL inheritance flags (files don't propagate further)
+// The implementation mirrors Samba libcli/security/create_descriptor.c
+// (calculate_inherited_from_parent + desc_expand_generic). For each parent
+// ACE, we compute two booleans:
 //
-// For directories (matches Samba libcli/security/create_descriptor.c
-// calculate_inherited_from_parent and MS-DTYP §2.5.3.4.1):
-//   - Drop ACEs with no OI and no CI (not inheritable to anything).
-//   - With NO_PROPAGATE_INHERIT: clear all inheritance flags so the ACE
-//     applies at this dir but does not propagate further; if the parent
-//     ACE has OI only (no CI), the ACE does not apply at the directory
-//     itself and is dropped entirely.
-//   - With CI: ACE applies at the dir; clear INHERIT_ONLY.
-//   - With OI only: ACE does NOT apply at this dir but must propagate to
-//     file grandchildren — emit on the child as OI|INHERIT_ONLY.
+//	applies     := (isDir && hasCI) || (!isDir && hasOI)
+//	expand_ace  := principal is CREATOR_OWNER/CREATOR_GROUP (today we do
+//	               not expand generic-mask bits; that is a separate fix)
 //
-// The ACE4_INHERITED_ACE bit on the resulting child ACE is conditional, per
-// MS-DTYP §2.5.3.4.2 and Samba calculate_inherited_from_parent: the bit
-// is set iff the parent SD has SE_DACL_AUTO_INHERITED (i.e.
-// parentACL.AutoInherited) OR the source parent ACE itself already
-// carries ACE4_INHERITED_ACE (meaning it was inherited from upstream —
-// that fact survives propagation to the child).
+// Cases:
 //
-// In both cases, any ACE whose Who is SpecialCreatorOwner or
-// SpecialCreatorGroup is rewritten in place with the creator's frozen
-// identity (sid:<SID> when known, otherwise "<uid|gid>@localdomain").
+//  1. applies && expand_ace
+//     Emit two ACEs (only on dir children — files are leaves):
+//     a) Resolved sibling: principal substituted, ALL inheritance flags
+//     cleared, then INHERITED_ACE added per the conditional rule.
+//     The resolved sibling applies at THIS object only — it does not
+//     propagate further.
+//     b) Preserved CREATOR: principal kept (CREATOR_OWNER /
+//     CREATOR_GROUP stays), flags = parent's OI|CI bits + INHERIT_ONLY,
+//     then INHERITED_ACE per the conditional rule. This preserves the
+//     placeholder for substitution at grandchild create time.
+//     On file children: only the resolved sibling is emitted (no need
+//     to preserve for grandchildren).
 //
-// CREATOR dual-emission on directory children (mirrors Samba
-// libcli/security/create_descriptor.c::calculate_inherited_from_parent):
-// when the parent ACE has CONTAINER_INHERIT (CI) and a CREATOR_OWNER /
-// CREATOR_GROUP principal, two child ACEs are emitted to the directory:
-//  1. The resolved ACE (principal substituted to the new directory's
-//     owner/group, inheritance flags propagated per the rules above).
-//  2. A preserved CREATOR ACE with CI|INHERIT_ONLY (plus OI if the parent
-//     had it) so grandchild directories still substitute against their
-//     own owner/group rather than receiving an already-resolved ACE.
+//  2. applies && !expand_ace
+//     Emit a single ACE with the original principal. For files, all
+//     inheritance flags are cleared. For directories, OI/CI bits are
+//     preserved (so grandchildren still inherit), and INHERIT_ONLY is
+//     cleared so the ACE is effective at this dir. NO_PROPAGATE clears
+//     OI/CI to stop further propagation.
 //
-// File children are leaves: no dual-emission — the resolved ACE is the
-// only one emitted (any inheritance to deeper levels is moot).
+//  3. !applies, but parent has bits that propagate to grandchildren of
+//     THIS object's type (e.g. parent OI on a dir child): emit a single
+//     "preserved" ACE — original principal (CREATOR stays CREATOR), parent's
+//     OI/CI bits preserved, INHERIT_ONLY added so it does not apply here.
+//     This is the OI-only-on-dir-child case (smbtorture row 1).
+//
+// The ACE4_INHERITED_ACE bit on every emitted child ACE is conditional,
+// per MS-DTYP §2.5.3.4.2 and Samba calculate_inherited_from_parent:
+// set iff parentACL.AutoInherited OR the source parent ACE already
+// carried ACE4_INHERITED_ACE.
+//
+// NO_PROPAGATE on the parent strips OI/CI/NP from any emitted ACE so
+// further inheritance stops at this child.
 //
 // Per MS-DTYP §2.5.3.4.2, when the parent SD has SE_DACL_AUTO_INHERITED set,
 // the computed child SD also has SE_DACL_AUTO_INHERITED set (mirrors Samba
@@ -124,9 +129,8 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 
 		// Cap enforcement (FIFO truncation, mirrors Samba behavior under
 		// pressure): never produce a child ACL exceeding MaxACECount.
-		// Check BEFORE appending the resolved ACE because the prior
-		// iteration may have already dual-emitted, leaving the result at
-		// capacity. Earlier parent ACEs take precedence over later ones.
+		// Check BEFORE appending so prior dual-emission is honored.
+		// Earlier parent ACEs take precedence over later ones.
 		if len(inherited) >= MaxACECount {
 			slog.Debug("acl.ComputeInheritedACL: MaxACECount reached — truncating remaining parent ACEs",
 				"max", MaxACECount, "produced", len(inherited),
@@ -134,97 +138,96 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 			break
 		}
 
-		newACE := *ace
 		// MS-DTYP §2.5.3.4.2 / Samba calculate_inherited_from_parent: the
-		// INHERITED_ACE bit on the child is conditional. It is set when
-		// the parent ACE already carries it (already-inherited fact
-		// survives propagation) OR the parent SD has AUTO_INHERITED set
-		// (parent is configured to mark its inherited children). Strip
-		// any pre-existing bit first so we apply the rule cleanly.
-		preservedInheritedACE := newACE.Flag & ACE4_INHERITED_ACE
-		newACE.Flag &^= ACE4_INHERITED_ACE
+		// INHERITED_ACE bit on the child is conditional — set when the
+		// parent ACE already carries it OR the parent SD has
+		// AUTO_INHERITED set.
+		inheritedBit := uint32(0)
+		if (ace.Flag&ACE4_INHERITED_ACE) != 0 || parentACL.AutoInherited {
+			inheritedBit = ACE4_INHERITED_ACE
+		}
 
-		if !isDirectory {
-			// Files are leaves: clear ALL inheritance flags.
-			newACE.Flag &^= inheritanceMask
-		} else if hasNP {
-			// NO_PROPAGATE: stop propagation to grandchildren. ACE
-			// applies at this dir only when it carries CI; an
-			// OI-only-with-NP parent ACE has no effect on the dir
-			// child (per Samba calculate_inherited_from_parent /
-			// smbtorture test_inheritance row 5).
-			if !hasCI {
+		applies := (isDirectory && hasCI) || (!isDirectory && hasOI)
+		isCreator := ace.Who == SpecialCreatorOwner || ace.Who == SpecialCreatorGroup
+		expandACE := isCreator
+
+		if applies && expandACE {
+			// Case 1: emit resolved sibling, plus preserved CREATOR on dir
+			// children (file children are leaves; no preserved emission).
+			resolved := *ace
+			resolved.Who = substituteCreator(ace.Who, creator)
+			// Resolved sibling applies AT THIS object only; clear all
+			// inheritance flags then add INHERITED_ACE per the rule.
+			resolved.Flag = inheritedBit
+			inherited = append(inherited, resolved)
+
+			if !isDirectory {
 				continue
 			}
-			newACE.Flag &^= inheritanceMask
-		} else if hasCI {
-			// CI (with or without OI) applies at this dir; clear
-			// INHERIT_ONLY so the ACE is effective here. OI is
-			// preserved when present so file grandchildren still
-			// inherit.
-			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
-		} else {
-			// OI only (no CI, no NP): ACE does not apply at this dir
-			// but must propagate to file grandchildren. Emit with
-			// OI|INHERIT_ONLY; clear NP/CI noise.
-			newACE.Flag &^= inheritanceMask
-			newACE.Flag |= ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
-		}
-
-		if preservedInheritedACE != 0 || parentACL.AutoInherited {
-			newACE.Flag |= ACE4_INHERITED_ACE
-		}
-
-		// MS-DTYP §2.5.3.4: substitute CREATOR_OWNER / CREATOR_GROUP
-		// placeholders with the creator's frozen identity.
-		originalWho := ace.Who
-		isCreator := originalWho == SpecialCreatorOwner || originalWho == SpecialCreatorGroup
-		newACE.Who = substituteCreator(originalWho, creator)
-
-		inherited = append(inherited, newACE)
-
-		// Dual-emit on directory children when parent ACE carried a
-		// CREATOR principal AND CONTAINER_INHERIT. Mirrors Samba
-		// calculate_inherited_from_parent: keep the original CREATOR ACE
-		// with CI|INHERIT_ONLY (preserving OI when present) so grandchild
-		// directories continue to substitute against THEIR own creator
-		// instead of inheriting the already-resolved owner/group.
-		//
-		// Skipped on:
-		//   - files (leaves)
-		//   - parent ACE without CI (no need to reach grandchild dirs)
-		//   - NO_PROPAGATE (Samba stops propagation in that branch)
-		if isDirectory && isCreator && hasCI && !hasNP {
-			// Budget check: dual-emit needs one extra slot. The resolved
-			// ACE was already appended above; we now want to also add the
-			// preserved CREATOR. If there is no room left, drop the
-			// preserved one (resolved already inherits — losing the
-			// preserved version only weakens grandchild substitution, not
-			// the immediate child's effective permissions). FIFO
-			// truncation: prefer earlier parent ACEs over later ones.
+			// Cap check before preserved emission.
 			if len(inherited) >= MaxACECount {
 				slog.Debug("acl.ComputeInheritedACL: dropping preserved CREATOR ACE — MaxACECount reached",
 					"max", MaxACECount, "produced", len(inherited),
-					"principal", originalWho)
+					"principal", ace.Who)
 				continue
 			}
 			preserved := *ace
-			preserved.Who = originalWho
+			// Principal stays CREATOR_OWNER / CREATOR_GROUP — substitution
+			// happens at grandchild create time.
 			preserved.Flag &^= inheritanceMask
-			preserved.Flag |= ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
 			if hasOI {
 				preserved.Flag |= ACE4_FILE_INHERIT_ACE
 			}
-			// INHERITED_ACE conditional: same rule as the resolved ACE
-			// (Bug A — PR 2). The preserved ACE was produced by the
-			// inheritance computation; it must carry the bit whenever
-			// the resolved sibling does.
-			preserved.Flag &^= ACE4_INHERITED_ACE
-			if (ace.Flag&ACE4_INHERITED_ACE) != 0 || parentACL.AutoInherited {
-				preserved.Flag |= ACE4_INHERITED_ACE
+			if hasCI {
+				preserved.Flag |= ACE4_DIRECTORY_INHERIT_ACE
 			}
+			preserved.Flag |= ACE4_INHERIT_ONLY_ACE
+			// NO_PROPAGATE: stop further propagation by clearing OI/CI/NP.
+			// (NB: hasNP && hasCI is the only NP path that reaches here for
+			// dir children; resolved-only emission below handles
+			// NP|OI-only and other shapes.)
+			if hasNP {
+				preserved.Flag &^= inheritanceMask
+			}
+			preserved.Flag &^= ACE4_INHERITED_ACE
+			preserved.Flag |= inheritedBit
 			inherited = append(inherited, preserved)
+			continue
 		}
+
+		if applies && !expandACE {
+			// Case 2: single ACE with original principal, OI/CI preserved,
+			// INHERIT_ONLY cleared, NP clears propagation.
+			newACE := *ace
+			newACE.Flag &^= ACE4_INHERIT_ONLY_ACE
+			newACE.Flag &^= ACE4_INHERITED_ACE
+			if !isDirectory || hasNP {
+				newACE.Flag &^= inheritanceMask
+			}
+			newACE.Flag |= inheritedBit
+			inherited = append(inherited, newACE)
+			continue
+		}
+
+		// Case 3: !applies — parent ACE does not apply at this child, but
+		// must propagate to grandchildren. Emit a preserved ACE with
+		// original principal (CREATOR_OWNER stays CREATOR_OWNER for
+		// future grandchild substitution).
+		//
+		// Only reachable when isDirectory && hasOI && !hasCI (parent OI
+		// only on dir child), since other !applies shapes were filtered
+		// out at the top of the loop. NO_PROPAGATE drops this entirely
+		// (no grandchildren to propagate to).
+		if hasNP {
+			continue
+		}
+		preserved := *ace
+		// Principal stays as-is — including CREATOR placeholders (not
+		// reached by isCreator branch above because applies==false here).
+		preserved.Flag &^= inheritanceMask
+		preserved.Flag |= ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE
+		preserved.Flag |= inheritedBit
+		inherited = append(inherited, preserved)
 	}
 
 	if len(inherited) == 0 {

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -213,19 +213,32 @@ func TestComputeInheritedACL_MixedInheritFlags(t *testing.T) {
 		t.Errorf("file ACE 1: expected GROUP@, got %s", fileResult.ACEs[1].Who)
 	}
 
-	// Directory child: should get ACE 1 (DIRECTORY_INHERIT) and ACE 2 (both).
+	// Directory child: should get all three ACEs.
+	//   ACE 0 (OI only on parent) → propagates to dir as OI|INHERIT_ONLY so
+	//     it does not apply here but reaches file grandchildren
+	//     (MS-DTYP §2.5.3.4.1 / Samba calculate_inherited_from_parent).
+	//   ACE 1 (CI only) → applies at this dir; CI preserved.
+	//   ACE 2 (OI|CI)   → applies and propagates; both bits preserved.
 	dirResult := ComputeInheritedACL(parentACL, true, Creator{})
 	if dirResult == nil {
 		t.Fatal("expected non-nil result for directory")
 	}
-	if len(dirResult.ACEs) != 2 {
-		t.Fatalf("expected 2 ACEs for directory, got %d", len(dirResult.ACEs))
+	if len(dirResult.ACEs) != 3 {
+		t.Fatalf("expected 3 ACEs for directory, got %d", len(dirResult.ACEs))
 	}
-	if dirResult.ACEs[0].Who != SpecialOwner {
-		t.Errorf("dir ACE 0: expected OWNER@, got %s", dirResult.ACEs[0].Who)
+	if dirResult.ACEs[0].Who != SpecialEveryone {
+		t.Errorf("dir ACE 0: expected EVERYONE@, got %s", dirResult.ACEs[0].Who)
 	}
-	if dirResult.ACEs[1].Who != SpecialGroup {
-		t.Errorf("dir ACE 1: expected GROUP@, got %s", dirResult.ACEs[1].Who)
+	wantACE0Flag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE)
+	if dirResult.ACEs[0].Flag != wantACE0Flag {
+		t.Errorf("dir ACE 0 (OI-only on parent): flag=0x%x, want 0x%x (OI|INHERIT_ONLY)",
+			dirResult.ACEs[0].Flag, wantACE0Flag)
+	}
+	if dirResult.ACEs[1].Who != SpecialOwner {
+		t.Errorf("dir ACE 1: expected OWNER@, got %s", dirResult.ACEs[1].Who)
+	}
+	if dirResult.ACEs[2].Who != SpecialGroup {
+		t.Errorf("dir ACE 2: expected GROUP@, got %s", dirResult.ACEs[2].Who)
 	}
 }
 
@@ -760,12 +773,10 @@ func formatMatrixName(i int, kind string) string {
 // with AutoInherited=true throughout. The child ACE is therefore always
 // expected to carry ACE4_INHERITED_ACE when it exists.
 //
-// Currently-failing rows (per #521 research) are dir-child rows 1 and 9:
-// parent OI-only (and IO|OI) must produce a dir-child ACE with OI|IO so
-// the dir continues to propagate inheritance to file grandchildren even
-// though the dir itself does not gain the right. DittoFS today filters
-// dir-child inheritance strictly on DI, dropping OI-only parents. Those
-// two subtests are skipped under #521 PR 3 (Bug C).
+// Dir-child rows 1 and 9 (parent OI-only / IO|OI) produce a dir-child
+// ACE with OI|INHERIT_ONLY so the dir does not gain the right itself but
+// continues to propagate to file grandchildren. This was Bug C, fixed in
+// #521 PR 3.
 func TestComputeInheritedACL_InheritanceACEFlagMatrix(t *testing.T) {
 	const (
 		OI = ACE4_FILE_INHERIT_ACE
@@ -793,7 +804,7 @@ func TestComputeInheritedACL_InheritanceACEFlagMatrix(t *testing.T) {
 
 	rows := []row{
 		/* 0  none           */ {0, expected{}, expected{}, ""},
-		/* 1  OI             */ {OI, expected{true, I}, expected{true, OI | IO | I}, "tracked under #521 PR 3 — Bug C OI propagation to dir child"},
+		/* 1  OI             */ {OI, expected{true, I}, expected{true, OI | IO | I}, ""},
 		/* 2  CI             */ {CI, expected{}, expected{true, CI | I}, ""},
 		/* 3  OI|CI          */ {OI | CI, expected{true, I}, expected{true, OI | CI | I}, ""},
 		/* 4  NP             */ {NP, expected{}, expected{}, ""},
@@ -801,7 +812,7 @@ func TestComputeInheritedACL_InheritanceACEFlagMatrix(t *testing.T) {
 		/* 6  NP|CI          */ {NP | CI, expected{}, expected{true, I}, ""},
 		/* 7  NP|OI|CI       */ {NP | OI | CI, expected{true, I}, expected{true, I}, ""},
 		/* 8  IO             */ {IO, expected{}, expected{}, ""},
-		/* 9  IO|OI          */ {IO | OI, expected{true, I}, expected{true, OI | IO | I}, "tracked under #521 PR 3 — Bug C OI propagation to dir child"},
+		/* 9  IO|OI          */ {IO | OI, expected{true, I}, expected{true, OI | IO | I}, ""},
 		/* 10 IO|CI          */ {IO | CI, expected{}, expected{true, CI | I}, ""},
 		/* 11 IO|OI|CI       */ {IO | OI | CI, expected{true, I}, expected{true, OI | CI | I}, ""},
 		/* 12 IO|NP          */ {IO | NP, expected{}, expected{}, ""},

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -864,6 +864,176 @@ func assertInheritedFlags(t *testing.T, row int, kind string, result *ACL, want 
 	}
 }
 
+// TestComputeInheritedACL_CreatorOwnerCI_DualEmit_Dir asserts that a parent
+// ACE with CREATOR_OWNER + OI|CI emits TWO ACEs onto a directory child:
+//  1. The resolved owner ACE that applies at the new dir (inheritance
+//     flags adjusted per PR 3 — OI propagates to file grandchildren as
+//     OI|INHERIT_ONLY-equivalent here; the resolved ACE still carries
+//     OI|CI so grandchildren of either kind inherit from it as well).
+//  2. The preserved CREATOR_OWNER ACE with CI|OI|INHERIT_ONLY so
+//     grandchild directories continue to substitute against THEIR own
+//     creator.
+//
+// Mirrors Samba calculate_inherited_from_parent (libcli/security/
+// create_descriptor.c). This is Bug G (#521 PR 4).
+func TestComputeInheritedACL_CreatorOwnerCI_DualEmit_Dir(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialCreatorOwner,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{UID: 1001})
+	if result == nil {
+		t.Fatal("expected non-nil result for dir child")
+	}
+	if len(result.ACEs) != 2 {
+		t.Fatalf("expected 2 ACEs (resolved + preserved CREATOR), got %d", len(result.ACEs))
+	}
+
+	// ACE 0: resolved owner — CI applies here so INHERIT_ONLY cleared.
+	// OI preserved on parent ACE => preserved on resolved child too.
+	resolved := result.ACEs[0]
+	if resolved.Who != "1001@localdomain" {
+		t.Errorf("resolved ACE: expected Who=1001@localdomain, got %q", resolved.Who)
+	}
+	wantResolvedFlag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERITED_ACE)
+	if resolved.Flag != wantResolvedFlag {
+		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (OI|CI|INHERITED)", resolved.Flag, wantResolvedFlag)
+	}
+
+	// ACE 1: preserved CREATOR_OWNER — CI|OI|IO + INHERITED.
+	preserved := result.ACEs[1]
+	if preserved.Who != SpecialCreatorOwner {
+		t.Errorf("preserved ACE: expected Who=%q, got %q", SpecialCreatorOwner, preserved.Who)
+	}
+	wantPreservedFlag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE | ACE4_INHERITED_ACE)
+	if preserved.Flag != wantPreservedFlag {
+		t.Errorf("preserved ACE: flag=0x%x, want 0x%x (OI|CI|IO|INHERITED)", preserved.Flag, wantPreservedFlag)
+	}
+	if preserved.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE {
+		t.Errorf("preserved ACE: type=%d, want ALLOW", preserved.Type)
+	}
+	if preserved.AccessMask != ACE4_WRITE_DATA {
+		t.Errorf("preserved ACE: mask=0x%x, want 0x%x", preserved.AccessMask, ACE4_WRITE_DATA)
+	}
+}
+
+// TestComputeInheritedACL_CreatorGroupCI_DualEmit_Dir is the CREATOR_GROUP
+// counterpart of the test above. CI-only on parent (no OI) — preserved
+// ACE should not include OI.
+func TestComputeInheritedACL_CreatorGroupCI_DualEmit_Dir(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialCreatorGroup,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{UID: 1001, GID: 2002})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 2 {
+		t.Fatalf("expected 2 ACEs, got %d", len(result.ACEs))
+	}
+
+	resolved := result.ACEs[0]
+	if resolved.Who != "2002@localdomain" {
+		t.Errorf("resolved ACE: expected Who=2002@localdomain, got %q", resolved.Who)
+	}
+	// CI applies at this dir; INHERIT_ONLY cleared; OI absent on parent.
+	wantResolvedFlag := uint32(ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERITED_ACE)
+	if resolved.Flag != wantResolvedFlag {
+		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (CI|INHERITED)", resolved.Flag, wantResolvedFlag)
+	}
+
+	preserved := result.ACEs[1]
+	if preserved.Who != SpecialCreatorGroup {
+		t.Errorf("preserved ACE: expected Who=%q, got %q", SpecialCreatorGroup, preserved.Who)
+	}
+	// No OI on parent => no OI on preserved ACE.
+	wantPreservedFlag := uint32(ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE | ACE4_INHERITED_ACE)
+	if preserved.Flag != wantPreservedFlag {
+		t.Errorf("preserved ACE: flag=0x%x, want 0x%x (CI|IO|INHERITED)", preserved.Flag, wantPreservedFlag)
+	}
+}
+
+// TestComputeInheritedACL_CreatorOwner_FileChild_NoDualEmit verifies that
+// file children are leaves and never receive the preserved CREATOR ACE.
+func TestComputeInheritedACL_CreatorOwner_FileChild_NoDualEmit(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialCreatorOwner,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected exactly 1 ACE on file child (no dual emit), got %d", len(result.ACEs))
+	}
+	if result.ACEs[0].Who != "1001@localdomain" {
+		t.Errorf("expected resolved owner, got Who=%q", result.ACEs[0].Who)
+	}
+}
+
+// TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir verifies that
+// when the parent ACE has OI only (no CI), the dir child receives the
+// resolved ACE as OI|INHERIT_ONLY (per PR 3) but NO preserved CREATOR ACE
+// — without CI on the source, there is no need to propagate to grandchild
+// directories.
+func TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialCreatorOwner,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{UID: 1001})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected exactly 1 ACE (no dual emit without CI), got %d", len(result.ACEs))
+	}
+	ace := result.ACEs[0]
+	// Per PR 3: OI-only on parent => dir child gets OI|INHERIT_ONLY.
+	wantFlag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE | ACE4_INHERITED_ACE)
+	if ace.Flag != wantFlag {
+		t.Errorf("expected flag 0x%x (OI|IO|INHERITED), got 0x%x", wantFlag, ace.Flag)
+	}
+	// And CREATOR was still substituted.
+	if ace.Who != "1001@localdomain" {
+		t.Errorf("expected resolved owner Who=1001@localdomain, got %q", ace.Who)
+	}
+}
+
 func TestPropagateACL_Directory(t *testing.T) {
 	existingACL := &ACL{ACEs: []ACE{
 		{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_DELETE, Who: "bob@example.com"},

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -1,6 +1,9 @@
 package acl
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestComputeInheritedACL_FileInheritOnChildFile(t *testing.T) {
 	parentACL := &ACL{ACEs: []ACE{
@@ -611,6 +614,221 @@ func TestComputeInheritedACL_ParentAutoInheritedButNoInheritableACEs_ReturnsNil(
 	result := ComputeInheritedACL(parentACL, false, Creator{})
 	if result != nil {
 		t.Errorf("expected nil when no inheritable ACEs even if parent has AutoInherited, got %+v", result)
+	}
+}
+
+// buildParentACLWithFlags constructs a parent ACL with a single inheritable
+// ACE for the inheritance conformance matrices below. It mirrors the
+// smbtorture parent SD shape used by `test_inheritance_flags` and
+// `test_inheritance`: one ALLOW ACE granting WRITE_DATA to EVERYONE@ with
+// the supplied ACE inheritance flags. controlFlags carries the bool pair
+// (autoInherited, protected) for the parent SD; parentACEHasInheritedBit
+// optionally pre-sets ACE4_INHERITED_ACE on the parent ACE itself (matching
+// smbtorture's "i&8" iteration bit).
+func buildParentACLWithFlags(autoInherited, protected bool, aceFlags uint32, parentACEHasInheritedBit bool) *ACL {
+	flag := aceFlags
+	if parentACEHasInheritedBit {
+		flag |= ACE4_INHERITED_ACE
+	}
+	return &ACL{
+		AutoInherited: autoInherited,
+		Protected:     protected,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       flag,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+}
+
+// TestComputeInheritedACL_InheritanceFlagsMatrix mirrors smbtorture's
+// `test_inheritance_flags` from source4/torture/smb2/acls.c. It walks a
+// 16-case matrix over the parent SD-level control flag combinations
+// affecting inheritance: AutoInherited, AutoInheritReq (request-only, not
+// stored on the in-memory model — skipped), Protected, and whether the
+// parent ACE itself carries ACE4_INHERITED_ACE.
+//
+// Bit layout (matches smbtorture i ∈ 0..15):
+//
+//	i&1 → parent SD.AutoInherited
+//	i&2 → AutoInheritReq (request flag; not on our model — ignored)
+//	i&4 → parent SD.Protected
+//	i&8 → parent ACE has ACE4_INHERITED_ACE pre-set
+//
+// Key invariant under test (MS-DTYP §2.5.3.4.2 / Samba `set_inherited_sd`):
+// the child ACE has ACE4_INHERITED_ACE iff parent.AutoInherited OR the
+// parent ACE already had ACE4_INHERITED_ACE.
+//
+// DittoFS today unconditionally sets ACE4_INHERITED_ACE on every inherited
+// child ACE, which violates the invariant whenever (i&1)==0 AND (i&8)==0
+// — that is i ∈ {0, 2, 4, 6}. Those iterations are skipped here under
+// #521 PR 2 (Bug A: conditional INHERITED_ACE).
+func TestComputeInheritedACL_InheritanceFlagsMatrix(t *testing.T) {
+	for i := 0; i < 16; i++ {
+		i := i
+		autoInherited := (i & 1) != 0
+		protected := (i & 4) != 0
+		aceHasInheritedBit := (i & 8) != 0
+		expectChildInherited := autoInherited || aceHasInheritedBit
+
+		for _, tc := range []struct {
+			name        string
+			isDirectory bool
+		}{
+			{"file", false},
+			{"dir", true},
+		} {
+			tc := tc
+			t.Run(formatMatrixName(i, tc.name), func(t *testing.T) {
+				if !expectChildInherited {
+					t.Skip("tracked under #521 PR 2 — Bug A conditional INHERITED_ACE")
+				}
+
+				parent := buildParentACLWithFlags(
+					autoInherited,
+					protected,
+					ACE4_FILE_INHERIT_ACE|ACE4_DIRECTORY_INHERIT_ACE,
+					aceHasInheritedBit,
+				)
+
+				result := ComputeInheritedACL(parent, tc.isDirectory, Creator{})
+				if result == nil {
+					t.Fatalf("i=%d %s: expected non-nil result (parent OI|CI grants both file and dir inherit)", i, tc.name)
+				}
+				if len(result.ACEs) != 1 {
+					t.Fatalf("i=%d %s: expected 1 child ACE, got %d", i, tc.name, len(result.ACEs))
+				}
+
+				gotInherited := result.ACEs[0].IsInherited()
+				if gotInherited != expectChildInherited {
+					t.Errorf("i=%d %s: child INHERITED_ACE=%v, want %v (parent AI=%v ace.I=%v)",
+						i, tc.name, gotInherited, expectChildInherited, autoInherited, aceHasInheritedBit)
+				}
+
+				// AutoInherited propagation (already correct under P6-2,
+				// asserted here as a non-skipped sanity check).
+				if result.AutoInherited != autoInherited {
+					t.Errorf("i=%d %s: child SD.AutoInherited=%v, want %v",
+						i, tc.name, result.AutoInherited, autoInherited)
+				}
+				// Protected is per-SD; never inherited.
+				if result.Protected {
+					t.Errorf("i=%d %s: child SD.Protected must always be false, got true", i, tc.name)
+				}
+			})
+		}
+	}
+}
+
+func formatMatrixName(i int, kind string) string {
+	return fmt.Sprintf("i=%02d_%s", i, kind)
+}
+
+// TestComputeInheritedACL_InheritanceACEFlagMatrix mirrors smbtorture's
+// `test_inheritance` from source4/torture/smb2/acls.c. It walks the 16
+// combinations of inheritance-related ACE flags on a single parent ACE
+// (OI, CI, NP, IO) and asserts the resulting child ACE's flag layout
+// against the MS-DTYP §2.5.3.4 truth table (Samba reference:
+// source3/lib/util_sd.c::sec_ace_inherit).
+//
+// To isolate this matrix from the SD-control-flag bug exercised in
+// TestComputeInheritedACL_InheritanceFlagsMatrix, the parent SD is set
+// with AutoInherited=true throughout. The child ACE is therefore always
+// expected to carry ACE4_INHERITED_ACE when it exists.
+//
+// Currently-failing rows (per #521 research) are dir-child rows 1 and 9:
+// parent OI-only (and IO|OI) must produce a dir-child ACE with OI|IO so
+// the dir continues to propagate inheritance to file grandchildren even
+// though the dir itself does not gain the right. DittoFS today filters
+// dir-child inheritance strictly on DI, dropping OI-only parents. Those
+// two subtests are skipped under #521 PR 3 (Bug C).
+func TestComputeInheritedACL_InheritanceACEFlagMatrix(t *testing.T) {
+	const (
+		OI = ACE4_FILE_INHERIT_ACE
+		CI = ACE4_DIRECTORY_INHERIT_ACE
+		NP = ACE4_NO_PROPAGATE_INHERIT_ACE
+		IO = ACE4_INHERIT_ONLY_ACE
+		I  = ACE4_INHERITED_ACE
+	)
+
+	// hasACE encodes the expected child outcome:
+	//   present=false → no inherited ACE (ComputeInheritedACL returns nil)
+	//   present=true  → exactly one inherited ACE with `flags` (INHERITED_ACE
+	//                   bit included when AutoInherited propagates).
+	type expected struct {
+		present bool
+		flags   uint32
+	}
+
+	type row struct {
+		parentFlags uint32
+		file        expected
+		dir         expected
+		skipDirPR   string // non-empty → skip the dir subtest with this reason
+	}
+
+	rows := []row{
+		/* 0  none           */ {0, expected{}, expected{}, ""},
+		/* 1  OI             */ {OI, expected{true, I}, expected{true, OI | IO | I}, "tracked under #521 PR 3 — Bug C OI propagation to dir child"},
+		/* 2  CI             */ {CI, expected{}, expected{true, CI | I}, ""},
+		/* 3  OI|CI          */ {OI | CI, expected{true, I}, expected{true, OI | CI | I}, ""},
+		/* 4  NP             */ {NP, expected{}, expected{}, ""},
+		/* 5  NP|OI          */ {NP | OI, expected{true, I}, expected{}, ""},
+		/* 6  NP|CI          */ {NP | CI, expected{}, expected{true, I}, ""},
+		/* 7  NP|OI|CI       */ {NP | OI | CI, expected{true, I}, expected{true, I}, ""},
+		/* 8  IO             */ {IO, expected{}, expected{}, ""},
+		/* 9  IO|OI          */ {IO | OI, expected{true, I}, expected{true, OI | IO | I}, "tracked under #521 PR 3 — Bug C OI propagation to dir child"},
+		/* 10 IO|CI          */ {IO | CI, expected{}, expected{true, CI | I}, ""},
+		/* 11 IO|OI|CI       */ {IO | OI | CI, expected{true, I}, expected{true, OI | CI | I}, ""},
+		/* 12 IO|NP          */ {IO | NP, expected{}, expected{}, ""},
+		/* 13 IO|NP|OI       */ {IO | NP | OI, expected{true, I}, expected{}, ""},
+		/* 14 IO|NP|CI       */ {IO | NP | CI, expected{}, expected{true, I}, ""},
+		/* 15 IO|NP|OI|CI    */ {IO | NP | OI | CI, expected{true, I}, expected{true, I}, ""},
+	}
+
+	for n, r := range rows {
+		n, r := n, r
+		t.Run(fmt.Sprintf("row_%02d_file", n), func(t *testing.T) {
+			parent := buildParentACLWithFlags(true /*AutoInherited*/, false, r.parentFlags, false)
+			result := ComputeInheritedACL(parent, false /*isDir*/, Creator{})
+			assertInheritedFlags(t, n, "file", result, r.file)
+		})
+		t.Run(fmt.Sprintf("row_%02d_dir", n), func(t *testing.T) {
+			if r.skipDirPR != "" {
+				t.Skip(r.skipDirPR)
+			}
+			parent := buildParentACLWithFlags(true /*AutoInherited*/, false, r.parentFlags, false)
+			result := ComputeInheritedACL(parent, true /*isDir*/, Creator{})
+			assertInheritedFlags(t, n, "dir", result, r.dir)
+		})
+	}
+}
+
+func assertInheritedFlags(t *testing.T, row int, kind string, result *ACL, want struct {
+	present bool
+	flags   uint32
+},
+) {
+	t.Helper()
+	if !want.present {
+		if result != nil && len(result.ACEs) > 0 {
+			t.Errorf("row %d %s: expected no inherited ACE, got %d ACE(s), first flags=0x%x",
+				row, kind, len(result.ACEs), result.ACEs[0].Flag)
+		}
+		return
+	}
+	if result == nil {
+		t.Fatalf("row %d %s: expected 1 inherited ACE, got nil ACL", row, kind)
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("row %d %s: expected 1 inherited ACE, got %d", row, kind, len(result.ACEs))
+	}
+	if result.ACEs[0].Flag != want.flags {
+		t.Errorf("row %d %s: child ACE flags=0x%x, want 0x%x",
+			row, kind, result.ACEs[0].Flag, want.flags)
 	}
 }
 

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -741,6 +741,12 @@ func TestComputeInheritedACL_InheritanceFlagsMatrix(t *testing.T) {
 					t.Errorf("i=%d %s: child INHERITED_ACE=%v, want %v (parent AI=%v ace.I=%v)",
 						i, tc.name, gotInherited, expectChildInherited, autoInherited, aceHasInheritedBit)
 				}
+				// Trustee assertion: parent uses non-CREATOR principal
+				// (EVERYONE@), so no substitution happens.
+				if result.ACEs[0].Who != SpecialEveryone {
+					t.Errorf("i=%d %s: child ACE Who=%q, want %q (no substitution for non-CREATOR principal)",
+						i, tc.name, result.ACEs[0].Who, SpecialEveryone)
+				}
 
 				// AutoInherited propagation (already correct under P6-2,
 				// asserted here as a non-skipped sanity check).
@@ -862,20 +868,115 @@ func assertInheritedFlags(t *testing.T, row int, kind string, result *ACL, want 
 		t.Errorf("row %d %s: child ACE flags=0x%x, want 0x%x",
 			row, kind, result.ACEs[0].Flag, want.flags)
 	}
+	// Non-CREATOR principal: must be preserved exactly. The matrix uses
+	// EVERYONE@ via buildParentACLWithFlags.
+	if result.ACEs[0].Who != SpecialEveryone {
+		t.Errorf("row %d %s: child ACE Who=%q, want %q (no substitution for non-CREATOR)",
+			row, kind, result.ACEs[0].Who, SpecialEveryone)
+	}
+}
+
+// TestComputeInheritedACL_CreatorMatrix_DirChild walks the CREATOR-specific
+// inheritance shapes on a directory child, checking BOTH per-ACE trustee
+// and flags. Bug H + Bug I from the post-PR #524 investigation:
+//   - OI-only on dir (applies=false): single preserved ACE with CREATOR
+//     trustee KEPT (no substitution), flag OI|IO+INHERITED.
+//   - CI on dir + CREATOR (applies=true): TWO ACEs. Resolved sibling has
+//     all inheritance flags CLEARED (flag = INHERITED only), trustee
+//     substituted. Preserved has CREATOR kept, flag = parent OI/CI
+//     bits + IO + INHERITED.
+func TestComputeInheritedACL_CreatorMatrix_DirChild(t *testing.T) {
+	const (
+		OI = ACE4_FILE_INHERIT_ACE
+		CI = ACE4_DIRECTORY_INHERIT_ACE
+		IO = ACE4_INHERIT_ONLY_ACE
+		I  = ACE4_INHERITED_ACE
+	)
+
+	type expectedACE struct {
+		who  string
+		flag uint32
+	}
+	cases := []struct {
+		name        string
+		parentFlags uint32
+		expect      []expectedACE
+	}{
+		{
+			name:        "OI-only / applies=false",
+			parentFlags: OI,
+			// Bug H: principal preserved, NOT substituted.
+			expect: []expectedACE{
+				{who: SpecialCreatorOwner, flag: OI | IO | I},
+			},
+		},
+		{
+			name:        "CI-only / applies=true",
+			parentFlags: CI,
+			// Bug I: resolved sibling flag = INHERITED only (all
+			// inheritance bits cleared); preserved keeps CREATOR.
+			expect: []expectedACE{
+				{who: "1001@localdomain", flag: I},
+				{who: SpecialCreatorOwner, flag: CI | IO | I},
+			},
+		},
+		{
+			name:        "OI|CI / applies=true",
+			parentFlags: OI | CI,
+			expect: []expectedACE{
+				{who: "1001@localdomain", flag: I},
+				{who: SpecialCreatorOwner, flag: OI | CI | IO | I},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			parent := &ACL{
+				AutoInherited: true,
+				ACEs: []ACE{
+					{
+						Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+						Flag:       tc.parentFlags,
+						AccessMask: ACE4_WRITE_DATA,
+						Who:        SpecialCreatorOwner,
+					},
+				},
+			}
+			result := ComputeInheritedACL(parent, true, Creator{UID: 1001})
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if len(result.ACEs) != len(tc.expect) {
+				t.Fatalf("got %d ACEs, want %d (%v)", len(result.ACEs), len(tc.expect), result.ACEs)
+			}
+			for i, want := range tc.expect {
+				got := result.ACEs[i]
+				if got.Who != want.who {
+					t.Errorf("ACE[%d].Who=%q, want %q", i, got.Who, want.who)
+				}
+				if got.Flag != want.flag {
+					t.Errorf("ACE[%d].Flag=0x%x, want 0x%x", i, got.Flag, want.flag)
+				}
+			}
+		})
+	}
 }
 
 // TestComputeInheritedACL_CreatorOwnerCI_DualEmit_Dir asserts that a parent
 // ACE with CREATOR_OWNER + OI|CI emits TWO ACEs onto a directory child:
-//  1. The resolved owner ACE that applies at the new dir (inheritance
-//     flags adjusted per PR 3 — OI propagates to file grandchildren as
-//     OI|INHERIT_ONLY-equivalent here; the resolved ACE still carries
-//     OI|CI so grandchildren of either kind inherit from it as well).
+//  1. The resolved owner ACE that applies at the new dir ONLY. Per Samba
+//     desc_expand_generic (libcli/security/create_descriptor.c), the
+//     resolved sibling has ALL inheritance flags cleared — only the
+//     INHERITED_ACE bit may be present. It does NOT propagate further;
+//     propagation to grandchildren happens via the preserved CREATOR.
 //  2. The preserved CREATOR_OWNER ACE with CI|OI|INHERIT_ONLY so
 //     grandchild directories continue to substitute against THEIR own
 //     creator.
 //
 // Mirrors Samba calculate_inherited_from_parent (libcli/security/
-// create_descriptor.c). This is Bug G (#521 PR 4).
+// create_descriptor.c).
 func TestComputeInheritedACL_CreatorOwnerCI_DualEmit_Dir(t *testing.T) {
 	parentACL := &ACL{
 		AutoInherited: true,
@@ -897,15 +998,16 @@ func TestComputeInheritedACL_CreatorOwnerCI_DualEmit_Dir(t *testing.T) {
 		t.Fatalf("expected 2 ACEs (resolved + preserved CREATOR), got %d", len(result.ACEs))
 	}
 
-	// ACE 0: resolved owner — CI applies here so INHERIT_ONLY cleared.
-	// OI preserved on parent ACE => preserved on resolved child too.
+	// ACE 0: resolved owner — Samba clears ALL inheritance flags on the
+	// resolved sibling; only INHERITED_ACE may remain. The resolved ACE
+	// applies at this object only.
 	resolved := result.ACEs[0]
 	if resolved.Who != "1001@localdomain" {
 		t.Errorf("resolved ACE: expected Who=1001@localdomain, got %q", resolved.Who)
 	}
-	wantResolvedFlag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERITED_ACE)
+	wantResolvedFlag := uint32(ACE4_INHERITED_ACE)
 	if resolved.Flag != wantResolvedFlag {
-		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (OI|CI|INHERITED)", resolved.Flag, wantResolvedFlag)
+		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (INHERITED only — Samba clears inheritance bits on resolved sibling)", resolved.Flag, wantResolvedFlag)
 	}
 
 	// ACE 1: preserved CREATOR_OWNER — CI|OI|IO + INHERITED.
@@ -953,10 +1055,11 @@ func TestComputeInheritedACL_CreatorGroupCI_DualEmit_Dir(t *testing.T) {
 	if resolved.Who != "2002@localdomain" {
 		t.Errorf("resolved ACE: expected Who=2002@localdomain, got %q", resolved.Who)
 	}
-	// CI applies at this dir; INHERIT_ONLY cleared; OI absent on parent.
-	wantResolvedFlag := uint32(ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERITED_ACE)
+	// Resolved sibling has ALL inheritance flags cleared (Samba
+	// desc_expand_generic); only INHERITED_ACE remains.
+	wantResolvedFlag := uint32(ACE4_INHERITED_ACE)
 	if resolved.Flag != wantResolvedFlag {
-		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (CI|INHERITED)", resolved.Flag, wantResolvedFlag)
+		t.Errorf("resolved ACE: flag=0x%x, want 0x%x (INHERITED only)", resolved.Flag, wantResolvedFlag)
 	}
 
 	preserved := result.ACEs[1]
@@ -998,11 +1101,14 @@ func TestComputeInheritedACL_CreatorOwner_FileChild_NoDualEmit(t *testing.T) {
 }
 
 // TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir verifies that
-// when the parent ACE has OI only (no CI), the dir child receives the
-// resolved ACE as OI|INHERIT_ONLY (per PR 3) but NO preserved CREATOR ACE
-// — without CI on the source, there is no need to propagate to grandchild
-// directories.
-func TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir(t *testing.T) {
+// when the parent ACE has OI only (no CI), the dir child receives a SINGLE
+// preserved ACE as OI|INHERIT_ONLY with the principal kept as
+// CREATOR_OWNER. The ACE does not apply at this dir; it propagates to file
+// grandchildren and substitution happens at THAT grandchild's create time,
+// not now. This is Bug H from #521 PR 5 — previously we substituted the
+// principal here, which leaked the dir owner identity onto the
+// grandchild's "creator".
+func TestComputeInheritedACL_CreatorOwner_OIOnlyDir_PreservesPrincipal(t *testing.T) {
 	parentACL := &ACL{
 		AutoInherited: true,
 		ACEs: []ACE{
@@ -1023,14 +1129,14 @@ func TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir(t *testing.T) {
 		t.Fatalf("expected exactly 1 ACE (no dual emit without CI), got %d", len(result.ACEs))
 	}
 	ace := result.ACEs[0]
-	// Per PR 3: OI-only on parent => dir child gets OI|INHERIT_ONLY.
 	wantFlag := uint32(ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE | ACE4_INHERITED_ACE)
 	if ace.Flag != wantFlag {
 		t.Errorf("expected flag 0x%x (OI|IO|INHERITED), got 0x%x", wantFlag, ace.Flag)
 	}
-	// And CREATOR was still substituted.
-	if ace.Who != "1001@localdomain" {
-		t.Errorf("expected resolved owner Who=1001@localdomain, got %q", ace.Who)
+	// Principal MUST stay CREATOR_OWNER (Bug H fix). Substitution is
+	// deferred to grandchild create time.
+	if ace.Who != SpecialCreatorOwner {
+		t.Errorf("expected preserved CreatorOwner@, got Who=%q (Bug H regression)", ace.Who)
 	}
 }
 

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -6,14 +6,19 @@ import (
 )
 
 func TestComputeInheritedACL_FileInheritOnChildFile(t *testing.T) {
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_FILE_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA,
-			Who:        SpecialEveryone,
+	// AutoInherited=true on the parent so the child carries INHERITED_ACE
+	// per MS-DTYP §2.5.3.4.2 (Samba calculate_inherited_from_parent).
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialEveryone,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, false, Creator{})
 
@@ -40,14 +45,17 @@ func TestComputeInheritedACL_FileInheritOnChildFile(t *testing.T) {
 }
 
 func TestComputeInheritedACL_DirectoryInheritOnChildDir(t *testing.T) {
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_DIRECTORY_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA | ACE4_EXECUTE,
-			Who:        SpecialGroup,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA | ACE4_EXECUTE,
+				Who:        SpecialGroup,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, true, Creator{})
 
@@ -69,14 +77,17 @@ func TestComputeInheritedACL_DirectoryInheritOnChildDir(t *testing.T) {
 }
 
 func TestComputeInheritedACL_NoPropagateStopsInheritance(t *testing.T) {
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_DIRECTORY_INHERIT_ACE | ACE4_NO_PROPAGATE_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA,
-			Who:        SpecialOwner,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE | ACE4_NO_PROPAGATE_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialOwner,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, true, Creator{})
 
@@ -100,14 +111,17 @@ func TestComputeInheritedACL_NoPropagateStopsInheritance(t *testing.T) {
 func TestComputeInheritedACL_InheritOnlyClearedOnChild(t *testing.T) {
 	// INHERIT_ONLY + DIRECTORY_INHERIT: ACE does NOT apply to parent,
 	// but DOES apply to child directory (INHERIT_ONLY should be cleared).
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
-			AccessMask: ACE4_WRITE_DATA,
-			Who:        SpecialEveryone,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialEveryone,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, true, Creator{})
 
@@ -218,14 +232,17 @@ func TestComputeInheritedACL_MixedInheritFlags(t *testing.T) {
 func TestComputeInheritedACL_FileInheritClearsAllFlags(t *testing.T) {
 	// FILE_INHERIT + DIRECTORY_INHERIT: when inherited by a file,
 	// ALL inheritance flags are cleared.
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA,
-			Who:        SpecialEveryone,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialEveryone,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, false, Creator{})
 	if result == nil {
@@ -272,14 +289,17 @@ func TestPropagateACL_ReplacesInheritedKeepsExplicit(t *testing.T) {
 		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: ACE4_INHERITED_ACE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
 	}}
 
-	newParentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_FILE_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA | ACE4_EXECUTE,
-			Who:        SpecialOwner,
+	newParentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA | ACE4_EXECUTE,
+				Who:        SpecialOwner,
+			},
 		},
-	}}
+	}
 
 	result := PropagateACL(newParentACL, existingACL, false, Creator{})
 
@@ -375,14 +395,17 @@ func TestComputeInheritedACL_CreatorOwnerSubstitution_POSIX(t *testing.T) {
 	// Parent has a CREATOR_OWNER inheritable placeholder ACE. When inherited
 	// onto a file with no Windows SID known, it should resolve to the POSIX
 	// form "<uid>@localdomain" frozen at create time.
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
-			AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA,
-			Who:        SpecialCreatorOwner,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
+				AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA,
+				Who:        SpecialCreatorOwner,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001})
 
@@ -407,14 +430,17 @@ func TestComputeInheritedACL_CreatorOwnerSubstitution_POSIX(t *testing.T) {
 
 func TestComputeInheritedACL_CreatorOwnerSubstitution_SID(t *testing.T) {
 	// Same scenario but creator has a Windows SID — substitution uses sid:<SID>.
-	parentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
-			AccessMask: ACE4_READ_DATA,
-			Who:        SpecialCreatorOwner,
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_INHERIT_ONLY_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialCreatorOwner,
+			},
 		},
-	}}
+	}
 
 	result := ComputeInheritedACL(parentACL, false, Creator{UID: 1001, SID: "S-1-5-21-1-2-3-2001"})
 
@@ -662,10 +688,9 @@ func buildParentACLWithFlags(autoInherited, protected bool, aceFlags uint32, par
 // the child ACE has ACE4_INHERITED_ACE iff parent.AutoInherited OR the
 // parent ACE already had ACE4_INHERITED_ACE.
 //
-// DittoFS today unconditionally sets ACE4_INHERITED_ACE on every inherited
-// child ACE, which violates the invariant whenever (i&1)==0 AND (i&8)==0
-// — that is i ∈ {0, 2, 4, 6}. Those iterations are skipped here under
-// #521 PR 2 (Bug A: conditional INHERITED_ACE).
+// After #521 PR 2 (Bug A conditional INHERITED_ACE), the implementation
+// enforces this invariant directly: ComputeInheritedACL sets the bit only
+// when parent.AutoInherited OR the parent ACE itself already had the bit.
 func TestComputeInheritedACL_InheritanceFlagsMatrix(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		i := i
@@ -683,10 +708,6 @@ func TestComputeInheritedACL_InheritanceFlagsMatrix(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(formatMatrixName(i, tc.name), func(t *testing.T) {
-				if !expectChildInherited {
-					t.Skip("tracked under #521 PR 2 — Bug A conditional INHERITED_ACE")
-				}
-
 				parent := buildParentACLWithFlags(
 					autoInherited,
 					protected,
@@ -838,14 +859,17 @@ func TestPropagateACL_Directory(t *testing.T) {
 		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: ACE4_INHERITED_ACE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
 	}}
 
-	newParentACL := &ACL{ACEs: []ACE{
-		{
-			Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			Flag:       ACE4_DIRECTORY_INHERIT_ACE,
-			AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA,
-			Who:        SpecialGroup,
+	newParentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA,
+				Who:        SpecialGroup,
+			},
 		},
-	}}
+	}
 
 	result := PropagateACL(newParentACL, existingACL, true, Creator{})
 

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -697,20 +697,27 @@ func buildParentACLWithFlags(autoInherited, protected bool, aceFlags uint32, par
 //	i&4 → parent SD.Protected
 //	i&8 → parent ACE has ACE4_INHERITED_ACE pre-set
 //
-// Key invariant under test (MS-DTYP §2.5.3.4.2 / Samba `set_inherited_sd`):
-// the child ACE has ACE4_INHERITED_ACE iff parent.AutoInherited OR the
-// parent ACE already had ACE4_INHERITED_ACE.
+// Key invariant under test (MS-DTYP §2.5.3.4.2 / Samba `set_inherited_sd`
+// + tflags table in source4/torture/smb2/acls.c): the child ACE has
+// ACE4_INHERITED_ACE iff parent.AutoInherited (after canonicalization).
+// The parent ACE's pre-existing INHERITED_ACE bit is NOT propagated
+// independently — Samba's tflags shows it is set on the child ONLY when
+// the parent SD has both AUTO_INHERITED and AUTO_INHERIT_REQ set, which
+// canonicalize down to parent.AutoInherited.
 //
-// After #521 PR 2 (Bug A conditional INHERITED_ACE), the implementation
-// enforces this invariant directly: ComputeInheritedACL sets the bit only
-// when parent.AutoInherited OR the parent ACE itself already had the bit.
+// After #521 PR 7 (Bug J), the implementation enforces this directly:
+// ComputeInheritedACL sets the bit only when parent.AutoInherited.
 func TestComputeInheritedACL_InheritanceFlagsMatrix(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		i := i
 		autoInherited := (i & 1) != 0
 		protected := (i & 4) != 0
 		aceHasInheritedBit := (i & 8) != 0
-		expectChildInherited := autoInherited || aceHasInheritedBit
+		// Bug J: child gets INHERITED_ACE iff parent.AutoInherited.
+		// Independent of whether the parent ACE pre-carried the bit
+		// (aceHasInheritedBit only feeds the parent shape for building
+		// the input; it does not influence the expected child outcome).
+		expectChildInherited := autoInherited
 
 		for _, tc := range []struct {
 			name        string

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -1034,6 +1034,91 @@ func TestComputeInheritedACL_CreatorOwner_OIOnly_NoDualEmit_Dir(t *testing.T) {
 	}
 }
 
+// TestComputeInheritedACL_MaxACECount_CapEnforced verifies that the
+// running result of ComputeInheritedACL never exceeds MaxACECount even
+// when the parent has many inheritable ACEs and a subset trigger
+// CREATOR dual-emission. FIFO truncation rule: earlier-in-parent ACEs
+// are preserved over later ones (matches Samba behavior under cap
+// pressure).
+func TestComputeInheritedACL_MaxACECount_CapEnforced(t *testing.T) {
+	// Build a parent ACL with MaxACECount+5 inheritable ACEs. Sprinkle
+	// CREATOR_OWNER + CI entries (which dual-emit on a dir child) so
+	// the cumulative resolved+preserved count would explode past
+	// MaxACECount if the cap were not enforced across both append
+	// paths. The first ACE is a uniquely-named "first@example.com"
+	// sentinel so we can assert FIFO preservation.
+	// Use a distinct per-index bit pattern in AccessMask so we can
+	// verify FIFO preservation regardless of CREATOR substitution
+	// rewriting the Who field. Bit 31 is set on each ACE; the low bits
+	// carry the parent index. This way:
+	//   - resolved CREATOR ACEs keep their (index-tagged) mask
+	//   - preserved CREATOR ACEs likewise keep the tagged mask
+	//   - we can detect leak of late-parent ACEs by mask alone
+	tag := func(i int) uint32 { return uint32(0x80000000) | uint32(i) }
+
+	aces := make([]ACE, 0, MaxACECount+5)
+	aces = append(aces, ACE{
+		Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+		Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
+		AccessMask: tag(0),
+		Who:        "first@example.com",
+	})
+	for i := 1; i < MaxACECount+5; i++ {
+		if i%3 == 0 {
+			// CREATOR_OWNER + CI => dual-emit on dir child.
+			aces = append(aces, ACE{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: tag(i),
+				Who:        SpecialCreatorOwner,
+			})
+		} else {
+			aces = append(aces, ACE{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: tag(i),
+				Who:        fmt.Sprintf("user%d@example.com", i),
+			})
+		}
+	}
+	parentACL := &ACL{ACEs: aces}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{UID: 1001})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) > MaxACECount {
+		t.Fatalf("result ACE count %d exceeds MaxACECount %d", len(result.ACEs), MaxACECount)
+	}
+	// We expect the cap to be saturated given the input size.
+	if len(result.ACEs) != MaxACECount {
+		t.Errorf("expected result saturated at MaxACECount=%d, got %d", MaxACECount, len(result.ACEs))
+	}
+
+	// FIFO: the first parent ACE must be the first child ACE (tag 0).
+	if result.ACEs[0].AccessMask != tag(0) || result.ACEs[0].Who != "first@example.com" {
+		t.Errorf("FIFO preservation broken: expected first ACE tag=0x%x Who=first@example.com, got tag=0x%x Who=%q",
+			tag(0), result.ACEs[0].AccessMask, result.ACEs[0].Who)
+	}
+
+	// Compute the highest parent index whose tag appears in the result.
+	// Under FIFO truncation, no late-parent ACE should leak past the
+	// earlier ACEs we had room for.
+	resultTags := make(map[uint32]bool, len(result.ACEs))
+	for _, a := range result.ACEs {
+		resultTags[a.AccessMask] = true
+	}
+	// The last parent ACE's tag must NOT be present.
+	if resultTags[tag(len(aces)-1)] {
+		t.Errorf("FIFO violation: last parent ACE (tag=0x%x) leaked into truncated child",
+			tag(len(aces)-1))
+	}
+	// Sanity: tag(0) (the first parent ACE) MUST be present.
+	if !resultTags[tag(0)] {
+		t.Errorf("FIFO violation: first parent ACE (tag=0x%x) missing from truncated child", tag(0))
+	}
+}
+
 func TestPropagateACL_Directory(t *testing.T) {
 	existingACL := &ACL{ACEs: []ACE{
 		{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_DELETE, Who: "bob@example.com"},


### PR DESCRIPTION
## Summary

Multi-PR phase of #521 — DACL inheritance correctness. **8 commits** ship comprehensive correctness fixes to `pkg/metadata/acl/inherit.go::ComputeInheritedACL` mirroring Samba `libcli/security/create_descriptor.c::calculate_inherited_from_parent` and MS-DTYP §2.5.3.4.

## What changed

1. **PR 1** (`7d0ee675`) — `test(acl)`: 16-case conformance matrix tests mirroring smbtorture `test_inheritance_flags` + `test_inheritance`. Foundation.

2. **PR 2** (`561904a2`) — Bug A: `ACE4_INHERITED_ACE` set conditionally (initial implementation).

3. **PR 3** (`13b5c433`) — Bug C: OI-only parent ACE propagates to directory child as `OI|INHERIT_ONLY` (was previously dropped). Per MS-DTYP §2.5.3.4.1.

4. **PR 4** (`fdc74a82`) — Bug G: when parent ACE has CONTAINER_INHERIT + CREATOR_OWNER/CREATOR_GROUP, dual-emit on directory child: (1) resolved sibling at the new directory, (2) preserved CREATOR with `OI?|CI|IO` for grandchildren.

5. **Cap fix** (`84c147c7`) — MaxACECount enforced across resolved + preserved emissions with FIFO truncation.

6. **Bug H + I** (`4bb3b76b`) — Restructure: when parent ACE doesn't apply at child (e.g. OI-only on dir), principal stays CREATOR_OWNER (Bug H). Resolved CREATOR sibling has `Flag = 0` (only conditional INHERITED_ACE) — was keeping CI/OI (Bug I). Matrix tests strengthened with trustee assertions.

7. **Bug J + K** (`3036e279`) — `INHERITED_ACE` rule simplified to parent.AutoInherited only (Bug J — removed over-broad "preserve parent ACE's INHERITED bit" clause). NP+CREATOR Case 2 paths clarified (Bug K, structurally already correct).

8. **NP+CREATOR skip** (`3bb2125f`) — Skip preserved CREATOR emission entirely under NO_PROPAGATE. Eliminated the residual NP+CI failures.

## Smbtorture verification (CI)

**INHERITANCE**:
- Pre-PR: 6+ failures including "Bad sd in child dir" on inheritable cases (parent flags 0x1, 0x2, 0x3, 0x6, 0x7, 0x9, 0xa, 0xb, 0xe, 0xf)
- Post-PR: **ZERO "Bad sd in child dir" failures**. All inheritable cases now produce Samba/Windows-matching output. Residual failures are "Expected default sd" for non-inheritable cases (DittoFS synthesizes POSIX-mapped ACL instead of Windows-default owner+SYSTEM FULL_CONTROL) — tracked in **#525**.

**INHERITFLAGS**: still failing at acls.c:1422 (parent SD round-trip), 1450 (child file SD), 1488 (inner-loop file SET). Root cause is in the SD build/parse round-trip (independent of inheritance computation) — tracked in **#526**.

**No regressions**: `smb2.acls_non_canonical.flags` continues to PASS (recovered via #514 on `/smbbasic`). NFS regression suite green. WPTS BVT green. Zero new failures.

## Why merge now (not wait for full target flip)

- Inheritance computation correctness is achieved per #521's stated scope (`ComputeInheritedACL` now mirrors Samba's `calculate_inherited_from_parent` 1:1 within the cases covered by the test matrix).
- Remaining failures are in **different layers** (default SD synthesis #525, SD round-trip #526) — orthogonal investigations.
- 8 commits represent substantial correctness work and a foundation (16-case matrix) for subsequent inheritance work.
- No regressions; CI fully green.

## Test plan

- [x] CI smbtorture/memory PASS
- [x] CI smbtorture Kerberos PASS
- [x] CI WPTS BVT PASS
- [x] CI NFS v3/v4/v4.1 PASS
- [x] INHERITANCE: zero "Bad sd in child dir" warnings (inheritance computation correct)
- [x] INHERITFLAGS: no regression
- [x] acls_non_canonical.flags: PASS preserved
- [ ] #525 follow-up: Windows default SD synthesis for files without inherited ACEs
- [ ] #526 follow-up: INHERITFLAGS SD round-trip build-side

## Eval-layer impact

Zero. `pkg/metadata/acl/evaluate.go` does not gate on `ACE4_INHERITED_ACE`. `INHERIT_ONLY` ACEs already filtered by `ace.IsInheritOnly()` in `checkACE`.

## Code style note

Bug F (generic-to-specific access mask expansion at inherit time, MS-DTYP §2.5.3.4.4) was originally planned as PR 5 of this phase. Deferred — correctness-only, doesn't move target tests, simpler as a follow-up.

Refs #521 #499 #520 #525 #526