### PR TITLE
fix(smb): synthesize Windows default SD when file has no ACL (#525)

### DIFF
--- a/internal/adapter/smb/v2/handlers/security.go
+++ b/internal/adapter/smb/v2/handlers/security.go
@@ -292,8 +292,11 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 }
 
 // buildDACL constructs a DACL (Discretionary Access Control List) from the file's ACL.
-// If the file has no ACL, a DACL is synthesized from POSIX mode bits using
-// acl.SynthesizeFromMode. Returns the source ACL used for SD control flag computation.
+// If the file has no ACL, the Windows default DACL is synthesized
+// (owner + SYSTEM FullControl, no inherit flags) per acl.SynthesizeWindowsDefault.
+// This matches Samba's sd_def1 (source4/torture/smb2/acls.c) and is what
+// Windows clients expect when no inheritable ACEs were available at create
+// time. Returns the source ACL used for SD control flag computation.
 func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
 	var aces []windowsACE
 	var fileACL *acl.ACL
@@ -301,9 +304,7 @@ func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
 	if file.ACL != nil && len(file.ACL.ACEs) > 0 {
 		fileACL = file.ACL
 	} else {
-		// No ACL: synthesize DACL from POSIX mode bits
-		isDir := file.Type == metadata.FileTypeDirectory
-		fileACL = acl.SynthesizeFromMode(file.Mode, file.UID, file.GID, isDir)
+		fileACL = acl.SynthesizeWindowsDefault()
 	}
 
 	aces = make([]windowsACE, 0, len(fileACL.ACEs))

--- a/internal/adapter/smb/v2/handlers/security.go
+++ b/internal/adapter/smb/v2/handlers/security.go
@@ -292,16 +292,27 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 }
 
 // buildDACL constructs a DACL (Discretionary Access Control List) from the file's ACL.
-// If the file has no ACL, the Windows default DACL is synthesized
-// (owner + SYSTEM FullControl, no inherit flags) per acl.SynthesizeWindowsDefault.
-// This matches Samba's sd_def1 (source4/torture/smb2/acls.c) and is what
-// Windows clients expect when no inheritable ACEs were available at create
-// time. Returns the source ACL used for SD control flag computation.
+//
+// Per pkg/metadata/file_types.go FileAttr.ACL contract:
+//   - file.ACL == nil          → no ACL stored; synthesize Windows-default
+//     (owner + SYSTEM FullControl, no inherit flags) via
+//     acl.SynthesizeWindowsDefault. Matches Samba's sd_def1
+//     (source4/torture/smb2/acls.c).
+//   - file.ACL != nil, len==0  → explicit empty DACL (deny-all). Emit a
+//     0-ACE DACL on the wire; do NOT synthesize a default.
+//   - file.ACL != nil, len>0   → emit stored ACEs as-is.
+//
+// Note: server-side access checks and computeMaximalAccess (create.go) still
+// fall back to POSIX mode bits for nil ACL — this is intentional. The SD shape
+// here is what the client sees; actual access enforcement keeps the legacy
+// POSIX semantics so Unix mode bits stay authoritative on the server.
+//
+// Returns the source ACL used for SD control flag computation.
 func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
 	var aces []windowsACE
 	var fileACL *acl.ACL
 
-	if file.ACL != nil && len(file.ACL.ACEs) > 0 {
+	if file.ACL != nil {
 		fileACL = file.ACL
 	} else {
 		fileACL = acl.SynthesizeWindowsDefault()

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -159,6 +159,37 @@ func TestBuildSD_NilACL_SynthesizesWindowsDefault(t *testing.T) {
 	}
 }
 
+// TestBuildSD_EmptyACL_EmitsZeroACEDACL verifies the FileAttr.ACL contract
+// (pkg/metadata/file_types.go): file.ACL non-nil with len(ACEs)==0 is an
+// explicit empty DACL (deny-all) and MUST NOT fall through to Windows-default
+// synthesis. Round-trip emits a 0-ACE DACL.
+func TestBuildSD_EmptyACL_EmitsZeroACEDACL(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL:  &acl.ACL{ACEs: nil},
+		},
+	}
+
+	data, err := BuildSecurityDescriptor(file, 0)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	_, _, parsedACL, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	if parsedACL == nil {
+		t.Fatal("Expected DACL, got nil")
+	}
+	if len(parsedACL.ACEs) != 0 {
+		t.Errorf("Expected 0-ACE DACL (deny-all), got %d ACEs — synthesis must not run for non-nil empty ACL", len(parsedACL.ACEs))
+	}
+}
+
 // TestBuildSD_ExplicitACL_UsesExisting verifies that an explicit ACL is encoded directly.
 func TestBuildSD_ExplicitACL_UsesExisting(t *testing.T) {
 	explicitACL := &acl.ACL{

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -103,9 +103,12 @@ func TestBuildSecurityDescriptorWithACL(t *testing.T) {
 	}
 }
 
-// TestBuildSD_NilACL_SynthesizesDACL verifies that BuildSecurityDescriptor
-// synthesizes a proper POSIX-derived DACL when the file has no explicit ACL.
-func TestBuildSD_NilACL_SynthesizesDACL(t *testing.T) {
+// TestBuildSD_NilACL_SynthesizesWindowsDefault verifies that
+// BuildSecurityDescriptor emits the Windows default DACL when the file
+// has no explicit ACL — owner + SYSTEM FULL_CONTROL, flags=0. Matches
+// Samba's sd_def1 (source4/torture/smb2/acls.c) and unblocks the
+// non-inheritable rows of smb2.acls.INHERITANCE.
+func TestBuildSD_NilACL_SynthesizesWindowsDefault(t *testing.T) {
 	file := &metadata.File{
 		FileAttr: metadata.FileAttr{
 			UID:  1000,
@@ -127,28 +130,32 @@ func TestBuildSD_NilACL_SynthesizesDACL(t *testing.T) {
 		t.Fatal("Expected DACL, got nil")
 	}
 
-	// Mode 0755 should produce Allow-only ACEs (Samba-style, no Deny ACEs).
-	// SynthesizeFromMode produces:
-	// 1. ALLOW OWNER@ (rwx + admin)
-	// 2. ALLOW GROUP@ (r-x)
-	// 3. ALLOW EVERYONE@ (r-x)
-	// 4. ALLOW SYSTEM@ (full)
-	// 5. ALLOW ADMINISTRATORS@ (full)
-	// Total: 5 Allow ACEs, 0 Deny ACEs.
-	if len(parsedACL.ACEs) != 5 {
-		t.Fatalf("Expected 5 ACEs from synthesis, got %d", len(parsedACL.ACEs))
+	// Windows default = 2 ACEs (owner FULL + SYSTEM FULL), no inherit flags.
+	if len(parsedACL.ACEs) != 2 {
+		t.Fatalf("Expected 2 ACEs (Windows default), got %d", len(parsedACL.ACEs))
 	}
 
-	// Samba-style: NO Deny ACEs should be present
-	for _, ace := range parsedACL.ACEs {
-		if ace.Type == acl.ACE4_ACCESS_DENIED_ACE_TYPE {
-			t.Errorf("Unexpected DENY ACE in synthesized DACL (Samba-style should be Allow-only): %s", ace.Who)
+	for i, ace := range parsedACL.ACEs {
+		if ace.Type != acl.ACE4_ACCESS_ALLOWED_ACE_TYPE {
+			t.Errorf("ACE[%d].Type = %d, want ALLOW(%d)", i, ace.Type, acl.ACE4_ACCESS_ALLOWED_ACE_TYPE)
+		}
+		if ace.Flag != 0 {
+			t.Errorf("ACE[%d].Flag = 0x%x, want 0 (Windows default is non-inheritable)", i, ace.Flag)
+		}
+		if ace.AccessMask != acl.FullAccessMask {
+			t.Errorf("ACE[%d].AccessMask = 0x%x, want FullAccessMask 0x%x", i, ace.AccessMask, acl.FullAccessMask)
 		}
 	}
 
-	// Should NOT be a simple "Everyone: Full Access" single ACE
-	if len(parsedACL.ACEs) == 1 && parsedACL.ACEs[0].AccessMask == 0x001F01FF {
-		t.Error("Got Everyone:Full single ACE -- expected POSIX-derived DACL with per-principal Allow ACEs")
+	// ACE order is fixed by SynthesizeWindowsDefault: owner first, SYSTEM second.
+	// After SD round-trip, owner@ resolves through the SIDMapper to
+	// "<uid>@localdomain"; SYSTEM (S-1-5-18) is not a domain SID so it
+	// surfaces as "sid:S-1-5-18".
+	if got, want := parsedACL.ACEs[0].Who, "1000@localdomain"; got != want {
+		t.Errorf("ACE[0].Who = %q, want %q (owner round-trip)", got, want)
+	}
+	if got, want := parsedACL.ACEs[1].Who, "sid:S-1-5-18"; got != want {
+		t.Errorf("ACE[1].Who = %q, want %q (SYSTEM SID round-trip)", got, want)
 	}
 }
 

--- a/pkg/metadata/acl/synthesize.go
+++ b/pkg/metadata/acl/synthesize.go
@@ -97,6 +97,39 @@ func SynthesizeFromMode(mode uint32, ownerUID, ownerGID uint32, isDirectory bool
 	}
 }
 
+// SynthesizeWindowsDefault returns the Windows default Security Descriptor
+// DACL used when a file has no stored ACL and no inheritable ACEs were
+// available from the parent at creation time.
+//
+// Shape (mirrors Samba's sd_def1 in source4/torture/smb2/acls.c):
+//   - ACE 1: ALLOW OWNER@ FullAccessMask, Flag=0
+//   - ACE 2: ALLOW SYSTEM@ FullAccessMask, Flag=0
+//
+// Flags are 0 (no inheritance) because this default is itself non-inheritable:
+// it represents "what a file should show when nothing else applies."
+//
+// This is the SMB read-side default. NFS callers should not use this — NFS
+// surfaces file.ACL as-is and synthesizes nothing.
+func SynthesizeWindowsDefault() *ACL {
+	return &ACL{
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       0,
+				AccessMask: FullAccessMask,
+				Who:        SpecialOwner,
+			},
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       0,
+				AccessMask: FullAccessMask,
+				Who:        SpecialSystem,
+			},
+		},
+		Source: ACLSourceWindowsDefault,
+	}
+}
+
 // rwxToFullMask maps a 3-bit rwx value to the full set of Windows access
 // rights associated with each permission. This provides fine-grained rights
 // mapping that Windows Explorer and icacls can display meaningfully.

--- a/pkg/metadata/acl/synthesize_test.go
+++ b/pkg/metadata/acl/synthesize_test.go
@@ -475,3 +475,39 @@ func TestSynthesizeWellKnownSIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestSynthesizeWindowsDefault verifies the SMB read-side default DACL
+// matches Samba sd_def1 in source4/torture/smb2/acls.c: 2 ALLOW ACEs
+// (OWNER@ then SYSTEM@) with FullAccessMask and Flag=0.
+func TestSynthesizeWindowsDefault(t *testing.T) {
+	acl := SynthesizeWindowsDefault()
+	if acl == nil {
+		t.Fatal("SynthesizeWindowsDefault returned nil")
+	}
+	if acl.Source != ACLSourceWindowsDefault {
+		t.Errorf("Source = %q, want %q", acl.Source, ACLSourceWindowsDefault)
+	}
+	if len(acl.ACEs) != 2 {
+		t.Fatalf("len(ACEs) = %d, want 2", len(acl.ACEs))
+	}
+
+	want := []ACE{
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: 0, AccessMask: FullAccessMask, Who: SpecialOwner},
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: 0, AccessMask: FullAccessMask, Who: SpecialSystem},
+	}
+	for i := range want {
+		if acl.ACEs[i] != want[i] {
+			t.Errorf("ACE[%d] = %+v, want %+v", i, acl.ACEs[i], want[i])
+		}
+	}
+
+	// No DENY, no inherit flags — the default is flat and non-inheritable.
+	for i, ace := range acl.ACEs {
+		if ace.Type == ACE4_ACCESS_DENIED_ACE_TYPE {
+			t.Errorf("ACE[%d] is DENY; Windows default is ALLOW-only", i)
+		}
+		if ace.Flag&inheritanceMask != 0 {
+			t.Errorf("ACE[%d].Flag = 0x%x carries inheritance bits; Windows default is flat", i, ace.Flag)
+		}
+	}
+}

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -145,6 +145,13 @@ const (
 
 	// ACLSourceNFSExplicit indicates the ACL was set explicitly via NFSv4.
 	ACLSourceNFSExplicit ACLSource = "nfs-explicit"
+
+	// ACLSourceWindowsDefault indicates the ACL was synthesized as the
+	// Windows default (owner + SYSTEM FullControl, no inherit flags). Used
+	// by SMB read-side when a file has no stored ACL and no inheritable
+	// ACEs were available at creation time. Mirrors Samba's sd_def1
+	// (source4/torture/smb2/acls.c).
+	ACLSourceWindowsDefault ACLSource = "windows-default"
 )
 
 // ACL represents an NFSv4 Access Control List.


### PR DESCRIPTION
## Summary

SMB read-side fallback in `BuildSecurityDescriptor` previously synthesized a POSIX-derived DACL (owner/group/world + SYSTEM + ADMINISTRATORS, 5 ACEs) when `file.ACL` was nil. Windows clients expect the platform-default SD shape — owner + SYSTEM FullControl, flags=0 — per Samba `sd_def1` (`source4/torture/smb2/acls.c`).

## Changes

- `pkg/metadata/acl/synthesize.go`: new `SynthesizeWindowsDefault()` returning the 2-ACE Windows default (owner FULL, SYSTEM FULL, no inherit flags).
- `pkg/metadata/acl/types.go`: new `ACLSourceWindowsDefault` constant.
- `internal/adapter/smb/v2/handlers/security.go`: `buildDACL` now uses `SynthesizeWindowsDefault()` when `file.ACL == nil` instead of `SynthesizeFromMode`.
- Updated `TestBuildSD_NilACL_*` to assert the new shape. Added `TestSynthesizeWindowsDefault`.

## Why this and not the issue's Option C

Issue #525 recommended Option C (store default SD at CREATE when share is SMB). Read-side synthesis is strictly less invasive:

- Zero storage churn — `file.ACL` stays nil.
- Zero NFS impact — NFS encodes `file.ACL` as-is (`internal/adapter/nfs/v4/attrs/encode.go:547`); never invoked `SynthesizeFromMode`. Mixed SMB+NFS shares unaffected.
- Same observable behavior on the SMB wire.

## Spec references

- MS-DTYP §2.5.3.4 — inheritance computation; default SD when no inheritable ACEs is platform-defined.
- MS-DTYP §2.4.6 — Security Descriptor format.
- Samba `source4/torture/smb2/acls.c::sd_def1` — ground-truth shape for "Windows default" expected by `smb2.acls.INHERITANCE`.

## Expected smbtorture impact

Should flip `smb2.acls.INHERITANCE` rows i=0, 2 (file), 4, 5 (dir), 8, 12 — currently failing with "Expected default sd" / "Expected default sd for dir at <i>". `KNOWN_FAILURES.md` left untouched until CI confirms.

May also flip `smb2.acls.OVERWRITE_READ_ONLY_FILE` depending on whether it depends on default-SD shape.

## Test plan

- [x] `go test ./pkg/metadata/acl/... ./internal/adapter/smb/...` — PASS
- [x] `go test ./internal/adapter/nfs/...` — PASS (no regression)
- [x] `go test ./pkg/metadata/...` — PASS
- [x] `go vet ./...` — clean
- [ ] CI smbtorture acls suite confirms `INHERITANCE` row flips
- [ ] No regression elsewhere in `smb2.acls.*`

Closes #525
Refs #521 #499