### PR TITLE
fix(acl): respect OWNER_RIGHTS (S-1-3-4) authority for file owner (#531)

### DIFF
--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -46,12 +46,15 @@ func HasExplicitDeny(a *ACL) bool {
 // true only if ALL requested permission bits are explicitly allowed.
 //
 // The algorithm:
-//  1. Pre-scan: detect whether any non-inherit-only OWNER_RIGHTS ACE is
-//     present. When present AND the requester is the file owner, the
-//     OWNER_RIGHTS ACEs become the sole authority for the owner: OWNER@
-//     ACEs are ignored for matching purposes (they would otherwise
-//     supersede the OWNER_RIGHTS decision under first-match-wins). This
-//     mirrors Samba `libcli/security/access_check.c::se_access_check`.
+//  1. Pre-scan (owner only): detect whether any effective OWNER_RIGHTS
+//     ACCESS_ALLOWED/ACCESS_DENIED ACE is present. When present AND the
+//     requester is the file owner, the OWNER_RIGHTS ACEs become the sole
+//     authority for the owner: OWNER@ ACEs are ignored for matching
+//     purposes (they would otherwise supersede the OWNER_RIGHTS decision
+//     under first-match-wins). This mirrors Samba
+//     `libcli/security/access_check.c::se_access_check`. AUDIT/ALARM
+//     ACEs do not affect access decisions and therefore do not trigger
+//     the override; non-owner requesters skip the pre-scan entirely.
 //  2. Process ACEs in order.
 //  3. Skip ACEs with INHERIT_ONLY flag (they only apply to children).
 //  4. For each matching ACE, record newly decided bits:
@@ -68,15 +71,26 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 		return false
 	}
 
-	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE?
-	// Inherit-only entries don't apply to access checks, so they don't count.
+	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE
+	// that affects access decisions? The override only matters when the
+	// requester is the file owner, so non-owners skip the scan entirely.
+	// AUDIT/ALARM ACEs are evaluation no-ops and must not trigger the
+	// override — only ACCESS_ALLOWED/ACCESS_DENIED count. Inherit-only
+	// entries don't apply to access checks, so they don't count either.
 	var ownerRightsPresent bool
-	for i := range a.ACEs {
-		ace := &a.ACEs[i]
-		if ace.IsInheritOnly() {
-			continue
-		}
-		if ace.Who == SpecialOwnerRights {
+	if evalCtx.UID == evalCtx.FileOwnerUID {
+		for i := range a.ACEs {
+			ace := &a.ACEs[i]
+			if ace.IsInheritOnly() {
+				continue
+			}
+			if ace.Who != SpecialOwnerRights {
+				continue
+			}
+			if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE &&
+				ace.Type != ACE4_ACCESS_DENIED_ACE_TYPE {
+				continue
+			}
 			ownerRightsPresent = true
 			break
 		}

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -41,24 +41,45 @@ func HasExplicitDeny(a *ACL) bool {
 }
 
 // Evaluate implements the NFSv4 ACL evaluation algorithm per RFC 7530
-// Section 6.2.1. It processes ACEs sequentially and returns true only
-// if ALL requested permission bits are explicitly allowed.
+// Section 6.2.1, with the OWNER_RIGHTS (S-1-3-4) override from
+// MS-DTYP §2.5.3 / §2.4.10. It processes ACEs sequentially and returns
+// true only if ALL requested permission bits are explicitly allowed.
 //
 // The algorithm:
-//  1. Process ACEs in order
-//  2. Skip ACEs with INHERIT_ONLY flag (they only apply to children)
-//  3. For each matching ACE, record newly decided bits:
+//  1. Pre-scan: detect whether any non-inherit-only OWNER_RIGHTS ACE is
+//     present. When present AND the requester is the file owner, the
+//     OWNER_RIGHTS ACEs become the sole authority for the owner: OWNER@
+//     ACEs are ignored for matching purposes (they would otherwise
+//     supersede the OWNER_RIGHTS decision under first-match-wins). This
+//     mirrors Samba `libcli/security/access_check.c::se_access_check`.
+//  2. Process ACEs in order.
+//  3. Skip ACEs with INHERIT_ONLY flag (they only apply to children).
+//  4. For each matching ACE, record newly decided bits:
 //     - ALLOW: mark undecided bits as allowed
 //     - DENY: mark undecided bits as denied
 //     - AUDIT/ALARM: skip (store-only per project decision)
-//  4. Once all requested bits are decided, stop early
-//  5. Return true if and only if ALL requested bits are in allowedBits
+//  5. Once all requested bits are decided, stop early.
+//  6. Return true if and only if ALL requested bits are in allowedBits.
 func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	if requestedMask == 0 {
 		return true
 	}
 	if a == nil || len(a.ACEs) == 0 {
 		return false
+	}
+
+	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE?
+	// Inherit-only entries don't apply to access checks, so they don't count.
+	var ownerRightsPresent bool
+	for i := range a.ACEs {
+		ace := &a.ACEs[i]
+		if ace.IsInheritOnly() {
+			continue
+		}
+		if ace.Who == SpecialOwnerRights {
+			ownerRightsPresent = true
+			break
+		}
 	}
 
 	var allowedBits uint32
@@ -73,7 +94,7 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 		}
 
 		// Check if this ACE applies to the requestor.
-		if !aceMatchesWho(ace, evalCtx) {
+		if !aceMatchesWhoWithOwnerRights(ace, evalCtx, ownerRightsPresent) {
 			continue
 		}
 
@@ -103,7 +124,10 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	return (allowedBits & requestedMask) == requestedMask
 }
 
-// aceMatchesWho checks if an ACE applies to the given evaluation context.
+// aceMatchesWho checks if an ACE applies to the given evaluation context,
+// with OWNER_RIGHTS treated as an ordinary owner-matching arm. Callers that
+// need MS-DTYP §2.5.3 OWNER_RIGHTS-vs-OWNER@ arbitration should use
+// aceMatchesWhoWithOwnerRights instead.
 //
 // Resolution rules for special identifiers (Pitfall 3 - dynamic resolution):
 //   - "OWNER@": matches when requestor UID == file owner UID
@@ -112,9 +136,30 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 //   - "EVERYONE@": always matches
 //   - Otherwise: exact string match on named principal
 func aceMatchesWho(ace *ACE, evalCtx *EvaluateContext) bool {
+	return aceMatchesWhoWithOwnerRights(ace, evalCtx, false)
+}
+
+// aceMatchesWhoWithOwnerRights is the OWNER_RIGHTS-aware variant of
+// aceMatchesWho. When ownerRightsPresent is true AND the requester is the
+// file owner, OWNER@ ACEs are made to not-match and OWNER_RIGHTS ACEs are
+// made to match — implementing MS-DTYP §2.5.3 / §2.4.10 (S-1-3-4): an
+// explicit OWNER_RIGHTS entry supersedes the implicit owner grants and
+// becomes the sole authority for the owner's effective rights.
+//
+// Mirrors Samba `libcli/security/access_check.c::se_access_check` handling
+// of `SID_OWNER_RIGHTS` / `SEC_RIGHTS_OWNER_RIGHTS`.
+func aceMatchesWhoWithOwnerRights(ace *ACE, evalCtx *EvaluateContext, ownerRightsPresent bool) bool {
+	requesterIsOwner := evalCtx.UID == evalCtx.FileOwnerUID
+
 	switch ace.Who {
 	case SpecialOwner:
-		return evalCtx.UID == evalCtx.FileOwnerUID
+		// OWNER_RIGHTS, when present, strips the file owner of the
+		// implicit OWNER@ identity for the purposes of this DACL walk.
+		// Non-owners are unaffected.
+		if ownerRightsPresent && requesterIsOwner {
+			return false
+		}
+		return requesterIsOwner
 
 	case SpecialGroup:
 		if evalCtx.GID == evalCtx.FileOwnerGID {
@@ -131,12 +176,9 @@ func aceMatchesWho(ace *ACE, evalCtx *EvaluateContext) bool {
 		return true
 
 	case SpecialOwnerRights:
-		// OWNER_RIGHTS (S-1-3-4) per MS-DTYP §2.5.3: when present in a DACL it
-		// supersedes the implicit owner READ_CONTROL/WRITE_DAC/WRITE_OWNER grant
-		// Windows applies. DittoFS does not grant those implicit owner rights
-		// today, so for us this arm reduces to: matches when requester is the
-		// file owner — same condition as SpecialOwner.
-		return evalCtx.UID == evalCtx.FileOwnerUID
+		// MS-DTYP §2.5.3 / §2.4.10: OWNER_RIGHTS (S-1-3-4) ACEs match the
+		// file owner only. They have no meaning for non-owner requesters.
+		return requesterIsOwner
 
 	default:
 		// SID-form ACE (set by SD parse): "sid:<canonical SID>".

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -469,3 +469,104 @@ func TestAceMatchesWho_OwnerRights(t *testing.T) {
 		})
 	}
 }
+
+// TestEvaluate_OwnerRights_SuppressesOwnerAce covers MS-DTYP §2.5.3 OWNER_RIGHTS
+// (S-1-3-4) semantics: when an OWNER_RIGHTS ACE is present in the DACL, the
+// OWNER@ ACEs are no longer authoritative for the file owner. Only the
+// OWNER_RIGHTS ACEs (Allow and Deny) decide what the owner is granted.
+func TestEvaluate_OwnerRights_SuppressesOwnerAce(t *testing.T) {
+	// OWNER_RIGHTS Allow READ + OWNER@ Allow WRITE → owner gets READ only.
+	// Without the override, OWNER@ would grant WRITE first; with it, OWNER@
+	// is ignored for owner identity and only OWNER_RIGHTS speaks.
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialOwner},
+		},
+	}
+	ctx := ownerCtx()
+
+	if !Evaluate(a, ctx, ACE4_READ_DATA) {
+		t.Error("expected owner to be allowed READ_DATA via OWNER_RIGHTS")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+		t.Error("expected owner to be denied WRITE_DATA (OWNER@ must be ignored when OWNER_RIGHTS is present)")
+	}
+	if Evaluate(a, ctx, ACE4_READ_DATA|ACE4_WRITE_DATA) {
+		t.Error("expected owner to be denied combined READ_DATA|WRITE_DATA")
+	}
+}
+
+// TestEvaluate_OwnerRights_DenyOverridesOwnerAllow covers the DENY case from
+// MS-DTYP §2.5.3 and the smb2.acls.OWNER-RIGHTS-DENY family of tests: an
+// OWNER_RIGHTS DENY ACE must take effect even when an OWNER@ ACE earlier in
+// (or simply elsewhere in) the DACL would grant the same bits.
+func TestEvaluate_OwnerRights_DenyOverridesOwnerAllow(t *testing.T) {
+	// Order matters under first-match-wins: place OWNER_RIGHTS Allow READ
+	// before the OWNER_RIGHTS Deny WRITE so that READ is granted via the
+	// OWNER_RIGHTS authority. OWNER@ Allow FULL must be ignored entirely.
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: 0xFFFFFFFF, Who: SpecialOwner},
+		},
+	}
+	ctx := ownerCtx()
+
+	if !Evaluate(a, ctx, ACE4_READ_DATA) {
+		t.Error("expected owner to be allowed READ_DATA via OWNER_RIGHTS Allow")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+		t.Error("expected owner to be denied WRITE_DATA via OWNER_RIGHTS Deny")
+	}
+}
+
+// TestEvaluate_NoOwnerRights_OwnerAceStillAuthoritative is the regression
+// check: when no OWNER_RIGHTS ACE is in the DACL, OWNER@ continues to handle
+// the file owner exactly as before. This guards against accidentally
+// breaking the common case.
+func TestEvaluate_NoOwnerRights_OwnerAceStillAuthoritative(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: 0xFFFFFFFF, Who: SpecialOwner},
+		},
+	}
+	ctx := ownerCtx()
+
+	if !Evaluate(a, ctx, ACE4_READ_DATA|ACE4_WRITE_DATA) {
+		t.Error("expected owner to retain OWNER@ Allow FULL when no OWNER_RIGHTS present")
+	}
+}
+
+// TestEvaluate_OwnerRights_NonOwnerUnaffected verifies that the OWNER_RIGHTS
+// override only suppresses OWNER@ matching for the file owner. A non-owner
+// requester observes normal OWNER@ semantics — i.e. OWNER@ never matched
+// them anyway, and OWNER_RIGHTS also never matches them — so other ACEs
+// (e.g. EVERYONE@) decide their effective access.
+func TestEvaluate_OwnerRights_NonOwnerUnaffected(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA, Who: SpecialEveryone},
+		},
+	}
+
+	// Non-owner: OWNER_RIGHTS ACEs don't match them, so EVERYONE@ grants
+	// both READ_DATA and WRITE_DATA.
+	nonOwner := nonOwnerCtx()
+	if !Evaluate(a, nonOwner, ACE4_READ_DATA|ACE4_WRITE_DATA) {
+		t.Error("expected non-owner to be allowed READ_DATA|WRITE_DATA via EVERYONE@")
+	}
+
+	// Owner: OWNER_RIGHTS speaks for them — READ allowed, WRITE denied —
+	// and EVERYONE@'s WRITE grant is shadowed by OWNER_RIGHTS Deny WRITE.
+	owner := ownerCtx()
+	if !Evaluate(a, owner, ACE4_READ_DATA) {
+		t.Error("expected owner to be allowed READ_DATA via OWNER_RIGHTS Allow")
+	}
+	if Evaluate(a, owner, ACE4_WRITE_DATA) {
+		t.Error("expected owner to be denied WRITE_DATA via OWNER_RIGHTS Deny (first-match-wins)")
+	}
+}

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -570,3 +570,43 @@ func TestEvaluate_OwnerRights_NonOwnerUnaffected(t *testing.T) {
 		t.Error("expected owner to be denied WRITE_DATA via OWNER_RIGHTS Deny (first-match-wins)")
 	}
 }
+
+// TestEvaluate_OwnerRights_AuditAceDoesNotSuppressOwner verifies that an
+// AUDIT (or ALARM) ACE for OwnerRights@ does NOT trigger the OWNER_RIGHTS
+// override. AUDIT/ALARM ACEs are evaluation no-ops per RFC 7530 / MS-DTYP;
+// only ACCESS_ALLOWED / ACCESS_DENIED ACEs for OwnerRights@ are authoritative.
+// Without this guard, an audit-only OwnerRights@ entry would incorrectly
+// strip OWNER@ identity from the file owner and silently deny owner access.
+func TestEvaluate_OwnerRights_AuditAceDoesNotSuppressOwner(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			// AUDIT ACE for OwnerRights@ — must NOT be treated as an
+			// OWNER_RIGHTS authority signal.
+			{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+			// OWNER@ Allow READ — must remain authoritative for the owner.
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+		},
+	}
+
+	owner := ownerCtx()
+	if !Evaluate(a, owner, ACE4_READ_DATA) {
+		t.Error("expected owner to retain OWNER@ READ_DATA when only an AUDIT OwnerRights@ ACE is present")
+	}
+}
+
+// TestEvaluate_OwnerRights_AlarmAceDoesNotSuppressOwner mirrors the AUDIT
+// case for ALARM ACEs — both are non-access ACE types and must not engage
+// the OWNER_RIGHTS override.
+func TestEvaluate_OwnerRights_AlarmAceDoesNotSuppressOwner(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_SYSTEM_ALARM_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialOwnerRights},
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA, Who: SpecialOwner},
+		},
+	}
+
+	owner := ownerCtx()
+	if !Evaluate(a, owner, ACE4_READ_DATA|ACE4_WRITE_DATA) {
+		t.Error("expected owner to retain OWNER@ rights when only an ALARM OwnerRights@ ACE is present")
+	}
+}


### PR DESCRIPTION
Closes #531.

## Summary

When an `OWNER_RIGHTS` (S-1-3-4) ACE is present in a DACL, MS-DTYP §2.5.3 makes it the sole authority for the file owner's effective rights — the implicit `OWNER@` grants/denies are suppressed. The previous evaluator treated `OWNER_RIGHTS` as just another owner-matching arm, so under our first-match-wins per-bit walk an `OWNER@` ALLOW earlier in the ACE list would decide owner bits first and a later `OWNER_RIGHTS` DENY would never get a chance to apply.

This PR implements the override:

- `acl.Evaluate` pre-scans the DACL for any non-inherit-only `OWNER_RIGHTS` ACE.
- When present AND the requester is the file owner, `OWNER@` ACEs are made to not-match for that requester; `OWNER_RIGHTS` ACEs continue to match.
- Non-owner requesters are unaffected (neither `OWNER@` nor `OWNER_RIGHTS` ever matched them).
- When no `OWNER_RIGHTS` ACE is present, `OWNER@` retains its existing semantics — regression-checked.

The behavior mirrors Samba `libcli/security/access_check.c::se_access_check` (`SID_OWNER_RIGHTS` / `SEC_RIGHTS_OWNER_RIGHTS`).

## Spec / reference

- MS-DTYP §2.5.3 — DACL evaluation algorithm.
- MS-DTYP §2.4.10 — Well-known SIDs (S-1-3-4 = `OWNER_RIGHTS`).
- Samba `libcli/security/access_check.c::se_access_check`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/metadata/acl/...` — new tests pass, existing pass.
- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/...` — no regressions.
- [ ] CI: full unit/integration suite.
- [ ] CI: smbtorture (see expected flips below).

New unit tests in `pkg/metadata/acl/evaluate_test.go`:

- `TestEvaluate_OwnerRights_SuppressesOwnerAce` — `OWNER_RIGHTS` Allow READ + `OWNER@` Allow WRITE ⇒ owner gets READ only.
- `TestEvaluate_OwnerRights_DenyOverridesOwnerAllow` — `OWNER_RIGHTS` Deny WRITE + `OWNER@` Allow FULL ⇒ owner denied WRITE; READ allowed via `OWNER_RIGHTS` Allow placed before the Deny.
- `TestEvaluate_NoOwnerRights_OwnerAceStillAuthoritative` — regression: no `OWNER_RIGHTS` ⇒ `OWNER@` Allow FULL still grants the owner everything.
- `TestEvaluate_OwnerRights_NonOwnerUnaffected` — non-owner observes normal semantics; only owner sees the `OWNER_RIGHTS` override.

## Expected smbtorture flips

- `smb2.acls.OWNER-RIGHTS`
- `smb2.acls.OWNER-RIGHTS-DENY`
- `smb2.acls.OWNER-RIGHTS-DENY1`

**Caveat:** This PR fixes only the *evaluation* semantics. The tests assert that the server actually denies opens whose `DesiredAccess` is not granted by the DACL; that wiring is tracked in **#529** (DACL enforcement on `DesiredAccess`). The two PRs are complementary — once #529 lands, this PR provides the correct denial outcome for the `OWNER_RIGHTS` DENY cases. Per the issue's scope statement, GENERIC mask mapping (#530) is out of scope here.

## Refs

- #531, #529, #530, #525, #499.