### PR TITLE
fix(smb): expand GENERIC_* access bits per MS-DTYP §2.4.3 (#530)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -175,13 +175,13 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 	}
 
 	r := smbenc.NewReader(body)
-	r.Skip(2)                                                    // StructureSize (2)
-	r.Skip(1)                                                    // SecurityFlags (1)
-	oplockLevel := r.ReadUint8()                                 // OplockLevel (1)
-	impersonationLevel := r.ReadUint32()                         // ImpersonationLevel (4)
-	r.Skip(8)                                                    // SmbCreateFlags (8)
-	r.Skip(8)                                                    // Reserved (8)
-	desiredAccess := r.ReadUint32() // DesiredAccess (4)
+	r.Skip(2)                            // StructureSize (2)
+	r.Skip(1)                            // SecurityFlags (1)
+	oplockLevel := r.ReadUint8()         // OplockLevel (1)
+	impersonationLevel := r.ReadUint32() // ImpersonationLevel (4)
+	r.Skip(8)                            // SmbCreateFlags (8)
+	r.Skip(8)                            // Reserved (8)
+	desiredAccess := r.ReadUint32()      // DesiredAccess (4)
 	// Per MS-DTYP §2.4.3 / §2.5.3, GENERIC_* bits in DesiredAccess MUST be
 	// expanded to file-object-specific rights before access-check
 	// evaluation. Do it at decode time so every downstream consumer

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -181,7 +181,13 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 	impersonationLevel := r.ReadUint32()                         // ImpersonationLevel (4)
 	r.Skip(8)                                                    // SmbCreateFlags (8)
 	r.Skip(8)                                                    // Reserved (8)
-	desiredAccess := r.ReadUint32()                              // DesiredAccess (4)
+	desiredAccess := r.ReadUint32() // DesiredAccess (4)
+	// Per MS-DTYP §2.4.3 / §2.5.3, GENERIC_* bits in DesiredAccess MUST be
+	// expanded to file-object-specific rights before access-check
+	// evaluation. Do it at decode time so every downstream consumer
+	// (permission checks, share-mode conflict, MxAc, OpenFile bookkeeping)
+	// observes resolved bits.
+	desiredAccess = acl.ExpandGenericMask(desiredAccess)
 	fileAttributes := types.FileAttributes(r.ReadUint32())       // FileAttributes (4)
 	shareAccess := r.ReadUint32()                                // ShareAccess (4)
 	createDisposition := types.CreateDisposition(r.ReadUint32()) // CreateDisposition (4)
@@ -1035,12 +1041,20 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 		}
 		evalCtx := buildMaxAccessEvalContext(file, authCtx)
 		var granted uint32
+		// maxAccessProbeBits is already file-object-specific (NFSv4 ACE4_*
+		// shares bit positions with Windows file rights — see comment on
+		// maxAccessProbeBits). ExpandGenericMask is applied defensively so
+		// that any future additions to the probe set with GENERIC_* bits
+		// are normalized per MS-DTYP §2.5.3 before evaluation.
 		for _, bit := range maxAccessProbeBits {
-			if acl.Evaluate(file.ACL, evalCtx, bit) {
-				granted |= bit
+			probe := acl.ExpandGenericMask(bit)
+			if acl.Evaluate(file.ACL, evalCtx, probe) {
+				granted |= probe
 			}
 		}
-		return granted
+		// Result also expanded for defense-in-depth: per MS-DTYP §2.5.3
+		// the MaximalAccess reply must contain only resolved rights.
+		return acl.ExpandGenericMask(granted)
 	}
 
 	// Check if the requesting user is the file owner

--- a/internal/adapter/smb/v2/handlers/security.go
+++ b/internal/adapter/smb/v2/handlers/security.go
@@ -544,10 +544,14 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 		// Convert SID to NFSv4 principal
 		who := defaultSIDMapper.SIDToPrincipal(s)
 
+		// Expand GENERIC_* bits to file-object-specific rights per
+		// MS-DTYP §2.4.3 / §2.5.3 before storing. Generic rights MUST
+		// be mapped at the SD-update boundary so subsequent access checks
+		// (MS-FSA §2.1.5.1.2.1) operate on resolved masks.
 		aces = append(aces, acl.ACE{
 			Type:       nfsACEType,
 			Flag:       acl.WindowsFlagsToNFSv4Flags(aceFlags),
-			AccessMask: accessMask,
+			AccessMask: acl.ExpandGenericMask(accessMask),
 			Who:        who,
 		})
 

--- a/internal/adapter/smb/v2/handlers/security_test.go
+++ b/internal/adapter/smb/v2/handlers/security_test.go
@@ -1276,3 +1276,94 @@ func TestParseSD_NoCanonicalization_PreservesAutoInherited(t *testing.T) {
 		})
 	}
 }
+
+// makeSDWithACEMask hand-crafts a self-relative SD containing a single
+// ALLOW-EVERYONE ACE with the given raw AccessMask on the wire. Used to
+// exercise the GENERIC_* expansion path through parseDACL.
+func makeSDWithACEMask(t *testing.T, accessMask uint32) []byte {
+	t.Helper()
+	everyoneSID := sid.WellKnownEveryone
+	sidLen := sid.SIDSize(everyoneSID)
+	aceLen := aceHeaderSize + sidLen
+	daclLen := aclHeaderSize + aceLen
+	totalLen := sdHeaderSize + daclLen
+	buf := make([]byte, totalLen)
+	buf[0] = 1
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(seSelfRelative|seDACLPresent))
+	binary.LittleEndian.PutUint32(buf[16:20], sdHeaderSize)
+	buf[20] = 2
+	binary.LittleEndian.PutUint16(buf[22:24], uint16(daclLen))
+	binary.LittleEndian.PutUint16(buf[24:26], 1)
+	aceOff := sdHeaderSize + aclHeaderSize
+	buf[aceOff] = accessAllowedACEType
+	binary.LittleEndian.PutUint16(buf[aceOff+2:aceOff+4], uint16(aceLen))
+	binary.LittleEndian.PutUint32(buf[aceOff+4:aceOff+8], accessMask)
+	var sidBuf bytes.Buffer
+	sid.EncodeSID(&sidBuf, everyoneSID)
+	copy(buf[aceOff+aceHeaderSize:], sidBuf.Bytes())
+	return buf
+}
+
+// TestParseSD_ExpandsGenericMaskInACE verifies that SET_INFO Security
+// parsing (via parseDACL) expands GENERIC_* access bits to file-object
+// specific rights per MS-DTYP §2.4.3 / §2.5.3 before storage. Generic bits
+// must not survive past the SD boundary — every downstream ACL evaluation
+// (MS-FSA §2.1.5.1.2.1) operates on resolved masks.
+//
+// Failing test driver: smb2.acls.GENERIC (source4/torture/smb2/acls.c:440).
+func TestParseSD_ExpandsGenericMaskInACE(t *testing.T) {
+	const (
+		genericRead    = uint32(0x80000000)
+		genericWrite   = uint32(0x40000000)
+		genericExecute = uint32(0x20000000)
+		genericAll     = uint32(0x10000000)
+
+		readExpanded    = uint32(0x00120089)
+		writeExpanded   = uint32(0x00120116)
+		executeExpanded = uint32(0x001200A0)
+		allExpanded     = uint32(0x001F01FF)
+	)
+
+	cases := []struct {
+		name string
+		wire uint32
+		want uint32
+	}{
+		{"GENERIC_READ", genericRead, readExpanded},
+		{"GENERIC_WRITE", genericWrite, writeExpanded},
+		{"GENERIC_EXECUTE", genericExecute, executeExpanded},
+		{"GENERIC_ALL", genericAll, allExpanded},
+		{
+			"GENERIC_READ | DELETE preserves DELETE",
+			genericRead | 0x00010000,
+			readExpanded | 0x00010000,
+		},
+		{
+			"specific-rights-only passes through unchanged",
+			0x00000001 | 0x00000080, // FILE_READ_DATA | FILE_READ_ATTRIBUTES
+			0x00000001 | 0x00000080,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sd := makeSDWithACEMask(t, tc.wire)
+			_, _, parsed, err := ParseSecurityDescriptor(sd)
+			if err != nil {
+				t.Fatalf("ParseSecurityDescriptor: %v", err)
+			}
+			if parsed == nil || len(parsed.ACEs) != 1 {
+				t.Fatalf("expected 1 ACE, got %v", parsed)
+			}
+			got := parsed.ACEs[0].AccessMask
+			if got != tc.want {
+				t.Errorf("stored AccessMask = 0x%08x; want 0x%08x (wire=0x%08x)",
+					got, tc.want, tc.wire)
+			}
+			// Hard invariant: no generic bits survive past parse.
+			if got&0xF0000000 != 0 {
+				t.Errorf("GENERIC bits leaked into stored ACE: 0x%08x", got&0xF0000000)
+			}
+		})
+	}
+}

--- a/pkg/metadata/acl/generic.go
+++ b/pkg/metadata/acl/generic.go
@@ -1,0 +1,111 @@
+package acl
+
+// Generic access-mask bits (MS-DTYP §2.4.3 ACCESS_MASK). These must be
+// expanded into file-object-specific rights before the mask is stored in an
+// ACE or evaluated against a security descriptor (MS-DTYP §2.5.3,
+// MS-FSA §2.1.5.1.2.1).
+const (
+	genericRead    uint32 = 0x80000000
+	genericWrite   uint32 = 0x40000000
+	genericExecute uint32 = 0x20000000
+	genericAll     uint32 = 0x10000000
+)
+
+// File-object specific rights and standard rights used by the expansion
+// table. Values match the NFSv4 ACE4_* and Windows file-object masks (which
+// share bit positions for the rights covered here).
+const (
+	fileReadData        uint32 = 0x00000001
+	fileWriteData       uint32 = 0x00000002
+	fileAppendData      uint32 = 0x00000004
+	fileReadEA          uint32 = 0x00000008
+	fileWriteEA         uint32 = 0x00000010
+	fileExecute         uint32 = 0x00000020
+	fileReadAttributes  uint32 = 0x00000080
+	fileWriteAttributes uint32 = 0x00000100
+
+	// Standard rights (MS-DTYP §2.4.3). For file objects:
+	//   STANDARD_RIGHTS_READ    = READ_CONTROL
+	//   STANDARD_RIGHTS_WRITE   = READ_CONTROL
+	//   STANDARD_RIGHTS_EXECUTE = READ_CONTROL
+	standardRightsRead    uint32 = 0x00020000 // READ_CONTROL
+	standardRightsWrite   uint32 = 0x00020000 // READ_CONTROL
+	standardRightsExecute uint32 = 0x00020000 // READ_CONTROL
+
+	synchronize uint32 = 0x00100000
+
+	// FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED (0x000F0000) |
+	//                   SYNCHRONIZE (0x00100000) |
+	//                   all file-specific rights (0x000001FF)
+	fileAllAccess uint32 = 0x001F01FF
+)
+
+// Expanded file-object masks per MS-DTYP §2.4.3 GenericMapping (the table
+// used by NTFS / SMB for file objects; matches the smbtorture
+// smb2.acls.GENERIC expectation and Samba's mapping).
+const (
+	genericReadFile = fileReadData |
+		fileReadAttributes |
+		fileReadEA |
+		standardRightsRead |
+		synchronize
+
+	genericWriteFile = fileWriteData |
+		fileWriteAttributes |
+		fileWriteEA |
+		fileAppendData |
+		standardRightsWrite |
+		synchronize
+
+	genericExecuteFile = fileReadAttributes |
+		fileExecute |
+		standardRightsExecute |
+		synchronize
+
+	genericAllFile = fileAllAccess
+)
+
+// ExpandGenericMask expands MS-DTYP GENERIC_* access bits to their
+// file-object-specific equivalents per MS-DTYP §2.4.3 GenericMapping.
+//
+// Mapping (file objects):
+//
+//	GENERIC_READ (0x80000000)    -> FILE_READ_DATA | FILE_READ_ATTRIBUTES |
+//	                                FILE_READ_EA | STANDARD_RIGHTS_READ |
+//	                                SYNCHRONIZE                              (0x00120089)
+//	GENERIC_WRITE (0x40000000)   -> FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES |
+//	                                FILE_WRITE_EA | FILE_APPEND_DATA |
+//	                                STANDARD_RIGHTS_WRITE | SYNCHRONIZE      (0x00120116)
+//	GENERIC_EXECUTE (0x20000000) -> FILE_READ_ATTRIBUTES | FILE_EXECUTE |
+//	                                STANDARD_RIGHTS_EXECUTE | SYNCHRONIZE    (0x001200A0)
+//	GENERIC_ALL (0x10000000)     -> FILE_ALL_ACCESS                          (0x001F01FF)
+//
+// Generic bits are stripped from the returned mask after expansion: a
+// post-mapping ACCESS_MASK must contain only specific rights (MS-DTYP
+// §2.5.3). Bits unrelated to the generic set pass through unchanged.
+//
+// Per MS-DTYP §2.5.3 / MS-FSA §2.1.5.1.2.1, this expansion MUST be applied:
+//   - at SET_INFO Security on each ACE AccessMask before persisting;
+//   - on SMB CREATE DesiredAccess before access-check evaluation;
+//   - on the probe set and result of any MaximalAccess computation.
+func ExpandGenericMask(mask uint32) uint32 {
+	expanded := mask
+
+	if expanded&genericRead != 0 {
+		expanded |= genericReadFile
+	}
+	if expanded&genericWrite != 0 {
+		expanded |= genericWriteFile
+	}
+	if expanded&genericExecute != 0 {
+		expanded |= genericExecuteFile
+	}
+	if expanded&genericAll != 0 {
+		expanded |= genericAllFile
+	}
+
+	// Strip the generic bits — only specific rights remain (MS-DTYP §2.5.3).
+	expanded &^= genericRead | genericWrite | genericExecute | genericAll
+
+	return expanded
+}

--- a/pkg/metadata/acl/generic.go
+++ b/pkg/metadata/acl/generic.go
@@ -11,58 +11,65 @@ const (
 	genericAll     uint32 = 0x10000000
 )
 
-// File-object specific rights and standard rights used by the expansion
-// table. Values match the NFSv4 ACE4_* and Windows file-object masks (which
-// share bit positions for the rights covered here).
-const (
-	fileReadData        uint32 = 0x00000001
-	fileWriteData       uint32 = 0x00000002
-	fileAppendData      uint32 = 0x00000004
-	fileReadEA          uint32 = 0x00000008
-	fileWriteEA         uint32 = 0x00000010
-	fileExecute         uint32 = 0x00000020
-	fileReadAttributes  uint32 = 0x00000080
-	fileWriteAttributes uint32 = 0x00000100
-
-	// Standard rights (MS-DTYP §2.4.3). For file objects:
-	//   STANDARD_RIGHTS_READ    = READ_CONTROL
-	//   STANDARD_RIGHTS_WRITE   = READ_CONTROL
-	//   STANDARD_RIGHTS_EXECUTE = READ_CONTROL
-	standardRightsRead    uint32 = 0x00020000 // READ_CONTROL
-	standardRightsWrite   uint32 = 0x00020000 // READ_CONTROL
-	standardRightsExecute uint32 = 0x00020000 // READ_CONTROL
-
-	synchronize uint32 = 0x00100000
-
-	// FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED (0x000F0000) |
-	//                   SYNCHRONIZE (0x00100000) |
-	//                   all file-specific rights (0x000001FF)
-	fileAllAccess uint32 = 0x001F01FF
-)
-
 // Expanded file-object masks per MS-DTYP §2.4.3 GenericMapping (the table
 // used by NTFS / SMB for file objects; matches the smbtorture
 // smb2.acls.GENERIC expectation and Samba's mapping).
+//
+// File-object specific rights and standard rights share bit positions with
+// the NFSv4 ACE4_* constants from types.go (MS-DTYP and NFSv4 deliberately
+// align here), so the mapping is expressed directly in ACE4_* terms.
+//
+// For file objects the three standard-rights aliases collapse to READ_CONTROL
+// (= ACE4_READ_ACL, 0x00020000), which is why GENERIC_READ/WRITE/EXECUTE all
+// contribute the same READ_CONTROL bit.
 const (
-	genericReadFile = fileReadData |
-		fileReadAttributes |
-		fileReadEA |
-		standardRightsRead |
-		synchronize
+	// GENERIC_READ -> FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES |
+	//                 READ_CONTROL  | SYNCHRONIZE                 (0x00120089)
+	genericReadFile = ACE4_READ_DATA |
+		ACE4_READ_NAMED_ATTRS |
+		ACE4_READ_ATTRIBUTES |
+		ACE4_READ_ACL | // STANDARD_RIGHTS_READ == READ_CONTROL
+		ACE4_SYNCHRONIZE
 
-	genericWriteFile = fileWriteData |
-		fileWriteAttributes |
-		fileWriteEA |
-		fileAppendData |
-		standardRightsWrite |
-		synchronize
+	// GENERIC_WRITE -> FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA |
+	//                  FILE_WRITE_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE
+	//                                                                (0x00120116)
+	genericWriteFile = ACE4_WRITE_DATA |
+		ACE4_APPEND_DATA |
+		ACE4_WRITE_NAMED_ATTRS |
+		ACE4_WRITE_ATTRIBUTES |
+		ACE4_READ_ACL | // STANDARD_RIGHTS_WRITE == READ_CONTROL
+		ACE4_SYNCHRONIZE
 
-	genericExecuteFile = fileReadAttributes |
-		fileExecute |
-		standardRightsExecute |
-		synchronize
+	// GENERIC_EXECUTE -> FILE_READ_ATTRIBUTES | FILE_EXECUTE |
+	//                    READ_CONTROL | SYNCHRONIZE              (0x001200A0)
+	genericExecuteFile = ACE4_READ_ATTRIBUTES |
+		ACE4_EXECUTE |
+		ACE4_READ_ACL | // STANDARD_RIGHTS_EXECUTE == READ_CONTROL
+		ACE4_SYNCHRONIZE
 
-	genericAllFile = fileAllAccess
+	// GENERIC_ALL -> FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED (0x000F0000) |
+	//                SYNCHRONIZE (0x00100000) |
+	//                all file-specific rights (0x000001FF)         (0x001F01FF)
+	//
+	// STANDARD_RIGHTS_REQUIRED = DELETE | READ_CONTROL | WRITE_DAC | WRITE_OWNER.
+	// File-specific bits 0x000001FF cover READ_DATA, WRITE_DATA, APPEND_DATA,
+	// READ_NAMED_ATTRS, WRITE_NAMED_ATTRS, EXECUTE, DELETE_CHILD,
+	// READ_ATTRIBUTES, WRITE_ATTRIBUTES.
+	genericAllFile = ACE4_DELETE |
+		ACE4_READ_ACL |
+		ACE4_WRITE_ACL |
+		ACE4_WRITE_OWNER |
+		ACE4_SYNCHRONIZE |
+		ACE4_READ_DATA |
+		ACE4_WRITE_DATA |
+		ACE4_APPEND_DATA |
+		ACE4_READ_NAMED_ATTRS |
+		ACE4_WRITE_NAMED_ATTRS |
+		ACE4_EXECUTE |
+		ACE4_DELETE_CHILD |
+		ACE4_READ_ATTRIBUTES |
+		ACE4_WRITE_ATTRIBUTES
 )
 
 // ExpandGenericMask expands MS-DTYP GENERIC_* access bits to their

--- a/pkg/metadata/acl/generic_test.go
+++ b/pkg/metadata/acl/generic_test.go
@@ -1,0 +1,113 @@
+package acl
+
+import "testing"
+
+func TestExpandGenericMask(t *testing.T) {
+	const (
+		genReadExpanded    = uint32(0x00120089) // FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE
+		genWriteExpanded   = uint32(0x00120116) // FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA | FILE_WRITE_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE
+		genExecuteExpanded = uint32(0x001200A0) // FILE_EXECUTE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE
+		genAllExpanded     = uint32(0x001F01FF) // FILE_ALL_ACCESS
+	)
+
+	tests := []struct {
+		name string
+		in   uint32
+		want uint32
+	}{
+		{"zero", 0, 0},
+		{"GENERIC_READ only", 0x80000000, genReadExpanded},
+		{"GENERIC_WRITE only", 0x40000000, genWriteExpanded},
+		{"GENERIC_EXECUTE only", 0x20000000, genExecuteExpanded},
+		{"GENERIC_ALL only", 0x10000000, genAllExpanded},
+		{
+			"GENERIC_READ | GENERIC_WRITE",
+			0x80000000 | 0x40000000,
+			genReadExpanded | genWriteExpanded,
+		},
+		{
+			"GENERIC_READ | GENERIC_EXECUTE",
+			0x80000000 | 0x20000000,
+			genReadExpanded | genExecuteExpanded,
+		},
+		{
+			"all four generic bits",
+			0x80000000 | 0x40000000 | 0x20000000 | 0x10000000,
+			genReadExpanded | genWriteExpanded | genExecuteExpanded | genAllExpanded,
+		},
+		{
+			"GENERIC_ALL == FILE_ALL_ACCESS",
+			0x10000000,
+			0x001F01FF,
+		},
+		{
+			"non-generic specific bit (FILE_READ_DATA) passes through",
+			0x00000001,
+			0x00000001,
+		},
+		{
+			"non-generic specific bits (DELETE | WRITE_DAC) pass through",
+			0x00010000 | 0x00040000,
+			0x00010000 | 0x00040000,
+		},
+		{
+			"MAXIMUM_ALLOWED is not generic — passes through",
+			0x02000000,
+			0x02000000,
+		},
+		{
+			"ACCESS_SYSTEM_SECURITY is not generic — passes through",
+			0x01000000,
+			0x01000000,
+		},
+		{
+			"GENERIC_READ combined with explicit DELETE",
+			0x80000000 | 0x00010000,
+			genReadExpanded | 0x00010000,
+		},
+		{
+			"GENERIC bits are stripped after expansion",
+			0x80000000,
+			genReadExpanded, // GENERIC_READ bit must NOT remain
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExpandGenericMask(tc.in)
+			if got != tc.want {
+				t.Errorf("ExpandGenericMask(0x%08x) = 0x%08x; want 0x%08x",
+					tc.in, got, tc.want)
+			}
+			// Post-condition: no generic bits remain.
+			const genericBits = uint32(0xF0000000)
+			if got&genericBits != 0 {
+				t.Errorf("ExpandGenericMask(0x%08x) leaked generic bits: 0x%08x",
+					tc.in, got&genericBits)
+			}
+		})
+	}
+}
+
+// TestExpandGenericMask_Idempotent verifies that expanding an already-
+// expanded mask is a no-op. Once generic bits are stripped, re-application
+// must produce the same value (callers that defensively re-expand at
+// multiple layers must not see drift).
+func TestExpandGenericMask_Idempotent(t *testing.T) {
+	inputs := []uint32{
+		0x80000000,
+		0x40000000,
+		0x20000000,
+		0x10000000,
+		0x80000000 | 0x40000000 | 0x20000000 | 0x10000000,
+		0x00000001 | 0x00010000,
+	}
+	for _, in := range inputs {
+		first := ExpandGenericMask(in)
+		second := ExpandGenericMask(first)
+		if first != second {
+			t.Errorf("ExpandGenericMask not idempotent for 0x%08x: first=0x%08x second=0x%08x",
+				in, first, second)
+		}
+	}
+}


### PR DESCRIPTION
Closes #530.

## Summary

Map MS-DTYP `GENERIC_READ` / `GENERIC_WRITE` / `GENERIC_EXECUTE` / `GENERIC_ALL` to file-object specific rights before either storing them in an ACE or evaluating them against a security descriptor. Previously DittoFS stored the raw generic bits and evaluated them as-is, producing `MaximalAccess = 0x001f01ff` instead of the expected `0x00070080` on `smb2.acls.GENERIC` (smbtorture `source4/torture/smb2/acls.c:440`).

## Spec

- MS-DTYP §2.4.3 (ACCESS_MASK, GenericMapping for file objects)
- MS-DTYP §2.5.3 (generic rights MUST be mapped before access check)
- MS-FSA §2.1.5.1.2.1 (SD evaluation uses mapped rights)
- Samba reference: `librpc/idl/security.idl` + `source3/smbd/open.c::map_canon_ace_perms`

## Changes

- `pkg/metadata/acl/generic.go` — new `ExpandGenericMask(uint32) uint32` helper. Generic bits stripped from output (only specific rights survive). Idempotent.
- `internal/adapter/smb/v2/handlers/security.go::parseDACL` — expands each parsed ACE's `AccessMask` before constructing the stored `acl.ACE`. SET_INFO Security now persists resolved rights.
- `internal/adapter/smb/v2/handlers/create.go::DecodeCreateRequest` — expands `DesiredAccess` at decode time so every downstream consumer (permission checks, share-mode conflict, `MxAc`, OpenFile bookkeeping) observes resolved bits. Sits naturally upstream of #529's `CheckFileAccess`.
- `internal/adapter/smb/v2/handlers/create.go::computeMaximalAccess` — expands the probe set and the result mask defensively, even though `maxAccessProbeBits` is currently specific-only.

## Tests

- Unit: `TestExpandGenericMask` covering all four generic bits, combinations, passthrough of specific-only and `MAXIMUM_ALLOWED` / `ACCESS_SYSTEM_SECURITY`, and idempotence.
- Integration: `TestParseSD_ExpandsGenericMaskInACE` — hand-crafted SD with a single ALLOW-EVERYONE ACE carrying `GENERIC_READ` (etc.) on the wire, parsed via `ParseSecurityDescriptor` → asserts stored bits are expanded and no generic bits leak past the parse boundary.

## Expected smbtorture flips

- `smb2.acls.GENERIC` (currently fails with `Incorrect access_flags 0x001f01ff - should be 0x00070080`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/...`
- [ ] CI smbtorture pass; verify `smb2.acls.GENERIC` flips to PASS

## Notes

- NFSv4 mask bits are file-specific by design (no GENERIC namespace) — NFS code intentionally untouched.
- Parallel work on #529 (DesiredAccess vs DACL enforcement), #531, #532 may textually conflict in `create.go::computeMaximalAccess` / DesiredAccess decode site; rebase as needed.
- KNOWN_FAILURES.md intentionally not touched (CI-confirmed flips workflow).