### PR TITLE
fix(smb): enforce DesiredAccess against file DACL on CREATE (#529)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -977,34 +977,6 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	return h.completeCreateAfterBreak(ctx, draft), nil
 }
 
-// maxAccessProbeBits is the set of MS-DTYP access-right bits probed against
-// a file's DACL when computing the MxAc create-context response. Per
-// MS-SMB2 §2.2.13.2, MaximalAccess must reflect actual security descriptor
-// evaluation — each bit is OR'd into the result iff the ACL explicitly
-// grants it to the requester. The set covers every ACE4_* file/dir right
-// that has a Windows access-mask analog per MS-DTYP §2.4.3; NFSv4 mask
-// bits share their bit positions with the equivalent Windows rights, so
-// the resulting mask is directly usable on the SMB2 wire. The NFSv4-only
-// retention bits (ACE4_WRITE_RETENTION = 0x200, ACE4_WRITE_RETENTION_HOLD
-// = 0x400) are intentionally excluded because they have no representation
-// in SMB access masks.
-var maxAccessProbeBits = [...]uint32{
-	acl.ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
-	acl.ACE4_WRITE_DATA,
-	acl.ACE4_APPEND_DATA,
-	acl.ACE4_READ_NAMED_ATTRS,
-	acl.ACE4_WRITE_NAMED_ATTRS,
-	acl.ACE4_EXECUTE,
-	acl.ACE4_DELETE_CHILD,
-	acl.ACE4_READ_ATTRIBUTES,
-	acl.ACE4_WRITE_ATTRIBUTES,
-	acl.ACE4_DELETE,
-	acl.ACE4_READ_ACL,
-	acl.ACE4_WRITE_ACL,
-	acl.ACE4_WRITE_OWNER,
-	acl.ACE4_SYNCHRONIZE,
-}
-
 // computeMaximalAccess computes the maximal access mask for a file used in
 // the MxAc create-context response.
 //
@@ -1041,12 +1013,11 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 		}
 		evalCtx := buildMaxAccessEvalContext(file, authCtx)
 		var granted uint32
-		// maxAccessProbeBits is already file-object-specific (NFSv4 ACE4_*
-		// shares bit positions with Windows file rights — see comment on
-		// maxAccessProbeBits). ExpandGenericMask is applied defensively so
-		// that any future additions to the probe set with GENERIC_* bits
-		// are normalized per MS-DTYP §2.5.3 before evaluation.
-		for _, bit := range maxAccessProbeBits {
+		// acl.ProbeBitsAll is the shared probe set (mirrors
+		// metadata.CheckFileAccess). ExpandGenericMask is applied defensively
+		// so any future additions with GENERIC_* bits are normalized per
+		// MS-DTYP §2.5.3 before evaluation.
+		for _, bit := range acl.ProbeBitsAll {
 			probe := acl.ExpandGenericMask(bit)
 			if acl.Evaluate(file.ACL, evalCtx, probe) {
 				granted |= probe

--- a/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
@@ -1,0 +1,335 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// Handler-level coverage for the #529 DACL enforcement gate on CREATE.
+//
+// The unit tests for MetadataService.CheckFileAccess (in pkg/metadata) exercise
+// the helper in isolation. These tests close the loop at the SMB handler layer:
+// they construct a fully-populated createDraft, invoke completeCreateAfterBreak
+// directly, and assert the on-wire CreateResponse.Status matches the expected
+// per-bit-DACL outcome.
+//
+// completeCreateAfterBreak is the call-site where CheckFileAccess runs, so
+// driving it directly with a pre-set draft (skipping the lease-break / async
+// park plumbing that lives upstream in Create()) is the minimal handler-level
+// exercise that still covers the integration: draft → DACL gate → response.
+
+// setupDaclTest stands up a Handler with an in-memory metadata store, a single
+// share, a parent directory, and returns a SMBHandlerContext / parent handle
+// pair the test can use to seed the file under test.
+func setupDaclTest(t *testing.T) (*Handler, *runtime.Runtime, *SMBHandlerContext, metadata.FileHandle, *metadata.AuthContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	shareName := "/dacl-test"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "test-meta",
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	rootUID := uint32(0)
+	rootGID := uint32(0)
+	rootAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &rootUID,
+			GID: &rootGID,
+		},
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	smbCtx := &SMBHandlerContext{
+		SessionID: 1,
+		TreeID:    1,
+		ShareName: shareName,
+	}
+
+	return h, rt, smbCtx, rootHandle, rootAuth
+}
+
+// makeDraft assembles a createDraft for an existing file under the given
+// parent. The draft mirrors what Create() would have produced after path
+// resolution + the pre-break share-mode check, ready for
+// completeCreateAfterBreak.
+func makeDraft(
+	t *testing.T,
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	existingFile *metadata.File,
+	baseName string,
+	desiredAccess uint32,
+) *createDraft {
+	t.Helper()
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			ShareAccess:       0x07, // R|W|D
+			CreateDisposition: types.FileOpen,
+			CreateOptions:     0,
+		},
+		tree:           tree,
+		authCtx:        authCtx,
+		filename:       baseName,
+		baseName:       baseName,
+		parentHandle:   parentHandle,
+		existingFile:   existingFile,
+		existingHandle: encHandle,
+		fileExists:     true,
+		createAction:   types.FileOpened,
+	}
+}
+
+// TestCreate_DaclEnforcement_DeniesWhenBitNotGranted covers Copilot review
+// case (1): a CREATE on a file whose DACL denies the requested bits must
+// fail with STATUS_ACCESS_DENIED.
+func TestCreate_DaclEnforcement_DeniesWhenBitNotGranted(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// DACL: ALLOW READ_DATA to requester only — no WRITE.
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "deny.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999, // not the requester
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	// Request WRITE_DATA — not in the DACL. Expect STATUS_ACCESS_DENIED.
+	const rightWriteData uint32 = 0x00000002
+	draft := makeDraft(t, tree, requesterAuth, rootHandle, existingFile, "deny.txt", rightWriteData)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("WRITE on read-only DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+}
+
+// TestCreate_DaclEnforcement_AllowsWhenBitGranted covers Copilot review
+// case (2): a CREATE on a file whose DACL allows the requested bits must
+// succeed (STATUS_SUCCESS).
+func TestCreate_DaclEnforcement_AllowsWhenBitGranted(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	allowACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "allow.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  allowACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	// Request READ_DATA — allowed by the DACL. Expect STATUS_SUCCESS.
+	const rightReadData uint32 = 0x00000001
+	draft := makeDraft(t, tree, requesterAuth, rootHandle, existingFile, "allow.txt", rightReadData)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("READ on allow-read DACL: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}
+
+// TestCreate_DaclEnforcement_MaximumAllowedNeverDenies covers Copilot review
+// case (3): MAXIMUM_ALLOWED on a restrictive DACL must NOT fail the open. The
+// CREATE succeeds and the handle's effective access reflects what the DACL
+// actually grants (a subset of what the requester would otherwise want).
+func TestCreate_DaclEnforcement_MaximumAllowedNeverDenies(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// DACL allows only READ_DATA — WRITE/DELETE/etc are not granted.
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA,
+			},
+		},
+	}
+	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "max.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	// MAXIMUM_ALLOWED — must never deny even though the DACL grants almost
+	// nothing.
+	const rightMaxAllowed uint32 = 0x02000000
+	draft := makeDraft(t, tree, requesterAuth, rootHandle, existingFile, "max.txt", rightMaxAllowed)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("MAXIMUM_ALLOWED on restrictive DACL: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}
+
+// TestCreate_DaclEnforcement_NilACLPermissive guards against the WPTS BVT
+// regression that triggered the post-PR rework: a file with no DACL must NOT
+// have any bits denied at the open gate, even for non-POSIX-rwx bits like
+// DELETE / WRITE_DAC / WRITE_OWNER. POSIX-mode enforcement happens later in
+// the per-op layer, not here.
+func TestCreate_DaclEnforcement_NilACLPermissive(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "no_dacl.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o600, // owner rw — but no DACL stored
+			UID:  9999,
+			GID:  9999,
+			// ACL: nil
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	requesterUID := uint32(2001)
+	requesterGID := uint32(2001)
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+		},
+	}
+
+	// Non-owner requesting DELETE | WRITE_DAC | WRITE_OWNER — bits the POSIX
+	// rwx mapping cannot encode. Pre-#529 server permitted these opens; the
+	// reworked gate must continue to permit them when there's no DACL.
+	const (
+		rightDelete     uint32 = 0x00010000
+		rightWriteDac   uint32 = 0x00040000
+		rightWriteOwner uint32 = 0x00080000
+	)
+	desired := rightDelete | rightWriteDac | rightWriteOwner
+	draft := makeDraft(t, tree, requesterAuth, rootHandle, existingFile, "no_dacl.txt", desired)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("nil-ACL high-namespace request: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -199,6 +199,27 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	}
 
+	// Step 6c-bis: Enforce DesiredAccess against the existing file's DACL.
+	//
+	// Per MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1, the server MUST evaluate
+	// the requested access bits against the object's security descriptor and
+	// fail the open with STATUS_ACCESS_DENIED when any non-MAXIMUM_ALLOWED bit
+	// is denied. New files (createAction == FileCreated) inherit their ACL from
+	// the parent at create time and don't need this check — parent write was
+	// already gated via CheckParentWriteAccess in Create(). Tracking #529.
+	metaSvc := h.Registry.GetMetadataService()
+	if fileExists && existingFile != nil {
+		granted, err := metaSvc.CheckFileAccess(existingFile, authCtx, req.DesiredAccess)
+		if err != nil {
+			logger.Debug("CREATE: DesiredAccess denied by DACL",
+				"path", filename,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"granted", fmt.Sprintf("0x%x", granted),
+				"error", err)
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
+		}
+	}
+
 	// Step 6d: Validate delete-on-close requirements per MS-FSA 2.1.5.1.2.1.
 	if req.CreateOptions&types.FileDeleteOnClose != 0 {
 		if !hasDeleteAccess(req.DesiredAccess) {
@@ -236,7 +257,6 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// Step 7: Perform create/open.
 	var file *metadata.File
 	var fileHandle metadata.FileHandle
-	metaSvc := h.Registry.GetMetadataService()
 	switch createAction {
 	case types.FileOpened:
 		file = existingFile

--- a/pkg/metadata/acl/probe.go
+++ b/pkg/metadata/acl/probe.go
@@ -1,0 +1,35 @@
+package acl
+
+// ProbeBitsAll is the canonical set of MS-DTYP access-right bits probed
+// against a file's DACL when computing effective access — for the SMB CREATE
+// MxAc create-context response and for MAXIMUM_ALLOWED enforcement.
+//
+// Per MS-SMB2 §2.2.13.2, MaximalAccess must reflect actual security descriptor
+// evaluation — each bit is OR'd into the result iff the ACL explicitly grants
+// it to the requester. The set covers every ACE4_* file/dir right that has a
+// Windows access-mask analog per MS-DTYP §2.4.3; NFSv4 mask bits share their
+// bit positions with the equivalent Windows rights, so the resulting mask is
+// directly usable on the SMB2 wire. The NFSv4-only retention bits
+// (ACE4_WRITE_RETENTION = 0x200, ACE4_WRITE_RETENTION_HOLD = 0x400) are
+// intentionally excluded because they have no representation in SMB access
+// masks.
+//
+// Kept here (rather than duplicated in pkg/metadata and internal/adapter/smb)
+// so the two consumers — metadata.CheckFileAccess (enforcement gate) and the
+// SMB handler computeMaximalAccess (MxAc reply) — cannot drift.
+var ProbeBitsAll = [...]uint32{
+	ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
+	ACE4_WRITE_DATA,
+	ACE4_APPEND_DATA,
+	ACE4_READ_NAMED_ATTRS,
+	ACE4_WRITE_NAMED_ATTRS,
+	ACE4_EXECUTE,
+	ACE4_DELETE_CHILD,
+	ACE4_READ_ATTRIBUTES,
+	ACE4_WRITE_ATTRIBUTES,
+	ACE4_DELETE,
+	ACE4_READ_ACL,
+	ACE4_WRITE_ACL,
+	ACE4_WRITE_OWNER,
+	ACE4_SYNCHRONIZE,
+}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -527,32 +527,30 @@ const (
 	// allowed and uses those as the granted access.
 	accessMaskMaximumAllowed uint32 = 0x02000000
 
-	// POSIX-fallback access masks, mirroring computeMaximalAccess in
-	// internal/adapter/smb/v2/handlers/create.go. Kept consistent so DACL
-	// nil → enforcement and MxAc reply agree. See PR #528 + issue #525 for
-	// the rationale on POSIX fallback over Windows-default synthesis at
-	// the enforcement layer.
+	// accessMaskPosixGenericAll is the Windows GENERIC_ALL bundle used for
+	// MAXIMUM_ALLOWED on the no-DACL path (root bypass + nil-ACL case). The
+	// numeric value is the same one computeMaximalAccess emits for an owner
+	// on the POSIX fallback in internal/adapter/smb/v2/handlers/create.go.
 	accessMaskPosixGenericAll uint32 = 0x001F01FF
-	accessMaskPosixRead       uint32 = 0x00120089
-	accessMaskPosixWrite      uint32 = 0x00120116
-	accessMaskPosixExecute    uint32 = 0x001200A0
-
-	// accessMaskMinAuthenticated is READ_CONTROL | SYNCHRONIZE — the floor
-	// granted to any authenticated requester even when POSIX mode bits would
-	// otherwise grant nothing. Mirrors computeMaximalAccess.
-	accessMaskMinAuthenticated uint32 = 0x00100000 | 0x00020000
 )
 
 // CheckFileAccess validates a CREATE DesiredAccess request against an
-// existing file's stored DACL (or POSIX mode bits when ACL == nil) per
-// MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1.
+// existing file's stored DACL per MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1.
 //
 // Returns the granted access mask. Behavior:
 //
-//   - Root bypass (UID 0): returns desiredAccess as granted.
-//   - file.ACL == nil: POSIX fallback (owner=ALL, group/other from mode bits),
-//     identical to computeMaximalAccess in create.go so the MxAc reply and the
-//     enforcement gate agree. AND'd with desiredAccess.
+//   - Root bypass (UID 0): returns desiredAccess as granted; MAXIMUM_ALLOWED
+//     resolves to GENERIC_ALL.
+//   - file.ACL == nil: NO DACL-level enforcement. Per MS-DTYP §2.5.3 a NULL
+//     DACL grants every right to every principal; per MS-FSA the access check
+//     against the security descriptor is only meaningful when an SD exists.
+//     We mirror that: return the requested set (minus MAXIMUM_ALLOWED itself)
+//     as granted. POSIX semantics (mode-bit enforcement on read/write/delete)
+//     remain enforced by the metadata operation layer downstream of CREATE;
+//     this is the open-time gate only, and it must not deny opens that the
+//     pre-#529 server permitted (load-bearing for WPTS BVT, smb2.create.multi,
+//     and DELETE/WRITE_DAC/WRITE_OWNER requests that the POSIX rwx mapping
+//     cannot encode).
 //   - file.ACL != nil: per-requested-bit acl.Evaluate; only the bits the DACL
 //     explicitly allows are granted. EVERYONE@/OWNER@/GROUP@/SID-form ACEs
 //     resolve via the same EvaluateContext shape as evaluateACLPermissions.
@@ -569,87 +567,70 @@ const (
 // out of scope here — those are tracked separately under #530/#531/#532.
 func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
 	maximumAllowed := desiredAccess&accessMaskMaximumAllowed != 0
+	explicit := desiredAccess &^ accessMaskMaximumAllowed
 
 	// Root bypass: identical semantics to computeMaximalAccess and
 	// evaluateACLPermissions. UID 0 gets everything; MAXIMUM_ALLOWED resolves
 	// to GENERIC_ALL.
 	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
 		if maximumAllowed {
-			return accessMaskPosixGenericAll, nil
+			return accessMaskPosixGenericAll | explicit, nil
 		}
-		return desiredAccess, nil
+		return explicit, nil
 	}
 
-	var granted uint32
-	if file.ACL != nil {
-		evalCtx := buildFileAccessEvalContext(file, authCtx)
-		// Per-bit probe: acl.Evaluate(mask, …) returns true only when ALL bits
-		// in mask are allowed, so we must probe each requested bit
-		// individually — anything else conflates per-bit DENY semantics.
-		probe := desiredAccess &^ accessMaskMaximumAllowed
-		for bit := uint32(1); bit != 0 && probe != 0; bit <<= 1 {
-			if probe&bit == 0 {
-				continue
-			}
-			if acl.Evaluate(file.ACL, evalCtx, bit) {
-				granted |= bit
-			}
-			probe &^= bit
+	// No DACL stored: nothing to enforce at the open gate. Grant the explicit
+	// set as-is; MAXIMUM_ALLOWED expands to GENERIC_ALL. Downstream metadata
+	// ops (read/write/delete/setattr) still apply their own POSIX-mode checks,
+	// so a per-op DENY for a non-owner with mode 0o600 still produces
+	// STATUS_ACCESS_DENIED at the operation level — just not at open.
+	if file.ACL == nil {
+		if maximumAllowed {
+			return accessMaskPosixGenericAll | explicit, nil
 		}
-	} else {
-		granted = posixFallbackAccessMask(file, authCtx) & (desiredAccess &^ accessMaskMaximumAllowed)
+		return explicit, nil
+	}
+
+	// DACL-present path: per-bit acl.Evaluate.
+	evalCtx := buildFileAccessEvalContext(file, authCtx)
+	var granted uint32
+	// Per-bit probe: acl.Evaluate(mask, …) returns true only when ALL bits in
+	// mask are allowed, so we must probe each requested bit individually —
+	// anything else conflates per-bit DENY semantics.
+	probe := explicit
+	for bit := uint32(1); bit != 0 && probe != 0; bit <<= 1 {
+		if probe&bit == 0 {
+			continue
+		}
+		if acl.Evaluate(file.ACL, evalCtx, bit) {
+			granted |= bit
+		}
+		probe &^= bit
 	}
 
 	if maximumAllowed {
 		// MAXIMUM_ALLOWED never denies. Compute the full set of bits the
 		// requester is allowed (independent of what they asked for, minus the
 		// MAXIMUM_ALLOWED bit itself) and return that as the granted mask.
-		// Mirrors computeMaximalAccess on the ACL path and the POSIX-fallback
-		// path so the handle's effective access matches the MxAc reply.
+		// Mirrors computeMaximalAccess so the handle's effective access
+		// matches the MxAc reply.
 		var effective uint32
-		if file.ACL != nil {
-			evalCtx := buildFileAccessEvalContext(file, authCtx)
-			for _, bit := range maxAccessProbeBits {
-				if acl.Evaluate(file.ACL, evalCtx, bit) {
-					effective |= bit
-				}
+		for _, bit := range acl.ProbeBitsAll {
+			if acl.Evaluate(file.ACL, evalCtx, bit) {
+				effective |= bit
 			}
-		} else {
-			effective = posixFallbackAccessMask(file, authCtx)
 		}
 		return effective | granted, nil
 	}
 
 	// Strict mode: any requested non-MAXIMUM_ALLOWED bit not granted = deny.
-	requestedExplicit := desiredAccess &^ accessMaskMaximumAllowed
-	if requestedExplicit != 0 && granted&requestedExplicit != requestedExplicit {
+	if explicit != 0 && granted&explicit != explicit {
 		return granted, &StoreError{
 			Code:    ErrAccessDenied,
 			Message: "desired access denied by file DACL",
 		}
 	}
 	return granted, nil
-}
-
-// maxAccessProbeBits is the set of MS-DTYP access-right bits probed against a
-// file's DACL when MAXIMUM_ALLOWED is requested. Mirrors create.go's identical
-// constant — kept in sync so CheckFileAccess and computeMaximalAccess agree on
-// the effective access reported for a handle.
-var maxAccessProbeBits = [...]uint32{
-	acl.ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
-	acl.ACE4_WRITE_DATA,
-	acl.ACE4_APPEND_DATA,
-	acl.ACE4_READ_NAMED_ATTRS,
-	acl.ACE4_WRITE_NAMED_ATTRS,
-	acl.ACE4_EXECUTE,
-	acl.ACE4_DELETE_CHILD,
-	acl.ACE4_READ_ATTRIBUTES,
-	acl.ACE4_WRITE_ATTRIBUTES,
-	acl.ACE4_DELETE,
-	acl.ACE4_READ_ACL,
-	acl.ACE4_WRITE_ACL,
-	acl.ACE4_WRITE_OWNER,
-	acl.ACE4_SYNCHRONIZE,
 }
 
 // buildFileAccessEvalContext mirrors evaluateACLPermissions's EvaluateContext
@@ -688,58 +669,4 @@ func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateC
 	evalCtx.GroupSIDs = identity.GroupSIDs
 
 	return evalCtx
-}
-
-// posixFallbackAccessMask computes the granted MS-DTYP access mask for a file
-// whose ACL is nil, using POSIX mode bits. Mirrors the POSIX branch of
-// computeMaximalAccess in internal/adapter/smb/v2/handlers/create.go so the
-// enforcement gate and the MxAc reply stay consistent.
-//
-// Owner gets GENERIC_ALL. Non-owners get a mask built from their applicable
-// permission bits (group or other), with a floor of READ_CONTROL | SYNCHRONIZE
-// for any authenticated user.
-func posixFallbackAccessMask(file *File, authCtx *AuthContext) uint32 {
-	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == file.UID {
-		return accessMaskPosixGenericAll
-	}
-
-	isGroupMember := false
-	if authCtx != nil && authCtx.Identity != nil {
-		if authCtx.Identity.GID != nil && *authCtx.Identity.GID == file.GID {
-			isGroupMember = true
-		}
-		if !isGroupMember {
-			for _, gid := range authCtx.Identity.GIDs {
-				if gid == file.GID {
-					isGroupMember = true
-					break
-				}
-			}
-		}
-	}
-
-	var permBits uint32
-	if isGroupMember {
-		permBits = (file.Mode >> 3) & 0x7
-	} else {
-		permBits = file.Mode & 0x7
-	}
-
-	var access uint32
-	if permBits&0x4 != 0 {
-		access |= accessMaskPosixRead
-	}
-	if permBits&0x2 != 0 {
-		access |= accessMaskPosixWrite
-	}
-	if permBits&0x1 != 0 {
-		access |= accessMaskPosixExecute
-	}
-
-	if access == 0 && authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil {
-		// Authenticated requester: floor at READ_CONTROL | SYNCHRONIZE.
-		access = accessMaskMinAuthenticated
-	}
-
-	return access
 }

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -514,3 +514,232 @@ func (s *MetadataService) checkReadPermission(ctx *AuthContext, handle FileHandl
 func (s *MetadataService) checkExecutePermission(ctx *AuthContext, handle FileHandle) error {
 	return s.checkPermission(ctx, handle, PermissionExecute, "execute permission denied")
 }
+
+// MS-DTYP access-right bits used by CheckFileAccess.
+//
+// Kept here (rather than importing the SMB types package) because permission
+// enforcement is protocol-agnostic and importing protocol packages from
+// metadata would invert the dependency. The numeric values are spec-fixed.
+const (
+	// accessMaskMaximumAllowed is MS-DTYP §2.4.3 MAXIMUM_ALLOWED.
+	// When set on a CREATE DesiredAccess request, the server MUST NOT deny
+	// the open — it computes and returns the bits the requester is actually
+	// allowed and uses those as the granted access.
+	accessMaskMaximumAllowed uint32 = 0x02000000
+
+	// POSIX-fallback access masks, mirroring computeMaximalAccess in
+	// internal/adapter/smb/v2/handlers/create.go. Kept consistent so DACL
+	// nil → enforcement and MxAc reply agree. See PR #528 + issue #525 for
+	// the rationale on POSIX fallback over Windows-default synthesis at
+	// the enforcement layer.
+	accessMaskPosixGenericAll uint32 = 0x001F01FF
+	accessMaskPosixRead       uint32 = 0x00120089
+	accessMaskPosixWrite      uint32 = 0x00120116
+	accessMaskPosixExecute    uint32 = 0x001200A0
+
+	// accessMaskMinAuthenticated is READ_CONTROL | SYNCHRONIZE — the floor
+	// granted to any authenticated requester even when POSIX mode bits would
+	// otherwise grant nothing. Mirrors computeMaximalAccess.
+	accessMaskMinAuthenticated uint32 = 0x00100000 | 0x00020000
+)
+
+// CheckFileAccess validates a CREATE DesiredAccess request against an
+// existing file's stored DACL (or POSIX mode bits when ACL == nil) per
+// MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1.
+//
+// Returns the granted access mask. Behavior:
+//
+//   - Root bypass (UID 0): returns desiredAccess as granted.
+//   - file.ACL == nil: POSIX fallback (owner=ALL, group/other from mode bits),
+//     identical to computeMaximalAccess in create.go so the MxAc reply and the
+//     enforcement gate agree. AND'd with desiredAccess.
+//   - file.ACL != nil: per-requested-bit acl.Evaluate; only the bits the DACL
+//     explicitly allows are granted. EVERYONE@/OWNER@/GROUP@/SID-form ACEs
+//     resolve via the same EvaluateContext shape as evaluateACLPermissions.
+//   - MAXIMUM_ALLOWED (0x02000000) in desiredAccess: never deny. The returned
+//     granted mask reflects what the DACL actually allows; the caller is
+//     expected to use it as the handle's effective access rights
+//     (MS-SMB2 §2.2.13.1 / §3.3.5.9 paragraph 8).
+//
+// Returns ErrAccessDenied as a *StoreError when MAXIMUM_ALLOWED is NOT set
+// and any requested bit is denied. Granted is always populated (even on
+// error) so callers can log what was/wasn't granted.
+//
+// GENERIC_*, OWNER_RIGHTS, and ACCESSBASED enumeration are intentionally
+// out of scope here — those are tracked separately under #530/#531/#532.
+func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
+	maximumAllowed := desiredAccess&accessMaskMaximumAllowed != 0
+
+	// Root bypass: identical semantics to computeMaximalAccess and
+	// evaluateACLPermissions. UID 0 gets everything; MAXIMUM_ALLOWED resolves
+	// to GENERIC_ALL.
+	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
+		if maximumAllowed {
+			return accessMaskPosixGenericAll, nil
+		}
+		return desiredAccess, nil
+	}
+
+	var granted uint32
+	if file.ACL != nil {
+		evalCtx := buildFileAccessEvalContext(file, authCtx)
+		// Per-bit probe: acl.Evaluate(mask, …) returns true only when ALL bits
+		// in mask are allowed, so we must probe each requested bit
+		// individually — anything else conflates per-bit DENY semantics.
+		probe := desiredAccess &^ accessMaskMaximumAllowed
+		for bit := uint32(1); bit != 0 && probe != 0; bit <<= 1 {
+			if probe&bit == 0 {
+				continue
+			}
+			if acl.Evaluate(file.ACL, evalCtx, bit) {
+				granted |= bit
+			}
+			probe &^= bit
+		}
+	} else {
+		granted = posixFallbackAccessMask(file, authCtx) & (desiredAccess &^ accessMaskMaximumAllowed)
+	}
+
+	if maximumAllowed {
+		// MAXIMUM_ALLOWED never denies. Compute the full set of bits the
+		// requester is allowed (independent of what they asked for, minus the
+		// MAXIMUM_ALLOWED bit itself) and return that as the granted mask.
+		// Mirrors computeMaximalAccess on the ACL path and the POSIX-fallback
+		// path so the handle's effective access matches the MxAc reply.
+		var effective uint32
+		if file.ACL != nil {
+			evalCtx := buildFileAccessEvalContext(file, authCtx)
+			for _, bit := range maxAccessProbeBits {
+				if acl.Evaluate(file.ACL, evalCtx, bit) {
+					effective |= bit
+				}
+			}
+		} else {
+			effective = posixFallbackAccessMask(file, authCtx)
+		}
+		return effective | granted, nil
+	}
+
+	// Strict mode: any requested non-MAXIMUM_ALLOWED bit not granted = deny.
+	requestedExplicit := desiredAccess &^ accessMaskMaximumAllowed
+	if requestedExplicit != 0 && granted&requestedExplicit != requestedExplicit {
+		return granted, &StoreError{
+			Code:    ErrAccessDenied,
+			Message: "desired access denied by file DACL",
+		}
+	}
+	return granted, nil
+}
+
+// maxAccessProbeBits is the set of MS-DTYP access-right bits probed against a
+// file's DACL when MAXIMUM_ALLOWED is requested. Mirrors create.go's identical
+// constant — kept in sync so CheckFileAccess and computeMaximalAccess agree on
+// the effective access reported for a handle.
+var maxAccessProbeBits = [...]uint32{
+	acl.ACE4_READ_DATA, // == ACE4_LIST_DIRECTORY
+	acl.ACE4_WRITE_DATA,
+	acl.ACE4_APPEND_DATA,
+	acl.ACE4_READ_NAMED_ATTRS,
+	acl.ACE4_WRITE_NAMED_ATTRS,
+	acl.ACE4_EXECUTE,
+	acl.ACE4_DELETE_CHILD,
+	acl.ACE4_READ_ATTRIBUTES,
+	acl.ACE4_WRITE_ATTRIBUTES,
+	acl.ACE4_DELETE,
+	acl.ACE4_READ_ACL,
+	acl.ACE4_WRITE_ACL,
+	acl.ACE4_WRITE_OWNER,
+	acl.ACE4_SYNCHRONIZE,
+}
+
+// buildFileAccessEvalContext mirrors evaluateACLPermissions's EvaluateContext
+// construction so per-bit ACL evaluation in CheckFileAccess produces the same
+// allow/deny decisions a downstream read/write permission check would later
+// produce against the same file. Kept private to the metadata package.
+func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateContext {
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		return &acl.EvaluateContext{
+			FileOwnerUID: file.UID,
+			FileOwnerGID: file.GID,
+		}
+	}
+
+	identity := authCtx.Identity
+	evalCtx := &acl.EvaluateContext{
+		UID:          *identity.UID,
+		GIDs:         identity.GIDs,
+		FileOwnerUID: file.UID,
+		FileOwnerGID: file.GID,
+	}
+	if identity.GID != nil {
+		evalCtx.GID = *identity.GID
+	}
+
+	switch {
+	case identity.Username != "" && identity.Domain != "":
+		evalCtx.Who = identity.Username + "@" + identity.Domain
+	case identity.Username != "":
+		evalCtx.Who = identity.Username
+	}
+
+	if identity.SID != nil {
+		evalCtx.SID = *identity.SID
+	}
+	evalCtx.GroupSIDs = identity.GroupSIDs
+
+	return evalCtx
+}
+
+// posixFallbackAccessMask computes the granted MS-DTYP access mask for a file
+// whose ACL is nil, using POSIX mode bits. Mirrors the POSIX branch of
+// computeMaximalAccess in internal/adapter/smb/v2/handlers/create.go so the
+// enforcement gate and the MxAc reply stay consistent.
+//
+// Owner gets GENERIC_ALL. Non-owners get a mask built from their applicable
+// permission bits (group or other), with a floor of READ_CONTROL | SYNCHRONIZE
+// for any authenticated user.
+func posixFallbackAccessMask(file *File, authCtx *AuthContext) uint32 {
+	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == file.UID {
+		return accessMaskPosixGenericAll
+	}
+
+	isGroupMember := false
+	if authCtx != nil && authCtx.Identity != nil {
+		if authCtx.Identity.GID != nil && *authCtx.Identity.GID == file.GID {
+			isGroupMember = true
+		}
+		if !isGroupMember {
+			for _, gid := range authCtx.Identity.GIDs {
+				if gid == file.GID {
+					isGroupMember = true
+					break
+				}
+			}
+		}
+	}
+
+	var permBits uint32
+	if isGroupMember {
+		permBits = (file.Mode >> 3) & 0x7
+	} else {
+		permBits = file.Mode & 0x7
+	}
+
+	var access uint32
+	if permBits&0x4 != 0 {
+		access |= accessMaskPosixRead
+	}
+	if permBits&0x2 != 0 {
+		access |= accessMaskPosixWrite
+	}
+	if permBits&0x1 != 0 {
+		access |= accessMaskPosixExecute
+	}
+
+	if access == 0 && authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil {
+		// Authenticated requester: floor at READ_CONTROL | SYNCHRONIZE.
+		access = accessMaskMinAuthenticated
+	}
+
+	return access
+}

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -200,10 +200,12 @@ func TestCheckFileAccess_RootBypassGetsEverything(t *testing.T) {
 	require.Equal(t, rightReadData|rightWriteData|rightDelete, granted)
 }
 
-// TestCheckFileAccess_NilACLPosixFallbackOwner covers the documented divergence
-// from buildDACL: when file.ACL == nil, enforcement uses POSIX mode bits (not
-// the synthesized Windows-default SD). Owner gets GENERIC_ALL.
-func TestCheckFileAccess_NilACLPosixFallbackOwner(t *testing.T) {
+// TestCheckFileAccess_NilACLOwnerGrantsRequested covers the nil-ACL path:
+// when file.ACL == nil there is no DACL to enforce at the open gate, so the
+// requested access bits are granted as-is. Downstream metadata operations
+// still apply POSIX-mode enforcement; CheckFileAccess gates only the SMB2
+// open, not the per-op read/write/delete.
+func TestCheckFileAccess_NilACLOwnerGrantsRequested(t *testing.T) {
 	f := newTestFixture(t)
 
 	ownerUID := uint32(1001)
@@ -213,7 +215,7 @@ func TestCheckFileAccess_NilACLPosixFallbackOwner(t *testing.T) {
 			Mode: 0o600,
 			UID:  ownerUID,
 			GID:  1001,
-			// ACL: nil — POSIX fallback path.
+			// ACL: nil — no DACL to enforce.
 		})
 	require.NoError(t, err)
 
@@ -221,13 +223,17 @@ func TestCheckFileAccess_NilACLPosixFallbackOwner(t *testing.T) {
 
 	granted, err := f.service.CheckFileAccess(created, authCtx, rightReadData|rightWriteData)
 	require.NoError(t, err)
-	require.Equal(t, rightReadData|rightWriteData, granted&(rightReadData|rightWriteData))
+	require.Equal(t, rightReadData|rightWriteData, granted)
 }
 
-// TestCheckFileAccess_NilACLPosixFallbackOtherDeniesWrite covers the
-// non-owner POSIX path: a file with mode 0o600 (rw owner only) must deny a
-// WRITE_DATA request from a non-owner non-group user.
-func TestCheckFileAccess_NilACLPosixFallbackOtherDeniesWrite(t *testing.T) {
+// TestCheckFileAccess_NilACLNonOwnerGrantsRequested verifies the open-time
+// gate does NOT deny a non-owner's request when file.ACL == nil — even when
+// the POSIX mode would deny the same operation downstream. This is the WPTS
+// BVT load-bearing case (and smb2.create.multi): CREATE asks for DELETE,
+// WRITE_DAC, or higher-namespace rights that the rwx mapping cannot encode,
+// and the pre-#529 server granted those opens. We must keep granting them at
+// open time; per-op enforcement in read/write/delete catches abuse.
+func TestCheckFileAccess_NilACLNonOwnerGrantsRequested(t *testing.T) {
 	f := newTestFixture(t)
 
 	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix_owner_only.txt",
@@ -241,11 +247,44 @@ func TestCheckFileAccess_NilACLPosixFallbackOtherDeniesWrite(t *testing.T) {
 
 	authCtx := f.authContext(1001, 1001)
 
-	_, err = f.service.CheckFileAccess(created, authCtx, rightWriteData|rightAppendData)
-	require.Error(t, err)
-	var storeErr *metadata.StoreError
-	require.ErrorAs(t, err, &storeErr)
-	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+	// Non-owner requesting WRITE_DATA on a 0o600 file. Open succeeds
+	// (no DACL to enforce); the actual WRITE op denies via POSIX mode.
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightWriteData|rightAppendData)
+	require.NoError(t, err)
+	require.Equal(t, rightWriteData|rightAppendData, granted)
+
+	// DELETE / WRITE_DAC / WRITE_OWNER — bits the POSIX rwx mapping cannot
+	// encode — must also pass the open gate when there is no DACL.
+	const rightWriteDac uint32 = 0x00040000
+	const rightWriteOwner uint32 = 0x00080000
+	probe := rightDelete | rightWriteDac | rightWriteOwner
+	granted, err = f.service.CheckFileAccess(created, authCtx, probe)
+	require.NoError(t, err)
+	require.Equal(t, probe, granted)
+}
+
+// TestCheckFileAccess_NilACLMaxAllowedReturnsGenericAll verifies that
+// MAXIMUM_ALLOWED on a no-DACL file returns the full GENERIC_ALL set, mirroring
+// the MxAc reply produced by computeMaximalAccess.
+func TestCheckFileAccess_NilACLMaxAllowedReturnsGenericAll(t *testing.T) {
+	f := newTestFixture(t)
+
+	ownerUID := uint32(1001)
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max_nil_acl.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o600,
+			UID:  ownerUID,
+			GID:  1001,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(ownerUID, 1001)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed)
+	require.NoError(t, err)
+	// GENERIC_ALL = 0x001F01FF
+	require.Equal(t, uint32(0x001F01FF), granted)
 }
 
 // TestCheckFileAccess_ZeroDesiredAccessIsNoop guards against returning

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -1,0 +1,303 @@
+package metadata_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #529: SMB CREATE must enforce DesiredAccess against the file's DACL.
+//
+// These tests cover MetadataService.CheckFileAccess — the helper SMB CREATE
+// calls between the share-mode recheck and the actual file open to gate the
+// caller's requested access bits against the stored security descriptor.
+//
+// MS-DTYP §2.4.3 access-right bits used here:
+//   FILE_READ_DATA       0x00000001
+//   FILE_WRITE_DATA      0x00000002
+//   FILE_APPEND_DATA     0x00000004
+//   DELETE               0x00010000
+//   READ_CONTROL         0x00020000
+//   SYNCHRONIZE          0x00100000
+//   MAXIMUM_ALLOWED      0x02000000
+
+const (
+	rightReadData    uint32 = 0x00000001
+	rightWriteData   uint32 = 0x00000002
+	rightAppendData  uint32 = 0x00000004
+	rightDelete      uint32 = 0x00010000
+	rightReadControl uint32 = 0x00020000
+	rightSynchronize uint32 = 0x00100000
+	rightMaxAllowed  uint32 = 0x02000000
+)
+
+// TestCheckFileAccess_DenyACEOnOwnerDeniesWrite covers smbtorture acls.OWNER /
+// acls.DENY1: an explicit DENY ACE targeting the owner's SID must override
+// the POSIX owner-everything fallback and refuse write access.
+func TestCheckFileAccess_DenyACEOnOwnerDeniesWrite(t *testing.T) {
+	f := newTestFixture(t)
+
+	ownerUID := uint32(1001)
+	ownerSID := "S-1-5-21-1-2-3-2001"
+
+	denyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:" + ownerSID,
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "owner_denied.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  ownerUID,
+			GID:  1001,
+			ACL:  denyACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(ownerUID, 1001)
+	authCtx.Identity.SID = strPtr(ownerSID)
+
+	// Request write; expect access denied even though the requester owns the file.
+	_, err = f.service.CheckFileAccess(created, authCtx, rightWriteData|rightReadData)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// TestCheckFileAccess_AllowOnlyReadGrantsReadDeniesWrite covers acls.OWNER's
+// allow-readonly probe: a file whose DACL grants only READ_DATA must allow
+// a CREATE that asks for READ_DATA and deny a CREATE that asks for WRITE_DATA.
+func TestCheckFileAccess_AllowOnlyReadGrantsReadDeniesWrite(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999, // not the requester
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	// READ probe must succeed.
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightReadData|rightSynchronize)
+	require.NoError(t, err)
+	require.NotZero(t, granted&rightReadData, "expected READ_DATA granted, got 0x%x", granted)
+
+	// WRITE probe must be denied.
+	_, err = f.service.CheckFileAccess(created, authCtx, rightWriteData)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// TestCheckFileAccess_MaximumAllowedNeverDenies covers acls.MXAC-NOT-GRANTED:
+// when the client requests MAXIMUM_ALLOWED, the server must return whatever
+// the DACL allows as the granted mask (no STATUS_ACCESS_DENIED), regardless
+// of how restrictive the DACL is.
+func TestCheckFileAccess_MaximumAllowedNeverDenies(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// DACL: a single ALLOW ACE for READ_DATA to the requester. No WRITE.
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	// MAXIMUM_ALLOWED alone must never deny — even though WRITE etc. aren't
+	// in the DACL. Granted bits should reflect what is allowed.
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed)
+	require.NoError(t, err)
+	require.NotZero(t, granted&acl.ACE4_READ_DATA, "expected READ_DATA in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&acl.ACE4_WRITE_DATA, "WRITE_DATA must not be granted, got 0x%x", granted)
+
+	// MAXIMUM_ALLOWED | WRITE_DATA must also not deny: the MAXIMUM_ALLOWED bit
+	// suppresses denial. The handle's effective access reflects the DACL.
+	granted, err = f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightWriteData)
+	require.NoError(t, err)
+	require.Zero(t, granted&acl.ACE4_WRITE_DATA, "WRITE_DATA must not be granted even when requested with MAXIMUM_ALLOWED, got 0x%x", granted)
+}
+
+// TestCheckFileAccess_RootBypassGetsEverything documents the root bypass:
+// UID 0 always gets the requested access, regardless of the DACL.
+func TestCheckFileAccess_RootBypassGetsEverything(t *testing.T) {
+	f := newTestFixture(t)
+
+	denyEveryoneACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "root_only.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o000,
+			UID:  1001,
+			GID:  1001,
+			ACL:  denyEveryoneACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.rootContext()
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightReadData|rightWriteData|rightDelete)
+	require.NoError(t, err)
+	require.Equal(t, rightReadData|rightWriteData|rightDelete, granted)
+}
+
+// TestCheckFileAccess_NilACLPosixFallbackOwner covers the documented divergence
+// from buildDACL: when file.ACL == nil, enforcement uses POSIX mode bits (not
+// the synthesized Windows-default SD). Owner gets GENERIC_ALL.
+func TestCheckFileAccess_NilACLPosixFallbackOwner(t *testing.T) {
+	f := newTestFixture(t)
+
+	ownerUID := uint32(1001)
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o600,
+			UID:  ownerUID,
+			GID:  1001,
+			// ACL: nil — POSIX fallback path.
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(ownerUID, 1001)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightReadData|rightWriteData)
+	require.NoError(t, err)
+	require.Equal(t, rightReadData|rightWriteData, granted&(rightReadData|rightWriteData))
+}
+
+// TestCheckFileAccess_NilACLPosixFallbackOtherDeniesWrite covers the
+// non-owner POSIX path: a file with mode 0o600 (rw owner only) must deny a
+// WRITE_DATA request from a non-owner non-group user.
+func TestCheckFileAccess_NilACLPosixFallbackOtherDeniesWrite(t *testing.T) {
+	f := newTestFixture(t)
+
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix_owner_only.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o600,
+			UID:  9999,
+			GID:  9999,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(1001, 1001)
+
+	_, err = f.service.CheckFileAccess(created, authCtx, rightWriteData|rightAppendData)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// TestCheckFileAccess_ZeroDesiredAccessIsNoop guards against returning
+// ErrAccessDenied for an empty request — empty DesiredAccess is a valid
+// shape (e.g., probing existence or paired solely with MAXIMUM_ALLOWED).
+func TestCheckFileAccess_ZeroDesiredAccessIsNoop(t *testing.T) {
+	f := newTestFixture(t)
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "empty.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  9999,
+			GID:  9999,
+		})
+	require.NoError(t, err)
+	authCtx := f.authContext(1001, 1001)
+	granted, err := f.service.CheckFileAccess(created, authCtx, 0)
+	require.NoError(t, err)
+	require.Zero(t, granted)
+}
+
+// TestCheckFileAccess_DenyErrorIsStoreError ensures the returned error is a
+// *StoreError, which is what common.MapToSMB depends on to produce the
+// correct STATUS_ACCESS_DENIED on the SMB wire.
+func TestCheckFileAccess_DenyErrorIsStoreError(t *testing.T) {
+	f := newTestFixture(t)
+
+	denyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  denyACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(1001, 1001)
+	_, err = f.service.CheckFileAccess(created, authCtx, rightReadData|rightSynchronize)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) {
+		t.Fatalf("error %v is not *StoreError", err)
+	}
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}

--- a/pkg/metadata/storetest/permissions.go
+++ b/pkg/metadata/storetest/permissions.go
@@ -10,7 +10,10 @@ import (
 //
 // These tests verify store-level operations that support permission checking,
 // such as file attributes used for access control. Business-level permission
-// checks (CheckAccess) live in the MetadataService layer, not in individual stores.
+// checks (CheckAccess, CheckFileAccess, CheckParentWriteAccess) live in the
+// MetadataService layer, not in individual stores — see
+// pkg/metadata/auth_permissions_*_test.go for the service-level coverage,
+// including CheckFileAccess (issue #529: DesiredAccess vs file DACL on CREATE).
 func runPermissionsTests(t *testing.T, factory StoreFactory) {
 	t.Run("FilePermissionAttributes", func(t *testing.T) { testFilePermissionAttributes(t, factory) })
 	t.Run("DirectoryPermissionAttributes", func(t *testing.T) { testDirectoryPermissionAttributes(t, factory) })


### PR DESCRIPTION
## Summary

CREATE previously validated share-level permissions, parent DACL, and read-only attributes — but **never evaluated the caller's `DesiredAccess` bits against the existing file's stored DACL**. A client requesting `0x1F01FF` (full access) on a file whose DACL grants only `READ` still opened successfully. This is a direct violation of MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1.

- New `MetadataService.CheckFileAccess(file, authCtx, desiredAccess) (granted, err)` in `pkg/metadata/auth_permissions.go`:
  - `file.ACL != nil`: per-requested-bit `acl.Evaluate` using the same `EvaluateContext` shape as `evaluateACLPermissions`.
  - `file.ACL == nil`: POSIX-mode fallback (owner → GENERIC_ALL, others derived from mode bits). Mirrors `computeMaximalAccess` in `create.go` so the MxAc reply and the enforcement gate agree. The buildDACL synthesis of a Windows-default SD remains an SD-on-wire concern only — server enforcement keeps POSIX-mode semantics per PR #528 / #525.
  - `MAXIMUM_ALLOWED (0x02000000)` never denies — returns the effective granted mask, mirroring `computeMaximalAccess`.
  - Root bypass (UID 0) preserved.
  - Denial returns `*StoreError{Code: ErrAccessDenied}` so `common.MapToSMB` maps to `STATUS_ACCESS_DENIED`.
- Call site in `internal/adapter/smb/v2/handlers/create_post_break.go::completeCreateAfterBreak`, immediately after the post-break share-mode recheck and before the delete-on-close validation. Gated on `fileExists`; new files inherit ACL from parent and are already covered by `CheckParentWriteAccess` in the main `Create()` flow.

## Spec references

- MS-SMB2 §3.3.5.9 — CREATE processing rules for DesiredAccess vs. SD.
- MS-FSA §2.1.5.1.2.1 — open-existing-file security check uses object DACL.
- MS-DTYP §2.5.3 — DACL evaluation algorithm (explicit-DENY precedence).
- Samba canonical reference: `source3/smbd/open.c::smbd_check_access_rights`.

## Expected smbtorture flips

Direct targets (signature: `Incorrect status NT_STATUS_OK - should be NT_STATUS_ACCESS_DENIED`):
- `smb2.acls.OWNER` (acls.c:774)
- `smb2.acls.CREATOR` (acls.c:162)
- `smb2.acls.DENY1`
- `smb2.acls.MXAC-NOT-GRANTED`
- `smb2.acls.INHERITANCE` (acls.c:1210, newly unblocked downstream of #525)

KNOWN_FAILURES walkback intentionally deferred per the project workflow rule — wait for CI to confirm flips.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/metadata/...` (all green; 8 new tests in `auth_permissions_file_access_test.go` cover DENY-on-owner, allow-readonly write-probe, MAXIMUM_ALLOWED never-denies, root bypass, nil-ACL POSIX fallback owner + non-owner, zero-DesiredAccess no-op, error-type assertion)
- [x] `go test ./internal/adapter/smb/...` (all green)
- [x] `go test ./internal/adapter/nfs/...` (all green — NFS uses its own evaluation path, untouched)
- [ ] CI WPTS BVT memory job stays green (broader blast radius: files with stored DACL that previously opened with full access will now correctly deny)
- [ ] CI smbtorture `smb2.acls` and `smb2.create` suites
- [ ] CI E2E POSIX

## Risk

Files with non-nil DACL that previously opened with full access may now correctly deny. Verified locally that the existing test corpus passes (unit + integration); WPTS BVT will be the canonical signal.

## Companion PRs

#529 is part of the same wave as parallel PRs:
- #530 — GENERIC_* access-mask expansion
- #531 — OWNER_RIGHTS semantics
- #532 — ACCESSBASED enumeration filter

`computeMaximalAccess` in `create.go` is shared territory with #530; this PR's edits are surgical and limited to enforcement at the CREATE call site.

Closes #529.