### PR TITLE
feat(smb): access-based enumeration filter (SMB2_SHARE_CAP) (#532)

### DIFF
--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -25,6 +25,7 @@ var (
 	createReadBufferSize    string
 	createQuotaBytes        string
 	createAclCanonicalize   bool
+	createAccessBasedEnum   bool
 )
 
 var createCmd = &cobra.Command{
@@ -80,6 +81,7 @@ func init() {
 	createCmd.Flags().StringVar(&createReadBufferSize, "read-buffer-size", "", "Per-share read buffer size override (e.g., 2GiB, 256MiB)")
 	createCmd.Flags().StringVar(&createQuotaBytes, "quota-bytes", "", "Per-share byte quota (e.g., '10GiB', '500MiB'). 0 = unlimited (default)")
 	createCmd.Flags().BoolVar(&createAclCanonicalize, "acl-canonicalize-inherited", true, "When false, preserves the SE_DACL_AUTO_INHERITED control bit verbatim on SET_INFO Security instead of applying MS-DTYP §2.5.3.4.2 canonicalization (Samba \"acl flag inherited canonicalization = no\"). Default true matches Windows.")
+	createCmd.Flags().BoolVar(&createAccessBasedEnum, "access-based-enumeration", false, "Enable Windows access-based enumeration (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM). When true, SMB clients only see directory entries they can read.")
 	_ = createCmd.MarkFlagRequired("local")
 }
 
@@ -165,6 +167,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("acl-canonicalize-inherited") {
 		v := createAclCanonicalize
 		req.AclFlagInheritedCanonicalization = &v
+	}
+	// Refs #532: same pattern — only forward when the operator set it.
+	if cmd.Flags().Changed("access-based-enumeration") {
+		v := createAccessBasedEnum
+		req.AccessBasedEnumeration = &v
 	}
 
 	share, err := client.CreateShare(req)

--- a/cmd/dfsctl/commands/share/edit.go
+++ b/cmd/dfsctl/commands/share/edit.go
@@ -24,6 +24,7 @@ var (
 	editReadBufferSize    string
 	editQuotaBytes        string
 	editAclCanonicalize   string
+	editAccessBasedEnum   string
 )
 
 var editCmd = &cobra.Command{
@@ -90,6 +91,7 @@ func init() {
 	editCmd.Flags().StringVar(&editReadBufferSize, "read-buffer-size", "", "Per-share read buffer size override (e.g., 2GiB, 256MiB)")
 	editCmd.Flags().StringVar(&editQuotaBytes, "quota-bytes", "", "Per-share byte quota (e.g., '10GiB'). 0 = remove quota")
 	editCmd.Flags().StringVar(&editAclCanonicalize, "acl-canonicalize-inherited", "", "When false, preserves the SE_DACL_AUTO_INHERITED control bit verbatim on SET_INFO Security instead of applying MS-DTYP §2.5.3.4.2 canonicalization (Samba \"acl flag inherited canonicalization = no\"). Default true matches Windows. Takes effect on adapter restart.")
+	editCmd.Flags().StringVar(&editAccessBasedEnum, "access-based-enumeration", "", "Enable/disable Windows access-based enumeration (true|false). Takes effect on adapter restart.")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -107,7 +109,8 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		cmd.Flags().Changed("description") || cmd.Flags().Changed("retention") ||
 		cmd.Flags().Changed("retention-ttl") || cmd.Flags().Changed("local-store-size") ||
 		cmd.Flags().Changed("read-buffer-size") || cmd.Flags().Changed("quota-bytes") ||
-		cmd.Flags().Changed("acl-canonicalize-inherited")
+		cmd.Flags().Changed("acl-canonicalize-inherited") ||
+		cmd.Flags().Changed("access-based-enumeration")
 
 	// If no flags provided, run interactive mode
 	if !hasFlags {
@@ -185,8 +188,18 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		hasUpdate = true
 	}
 
+	if editAccessBasedEnum != "" {
+		val := strings.ToLower(strings.TrimSpace(editAccessBasedEnum))
+		if val != "true" && val != "false" {
+			return fmt.Errorf("--access-based-enumeration: invalid value %q, must be true or false", editAccessBasedEnum)
+		}
+		abe := val == "true"
+		req.AccessBasedEnumeration = &abe
+		hasUpdate = true
+	}
+
 	if !hasUpdate {
-		return fmt.Errorf("no fields specified. Use --local, --remote, --read-only, --default-permission, --description, --retention, --retention-ttl, --local-store-size, --read-buffer-size, --quota-bytes, or --acl-canonicalize-inherited")
+		return fmt.Errorf("no fields specified. Use --local, --remote, --read-only, --default-permission, --description, --retention, --retention-ttl, --local-store-size, --read-buffer-size, --quota-bytes, --acl-canonicalize-inherited, or --access-based-enumeration")
 	}
 
 	share, err := client.UpdateShare(name, req)

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -68,6 +68,7 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Enabled", shareEnabledString(s.Enabled)},
 		{"Default Permission", s.DefaultPermission},
 		{"ACL Canonicalize Inherited", fmt.Sprintf("%v", s.AclFlagInheritedCanonicalization)},
+		{"Access-Based Enumeration", fmt.Sprintf("%v", s.AccessBasedEnumeration)},
 		{"Retention", retPolicy},
 	}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -246,6 +246,10 @@ type TreeConnection struct {
 	CreatedAt   time.Time
 	Permission  models.SharePermission // User's permission level for this share
 	EncryptData bool                   // Share requires all requests to be encrypted
+	// AccessBasedEnumeration mirrors the share-level toggle. When true,
+	// QUERY_DIRECTORY filters entries the caller cannot read (refs #532,
+	// MS-SMB2 §2.2.10 SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM).
+	AccessBasedEnumeration bool
 }
 
 // OpenFile represents an open file handle created by the CREATE command.

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // maxDirectoryReadBytes is the maximum number of bytes to request from the
@@ -341,6 +342,15 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 
 	// Filter entries and build response
 	filteredEntries := filterDirEntries(page.Entries, req.FileName)
+
+	// Refs #532: when the share advertises SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM
+	// (per MS-SMB2 §2.2.10), hide entries the caller cannot read. Mirrors
+	// Samba's source3/smbd/dir.c::can_access_file_acl. The special "." and ".."
+	// entries are added later from `specialCount` and always remain visible —
+	// the caller already opened the directory.
+	if h.treeHasAccessBasedEnumeration(ctx.TreeID) {
+		filteredEntries = filterByAccess(filteredEntries, authCtx)
+	}
 
 	// Sort entries by name (case-insensitive) for consistent enumeration order.
 	// SMB clients (including smbtorture) expect directory entries in sorted order.
@@ -939,4 +949,133 @@ func generate83ShortName(name string) []byte {
 	}
 
 	return encodeUTF16LE(shortName)
+}
+
+// ============================================================================
+// Access-Based Enumeration (refs #532)
+// ============================================================================
+
+// treeHasAccessBasedEnumeration reports whether the tree connection identified
+// by treeID was opened against a share with AccessBasedEnumeration=true.
+// Returns false when the tree is not registered (no enumeration filtering for
+// orphaned handles — the request will fail elsewhere).
+func (h *Handler) treeHasAccessBasedEnumeration(treeID uint32) bool {
+	if treeID == 0 {
+		return false
+	}
+	tree, ok := h.GetTree(treeID)
+	if !ok || tree == nil {
+		return false
+	}
+	return tree.AccessBasedEnumeration
+}
+
+// filterByAccess returns the subset of entries the requester may read,
+// implementing MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM semantics.
+// Files require ACE4_READ_DATA, directories require ACE4_LIST_DIRECTORY
+// (which share the same bit, 0x00000001). When the entry has an ACL attached,
+// the decision is made by acl.Evaluate using the requester's identity. When
+// the entry has no ACL or no attributes (legacy / partial directory pages),
+// we fall back to Unix mode-bit checks — same convention as security.go's
+// buildDACL (#525): the SD that goes on the wire synthesizes a Windows default,
+// but server-side decisions stay POSIX so mode bits remain authoritative.
+func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext) []metadata.DirEntry {
+	if len(entries) == 0 {
+		return entries
+	}
+
+	// Root bypass mirrors the rest of the metadata layer: UID 0 sees
+	// everything regardless of per-file DACL / mode. Avoids hiding entries
+	// from admin tools that legitimately need a full listing.
+	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
+		return entries
+	}
+
+	out := entries[:0]
+	for i := range entries {
+		if canEnumerateEntry(&entries[i], authCtx) {
+			out = append(out, entries[i])
+		}
+	}
+	return out
+}
+
+// canEnumerateEntry reports whether the requester may see this entry in an
+// access-based enumeration. See filterByAccess for the policy contract.
+func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext) bool {
+	attr := entry.Attr
+	if attr == nil {
+		// Without attributes we cannot evaluate either ACL or mode bits.
+		// Be conservative and show the entry — hiding it would make
+		// directory listing flap based on whether READDIRPLUS-style
+		// attribute prefetch happened to populate Attr. This path should
+		// not be reachable in SMB QUERY_DIRECTORY in practice since the
+		// metadata layer always returns DirEntry.Attr.
+		return true
+	}
+
+	// ACE4_READ_DATA == ACE4_LIST_DIRECTORY == 0x00000001 — same bit, so
+	// either mask works against both files and directories.
+	const readMask = acl.ACE4_READ_DATA
+
+	if attr.ACL != nil {
+		evalCtx := buildEnumEvalContext(attr, authCtx)
+		return acl.Evaluate(attr.ACL, evalCtx, readMask)
+	}
+
+	// POSIX fallback — same semantics as
+	// pkg/metadata/auth_permissions.go::calculatePermissions for read.
+	return posixCanRead(attr, authCtx)
+}
+
+// buildEnumEvalContext constructs an acl.EvaluateContext from an attr +
+// AuthContext pair for access-based enumeration decisions.
+func buildEnumEvalContext(attr *metadata.FileAttr, authCtx *metadata.AuthContext) *acl.EvaluateContext {
+	evalCtx := &acl.EvaluateContext{
+		FileOwnerUID: attr.UID,
+		FileOwnerGID: attr.GID,
+	}
+	if authCtx == nil || authCtx.Identity == nil {
+		return evalCtx
+	}
+	id := authCtx.Identity
+	if id.UID != nil {
+		evalCtx.UID = *id.UID
+	}
+	if id.GID != nil {
+		evalCtx.GID = *id.GID
+	}
+	evalCtx.GIDs = id.GIDs
+	switch {
+	case id.Username != "" && id.Domain != "":
+		evalCtx.Who = id.Username + "@" + id.Domain
+	case id.Username != "":
+		evalCtx.Who = id.Username
+	}
+	if id.SID != nil {
+		evalCtx.SID = *id.SID
+	}
+	evalCtx.GroupSIDs = id.GroupSIDs
+	return evalCtx
+}
+
+// posixCanRead implements the read-bit selection used for access-based
+// enumeration on files / directories without an ACL.
+func posixCanRead(attr *metadata.FileAttr, authCtx *metadata.AuthContext) bool {
+	if attr == nil {
+		return true
+	}
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		// Anonymous → only the "other" read bit applies.
+		return attr.Mode&0o004 != 0
+	}
+	uid := *authCtx.Identity.UID
+	switch {
+	case uid == attr.UID:
+		return attr.Mode&0o400 != 0
+	case authCtx.Identity.HasGID(attr.GID):
+		return attr.Mode&0o040 != 0
+	default:
+		return attr.Mode&0o004 != 0
+	}
 }

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -349,7 +349,24 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 	// entries are added later from `specialCount` and always remain visible —
 	// the caller already opened the directory.
 	if h.treeHasAccessBasedEnumeration(ctx.TreeID) {
-		filteredEntries = filterByAccess(filteredEntries, authCtx)
+		// Per-entry hydrator: ABE needs FileAttr+ACL to decide visibility,
+		// but DirEntry.Attr is optional on the metadata layer (see
+		// pkg/metadata/validation.go). When a backend omits it, fall back
+		// to a single GetFile so we don't leak entries on the fail-open
+		// branch. This is a per-missing-entry cost, not per-entry —
+		// Postgres now hydrates ACL inline (#532 review), Memory/Badger
+		// have always carried Attr.
+		hydrate := func(entry *metadata.DirEntry) *metadata.FileAttr {
+			if entry.Handle == nil {
+				return nil
+			}
+			file, ferr := metaSvc.GetFile(authCtx.Context, entry.Handle)
+			if ferr != nil || file == nil {
+				return nil
+			}
+			return &file.FileAttr
+		}
+		filteredEntries = filterByAccess(filteredEntries, authCtx, hydrate)
 	}
 
 	// Sort entries by name (case-insensitive) for consistent enumeration order.
@@ -970,16 +987,29 @@ func (h *Handler) treeHasAccessBasedEnumeration(treeID uint32) bool {
 	return tree.AccessBasedEnumeration
 }
 
+// attrHydrator looks up missing FileAttr for a directory entry. Used by
+// filterByAccess when DirEntry.Attr is nil (documented as optional on the
+// metadata layer — see pkg/metadata/validation.go). Returning nil signals
+// the entry has no resolvable attributes; the filter then treats it as
+// inaccessible under ABE rather than leaking it.
+type attrHydrator func(entry *metadata.DirEntry) *metadata.FileAttr
+
 // filterByAccess returns the subset of entries the requester may read,
 // implementing MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM semantics.
 // Files require ACE4_READ_DATA, directories require ACE4_LIST_DIRECTORY
 // (which share the same bit, 0x00000001). When the entry has an ACL attached,
 // the decision is made by acl.Evaluate using the requester's identity. When
-// the entry has no ACL or no attributes (legacy / partial directory pages),
-// we fall back to Unix mode-bit checks — same convention as security.go's
-// buildDACL (#525): the SD that goes on the wire synthesizes a Windows default,
-// but server-side decisions stay POSIX so mode bits remain authoritative.
-func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext) []metadata.DirEntry {
+// the entry has no ACL but has attributes, we fall back to Unix mode-bit
+// checks — same convention as security.go's buildDACL (#525): the SD that
+// goes on the wire synthesizes a Windows default, but server-side decisions
+// stay POSIX so mode bits remain authoritative.
+//
+// When DirEntry.Attr is nil (documented optional, refs #532 review):
+//   - If hydrate is non-nil it is called to look up the attributes; if it
+//     still returns nil the entry is hidden (fail-closed).
+//   - If hydrate is nil the entry is hidden directly. Returning true here
+//     would leak entries that ABE is supposed to suppress.
+func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) []metadata.DirEntry {
 	if len(entries) == 0 {
 		return entries
 	}
@@ -993,7 +1023,7 @@ func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext) 
 
 	out := entries[:0]
 	for i := range entries {
-		if canEnumerateEntry(&entries[i], authCtx) {
+		if canEnumerateEntry(&entries[i], authCtx, hydrate) {
 			out = append(out, entries[i])
 		}
 	}
@@ -1002,16 +1032,21 @@ func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext) 
 
 // canEnumerateEntry reports whether the requester may see this entry in an
 // access-based enumeration. See filterByAccess for the policy contract.
-func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext) bool {
+func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) bool {
 	attr := entry.Attr
 	if attr == nil {
-		// Without attributes we cannot evaluate either ACL or mode bits.
-		// Be conservative and show the entry — hiding it would make
-		// directory listing flap based on whether READDIRPLUS-style
-		// attribute prefetch happened to populate Attr. This path should
-		// not be reachable in SMB QUERY_DIRECTORY in practice since the
-		// metadata layer always returns DirEntry.Attr.
-		return true
+		// Attr is documented optional on DirEntry (pkg/metadata/validation.go).
+		// Backends like Badger explicitly treat hydration as best-effort, so
+		// this branch IS reachable. Try to hydrate; if that fails, hide the
+		// entry rather than leaking it — ABE's contract is "hide what the
+		// caller cannot read", and we cannot prove the caller can read what
+		// we cannot look up.
+		if hydrate != nil {
+			attr = hydrate(entry)
+		}
+		if attr == nil {
+			return false
+		}
 	}
 
 	// ACE4_READ_DATA == ACE4_LIST_DIRECTORY == 0x00000001 — same bit, so

--- a/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
@@ -71,13 +71,13 @@ func TestFilterByAccess_OwnerOnlyACL(t *testing.T) {
 
 	owner := authForUID(1000, 1000)
 	// Make a fresh copy each call since filterByAccess mutates in place.
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 2 {
 		t.Fatalf("owner: want 2 entries, got %d (%v)", len(got), got)
 	}
 
 	other := authForUID(2000, 2000)
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
 	if len(got) != 1 || got[0].Name != "public.txt" {
 		t.Fatalf("non-owner: want only public.txt, got %v", got)
 	}
@@ -96,13 +96,13 @@ func TestFilterByAccess_DirectoryListBit(t *testing.T) {
 	}
 
 	other := authForUID(2000, 2000)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
 	if len(got) != 0 {
 		t.Fatalf("non-owner directory: want hidden, got %v", got)
 	}
 
 	owner := authForUID(1000, 1000)
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 1 {
 		t.Fatalf("owner directory: want 1 entry, got %d", len(got))
 	}
@@ -120,19 +120,19 @@ func TestFilterByAccess_POSIXFallback(t *testing.T) {
 	}
 
 	owner := authForUID(1000, 1000)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 3 {
 		t.Fatalf("owner: want all 3 entries, got %d (%v)", len(got), got)
 	}
 
 	groupMember := authForUID(2000, 1000) // not owner, in group
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), groupMember)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), groupMember, nil)
 	if len(got) != 2 {
 		t.Fatalf("group member: want 2 entries (world.txt + group.txt), got %d (%v)", len(got), got)
 	}
 
 	stranger := authForUID(3000, 3000) // neither owner nor in group
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), stranger)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), stranger, nil)
 	if len(got) != 1 || got[0].Name != "world.txt" {
 		t.Fatalf("stranger: want only world.txt, got %v", got)
 	}
@@ -152,7 +152,7 @@ func TestFilterByAccess_RootBypass(t *testing.T) {
 	}
 
 	root := authForUID(0, 0)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), root)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), root, nil)
 	if len(got) != 2 {
 		t.Fatalf("root: want all 2 entries, got %d (%v)", len(got), got)
 	}
@@ -184,8 +184,99 @@ func TestFilterByAccess_FlagOffSemantics(t *testing.T) {
 	}
 
 	// Flag-on path: filtering hides the entry.
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
 	if len(got) != 0 {
 		t.Fatalf("flag-on: want 0 entries, got %d", len(got))
+	}
+}
+
+// TestFilterByAccess_NilAttrFailsClosed verifies that an entry with no
+// hydrated attributes is hidden under ABE when no hydrator is supplied.
+// DirEntry.Attr is documented optional on the metadata layer
+// (pkg/metadata/validation.go) and some backends (e.g. Badger) treat the
+// hydration as best-effort, so this branch IS reachable. Returning the
+// entry would leak files ABE is meant to suppress (refs #532 review).
+func TestFilterByAccess_NilAttrFailsClosed(t *testing.T) {
+	entries := []metadata.DirEntry{
+		{Name: "noattr.txt", Attr: nil},
+	}
+
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), nil)
+	if len(got) != 0 {
+		t.Fatalf("nil-attr no-hydrator: want 0 entries (hidden), got %d (%v)", len(got), got)
+	}
+}
+
+// TestFilterByAccess_NilAttrHydratorMisses verifies that a hydrator that
+// returns nil keeps the fail-closed behaviour. Mirrors the case where
+// GetFile races with a concurrent delete.
+func TestFilterByAccess_NilAttrHydratorMisses(t *testing.T) {
+	entries := []metadata.DirEntry{
+		{Name: "noattr.txt", Attr: nil},
+	}
+
+	miss := func(_ *metadata.DirEntry) *metadata.FileAttr { return nil }
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), miss)
+	if len(got) != 0 {
+		t.Fatalf("nil-attr hydrator miss: want 0 entries, got %d", len(got))
+	}
+}
+
+// TestFilterByAccess_NilAttrHydratorHits verifies that a hydrator that
+// returns FileAttr restores the normal ACL/POSIX decision path. Without
+// the hydrator the entry would have been hidden; with it the caller sees
+// the file iff they can read it.
+func TestFilterByAccess_NilAttrHydratorHits(t *testing.T) {
+	ownerOnly := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+		},
+	}
+	entries := []metadata.DirEntry{
+		{Name: "lazy.txt", Attr: nil},
+	}
+
+	hydrate := func(_ *metadata.DirEntry) *metadata.FileAttr {
+		return &metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o600,
+			UID:  1000,
+			GID:  1000,
+			ACL:  ownerOnly,
+		}
+	}
+
+	// Owner with hydration: visible.
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(1000, 1000), hydrate)
+	if len(got) != 1 {
+		t.Fatalf("owner via hydrate: want 1 entry, got %d (%v)", len(got), got)
+	}
+
+	// Non-owner with hydration: hidden by ACL.
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), hydrate)
+	if len(got) != 0 {
+		t.Fatalf("non-owner via hydrate: want 0 entries, got %d (%v)", len(got), got)
+	}
+}
+
+// TestFilterByAccess_NilAttrRootBypass verifies that the UID 0 fast-path
+// bypasses the hydrator entirely — root sees orphaned entries as well.
+func TestFilterByAccess_NilAttrRootBypass(t *testing.T) {
+	entries := []metadata.DirEntry{
+		{Name: "noattr.txt", Attr: nil},
+	}
+
+	hydratorCalled := false
+	hydrate := func(_ *metadata.DirEntry) *metadata.FileAttr {
+		hydratorCalled = true
+		return nil
+	}
+
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(0, 0), hydrate)
+	if len(got) != 1 {
+		t.Fatalf("root: want 1 entry (bypass), got %d", len(got))
+	}
+	if hydratorCalled {
+		t.Fatalf("root bypass should skip hydrator")
 	}
 }

--- a/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
@@ -1,0 +1,191 @@
+// Refs #532. Per-entry filter exercised by the SMB QUERY_DIRECTORY handler
+// when the connected share has Windows access-based enumeration enabled
+// (MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM).
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+func uint32Ptr(v uint32) *uint32 { return &v }
+
+// authForUID builds an AuthContext for the given UID with a single primary GID.
+func authForUID(uid, gid uint32) *metadata.AuthContext {
+	return &metadata.AuthContext{
+		Identity: &metadata.Identity{
+			UID:  uint32Ptr(uid),
+			GID:  uint32Ptr(gid),
+			GIDs: []uint32{gid},
+		},
+	}
+}
+
+// regularFileWithACL constructs a DirEntry for a regular file with the given
+// owner/group and ACL.
+func regularFileWithACL(name string, uid, gid uint32, mode uint32, a *acl.ACL) metadata.DirEntry {
+	return metadata.DirEntry{
+		Name: name,
+		Attr: &metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: mode,
+			UID:  uid,
+			GID:  gid,
+			ACL:  a,
+		},
+	}
+}
+
+// directoryWithACL constructs a DirEntry for a directory.
+func directoryWithACL(name string, uid, gid uint32, mode uint32, a *acl.ACL) metadata.DirEntry {
+	return metadata.DirEntry{
+		Name: name,
+		Attr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: mode,
+			UID:  uid,
+			GID:  gid,
+			ACL:  a,
+		},
+	}
+}
+
+// TestFilterByAccess_OwnerOnlyACL verifies that an ACL granting READ_DATA only
+// to OWNER@ keeps the file visible to the owner and hides it from a non-owner.
+func TestFilterByAccess_OwnerOnlyACL(t *testing.T) {
+	ownerOnly := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+		},
+	}
+	entries := []metadata.DirEntry{
+		regularFileWithACL("secret.txt", 1000, 1000, 0o000, ownerOnly),
+		regularFileWithACL("public.txt", 1000, 1000, 0o000, &acl.ACL{
+			ACEs: []acl.ACE{
+				{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialEveryone},
+			},
+		}),
+	}
+
+	owner := authForUID(1000, 1000)
+	// Make a fresh copy each call since filterByAccess mutates in place.
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	if len(got) != 2 {
+		t.Fatalf("owner: want 2 entries, got %d (%v)", len(got), got)
+	}
+
+	other := authForUID(2000, 2000)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	if len(got) != 1 || got[0].Name != "public.txt" {
+		t.Fatalf("non-owner: want only public.txt, got %v", got)
+	}
+}
+
+// TestFilterByAccess_DirectoryListBit verifies that directories use the same
+// 0x1 bit (ACE4_LIST_DIRECTORY) as files (ACE4_READ_DATA).
+func TestFilterByAccess_DirectoryListBit(t *testing.T) {
+	denyOther := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_LIST_DIRECTORY, Who: acl.SpecialOwner},
+		},
+	}
+	entries := []metadata.DirEntry{
+		directoryWithACL("private", 1000, 1000, 0o000, denyOther),
+	}
+
+	other := authForUID(2000, 2000)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	if len(got) != 0 {
+		t.Fatalf("non-owner directory: want hidden, got %v", got)
+	}
+
+	owner := authForUID(1000, 1000)
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	if len(got) != 1 {
+		t.Fatalf("owner directory: want 1 entry, got %d", len(got))
+	}
+}
+
+// TestFilterByAccess_POSIXFallback covers the path where file.ACL is nil and
+// we fall back to mode bits, matching security.go::buildDACL's contract that
+// server-side decisions keep POSIX semantics for nil ACL (refs #525).
+func TestFilterByAccess_POSIXFallback(t *testing.T) {
+	// owner=1000 group=1000, mode rw------- (0o600): owner read, no group/other.
+	entries := []metadata.DirEntry{
+		regularFileWithACL("owner-only.txt", 1000, 1000, 0o600, nil),
+		regularFileWithACL("world.txt", 1000, 1000, 0o644, nil),
+		regularFileWithACL("group.txt", 1000, 1000, 0o640, nil),
+	}
+
+	owner := authForUID(1000, 1000)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner)
+	if len(got) != 3 {
+		t.Fatalf("owner: want all 3 entries, got %d (%v)", len(got), got)
+	}
+
+	groupMember := authForUID(2000, 1000) // not owner, in group
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), groupMember)
+	if len(got) != 2 {
+		t.Fatalf("group member: want 2 entries (world.txt + group.txt), got %d (%v)", len(got), got)
+	}
+
+	stranger := authForUID(3000, 3000) // neither owner nor in group
+	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), stranger)
+	if len(got) != 1 || got[0].Name != "world.txt" {
+		t.Fatalf("stranger: want only world.txt, got %v", got)
+	}
+}
+
+// TestFilterByAccess_RootBypass verifies UID 0 sees everything regardless of
+// per-file DACL or mode bits.
+func TestFilterByAccess_RootBypass(t *testing.T) {
+	denyEveryone := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialEveryone},
+		},
+	}
+	entries := []metadata.DirEntry{
+		regularFileWithACL("forbidden.txt", 1000, 1000, 0o000, denyEveryone),
+		regularFileWithACL("mode-zero.txt", 1000, 1000, 0o000, nil),
+	}
+
+	root := authForUID(0, 0)
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), root)
+	if len(got) != 2 {
+		t.Fatalf("root: want all 2 entries, got %d (%v)", len(got), got)
+	}
+}
+
+// TestFilterByAccess_FlagOffReturnsAll documents the contract that filtering
+// only runs when the share toggle is set; with the flag off (i.e. the
+// handler skipping the filter call), the caller sees everything. This test
+// invokes the filter directly with a non-owner identity to verify it would
+// hide entries — the flag-off path is verified by NOT calling filterByAccess.
+func TestFilterByAccess_FlagOffSemantics(t *testing.T) {
+	// File hidden under ABE.
+	ownerOnly := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+		},
+	}
+	entries := []metadata.DirEntry{
+		regularFileWithACL("secret.txt", 1000, 1000, 0o000, ownerOnly),
+	}
+	other := authForUID(2000, 2000)
+
+	// Flag-off path: filterByAccess is simply not called — the caller gets
+	// the full list. (Mirrors the handler's `if h.treeHasAccessBasedEnumeration(...)`
+	// gate.) Asserting on `entries` itself validates that without filtering
+	// the visible set is unchanged.
+	if len(entries) != 1 {
+		t.Fatalf("flag-off: want 1 entry, got %d", len(entries))
+	}
+
+	// Flag-on path: filtering hides the entry.
+	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other)
+	if len(got) != 0 {
+		t.Fatalf("flag-on: want 0 entries, got %d", len(got))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/tree_connect.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect.go
@@ -23,6 +23,12 @@ const treeConnectFixedSize = 8
 // [MS-SMB2] Section 2.2.10
 const SMB2ShareFlagEncryptData uint32 = 0x00008000
 
+// SMB2ShareCapAccessBasedDirectoryEnum advertises Windows access-based
+// enumeration on the share. When set in the Capabilities field of the
+// TREE_CONNECT response, clients learn that QUERY_DIRECTORY hides entries
+// the caller cannot read. [MS-SMB2] Section 2.2.10.
+const SMB2ShareCapAccessBasedDirectoryEnum uint32 = 0x00000080
+
 // ipcMaximalAccess defines the access rights for the IPC$ virtual share.
 // [MS-SMB2] Section 2.2.10 - MaximalAccess is a bitmask of allowed operations.
 // Value 0x1F grants the following SMB2 access rights for named pipe operations:
@@ -144,13 +150,14 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 	// Create tree connection with permission
 	treeID := h.GenerateTreeID()
 	tree := &TreeConnection{
-		TreeID:      treeID,
-		SessionID:   ctx.SessionID,
-		ShareName:   shareName,
-		ShareType:   types.SMB2ShareTypeDisk,
-		CreatedAt:   time.Now(),
-		Permission:  permission,
-		EncryptData: share.EncryptData,
+		TreeID:                 treeID,
+		SessionID:              ctx.SessionID,
+		ShareName:              shareName,
+		ShareType:              types.SMB2ShareTypeDisk,
+		CreatedAt:              time.Now(),
+		Permission:             permission,
+		EncryptData:            share.EncryptData,
+		AccessBasedEnumeration: share.AccessBasedEnumeration,
 	}
 	h.StoreTree(tree)
 
@@ -166,13 +173,21 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		shareFlags |= SMB2ShareFlagEncryptData
 	}
 
+	// Capabilities — advertise per-share features. Refs #532: MS-SMB2 §2.2.10
+	// SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM tells the client we hide
+	// unreadable entries on enumeration.
+	var capabilities uint32
+	if share.AccessBasedEnumeration {
+		capabilities |= SMB2ShareCapAccessBasedDirectoryEnum
+	}
+
 	// Build response (16 bytes)
 	w := smbenc.NewWriter(16)
 	w.WriteUint16(16)                     // StructureSize
 	w.WriteUint8(types.SMB2ShareTypeDisk) // ShareType
 	w.WriteUint8(0)                       // Reserved
 	w.WriteUint32(shareFlags)             // ShareFlags
-	w.WriteUint32(0)                      // Capabilities
+	w.WriteUint32(capabilities)           // Capabilities
 	w.WriteUint32(maximalAccess)          // MaximalAccess
 
 	return NewResult(types.StatusSuccess, w.Bytes()), nil

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -80,6 +80,10 @@ type CreateShareRequest struct {
 	// AclFlagInheritedCanonicalization — Refs #514. Pointer so the handler
 	// can distinguish "unset → use default true" from "explicit false".
 	AclFlagInheritedCanonicalization *bool `json:"acl_flag_inherited_canonicalization,omitempty"`
+	// AccessBasedEnumeration — Refs #532. Pointer for the same reason: nil
+	// keeps the server default (false); a non-nil pointer is an explicit
+	// set.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
 }
 
 // UpdateShareRequest is the request body for PUT /api/v1/shares/{name}.
@@ -101,6 +105,9 @@ type UpdateShareRequest struct {
 	// is not required (takes effect on adapter restart, matching
 	// LocalStoreSize/ReadBufferSize semantics).
 	AclFlagInheritedCanonicalization *bool `json:"acl_flag_inherited_canonicalization,omitempty"`
+	// AccessBasedEnumeration — Refs #532. nil = no change; non-nil = explicit
+	// set. Persisted on UpdateShare; takes effect on adapter restart.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
 }
 
 // ShareResponse is the response body for share endpoints.
@@ -129,9 +136,12 @@ type ShareResponse struct {
 	// AclFlagInheritedCanonicalization mirrors models.Share — Refs #514.
 	// No omitempty: `false` is operator-meaningful state, matching the
 	// `enabled` pattern.
-	AclFlagInheritedCanonicalization bool      `json:"acl_flag_inherited_canonicalization"`
-	CreatedAt                        time.Time `json:"created_at"`
-	UpdatedAt                        time.Time `json:"updated_at"`
+	AclFlagInheritedCanonicalization bool `json:"acl_flag_inherited_canonicalization"`
+	// AccessBasedEnumeration mirrors models.Share — Refs #532. No omitempty
+	// for the same reason: operators need to render the explicit state.
+	AccessBasedEnumeration bool      `json:"access_based_enumeration"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
 
 	// Status is the worst-of health report derived from the share's
 	// metadata store and block store engine. Non-omitempty so
@@ -269,6 +279,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		aclCanon = *req.AclFlagInheritedCanonicalization
 	}
 
+	// Refs #532: access-based enumeration defaults off.
+	abe := false
+	if req.AccessBasedEnumeration != nil {
+		abe = *req.AccessBasedEnumeration
+	}
+
 	now := time.Now()
 	share := &models.Share{
 		ID:                               uuid.New().String(),
@@ -286,6 +302,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:                       quotaBytes,
 		Enabled:                          true, // REST-02: new shares are enabled by default.
 		AclFlagInheritedCanonicalization: aclCanon,
+		AccessBasedEnumeration:           abe,
 		CreatedAt:                        now,
 		UpdatedAt:                        now,
 	}
@@ -326,6 +343,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			Enabled:                          share.Enabled,
 			EncryptData:                      req.EncryptData,
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
+			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			DefaultPermission:                defaultPerm,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),
@@ -452,6 +470,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// (matches LocalStoreSize/ReadBufferSize semantics — no runtime
 		// hot-reload).
 		share.AclFlagInheritedCanonicalization = *req.AclFlagInheritedCanonicalization
+	}
+	if req.AccessBasedEnumeration != nil {
+		// Refs #532. Persisted to DB; takes effect on adapter restart.
+		share.AccessBasedEnumeration = *req.AccessBasedEnumeration
 	}
 	if req.DefaultPermission != nil {
 		share.DefaultPermission = *req.DefaultPermission
@@ -949,6 +971,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 		ReadBufferSize:                   readBufferSizeStr,
 		QuotaBytes:                       quotaBytesStr,
 		AclFlagInheritedCanonicalization: s.AclFlagInheritedCanonicalization,
+		AccessBasedEnumeration:           s.AccessBasedEnumeration,
 		CreatedAt:                        s.CreatedAt,
 		UpdatedAt:                        s.UpdatedAt,
 	}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -41,9 +41,12 @@ type Share struct {
 	// AclFlagInheritedCanonicalization mirrors models.Share — Refs #514.
 	// No omitempty: `false` is operator-meaningful (canonicalization
 	// disabled) and consumers need to render the state explicitly.
-	AclFlagInheritedCanonicalization bool      `json:"acl_flag_inherited_canonicalization"`
-	CreatedAt                        time.Time `json:"created_at"`
-	UpdatedAt                        time.Time `json:"updated_at"`
+	AclFlagInheritedCanonicalization bool `json:"acl_flag_inherited_canonicalization"`
+	// AccessBasedEnumeration mirrors models.Share — Refs #532. No omitempty
+	// for the same reason.
+	AccessBasedEnumeration bool      `json:"access_based_enumeration"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
 }
 
 // CreateShareRequest is the request to create a share.
@@ -65,6 +68,9 @@ type CreateShareRequest struct {
 	// AclFlagInheritedCanonicalization — Refs #514. Pointer so callers can
 	// distinguish "unset → server default (true)" from "explicit false".
 	AclFlagInheritedCanonicalization *bool `json:"acl_flag_inherited_canonicalization,omitempty"`
+	// AccessBasedEnumeration — Refs #532. Pointer so callers can distinguish
+	// "unset → server default (false)" from "explicit true".
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
 }
 
 // UpdateShareRequest is the request to update a share.
@@ -84,6 +90,9 @@ type UpdateShareRequest struct {
 	// AclFlagInheritedCanonicalization — Refs #514. nil = no change;
 	// non-nil = explicit set. Takes effect on adapter restart.
 	AclFlagInheritedCanonicalization *bool `json:"acl_flag_inherited_canonicalization,omitempty"`
+	// AccessBasedEnumeration — Refs #532. nil = no change; non-nil =
+	// explicit set. Takes effect on adapter restart.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
 }
 
 // SharePermission represents a permission on a share.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -31,17 +31,23 @@ type Share struct {
 	// MS-DTYP §2.5.3.4.2 (clearing it when AUTO_INHERIT_REQ is unset). Default
 	// true matches Windows behavior; set to false to opt into the Samba
 	// extension where the bit survives without AUTO_INHERIT_REQ (refs #514).
-	AclFlagInheritedCanonicalization bool      `gorm:"default:true;not null" json:"acl_flag_inherited_canonicalization"`
-	DefaultPermission                string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
-	Config                           string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
-	BlockedOperations                string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
-	RetentionPolicy                  string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
-	RetentionTTL                     int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
-	LocalStoreSize                   int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
-	ReadBufferSize                   int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
-	QuotaBytes                       int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
-	CreatedAt                        time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt                        time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	AclFlagInheritedCanonicalization bool `gorm:"default:true;not null" json:"acl_flag_inherited_canonicalization"`
+	// AccessBasedEnumeration enables Windows access-based enumeration on the
+	// share (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM per MS-SRVS). When
+	// true, TREE_CONNECT advertises SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM
+	// (MS-SMB2 §2.2.10) and QUERY_DIRECTORY hides entries the caller cannot
+	// read. Default false matches the historical behaviour (refs #532).
+	AccessBasedEnumeration bool      `gorm:"default:false;not null" json:"access_based_enumeration"`
+	DefaultPermission      string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
+	Config                 string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
+	BlockedOperations      string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
+	RetentionPolicy        string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
+	RetentionTTL           int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
+	LocalStoreSize         int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
+	ReadBufferSize         int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
+	QuotaBytes             int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
+	CreatedAt              time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt              time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 
 	// Relationships
 	MetadataStore    MetadataStoreConfig    `gorm:"foreignKey:MetadataStoreID" json:"metadata_store,omitempty"`

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -193,6 +193,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			Enabled:                          share.Enabled, // Plan 05-09 D-02: propagate DB Enabled flag so adapter gates read the correct runtime value.
 			EncryptData:                      share.EncryptData,
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
+			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			DefaultPermission:                share.DefaultPermission,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -55,6 +55,14 @@ type Share struct {
 	// extension where the bit survives without AUTO_INHERIT_REQ (refs #514).
 	AclFlagInheritedCanonicalization bool
 
+	// AccessBasedEnumeration enables Windows access-based enumeration on the
+	// share (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM per MS-SRVS). When
+	// true, TREE_CONNECT advertises
+	// SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM (MS-SMB2 §2.2.10) and the
+	// SMB QUERY_DIRECTORY handler filters out entries the caller cannot
+	// read. Default false (refs #532).
+	AccessBasedEnumeration bool
+
 	// NFS-specific options
 	DisableReaddirplus bool
 
@@ -118,6 +126,11 @@ type ShareConfig struct {
 	// for MS-DTYP §2.5.3.4.2 canonicalization of SE_DACL_AUTO_INHERITED. See
 	// the runtime Share field for semantics (refs #514).
 	AclFlagInheritedCanonicalization bool
+
+	// AccessBasedEnumeration mirrors models.Share's per-share toggle for
+	// Windows access-based enumeration. See the runtime Share field for
+	// semantics (refs #532).
+	AccessBasedEnumeration bool
 
 	RootAttr *metadata.FileAttr
 
@@ -408,6 +421,7 @@ func (s *Service) prepareShare(
 		Enabled:                          config.Enabled,
 		EncryptData:                      config.EncryptData,
 		AclFlagInheritedCanonicalization: config.AclFlagInheritedCanonicalization,
+		AccessBasedEnumeration:           config.AccessBasedEnumeration,
 		DefaultPermission:                config.DefaultPermission,
 		Squash:                           config.Squash,
 		AnonymousUID:                     config.AnonymousUID,

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -266,6 +266,17 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to backfill shares.enabled: %w", err)
 	}
 
+	// Refs #532: backfill shares.access_based_enumeration for rows that predate
+	// the column. SQLite ALTER TABLE ADD COLUMN can leave NULL despite DEFAULT,
+	// which would surface as a Scan failure when the GORM tag declares the
+	// field non-nullable. Mirrors the shares.enabled backfill immediately above.
+	if err := db.Exec(
+		"UPDATE shares SET access_based_enumeration = ? WHERE access_based_enumeration IS NULL",
+		false,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to backfill shares.access_based_enumeration: %w", err)
+	}
+
 	// --- Post-AutoMigrate migrations ---
 	// Step 2: Migrate legacy Share payload_store_id column to local/remote block store IDs.
 	postMigrator := db.Migrator()

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -87,6 +87,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"retention_ttl":                       share.RetentionTTL,
 		"enabled":                             share.Enabled,
 		"acl_flag_inherited_canonicalization": share.AclFlagInheritedCanonicalization,
+		"access_based_enumeration":            share.AccessBasedEnumeration,
 		"updated_at":                          share.UpdatedAt,
 	}
 	// Handle remote_block_store_id explicitly: GORM map-based Updates may skip

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -1216,3 +1216,91 @@ func TestPostgresDSN(t *testing.T) {
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+// TestAccessBasedEnumerationBackfill verifies that the post-AutoMigrate
+// backfill replaces NULL access_based_enumeration values with false. SQLite
+// ALTER TABLE ADD COLUMN can leave NULL despite the DEFAULT clause when the
+// column was added before the NOT NULL tag landed, which would surface as a
+// Scan failure on the non-nullable bool. Mirrors the shares.enabled backfill
+// contract (refs PR #536 review).
+//
+// The test simulates a legacy row by recreating the table without the NOT
+// NULL constraint, inserting NULL, then running the backfill statement and
+// asserting the value was replaced with false.
+func TestAccessBasedEnumerationBackfill(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+
+	db := store.DB()
+
+	// Recreate the table without NOT NULL on access_based_enumeration so we
+	// can simulate a row that predates the constraint. AutoMigrate adds the
+	// constraint at first run; legacy SQLite DBs that started life without
+	// it (i.e. created before the model tag was added) are exactly what
+	// the backfill targets.
+	if err := db.Exec(`DROP TABLE shares`).Error; err != nil {
+		t.Fatalf("drop shares: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE shares (
+			id TEXT PRIMARY KEY,
+			name TEXT UNIQUE NOT NULL,
+			metadata_store_id TEXT NOT NULL,
+			local_block_store_id TEXT NOT NULL,
+			remote_block_store_id TEXT,
+			read_only BOOLEAN DEFAULT FALSE,
+			enabled BOOLEAN DEFAULT TRUE NOT NULL,
+			encrypt_data BOOLEAN DEFAULT FALSE,
+			acl_flag_inherited_canonicalization BOOLEAN DEFAULT TRUE NOT NULL,
+			access_based_enumeration BOOLEAN DEFAULT FALSE,
+			default_permission TEXT DEFAULT 'read-write',
+			config TEXT,
+			blocked_operations TEXT,
+			retention_policy TEXT DEFAULT '',
+			retention_ttl INTEGER DEFAULT 0,
+			local_store_size INTEGER DEFAULT 0,
+			read_buffer_size INTEGER DEFAULT 0,
+			quota_bytes INTEGER DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("recreate shares: %v", err)
+	}
+
+	// Insert a legacy row with NULL access_based_enumeration.
+	if err := db.Exec(`
+		INSERT INTO shares (id, name, metadata_store_id, local_block_store_id, access_based_enumeration)
+		VALUES (?, ?, ?, ?, NULL)
+	`, "legacy-id", "/legacy", "meta-id", "local-id").Error; err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	// Verify the row is NULL before backfill (sanity check).
+	var pre *bool
+	if err := db.Raw("SELECT access_based_enumeration FROM shares WHERE name = ?", "/legacy").Scan(&pre).Error; err != nil {
+		t.Fatalf("pre-backfill scan: %v", err)
+	}
+	if pre != nil {
+		t.Fatalf("setup: expected NULL, got %v", *pre)
+	}
+
+	// Run the backfill (mirrors gorm.go).
+	if err := db.Exec(
+		"UPDATE shares SET access_based_enumeration = ? WHERE access_based_enumeration IS NULL",
+		false,
+	).Error; err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	var post *bool
+	if err := db.Raw("SELECT access_based_enumeration FROM shares WHERE name = ?", "/legacy").Scan(&post).Error; err != nil {
+		t.Fatalf("post-backfill scan: %v", err)
+	}
+	if post == nil {
+		t.Fatalf("backfill left value NULL")
+	}
+	if *post {
+		t.Fatalf("backfill set true, want false")
+	}
+}

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // ============================================================================
@@ -216,9 +217,16 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		limit = 1000
 	}
 
+	// Refs #532 (PR #536 review): hydrate f.acl so DirEntry.Attr.ACL is
+	// populated, matching the Memory/Badger backends. Without this column,
+	// access-based enumeration (and any other ACL-aware caller iterating
+	// DirEntry.Attr) silently degrades to POSIX mode bits even on files that
+	// have a DACL set. ACL JSONB rows are typically small relative to the
+	// listing row itself, so the extra column adds negligible per-row cost
+	// versus the per-entry GetFile() round trip it avoids.
 	query := `
 		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.object_id, lc.link_count
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.object_id, lc.link_count
 		FROM parent_child_map dc
 		LEFT JOIN files f ON dc.child_id = f.id
 		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
@@ -241,11 +249,12 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		var size int64
 		var atime, mtime, ctime, creationTime time.Time
 		var hidden bool
+		var aclJSON []byte
 		var objectIDRaw []byte
 		var linkCount sql.NullInt32
 
 		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &objectIDRaw, &linkCount)
+			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &objectIDRaw, &linkCount)
 		if err != nil {
 			return nil, "", err
 		}
@@ -306,6 +315,17 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 				)
 			}
 			copy(attr.ObjectID[:], objectIDRaw)
+		}
+
+		// Refs #532 (PR #536 review): mirror fileRowToFileWithNlink. A
+		// malformed ACL row is treated as "no ACL" rather than failing the
+		// whole listing — same lenient behaviour the GetFile path has had
+		// since the column was introduced.
+		if len(aclJSON) > 0 {
+			var fileACL acl.ACL
+			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+				attr.ACL = &fileACL
+			}
 		}
 
 		entry := metadata.DirEntry{

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // Maximum number of retries for retryable errors (deadlock, serialization failure)
@@ -489,9 +490,11 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 		limit = 1000
 	}
 
+	// Refs #532 (PR #536 review): hydrate f.acl — keep parity with the
+	// pool-query ListChildren above. See files.go for rationale.
 	query := `
 		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.object_id, lc.link_count
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.object_id, lc.link_count
 		FROM parent_child_map dc
 		LEFT JOIN files f ON dc.child_id = f.id
 		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
@@ -514,11 +517,12 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 		var size int64
 		var atime, mtime, ctime, creationTime time.Time
 		var hidden bool
+		var aclJSON []byte
 		var objectIDRaw []byte
 		var linkCount sql.NullInt32
 
 		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &objectIDRaw, &linkCount)
+			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &objectIDRaw, &linkCount)
 		if err != nil {
 			return nil, "", err
 		}
@@ -564,6 +568,15 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 				)
 			}
 			copy(attr.ObjectID[:], objectIDRaw)
+		}
+
+		// Refs #532 (PR #536 review): mirror fileRowToFileWithNlink — soft
+		// failure on malformed ACL JSON, same as the pool-query path.
+		if len(aclJSON) > 0 {
+			var fileACL acl.ACL
+			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+				attr.ACL = &fileACL
+			}
 		}
 
 		entry := metadata.DirEntry{

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // runDirOpsTests runs all directory operation conformance tests.
 func runDirOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("CreateDirectory", func(t *testing.T) { testCreateDirectory(t, factory) })
 	t.Run("ListDirectory", func(t *testing.T) { testListDirectory(t, factory) })
+	t.Run("ListDirectoryHydratesACL", func(t *testing.T) { testListDirectoryHydratesACL(t, factory) })
 	t.Run("RemoveEmptyDirectory", func(t *testing.T) { testRemoveEmptyDirectory(t, factory) })
 	t.Run("NestedDirectories", func(t *testing.T) { testNestedDirectories(t, factory) })
 	t.Run("RootDirectoryIdempotent", func(t *testing.T) { testRootDirectoryIdempotent(t, factory) })
@@ -97,6 +99,67 @@ func testListDirectory(t *testing.T, factory StoreFactory) {
 		if names[i] != want {
 			t.Errorf("names[%d] = %q, want %q", i, names[i], want)
 		}
+	}
+}
+
+// testListDirectoryHydratesACL verifies that ListChildren populates
+// DirEntry.Attr.ACL so callers (notably SMB access-based enumeration, refs
+// PR #536) can make ACL-aware decisions without a follow-up GetFile per
+// entry. All non-trivial backends (Memory, Badger, Postgres) must satisfy
+// this contract.
+func testListDirectoryHydratesACL(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+
+	handle := createTestFile(t, store, "/test", rootHandle, "with-acl.txt", 0o600)
+
+	ctx := t.Context()
+
+	// Attach an ACL by reading + putting back the file with ACL set.
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	file.ACL = &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: acl.ACE4_READ_DATA,
+				Who:        acl.SpecialOwner,
+			},
+		},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile with ACL: %v", err)
+	}
+
+	entries, _, err := store.ListChildren(ctx, rootHandle, "", 100)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+
+	var found *metadata.DirEntry
+	for i := range entries {
+		if entries[i].Name == "with-acl.txt" {
+			found = &entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("with-acl.txt missing from listing")
+	}
+	if found.Attr == nil {
+		t.Fatalf("DirEntry.Attr nil — backend must hydrate attributes on ListChildren")
+	}
+	if found.Attr.ACL == nil {
+		t.Fatalf("DirEntry.Attr.ACL nil — backend must hydrate ACL on ListChildren so ABE can evaluate without per-entry GetFile")
+	}
+	if len(found.Attr.ACL.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE on hydrated ACL, got %d", len(found.Attr.ACL.ACEs))
+	}
+	got := found.Attr.ACL.ACEs[0]
+	if got.Type != acl.ACE4_ACCESS_ALLOWED_ACE_TYPE || got.AccessMask != acl.ACE4_READ_DATA || got.Who != acl.SpecialOwner {
+		t.Fatalf("hydrated ACE differs from stored: %+v", got)
 	}
 }
 

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -159,6 +159,10 @@ main() {
     $DFSCTL share create --name /smbbasic --acl-canonicalize-inherited=false $share_flags
     $DFSCTL share create --name /smbencrypted --encrypt-data $share_flags
     $DFSCTL share create --name /fileshare $share_flags
+    # Refs #532: smbtorture smb2.acls.ACCESSBASED connects to a share with the
+    # MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
+    # QUERY_DIRECTORY hides entries the caller cannot read.
+    $DFSCTL share create --name /hideunread --access-based-enumeration $share_flags
 
     # Create test users
     log_info "Creating test users..."
@@ -193,7 +197,7 @@ main() {
     # Wait for SMB adapter to start
     wait_for_smb localhost
 
-    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
+    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Implements per-share Windows access-based enumeration (MS-SRVS
`SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM`) so smbtorture
`smb2.acls.ACCESSBASED` can TREE_CONNECT to a `hideunread` share and
observe filtered directory listings.

- New `AccessBasedEnumeration` toggle on `models.Share`, runtime `Share`
  / `ShareConfig`, REST request/response, apiclient, and `dfsctl share
  create/edit/show` (default false).
- TREE_CONNECT response advertises
  `SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM` (0x00000080) per MS-SMB2
  §2.2.10 when the share has the flag set; flag is also captured on
  `TreeConnection` so per-request lookups stay O(1).
- `QUERY_DIRECTORY` filters entries the caller cannot read when ABE is
  enabled. Per-entry decision uses `acl.Evaluate` with `ACE4_READ_DATA`
  (== `ACE4_LIST_DIRECTORY` == 0x1); when `attr.ACL == nil` we fall back
  to POSIX mode bits, matching the existing
  `security.go::buildDACL` contract (refs #525) — the SD on the wire
  synthesizes a Windows default but server-side checks keep POSIX
  semantics so Unix mode bits remain authoritative. Root (UID 0)
  bypasses filtering.
- CI bootstrap (`test/smb-conformance/bootstrap.sh`) creates a
  `/hideunread` share with the toggle set.

## Spec refs

- MS-SMB2 §2.2.10 — TREE_CONNECT response `Capabilities`
  `SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM` (0x00000080)
- MS-SRVS — `SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM`
- Samba reference: `source3/smbd/dir.c::can_access_file_acl`

## Out of scope (parallel PRs)

- #529 / #530 / #531 — orthogonal DesiredAccess / ACL evaluation work.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] New unit tests in
  `internal/adapter/smb/v2/handlers/query_directory_abe_test.go`
  cover owner-only ACL, directory `LIST_DIRECTORY` semantics, POSIX
  mode-bit fallback, root bypass, and flag-off no-op semantics.
- [x] Targeted tests pass: `go test
  ./internal/adapter/smb/v2/handlers/...
  ./pkg/controlplane/... ./internal/controlplane/api/handlers/...
  ./pkg/apiclient/... ./cmd/dfsctl/...`
- [ ] CI smbtorture: `smb2.acls.ACCESSBASED` expected to flip from
  `Unable to connect to share 'hideunread'` to PASS (or surface a
  downstream ACL-eval gap to be tracked separately).

Closes #532.