### PR TITLE
fix(acl): owner implicit READ_CONTROL/WRITE_DAC/WRITE_OWNER per MS-DTYP §2.5.3.2 (#538)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -747,11 +747,15 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 		}
 	})
 
-	t.Run("AllowOnlyACEGrantsExactlyListedBits", func(t *testing.T) {
+	t.Run("AllowOnlyACEGrantsExactlyListedBitsPlusOwnerImplicit", func(t *testing.T) {
 		// Single ALLOW ACE granting exactly READ_DATA|READ_ATTRIBUTES|
-		// READ_ACL|SYNCHRONIZE — no extra bits should leak in from POSIX mode.
+		// READ_ACL|SYNCHRONIZE for OWNER@. No POSIX-mode leakage is allowed,
+		// but MS-DTYP §2.5.3.2 layers READ_CONTROL|WRITE_DAC|WRITE_OWNER on
+		// top of the explicit grants when the requester is the file owner.
 		authCtx := mkOwnerCtx()
-		want := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+		explicit := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
+		want := explicit | ownerImplicit
 		file := &metadata.File{
 			FileAttr: metadata.FileAttr{
 				UID:  1000,
@@ -762,7 +766,7 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 						{
 							Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
 							Who:        acl.SpecialOwner,
-							AccessMask: want,
+							AccessMask: explicit,
 						},
 					},
 				},
@@ -771,14 +775,17 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 
 		access := computeMaximalAccess(file, authCtx)
 		if access != want {
-			t.Errorf("MxAc = 0x%08x, expected exactly 0x%08x", access, want)
+			t.Errorf("MxAc = 0x%08x, expected 0x%08x (explicit 0x%08x + owner-implicit 0x%08x per MS-DTYP §2.5.3.2)",
+				access, want, explicit, ownerImplicit)
 		}
 	})
 
-	t.Run("EmptyACLDeniesAllProbedBits", func(t *testing.T) {
-		// An ACL with zero ACEs decides no bits — Evaluate returns false for
-		// every probe and the granted mask must be zero.
+	t.Run("EmptyACLGrantsOnlyOwnerImplicitBits", func(t *testing.T) {
+		// An ACL with zero ACEs has no explicit grants for anyone, but
+		// MS-DTYP §2.5.3.2 still grants the file owner READ_CONTROL|
+		// WRITE_DAC|WRITE_OWNER. Non-owners get nothing (covered elsewhere).
 		authCtx := mkOwnerCtx()
+		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
 		file := &metadata.File{
 			FileAttr: metadata.FileAttr{
 				UID:  1000,
@@ -789,8 +796,8 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 		}
 
 		access := computeMaximalAccess(file, authCtx)
-		if access != 0 {
-			t.Errorf("Empty ACL must deny all bits, got 0x%08x", access)
+		if access != ownerImplicit {
+			t.Errorf("Empty ACL: owner must receive only implicit RC|WRITE_DAC|WRITE_OWNER, got 0x%08x want 0x%08x", access, ownerImplicit)
 		}
 	})
 

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -747,13 +747,15 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 		}
 	})
 
-	t.Run("AllowOnlyACEGrantsExactlyListedBitsPlusOwnerImplicit", func(t *testing.T) {
+	t.Run("AllowACEPlusOwnerImplicitBits", func(t *testing.T) {
 		// Single ALLOW ACE granting exactly READ_DATA|READ_ATTRIBUTES|
-		// READ_ACL|SYNCHRONIZE for OWNER@. No POSIX-mode leakage is allowed,
-		// but MS-DTYP §2.5.3.2 layers READ_CONTROL|WRITE_DAC|WRITE_OWNER on
-		// top of the explicit grants when the requester is the file owner.
+		// SYNCHRONIZE for OWNER@. No POSIX-mode leakage is allowed, but
+		// MS-DTYP §2.5.3.2 layers READ_CONTROL|WRITE_DAC|WRITE_OWNER on top
+		// of the explicit grants when the requester is the file owner.
+		// `explicit` deliberately omits READ_CONTROL so the implicit-grant
+		// contribution is unambiguous in the assertion.
 		authCtx := mkOwnerCtx()
-		explicit := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+		explicit := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_SYNCHRONIZE)
 		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
 		want := explicit | ownerImplicit
 		file := &metadata.File{

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -40,10 +40,22 @@ func HasExplicitDeny(a *ACL) bool {
 	return false
 }
 
+// ownerImplicitRights is the set of access rights MS-DTYP §2.5.3.2 grants
+// implicitly to the file owner: READ_CONTROL, WRITE_DAC, and WRITE_OWNER.
+// These are layered on top of the explicit DACL grants unless suppressed by
+// an effective OWNER_RIGHTS (S-1-3-4) ACE in the DACL. Explicit DENY ACEs
+// in the DACL still win over the implicit grant for any specific bit.
+//
+// NFSv4 mask bits intentionally share positions with Windows MS-DTYP rights
+// (RFC 7530 §6.2.1), so the same constants describe both layers.
+const ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER
+
 // Evaluate implements the NFSv4 ACL evaluation algorithm per RFC 7530
-// Section 6.2.1, with the OWNER_RIGHTS (S-1-3-4) override from
-// MS-DTYP §2.5.3 / §2.4.10. It processes ACEs sequentially and returns
-// true only if ALL requested permission bits are explicitly allowed.
+// Section 6.2.1, with the OWNER_RIGHTS (S-1-3-4) override and the owner
+// implicit-grant rule from MS-DTYP §2.5.3 / §2.4.10 / §2.5.3.2. It
+// processes ACEs sequentially and returns true only if ALL requested
+// permission bits are explicitly allowed (or implicitly granted to the
+// owner per §2.5.3.2).
 //
 // The algorithm:
 //  1. Pre-scan (owner only): detect whether any effective OWNER_RIGHTS
@@ -51,7 +63,8 @@ func HasExplicitDeny(a *ACL) bool {
 //     requester is the file owner, the OWNER_RIGHTS ACEs become the sole
 //     authority for the owner: OWNER@ ACEs are ignored for matching
 //     purposes (they would otherwise supersede the OWNER_RIGHTS decision
-//     under first-match-wins). This mirrors Samba
+//     under first-match-wins) AND the §2.5.3.2 implicit owner grants are
+//     suppressed. This mirrors Samba
 //     `libcli/security/access_check.c::se_access_check`. AUDIT/ALARM
 //     ACEs do not affect access decisions and therefore do not trigger
 //     the override; non-owner requesters skip the pre-scan entirely.
@@ -62,14 +75,23 @@ func HasExplicitDeny(a *ACL) bool {
 //     - DENY: mark undecided bits as denied
 //     - AUDIT/ALARM: skip (store-only per project decision)
 //  5. Once all requested bits are decided, stop early.
-//  6. Return true if and only if ALL requested bits are in allowedBits.
+//  6. Owner-implicit pass (MS-DTYP §2.5.3.2): if the requester is the file
+//     owner AND no OWNER_RIGHTS ACE is present, OR `ownerImplicitRights`
+//     into `allowedBits` for any of those bits not already denied. Explicit
+//     DENY in the DACL still wins per-bit.
+//  7. Return true if and only if ALL requested bits are in allowedBits.
 func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	if requestedMask == 0 {
 		return true
 	}
-	if a == nil || len(a.ACEs) == 0 {
+	if a == nil {
 		return false
 	}
+	// Empty DACL: per MS-DTYP §2.5.3 the explicit grant set is empty
+	// ("deny all"). MS-DTYP §2.5.3.2 still applies — the file owner
+	// receives the implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER grants
+	// even when no ACE is present. Fall through to the owner-implicit
+	// pass below; non-owners terminate with an empty allowedBits.
 
 	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE
 	// that affects access decisions? The override only matters when the
@@ -132,6 +154,13 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 		if (allowedBits|deniedBits)&requestedMask == requestedMask {
 			break
 		}
+	}
+
+	// MS-DTYP §2.5.3.2 owner implicit grants: layered after the DACL walk
+	// so explicit DENY ACEs still win per-bit. Suppressed when OWNER_RIGHTS
+	// is present (§2.5.3 — OWNER_RIGHTS is the sole authority for the owner).
+	if evalCtx.UID == evalCtx.FileOwnerUID && !ownerRightsPresent {
+		allowedBits |= ownerImplicitRights &^ deniedBits
 	}
 
 	// Access is granted only if ALL requested bits are in allowedBits.

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -76,22 +76,22 @@ const ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER
 //     - AUDIT/ALARM: skip (store-only per project decision)
 //  5. Once all requested bits are decided, stop early.
 //  6. Owner-implicit pass (MS-DTYP §2.5.3.2): if the requester is the file
-//     owner AND no OWNER_RIGHTS ACE is present, OR `ownerImplicitRights`
-//     into `allowedBits` for any of those bits not already denied. Explicit
+//     owner AND no OWNER_RIGHTS ACE is present, add `ownerImplicitRights`
+//     to `allowedBits`, masked by the bits not already denied. Explicit
 //     DENY in the DACL still wins per-bit.
 //  7. Return true if and only if ALL requested bits are in allowedBits.
 func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	if requestedMask == 0 {
 		return true
 	}
+	// A nil ACL means "no DACL at all" — distinct from an empty DACL.
+	// An empty DACL (len(a.ACEs) == 0) is the MS-DTYP §2.5.3 "deny all"
+	// case but §2.5.3.2 still grants the file owner READ_CONTROL|
+	// WRITE_DAC|WRITE_OWNER, so we must fall through to the owner-implicit
+	// pass below rather than short-circuiting here.
 	if a == nil {
 		return false
 	}
-	// Empty DACL: per MS-DTYP §2.5.3 the explicit grant set is empty
-	// ("deny all"). MS-DTYP §2.5.3.2 still applies — the file owner
-	// receives the implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER grants
-	// even when no ACE is present. Fall through to the owner-implicit
-	// pass below; non-owners terminate with an empty allowedBits.
 
 	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE
 	// that affects access decisions? The override only matters when the
@@ -99,8 +99,9 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	// AUDIT/ALARM ACEs are evaluation no-ops and must not trigger the
 	// override — only ACCESS_ALLOWED/ACCESS_DENIED count. Inherit-only
 	// entries don't apply to access checks, so they don't count either.
+	requesterIsOwner := evalCtx.UID == evalCtx.FileOwnerUID
 	var ownerRightsPresent bool
-	if evalCtx.UID == evalCtx.FileOwnerUID {
+	if requesterIsOwner {
 		for i := range a.ACEs {
 			ace := &a.ACEs[i]
 			if ace.IsInheritOnly() {
@@ -159,7 +160,7 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	// MS-DTYP §2.5.3.2 owner implicit grants: layered after the DACL walk
 	// so explicit DENY ACEs still win per-bit. Suppressed when OWNER_RIGHTS
 	// is present (§2.5.3 — OWNER_RIGHTS is the sole authority for the owner).
-	if evalCtx.UID == evalCtx.FileOwnerUID && !ownerRightsPresent {
+	if requesterIsOwner && !ownerRightsPresent {
 		allowedBits |= ownerImplicitRights &^ deniedBits
 	}
 

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -610,3 +610,96 @@ func TestEvaluate_OwnerRights_AlarmAceDoesNotSuppressOwner(t *testing.T) {
 		t.Error("expected owner to retain OWNER@ rights when only an ALARM OwnerRights@ ACE is present")
 	}
 }
+
+// TestEvaluate_OwnerImplicitGrants_DataPlusImplicit verifies MS-DTYP §2.5.3.2:
+// owner gets READ_CONTROL / WRITE_DAC / WRITE_OWNER on top of explicit DACL
+// grants when no OWNER_RIGHTS ACE is present. The DACL here grants OWNER@
+// only READ_DATA; the owner must still be able to open for READ_DATA + the
+// three implicit standard rights together.
+func TestEvaluate_OwnerImplicitGrants_DataPlusImplicit(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+		},
+	}
+
+	requested := uint32(ACE4_READ_DATA | ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER)
+	if !Evaluate(a, ownerCtx(), requested) {
+		t.Error("expected owner to receive READ_DATA + implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER")
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_NoOwnerAceAtAll verifies that the owner
+// gets the §2.5.3.2 implicit grants even when the DACL has no OWNER@ ACE at
+// all — implicit grants are not gated on the owner being mentioned.
+func TestEvaluate_OwnerImplicitGrants_NoOwnerAceAtAll(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+		},
+	}
+
+	requested := uint32(ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER)
+	if !Evaluate(a, ownerCtx(), requested) {
+		t.Error("expected owner to receive implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER even with no OWNER@ ACE")
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_OwnerRightsSuppresses verifies §2.5.3:
+// when OWNER_RIGHTS ACE is present, the §2.5.3.2 implicit owner grants are
+// suppressed — OWNER_RIGHTS is the sole authority for the owner's rights.
+func TestEvaluate_OwnerImplicitGrants_OwnerRightsSuppresses(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+		},
+	}
+
+	// Owner requests READ_DATA — granted via OWNER_RIGHTS Allow.
+	if !Evaluate(a, ownerCtx(), ACE4_READ_DATA) {
+		t.Error("expected owner to receive READ_DATA from OWNER_RIGHTS Allow")
+	}
+	// Owner requests READ_CONTROL — should be DENIED because OWNER_RIGHTS
+	// suppresses the implicit grant and only Allows READ_DATA.
+	if Evaluate(a, ownerCtx(), ACE4_READ_ACL) {
+		t.Error("expected owner to be denied implicit READ_CONTROL when OWNER_RIGHTS is present")
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_ExplicitDenyWins verifies that an
+// explicit DENY ACE on a standard right (e.g., WRITE_DAC) overrides the
+// §2.5.3.2 implicit grant for that bit. Explicit DENY always wins.
+func TestEvaluate_OwnerImplicitGrants_ExplicitDenyWins(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			// DENY WRITE_DAC for owner — first-match-wins.
+			{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_ACL, Who: SpecialOwner},
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+		},
+	}
+
+	// READ_CONTROL + WRITE_OWNER (implicit) should still work.
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_OWNER) {
+		t.Error("expected owner to receive implicit READ_CONTROL|WRITE_OWNER")
+	}
+	// WRITE_DAC must be denied by explicit DENY.
+	if Evaluate(a, ownerCtx(), ACE4_WRITE_ACL) {
+		t.Error("expected owner WRITE_DAC denied by explicit DENY ACE")
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_NonOwnerUnaffected verifies non-owner
+// requesters do NOT receive the implicit standard rights — those are
+// owner-only per §2.5.3.2.
+func TestEvaluate_OwnerImplicitGrants_NonOwnerUnaffected(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+		},
+	}
+
+	// Non-owner requesting READ_CONTROL — must be denied (no implicit grant).
+	if Evaluate(a, nonOwnerCtx(), ACE4_READ_ACL) {
+		t.Error("expected non-owner to be denied READ_CONTROL (no implicit grant)")
+	}
+}

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -703,3 +703,44 @@ func TestEvaluate_OwnerImplicitGrants_NonOwnerUnaffected(t *testing.T) {
 		t.Error("expected non-owner to be denied READ_CONTROL (no implicit grant)")
 	}
 }
+
+// TestEvaluate_OwnerImplicitGrants_EmptyACL verifies the narrowed early-return:
+// an explicitly empty DACL (len(ACEs) == 0) is the MS-DTYP §2.5.3 "deny all"
+// case but §2.5.3.2 still grants the file owner READ_CONTROL|WRITE_DAC|
+// WRITE_OWNER. Non-owners get nothing.
+func TestEvaluate_OwnerImplicitGrants_EmptyACL(t *testing.T) {
+	a := &ACL{ACEs: nil}
+
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL|ACE4_WRITE_OWNER) {
+		t.Error("empty ACL: expected owner to receive implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER")
+	}
+	if Evaluate(a, ownerCtx(), ACE4_READ_DATA) {
+		t.Error("empty ACL: owner must NOT receive READ_DATA (not in implicit grant set)")
+	}
+	if Evaluate(a, nonOwnerCtx(), ACE4_READ_ACL) {
+		t.Error("empty ACL: non-owner must NOT receive any access")
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_InheritOnlyOwnerRightsDoesNotSuppress
+// locks in that an INHERIT_ONLY OWNER_RIGHTS ACE applies only to children and
+// does NOT suppress the §2.5.3.2 implicit owner grants on the current object.
+func TestEvaluate_OwnerImplicitGrants_InheritOnlyOwnerRightsDoesNotSuppress(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			// INHERIT_ONLY: applies only to children created under this dir.
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_INHERIT_ONLY_ACE | ACE4_FILE_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA,
+				Who:        SpecialOwnerRights,
+			},
+		},
+	}
+
+	// Owner still gets the implicit standard rights — the INHERIT_ONLY
+	// OWNER_RIGHTS ACE doesn't apply to this object's access check.
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL|ACE4_WRITE_OWNER) {
+		t.Error("INHERIT_ONLY OwnerRights@ must not suppress the implicit owner grants on this object")
+	}
+}


### PR DESCRIPTION
## Summary

Layers the file-owner implicit standard rights on top of explicit DACL grants per MS-DTYP §2.5.3.2. Suppressed when OWNER_RIGHTS (S-1-3-4) ACE is present per §2.5.3.

## Why

PR #531 (commit `ce671cee`) intentionally left this gap noted in the code: "DittoFS does not grant those implicit owner rights today." After PR #535 (`f662e05d`) wired DACL enforcement into CREATE, the gap surfaces as **over-deny cascades**.

`smb2.acls.CREATOR` fails at `source4/torture/smb2/acls.c:208`:
```
Incorrect status NT_STATUS_ACCESS_DENIED - should be NT_STATUS_OK
```

A DACL granting OWNER@ READ_DATA isn't enough for an open whose desired access also includes READ_CONTROL / SYNCHRONIZE — the spec layers those on top implicitly for the owner. Once acls.CREATOR fails, its leftover state breaks every later acls.* test at setup (`Unable to deltree when setting up smb2-testsd`), so this single bug cascades into ~10 setup-blocked failures.

## Changes

- `pkg/metadata/acl/evaluate.go`:
  - New `ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER` constant.
  - Post-walk `Evaluate` pass: when requester is file owner AND no effective OWNER_RIGHTS ACE is present, OR `ownerImplicitRights` into `allowedBits` for any bit not in `deniedBits` (explicit DENY still wins).
  - Empty-DACL early return narrowed: previously denied everything; now falls through to the owner-implicit pass so an empty DACL still grants its owner the three standard rights.
- `pkg/metadata/acl/evaluate_test.go`: 5 new cases (data+implicit, no OWNER@ ACE at all, OWNER_RIGHTS suppresses, explicit DENY wins, non-owner unaffected).
- `internal/adapter/smb/v2/handlers/create_test.go`: two existing `computeMaximalAccess` cases updated for the new contract.

## Spec references

- **MS-DTYP §2.5.3.2** — owner implicit `READ_CONTROL | WRITE_DAC | WRITE_OWNER`.
- **MS-DTYP §2.5.3 / §2.4.10.9** — OWNER_RIGHTS (S-1-3-4) suppresses the implicit grants.
- **Samba** `libcli/security/access_check.c::se_access_check` — search `SEC_STD_WRITE_DAC | SEC_STD_WRITE_OWNER | SEC_STD_READ_CONTROL` — canonical implementation.

## Expected smbtorture impact

Direct flip: `smb2.acls.CREATOR`.

Cascade unblock (these currently fail at setup because acls.CREATOR's leftover state breaks them):
- `smb2.acls.GENERIC`
- `smb2.acls.OWNER`
- `smb2.acls.INHERITANCE`
- `smb2.acls.INHERITFLAGS`
- `smb2.acls.SDFLAGSVSCHOWN`
- `smb2.acls.DYNAMIC`
- `smb2.acls.OWNER-RIGHTS`
- `smb2.acls.OWNER-RIGHTS-DENY`
- `smb2.acls.OWNER-RIGHTS-DENY1`
- `smb2.acls.DENY1`
- `smb2.acls.MXAC-NOT-GRANTED`
- `smb2.acls.OVERWRITE_READ_ONLY_FILE`

Most will likely still fail at deeper points (each exercises a different DACL feature) — this PR unblocks the cascade so each test reveals its actual next-layer bug. `KNOWN_FAILURES.md` left untouched per workflow rule; walk back after CI confirms each flip.

## Test plan

- [x] `go test ./pkg/metadata/acl/... ./pkg/metadata/... ./internal/adapter/smb/... ./internal/adapter/nfs/...` — all PASS
- [x] `go vet ./...` — clean
- [ ] CI smbtorture confirms `acls.CREATOR` flips
- [ ] CI smbtorture surfaces next-layer bugs in the previously-cascade-blocked acls.* tests

Closes #538
Refs #525 #528 #529 #530 #531 #532 #535