### PR TITLE
fix(smb/acl): match localdomain ACE Who form against requester UID

### DIFF
--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -2,8 +2,16 @@ package acl
 
 import (
 	"slices"
+	"strconv"
 	"strings"
 )
+
+// localDomainSuffix is the synthetic domain string SIDMapper.SIDToPrincipal
+// produces for machine-domain user/group SIDs ("{uid}@localdomain"). When an
+// SD round-trips through parse → store → evaluate, ACE.Who is in this form
+// for any SID that maps to a Unix UID/GID. Matching it against the requester
+// is by numeric UID/GID, not the username-form evalCtx.Who.
+const localDomainSuffix = "@localdomain"
 
 // EvaluateContext carries the requestor's identity and the file's
 // owner/group for dynamic OWNER@/GROUP@/EVERYONE@ resolution.
@@ -233,7 +241,35 @@ func aceMatchesWhoWithOwnerRights(ace *ACE, evalCtx *EvaluateContext, ownerRight
 			}
 			return slices.Contains(evalCtx.GroupSIDs, target)
 		}
-		// Legacy/string match (numeric uid, named principal).
+		// Machine-domain SIDs round-trip through SIDMapper.SIDToPrincipal as
+		// "{uid}@localdomain" (users) or "{gid}@localdomain" (groups). Match
+		// numerically against the requester's UID/GIDs so an ACE written with
+		// a raw machine-domain SID resolves the same as an OWNER@/GROUP@ ACE.
+		if id, ok := parseLocalDomainID(ace.Who); ok {
+			if id == evalCtx.UID {
+				return true
+			}
+			if id == evalCtx.GID {
+				return true
+			}
+			return slices.Contains(evalCtx.GIDs, id)
+		}
+		// Legacy/string match (named principal).
 		return ace.Who == evalCtx.Who
 	}
+}
+
+// parseLocalDomainID extracts the numeric prefix from a "{N}@localdomain"
+// ACE Who string. Returns (id, true) for valid forms only — non-numeric
+// prefixes and any other suffix yield (0, false).
+func parseLocalDomainID(who string) (uint32, bool) {
+	prefix, ok := strings.CutSuffix(who, localDomainSuffix)
+	if !ok {
+		return 0, false
+	}
+	id, err := strconv.ParseUint(prefix, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(id), true
 }

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -397,6 +397,86 @@ func TestAceMatchesWho_SIDForm(t *testing.T) {
 	}
 }
 
+func TestAceMatchesWho_LocalDomain(t *testing.T) {
+	cases := []struct {
+		name    string
+		aceWho  string
+		ctxUID  uint32
+		ctxGID  uint32
+		ctxGIDs []uint32
+		want    bool
+	}{
+		{
+			name:   "user_match_by_uid",
+			aceWho: "1000@localdomain",
+			ctxUID: 1000,
+			want:   true,
+		},
+		{
+			name:   "user_mismatch",
+			aceWho: "1000@localdomain",
+			ctxUID: 2000,
+			want:   false,
+		},
+		{
+			name:   "group_match_by_primary_gid",
+			aceWho: "500@localdomain",
+			ctxUID: 1000,
+			ctxGID: 500,
+			want:   true,
+		},
+		{
+			name:    "group_match_by_supplementary_gid",
+			aceWho:  "500@localdomain",
+			ctxUID:  1000,
+			ctxGID:  100,
+			ctxGIDs: []uint32{200, 500, 300},
+			want:    true,
+		},
+		{
+			name:   "non_numeric_prefix_falls_through",
+			aceWho: "alice@localdomain",
+			ctxUID: 1000,
+			want:   false,
+		},
+		{
+			name:   "wrong_suffix_falls_through",
+			aceWho: "1000@example.com",
+			ctxUID: 1000,
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ace := &ACE{Who: tc.aceWho, Type: ACE4_ACCESS_ALLOWED_ACE_TYPE}
+			ctx := &EvaluateContext{UID: tc.ctxUID, GID: tc.ctxGID, GIDs: tc.ctxGIDs}
+			got := aceMatchesWho(ace, ctx)
+			if got != tc.want {
+				t.Errorf("aceMatchesWho(%q, UID=%d, GID=%d, GIDs=%v) = %v, want %v",
+					tc.aceWho, tc.ctxUID, tc.ctxGID, tc.ctxGIDs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluate_LocalDomainOwnerMatch(t *testing.T) {
+	// Mirrors smbtorture acls.CREATOR: DACL contains an ALLOW ACE keyed by
+	// the file owner's raw machine-domain SID (round-tripped as
+	// "{uid}@localdomain" by SIDMapper.SIDToPrincipal). The owner must
+	// receive the granted access via the localdomain match, not the implicit
+	// owner pass — proving the parse → evaluate path works end-to-end.
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: "1000@localdomain", AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA},
+		},
+	}
+	ctx := &EvaluateContext{UID: 1000, FileOwnerUID: 1000}
+	if !Evaluate(a, ctx, ACE4_READ_DATA|ACE4_WRITE_DATA) {
+		t.Error("expected READ|WRITE granted to owner via localdomain ACE")
+	}
+}
+
 func TestEvaluate_DenyDoesNotAffectAlreadyDecidedBits(t *testing.T) {
 	// ALLOW read first, then DENY read: the bit is already decided as allowed.
 	a := &ACL{


### PR DESCRIPTION
## Summary

- Add `{N}@localdomain` recognition to `acl.aceMatchesWho` default branch
- Numeric match against requester UID + primary GID + supplementary GIDs
- Symmetric with `SIDMapper.SIDToPrincipal` round-trip form for machine-domain SIDs

## Why

`smbtorture smb2.acls.CREATOR` and the downstream phase-2 cascade fail because DACLs keyed by the file owner's **raw machine-domain SID** never match the owner. `SIDToPrincipal` stores ACE.Who as `{uid}@localdomain` for any SID that maps to a Unix UID; `aceMatchesWho` default branch was string-comparing against the username form (`wpts-admin@DITTOFS.TEST`) — so an explicit `FILE_READ_DATA | FILE_WRITE_DATA` grant keyed by raw SID stayed invisible. Owner-implicit (§2.5.3.2) only covers READ_CONTROL/WRITE_DAC/WRITE_OWNER, which doesn't help.

This is the missing piece phase-1 PRs (#533–#536, #539) all assumed was already wired.

## Spec / reference

- MS-DTYP §2.5.3 — ACE matching is per-token-identity; OWNER@/GROUP@ resolve dynamically
- MS-FSA §2.1.5.1.2.1 — open-existing security check
- Samba `source4/torture/smb2/acls.c::test_creator_sid` L211–244 — uses raw `owner_sid` ACE
- DittoFS `pkg/auth/sid/mapper.go::SIDToPrincipal` L235–260 — machine-domain SID → `{uid}@localdomain`

## Test plan

- [x] `go test ./pkg/metadata/acl/...` — new `TestAceMatchesWho_LocalDomain` (6 cases) + `TestEvaluate_LocalDomainOwnerMatch`
- [x] `go test ./pkg/metadata/...` — regression sweep
- [x] `go test ./internal/adapter/smb/v2/handlers/...` — regression sweep
- [ ] CI smbtorture: expect `smb2.acls.CREATOR` flip + adjacent raw-SID DACL tests (`GENERIC*`, `OWNER*`) to advance

## Closes

Closes #541. Refs #525 #529 #530 #531 #532.