### PR TITLE
fix(smb): per-class FILE_READ_ATTRIBUTES gate for QUERY_INFO (MS-SMB2 §3.3.5.20.1)

### DIFF
--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -272,12 +272,24 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// ========================================================================
 	// Step 2b: Validate DesiredAccess for QUERY_INFO
 	// ========================================================================
-	// Per MS-SMB2 3.3.5.20.1: For file and filesystem info, the open must
-	// include FILE_READ_ATTRIBUTES. GENERIC_ALL, MAXIMUM_ALLOWED, GENERIC_READ,
-	// and GENERIC_EXECUTE implicitly include FILE_READ_ATTRIBUTES.
-	if req.InfoType == types.SMB2InfoTypeFile || req.InfoType == types.SMB2InfoTypeFilesystem {
-		if !hasAccessRight(openFile.DesiredAccess, uint32(types.FileReadAttributes)) {
-			return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
+	// Per MS-SMB2 §3.3.5.20.1: only a closed list of FileInformationClass
+	// values are gated on Open.GrantedAccess. FILE_READ_ATTRIBUTES is
+	// required for FileBasicInformation, FileAllInformation, FilePipe*
+	// (FILE_PIPE_INFORMATION / FILE_PIPE_LOCAL_INFORMATION /
+	// FILE_PIPE_REMOTE_INFORMATION), FileNetworkOpenInformation, and
+	// FileAttributeTagInformation; FILE_READ_EA is required for
+	// FileFullEaInformation. All other classes (FileAccessInformation,
+	// FileStandardInformation, FileInternalInformation, FileNameInformation,
+	// …) are NOT gated and must succeed on opens that lack those rights —
+	// otherwise Samba's `CHECK_ACCESS_FLAGS` macro (smbtorture acls.CREATOR
+	// at acls.c:209, smb2_getinfo of FileAccessInformation on a
+	// FILE_READ_DATA-only handle) fails. Filesystem-class queries are gated
+	// at TreeConnect, not at Open, so no Open-level gate applies here.
+	if req.InfoType == types.SMB2InfoTypeFile {
+		if right, gated := fileInfoClassRequiredAccess(types.FileInfoClass(req.FileInfoClass)); gated {
+			if !hasAccessRight(openFile.DesiredAccess, right) {
+				return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
+			}
 		}
 	}
 
@@ -1065,6 +1077,30 @@ func resolveAccessFlags(desiredAccess uint32) uint32 {
 		uint32(types.GenericRead) | uint32(types.GenericWrite) | uint32(types.GenericExecute)
 
 	return resolved
+}
+
+// fileInfoClassRequiredAccess returns the access right Open.GrantedAccess
+// must include for a given SMB2_0_INFO_FILE FileInformationClass, per
+// MS-SMB2 §3.3.5.20.1. The second return value reports whether the class
+// is gated at all — classes not listed in the spec (FileAccessInformation,
+// FileStandardInformation, FileInternalInformation, FileNameInformation,
+// FilePositionInformation, FileModeInformation, FileAlignmentInformation,
+// FileStreamInformation, FileAlternateNameInformation,
+// FileNormalizedNameInformation, FileIdInformation, FileCompressionInformation,
+// FileEaInformation) succeed regardless of GrantedAccess. Pipe-only
+// classes (FILE_PIPE_*, MS-FSCC §2.4) are handled in handlePipeQueryInfo
+// before this gate runs, so we don't need to list them here.
+func fileInfoClassRequiredAccess(class types.FileInfoClass) (uint32, bool) {
+	switch class {
+	case types.FileBasicInformation,
+		types.FileAllInformation,
+		types.FileNetworkOpenInformation,
+		types.FileAttributeTagInformation:
+		return uint32(types.FileReadAttributes), true
+	case 15: // FileFullEaInformation [MS-FSCC §2.4.15]; constant not defined in types pkg
+		return uint32(types.FileReadEA), true
+	}
+	return 0, false
 }
 
 // hasAccessRight checks if the granted access mask includes the required right.

--- a/internal/adapter/smb/v2/handlers/query_info_test.go
+++ b/internal/adapter/smb/v2/handlers/query_info_test.go
@@ -276,6 +276,50 @@ func TestBuildFileInfoFromStore_FileStreamInformation(t *testing.T) {
 	})
 }
 
+func TestFileInfoClassRequiredAccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    types.FileInfoClass
+		want     uint32
+		wantGate bool
+	}{
+		// MS-SMB2 §3.3.5.20.1: gated on FILE_READ_ATTRIBUTES.
+		{"basic", types.FileBasicInformation, uint32(types.FileReadAttributes), true},
+		{"all", types.FileAllInformation, uint32(types.FileReadAttributes), true},
+		{"network_open", types.FileNetworkOpenInformation, uint32(types.FileReadAttributes), true},
+		{"attribute_tag", types.FileAttributeTagInformation, uint32(types.FileReadAttributes), true},
+		// MS-SMB2 §3.3.5.20.1: gated on FILE_READ_EA.
+		{"full_ea", 15, uint32(types.FileReadEA), true},
+		// Not gated by the spec — must succeed on any open. This is the
+		// acls.CREATOR / CHECK_ACCESS_FLAGS case that was previously broken
+		// by the blanket FILE_READ_ATTRIBUTES gate.
+		{"access_information", types.FileAccessInformation, 0, false},
+		{"standard_information", types.FileStandardInformation, 0, false},
+		{"internal_information", types.FileInternalInformation, 0, false},
+		{"name_information", types.FileNameInformation, 0, false},
+		{"position_information", types.FilePositionInformation, 0, false},
+		{"mode_information", types.FileModeInformation, 0, false},
+		{"alignment_information", types.FileAlignmentInformation, 0, false},
+		{"stream_information", types.FileStreamInformation, 0, false},
+		{"alternate_name_information", types.FileAlternateNameInformation, 0, false},
+		{"normalized_name_information", types.FileNormalizedNameInformation, 0, false},
+		{"id_information", types.FileIdInformation, 0, false},
+		{"ea_information", types.FileEaInformation, 0, false},
+		{"compression_information", types.FileCompressionInformation, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRight, gotGate := fileInfoClassRequiredAccess(tt.class)
+			if gotGate != tt.wantGate {
+				t.Errorf("fileInfoClassRequiredAccess(%d) gated=%v, want %v", tt.class, gotGate, tt.wantGate)
+			}
+			if gotRight != tt.want {
+				t.Errorf("fileInfoClassRequiredAccess(%d) right=0x%x, want 0x%x", tt.class, gotRight, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveAccessFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -50,7 +50,6 @@ descriptors, and owner rights are not implemented.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.acls.ACCESSBASED | ACLs | Windows ACL semantics not implemented | - |
-| smb2.acls.CREATOR | ACLs | Creator SID semantics not implemented | - |
 | smb2.acls.DENY1 | ACLs | ACL deny semantics not implemented | - |
 | smb2.acls.DYNAMIC | ACLs | Dynamic access checks not implemented | - |
 | smb2.acls.GENERIC | ACLs | Generic ACL mapping not implemented | - |


### PR DESCRIPTION
## Summary

- Replace blanket `FILE_READ_ATTRIBUTES`-on-every-class gate in `query_info.go` with a per-class allow-list keyed off `FileInfoClass`
- Add `fileInfoClassRequiredAccess` helper
- Drop the spurious filesystem-info gate (TreeConnect handles fs-class access at share level)
- Honor MS-SMB2 §3.3.5.20.1 exactly: only Basic / All / Pipe* / NetworkOpen / AttributeTag need `FILE_READ_ATTRIBUTES`; FullEa needs `FILE_READ_EA`; everything else is ungated

## Why

`smbtorture smb2.acls.CREATOR` fails at `acls.c:209`. After PR #542 the DACL match works and the CREATE with `FILE_READ_DATA` (only) succeeds — but the very next `QUERY_INFO FileAccessInformation` (Samba's `CHECK_ACCESS_FLAGS` macro) returns `STATUS_ACCESS_DENIED` because the open lacks `FILE_READ_ATTRIBUTES`. Spec doesn't gate that class. Same blanket gate is breaking other acls.* tests downstream and any client that opens read-only and queries effective rights.

Debug-agent root cause analysis confirmed via `/tmp/smbt-pr542/.../dittofs.log` trace.

## Spec / reference

- MS-SMB2 §3.3.5.20.1 — closed list of gated classes
- Samba `source3/smbd/smb2_getinfo.c` — exact case-set match (`FSCC_FILE_BASIC_INFORMATION`, `FSCC_FILE_ALL_INFORMATION`, `FSCC_FILE_NETWORK_OPEN_INFORMATION`, `FSCC_FILE_ATTRIBUTE_TAG_INFORMATION` → `SEC_FILE_READ_ATTRIBUTE`; `FullEaInformation` → `SEC_FILE_READ_EA`)
- Samba `source4/torture/smb2/acls.c::test_creator_sid` lines 207-210 — the failing `CHECK_ACCESS_FLAGS` invocation

## Test plan

- [x] `go test ./internal/adapter/smb/v2/handlers/...` — new `TestFileInfoClassRequiredAccess` (4 attr-gated + 1 EA-gated + 12 ungated)
- [x] `go test ./pkg/metadata/...` — regression sweep
- [ ] CI smbtorture: expect `smb2.acls.CREATOR` flip + likely `acls.OWNER` + adjacent narrow-access getinfo tests

## Closes

Closes #544. Refs #541 #542.