### PR TITLE
fix(smb): emit ABE bit in ShareFlags, not Capabilities (MS-SMB2 §2.2.10)

### DIFF
--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -248,7 +248,7 @@ type TreeConnection struct {
 	EncryptData bool                   // Share requires all requests to be encrypted
 	// AccessBasedEnumeration mirrors the share-level toggle. When true,
 	// QUERY_DIRECTORY filters entries the caller cannot read (refs #532,
-	// MS-SMB2 §2.2.10 SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM).
+	// MS-SMB2 §2.2.10 SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM).
 	AccessBasedEnumeration bool
 }
 

--- a/internal/adapter/smb/v2/handlers/tree_connect.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect.go
@@ -23,11 +23,13 @@ const treeConnectFixedSize = 8
 // [MS-SMB2] Section 2.2.10
 const SMB2ShareFlagEncryptData uint32 = 0x00008000
 
-// SMB2ShareCapAccessBasedDirectoryEnum advertises Windows access-based
-// enumeration on the share. When set in the Capabilities field of the
+// SMB2ShareFlagAccessBasedDirectoryEnum advertises Windows access-based
+// enumeration on the share. When set in the ShareFlags field of the
 // TREE_CONNECT response, clients learn that QUERY_DIRECTORY hides entries
-// the caller cannot read. [MS-SMB2] Section 2.2.10.
-const SMB2ShareCapAccessBasedDirectoryEnum uint32 = 0x00000080
+// the caller cannot read. [MS-SMB2] Section 2.2.10. Note: this lives in
+// ShareFlags (0x0800), not Capabilities — the Capabilities value 0x80 is
+// SMB2_SHARE_CAP_ASYMMETRIC, an unrelated dialect-3.0.2 feature.
+const SMB2ShareFlagAccessBasedDirectoryEnum uint32 = 0x00000800
 
 // ipcMaximalAccess defines the access rights for the IPC$ virtual share.
 // [MS-SMB2] Section 2.2.10 - MaximalAccess is a bitmask of allowed operations.
@@ -172,14 +174,17 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 	if share.EncryptData {
 		shareFlags |= SMB2ShareFlagEncryptData
 	}
-
-	// Capabilities — advertise per-share features. Refs #532: MS-SMB2 §2.2.10
-	// SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM tells the client we hide
-	// unreadable entries on enumeration.
-	var capabilities uint32
+	// Refs #549: SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM (MS-SMB2 §2.2.10)
+	// tells the client we hide unreadable entries on enumeration. The bit
+	// belongs in ShareFlags (0x0800), not Capabilities — matches Samba
+	// source3/smbd/smb2_tcon.c and the smbtorture acls.ACCESSBASED check
+	// at source4/torture/smb2/acls.c which reads smb2cli_tcon_flags().
 	if share.AccessBasedEnumeration {
-		capabilities |= SMB2ShareCapAccessBasedDirectoryEnum
+		shareFlags |= SMB2ShareFlagAccessBasedDirectoryEnum
 	}
+
+	// Capabilities — no per-share caps currently emitted.
+	var capabilities uint32
 
 	// Build response (16 bytes)
 	w := smbenc.NewWriter(16)

--- a/internal/adapter/smb/v2/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect_test.go
@@ -443,6 +443,16 @@ func TestTreeConnect_ShareEncryptDataConstant(t *testing.T) {
 	}
 }
 
+// Refs #549: SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM must be 0x00000800 in
+// the ShareFlags field per MS-SMB2 §2.2.10. PR #536 previously emitted 0x80 in
+// the Capabilities field, which is SMB2_SHARE_CAP_ASYMMETRIC and unrelated;
+// smbtorture smb2.acls.ACCESSBASED reads ShareFlags via smb2cli_tcon_flags.
+func TestTreeConnect_ShareFlagAccessBasedEnumConstant(t *testing.T) {
+	if SMB2ShareFlagAccessBasedDirectoryEnum != 0x00000800 {
+		t.Errorf("SMB2ShareFlagAccessBasedDirectoryEnum = 0x%08x, expected 0x00000800", SMB2ShareFlagAccessBasedDirectoryEnum)
+	}
+}
+
 func TestTreeConnect_EncryptedShareFlagsInResponse(t *testing.T) {
 	// Test that building a tree connect response with share flags at offset 4
 	// correctly encodes the ENCRYPT_DATA flag.

--- a/internal/adapter/smb/v2/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect_test.go
@@ -453,6 +453,111 @@ func TestTreeConnect_ShareFlagAccessBasedEnumConstant(t *testing.T) {
 	}
 }
 
+// newTreeConnectABEHandler builds an SMB handler with a single share whose
+// AccessBasedEnumeration flag is configurable. Returns the handler and the
+// session ID of an authenticated session, mirroring newTreeConnectGateHandler.
+func newTreeConnectABEHandler(t *testing.T, shareName string, abe bool) (*Handler, uint64) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	metaStore := memorymeta.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	cfg := &runtime.ShareConfig{
+		Name:                   shareName,
+		MetadataStore:          "test-meta",
+		Enabled:                true,
+		AccessBasedEnumeration: abe,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}
+	if err := rt.AddShare(context.Background(), cfg); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	sess := h.CreateSession("127.0.0.1:12345", false, "testuser", "")
+	return h, sess.SessionID
+}
+
+// TestTreeConnect_AccessBasedEnumerationShareFlag verifies the wire-level
+// TREE_CONNECT response when a share has AccessBasedEnumeration set. The ABE
+// bit (0x0800) must appear in ShareFlags (offset 4) and must NOT leak into
+// Capabilities (offset 8) — the latter holds SMB2_SHARE_CAP_ASYMMETRIC at 0x80
+// per MS-SMB2 §2.2.10 and is unrelated to ABE (refs #549).
+func TestTreeConnect_AccessBasedEnumerationShareFlag(t *testing.T) {
+	t.Run("EnabledShareSetsShareFlagBit", func(t *testing.T) {
+		h, sessionID := newTreeConnectABEHandler(t, "/abe", true)
+		ctx := newTreeConnectTestContext(sessionID)
+
+		body := buildTreeConnectRequestBody("\\\\server\\abe")
+		result, err := h.TreeConnect(ctx, body)
+		if err != nil {
+			t.Fatalf("TreeConnect returned unexpected error: %v", err)
+		}
+		if result.Status != types.StatusSuccess {
+			t.Fatalf("Status = 0x%x, want StatusSuccess (0x%x)",
+				result.Status, types.StatusSuccess)
+		}
+		if len(result.Data) != 16 {
+			t.Fatalf("Response should be 16 bytes, got %d", len(result.Data))
+		}
+
+		// ShareFlags at offset 4..8 must have ABE bit (0x0800) set.
+		shareFlags := binary.LittleEndian.Uint32(result.Data[4:8])
+		if shareFlags&SMB2ShareFlagAccessBasedDirectoryEnum == 0 {
+			t.Errorf("ShareFlags = 0x%08x, expected SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM (0x0800) set",
+				shareFlags)
+		}
+
+		// Capabilities at offset 8..12 must NOT carry the previously-wrong
+		// 0x80 bit (that is SMB2_SHARE_CAP_ASYMMETRIC and unrelated to ABE).
+		capabilities := binary.LittleEndian.Uint32(result.Data[8:12])
+		if capabilities&0x80 != 0 {
+			t.Errorf("Capabilities = 0x%08x, should NOT have 0x80 set (refs #549 regression)",
+				capabilities)
+		}
+	})
+
+	t.Run("DisabledShareDoesNotSetShareFlagBit", func(t *testing.T) {
+		h, sessionID := newTreeConnectABEHandler(t, "/no-abe", false)
+		ctx := newTreeConnectTestContext(sessionID)
+
+		body := buildTreeConnectRequestBody("\\\\server\\no-abe")
+		result, err := h.TreeConnect(ctx, body)
+		if err != nil {
+			t.Fatalf("TreeConnect returned unexpected error: %v", err)
+		}
+		if result.Status != types.StatusSuccess {
+			t.Fatalf("Status = 0x%x, want StatusSuccess (0x%x)",
+				result.Status, types.StatusSuccess)
+		}
+		if len(result.Data) != 16 {
+			t.Fatalf("Response should be 16 bytes, got %d", len(result.Data))
+		}
+
+		// ShareFlags at offset 4..8 must NOT have the ABE bit (0x0800) set.
+		shareFlags := binary.LittleEndian.Uint32(result.Data[4:8])
+		if shareFlags&SMB2ShareFlagAccessBasedDirectoryEnum != 0 {
+			t.Errorf("ShareFlags = 0x%08x, should NOT have SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM (0x0800) set when ABE is disabled",
+				shareFlags)
+		}
+
+		// And the wrong 0x80 bit must not leak into Capabilities either.
+		capabilities := binary.LittleEndian.Uint32(result.Data[8:12])
+		if capabilities&0x80 != 0 {
+			t.Errorf("Capabilities = 0x%08x, should NOT have 0x80 set",
+				capabilities)
+		}
+	})
+}
+
 func TestTreeConnect_EncryptedShareFlagsInResponse(t *testing.T) {
 	// Test that building a tree connect response with share flags at offset 4
 	// correctly encodes the ENCRYPT_DATA flag.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -34,9 +34,10 @@ type Share struct {
 	AclFlagInheritedCanonicalization bool `gorm:"default:true;not null" json:"acl_flag_inherited_canonicalization"`
 	// AccessBasedEnumeration enables Windows access-based enumeration on the
 	// share (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM per MS-SRVS). When
-	// true, TREE_CONNECT advertises SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM
-	// (MS-SMB2 §2.2.10) and QUERY_DIRECTORY hides entries the caller cannot
-	// read. Default false matches the historical behaviour (refs #532).
+	// true, TREE_CONNECT sets SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM in
+	// ShareFlags (MS-SMB2 §2.2.10) and QUERY_DIRECTORY hides entries the
+	// caller cannot read. Default false matches the historical behaviour
+	// (refs #532, #549).
 	AccessBasedEnumeration bool      `gorm:"default:false;not null" json:"access_based_enumeration"`
 	DefaultPermission      string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
 	Config                 string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -57,10 +57,10 @@ type Share struct {
 
 	// AccessBasedEnumeration enables Windows access-based enumeration on the
 	// share (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM per MS-SRVS). When
-	// true, TREE_CONNECT advertises
-	// SMB2_SHARE_CAP_ACCESS_BASED_DIRECTORY_ENUM (MS-SMB2 §2.2.10) and the
-	// SMB QUERY_DIRECTORY handler filters out entries the caller cannot
-	// read. Default false (refs #532).
+	// true, TREE_CONNECT sets SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM in
+	// ShareFlags (MS-SMB2 §2.2.10) and the SMB QUERY_DIRECTORY handler
+	// filters out entries the caller cannot read. Default false (refs #532,
+	// #549).
 	AccessBasedEnumeration bool
 
 	// NFS-specific options


### PR DESCRIPTION
## Summary

PR #536 ORed the access-based-enumeration bit (0x80) into the **Capabilities** field of the SMB2 TREE_CONNECT response. Per MS-SMB2 §2.2.10 the correct field is **ShareFlags**, and the value is `0x0800` — `SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM`. The value `0x80` in Capabilities is `SMB2_SHARE_CAP_ASYMMETRIC` (dialect ≥ 3.0.2), unrelated to ABE.

This is why `smbtorture smb2.acls.ACCESSBASED` fails at `source4/torture/smb2/acls.c:2222` with `No access enumeration on share 'hideunread'` — the test reads `smb2cli_tcon_flags()` which returns `tcon->smb2.flags` (the ShareFlags field) and checks for `SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM`.

The fix matches Samba's `source3/smbd/smb2_tcon.c`, which sets the bit via `*out_share_flags |= SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM`.

The rest of the wiring (CLI `--access-based-enumeration` flag, model column, store persistence, runtime config propagation, QUERY_DIRECTORY filtering) was correct from #536 — only the wire-format field assignment was wrong.

## Changes

- `internal/adapter/smb/v2/handlers/tree_connect.go` — rename `SMB2ShareCapAccessBasedDirectoryEnum (0x80)` → `SMB2ShareFlagAccessBasedDirectoryEnum (0x0800)`; OR it into `shareFlags` instead of `capabilities`.
- `internal/adapter/smb/v2/handlers/tree_connect_test.go` — add constant test asserting the value is `0x0800`.
- Doc-comment fixes in `handler.go`, `models/share.go`, `runtime/shares/service.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/adapter/smb/... ./pkg/controlplane/...` — SMB + controlplane suites pass (one unrelated port-bind flake in `pkg/controlplane/api`).
- [ ] CI smbtorture: expect `smb2.acls.ACCESSBASED` to advance past the share-cap check at `acls.c:2222`. KNOWN_FAILURES.md walkback deferred to a follow-up commit once CI confirms — the test may still fail at deeper Windows-ACL enforcement layers (entry line 52 reason is "Windows ACL semantics not implemented", so a full flip is not guaranteed by this PR alone).

Closes #549. Refs #532 #536.