### PR TITLE
fix(smb): FileAccessInformation reports DACL-evaluated GrantedAccess

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1222,14 +1222,28 @@ func (h *Handler) handleOpenRootCreate(
 
 	// Store open file
 	smbFileID := h.GenerateFileID()
-	// Share-root opens have no per-file DACL gate; the granted set is the
-	// resolved request mask. Honors MS-SMB2 §3.3.5.9 paragraph 8 for the
-	// share-root pseudo-object.
-	grantedAccess := resolveAccessFlags(req.DesiredAccess)
+	// Share-root open: report the DACL-evaluated per-bit granted mask per
+	// MS-SMB2 §3.3.5.9 paragraph 8. CheckFileAccess returns the granted
+	// intersection on both arms (allow AND ErrAccessDenied). Share-root
+	// access has already been authorised upstream (CheckExportAccess at
+	// mount + Tree Connect ACL); a partial-deny here therefore reflects a
+	// narrower DACL than the share-level grant, not a fatal denial, so we
+	// log it and continue with the (possibly narrowed) mask rather than
+	// overstate rights by re-resolving DesiredAccess.
+	var grantedAccess uint32
 	if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil {
-		if g, err := metaSvc.CheckFileAccess(rootFile, authCtx, req.DesiredAccess); err == nil {
-			grantedAccess = g
+		g, err := metaSvc.CheckFileAccess(rootFile, authCtx, req.DesiredAccess)
+		if err != nil {
+			logger.Debug("CREATE: share-root CheckFileAccess returned narrowed mask",
+				"share", tree.ShareName,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"granted", fmt.Sprintf("0x%x", g),
+				"error", err)
 		}
+		grantedAccess = g
+	} else {
+		// No metadata service available: fall back to the resolved mask.
+		grantedAccess = resolveAccessFlags(req.DesiredAccess)
 	}
 	openFile := &OpenFile{
 		FileID:         smbFileID,

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1166,6 +1166,8 @@ func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, t
 		ShareName:     tree.ShareName,
 		OpenTime:      time.Now(),
 		DesiredAccess: req.DesiredAccess,
+		// Pipes have no DACL; the granted set is the resolved request.
+		GrantedAccess: resolveAccessFlags(req.DesiredAccess),
 		IsDirectory:   false,
 		IsPipe:        true,
 		PipeName:      pipeName,
@@ -1220,6 +1222,15 @@ func (h *Handler) handleOpenRootCreate(
 
 	// Store open file
 	smbFileID := h.GenerateFileID()
+	// Share-root opens have no per-file DACL gate; the granted set is the
+	// resolved request mask. Honors MS-SMB2 §3.3.5.9 paragraph 8 for the
+	// share-root pseudo-object.
+	grantedAccess := resolveAccessFlags(req.DesiredAccess)
+	if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil {
+		if g, err := metaSvc.CheckFileAccess(rootFile, authCtx, req.DesiredAccess); err == nil {
+			grantedAccess = g
+		}
+	}
 	openFile := &OpenFile{
 		FileID:         smbFileID,
 		TreeID:         ctx.TreeID,
@@ -1228,6 +1239,7 @@ func (h *Handler) handleOpenRootCreate(
 		ShareName:      tree.ShareName,
 		OpenTime:       time.Now(),
 		DesiredAccess:  req.DesiredAccess,
+		GrantedAccess:  grantedAccess,
 		IsDirectory:    true,
 		MetadataHandle: rootHandle,
 	}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -207,7 +207,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// is denied. New files (createAction == FileCreated) inherit their ACL from
 	// the parent at create time and don't need this check — parent write was
 	// already gated via CheckParentWriteAccess in Create(). Tracking #529.
+	//
+	// grantedAccess captures the effective rights for the open per
+	// MS-SMB2 §3.3.5.9 paragraph 8: the per-bit intersection of the
+	// requested mask with the file's DACL. Carried onto OpenFile.GrantedAccess
+	// below and consumed by FileAccessInformation (#548, MS-FSCC §2.4.1) and
+	// the QUERY_INFO open-level access gate (MS-SMB2 §3.3.5.20.1).
 	metaSvc := h.Registry.GetMetadataService()
+	var grantedAccess uint32
+	var grantedComputed bool
 	if fileExists && existingFile != nil {
 		granted, err := metaSvc.CheckFileAccess(existingFile, authCtx, req.DesiredAccess)
 		if err != nil {
@@ -218,6 +226,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				"error", err)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
 		}
+		grantedAccess = granted
+		grantedComputed = true
 	}
 
 	// Step 6d: Validate delete-on-close requirements per MS-FSA 2.1.5.1.2.1.
@@ -279,6 +289,25 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		if err != nil {
 			logger.Warn("CREATE: failed to overwrite file", "name", baseName, "error", err)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
+		}
+	}
+
+	// Compute GrantedAccess for new/overwritten files. The fileExists branch
+	// above already populated grantedAccess from CheckFileAccess. For
+	// FileCreated the ACL was inherited from the parent at create time; for
+	// FileOverwritten/Superseded the existing DACL is preserved. Both need
+	// the intersection of req.DesiredAccess with the resulting file's DACL —
+	// CheckFileAccess returns it without ever denying (we already passed all
+	// upstream gates including CheckParentWriteAccess for FileCreated).
+	// Errors from CheckFileAccess here are non-fatal: fall back to the
+	// resolved DesiredAccess so the open still succeeds.
+	if !grantedComputed && file != nil {
+		if g, err := metaSvc.CheckFileAccess(file, authCtx, req.DesiredAccess); err == nil {
+			grantedAccess = g
+		} else {
+			logger.Debug("CREATE: post-create CheckFileAccess fallback",
+				"path", filename, "error", err)
+			grantedAccess = resolveAccessFlags(req.DesiredAccess)
 		}
 	}
 
@@ -450,6 +479,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		ShareName:      tree.ShareName,
 		OpenTime:       time.Now(),
 		DesiredAccess:  req.DesiredAccess,
+		GrantedAccess:  grantedAccess,
 		IsDirectory:    file.Type == metadata.FileTypeDirectory,
 		MetadataHandle: fileHandle,
 		PayloadID:      file.PayloadID,

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -297,18 +297,24 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// FileCreated the ACL was inherited from the parent at create time; for
 	// FileOverwritten/Superseded the existing DACL is preserved. Both need
 	// the intersection of req.DesiredAccess with the resulting file's DACL —
-	// CheckFileAccess returns it without ever denying (we already passed all
-	// upstream gates including CheckParentWriteAccess for FileCreated).
-	// Errors from CheckFileAccess here are non-fatal: fall back to the
-	// resolved DesiredAccess so the open still succeeds.
+	// CheckFileAccess returns the per-bit granted mask in both arms (allow
+	// AND deny), so always take the returned mask. Upstream gates
+	// (CheckParentWriteAccess for FileCreated; DACL check at step 6c-bis for
+	// the existing-file path that flows into Overwrite/Supersede) have
+	// already approved the open — an unexpected ErrAccessDenied here would
+	// indicate the post-create DACL diverged from the parent's inherited
+	// set, so we log and continue with the (possibly narrowed) granted mask
+	// rather than overstate rights by re-resolving DesiredAccess.
 	if !grantedComputed && file != nil {
-		if g, err := metaSvc.CheckFileAccess(file, authCtx, req.DesiredAccess); err == nil {
-			grantedAccess = g
-		} else {
-			logger.Debug("CREATE: post-create CheckFileAccess fallback",
-				"path", filename, "error", err)
-			grantedAccess = resolveAccessFlags(req.DesiredAccess)
+		g, err := metaSvc.CheckFileAccess(file, authCtx, req.DesiredAccess)
+		if err != nil {
+			logger.Debug("CREATE: post-create CheckFileAccess returned narrowed mask",
+				"path", filename,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"granted", fmt.Sprintf("0x%x", g),
+				"error", err)
 		}
+		grantedAccess = g
 	}
 
 	// Step 7a: Restore frozen timestamps on parent directory (MS-FSA 2.1.5.14.2).

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -460,11 +460,19 @@ func validateAndRestore(
 		"shareName", handle.ShareName)
 
 	restored := &OpenFile{
-		FileID:         handle.FileID,
-		SessionID:      sessionID,
-		Path:           handle.Path,
-		ShareName:      handle.ShareName,
-		DesiredAccess:  handle.DesiredAccess,
+		FileID:        handle.FileID,
+		SessionID:     sessionID,
+		Path:          handle.Path,
+		ShareName:     handle.ShareName,
+		DesiredAccess: handle.DesiredAccess,
+		// Durable reconnect: GrantedAccess is not currently persisted
+		// (PersistedDurableHandle predates #548). Fall back to the resolved
+		// DesiredAccess — the same value FileAccessInformation returned
+		// before #548. Persisting GrantedAccess across reconnect is tracked
+		// as a follow-up; today's clients reconnecting with the same
+		// DesiredAccess (per MS-SMB2 §3.3.5.9.9 mismatch check) see identical
+		// behavior to the pre-fix code path.
+		GrantedAccess:  resolveAccessFlags(handle.DesiredAccess),
 		MetadataHandle: handle.MetadataHandle,
 		PayloadID:      metadata.PayloadID(handle.PayloadID),
 		ShareAccess:    handle.ShareAccess,

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -465,14 +465,23 @@ func validateAndRestore(
 		Path:          handle.Path,
 		ShareName:     handle.ShareName,
 		DesiredAccess: handle.DesiredAccess,
-		// Durable reconnect: GrantedAccess is not currently persisted
-		// (PersistedDurableHandle predates #548). Fall back to the resolved
-		// DesiredAccess — the same value FileAccessInformation returned
-		// before #548. Persisting GrantedAccess across reconnect is tracked
-		// as a follow-up; today's clients reconnecting with the same
-		// DesiredAccess (per MS-SMB2 §3.3.5.9.9 mismatch check) see identical
-		// behavior to the pre-fix code path.
-		GrantedAccess:  resolveAccessFlags(handle.DesiredAccess),
+		// Restore the original DACL-evaluated GrantedAccess persisted at
+		// disconnect. Mirrors Samba: the access mask captured at open is
+		// preserved verbatim through reconnect so the re-established
+		// handle reports identical rights via FileAccessInformation /
+		// FileAllInformation, even when the open was made with
+		// MAXIMUM_ALLOWED or the file's DACL has changed in the interim.
+		// Pre-#548 persisted handles (written before this field existed)
+		// decode with GrantedAccess=0; fall back to the resolved
+		// DesiredAccess in that case for forward compatibility — the
+		// fallback matches the pre-#548 behaviour and only affects in-flight
+		// reconnects across the upgrade boundary.
+		GrantedAccess: func() uint32 {
+			if handle.GrantedAccess != 0 {
+				return handle.GrantedAccess
+			}
+			return resolveAccessFlags(handle.DesiredAccess)
+		}(),
 		MetadataHandle: handle.MetadataHandle,
 		PayloadID:      metadata.PayloadID(handle.PayloadID),
 		ShareAccess:    handle.ShareAccess,
@@ -612,6 +621,7 @@ func buildPersistedDurableHandle(
 		Path:            openFile.Path,
 		ShareName:       openFile.ShareName,
 		DesiredAccess:   openFile.DesiredAccess,
+		GrantedAccess:   openFile.GrantedAccess,
 		ShareAccess:     openFile.ShareAccess,
 		CreateOptions:   uint32(openFile.CreateOptions),
 		MetadataHandle:  metaHandle,

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -257,14 +257,25 @@ type TreeConnection struct {
 // tracks directory enumeration state, delete-on-close flags, and oplock level.
 // Stored in a sync.Map keyed by the 16-byte FileID.
 type OpenFile struct {
-	FileID              [16]byte
-	TreeID              uint32
-	SessionID           uint64
-	Path                string
-	ShareName           string
-	cachedOpenID        string // cached hex(FileID) for hot-path lock operations
-	OpenTime            time.Time
-	DesiredAccess       uint32
+	FileID        [16]byte
+	TreeID        uint32
+	SessionID     uint64
+	Path          string
+	ShareName     string
+	cachedOpenID  string // cached hex(FileID) for hot-path lock operations
+	OpenTime      time.Time
+	DesiredAccess uint32
+	// GrantedAccess is the effective access mask the open actually holds,
+	// computed at CREATE as the per-bit intersection of the requested mask
+	// with the file's DACL (via metadata.CheckFileAccess). Per MS-SMB2
+	// §3.3.5.9 paragraph 8 / §2.2.13.1, when MAXIMUM_ALLOWED is requested
+	// this is the set of rights the requester is allowed; for explicit
+	// requests it is the requested set (the open would have been rejected
+	// if any non-MAXIMUM_ALLOWED bit was denied). Per MS-SMB2 §3.3.5.20.1
+	// and MS-FSCC §2.4.1, FileAccessInformation and QUERY_INFO open-level
+	// access gates consult this field, not DesiredAccess (smb2.acls.GENERIC
+	// at acls.c:440).
+	GrantedAccess       uint32
 	IsDirectory         bool
 	IsPipe              bool   // True if this is a named pipe (IPC$)
 	PipeName            string // Named pipe name (e.g., "srvsvc")

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -287,7 +287,11 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// at TreeConnect, not at Open, so no Open-level gate applies here.
 	if req.InfoType == types.SMB2InfoTypeFile {
 		if right, gated := fileInfoClassRequiredAccess(types.FileInfoClass(req.FileInfoClass)); gated {
-			if !hasAccessRight(openFile.DesiredAccess, right) {
+			// MS-SMB2 §3.3.5.20.1: "If the FileInformationClass is
+			// FileBasicInformation [...] and Open.GrantedAccess does not
+			// include FILE_READ_ATTRIBUTES, return STATUS_ACCESS_DENIED."
+			// GrantedAccess is set at CREATE via CheckFileAccess.
+			if !hasAccessRight(openFile.GrantedAccess, right) {
 				return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 			}
 		}
@@ -560,9 +564,13 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileAccessInformation:
 		// FILE_ACCESS_INFORMATION [MS-FSCC] 2.4.1 (4 bytes)
-		// Per MS-FSCC 2.4.1: AccessFlags reflects the access granted to the caller.
+		// Per MS-FSCC 2.4.1 the AccessFlags field reports the access
+		// granted to the caller — not the requested DesiredAccess. Per
+		// MS-SMB2 §3.3.5.9 paragraph 8 the server computes this at CREATE
+		// as DesiredAccess intersected with the file's DACL and stores it
+		// on Open.GrantedAccess (#548, smb2.acls.GENERIC at acls.c:440).
 		w := smbenc.NewWriter(4)
-		w.WriteUint32(resolveAccessFlags(openFile.DesiredAccess))
+		w.WriteUint32(openFile.GrantedAccess)
 		return w.Bytes(), nil
 
 	case types.FileStreamInformation:
@@ -710,13 +718,13 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	fileIndex := binary.LittleEndian.Uint64(internalFileID[:8])
 
 	w := smbenc.NewWriter(36)
-	w.WriteUint64(fileIndex)                                  // InternalInformation (8 bytes) at offset 64
-	w.WriteUint32(0)                                          // EaInformation (4 bytes) at offset 72
-	w.WriteUint32(resolveAccessFlags(openFile.DesiredAccess)) // AccessInformation (4 bytes) at offset 76
-	w.WriteUint64(0)                                          // PositionInformation (8 bytes) at offset 80
-	w.WriteUint32(0)                                          // ModeInformation (4 bytes) at offset 88
-	w.WriteUint32(0)                                          // AlignmentInformation (4 bytes) at offset 92
-	w.WriteUint32(uint32(len(nameBytes)))                     // NameInformation length at offset 96
+	w.WriteUint64(fileIndex)              // InternalInformation (8 bytes) at offset 64
+	w.WriteUint32(0)                      // EaInformation (4 bytes) at offset 72
+	w.WriteUint32(openFile.GrantedAccess) // AccessInformation (4 bytes) at offset 76 — see FileAccessInformation
+	w.WriteUint64(0)                      // PositionInformation (8 bytes) at offset 80
+	w.WriteUint32(0)                      // ModeInformation (4 bytes) at offset 88
+	w.WriteUint32(0)                      // AlignmentInformation (4 bytes) at offset 92
+	w.WriteUint32(uint32(len(nameBytes))) // NameInformation length at offset 96
 	copy(info[64:100], w.Bytes())
 
 	copy(info[100:], nameBytes)

--- a/internal/adapter/smb/v2/handlers/query_info_test.go
+++ b/internal/adapter/smb/v2/handlers/query_info_test.go
@@ -360,6 +360,49 @@ func TestFileAccessInformation_ReturnsGrantedAccess(t *testing.T) {
 	}
 }
 
+// TestFileAllInformation_AccessInformationReturnsGrantedAccess locks the
+// contract added in #548 for the FileAllInformation embedded
+// AccessInformation field. Per MS-FSCC §2.4.2 the AccessInformation block
+// sits at fixed offset 76 (Basic 40 + Standard 24 + Internal 8 + EA 4 = 76)
+// and MUST report the DACL-evaluated effective rights — i.e. mirror what a
+// standalone FileAccessInformation query would return — NOT a re-resolved
+// DesiredAccess. Companion to TestFileAccessInformation_ReturnsGrantedAccess.
+func TestFileAllInformation_AccessInformationReturnsGrantedAccess(t *testing.T) {
+	h := NewHandler()
+	file := &metadata.File{
+		ID: uuid.New(),
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Size: 0,
+		},
+	}
+	// Mirrors the FileAccessInformation test: open made with MAXIMUM_ALLOWED
+	// whose effective DACL grant is 0x00070080, not FILE_ALL_ACCESS.
+	const expected uint32 = 0x00070080
+	openFile := &OpenFile{
+		FileName:      "test.txt",
+		Path:          "test.txt",
+		DesiredAccess: uint32(types.MaximumAllowed),
+		GrantedAccess: expected,
+	}
+	info, err := h.buildFileInfoFromStore(
+		&metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}},
+		file, openFile, types.FileAllInformation,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// FileAllInformation fixed prefix is 100 bytes (40+24+8+4+4+8+4+4+4).
+	// AccessInformation is the 4-byte field at offset 76.
+	if len(info) < 80 {
+		t.Fatalf("info length = %d, want >= 80", len(info))
+	}
+	got := binary.LittleEndian.Uint32(info[76:80])
+	if got != expected {
+		t.Errorf("FileAllInformation AccessInformation @ offset 76 = 0x%08x, want 0x%08x (GrantedAccess)", got, expected)
+	}
+}
+
 func TestResolveAccessFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/adapter/smb/v2/handlers/query_info_test.go
+++ b/internal/adapter/smb/v2/handlers/query_info_test.go
@@ -320,6 +320,46 @@ func TestFileInfoClassRequiredAccess(t *testing.T) {
 	}
 }
 
+// TestFileAccessInformation_ReturnsGrantedAccess locks the contract added
+// in #548: FileAccessInformation MUST report OpenFile.GrantedAccess (the
+// DACL-evaluated effective rights), NOT a re-resolved DesiredAccess.
+// smbtorture smb2.acls.GENERIC at acls.c:440 fails when this is wrong.
+func TestFileAccessInformation_ReturnsGrantedAccess(t *testing.T) {
+	h := NewHandler()
+	file := &metadata.File{
+		ID: uuid.New(),
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Size: 0,
+		},
+	}
+	// Simulate an open made with MAXIMUM_ALLOWED whose DACL only granted
+	// the GENERIC_WRITE specific bits + the smbtorture "expected_mask"
+	// standard rights. This is the exact 0x00070080 the GENERIC test asks
+	// for; the pre-fix code would have returned 0x001F01FF (FILE_ALL_ACCESS).
+	const expected uint32 = 0x00070080
+	openFile := &OpenFile{
+		FileName:      "test.txt",
+		Path:          "test.txt",
+		DesiredAccess: uint32(types.MaximumAllowed),
+		GrantedAccess: expected,
+	}
+	info, err := h.buildFileInfoFromStore(
+		&metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}},
+		file, openFile, types.FileAccessInformation,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(info) != 4 {
+		t.Fatalf("info length = %d, want 4", len(info))
+	}
+	got := binary.LittleEndian.Uint32(info[0:4])
+	if got != expected {
+		t.Errorf("FileAccessInformation = 0x%08x, want 0x%08x (GrantedAccess)", got, expected)
+	}
+}
+
 func TestResolveAccessFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -10,11 +10,11 @@ import (
 // and stored in the DurableHandleStore. If the client reconnects before the
 // timeout expires, the state is restored and the open is resumed without data loss.
 type PersistedDurableHandle struct {
-	ID              string
-	FileID          [16]byte
-	Path            string
-	ShareName       string
-	DesiredAccess   uint32
+	ID            string
+	FileID        [16]byte
+	Path          string
+	ShareName     string
+	DesiredAccess uint32
 	// GrantedAccess is the DACL-evaluated per-bit mask returned to the
 	// client at the original open time (MS-SMB2 §3.3.5.9 paragraph 8).
 	// Persisted across durable reconnect so re-establishment of the open

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -15,6 +15,16 @@ type PersistedDurableHandle struct {
 	Path            string
 	ShareName       string
 	DesiredAccess   uint32
+	// GrantedAccess is the DACL-evaluated per-bit mask returned to the
+	// client at the original open time (MS-SMB2 §3.3.5.9 paragraph 8).
+	// Persisted across durable reconnect so re-establishment of the open
+	// (MS-SMB2 §3.3.5.9.7, §3.3.5.9.12) restores the exact granted set —
+	// not a freshly re-resolved DesiredAccess, which would silently
+	// inflate rights when the open was made with MAXIMUM_ALLOWED, or when
+	// the file's DACL has changed since open. Mirrors Samba's
+	// smbXsrv_open_global semantics where the access_mask field is
+	// preserved verbatim across reconnect.
+	GrantedAccess   uint32
 	ShareAccess     uint32
 	CreateOptions   uint32
 	MetadataHandle  []byte

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -214,6 +214,7 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 		Path:            h.Path,
 		ShareName:       h.ShareName,
 		DesiredAccess:   h.DesiredAccess,
+		GrantedAccess:   h.GrantedAccess,
 		ShareAccess:     h.ShareAccess,
 		CreateOptions:   h.CreateOptions,
 		PayloadID:       h.PayloadID,

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -21,7 +21,7 @@ func newPostgresDurableStore(pool *pgxpool.Pool) *postgresDurableStore {
 }
 
 const durableHandleColumns = `
-	id, file_id, path, share_name, desired_access, share_access,
+	id, file_id, path, share_name, desired_access, granted_access, share_access,
 	create_options, metadata_handle, payload_id, oplock_level,
 	lease_key, lease_state, create_guid, app_instance_id,
 	username, session_key_hash, is_v2, created_at, disconnected_at,
@@ -39,6 +39,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&h.Path,
 		&h.ShareName,
 		&h.DesiredAccess,
+		&h.GrantedAccess,
 		&h.ShareAccess,
 		&h.CreateOptions,
 		&h.MetadataHandle,
@@ -87,6 +88,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&h.Path,
 			&h.ShareName,
 			&h.DesiredAccess,
+			&h.GrantedAccess,
 			&h.ShareAccess,
 			&h.CreateOptions,
 			&h.MetadataHandle,
@@ -153,19 +155,20 @@ func nullableBytes16(b [16]byte) []byte {
 func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
 	query := `
 		INSERT INTO durable_handles (
-			id, file_id, path, share_name, desired_access, share_access,
+			id, file_id, path, share_name, desired_access, granted_access, share_access,
 			create_options, metadata_handle, payload_id, oplock_level,
 			lease_key, lease_state, create_guid, app_instance_id,
 			username, session_key_hash, is_v2, created_at, disconnected_at,
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
 			share_name = EXCLUDED.share_name,
 			desired_access = EXCLUDED.desired_access,
+			granted_access = EXCLUDED.granted_access,
 			share_access = EXCLUDED.share_access,
 			create_options = EXCLUDED.create_options,
 			metadata_handle = EXCLUDED.metadata_handle,
@@ -194,6 +197,7 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		handle.Path,
 		handle.ShareName,
 		handle.DesiredAccess,
+		handle.GrantedAccess,
 		handle.ShareAccess,
 		handle.CreateOptions,
 		handle.MetadataHandle,

--- a/pkg/metadata/store/postgres/migrations/000016_durable_handle_granted_access.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000016_durable_handle_granted_access.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE durable_handles DROP COLUMN IF EXISTS granted_access;

--- a/pkg/metadata/store/postgres/migrations/000016_durable_handle_granted_access.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000016_durable_handle_granted_access.up.sql
@@ -1,0 +1,8 @@
+-- Persist GrantedAccess (DACL-evaluated per-bit mask) on durable handles
+-- (#552 review follow-up). Preserves the exact granted set across reconnect
+-- so FileAccessInformation / FileAllInformation return identical rights
+-- after re-establishment, mirroring Samba's smbXsrv_open_global semantics.
+-- Pre-existing rows default to 0, which triggers the in-code fallback to
+-- the resolved DesiredAccess for forward compatibility.
+
+ALTER TABLE durable_handles ADD COLUMN IF NOT EXISTS granted_access BIGINT NOT NULL DEFAULT 0;

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -119,6 +119,7 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 		Path:            "/test/" + id + ".txt",
 		ShareName:       shareName,
 		DesiredAccess:   0x12019F,
+		GrantedAccess:   0x100081,
 		ShareAccess:     0x07,
 		CreateOptions:   0x40,
 		MetadataHandle:  []byte("handle-" + id),
@@ -159,6 +160,9 @@ func assertDurableHandleEqual(t *testing.T, expected, actual *lock.PersistedDura
 	}
 	if expected.DesiredAccess != actual.DesiredAccess {
 		t.Errorf("DesiredAccess: got %d, want %d", actual.DesiredAccess, expected.DesiredAccess)
+	}
+	if expected.GrantedAccess != actual.GrantedAccess {
+		t.Errorf("GrantedAccess: got %d, want %d", actual.GrantedAccess, expected.GrantedAccess)
 	}
 	if expected.ShareAccess != actual.ShareAccess {
 		t.Errorf("ShareAccess: got %d, want %d", actual.ShareAccess, expected.ShareAccess)


### PR DESCRIPTION
Closes #548.

## Root cause

`FileAccessInformation` (MS-FSCC §2.4.1) was returning a re-resolved
`DesiredAccess` (with `MAXIMUM_ALLOWED` / `GENERIC_ALL` expanded to
`FILE_ALL_ACCESS = 0x001F01FF`) instead of the access actually granted
to the open. Per MS-SMB2 §3.3.5.9 paragraph 8 / §2.2.13.1,
`Open.GrantedAccess` is the per-bit intersection of `DesiredAccess`
with the file's DACL (Samba's `fsp->access_mask`,
`source3/smbd/open.c::open_file`).

smbtorture `smb2.acls.GENERIC` at `acls.c:440` sets a DACL granting
only the `SEC_GENERIC_WRITE` specific bits to the owner, opens with
`SEC_FLAG_MAXIMUM_ALLOWED`, and expects `expected_mask | specific_bits =
0x00070080` (`SEC_STD_WRITE_DAC | SEC_STD_READ_CONTROL |
SEC_FILE_READ_ATTRIBUTE | SEC_STD_DELETE | SEC_RIGHTS_FILE_WRITE`).
We returned `0x001F01FF`.

## Fix

- Add `OpenFile.GrantedAccess`. Populate at CREATE from
  `metadata.CheckFileAccess`, which already performs per-bit
  `acl.Evaluate` to gate the open (returns the requester's effective
  rights, with `MAXIMUM_ALLOWED` resolving to "everything the DACL
  actually allows").
- `FileAccessInformation` and the `FileAllInformation` embedded
  `AccessInformation` field read `GrantedAccess`.
- The QUERY_INFO open-level gate (`FileBasicInfo` / `FileAllInfo` /
  `FileNetworkOpenInfo` / `FileAttributeTagInfo` /
  `FileFullEaInfo`) switches to `GrantedAccess` to match MS-SMB2
  §3.3.5.20.1 wording ("`Open.GrantedAccess`").
- Pipe opens, share-root opens, and durable reconnect populate
  `GrantedAccess` (root via `CheckFileAccess` on the root file; pipes
  and durable reconnect fall back to `resolveAccessFlags(DesiredAccess)`,
  the pre-fix value — durable reconnect doesn't persist `GrantedAccess`
  through `PersistedDurableHandle` yet, a follow-up; reconnect already
  enforces `DesiredAccess` identity per MS-SMB2 §3.3.5.9.9 so the
  effective rights remain consistent).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/smb/... ./pkg/metadata/... -count=1`
- [x] New unit test `TestFileAccessInformation_ReturnsGrantedAccess`
      locks the contract.
- [ ] CI smbtorture: expect `smb2.acls.GENERIC` to flip to PASS at
      `acls.c:440`. The downstream `acls.OWNER` failure at `acls.c:774`
      ("Incorrect status NT_STATUS_OK - should be NT_STATUS_ACCESS_DENIED")
      is a different bug, not in scope.
- [ ] No regression expected on `acls.CREATOR` (the per-class
      QUERY_INFO gate continues to use `hasAccessRight`, which honors
      `MAXIMUM_ALLOWED` / `GENERIC_ALL` short-circuits).

`KNOWN_FAILURES.md` walkback intentionally deferred until CI confirms
the flip — per project workflow ("never touch KNOWN_FAILURES until CI
confirms").

## Spec / reference

- MS-SMB2 §3.3.5.9 paragraph 8 — CREATE Response GrantedAccess.
- MS-SMB2 §2.2.13.1 — DesiredAccess vs. GrantedAccess.
- MS-SMB2 §3.3.5.20.1 — per-class QUERY_INFO gate consults
  `Open.GrantedAccess`.
- MS-FSCC §2.4.1 — `FileAccessInformation` is the granted access.
- Samba `source3/smbd/open.c::open_file` — `fsp->access_mask =
  requested & sd_allowed & share_grants`.

Refs #469, #545.