### PR TITLE
fix(smb/acl): parent FILE_DELETE_CHILD override for DELETE access — close #547

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -209,7 +209,17 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// already gated via CheckParentWriteAccess in Create(). Tracking #529.
 	metaSvc := h.Registry.GetMetadataService()
 	if fileExists && existingFile != nil {
-		granted, err := metaSvc.CheckFileAccess(existingFile, authCtx, req.DesiredAccess)
+		// Fetch parent so CheckFileAccessWithParent can apply the
+		// FILE_DELETE_CHILD override per MS-FSA §2.1.4.13 (Samba
+		// parent_override_delete). Best-effort: a parent-lookup failure
+		// falls back to file-only DACL evaluation (nil parent is safe).
+		var parentFile *metadata.File
+		if parentHandle != nil {
+			if pf, err := metaSvc.GetFile(authCtx.Context, parentHandle); err == nil {
+				parentFile = pf
+			}
+		}
+		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, req.DesiredAccess)
 		if err != nil {
 			logger.Debug("CREATE: DesiredAccess denied by DACL",
 				"path", filename,

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -563,9 +563,41 @@ const (
 // and any requested bit is denied. Granted is always populated (even on
 // error) so callers can log what was/wasn't granted.
 //
+// This wrapper preserves the legacy "no parent" signature for call sites that
+// don't have a parent handle in scope (root-handle access checks). CREATE-path
+// callers with a parent in scope should use CheckFileAccessWithParent so the
+// parent's FILE_DELETE_CHILD can override a DELETE denial on the file's own
+// DACL — see that function's documentation for the spec citation.
+//
 // GENERIC_*, OWNER_RIGHTS, and ACCESSBASED enumeration are intentionally
 // out of scope here — those are tracked separately under #530/#531/#532.
 func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
+	return s.CheckFileAccessWithParent(file, nil, authCtx, desiredAccess)
+}
+
+// CheckFileAccessWithParent extends CheckFileAccess with the standard
+// Windows "delete via parent" override per MS-FSA §2.1.4.13 / §2.1.5.1.2.4:
+// when the file's own DACL denies DELETE but the parent directory grants
+// FILE_DELETE_CHILD (ACE4_DELETE_CHILD, 0x40) to the caller, DELETE is
+// granted on the open. This mirrors Samba's parent_override_delete() in
+// source3/smbd/open.c, which cites
+// https://blogs.msdn.com/oldnewthing/archive/2004/06/04/148426.aspx —
+// "Why does this user with administrative rights get an access-denied
+// error when trying to delete a file?"
+//
+// Without this override, smbtorture's smb2_deltree algorithm cannot remove
+// test files whose own DACL was set restrictively by a prior subtest,
+// because deltree's recursive unlink opens each child with
+// SEC_STD_DELETE | FILE_DELETE_ON_CLOSE | FILE_NON_DIRECTORY_FILE. The
+// owner of the parent dir always has DELETE_CHILD via the synthesized
+// owner-rwx mask (acl/synthesize.go::rwxToFullMask), so the override
+// reliably succeeds for setup_dir's intended cleanup.
+//
+// The override only applies to the DELETE bit. All other bits remain
+// gated by the file's own DACL.
+//
+// When parent is nil, behavior is identical to CheckFileAccess.
+func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
 	maximumAllowed := desiredAccess&accessMaskMaximumAllowed != 0
 	explicit := desiredAccess &^ accessMaskMaximumAllowed
 
@@ -608,6 +640,22 @@ func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desi
 		probe &^= bit
 	}
 
+	// Parent override for DELETE: when the file's own DACL denied DELETE but
+	// the parent directory grants FILE_DELETE_CHILD to the caller, grant
+	// DELETE here (MS-FSA §2.1.4.13 / Samba parent_override_delete). The
+	// override fires only when DELETE was actually requested and not yet
+	// granted, and only when a parent file is in scope. This is the same
+	// Windows semantics that lets administrators delete files with no DELETE
+	// in their own DACL via the containing folder's permissions.
+	//
+	// Null parent DACL (parent.ACL == nil) follows MS-DTYP §2.5.3: a NULL DACL
+	// grants every right to every principal, so the override applies.
+	if explicit&acl.ACE4_DELETE != 0 && granted&acl.ACE4_DELETE == 0 && parent != nil {
+		if parentGrantsDeleteChild(parent, authCtx) {
+			granted |= acl.ACE4_DELETE
+		}
+	}
+
 	if maximumAllowed {
 		// MAXIMUM_ALLOWED never denies. Compute the full set of bits the
 		// requester is allowed (independent of what they asked for, minus the
@@ -620,6 +668,13 @@ func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desi
 				effective |= bit
 			}
 		}
+		// Apply parent FILE_DELETE_CHILD override to the MAXIMUM_ALLOWED
+		// effective-rights set too so the open's GrantedAccess (which the
+		// caller propagates into Open.GrantedAccess and surfaces via MxAc)
+		// reflects the same Windows semantics on MaxAccess queries.
+		if parent != nil && parentGrantsDeleteChild(parent, authCtx) {
+			effective |= acl.ACE4_DELETE
+		}
 		return effective | granted, nil
 	}
 
@@ -631,6 +686,27 @@ func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desi
 		}
 	}
 	return granted, nil
+}
+
+// parentGrantsDeleteChild decides whether a parent directory grants
+// FILE_DELETE_CHILD (ACE4_DELETE_CHILD) to the requester for the purposes
+// of the MS-FSA §2.1.4.13 delete-via-parent override. Null DACL on the
+// parent grants everything (MS-DTYP §2.5.3). Root and nil-identity callers
+// also bypass — consistent with the rest of CheckFileAccessWithParent.
+func parentGrantsDeleteChild(parent *File, authCtx *AuthContext) bool {
+	if parent == nil {
+		return false
+	}
+	// Null DACL: grant per MS-DTYP §2.5.3.
+	if parent.ACL == nil {
+		return true
+	}
+	// Root bypass: identical to the file-side root short-circuit.
+	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
+		return true
+	}
+	parentEvalCtx := buildFileAccessEvalContext(parent, authCtx)
+	return acl.Evaluate(parent.ACL, parentEvalCtx, acl.ACE4_DELETE_CHILD)
 }
 
 // buildFileAccessEvalContext mirrors evaluateACLPermissions's EvaluateContext

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -340,3 +340,250 @@ func TestCheckFileAccess_DenyErrorIsStoreError(t *testing.T) {
 	}
 	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 }
+
+// TestCheckFileAccessWithParent_DeleteOverrideViaParentDeleteChild covers
+// issue #547: when a file's own DACL denies DELETE but the parent directory
+// grants FILE_DELETE_CHILD to the caller, DELETE on the open must be
+// granted (MS-FSA §2.1.4.13, mirrors Samba parent_override_delete in
+// source3/smbd/open.c).
+//
+// Without this override, smbtorture's smb2_deltree algorithm cannot recover
+// from a prior subtest that left a restrictive DACL on a child file, and
+// the entire acls.* cluster errors at setup_dir with "Unable to deltree".
+func TestCheckFileAccessWithParent_DeleteOverrideViaParentDeleteChild(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Parent dir DACL grants FILE_DELETE_CHILD (and basic read) to the
+	// requester. This is what synthesize.go::rwxToFullMask produces for the
+	// owner of a dir with mode-bit `w`.
+	parentACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_DELETE_CHILD | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deldir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  parentACL,
+		})
+	require.NoError(t, err)
+
+	// Build the child File directly (avoiding CreateFile which would apply
+	// parent ACL inheritance and replace the child's DACL). CheckFileAccess
+	// only reads File fields, so an in-memory File suffices.
+	childACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	childCreated := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  childACL,
+		},
+	}
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	// Without parent: file's own DACL denies DELETE.
+	_, err = f.service.CheckFileAccess(childCreated, authCtx, rightDelete)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+
+	// With parent: FILE_DELETE_CHILD on parent grants DELETE on the open.
+	granted, err := f.service.CheckFileAccessWithParent(childCreated, parentCreated, authCtx, rightDelete)
+	require.NoError(t, err)
+	require.Equal(t, rightDelete, granted)
+}
+
+// TestCheckFileAccessWithParent_OverrideDoesNotApplyToNonDeleteBits ensures
+// the parent FILE_DELETE_CHILD override is scoped to DELETE only. Other
+// rights denied by the file's DACL must remain denied even when the parent
+// would otherwise grant broad access.
+func TestCheckFileAccessWithParent_OverrideDoesNotApplyToNonDeleteBits(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Parent dir grants FULL access including FILE_DELETE_CHILD.
+	parentACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "broadparent",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  parentACL,
+		})
+	require.NoError(t, err)
+
+	// Child file denies WRITE.
+	childACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	childCreated := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  childACL,
+		},
+	}
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	// WRITE alone — parent override is delete-only; must still deny.
+	_, err = f.service.CheckFileAccessWithParent(childCreated, parentCreated, authCtx, rightWriteData)
+	require.Error(t, err)
+
+	// DELETE + WRITE — DELETE is granted via parent, WRITE is not → still deny.
+	_, err = f.service.CheckFileAccessWithParent(childCreated, parentCreated, authCtx, rightDelete|rightWriteData)
+	require.Error(t, err)
+}
+
+// TestCheckFileAccessWithParent_NullParentDACLGrantsDelete pins MS-DTYP
+// §2.5.3: a NULL DACL on the parent grants every right to every principal,
+// including FILE_DELETE_CHILD, so the parent override grants DELETE on the
+// child. This is the load-bearing case for smbtorture deltree recovery —
+// new dirs in DittoFS are created without an explicit ACL, so parent.ACL
+// is nil for most filesystem state.
+func TestCheckFileAccessWithParent_NullParentDACLGrantsDelete(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Parent: created with no explicit ACL → parent.ACL is nil.
+	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "nullacldir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+			UID:  requesterUID,
+			GID:  1001,
+		})
+	require.NoError(t, err)
+	require.Nil(t, parentCreated.ACL, "parent ACL must be nil for this scenario")
+
+	// Child: restrictive DACL denying DELETE.
+	childACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	childCreated := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  childACL,
+		},
+	}
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	granted, err := f.service.CheckFileAccessWithParent(childCreated, parentCreated, authCtx, rightDelete)
+	require.NoError(t, err)
+	require.Equal(t, rightDelete, granted)
+}
+
+// TestCheckFileAccessWithParent_NoOverrideWhenParentLacksDeleteChild verifies
+// that when the parent's own DACL also lacks FILE_DELETE_CHILD for the
+// caller, the override does NOT grant DELETE — the file remains undeletable.
+// This pins the Windows "delete via parent" rule: parent permission, not just
+// parent presence, is what overrides.
+func TestCheckFileAccessWithParent_NoOverrideWhenParentLacksDeleteChild(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	parentACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "lockedparent",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  parentACL,
+		})
+	require.NoError(t, err)
+
+	childACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	childCreated := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  childACL,
+		},
+	}
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	_, err = f.service.CheckFileAccessWithParent(childCreated, parentCreated, authCtx, rightDelete)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}


### PR DESCRIPTION
## Summary

Implements the MS-FSA §2.1.4.13 "delete via parent" override (Samba `parent_override_delete`): when a file's own DACL denies `DELETE` but the parent directory grants `FILE_DELETE_CHILD` to the caller, `DELETE` is granted on the open.

## Root cause

`smbtorture`'s `smb2_deltree` (libcli/smb2/util.c) opens each child with `SEC_STD_DELETE | FILE_DELETE_ON_CLOSE | FILE_NON_DIRECTORY_FILE` (the `smb2_composite_unlink` shape). When the previous subtest (`smb2.acls.GENERIC`) `goto done`s on a `CHECK_ACCESS_FLAGS` failure mid-loop, it leaves `creator.txt`/`generic.txt` with a restrictive DACL — owner has no DELETE. The NEXT test's `setup_dir` → `smb2_deltree(BASEDIR)` then hits `STATUS_ACCESS_DENIED` on the child unlink, can't iterate the directory empty, fails the final rmdir with `STATUS_DIRECTORY_NOT_EMPTY`, and aborts with "Unable to deltree".

Samba documents this exact pattern: https://blogs.msdn.com/oldnewthing/archive/2004/06/04/148426.aspx. The fix is the standard Windows override — if the file's own DACL denies DELETE, the parent directory's `FILE_DELETE_CHILD` grants it.

Investigated via pcap-equivalent log diff: `parentHasACL=false granted=0x0` on the child confirmed parent had nil-DACL but `CheckFileAccess` never consulted it. Verified against Samba `source3/smbd/open.c::parent_override_delete` and `MS-FSA §2.1.4.13` access-check algorithm.

## Change

- New `MetadataService.CheckFileAccessWithParent(file, parent, authCtx, desiredAccess)`. Override is scoped to the DELETE bit only; other denied bits remain denied (per Samba).
- `CheckFileAccess` preserved as a `parent=nil` wrapper for call sites that lack parent context (e.g. root-handle MxAc probe in `create.go:1230`).
- NULL parent DACL → grants per MS-DTYP §2.5.3 (a NULL DACL grants every right to every principal).
- `MAXIMUM_ALLOWED` effective-rights path also honors the override so `MxAc` replies reflect the open's actual delete authority.
- CREATE handler (`create_post_break.go::completeCreateAfterBreak`) fetches parent via `metaSvc.GetFile(parentHandle)` and routes through the new entry point. Best-effort: a lookup failure falls back to file-only evaluation.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./pkg/metadata/...` + `./internal/adapter/smb/...` — all green.
- [x] New unit tests (4) in `auth_permissions_file_access_test.go`:
  - `DeleteOverrideViaParentDeleteChild` — happy path.
  - `OverrideDoesNotApplyToNonDeleteBits` — scope is delete-only.
  - `NullParentDACLGrantsDelete` — NULL DACL grants (MS-DTYP §2.5.3) — load-bearing for deltree cluster.
  - `NoOverrideWhenParentLacksDeleteChild` — pins denial when parent also lacks DELETE_CHILD.
- [x] `./test/smb-conformance/smbtorture/run.sh --filter smb2.acls`:
  - Before: 1 PASS (CREATOR), 11 ERROR-at-setup ("Unable to deltree"), 2 FAIL.
  - After: **5 PASS (CREATOR + INHERITANCE + OWNER-RIGHTS + OWNER-RIGHTS-DENY + OWNER-RIGHTS-DENY1)**, 9 FAIL at deeper points, 0 ERROR. Cascade-unlock achieved — remaining 9 fail at their actual test logic, not at setup.
- [x] `./test/smb-conformance/smbtorture/run.sh --filter smb2.delete-on-close-perms` — 9/9 PASS, no regressions.
- [x] `./test/smb-conformance/smbtorture/run.sh --filter smb2.acls_non_canonical` — PASS, no regressions.

## KNOWN_FAILURES update

Deliberately NOT updated in this PR per the two-commit pattern. The 4 tests that flipped to PASS in local smbtorture (INHERITANCE, OWNER-RIGHTS, OWNER-RIGHTS-DENY, OWNER-RIGHTS-DENY1) need CI confirmation before the entries are removed. A follow-up commit can prune them once CI confirms.

## Cascade unlock note

The 9 remaining `smb2.acls.*` failures (GENERIC, OWNER, INHERITFLAGS, SDFLAGSVSCHOWN, DYNAMIC, ACCESSBASED, DENY1, MXAC-NOT-GRANTED, OVERWRITE_READ_ONLY_FILE) now reach their real test logic — separate downstream bugs that should be triaged as individual issues per the cascade-unlock plan.

Closes #547
Refs #469 #499