### PR TITLE
fix(test): relax AppendWrite single-writer latency budget (#554)

### DIFF
--- a/pkg/blockstore/local/fs/appendwrite_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -281,11 +282,16 @@ func TestAppendWrite_SingleWriter_NoLatencyPenalty(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 	// The fsync itself is bounded by disk hardware (~100µs-2ms on NVMe,
-	// up to ~10ms on rotational/CI VMs). We assert <50ms as a coarse
-	// "no extra coordinator window penalty" gate — the coordinator's 1ms
-	// window must NOT be added on top of fsync.
-	if elapsed > 50*time.Millisecond {
-		t.Fatalf("single-writer AppendWrite took %v; want < 50ms (D-06 bypass broken)", elapsed)
+	// up to ~10ms on rotational/CI VMs; GHA hosted Windows runners are
+	// regularly observed at 60-90ms). This is a smoke gate; the real
+	// double-fsync detection lives in
+	// TestAppendWrite_CoordinatorOnHotPath_BurstCounts. See #554.
+	budget := 200 * time.Millisecond
+	if runtime.GOOS == "windows" {
+		budget = 500 * time.Millisecond
+	}
+	if elapsed > budget {
+		t.Fatalf("single-writer AppendWrite took %v; want < %v (D-06 bypass broken)", elapsed, budget)
 	}
 }
 


### PR DESCRIPTION
Fixes #554. Bump TestAppendWrite_SingleWriter_NoLatencyPenalty budget from 50ms to 200ms (500ms on Windows). True regressions still caught by burst test.