### PR TITLE
refactor(layout): drop redundant blocks/ parent under share root

### DIFF
--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -64,14 +64,14 @@ migration rewrites the on-disk layout in place and a concurrent server
 would race the rename and corrupt the store.
 
 Required flag: --storage-dir <root>. The storage root is expected to
-contain a shares/<name>/blocks/ subtree per share; the command refuses
-to start if the path is missing or empty.
+contain a shares/<name>/blocks/ subtree per share (legacy v0.13 layout);
+the command refuses to start if the path is missing or empty.
 
 The command is idempotent: a per-share journal at
 <storage-dir>/shares/<name>/.dittofs-migrate-to-cas.state lets you
 resume after a crash or Ctrl-C without re-uploading already-migrated
 chunks. Successful completion writes
-<storage-dir>/shares/<name>/blocks/.cas-migrated-v1 via atomic rename;
+<storage-dir>/shares/<name>/.cas-migrated-v1 via atomic rename;
 the boot guard refuses to start dfs until this sentinel exists (exit
 code 78).
 
@@ -153,13 +153,16 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		shareDir := filepath.Join(sharesRoot, name)
-		blockDir := filepath.Join(shareDir, "blocks")
 
 		// Destination BlockStore for this share. Use the migration-bypass
 		// constructor so Plan 09's sentinel-detection gate (added later
 		// inside fs.New / fs.NewWithOptions) does not refuse the share
 		// — that gate is precisely what the migration is establishing.
-		bs, openErr := fs.NewFSStoreForMigration(blockDir,
+		//
+		// Phase 19 follow-up: baseDir is the share root (not the redundant
+		// `<shareDir>/blocks/` sub-path). FSStore internally creates
+		// `blocks/` (CAS) + `logs/` (append log) as siblings under baseDir.
+		bs, openErr := fs.NewFSStoreForMigration(shareDir,
 			migrateMaxDisk, migrateMaxMemory, nopFileBlockStore{},
 			fs.FSStoreOptions{})
 		if openErr != nil {
@@ -169,10 +172,10 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 		opts := migrate.MigrationOpts{
 			DryRun:   migrateDryRun,
 			Progress: makeProgressFn(name),
-			// Sentinel must live at the FSStore baseDir (Plan 09 boot
-			// guard probes `<baseDir>/.cas-migrated-v1`), which here is
-			// blockDir (a subdir of shareDir), not shareDir itself.
-			StoreDir: blockDir,
+			// Sentinel lives at the FSStore baseDir (Plan 09 boot guard
+			// probes `<baseDir>/.cas-migrated-v1`), which post-follow-up
+			// is shareDir.
+			StoreDir: shareDir,
 		}
 
 		adapter := &cliMetadataAdapter{shareName: name}

--- a/cmd/dfs/commands/start_test.go
+++ b/cmd/dfs/commands/start_test.go
@@ -59,7 +59,7 @@ func TestStart_LegacyLayoutExitCode(t *testing.T) {
 	// Synthesize the exact wrap shape runtime.LoadSharesFromStore
 	// produces: `share %q: %w` around the fs.NewFSStore output, which
 	// is itself `share %s: %w` around blockstore.ErrLegacyLayoutDetected.
-	sharePath := filepath.Join(t.TempDir(), "share-A", "blocks")
+	sharePath := filepath.Join(t.TempDir(), "share-A")
 	innerErr := fmt.Errorf("share %s: %w", sharePath, blockstore.ErrLegacyLayoutDetected)
 	loadErr := fmt.Errorf("share %q: %w", "share-A", innerErr)
 

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -379,9 +379,11 @@ const sentinelFileName = ".cas-migrated-v1"
 // legacyLayoutWalkDepthCap bounds the depth-limited `.blk` probe so a
 // freshly-provisioned share with deeply nested non-legacy content does
 // not pay an unbounded WalkDir at every boot. Legacy `.blk` files live
-// at <baseDir>/<shard>/<payloadID>/<idx>.blk (depth 3 under baseDir);
-// any `.blk` past depth 3 is treated as non-legacy noise and skipped.
-const legacyLayoutWalkDepthCap = 3
+// at <baseDir>/blocks/<shard>/<payloadID>/<idx>.blk (depth 4 under
+// baseDir after the v0.16 follow-up that dropped the redundant outer
+// `blocks/` parent — pre-follow-up was depth 3 under <baseDir>/blocks).
+// Any `.blk` past depth 4 is treated as non-legacy noise and skipped.
+const legacyLayoutWalkDepthCap = 4
 
 // checkLegacyLayoutSentinel implements Plan 09 D-10 / D-11. Returns
 // blockstore.ErrLegacyLayoutDetected (wrapped with the share path) when

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -65,11 +65,12 @@ func TestCreateLocalStoreFromConfig_AppendLogMandatory(t *testing.T) {
 		t.Fatalf("AppendWrite: %v", err)
 	}
 
-	// Sanity check: the block dir was created at the expected location
-	// under the sanitized share name.
-	expectedBlockDir := filepath.Join(tmp, "shares", "test-share", "blocks")
-	if _, statErr := statDir(expectedBlockDir); statErr != nil {
-		t.Errorf("block dir %q not created: %v", expectedBlockDir, statErr)
+	// Sanity check: the share root was created at the expected location.
+	// Phase 19 follow-up: baseDir is shareDir, not shareDir/blocks; the
+	// FSStore creates `blocks/` (CAS) + `logs/` (append log) inside.
+	expectedShareDir := filepath.Join(tmp, "shares", "test-share")
+	if _, statErr := statDir(expectedShareDir); statErr != nil {
+		t.Errorf("share dir %q not created: %v", expectedShareDir, statErr)
 	}
 }
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1463,7 +1463,13 @@ func CreateLocalStoreFromConfig(
 			return nil, fmt.Errorf("fs local store path must be absolute, got %q", basePath)
 		}
 		sanitized := sanitizeShareName(shareName)
-		blockDir := filepath.Join(expanded, "shares", sanitized, "blocks")
+		// Phase 19 follow-up: drop the redundant `blocks/` parent dir; the
+		// FSStore already creates `blocks/` (CAS) and `logs/` (append log) as
+		// siblings under its baseDir. The previous layout produced a doubled
+		// `shares/{name}/blocks/blocks/...` path. Existing pre-v0.16 installs
+		// migrate via `dfs migrate-to-cas` (which uses share-root as its
+		// state-dir, already aligned with deriveLocalStoreDir).
+		blockDir := filepath.Join(expanded, "shares", sanitized)
 		if err := os.MkdirAll(blockDir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create block store directory: %w", err)
 		}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1469,9 +1469,9 @@ func CreateLocalStoreFromConfig(
 		// `shares/{name}/blocks/blocks/...` path. Existing pre-v0.16 installs
 		// migrate via `dfs migrate-to-cas` (which uses share-root as its
 		// state-dir, already aligned with deriveLocalStoreDir).
-		blockDir := filepath.Join(expanded, "shares", sanitized)
-		if err := os.MkdirAll(blockDir, 0755); err != nil {
-			return nil, fmt.Errorf("failed to create block store directory: %w", err)
+		shareDir := filepath.Join(expanded, "shares", sanitized)
+		if err := os.MkdirAll(shareDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create share directory: %w", err)
 		}
 
 		// Phase 17: append is mandatory. Wire a RollupStore from the
@@ -1493,7 +1493,7 @@ func CreateLocalStoreFromConfig(
 		if shs, ok := fileBlockStore.(metadata.SyncedHashStore); ok {
 			fsOpts.SyncedHashStore = shs
 		}
-		store, err := fs.NewWithOptions(blockDir, maxDisk, maxMemory, fileBlockStore, fsOpts)
+		store, err := fs.NewWithOptions(shareDir, maxDisk, maxMemory, fileBlockStore, fsOpts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Smoke-test observation: on-disk layout had `shares/<name>/blocks/blocks/...` — the outer `blocks/` parent was redundant. FSStore already creates `blocks/` (CAS) + `logs/` (append-log) siblings under its baseDir.

Flattens to:
```
<root>/shares/<name>/blocks/<2h>/<2h>/<hash>   (CAS)
<root>/shares/<name>/logs/<share>/<file>.log   (append-log)
```

## Touched
- `service.go createBlockStoreForShare` — baseDir = shareDir (was shareDir/blocks)
- `migrate_to_cas.go` — destination FSStore baseDir + sentinel target move to shareDir
- `fs.go boot-guard` — `legacyLayoutWalkDepthCap` 3→4 so the depth-capped `.blk` probe finds legacy data one level deeper relative to new baseDir
- Tests adjusted to assert the flattened layout

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./pkg/blockstore/local/fs/... ./pkg/controlplane/runtime/shares/... ./pkg/blockstore/migrate/... ./cmd/dfs/... -count=1` green
- [x] Live verified on local Mac: fresh share creates the flat layout; append-log + CAS blocks (when produced) land at the new paths
- [ ] Full `go test ./...` on CI

## Caveat
Live smoke surfaced a **separate** rollup-pathology — for some NFS write patterns the append-log records' `file_offset` field does not match the dirty-interval tree, leaving rollup unable to find records that match the stable interval (recs=0). Reproduced on macOS NFSv3 + a 4 MiB random-file write. Not introduced by this PR (predates the layout change). Will file a follow-up issue with the dfs.log evidence captured during the smoke test.