### PR TITLE
chore(smb): walk back KNOWN_FAILURES for #547 + #548 + #549 flips

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-04-29 (HIDDEN/SYSTEM attribute round-trip, #476)
+Last updated: 2026-05-22 (ACL OWNER-RIGHTS family flips after #547/#548/#549/#553)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -49,19 +49,16 @@ descriptors, and owner rights are not implemented.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.acls.ACCESSBASED | ACLs | Windows ACL semantics not implemented | - |
-| smb2.acls.DENY1 | ACLs | ACL deny semantics not implemented | - |
-| smb2.acls.DYNAMIC | ACLs | Dynamic access checks not implemented | - |
-| smb2.acls.GENERIC | ACLs | Generic ACL mapping not implemented | - |
-| smb2.acls.INHERITANCE | ACLs | ACL inheritance not implemented | - |
-| smb2.acls.INHERITFLAGS | ACLs | ACL inherit flags not implemented | - |
-| smb2.acls.MXAC-NOT-GRANTED | ACLs | Maximum access not-granted not implemented | - |
-| smb2.acls.OVERWRITE_READ_ONLY_FILE | ACLs | ACL overwrite read-only not implemented | - |
-| smb2.acls.OWNER | ACLs | Owner SID semantics not implemented | - |
-| smb2.acls.OWNER-RIGHTS | ACLs | Owner rights not implemented | - |
-| smb2.acls.OWNER-RIGHTS-DENY | ACLs | Owner rights deny not implemented | - |
-| smb2.acls.OWNER-RIGHTS-DENY1 | ACLs | Owner rights deny not implemented | - |
-| smb2.acls.SDFLAGSVSCHOWN | ACLs | SD flags vs chown not implemented | - |
+| smb2.acls.ACCESSBASED | ACLs | Deeper failure at acls.c:2308 after PR #551 (ABE bit moved to ShareFlags) — SD 0x20081 still leaks file `smb2-testsd` to non-readers; requires ABE filtering in directory enumeration | - |
+| smb2.acls.DENY1 | ACLs | Deeper failure at acls.c:2862 — maximal_access reports 0x1E008B but expected 0x16008B (extra `SEC_DIR_DELETE_CHILD` bit set); MaxAccess computation needs to drop dir-only rights on file objects | - |
+| smb2.acls.DYNAMIC | ACLs | Dynamic access checks not implemented (fails at acls.c:1863 with NT_STATUS_OBJECT_NAME_NOT_FOUND) | - |
+| smb2.acls.GENERIC | ACLs | Deeper failure at acls.c:440 after PR #552 (FileAccessInformation now DACL-evaluated) — granted access reports 0x000f0000 but expected 0x00070080; GENERIC_ALL→specific-rights mapping still drops STANDARD bits | - |
+| smb2.acls.INHERITANCE | ACLs | Deeper failure at acls.c:1168 after PR #553 (FILE_DELETE_CHILD override) — access_flags 0x000e0002 but expected 0x001f01ff; inherited DACL on child still missing GENERIC_ALL→specific-rights expansion | - |
+| smb2.acls.INHERITFLAGS | ACLs | Deeper failure at acls.c:1434 — access_flags 0x000e0002 but expected 0x001f01ff; same inherited-DACL specific-rights expansion gap as INHERITANCE | - |
+| smb2.acls.MXAC-NOT-GRANTED | ACLs | Deeper failure at acls.c:2979 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED; MaxAccess should not implicitly grant when DACL denies the requested access | - |
+| smb2.acls.OVERWRITE_READ_ONLY_FILE | ACLs | Deeper failure at acls.c:3104 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED on OVERWRITE of read-only file | - |
+| smb2.acls.OWNER | ACLs | Owner SID semantics not implemented (fails at acls.c:765 with NT_STATUS_ACCESS_DENIED instead of NT_STATUS_OK) | - |
+| smb2.acls.SDFLAGSVSCHOWN | ACLs | Deeper failure at acls.c:1680 — access_flags 0x000e0002 but expected 0x001f01ff; same inherited-DACL specific-rights expansion gap | - |
 | smb2.sdread | Security descriptors | Security descriptor read not implemented | - |
 | smb2.secleak | Security descriptors | Security descriptor leak test not implemented | - |
 


### PR DESCRIPTION
## Summary

CI run [26279181361](https://github.com/marmos91/dittofs/actions/runs/26279181361) on develop tip (`32a928a5`) confirms three `acls.*` tests now PASS across `memory`, `memory-fs`, and `badger-fs` profiles. Walk them back from `KNOWN_FAILURES.md`.

Several other ACL tests advance past their previous setup failure point after PRs #551 / #552 / #553 but still fail at a deeper assertion. Per the workflow (keep rows for tests still failing, just refresh `reason`), update those `reason` cells with the current `acls.c:LINE` and a one-line hypothesis of the remaining gap.

## Rows removed (now PASS in CI)

- `smb2.acls.OWNER-RIGHTS`
- `smb2.acls.OWNER-RIGHTS-DENY`
- `smb2.acls.OWNER-RIGHTS-DENY1`

## Rows whose `reason` field was refreshed

| Test | New failure point | Hypothesis |
|------|-------------------|------------|
| `smb2.acls.ACCESSBASED` | `acls.c:2308` | ABE filtering in directory enumeration missing (after PR #551 moved ABE bit to `ShareFlags`) |
| `smb2.acls.GENERIC` | `acls.c:440` | `GENERIC_ALL` -> specific-rights mapping still drops STANDARD bits (after PR #552 made `FileAccessInformation` DACL-evaluated) |
| `smb2.acls.INHERITANCE` | `acls.c:1168` | Inherited DACL on child missing `GENERIC_ALL` expansion (after PR #553 added parent `FILE_DELETE_CHILD` override) |
| `smb2.acls.INHERITFLAGS` | `acls.c:1434` | Same inherited-DACL specific-rights expansion gap |
| `smb2.acls.SDFLAGSVSCHOWN` | `acls.c:1680` | Same expansion gap |
| `smb2.acls.DENY1` | `acls.c:2862` | MaxAccess includes `SEC_DIR_DELETE_CHILD` on file objects |
| `smb2.acls.MXAC-NOT-GRANTED` | `acls.c:2979` | MaxAccess must respect DACL deny ACE |
| `smb2.acls.OVERWRITE_READ_ONLY_FILE` | `acls.c:3104` | `OVERWRITE` on read-only file should return `NT_STATUS_ACCESS_DENIED` |
| `smb2.acls.OWNER` | `acls.c:765` | Reason text refreshed only (no advancement) |
| `smb2.acls.DYNAMIC` | `acls.c:1863` | Reason text refreshed only (no advancement) |

`acls.OWNER` and `acls.DYNAMIC` get reason-text refresh only; their failure point is unchanged. No other rows in either KNOWN_FAILURES file are modified.

## Test plan
- [x] CI run on develop tip (`32a928a5`) confirms three target tests PASS in memory / memory-fs / badger-fs (no flake — 3/3 profiles)
- [x] `parse-results.sh` table-row parser unaffected (cell text only — no `|` introduced into reasons)
- [ ] SMB Conformance Tests workflow on this branch remains green (no new failures)