### PR TITLE
fix(fs): rollup redesign — per-file logIndex (Direction 1)

### DIFF
--- a/pkg/blockstore/local/fs/appendlog.go
+++ b/pkg/blockstore/local/fs/appendlog.go
@@ -185,6 +185,42 @@ func readRecord(r io.Reader) (uint64, []byte, bool, error) {
 	return fileOffset, payload, true, nil
 }
 
+// readRecordAt reads the framed record whose first byte sits at logPos
+// in rf. payloadLen is the caller-known payload size (the logIndex
+// entry's payloadLen field), so we issue a single pread of the full
+// record (frame header + payload) instead of two sequential reads.
+//
+// Returns the decoded file_offset and the payload bytes. Errors:
+//   - the pread returned an I/O error / short read
+//   - the frame's declared payload_len disagrees with the index
+//   - CRC over (file_offset || payload) mismatches the stored CRC
+//
+// All three indicate either log-fd corruption or a logIndex/log
+// divergence bug — the caller (rollup) treats them as a hard failure
+// and skips the rollup pass so a future attempt can reseed.
+func readRecordAt(rf io.ReaderAt, logPos uint64, payloadLen uint32) (uint64, []byte, error) {
+	total := uint64(recordFrameOverhead) + uint64(payloadLen)
+	buf := make([]byte, total)
+	if _, err := rf.ReadAt(buf, int64(logPos)); err != nil {
+		return 0, nil, fmt.Errorf("append log: pread at %d (len=%d): %w", logPos, total, err)
+	}
+	declaredLen := binary.LittleEndian.Uint32(buf[0:4])
+	if declaredLen != payloadLen {
+		return 0, nil, fmt.Errorf("append log: frame payload_len %d != logIndex %d at logPos=%d", declaredLen, payloadLen, logPos)
+	}
+	fileOffset := binary.LittleEndian.Uint64(buf[4:12])
+	wantCRC := binary.LittleEndian.Uint32(buf[12:16])
+	payload := buf[recordFrameOverhead:]
+	var offBuf [8]byte
+	binary.LittleEndian.PutUint64(offBuf[:], fileOffset)
+	gotCRC := crc32.Update(0, crcTable, offBuf[:])
+	gotCRC = crc32.Update(gotCRC, crcTable, payload)
+	if gotCRC != wantCRC {
+		return 0, nil, fmt.Errorf("append log: CRC mismatch at logPos=%d", logPos)
+	}
+	return fileOffset, payload, nil
+}
+
 // advanceRollupOffset atomically updates the log header's rollup_offset
 // field and fsyncs. FIX-6: split into a two-phase pwrite+fsync sequence
 // so the on-disk state is always either fully old-valid, fully new-valid,

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -40,6 +40,15 @@ type logFile struct {
 	// which is the correct error posture (D-08 — caller observes the
 	// fsync result).
 	groupCommit *groupCommit
+
+	// eofPos tracks the on-disk EOF byte offset of this log. Initialized
+	// at construction (either logHeaderSize for a freshly initialized log
+	// or the seek-end offset for a reopened one) and advanced under the
+	// per-file `mu` after each successful writeRecord + groupCommit.Sync
+	// pair in AppendWrite. It is the canonical "log position" cursor used
+	// by the per-file logIndex (Direction 1 redesign) to record where in
+	// the log each AppendWrite's record landed without re-statting the fd.
+	eofPos uint64
 }
 
 // logPath returns the on-disk path for a payload's append-log file:
@@ -87,6 +96,7 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 		// Declare f at outer scope and use `=` (not `:=`) in the branches
 		// below to avoid the shadowing bug called out in plan 04.
 		var f *os.File
+		var eof int64
 		_, statErr := os.Stat(path)
 		if statErr == nil {
 			// Reopen existing log, seek to EOF for append.
@@ -95,7 +105,7 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("append log: reopen: %w", err)
 			}
-			if _, err = f.Seek(0, io.SeekEnd); err != nil {
+			if eof, err = f.Seek(0, io.SeekEnd); err != nil {
 				_ = f.Close()
 				return nil, nil, nil, fmt.Errorf("append log: seek end: %w", err)
 			}
@@ -105,14 +115,14 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			if _, err = f.Seek(0, io.SeekEnd); err != nil {
+			if eof, err = f.Seek(0, io.SeekEnd); err != nil {
 				_ = f.Close()
 				return nil, nil, nil, fmt.Errorf("append log: seek end: %w", err)
 			}
 		} else {
 			return nil, nil, nil, fmt.Errorf("append log: stat: %w", statErr)
 		}
-		lf = &logFile{f: f, path: path}
+		lf = &logFile{f: f, path: path, eofPos: uint64(eof)}
 		// Phase 19 Opt 2 (D-06/D-07/D-08): per-file fsync coordinator.
 		// Bound method value captures lf.f at construction; lf.f is not
 		// rotated for the FSStore lifetime, so the binding stays valid.
@@ -302,6 +312,14 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	if err := lf.groupCommit.Sync(ctx); err != nil {
 		return fmt.Errorf("log fsync: %w", err)
 	}
+	// Advance the log-position cursor only after the writeRecord +
+	// groupCommit.Sync pair has succeeded. We are still under the per-
+	// file `mu`, so the increment is serialized against any other writer
+	// or rollup pread that consults lf.eofPos. Direction-1 redesign: the
+	// pre-advance value is the logPos at which this record's frame
+	// starts; the logIndex (added in P2/P3) will capture that snapshot
+	// before this advance.
+	lf.eofPos += uint64(n)
 	bc.logBytesTotal.Add(int64(n))
 	tree.Insert(offset, uint32(len(data)), time.Now())
 

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -137,6 +137,12 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 		tree = newIntervalTree()
 		bc.dirtyIntervals[payloadID] = tree
 	}
+	// Direction-1 rollup redesign: pair every payload's interval tree
+	// with a logIndex. The logIndex is allocated on first touch (here)
+	// and from recovery's install path. Both sites run under bc.logsMu.
+	if _, ok := bc.logIndices[payloadID]; !ok {
+		bc.logIndices[payloadID] = newLogIndex()
+	}
 	return lf, mu, tree, nil
 }
 
@@ -317,11 +323,25 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// file `mu`, so the increment is serialized against any other writer
 	// or rollup pread that consults lf.eofPos. Direction-1 redesign: the
 	// pre-advance value is the logPos at which this record's frame
-	// starts; the logIndex (added in P2/P3) will capture that snapshot
-	// before this advance.
+	// starts; capture it before the advance so the logIndex entry
+	// points at the correct frame boundary.
+	logPos := lf.eofPos
 	lf.eofPos += uint64(n)
 	bc.logBytesTotal.Add(int64(n))
 	tree.Insert(offset, uint32(len(data)), time.Now())
+	// Direction-1 redesign: record this AppendWrite in the per-payload
+	// logIndex. The interval tree above answers "which file regions are
+	// dirty"; logIndex answers "where in the log are the records for
+	// those regions" — decoupling the two domains so the rollup can
+	// translate a stable file-offset interval into a pread set even
+	// when records arrived out of file-offset order. Still no consumer
+	// in this commit; P5 switches the rollup to read it.
+	bc.logsMu.RLock()
+	idx := bc.logIndices[payloadID]
+	bc.logsMu.RUnlock()
+	if idx != nil {
+		idx.Append(logPos, offset, uint32(len(data)))
+	}
 
 	// Non-blocking nudge to the rollup pool (plan 06). If the channel is
 	// full, drop the signal — the rollup worker's ticker arm will pick up
@@ -489,6 +509,7 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	delete(bc.logFDs, payloadID)
 	delete(bc.logLocks, payloadID)
 	delete(bc.dirtyIntervals, payloadID)
+	delete(bc.logIndices, payloadID)
 	delete(bc.truncations, payloadID)
 	delete(bc.tombstones, payloadID)
 	bc.logsMu.Unlock()

--- a/pkg/blockstore/local/fs/doc.go
+++ b/pkg/blockstore/local/fs/doc.go
@@ -52,6 +52,58 @@
 // between (1) and (2) leaves an orphan chunk under blocks/; Phase 11's
 // mark-sweep GC cleans it up (not in Phase 10).
 //
+// # Per-file logIndex (Direction 1)
+//
+// The append log stores records in arrival order (per-file mu serializes
+// AppendWrite), NOT in file_offset order. Parallel clients (e.g. macOS
+// NFSv3) routinely produce interleaved file_offsets across consecutive
+// records. The interval tree owns the file-offset domain — "which file
+// regions are dirty/stable" — and a per-payload logIndex owns the
+// log-position domain — "where in the log does each record's frame
+// start". The two are populated in lockstep:
+//
+//   - AppendWrite advances lf.eofPos under the per-file mu and appends
+//     (logPos, fileOff, payloadLen) to the logIndex.
+//   - Recovery's per-log scan does the same, then idx.SetFence(effectiveOff)
+//     pins the compactionFence at the persisted rollup_offset.
+//
+// Rollup runs against this pair:
+//
+//   - tree.EarliestStable picks the next file-offset interval to chunk.
+//   - idx.EntriesForInterval(off, length) returns the records whose
+//     fileOffsets intersect that window, in arrival (logPos) order — the
+//     order reconstructStream needs to honor D-35 "later-record-wins"
+//     overwrites at the same offset.
+//   - readRecordAt(rf, logPos, payloadLen) does a single pread per record
+//     (header + payload), CRC-validates, and returns the payload.
+//   - After StoreChunk succeeds for every emitted chunk, idx.MarkConsumed
+//     is called for each surviving logPos; idx.AdvanceFence walks the
+//     consumed set forward from the prior fence and returns the new one
+//     — that value is what gets persisted as rollup_offset.
+//
+// rollup_offset semantic shift: the on-disk format is unchanged, but
+// the value now records the compactionFence (largest logPos s.t. every
+// earlier entry has been consumed) rather than a sequential scan cursor.
+// A consumed entry preceded by an unconsumed predecessor does NOT advance
+// the fence — its chunks are durable, but the log byte prefix stays
+// anchored until the predecessor is consumed (the "stalled fence"
+// scenario). tree.ConsumeUpTo still runs every pass that emits chunks,
+// so the dirty interval clears and the workload makes forward progress
+// even when the fence cannot.
+//
+// TRANSITIONAL-V0.17+: physical log compaction (rewriting the log file
+// dropping consumed records up to compactionFence) is not implemented
+// here. The log grows until the payload is deleted; pressure machinery
+// caps the worst case via maxLogBytes. A future milestone will
+// add a compaction pass that truncates the on-disk log down to its
+// post-fence suffix.
+//
+// TRANSITIONAL-V0.17+: tracking consumption by file-offset interval
+// instead of log position would eliminate the stalled-fence pathology
+// entirely. Direction 1 keeps consumption keyed by logPos for minimal
+// surface change; the file-offset-keyed variant is a v0.17 follow-up
+// per R-7 in .planning/proposals/2026-05-22-logindex-rollup-redesign.md.
+//
 // # Pressure channel (LSL-04, INV-05)
 //
 // logBytesTotal <= max_log_bytes per FSStore. When budget is exceeded,
@@ -73,7 +125,9 @@
 //	          |    +-- readRecord ok=false (torn / CRC mismatch) ?
 //	          |         -> truncate log at this record boundary
 //	          |
-//	          +-- rebuild per-file interval tree from surviving records
+//	          +-- rebuild per-file interval tree AND logIndex from
+//	              surviving records (Direction 1); SetFence(effectiveOff)
+//	              pins compactionFence at the boot-time rollup_offset
 //	          |
 //	          +-- orphan sweep:
 //	               metadata.GetRollupOffset(payloadID) == 0

--- a/pkg/blockstore/local/fs/eofpos_test.go
+++ b/pkg/blockstore/local/fs/eofpos_test.go
@@ -1,0 +1,140 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestLogFile_EofPos_InitialFresh verifies that getOrCreateLog initializes
+// lf.eofPos to logHeaderSize on a fresh log (no prior on-disk file).
+func TestLogFile_EofPos_InitialFresh(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	lf, _, _, err := bc.getOrCreateLog("file-fresh")
+	if err != nil {
+		t.Fatalf("getOrCreateLog: %v", err)
+	}
+	if lf.eofPos != logHeaderSize {
+		t.Fatalf("fresh eofPos: got %d want %d", lf.eofPos, logHeaderSize)
+	}
+	path := bc.logPath("file-fresh")
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if uint64(st.Size()) != lf.eofPos {
+		t.Fatalf("fresh disk size %d != eofPos %d", st.Size(), lf.eofPos)
+	}
+}
+
+// TestLogFile_EofPos_MatchesDiskSizeSequential writes several records back-
+// to-back and asserts that lf.eofPos equals the actual on-disk size after
+// each one. Locks the per-file mu before each read because the production
+// path advances eofPos under that mutex.
+func TestLogFile_EofPos_MatchesDiskSizeSequential(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	payload := bytes.Repeat([]byte{0x5A}, 256)
+	for i, off := range []uint64{0, 4096, 8192, 12288, 16384} {
+		if err := bc.AppendWrite(context.Background(), "file-seq", payload, off); err != nil {
+			t.Fatalf("AppendWrite[%d]: %v", i, err)
+		}
+		path := bc.logPath("file-seq")
+		st, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		bc.logsMu.RLock()
+		lf := bc.logFDs["file-seq"]
+		mu := bc.logLocks["file-seq"]
+		bc.logsMu.RUnlock()
+		mu.Lock()
+		got := lf.eofPos
+		mu.Unlock()
+		if uint64(st.Size()) != got {
+			t.Fatalf("after write %d: disk size %d != eofPos %d", i, st.Size(), got)
+		}
+	}
+}
+
+// TestLogFile_EofPos_MatchesDiskSizeConcurrent fires N goroutines at the
+// same payload and verifies the eofPos cursor stays consistent with the
+// on-disk size when all writers have drained. The per-file mu serializes
+// the increment, so the final value must equal the deterministic total
+// of all framed-record sizes.
+func TestLogFile_EofPos_MatchesDiskSizeConcurrent(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	const goroutines = 32
+	const payloadLen = 128
+	payload := bytes.Repeat([]byte{0xAB}, payloadLen)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if err := bc.AppendWrite(context.Background(), "file-conc", payload, uint64(i*4096)); err != nil {
+				t.Errorf("AppendWrite: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	path := bc.logPath("file-conc")
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	wantDisk := int64(logHeaderSize + goroutines*(recordFrameOverhead+payloadLen))
+	if st.Size() != wantDisk {
+		t.Fatalf("disk size: got %d want %d", st.Size(), wantDisk)
+	}
+	bc.logsMu.RLock()
+	lf := bc.logFDs["file-conc"]
+	mu := bc.logLocks["file-conc"]
+	bc.logsMu.RUnlock()
+	mu.Lock()
+	got := lf.eofPos
+	mu.Unlock()
+	if uint64(st.Size()) != got {
+		t.Fatalf("disk size %d != eofPos %d", st.Size(), got)
+	}
+}
+
+// TestLogFile_EofPos_RestoredAfterRecover writes records, closes the
+// FSStore, then reopens it via Recover. The reopened logFile must have
+// eofPos restored to the on-disk size by recovery's seek(0, SeekEnd).
+func TestLogFile_EofPos_RestoredAfterRecover(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreWithRS(t, rs)
+	payload := bytes.Repeat([]byte{0x77}, 200)
+	for _, off := range []uint64{0, 4096, 8192} {
+		if err := bc.AppendWrite(context.Background(), "file-rec", payload, off); err != nil {
+			t.Fatalf("AppendWrite: %v", err)
+		}
+	}
+	path := filepath.Join(bc.baseDir, "logs", "file-rec.log")
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	preCloseSize := st.Size()
+
+	bc2 := reopenFSStore(t, bc, rs)
+	bc2.logsMu.RLock()
+	lf := bc2.logFDs["file-rec"]
+	mu := bc2.logLocks["file-rec"]
+	bc2.logsMu.RUnlock()
+	if lf == nil {
+		t.Fatalf("logFile not restored after recover")
+	}
+	mu.Lock()
+	got := lf.eofPos
+	mu.Unlock()
+	if uint64(preCloseSize) != got {
+		t.Fatalf("post-recover eofPos: got %d want %d (on-disk size)", got, preCloseSize)
+	}
+}

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -177,13 +177,20 @@ type FSStore struct {
 	// along with ctx.Done() and bc.done.
 	pressureCh chan struct{}
 
-	// logsMu guards logFDs, logLocks, dirtyIntervals, and tombstones.
-	// Double-checked locking idiom matches blocksMu / memBlocks in
-	// getOrCreateMemBlock.
+	// logsMu guards logFDs, logLocks, dirtyIntervals, logIndices, and
+	// tombstones. Double-checked locking idiom matches blocksMu /
+	// memBlocks in getOrCreateMemBlock.
 	logsMu         sync.RWMutex
 	logFDs         map[string]*logFile      // payloadID -> open log fd wrapper (D-34: one fd per file, bypasses fdPool)
 	logLocks       map[string]*sync.Mutex   // payloadID -> per-file append mutex (D-32)
 	dirtyIntervals map[string]*intervalTree // payloadID -> dirty-region tree (D-16)
+	// logIndices is the per-payload log-position oracle (Direction-1
+	// rollup redesign). One entry per appended record carries the
+	// frame's log byte offset, its file_offset, and its payload length.
+	// Populated under the per-file `mu` from AppendWrite (P3) and from
+	// the recovery scan (P4). Consumed by the rollup (P5) to translate
+	// a stable file-offset interval into the set of records to pread.
+	logIndices map[string]*logIndex
 	// tombstones marks payloadIDs whose append log has been (or is being)
 	// deleted by DeleteAppendLog (plan 09). rollupFile (plan 06) consults
 	// this BEFORE and AFTER the per-file mutex hand-off to ensure no
@@ -353,6 +360,7 @@ func newFSStoreInternal(baseDir string, maxDisk int64, maxMemory int64, fileBloc
 	bc.logFDs = make(map[string]*logFile)
 	bc.logLocks = make(map[string]*sync.Mutex)
 	bc.dirtyIntervals = make(map[string]*intervalTree)
+	bc.logIndices = make(map[string]*logIndex)
 	bc.tombstones = make(map[string]struct{})
 	bc.truncations = make(map[string]uint64)
 	bc.maxLogBytes = 1 << 30 // 1 GiB default (D-14)

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -21,6 +21,14 @@ package fs
 // the per-file `mu` (see appendwrite.go::AppendWrite and rollup.go::
 // rollupFile). The invariant matches the rest of the per-payload state
 // (interval tree, truncation boundary).
+//
+// TRANSITIONAL-V0.17+: physical log compaction (truncating the log file
+// at compactionFence) is out of scope. Consumed entries linger in
+// idx.entries until DeleteAppendLog wipes the payload; memory grows
+// roughly with arrival count between payload-lifetime endpoints. R-7 in
+// .planning/proposals/2026-05-22-logindex-rollup-redesign.md is the
+// follow-up to replace logPos-keyed consumption with file-offset-keyed
+// consumption, eliminating the stalled-fence pathology entirely.
 
 // logEntry is one record's position in the log + the file-offset extent it
 // covers. The entry is immutable once appended; consumption is tracked

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -1,0 +1,143 @@
+package fs
+
+// Per-file logIndex (Direction 1 redesign — see
+// .planning/proposals/2026-05-22-logindex-rollup-redesign.md).
+//
+// The existing interval tree (interval_tree.go) is the oracle for which
+// FILE-OFFSET regions are dirty and stable. The logIndex is the oracle for
+// where in the on-disk LOG each AppendWrite's framed record lives. The two
+// domains are decoupled so the rollup can find every record covering a
+// stable file-offset interval — independent of arrival order — by
+// translating a file-offset range into a set of log positions and pread-ing
+// them directly.
+//
+// The previous design assumed records on the per-file log were stored in
+// file-offset order; macOS NFSv3 (and any parallel-write client) violates
+// that — AppendWrite records land in arrival order. The linear log scan
+// short-circuited on the first in-range frame and silently produced
+// recs=0 rollups for parallel-write workloads.
+//
+// Concurrency: logIndex is NOT internally synchronized. All callers hold
+// the per-file `mu` (see appendwrite.go::AppendWrite and rollup.go::
+// rollupFile). The invariant matches the rest of the per-payload state
+// (interval tree, truncation boundary).
+
+// logEntry is one record's position in the log + the file-offset extent it
+// covers. The entry is immutable once appended; consumption is tracked
+// separately via the consumed map on logIndex.
+type logEntry struct {
+	logPos     uint64 // byte offset of the frame's first byte in the log file
+	fileOff    uint64 // record's file_offset field (16-byte frame header)
+	payloadLen uint32 // payload byte count (excludes frame overhead)
+}
+
+// fileEnd returns the exclusive file-offset upper bound for this record.
+func (e logEntry) fileEnd() uint64 {
+	return e.fileOff + uint64(e.payloadLen)
+}
+
+// logIndex maintains per-file log-position bookkeeping. Entries are
+// appended in arrival order (== logPos order, since AppendWrite advances
+// lf.eofPos monotonically under per-file mu). The consumed map records
+// which logPos values have been rolled up into CAS; compactionFence is
+// the largest logPos such that every entry with logPos <= fence has been
+// consumed — i.e. the on-disk byte prefix that is now eligible for
+// physical compaction (deferred to v0.17+).
+//
+// rollup_offset on disk continues to mean "consumed up to this log byte
+// offset"; conceptually it now records compactionFence rather than a
+// running scan cursor.
+type logIndex struct {
+	entries         []logEntry
+	consumed        map[uint64]struct{} // key = logEntry.logPos
+	compactionFence uint64
+}
+
+// newLogIndex constructs an empty logIndex. compactionFence starts at
+// logHeaderSize because the header itself is never a candidate for
+// compaction.
+func newLogIndex() *logIndex {
+	return &logIndex{
+		entries:         nil,
+		consumed:        make(map[uint64]struct{}),
+		compactionFence: logHeaderSize,
+	}
+}
+
+// Append records a new entry. Caller MUST hold the per-file mu and MUST
+// pass a logPos strictly greater than the most recent entry's logPos
+// (eofPos advances monotonically). Append does not validate ordering —
+// the contract is on the caller.
+func (idx *logIndex) Append(logPos uint64, fileOff uint64, payloadLen uint32) {
+	idx.entries = append(idx.entries, logEntry{
+		logPos:     logPos,
+		fileOff:    fileOff,
+		payloadLen: payloadLen,
+	})
+}
+
+// EntriesForInterval returns every entry whose file-offset extent
+// intersects [fileOff, fileOff+length). Order of returned entries
+// preserves logPos order (== arrival order) so the rollup can apply
+// FastCDC over the canonical stream while still walking out-of-order
+// arrivals.
+//
+// Length == 0 returns nil.
+func (idx *logIndex) EntriesForInterval(fileOff uint64, length uint64) []logEntry {
+	if length == 0 {
+		return nil
+	}
+	end := fileOff + length
+	out := make([]logEntry, 0, 4)
+	for _, e := range idx.entries {
+		if e.fileEnd() <= fileOff {
+			continue
+		}
+		if e.fileOff >= end {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// MarkConsumed records that the entry at logPos has been rolled into
+// CAS. Idempotent — repeat calls for the same logPos are a no-op.
+func (idx *logIndex) MarkConsumed(logPos uint64) {
+	idx.consumed[logPos] = struct{}{}
+}
+
+// AdvanceFence walks consumed entries in logPos order from the current
+// fence forward, advancing compactionFence past every entry that is
+// consumed and contiguous. Stops at the first non-consumed entry. The
+// new fence is returned. An out-of-order consumed entry (a "hole" left
+// by an unconsumed predecessor) does NOT advance the fence — it stays
+// in `consumed` until the predecessor is consumed too.
+//
+// This is the operation the rollup invokes after persisting a CAS
+// commit; the returned fence is what advanceRollupOffset eventually
+// writes to disk.
+func (idx *logIndex) AdvanceFence() uint64 {
+	for _, e := range idx.entries {
+		if e.logPos < idx.compactionFence {
+			continue
+		}
+		if _, ok := idx.consumed[e.logPos]; !ok {
+			break
+		}
+		// Fence advances past the consumed entry's full record extent.
+		idx.compactionFence = e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen)
+	}
+	return idx.compactionFence
+}
+
+// Fence returns the current compactionFence without mutation.
+func (idx *logIndex) Fence() uint64 {
+	return idx.compactionFence
+}
+
+// Len returns the total number of indexed entries (consumed + unconsumed).
+// Test/debug surface.
+func (idx *logIndex) Len() int {
+	return len(idx.entries)
+}

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -136,6 +136,17 @@ func (idx *logIndex) Fence() uint64 {
 	return idx.compactionFence
 }
 
+// SetFence overrides the compaction fence. Intended for recovery, which
+// reconstructs the logIndex from records at and after the persisted
+// rollup_offset; any record below that offset was already consumed by a
+// pre-boot rollup pass and must not be replayed. Setting the fence to
+// the boot-time rollup_offset preserves that invariant for the
+// post-boot AdvanceFence walks. MUST be called before any MarkConsumed
+// /AdvanceFence calls on the same logIndex.
+func (idx *logIndex) SetFence(fence uint64) {
+	idx.compactionFence = fence
+}
+
 // Len returns the total number of indexed entries (consumed + unconsumed).
 // Test/debug surface.
 func (idx *logIndex) Len() int {

--- a/pkg/blockstore/local/fs/logindex_appendwrite_test.go
+++ b/pkg/blockstore/local/fs/logindex_appendwrite_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // snapshotLogIndex returns a copy of the per-payload logIndex entries
@@ -199,5 +201,51 @@ func TestLogIndex_LogPosMatchesEofPosProgress(t *testing.T) {
 	wantLogPos := lf.eofPos - uint64(recordFrameOverhead) - uint64(len(payload))
 	if last.logPos != wantLogPos {
 		t.Fatalf("last entry logPos: got %d want %d (eofPos=%d)", last.logPos, wantLogPos, lf.eofPos)
+	}
+}
+
+// TestLogIndex_SeededByRecovery writes several records, closes the
+// FSStore, and reopens via Recover. The reconstructed logIndex must
+// carry one entry per on-disk record with logPos pointing at the frame
+// boundary and fence pinned at the persisted rollup_offset (no
+// pre-existing offset in this test => header boundary).
+func TestLogIndex_SeededByRecovery(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreWithRS(t, rs)
+	payload := bytes.Repeat([]byte{0x99}, 128)
+	offsets := []uint64{0, 4096, 8192}
+	for _, off := range offsets {
+		if err := bc.AppendWrite(context.Background(), "file-rec-idx", payload, off); err != nil {
+			t.Fatalf("AppendWrite: %v", err)
+		}
+	}
+
+	bc2 := reopenFSStore(t, bc, rs)
+	bc2.logsMu.RLock()
+	idx := bc2.logIndices["file-rec-idx"]
+	mu := bc2.logLocks["file-rec-idx"]
+	bc2.logsMu.RUnlock()
+	if idx == nil || mu == nil {
+		t.Fatalf("logIndex / mu missing after recovery")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(idx.entries) != len(offsets) {
+		t.Fatalf("entry count after recovery: got %d want %d", len(idx.entries), len(offsets))
+	}
+	step := uint64(recordFrameOverhead) + uint64(len(payload))
+	wantLogPos := uint64(logHeaderSize)
+	for i, e := range idx.entries {
+		if e.logPos != wantLogPos {
+			t.Fatalf("entry[%d].logPos: got %d want %d", i, e.logPos, wantLogPos)
+		}
+		if e.fileOff != offsets[i] {
+			t.Fatalf("entry[%d].fileOff: got %d want %d", i, e.fileOff, offsets[i])
+		}
+		wantLogPos += step
+	}
+	if idx.Fence() != logHeaderSize {
+		t.Fatalf("fence after recovery (no prior rollup): got %d want %d", idx.Fence(), logHeaderSize)
 	}
 }

--- a/pkg/blockstore/local/fs/logindex_appendwrite_test.go
+++ b/pkg/blockstore/local/fs/logindex_appendwrite_test.go
@@ -1,0 +1,203 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// snapshotLogIndex returns a copy of the per-payload logIndex entries
+// under both bc.logsMu and the per-file mu so the snapshot is consistent
+// with concurrent AppendWriters. Test-only helper.
+func snapshotLogIndex(t *testing.T, bc *FSStore, payloadID string) []logEntry {
+	t.Helper()
+	bc.logsMu.RLock()
+	idx := bc.logIndices[payloadID]
+	mu := bc.logLocks[payloadID]
+	bc.logsMu.RUnlock()
+	if idx == nil || mu == nil {
+		return nil
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]logEntry, len(idx.entries))
+	copy(out, idx.entries)
+	return out
+}
+
+// TestLogIndex_PopulatedFromAppendWrite_Sequential verifies that every
+// AppendWrite produces exactly one logIndex entry, with logPos pointing
+// at the frame boundary the writer wrote to.
+func TestLogIndex_PopulatedFromAppendWrite_Sequential(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	payload := bytes.Repeat([]byte{0x42}, 512)
+	offsets := []uint64{0, 4096, 8192, 12288}
+	for _, off := range offsets {
+		if err := bc.AppendWrite(context.Background(), "file-seq", payload, off); err != nil {
+			t.Fatalf("AppendWrite: %v", err)
+		}
+	}
+	entries := snapshotLogIndex(t, bc, "file-seq")
+	if len(entries) != len(offsets) {
+		t.Fatalf("entry count: got %d want %d", len(entries), len(offsets))
+	}
+	// Expected logPos walk: header, then each prior frame.
+	step := uint64(recordFrameOverhead) + uint64(len(payload))
+	wantLogPos := uint64(logHeaderSize)
+	for i, e := range entries {
+		if e.logPos != wantLogPos {
+			t.Fatalf("entry[%d].logPos: got %d want %d", i, e.logPos, wantLogPos)
+		}
+		if e.fileOff != offsets[i] {
+			t.Fatalf("entry[%d].fileOff: got %d want %d", i, e.fileOff, offsets[i])
+		}
+		if e.payloadLen != uint32(len(payload)) {
+			t.Fatalf("entry[%d].payloadLen: got %d want %d", i, e.payloadLen, len(payload))
+		}
+		wantLogPos += step
+	}
+}
+
+// TestLogIndex_PopulatedFromAppendWrite_Concurrent fires N goroutines at
+// the same payload with distinct file offsets and verifies the logIndex
+// captures every record. logPos must be strictly ascending (per-file mu
+// serializes the increment); the set of fileOffsets must match the set
+// of writers.
+func TestLogIndex_PopulatedFromAppendWrite_Concurrent(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	const goroutines = 64
+	const payloadLen = 256
+	payload := bytes.Repeat([]byte{0xAA}, payloadLen)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if err := bc.AppendWrite(context.Background(), "file-conc", payload, uint64(i*8192)); err != nil {
+				t.Errorf("AppendWrite: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	entries := snapshotLogIndex(t, bc, "file-conc")
+	if len(entries) != goroutines {
+		t.Fatalf("entry count: got %d want %d", len(entries), goroutines)
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i].logPos <= entries[i-1].logPos {
+			t.Fatalf("logPos not strictly ascending at i=%d: %+v", i, entries[i-1:i+1])
+		}
+	}
+	gotOffs := make([]uint64, len(entries))
+	for i, e := range entries {
+		gotOffs[i] = e.fileOff
+	}
+	sort.Slice(gotOffs, func(a, b int) bool { return gotOffs[a] < gotOffs[b] })
+	for i, off := range gotOffs {
+		if off != uint64(i*8192) {
+			t.Fatalf("sorted fileOff[%d]: got %d want %d", i, off, i*8192)
+		}
+	}
+}
+
+// TestLogIndex_OutOfOrderArrivals_RecoverableByLookup is the end-to-end
+// regression case. Several goroutines write to interleaved file offsets;
+// after they drain, an EntriesForInterval query against a window that
+// includes the LATEST-arrived file offset (which lands in the middle of
+// the log, not at its head) must surface the matching record. This is
+// the failure mode that produced silent recs=0 rollups under macOS
+// NFSv3 parallel writes.
+func TestLogIndex_OutOfOrderArrivals_RecoverableByLookup(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	// Sequential arrivals at distinct, NON-MONOTONIC file offsets — the
+	// per-file mu enforces serialized log-append order, so we exercise
+	// the bug shape (file_off NOT in arrival order) with deterministic
+	// arrival order.
+	const payloadLen = 32 * 1024
+	payload := bytes.Repeat([]byte{0xCC}, payloadLen)
+	arrivals := []uint64{32768, 458752, 0, 1540096, 524288}
+	for _, off := range arrivals {
+		if err := bc.AppendWrite(context.Background(), "file-ooo", payload, off); err != nil {
+			t.Fatalf("AppendWrite at %d: %v", off, err)
+		}
+	}
+
+	bc.logsMu.RLock()
+	idx := bc.logIndices["file-ooo"]
+	mu := bc.logLocks["file-ooo"]
+	bc.logsMu.RUnlock()
+	mu.Lock()
+	// Query [0, 65536) — must find both fileOff=32768 (rec#0) and
+	// fileOff=0 (rec#2), the latter buried after a higher-offset record
+	// in the log. This is the bug shape from the proposal example.
+	hits := idx.EntriesForInterval(0, 65536)
+	mu.Unlock()
+	if len(hits) != 2 {
+		t.Fatalf("EntriesForInterval([0,65536)): got %d entries want 2 (%+v)", len(hits), hits)
+	}
+	wantFileOffs := []uint64{32768, 0} // arrival order
+	for i, e := range hits {
+		if e.fileOff != wantFileOffs[i] {
+			t.Fatalf("hit[%d].fileOff: got %d want %d", i, e.fileOff, wantFileOffs[i])
+		}
+	}
+	if hits[0].logPos >= hits[1].logPos {
+		t.Fatalf("logPos out of arrival order across hits: %+v", hits)
+	}
+}
+
+// TestLogIndex_ClearedByDeleteAppendLog verifies the DeleteAppendLog
+// step-5 cleanup wipes the logIndex map entry alongside the rest of
+// per-payload state.
+func TestLogIndex_ClearedByDeleteAppendLog(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	if err := bc.AppendWrite(context.Background(), "file-del", []byte("hello"), 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	bc.logsMu.RLock()
+	_, exists := bc.logIndices["file-del"]
+	bc.logsMu.RUnlock()
+	if !exists {
+		t.Fatalf("logIndex not populated before delete")
+	}
+
+	if err := bc.DeleteAppendLog(context.Background(), "file-del"); err != nil {
+		t.Fatalf("DeleteAppendLog: %v", err)
+	}
+	bc.logsMu.RLock()
+	_, exists = bc.logIndices["file-del"]
+	bc.logsMu.RUnlock()
+	if exists {
+		t.Fatalf("logIndex still present after DeleteAppendLog")
+	}
+}
+
+// TestLogIndex_LogPosMatchesEofPosProgress cross-checks that the
+// captured logPos in the LAST entry equals lf.eofPos minus the last
+// record's framed size — i.e. the entry points at the frame boundary
+// the writer wrote to, NOT at the post-advance cursor.
+func TestLogIndex_LogPosMatchesEofPosProgress(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	payload := bytes.Repeat([]byte{0xEE}, 333)
+	for _, off := range []uint64{0, 4096} {
+		if err := bc.AppendWrite(context.Background(), "file-pos", payload, off); err != nil {
+			t.Fatalf("AppendWrite: %v", err)
+		}
+	}
+	bc.logsMu.RLock()
+	lf := bc.logFDs["file-pos"]
+	idx := bc.logIndices["file-pos"]
+	mu := bc.logLocks["file-pos"]
+	bc.logsMu.RUnlock()
+	mu.Lock()
+	defer mu.Unlock()
+	last := idx.entries[len(idx.entries)-1]
+	wantLogPos := lf.eofPos - uint64(recordFrameOverhead) - uint64(len(payload))
+	if last.logPos != wantLogPos {
+		t.Fatalf("last entry logPos: got %d want %d (eofPos=%d)", last.logPos, wantLogPos, lf.eofPos)
+	}
+}

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -1,0 +1,223 @@
+package fs
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestLogIndex_Empty verifies the zero state: no entries, fence at the
+// log header boundary, no lookup hits.
+func TestLogIndex_Empty(t *testing.T) {
+	idx := newLogIndex()
+	if idx.Len() != 0 {
+		t.Fatalf("Len: got %d want 0", idx.Len())
+	}
+	if idx.Fence() != logHeaderSize {
+		t.Fatalf("Fence: got %d want %d", idx.Fence(), logHeaderSize)
+	}
+	if got := idx.EntriesForInterval(0, 4096); len(got) != 0 {
+		t.Fatalf("EntriesForInterval on empty: got %v want []", got)
+	}
+}
+
+// TestLogIndex_AppendAndLookup_InOrder seeds three records at adjacent
+// file offsets and verifies a covering interval returns all three in
+// logPos order.
+func TestLogIndex_AppendAndLookup_InOrder(t *testing.T) {
+	idx := newLogIndex()
+	idx.Append(logHeaderSize, 0, 1024)
+	idx.Append(logHeaderSize+1024+recordFrameOverhead, 1024, 1024)
+	idx.Append(logHeaderSize+2*(1024+recordFrameOverhead), 2048, 1024)
+
+	got := idx.EntriesForInterval(0, 3072)
+	if len(got) != 3 {
+		t.Fatalf("EntriesForInterval count: got %d want 3", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].logPos <= got[i-1].logPos {
+			t.Fatalf("entries not in logPos order: %+v", got)
+		}
+	}
+}
+
+// TestLogIndex_AppendAndLookup_OutOfOrderArrivals is the core regression
+// case: macOS NFSv3 parallel writes deliver records in arrival order, not
+// file-offset order. The lookup must still find every record covering the
+// requested file interval, in arrival order.
+func TestLogIndex_AppendAndLookup_OutOfOrderArrivals(t *testing.T) {
+	idx := newLogIndex()
+	// Arrival order: file offsets 32768, 458752, 0, 1540096
+	// (matches the example transcript in the redesign proposal).
+	type rec struct {
+		fileOff uint64
+		length  uint32
+	}
+	arrivals := []rec{
+		{fileOff: 32768, length: 32784},
+		{fileOff: 458752, length: 32784},
+		{fileOff: 0, length: 32768},
+		{fileOff: 1540096, length: 32784},
+	}
+	pos := uint64(logHeaderSize)
+	for _, a := range arrivals {
+		idx.Append(pos, a.fileOff, a.length)
+		pos += uint64(recordFrameOverhead) + uint64(a.length)
+	}
+
+	// Query the [0, 65536) window — must surface the rec#2 arrival even
+	// though it sits AFTER higher-offset records in the log.
+	got := idx.EntriesForInterval(0, 65536)
+	if len(got) != 2 {
+		t.Fatalf("EntriesForInterval out-of-order: got %d entries want 2 (%+v)", len(got), got)
+	}
+	wantFileOffs := []uint64{32768, 0}
+	for i, e := range got {
+		if e.fileOff != wantFileOffs[i] {
+			t.Fatalf("entry %d fileOff: got %d want %d (full result: %+v)", i, e.fileOff, wantFileOffs[i], got)
+		}
+	}
+	// logPos must still be ascending — the arrival-order invariant
+	// the rollup relies on for FastCDC stream reconstruction.
+	if got[0].logPos >= got[1].logPos {
+		t.Fatalf("logPos not ascending across out-of-order arrivals: %+v", got)
+	}
+}
+
+// TestLogIndex_EntriesForInterval_Boundaries exercises the inclusive/
+// exclusive edge cases of the file-offset overlap test.
+func TestLogIndex_EntriesForInterval_Boundaries(t *testing.T) {
+	idx := newLogIndex()
+	// Three records, contiguous in file-offset space: [0, 100), [100, 200), [200, 300).
+	idx.Append(logHeaderSize+0, 0, 100)
+	idx.Append(logHeaderSize+1*(100+recordFrameOverhead), 100, 100)
+	idx.Append(logHeaderSize+2*(100+recordFrameOverhead), 200, 100)
+
+	cases := []struct {
+		name        string
+		off, length uint64
+		want        []uint64 // expected fileOff values, in returned order
+	}{
+		{"zero length returns none", 50, 0, nil},
+		{"no overlap below", 0, 0, nil}, // length 0 short-circuits
+		{"left edge inclusive", 0, 1, []uint64{0}},
+		{"right edge exclusive at 100", 99, 1, []uint64{0}},
+		{"hits second only via boundary", 100, 1, []uint64{100}},
+		{"spans first and second", 50, 100, []uint64{0, 100}},
+		{"exact match second", 100, 100, []uint64{100}},
+		{"covers all three", 0, 300, []uint64{0, 100, 200}},
+		{"strictly past last", 300, 50, nil},
+		{"touches start of last", 200, 1, []uint64{200}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := idx.EntriesForInterval(tc.off, tc.length)
+			var gotOffs []uint64
+			for _, e := range got {
+				gotOffs = append(gotOffs, e.fileOff)
+			}
+			if !reflect.DeepEqual(gotOffs, tc.want) {
+				t.Fatalf("offsets: got %v want %v", gotOffs, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogIndex_AdvanceFence_Contiguous verifies that consuming records in
+// arrival order advances the fence past each full record extent.
+func TestLogIndex_AdvanceFence_Contiguous(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(256)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+	positions := make([]uint64, 0, 3)
+	for i := 0; i < 3; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		positions = append(positions, pos)
+		pos += step
+	}
+
+	// No consumption → fence stays at logHeaderSize.
+	if got := idx.AdvanceFence(); got != logHeaderSize {
+		t.Fatalf("fence with no consumption: got %d want %d", got, logHeaderSize)
+	}
+
+	// Consume the first entry. Fence advances to end of record 0.
+	idx.MarkConsumed(positions[0])
+	want := positions[0] + step
+	if got := idx.AdvanceFence(); got != want {
+		t.Fatalf("fence after consume[0]: got %d want %d", got, want)
+	}
+
+	// Consume the second entry. Fence advances to end of record 1.
+	idx.MarkConsumed(positions[1])
+	want = positions[1] + step
+	if got := idx.AdvanceFence(); got != want {
+		t.Fatalf("fence after consume[1]: got %d want %d", got, want)
+	}
+
+	// Consume the third entry. Fence advances to end of record 2 (== pos).
+	idx.MarkConsumed(positions[2])
+	want = positions[2] + step
+	if got := idx.AdvanceFence(); got != want {
+		t.Fatalf("fence after consume[2]: got %d want %d", got, want)
+	}
+}
+
+// TestLogIndex_AdvanceFence_HoleBlocks verifies the load-bearing
+// invariant for R-7: a consumed entry preceded by an unconsumed
+// predecessor must NOT advance the fence.
+func TestLogIndex_AdvanceFence_HoleBlocks(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(256)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+	positions := []uint64{}
+	for i := 0; i < 3; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		positions = append(positions, pos)
+		pos += step
+	}
+
+	// Consume entries 1 and 2 (skipping 0). Fence MUST stay at the
+	// header boundary because record 0 is still in-flight.
+	idx.MarkConsumed(positions[1])
+	idx.MarkConsumed(positions[2])
+	if got := idx.AdvanceFence(); got != logHeaderSize {
+		t.Fatalf("hole at head: fence got %d want %d", got, logHeaderSize)
+	}
+
+	// Now consume record 0. The fence walks through all three because
+	// 1 and 2 are already marked.
+	idx.MarkConsumed(positions[0])
+	want := positions[2] + step
+	if got := idx.AdvanceFence(); got != want {
+		t.Fatalf("fence after head-consume: got %d want %d", got, want)
+	}
+}
+
+// TestLogIndex_MarkConsumed_Idempotent guards against repeated rollup
+// calls for the same entry inflating any internal accounting. (None
+// today, but cheap to enforce.)
+func TestLogIndex_MarkConsumed_Idempotent(t *testing.T) {
+	idx := newLogIndex()
+	idx.Append(logHeaderSize, 0, 100)
+	idx.MarkConsumed(logHeaderSize)
+	idx.MarkConsumed(logHeaderSize)
+	idx.MarkConsumed(logHeaderSize)
+	want := uint64(logHeaderSize) + uint64(recordFrameOverhead) + 100
+	if got := idx.AdvanceFence(); got != want {
+		t.Fatalf("fence: got %d want %d", got, want)
+	}
+}
+
+// TestLogIndex_AdvanceFence_NoConsumed_NoMove verifies AdvanceFence is
+// idempotent when called repeatedly with no new consumption.
+func TestLogIndex_AdvanceFence_NoConsumed_NoMove(t *testing.T) {
+	idx := newLogIndex()
+	idx.Append(logHeaderSize, 0, 100)
+	for i := 0; i < 3; i++ {
+		if got := idx.AdvanceFence(); got != logHeaderSize {
+			t.Fatalf("AdvanceFence call %d: got %d want %d", i, got, logHeaderSize)
+		}
+	}
+}

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -389,13 +389,14 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 		}
 
 		// Install fd into FSStore, seeked to EOF for subsequent appends.
-		if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		eof, err := f.Seek(0, io.SeekEnd)
+		if err != nil {
 			logger.Warn("recovery: seek end failed", "path", path, "error", err)
 			_ = f.Close()
 			return nil
 		}
 		bc.logsMu.Lock()
-		lf := &logFile{f: f, path: path}
+		lf := &logFile{f: f, path: path, eofPos: uint64(eof)}
 		// Phase 19 Opt 2 (D-06/D-07/D-08): per-file fsync coordinator,
 		// matching the getOrCreateLog construction site in appendwrite.go.
 		lf.groupCommit = newGroupCommit(lf.f.Sync)

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -298,6 +298,14 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 			return nil
 		}
 		tree := newIntervalTree()
+		// Direction-1 rollup redesign: build the per-payload logIndex in
+		// lockstep with the interval tree. Each successfully replayed
+		// record's frame start is captured as logPos so the post-boot
+		// rollup can run the same logIndex-driven path as a steady-state
+		// rollup. SetFence below pins the compactionFence at the persisted
+		// rollup_offset so AdvanceFence walks start from there.
+		idx := newLogIndex()
+		idx.SetFence(effectiveOff)
 		pos := effectiveOff
 		records := 0
 		for {
@@ -343,6 +351,7 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 				break
 			}
 			tree.Insert(off, uint32(len(payload)), time.Now())
+			idx.Append(lastPos, off, uint32(len(payload)))
 			pos += uint64(recordFrameOverhead) + uint64(len(payload))
 			records++
 		}
@@ -403,14 +412,11 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 		bc.logFDs[payloadID] = lf
 		bc.logLocks[payloadID] = &sync.Mutex{}
 		bc.dirtyIntervals[payloadID] = tree
-		// Direction-1 redesign: allocate an empty logIndex here so any
-		// AppendWrite that races recovery's tail finds a non-nil map
-		// entry. P4 seeds it from the scanned records before this
-		// publish; for now it stays empty (the rollup ignores logIndex
-		// until P5).
-		if _, ok := bc.logIndices[payloadID]; !ok {
-			bc.logIndices[payloadID] = newLogIndex()
-		}
+		// Direction-1 redesign: publish the recovery-built logIndex.
+		// The scan above populated one entry per unconsumed record and
+		// pinned the compaction fence at effectiveOff so post-boot
+		// AdvanceFence walks start from the persisted rollup_offset.
+		bc.logIndices[payloadID] = idx
 		bc.logsMu.Unlock()
 		// Reflect the resident (un-rolled-up) log bytes in logBytesTotal
 		// so the pressure loop sees accurate state after boot.

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -403,6 +403,14 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 		bc.logFDs[payloadID] = lf
 		bc.logLocks[payloadID] = &sync.Mutex{}
 		bc.dirtyIntervals[payloadID] = tree
+		// Direction-1 redesign: allocate an empty logIndex here so any
+		// AppendWrite that races recovery's tail finds a non-nil map
+		// entry. P4 seeds it from the scanned records before this
+		// publish; for now it stays empty (the rollup ignores logIndex
+		// until P5).
+		if _, ok := bc.logIndices[payloadID]; !ok {
+			bc.logIndices[payloadID] = newLogIndex()
+		}
 		bc.logsMu.Unlock()
 		// Reflect the resident (un-rolled-up) log bytes in logBytesTotal
 		// so the pressure loop sees accurate state after boot.

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -138,8 +137,9 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	lf := bc.logFDs[payloadID]
 	tree := bc.dirtyIntervals[payloadID]
 	mu := bc.logLocks[payloadID]
+	idx := bc.logIndices[payloadID]
 	bc.logsMu.RUnlock()
-	if lf == nil || tree == nil || mu == nil {
+	if lf == nil || tree == nil || mu == nil || idx == nil {
 		// Nothing to do — payload never had an AppendWrite (or was
 		// cleared by Close/DeleteAppendLog).
 		return nil
@@ -183,58 +183,62 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
-	// Read the log header to learn the current rollup_offset.
+	// Read the log header to learn the current rollup_offset (used below
+	// only as the prior fence the new advance is compared against).
 	hdr, err := readLogHeader(lf.f)
 	if err != nil {
 		slog.Warn("rollup: read header", "payloadID", payloadID, "error", err)
 		return err
 	}
 
-	// Scan records from rollup_offset onward using a SEPARATE read-only fd
-	// so we don't disturb lf.f's append position (getOrCreateLog seeks it
-	// to EOF). The reader is closed before the method returns.
+	// Direction-1 rollup redesign: consult the per-payload logIndex to
+	// translate the stable file-offset interval into a set of records
+	// whose frames sit somewhere in the on-disk log (not necessarily
+	// contiguous at the head). Each entry carries logPos + payloadLen,
+	// so we pread each frame directly instead of scanning the log
+	// sequentially. A separate read-only fd is used so we don't disturb
+	// lf.f's append position.
+	stableEnd := stable.Offset + uint64(stable.Length)
+	entries := idx.EntriesForInterval(stable.Offset, uint64(stable.Length))
+	if len(entries) == 0 {
+		return nil
+	}
+
 	rf, err := os.Open(lf.path)
 	if err != nil {
 		return fmt.Errorf("rollup: open log for read: %w", err)
 	}
 	defer func() { _ = rf.Close() }()
-	if _, err := rf.Seek(int64(hdr.RollupOffset), io.SeekStart); err != nil {
-		return fmt.Errorf("rollup: seek: %w", err)
-	}
 
-	stableEnd := stable.Offset + uint64(stable.Length)
-
-	var recs []rec
-	currentPos := hdr.RollupOffset
-	targetPos := currentPos
-	for {
-		off, payload, rok, rerr := readRecord(rf)
+	recs := make([]rec, 0, len(entries))
+	consumedPositions := make([]uint64, 0, len(entries))
+	for _, e := range entries {
+		off, payload, rerr := readRecordAt(rf, e.logPos, e.payloadLen)
 		if rerr != nil {
-			return fmt.Errorf("rollup: readRecord: %w", rerr)
+			// A CRC mismatch or pread failure at a record the logIndex
+			// claims is valid implies log-fd corruption or a logIndex/
+			// log divergence bug. Treat as a hard fail for this pass —
+			// metadata stays unchanged, the tree keeps the interval
+			// dirty, a future pass (possibly after recovery) can retry.
+			slog.Warn("rollup: readRecordAt", "payloadID", payloadID,
+				"logPos", e.logPos, "error", rerr)
+			return nil
 		}
-		if !rok {
-			break // clean EOF / torn tail — recovery handles truncation
+		if off != e.fileOff {
+			slog.Warn("rollup: logIndex fileOff mismatch", "payloadID", payloadID,
+				"logPos", e.logPos, "indexed", e.fileOff, "frame", off)
+			return nil
 		}
-		recSize := uint64(recordFrameOverhead) + uint64(len(payload))
-		nextPos := currentPos + recSize
-
-		// Record entirely before the stable interval — already covered by
-		// an earlier rollup (shouldn't normally happen since we started at
-		// hdr.RollupOffset, but be defensive). Advance targetPos past it.
-		if off+uint64(len(payload)) <= stable.Offset {
-			targetPos = nextPos
-			currentPos = nextPos
-			continue
-		}
-		// Record entirely past the stable interval — stop; later records
-		// belong to a future pass.
-		if off >= stableEnd {
-			break
-		}
-		// Record intersects the stable interval — include it.
-		recs = append(recs, rec{off: off, payload: payload, endPos: nextPos})
-		targetPos = nextPos
-		currentPos = nextPos
+		recs = append(recs, rec{
+			off:     off,
+			payload: payload,
+			// endPos preserved for downstream consumers that still rely
+			// on it; with the logIndex-driven path it is no longer used
+			// to advance targetPos, but reconstructStream / dedup code
+			// reads it via the rec struct.
+			endPos: e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen),
+		})
+		consumedPositions = append(consumedPositions, e.logPos)
 	}
 
 	// D-29 truncation filter: drop records entirely past the truncation
@@ -242,20 +246,18 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// (plan 09); consulted here so emitted chunks never contain bytes
 	// beyond the client-observed size at truncate time.
 	//
-	// FIX-19: when truncation drops records, targetPos was already advanced
-	// past their on-disk frames during the scan above. Recompute targetPos
-	// from the filtered set so SetRollupOffset never claims to have
-	// committed bytes for records that produced no chunks. The cap is the
-	// pre-filter targetPos so we don't accidentally walk BACKWARDS past a
-	// previously-scanned "skipped" record (the early-pre-stable arm above
-	// also bumps targetPos but never appends to recs).
+	// Direction-1 redesign: consumedPositions is filtered in lockstep with
+	// recs so we only mark logIndex entries consumed for records that
+	// actually contributed payload bytes to a stored chunk. Entries that
+	// truncation dropped entirely stay unconsumed; the on-disk bytes
+	// belong to a truncated tail the operator already invalidated.
 	bc.logsMu.RLock()
 	trunc, hasTrunc := bc.truncations[payloadID]
 	bc.logsMu.RUnlock()
 	if hasTrunc {
-		preFilterTarget := targetPos
 		filtered := recs[:0]
-		for _, r := range recs {
+		filteredPos := consumedPositions[:0]
+		for i, r := range recs {
 			if r.off >= trunc {
 				continue
 			}
@@ -264,24 +266,10 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 				r.payload = r.payload[:trunc-r.off]
 			}
 			filtered = append(filtered, r)
+			filteredPos = append(filteredPos, consumedPositions[i])
 		}
 		recs = filtered
-		// Recompute targetPos based on the LAST RECORD ACTUALLY in recs.
-		// If everything was filtered out, fall through to the len(recs)==0
-		// short-circuit below; targetPos stays unchanged so we don't
-		// regress the offset (irrelevant since we won't call
-		// SetRollupOffset).
-		if len(recs) > 0 {
-			lastEnd := recs[0].endPos
-			for _, r := range recs[1:] {
-				if r.endPos > lastEnd {
-					lastEnd = r.endPos
-				}
-			}
-			if lastEnd < preFilterTarget {
-				targetPos = lastEnd
-			}
-		}
+		consumedPositions = filteredPos
 	}
 
 	if len(recs) == 0 {
@@ -385,13 +373,34 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
+	// Direction-1 redesign: now that the chunks are stored, mark every
+	// surviving record's logPos consumed in the logIndex and ask the
+	// index for the new compaction fence. This is the value we persist
+	// as rollup_offset — semantically the same on-disk format, but
+	// computed from the consumed-record set instead of the pre-Direction-1
+	// "scan cursor advances past each record" arithmetic. A consumed
+	// entry preceded by an unconsumed predecessor does NOT advance the
+	// fence; the chunks are committed but the on-disk log byte prefix
+	// stays anchored until the predecessor is consumed too (R-7).
+	for _, lp := range consumedPositions {
+		idx.MarkConsumed(lp)
+	}
+	targetPos := idx.AdvanceFence()
+
 	// CommitChunks atomic sequence (D-12). SetRollupOffset is atomic-monotone
 	// at the RollupStore layer: on attempted regression it returns
-	// ErrRollupOffsetRegression and the stored value is unchanged. We treat
-	// that as benign (another worker raced ahead) and return nil.
+	// ErrRollupOffsetRegression and the stored value is unchanged. With
+	// Direction-1 the fence is monotonic by construction (newLogIndex /
+	// recovery seed + AdvanceFence forward-walk), and the per-file mu
+	// serializes rollup workers on the same payload, so regression
+	// should be unreachable in steady state. Keep the bail-out anyway —
+	// if some future change introduces a regression source, the
+	// conservative posture is the same as today: chunks are durable
+	// (content-addressed, idempotent on retry); a future pass will
+	// re-emit them.
 	_, err = bc.rollupStore.SetRollupOffset(ctx, payloadID, targetPos)
 	if errors.Is(err, metadata.ErrRollupOffsetRegression) {
-		slog.Debug("rollup: SetRollupOffset regression rejected (benign — another worker advanced past us)",
+		slog.Debug("rollup: SetRollupOffset regression rejected (benign)",
 			"payloadID", payloadID, "target", targetPos)
 		return nil
 	}

--- a/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
@@ -1,0 +1,171 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRollup_OutOfOrderArrivals_AllRecordsRolledUp is the load-bearing
+// regression case from the Direction-1 redesign proposal. Four AppendWrites
+// at file offsets {32768, 458752, 0, 1540096} arrive in that order — the
+// per-file mu serializes them so on-disk frame order matches arrival order,
+// which is exactly the parallel-write shape that broke the legacy rollup.
+//
+// Pre-fix: the linear scan from rollup_offset read frame 0 (file_off=32768),
+// then frame 1 (file_off=458752) — past the chosen stable interval — and
+// broke out. Frame 2 (file_off=0) was never read for the [0, …) stable
+// interval. Net effect: recs=0, no chunks for that region, rollup_offset
+// stalled or skipped past it.
+//
+// Post-fix: every stable interval's EntriesForInterval lookup finds the
+// matching arrival-order entries regardless of where they sit in the log,
+// so all four regions produce chunks and rollup_offset advances to EOF.
+func TestRollup_OutOfOrderArrivals_AllRecordsRolledUp(t *testing.T) {
+	bc, rs := newRollupFSStore(t, 1<<30, 10)
+	ctx := context.Background()
+
+	// Distinct fill bytes per region so content-addressing produces
+	// distinguishable chunks (no inadvertent dedup collapse). Each
+	// payload is 32 KiB — large enough to clear the FastCDC minimum
+	// chunk size and small enough to keep the test fast.
+	const payloadLen = 32 * 1024
+	type write struct {
+		fileOff uint64
+		fill    byte
+	}
+	writes := []write{
+		{fileOff: 32768, fill: 0xA1},
+		{fileOff: 458752, fill: 0xA2},
+		{fileOff: 0, fill: 0xA3},
+		{fileOff: 1540096, fill: 0xA4},
+	}
+	for _, w := range writes {
+		payload := bytes.Repeat([]byte{w.fill}, payloadLen)
+		if err := bc.AppendWrite(ctx, "file-ooo", payload, w.fileOff); err != nil {
+			t.Fatalf("AppendWrite at %d: %v", w.fileOff, err)
+		}
+	}
+
+	// All four intervals must eventually roll up. Wait for the log
+	// budget to decrement (the rollup pool fires the ConsumeUpTo +
+	// logBytesTotal.Add(-reclaimed) sequence once chunks are durable).
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		off, err := rs.GetRollupOffset(ctx, "file-ooo")
+		if err != nil {
+			t.Fatalf("GetRollupOffset: %v", err)
+		}
+		// Expected end-state rollup_offset: header + 4 * (frame + payload).
+		wantOff := uint64(logHeaderSize) + 4*(uint64(recordFrameOverhead)+uint64(payloadLen))
+		if off >= wantOff {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	off, err := rs.GetRollupOffset(ctx, "file-ooo")
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	wantOff := uint64(logHeaderSize) + 4*(uint64(recordFrameOverhead)+uint64(payloadLen))
+	if off < wantOff {
+		t.Fatalf("rollup_offset did not advance to EOF: got %d want >= %d (pre-fix bug shape)", off, wantOff)
+	}
+
+	// At least one chunk must exist in blocks/ for each write — since
+	// each write filled a distinct region with a distinct byte, dedup
+	// cannot collapse them across writes. With FastCDC the chunk count
+	// may exceed 4 (large payloads split), but it must NOT be < 4. The
+	// pre-fix bug would have produced 1 (rec#0 only — and even that one
+	// might have been lost depending on stabilization ordering).
+	if n := countChunksInBlocks(t, bc.baseDir); n < 4 {
+		t.Fatalf("expected at least 4 chunks in blocks/, found %d — Direction-1 bug-shape regression", n)
+	}
+
+	// logBytesTotal must have dropped to zero (every dirty interval
+	// consumed). A non-zero residue would indicate the log-budget
+	// release missed an interval.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bc.logBytesTotal.Load() == 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if got := bc.logBytesTotal.Load(); got != 0 {
+		t.Fatalf("logBytesTotal nonzero after full out-of-order rollup: %d", got)
+	}
+}
+
+// TestRollup_StalledFence_ChunksStillCommitted asserts that even when the
+// compaction fence cannot advance because of a record at the head of the
+// log waiting on stabilization, later stable intervals still produce
+// chunks. This is the R-7 path in the proposal — chunks are durable
+// content-addressed bytes, and tree.ConsumeUpTo runs regardless of fence
+// stall in the typical case.
+//
+// The simulation uses a small stabilization window (50 ms) and arranges
+// for the FIRST written record's interval to remain in the dirty tree
+// (via a later overlapping write to the same offset that refreshes
+// Touched on the same interval, pushing its stabilization). The LATER
+// records at distinct, non-overlapping file regions stabilize and roll
+// up — producing chunks even while the head record waits. Verifies the
+// chunk count and a non-empty blocks/ tree before the head-write
+// stabilizes.
+func TestRollup_StalledFence_ChunksStillCommitted(t *testing.T) {
+	bc, rs := newRollupFSStore(t, 1<<30, 50)
+	ctx := context.Background()
+
+	const payloadLen = 16 * 1024
+	// Head write at file_off=0 (lowest logPos). The test will refresh
+	// Touched on this interval just before the stabilization deadline
+	// so its stabilization keeps slipping; meanwhile the other writes
+	// stabilize and roll up.
+	head := bytes.Repeat([]byte{0xB1}, payloadLen)
+	if err := bc.AppendWrite(ctx, "file-stall", head, 0); err != nil {
+		t.Fatalf("AppendWrite head: %v", err)
+	}
+	// Later writes at distinct, non-overlapping regions.
+	for i, fill := range []byte{0xB2, 0xB3, 0xB4} {
+		payload := bytes.Repeat([]byte{fill}, payloadLen)
+		off := uint64((i + 1) * 524288)
+		if err := bc.AppendWrite(ctx, "file-stall", payload, off); err != nil {
+			t.Fatalf("AppendWrite[%d]: %v", i, err)
+		}
+	}
+
+	// Refresh the head interval a few times to keep it un-stable
+	// while the others stabilize. Each refresh writes the same content
+	// to file_off=0; per-file mu serializes the appends, and the tree
+	// merges the overlapping insert, bumping Touched.
+	for i := 0; i < 3; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if err := bc.AppendWrite(ctx, "file-stall", head, 0); err != nil {
+			t.Fatalf("AppendWrite head refresh[%d]: %v", i, err)
+		}
+	}
+
+	// Wait long enough for the later regions to stabilize and roll
+	// up. The head region keeps getting refreshed during this loop
+	// (via the refresh writes above already issued); after the refresh
+	// loop completes, wait one stabilization window for the later
+	// regions.
+	time.Sleep(200 * time.Millisecond)
+
+	if n := countChunksInBlocks(t, bc.baseDir); n < 3 {
+		t.Fatalf("expected ≥3 chunks for later regions while head stalls, got %d", n)
+	}
+
+	// Now stop refreshing head and let it stabilize too. Then the
+	// full file should roll up and rollup_offset advance to (or past)
+	// the end of all records we appended.
+	time.Sleep(300 * time.Millisecond)
+	off, err := rs.GetRollupOffset(ctx, "file-stall")
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	if off <= uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset did not advance after head stabilization: got %d", off)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the parallel-write rollup bug observed on macOS NFSv3: records on the per-file append log are stored in AppendWrite **arrival order**, not file-offset order, so the legacy linear scan in `rollup.go` short-circuited on the first frame past `stableEnd` and silently produced `recs=0` rollups whenever an in-stable record sat after a higher-offset record in the log.

Direction-1 redesign per `.planning/proposals/2026-05-22-logindex-rollup-redesign.md` (committed at `a726933e`, merged in #557):

- New per-payload `logIndex` decouples the file-offset domain (interval tree) from the log-position domain. Entries carry `(logPos, fileOff, payloadLen)`; `EntriesForInterval(off, length)` returns covering records in arrival order regardless of where they sit in the log.
- `lf.eofPos` cursor tracks the on-disk EOF position, advanced under the per-file `mu` after each successful `writeRecord + groupCommit.Sync`. AppendWrite captures the pre-advance value as `logPos`.
- Recovery seeds the logIndex from the same on-disk record scan it uses for the interval tree, then pins `compactionFence` at the persisted `rollup_offset`.
- Rollup pass now: `tree.EarliestStable` → `idx.EntriesForInterval` → `readRecordAt` (single pread per record, CRC-validated) → `StoreChunk` → `idx.MarkConsumed` → `idx.AdvanceFence`. The fence is the new value persisted as `rollup_offset` (on-disk format unchanged, conceptually shifted from "scan cursor" to "compaction fence").

## Commit sequence (per proposal's phased plan)

| # | Commit | Plan |
|---|---|---|
| `b0690923` | feat(fs): logFile.eofPos cursor | P1.1 |
| `3785dc45` | test(fs): eofPos invariant | P1.2 |
| `a2850780` | feat(fs): logIndex struct | P2.1 |
| `a494ddc4` | test(fs): logIndex unit tests | P2.2 |
| `e2f5eceb` | feat(fs): populate logIndex on AppendWrite | P3.1 |
| `c5184f09` | test(fs): logIndex tracks records under concurrency | P3.2 |
| `4bb21789` | feat(fs): recovery seeds logIndex | P4 |
| `1a69a419` | refactor(fs): rollup consumes via logIndex | P5.1 |
| `690220f1` | test(fs): out-of-order + stalled-fence regression | P5.2 |
| `947319a2` | docs(fs): consumption model + semantic shift | P6 |

## Invariants preserved (per proposal's table)

- Crash durability (AppendWrite + fsync = durable bytes)
- BLAKE3 content addressing + FastCDC boundary stability (D-21)
- Lock ordering: per-file `mu` → `bc.logsMu` → `groupCommit.mu`
- All three metadata backends pass `pkg/metadata/storetest/file_block_ops.go` conformance
- RFC1813 / SMB2 write semantics
- CommitChunks D-12 ordering: StoreChunk → SetRollupOffset → advanceRollupOffset → ConsumeUpTo

## Invariants retired (per proposal's table)

- `rollup_offset` == monotonic byte prefix of consumed log → now records `compactionFence` (same on-disk shape).
- Interval tree as log-scan controller → file-offset oracle only; log-position lookup moves to logIndex.
- Linear log scan from `rollup_offset` → replaced by `EntriesForInterval` + per-entry `ReadAt`.

## Phase 19 RAM-opt compatibility

All four optimizations survive unchanged: LRU dedup, group commit, OnChunkComplete callback, eager small-file dedup.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/blockstore/local/fs/ -race -count=1` — 100+ tests pass, including 4 new on `eofPos`, 8 on `logIndex` unit, 5 on `logIndex` integration, 1 on recovery seeding, 2 on rollup regression
- [x] `go test ./... -race -count=1` — full repo green
- [ ] CI: WPTS BVT memory + smbtorture memory + NFS v3/v4/v4.1 memory + Integration + E2E
- [ ] Live smoke macOS NFSv3: 4 MiB random write → CAS blocks within 2s (the original bug shape)
- [ ] Live smoke macOS NFSv3: 18-byte file → single chunk within 1s
- [ ] Live smoke: 1 GiB sustained write → log pressure releases correctly

## TRANSITIONAL-V0.17+

Documented in `doc.go` + `logindex.go`:
- Physical log compaction (rewriting log file dropping consumed records up to `compactionFence`) — out of scope for this PR.
- Tracking consumption by file-offset interval instead of log position (R-7 follow-up) — eliminates the stalled-fence pathology entirely; deferred to v0.17.

## Out of scope

- Direction 2 (in-memory tree holds payload bytes) — rejected by architect; violates `maxLogBytes` RAM budget.
- Direction 3 (per-record tombstone + compaction) — rejected by architect; strictly more I/O than Direction 1.