### PR TITLE
fix(smb/acl): grant resolved DesiredAccess on FileCreated, skip DACL re-check

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_filecreated_grant_test.go
+++ b/internal/adapter/smb/v2/handlers/create_filecreated_grant_test.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// TestCreate_FileCreated_GrantsResolvedDesiredAccess covers the regression
+// behind #560 (smb2.acls.INHERITFLAGS) and #561 (smb2.acls.SDFLAGSVSCHOWN):
+//
+// Both tests build a parent directory with an inheritable DACL that grants
+// the creator only a narrow subset of rights (SEC_FILE_WRITE_DATA |
+// SEC_STD_WRITE_DAC). They then CREATE a child file with
+// DesiredAccess=SEC_RIGHTS_FILE_ALL (0x001F01FF) and assert via
+// FileAccessInformation that the open's granted access mask equals
+// SEC_RIGHTS_FILE_ALL — not the narrowed subset that the inherited DACL
+// would imply.
+//
+// Per MS-FSA §2.1.5.1.2 CreateFile and Samba
+// source3/smbd/open.c::open_file_ntcreate, when a new file is created the
+// server grants the creator the resolved DesiredAccess as-is. The parent
+// DACL gates the create operation (already enforced upstream via
+// CheckParentWriteAccess); the inherited child DACL governs subsequent
+// opens by other principals and must not narrow the creator's handle.
+//
+// Before the fix, completeCreateAfterBreak re-evaluated DesiredAccess
+// against the just-inherited child DACL for the FileCreated path, yielding
+// the smbtorture symptom: granted=0x000e0002 vs expected=0x001f01ff.
+func TestCreate_FileCreated_GrantsResolvedDesiredAccess(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	creatorUID := uint32(1000)
+	creatorGID := uint32(1000)
+
+	// Parent directory's DACL: a single OI|CI ACE that only grants
+	// WRITE_DATA + WRITE_DAC to the creator (mirrors smbtorture
+	// test_inheritance_flags / test_sd_flags_vs_chown parent SD shape).
+	parentACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag: acl.ACE4_FILE_INHERIT_ACE |
+					acl.ACE4_DIRECTORY_INHERIT_ACE,
+				// SEC_FILE_WRITE_DATA | SEC_STD_WRITE_DAC; APPEND_DATA is
+				// added because DittoFS's PermissionWrite mapping currently
+				// requires both bits on the parent (this is independent of
+				// the bug under test — see permToACLMask in auth_permissions.go).
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA | acl.ACE4_WRITE_ACL,
+				Who:        "1000@localdomain",
+			},
+		},
+	}
+	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "testdir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			UID:  creatorUID,
+			GID:  creatorGID,
+			ACL:  parentACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	parentHandle, err := metadata.EncodeFileHandle(parentDir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	creatorAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID:  &creatorUID,
+			GID:  &creatorGID,
+			GIDs: []uint32{creatorGID},
+		},
+	}
+
+	const secRightsFileAll uint32 = 0x001F01FF
+
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "testfile",
+			DesiredAccess:     secRightsFileAll,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileCreate,
+			CreateOptions:     0,
+			FileAttributes:    types.FileAttributeNormal,
+		},
+		tree:         tree,
+		authCtx:      creatorAuth,
+		filename:     "testdir\\testfile",
+		baseName:     "testfile",
+		parentHandle: parentHandle,
+		fileExists:   false,
+		createAction: types.FileCreated,
+	}
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("CREATE: status=0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+
+	openFile, ok := h.GetOpenFile(resp.FileID)
+	if !ok {
+		t.Fatal("OpenFile not registered after CREATE")
+	}
+
+	if openFile.GrantedAccess != secRightsFileAll {
+		t.Errorf("GrantedAccess = 0x%08x; want 0x%08x (delta 0x%08x)",
+			openFile.GrantedAccess, secRightsFileAll,
+			secRightsFileAll^openFile.GrantedAccess)
+	}
+}
+
+// TestCreate_FileCreated_ExpandsGenericAll covers the MAXIMUM_ALLOWED /
+// GENERIC_ALL branch of resolveAccessFlags on the FileCreated path: when
+// the caller asks for GENERIC_ALL on CREATE, the handle's GrantedAccess
+// must report the full SEC_RIGHTS_FILE_ALL specific-rights mask
+// (0x001F01FF), per MS-DTYP §2.4.3 GenericMapping for file objects.
+func TestCreate_FileCreated_ExpandsGenericAll(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	creatorUID := uint32(1000)
+	creatorGID := uint32(1000)
+
+	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "gendir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			UID:  creatorUID,
+			GID:  creatorGID,
+		})
+	if err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	parentHandle, err := metadata.EncodeFileHandle(parentDir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	creatorAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID:  &creatorUID,
+			GID:  &creatorGID,
+			GIDs: []uint32{creatorGID},
+		},
+	}
+
+	const (
+		genericAll       uint32 = 0x10000000
+		secRightsFileAll uint32 = 0x001F01FF
+	)
+
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "f",
+			DesiredAccess:     genericAll,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileCreate,
+			CreateOptions:     0,
+			FileAttributes:    types.FileAttributeNormal,
+		},
+		tree:         tree,
+		authCtx:      creatorAuth,
+		filename:     "gendir\\f",
+		baseName:     "f",
+		parentHandle: parentHandle,
+		fileExists:   false,
+		createAction: types.FileCreated,
+	}
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("CREATE: status=0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+
+	openFile, ok := h.GetOpenFile(resp.FileID)
+	if !ok {
+		t.Fatal("OpenFile not registered after CREATE")
+	}
+
+	if openFile.GrantedAccess&secRightsFileAll != secRightsFileAll {
+		t.Errorf("GrantedAccess = 0x%08x; expected GENERIC_ALL to expand to >= 0x%08x",
+			openFile.GrantedAccess, secRightsFileAll)
+	}
+	if openFile.GrantedAccess&genericAll != 0 {
+		t.Errorf("GrantedAccess = 0x%08x; GENERIC_ALL bit must be stripped after expansion",
+			openFile.GrantedAccess)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -303,28 +303,30 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 
 	// Compute GrantedAccess for new/overwritten files. The fileExists branch
-	// above already populated grantedAccess from CheckFileAccess. For
-	// FileCreated the ACL was inherited from the parent at create time; for
-	// FileOverwritten/Superseded the existing DACL is preserved. Both need
-	// the intersection of req.DesiredAccess with the resulting file's DACL —
-	// CheckFileAccess returns the per-bit granted mask in both arms (allow
-	// AND deny), so always take the returned mask. Upstream gates
-	// (CheckParentWriteAccess for FileCreated; DACL check at step 6c-bis for
-	// the existing-file path that flows into Overwrite/Supersede) have
-	// already approved the open — an unexpected ErrAccessDenied here would
-	// indicate the post-create DACL diverged from the parent's inherited
-	// set, so we log and continue with the (possibly narrowed) granted mask
-	// rather than overstate rights by re-resolving DesiredAccess.
-	if !grantedComputed && file != nil {
-		g, err := metaSvc.CheckFileAccess(file, authCtx, req.DesiredAccess)
-		if err != nil {
-			logger.Debug("CREATE: post-create CheckFileAccess returned narrowed mask",
-				"path", filename,
-				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
-				"granted", fmt.Sprintf("0x%x", g),
-				"error", err)
-		}
-		grantedAccess = g
+	// above already populated grantedAccess from CheckFileAccess on the
+	// existing file's DACL (the open-time gate).
+	//
+	// For FileCreated the file is brand-new: Windows/Samba grant the creator
+	// the resolved DesiredAccess as-is and never re-check it against the
+	// inherited DACL. The inherited DACL governs subsequent opens by other
+	// principals — it does not narrow the creator's handle. This matches
+	// Samba `source3/smbd/open.c::open_file_ntcreate`, which only runs the
+	// DACL check on existing-file paths, and MS-FSA §2.1.5.1.2 CreateFile
+	// (the DesiredAccess check is gated by the parent DACL, not the new
+	// child's inherited DACL). Re-checking would surface the smbtorture
+	// failure in smb2.acls.INHERITANCE/INHERITFLAGS/SDFLAGSVSCHOWN, where
+	// a parent DACL grants the creator only WRITE_DATA|WRITE_DAC
+	// inheritably but the test still expects the new handle to carry
+	// SEC_RIGHTS_FILE_ALL (per Samba behavior).
+	//
+	// For FileOverwritten/Superseded the prior DACL is preserved and the
+	// open-time gate at step 6c-bis already validated DesiredAccess against
+	// it; grantedAccess was set there. If grantedComputed is false in that
+	// branch (defensive — should not happen in practice because
+	// fileExists==true for overwrite/supersede) we fall back to the
+	// resolved DesiredAccess to avoid under-granting.
+	if !grantedComputed {
+		grantedAccess = resolveAccessFlags(req.DesiredAccess)
 	}
 
 	// Step 7a: Restore frozen timestamps on parent directory (MS-FSA 2.1.5.14.2).


### PR DESCRIPTION
## Summary

- Per MS-FSA §2.1.5.1.2 CreateFile and Samba `source3/smbd/open.c::open_file_ntcreate`, a newly created file's handle carries the resolved `DesiredAccess` as its `GrantedAccess`. The inherited child DACL governs subsequent opens by other principals; it does **not** narrow the creator's own handle. The parent DACL already gates the create operation via `CheckParentWriteAccess` upstream.
- `completeCreateAfterBreak` was running `CheckFileAccess` against the just-inherited child DACL on the `FileCreated` path, yielding `0x000e0002` (parent inheritable `SEC_FILE_WRITE_DATA | SEC_STD_WRITE_DAC` + MS-DTYP §2.5.3.2 owner-implicit `READ_CONTROL | WRITE_DAC | WRITE_OWNER`) where Samba grants the requested `SEC_RIGHTS_FILE_ALL` (`0x001F01FF`).
- Fix scopes to the `FileCreated` arm: grant `resolveAccessFlags(req.DesiredAccess)`. `FileOpened` still runs the open-time DACL gate at step 6c-bis; `FileOverwritten`/`FileSuperseded` continue to honor the preserved DACL through the same `grantedComputed` path as before.

## Spec / reference

- MS-FSA §2.1.5.1.2 — CreateFile algorithm: DesiredAccess check is gated by the parent DACL, not the child's inherited DACL.
- MS-DTYP §2.4.3 — GenericMapping (handled by `resolveAccessFlags`).
- Samba `source3/smbd/open.c::open_file_ntcreate` — only existing-file paths run `smbd_check_access_rights_fsp`; newly created files accept the requested mask as-is.

## Affected tests (expected flips)

- `smb2.acls.INHERITFLAGS` — primary target (acls.c:1442).
- `smb2.acls.SDFLAGSVSCHOWN` — twin (acls.c:1697); same precondition.
- `smb2.acls.INHERITANCE` — same `0x000e0002` vs `0x001f01ff` shape per `chore(smb): walk back KNOWN_FAILURES` (4e812fd8).

KNOWN_FAILURES walkback intentionally **not** done in this PR — leaving for a separate commit after CI confirms which tests actually flip.

## Test plan

- [x] `go test ./internal/adapter/smb/v2/handlers/...` (handler suite incl. new `TestCreate_FileCreated_GrantsResolvedDesiredAccess` and `TestCreate_FileCreated_ExpandsGenericAll`).
- [x] `go test ./pkg/metadata/...` (no regression on DACL / inheritance / file-access unit suites).
- [x] `go test ./internal/adapter/nfs/...` (NFS regression sweep — metadata-layer untouched).
- [x] `go test -race -run TestCreate_FileCreated|TestCreate_DaclEnforcement ./internal/adapter/smb/v2/handlers/`.
- [x] Verified the new test fails on develop tip (without fix): `GrantedAccess = 0x000e0006; want 0x001f01ff` — exact `0x000e0002`-family symptom from the smbtorture trace.
- [ ] CI smbtorture run — verify `smb2.acls.INHERITFLAGS`, `smb2.acls.SDFLAGSVSCHOWN`, `smb2.acls.INHERITANCE` flip to PASS.

Closes #560
Closes #561