### PR TITLE
fix(smb/acl): gate owner-implicit WRITE_OWNER on SeTakeOwnershipPrivilege (#563)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1119,6 +1119,10 @@ func buildMaxAccessEvalContext(file *metadata.File, authCtx *metadata.AuthContex
 		evalCtx.SID = *identity.SID
 	}
 	evalCtx.GroupSIDs = identity.GroupSIDs
+	// MS-DTYP §2.5.3.2: WRITE_OWNER is implicitly granted to file owners
+	// only when the requester holds SeTakeOwnershipPrivilege. Without this,
+	// the MxAc reply for a plain owner over-grants WRITE_OWNER (#563).
+	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
 
 	return evalCtx
 }

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -750,13 +750,15 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 	t.Run("AllowACEPlusOwnerImplicitBits", func(t *testing.T) {
 		// Single ALLOW ACE granting exactly READ_DATA|READ_ATTRIBUTES|
 		// SYNCHRONIZE for OWNER@. No POSIX-mode leakage is allowed, but
-		// MS-DTYP §2.5.3.2 layers READ_CONTROL|WRITE_DAC|WRITE_OWNER on top
-		// of the explicit grants when the requester is the file owner.
+		// MS-DTYP §2.5.3.2 layers READ_CONTROL|WRITE_DAC on top of the
+		// explicit grants when the requester is the file owner. WRITE_OWNER
+		// is admin-only (SeTakeOwnershipPrivilege) and is excluded here
+		// because mkOwnerCtx returns a non-admin identity (#563).
 		// `explicit` deliberately omits READ_CONTROL so the implicit-grant
 		// contribution is unambiguous in the assertion.
 		authCtx := mkOwnerCtx()
 		explicit := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_SYNCHRONIZE)
-		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
+		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL)
 		want := explicit | ownerImplicit
 		file := &metadata.File{
 			FileAttr: metadata.FileAttr{
@@ -780,14 +782,20 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 			t.Errorf("MxAc = 0x%08x, expected 0x%08x (explicit 0x%08x + owner-implicit 0x%08x per MS-DTYP §2.5.3.2)",
 				access, want, explicit, ownerImplicit)
 		}
+		// #563 regression guard: WRITE_OWNER must NOT be in the reply for a
+		// non-admin owner. Mirrors smbtorture smb2.acls.DENY1.
+		if access&acl.ACE4_WRITE_OWNER != 0 {
+			t.Errorf("MxAc includes WRITE_OWNER (0x%08x) for non-admin owner — over-grants per #563", access)
+		}
 	})
 
 	t.Run("EmptyACLGrantsOnlyOwnerImplicitBits", func(t *testing.T) {
 		// An ACL with zero ACEs has no explicit grants for anyone, but
 		// MS-DTYP §2.5.3.2 still grants the file owner READ_CONTROL|
-		// WRITE_DAC|WRITE_OWNER. Non-owners get nothing (covered elsewhere).
+		// WRITE_DAC. WRITE_OWNER is admin-only (SeTakeOwnershipPrivilege).
+		// Non-owners get nothing (covered elsewhere).
 		authCtx := mkOwnerCtx()
-		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
+		ownerImplicit := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL)
 		file := &metadata.File{
 			FileAttr: metadata.FileAttr{
 				UID:  1000,
@@ -799,7 +807,40 @@ func TestHandleCreate_MxAcContext_ACL(t *testing.T) {
 
 		access := computeMaximalAccess(file, authCtx)
 		if access != ownerImplicit {
-			t.Errorf("Empty ACL: owner must receive only implicit RC|WRITE_DAC|WRITE_OWNER, got 0x%08x want 0x%08x", access, ownerImplicit)
+			t.Errorf("Empty ACL: owner must receive only implicit RC|WRITE_DAC, got 0x%08x want 0x%08x", access, ownerImplicit)
+		}
+	})
+
+	t.Run("AdminOwnerGetsWriteOwnerImplicit", func(t *testing.T) {
+		// MS-DTYP §2.5.3.2: a file owner who holds SeTakeOwnershipPrivilege
+		// (i.e. is a member of BUILTIN\Administrators by default) receives
+		// the additional implicit WRITE_OWNER grant on top of READ_CONTROL|
+		// WRITE_DAC. Mirrors Samba access_check.c::se_access_check_implicit_owner.
+		// Regression guard for #563: ensure the privilege-gated path
+		// remains intact.
+		uid := uint32(1000)
+		gid := uint32(1000)
+		adminSID := "S-1-5-32-544" // BUILTIN\Administrators
+		authCtx := &metadata.AuthContext{
+			Context: context.Background(),
+			Identity: &metadata.Identity{
+				UID: &uid,
+				GID: &gid,
+				SID: &adminSID,
+			},
+		}
+		file := &metadata.File{
+			FileAttr: metadata.FileAttr{
+				UID:  1000,
+				GID:  1000,
+				Mode: 0755,
+				ACL:  &acl.ACL{},
+			},
+		}
+		access := computeMaximalAccess(file, authCtx)
+		want := uint32(acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_WRITE_OWNER)
+		if access != want {
+			t.Errorf("Admin owner MxAc = 0x%08x, want 0x%08x (RC|WRITE_DAC|WRITE_OWNER)", access, want)
 		}
 	})
 

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -1091,6 +1091,9 @@ func buildEnumEvalContext(attr *metadata.FileAttr, authCtx *metadata.AuthContext
 		evalCtx.SID = *id.SID
 	}
 	evalCtx.GroupSIDs = id.GroupSIDs
+	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
+	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
+	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
 	return evalCtx
 }
 

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -1,10 +1,52 @@
 package acl
 
 import (
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 )
+
+// builtinAdministratorsSID is BUILTIN\Administrators — the SID Windows
+// uses to denote the local administrators group. Members of this group
+// hold SeTakeOwnershipPrivilege by default per MS-DTYP §2.5.3.2.
+const builtinAdministratorsSID = "S-1-5-32-544"
+
+// domainAdminSIDPattern matches the local/domain Administrator account SID
+// (S-1-5-21-{auth1}-{auth2}-{auth3}-500). Mirrors the pattern in
+// pkg/metadata/auth_identity.go::IsAdministratorSID. Kept local to the
+// acl package to avoid a cyclic import from pkg/metadata.
+var domainAdminSIDPattern = regexp.MustCompile(`^S-1-5-21-\d+-\d+-\d+-500$`)
+
+// HasTakeOwnershipPrivilege reports whether the given requester SID +
+// group SIDs imply SeTakeOwnershipPrivilege. By default this is granted
+// only to BUILTIN\Administrators (S-1-5-32-544) members and the
+// local/domain Administrator (RID 500) account.
+//
+// Used by callers building EvaluateContext.RequesterHasTakeOwnership so
+// the MS-DTYP §2.5.3.2 owner-implicit WRITE_OWNER grant is restricted
+// to admins, matching Samba access_check.c::se_access_check_implicit_owner.
+func HasTakeOwnershipPrivilege(requesterSID string, groupSIDs []string) bool {
+	if isAdminSID(requesterSID) {
+		return true
+	}
+	for _, g := range groupSIDs {
+		if isAdminSID(g) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAdminSID(sid string) bool {
+	if sid == "" {
+		return false
+	}
+	if sid == builtinAdministratorsSID {
+		return true
+	}
+	return domainAdminSIDPattern.MatchString(sid)
+}
 
 // localDomainSuffix is the synthetic domain string SIDMapper.SIDToPrincipal
 // produces for machine-domain user/group SIDs ("{uid}@localdomain"). When an
@@ -30,6 +72,15 @@ type EvaluateContext struct {
 	// GroupSIDs is the requester's group SIDs.
 	// Empty when the session is POSIX-only.
 	GroupSIDs []string
+
+	// RequesterHasTakeOwnership indicates whether the requester holds the
+	// SeTakeOwnershipPrivilege (MS-DTYP §2.5.3.2). Only privilege holders
+	// receive WRITE_OWNER implicitly when they own the file. On Windows
+	// this privilege is granted to BUILTIN\Administrators by default.
+	// Callers should set this from IsAdministratorSID(SID) or equivalent
+	// admin-group membership detection. POSIX-only sessions default to
+	// false; UID==0 callers are usually short-circuited above acl.Evaluate.
+	RequesterHasTakeOwnership bool
 }
 
 // HasExplicitDeny reports whether the ACL contains any explicit DENY ACE.
@@ -49,14 +100,26 @@ func HasExplicitDeny(a *ACL) bool {
 }
 
 // ownerImplicitRights is the set of access rights MS-DTYP §2.5.3.2 grants
-// implicitly to the file owner: READ_CONTROL, WRITE_DAC, and WRITE_OWNER.
-// These are layered on top of the explicit DACL grants unless suppressed by
-// an effective OWNER_RIGHTS (S-1-3-4) ACE in the DACL. Explicit DENY ACEs
-// in the DACL still win over the implicit grant for any specific bit.
+// implicitly to the file owner: READ_CONTROL and WRITE_DAC. These are
+// layered on top of the explicit DACL grants unless suppressed by an
+// effective OWNER_RIGHTS (S-1-3-4) ACE in the DACL. Explicit DENY ACEs in
+// the DACL still win over the implicit grant for any specific bit.
+//
+// WRITE_OWNER is NOT in this base set per MS-DTYP §2.5.3.2: it requires
+// SeTakeOwnershipPrivilege (only Administrators by default). Callers grant
+// it by setting EvaluateContext.RequesterHasTakeOwnership; see the
+// owner-implicit pass in Evaluate. This mirrors Samba
+// libcli/security/access_check.c::se_access_check_implicit_owner.
 //
 // NFSv4 mask bits intentionally share positions with Windows MS-DTYP rights
 // (RFC 7530 §6.2.1), so the same constants describe both layers.
-const ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER
+const ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL
+
+// takeOwnershipImplicitRight is the additional implicit grant a requester
+// receives when they own the file AND hold SeTakeOwnershipPrivilege per
+// MS-DTYP §2.5.3.2. Layered on top of ownerImplicitRights, masked by
+// deniedBits like the base owner-implicit grants.
+const takeOwnershipImplicitRight = ACE4_WRITE_OWNER
 
 // Evaluate implements the NFSv4 ACL evaluation algorithm per RFC 7530
 // Section 6.2.1, with the OWNER_RIGHTS (S-1-3-4) override and the owner
@@ -85,8 +148,10 @@ const ownerImplicitRights = ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER
 //  5. Once all requested bits are decided, stop early.
 //  6. Owner-implicit pass (MS-DTYP §2.5.3.2): if the requester is the file
 //     owner AND no OWNER_RIGHTS ACE is present, add `ownerImplicitRights`
-//     to `allowedBits`, masked by the bits not already denied. Explicit
-//     DENY in the DACL still wins per-bit.
+//     (READ_CONTROL|WRITE_DAC) to `allowedBits`, masked by the bits not
+//     already denied. WRITE_OWNER is added on top ONLY when the requester
+//     holds SeTakeOwnershipPrivilege (evalCtx.RequesterHasTakeOwnership).
+//     Explicit DENY in the DACL still wins per-bit.
 //  7. Return true if and only if ALL requested bits are in allowedBits.
 func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	if requestedMask == 0 {
@@ -168,8 +233,19 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	// MS-DTYP §2.5.3.2 owner implicit grants: layered after the DACL walk
 	// so explicit DENY ACEs still win per-bit. Suppressed when OWNER_RIGHTS
 	// is present (§2.5.3 — OWNER_RIGHTS is the sole authority for the owner).
+	//
+	// The base set is READ_CONTROL|WRITE_DAC; WRITE_OWNER is layered in
+	// only when the requester holds SeTakeOwnershipPrivilege (admins).
+	// This mirrors Samba access_check.c::se_access_check_implicit_owner:
+	// non-privileged owners cannot reassign ownership via the implicit
+	// grant — they need either an explicit WRITE_OWNER ACE or the
+	// privilege. Tests under smb2.acls (DENY1, MXAC-NOT-GRANTED, OWNER)
+	// rely on this split for the MxAc reply.
 	if requesterIsOwner && !ownerRightsPresent {
 		allowedBits |= ownerImplicitRights &^ deniedBits
+		if evalCtx.RequesterHasTakeOwnership {
+			allowedBits |= takeOwnershipImplicitRight &^ deniedBits
+		}
 	}
 
 	// Access is granted only if ALL requested bits are in allowedBits.

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -692,10 +692,11 @@ func TestEvaluate_OwnerRights_AlarmAceDoesNotSuppressOwner(t *testing.T) {
 }
 
 // TestEvaluate_OwnerImplicitGrants_DataPlusImplicit verifies MS-DTYP §2.5.3.2:
-// owner gets READ_CONTROL / WRITE_DAC / WRITE_OWNER on top of explicit DACL
-// grants when no OWNER_RIGHTS ACE is present. The DACL here grants OWNER@
-// only READ_DATA; the owner must still be able to open for READ_DATA + the
-// three implicit standard rights together.
+// owner gets READ_CONTROL / WRITE_DAC on top of explicit DACL grants when no
+// OWNER_RIGHTS ACE is present. The DACL here grants OWNER@ only READ_DATA;
+// the owner must still be able to open for READ_DATA + the two base implicit
+// standard rights together. WRITE_OWNER is excluded — only admins receive it
+// implicitly (see TestEvaluate_OwnerImplicitGrants_WriteOwnerRequiresAdmin).
 func TestEvaluate_OwnerImplicitGrants_DataPlusImplicit(t *testing.T) {
 	a := &ACL{
 		ACEs: []ACE{
@@ -703,9 +704,13 @@ func TestEvaluate_OwnerImplicitGrants_DataPlusImplicit(t *testing.T) {
 		},
 	}
 
-	requested := uint32(ACE4_READ_DATA | ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER)
+	requested := uint32(ACE4_READ_DATA | ACE4_READ_ACL | ACE4_WRITE_ACL)
 	if !Evaluate(a, ownerCtx(), requested) {
-		t.Error("expected owner to receive READ_DATA + implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER")
+		t.Error("expected owner to receive READ_DATA + implicit READ_CONTROL|WRITE_DAC")
+	}
+	// Non-admin owner must NOT receive WRITE_OWNER implicitly.
+	if Evaluate(a, ownerCtx(), ACE4_WRITE_OWNER) {
+		t.Error("expected non-admin owner to be denied implicit WRITE_OWNER (#563)")
 	}
 }
 
@@ -719,9 +724,9 @@ func TestEvaluate_OwnerImplicitGrants_NoOwnerAceAtAll(t *testing.T) {
 		},
 	}
 
-	requested := uint32(ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER)
+	requested := uint32(ACE4_READ_ACL | ACE4_WRITE_ACL)
 	if !Evaluate(a, ownerCtx(), requested) {
-		t.Error("expected owner to receive implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER even with no OWNER@ ACE")
+		t.Error("expected owner to receive implicit READ_CONTROL|WRITE_DAC even with no OWNER@ ACE")
 	}
 }
 
@@ -758,9 +763,13 @@ func TestEvaluate_OwnerImplicitGrants_ExplicitDenyWins(t *testing.T) {
 		},
 	}
 
-	// READ_CONTROL + WRITE_OWNER (implicit) should still work.
-	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_OWNER) {
-		t.Error("expected owner to receive implicit READ_CONTROL|WRITE_OWNER")
+	// READ_CONTROL (implicit) should still work for a plain owner.
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL) {
+		t.Error("expected owner to receive implicit READ_CONTROL")
+	}
+	// WRITE_OWNER is admin-only — non-admin owner must be denied.
+	if Evaluate(a, ownerCtx(), ACE4_WRITE_OWNER) {
+		t.Error("expected non-admin owner to be denied implicit WRITE_OWNER (#563)")
 	}
 	// WRITE_DAC must be denied by explicit DENY.
 	if Evaluate(a, ownerCtx(), ACE4_WRITE_ACL) {
@@ -786,13 +795,17 @@ func TestEvaluate_OwnerImplicitGrants_NonOwnerUnaffected(t *testing.T) {
 
 // TestEvaluate_OwnerImplicitGrants_EmptyACL verifies the narrowed early-return:
 // an explicitly empty DACL (len(ACEs) == 0) is the MS-DTYP §2.5.3 "deny all"
-// case but §2.5.3.2 still grants the file owner READ_CONTROL|WRITE_DAC|
-// WRITE_OWNER. Non-owners get nothing.
+// case but §2.5.3.2 still grants the file owner READ_CONTROL|WRITE_DAC. The
+// non-admin owner does NOT receive WRITE_OWNER implicitly. Non-owners get
+// nothing.
 func TestEvaluate_OwnerImplicitGrants_EmptyACL(t *testing.T) {
 	a := &ACL{ACEs: nil}
 
-	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL|ACE4_WRITE_OWNER) {
-		t.Error("empty ACL: expected owner to receive implicit READ_CONTROL|WRITE_DAC|WRITE_OWNER")
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL) {
+		t.Error("empty ACL: expected owner to receive implicit READ_CONTROL|WRITE_DAC")
+	}
+	if Evaluate(a, ownerCtx(), ACE4_WRITE_OWNER) {
+		t.Error("empty ACL: non-admin owner must NOT receive implicit WRITE_OWNER (#563)")
 	}
 	if Evaluate(a, ownerCtx(), ACE4_READ_DATA) {
 		t.Error("empty ACL: owner must NOT receive READ_DATA (not in implicit grant set)")
@@ -820,7 +833,108 @@ func TestEvaluate_OwnerImplicitGrants_InheritOnlyOwnerRightsDoesNotSuppress(t *t
 
 	// Owner still gets the implicit standard rights — the INHERIT_ONLY
 	// OWNER_RIGHTS ACE doesn't apply to this object's access check.
-	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL|ACE4_WRITE_OWNER) {
+	if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL) {
 		t.Error("INHERIT_ONLY OwnerRights@ must not suppress the implicit owner grants on this object")
+	}
+}
+
+// adminOwnerCtx returns an EvaluateContext where the requester IS the file
+// owner AND holds SeTakeOwnershipPrivilege (admin). Used to lock in that
+// admin owners receive the MS-DTYP §2.5.3.2 implicit WRITE_OWNER grant on
+// top of the base READ_CONTROL|WRITE_DAC. Mirrors ownerCtx() with the
+// privilege flag flipped on.
+func adminOwnerCtx() *EvaluateContext {
+	return &EvaluateContext{
+		Who:                       "admin@example.com",
+		UID:                       1000,
+		GID:                       1000,
+		GIDs:                      nil,
+		FileOwnerUID:              1000,
+		FileOwnerGID:              1000,
+		RequesterHasTakeOwnership: true,
+	}
+}
+
+// TestEvaluate_OwnerImplicitGrants_WriteOwnerRequiresAdmin locks in the
+// MS-DTYP §2.5.3.2 split: WRITE_OWNER is granted implicitly only when the
+// requester holds SeTakeOwnershipPrivilege (admin). A plain owner receives
+// READ_CONTROL|WRITE_DAC only — exactly what Samba
+// access_check.c::se_access_check_implicit_owner enforces. This is the
+// regression-prevention test for #563 (smb2.acls.DENY1 over-granted
+// WRITE_OWNER in the MxAc reply).
+func TestEvaluate_OwnerImplicitGrants_WriteOwnerRequiresAdmin(t *testing.T) {
+	// Empty DACL exposes only the implicit owner grants.
+	a := &ACL{ACEs: nil}
+
+	t.Run("non-admin owner denied WRITE_OWNER", func(t *testing.T) {
+		if Evaluate(a, ownerCtx(), ACE4_WRITE_OWNER) {
+			t.Error("plain owner must NOT receive implicit WRITE_OWNER (#563)")
+		}
+		// Base implicit grants still hold.
+		if !Evaluate(a, ownerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL) {
+			t.Error("plain owner must still receive READ_CONTROL|WRITE_DAC implicitly")
+		}
+	})
+
+	t.Run("admin owner receives WRITE_OWNER", func(t *testing.T) {
+		if !Evaluate(a, adminOwnerCtx(), ACE4_WRITE_OWNER) {
+			t.Error("admin owner must receive implicit WRITE_OWNER via SeTakeOwnershipPrivilege")
+		}
+		// And still gets the base set.
+		if !Evaluate(a, adminOwnerCtx(), ACE4_READ_ACL|ACE4_WRITE_ACL|ACE4_WRITE_OWNER) {
+			t.Error("admin owner must receive READ_CONTROL|WRITE_DAC|WRITE_OWNER")
+		}
+	})
+
+	t.Run("non-owner with admin privilege gets nothing implicit", func(t *testing.T) {
+		// Non-owner, admin-privileged caller: privilege only matters for
+		// owners under §2.5.3.2. Without ownership, no implicit grant.
+		ctx := nonOwnerCtx()
+		ctx.RequesterHasTakeOwnership = true
+		if Evaluate(a, ctx, ACE4_WRITE_OWNER) {
+			t.Error("admin non-owner must not receive implicit WRITE_OWNER (privilege is owner-gated)")
+		}
+		if Evaluate(a, ctx, ACE4_READ_ACL) {
+			t.Error("admin non-owner must not receive implicit READ_CONTROL")
+		}
+	})
+
+	t.Run("explicit DENY WRITE_OWNER beats admin implicit grant", func(t *testing.T) {
+		denyOwner := &ACL{
+			ACEs: []ACE{
+				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_OWNER, Who: SpecialOwner},
+			},
+		}
+		if Evaluate(denyOwner, adminOwnerCtx(), ACE4_WRITE_OWNER) {
+			t.Error("explicit DENY WRITE_OWNER must override admin implicit grant")
+		}
+	})
+}
+
+// TestHasTakeOwnershipPrivilege locks in the admin-SID detection used by
+// callers to populate EvaluateContext.RequesterHasTakeOwnership. Mirrors
+// pkg/metadata.IsAdministratorSID coverage but lives here so the acl
+// package can stay self-contained.
+func TestHasTakeOwnershipPrivilege(t *testing.T) {
+	cases := []struct {
+		name      string
+		sid       string
+		groupSIDs []string
+		want      bool
+	}{
+		{"empty", "", nil, false},
+		{"plain user SID", "S-1-5-21-1-2-3-1001", nil, false},
+		{"BUILTIN Administrators as user SID", "S-1-5-32-544", nil, true},
+		{"BUILTIN Administrators in groups", "S-1-5-21-1-2-3-1001", []string{"S-1-5-32-544"}, true},
+		{"Administrator RID 500 as user SID", "S-1-5-21-1-2-3-500", nil, true},
+		{"plain SID + plain groups", "S-1-5-21-1-2-3-1001", []string{"S-1-5-32-545"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasTakeOwnershipPrivilege(tc.sid, tc.groupSIDs); got != tc.want {
+				t.Errorf("HasTakeOwnershipPrivilege(%q, %v) = %v, want %v",
+					tc.sid, tc.groupSIDs, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -393,6 +393,9 @@ func evaluateACLPermissions(
 		evalCtx.SID = *identity.SID
 	}
 	evalCtx.GroupSIDs = identity.GroupSIDs
+	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
+	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
+	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
 
 	return evaluateWithACL(file.ACL, evalCtx, requested, shareOpts)
 }
@@ -743,6 +746,9 @@ func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateC
 		evalCtx.SID = *identity.SID
 	}
 	evalCtx.GroupSIDs = identity.GroupSIDs
+	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
+	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
+	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
 
 	return evalCtx
 }


### PR DESCRIPTION
## Summary

`smb2.acls.DENY1` failed on the MxAc maximal-access assertion: DittoFS returned `0x1E008B`, expected `0x16008B`. Diff `0x080000 = SEC_STD_WRITE_OWNER` — the MxAc reply over-granted `WRITE_OWNER` to a plain (non-admin) owner.

## Root cause

Commit `972c3a83` ("fix(acl): owner implicit READ_CONTROL/WRITE_DAC/WRITE_OWNER per MS-DTYP §2.5.3.2") added the owner-implicit pass to `acl.Evaluate` with the wrong base set: `READ_CONTROL | WRITE_DAC | WRITE_OWNER`. Per MS-DTYP §2.5.3.2, the owner-implicit set is `READ_CONTROL | WRITE_DAC` only; `WRITE_OWNER` requires `SeTakeOwnershipPrivilege` (held by `BUILTIN\Administrators` by default). This matches Samba `libcli/security/access_check.c::se_access_check_implicit_owner`.

## Fix

- Split `ownerImplicitRights` (`READ_CONTROL | WRITE_DAC`) from `takeOwnershipImplicitRight` (`WRITE_OWNER`).
- Add `EvaluateContext.RequesterHasTakeOwnership bool`; only OR `WRITE_OWNER` into `allowedBits` when set.
- New `acl.HasTakeOwnershipPrivilege(sid, groupSIDs)` helper detects `BUILTIN\Administrators` (`S-1-5-32-544`) + domain Administrator (`-500` RID). Kept inside the `acl` package to avoid a cyclic import from `pkg/metadata`.
- Wired at all four `EvaluateContext` construction sites: `buildMaxAccessEvalContext`, `buildFileAccessEvalContext`, `evaluateACLPermissions`, `buildEnumEvalContext`.
- Explicit `DENY WRITE_OWNER` still beats the admin implicit grant (existing per-bit masking preserved).

## Test plan

- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/...` green
- [x] Updated `TestEvaluate_OwnerImplicitGrants_{DataPlusImplicit,NoOwnerAceAtAll,ExplicitDenyWins,EmptyACL,InheritOnlyOwnerRightsDoesNotSuppress}` to expect the new RC|WRITE_DAC base
- [x] New `TestEvaluate_OwnerImplicitGrants_WriteOwnerRequiresAdmin` covers: non-admin owner denied WRITE_OWNER; admin owner gets WRITE_OWNER; admin non-owner gets nothing implicit; explicit DENY beats admin implicit
- [x] New `TestHasTakeOwnershipPrivilege` covers SID detection (empty, plain, BUILTIN\Administrators, RID 500, group membership)
- [x] Updated `TestHandleCreate_MxAcContext_ACL/AllowACEPlusOwnerImplicitBits` to assert `WRITE_OWNER` excluded for non-admin
- [x] New `TestHandleCreate_MxAcContext_ACL/AdminOwnerGetsWriteOwnerImplicit` locks in admin path
- [ ] Smbtorture `smb2.acls.DENY1` PASS verified in CI
- [ ] No regression in `smb2.acls.OWNER-RIGHTS{,-DENY,-DENY1}` and `smb2.acls.CREATOR`

## Spec refs

- MS-DTYP §2.5.3.2 (AccessCheck — owner implicit rights)
- Samba `libcli/security/access_check.c::se_access_check_implicit_owner`

Closes #563