### PR TITLE
fix(smb): bypass parent traverse check for SMB sessions (#562)

### DIFF
--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -34,10 +34,11 @@ func BuildAuthContext(ctx *SMBHandlerContext) (*metadata.AuthContext, error) {
 	}
 
 	authCtx := &metadata.AuthContext{
-		Context:      ctx.Context,
-		ClientAddr:   ctx.ClientAddr,
-		LockClientID: fmt.Sprintf("smb:%d", ctx.SessionID),
-		Identity:     &metadata.Identity{},
+		Context:                ctx.Context,
+		ClientAddr:             ctx.ClientAddr,
+		LockClientID:           fmt.Sprintf("smb:%d", ctx.SessionID),
+		Identity:               &metadata.Identity{},
+		BypassTraverseChecking: true,
 	}
 
 	if ctx.IsGuest {
@@ -114,10 +115,11 @@ func getUserIdentity(user *models.User) (uid, gid uint32) {
 // Unix permission checks.
 func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metadata.AuthContext {
 	authCtx := &metadata.AuthContext{
-		Context:      ctx.Context,
-		ClientAddr:   ctx.ClientAddr,
-		LockClientID: fmt.Sprintf("smb:%d", ctx.SessionID),
-		Identity:     &metadata.Identity{},
+		Context:                ctx.Context,
+		ClientAddr:             ctx.ClientAddr,
+		LockClientID:           fmt.Sprintf("smb:%d", ctx.SessionID),
+		Identity:               &metadata.Identity{},
+		BypassTraverseChecking: true,
 	}
 
 	if user != nil {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -909,8 +909,9 @@ func (h *Handler) flushFileCache(ctx context.Context, openFile *OpenFile) {
 // Otherwise, it falls back to root credentials for cleanup operations.
 func (h *Handler) buildCleanupAuthContext(ctx context.Context, sess *session.Session) *metadata.AuthContext {
 	authCtx := &metadata.AuthContext{
-		Context:  ctx,
-		Identity: &metadata.Identity{},
+		Context:                ctx,
+		Identity:               &metadata.Identity{},
+		BypassTraverseChecking: true,
 	}
 
 	if sess != nil && sess.User != nil {

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -61,6 +61,27 @@ type AuthContext struct {
 	// CREATE with FILE_DELETE_ON_CLOSE + desiredAccess=DELETE. Leave false for
 	// NFS and any operation that must enforce strict POSIX write-on-parent.
 	HasDeleteAccess bool
+
+	// BypassTraverseChecking signals that the caller holds the Windows
+	// SeChangeNotifyPrivilege ("Bypass traverse checking"). Per MS-DTYP
+	// §2.5.3.2 and MS-FSA §2.1.5.1.1, holders of this privilege are exempt
+	// from the per-directory FILE_TRAVERSE (FILE_EXECUTE) check during path
+	// resolution: a deny on an intermediate directory's DACL does not prevent
+	// resolving a child whose own DACL grants the requested access.
+	//
+	// On Windows this privilege is granted to BUILTIN\Users and Everyone by
+	// default, so virtually every interactive and SMB session holds it.
+	// Samba mirrors the behavior — its `unix extensions = no` / `acl
+	// allow execute always` default skips the parent traverse check during
+	// SMB path walks.
+	//
+	// SMB handlers MUST set this on every AuthContext they build so that
+	// CREATE/OPEN against a child of a parent whose DACL omits FILE_TRAVERSE
+	// (but grants the requested rights on the child) returns STATUS_OK
+	// instead of STATUS_OBJECT_NAME_NOT_FOUND / STATUS_ACCESS_DENIED.
+	// NFS handlers MUST leave this false — POSIX traverse semantics differ
+	// and there is no equivalent privilege model.
+	BypassTraverseChecking bool
 }
 
 // NewSystemAuthContext creates an AuthContext for internal/system operations

--- a/pkg/metadata/auth_permissions_bypass_traverse_test.go
+++ b/pkg/metadata/auth_permissions_bypass_traverse_test.go
@@ -1,0 +1,128 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLookup_BypassTraverseChecking_GrantsAccess regresses GitHub issue #562.
+//
+// Reproduces the parent-DACL restriction from smbtorture's
+// `smb2.acls.DYNAMIC` (source4/torture/smb2/acls.c::test_inheritance_dynamic):
+// a parent directory whose DACL grants only WRITE_DATA|DELETE|READ_ATTRIBUTE
+// to the owner (no FILE_EXECUTE / FILE_TRAVERSE) must still permit name
+// resolution of a child when the caller holds Windows
+// SeChangeNotifyPrivilege ("Bypass traverse checking"). DittoFS encodes that
+// privilege as AuthContext.BypassTraverseChecking, set by every SMB session.
+//
+// Before the fix, the Lookup on the restricted parent failed with
+// ErrAccessDenied (mapped to STATUS_ACCESS_DENIED) or the upstream walkPath
+// remapped it to STATUS_OBJECT_NAME_NOT_FOUND, neither of which matches the
+// MS-FSA §2.1.5.1.1 behavior.
+func TestLookup_BypassTraverseChecking_GrantsAccess(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	ctx := context.Background()
+
+	// Root creates a subdirectory and a child file inside it. We then
+	// restrict the parent's DACL so callers without bypass cannot traverse.
+	rootCtx := fx.rootContext()
+	rootCtx.BypassTraverseChecking = true
+	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "restricted", &metadata.FileAttr{
+		Mode: 0700,
+		UID:  1000,
+		GID:  1000,
+	})
+	require.NoError(t, err)
+
+	subHandle, err := fx.store.GetChild(ctx, fx.rootHandle, "restricted")
+	require.NoError(t, err)
+
+	_, err = fx.service.CreateFile(rootCtx, subHandle, "child.txt", &metadata.FileAttr{
+		Mode: 0644,
+		UID:  1000,
+		GID:  1000,
+	})
+	require.NoError(t, err)
+
+	// Install an owner-only DACL granting WRITE_DATA|READ_ATTRIBUTES but
+	// NOT FILE_EXECUTE / FILE_TRAVERSE — matches the
+	// security_descriptor_dacl_create(...) call at acls.c:1916.
+	restrictedACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_READ_ATTRIBUTES,
+				Who:        acl.SpecialOwner,
+			},
+		},
+	}
+	err = fx.service.SetFileAttributes(rootCtx, subHandle, &metadata.SetAttrs{
+		ACL: restrictedACL,
+	})
+	require.NoError(t, err)
+
+	// Sanity check: without BypassTraverseChecking, a non-owner caller's
+	// Lookup of "child.txt" through the restricted parent fails (strict
+	// POSIX/NFS semantics — this is what NFS still gets after the fix).
+	strictCtx := fx.authContext(2000, 2000)
+	strictCtx.BypassTraverseChecking = false
+	_, err = fx.service.Lookup(strictCtx, subHandle, "child.txt")
+	require.Error(t, err, "without bypass, lookup must fail when parent denies traverse")
+
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code,
+		"traverse denial must map to ErrAccessDenied, not ErrNoEntity (issue #562)")
+
+	// With BypassTraverseChecking (the SMB default), the same Lookup succeeds.
+	bypassCtx := fx.authContext(2000, 2000)
+	bypassCtx.BypassTraverseChecking = true
+	got, err := fx.service.Lookup(bypassCtx, subHandle, "child.txt")
+	require.NoError(t, err,
+		"with BypassTraverseChecking, lookup must succeed even when parent omits FILE_EXECUTE")
+	assert.Equal(t, "/restricted/child.txt", got.Path)
+}
+
+// TestLookup_BypassTraverseChecking_NFSStrict pins the NFS-side contract:
+// callers that leave BypassTraverseChecking false continue to enforce
+// per-directory FILE_EXECUTE on Lookup. Guards against accidentally
+// loosening POSIX traverse for the NFS adapter while flipping the SMB bit.
+func TestLookup_BypassTraverseChecking_NFSStrict(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	ctx := context.Background()
+
+	rootCtx := fx.rootContext()
+	rootCtx.BypassTraverseChecking = true
+	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "nfs-dir", &metadata.FileAttr{
+		Mode: 0700,
+		UID:  1000,
+		GID:  1000,
+	})
+	require.NoError(t, err)
+
+	subHandle, err := fx.store.GetChild(ctx, fx.rootHandle, "nfs-dir")
+	require.NoError(t, err)
+
+	_, err = fx.service.CreateFile(rootCtx, subHandle, "file", &metadata.FileAttr{
+		Mode: 0644,
+		UID:  1000,
+		GID:  1000,
+	})
+	require.NoError(t, err)
+
+	// Non-owner caller, no group match, mode 0700 → no other-execute bit.
+	nfsCtx := fx.authContext(2000, 2000) // BypassTraverseChecking left false
+	_, err = fx.service.Lookup(nfsCtx, subHandle, "file")
+	require.Error(t, err, "NFS-strict caller must still get traverse-denied")
+
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -38,9 +38,19 @@ func (s *MetadataService) Lookup(ctx *AuthContext, dirHandle FileHandle, name st
 		}
 	}
 
-	// Check execute/search permission on directory
-	if err := s.checkExecutePermission(ctx, dirHandle); err != nil {
-		return nil, err
+	// Check execute/search permission on directory.
+	//
+	// Skipped when the caller holds "Bypass traverse checking"
+	// (Windows SeChangeNotifyPrivilege, MS-DTYP §2.5.3.2 + MS-FSA
+	// §2.1.5.1.1). Every SMB session sets ctx.BypassTraverseChecking so
+	// that a parent directory whose DACL omits FILE_TRAVERSE does not
+	// block resolution of a child whose own DACL grants the request. NFS
+	// callers leave the flag false and continue to enforce POSIX execute
+	// semantics on each path component.
+	if !ctx.BypassTraverseChecking {
+		if err := s.checkExecutePermission(ctx, dirHandle); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle special names


### PR DESCRIPTION
## Summary

`smb2.acls.DYNAMIC` (`test_inheritance_dynamic` in `source4/torture/smb2/acls.c`) returned `STATUS_OBJECT_NAME_NOT_FOUND` when creating `BASEDIR\inheritance\testfile` after the parent directory's DACL was set to grant only `WRITE_DATA | DELETE | READ_ATTRIBUTE` to the owner (no `FILE_EXECUTE` / `FILE_TRAVERSE`). Windows returns `STATUS_OK` because every interactive and SMB session holds `SeChangeNotifyPrivilege` ("Bypass traverse checking") by default, which exempts the caller from the per-directory `FILE_TRAVERSE` check during path resolution (MS-DTYP §2.5.3.2 + MS-FSA §2.1.5.1.1). Samba mirrors that default.

DittoFS was strictly enforcing the parent's execute bit inside `MetadataService.Lookup`, so the smbtorture test failed.

## Changes

- `pkg/metadata/auth_identity.go` — add `AuthContext.BypassTraverseChecking` flag, document the spec citations and the contract (SMB sets true, NFS leaves false).
- `pkg/metadata/file_modify.go` — `Lookup` skips `checkExecutePermission` on the parent when the flag is set.
- `internal/adapter/smb/v2/handlers/auth_helper.go` — `BuildAuthContext` and `BuildAuthContextFromUser` set `BypassTraverseChecking = true`.
- `internal/adapter/smb/v2/handlers/handler.go` — `buildCleanupAuthContext` does the same.
- `pkg/metadata/auth_permissions_bypass_traverse_test.go` — two regression tests:
  - `TestLookup_BypassTraverseChecking_GrantsAccess` reproduces the `acls.DYNAMIC` parent-DACL scenario, asserts denial without the flag returns `ErrAccessDenied` (not `ErrNoEntity`), and asserts that with the flag set the lookup succeeds.
  - `TestLookup_BypassTraverseChecking_NFSStrict` pins the NFS-side contract that POSIX traverse is still enforced when the flag is absent.

## Test plan

- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/... ./internal/adapter/nfs/...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI smbtorture run flips `smb2.acls.DYNAMIC` (and may unblock other tests whose CREATEs were misrouted through the same Lookup path).

## Spec references

- MS-DTYP §2.5.3.2 (AccessCheck — `SeChangeNotifyPrivilege` semantics)
- MS-FSA §2.1.5.1.1 (Open of an Existing File — parent traverse handling)
- Samba `source3/smbd/dosmode.c`, `source3/smbd/open.c::check_parent_access_fsp`

Closes #562