### PR TITLE
fix(smb/acl): access-check before MAX expansion + disposition (#564 #565)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
@@ -333,3 +333,260 @@ func TestCreate_DaclEnforcement_NilACLPermissive(t *testing.T) {
 			uint32(resp.Status))
 	}
 }
+
+// makeDraftWithDisposition builds a createDraft whose disposition + createAction
+// match a destructive open (OVERWRITE / OVERWRITE_IF / SUPERSEDE). Used by the
+// #565 tests below to exercise the disposition-implied FILE_WRITE_DATA check.
+func makeDraftWithDisposition(
+	t *testing.T,
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	existingFile *metadata.File,
+	baseName string,
+	desiredAccess uint32,
+	disposition types.CreateDisposition,
+	action types.CreateAction,
+) *createDraft {
+	t.Helper()
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			ShareAccess:       0x07,
+			CreateDisposition: disposition,
+			CreateOptions:     0,
+		},
+		tree:           tree,
+		authCtx:        authCtx,
+		filename:       baseName,
+		baseName:       baseName,
+		parentHandle:   parentHandle,
+		existingFile:   existingFile,
+		existingHandle: encHandle,
+		fileExists:     true,
+		createAction:   action,
+	}
+}
+
+// restrictedDACLFile creates an existing file whose DACL grants the requester
+// only READ_DATA (no WRITE / DELETE). Used by both the #564 MAX-plus-explicit
+// and #565 disposition-implied tests.
+func restrictedDACLFile(
+	t *testing.T,
+	metaSvc *metadata.MetadataService,
+	rootAuth *metadata.AuthContext,
+	rootHandle metadata.FileHandle,
+	name string,
+	requesterSID string,
+) *metadata.File {
+	t.Helper()
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	f, err := metaSvc.CreateFile(rootAuth, rootHandle, name,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	return f
+}
+
+// TestCreate_MaxAllowedPlusExplicitDeniedBit_ReturnsAccessDenied covers
+// smbtorture smb2.acls.MXAC-NOT-GRANTED (issue #564) at the SMB handler layer.
+// CREATE with DesiredAccess = MAXIMUM_ALLOWED | FILE_WRITE_DATA against a file
+// whose DACL only grants READ_DATA must fail STATUS_ACCESS_DENIED. The explicit
+// WRITE_DATA bit is verified against the granted set independently of MAX.
+//
+// Per MS-SMB2 §3.3.5.9 paragraph 8 and Samba
+// smbd_calculate_maximum_allowed_access_fsp.
+func TestCreate_MaxAllowedPlusExplicitDeniedBit_ReturnsAccessDenied(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	existingFile := restrictedDACLFile(t, rt.GetMetadataService(), rootAuth, rootHandle, "mxac.txt", requesterSID)
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	const (
+		rightMaxAllowed uint32 = 0x02000000
+		rightWriteData  uint32 = 0x00000002
+	)
+	draft := makeDraft(t, tree, requesterAuth, rootHandle, existingFile, "mxac.txt", rightMaxAllowed|rightWriteData)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("MAX|WRITE_DATA on READ-only DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+}
+
+// TestCreate_OverwriteRestrictedFile_ReturnsAccessDenied covers smbtorture
+// smb2.acls.OVERWRITE_READ_ONLY_FILE (issue #565) — OVERWRITE arm at
+// source4/torture/smb2/acls.c:3150. CREATE with disposition FILE_OVERWRITE and
+// DesiredAccess = FILE_READ_DATA against a DACL-restricted file must fail
+// STATUS_ACCESS_DENIED because OVERWRITE implicitly requires FILE_WRITE_DATA
+// to truncate the existing file, which the DACL does not grant.
+//
+// Per MS-FSA §2.1.5.1.2.1 and Samba open_file_ntcreate
+// (`open_access_mask |= FILE_WRITE_DATA` when O_TRUNC).
+func TestCreate_OverwriteRestrictedFile_ReturnsAccessDenied(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	existingFile := restrictedDACLFile(t, rt.GetMetadataService(), rootAuth, rootHandle, "overwrite.txt", requesterSID)
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	const rightReadData uint32 = 0x00000001
+	draft := makeDraftWithDisposition(t, tree, requesterAuth, rootHandle, existingFile, "overwrite.txt",
+		rightReadData, types.FileOverwrite, types.FileOverwritten)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("OVERWRITE on READ-only DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+}
+
+// TestCreate_SupersedeRestrictedFile_ReturnsAccessDenied covers smbtorture
+// smb2.acls.OVERWRITE_READ_ONLY_FILE (issue #565) — SUPERSEDE arm at
+// source4/torture/smb2/acls.c:3104. Mirrors the OVERWRITE test above but with
+// FILE_SUPERSEDE disposition: SUPERSEDE replaces the existing file content,
+// which inherently requires FILE_WRITE_DATA per MS-FSA §2.1.5.1.2.1 and must
+// be denied when the DACL grants only READ_DATA.
+func TestCreate_SupersedeRestrictedFile_ReturnsAccessDenied(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	existingFile := restrictedDACLFile(t, rt.GetMetadataService(), rootAuth, rootHandle, "supersede.txt", requesterSID)
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	const rightReadData uint32 = 0x00000001
+	draft := makeDraftWithDisposition(t, tree, requesterAuth, rootHandle, existingFile, "supersede.txt",
+		rightReadData, types.FileSupersede, types.FileSuperseded)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("SUPERSEDE on READ-only DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+}
+
+// TestCreate_OverwriteIfRestrictedFile_ReturnsAccessDenied covers the
+// OVERWRITE_IF arm for #565 — same DACL-restricted truncate semantics as
+// OVERWRITE and SUPERSEDE.
+func TestCreate_OverwriteIfRestrictedFile_ReturnsAccessDenied(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	existingFile := restrictedDACLFile(t, rt.GetMetadataService(), rootAuth, rootHandle, "overwriteif.txt", requesterSID)
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	const rightReadData uint32 = 0x00000001
+	draft := makeDraftWithDisposition(t, tree, requesterAuth, rootHandle, existingFile, "overwriteif.txt",
+		rightReadData, types.FileOverwriteIf, types.FileOverwritten)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("OVERWRITE_IF on READ-only DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+}
+
+// TestCreate_OpenRestrictedFileForRead_Succeeds is the positive control for
+// #565: the same READ-only DACL allows FILE_OPEN with DesiredAccess=READ_DATA
+// (the spec test's first row at acls.c:3088). Guards against the
+// disposition-implied augmentation accidentally firing for non-destructive
+// dispositions.
+func TestCreate_OpenRestrictedFileForRead_Succeeds(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	existingFile := restrictedDACLFile(t, rt.GetMetadataService(), rootAuth, rootHandle, "open.txt", requesterSID)
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+
+	const rightReadData uint32 = 0x00000001
+	draft := makeDraftWithDisposition(t, tree, requesterAuth, rootHandle, existingFile, "open.txt",
+		rightReadData, types.FileOpen, types.FileOpened)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("FILE_OPEN READ on READ-only DACL: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -227,14 +227,49 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				parentFile = pf
 			}
 		}
-		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, req.DesiredAccess)
+
+		// Fold in disposition-implied access bits before the DACL check.
+		// Per MS-FSA §2.1.5.1.2.1 and Samba open_file_ntcreate (which sets
+		// `open_access_mask |= FILE_WRITE_DATA` when O_TRUNC is implied by
+		// the disposition), OVERWRITE / OVERWRITE_IF / SUPERSEDE on an
+		// existing file inherently truncate it and so REQUIRE FILE_WRITE_DATA
+		// to be granted by the DACL — independent of whether the client put
+		// WRITE_DATA in DesiredAccess. The Samba check runs against
+		// open_access_mask in smbd_check_access_rights_fsp; we mirror that
+		// by extending the mask passed to CheckFileAccessWithParent so a
+		// DACL that grants only READ_DATA fails OVERWRITE/SUPERSEDE with
+		// STATUS_ACCESS_DENIED. Covers smb2.acls.OVERWRITE_READ_ONLY_FILE
+		// (issue #565).
+		//
+		// Skipped when MAXIMUM_ALLOWED is set: MAX expansion lets the
+		// MaxAllowed branch report the granted mask without exposing the
+		// implied write requirement as an explicit-bit denial. Samba does
+		// the same — the FILE_WRITE_DATA augmentation only fires for the
+		// non-MAX disposition path.
+		effectiveAccess := req.DesiredAccess
+		const maxAllowedBit uint32 = 0x02000000
+		if effectiveAccess&maxAllowedBit == 0 && isDestructiveDisposition(req.CreateDisposition) {
+			effectiveAccess |= uint32(types.FileWriteData)
+		}
+
+		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
 		if err != nil {
 			logger.Debug("CREATE: DesiredAccess denied by DACL",
 				"path", filename,
 				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
 				"granted", fmt.Sprintf("0x%x", granted),
+				"disposition", req.CreateDisposition,
 				"error", err)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
+		}
+		// Preserve the client-visible grant: clear the disposition-implied
+		// bit before propagating so QUERY_INFO / FileAccessInformation report
+		// only what was actually requested (Samba `fsp->access_mask` mirrors
+		// the original DesiredAccess after the open succeeds — see
+		// open_file_ntcreate line where access_mask is restored).
+		if effectiveAccess != req.DesiredAccess {
+			granted &^= (effectiveAccess &^ req.DesiredAccess)
 		}
 		grantedAccess = granted
 		grantedComputed = true

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -657,11 +657,10 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 	}
 
 	if maximumAllowed {
-		// MAXIMUM_ALLOWED never denies. Compute the full set of bits the
-		// requester is allowed (independent of what they asked for, minus the
-		// MAXIMUM_ALLOWED bit itself) and return that as the granted mask.
-		// Mirrors computeMaximalAccess so the handle's effective access
-		// matches the MxAc reply.
+		// MAXIMUM_ALLOWED on its own never denies. Compute the full set of
+		// bits the requester is allowed (independent of what they asked for,
+		// minus the MAXIMUM_ALLOWED bit itself). Mirrors computeMaximalAccess
+		// so the handle's effective access matches the MxAc reply.
 		var effective uint32
 		for _, bit := range acl.ProbeBitsAll {
 			if acl.Evaluate(file.ACL, evalCtx, bit) {
@@ -675,7 +674,23 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 		if parent != nil && parentGrantsDeleteChild(parent, authCtx) {
 			effective |= acl.ACE4_DELETE
 		}
-		return effective | granted, nil
+		effective |= granted
+
+		// Per MS-SMB2 §3.3.5.9 paragraph 8 and Samba
+		// smbd_calculate_maximum_allowed_access_fsp: even when
+		// MAXIMUM_ALLOWED is set, every EXPLICIT non-MAX bit in DesiredAccess
+		// MUST be granted by the DACL. If any explicit bit is missing from
+		// the resolved effective set, the open MUST fail STATUS_ACCESS_DENIED.
+		// MAXIMUM_ALLOWED suppresses denial only for the bits IMPLICITLY
+		// requested via the MAX flag itself, not for bits the caller named
+		// outright. Covers smb2.acls.MXAC-NOT-GRANTED.
+		if explicit != 0 && effective&explicit != explicit {
+			return effective, &StoreError{
+				Code:    ErrAccessDenied,
+				Message: "explicit non-MAXIMUM_ALLOWED bit denied by file DACL",
+			}
+		}
+		return effective, nil
 	}
 
 	// Strict mode: any requested non-MAXIMUM_ALLOWED bit not granted = deny.

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -122,11 +122,14 @@ func TestCheckFileAccess_AllowOnlyReadGrantsReadDeniesWrite(t *testing.T) {
 	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 }
 
-// TestCheckFileAccess_MaximumAllowedNeverDenies covers acls.MXAC-NOT-GRANTED:
-// when the client requests MAXIMUM_ALLOWED, the server must return whatever
-// the DACL allows as the granted mask (no STATUS_ACCESS_DENIED), regardless
-// of how restrictive the DACL is.
-func TestCheckFileAccess_MaximumAllowedNeverDenies(t *testing.T) {
+// TestCheckFileAccess_MaximumAllowedAloneNeverDenies covers the baseline
+// MAXIMUM_ALLOWED contract: when the client requests MAXIMUM_ALLOWED with NO
+// explicit bits, the server must return whatever the DACL allows as the
+// granted mask (no STATUS_ACCESS_DENIED), regardless of how restrictive the
+// DACL is. Per MS-SMB2 §3.3.5.9 paragraph 8, this never-deny guarantee only
+// applies to MAX-alone; explicit non-MAX bits are validated separately (see
+// TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies).
+func TestCheckFileAccess_MaximumAllowedAloneNeverDenies(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterUID := uint32(1001)
@@ -161,12 +164,55 @@ func TestCheckFileAccess_MaximumAllowedNeverDenies(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, granted&acl.ACE4_READ_DATA, "expected READ_DATA in granted mask, got 0x%x", granted)
 	require.Zero(t, granted&acl.ACE4_WRITE_DATA, "WRITE_DATA must not be granted, got 0x%x", granted)
+}
 
-	// MAXIMUM_ALLOWED | WRITE_DATA must also not deny: the MAXIMUM_ALLOWED bit
-	// suppresses denial. The handle's effective access reflects the DACL.
-	granted, err = f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightWriteData)
+// TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies covers
+// smbtorture acls.MXAC-NOT-GRANTED (issue #564). When the requester combines
+// MAXIMUM_ALLOWED with an EXPLICIT non-MAX access bit that the DACL does not
+// grant, the open must fail with STATUS_ACCESS_DENIED. MAXIMUM_ALLOWED only
+// suppresses denial for bits the caller did not name outright — it cannot
+// rescue an explicitly requested bit that the DACL rejects.
+//
+// Per MS-SMB2 §3.3.5.9 paragraph 8 and Samba
+// source3/smbd/open.c::smbd_calculate_maximum_allowed_access_fsp, which
+// passes the requested mask (minus MAX) through se_file_access_check and
+// returns NT_STATUS_ACCESS_DENIED when any explicit bit is rejected.
+func TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// DACL: ALLOW READ_DATA only. WRITE_DATA is not granted to anyone.
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "mxac.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999,
+			GID:  9999,
+			ACL:  readOnlyACL,
+		})
 	require.NoError(t, err)
-	require.Zero(t, granted&acl.ACE4_WRITE_DATA, "WRITE_DATA must not be granted even when requested with MAXIMUM_ALLOWED, got 0x%x", granted)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	// MAXIMUM_ALLOWED | WRITE_DATA — WRITE_DATA is the explicit bit, the
+	// DACL does not grant it, so the open MUST deny.
+	_, err = f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightWriteData)
+	require.Error(t, err, "MAX|WRITE_DATA against READ-only DACL must deny")
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 }
 
 // TestCheckFileAccess_RootBypassGetsEverything documents the root bypass:


### PR DESCRIPTION
## Summary

Two related access-check bugs in CREATE that share the same root cause — the DACL check ran against a mask that didn't reflect what the open actually required.

### #564 — `smb2.acls.MXAC-NOT-GRANTED`

`MAXIMUM_ALLOWED | FILE_WRITE_DATA` against a DACL that grants only `READ_DATA` was succeeding. Per MS-SMB2 §3.3.5.9 ¶8 and Samba `smbd_calculate_maximum_allowed_access_fsp`, `MAXIMUM_ALLOWED` suppresses denial only for *implicitly* requested bits; explicit non-MAX bits must still pass the DACL check.

Fix in `pkg/metadata/auth_permissions.go::CheckFileAccessWithParent`: after MAX expansion, verify every explicit bit against the resolved effective mask. Deny with `ErrAccessDenied` if any explicit bit is missing.

### #565 — `smb2.acls.OVERWRITE_READ_ONLY_FILE`

`FILE_SUPERSEDE` / `FILE_OVERWRITE` / `FILE_OVERWRITE_IF` with `DesiredAccess = FILE_READ_DATA` on a DACL-restricted file was succeeding. Per MS-FSA §2.1.5.1.2.1 and Samba `open_file_ntcreate` (`open_access_mask |= FILE_WRITE_DATA` when `O_TRUNC`), these destructive dispositions inherently require `FILE_WRITE_DATA` regardless of what the client put in `DesiredAccess`.

Fix in `internal/adapter/smb/v2/handlers/create_post_break.go::completeCreateAfterBreak`: when the disposition is destructive and `MAXIMUM_ALLOWED` is not set, fold `FILE_WRITE_DATA` into the mask passed to `CheckFileAccessWithParent`. Strip the implied bit back out of the returned grant so `QUERY_INFO` / `FileAccessInformation` still report the client-requested set.

## Test plan

- [x] `go test ./pkg/metadata/...` — new `TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies` passes; existing renamed `...AloneNeverDenies` still passes.
- [x] `go test ./internal/adapter/smb/v2/handlers/...` — new handler tests pass:
  - `TestCreate_MaxAllowedPlusExplicitDeniedBit_ReturnsAccessDenied` (#564)
  - `TestCreate_OverwriteRestrictedFile_ReturnsAccessDenied` (#565)
  - `TestCreate_SupersedeRestrictedFile_ReturnsAccessDenied` (#565)
  - `TestCreate_OverwriteIfRestrictedFile_ReturnsAccessDenied` (#565)
  - `TestCreate_OpenRestrictedFileForRead_Succeeds` (regression guard: FILE_OPEN+READ still allowed by the same READ-only DACL)
- [x] `go test ./... -short` green, no regressions in existing DACL-enforcement or MaxAllowed coverage.
- [x] `go vet ./...` clean.
- [ ] CI smbtorture run to confirm `smb2.acls.MXAC-NOT-GRANTED` and `smb2.acls.OVERWRITE_READ_ONLY_FILE` flip; `KNOWN_FAILURES.md` walkback in follow-up commit per the "never touch KNOWN_FAILURES until CI confirms" workflow.

## Notes

- The pre-existing `TestCheckFileAccess_MaximumAllowedNeverDenies` had an assertion encoding the buggy "MAX|WRITE_DATA must not deny" behavior. Renamed to `...AloneNeverDenies` and the wrong assertion replaced with the new test asserting the spec-correct denial.
- `KNOWN_FAILURES.md` deliberately not touched in this PR — waiting for CI confirmation.

Closes #564
Closes #565