### PR TITLE
fix(smb/acl): SET_INFO Security authz against handle GrantedAccess + READ_ATTRIBUTES always-grant

### DIFF
--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1182,6 +1182,23 @@ func (h *Handler) parseSDOptsForShare(shareName string) ParseSDOptions {
 //
 // Parses the binary Security Descriptor from the client, extracts owner/group/ACL,
 // and applies the changes to the file via MetadataService.SetFileAttributes.
+//
+// Per MS-SMB2 §3.3.5.21.3 and MS-FSA §2.1.5.14, the access authorization for
+// SET_INFO Security is performed against the OPEN'S granted access mask
+// (captured at CREATE time), NOT against the file's current DACL. The new
+// SD being installed is irrelevant to the authorization decision — installing
+// a DACL that strips WRITE_DAC must still succeed if the handle was opened
+// with WRITE_DAC. Section→bit mapping (mirrors Samba
+// source3/smbd/smb2_setinfo.c::smbd_smb2_setinfo_security):
+//
+//	SECINFO_DACL  → SEC_STD_WRITE_DAC
+//	SECINFO_OWNER → SEC_STD_WRITE_OWNER
+//	SECINFO_GROUP → SEC_STD_WRITE_OWNER
+//	SECINFO_SACL  → ACCESS_SYSTEM_SECURITY
+//
+// Each requested section is gated independently; the request is denied as a
+// whole if any requested section lacks the corresponding bit on the handle.
+// Refs #559.
 func (h *Handler) setSecurityInfo(
 	authCtx *metadata.AuthContext,
 	openFile *OpenFile,
@@ -1190,6 +1207,17 @@ func (h *Handler) setSecurityInfo(
 ) (*SetInfoResponse, error) {
 	if len(buffer) == 0 {
 		return setInfoStatus(types.StatusInvalidParameter), nil
+	}
+
+	// MS-SMB2 §3.3.5.21.3: authorize each requested SD section against the
+	// open's GrantedAccess. The new SD is not consulted — the handle's mask
+	// already captured the DACL-evaluated rights at CREATE time.
+	if status, ok := checkSetInfoSecurityAccess(openFile.GrantedAccess, additionalInfo); !ok {
+		logger.Debug("SET_INFO Security: handle lacks required access",
+			"path", openFile.Path,
+			"additionalInfo", fmt.Sprintf("0x%x", additionalInfo),
+			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
+		return setInfoStatus(status), nil
 	}
 
 	// Per-share opt-out of MS-DTYP §2.5.3.4.2 canonicalization. Default true
@@ -1246,6 +1274,39 @@ func (h *Handler) setSecurityInfo(
 	}
 
 	return setInfoStatus(types.StatusSuccess), nil
+}
+
+// checkSetInfoSecurityAccess maps requested SECURITY_INFORMATION sections to
+// the access mask bits MS-SMB2 §3.3.5.21.3 / MS-FSA §2.1.5.14 require on the
+// open's GrantedAccess, and verifies each requested section against the mask.
+//
+// Returns (StatusSuccess, true) when every requested section has the matching
+// bit on the open; (StatusAccessDenied, false) otherwise. An additionalInfo
+// of zero authorizes (no sections to gate).
+//
+// Mirrors Samba source3/smbd/smb2_setinfo.c::smbd_smb2_setinfo_security and
+// source3/smbd/posix_acls.c::set_nt_acl — both consult `fsp->access_mask`
+// (the equivalent of OpenFile.GrantedAccess), never re-evaluate against the
+// file's current DACL. Refs #559.
+func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Status, bool) {
+	if additionalInfo&DACLSecurityInformation != 0 {
+		if !hasAccessRight(grantedAccess, uint32(types.WriteDac)) {
+			return types.StatusAccessDenied, false
+		}
+	}
+	// SECINFO_OWNER and SECINFO_GROUP both require WRITE_OWNER per MS-DTYP
+	// §2.5.3.3 (the algorithm folds owner+group under one privilege gate).
+	if additionalInfo&(OwnerSecurityInformation|GroupSecurityInformation) != 0 {
+		if !hasAccessRight(grantedAccess, uint32(types.WriteOwner)) {
+			return types.StatusAccessDenied, false
+		}
+	}
+	if additionalInfo&SACLSecurityInformation != 0 {
+		if !hasAccessRight(grantedAccess, uint32(types.AccessSystemSecurity)) {
+			return types.StatusAccessDenied, false
+		}
+	}
+	return types.StatusSuccess, true
 }
 
 // breakParentDirLeases breaks leases on the parent directory when a child

--- a/internal/adapter/smb/v2/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_security_authz_test.go
@@ -1,0 +1,273 @@
+// Tests for SET_INFO Security access authorization against the open's
+// GrantedAccess (Samba `fsp->access_mask`). Per MS-SMB2 §3.3.5.21.3 and
+// MS-FSA §2.1.5.14 the SD-section→access-bit gate is:
+//
+//	SECINFO_DACL  → WRITE_DAC
+//	SECINFO_OWNER → WRITE_OWNER
+//	SECINFO_GROUP → WRITE_OWNER
+//	SECINFO_SACL  → ACCESS_SYSTEM_SECURITY
+//
+// The handle's GrantedAccess captured at CREATE is the sole authority —
+// the new SD being installed is irrelevant. Refs #559.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupSecurityAuthzTest provisions a runtime + share + file and returns a
+// handler, the open file (caller stamps GrantedAccess), and an auth context.
+func setupSecurityAuthzTest(t *testing.T) (*Handler, *OpenFile, *metadata.AuthContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("authz-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	shareName := "/authz"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "authz-meta",
+		Enabled:       true,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	metaSvc := rt.GetMetadataService()
+	file, err := metaSvc.CreateFile(authCtx, rootHandle, "g.dat", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	openFile := &OpenFile{
+		FileID:         [16]byte{9, 9, 9, 9},
+		MetadataHandle: fileHandle,
+		ParentHandle:   rootHandle,
+		FileName:       "g.dat",
+		Path:           "g.dat",
+		ShareName:      shareName,
+		// GrantedAccess intentionally zero; caller stamps per test.
+	}
+	h.StoreOpenFile(openFile)
+	return h, openFile, authCtx
+}
+
+// minimalDACLSDForOwner builds a self-relative SD with a DACL_PRESENT control
+// and a single allow-WRITE_DATA ACE for an arbitrary user-style SID. Mirrors
+// the SD smb2.acls.OWNER (acls.c::test_owner_bits) installs at line 763.
+func minimalDACLSDForOwner(t *testing.T) []byte {
+	t.Helper()
+	owner := buildSID(t, "S-1-5-21-1000-1000-1000-500")
+	const writeData uint32 = 0x00000002
+	ace := buildACE(accessAllowedACEType, 0x00, writeData, owner)
+	dacl := buildRawDACL(1, ace)
+	control := uint16(seDACLPresent)
+	return buildSelfRelativeSD(t, control, owner, nil, dacl)
+}
+
+// TestSetInfo_SECINFO_DACL_AuthzAgainstHandleGrantedAccess — primary case
+// for #559. SET_INFO SECINFO_DACL must succeed when the handle has WRITE_DAC
+// and must deny when it does not, regardless of what the file's current DACL
+// says or what the new SD looks like.
+func TestSetInfo_SECINFO_DACL_AuthzAgainstHandleGrantedAccess(t *testing.T) {
+	sd := minimalDACLSDForOwner(t)
+
+	t.Run("grants_when_handle_has_WRITE_DAC", func(t *testing.T) {
+		h, openFile, authCtx := setupSecurityAuthzTest(t)
+		openFile.GrantedAccess = uint32(types.WriteDac)
+		h.StoreOpenFile(openFile)
+
+		resp, err := h.setSecurityInfo(authCtx, openFile, DACLSecurityInformation, sd)
+		if err != nil {
+			t.Fatalf("setSecurityInfo: %v", err)
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("status = 0x%08x, want StatusSuccess (handle has WRITE_DAC)", resp.Status)
+		}
+	})
+
+	t.Run("denies_when_handle_lacks_WRITE_DAC", func(t *testing.T) {
+		h, openFile, authCtx := setupSecurityAuthzTest(t)
+		// READ_CONTROL alone (no WRITE_DAC) — owner could have READ_CONTROL
+		// implicitly but the handle was not opened with WRITE_DAC, so SET_INFO
+		// SECINFO_DACL must be denied.
+		openFile.GrantedAccess = uint32(types.ReadControl)
+		h.StoreOpenFile(openFile)
+
+		resp, err := h.setSecurityInfo(authCtx, openFile, DACLSecurityInformation, sd)
+		if err != nil {
+			t.Fatalf("setSecurityInfo: %v", err)
+		}
+		if resp.Status != types.StatusAccessDenied {
+			t.Fatalf("status = 0x%08x, want StatusAccessDenied (handle missing WRITE_DAC)", resp.Status)
+		}
+	})
+}
+
+// TestSetInfo_SECINFO_OWNER_AuthzAgainstHandleGrantedAccess verifies the
+// OWNER + GROUP sections both gate on WRITE_OWNER (MS-DTYP §2.5.3.3).
+func TestSetInfo_SECINFO_OWNER_AuthzAgainstHandleGrantedAccess(t *testing.T) {
+	sd := minimalDACLSDForOwner(t) // SD also carries an owner SID
+
+	for _, tc := range []struct {
+		name           string
+		additionalInfo uint32
+	}{
+		{"owner_section", OwnerSecurityInformation},
+		{"group_section", GroupSecurityInformation},
+		{"owner_and_group", OwnerSecurityInformation | GroupSecurityInformation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("grants_when_handle_has_WRITE_OWNER", func(t *testing.T) {
+				h, openFile, authCtx := setupSecurityAuthzTest(t)
+				openFile.GrantedAccess = uint32(types.WriteOwner)
+				h.StoreOpenFile(openFile)
+
+				resp, err := h.setSecurityInfo(authCtx, openFile, tc.additionalInfo, sd)
+				if err != nil {
+					t.Fatalf("setSecurityInfo: %v", err)
+				}
+				// SUCCESS expected — the gate passes. Downstream SetFileAttributes
+				// may still fail on the metadata layer for a non-root requester
+				// trying to chown to a different UID, but that's a separate path
+				// and not what this test asserts. We only verify the access gate.
+				if resp.Status != types.StatusSuccess {
+					t.Fatalf("status = 0x%08x, want StatusSuccess (handle has WRITE_OWNER)", resp.Status)
+				}
+			})
+
+			t.Run("denies_when_handle_lacks_WRITE_OWNER", func(t *testing.T) {
+				h, openFile, authCtx := setupSecurityAuthzTest(t)
+				// WRITE_DAC alone is not WRITE_OWNER — must be denied.
+				openFile.GrantedAccess = uint32(types.WriteDac)
+				h.StoreOpenFile(openFile)
+
+				resp, err := h.setSecurityInfo(authCtx, openFile, tc.additionalInfo, sd)
+				if err != nil {
+					t.Fatalf("setSecurityInfo: %v", err)
+				}
+				if resp.Status != types.StatusAccessDenied {
+					t.Fatalf("status = 0x%08x, want StatusAccessDenied", resp.Status)
+				}
+			})
+		})
+	}
+}
+
+// TestSetInfo_SECINFO_SACL_AuthzAgainstHandleGrantedAccess verifies the SACL
+// section gates on ACCESS_SYSTEM_SECURITY per MS-DTYP §2.5.3.3 / MS-SMB2
+// §3.3.5.21.3.
+func TestSetInfo_SECINFO_SACL_AuthzAgainstHandleGrantedAccess(t *testing.T) {
+	sd := minimalDACLSDForOwner(t)
+
+	t.Run("grants_when_handle_has_ACCESS_SYSTEM_SECURITY", func(t *testing.T) {
+		h, openFile, authCtx := setupSecurityAuthzTest(t)
+		openFile.GrantedAccess = uint32(types.AccessSystemSecurity)
+		h.StoreOpenFile(openFile)
+
+		resp, err := h.setSecurityInfo(authCtx, openFile, SACLSecurityInformation, sd)
+		if err != nil {
+			t.Fatalf("setSecurityInfo: %v", err)
+		}
+		// SACL changes are no-ops in DittoFS (no SACL persistence yet), so the
+		// handler returns SUCCESS once the gate passes.
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("status = 0x%08x, want StatusSuccess (handle has ACCESS_SYSTEM_SECURITY)", resp.Status)
+		}
+	})
+
+	t.Run("denies_when_handle_lacks_ACCESS_SYSTEM_SECURITY", func(t *testing.T) {
+		h, openFile, authCtx := setupSecurityAuthzTest(t)
+		openFile.GrantedAccess = uint32(types.WriteDac | types.WriteOwner)
+		h.StoreOpenFile(openFile)
+
+		resp, err := h.setSecurityInfo(authCtx, openFile, SACLSecurityInformation, sd)
+		if err != nil {
+			t.Fatalf("setSecurityInfo: %v", err)
+		}
+		if resp.Status != types.StatusAccessDenied {
+			t.Fatalf("status = 0x%08x, want StatusAccessDenied", resp.Status)
+		}
+	})
+}
+
+// TestCheckSetInfoSecurityAccess_Helper covers the helper directly across
+// the section→bit matrix and edge cases (zero info, MAXIMUM_ALLOWED).
+func TestCheckSetInfoSecurityAccess_Helper(t *testing.T) {
+	cases := []struct {
+		name           string
+		grantedAccess  uint32
+		additionalInfo uint32
+		wantStatus     types.Status
+		wantOK         bool
+	}{
+		{"no_sections_no_gate", 0, 0, types.StatusSuccess, true},
+		{"DACL_with_WRITE_DAC", uint32(types.WriteDac), DACLSecurityInformation, types.StatusSuccess, true},
+		{"DACL_without_WRITE_DAC", uint32(types.ReadControl), DACLSecurityInformation, types.StatusAccessDenied, false},
+		{"OWNER_with_WRITE_OWNER", uint32(types.WriteOwner), OwnerSecurityInformation, types.StatusSuccess, true},
+		{"OWNER_without_WRITE_OWNER", uint32(types.WriteDac), OwnerSecurityInformation, types.StatusAccessDenied, false},
+		{"GROUP_with_WRITE_OWNER", uint32(types.WriteOwner), GroupSecurityInformation, types.StatusSuccess, true},
+		{"SACL_with_ACCESS_SYSTEM_SECURITY", uint32(types.AccessSystemSecurity), SACLSecurityInformation, types.StatusSuccess, true},
+		{"SACL_without_ACCESS_SYSTEM_SECURITY", uint32(types.WriteDac), SACLSecurityInformation, types.StatusAccessDenied, false},
+		{"DACL_with_MAXIMUM_ALLOWED", uint32(types.MaximumAllowed), DACLSecurityInformation, types.StatusSuccess, true},
+		{"DACL_with_GENERIC_ALL", uint32(types.GenericAll), DACLSecurityInformation, types.StatusSuccess, true},
+		{
+			name:           "all_sections_with_all_bits",
+			grantedAccess:  uint32(types.WriteDac | types.WriteOwner | types.AccessSystemSecurity),
+			additionalInfo: OwnerSecurityInformation | GroupSecurityInformation | DACLSecurityInformation | SACLSecurityInformation,
+			wantStatus:     types.StatusSuccess,
+			wantOK:         true,
+		},
+		{
+			name:           "DACL_and_OWNER_missing_OWNER_bit",
+			grantedAccess:  uint32(types.WriteDac),
+			additionalInfo: DACLSecurityInformation | OwnerSecurityInformation,
+			wantStatus:     types.StatusAccessDenied,
+			wantOK:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotOK := checkSetInfoSecurityAccess(tc.grantedAccess, tc.additionalInfo)
+			if gotOK != tc.wantOK {
+				t.Errorf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotStatus != tc.wantStatus {
+				t.Errorf("status = 0x%08x, want 0x%08x", gotStatus, tc.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/v2/handlers/set_info_security_toggle_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_security_toggle_test.go
@@ -76,6 +76,9 @@ func setupACLToggleTest(t *testing.T, shareName string, canonicalize bool) (*Han
 		Path:           "f.dat",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.WriteDac),
+		// Refs #559: setSecurityInfo gates on the open's GrantedAccess
+		// (Samba fsp->access_mask); SECINFO_DACL requires WRITE_DAC.
+		GrantedAccess: uint32(types.FileWriteAttributes) | uint32(types.WriteDac),
 	}
 	h.StoreOpenFile(openFile)
 

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -643,6 +643,20 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 		probe &^= bit
 	}
 
+	// MS-FSA §2.1.4.13 "Algorithm to Check Access to an Existing File":
+	// FILE_READ_ATTRIBUTES is always granted from the containing directory
+	// once traverse access to the file's path succeeds. The bit is unmasked
+	// from the file's DACL evaluation — even a DACL that explicitly omits
+	// READ_ATTRIBUTES still yields a successful open requesting it.
+	//
+	// Mirrors Samba source3/smbd/open.c::smbd_check_access_rights_fsp which
+	// sets `do_not_check_mask = FILE_READ_ATTRIBUTES` before invoking the
+	// DACL check. Covers smb2.acls.OWNER (acls.c:765 loop iteration with
+	// bit=0x80 expecting OK on a DACL that only grants WRITE_DATA). Refs #559.
+	if explicit&acl.ACE4_READ_ATTRIBUTES != 0 && granted&acl.ACE4_READ_ATTRIBUTES == 0 {
+		granted |= acl.ACE4_READ_ATTRIBUTES
+	}
+
 	// Parent override for DELETE: when the file's own DACL denied DELETE but
 	// the parent directory grants FILE_DELETE_CHILD to the caller, grant
 	// DELETE here (MS-FSA §2.1.4.13 / Samba parent_override_delete). The
@@ -677,6 +691,11 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 		if parent != nil && parentGrantsDeleteChild(parent, authCtx) {
 			effective |= acl.ACE4_DELETE
 		}
+		// MS-FSA §2.1.4.13: FILE_READ_ATTRIBUTES is always granted from the
+		// containing directory (see explicit-branch comment above). Surface it
+		// in the MaxAccess set so MxAc replies and MAXIMUM_ALLOWED opens carry
+		// the bit. Refs #559.
+		effective |= acl.ACE4_READ_ATTRIBUTES
 		effective |= granted
 
 		// Per MS-SMB2 §3.3.5.9 paragraph 8 and Samba

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -633,3 +633,68 @@ func TestCheckFileAccessWithParent_NoOverrideWhenParentLacksDeleteChild(t *testi
 	require.ErrorAs(t, err, &storeErr)
 	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 }
+
+// TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent covers MS-FSA
+// §2.1.4.13 "Algorithm to Check Access to an Existing File": FILE_READ_ATTRIBUTES
+// is unconditionally granted from the containing directory once traverse access
+// to the path succeeds. Even a DACL that explicitly omits READ_ATTRIBUTES must
+// not block an open that asks for it.
+//
+// Covers smb2.acls.OWNER (acls.c::test_owner_bits, line 765 loop) where the
+// test installs a DACL granting only FILE_WRITE_DATA to the owner and then
+// expects an open with desired_access=0x80 (READ_ATTRIBUTES) to succeed.
+// Mirrors Samba source3/smbd/open.c::smbd_check_access_rights_fsp setting
+// `do_not_check_mask = FILE_READ_ATTRIBUTES`. Refs #559.
+func TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent(t *testing.T) {
+	f := newTestFixture(t)
+
+	const rightReadAttributes uint32 = 0x00000080
+
+	ownerUID := uint32(1001)
+	ownerSID := "S-1-5-21-1-2-3-2001"
+
+	// DACL grants the owner ONLY FILE_WRITE_DATA — no READ_ATTRIBUTES.
+	writeOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + ownerSID,
+				AccessMask: acl.ACE4_WRITE_DATA,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "raa.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  ownerUID,
+			GID:  1001,
+			ACL:  writeOnlyACL,
+		})
+	require.NoError(t, err)
+
+	authCtx := f.authContext(ownerUID, 1001)
+	authCtx.Identity.SID = strPtr(ownerSID)
+
+	// Bit 0x80 alone — DACL omits it but MS-FSA always-grants it from parent.
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightReadAttributes)
+	require.NoError(t, err, "READ_ATTRIBUTES must be granted even when DACL omits it")
+	require.Equal(t, rightReadAttributes, granted&rightReadAttributes,
+		"expected READ_ATTRIBUTES in granted mask, got 0x%x", granted)
+
+	// READ_ATTRIBUTES combined with the DACL-granted WRITE_DATA — both must
+	// be present. Mirrors smb2.acls.OWNER's expected_bits = WRITE_DATA|READ_ATTRIBUTE.
+	probe := rightReadAttributes | rightWriteData
+	granted, err = f.service.CheckFileAccess(created, authCtx, probe)
+	require.NoError(t, err)
+	require.Equal(t, probe, granted&probe,
+		"expected WRITE_DATA|READ_ATTRIBUTES granted, got 0x%x", granted)
+
+	// READ_DATA must still be denied — the always-grant rule covers only
+	// READ_ATTRIBUTES, not the rest of the read namespace.
+	_, err = f.service.CheckFileAccess(created, authCtx, rightReadData)
+	require.Error(t, err)
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}


### PR DESCRIPTION
## Summary

Two MS-FSA / MS-SMB2 §3.3.5.21.3 gaps fixed in tandem to flip `smb2.acls.OWNER`:

1. **SET_INFO Security gates on handle's GrantedAccess.** \`setSecurityInfo\` now authorizes each requested SECURITY_INFORMATION section against the open's \`GrantedAccess\` (Samba's \`fsp->access_mask\`), not the file's current DACL:

   | Section | Required bit |
   | --- | --- |
   | SECINFO_DACL | WRITE_DAC |
   | SECINFO_OWNER | WRITE_OWNER |
   | SECINFO_GROUP | WRITE_OWNER |
   | SECINFO_SACL | ACCESS_SYSTEM_SECURITY |

   The new SD being installed is irrelevant to the authz decision — installing a DACL that strips WRITE_DAC must still succeed when the handle carries WRITE_DAC. Mirrors \`source3/smbd/smb2_setinfo.c::smbd_smb2_setinfo_security\` / \`source3/smbd/posix_acls.c::set_nt_acl\`.

2. **FILE_READ_ATTRIBUTES always granted from containing directory.** \`CheckFileAccessWithParent\` unconditionally adds READ_ATTRIBUTES to the granted mask when requested. Per MS-FSA §2.1.4.13 "Algorithm to Check Access to an Existing File", the bit is always granted from the parent once traverse succeeds. Mirrors Samba \`smbd_check_access_rights_fsp\` setting \`do_not_check_mask = FILE_READ_ATTRIBUTES\`.

## Why

\`smb2.acls.OWNER\` (\`test_owner_bits\`, \`source4/torture/smb2/acls.c:765\`) installs a DACL granting the owner only SEC_FILE_WRITE_DATA, then loops through 16 bits opening each. \`expected_bits = SEC_FILE_WRITE_DATA | SEC_FILE_READ_ATTRIBUTE\` — so an open with desired_access=0x80 (READ_ATTRIBUTES) is expected to succeed. DittoFS denied it because the new DACL lacks READ_ATTRIBUTES; per spec the bit comes from the parent, not the file's own DACL.

The SET_INFO gate was missing entirely. While the OWNER test specifically didn't fail there (the requester is the file owner and SetFileAttributes accepts owner edits), the gate is required per spec and the absence would surface in other tests where the handle's WRITE_DAC was retracted by the very SD being installed.

## Spec / reference

- MS-SMB2 §3.3.5.21.3 — SMB2 SET_INFO with \`InfoType = SMB2_0_INFO_SECURITY\`
- MS-DTYP §2.5.3.3 — Algorithm for setting Security Descriptor
- MS-FSA §2.1.5.14 — Server SetSecurityInformation
- MS-FSA §2.1.4.13 — Algorithm to Check Access to an Existing File (READ_ATTRIBUTES rule)
- Samba \`source3/smbd/smb2_setinfo.c\`, \`source3/smbd/posix_acls.c::set_nt_acl\`, \`source3/smbd/open.c::smbd_check_access_rights_fsp\`

## Test plan

- [x] \`go test ./internal/adapter/smb/v2/handlers/...\` — new \`TestSetInfo_SECINFO_DACL_AuthzAgainstHandleGrantedAccess\`, \`TestSetInfo_SECINFO_OWNER_AuthzAgainstHandleGrantedAccess\`, \`TestSetInfo_SECINFO_SACL_AuthzAgainstHandleGrantedAccess\`, \`TestCheckSetInfoSecurityAccess_Helper\`
- [x] \`go test ./pkg/metadata/...\` — new \`TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent\`
- [x] \`go test ./...\` — full suite green, no regressions
- [x] \`go vet ./...\` clean
- [ ] CI smbtorture: expect \`smb2.acls.OWNER\` flip

## Files touched

- \`internal/adapter/smb/v2/handlers/set_info.go\` — gate added in \`setSecurityInfo\`; \`checkSetInfoSecurityAccess\` helper
- \`internal/adapter/smb/v2/handlers/set_info_security_authz_test.go\` — new test file (gate matrix)
- \`internal/adapter/smb/v2/handlers/set_info_security_toggle_test.go\` — stamp \`GrantedAccess\` on the test \`OpenFile\` so the existing toggle test still passes the new gate
- \`pkg/metadata/auth_permissions.go\` — READ_ATTRIBUTES always-grant in explicit + MaximumAllowed branches
- \`pkg/metadata/auth_permissions_file_access_test.go\` — new \`TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent\`

## Closes

Closes #559.