### PR TITLE
fix(smb/acl): acls.OVERWRITE_READ_ONLY_FILE sharing_tcases — fold WRITE_DATA into share-mode check (#575)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
@@ -556,6 +556,225 @@ func TestCreate_OverwriteIfRestrictedFile_ReturnsAccessDenied(t *testing.T) {
 	}
 }
 
+// makeDraftWithShareAccess assembles a createDraft with explicit
+// DesiredAccess, ShareAccess, and CreateDisposition. Used by the share-mode
+// conflict tests that need to exercise the per-bit deny semantics against a
+// pre-seeded OpenFile.
+func makeDraftWithShareAccess(
+	t *testing.T,
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	existingFile *metadata.File,
+	baseName string,
+	desiredAccess uint32,
+	shareAccess uint32,
+	disposition types.CreateDisposition,
+	action types.CreateAction,
+) *createDraft {
+	t.Helper()
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			ShareAccess:       shareAccess,
+			CreateDisposition: disposition,
+			CreateOptions:     0,
+		},
+		tree:           tree,
+		authCtx:        authCtx,
+		filename:       baseName,
+		baseName:       baseName,
+		parentHandle:   parentHandle,
+		existingFile:   existingFile,
+		existingHandle: encHandle,
+		fileExists:     true,
+		createAction:   action,
+	}
+}
+
+// runDestructiveShareViolationCase exercises the smbtorture
+// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases shape (#575):
+//
+//  1. First handle: CREATE(desired=READ_DATA, share=SHARE_READ, disp=OPEN_IF).
+//     Recorded as an OpenFile in the handler's open table.
+//  2. Second handle: CREATE(desired=READ_DATA, share=SHARE_READ, disp=DESTRUCTIVE).
+//     Must return STATUS_SHARING_VIOLATION because the destructive disposition
+//     implicitly requires FILE_WRITE_DATA, which the existing handle's
+//     SHARE_READ-only share mode does not allow.
+//
+// Mirrors Samba `open_file_ntcreate`'s `open_access_mask |= FILE_WRITE_DATA`
+// for O_TRUNC dispositions, which is then used for the share-mode conflict
+// check in `open_mode_check`.
+func runDestructiveShareViolationCase(t *testing.T, fname string, disposition types.CreateDisposition, action types.CreateAction) {
+	t.Helper()
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	// File owned by the test user with a permissive DACL (the sharing_tcases
+	// arm runs AFTER the test restores the original SD, so the DACL is not
+	// the restriction under test here — the share mode is).
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+	fullAccessACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_WRITE_ATTRIBUTES | acl.ACE4_DELETE | acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, fname,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  requesterGID,
+			ACL:  fullAccessACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	// Seed the handler open table with the first handle (SHARE_READ only).
+	const (
+		fileReadData  uint32 = 0x00000001
+		fileShareRead uint32 = 0x01
+	)
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	firstFileID := h.GenerateFileID()
+	h.StoreOpenFile(&OpenFile{
+		FileID:         firstFileID,
+		TreeID:         smbCtx.TreeID,
+		SessionID:      smbCtx.SessionID,
+		Path:           fname,
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  fileReadData,
+		ShareAccess:    fileShareRead,
+		MetadataHandle: encHandle,
+	})
+
+	// Second handle: destructive disposition, READ_DATA, SHARE_READ.
+	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, fname,
+		fileReadData, fileShareRead, disposition, action)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSharingViolation {
+		t.Fatalf("disp=%d with SHARE_READ vs existing SHARE_READ-only holder: status = 0x%08x, expected STATUS_SHARING_VIOLATION (0x%08x)",
+			disposition, uint32(resp.Status), uint32(types.StatusSharingViolation))
+	}
+}
+
+// TestCreate_SupersedeWithReadShareConflictsExistingHolder covers
+// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases SUPERSEDE arm (#575) at
+// samba 4.22.6 source4/torture/smb2/acls.c:3175. The destructive disposition
+// implicitly requires FILE_WRITE_DATA, which conflicts with an existing
+// SHARE_READ-only handle.
+func TestCreate_SupersedeWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "supersede_share.txt", types.FileSupersede, types.FileSuperseded)
+}
+
+// TestCreate_OverwriteWithReadShareConflictsExistingHolder covers the
+// OVERWRITE arm of the same sharing_tcases loop (#575).
+func TestCreate_OverwriteWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "overwrite_share.txt", types.FileOverwrite, types.FileOverwritten)
+}
+
+// TestCreate_OverwriteIfWithReadShareConflictsExistingHolder covers the
+// OVERWRITE_IF arm of the same sharing_tcases loop (#575).
+func TestCreate_OverwriteIfWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "overwriteif_share.txt", types.FileOverwriteIf, types.FileOverwritten)
+}
+
+// TestCreate_OpenWithReadShareDoesNotConflictExistingHolder is the negative
+// control for #575: a non-destructive disposition (FILE_OPEN) with the same
+// READ_DATA + SHARE_READ shape against a SHARE_READ-only holder must succeed,
+// because the disposition-implied FILE_WRITE_DATA fold does not fire and the
+// raw DesiredAccess carries no write requirement.
+func TestCreate_OpenWithReadShareDoesNotConflictExistingHolder(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+	fullAccessACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, "open_share.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  requesterGID,
+			ACL:  fullAccessACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	const (
+		fileReadData  uint32 = 0x00000001
+		fileShareRead uint32 = 0x01
+	)
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:         h.GenerateFileID(),
+		TreeID:         smbCtx.TreeID,
+		SessionID:      smbCtx.SessionID,
+		Path:           "open_share.txt",
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  fileReadData,
+		ShareAccess:    fileShareRead,
+		MetadataHandle: encHandle,
+	})
+
+	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, "open_share.txt",
+		fileReadData, fileShareRead, types.FileOpen, types.FileOpened)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("FILE_OPEN READ_DATA + SHARE_READ vs SHARE_READ holder: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}
+
 // TestCreate_OpenRestrictedFileForRead_Succeeds is the positive control for
 // #565: the same READ-only DACL allows FILE_OPEN with DesiredAccess=READ_DATA
 // (the spec test's first row at acls.c:3088). Guards against the

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -64,6 +64,43 @@ func isDestructiveDisposition(d types.CreateDisposition) bool {
 	return false
 }
 
+// effectiveAccessForOpen folds disposition-implied access bits into the
+// client-requested DesiredAccess, mirroring Samba's `open_access_mask`
+// computation in source3/smbd/open.c::open_file_ntcreate:
+//
+//	open_access_mask = access_mask;
+//	if (flags & O_TRUNC) {
+//	    open_access_mask |= FILE_WRITE_DATA; /* This will cause oplock breaks. */
+//	}
+//
+// Per MS-FSA §2.1.5.1.2.1, OVERWRITE / OVERWRITE_IF / SUPERSEDE on an existing
+// file inherently truncate it and so require FILE_WRITE_DATA regardless of
+// what the client put in DesiredAccess. Samba uses `open_access_mask` for
+// BOTH the DACL access-rights check (smbd_check_access_rights_fsp) AND the
+// share-mode conflict check (open_mode_check). We mirror that here so:
+//   - a DACL granting only READ_DATA fails OVERWRITE/SUPERSEDE with
+//     STATUS_ACCESS_DENIED (smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm,
+//     #565)
+//   - an existing handle with SHARE_READ but no SHARE_WRITE causes a second
+//     destructive open to fail with STATUS_SHARING_VIOLATION (smb2.acls.
+//     OVERWRITE_READ_ONLY_FILE sharing_tcases arm, #575)
+//
+// MAXIMUM_ALLOWED skips the augmentation: MAX expansion already reflects the
+// requester's full effective rights without exposing the implied write as an
+// explicit-bit denial, and the share-mode `hasWrite` helper already keys off
+// MAX as implying write. Matches Samba — the FILE_WRITE_DATA fold only fires
+// for the non-MAX disposition path.
+func effectiveAccessForOpen(desiredAccess uint32, disposition types.CreateDisposition) uint32 {
+	const maxAllowedBit uint32 = 0x02000000
+	if desiredAccess&maxAllowedBit != 0 {
+		return desiredAccess
+	}
+	if !isDestructiveDisposition(disposition) {
+		return desiredAccess
+	}
+	return desiredAccess | uint32(types.FileWriteData)
+}
+
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
 // the post-break share-mode check, then decides between parking the CREATE on
 // an interim STATUS_PENDING (returning a non-zero AsyncId) or waiting
@@ -185,16 +222,31 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	createAction := d.createAction
 	excludeOwner := d.excludeOwner
 
+	// Compute the effective access mask once for both the share-mode conflict
+	// check below and the DACL access-rights check downstream. Mirrors Samba's
+	// `open_access_mask` (source3/smbd/open.c::open_file_ntcreate) which folds
+	// FILE_WRITE_DATA into the mask for O_TRUNC dispositions and then uses the
+	// augmented mask for BOTH checks. See effectiveAccessForOpen for spec refs.
+	effectiveAccess := effectiveAccessForOpen(req.DesiredAccess, req.CreateDisposition)
+
 	// Share-mode recheck (fileExists path) after any lease breaks have drained.
 	// A pre-break violation selected the Handle-strip break mask so the holder
 	// could close cached handles on ack; the recheck runs against the post-break
 	// open table to decide the final CREATE outcome.
+	//
+	// Uses effectiveAccess (not raw req.DesiredAccess) so a destructive
+	// disposition with a read-only DesiredAccess (e.g. SUPERSEDE+READ_DATA)
+	// still trips the SHARE_WRITE deny check against an existing SHARE_READ-only
+	// holder, returning STATUS_SHARING_VIOLATION. Covers
+	// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases arm (#575).
 	if fileExists && d.existingHandle != nil {
-		if shareConflict := h.checkShareModeConflict(d.existingHandle, req.DesiredAccess, req.ShareAccess, filename); shareConflict {
+		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, filename); shareConflict {
 			logger.Debug("CREATE: sharing violation",
 				"path", filename,
 				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
-				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess))
+				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
+				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess),
+				"disposition", req.CreateDisposition)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSharingViolation}}
 		}
 	}
@@ -228,30 +280,12 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			}
 		}
 
-		// Fold in disposition-implied access bits before the DACL check.
-		// Per MS-FSA §2.1.5.1.2.1 and Samba open_file_ntcreate (which sets
-		// `open_access_mask |= FILE_WRITE_DATA` when O_TRUNC is implied by
-		// the disposition), OVERWRITE / OVERWRITE_IF / SUPERSEDE on an
-		// existing file inherently truncate it and so REQUIRE FILE_WRITE_DATA
-		// to be granted by the DACL — independent of whether the client put
-		// WRITE_DATA in DesiredAccess. The Samba check runs against
-		// open_access_mask in smbd_check_access_rights_fsp; we mirror that
-		// by extending the mask passed to CheckFileAccessWithParent so a
-		// DACL that grants only READ_DATA fails OVERWRITE/SUPERSEDE with
-		// STATUS_ACCESS_DENIED. Covers smb2.acls.OVERWRITE_READ_ONLY_FILE
-		// (issue #565).
-		//
-		// Skipped when MAXIMUM_ALLOWED is set: MAX expansion lets the
-		// MaxAllowed branch report the granted mask without exposing the
-		// implied write requirement as an explicit-bit denial. Samba does
-		// the same — the FILE_WRITE_DATA augmentation only fires for the
-		// non-MAX disposition path.
-		effectiveAccess := req.DesiredAccess
-		const maxAllowedBit uint32 = 0x02000000
-		if effectiveAccess&maxAllowedBit == 0 && isDestructiveDisposition(req.CreateDisposition) {
-			effectiveAccess |= uint32(types.FileWriteData)
-		}
-
+		// effectiveAccess (computed above the share-mode check) folds the
+		// disposition-implied FILE_WRITE_DATA into the mask. The DACL check
+		// uses the same augmented mask Samba's smbd_check_access_rights_fsp
+		// receives, so a DACL that grants only READ_DATA fails OVERWRITE /
+		// OVERWRITE_IF / SUPERSEDE with STATUS_ACCESS_DENIED. Covers
+		// smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm (#565).
 		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
 		if err != nil {
 			logger.Debug("CREATE: DesiredAccess denied by DACL",


### PR DESCRIPTION
## Summary

PR #571 fixed `smb2.acls.OVERWRITE_READ_ONLY_FILE` for the `fs_tcases` arm (DACL-restricted destructive disposition) by folding `FILE_WRITE_DATA` into the mask used for the access-rights check. CI revealed the test advanced past that point and now fails on the `sharing_tcases` arm at samba 4.22.6 `source4/torture/smb2/acls.c:3175` with `expected NT_STATUS_SHARING_VIOLATION`.

Same #571-shaped fix, different code path. The destructive disposition's implicit `FILE_WRITE_DATA` must be folded into the mask used for the **share-mode conflict check** too — Samba's `open_file_ntcreate` uses a single `open_access_mask` for both checks, and we now do the same via a `effectiveAccessForOpen` helper.

## Repro

1. First handle: `CREATE(desired=READ_DATA, share=SHARE_READ, disp=OPEN_IF)` — succeeds.
2. Second handle: `CREATE(desired=READ_DATA, share=SHARE_READ, disp=SUPERSEDE|OVERWRITE|OVERWRITE_IF)`.
3. Pre-fix: `STATUS_OK` (bug — `hasWrite(raw req.DesiredAccess) == false`, so no conflict detected).
4. Post-fix: `STATUS_SHARING_VIOLATION` (matches Samba and the smbtorture assertion).

## Changes

- `internal/adapter/smb/v2/handlers/create_post_break.go`:
  - New `effectiveAccessForOpen(desired, disposition)` helper folding `FILE_WRITE_DATA` for destructive dispositions (mirrors Samba `open_access_mask |= FILE_WRITE_DATA` when `O_TRUNC`).
  - `completeCreateAfterBreak` computes `effectiveAccess` once, uses it for both `checkShareModeConflict` (the bug fix) and `CheckFileAccessWithParent` (replaces the inline fold added by #571 — semantically identical, deduplicated).
  - Same `MAXIMUM_ALLOWED` skip rule preserved.
  - Same client-visible grant masking preserved (strip the implied bit off returned `GrantedAccess` so `QUERY_INFO` reports only what was requested).
- `internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go`:
  - Three new tests, one per destructive disposition, asserting `STATUS_SHARING_VIOLATION` against a pre-seeded `SHARE_READ`-only holder.
  - `TestCreate_OpenWithReadShareDoesNotConflictExistingHolder` negative control: `FILE_OPEN` (non-destructive) does **not** trip the fold.

## Test plan

- [x] `go test ./internal/adapter/smb/v2/handlers/... -count=1` — all green including the existing #565 / #564 / share-mode-conflict tests.
- [x] `go test ./internal/adapter/smb/...` — all green.
- [x] `go vet ./...` clean.
- [ ] CI smbtorture run to confirm `smb2.acls.OVERWRITE_READ_ONLY_FILE` flips. `KNOWN_FAILURES.md` walkback in follow-up commit after CI confirms (per the "never touch KNOWN_FAILURES until CI confirms" workflow).

## Spec references

- MS-FSA §2.1.5.1.2.1 — Open of Existing File / Overwrite-Supersede rules
- MS-SMB2 §3.3.5.9 — CREATE share-mode check
- Samba `source3/smbd/open.c::open_file_ntcreate` lines ~3819-3822 (4.22.6) — `open_access_mask |= FILE_WRITE_DATA` for `O_TRUNC`, used for both `smbd_check_access_rights_fsp` and `open_mode_check`.

Closes #575
Refs #565 #571