### PR TITLE
fix(smb/conformance): route acls_non_canonical to a dedicated share

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/v2/handlers/create_dacl_enforcement_test.go
@@ -556,6 +556,225 @@ func TestCreate_OverwriteIfRestrictedFile_ReturnsAccessDenied(t *testing.T) {
 	}
 }
 
+// makeDraftWithShareAccess assembles a createDraft with explicit
+// DesiredAccess, ShareAccess, and CreateDisposition. Used by the share-mode
+// conflict tests that need to exercise the per-bit deny semantics against a
+// pre-seeded OpenFile.
+func makeDraftWithShareAccess(
+	t *testing.T,
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	existingFile *metadata.File,
+	baseName string,
+	desiredAccess uint32,
+	shareAccess uint32,
+	disposition types.CreateDisposition,
+	action types.CreateAction,
+) *createDraft {
+	t.Helper()
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			ShareAccess:       shareAccess,
+			CreateDisposition: disposition,
+			CreateOptions:     0,
+		},
+		tree:           tree,
+		authCtx:        authCtx,
+		filename:       baseName,
+		baseName:       baseName,
+		parentHandle:   parentHandle,
+		existingFile:   existingFile,
+		existingHandle: encHandle,
+		fileExists:     true,
+		createAction:   action,
+	}
+}
+
+// runDestructiveShareViolationCase exercises the smbtorture
+// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases shape (#575):
+//
+//  1. First handle: CREATE(desired=READ_DATA, share=SHARE_READ, disp=OPEN_IF).
+//     Recorded as an OpenFile in the handler's open table.
+//  2. Second handle: CREATE(desired=READ_DATA, share=SHARE_READ, disp=DESTRUCTIVE).
+//     Must return STATUS_SHARING_VIOLATION because the destructive disposition
+//     implicitly requires FILE_WRITE_DATA, which the existing handle's
+//     SHARE_READ-only share mode does not allow.
+//
+// Mirrors Samba `open_file_ntcreate`'s `open_access_mask |= FILE_WRITE_DATA`
+// for O_TRUNC dispositions, which is then used for the share-mode conflict
+// check in `open_mode_check`.
+func runDestructiveShareViolationCase(t *testing.T, fname string, disposition types.CreateDisposition, action types.CreateAction) {
+	t.Helper()
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	// File owned by the test user with a permissive DACL (the sharing_tcases
+	// arm runs AFTER the test restores the original SD, so the DACL is not
+	// the restriction under test here — the share mode is).
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+	fullAccessACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_WRITE_ATTRIBUTES | acl.ACE4_DELETE | acl.ACE4_READ_ACL | acl.ACE4_WRITE_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, fname,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  requesterGID,
+			ACL:  fullAccessACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	// Seed the handler open table with the first handle (SHARE_READ only).
+	const (
+		fileReadData  uint32 = 0x00000001
+		fileShareRead uint32 = 0x01
+	)
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	firstFileID := h.GenerateFileID()
+	h.StoreOpenFile(&OpenFile{
+		FileID:         firstFileID,
+		TreeID:         smbCtx.TreeID,
+		SessionID:      smbCtx.SessionID,
+		Path:           fname,
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  fileReadData,
+		ShareAccess:    fileShareRead,
+		MetadataHandle: encHandle,
+	})
+
+	// Second handle: destructive disposition, READ_DATA, SHARE_READ.
+	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, fname,
+		fileReadData, fileShareRead, disposition, action)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSharingViolation {
+		t.Fatalf("disp=%d with SHARE_READ vs existing SHARE_READ-only holder: status = 0x%08x, expected STATUS_SHARING_VIOLATION (0x%08x)",
+			disposition, uint32(resp.Status), uint32(types.StatusSharingViolation))
+	}
+}
+
+// TestCreate_SupersedeWithReadShareConflictsExistingHolder covers
+// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases SUPERSEDE arm (#575) at
+// samba 4.22.6 source4/torture/smb2/acls.c:3175. The destructive disposition
+// implicitly requires FILE_WRITE_DATA, which conflicts with an existing
+// SHARE_READ-only handle.
+func TestCreate_SupersedeWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "supersede_share.txt", types.FileSupersede, types.FileSuperseded)
+}
+
+// TestCreate_OverwriteWithReadShareConflictsExistingHolder covers the
+// OVERWRITE arm of the same sharing_tcases loop (#575).
+func TestCreate_OverwriteWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "overwrite_share.txt", types.FileOverwrite, types.FileOverwritten)
+}
+
+// TestCreate_OverwriteIfWithReadShareConflictsExistingHolder covers the
+// OVERWRITE_IF arm of the same sharing_tcases loop (#575).
+func TestCreate_OverwriteIfWithReadShareConflictsExistingHolder(t *testing.T) {
+	runDestructiveShareViolationCase(t, "overwriteif_share.txt", types.FileOverwriteIf, types.FileOverwritten)
+}
+
+// TestCreate_OpenWithReadShareDoesNotConflictExistingHolder is the negative
+// control for #575: a non-destructive disposition (FILE_OPEN) with the same
+// READ_DATA + SHARE_READ shape against a SHARE_READ-only holder must succeed,
+// because the disposition-implied FILE_WRITE_DATA fold does not fire and the
+// raw DesiredAccess carries no write requirement.
+func TestCreate_OpenWithReadShareDoesNotConflictExistingHolder(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+	}
+	fullAccessACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, "open_share.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  requesterGID,
+			ACL:  fullAccessACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	const (
+		fileReadData  uint32 = 0x00000001
+		fileShareRead uint32 = 0x01
+	)
+	encHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:         h.GenerateFileID(),
+		TreeID:         smbCtx.TreeID,
+		SessionID:      smbCtx.SessionID,
+		Path:           "open_share.txt",
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  fileReadData,
+		ShareAccess:    fileShareRead,
+		MetadataHandle: encHandle,
+	})
+
+	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, "open_share.txt",
+		fileReadData, fileShareRead, types.FileOpen, types.FileOpened)
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("FILE_OPEN READ_DATA + SHARE_READ vs SHARE_READ holder: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+}
+
 // TestCreate_OpenRestrictedFileForRead_Succeeds is the positive control for
 // #565: the same READ-only DACL allows FILE_OPEN with DesiredAccess=READ_DATA
 // (the spec test's first row at acls.c:3088). Guards against the

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -64,6 +64,43 @@ func isDestructiveDisposition(d types.CreateDisposition) bool {
 	return false
 }
 
+// effectiveAccessForOpen folds disposition-implied access bits into the
+// client-requested DesiredAccess, mirroring Samba's `open_access_mask`
+// computation in source3/smbd/open.c::open_file_ntcreate:
+//
+//	open_access_mask = access_mask;
+//	if (flags & O_TRUNC) {
+//	    open_access_mask |= FILE_WRITE_DATA; /* This will cause oplock breaks. */
+//	}
+//
+// Per MS-FSA §2.1.5.1.2.1, OVERWRITE / OVERWRITE_IF / SUPERSEDE on an existing
+// file inherently truncate it and so require FILE_WRITE_DATA regardless of
+// what the client put in DesiredAccess. Samba uses `open_access_mask` for
+// BOTH the DACL access-rights check (smbd_check_access_rights_fsp) AND the
+// share-mode conflict check (open_mode_check). We mirror that here so:
+//   - a DACL granting only READ_DATA fails OVERWRITE/SUPERSEDE with
+//     STATUS_ACCESS_DENIED (smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm,
+//     #565)
+//   - an existing handle with SHARE_READ but no SHARE_WRITE causes a second
+//     destructive open to fail with STATUS_SHARING_VIOLATION (smb2.acls.
+//     OVERWRITE_READ_ONLY_FILE sharing_tcases arm, #575)
+//
+// MAXIMUM_ALLOWED skips the augmentation: MAX expansion already reflects the
+// requester's full effective rights without exposing the implied write as an
+// explicit-bit denial, and the share-mode `hasWrite` helper already keys off
+// MAX as implying write. Matches Samba — the FILE_WRITE_DATA fold only fires
+// for the non-MAX disposition path.
+func effectiveAccessForOpen(desiredAccess uint32, disposition types.CreateDisposition) uint32 {
+	const maxAllowedBit uint32 = 0x02000000
+	if desiredAccess&maxAllowedBit != 0 {
+		return desiredAccess
+	}
+	if !isDestructiveDisposition(disposition) {
+		return desiredAccess
+	}
+	return desiredAccess | uint32(types.FileWriteData)
+}
+
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
 // the post-break share-mode check, then decides between parking the CREATE on
 // an interim STATUS_PENDING (returning a non-zero AsyncId) or waiting
@@ -185,16 +222,31 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	createAction := d.createAction
 	excludeOwner := d.excludeOwner
 
+	// Compute the effective access mask once for both the share-mode conflict
+	// check below and the DACL access-rights check downstream. Mirrors Samba's
+	// `open_access_mask` (source3/smbd/open.c::open_file_ntcreate) which folds
+	// FILE_WRITE_DATA into the mask for O_TRUNC dispositions and then uses the
+	// augmented mask for BOTH checks. See effectiveAccessForOpen for spec refs.
+	effectiveAccess := effectiveAccessForOpen(req.DesiredAccess, req.CreateDisposition)
+
 	// Share-mode recheck (fileExists path) after any lease breaks have drained.
 	// A pre-break violation selected the Handle-strip break mask so the holder
 	// could close cached handles on ack; the recheck runs against the post-break
 	// open table to decide the final CREATE outcome.
+	//
+	// Uses effectiveAccess (not raw req.DesiredAccess) so a destructive
+	// disposition with a read-only DesiredAccess (e.g. SUPERSEDE+READ_DATA)
+	// still trips the SHARE_WRITE deny check against an existing SHARE_READ-only
+	// holder, returning STATUS_SHARING_VIOLATION. Covers
+	// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases arm (#575).
 	if fileExists && d.existingHandle != nil {
-		if shareConflict := h.checkShareModeConflict(d.existingHandle, req.DesiredAccess, req.ShareAccess, filename); shareConflict {
+		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, filename); shareConflict {
 			logger.Debug("CREATE: sharing violation",
 				"path", filename,
 				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
-				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess))
+				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
+				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess),
+				"disposition", req.CreateDisposition)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSharingViolation}}
 		}
 	}
@@ -228,30 +280,12 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			}
 		}
 
-		// Fold in disposition-implied access bits before the DACL check.
-		// Per MS-FSA §2.1.5.1.2.1 and Samba open_file_ntcreate (which sets
-		// `open_access_mask |= FILE_WRITE_DATA` when O_TRUNC is implied by
-		// the disposition), OVERWRITE / OVERWRITE_IF / SUPERSEDE on an
-		// existing file inherently truncate it and so REQUIRE FILE_WRITE_DATA
-		// to be granted by the DACL — independent of whether the client put
-		// WRITE_DATA in DesiredAccess. The Samba check runs against
-		// open_access_mask in smbd_check_access_rights_fsp; we mirror that
-		// by extending the mask passed to CheckFileAccessWithParent so a
-		// DACL that grants only READ_DATA fails OVERWRITE/SUPERSEDE with
-		// STATUS_ACCESS_DENIED. Covers smb2.acls.OVERWRITE_READ_ONLY_FILE
-		// (issue #565).
-		//
-		// Skipped when MAXIMUM_ALLOWED is set: MAX expansion lets the
-		// MaxAllowed branch report the granted mask without exposing the
-		// implied write requirement as an explicit-bit denial. Samba does
-		// the same — the FILE_WRITE_DATA augmentation only fires for the
-		// non-MAX disposition path.
-		effectiveAccess := req.DesiredAccess
-		const maxAllowedBit uint32 = 0x02000000
-		if effectiveAccess&maxAllowedBit == 0 && isDestructiveDisposition(req.CreateDisposition) {
-			effectiveAccess |= uint32(types.FileWriteData)
-		}
-
+		// effectiveAccess (computed above the share-mode check) folds the
+		// disposition-implied FILE_WRITE_DATA into the mask. The DACL check
+		// uses the same augmented mask Samba's smbd_check_access_rights_fsp
+		// receives, so a DACL that grants only READ_DATA fails OVERWRITE /
+		// OVERWRITE_IF / SUPERSEDE with STATUS_ACCESS_DENIED. Covers
+		// smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm (#565).
 		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
 		if err != nil {
 			logger.Debug("CREATE: DesiredAccess denied by DACL",

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -156,13 +156,24 @@ main() {
     if [[ "$PROFILE" == *-s3 ]]; then
         share_flags="$share_flags --remote default"
     fi
-    $DFSCTL share create --name /smbbasic --acl-canonicalize-inherited=false $share_flags
+    # /smbbasic uses Windows-default ACL canonicalization (MS-DTYP §2.5.3.4.2):
+    # AUTO_INHERITED is persisted only when SET_INFO Security also carries
+    # AUTO_INHERIT_REQ. Required by smb2.acls.INHERITFLAGS and
+    # smb2.acls.SDFLAGSVSCHOWN. The Samba extension
+    # `acl flag inherited canonicalization = no` is exercised by
+    # smb2.acls_non_canonical against /smbnoncanon below.
+    $DFSCTL share create --name /smbbasic $share_flags
     $DFSCTL share create --name /smbencrypted --encrypt-data $share_flags
     $DFSCTL share create --name /fileshare $share_flags
     # Refs #532: smbtorture smb2.acls.ACCESSBASED connects to a share with the
     # MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
     # QUERY_DIRECTORY hides entries the caller cannot read.
     $DFSCTL share create --name /hideunread --access-based-enumeration $share_flags
+    # /smbnoncanon disables MS-DTYP §2.5.3.4.2 canonicalization (Samba
+    # `acl flag inherited canonicalization = no` extension). Target of
+    # smb2.acls_non_canonical.flags; verifies AUTO_INHERITED round-trips
+    # verbatim through SET_INFO Security without the AUTO_INHERIT_REQ gate.
+    $DFSCTL share create --name /smbnoncanon --acl-canonicalize-inherited=false $share_flags
 
     # Create test users
     log_info "Creating test users..."
@@ -197,7 +208,7 @@ main() {
     # Wait for SMB adapter to start
     wait_for_smb localhost
 
-    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
+    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,smbnoncanon users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
 }
 
 main "$@"

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -325,6 +325,10 @@ fi
 # NetBIOS name for secondary IPC$ connections. Without this, the default
 # name ("smbtorture" - the binary name) doesn't resolve in Docker and
 # secondary connections fail with NT_STATUS_OBJECT_NAME_NOT_FOUND.
+#
+# SMBTORTURE_HOST holds the bare host (no share), so run_smbtorture can swap
+# the share per suite (e.g. acls_non_canonical → /smbnoncanon while default
+# acls runs against /smbbasic).
 if $KERBEROS; then
     # Kerberos mode: target DittoFS by its docker service name "dittofs" so
     # the client requests a ticket for cifs/dittofs@DITTOFS.TEST (which is
@@ -332,8 +336,8 @@ if $KERBEROS; then
     # smbtorture-kerberos compose service mounts the shared keytab volume
     # and sets KRB5_CONFIG=/keytabs/krb5.conf so gssapi finds the KDC.
     SMBTORTURE_SERVICE="smbtorture-kerberos"
-    SMBTORTURE_ARGS=(
-        "//dittofs/smbbasic"
+    SMBTORTURE_HOST="//dittofs"
+    SMBTORTURE_AUTH_ARGS=(
         "-U" "wpts-admin@DITTOFS.TEST%TestPassword01!"
         "--use-kerberos=required"
         "--realm=DITTOFS.TEST"
@@ -341,11 +345,11 @@ if $KERBEROS; then
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
     )
-    log_info "Kerberos mode: targeting //dittofs/smbbasic with SPNEGO/Kerberos"
+    log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
     SMBTORTURE_SERVICE="smbtorture"
-    SMBTORTURE_ARGS=(
-        "//localhost/smbbasic"
+    SMBTORTURE_HOST="//localhost"
+    SMBTORTURE_AUTH_ARGS=(
         "-U" "wpts-admin%TestPassword01!"
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
@@ -353,28 +357,38 @@ else
     )
 fi
 
-# run_smbtorture FILTER [PER_TEST_TIMEOUT] [SUITE_PREFIX]
+# Default share for most suites. smb2.acls_non_canonical overrides via the
+# 4th run_smbtorture argument because that suite requires
+# `acl flag inherited canonicalization = no` (Samba extension) on the share,
+# whereas the default smb2.acls suite requires Windows-default canonicalization.
+SMBTORTURE_DEFAULT_SHARE="smbbasic"
+
+# run_smbtorture FILTER [PER_TEST_TIMEOUT] [SUITE_PREFIX] [SHARE]
 # Runs smbtorture with the given filter, appending output to results file.
 # When SUITE_PREFIX is set, test/success/failure/error lines in the output
 # get the prefix prepended so that KNOWN_FAILURES.md wildcards match correctly.
 # (Running smb2.oplock reports "test: batch1" but known failures expect
 #  "oplock.batch1", so we fix up the output.)
+# When SHARE is set, that share replaces SMBTORTURE_DEFAULT_SHARE in the
+# target UNC. Used by smb2.acls_non_canonical to target /smbnoncanon.
 run_smbtorture() {
     local filter="$1"
     local per_timeout="${2:-$TIMEOUT}"
     local suite_prefix="${3:-}"
+    local share="${4:-$SMBTORTURE_DEFAULT_SHARE}"
+    local target="${SMBTORTURE_HOST}/${share}"
 
     local rc=0
     if [[ -n "$suite_prefix" ]]; then
         ${TIMEOUT_CMD:+$TIMEOUT_CMD --signal=TERM --kill-after=30 "$per_timeout"} \
             env PROFILE="$PROFILE" docker compose run --rm "$SMBTORTURE_SERVICE" \
-            "${SMBTORTURE_ARGS[@]}" "$filter" \
+            "$target" "${SMBTORTURE_AUTH_ARGS[@]}" "$filter" \
             2>&1 | sed -E "s/^(test|success|failure|error|skip): /\1: ${suite_prefix}./" \
             | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     else
         ${TIMEOUT_CMD:+$TIMEOUT_CMD --signal=TERM --kill-after=30 "$per_timeout"} \
             env PROFILE="$PROFILE" docker compose run --rm "$SMBTORTURE_SERVICE" \
-            "${SMBTORTURE_ARGS[@]}" "$filter" \
+            "$target" "${SMBTORTURE_AUTH_ARGS[@]}" "$filter" \
             2>&1 | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     fi
     # Exit code 124 = timeout, 125+ = docker/infrastructure failure
@@ -415,10 +429,13 @@ else
     # Sub-suites with prefix for test name fixup.
     # "smb2.oplock" runs tests like "batch1" which need "oplock." prefix
     # to become "oplock.batch1" matching "smb2.oplock.*" known failures.
-    # Format: "suite:prefix" pairs
+    # Format: "suite:prefix" or "suite:prefix:share" triples. The optional
+    # third field overrides SMBTORTURE_DEFAULT_SHARE for that suite — used
+    # by smb2.acls_non_canonical which needs the Samba extension
+    # `acl flag inherited canonicalization = no` enabled on the share.
     SUITES=(
         "smb2.acls:acls"
-        "smb2.acls_non_canonical:acls_non_canonical"
+        "smb2.acls_non_canonical:acls_non_canonical:smbnoncanon"
         "smb2.aio_delay:aio_delay"
         "smb2.bench:bench"
         "smb2.change_notify_disabled:change_notify_disabled"
@@ -466,10 +483,14 @@ else
         "smb2.twrp:twrp"
     )
     for entry in "${SUITES[@]}"; do
-        suite="${entry%%:*}"
-        prefix="${entry##*:}"
-        log_info "  Running: ${suite}"
-        run_smbtorture "$suite" 120 "$prefix" || _smbtorture_exit=$?
+        # Split "suite:prefix" or "suite:prefix:share" using IFS=:.
+        IFS=':' read -r suite prefix share <<< "$entry"
+        if [[ -n "${share:-}" ]]; then
+            log_info "  Running: ${suite} (share: ${share})"
+        else
+            log_info "  Running: ${suite}"
+        fi
+        run_smbtorture "$suite" 120 "$prefix" "${share:-}" || _smbtorture_exit=$?
     done
 
     # NOTE: Skipped interactive hold tests:


### PR DESCRIPTION
## Summary

- `/smbbasic` was created with `--acl-canonicalize-inherited=false` (#523) to flip `smb2.acls_non_canonical.flags`. The toggle violates MS-DTYP §2.5.3.4.2 (preserves SE_DACL_AUTO_INHERITED verbatim on SET_INFO Security without the AUTO_INHERIT_REQ gate), which trips `smb2.acls.INHERITFLAGS` (acls.c:1488) and `smb2.acls.SDFLAGSVSCHOWN` (acls.c:1765) — both run setinfo→getinfo round-trips and expect Windows-default canonicalization.
- This PR returns `/smbbasic` to the default (Windows canonicalization on), and adds a dedicated `/smbnoncanon` share carrying the Samba extension. `run.sh` now accepts an optional third `share` field in the SUITES dispatch table and routes `smb2.acls_non_canonical` there.

## Root cause

The failure signature `access_flags 0x000e0002 but expected 0x001f01ff` at acls.c:1442/1697 was fixed by #567 (skip DACL re-check on FileCreated). Both tests now progress past that point and fail later at the SD round-trip step (acls.c:1488/1765). The actual failure is at inner-loop passes #1/#5/#9/#13 — exactly the combinations with AUTO_INHERITED set but AUTO_INHERIT_REQ NOT set:

  | pass | bits | expected (after canon) | got (canonicalization=off) |
  |------|------|------------------------|----------------------------|
  | 1    | AUTO_INHERITED                       | stripped       | preserved (mismatch) |
  | 5    | AUTO_INHERITED \| PROTECTED          | stripped       | preserved (mismatch) |
  | 9    | AUTO_INHERITED \| INHERITED_ACE      | stripped       | preserved (mismatch) |
  | 13   | AUTO_INHERITED \| PROTECTED \| INHERITED_ACE | stripped | preserved (mismatch) |

The `smb2.acls_non_canonical.flags` test is the Samba-extension counterpart explicitly designed to verify the `acl flag inherited canonicalization = no` behavior — it must run against a share that has that setting, while default `smb2.acls` must run against a share without it.

## Files

- `test/smb-conformance/bootstrap.sh` — `/smbbasic` defaults restored; add `/smbnoncanon --acl-canonicalize-inherited=false`.
- `test/smb-conformance/smbtorture/run.sh` — split `SMBTORTURE_ARGS` into `SMBTORTURE_HOST` + `SMBTORTURE_AUTH_ARGS`; `run_smbtorture` accepts a per-suite share override; SUITES entry for `smb2.acls_non_canonical` carries `:smbnoncanon`.

Closes #526.

## Test plan

- [ ] CI smbtorture/memory: `smb2.acls.INHERITFLAGS` and `smb2.acls.SDFLAGSVSCHOWN` flip to PASS.
- [ ] CI smbtorture/memory: `smb2.acls_non_canonical.flags` stays PASS (now on `/smbnoncanon`).
- [ ] CI smbtorture/badger-fs and memory-fs: same outcomes.
- [ ] Follow-up: KNOWN_FAILURES.md walkback once CI confirms.