### PR TITLE
fix(fs): address Copilot review on PR #566 (Direction-1 rollup)

### DIFF
--- a/pkg/blockstore/local/fs/appendlog.go
+++ b/pkg/blockstore/local/fs/appendlog.go
@@ -29,6 +29,14 @@ const (
 	logHeaderSize       = 64
 	recordFrameOverhead = 16 // payload_len(4) + file_offset(8) + crc(4)
 	logVersion          = uint32(1)
+	// maxRecordPayload (FIX-4) clamps the per-record payload allocation.
+	// A torn-tail or hostile log frame can present an arbitrary 32-bit
+	// payload_len; without a cap, recovery / rollup replay would attempt
+	// a 4 GiB-1 allocation per bad frame → OOM / DoS. Set just above the
+	// chunker's hard maximum (16 MiB) plus slack so legitimate records
+	// always pass; anything larger is treated as corruption and the
+	// caller (LSL-06) truncates the log at the previous valid position.
+	maxRecordPayload = 17 * 1024 * 1024
 )
 
 // logMagic is the fixed 4-byte prefix of every DittoFS append log: 'DFLG'.
@@ -156,15 +164,8 @@ func readRecord(r io.Reader) (uint64, []byte, bool, error) {
 	payloadLen := binary.LittleEndian.Uint32(frame[0:4])
 	fileOffset := binary.LittleEndian.Uint64(frame[4:12])
 	wantCRC := binary.LittleEndian.Uint32(frame[12:16])
-	// FIX-4: clamp the per-record payload allocation. A torn-tail or
-	// hostile log frame can present an arbitrary 32-bit payload_len;
-	// without a cap, recovery (or any rollup replay) would attempt a
-	// 4 GiB-1 allocation per bad frame → OOM / DoS. The cap is set just
-	// above the chunker's hard maximum (16 MiB) plus slack so legitimate
-	// records always pass; anything larger is treated as corruption and
-	// the caller (LSL-06) truncates the log at the previous valid
-	// position.
-	const maxRecordPayload = 17 * 1024 * 1024
+	// FIX-4: clamp via the file-scope maxRecordPayload cap (defined
+	// alongside the framing constants).
 	if payloadLen > maxRecordPayload {
 		return 0, nil, false, nil
 	}
@@ -191,14 +192,21 @@ func readRecord(r io.Reader) (uint64, []byte, bool, error) {
 // record (frame header + payload) instead of two sequential reads.
 //
 // Returns the decoded file_offset and the payload bytes. Errors:
+//   - payloadLen exceeds the maxRecordPayload DoS cap (also enforced
+//     by readRecord; mirrored here so a pathological logIndex entry
+//     cannot drive a multi-GB allocation if memory corruption ever
+//     forged one)
 //   - the pread returned an I/O error / short read
 //   - the frame's declared payload_len disagrees with the index
 //   - CRC over (file_offset || payload) mismatches the stored CRC
 //
-// All three indicate either log-fd corruption or a logIndex/log
-// divergence bug — the caller (rollup) treats them as a hard failure
-// and skips the rollup pass so a future attempt can reseed.
+// All cases indicate either log-fd corruption or a logIndex/log
+// divergence bug — the caller (rollup) surfaces them as a hard error.
 func readRecordAt(rf io.ReaderAt, logPos uint64, payloadLen uint32) (uint64, []byte, error) {
+	if payloadLen > maxRecordPayload {
+		return 0, nil, fmt.Errorf("append log: payloadLen %d exceeds %d cap at logPos=%d",
+			payloadLen, maxRecordPayload, logPos)
+	}
 	total := uint64(recordFrameOverhead) + uint64(payloadLen)
 	buf := make([]byte, total)
 	if _, err := rf.ReadAt(buf, int64(logPos)); err != nil {

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -59,6 +59,12 @@ type logIndex struct {
 	entries         []logEntry
 	consumed        map[uint64]struct{} // key = logEntry.logPos
 	compactionFence uint64
+	// fenceCursor is the index into `entries` of the first entry whose
+	// logPos is at or beyond compactionFence. AdvanceFence resumes its
+	// walk from this cursor instead of rescanning the entire slice on
+	// every call, keeping amortized cost proportional to the entries
+	// it newly consumes rather than the historical entry count.
+	fenceCursor int
 }
 
 // newLogIndex constructs an empty logIndex. compactionFence starts at
@@ -90,12 +96,20 @@ func (idx *logIndex) Append(logPos uint64, fileOff uint64, payloadLen uint32) {
 // FastCDC over the canonical stream while still walking out-of-order
 // arrivals.
 //
-// Length == 0 returns nil.
+// Length == 0 returns nil. The fileOff + length sum is computed with
+// overflow detection: a query that would wrap past math.MaxUint64
+// saturates end to MaxUint64 so the overlap predicate stays well-
+// formed (no record can have fileOff == MaxUint64 in practice — the
+// log can't store payloads near that scale — but the cheap guard
+// prevents pathological queries from missing genuine overlaps).
 func (idx *logIndex) EntriesForInterval(fileOff uint64, length uint64) []logEntry {
 	if length == 0 {
 		return nil
 	}
 	end := fileOff + length
+	if end < fileOff {
+		end = ^uint64(0)
+	}
 	out := make([]logEntry, 0, 4)
 	for _, e := range idx.entries {
 		if e.fileEnd() <= fileOff {
@@ -116,25 +130,29 @@ func (idx *logIndex) MarkConsumed(logPos uint64) {
 }
 
 // AdvanceFence walks consumed entries in logPos order from the current
-// fence forward, advancing compactionFence past every entry that is
-// consumed and contiguous. Stops at the first non-consumed entry. The
-// new fence is returned. An out-of-order consumed entry (a "hole" left
-// by an unconsumed predecessor) does NOT advance the fence — it stays
-// in `consumed` until the predecessor is consumed too.
+// fenceCursor forward, advancing compactionFence past every entry that
+// is consumed and contiguous. Stops at the first non-consumed entry.
+// The new fence is returned. An out-of-order consumed entry (a "hole"
+// left by an unconsumed predecessor) does NOT advance the fence — it
+// stays in `consumed` until the predecessor is consumed too.
+//
+// fenceCursor tracks the first entry index at or beyond the current
+// fence so repeated calls cost O(newly-consumed-entries) rather than
+// O(total-entries), avoiding quadratic walks across long-lived
+// payloads.
 //
 // This is the operation the rollup invokes after persisting a CAS
 // commit; the returned fence is what advanceRollupOffset eventually
 // writes to disk.
 func (idx *logIndex) AdvanceFence() uint64 {
-	for _, e := range idx.entries {
-		if e.logPos < idx.compactionFence {
-			continue
-		}
+	for idx.fenceCursor < len(idx.entries) {
+		e := idx.entries[idx.fenceCursor]
 		if _, ok := idx.consumed[e.logPos]; !ok {
 			break
 		}
 		// Fence advances past the consumed entry's full record extent.
 		idx.compactionFence = e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen)
+		idx.fenceCursor++
 	}
 	return idx.compactionFence
 }
@@ -151,8 +169,14 @@ func (idx *logIndex) Fence() uint64 {
 // the boot-time rollup_offset preserves that invariant for the
 // post-boot AdvanceFence walks. MUST be called before any MarkConsumed
 // /AdvanceFence calls on the same logIndex.
+//
+// fenceCursor is rewound to 0 — recovery seeds entries in order, so
+// the cursor naturally starts at the head of the slice; subsequent
+// AdvanceFence calls will skip past any pre-fence entries on the first
+// invocation only.
 func (idx *logIndex) SetFence(fence uint64) {
 	idx.compactionFence = fence
+	idx.fenceCursor = 0
 }
 
 // Len returns the total number of indexed entries (consumed + unconsumed).

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -221,3 +221,62 @@ func TestLogIndex_AdvanceFence_NoConsumed_NoMove(t *testing.T) {
 		}
 	}
 }
+
+// TestLogIndex_AdvanceFence_CursorSkipsConsumed exercises the
+// fenceCursor optimization: after a partial advance, repeated
+// AdvanceFence calls must not rescan entries that were already
+// fence-passed. We can't observe big-O directly, but we can prove
+// correctness by appending more entries AFTER a partial advance and
+// verifying the cursor picks them up without rewalking the prefix.
+func TestLogIndex_AdvanceFence_CursorSkipsConsumed(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(64)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+	for i := 0; i < 3; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		idx.MarkConsumed(pos)
+		pos += step
+	}
+	wantAfterThree := uint64(logHeaderSize) + 3*step
+	if got := idx.AdvanceFence(); got != wantAfterThree {
+		t.Fatalf("after 3 consumed: got %d want %d", got, wantAfterThree)
+	}
+	// Append two more entries, mark both consumed, AdvanceFence again.
+	for i := 3; i < 5; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		idx.MarkConsumed(pos)
+		pos += step
+	}
+	wantAfterFive := uint64(logHeaderSize) + 5*step
+	if got := idx.AdvanceFence(); got != wantAfterFive {
+		t.Fatalf("after 5 consumed: got %d want %d", got, wantAfterFive)
+	}
+}
+
+// TestLogIndex_EntriesForInterval_OverflowGuard verifies that a query
+// whose fileOff + length sum wraps past MaxUint64 still returns the
+// expected records — the saturating end calculation prevents the
+// overlap predicate from misclassifying high-offset entries.
+func TestLogIndex_EntriesForInterval_OverflowGuard(t *testing.T) {
+	idx := newLogIndex()
+	// Three entries, the last one near (but not at) MaxUint64.
+	idx.Append(logHeaderSize, 0, 100)
+	idx.Append(logHeaderSize+100+recordFrameOverhead, 1024, 100)
+	idx.Append(logHeaderSize+2*(100+recordFrameOverhead), ^uint64(0)-200, 100)
+
+	// Query [^uint64(0)-300, ^uint64(0)-50): sum overflows but should
+	// still surface the third record.
+	hits := idx.EntriesForInterval(^uint64(0)-300, 250)
+	if len(hits) != 1 || hits[0].fileOff != ^uint64(0)-200 {
+		t.Fatalf("overflow query: got %+v want one entry at fileOff %d", hits, ^uint64(0)-200)
+	}
+
+	// Query at fileOff = ^uint64(0) - 50 with length = 100 (definite
+	// overflow). End saturates to MaxUint64; no entries should match
+	// since the high record's extent ends at ^uint64(0) - 100.
+	hits = idx.EntriesForInterval(^uint64(0)-50, 100)
+	if len(hits) != 0 {
+		t.Fatalf("post-extent query: got %+v want []", hits)
+	}
+}

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -183,10 +183,11 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
-	// Read the log header to learn the current rollup_offset (used below
-	// only as the prior fence the new advance is compared against).
-	hdr, err := readLogHeader(lf.f)
-	if err != nil {
+	// Read + validate the log header. Direction-1 no longer uses
+	// hdr.RollupOffset for any computation (the in-memory idx.Fence is
+	// the truth), but the read still serves as a corruption sanity
+	// check before we issue preads against the same fd.
+	if _, err := readLogHeader(lf.f); err != nil {
 		slog.Warn("rollup: read header", "payloadID", payloadID, "error", err)
 		return err
 	}
@@ -201,7 +202,16 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	stableEnd := stable.Offset + uint64(stable.Length)
 	entries := idx.EntriesForInterval(stable.Offset, uint64(stable.Length))
 	if len(entries) == 0 {
-		return nil
+		// The tree reported a stable interval the logIndex cannot back —
+		// only possible under a tree/logIndex divergence (e.g. AppendWrite
+		// inserted into the tree but skipped the logIndex append, or
+		// recovery rebuilt the tree from records the index missed).
+		// Returning nil here would silently re-queue the same dirty
+		// interval indefinitely; surface a hard error so the worker pool
+		// logs it and a future pass after recovery / restart can retry
+		// from a known-good state.
+		return fmt.Errorf("rollup: tree/logIndex divergence — stable interval [%d,%d) has no logIndex entries",
+			stable.Offset, stableEnd)
 	}
 
 	rf, err := os.Open(lf.path)
@@ -217,17 +227,15 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		if rerr != nil {
 			// A CRC mismatch or pread failure at a record the logIndex
 			// claims is valid implies log-fd corruption or a logIndex/
-			// log divergence bug. Treat as a hard fail for this pass —
-			// metadata stays unchanged, the tree keeps the interval
-			// dirty, a future pass (possibly after recovery) can retry.
-			slog.Warn("rollup: readRecordAt", "payloadID", payloadID,
-				"logPos", e.logPos, "error", rerr)
-			return nil
+			// log divergence bug. Returning nil here would re-queue the
+			// interval forever — surface a hard error instead so the
+			// worker pool's error log captures the divergence and
+			// operators can inspect the log fd.
+			return fmt.Errorf("rollup: readRecordAt(logPos=%d): %w", e.logPos, rerr)
 		}
 		if off != e.fileOff {
-			slog.Warn("rollup: logIndex fileOff mismatch", "payloadID", payloadID,
-				"logPos", e.logPos, "indexed", e.fileOff, "frame", off)
-			return nil
+			return fmt.Errorf("rollup: logIndex fileOff divergence at logPos=%d (indexed=%d frame=%d)",
+				e.logPos, e.fileOff, off)
 		}
 		recs = append(recs, rec{
 			off:     off,
@@ -382,6 +390,14 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// entry preceded by an unconsumed predecessor does NOT advance the
 	// fence; the chunks are committed but the on-disk log byte prefix
 	// stays anchored until the predecessor is consumed too (R-7).
+	//
+	// priorFence is captured BEFORE MarkConsumed/AdvanceFence so the
+	// budget-release math at the bottom uses the in-memory fence delta
+	// (truth) rather than (targetPos - hdr.RollupOffset). The log header
+	// is derived state that can lag if a prior advanceRollupOffset
+	// failed — using it to compute reclaimed would double-decrement
+	// logBytesTotal on the recovery-from-stale-header path.
+	priorFence := idx.Fence()
 	for _, lp := range consumedPositions {
 		idx.MarkConsumed(lp)
 	}
@@ -438,11 +454,14 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	}
 
 	// Consume the dirty interval(s) this rollup just covered and release
-	// the corresponding log budget.
-	reclaimed := int64(targetPos - hdr.RollupOffset)
+	// the corresponding log budget. Reclaimed bytes are measured against
+	// the in-memory priorFence, NOT hdr.RollupOffset — the log header is
+	// derived state that may lag the metadata-authoritative fence after
+	// a prior advanceRollupOffset failure, and basing reclaimed on the
+	// stale header would double-decrement budget on the next pass.
 	tree.ConsumeUpTo(stableEnd)
-	if reclaimed > 0 {
-		bc.logBytesTotal.Add(-reclaimed)
+	if targetPos > priorFence {
+		bc.logBytesTotal.Add(-int64(targetPos - priorFence))
 	}
 
 	// Non-blocking signal to unblock any AppendWrite waiting on pressure.


### PR DESCRIPTION
## Summary

Follow-up to #566 — two commits land the Copilot review fixes that were pushed shortly after the squash merge and therefore missed the original ship.

### Correctness (`5d1a067e`)

1. **Divergence cases now return errors, not nil.** Three sites in `rollupFile` (empty `EntriesForInterval` against a non-empty stable interval, `readRecordAt` failure, indexed-vs-frame fileOff mismatch) used to return nil — the dirty interval stayed in the tree forever and the worker pool's error log never surfaced the divergence. They now return wrapped errors so the same retry surfaces in operator logs.

2. **Budget release is computed from `idx.Fence()`, not `hdr.RollupOffset`.** The log header is derived state and lags the metadata-authoritative fence after a prior `advanceRollupOffset` failure; basing `reclaimed` on the stale header double-decrements `logBytesTotal` on the next pass. `priorFence` is now captured before `MarkConsumed/AdvanceFence` and used for the budget delta.

3. The header read is kept as a corruption sanity check; its value is no longer used downstream.

### Defensive + perf (`2fa3be2d`)

1. **`logIndex.AdvanceFence` cursor optimization.** Previously O(total entries) per call; with long-lived payloads the total work grew quadratically across rollup passes. A new `fenceCursor` field tracks the first entry at or beyond `compactionFence`, so per-call cost is proportional to newly-consumed entries. `SetFence` rewinds the cursor to 0 to match the recovery seed-from-effectiveOff invariant.

2. **`EntriesForInterval` overflow guard.** `fileOff + length` could wrap past `MaxUint64` on pathological queries; the saturating end calc keeps the overlap predicate well-formed.

3. **`readRecordAt` payload cap.** Promoted `maxRecordPayload` from a function-local const inside `readRecord` to a file-scope const so `readRecordAt` can also enforce it. Without the cap a memory-corrupted logIndex entry could drive a multi-GB allocation.

Two new tests cover the new code:
- `TestLogIndex_AdvanceFence_CursorSkipsConsumed`: partial-advance + later-appends scenario, verifies the cursor picks up new consumption without rewalking pre-fence entries.
- `TestLogIndex_EntriesForInterval_OverflowGuard`: high-fileOff records with a query whose sum overflows MaxUint64.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/blockstore/local/fs/ -race -count=1` — green (one independently-known flake on `TestAppendWrite_DeleteRace_NoDeadlock` cleared on rerun)
- [ ] CI: full suite

Copilot review thread: https://github.com/marmos91/dittofs/pull/566