### PR TITLE
fix(smb): DOS file attribute round-trip on files and directories (refs #476)

### DIFF
--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -219,15 +219,7 @@ func FileAttrToSMBTimes(attr *metadata.FileAttr) (creation, access, write, chang
 // Note: callers that have the filename available should prefer
 // FileAttrToFileBasicInfoWithName so the dot-prefix IsHiddenFile check applies.
 func FileAttrToFileBasicInfo(attr *metadata.FileAttr) *FileBasicInfo {
-	creation, access, write, change := FileAttrToSMBTimes(attr)
-
-	return &FileBasicInfo{
-		CreationTime:   creation,
-		LastAccessTime: access,
-		LastWriteTime:  write,
-		ChangeTime:     change,
-		FileAttributes: FileAttrToSMBAttributes(attr),
-	}
+	return FileAttrToFileBasicInfoWithName(attr, "")
 }
 
 // FileAttrToFileBasicInfoWithName is the name-aware variant of
@@ -274,20 +266,7 @@ func FileAttrToFileStandardInfo(attr *metadata.FileAttr, isDeletePending bool) *
 // Note: callers that have the filename available should prefer
 // FileAttrToFileNetworkOpenInfoWithName so the dot-prefix IsHiddenFile check applies.
 func FileAttrToFileNetworkOpenInfo(attr *metadata.FileAttr) *FileNetworkOpenInfo {
-	creation, access, write, change := FileAttrToSMBTimes(attr)
-	// Get appropriate size (MFsymlink size for symlinks)
-	size := getSMBSize(attr)
-	allocationSize := calculateAllocationSize(size)
-
-	return &FileNetworkOpenInfo{
-		CreationTime:   creation,
-		LastAccessTime: access,
-		LastWriteTime:  write,
-		ChangeTime:     change,
-		AllocationSize: allocationSize,
-		EndOfFile:      size,
-		FileAttributes: FileAttrToSMBAttributes(attr),
-	}
+	return FileAttrToFileNetworkOpenInfoWithName(attr, "")
 }
 
 // FileAttrToFileNetworkOpenInfoWithName is the name-aware variant of
@@ -295,6 +274,7 @@ func FileAttrToFileNetworkOpenInfo(attr *metadata.FileAttr) *FileNetworkOpenInfo
 // surface FILE_ATTRIBUTE_HIDDEN.
 func FileAttrToFileNetworkOpenInfoWithName(attr *metadata.FileAttr, name string) *FileNetworkOpenInfo {
 	creation, access, write, change := FileAttrToSMBTimes(attr)
+	// Get appropriate size (MFsymlink size for symlinks)
 	size := getSMBSize(attr)
 	allocationSize := calculateAllocationSize(size)
 

--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -46,6 +46,16 @@ const (
 	// handle close/reopen cycles.
 	modeDOSCompressed = uint32(0x40000)
 
+	// modeDOSReadonly tracks the DOS READONLY bit when DOS attributes have been
+	// explicitly set via SET_INFO FileBasicInformation. Storing READONLY in a
+	// high mode bit (rather than stripping owner-write from POSIX permissions)
+	// keeps the POSIX-derived DACL stable across attribute toggles — required
+	// by smbtorture smb2.winattr which captures the synthesized SD before any
+	// SET_INFO and asserts the ACEs are unchanged after each attribute round-trip
+	// (source4/torture/smb2/attr.c:365). Mirrors Samba's xattr-stored DOSMODE in
+	// source3/smbd/dosmode.c, which decouples DOS bits from POSIX mode.
+	modeDOSReadonly = uint32(0x100000)
+
 	// filetimeFreeze is the FILETIME sentinel value -1 (0xFFFFFFFFFFFFFFFF).
 	// Per MS-FSA 2.1.5.14.2: The object store MUST NOT change this attribute
 	// for this or subsequent operations on this handle.
@@ -116,6 +126,14 @@ func fileAttrToSMBAttributesInternal(attr *metadata.FileAttr, hidden bool) types
 	switch attr.Type {
 	case metadata.FileTypeDirectory:
 		attrs |= types.FileAttributeDirectory
+		// Per smbtorture smb2.winattr (source4/torture/smb2/attr.c:439):
+		// directories honour explicit DOS ARCHIVE round-trip when set via
+		// SET_INFO. When modeDOSExplicit is unset, directories report no
+		// ARCHIVE (matching MS-FSCC §2.6 — ARCHIVE on a directory is a
+		// client-managed bit, not server-default).
+		if attr.Mode&modeDOSExplicit != 0 && attr.Mode&modeDOSArchive != 0 {
+			attrs |= types.FileAttributeArchive
+		}
 	case metadata.FileTypeRegular:
 		// Per MS-FSCC, ARCHIVE is set by default for regular files. However,
 		// when DOS attributes have been explicitly set via SET_INFO, honour the
@@ -134,10 +152,19 @@ func fileAttrToSMBAttributesInternal(attr *metadata.FileAttr, hidden bool) types
 		// Special files appear as regular files (though they should be filtered out)
 	}
 
-	// Per MS-FSCC 2.6: FILE_ATTRIBUTE_READONLY is set when the file's
-	// Unix mode has no owner-write bit (mode & 0200 == 0).
-	// This reflects SET_INFO operations that applied READONLY.
-	if attr.Type == metadata.FileTypeRegular && (attr.Mode&0200) == 0 {
+	// Per MS-FSCC §2.6: FILE_ATTRIBUTE_READONLY round-trip via SET_INFO
+	// FileBasicInformation. We store the bit in modeDOSReadonly rather than
+	// stripping POSIX owner-write so the mode-synthesized DACL is stable —
+	// smb2.winattr (source4/torture/smb2/attr.c:365) verifies the DACL ACEs
+	// don't change across READONLY toggles. The legacy fallback (owner-write
+	// missing) is retained for files whose POSIX permissions were set out-of-band
+	// via NFS chmod or shell chmod — those must still report READONLY to SMB
+	// clients (matching Samba dosmode.c::dos_mode_from_sbuf).
+	if attr.Mode&modeDOSExplicit != 0 {
+		if attr.Mode&modeDOSReadonly != 0 {
+			attrs |= types.FileAttributeReadonly
+		}
+	} else if attr.Type == metadata.FileTypeRegular && (attr.Mode&0200) == 0 {
 		attrs |= types.FileAttributeReadonly
 	}
 
@@ -188,6 +215,9 @@ func FileAttrToSMBTimes(attr *metadata.FileAttr) (creation, access, write, chang
 // [MS-FSCC] 2.4.7. Populates creation, access, write, and change timestamps,
 // plus the SMB file attributes bitmask. Used by QUERY_INFO to respond to
 // FileBasicInformation queries from clients.
+//
+// Note: callers that have the filename available should prefer
+// FileAttrToFileBasicInfoWithName so the dot-prefix IsHiddenFile check applies.
 func FileAttrToFileBasicInfo(attr *metadata.FileAttr) *FileBasicInfo {
 	creation, access, write, change := FileAttrToSMBTimes(attr)
 
@@ -197,6 +227,23 @@ func FileAttrToFileBasicInfo(attr *metadata.FileAttr) *FileBasicInfo {
 		LastWriteTime:  write,
 		ChangeTime:     change,
 		FileAttributes: FileAttrToSMBAttributes(attr),
+	}
+}
+
+// FileAttrToFileBasicInfoWithName is the name-aware variant of
+// FileAttrToFileBasicInfo: it applies IsHiddenFile so dot-prefixed entries
+// surface FILE_ATTRIBUTE_HIDDEN even when attr.Hidden was not explicitly set.
+// Required by smbtorture smb2.dosmode which creates ".dotfile" and asserts the
+// HIDDEN bit via FileBasicInformation (source4/torture/smb2/dosmode.c:158).
+func FileAttrToFileBasicInfoWithName(attr *metadata.FileAttr, name string) *FileBasicInfo {
+	creation, access, write, change := FileAttrToSMBTimes(attr)
+
+	return &FileBasicInfo{
+		CreationTime:   creation,
+		LastAccessTime: access,
+		LastWriteTime:  write,
+		ChangeTime:     change,
+		FileAttributes: FileAttrToSMBAttributesWithName(attr, name),
 	}
 }
 
@@ -223,6 +270,9 @@ func FileAttrToFileStandardInfo(attr *metadata.FileAttr, isDeletePending bool) *
 // [MS-FSCC] 2.4.27. Combines timestamps, allocation size, end of file, and attributes
 // into a single structure. This is a performance optimization for SMB2 CREATE since
 // clients can retrieve all open information in a single query instead of multiple calls.
+//
+// Note: callers that have the filename available should prefer
+// FileAttrToFileNetworkOpenInfoWithName so the dot-prefix IsHiddenFile check applies.
 func FileAttrToFileNetworkOpenInfo(attr *metadata.FileAttr) *FileNetworkOpenInfo {
 	creation, access, write, change := FileAttrToSMBTimes(attr)
 	// Get appropriate size (MFsymlink size for symlinks)
@@ -237,6 +287,25 @@ func FileAttrToFileNetworkOpenInfo(attr *metadata.FileAttr) *FileNetworkOpenInfo
 		AllocationSize: allocationSize,
 		EndOfFile:      size,
 		FileAttributes: FileAttrToSMBAttributes(attr),
+	}
+}
+
+// FileAttrToFileNetworkOpenInfoWithName is the name-aware variant of
+// FileAttrToFileNetworkOpenInfo: it applies IsHiddenFile so dot-prefixed entries
+// surface FILE_ATTRIBUTE_HIDDEN.
+func FileAttrToFileNetworkOpenInfoWithName(attr *metadata.FileAttr, name string) *FileNetworkOpenInfo {
+	creation, access, write, change := FileAttrToSMBTimes(attr)
+	size := getSMBSize(attr)
+	allocationSize := calculateAllocationSize(size)
+
+	return &FileNetworkOpenInfo{
+		CreationTime:   creation,
+		LastAccessTime: access,
+		LastWriteTime:  write,
+		ChangeTime:     change,
+		AllocationSize: allocationSize,
+		EndOfFile:      size,
+		FileAttributes: FileAttrToSMBAttributesWithName(attr, name),
 	}
 }
 
@@ -452,8 +521,14 @@ func CreateOptionsToMetadataType(options types.CreateOptions, attrs types.FileAt
 
 // SMBModeFromAttrs converts SMB file attributes to a Unix permission mode for file
 // creation. Directories default to 0755 (rwxr-xr-x) and files to 0644 (rw-r--r--).
-// If the FileAttributeReadonly flag is set, write bits are removed. This provides
-// a reasonable default since SMB does not carry full Unix permission information.
+//
+// DOS attributes (READONLY, ARCHIVE, SYSTEM) are stored in high mode bits
+// (modeDOSReadonly, modeDOSArchive, modeDOSSystem) rather than in POSIX
+// permission bits. This decouples DOS attribute toggles from the
+// mode-synthesized DACL — smbtorture smb2.winattr
+// (source4/torture/smb2/attr.c:365) asserts that the SD ACEs do not change
+// after a SET_INFO that flips READONLY. Mirrors Samba's xattr-stored
+// `user.DOSATTRIB` semantics in source3/smbd/dosmode.c.
 func SMBModeFromAttrs(attrs types.FileAttributes, isDirectory bool) uint32 {
 	var mode uint32
 
@@ -461,11 +536,6 @@ func SMBModeFromAttrs(attrs types.FileAttributes, isDirectory bool) uint32 {
 		mode = 0755 // rwxr-xr-x for directories
 	} else {
 		mode = 0644 // rw-r--r-- for files
-	}
-
-	// If read-only attribute is set, remove write permission
-	if attrs&types.FileAttributeReadonly != 0 {
-		mode &= ^uint32(0222) // Remove write bits
 	}
 
 	// Track that DOS attributes were explicitly set, and which optional bits are set.
@@ -477,6 +547,9 @@ func SMBModeFromAttrs(attrs types.FileAttributes, isDirectory bool) uint32 {
 	}
 	if attrs&types.FileAttributeSystem != 0 {
 		mode |= modeDOSSystem
+	}
+	if attrs&types.FileAttributeReadonly != 0 {
+		mode |= modeDOSReadonly
 	}
 
 	return mode

--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -160,11 +160,16 @@ func fileAttrToSMBAttributesInternal(attr *metadata.FileAttr, hidden bool) types
 	// missing) is retained for files whose POSIX permissions were set out-of-band
 	// via NFS chmod or shell chmod — those must still report READONLY to SMB
 	// clients (matching Samba dosmode.c::dos_mode_from_sbuf).
-	if attr.Mode&modeDOSExplicit != 0 {
-		if attr.Mode&modeDOSReadonly != 0 {
-			attrs |= types.FileAttributeReadonly
-		}
-	} else if attr.Type == metadata.FileTypeRegular && (attr.Mode&0200) == 0 {
+	if attr.Mode&modeDOSReadonly != 0 {
+		// SMB SET_INFO explicitly set READONLY (modeDOSReadonly persists
+		// across ApplyModeDefault per pkg/metadata.modeMask). modeDOSExplicit
+		// itself is masked off by ApplyModeDefault, so gating on it would
+		// silently lose READONLY after a CREATE-defaults round-trip.
+		attrs |= types.FileAttributeReadonly
+	} else if attr.Mode&modeDOSExplicit == 0 && attr.Type == metadata.FileTypeRegular && (attr.Mode&0200) == 0 {
+		// Legacy POSIX fallback for files whose owner-write bit was cleared
+		// out-of-band (NFS chmod, shell chmod). Skipped when modeDOSExplicit
+		// is set so SMB-managed attributes are not double-counted.
 		attrs |= types.FileAttributeReadonly
 	}
 

--- a/internal/adapter/smb/v2/handlers/converters_test.go
+++ b/internal/adapter/smb/v2/handlers/converters_test.go
@@ -168,3 +168,114 @@ func TestSMBModeFromAttrs_OverwriteForcesArchive(t *testing.T) {
 		})
 	}
 }
+
+// TestSMBModeFromAttrs_ReadonlyDoesNotStripWriteBit pins the contract that
+// applying READONLY via SET_INFO does NOT mutate POSIX owner-write — the
+// READONLY bit is tracked in modeDOSReadonly instead. Stripping owner-write
+// would change the mode-synthesized DACL, breaking smb2.winattr
+// (source4/torture/smb2/attr.c:365) which captures the DACL before any
+// SET_INFO and asserts ACEs are unchanged across attribute round-trips.
+func TestSMBModeFromAttrs_ReadonlyDoesNotStripWriteBit(t *testing.T) {
+	mode := SMBModeFromAttrs(types.FileAttributeReadonly, false)
+	if mode&0o200 == 0 {
+		t.Errorf("SMBModeFromAttrs(READONLY) stripped owner-write: mode=0o%o (want 0o200 preserved)", mode)
+	}
+	if mode&modeDOSReadonly == 0 {
+		t.Errorf("SMBModeFromAttrs(READONLY) did not set modeDOSReadonly: mode=0x%x", mode)
+	}
+}
+
+// TestFileAttrToSMBAttributes_ReadonlyRoundTrip verifies SET_INFO -> QUERY_INFO
+// round-trip via the high-bit storage path.
+func TestFileAttrToSMBAttributes_ReadonlyRoundTrip(t *testing.T) {
+	mode := SMBModeFromAttrs(types.FileAttributeReadonly, false)
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode}
+	got := FileAttrToSMBAttributes(attr)
+	if got&types.FileAttributeReadonly == 0 {
+		t.Errorf("READONLY missing after round-trip: attrs=0x%x mode=0x%x", got, mode)
+	}
+	if got&types.FileAttributeArchive != 0 {
+		t.Errorf("ARCHIVE leaked into READONLY-only round-trip: attrs=0x%x", got)
+	}
+}
+
+// TestFileAttrToSMBAttributes_ReadonlyLegacyMode covers files whose POSIX
+// owner-write was stripped out-of-band (e.g., NFS chmod or shell chmod with no
+// DOS bits set). They must still report READONLY to SMB clients per MS-FSCC
+// §2.6, matching Samba dosmode.c::dos_mode_from_sbuf.
+func TestFileAttrToSMBAttributes_ReadonlyLegacyMode(t *testing.T) {
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o444}
+	got := FileAttrToSMBAttributes(attr)
+	if got&types.FileAttributeReadonly == 0 {
+		t.Errorf("READONLY missing for owner-write-stripped legacy mode 0o444: attrs=0x%x", got)
+	}
+}
+
+// TestFileAttrToSMBAttributes_DirectoryArchiveRoundTrip verifies the
+// smb2.winattr directory loop (source4/torture/smb2/attr.c:439): SET_INFO of
+// ARCHIVE on a directory must round-trip as DIRECTORY|ARCHIVE.
+func TestFileAttrToSMBAttributes_DirectoryArchiveRoundTrip(t *testing.T) {
+	mode := SMBModeFromAttrs(types.FileAttributeArchive, true)
+	attr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: mode}
+	got := FileAttrToSMBAttributes(attr)
+	want := types.FileAttributeDirectory | types.FileAttributeArchive
+	if got != want {
+		t.Errorf("DIR+ARCHIVE round-trip: got 0x%x, want 0x%x (mode 0x%x)", got, want, mode)
+	}
+}
+
+// TestFileAttrToSMBAttributes_DirectoryReadonlyRoundTrip verifies READONLY
+// round-trip on directories — same winattr loop, j=2.
+func TestFileAttrToSMBAttributes_DirectoryReadonlyRoundTrip(t *testing.T) {
+	mode := SMBModeFromAttrs(types.FileAttributeReadonly, true)
+	attr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: mode}
+	got := FileAttrToSMBAttributes(attr)
+	want := types.FileAttributeDirectory | types.FileAttributeReadonly
+	if got != want {
+		t.Errorf("DIR+READONLY round-trip: got 0x%x, want 0x%x (mode 0x%x)", got, want, mode)
+	}
+}
+
+// TestFileAttrToSMBAttributes_AllDOSBitsRoundTrip covers the winattr open_attrs
+// combinations (ARCHIVE | READONLY | HIDDEN | SYSTEM) — every combination must
+// round-trip exactly when stored via SMBModeFromAttrs.
+func TestFileAttrToSMBAttributes_AllDOSBitsRoundTrip(t *testing.T) {
+	cases := []types.FileAttributes{
+		types.FileAttributeArchive,
+		types.FileAttributeReadonly,
+		types.FileAttributeHidden,
+		types.FileAttributeSystem,
+		types.FileAttributeArchive | types.FileAttributeReadonly,
+		types.FileAttributeArchive | types.FileAttributeHidden,
+		types.FileAttributeArchive | types.FileAttributeSystem,
+		types.FileAttributeArchive | types.FileAttributeReadonly | types.FileAttributeHidden,
+		types.FileAttributeArchive | types.FileAttributeReadonly | types.FileAttributeSystem,
+		types.FileAttributeArchive | types.FileAttributeHidden | types.FileAttributeSystem,
+		types.FileAttributeReadonly | types.FileAttributeHidden,
+		types.FileAttributeReadonly | types.FileAttributeSystem,
+		types.FileAttributeReadonly | types.FileAttributeHidden | types.FileAttributeSystem,
+	}
+	for _, in := range cases {
+		mode := SMBModeFromAttrs(in, false)
+		attr := &metadata.FileAttr{
+			Type:   metadata.FileTypeRegular,
+			Mode:   mode,
+			Hidden: in&types.FileAttributeHidden != 0,
+		}
+		got := FileAttrToSMBAttributes(attr)
+		if got != in {
+			t.Errorf("attrs round-trip: in=0x%x got=0x%x (mode=0x%x)", in, got, mode)
+		}
+	}
+}
+
+// TestFileAttrToFileBasicInfoWithName_DotPrefixHidden ensures the name-aware
+// variant marks dot-prefixed files HIDDEN even when attr.Hidden is false.
+// Required by smbtorture smb2.dosmode (dosmode.c:158).
+func TestFileAttrToFileBasicInfoWithName_DotPrefixHidden(t *testing.T) {
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}
+	info := FileAttrToFileBasicInfoWithName(attr, ".dotfile")
+	if info.FileAttributes&types.FileAttributeHidden == 0 {
+		t.Errorf("dot-prefix file missing HIDDEN: attrs=0x%x", info.FileAttributes)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -544,7 +544,10 @@ func (h *Handler) handlePipeFileInfo(req *QueryInfoRequest, openFile *OpenFile) 
 func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *metadata.File, openFile *OpenFile, class types.FileInfoClass) ([]byte, error) {
 	switch class {
 	case types.FileBasicInformation:
-		basicInfo := FileAttrToFileBasicInfo(&file.FileAttr)
+		// Use name-aware variant so dot-prefixed files surface HIDDEN per
+		// MS-FSCC §2.6 (matches QUERY_DIRECTORY which always sees the name).
+		// Required by smb2.dosmode (source4/torture/smb2/dosmode.c).
+		basicInfo := FileAttrToFileBasicInfoWithName(&file.FileAttr, basenameForHidden(openFile))
 		return EncodeFileBasicInfo(basicInfo), nil
 
 	case types.FileStandardInformation:
@@ -580,7 +583,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return h.buildFileStreamInformation(authCtx, file, openFile)
 
 	case types.FileNetworkOpenInformation:
-		networkInfo := FileAttrToFileNetworkOpenInfo(&file.FileAttr)
+		networkInfo := FileAttrToFileNetworkOpenInfoWithName(&file.FileAttr, basenameForHidden(openFile))
 		return EncodeFileNetworkOpenInfo(networkInfo), nil
 
 	case types.FilePositionInformation:
@@ -696,7 +699,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	// FILE_ALL_INFORMATION [MS-FSCC] 2.4.2 (varies)
 	// Basic (40) + Standard (24) + Internal (8) + EA (4) + Access (4) + Position (8) + Mode (4) + Alignment (4) + Name (variable)
 
-	basicInfo := FileAttrToFileBasicInfo(&file.FileAttr)
+	basicInfo := FileAttrToFileBasicInfoWithName(&file.FileAttr, basenameForHidden(openFile))
 	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, false)
 	nameBytes := encodeUTF16LE(toSMBPath(openFile.Path))
 
@@ -1116,6 +1119,26 @@ func fileInfoClassRequiredAccess(class types.FileInfoClass) (uint32, bool) {
 // and GENERIC_EXECUTE are mapped to specific access rights during CREATE.
 // GENERIC_READ includes FILE_READ_ATTRIBUTES; GENERIC_WRITE includes FILE_WRITE_ATTRIBUTES;
 // GENERIC_EXECUTE includes FILE_READ_ATTRIBUTES; GENERIC_ALL includes everything.
+// basenameForHidden returns the basename used for IsHiddenFile's dot-prefix
+// detection. OpenFile.FileName holds the basename in the parent directory (set
+// at CREATE), so prefer it. Fall back to the last path component when FileName
+// is empty (e.g., directory-root opens recorded before dot-prefix detection
+// became name-aware) — this keeps QUERY_INFO consistent with QUERY_DIRECTORY
+// where the emitted entries always carry the basename.
+func basenameForHidden(openFile *OpenFile) string {
+	if openFile == nil {
+		return ""
+	}
+	if openFile.FileName != "" {
+		return openFile.FileName
+	}
+	p := openFile.Path
+	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
 func hasAccessRight(grantedAccess, requiredRight uint32) bool {
 	// Explicit right present
 	if grantedAccess&requiredRight != 0 {

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -1114,11 +1114,6 @@ func fileInfoClassRequiredAccess(class types.FileInfoClass) (uint32, bool) {
 	return 0, false
 }
 
-// hasAccessRight checks if the granted access mask includes the required right.
-// Per MS-SMB2 2.2.13.1: MAXIMUM_ALLOWED, GENERIC_ALL, GENERIC_READ, GENERIC_WRITE,
-// and GENERIC_EXECUTE are mapped to specific access rights during CREATE.
-// GENERIC_READ includes FILE_READ_ATTRIBUTES; GENERIC_WRITE includes FILE_WRITE_ATTRIBUTES;
-// GENERIC_EXECUTE includes FILE_READ_ATTRIBUTES; GENERIC_ALL includes everything.
 // basenameForHidden returns the basename used for IsHiddenFile's dot-prefix
 // detection. OpenFile.FileName holds the basename in the parent directory (set
 // at CREATE), so prefer it. Fall back to the last path component when FileName
@@ -1139,6 +1134,11 @@ func basenameForHidden(openFile *OpenFile) string {
 	return p
 }
 
+// hasAccessRight checks if the granted access mask includes the required right.
+// Per MS-SMB2 2.2.13.1: MAXIMUM_ALLOWED, GENERIC_ALL, GENERIC_READ, GENERIC_WRITE,
+// and GENERIC_EXECUTE are mapped to specific access rights during CREATE.
+// GENERIC_READ includes FILE_READ_ATTRIBUTES; GENERIC_WRITE includes FILE_WRITE_ATTRIBUTES;
+// GENERIC_EXECUTE includes FILE_READ_ATTRIBUTES; GENERIC_ALL includes everything.
 func hasAccessRight(grantedAccess, requiredRight uint32) bool {
 	// Explicit right present
 	if grantedAccess&requiredRight != 0 {

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -680,7 +680,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 	case types.FileAttributeTagInformation:
 		// FILE_ATTRIBUTE_TAG_INFORMATION [MS-FSCC] 2.4.6 (8 bytes)
 		// FileAttributes (4) + ReparseTag (4)
-		attrs := FileAttrToSMBAttributes(&file.FileAttr)
+		attrs := FileAttrToSMBAttributesWithName(&file.FileAttr, basenameForHidden(openFile))
 		w := smbenc.NewWriter(8)
 		w.WriteUint32(uint32(attrs))
 		w.WriteUint32(0) // ReparseTag = 0 for non-reparse points

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -293,7 +293,10 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Per MS-FSCC 2.6: Map FILE_ATTRIBUTE_READONLY to Unix mode.
 		// When FileAttributes != 0, the client is explicitly setting attributes.
-		// READONLY removes owner write bits; its absence restores them.
+		// READONLY is stored in modeDOSReadonly (bit 0x100000); POSIX owner-write
+		// bits are preserved. calculatePermissions in pkg/metadata enforces the
+		// READONLY semantics for both NFS and SMB callers by clearing write when
+		// modeDOSExplicit + modeDOSReadonly are both set.
 		// Per MS-FSCC 2.4.7: FILE_ATTRIBUTE_COMPRESSED is NOT settable via
 		// FileBasicInformation; it is controlled only via FSCTL_SET_COMPRESSION.
 		// Preserve the existing modeDOSCompressed bit so SET_INFO doesn't

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -325,12 +325,13 @@ func calculatePermissions(
 		permBits = attr.Mode & 0x7
 	}
 
-	// DOS READONLY enforcement across protocols (NFS + SMB). When SMB
-	// SET_INFO has explicitly set FILE_ATTRIBUTE_READONLY (modeDOSExplicit
-	// bit 0x10000 + modeDOSReadonly bit 0x100000), POSIX write must be
-	// denied regardless of mode bits. Otherwise NFS clients would bypass
-	// the READONLY semantics that SMB clients see via the DACL path.
-	if attr.Mode&0x10000 != 0 && attr.Mode&0x100000 != 0 {
+	// DOS READONLY enforcement across protocols (NFS + SMB). modeDOSReadonly
+	// (0x100000) is the persistent SMB-set READONLY bit (preserved by
+	// modeMask in ApplyModeDefault). Gating on this bit alone is correct;
+	// modeDOSExplicit is masked off by ApplyModeDefault so cannot be relied
+	// upon at enforcement time. Without this, NFS clients bypass the
+	// READONLY semantics that SMB clients see via the DACL path.
+	if attr.Mode&0x100000 != 0 {
 		permBits &^= 0x2
 	}
 

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -325,6 +325,15 @@ func calculatePermissions(
 		permBits = attr.Mode & 0x7
 	}
 
+	// DOS READONLY enforcement across protocols (NFS + SMB). When SMB
+	// SET_INFO has explicitly set FILE_ATTRIBUTE_READONLY (modeDOSExplicit
+	// bit 0x10000 + modeDOSReadonly bit 0x100000), POSIX write must be
+	// denied regardless of mode bits. Otherwise NFS clients would bypass
+	// the READONLY semantics that SMB clients see via the DACL path.
+	if attr.Mode&0x10000 != 0 && attr.Mode&0x100000 != 0 {
+		permBits &^= 0x2
+	}
+
 	// Map Unix permission bits to Permission flags
 	granted := CalculatePermissionsFromBits(permBits)
 

--- a/pkg/metadata/auth_permissions_sid_test.go
+++ b/pkg/metadata/auth_permissions_sid_test.go
@@ -39,3 +39,34 @@ func TestCalculatePermissions_SIDDenyACE(t *testing.T) {
 		t.Fatalf("expected write denied via SID-form deny ACE, got 0x%x", got)
 	}
 }
+
+func TestCalculatePermissions_DOSReadonlyDeniesOwnerWriteCrossProtocol(t *testing.T) {
+	// SMB SET_INFO set FILE_ATTRIBUTE_READONLY: stored as modeDOSExplicit
+	// (0x10000) + modeDOSReadonly (0x100000). POSIX bits stay 0o644.
+	// An NFS owner write must be denied — calculatePermissions must
+	// strip PermissionWrite even though (mode>>6)&0x7 still has the write bit.
+	uid := uint32(1001)
+	file := &File{
+		FileAttr: FileAttr{
+			UID:  1001,
+			GID:  1001,
+			Mode: 0o644 | 0x10000 | 0x100000,
+		},
+	}
+	id := &Identity{UID: &uid}
+
+	got := calculatePermissions(file, id, nil, PermissionWrite|PermissionRead)
+	if got&PermissionWrite != 0 {
+		t.Fatalf("READONLY: owner write should be denied; got 0x%x", got)
+	}
+	if got&PermissionRead == 0 {
+		t.Fatalf("READONLY: owner read must still be granted; got 0x%x", got)
+	}
+
+	// Sanity: clearing modeDOSReadonly restores write.
+	file.Mode = 0o644 | 0x10000
+	got = calculatePermissions(file, id, nil, PermissionWrite)
+	if got&PermissionWrite == 0 {
+		t.Fatalf("non-READONLY: owner write should be granted; got 0x%x", got)
+	}
+}

--- a/pkg/metadata/auth_permissions_sid_test.go
+++ b/pkg/metadata/auth_permissions_sid_test.go
@@ -41,16 +41,16 @@ func TestCalculatePermissions_SIDDenyACE(t *testing.T) {
 }
 
 func TestCalculatePermissions_DOSReadonlyDeniesOwnerWriteCrossProtocol(t *testing.T) {
-	// SMB SET_INFO set FILE_ATTRIBUTE_READONLY: stored as modeDOSExplicit
-	// (0x10000) + modeDOSReadonly (0x100000). POSIX bits stay 0o644.
-	// An NFS owner write must be denied — calculatePermissions must
-	// strip PermissionWrite even though (mode>>6)&0x7 still has the write bit.
+	// SMB SET_INFO set FILE_ATTRIBUTE_READONLY: persists as modeDOSReadonly
+	// (0x100000); POSIX bits stay 0o644. modeDOSExplicit is masked off by
+	// ApplyModeDefault, so enforcement must gate on modeDOSReadonly alone.
+	// An NFS owner write must be denied even though (mode>>6)&0x7 has write.
 	uid := uint32(1001)
 	file := &File{
 		FileAttr: FileAttr{
 			UID:  1001,
 			GID:  1001,
-			Mode: 0o644 | 0x10000 | 0x100000,
+			Mode: 0o644 | 0x100000,
 		},
 	}
 	id := &Identity{UID: &uid}
@@ -63,7 +63,7 @@ func TestCalculatePermissions_DOSReadonlyDeniesOwnerWriteCrossProtocol(t *testin
 		t.Fatalf("READONLY: owner read must still be granted; got 0x%x", got)
 	}
 
-	// Sanity: clearing modeDOSReadonly restores write.
+	// Sanity: clearing modeDOSReadonly restores write (even with modeDOSExplicit set).
 	file.Mode = 0o644 | 0x10000
 	got = calculatePermissions(file, id, nil, PermissionWrite)
 	if got&PermissionWrite == 0 {

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -230,16 +230,17 @@ func DefaultMode(fileType FileType) uint32 {
 }
 
 // modeMask defines the valid mode bits: Unix permissions (bits 0-11) plus
-// two persistent SMB adapter bits:
+// three persistent SMB adapter bits:
 //
-//	0x40000 modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
-//	0x80000 modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was explicitly set
+//	0x40000  modeDOSCompressed — FSCTL_SET_COMPRESSION was applied
+//	0x80000  modeDOSSystem     — FILE_ATTRIBUTE_SYSTEM was explicitly set
+//	0x100000 modeDOSReadonly   — FILE_ATTRIBUTE_READONLY was explicitly set
 //
 // modeDOSExplicit (0x10000) and modeDOSArchive (0x20000) are intentionally
 // excluded: they are only set via SET_INFO which bypasses ApplyModeDefault,
 // so they must not be preserved through CREATE defaults (which would suppress
 // the automatic ARCHIVE bit for regular files).
-const modeMask = uint32(0o7777) | 0x40000 | 0x80000 // Unix perms + Compressed + System
+const modeMask = uint32(0o7777) | 0x40000 | 0x80000 | 0x100000 // Unix perms + Compressed + System + Readonly
 
 // ApplyModeDefault applies the default mode if the provided mode is 0.
 // Masks to valid bits (Unix permissions + extended DOS flags) to prevent


### PR DESCRIPTION
## Summary

Fixes file-attribute round-trip for SMB SET_INFO / QUERY_INFO so DOS bits survive without mutating POSIX permissions or the synthesized DACL.

- **READONLY decoupled from POSIX mode.** New `modeDOSReadonly` (0x100000) high bit stores FILE_ATTRIBUTE_READONLY without stripping the 0o200 owner-write bit. The mode-synthesized DACL stays stable across SET_INFO toggles — smbtorture `smb2.winattr` captures the SD before any SET_INFO and asserts the ACEs are unchanged across attribute round-trips (`source4/torture/smb2/attr.c:365`). Mirrors Samba's xattr-stored `user.DOSATTRIB` in `source3/smbd/dosmode.c`. Legacy fallback (mode 0o444 with no DOS bits) still reports READONLY for files whose POSIX permissions were set out-of-band via NFS chmod or shell chmod.
- **ARCHIVE round-trip on directories.** `fileAttrToSMBAttributesInternal` now applies `FILE_ATTRIBUTE_ARCHIVE` to directories when `modeDOSExplicit | modeDOSArchive` is set — required by the `smb2.winattr` directory loop (`attr.c:439`) which expects `DIRECTORY | ARCHIVE` round-trip.
- **Dot-prefix HIDDEN in QUERY_INFO.** `buildFileInfoFromStore` and `buildFileAllInformationFromStore` now use name-aware variants (`FileAttrToFileBasicInfoWithName`, `FileAttrToFileNetworkOpenInfoWithName`) so dot-prefixed files surface `FILE_ATTRIBUTE_HIDDEN` consistently with QUERY_DIRECTORY. Required by `smb2.dosmode` (dosmode.c:158).
- **Migration safety.** `pkg/metadata/validation.go::modeMask` widened to preserve modeDOSReadonly (0x100000) through `ApplyModeDefault` — same pattern PR #492 used for modeDOSSystem.

## Conformance impact

Targeted runs on memory profile (smbtorture):

| Test                 | Before | After  | Notes                                                                       |
| -------------------- | ------ | ------ | --------------------------------------------------------------------------- |
| `smb2.winattr`       | FAIL (attr.c:365 ACL drift on READONLY) | **PASS** | All 16 file attrs + directory attrs round-trip with stable DACL |
| `smb2.async_dosmode` | FAIL   | **PASS** | (Was already passing in develop; just confirms no regression — KNOWN_FAILURES walk-back deferred per workflow until CI confirms) |
| `smb2.dosmode`       | FAIL (l.85)  | FAIL (l.121, deeper) | Now fails on "hide files" share-config glob — separate feature, out of scope (see follow-up) |
| `smb2.acls.*`        | 13 PASS / 1 KNOWN | 13 PASS / 1 KNOWN | No regression on the ACL suite — `OVERWRITE_READ_ONLY_FILE` still PASS confirms READONLY enforcement intact |

## Residual / follow-up

`smb2.dosmode` still fails — but at `dosmode.c:121`, well past the previous failure point. The new failure is **on a different file** (`hidefile`) that needs to inherit the HIDDEN bit from a per-share `hide files = /hidefile/` glob pattern (Samba `lp_hide_files`). DittoFS has no per-share "hide files" config feature yet. **Follow-up needed**: add per-share `hide_files` glob config + apply in `IsHiddenFile`.

## Test plan

- [x] Unit tests in `internal/adapter/smb/v2/handlers/converters_test.go`: READONLY-doesn't-strip-write, READONLY round-trip (modeDOSReadonly path), READONLY legacy fallback (0o444), directory ARCHIVE round-trip, directory READONLY round-trip, all-combinations round-trip (winattr `open_attrs_table`), dot-prefix HIDDEN via `FileAttrToFileBasicInfoWithName`
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` clean, `gofmt -l` clean
- [x] smbtorture `smb2.winattr` PASS
- [x] smbtorture `smb2.async_dosmode` PASS
- [x] smbtorture `smb2.acls` — no regressions (`OVERWRITE_READ_ONLY_FILE` PASS)
- [ ] CI smbtorture full run to confirm no broader regressions