### PR TITLE
test(smb/acl): handler-level ABE coverage for QUERY_DIRECTORY (#573)

### DIFF
--- a/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -13,8 +14,11 @@ import (
 func uint32Ptr(v uint32) *uint32 { return &v }
 
 // authForUID builds an AuthContext for the given UID with a single primary GID.
+// Context is wired to context.Background() so future hydrators that dereference
+// authCtx.Context don't panic.
 func authForUID(uid, gid uint32) *metadata.AuthContext {
 	return &metadata.AuthContext{
+		Context: context.Background(),
 		Identity: &metadata.Identity{
 			UID:  uint32Ptr(uid),
 			GID:  uint32Ptr(gid),
@@ -158,13 +162,11 @@ func TestFilterByAccess_RootBypass(t *testing.T) {
 	}
 }
 
-// TestFilterByAccess_FlagOffReturnsAll documents the contract that filtering
-// only runs when the share toggle is set; with the flag off (i.e. the
-// handler skipping the filter call), the caller sees everything. This test
-// invokes the filter directly with a non-owner identity to verify it would
-// hide entries — the flag-off path is verified by NOT calling filterByAccess.
-func TestFilterByAccess_FlagOffSemantics(t *testing.T) {
-	// File hidden under ABE.
+// TestFilterByAccess_HidesNonReadable exercises the pure filter on a
+// non-owner identity against an owner-only ACL. The handler-side gate
+// (whether the filter is called at all) is covered end-to-end by
+// TestQueryDirectory_ABE in query_directory_test.go.
+func TestFilterByAccess_HidesNonReadable(t *testing.T) {
 	ownerOnly := &acl.ACL{
 		ACEs: []acl.ACE{
 			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
@@ -173,20 +175,9 @@ func TestFilterByAccess_FlagOffSemantics(t *testing.T) {
 	entries := []metadata.DirEntry{
 		regularFileWithACL("secret.txt", 1000, 1000, 0o000, ownerOnly),
 	}
-	other := authForUID(2000, 2000)
-
-	// Flag-off path: filterByAccess is simply not called — the caller gets
-	// the full list. (Mirrors the handler's `if h.treeHasAccessBasedEnumeration(...)`
-	// gate.) Asserting on `entries` itself validates that without filtering
-	// the visible set is unchanged.
-	if len(entries) != 1 {
-		t.Fatalf("flag-off: want 1 entry, got %d", len(entries))
-	}
-
-	// Flag-on path: filtering hides the entry.
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
+	got := filterByAccess(entries, authForUID(2000, 2000), nil)
 	if len(got) != 0 {
-		t.Fatalf("flag-on: want 0 entries, got %d", len(got))
+		t.Fatalf("want 0 entries, got %d", len(got))
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/query_directory_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_test.go
@@ -1,0 +1,302 @@
+// Refs #573. Handler-level integration coverage for SMB2 QUERY_DIRECTORY
+// with the share's AccessBasedEnumeration toggle. Mirrors MS-SMB2 §3.3.5.18.1
+// ¶6 ("If TreeConnect.Share.AccessBasedEnumeration is TRUE, the server MUST
+// NOT include entries for which the user does not have FILE_READ_DATA /
+// FILE_LIST_DIRECTORY access") and the smb2.acls.ACCESSBASED smbtorture
+// case at source4/torture/smb2/acls.c:2308.
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// abeChild describes a single per-entry fixture: a regular file with the
+// given name, UID/GID, mode bits and (optional) DACL. The SMB SET_INFO
+// Security wire path lands at metadata.SetFileAttributes with SetAttrs.ACL,
+// so the test setup uses the same metadata API.
+type abeChild struct {
+	name string
+	uid  uint32
+	gid  uint32
+	mode uint32
+	acl  *acl.ACL
+}
+
+// setupABEQueryDirTest wires a Handler against an in-memory metadata store
+// where the share has AccessBasedEnumeration explicitly toggled and the
+// caller identity is built from callerUID / callerGID. children are
+// created beneath the share root with the per-entry attrs given.
+//
+// The returned SMBHandlerContext is pre-populated with TreeID + User so
+// QueryDirectory's ABE branch (gated on h.GetTree(TreeID).AccessBasedEnumeration
+// + BuildAuthContext(ctx.User)) finds both the share toggle and the
+// caller's UID/GID.
+func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, children []abeChild) (*Handler, *OpenFile, *SMBHandlerContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	shareName := "/abe"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:                   shareName,
+		MetadataStore:          "test-meta",
+		AccessBasedEnumeration: abe,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	// Files are created as root so per-file ACL / mode-bit decisions made
+	// downstream reflect the fixture exactly and aren't shadowed by the
+	// creator's owner-implicit grants.
+	rootUID := uint32(0)
+	rootGID := uint32(0)
+	rootAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &rootUID,
+			GID: &rootGID,
+		},
+	}
+	metaSvc := rt.GetMetadataService()
+	for _, c := range children {
+		if _, err := metaSvc.CreateFile(rootAuth, rootHandle, c.name, &metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: c.mode,
+			UID:  c.uid,
+			GID:  c.gid,
+		}); err != nil {
+			t.Fatalf("CreateFile(%q): %v", c.name, err)
+		}
+		if c.acl != nil {
+			// SetFileAttributes with SetAttrs.ACL is the metadata-layer
+			// entrypoint that SET_INFO Security calls after parsing the
+			// wire SD; mirrors what a Windows client triggers via
+			// smb2_setinfo_file. Re-resolve the child handle here
+			// because CreateFile returns *File; we need FileHandle.
+			childFile, lookupErr := metaSvc.Lookup(rootAuth, rootHandle, c.name)
+			if lookupErr != nil {
+				t.Fatalf("Lookup(%q): %v", c.name, lookupErr)
+			}
+			childHandle, encodeErr := metadata.EncodeFileHandle(childFile)
+			if encodeErr != nil {
+				t.Fatalf("EncodeFileHandle(%q): %v", c.name, encodeErr)
+			}
+			if err := metaSvc.SetFileAttributes(rootAuth, childHandle, &metadata.SetAttrs{ACL: c.acl}); err != nil {
+				t.Fatalf("SetFileAttributes ACL(%q): %v", c.name, err)
+			}
+		}
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	// Register the tree so QueryDirectory's ABE gate
+	// (treeHasAccessBasedEnumeration) finds the share toggle. TreeID = 1
+	// is arbitrary as long as it matches smbCtx.TreeID below.
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:                 treeID,
+		ShareName:              shareName,
+		AccessBasedEnumeration: abe,
+	})
+
+	open := &OpenFile{
+		FileID:         h.GenerateFileID(),
+		TreeID:         treeID,
+		Path:           shareName,
+		IsDirectory:    true,
+		MetadataHandle: rootHandle,
+	}
+	h.StoreOpenFile(open)
+
+	// SMB session carries a User struct (callerUID / callerGID);
+	// QueryDirectory goes through BuildAuthContext → BuildAuthContextFromUser
+	// which mirrors the production session-setup → request-dispatch handoff.
+	uidPtr := callerUID
+	gidPtr := callerGID
+	smbCtx := &SMBHandlerContext{
+		Context: context.Background(),
+		TreeID:  treeID,
+		User: &models.User{
+			Username: fmt.Sprintf("uid-%d", callerUID),
+			UID:      &uidPtr,
+			Groups:   []models.Group{{GID: &gidPtr}},
+		},
+	}
+
+	return h, open, smbCtx
+}
+
+// callABEQuery invokes QueryDirectory with sensible defaults for the ABE
+// handler-level tests. Mirrors the smbtorture acls.ACCESSBASED enumeration
+// which uses SMB2_FIND_DIRECTORY_INFO with continue_flags=REOPEN and a
+// 4 KiB output buffer.
+func callABEQuery(t *testing.T, h *Handler, smbCtx *SMBHandlerContext, openID [16]byte) *QueryDirectoryResponse {
+	t.Helper()
+	req := &QueryDirectoryRequest{
+		FileInfoClass:      uint8(types.FileIdBothDirectoryInformation),
+		Flags:              uint8(types.SMB2RestartScans),
+		FileID:             openID,
+		FileName:           "*",
+		OutputBufferLength: 65536,
+	}
+	resp, err := h.QueryDirectory(smbCtx, req)
+	if err != nil {
+		t.Fatalf("QueryDirectory error: %v", err)
+	}
+	return resp
+}
+
+// countABEEntries walks the NextEntryOffset chain in a directory info buffer
+// and returns the entry count. Encoder-class-agnostic: only the first
+// 4 bytes of each entry (NextEntryOffset) are read.
+func countABEEntries(buf []byte) int {
+	if len(buf) < 4 {
+		return 0
+	}
+	n := 0
+	off := 0
+	for {
+		n++
+		next := binary.LittleEndian.Uint32(buf[off : off+4])
+		if next == 0 {
+			return n
+		}
+		off += int(next)
+		if off+4 > len(buf) {
+			return n
+		}
+	}
+}
+
+// ownerOnlyReadACL grants ACE4_READ_DATA only to the file owner. Under ABE,
+// such an entry is hidden from any caller that isn't the owner.
+func ownerOnlyReadACL() *acl.ACL {
+	return &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: acl.ACE4_READ_DATA,
+				Who:        acl.SpecialOwner,
+			},
+		},
+	}
+}
+
+// everyoneReadACL grants ACE4_READ_DATA to EVERYONE@. Under ABE, the entry
+// remains visible to any caller.
+func everyoneReadACL() *acl.ACL {
+	return &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: acl.ACE4_READ_DATA,
+				Who:        acl.SpecialEveryone,
+			},
+		},
+	}
+}
+
+// TestQueryDirectory_ABE_OmitsNonReadableEntries — refs #573. With ABE on
+// and the only child entry's DACL denying the caller READ_DATA, the
+// QUERY_DIRECTORY response must hide the entry. Mirrors smb2.acls.ACCESSBASED
+// at source4/torture/smb2/acls.c:2308.
+func TestQueryDirectory_ABE_OmitsNonReadableEntries(t *testing.T) {
+	const callerUID = uint32(2000)
+	const callerGID = uint32(2000)
+	h, open, smbCtx := setupABEQueryDirTest(t, true, callerUID, callerGID, []abeChild{
+		{
+			name: "secret.txt",
+			uid:  1000, // not the caller — DACL denies non-owners
+			gid:  1000,
+			mode: 0o600,
+			acl:  ownerOnlyReadACL(),
+		},
+	})
+
+	resp := callABEQuery(t, h, smbCtx, open.FileID)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
+	}
+	// Only "." and ".." should remain; secret.txt is filtered out.
+	if got := countABEEntries(resp.Data); got != 2 {
+		t.Fatalf("entries = %d, want 2 (. and .. only — secret.txt must be hidden)", got)
+	}
+}
+
+// TestQueryDirectory_ABE_IncludesReadableEntries — refs #573. With ABE on
+// and the child entry's DACL granting EVERYONE@ READ_DATA, the entry must
+// remain visible in the listing.
+func TestQueryDirectory_ABE_IncludesReadableEntries(t *testing.T) {
+	const callerUID = uint32(2000)
+	const callerGID = uint32(2000)
+	h, open, smbCtx := setupABEQueryDirTest(t, true, callerUID, callerGID, []abeChild{
+		{
+			name: "public.txt",
+			uid:  1000,
+			gid:  1000,
+			mode: 0o644,
+			acl:  everyoneReadACL(),
+		},
+	})
+
+	resp := callABEQuery(t, h, smbCtx, open.FileID)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
+	}
+	// ".", "..", public.txt — 3 entries.
+	if got := countABEEntries(resp.Data); got != 3 {
+		t.Fatalf("entries = %d, want 3 (. + .. + public.txt)", got)
+	}
+}
+
+// TestQueryDirectory_ABEDisabled_IncludesAllEntries — refs #573. With ABE
+// off, the handler must NOT apply the per-entry filter even when the
+// child's DACL would deny the caller. Same fixture as
+// TestQueryDirectory_ABE_OmitsNonReadableEntries but with the share toggle
+// disabled.
+func TestQueryDirectory_ABEDisabled_IncludesAllEntries(t *testing.T) {
+	const callerUID = uint32(2000)
+	const callerGID = uint32(2000)
+	h, open, smbCtx := setupABEQueryDirTest(t, false, callerUID, callerGID, []abeChild{
+		{
+			name: "secret.txt",
+			uid:  1000,
+			gid:  1000,
+			mode: 0o600,
+			acl:  ownerOnlyReadACL(),
+		},
+	})
+
+	resp := callABEQuery(t, h, smbCtx, open.FileID)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
+	}
+	// ".", "..", secret.txt — 3 entries (no ABE filter).
+	if got := countABEEntries(resp.Data); got != 3 {
+		t.Fatalf("entries = %d, want 3 (. + .. + secret.txt — ABE off)", got)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/query_directory_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_test.go
@@ -51,8 +51,8 @@ func readOnlyACL(who string) *acl.ACL {
 //
 // The returned SMBHandlerContext is pre-populated with TreeID + User so
 // QueryDirectory's ABE branch (gated on h.GetTree(TreeID).AccessBasedEnumeration
-// + BuildAuthContext(ctx.User)) finds both the share toggle and the
-// caller's UID/GID.
+// + BuildAuthContext(ctx), which itself reads ctx.User) finds both the
+// share toggle and the caller's UID/GID.
 func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, children []abeChild) (*Handler, *OpenFile, *SMBHandlerContext) {
 	t.Helper()
 

--- a/internal/adapter/smb/v2/handlers/query_directory_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_test.go
@@ -32,6 +32,18 @@ type abeChild struct {
 	acl  *acl.ACL
 }
 
+// readOnlyACL grants ACE4_READ_DATA to a single principal. Under ABE,
+// only callers matching that principal see the entry in the listing.
+func readOnlyACL(who string) *acl.ACL {
+	return &acl.ACL{
+		ACEs: []acl.ACE{{
+			Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+			AccessMask: acl.ACE4_READ_DATA,
+			Who:        who,
+		}},
+	}
+}
+
 // setupABEQueryDirTest wires a Handler against an in-memory metadata store
 // where the share has AccessBasedEnumeration explicitly toggled and the
 // caller identity is built from callerUID / callerGID. children are
@@ -50,7 +62,7 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
 
-	shareName := "/abe"
+	const shareName = "/abe"
 	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
 		Name:                   shareName,
 		MetadataStore:          "test-meta",
@@ -71,8 +83,7 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 	// Files are created as root so per-file ACL / mode-bit decisions made
 	// downstream reflect the fixture exactly and aren't shadowed by the
 	// creator's owner-implicit grants.
-	rootUID := uint32(0)
-	rootGID := uint32(0)
+	rootUID, rootGID := uint32(0), uint32(0)
 	rootAuth := &metadata.AuthContext{
 		Context: context.Background(),
 		Identity: &metadata.Identity{
@@ -82,31 +93,28 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 	}
 	metaSvc := rt.GetMetadataService()
 	for _, c := range children {
-		if _, err := metaSvc.CreateFile(rootAuth, rootHandle, c.name, &metadata.FileAttr{
+		childFile, err := metaSvc.CreateFile(rootAuth, rootHandle, c.name, &metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: c.mode,
 			UID:  c.uid,
 			GID:  c.gid,
-		}); err != nil {
+		})
+		if err != nil {
 			t.Fatalf("CreateFile(%q): %v", c.name, err)
 		}
-		if c.acl != nil {
-			// SetFileAttributes with SetAttrs.ACL is the metadata-layer
-			// entrypoint that SET_INFO Security calls after parsing the
-			// wire SD; mirrors what a Windows client triggers via
-			// smb2_setinfo_file. Re-resolve the child handle here
-			// because CreateFile returns *File; we need FileHandle.
-			childFile, lookupErr := metaSvc.Lookup(rootAuth, rootHandle, c.name)
-			if lookupErr != nil {
-				t.Fatalf("Lookup(%q): %v", c.name, lookupErr)
-			}
-			childHandle, encodeErr := metadata.EncodeFileHandle(childFile)
-			if encodeErr != nil {
-				t.Fatalf("EncodeFileHandle(%q): %v", c.name, encodeErr)
-			}
-			if err := metaSvc.SetFileAttributes(rootAuth, childHandle, &metadata.SetAttrs{ACL: c.acl}); err != nil {
-				t.Fatalf("SetFileAttributes ACL(%q): %v", c.name, err)
-			}
+		if c.acl == nil {
+			continue
+		}
+		// SetFileAttributes with SetAttrs.ACL is the metadata-layer
+		// entrypoint that SET_INFO Security calls after parsing the
+		// wire SD; mirrors what a Windows client triggers via
+		// smb2_setinfo_file.
+		childHandle, err := metadata.EncodeFileHandle(childFile)
+		if err != nil {
+			t.Fatalf("EncodeFileHandle(%q): %v", c.name, err)
+		}
+		if err := metaSvc.SetFileAttributes(rootAuth, childHandle, &metadata.SetAttrs{ACL: c.acl}); err != nil {
+			t.Fatalf("SetFileAttributes ACL(%q): %v", c.name, err)
 		}
 	}
 
@@ -135,15 +143,13 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 	// SMB session carries a User struct (callerUID / callerGID);
 	// QueryDirectory goes through BuildAuthContext → BuildAuthContextFromUser
 	// which mirrors the production session-setup → request-dispatch handoff.
-	uidPtr := callerUID
-	gidPtr := callerGID
 	smbCtx := &SMBHandlerContext{
 		Context: context.Background(),
 		TreeID:  treeID,
 		User: &models.User{
 			Username: fmt.Sprintf("uid-%d", callerUID),
-			UID:      &uidPtr,
-			Groups:   []models.Group{{GID: &gidPtr}},
+			UID:      &callerUID,
+			Groups:   []models.Group{{GID: &callerGID}},
 		},
 	}
 
@@ -156,14 +162,13 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 // 4 KiB output buffer.
 func callABEQuery(t *testing.T, h *Handler, smbCtx *SMBHandlerContext, openID [16]byte) *QueryDirectoryResponse {
 	t.Helper()
-	req := &QueryDirectoryRequest{
+	resp, err := h.QueryDirectory(smbCtx, &QueryDirectoryRequest{
 		FileInfoClass:      uint8(types.FileIdBothDirectoryInformation),
 		Flags:              uint8(types.SMB2RestartScans),
 		FileID:             openID,
 		FileName:           "*",
 		OutputBufferLength: 65536,
-	}
-	resp, err := h.QueryDirectory(smbCtx, req)
+	})
 	if err != nil {
 		t.Fatalf("QueryDirectory error: %v", err)
 	}
@@ -177,8 +182,7 @@ func countABEEntries(buf []byte) int {
 	if len(buf) < 4 {
 		return 0
 	}
-	n := 0
-	off := 0
+	n, off := 0, 0
 	for {
 		n++
 		next := binary.LittleEndian.Uint32(buf[off : off+4])
@@ -192,111 +196,76 @@ func countABEEntries(buf []byte) int {
 	}
 }
 
-// ownerOnlyReadACL grants ACE4_READ_DATA only to the file owner. Under ABE,
-// such an entry is hidden from any caller that isn't the owner.
-func ownerOnlyReadACL() *acl.ACL {
-	return &acl.ACL{
-		ACEs: []acl.ACE{
-			{
-				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
-				AccessMask: acl.ACE4_READ_DATA,
-				Who:        acl.SpecialOwner,
+// TestQueryDirectory_ABE covers the share-level AccessBasedEnumeration toggle
+// at the QUERY_DIRECTORY handler boundary. Each case seeds a single child
+// under the share root and asserts the resulting entry count after the
+// handler's per-entry ABE filter has run. Refs #573; mirrors
+// smb2.acls.ACCESSBASED at source4/torture/smb2/acls.c:2308.
+func TestQueryDirectory_ABE(t *testing.T) {
+	const (
+		callerUID = uint32(2000)
+		callerGID = uint32(2000)
+		// Owner UID for fixture children — distinct from callerUID so
+		// owner-only DACLs deny the caller.
+		ownerUID = uint32(1000)
+		ownerGID = uint32(1000)
+	)
+
+	cases := []struct {
+		name        string
+		abe         bool
+		child       abeChild
+		wantEntries int // ". " + ".." + (child if visible)
+	}{
+		{
+			name: "ABE_on_omits_non_readable",
+			abe:  true,
+			child: abeChild{
+				name: "secret.txt",
+				uid:  ownerUID,
+				gid:  ownerGID,
+				mode: 0o600,
+				acl:  readOnlyACL(acl.SpecialOwner),
 			},
+			wantEntries: 2,
 		},
-	}
-}
-
-// everyoneReadACL grants ACE4_READ_DATA to EVERYONE@. Under ABE, the entry
-// remains visible to any caller.
-func everyoneReadACL() *acl.ACL {
-	return &acl.ACL{
-		ACEs: []acl.ACE{
-			{
-				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
-				AccessMask: acl.ACE4_READ_DATA,
-				Who:        acl.SpecialEveryone,
+		{
+			name: "ABE_on_includes_readable",
+			abe:  true,
+			child: abeChild{
+				name: "public.txt",
+				uid:  ownerUID,
+				gid:  ownerGID,
+				mode: 0o644,
+				acl:  readOnlyACL(acl.SpecialEveryone),
 			},
+			wantEntries: 3,
 		},
-	}
-}
-
-// TestQueryDirectory_ABE_OmitsNonReadableEntries — refs #573. With ABE on
-// and the only child entry's DACL denying the caller READ_DATA, the
-// QUERY_DIRECTORY response must hide the entry. Mirrors smb2.acls.ACCESSBASED
-// at source4/torture/smb2/acls.c:2308.
-func TestQueryDirectory_ABE_OmitsNonReadableEntries(t *testing.T) {
-	const callerUID = uint32(2000)
-	const callerGID = uint32(2000)
-	h, open, smbCtx := setupABEQueryDirTest(t, true, callerUID, callerGID, []abeChild{
 		{
-			name: "secret.txt",
-			uid:  1000, // not the caller — DACL denies non-owners
-			gid:  1000,
-			mode: 0o600,
-			acl:  ownerOnlyReadACL(),
+			name: "ABE_off_includes_all",
+			abe:  false,
+			child: abeChild{
+				name: "secret.txt",
+				uid:  ownerUID,
+				gid:  ownerGID,
+				mode: 0o600,
+				acl:  readOnlyACL(acl.SpecialOwner),
+			},
+			wantEntries: 3,
 		},
-	})
-
-	resp := callABEQuery(t, h, smbCtx, open.FileID)
-	if resp.Status != types.StatusSuccess {
-		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
 	}
-	// Only "." and ".." should remain; secret.txt is filtered out.
-	if got := countABEEntries(resp.Data); got != 2 {
-		t.Fatalf("entries = %d, want 2 (. and .. only — secret.txt must be hidden)", got)
-	}
-}
 
-// TestQueryDirectory_ABE_IncludesReadableEntries — refs #573. With ABE on
-// and the child entry's DACL granting EVERYONE@ READ_DATA, the entry must
-// remain visible in the listing.
-func TestQueryDirectory_ABE_IncludesReadableEntries(t *testing.T) {
-	const callerUID = uint32(2000)
-	const callerGID = uint32(2000)
-	h, open, smbCtx := setupABEQueryDirTest(t, true, callerUID, callerGID, []abeChild{
-		{
-			name: "public.txt",
-			uid:  1000,
-			gid:  1000,
-			mode: 0o644,
-			acl:  everyoneReadACL(),
-		},
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, open, smbCtx := setupABEQueryDirTest(t, tc.abe, callerUID, callerGID, []abeChild{tc.child})
 
-	resp := callABEQuery(t, h, smbCtx, open.FileID)
-	if resp.Status != types.StatusSuccess {
-		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
-	}
-	// ".", "..", public.txt — 3 entries.
-	if got := countABEEntries(resp.Data); got != 3 {
-		t.Fatalf("entries = %d, want 3 (. + .. + public.txt)", got)
-	}
-}
-
-// TestQueryDirectory_ABEDisabled_IncludesAllEntries — refs #573. With ABE
-// off, the handler must NOT apply the per-entry filter even when the
-// child's DACL would deny the caller. Same fixture as
-// TestQueryDirectory_ABE_OmitsNonReadableEntries but with the share toggle
-// disabled.
-func TestQueryDirectory_ABEDisabled_IncludesAllEntries(t *testing.T) {
-	const callerUID = uint32(2000)
-	const callerGID = uint32(2000)
-	h, open, smbCtx := setupABEQueryDirTest(t, false, callerUID, callerGID, []abeChild{
-		{
-			name: "secret.txt",
-			uid:  1000,
-			gid:  1000,
-			mode: 0o600,
-			acl:  ownerOnlyReadACL(),
-		},
-	})
-
-	resp := callABEQuery(t, h, smbCtx, open.FileID)
-	if resp.Status != types.StatusSuccess {
-		t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
-	}
-	// ".", "..", secret.txt — 3 entries (no ABE filter).
-	if got := countABEEntries(resp.Data); got != 3 {
-		t.Fatalf("entries = %d, want 3 (. + .. + secret.txt — ABE off)", got)
+			resp := callABEQuery(t, h, smbCtx, open.FileID)
+			if resp.Status != types.StatusSuccess {
+				t.Fatalf("status = 0x%x, want StatusSuccess", uint32(resp.Status))
+			}
+			if got := countABEEntries(resp.Data); got != tc.wantEntries {
+				t.Fatalf("entries = %d, want %d", got, tc.wantEntries)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Per-entry DACL filtering on shares with `AccessBasedEnumeration=true` is already implemented (PR #532) and unit-tested at the helper layer in `query_directory_abe_test.go` via `TestFilterByAccess_*`. This PR adds the missing **handler-level** integration tests that drive `QueryDirectory` end-to-end on a memory metadata store with the share toggle on and off — locking in the behavior gated by MS-SMB2 §3.3.5.18.1 ¶6 and the smb2.acls.ACCESSBASED smbtorture case at `source4/torture/smb2/acls.c:2308`.

The existing pipeline:
- `tree_connect.go` carries `AccessBasedEnumeration` from the share record into the `TreeConnection` and ORs `SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM` into the response (PR #551, refs #549).
- `query_directory.go::QueryDirectory` calls `filterByAccess` after listing children when `treeHasAccessBasedEnumeration(ctx.TreeID)` is true (PR #532). Filter uses `acl.Evaluate` (or POSIX mode-bit fallback for nil ACLs), with a fail-closed hydrator for backends that omit `DirEntry.Attr`.
- `pkg/auth/sid::SIDMapper.SIDToPrincipal` maps an owner SID like `S-1-5-21-...-{uid*2+1000}` to `"{uid}@localdomain"`, and `acl.Evaluate` resolves that via `parseLocalDomainID` numerically against the requester's UID.

This PR exercises that pipeline with three handler tests:

- `TestQueryDirectory_ABE_OmitsNonReadableEntries` — owner-only DACL hides the entry from a non-owner caller when ABE is on. Mirrors smbtorture's check at `acls.c:2308`.
- `TestQueryDirectory_ABE_IncludesReadableEntries` — `EVERYONE@`-readable entries remain visible under ABE.
- `TestQueryDirectory_ABEDisabled_IncludesAllEntries` — same restrictive DACL as the omit case, but ABE off → entry listed.

The test setup attaches a DACL post-create via `MetadataService.SetFileAttributes(SetAttrs{ACL: ...})` — the same metadata entrypoint that `SET_INFO Security` lands at after the wire SD is parsed (mirrors the smbtorture wire sequence `smb2_setinfo_file` → `parseSecurityDescriptor` → `SetFileAttributes`).

Closes #573.

## Test plan

- [x] `go vet ./internal/adapter/smb/v2/handlers/` — clean
- [x] `go test -run TestQueryDirectory_ABE ./internal/adapter/smb/v2/handlers/` — 3/3 PASS
- [x] `go test ./internal/adapter/smb/v2/handlers/` — all PASS (no regressions)
- [x] `go test ./...` — all PASS
- [ ] CI: smbtorture `smb2.acls.ACCESSBASED` flips to PASS (handled by `KNOWN_FAILURES.md` walkback in a follow-up commit once CI confirms — per the project workflow)