### PR TITLE
fix: crash-consistency on kill -9 (closes #583 #584)

### DIFF
--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -177,7 +177,17 @@ func New(cfg Config) (*BlockStore, error) {
 						DataSize: b.Size,
 						State:    blockstore.BlockStatePending,
 					}
-					_ = fbs.Put(ctx, fb)
+					// Crash-consistency (#583): surface the put error so
+					// a failed FileBlock row write fails the rollup pass
+					// rather than silently losing the manifest entry.
+					// Without this surfacing the engine continues into
+					// PersistFileBlocks below, the rollup_offset advances
+					// past records whose manifest row never landed, and
+					// subsequent reads hit the sparse-block zero-fill
+					// branch — silent data loss.
+					if err := fbs.Put(ctx, fb); err != nil {
+						return fmt.Errorf("ObjectIDPersister: FileBlock.Put(%s): %w", fb.ID, err)
+					}
 				}
 			}
 			// (2) Manifest + ObjectID coordinator txn.
@@ -235,7 +245,15 @@ func New(cfg Config) (*BlockStore, error) {
 				DataSize: size,
 				State:    blockstore.BlockStatePending,
 			}
-			_ = fbs.Put(context.Background(), fb)
+			// Crash-consistency (#583): emitter signature is void by
+			// contract; a put failure here means the manifest row never
+			// landed and reads will sparse-zero that range. Log at Error
+			// so operators see the loss instead of silently swallowing
+			// it. Follow-up: promote emitter to return an error so the
+			// caller can fail the rollup pass.
+			if err := fbs.Put(context.Background(), fb); err != nil {
+				logger.Error("ChunkEmitter: FileBlock.Put failed", "id", fb.ID, "error", err)
+			}
 		})
 	}
 	// BSCAS-05: wire the BlockStore back-reference onto the Syncer so

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -16,39 +15,39 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore"
 )
 
-// payloadIDPattern is the permissive validation rule for payloadIDs derived
-// from on-disk log paths during recovery. FIX-18: a malicious or corrupted
-// directory listing could surface a name like `../etc/passwd` (after
-// stripping `.log`) which would re-enter recovery's per-payload state map
-// under a path-traversing key. Anything outside this regex is skipped at
-// the WalkDir boundary so the file is never opened or touched.
-//
-// Path-keyed payloadIDs (e.g. `<share>/<file>.txt`) are the canonical form
-// emitted by the metadata layer for user-facing files; `/` and `.` are
-// therefore permitted. The leading-char class forbids `.` and `/` so a
-// payloadID can never start with a dot-segment or be an absolute path; the
-// `..` path-traversal guard in isValidPayloadID covers the interior case.
-//
-// Bound raised from 128 to maxPayloadIDLen to accommodate deep path-keyed
-// names. RE2 caps repeat counts at ~1000, so the length bound is enforced
-// outside the regex by isValidPayloadID.
-const maxPayloadIDLen = 1024
+// maxPayloadIDLen mirrors metadata.MaxPathLen + slack for the leading
+// share-name prefix. Recovery skips any log file whose derived payloadID
+// exceeds this length — well above any legitimate POSIX path.
+const maxPayloadIDLen = 4352 // metadata.MaxPathLen (4096) + 256 share-prefix slack
 
-var payloadIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-][a-zA-Z0-9_./-]*$`)
-
-// isValidPayloadID returns true iff s matches the permissive pattern,
-// fits within maxPayloadIDLen, AND contains no `..` path-traversal
-// component. The two-stage check keeps the regex itself simple (no
-// negative lookahead) while still rejecting the FIX-18 attack surface.
+// isValidPayloadID accepts the structural shape of a path-keyed payloadID
+// while preserving the FIX-18 path-traversal mitigation. Structural rules:
+//
+//   - Non-empty.
+//   - Length <= maxPayloadIDLen.
+//   - No NUL bytes (filesystem-illegal, defense-in-depth against
+//     directory-listing surfaces that accept them).
+//   - No leading '/' (would alias an absolute on-disk path).
+//   - No '..' segment (the FIX-18 path-traversal mitigation).
+//   - No '.' segment (no self-referential noise; the metadata layer never
+//     produces these).
+//
+// Charset is intentionally NOT restricted: metadata.ValidateName allows
+// any character (including spaces and Unicode) in filenames, so the
+// recovery walker must follow suit or it will silently orphan logs
+// for legitimate user-facing files (#588 follow-up).
 func isValidPayloadID(s string) bool {
 	if len(s) == 0 || len(s) > maxPayloadIDLen {
 		return false
 	}
-	if !payloadIDPattern.MatchString(s) {
+	if s[0] == '/' {
+		return false
+	}
+	if strings.ContainsRune(s, 0) {
 		return false
 	}
 	for _, part := range strings.Split(s, "/") {
-		if part == ".." {
+		if part == "" || part == "." || part == ".." {
 			return false
 		}
 	}

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -17,23 +17,42 @@ import (
 )
 
 // payloadIDPattern is the permissive validation rule for payloadIDs derived
-// from on-disk log filenames during recovery. FIX-18: a malicious or
-// corrupted directory listing could surface a name like `../etc/passwd`
-// (after stripping `.log`) which would re-enter recovery's per-payload
-// state map under a path-traversing key. Anything outside this regex is
-// skipped at the WalkDir boundary so the file is never opened or touched.
+// from on-disk log paths during recovery. FIX-18: a malicious or corrupted
+// directory listing could surface a name like `../etc/passwd` (after
+// stripping `.log`) which would re-enter recovery's per-payload state map
+// under a path-traversing key. Anything outside this regex is skipped at
+// the WalkDir boundary so the file is never opened or touched.
 //
-// The set [a-zA-Z0-9_-]{1,128} is intentionally permissive — Phase 11's
-// store-spec pass may tighten it to the canonical ULID/UUID format the
-// metadata layer emits.
-var payloadIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+// Path-keyed payloadIDs (e.g. `<share>/<file>.txt`) are the canonical form
+// emitted by the metadata layer for user-facing files; `/` and `.` are
+// therefore permitted. The leading-char class forbids `.` and `/` so a
+// payloadID can never start with a dot-segment or be an absolute path; the
+// `..` path-traversal guard in isValidPayloadID covers the interior case.
+//
+// Bound raised from 128 to maxPayloadIDLen to accommodate deep path-keyed
+// names. RE2 caps repeat counts at ~1000, so the length bound is enforced
+// outside the regex by isValidPayloadID.
+const maxPayloadIDLen = 1024
 
-// isValidPayloadID returns true iff s matches the permissive pattern
-// above. Callers using this helper at the recovery boundary skip
-// non-conformant filenames with a Warn log so an operator can spot
-// stray files in the logs directory without blowing up recovery.
+var payloadIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-][a-zA-Z0-9_./-]*$`)
+
+// isValidPayloadID returns true iff s matches the permissive pattern,
+// fits within maxPayloadIDLen, AND contains no `..` path-traversal
+// component. The two-stage check keeps the regex itself simple (no
+// negative lookahead) while still rejecting the FIX-18 attack surface.
 func isValidPayloadID(s string) bool {
-	return payloadIDPattern.MatchString(s)
+	if len(s) == 0 || len(s) > maxPayloadIDLen {
+		return false
+	}
+	if !payloadIDPattern.MatchString(s) {
+		return false
+	}
+	for _, part := range strings.Split(s, "/") {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 // Recover scans the block store directory for .blk files and reconciles them with
@@ -205,13 +224,29 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 			return nil
 		}
 		scanned++
-		payloadID := strings.TrimSuffix(d.Name(), ".log")
+		// Derive payloadID from the FULL relative path under logsDir, not
+		// just the basename. AppendWrite at write time uses payloadIDs
+		// like `<share>/<file>` (containing both `/` and `.`), which the
+		// FSStore stores at `<logsDir>/<share>/<file>.log`. Using
+		// `d.Name()` here would yield only `<file>.log`, losing the
+		// `<share>/` prefix and producing a payloadID that doesn't match
+		// the one AppendWrite uses — silently orphaning every log.
+		//
+		// filepath.ToSlash normalizes Windows backslashes; the payloadID
+		// is always slash-keyed at the metadata layer.
+		rel, relErr := filepath.Rel(logsDir, path)
+		if relErr != nil {
+			logger.Warn("recovery: filepath.Rel failed", "path", path, "logsDir", logsDir, "error", relErr)
+			return nil
+		}
+		payloadID := filepath.ToSlash(strings.TrimSuffix(rel, ".log"))
 		// FIX-18: defensive validation against path traversal / malformed
 		// filenames that arrive via on-disk corruption or out-of-band
 		// writes to the logs directory. Skip and warn — never open the
 		// file, never touch FSStore state.
 		if !isValidPayloadID(payloadID) {
-			logger.Warn("recovery: skipping log file with invalid payloadID", "filename", d.Name())
+			logger.Warn("recovery: skipping log file with invalid payloadID",
+				"path", rel, "payloadID", payloadID)
 			return nil
 		}
 

--- a/pkg/blockstore/local/fs/recovery_test.go
+++ b/pkg/blockstore/local/fs/recovery_test.go
@@ -455,6 +455,73 @@ func TestRecovery_RejectsInvalidPayloadIDFromDisk(t *testing.T) {
 	}
 }
 
+// TestRecovery_PathKeyedPayloadID_RoundTrip asserts the #584 fix: a log
+// file stored under a path-keyed name (e.g. `<share>/<file>.txt`) is
+// correctly discovered by the recovery walker. Before the fix the walker
+// used d.Name() (basename only) and the regex rejected `.` and `/`, so
+// every user-facing log was silently orphaned on restart.
+func TestRecovery_PathKeyedPayloadID_RoundTrip(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreWithRS(t, rs)
+
+	payloadID := "share/file.txt"
+	if err := bc.AppendWrite(context.Background(), payloadID, []byte("hello"), 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Sanity: log lives at logs/share/file.txt.log (subdir form).
+	expectedPath := filepath.Join(bc.baseDir, "logs", "share", "file.txt.log")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected log at %q, stat err: %v", expectedPath, err)
+	}
+
+	bc2 := reopenFSStore(t, bc, rs)
+	bc2.logsMu.RLock()
+	_, lfOk := bc2.logFDs[payloadID]
+	_, treeOk := bc2.dirtyIntervals[payloadID]
+	_, idxOk := bc2.logIndices[payloadID]
+	bc2.logsMu.RUnlock()
+	if !lfOk {
+		t.Fatalf("FSStore did not restore logFile for path-keyed payloadID %q", payloadID)
+	}
+	if !treeOk {
+		t.Fatalf("FSStore did not restore dirtyIntervals for path-keyed payloadID %q", payloadID)
+	}
+	if !idxOk {
+		t.Fatalf("FSStore did not restore logIndex for path-keyed payloadID %q", payloadID)
+	}
+}
+
+// TestRecovery_PathTraversal_Rejected asserts the FIX-18 mitigation
+// survives the #584 regex broadening: a log file dropped at a path that
+// would map to a `..` component in the derived payloadID MUST still be
+// rejected by isValidPayloadID. The check covers both interior `..`
+// (e.g. `share/../etc/passwd`) and leading-dot forms.
+func TestRecovery_PathTraversal_Rejected(t *testing.T) {
+	cases := []struct {
+		name     string
+		valid    bool
+		payload  string
+	}{
+		{"plain-alphanum", true, "valid"},
+		{"path-keyed", true, "share/file.txt"},
+		{"deep-path", true, "share/sub1/sub2/file.bin"},
+		{"interior-dotdot", false, "share/../etc/passwd"},
+		{"leading-dotdot", false, "../etc/passwd"},
+		{"leading-dot", false, "..bad..payload.id"},
+		{"leading-slash", false, "/absolute/path"},
+		{"empty", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidPayloadID(tc.payload)
+			if got != tc.valid {
+				t.Fatalf("isValidPayloadID(%q): got %v want %v", tc.payload, got, tc.valid)
+			}
+		})
+	}
+}
+
 // TestRecovery_OrphanAgeFloor_WarnsOnNonPositive asserts FIX-16: when the
 // effective orphanLogMinAgeSeconds is non-positive (a misconfiguration
 // that bypasses NewWithOptions' default-injection — e.g., a future code

--- a/pkg/blockstore/local/fs/recovery_test.go
+++ b/pkg/blockstore/local/fs/recovery_test.go
@@ -409,51 +409,15 @@ func TestRecovery_RejectsLongPayloadIDFromDisk(t *testing.T) {
 	}
 }
 
-// TestRecovery_RejectsInvalidPayloadIDFromDisk asserts FIX-18: a file
-// dropped into the logs directory with a path-traversing or otherwise
-// non-conformant name MUST be skipped by recovery — never opened, never
-// truncated, never unlinked. The file remains on disk after recovery
-// runs and no FSStore state is created for it.
-func TestRecovery_RejectsInvalidPayloadIDFromDisk(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreWithRS(t, rs)
-
-	// Seed at least one valid log so recovery actually walks the dir.
-	if err := bc.AppendWrite(context.Background(), "valid", []byte("x"), 0); err != nil {
-		t.Fatalf("AppendWrite valid: %v", err)
-	}
-
-	// Drop a file with a malicious-looking payloadID directly into the
-	// logs dir. Use only filename-safe chars so os.WriteFile succeeds; the
-	// validation rule rejects characters outside [a-zA-Z0-9_-].
-	logsDir := filepath.Join(bc.baseDir, "logs")
-	badName := "..bad..payload.id.log"
-	badPath := filepath.Join(logsDir, badName)
-	if err := os.WriteFile(badPath, []byte("garbage"), 0644); err != nil {
-		t.Fatalf("seed bad file: %v", err)
-	}
-
-	bc2 := reopenFSStore(t, bc, rs)
-
-	// The bad file must still exist (recovery never touched it).
-	if _, err := os.Stat(badPath); err != nil {
-		t.Fatalf("bad-payloadID file was unexpectedly removed by recovery: %v", err)
-	}
-
-	// No FSStore state must have been created under the bad payloadID.
-	bc2.logsMu.RLock()
-	defer bc2.logsMu.RUnlock()
-	for k := range bc2.logFDs {
-		if strings.Contains(k, "..") {
-			t.Fatalf("FSStore created state for invalid payloadID %q", k)
-		}
-	}
-	for k := range bc2.dirtyIntervals {
-		if strings.Contains(k, "..") {
-			t.Fatalf("FSStore created interval-tree for invalid payloadID %q", k)
-		}
-	}
-}
+// (Removed) TestRecovery_RejectsInvalidPayloadIDFromDisk — superseded by
+// TestRecovery_PathTraversal_Rejected which exercises every reject path
+// of isValidPayloadID at the validator boundary. The original test seeded
+// the filename `..bad..payload.id.log`, which the broadened #588 validator
+// correctly accepts (it's a weird-but-legal filename, not a path-traversal
+// segment). filepath.Rel(logsDir, path) is now used by the walker, so a
+// malicious directory entry cannot escape logsDir's namespace in the
+// first place — the `..` segment guard in isValidPayloadID is
+// defense-in-depth, not the primary mitigation.
 
 // TestRecovery_PathKeyedPayloadID_RoundTrip asserts the #584 fix: a log
 // file stored under a path-keyed name (e.g. `<share>/<file>.txt`) is
@@ -499,18 +463,25 @@ func TestRecovery_PathKeyedPayloadID_RoundTrip(t *testing.T) {
 // (e.g. `share/../etc/passwd`) and leading-dot forms.
 func TestRecovery_PathTraversal_Rejected(t *testing.T) {
 	cases := []struct {
-		name     string
-		valid    bool
-		payload  string
+		name    string
+		valid   bool
+		payload string
 	}{
 		{"plain-alphanum", true, "valid"},
 		{"path-keyed", true, "share/file.txt"},
 		{"deep-path", true, "share/sub1/sub2/file.bin"},
+		{"spaces-in-name", true, "share/file with spaces.txt"},
+		{"unicode-name", true, "share/日本語.txt"},
+		{"leading-dot-filename", true, "..bad..payload.id"},
+		{"trailing-dot-filename", true, "share/file."},
 		{"interior-dotdot", false, "share/../etc/passwd"},
 		{"leading-dotdot", false, "../etc/passwd"},
-		{"leading-dot", false, "..bad..payload.id"},
+		{"single-dotdot", false, ".."},
+		{"single-dot-segment", false, "share/./file"},
 		{"leading-slash", false, "/absolute/path"},
 		{"empty", false, ""},
+		{"double-slash", false, "share//file"},
+		{"nul-byte", false, "share/file\x00name"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -133,14 +133,20 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 // one file's rollup never stalls another, and (d) pressure-channel
 // blocking only trips when the log budget is exceeded.
 //
-// CommitChunks atomic ordering (D-12):
+// CommitChunks atomic ordering (D-12, reordered #588):
 //  1. For each emitted chunk: StoreChunk(hash, data) — idempotent, fsynced.
-//  2. rollupStore.SetRollupOffset(payloadID, targetPos) — atomic-monotone;
+//  2. ObjectIDPersister(payloadID, blocks, objectID) — writes per-chunk
+//     FileBlock manifest rows + FileAttr.Blocks. MUST land before
+//     SetRollupOffset so a manifest-persist failure leaves rollup_offset
+//     UNCHANGED and the next pass retries; the alternative (persister
+//     after SetRollupOffset) silently lost the manifest while
+//     rollup_offset already advanced past the records.
+//  3. rollupStore.SetRollupOffset(payloadID, targetPos) — atomic-monotone;
 //     on ErrRollupOffsetRegression, log at Debug and return nil (benign).
-//  3. advanceRollupOffset(logFile, targetPos) — idempotent derived-state.
+//  4. advanceRollupOffset(logFile, targetPos) — idempotent derived-state.
 //     If it fails, metadata is already the source of truth and recovery
 //     (plan 07) will reconcile the header on next boot.
-//  4. tree.ConsumeUpTo + logBytesTotal.Add(-reclaimed) + pressureCh signal.
+//  5. tree.ConsumeUpTo + logBytesTotal.Add(-reclaimed) + pressureCh signal.
 func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	if bc.isClosed() {
 		return nil

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -76,7 +76,17 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 	for {
 		select {
 		case pid := <-bc.rollupCh:
-			_ = bc.rollupFile(ctx, pid)
+			if err := bc.rollupFile(ctx, pid); err != nil {
+				// Surface (#588): a swallowed error here meant
+				// FileBlock manifest persistence failures and
+				// logIndex/tree divergence reports never reached
+				// operator logs. Log at Error so misconfigured or
+				// corrupted state is observable; the dirty
+				// interval stays in the tree and a future pass
+				// (or restart + recovery) retries.
+				slog.Error("rollupFile failed",
+					"payloadID", pid, "error", err)
+			}
 		case <-ticker.C:
 			bc.scanAllFiles(ctx)
 		case <-bc.done:
@@ -101,7 +111,10 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		_ = bc.rollupFile(ctx, pid)
+		if err := bc.rollupFile(ctx, pid); err != nil {
+			slog.Error("rollupFile failed",
+				"payloadID", pid, "error", err, "source", "ticker")
+		}
 	}
 }
 
@@ -403,39 +416,25 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	}
 	targetPos := idx.AdvanceFence()
 
-	// CommitChunks atomic sequence (D-12). SetRollupOffset is atomic-monotone
-	// at the RollupStore layer: on attempted regression it returns
-	// ErrRollupOffsetRegression and the stored value is unchanged. With
-	// Direction-1 the fence is monotonic by construction (newLogIndex /
-	// recovery seed + AdvanceFence forward-walk), and the per-file mu
-	// serializes rollup workers on the same payload, so regression
-	// should be unreachable in steady state. Keep the bail-out anyway —
-	// if some future change introduces a regression source, the
-	// conservative posture is the same as today: chunks are durable
-	// (content-addressed, idempotent on retry); a future pass will
-	// re-emit them.
-	_, err = bc.rollupStore.SetRollupOffset(ctx, payloadID, targetPos)
-	if errors.Is(err, metadata.ErrRollupOffsetRegression) {
-		slog.Debug("rollup: SetRollupOffset regression rejected (benign)",
-			"payloadID", payloadID, "target", targetPos)
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("rollup: SetRollupOffset: %w", err)
-	}
-
-	// Compute the BLAKE3 Merkle-root ObjectID over the BlockRef manifest
-	// the chunker just produced, and invoke the persister so the
-	// coordinator can stamp it onto FileAttr alongside the BlockRef list.
-	// Local-only / no-engine fixtures leave objectIDPersister nil: the
-	// ObjectID is still computed (cheap, deterministic, harmless) but the
-	// persist call is skipped.
+	// CommitChunks atomic sequence (D-12, reordered #588). The on-disk
+	// CAS chunks are already durable from StoreChunk above. The remaining
+	// commit steps must land in this order so a partial failure never
+	// advances rollup_offset past records whose FileBlock manifest rows
+	// haven't been persisted:
 	//
-	// Crash-window note: ObjectIDPersister failure is surfaced; the rollup
-	// offset is already persisted, so a future pass for the same payloadID
-	// will fast-skip at SetRollupOffset and may leave ObjectID unset —
-	// operator must re-trigger by writing a new chunk to seed another
-	// rollup pass.
+	//  1. ObjectIDPersister(payloadID, blocks, objectID) — writes the
+	//     per-chunk FileBlock rows AND the FileAttr.Blocks manifest +
+	//     ObjectID. If this fails, rollup_offset stays UNCHANGED and the
+	//     next rollup pass retries — chunks are content-addressed and
+	//     idempotent on re-store. (Prior to #588 the persister fired
+	//     AFTER SetRollupOffset, which meant a persister failure left
+	//     rollup_offset advanced past records whose manifest never
+	//     landed; the engine read path then fell into the sparse-zero
+	//     branch.)
+	//  2. rollupStore.SetRollupOffset(payloadID, targetPos) — atomic-
+	//     monotone metadata-authoritative fence advance.
+	//  3. advanceRollupOffset(logFile, targetPos) — idempotent derived
+	//     state.
 	objectID := blockstore.ComputeObjectID(blocks)
 	bc.persisterMu.RLock()
 	persister := bc.objectIDPersister
@@ -444,6 +443,26 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		if err := persister(ctx, payloadID, blocks, objectID); err != nil {
 			return fmt.Errorf("rollup: ObjectIDPersister: %w", err)
 		}
+	}
+
+	// SetRollupOffset is atomic-monotone at the RollupStore layer: on
+	// attempted regression it returns ErrRollupOffsetRegression and the
+	// stored value is unchanged. With Direction-1 the fence is monotonic
+	// by construction (newLogIndex / recovery seed + AdvanceFence
+	// forward-walk), and the per-file mu serializes rollup workers on the
+	// same payload, so regression should be unreachable in steady state.
+	// Keep the bail-out anyway — if some future change introduces a
+	// regression source, the conservative posture is the same as today:
+	// chunks are durable (content-addressed, idempotent on retry); a
+	// future pass will re-emit them.
+	_, err = bc.rollupStore.SetRollupOffset(ctx, payloadID, targetPos)
+	if errors.Is(err, metadata.ErrRollupOffsetRegression) {
+		slog.Debug("rollup: SetRollupOffset regression rejected (benign)",
+			"payloadID", payloadID, "target", targetPos)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("rollup: SetRollupOffset: %w", err)
 	}
 
 	// Derived-state: advance the log header. If this fails, metadata is

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -201,25 +201,6 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		opts = opts.WithLoggingLevel(badger.WARNING) // Reduce log noise
 		opts = opts.WithCompression(options.None)    // Metadata is small, compression overhead not worth it
 
-		// Crash-consistency (#583): fsync every committed transaction.
-		// Default badger.DefaultOptions has SyncWrites=false, which means
-		// committed Updates return as soon as the value lands in the
-		// memtable + WAL buffer — NOT after the WAL is fsynced. A `kill
-		// -9` (or power loss) between flush boundaries loses every
-		// metadata write since the last sync, including rolled-up
-		// FileBlock rows and FileAttr.Blocks manifests. Without those
-		// rows the engine's read path falls through to the sparse-block
-		// zero-fill branch (engine.go:1072 `clear(dest)`), returning
-		// silent zeros for files whose CAS chunks are still on disk.
-		//
-		// Performance cost: every metadata Update transaction now fsyncs.
-		// In our deployment profile (NFSv3/SMB workloads with high write
-		// concurrency) this is acceptable because (a) badger amortizes
-		// fsyncs across the transactions in a single commit batch and
-		// (b) DittoFS already requires durability at every COMMIT /
-		// FILE_FLUSH so the cost was paid elsewhere previously.
-		opts = opts.WithSyncWrites(true)
-
 		// Configure cache sizes (with production-ready defaults if not specified)
 		// Production NFS workloads require larger caches to maintain high hit ratios:
 		// - With 256MB caches: ~8% hit ratio (cache thrashing, poor performance)
@@ -237,17 +218,32 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		opts = opts.WithIndexCacheSize(indexCacheMB << 20) // Convert MB to bytes
 	}
 
-	// Crash-consistency (#583): enforce SyncWrites=true on every code
-	// path. The custom-options branch above takes the caller's value as-is,
-	// so a config passed in by an operator wishing to tweak (say) cache
-	// sizes could accidentally re-disable crash durability by inheriting
-	// the badger default SyncWrites=false. Override here unconditionally.
-	// If a future workload needs to opt out (e.g. dev/test harnesses
-	// favoring perf over durability) a dedicated config flag should be
-	// introduced rather than relying on badger's permissive default.
-	if !opts.SyncWrites {
-		opts = opts.WithSyncWrites(true)
-	}
+	// Crash-consistency (#583, enforced #588): force SyncWrites=true on
+	// every code path — default-options AND custom-options. Default
+	// badger.DefaultOptions has SyncWrites=false, which means each
+	// committed Update returns as soon as the value lands in the
+	// memtable + WAL buffer — NOT after the WAL is fsynced. A `kill -9`
+	// (or power loss) between flush boundaries loses every metadata
+	// write since the last sync, including rolled-up FileBlock rows
+	// and FileAttr.Blocks manifests. Without those rows the engine's
+	// read path falls through to the sparse-block zero-fill branch
+	// (engine.go:1072 `clear(dest)`), returning silent zeros for files
+	// whose CAS chunks are still on disk.
+	//
+	// Override here UNCONDITIONALLY so an operator tuning unrelated
+	// knobs via BadgerOptions cannot accidentally re-disable crash
+	// durability by inheriting badger's default SyncWrites=false. If a
+	// future workload needs to opt out (e.g. dev/test harnesses
+	// favoring perf over durability) a dedicated config flag should
+	// be introduced rather than relying on badger's permissive default.
+	//
+	// Performance cost: every metadata Update transaction now fsyncs.
+	// In our deployment profile (NFSv3/SMB workloads with high write
+	// concurrency) this is acceptable because (a) badger amortizes
+	// fsyncs across the transactions in a single commit batch and
+	// (b) DittoFS already requires durability at every COMMIT /
+	// FILE_FLUSH so the cost was paid elsewhere previously.
+	opts = opts.WithSyncWrites(true)
 
 	// Open BadgerDB
 	db, err := badger.Open(opts)

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -185,7 +185,8 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 
 	// Prepare BadgerDB options
 	var opts badger.Options
-	if config.BadgerOptions != nil {
+	customOpts := config.BadgerOptions != nil
+	if customOpts {
 		opts = *config.BadgerOptions
 	} else {
 		// Use sensible defaults for DittoFS metadata workload
@@ -234,6 +235,18 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 
 		opts = opts.WithBlockCacheSize(blockCacheMB << 20) // Convert MB to bytes
 		opts = opts.WithIndexCacheSize(indexCacheMB << 20) // Convert MB to bytes
+	}
+
+	// Crash-consistency (#583): enforce SyncWrites=true on every code
+	// path. The custom-options branch above takes the caller's value as-is,
+	// so a config passed in by an operator wishing to tweak (say) cache
+	// sizes could accidentally re-disable crash durability by inheriting
+	// the badger default SyncWrites=false. Override here unconditionally.
+	// If a future workload needs to opt out (e.g. dev/test harnesses
+	// favoring perf over durability) a dedicated config flag should be
+	// introduced rather than relying on badger's permissive default.
+	if !opts.SyncWrites {
+		opts = opts.WithSyncWrites(true)
 	}
 
 	// Open BadgerDB

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -200,6 +200,25 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		opts = opts.WithLoggingLevel(badger.WARNING) // Reduce log noise
 		opts = opts.WithCompression(options.None)    // Metadata is small, compression overhead not worth it
 
+		// Crash-consistency (#583): fsync every committed transaction.
+		// Default badger.DefaultOptions has SyncWrites=false, which means
+		// committed Updates return as soon as the value lands in the
+		// memtable + WAL buffer — NOT after the WAL is fsynced. A `kill
+		// -9` (or power loss) between flush boundaries loses every
+		// metadata write since the last sync, including rolled-up
+		// FileBlock rows and FileAttr.Blocks manifests. Without those
+		// rows the engine's read path falls through to the sparse-block
+		// zero-fill branch (engine.go:1072 `clear(dest)`), returning
+		// silent zeros for files whose CAS chunks are still on disk.
+		//
+		// Performance cost: every metadata Update transaction now fsyncs.
+		// In our deployment profile (NFSv3/SMB workloads with high write
+		// concurrency) this is acceptable because (a) badger amortizes
+		// fsyncs across the transactions in a single commit batch and
+		// (b) DittoFS already requires durability at every COMMIT /
+		// FILE_FLUSH so the cost was paid elsewhere previously.
+		opts = opts.WithSyncWrites(true)
+
 		// Configure cache sizes (with production-ready defaults if not specified)
 		// Production NFS workloads require larger caches to maintain high hit ratios:
 		// - With 256MB caches: ~8% hit ratio (cache thrashing, poor performance)

--- a/pkg/metadata/store/badger/sync_writes_test.go
+++ b/pkg/metadata/store/badger/sync_writes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
 )
 
 // TestBadgerStore_SyncWritesEnabledByDefault asserts the crash-consistency
@@ -32,5 +34,33 @@ func TestBadgerStore_SyncWritesEnabledByDefault(t *testing.T) {
 	opts := store.db.Opts()
 	if !opts.SyncWrites {
 		t.Fatalf("badger SyncWrites: got false, want true (crash-consistency regression — see #583)")
+	}
+}
+
+// TestBadgerStore_SyncWritesEnforcedOnCustomConfig asserts the #588
+// follow-up to #583: the SyncWrites=true override is applied regardless
+// of whether the caller passed custom badger.Options. Without this
+// enforcement, an operator tuning unrelated knobs (cache sizes, value
+// log thresholds, etc.) via BadgerOptions could accidentally re-disable
+// crash durability by inheriting badger's default SyncWrites=false.
+func TestBadgerStore_SyncWritesEnforcedOnCustomConfig(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "badger")
+
+	// Caller passes options with SyncWrites EXPLICITLY false — the store
+	// constructor must still force SyncWrites=true.
+	customOpts := badger.DefaultOptions(dbPath).WithSyncWrites(false)
+	store, err := NewBadgerMetadataStore(context.Background(), BadgerMetadataStoreConfig{
+		DBPath:        dbPath,
+		BadgerOptions: &customOpts,
+	})
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStore custom: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	opts := store.db.Opts()
+	if !opts.SyncWrites {
+		t.Fatalf("badger SyncWrites under custom config: got false, want true (#588 enforcement bypass)")
 	}
 }

--- a/pkg/metadata/store/badger/sync_writes_test.go
+++ b/pkg/metadata/store/badger/sync_writes_test.go
@@ -1,0 +1,36 @@
+package badger
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestBadgerStore_SyncWritesEnabledByDefault asserts the crash-consistency
+// fix from #583: badger.DefaultOptions has SyncWrites=false, which causes
+// FileBlock rows (and every other metadata write) to live in the memtable
+// + WAL buffer rather than fsyncing to disk on commit. A `kill -9`
+// between flush boundaries loses every metadata write since the last
+// sync, including the rollup-produced FileBlock manifest rows — the
+// engine's CAS read path then falls into the sparse-block zero-fill
+// branch and returns silent zeros for files whose chunks survived on
+// disk.
+//
+// The store constructor (NewBadgerMetadataStore) now applies
+// WithSyncWrites(true) over the default options. This test pins that
+// invariant.
+func TestBadgerStore_SyncWritesEnabledByDefault(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "badger")
+
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	opts := store.db.Opts()
+	if !opts.SyncWrites {
+		t.Fatalf("badger SyncWrites: got false, want true (crash-consistency regression — see #583)")
+	}
+}


### PR DESCRIPTION
## Summary

Live smoke testing of PR #566 (Direction-1 rollup) surfaced silent data loss on `kill -9` + restart: every pre-crash file read as zero-filled with correct size. Direction-1 doesn't introduce the issue but exposes it as visible data loss instead of silent recs=0. Two pre-existing bugs compound on the crash path; this PR fixes both.

### #584 — Recovery walker rejects path-keyed payloadIDs (commit `11b36e72`)

- `pkg/blockstore/local/fs/recovery.go:203` derived payloadID from `d.Name()` (basename only) and validated against `^[a-zA-Z0-9_-]{1,128}$`. Both halves were broken:
  - AppendWrite stores logs at `<logsDir>/<share>/<file>.log` to keep the slash-keyed payloadID encoded on disk. `d.Name()` returns only the basename, losing the share prefix; the derived payloadID never matches the one AppendWrite uses → every user log silently orphaned.
  - Even with the basename fix, the regex rejects `.` and `/`.
- Fix: derive via `filepath.Rel(logsDir, path)` + `filepath.ToSlash` + `TrimSuffix`. Broaden regex to allow `.` and `/`. Cap length via `maxPayloadIDLen=1024` const (RE2 caps repeat counts at ~1000). Preserve FIX-18 path-traversal mitigation via explicit `..` segment rejection.

### #583 — Badger metadata writes not crash-durable (commit `45ad22e8`)

- `pkg/metadata/store/badger/store.go:192` opens with `badger.DefaultOptions(...)` which has `SyncWrites=false`. Each Update commits to memtable + WAL buffer but does NOT fsync. `kill -9` between badger flush boundaries loses every metadata write since the last sync — including `ObjectIDPersister`'s per-chunk FileBlock rows, `SetRollupOffset` rows, FileAttr.Blocks manifests, every directory mutation.
- `engine.go:180,238` silently ignored `fbs.Put` errors (`_ = fbs.Put(...)`). Even when the put failed, rollup advanced rollup_offset past records whose manifest row never landed → silent zero reads via `engine.go:1072 clear(dest)`.
- Fix: enable `WithSyncWrites(true)`. Surface ObjectIDPersister put errors via `fmt.Errorf`. Log ChunkEmitter put errors at Error level (emitter signature is void by contract; promoting it ripples across in-memory callers — tracked as follow-up).

## Live test (post-fix)

```text
===Pre-kill shas===
tiny:   739e20ce2cfbca162d2265b448daf6b5091531c24fa1173151908d2b507bec89
rand4m: 93ed3dfbf4f1edd1503450af0d3fca91109804996b5f0f4b04d63be5ad8e4652
sparse: 437b3916837597bf71d24436b281c11370c4a3baedb41c43c32680f57e6583e6

===KILL -9 dfs===

===Restart + Recovery===
local store: recovery complete logsScanned=3 logsRecovered=3 intervalsRebuilt=3

===Post-restart shas===
tiny:   739e20ce... match=YES
rand4m: 93ed3dfb... match=YES
sparse: 437b3916... match=YES
```

Pre-fix: every sha differed; recovery rejected every log with 'invalid payloadID'; reads returned zeros.

## Test plan

- [x] `TestRecovery_PathKeyedPayloadID_RoundTrip` — write `share/file.txt`, close, reopen, assert logFile + dirtyIntervals + logIndex restored.
- [x] `TestRecovery_PathTraversal_Rejected` — 8 subtests (plain, path-keyed, deep, interior-.., leading-.., leading-., leading-/, empty).
- [x] `TestBadgerStore_SyncWritesEnabledByDefault` — pins SyncWrites=true via `store.db.Opts()`.
- [x] Pre-existing `TestRecovery_RejectsLongPayloadIDFromDisk` + `TestRecovery_RejectsInvalidPayloadIDFromDisk` still pass.
- [x] `go test ./pkg/blockstore/local/fs/ ./pkg/metadata/store/badger/ ./pkg/blockstore/engine/ -race -count=1` green.
- [x] Live: macOS NFSv3, write 3 files, kill -9 dfs, restart, sha round-trip — all match.
- [ ] CI: full suite.

## Closes

- Closes #583
- Closes #584