### PR TITLE
test(smb): regression coverage for delete-on-close-perms (#475)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -458,6 +458,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		"disposition", req.CreateDisposition,
 		"options", req.CreateOptions,
 		"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+		"fileAttributes", fmt.Sprintf("0x%x", req.FileAttributes),
 		"oplockLevel", fmt.Sprintf("0x%02x", req.OplockLevel),
 		"createContexts", len(req.CreateContexts))
 

--- a/internal/adapter/smb/v2/handlers/create_doc_perms_test.go
+++ b/internal/adapter/smb/v2/handlers/create_doc_perms_test.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// Handler-level regression coverage for the MS-FSA §2.1.5.18 delete-on-close
+// permission semantics exercised by smbtorture
+// smb2.delete-on-close-perms.{CREATE,CREATE_IF,OVERWRITE_IF,READONLY}.
+//
+// These tests drive completeCreateAfterBreak directly with a pre-built
+// createDraft (mirroring TestCreate_DaclEnforcement_*) so the DOC-permission
+// arm of step 6d is exercised without bringing up the wire stack.
+
+// setupDocTest stands up a Handler with an in-memory metadata store and
+// returns a SMBHandlerContext / parent handle pair the test can use to seed
+// the file under test. Authenticates as root for the parent-directory ops so
+// the test scenarios isolate the DOC permission check on the *file*.
+func setupDocTest(t *testing.T) (*Handler, *runtime.Runtime, *SMBHandlerContext, metadata.FileHandle, *metadata.AuthContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	shareName := "/doc-test"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "test-meta",
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	rootUID := uint32(0)
+	rootGID := uint32(0)
+	rootAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &rootUID,
+			GID: &rootGID,
+		},
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	smbCtx := &SMBHandlerContext{
+		SessionID: 1,
+		TreeID:    1,
+		ShareName: shareName,
+	}
+
+	return h, rt, smbCtx, rootHandle, rootAuth
+}
+
+// makeDocDraft builds a createDraft for a CREATE with the FILE_DELETE_ON_CLOSE
+// option set. Disposition / fileExists / createAction / existingFile are
+// supplied by the caller to cover the OPEN-existing and CREATE-new arms.
+func makeDocDraft(
+	t *testing.T,
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	existingFile *metadata.File,
+	baseName string,
+	disposition types.CreateDisposition,
+	createAction types.CreateAction,
+	desiredAccess uint32,
+	reqFileAttrs types.FileAttributes,
+) *createDraft {
+	t.Helper()
+	var existingHandle metadata.FileHandle
+	fileExists := existingFile != nil
+	if fileExists {
+		eh, err := metadata.EncodeFileHandle(existingFile)
+		if err != nil {
+			t.Fatalf("EncodeFileHandle: %v", err)
+		}
+		existingHandle = eh
+	}
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			FileAttributes:    reqFileAttrs,
+			ShareAccess:       0x07, // R|W|D
+			CreateDisposition: disposition,
+			CreateOptions:     types.FileDeleteOnClose | types.FileNonDirectoryFile,
+		},
+		tree:           tree,
+		authCtx:        authCtx,
+		filename:       baseName,
+		baseName:       baseName,
+		parentHandle:   parentHandle,
+		existingFile:   existingFile,
+		existingHandle: existingHandle,
+		fileExists:     fileExists,
+		createAction:   createAction,
+	}
+}
+
+// TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete locks down the
+// MS-FSA §2.1.5.18 gate exercised by smb2.delete-on-close-perms.READONLY
+// step 6: OPEN-ing an existing file with FILE_ATTRIBUTE_READONLY and the
+// FILE_DELETE_ON_CLOSE create option MUST return STATUS_CANNOT_DELETE,
+// regardless of whether the caller holds DELETE on the file's DACL.
+//
+// The mode-synthesis path here mirrors what
+// internal/adapter/smb/v2/handlers/SMBModeFromAttrs(FileAttributeReadonly,
+// false) produces after metadata.ApplyModeDefault strips the
+// modeDOSExplicit bit (0o444). The owner-write-clear leg of
+// fileAttrToSMBAttributesInternal restores FILE_ATTRIBUTE_READONLY on
+// QUERY_INFO so the DOC-arm of completeCreateAfterBreak can recognize the
+// readonly state.
+func TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDocTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	// Persist a regular file with the mode bits CREATE+FILE_ATTRIBUTE_READONLY
+	// would leave after the store round-trip (owner-write cleared, no DACL).
+	readonlyFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "ro.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o444,
+			UID:  0,
+			GID:  0,
+		})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+
+	// OPEN existing READONLY file with DELETE_ON_CLOSE. DesiredAccess carries
+	// SEC_STD_DELETE | SEC_RIGHTS_FILE_READ so hasDeleteAccess is satisfied —
+	// the MS-FSA §2.1.5.18 readonly veto must still fire.
+	const desiredAccess uint32 = 0x00130089 // SEC_RIGHTS_FILE_READ | SEC_STD_DELETE
+	draft := makeDocDraft(t, tree, rootAuth, rootHandle, readonlyFile,
+		"ro.txt", types.FileOpen, types.FileOpened, desiredAccess, 0)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusCannotDelete {
+		t.Fatalf("DOC on existing READONLY: status = 0x%08x, expected STATUS_CANNOT_DELETE (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusCannotDelete))
+	}
+}
+
+// TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete covers
+// smb2.delete-on-close-perms.READONLY step 1: a CREATE that asks to mark a
+// new file READONLY *and* DELETE_ON_CLOSE simultaneously is an immediate
+// MS-FSA §2.1.5.18 contradiction. completeCreateAfterBreak must reject the
+// open with STATUS_CANNOT_DELETE before the file is materialized in the
+// metadata store.
+func TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete(t *testing.T) {
+	h, _, smbCtx, rootHandle, rootAuth := setupDocTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	const desiredAccess uint32 = 0x001F01FF // SEC_RIGHTS_DIR_ALL (carries DELETE)
+	draft := makeDocDraft(t, tree, rootAuth, rootHandle, nil,
+		"new-ro.txt", types.FileCreate, types.FileCreated,
+		desiredAccess, types.FileAttributeReadonly)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusCannotDelete {
+		t.Fatalf("CREATE+READONLY+DOC: status = 0x%08x, expected STATUS_CANNOT_DELETE",
+			uint32(resp.Status))
+	}
+}
+
+// TestCreate_DeleteOnClose_WithoutDeleteAccess_ReturnsAccessDenied locks down
+// the MS-FSA §2.1.5.18 gate that the DOC option requires DELETE in
+// DesiredAccess (Samba: smbd_set_initial_delete_on_close). This is the
+// "hasDeleteAccess" leg of step 6d and is the first guard the DOC-perms
+// suite relies on for new-file scenarios.
+func TestCreate_DeleteOnClose_WithoutDeleteAccess_ReturnsAccessDenied(t *testing.T) {
+	h, _, smbCtx, rootHandle, rootAuth := setupDocTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	// DesiredAccess deliberately omits SEC_STD_DELETE / GENERIC_ALL /
+	// MAXIMUM_ALLOWED — hasDeleteAccess must return false and the DOC gate
+	// must fail the open with STATUS_ACCESS_DENIED.
+	const desiredAccess uint32 = 0x00120089 // SEC_RIGHTS_FILE_READ only
+	draft := makeDocDraft(t, tree, rootAuth, rootHandle, nil,
+		"no-del.txt", types.FileCreate, types.FileCreated, desiredAccess, 0)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("DOC without DELETE in DesiredAccess: status = 0x%08x, expected STATUS_ACCESS_DENIED",
+			uint32(resp.Status))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #475.

The 5 tests listed under "Delete-on-Close (Advanced Semantics)" in `test/smb-conformance/smbtorture/KNOWN_FAILURES.md` all pass on `develop` already. The KNOWN_FAILURES table is stale — the fixes landed as side effects of recent PRs touching the share-mode + DACL gates around CREATE (#553, #565, #566, #574, #575/#576).

Verified locally against `memory` profile, 3 consecutive clean runs of `./smbtorture/run.sh --filter smb2.delete-on-close-perms` — all 9 subtests PASS:
- `OVERWRITE_IF` / `OVERWRITE_IF Existing`
- `CREATE` / `CREATE Existing`
- `CREATE_IF` / `CREATE_IF Existing`
- `FIND_and_set_DOC`
- `READONLY`
- `BUG14427`

This PR adds handler-level regression tests that drive `completeCreateAfterBreak` directly so a future refactor of the step-6d DOC-arm cannot silently regress these scenarios:

- `TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete` — OPEN existing `FILE_ATTRIBUTE_READONLY` file with `FILE_DELETE_ON_CLOSE` → `STATUS_CANNOT_DELETE` (covers `delete-on-close-perms.READONLY` step 6, the most regression-prone arm because it relies on the mode-synthesis owner-write-clear round-trip).
- `TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete` — CREATE new file with `FILE_ATTRIBUTE_READONLY + FILE_DELETE_ON_CLOSE` simultaneously → `STATUS_CANNOT_DELETE` (covers the `propagatesReqAttrs` early veto, `delete-on-close-perms.READONLY` step 1).
- `TestCreate_DeleteOnClose_WithoutDeleteAccess_ReturnsAccessDenied` — `FILE_DELETE_ON_CLOSE` without `DELETE` / `GENERIC_ALL` / `MAXIMUM_ALLOWED` in `DesiredAccess` → `STATUS_ACCESS_DENIED` (covers the `hasDeleteAccess` precondition guarding the entire DOC arm).

Also adds a single `fileAttributes` field to the `CREATE request` debug log so future DOC-perms / `winattr` investigations don't need to re-instrument the wire parser to see what the client sent.

## Root cause summary per test

| Test | Status on develop | Root cause |
|------|-------------------|------------|
| `CREATE` | PASS | Cascade: was failing only because earlier subtests leaked `test_dir/test_create.dat`; recent share-mode + DACL fixes let the predecessor subtests' DOC-on-close cleanly unlink the file. |
| `CREATE_IF` | PASS | Same cascade — fixed transitively. |
| `OVERWRITE_IF` | PASS | Same cascade — fixed transitively. |
| `READONLY` | PASS | `SMBModeFromAttrs(FILE_ATTRIBUTE_READONLY, false)` clears owner-write (0o644 → 0o444); after `metadata.ApplyModeDefault` strips `modeDOSExplicit` (correctly, so auto-ARCHIVE for regular files still fires), the persisted mode keeps `(mode & 0o200) == 0`, so the legacy `fileAttrToSMBAttributesInternal` owner-write-clear leg restores `FILE_ATTRIBUTE_READONLY` on the next QUERY_INFO. Step 6d's existing-file readonly arm then fires `STATUS_CANNOT_DELETE`. |
| `FIND_and_set_DOC` | PASS | Standalone test on a freshly-created directory with full perms; no cascade. |

KNOWN_FAILURES.md is intentionally untouched per project convention — that file is walked back in a follow-up only after CI on the merged commit confirms the green status.

## Test plan
- [ ] CI green on `make smbtorture-test` (memory + memory-fs + badger-fs)
- [ ] `go test ./internal/adapter/smb/v2/handlers/ -run TestCreate_DeleteOnClose` — all 3 new tests PASS
- [ ] `go test ./internal/adapter/smb/v2/handlers/ -count=1` — no regressions in existing tests