### PR TITLE
fix(smb/acl): expand GENERIC_* on inherited ACEs (Samba desc_expand_generic)

### DIFF
--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -58,8 +58,13 @@ func substituteCreator(who string, creator Creator) string {
 // ACE, we compute two booleans:
 //
 //	applies     := (isDir && hasCI) || (!isDir && hasOI)
-//	expand_ace  := principal is CREATOR_OWNER/CREATOR_GROUP (today we do
-//	               not expand generic-mask bits; that is a separate fix)
+//	expand_ace  := principal is CREATOR_OWNER/CREATOR_GROUP
+//
+// After the per-ACE loop, generic access bits (GENERIC_READ/WRITE/EXECUTE/ALL)
+// are expanded on every emitted ACE that does NOT carry INHERIT_ONLY — mirroring
+// Samba desc_expand_generic. INHERIT_ONLY ACEs (preserved placeholders for
+// grandchildren) retain their generic bits so the expansion happens against
+// the eventual leaf object's type at that later inherit step.
 //
 // Cases:
 //
@@ -260,6 +265,22 @@ func ComputeInheritedACL(parentACL *ACL, isDirectory bool, creator Creator) *ACL
 
 	if len(inherited) == 0 {
 		return nil
+	}
+
+	// Samba desc_expand_generic (libcli/security/create_descriptor.c): after
+	// inheritance computation, expand GENERIC_* bits on every effective ACE
+	// against the child object's GenericMapping. ACEs marked INHERIT_ONLY are
+	// placeholders for grandchildren — they keep their generic bits so the
+	// expansion fires against the eventual leaf object type at the next
+	// inherit step. Without this, inherited ACEs that name GENERIC_ALL leak
+	// 0x10000000 onto the child's effective DACL, and smbtorture acls
+	// INHERITANCE/INHERITFLAGS/SDFLAGSVSCHOWN see 0x000e0002 instead of the
+	// expected 0x001f01ff (FILE_ALL_ACCESS).
+	for i := range inherited {
+		if inherited[i].Flag&ACE4_INHERIT_ONLY_ACE != 0 {
+			continue
+		}
+		inherited[i].AccessMask = ExpandGenericMask(inherited[i].AccessMask)
 	}
 
 	result := &ACL{ACEs: inherited}

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -1162,12 +1162,14 @@ func TestComputeInheritedACL_MaxACECount_CapEnforced(t *testing.T) {
 	// sentinel so we can assert FIFO preservation.
 	// Use a distinct per-index bit pattern in AccessMask so we can
 	// verify FIFO preservation regardless of CREATOR substitution
-	// rewriting the Who field. Bit 31 is set on each ACE; the low bits
-	// carry the parent index. This way:
+	// rewriting the Who field. Bit 26 (0x04000000) is a reserved bit
+	// outside the GENERIC_* and MAXIMUM_ALLOWED / ACCESS_SYSTEM_SECURITY
+	// ranges, so it passes through ExpandGenericMask unchanged. The low
+	// bits carry the parent index. This way:
 	//   - resolved CREATOR ACEs keep their (index-tagged) mask
 	//   - preserved CREATOR ACEs likewise keep the tagged mask
 	//   - we can detect leak of late-parent ACEs by mask alone
-	tag := func(i int) uint32 { return uint32(0x80000000) | uint32(i) }
+	tag := func(i int) uint32 { return uint32(0x04000000) | uint32(i) }
 
 	aces := make([]ACE, 0, MaxACECount+5)
 	aces = append(aces, ACE{
@@ -1229,6 +1231,113 @@ func TestComputeInheritedACL_MaxACECount_CapEnforced(t *testing.T) {
 	// Sanity: tag(0) (the first parent ACE) MUST be present.
 	if !resultTags[tag(0)] {
 		t.Errorf("FIFO violation: first parent ACE (tag=0x%x) missing from truncated child", tag(0))
+	}
+}
+
+// TestComputeInheritedACL_GenericExpansion_File asserts that a parent ACE
+// carrying GENERIC_ALL inherits onto a file child with the generic bit
+// expanded to FILE_ALL_ACCESS (0x001f01ff) — mirroring Samba
+// desc_expand_generic (libcli/security/create_descriptor.c). Regression
+// guard for smbtorture acls INHERITANCE / INHERITFLAGS / SDFLAGSVSCHOWN,
+// which previously observed 0x000e0002 because the generic bit leaked
+// onto the child's effective DACL.
+func TestComputeInheritedACL_GenericExpansion_File(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: 0x10000000, // GENERIC_ALL
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+	if result == nil {
+		t.Fatal("expected non-nil result for file child")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %d", len(result.ACEs))
+	}
+	const wantMask uint32 = 0x001f01ff // FILE_ALL_ACCESS
+	if got := result.ACEs[0].AccessMask; got != wantMask {
+		t.Errorf("AccessMask=0x%08x, want 0x%08x (FILE_ALL_ACCESS)", got, wantMask)
+	}
+	if result.ACEs[0].AccessMask&0xf0000000 != 0 {
+		t.Errorf("generic bits leaked into effective ACE: 0x%08x", result.ACEs[0].AccessMask)
+	}
+}
+
+// TestComputeInheritedACL_GenericExpansion_DirPreservesInheritOnly verifies
+// that on a directory child, the resolved sibling (effective) gets generic
+// bits expanded, while the preserved CREATOR ACE (INHERIT_ONLY) retains its
+// raw generic mask so expansion fires later against the eventual leaf's
+// GenericMapping.
+func TestComputeInheritedACL_GenericExpansion_DirPreservesInheritOnly(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE,
+				AccessMask: 0x10000000, // GENERIC_ALL
+				Who:        SpecialCreatorOwner,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{UID: 1001})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ACEs) != 2 {
+		t.Fatalf("expected 2 ACEs (resolved + preserved CREATOR), got %d", len(result.ACEs))
+	}
+
+	resolved := result.ACEs[0]
+	if resolved.Flag&ACE4_INHERIT_ONLY_ACE != 0 {
+		t.Errorf("resolved sibling unexpectedly INHERIT_ONLY (flag=0x%x)", resolved.Flag)
+	}
+	const wantResolved uint32 = 0x001f01ff // FILE_ALL_ACCESS
+	if resolved.AccessMask != wantResolved {
+		t.Errorf("resolved AccessMask=0x%08x, want 0x%08x", resolved.AccessMask, wantResolved)
+	}
+
+	preserved := result.ACEs[1]
+	if preserved.Flag&ACE4_INHERIT_ONLY_ACE == 0 {
+		t.Errorf("preserved ACE missing INHERIT_ONLY (flag=0x%x)", preserved.Flag)
+	}
+	if preserved.AccessMask != 0x10000000 {
+		t.Errorf("preserved AccessMask=0x%08x, want raw GENERIC_ALL preserved for grandchild expansion", preserved.AccessMask)
+	}
+}
+
+// TestComputeInheritedACL_GenericExpansion_NonGenericPassesThrough asserts
+// that ACEs without generic bits are unchanged by the post-loop expansion
+// pass.
+func TestComputeInheritedACL_GenericExpansion_NonGenericPassesThrough(t *testing.T) {
+	const explicitMask = ACE4_READ_DATA | ACE4_WRITE_DATA | ACE4_READ_ATTRIBUTES
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: explicitMask,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, false, Creator{})
+	if result == nil || len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 ACE, got %+v", result)
+	}
+	if result.ACEs[0].AccessMask != explicitMask {
+		t.Errorf("non-generic AccessMask mutated: got 0x%08x, want 0x%08x",
+			result.ACEs[0].AccessMask, explicitMask)
 	}
 }
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -53,12 +53,9 @@ descriptors, and owner rights are not implemented.
 | smb2.acls.DENY1 | ACLs | Deeper failure at acls.c:2862 — maximal_access reports 0x1E008B but expected 0x16008B (extra `SEC_DIR_DELETE_CHILD` bit set); MaxAccess computation needs to drop dir-only rights on file objects | - |
 | smb2.acls.DYNAMIC | ACLs | Dynamic access checks not implemented (fails at acls.c:1863 with NT_STATUS_OBJECT_NAME_NOT_FOUND) | - |
 | smb2.acls.GENERIC | ACLs | Deeper failure at acls.c:440 after PR #552 (FileAccessInformation now DACL-evaluated) — granted access reports 0x000f0000 but expected 0x00070080; GENERIC_ALL→specific-rights mapping still drops STANDARD bits | - |
-| smb2.acls.INHERITANCE | ACLs | Deeper failure at acls.c:1168 after PR #553 (FILE_DELETE_CHILD override) — access_flags 0x000e0002 but expected 0x001f01ff; inherited DACL on child still missing GENERIC_ALL→specific-rights expansion | - |
-| smb2.acls.INHERITFLAGS | ACLs | Deeper failure at acls.c:1434 — access_flags 0x000e0002 but expected 0x001f01ff; same inherited-DACL specific-rights expansion gap as INHERITANCE | - |
 | smb2.acls.MXAC-NOT-GRANTED | ACLs | Deeper failure at acls.c:2979 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED; MaxAccess should not implicitly grant when DACL denies the requested access | - |
 | smb2.acls.OVERWRITE_READ_ONLY_FILE | ACLs | Deeper failure at acls.c:3104 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED on OVERWRITE of read-only file | - |
 | smb2.acls.OWNER | ACLs | Owner SID semantics not implemented (fails at acls.c:765 with NT_STATUS_ACCESS_DENIED instead of NT_STATUS_OK) | - |
-| smb2.acls.SDFLAGSVSCHOWN | ACLs | Deeper failure at acls.c:1680 — access_flags 0x000e0002 but expected 0x001f01ff; same inherited-DACL specific-rights expansion gap | - |
 | smb2.sdread | Security descriptors | Security descriptor read not implemented | - |
 | smb2.secleak | Security descriptors | Security descriptor leak test not implemented | - |
 


### PR DESCRIPTION
## Summary

Mirror Samba's `desc_expand_generic` (libcli/security/create_descriptor.c): after `ComputeInheritedACL` builds the child DACL, expand `GENERIC_READ/WRITE/EXECUTE/ALL` on every emitted ACE that is **not** `INHERIT_ONLY`. Placeholder ACEs (CREATOR_OWNER preserved with `INHERIT_ONLY` for grandchildren) keep their raw generic bits so expansion fires later against the leaf object's `GenericMapping`.

Without this pass, inherited ACEs naming `GENERIC_ALL` leaked `0x10000000` into the child's effective DACL — smbtorture expected `FILE_ALL_ACCESS` (`0x001f01ff`), DittoFS returned `0x000e0002`.

## Tests targeted (KNOWN_FAILURES)

- `smb2.acls.INHERITANCE` (acls.c:1168, recurring `0x000e0002 vs 0x001f01ff`)
- `smb2.acls.INHERITFLAGS` (acls.c:1434, same gap)
- `smb2.acls.SDFLAGSVSCHOWN` (acls.c:1680, same gap)

## Changes

- ` pkg/metadata/acl/inherit.go`: post-loop pass expands generic bits on effective ACEs.
- ` pkg/metadata/acl/inherit_test.go`:
  - 3 new tests: `GenericExpansion_File`, `GenericExpansion_DirPreservesInheritOnly`, `GenericExpansion_NonGenericPassesThrough`.
  - `MaxACECount_CapEnforced` index tag flipped from `0x80000000` (GENERIC_READ — now expanded) to reserved bit `0x04000000` (passes through unchanged).

## Test plan

- [x] ` go test ./pkg/metadata/acl/...` — green (existing + 3 new)
- [x] ` go test ./pkg/metadata/... ./internal/adapter/smb/...` — green
- [ ] CI smbtorture must show INHERITANCE / INHERITFLAGS / SDFLAGSVSCHOWN flip (or progress to a deeper failure point); no regressions in passing tests
- [ ] KNOWN_FAILURES walkback as a follow-up commit after CI confirms

Refs #469.