### PR TITLE
fix(fs): trim logIndex below compactionFence (closes #581)

### DIFF
--- a/pkg/blockstore/local/fs/doc.go
+++ b/pkg/blockstore/local/fs/doc.go
@@ -100,10 +100,11 @@
 //
 // In-memory bookkeeping IS trimmed (R-2, #581): every AdvanceFence
 // call drops the prefix of logIndex.entries (and the matching consumed
-// map keys) that the fence walked past. Steady-state RSS for a
-// long-lived payload tracks the unconsumed-record set, not the full
-// arrival history — bounding the per-file index at the upper edge of
-// the dirty interval tree.
+// map keys) that the fence walked past. The backing array is
+// reallocated whenever its capacity exceeds 4× the surviving length so
+// the old high-water allocation can be reclaimed by the GC. Steady-state
+// RSS for a long-lived payload is therefore bounded at O(unconsumed-
+// record set), not at the historical arrival count.
 //
 // TRANSITIONAL-V0.17+: tracking consumption by file-offset interval
 // instead of log position would eliminate the stalled-fence pathology

--- a/pkg/blockstore/local/fs/doc.go
+++ b/pkg/blockstore/local/fs/doc.go
@@ -93,10 +93,17 @@
 //
 // TRANSITIONAL-V0.17+: physical log compaction (rewriting the log file
 // dropping consumed records up to compactionFence) is not implemented
-// here. The log grows until the payload is deleted; pressure machinery
-// caps the worst case via maxLogBytes. A future milestone will
-// add a compaction pass that truncates the on-disk log down to its
-// post-fence suffix.
+// here. The on-disk log grows until the payload is deleted; pressure
+// machinery caps the worst case via maxLogBytes. A future milestone
+// will add a compaction pass that truncates the on-disk log down to
+// its post-fence suffix.
+//
+// In-memory bookkeeping IS trimmed (R-2, #581): every AdvanceFence
+// call drops the prefix of logIndex.entries (and the matching consumed
+// map keys) that the fence walked past. Steady-state RSS for a
+// long-lived payload tracks the unconsumed-record set, not the full
+// arrival history — bounding the per-file index at the upper edge of
+// the dirty interval tree.
 //
 // TRANSITIONAL-V0.17+: tracking consumption by file-offset interval
 // instead of log position would eliminate the stalled-fence pathology

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -210,11 +210,11 @@ func (idx *logIndex) AdvanceFence() uint64 {
 // idx.mu. fenceCursor is reset to 0 so subsequent AdvanceFence calls
 // resume from the new head.
 //
-// A copy-shift (append-to-truncated-zero-len-slice) is used rather
-// than `entries = entries[fenceCursor:]` so the underlying backing
-// array's head bytes are released to the GC instead of being pinned
-// forever by the slice header — the long-lived-payload pathology
-// (#581) was precisely about that backing array growing unbounded.
+// To bound RSS at ~steady-state (not at the historical high-water mark),
+// the backing array is REALLOCATED whenever its capacity exceeds 4x the
+// surviving length. A plain reslice (`entries[fenceCursor:]`) would pin
+// the original backing array forever — defeating the point of #581 on
+// long-lived payloads whose log shrinks after a burst.
 func (idx *logIndex) trimBelowFenceLocked() {
 	if idx.fenceCursor == 0 {
 		return
@@ -223,18 +223,21 @@ func (idx *logIndex) trimBelowFenceLocked() {
 		delete(idx.consumed, idx.entries[i].logPos)
 	}
 	remaining := len(idx.entries) - idx.fenceCursor
-	if remaining == 0 {
-		// Reset to nil so the backing array drops to GC; a long-idle
-		// payload that has just had its log fully consumed should not
-		// hold on to a megabyte-class slice.
+	switch {
+	case remaining == 0:
+		// Full drain — release backing array to GC.
 		idx.entries = nil
-	} else {
-		// Shift-and-truncate. copy + reslice keeps allocations at zero
-		// on the hot path; the freed tail elements are zeroed so any
-		// retained references to payload extents would be visible to
-		// the race detector (none exist today — logEntry is a value
-		// type — but the discipline keeps future logEntry additions
-		// safe by default).
+	case cap(idx.entries) > 4*remaining:
+		// Bloated backing array — copy into a right-sized one so the old
+		// allocation can be reclaimed by the GC. The 4x threshold keeps
+		// reallocations rare in steady state while bounding cap at O(N).
+		shrunk := make([]logEntry, remaining)
+		copy(shrunk, idx.entries[idx.fenceCursor:])
+		idx.entries = shrunk
+	default:
+		// Cap already proportional to remaining — in-place shift avoids
+		// the allocation. Zero the freed tail so logEntry pointer fields
+		// (none today — value type — but future-proofed) aren't pinned.
 		copy(idx.entries, idx.entries[idx.fenceCursor:])
 		for i := remaining; i < len(idx.entries); i++ {
 			idx.entries[i] = logEntry{}

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -219,8 +219,8 @@ func (idx *logIndex) trimBelowFenceLocked() {
 	if idx.fenceCursor == 0 {
 		return
 	}
-	for i := 0; i < idx.fenceCursor; i++ {
-		delete(idx.consumed, idx.entries[i].logPos)
+	for _, e := range idx.entries[:idx.fenceCursor] {
+		delete(idx.consumed, e.logPos)
 	}
 	remaining := len(idx.entries) - idx.fenceCursor
 	switch {
@@ -239,9 +239,7 @@ func (idx *logIndex) trimBelowFenceLocked() {
 		// the allocation. Zero the freed tail so logEntry pointer fields
 		// (none today — value type — but future-proofed) aren't pinned.
 		copy(idx.entries, idx.entries[idx.fenceCursor:])
-		for i := remaining; i < len(idx.entries); i++ {
-			idx.entries[i] = logEntry{}
-		}
+		clear(idx.entries[remaining:])
 		idx.entries = idx.entries[:remaining]
 	}
 	idx.fenceCursor = 0

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -30,12 +30,21 @@ import "sync"
 // ops; the slow path only trips under genuine contention.
 //
 // TRANSITIONAL-V0.17+: physical log compaction (truncating the log file
-// at compactionFence) is out of scope. Consumed entries linger in
-// idx.entries until DeleteAppendLog wipes the payload; memory grows
-// roughly with arrival count between payload-lifetime endpoints. R-7 in
+// at compactionFence) is out of scope. The on-disk log keeps growing
+// until DeleteAppendLog wipes the payload; pressure machinery caps the
+// worst case via maxLogBytes. R-7 in
 // .planning/proposals/2026-05-22-logindex-rollup-redesign.md is the
 // follow-up to replace logPos-keyed consumption with file-offset-keyed
 // consumption, eliminating the stalled-fence pathology entirely.
+//
+// Memory bookkeeping (R-2, issue #581): in-memory `idx.entries` and
+// `idx.consumed` are TRIMMED in lockstep with AdvanceFence — every
+// fence advance drops the prefix of entries that now sit at or below
+// compactionFence and removes the matching keys from the consumed map.
+// Steady-state RSS therefore tracks the unconsumed-record set, not the
+// full payload history. The trim invariant after every AdvanceFence
+// call is: for all i, idx.entries[i].logPos >= idx.compactionFence
+// (the surviving prefix is the unconsumed-and-after-fence suffix).
 
 // logEntry is one record's position in the log + the file-offset extent it
 // covers. The entry is immutable once appended; consumption is tracked
@@ -157,6 +166,26 @@ func (idx *logIndex) MarkConsumed(logPos uint64) {
 // O(total-entries), avoiding quadratic walks across long-lived
 // payloads.
 //
+// R-2 (#581) trim: any prefix that the fence walks past in this call
+// is then DROPPED from `idx.entries` and the matching keys are removed
+// from `idx.consumed`. This bounds steady-state memory at the
+// unconsumed-record set, not the full payload history. Trimming is
+// safe because:
+//
+//   - Fenced entries' chunks are already durable in CAS (the rollup
+//     called MarkConsumed only after a successful StoreChunk pass).
+//   - rollupFile invokes tree.ConsumeUpTo immediately after
+//     AdvanceFence, so the matching file-offset intervals leave the
+//     dirty tree at the same point and no future EntriesForInterval
+//     query will look for them.
+//   - Recovery's lastPos walk rebuilds the index from scratch from the
+//     persisted rollup_offset forward — it never consults pre-fence
+//     in-memory entries.
+//
+// After trim, the post-condition holds: for all i,
+// idx.entries[i].logPos >= idx.compactionFence; fenceCursor is reset
+// to 0 so the next AdvanceFence call starts from the new head.
+//
 // This is the operation the rollup invokes after persisting a CAS
 // commit; the returned fence is what advanceRollupOffset eventually
 // writes to disk.
@@ -172,7 +201,47 @@ func (idx *logIndex) AdvanceFence() uint64 {
 		idx.compactionFence = e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen)
 		idx.fenceCursor++
 	}
+	idx.trimBelowFenceLocked()
 	return idx.compactionFence
+}
+
+// trimBelowFenceLocked drops the [0:fenceCursor) prefix of `entries`
+// and removes the matching keys from `consumed`. Caller MUST hold
+// idx.mu. fenceCursor is reset to 0 so subsequent AdvanceFence calls
+// resume from the new head.
+//
+// A copy-shift (append-to-truncated-zero-len-slice) is used rather
+// than `entries = entries[fenceCursor:]` so the underlying backing
+// array's head bytes are released to the GC instead of being pinned
+// forever by the slice header — the long-lived-payload pathology
+// (#581) was precisely about that backing array growing unbounded.
+func (idx *logIndex) trimBelowFenceLocked() {
+	if idx.fenceCursor == 0 {
+		return
+	}
+	for i := 0; i < idx.fenceCursor; i++ {
+		delete(idx.consumed, idx.entries[i].logPos)
+	}
+	remaining := len(idx.entries) - idx.fenceCursor
+	if remaining == 0 {
+		// Reset to nil so the backing array drops to GC; a long-idle
+		// payload that has just had its log fully consumed should not
+		// hold on to a megabyte-class slice.
+		idx.entries = nil
+	} else {
+		// Shift-and-truncate. copy + reslice keeps allocations at zero
+		// on the hot path; the freed tail elements are zeroed so any
+		// retained references to payload extents would be visible to
+		// the race detector (none exist today — logEntry is a value
+		// type — but the discipline keeps future logEntry additions
+		// safe by default).
+		copy(idx.entries, idx.entries[idx.fenceCursor:])
+		for i := remaining; i < len(idx.entries); i++ {
+			idx.entries[i] = logEntry{}
+		}
+		idx.entries = idx.entries[:remaining]
+	}
+	idx.fenceCursor = 0
 }
 
 // Fence returns the current compactionFence without mutation.

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -428,8 +428,7 @@ func TestLogIndex_AdvanceFence_TrimBoundedBySteadyState(t *testing.T) {
 		idx.Append(pos, uint64((inflightAhead+c)*4096), payload)
 		// Consume the OLDEST in-flight entry.
 		oldest := inflight[0]
-		inflight = append(inflight[:0], inflight[1:]...)
-		inflight = append(inflight, pos)
+		inflight = append(inflight[1:], pos)
 		idx.MarkConsumed(oldest)
 		idx.AdvanceFence()
 		pos += step

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -361,9 +361,10 @@ func TestLogIndex_AdvanceFence_TrimDoesNotCrossHole(t *testing.T) {
 
 // TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray verifies
 // the R-2 acceptance criterion: a payload that takes many AppendWrite +
-// rollup cycles must not retain unbounded entries. Drives K cycles and
-// asserts Len() stays at zero when the workload fully consumes each
-// batch, instead of growing linearly with arrival count.
+// rollup cycles must not retain unbounded entries. Drives K cycles, then
+// asserts that (a) Len()==0 after each fully-consumed cycle and (b) the
+// backing array itself is released to the GC at the end of the run by
+// inspecting `idx.entries == nil` directly (internal-package test).
 func TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray(t *testing.T) {
 	idx := newLogIndex()
 	const payload = uint32(64)
@@ -387,6 +388,17 @@ func TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray(t *testing.T) {
 	wantFence := uint64(logHeaderSize) + uint64(cycles)*step
 	if got := idx.Fence(); got != wantFence {
 		t.Fatalf("post-drain fence: got %d want %d", got, wantFence)
+	}
+	// Backing array MUST be released on full drain — internal access.
+	idx.mu.Lock()
+	entriesNil := idx.entries == nil
+	consumedLen := len(idx.consumed)
+	idx.mu.Unlock()
+	if !entriesNil {
+		t.Fatalf("full drain did not release entries backing array (still non-nil)")
+	}
+	if consumedLen != 0 {
+		t.Fatalf("consumed map not drained: len=%d", consumedLen)
 	}
 }
 

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -254,6 +254,185 @@ func TestLogIndex_AdvanceFence_CursorSkipsConsumed(t *testing.T) {
 	}
 }
 
+// TestLogIndex_AdvanceFence_TrimsConsumedPrefix verifies the R-2 (#581)
+// invariant: after AdvanceFence walks past a prefix of consumed entries,
+// those entries are dropped from idx.entries and their logPos keys are
+// removed from idx.consumed. The fence value itself is preserved.
+func TestLogIndex_AdvanceFence_TrimsConsumedPrefix(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(128)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+	positions := make([]uint64, 0, 4)
+	for i := 0; i < 4; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		positions = append(positions, pos)
+		pos += step
+	}
+	if idx.Len() != 4 {
+		t.Fatalf("pre-advance Len: got %d want 4", idx.Len())
+	}
+
+	// Consume the first two entries. Fence walks past 0,1; trim drops
+	// entries[0:2] and shifts entries[2:] to the head.
+	idx.MarkConsumed(positions[0])
+	idx.MarkConsumed(positions[1])
+	wantFence := positions[1] + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("fence after consume 0,1: got %d want %d", got, wantFence)
+	}
+	if got := idx.Len(); got != 2 {
+		t.Fatalf("Len after trim: got %d want 2", got)
+	}
+
+	// Surviving entries must be the original positions[2] and positions[3]
+	// — verifiable via EntriesForInterval over the file-offset window
+	// they cover.
+	hits := idx.EntriesForInterval(0, 4*4096)
+	if len(hits) != 2 {
+		t.Fatalf("EntriesForInterval after trim: got %d want 2", len(hits))
+	}
+	if hits[0].logPos != positions[2] || hits[1].logPos != positions[3] {
+		t.Fatalf("entries after trim: got logPos %d,%d want %d,%d",
+			hits[0].logPos, hits[1].logPos, positions[2], positions[3])
+	}
+
+	// Trim invariant: every surviving entry has logPos >= compactionFence.
+	for _, e := range hits {
+		if e.logPos < wantFence {
+			t.Fatalf("trim invariant violated: entry logPos=%d < fence=%d", e.logPos, wantFence)
+		}
+	}
+
+	// `consumed` map keys for the trimmed entries are gone. Re-consuming
+	// the now-trailing entry (entries[1] in the trimmed slice) must work
+	// from the new head without help from the stale keys.
+	idx.MarkConsumed(positions[2])
+	wantFence = positions[2] + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("fence after consume positions[2]: got %d want %d", got, wantFence)
+	}
+	if got := idx.Len(); got != 1 {
+		t.Fatalf("Len after second trim: got %d want 1", got)
+	}
+}
+
+// TestLogIndex_AdvanceFence_TrimDoesNotCrossHole pins the load-bearing
+// safety property: a "hole" entry (unconsumed) at the head of the slice
+// blocks both the fence advance AND the trim, even when later entries
+// are already consumed. Otherwise we'd lose the trailing consumed
+// entries from the consumed map and AdvanceFence would never finish
+// the walk.
+func TestLogIndex_AdvanceFence_TrimDoesNotCrossHole(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(128)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+	positions := make([]uint64, 0, 4)
+	for i := 0; i < 4; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		positions = append(positions, pos)
+		pos += step
+	}
+
+	// Consume positions 1, 2, 3 but NOT 0. Fence cannot advance; trim
+	// must not run.
+	idx.MarkConsumed(positions[1])
+	idx.MarkConsumed(positions[2])
+	idx.MarkConsumed(positions[3])
+	if got := idx.AdvanceFence(); got != logHeaderSize {
+		t.Fatalf("fence with hole at head: got %d want %d", got, logHeaderSize)
+	}
+	if got := idx.Len(); got != 4 {
+		t.Fatalf("Len with hole at head: got %d want 4 (trim must not run with unconsumed head)", got)
+	}
+
+	// Filling the hole should now cascade — all four entries advance and
+	// then the entire slice is trimmed.
+	idx.MarkConsumed(positions[0])
+	wantFence := positions[3] + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("fence after head-fill: got %d want %d", got, wantFence)
+	}
+	if got := idx.Len(); got != 0 {
+		t.Fatalf("Len after full drain: got %d want 0", got)
+	}
+}
+
+// TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray verifies
+// the R-2 acceptance criterion: a payload that takes many AppendWrite +
+// rollup cycles must not retain unbounded entries. Drives K cycles and
+// asserts Len() stays at zero when the workload fully consumes each
+// batch, instead of growing linearly with arrival count.
+func TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(64)
+	const cycles = 1024 // enough that pre-trim behavior would clearly diverge
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+
+	for c := 0; c < cycles; c++ {
+		// One AppendWrite per cycle, fully consumed immediately.
+		idx.Append(pos, uint64(c*4096), payload)
+		idx.MarkConsumed(pos)
+		idx.AdvanceFence()
+		pos += step
+		// After every cycle the slice should be empty — there are no
+		// in-flight unconsumed records.
+		if got := idx.Len(); got != 0 {
+			t.Fatalf("cycle %d: Len got %d want 0 — trim is not running", c, got)
+		}
+	}
+	// Fence must reflect the total bytes consumed across all cycles.
+	wantFence := uint64(logHeaderSize) + uint64(cycles)*step
+	if got := idx.Fence(); got != wantFence {
+		t.Fatalf("post-drain fence: got %d want %d", got, wantFence)
+	}
+}
+
+// TestLogIndex_AdvanceFence_TrimBoundedBySteadyState exercises the
+// realistic shape: a payload with a small unconsumed working set but
+// many lifetime arrivals. After K AppendWrite+rollup cycles, Len() must
+// stay proportional to the working-set size, not to K.
+func TestLogIndex_AdvanceFence_TrimBoundedBySteadyState(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(64)
+	const cycles = 2048
+	const inflightAhead = 4 // every batch leaves 4 newest entries unconsumed
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+
+	// Pre-fill the in-flight window so each cycle below stays in steady
+	// state.
+	inflight := make([]uint64, 0, inflightAhead)
+	for i := 0; i < inflightAhead; i++ {
+		idx.Append(pos, uint64(i*4096), payload)
+		inflight = append(inflight, pos)
+		pos += step
+	}
+
+	for c := 0; c < cycles; c++ {
+		// Add a new arrival.
+		idx.Append(pos, uint64((inflightAhead+c)*4096), payload)
+		// Consume the OLDEST in-flight entry.
+		oldest := inflight[0]
+		inflight = append(inflight[:0], inflight[1:]...)
+		inflight = append(inflight, pos)
+		idx.MarkConsumed(oldest)
+		idx.AdvanceFence()
+		pos += step
+
+		// Len must stay bounded by the in-flight window — never grow
+		// linearly with c. Allow a small slack (1) for the just-appended
+		// entry; the working-set guard is 2*inflightAhead which is
+		// generous but still O(1) in c.
+		if got := idx.Len(); got > 2*inflightAhead {
+			t.Fatalf("cycle %d: Len got %d, exceeds steady-state bound %d — trim is leaking",
+				c, got, 2*inflightAhead)
+		}
+	}
+}
+
 // TestLogIndex_EntriesForInterval_OverflowGuard verifies that a query
 // whose fileOff + length sum wraps past MaxUint64 still returns the
 // expected records — the saturating end calculation prevents the


### PR DESCRIPTION
## Summary

- After `AdvanceFence` walks past a prefix of consumed entries, drop those entries from `idx.entries` and remove the matching keys from `idx.consumed`. Steady-state RSS for a long-lived payload now tracks the unconsumed-record set rather than the full arrival history.
- Trim invariant post-condition: for all `i`, `entries[i].logPos >= compactionFence`. `fenceCursor` resets to 0; entries past an unconsumed hole stay intact (load-bearing for the stalled-fence path).
- Backing array is released to the GC on full drain (`entries = nil`), avoiding pinning a megabyte-class slice on idle payloads.

Stacks on #592 (internal `idx.mu` from #590). Once #592 merges, this should rebase cleanly onto develop.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/blockstore/local/fs/ -count=1` — all green
- [x] `go vet ./...`
- [x] `go test ./pkg/blockstore/... -count=1` — all green
- [x] New tests: prefix trim, hole-blocks-trim invariant, full-drain backing-array release, sustained 2048-cycle write+rollup loop asserting `Len()` stays bounded by the in-flight window