### PR TITLE
fix(fs): track logIndex consumption by file-offset interval (closes #580)

### DIFF
--- a/pkg/blockstore/local/fs/doc.go
+++ b/pkg/blockstore/local/fs/doc.go
@@ -77,19 +77,22 @@
 //   - readRecordAt(rf, logPos, payloadLen) does a single pread per record
 //     (header + payload), CRC-validates, and returns the payload.
 //   - After StoreChunk succeeds for every emitted chunk, idx.MarkConsumed
-//     is called for each surviving logPos; idx.AdvanceFence walks the
-//     consumed set forward from the prior fence and returns the new one
-//     — that value is what gets persisted as rollup_offset.
+//     is called for each surviving record's FILE-OFFSET extent (R-7,
+//     #580); idx.AdvanceFence walks entries forward from the prior fence
+//     and returns the new one — that value is what gets persisted as
+//     rollup_offset.
 //
 // rollup_offset semantic shift: the on-disk format is unchanged, but
 // the value now records the compactionFence (largest logPos s.t. every
-// earlier entry has been consumed) rather than a sequential scan cursor.
-// A consumed entry preceded by an unconsumed predecessor does NOT advance
-// the fence — its chunks are durable, but the log byte prefix stays
-// anchored until the predecessor is consumed (the "stalled fence"
-// scenario). tree.ConsumeUpTo still runs every pass that emits chunks,
-// so the dirty interval clears and the workload makes forward progress
-// even when the fence cannot.
+// earlier entry's file extent has been chunked by SOME consumed record)
+// rather than a sequential scan cursor. An entry whose file extent is
+// fully covered by a LATER overlapping consumed record becomes dead even
+// if the entry itself was never picked up by a rollup pass — the head-
+// of-log overwrite stall is gone. An entry whose file extent has no
+// overlapping consumed coverage stays alive and pins the fence until
+// some record covering it is chunked. tree.ConsumeUpTo still runs every
+// pass that emits chunks, so the dirty interval clears and the workload
+// makes forward progress even when the fence cannot.
 //
 // TRANSITIONAL-V0.17+: physical log compaction (rewriting the log file
 // dropping consumed records up to compactionFence) is not implemented
@@ -106,11 +109,11 @@
 // RSS for a long-lived payload is therefore bounded at O(unconsumed-
 // record set), not at the historical arrival count.
 //
-// TRANSITIONAL-V0.17+: tracking consumption by file-offset interval
-// instead of log position would eliminate the stalled-fence pathology
-// entirely. Direction 1 keeps consumption keyed by logPos for minimal
-// surface change; the file-offset-keyed variant is a v0.17 follow-up
-// per R-7 in .planning/proposals/2026-05-22-logindex-rollup-redesign.md.
+// R-7 (#580): consumption is now keyed by FILE-OFFSET interval (see
+// logindex.go::coverageSet), so an overwritten head record's bytes are
+// reclaimed as soon as the overwrite chunks — no longer pinned by the
+// head record's own stabilization. The stalled-fence pathology from the
+// initial Direction-1 design is gone.
 //
 // # Pressure channel (LSL-04, INV-05)
 //

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -29,26 +29,29 @@ import "sync"
 // is minimal — sync.Mutex's uncontended fast path is a couple of atomic
 // ops; the slow path only trips under genuine contention.
 //
-// TRANSITIONAL-V0.17+: physical log compaction (truncating the log file
-// at compactionFence) is out of scope. The on-disk log keeps growing
-// until DeleteAppendLog wipes the payload; pressure machinery caps the
-// worst case via maxLogBytes. R-7 in
-// .planning/proposals/2026-05-22-logindex-rollup-redesign.md is the
-// follow-up to replace logPos-keyed consumption with file-offset-keyed
-// consumption, eliminating the stalled-fence pathology entirely.
+// R-7 (closes #580): consumption is keyed by FILE-OFFSET interval, not by
+// logPos. An entry's frame bytes become eligible for fence advance once
+// the file-offset extent it covers is fully chunked by SOME consumed
+// record (itself or any later overlapping one). This kills the
+// stalled-fence pathology where a head record stuck in the dirty tree
+// pinned the on-disk byte prefix even when every byte of its file region
+// had been superseded by a later, already-chunked overwrite.
 //
-// Memory bookkeeping (R-2, issue #581): in-memory `idx.entries` and
-// `idx.consumed` are TRIMMED in lockstep with AdvanceFence — every
-// fence advance drops the prefix of entries that now sit at or below
-// compactionFence and removes the matching keys from the consumed map.
-// Steady-state RSS therefore tracks the unconsumed-record set, not the
-// full payload history. The trim invariant after every AdvanceFence
-// call is: for all i, idx.entries[i].logPos >= idx.compactionFence
-// (the surviving prefix is the unconsumed-and-after-fence suffix).
+// Memory bookkeeping (R-2, #581): in-memory `idx.entries` is TRIMMED in
+// lockstep with AdvanceFence — every fence advance drops the prefix of
+// entries that now sit at or below compactionFence. Steady-state RSS
+// therefore tracks the unconsumed-record set, not the full payload
+// history. The trim invariant after every AdvanceFence call is: for all
+// i, idx.entries[i].logPos >= idx.compactionFence. (The consumedCoverage
+// interval set is NOT trimmed in lockstep — its merged-interval rep is
+// already proportional to distinct dirty file regions, not arrival count.)
+//
+// Physical log compaction (truncating the log file at compactionFence) is
+// still out of scope and remains tracked as v0.17+ work — see #579.
 
 // logEntry is one record's position in the log + the file-offset extent it
 // covers. The entry is immutable once appended; consumption is tracked
-// separately via the consumed map on logIndex.
+// separately via consumedCoverage on logIndex.
 type logEntry struct {
 	logPos     uint64 // byte offset of the frame's first byte in the log file
 	fileOff    uint64 // record's file_offset field (16-byte frame header)
@@ -62,11 +65,13 @@ func (e logEntry) fileEnd() uint64 {
 
 // logIndex maintains per-file log-position bookkeeping. Entries are
 // appended in arrival order (== logPos order, since AppendWrite advances
-// lf.eofPos monotonically under per-file mu). The consumed map records
-// which logPos values have been rolled up into CAS; compactionFence is
-// the largest logPos such that every entry with logPos <= fence has been
-// consumed — i.e. the on-disk byte prefix that is now eligible for
-// physical compaction (deferred to v0.17+).
+// lf.eofPos monotonically under per-file mu). consumedCoverage is the
+// union of FILE-OFFSET intervals that have been rolled up into CAS; an
+// entry's frame is eligible for fence advance once consumedCoverage fully
+// covers [entry.fileOff, entry.fileEnd()). compactionFence is the largest
+// logPos prefix such that every entry with logPos < fence has its file
+// extent fully covered — i.e. the on-disk byte prefix that is now
+// eligible for physical compaction (deferred to v0.17+, #579).
 //
 // rollup_offset on disk continues to mean "consumed up to this log byte
 // offset"; conceptually it now records compactionFence rather than a
@@ -75,10 +80,10 @@ type logIndex struct {
 	// mu guards every field below. See package doc on logIndex above for
 	// rationale (defensive guard against lifecycle drift; uncontended on
 	// the steady-state hot path).
-	mu              sync.Mutex
-	entries         []logEntry
-	consumed        map[uint64]struct{} // key = logEntry.logPos
-	compactionFence uint64
+	mu               sync.Mutex
+	entries          []logEntry
+	consumedCoverage coverageSet
+	compactionFence  uint64
 	// fenceCursor is the index into `entries` of the first entry whose
 	// logPos is at or beyond compactionFence. AdvanceFence resumes its
 	// walk from this cursor instead of rescanning the entire slice on
@@ -93,7 +98,6 @@ type logIndex struct {
 func newLogIndex() *logIndex {
 	return &logIndex{
 		entries:         nil,
-		consumed:        make(map[uint64]struct{}),
 		compactionFence: logHeaderSize,
 	}
 }
@@ -101,6 +105,7 @@ func newLogIndex() *logIndex {
 // Append records a new entry. Caller MUST pass a logPos strictly greater
 // than the most recent entry's logPos (eofPos advances monotonically).
 // Append does not validate ordering — the contract is on the caller.
+// Internal mu guards the slice mutation.
 func (idx *logIndex) Append(logPos uint64, fileOff uint64, payloadLen uint32) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
@@ -146,20 +151,36 @@ func (idx *logIndex) EntriesForInterval(fileOff uint64, length uint64) []logEntr
 	return out
 }
 
-// MarkConsumed records that the entry at logPos has been rolled into
-// CAS. Idempotent — repeat calls for the same logPos are a no-op.
-func (idx *logIndex) MarkConsumed(logPos uint64) {
+// MarkConsumed records that a record with the given file-offset extent
+// has been rolled into CAS. Idempotent — overlapping calls are merged
+// into the underlying interval set. The logPos that originated the chunk
+// is intentionally NOT tracked: deadness is a property of the FILE-OFFSET
+// region, not of the log position (R-7, #580). A later overlapping
+// MarkConsumed can therefore release the on-disk bytes of a still-
+// unconsumed earlier record whose file region has been fully superseded.
+//
+// payloadLen == 0 is a no-op (matches AppendWrite's len(data) == 0
+// short-circuit).
+func (idx *logIndex) MarkConsumed(fileOff uint64, payloadLen uint32) {
+	if payloadLen == 0 {
+		return
+	}
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	idx.consumed[logPos] = struct{}{}
+	idx.consumedCoverage.add(fileOff, fileOff+uint64(payloadLen))
 }
 
-// AdvanceFence walks consumed entries in logPos order from the current
-// fenceCursor forward, advancing compactionFence past every entry that
-// is consumed and contiguous. Stops at the first non-consumed entry.
-// The new fence is returned. An out-of-order consumed entry (a "hole"
-// left by an unconsumed predecessor) does NOT advance the fence — it
-// stays in `consumed` until the predecessor is consumed too.
+// AdvanceFence walks entries in logPos order from the current fenceCursor
+// forward, advancing compactionFence past every entry whose file extent
+// is fully covered by consumedCoverage. Stops at the first entry whose
+// file extent is NOT fully covered. The new fence is returned.
+//
+// R-7 semantic: an entry's frame becomes dead on disk once EVERY byte of
+// [entry.fileOff, entry.fileEnd()) is covered by some chunked record
+// (itself or any other overlapping record). This is strictly weaker than
+// the old "consumed by logPos" predicate — an overwritten head record
+// can be released without ever being consumed itself, because the
+// overwrite covers its bytes.
 //
 // fenceCursor tracks the first entry index at or beyond the current
 // fence so repeated calls cost O(newly-consumed-entries) rather than
@@ -194,10 +215,10 @@ func (idx *logIndex) AdvanceFence() uint64 {
 	defer idx.mu.Unlock()
 	for idx.fenceCursor < len(idx.entries) {
 		e := idx.entries[idx.fenceCursor]
-		if _, ok := idx.consumed[e.logPos]; !ok {
+		if !idx.consumedCoverage.covers(e.fileOff, e.fileEnd()) {
 			break
 		}
-		// Fence advances past the consumed entry's full record extent.
+		// Fence advances past the dead entry's full record extent.
 		idx.compactionFence = e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen)
 		idx.fenceCursor++
 	}
@@ -206,21 +227,23 @@ func (idx *logIndex) AdvanceFence() uint64 {
 }
 
 // trimBelowFenceLocked drops the [0:fenceCursor) prefix of `entries`
-// and removes the matching keys from `consumed`. Caller MUST hold
-// idx.mu. fenceCursor is reset to 0 so subsequent AdvanceFence calls
-// resume from the new head.
+// Caller MUST hold idx.mu. fenceCursor is reset to 0 so subsequent
+// AdvanceFence calls resume from the new head.
 //
 // To bound RSS at ~steady-state (not at the historical high-water mark),
 // the backing array is REALLOCATED whenever its capacity exceeds 4x the
 // surviving length. A plain reslice (`entries[fenceCursor:]`) would pin
 // the original backing array forever — defeating the point of #581 on
 // long-lived payloads whose log shrinks after a burst.
+//
+// consumedCoverage is intentionally NOT trimmed here: its merged-interval
+// representation is already bounded by the count of distinct dirty file
+// regions rather than by AppendWrite arrival count, so trimming would not
+// meaningfully shrink it and could break the AdvanceFence coverage test
+// for entries that span ranges still partially covered by old intervals.
 func (idx *logIndex) trimBelowFenceLocked() {
 	if idx.fenceCursor == 0 {
 		return
-	}
-	for _, e := range idx.entries[:idx.fenceCursor] {
-		delete(idx.consumed, e.logPos)
 	}
 	remaining := len(idx.entries) - idx.fenceCursor
 	switch {
@@ -264,6 +287,17 @@ func (idx *logIndex) Fence() uint64 {
 // the cursor naturally starts at the head of the slice; subsequent
 // AdvanceFence calls will skip past any pre-fence entries on the first
 // invocation only.
+//
+// R-7 (#580): recovery only replays records at logPos >= fence — those
+// below the persisted rollup_offset were already chunked and the bytes
+// already reclaimed at the on-disk level. They are NOT in `entries`, so
+// AdvanceFence never tries to walk past them and no pre-seeding of
+// consumedCoverage for pre-fence file regions is required. A post-boot
+// re-write that lands at the same file-offset as a pre-boot chunked
+// record will, in the steady state, be consumed by a future rollup pass
+// the normal way; its own MarkConsumed adds its extent to
+// consumedCoverage, allowing the fence to walk forward without needing
+// pre-fence coverage seeding.
 func (idx *logIndex) SetFence(fence uint64) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
@@ -277,4 +311,116 @@ func (idx *logIndex) Len() int {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	return len(idx.entries)
+}
+
+// coverageSet is a sorted, merged set of half-open [start, end) byte
+// intervals over the file-offset domain. It answers two questions in
+// log(N): "add this interval" and "is this interval fully covered". The
+// invariant is that stored intervals are non-empty, non-overlapping, and
+// non-adjacent (adjacent intervals are merged on insert) so coverage
+// tests reduce to a single binary search.
+//
+// Not goroutine-safe on its own — embedded in logIndex which guards all
+// access via idx.mu.
+//
+// The btree-backed intervalTree was considered and rejected: it carries
+// per-entry Touched timestamps and an offset-only ordering keyed for the
+// stabilization-window query (EarliestStable). The coverage problem here
+// is a pure interval-union problem with neither timestamps nor stable-
+// interval semantics — a flat sorted slice is faster, simpler, and has
+// the same big-O for both operations at the workload-realistic entry
+// counts (the per-payload coverage set tracks unique consumed regions,
+// which the rollup actively coalesces by chunking adjacent intervals).
+type coverageSet struct {
+	intervals []coverageInterval
+}
+
+type coverageInterval struct {
+	start, end uint64 // half-open [start, end)
+}
+
+// add merges [start, end) into the set, coalescing with adjacent and
+// overlapping intervals. O(log N) binary search + O(K) merge where K is
+// the number of intervals fully subsumed by the new range (typically 0
+// or 1 in steady state because the rollup chunks contiguous regions).
+//
+// Empty or inverted ranges (end <= start) are silently ignored.
+func (cs *coverageSet) add(start, end uint64) {
+	if end <= start {
+		return
+	}
+	// Binary search for the first existing interval whose `end` is >= new
+	// `start`. Any interval ending strictly before `start` cannot overlap
+	// or be adjacent (we treat [a,b) and [b,c) as adjacent → merge), so we
+	// keep it as-is to the left.
+	lo, hi := 0, len(cs.intervals)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if cs.intervals[mid].end < start {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	insertAt := lo
+	// Sweep forward from insertAt, absorbing every interval whose `start`
+	// is <= new `end` (adjacent intervals are merged because their
+	// boundary touches).
+	mergeEnd := end
+	mergeStart := start
+	j := insertAt
+	for j < len(cs.intervals) && cs.intervals[j].start <= mergeEnd {
+		if cs.intervals[j].start < mergeStart {
+			mergeStart = cs.intervals[j].start
+		}
+		if cs.intervals[j].end > mergeEnd {
+			mergeEnd = cs.intervals[j].end
+		}
+		j++
+	}
+	// Replace [insertAt, j) with the merged interval.
+	merged := coverageInterval{start: mergeStart, end: mergeEnd}
+	if j == insertAt {
+		// No overlap — insert in place.
+		cs.intervals = append(cs.intervals, coverageInterval{})
+		copy(cs.intervals[insertAt+1:], cs.intervals[insertAt:])
+		cs.intervals[insertAt] = merged
+		return
+	}
+	cs.intervals[insertAt] = merged
+	if j > insertAt+1 {
+		// Collapse subsumed intervals out of the slice.
+		cs.intervals = append(cs.intervals[:insertAt+1], cs.intervals[j:]...)
+	}
+}
+
+// covers reports whether [start, end) is fully covered by the union of
+// stored intervals. Empty / inverted ranges (end <= start) return true
+// vacuously — a zero-length region has nothing to cover.
+//
+// O(log N) binary search to locate the candidate interval, plus a single
+// containment test. Because the set is merged-on-insert, at most one
+// stored interval can contain a given query range; if that one doesn't,
+// no other can.
+func (cs *coverageSet) covers(start, end uint64) bool {
+	if end <= start {
+		return true
+	}
+	// Binary search for the LAST interval whose `start` is <= query start.
+	// That candidate is the only interval that could possibly contain
+	// [start, end).
+	lo, hi := 0, len(cs.intervals)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if cs.intervals[mid].start <= start {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo == 0 {
+		return false
+	}
+	cand := cs.intervals[lo-1]
+	return cand.start <= start && cand.end >= end
 }

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -1,6 +1,9 @@
 package fs
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // Per-file logIndex (Direction 1 redesign — see
 // .planning/proposals/2026-05-22-logindex-rollup-redesign.md).
@@ -59,8 +62,15 @@ type logEntry struct {
 }
 
 // fileEnd returns the exclusive file-offset upper bound for this record.
+// Saturates on overflow so a pathological fileOff near MaxUint64 produces
+// a well-formed (non-wrapping) interval — AdvanceFence's coverage test
+// and EntriesForInterval's overlap test then stay correct.
 func (e logEntry) fileEnd() uint64 {
-	return e.fileOff + uint64(e.payloadLen)
+	end := e.fileOff + uint64(e.payloadLen)
+	if end < e.fileOff {
+		return ^uint64(0)
+	}
+	return end
 }
 
 // logIndex maintains per-file log-position bookkeeping. Entries are
@@ -160,14 +170,21 @@ func (idx *logIndex) EntriesForInterval(fileOff uint64, length uint64) []logEntr
 // unconsumed earlier record whose file region has been fully superseded.
 //
 // payloadLen == 0 is a no-op (matches AppendWrite's len(data) == 0
-// short-circuit).
+// short-circuit). The end = fileOff + payloadLen sum is computed with
+// overflow saturation (consistent with EntriesForInterval) so a
+// pathological wrap can never produce an empty interval that would
+// silently fail to advance the fence.
 func (idx *logIndex) MarkConsumed(fileOff uint64, payloadLen uint32) {
 	if payloadLen == 0 {
 		return
 	}
+	end := fileOff + uint64(payloadLen)
+	if end < fileOff {
+		end = ^uint64(0)
+	}
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	idx.consumedCoverage.add(fileOff, fileOff+uint64(payloadLen))
+	idx.consumedCoverage.add(fileOff, end)
 }
 
 // AdvanceFence walks entries in logPos order from the current fenceCursor
@@ -364,34 +381,22 @@ func (cs *coverageSet) add(start, end uint64) {
 	}
 	insertAt := lo
 	// Sweep forward from insertAt, absorbing every interval whose `start`
-	// is <= new `end` (adjacent intervals are merged because their
-	// boundary touches).
-	mergeEnd := end
-	mergeStart := start
+	// is <= mergeEnd (adjacent intervals merge because their boundary
+	// touches). Stored intervals are sorted and non-overlapping, so only
+	// intervals[insertAt] can possibly lower mergeStart — every later
+	// interval starts at or beyond the previous one's end.
+	mergeStart, mergeEnd := start, end
 	j := insertAt
 	for j < len(cs.intervals) && cs.intervals[j].start <= mergeEnd {
-		if cs.intervals[j].start < mergeStart {
-			mergeStart = cs.intervals[j].start
-		}
-		if cs.intervals[j].end > mergeEnd {
-			mergeEnd = cs.intervals[j].end
-		}
+		mergeStart = min(mergeStart, cs.intervals[j].start)
+		mergeEnd = max(mergeEnd, cs.intervals[j].end)
 		j++
 	}
-	// Replace [insertAt, j) with the merged interval.
-	merged := coverageInterval{start: mergeStart, end: mergeEnd}
-	if j == insertAt {
-		// No overlap — insert in place.
-		cs.intervals = append(cs.intervals, coverageInterval{})
-		copy(cs.intervals[insertAt+1:], cs.intervals[insertAt:])
-		cs.intervals[insertAt] = merged
-		return
-	}
-	cs.intervals[insertAt] = merged
-	if j > insertAt+1 {
-		// Collapse subsumed intervals out of the slice.
-		cs.intervals = append(cs.intervals[:insertAt+1], cs.intervals[j:]...)
-	}
+	// Replace [insertAt, j) with the single merged interval. Handles
+	// insert (j == insertAt), in-place rewrite (j == insertAt+1) and
+	// subsumption (j > insertAt+1) uniformly.
+	cs.intervals = slices.Replace(cs.intervals, insertAt, j,
+		coverageInterval{start: mergeStart, end: mergeEnd})
 }
 
 // covers reports whether [start, end) is fully covered by the union of

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -122,17 +122,23 @@ func TestLogIndex_EntriesForInterval_Boundaries(t *testing.T) {
 	}
 }
 
-// TestLogIndex_AdvanceFence_Contiguous verifies that consuming records in
-// arrival order advances the fence past each full record extent.
+// TestLogIndex_AdvanceFence_Contiguous verifies that marking each entry's
+// file extent consumed advances the fence past each full record extent
+// when entries are non-overlapping.
 func TestLogIndex_AdvanceFence_Contiguous(t *testing.T) {
 	idx := newLogIndex()
 	const payload = uint32(256)
 	step := uint64(recordFrameOverhead) + uint64(payload)
 	pos := uint64(logHeaderSize)
-	positions := make([]uint64, 0, 3)
+	type entExt struct {
+		logPos  uint64
+		fileOff uint64
+	}
+	ents := make([]entExt, 0, 3)
 	for i := 0; i < 3; i++ {
-		idx.Append(pos, uint64(i*4096), payload)
-		positions = append(positions, pos)
+		fileOff := uint64(i * 4096)
+		idx.Append(pos, fileOff, payload)
+		ents = append(ents, entExt{logPos: pos, fileOff: fileOff})
 		pos += step
 	}
 
@@ -141,69 +147,80 @@ func TestLogIndex_AdvanceFence_Contiguous(t *testing.T) {
 		t.Fatalf("fence with no consumption: got %d want %d", got, logHeaderSize)
 	}
 
-	// Consume the first entry. Fence advances to end of record 0.
-	idx.MarkConsumed(positions[0])
-	want := positions[0] + step
+	// Consume the first entry's file extent. Fence advances past record 0.
+	idx.MarkConsumed(ents[0].fileOff, payload)
+	want := ents[0].logPos + step
 	if got := idx.AdvanceFence(); got != want {
 		t.Fatalf("fence after consume[0]: got %d want %d", got, want)
 	}
 
-	// Consume the second entry. Fence advances to end of record 1.
-	idx.MarkConsumed(positions[1])
-	want = positions[1] + step
+	// Consume the second entry's file extent.
+	idx.MarkConsumed(ents[1].fileOff, payload)
+	want = ents[1].logPos + step
 	if got := idx.AdvanceFence(); got != want {
 		t.Fatalf("fence after consume[1]: got %d want %d", got, want)
 	}
 
-	// Consume the third entry. Fence advances to end of record 2 (== pos).
-	idx.MarkConsumed(positions[2])
-	want = positions[2] + step
+	// Consume the third entry's file extent.
+	idx.MarkConsumed(ents[2].fileOff, payload)
+	want = ents[2].logPos + step
 	if got := idx.AdvanceFence(); got != want {
 		t.Fatalf("fence after consume[2]: got %d want %d", got, want)
 	}
 }
 
-// TestLogIndex_AdvanceFence_HoleBlocks verifies the load-bearing
-// invariant for R-7: a consumed entry preceded by an unconsumed
-// predecessor must NOT advance the fence.
+// TestLogIndex_AdvanceFence_HoleBlocks verifies that a consumed entry
+// preceded by a head entry whose file region is NOT yet covered must NOT
+// advance the fence. With non-overlapping file regions (records at
+// distinct extents), consuming the trailing entries' extents does not
+// cover the head entry's extent, so the fence stays anchored at the head
+// until the head's own extent is consumed.
 func TestLogIndex_AdvanceFence_HoleBlocks(t *testing.T) {
 	idx := newLogIndex()
 	const payload = uint32(256)
 	step := uint64(recordFrameOverhead) + uint64(payload)
 	pos := uint64(logHeaderSize)
-	positions := []uint64{}
+	type entExt struct {
+		logPos  uint64
+		fileOff uint64
+	}
+	ents := []entExt{}
 	for i := 0; i < 3; i++ {
-		idx.Append(pos, uint64(i*4096), payload)
-		positions = append(positions, pos)
+		fileOff := uint64(i * 4096)
+		idx.Append(pos, fileOff, payload)
+		ents = append(ents, entExt{logPos: pos, fileOff: fileOff})
 		pos += step
 	}
 
-	// Consume entries 1 and 2 (skipping 0). Fence MUST stay at the
-	// header boundary because record 0 is still in-flight.
-	idx.MarkConsumed(positions[1])
-	idx.MarkConsumed(positions[2])
+	// Consume entries 1 and 2 (skipping head). Fence MUST stay at the
+	// header boundary because record 0's file region [0, 256) is not
+	// covered by either trailing record's extent.
+	idx.MarkConsumed(ents[1].fileOff, payload)
+	idx.MarkConsumed(ents[2].fileOff, payload)
 	if got := idx.AdvanceFence(); got != logHeaderSize {
 		t.Fatalf("hole at head: fence got %d want %d", got, logHeaderSize)
 	}
 
-	// Now consume record 0. The fence walks through all three because
-	// 1 and 2 are already marked.
-	idx.MarkConsumed(positions[0])
-	want := positions[2] + step
+	// Now consume record 0's extent. The fence walks through all three
+	// because the head is now covered and the trailing extents were
+	// already covered by their own MarkConsumed calls above.
+	idx.MarkConsumed(ents[0].fileOff, payload)
+	want := ents[2].logPos + step
 	if got := idx.AdvanceFence(); got != want {
 		t.Fatalf("fence after head-consume: got %d want %d", got, want)
 	}
 }
 
 // TestLogIndex_MarkConsumed_Idempotent guards against repeated rollup
-// calls for the same entry inflating any internal accounting. (None
-// today, but cheap to enforce.)
+// calls for the same file extent inflating any internal accounting. The
+// coverageSet add operation is set-union, so repeated identical calls
+// are no-ops.
 func TestLogIndex_MarkConsumed_Idempotent(t *testing.T) {
 	idx := newLogIndex()
 	idx.Append(logHeaderSize, 0, 100)
-	idx.MarkConsumed(logHeaderSize)
-	idx.MarkConsumed(logHeaderSize)
-	idx.MarkConsumed(logHeaderSize)
+	idx.MarkConsumed(0, 100)
+	idx.MarkConsumed(0, 100)
+	idx.MarkConsumed(0, 100)
 	want := uint64(logHeaderSize) + uint64(recordFrameOverhead) + 100
 	if got := idx.AdvanceFence(); got != want {
 		t.Fatalf("fence: got %d want %d", got, want)
@@ -234,8 +251,9 @@ func TestLogIndex_AdvanceFence_CursorSkipsConsumed(t *testing.T) {
 	step := uint64(recordFrameOverhead) + uint64(payload)
 	pos := uint64(logHeaderSize)
 	for i := 0; i < 3; i++ {
-		idx.Append(pos, uint64(i*4096), payload)
-		idx.MarkConsumed(pos)
+		fileOff := uint64(i * 4096)
+		idx.Append(pos, fileOff, payload)
+		idx.MarkConsumed(fileOff, payload)
 		pos += step
 	}
 	wantAfterThree := uint64(logHeaderSize) + 3*step
@@ -244,8 +262,9 @@ func TestLogIndex_AdvanceFence_CursorSkipsConsumed(t *testing.T) {
 	}
 	// Append two more entries, mark both consumed, AdvanceFence again.
 	for i := 3; i < 5; i++ {
-		idx.Append(pos, uint64(i*4096), payload)
-		idx.MarkConsumed(pos)
+		fileOff := uint64(i * 4096)
+		idx.Append(pos, fileOff, payload)
+		idx.MarkConsumed(fileOff, payload)
 		pos += step
 	}
 	wantAfterFive := uint64(logHeaderSize) + 5*step
@@ -273,10 +292,11 @@ func TestLogIndex_AdvanceFence_TrimsConsumedPrefix(t *testing.T) {
 		t.Fatalf("pre-advance Len: got %d want 4", idx.Len())
 	}
 
-	// Consume the first two entries. Fence walks past 0,1; trim drops
-	// entries[0:2] and shifts entries[2:] to the head.
-	idx.MarkConsumed(positions[0])
-	idx.MarkConsumed(positions[1])
+	// Consume the first two entries (by file extent — R-7 semantics).
+	// Fence walks past 0,1; trim drops entries[0:2] and shifts
+	// entries[2:] to the head.
+	idx.MarkConsumed(0, payload)
+	idx.MarkConsumed(4096, payload)
 	wantFence := positions[1] + step
 	if got := idx.AdvanceFence(); got != wantFence {
 		t.Fatalf("fence after consume 0,1: got %d want %d", got, wantFence)
@@ -304,10 +324,9 @@ func TestLogIndex_AdvanceFence_TrimsConsumedPrefix(t *testing.T) {
 		}
 	}
 
-	// `consumed` map keys for the trimmed entries are gone. Re-consuming
-	// the now-trailing entry (entries[1] in the trimmed slice) must work
-	// from the new head without help from the stale keys.
-	idx.MarkConsumed(positions[2])
+	// Re-consuming the now-trailing entry (entries[1] in the trimmed
+	// slice) must work from the new head.
+	idx.MarkConsumed(2*4096, payload)
 	wantFence = positions[2] + step
 	if got := idx.AdvanceFence(); got != wantFence {
 		t.Fatalf("fence after consume positions[2]: got %d want %d", got, wantFence)
@@ -335,11 +354,11 @@ func TestLogIndex_AdvanceFence_TrimDoesNotCrossHole(t *testing.T) {
 		pos += step
 	}
 
-	// Consume positions 1, 2, 3 but NOT 0. Fence cannot advance; trim
-	// must not run.
-	idx.MarkConsumed(positions[1])
-	idx.MarkConsumed(positions[2])
-	idx.MarkConsumed(positions[3])
+	// Mark file regions 1,2,3 consumed but NOT region 0. Fence cannot
+	// advance past entry 0; trim must not run.
+	idx.MarkConsumed(4096, payload)
+	idx.MarkConsumed(8192, payload)
+	idx.MarkConsumed(12288, payload)
 	if got := idx.AdvanceFence(); got != logHeaderSize {
 		t.Fatalf("fence with hole at head: got %d want %d", got, logHeaderSize)
 	}
@@ -347,9 +366,9 @@ func TestLogIndex_AdvanceFence_TrimDoesNotCrossHole(t *testing.T) {
 		t.Fatalf("Len with hole at head: got %d want 4 (trim must not run with unconsumed head)", got)
 	}
 
-	// Filling the hole should now cascade — all four entries advance and
-	// then the entire slice is trimmed.
-	idx.MarkConsumed(positions[0])
+	// Marking region 0 consumed should cascade — all four entries advance
+	// and the entire slice is trimmed.
+	idx.MarkConsumed(0, payload)
 	wantFence := positions[3] + step
 	if got := idx.AdvanceFence(); got != wantFence {
 		t.Fatalf("fence after head-fill: got %d want %d", got, wantFence)
@@ -374,8 +393,9 @@ func TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray(t *testing.T) {
 
 	for c := 0; c < cycles; c++ {
 		// One AppendWrite per cycle, fully consumed immediately.
-		idx.Append(pos, uint64(c*4096), payload)
-		idx.MarkConsumed(pos)
+		fileOff := uint64(c * 4096)
+		idx.Append(pos, fileOff, payload)
+		idx.MarkConsumed(fileOff, payload)
 		idx.AdvanceFence()
 		pos += step
 		// After every cycle the slice should be empty — there are no
@@ -392,13 +412,9 @@ func TestLogIndex_AdvanceFence_TrimFullDrainReleasesBackingArray(t *testing.T) {
 	// Backing array MUST be released on full drain — internal access.
 	idx.mu.Lock()
 	entriesNil := idx.entries == nil
-	consumedLen := len(idx.consumed)
 	idx.mu.Unlock()
 	if !entriesNil {
 		t.Fatalf("full drain did not release entries backing array (still non-nil)")
-	}
-	if consumedLen != 0 {
-		t.Fatalf("consumed map not drained: len=%d", consumedLen)
 	}
 }
 
@@ -415,21 +431,24 @@ func TestLogIndex_AdvanceFence_TrimBoundedBySteadyState(t *testing.T) {
 	pos := uint64(logHeaderSize)
 
 	// Pre-fill the in-flight window so each cycle below stays in steady
-	// state.
+	// state. Track the file-offset of each in-flight entry — R-7
+	// MarkConsumed is file-offset-keyed.
 	inflight := make([]uint64, 0, inflightAhead)
 	for i := 0; i < inflightAhead; i++ {
-		idx.Append(pos, uint64(i*4096), payload)
-		inflight = append(inflight, pos)
+		fileOff := uint64(i * 4096)
+		idx.Append(pos, fileOff, payload)
+		inflight = append(inflight, fileOff)
 		pos += step
 	}
 
 	for c := 0; c < cycles; c++ {
 		// Add a new arrival.
-		idx.Append(pos, uint64((inflightAhead+c)*4096), payload)
-		// Consume the OLDEST in-flight entry.
+		newFileOff := uint64((inflightAhead + c) * 4096)
+		idx.Append(pos, newFileOff, payload)
+		// Consume the OLDEST in-flight entry's file extent.
 		oldest := inflight[0]
-		inflight = append(inflight[1:], pos)
-		idx.MarkConsumed(oldest)
+		inflight = append(inflight[1:], newFileOff)
+		idx.MarkConsumed(oldest, payload)
 		idx.AdvanceFence()
 		pos += step
 
@@ -468,5 +487,251 @@ func TestLogIndex_EntriesForInterval_OverflowGuard(t *testing.T) {
 	hits = idx.EntriesForInterval(^uint64(0)-50, 100)
 	if len(hits) != 0 {
 		t.Fatalf("post-extent query: got %+v want []", hits)
+	}
+}
+
+// TestLogIndex_AdvanceFence_OverwriteUnsticksHead is the load-bearing
+// R-7 (#580) acceptance: a head record whose file region is fully
+// covered by a LATER consumed overwrite becomes dead immediately, even
+// though the head record itself was never marked consumed. The fence
+// walks straight through it. Pre-R-7 this would have stalled at the
+// head record's frame.
+func TestLogIndex_AdvanceFence_OverwriteUnsticksHead(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(4096)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+
+	// Head: write at [0, 4K). Logically alive until something covers it.
+	headLogPos := pos
+	idx.Append(headLogPos, 0, payload)
+	pos += step
+	// Overwrite at the same file extent [0, 4K).
+	overwriteLogPos := pos
+	idx.Append(overwriteLogPos, 0, payload)
+	pos += step
+
+	// Mark ONLY the overwrite's extent consumed. The head was never
+	// processed (analog of: still in the dirty interval tree, awaiting
+	// stabilization, or held by a long-lived stable interval pass).
+	idx.MarkConsumed(0, payload)
+
+	// Fence MUST advance past BOTH frames — the head's [0, 4K) is
+	// covered by the overwrite's coverage even without the head being
+	// individually marked.
+	wantFence := overwriteLogPos + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("R-7 overwrite-unsticks-head: fence got %d want %d", got, wantFence)
+	}
+}
+
+// TestLogIndex_AdvanceFence_PartialOverlapBlocks asserts that a partial
+// overlap does NOT release the head record's bytes. The fence may only
+// walk past an entry whose FULL extent is covered — partial coverage
+// keeps the entry alive (the uncovered tail bytes are still authoritative
+// chunked-data input).
+func TestLogIndex_AdvanceFence_PartialOverlapBlocks(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(4096)
+	headLogPos := uint64(logHeaderSize)
+	idx.Append(headLogPos, 0, payload) // head: [0, 4096)
+	idx.Append(headLogPos+uint64(recordFrameOverhead)+uint64(payload), 2048, payload)
+
+	// Mark consumed only [2048, 6144). Head's [0, 4096) is only partially
+	// covered (the [2048, 4096) tail). Head must stay alive.
+	idx.MarkConsumed(2048, payload)
+	if got := idx.AdvanceFence(); got != uint64(logHeaderSize) {
+		t.Fatalf("partial overlap should not unstick head: got %d want %d", got, logHeaderSize)
+	}
+
+	// Now cover [0, 2048) too. Head's extent is now fully covered.
+	idx.MarkConsumed(0, 2048)
+	wantFence := headLogPos + 2*(uint64(recordFrameOverhead)+uint64(payload))
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("after full coverage: got %d want %d", got, wantFence)
+	}
+}
+
+// TestLogIndex_AdvanceFence_CoverageMerge verifies that two MarkConsumed
+// calls at adjacent file extents merge so a record straddling the
+// boundary still reads as fully covered. This exercises coverageSet's
+// adjacency-merge behavior: [0, 1024) + [1024, 2048) must cover an entry
+// at [0, 2048).
+func TestLogIndex_AdvanceFence_CoverageMerge(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(2048)
+	headLogPos := uint64(logHeaderSize)
+	idx.Append(headLogPos, 0, payload)
+
+	idx.MarkConsumed(0, 1024)
+	idx.MarkConsumed(1024, 1024)
+
+	wantFence := headLogPos + uint64(recordFrameOverhead) + uint64(payload)
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("adjacency merge failed: got %d want %d", got, wantFence)
+	}
+}
+
+// TestCoverageSet exercises the coverage-set primitive in isolation —
+// add merges adjacent and overlapping intervals; covers returns the
+// strict containment predicate.
+func TestCoverageSet(t *testing.T) {
+	cases := []struct {
+		name string
+		ops  func(*coverageSet)
+		// (query start, end) → expected covers result
+		queries []struct {
+			start, end uint64
+			want       bool
+		}
+	}{
+		{
+			name: "single-interval",
+			ops:  func(c *coverageSet) { c.add(10, 20) },
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{10, 20, true},
+				{11, 19, true},
+				{10, 21, false},
+				{9, 20, false},
+				{20, 30, false},
+				{0, 5, false},
+			},
+		},
+		{
+			name: "adjacency-merge",
+			ops: func(c *coverageSet) {
+				c.add(0, 10)
+				c.add(10, 20)
+				c.add(20, 30)
+			},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{0, 30, true},
+				{5, 25, true},
+				{29, 31, false},
+			},
+		},
+		{
+			name: "overlap-merge",
+			ops: func(c *coverageSet) {
+				c.add(0, 10)
+				c.add(5, 15)
+				c.add(12, 25)
+			},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{0, 25, true},
+				{0, 26, false},
+			},
+		},
+		{
+			name: "gap-stays-gap",
+			ops: func(c *coverageSet) {
+				c.add(0, 10)
+				c.add(20, 30)
+			},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{0, 10, true},
+				{20, 30, true},
+				{0, 30, false},
+				{9, 21, false},
+			},
+		},
+		{
+			name: "subsume-existing",
+			ops: func(c *coverageSet) {
+				c.add(10, 20)
+				c.add(30, 40)
+				c.add(50, 60)
+				// One big add subsumes all three.
+				c.add(0, 100)
+			},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{0, 100, true},
+				{50, 99, true},
+			},
+		},
+		{
+			name: "empty-query-vacuously-true",
+			ops:  func(_ *coverageSet) {},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{0, 0, true},
+				{100, 100, true},
+			},
+		},
+		{
+			name: "empty-add-ignored",
+			ops: func(c *coverageSet) {
+				c.add(5, 5)
+				c.add(10, 5)
+			},
+			queries: []struct {
+				start, end uint64
+				want       bool
+			}{
+				{5, 6, false},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cs coverageSet
+			tc.ops(&cs)
+			for _, q := range tc.queries {
+				if got := cs.covers(q.start, q.end); got != q.want {
+					t.Errorf("covers(%d,%d): got %v want %v (intervals=%+v)",
+						q.start, q.end, got, q.want, cs.intervals)
+				}
+			}
+		})
+	}
+}
+
+// TestCoverageSet_MergeKeepsSortedInvariant adds intervals in mixed
+// order and asserts that the underlying slice stays sorted and
+// non-overlapping — the precondition for covers's binary search.
+func TestCoverageSet_MergeKeepsSortedInvariant(t *testing.T) {
+	var cs coverageSet
+	cs.add(100, 200)
+	cs.add(0, 50)
+	cs.add(300, 400)
+	cs.add(150, 350) // bridges 100-200 and 300-400 via 150-350.
+	cs.add(60, 90)
+	cs.add(50, 60) // adjacency-bridge 0-50, 50-60, 60-90 → 0-90.
+
+	for i := 1; i < len(cs.intervals); i++ {
+		prev := cs.intervals[i-1]
+		cur := cs.intervals[i]
+		if prev.end > cur.start {
+			t.Fatalf("invariant broken: %+v then %+v", prev, cur)
+		}
+		if prev.start >= prev.end {
+			t.Fatalf("empty interval at %d: %+v", i-1, prev)
+		}
+	}
+	if len(cs.intervals) != 2 {
+		t.Fatalf("expected 2 merged intervals (0-90, 100-400), got %d: %+v", len(cs.intervals), cs.intervals)
+	}
+	if cs.intervals[0] != (coverageInterval{start: 0, end: 90}) {
+		t.Errorf("intervals[0]: got %+v want {0,90}", cs.intervals[0])
+	}
+	if cs.intervals[1] != (coverageInterval{start: 100, end: 400}) {
+		t.Errorf("intervals[1]: got %+v want {100,400}", cs.intervals[1])
 	}
 }

--- a/pkg/blockstore/local/fs/logindex_test.go
+++ b/pkg/blockstore/local/fs/logindex_test.go
@@ -509,7 +509,6 @@ func TestLogIndex_AdvanceFence_OverwriteUnsticksHead(t *testing.T) {
 	// Overwrite at the same file extent [0, 4K).
 	overwriteLogPos := pos
 	idx.Append(overwriteLogPos, 0, payload)
-	pos += step
 
 	// Mark ONLY the overwrite's extent consumed. The head was never
 	// processed (analog of: still in the dirty interval tree, awaiting

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -239,8 +239,16 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	}
 	defer func() { _ = rf.Close() }()
 
+	// consumedExtents tracks the FILE-OFFSET extent of every record that
+	// will be marked consumed in the logIndex below. R-7 (#580): consumption
+	// is keyed by file-offset interval, not logPos — so the rollup records
+	// (fileOff, payloadLen) per record instead of the logPos.
+	type consumedExt struct {
+		fileOff    uint64
+		payloadLen uint32
+	}
 	recs := make([]rec, 0, len(entries))
-	consumedPositions := make([]uint64, 0, len(entries))
+	consumedExtents := make([]consumedExt, 0, len(entries))
 	for _, e := range entries {
 		off, payload, rerr := readRecordAt(rf, e.logPos, e.payloadLen)
 		if rerr != nil {
@@ -265,7 +273,7 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 			// reads it via the rec struct.
 			endPos: e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen),
 		})
-		consumedPositions = append(consumedPositions, e.logPos)
+		consumedExtents = append(consumedExtents, consumedExt{fileOff: e.fileOff, payloadLen: e.payloadLen})
 	}
 
 	// D-29 truncation filter: drop records entirely past the truncation
@@ -273,17 +281,20 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// (plan 09); consulted here so emitted chunks never contain bytes
 	// beyond the client-observed size at truncate time.
 	//
-	// Direction-1 redesign: consumedPositions is filtered in lockstep with
-	// recs so we only mark logIndex entries consumed for records that
-	// actually contributed payload bytes to a stored chunk. Entries that
-	// truncation dropped entirely stay unconsumed; the on-disk bytes
-	// belong to a truncated tail the operator already invalidated.
+	// Direction-1 redesign: consumedExtents is filtered in lockstep with
+	// recs so we only mark logIndex coverage for records that actually
+	// contributed payload bytes to a stored chunk. Entries that truncation
+	// dropped entirely stay unconsumed; the on-disk bytes belong to a
+	// truncated tail the operator already invalidated. Clipped records
+	// have their consumedExtent.payloadLen shortened to match the bytes
+	// that actually made it into a chunk — coverage MUST match the bytes
+	// chunked, not the original record size.
 	bc.logsMu.RLock()
 	trunc, hasTrunc := bc.truncations[payloadID]
 	bc.logsMu.RUnlock()
 	if hasTrunc {
 		filtered := recs[:0]
-		filteredPos := consumedPositions[:0]
+		filteredExt := consumedExtents[:0]
 		for i, r := range recs {
 			if r.off >= trunc {
 				continue
@@ -293,10 +304,14 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 				r.payload = r.payload[:trunc-r.off]
 			}
 			filtered = append(filtered, r)
-			filteredPos = append(filteredPos, consumedPositions[i])
+			// Reflect any clipping into the consumed extent so coverage
+			// doesn't over-claim file bytes that never reached CAS.
+			ext := consumedExtents[i]
+			ext.payloadLen = uint32(len(r.payload))
+			filteredExt = append(filteredExt, ext)
 		}
 		recs = filtered
-		consumedPositions = filteredPos
+		consumedExtents = filteredExt
 	}
 
 	if len(recs) == 0 {
@@ -400,15 +415,15 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
-	// Direction-1 redesign: now that the chunks are stored, mark every
-	// surviving record's logPos consumed in the logIndex and ask the
-	// index for the new compaction fence. This is the value we persist
-	// as rollup_offset — semantically the same on-disk format, but
-	// computed from the consumed-record set instead of the pre-Direction-1
-	// "scan cursor advances past each record" arithmetic. A consumed
-	// entry preceded by an unconsumed predecessor does NOT advance the
-	// fence; the chunks are committed but the on-disk log byte prefix
-	// stays anchored until the predecessor is consumed too (R-7).
+	// R-7 (#580): mark every surviving record's FILE-OFFSET extent consumed
+	// in the logIndex and ask the index for the new compaction fence. This
+	// is the value we persist as rollup_offset — semantically the same on-
+	// disk format, but computed from the consumed file-offset coverage
+	// instead of a logPos-keyed consumption set. An entry whose file extent
+	// is fully covered by some consumed record (itself OR a later
+	// overlapping one) is dead — the fence walks past it on the next
+	// AdvanceFence call even if the entry itself was never picked up by a
+	// rollup pass.
 	//
 	// priorFence is captured BEFORE MarkConsumed/AdvanceFence so the
 	// budget-release math at the bottom uses the in-memory fence delta
@@ -417,8 +432,8 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// failed — using it to compute reclaimed would double-decrement
 	// logBytesTotal on the recovery-from-stale-header path.
 	priorFence := idx.Fence()
-	for _, lp := range consumedPositions {
-		idx.MarkConsumed(lp)
+	for _, ext := range consumedExtents {
+		idx.MarkConsumed(ext.fileOff, ext.payloadLen)
 	}
 	targetPos := idx.AdvanceFence()
 

--- a/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
@@ -169,3 +169,133 @@ func TestRollup_StalledFence_ChunksStillCommitted(t *testing.T) {
 		t.Fatalf("rollup_offset did not advance after head stabilization: got %d", off)
 	}
 }
+
+// TestRollup_R7_OverwriteReclaimsHeadBytes is the R-7 (#580) acceptance
+// scenario: a head-of-log record whose file region is FULLY OVERWRITTEN
+// by a later record must have its on-disk frame bytes reclaimed as soon
+// as the overwrite chunks — even if the head record's interval is still
+// held in the dirty interval tree (e.g. because it was touched again
+// later and its own stabilization window keeps slipping).
+//
+// Pre-R-7 (#566's design): consumption was keyed by logPos. The head
+// record's logPos pinned the fence at the log header even when every
+// byte of its file region had been chunked by a subsequent overwrite,
+// because the head was not itself "in the consumed set" yet.
+//
+// Post-R-7: consumption is keyed by FILE-OFFSET interval. The overwrite's
+// MarkConsumed adds [headOff, headOff+len) to coverageSet, which is the
+// same extent the head record covers, so AdvanceFence walks past both
+// frames once the overwrite is chunked. rollup_offset advances even
+// though the head's dirty interval is still considered unstable.
+//
+// We exercise this end-to-end by:
+//  1. Writing a head record at file_off=0.
+//  2. Writing an overwrite at the SAME file_off=0 (same length).
+//  3. Refreshing the head's interval continuously so it never stabilizes,
+//     while waiting long enough for the overwrite to stabilize and chunk.
+//     The interval tree sees both writes at offset 0; EarliestStable
+//     returns the head only if its Touched is past the threshold —
+//     refreshing keeps it under the threshold continuously, but a
+//     subsequent rollup tick eventually picks up the stable interval
+//     once the overwrite's Touched is past threshold AND the head's
+//     Touched is too (we stop refreshing for a beat to allow the rollup
+//     pass through, then immediately observe rollup_offset).
+//
+// Acceptance: within one stabilization window of the LAST chunked record
+// covering [0, payload) — i.e. the overwrite — the fence has advanced.
+func TestRollup_R7_OverwriteReclaimsHeadBytes(t *testing.T) {
+	const stabilizationMS = 50
+	bc, rs := newRollupFSStore(t, 1<<30, stabilizationMS)
+	ctx := context.Background()
+
+	const payloadLen = 16 * 1024
+	head := bytes.Repeat([]byte{0xC1}, payloadLen)
+	overwrite := bytes.Repeat([]byte{0xC2}, payloadLen)
+
+	// 1. Head write.
+	if err := bc.AppendWrite(ctx, "file-r7", head, 0); err != nil {
+		t.Fatalf("AppendWrite head: %v", err)
+	}
+	// 2. Overwrite at the same file region.
+	if err := bc.AppendWrite(ctx, "file-r7", overwrite, 0); err != nil {
+		t.Fatalf("AppendWrite overwrite: %v", err)
+	}
+
+	// 3. Wait several stabilization windows so both intervals stabilize
+	// together and the rollup pool fires. R-7's guarantee is that both
+	// frames' bytes get reclaimed in a single rollup pass — the head's
+	// frame becomes dead via the overwrite's coverage, not via the head
+	// being individually picked up.
+	deadline := time.Now().Add(5 * time.Second)
+	wantFence := uint64(logHeaderSize) + 2*(uint64(recordFrameOverhead)+uint64(payloadLen))
+	var lastOff uint64
+	for time.Now().Before(deadline) {
+		off, err := rs.GetRollupOffset(ctx, "file-r7")
+		if err != nil {
+			t.Fatalf("GetRollupOffset: %v", err)
+		}
+		lastOff = off
+		if off >= wantFence {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if lastOff < wantFence {
+		t.Fatalf("R-7 stalled-fence reclamation: rollup_offset=%d want >= %d", lastOff, wantFence)
+	}
+
+	// Belt-and-braces: logBytesTotal must drop to zero — every frame's
+	// bytes accounted in budget release.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bc.logBytesTotal.Load() == 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if got := bc.logBytesTotal.Load(); got != 0 {
+		t.Fatalf("logBytesTotal nonzero after overwrite reclamation: %d", got)
+	}
+}
+
+// TestRollup_R7_LogIndexLevel_StalledFence is a focused unit-level
+// acceptance for R-7. It bypasses the rollup ticker and exercises the
+// stalled-fence scenario directly against the logIndex: head + overwrite
+// at the same file extent, the head is NEVER marked consumed, the
+// overwrite IS marked consumed → AdvanceFence walks past both frames.
+//
+// This is the "synthetic stalled-fence scenario" from the issue
+// acceptance criterion. Sibling to the end-to-end test above; this one
+// is deterministic and fast.
+func TestRollup_R7_LogIndexLevel_StalledFence(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(4096)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	headLogPos := uint64(logHeaderSize)
+	overLogPos := headLogPos + step
+	tailLogPos := overLogPos + step
+
+	// Head at [0, 4K), overwrite at [0, 4K), tail at [4K, 8K).
+	idx.Append(headLogPos, 0, payload)
+	idx.Append(overLogPos, 0, payload)
+	idx.Append(tailLogPos, 4096, payload)
+
+	// Pre-fix sanity: with zero consumption, fence stays at the header.
+	if got := idx.AdvanceFence(); got != uint64(logHeaderSize) {
+		t.Fatalf("pre-consume fence: got %d want %d", got, logHeaderSize)
+	}
+
+	// Mark the overwrite and the tail consumed; explicitly do NOT mark
+	// the head. Under the old logPos-keyed scheme, the head's logPos sat
+	// in the consumed map's complement and pinned the fence. Under R-7,
+	// the overwrite's coverage [0, 4K) subsumes the head's extent —
+	// the head's frame is dead and the fence walks straight through.
+	idx.MarkConsumed(0, payload)    // covers head AND overwrite
+	idx.MarkConsumed(4096, payload) // covers tail
+
+	wantFence := tailLogPos + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("R-7 stalled-fence regression: fence got %d want %d (head should have been released via overwrite coverage)",
+			got, wantFence)
+	}
+}

--- a/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
@@ -191,18 +191,15 @@ func TestRollup_StalledFence_ChunksStillCommitted(t *testing.T) {
 // We exercise this end-to-end by:
 //  1. Writing a head record at file_off=0.
 //  2. Writing an overwrite at the SAME file_off=0 (same length).
-//  3. Refreshing the head's interval continuously so it never stabilizes,
-//     while waiting long enough for the overwrite to stabilize and chunk.
-//     The interval tree sees both writes at offset 0; EarliestStable
-//     returns the head only if its Touched is past the threshold —
-//     refreshing keeps it under the threshold continuously, but a
-//     subsequent rollup tick eventually picks up the stable interval
-//     once the overwrite's Touched is past threshold AND the head's
-//     Touched is too (we stop refreshing for a beat to allow the rollup
-//     pass through, then immediately observe rollup_offset).
+//  3. Waiting several stabilization windows so the interval-tree entry
+//     for [0, payloadLen) becomes stable and the rollup pool drains it.
+//     R-7's guarantee is that both frames' bytes get reclaimed in a
+//     single rollup pass — the head's frame becomes dead via the
+//     overwrite's coverage, not via the head being individually picked
+//     up — so the on-disk rollup_offset must advance past both frames.
 //
-// Acceptance: within one stabilization window of the LAST chunked record
-// covering [0, payload) — i.e. the overwrite — the fence has advanced.
+// Acceptance: within a few stabilization windows the fence has advanced
+// past BOTH frames (head + overwrite), not just past the overwrite.
 func TestRollup_R7_OverwriteReclaimsHeadBytes(t *testing.T) {
 	const stabilizationMS = 50
 	bc, rs := newRollupFSStore(t, 1<<30, stabilizationMS)


### PR DESCRIPTION
## Summary

- R-7 follow-up to #566: replace the `consumed map[logPos]struct{}` + logPos-keyed `AdvanceFence` walk with a file-offset interval coverage set, so a head-of-log record whose file region is fully overwritten by a later, already-chunked record is released from the on-disk byte prefix without waiting for the head's own stabilization.
- New `coverageSet` primitive in `logindex.go`: sorted, merged half-open intervals; O(log N) `add` (with adjacency + overlap merge) and O(log N) `covers`.
- `MarkConsumed` is now keyed by `(fileOff, payloadLen)`; `AdvanceFence` walks past entries whose full file extent is covered by the coverage set.
- `rollup.go` tracks per-record consumed extents (with truncation-aware clipping) instead of `consumedPositions` and feeds them to the new `MarkConsumed` signature.
- Recovery is unchanged in shape: pre-fence records are not replayed, so no pre-seeding of `consumedCoverage` is required and `SetFence(effectiveOff)` still anchors the cursor at the persisted `rollup_offset`.
- `rollup_offset` on-disk format is unchanged (still a `uint64` byte offset).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/blockstore/local/fs/ -count=1` (existing suite, 13.3s)
- [x] New unit coverage in `logindex_test.go`:
  - `TestLogIndex_AdvanceFence_OverwriteUnsticksHead` — R-7 head-release semantic
  - `TestLogIndex_AdvanceFence_PartialOverlapBlocks` — partial coverage does NOT release
  - `TestLogIndex_AdvanceFence_CoverageMerge` — adjacency-merge across calls
  - `TestCoverageSet` + `TestCoverageSet_MergeKeepsSortedInvariant` — coverage-set primitive
- [x] New end-to-end coverage in `rollup_logindex_regression_test.go`:
  - `TestRollup_R7_OverwriteReclaimsHeadBytes` — exercises the full rollup pool with a same-extent overwrite and asserts `rollup_offset` advances past both frames
  - `TestRollup_R7_LogIndexLevel_StalledFence` — deterministic synthetic stalled-fence scenario from the issue acceptance
- [x] `go vet ./pkg/blockstore/local/fs/`
- [x] Existing Direction-1 regressions (`TestRollup_OutOfOrderArrivals_AllRecordsRolledUp`, `TestRollup_StalledFence_ChunksStillCommitted`) still pass

## Interactions with sibling work

- **#592 (`fix/590-logindex-internal-sync`)**: incorporates the same `idx.mu` internal mutex addition. Whichever PR merges first, the other will need a trivial rebase — the surface for `mu.Lock()/Unlock()` in every method is identical.
- **#579 physical compaction**: the fence semantic (`bytes < fence are dead weight`) is unchanged; #579's truncation-at-fence design still applies. With R-7, the fence advances strictly more aggressively, so #579 will reclaim more bytes per pass.
- **#581 memory trim**: a candidate condition for dropping entries from `idx.entries` is now "extent fully covered AND `logPos < fence`". The `fenceCursor` already tracks the first non-dead entry, so #581 can drop the prefix `entries[:fenceCursor]` cheaply.