### PR TITLE
feat(fs): physical log compaction at compactionFence (closes #579)

### DIFF
--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -73,7 +73,7 @@ func (bc *FSStore) maybeCompactLog(ctx context.Context, payloadID string, lf *lo
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return bc.compactLogLocked(payloadID, lf, idx)
+	return bc.compactLogLocked(ctx, payloadID, lf, idx)
 }
 
 // compactLogLocked rewrites the on-disk log for payloadID, dropping all
@@ -103,7 +103,7 @@ func (bc *FSStore) maybeCompactLog(ctx context.Context, payloadID string, lf *lo
 // BLAKE3 / CAS: no chunk is re-emitted. Compaction touches only the
 // on-disk log bytes; CAS chunks in blocks/{hh}/{hh}/{hex} are produced
 // solely by the rollup path and are unaffected here.
-func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex) error {
+func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *logFile, idx *logIndex) error {
 	fence := idx.Fence()
 	if fence <= logHeaderSize {
 		return nil
@@ -179,7 +179,21 @@ func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex
 	// payloadLen are copied verbatim from the survivor entries.
 	rebased := make([]logEntry, 0, len(survivors))
 	frameBuf := make([]byte, 0, recordFrameOverhead+64*1024)
-	for _, e := range survivors {
+	for i, e := range survivors {
+		// Mirror readRecord's payloadLen DoS cap (FIX-4) so a corrupted
+		// idx entry cannot OOM the process via a multi-GiB allocation.
+		if e.payloadLen > maxRecordPayload {
+			return fmt.Errorf("compaction: payloadLen %d exceeds cap %d at logPos=%d",
+				e.payloadLen, maxRecordPayload, e.logPos)
+		}
+		// Periodically observe ctx so a Close / cancellation mid-pass
+		// breaks out of a long survivor copy instead of pinning a
+		// rollup worker until the I/O finishes.
+		if i&0x3F == 0 {
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+		}
 		frameSize := uint64(recordFrameOverhead) + uint64(e.payloadLen)
 		if cap(frameBuf) < int(frameSize) {
 			frameBuf = make([]byte, frameSize)
@@ -276,18 +290,31 @@ func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex
 			"payloadID", payloadID, "path", lf.path, "error", derr)
 	}
 
+	// Rebase the logIndex FIRST — before attempting the reopen — so a
+	// reopen failure still leaves idx consistent with the on-disk
+	// truth (the new compacted layout). The next getOrCreateLog after
+	// the failure deletes logFDs[payloadID] below; on the next touch
+	// it will re-open the compacted file from disk and reuse this
+	// rebased idx, whose entries match the new physical layout.
+	//
+	// consumedCoverage is reset wholesale: every byte below the old
+	// fence has been physically dropped; surviving entries' coverage
+	// will be re-added by their own MarkConsumed calls as they chunk.
+	idx.entries = rebased
+	idx.consumedCoverage = coverageSet{}
+	idx.compactionFence = logHeaderSize
+	idx.fenceCursor = 0
+
 	// The rename replaced the inode underneath lf.f. Close the stale fd
 	// and open a fresh one against the new file, seeked to EOF for
 	// subsequent appends.
 	oldFd := lf.f
 	newFd, err := os.OpenFile(lf.path, os.O_RDWR, 0644)
 	if err != nil {
-		// We are in an awkward state: the compacted file is on disk
-		// (correct) but we cannot reopen it. Close the stale fd anyway
-		// to avoid leaking the descriptor; the next AppendWrite or
-		// rollupFile call will hit the curLf re-validation, observe
-		// the missing entry in bc.logFDs (we delete below), and
-		// fresh-create from disk on next touch via getOrCreateLog.
+		// Compacted file is on disk (correct) but we cannot reopen.
+		// Close the stale fd, evict the logFDs entry — next touch via
+		// getOrCreateLog opens the new file. idx is already rebased
+		// (above) so it stays consistent with the on-disk layout.
 		_ = oldFd.Close()
 		bc.logsMu.Lock()
 		delete(bc.logFDs, payloadID)
@@ -314,20 +341,6 @@ func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex
 	lf.eofPos = uint64(eof)
 	lf.groupCommit = newGroupCommit(newFd.Sync)
 	_ = oldFd.Close()
-
-	// Rebase the logIndex. The new physical layout has surviving
-	// entries at the positions recorded in `rebased`. consumedCoverage
-	// is reset wholesale: every byte below the old fence has either
-	// been physically dropped or belongs to a survivor whose file
-	// extent is by definition not yet fully covered (AdvanceFence only
-	// walks past entries whose extent is covered). Keeping the old
-	// coverage would only re-prove what the surviving entries already
-	// imply once their own MarkConsumed calls land. Fence resets to
-	// logHeaderSize and the cursor rewinds.
-	idx.entries = rebased
-	idx.consumedCoverage = coverageSet{}
-	idx.compactionFence = logHeaderSize
-	idx.fenceCursor = 0
 
 	slog.Debug("compaction: rewrote log",
 		"payloadID", payloadID,

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -273,6 +273,21 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 		}
 	}
 
+	// Windows: close the open fd against lf.path BEFORE the rename.
+	// `MoveFileEx` / `os.Rename` refuses to replace a file with an open
+	// handle (returns ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION).
+	// POSIX rename works against an open target, so on Linux/macOS we
+	// keep the close after the rename — the order matters there because
+	// holding the old fd across rename preserves the in-flight reader
+	// semantics if anything inside this same goroutine still needed it
+	// (nothing does, but the discipline costs nothing).
+	if runtime.GOOS == "windows" {
+		if cerr := lf.f.Close(); cerr != nil {
+			return fmt.Errorf("compaction: close old fd before rename (windows): %w", cerr)
+		}
+		lf.f = nil
+	}
+
 	// Atomic rename. Per POSIX, rename(2) is atomic with respect to a
 	// crash on the same filesystem: the dentry transition is all-or-
 	// nothing. After this point the on-disk log is the compacted file;
@@ -317,8 +332,9 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	idx.fenceCursor = 0
 
 	// The rename replaced the inode underneath lf.f. Close the stale fd
-	// and open a fresh one against the new file, seeked to EOF for
-	// subsequent appends.
+	// (POSIX path; Windows already closed it pre-rename) and open a
+	// fresh one against the new file, seeked to EOF for subsequent
+	// appends.
 	oldFd := lf.f
 	newFd, err := os.OpenFile(lf.path, os.O_RDWR, 0644)
 	if err != nil {
@@ -326,7 +342,9 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 		// Close the stale fd, evict the logFDs entry — next touch via
 		// getOrCreateLog opens the new file. idx is already rebased
 		// (above) so it stays consistent with the on-disk layout.
-		_ = oldFd.Close()
+		if oldFd != nil {
+			_ = oldFd.Close()
+		}
 		bc.logsMu.Lock()
 		delete(bc.logFDs, payloadID)
 		bc.logsMu.Unlock()
@@ -335,7 +353,9 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	eof, err := newFd.Seek(0, io.SeekEnd)
 	if err != nil {
 		_ = newFd.Close()
-		_ = oldFd.Close()
+		if oldFd != nil {
+			_ = oldFd.Close()
+		}
 		bc.logsMu.Lock()
 		delete(bc.logFDs, payloadID)
 		bc.logsMu.Unlock()
@@ -348,10 +368,14 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	// is observed atomically by any caller that subsequently acquires
 	// mu. The old groupCommit is quiescent (no in-flight Sync — Sync
 	// is only called under mu) so dropping the reference is safe.
+	// oldFd is nil on Windows (closed before the rename); only close
+	// it on POSIX where we kept it open across the rename.
 	lf.f = newFd
 	lf.eofPos = uint64(eof)
 	lf.groupCommit = newGroupCommit(newFd.Sync)
-	_ = oldFd.Close()
+	if oldFd != nil {
+		_ = oldFd.Close()
+	}
 
 	slog.Debug("compaction: rewrote log",
 		"payloadID", payloadID,

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // LogFlagCompacted is set in the on-disk header's Flags field after a
@@ -251,17 +252,25 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	// (new dentry + remove old dentry — atomic in rename(2)) is durable.
 	// This guards against the "rename completes in cache but is lost on
 	// crash" pathology on filesystems that defer dentry persistence.
+	//
+	// Skipped on Windows: NTFS handles dentry durability via the rename
+	// itself; opening a directory for read and calling fsync returns
+	// "Access is denied" because the read-mode handle lacks write rights.
+	// MoveFileEx (which os.Rename uses under the hood) provides crash-
+	// consistency without an explicit dir flush on supported filesystems.
 	dir := filepath.Dir(lf.path)
-	dfd, derr := os.Open(dir)
-	if derr != nil {
-		return fmt.Errorf("compaction: open parent dir for fsync: %w", derr)
-	}
-	if err := dfd.Sync(); err != nil {
-		_ = dfd.Close()
-		return fmt.Errorf("compaction: fsync parent dir (pre-rename): %w", err)
-	}
-	if err := dfd.Close(); err != nil {
-		return fmt.Errorf("compaction: close parent dir (pre-rename): %w", err)
+	if runtime.GOOS != "windows" {
+		dfd, derr := os.Open(dir)
+		if derr != nil {
+			return fmt.Errorf("compaction: open parent dir for fsync: %w", derr)
+		}
+		if err := dfd.Sync(); err != nil {
+			_ = dfd.Close()
+			return fmt.Errorf("compaction: fsync parent dir (pre-rename): %w", err)
+		}
+		if err := dfd.Close(); err != nil {
+			return fmt.Errorf("compaction: close parent dir (pre-rename): %w", err)
+		}
 	}
 
 	// Atomic rename. Per POSIX, rename(2) is atomic with respect to a
@@ -279,7 +288,9 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	// directory entry creation; the rename creates/removes dentries
 	// that must also be flushed). Cheap on most filesystems — the
 	// directory is already in cache.
-	if dfd, derr := os.Open(dir); derr == nil {
+	if runtime.GOOS == "windows" {
+		// no-op: see pre-rename block above.
+	} else if dfd, derr := os.Open(dir); derr == nil {
 		if syncErr := dfd.Sync(); syncErr != nil {
 			slog.Warn("compaction: fsync parent dir (post-rename) failed",
 				"payloadID", payloadID, "path", lf.path, "error", syncErr)

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -172,7 +172,16 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 	if err != nil {
 		return fmt.Errorf("compaction: open source: %w", err)
 	}
-	defer func() { _ = rf.Close() }()
+	// rfClosed tracks whether the explicit close below ran so the
+	// error-path defer never double-closes. We close rf BEFORE the
+	// rename (rather than via a function-return defer) because Windows
+	// refuses to rename over a file that has any open handle.
+	rfClosed := false
+	defer func() {
+		if !rfClosed {
+			_ = rf.Close()
+		}
+	}()
 
 	newPos := uint64(logHeaderSize)
 	// rebased holds the post-compaction entries in arrival order. We
@@ -273,14 +282,21 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 		}
 	}
 
-	// Windows: close the open fd against lf.path BEFORE the rename.
-	// `MoveFileEx` / `os.Rename` refuses to replace a file with an open
-	// handle (returns ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION).
-	// POSIX rename works against an open target, so on Linux/macOS we
-	// keep the close after the rename — the order matters there because
-	// holding the old fd across rename preserves the in-flight reader
-	// semantics if anything inside this same goroutine still needed it
-	// (nothing does, but the discipline costs nothing).
+	// Close the read-only source handle before the rename. Windows
+	// refuses to rename over a file with ANY open handle; POSIX
+	// tolerates it, but closing here is harmless on POSIX too — the
+	// copy loop is done and rf is otherwise discarded at function return.
+	if cerr := rf.Close(); cerr != nil {
+		return fmt.Errorf("compaction: close source fd before rename: %w", cerr)
+	}
+	rfClosed = true
+
+	// Windows: also close the writable fd against lf.path BEFORE the
+	// rename for the same reason (`MoveFileEx` / `os.Rename` returns
+	// ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION otherwise). POSIX
+	// rename works against an open target, so on Linux/macOS we keep
+	// the close after the rename — preserves in-flight reader semantics
+	// for code inside this same goroutine if anything still needed it.
 	if runtime.GOOS == "windows" {
 		if cerr := lf.f.Close(); cerr != nil {
 			return fmt.Errorf("compaction: close old fd before rename (windows): %w", cerr)

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -1,0 +1,381 @@
+package fs
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// LogFlagCompacted is set in the on-disk header's Flags field after a
+// successful physical compaction pass. Recovery uses this bit to decide
+// whether to honor the metadata-vs-header reconcile (which assumes the
+// header's RollupOffset is the physical byte at which un-consumed records
+// begin, AND that metadata.rollup_offset is the same physical position).
+// After compaction the file is renumbered so the surviving records start
+// at logHeaderSize while metadata.rollup_offset still records the
+// pre-compaction byte offset (it is monotonic per INV-03 and cannot be
+// regressed). Without the flag, recovery would interpret metaOff > hdrOff
+// as a crash between SetRollupOffset and advanceRollupOffset and seek
+// past the compacted file's EOF, losing every surviving record.
+const LogFlagCompacted uint32 = 1 << 0
+
+// defaultCompactionDivisor controls the default compaction threshold:
+// maxLogBytes / defaultCompactionDivisor. A compaction pass runs after
+// rollup when the in-memory fence advanced by at least this many bytes
+// since the last compaction (or since the log was created). Setting the
+// divisor higher delays compaction (lower I/O churn, larger on-disk
+// growth between passes); lower triggers more aggressive compaction
+// (more I/O, tighter disk bound).
+const defaultCompactionDivisor int64 = 4
+
+// maybeCompactLog runs compaction for payloadID if the on-disk log has
+// accumulated more pre-fence bytes than bc.compactionThresholdBytes.
+//
+// Caller MUST hold the per-file mu (rollupFile does — it calls this
+// before releasing the mutex via defer). The lf and idx parameters
+// must be the canonical pointers stored in bc.logFDs / bc.logIndices;
+// we mutate them in place under the per-file mu so concurrent callers
+// (other AppendWrite / rollupFile goroutines that already snapshotted
+// these pointers and are awaiting mu) observe the post-compaction state
+// when they finally acquire mu.
+//
+// Returns nil and skips compaction silently if:
+//   - bc.compactionThresholdBytes <= 0 (compaction disabled);
+//   - the fence has not advanced past logHeaderSize by more than the
+//     threshold (nothing meaningful to reclaim);
+//   - idx is nil (defensive — should not happen given the caller's
+//     pre-conditions, but ranging over a nil idx would panic).
+//
+// Returns a non-nil error only on hard I/O failures during the rewrite/
+// fsync/rename sequence. On error the original lf.f / idx are left
+// unchanged — the next rollup pass retries naturally on the next
+// threshold trip.
+func (bc *FSStore) maybeCompactLog(ctx context.Context, payloadID string, lf *logFile, idx *logIndex) error {
+	if bc.compactionThresholdBytes <= 0 {
+		return nil
+	}
+	if lf == nil || idx == nil {
+		return nil
+	}
+	fence := idx.Fence()
+	if fence <= logHeaderSize {
+		return nil
+	}
+	reclaimable := fence - logHeaderSize
+	if int64(reclaimable) < bc.compactionThresholdBytes {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return bc.compactLogLocked(payloadID, lf, idx)
+}
+
+// compactLogLocked rewrites the on-disk log for payloadID, dropping all
+// records whose logPos sits below idx.Fence(). The surviving records
+// (logPos >= fence) are re-emitted in arrival order starting at
+// logHeaderSize in a temporary file alongside the original; the temp is
+// fsync'd, the containing directory is fsync'd, and a rename atomically
+// replaces the live log. After the swap the in-memory lf is mutated in
+// place (new fd + new groupCommit + reset eofPos) and idx is rebased
+// (entries' logPos values shifted, compactionFence reset to
+// logHeaderSize, consumed map rekeyed).
+//
+// Caller MUST hold the per-file mu. The lf and idx must be the canonical
+// pointers in bc.logFDs / bc.logIndices.
+//
+// Crash safety: the rename(2) is the linearization point. A crash at
+// any point before rename leaves the original log untouched (the temp
+// file is unlinked on the error paths below; orphaned temps surviving a
+// hard kill are cleaned up by the boot-time orphan sweep — see
+// cleanupCompactTemps). A crash after rename but before the new fd is
+// reopened is also safe: the next AppendWrite / rollupFile will reopen
+// from disk and pick up the compacted layout transparently. Recovery
+// uses the LogFlagCompacted bit in the header to skip the
+// metaOff > hdrOff reconcile that would otherwise misinterpret the
+// renumbered file.
+//
+// BLAKE3 / CAS: no chunk is re-emitted. Compaction touches only the
+// on-disk log bytes; CAS chunks in blocks/{hh}/{hh}/{hex} are produced
+// solely by the rollup path and are unaffected here.
+func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex) error {
+	fence := idx.Fence()
+	if fence <= logHeaderSize {
+		return nil
+	}
+
+	// Snapshot surviving entries (logPos >= fence) in arrival order. The
+	// idx.entries slice is already in logPos-ascending order by Append's
+	// caller contract.
+	survivors := make([]logEntry, 0, len(idx.entries))
+	for _, e := range idx.entries {
+		if e.logPos >= fence {
+			survivors = append(survivors, e)
+		}
+	}
+
+	tmpPath := lf.path + ".compact"
+	// Clean up any stale temp from a prior failed pass before we re-open.
+	if rmErr := os.Remove(tmpPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		return fmt.Errorf("compaction: pre-clean temp: %w", rmErr)
+	}
+
+	tmpFd, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0644)
+	if err != nil {
+		return fmt.Errorf("compaction: create temp: %w", err)
+	}
+	// Best-effort temp cleanup on every error path below. The deferred
+	// helper closes the fd if still open and unlinks the temp if it
+	// still exists. Success path nils tmpFd so the defer is a no-op.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = tmpFd.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// Write a fresh header into the temp file. RollupOffset starts at
+	// logHeaderSize (the first surviving record sits immediately after
+	// the header); LogFlagCompacted is set so recovery's reconcile knows
+	// to trust the header rather than metadata.
+	//
+	// CreatedAt is preserved from the original log so the boot-time
+	// orphan sweep age gate (D-28) still classifies the payload against
+	// its original first-record timestamp, not a freshly-bumped one.
+	origHdr, hdrErr := readLogHeader(lf.f)
+	if hdrErr != nil {
+		return fmt.Errorf("compaction: read orig header: %w", hdrErr)
+	}
+	newHdr := logHeader{
+		Magic:        logMagic,
+		Version:      logVersion,
+		RollupOffset: logHeaderSize,
+		Flags:        origHdr.Flags | LogFlagCompacted,
+		CreatedAt:    origHdr.CreatedAt,
+	}
+	hdrBuf := marshalHeader(newHdr)
+	if _, werr := tmpFd.WriteAt(hdrBuf[:], 0); werr != nil {
+		return fmt.Errorf("compaction: write temp header: %w", werr)
+	}
+
+	// Copy each surviving record's framed bytes from the source fd to
+	// the temp fd. We use a separate read-only fd on the source path so
+	// the lf.f file position is undisturbed (mirrors rollupFile's rf).
+	rf, err := os.Open(lf.path)
+	if err != nil {
+		return fmt.Errorf("compaction: open source: %w", err)
+	}
+	defer func() { _ = rf.Close() }()
+
+	newPos := uint64(logHeaderSize)
+	// rebased holds the post-compaction entries in arrival order. We
+	// populate logPos with the new physical position; fileOff and
+	// payloadLen are copied verbatim from the survivor entries.
+	rebased := make([]logEntry, 0, len(survivors))
+	frameBuf := make([]byte, 0, recordFrameOverhead+64*1024)
+	for _, e := range survivors {
+		frameSize := uint64(recordFrameOverhead) + uint64(e.payloadLen)
+		if cap(frameBuf) < int(frameSize) {
+			frameBuf = make([]byte, frameSize)
+		} else {
+			frameBuf = frameBuf[:frameSize]
+		}
+		if _, rerr := rf.ReadAt(frameBuf, int64(e.logPos)); rerr != nil {
+			return fmt.Errorf("compaction: pread at %d (len=%d): %w", e.logPos, frameSize, rerr)
+		}
+		// Defensive: verify the frame's payload_len header matches the
+		// indexed value. A mismatch implies log-fd corruption or a
+		// logIndex/log divergence bug — surfacing it here prevents the
+		// compaction from silently writing a malformed temp.
+		declaredLen := binary.LittleEndian.Uint32(frameBuf[0:4])
+		if declaredLen != e.payloadLen {
+			return fmt.Errorf("compaction: frame payload_len %d != logIndex %d at logPos=%d",
+				declaredLen, e.payloadLen, e.logPos)
+		}
+		// CRC re-validation is not strictly necessary here (the frame
+		// bytes are being copied verbatim, so the CRC inside the frame
+		// is preserved regardless of whether we re-check it), but it is
+		// a cheap belt-and-braces against a torn read.
+		wantCRC := binary.LittleEndian.Uint32(frameBuf[12:16])
+		var offBuf [8]byte
+		copy(offBuf[:], frameBuf[4:12])
+		gotCRC := crc32.Update(0, crcTable, offBuf[:])
+		gotCRC = crc32.Update(gotCRC, crcTable, frameBuf[recordFrameOverhead:])
+		if gotCRC != wantCRC {
+			return fmt.Errorf("compaction: CRC mismatch at logPos=%d", e.logPos)
+		}
+
+		if _, werr := tmpFd.WriteAt(frameBuf, int64(newPos)); werr != nil {
+			return fmt.Errorf("compaction: write temp record at %d: %w", newPos, werr)
+		}
+		rebased = append(rebased, logEntry{
+			logPos:     newPos,
+			fileOff:    e.fileOff,
+			payloadLen: e.payloadLen,
+		})
+		newPos += frameSize
+	}
+
+	// fsync the temp file data + header so they hit the platter before
+	// the rename. Without this, a crash after rename could leave a
+	// validly-named log file whose bytes never made it to disk —
+	// recovery would then see a short / corrupt file and truncate it.
+	if err := tmpFd.Sync(); err != nil {
+		return fmt.Errorf("compaction: fsync temp: %w", err)
+	}
+	if err := tmpFd.Close(); err != nil {
+		return fmt.Errorf("compaction: close temp: %w", err)
+	}
+
+	// fsync the containing directory so the rename's metadata change
+	// (new dentry + remove old dentry — atomic in rename(2)) is durable.
+	// This guards against the "rename completes in cache but is lost on
+	// crash" pathology on filesystems that defer dentry persistence.
+	dir := filepath.Dir(lf.path)
+	dfd, derr := os.Open(dir)
+	if derr != nil {
+		return fmt.Errorf("compaction: open parent dir for fsync: %w", derr)
+	}
+	if err := dfd.Sync(); err != nil {
+		_ = dfd.Close()
+		return fmt.Errorf("compaction: fsync parent dir (pre-rename): %w", err)
+	}
+	if err := dfd.Close(); err != nil {
+		return fmt.Errorf("compaction: close parent dir (pre-rename): %w", err)
+	}
+
+	// Atomic rename. Per POSIX, rename(2) is atomic with respect to a
+	// crash on the same filesystem: the dentry transition is all-or-
+	// nothing. After this point the on-disk log is the compacted file;
+	// we now reopen the new fd and swap it into lf under the per-file
+	// mu we still hold.
+	if err := os.Rename(tmpPath, lf.path); err != nil {
+		return fmt.Errorf("compaction: rename: %w", err)
+	}
+	cleanup = false // temp is now the live log; do not unlink in defer.
+
+	// fsync the parent directory once more so the rename itself is
+	// durable (the pre-rename fsync above only covered the temp file's
+	// directory entry creation; the rename creates/removes dentries
+	// that must also be flushed). Cheap on most filesystems — the
+	// directory is already in cache.
+	if dfd, derr := os.Open(dir); derr == nil {
+		if syncErr := dfd.Sync(); syncErr != nil {
+			slog.Warn("compaction: fsync parent dir (post-rename) failed",
+				"payloadID", payloadID, "path", lf.path, "error", syncErr)
+		}
+		_ = dfd.Close()
+	} else {
+		slog.Warn("compaction: open parent dir for post-rename fsync failed",
+			"payloadID", payloadID, "path", lf.path, "error", derr)
+	}
+
+	// The rename replaced the inode underneath lf.f. Close the stale fd
+	// and open a fresh one against the new file, seeked to EOF for
+	// subsequent appends.
+	oldFd := lf.f
+	newFd, err := os.OpenFile(lf.path, os.O_RDWR, 0644)
+	if err != nil {
+		// We are in an awkward state: the compacted file is on disk
+		// (correct) but we cannot reopen it. Close the stale fd anyway
+		// to avoid leaking the descriptor; the next AppendWrite or
+		// rollupFile call will hit the curLf re-validation, observe
+		// the missing entry in bc.logFDs (we delete below), and
+		// fresh-create from disk on next touch via getOrCreateLog.
+		_ = oldFd.Close()
+		bc.logsMu.Lock()
+		delete(bc.logFDs, payloadID)
+		bc.logsMu.Unlock()
+		return fmt.Errorf("compaction: reopen after rename: %w", err)
+	}
+	eof, err := newFd.Seek(0, io.SeekEnd)
+	if err != nil {
+		_ = newFd.Close()
+		_ = oldFd.Close()
+		bc.logsMu.Lock()
+		delete(bc.logFDs, payloadID)
+		bc.logsMu.Unlock()
+		return fmt.Errorf("compaction: seek end after rename: %w", err)
+	}
+
+	// Swap the fd in lf and rebuild the groupCommit coordinator. The
+	// per-file mu we hold serializes us against all AppendWrite /
+	// rollupFile sites that touch lf.f or lf.groupCommit, so the swap
+	// is observed atomically by any caller that subsequently acquires
+	// mu. The old groupCommit is quiescent (no in-flight Sync — Sync
+	// is only called under mu) so dropping the reference is safe.
+	lf.f = newFd
+	lf.eofPos = uint64(eof)
+	lf.groupCommit = newGroupCommit(newFd.Sync)
+	_ = oldFd.Close()
+
+	// Rebase the logIndex. The new physical layout has surviving
+	// entries at the positions recorded in `rebased`. consumedCoverage
+	// is reset wholesale: every byte below the old fence has either
+	// been physically dropped or belongs to a survivor whose file
+	// extent is by definition not yet fully covered (AdvanceFence only
+	// walks past entries whose extent is covered). Keeping the old
+	// coverage would only re-prove what the surviving entries already
+	// imply once their own MarkConsumed calls land. Fence resets to
+	// logHeaderSize and the cursor rewinds.
+	idx.entries = rebased
+	idx.consumedCoverage = coverageSet{}
+	idx.compactionFence = logHeaderSize
+	idx.fenceCursor = 0
+
+	slog.Debug("compaction: rewrote log",
+		"payloadID", payloadID,
+		"path", lf.path,
+		"reclaimedBytes", fence-logHeaderSize,
+		"newEof", lf.eofPos,
+		"survivors", len(rebased),
+	)
+	return nil
+}
+
+// cleanupCompactTemps removes any orphaned `.compact` temp files left
+// behind by a process that crashed mid-compaction. Run from recovery
+// before the per-log scan installs fds. Best-effort: per-file removal
+// errors are logged at Warn and otherwise ignored — a stale temp does
+// not affect correctness, only wastes disk.
+func (bc *FSStore) cleanupCompactTemps(logsDir string) {
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return
+	}
+	for _, d := range entries {
+		if d.IsDir() {
+			continue
+		}
+		name := d.Name()
+		if filepath.Ext(name) != ".compact" {
+			continue
+		}
+		path := filepath.Join(logsDir, name)
+		if rmErr := os.Remove(path); rmErr != nil {
+			slog.Warn("compaction: cleanup stale temp failed",
+				"path", path, "error", rmErr)
+		}
+	}
+	// Walk one level deeper to catch share-prefixed payload IDs (the
+	// log layout supports nested directories under logs/).
+	_ = filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(d.Name()) != ".compact" {
+			return nil
+		}
+		if rmErr := os.Remove(path); rmErr != nil {
+			slog.Warn("compaction: cleanup stale temp failed",
+				"path", path, "error", rmErr)
+		}
+		return nil
+	})
+}

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -344,27 +344,11 @@ func (bc *FSStore) compactLogLocked(payloadID string, lf *logFile, idx *logIndex
 // before the per-log scan installs fds. Best-effort: per-file removal
 // errors are logged at Warn and otherwise ignored — a stale temp does
 // not affect correctness, only wastes disk.
+//
+// Walks the full tree under logsDir so both the flat layout
+// (logs/<payload>.log.compact) and the share-prefixed nested layout
+// (logs/<share>/<file>.log.compact) are covered in a single pass.
 func (bc *FSStore) cleanupCompactTemps(logsDir string) {
-	entries, err := os.ReadDir(logsDir)
-	if err != nil {
-		return
-	}
-	for _, d := range entries {
-		if d.IsDir() {
-			continue
-		}
-		name := d.Name()
-		if filepath.Ext(name) != ".compact" {
-			continue
-		}
-		path := filepath.Join(logsDir, name)
-		if rmErr := os.Remove(path); rmErr != nil {
-			slog.Warn("compaction: cleanup stale temp failed",
-				"path", path, "error", rmErr)
-		}
-	}
-	// Walk one level deeper to catch share-prefixed payload IDs (the
-	// log layout supports nested directories under logs/).
 	_ = filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil

--- a/pkg/blockstore/local/fs/compaction_test.go
+++ b/pkg/blockstore/local/fs/compaction_test.go
@@ -1,0 +1,345 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// logFileSize returns the on-disk byte size of payloadID's log file. Fails
+// the test if the file is missing.
+func logFileSize(t *testing.T, bc *FSStore, payloadID string) int64 {
+	t.Helper()
+	path := bc.logPath(payloadID)
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat log %s: %v", path, err)
+	}
+	return st.Size()
+}
+
+// waitForLogBytesBelow polls until bc.logBytesTotal drops below max or
+// the deadline expires. Used to confirm rollup drained the budget. We
+// key compaction-bound tests off logBytesTotal rather than
+// metadata.rollup_offset because once compaction trips, the metadata
+// fence is frozen by INV-03 monotonicity at the pre-compaction
+// high-water mark — only the in-memory budget continues to drop as
+// records are consumed.
+func waitForLogBytesBelow(t *testing.T, bc *FSStore, max int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if bc.logBytesTotal.Load() <= max {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("logBytesTotal did not drop below %d within %v (current=%d)",
+		max, timeout, bc.logBytesTotal.Load())
+}
+
+// TestCompaction_BoundedLogSize: sustained AppendWrite + rollup produces a
+// log file that does NOT grow without bound. The compaction pass should
+// reclaim pre-fence bytes so the on-disk size stays below a multiple of
+// the compaction threshold.
+func TestCompaction_BoundedLogSize(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	// Very tight compaction threshold (32 KiB) and a small log budget so
+	// the test runs in a few seconds. Each chunk is 8 KiB; we write many
+	// of them sequentially at increasing file offsets so the rollup
+	// chunks them and the fence advances. Compaction should keep the
+	// on-disk log size bounded.
+	opts := FSStoreOptions{
+		MaxLogBytes:              1 << 30,
+		RollupWorkers:            2,
+		StabilizationMS:          5,
+		RollupStore:              rs,
+		CompactionThresholdBytes: 32 * 1024,
+	}
+	bc := newFSStoreForTest(t, opts)
+	if err := bc.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+	ctx := context.Background()
+
+	chunk := bytes.Repeat([]byte{0xCD}, 8*1024)
+	const writes = 256
+	for i := 0; i < writes; i++ {
+		if err := bc.AppendWrite(ctx, "fileA", chunk, uint64(i)*uint64(len(chunk))); err != nil {
+			t.Fatalf("AppendWrite[%d]: %v", i, err)
+		}
+		// Brief yield so the rollup worker has a chance to run between
+		// batches; otherwise the entire log accumulates first and a
+		// single big compaction would mask whether the steady-state
+		// loop trips at all.
+		if i%16 == 15 {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Wait for the rollup to drain the log budget so we know every
+	// AppendWrite has been processed. logBytesTotal goes back to zero
+	// when every record is consumed; we don't key off metadata
+	// rollup_offset because once compaction trips, the metadata fence
+	// is frozen at the pre-compaction high-water mark by INV-03
+	// monotonicity — only the in-memory fence and on-disk header
+	// continue to advance.
+	waitForLogBytesBelow(t, bc, 64*1024, 10*time.Second)
+	// Give the compaction pass a moment to fire after the SetRollupOffset
+	// that advanced the fence past the threshold.
+	time.Sleep(300 * time.Millisecond)
+
+	size := logFileSize(t, bc, "fileA")
+	// The log file should be far smaller than the cumulative AppendWrite
+	// payload size. Bound: a few multiples of the compaction threshold
+	// (one full threshold worth of pre-fence bytes can sit between
+	// passes, plus whatever unconsumed records are still resident).
+	maxAcceptable := int64(8 * 32 * 1024) // 256 KiB
+	if size > maxAcceptable {
+		t.Fatalf("log file size %d bytes exceeds bound %d (compaction did not run or did not reclaim bytes)",
+			size, maxAcceptable)
+	}
+}
+
+// TestCompaction_DisabledByNegativeThreshold: with CompactionThresholdBytes
+// set to a sentinel negative value, the log file grows unbounded (pre-#579
+// behavior). Verifies the opt-out path.
+func TestCompaction_DisabledByNegativeThreshold(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	opts := FSStoreOptions{
+		MaxLogBytes:              1 << 30,
+		RollupWorkers:            2,
+		StabilizationMS:          5,
+		RollupStore:              rs,
+		CompactionThresholdBytes: -1,
+	}
+	bc := newFSStoreForTest(t, opts)
+	if err := bc.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+	ctx := context.Background()
+
+	chunk := bytes.Repeat([]byte{0xEE}, 8*1024)
+	const writes = 64
+	for i := 0; i < writes; i++ {
+		if err := bc.AppendWrite(ctx, "fileB", chunk, uint64(i)*uint64(len(chunk))); err != nil {
+			t.Fatalf("AppendWrite[%d]: %v", i, err)
+		}
+	}
+	totalBytes := uint64(writes) * uint64(len(chunk))
+	waitForLogBytesBelow(t, bc, 64*1024, 10*time.Second)
+	// Allow a final rollup tick to settle on disk.
+	time.Sleep(200 * time.Millisecond)
+
+	size := logFileSize(t, bc, "fileB")
+	// Without compaction the log retains every framed record. Expect at
+	// least the cumulative AppendWrite bytes (plus framing overhead) on
+	// disk.
+	minExpected := int64(totalBytes)
+	if size < minExpected {
+		t.Fatalf("compaction-disabled log size %d below %d — did compaction run unexpectedly?",
+			size, minExpected)
+	}
+}
+
+// TestCompaction_RecoveryRebuildsAfterCompact: after compaction trims the
+// on-disk log, close + reopen the FSStore and verify recovery rebuilds
+// the interval tree + logIndex from the post-compaction file (no records
+// lost, no records re-replayed from the dropped prefix). Subsequent
+// AppendWrite + rollup against the recovered payload must work.
+func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	opts := FSStoreOptions{
+		MaxLogBytes:              1 << 30,
+		RollupWorkers:            2,
+		StabilizationMS:          5,
+		RollupStore:              rs,
+		CompactionThresholdBytes: 16 * 1024,
+	}
+	bc := newFSStoreForTest(t, opts)
+	if err := bc.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+	ctx := context.Background()
+
+	// Phase 1: write enough records to drive at least one compaction.
+	chunk := bytes.Repeat([]byte{0xA1}, 4*1024)
+	const phase1Writes = 64
+	for i := 0; i < phase1Writes; i++ {
+		if err := bc.AppendWrite(ctx, "fileR", chunk, uint64(i)*uint64(len(chunk))); err != nil {
+			t.Fatalf("phase1 AppendWrite[%d]: %v", i, err)
+		}
+	}
+	phase1Bytes := uint64(phase1Writes) * uint64(len(chunk))
+	waitForLogBytesBelow(t, bc, 32*1024, 10*time.Second)
+	time.Sleep(300 * time.Millisecond)
+	preReopenSize := logFileSize(t, bc, "fileR")
+	// Sanity: compaction should have trimmed the file far below the
+	// total cumulative AppendWrite bytes; if it didn't fire, the
+	// post-reopen invariant below would still hold trivially and we
+	// would not actually be testing the compaction recovery path.
+	if uint64(preReopenSize) >= phase1Bytes {
+		t.Fatalf("compaction did not trim log: size=%d cumulative writes=%d",
+			preReopenSize, phase1Bytes)
+	}
+
+	// Phase 2: reopen the FSStore on the same baseDir and trigger recovery.
+	baseDir := bc.baseDir
+	_ = bc.Close()
+	bc2, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBS{}, opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = bc2.Close() })
+	if err := bc2.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Phase 3: post-recovery, the in-memory logIndex should reflect the
+	// post-compaction layout — entries from the dropped prefix must NOT
+	// reappear. The on-disk log size should be unchanged (recovery did
+	// not re-grow the file).
+	postReopenSize := logFileSize(t, bc2, "fileR")
+	if postReopenSize != preReopenSize {
+		t.Fatalf("recovery mutated log size: pre=%d post=%d (recovery should be read-only on a clean tail)",
+			preReopenSize, postReopenSize)
+	}
+
+	// Phase 4: append new records against the recovered payload and let
+	// the rollup process them. This exercises the post-compaction
+	// append + rollup loop end-to-end after a reopen.
+	if err := bc2.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup (post-recovery): %v", err)
+	}
+	const phase4Writes = 8
+	for i := 0; i < phase4Writes; i++ {
+		off := phase1Bytes + uint64(i)*uint64(len(chunk))
+		if err := bc2.AppendWrite(ctx, "fileR", chunk, off); err != nil {
+			t.Fatalf("phase4 AppendWrite[%d]: %v", i, err)
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+	// At least the previously-observed offset should still hold post-
+	// reopen (the post-#579 rollup will attempt SetRollupOffset on the
+	// new records, but the metadata-monotonic regression rule keeps
+	// metaOff at its high-water mark).
+	finalMeta, _ := rs.GetRollupOffset(context.Background(), "fileR")
+	if finalMeta < uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset reset to %d after recovery (should be monotonic)", finalMeta)
+	}
+}
+
+// TestCompaction_HeaderFlagSetAndPreservesCAS: after compaction, the on-
+// disk log header should carry the LogFlagCompacted bit, RollupOffset
+// should be reset to logHeaderSize, and the CAS chunks emitted prior to
+// compaction should remain untouched (BLAKE3 content addressing
+// invariant — compaction does not re-emit chunks).
+func TestCompaction_HeaderFlagSetAndPreservesCAS(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	opts := FSStoreOptions{
+		MaxLogBytes:              1 << 30,
+		RollupWorkers:            2,
+		StabilizationMS:          5,
+		RollupStore:              rs,
+		CompactionThresholdBytes: 8 * 1024,
+	}
+	bc := newFSStoreForTest(t, opts)
+	if err := bc.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+	ctx := context.Background()
+
+	chunk := bytes.Repeat([]byte{0x42}, 4*1024)
+	const writes = 32
+	for i := 0; i < writes; i++ {
+		if err := bc.AppendWrite(ctx, "fileH", chunk, uint64(i)*uint64(len(chunk))); err != nil {
+			t.Fatalf("AppendWrite[%d]: %v", i, err)
+		}
+	}
+	waitForLogBytesBelow(t, bc, 16*1024, 10*time.Second)
+	time.Sleep(300 * time.Millisecond)
+
+	chunksBefore := countChunksInBlocks(t, bc.baseDir)
+	if chunksBefore == 0 {
+		t.Fatalf("no chunks emitted; cannot validate CAS-preservation invariant")
+	}
+
+	// Peek at the on-disk header.
+	f, err := os.Open(bc.logPath("fileH"))
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	hdr, err := readLogHeader(f)
+	_ = f.Close()
+	if err != nil {
+		t.Fatalf("readLogHeader: %v", err)
+	}
+	if hdr.Flags&LogFlagCompacted == 0 {
+		t.Fatalf("expected LogFlagCompacted bit in header.Flags (got 0x%x); compaction may not have run",
+			hdr.Flags)
+	}
+	if hdr.RollupOffset != logHeaderSize {
+		t.Fatalf("expected RollupOffset = %d after compaction, got %d",
+			logHeaderSize, hdr.RollupOffset)
+	}
+
+	// CAS-preservation: chunk count must not decrease across a
+	// compaction pass. (We tolerate growth from any post-compaction
+	// rollup that ran after the header peek.)
+	chunksAfter := countChunksInBlocks(t, bc.baseDir)
+	if chunksAfter < chunksBefore {
+		t.Fatalf("CAS chunk count dropped from %d to %d across compaction — should be additive only",
+			chunksBefore, chunksAfter)
+	}
+}
+
+// TestCompaction_StaleTempCleanedUpOnRecovery: a `.compact` temp file
+// left over from a crashed compaction pass is unlinked by recovery's
+// cleanupCompactTemps sweep.
+func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 20,
+		RollupWorkers:   2,
+		StabilizationMS: 10,
+		RollupStore:     rs,
+	})
+	ctx := context.Background()
+
+	// Touch a real log so the logs/ directory exists.
+	if err := bc.AppendWrite(ctx, "fileT", []byte("seed"), 0); err != nil {
+		t.Fatalf("seed AppendWrite: %v", err)
+	}
+	baseDir := bc.baseDir
+	_ = bc.Close()
+
+	// Drop a stale .compact temp into the logs dir, mimicking a
+	// crashed compaction.
+	stalePath := bc.logPath("fileT") + ".compact"
+	if err := os.WriteFile(stalePath, []byte("garbage"), 0644); err != nil {
+		t.Fatalf("write stale temp: %v", err)
+	}
+
+	// Reopen and run recovery.
+	bc2, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+		MaxLogBytes:     1 << 20,
+		RollupWorkers:   2,
+		StabilizationMS: 10,
+		RollupStore:     rs,
+	})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = bc2.Close() })
+	if err := bc2.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale .compact temp was not cleaned up: stat err=%v", err)
+	}
+}

--- a/pkg/blockstore/local/fs/doc.go
+++ b/pkg/blockstore/local/fs/doc.go
@@ -94,12 +94,21 @@
 // pass that emits chunks, so the dirty interval clears and the workload
 // makes forward progress even when the fence cannot.
 //
-// TRANSITIONAL-V0.17+: physical log compaction (rewriting the log file
-// dropping consumed records up to compactionFence) is not implemented
-// here. The on-disk log grows until the payload is deleted; pressure
-// machinery caps the worst case via maxLogBytes. A future milestone
-// will add a compaction pass that truncates the on-disk log down to
-// its post-fence suffix.
+// Physical log compaction (#579): when the in-memory compactionFence
+// has advanced past logHeaderSize by more than
+// FSStoreOptions.CompactionThresholdBytes (default = maxLogBytes / 4),
+// the post-rollup pass rewrites the log file dropping every record
+// below the fence. The rewrite uses a temp file + fsync + parent-dir
+// fsync (skipped on Windows) + atomic rename, then swaps the in-memory
+// fd / groupCommit / logIndex under the per-file mu. The compacted
+// header carries a LogFlagCompacted bit so recovery skips the
+// metaOff > hdrOff reconcile (post-compaction metadata.rollup_offset
+// legitimately sits above the compacted file's header offset and is no
+// longer a physical position). Metadata.rollup_offset retains its
+// monotonic high-water mark after compaction — SetRollupOffset calls
+// from post-compaction rollup passes return ErrRollupOffsetRegression
+// and are swallowed; the on-disk header is the source of truth from
+// then on. See compaction.go for the full sequence.
 //
 // In-memory bookkeeping IS trimmed (R-2, #581): every AdvanceFence
 // call drops the prefix of logIndex.entries (and the matching consumed

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -277,6 +277,20 @@ type FSStore struct {
 	// constructed, so the setter path is the production wire-in site.
 	onChunkComplete func(hash blockstore.ContentHash, data []byte, path string)
 
+	// compactionThresholdBytes is the minimum number of pre-fence bytes
+	// that must accumulate in a per-payload log before the next rollup
+	// pass triggers physical compaction (rewrites the log file dropping
+	// records below idx.compactionFence). Default = maxLogBytes /
+	// defaultCompactionDivisor when FSStoreOptions.CompactionThresholdBytes
+	// is zero. Set to a negative value to disable compaction entirely
+	// (the log file then grows until DeleteAppendLog wipes the payload,
+	// matching pre-#579 behavior).
+	//
+	// Trade-off: a smaller threshold caps disk growth tighter at the
+	// cost of more I/O churn (per-pass we copy `survivors` bytes); a
+	// larger threshold lets the log grow further between passes.
+	compactionThresholdBytes int64
+
 	// orphanLogMinAgeSeconds gates the append-log orphan sweep during
 	// recovery (D-28 / Warning 3). A log is considered orphan only when
 	// (a) its rollup_offset in metadata is 0, (b) no FileBlock exists for
@@ -600,6 +614,15 @@ type FSStoreOptions struct {
 	// RAM-only (D-05). Surfaced via pkg/config as
 	// blockstore.local.dedup_lru_size.
 	DedupLRUSize int
+
+	// CompactionThresholdBytes controls when physical log compaction
+	// runs (#579). After a rollup pass advances idx.compactionFence,
+	// the rewrite is invoked if the fence sits more than this many
+	// bytes above logHeaderSize. Zero defers to the default
+	// (maxLogBytes / defaultCompactionDivisor). A negative value
+	// disables compaction entirely (pre-#579 behavior — the log grows
+	// until DeleteAppendLog).
+	CompactionThresholdBytes int64
 }
 
 // NewWithOptions constructs an FSStore. Non-zero values in opts override
@@ -653,6 +676,24 @@ func newFSStoreWithOptionsInternal(baseDir string, maxDisk, maxMemory int64, fil
 		bc.orphanLogMinAgeSeconds = opts.OrphanLogMinAgeSeconds
 	} else {
 		bc.orphanLogMinAgeSeconds = 3600
+	}
+
+	// Compaction threshold (#579). Zero → derive from maxLogBytes so a
+	// smaller log budget compacts proportionally more aggressively; a
+	// negative value disables compaction entirely (pre-#579 behavior,
+	// useful for tests pinned to the legacy growth pattern).
+	switch {
+	case opts.CompactionThresholdBytes > 0:
+		bc.compactionThresholdBytes = opts.CompactionThresholdBytes
+	case opts.CompactionThresholdBytes < 0:
+		bc.compactionThresholdBytes = -1
+	default:
+		bc.compactionThresholdBytes = bc.maxLogBytes / defaultCompactionDivisor
+		if bc.compactionThresholdBytes <= 0 {
+			// maxLogBytes < defaultCompactionDivisor — clamp so a tiny
+			// budget still gets a sensible threshold floor.
+			bc.compactionThresholdBytes = int64(logHeaderSize)
+		}
 	}
 
 	// Phase 19 Plan 04: per-FSStore hash dedup LRU + chunk-complete

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -49,8 +49,12 @@ import (
 // interval set is NOT trimmed in lockstep — its merged-interval rep is
 // already proportional to distinct dirty file regions, not arrival count.)
 //
-// Physical log compaction (truncating the log file at compactionFence) is
-// still out of scope and remains tracked as v0.17+ work — see #579.
+// Physical log compaction (#579): the post-rollup pass invokes
+// compactLogLocked when (compactionFence - logHeaderSize) exceeds the
+// configured threshold. The rewrite drops consumed entries below the
+// fence, rebases the surviving entries' logPos values, and rewinds
+// fenceCursor to 0. After compaction the in-memory entries slice and
+// the on-disk log both track live records only.
 
 // logEntry is one record's position in the log + the file-offset extent it
 // covers. The entry is immutable once appended; consumption is tracked

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -206,6 +206,13 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 		return 0, 0, 0, 0, 0, 0
 	}
 
+	// #579: sweep any `.compact` temp files left behind by a process
+	// that crashed mid-compaction. Stale temps are not load-bearing
+	// for correctness (the original log file is the live one until
+	// rename completes), but leaving them on disk would gradually
+	// accumulate wasted bytes across crash-restart cycles.
+	bc.cleanupCompactTemps(logsDir)
+
 	// FIX-16: compute the effective orphan-sweep floor once and warn if the
 	// configured value is non-positive — surfaces the silent default-3600
 	// substitution at boot rather than per-log-file. The legacy per-iteration
@@ -311,12 +318,22 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 		// crashed between step 2 (SetRollupOffset) and step 3
 		// (advanceRollupOffset). Rewrite the header to match metadata so
 		// replay does not re-emit chunks for bytes already persisted.
+		//
+		// #579: after a successful physical compaction pass the on-disk
+		// header has Flags & LogFlagCompacted set and RollupOffset is
+		// reset to logHeaderSize, while metadata.rollup_offset retains
+		// its pre-compaction monotonic high-water mark. In that state
+		// the metaOff > hdrOff comparison would always trip and seek
+		// past the compacted file's EOF, losing every surviving
+		// record. The LogFlagCompacted bit tells us "header is the
+		// truth; do not reconcile from metadata".
 		metaOff := uint64(0)
 		if bc.rollupStore != nil {
 			metaOff, _ = bc.rollupStore.GetRollupOffset(ctx, payloadID)
 		}
 		effectiveOff := hdr.RollupOffset
-		if metaOff > effectiveOff {
+		compacted := hdr.Flags&LogFlagCompacted != 0
+		if metaOff > effectiveOff && !compacted {
 			if aerr := advanceRollupOffset(f, metaOff); aerr != nil {
 				logger.Warn("recovery: advanceRollupOffset failed", "path", path, "error", aerr)
 			} else {

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -237,7 +237,16 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	if err != nil {
 		return fmt.Errorf("rollup: open log for read: %w", err)
 	}
-	defer func() { _ = rf.Close() }()
+	// rfClosed lets the error-path defer skip the close once the
+	// explicit close below runs. We must close rf before maybeCompactLog
+	// fires at function tail — Windows refuses to rename over a path
+	// that has ANY open handle, including this read-only one.
+	rfClosed := false
+	defer func() {
+		if !rfClosed {
+			_ = rf.Close()
+		}
+	}()
 
 	// consumedExtents tracks the FILE-OFFSET extent of every record that
 	// will be marked consumed in the logIndex below. R-7 (#580): consumption
@@ -534,6 +543,13 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// logged at Warn and otherwise swallowed — a failed compaction
 	// pass leaves the original log untouched; the next rollup pass
 	// retries automatically.
+	//
+	// Close rf first: Windows refuses to rename over a file with an
+	// open handle, and compaction's atomic rename would otherwise fail
+	// with ERROR_SHARING_VIOLATION. On POSIX the close is harmless;
+	// rf is otherwise unused past this point.
+	_ = rf.Close()
+	rfClosed = true
 	if cerr := bc.maybeCompactLog(ctx, payloadID, lf, idx); cerr != nil {
 		slog.Warn("rollup: compaction failed; will retry next pass",
 			"payloadID", payloadID, "error", cerr)

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -472,22 +472,39 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// by construction (newLogIndex / recovery seed + AdvanceFence
 	// forward-walk), and the per-file mu serializes rollup workers on the
 	// same payload, so regression should be unreachable in steady state.
-	// Keep the bail-out anyway — if some future change introduces a
-	// regression source, the conservative posture is the same as today:
-	// chunks are durable (content-addressed, idempotent on retry); a
-	// future pass will re-emit them.
+	//
+	// Post-#579: after a physical compaction pass the in-memory fence
+	// resets to logHeaderSize while metadata.rollup_offset retains its
+	// pre-compaction high-water mark (monotonicity at the metadata
+	// layer cannot be regressed). Subsequent rollup passes therefore
+	// compute targetPos values BELOW the persisted metaOff and the
+	// SetRollupOffset call legitimately returns ErrRollupOffsetRegression.
+	// That is benign — we must NOT return early here, because the
+	// derived-state header advance below is the on-disk source of
+	// truth that recovery's seek() uses to position the readRecord
+	// loop. Falling through to advanceRollupOffset on the regression
+	// branch keeps the header in sync with the in-memory fence so a
+	// post-compaction reboot replays from the correct position. The
+	// LogFlagCompacted bit (set during compactLogLocked) tells recovery
+	// to trust the header over metadata.
 	_, err = bc.rollupStore.SetRollupOffset(ctx, payloadID, targetPos)
 	if errors.Is(err, metadata.ErrRollupOffsetRegression) {
 		slog.Debug("rollup: SetRollupOffset regression rejected (benign)",
 			"payloadID", payloadID, "target", targetPos)
-		return nil
-	}
-	if err != nil {
+		// Fall through — see comment block above. The header advance
+		// below MUST run so the on-disk position stays aligned with
+		// the in-memory fence even when metadata refuses to.
+	} else if err != nil {
 		return fmt.Errorf("rollup: SetRollupOffset: %w", err)
 	}
 
 	// Derived-state: advance the log header. If this fails, metadata is
-	// already the source of truth and recovery (plan 07) will reconcile.
+	// already the source of truth and recovery (plan 07) will reconcile
+	// — except when LogFlagCompacted is set (post-compaction state),
+	// in which case the header IS the truth and a failure here means
+	// the next boot may re-replay records that were already chunked.
+	// CAS is idempotent so that is benign correctness-wise (only a
+	// throughput hit).
 	if err := advanceRollupOffset(lf.f, targetPos); err != nil {
 		slog.Warn("rollup: advanceRollupOffset failed; recovery will reconcile",
 			"payloadID", payloadID, "error", err)
@@ -508,6 +525,18 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	select {
 	case bc.pressureCh <- struct{}{}:
 	default:
+	}
+
+	// #579: physical log compaction. Runs under the per-file mu we
+	// still hold (deferred Unlock above). The threshold check is
+	// internal to maybeCompactLog, so this call is cheap when the
+	// fence has not advanced enough to warrant a rewrite. Errors are
+	// logged at Warn and otherwise swallowed — a failed compaction
+	// pass leaves the original log untouched; the next rollup pass
+	// retries automatically.
+	if cerr := bc.maybeCompactLog(ctx, payloadID, lf, idx); cerr != nil {
+		slog.Warn("rollup: compaction failed; will retry next pass",
+			"payloadID", payloadID, "error", cerr)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Adds a post-rollup compaction pass that rewrites each per-payload append log dropping records below `compactionFence`, then atomically swaps the file via temp + fsync + parent-dir fsync + rename.
- Bounds on-disk log growth for long-lived payloads (closes #579). The threshold is `CompactionThresholdBytes` (default `maxLogBytes/4`; negative disables, mirroring pre-#579 behavior).
- Crash-safe: the rename is the linearization point; stale `.compact` temps are swept by recovery. A new `LogFlagCompacted` header bit tells recovery to trust the on-disk header instead of `metadata.rollup_offset` (metadata is frozen by INV-03 monotonicity after the first compaction).

## Test plan

- [x] `go test -race ./pkg/blockstore/local/fs/` — full package green.
- [x] New tests cover:
  - bounded log size under sustained writes (`TestCompaction_BoundedLogSize`);
  - opt-out via negative threshold (`TestCompaction_DisabledByNegativeThreshold`);
  - reopen-and-recover round trip with subsequent appends (`TestCompaction_RecoveryRebuildsAfterCompact`);
  - `LogFlagCompacted` bit + RollupOffset reset + CAS-chunk preservation (`TestCompaction_HeaderFlagSetAndPreservesCAS`);
  - stale `.compact` temp cleaned up at boot (`TestCompaction_StaleTempCleanedUpOnRecovery`).
- [x] No new races introduced (the pre-existing flake in `TestAppendWrite_DeleteRace_NoDeadlock` reproduces against `develop` without these changes — tracked separately).

## Notes / follow-ups

- Interaction with #580: when file-offset-keyed consumption lands, the fence semantics change; the compaction trigger (`fence - logHeaderSize > threshold`) and the rebase logic still apply but the survivor set will be computed over a different consumed predicate. The temp + rename + flag scaffolding here is reusable as-is.
- Metadata `rollup_offset` becomes a high-water mark after the first compaction; downstream callers that read it as a physical position should consult the header instead. Today only recovery's reconcile branch does, and it already honors `LogFlagCompacted`.