### PR TITLE
chore(smb): walk back KNOWN_FAILURES for #591 silent flips (+6 ACL tests)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -50,12 +50,6 @@ descriptors, and owner rights are not implemented.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.acls.ACCESSBASED | ACLs | Deeper failure at acls.c:2308 after PR #551 (ABE bit moved to ShareFlags) — SD 0x20081 still leaks file `smb2-testsd` to non-readers; requires ABE filtering in directory enumeration | - |
-| smb2.acls.DENY1 | ACLs | Deeper failure at acls.c:2862 — maximal_access reports 0x1E008B but expected 0x16008B (extra `SEC_DIR_DELETE_CHILD` bit set); MaxAccess computation needs to drop dir-only rights on file objects | - |
-| smb2.acls.DYNAMIC | ACLs | Dynamic access checks not implemented (fails at acls.c:1863 with NT_STATUS_OBJECT_NAME_NOT_FOUND) | - |
-| smb2.acls.GENERIC | ACLs | Deeper failure at acls.c:440 after PR #552 (FileAccessInformation now DACL-evaluated) — granted access reports 0x000f0000 but expected 0x00070080; GENERIC_ALL→specific-rights mapping still drops STANDARD bits | - |
-| smb2.acls.MXAC-NOT-GRANTED | ACLs | Deeper failure at acls.c:2979 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED; MaxAccess should not implicitly grant when DACL denies the requested access | - |
-| smb2.acls.OVERWRITE_READ_ONLY_FILE | ACLs | Deeper failure at acls.c:3104 — smb2_create returns NT_STATUS_OK but expected NT_STATUS_ACCESS_DENIED on OVERWRITE of read-only file | - |
-| smb2.acls.OWNER | ACLs | Owner SID semantics not implemented (fails at acls.c:765 with NT_STATUS_ACCESS_DENIED instead of NT_STATUS_OK) | - |
 | smb2.sdread | Security descriptors | Security descriptor read not implemented | - |
 | smb2.secleak | Security descriptors | Security descriptor leak test not implemented | - |
 


### PR DESCRIPTION
## Summary

PR #591 (Samba \`desc_expand_generic\` on inherited DACL) silently flipped **6 additional ACL tests** beyond the 3 walked back at merge time. CI on develop confirmed PASS for:

- ` smb2.acls.GENERIC` (was acls.c:440, \`0x000f0000 vs 0x00070080\`)
- ` smb2.acls.OWNER` (was acls.c:765)
- ` smb2.acls.DYNAMIC` (was acls.c:1863)
- ` smb2.acls.DENY1` (was acls.c:2862)
- ` smb2.acls.MXAC-NOT-GRANTED` (was acls.c:2979)
- ` smb2.acls.OVERWRITE_READ_ONLY_FILE` (was acls.c:3104)

All previously failed at points downstream of the inherited-DACL generic-bit gap fixed in #591 — expanding GENERIC_* on the resolved child ACEs unblocked the subsequent access-grant / MaxAccess / disposition assertions. Net win from #591: **+9 ACL flips** (3 known + 6 silent).

` smb2.acls.ACCESSBASED` stays — separate failure path (directory-enumeration ABE leak).

## Test plan

- [x] Confirmed PASS for all 6 in latest CI run on develop (smbtorture / memory job on commit \`c88bc74c\`)
- [ ] CI must stay green; any flake means a test should go back

Refs #591, #469.