### PR TITLE
test(smb/acl): regression guard for Case-3 preserved INHERIT_ONLY + GENERIC_*

### DIFF
--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -1341,6 +1341,46 @@ func TestComputeInheritedACL_GenericExpansion_NonGenericPassesThrough(t *testing
 	}
 }
 
+// TestComputeInheritedACL_GenericExpansion_Case3PreservedSkipsExpand covers
+// the case where a parent OI-only ACE on a non-CREATOR principal lands on a
+// dir child: ComputeInheritedACL emits a single preserved INHERIT_ONLY ACE
+// (no resolved sibling) with the parent's raw AccessMask intact, so a future
+// grandchild file inherits the same generic bits and expands them against
+// the leaf's GenericMapping at that step.
+//
+// The post-loop expansion pass must skip this ACE because it is INHERIT_ONLY.
+// Regression guard against any refactor that clears INHERIT_ONLY on the
+// Case-3 preserved emission path.
+func TestComputeInheritedACL_GenericExpansion_Case3PreservedSkipsExpand(t *testing.T) {
+	parentACL := &ACL{
+		AutoInherited: true,
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE, // OI only — does not apply at dir child
+				AccessMask: 0x10000000,            // GENERIC_ALL
+				Who:        "user@example.com",
+			},
+		},
+	}
+
+	result := ComputeInheritedACL(parentACL, true, Creator{})
+	if result == nil {
+		t.Fatal("expected non-nil result for dir child with OI-only parent ACE")
+	}
+	if len(result.ACEs) != 1 {
+		t.Fatalf("expected 1 preserved INHERIT_ONLY ACE, got %d", len(result.ACEs))
+	}
+	preserved := result.ACEs[0]
+	if preserved.Flag&ACE4_INHERIT_ONLY_ACE == 0 {
+		t.Errorf("Case-3 preserved ACE missing INHERIT_ONLY (flag=0x%x)", preserved.Flag)
+	}
+	if preserved.AccessMask != 0x10000000 {
+		t.Errorf("Case-3 AccessMask=0x%08x, want raw GENERIC_ALL retained for grandchild expansion",
+			preserved.AccessMask)
+	}
+}
+
 func TestPropagateACL_Directory(t *testing.T) {
 	existingACL := &ACL{ACEs: []ACE{
 		{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_DELETE, Who: "bob@example.com"},


### PR DESCRIPTION
## Summary

Test-only follow-up to #591 covering the coverage gap surfaced in code review.

#591 added a post-loop pass in \`ComputeInheritedACL\` that expands GENERIC_* on every emitted ACE not marked \`INHERIT_ONLY\`. The existing \`GenericExpansion_DirPreservesInheritOnly\` test covered Case-1 (CREATOR_OWNER dual-emit producing both a resolved sibling and a preserved INHERIT_ONLY placeholder). It did NOT exercise Case-3: a parent OI-only ACE on a **non-CREATOR principal** landing on a dir child, which emits a single preserved INHERIT_ONLY ACE (no resolved sibling).

The behavior is already correct — the post-loop pass skips it because it carries \`INHERIT_ONLY\` — but with no test, a future refactor that clears \`INHERIT_ONLY\` on the Case-3 emission path could silently expand grandchild placeholder bits.

## Test plan

- [x] ` go test ./pkg/metadata/acl/... -run TestComputeInheritedACL_GenericExpansion` — all 4 cases green
- [ ] CI green