### PR TITLE
fix(smb/acl): sentinel FileOwnerUID for anonymous to avoid OWNER@ collision (#540)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1083,17 +1083,15 @@ func computeMaximalAccess(file *metadata.File, authCtx *metadata.AuthContext) ui
 // subsequent operations against the same handle.
 //
 // Anonymous (no Identity or no UID) sessions produce a context with only
-// the file's owner UID/GID populated. EVERYONE@ ACEs still match. Note that
-// OWNER@/GROUP@ will spuriously match when the file is owned by uid/gid 0
-// (the zero-value default in the returned context); this matches the legacy
-// behavior of metadata.evaluateACLPermissions and is acceptable today because
-// anonymous SMB sessions are not granted access at the share level. Tracked
-// as a future hardening item: use a sentinel UID/GID that cannot collide
-// with a real owner.
+// the file's owner GID populated and FileOwnerUID forced to
+// acl.AnonymousFileOwnerUID. The sentinel prevents the requester's
+// zero-valued UID from collapsing onto a root-owned file's owner — without
+// it, anonymous OWNER@ matches and pulls in the MS-DTYP §2.5.3.2 implicit
+// RC|WRITE_DAC grant on every root-owned object. See #540.
 func buildMaxAccessEvalContext(file *metadata.File, authCtx *metadata.AuthContext) *acl.EvaluateContext {
 	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
 		return &acl.EvaluateContext{
-			FileOwnerUID: file.UID,
+			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -1087,7 +1087,13 @@ func buildEnumEvalContext(attr *metadata.FileAttr, authCtx *metadata.AuthContext
 		FileOwnerUID: attr.UID,
 		FileOwnerGID: attr.GID,
 	}
-	if authCtx == nil || authCtx.Identity == nil {
+	// Anonymous (no Identity or no UID): force FileOwnerUID to the
+	// AnonymousFileOwnerUID sentinel so the requester's zero-valued UID
+	// cannot collapse onto a root-owned entry's owner and pick up OWNER@
+	// ACEs plus the MS-DTYP §2.5.3.2 owner-implicit grant during ABE
+	// visibility checks. See #540.
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		evalCtx.FileOwnerUID = acl.AnonymousFileOwnerUID
 		return evalCtx
 	}
 	id := authCtx.Identity

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -55,6 +55,20 @@ func isAdminSID(sid string) bool {
 // is by numeric UID/GID, not the username-form evalCtx.Who.
 const localDomainSuffix = "@localdomain"
 
+// AnonymousFileOwnerUID is the sentinel callers must use for
+// EvaluateContext.FileOwnerUID when building a context for an anonymous /
+// unauthenticated requester. It guarantees the OWNER@ identity arm
+// (UID == FileOwnerUID) and the MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC
+// pass both miss, regardless of the file's real owner.
+//
+// Without this sentinel, an anonymous requester (Go zero-value UID == 0)
+// matches OWNER@ on every root-owned file and receives the implicit
+// READ_CONTROL|WRITE_DAC grant on top — handing privileged DACL-edit rights
+// to unauthenticated sessions. 0xFFFFFFFF mirrors the "nobody"/invalid-UID
+// convention already used in file_modify.go and validation.go and is outside
+// any realistic POSIX UID range. See #540.
+const AnonymousFileOwnerUID uint32 = ^uint32(0)
+
 // EvaluateContext carries the requestor's identity and the file's
 // owner/group for dynamic OWNER@/GROUP@/EVERYONE@ resolution.
 type EvaluateContext struct {

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -938,3 +938,84 @@ func TestHasTakeOwnershipPrivilege(t *testing.T) {
 		})
 	}
 }
+
+// anonRootOwnedCtx returns the EvaluateContext shape callers MUST produce
+// for an anonymous (unauthenticated) requester probing a root-owned (UID 0)
+// file: requester UID == 0 (Go zero value) and FileOwnerUID ==
+// AnonymousFileOwnerUID. The sentinel breaks the UID == FileOwnerUID arm
+// so OWNER@ matching and the MS-DTYP §2.5.3.2 owner-implicit pass both
+// miss. See #540.
+func anonRootOwnedCtx() *EvaluateContext {
+	return &EvaluateContext{
+		UID:          0,
+		FileOwnerUID: AnonymousFileOwnerUID,
+		FileOwnerGID: 0,
+	}
+}
+
+// TestEvaluate_Anonymous_NoOwnerMatchOnRootOwnedFile is the regression test
+// for #540: an anonymous requester (Go zero-value UID == 0) probing a
+// root-owned file (FileOwnerUID == 0 in the raw file record) MUST NOT match
+// OWNER@ ACEs. The AnonymousFileOwnerUID sentinel makes this hold.
+func TestEvaluate_Anonymous_NoOwnerMatchOnRootOwnedFile(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			// Grant the file owner full control. Without the sentinel,
+			// anonymous would collapse onto OWNER@ and receive this mask.
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: 0xFFFFFFFF, Who: SpecialOwner},
+		},
+	}
+
+	ctx := anonRootOwnedCtx()
+	if Evaluate(a, ctx, ACE4_READ_DATA) {
+		t.Error("#540: anonymous must not match OWNER@ on root-owned file (READ_DATA)")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+		t.Error("#540: anonymous must not match OWNER@ on root-owned file (WRITE_DATA)")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_ACL) {
+		t.Error("#540: anonymous must not match OWNER@ on root-owned file (WRITE_DAC)")
+	}
+}
+
+// TestEvaluate_Anonymous_NoOwnerImplicitGrantOnRootOwnedFile is the second
+// half of the #540 regression: even with no OWNER@ ACE at all, the MS-DTYP
+// §2.5.3.2 owner-implicit pass would silently hand RC|WRITE_DAC to anonymous
+// on every root-owned object. The AnonymousFileOwnerUID sentinel blocks the
+// implicit pass via the requesterIsOwner predicate.
+func TestEvaluate_Anonymous_NoOwnerImplicitGrantOnRootOwnedFile(t *testing.T) {
+	// Empty DACL — MS-DTYP §2.5.3 "deny all" except for the §2.5.3.2
+	// owner-implicit grants. Anonymous must receive nothing.
+	a := &ACL{ACEs: nil}
+
+	ctx := anonRootOwnedCtx()
+	if Evaluate(a, ctx, ACE4_READ_ACL) {
+		t.Error("#540: anonymous must not receive implicit READ_CONTROL on root-owned file")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_ACL) {
+		t.Error("#540: anonymous must not receive implicit WRITE_DAC on root-owned file")
+	}
+	if Evaluate(a, ctx, ACE4_WRITE_OWNER) {
+		t.Error("#540: anonymous must not receive implicit WRITE_OWNER on root-owned file")
+	}
+}
+
+// TestEvaluate_Anonymous_EveryoneStillMatches confirms the sentinel only
+// suppresses owner-arm matching; EVERYONE@ ACEs still grant access to the
+// anonymous requester, which is the intended behavior.
+func TestEvaluate_Anonymous_EveryoneStillMatches(t *testing.T) {
+	a := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+		},
+	}
+
+	ctx := anonRootOwnedCtx()
+	if !Evaluate(a, ctx, ACE4_READ_DATA) {
+		t.Error("#540: EVERYONE@ allow must still match an anonymous requester")
+	}
+	// But nothing beyond what EVERYONE@ grants.
+	if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+		t.Error("#540: anonymous must not receive bits outside the EVERYONE@ grant")
+	}
+}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -362,9 +362,13 @@ func evaluateACLPermissions(
 ) Permission {
 	// Handle anonymous/no identity
 	if identity == nil || identity.UID == nil {
-		// Evaluate as EVERYONE@ only
+		// Evaluate as EVERYONE@ only. FileOwnerUID is forced to the
+		// AnonymousFileOwnerUID sentinel so the anonymous requester's
+		// zero-valued UID cannot collapse onto a root-owned file's owner
+		// and pick up OWNER@ ACEs plus the MS-DTYP §2.5.3.2 owner-implicit
+		// RC|WRITE_DAC grant. See #540.
 		evalCtx := &acl.EvaluateContext{
-			FileOwnerUID: file.UID,
+			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,
 		}
 		return evaluateWithACL(file.ACL, evalCtx, requested, shareOpts)
@@ -762,8 +766,12 @@ func parentGrantsDeleteChild(parent *File, authCtx *AuthContext) bool {
 // produce against the same file. Kept private to the metadata package.
 func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateContext {
 	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		// FileOwnerUID is forced to the AnonymousFileOwnerUID sentinel so
+		// the anonymous requester's zero-valued UID cannot collapse onto a
+		// root-owned file's owner and pick up OWNER@ ACEs plus the
+		// MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC grant. See #540.
 		return &acl.EvaluateContext{
-			FileOwnerUID: file.UID,
+			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #540.

Anonymous SMB sessions (no `Identity` or no `Identity.UID`) built an `acl.EvaluateContext` with the requester's `UID` left at its Go zero value (`0`) and `FileOwnerUID = file.UID`. On root-owned files (`file.UID == 0`) the OWNER@ identity arm matched (`UID == FileOwnerUID`), and the MS-DTYP §2.5.3.2 owner-implicit pass (#539) layered `READ_CONTROL | WRITE_DAC` on top — handing privileged DACL-edit rights to unauthenticated requesters on every root-owned object.

## Fix

Introduce `acl.AnonymousFileOwnerUID = ^uint32(0)` and use it as the `FileOwnerUID` in all anonymous-context builders:

- `pkg/metadata/auth_permissions.evaluateACLPermissions`
- `pkg/metadata/auth_permissions.buildFileAccessEvalContext` (also covers the parent-DACL evaluation path in `parentGrantsDeleteChild`)
- `internal/adapter/smb/v2/handlers/create.buildMaxAccessEvalContext`
- `internal/adapter/smb/v2/handlers/query_directory.buildEnumEvalContext` — bonus catch: the original guard only checked `Identity == nil`, missing the `Identity != nil && UID == nil` case where the same collapse occurred. Guard broadened.

`0xFFFFFFFF` mirrors the "nobody"/invalid-UID convention already used in `pkg/metadata/file_modify.go` and `pkg/metadata/validation.go`, and is outside any realistic POSIX UID range. The sentinel is read-only in `acl.Evaluate` (consumed by two `requesterIsOwner := UID == FileOwnerUID` comparisons); no other code path treats it as a positive signal.

## Scope notes

- This PR addresses the OWNER@ / owner-implicit collision specifically (what #540 describes). The same `UID == 0` collapse can in theory match a `"0@localdomain"` localdomain-form ACE on the default branch of `aceMatchesWhoWithOwnerRights`; that path is orthogonal and rarely exercised — left for a follow-up if it turns out to bite in conformance.
- GROUP@ matching on GID 0 is unaffected (the issue scoped to OWNER@; GROUP@ does not trigger the implicit-grant pass).

## Test plan

- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/...` — green
- [x] `go vet ./...` — clean
- [x] New regression tests in `pkg/metadata/acl/evaluate_test.go`:
  - `TestEvaluate_Anonymous_NoOwnerMatchOnRootOwnedFile` — OWNER@ ACE granting full control must NOT match anonymous on a root-owned file
  - `TestEvaluate_Anonymous_NoOwnerImplicitGrantOnRootOwnedFile` — empty DACL must NOT grant implicit RC|WRITE_DAC|WRITE_OWNER to anonymous on a root-owned file
  - `TestEvaluate_Anonymous_EveryoneStillMatches` — EVERYONE@ continues to grant access to anonymous (no over-restriction)