### PR TITLE
fix(smb/abe): widen access mask to match Samba user_can_read_fsp

### DIFF
--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -1066,13 +1066,21 @@ func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext, 
 		}
 	}
 
-	// ACE4_READ_DATA == ACE4_LIST_DIRECTORY == 0x00000001 — same bit, so
-	// either mask works against both files and directories.
-	const readMask = acl.ACE4_READ_DATA
+	// Mirror Samba source3/smbd/dir.c::user_can_read_fsp: ABE requires the
+	// caller to hold FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES |
+	// READ_CONTROL on the entry. NFSv4 bits intentionally share positions with
+	// Windows MS-DTYP rights (RFC 7530 §6.2.1) — READ_DATA == LIST_DIRECTORY
+	// (0x1), READ_NAMED_ATTRS == READ_EA (0x8), so the same mask applies to
+	// both files and directories. The smbtorture smb2.acls.ACCESSBASED test
+	// asserts a file granting only a strict subset of these bits is hidden.
+	const enumMask = acl.ACE4_READ_DATA |
+		acl.ACE4_READ_NAMED_ATTRS |
+		acl.ACE4_READ_ATTRIBUTES |
+		acl.ACE4_READ_ACL
 
 	if attr.ACL != nil {
 		evalCtx := buildEnumEvalContext(attr, authCtx)
-		return acl.Evaluate(attr.ACL, evalCtx, readMask)
+		return acl.Evaluate(attr.ACL, evalCtx, enumMask)
 	}
 
 	// POSIX fallback — same semantics as

--- a/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_abe_test.go
@@ -56,19 +56,29 @@ func directoryWithACL(name string, uid, gid uint32, mode uint32, a *acl.ACL) met
 	}
 }
 
-// TestFilterByAccess_OwnerOnlyACL verifies that an ACL granting READ_DATA only
-// to OWNER@ keeps the file visible to the owner and hides it from a non-owner.
+// fullReadMask is the access-mask Samba (source3/smbd/dir.c::user_can_read_fsp)
+// requires for ABE visibility: READ_DATA | READ_EA | READ_ATTRIBUTES |
+// READ_CONTROL. Tests grant this exact mask whenever they want the entry to
+// stay visible under the filter.
+const fullReadMask = acl.ACE4_READ_DATA |
+	acl.ACE4_READ_NAMED_ATTRS |
+	acl.ACE4_READ_ATTRIBUTES |
+	acl.ACE4_READ_ACL
+
+// TestFilterByAccess_OwnerOnlyACL verifies that an ACL granting the full ABE
+// read mask only to OWNER@ keeps the file visible to the owner and hides it
+// from a non-owner.
 func TestFilterByAccess_OwnerOnlyACL(t *testing.T) {
 	ownerOnly := &acl.ACL{
 		ACEs: []acl.ACE{
-			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullReadMask, Who: acl.SpecialOwner},
 		},
 	}
 	entries := []metadata.DirEntry{
 		regularFileWithACL("secret.txt", 1000, 1000, 0o000, ownerOnly),
 		regularFileWithACL("public.txt", 1000, 1000, 0o000, &acl.ACL{
 			ACEs: []acl.ACE{
-				{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialEveryone},
+				{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullReadMask, Who: acl.SpecialEveryone},
 			},
 		}),
 	}
@@ -87,12 +97,45 @@ func TestFilterByAccess_OwnerOnlyACL(t *testing.T) {
 	}
 }
 
+// TestFilterByAccess_PartialReadMaskHidesFromOwner exercises the
+// smb2.acls.ACCESSBASED iterations 2-4: an ACL granting the file owner some
+// but not all of {READ_DATA, READ_EA, READ_ATTRIBUTES, READ_CONTROL} must hide
+// the file from a directory listing — even though the requester IS the owner
+// (the test enumerates as the same user that set the SD). Mirrors Samba
+// source3/smbd/dir.c::user_can_read_fsp which requires the full mask.
+func TestFilterByAccess_PartialReadMaskHidesFromOwner(t *testing.T) {
+	cases := []struct {
+		name string
+		mask uint32
+	}{
+		{"missing_read_ea", acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL},
+		{"missing_read_attributes", acl.ACE4_READ_DATA | acl.ACE4_READ_NAMED_ATTRS | acl.ACE4_READ_ACL},
+		{"missing_read_data", acl.ACE4_READ_NAMED_ATTRS | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL},
+	}
+	owner := authForUID(1000, 1000)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &acl.ACL{
+				ACEs: []acl.ACE{
+					{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: tc.mask, Who: acl.SpecialOwner},
+				},
+			}
+			entries := []metadata.DirEntry{regularFileWithACL("smb2-testsd", 1000, 1000, 0o000, a)}
+			got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
+			if len(got) != 0 {
+				t.Fatalf("owner with partial mask %#x: want hidden, got %d entries", tc.mask, len(got))
+			}
+		})
+	}
+}
+
 // TestFilterByAccess_DirectoryListBit verifies that directories use the same
-// 0x1 bit (ACE4_LIST_DIRECTORY) as files (ACE4_READ_DATA).
+// 0x1 bit (ACE4_LIST_DIRECTORY) as files (ACE4_READ_DATA). The owner ACE
+// carries the full ABE read mask so the owner remains visible.
 func TestFilterByAccess_DirectoryListBit(t *testing.T) {
 	denyOther := &acl.ACL{
 		ACEs: []acl.ACE{
-			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_LIST_DIRECTORY, Who: acl.SpecialOwner},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullReadMask, Who: acl.SpecialOwner},
 		},
 	}
 	entries := []metadata.DirEntry{
@@ -169,7 +212,7 @@ func TestFilterByAccess_RootBypass(t *testing.T) {
 func TestFilterByAccess_HidesNonReadable(t *testing.T) {
 	ownerOnly := &acl.ACL{
 		ACEs: []acl.ACE{
-			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullReadMask, Who: acl.SpecialOwner},
 		},
 	}
 	entries := []metadata.DirEntry{
@@ -220,7 +263,7 @@ func TestFilterByAccess_NilAttrHydratorMisses(t *testing.T) {
 func TestFilterByAccess_NilAttrHydratorHits(t *testing.T) {
 	ownerOnly := &acl.ACL{
 		ACEs: []acl.ACE{
-			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullReadMask, Who: acl.SpecialOwner},
 		},
 	}
 	entries := []metadata.DirEntry{

--- a/internal/adapter/smb/v2/handlers/query_directory_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_test.go
@@ -32,13 +32,15 @@ type abeChild struct {
 	acl  *acl.ACL
 }
 
-// readOnlyACL grants ACE4_READ_DATA to a single principal. Under ABE,
-// only callers matching that principal see the entry in the listing.
+// readOnlyACL grants the full ABE read mask (fullReadMask) to a single
+// principal. Under ABE, only callers matching that principal see the entry in
+// the listing — see canEnumerateEntry, which mirrors Samba
+// dir.c::user_can_read_fsp.
 func readOnlyACL(who string) *acl.ACL {
 	return &acl.ACL{
 		ACEs: []acl.ACE{{
 			Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
-			AccessMask: acl.ACE4_READ_DATA,
+			AccessMask: fullReadMask,
 			Who:        who,
 		}},
 	}


### PR DESCRIPTION
## Summary

`smb2.acls.ACCESSBASED` regressed at SD `0x20081` (READ_DATA|READ_ATTRIBUTES|READ_ACL — i.e. the smbtorture iteration that strips `READ_EA`). The ABE filter in `query_directory.go::canEnumerateEntry` only required `ACE4_READ_DATA`, so any DACL granting that single bit kept the entry visible — even when the SD intentionally withheld other read rights.

Samba's `source3/smbd/dir.c::user_can_read_fsp` requires the full `READ_DATA | READ_EA | READ_ATTRIBUTES | READ_CONTROL` mask before exposing an entry under access-based directory enumeration. This PR aligns DittoFS with that contract.

NFSv4 mask bits intentionally share positions with Windows MS-DTYP rights (RFC 7530 §6.2.1):
- `ACE4_READ_DATA` (0x1) == `FILE_READ_DATA` == `FILE_LIST_DIRECTORY`
- `ACE4_READ_NAMED_ATTRS` (0x8) == `FILE_READ_EA`
- `ACE4_READ_ATTRIBUTES` (0x80) == `FILE_READ_ATTRIBUTES`
- `ACE4_READ_ACL` (0x20000) == `READ_CONTROL`

so the same mask works against both files and directories.

Owner-implicit `READ_CONTROL` from MS-DTYP §2.5.3.2 (already in `acl.Evaluate`) keeps the iteration-1 owner case visible without requiring the explicit ACE to carry that bit.

POSIX-fallback path (no ACL) is unchanged: mode-bit read still maps to "may enumerate".

## Test plan

- [x] `go test ./pkg/metadata/acl/... ./internal/adapter/smb/...` green
- [x] New `TestFilterByAccess_PartialReadMaskHidesFromOwner` exercises the exact ACCESSBASED iterations (missing READ_EA / READ_ATTRIBUTES / READ_DATA)
- [x] Existing ABE tests updated to grant the full mask where owner visibility is intentional
- [ ] CI smbtorture confirms `smb2.acls.ACCESSBASED` flips to PASS