### PR TITLE
chore(acl): clarify anonymous-context comment (Copilot review on #598)

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -362,11 +362,13 @@ func evaluateACLPermissions(
 ) Permission {
 	// Handle anonymous/no identity
 	if identity == nil || identity.UID == nil {
-		// Evaluate as EVERYONE@ only. FileOwnerUID is forced to the
-		// AnonymousFileOwnerUID sentinel so the anonymous requester's
-		// zero-valued UID cannot collapse onto a root-owned file's owner
-		// and pick up OWNER@ ACEs plus the MS-DTYP §2.5.3.2 owner-implicit
-		// RC|WRITE_DAC grant. See #540.
+		// Anonymous: suppress OWNER@ matching and the MS-DTYP §2.5.3.2
+		// owner-implicit RC|WRITE_DAC pass by forcing FileOwnerUID to
+		// the AnonymousFileOwnerUID sentinel — without it the requester's
+		// zero-valued UID would collapse onto a root-owned file's owner.
+		// EVERYONE@ ACEs still match. GROUP@ and the "<n>@localdomain"
+		// form may still match on UID/GID-0 owned files (residuals
+		// tracked under #540).
 		evalCtx := &acl.EvaluateContext{
 			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,


### PR DESCRIPTION
## Summary

Addresses the single Copilot inline comment on PR #598 at \`pkg/metadata/auth_permissions.go:369\`:

> The comment \"Evaluate as EVERYONE@ only\" is not accurate with the current anonymous EvaluateContext: \`evalCtx.GID\` remains the zero value (0) and \`FileOwnerGID\` is set to \`file.GID\`, so GROUP@ will still match when the file's group is 0; additionally, \`\"0@localdomain\"\` ACEs can still match via the numeric localdomain arm.

Reworded the comment to accurately describe what the AnonymousFileOwnerUID sentinel does (suppress OWNER@ + MS-DTYP §2.5.3.2 owner-implicit pass), what still matches (EVERYONE@), and what residuals remain tracked under #540 (GROUP@ and \`\"<n>@localdomain\"\` on UID/GID-0 owned files).

Comment-only change in one spot. Build + tests green.