### PR TITLE
fix(smb/conformance): assign distinct UIDs to test users (closes ACCESSBASED leak)

### DIFF
--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -175,10 +175,16 @@ main() {
     # verbatim through SET_INFO Security without the AUTO_INHERIT_REQ gate.
     $DFSCTL share create --name /smbnoncanon --acl-canonicalize-inherited=false $share_flags
 
-    # Create test users
+    # Create test users with DISTINCT UIDs. Without --uid each user falls back
+    # to defaultUID=1000 in internal/adapter/smb/v2/handlers/auth_helper.go,
+    # which collapses both identities onto the same POSIX UID. That collision
+    # makes the second user match OWNER@ on files created by the first via
+    # acl.Evaluate's UID == FileOwnerUID arm, leaking access to a "non-owner"
+    # that is actually the same UID at the POSIX layer. smbtorture
+    # smb2.acls.ACCESSBASED depends on these two principals being distinct.
     log_info "Creating test users..."
-    $DFSCTL user create --username wpts-admin --password "$TEST_PASSWORD"
-    $DFSCTL user create --username nonadmin --password "$TEST_PASSWORD"
+    $DFSCTL user create --username wpts-admin --password "$TEST_PASSWORD" --uid 1000
+    $DFSCTL user create --username nonadmin   --password "$TEST_PASSWORD" --uid 1001
 
     # Identity mapping for Kerberos: the principal "wpts-admin@${KERBEROS_REALM}"
     # must resolve to the "wpts-admin" control plane user. Strip-realm would


### PR DESCRIPTION
## Summary

Pins distinct UIDs for the two smbtorture test users to fix the residual leak in \`smb2.acls.ACCESSBASED\`.

## Root cause

\`test/smb-conformance/bootstrap.sh\` created \`wpts-admin\` and \`nonadmin\` without passing \`--uid\`, so server-side both stayed at \`User.UID == nil\`. \`getUserIdentity\` in \`internal/adapter/smb/v2/handlers/auth_helper.go\` falls back to \`defaultUID = 1000\` whenever \`User.UID\` is nil. Result: both SMB principals collapse onto POSIX UID 1000.

\`acl.Evaluate\` then matches OWNER@ via \`evalCtx.UID == evalCtx.FileOwnerUID\`. On a file created by \`wpts-admin\` (file.UID = 1000), the \"non-owner\" \`nonadmin\` (UID = 1000) matches OWNER@, picks up the explicit ACE PLUS the MS-DTYP §2.5.3.2 owner-implicit pass, and sees the file under ABE enumeration.

This was the residual leak behind \`smb2.acls.ACCESSBASED\` (acls.c:2308 — \"SD 0x20081 - can see file smb2-testsd\"). PR #599 widened the ABE read-mask check to mirror Samba \`user_can_read_fsp\`, but no mask tightening helps when the requester resolves to the file's owner.

## Fix

Pin \`wpts-admin = 1000\`, \`nonadmin = 1001\` so the two principals stay distinct at the POSIX layer.

## Test plan

- [ ] CI smbtorture must flip \`smb2.acls.ACCESSBASED\` to PASS; no regressions on other ACL tests (especially OWNER@-sensitive ones like \`OWNER\`, \`OWNER-RIGHTS\`, \`DENY1\`, \`MXAC-NOT-GRANTED\`).
- [ ] WPTS BVT stays green.
- [ ] If the test flips, KNOWN_FAILURES walkback follows in a second commit (per project two-commit pattern).

## Follow-up

A proper server-side auto-assign of unique UIDs when \`CreateUser\` is called with \`UID == nil\` is a larger change (touches the controlplane user-create path) and is worth filing as a separate issue — real-world deployments tend to provision distinct UIDs anyway, so the bootstrap-side pin is the minimal change needed to unblock conformance.

Refs #469 (ACL cluster).