### PR TITLE
fix(smb/conformance): enable ABE on /smbbasic so acls.ACCESSBASED actually exercises the filter

### DIFF
--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -162,12 +162,20 @@ main() {
     # smb2.acls.SDFLAGSVSCHOWN. The Samba extension
     # `acl flag inherited canonicalization = no` is exercised by
     # smb2.acls_non_canonical against /smbnoncanon below.
-    $DFSCTL share create --name /smbbasic $share_flags
+    #
+    # --access-based-enumeration: smbtorture smb2.acls.ACCESSBASED runs against
+    # the default share (/smbbasic) and asserts QUERY_DIRECTORY hides files the
+    # caller cannot read. Other tests in the smb2.acls suite enumerate as the
+    # file's owner with full rights, so ABE is a no-op for them — enabling the
+    # flag here is safe and avoids needing a separate ABE-only share or
+    # excluding ACCESSBASED from the suite filter. (Refs #532 / MS-SRVS
+    # SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM / MS-SMB2 §2.2.10
+    # SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM.)
+    $DFSCTL share create --name /smbbasic --access-based-enumeration $share_flags
     $DFSCTL share create --name /smbencrypted --encrypt-data $share_flags
     $DFSCTL share create --name /fileshare $share_flags
-    # Refs #532: smbtorture smb2.acls.ACCESSBASED connects to a share with the
-    # MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
-    # QUERY_DIRECTORY hides entries the caller cannot read.
+    # Kept as the previous home of acls.ACCESSBASED (refs #532). Other test
+    # paths may still expect a share named /hideunread; harmless duplicate.
     $DFSCTL share create --name /hideunread --access-based-enumeration $share_flags
     # /smbnoncanon disables MS-DTYP §2.5.3.4.2 canonicalization (Samba
     # `acl flag inherited canonicalization = no` extension). Target of

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -175,10 +175,16 @@ main() {
     # verbatim through SET_INFO Security without the AUTO_INHERIT_REQ gate.
     $DFSCTL share create --name /smbnoncanon --acl-canonicalize-inherited=false $share_flags
 
-    # Create test users
+    # Create test users with DISTINCT UIDs. Without --uid each user falls back
+    # to defaultUID=1000 in internal/adapter/smb/v2/handlers/auth_helper.go,
+    # which collapses both identities onto the same POSIX UID. That collision
+    # makes the second user match OWNER@ on files created by the first via
+    # acl.Evaluate's UID == FileOwnerUID arm, leaking access to a "non-owner"
+    # that is actually the same UID at the POSIX layer. smbtorture
+    # smb2.acls.ACCESSBASED depends on these two principals being distinct.
     log_info "Creating test users..."
-    $DFSCTL user create --username wpts-admin --password "$TEST_PASSWORD"
-    $DFSCTL user create --username nonadmin --password "$TEST_PASSWORD"
+    $DFSCTL user create --username wpts-admin --password "$TEST_PASSWORD" --uid 1000
+    $DFSCTL user create --username nonadmin   --password "$TEST_PASSWORD" --uid 1001
 
     # Identity mapping for Kerberos: the principal "wpts-admin@${KERBEROS_REALM}"
     # must resolve to the "wpts-admin" control plane user. Strip-realm would


### PR DESCRIPTION
## Summary

The smbtorture \`smb2.acls\` suite runs against the default share \`/smbbasic\`. The \`smb2.acls.ACCESSBASED\` iteration asserts \`QUERY_DIRECTORY\` hides entries the caller cannot read — but \`/smbbasic\` was created without \`--access-based-enumeration\`, so DittoFS never invoked the ABE filter and the file naturally leaked. Test failed at \`acls.c:2308 'SD 0x20081 - can see file smb2-testsd'\` regardless of how tight the ABE mask check was (#599) or how distinct the test user UIDs were (#601).

Both previous fixes were correct on their own (Samba upstream mask + distinct UIDs) but neither addressed the actual culprit: the filter wasn't running.

## Fix

Enable \`--access-based-enumeration\` on \`/smbbasic\` in \`bootstrap.sh\`. The other \`smb2.acls\` tests enumerate as the file's owner with full rights, so the ABE filter is a no-op for them — enabling the flag is safe.

Keeps \`/hideunread\` around for any test path that still expects it; harmless duplicate.

## Test plan

- [ ] CI smbtorture must flip \`smb2.acls.ACCESSBASED\` to PASS.
- [ ] All other \`smb2.acls.*\` tests still PASS / KNOWN-FAILURE as before — no regressions.
- [ ] WPTS BVT stays green.
- [ ] On flip, KNOWN_FAILURES walkback follows in a second commit.

Refs #469 (final ACL cluster failure).