### PR TITLE
fix(smb): delayed write-time semantics for smb2.timestamps.* (closes #434)

### DIFF
--- a/internal/adapter/smb/v2/handlers/flush.go
+++ b/internal/adapter/smb/v2/handlers/flush.go
@@ -262,6 +262,12 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 		}
 	}
 
+	// Samba parity (fileio.c::trigger_write_time_update_immediate): FLUSH
+	// collapses the pending write-time window so the next QUERY_INFO sees
+	// the post-write Mtime.
+	flushSmbDelayedWrite(openFile)
+	h.StoreOpenFile(openFile)
+
 	logger.Debug("FLUSH successful", "path", openFile.Path)
 
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -319,6 +319,17 @@ type OpenFile struct {
 	FrozenCtime *time.Time // Saved Ctime value at freeze time
 	FrozenAtime *time.Time // Saved Atime value at freeze time
 
+	// SMB delayed-write timestamp semantics, mirroring Samba
+	// `source3/smbd/fileio.c::trigger_write_time_update` (2-second delay
+	// before a write becomes visible via QUERY_INFO, then sticky for the
+	// rest of the open) and `write_time_forced` (an explicit SetBasic
+	// write_time pins the value until close).
+	SmbWriteTriggered  bool       // first WRITE on this handle has occurred
+	SmbWritePreMtime   *time.Time // Mtime captured before first WRITE — visible during the 2s window
+	SmbWriteFlushMtime *time.Time // Mtime to surface once the 2s window expires or a flush trigger fires
+	SmbWriteFlushAt    time.Time  // wall-clock when the 2s window expires (zero ⇒ already flushed)
+	SmbStickyWriteTime *time.Time // explicit SetBasic write_time — wins over any pending update
+
 	// Oplock state
 	// OplockLevel is the current oplock level for this handle.
 	// Thread safety: This field is written during CREATE (before storing in sync.Map)

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -316,6 +316,12 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// QUERY_INFO returns the timestamp as it was at freeze time.
 	applyFrozenTimestamps(openFile, file)
 
+	// Samba parity (fileio.c): present the delayed-write view of LastWriteTime
+	// — pre-write Mtime during the 2-second window, the first-write Mtime after.
+	// CLOSE intentionally bypasses this so it surfaces the persisted Mtime
+	// (which may include another handle's explicit SetBasic).
+	applySmbDelayedWriteOverride(openFile, file)
+
 	// ========================================================================
 	// Step 3: Validate OutputBufferLength for fixed-size info classes
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -460,6 +460,16 @@ func (h *Handler) setFileInfoFromStore(
 			h.StoreOpenFile(openFile)
 		}
 
+		// Samba parity (fileio.c): any SET_INFO BasicInfo — even with all
+		// zero timestamps — collapses the pending delayed-write window so
+		// the post-write Mtime becomes visible. An explicit, non-sentinel
+		// write_time also makes the value sticky until close.
+		flushSmbDelayedWrite(openFile)
+		if setAttrs.Mtime != nil && mtimeFT != 0 && !isFiletimeSentinel(mtimeFT) {
+			setSmbStickyWriteTime(openFile, *setAttrs.Mtime)
+		}
+		h.StoreOpenFile(openFile)
+
 		// Notify watchers about attribute/timestamp changes
 		if h.NotifyRegistry != nil {
 			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
@@ -971,6 +981,11 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Restore frozen timestamps after truncation (which updates Mtime/Ctime)
 		h.restoreFrozenTimestamps(authCtx, openFile)
+
+		// Samba parity (fileio.c): SET_INFO EndOfFile also flushes the
+		// pending delayed-write window.
+		flushSmbDelayedWrite(openFile)
+		h.StoreOpenFile(openFile)
 
 		// Notify watchers about size changes
 		if h.NotifyRegistry != nil {

--- a/internal/adapter/smb/v2/handlers/timestamps.go
+++ b/internal/adapter/smb/v2/handlers/timestamps.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// SMB delayed-write timestamp semantics
+//
+// Windows / Samba surface LastWriteTime to clients with a 2-second delay:
+// the first WRITE on a handle leaves the visible Mtime at its pre-write
+// value for two seconds, then advances it to the first-write timestamp
+// and pins it there for the rest of the open. Subsequent writes do not
+// re-arm the timer, so QUERY_INFO keeps returning that same value until
+// a flush trigger (SMB FLUSH, SET_INFO BasicInfo, SET_INFO EndOfFile) or
+// CLOSE. An explicit SetBasic write_time makes the value sticky until
+// the handle is closed.
+//
+// DittoFS's metadata layer bumps file.Mtime synchronously on every write
+// (NFS semantics). We layer the SMB-only delay on top via per-OpenFile
+// state so NFS callers still see immediate updates while SMB QUERY_INFO
+// presents the Samba-style view that smb2.timestamps.* asserts.
+//
+// References:
+//   - source3/smbd/fileio.c::trigger_write_time_update
+//   - source4/torture/smb2/timestamps.c (delayed-*, freeze-thaw)
+
+// smbDelayedWriteWindow is Samba's WRITE_TIME_UPDATE_USEC_DELAY (2 s).
+const smbDelayedWriteWindow = 2 * time.Second
+
+// armSmbDelayedWrite records that a WRITE happened and arms the 2-second
+// visibility window on the first call. Subsequent calls are no-ops.
+func armSmbDelayedWrite(openFile *OpenFile, preMtime time.Time, writeTime time.Time) {
+	if openFile == nil {
+		return
+	}
+	if openFile.SmbStickyWriteTime != nil {
+		return
+	}
+	if openFile.SmbWriteTriggered {
+		return
+	}
+	openFile.SmbWriteTriggered = true
+	pre := preMtime
+	flush := writeTime
+	openFile.SmbWritePreMtime = &pre
+	openFile.SmbWriteFlushMtime = &flush
+	openFile.SmbWriteFlushAt = time.Now().Add(smbDelayedWriteWindow)
+}
+
+// flushSmbDelayedWrite collapses the visibility window so the next
+// QUERY_INFO surfaces the post-write Mtime. Called from FLUSH, SET_INFO
+// BasicInfo (any flavour) and SET_INFO EndOfFile per Samba's
+// trigger_write_time_update_immediate.
+func flushSmbDelayedWrite(openFile *OpenFile) {
+	if openFile == nil || !openFile.SmbWriteTriggered {
+		return
+	}
+	openFile.SmbWriteFlushAt = time.Time{}
+}
+
+// setSmbStickyWriteTime records an explicit SetBasic write_time. While
+// sticky, QUERY_INFO returns the chosen value regardless of subsequent
+// writes on this handle.
+func setSmbStickyWriteTime(openFile *OpenFile, t time.Time) {
+	if openFile == nil {
+		return
+	}
+	v := t
+	openFile.SmbStickyWriteTime = &v
+}
+
+// applySmbDelayedWriteOverride overlays the SMB-visible LastWriteTime on
+// top of a freshly-read metadata.File for QUERY_INFO responses. Returns
+// the file unchanged when the handle has no delayed-write state.
+func applySmbDelayedWriteOverride(openFile *OpenFile, file *metadata.File) {
+	if openFile == nil || file == nil {
+		return
+	}
+	if openFile.SmbStickyWriteTime != nil {
+		file.Mtime = *openFile.SmbStickyWriteTime
+		return
+	}
+	if !openFile.SmbWriteTriggered {
+		return
+	}
+	if !openFile.SmbWriteFlushAt.IsZero() && time.Now().Before(openFile.SmbWriteFlushAt) {
+		if openFile.SmbWritePreMtime != nil {
+			file.Mtime = *openFile.SmbWritePreMtime
+		}
+		return
+	}
+	if openFile.SmbWriteFlushMtime != nil {
+		file.Mtime = *openFile.SmbWriteFlushMtime
+	}
+}

--- a/internal/adapter/smb/v2/handlers/timestamps_delayed_test.go
+++ b/internal/adapter/smb/v2/handlers/timestamps_delayed_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Drives the helpers directly because the SMB WRITE handler depends on
+// session/tree/blockstore plumbing that is heavyweight to fake. The
+// helpers encode the entire delayed-write state machine, so covering
+// them gives the same protection as a full handler test would.
+
+func mustGet(t *testing.T, h *Handler, fh metadata.FileHandle, authCtx *metadata.AuthContext) *metadata.File {
+	t.Helper()
+	file, err := h.Registry.GetMetadataService().GetFile(authCtx.Context, fh)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	return file
+}
+
+func TestSmbDelayedWrite_VisibleMtimeUntilWindowExpires(t *testing.T) {
+	h, authCtx, fh, openFile := setupTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	preWriteMtime := mustGet(t, h, fh, authCtx).Mtime
+
+	// Simulate a WRITE: PrepareWrite -> CommitWrite -> arm window.
+	op, err := metaSvc.PrepareWrite(authCtx, fh, 1)
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, op); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fh); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	armSmbDelayedWrite(openFile, preWriteMtime, op.NewMtime)
+
+	// Inside the window: QUERY_INFO surfaces the pre-write Mtime.
+	file := mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(preWriteMtime) {
+		t.Fatalf("inside window: got %v want %v", file.Mtime, preWriteMtime)
+	}
+
+	// Force the window past expiry without sleeping 2 seconds.
+	openFile.SmbWriteFlushAt = time.Now().Add(-time.Second)
+	file = mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(op.NewMtime) {
+		t.Errorf("after window: got %v want %v", file.Mtime, op.NewMtime)
+	}
+}
+
+func TestSmbDelayedWrite_SecondWriteDoesNotAdvanceVisibleMtime(t *testing.T) {
+	h, authCtx, fh, openFile := setupTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	pre := mustGet(t, h, fh, authCtx).Mtime
+
+	op1, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
+	_, _ = metaSvc.CommitWrite(authCtx, op1)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	armSmbDelayedWrite(openFile, pre, op1.NewMtime)
+	openFile.SmbWriteFlushAt = time.Now().Add(-time.Second) // simulate post-window
+
+	time.Sleep(20 * time.Millisecond)
+	op2, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
+	_, _ = metaSvc.CommitWrite(authCtx, op2)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	armSmbDelayedWrite(openFile, mustGet(t, h, fh, authCtx).Mtime, op2.NewMtime)
+
+	file := mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(op1.NewMtime) {
+		t.Errorf("second write must not advance visible mtime: got %v want %v",
+			file.Mtime, op1.NewMtime)
+	}
+}
+
+func TestSmbDelayedWrite_FlushCollapsesWindow(t *testing.T) {
+	h, authCtx, fh, openFile := setupTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	pre := mustGet(t, h, fh, authCtx).Mtime
+	op, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
+	_, _ = metaSvc.CommitWrite(authCtx, op)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	armSmbDelayedWrite(openFile, pre, op.NewMtime)
+
+	// Without flush, override returns pre.
+	file := mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(pre) {
+		t.Fatalf("before flush: got %v want %v", file.Mtime, pre)
+	}
+
+	flushSmbDelayedWrite(openFile)
+
+	file = mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(op.NewMtime) {
+		t.Errorf("after flush: got %v want %v", file.Mtime, op.NewMtime)
+	}
+}
+
+func TestSmbDelayedWrite_StickyWinsOverDelayedWindow(t *testing.T) {
+	h, authCtx, fh, openFile := setupTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	pre := mustGet(t, h, fh, authCtx).Mtime
+	op, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
+	_, _ = metaSvc.CommitWrite(authCtx, op)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	armSmbDelayedWrite(openFile, pre, op.NewMtime)
+
+	future := time.Now().Add(24 * time.Hour).UTC()
+	setSmbStickyWriteTime(openFile, future)
+
+	file := mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(future) {
+		t.Errorf("sticky must win: got %v want %v", file.Mtime, future)
+	}
+}
+
+func TestSmbDelayedWrite_NoOpWhenNothingTriggered(t *testing.T) {
+	h, authCtx, fh, openFile := setupTimestampTest(t)
+	original := mustGet(t, h, fh, authCtx).Mtime
+
+	file := mustGet(t, h, fh, authCtx)
+	applySmbDelayedWriteOverride(openFile, file)
+	if !file.Mtime.Equal(original) {
+		t.Errorf("override mutated mtime with no state: got %v want %v",
+			file.Mtime, original)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -343,6 +343,17 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Step 9: Prepare write operation
 	// ========================================================================
 
+	// Snapshot the pre-write Mtime so the SMB delayed-write window can
+	// keep returning that value via QUERY_INFO until the 2-second timer
+	// expires (Samba: trigger_write_time_update). Best-effort — only the
+	// first WRITE on the open consumes the snapshot.
+	var preWriteMtime time.Time
+	if !openFile.SmbWriteTriggered && openFile.SmbStickyWriteTime == nil {
+		if preFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil {
+			preWriteMtime = preFile.Mtime
+		}
+	}
+
 	newSize := req.Offset + uint64(len(req.Data))
 	writeOp, err := metaSvc.PrepareWrite(authCtx, openFile.MetadataHandle, newSize)
 	if err != nil {
@@ -384,6 +395,11 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Per MS-FSA 2.1.5.14.2: If timestamps are frozen via SET_INFO with -1,
 	// CommitWrite unconditionally updated Mtime/Ctime. Restore frozen values.
 	h.restoreFrozenTimestamps(authCtx, openFile)
+
+	// Arm the SMB delayed-write window so QUERY_INFO masks the just-bumped
+	// Mtime until the 2-second timer expires (Samba parity).
+	armSmbDelayedWrite(openFile, preWriteMtime, writeOp.NewMtime)
+	h.StoreOpenFile(openFile)
 
 	// Detect ADS writes once for timestamp propagation and change notification.
 	isADSWrite := false


### PR DESCRIPTION
## Summary

Implements Samba's 2-second delayed write-time window + sticky
LastWriteTime so QUERY_INFO no longer leaks the post-write Mtime
immediately. Targets the 5 `smb2.timestamps.*` tests tracked by #434:
`delayed-2write`, `delayed-write-vs-flush`, `delayed-write-vs-seteof`,
`delayed-write-vs-setbasic`, plus the previously-passing
`freeze-thaw` (unchanged behaviour, regression check).

The metadata layer still bumps `file.Mtime` synchronously to keep NFS
semantics intact. The delay lives entirely in the SMB handler as an
overlay on top of `GetFile()` results, applied only on QUERY_INFO.
CLOSE keeps returning `file.Mtime` so a second handle's explicit
SetBasic write_time surfaces in the first handle's CLOSE
FULL_INFORMATION response, which `delayed-write-vs-seteof` asserts.

### Mechanism (mirrors `source3/smbd/fileio.c`)

- WRITE arms a 2-second visibility window the first time it runs on an
  open handle; subsequent writes do not re-arm.
- QUERY_INFO overlay returns:
  - the explicit sticky write_time if SetBasic set one, else
  - the pre-write Mtime while inside the window, else
  - the first-write Mtime (frozen for the life of the open).
- FLUSH / SET_INFO BasicInfo / SET_INFO EndOfFile collapse the window
  (Samba `trigger_write_time_update_immediate`). SetBasic with an
  explicit non-sentinel write_time additionally sets sticky.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/metadata/... ./internal/adapter/smb/...`
- [x] `go test -race ./pkg/metadata/... ./internal/adapter/smb/v2/handlers/...`
- [x] New unit tests cover: visibility-during-window, second-write-no-advance,
  flush-collapses-window, sticky-wins, no-op-when-untriggered.
- [ ] CI smbtorture: 5 `smb2.timestamps.*` tests flip; no regressions.
  `KNOWN_FAILURES.md` walkback in a follow-up commit after CI confirms.

Closes #434