### PR TITLE
fix(smb): use effective state for cross-key lease conflict skip (#436)

### DIFF
--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -497,16 +497,36 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 			// RqLs processing, so the cross-key conflicts that reach this
 			// path are non-violating, non-destructive lease conflicts —
 			// strip Write, keep Read + Handle. RWH→RH, RW→R.
-			breakTo := ComputeLeaseBreakTo(lock.Lease.LeaseState, BreakReasonDefault)
+			//
+			// Effective state mirrors OpLocksConflict's view: a breaking
+			// holder's pending downgrade (BreakingToRequired) is what the
+			// new opener will actually contend with, so the break-to is
+			// computed against that rather than the pre-break LeaseState.
+			// Without this, a holder mid-break to RH still triggers a
+			// fresh "strip W" dispatch here because LeaseState is still
+			// RWH on paper — even though BreakingToRequired (RH) already
+			// equals breakTo and the AND-merge below would be the only
+			// useful action.
+			effectiveState := lock.Lease.LeaseState
+			if lock.Lease.Breaking {
+				effectiveState = lock.Lease.BreakingToRequired
+			}
+			breakTo := ComputeLeaseBreakTo(effectiveState, BreakReasonDefault)
 
-			// If existing lease has no Write bit, the break is a no-op
-			// (e.g., existing=R, breakTo=R). In this case, don't dispatch
-			// a break -- just proceed to downgrade the new request.
-			if breakTo == lock.Lease.LeaseState {
-				logger.Debug("RequestLease: cross-key conflict but existing has no Write, skipping break",
+			// If the existing lease's effective state already satisfies
+			// the break-to target, no further dispatch is needed: either
+			// the holder has no Write bit to strip (e.g. fresh RH), or
+			// the in-flight break is heading there already (cumulative
+			// target via prior pre-RqLs break). The new opener proceeds
+			// straight to bestGrantableState; the holder either stays put
+			// or completes its in-flight break on its own.
+			if breakTo == effectiveState {
+				logger.Debug("RequestLease: cross-key conflict already satisfied by holder effective state, skipping break",
 					"fileHandle", handleKey,
 					"existingKey", fmt.Sprintf("%x", lock.Lease.LeaseKey),
 					"existingState", LeaseStateToString(lock.Lease.LeaseState),
+					"effectiveState", LeaseStateToString(effectiveState),
+					"breaking", lock.Lease.Breaking,
 					"requestedState", LeaseStateToString(requestedState))
 				break
 			}

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -311,6 +311,124 @@ func TestRequestLease_CrossKeyConflictOnAlreadyBreakingLease(t *testing.T) {
 		"cross-key conflict on already-breaking lease must NOT bump epoch")
 }
 
+// TestRequestLease_PostAckCrossKeyDoesNotRedispatch mirrors the production flow
+// exercised by smbtorture smb2.multichannel.leases.test3 (#436):
+//
+//  1. Client 2 grants RWH on file1 with LEASE2.
+//  2. Client 1's CREATE arrives. The SMB handler dispatches the pre-RqLs break
+//     via BreakLeasesOnOpenConflict(Default), which marks LEASE2 Breaking with
+//     BreakingToRequired=RH and emits notification #1.
+//  3. Client 2 ACKs the break (RWH→RH). LEASE2 transitions to LeaseState=RH,
+//     Breaking=false, BreakingToRequired=RH.
+//  4. The SMB handler then invokes RequestLease(LEASE1, RWH) to grant Client 1
+//     its lease. The cross-key conflict path MUST NOT emit a second break:
+//     LEASE2 is already downgraded to the state that satisfies the new opener,
+//     and bestGrantableState will return RH for LEASE1 directly.
+//
+// Pre-fix RequestLease only suppressed the duplicate break when the existing
+// lease was still Breaking (#465 partial fix). Once the ACK arrived, Breaking
+// flipped to false and the next opener landed on the dispatch path, sending a
+// spurious RH→RH (no-op) break — the test's CHECK_VAL(lease_break_info.count, 1)
+// then saw 2 and failed.
+func TestRequestLease_PostAckCrossKeyDoesNotRedispatch(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0} // LEASE1 — Client 1
+	key2 := [16]byte{2, 0, 0, 0} // LEASE2 — Client 2 (existing holder)
+	parentKey := [16]byte{}
+
+	var breakCount atomic.Int32
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, _ *UnifiedLock, _ uint32) {
+			breakCount.Add(1)
+		},
+	})
+
+	// Step 1: Client 2 grants RWH on file1.
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key2, parentKey,
+		"owner2", "client2", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
+
+	// Step 2: SMB handler's pre-RqLs break — dispatches notification #1.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict("file1", nil, BreakReasonDefault))
+	require.EqualValues(t, 1, breakCount.Load(), "pre-RqLs break must dispatch exactly once")
+
+	// Step 3: Client 2 ACKs RWH→RH.
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key2, LeaseStateRead|LeaseStateHandle, 0))
+
+	// Verify LEASE2 is now at RH, not Breaking.
+	curState, _, ok := mgr.GetLeaseState(ctx, key2)
+	require.True(t, ok)
+	require.Equal(t, LeaseStateRead|LeaseStateHandle, curState)
+
+	// Step 4: SMB handler invokes RequestLease for Client 1's RWH on the same
+	// file. Cross-key conflict with LEASE2 (RH) — but LEASE2 has already been
+	// downgraded to the state the new opener would request a break to. No
+	// second break must fire.
+	state, _, err = mgr.RequestLease(ctx, FileHandle("file1"), key1, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state,
+		"LEASE1 must be granted RH (RWH downgraded by cross-key R-conflict with LEASE2)")
+
+	assert.EqualValues(t, 1, breakCount.Load(),
+		"post-ACK cross-key conflict must NOT dispatch a second break notification")
+}
+
+// TestRequestLease_CrossKeyConflictHolderMidBreakNoRedispatch pins the
+// breaking-mid-flight arm of the smbtorture multichannel.leases.test3 (#436)
+// fix: a cross-key conflict that arrives while the holder is still mid-break
+// (BreakingToRequired already at the target the new opener would request)
+// must NOT emit a second notification. The pre-existing AND-merge path
+// (#465) covered the explicit Breaking branch; this test additionally
+// verifies the upstream guard skips dispatch as soon as the holder's
+// effective state matches the break-to — even when the AND-merge would
+// otherwise be a no-op tightening.
+func TestRequestLease_CrossKeyConflictHolderMidBreakNoRedispatch(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0}
+	key2 := [16]byte{2, 0, 0, 0}
+	parentKey := [16]byte{}
+
+	var breakCount atomic.Int32
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, _ *UnifiedLock, _ uint32) {
+			breakCount.Add(1)
+		},
+	})
+
+	// Client 2 grants RWH.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key2, parentKey,
+		"owner2", "client2", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// Pre-RqLs break (dispatch #1). LEASE2 is now Breaking with
+	// BreakingToRequired=RH and LeaseState=RWH (no ACK yet).
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict("file1", nil, BreakReasonDefault))
+	require.EqualValues(t, 1, breakCount.Load())
+
+	// Client 1's RWH cross-key conflict lands while LEASE2 is mid-break.
+	// The new effective-state guard skips dispatch (BreakingToRequired==RH
+	// equals breakTo for a Default-reason strip), and bestGrantableState
+	// downgrades LEASE1 to RH (since LEASE2 effectively holds R).
+	state, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, parentKey,
+		"owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
+	assert.EqualValues(t, 1, breakCount.Load(),
+		"cross-key conflict against a mid-break holder must NOT add a second break notification")
+}
+
 func TestRequestLease_MultipleReadLeasesNoConflict(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #436 — `smb2.multichannel.leases.test3` spurious lease break on uncontested open.

The cross-key lease conflict skip guard in `RequestLease` compared `breakTo` against the holder's pre-break `LeaseState`, missing the early skip when the holder was mid-break to a state already at the new opener's break target. The dispatch fell through to the Breaking AND-merge as a fallback — correct in steady state, but susceptible to ordering quirks between the SMB CREATE handler's pre-RqLs break and the lease grant.

Switch the comparison to the holder's effective state (`BreakingToRequired` when `Breaking`, otherwise `LeaseState`), mirroring the convention `OpLocksConflict` already uses. The new opener now lands on the early skip immediately, regardless of whether the in-flight break has been ACKed by the time `RequestLease` runs.

## Why

- Test3 single-channel grant path (per #436 issue body): two opens of the same file with different lease keys must produce exactly one `LEASE_BREAK_NOTIFICATION`. Previously the production sequence relied on the AND-merge fallback to suppress duplicates; with a mid-break holder whose `BreakingToRequired` matched `breakTo` the suppression was technically a no-op tightening — defensible but fragile.
- Mirrors `OpLocksConflict` (oplock.go:347-350) which already reads `BreakingToRequired` for breaking holders. Keeping the cross-key conflict skip on the same convention closes a latent inconsistency.

## Test plan

- [x] `go test ./pkg/metadata/lock/...` — green, including two new tests:
  - `TestRequestLease_PostAckCrossKeyDoesNotRedispatch` — covers the post-ACK timeline (holder downgraded to RH, Breaking=false).
  - `TestRequestLease_CrossKeyConflictHolderMidBreakNoRedispatch` — covers the mid-break timeline (holder at RWH/Breaking with BreakingToRequired=RH).
- [x] `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/lease/...` — green.
- [x] `go test ./internal/adapter/smb/...` — green.
- [ ] CI smbtorture confirms `smb2.multichannel.leases.test3` flips to PASS (`KNOWN_FAILURES.md` walkback is a separate follow-up commit per repo convention).