### PR TITLE
fix(smb/notify): cleanup, sticky overflow, change-notify-disabled

### DIFF
--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -26,6 +26,7 @@ var (
 	createQuotaBytes        string
 	createAclCanonicalize   bool
 	createAccessBasedEnum   bool
+	createChangeNotifyOff   bool
 )
 
 var createCmd = &cobra.Command{
@@ -82,6 +83,7 @@ func init() {
 	createCmd.Flags().StringVar(&createQuotaBytes, "quota-bytes", "", "Per-share byte quota (e.g., '10GiB', '500MiB'). 0 = unlimited (default)")
 	createCmd.Flags().BoolVar(&createAclCanonicalize, "acl-canonicalize-inherited", true, "When false, preserves the SE_DACL_AUTO_INHERITED control bit verbatim on SET_INFO Security instead of applying MS-DTYP §2.5.3.4.2 canonicalization (Samba \"acl flag inherited canonicalization = no\"). Default true matches Windows.")
 	createCmd.Flags().BoolVar(&createAccessBasedEnum, "access-based-enumeration", false, "Enable Windows access-based enumeration (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM). When true, SMB clients only see directory entries they can read.")
+	createCmd.Flags().BoolVar(&createChangeNotifyOff, "change-notify-disabled", false, "Reject SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED on this share (mirrors Samba 'kernel change notify = no').")
 	_ = createCmd.MarkFlagRequired("local")
 }
 
@@ -172,6 +174,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("access-based-enumeration") {
 		v := createAccessBasedEnum
 		req.AccessBasedEnumeration = &v
+	}
+	if cmd.Flags().Changed("change-notify-disabled") {
+		v := createChangeNotifyOff
+		req.ChangeNotifyDisabled = &v
 	}
 
 	share, err := client.CreateShare(req)

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -124,6 +124,11 @@ const (
 	// StatusNotSupported indicates the operation is not supported.
 	StatusNotSupported Status = 0xC00000BB
 
+	// StatusNotImplemented signals the requested command is not implemented
+	// by the server [MS-ERREF]. Used by the SMB2 CHANGE_NOTIFY path when
+	// the target share has change notify administratively disabled.
+	StatusNotImplemented Status = 0xC0000002
+
 	// StatusNetworkNameDeleted indicates the share was deleted.
 	StatusNetworkNameDeleted Status = 0xC00000C9
 
@@ -241,6 +246,8 @@ func (s Status) String() string {
 		return "STATUS_INVALID_HANDLE"
 	case StatusNotSupported:
 		return "STATUS_NOT_SUPPORTED"
+	case StatusNotImplemented:
+		return "STATUS_NOT_IMPLEMENTED"
 	case StatusDirectoryNotEmpty:
 		return "STATUS_DIRECTORY_NOT_EMPTY"
 	case StatusNotADirectory:

--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -130,6 +130,13 @@ type FileNotifyInformation struct {
 // Returns an error if the response could not be sent (e.g., connection closed).
 type AsyncResponseCallback func(sessionID, messageID, asyncId uint64, response *ChangeNotifyResponse) error
 
+// OnOverflow is an optional hook fired when sendAndUnregister returns
+// STATUS_NOTIFY_ENUM_DIR. The directory handle's overflow flag must be set
+// so the next CHANGE_NOTIFY on the same handle also returns ENUM_DIR
+// (smb2.notify.valid-req: "if the first notify returns NOTIFY_ENUM_DIR,
+// all do"). Wired by the registering handler; nil for unit tests.
+type OnOverflow func(fileID [16]byte)
+
 // PendingNotify tracks a pending CHANGE_NOTIFY request waiting for filesystem events.
 // Each instance represents one client watch registered via the CHANGE_NOTIFY command.
 // It stores the watch path, completion filter, and the async callback for delivering
@@ -160,6 +167,11 @@ type PendingNotify struct {
 	// If nil, the change is logged but no response is sent.
 	// The callback is responsible for sending the async SMB2 response.
 	AsyncCallback AsyncResponseCallback
+
+	// OnOverflow is fired when sendAndUnregister returns
+	// STATUS_NOTIFY_ENUM_DIR so the open handle's sticky overflow flag can
+	// be set. Optional.
+	OnOverflow OnOverflow
 }
 
 // NotifyRegistry manages pending CHANGE_NOTIFY requests from SMB2 clients.
@@ -633,6 +645,11 @@ func (r *NotifyRegistry) sendAndUnregister(w *PendingNotify, changes []FileNotif
 			"encodedLength", len(buffer),
 			"maxOutputLength", removed.MaxOutputLength,
 			"messageID", removed.MessageID)
+		// Mark the handle as overflowed so the next CHANGE_NOTIFY on it
+		// also returns ENUM_DIR per Samba notify_buffer semantics.
+		if removed.OnOverflow != nil {
+			removed.OnOverflow(removed.FileID)
+		}
 		enumResp := &ChangeNotifyResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
 		}

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1201,6 +1201,83 @@ func TestUnregisterAllForSession_PreservesOtherSessions(t *testing.T) {
 	}
 }
 
+// TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer covers the
+// smb2.notify.valid-req "sticky" overflow contract: when the encoded
+// change list exceeds MaxOutputLength we must (a) return STATUS_NOTIFY_ENUM_DIR
+// to the client and (b) invoke OnOverflow so the directory handle's overflow
+// flag survives across notifies and the next notify also returns ENUM_DIR.
+func TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	var overflowFiredFor [16]byte
+	var deliveredStatus types.Status
+	fileID := [16]byte{0xAA}
+
+	mustRegister(t, r, &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  0, // any encoded notification exceeds this
+		AsyncCallback: func(_, _, _ uint64, response *ChangeNotifyResponse) error {
+			deliveredStatus = response.GetStatus()
+			return nil
+		},
+		OnOverflow: func(id [16]byte) { overflowFiredFor = id },
+	})
+
+	r.NotifyChange("share1", "/dir", "file.txt", FileActionAdded)
+
+	if deliveredStatus != types.StatusNotifyEnumDir {
+		t.Errorf("expected STATUS_NOTIFY_ENUM_DIR, got 0x%08X", uint32(deliveredStatus))
+	}
+	if overflowFiredFor != fileID {
+		t.Errorf("expected OnOverflow to fire with fileID %v, got %v", fileID, overflowFiredFor)
+	}
+}
+
+// TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback verifies
+// that watchers removed by UnregisterAllForSession retain their AsyncCallback
+// so the caller can fire STATUS_NOTIFY_CLEANUP per MS-SMB2 3.3.5.5.2
+// (smb2.notify.invalid-reauth / session-reconnect / .tcon / .dir).
+func TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	var calledWithStatus types.Status
+	mustRegister(t, r, &PendingNotify{
+		FileID:           [16]byte{1},
+		SessionID:        100,
+		MessageID:        10,
+		AsyncId:          1000,
+		WatchPath:        "/dir1",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		AsyncCallback: func(_, _, _ uint64, response *ChangeNotifyResponse) error {
+			calledWithStatus = response.GetStatus()
+			return nil
+		},
+	})
+
+	removed := r.UnregisterAllForSession(100)
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removed, got %d", len(removed))
+	}
+
+	// Caller invokes the callback to deliver STATUS_NOTIFY_CLEANUP.
+	resp := &ChangeNotifyResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyCleanup},
+	}
+	if err := removed[0].AsyncCallback(removed[0].SessionID, removed[0].MessageID, removed[0].AsyncId, resp); err != nil {
+		t.Fatalf("AsyncCallback returned error: %v", err)
+	}
+	if calledWithStatus != types.StatusNotifyCleanup {
+		t.Errorf("expected callback to receive STATUS_NOTIFY_CLEANUP, got 0x%08X", uint32(calledWithStatus))
+	}
+}
+
 func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	r := NewNotifyRegistry()
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -250,6 +250,11 @@ type TreeConnection struct {
 	// QUERY_DIRECTORY filters entries the caller cannot read (refs #532,
 	// MS-SMB2 §2.2.10 SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM).
 	AccessBasedEnumeration bool
+	// ChangeNotifyDisabled mirrors the share-level toggle. When true,
+	// CHANGE_NOTIFY requests on this tree are rejected with
+	// STATUS_NOT_IMPLEMENTED — matches Samba `kernel change notify = no`
+	// and the smb2.change_notify_disabled torture test.
+	ChangeNotifyDisabled bool
 }
 
 // OpenFile represents an open file handle created by the CREATE command.
@@ -348,6 +353,18 @@ type OpenFile struct {
 	// DurableTimeoutMs is the granted durable handle timeout in milliseconds.
 	// The handle expires this many milliseconds after client disconnects.
 	DurableTimeoutMs uint32
+
+	// NotifyOverflowed is the sticky overflow flag for SMB2 CHANGE_NOTIFY on
+	// this directory handle. Set when a notify completes with
+	// STATUS_NOTIFY_ENUM_DIR because the encoded change list exceeds the
+	// requested OutputBufferLength. The next CHANGE_NOTIFY on this handle
+	// MUST also return STATUS_NOTIFY_ENUM_DIR regardless of the new buffer
+	// size — once events are lost the directory state is considered
+	// inconsistent and the client must re-enumerate (Samba notify_buffer
+	// is_overflow semantics; smb2.notify.valid-req "if the first notify
+	// returns NOTIFY_ENUM_DIR, all do"). Cleared after that next notify
+	// consumes it. Lifetime is the handle: closing/reopening resets it.
+	NotifyOverflowed atomic.Bool
 }
 
 // OpenID returns a unique identifier for this open file handle.
@@ -627,8 +644,23 @@ func (h *Handler) closeFilesWithFilter(
 		// stale watchers persist in the NotifyRegistry after connection
 		// cleanup and can fire during subsequent tests, sending async
 		// responses on dead connections with partially-destroyed sessions.
+		// Per MS-SMB2 3.3.4.1: when the watched handle goes away the
+		// pending request MUST complete with STATUS_NOTIFY_CLEANUP so the
+		// client's async recv unblocks (smb2.notify.tcon, .dir).
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.Unregister(fileID)
+			if notify := h.NotifyRegistry.Unregister(fileID); notify != nil && notify.AsyncCallback != nil {
+				go func(n *PendingNotify) {
+					cleanupResp := &ChangeNotifyResponse{
+						SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyCleanup},
+					}
+					if err := n.AsyncCallback(n.SessionID, n.MessageID, n.AsyncId, cleanupResp); err != nil {
+						logger.Debug("closeFilesWithFilter: failed to send STATUS_NOTIFY_CLEANUP",
+							"sessionID", n.SessionID,
+							"messageID", n.MessageID,
+							"error", err)
+					}
+				}(notify)
+			}
 		}
 		h.DeleteOpenFile(fileID)
 	}
@@ -782,7 +814,27 @@ func (h *Handler) releaseSessionLeasesAndNotifies(ctx context.Context, sessionID
 		}
 	}
 	if h.NotifyRegistry != nil {
-		h.NotifyRegistry.UnregisterAllForSession(sessionID)
+		// Per MS-SMB2 3.3.5.5.2 / 3.3.5.5.3: when a session is destroyed
+		// (LOGOFF, transport drop, re-auth failure, or PreviousSessionID
+		// supersession), pending CHANGE_NOTIFY requests MUST complete with
+		// STATUS_NOTIFY_CLEANUP so the client unblocks its async recv.
+		// Mirrors the per-file path in close.go.
+		for _, notify := range h.NotifyRegistry.UnregisterAllForSession(sessionID) {
+			if notify.AsyncCallback == nil {
+				continue
+			}
+			go func(n *PendingNotify) {
+				cleanupResp := &ChangeNotifyResponse{
+					SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyCleanup},
+				}
+				if err := n.AsyncCallback(n.SessionID, n.MessageID, n.AsyncId, cleanupResp); err != nil {
+					logger.Debug("session cleanup: failed to send STATUS_NOTIFY_CLEANUP",
+						"sessionID", n.SessionID,
+						"messageID", n.MessageID,
+						"error", err)
+				}
+			}(notify)
+		}
 	}
 	if h.PipeReadRegistry != nil {
 		for _, pending := range h.PipeReadRegistry.UnregisterAllForSession(sessionID) {

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -348,6 +348,15 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
+	// Shares with change notify disabled reject every request with
+	// STATUS_NOT_IMPLEMENTED, matching Samba `kernel change notify = no`
+	// and smb2.change_notify_disabled.
+	if tree, ok := h.GetTree(ctx.TreeID); ok && tree.ChangeNotifyDisabled {
+		logger.Debug("CHANGE_NOTIFY: rejected — share has change notify disabled",
+			"shareName", tree.ShareName)
+		return NewErrorResult(types.StatusNotImplemented), nil
+	}
+
 	// Get the open file (must be a directory)
 	openFile, ok := h.GetOpenFile(req.FileID)
 	if !ok {
@@ -409,6 +418,22 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusNotSupported), nil
 	}
 
+	// Sticky overflow: a previous CHANGE_NOTIFY on this handle exceeded its
+	// buffer and completed with STATUS_NOTIFY_ENUM_DIR. Per Samba
+	// notify_buffer semantics and smb2.notify.valid-req, the next notify on
+	// the handle MUST also return ENUM_DIR (events were dropped, directory
+	// state is now inconsistent). Consume the flag and reply sync — the
+	// client's recv loop accepts either sync or async completion.
+	if openFile.NotifyOverflowed.CompareAndSwap(true, false) {
+		respBytes, err := (&ChangeNotifyResponse{
+			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
+		}).Encode()
+		if err != nil {
+			return NewErrorResult(types.StatusInternalError), nil
+		}
+		return NewResult(types.StatusNotifyEnumDir, respBytes), nil
+	}
+
 	// Generate a unique AsyncId for this pending request.
 	// Per MS-SMB2 3.3.5.15, the server assigns an AsyncId and sends an
 	// interim response with STATUS_PENDING. The same AsyncId is used in
@@ -427,6 +452,11 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		WatchTree:        req.Flags&SMB2WatchTree != 0,
 		MaxOutputLength:  req.OutputBufferLength,
 		AsyncCallback:    ctx.AsyncNotifyCallback,
+		OnOverflow: func(fileID [16]byte) {
+			if of, ok := h.GetOpenFile(fileID); ok {
+				of.NotifyOverflowed.Store(true)
+			}
+		},
 	}
 
 	// Per MS-SMB2 §3.3.5.2.5: enforce max_async_credits before going async.

--- a/internal/adapter/smb/v2/handlers/tree_connect.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect.go
@@ -160,6 +160,7 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		Permission:             permission,
 		EncryptData:            share.EncryptData,
 		AccessBasedEnumeration: share.AccessBasedEnumeration,
+		ChangeNotifyDisabled:   share.ChangeNotifyDisabled,
 	}
 	h.StoreTree(tree)
 

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -84,6 +84,9 @@ type CreateShareRequest struct {
 	// keeps the server default (false); a non-nil pointer is an explicit
 	// set.
 	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// ChangeNotifyDisabled — pointer so nil keeps default false (change
+	// notify enabled).
+	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
 }
 
 // UpdateShareRequest is the request body for PUT /api/v1/shares/{name}.
@@ -108,6 +111,9 @@ type UpdateShareRequest struct {
 	// AccessBasedEnumeration — Refs #532. nil = no change; non-nil = explicit
 	// set. Persisted on UpdateShare; takes effect on adapter restart.
 	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// ChangeNotifyDisabled — nil = no change; non-nil = explicit set.
+	// Persisted on UpdateShare; takes effect on adapter restart.
+	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
 }
 
 // ShareResponse is the response body for share endpoints.
@@ -139,9 +145,12 @@ type ShareResponse struct {
 	AclFlagInheritedCanonicalization bool `json:"acl_flag_inherited_canonicalization"`
 	// AccessBasedEnumeration mirrors models.Share — Refs #532. No omitempty
 	// for the same reason: operators need to render the explicit state.
-	AccessBasedEnumeration bool      `json:"access_based_enumeration"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	AccessBasedEnumeration bool `json:"access_based_enumeration"`
+	// ChangeNotifyDisabled mirrors models.Share. No omitempty for the same
+	// reason.
+	ChangeNotifyDisabled bool      `json:"change_notify_disabled"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
 
 	// Status is the worst-of health report derived from the share's
 	// metadata store and block store engine. Non-omitempty so
@@ -285,6 +294,13 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		abe = *req.AccessBasedEnumeration
 	}
 
+	// Change notify defaults enabled (false = enabled, mirrors Samba's
+	// `kernel change notify = yes` default).
+	cnDisabled := false
+	if req.ChangeNotifyDisabled != nil {
+		cnDisabled = *req.ChangeNotifyDisabled
+	}
+
 	now := time.Now()
 	share := &models.Share{
 		ID:                               uuid.New().String(),
@@ -303,6 +319,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Enabled:                          true, // REST-02: new shares are enabled by default.
 		AclFlagInheritedCanonicalization: aclCanon,
 		AccessBasedEnumeration:           abe,
+		ChangeNotifyDisabled:             cnDisabled,
 		CreatedAt:                        now,
 		UpdatedAt:                        now,
 	}
@@ -344,6 +361,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			EncryptData:                      req.EncryptData,
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
+			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			DefaultPermission:                defaultPerm,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),
@@ -474,6 +492,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.AccessBasedEnumeration != nil {
 		// Refs #532. Persisted to DB; takes effect on adapter restart.
 		share.AccessBasedEnumeration = *req.AccessBasedEnumeration
+	}
+	if req.ChangeNotifyDisabled != nil {
+		// Persisted to DB; takes effect on adapter restart.
+		share.ChangeNotifyDisabled = *req.ChangeNotifyDisabled
 	}
 	if req.DefaultPermission != nil {
 		share.DefaultPermission = *req.DefaultPermission
@@ -972,6 +994,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 		QuotaBytes:                       quotaBytesStr,
 		AclFlagInheritedCanonicalization: s.AclFlagInheritedCanonicalization,
 		AccessBasedEnumeration:           s.AccessBasedEnumeration,
+		ChangeNotifyDisabled:             s.ChangeNotifyDisabled,
 		CreatedAt:                        s.CreatedAt,
 		UpdatedAt:                        s.UpdatedAt,
 	}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -44,9 +44,12 @@ type Share struct {
 	AclFlagInheritedCanonicalization bool `json:"acl_flag_inherited_canonicalization"`
 	// AccessBasedEnumeration mirrors models.Share — Refs #532. No omitempty
 	// for the same reason.
-	AccessBasedEnumeration bool      `json:"access_based_enumeration"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	AccessBasedEnumeration bool `json:"access_based_enumeration"`
+	// ChangeNotifyDisabled mirrors models.Share. No omitempty: `false` is
+	// the operator-meaningful "change notify enabled" state.
+	ChangeNotifyDisabled bool      `json:"change_notify_disabled"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
 }
 
 // CreateShareRequest is the request to create a share.
@@ -71,6 +74,9 @@ type CreateShareRequest struct {
 	// AccessBasedEnumeration — Refs #532. Pointer so callers can distinguish
 	// "unset → server default (false)" from "explicit true".
 	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// ChangeNotifyDisabled — pointer so callers can distinguish "unset →
+	// server default (false)" from "explicit true".
+	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
 }
 
 // UpdateShareRequest is the request to update a share.
@@ -93,6 +99,9 @@ type UpdateShareRequest struct {
 	// AccessBasedEnumeration — Refs #532. nil = no change; non-nil =
 	// explicit set. Takes effect on adapter restart.
 	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// ChangeNotifyDisabled — nil = no change; non-nil = explicit set. Takes
+	// effect on adapter restart.
+	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
 }
 
 // SharePermission represents a permission on a share.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -38,17 +38,22 @@ type Share struct {
 	// ShareFlags (MS-SMB2 §2.2.10) and QUERY_DIRECTORY hides entries the
 	// caller cannot read. Default false matches the historical behaviour
 	// (refs #532, #549).
-	AccessBasedEnumeration bool      `gorm:"default:false;not null" json:"access_based_enumeration"`
-	DefaultPermission      string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
-	Config                 string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
-	BlockedOperations      string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
-	RetentionPolicy        string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
-	RetentionTTL           int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
-	LocalStoreSize         int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
-	ReadBufferSize         int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
-	QuotaBytes             int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
-	CreatedAt              time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt              time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	AccessBasedEnumeration bool `gorm:"default:false;not null" json:"access_based_enumeration"`
+	// ChangeNotifyDisabled rejects SMB2 CHANGE_NOTIFY on this share with
+	// STATUS_NOT_IMPLEMENTED. Mirrors Samba `kernel change notify = no` and
+	// the smb2.change_notify_disabled torture test. Default false leaves
+	// change notify enabled.
+	ChangeNotifyDisabled bool      `gorm:"default:false;not null" json:"change_notify_disabled"`
+	DefaultPermission    string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
+	Config               string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
+	BlockedOperations    string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
+	RetentionPolicy      string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
+	RetentionTTL         int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
+	LocalStoreSize       int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
+	ReadBufferSize       int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
+	QuotaBytes           int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
+	CreatedAt            time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt            time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 
 	// Relationships
 	MetadataStore    MetadataStoreConfig    `gorm:"foreignKey:MetadataStoreID" json:"metadata_store,omitempty"`

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -194,6 +194,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			EncryptData:                      share.EncryptData,
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
+			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			DefaultPermission:                share.DefaultPermission,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -63,6 +63,11 @@ type Share struct {
 	// #549).
 	AccessBasedEnumeration bool
 
+	// ChangeNotifyDisabled rejects SMB2 CHANGE_NOTIFY on this share with
+	// STATUS_NOT_IMPLEMENTED. Mirrors Samba `kernel change notify = no`
+	// and the smb2.change_notify_disabled torture test.
+	ChangeNotifyDisabled bool
+
 	// NFS-specific options
 	DisableReaddirplus bool
 
@@ -131,6 +136,10 @@ type ShareConfig struct {
 	// Windows access-based enumeration. See the runtime Share field for
 	// semantics (refs #532).
 	AccessBasedEnumeration bool
+
+	// ChangeNotifyDisabled mirrors models.Share's per-share toggle that
+	// rejects SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED.
+	ChangeNotifyDisabled bool
 
 	RootAttr *metadata.FileAttr
 
@@ -428,6 +437,7 @@ func (s *Service) prepareShare(
 		EncryptData:                      config.EncryptData,
 		AclFlagInheritedCanonicalization: config.AclFlagInheritedCanonicalization,
 		AccessBasedEnumeration:           config.AccessBasedEnumeration,
+		ChangeNotifyDisabled:             config.ChangeNotifyDisabled,
 		DefaultPermission:                config.DefaultPermission,
 		Squash:                           config.Squash,
 		AnonymousUID:                     config.AnonymousUID,

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -277,6 +277,15 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to backfill shares.access_based_enumeration: %w", err)
 	}
 
+	// Backfill shares.change_notify_disabled for rows that predate the
+	// column — same SQLite quirk as access_based_enumeration above.
+	if err := db.Exec(
+		"UPDATE shares SET change_notify_disabled = ? WHERE change_notify_disabled IS NULL",
+		false,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to backfill shares.change_notify_disabled: %w", err)
+	}
+
 	// --- Post-AutoMigrate migrations ---
 	// Step 2: Migrate legacy Share payload_store_id column to local/remote block store IDs.
 	postMigrator := db.Migrator()

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -88,6 +88,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"enabled":                             share.Enabled,
 		"acl_flag_inherited_canonicalization": share.AclFlagInheritedCanonicalization,
 		"access_based_enumeration":            share.AccessBasedEnumeration,
+		"change_notify_disabled":              share.ChangeNotifyDisabled,
 		"updated_at":                          share.UpdatedAt,
 	}
 	// Handle remote_block_store_id explicitly: GORM map-based Updates may skip

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -169,6 +169,11 @@ main() {
     # MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
     # QUERY_DIRECTORY hides entries the caller cannot read.
     $DFSCTL share create --name /hideunread --access-based-enumeration $share_flags
+    # /change_notify_disabled rejects SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED.
+    # Target of smb2.change_notify_disabled.notfiy_disabled which verifies the
+    # server signals "unsupported" rather than silently accepting notifies on a
+    # share where change notify is administratively disabled.
+    $DFSCTL share create --name /change_notify_disabled --change-notify-disabled $share_flags
     # /smbnoncanon disables MS-DTYP §2.5.3.4.2 canonicalization (Samba
     # `acl flag inherited canonicalization = no` extension). Target of
     # smb2.acls_non_canonical.flags; verifies AUTO_INHERITED round-trips
@@ -214,7 +219,7 @@ main() {
     # Wait for SMB adapter to start
     wait_for_smb localhost
 
-    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,smbnoncanon users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
+    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,change_notify_disabled,smbnoncanon users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
 }
 
 main "$@"

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -438,7 +438,7 @@ else
         "smb2.acls_non_canonical:acls_non_canonical:smbnoncanon"
         "smb2.aio_delay:aio_delay"
         "smb2.bench:bench"
-        "smb2.change_notify_disabled:change_notify_disabled"
+        "smb2.change_notify_disabled:change_notify_disabled:change_notify_disabled"
         "smb2.charset:charset"
         "smb2.compound:compound"
         "smb2.compound_async:compound_async"


### PR DESCRIPTION
## Summary

Three independent fixes against the SMB2 CHANGE_NOTIFY surface so the `smb2.notify.*` and `smb2.change_notify_disabled.*` smbtorture suites can advance. Refs #473.

### 1. Session/tree teardown fires STATUS_NOTIFY_CLEANUP

`closeFilesWithFilter` (the bulk close path used by LOGOFF, transport
disconnect, re-auth failure, and `PreviousSessionID` supersession) was
stripping pending CHANGE_NOTIFY watchers without firing their async
callback. `releaseSessionLeasesAndNotifies` had the same gap. Both now
deliver `STATUS_NOTIFY_CLEANUP` to every watcher per MS-SMB2 3.3.5.5.2 /
3.3.5.5.3, mirroring the per-file CLOSE handler. Targets:

- `smb2.notify.invalid-reauth` — reauth failure must unblock pending notify
- `smb2.notify.session-reconnect` — `PreviousSessionID` supersession must unblock
- `smb2.notify.tcon` / `smb2.notify.dir` — tree disconnect must unblock

### 2. Sticky overflow flag per handle

Added `OpenFile.NotifyOverflowed` (atomic.Bool). When `sendAndUnregister`
returns `STATUS_NOTIFY_ENUM_DIR` (encoded change list exceeds
`MaxOutputLength`), it now sets the flag via a new `OnOverflow` hook on
`PendingNotify`. The next `CHANGE_NOTIFY` on the same handle consumes the
flag and completes synchronously with ENUM_DIR — regardless of the new
`OutputBufferLength`. Mirrors Samba `notify_buffer` is_overflow semantics
and satisfies the `valid-req` assertion "if the first notify returns
NOTIFY_ENUM_DIR, all do". Target:

- `smb2.notify.valid-req`

### 3. Per-share change_notify_disabled toggle

New `Share.ChangeNotifyDisabled` field plumbed through:

- `pkg/controlplane/models/share.go` (gorm column + JSON)
- `pkg/controlplane/store/{shares,gorm}.go` (update map + backfill)
- `pkg/apiclient/shares.go` (Share / CreateShareRequest / UpdateShareRequest)
- `internal/controlplane/api/handlers/shares.go` (create + update + response)
- `pkg/controlplane/runtime/shares/service.go` and `runtime/init.go`
- `internal/adapter/smb/v2/handlers/{handler,tree_connect,stub_handlers}.go`
- `cmd/dfsctl/commands/share/create.go` — `--change-notify-disabled` flag
- `test/smb-conformance/bootstrap.sh` — new `/change_notify_disabled` share
- `test/smb-conformance/smbtorture/run.sh` — point suite at the new share

Handler rejects `CHANGE_NOTIFY` with new `StatusNotImplemented`
(`NT_STATUS_NOT_IMPLEMENTED`, 0xC0000002) when the tree's share has the
toggle set. Matches Samba `kernel change notify = no`. Target:

- `smb2.change_notify_disabled.notfiy_disabled`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (full suite, including new unit tests)
- [x] `go test -race ./internal/adapter/smb/...` green
- [x] New unit tests:
  - `TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer` — sticky-overflow contract
  - `TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback` — cleanup callback path
- [ ] CI `smbtorture` run to confirm flips on the listed targets