### PR TITLE
chore(smb): walk back KNOWN_FAILURES for #604 + #478 silent flips (+7 tests)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -320,17 +320,6 @@ Advanced delete-on-close permission checks and edge cases. Basic DOC works
 | smb2.delete-on-close-perms.READONLY | Delete on close | DOC on read-only files not implemented | - |
 | smb2.delete-on-close-perms.FIND_and_set_DOC | Delete on close | Cascade from the CREATE/CREATE_IF/OVERWRITE_IF Existing DOC failures above: those subtests leak `test_dir/test_create.dat` that `smb2_deltree` can't recover from, so `torture_smb2_testdir` reopens a non-empty `test_dir` and the final CLOSE correctly returns DIRECTORY_NOT_EMPTY. Pre-#388 the unlink error was silently swallowed by CLOSE so the test "passed" by accident. Will self-resolve once the upstream DOC permission checks are implemented. | - |
 
-### File IDs (Different Handle Scheme)
-
-DittoFS uses a different file handle scheme than Windows NTFS file IDs.
-Stable file ID tracking across renames and uniqueness guarantees are not
-implemented.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.fileid.fileid | File IDs | Stable file ID not implemented | - |
-| smb2.fileid.fileid-dir | File IDs | Stable directory file ID not implemented | - |
-
 ### Maximum Allowed Access (Partial)
 
 Maximum allowed access computation is partially implemented. Read-only
@@ -666,19 +655,6 @@ requests with durable handles. Newly reachable after GMAC signing fix.
 | smb2.replay.replay4 | Replay | Replay detection not implemented | - |
 | smb2.replay.replay5 | Replay | Replay detection not implemented | - |
 | smb2.replay.replay6 | Replay | Replay detection not implemented | - |
-
-### Timestamps (Fix Candidate)
-
-Timestamp update semantics partially implemented but tests fail due to
-incomplete delayed-write and timestamp freeze/unfreeze logic.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.timestamps.delayed-2write | Timestamps | Delayed write timestamp update not working | #434 |
-| smb2.timestamps.delayed-write-vs-flush | Timestamps | Delayed write vs flush timestamp not working | #434 |
-| smb2.timestamps.delayed-write-vs-setbasic | Timestamps | Delayed write vs setbasic timestamp not working | #434 |
-| smb2.timestamps.delayed-write-vs-seteof | Timestamps | Delayed write vs seteof timestamp not working | #434 |
-| smb2.timestamps.freeze-thaw | Timestamps | CreationTime freeze/unfreeze not fully working | #434 |
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

PR #604 (delayed write-time semantics) flipped 5 \`smb2.timestamps.*\` tests to PASS:
- ` smb2.timestamps.delayed-2write`
- ` smb2.timestamps.delayed-write-vs-flush`
- ` smb2.timestamps.delayed-write-vs-setbasic`
- ` smb2.timestamps.delayed-write-vs-seteof`
- ` smb2.timestamps.freeze-thaw`

PR #605 (regression tests added under #478) confirmed both \`smb2.fileid.fileid\` and \`smb2.fileid.fileid-dir\` already pass on develop — the KNOWN_FAILURES entries were stale (the fix was implicit in earlier handle-scheme work):
- ` smb2.fileid.fileid`
- ` smb2.fileid.fileid-dir`

Drop both clusters' tables entirely. Net +7 PASS, no new failures.

CI confirmed both via the smbtorture/memory job on PRs #604 (\`7d60e465\`) and #605.

Refs #434, #478.