### PR TITLE
feat(blockstore): per-remote compression decorator (zstd/lz4) (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **Block-level compression on remote stores (opt-in).** A new
+  `pkg/blockstore/compression` decorator transparently compresses block
+  payloads before upload and decompresses on download. Configured per
+  remote via the `compression` key in the block-store config JSON
+  (`{ "compression": { "algo": "zstd" } }` or `{ "compression": { "algo": "lz4" } }`).
+  The plaintext BLAKE3 hash stays the CAS key — dedup, GC, and
+  `ReadBlockVerified` semantics are unchanged. Per-block adaptive:
+  incompressible bodies are stored raw with no header. See
+  `docs/CONFIGURATION.md` for the operator guide.
+
 ## [0.13.0] — YYYY-MM-DD
 
 ### Breaking Changes

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -418,6 +418,41 @@ See [ARCHITECTURE.md](ARCHITECTURE.md#garbage-collection-mark-sweep-v0150-phase-
 for the full mark-sweep design and [CLI.md](CLI.md) for the on-demand
 `dfsctl store block gc` command.
 
+#### Remote block-level compression (opt-in)
+
+A remote block store may compress block payloads before upload and
+decompress on download. The plaintext BLAKE3 hash remains the CAS key,
+so dedup and GC are unaffected. The decorator is per-remote: every
+share that references the remote inherits its compression policy.
+
+Add a `compression` block to the remote store's `config` JSON when
+creating it:
+
+```bash
+./dfsctl store block add --kind remote --name prod-s3 --type s3 \
+  --config '{"region":"us-east-1","bucket":"dfs-production","compression":{"algo":"zstd"}}'
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `algo` | string | `"zstd"` | Algorithm: `"zstd"` or `"lz4"`. Defaults to zstd when the `compression` block is present but `algo` is omitted. |
+
+Notes:
+
+- Absence of the `compression` block means no wrapping — zero behavior
+  change for existing remotes.
+- Per-block adaptive: if the compressed body is not strictly smaller
+  than the plaintext, the decorator stores the raw plaintext with no
+  header. Incompressible payloads (random data, already-compressed
+  media) cost only the encoder pass, no on-wire expansion.
+- `GetRange` on a framed block decompresses the full block before
+  slicing — there is no random access into a compressed body. Read
+  paths that consume whole CDC chunks are unaffected.
+- The policy is captured at remote-store creation; restart the share
+  after editing the config to switch algorithms. Mixed framed and raw
+  blocks coexist within one remote and the reader auto-detects via the
+  5-byte `DFCMP` magic prefix.
+
 ### 7. Metadata Configuration
 
 Metadata configuration has two parts: filesystem capabilities (server config file) and store instances (managed via CLI).

--- a/go.mod
+++ b/go.mod
@@ -26,13 +26,12 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	golang.org/x/sync v0.18.0
-	golang.org/x/term v0.42.0
-	golang.org/x/time v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -99,6 +98,8 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
@@ -135,7 +136,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.6
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -268,6 +268,8 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/blockstore/compression/codec.go
+++ b/pkg/blockstore/compression/codec.go
@@ -1,0 +1,202 @@
+package compression
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+// codec is the streaming interface every compression algorithm
+// implementation satisfies. EncodeStream wraps a writer that receives
+// compressed bytes; the caller writes plaintext into the returned
+// WriteCloser and MUST call Close to flush + release the pooled
+// encoder. DecodeStream mirrors that contract on the read side.
+type codec interface {
+	EncodeStream(w io.Writer) (io.WriteCloser, error)
+	DecodeStream(r io.Reader) (io.ReadCloser, error)
+}
+
+// newCodec returns the singleton codec for the given algorithm. Codecs
+// are stateless wrappers around their library's encoder/decoder pools.
+func newCodec(a Algo) (codec, error) {
+	switch a {
+	case AlgoZstd:
+		return zstdCodec, nil
+	case AlgoLZ4:
+		return lz4Codec, nil
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedCompressionAlgo, a)
+	}
+}
+
+// --- zstd ---------------------------------------------------------------
+
+var zstdCodec codec = &zstdImpl{}
+
+type zstdImpl struct{}
+
+var zstdEncoderPool = sync.Pool{
+	New: func() any {
+		// Discard the bound writer here; callers Reset() before use.
+		enc, err := zstd.NewWriter(io.Discard,
+			zstd.WithEncoderLevel(zstd.SpeedDefault),
+			zstd.WithEncoderConcurrency(1),
+		)
+		if err != nil {
+			// Library default level cannot fail to construct; surface
+			// the error indirectly via a nil pool entry.
+			return nil
+		}
+		return enc
+	},
+}
+
+var zstdDecoderPool = sync.Pool{
+	New: func() any {
+		dec, err := zstd.NewReader(nil,
+			zstd.WithDecoderConcurrency(1),
+		)
+		if err != nil {
+			return nil
+		}
+		return dec
+	},
+}
+
+func (zstdImpl) EncodeStream(w io.Writer) (io.WriteCloser, error) {
+	v := zstdEncoderPool.Get()
+	if v == nil {
+		return nil, fmt.Errorf("compression: zstd encoder unavailable")
+	}
+	enc := v.(*zstd.Encoder)
+	enc.Reset(w)
+	return &zstdEncoderHandle{enc: enc}, nil
+}
+
+type zstdEncoderHandle struct {
+	enc    *zstd.Encoder
+	closed bool
+}
+
+func (h *zstdEncoderHandle) Write(p []byte) (int, error) {
+	return h.enc.Write(p)
+}
+
+func (h *zstdEncoderHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	err := h.enc.Close()
+	zstdEncoderPool.Put(h.enc)
+	h.enc = nil
+	return err
+}
+
+func (zstdImpl) DecodeStream(r io.Reader) (io.ReadCloser, error) {
+	v := zstdDecoderPool.Get()
+	if v == nil {
+		return nil, fmt.Errorf("compression: zstd decoder unavailable")
+	}
+	dec := v.(*zstd.Decoder)
+	if err := dec.Reset(r); err != nil {
+		zstdDecoderPool.Put(dec)
+		return nil, err
+	}
+	return &zstdDecoderHandle{dec: dec}, nil
+}
+
+type zstdDecoderHandle struct {
+	dec    *zstd.Decoder
+	closed bool
+}
+
+func (h *zstdDecoderHandle) Read(p []byte) (int, error) {
+	return h.dec.Read(p)
+}
+
+func (h *zstdDecoderHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	// Reset to a nil reader so the decoder's internal state is released.
+	_ = h.dec.Reset(nil)
+	zstdDecoderPool.Put(h.dec)
+	h.dec = nil
+	return nil
+}
+
+// --- lz4 ----------------------------------------------------------------
+
+var lz4Codec codec = &lz4Impl{}
+
+type lz4Impl struct{}
+
+var lz4WriterPool = sync.Pool{
+	New: func() any {
+		return lz4.NewWriter(io.Discard)
+	},
+}
+
+var lz4ReaderPool = sync.Pool{
+	New: func() any {
+		return lz4.NewReader(nil)
+	},
+}
+
+func (lz4Impl) EncodeStream(w io.Writer) (io.WriteCloser, error) {
+	zw := lz4WriterPool.Get().(*lz4.Writer)
+	zw.Reset(w)
+	return &lz4EncoderHandle{w: zw}, nil
+}
+
+type lz4EncoderHandle struct {
+	w      *lz4.Writer
+	closed bool
+}
+
+func (h *lz4EncoderHandle) Write(p []byte) (int, error) {
+	return h.w.Write(p)
+}
+
+func (h *lz4EncoderHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	err := h.w.Close()
+	lz4WriterPool.Put(h.w)
+	h.w = nil
+	return err
+}
+
+func (lz4Impl) DecodeStream(r io.Reader) (io.ReadCloser, error) {
+	zr := lz4ReaderPool.Get().(*lz4.Reader)
+	zr.Reset(r)
+	return &lz4DecoderHandle{r: zr}, nil
+}
+
+type lz4DecoderHandle struct {
+	r      *lz4.Reader
+	closed bool
+}
+
+func (h *lz4DecoderHandle) Read(p []byte) (int, error) {
+	return h.r.Read(p)
+}
+
+func (h *lz4DecoderHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	// Reset binds reader to nil so the underlying source is released.
+	h.r.Reset(nil)
+	lz4ReaderPool.Put(h.r)
+	h.r = nil
+	return nil
+}

--- a/pkg/blockstore/compression/codec_test.go
+++ b/pkg/blockstore/compression/codec_test.go
@@ -1,0 +1,109 @@
+package compression
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"strings"
+	"testing"
+)
+
+func codecRoundTrip(t *testing.T, c codec, plaintext []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	enc, err := c.EncodeStream(&compressed)
+	if err != nil {
+		t.Fatalf("EncodeStream: %v", err)
+	}
+	if _, err := enc.Write(plaintext); err != nil {
+		t.Fatalf("encoder Write: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("encoder Close: %v", err)
+	}
+	dec, err := c.DecodeStream(bytes.NewReader(compressed.Bytes()))
+	if err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	out, err := io.ReadAll(dec)
+	if err != nil {
+		t.Fatalf("decoder ReadAll: %v", err)
+	}
+	if err := dec.Close(); err != nil {
+		t.Fatalf("decoder Close: %v", err)
+	}
+	if !bytes.Equal(out, plaintext) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d bytes", len(out), len(plaintext))
+	}
+	return compressed.Bytes()
+}
+
+func TestCodec_RoundTrip(t *testing.T) {
+	rng := bytes.Repeat([]byte("Lorem ipsum dolor sit amet, "), 1024) // 27 KiB-ish text
+	zeros := make([]byte, 1<<20)
+	randBuf := make([]byte, 1<<20)
+	if _, err := rand.Read(randBuf); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"empty", nil},
+		{"single_byte", []byte{42}},
+		{"text_27k", rng},
+		{"zeros_1mib", zeros},
+		{"random_1mib", randBuf},
+	}
+	for _, algo := range []Algo{AlgoZstd, AlgoLZ4} {
+		c, err := newCodec(algo)
+		if err != nil {
+			t.Fatalf("newCodec(%v): %v", algo, err)
+		}
+		for _, tc := range cases {
+			t.Run(algo.String()+"/"+tc.name, func(t *testing.T) {
+				codecRoundTrip(t, c, tc.body)
+			})
+		}
+	}
+}
+
+func TestCodec_PooledReuse(t *testing.T) {
+	// Drive the pool through many sequential encodes to confirm reset()
+	// works and no encoder leaks bytes between successive callers.
+	c, err := newCodec(AlgoZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodies := [][]byte{
+		[]byte("hello"),
+		bytes.Repeat([]byte{0}, 4096),
+		[]byte(strings.Repeat("abc", 1000)),
+	}
+	for i := range 20 {
+		body := bodies[i%len(bodies)]
+		codecRoundTrip(t, c, body)
+	}
+}
+
+func TestNewCodec_UnknownAlgo(t *testing.T) {
+	_, err := newCodec(Algo(0xff))
+	if err == nil {
+		t.Fatal("expected error for unknown algo")
+	}
+}
+
+func TestCodec_CompressibleShrinks(t *testing.T) {
+	// Smoke check: both codecs must shrink a highly-redundant payload.
+	body := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog. "), 4096)
+	for _, algo := range []Algo{AlgoZstd, AlgoLZ4} {
+		c, err := newCodec(algo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		compressed := codecRoundTrip(t, c, body)
+		if len(compressed) >= len(body)/2 {
+			t.Fatalf("%v: expected >2x compression on redundant text, got %d -> %d", algo, len(body), len(compressed))
+		}
+	}
+}

--- a/pkg/blockstore/compression/decorator.go
+++ b/pkg/blockstore/compression/decorator.go
@@ -1,0 +1,269 @@
+package compression
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// Decorator wraps a remote.RemoteStore and transparently compresses
+// block bodies on Put while decompressing on Get. The plaintext BLAKE3
+// remains the CAS key — dedup, GC, and verification semantics are
+// unchanged from the perspective of callers above the decorator.
+//
+// Compression is per-block adaptive: if the compressed body is not
+// strictly smaller than the plaintext, the decorator stores the raw
+// plaintext with no header. Get detects framed vs raw by checking the
+// 5-byte DFCMP magic prefix.
+type Decorator struct {
+	inner remote.RemoteStore
+	algo  Algo
+	codec codec
+}
+
+// NewRemote constructs a compression decorator wrapping inner. The
+// policy's algorithm is captured for the lifetime of the decorator.
+func NewRemote(inner remote.RemoteStore, p CompressionPolicy) (*Decorator, error) {
+	if inner == nil {
+		return nil, fmt.Errorf("compression: inner RemoteStore is nil")
+	}
+	c, err := newCodec(p.Algo)
+	if err != nil {
+		return nil, err
+	}
+	return &Decorator{inner: inner, algo: p.Algo, codec: c}, nil
+}
+
+// Algo returns the algorithm this decorator emits on Put. Reads accept
+// any algorithm encoded in the wire frame regardless.
+func (d *Decorator) Algo() Algo { return d.algo }
+
+// --- write path ---------------------------------------------------------
+
+// Put compresses data; if the result is strictly smaller than the input
+// it stores the framed compressed body, else it stores the raw
+// plaintext with no header.
+func (d *Decorator) Put(ctx context.Context, hash blockstore.ContentHash, data []byte) error {
+	var compressed bytes.Buffer
+	enc, err := d.codec.EncodeStream(&compressed)
+	if err != nil {
+		return fmt.Errorf("compression: EncodeStream: %w", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		_ = enc.Close()
+		return fmt.Errorf("compression: encoder write: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("compression: encoder close: %w", err)
+	}
+
+	wire := selectWireForm(d.algo, data, compressed.Bytes())
+	return d.inner.Put(ctx, hash, wire)
+}
+
+// selectWireForm picks raw plaintext or a framed compressed body based
+// on which is smaller. Computes the framed length up front so the
+// allocate-and-copy frame build is skipped entirely on the
+// incompressible path.
+func selectWireForm(algo Algo, plaintext, compressed []byte) []byte {
+	framedLen := frameOverhead(uint64(len(plaintext))) + len(compressed)
+	if framedLen >= len(plaintext) {
+		return plaintext
+	}
+	return encodeFrame(algo, uint64(len(plaintext)), compressed)
+}
+
+// --- read path ----------------------------------------------------------
+
+// Get returns the plaintext for the block identified by hash.
+func (d *Decorator) Get(ctx context.Context, hash blockstore.ContentHash) ([]byte, error) {
+	raw, err := d.inner.Get(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return d.decode(raw)
+}
+
+// MaxFramedPlaintextSize caps the declared plaintext size a frame
+// header is allowed to claim. Guards against decompression-bomb /
+// huge-preallocation attacks via a corrupt wire header. The bound is
+// generous vs FastCDC's ~16 MiB max chunk; tune if larger chunks land.
+const MaxFramedPlaintextSize = 64 * 1024 * 1024
+
+func (d *Decorator) decode(raw []byte) ([]byte, error) {
+	algo, origSize, body, framed, err := tryDecodeFrame(raw)
+	if !framed {
+		return raw, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if origSize > MaxFramedPlaintextSize {
+		return nil, fmt.Errorf("%w: declared plaintext size %d exceeds cap %d", ErrCompressedFrameCorrupt, origSize, MaxFramedPlaintextSize)
+	}
+	c, err := newCodec(algo)
+	if err != nil {
+		return nil, err
+	}
+	dec, err := c.DecodeStream(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("compression: DecodeStream: %w", err)
+	}
+	defer func() { _ = dec.Close() }()
+
+	// Cap the read at origSize+1: anything over origSize means the body
+	// produced more bytes than the header declared (corrupt frame). The
+	// +1 lets the truncation check below trip on overflow rather than
+	// silently succeed when the codec emits extra bytes.
+	limited := io.LimitReader(dec, int64(origSize)+1)
+	buf := bytes.NewBuffer(make([]byte, 0, int(origSize)))
+	if _, err := io.Copy(buf, limited); err != nil {
+		return nil, fmt.Errorf("compression: decode: %w", err)
+	}
+	out := buf.Bytes()
+	if uint64(len(out)) != origSize {
+		return nil, fmt.Errorf("%w: decoded %d bytes, header declared %d", ErrCompressedFrameCorrupt, len(out), origSize)
+	}
+	return out, nil
+}
+
+// GetRange returns a byte sub-range of the plaintext. For framed
+// blocks this materialises the full plaintext and slices — there is no
+// random access into compressed bodies.
+func (d *Decorator) GetRange(ctx context.Context, hash blockstore.ContentHash, offset, length int64) ([]byte, error) {
+	if length <= 0 {
+		return nil, fmt.Errorf("%w: length %d", blockstore.ErrInvalidSize, length)
+	}
+	full, err := d.Get(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 || offset > int64(len(full)) {
+		return nil, fmt.Errorf("%w: offset %d out of bounds (size %d)", blockstore.ErrInvalidOffset, offset, len(full))
+	}
+	end := min(offset+length, int64(len(full)))
+	out := make([]byte, end-offset)
+	copy(out, full[offset:end])
+	return out, nil
+}
+
+// Has reports presence by probing inner.Head. NotFound errors map to
+// (false, nil); any other backend error propagates.
+func (d *Decorator) Has(ctx context.Context, hash blockstore.ContentHash) (bool, error) {
+	_, err := d.inner.Head(ctx, hash)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, blockstore.ErrBlockNotFound) || errors.Is(err, blockstore.ErrChunkNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Head returns Meta whose Size is the plaintext byte length. For
+// framed blocks this requires a short range-GET to parse the frame
+// header.
+func (d *Decorator) Head(ctx context.Context, hash blockstore.ContentHash) (blockstore.Meta, error) {
+	m, err := d.inner.Head(ctx, hash)
+	if err != nil {
+		return m, err
+	}
+	size, err := d.plaintextSizeFor(ctx, hash, m.Size)
+	if err != nil {
+		return blockstore.Meta{}, err
+	}
+	m.Size = size
+	return m, nil
+}
+
+// plaintextSizeFor returns the plaintext byte length of the block by
+// probing the frame header in the inner store. For framed blocks the
+// header carries the plaintext size; for raw passthrough blocks
+// wireSize already equals plaintext size and is returned unchanged.
+//
+// A probe failure is propagated as an error rather than silently
+// reporting wireSize: when the magic check can't run, the caller has
+// no way to distinguish a raw block (wireSize correct) from a framed
+// block (wireSize is the compressed size) — surfacing the error keeps
+// Meta.Size honest per the blockstore.go:130 contract.
+func (d *Decorator) plaintextSizeFor(ctx context.Context, hash blockstore.ContentHash, wireSize int64) (int64, error) {
+	probeLen := min(int64(FrameHeaderFixedSize+maxOrigSizeVarint), wireSize)
+	if probeLen <= 0 {
+		return wireSize, nil
+	}
+	probe, err := d.inner.GetRange(ctx, hash, 0, probeLen)
+	if err != nil {
+		return 0, fmt.Errorf("compression: plaintext-size probe: %w", err)
+	}
+	_, origSize, _, framed, err := tryDecodeFrame(probe)
+	if err != nil {
+		return 0, err
+	}
+	if !framed {
+		return wireSize, nil
+	}
+	return int64(origSize), nil
+}
+
+// Walk wraps the inner Walk and rewrites Meta.Size to plaintext size
+// for each framed block before invoking the user callback. Per-block
+// probe errors halt the walk and are surfaced to the caller.
+func (d *Decorator) Walk(ctx context.Context, fn func(hash blockstore.ContentHash, meta blockstore.Meta) error) error {
+	return d.inner.Walk(ctx, func(h blockstore.ContentHash, m blockstore.Meta) error {
+		size, err := d.plaintextSizeFor(ctx, h, m.Size)
+		if err != nil {
+			return err
+		}
+		m.Size = size
+		return fn(h, m)
+	})
+}
+
+// Delete is a straight passthrough.
+func (d *Decorator) Delete(ctx context.Context, hash blockstore.ContentHash) error {
+	return d.inner.Delete(ctx, hash)
+}
+
+// --- remote.RemoteStore extras -----------------------------------------
+
+// ReadBlockVerified GETs the block, decodes it, then re-verifies the
+// BLAKE3 hash over the plaintext. Streaming verification over the wire
+// bytes is not possible once the body is compressed.
+func (d *Decorator) ReadBlockVerified(ctx context.Context, hash blockstore.ContentHash, expected blockstore.ContentHash) ([]byte, error) {
+	plain, err := d.Get(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	actual := blake3.Sum256(plain)
+	var got blockstore.ContentHash
+	copy(got[:], actual[:])
+	if got != expected {
+		return nil, fmt.Errorf("%w: got %s want %s", blockstore.ErrCASContentMismatch, got, expected)
+	}
+	return plain, nil
+}
+
+// Close releases inner resources.
+func (d *Decorator) Close() error { return d.inner.Close() }
+
+// HealthCheck delegates to inner.
+func (d *Decorator) HealthCheck(ctx context.Context) error { return d.inner.HealthCheck(ctx) }
+
+// Healthcheck delegates to inner.
+func (d *Decorator) Healthcheck(ctx context.Context) health.Report {
+	return d.inner.Healthcheck(ctx)
+}
+
+// Compile-time interface assertions.
+var (
+	_ blockstore.BlockStore = (*Decorator)(nil)
+	_ remote.RemoteStore    = (*Decorator)(nil)
+)

--- a/pkg/blockstore/compression/decorator_test.go
+++ b/pkg/blockstore/compression/decorator_test.go
@@ -1,0 +1,349 @@
+package compression
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/blockstoretest"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+)
+
+func factoryFor(algo Algo) blockstoretest.Factory {
+	return func(t *testing.T) (blockstore.BlockStore, func()) {
+		t.Helper()
+		inner := remotememory.New()
+		d, err := NewRemote(inner, CompressionPolicy{Algo: algo})
+		if err != nil {
+			t.Fatalf("NewRemote: %v", err)
+		}
+		return d, func() { _ = d.Close() }
+	}
+}
+
+func TestConformance_Zstd(t *testing.T) {
+	blockstoretest.BlockStoreConformance(t, factoryFor(AlgoZstd))
+}
+
+func TestConformance_LZ4(t *testing.T) {
+	blockstoretest.BlockStoreConformance(t, factoryFor(AlgoLZ4))
+}
+
+// --- savings (paired raw vs zstd vs lz4) --------------------------------
+
+// spyRemote wraps an inner RemoteStore and records the wire bytes
+// observed at Put, so the savings test can compare the compressed wire
+// size against the plaintext.
+type spyRemote struct {
+	remote.RemoteStore
+	mu       sync.Mutex
+	lastWire []byte
+}
+
+func (s *spyRemote) Put(ctx context.Context, h blockstore.ContentHash, data []byte) error {
+	s.mu.Lock()
+	s.lastWire = append([]byte(nil), data...)
+	s.mu.Unlock()
+	return s.RemoteStore.Put(ctx, h, data)
+}
+
+func (s *spyRemote) wireLen() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.lastWire)
+}
+
+func putAndGet(t *testing.T, bs blockstore.BlockStore, payload []byte) blockstore.ContentHash {
+	t.Helper()
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := bs.Put(context.Background(), h, payload); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := bs.Get(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("round-trip mismatch: %d bytes back, want %d", len(got), len(payload))
+	}
+	return h
+}
+
+func TestSavings_PairedRawZstdLZ4(t *testing.T) {
+	const size = 4 << 20 // 4 MiB
+
+	textPayload := bytes.Repeat([]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit. "), size/57+1)[:size]
+	zeroPayload := make([]byte, size)
+	randPayload := make([]byte, size)
+	if _, err := rand.Read(randPayload); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name             string
+		payload          []byte
+		expectShrinkZstd bool
+		expectShrinkLZ4  bool
+	}{
+		{"text_4mib", textPayload, true, true},
+		{"zero_4mib", zeroPayload, true, true},
+		{"random_4mib", randPayload, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// raw baseline
+			rawSpy := &spyRemote{RemoteStore: remotememory.New()}
+			rawHash := putThroughSpy(t, rawSpy, tc.payload)
+			rawWire := rawSpy.wireLen()
+
+			zstdSpy := &spyRemote{RemoteStore: remotememory.New()}
+			zstdDec, err := NewRemote(zstdSpy, CompressionPolicy{Algo: AlgoZstd})
+			if err != nil {
+				t.Fatalf("NewRemote zstd: %v", err)
+			}
+			zstdHash := putAndGet(t, zstdDec, tc.payload)
+			zstdWire := zstdSpy.wireLen()
+
+			lz4Spy := &spyRemote{RemoteStore: remotememory.New()}
+			lz4Dec, err := NewRemote(lz4Spy, CompressionPolicy{Algo: AlgoLZ4})
+			if err != nil {
+				t.Fatalf("NewRemote lz4: %v", err)
+			}
+			lz4Hash := putAndGet(t, lz4Dec, tc.payload)
+			lz4Wire := lz4Spy.wireLen()
+
+			// CAS invariant: hash is over plaintext, same across all variants.
+			if rawHash != zstdHash || rawHash != lz4Hash {
+				t.Fatalf("hashes differ: raw=%s zstd=%s lz4=%s", rawHash, zstdHash, lz4Hash)
+			}
+
+			if rawWire != len(tc.payload) {
+				t.Fatalf("raw wire size: got %d want %d", rawWire, len(tc.payload))
+			}
+
+			if tc.expectShrinkZstd {
+				if zstdWire >= rawWire {
+					t.Errorf("zstd did not shrink %s: %d wire vs %d raw", tc.name, zstdWire, rawWire)
+				}
+			} else {
+				// incompressible: decorator falls back to raw passthrough (no frame).
+				if zstdWire != rawWire {
+					t.Errorf("zstd on incompressible %s: wire=%d want raw=%d (skip-on-expansion)", tc.name, zstdWire, rawWire)
+				}
+			}
+			if tc.expectShrinkLZ4 {
+				if lz4Wire >= rawWire {
+					t.Errorf("lz4 did not shrink %s: %d wire vs %d raw", tc.name, lz4Wire, rawWire)
+				}
+			} else {
+				if lz4Wire != rawWire {
+					t.Errorf("lz4 on incompressible %s: wire=%d want raw=%d (skip-on-expansion)", tc.name, lz4Wire, rawWire)
+				}
+			}
+			t.Logf("%s: raw=%d  zstd=%d (%.1f%%)  lz4=%d (%.1f%%)",
+				tc.name, rawWire,
+				zstdWire, 100*float64(zstdWire)/float64(rawWire),
+				lz4Wire, 100*float64(lz4Wire)/float64(rawWire))
+		})
+	}
+}
+
+func putThroughSpy(t *testing.T, spy *spyRemote, payload []byte) blockstore.ContentHash {
+	t.Helper()
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := spy.Put(context.Background(), h, payload); err != nil {
+		t.Fatalf("spy Put: %v", err)
+	}
+	got, err := spy.Get(context.Background(), h)
+	if err != nil {
+		t.Fatalf("spy Get: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("spy round-trip mismatch")
+	}
+	return h
+}
+
+// --- ReadBlockVerified --------------------------------------------------
+
+func TestReadBlockVerified_RoundTrip(t *testing.T) {
+	inner := remotememory.New()
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("verify-me-please. "), 4096)
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := d.Put(context.Background(), h, payload); err != nil {
+		t.Fatal(err)
+	}
+	out, err := d.ReadBlockVerified(context.Background(), h, h)
+	if err != nil {
+		t.Fatalf("ReadBlockVerified: %v", err)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Fatal("plaintext mismatch")
+	}
+}
+
+func TestReadBlockVerified_MismatchTrips(t *testing.T) {
+	inner := remotememory.New()
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("trip-me. "), 4096)
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := d.Put(context.Background(), h, payload); err != nil {
+		t.Fatal(err)
+	}
+	bogus := h
+	bogus[0] ^= 0xff
+	_, err = d.ReadBlockVerified(context.Background(), h, bogus)
+	if !errors.Is(err, blockstore.ErrCASContentMismatch) {
+		t.Fatalf("err: got %v want wraps ErrCASContentMismatch", err)
+	}
+}
+
+// --- Head + Walk plaintext-size contract --------------------------------
+
+func TestHead_ReportsPlaintextSize(t *testing.T) {
+	inner := remotememory.New()
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("compressible-text. "), 4096)
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := d.Put(context.Background(), h, payload); err != nil {
+		t.Fatal(err)
+	}
+	m, err := d.Head(context.Background(), h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Size != int64(len(payload)) {
+		t.Fatalf("Head.Size: got %d want %d (plaintext)", m.Size, len(payload))
+	}
+}
+
+func TestGetRange_InvalidLength(t *testing.T) {
+	inner := remotememory.New()
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("range. "), 4096)
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	if err := d.Put(context.Background(), h, payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, length := range []int64{0, -1, -1024} {
+		_, err := d.GetRange(context.Background(), h, 0, length)
+		if !errors.Is(err, blockstore.ErrInvalidSize) {
+			t.Errorf("length=%d: got %v, want wraps ErrInvalidSize", length, err)
+		}
+	}
+}
+
+// failingRangeStore wraps an inner RemoteStore and forces inner.GetRange
+// to return an error. Used to exercise the plaintext-size probe failure
+// path.
+type failingRangeStore struct {
+	remote.RemoteStore
+}
+
+func (f *failingRangeStore) GetRange(ctx context.Context, hash blockstore.ContentHash, offset, length int64) ([]byte, error) {
+	return nil, errors.New("simulated backend range failure")
+}
+
+func TestHead_ProbeFailurePropagates(t *testing.T) {
+	// Stage a real framed block in the inner store via a normally
+	// functioning decorator, then re-wrap the same inner with a
+	// failingRangeStore so the plaintext-size probe path is exercised
+	// against actual framed bytes on the wire.
+	inner := remotememory.New()
+	payload := bytes.Repeat([]byte("compressible. "), 4096)
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	staging, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := staging.Put(context.Background(), h, payload); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewRemote(&failingRangeStore{RemoteStore: inner}, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Head(context.Background(), h); err == nil {
+		t.Fatal("Head: expected probe error, got nil")
+	}
+}
+
+// --- alloc bound --------------------------------------------------------
+
+func TestPut_AllocBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping alloc bound under -short")
+	}
+	if raceEnabled {
+		t.Skip("skipping alloc bound under -race (instrumentation doubles allocs)")
+	}
+	inner := remotememory.New()
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const size = 4 << 20
+	payload := bytes.Repeat([]byte("alloc-bound-text. "), size/18+1)[:size]
+	sum := blake3.Sum256(payload)
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	// Warm pools.
+	for range 4 {
+		if err := d.Put(context.Background(), h, payload); err != nil {
+			t.Fatalf("warmup Put: %v", err)
+		}
+	}
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	const N = 8
+	for range N {
+		if err := d.Put(context.Background(), h, payload); err != nil {
+			t.Fatalf("measured Put: %v", err)
+		}
+	}
+	runtime.ReadMemStats(&after)
+	allocPerPut := (after.TotalAlloc - before.TotalAlloc) / N
+	// Plaintext (4 MiB) + codec window (≤ ~256 KiB) — leave generous headroom for runtime noise.
+	const budget = (4 << 20) + (1 << 20)
+	if allocPerPut > budget {
+		t.Fatalf("alloc per Put = %d bytes, budget %d", allocPerPut, budget)
+	}
+	t.Logf("alloc per 4 MiB Put: %d bytes (budget %d)", allocPerPut, budget)
+}

--- a/pkg/blockstore/compression/doc.go
+++ b/pkg/blockstore/compression/doc.go
@@ -1,0 +1,27 @@
+// Package compression provides a per-remote BlockStore decorator that
+// compresses block payloads before they leave the host and decompresses
+// them on the way back, preserving the BLAKE3-over-plaintext CAS key.
+//
+// The decorator wraps remote.RemoteStore and is installed once per remote
+// in the controlplane share service. Engine, cache, GC, and metadata
+// stores see only plaintext bytes; compression is opaque above and below.
+//
+// On-wire format (per block when compression actually shrinks the body):
+//
+//	offset 0..4   magic     5 bytes  "DFCMP"
+//	offset 5      algo      1 byte   1=zstd, 2=lz4
+//	offset 6..    orig_size uvarint  (1-10 bytes)
+//	offset N..    body               compressed bytes
+//
+// If a block does not compress (len(compressed) >= len(plaintext)), the
+// decorator writes the raw plaintext with no header — the Get path
+// detects framed vs raw by checking the 5-byte magic prefix.
+//
+// Compression is opt-in per remote via the BlockStoreConfig.Config JSON:
+//
+//	{ "compression": { "algo": "zstd" } }
+//
+// Absence of the compression block means no wrapping (zero behavior
+// change). Algorithm defaults to zstd when the block is present without
+// an explicit algo key.
+package compression

--- a/pkg/blockstore/compression/errors.go
+++ b/pkg/blockstore/compression/errors.go
@@ -1,0 +1,15 @@
+package compression
+
+import "errors"
+
+var (
+	// ErrUnsupportedCompressionAlgo is returned when a frame header or
+	// policy specifies an algorithm byte/string this build does not
+	// recognise.
+	ErrUnsupportedCompressionAlgo = errors.New("compression: unsupported algorithm")
+
+	// ErrCompressedFrameCorrupt is returned when a wire payload begins
+	// with the DFCMP magic but the rest of the header (algo byte,
+	// uvarint orig_size) fails to parse.
+	ErrCompressedFrameCorrupt = errors.New("compression: corrupt frame header")
+)

--- a/pkg/blockstore/compression/frame.go
+++ b/pkg/blockstore/compression/frame.go
@@ -1,0 +1,77 @@
+package compression
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// FrameMagic is the 5-byte prefix every framed block starts with.
+var FrameMagic = [5]byte{'D', 'F', 'C', 'M', 'P'}
+
+// FrameHeaderFixedSize is the byte count of the fixed-width portion of
+// the frame header (magic + algo). The orig_size uvarint that follows
+// occupies 1..10 additional bytes.
+const FrameHeaderFixedSize = len(FrameMagic) + 1
+
+// maxOrigSizeVarint is the worst-case byte count of an encoded uvarint.
+const maxOrigSizeVarint = binary.MaxVarintLen64
+
+// frameOverhead returns the header byte count for a frame declaring
+// the given plaintext size. Used by callers that need to know the
+// total wire size of a hypothetical frame without building it.
+func frameOverhead(origSize uint64) int {
+	var buf [maxOrigSizeVarint]byte
+	n := binary.PutUvarint(buf[:], origSize)
+	return FrameHeaderFixedSize + n
+}
+
+// encodeFrame builds the wire form for a compressed body:
+//
+//	[magic | algo | uvarint(origSize) | body]
+func encodeFrame(algo Algo, origSize uint64, body []byte) []byte {
+	out := make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint+len(body))
+	out = append(out, FrameMagic[:]...)
+	out = append(out, byte(algo))
+	var sizeBuf [maxOrigSizeVarint]byte
+	n := binary.PutUvarint(sizeBuf[:], origSize)
+	out = append(out, sizeBuf[:n]...)
+	out = append(out, body...)
+	return out
+}
+
+// hasFrameMagic reports whether b begins with the 5-byte DFCMP prefix.
+// It does NOT validate the algo byte or the uvarint; callers that need
+// a full parse use tryDecodeFrame.
+func hasFrameMagic(b []byte) bool {
+	return len(b) >= FrameHeaderFixedSize && bytes.Equal(b[:len(FrameMagic)], FrameMagic[:])
+}
+
+// tryDecodeFrame parses b and returns the framed payload metadata. When
+// b does not carry the DFCMP magic, framed is false and (algo, origSize,
+// body) are zero-valued — callers treat b as raw plaintext in that
+// case.
+//
+// When the magic is present but the rest of the header is malformed
+// (unknown algo byte, missing or truncated uvarint), an error wrapping
+// ErrCompressedFrameCorrupt or ErrUnsupportedCompressionAlgo is
+// returned.
+func tryDecodeFrame(b []byte) (algo Algo, origSize uint64, body []byte, framed bool, err error) {
+	if !hasFrameMagic(b) {
+		return 0, 0, nil, false, nil
+	}
+	algoByte := b[len(FrameMagic)]
+	switch Algo(algoByte) {
+	case AlgoZstd, AlgoLZ4:
+		algo = Algo(algoByte)
+	default:
+		return 0, 0, nil, true, fmt.Errorf("%w: byte 0x%02x", ErrUnsupportedCompressionAlgo, algoByte)
+	}
+	rest := b[FrameHeaderFixedSize:]
+	size, n := binary.Uvarint(rest)
+	if n <= 0 {
+		return 0, 0, nil, true, fmt.Errorf("%w: bad orig_size uvarint", ErrCompressedFrameCorrupt)
+	}
+	body = rest[n:]
+	return algo, size, body, true, nil
+}

--- a/pkg/blockstore/compression/frame_test.go
+++ b/pkg/blockstore/compression/frame_test.go
@@ -1,0 +1,170 @@
+package compression
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestEncodeDecodeFrame_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		algo     Algo
+		origSize uint64
+		body     []byte
+	}{
+		{"zstd_small", AlgoZstd, 16, []byte{0xde, 0xad, 0xbe, 0xef}},
+		{"lz4_small", AlgoLZ4, 1024, bytes.Repeat([]byte{0x42}, 32)},
+		{"zstd_empty_body", AlgoZstd, 0, nil},
+		{"zstd_large_size", AlgoZstd, 1 << 30, []byte("x")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire := encodeFrame(tc.algo, tc.origSize, tc.body)
+			if !hasFrameMagic(wire) {
+				t.Fatalf("encoded frame missing magic prefix: % x", wire[:8])
+			}
+			algo, size, body, framed, err := tryDecodeFrame(wire)
+			if err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			if !framed {
+				t.Fatal("expected framed=true")
+			}
+			if algo != tc.algo {
+				t.Fatalf("algo: got %v want %v", algo, tc.algo)
+			}
+			if size != tc.origSize {
+				t.Fatalf("origSize: got %d want %d", size, tc.origSize)
+			}
+			if !bytes.Equal(body, tc.body) {
+				t.Fatalf("body: got % x want % x", body, tc.body)
+			}
+		})
+	}
+}
+
+func TestTryDecodeFrame_NotFramed(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		[]byte("hello"),
+		[]byte("DFCM"),               // too short
+		[]byte("DFCMQ\x01\x00"),      // wrong magic
+		bytes.Repeat([]byte{0}, 256), // random-ish, no magic
+	}
+	for i, b := range cases {
+		_, _, _, framed, err := tryDecodeFrame(b)
+		if err != nil {
+			t.Fatalf("case %d: unexpected err: %v", i, err)
+		}
+		if framed {
+			t.Fatalf("case %d: framed=true for non-framed input", i)
+		}
+	}
+}
+
+func TestTryDecodeFrame_UnknownAlgo(t *testing.T) {
+	wire := append([]byte{}, FrameMagic[:]...)
+	wire = append(wire, 0x7f) // unknown algo byte
+	wire = append(wire, 0x00) // uvarint=0
+	_, _, _, framed, err := tryDecodeFrame(wire)
+	if !framed {
+		t.Fatal("framed should be true (magic present)")
+	}
+	if !errors.Is(err, ErrUnsupportedCompressionAlgo) {
+		t.Fatalf("err: got %v want wraps ErrUnsupportedCompressionAlgo", err)
+	}
+}
+
+func TestTryDecodeFrame_TruncatedUvarint(t *testing.T) {
+	// magic + zstd algo + a multi-byte uvarint that is cut short.
+	wire := append([]byte{}, FrameMagic[:]...)
+	wire = append(wire, byte(AlgoZstd))
+	// 0x80 with no continuation -> binary.Uvarint returns n<=0
+	wire = append(wire, 0x80)
+	_, _, _, framed, err := tryDecodeFrame(wire)
+	if !framed {
+		t.Fatal("framed should be true (magic present)")
+	}
+	if !errors.Is(err, ErrCompressedFrameCorrupt) {
+		t.Fatalf("err: got %v want wraps ErrCompressedFrameCorrupt", err)
+	}
+}
+
+func TestFrameHeaderSize_MatchesEncoding(t *testing.T) {
+	// origSize=0 fits in a single uvarint byte: header is exactly fixed+1.
+	wire := encodeFrame(AlgoZstd, 0, nil)
+	want := FrameHeaderFixedSize + 1
+	if len(wire) != want {
+		t.Fatalf("frame size for empty body: got %d want %d", len(wire), want)
+	}
+	// Sanity: uvarint encoding of 0 is one byte 0x00.
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], 0)
+	if n != 1 || buf[0] != 0x00 {
+		t.Fatalf("unexpected uvarint(0): n=%d buf[0]=0x%02x", n, buf[0])
+	}
+}
+
+func TestParsePolicy_Default(t *testing.T) {
+	p, err := ParsePolicy(json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("ParsePolicy: %v", err)
+	}
+	if p.Algo != AlgoZstd {
+		t.Fatalf("default algo: got %v want zstd", p.Algo)
+	}
+}
+
+func TestParsePolicy_Empty(t *testing.T) {
+	p, err := ParsePolicy(nil)
+	if err != nil {
+		t.Fatalf("ParsePolicy(nil): %v", err)
+	}
+	if p.Algo != AlgoZstd {
+		t.Fatalf("nil-raw default algo: got %v want zstd", p.Algo)
+	}
+}
+
+func TestParsePolicy_Explicit(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want Algo
+	}{
+		{`{"algo":"zstd"}`, AlgoZstd},
+		{`{"algo":"lz4"}`, AlgoLZ4},
+	} {
+		p, err := ParsePolicy(json.RawMessage(tc.in))
+		if err != nil {
+			t.Fatalf("ParsePolicy(%q): %v", tc.in, err)
+		}
+		if p.Algo != tc.want {
+			t.Fatalf("algo for %q: got %v want %v", tc.in, p.Algo, tc.want)
+		}
+	}
+}
+
+func TestParsePolicy_UnknownAlgo(t *testing.T) {
+	_, err := ParsePolicy(json.RawMessage(`{"algo":"snappy"}`))
+	if !errors.Is(err, ErrUnsupportedCompressionAlgo) {
+		t.Fatalf("err: got %v want wraps ErrUnsupportedCompressionAlgo", err)
+	}
+}
+
+func TestParsePolicy_BadJSON(t *testing.T) {
+	_, err := ParsePolicy(json.RawMessage(`{`))
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+func TestParsePolicy_RejectsNonObject(t *testing.T) {
+	for _, in := range []string{`null`, `"zstd"`, `["zstd"]`, `42`, `true`} {
+		if _, err := ParsePolicy(json.RawMessage(in)); err == nil {
+			t.Errorf("ParsePolicy(%q): expected error, got nil", in)
+		}
+	}
+}

--- a/pkg/blockstore/compression/policy.go
+++ b/pkg/blockstore/compression/policy.go
@@ -1,0 +1,83 @@
+package compression
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Algo identifies a compression algorithm. The wire byte values are
+// stable: changing them would invalidate existing framed blocks.
+type Algo uint8
+
+const (
+	// AlgoZstd selects zstd via github.com/klauspost/compress/zstd at
+	// the library's default level.
+	AlgoZstd Algo = 1
+
+	// AlgoLZ4 selects lz4 via github.com/pierrec/lz4/v4 at the library's
+	// default level.
+	AlgoLZ4 Algo = 2
+)
+
+// String returns the canonical lowercase config string for an Algo.
+func (a Algo) String() string {
+	switch a {
+	case AlgoZstd:
+		return "zstd"
+	case AlgoLZ4:
+		return "lz4"
+	default:
+		return fmt.Sprintf("Algo(%d)", uint8(a))
+	}
+}
+
+// parseAlgoString converts the lowercase config form into an Algo.
+func parseAlgoString(s string) (Algo, error) {
+	switch s {
+	case "zstd":
+		return AlgoZstd, nil
+	case "lz4":
+		return AlgoLZ4, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", ErrUnsupportedCompressionAlgo, s)
+	}
+}
+
+// CompressionPolicy holds the per-remote compression configuration.
+// Captured at remote-store construction and immutable thereafter.
+type CompressionPolicy struct {
+	Algo Algo
+}
+
+// policyJSON is the JSON shape stored in BlockStoreConfig.Config under
+// the "compression" key.
+type policyJSON struct {
+	Algo string `json:"algo"`
+}
+
+// ParsePolicy decodes the JSON value sitting under the "compression"
+// key. An empty object (`{}`) yields the zstd default. Non-object
+// inputs (null, arrays, scalars) are rejected so misconfigurations
+// fail fast instead of silently enabling compression with defaults.
+func ParsePolicy(raw json.RawMessage) (CompressionPolicy, error) {
+	if len(raw) == 0 {
+		return CompressionPolicy{Algo: AlgoZstd}, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return CompressionPolicy{}, fmt.Errorf("compression: parse policy: expected JSON object, got %s", trimmed)
+	}
+	var pj policyJSON
+	if err := json.Unmarshal(trimmed, &pj); err != nil {
+		return CompressionPolicy{}, fmt.Errorf("compression: parse policy: %w", err)
+	}
+	if pj.Algo == "" {
+		return CompressionPolicy{Algo: AlgoZstd}, nil
+	}
+	a, err := parseAlgoString(pj.Algo)
+	if err != nil {
+		return CompressionPolicy{}, err
+	}
+	return CompressionPolicy{Algo: a}, nil
+}

--- a/pkg/blockstore/compression/race_norace_test.go
+++ b/pkg/blockstore/compression/race_norace_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package compression
+
+const raceEnabled = false

--- a/pkg/blockstore/compression/race_race_test.go
+++ b/pkg/blockstore/compression/race_race_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package compression
+
+const raceEnabled = true

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -79,6 +79,9 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 			if !ok || secretAccessKey == "" {
 				return errors.New("s3 remote block store requires secret_access_key in config")
 			}
+			if err := validateCompressionSubconfig(config); err != nil {
+				return err
+			}
 			return nil
 		default:
 			return fmt.Errorf("unsupported remote block store type: %s", storeType)
@@ -86,5 +89,34 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 
 	default:
 		return fmt.Errorf("unsupported block store kind: %s", kind)
+	}
+}
+
+// validateCompressionSubconfig accepts the parsed `compression` value
+// from a BlockStoreConfig and verifies its shape. An absent key is
+// allowed (compression is opt-in). When present, the value MUST be a
+// JSON object; an `algo` key, if set, MUST be either "zstd" or "lz4".
+func validateCompressionSubconfig(config map[string]any) error {
+	raw, ok := config["compression"]
+	if !ok {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("compression: expected object, got %T", raw)
+	}
+	algoVal, present := obj["algo"]
+	if !present {
+		return nil // defaults to zstd
+	}
+	algoStr, ok := algoVal.(string)
+	if !ok {
+		return fmt.Errorf("compression.algo: expected string, got %T", algoVal)
+	}
+	switch algoStr {
+	case "zstd", "lz4":
+		return nil
+	default:
+		return fmt.Errorf("compression.algo: unsupported value %q (want zstd or lz4)", algoStr)
 	}
 }

--- a/pkg/controlplane/runtime/blockstore_init_test.go
+++ b/pkg/controlplane/runtime/blockstore_init_test.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCompressionSubconfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]any
+		wantErr string // substring; "" means accept
+	}{
+		{"absent", map[string]any{}, ""},
+		{"empty_object_defaults_zstd", map[string]any{"compression": map[string]any{}}, ""},
+		{"explicit_zstd", map[string]any{"compression": map[string]any{"algo": "zstd"}}, ""},
+		{"explicit_lz4", map[string]any{"compression": map[string]any{"algo": "lz4"}}, ""},
+		{"unknown_algo", map[string]any{"compression": map[string]any{"algo": "snappy"}}, "unsupported value"},
+		{"wrong_type_block", map[string]any{"compression": "zstd"}, "expected object"},
+		{"wrong_type_algo", map[string]any{"compression": map[string]any{"algo": 7}}, "expected string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCompressionSubconfig(tc.cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2,6 +2,7 @@ package shares
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -15,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/compression"
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	"github.com/marmos91/dittofs/pkg/blockstore/local"
 	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
@@ -618,6 +620,16 @@ func (s *Service) acquireRemoteStore(ctx context.Context, configID string, provi
 		return nil, "", fmt.Errorf("failed to create remote store: %w", err)
 	}
 
+	// Wrap with compression decorator when the remote's config carries a
+	// `compression` block. Policy is captured at acquire time and never
+	// re-read; operators must restart the share to change the algorithm.
+	wrapped, err := maybeWrapCompression(newStore, remoteCfg)
+	if err != nil {
+		_ = newStore.Close()
+		return nil, "", fmt.Errorf("failed to apply compression policy: %w", err)
+	}
+	newStore = wrapped
+
 	// Double-check: another goroutine may have created the store concurrently.
 	s.mu.Lock()
 	if sr, ok := s.remoteStores[configID]; ok {
@@ -636,6 +648,29 @@ func (s *Service) acquireRemoteStore(ctx context.Context, configID string, provi
 
 	logger.Info("Created shared remote store", "config_id", configID, "type", remoteCfg.Type)
 	return newStore, configID, nil
+}
+
+// maybeWrapCompression inspects the remote config's "compression" key
+// and, when present, wraps inner with a compression.Decorator. Returns
+// inner unchanged when the key is absent.
+func maybeWrapCompression(inner remote.RemoteStore, cfg *models.BlockStoreConfig) (remote.RemoteStore, error) {
+	parsed, err := cfg.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("parse block store config: %w", err)
+	}
+	raw, ok := parsed["compression"]
+	if !ok {
+		return inner, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal compression sub-config: %w", err)
+	}
+	policy, err := compression.ParsePolicy(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return compression.NewRemote(inner, policy)
 }
 
 // releaseRemoteStore decrements the reference count and closes the remote store if no longer used.


### PR DESCRIPTION
## Summary

Adds `pkg/blockstore/compression` — a `remote.RemoteStore` decorator that transparently compresses block payloads before upload and decompresses on download. Per-remote opt-in via the `compression` key in `BlockStoreConfig.Config` JSON. Plaintext BLAKE3 stays the CAS key; dedup, GC, and `ReadBlockVerified` semantics are unchanged.

Closes #185.

## Design

- **On-wire**: 5-byte `DFCMP` magic + 1-byte algo + uvarint orig_size + compressed body.
- **Per-block adaptive**: if compressed body ≥ plaintext size, decorator stores the raw plaintext with no header (zero expansion on incompressible data).
- **Algorithms**: `zstd` (klauspost/compress, default) and `lz4` (pierrec/lz4). Streaming codec interface with `sync.Pool`-backed encoder/decoder reuse.
- **Wiring**: one site at `pkg/controlplane/runtime/shares/service.go::acquireRemoteStore`, between `CreateRemoteStoreFromConfig` and the `sharedRemote` registry.
- **Validation**: `ValidateBlockStoreConfig` rejects unknown algo strings via the s3 branch.
- **Contract preservation**: `Decorator.Head` and `.Walk` rewrite `Meta.Size` to the plaintext byte length via a small frame-header probe (`inner.GetRange(0, ≤16)`). Probe errors propagate rather than silently reporting wire size.

## Config

```json
{ "compression": { "algo": "zstd" } }
```

Absent block = no wrapping (zero behavior change). See `docs/CONFIGURATION.md` for the operator guide.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/blockstore/compression/... ./pkg/controlplane/runtime/... -count=1 -race`
- [x] `blockstoretest.BlockStoreConformance` passes for both zstd and lz4 algos
- [x] Paired raw / zstd / lz4 savings matrix on text + zero + random 4 MiB payloads — confirms CAS hash invariant + savings + skip-on-expansion
- [x] `ReadBlockVerified` mismatch trips `ErrCASContentMismatch`
- [x] `GetRange` invalid-length returns `ErrInvalidSize`
- [x] `Head` probe failure propagates as error (no silent wire-size fallback)
- [x] Per-Put allocation bound check (skipped under `-race`)

Empirical savings on 4 MiB payloads through the memory backend:

| payload | raw | zstd | lz4 |
|---|---|---|---|
| repeated text | 4194304 | 519 (0.0%) | 16559 (0.4%) |
| zero | 4194304 | 461 (0.0%) | 16500 (0.4%) |
| random | 4194304 | 4194304 (raw passthrough) | 4194304 (raw passthrough) |

## Out of scope

- Local FS compression.
- Migration tool for legacy raw blocks (magic-byte detection handles mixed coexistence indefinitely).
- Compression of `BlockStoreAppend.AppendWrite` (random-write log, not CAS-keyed).
- Per-block level / skip-ratio tuning knobs.