### PR TITLE
chore(smb): walk back KNOWN_FAILURES for #608 flips (+2 notify tests)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -129,9 +129,7 @@ tdis1, tcp, tcon now pass. Remaining tests require features not yet implemented.
 | smb2.notify.overflow | Change Notify | Notify buffer overflow edge case | - |
 | smb2.notify.session-reconnect | Change Notify | Depends on session reconnect (not re-auth) | - |
 | smb2.notify.valid-req | Change Notify | CompletionFilter validation rejects previously-accepted requests | - |
-| smb2.notify.tcon | Change Notify | Full-suite flaky (tree disconnect notify race) | - |
 | smb2.notify.dir | Change Notify | Full-suite flaky (directory notify race) | - |
-| smb2.change_notify_disabled.notfiy_disabled | Change Notify | Change notify disabled mode test | - |
 
 ### Oplocks (Multi-Client Coordination Not Implemented)
 


### PR DESCRIPTION
## Summary

PR #608 (cleanup callbacks + sticky overflow + change-notify-disabled toggle) flipped two tests to PASS on CI smbtorture/memory (develop tip \`6d104afc\`):

- ` smb2.notify.tcon` — STATUS_NOTIFY_CLEANUP delivery on tree disconnect
- ` smb2.change_notify_disabled.notfiy_disabled` — per-share toggle returns STATUS_NOT_IMPLEMENTED

Refs #473.