### PR TITLE
fix(smb/notify): per-handle sticky max_buffer_size for smb2.notify.valid-req

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -898,6 +898,11 @@ func (r *NotifyRegistry) sendAndUnregister(w *PendingNotify, changes []FileNotif
 	// Per MS-SMB2 3.3.4.4 / MS-FSCC 2.4.42: when the encoded notification
 	// exceeds MaxOutputLength, complete the request with STATUS_NOTIFY_ENUM_DIR
 	// to tell the client to re-enumerate the directory.
+	//
+	// The "if the first notify returns NOTIFY_ENUM_DIR, all do" property
+	// from smb2.notify.valid-req is satisfied at the handler layer: the
+	// handle's NotifyMaxBufferSize is fixed by the first CHANGE_NOTIFY and
+	// MIN-capped into MaxOutputLength here on every subsequent request.
 	if uint32(len(buffer)) > removed.MaxOutputLength {
 		logger.Warn("CHANGE_NOTIFY: notification exceeds MaxOutputLength; sending STATUS_NOTIFY_ENUM_DIR",
 			"watchPath", removed.WatchPath,

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1940,7 +1940,7 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 		t.Fatalf("NotifyMaxBufferSize after second call = (%d, set=%v), want (0, true) — sticky-zero broken", got, set)
 	}
 
-	var pendingMax uint32 = ^uint32(0) // poison
+	pendingMax := ^uint32(0) // poison
 	found := false
 	h.NotifyRegistry.RangeWatchers(func(p *PendingNotify) bool {
 		if p.FileID == fileID {

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1758,6 +1758,7 @@ func TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq(t *testing.T) {
 		SessionID:     1,
 		TreeID:        1,
 		DesiredAccess: 0x00000001, // FILE_LIST_DIRECTORY
+		GrantedAccess: 0x00000001,
 	}
 	h.StoreOpenFile(openFile)
 
@@ -1785,8 +1786,8 @@ func TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq(t *testing.T) {
 	if res1 == nil || res1.Status != types.StatusPending {
 		t.Fatalf("first CHANGE_NOTIFY: want STATUS_PENDING, got %+v", res1)
 	}
-	if got := openFile.NotifyMaxBufferSize.Load(); got != 1 {
-		t.Fatalf("NotifyMaxBufferSize after first call = %d, want 1", got)
+	if got, set := openFile.NotifyMaxBufferSizeValue(); !set || got != 1 {
+		t.Fatalf("NotifyMaxBufferSize after first call = (%d, set=%v), want (1, true)", got, set)
 	}
 
 	// Drain the registered watcher so the second CHANGE_NOTIFY can register
@@ -1804,8 +1805,8 @@ func TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq(t *testing.T) {
 	if res2 == nil || res2.Status != types.StatusPending {
 		t.Fatalf("second CHANGE_NOTIFY: want STATUS_PENDING (not InvalidParameter), got %+v", res2)
 	}
-	if got := openFile.NotifyMaxBufferSize.Load(); got != 1 {
-		t.Fatalf("NotifyMaxBufferSize after second call = %d, want 1 (stuck)", got)
+	if got, set := openFile.NotifyMaxBufferSizeValue(); !set || got != 1 {
+		t.Fatalf("NotifyMaxBufferSize after second call = (%d, set=%v), want (1, true) (stuck)", got, set)
 	}
 
 	// The pending notify must carry the MIN-capped MaxOutputLength, not the
@@ -1835,7 +1836,7 @@ func TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest(t *testing.T) {
 	fileID := [16]byte{0x11}
 	openFile := &OpenFile{
 		FileID: fileID, IsDirectory: true, ShareName: "share1",
-		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001,
+		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
 	}
 	h.StoreOpenFile(openFile)
 
@@ -1873,7 +1874,85 @@ func TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest(t *testing.T) {
 	if pendingMax != 256 {
 		t.Errorf("PendingNotify.MaxOutputLength = %d, want 256 (request smaller than stored max)", pendingMax)
 	}
-	if got := openFile.NotifyMaxBufferSize.Load(); got != 65536 {
-		t.Errorf("NotifyMaxBufferSize must not be updated by later calls; got %d, want 65536", got)
+	if got, set := openFile.NotifyMaxBufferSizeValue(); !set || got != 65536 {
+		t.Errorf("NotifyMaxBufferSize must not be updated by later calls; got (%d, set=%v), want (65536, true)", got, set)
+	}
+}
+
+// TestChangeNotify_FirstZeroBuffer_StickyAtZero pins the OutputBufferLength=0
+// edge case. SMB2 CHANGE_NOTIFY permits OutputBufferLength=0 as a valid
+// request; the per-handle "first wins" max_buffer_size must remember that
+// zero and cap every later notify at zero (so even a max_trans_size follow-up
+// overflows immediately, matching Samba `change_notify_create` semantics).
+//
+// The old encoding used 0 as the "unset" sentinel and would silently let a
+// later large request overwrite the captured cap — breaking the sticky
+// invariant. Guards against that regression.
+func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	fileID := [16]byte{0x99}
+	openFile := &OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1",
+		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}
+	h.StoreOpenFile(openFile)
+
+	makeCtx := func() *SMBHandlerContext {
+		return &SMBHandlerContext{
+			SessionID: 1, TreeID: 1, MessageID: 1, ConnID: 1,
+			TryReserveAsync: func() bool { return true },
+			ReleaseAsync:    func() {},
+			AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+				return nil
+			},
+		}
+	}
+
+	// First CHANGE_NOTIFY: OutputBufferLength = 0 — legal per MS-SMB2 §2.2.35.
+	body1 := encodeChangeNotifyReq(0, 0, fileID, FileNotifyChangeFileName)
+	if _, err := h.ChangeNotify(makeCtx(), body1); err != nil {
+		t.Fatalf("first CHANGE_NOTIFY (OutputBufferLength=0) error: %v", err)
+	}
+
+	// The capture MUST be recorded even though the value is zero.
+	got, set := openFile.NotifyMaxBufferSizeValue()
+	if !set {
+		t.Fatal("NotifyMaxBufferSize was not marked set after first CHANGE_NOTIFY with OutputBufferLength=0")
+	}
+	if got != 0 {
+		t.Fatalf("NotifyMaxBufferSize after first call = %d, want 0", got)
+	}
+
+	h.NotifyRegistry.Unregister(fileID)
+
+	// Second CHANGE_NOTIFY: max_trans_size buffer. The sticky cap MUST clamp
+	// it down to zero, NOT overwrite the captured zero with the new value.
+	body2 := encodeChangeNotifyReq(0, h.MaxTransactSize, fileID, FileNotifyChangeFileName)
+	if _, err := h.ChangeNotify(makeCtx(), body2); err != nil {
+		t.Fatalf("second CHANGE_NOTIFY error: %v", err)
+	}
+
+	got, set = openFile.NotifyMaxBufferSizeValue()
+	if !set || got != 0 {
+		t.Fatalf("NotifyMaxBufferSize after second call = (%d, set=%v), want (0, true) — sticky-zero broken", got, set)
+	}
+
+	var pendingMax uint32 = ^uint32(0) // poison
+	found := false
+	h.NotifyRegistry.RangeWatchers(func(p *PendingNotify) bool {
+		if p.FileID == fileID {
+			pendingMax = p.MaxOutputLength
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("second CHANGE_NOTIFY did not register a PendingNotify")
+	}
+	if pendingMax != 0 {
+		t.Errorf("PendingNotify.MaxOutputLength = %d, want 0 (capped to first call's zero)", pendingMax)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1202,15 +1202,15 @@ func TestUnregisterAllForSession_PreservesOtherSessions(t *testing.T) {
 	}
 }
 
-// TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer covers the
-// smb2.notify.valid-req "sticky" overflow contract: when the encoded
-// change list exceeds MaxOutputLength we must (a) return STATUS_NOTIFY_ENUM_DIR
-// to the client and (b) invoke OnOverflow so the directory handle's overflow
-// flag survives across notifies and the next notify also returns ENUM_DIR.
-func TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer(t *testing.T) {
+// TestSendAndUnregister_UndersizedBufferYieldsEnumDir covers the
+// smb2.notify.valid-req contract for one notify cycle: when the encoded
+// change list exceeds MaxOutputLength, the registry MUST return
+// STATUS_NOTIFY_ENUM_DIR to the client. The "if the first notify returns
+// NOTIFY_ENUM_DIR, all do" sticky property is enforced one layer up at the
+// handler via OpenFile.NotifyMaxBufferSize, not by the registry.
+func TestSendAndUnregister_UndersizedBufferYieldsEnumDir(t *testing.T) {
 	r := NewNotifyRegistry()
 
-	var overflowFiredFor [16]byte
 	var deliveredStatus types.Status
 	fileID := [16]byte{0xAA}
 
@@ -1227,16 +1227,12 @@ func TestSendAndUnregister_OnOverflowFiresForUndersizedBuffer(t *testing.T) {
 			deliveredStatus = response.GetStatus()
 			return nil
 		},
-		OnOverflow: func(id [16]byte) { overflowFiredFor = id },
 	})
 
 	r.NotifyChange("share1", "/dir", "file.txt", FileActionAdded)
 
 	if deliveredStatus != types.StatusNotifyEnumDir {
 		t.Errorf("expected STATUS_NOTIFY_ENUM_DIR, got 0x%08X", uint32(deliveredStatus))
-	}
-	if overflowFiredFor != fileID {
-		t.Errorf("expected OnOverflow to fire with fileID %v, got %v", fileID, overflowFiredFor)
 	}
 }
 
@@ -1711,5 +1707,173 @@ func TestChangeNotify_HandlePermissions_GrantedAccessGate(t *testing.T) {
 				t.Errorf("expected one pending watcher after STATUS_PENDING, got %d", watchers)
 			}
 		})
+	}
+}
+
+// encodeChangeNotifyReq builds an SMB2 CHANGE_NOTIFY request body
+// per MS-SMB2 2.2.35.
+func encodeChangeNotifyReq(flags uint16, outBufLen uint32, fileID [16]byte, completionFilter uint32) []byte {
+	body := make([]byte, 32)
+	// StructureSize = 32
+	body[0] = 0x20
+	body[1] = 0x00
+	// Flags
+	body[2] = byte(flags)
+	body[3] = byte(flags >> 8)
+	// OutputBufferLength
+	body[4] = byte(outBufLen)
+	body[5] = byte(outBufLen >> 8)
+	body[6] = byte(outBufLen >> 16)
+	body[7] = byte(outBufLen >> 24)
+	// FileID
+	copy(body[8:24], fileID[:])
+	// CompletionFilter
+	body[24] = byte(completionFilter)
+	body[25] = byte(completionFilter >> 8)
+	body[26] = byte(completionFilter >> 16)
+	body[27] = byte(completionFilter >> 24)
+	return body
+}
+
+// TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq is the unit-level
+// cover for smb2.notify.valid-req's "if the first notify returns
+// NOTIFY_ENUM_DIR, all do" property. Per Samba `change_notify_create` the
+// notify_buffer's max_buffer_size is captured from the FIRST notify on the
+// handle and MIN-capped into every subsequent reply. A small first call
+// therefore caps every later call on the same handle — even when the later
+// call requests max_trans_size.
+func TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	var fileID [16]byte
+	copy(fileID[:], []byte{0x77, 0x88})
+
+	openFile := &OpenFile{
+		FileID:        fileID,
+		IsDirectory:   true,
+		ShareName:     "share1",
+		Path:          "/dir",
+		SessionID:     1,
+		TreeID:        1,
+		DesiredAccess: 0x00000001, // FILE_LIST_DIRECTORY
+	}
+	h.StoreOpenFile(openFile)
+
+	makeCtx := func() *SMBHandlerContext {
+		return &SMBHandlerContext{
+			SessionID:       1,
+			TreeID:          1,
+			MessageID:       1,
+			ConnID:          1,
+			TryReserveAsync: func() bool { return true },
+			ReleaseAsync:    func() {},
+			AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+				return nil
+			},
+		}
+	}
+
+	// First CHANGE_NOTIFY with a tiny buffer (1 byte). The handler must
+	// accept it and store NotifyMaxBufferSize = 1 on the OpenFile.
+	body1 := encodeChangeNotifyReq(0, 1, fileID, FileNotifyChangeFileName)
+	res1, err := h.ChangeNotify(makeCtx(), body1)
+	if err != nil {
+		t.Fatalf("first CHANGE_NOTIFY error: %v", err)
+	}
+	if res1 == nil || res1.Status != types.StatusPending {
+		t.Fatalf("first CHANGE_NOTIFY: want STATUS_PENDING, got %+v", res1)
+	}
+	if got := openFile.NotifyMaxBufferSize.Load(); got != 1 {
+		t.Fatalf("NotifyMaxBufferSize after first call = %d, want 1", got)
+	}
+
+	// Drain the registered watcher so the second CHANGE_NOTIFY can register
+	// a fresh one (Register replaces same-FileID entries).
+	h.NotifyRegistry.Unregister(fileID)
+
+	// Second CHANGE_NOTIFY with max_trans_size — must NOT be rejected as
+	// "previously-accepted requests" and must be MIN-capped down to 1 so
+	// any encoded change overflows and yields STATUS_NOTIFY_ENUM_DIR.
+	body2 := encodeChangeNotifyReq(0, h.MaxTransactSize, fileID, FileNotifyChangeFileName|FileNotifyChangeDirName)
+	res2, err := h.ChangeNotify(makeCtx(), body2)
+	if err != nil {
+		t.Fatalf("second CHANGE_NOTIFY error: %v", err)
+	}
+	if res2 == nil || res2.Status != types.StatusPending {
+		t.Fatalf("second CHANGE_NOTIFY: want STATUS_PENDING (not InvalidParameter), got %+v", res2)
+	}
+	if got := openFile.NotifyMaxBufferSize.Load(); got != 1 {
+		t.Fatalf("NotifyMaxBufferSize after second call = %d, want 1 (stuck)", got)
+	}
+
+	// The pending notify must carry the MIN-capped MaxOutputLength, not the
+	// request's max_trans_size — this is what guarantees overflow on
+	// delivery and matches Samba `change_notify_reply` MIN semantics.
+	var pendingMax uint32
+	h.NotifyRegistry.RangeWatchers(func(p *PendingNotify) bool {
+		if p.FileID == fileID {
+			pendingMax = p.MaxOutputLength
+		}
+		return true
+	})
+	if pendingMax != 1 {
+		t.Errorf("registered PendingNotify.MaxOutputLength = %d, want 1 (MIN-capped to first call's value)", pendingMax)
+	}
+}
+
+// TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest verifies the
+// inverse: when the first notify uses a large buffer, a subsequent notify
+// with a smaller request honors the smaller value (no upward cap, the cap
+// is asymmetric — Samba `MIN(max_param, notify_buf->max_buffer_size)`).
+func TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	fileID := [16]byte{0x11}
+	openFile := &OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1",
+		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001,
+	}
+	h.StoreOpenFile(openFile)
+
+	makeCtx := func() *SMBHandlerContext {
+		return &SMBHandlerContext{
+			SessionID: 1, TreeID: 1, MessageID: 1, ConnID: 1,
+			TryReserveAsync: func() bool { return true },
+			ReleaseAsync:    func() {},
+			AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+				return nil
+			},
+		}
+	}
+
+	// First call: 65536 byte buffer.
+	body1 := encodeChangeNotifyReq(0, 65536, fileID, FileNotifyChangeFileName)
+	if _, err := h.ChangeNotify(makeCtx(), body1); err != nil {
+		t.Fatalf("first CHANGE_NOTIFY error: %v", err)
+	}
+	h.NotifyRegistry.Unregister(fileID)
+
+	// Second call: 256 byte buffer — smaller than stored, must be used as-is.
+	body2 := encodeChangeNotifyReq(0, 256, fileID, FileNotifyChangeFileName)
+	if _, err := h.ChangeNotify(makeCtx(), body2); err != nil {
+		t.Fatalf("second CHANGE_NOTIFY error: %v", err)
+	}
+
+	var pendingMax uint32
+	h.NotifyRegistry.RangeWatchers(func(p *PendingNotify) bool {
+		if p.FileID == fileID {
+			pendingMax = p.MaxOutputLength
+		}
+		return true
+	})
+	if pendingMax != 256 {
+		t.Errorf("PendingNotify.MaxOutputLength = %d, want 256 (request smaller than stored max)", pendingMax)
+	}
+	if got := openFile.NotifyMaxBufferSize.Load(); got != 65536 {
+		t.Errorf("NotifyMaxBufferSize must not be updated by later calls; got %d, want 65536", got)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -376,6 +376,18 @@ type OpenFile struct {
 	// returns NOTIFY_ENUM_DIR, all do"). Cleared after that next notify
 	// consumes it. Lifetime is the handle: closing/reopening resets it.
 	NotifyOverflowed atomic.Bool
+
+	// NotifyMaxBufferSize is the OutputBufferLength captured from the FIRST
+	// CHANGE_NOTIFY issued on this handle. Subsequent notifies cap their
+	// effective max with MIN(req.OutputBufferLength, NotifyMaxBufferSize),
+	// matching Samba `change_notify_create` / `change_notify_reply` semantics
+	// (max_buffer_size is stored on notify_buffer creation and applied to
+	// every reply via MIN). This is what gives the smb2.notify.valid-req
+	// "if the first notify returns NOTIFY_ENUM_DIR, all do" property: a
+	// tiny first buffer permanently caps later notifies on the same handle.
+	// Zero means no CHANGE_NOTIFY has been issued yet on this handle. Set
+	// once via CompareAndSwap and never updated after.
+	NotifyMaxBufferSize atomic.Uint32
 }
 
 // OpenID returns a unique identifier for this open file handle.

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -385,9 +385,15 @@ type OpenFile struct {
 	// every reply via MIN). This is what gives the smb2.notify.valid-req
 	// "if the first notify returns NOTIFY_ENUM_DIR, all do" property: a
 	// tiny first buffer permanently caps later notifies on the same handle.
-	// Zero means no CHANGE_NOTIFY has been issued yet on this handle. Set
-	// once via CompareAndSwap and never updated after.
-	NotifyMaxBufferSize atomic.Uint32
+	//
+	// Encoding: SMB2 OutputBufferLength is uint32 and 0 is a valid request
+	// value (a peer may issue CHANGE_NOTIFY with OutputBufferLength=0), so
+	// we cannot use 0 as the "unset" sentinel. Instead we pack into a
+	// uint64: bit `notifyMaxBufferSizeSetBit` (1<<32) is set on the first
+	// capture, and the low 32 bits hold the captured OutputBufferLength.
+	// "Unset" is the all-zero value. Set once via CompareAndSwap(0, ...)
+	// and never updated after. Use `notifyMaxBufferSizeLoad` to decode.
+	NotifyMaxBufferSize atomic.Uint64
 }
 
 // OpenID returns a unique identifier for this open file handle.
@@ -398,6 +404,36 @@ func (f *OpenFile) OpenID() string {
 		f.cachedOpenID = fmt.Sprintf("%x", f.FileID)
 	}
 	return f.cachedOpenID
+}
+
+// notifyMaxBufferSizeSetBit marks the NotifyMaxBufferSize uint64 as having
+// been initialized by the first CHANGE_NOTIFY on the handle. The low 32 bits
+// of the same uint64 hold the captured OutputBufferLength (which may legally
+// be zero — see the field comment for the encoding rationale).
+const notifyMaxBufferSizeSetBit uint64 = 1 << 32
+
+// CaptureNotifyMaxBufferSize atomically records the OutputBufferLength of the
+// first CHANGE_NOTIFY on this handle. Returns the captured value (low 32 bits)
+// and true if this call performed the capture, or the previously-captured
+// value and false if a prior CHANGE_NOTIFY already set it. Safe for
+// concurrent callers; only the first wins.
+func (f *OpenFile) CaptureNotifyMaxBufferSize(outputBufferLength uint32) (captured uint32, didCapture bool) {
+	packed := notifyMaxBufferSizeSetBit | uint64(outputBufferLength)
+	if f.NotifyMaxBufferSize.CompareAndSwap(0, packed) {
+		return outputBufferLength, true
+	}
+	return uint32(f.NotifyMaxBufferSize.Load()), false
+}
+
+// NotifyMaxBufferSizeValue returns the captured first-CHANGE_NOTIFY
+// OutputBufferLength and whether it has been set yet. Returns (0, false)
+// before the first CHANGE_NOTIFY on this handle.
+func (f *OpenFile) NotifyMaxBufferSizeValue() (value uint32, set bool) {
+	raw := f.NotifyMaxBufferSize.Load()
+	if raw&notifyMaxBufferSizeSetBit == 0 {
+		return 0, false
+	}
+	return uint32(raw), true
 }
 
 // lastDeniedLock tracks the last denied lock request per open for

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -484,12 +484,12 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	// is the mechanism behind smb2.notify.valid-req's "if the first notify
 	// returns NOTIFY_ENUM_DIR, all do": a tiny first buffer caps every
 	// later notify on the same handle, so even a max-sized follow-up
-	// overflows. Capture on first call via CompareAndSwap; cap thereafter.
+	// overflows. Capture on first call; cap thereafter. OutputBufferLength=0
+	// is a valid SMB2 request so we cannot encode "unset" as 0 — see the
+	// NotifyMaxBufferSize field comment / CaptureNotifyMaxBufferSize helper.
 	effectiveMax := req.OutputBufferLength
-	if !openFile.NotifyMaxBufferSize.CompareAndSwap(0, effectiveMax) {
-		if stored := openFile.NotifyMaxBufferSize.Load(); stored < effectiveMax {
-			effectiveMax = stored
-		}
+	if stored, didCapture := openFile.CaptureNotifyMaxBufferSize(effectiveMax); !didCapture && stored < effectiveMax {
+		effectiveMax = stored
 	}
 
 	// Generate a unique AsyncId for this pending request.

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -477,6 +477,21 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewResult(types.StatusNotifyEnumDir, respBytes), nil
 	}
 
+	// Per Samba `change_notify_create` (source3/smbd/notify.c): the
+	// notify_buffer's max_buffer_size is set from the FIRST CHANGE_NOTIFY
+	// on the handle and reused for every subsequent notify via
+	// MIN(request.OutputBufferLength, notify_buffer.max_buffer_size). This
+	// is the mechanism behind smb2.notify.valid-req's "if the first notify
+	// returns NOTIFY_ENUM_DIR, all do": a tiny first buffer caps every
+	// later notify on the same handle, so even a max-sized follow-up
+	// overflows. Capture on first call via CompareAndSwap; cap thereafter.
+	effectiveMax := req.OutputBufferLength
+	if !openFile.NotifyMaxBufferSize.CompareAndSwap(0, effectiveMax) {
+		if stored := openFile.NotifyMaxBufferSize.Load(); stored < effectiveMax {
+			effectiveMax = stored
+		}
+	}
+
 	// Generate a unique AsyncId for this pending request.
 	// Per MS-SMB2 3.3.5.15, the server assigns an AsyncId and sends an
 	// interim response with STATUS_PENDING. The same AsyncId is used in
@@ -493,13 +508,9 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		ShareName:        openFile.ShareName,
 		CompletionFilter: req.CompletionFilter,
 		WatchTree:        req.Flags&SMB2WatchTree != 0,
-		MaxOutputLength:  req.OutputBufferLength,
-		AsyncCallback:    ctx.AsyncNotifyCallback,
-		OnOverflow: func(fileID [16]byte) {
-			if of, ok := h.GetOpenFile(fileID); ok {
-				of.NotifyOverflowed.Store(true)
-			}
-		},
+		// Use the per-handle MIN-capped max (Samba notify_buffer semantics).
+		MaxOutputLength: effectiveMax,
+		AsyncCallback:   ctx.AsyncNotifyCallback,
 	}
 
 	// Per MS-SMB2 §3.3.5.2.5: enforce max_async_credits before going async.
@@ -524,6 +535,8 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		"share", openFile.ShareName,
 		"filter", fmt.Sprintf("0x%08X", req.CompletionFilter),
 		"recursive", notify.WatchTree,
+		"reqBufLen", req.OutputBufferLength,
+		"effectiveBufLen", effectiveMax,
 		"messageID", ctx.MessageID,
 		"asyncId", asyncId,
 		"asyncEnabled", hasAsyncCallback)


### PR DESCRIPTION
## Summary

Replaces the per-handle sticky-overflow flag from #608 with a per-handle sticky `max_buffer_size`, mirroring Samba `change_notify_create` / `change_notify_reply` (`source3/smbd/notify.c`).

The first `CHANGE_NOTIFY` on a directory handle captures `req.OutputBufferLength` into `OpenFile.NotifyMaxBufferSize`; every subsequent notify on the same handle is `MIN`-capped against that stored value. The stored value is never updated after the first call.

## Root cause

`smb2.notify.valid-req` (Samba `source4/torture/smb2/notify.c::test_valid_request`) issues this sequence on one handle:

1. notify(max_buffer_size) - expect `OK` + 1 change
2. notify(0) - expect `NOTIFY_ENUM_DIR` (buffer too small)
3. notify(max_buffer_size) - expect `OK` + 3 changes ← we were returning `ENUM_DIR`

The #608 fix set a sticky `NotifyOverflowed` boolean whenever a notify returned `NOTIFY_ENUM_DIR`, consuming it on the next call. That made step 3 fail because the flag from step 2's legitimate overflow stuck around and pre-empted a valid request.

Samba's actual mechanism is different: `notify_buffer.max_buffer_size` is set once on `change_notify_create` and applied via `MIN(max_param, notify_buf->max_buffer_size)` in `change_notify_reply`. This still satisfies "if the first notify returns `NOTIFY_ENUM_DIR`, all do" (the test's later assertion across a reopen): a small first buffer permanently caps every later notify, so even a max-sized follow-up overflows. But it does not falsely reject a notify whose effective cap fits its changes.

## Changes

- `OpenFile.NotifyOverflowed atomic.Bool` -> `OpenFile.NotifyMaxBufferSize atomic.Uint32` (zero = unset)
- `ChangeNotify` handler captures via `CompareAndSwap(0, req.OutputBufferLength)` on first call, then `min(req.OutputBufferLength, stored)` for the effective max passed to the registered `PendingNotify`
- Drop the now-dead `OnOverflow` hook on `PendingNotify` and its plumbing
- Update existing registry overflow test (was asserting the now-removed hook fired)

## Tests

Two new handler-level tests in `change_notify_test.go`:

- `TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq` - first notify with `outBufLen=1` is captured; second notify with `MaxTransactSize` is accepted (`STATUS_PENDING`, not `STATUS_INVALID_PARAMETER`) and `PendingNotify.MaxOutputLength` is `MIN`-capped to 1
- `TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest` - asymmetric cap: smaller subsequent request is honored; stored value is not updated

## Test plan

- [x] `go test ./internal/adapter/smb/... -race` clean
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [ ] CI smbtorture: `smb2.notify.valid-req` flips PASS; no regressions in `smb2.notify.*`