### PR TITLE
fix(smb/notify): buffer events while handle is armed but unwatched

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -724,29 +724,21 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 // flagged, OnOverflow fires once and the entry's Overflowed flag latches
 // until the next CHANGE_NOTIFY consumes the sticky bit (which calls
 // ResetArmedOverflow).
+//
+// The encoded size is computed PER-WATCHER: each armed handle's FileName
+// field carries a watcher-relative path (relativePathFromWatch), so a
+// recursive watcher rooted at "/" sees "subdir/file.txt" while an exact
+// watcher on "/subdir" sees "file.txt". Charging the bare fileName against
+// every handle would systematically undercount for ancestor / WatchTree
+// watchers (PR #613 Copilot review) and let the overflow latch later than
+// a real FILE_NOTIFY_INFORMATION marshal — Samba's notify_marshall_changes
+// (source3/smbd/notify.c) likewise marshals the stored per-watcher name,
+// with UTF-16 length doubling and a 4-byte alignment pad.
 func (r *NotifyRegistry) chargeArmedBuffer(
 	shareName, parentPath string, action uint32,
 	candidateNames []string,
 	skipFileIDs map[[16]byte]struct{},
 ) {
-	// Estimate encoded size: each entry is at least minNotifyEntryBytes
-	// (12-byte header + ≥2-byte name + ≤2-byte padding). We don't UTF-16
-	// encode here because the goal is a conservative upper bound; under-
-	// charging would let the test miss the overflow trip, overcharging
-	// would flip overflow on tiny event bursts that a real encoder would
-	// have fit.
-	var addBytes uint32
-	for _, name := range candidateNames {
-		entry := uint32(12 + 2*max(len(name), 1))
-		if entry%4 != 0 {
-			entry += 4 - (entry % 4)
-		}
-		if entry < minNotifyEntryBytes {
-			entry = minNotifyEntryBytes
-		}
-		addBytes += entry
-	}
-
 	type pendingFire struct {
 		fn OnOverflow
 		id [16]byte
@@ -780,6 +772,14 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 		if a.Overflowed {
 			continue
 		}
+		// Size against THIS watcher's view: relativePathFromWatch is what
+		// the real marshal would put on the wire for this handle, so it's
+		// also what should accumulate toward MaxOutputLength.
+		var addBytes uint32
+		for _, name := range candidateNames {
+			relName := relativePathFromWatch(a.WatchPath, parentPath, name)
+			addBytes += encodedNotifyEntrySize(relName)
+		}
 		a.BufferedBytes += addBytes
 		if a.MaxOutputLength == 0 || a.BufferedBytes > a.MaxOutputLength {
 			a.Overflowed = true
@@ -795,6 +795,27 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 	for _, f := range toFire {
 		f.fn(f.id)
 	}
+}
+
+// encodedNotifyEntrySize returns the wire size of a single
+// FILE_NOTIFY_INFORMATION entry whose FileName is name (MS-FSCC §2.4.42):
+// 12-byte fixed header (NextEntryOffset | Action | FileNameLength) plus the
+// UTF-16LE filename bytes, aligned up to 4 bytes. Empty names are charged
+// the minNotifyEntryBytes floor to avoid undercounting a sentinel-encoded
+// entry on the wire.
+func encodedNotifyEntrySize(name string) uint32 {
+	nameBytes := 2 * uint32(len(utf16.Encode([]rune(name))))
+	if nameBytes == 0 {
+		nameBytes = 2
+	}
+	entry := 12 + nameBytes
+	if entry%4 != 0 {
+		entry += 4 - (entry % 4)
+	}
+	if entry < minNotifyEntryBytes {
+		entry = minNotifyEntryBytes
+	}
+	return entry
 }
 
 // pathIsAncestor reports whether ancestor is a path-prefix of descendant

--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -729,9 +729,6 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 	candidateNames []string,
 	skipFileIDs map[[16]byte]struct{},
 ) {
-	if len(r.armed) == 0 {
-		return
-	}
 	// Estimate encoded size: each entry is at least minNotifyEntryBytes
 	// (12-byte header + ≥2-byte name + ≤2-byte padding). We don't UTF-16
 	// encode here because the goal is a conservative upper bound; under-
@@ -750,9 +747,16 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 		addBytes += entry
 	}
 
-	var toFireOverflow []OnOverflow
-	var fireFileIDs [][16]byte
+	type pendingFire struct {
+		fn OnOverflow
+		id [16]byte
+	}
+	var toFire []pendingFire
 	r.mu.Lock()
+	if len(r.armed) == 0 {
+		r.mu.Unlock()
+		return
+	}
 	for _, a := range r.armed {
 		if a.ShareName != shareName {
 			continue
@@ -780,8 +784,7 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 		if a.MaxOutputLength == 0 || a.BufferedBytes > a.MaxOutputLength {
 			a.Overflowed = true
 			if a.OnOverflow != nil {
-				toFireOverflow = append(toFireOverflow, a.OnOverflow)
-				fireFileIDs = append(fireFileIDs, a.FileID)
+				toFire = append(toFire, pendingFire{fn: a.OnOverflow, id: a.FileID})
 			}
 		}
 	}
@@ -789,8 +792,8 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 
 	// Fire OnOverflow outside the lock — it touches OpenFile state through
 	// the Handler and we don't want to nest those locks under r.mu.
-	for i, fn := range toFireOverflow {
-		fn(fireFileIDs[i])
+	for _, f := range toFire {
+		f.fn(f.id)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -190,6 +190,47 @@ type NotifyRegistry struct {
 	// evicts them on Register (issue #416).
 	byMsgKey  map[notifyMsgKey]*PendingNotify
 	byAsyncId map[uint64]*PendingNotify // asyncId -> pending request (for async CANCEL)
+
+	// armed tracks directory handles that have at some point issued a
+	// CHANGE_NOTIFY. Mirrors Samba `notify_buffer`: once a watcher has been
+	// "armed" on a handle, subsequent matching filesystem events MUST be
+	// counted (and their would-be encoded size accumulated) even when no
+	// live PendingNotify is currently waiting. When the accumulated size
+	// would exceed the watcher's last MaxOutputLength, OnOverflow fires so
+	// the open handle's sticky-overflow flag is set; the next CHANGE_NOTIFY
+	// on the handle then returns STATUS_NOTIFY_ENUM_DIR with zero output
+	// (MS-SMB2 §3.3.5.19 / smb2.notify.overflow).
+	//
+	// Keyed by FileID string. Lifetime = handle: an entry survives across
+	// CANCEL and one-shot completion of pending notifies, and is only torn
+	// down by Disarm (called from CLOSE and from session/tree teardown).
+	armed map[string]*armedHandle
+}
+
+// armedHandle records the buffered-events accounting for a single open
+// directory handle that has ever armed a CHANGE_NOTIFY. See NotifyRegistry.armed.
+type armedHandle struct {
+	FileID           [16]byte
+	SessionID        uint64
+	ShareName        string
+	WatchPath        string
+	CompletionFilter uint32
+	WatchTree        bool
+	// MaxOutputLength is the most recent OutputBufferLength advertised by a
+	// CHANGE_NOTIFY on this handle. The overflow threshold is recomputed
+	// against this value on every event so a client that re-arms with a
+	// larger buffer can keep buffering rather than overflow at the old cap.
+	MaxOutputLength uint32
+	// BufferedBytes is the running estimate of how many bytes a paired
+	// FILE_NOTIFY_INFORMATION list of the buffered events would occupy.
+	BufferedBytes uint32
+	// OnOverflow is invoked exactly once (per arming) when BufferedBytes
+	// exceeds MaxOutputLength. Wires the handle-level sticky NotifyOverflowed
+	// flag — see OpenFile.NotifyOverflowed.
+	OnOverflow OnOverflow
+	// Overflowed is set on first overflow trip and prevents further
+	// OnOverflow invocations until Disarm/ResetArmedOverflow.
+	Overflowed bool
 }
 
 // notifyMsgKey identifies a pending notify by the tuple that uniquely names
@@ -206,6 +247,76 @@ func NewNotifyRegistry() *NotifyRegistry {
 		byFileID:  make(map[string]*PendingNotify),
 		byMsgKey:  make(map[notifyMsgKey]*PendingNotify),
 		byAsyncId: make(map[uint64]*PendingNotify),
+		armed:     make(map[string]*armedHandle),
+	}
+}
+
+// minNotifyEntryBytes is a lower-bound estimate of one encoded
+// FILE_NOTIFY_INFORMATION entry: 12-byte fixed header + at least one UTF-16
+// code unit + 4-byte alignment padding. Used to charge bytes against an
+// armed handle's MaxOutputLength when an event arrives without a live
+// watcher to encode against.
+const minNotifyEntryBytes uint32 = 16
+
+// armLocked records or refreshes the armed-handle entry for a pending
+// notify. Must be called with r.mu held.
+func (r *NotifyRegistry) armLocked(n *PendingNotify) {
+	key := string(n.FileID[:])
+	if existing, ok := r.armed[key]; ok {
+		// Refresh routing fields (path/filter/recursive can change across
+		// re-arms on the same handle, e.g. after a cancel) but preserve
+		// BufferedBytes and Overflowed so events that arrived in the gap
+		// still count.
+		existing.SessionID = n.SessionID
+		existing.ShareName = n.ShareName
+		existing.WatchPath = n.WatchPath
+		existing.CompletionFilter = n.CompletionFilter
+		existing.WatchTree = n.WatchTree
+		existing.MaxOutputLength = n.MaxOutputLength
+		if n.OnOverflow != nil {
+			existing.OnOverflow = n.OnOverflow
+		}
+		return
+	}
+	r.armed[key] = &armedHandle{
+		FileID:           n.FileID,
+		SessionID:        n.SessionID,
+		ShareName:        n.ShareName,
+		WatchPath:        n.WatchPath,
+		CompletionFilter: n.CompletionFilter,
+		WatchTree:        n.WatchTree,
+		MaxOutputLength:  n.MaxOutputLength,
+		OnOverflow:       n.OnOverflow,
+	}
+}
+
+// Disarm tears down the buffered-event accounting for a directory handle.
+// Called from CLOSE and from session/tree teardown. After Disarm, no further
+// matching events will be counted against this handle until a new
+// CHANGE_NOTIFY re-arms it. Returns true if an entry was removed.
+func (r *NotifyRegistry) Disarm(fileID [16]byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := string(fileID[:])
+	if _, ok := r.armed[key]; !ok {
+		return false
+	}
+	delete(r.armed, key)
+	return true
+}
+
+// ResetArmedOverflow clears the buffered-byte counter and overflow flag for
+// a directory handle while keeping it armed. Called by the handler after
+// it has consumed the sticky overflow flag and responded with
+// STATUS_NOTIFY_ENUM_DIR — the next event must once again accumulate from
+// zero against the freshly advertised MaxOutputLength.
+func (r *NotifyRegistry) ResetArmedOverflow(fileID [16]byte, newMaxOutputLength uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if a, ok := r.armed[string(fileID[:])]; ok {
+		a.BufferedBytes = 0
+		a.Overflowed = false
+		a.MaxOutputLength = newMaxOutputLength
 	}
 }
 
@@ -249,6 +360,15 @@ func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 	r.byMsgKey[msgKey] = notify
 	r.byAsyncId[notify.AsyncId] = notify
 	r.pending[notify.WatchPath] = append(r.pending[notify.WatchPath], notify)
+
+	// Arm the handle for buffered-event accounting. The armed entry survives
+	// across CANCEL and one-shot completion of this pending notify; only
+	// CLOSE or session/tree teardown disarms it. If the handle was already
+	// armed (re-issued CHANGE_NOTIFY after a CANCEL or after a successful
+	// async completion), refresh the MaxOutputLength but preserve the
+	// running BufferedBytes / Overflowed state — events accumulated while
+	// the client wasn't waiting must continue to count.
+	r.armLocked(notify)
 
 	logger.Debug("NotifyRegistry: registered watch",
 		"path", notify.WatchPath,
@@ -506,6 +626,10 @@ func EncodeFileNotifyInformation(changes []FileNotifyInformation) []byte {
 func (r *NotifyRegistry) NotifyChange(shareName, parentPath, fileName string, action uint32) {
 	r.mu.RLock()
 	watchers := r.findWatchersLocked(shareName, parentPath, action)
+	liveFileIDs := make(map[[16]byte]struct{}, len(watchers))
+	for _, w := range watchers {
+		liveFileIDs[w.notify.FileID] = struct{}{}
+	}
 	r.mu.RUnlock()
 
 	for _, w := range watchers {
@@ -515,6 +639,11 @@ func (r *NotifyRegistry) NotifyChange(shareName, parentPath, fileName string, ac
 		}
 		r.sendAndUnregister(w.notify, changes, actionToString(action))
 	}
+
+	// Charge against armed-but-unsatisfied handles so subsequent events
+	// while the client isn't waiting still count toward overflow. Handles
+	// with a live watcher were already serviced above and are excluded.
+	r.chargeArmedBuffer(shareName, parentPath, action, []string{fileName}, liveFileIDs)
 }
 
 // NotifyRename records a rename event as a paired FILE_NOTIFY_INFORMATION response.
@@ -557,12 +686,17 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 		}
 	}
 
+	combined := append(oldWatchers, newWatchers...)
+	liveFileIDs := make(map[[16]byte]struct{}, len(combined))
+	for _, w := range combined {
+		liveFileIDs[w.notify.FileID] = struct{}{}
+	}
 	r.mu.RUnlock()
 
 	// Send paired rename notifications for all matched watchers.
 	// Both old and new names are computed relative to each watcher's watch path,
 	// so recursive watchers at higher-level directories report correct paths.
-	for _, w := range append(oldWatchers, newWatchers...) {
+	for _, w := range combined {
 		oldRelativePath := relativePathFromWatch(w.watchPath, oldParentPath, oldFileName)
 		newRelativePath := relativePathFromWatch(w.watchPath, newParentPath, newFileName)
 		changes := []FileNotifyInformation{
@@ -571,6 +705,108 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 		}
 		r.sendAndUnregister(w.notify, changes, "RENAME")
 	}
+
+	// Charge against any armed handles that did not have a live waiter.
+	// Both directories are checked so handles armed on either end of a
+	// cross-directory rename are accounted for.
+	r.chargeArmedBuffer(shareName, oldParentPath, FileActionRenamedOldName, []string{oldFileName, newFileName}, liveFileIDs)
+	if newParentPath != oldParentPath {
+		r.chargeArmedBuffer(shareName, newParentPath, FileActionRenamedNewName, []string{oldFileName, newFileName}, liveFileIDs)
+	}
+}
+
+// chargeArmedBuffer charges the byte cost of a not-yet-delivered set of
+// FILE_NOTIFY_INFORMATION entries against every armed handle whose
+// (share, path, filter, WatchTree) tuple would have matched. Handles that
+// already had a live waiter (passed via skipFileIDs) are excluded because
+// the live path already delivered the event one-shot. If the running
+// total crosses the handle's MaxOutputLength and the handle isn't already
+// flagged, OnOverflow fires once and the entry's Overflowed flag latches
+// until the next CHANGE_NOTIFY consumes the sticky bit (which calls
+// ResetArmedOverflow).
+func (r *NotifyRegistry) chargeArmedBuffer(
+	shareName, parentPath string, action uint32,
+	candidateNames []string,
+	skipFileIDs map[[16]byte]struct{},
+) {
+	if len(r.armed) == 0 {
+		return
+	}
+	// Estimate encoded size: each entry is at least minNotifyEntryBytes
+	// (12-byte header + ≥2-byte name + ≤2-byte padding). We don't UTF-16
+	// encode here because the goal is a conservative upper bound; under-
+	// charging would let the test miss the overflow trip, overcharging
+	// would flip overflow on tiny event bursts that a real encoder would
+	// have fit.
+	var addBytes uint32
+	for _, name := range candidateNames {
+		entry := uint32(12 + 2*max(len(name), 1))
+		if entry%4 != 0 {
+			entry += 4 - (entry % 4)
+		}
+		if entry < minNotifyEntryBytes {
+			entry = minNotifyEntryBytes
+		}
+		addBytes += entry
+	}
+
+	var toFireOverflow []OnOverflow
+	var fireFileIDs [][16]byte
+	r.mu.Lock()
+	for _, a := range r.armed {
+		if a.ShareName != shareName {
+			continue
+		}
+		if _, live := skipFileIDs[a.FileID]; live {
+			continue
+		}
+		// Match path scope: exact match always counts; ancestor paths only
+		// count when WatchTree is set.
+		if a.WatchPath != parentPath {
+			if !a.WatchTree {
+				continue
+			}
+			if !pathIsAncestor(a.WatchPath, parentPath) {
+				continue
+			}
+		}
+		if !MatchesFilter(action, a.CompletionFilter) {
+			continue
+		}
+		if a.Overflowed {
+			continue
+		}
+		a.BufferedBytes += addBytes
+		if a.MaxOutputLength == 0 || a.BufferedBytes > a.MaxOutputLength {
+			a.Overflowed = true
+			if a.OnOverflow != nil {
+				toFireOverflow = append(toFireOverflow, a.OnOverflow)
+				fireFileIDs = append(fireFileIDs, a.FileID)
+			}
+		}
+	}
+	r.mu.Unlock()
+
+	// Fire OnOverflow outside the lock — it touches OpenFile state through
+	// the Handler and we don't want to nest those locks under r.mu.
+	for i, fn := range toFireOverflow {
+		fn(fireFileIDs[i])
+	}
+}
+
+// pathIsAncestor reports whether ancestor is a path-prefix of descendant
+// at a directory boundary. "/" is treated as an ancestor of every path.
+func pathIsAncestor(ancestor, descendant string) bool {
+	if ancestor == "" || ancestor == "/" {
+		return descendant != "" && descendant != "/"
+	}
+	if !strings.HasPrefix(descendant, ancestor) {
+		return false
+	}
+	if len(descendant) == len(ancestor) {
+		return false
+	}
+	return descendant[len(ancestor)] == '/'
 }
 
 // watcherMatch pairs a matched watcher with the watch path that matched it.
@@ -736,6 +972,13 @@ func (r *NotifyRegistry) UnregisterAllForSession(sessionID uint64) []*PendingNot
 	for _, w := range toRemove {
 		r.unregisterLocked(w)
 	}
+	// Disarm any handles armed by this session so their buffered-event
+	// accounting doesn't outlive the session that opened them.
+	for key, a := range r.armed {
+		if a.SessionID == sessionID {
+			delete(r.armed, key)
+		}
+	}
 	r.mu.Unlock()
 	return toRemove
 }
@@ -755,6 +998,11 @@ func (r *NotifyRegistry) UnregisterAllForTree(sessionID uint64, shareName string
 	}
 	for _, w := range toRemove {
 		r.unregisterLocked(w)
+	}
+	for key, a := range r.armed {
+		if a.SessionID == sessionID && a.ShareName == shareName {
+			delete(r.armed, key)
+		}
 	}
 	r.mu.Unlock()
 	return toRemove

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -1278,6 +1279,208 @@ func TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback(t *testin
 	}
 }
 
+// TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher reproduces the
+// smb2.notify.overflow torture flow: a CHANGE_NOTIFY arms the handle and is
+// then cancelled (no live watcher remains), 100 directory-create events
+// fire (each FILE_ACTION_ADDED), and the next CHANGE_NOTIFY on the handle
+// must observe the armed overflow trip via OnOverflow. The bug before the
+// fix was that NotifyChange short-circuited when no live watcher matched,
+// so events accumulated in the gap were never counted and the handle's
+// sticky overflow was never set.
+func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	fileID := [16]byte{0xCC}
+	var overflowFireCount int32
+	var lastOverflowFileID [16]byte
+
+	// Match the torture test parameters: 1000-byte buffer, recursive,
+	// FILE_NOTIFY_CHANGE_NAME (covered by FileNotifyChangeFileName |
+	// FileNotifyChangeDirName).
+	first := &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		ConnID:           1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/basedir_ovf",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName | FileNotifyChangeDirName,
+		WatchTree:        true,
+		MaxOutputLength:  1000,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			return nil
+		},
+		OnOverflow: func(id [16]byte) {
+			atomic.AddInt32(&overflowFireCount, 1)
+			lastOverflowFileID = id
+		},
+	}
+	mustRegister(t, r, first)
+
+	// Client cancels the initial notify (smbtorture does this to "set up
+	// the buffer"). Pending entry is removed but the handle stays armed.
+	if got := r.UnregisterByAsyncId(100); got == nil {
+		t.Fatalf("expected to unregister live watcher on cancel")
+	}
+
+	// Fire 100 FILE_ACTION_ADDED events on subdirs (mirroring the torture
+	// loop that creates 100 directories inside the watched root).
+	for i := 0; i < 100; i++ {
+		r.NotifyChange("share1", "/basedir_ovf", fmt.Sprintf("test%d.txt", i), FileActionAdded)
+	}
+
+	// Sticky overflow must have tripped exactly once.
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Fatalf("expected OnOverflow to fire exactly 1× across 100 events, got %d", overflowFireCount)
+	}
+	if lastOverflowFileID != fileID {
+		t.Errorf("expected OnOverflow with fileID %v, got %v", fileID, lastOverflowFileID)
+	}
+
+	// Disarm clears the armed slot — events fired after this must NOT
+	// re-trip overflow (the handle has been closed).
+	if !r.Disarm(fileID) {
+		t.Errorf("expected Disarm to report removal")
+	}
+	r.NotifyChange("share1", "/basedir_ovf", "post-close.txt", FileActionAdded)
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Errorf("expected no additional OnOverflow after Disarm, got count=%d", overflowFireCount)
+	}
+}
+
+// TestArmedBuffer_ResetClearsOverflowForNextWindow exercises the
+// ResetArmedOverflow path: after the handler consumes the sticky overflow
+// (returning STATUS_NOTIFY_ENUM_DIR) it must reset the armed counter so
+// the next batch of events accumulates against the freshly advertised
+// MaxOutputLength rather than re-tripping immediately.
+func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	fileID := [16]byte{0xDD}
+	var overflowFireCount int32
+
+	mustRegister(t, r, &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		ConnID:           1,
+		MessageID:        20,
+		AsyncId:          200,
+		WatchPath:        "/d",
+		ShareName:        "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  16, // overflow on the first event
+		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
+		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
+	})
+	if got := r.UnregisterByAsyncId(200); got == nil {
+		t.Fatalf("cancel")
+	}
+
+	// First event trips overflow.
+	r.NotifyChange("s", "/d", "a.txt", FileActionAdded)
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Fatalf("expected first event to trip overflow, count=%d", overflowFireCount)
+	}
+
+	// More events while overflowed must not re-fire OnOverflow.
+	for i := 0; i < 5; i++ {
+		r.NotifyChange("s", "/d", "b.txt", FileActionAdded)
+	}
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Errorf("expected overflow to latch (no re-fire), got count=%d", overflowFireCount)
+	}
+
+	// Client issues a new CHANGE_NOTIFY with a generous buffer; the handler
+	// consumes the sticky flag and resets the armed accounting.
+	r.ResetArmedOverflow(fileID, 64*1024)
+
+	// Single small event must NOT trip overflow against the new 64KB buffer.
+	r.NotifyChange("s", "/d", "c.txt", FileActionAdded)
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Errorf("expected no overflow after reset+small event, got count=%d", overflowFireCount)
+	}
+}
+
+// TestArmedBuffer_ScopedByShareAndPath confirms armed-handle accounting
+// respects ShareName, WatchPath, WatchTree, and CompletionFilter — events
+// on unrelated shares/paths/filters must not charge against an armed
+// handle. Guards against false-positive overflows on unrelated buckets.
+func TestArmedBuffer_ScopedByShareAndPath(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	fileID := [16]byte{0xEE}
+	var overflowFireCount int32
+
+	mustRegister(t, r, &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		ConnID:           1,
+		MessageID:        30,
+		AsyncId:          300,
+		WatchPath:        "/watched",
+		ShareName:        "share-a",
+		CompletionFilter: FileNotifyChangeFileName,
+		WatchTree:        false, // non-recursive
+		MaxOutputLength:  16,
+		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
+		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
+	})
+	if got := r.UnregisterByAsyncId(300); got == nil {
+		t.Fatalf("cancel")
+	}
+
+	// Different share — must not charge.
+	r.NotifyChange("share-b", "/watched", "x.txt", FileActionAdded)
+	// Subdirectory but non-recursive — must not charge.
+	r.NotifyChange("share-a", "/watched/sub", "x.txt", FileActionAdded)
+	// Wrong filter (Modified vs FileName) — must not charge.
+	r.NotifyChange("share-a", "/watched", "x.txt", FileActionModified)
+
+	if atomic.LoadInt32(&overflowFireCount) != 0 {
+		t.Errorf("expected no overflow on unrelated events, got count=%d", overflowFireCount)
+	}
+
+	// Matching event on the watched path — overflow must trip.
+	r.NotifyChange("share-a", "/watched", "x.txt", FileActionAdded)
+	if atomic.LoadInt32(&overflowFireCount) != 1 {
+		t.Errorf("expected overflow trip for matching event, got count=%d", overflowFireCount)
+	}
+}
+
+// TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent guards against
+// double-counting: the live-watcher one-shot path already encodes and
+// delivers the event, so the armed accounting must skip handles that just
+// fired (the armed entry will be torn down/replaced on the next Register).
+func TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	fileID := [16]byte{0xEF}
+	var overflowFireCount int32
+
+	mustRegister(t, r, &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		ConnID:           1,
+		MessageID:        40,
+		AsyncId:          400,
+		WatchPath:        "/d",
+		ShareName:        "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  16, // would overflow if double-counted
+		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
+		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
+	})
+
+	// Live watcher is present; one matching event fires through the live
+	// path (which itself overflows the 16-byte buffer → OnOverflow). The
+	// armed-accounting path must NOT also charge the event and double-fire.
+	r.NotifyChange("s", "/d", "a.txt", FileActionAdded)
+	if got := atomic.LoadInt32(&overflowFireCount); got != 1 {
+		t.Errorf("expected OnOverflow exactly 1× (live path only), got %d — armed path is double-counting", got)
+	}
+}
+
 func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	r := NewNotifyRegistry()
 
@@ -1301,5 +1504,127 @@ func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	watchers := r.GetWatchersForPath("/dir1")
 	if len(watchers) != 1 || watchers[0].ShareName != "share2" {
 		t.Errorf("expected share2 watcher to remain, got %d watchers", len(watchers))
+	}
+}
+
+// encodeChangeNotifyRequest builds a wire-format CHANGE_NOTIFY request body
+// per MS-SMB2 2.2.35 (fixed size 32 bytes). Used by handler-level tests that
+// exercise Handler.ChangeNotify through its parser.
+func encodeChangeNotifyRequest(flags uint16, outputBufferLength uint32, fileID [16]byte, completionFilter uint32) []byte {
+	body := make([]byte, 32)
+	// StructureSize = 32 (LE u16)
+	body[0] = 32
+	body[1] = 0
+	// Flags (LE u16)
+	body[2] = byte(flags)
+	body[3] = byte(flags >> 8)
+	// OutputBufferLength (LE u32)
+	body[4] = byte(outputBufferLength)
+	body[5] = byte(outputBufferLength >> 8)
+	body[6] = byte(outputBufferLength >> 16)
+	body[7] = byte(outputBufferLength >> 24)
+	// FileID (16 bytes)
+	copy(body[8:24], fileID[:])
+	// CompletionFilter (LE u32)
+	body[24] = byte(completionFilter)
+	body[25] = byte(completionFilter >> 8)
+	body[26] = byte(completionFilter >> 16)
+	body[27] = byte(completionFilter >> 24)
+	return body
+}
+
+// TestChangeNotify_HandlePermissions_GrantedAccessGate mirrors the smbtorture
+// smb2.notify.handle-permissions test (source4/torture/smb2/notify.c::
+// torture_smb2_notify_handle_permissions): a directory handle opened with only
+// FILE_READ_ATTRIBUTES (no FILE_LIST_DIRECTORY) MUST reject CHANGE_NOTIFY
+// with STATUS_ACCESS_DENIED per MS-SMB2 §3.3.5.19 / Samba
+// source3/smbd/notify.c::change_notify_create (check_any_access_fsp with
+// SEC_DIR_LIST). Refs #473.
+func TestChangeNotify_HandlePermissions_GrantedAccessGate(t *testing.T) {
+	const (
+		fileReadAttributes uint32 = 0x00000080 // SEC_FILE_READ_ATTRIBUTE
+		fileListDirectory  uint32 = 0x00000001 // SEC_DIR_LIST
+	)
+	fileID := [16]byte{0xAA, 0xBB, 0xCC, 0xDD}
+	const treeID uint32 = 1
+	const sessionID uint64 = 42
+
+	cases := []struct {
+		name          string
+		grantedAccess uint32
+		desiredAccess uint32
+		wantStatus    types.Status
+	}{
+		{
+			name:          "ReadAttributesOnly_Denied",
+			grantedAccess: fileReadAttributes,
+			desiredAccess: fileReadAttributes,
+			wantStatus:    types.StatusAccessDenied,
+		},
+		{
+			name:          "ListDirectory_Allowed",
+			grantedAccess: fileListDirectory | fileReadAttributes,
+			desiredAccess: fileListDirectory | fileReadAttributes,
+			wantStatus:    types.StatusPending,
+		},
+		{
+			// Regression: an open whose DesiredAccess carries
+			// FILE_LIST_DIRECTORY but whose DACL-resolved GrantedAccess
+			// stripped it (per-bit intersection at CREATE, MS-SMB2
+			// §3.3.5.9 paragraph 8) must still be rejected. The pre-fix
+			// gate consulted DesiredAccess and silently let this through.
+			name:          "DesiredHasListDir_GrantedDoesNot_Denied",
+			grantedAccess: fileReadAttributes,
+			desiredAccess: fileListDirectory | fileReadAttributes,
+			wantStatus:    types.StatusAccessDenied,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler()
+
+			h.StoreOpenFile(&OpenFile{
+				FileID:        fileID,
+				TreeID:        treeID,
+				SessionID:     sessionID,
+				Path:          "/HPERM",
+				ShareName:     "share1",
+				DesiredAccess: tc.desiredAccess,
+				GrantedAccess: tc.grantedAccess,
+				IsDirectory:   true,
+			})
+
+			ctx := &SMBHandlerContext{
+				SessionID:       sessionID,
+				TreeID:          treeID,
+				MessageID:       100,
+				TryReserveAsync: func() bool { return true },
+				ReleaseAsync:    func() {},
+			}
+
+			body := encodeChangeNotifyRequest(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName|FileNotifyChangeDirName)
+
+			result, err := h.ChangeNotify(ctx, body)
+			if err != nil {
+				t.Fatalf("ChangeNotify returned error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("ChangeNotify returned nil result")
+			}
+			if result.Status != tc.wantStatus {
+				t.Errorf("status = 0x%08x, want 0x%08x", uint32(result.Status), uint32(tc.wantStatus))
+			}
+
+			// On ACCESS_DENIED no watcher must have been registered (also
+			// guarantees no async slot was reserved beyond the pre-check).
+			watchers := h.NotifyRegistry.WatcherCount()
+			if tc.wantStatus == types.StatusAccessDenied && watchers != 0 {
+				t.Errorf("expected zero pending watchers after ACCESS_DENIED, got %d", watchers)
+			}
+			if tc.wantStatus == types.StatusPending && watchers != 1 {
+				t.Errorf("expected one pending watcher after STATUS_PENDING, got %d", watchers)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1481,6 +1481,90 @@ func TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent(t *testing.T) {
 	}
 }
 
+// TestArmedBuffer_RecursiveWatcherChargesRelativePath asserts the buffered-
+// byte accounting uses the per-watcher relative path (what would actually
+// be encoded into FILE_NOTIFY_INFORMATION.FileName), not the bare
+// fileName. A WatchTree watcher rooted at "/" that sees an event in a deep
+// subdirectory must accumulate the longer "subdir/file.txt" — not the
+// truncated "file.txt" — toward MaxOutputLength.
+//
+// Regression test for PR #613 Copilot review: charging the bare fileName
+// systematically undercounted recursive watchers and let overflow latch
+// later than a real marshal (or Samba notify_marshall_changes) would.
+func TestArmedBuffer_RecursiveWatcherChargesRelativePath(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	fileID := [16]byte{0xF0}
+	var overflowFireCount int32
+
+	// Pick MaxOutputLength so the bare-name accounting (12 + 2*1 = 14, pad
+	// to 16) would fit but the relative-path accounting (12 + 2*20 = 52,
+	// pad to 52) overflows on the first event.
+	//   bare "x.txt"            -> 12 + 2*5 = 22 → 24 bytes
+	//   relative "a/b/c/d/x.txt" -> 12 + 2*13 = 38 → 40 bytes
+	// Set MaxOutputLength=32 so bare would NOT trip but relative WILL.
+	mustRegister(t, r, &PendingNotify{
+		FileID:           fileID,
+		SessionID:        1,
+		ConnID:           1,
+		MessageID:        50,
+		AsyncId:          500,
+		WatchPath:        "/",
+		ShareName:        "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		WatchTree:        true,
+		MaxOutputLength:  32,
+		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
+		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
+	})
+	if r.UnregisterByAsyncId(500) == nil {
+		t.Fatalf("cancel pending watcher to leave handle armed-but-unwatched")
+	}
+
+	// Event in a deep subdir. Relative-from-root encoding is
+	// "a/b/c/d/x.txt" — 26 bytes UTF-16LE plus 12-byte header = 38, pad
+	// to 40. That single entry alone exceeds MaxOutputLength=32, so
+	// overflow must trip on this event.
+	r.NotifyChange("s", "/a/b/c/d", "x.txt", FileActionAdded)
+	if got := atomic.LoadInt32(&overflowFireCount); got != 1 {
+		t.Errorf("expected overflow to trip on first deep-path event (relative-path accounting), got count=%d — recursive watcher is undercounting", got)
+	}
+}
+
+// TestEncodedNotifyEntrySize_MatchesMarshaledSize asserts the byte estimate
+// used by chargeArmedBuffer agrees with the encoder for representative
+// names — guarding against drift between the accounting and the real wire
+// marshal (EncodeFileNotifyInformation).
+func TestEncodedNotifyEntrySize_MatchesMarshaledSize(t *testing.T) {
+	cases := []string{
+		"a",                 // 1 BMP rune → 12+2+pad(2) = 16
+		"file.txt",          // 8 BMP runes → 12+16 = 28 → pad to 28
+		"sub/deep/name.txt", // 17 BMP runes → 12+34 = 46 → pad to 48
+		"",                  // empty → floor = minNotifyEntryBytes
+		"é",                 // 1 BMP rune (precomposed) → 12+2+pad(2) = 16
+	}
+	for _, name := range cases {
+		got := encodedNotifyEntrySize(name)
+		marshaled := EncodeFileNotifyInformation([]FileNotifyInformation{
+			{Action: FileActionAdded, FileName: name},
+		})
+		want := uint32(len(marshaled))
+		// Single-entry marshal has NextEntryOffset=0 so the trailing pad
+		// is the only difference from a real "next entry follows" frame.
+		// For the empty-name floor case the estimator over-counts by
+		// design (sentinel-size); allow the estimator ≥ marshaled.
+		if name == "" {
+			if got < want {
+				t.Errorf("encodedNotifyEntrySize(%q) = %d < marshaled %d (must be ≥)", name, got, want)
+			}
+			continue
+		}
+		if got != want {
+			t.Errorf("encodedNotifyEntrySize(%q) = %d; marshaled = %d", name, got, want)
+		}
+	}
+}
+
 func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	r := NewNotifyRegistry()
 

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1497,12 +1497,13 @@ func TestArmedBuffer_RecursiveWatcherChargesRelativePath(t *testing.T) {
 	fileID := [16]byte{0xF0}
 	var overflowFireCount int32
 
-	// Pick MaxOutputLength so the bare-name accounting (12 + 2*1 = 14, pad
-	// to 16) would fit but the relative-path accounting (12 + 2*20 = 52,
-	// pad to 52) overflows on the first event.
-	//   bare "x.txt"            -> 12 + 2*5 = 22 → 24 bytes
-	//   relative "a/b/c/d/x.txt" -> 12 + 2*13 = 38 → 40 bytes
-	// Set MaxOutputLength=32 so bare would NOT trip but relative WILL.
+	// Pick MaxOutputLength so the bare-name accounting fits but the
+	// relative-path accounting overflows on the first event:
+	//   bare     "x.txt"          -> 12 + 2*5  = 22, pad to 24 bytes
+	//   relative "a/b/c/d/x.txt"  -> 12 + 2*13 = 38, pad to 40 bytes
+	// MaxOutputLength=32 leaves room for the bare-name entry but not the
+	// relative-path entry, so charging bare would NOT trip overflow and
+	// charging relative WILL.
 	mustRegister(t, r, &PendingNotify{
 		FileID:           fileID,
 		SessionID:        1,

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -407,6 +407,11 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// The watches are keyed by FileID, so closing the handle invalidates them.
 
 	if openFile.IsDirectory && h.NotifyRegistry != nil {
+		// Disarm buffered-event accounting first so any in-flight event
+		// after this point can't keep charging against a closed handle
+		// (the OnOverflow callback would race against DeleteOpenFile and
+		// touch a stale OpenFile struct).
+		h.NotifyRegistry.Disarm(req.FileID)
 		if notify := h.NotifyRegistry.Unregister(req.FileID); notify != nil {
 			// Per MS-SMB2 3.3.4.1 and 3.3.5.16.1: when the directory handle for
 			// a pending CHANGE_NOTIFY is closed, complete the request with

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -659,6 +659,7 @@ func (h *Handler) closeFilesWithFilter(
 		// pending request MUST complete with STATUS_NOTIFY_CLEANUP so the
 		// client's async recv unblocks (smb2.notify.tcon, .dir).
 		if h.NotifyRegistry != nil {
+			h.NotifyRegistry.Disarm(fileID)
 			if notify := h.NotifyRegistry.Unregister(fileID); notify != nil && notify.AsyncCallback != nil {
 				go func(n *PendingNotify) {
 					cleanupResp := &ChangeNotifyResponse{

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -387,15 +387,27 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	// Per MS-SMB2 3.3.5.15: The directory handle must have been opened
-	// with FILE_LIST_DIRECTORY (0x0001) access. Generic rights (GENERIC_READ,
-	// GENERIC_ALL, MAXIMUM_ALLOWED) implicitly include FILE_LIST_DIRECTORY
-	// for directories, so we check both specific and generic forms.
-	const listDirMask = 0x00000001 | 0x80000000 | 0x10000000 | 0x02000000 // FILE_LIST_DIRECTORY | GENERIC_READ | GENERIC_ALL | MAXIMUM_ALLOWED
-	hasListDir := openFile.DesiredAccess&listDirMask != 0
-	if !hasListDir {
+	// Per MS-SMB2 §3.3.5.19: the directory handle MUST have been opened with
+	// FILE_LIST_DIRECTORY (0x00000001) access; otherwise the server returns
+	// STATUS_ACCESS_DENIED. Mirrors Samba `source3/smbd/smb2_notify.c`
+	// (`smbd_smb2_notify_send` rejects when the open lacks
+	// SEC_DIR_LIST). Checked against Open.GrantedAccess — the per-bit
+	// intersection of the requested mask with the file's DACL resolved at
+	// CREATE (MS-SMB2 §3.3.5.9 paragraph 8). DesiredAccess is the pre-DACL
+	// request and can overstate what the handle actually holds, so the access
+	// gate MUST consult GrantedAccess to stay aligned with the spec and the
+	// open-level checks in §3.3.5.20.1 (QUERY_INFO) / §3.3.5.21 (SET_INFO).
+	// GENERIC_* bits and MAXIMUM_ALLOWED are already resolved to specific
+	// rights on GrantedAccess (acl.ExpandGenericMask at CREATE decode +
+	// resolveAccessFlags / CheckFileAccess at CREATE), so a single bit test
+	// against FILE_LIST_DIRECTORY is sufficient — smbtorture
+	// `smb2.notify.handle-permissions` opens with SEC_FILE_READ_ATTRIBUTE
+	// (0x80) only and expects STATUS_ACCESS_DENIED here.
+	const fileListDirectory uint32 = 0x00000001
+	if openFile.GrantedAccess&fileListDirectory == 0 {
 		logger.Debug("CHANGE_NOTIFY: missing FILE_LIST_DIRECTORY access",
 			"path", openFile.Path,
+			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess),
 			"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -420,11 +432,16 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	// Sticky overflow: a previous CHANGE_NOTIFY on this handle exceeded its
 	// buffer and completed with STATUS_NOTIFY_ENUM_DIR. Per Samba
-	// notify_buffer semantics and smb2.notify.valid-req, the next notify on
-	// the handle MUST also return ENUM_DIR (events were dropped, directory
-	// state is now inconsistent). Consume the flag and reply sync — the
-	// client's recv loop accepts either sync or async completion.
+	// notify_buffer semantics and smb2.notify.valid-req / .overflow, the
+	// next notify on the handle MUST also return ENUM_DIR (events were
+	// dropped, directory state is now inconsistent). Consume the flag and
+	// reply sync — the client's recv loop accepts either sync or async
+	// completion. Also reset the registry's buffered-event accounting so
+	// the buffer starts fresh with the newly advertised OutputBufferLength.
 	if openFile.NotifyOverflowed.CompareAndSwap(true, false) {
+		if h.NotifyRegistry != nil {
+			h.NotifyRegistry.ResetArmedOverflow(req.FileID, req.OutputBufferLength)
+		}
 		respBytes, err := (&ChangeNotifyResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
 		}).Encode()


### PR DESCRIPTION
## Summary

Fixes the `smb2.notify.overflow` torture test (refs #473). The #608 sticky-overflow fix only triggered when an event was delivered through a live `PendingNotify` whose encoded payload exceeded `MaxOutputLength`. The torture flow doesn't have a live waiter at overflow time:

1. CHANGE_NOTIFY (buffer=1000B, recursive, FILE_NOTIFY_CHANGE_NAME) — arms the buffer
2. CANCEL — pending notify removed, no live watcher
3. 100 directory creates fire (each is a FILE_ACTION_ADDED event)
4. CHANGE_NOTIFY again — expects `STATUS_NOTIFY_ENUM_DIR` with `num_changes == 0`

Without a live watcher in step 3, every event short-circuited out of `NotifyRegistry.NotifyChange` and was silently dropped — overflow never tripped, step 4 went `STATUS_PENDING` and the test hung.

## Fix

Mirror Samba's `notify_buffer` semantics with a per-handle "armed" accounting layer in `NotifyRegistry`:

- `Register` arms the FileID on first CHANGE_NOTIFY; the entry survives CANCEL and one-shot completion of the pending notify.
- `NotifyChange` / `NotifyRename` now charge the estimated encoded byte cost of each event against every armed handle whose `(share, path, filter, WatchTree)` tuple would have matched, skipping handles a live watcher just served (no double-counting).
- When the running total crosses the handle's last-advertised `MaxOutputLength`, `OnOverflow` latches the existing `OpenFile.NotifyOverflowed` flag from #608. The next CHANGE_NOTIFY consumes it and returns ENUM_DIR with zero output.
- `ResetArmedOverflow` clears the buffer when the handler consumes the sticky bit so the next window accumulates against the new buffer rather than re-tripping immediately.
- `CLOSE` (per-handle) and session/tree teardown call `Disarm` so post-close events can't race against a freed `OpenFile`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/adapter/smb/...` green
- [x] New unit tests in `change_notify_test.go`:
  - `TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher` — direct reproduction of the torture flow (arm → cancel → 100 events → expect 1× OnOverflow)
  - `TestArmedBuffer_ResetClearsOverflowForNextWindow` — `ResetArmedOverflow` lets a new wide buffer absorb events without re-tripping
  - `TestArmedBuffer_ScopedByShareAndPath` — share / non-recursive / wrong-filter events don't false-positive overflow
  - `TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent` — armed path defers to the live path when both could fire (no double overflow)
- [ ] CI smbtorture confirms `smb2.notify.overflow` flip