### PR TITLE
fix(smb/notify): sync NOTIFY_CLEANUP delivery in session cleanup

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1566,6 +1566,87 @@ func TestEncodedNotifyEntrySize_MatchesMarshaledSize(t *testing.T) {
 	}
 }
 
+// TestReleaseSessionLeasesAndNotifies_FiresCleanupSynchronously verifies that
+// pending CHANGE_NOTIFY watchers belonging to a session are completed with
+// STATUS_NOTIFY_CLEANUP SYNCHRONOUSLY — before releaseSessionLeasesAndNotifies
+// returns. This is critical for smb2.notify.session-reconnect (issue #473):
+// CleanupSession calls DeleteSession immediately after releasing notifies,
+// and SendMessage requires the session to still exist to sign the response.
+// An async (`go func`) delivery races with DeleteSession and emits an
+// unsigned response that the client rejects, hanging the test.
+func TestReleaseSessionLeasesAndNotifies_FiresCleanupSynchronously(t *testing.T) {
+	h := NewHandler()
+
+	const sessionID uint64 = 0xA1B2C3D4E5F60001
+
+	var firedCount atomic.Int32
+	var firedStatus atomic.Uint32
+	var firedSessionID atomic.Uint64
+	if err := h.NotifyRegistry.Register(&PendingNotify{
+		FileID:           [16]byte{1, 2, 3, 4},
+		SessionID:        sessionID,
+		ConnID:           1,
+		MessageID:        42,
+		AsyncId:          7,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		AsyncCallback: func(sid, _, _ uint64, response *ChangeNotifyResponse) error {
+			firedCount.Add(1)
+			firedStatus.Store(uint32(response.GetStatus()))
+			firedSessionID.Store(sid)
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	// A watcher belonging to a different session must NOT be fired.
+	const otherSessionID uint64 = 0xA1B2C3D4E5F60002
+	var otherFired atomic.Int32
+	if err := h.NotifyRegistry.Register(&PendingNotify{
+		FileID:           [16]byte{5, 6, 7, 8},
+		SessionID:        otherSessionID,
+		ConnID:           2,
+		MessageID:        99,
+		AsyncId:          17,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			otherFired.Add(1)
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Register(other) failed: %v", err)
+	}
+
+	// LeaseManager is nil on a fresh handler — exercise the notify branch only.
+	h.releaseSessionLeasesAndNotifies(t.Context(), sessionID)
+
+	// The cleanup callback MUST have fired by the time the call returns —
+	// no `go func`, no sleep, no eventually loop. Sync delivery is the fix.
+	if got := firedCount.Load(); got != 1 {
+		t.Fatalf("AsyncCallback fired %d times, want 1 synchronous fire", got)
+	}
+	if got := types.Status(firedStatus.Load()); got != types.StatusNotifyCleanup {
+		t.Errorf("callback received status 0x%08X, want STATUS_NOTIFY_CLEANUP (0x%08X)",
+			uint32(got), uint32(types.StatusNotifyCleanup))
+	}
+	if got := firedSessionID.Load(); got != sessionID {
+		t.Errorf("callback received sessionID 0x%X, want 0x%X (must be OLD session for signing)",
+			got, sessionID)
+	}
+	if got := otherFired.Load(); got != 0 {
+		t.Errorf("other-session watcher fired %d times, want 0 (cleanup must be scoped to sessionID)", got)
+	}
+	// Watcher must be unregistered so a subsequent CHANGE_NOTIFY on a new
+	// session can re-register without colliding on FileID.
+	if got := h.NotifyRegistry.WatcherCount(); got != 1 {
+		t.Errorf("WatcherCount = %d, want 1 (only the other-session watcher should remain)", got)
+	}
+}
+
 func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	r := NewNotifyRegistry()
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -831,21 +831,30 @@ func (h *Handler) releaseSessionLeasesAndNotifies(ctx context.Context, sessionID
 		// supersession), pending CHANGE_NOTIFY requests MUST complete with
 		// STATUS_NOTIFY_CLEANUP so the client unblocks its async recv.
 		// Mirrors the per-file path in close.go.
+		//
+		// Delivery is SYNCHRONOUS — the response carries the OLD session's
+		// SessionID and MUST be signed with that session's key. Our caller
+		// (CleanupSession on the PreviousSessionID path) deletes the session
+		// immediately after this returns; an async (`go func`) delivery would
+		// race with DeleteSession and send the response unsigned, which the
+		// client rejects. This is the missing piece behind
+		// smb2.notify.session-reconnect (issue #473): the client never sees
+		// the cleanup and hangs in smb2_notify_recv. The LOGOFF caller keeps
+		// the session alive for response signing anyway, so sync delivery is
+		// correct there as well.
 		for _, notify := range h.NotifyRegistry.UnregisterAllForSession(sessionID) {
 			if notify.AsyncCallback == nil {
 				continue
 			}
-			go func(n *PendingNotify) {
-				cleanupResp := &ChangeNotifyResponse{
-					SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyCleanup},
-				}
-				if err := n.AsyncCallback(n.SessionID, n.MessageID, n.AsyncId, cleanupResp); err != nil {
-					logger.Debug("session cleanup: failed to send STATUS_NOTIFY_CLEANUP",
-						"sessionID", n.SessionID,
-						"messageID", n.MessageID,
-						"error", err)
-				}
-			}(notify)
+			cleanupResp := &ChangeNotifyResponse{
+				SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyCleanup},
+			}
+			if err := notify.AsyncCallback(notify.SessionID, notify.MessageID, notify.AsyncId, cleanupResp); err != nil {
+				logger.Debug("session cleanup: failed to send STATUS_NOTIFY_CLEANUP",
+					"sessionID", notify.SessionID,
+					"messageID", notify.MessageID,
+					"error", err)
+			}
 		}
 	}
 	if h.PipeReadRegistry != nil {


### PR DESCRIPTION
## Summary

Fixes `smb2.notify.session-reconnect` (refs #473).

Per MS-SMB2 3.3.5.5.2/3, pending CHANGE_NOTIFY watchers on a destroyed session must complete with `STATUS_NOTIFY_CLEANUP`. The response carries the OLD session's SessionID and so must be signed with that session's key.

`CleanupSession` (PreviousSessionID path) calls `DeleteSession` immediately after `releaseSessionLeasesAndNotifies` returns. The previous code fired the `AsyncCallback` in a `go func`, racing with `DeleteSession`. The goroutine reached `SendMessage` after the session was gone, so `GetSession(hdr.SessionID)` returned nil and the response went out **unsigned**. The client (smbtorture) rejects unsigned responses on a signed session and hangs in `smb2_notify_recv`.

Switch delivery to synchronous so signing happens while the session still exists. LOGOFF and re-auth-failure callers keep the session alive for response signing anyway, so sync delivery is correct on those paths too.

## Notes

- `smb2.notify.invalid-reauth` is being handled by a parallel agent on a separate branch — this fix is scoped to the cleanup callback timing only and does not touch the re-auth path.
- The session-reconnect test currently never executes because `smb2.notify.dir` hangs earlier in the suite (separate flake, listed in KNOWN_FAILURES as #473). The fix here is verified by a synchronous-delivery unit test; a real wire flip will require fixing notify.dir first.

## Test plan

- [x] `go test ./internal/adapter/smb/... ./pkg/adapter/smb/... -race -count=1`
- [x] `go fmt ./... && go vet ./...`
- [x] New test `TestReleaseSessionLeasesAndNotifies_FiresCleanupSynchronously` asserts callback fires before the function returns, with the OLD SessionID and `STATUS_NOTIFY_CLEANUP`, and is scoped to the target session only.
- [ ] SMB conformance CI to confirm no regressions in other notify subtests.