### PR TITLE
fix(smb/session): destroy session on failed re-auth, complete pending notifies

### DIFF
--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -720,11 +720,11 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			// replace the existing session (including a guest downgrade).
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
+		// Re-auth with an unparseable TYPE_3 destroys the existing session
+		// per MS-SMB2 §3.3.5.5.3. Do not downgrade to guest — the original
+		// authenticated identity must not survive a failed re-auth.
 		if pending.IsReauth {
-			// Re-auth with an unparseable TYPE_3 destroys the existing session
-			// per MS-SMB2 §3.3.5.5.3. Do not downgrade to guest — the original
-			// authenticated identity must not survive a failed re-auth.
-			h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, "")
+			h.destroySessionOnReauthFailure(ctx.Context, pending, "")
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 		return h.createGuestSessionWithID(ctx, pending)
@@ -816,9 +816,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 						"serverChallenge", fmt.Sprintf("%x", pending.ServerChallenge),
 						"ntHashPrefix", fmt.Sprintf("%x", ntHash[:4]),
 						"pendingSessionID", pending.SessionID)
-					if pending.IsReauth {
-						h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
-					}
+					h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 					return NewErrorResult(types.StatusLogonFailure), nil
 				}
 
@@ -920,9 +918,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			logger.Debug("User not found in UserStore", "username", resolvedUsername, "error", err)
 		} else if user != nil && !user.Enabled {
 			logger.Debug("User account disabled", "username", resolvedUsername)
-			if pending.IsReauth {
-				h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
-			}
+			h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 
@@ -932,9 +928,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		if mappingFound {
 			logger.Info("Identity mapping resolved but user not found, denying access",
 				"principal", principal, "resolvedUsername", resolvedUsername)
-			if pending.IsReauth {
-				h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
-			}
+			h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 	}
@@ -947,7 +941,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 	// the pending CHANGE_NOTIFY must complete with STATUS_NOTIFY_CLEANUP
 	// and subsequent ops must return STATUS_USER_SESSION_DELETED.
 	if pending.IsReauth {
-		h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
+		h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 
@@ -961,7 +955,8 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 }
 
 // destroySessionOnReauthFailure tears down an existing session after its
-// re-authentication attempt failed.
+// re-authentication attempt failed. No-op when pending is not a re-auth, so
+// callers can invoke it unconditionally on every auth-failure path.
 //
 // Per MS-SMB2 §3.3.5.5.3, a failed re-auth MUST destroy the session: the
 // original authenticated identity does not survive bad credentials, and
@@ -979,16 +974,19 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 //
 // Reference: Samba source3/smbd/smb2_sesssetup.c — smbXsrv_session_logoff()
 // equivalent path runs on reauth_session_setup_fail.
-func (h *Handler) destroySessionOnReauthFailure(ctx context.Context, sessionID uint64, attemptedUsername string) {
+func (h *Handler) destroySessionOnReauthFailure(ctx context.Context, pending *PendingAuth, attemptedUsername string) {
+	if pending == nil || !pending.IsReauth {
+		return
+	}
 	logger.Info("Re-authentication failed, destroying session",
-		"sessionID", sessionID,
+		"sessionID", pending.SessionID,
 		"attemptedUsername", attemptedUsername)
-	if sess, ok := h.GetSession(sessionID); ok {
+	if sess, ok := h.GetSession(pending.SessionID); ok {
 		sess.LoggedOff.Store(true)
 	}
-	h.CloseAllFilesForSession(ctx, sessionID, false)
-	h.releaseSessionLeasesAndNotifies(ctx, sessionID)
-	h.DeleteAllTreesForSession(sessionID)
+	h.CloseAllFilesForSession(ctx, pending.SessionID, false)
+	h.releaseSessionLeasesAndNotifies(ctx, pending.SessionID)
+	h.DeleteAllTreesForSession(pending.SessionID)
 }
 
 // createGuestSessionWithID creates a guest session with a specific session ID.

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -719,6 +720,13 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			// replace the existing session (including a guest downgrade).
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
+		if pending.IsReauth {
+			// Re-auth with an unparseable TYPE_3 destroys the existing session
+			// per MS-SMB2 §3.3.5.5.3. Do not downgrade to guest — the original
+			// authenticated identity must not survive a failed re-auth.
+			h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, "")
+			return NewErrorResult(types.StatusLogonFailure), nil
+		}
 		return h.createGuestSessionWithID(ctx, pending)
 	}
 
@@ -809,23 +817,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 						"ntHashPrefix", fmt.Sprintf("%x", ntHash[:4]),
 						"pendingSessionID", pending.SessionID)
 					if pending.IsReauth {
-						// Per MS-SMB2 3.3.5.5.2: if re-authentication fails,
-						// the session MUST be deleted. Clean up resources and
-						// mark it as logged off so prepareDispatch rejects
-						// subsequent requests with STATUS_USER_SESSION_DELETED.
-						// The session itself is kept alive (not deleted from the
-						// session manager) so that in-flight goroutines can
-						// still sign their responses. Actual session deletion
-						// happens on connection close via cleanupSessions().
-						logger.Info("Re-authentication failed, destroying session",
-							"sessionID", pending.SessionID,
-							"username", authMsg.Username)
-						if sess, ok := h.GetSession(pending.SessionID); ok {
-							sess.LoggedOff.Store(true)
-						}
-						h.CloseAllFilesForSession(ctx.Context, pending.SessionID, false)
-						h.releaseSessionLeasesAndNotifies(ctx.Context, pending.SessionID)
-						h.DeleteAllTreesForSession(pending.SessionID)
+						h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
 					}
 					return NewErrorResult(types.StatusLogonFailure), nil
 				}
@@ -928,6 +920,9 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			logger.Debug("User not found in UserStore", "username", resolvedUsername, "error", err)
 		} else if user != nil && !user.Enabled {
 			logger.Debug("User account disabled", "username", resolvedUsername)
+			if pending.IsReauth {
+				h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
+			}
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 
@@ -937,8 +932,23 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		if mappingFound {
 			logger.Info("Identity mapping resolved but user not found, denying access",
 				"principal", principal, "resolvedUsername", resolvedUsername)
+			if pending.IsReauth {
+				h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
+			}
 			return NewErrorResult(types.StatusLogonFailure), nil
 		}
+	}
+
+	// Re-auth with credentials that don't resolve to any user (no UserStore,
+	// unknown principal, etc.) MUST destroy the existing session per
+	// MS-SMB2 §3.3.5.5.3 — silently downgrading to guest would let an
+	// attacker who knows a SessionID strip its authenticated identity.
+	// smb2.notify.invalid-reauth depends on this: after the failed re-auth
+	// the pending CHANGE_NOTIFY must complete with STATUS_NOTIFY_CLEANUP
+	// and subsequent ops must return STATUS_USER_SESSION_DELETED.
+	if pending.IsReauth {
+		h.destroySessionOnReauthFailure(ctx.Context, pending.SessionID, authMsg.Username)
+		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 
 	// Fall back to guest session (never for binding — a bind must only succeed
@@ -948,6 +958,37 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 	return h.createGuestSessionWithID(ctx, pending)
+}
+
+// destroySessionOnReauthFailure tears down an existing session after its
+// re-authentication attempt failed.
+//
+// Per MS-SMB2 §3.3.5.5.3, a failed re-auth MUST destroy the session: the
+// original authenticated identity does not survive bad credentials, and
+// silently downgrading to a guest session would let any client that knows
+// the SessionID strip authentication from another user's session.
+//
+// Resource cleanup mirrors transport-drop / explicit-LOGOFF (CleanupSession
+// and the LOGOFF handler): the session is marked LoggedOff so future
+// requests are rejected with STATUS_USER_SESSION_DELETED via prepareDispatch,
+// all open files are closed, leases are released, pending CHANGE_NOTIFY
+// requests complete with STATUS_NOTIFY_CLEANUP, tree connects are torn
+// down. The Session record itself is left in the session manager so any
+// in-flight handler goroutines can still sign their responses; the manager
+// entry is reaped on connection close via CleanupSession.
+//
+// Reference: Samba source3/smbd/smb2_sesssetup.c — smbXsrv_session_logoff()
+// equivalent path runs on reauth_session_setup_fail.
+func (h *Handler) destroySessionOnReauthFailure(ctx context.Context, sessionID uint64, attemptedUsername string) {
+	logger.Info("Re-authentication failed, destroying session",
+		"sessionID", sessionID,
+		"attemptedUsername", attemptedUsername)
+	if sess, ok := h.GetSession(sessionID); ok {
+		sess.LoggedOff.Store(true)
+	}
+	h.CloseAllFilesForSession(ctx, sessionID, false)
+	h.releaseSessionLeasesAndNotifies(ctx, sessionID)
+	h.DeleteAllTreesForSession(sessionID)
 }
 
 // createGuestSessionWithID creates a guest session with a specific session ID.

--- a/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/binary"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
 // encodeUTF16LEForTest encodes an ASCII string as UTF-16LE for embedding in
@@ -22,25 +24,30 @@ func encodeUTF16LEForTest(s string) []byte {
 	return buf
 }
 
-// buildMinimalNTLMAuthenticate builds an NTLM Type 3 (AUTHENTICATE) message
-// containing the given username and domain in UTF-16LE. Suitable for triggering
-// the user-not-found / re-auth-fails code path in completeNTLMAuth — no
-// NtChallengeResponse is included, so NTLMv2 validation does not run; the
-// flow lands on "user not found in UserStore" (which is the spec-equivalent
-// outcome for the invalid credentials the smbtorture invalid-reauth test
-// sends).
-func buildMinimalNTLMAuthenticate(username, domain string) []byte {
+// buildNTLMAuthenticateForTest builds an NTLM Type 3 (AUTHENTICATE) message
+// containing the given username and domain in UTF-16LE plus an optional
+// NtChallengeResponse blob. Use an empty ntResponse to skip NTLMv2 validation
+// (drives the "no NT response → user lookup only" path); pass a 24+ byte blob
+// to force ValidateNTLMv2Response to run (and, with garbage bytes, fail).
+func buildNTLMAuthenticateForTest(username, domain string, ntResponse []byte) []byte {
 	usernameBytes := encodeUTF16LEForTest(username)
 	domainBytes := encodeUTF16LEForTest(domain)
 
 	payloadOffset := 88
 	domainOffset := payloadOffset
 	userOffset := domainOffset + len(domainBytes)
+	ntRespOffset := userOffset + len(usernameBytes)
+	totalLen := ntRespOffset + len(ntResponse)
 
-	msg := make([]byte, userOffset+len(usernameBytes))
+	msg := make([]byte, totalLen)
 
 	copy(msg[0:8], auth.Signature)
 	binary.LittleEndian.PutUint32(msg[8:12], uint32(auth.Authenticate))
+
+	// NtChallengeResponse fields (length/maxLen/offset at 20..28)
+	binary.LittleEndian.PutUint16(msg[20:22], uint16(len(ntResponse)))
+	binary.LittleEndian.PutUint16(msg[22:24], uint16(len(ntResponse)))
+	binary.LittleEndian.PutUint32(msg[24:28], uint32(ntRespOffset))
 
 	// DomainName fields (length/maxLen/offset at 28..36)
 	binary.LittleEndian.PutUint16(msg[28:30], uint16(len(domainBytes)))
@@ -57,39 +64,52 @@ func buildMinimalNTLMAuthenticate(username, domain string) []byte {
 
 	copy(msg[domainOffset:], domainBytes)
 	copy(msg[userOffset:], usernameBytes)
+	copy(msg[ntRespOffset:], ntResponse)
 
 	return msg
 }
 
-// TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify mirrors the
-// smbtorture invalid-reauth wire flow at the unit-test boundary:
-//
-//  1. An authenticated session exists with a pending CHANGE_NOTIFY watcher.
-//  2. The client re-authenticates that session with invalid credentials —
-//     SESSION_SETUP carries an NTLM TYPE_1 first (re-auth handshake start),
-//     then a TYPE_3 with a username the UserStore does not know.
-//  3. The TYPE_3 must return STATUS_LOGON_FAILURE (per MS-SMB2 §3.3.5.5.3)
-//     and must NOT downgrade the session to guest.
-//  4. The pending CHANGE_NOTIFY MUST complete with STATUS_NOTIFY_CLEANUP.
-//  5. The session MUST be flagged LoggedOff so subsequent ops are rejected
-//     with STATUS_USER_SESSION_DELETED via prepareDispatch.
-//
-// Reference Samba test: source4/torture/smb2/notify.c::
-// torture_smb2_notify_invalid_reauth (the smb2.notify.invalid-reauth case
-// tracked under issue #473).
-func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) {
+// newInMemoryStoreForTest stands up an in-memory SQLite control-plane store
+// suitable for wiring into runtime.New(...). Tests use this when they need
+// completeNTLMAuth to take the userStore != nil branch (user-not-found,
+// user-disabled, NTLMv2-validation-failure).
+func newInMemoryStoreForTest(t *testing.T) store.Store {
+	t.Helper()
+	cfg := store.Config{
+		Type:   "sqlite",
+		SQLite: store.SQLiteConfig{Path: ":memory:"},
+	}
+	s, err := store.New(&cfg)
+	if err != nil {
+		t.Fatalf("store.New(:memory:): %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// reauthFixture sets up a pre-authenticated SMB2 session with a pending
+// CHANGE_NOTIFY watcher and primes a re-auth handshake (TYPE_1) so the test
+// can drive TYPE_3 with any payload. The returned cb fields capture the
+// notify completion status so the caller can assert STATUS_NOTIFY_CLEANUP.
+type reauthFixture struct {
+	h            *Handler
+	ctx          *SMBHandlerContext
+	sessionID    uint64
+	notifyFired  *atomic.Bool
+	notifyStatus *atomic.Uint32
+	authedUser   *models.User
+}
+
+// newReauthFixture seeds Handler state for the failed-re-auth scenarios.
+// store may be nil; pass a real store when the test needs the userStore != nil
+// branch in completeNTLMAuth.
+func newReauthFixture(t *testing.T, cpStore store.Store) *reauthFixture {
+	t.Helper()
 	h := NewHandler()
 	h.NotifyRegistry = NewNotifyRegistry()
 	h.NtlmEnabled = true
-	// completeNTLMAuth dereferences h.Registry.GetUserStore(); supply an
-	// empty Runtime so the "unknown user → fall through" path is exercised
-	// without needing a real backing store.
-	h.Registry = runtime.New(nil)
+	h.Registry = runtime.New(cpStore)
 
-	// Stand up an authenticated session as if a prior SESSION_SETUP had
-	// succeeded. We do not need a real UserStore entry to exist — the test
-	// drives the re-auth failure through the "no NTLMv2 validation possible
-	// → user not found" branch.
 	const sessionID = uint64(0xdeadbeef)
 	authedUser := &models.User{Username: "alice", Enabled: true}
 	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", authedUser, "")
@@ -97,11 +117,8 @@ func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) 
 		t.Fatal("seed session unexpectedly starts logged-off")
 	}
 
-	// Register a pending CHANGE_NOTIFY on a directory handle belonging to the
-	// session. The async callback records the status it was invoked with so
-	// the test can assert STATUS_NOTIFY_CLEANUP.
-	var notifyFired atomic.Bool
-	var notifyStatus atomic.Uint32
+	notifyFired := &atomic.Bool{}
+	notifyStatus := &atomic.Uint32{}
 	var fileID [16]byte
 	copy(fileID[:], []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08})
 	notify := &PendingNotify{
@@ -121,11 +138,10 @@ func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) 
 		t.Fatalf("Register pending notify: %v", err)
 	}
 
-	// Drive the re-auth TYPE_1 (NEGOTIATE) so the Handler stores a
-	// PendingAuth with IsReauth=true keyed to this session.
+	// Drive TYPE_1 (NEGOTIATE) so the Handler stores a PendingAuth keyed to
+	// this session with IsReauth=true.
 	ctx := newTestContext(sessionID)
-	negotiateBody := buildSessionSetupRequestBody(validNTLMNegotiateMessage())
-	negResult, err := h.SessionSetup(ctx, negotiateBody)
+	negResult, err := h.SessionSetup(ctx, buildSessionSetupRequestBody(validNTLMNegotiateMessage()))
 	if err != nil {
 		t.Fatalf("SESSION_SETUP TYPE_1 returned error: %v", err)
 	}
@@ -141,27 +157,34 @@ func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) 
 		t.Fatal("PendingAuth.IsReauth must be true on re-auth handshake")
 	}
 
-	// Drive the re-auth TYPE_3 (AUTHENTICATE) with a username the UserStore
-	// does not know — mirrors smbtorture's "__none__invalid__none__" creds.
-	type3Body := buildSessionSetupRequestBody(
-		buildMinimalNTLMAuthenticate("__none__invalid__none__", "__none__invalid__none__"),
-	)
-	authResult, err := h.SessionSetup(ctx, type3Body)
-	if err != nil {
-		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	return &reauthFixture{
+		h:            h,
+		ctx:          ctx,
+		sessionID:    sessionID,
+		notifyFired:  notifyFired,
+		notifyStatus: notifyStatus,
+		authedUser:   authedUser,
 	}
+}
 
-	// (a) Re-auth must fail with STATUS_LOGON_FAILURE — never silently
-	// downgrade to a guest session.
-	if authResult.Status != types.StatusLogonFailure {
+// assertSessionDestroyedAndNotifyCleaned verifies the post-conditions every
+// failed re-auth path MUST satisfy per MS-SMB2 §3.3.5.5.3:
+//
+//   - TYPE_3 response status is STATUS_LOGON_FAILURE (no guest downgrade).
+//   - Session record remains in the manager (so in-flight handler goroutines
+//     can still sign their responses) but is flagged LoggedOff so subsequent
+//     ops are rejected with STATUS_USER_SESSION_DELETED via prepareDispatch.
+//   - Pending CHANGE_NOTIFY completes with STATUS_NOTIFY_CLEANUP and the
+//     watcher is unregistered.
+func (f *reauthFixture) assertSessionDestroyedAndNotifyCleaned(t *testing.T, status types.Status) {
+	t.Helper()
+
+	if status != types.StatusLogonFailure {
 		t.Errorf("TYPE_3 status = 0x%x, want LOGON_FAILURE (0x%x) — failed re-auth must not downgrade to guest",
-			uint32(authResult.Status), uint32(types.StatusLogonFailure))
+			uint32(status), uint32(types.StatusLogonFailure))
 	}
 
-	// (b) The session record must remain in the manager (so in-flight
-	// goroutines can sign their responses) but be flagged LoggedOff so
-	// prepareDispatch rejects subsequent requests with USER_SESSION_DELETED.
-	gotSess, exists := h.GetSession(sessionID)
+	gotSess, exists := f.h.GetSession(f.sessionID)
 	if !exists {
 		t.Fatal("session disappeared from manager after failed re-auth; in-flight signing would break")
 	}
@@ -172,22 +195,161 @@ func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) 
 		t.Error("session was downgraded to guest after failed re-auth — must not happen per MS-SMB2 §3.3.5.5.3")
 	}
 
-	// (c) The pending CHANGE_NOTIFY must have been completed with
-	// STATUS_NOTIFY_CLEANUP. The cleanup is dispatched on a goroutine, so
-	// allow a brief settle window before failing — the test deadlocks would
-	// otherwise mask the real issue.
+	// notify cleanup is dispatched on a goroutine — settle briefly.
 	deadline := time.Now().Add(2 * time.Second)
-	for !notifyFired.Load() && time.Now().Before(deadline) {
+	for !f.notifyFired.Load() && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if !notifyFired.Load() {
+	if !f.notifyFired.Load() {
 		t.Fatal("pending CHANGE_NOTIFY was not completed after failed re-auth (expected STATUS_NOTIFY_CLEANUP)")
 	}
-	if got := types.Status(notifyStatus.Load()); got != types.StatusNotifyCleanup {
+	if got := types.Status(f.notifyStatus.Load()); got != types.StatusNotifyCleanup {
 		t.Errorf("CHANGE_NOTIFY completion status = 0x%08x, want STATUS_NOTIFY_CLEANUP (0x%08x)",
 			uint32(got), uint32(types.StatusNotifyCleanup))
 	}
-	if h.NotifyRegistry.WatcherCount() != 0 {
-		t.Errorf("notify watcher still registered after failed re-auth: %d", h.NotifyRegistry.WatcherCount())
+	if f.h.NotifyRegistry.WatcherCount() != 0 {
+		t.Errorf("notify watcher still registered after failed re-auth: %d", f.h.NotifyRegistry.WatcherCount())
 	}
+}
+
+// TestSessionSetup_FailedReauth_NoUserStore_DestroysSession exercises the
+// "no UserStore configured" tail of completeNTLMAuth — `runtime.New(nil)`
+// returns a nil userStore from GetUserStore, so the per-user lookup block
+// is skipped entirely and execution falls through to the final
+// `if pending.IsReauth { destroySessionOnReauthFailure(...) }` guard.
+//
+// This is the smbtorture invalid-reauth wire flow at its simplest: the
+// TYPE_3 carries a username DittoFS could not authenticate against (because
+// there's no userStore to authenticate against), so the session MUST be
+// destroyed rather than silently downgraded to guest.
+//
+// Reference Samba test: source4/torture/smb2/notify.c::
+// torture_smb2_notify_invalid_reauth (smb2.notify.invalid-reauth, #473).
+func TestSessionSetup_FailedReauth_NoUserStore_DestroysSession(t *testing.T) {
+	f := newReauthFixture(t, nil)
+
+	type3Body := buildSessionSetupRequestBody(
+		buildNTLMAuthenticateForTest("__none__invalid__none__", "__none__invalid__none__", nil),
+	)
+	result, err := f.h.SessionSetup(f.ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
+}
+
+// TestSessionSetup_FailedReauth_UnknownUser_DestroysSession covers the
+// userStore.GetUser() returns ErrUserNotFound branch: a real UserStore is
+// wired, but the principal in the TYPE_3 does not exist. Execution still
+// falls through to the final IsReauth guard (the lookup error logs at debug
+// and continues), and the session MUST be destroyed.
+func TestSessionSetup_FailedReauth_UnknownUser_DestroysSession(t *testing.T) {
+	f := newReauthFixture(t, newInMemoryStoreForTest(t))
+
+	type3Body := buildSessionSetupRequestBody(
+		buildNTLMAuthenticateForTest("nosuchuser", "WORKGROUP", nil),
+	)
+	result, err := f.h.SessionSetup(f.ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
+}
+
+// TestSessionSetup_FailedReauth_UserDisabled_DestroysSession covers the
+// "user found but !user.Enabled" branch (session_setup.go:919-923). This is
+// the only branch that calls destroySessionOnReauthFailure from INSIDE the
+// userStore != nil block (not via the fall-through tail), so it must be
+// exercised separately to defend against future refactors that accidentally
+// re-route disabled users to guest.
+func TestSessionSetup_FailedReauth_UserDisabled_DestroysSession(t *testing.T) {
+	cpStore := newInMemoryStoreForTest(t)
+	// Create then disable. GORM substitutes the `default:true` on Create
+	// when the bool is its zero value (same gotcha as the per-share ACL
+	// canonicalization toggle), so the disabled state must be applied via
+	// UpdateUser, which uses Select(...) and respects explicit false.
+	disabled := &models.User{Username: "bob", Enabled: true}
+	disabled.SetNTHashFromPassword("anyhash")
+	if _, err := cpStore.CreateUser(context.Background(), disabled); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	disabled.Enabled = false
+	if err := cpStore.UpdateUser(context.Background(), disabled); err != nil {
+		t.Fatalf("UpdateUser(Enabled=false): %v", err)
+	}
+
+	f := newReauthFixture(t, cpStore)
+
+	type3Body := buildSessionSetupRequestBody(
+		buildNTLMAuthenticateForTest("bob", "WORKGROUP", nil),
+	)
+	result, err := f.h.SessionSetup(f.ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
+}
+
+// TestSessionSetup_FailedReauth_NTLMv2ValidationFails_DestroysSession covers
+// the wrong-password branch: a real enabled user with an NT hash, but the
+// TYPE_3 carries a NtChallengeResponse that doesn't validate against
+// (ServerChallenge, ClientBlob, NTLMv2Hash). Hits the explicit
+// destroySessionOnReauthFailure at session_setup.go:819 rather than the
+// fall-through tail — this is the path that already existed before #473;
+// it's pinned here so the guarantee survives.
+func TestSessionSetup_FailedReauth_NTLMv2ValidationFails_DestroysSession(t *testing.T) {
+	cpStore := newInMemoryStoreForTest(t)
+	enabled := &models.User{
+		Username: "carol",
+		Enabled:  true,
+	}
+	enabled.SetNTHashFromPassword("the-real-password")
+	if _, err := cpStore.CreateUser(context.Background(), enabled); err != nil {
+		t.Fatalf("CreateUser(enabled): %v", err)
+	}
+
+	f := newReauthFixture(t, cpStore)
+
+	// 24 bytes of garbage as NtChallengeResponse — passes the length gate in
+	// ValidateNTLMv2Response (line 754) but fails the HMAC compare (line 773).
+	bogusNTResponse := make([]byte, 32)
+	for i := range bogusNTResponse {
+		bogusNTResponse[i] = 0xFF
+	}
+
+	type3Body := buildSessionSetupRequestBody(
+		buildNTLMAuthenticateForTest("carol", "WORKGROUP", bogusNTResponse),
+	)
+	result, err := f.h.SessionSetup(f.ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
+}
+
+// TestSessionSetup_FailedReauth_UnparseableType3_DestroysSession covers the
+// ParseAuthenticate failure branch (session_setup.go:715-729). An NTLM TYPE_3
+// header so short it fails to parse must also destroy the session — without
+// the IsReauth gate added in #473 this branch fell through to
+// createGuestSessionWithID and silently downgraded the existing identity.
+func TestSessionSetup_FailedReauth_UnparseableType3_DestroysSession(t *testing.T) {
+	f := newReauthFixture(t, nil)
+
+	// Valid NTLM signature + TYPE_3 type but missing all the field tables —
+	// ParseAuthenticate will reject it.
+	truncated := make([]byte, 12)
+	copy(truncated[0:8], auth.Signature)
+	binary.LittleEndian.PutUint32(truncated[8:12], uint32(auth.Authenticate))
+
+	type3Body := buildSessionSetupRequestBody(truncated)
+	result, err := f.h.SessionSetup(f.ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
 }

--- a/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
@@ -1,0 +1,193 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// encodeUTF16LEForTest encodes an ASCII string as UTF-16LE for embedding in
+// an NTLM AUTHENTICATE message.
+func encodeUTF16LEForTest(s string) []byte {
+	buf := make([]byte, len(s)*2)
+	for i, r := range s {
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(r))
+	}
+	return buf
+}
+
+// buildMinimalNTLMAuthenticate builds an NTLM Type 3 (AUTHENTICATE) message
+// containing the given username and domain in UTF-16LE. Suitable for triggering
+// the user-not-found / re-auth-fails code path in completeNTLMAuth — no
+// NtChallengeResponse is included, so NTLMv2 validation does not run; the
+// flow lands on "user not found in UserStore" (which is the spec-equivalent
+// outcome for the invalid credentials the smbtorture invalid-reauth test
+// sends).
+func buildMinimalNTLMAuthenticate(username, domain string) []byte {
+	usernameBytes := encodeUTF16LEForTest(username)
+	domainBytes := encodeUTF16LEForTest(domain)
+
+	payloadOffset := 88
+	domainOffset := payloadOffset
+	userOffset := domainOffset + len(domainBytes)
+
+	msg := make([]byte, userOffset+len(usernameBytes))
+
+	copy(msg[0:8], auth.Signature)
+	binary.LittleEndian.PutUint32(msg[8:12], uint32(auth.Authenticate))
+
+	// DomainName fields (length/maxLen/offset at 28..36)
+	binary.LittleEndian.PutUint16(msg[28:30], uint16(len(domainBytes)))
+	binary.LittleEndian.PutUint16(msg[30:32], uint16(len(domainBytes)))
+	binary.LittleEndian.PutUint32(msg[32:36], uint32(domainOffset))
+
+	// UserName fields (length/maxLen/offset at 36..44)
+	binary.LittleEndian.PutUint16(msg[36:38], uint16(len(usernameBytes)))
+	binary.LittleEndian.PutUint16(msg[38:40], uint16(len(usernameBytes)))
+	binary.LittleEndian.PutUint32(msg[40:44], uint32(userOffset))
+
+	// NegotiateFlags at offset 60 — Unicode strings, NTLM.
+	binary.LittleEndian.PutUint32(msg[60:64], uint32(auth.FlagUnicode|auth.FlagNTLM))
+
+	copy(msg[domainOffset:], domainBytes)
+	copy(msg[userOffset:], usernameBytes)
+
+	return msg
+}
+
+// TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify mirrors the
+// smbtorture invalid-reauth wire flow at the unit-test boundary:
+//
+//  1. An authenticated session exists with a pending CHANGE_NOTIFY watcher.
+//  2. The client re-authenticates that session with invalid credentials —
+//     SESSION_SETUP carries an NTLM TYPE_1 first (re-auth handshake start),
+//     then a TYPE_3 with a username the UserStore does not know.
+//  3. The TYPE_3 must return STATUS_LOGON_FAILURE (per MS-SMB2 §3.3.5.5.3)
+//     and must NOT downgrade the session to guest.
+//  4. The pending CHANGE_NOTIFY MUST complete with STATUS_NOTIFY_CLEANUP.
+//  5. The session MUST be flagged LoggedOff so subsequent ops are rejected
+//     with STATUS_USER_SESSION_DELETED via prepareDispatch.
+//
+// Reference Samba test: source4/torture/smb2/notify.c::
+// torture_smb2_notify_invalid_reauth (the smb2.notify.invalid-reauth case
+// tracked under issue #473).
+func TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.NtlmEnabled = true
+	// completeNTLMAuth dereferences h.Registry.GetUserStore(); supply an
+	// empty Runtime so the "unknown user → fall through" path is exercised
+	// without needing a real backing store.
+	h.Registry = runtime.New(nil)
+
+	// Stand up an authenticated session as if a prior SESSION_SETUP had
+	// succeeded. We do not need a real UserStore entry to exist — the test
+	// drives the re-auth failure through the "no NTLMv2 validation possible
+	// → user not found" branch.
+	const sessionID = uint64(0xdeadbeef)
+	authedUser := &models.User{Username: "alice", Enabled: true}
+	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", authedUser, "")
+	if sess.LoggedOff.Load() {
+		t.Fatal("seed session unexpectedly starts logged-off")
+	}
+
+	// Register a pending CHANGE_NOTIFY on a directory handle belonging to the
+	// session. The async callback records the status it was invoked with so
+	// the test can assert STATUS_NOTIFY_CLEANUP.
+	var notifyFired atomic.Bool
+	var notifyStatus atomic.Uint32
+	var fileID [16]byte
+	copy(fileID[:], []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08})
+	notify := &PendingNotify{
+		FileID:    fileID,
+		SessionID: sessionID,
+		MessageID: 100,
+		AsyncId:   200,
+		WatchPath: "/share/dir",
+		ShareName: "share",
+		AsyncCallback: func(sid, mid, aid uint64, resp *ChangeNotifyResponse) error {
+			notifyFired.Store(true)
+			notifyStatus.Store(uint32(resp.GetStatus()))
+			return nil
+		},
+	}
+	if err := h.NotifyRegistry.Register(notify); err != nil {
+		t.Fatalf("Register pending notify: %v", err)
+	}
+
+	// Drive the re-auth TYPE_1 (NEGOTIATE) so the Handler stores a
+	// PendingAuth with IsReauth=true keyed to this session.
+	ctx := newTestContext(sessionID)
+	negotiateBody := buildSessionSetupRequestBody(validNTLMNegotiateMessage())
+	negResult, err := h.SessionSetup(ctx, negotiateBody)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_1 returned error: %v", err)
+	}
+	if negResult.Status != types.StatusMoreProcessingRequired {
+		t.Fatalf("TYPE_1 status = 0x%x, want MORE_PROCESSING_REQUIRED (0x%x)",
+			negResult.Status, types.StatusMoreProcessingRequired)
+	}
+	pending, ok := h.GetPendingAuth(sessionID, ctx.ConnID)
+	if !ok {
+		t.Fatal("TYPE_1 did not store PendingAuth for re-auth")
+	}
+	if !pending.IsReauth {
+		t.Fatal("PendingAuth.IsReauth must be true on re-auth handshake")
+	}
+
+	// Drive the re-auth TYPE_3 (AUTHENTICATE) with a username the UserStore
+	// does not know — mirrors smbtorture's "__none__invalid__none__" creds.
+	type3Body := buildSessionSetupRequestBody(
+		buildMinimalNTLMAuthenticate("__none__invalid__none__", "__none__invalid__none__"),
+	)
+	authResult, err := h.SessionSetup(ctx, type3Body)
+	if err != nil {
+		t.Fatalf("SESSION_SETUP TYPE_3 returned error: %v", err)
+	}
+
+	// (a) Re-auth must fail with STATUS_LOGON_FAILURE — never silently
+	// downgrade to a guest session.
+	if authResult.Status != types.StatusLogonFailure {
+		t.Errorf("TYPE_3 status = 0x%x, want LOGON_FAILURE (0x%x) — failed re-auth must not downgrade to guest",
+			uint32(authResult.Status), uint32(types.StatusLogonFailure))
+	}
+
+	// (b) The session record must remain in the manager (so in-flight
+	// goroutines can sign their responses) but be flagged LoggedOff so
+	// prepareDispatch rejects subsequent requests with USER_SESSION_DELETED.
+	gotSess, exists := h.GetSession(sessionID)
+	if !exists {
+		t.Fatal("session disappeared from manager after failed re-auth; in-flight signing would break")
+	}
+	if !gotSess.LoggedOff.Load() {
+		t.Error("session not flagged LoggedOff after failed re-auth; subsequent ops will not return STATUS_USER_SESSION_DELETED")
+	}
+	if gotSess.IsGuest {
+		t.Error("session was downgraded to guest after failed re-auth — must not happen per MS-SMB2 §3.3.5.5.3")
+	}
+
+	// (c) The pending CHANGE_NOTIFY must have been completed with
+	// STATUS_NOTIFY_CLEANUP. The cleanup is dispatched on a goroutine, so
+	// allow a brief settle window before failing — the test deadlocks would
+	// otherwise mask the real issue.
+	deadline := time.Now().Add(2 * time.Second)
+	for !notifyFired.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !notifyFired.Load() {
+		t.Fatal("pending CHANGE_NOTIFY was not completed after failed re-auth (expected STATUS_NOTIFY_CLEANUP)")
+	}
+	if got := types.Status(notifyStatus.Load()); got != types.StatusNotifyCleanup {
+		t.Errorf("CHANGE_NOTIFY completion status = 0x%08x, want STATUS_NOTIFY_CLEANUP (0x%08x)",
+			uint32(got), uint32(types.StatusNotifyCleanup))
+	}
+	if h.NotifyRegistry.WatcherCount() != 0 {
+		t.Errorf("notify watcher still registered after failed re-auth: %d", h.NotifyRegistry.WatcherCount())
+	}
+}

--- a/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
@@ -14,24 +14,14 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
-// encodeUTF16LEForTest encodes an ASCII string as UTF-16LE for embedding in
-// an NTLM AUTHENTICATE message.
-func encodeUTF16LEForTest(s string) []byte {
-	buf := make([]byte, len(s)*2)
-	for i, r := range s {
-		binary.LittleEndian.PutUint16(buf[i*2:], uint16(r))
-	}
-	return buf
-}
-
 // buildNTLMAuthenticateForTest builds an NTLM Type 3 (AUTHENTICATE) message
 // containing the given username and domain in UTF-16LE plus an optional
 // NtChallengeResponse blob. Use an empty ntResponse to skip NTLMv2 validation
 // (drives the "no NT response → user lookup only" path); pass a 24+ byte blob
 // to force ValidateNTLMv2Response to run (and, with garbage bytes, fail).
 func buildNTLMAuthenticateForTest(username, domain string, ntResponse []byte) []byte {
-	usernameBytes := encodeUTF16LEForTest(username)
-	domainBytes := encodeUTF16LEForTest(domain)
+	usernameBytes := encodeUTF16LE(username)
+	domainBytes := encodeUTF16LE(domain)
 
 	payloadOffset := 88
 	domainOffset := payloadOffset


### PR DESCRIPTION
## Summary

Fix `smb2.notify.invalid-reauth` (tracked under #473): re-authentication of an existing SMB2 session that fails authentication MUST destroy that session per MS-SMB2 §3.3.5.5.3, completing any pending CHANGE_NOTIFY watchers with `STATUS_NOTIFY_CLEANUP` and rejecting subsequent ops with `STATUS_USER_SESSION_DELETED`.

Previously `completeNTLMAuth` only took the destroy path on NTLMv2 validation failure. Every other re-auth failure branch (unknown user, disabled account, identity-mapping miss, unparseable TYPE_3) silently fell through to `createGuestSessionWithID`, which **downgraded the authenticated session to guest on the same SessionID** — a security bug as well as a notify-cleanup bug. Pending notify watchers on the original session stayed registered forever and the smbtorture test deadlocked.

## Changes

- Extract the destroy-session logic into `destroySessionOnReauthFailure` (mark `LoggedOff`, close files, release leases + notify watchers via the existing `releaseSessionLeasesAndNotifies` helper, tear down trees). Session record is kept alive in the manager so any in-flight handler goroutines can sign their responses; final cleanup runs on connection close.
- Call it from every re-auth failure path in `completeNTLMAuth`:
  - NTLMv2 validation failure (existing path, now via helper)
  - User-not-found / no UserStore (was: silent guest downgrade)
  - User disabled (was: just returned LOGON_FAILURE, session kept its identity)
  - Identity mapping resolved but user missing (was: just returned LOGON_FAILURE)
  - Unparseable TYPE_3 (was: silent guest downgrade)

## Test plan

- [x] New unit test `TestSessionSetup_FailedReauth_DestroysSessionAndCleansNotify` mirrors the smbtorture wire flow: authenticated session + pending CHANGE_NOTIFY → invalid-creds TYPE_1/TYPE_3 → asserts LOGON_FAILURE, session flagged `LoggedOff`, not downgraded to guest, and CHANGE_NOTIFY callback fired with `STATUS_NOTIFY_CLEANUP`.
- [x] `go test ./internal/adapter/smb/... -race` clean.
- [x] `go fmt ./...` / `go vet ./...` clean.
- [ ] CI smbtorture run flips `smb2.notify.invalid-reauth` (KNOWN_FAILURES walkback follows post-CI per project policy).

Reference: Samba `source4/torture/smb2/notify.c::torture_smb2_notify_invalid_reauth`; MS-SMB2 §3.3.5.5.3.