### PR TITLE
fix(smb/notify): gate CHANGE_NOTIFY on GrantedAccess (refs #473)

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/binary"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -1597,24 +1598,11 @@ func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 // exercise Handler.ChangeNotify through its parser.
 func encodeChangeNotifyRequest(flags uint16, outputBufferLength uint32, fileID [16]byte, completionFilter uint32) []byte {
 	body := make([]byte, 32)
-	// StructureSize = 32 (LE u16)
-	body[0] = 32
-	body[1] = 0
-	// Flags (LE u16)
-	body[2] = byte(flags)
-	body[3] = byte(flags >> 8)
-	// OutputBufferLength (LE u32)
-	body[4] = byte(outputBufferLength)
-	body[5] = byte(outputBufferLength >> 8)
-	body[6] = byte(outputBufferLength >> 16)
-	body[7] = byte(outputBufferLength >> 24)
-	// FileID (16 bytes)
+	binary.LittleEndian.PutUint16(body[0:2], 32) // StructureSize
+	binary.LittleEndian.PutUint16(body[2:4], flags)
+	binary.LittleEndian.PutUint32(body[4:8], outputBufferLength)
 	copy(body[8:24], fileID[:])
-	// CompletionFilter (LE u32)
-	body[24] = byte(completionFilter)
-	body[25] = byte(completionFilter >> 8)
-	body[26] = byte(completionFilter >> 16)
-	body[27] = byte(completionFilter >> 24)
+	binary.LittleEndian.PutUint32(body[24:28], completionFilter)
 	return body
 }
 


### PR DESCRIPTION
## Summary

Tighten the SMB2 CHANGE_NOTIFY access gate so the smbtorture
`smb2.notify.handle-permissions` test can flip. Refs #473.

The existing check consulted `Open.DesiredAccess` (the pre-DACL request)
when MS-SMB2 §3.3.5.19 and Samba `source3/smbd/notify.c::change_notify_create`
(via `check_any_access_fsp(fsp, SEC_DIR_LIST)`) require the test to run
against the open's effective rights — the per-bit intersection with the
file's DACL resolved at CREATE (MS-SMB2 §3.3.5.9 paragraph 8). An open
whose request carried `FILE_LIST_DIRECTORY` but whose granted mask
stripped it would silently arm a notify the handle has no right to.

Switch the gate to `Open.GrantedAccess`. GENERIC_* and MAXIMUM_ALLOWED
are already resolved into specific rights on GrantedAccess
(`acl.ExpandGenericMask` at CREATE decode + `resolveAccessFlags` /
`CheckFileAccess` at CREATE), so the prior mask of listed-and-generic
bits collapses to a single `FILE_LIST_DIRECTORY` (0x00000001) bit test.

## Target

- `smb2.notify.handle-permissions` — opens a directory with
  `SEC_FILE_READ_ATTRIBUTE` only and expects `STATUS_ACCESS_DENIED`
  after a `smb2_cancel` race; the synchronous access-denied response
  arrives before the cancel and `notify_recv` reports the denial.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/adapter/smb/...` clean
- [x] `go test -race ./internal/adapter/smb/...` green (full SMB tree)
- [x] New unit test `TestChangeNotify_HandlePermissions_GrantedAccessGate`
  - `ReadAttributesOnly_Denied` — only `FILE_READ_ATTRIBUTES`, expect ACCESS_DENIED
  - `ListDirectory_Allowed` — `FILE_LIST_DIRECTORY` granted, expect STATUS_PENDING + registered watcher
  - `DesiredHasListDir_GrantedDoesNot_Denied` — DesiredAccess includes the bit but DACL stripped it on GrantedAccess; would have passed the old gate, expect ACCESS_DENIED
- [ ] CI smbtorture run to confirm `smb2.notify.handle-permissions` flips