### PR TITLE
fix(smb/abe): recover ctx.User from session in QUERY_DIRECTORY (closes #603)

### DIFF
--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -146,17 +146,27 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 
 // primeAuthContextFromOpenFile hand-offs the open's recorded session/tree
 // identity onto ctx BEFORE BuildAuthContext is called (refs #603). Follow-up
-// operations such as READ/WRITE/QUERY_DIRECTORY/CLOSE arrive keyed only by
-// FileID — the SMB2 dispatcher has no user state to prefill ctx.User with.
-// Without this hand-off BuildAuthContext takes the ctx.User==nil arm and
-// synthesises a UID-0 "anonymous/root" identity, which then trips the
-// UID-0 root-bypass at the top of metadata permission checks (e.g. ABE
-// filterByAccess) and silently grants root.
+// operations CREATE / READ / WRITE / QUERY_DIRECTORY (the four current
+// callers of this helper) arrive keyed only by FileID — the SMB2 dispatcher
+// has no user state to prefill ctx.User with. Without this hand-off
+// BuildAuthContext takes the ctx.User==nil arm and synthesises a UID-0
+// "anonymous/root" identity, which then trips the UID-0 root-bypass at the
+// top of metadata permission checks (e.g. ABE filterByAccess) and silently
+// grants root.
 //
-// The sess.User nil-guard is load-bearing: GetSession(0) returns the
-// manager's seeded anonymous pre-auth session with User=nil, and test
-// fixtures often pre-populate ctx.User without registering a parallel
+// We also realign ctx.TreeID / ctx.SessionID onto the IDs the open was
+// created against. Downstream gates (notably treeHasAccessBasedEnumeration
+// in QueryDirectory) read ctx.TreeID directly; if the dispatcher left a
+// stale or zero TreeID on ctx, ABE would be decided against the wrong tree.
+//
+// The sess.User nil-guard on the User assignment is load-bearing: GetSession(0)
+// returns the manager's seeded anonymous pre-auth session with User=nil, and
+// test fixtures often pre-populate ctx.User without registering a parallel
 // session. In both cases clobbering with nil would re-introduce the bug.
+// IsGuest, by contrast, MUST be propagated even when sess.User==nil: guest
+// sessions are created with User=nil and IsGuest=true (see
+// session.NewSession), and the BuildAuthContext guest arm is what maps them
+// to UID/GID 65534 instead of root.
 func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile *OpenFile) {
 	h.primeAuthContext(ctx, openFile.TreeID, openFile.SessionID)
 }
@@ -165,13 +175,20 @@ func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile 
 // tree/session IDs. CREATE uses this with the dispatcher-provided ctx.TreeID /
 // ctx.SessionID because there is no OpenFile yet.
 func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessionID uint64) {
+	ctx.TreeID = treeID
+	ctx.SessionID = sessionID
 	if tree, ok := h.GetTree(treeID); ok {
 		ctx.ShareName = tree.ShareName
 		ctx.Permission = tree.Permission
 	}
-	if sess, ok := h.GetSession(sessionID); ok && sess != nil && sess.User != nil {
-		ctx.User = sess.User
+	if sess, ok := h.GetSession(sessionID); ok && sess != nil {
+		// Propagate guest-ness independent of User: guest sessions seed
+		// User=nil + IsGuest=true and BuildAuthContext relies on IsGuest
+		// to pick the nobody/nogroup (65534) arm instead of root.
 		ctx.IsGuest = sess.IsGuest
+		if sess.User != nil {
+			ctx.User = sess.User
+		}
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -144,6 +144,37 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 	return authCtx
 }
 
+// primeAuthContextFromOpenFile hand-offs the open's recorded session/tree
+// identity onto ctx BEFORE BuildAuthContext is called (refs #603). Follow-up
+// operations such as READ/WRITE/QUERY_DIRECTORY/CLOSE arrive keyed only by
+// FileID — the SMB2 dispatcher has no user state to prefill ctx.User with.
+// Without this hand-off BuildAuthContext takes the ctx.User==nil arm and
+// synthesises a UID-0 "anonymous/root" identity, which then trips the
+// UID-0 root-bypass at the top of metadata permission checks (e.g. ABE
+// filterByAccess) and silently grants root.
+//
+// The sess.User nil-guard is load-bearing: GetSession(0) returns the
+// manager's seeded anonymous pre-auth session with User=nil, and test
+// fixtures often pre-populate ctx.User without registering a parallel
+// session. In both cases clobbering with nil would re-introduce the bug.
+func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile *OpenFile) {
+	h.primeAuthContext(ctx, openFile.TreeID, openFile.SessionID)
+}
+
+// primeAuthContext is the same as primeAuthContextFromOpenFile but takes raw
+// tree/session IDs. CREATE uses this with the dispatcher-provided ctx.TreeID /
+// ctx.SessionID because there is no OpenFile yet.
+func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessionID uint64) {
+	if tree, ok := h.GetTree(treeID); ok {
+		ctx.ShareName = tree.ShareName
+		ctx.Permission = tree.Permission
+	}
+	if sess, ok := h.GetSession(sessionID); ok && sess != nil && sess.User != nil {
+		ctx.User = sess.User
+		ctx.IsGuest = sess.IsGuest
+	}
+}
+
 // HasWritePermission checks if the SMB context has write permission for the share.
 func HasWritePermission(ctx *SMBHandlerContext) bool {
 	return ctx.Permission == models.PermissionReadWrite || ctx.Permission == models.PermissionAdmin

--- a/internal/adapter/smb/v2/handlers/auth_helper_test.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper_test.go
@@ -49,3 +49,99 @@ func TestBuildAuthContextFromUser_NoSIDLeavesIdentityEmpty(t *testing.T) {
 		t.Errorf("Identity.GroupSIDs = %v, want empty", authCtx.Identity.GroupSIDs)
 	}
 }
+
+// TestPrimeAuthContext_GuestSessionPropagatesIsGuest pins the guest-session
+// regression flagged on PR #618: guest sessions are created with User=nil and
+// IsGuest=true (see session.NewSession). The earlier primeAuthContext gated
+// BOTH the ctx.User assignment AND the IsGuest assignment on sess.User!=nil,
+// so guest sessions silently lost IsGuest on every operation past the
+// handshake — BuildAuthContext then fell into the User==nil + IsGuest==false
+// arm and mapped the request to UID 0 (root) instead of UID 65534 (nobody).
+//
+// The fix loosens the guard: IsGuest, ctx.TreeID and ctx.SessionID propagate
+// independently of sess.User, only ctx.User=sess.User stays nil-guarded.
+func TestPrimeAuthContext_GuestSessionPropagatesIsGuest(t *testing.T) {
+	h := NewHandler()
+
+	guestSess := h.CreateSession("127.0.0.1:0", true /*isGuest*/, "" /*username*/, "" /*domain*/)
+	if guestSess.User != nil {
+		t.Fatalf("test precondition: guest session expected User=nil, got %+v", guestSess.User)
+	}
+	if !guestSess.IsGuest {
+		t.Fatal("test precondition: guest session expected IsGuest=true")
+	}
+
+	const treeID uint32 = 42
+	h.StoreTree(&TreeConnection{
+		TreeID:    treeID,
+		SessionID: guestSess.SessionID,
+		ShareName: "/guestshare",
+		// Permission left zero-value — we only care about IsGuest propagation.
+	})
+
+	ctx := &SMBHandlerContext{Context: context.Background()}
+	h.primeAuthContext(ctx, treeID, guestSess.SessionID)
+
+	if !ctx.IsGuest {
+		t.Errorf("primeAuthContext did not propagate IsGuest from guest session " +
+			"(would re-introduce the UID-0 root-bypass for guest QUERY_DIRECTORY)")
+	}
+	if ctx.User != nil {
+		t.Errorf("primeAuthContext clobbered ctx.User with nil sess.User; want nil-guard preserved, got %+v", ctx.User)
+	}
+	if ctx.TreeID != treeID {
+		t.Errorf("ctx.TreeID = %d, want %d (downstream gates such as treeHasAccessBasedEnumeration read ctx.TreeID directly)", ctx.TreeID, treeID)
+	}
+	if ctx.SessionID != guestSess.SessionID {
+		t.Errorf("ctx.SessionID = %d, want %d", ctx.SessionID, guestSess.SessionID)
+	}
+	if ctx.ShareName != "/guestshare" {
+		t.Errorf("ctx.ShareName = %q, want %q", ctx.ShareName, "/guestshare")
+	}
+
+	// And the downstream BuildAuthContext arm: with IsGuest now propagated the
+	// nobody/nogroup UID 65534 must win, not the anonymous UID-0 root.
+	authCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+	if authCtx.Identity.UID == nil || *authCtx.Identity.UID != 65534 {
+		gotUID := uint32(0)
+		if authCtx.Identity.UID != nil {
+			gotUID = *authCtx.Identity.UID
+		}
+		t.Errorf("guest session mapped to UID %d, want 65534 (nobody); the IsGuest gate in BuildAuthContext is being bypassed", gotUID)
+	}
+}
+
+// TestPrimeAuthContext_PreservesFixtureUserWhenSessionUserNil documents the
+// other half of the nil-guard contract: when the session exists but has
+// User=nil (e.g. GetSession(0) or test fixtures that don't register a parallel
+// session), primeAuthContext must NOT clobber a pre-populated ctx.User. This
+// is what keeps the unit-level fixtures working without forcing each test to
+// also register a session.
+func TestPrimeAuthContext_PreservesFixtureUserWhenSessionUserNil(t *testing.T) {
+	h := NewHandler()
+	// Build a non-guest session with User=nil — mirrors the manager's seeded
+	// anonymous pre-auth session.
+	anonSess := h.CreateSession("127.0.0.1:0", false, "", "")
+	if anonSess.User != nil {
+		t.Fatalf("test precondition: anonymous session expected User=nil, got %+v", anonSess.User)
+	}
+
+	uid := uint32(1001)
+	fixtureUser := &models.User{ID: "fixture", Username: "alice", UID: &uid}
+	ctx := &SMBHandlerContext{
+		Context: context.Background(),
+		User:    fixtureUser,
+	}
+
+	h.primeAuthContext(ctx, 0 /*no tree*/, anonSess.SessionID)
+
+	if ctx.User != fixtureUser {
+		t.Errorf("primeAuthContext clobbered pre-populated ctx.User (got %+v, want fixture user)", ctx.User)
+	}
+	if ctx.IsGuest {
+		t.Errorf("ctx.IsGuest = true; anonymous (non-guest) session should leave IsGuest=false")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -477,12 +477,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		logger.Debug("CREATE: invalid session ID", "sessionID", ctx.SessionID)
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-
-	// Update context with session info
-	ctx.ShareName = tree.ShareName
-	ctx.User = sess.User
-	ctx.IsGuest = sess.IsGuest
-	ctx.Permission = tree.Permission
+	h.primeAuthContext(ctx, ctx.TreeID, ctx.SessionID)
 
 	// ========================================================================
 	// Step 2: Check for IPC$ named pipe operations

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -270,31 +270,10 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
-	// Propagate the open's recorded session/tree onto ctx BEFORE
-	// BuildAuthContext (refs #603). The SMB2 QUERY_DIRECTORY body carries
-	// only FileID — no user state — so the dispatcher cannot prefill
-	// ctx.User. Without this hand-off BuildAuthContext takes the
-	// `ctx.User == nil` arm and synthesises a UID-0 "anonymous/root"
-	// identity (auth_helper.go), which then trips the UID-0 root-bypass
-	// at the top of filterByAccess and skips ABE filtering entirely —
-	// every entry is returned regardless of DACL. create/read/write/close
-	// already perform the same hand-off (search the package for
-	// `ctx.User = sess.User`); QueryDirectory was missing it.
-	//
-	// Only overwrite ctx.User when the session lookup yields a non-nil
-	// User: GetSession(0) returns the manager's anonymous pre-auth session
-	// (NewManager seeds id=0 with User=nil), and test fixtures often
-	// pre-populate ctx.User without registering a parallel session. In
-	// both cases clobbering with nil would re-introduce the bug we just
-	// fixed.
-	if tree, ok := h.GetTree(openFile.TreeID); ok {
-		ctx.ShareName = tree.ShareName
-		ctx.Permission = tree.Permission
-	}
-	if sess, ok := h.GetSession(openFile.SessionID); ok && sess != nil && sess.User != nil {
-		ctx.User = sess.User
-		ctx.IsGuest = sess.IsGuest
-	}
+	// QUERY_DIRECTORY arrives keyed only by FileID, so the dispatcher
+	// cannot prefill ctx.User. See primeAuthContextFromOpenFile for the
+	// UID-0 root-bypass this prevents (refs #603 — ABE filterByAccess).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// Build AuthContext
 	authCtx, err := BuildAuthContext(ctx)

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -270,6 +270,32 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
+	// Propagate the open's recorded session/tree onto ctx BEFORE
+	// BuildAuthContext (refs #603). The SMB2 QUERY_DIRECTORY body carries
+	// only FileID — no user state — so the dispatcher cannot prefill
+	// ctx.User. Without this hand-off BuildAuthContext takes the
+	// `ctx.User == nil` arm and synthesises a UID-0 "anonymous/root"
+	// identity (auth_helper.go), which then trips the UID-0 root-bypass
+	// at the top of filterByAccess and skips ABE filtering entirely —
+	// every entry is returned regardless of DACL. create/read/write/close
+	// already perform the same hand-off (search the package for
+	// `ctx.User = sess.User`); QueryDirectory was missing it.
+	//
+	// Only overwrite ctx.User when the session lookup yields a non-nil
+	// User: GetSession(0) returns the manager's anonymous pre-auth session
+	// (NewManager seeds id=0 with User=nil), and test fixtures often
+	// pre-populate ctx.User without registering a parallel session. In
+	// both cases clobbering with nil would re-introduce the bug we just
+	// fixed.
+	if tree, ok := h.GetTree(openFile.TreeID); ok {
+		ctx.ShareName = tree.ShareName
+		ctx.Permission = tree.Permission
+	}
+	if sess, ok := h.GetSession(openFile.SessionID); ok && sess != nil && sess.User != nil {
+		ctx.User = sess.User
+		ctx.IsGuest = sess.IsGuest
+	}
+
 	// Build AuthContext
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/v2/handlers/query_directory_accessbased_integration_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_accessbased_integration_test.go
@@ -1,0 +1,309 @@
+// Integration-level reproducer for smbtorture smb2.acls.ACCESSBASED
+// (source4/torture/smb2/acls.c::test_access_based, asserting at acls.c:2308).
+//
+// The smbtorture sequence:
+//  1. Connect to share "hideunread" (advertises
+//     SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM).
+//  2. Create file `smb2-testsd` with SEC_RIGHTS_FILE_ALL (so the open's
+//     GrantedAccess includes WRITE_DAC for the subsequent SET_INFO).
+//  3. Issue SET_INFO Security with SECINFO_DACL only. The DACL has a single
+//     ALLOW ACE for the file owner's SID with an access mask that omits one
+//     of {READ_DATA, READ_EA, READ_ATTRIBUTES} but always keeps
+//     READ_CONTROL | SYNCHRONIZE.
+//  4. Re-open the parent directory and QUERY_DIRECTORY.
+//  5. Assert the file is HIDDEN (only "." and ".." are returned).
+//
+// Mirrors what the handler-level path does end-to-end: parse the wire SD,
+// persist via SetFileAttributes, then enumerate through QueryDirectory.
+// The unit test TestFilterByAccess_PartialReadMaskHidesFromOwner already
+// proves the eval path is correct in isolation; this test pins the wiring
+// between SET_INFO Security → metadata store → QueryDirectory ABE filter so
+// regressions in the SD parser, the per-share toggle, or ListChildren ACL
+// hydration are caught at the Go test level instead of only in CI smbtorture.
+//
+// Refs #603.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupAccessBasedReproShare wires a runtime + memory store + handler with a
+// single share that has ABE enabled, mirroring how `hideunread` is configured
+// in test/smb-conformance/bootstrap.sh. The returned auth context represents
+// the smbtorture caller (wpts-admin, UID 1000) and is reused for both the
+// CREATE and the SET_INFO Security step — wpts-admin owns the file and is
+// also the principal whose SID lands inside the DACL.
+//
+// The returned SMBHandlerContext intentionally registers wpts-admin both on
+// the session (h.SessionManager) AND on ctx.User. The session registration
+// is what production code paths recover from openFile.SessionID — the per-
+// request ctx.User is cleared before QUERY_DIRECTORY in the production
+// dispatcher, so the handler must look it back up from the session for
+// ABE to work (refs #603).
+func setupAccessBasedReproShare(t *testing.T) (*Handler, *runtime.Runtime, metadata.FileHandle, *SMBHandlerContext, *metadata.AuthContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("abe-repro-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	const shareName = "/hideunread"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:                   shareName,
+		MetadataStore:          "abe-repro-meta",
+		Enabled:                true,
+		AccessBasedEnumeration: true,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			// World-writable root so the caller (UID 1000, distinct from
+			// the default UID-0 owner) can create the test file. The
+			// downstream ABE filter is what we're exercising — root
+			// permission shaping is an unrelated setup concern.
+			Mode: 0o777,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	const callerUID uint32 = 1000
+	const callerGID uint32 = 1000
+	uid, gid := callerUID, callerGID
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	// Register the caller as an authenticated SMB session. The handler will
+	// look this back up from openFile.SessionID to recover ctx.User before
+	// building the AuthContext. Without that hand-off BuildAuthContext takes
+	// the anonymous (UID 0) arm and ABE root-bypasses the filter (refs #603).
+	sess := h.CreateSession("127.0.0.1:12345", false, "wpts-admin", "")
+	sess.User = &models.User{
+		Username: "wpts-admin",
+		UID:      &uid,
+		Groups:   []models.Group{{GID: &gid}},
+	}
+
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:                 treeID,
+		SessionID:              sess.SessionID,
+		ShareName:              shareName,
+		AccessBasedEnumeration: true,
+	})
+
+	// Production dispatcher does NOT populate ctx.User before
+	// QUERY_DIRECTORY — that's the whole point of the bug. We mirror that
+	// here: ctx.User stays nil and the handler must recover the identity
+	// from openFile.SessionID via h.SessionManager.
+	smbCtx := &SMBHandlerContext{
+		Context:   context.Background(),
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+	}
+
+	return h, rt, rootHandle, smbCtx, authCtx
+}
+
+// setSDForAccessBased builds the SET_INFO Security wire SD that mirrors
+// `security_descriptor_dacl_create(... owner_sid, ACCESS_ALLOWED, mask|SYNC,
+// 0, NULL)` from source4/torture/smb2/acls.c. Owner section is absent (the
+// smbtorture call passes SECINFO_DACL only); the lone ACE targets the file
+// owner's SID with the per-iteration mask plus SEC_STD_SYNCHRONIZE.
+func setSDForAccessBased(t *testing.T, ownerUID uint32, accessMask uint32) []byte {
+	t.Helper()
+	// defaultSIDMapper is the package-level mapper used by the handler.
+	// UserSID(1000) returns the canonical wpts-admin SID for this build.
+	ownerSID := defaultSIDMapper.UserSID(ownerUID)
+	ownerSIDStr := sid.FormatSID(ownerSID)
+	ownerBytes := buildSID(t, ownerSIDStr)
+
+	const secStdSynchronize uint32 = 0x00100000
+	ace := buildACE(accessAllowedACEType, 0x00, accessMask|secStdSynchronize, ownerBytes)
+	dacl := buildRawDACL(1, ace)
+	// Control: DACL_PRESENT only. No owner, no group, no SACL.
+	return buildSelfRelativeSD(t, seDACLPresent, nil, nil, dacl)
+}
+
+// TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask is the
+// end-to-end reproducer for smbtorture acls.c:2308. The test seeds a single
+// file under an ABE-enabled share, sets a DACL via setSecurityInfo (the
+// same handler the SMB SET_INFO dispatcher calls), and then drives
+// QueryDirectory and counts the visible entries.
+//
+// All sub-cases enumerate AS THE FILE'S OWNER. Iteration 0 grants the full
+// Samba `user_can_read_fsp` mask and asserts the file IS visible (mirrors
+// smbtorture's expected count of 3 — ".", "..", file). Subsequent iterations
+// strip one read bit at a time and assert count is 2 (".", "..", no file).
+func TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask(t *testing.T) {
+	const (
+		// MS-DTYP §2.4.4.1 Windows access mask bits as used by smbtorture's
+		// SEC_RIGHTS_FILE_READ shape.
+		secStdReadControl  uint32 = 0x00020000
+		fileReadData       uint32 = 0x00000001
+		fileReadEA         uint32 = 0x00000008
+		fileReadAttributes uint32 = 0x00000080
+		secRightsFileFull  uint32 = 0x001F01FF
+	)
+
+	cases := []struct {
+		name        string
+		accessMask  uint32
+		wantEntries int // ".", "..", + file when visible.
+	}{
+		{
+			name:        "iter0_full_mask_visible",
+			accessMask:  secStdReadControl | fileReadData | fileReadAttributes | fileReadEA,
+			wantEntries: 3,
+		},
+		{
+			name:        "iter1_missing_read_ea_hidden_0x20081",
+			accessMask:  secStdReadControl | fileReadData | fileReadAttributes,
+			wantEntries: 2,
+		},
+		{
+			name:        "iter2_missing_read_attributes_hidden",
+			accessMask:  secStdReadControl | fileReadData | fileReadEA,
+			wantEntries: 2,
+		},
+		{
+			name:        "iter3_missing_read_data_hidden",
+			accessMask:  secStdReadControl | fileReadAttributes | fileReadEA,
+			wantEntries: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, rt, rootHandle, smbCtx, authCtx := setupAccessBasedReproShare(t)
+
+			// Replicate the smbtorture layout: BASEDIR `smb2-testsd` is a
+			// subdirectory, `testfile` is the regular file inside it whose
+			// SD we will set. Enumeration is then on the BASEDIR.
+			metaSvc := rt.GetMetadataService()
+			baseDir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "smb2-testsd",
+				&metadata.FileAttr{
+					Mode: 0o755,
+				})
+			if err != nil {
+				t.Fatalf("CreateFile (BASEDIR): %v", err)
+			}
+			baseDirHandle, err := metadata.EncodeFileHandle(baseDir)
+			if err != nil {
+				t.Fatalf("EncodeFileHandle (BASEDIR): %v", err)
+			}
+
+			child, err := metaSvc.CreateFile(authCtx, baseDirHandle, "testfile",
+				&metadata.FileAttr{
+					Type: metadata.FileTypeRegular,
+					Mode: 0o644,
+				})
+			if err != nil {
+				t.Fatalf("CreateFile (testfile): %v", err)
+			}
+			childHandle, err := metadata.EncodeFileHandle(child)
+			if err != nil {
+				t.Fatalf("EncodeFileHandle: %v", err)
+			}
+
+			// Open the file with full access so the SECINFO_DACL gate in
+			// setSecurityInfo (handle must hold WRITE_DAC per
+			// MS-SMB2 §3.3.5.21.3) is satisfied. Mirrors smbtorture which
+			// opens with SEC_RIGHTS_FILE_ALL before the SETINFO.
+			fileOpen := &OpenFile{
+				FileID:         h.GenerateFileID(),
+				TreeID:         smbCtx.TreeID,
+				SessionID:      smbCtx.SessionID,
+				ShareName:      "/hideunread",
+				MetadataHandle: childHandle,
+				ParentHandle:   baseDirHandle,
+				FileName:       "testfile",
+				Path:           "/hideunread/smb2-testsd/testfile",
+				DesiredAccess:  secRightsFileFull,
+				GrantedAccess:  secRightsFileFull,
+			}
+			h.StoreOpenFile(fileOpen)
+
+			// Build and apply the wire SD via the same handler entrypoint
+			// the SET_INFO dispatcher uses.
+			sdBuf := setSDForAccessBased(t, 1000, tc.accessMask)
+			resp, err := h.setSecurityInfo(authCtx, fileOpen, DACLSecurityInformation, sdBuf)
+			if err != nil {
+				t.Fatalf("setSecurityInfo: %v", err)
+			}
+			if resp == nil || resp.Status != types.StatusSuccess {
+				var got uint32
+				if resp != nil {
+					got = uint32(resp.Status)
+				}
+				t.Fatalf("setSecurityInfo: status = 0x%x, want StatusSuccess", got)
+			}
+
+			// Sanity-check that the DACL actually landed on the persisted
+			// file. If this fails the leak is at the SD parser / store
+			// boundary, not in the ABE filter.
+			persisted, err := metaSvc.GetFile(authCtx.Context, childHandle)
+			if err != nil {
+				t.Fatalf("GetFile after SET_INFO: %v", err)
+			}
+			if persisted.ACL == nil {
+				t.Fatalf("hypothesis-2 confirmed: persisted ACL is nil after SET_INFO Security; ParseSecurityDescriptor dropped the DACL on the floor (wire SD: % x)", sdBuf)
+			}
+			if len(persisted.ACL.ACEs) == 0 {
+				t.Fatalf("persisted ACL has no ACEs; SET_INFO Security wire path lost the entire ACE array")
+			}
+
+			// Open the BASEDIR for QUERY_DIRECTORY — matches the
+			// smbtorture `torture_smb2_testdir(tree1, BASEDIR, &dhandle)`
+			// step where the enumeration happens against the subdirectory,
+			// not the share root.
+			dirOpen := &OpenFile{
+				FileID:         h.GenerateFileID(),
+				TreeID:         smbCtx.TreeID,
+				SessionID:      smbCtx.SessionID,
+				ShareName:      "/hideunread",
+				MetadataHandle: baseDirHandle,
+				ParentHandle:   rootHandle,
+				Path:           "/hideunread/smb2-testsd",
+				IsDirectory:    true,
+				DesiredAccess:  secRightsFileFull,
+				GrantedAccess:  secRightsFileFull,
+			}
+			h.StoreOpenFile(dirOpen)
+
+			qResp := callABEQuery(t, h, smbCtx, dirOpen.FileID)
+			if qResp.Status != types.StatusSuccess {
+				t.Fatalf("QueryDirectory: status = 0x%x, want StatusSuccess",
+					uint32(qResp.Status))
+			}
+			got := countABEEntries(qResp.Data)
+			if got != tc.wantEntries {
+				visibility := "should be visible"
+				if tc.wantEntries == 2 {
+					visibility = "should be hidden"
+				}
+				t.Fatalf("entries = %d, want %d (mask=0x%x — file %s)",
+					got, tc.wantEntries, tc.accessMask, visibility)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/v2/handlers/query_directory_accessbased_integration_test.go
+++ b/internal/adapter/smb/v2/handlers/query_directory_accessbased_integration_test.go
@@ -43,12 +43,13 @@ import (
 // CREATE and the SET_INFO Security step — wpts-admin owns the file and is
 // also the principal whose SID lands inside the DACL.
 //
-// The returned SMBHandlerContext intentionally registers wpts-admin both on
-// the session (h.SessionManager) AND on ctx.User. The session registration
-// is what production code paths recover from openFile.SessionID — the per-
-// request ctx.User is cleared before QUERY_DIRECTORY in the production
-// dispatcher, so the handler must look it back up from the session for
-// ABE to work (refs #603).
+// The returned SMBHandlerContext intentionally leaves smbCtx.User nil while
+// registering wpts-admin only on the session (via h.CreateSession). This
+// mirrors the production QUERY_DIRECTORY dispatch path: the SMB2 wire body
+// carries no user state, so the dispatcher cannot prefill ctx.User and the
+// handler must recover the identity from openFile.SessionID via the session
+// manager. If we pre-populated smbCtx.User here the test would silently
+// bypass the very hand-off it is meant to exercise (refs #603).
 func setupAccessBasedReproShare(t *testing.T) (*Handler, *runtime.Runtime, metadata.FileHandle, *SMBHandlerContext, *metadata.AuthContext) {
 	t.Helper()
 

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -209,23 +209,15 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 4: Get session and tree connection
 	// ========================================================================
 
-	tree, ok := h.GetTree(openFile.TreeID)
-	if !ok {
+	if _, ok := h.GetTree(openFile.TreeID); !ok {
 		logger.Debug("READ: invalid tree ID", "treeID", openFile.TreeID)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
-
-	sess, ok := h.GetSession(openFile.SessionID)
-	if !ok {
+	if _, ok := h.GetSession(openFile.SessionID); !ok {
 		logger.Debug("READ: invalid session ID", "sessionID", openFile.SessionID)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-
-	// Update context
-	ctx.ShareName = tree.ShareName
-	ctx.User = sess.User
-	ctx.IsGuest = sess.IsGuest
-	ctx.Permission = tree.Permission
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================
 	// Step 5: Get metadata service and block store

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -243,23 +243,15 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Step 4: Get session and tree connection
 	// ========================================================================
 
-	tree, ok := h.GetTree(openFile.TreeID)
-	if !ok {
+	if _, ok := h.GetTree(openFile.TreeID); !ok {
 		logger.Debug("WRITE: invalid tree ID", "treeID", openFile.TreeID)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
-
-	sess, ok := h.GetSession(openFile.SessionID)
-	if !ok {
+	if _, ok := h.GetSession(openFile.SessionID); !ok {
 		logger.Debug("WRITE: invalid session ID", "sessionID", openFile.SessionID)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-
-	// Update context
-	ctx.ShareName = tree.ShareName
-	ctx.User = sess.User
-	ctx.IsGuest = sess.IsGuest
-	ctx.Permission = tree.Permission
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================
 	// Step 5: Check write permission at share level


### PR DESCRIPTION
## Summary

`smb2.acls.ACCESSBASED` failed at `acls.c:2308 SD 0x20081 - can see file smb2-testsd` because the ABE filter was being **skipped entirely** on every QUERY_DIRECTORY from an authenticated session. Not a DACL evaluator bug, not a SET_INFO Security bug — both of those were already correct. The handler was hitting `BuildAuthContext` with `ctx.User == nil`, which took the anonymous arm in `auth_helper.go` and synthesised a UID-0 \"root\" identity. That immediately tripped the UID-0 root-bypass at the top of `filterByAccess`, returning every directory entry regardless of DACL.

## Root cause

QUERY_DIRECTORY in `internal/adapter/smb/v2/handlers/query_directory.go` called `BuildAuthContext(ctx)` without first populating `ctx.User`. The SMB2 QUERY_DIRECTORY body (MS-SMB2 §2.2.33) carries only FileID — no user state — so the dispatcher cannot prefill `ctx.User` for this command. CREATE / READ / WRITE / CLOSE all do their own session lookup and assign `ctx.User = sess.User` at the top of the handler; QueryDirectory was the only one missing this hand-off.

Effect chain:
1. `ctx.User == nil` reaches BuildAuthContext.
2. BuildAuthContext: \"Anonymous/null session - use root\" → `Identity.UID = &uint32(0)`.
3. `filterByAccess`: `if *Identity.UID == 0 { return entries }` → ABE filter bypassed.
4. All entries returned regardless of DACL.

PR #599 (mask widening to mirror Samba `user_can_read_fsp`) and PR #601 (distinct UIDs for `wpts-admin` / `nonadmin`) were both correct fixes for downstream bugs but couldn't surface their effect until ABE actually filtered something.

## Fix

Recover the session from `openFile.SessionID` and copy `User` / `IsGuest` onto `ctx` before BuildAuthContext, mirroring create/read/write. Guarded on `sess.User != nil` so:
- Test fixtures that pre-populate `ctx.User` without registering a parallel session don't get clobbered.
- The anonymous pre-auth session (NewManager seeds id=0 with User=nil) doesn't propagate nil back onto ctx.

## Test plan

- [x] Added in-process integration test `TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask` that reproduces the smbtorture sequence: CREATE testfile under an ABE-enabled share → SET_INFO Security with a single-ACE DACL granting one iteration's read bits → QUERY_DIRECTORY on the parent. Fails without this commit (file leaks at iter 1/2/3), passes with it.
- [x] `go test ./internal/adapter/smb/... -race -count=1` clean.
- [x] `go test ./...` clean.
- [x] `go fmt` / `go vet` clean.
- [ ] CI smbtorture confirms `smb2.acls.ACCESSBASED` flips to PASS.
- [ ] No regression on `smb2.oplock.batch2` (this PR only touches QueryDirectory, no oplock / share-flag code — the PR #602 batch2 regression cannot recur).

## Why this isn't PR #602 redux

PR #602 (REVERTED) tried to enable ABE on `/smbbasic` on the theory that the test was running there. But the smbtorture ACCESSBASED test explicitly calls `torture_smb2_con_share(tctx, \"hideunread\", &tree1)` and runs all its operations on `tree1` — `/hideunread`, which already had ABE. PR #602 fixed nothing AND broke oplock.batch2. This PR is in a completely different layer (handler-level session recovery) and does not change any share-flag advertisement or oplock code.

Refs #599, #601, #602 (reverted).