### PR TITLE
feat(dfsctl): --compression flag on remote store add (#185)

### DIFF
--- a/cmd/dfsctl/commands/store/block/remote/add.go
+++ b/cmd/dfsctl/commands/store/block/remote/add.go
@@ -16,12 +16,13 @@ var (
 	addType   string
 	addConfig string
 	// S3 specific
-	addBucket    string
-	addRegion    string
-	addEndpoint  string
-	addPrefix    string
-	addAccessKey string
-	addSecretKey string
+	addBucket      string
+	addRegion      string
+	addEndpoint    string
+	addPrefix      string
+	addAccessKey   string
+	addSecretKey   string
+	addCompression string
 )
 
 var addCmd = &cobra.Command{
@@ -52,6 +53,9 @@ Examples:
   # Add a MinIO store (S3-compatible)
   dfsctl store block remote add --name minio-store --type s3 --bucket data --endpoint http://localhost:9000
 
+  # Add an S3 store with zstd block compression
+  dfsctl store block remote add --name prod-s3 --type s3 --bucket my-bucket --compression zstd
+
   # Add a memory store (for testing)
   dfsctl store block remote add --name test-remote --type memory`,
 	RunE: runAdd,
@@ -68,6 +72,7 @@ func init() {
 	addCmd.Flags().StringVar(&addPrefix, "prefix", "", "Key prefix within the bucket (for s3)")
 	addCmd.Flags().StringVar(&addAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	addCmd.Flags().StringVar(&addSecretKey, "secret-key", "", "AWS secret access key (for s3)")
+	addCmd.Flags().StringVar(&addCompression, "compression", "", "Enable per-block compression: zstd, lz4 (default: off)")
 	_ = addCmd.MarkFlagRequired("name")
 }
 
@@ -77,7 +82,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config, err := buildRemoteConfig(addType, addConfig, addBucket, addRegion, addEndpoint, addPrefix, addAccessKey, addSecretKey)
+	config, err := buildRemoteConfig(addType, addConfig, addBucket, addRegion, addEndpoint, addPrefix, addAccessKey, addSecretKey, addCompression)
 	if err != nil {
 		return cmdutil.HandleAbort(err)
 	}
@@ -96,13 +101,18 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	return cmdutil.PrintResourceWithSuccess(os.Stdout, store, fmt.Sprintf("Remote block store '%s' (type: %s) created successfully", store.Name, store.Type))
 }
 
-func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, accessKey, secretKey string) (any, error) {
+func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, accessKey, secretKey, compression string) (any, error) {
 	if jsonConfig != "" {
 		var config any
 		if err := json.Unmarshal([]byte(jsonConfig), &config); err != nil {
 			return nil, fmt.Errorf("invalid JSON config: %w", err)
 		}
 		return config, nil
+	}
+
+	compressionBlock, err := buildCompressionBlock(compression)
+	if err != nil {
+		return nil, err
 	}
 
 	switch storeType {
@@ -167,9 +177,26 @@ func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, 
 		if s3Prefix != "" {
 			config["prefix"] = s3Prefix
 		}
+		if compressionBlock != nil {
+			config["compression"] = compressionBlock
+		}
 		return config, nil
 
 	default:
 		return nil, fmt.Errorf("unknown store type: %s (supported: s3, memory)", storeType)
+	}
+}
+
+// buildCompressionBlock validates the --compression flag and returns the
+// JSON sub-object to merge into the remote config map. Returns (nil, nil)
+// when the flag is empty (compression off).
+func buildCompressionBlock(algo string) (map[string]any, error) {
+	switch algo {
+	case "":
+		return nil, nil
+	case "zstd", "lz4":
+		return map[string]any{"algo": algo}, nil
+	default:
+		return nil, fmt.Errorf("invalid --compression value %q (want one of: zstd, lz4)", algo)
 	}
 }

--- a/cmd/dfsctl/commands/store/block/remote/add_test.go
+++ b/cmd/dfsctl/commands/store/block/remote/add_test.go
@@ -1,0 +1,93 @@
+package remote
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCompressionBlock(t *testing.T) {
+	cases := []struct {
+		algo     string
+		wantAlgo string // "" → expect nil block
+		wantErr  string // substring; "" → no error
+	}{
+		{"", "", ""},
+		{"zstd", "zstd", ""},
+		{"lz4", "lz4", ""},
+		{"snappy", "", "invalid --compression"},
+		{"none", "", "invalid --compression"},
+		{"ZSTD", "", "invalid --compression"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.algo, func(t *testing.T) {
+			block, err := buildCompressionBlock(tc.algo)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantAlgo == "" {
+				if block != nil {
+					t.Fatalf("expected nil block for empty flag, got %#v", block)
+				}
+				return
+			}
+			if got, _ := block["algo"].(string); got != tc.wantAlgo {
+				t.Fatalf("algo=%v, want %s", block["algo"], tc.wantAlgo)
+			}
+		})
+	}
+}
+
+func TestBuildRemoteConfig_S3_CompressionMergesIn(t *testing.T) {
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "zstd")
+	if err != nil {
+		t.Fatalf("buildRemoteConfig: %v", err)
+	}
+	m, ok := cfg.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", cfg)
+	}
+	comp, ok := m["compression"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing compression block in config: %#v", m)
+	}
+	if comp["algo"] != "zstd" {
+		t.Fatalf("algo=%v, want zstd", comp["algo"])
+	}
+}
+
+func TestBuildRemoteConfig_S3_NoCompressionByDefault(t *testing.T) {
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "")
+	if err != nil {
+		t.Fatalf("buildRemoteConfig: %v", err)
+	}
+	m, _ := cfg.(map[string]any)
+	if _, present := m["compression"]; present {
+		t.Fatalf("compression key should be absent when flag empty: %#v", m)
+	}
+}
+
+func TestBuildRemoteConfig_S3_RejectsInvalidAlgo(t *testing.T) {
+	_, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "gzip")
+	if err == nil || !strings.Contains(err.Error(), "invalid --compression") {
+		t.Fatalf("err=%v, want invalid --compression error", err)
+	}
+}
+
+func TestBuildRemoteConfig_JSONConfigShortCircuitsFlag(t *testing.T) {
+	// --config takes the parsed JSON verbatim; --compression flag is
+	// ignored when --config is set (matches existing flag interaction).
+	cfg, err := buildRemoteConfig("s3", `{"bucket":"x"}`, "", "", "", "", "", "", "lz4")
+	if err != nil {
+		t.Fatalf("buildRemoteConfig: %v", err)
+	}
+	m, _ := cfg.(map[string]any)
+	if _, present := m["compression"]; present {
+		t.Fatalf("compression must not be injected when --config provided: %#v", m)
+	}
+}


### PR DESCRIPTION
## Summary

Surfaces per-remote block compression as a first-class \`dfsctl\` flag. Until now, enabling zstd / lz4 on a remote required hand-crafting a \`--config\` JSON blob (\`'{...,"compression":{"algo":"zstd"}}'\`). This adds:

\`\`\`
--compression string   Enable per-block compression: zstd, lz4 (default: off)
\`\`\`

Example:

\`\`\`bash
dfsctl store block remote add --name prod-s3 --type s3 \\
  --bucket my-bucket --access-key AKIA... --secret-key ... \\
  --compression zstd
\`\`\`

Compression remains a per-remote property (immutable at acquire time, shared across shares pointing at the same remote) — matches the architecture landed in #610.

## Behavior

- Flag empty / unset → no \`compression\` block in the built config (zero behavior change).
- \`zstd\` or \`lz4\` → injects \`{"compression":{"algo":"<algo>"}}\` into the config map.
- Any other value → rejected client-side at flag parse, before hitting the server.
- \`--config '{...}'\` short-circuits the flag-built path (existing pattern); operator using raw JSON keeps full control. \`--compression\` is ignored in that path.
- No interactive prompt — compression is opt-in, off by default.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./cmd/dfsctl/commands/store/block/remote/... -count=1 -race\` — unit tests cover validate (zstd/lz4/empty pass; snappy/none/case-mismatch fail), JSON merge on s3 branch, default-absent invariant, \`--config\` short-circuit.
- [x] Manual: \`dfsctl store block remote add --help\` shows flag + new example line.