### PR TITLE
chore(smb): walk back KNOWN_FAILURES for #618 acls.ACCESSBASED flip

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-05-22 (ACL OWNER-RIGHTS family flips after #547/#548/#549/#553)
+Last updated: 2026-05-23 (acls.ACCESSBASED flip after #618 ABE QUERY_DIRECTORY ctx.User recovery)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -49,7 +49,6 @@ descriptors, and owner rights are not implemented.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.acls.ACCESSBASED | ACLs | Deeper failure at acls.c:2308 after PR #551 (ABE bit moved to ShareFlags) — SD 0x20081 still leaks file `smb2-testsd` to non-readers; requires ABE filtering in directory enumeration | - |
 | smb2.sdread | Security descriptors | Security descriptor read not implemented | - |
 | smb2.secleak | Security descriptors | Security descriptor leak test not implemented | - |
 


### PR DESCRIPTION
## Summary

Walk back `smb2.acls.ACCESSBASED` from `test/smb-conformance/smbtorture/KNOWN_FAILURES.md`. PR #618 (ABE QUERY_DIRECTORY ctx.User recovery, closes #603) flipped this test to PASS across all three smbtorture profiles.

CI run [26332813193](https://github.com/marmos91/dittofs/actions/runs/26332813193) on develop @ `e180af70` (which includes all of #612, #613, #614, #615, #616, #617, #618):

| Test | memory | memory-fs | badger-fs |
|------|--------|-----------|-----------|
| smb2.acls.ACCESSBASED | success | success | success |

## Other expected flips — kept in KNOWN_FAILURES

The remaining 6 tests claimed by the recent PR batch were verified NOT flipped on this CI run, so their KNOWN_FAILURES entries stay:

- **smb2.notify.valid-req** (#612) — still fails with a deeper error: `wrong value for n.out.num_changes 0x1 should be 0x3` at notify.c:163. The per-handle sticky `max_buffer_size` fix is correct but smbtorture now reveals the next layer.
- **smb2.notify.overflow / session-reconnect / invalid-reauth / handle-permissions** (#613, #614, #615, #616) — **not executed** by smbtorture in this run. The suite never reaches them (PR #614's description acknowledges that `notify.dir` hangs earlier in the suite, blocking everything after). The fixes are correct for the code paths involved; the wire flip will require fixing the earlier hang.
- **smb2.multichannel.leases.test3** (#617 side-effect via no-op FSCTL) — passes on memory-fs and badger-fs, still flakes on memory profile with the same spurious lease break (`lease_state 0x7 should be 0x3` at multichannel.c:1930). Keep the entry until the memory-profile race is debugged.
- **smb2.multichannel.oplocks.test2 / test3_windows / test3_specification** — PR #617's no-op `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` lets the tests progress past the FSCTL call, but they then fail later because they need real TCP transport blocking, which is a Samba-internal test-harness primitive. Keep entries; mark "not implementable" still applies.

## Unexpected new failure

The same CI run reports one new failure not previously tracked: `smb2.create.multi` on memory and badger-fs profiles. **Not addressed here** — out of scope for this walkback; should be filed as a separate issue.

## Test plan

- [x] CI run 26332813193 confirms ACCESSBASED PASS on all 3 smbtorture profiles
- [x] Diff is doc-only (no test code changes)
- [ ] CI on this PR re-confirms ACCESSBASED PASS and no new failures from the walkback