### PR TITLE
fix(smb/auth): close UID-0 root-bypass + DesiredAccess-vs-GrantedAccess in 14 handlers (#619)

### DIFF
--- a/internal/adapter/smb/v2/handlers/auth_priming_test.go
+++ b/internal/adapter/smb/v2/handlers/auth_priming_test.go
@@ -1,0 +1,250 @@
+package handlers
+
+// Tests for the two correctness bug classes addressed in #619:
+//
+//  A. UID-0 root-bypass — handler sites that called BuildAuthContext(ctx)
+//     without first priming ctx.User from the OpenFile's recorded session.
+//     With User==nil, BuildAuthContext synthesises UID-0 (root), bypassing
+//     all DACL checks in the metadata layer. Same bug class as #603
+//     (QUERY_DIRECTORY) fixed in PR #618.
+//
+//  B. DesiredAccess vs GrantedAccess — handler sites that gated access
+//     decisions on the pre-DACL DesiredAccess instead of the post-DACL
+//     GrantedAccess. Same flaw as #616 (ChangeNotify), flagged by the #616
+//     reviewer.
+//
+// We test two sites per bug class (4 tests total): a positive case where the
+// access is granted and a negative case where the bit is stripped (DACL) or
+// the priming would otherwise have leaked UID-0 root.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// =============================================================================
+// Bug class A — UID-0 root-bypass
+// =============================================================================
+
+// TestClose_PrimesAuthContextFromOpenFile pins the CLOSE handler's hand-off
+// of the OpenFile's recorded session identity onto ctx.User BEFORE
+// BuildAuthContext is invoked for the deferred-metadata-flush / delete-on-
+// close paths. Without the prime, ctx.User==nil falls through to the
+// anonymous arm and synthesises UID-0 (root), silently granting root on the
+// metadata-layer DACL gates (#619). This test exercises the regular-file
+// CLOSE path that runs metaSvc.FlushPendingWriteForFile under the auth
+// context.
+func TestClose_PrimesAuthContextFromOpenFile(t *testing.T) {
+	h := NewHandler()
+
+	uid := uint32(1001)
+	user := &models.User{ID: "alice", Username: "alice", UID: &uid}
+	sess := h.CreateSession("127.0.0.1:0", false, "alice", "")
+	sess.User = user
+
+	const treeID uint32 = 7
+	h.StoreTree(&TreeConnection{
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		ShareName: "/share",
+	})
+
+	openFile := &OpenFile{
+		FileID:    [16]byte{0x01, 0x02},
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		Path:      "/share/a.txt",
+		// No MetadataHandle / PayloadID — Close skips the BlockStore /
+		// metadata-flush paths entirely, but Step 2b primer still runs.
+	}
+	h.StoreOpenFile(openFile)
+
+	// Build a ctx with zero session/tree state — mirrors the dispatcher,
+	// which arrives keyed only by FileID.
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0 /*session*/, 0 /*tree*/, 1 /*msg*/)
+	if ctx.User != nil {
+		t.Fatal("precondition: ctx.User should start nil so the prime is observable")
+	}
+
+	resp, err := h.Close(ctx, &CloseRequest{FileID: openFile.FileID})
+	if err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Close status = %v, want StatusSuccess", resp.Status)
+	}
+
+	// After Close, ctx.User must have been primed from the session — without
+	// the prime BuildAuthContext would have minted a UID-0 root identity.
+	if ctx.User != user {
+		t.Errorf("ctx.User = %+v, want primed from session (alice); without the prime BuildAuthContext mints UID-0 root and bypasses DACL checks", ctx.User)
+	}
+	if ctx.SessionID != sess.SessionID {
+		t.Errorf("ctx.SessionID = %d, want %d (primed from openFile)", ctx.SessionID, sess.SessionID)
+	}
+	if ctx.TreeID != treeID {
+		t.Errorf("ctx.TreeID = %d, want %d (primed from openFile)", ctx.TreeID, treeID)
+	}
+}
+
+// TestFlush_PrimesAuthContextFromOpenFile pins the same hand-off on the
+// FLUSH path: BuildAuthContext is invoked to authorise the deferred
+// metadata flush, and without the prime ctx.User==nil → UID-0 root → DACL
+// bypass on FlushPendingWriteForFile. FLUSH returns
+// StatusInternalError early (no block store wired in the test handler);
+// the assertion is that ctx.User has been primed REGARDLESS of the
+// downstream short-circuit — i.e. the prime runs at Step 1, not at Step 4.
+//
+// Note: with the current FLUSH layout the prime is placed at the
+// BuildAuthContext call site (Step 4). When the block-store resolution at
+// Step 2 fails the handler returns before that prime runs, which is the
+// CORRECT behaviour: there is no BuildAuthContext call to protect. We
+// therefore test the prime via the same code path the auth_helper_test
+// uses: invoke primeAuthContextFromOpenFile directly on the same OpenFile
+// to confirm the helper integrates with the session/tree fixtures the
+// flush handler will rely on once it reaches the BuildAuthContext gate.
+func TestFlush_PrimesAuthContextFromOpenFile(t *testing.T) {
+	h := NewHandler()
+
+	uid := uint32(2002)
+	user := &models.User{ID: "bob", Username: "bob", UID: &uid}
+	sess := h.CreateSession("127.0.0.1:0", false, "bob", "")
+	sess.User = user
+
+	const treeID uint32 = 9
+	h.StoreTree(&TreeConnection{
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		ShareName: "/share2",
+	})
+
+	openFile := &OpenFile{
+		FileID:    [16]byte{0x10, 0x20},
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		Path:      "/share2/b.txt",
+	}
+
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	if ctx.User != nil {
+		t.Fatal("precondition: ctx.User should start nil")
+	}
+
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
+	if ctx.User != user {
+		t.Errorf("ctx.User not primed from session (got %+v, want bob)", ctx.User)
+	}
+	if ctx.TreeID != treeID {
+		t.Errorf("ctx.TreeID = %d, want %d", ctx.TreeID, treeID)
+	}
+
+	// Negative: with no prime, BuildAuthContext mints UID-0 root. Confirm
+	// the bug exists in the bare path so the positive prime fix is
+	// actually load-bearing.
+	bareCtx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	bareAuth, err := BuildAuthContext(bareCtx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext (bare): %v", err)
+	}
+	if bareAuth.Identity == nil || bareAuth.Identity.UID == nil || *bareAuth.Identity.UID != 0 {
+		gotUID := uint32(0xffffffff)
+		if bareAuth.Identity != nil && bareAuth.Identity.UID != nil {
+			gotUID = *bareAuth.Identity.UID
+		}
+		t.Errorf("bare-ctx BuildAuthContext.UID = %d, want 0 (root) — anonymous arm is what the prime is supposed to bypass; test fixture has drifted", gotUID)
+	}
+}
+
+// =============================================================================
+// Bug class B — DesiredAccess vs GrantedAccess
+// =============================================================================
+
+// TestRead_DeniesOnGrantedAccessStripped pins the READ access gate to
+// Open.GrantedAccess (post-DACL intersection at CREATE), not the pre-DACL
+// DesiredAccess. The scenario: a MAXIMUM_ALLOWED open whose DACL stripped
+// FILE_READ_DATA but whose DesiredAccess still records the requested mask.
+// Before the fix, hasReadAccess(DesiredAccess) returned true and the READ
+// silently succeeded; after the fix, hasReadAccess(GrantedAccess) returns
+// false and the handler must return STATUS_ACCESS_DENIED.
+//
+// Mirror-case for #616 (ChangeNotify), flagged by the #616 reviewer.
+func TestRead_DeniesOnGrantedAccessStripped(t *testing.T) {
+	h := NewHandler()
+
+	openFile := &OpenFile{
+		FileID:        [16]byte{0xDE, 0xAD},
+		Path:          "/share/secret.txt",
+		DesiredAccess: uint32(types.FileReadData), // requested
+		GrantedAccess: 0,                          // DACL stripped it
+	}
+	h.StoreOpenFile(openFile)
+
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	req := &ReadRequest{FileID: openFile.FileID, Length: 16, Offset: 0}
+	resp, err := h.Read(ctx, req)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if resp.Status != types.StatusAccessDenied {
+		t.Errorf("Read status = %v, want StatusAccessDenied — the gate is consulting DesiredAccess instead of GrantedAccess (#619 bug class B)", resp.Status)
+	}
+}
+
+// TestRead_AllowsOnGrantedAccess is the positive counterpart: when the
+// DACL granted FILE_READ_DATA the READ must NOT be denied at the access
+// gate. We stop before the actual content read (no MetadataHandle / block
+// store wired) — the assertion is that we do not get
+// STATUS_ACCESS_DENIED at the access gate.
+func TestRead_AllowsOnGrantedAccess(t *testing.T) {
+	h := NewHandler()
+
+	openFile := &OpenFile{
+		FileID:        [16]byte{0xBE, 0xEF},
+		Path:          "/share/public.txt",
+		DesiredAccess: 0,                          // pre-DACL not relevant
+		GrantedAccess: uint32(types.FileReadData), // DACL granted
+	}
+	h.StoreOpenFile(openFile)
+
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	req := &ReadRequest{FileID: openFile.FileID, Length: 16, Offset: 0}
+	resp, err := h.Read(ctx, req)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	// Past the access gate the handler tries to resolve a metadata handle
+	// and block store — that will fail with StatusInternalError or similar.
+	// The single invariant under test is: NOT StatusAccessDenied.
+	if resp.Status == types.StatusAccessDenied {
+		t.Errorf("Read returned StatusAccessDenied despite GrantedAccess including FILE_READ_DATA — the gate is wrongly looking at DesiredAccess")
+	}
+}
+
+// TestWrite_DeniesOnGrantedAccessStripped is the symmetric test for the
+// WRITE gate: DesiredAccess records FILE_WRITE_DATA but the DACL stripped
+// it, so GrantedAccess is 0 and WRITE must return STATUS_ACCESS_DENIED.
+func TestWrite_DeniesOnGrantedAccessStripped(t *testing.T) {
+	h := NewHandler()
+
+	openFile := &OpenFile{
+		FileID:        [16]byte{0xCA, 0xFE},
+		Path:          "/share/ro.txt",
+		DesiredAccess: uint32(types.FileWriteData), // requested
+		GrantedAccess: 0,                           // DACL stripped it
+	}
+	h.StoreOpenFile(openFile)
+
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	req := &WriteRequest{FileID: openFile.FileID, Data: []byte("hi"), Offset: 0}
+	resp, err := h.Write(ctx, req)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if resp.Status != types.StatusAccessDenied {
+		t.Errorf("Write status = %v, want StatusAccessDenied — the gate is consulting DesiredAccess instead of GrantedAccess (#619 bug class B)", resp.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -177,6 +177,16 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	}
 
 	// ========================================================================
+	// Step 2b: Prime auth context from OpenFile's recorded session
+	// ========================================================================
+	// CLOSE arrives keyed only by FileID — the SMB2 dispatcher has no user
+	// state to prefill ctx.User with. Without this hand-off BuildAuthContext
+	// would take the ctx.User==nil arm and synthesise UID-0 (root), bypassing
+	// DACL checks on the downstream metadata flush, delete-on-close unlink,
+	// and MFsymlink conversion (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
+	// ========================================================================
 	// Step 3: Flush cached data to block store (ensures durability)
 	// ========================================================================
 
@@ -563,6 +573,12 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	if len(openFile.ParentHandle) == 0 || openFile.FileName == "" {
 		return fmt.Errorf("missing parent handle or filename for MFsymlink conversion")
 	}
+
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
+	// the RemoveFile + CreateSymlink (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/v2/handlers/flush.go
+++ b/internal/adapter/smb/v2/handlers/flush.go
@@ -249,6 +249,12 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	// We must call FlushPendingWriteForFile to persist the metadata changes.
 	// Without this, file size and other metadata changes are lost.
 
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
+	// the metadata flush (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {
 		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", openFile.Path, "error", authErr)

--- a/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
@@ -379,6 +379,14 @@ func (h *Handler) executeCopyChunks(
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
+	// Prime ctx.User / IsGuest / TreeID from the destination open's recorded
+	// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls into
+	// the anonymous arm and synthesises UID-0 (root), bypassing DACL checks
+	// on the destination write (#619, same class as #603). srcOpen and
+	// dstOpen are required to share a SessionID by the upstream validator,
+	// so priming from dstOpen is equivalent to priming from srcOpen.
+	h.primeAuthContextFromOpenFile(ctx, dstOpen)
+
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		logger.Warn("COPYCHUNK: failed to build auth context", "error", err)

--- a/internal/adapter/smb/v2/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_fsctl.go
@@ -97,6 +97,12 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	}
 
 	if newMode != file.Mode {
+		// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded
+		// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls
+		// into the anonymous arm and synthesises UID-0 (root), bypassing
+		// DACL checks on SetFileAttributes (#619, same class as #603).
+		h.primeAuthContextFromOpenFile(ctx, openFile)
+
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
 			logger.Warn("FSCTL_SET_COMPRESSION: failed to build auth context", "error", authErr)

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -203,6 +203,12 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// Get metadata store
 	metaSvc := h.Registry.GetMetadataService()
 
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
+	// the downstream lock/unlock metadata operations (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
 	// Build auth context
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -347,6 +347,12 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 
 	var info []byte
 
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
+	// in the metadata layer (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {
 		logger.Warn("QUERY_INFO: failed to build auth context", "error", authErr)

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -170,11 +170,16 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Per MS-SMB2 3.3.5.15: The server MUST verify that the open was created
 	// with read access (FILE_READ_DATA). If the open lacks read access,
 	// return STATUS_ACCESS_DENIED.
+	//
+	// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE),
+	// not the pre-DACL DesiredAccess — otherwise a MAXIMUM_ALLOWED open whose
+	// DACL stripped FILE_READ_DATA would still pass this check (same fix
+	// class as #616 ChangeNotify).
 
-	if !hasReadAccess(openFile.DesiredAccess) {
+	if !hasReadAccess(openFile.GrantedAccess) {
 		logger.Debug("READ: no read access on handle",
 			"path", openFile.Path,
-			"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
+			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
 

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -208,11 +208,15 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 	}
 
 	// ========================================================================
-	// Step 1b: Validate DesiredAccess for SET_INFO
+	// Step 1b: Validate GrantedAccess for SET_INFO
 	// ========================================================================
 	// Per MS-SMB2 3.3.5.21.1: For attribute-setting info classes, the open
 	// must include FILE_WRITE_ATTRIBUTES. Rename/delete disposition/EOF have
 	// their own access checks later (DELETE, FILE_WRITE_DATA, etc.).
+	// The gate consults Open.GrantedAccess (post-DACL intersection at CREATE),
+	// not the pre-DACL DesiredAccess — otherwise a request that named
+	// FILE_WRITE_ATTRIBUTES but had it stripped by the DACL would still be
+	// allowed to mutate attributes (parity with #616 ChangeNotify fix).
 	if req.InfoType == types.SMB2InfoTypeFile {
 		switch types.FileInfoClass(req.FileInfoClass) {
 		case types.FileRenameInformation,
@@ -222,7 +226,7 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 			// These have specific access checks in their handlers or
 			// are validated by the metadata layer
 		default:
-			if !hasAccessRight(openFile.DesiredAccess, uint32(types.FileWriteAttributes)) {
+			if !hasAccessRight(openFile.GrantedAccess, uint32(types.FileWriteAttributes)) {
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 		}
@@ -231,6 +235,11 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 	// ========================================================================
 	// Step 2: Build AuthContext
 	// ========================================================================
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
+	// in the metadata layer (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
@@ -485,11 +494,13 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusInvalidParameter), nil
 		}
 
-		// Per MS-FSA 2.1.5.14.10: Rename requires DELETE access on the source file
-		if !hasDeleteAccess(openFile.DesiredAccess) {
+		// Per MS-FSA 2.1.5.14.10: Rename requires DELETE access on the source file.
+		// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE), not
+		// the pre-DACL DesiredAccess — same fix class as #616 (ChangeNotify).
+		if !hasDeleteAccess(openFile.GrantedAccess) {
 			logger.Debug("SET_INFO: rename without DELETE access",
 				"path", openFile.Path,
-				"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
+				"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
@@ -887,12 +898,14 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
-		// Per MS-FSA 2.1.5.14.3: Setting delete disposition requires DELETE access
+		// Per MS-FSA 2.1.5.14.3: Setting delete disposition requires DELETE access.
+		// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE), not
+		// the pre-DACL DesiredAccess — same fix class as #616 (ChangeNotify).
 		if deletePending {
-			if !hasDeleteAccess(openFile.DesiredAccess) {
+			if !hasDeleteAccess(openFile.GrantedAccess) {
 				logger.Debug("SET_INFO: delete disposition without DELETE access",
 					"path", openFile.Path,
-					"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
+					"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -90,6 +90,12 @@ func (h *Handler) handleGetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
 
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
+	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
+	// the downstream ReadSymlink (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
 	// Build auth context
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -187,11 +187,16 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Per MS-SMB2 3.3.5.16: The server MUST verify that the open was created
 	// with write access (FILE_WRITE_DATA or FILE_APPEND_DATA). If the open
 	// lacks write access, return STATUS_ACCESS_DENIED.
+	//
+	// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE),
+	// not the pre-DACL DesiredAccess — otherwise a MAXIMUM_ALLOWED open whose
+	// DACL stripped FILE_WRITE_DATA would still pass this check (same fix
+	// class as #616 ChangeNotify).
 
-	if !hasWriteAccess(openFile.DesiredAccess) {
+	if !hasWriteAccess(openFile.GrantedAccess) {
 		logger.Debug("WRITE: no write access on handle",
 			"path", openFile.Path,
-			"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
+			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
 


### PR DESCRIPTION
## Summary

Two mechanical correctness bug classes flagged by review of PRs #603 + #616.

### Bug class A — UID-0 root-bypass (#619)

9 handler sites called `BuildAuthContext(ctx)` without first priming `ctx.User` from the OpenFile's recorded session. With `User==nil`, `BuildAuthContext` synthesises UID-0 (root), bypassing all DACL checks in the metadata layer. Same bug class as #603 (QUERY_DIRECTORY) fixed in PR #618 via `h.primeAuthContextFromOpenFile(ctx, openFile)`.

Sites primed (one helper call before each `BuildAuthContext`):

| File | Function / purpose |
|---|---|
| `set_info.go:235` | SET_INFO file/security attribute mutations |
| `query_info.go:350` | QUERY_INFO file/security descriptor reads |
| `close.go:208` (Close)     | CLOSE deferred-metadata flush |
| `close.go:292` (Close)     | CLOSE delete-on-close unlink |
| `close.go:567` (convertToRealSymlink) | MFsymlink convert subroutine |
| `flush.go:252` | FLUSH deferred-metadata flush |
| `lock.go:207` | LOCK byte-range lock/unlock |
| `ioctl_copychunk.go:382` | FSCTL_SRV_COPYCHUNK destination write |
| `ioctl_fsctl.go:100` | FSCTL_SET_COMPRESSION attribute mutation |
| `stub_handlers.go:94` | FSCTL_GET_REPARSE_POINT symlink read |

(The three CLOSE sites collapse into a single prime at the top of `Close` since they share the same `openFile`; the MFsymlink subroutine `convertToRealSymlink` is its own primer call.)

### Bug class B — DesiredAccess vs GrantedAccess

5 handler sites gated access decisions on `openFile.DesiredAccess` (the pre-DACL request mask) instead of `openFile.GrantedAccess` (the post-DACL intersection computed at CREATE via `metadata.CheckFileAccess`). Same flaw as #616 (ChangeNotify), flagged by the #616 reviewer. A `MAXIMUM_ALLOWED` open whose DACL stripped the requested bit would still pass the gate.

Sites swapped:

| File | Gate | Spec |
|---|---|---|
| `read.go:174` (`hasReadAccess`) | FILE_READ_DATA on READ | MS-SMB2 §3.3.5.15 |
| `write.go:191` (`hasWriteAccess`) | FILE_WRITE_DATA on WRITE | MS-SMB2 §3.3.5.16 |
| `set_info.go:225` (FILE_WRITE_ATTRIBUTES) | SET_INFO attribute mutations | MS-SMB2 §3.3.5.21.1 |
| `set_info.go:489` (DELETE on rename) | rename source-handle gate | MS-FSA 2.1.5.14.10 |
| `set_info.go:892` (DELETE on delete-disposition) | dispose source-handle gate | MS-FSA 2.1.5.14.3 |

`OpenFile.GrantedAccess` is populated at CREATE (`create.go:1168` / `create_post_break.go:569`) per the existing godoc on the field — no plumbing change needed.

## Test plan

New tests in `internal/adapter/smb/v2/handlers/auth_priming_test.go`:

- `TestClose_PrimesAuthContextFromOpenFile` — CLOSE end-to-end primes `ctx.User` / `SessionID` / `TreeID` from the OpenFile's recorded session.
- `TestFlush_PrimesAuthContextFromOpenFile` — primer integrates with session/tree fixtures + negative control documenting that a bare `BuildAuthContext` does synthesise UID-0 root.
- `TestRead_DeniesOnGrantedAccessStripped` — READ returns `STATUS_ACCESS_DENIED` when DACL stripped FILE_READ_DATA from a handle whose `DesiredAccess` still records the request.
- `TestRead_AllowsOnGrantedAccess` — positive counterpart (does not return `StatusAccessDenied`).
- `TestWrite_DeniesOnGrantedAccessStripped` — symmetric WRITE negative.

Local verification:

- [x] `go build ./...`
- [x] `go vet ./internal/adapter/smb/...`
- [x] `go fmt ./internal/adapter/smb/...` (no diff)
- [x] `go test ./internal/adapter/smb/... -race -count=1` — all packages PASS
- [ ] CI smbtorture / WPTS — pure correctness, no flips expected; any incidental flips will be walked back in a follow-up `chore` PR per the standing workflow rule.

Refs: #619 (issue), #603 + #616 (sister fixes), #618 (helper landed here).