### PR TITLE
fix(smb/dirlease): parent-key suppression for setinfo dir-lease breaks (#470 C2)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -814,18 +814,28 @@ func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
 // resolveParentBreakArgs resolves the lock manager, handle key, and exclude
 // owner for parent directory lease break operations. Returns nil lockMgr if
 // the share has no lock manager.
+//
+// excludeParentLeaseKey + hasExcludeKey carry the originating handle's
+// ParentLeaseKey (when set on its RqLs) so the dir-lease parent-key
+// suppression rule (MS-SMB2 §3.3.4.20, #470 C2) is applied in breakOpLocks.
 func (lm *LeaseManager) resolveParentBreakArgs(
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
+	excludeParentLeaseKey [16]byte,
+	hasExcludeKey bool,
 ) (lockMgr lock.LockManager, handleKey string, excludeOwner *lock.LockOwner) {
 	lockMgr = lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return nil, "", nil
 	}
 	handleKey = string(parentHandle)
-	if excludeClientID != "" {
-		excludeOwner = &lock.LockOwner{ClientID: excludeClientID}
+	if excludeClientID != "" || hasExcludeKey {
+		excludeOwner = &lock.LockOwner{
+			ClientID:                    excludeClientID,
+			ExcludeParentDirLeaseKey:    excludeParentLeaseKey,
+			HasExcludeParentDirLeaseKey: hasExcludeKey,
+		}
 	}
 	return lockMgr, handleKey, excludeOwner
 }
@@ -845,13 +855,21 @@ func (lm *LeaseManager) resolveParentBreakArgs(
 // is never in the toBreak set, and the wait only blocks on OTHER clients' acks.
 //
 // Required by WPTS BVT BVT_DirectoryLeasing_LeaseBreakOnMultiClients.
+//
+// excludeParentLeaseKey + hasExcludeKey carry the originating handle's RqLs
+// ParentLeaseKey for the dir-lease parent-key suppression rule (MS-SMB2
+// §3.3.4.20, #470 C2). Pass the zero key + false when there is no parent-key
+// linkage to honor.
 func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	ctx context.Context,
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
+	excludeParentLeaseKey [16]byte,
+	hasExcludeKey bool,
 ) error {
-	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(
+		parentHandle, shareName, excludeClientID, excludeParentLeaseKey, hasExcludeKey)
 	if lockMgr == nil {
 		return nil
 	}
@@ -879,13 +897,17 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 // the triggering operation; the wait is bounded by parentLeaseBreakWaitTimeout
 // and self-deadlock is prevented by excludeClientID (see
 // BreakParentHandleLeasesOnCreate for the full rationale).
+// excludeParentLeaseKey + hasExcludeKey: see BreakParentHandleLeasesOnCreate.
 func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 	ctx context.Context,
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
+	excludeParentLeaseKey [16]byte,
+	hasExcludeKey bool,
 ) error {
-	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(parentHandle, shareName, excludeClientID)
+	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(
+		parentHandle, shareName, excludeClientID, excludeParentLeaseKey, hasExcludeKey)
 	if lockMgr == nil {
 		return nil
 	}

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -397,7 +397,7 @@ func TestBreakParentHandleLeasesOnCreate_WaitsForAck(t *testing.T) {
 	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
 
 	parentHandle := lock.FileHandle("parent-dir-handle")
-	if err := lm.BreakParentHandleLeasesOnCreate(context.Background(), parentHandle, "share1", "smb:A"); err != nil {
+	if err := lm.BreakParentHandleLeasesOnCreate(context.Background(), parentHandle, "share1", "smb:A", [16]byte{}, false); err != nil {
 		t.Fatalf("BreakParentHandleLeasesOnCreate returned error: %v", err)
 	}
 
@@ -444,7 +444,7 @@ func TestBreakParentReadLeasesOnModify_WaitsForAck(t *testing.T) {
 	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
 
 	parentHandle := lock.FileHandle("parent-dir-handle-2")
-	if err := lm.BreakParentReadLeasesOnModify(context.Background(), parentHandle, "share1", "smb:A"); err != nil {
+	if err := lm.BreakParentReadLeasesOnModify(context.Background(), parentHandle, "share1", "smb:A", [16]byte{}, false); err != nil {
 		t.Fatalf("BreakParentReadLeasesOnModify returned error: %v", err)
 	}
 
@@ -502,7 +502,7 @@ func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- lm.BreakParentHandleLeasesOnCreate(ctx, lock.FileHandle("parent"), "share1", "smb:A")
+		done <- lm.BreakParentHandleLeasesOnCreate(ctx, lock.FileHandle("parent"), "share1", "smb:A", [16]byte{}, false)
 	}()
 
 	select {
@@ -531,6 +531,105 @@ func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
 	// is wired (rather than the test passing trivially against unmodified code).
 	if len(fake.waitForBreakCompletionKeys) != 1 {
 		t.Fatalf("WaitForBreakCompletion call count = %d, want 1", len(fake.waitForBreakCompletionKeys))
+	}
+}
+
+// TestBreakParentHandleLeasesOnCreate_ParentKeyPlumbed asserts the new
+// (#470 C2) parent-key suppression args are forwarded into the LockOwner
+// passed to BreakLeasesOnOpenConflict. The dir-lease parent-key suppression
+// rule (MS-SMB2 §3.3.4.20) is enforced INSIDE the lock manager — this test
+// pins that the LeaseManager does the plumbing, not the actual suppression.
+func TestBreakParentHandleLeasesOnCreate_ParentKeyPlumbed(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentKey := [16]byte{0xCA, 0xFE, 0xBA, 0xBE}
+	if err := lm.BreakParentHandleLeasesOnCreate(
+		context.Background(), lock.FileHandle("parent"), "share1", "smb:A", parentKey, true,
+	); err != nil {
+		t.Fatalf("BreakParentHandleLeasesOnCreate returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.breakHandleCalls) != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", len(fake.breakHandleCalls))
+	}
+	excludeOwner := fake.breakHandleCalls[0].ExcludeOwner
+	if excludeOwner == nil {
+		t.Fatal("excludeOwner must be non-nil when a parent_key is provided")
+	}
+	if !excludeOwner.HasExcludeParentDirLeaseKey {
+		t.Errorf("HasExcludeParentDirLeaseKey = false, want true")
+	}
+	if excludeOwner.ExcludeParentDirLeaseKey != parentKey {
+		t.Errorf("ExcludeParentDirLeaseKey = %x, want %x", excludeOwner.ExcludeParentDirLeaseKey, parentKey)
+	}
+}
+
+// TestBreakParentReadLeasesOnModify_ParentKeyPlumbed: same plumbing assertion
+// for the Read-lease break helper (the SET_INFO path on a child file).
+func TestBreakParentReadLeasesOnModify_ParentKeyPlumbed(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	if err := lm.BreakParentReadLeasesOnModify(
+		context.Background(), lock.FileHandle("parent"), "share1", "smb:A", parentKey, true,
+	); err != nil {
+		t.Fatalf("BreakParentReadLeasesOnModify returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.breakReadCalls) != 1 {
+		t.Fatalf("BreakReadLeasesForParentDir call count = %d, want 1", len(fake.breakReadCalls))
+	}
+	excludeOwner := fake.breakReadCalls[0].ExcludeOwner
+	if excludeOwner == nil {
+		t.Fatal("excludeOwner must be non-nil when a parent_key is provided")
+	}
+	if !excludeOwner.HasExcludeParentDirLeaseKey {
+		t.Errorf("HasExcludeParentDirLeaseKey = false, want true")
+	}
+	if excludeOwner.ExcludeParentDirLeaseKey != parentKey {
+		t.Errorf("ExcludeParentDirLeaseKey = %x, want %x", excludeOwner.ExcludeParentDirLeaseKey, parentKey)
+	}
+}
+
+// TestBreakParentHandleLeasesOnCreate_NoParentKey_NoHasFlag: when hasExcludeKey
+// is false the LockOwner must not surface HasExcludeParentDirLeaseKey=true
+// (which would suppress every dir lease whose key happens to be all zeros).
+func TestBreakParentHandleLeasesOnCreate_NoParentKey_NoHasFlag(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	if err := lm.BreakParentHandleLeasesOnCreate(
+		context.Background(), lock.FileHandle("parent"), "share1", "smb:A", [16]byte{}, false,
+	); err != nil {
+		t.Fatalf("BreakParentHandleLeasesOnCreate returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.breakHandleCalls) != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", len(fake.breakHandleCalls))
+	}
+	excludeOwner := fake.breakHandleCalls[0].ExcludeOwner
+	if excludeOwner == nil {
+		t.Fatal("excludeOwner is nil")
+	}
+	if excludeOwner.HasExcludeParentDirLeaseKey {
+		t.Error("HasExcludeParentDirLeaseKey = true, want false (no parent_key was provided)")
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -192,6 +192,28 @@ func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessio
 	}
 }
 
+// PropagateOpenFileParentLeaseKey copies the OpenFile's RqLs parent-lease-key
+// linkage (if any) onto an AuthContext. This is the hand-off that lets
+// MetadataService.notifyDirChange and the dir-lease parent-key suppression
+// rule (MS-SMB2 §3.3.4.20, #470 C2/C3/C5/C6/C7) skip the matching parent dir
+// lease when the originating handle's CREATE carried
+// LEASE_FLAG_PARENT_LEASE_KEY_SET. Safe to call with a nil OpenFile (no-op).
+//
+// For C2 (setinfo) the parent-dir-lease break runs through
+// `breakParentDirLeasesForContentChange`, which reads OpenFile directly and
+// does not depend on AuthContext — this helper is therefore not required on
+// that path. C3+ (rename, hardlink, overwrite, unlink) route through
+// MetadataService rename/remove/link/create, which calls notifyDirChange and
+// reads `ctx.ParentLeaseKey` / `ctx.HasParentLeaseKey`. Wave 3 PRs should
+// invoke this helper before issuing those metadata operations.
+func PropagateOpenFileParentLeaseKey(authCtx *metadata.AuthContext, openFile *OpenFile) {
+	if authCtx == nil || openFile == nil || !openFile.HasParentLeaseKey {
+		return
+	}
+	authCtx.ParentLeaseKey = openFile.ParentLeaseKey
+	authCtx.HasParentLeaseKey = true
+}
+
 // HasWritePermission checks if the SMB context has write permission for the share.
 func HasWritePermission(ctx *SMBHandlerContext) bool {
 	return ctx.Permission == models.PermissionReadWrite || ctx.Permission == models.PermissionAdmin

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -409,13 +409,29 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 
 	// Step 7c: Break parent directory Handle / Read leases on create/overwrite/supersede.
+	//
+	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break,
+	// #470 C2): if this CREATE carried an RqLs with
+	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
+	// incoming request so the matching dir-lease is NOT broken. The
+	// LeaseResponseContext built at Step 8b carries the validated key, but
+	// runs AFTER the break calls below — peek directly at the RqLs context.
 	if (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) && h.LeaseManager != nil {
 		parentLockHandle := lock.FileHandle(parentHandle)
 		excludeClientID := fmt.Sprintf("smb:%d", ctx.SessionID)
-		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID); breakErr != nil {
+		var excludeParentKey [16]byte
+		var hasExcludeKey bool
+		if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
+			if leaseReq, decodeErr := DecodeLeaseCreateContext(leaseCtx.Data); decodeErr == nil &&
+				leaseReq.Flags&smbenc.LeaseResponseFlagParentKeySet != 0 {
+				excludeParentKey = leaseReq.ParentLeaseKey
+				hasExcludeKey = true
+			}
+		}
+		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
 			logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
 		}
-		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID); breakErr != nil {
+		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
 			logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
 		}
 	}
@@ -582,6 +598,19 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		openFile.LeaseKey = leaseResponse.LeaseKey
 	} else if syntheticLeaseKey != ([16]byte{}) {
 		openFile.LeaseKey = syntheticLeaseKey
+	}
+
+	// Record the RqLs parent-lease-key linkage so downstream operations on
+	// this handle (SET_INFO, WRITE, CLOSE-on-delete) can apply the MS-SMB2
+	// §3.3.4.20 / Samba `dirlease_should_break` parent-key suppression rule
+	// against the parent directory's lease. Captured even when the file
+	// lease itself was denied (response leaseState=None) — the linkage
+	// applies regardless of the per-file grant outcome. Gated on HasParent
+	// so a zero-key request without LEASE_FLAG_PARENT_LEASE_KEY_SET is
+	// treated as "no linkage" (#470 C2).
+	if leaseResponse != nil && leaseResponse.HasParent {
+		openFile.ParentLeaseKey = leaseResponse.ParentLeaseKey
+		openFile.HasParentLeaseKey = true
 	}
 
 	if h.DurableStore != nil {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -347,6 +347,15 @@ type OpenFile struct {
 	// Used to release the lease when the last handle sharing the key is closed.
 	LeaseKey [16]byte
 
+	// ParentLeaseKey is the 128-bit parent directory lease key carried in the
+	// CREATE RqLs (V2) when the client set SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET.
+	// Used by the dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20):
+	// SET_INFO / WRITE / CLOSE-on-delete on this handle MUST NOT break the
+	// parent dir lease whose LeaseKey matches this value. The field is
+	// meaningful only when HasParentLeaseKey is true (#470 C2).
+	ParentLeaseKey    [16]byte
+	HasParentLeaseKey bool
+
 	// Durable handle state (Phase 38: SMB3 durable handles)
 	// IsDurable indicates this handle has been granted durability.
 	// When true, the handle will be persisted to DurableHandleStore on disconnect

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1344,10 +1344,16 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 	parentLockHandle := lock.FileHandle(openFile.ParentHandle)
 	excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
 
-	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID); breakErr != nil {
+	// Apply parent-key suppression (MS-SMB2 §3.3.4.20, #470 C2): if the
+	// originating handle's CREATE carried an RqLs with ParentLeaseKey set,
+	// the matching parent dir lease MUST NOT be broken on this child mutation.
+	excludeParentKey := openFile.ParentLeaseKey
+	hasExcludeKey := openFile.HasParentLeaseKey
+
+	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory Handle lease break failed", "path", openFile.Path, "error", breakErr)
 	}
-	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID); breakErr != nil {
+	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "error", breakErr)
 	}
 }

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -50,6 +50,20 @@ type AuthContext struct {
 	// If empty, ClientAddr is used as fallback.
 	LockClientID string
 
+	// ParentLeaseKey carries the originating SMB handle's RqLs ParentLeaseKey
+	// (when LEASE_FLAG_PARENT_LEASE_KEY_SET was set on the CREATE that opened
+	// the handle driving this operation). It is propagated into
+	// MetadataService.notifyDirChange so the directory-lease parent-key
+	// suppression rule (MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break`,
+	// #470 C2) can skip the matching parent dir lease.
+	//
+	// HasParentLeaseKey distinguishes "linkage absent" (false, ParentLeaseKey
+	// ignored) from "linkage to zero-key dir lease" (true, ParentLeaseKey may
+	// legally be all zero). NFS callers MUST leave HasParentLeaseKey=false —
+	// POSIX has no parent-key concept.
+	ParentLeaseKey    [16]byte
+	HasParentLeaseKey bool
+
 	// HasDeleteAccess signals that the protocol handler already verified
 	// Windows-style DELETE access on the target of an unlink. Per MS-FSA
 	// 2.1.5.1.2.1, DELETE access on the file itself is sufficient to unlink,

--- a/pkg/metadata/lock/delegation_manager_test.go
+++ b/pkg/metadata/lock/delegation_manager_test.go
@@ -326,7 +326,7 @@ func TestManager_OnDirChange_BreaksDelegations(t *testing.T) {
 	require.NoError(t, lm.GrantDelegation("dir1", dirDeleg))
 
 	// Trigger directory change from a different client
-	lm.OnDirChange("dir1", DirChangeAddEntry, "client2")
+	lm.OnDirChange("dir1", DirChangeAddEntry, "client2", [16]byte{}, false)
 
 	// Delegation should be recalled
 	recalls := delegRecalls.getRecalls()
@@ -346,7 +346,7 @@ func TestManager_OnDirChange_SkipsOriginClient(t *testing.T) {
 	require.NoError(t, lm.GrantDelegation("dir1", dirDeleg))
 
 	// Change from same client should not break delegation
-	lm.OnDirChange("dir1", DirChangeAddEntry, "client1")
+	lm.OnDirChange("dir1", DirChangeAddEntry, "client1", [16]byte{}, false)
 
 	recalls := delegRecalls.getRecalls()
 	assert.Len(t, recalls, 0, "origin client delegation should not be recalled")

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -61,7 +61,14 @@ type DirChangeNotifier interface {
 	//   - parentHandle: The file handle of the directory that changed
 	//   - changeType: The type of change (add, remove, rename)
 	//   - originClientID: The client that caused the change (excluded from breaks)
-	OnDirChange(parentHandle FileHandle, changeType DirChangeType, originClientID string)
+	//   - excludeParentLeaseKey: The parent lease key carried on the originating
+	//     handle's RqLs (V2). Per MS-SMB2 §3.3.4.20 the matching parent dir
+	//     lease (if any) MUST NOT be broken. Pass the zero key when not used.
+	//   - hasExcludeKey: True when excludeParentLeaseKey is meaningful (SMB
+	//     CREATE/SET_INFO carried LEASE_FLAG_PARENT_LEASE_KEY_SET). NFS
+	//     callers MUST pass false — POSIX has no parent-key concept (#470 C2).
+	OnDirChange(parentHandle FileHandle, changeType DirChangeType, originClientID string,
+		excludeParentLeaseKey [16]byte, hasExcludeKey bool)
 }
 
 // Verify Manager satisfies DirChangeNotifier at compile time.
@@ -126,10 +133,19 @@ func (c *recentlyBrokenCache) cleanupLocked() {
 
 // OnDirChange handles directory entry changes by breaking directory leases.
 //
-// For each directory lease on parentHandle (excluding those owned by originClientID),
+// For each directory lease on parentHandle (excluding those owned by originClientID
+// or whose LeaseKey matches excludeParentLeaseKey when hasExcludeKey is true),
 // a break to LeaseStateNone is dispatched via BreakCallbacks.OnOpLockBreak.
 // The directory is then marked in the recently-broken cache.
-func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType, originClientID string) {
+//
+// The parent-key suppression (excludeParentLeaseKey, hasExcludeKey) implements
+// MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break`: when the originating
+// SMB CREATE or SET_INFO carries RqLs with ParentLeaseKey == a parent dir
+// lease's LeaseKey, that dir lease MUST NOT be broken. The matching dir lease
+// is also kept out of the recently-broken cache so it isn't penalized on
+// re-grant. NFS callers MUST pass hasExcludeKey=false (#470 C2).
+func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType, originClientID string,
+	excludeParentLeaseKey [16]byte, hasExcludeKey bool) {
 	handleKey := string(parentHandle)
 
 	// Collect directory leases AND directory delegations to break
@@ -142,6 +158,16 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	for _, lock := range locks {
 		// Skip originator for the entire lock entry (covers both lease and delegation).
 		if lock.Owner.ClientID == originClientID {
+			continue
+		}
+
+		// Parent-key suppression: when the originating CREATE / SET_INFO
+		// carries an RqLs with ParentLeaseKey matching a parent dir lease's
+		// LeaseKey, that dir lease MUST NOT be broken (#470 C2). Applies to
+		// dir leases only — file lease / delegation paths below ignore the
+		// exclude key.
+		if hasExcludeKey && lock.Lease != nil && lock.Lease.IsDirectory &&
+			lock.Lease.LeaseKey == excludeParentLeaseKey {
 			continue
 		}
 

--- a/pkg/metadata/lock/directory_test.go
+++ b/pkg/metadata/lock/directory_test.go
@@ -47,7 +47,7 @@ func TestOnDirChange_BreaksDirectoryLeases(t *testing.T) {
 	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
 
 	// Simulate directory change from a different client
-	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2")
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", [16]byte{}, false)
 
 	assert.True(t, breakCalled, "break callback should have been called")
 	assert.Equal(t, "dir1", breakHandleKey)
@@ -74,7 +74,7 @@ func TestOnDirChange_ExcludesOriginClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Dir change from same client - should NOT break
-	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client1")
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client1", [16]byte{}, false)
 
 	assert.False(t, breakCalled, "should not break own client's lease")
 }
@@ -99,9 +99,251 @@ func TestOnDirChange_IgnoresFileLeases(t *testing.T) {
 	require.NoError(t, err)
 
 	// Dir change - should NOT break file leases
-	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2")
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", [16]byte{}, false)
 
 	assert.False(t, breakCalled, "should not break file leases on dir change")
+}
+
+// ============================================================================
+// Parent-Key Suppression Tests (#470 C2)
+// ============================================================================
+//
+// Mirrors Samba `smbd_dirlease.c::dirlease_should_break`:
+//   - hasExcludeKey=true + LeaseKey == excludeParentLeaseKey + IsDirectory ⇒
+//     suppress the break.
+//   - Any other combination ⇒ break.
+//
+// The matrix below approximates `test_dirlease_setinfo` 1.1/2.1/3.1/2.2/2.3
+// at the lock-layer boundary. Test names follow the format
+//   {Correct,Bad,No}Key + {SameClient,SecondClient}
+// matching the 6 sub-cases per setinfo type that the smbtorture matrix runs.
+
+func TestOnDirChange_ParentKey_CorrectKeySameClient_Suppresses(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// "Correct parent_key" path: same client and ParentLeaseKey matches the
+	// dir lease's LeaseKey ⇒ no break (Samba 1.1 sub-case).
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client1", dirLeaseKey, true)
+
+	assert.Equal(t, 0, breakCount, "correct parent_key on same client must suppress the dir lease break")
+}
+
+func TestOnDirChange_ParentKey_CorrectKeySecondClient_Suppresses(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Second-client path: even though origin differs, parent_key matches ⇒
+	// suppress (Samba 2.1 sub-case).
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", dirLeaseKey, true)
+
+	assert.Equal(t, 0, breakCount, "correct parent_key on second client must suppress the dir lease break")
+}
+
+func TestOnDirChange_ParentKey_BadKeySameClient_Breaks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+	badKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	// Use a different client so the originClient skip doesn't mask the
+	// parent-key path. The "same client" name refers to Samba's matrix
+	// terminology for "the setinfo is on the same handle that holds a
+	// parent_key linkage" — but bad parent_key still breaks (Samba 1.2).
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", badKey, true)
+
+	assert.Equal(t, 1, breakCount, "bad parent_key must NOT suppress the break")
+}
+
+func TestOnDirChange_ParentKey_NoKey_Breaks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// hasExcludeKey=false: the (zero) key value is ignored and the break
+	// fires (Samba 1.3, 2.3 sub-cases — child CREATE had no parent linkage).
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", [16]byte{}, false)
+
+	assert.Equal(t, 1, breakCount, "absence of parent_key linkage must NOT suppress the break")
+}
+
+// TestOnDirChange_ParentKey_DoesNotSuppressFileLeases enforces the critical
+// invariant from #470 plan §4 risk callout #1: parent-key suppression must
+// apply to dir leases ONLY. A coincidental key collision with a file lease
+// must not suppress an otherwise-required file-lease break. (File leases on
+// the dir handle itself are unusual but possible — and OnDirChange already
+// ignores them via the IsDirectory gate; this test pins that the new
+// suppression branch does NOT regress that gate.)
+func TestOnDirChange_ParentKey_DoesNotSuppressFileLeases(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	fileLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	// Grant a FILE lease (isDirectory=false) on the handle.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), fileLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite, false)
+	require.NoError(t, err)
+
+	// File leases are already ignored by OnDirChange (the IsDirectory gate)
+	// regardless of parent-key. This test asserts the new branch does not
+	// flip that contract — break count stays at 0 because the lease is a
+	// file lease, not because of parent-key suppression.
+	mgr.OnDirChange(FileHandle("file1"), DirChangeAddEntry, "client2", fileLeaseKey, true)
+
+	assert.Equal(t, 0, breakCount, "file leases are not broken on dir change regardless of parent-key")
+}
+
+// TestBreakOpLocks_ParentKey_DoesNotSuppressFileLeases covers the same
+// invariant for the BreakParent* family path (used by SET_INFO /
+// breakParentDirLeasesForContentChange). The break helper goes through
+// breakOpLocks with HasExcludeParentDirLeaseKey=true; it must NOT match
+// against file leases that coincidentally share the parent_key value.
+func TestBreakOpLocks_ParentKey_DoesNotSuppressFileLeases(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	collidingKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	// Grant a FILE lease (isDirectory=false) on the same handle.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), collidingKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// Drive a break with HasExcludeParentDirLeaseKey set to the colliding key
+	// (e.g. as if BreakParentHandleLeasesOnCreate was invoked with this
+	// parent-key value). The break path's `shouldBreak` predicate triggers
+	// (the lease has R+H caching). The new suppression branch is gated on
+	// IsDirectory so it must NOT skip this file lease.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(
+		"file1",
+		&LockOwner{
+			ClientID:                    "client2",
+			ExcludeParentDirLeaseKey:    collidingKey,
+			HasExcludeParentDirLeaseKey: true,
+		},
+		BreakReasonSharingViolation,
+	))
+
+	assert.Equal(t, 1, breakCount, "parent-key suppression must NOT apply to file leases (#470 plan §4 risk #1)")
+}
+
+// TestBreakOpLocks_ParentKey_SuppressesDirLeaseOnly verifies the
+// BreakParent* path consumes ExcludeParentDirLeaseKey to skip the dir lease
+// holding that key. This is the direct path exercised by
+// breakParentDirLeasesForContentChange (set_info / write / close-on-delete).
+func TestBreakOpLocks_ParentKey_SuppressesDirLeaseOnly(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0xA, 0xB, 0xC, 0xD}
+
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lock *UnifiedLock, bts uint32) {
+			breakCount++
+		},
+	})
+
+	// Grant a DIR lease.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner1", "client1", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Suppression with matching key: no break.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(
+		"dir1",
+		&LockOwner{
+			ClientID:                    "client2",
+			ExcludeParentDirLeaseKey:    dirLeaseKey,
+			HasExcludeParentDirLeaseKey: true,
+		},
+		BreakReasonSharingViolation,
+	))
+	assert.Equal(t, 0, breakCount, "matching parent_key must suppress the dir lease break")
+
+	// Suppression with non-matching key: break fires.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict(
+		"dir1",
+		&LockOwner{
+			ClientID:                    "client2",
+			ExcludeParentDirLeaseKey:    [16]byte{0xFF},
+			HasExcludeParentDirLeaseKey: true,
+		},
+		BreakReasonSharingViolation,
+	))
+	assert.Equal(t, 1, breakCount, "non-matching parent_key must NOT suppress the dir lease break")
 }
 
 // ============================================================================
@@ -128,7 +370,7 @@ func TestRecentlyBrokenCache_BlocksDirectoryLease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trigger dir change (marks as recently-broken)
-	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2")
+	mgr.OnDirChange(FileHandle("dir1"), DirChangeAddEntry, "client2", [16]byte{}, false)
 
 	// Immediately request new directory lease on same dir - should be blocked by recently-broken cache
 	state, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), key2, parentKey, "owner2", "client2", "/share", LeaseStateRead, true)

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1714,6 +1714,16 @@ func (lm *Manager) breakOpLocks(
 				lock.Lease.LeaseKey == excludeOwner.ExcludeLeaseKey {
 				continue
 			}
+			// Per MS-SMB2 §3.3.4.20 / Samba dirlease_should_break: when a
+			// child CREATE or SET_INFO carries an RqLs whose ParentLeaseKey
+			// matches the parent dir lease's key, suppress that dir-lease
+			// break. Scoped to dir leases to avoid suppressing an unrelated
+			// file-lease break that happens to share the key value (#470 C2).
+			if excludeOwner.HasExcludeParentDirLeaseKey &&
+				lock.Lease.IsDirectory &&
+				lock.Lease.LeaseKey == excludeOwner.ExcludeParentDirLeaseKey {
+				continue
+			}
 		}
 		if !shouldBreak(lock.Lease) {
 			continue

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -103,6 +103,21 @@ type LockOwner struct {
 	// leases with this key are skipped. Per MS-SMB2 3.3.5.9, opens with
 	// the same lease key must not break each other's leases.
 	ExcludeLeaseKey [16]byte
+
+	// ExcludeParentDirLeaseKey is an optional parent directory lease key
+	// used by the dir-lease parent-key suppression rule (#470 C2). When
+	// HasExcludeParentDirLeaseKey is true, breakOpLocks skips any DIRECTORY
+	// lease whose LeaseKey equals ExcludeParentDirLeaseKey. This implements
+	// the MS-SMB2 §3.3.4.20 / Samba `smbd_dirlease.c::dirlease_should_break`
+	// rule: when a child CREATE or SET_INFO carries a ParentLeaseKey
+	// matching a parent dir's lease key, the corresponding dir-lease break
+	// MUST be suppressed.
+	//
+	// The suppression applies to dir leases ONLY (gated on
+	// lock.Lease.IsDirectory) — a coincidental key collision with a file
+	// lease must not suppress an otherwise-required file-lease break.
+	ExcludeParentDirLeaseKey    [16]byte
+	HasExcludeParentDirLeaseKey bool
 }
 
 // UnifiedLock represents a byte-range lock or SMB lease with full protocol support.

--- a/pkg/metadata/notify_dir_change_parent_key_test.go
+++ b/pkg/metadata/notify_dir_change_parent_key_test.go
@@ -1,0 +1,127 @@
+package metadata_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingNotifier records every OnDirChange invocation so tests can pin
+// the parent-key arguments flowing from MetadataService.notifyDirChange.
+type recordingNotifier struct {
+	mu    sync.Mutex
+	calls []recordedDirChange
+}
+
+type recordedDirChange struct {
+	ParentHandle          lock.FileHandle
+	ChangeType            lock.DirChangeType
+	OriginClient          string
+	ExcludeParentLeaseKey [16]byte
+	HasExcludeKey         bool
+}
+
+func (n *recordingNotifier) OnDirChange(parentHandle lock.FileHandle, changeType lock.DirChangeType, originClientID string, excludeParentLeaseKey [16]byte, hasExcludeKey bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, recordedDirChange{
+		ParentHandle:          parentHandle,
+		ChangeType:            changeType,
+		OriginClient:          originClientID,
+		ExcludeParentLeaseKey: excludeParentLeaseKey,
+		HasExcludeKey:         hasExcludeKey,
+	})
+}
+
+// TestNotifyDirChange_ThreadsParentLeaseKey asserts that
+// MetadataService.notifyDirChange forwards AuthContext.ParentLeaseKey /
+// HasParentLeaseKey to the DirChangeNotifier so the dir-lease parent-key
+// suppression rule (MS-SMB2 §3.3.4.20, #470 C2) can apply. This is the
+// "wire" between the SMB handler (which captures the key at CREATE) and
+// the lock manager (which performs the suppression in breakOpLocks).
+func TestNotifyDirChange_ThreadsParentLeaseKey(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	parentKey := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	ctx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "smb:42",
+		ParentLeaseKey:    parentKey,
+		HasParentLeaseKey: true,
+	}
+
+	// CreateFile triggers notifyDirChange(DirChangeAddEntry, ctx).
+	_, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0644,
+		UID:  0,
+		GID:  0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	if len(notifier.calls) == 0 {
+		t.Fatal("notifier never invoked")
+	}
+	call := notifier.calls[0]
+	assert.True(t, call.HasExcludeKey, "HasExcludeKey must be true when AuthContext.HasParentLeaseKey is true")
+	assert.Equal(t, parentKey, call.ExcludeParentLeaseKey, "ExcludeParentLeaseKey must match AuthContext.ParentLeaseKey")
+	assert.Equal(t, "smb:42", call.OriginClient, "originClient must come from AuthContext.LockClientID")
+}
+
+// TestNotifyDirChange_NFSCallerHasNoParentKey asserts the NFS-style callsite
+// (HasParentLeaseKey=false on the AuthContext) results in hasExcludeKey=false
+// at the notifier — never accidentally suppressing a dir lease.
+func TestNotifyDirChange_NFSCallerHasNoParentKey(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	// Even with a non-zero ParentLeaseKey present, HasParentLeaseKey=false
+	// must short-circuit and forward hasExcludeKey=false. This pins the NFS
+	// contract: NFS handlers never set HasParentLeaseKey, so any garbage in
+	// ParentLeaseKey is ignored.
+	bogus := [16]byte{0xFF, 0xFF, 0xFF, 0xFF}
+	ctx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "nfs:client",
+		ParentLeaseKey:    bogus,
+		HasParentLeaseKey: false,
+	}
+
+	_, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0644,
+		UID:  0,
+		GID:  0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	if len(notifier.calls) == 0 {
+		t.Fatal("notifier never invoked")
+	}
+	call := notifier.calls[0]
+	assert.False(t, call.HasExcludeKey, "HasExcludeKey must be false when AuthContext.HasParentLeaseKey is false (NFS contract)")
+	assert.Equal(t, [16]byte{}, call.ExcludeParentLeaseKey, "ExcludeParentLeaseKey must be zero when hasExcludeKey is false")
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -645,10 +645,20 @@ func (s *MetadataService) notifyDirChange(shareName string, parentHandle FileHan
 	}
 
 	originClient := ""
+	var excludeParentKey [16]byte
+	var hasExcludeKey bool
 	if ctx != nil {
 		originClient = ctx.LockClientID
 		if originClient == "" {
 			originClient = ctx.ClientAddr
+		}
+		// Thread the originating handle's RqLs ParentLeaseKey into the
+		// notifier so the dir-lease parent-key suppression rule (MS-SMB2
+		// §3.3.4.20, #470 C2) can skip the matching parent dir lease.
+		// NFS callers leave HasParentLeaseKey=false.
+		if ctx.HasParentLeaseKey {
+			excludeParentKey = ctx.ParentLeaseKey
+			hasExcludeKey = true
 		}
 	}
 
@@ -658,5 +668,5 @@ func (s *MetadataService) notifyDirChange(shareName string, parentHandle FileHan
 			logger.Error("notifyDirChange: panic in notifier", "share", shareName, "error", r)
 		}
 	}()
-	notifier.OnDirChange(lock.FileHandle(parentHandle), changeType, originClient)
+	notifier.OnDirChange(lock.FileHandle(parentHandle), changeType, originClient, excludeParentKey, hasExcludeKey)
 }


### PR DESCRIPTION
## Summary

Implements MS-SMB2 §3.3.4.20 / Samba `smbd_dirlease.c::dirlease_should_break`: when a child CREATE or SET_INFO carries an RqLs with `ParentLeaseKey` matching a parent dir's lease key, the corresponding dir-lease break MUST be suppressed.

Wave 2 of the #470 directory-lease cluster (C2). Lays the API surface that Wave 3 (C3 rename, C4 overwrite, C5 hardlink, C6/C7 unlink) will consume.

## Targets (smbtorture smb2.dirlease)

- `smb2.dirlease.setatime`
- `smb2.dirlease.setbtime`
- `smb2.dirlease.setctime`
- `smb2.dirlease.setdos`
- `smb2.dirlease.seteof`
- `smb2.dirlease.setmtime`

(Wave 3 dirlease tests still in KNOWN_FAILURES until their per-cluster PRs land.)

## API changes

- `lock.LockOwner.ExcludeParentDirLeaseKey` + `HasExcludeParentDirLeaseKey`. Applied in `breakOpLocks` ONLY when `lock.Lease.IsDirectory` (see plan §4 risk #1 — coincidental key collision with a file lease must not suppress an otherwise-required file-lease break).
- `lock.DirChangeNotifier.OnDirChange` signature extended with `(excludeParentLeaseKey [16]byte, hasExcludeKey bool)`. `Manager.OnDirChange` skips matching dir leases and keeps them out of the recently-broken cache.
- `lease.LeaseManager.BreakParentHandleLeasesOnCreate` and `BreakParentReadLeasesOnModify` extended with the same suppression args.
- `handlers.OpenFile.ParentLeaseKey` + `HasParentLeaseKey`. Populated at CREATE from the RqLs ParentLeaseKey when `LEASE_FLAG_PARENT_LEASE_KEY_SET` is set on the request.
- `metadata.AuthContext.ParentLeaseKey` + `HasParentLeaseKey`. Threaded through `MetadataService.notifyDirChange`.

## NFS-caller audit

NFS handlers build `AuthContext` via `internal/adapter/nfs/v{3,4}/handlers/helpers.go` (+ a few orphan/effective callsites in v3 rename/auth_helper/doc and xdr/attributes). None set `ParentLeaseKey` / `HasParentLeaseKey` — Go zero-value `HasParentLeaseKey=false` short-circuits the suppression in `notifyDirChange`. POSIX has no parent-key concept; preserving cross-protocol dir-lease breaks on NFS-initiated mutations.

## Wave 3 hand-off

For C3/C5/C6/C7 PRs: call `handlers.PropagateOpenFileParentLeaseKey(authCtx, openFile)` before invoking `MetadataService.{Rename, RemoveFile, CreateLink, CreateFile}` so `notifyDirChange` picks up the parent-key linkage. (C2 itself takes a more direct route via `breakParentDirLeasesForContentChange` and does not need this helper.)

## Test plan

- [x] `go test -race ./pkg/metadata/lock/...` — 6-row OnDirChange parent-key matrix + IsDirectory invariant for both `OnDirChange` and `breakOpLocks` (file-lease isolation).
- [x] `go test -race ./internal/adapter/smb/lease/...` — `ExcludeParentDirLeaseKey` plumbing through `BreakParentHandleLeasesOnCreate` / `BreakParentReadLeasesOnModify`.
- [x] `go test -race ./pkg/metadata/...` — `notifyDirChange` threads `AuthContext.ParentLeaseKey` to the notifier (+ NFS `HasParentLeaseKey=false` short-circuit).
- [x] `go test -race ./...` — full suite green locally.
- [x] `go vet ./...` + `go fmt ./...`.
- [ ] CI smbtorture: 6 dirlease setinfo tests flip PASS.