### PR TITLE
fix(smb/dirlease): break dst-parent dir-lease on hardlink with parent-key suppression (#470 C5)

### DIFF
--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -537,6 +537,7 @@ const (
 	FileAccessInformation          FileInfoClass = 8
 	FileNameInformation            FileInfoClass = 9
 	FileRenameInformation          FileInfoClass = 10
+	FileLinkInformation            FileInfoClass = 11
 	FileNamesInformation           FileInfoClass = 12
 	FileDispositionInformation     FileInfoClass = 13
 	FilePositionInformation        FileInfoClass = 14

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -220,6 +220,7 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 	if req.InfoType == types.SMB2InfoTypeFile {
 		switch types.FileInfoClass(req.FileInfoClass) {
 		case types.FileRenameInformation,
+			types.FileLinkInformation,
 			types.FileDispositionInformation, types.FileDispositionInformationEx,
 			types.FileEndOfFileInformation, types.FileAllocationInformation,
 			15: // FileFullEaInformation
@@ -1022,8 +1023,11 @@ func (h *Handler) setFileInfoFromStore(
 		// Set allocation size - accept but treat as no-op (allocation handled automatically)
 		return setInfoStatus(types.StatusSuccess), nil
 
-	case 11: // FileLinkInformation - hard links not supported
-		return setInfoStatus(types.StatusNotSupported), nil
+	case types.FileLinkInformation:
+		// FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2 — hard link creation.
+		// Wire format mirrors FILE_RENAME_INFORMATION: ReplaceIfExists (1B),
+		// Reserved (7B), RootDirectory (8B), FileNameLength (4B), FileName (UTF-16LE).
+		return h.handleFileLinkInformation(authCtx, openFile, buffer)
 
 	case 15: // FileFullEaInformation [MS-FSCC] 2.4.15 - Extended attributes
 		// Accept EA writes as a no-op. DittoFS does not persist extended attributes
@@ -1369,4 +1373,200 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "error", breakErr)
 	}
+}
+
+// FileLinkInfo represents FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2.
+// The wire format mirrors FILE_RENAME_INFORMATION (same byte layout).
+type FileLinkInfo struct {
+	// ReplaceIfExists indicates whether to replace an existing file at the
+	// destination. Hard-link creation rejects collisions when this is false.
+	ReplaceIfExists bool
+
+	// RootDirectory is the file handle of the destination directory, or all
+	// zeros to indicate FileName is a full path relative to the share root.
+	RootDirectory [8]byte
+
+	// FileName is the path to the new hard link (UTF-16LE on the wire).
+	FileName string
+}
+
+// DecodeFileLinkInfo parses FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2.
+// Returns an error if the buffer is less than 20 bytes (fixed header) or the
+// declared FileNameLength would read past buffer end.
+func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
+	if len(buffer) < 20 {
+		return nil, fmt.Errorf("buffer too short for FILE_LINK_INFORMATION: %d bytes", len(buffer))
+	}
+
+	info := &FileLinkInfo{
+		ReplaceIfExists: buffer[0] != 0,
+	}
+	// Reserved (7 bytes at offset 1-7) - skip
+	copy(info.RootDirectory[:], buffer[8:16])
+
+	r := smbenc.NewReader(buffer[16:20])
+	fileNameLength := r.ReadUint32()
+
+	if len(buffer) < 20+int(fileNameLength) {
+		return nil, fmt.Errorf("buffer too short for filename: need %d, have %d", 20+fileNameLength, len(buffer))
+	}
+	if fileNameLength > 0 {
+		info.FileName = decodeUTF16LE(buffer[20 : 20+fileNameLength])
+	}
+	return info, nil
+}
+
+// handleFileLinkInformation implements SET_INFO FileLinkInformation [MS-FSCC]
+// 2.4.21.2: create a new hard link to the open file in the requested
+// destination directory.
+//
+// Per MS-FSA 2.1.5.14.5: the operation creates a NEW directory entry in the
+// destination directory that references the same file ID as the open file.
+// Returns STATUS_OBJECT_NAME_COLLISION if the destination already exists and
+// ReplaceIfExists is FALSE; STATUS_FILE_IS_A_DIRECTORY if the open file is a
+// directory (hard-linking directories is forbidden, MS-FSA 2.1.5.14.5).
+//
+// Directory-lease coordination (#470 C5 — smb2.dirlease.hardlink): a hardlink
+// is an add-entry in the destination parent. We thread the open file's RqLs
+// ParentLeaseKey into the auth context so:
+//   - MetadataService.notifyDirChange forwards it to OnDirChange, which
+//     suppresses the matching dst-parent dir lease (parent-key match).
+//   - LeaseManager.BreakParentHandleLeasesOnCreate / BreakParentReadLeasesOnModify
+//     called directly on the dst-parent honor the same suppression rule.
+//
+// This mirrors Samba `dlt_hardlinks` matrix (source4/torture/smb2/lease.c):
+// same-dir + same-parent-key suppresses; same-dir + different-parent-key
+// breaks; cross-dir always breaks the dst parent unless its key matches.
+func (h *Handler) handleFileLinkInformation(
+	authCtx *metadata.AuthContext,
+	openFile *OpenFile,
+	buffer []byte,
+) (*SetInfoResponse, error) {
+	linkInfo, err := DecodeFileLinkInfo(buffer)
+	if err != nil {
+		logger.Debug("SET_INFO: failed to decode link info", "error", err)
+		return setInfoStatus(types.StatusInvalidParameter), nil
+	}
+
+	// Hard-linking a directory is forbidden (MS-FSA 2.1.5.14.5).
+	if openFile.IsDirectory {
+		logger.Debug("SET_INFO: hardlink on directory rejected",
+			"path", openFile.Path)
+		return setInfoStatus(types.StatusFileIsADirectory), nil
+	}
+
+	// Normalize path separators (Windows uses backslash, we use forward slash).
+	newPath := strings.ReplaceAll(linkInfo.FileName, "\\", "/")
+	newPath = strings.TrimPrefix(newPath, "/")
+	if newPath == "" {
+		logger.Debug("SET_INFO: hardlink with empty destination name")
+		return setInfoStatus(types.StatusInvalidParameter), nil
+	}
+
+	// Resolve destination directory + link name.
+	var dstDir metadata.FileHandle
+	var linkName string
+
+	var zeroRootDir [8]byte
+	if !bytes.Equal(linkInfo.RootDirectory[:], zeroRootDir[:]) {
+		// Non-zero RootDirectory: FileName is relative to it. We don't yet
+		// resolve FileId handles to directory handles (parity with rename);
+		// fall back to same-directory link.
+		logger.Debug("SET_INFO: hardlink with non-zero RootDirectory (using same-dir fallback)",
+			"rootDirectory", fmt.Sprintf("%x", linkInfo.RootDirectory))
+		dstDir = openFile.ParentHandle
+		linkName = path.Base(newPath)
+	} else {
+		tree, ok := h.GetTree(openFile.TreeID)
+		if !ok {
+			logger.Debug("SET_INFO: invalid tree for hardlink", "treeID", openFile.TreeID)
+			return setInfoStatus(types.StatusInvalidHandle), nil
+		}
+		rootHandle, err := h.Registry.GetRootHandle(tree.ShareName)
+		if err != nil {
+			logger.Debug("SET_INFO: failed to get root handle for hardlink", "error", err)
+			return setInfoStatus(types.StatusObjectPathNotFound), nil
+		}
+
+		linkName = path.Base(newPath)
+		dirPath := path.Dir(newPath)
+		if dirPath == "." || dirPath == "" || dirPath == "/" {
+			dstDir = rootHandle
+		} else {
+			dstDir, err = h.walkPath(authCtx, rootHandle, dirPath)
+			if err != nil {
+				logger.Debug("SET_INFO: hardlink destination path not found",
+					"path", dirPath, "error", err)
+				return setInfoStatus(types.StatusObjectPathNotFound), nil
+			}
+		}
+	}
+
+	// Replace-if-exists for hardlink is rare (most clients pass FALSE). Honor
+	// it by attempting a delete of the existing destination before linking.
+	// If ReplaceIfExists=false and the target exists, CreateHardLink returns
+	// ErrAlreadyExists → STATUS_OBJECT_NAME_COLLISION via common.MapToSMB.
+	metaSvc := h.Registry.GetMetadataService()
+	if linkInfo.ReplaceIfExists {
+		if existing, lookupErr := metaSvc.Lookup(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
+			if _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, linkName); rmErr != nil {
+				logger.Debug("SET_INFO: hardlink replace failed to remove existing",
+					"name", linkName, "error", rmErr)
+				return setInfoStatus(common.MapToSMB(rmErr)), nil
+			}
+		}
+	}
+
+	// #470 C5: thread the open file's ParentLeaseKey into the auth context so
+	// MetadataService.notifyDirChange forwards it to OnDirChange and the
+	// dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20) skips the
+	// matching parent dir lease (same-key holder does not get broken).
+	PropagateOpenFileParentLeaseKey(authCtx, openFile)
+
+	if err := metaSvc.CreateHardLink(authCtx, dstDir, linkName, openFile.MetadataHandle); err != nil {
+		logger.Debug("SET_INFO: CreateHardLink failed",
+			"src", openFile.Path, "dst", newPath, "error", err)
+		return setInfoStatus(common.MapToSMB(err)), nil
+	}
+
+	// Break Handle/Read leases on the destination parent (MS-FSA 2.1.5.14:
+	// directory contents changed). Parent-key suppression flows through the
+	// same exclude args used by the metadata-layer notifier.
+	if h.LeaseManager != nil {
+		dstParentLock := lock.FileHandle(dstDir)
+		excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
+		excludeParentKey := openFile.ParentLeaseKey
+		hasExcludeKey := openFile.HasParentLeaseKey
+		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(
+			authCtx.Context, dstParentLock, openFile.ShareName,
+			excludeClientID, excludeParentKey, hasExcludeKey,
+		); breakErr != nil {
+			logger.Debug("SET_INFO: hardlink dst-parent Handle lease break failed",
+				"dst", newPath, "error", breakErr)
+		}
+		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(
+			authCtx.Context, dstParentLock, openFile.ShareName,
+			excludeClientID, excludeParentKey, hasExcludeKey,
+		); breakErr != nil {
+			logger.Debug("SET_INFO: hardlink dst-parent Read lease break failed",
+				"dst", newPath, "error", breakErr)
+		}
+	}
+
+	// Notify change-notify watchers: an entry was added in the destination
+	// parent directory.
+	if h.NotifyRegistry != nil {
+		tree, ok := h.GetTree(openFile.TreeID)
+		if ok {
+			dstParentPath := GetParentPath(newPath)
+			if dstParentPath == "" || dstParentPath == "." {
+				dstParentPath = "/"
+			}
+			h.NotifyRegistry.NotifyChange(tree.ShareName, dstParentPath, linkName, FileActionAdded)
+		}
+	}
+
+	logger.Debug("SET_INFO: hardlink created",
+		"src", openFile.Path, "dst", newPath, "name", linkName)
+	return setInfoStatus(types.StatusSuccess), nil
 }

--- a/internal/adapter/smb/v2/handlers/set_info_link_info_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_link_info_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+// encodeFileLinkInfoWire serialises a FILE_LINK_INFORMATION blob in MS-FSCC
+// 2.4.21.2 wire format for use by tests:
+//
+//	+0   1B  ReplaceIfExists
+//	+1   7B  Reserved
+//	+8   8B  RootDirectory
+//	+16  4B  FileNameLength (bytes)
+//	+20  N   FileName (UTF-16LE)
+func encodeFileLinkInfoWire(t *testing.T, replaceIfExists bool, rootDir [8]byte, fileName string) []byte {
+	t.Helper()
+	utf16Buf := utf16.Encode([]rune(fileName))
+	nameBytes := make([]byte, 2*len(utf16Buf))
+	for i, w := range utf16Buf {
+		binary.LittleEndian.PutUint16(nameBytes[2*i:], w)
+	}
+	buf := make([]byte, 20+len(nameBytes))
+	if replaceIfExists {
+		buf[0] = 1
+	}
+	copy(buf[8:16], rootDir[:])
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(len(nameBytes)))
+	copy(buf[20:], nameBytes)
+	return buf
+}
+
+// TestDecodeFileLinkInfo_Basic round-trips the FILE_LINK_INFORMATION wire
+// format and pins MS-FSCC 2.4.21.2: ReplaceIfExists, RootDirectory, and
+// the UTF-16LE FileName field land in the decoded struct verbatim.
+func TestDecodeFileLinkInfo_Basic(t *testing.T) {
+	t.Parallel()
+
+	rootDir := [8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11}
+	buf := encodeFileLinkInfoWire(t, true, rootDir, "newlink.txt")
+
+	info, err := DecodeFileLinkInfo(buf)
+	if err != nil {
+		t.Fatalf("DecodeFileLinkInfo: %v", err)
+	}
+	if !info.ReplaceIfExists {
+		t.Errorf("ReplaceIfExists = false, want true")
+	}
+	if !bytes.Equal(info.RootDirectory[:], rootDir[:]) {
+		t.Errorf("RootDirectory = %x, want %x", info.RootDirectory, rootDir)
+	}
+	if info.FileName != "newlink.txt" {
+		t.Errorf("FileName = %q, want %q", info.FileName, "newlink.txt")
+	}
+}
+
+// TestDecodeFileLinkInfo_ZeroRootDir pins the zero-RootDirectory case which
+// the handler interprets as "FileName is a path from the share root".
+func TestDecodeFileLinkInfo_ZeroRootDir(t *testing.T) {
+	t.Parallel()
+
+	buf := encodeFileLinkInfoWire(t, false, [8]byte{}, "subdir\\link.dat")
+	info, err := DecodeFileLinkInfo(buf)
+	if err != nil {
+		t.Fatalf("DecodeFileLinkInfo: %v", err)
+	}
+	if info.ReplaceIfExists {
+		t.Errorf("ReplaceIfExists = true, want false")
+	}
+	for i, b := range info.RootDirectory {
+		if b != 0 {
+			t.Errorf("RootDirectory[%d] = 0x%02x, want 0", i, b)
+		}
+	}
+	if info.FileName != "subdir\\link.dat" {
+		t.Errorf("FileName = %q (backslash should be decoded verbatim — normalization happens in handler)", info.FileName)
+	}
+}
+
+// TestDecodeFileLinkInfo_TooShort asserts that buffers smaller than the
+// 20-byte fixed header are rejected with a descriptive error rather than
+// causing an index panic.
+func TestDecodeFileLinkInfo_TooShort(t *testing.T) {
+	t.Parallel()
+
+	cases := []int{0, 1, 19}
+	for _, n := range cases {
+		_, err := DecodeFileLinkInfo(make([]byte, n))
+		if err == nil {
+			t.Errorf("DecodeFileLinkInfo(%d-byte buf): expected error, got nil", n)
+		}
+	}
+}
+
+// TestDecodeFileLinkInfo_FileNameLengthTooLarge asserts that an
+// out-of-bounds FileNameLength does not over-read the underlying buffer
+// (defence against malformed client input).
+func TestDecodeFileLinkInfo_FileNameLengthTooLarge(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, 22) // header + 2 bytes of name budget
+	binary.LittleEndian.PutUint32(buf[16:20], 1024)
+	if _, err := DecodeFileLinkInfo(buf); err == nil {
+		t.Errorf("expected error for FileNameLength=1024 with only 2 name bytes available")
+	}
+}

--- a/pkg/metadata/hardlink_parent_key_test.go
+++ b/pkg/metadata/hardlink_parent_key_test.go
@@ -78,9 +78,8 @@ func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
 
 			// Destination directory: either same as src or distinct.
 			dstDirHandle := srcDirHandle
-			dstDirName := "srcdir"
 			if tc.differentDir {
-				dstDirName = "dstdir"
+				dstDirName := "dstdir"
 				_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, dstDirName, &metadata.FileAttr{
 					Type: metadata.FileTypeDirectory, Mode: 0o777,
 				})

--- a/pkg/metadata/hardlink_parent_key_test.go
+++ b/pkg/metadata/hardlink_parent_key_test.go
@@ -1,0 +1,201 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCreateHardLink_NotifyDirChangeMatrix pins the four sub-cases of the
+// Samba `dlt_hardlinks` matrix (source4/torture/smb2/lease.c::dlt_hardlinks)
+// against MetadataService.CreateHardLink, asserting that the dst-parent
+// DirChangeNotifier is invoked with the correct (excludeParentLeaseKey,
+// hasExcludeKey) tuple. The dir-lease parent-key suppression rule lives in
+// lock.Manager.OnDirChange (covered separately); this test pins the
+// MetadataService → notifier wire — i.e. the C5 plumbing #470 expects.
+//
+// Sub-cases (rows of dlt_hardlinks):
+//   - samedir + samekey         → hasExcludeKey=true,  key matches
+//   - samedir + diffkey         → hasExcludeKey=true,  key differs
+//   - differentdir + samekey    → hasExcludeKey=true,  key matches
+//   - differentdir + diffkey    → hasExcludeKey=true,  key differs
+//
+// The "samekey" / "diffkey" axis is verified by the OnDirChange suppression
+// matrix in pkg/metadata/lock/directory_test.go — here we only verify the
+// AuthContext.ParentLeaseKey lands on the notifier verbatim.
+func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
+	t.Parallel()
+
+	type sub struct {
+		name         string
+		differentDir bool
+		parentKey    [16]byte
+	}
+	keyA := [16]byte{0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8}
+	keyB := [16]byte{0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8}
+
+	cases := []sub{
+		{name: "samedir_samekey", differentDir: false, parentKey: keyA},
+		{name: "samedir_diffkey", differentDir: false, parentKey: keyB},
+		{name: "differentdir_samekey", differentDir: true, parentKey: keyA},
+		{name: "differentdir_diffkey", differentDir: true, parentKey: keyB},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fx := newTestFixture(t)
+			notifier := &recordingNotifier{}
+			fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+			rootCtx := fx.rootContext()
+
+			// Source dir + file (always linked from "srcdir").
+			_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "srcdir", &metadata.FileAttr{
+				Type: metadata.FileTypeDirectory, Mode: 0o777,
+			})
+			if err != nil {
+				t.Fatalf("CreateDirectory(srcdir): %v", err)
+			}
+			srcDirHandle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "srcdir")
+			if err != nil {
+				t.Fatalf("GetChild(srcdir): %v", err)
+			}
+			srcFile, err := fx.service.CreateFile(rootCtx, srcDirHandle, "src.txt", &metadata.FileAttr{
+				Type: metadata.FileTypeRegular, Mode: 0o644,
+			})
+			if err != nil {
+				t.Fatalf("CreateFile(src.txt): %v", err)
+			}
+			srcHandle, err := metadata.EncodeFileHandle(srcFile)
+			if err != nil {
+				t.Fatalf("EncodeFileHandle(src): %v", err)
+			}
+
+			// Destination directory: either same as src or distinct.
+			dstDirHandle := srcDirHandle
+			dstDirName := "srcdir"
+			if tc.differentDir {
+				dstDirName = "dstdir"
+				_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, dstDirName, &metadata.FileAttr{
+					Type: metadata.FileTypeDirectory, Mode: 0o777,
+				})
+				if err != nil {
+					t.Fatalf("CreateDirectory(dstdir): %v", err)
+				}
+				dstDirHandle, err = fx.store.GetChild(context.Background(), fx.rootHandle, dstDirName)
+				if err != nil {
+					t.Fatalf("GetChild(dstdir): %v", err)
+				}
+			}
+
+			// Reset notifier (CreateDirectory / CreateFile above already fired
+			// add-entry notifications we don't care about for this assertion).
+			notifier.mu.Lock()
+			notifier.calls = nil
+			notifier.mu.Unlock()
+
+			// AuthContext mirrors what the SMB hardlink handler builds after
+			// PropagateOpenFileParentLeaseKey: the opening handle's
+			// ParentLeaseKey lands on the AuthContext.
+			linkCtx := &metadata.AuthContext{
+				Context:           context.Background(),
+				Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+				LockClientID:      "smb:hardlink-client",
+				ParentLeaseKey:    tc.parentKey,
+				HasParentLeaseKey: true,
+			}
+
+			if err := fx.service.CreateHardLink(linkCtx, dstDirHandle, "link.txt", srcHandle); err != nil {
+				t.Fatalf("CreateHardLink: %v", err)
+			}
+
+			notifier.mu.Lock()
+			defer notifier.mu.Unlock()
+			if len(notifier.calls) == 0 {
+				t.Fatalf("CreateHardLink did not fire a directory-change notification on dst parent")
+			}
+
+			// Expect exactly one notification, targeted at dstDirHandle.
+			call := notifier.calls[0]
+			assert.Equal(t, lock.FileHandle(dstDirHandle), call.ParentHandle,
+				"notification must target the destination parent directory (dst-parent break)")
+			assert.Equal(t, lock.DirChangeAddEntry, call.ChangeType,
+				"hardlink is an AddEntry on the destination parent")
+			assert.Equal(t, "smb:hardlink-client", call.OriginClient,
+				"originClient must come from AuthContext.LockClientID for ClientID-scoped exclusion")
+			assert.True(t, call.HasExcludeKey,
+				"HasExcludeKey must be true so the dst-parent dir-lease parent-key suppression rule can fire")
+			assert.Equal(t, tc.parentKey, call.ExcludeParentLeaseKey,
+				"ExcludeParentLeaseKey must equal AuthContext.ParentLeaseKey (verbatim hand-off)")
+		})
+	}
+}
+
+// TestCreateHardLink_NFSCallerHasNoParentKey asserts that an NFS-style caller
+// (HasParentLeaseKey=false on the AuthContext) does NOT enable parent-key
+// suppression on the dst-parent notification. POSIX clients have no
+// dir-lease concept and any bytes in ParentLeaseKey must be ignored — same
+// short-circuit invariant pinned by TestNotifyDirChange_NFSCallerHasNoParentKey
+// for the CreateFile path, extended here to CreateHardLink (#470 C5).
+func TestCreateHardLink_NFSCallerHasNoParentKey(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	rootCtx := fx.rootContext()
+
+	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "d", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o777,
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	dirHandle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "d")
+	if err != nil {
+		t.Fatalf("GetChild: %v", err)
+	}
+	srcFile, err := fx.service.CreateFile(rootCtx, dirHandle, "src.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	srcHandle, err := metadata.EncodeFileHandle(srcFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	notifier.mu.Lock()
+	notifier.calls = nil
+	notifier.mu.Unlock()
+
+	bogus := [16]byte{0xFF, 0xFF, 0xFF, 0xFF}
+	nfsCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "nfs:client",
+		ParentLeaseKey:    bogus,
+		HasParentLeaseKey: false,
+	}
+	if err := fx.service.CreateHardLink(nfsCtx, dirHandle, "link.txt", srcHandle); err != nil {
+		t.Fatalf("CreateHardLink: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	if len(notifier.calls) == 0 {
+		t.Fatalf("CreateHardLink did not fire a notification")
+	}
+	call := notifier.calls[0]
+	assert.False(t, call.HasExcludeKey,
+		"NFS path (HasParentLeaseKey=false) must NOT enable parent-key suppression")
+	assert.Equal(t, [16]byte{}, call.ExcludeParentLeaseKey,
+		"ExcludeParentLeaseKey must be zero when hasExcludeKey is false")
+}


### PR DESCRIPTION
## Summary

Implements SET_INFO FileLinkInformation (class 11), which previously returned `STATUS_NOT_SUPPORTED`. Hard link creation adds a new directory entry in the destination parent, so per MS-FSA 2.1.5.14 the dst-parent dir-lease holders must be notified, minus the originating handle (identified by the RqLs ParentLeaseKey set at CREATE).

Consumes the C2 plumbing (PR #627): the handler threads `OpenFile.ParentLeaseKey` onto `AuthContext` via `PropagateOpenFileParentLeaseKey` so `MetadataService.notifyDirChange` forwards the exclude key to `OnDirChange`, and the same key feeds `BreakParentHandleLeasesOnCreate` / `BreakParentReadLeasesOnModify` on the destination parent.

Targets Samba `dlt_hardlinks` matrix (`source4/torture/smb2/lease.c:7519`):
- samedir + samekey -> suppress
- samedir + diffkey -> break
- crossdir + samekey -> suppress on dst-parent
- crossdir + diffkey -> break dst-parent

## Wave-3 cluster (#470)

C5 hardlink. Consumes C2 (#627) plumbing. Targets one `smb2.dirlease` test: `hardlink`.

## Changes

- `types.FileLinkInformation = 11` constant.
- `DecodeFileLinkInfo` (MS-FSCC 2.4.21.2 wire format; mirrors RENAME).
- `handleFileLinkInformation`: directory-reject, path-walk to dst, optional ReplaceIfExists, `CreateHardLink`, dst-parent H/R lease break with parent-key suppression, ChangeNotify add-entry on dst parent.
- `FileLinkInformation` added to the SET_INFO access-gate allow-list (its permission checks live in the metadata layer, parity with RENAME).

## Test plan

- [x] `go test -race ./internal/adapter/smb/... ./pkg/metadata/...` green
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] 4-case `DecodeFileLinkInfo` wire format + length/overrun guards
- [x] 4-row `dlt_hardlinks` matrix on `CreateHardLink` notifier hand-off (samedir/diffdir x samekey/diffkey)
- [x] NFS short-circuit invariant (`HasParentLeaseKey=false` -> `hasExcludeKey=false`)
- [ ] CI smbtorture: `smb2.dirlease.hardlink` should flip