### PR TITLE
fix(smb/dirlease): src+dst parent break on rename with parent-key suppression (#470 C3)

### DIFF
--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -657,6 +657,18 @@ func (h *Handler) setFileInfoFromStore(
 		// that directory that lacks FILE_SHARE_DELETE or holds DELETE access
 		// conflicts. Stream renames don't traverse the directory layer and
 		// returned earlier above; we're past that branch here.
+		//
+		// Pre-conflict dst-parent dir-lease break (#470 C3 / smbtorture
+		// smb2.dirlease.rename_dst_parent, lease.c:7331). Even when the
+		// conflict surfaces SHARING_VIOLATION, the dst-parent's RH dir-lease
+		// holder must observe an RH→R break: the rename's implicit destructive
+		// open intent invalidates the holder's Handle caching regardless of
+		// whether the rename ultimately succeeds. Parent-key suppression
+		// applies (the renamer's RqLs ParentLeaseKey, if any, marks the holder
+		// as the renamer itself). On Phase-2 of the test, the holder's break
+		// handler closes its handle inside our wait, the post-break conflict
+		// recheck observes the close, and the rename proceeds.
+		h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
 		if conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir); conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
 				"path", openFile.Path,
@@ -783,6 +795,10 @@ func (h *Handler) setFileInfoFromStore(
 		oldPath := openFile.Path
 		oldFileName := openFile.FileName
 		oldParentPath := GetParentPath(oldPath)
+		// Snapshot src-parent handle so the post-rename dir-lease break can
+		// fire on the source parent (line 862 update below overwrites
+		// openFile.ParentHandle to toDir).
+		srcParentHandle := openFile.ParentHandle
 
 		// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename so we can
 		// restore them after. Rename should NOT update the file's timestamps.
@@ -857,9 +873,16 @@ func (h *Handler) setFileInfoFromStore(
 		openFile.ParentHandle = toDir
 		h.StoreOpenFile(openFile)
 
-		// Per MS-FSA 2.1.5.14.10: Rename changes directory contents.
-		// Break Handle + Read leases on parent directories.
-		h.breakParentDirLeasesForContentChange(authCtx, openFile)
+		// Per MS-FSA 2.1.5.14.10 + #470 C3 (smbtorture smb2.dirlease.rename):
+		// rename changes directory contents on BOTH source and destination
+		// parents. Break Handle + Read dir leases on each (RH → ""), honoring
+		// the renamer's ParentLeaseKey suppression from C2. Skip the dst
+		// break when src == dst (same-dir rename) to avoid a redundant
+		// double-break on a single dir-lease holder.
+		h.breakParentDirLeasesForContentChangeOn(authCtx, srcParentHandle, openFile)
+		if !bytes.Equal(toDir, srcParentHandle) {
+			h.breakParentDirLeasesForContentChangeOn(authCtx, toDir, openFile)
+		}
 
 		logger.Debug("SET_INFO: rename successful",
 			"oldPath", oldPath,
@@ -1350,11 +1373,22 @@ func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Sta
 // the parent directory when directory CONTENT changes (rename, delete). These
 // operations affect what READDIR returns, invalidating Read caching.
 func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthContext, openFile *OpenFile) {
-	if h.LeaseManager == nil || len(openFile.ParentHandle) == 0 {
+	if len(openFile.ParentHandle) == 0 {
+		return
+	}
+	h.breakParentDirLeasesForContentChangeOn(authCtx, openFile.ParentHandle, openFile)
+}
+
+// breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
+// the rename branch (#470 C3): break Handle + Read leases on an arbitrary
+// directory handle (src-parent or dst-parent), still honoring the originating
+// handle's ClientID + ParentLeaseKey suppression from C2.
+func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, openFile *OpenFile) {
+	if h.LeaseManager == nil || len(parentHandle) == 0 {
 		return
 	}
 
-	parentLockHandle := lock.FileHandle(openFile.ParentHandle)
+	parentLockHandle := lock.FileHandle(parentHandle)
 	excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
 
 	// Apply parent-key suppression (MS-SMB2 §3.3.4.20, #470 C2): if the
@@ -1364,9 +1398,34 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 	hasExcludeKey := openFile.HasParentLeaseKey
 
 	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-		logger.Debug("SET_INFO: parent directory Handle lease break failed", "path", openFile.Path, "error", breakErr)
+		logger.Debug("SET_INFO: parent directory Handle lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
 	}
 	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "error", breakErr)
+		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
+	}
+}
+
+// breakDstParentDirHandleLeasesForRename strips the Handle bit only (RH -> R)
+// on dst-parent dir leases held by holders that conflict with the rename's
+// implicit DELETE+FILE_ADD_FILE open. Called BEFORE the dst-parent share-mode
+// conflict check so the break notification is observed even when the conflict
+// surfaces STATUS_SHARING_VIOLATION (smbtorture smb2.dirlease.rename_dst_parent
+// Phase 1, lease.c:7331). Read caching is preserved (RH -> R) — the rename
+// hasn't mutated directory contents yet, only the dst-parent's Handle caching
+// is invalidated by the implicit destructive open intent.
+//
+// Honors the same ClientID + ParentLeaseKey suppression as C2: if the renamer
+// carries a ParentLeaseKey on its own RqLs that matches the dst-parent's
+// dir-lease key, suppress (Samba dirlease_for_rename behavior).
+func (h *Handler) breakDstParentDirHandleLeasesForRename(authCtx *metadata.AuthContext, dstParent metadata.FileHandle, openFile *OpenFile) {
+	if h.LeaseManager == nil || len(dstParent) == 0 {
+		return
+	}
+	parentLockHandle := lock.FileHandle(dstParent)
+	excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
+	excludeParentKey := openFile.ParentLeaseKey
+	hasExcludeKey := openFile.HasParentLeaseKey
+	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+		logger.Debug("SET_INFO: dst-parent dir Handle lease pre-break failed", "path", openFile.Path, "dstParent", fmt.Sprintf("%x", dstParent), "error", breakErr)
 	}
 }

--- a/pkg/metadata/lock/directory_test.go
+++ b/pkg/metadata/lock/directory_test.go
@@ -424,3 +424,230 @@ func TestRecentlyBrokenCache_Expiry(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	assert.False(t, cache.IsRecentlyBroken("dir1"), "should expire after TTL")
 }
+
+// ============================================================================
+// #470 C3 — Rename (dual-parent break + parent-key suppression)
+// ============================================================================
+//
+// These tests mirror the Samba `dlt_renames` matrix
+// (source4/torture/smb2/lease.c:7028) at the lock-manager layer. The C3 rename
+// branch in internal/adapter/smb/v2/handlers/set_info.go invokes
+// BreakLeasesOnOpenConflict + BreakReadLeasesForParentDir on BOTH src-parent
+// and dst-parent (RH → ""), each honoring the renamer's ClientID + parent-key
+// suppression. We verify the underlying break path produces the right per-key
+// break count for each matrix row.
+//
+// We exercise the dual call directly because the parent-key gating is the
+// load-bearing rule (smbtorture rows: correct vs wrong vs no parent_key, in
+// otherdir / samedir layout).
+
+// breakBothParentsAsRename simulates the C3 post-rename break invocation:
+// strip H then R on a parent handle, with parent-key suppression. Mirrors
+// internal/adapter/smb/v2/handlers/set_info.go::breakParentDirLeasesForContentChangeOn
+// composed twice (src and dst).
+func breakBothParentsAsRename(t *testing.T, mgr *Manager, srcParent, dstParent string, excludeClientID string, excludeKey [16]byte, hasKey bool) {
+	t.Helper()
+	owner := &LockOwner{
+		ClientID:                    excludeClientID,
+		ExcludeParentDirLeaseKey:    excludeKey,
+		HasExcludeParentDirLeaseKey: hasKey,
+	}
+	for _, parent := range []string{srcParent, dstParent} {
+		if parent == "" {
+			continue
+		}
+		require.NoError(t, mgr.BreakLeasesOnOpenConflict(parent, owner, BreakReasonSharingViolation))
+		require.NoError(t, mgr.BreakReadLeasesForParentDir(parent, owner))
+	}
+}
+
+// TestRenameC3_OtherDir_NoParentKey_BreaksBoth covers
+// dlt_renames "otherdir-no-parent-leaskey" (lease.c:7096): rename across two
+// directories by a renamer without a parent_key — both src and dst dir leases
+// must break.
+func TestRenameC3_OtherDir_NoParentKey_BreaksBoth(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	srcLeaseKey := [16]byte{0x01}
+	dstLeaseKey := [16]byte{0x02}
+
+	breakKeys := map[string]int{}
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakKeys[handleKey]++
+		},
+	})
+
+	// Two dir leases held by a "second client" on separate parent handles.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("srcdir"), srcLeaseKey, [16]byte{},
+		"owner-src", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("dstdir"), dstLeaseKey, [16]byte{},
+		"owner-dst", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Renamer is a third client with no parent_key.
+	breakBothParentsAsRename(t, mgr, "srcdir", "dstdir", "clientB", [16]byte{}, false)
+
+	assert.GreaterOrEqual(t, breakKeys["srcdir"], 1, "src dir lease must break when renamer carries no matching parent_key")
+	assert.GreaterOrEqual(t, breakKeys["dstdir"], 1, "dst dir lease must break when renamer carries no matching parent_key")
+}
+
+// TestRenameC3_OtherDir_CorrectSrcParentKey_SuppressesSrc covers
+// "otherdir-correct-srcparent-leaskey" (lease.c:7063): renamer's parent_key
+// matches src-parent's lease → src suppressed, dst breaks.
+func TestRenameC3_OtherDir_CorrectSrcParentKey_SuppressesSrc(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	srcLeaseKey := [16]byte{0x01}
+	dstLeaseKey := [16]byte{0x02}
+
+	breakKeys := map[string]int{}
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakKeys[handleKey]++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("srcdir"), srcLeaseKey, [16]byte{},
+		"owner-src", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("dstdir"), dstLeaseKey, [16]byte{},
+		"owner-dst", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Renamer carries src-parent's lease key as its own parent_key.
+	breakBothParentsAsRename(t, mgr, "srcdir", "dstdir", "clientB", srcLeaseKey, true)
+
+	assert.Equal(t, 0, breakKeys["srcdir"], "src dir lease must be suppressed by matching parent_key (#470 C3)")
+	assert.GreaterOrEqual(t, breakKeys["dstdir"], 1, "dst dir lease must still break when parent_key matches src only")
+}
+
+// TestRenameC3_OtherDir_CorrectDstParentKey_SuppressesDst covers
+// "otherdir-correct-dstparent-leaskey" (lease.c:7074): symmetric case where
+// renamer's parent_key matches dst-parent's lease → dst suppressed, src breaks.
+func TestRenameC3_OtherDir_CorrectDstParentKey_SuppressesDst(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	srcLeaseKey := [16]byte{0x01}
+	dstLeaseKey := [16]byte{0x02}
+
+	breakKeys := map[string]int{}
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakKeys[handleKey]++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("srcdir"), srcLeaseKey, [16]byte{},
+		"owner-src", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("dstdir"), dstLeaseKey, [16]byte{},
+		"owner-dst", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	breakBothParentsAsRename(t, mgr, "srcdir", "dstdir", "clientB", dstLeaseKey, true)
+
+	assert.GreaterOrEqual(t, breakKeys["srcdir"], 1, "src dir lease must still break when parent_key matches dst only")
+	assert.Equal(t, 0, breakKeys["dstdir"], "dst dir lease must be suppressed by matching parent_key (#470 C3)")
+}
+
+// TestRenameC3_SameDir_CorrectParentKey_NoBreak covers
+// "samedir-correct-parent-leaskey" (lease.c:7030): same-directory rename by a
+// renamer carrying the dir's parent_key → no break at all. The handler-level
+// code de-dupes the (src == dst) case so the helper fires exactly once on the
+// single dir lease, which is then suppressed by the parent-key match.
+func TestRenameC3_SameDir_CorrectParentKey_NoBreak(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0x01}
+
+	breakKeys := map[string]int{}
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakKeys[handleKey]++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner-d", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Same-dir rename: handler passes srcParent == dstParent; the helper de-dupes
+	// to a single break invocation. Renamer's parent_key matches → suppressed.
+	breakBothParentsAsRename(t, mgr, "dir1", "", "clientB", dirLeaseKey, true)
+
+	assert.Equal(t, 0, breakKeys["dir1"], "same-dir rename with matching parent_key must not break (samedir-correct-parent-leaskey)")
+}
+
+// TestRenameC3_SameDir_WrongParentKey_Breaks covers
+// "samedir-wrong-parent-leaskey" (lease.c:7041): renamer carries a parent_key
+// that does NOT match the dir's lease key → break fires.
+func TestRenameC3_SameDir_WrongParentKey_Breaks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dirLeaseKey := [16]byte{0x01}
+	wrongKey := [16]byte{0x03}
+
+	breakKeys := map[string]int{}
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakKeys[handleKey]++
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dir1"), dirLeaseKey, [16]byte{},
+		"owner-d", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	breakBothParentsAsRename(t, mgr, "dir1", "", "clientB", wrongKey, true)
+
+	assert.GreaterOrEqual(t, breakKeys["dir1"], 1, "same-dir rename with wrong parent_key must break (samedir-wrong-parent-leaskey)")
+}
+
+// TestRenameC3_DstParent_PreConflictBreak_OnlyStripsHandle covers the
+// rename_dst_parent first-phase semantics (lease.c:7331). The dst-parent
+// dir-lease holder must receive an H-strip break (RH → R) before the
+// SHARING_VIOLATION return — this is the BreakReasonSharingViolation path the
+// new breakDstParentDirHandleLeasesForRename helper takes. Read caching is
+// preserved (no R-strip happens at this stage).
+func TestRenameC3_DstParent_PreConflictBreak_OnlyStripsHandle(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	dstLeaseKey := [16]byte{0x01}
+
+	var lastBreakTo uint32
+	var breakCount int
+	mgr.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(handleKey string, lk *UnifiedLock, bts uint32) {
+			breakCount++
+			lastBreakTo = bts
+		},
+	})
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("dstdir"), dstLeaseKey, [16]byte{},
+		"owner-d", "clientA", "/share", LeaseStateRead|LeaseStateHandle, true)
+	require.NoError(t, err)
+
+	// Renamer (clientB) carries no parent_key → break fires; reason
+	// SharingViolation strips H, preserves R (RH → R).
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict("dstdir",
+		&LockOwner{ClientID: "clientB"},
+		BreakReasonSharingViolation,
+	))
+
+	assert.Equal(t, 1, breakCount, "dst-parent dir lease must break exactly once on the pre-conflict path")
+	assert.Equal(t, uint32(LeaseStateRead), lastBreakTo, "pre-conflict dst-parent break must strip H but preserve R (RH → R, rename_dst_parent Phase 1)")
+}


### PR DESCRIPTION
## Summary

Wave 3 / Cluster C3 of #470 — flips `smb2.dirlease.rename` and `smb2.dirlease.rename_dst_parent`.

- Rename now breaks dir-leases on **both** source-parent and destination-parent, each honoring the renamer's RqLs ParentLeaseKey suppression (MS-SMB2 §3.3.4.20). Today the post-rename break only fires on `openFile.ParentHandle` after it has been overwritten to `toDir` — so src-parent dir-leases were never broken on a cross-directory rename.
- Pre-conflict dst-parent H-strip break: dispatched **before** `checkParentDirRenameConflict` returns `STATUS_SHARING_VIOLATION`, so the dst-parent dir-lease holder observes RH → R even when the rename ultimately fails (smbtorture `rename_dst_parent` Phase 1, `lease.c:7331`).
- Same-dir rename de-dupes (`toDir == srcParent`) to a single break invocation.

Mirrors Samba `source3/smbd/dirlease_for_rename`. Builds on the C2 plumbing merged at d4fc1b5c (`OpenFile.ParentLeaseKey` + `BreakParent*(...excludeKey, hasKey)`).

**Invariant preserved**: parent-key suppression is gated on `Lease.IsDirectory == true` in `breakOpLocks`, so file leases that happen to share a key value are not suppressed (#470 plan §4 risk #1).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test -race ./internal/adapter/smb/... ./pkg/metadata/...` green
- [x] 6 new unit tests in `pkg/metadata/lock/directory_test.go` covering the Samba `dlt_renames` matrix at the lock-manager layer:
  - `TestRenameC3_OtherDir_NoParentKey_BreaksBoth`
  - `TestRenameC3_OtherDir_CorrectSrcParentKey_SuppressesSrc`
  - `TestRenameC3_OtherDir_CorrectDstParentKey_SuppressesDst`
  - `TestRenameC3_SameDir_CorrectParentKey_NoBreak`
  - `TestRenameC3_SameDir_WrongParentKey_Breaks`
  - `TestRenameC3_DstParent_PreConflictBreak_OnlyStripsHandle` (RH → R, not None)
- [ ] CI confirms `smb2.dirlease.rename` + `smb2.dirlease.rename_dst_parent` flip to PASS
- [ ] Zero regression on currently-passing `smb2.lease.*` (rename family, including round-5 `rename_wait` / `v2_rename` / `v2_rename_target_overwrite` / `rename_dir_openfile`)