### PR TITLE
fix(smb/dirlease): break parent dir-lease on delete-triggering close with parent-key suppression (#470 C6+C7)

### DIFF
--- a/internal/adapter/smb/v2/handlers/auth_helper_test.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 func TestBuildAuthContextFromUser_PopulatesSID(t *testing.T) {
@@ -144,4 +145,54 @@ func TestPrimeAuthContext_PreservesFixtureUserWhenSessionUserNil(t *testing.T) {
 	if ctx.IsGuest {
 		t.Errorf("ctx.IsGuest = true; anonymous (non-guest) session should leave IsGuest=false")
 	}
+}
+
+// TestPropagateOpenFileParentLeaseKey_Set asserts that the helper copies
+// OpenFile.ParentLeaseKey / HasParentLeaseKey onto the AuthContext so the
+// metadata layer can route the value into notifyDirChange (#470 C6/C7).
+func TestPropagateOpenFileParentLeaseKey_Set(t *testing.T) {
+	openFile := &OpenFile{
+		ParentLeaseKey:    [16]byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04},
+		HasParentLeaseKey: true,
+	}
+	authCtx := &metadata.AuthContext{Context: context.Background()}
+
+	PropagateOpenFileParentLeaseKey(authCtx, openFile)
+
+	if !authCtx.HasParentLeaseKey {
+		t.Fatal("HasParentLeaseKey must be true after propagation from a flagged OpenFile")
+	}
+	if authCtx.ParentLeaseKey != openFile.ParentLeaseKey {
+		t.Errorf("ParentLeaseKey = %x, want %x", authCtx.ParentLeaseKey, openFile.ParentLeaseKey)
+	}
+}
+
+// TestPropagateOpenFileParentLeaseKey_Unset asserts no-op when the OpenFile
+// had no RqLs+parent-key linkage. This preserves the "no parent-key on the
+// closing handle" path (different_set_and_close, different_initial_and_close)
+// where all dir leases MUST break.
+func TestPropagateOpenFileParentLeaseKey_Unset(t *testing.T) {
+	openFile := &OpenFile{HasParentLeaseKey: false}
+	authCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		ParentLeaseKey:    [16]byte{}, // start clean
+		HasParentLeaseKey: false,
+	}
+	// Should leave the context unchanged.
+	PropagateOpenFileParentLeaseKey(authCtx, openFile)
+	if authCtx.HasParentLeaseKey {
+		t.Fatal("HasParentLeaseKey must stay false when OpenFile has no linkage")
+	}
+	if authCtx.ParentLeaseKey != ([16]byte{}) {
+		t.Errorf("ParentLeaseKey must stay zero when OpenFile has no linkage, got %x", authCtx.ParentLeaseKey)
+	}
+}
+
+// TestPropagateOpenFileParentLeaseKey_NilSafe pins the documented nil-safety
+// contract: callers in close.go / cleanup paths may receive nil OpenFile or
+// authCtx if state is partially torn down; the helper must not panic.
+func TestPropagateOpenFileParentLeaseKey_NilSafe(t *testing.T) {
+	PropagateOpenFileParentLeaseKey(nil, nil)
+	PropagateOpenFileParentLeaseKey(&metadata.AuthContext{Context: context.Background()}, nil)
+	PropagateOpenFileParentLeaseKey(nil, &OpenFile{HasParentLeaseKey: true})
 }

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -309,6 +309,15 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// that to the metadata layer so the owner-of-target delete rule
 			// applies without loosening POSIX unlink(2) for NFS callers.
 			authCtx.HasDeleteAccess = true
+			// Thread the CLOSING handle's RqLs ParentLeaseKey through to
+			// notifyDirChange so the dir-lease parent-key suppression rule
+			// (MS-SMB2 §3.3.4.20, #470 C6/C7) can skip the parent dir lease
+			// whose key matches. The exclude key is the parent_key of the
+			// deleting CLOSE's handle, NOT of the handle that set DOC —
+			// covers both `*_set_and_close` and `*_initial_and_close` paths
+			// because OpenFile.ParentLeaseKey is captured at CREATE time
+			// regardless of when delete-on-close was set.
+			PropagateOpenFileParentLeaseKey(authCtx, openFile)
 			metaSvc := h.Registry.GetMetadataService()
 			var deleteErr error
 			if openFile.IsDirectory {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -761,6 +761,10 @@ func (h *Handler) closeFilesWithFilter(
 // returns.
 func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session, openFile *OpenFile, caller string) {
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
+	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
+	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
+	// suppression rule on the parent dir lease (#470 C6/C7).
+	PropagateOpenFileParentLeaseKey(authCtx, openFile)
 	metaSvc := h.Registry.GetMetadataService()
 
 	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {

--- a/pkg/metadata/notify_dir_change_parent_key_test.go
+++ b/pkg/metadata/notify_dir_change_parent_key_test.go
@@ -82,6 +82,226 @@ func TestNotifyDirChange_ThreadsParentLeaseKey(t *testing.T) {
 	assert.Equal(t, "smb:42", call.OriginClient, "originClient must come from AuthContext.LockClientID")
 }
 
+// TestRemoveFile_UnlinkSameSetAndClose verifies the #470 C6 path:
+// when an SMB CLOSE triggers the actual delete (delete-on-close set via
+// SET_INFO on the SAME handle that's now closing), the parent dir-lease
+// matching that handle's ParentLeaseKey MUST be suppressed.
+//
+// Maps to smbtorture smb2.dirlease.unlink_same_set_and_close — H2 set DOC,
+// H2 closes last, H2's ParentLeaseKey == dir2-key, so dir2 stays unbroken
+// and dir1 gets the RemoveEntry break.
+func TestRemoveFile_UnlinkSameSetAndClose(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	// Pre-create the victim file under root so RemoveFile has something to unlink.
+	rootCtx := fx.rootContext()
+	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	// CLOSE-triggered delete: the closing handle carries its ParentLeaseKey
+	// (set at CREATE by lease_context). Same-handle: the parent-key in the
+	// AuthContext is the SAME handle's key.
+	parentKey := [16]byte{0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8}
+	closeCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "smb:H2",
+		ParentLeaseKey:    parentKey,
+		HasParentLeaseKey: true,
+		HasDeleteAccess:   true,
+	}
+	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+		t.Fatalf("RemoveFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	// Find the RemoveEntry call (the AddEntry from the pre-create is also in calls).
+	var removeCalls []recordedDirChange
+	for _, c := range notifier.calls {
+		if c.ChangeType == lock.DirChangeRemoveEntry {
+			removeCalls = append(removeCalls, c)
+		}
+	}
+	if len(removeCalls) != 1 {
+		t.Fatalf("expected exactly 1 RemoveEntry notification, got %d", len(removeCalls))
+	}
+	assert.True(t, removeCalls[0].HasExcludeKey,
+		"same_set_and_close: closing handle's HasParentLeaseKey must reach the notifier")
+	assert.Equal(t, parentKey, removeCalls[0].ExcludeParentLeaseKey,
+		"same_set_and_close: exclude key MUST be the closing handle's ParentLeaseKey")
+	assert.Equal(t, "smb:H2", removeCalls[0].OriginClient,
+		"originClient must come from the closing handle's session")
+}
+
+// TestRemoveFile_UnlinkDifferentSetAndClose verifies the #470 C6 path:
+// when H1 set DOC but H2 (no parent-key on its own handle) closes last and
+// triggers the actual delete, the exclude key comes from H2 — i.e.
+// HasParentLeaseKey=false on the AuthContext — so all dir leases break.
+//
+// Maps to smbtorture smb2.dirlease.unlink_different_set_and_close.
+func TestRemoveFile_UnlinkDifferentSetAndClose(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	rootCtx := fx.rootContext()
+	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	// Closing handle is H2 — never carried a ParentLeaseKey (e.g. opened
+	// without RqLs or with Flags=0). The AuthContext therefore has
+	// HasParentLeaseKey=false even though the file has DOC set by H1.
+	closeCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "smb:H2",
+		HasParentLeaseKey: false,
+		HasDeleteAccess:   true,
+	}
+	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+		t.Fatalf("RemoveFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	var removeCalls []recordedDirChange
+	for _, c := range notifier.calls {
+		if c.ChangeType == lock.DirChangeRemoveEntry {
+			removeCalls = append(removeCalls, c)
+		}
+	}
+	if len(removeCalls) != 1 {
+		t.Fatalf("expected exactly 1 RemoveEntry notification, got %d", len(removeCalls))
+	}
+	assert.False(t, removeCalls[0].HasExcludeKey,
+		"different_set_and_close: closing handle has no parent-key; HasExcludeKey must be false so ALL dir leases break")
+	assert.Equal(t, [16]byte{}, removeCalls[0].ExcludeParentLeaseKey,
+		"different_set_and_close: zero key on the wire when hasExcludeKey=false")
+}
+
+// TestRemoveFile_UnlinkSameInitialAndClose verifies the #470 C7 path:
+// when DOC was set via FILE_DELETE_ON_CLOSE create option (rather than later
+// SET_INFO) on the SAME handle that's now closing, the parent-key suppression
+// still applies — OpenFile.ParentLeaseKey is captured at CREATE regardless of
+// when DOC was set, so the AuthContext propagation is symmetric.
+//
+// Maps to smbtorture smb2.dirlease.unlink_same_initial_and_close.
+func TestRemoveFile_UnlinkSameInitialAndClose(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	rootCtx := fx.rootContext()
+	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	// Initial DOC: same wire shape — close.go path propagates OpenFile.ParentLeaseKey
+	// into AuthContext.ParentLeaseKey via PropagateOpenFileParentLeaseKey,
+	// regardless of whether DOC came from CREATE option or SET_INFO.
+	parentKey := [16]byte{0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8}
+	closeCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "smb:H_initial",
+		ParentLeaseKey:    parentKey,
+		HasParentLeaseKey: true,
+		HasDeleteAccess:   true,
+	}
+	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+		t.Fatalf("RemoveFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	var removeCalls []recordedDirChange
+	for _, c := range notifier.calls {
+		if c.ChangeType == lock.DirChangeRemoveEntry {
+			removeCalls = append(removeCalls, c)
+		}
+	}
+	if len(removeCalls) != 1 {
+		t.Fatalf("expected exactly 1 RemoveEntry notification, got %d", len(removeCalls))
+	}
+	assert.True(t, removeCalls[0].HasExcludeKey,
+		"same_initial_and_close: parent-key suppression MUST work for create-option DOC, not just SET_INFO DOC")
+	assert.Equal(t, parentKey, removeCalls[0].ExcludeParentLeaseKey,
+		"same_initial_and_close: exclude key MUST be the closing handle's ParentLeaseKey")
+}
+
+// TestRemoveFile_UnlinkDifferentInitialAndClose verifies the #470 C7 path:
+// when H1 created with FILE_DELETE_ON_CLOSE create option and H2 (no
+// parent-key) closes last, the closing handle's HasParentLeaseKey=false
+// reaches the notifier so all dir leases break.
+//
+// Maps to smbtorture smb2.dirlease.unlink_different_initial_and_close.
+func TestRemoveFile_UnlinkDifferentInitialAndClose(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	rootCtx := fx.rootContext()
+	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	closeCtx := &metadata.AuthContext{
+		Context:           context.Background(),
+		Identity:          &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		LockClientID:      "smb:H2",
+		HasParentLeaseKey: false,
+		HasDeleteAccess:   true,
+	}
+	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+		t.Fatalf("RemoveFile failed: %v", err)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+
+	var removeCalls []recordedDirChange
+	for _, c := range notifier.calls {
+		if c.ChangeType == lock.DirChangeRemoveEntry {
+			removeCalls = append(removeCalls, c)
+		}
+	}
+	if len(removeCalls) != 1 {
+		t.Fatalf("expected exactly 1 RemoveEntry notification, got %d", len(removeCalls))
+	}
+	assert.False(t, removeCalls[0].HasExcludeKey,
+		"different_initial_and_close: no parent-key on closing handle ⇒ all dir leases must break")
+	assert.Equal(t, [16]byte{}, removeCalls[0].ExcludeParentLeaseKey,
+		"different_initial_and_close: zero key on the wire when hasExcludeKey=false")
+}
+
 // TestNotifyDirChange_NFSCallerHasNoParentKey asserts the NFS-style callsite
 // (HasParentLeaseKey=false on the AuthContext) results in hasExcludeKey=false
 // at the notifier — never accidentally suppressing a dir lease.


### PR DESCRIPTION
## Summary

Wave 3 C6+C7 of issue #470. Builds on the C2 plumbing merged in #627.

The four `smb2.dirlease.unlink_*_{set,initial}_and_close` tests fire the parent dir-lease break from the CLOSE that **actually** unlinks the file. Per MS-SMB2 §3.3.4.20 the exclude key passed to `OnDirChange(parent, RemoveEntry, ...)` is the parent_key of the **deleting CLOSE's handle**, not the handle that set DOC.

- `unlink_same_*`: H2 set DOC and H2 closes last; H2's parent_key matches dir2 ⇒ dir2 suppressed, dir1 breaks.
- `unlink_different_*`: H1 set DOC, H2 closes last; H2 has no parent_key ⇒ all dir leases break.
- `_initial_and_close` variants: same logic, DOC came from `FILE_DELETE_ON_CLOSE` create option rather than `SET_INFO`. Symmetric because `OpenFile.ParentLeaseKey` is captured at CREATE regardless of when DOC was set.

## Plumbing

```
OpenFile.ParentLeaseKey (set in create_post_break.go at CREATE)
  -> close.go::CLOSE delete-on-close branch
     + handler.go::handleDeleteOnClose (session-cleanup path)
       -> PropagateOpenFileParentLeaseKey(authCtx, openFile)
          -> metaSvc.RemoveFile(authCtx, ...)
             -> notifyDirChange -> OnDirChange(..., excludeKey, hasKey)
                -> Manager.OnDirChange skips matching dir lease  (#627 C2)
```

The SMB-direct `breakParentDirLeasesForContentChange(authCtx, openFile)` (close.go:349) already reads `openFile.ParentLeaseKey` after #627. With this PR the second path (the metadata-routed one) sees the same key.

## Targets

- `smb2.dirlease.unlink_same_set_and_close`
- `smb2.dirlease.unlink_different_set_and_close`
- `smb2.dirlease.unlink_same_initial_and_close`
- `smb2.dirlease.unlink_different_initial_and_close`

## Test plan

- [x] `pkg/metadata`: 4 new RemoveFile-driven scenarios pin the exclude key flow through `notifyDirChange` for both same/different and set/initial sub-cases.
- [x] `internal/adapter/smb/v2/handlers`: 3 new unit tests on `PropagateOpenFileParentLeaseKey` (set / unset / nil-safe).
- [x] `go test -race ./internal/adapter/smb/v2/handlers/ ./pkg/metadata/ ./pkg/metadata/lock/ ./internal/adapter/smb/lease/` clean.
- [x] `go fmt`, `go vet` clean.
- [ ] smbtorture flips the 4 dirlease unlink targets in CI.