### PR TITLE
fix(smb/dirlease): break parent dir-lease on child OVERWRITE/SUPERSEDE (#470 C4)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -887,6 +887,50 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
+// BreakParentDirLeasesOnDestructiveCreate breaks every parent-directory lease
+// to None in a single notification when a child file is being OVERWRITTEN or
+// SUPERSEDED by a CREATE from another client. Per MS-SMB2 §3.3.5.9 and Samba
+// `delay_for_oplock_fn` (source3/smbd/open.c) the destructive `will_overwrite`
+// arm strips both SMB2_LEASE_HANDLE and SMB2_LEASE_READ from the break_to
+// mask atomically — i.e. an RH parent lease must transition RH → "" via ONE
+// LEASE_BREAK_NOTIFICATION, not via the two-step (strip-H then strip-R) pattern
+// used by the non-destructive CREATE path (BreakParentHandleLeasesOnCreate +
+// BreakParentReadLeasesOnModify). smb2.dirlease.overwrite (#470 C4) asserts
+// exactly two break notifications for the test scenario — one on the file
+// lease, one on the dir lease — so the two-step pattern produces three and
+// fails the test.
+//
+// Waits for LEASE_BREAK_ACK with parentLeaseBreakWaitTimeout (same ack-wait
+// guarantee as BreakParentHandleLeasesOnCreate). excludeClientID +
+// excludeParentLeaseKey + hasExcludeKey carry the suppression rules from
+// MS-SMB2 §3.3.4.20 (#470 C2) so a same-client or parent-key-linked dir
+// lease is not broken.
+func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
+	ctx context.Context,
+	parentHandle lock.FileHandle,
+	shareName string,
+	excludeClientID string,
+	excludeParentLeaseKey [16]byte,
+	hasExcludeKey bool,
+) error {
+	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(
+		parentHandle, shareName, excludeClientID, excludeParentLeaseKey, hasExcludeKey)
+	if lockMgr == nil {
+		return nil
+	}
+	// BreakReasonDestructive collapses the strip-H + strip-R steps into a
+	// single break-to-None notification per ComputeLeaseBreakTo. The parent
+	// handle hosts only directory leases (we never request file leases on a
+	// directory handle key), so this does not over-break unrelated file
+	// leases.
+	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonDestructive); err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
+	defer cancel()
+	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+}
+
 // BreakParentReadLeasesOnModify breaks Read leases on a parent directory
 // when a child file's metadata is modified via SET_INFO, WRITE, or DELETE.
 // Per MS-FSA 2.1.5.14: changes to directory contents invalidate Read caching,

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -828,3 +828,103 @@ func TestBreakFileHandleLeasesOnDelete_StripsHandleAndExcludesSetterKey(t *testi
 			len(fake.waitForBreakCompletionKeys))
 	}
 }
+
+// TestBreakParentDirLeasesOnDestructiveCreate_SingleBreakWithDestructiveReason
+// pins the #470 C4 contract: OVERWRITE/SUPERSEDE on a child must break the
+// parent dir lease via ONE BreakLeasesOnOpenConflict call with
+// BreakReasonDestructive (collapses strip-H + strip-R into break-to-None),
+// then wait for the ack. This is the bug fix path — the legacy two-step
+// (strip-H then strip-R) produced two notifications on a single RH dir lease
+// and failed smb2.dirlease.overwrite which asserts exactly two break
+// notifications across both the file and dir leases.
+func TestBreakParentDirLeasesOnDestructiveCreate_SingleBreakWithDestructiveReason(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentHandle := lock.FileHandle("parent-dir-handle-destructive")
+	if err := lm.BreakParentDirLeasesOnDestructiveCreate(
+		context.Background(), parentHandle, "share1", "smb:A", [16]byte{}, false,
+	); err != nil {
+		t.Fatalf("BreakParentDirLeasesOnDestructiveCreate returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if got := len(fake.breakHandleCalls); got != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1 (a single destructive break collapses strip-H and strip-R)", got)
+	}
+	if got := fake.breakHandleCalls[0].Reason; got != lock.BreakReasonDestructive {
+		t.Errorf("Reason = %d, want BreakReasonDestructive (Samba `will_overwrite` arm strips H|R atomically)", got)
+	}
+	if fake.breakHandleCalls[0].HandleKey != string(parentHandle) {
+		t.Errorf("handleKey = %q, want %q", fake.breakHandleCalls[0].HandleKey, string(parentHandle))
+	}
+
+	// No second BreakReadLeasesForParentDir call — the test would otherwise
+	// produce three break notifications when a single RH parent lease is in
+	// play, breaking smb2.dirlease.overwrite (#470 C4).
+	if got := len(fake.breakReadCalls); got != 0 {
+		t.Errorf("BreakReadLeasesForParentDir call count = %d, want 0 (destructive path collapses both steps into one notification)", got)
+	}
+
+	if got := len(fake.waitForBreakCompletionKeys); got != 1 {
+		t.Fatalf("WaitForBreakCompletion call count = %d, want 1 (CREATE must wait for ack per MS-SMB2 §3.3.4.7)", got)
+	}
+	if fake.waitForBreakCompletionKeys[0] != string(parentHandle) {
+		t.Errorf("WaitForBreakCompletion handleKey = %q, want %q",
+			fake.waitForBreakCompletionKeys[0], string(parentHandle))
+	}
+
+	// Order: break must precede wait.
+	if len(fake.callOrder) < 2 {
+		t.Fatalf("expected at least 2 calls in order, got %v", fake.callOrder)
+	}
+	if fake.callOrder[0] != "BreakLeasesOnOpenConflict" {
+		t.Errorf("first call = %q, want BreakLeasesOnOpenConflict", fake.callOrder[0])
+	}
+	if fake.callOrder[1] != "WaitForBreakCompletion" {
+		t.Errorf("second call = %q, want WaitForBreakCompletion", fake.callOrder[1])
+	}
+}
+
+// TestBreakParentDirLeasesOnDestructiveCreate_PlumbsParentKeySuppression pins
+// that the C2 parent-key-suppression args (excludeClientID + parent_key +
+// hasExcludeKey) are forwarded into the LockOwner used for the break call,
+// so the dir-lease parent-key rule (MS-SMB2 §3.3.4.20) keeps applying on the
+// destructive path.
+func TestBreakParentDirLeasesOnDestructiveCreate_PlumbsParentKeySuppression(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeLockManager{}
+	lm := NewLeaseManager(&fakeResolver{mgr: fake}, nil)
+
+	parentKey := [16]byte{0xAB, 0xCD, 0xEF, 0x01}
+	if err := lm.BreakParentDirLeasesOnDestructiveCreate(
+		context.Background(), lock.FileHandle("parent"), "share1", "smb:client-B", parentKey, true,
+	); err != nil {
+		t.Fatalf("BreakParentDirLeasesOnDestructiveCreate returned error: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.breakHandleCalls) != 1 {
+		t.Fatalf("BreakLeasesOnOpenConflict call count = %d, want 1", len(fake.breakHandleCalls))
+	}
+	excludeOwner := fake.breakHandleCalls[0].ExcludeOwner
+	if excludeOwner == nil {
+		t.Fatal("excludeOwner must be non-nil when clientID + parent_key are provided")
+	}
+	if excludeOwner.ClientID != "smb:client-B" {
+		t.Errorf("ClientID = %q, want %q", excludeOwner.ClientID, "smb:client-B")
+	}
+	if !excludeOwner.HasExcludeParentDirLeaseKey {
+		t.Errorf("HasExcludeParentDirLeaseKey = false, want true")
+	}
+	if excludeOwner.ExcludeParentDirLeaseKey != parentKey {
+		t.Errorf("ExcludeParentDirLeaseKey = %x, want %x", excludeOwner.ExcludeParentDirLeaseKey, parentKey)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -416,6 +416,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// incoming request so the matching dir-lease is NOT broken. The
 	// LeaseResponseContext built at Step 8b carries the validated key, but
 	// runs AFTER the break calls below — peek directly at the RqLs context.
+	//
+	// Destructive disposition split (#470 C4, smb2.dirlease.overwrite): per
+	// Samba `delay_for_oplock_fn` `will_overwrite` arm, OVERWRITE/SUPERSEDE
+	// collapses the strip-H + strip-R steps into a single break-to-None
+	// notification on each affected dir lease. The test asserts exactly two
+	// break notifications (one on the file lease, one on the dir lease) —
+	// the legacy two-step path would emit three. CREATE (FileCreated) keeps
+	// the two-step pattern because the parent dir-lease only loses Handle
+	// caching there (Read is preserved per MS-FSA §2.1.5.14).
 	if (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) && h.LeaseManager != nil {
 		parentLockHandle := lock.FileHandle(parentHandle)
 		excludeClientID := fmt.Sprintf("smb:%d", ctx.SessionID)
@@ -428,11 +437,18 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				hasExcludeKey = true
 			}
 		}
-		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-			logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
-		}
-		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-			logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
+		isDestructive := createAction == types.FileOverwritten || createAction == types.FileSuperseded
+		if isDestructive {
+			if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory destructive lease break failed", "error", breakErr)
+			}
+		} else {
+			if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
+			}
+			if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix `smb2.dirlease.overwrite` (Wave 3 C4 of #470). A CREATE that OVERWRITEs or SUPERSEDEs a child file from a second client must break the parent directory lease atomically (RH -> "" in a single notification), not via the legacy two-step strip-H then strip-R sequence that Step 7c was using for all CREATE flavours.

MS-SMB2 3.3.5.9 + Samba `delay_for_oplock_fn` `will_overwrite` arm: destructive disposition removes both `SMB2_LEASE_HANDLE` and `SMB2_LEASE_READ` from the break-to mask atomically. The test asserts exactly two break notifications (one on the file lease, one on the dir lease); the two-step path produced three and failed.

## Changes

- Add `LeaseManager.BreakParentDirLeasesOnDestructiveCreate` (routes through `BreakLeasesOnOpenConflict` with `BreakReasonDestructive`; waits for ack with `parentLeaseBreakWaitTimeout`; honours C2 parent-key suppression).
- Split Step 7c in `create_post_break.go` to use the new helper on `FileOverwritten` / `FileSuperseded`, keeping the two-step Handle+Read path for the non-destructive `FileCreated` arm (parent only loses Handle caching per MS-FSA 2.1.5.14 there).
- Unit tests pinning the single-call destructive contract and parent-key plumbing.

Samba ref: `source4/torture/smb2/lease.c::test_overwrite` (line 7378). Tracker: #470.

## Test plan
- [x] `go test -race ./internal/adapter/smb/lease/...` (existing + 2 new tests)
- [x] `go test -race ./internal/adapter/smb/v2/handlers/...`
- [x] `go vet ./...`, `gofmt -l` clean
- [ ] CI smbtorture flips `smb2.dirlease.overwrite` to PASS