### PR TITLE
test(smb/dirlease): split suite per-subtest, skip oplocks SIGSEGV (#633)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -184,7 +184,7 @@ DittoFS implements file leases (Phase 37) but not directory leases.
 |-----------|----------|--------|-------|
 | smb2.dirlease.hardlink | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.leases | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.oplocks | Directory Leases | Directory leases not implemented | - |
+| smb2.dirlease.oplocks | Directory Leases | Skipped by runner — smbtorture 4.22.6 client SIGSEGVs in this subtest and aborts the rest of the dirlease suite (see run.sh) | #633 |
 | smb2.dirlease.overwrite | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.rename | Directory Leases | Directory leases not implemented | - |
 | smb2.dirlease.rename_dst_parent | Directory Leases | Directory leases not implemented | - |

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -449,7 +449,28 @@ else
         "smb2.delete-on-close-perms:delete-on-close-perms"
         "smb2.deny:deny"
         "smb2.dir:dir"
-        "smb2.dirlease:dirlease"
+        # smb2.dirlease is run per-subtest with smb2.dirlease.oplocks
+        # skipped: smbtorture 4.22.6 client SIGSEGVs inside that subtest and
+        # aborts the rest of the dirlease suite, hiding pass/fail for the 17
+        # other subtests. Tracked in #633 — drop this workaround once the
+        # smbtorture client crash is fixed upstream (or we upgrade past it).
+        "smb2.dirlease.v2_request:dirlease"
+        "smb2.dirlease.v2_request_parent:dirlease"
+        "smb2.dirlease.leases:dirlease"
+        "smb2.dirlease.overwrite:dirlease"
+        "smb2.dirlease.rename:dirlease"
+        "smb2.dirlease.rename_dst_parent:dirlease"
+        "smb2.dirlease.hardlink:dirlease"
+        "smb2.dirlease.setatime:dirlease"
+        "smb2.dirlease.setbtime:dirlease"
+        "smb2.dirlease.setctime:dirlease"
+        "smb2.dirlease.setmtime:dirlease"
+        "smb2.dirlease.setdos:dirlease"
+        "smb2.dirlease.seteof:dirlease"
+        "smb2.dirlease.unlink_same_initial_and_close:dirlease"
+        "smb2.dirlease.unlink_same_set_and_close:dirlease"
+        "smb2.dirlease.unlink_different_initial_and_close:dirlease"
+        "smb2.dirlease.unlink_different_set_and_close:dirlease"
         "smb2.durable-open:durable-open"
         "smb2.durable-open-disconnect:durable-open-disconnect"
         "smb2.durable-v2-open:durable-v2-open"


### PR DESCRIPTION
## Summary

Workaround for #633: smbtorture 4.22.6 client SIGSEGVs inside `smb2.dirlease.oplocks` and aborts the rest of the dirlease suite. This hides pass/fail for the 17 other dirlease subtests and blocks CI verification of #470 Wave 3 (#626 #627 #629 #630 #631 #632).

## Approach

Option 3 from #633: replace the single `smb2.dirlease` suite filter in `test/smb-conformance/smbtorture/run.sh` with a per-subtest filter list, omitting only `oplocks`. All 17 other subtests now run independently. `dirlease.oplocks` is annotated in `KNOWN_FAILURES.md` with the skip reason and #633 link.

Cleanest fast unblock — doesn't change container image (`quay.io/samba.org/samba-toolbox:v0.8` stays pinned), doesn't require patching the upstream client, and doesn't add maintenance burden of tracking Samba releases. Drop this workaround once the upstream client crash is fixed or we upgrade past 4.22.6.

## Test plan

- [ ] CI smb-conformance job (smbtorture/memory) runs the 17 dirlease subtests and reports pass/fail.
- [ ] Pre-existing dirlease KNOWN_FAILURES entries continue to match (no spurious "new failures").
- [ ] No regression on other suites (run order unchanged for everything except dirlease).

Closes #633 once CI confirms suite unblocks.