### PR TITLE
fix(smb/notify): unblock smb2.notify.dir hang (closes #623)

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf16"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
@@ -205,7 +206,32 @@ type NotifyRegistry struct {
 	// CANCEL and one-shot completion of pending notifies, and is only torn
 	// down by Disarm (called from CLOSE and from session/tree teardown).
 	armed map[string]*armedHandle
+
+	// cancelTombstones records an SMB2_CANCEL that arrived BEFORE the matching
+	// CHANGE_NOTIFY had a chance to Register. Each request is dispatched on its
+	// own goroutine (pkg/adapter/smb/connection.go), so a client that fires
+	// CHANGE_NOTIFY immediately followed by CANCEL (smb2.notify.dir's "notify
+	// cancel" subtest does exactly this) can race: the CANCEL handler runs
+	// first, finds nothing in the registry, and returns. The CHANGE_NOTIFY
+	// then registers a watcher that nobody will ever cancel — the test waits
+	// forever for STATUS_CANCELLED and the whole notify suite times out at
+	// 120s (issue #623).
+	//
+	// Tombstones are keyed by (ConnID, MessageID) — the only identifier the
+	// client can reference before it has seen the server-assigned AsyncId.
+	// They expire after cancelTombstoneTTL to bound memory; any later
+	// matching Register short-circuits to STATUS_CANCELLED. AsyncId-flagged
+	// CANCEL cannot race because the client only learns AsyncId from the
+	// interim response, which is sent strictly AFTER Register has run.
+	cancelTombstones map[notifyMsgKey]time.Time
 }
+
+// cancelTombstoneTTL bounds how long a pre-arrival SMB2_CANCEL is remembered
+// when no matching CHANGE_NOTIFY ever registers (e.g. client cancelled a
+// notify that the server rejected synchronously). Five seconds is generous
+// enough for any plausible per-request goroutine scheduling delay while still
+// expiring promptly if no Register ever happens.
+const cancelTombstoneTTL = 5 * time.Second
 
 // armedHandle records the buffered-events accounting for a single open
 // directory handle that has ever armed a CHANGE_NOTIFY. See NotifyRegistry.armed.
@@ -243,12 +269,64 @@ type notifyMsgKey struct {
 // NewNotifyRegistry creates a new notify registry.
 func NewNotifyRegistry() *NotifyRegistry {
 	return &NotifyRegistry{
-		pending:   make(map[string][]*PendingNotify),
-		byFileID:  make(map[string]*PendingNotify),
-		byMsgKey:  make(map[notifyMsgKey]*PendingNotify),
-		byAsyncId: make(map[uint64]*PendingNotify),
-		armed:     make(map[string]*armedHandle),
+		pending:          make(map[string][]*PendingNotify),
+		byFileID:         make(map[string]*PendingNotify),
+		byMsgKey:         make(map[notifyMsgKey]*PendingNotify),
+		byAsyncId:        make(map[uint64]*PendingNotify),
+		armed:            make(map[string]*armedHandle),
+		cancelTombstones: make(map[notifyMsgKey]time.Time),
 	}
+}
+
+// ErrAlreadyCancelled is returned from Register when a matching SMB2_CANCEL
+// arrived before this CHANGE_NOTIFY could register (issue #623). The handler
+// must respond with STATUS_CANCELLED synchronously instead of returning
+// STATUS_PENDING.
+var ErrAlreadyCancelled = fmt.Errorf("change_notify already cancelled before register")
+
+// MarkPendingCancel records a tombstone for a CHANGE_NOTIFY that may not yet
+// have registered. Called by the SMB2_CANCEL handler when its lookup by
+// (ConnID, MessageID) finds nothing — the matching CHANGE_NOTIFY is likely
+// being processed concurrently on another goroutine. If that NOTIFY then
+// reaches Register, the tombstone causes it to return ErrAlreadyCancelled
+// instead of registering and waiting forever (issue #623).
+//
+// Tombstones expire after cancelTombstoneTTL so a stray CANCEL for a notify
+// that was already rejected synchronously (e.g. invalid filter) doesn't
+// cancel a future unrelated CHANGE_NOTIFY that happens to reuse the same
+// (ConnID, MessageID) much later.
+func (r *NotifyRegistry) MarkPendingCancel(connID, messageID uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancelTombstones[notifyMsgKey{ConnID: connID, MessageID: messageID}] = time.Now()
+	r.gcCancelTombstonesLocked()
+}
+
+// gcCancelTombstonesLocked evicts expired tombstones. Must be called with
+// r.mu held for write. Called opportunistically from MarkPendingCancel and
+// Register so we don't need a background ticker; tombstones are only created
+// in races and expire quickly even under high load.
+func (r *NotifyRegistry) gcCancelTombstonesLocked() {
+	now := time.Now()
+	for k, ts := range r.cancelTombstones {
+		if now.Sub(ts) > cancelTombstoneTTL {
+			delete(r.cancelTombstones, k)
+		}
+	}
+}
+
+// consumeCancelTombstoneLocked checks for and removes a tombstone matching
+// the given (ConnID, MessageID). Returns true if one was found (and the
+// caller should treat the operation as cancelled). Must be called with r.mu
+// held for write. Expired tombstones are treated as absent.
+func (r *NotifyRegistry) consumeCancelTombstoneLocked(connID, messageID uint64) bool {
+	key := notifyMsgKey{ConnID: connID, MessageID: messageID}
+	ts, ok := r.cancelTombstones[key]
+	if !ok {
+		return false
+	}
+	delete(r.cancelTombstones, key)
+	return time.Since(ts) <= cancelTombstoneTTL
 }
 
 // minNotifyEntryBytes is a lower-bound estimate of one encoded
@@ -331,9 +409,26 @@ var ErrTooManyWatches = fmt.Errorf("too many pending ChangeNotify watches (max %
 // Register adds a pending notification request.
 // If a request with the same FileID already exists, it is replaced.
 // Returns ErrTooManyWatches if the global limit would be exceeded.
+// Returns ErrAlreadyCancelled when an SMB2_CANCEL for the same
+// (ConnID, MessageID) arrived before this Register call (issue #623); the
+// caller MUST respond with STATUS_CANCELLED synchronously instead of
+// emitting STATUS_PENDING.
 func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// Check for a CANCEL that arrived before us. Tombstones are exact:
+	// a matching (ConnID, MessageID) means the client's CANCEL has already
+	// been dispatched but couldn't find us yet. Short-circuit instead of
+	// registering — the handler will emit STATUS_CANCELLED synchronously.
+	if r.consumeCancelTombstoneLocked(notify.ConnID, notify.MessageID) {
+		logger.Debug("NotifyRegistry: register short-circuited by pre-arrival CANCEL",
+			"connID", notify.ConnID,
+			"messageID", notify.MessageID,
+			"path", notify.WatchPath)
+		return ErrAlreadyCancelled
+	}
+	r.gcCancelTombstonesLocked()
 
 	// If there's already a registration for this FileID, remove the old entry
 	// to keep data structures consistent.

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 )
@@ -2023,5 +2025,193 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 	}
 	if pendingMax != 0 {
 		t.Errorf("PendingNotify.MaxOutputLength = %d, want 0 (capped to first call's zero)", pendingMax)
+	}
+}
+
+// TestNotifyRegistry_PreArrivalCancel_TombstoneShortCircuitsRegister is the
+// unit regression for issue #623. It mirrors what smb2.notify.dir's "notify
+// cancel" subtest does on the wire: fire CHANGE_NOTIFY immediately followed
+// by SMB2_CANCEL. Because every SMB2 request runs on its own goroutine
+// (pkg/adapter/smb/connection.go), the CANCEL can dispatch first, find
+// nothing in the NotifyRegistry, and return — and the still-running
+// CHANGE_NOTIFY then registers a watcher that will never be cancelled.
+// The whole smb2.notify suite then exceeds smbtorture's 120s per-suite
+// timeout, taking the four other notify tests down with it.
+//
+// The fix tracks pre-arrival CANCELs as tombstones; Register checks the
+// tombstone and returns ErrAlreadyCancelled so the handler can answer
+// STATUS_CANCELLED synchronously.
+func TestNotifyRegistry_PreArrivalCancel_TombstoneShortCircuitsRegister(t *testing.T) {
+	r := NewNotifyRegistry()
+
+	const connID, messageID uint64 = 7, 42
+
+	// CANCEL arrives first — no matching entry, so the handler drops a
+	// tombstone for the future Register to find.
+	r.MarkPendingCancel(connID, messageID)
+
+	notify := &PendingNotify{
+		FileID:           [16]byte{0xAB},
+		SessionID:        1,
+		ConnID:           connID,
+		MessageID:        messageID,
+		AsyncId:          9001,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+	}
+	err := r.Register(notify)
+	if err == nil {
+		t.Fatal("Register: want ErrAlreadyCancelled, got nil")
+	}
+	if !errors.Is(err, ErrAlreadyCancelled) {
+		t.Fatalf("Register: want ErrAlreadyCancelled, got %v", err)
+	}
+
+	// Tombstone must be one-shot: a subsequent Register with the same
+	// (ConnID, MessageID) should succeed normally.
+	if err := r.Register(notify); err != nil {
+		t.Fatalf("Register after tombstone consumed: want nil, got %v", err)
+	}
+	if got := r.WatcherCount(); got != 1 {
+		t.Fatalf("WatcherCount after re-register = %d, want 1", got)
+	}
+}
+
+// TestNotifyRegistry_CancelTombstoneNoCrossMessageIDLeak guards the bound on
+// the tombstone: a CANCEL on (conn=1, msg=10) MUST NOT short-circuit a
+// future CHANGE_NOTIFY with a different MessageID (or different ConnID).
+// Without this guard, the tombstone would be a global blocker.
+func TestNotifyRegistry_CancelTombstoneNoCrossMessageIDLeak(t *testing.T) {
+	r := NewNotifyRegistry()
+	r.MarkPendingCancel(1, 10)
+
+	otherMsg := &PendingNotify{
+		FileID: [16]byte{0xFE}, ConnID: 1, MessageID: 11, AsyncId: 1,
+		WatchPath: "/a", ShareName: "s", CompletionFilter: FileNotifyChangeFileName,
+	}
+	if err := r.Register(otherMsg); err != nil {
+		t.Fatalf("Register (different MessageID): want nil, got %v", err)
+	}
+
+	otherConn := &PendingNotify{
+		FileID: [16]byte{0xFD}, ConnID: 2, MessageID: 10, AsyncId: 2,
+		WatchPath: "/b", ShareName: "s", CompletionFilter: FileNotifyChangeFileName,
+	}
+	if err := r.Register(otherConn); err != nil {
+		t.Fatalf("Register (different ConnID): want nil, got %v", err)
+	}
+}
+
+// TestNotifyRegistry_CancelTombstoneExpires verifies the TTL: a tombstone
+// older than cancelTombstoneTTL is treated as absent so a CANCEL that was
+// dropped on a notify the server already rejected synchronously cannot
+// cancel a much-later unrelated notify that happens to reuse the same
+// (ConnID, MessageID). This uses the public surface — direct map-poking
+// would couple the test to the internal layout.
+func TestNotifyRegistry_CancelTombstoneExpires(t *testing.T) {
+	r := NewNotifyRegistry()
+	r.MarkPendingCancel(1, 99)
+
+	// Manually age the tombstone by rewriting it past the TTL. Going through
+	// the map directly is the only way to simulate time passage without
+	// sleeping for cancelTombstoneTTL in tests.
+	r.mu.Lock()
+	r.cancelTombstones[notifyMsgKey{ConnID: 1, MessageID: 99}] = time.Now().Add(-2 * cancelTombstoneTTL)
+	r.mu.Unlock()
+
+	notify := &PendingNotify{
+		FileID: [16]byte{0xDE}, ConnID: 1, MessageID: 99, AsyncId: 1,
+		WatchPath: "/c", ShareName: "s", CompletionFilter: FileNotifyChangeFileName,
+	}
+	if err := r.Register(notify); err != nil {
+		t.Fatalf("Register after tombstone TTL: want nil, got %v", err)
+	}
+}
+
+// TestChangeNotify_PreArrivalCancel_HandlerReturnsCancelledSync is the
+// end-to-end regression: invoke the handler with a tombstone already in
+// place and confirm it returns STATUS_CANCELLED synchronously rather than
+// STATUS_PENDING. This is what unblocks the in-flight smbtorture client.
+func TestChangeNotify_PreArrivalCancel_HandlerReturnsCancelledSync(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	fileID := [16]byte{0x42}
+	openFile := &OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1",
+		Path: "/dir", SessionID: 1, TreeID: 1,
+		DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}
+	h.StoreOpenFile(openFile)
+
+	ctx := &SMBHandlerContext{
+		SessionID: 1, TreeID: 1, MessageID: 77, ConnID: 5,
+		TryReserveAsync: func() bool { return true },
+		ReleaseAsync:    func() {},
+		AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			return nil
+		},
+	}
+
+	// CANCEL arrived ahead of us.
+	h.NotifyRegistry.MarkPendingCancel(ctx.ConnID, ctx.MessageID)
+
+	body := encodeChangeNotifyReq(0, 1000, fileID, FileNotifyChangeFileName)
+	res, err := h.ChangeNotify(ctx, body)
+	if err != nil {
+		t.Fatalf("ChangeNotify error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("ChangeNotify returned nil result")
+	}
+	if res.Status != types.StatusCancelled {
+		t.Fatalf("ChangeNotify status = %v, want STATUS_CANCELLED", res.Status)
+	}
+	if res.AsyncId != 0 {
+		t.Errorf("ChangeNotify AsyncId = %d on cancelled sync reply, want 0", res.AsyncId)
+	}
+	if got := h.NotifyRegistry.WatcherCount(); got != 0 {
+		t.Errorf("WatcherCount after cancelled CHANGE_NOTIFY = %d, want 0", got)
+	}
+}
+
+// TestNotifyRegistry_ConcurrentCancelBeforeRegister stresses the race that
+// caused #623. We spin up many goroutines that each fire MarkPendingCancel
+// followed by Register on the same (ConnID, MessageID). Either outcome is
+// correct (tombstone consumed before Register, or Register raced past) but
+// no goroutine can land in a state where a watcher remains registered for a
+// (ConnID, MessageID) we already tombstoned — the smbtorture hang condition.
+func TestNotifyRegistry_ConcurrentCancelBeforeRegister(t *testing.T) {
+	const iters = 200
+	for i := 0; i < iters; i++ {
+		r := NewNotifyRegistry()
+		connID := uint64(i)
+		messageID := uint64(i*2 + 1)
+		fileID := [16]byte{byte(i), byte(i >> 8)}
+
+		done := make(chan struct{}, 2)
+		// Cancel first, then notify — guarantees ErrAlreadyCancelled.
+		go func() {
+			r.MarkPendingCancel(connID, messageID)
+			done <- struct{}{}
+		}()
+		go func() {
+			<-done // Force ordering: cancel definitely first.
+			notify := &PendingNotify{
+				FileID: fileID, ConnID: connID, MessageID: messageID, AsyncId: uint64(i + 100000),
+				WatchPath: "/x", ShareName: "s", CompletionFilter: FileNotifyChangeFileName,
+			}
+			err := r.Register(notify)
+			if !errors.Is(err, ErrAlreadyCancelled) {
+				t.Errorf("iter %d: Register want ErrAlreadyCancelled, got %v", i, err)
+			}
+			if got := r.WatcherCount(); got != 0 {
+				t.Errorf("iter %d: WatcherCount = %d, want 0", i, got)
+			}
+			done <- struct{}{}
+		}()
+		<-done
 	}
 }

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -252,6 +252,21 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 						"error", err)
 				}
 			}
+		} else if ctx.RequestAsyncId == 0 {
+			// CANCEL arrived before the matching CHANGE_NOTIFY had a chance
+			// to register. Each request runs on its own goroutine, so a
+			// client that fires NOTIFY immediately followed by CANCEL (the
+			// "notify cancel" subtest in smb2.notify.dir does this) can
+			// reorder them on the server side. Drop a tombstone so the
+			// in-flight CHANGE_NOTIFY's Register returns ErrAlreadyCancelled
+			// and the handler answers STATUS_CANCELLED synchronously.
+			// AsyncId-flagged CANCEL cannot race this way (the client only
+			// learns AsyncId from the interim response, which is sent strictly
+			// after Register). See issue #623.
+			h.NotifyRegistry.MarkPendingCancel(ctx.ConnID, ctx.MessageID)
+			logger.Debug("CANCEL: no matching CHANGE_NOTIFY yet — tombstoned for race",
+				"connID", ctx.ConnID,
+				"messageID", ctx.MessageID)
 		}
 	}
 
@@ -529,6 +544,17 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	if err := h.NotifyRegistry.Register(notify); err != nil {
 		ctx.ReleaseAsync()
+		// Pre-arrival CANCEL race (issue #623): SMB2_CANCEL for this
+		// (ConnID, MessageID) was dispatched before our Register could run.
+		// Answer STATUS_CANCELLED synchronously on this MessageID instead
+		// of emitting STATUS_PENDING and waiting forever.
+		if errors.Is(err, ErrAlreadyCancelled) {
+			logger.Debug("CHANGE_NOTIFY: pre-arrival CANCEL — replying STATUS_CANCELLED",
+				"path", watchPath,
+				"sessionID", ctx.SessionID,
+				"messageID", ctx.MessageID)
+			return NewErrorResult(types.StatusCancelled), nil
+		}
 		logger.Warn("CHANGE_NOTIFY: rejected — too many pending watches",
 			"path", watchPath,
 			"sessionID", ctx.SessionID)


### PR DESCRIPTION
## Summary

- Pre-arrival SMB2_CANCEL on a CHANGE_NOTIFY was racing with NOTIFY's `Register` because every request runs on its own goroutine. CANCEL fired first, found nothing, returned; NOTIFY then registered a watcher that nobody would ever cancel.
- The whole `smb2.notify` suite exceeded smbtorture's 120s per-suite timeout, leaving `smb2.notify.session-reconnect` / `.invalid-reauth` / `.handle-permissions` / `.overflow` reported as unreached.

## Fix

Track pre-arrival CANCELs as short-TTL tombstones keyed by `(ConnID, MessageID)`. `NotifyRegistry.Register` checks the tombstone first and returns the new `ErrAlreadyCancelled` sentinel when one matches; `ChangeNotify` then replies STATUS_CANCELLED synchronously instead of emitting STATUS_PENDING.

AsyncId-flagged CANCEL cannot race the same way because the client only learns AsyncId from the interim response, which is sent strictly after Register.

Tombstones expire after 5s so a stray CANCEL on a NOTIFY the server rejected synchronously cannot mis-cancel a later unrelated NOTIFY reusing the same `(ConnID, MessageID)`.

## Test plan

- [x] `go test -race -count=10 ./internal/adapter/smb/v2/handlers/` — clean
- [x] `go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/...` — clean
- [x] New unit + concurrent race tests:
  - `TestNotifyRegistry_PreArrivalCancel_TombstoneShortCircuitsRegister`
  - `TestNotifyRegistry_CancelTombstoneNoCrossMessageIDLeak`
  - `TestNotifyRegistry_CancelTombstoneExpires`
  - `TestChangeNotify_PreArrivalCancel_HandlerReturnsCancelledSync`
  - `TestNotifyRegistry_ConcurrentCancelBeforeRegister` (200 iters)
- [ ] CI smbtorture confirms `smb2.notify.dir` completes within the per-suite timeout and downstream notify subtests (#613/#614/#615/#616) report pass/fail rather than unreached. KNOWN_FAILURES walkback in a follow-up PR.