### PR TITLE
fix(blockstore): accept v0.14.x JSON array form in ContentHash unmarshal

### DIFF
--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -113,9 +113,10 @@ func (h *ContentHash) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && data[0] == '[' {
 		var arr [HashSize]byte
 		if err := json.Unmarshal(data, &arr); err == nil {
-			*h = arr
+			*h = ContentHash(arr)
 			return nil
 		}
+		return fmt.Errorf("ContentHash.UnmarshalJSON: invalid JSON array: %q", data)
 	}
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("ContentHash.UnmarshalJSON: not a JSON string: %q", data)

--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -3,6 +3,7 @@ package blockstore
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -106,6 +107,16 @@ func (h ContentHash) MarshalJSON() ([]byte, error) {
 // fallback preserves backward compatibility for FileBlock rows persisted
 // by Phase 11 Badger before this MarshalJSON existed.
 func (h *ContentHash) UnmarshalJSON(data []byte) error {
+	// v0.14.x and earlier had no custom MarshalJSON — encoding/json
+	// serialized [32]byte as a JSON number array: [0,0,...,0]. Accept
+	// that form so develop can read legacy badger metadata.
+	if len(data) > 0 && data[0] == '[' {
+		var arr [HashSize]byte
+		if err := json.Unmarshal(data, &arr); err == nil {
+			*h = arr
+			return nil
+		}
+	}
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("ContentHash.UnmarshalJSON: not a JSON string: %q", data)
 	}

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -485,7 +485,7 @@ func TestContentHash_JSONBackwardCompat(t *testing.T) {
 // MarshalJSON existed). Critical for reading badger metadata written by
 // v0.14.2 servers during upgrade migration.
 func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
-	// v0.14.x zero-value ObjectID serialized as [0,0,...,0]
+	// v0.14.x zero-value ContentHash serialized as [0,0,...,0]
 	zeroArr := "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
 	var got ContentHash
 	if err := got.UnmarshalJSON([]byte(zeroArr)); err != nil {
@@ -501,7 +501,10 @@ func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
 	if err := got2.UnmarshalJSON([]byte(nonZeroArr)); err != nil {
 		t.Fatalf("UnmarshalJSON v0.14 non-zero array: %v", err)
 	}
-	want, _ := ParseContentHash(blake3EmptyHex)
+	want, err := ParseContentHash(blake3EmptyHex)
+	if err != nil {
+		t.Fatalf("ParseContentHash: %v", err)
+	}
 	if !bytes.Equal(got2[:], want[:]) {
 		t.Fatalf("v0.14 non-zero array decode mismatch:\n got: %x\nwant: %x", got2[:], want[:])
 	}

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -479,6 +479,34 @@ func TestContentHash_JSONBackwardCompat(t *testing.T) {
 	}
 }
 
+// TestContentHash_JSONBackwardCompat_V014Array asserts UnmarshalJSON accepts
+// the JSON number-array form that v0.14.x and earlier serialized for
+// ContentHash (encoding/json's default for [32]byte when no custom
+// MarshalJSON existed). Critical for reading badger metadata written by
+// v0.14.2 servers during upgrade migration.
+func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
+	// v0.14.x zero-value ObjectID serialized as [0,0,...,0]
+	zeroArr := "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
+	var got ContentHash
+	if err := got.UnmarshalJSON([]byte(zeroArr)); err != nil {
+		t.Fatalf("UnmarshalJSON v0.14 zero array: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("expected zero hash, got %x", got[:])
+	}
+
+	// Non-zero array (simulates a v0.14.x row with actual content hash)
+	nonZeroArr := "[175,19,73,185,245,249,161,166,160,64,77,234,54,220,201,73,155,203,37,201,173,193,18,183,204,154,147,202,228,31,50,98]"
+	var got2 ContentHash
+	if err := got2.UnmarshalJSON([]byte(nonZeroArr)); err != nil {
+		t.Fatalf("UnmarshalJSON v0.14 non-zero array: %v", err)
+	}
+	want, _ := ParseContentHash(blake3EmptyHex)
+	if !bytes.Equal(got2[:], want[:]) {
+		t.Fatalf("v0.14 non-zero array decode mismatch:\n got: %x\nwant: %x", got2[:], want[:])
+	}
+}
+
 // TestErrBlockRefMissing asserts the new sentinel exists, is self-identical
 // via errors.Is, and has the expected message style ("blockstore:" prefix
 // + mentions "block ref"). Phase 12 D-23.


### PR DESCRIPTION
## Summary

- Fix `ContentHash.UnmarshalJSON` to accept the JSON number-array form (`[0,0,...,0]`) that v0.14.x serialized for `[32]byte` fields (no custom `MarshalJSON` existed before Phase 12)
- Without this, develop cannot read legacy badger metadata — blocks the entire migration path from v0.14.x to v0.16+
- Found during end-to-end migration testing against real v0.14.2 data

## Test plan

- [x] New test `TestContentHash_JSONBackwardCompat_V014Array` covers zero and non-zero array forms
- [x] Existing backward-compat tests still pass (hex, blake3:hex, base64)
- [x] Full `go test ./pkg/blockstore/...` green
- [x] Verified against real v0.14.2 badger DB: all 59 files now decode successfully