### PR TITLE
feat(migrate): production-ready migrate-to-cas CLI

### DIFF
--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -353,7 +353,23 @@ func (a *cliMetadataAdapter) UpdateFileBlocks(ctx context.Context, handle metada
 		return fmt.Errorf("get file for update: %w", err)
 	}
 	file.Blocks = blocks
-	return a.store.PutFile(ctx, file)
+	if err := a.store.PutFile(ctx, file); err != nil {
+		return err
+	}
+	pid := string(file.PayloadID)
+	for _, br := range blocks {
+		fb := &blockstore.FileBlock{
+			ID:       fmt.Sprintf("%s/%d", pid, br.Offset),
+			Hash:     br.Hash,
+			DataSize: br.Size,
+			State:    blockstore.BlockStateRemote,
+			RefCount: 1,
+		}
+		if err := a.store.Put(ctx, fb); err != nil {
+			return fmt.Errorf("create FileBlock row %s: %w", fb.ID, err)
+		}
+	}
+	return nil
 }
 
 // nopFileBlockStore satisfies blockstore.EngineFileBlockStore without

--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -19,6 +19,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
 	"github.com/marmos91/dittofs/pkg/blockstore/migrate"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 )
 
 // Plan 08 (Phase 17): offline `dfs migrate-to-cas` subcommand.
@@ -45,12 +46,13 @@ import (
 // emission, and the FSStore-for-migration construction.
 
 var (
-	migrateStorageDir string
-	migrateShare      string
-	migrateDryRun     bool
-	migrateJSON       bool
-	migrateMaxDisk    int64
-	migrateMaxMemory  int64
+	migrateStorageDir  string
+	migrateMetadataDir string
+	migrateShare       string
+	migrateDryRun      bool
+	migrateJSON        bool
+	migrateMaxDisk     int64
+	migrateMaxMemory   int64
 )
 
 var migrateToCASCmd = &cobra.Command{
@@ -98,6 +100,8 @@ func init() {
 		"Per-share max-disk budget for the destination FSStore (0 = unlimited)")
 	migrateToCASCmd.Flags().Int64Var(&migrateMaxMemory, "max-memory", 0,
 		"Per-share max-memory budget for the destination FSStore (0 = 256 MiB default)")
+	migrateToCASCmd.Flags().StringVar(&migrateMetadataDir, "metadata-dir", "",
+		"Path to the badger metadata database directory (REQUIRED; the directory passed to the metadata store's 'path' config)")
 }
 
 func runMigrateToCAS(cmd *cobra.Command, args []string) error {
@@ -116,6 +120,15 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve --storage-dir: %w", err)
 	}
 	migrateStorageDir = abs
+
+	if migrateMetadataDir == "" {
+		return errors.New("--metadata-dir is required (path to the badger metadata database directory)")
+	}
+	metaAbs, err := filepath.Abs(migrateMetadataDir)
+	if err != nil {
+		return fmt.Errorf("resolve --metadata-dir: %w", err)
+	}
+	migrateMetadataDir = metaAbs
 
 	sharesRoot := filepath.Join(migrateStorageDir, "shares")
 	entries, err := os.ReadDir(sharesRoot)
@@ -146,6 +159,12 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	mds, err := badgerstore.NewBadgerMetadataStoreWithDefaults(ctx, migrateMetadataDir)
+	if err != nil {
+		return fmt.Errorf("open metadata store at %q: %w", migrateMetadataDir, err)
+	}
+	defer func() { _ = mds.Close() }()
 
 	var aggregate migrate.MigrationStats
 	for _, name := range shareNames {
@@ -178,7 +197,7 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 			StoreDir: shareDir,
 		}
 
-		adapter := &cliMetadataAdapter{shareName: name}
+		adapter := &cliMetadataAdapter{shareName: "/" + name, store: mds}
 		res, runErr := migrate.MigrateShareToCAS(ctx, shareDir, bs, adapter, opts)
 		_ = bs.Close()
 		if runErr != nil {
@@ -259,35 +278,82 @@ func makeProgressFn(shareName string) func(migrate.MigrationStats) {
 	}
 }
 
-// cliMetadataAdapter is the CLI-side bridge between the migration
-// library and the share's metadata store. Plan 08 ships it as a no-op
-// stub — production share-by-share wiring lands in Plan 17-09 alongside
-// the boot-guard sentinel-detection gate (which closes the loop: the
-// migration library writes the sentinel, the boot guard reads it).
-//
-// Until then, invoking `dfs migrate-to-cas` against a share with legacy
-// `.blk` files writes the CAS chunks + sentinel but reports zero
-// metadata updates — operators in pre-v0.16 production environments
-// MUST wait for Plan 17-09 to ship before treating the migration as
-// complete.
+// cliMetadataAdapter bridges the migration library to a live badger
+// metadata store opened directly by the CLI (offline — server must be
+// stopped). ListLegacyFiles walks the share tree and returns every
+// regular file with Size > 0 and empty Blocks (unmigrated). UpdateFileBlocks
+// commits the new CAS BlockRef manifest transactionally via PutFile.
 type cliMetadataAdapter struct {
 	shareName string
+	store     *badgerstore.BadgerMetadataStore
 }
 
 func (a *cliMetadataAdapter) ListLegacyFiles(ctx context.Context) ([]migrate.LegacyFileInfo, error) {
-	// Plan 08 ships the library + CLI scaffolding; metadata-store
-	// enumeration is wired in Plan 17-09 (per Phase 17 sequencing). The
-	// no-op stub here lets `dfs migrate-to-cas` exercise the library's
-	// dry-run path + sentinel-write path against an empty file set —
-	// which still produces the `.cas-migrated-v1` sentinel and exercises
-	// the boot-guard contract end-to-end.
-	return nil, nil
+	rootHandle, err := a.store.GetRootHandle(ctx, a.shareName)
+	if err != nil {
+		return nil, fmt.Errorf("get root handle for %s: %w", a.shareName, err)
+	}
+	var files []migrate.LegacyFileInfo
+	if err := a.walkDir(ctx, rootHandle, "", &files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func (a *cliMetadataAdapter) walkDir(ctx context.Context, dirHandle metadata.FileHandle, prefix string, out *[]migrate.LegacyFileInfo) error {
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entries, nextCursor, err := a.store.ListChildren(ctx, dirHandle, cursor, 500)
+		if err != nil {
+			return fmt.Errorf("list children at %q: %w", prefix, err)
+		}
+		for _, e := range entries {
+			file, err := a.store.GetFile(ctx, e.Handle)
+			if err != nil {
+				return fmt.Errorf("get file %s%s: %w", prefix, e.Name, err)
+			}
+			if file.Type == metadata.FileTypeDirectory {
+				if err := a.walkDir(ctx, e.Handle, prefix+e.Name+"/", out); err != nil {
+					return err
+				}
+				continue
+			}
+			if file.Type != metadata.FileTypeRegular || file.Size == 0 {
+				continue
+			}
+			if len(file.Blocks) > 0 {
+				continue
+			}
+			handle, err := metadata.EncodeFileHandle(file)
+			if err != nil {
+				return fmt.Errorf("encode handle for %s%s: %w", prefix, e.Name, err)
+			}
+			*out = append(*out, migrate.LegacyFileInfo{
+				Handle:    handle,
+				Path:      prefix + e.Name,
+				PayloadID: file.PayloadID,
+				Size:      int64(file.Size),
+				BlockSize: blockstore.BlockSize,
+			})
+		}
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+	return nil
 }
 
 func (a *cliMetadataAdapter) UpdateFileBlocks(ctx context.Context, handle metadata.FileHandle, blocks []blockstore.BlockRef) error {
-	// Unreachable: ListLegacyFiles returns no files. Plan 17-09 lands
-	// the per-share metadata-store opener + transactional PutFile path.
-	return errors.New("migrate-to-cas: metadata adapter not wired (Plan 17-09)")
+	file, err := a.store.GetFile(ctx, handle)
+	if err != nil {
+		return fmt.Errorf("get file for update: %w", err)
+	}
+	file.Blocks = blocks
+	return a.store.PutFile(ctx, file)
 }
 
 // nopFileBlockStore satisfies blockstore.EngineFileBlockStore without

--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -22,28 +22,20 @@ import (
 	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 )
 
-// Plan 08 (Phase 17): offline `dfs migrate-to-cas` subcommand.
+// Offline `dfs migrate-to-cas` subcommand.
 //
 // Walks the configured storage tree, opens each share's destination CAS
 // BlockStore via fs.NewFSStoreForMigration (sentinel-bypass), invokes
 // migrate.MigrateShareToCAS per share, and writes the per-share
-// `.cas-migrated-v1` sentinel that Plan 09's boot guard requires.
+// `.cas-migrated-v1` sentinel that the boot guard requires.
 //
 // Refuses to run while the dfs server holds the PID lockfile (D-02
 // OFFLINE constraint).
 //
-// The MetadataAdapter used here is intentionally minimal: production
-// shares persist their metadata through the controlplane runtime
-// (pkg/controlplane/runtime/shares/service.go), which boots an entire
-// services graph. The migration tool short-circuits that by opening the
-// metadata backend directly per share — currently a no-op stub that
-// surfaces an explicit error to the operator when invoked against a
-// share whose metadata-store adapter has not yet been wired up by Plan
-// 17-09. The library half (pkg/blockstore/migrate/migrate_to_cas.go) is
-// fully exercised by its own unit suite (Task 3) which provides an
-// in-memory MetadataAdapter for testing. The CLI half here provides the
-// PID guard, flag wiring, share discovery, JSON / plain-text progress
-// emission, and the FSStore-for-migration construction.
+// The MetadataAdapter opens the badger metadata store directly (offline
+// — the server must be stopped). Production shares normally go through
+// the controlplane runtime, but the migration tool short-circuits that
+// to avoid booting the full services graph.
 
 var (
 	migrateStorageDir  string

--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -345,23 +345,25 @@ func (a *cliMetadataAdapter) UpdateFileBlocks(ctx context.Context, handle metada
 		return fmt.Errorf("get file for update: %w", err)
 	}
 	file.Blocks = blocks
-	if err := a.store.PutFile(ctx, file); err != nil {
-		return err
-	}
 	pid := string(file.PayloadID)
-	for _, br := range blocks {
-		fb := &blockstore.FileBlock{
-			ID:       fmt.Sprintf("%s/%d", pid, br.Offset),
-			Hash:     br.Hash,
-			DataSize: br.Size,
-			State:    blockstore.BlockStateRemote,
-			RefCount: 1,
+	return a.store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if err := tx.PutFile(ctx, file); err != nil {
+			return err
 		}
-		if err := a.store.Put(ctx, fb); err != nil {
-			return fmt.Errorf("create FileBlock row %s: %w", fb.ID, err)
+		for _, br := range blocks {
+			fb := &blockstore.FileBlock{
+				ID:       fmt.Sprintf("%s/%d", pid, br.Offset),
+				Hash:     br.Hash,
+				DataSize: br.Size,
+				State:    blockstore.BlockStateRemote,
+				RefCount: 1,
+			}
+			if err := tx.Put(ctx, fb); err != nil {
+				return fmt.Errorf("create FileBlock row %s: %w", fb.ID, err)
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // nopFileBlockStore satisfies blockstore.EngineFileBlockStore without

--- a/pkg/blockstore/migrate/migrate_to_cas.go
+++ b/pkg/blockstore/migrate/migrate_to_cas.go
@@ -392,8 +392,14 @@ func migrateOneFile(
 // variant is deferred to Phase 18 if large-VM operators report OOMs.
 func readLegacyFileStream(shareDir string, f LegacyFileInfo) ([]byte, error) {
 	pid := string(f.PayloadID)
+	if len(pid) < 2 {
+		return nil, fmt.Errorf("migrate: PayloadID %q too short for shard prefix", pid)
+	}
 	shard := pid[:2]
 	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
+	if !strings.HasPrefix(payloadDir, shareDir) {
+		return nil, fmt.Errorf("migrate: PayloadID %q escapes share directory", pid)
+	}
 	entries, err := os.ReadDir(payloadDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -461,6 +467,9 @@ func sortBlks(blks []legacyBlk) {
 // entries as success.
 func removeLegacyBlkFiles(shareDir string, f LegacyFileInfo) error {
 	pid := string(f.PayloadID)
+	if len(pid) < 2 {
+		return nil
+	}
 	shard := pid[:2]
 	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 	entries, err := os.ReadDir(payloadDir)

--- a/pkg/blockstore/migrate/migrate_to_cas.go
+++ b/pkg/blockstore/migrate/migrate_to_cas.go
@@ -110,7 +110,7 @@ type LegacyFileInfo struct {
 	Handle metadata.FileHandle
 	// Path is the share-relative path (forensic display).
 	Path string
-	// PayloadID locates the `.blk` tree at `<shareDir>/<PayloadID>/<idx>.blk`.
+	// PayloadID locates the `.blk` tree at `<shareDir>/blocks/<shard>/<PayloadID>/<idx>.blk`.
 	PayloadID metadata.PayloadID
 	// Size is FileAttr.Size in bytes.
 	Size int64
@@ -386,19 +386,14 @@ func migrateOneFile(
 }
 
 // readLegacyFileStream concatenates every `<idx>.blk` file under
-// `<shareDir>/<PayloadID>/` in offset order into a single in-memory
-// stream. Last block may be short. In-memory concat acceptable for the
-// v0.16 migration window (offline, bounded by share quota); a streaming
-// variant is deferred to Phase 18 if large-VM operators report OOMs.
+// `<shareDir>/blocks/<shard>/<PayloadID>/` in offset order into a single
+// in-memory stream. Last block may be short. In-memory concat acceptable
+// for the v0.16 migration window (offline, bounded by share quota); a
+// streaming variant is deferred if large-VM operators report OOMs.
 func readLegacyFileStream(shareDir string, f LegacyFileInfo) ([]byte, error) {
-	pid := string(f.PayloadID)
-	if len(pid) < 2 {
-		return nil, fmt.Errorf("migrate: PayloadID %q too short for shard prefix", pid)
-	}
-	shard := pid[:2]
-	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
-	if !strings.HasPrefix(payloadDir, shareDir) {
-		return nil, fmt.Errorf("migrate: PayloadID %q escapes share directory", pid)
+	payloadDir, err := legacyPayloadDir(shareDir, string(f.PayloadID))
+	if err != nil {
+		return nil, err
 	}
 	entries, err := os.ReadDir(payloadDir)
 	if err != nil {
@@ -444,6 +439,22 @@ func readLegacyFileStream(shareDir string, f LegacyFileInfo) ([]byte, error) {
 	return out, nil
 }
 
+// legacyPayloadDir returns the on-disk directory for a legacy file's .blk
+// tree: <shareDir>/blocks/<shard>/<payloadID>. Returns ("", error) when
+// the PayloadID is too short for the 2-char shard prefix or the resolved
+// path escapes the share directory.
+func legacyPayloadDir(shareDir string, pid string) (string, error) {
+	if len(pid) < 2 {
+		return "", fmt.Errorf("migrate: PayloadID %q too short for shard prefix", pid)
+	}
+	shard := pid[:2]
+	dir := filepath.Join(shareDir, "blocks", shard, pid)
+	if !strings.HasPrefix(dir, shareDir) {
+		return "", fmt.Errorf("migrate: PayloadID %q escapes share directory", pid)
+	}
+	return dir, nil
+}
+
 // legacyBlk is a single `<idx>.blk` file under a legacy payload tree.
 type legacyBlk struct {
 	idx  uint64
@@ -466,12 +477,10 @@ func sortBlks(blks []legacyBlk) {
 // metadata-store artifacts may live alongside) and treats missing
 // entries as success.
 func removeLegacyBlkFiles(shareDir string, f LegacyFileInfo) error {
-	pid := string(f.PayloadID)
-	if len(pid) < 2 {
-		return nil
+	payloadDir, err := legacyPayloadDir(shareDir, string(f.PayloadID))
+	if err != nil {
+		return nil // Short/invalid PayloadID: nothing to remove.
 	}
-	shard := pid[:2]
-	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 	entries, err := os.ReadDir(payloadDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/blockstore/migrate/migrate_to_cas.go
+++ b/pkg/blockstore/migrate/migrate_to_cas.go
@@ -391,7 +391,9 @@ func migrateOneFile(
 // v0.16 migration window (offline, bounded by share quota); a streaming
 // variant is deferred to Phase 18 if large-VM operators report OOMs.
 func readLegacyFileStream(shareDir string, f LegacyFileInfo) ([]byte, error) {
-	payloadDir := filepath.Join(shareDir, string(f.PayloadID))
+	pid := string(f.PayloadID)
+	shard := pid[:2]
+	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 	entries, err := os.ReadDir(payloadDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -458,7 +460,9 @@ func sortBlks(blks []legacyBlk) {
 // metadata-store artifacts may live alongside) and treats missing
 // entries as success.
 func removeLegacyBlkFiles(shareDir string, f LegacyFileInfo) error {
-	payloadDir := filepath.Join(shareDir, string(f.PayloadID))
+	pid := string(f.PayloadID)
+	shard := pid[:2]
+	payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 	entries, err := os.ReadDir(payloadDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/blockstore/migrate/migrate_to_cas.go
+++ b/pkg/blockstore/migrate/migrate_to_cas.go
@@ -449,7 +449,7 @@ func legacyPayloadDir(shareDir string, pid string) (string, error) {
 	}
 	shard := pid[:2]
 	dir := filepath.Join(shareDir, "blocks", shard, pid)
-	if !strings.HasPrefix(dir, shareDir) {
+	if !strings.HasPrefix(dir, filepath.Clean(shareDir)+string(os.PathSeparator)) {
 		return "", fmt.Errorf("migrate: PayloadID %q escapes share directory", pid)
 	}
 	return dir, nil

--- a/pkg/blockstore/migrate/migrate_to_cas_test.go
+++ b/pkg/blockstore/migrate/migrate_to_cas_test.go
@@ -176,7 +176,7 @@ func (s *stubMetadataAdapter) UpdateFileBlocks(_ context.Context, handle metadat
 
 // buildLegacyShare materializes a fake share directory with `fileCount`
 // legacy files of `fileSize` bytes each. The on-disk layout mirrors the
-// pre-Phase-17 `<shareDir>/<PayloadID>/<idx>.blk` shape. Returns the
+// pre-Phase-17 `<shareDir>/blocks/<shard>/<PayloadID>/<idx>.blk` shape. Returns the
 // share directory + the LegacyFileInfo list ready to feed into the stub
 // MetadataAdapter.
 func buildLegacyShare(t *testing.T, fileCount int, fileSize int64) (string, []LegacyFileInfo) {
@@ -188,7 +188,9 @@ func buildLegacyShare(t *testing.T, fileCount int, fileSize int64) (string, []Le
 	var files []LegacyFileInfo
 	for i := 0; i < fileCount; i++ {
 		payloadID := metadata.PayloadID(fmt.Sprintf("file-%03d", i))
-		payloadDir := filepath.Join(shareDir, string(payloadID))
+		pid := string(payloadID)
+		shard := pid[:2]
+		payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 		if err := os.MkdirAll(payloadDir, 0o755); err != nil {
 			t.Fatalf("MkdirAll: %v", err)
 		}
@@ -278,7 +280,9 @@ func TestMigrateShareToCAS_HappyPath(t *testing.T) {
 
 	// Legacy .blk files removed.
 	for _, f := range files {
-		payloadDir := filepath.Join(shareDir, string(f.PayloadID))
+		pid := string(f.PayloadID)
+		shard := pid[:2]
+		payloadDir := filepath.Join(shareDir, "blocks", shard, pid)
 		entries, _ := os.ReadDir(payloadDir)
 		for _, e := range entries {
 			if filepath.Ext(e.Name()) == ".blk" {

--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -113,9 +113,10 @@ func (h *ContentHash) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && data[0] == '[' {
 		var arr [HashSize]byte
 		if err := json.Unmarshal(data, &arr); err == nil {
-			*h = arr
+			*h = ContentHash(arr)
 			return nil
 		}
+		return fmt.Errorf("ContentHash.UnmarshalJSON: invalid JSON array: %q", data)
 	}
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("ContentHash.UnmarshalJSON: not a JSON string: %q", data)

--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -3,6 +3,7 @@ package blockstore
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -106,6 +107,16 @@ func (h ContentHash) MarshalJSON() ([]byte, error) {
 // fallback preserves backward compatibility for FileBlock rows persisted
 // by Phase 11 Badger before this MarshalJSON existed.
 func (h *ContentHash) UnmarshalJSON(data []byte) error {
+	// v0.14.x and earlier had no custom MarshalJSON — encoding/json
+	// serialized [32]byte as a JSON number array: [0,0,...,0]. Accept
+	// that form so develop can read legacy badger metadata.
+	if len(data) > 0 && data[0] == '[' {
+		var arr [HashSize]byte
+		if err := json.Unmarshal(data, &arr); err == nil {
+			*h = arr
+			return nil
+		}
+	}
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("ContentHash.UnmarshalJSON: not a JSON string: %q", data)
 	}

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -485,7 +485,7 @@ func TestContentHash_JSONBackwardCompat(t *testing.T) {
 // MarshalJSON existed). Critical for reading badger metadata written by
 // v0.14.2 servers during upgrade migration.
 func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
-	// v0.14.x zero-value ObjectID serialized as [0,0,...,0]
+	// v0.14.x zero-value ContentHash serialized as [0,0,...,0]
 	zeroArr := "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
 	var got ContentHash
 	if err := got.UnmarshalJSON([]byte(zeroArr)); err != nil {
@@ -501,7 +501,10 @@ func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
 	if err := got2.UnmarshalJSON([]byte(nonZeroArr)); err != nil {
 		t.Fatalf("UnmarshalJSON v0.14 non-zero array: %v", err)
 	}
-	want, _ := ParseContentHash(blake3EmptyHex)
+	want, err := ParseContentHash(blake3EmptyHex)
+	if err != nil {
+		t.Fatalf("ParseContentHash: %v", err)
+	}
 	if !bytes.Equal(got2[:], want[:]) {
 		t.Fatalf("v0.14 non-zero array decode mismatch:\n got: %x\nwant: %x", got2[:], want[:])
 	}

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -479,6 +479,34 @@ func TestContentHash_JSONBackwardCompat(t *testing.T) {
 	}
 }
 
+// TestContentHash_JSONBackwardCompat_V014Array asserts UnmarshalJSON accepts
+// the JSON number-array form that v0.14.x and earlier serialized for
+// ContentHash (encoding/json's default for [32]byte when no custom
+// MarshalJSON existed). Critical for reading badger metadata written by
+// v0.14.2 servers during upgrade migration.
+func TestContentHash_JSONBackwardCompat_V014Array(t *testing.T) {
+	// v0.14.x zero-value ObjectID serialized as [0,0,...,0]
+	zeroArr := "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
+	var got ContentHash
+	if err := got.UnmarshalJSON([]byte(zeroArr)); err != nil {
+		t.Fatalf("UnmarshalJSON v0.14 zero array: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("expected zero hash, got %x", got[:])
+	}
+
+	// Non-zero array (simulates a v0.14.x row with actual content hash)
+	nonZeroArr := "[175,19,73,185,245,249,161,166,160,64,77,234,54,220,201,73,155,203,37,201,173,193,18,183,204,154,147,202,228,31,50,98]"
+	var got2 ContentHash
+	if err := got2.UnmarshalJSON([]byte(nonZeroArr)); err != nil {
+		t.Fatalf("UnmarshalJSON v0.14 non-zero array: %v", err)
+	}
+	want, _ := ParseContentHash(blake3EmptyHex)
+	if !bytes.Equal(got2[:], want[:]) {
+		t.Fatalf("v0.14 non-zero array decode mismatch:\n got: %x\nwant: %x", got2[:], want[:])
+	}
+}
+
 // TestErrBlockRefMissing asserts the new sentinel exists, is self-identical
 // via errors.Is, and has the expected message style ("blockstore:" prefix
 // + mentions "block ref"). Phase 12 D-23.

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -99,8 +99,12 @@ func (s *BadgerMetadataStore) Put(ctx context.Context, block *metadata.FileBlock
 
 		// Maintain file index: fb-file:{payloadID}:{blockIdx} -> block.ID
 		// This allows ListFileBlocks to iterate O(file_blocks) via prefix scan.
-		if parts := strings.SplitN(block.ID, "/", 2); len(parts) == 2 {
-			fileKey := []byte(fileBlockFilePrefix + parts[0] + ":" + parts[1])
+		// Split on the LAST "/" so nested payloadIDs (e.g. "share/dir/file/0")
+		// produce the correct payloadID prefix for ListFileBlocks lookups.
+		if lastSlash := strings.LastIndex(block.ID, "/"); lastSlash > 0 {
+			pid := block.ID[:lastSlash]
+			idx := block.ID[lastSlash+1:]
+			fileKey := []byte(fileBlockFilePrefix + pid + ":" + idx)
 			if err := txn.Set(fileKey, []byte(block.ID)); err != nil {
 				return err
 			}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -99,11 +99,7 @@ func (s *BadgerMetadataStore) Put(ctx context.Context, block *metadata.FileBlock
 
 		// Maintain file index: fb-file:{payloadID}:{blockIdx} -> block.ID
 		// This allows ListFileBlocks to iterate O(file_blocks) via prefix scan.
-		// Split on the LAST "/" so nested payloadIDs (e.g. "share/dir/file/0")
-		// produce the correct payloadID prefix for ListFileBlocks lookups.
-		if lastSlash := strings.LastIndex(block.ID, "/"); lastSlash > 0 {
-			pid := block.ID[:lastSlash]
-			idx := block.ID[lastSlash+1:]
+		if pid, idx, ok := splitBlockID(block.ID); ok {
 			fileKey := []byte(fileBlockFilePrefix + pid + ":" + idx)
 			if err := txn.Set(fileKey, []byte(block.ID)); err != nil {
 				return err
@@ -149,10 +145,8 @@ func (s *BadgerMetadataStore) Delete(ctx context.Context, id string) error {
 		// Remove local index
 		_ = txn.Delete([]byte(fileBlockLocalPrefix + id))
 
-		// Remove file index (split on LAST "/" for nested payloadIDs)
-		if lastSlash := strings.LastIndex(id, "/"); lastSlash > 0 {
-			pid := id[:lastSlash]
-			idx := id[lastSlash+1:]
+		// Remove file index
+		if pid, idx, ok := splitBlockID(id); ok {
 			_ = txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
 		}
 
@@ -518,11 +512,23 @@ func (s *BadgerMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(b
 	})
 }
 
+// splitBlockID splits a block ID into (payloadID, blockIdx) on the LAST
+// "/" separator. Nested payloadIDs (e.g. "share/dir/file/0") produce the
+// correct payloadID prefix for the fb-file: secondary index. Returns
+// ("", "", false) when the ID contains no "/".
+func splitBlockID(id string) (pid, idx string, ok bool) {
+	lastSlash := strings.LastIndex(id, "/")
+	if lastSlash <= 0 {
+		return "", "", false
+	}
+	return id[:lastSlash], id[lastSlash+1:], true
+}
+
 // parseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
 func parseBlockIdx(id string) int {
-	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+	if _, idx, ok := splitBlockID(id); ok {
 		var v int
-		if _, err := fmt.Sscanf(id[idx+1:], "%d", &v); err == nil {
+		if _, err := fmt.Sscanf(idx, "%d", &v); err == nil {
 			return v
 		}
 	}
@@ -585,9 +591,7 @@ func (tx *badgerTransaction) Put(ctx context.Context, block *metadata.FileBlock)
 	} else {
 		_ = tx.txn.Delete(localKey)
 	}
-	if lastSlash := strings.LastIndex(block.ID, "/"); lastSlash > 0 {
-		pid := block.ID[:lastSlash]
-		idx := block.ID[lastSlash+1:]
+	if pid, idx, ok := splitBlockID(block.ID); ok {
 		fileKey := []byte(fileBlockFilePrefix + pid + ":" + idx)
 		if err := tx.txn.Set(fileKey, []byte(block.ID)); err != nil {
 			return err
@@ -622,9 +626,7 @@ func (tx *badgerTransaction) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	_ = tx.txn.Delete([]byte(fileBlockLocalPrefix + id))
-	if lastSlash := strings.LastIndex(id, "/"); lastSlash > 0 {
-		pid := id[:lastSlash]
-		idx := id[lastSlash+1:]
+	if pid, idx, ok := splitBlockID(id); ok {
 		_ = tx.txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
 	}
 	if block.IsFinalized() {

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -149,9 +149,11 @@ func (s *BadgerMetadataStore) Delete(ctx context.Context, id string) error {
 		// Remove local index
 		_ = txn.Delete([]byte(fileBlockLocalPrefix + id))
 
-		// Remove file index
-		if parts := strings.SplitN(id, "/", 2); len(parts) == 2 {
-			_ = txn.Delete([]byte(fileBlockFilePrefix + parts[0] + ":" + parts[1]))
+		// Remove file index (split on LAST "/" for nested payloadIDs)
+		if lastSlash := strings.LastIndex(id, "/"); lastSlash > 0 {
+			pid := id[:lastSlash]
+			idx := id[lastSlash+1:]
+			_ = txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
 		}
 
 		// Remove hash index
@@ -583,8 +585,10 @@ func (tx *badgerTransaction) Put(ctx context.Context, block *metadata.FileBlock)
 	} else {
 		_ = tx.txn.Delete(localKey)
 	}
-	if parts := strings.SplitN(block.ID, "/", 2); len(parts) == 2 {
-		fileKey := []byte(fileBlockFilePrefix + parts[0] + ":" + parts[1])
+	if lastSlash := strings.LastIndex(block.ID, "/"); lastSlash > 0 {
+		pid := block.ID[:lastSlash]
+		idx := block.ID[lastSlash+1:]
+		fileKey := []byte(fileBlockFilePrefix + pid + ":" + idx)
 		if err := tx.txn.Set(fileKey, []byte(block.ID)); err != nil {
 			return err
 		}
@@ -618,8 +622,10 @@ func (tx *badgerTransaction) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	_ = tx.txn.Delete([]byte(fileBlockLocalPrefix + id))
-	if parts := strings.SplitN(id, "/", 2); len(parts) == 2 {
-		_ = tx.txn.Delete([]byte(fileBlockFilePrefix + parts[0] + ":" + parts[1]))
+	if lastSlash := strings.LastIndex(id, "/"); lastSlash > 0 {
+		pid := id[:lastSlash]
+		idx := id[lastSlash+1:]
+		_ = tx.txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
 	}
 	if block.IsFinalized() {
 		hashKey := []byte(fileBlockHashPrefix + block.Hash.String())


### PR DESCRIPTION
## Summary

Makes `dfs migrate-to-cas` production-ready for v0.14.x → v0.16+ upgrades. Depends on #636 (ContentHash unmarshal fix).

**4 bugs found and fixed during end-to-end testing against real v0.14.2 data on Cubbit S3:**

1. **Wire real metadata adapter** — replace the no-op `cliMetadataAdapter` stub with a real implementation that opens a badger metadata store (new `--metadata-dir` flag), walks the share tree via `GetRootHandle` + `ListChildren`, and enumerates legacy files (regular, Size>0, empty Blocks)

2. **Fix legacy block paths** — `readLegacyFileStream` and `removeLegacyBlkFiles` used `<shareDir>/<PayloadID>/<N>.blk` but the actual on-disk layout is `<shareDir>/blocks/<PayloadID[:2]>/<PayloadID>/<N>.blk` (2-char hash shard under `blocks/` subdir)

3. **Create FileBlock metadata rows** — `UpdateFileBlocks` now creates `FileBlock` rows for each CAS chunk so the engine read path (`readLocalByHash` → `ListFileBlocks` → Hash → local CAS Get) can resolve blocks. Without these, all reads returned zero-filled sparse data

4. **Fix badger file-index key split** — `Put` used `SplitN(ID, "/", 2)` (first `/`) but `ListFileBlocks` searches by full payloadID prefix. Fixed to `LastIndex` (last `/`), consistent with `ParseBlockID`

## Test plan

- [x] Unit tests: `go test ./pkg/blockstore/migrate/...` (20 PASS)
- [x] Unit tests: `go test ./pkg/metadata/store/badger/...` (PASS)
- [x] E2E: v0.14.2 server → upload 4 files via NFS → stop → `dfs migrate-to-cas` → develop server → NFS mount → **all checksums match**
- [x] Verified: 0 legacy `.blk` files remain, `.cas-migrated-v1` sentinel written, CAS chunks at `blocks/{hh}/{hh}/{hex}`
- [x] Verified: FileBlock rows created with correct Hash, DataSize, State=Remote