### PR TITLE
fix(smb): close TOCTOU race in concurrent FILE_CREATE (closes #624)

### DIFF
--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -118,6 +118,17 @@ func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle,
 
 	// Execute all write operations in a single transaction for better performance.
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-check existence inside the transaction to close the TOCTOU race
+		// between the outer GetChild and this SetChild (same pattern as
+		// createEntry).
+		if _, innerErr := tx.GetChild(ctx.Context, dirHandle, name); innerErr == nil {
+			return &StoreError{
+				Code:    ErrAlreadyExists,
+				Message: "file already exists",
+				Path:    name,
+			}
+		}
+
 		// Add to directory's children
 		if err := tx.SetChild(ctx.Context, dirHandle, name, targetHandle); err != nil {
 			return err
@@ -307,6 +318,21 @@ func (s *MetadataService) createEntry(
 	// Execute all write operations in a single transaction for better performance.
 	// This reduces PostgreSQL round-trips from 6+ to 2 (BEGIN + COMMIT).
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-check existence inside the transaction to close the TOCTOU race
+		// between the outer GetChild (line 198) and this SetChild. Without
+		// this guard, concurrent FILE_CREATE requests that all pass the outer
+		// check can all succeed — the memory store's SetChild overwrites, and
+		// BadgerDB's MVCC may not conflict on separate keys. The outer check
+		// is kept as a fast-path to avoid unnecessary handle generation /
+		// attribute computation for the common non-concurrent case.
+		if _, innerErr := tx.GetChild(ctx.Context, parentHandle, name); innerErr == nil {
+			return &StoreError{
+				Code:    ErrAlreadyExists,
+				Message: "file already exists",
+				Path:    name,
+			}
+		}
+
 		// Store the entry
 		if err := tx.PutFile(ctx.Context, newFile); err != nil {
 			return err

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -318,13 +318,7 @@ func (s *MetadataService) createEntry(
 	// Execute all write operations in a single transaction for better performance.
 	// This reduces PostgreSQL round-trips from 6+ to 2 (BEGIN + COMMIT).
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
-		// Re-check existence inside the transaction to close the TOCTOU race
-		// between the outer GetChild (line 198) and this SetChild. Without
-		// this guard, concurrent FILE_CREATE requests that all pass the outer
-		// check can all succeed — the memory store's SetChild overwrites, and
-		// BadgerDB's MVCC may not conflict on separate keys. The outer check
-		// is kept as a fast-path to avoid unnecessary handle generation /
-		// attribute computation for the common non-concurrent case.
+		// TOCTOU guard: re-check inside transaction.
 		if _, innerErr := tx.GetChild(ctx.Context, parentHandle, name); innerErr == nil {
 			return &StoreError{
 				Code:    ErrAlreadyExists,

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -235,6 +235,45 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		assert.Equal(t, metadata.ErrAlreadyExists, storeErr.Code)
 	})
 
+	t.Run("concurrent creates: exactly one succeeds (TOCTOU guard)", func(t *testing.T) {
+		t.Parallel()
+
+		for iter := 0; iter < 20; iter++ {
+			fx := newTestFixture(t)
+
+			const numWorkers = 5
+			type result struct {
+				err error
+			}
+			results := make(chan result, numWorkers)
+
+			for i := 0; i < numWorkers; i++ {
+				go func() {
+					_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "race.txt", &metadata.FileAttr{
+						Mode: 0644,
+					})
+					results <- result{err: err}
+				}()
+			}
+
+			var numOK, numCollision int
+			for i := 0; i < numWorkers; i++ {
+				r := <-results
+				if r.err == nil {
+					numOK++
+				} else {
+					var storeErr *metadata.StoreError
+					if assert.ErrorAs(t, r.err, &storeErr) && storeErr.Code == metadata.ErrAlreadyExists {
+						numCollision++
+					}
+				}
+			}
+
+			assert.Equal(t, 1, numOK, "iter %d: exactly one create should succeed", iter)
+			assert.Equal(t, numWorkers-1, numCollision, "iter %d: remaining creates should get ErrAlreadyExists", iter)
+		}
+	})
+
 	t.Run("permission denied for non-root on root-owned directory", func(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)


### PR DESCRIPTION
## Summary

- Fix TOCTOU race in `createEntry` / `CreateHardLink` that allowed concurrent `FILE_CREATE` requests to all succeed when only one should
- Add in-transaction `GetChild` re-check to atomically guard against duplicate child creation
- Add 5-goroutine concurrent-create test (20 iterations, `-race`) to pin the fix

## Root cause

`createEntry` (called by `CreateFile`, `CreateDirectory`) checked for duplicate names via `store.GetChild` **outside** the write transaction. The memory store's `SetChild` silently overwrites, and BadgerDB's MVCC does not conflict across separate key paths. Concurrent creates that all passed the outer check could all commit successfully.

This broke `smb2.create.multi`, which sends 3 simultaneous `CREATE` requests with `NTCREATEX_DISP_CREATE` (create-only, fail if exists) and expects exactly 1 `STATUS_OK` + 2 `STATUS_OBJECT_NAME_COLLISION`. CI showed:
- **memory**: all 3 returned `NT_STATUS_OK` (0 collisions)
- **badger-fs**: 2 returned `NT_STATUS_OK`, 1 collision
- **memory-fs**: PASS (1 OK, 2 collisions — timing difference masked the race)

## Fix

Add an authoritative `tx.GetChild` re-check inside `WithTransaction` for both `createEntry` and `CreateHardLink`. The outer check is retained as a fast-path to skip unnecessary handle generation and attribute computation in the common non-concurrent case.

## Test plan

- [x] `go test ./pkg/metadata -race -count=1` passes
- [x] `go test ./... -count=1` all green
- [x] `go vet ./...` clean
- [x] New test: `TestMetadataService_CreateFile/concurrent_creates:_exactly_one_succeeds_(TOCTOU_guard)` — 5 goroutines x 20 iterations under `-race`
- [ ] CI smbtorture: `smb2.create.multi` should flip to PASS on memory + badger-fs profiles