### PR TITLE
fix(smb/compound): handle async CREATE + FIND/CLOSE race in compounds (#472)

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -137,6 +137,48 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		"messageID", firstHeader.MessageID)
 
 	result, fileID, handlerCtx := ProcessRequestWithFileIDAndCallback(ctx, firstHeader, firstBody, firstRaw, connInfo, isEncrypted, asyncNotifyCallback)
+
+	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
+	// When a compound command returns STATUS_PENDING with an AsyncId AND
+	// there are remaining commands, send the interim response standalone and
+	// defer the remaining compound commands to the async completion callback.
+	// Without this, the compound processor would try to process subsequent
+	// related commands without a FileID (the CREATE hasn't completed yet),
+	// and the inline sync wait would deadlock because the test/client cannot
+	// ACK the lease break until it receives the STATUS_PENDING interim.
+	if result != nil && result.Status == types.StatusPending && result.AsyncId != 0 && len(compoundData) >= header.HeaderSize {
+		// Send interim STATUS_PENDING as a standalone async response.
+		interimCredits := grantConnectionCredits(connInfo, firstHeader.SessionID, firstHeader.Credits, firstHeader.CreditCharge)
+		interimHeader := header.NewResponseHeaderWithCredits(firstHeader, types.StatusPending, interimCredits)
+		interimHeader.Flags |= types.FlagAsync
+		interimHeader.AsyncId = result.AsyncId
+		if err := SendMessage(interimHeader, MakeErrorBody(), connInfo); err != nil {
+			logger.Debug("Error sending compound async interim response", "error", err)
+		}
+
+		// The parkCreateOnLeaseBreak goroutine will call
+		// AsyncCreateCompleteCallback when the CREATE completes. We
+		// overwrite that callback (it was set to send a standalone
+		// completion) with one that continues compound processing.
+		// The original callback was captured by the goroutine's closure
+		// via PendingCreate.Callback; we replace PendingCreate.Callback
+		// in the registry so the goroutine picks up our wrapper.
+		if connInfo.Handler.PendingCreateRegistry != nil {
+			connInfo.Handler.PendingCreateRegistry.ReplaceCallback(result.AsyncId, func(sessionID, messageID, asyncID uint64, status types.Status, createBody []byte) error {
+				connInfo.ReleaseAsync()
+				// Build a compound response starting with the CREATE's final result,
+				// followed by the remaining compound commands processed with the
+				// CREATE's FileID.
+				completeCompoundAfterAsyncCreate(
+					ctx, firstHeader, status, createBody, asyncID,
+					compoundData, connInfo, isEncrypted, asyncNotifyCallback,
+				)
+				return nil
+			})
+		}
+		return
+	}
+
 	if fileID != [16]byte{} {
 		lastFileID = fileID
 	} else {
@@ -764,4 +806,196 @@ func InjectFileID(command types.Command, body []byte, fileID [16]byte) []byte {
 		"offset", offset)
 
 	return newBody
+}
+
+// completeCompoundAfterAsyncCreate runs from the async CREATE resume goroutine
+// to finish a compound request whose first command (CREATE) went async with
+// STATUS_PENDING. It builds a compound response containing the CREATE's final
+// result and all subsequent commands, then sends it as a single compound frame.
+//
+// Per MS-SMB2 §3.3.4.4: the CREATE's interim STATUS_PENDING was already sent
+// standalone by ProcessCompoundRequest. This function delivers the remaining
+// responses (the CREATE completion + GETINFO + CLOSE etc.) as a compound.
+//
+// The asyncID is used to set FlagAsync on the CREATE's final response header
+// so the client correlates it with the earlier interim.
+func completeCompoundAfterAsyncCreate(
+	ctx context.Context,
+	firstHeader *header.SMB2Header,
+	createStatus types.Status,
+	createBody []byte,
+	asyncID uint64,
+	compoundData []byte,
+	connInfo *ConnInfo,
+	isEncrypted bool,
+	asyncNotifyCallback handlers.AsyncResponseCallback,
+) {
+	var responses []compoundResponse
+	var postSendHooks []func()
+
+	// Build CREATE completion response (async header format).
+	createCredits := grantConnectionCredits(connInfo, firstHeader.SessionID, firstHeader.Credits, firstHeader.CreditCharge)
+	createRespHeader := header.NewResponseHeaderWithCredits(firstHeader, createStatus, createCredits)
+	createRespHeader.Flags |= types.FlagAsync
+	createRespHeader.AsyncId = asyncID
+
+	createRespBody := createBody
+	if (createStatus.IsError() || createStatus.IsWarning()) &&
+		createStatus != types.StatusMoreProcessingRequired &&
+		createStatus != types.StatusBufferOverflow {
+		createRespBody = MakeErrorBody()
+	}
+	if createRespBody == nil {
+		createRespBody = MakeErrorBody()
+	}
+	responses = append(responses, compoundResponse{respHeader: createRespHeader, body: createRespBody})
+
+	// Extract the FileID from the CREATE response so related commands can inherit it.
+	var lastFileID [16]byte
+	if createStatus == types.StatusSuccess && len(createBody) >= 80 {
+		copy(lastFileID[:], createBody[64:80])
+	}
+	lastSessionID := firstHeader.SessionID
+	lastTreeID := firstHeader.TreeID
+
+	lastCmdFailed := createStatus.IsError()
+	lastCmdSessionFailed := isSessionLevelError(createStatus)
+	var lastCmdStatus types.Status
+	if lastCmdFailed {
+		lastCmdStatus = createStatus
+	}
+
+	// Process remaining compound commands (same logic as the main loop in
+	// ProcessCompoundRequest).
+	remaining := compoundData
+	for len(remaining) >= header.HeaderSize {
+		currentCommandData := remaining
+		hdr, cmdBody, nextRemaining, err := ParseCompoundCommand(remaining)
+		if err != nil {
+			logger.Debug("Error parsing compound command in async completion", "error", err)
+			errRh, errRb := buildCompoundParseErrorResponse(remaining, connInfo)
+			responses = append(responses, compoundResponse{respHeader: errRh, body: errRb})
+			break
+		}
+		remaining = nextRemaining
+
+		if !isEncrypted {
+			if err := VerifyCompoundCommandSignature(currentCommandData, hdr, connInfo); err != nil {
+				logger.Warn("Compound command signature verification failed (async)", "error", err)
+				errHeader, errBody := buildErrorResponseHeaderAndBody(hdr, types.StatusAccessDenied, connInfo)
+				responses = append(responses, compoundResponse{respHeader: errHeader, body: errBody})
+				break
+			}
+		}
+
+		if hdr.IsRelated() && lastCmdSessionFailed {
+			errHeader, errBody := buildErrorResponseHeaderAndBody(hdr, types.StatusInvalidParameter, connInfo)
+			errHeader.Flags |= types.FlagRelated
+			responses = append(responses, compoundResponse{respHeader: errHeader, body: errBody})
+			lastCmdSessionFailed = true
+			lastCmdFailed = true
+			continue
+		}
+
+		if hdr.IsRelated() && lastCmdFailed && lastFileID == [16]byte{} {
+			propagatedStatus := lastCmdStatus
+			if propagatedStatus == 0 {
+				propagatedStatus = types.StatusInvalidParameter
+			}
+			errHeader, errBody := buildErrorResponseHeaderAndBody(hdr, propagatedStatus, connInfo)
+			errHeader.Flags |= types.FlagRelated
+			responses = append(responses, compoundResponse{respHeader: errHeader, body: errBody})
+			lastCmdFailed = true
+			continue
+		}
+
+		if hdr.IsRelated() {
+			if hdr.SessionID == 0 || hdr.SessionID == 0xFFFFFFFFFFFFFFFF {
+				hdr.SessionID = lastSessionID
+			}
+			if hdr.TreeID == 0 || hdr.TreeID == 0xFFFFFFFF {
+				hdr.TreeID = lastTreeID
+			}
+		}
+
+		isLastCommand := len(remaining) < header.HeaderSize
+		if hdr.Command == types.SMB2ChangeNotify && !isLastCommand {
+			errHeader, errBody := buildErrorResponseHeaderAndBody(hdr, types.StatusInternalError, connInfo)
+			if hdr.IsRelated() {
+				errHeader.Flags |= types.FlagRelated
+			}
+			responses = append(responses, compoundResponse{respHeader: errHeader, body: errBody})
+			lastCmdFailed = true
+			lastCmdStatus = types.StatusInternalError
+			lastCmdSessionFailed = false
+			continue
+		}
+
+		subRaw := currentCommandData[:header.HeaderSize+len(cmdBody)]
+		var cmdResult *HandlerResult
+		var cmdCtx *handlers.SMBHandlerContext
+		if hdr.IsRelated() && lastFileID != [16]byte{} {
+			var fid [16]byte
+			cmdResult, fid, cmdCtx = ProcessRequestWithInheritedFileID(ctx, hdr, cmdBody, subRaw, lastFileID, connInfo, isEncrypted, asyncNotifyCallback)
+			if fid != [16]byte{} {
+				lastFileID = fid
+			}
+		} else {
+			var fid [16]byte
+			cmdResult, fid, cmdCtx = ProcessRequestWithFileIDAndCallback(ctx, hdr, cmdBody, subRaw, connInfo, isEncrypted, asyncNotifyCallback)
+			if fid != [16]byte{} {
+				lastFileID = fid
+			} else if !hdr.IsRelated() {
+				if extracted := ExtractFileID(hdr.Command, cmdBody); extracted != [16]byte{} {
+					lastFileID = extracted
+				}
+			}
+		}
+
+		if cmdCtx != nil {
+			if cmdCtx.SessionID != 0 {
+				lastSessionID = cmdCtx.SessionID
+			}
+			if cmdCtx.TreeID != 0 {
+				lastTreeID = cmdCtx.TreeID
+			}
+		}
+
+		if cmdResult != nil {
+			lastCmdSessionFailed = isSessionLevelError(cmdResult.Status)
+			lastCmdFailed = cmdResult.Status.IsError()
+			if lastCmdFailed {
+				lastCmdStatus = cmdResult.Status
+			}
+		} else {
+			lastCmdSessionFailed = false
+			lastCmdFailed = false
+			lastCmdStatus = 0
+		}
+
+		rh, rb := buildResponseHeaderAndBody(hdr, cmdCtx, cmdResult, connInfo)
+		if hdr.IsRelated() {
+			rh.Flags |= types.FlagRelated
+		}
+		var subRelease func()
+		if cmdResult != nil {
+			subRelease = cmdResult.ReleaseData
+		}
+		responses = append(responses, compoundResponse{respHeader: rh, body: rb, releaseData: subRelease})
+
+		if cmdCtx != nil && cmdCtx.PostSend != nil {
+			postSendHooks = append(postSendHooks, cmdCtx.PostSend)
+		}
+	}
+
+	sendErr := sendCompoundResponses(responses, connInfo)
+	if sendErr != nil {
+		logger.Debug("Error sending compound async completion responses", "error", sendErr)
+	}
+
+	if sendErr == nil {
+		for _, hook := range postSendHooks {
+			hook()
+		}
+	}
 }

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -535,7 +535,12 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// Step 11: Remove the open file handle
 	// ========================================================================
 
-	h.DeleteOpenFile(req.FileID)
+	// WaitAndDeleteOpenFile drains in-flight operations (e.g., a concurrent
+	// QueryDirectory on the same handle) before removing the handle from
+	// the map. This prevents a CLOSE goroutine from racing ahead of a FIND
+	// goroutine on the same connection and causing a spurious FILE_CLOSED
+	// (smbtorture compound_find.compound_find_close).
+	h.WaitAndDeleteOpenFile(req.FileID)
 
 	logger.Debug("CLOSE successful",
 		"fileID", fmt.Sprintf("%x", req.FileID),

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -186,11 +186,15 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		return 0
 	}
 
-	// Async park is only safe when this CREATE is the last op in its message
-	// (MS-SMB2 §3.3.4.4). NextCommand == 0 ⇒ standalone or last-in-compound;
-	// nonzero means a related follow-up wants a FileID we haven't allocated
-	// yet, so we must block inline instead.
-	if ctx.NextCommand == 0 && h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
+	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
+	// When a compound CREATE needs to wait for a lease break, it MUST go async
+	// (STATUS_PENDING) even if it is not the last command in the compound.
+	// The compound processor handles non-last STATUS_PENDING by sending the
+	// interim response standalone and deferring remaining compound commands
+	// until the CREATE completes. Without this, the sync wait path deadlocks:
+	// the test (and real clients) cannot ACK the lease break until they
+	// receive the STATUS_PENDING interim response.
+	if h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
 		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey); asyncId != 0 {
 			return asyncId
 		}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -191,6 +191,16 @@ type Handler struct {
 	// resumeKeys maps opaque 24-byte resume keys to FileIDs for FSCTL_SRV_COPYCHUNK.
 	// Keys are issued via FSCTL_SRV_REQUEST_RESUME_KEY and revoked on file close.
 	resumeKeys *resumeKeyStore
+
+	// handleOps tracks in-flight operations per FileID so that CLOSE can wait
+	// for concurrent operations (e.g. QueryDirectory) to snapshot the OpenFile
+	// before deleting it. Without this, a CLOSE goroutine can race ahead of a
+	// concurrent QueryDirectory goroutine on the same connection and delete the
+	// OpenFile before QueryDirectory calls GetOpenFile, causing a spurious
+	// STATUS_FILE_CLOSED (smbtorture compound_find.compound_find_close). The
+	// value is *handleOpTracker; see AcquireOpenFile / ReleaseOpenFile /
+	// WaitAndDeleteOpenFile.
+	handleOps sync.Map // string(fileID) → *handleOpTracker
 }
 
 // EncryptionConfig holds encryption policy for the handler.
@@ -547,6 +557,59 @@ func (h *Handler) GetOpenFile(fileID [16]byte) (*OpenFile, bool) {
 		return nil, false
 	}
 	return v.(*OpenFile), true
+}
+
+// handleOpTracker tracks in-flight operations on a FileID via a WaitGroup.
+// Created lazily by AcquireOpenFile; AcquireOpenFile adds and ReleaseOpenFile
+// calls Done. WaitAndDeleteOpenFile waits for the WaitGroup to drain before
+// removing the OpenFile from the map.
+type handleOpTracker struct {
+	wg sync.WaitGroup
+}
+
+// AcquireOpenFile retrieves an open file by FileID and registers an in-flight
+// operation on it. The caller MUST call ReleaseOpenFile when done. Returns
+// nil,false when the handle is not found. This prevents a CLOSE on a concurrent
+// goroutine from deleting the OpenFile before the caller finishes using it
+// (smbtorture compound_find.compound_find_close).
+func (h *Handler) AcquireOpenFile(fileID [16]byte) (*OpenFile, bool) {
+	key := string(fileID[:])
+	// Load-or-store the tracker; add to the WaitGroup BEFORE checking the
+	// files map so that a concurrent WaitAndDeleteOpenFile sees our Add.
+	v, _ := h.handleOps.LoadOrStore(key, &handleOpTracker{})
+	tracker := v.(*handleOpTracker)
+	tracker.wg.Add(1)
+
+	f, ok := h.files.Load(key)
+	if !ok {
+		// File was already deleted; undo the Add.
+		tracker.wg.Done()
+		return nil, false
+	}
+	return f.(*OpenFile), true
+}
+
+// ReleaseOpenFile marks an in-flight operation on fileID as complete.
+// Must be called exactly once for each successful AcquireOpenFile.
+func (h *Handler) ReleaseOpenFile(fileID [16]byte) {
+	key := string(fileID[:])
+	if v, ok := h.handleOps.Load(key); ok {
+		v.(*handleOpTracker).wg.Done()
+	}
+}
+
+// WaitAndDeleteOpenFile waits for in-flight operations on fileID to drain,
+// then deletes the OpenFile from the map and revokes resume keys. This
+// replaces DeleteOpenFile for the CLOSE handler to prevent the race where
+// CLOSE deletes a handle that QueryDirectory is about to look up.
+func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
+	key := string(fileID[:])
+	if v, ok := h.handleOps.Load(key); ok {
+		v.(*handleOpTracker).wg.Wait()
+		h.handleOps.Delete(key)
+	}
+	h.files.Delete(key)
+	h.resumeKeys.revoke(fileID)
 }
 
 // DeleteOpenFile removes an open file by FileID and revokes any

--- a/internal/adapter/smb/v2/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/v2/handlers/pending_create_registry.go
@@ -212,6 +212,23 @@ func (r *PendingCreateRegistry) removeLocked(asyncId uint64) *PendingCreate {
 	return p
 }
 
+// ReplaceCallback atomically replaces the Callback of a pending CREATE
+// identified by asyncId. Used by the compound processor to redirect the
+// CREATE's completion from sending a standalone response to continuing
+// compound processing (smbtorture compound_async.getinfo_middle). Returns
+// true if the entry was found and updated, false if it was already gone
+// (e.g. concurrently cancelled).
+func (r *PendingCreateRegistry) ReplaceCallback(asyncId uint64, cb AsyncCreateCompleteCallback) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byAsyncId[asyncId]
+	if !ok {
+		return false
+	}
+	p.Callback = cb
+	return true
+}
+
 // Len returns the number of pending CREATEs.
 func (r *PendingCreateRegistry) Len() int {
 	r.mu.Lock()

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -258,12 +258,15 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidInfoClass}}, nil
 	}
 
-	// Get OpenFile by FileID
-	openFile, ok := h.GetOpenFile(req.FileID)
+	// Acquire OpenFile by FileID. AcquireOpenFile registers an in-flight
+	// operation so a concurrent CLOSE on the same connection waits for us
+	// to finish before deleting the handle (compound_find.compound_find_close).
+	openFile, ok := h.AcquireOpenFile(req.FileID)
 	if !ok {
 		logger.Debug("QUERY_DIRECTORY: file handle not found (closed)", "fileID", fmt.Sprintf("%x", req.FileID))
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
 	}
+	defer h.ReleaseOpenFile(req.FileID)
 
 	if !openFile.IsDirectory {
 		logger.Debug("QUERY_DIRECTORY: not a directory", "path", openFile.Path)

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -344,7 +344,6 @@ if $KERBEROS; then
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
-        "--option=smbd=false"
     )
     log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
@@ -355,7 +354,6 @@ else
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
-        "--option=smbd=false"
     )
 fi
 

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -344,6 +344,7 @@ if $KERBEROS; then
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
+        "--option=smbd=false"
     )
     log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
@@ -354,6 +355,7 @@ else
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
+        "--option=smbd=false"
     )
 fi
 


### PR DESCRIPTION
## Summary

- **compound_find_close**: Add per-handle reference counting (`AcquireOpenFile` / `WaitAndDeleteOpenFile`) so CLOSE waits for concurrent QueryDirectory operations to snapshot the OpenFile before deleting it. Prevents a goroutine race where CLOSE deletes the handle before FIND calls `GetOpenFile`.

- **getinfo_middle**: Allow compound CREATE to go async (STATUS_PENDING) even when it is not the last command in the compound. The compound processor sends the interim response standalone, then `PendingCreateRegistry.ReplaceCallback` redirects the async completion to process remaining compound commands with the CREATE's FileID. Fixes a deadlock where the client cannot ACK a lease break until it receives STATUS_PENDING.

- **write_write / read_read**: Set `--option=smbd=false` in the smbtorture runner since DittoFS is not smbd and should not implement smbd-specific async I/O deferral for compound last-element writes/reads. The non-smbd path in smbtorture expects synchronous completion, which DittoFS already provides.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go test -race ./internal/adapter/smb/...` passes
- [ ] CI smbtorture confirms `compound_find.compound_find_close`, `compound_async.getinfo_middle`, `compound_async.read_read`, `compound_async.write_write` flip to PASS