### PR TITLE
fix(smb/dirlease): complete dir-lease break coverage for remaining tests (#470)

### DIFF
--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -299,69 +299,133 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// ========================================================================
 
 	if openFile.DeletePending {
-		authCtx, err := BuildAuthContext(ctx)
-		if err != nil {
-			logger.Warn("CLOSE: failed to build auth context for delete", "error", err)
+		// Per MS-FSA 2.1.5.4: delete-on-close only removes the file when the
+		// LAST handle closes. If other handles on the same file exist, propagate
+		// the DOC flag + the original DOC-setter's parent key to remaining handles
+		// so the delete fires on their eventual close.
+		otherHandleExists := false
+		if len(openFile.MetadataHandle) > 0 {
+			h.files.Range(func(_, value any) bool {
+				other := value.(*OpenFile)
+				if other.FileID == openFile.FileID {
+					return true // skip self
+				}
+				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+					otherHandleExists = true
+					return false
+				}
+				return true
+			})
+		}
+
+		if otherHandleExists {
+			// Not the last handle: propagate DOC to remaining handles so the
+			// actual delete fires when they close. The DOC-setter's parent key
+			// is preserved so the closer can compare it for dir-lease
+			// suppression (test_unlink_different_* vs test_unlink_same_*).
+			h.files.Range(func(_, value any) bool {
+				other := value.(*OpenFile)
+				if other.FileID == openFile.FileID {
+					return true
+				}
+				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+					other.DeletePending = true
+					other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
+					other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+					h.StoreOpenFile(other)
+				}
+				return true
+			})
+			logger.Debug("CLOSE: DOC propagated to other handles (not last)",
+				"path", openFile.Path)
 		} else {
-			// DELETE access was verified upstream before DeletePending was set:
-			// either by CREATE honoring FILE_DELETE_ON_CLOSE (create.go:913) or
-			// by SET_INFO FileDispositionInformation (set_info.go:752). Signal
-			// that to the metadata layer so the owner-of-target delete rule
-			// applies without loosening POSIX unlink(2) for NFS callers.
-			authCtx.HasDeleteAccess = true
-			// Thread the CLOSING handle's RqLs ParentLeaseKey through to
-			// notifyDirChange so the dir-lease parent-key suppression rule
-			// (MS-SMB2 §3.3.4.20, #470 C6/C7) can skip the parent dir lease
-			// whose key matches. The exclude key is the parent_key of the
-			// deleting CLOSE's handle, NOT of the handle that set DOC —
-			// covers both `*_set_and_close` and `*_initial_and_close` paths
-			// because OpenFile.ParentLeaseKey is captured at CREATE time
-			// regardless of when delete-on-close was set.
+			// Last handle: perform the actual delete.
+			authCtx, err := BuildAuthContext(ctx)
+			if err != nil {
+				logger.Warn("CLOSE: failed to build auth context for delete", "error", err)
+			} else {
+				authCtx.HasDeleteAccess = true
+
+				// Dir-lease parent-key suppression (#470 C6/C7): when the closer's
+				// parent key matches the DOC-setter's parent key, use the closer's
+				// key for suppression (test_unlink_same_*). When they differ, no
+				// suppression — ALL parent dir leases break (test_unlink_different_*).
+				docSetterKeysDiffer := openFile.HasDeleteOnCloseParentKey &&
+					openFile.HasParentLeaseKey &&
+					openFile.DeleteOnCloseParentKey != openFile.ParentLeaseKey
+				if !docSetterKeysDiffer {
+					// Same key (or no DOC key tracking): use closer's parent key
+					PropagateOpenFileParentLeaseKey(authCtx, openFile)
+				}
+				// else: different keys — don't propagate, all dir leases break
+
+				metaSvc := h.Registry.GetMetadataService()
+				var deleteErr error
+				if openFile.IsDirectory {
+					deleteErr = metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName)
+				} else {
+					_, deleteErr = metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
+				}
+
+				if deleteErr != nil {
+					resp.Status = common.MapToSMB(deleteErr)
+					logger.Debug("CLOSE: failed to delete",
+						"path", openFile.Path,
+						"isDir", openFile.IsDirectory,
+						"status", resp.Status,
+						"error", deleteErr)
+				} else {
+					logger.Debug("CLOSE: deleted", "path", openFile.Path, "isDir", openFile.IsDirectory)
+
+					if !openFile.IsDirectory && !strings.Contains(openFile.FileName, ":") {
+						h.cascadeDeleteADSStreams(authCtx, metaSvc, openFile)
+					}
+					h.restoreParentDirFrozenTimestamps(authCtx, openFile.ParentHandle)
+
+					// Break parent directory leases: deletion changes directory
+					// content. When docSetterKeysDiffer, clear the closer's
+					// parent key so no suppression applies — all dir leases break.
+					if docSetterKeysDiffer {
+						savedKey := openFile.ParentLeaseKey
+						savedHas := openFile.HasParentLeaseKey
+						openFile.HasParentLeaseKey = false
+						openFile.ParentLeaseKey = [16]byte{}
+						h.breakParentDirLeasesForContentChange(authCtx, openFile)
+						openFile.ParentLeaseKey = savedKey
+						openFile.HasParentLeaseKey = savedHas
+					} else {
+						h.breakParentDirLeasesForContentChange(authCtx, openFile)
+					}
+
+					if h.NotifyRegistry != nil {
+						parentPath := GetParentPath(openFile.Path)
+						h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, openFile.FileName, FileActionRemoved)
+					}
+				}
+			}
+		}
+	}
+
+	// ========================================================================
+	// Step 8b: Break parent dir leases on close of modified file
+	// ========================================================================
+	// Per MS-SMB2 3.3.4.7 / Samba open.c close_directory: closing a handle
+	// that modified the file (WRITE occurred) breaks parent-dir leases. The
+	// WRITE itself does NOT break — only the CLOSE triggers the break so
+	// directory caching is only invalidated once the mutation is committed.
+	// Parent-key suppression (MS-SMB2 §3.3.4.20, #470 C2) applies: if the
+	// closing handle carried a ParentLeaseKey matching the parent's dir lease,
+	// that lease is suppressed. Covers smb2.dirlease.v2_request: write without
+	// parent key -> close breaks dir lease; write with parent key -> close
+	// does NOT break (suppressed).
+
+	if !openFile.DeletePending && !openFile.IsDirectory && openFile.SmbWriteTriggered {
+		authCtx, authErr := BuildAuthContext(ctx)
+		if authErr != nil {
+			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", openFile.Path, "error", authErr)
+		} else {
 			PropagateOpenFileParentLeaseKey(authCtx, openFile)
-			metaSvc := h.Registry.GetMetadataService()
-			var deleteErr error
-			if openFile.IsDirectory {
-				deleteErr = metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName)
-			} else {
-				_, deleteErr = metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
-			}
-
-			if deleteErr != nil {
-				// Per MS-SMB2 3.3.5.10 and MS-FSA 2.1.5.4, a CLOSE that cannot
-				// honor DELETE_ON_CLOSE must surface the failure to the client.
-				// Returning STATUS_SUCCESS while the underlying unlink failed
-				// causes the client to believe the file is gone and reissue
-				// CREATE/CLOSE in a tight loop (smbtorture smb2.session.reauth5,
-				// issue #388).
-				resp.Status = common.MapToSMB(deleteErr)
-				logger.Debug("CLOSE: failed to delete",
-					"path", openFile.Path,
-					"isDir", openFile.IsDirectory,
-					"status", resp.Status,
-					"error", deleteErr)
-			} else {
-				logger.Debug("CLOSE: deleted", "path", openFile.Path, "isDir", openFile.IsDirectory)
-
-				// Cascade delete ADS streams: when a base file is deleted,
-				// all its alternate data streams (stored as "baseFile:streamName"
-				// children in the same parent directory) must also be removed.
-				// Per MS-FSA 2.1.5.9.7: all streams of a file are deleted when
-				// the file itself is deleted.
-				if !openFile.IsDirectory && !strings.Contains(openFile.FileName, ":") {
-					h.cascadeDeleteADSStreams(authCtx, metaSvc, openFile)
-				}
-				// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on parent directory
-				// after delete updates parent Mtime/Ctime/Atime.
-				h.restoreParentDirFrozenTimestamps(authCtx, openFile.ParentHandle)
-
-				// Break parent directory leases: deletion changes directory content.
-				h.breakParentDirLeasesForContentChange(authCtx, openFile)
-
-				if h.NotifyRegistry != nil {
-					parentPath := GetParentPath(openFile.Path)
-					h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, openFile.FileName, FileActionRemoved)
-				}
-			}
+			h.breakParentDirLeasesForContentChange(authCtx, openFile)
 		}
 	}
 

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -343,6 +343,53 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	}
 
+	// Step 6e: Break parent directory Handle / Read leases on
+	// create/overwrite/supersede BEFORE the actual file mutation so the
+	// metadata-layer notifyDirChange (fire-and-forget) finds the dir lease
+	// already broken and does not mark the recently-broken cache — which
+	// would block the test's lease rearm (test_rearm_dirlease). Mirrors
+	// Samba's delay_for_oplock_fn running before the actual create.
+	//
+	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break,
+	// #470 C2): if this CREATE carried an RqLs with
+	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
+	// incoming request so the matching dir-lease is NOT broken.
+	//
+	// Destructive disposition split (#470 C4, smb2.dirlease.overwrite): per
+	// Samba `delay_for_oplock_fn` `will_overwrite` arm, OVERWRITE/SUPERSEDE
+	// collapses the strip-H + strip-R steps into a single break-to-None
+	// notification. CREATE (FileCreated) keeps the two-step pattern because
+	// the parent dir-lease only loses Handle caching there.
+	if (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) && h.LeaseManager != nil {
+		parentLockHandle := lock.FileHandle(parentHandle)
+		// Per Samba dirlease_should_break: no ClientID exclusion for parent
+		// dir lease breaks. Same-client CREATEs break the parent dir lease
+		// unless the ParentLeaseKey matches (smb2.dirlease.v2_request,
+		// smb2.dirlease.leases). Only ParentLeaseKey suppression applies.
+		var excludeParentKey [16]byte
+		var hasExcludeKey bool
+		if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
+			if leaseReq, decodeErr := DecodeLeaseCreateContext(leaseCtx.Data); decodeErr == nil &&
+				leaseReq.Flags&smbenc.LeaseResponseFlagParentKeySet != 0 {
+				excludeParentKey = leaseReq.ParentLeaseKey
+				hasExcludeKey = true
+			}
+		}
+		isDestructive := createAction == types.FileOverwritten || createAction == types.FileSuperseded
+		if isDestructive {
+			if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory destructive lease break failed", "error", breakErr)
+			}
+		} else {
+			if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
+			}
+			if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
+				logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
+			}
+		}
+	}
+
 	// Step 7: Perform create/open.
 	var file *metadata.File
 	var fileHandle metadata.FileHandle
@@ -406,50 +453,6 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// Step 7b: Update base object ChangeTime for ADS operations (MS-FSA / NTFS).
 	if colonIdx := strings.Index(baseName, ":"); colonIdx > 0 && (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) {
 		h.updateBaseObjectCtime(authCtx, metaSvc, parentHandle, baseName[:colonIdx])
-	}
-
-	// Step 7c: Break parent directory Handle / Read leases on create/overwrite/supersede.
-	//
-	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break,
-	// #470 C2): if this CREATE carried an RqLs with
-	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
-	// incoming request so the matching dir-lease is NOT broken. The
-	// LeaseResponseContext built at Step 8b carries the validated key, but
-	// runs AFTER the break calls below — peek directly at the RqLs context.
-	//
-	// Destructive disposition split (#470 C4, smb2.dirlease.overwrite): per
-	// Samba `delay_for_oplock_fn` `will_overwrite` arm, OVERWRITE/SUPERSEDE
-	// collapses the strip-H + strip-R steps into a single break-to-None
-	// notification on each affected dir lease. The test asserts exactly two
-	// break notifications (one on the file lease, one on the dir lease) —
-	// the legacy two-step path would emit three. CREATE (FileCreated) keeps
-	// the two-step pattern because the parent dir-lease only loses Handle
-	// caching there (Read is preserved per MS-FSA §2.1.5.14).
-	if (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) && h.LeaseManager != nil {
-		parentLockHandle := lock.FileHandle(parentHandle)
-		excludeClientID := fmt.Sprintf("smb:%d", ctx.SessionID)
-		var excludeParentKey [16]byte
-		var hasExcludeKey bool
-		if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
-			if leaseReq, decodeErr := DecodeLeaseCreateContext(leaseCtx.Data); decodeErr == nil &&
-				leaseReq.Flags&smbenc.LeaseResponseFlagParentKeySet != 0 {
-				excludeParentKey = leaseReq.ParentLeaseKey
-				hasExcludeKey = true
-			}
-		}
-		isDestructive := createAction == types.FileOverwritten || createAction == types.FileSuperseded
-		if isDestructive {
-			if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory destructive lease break failed", "error", breakErr)
-			}
-		} else {
-			if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
-			}
-			if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
-			}
-		}
 	}
 
 	// Step 8: Generate FileID.
@@ -643,6 +646,13 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	if leaseResponse != nil && leaseResponse.HasParent {
 		openFile.ParentLeaseKey = leaseResponse.ParentLeaseKey
 		openFile.HasParentLeaseKey = true
+	}
+
+	// Record the DOC setter's parent key for initial delete-on-close
+	// (CREATE with FILE_DELETE_ON_CLOSE). Covers dirlease unlink tests.
+	if openFile.DeletePending {
+		openFile.DeleteOnCloseParentKey = openFile.ParentLeaseKey
+		openFile.HasDeleteOnCloseParentKey = openFile.HasParentLeaseKey
 	}
 
 	if h.DurableStore != nil {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -356,6 +356,16 @@ type OpenFile struct {
 	ParentLeaseKey    [16]byte
 	HasParentLeaseKey bool
 
+	// DeleteOnCloseParentKey tracks the ParentLeaseKey of the handle that
+	// originally set delete-on-close (via SET_INFO or CREATE option).
+	// When the last handle closes and triggers the actual deletion, the
+	// closer's ParentLeaseKey is compared to this: if they match, parent-key
+	// suppression applies (test_unlink_same_*); if they differ, ALL parent
+	// dir leases are broken without suppression (test_unlink_different_*).
+	// HasDeleteOnCloseParentKey is true when the value is meaningful.
+	DeleteOnCloseParentKey    [16]byte
+	HasDeleteOnCloseParentKey bool
+
 	// Durable handle state (Phase 38: SMB3 durable handles)
 	// IsDurable indicates this handle has been granted durability.
 	// When true, the handle will be persisted to DurableHandleStore on disconnect

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -480,6 +480,14 @@ func (h *Handler) setFileInfoFromStore(
 		}
 		h.StoreOpenFile(openFile)
 
+		// Break parent directory leases on child metadata change (#470:
+		// smb2.dirlease.set{atime,btime,ctime,mtime,dos}). Per MS-FSA
+		// 2.1.5.14: any child SET_INFO that modifies file attributes or
+		// timestamps changes what READDIR returns, invalidating parent-dir
+		// Read + Handle caching. Parent-key suppression (C2) flows through
+		// the same breakParentDirLeasesForContentChange plumbing.
+		h.breakParentDirLeasesForContentChange(authCtx, openFile)
+
 		// Notify watchers about attribute/timestamp changes
 		if h.NotifyRegistry != nil {
 			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
@@ -969,8 +977,13 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Mark file for deletion on close
+		// Mark file for deletion on close and record the DOC setter's
+		// parent key for unlink parent-key suppression (#470 C6/C7).
 		openFile.DeletePending = deletePending
+		if deletePending {
+			openFile.DeleteOnCloseParentKey = openFile.ParentLeaseKey
+			openFile.HasDeleteOnCloseParentKey = openFile.HasParentLeaseKey
+		}
 		h.StoreOpenFile(openFile)
 
 		logger.Debug("SET_INFO: delete disposition set",
@@ -1023,6 +1036,12 @@ func (h *Handler) setFileInfoFromStore(
 		// pending delayed-write window.
 		flushSmbDelayedWrite(openFile)
 		h.StoreOpenFile(openFile)
+
+		// Break parent directory leases on child EOF change (#470:
+		// smb2.dirlease.seteof). Per MS-FSA 2.1.5.14: size changes
+		// are visible in READDIR results, invalidating parent-dir
+		// Read + Handle caching. Parent-key suppression (C2) applies.
+		h.breakParentDirLeasesForContentChange(authCtx, openFile)
 
 		// Notify watchers about size changes
 		if h.NotifyRegistry != nil {
@@ -1385,26 +1404,33 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
 // the rename branch (#470 C3): break Handle + Read leases on an arbitrary
-// directory handle (src-parent or dst-parent), still honoring the originating
-// handle's ClientID + ParentLeaseKey suppression from C2.
+// directory handle (src-parent or dst-parent), honoring the originating
+// handle's ParentLeaseKey suppression from C2.
+//
+// Per Samba dirlease_should_break: ClientID is NOT used for suppression —
+// a same-client SET_INFO / WRITE / CLOSE / RENAME with a mismatched (or
+// absent) ParentLeaseKey MUST still break the parent dir lease held by that
+// same client. The smbtorture dirlease tests (setinfo, rename, hardlink,
+// unlink, v2_request) all exercise same-client scenarios where the dir
+// lease is expected to break when the parent key doesn't match.
 func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, openFile *OpenFile) {
 	if h.LeaseManager == nil || len(parentHandle) == 0 {
 		return
 	}
 
 	parentLockHandle := lock.FileHandle(parentHandle)
-	excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
 
-	// Apply parent-key suppression (MS-SMB2 §3.3.4.20, #470 C2): if the
-	// originating handle's CREATE carried an RqLs with ParentLeaseKey set,
-	// the matching parent dir lease MUST NOT be broken on this child mutation.
+	// Apply parent-key suppression only (MS-SMB2 §3.3.4.20, #470 C2): if
+	// the originating handle's CREATE carried an RqLs with ParentLeaseKey
+	// set, the matching parent dir lease MUST NOT be broken. No ClientID
+	// exclusion — same-client breaks fire when the key doesn't match.
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
 
-	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory Handle lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
 	}
-	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
 	}
 }
@@ -1418,18 +1444,16 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthC
 // hasn't mutated directory contents yet, only the dst-parent's Handle caching
 // is invalidated by the implicit destructive open intent.
 //
-// Honors the same ClientID + ParentLeaseKey suppression as C2: if the renamer
-// carries a ParentLeaseKey on its own RqLs that matches the dst-parent's
-// dir-lease key, suppress (Samba dirlease_for_rename behavior).
+// Honors ParentLeaseKey suppression from C2 only — no ClientID exclusion,
+// same-client dir leases break when the key doesn't match.
 func (h *Handler) breakDstParentDirHandleLeasesForRename(authCtx *metadata.AuthContext, dstParent metadata.FileHandle, openFile *OpenFile) {
 	if h.LeaseManager == nil || len(dstParent) == 0 {
 		return
 	}
 	parentLockHandle := lock.FileHandle(dstParent)
-	excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
-	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, excludeClientID, excludeParentKey, hasExcludeKey); breakErr != nil {
+	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
 		logger.Debug("SET_INFO: dst-parent dir Handle lease pre-break failed", "path", openFile.Path, "dstParent", fmt.Sprintf("%x", dstParent), "error", breakErr)
 	}
 }
@@ -1589,23 +1613,22 @@ func (h *Handler) handleFileLinkInformation(
 	}
 
 	// Break Handle/Read leases on the destination parent (MS-FSA 2.1.5.14:
-	// directory contents changed). Parent-key suppression flows through the
-	// same exclude args used by the metadata-layer notifier.
+	// directory contents changed). Parent-key suppression only — no ClientID
+	// exclusion per Samba dirlease_should_break.
 	if h.LeaseManager != nil {
 		dstParentLock := lock.FileHandle(dstDir)
-		excludeClientID := fmt.Sprintf("smb:%d", openFile.SessionID)
 		excludeParentKey := openFile.ParentLeaseKey
 		hasExcludeKey := openFile.HasParentLeaseKey
 		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(
 			authCtx.Context, dstParentLock, openFile.ShareName,
-			excludeClientID, excludeParentKey, hasExcludeKey,
+			"", excludeParentKey, hasExcludeKey,
 		); breakErr != nil {
 			logger.Debug("SET_INFO: hardlink dst-parent Handle lease break failed",
 				"dst", newPath, "error", breakErr)
 		}
 		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(
 			authCtx.Context, dstParentLock, openFile.ShareName,
-			excludeClientID, excludeParentKey, hasExcludeKey,
+			"", excludeParentKey, hasExcludeKey,
 		); breakErr != nil {
 			logger.Debug("SET_INFO: hardlink dst-parent Read lease break failed",
 				"dst", newPath, "error", breakErr)


### PR DESCRIPTION
## Summary

- **SET_INFO dir-lease breaks**: `FileBasicInformation` (timestamps + DOS attrs) and `FileEndOfFileInformation` now break parent dir leases after the operation succeeds (covers `dirlease.set{atime,btime,ctime,mtime,dos,eof}`)
- **Remove ClientID exclusion**: per Samba `dirlease_should_break`, only `ParentLeaseKey` match suppresses dir-lease breaks -- same-client ops with mismatched keys must break (affects all 14 remaining tests)
- **Close-of-modified-file break**: CLOSE of a file that was written to breaks parent dir leases with parent-key suppression (covers `dirlease.v2_request` WRITE+CLOSE interaction)
- **DOC propagation + key tracking**: when a handle with delete-on-close closes but other handles remain, propagate DOC to remaining handles and track the original setter's `ParentLeaseKey`; matching keys get suppression (`unlink_same_*`), differing keys break ALL dir leases (`unlink_different_*`)
- **Pre-create break ordering**: move parent dir-lease break dispatch before the actual file creation so the metadata-layer `notifyDirChange` finds the dir lease already broken and does not poison the recently-broken cache

## Target tests (14 of 15 remaining, skipping `oplocks` per #633)

```
smb2.dirlease.hardlink
smb2.dirlease.rename
smb2.dirlease.rename_dst_parent
smb2.dirlease.setatime
smb2.dirlease.setbtime
smb2.dirlease.setctime
smb2.dirlease.setdos
smb2.dirlease.seteof
smb2.dirlease.setmtime
smb2.dirlease.unlink_different_initial_and_close
smb2.dirlease.unlink_different_set_and_close
smb2.dirlease.unlink_same_initial_and_close
smb2.dirlease.unlink_same_set_and_close
smb2.dirlease.v2_request
```

## Key files

- `internal/adapter/smb/v2/handlers/set_info.go` -- SET_INFO parent breaks + ClientID removal
- `internal/adapter/smb/v2/handlers/close.go` -- modified-file close break + DOC propagation
- `internal/adapter/smb/v2/handlers/create_post_break.go` -- pre-create ordering + ClientID removal
- `internal/adapter/smb/v2/handlers/handler.go` -- `DeleteOnCloseParentKey` field on `OpenFile`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` -- all pass
- [ ] CI smbtorture `smb2.dirlease.*` subtests
- [ ] No regressions on `smb2.lease.*`, `smb2.acls.*`, `smb2.notify.*`