### PR TITLE
fix(smb/compound): Windows-compatible compound async tests (#472)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-05-26 (walk back 25 confirmed PASS + add 2 new failures)
+Last updated: 2026-05-27 (walk back 4 compound tests — section removed)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -265,19 +265,6 @@ checks, and ACL-based access control.
 | smb2.getinfo.qfs_buffercheck | Query Info | FS buffer check not implemented | - |
 | smb2.getinfo.qsec_buffercheck | Query Info | Security buffer check not implemented | - |
 | smb2.setinfo | Set Info | SET_INFO timestamp preservation not implemented | - |
-
-### Compound Requests (Remaining)
-
-Phase 73.1 fixed compound related/unrelated chaining, error propagation,
-interim responses, padding, compound find, and async flush. Remaining
-failures require DACL enforcement or full async I/O support.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.compound_find.compound_find_close | Compound | Compound FIND + CLOSE ordering — directory enumeration state handoff across compound subcommands not implemented | - |
-| smb2.compound_async.getinfo_middle | Compound | Async getinfo in compound middle position | - |
-| smb2.compound_async.read_read | Compound | Async read+read compound not implemented | - |
-| smb2.compound_async.write_write | Compound | Async write+write compound not implemented | - |
 
 ### Share Modes and Deny (Advanced Scenarios)
 
@@ -627,6 +614,18 @@ requests with durable handles. Newly reachable after GMAC signing fix.
 | smb2.replay.replay6 | Replay | Replay detection not implemented | - |
 
 ## Changelog
+
+### 2026-05-27 — Walk back 4 compound tests (section removed)
+
+Set `torture:smbd=false` in smbtorture args (DittoFS is not smbd — the
+`is_smbd` flag only affects `read_read` and `write_write` which expect
+Samba-specific async last-compound-element behavior). Combined with PR
+#640's fixes for `compound_find_close` and `getinfo_middle`, the entire
+Compound Requests section is now empty and removed.
+
+- **Compound** (section removed): `smb2.compound_find.compound_find_close`,
+  `smb2.compound_async.getinfo_middle`, `smb2.compound_async.read_read`,
+  `smb2.compound_async.write_write`
 
 ### 2026-05-26 — Walk back 25 confirmed PASS + add 2 new failures
 

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -344,6 +344,7 @@ if $KERBEROS; then
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
+        "--option=torture:smbd=false"
     )
     log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
@@ -354,6 +355,7 @@ else
         "--option=netbios name=localhost"
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
+        "--option=torture:smbd=false"
     )
 fi
 


### PR DESCRIPTION
## Summary

- Set `torture:smbd=false` in smbtorture args so compound async tests validate the Windows-compatible synchronous path (not Samba's async-last-element optimization)
- Walk back all 4 remaining compound known failures — section removed from KNOWN_FAILURES.md
- Combined with PR #640 fixes, closes #472 (Compound Requests remaining — 0 tests left)

## Verified

- `smb2.compound` (20 tests): **20 PASS**
- `smb2.compound_async` (10 tests): **10 PASS**
- `smb2.compound_find` included above: **PASS**

## Context

The `is_smbd` torture setting (default `true`) only affects `read_read` and `write_write` in Samba's `compound.c`. When true, smbtorture expects the last compound element to return STATUS_PENDING + async completion — a Samba-specific optimization not required by MS-SMB2 and not implemented by Windows Server. DittoFS follows the Windows path (synchronous compound completion), so `smbd=false` is the correct setting.

Closes #472