### PR TITLE
fix(smb/session): per-connection scope + signed teardown responses

### DIFF
--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -99,6 +99,13 @@ type Session struct {
 	// attempting signature verification on a defunct session.
 	LoggedOff atomic.Bool
 
+	// OriginConnID is the ConnID of the TCP connection that created this
+	// session via SESSION_SETUP. For SMB 2.x (below 3.0), session lookup
+	// is per-connection per MS-SMB2 §3.3.5.5, so a SESSION_SETUP from a
+	// different connection referencing this session's ID must return
+	// STATUS_USER_SESSION_DELETED. For SMB 3.x, sessions are global.
+	OriginConnID uint64
+
 	// Credit tracking
 	credits Credits
 

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -103,6 +103,7 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		authResult.Realm,
 		authResult.APReq.Ticket.DecryptedEncPart.EndTime,
 	)
+	sess.OriginConnID = ctx.ConnID
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
 

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -166,11 +166,28 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 			return h.completeNTLMAuth(ctx, req.SecurityBuffer)
 		}
 
-		// Re-authentication: client sends SESSION_SETUP on an existing session
-		// with no pending auth. Per MS-SMB2 3.3.5.5.2, this initiates a new
-		// authentication on the existing session (identity update).
-		// The existing session remains valid until re-auth completes.
-		if _, ok := h.GetSession(ctx.SessionID); ok {
+		// Per MS-SMB2 §3.3.5.5: for dialects below 3.0, session lookup uses
+		// Connection.SessionTable (per-connection). A non-binding SESSION_SETUP
+		// from a different connection than the one that created the session
+		// must return STATUS_USER_SESSION_DELETED.
+		if sess, ok := h.GetSession(ctx.SessionID); ok {
+			var connDialect types.Dialect
+			if ctx.ConnCryptoState != nil {
+				connDialect = ctx.ConnCryptoState.GetDialect()
+			}
+			if connDialect < types.Dialect0300 && sess.OriginConnID != ctx.ConnID {
+				logger.Debug("SESSION_SETUP: session belongs to different connection (SMB 2.x per-connection scope)",
+					"sessionID", ctx.SessionID,
+					"sessionConnID", sess.OriginConnID,
+					"requestConnID", ctx.ConnID,
+					"dialect", fmt.Sprintf("0x%04x", uint16(connDialect)))
+				return NewErrorResult(types.StatusUserSessionDeleted), nil
+			}
+
+			// Re-authentication: client sends SESSION_SETUP on an existing session
+			// with no pending auth. Per MS-SMB2 3.3.5.5.2, this initiates a new
+			// authentication on the existing session (identity update).
+			// The existing session remains valid until re-auth completes.
 			logger.Debug("SESSION_SETUP: re-authentication on existing session",
 				"sessionID", ctx.SessionID)
 			// Fall through to normal auth flow — the NTLM negotiate handler
@@ -861,6 +878,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				}
 
 				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
+				sess.OriginConnID = ctx.ConnID
 
 				// Configure signing with derived signing key
 				if errResult := h.configureSessionSigningWithKey(sess, signingKey[:], ctx); errResult != nil {
@@ -902,6 +920,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 			}
 
 			sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
+			sess.OriginConnID = ctx.ConnID
 
 			// No signing without proper session key derivation
 			logger.Debug("NTLM authentication complete (no credential validation)",
@@ -990,6 +1009,7 @@ func (h *Handler) createGuestSessionWithID(ctx *SMBHandlerContext, pending *Pend
 	}
 
 	sess := h.CreateSessionWithID(pending.SessionID, pending.ClientAddr, true, "guest", "")
+	sess.OriginConnID = ctx.ConnID
 	ctx.IsGuest = true
 
 	logger.Info("Guest session created",
@@ -1012,6 +1032,7 @@ func (h *Handler) createGuestSession(ctx *SMBHandlerContext) (*HandlerResult, er
 	}
 
 	sess := h.CreateSession(ctx.ClientAddr, true, "guest", "")
+	sess.OriginConnID = ctx.ConnID
 
 	ctx.SessionID = sess.SessionID
 	ctx.IsGuest = true


### PR DESCRIPTION
## Summary

- Fix session reconnect tests (`reconnect1`, `reconnect2`) returning `STATUS_ACCESS_DENIED` instead of `STATUS_USER_SESSION_DELETED` — error responses for torn-down sessions couldn't be signed because `CleanupSession` deleted the session record immediately
- Fix session binding negative tests (`bind_negative_smb202`, `bind_negative_smb210s`, `bind_negative_smb210d`) — DittoFS used a global session table for all dialects, but MS-SMB2 §3.3.5.5 requires per-connection session lookup for SMB 2.x

## Changes

**CleanupSession signing fix** (`handler.go`):
- Mark `LoggedOff=true` at the start of `CleanupSession` so concurrent requests see `STATUS_USER_SESSION_DELETED` immediately
- When triggered by `PreviousSessionId` (`isDisconnect=false`), keep the session record alive for signing; reap via 30s deferred goroutine to prevent leaks

**Per-connection session scope** (`session.go`, `session_setup.go`, `handler.go`, `kerberos_auth.go`):
- Add `OriginConnID` field to `Session` — stamped before `StoreSession` to close TOCTOU window
- In `SESSION_SETUP`, reject non-binding requests from foreign connections when dialect < SMB 3.0

## Test plan

- [x] `smb2.session.reconnect1` — PASS (was FAIL: ACCESS_DENIED)
- [x] `smb2.session.reconnect2` — PASS (was FAIL: ACCESS_DENIED)
- [x] `smb2.session.bind_negative_smb202` — PASS (was FAIL)
- [x] `smb2.session.bind_negative_smb210s` — PASS (was FAIL)
- [x] `smb2.session.bind_negative_smb210d` — PASS (was FAIL)
- [x] All SMB adapter unit tests pass
- [ ] CI smbtorture full suite — no regressions expected (KNOWN_FAILURES walkback deferred to CI confirmation)

Closes #474