### PR TITLE
fix(smb/notify): per-event filter matching, buffered delivery, sticky CompletionFilter (#473)

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -956,8 +956,7 @@ func (r *NotifyRegistry) bufferEventLocked(notify *PendingNotify, change FileNot
 // timer after notifyFlushDelay.
 func (r *NotifyRegistry) flushWatcher(fileID [16]byte) {
 	r.mu.Lock()
-	key := string(fileID[:])
-	notify, ok := r.byFileID[key]
+	notify, ok := r.byFileID[string(fileID[:])]
 	if !ok {
 		r.mu.Unlock()
 		return

--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -138,6 +138,14 @@ type AsyncResponseCallback func(sessionID, messageID, asyncId uint64, response *
 // all do"). Wired by the registering handler; nil for unit tests.
 type OnOverflow func(fileID [16]byte)
 
+// notifyFlushDelay is the accumulation window for buffered CHANGE_NOTIFY
+// events. When the first event matches a live watcher, a timer starts;
+// subsequent events from the same burst (e.g. REMOVED + ADDED + MODIFIED
+// for an OVERWRITE/SUPERSEDE) append to the buffer. When the timer fires,
+// all accumulated events are encoded into a single FILE_NOTIFY_INFORMATION
+// response. Mirrors Samba's tevent-based deferred delivery.
+const notifyFlushDelay = 100 * time.Microsecond
+
 // PendingNotify tracks a pending CHANGE_NOTIFY request waiting for filesystem events.
 // Each instance represents one client watch registered via the CHANGE_NOTIFY command.
 // It stores the watch path, completion filter, and the async callback for delivering
@@ -173,6 +181,14 @@ type PendingNotify struct {
 	// STATUS_NOTIFY_ENUM_DIR so the open handle's sticky overflow flag can
 	// be set. Optional.
 	OnOverflow OnOverflow
+
+	// bufferedChanges accumulates events during the notifyFlushDelay window.
+	// Protected by NotifyRegistry.mu.
+	bufferedChanges []FileNotifyInformation
+
+	// flushTimer fires after notifyFlushDelay to deliver all buffered events.
+	// nil when no events are buffered. Protected by NotifyRegistry.mu.
+	flushTimer *time.Timer
 }
 
 // NotifyRegistry manages pending CHANGE_NOTIFY requests from SMB2 clients.
@@ -520,9 +536,14 @@ func (r *NotifyRegistry) UnregisterByAsyncId(asyncId uint64) *PendingNotify {
 	return r.unregisterLocked(notify)
 }
 
-// unregisterLocked removes a PendingNotify from all internal maps.
-// Must be called with r.mu held.
+// unregisterLocked removes a PendingNotify from all internal maps and cancels
+// any pending flush timer. Must be called with r.mu held.
 func (r *NotifyRegistry) unregisterLocked(notify *PendingNotify) *PendingNotify {
+	if notify.flushTimer != nil {
+		notify.flushTimer.Stop()
+		notify.flushTimer = nil
+	}
+
 	fileIDKey := string(notify.FileID[:])
 	delete(r.byFileID, fileIDKey)
 	delete(r.byMsgKey, notifyMsgKey{ConnID: notify.ConnID, MessageID: notify.MessageID})
@@ -703,77 +724,42 @@ func EncodeFileNotifyInformation(changes []FileNotifyInformation) []byte {
 // ============================================================================
 
 // NotifyChange records a filesystem change that may trigger pending CHANGE_NOTIFY
-// requests. When a matching watcher has an AsyncCallback set, it sends the
-// async response. Otherwise, the change is logged for debugging.
+// requests. Events are buffered for notifyFlushDelay before delivery so that
+// multiple events from the same burst (e.g. OVERWRITE -> REMOVED+ADDED+MODIFIED)
+// are batched into a single response.
 //
-// Parameters:
-//   - shareName: The share where the change occurred
-//   - parentPath: Share-relative path of the directory containing the changed item
-//   - fileName: Name of the changed file/directory
-//   - action: One of FileAction* constants
-//
-// The function walks up the directory hierarchy to support recursive (WatchTree)
-// watchers. When a matching watcher is found:
-//  1. Builds a FileNotifyInformation structure with the change details
-//  2. Encodes it into the response format
-//  3. Calls the AsyncCallback to send the response
-//  4. Unregisters the watcher (CHANGE_NOTIFY is one-shot per request)
-func (r *NotifyRegistry) NotifyChange(shareName, parentPath, fileName string, action uint32) {
-	r.mu.RLock()
-	watchers := r.findWatchersLocked(shareName, parentPath, action)
+// filter specifies which FILE_NOTIFY_CHANGE_* flags this event matches. Only
+// watchers whose CompletionFilter intersects filter are notified.
+func (r *NotifyRegistry) NotifyChange(shareName, parentPath, fileName string, action uint32, filter uint32) {
+	r.mu.Lock()
+	watchers := r.findWatchersLocked(shareName, parentPath, filter)
 	liveFileIDs := make(map[[16]byte]struct{}, len(watchers))
 	for _, w := range watchers {
 		liveFileIDs[w.notify.FileID] = struct{}{}
-	}
-	r.mu.RUnlock()
-
-	for _, w := range watchers {
 		relativePath := relativePathFromWatch(w.watchPath, parentPath, fileName)
-		changes := []FileNotifyInformation{
-			{Action: action, FileName: relativePath},
-		}
-		r.sendAndUnregister(w.notify, changes, actionToString(action))
+		r.bufferEventLocked(w.notify, FileNotifyInformation{Action: action, FileName: relativePath})
 	}
+	r.mu.Unlock()
 
-	// Charge against armed-but-unsatisfied handles so subsequent events
-	// while the client isn't waiting still count toward overflow. Handles
-	// with a live watcher were already serviced above and are excluded.
-	r.chargeArmedBuffer(shareName, parentPath, action, []string{fileName}, liveFileIDs)
+	r.chargeArmedBuffer(shareName, parentPath, filter, []string{fileName}, liveFileIDs)
 }
 
-// NotifyRename records a rename event as a paired FILE_NOTIFY_INFORMATION response.
-//
-// Per [MS-FSCC] 2.4.42 and [MS-SMB2] 3.3.4.4, a rename notification MUST contain
-// two entries in a single response: FILE_ACTION_RENAMED_OLD_NAME followed by
-// FILE_ACTION_RENAMED_NEW_NAME. Sending them as separate one-shot notifications
-// is incorrect because CHANGE_NOTIFY is one-shot -- the first notification
-// unregisters the watcher, causing the second to be silently dropped.
-//
-// Parameters:
-//   - shareName: The share where the rename occurred
-//   - oldParentPath: Share-relative directory path of the old location
-//   - oldFileName: Old filename
-//   - newParentPath: Share-relative directory path of the new location
-//   - newFileName: New filename
-func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, newParentPath, newFileName string) {
-	r.mu.RLock()
+// NotifyRename records a rename as a paired FILE_ACTION_RENAMED_OLD_NAME /
+// FILE_ACTION_RENAMED_NEW_NAME response. filter specifies the
+// FILE_NOTIFY_CHANGE_* flags (typically FileName or DirName).
+func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, newParentPath, newFileName string, filter uint32) {
+	r.mu.Lock()
 
-	// Walk up from the old parent path to find watchers.
-	// We match against the old parent path as the primary watch target,
-	// since that's where Explorer has its directory watch.
-	oldWatchers := r.findWatchersLocked(shareName, oldParentPath, FileActionRenamedOldName)
+	oldWatchers := r.findWatchersLocked(shareName, oldParentPath, filter)
 
-	// Also walk up from the new parent path if different, to catch watchers
-	// on the destination directory that aren't ancestors of the old path.
 	var newWatchers []watcherMatch
 	if newParentPath != oldParentPath {
-		// Build a set of already-matched FileIDs for O(1) dedup lookup
 		matchedFileIDs := make(map[[16]byte]struct{}, len(oldWatchers))
 		for _, m := range oldWatchers {
 			matchedFileIDs[m.notify.FileID] = struct{}{}
 		}
 
-		allNew := r.findWatchersLocked(shareName, newParentPath, FileActionRenamedNewName)
+		allNew := r.findWatchersLocked(shareName, newParentPath, filter)
 		for _, m := range allNew {
 			if _, alreadyMatched := matchedFileIDs[m.notify.FileID]; !alreadyMatched {
 				newWatchers = append(newWatchers, m)
@@ -785,28 +771,16 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 	liveFileIDs := make(map[[16]byte]struct{}, len(combined))
 	for _, w := range combined {
 		liveFileIDs[w.notify.FileID] = struct{}{}
-	}
-	r.mu.RUnlock()
-
-	// Send paired rename notifications for all matched watchers.
-	// Both old and new names are computed relative to each watcher's watch path,
-	// so recursive watchers at higher-level directories report correct paths.
-	for _, w := range combined {
 		oldRelativePath := relativePathFromWatch(w.watchPath, oldParentPath, oldFileName)
 		newRelativePath := relativePathFromWatch(w.watchPath, newParentPath, newFileName)
-		changes := []FileNotifyInformation{
-			{Action: FileActionRenamedOldName, FileName: oldRelativePath},
-			{Action: FileActionRenamedNewName, FileName: newRelativePath},
-		}
-		r.sendAndUnregister(w.notify, changes, "RENAME")
+		r.bufferEventLocked(w.notify, FileNotifyInformation{Action: FileActionRenamedOldName, FileName: oldRelativePath})
+		r.bufferEventLocked(w.notify, FileNotifyInformation{Action: FileActionRenamedNewName, FileName: newRelativePath})
 	}
+	r.mu.Unlock()
 
-	// Charge against any armed handles that did not have a live waiter.
-	// Both directories are checked so handles armed on either end of a
-	// cross-directory rename are accounted for.
-	r.chargeArmedBuffer(shareName, oldParentPath, FileActionRenamedOldName, []string{oldFileName, newFileName}, liveFileIDs)
+	r.chargeArmedBuffer(shareName, oldParentPath, filter, []string{oldFileName, newFileName}, liveFileIDs)
 	if newParentPath != oldParentPath {
-		r.chargeArmedBuffer(shareName, newParentPath, FileActionRenamedNewName, []string{oldFileName, newFileName}, liveFileIDs)
+		r.chargeArmedBuffer(shareName, newParentPath, filter, []string{oldFileName, newFileName}, liveFileIDs)
 	}
 }
 
@@ -830,7 +804,7 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 // (source3/smbd/notify.c) likewise marshals the stored per-watcher name,
 // with UTF-16 length doubling and a 4-byte alignment pad.
 func (r *NotifyRegistry) chargeArmedBuffer(
-	shareName, parentPath string, action uint32,
+	shareName, parentPath string, filter uint32,
 	candidateNames []string,
 	skipFileIDs map[[16]byte]struct{},
 ) {
@@ -861,7 +835,7 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 				continue
 			}
 		}
-		if !MatchesFilter(action, a.CompletionFilter) {
+		if a.CompletionFilter&filter == 0 {
 			continue
 		}
 		if a.Overflowed {
@@ -936,9 +910,9 @@ type watcherMatch struct {
 }
 
 // findWatchersLocked walks up the directory hierarchy from parentPath to find
-// watchers matching the given share and action. Must be called with r.mu held
-// (at least read-locked). Returns matched watchers with their watch paths.
-func (r *NotifyRegistry) findWatchersLocked(shareName, parentPath string, action uint32) []watcherMatch {
+// watchers whose CompletionFilter intersects the event's filter mask. Must be
+// called with r.mu held (at least read-locked).
+func (r *NotifyRegistry) findWatchersLocked(shareName, parentPath string, filter uint32) []watcherMatch {
 	var matches []watcherMatch
 
 	currentPath := parentPath
@@ -950,7 +924,7 @@ func (r *NotifyRegistry) findWatchersLocked(shareName, parentPath string, action
 			if currentPath != parentPath && !w.WatchTree {
 				continue
 			}
-			if !MatchesFilter(action, w.CompletionFilter) {
+			if w.CompletionFilter&filter == 0 {
 				continue
 			}
 			matches = append(matches, watcherMatch{notify: w, watchPath: currentPath})
@@ -965,58 +939,65 @@ func (r *NotifyRegistry) findWatchersLocked(shareName, parentPath string, action
 	return matches
 }
 
-// sendAndUnregister encodes a list of FileNotifyInformation changes, sends
-// the notification via the watcher's AsyncCallback, and unregisters the
-// watcher (CHANGE_NOTIFY is one-shot). If the encoded buffer exceeds the
-// watcher's MaxOutputLength, the watcher is unregistered without sending.
-func (r *NotifyRegistry) sendAndUnregister(w *PendingNotify, changes []FileNotifyInformation, label string) {
-	// Unregister FIRST to prevent double-fire: two concurrent NotifyChange calls
-	// can both snapshot the same watcher under RLock. By unregistering before
-	// calling the callback, only the first caller proceeds (Unregister returns
-	// nil for the second). This is critical because sending two async responses
-	// for the same MessageID violates the protocol.
-	removed := r.Unregister(w.FileID)
-	if removed == nil {
-		return // already fired by another goroutine
+// bufferEventLocked appends a change to the watcher's buffer and starts the
+// flush timer on the first event. Must be called with r.mu held for write.
+func (r *NotifyRegistry) bufferEventLocked(notify *PendingNotify, change FileNotifyInformation) {
+	notify.bufferedChanges = append(notify.bufferedChanges, change)
+	if notify.flushTimer == nil {
+		fileID := notify.FileID
+		notify.flushTimer = time.AfterFunc(notifyFlushDelay, func() {
+			r.flushWatcher(fileID)
+		})
 	}
+}
 
-	if removed.AsyncCallback == nil {
-		logger.Debug("CHANGE_NOTIFY: would notify watcher (no callback)",
-			"watchPath", removed.WatchPath,
-			"action", label,
-			"messageID", removed.MessageID)
+// flushWatcher drains the buffered events for a watcher identified by fileID,
+// unregisters it (one-shot), and sends the async response. Called by the flush
+// timer after notifyFlushDelay.
+func (r *NotifyRegistry) flushWatcher(fileID [16]byte) {
+	r.mu.Lock()
+	key := string(fileID[:])
+	notify, ok := r.byFileID[key]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	changes := notify.bufferedChanges
+	notify.bufferedChanges = nil
+	notify.flushTimer = nil
+	r.unregisterLocked(notify)
+	r.mu.Unlock()
+
+	r.deliverChanges(notify, changes)
+}
+
+// deliverChanges encodes and sends buffered events via the watcher's
+// AsyncCallback. Called from flushWatcher (timer path) and FlushAll (test
+// path). Must be called AFTER the watcher is unregistered — caller is
+// responsible for one-shot semantics.
+func (r *NotifyRegistry) deliverChanges(notify *PendingNotify, changes []FileNotifyInformation) {
+	if notify.AsyncCallback == nil || len(changes) == 0 {
 		return
 	}
 
 	buffer := EncodeFileNotifyInformation(changes)
 
-	// Per MS-SMB2 3.3.4.4 / MS-FSCC 2.4.42: when the encoded notification
-	// exceeds MaxOutputLength, complete the request with STATUS_NOTIFY_ENUM_DIR
-	// to tell the client to re-enumerate the directory.
-	//
-	// The "if the first notify returns NOTIFY_ENUM_DIR, all do" property
-	// from smb2.notify.valid-req is satisfied at the handler layer: the
-	// handle's NotifyMaxBufferSize is fixed by the first CHANGE_NOTIFY and
-	// MIN-capped into MaxOutputLength here on every subsequent request.
-	if uint32(len(buffer)) > removed.MaxOutputLength {
-		logger.Warn("CHANGE_NOTIFY: notification exceeds MaxOutputLength; sending STATUS_NOTIFY_ENUM_DIR",
-			"watchPath", removed.WatchPath,
-			"action", label,
+	if uint32(len(buffer)) > notify.MaxOutputLength {
+		logger.Warn("CHANGE_NOTIFY: flush exceeds MaxOutputLength; sending STATUS_NOTIFY_ENUM_DIR",
+			"watchPath", notify.WatchPath,
+			"numChanges", len(changes),
 			"encodedLength", len(buffer),
-			"maxOutputLength", removed.MaxOutputLength,
-			"messageID", removed.MessageID)
-		// Mark the handle as overflowed so the next CHANGE_NOTIFY on it
-		// also returns ENUM_DIR per Samba notify_buffer semantics.
-		if removed.OnOverflow != nil {
-			removed.OnOverflow(removed.FileID)
+			"maxOutputLength", notify.MaxOutputLength,
+			"messageID", notify.MessageID)
+		if notify.OnOverflow != nil {
+			notify.OnOverflow(notify.FileID)
 		}
 		enumResp := &ChangeNotifyResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
 		}
-		if err := removed.AsyncCallback(removed.SessionID, removed.MessageID, removed.AsyncId, enumResp); err != nil {
+		if err := notify.AsyncCallback(notify.SessionID, notify.MessageID, notify.AsyncId, enumResp); err != nil {
 			logger.Warn("CHANGE_NOTIFY: failed to send STATUS_NOTIFY_ENUM_DIR",
-				"messageID", removed.MessageID,
-				"error", err)
+				"messageID", notify.MessageID, "error", err)
 		}
 		return
 	}
@@ -1026,16 +1007,15 @@ func (r *NotifyRegistry) sendAndUnregister(w *PendingNotify, changes []FileNotif
 		Buffer:             buffer,
 	}
 
-	logger.Debug("CHANGE_NOTIFY: sending async response",
-		"watchPath", removed.WatchPath,
-		"action", label,
-		"messageID", removed.MessageID,
-		"sessionID", removed.SessionID)
+	logger.Debug("CHANGE_NOTIFY: flush — sending async response",
+		"watchPath", notify.WatchPath,
+		"numChanges", len(changes),
+		"messageID", notify.MessageID,
+		"sessionID", notify.SessionID)
 
-	if err := removed.AsyncCallback(removed.SessionID, removed.MessageID, removed.AsyncId, response); err != nil {
+	if err := notify.AsyncCallback(notify.SessionID, notify.MessageID, notify.AsyncId, response); err != nil {
 		logger.Warn("CHANGE_NOTIFY: failed to send async response",
-			"messageID", removed.MessageID,
-			"error", err)
+			"messageID", notify.MessageID, "error", err)
 	}
 }
 
@@ -1078,7 +1058,7 @@ func (r *NotifyRegistry) NotifyRmdir(shareName, parentPath, dirName string) {
 	}
 
 	// Second: notify parent watchers about the directory removal
-	r.NotifyChange(shareName, parentPath, dirName, FileActionRemoved)
+	r.NotifyChange(shareName, parentPath, dirName, FileActionRemoved, FileNotifyChangeDirName)
 }
 
 // UnregisterAllForSession unregisters all pending watchers for a session.
@@ -1130,6 +1110,39 @@ func (r *NotifyRegistry) UnregisterAllForTree(sessionID uint64, shareName string
 	}
 	r.mu.Unlock()
 	return toRemove
+}
+
+// FlushAll stops all pending flush timers and immediately delivers buffered
+// events for every watcher that has data. Drains buffers under the lock to
+// prevent a TOCTOU race where a concurrent NotifyChange buffers an event
+// between the timer stop and the flush. Used by unit tests.
+func (r *NotifyRegistry) FlushAll() {
+	type snapshot struct {
+		notify  *PendingNotify
+		changes []FileNotifyInformation
+	}
+	r.mu.Lock()
+	var snaps []snapshot
+	for _, notify := range r.byFileID {
+		if len(notify.bufferedChanges) == 0 {
+			continue
+		}
+		if notify.flushTimer != nil {
+			notify.flushTimer.Stop()
+			notify.flushTimer = nil
+		}
+		snaps = append(snaps, snapshot{
+			notify:  notify,
+			changes: notify.bufferedChanges,
+		})
+		notify.bufferedChanges = nil
+		r.unregisterLocked(notify)
+	}
+	r.mu.Unlock()
+
+	for _, s := range snaps {
+		r.deliverChanges(s.notify, s.changes)
+	}
 }
 
 // WatcherCount returns the total number of pending notify watchers.
@@ -1240,30 +1253,6 @@ func IsValidCompletionFilter(filter uint32) bool {
 	// Windows Server ignores reserved/unknown bits rather than rejecting them,
 	// so we only check that at least one recognized bit is set.
 	return filter&AllValidCompletionFilterFlags != 0
-}
-
-// actionToString converts an action code to a readable string.
-func actionToString(action uint32) string {
-	switch action {
-	case FileActionAdded:
-		return "ADDED"
-	case FileActionRemoved:
-		return "REMOVED"
-	case FileActionModified:
-		return "MODIFIED"
-	case FileActionRenamedOldName:
-		return "RENAMED_OLD"
-	case FileActionRenamedNewName:
-		return "RENAMED_NEW"
-	case FileActionAddedStream:
-		return "ADDED_STREAM"
-	case FileActionRemovedStream:
-		return "REMOVED_STREAM"
-	case FileActionModifiedStream:
-		return "MODIFIED_STREAM"
-	default:
-		return fmt.Sprintf("UNKNOWN(0x%X)", action)
-	}
 }
 
 // relativePathFromWatch computes the relative path of a changed item from the

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -517,12 +517,12 @@ func TestNotifyChange_ConcurrentDoubleFire(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		r.NotifyChange("share1", "/dir", "a.txt", FileActionAdded, FileNotifyChangeFileName)
-	r.FlushAll()
+		r.FlushAll()
 		done <- struct{}{}
 	}()
 	go func() {
 		r.NotifyChange("share1", "/dir", "b.txt", FileActionAdded, FileNotifyChangeFileName)
-	r.FlushAll()
+		r.FlushAll()
 		done <- struct{}{}
 	}()
 	<-done
@@ -1405,7 +1405,7 @@ func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
 	// More events while overflowed must not re-fire OnOverflow.
 	for i := 0; i < 5; i++ {
 		r.NotifyChange("s", "/d", "b.txt", FileActionAdded, FileNotifyChangeFileName)
-	r.FlushAll()
+		r.FlushAll()
 	}
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Errorf("expected overflow to latch (no re-fire), got count=%d", overflowFireCount)

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -292,7 +291,8 @@ func TestNotifyChange_ExactPath(t *testing.T) {
 	})
 
 	// Fire a matching change
-	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if !notified {
 		t.Fatal("expected watcher to be notified")
@@ -325,7 +325,8 @@ func TestNotifyChange_NoMatchDifferentShare(t *testing.T) {
 	})
 
 	// Fire change on different share
-	r.NotifyChange("share2", "/dir", "test.txt", FileActionAdded)
+	r.NotifyChange("share2", "/dir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if notified {
 		t.Error("should not notify watcher on different share")
@@ -353,7 +354,8 @@ func TestNotifyChange_RecursiveWatchTree(t *testing.T) {
 	})
 
 	// Fire change in subdirectory
-	r.NotifyChange("share1", "/subdir", "test.txt", FileActionAdded)
+	r.NotifyChange("share1", "/subdir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if !notified {
 		t.Error("recursive watcher should be notified for subdirectory changes")
@@ -381,7 +383,8 @@ func TestNotifyChange_NonRecursiveNoMatch(t *testing.T) {
 	})
 
 	// Fire change in subdirectory (should NOT match non-recursive watcher)
-	r.NotifyChange("share1", "/subdir", "test.txt", FileActionAdded)
+	r.NotifyChange("share1", "/subdir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if notified {
 		t.Error("non-recursive watcher should not be notified for subdirectory changes")
@@ -411,7 +414,8 @@ func TestNotifyRename_PairedNotification(t *testing.T) {
 		},
 	})
 
-	r.NotifyRename("share1", "/dir", "old.txt", "/dir", "new.txt")
+	r.NotifyRename("share1", "/dir", "old.txt", "/dir", "new.txt", FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if !notified {
 		t.Error("watcher should be notified on rename")
@@ -448,7 +452,8 @@ func TestNotifyRename_CrossDirectory(t *testing.T) {
 	})
 
 	// Cross-directory rename: /src/old.txt -> /dst/new.txt
-	r.NotifyRename("share1", "/src", "old.txt", "/dst", "new.txt")
+	r.NotifyRename("share1", "/src", "old.txt", "/dst", "new.txt", FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if !notified {
 		t.Error("recursive root watcher should be notified on cross-directory rename")
@@ -474,7 +479,8 @@ func TestNotifyChange_MaxOutputLengthExceeded_SendsEnumDir(t *testing.T) {
 		},
 	})
 
-	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if receivedStatus != types.StatusNotifyEnumDir {
 		t.Errorf("expected STATUS_NOTIFY_ENUM_DIR (0x%08X), got 0x%08X",
@@ -510,11 +516,13 @@ func TestNotifyChange_ConcurrentDoubleFire(t *testing.T) {
 	// Fire two concurrent events — only one should trigger the callback
 	done := make(chan struct{})
 	go func() {
-		r.NotifyChange("share1", "/dir", "a.txt", FileActionAdded)
+		r.NotifyChange("share1", "/dir", "a.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 		done <- struct{}{}
 	}()
 	go func() {
-		r.NotifyChange("share1", "/dir", "b.txt", FileActionAdded)
+		r.NotifyChange("share1", "/dir", "b.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 		done <- struct{}{}
 	}()
 	<-done
@@ -698,7 +706,8 @@ func TestNotifyChange_StreamNameOnADSCreate(t *testing.T) {
 	})
 
 	// Simulate ADS stream creation: file:stream:$DATA created in /dir
-	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionAdded, FileNotifyChangeStreamName)
+	r.FlushAll()
 
 	if !notified {
 		t.Fatal("expected watcher with FileNotifyChangeStreamName to be notified on ADS create")
@@ -725,7 +734,8 @@ func TestNotifyChange_StreamWriteOnADSWrite(t *testing.T) {
 	})
 
 	// Simulate ADS stream write: file:stream:$DATA modified in /dir
-	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionModified)
+	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionModifiedStream, FileNotifyChangeStreamWrite)
+	r.FlushAll()
 
 	if !notified {
 		t.Fatal("expected watcher with FileNotifyChangeStreamWrite to be notified on ADS write")
@@ -752,7 +762,8 @@ func TestNotifyChange_StreamSizeOnADSWrite(t *testing.T) {
 	})
 
 	// Simulate ADS stream size change
-	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionModified)
+	r.NotifyChange("share1", "/dir", "file:stream:$DATA", FileActionModifiedStream, FileNotifyChangeStreamSize)
+	r.FlushAll()
 
 	if !notified {
 		t.Fatal("expected watcher with FileNotifyChangeStreamSize to be notified on ADS size change")
@@ -779,7 +790,8 @@ func TestNotifyChange_SecurityDescriptorChange(t *testing.T) {
 	})
 
 	// Simulate security descriptor change on a file in /dir
-	r.NotifyChange("share1", "/dir", "file.txt", FileActionModified)
+	r.NotifyChange("share1", "/dir", "file.txt", FileActionModified, FileNotifyChangeSecurity)
+	r.FlushAll()
 
 	if !notified {
 		t.Fatal("expected watcher with FileNotifyChangeSecurity to be notified on security change")
@@ -847,7 +859,8 @@ func TestNotifyChange_DoubleWatchers_BothNotified(t *testing.T) {
 	})
 
 	// Fire a change — both watchers should be notified
-	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "test.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if count1.Load() != 1 {
 		t.Errorf("watcher 1: expected 1 notification, got %d", count1.Load())
@@ -934,6 +947,7 @@ func TestNotifyRmdir_SendsCleanupToWatchersOnRemovedDir(t *testing.T) {
 
 	// Remove the directory being watched
 	r.NotifyRmdir("share1", "/parent", "target")
+	r.FlushAll()
 
 	if receivedStatus != types.StatusNotifyCleanup {
 		t.Errorf("expected STATUS_NOTIFY_CLEANUP (0x%08X), got 0x%08X",
@@ -961,6 +975,7 @@ func TestNotifyRmdir_NotifiesParentWatcher(t *testing.T) {
 	})
 
 	r.NotifyRmdir("share1", "/parent", "child")
+	r.FlushAll()
 
 	if !parentNotified {
 		t.Error("parent watcher should receive FileActionRemoved notification for rmdir")
@@ -1152,7 +1167,8 @@ func TestNotifyChange_OverflowWithMultipleChanges(t *testing.T) {
 	})
 
 	// Any file change will produce a FileNotifyInformation entry larger than 16 bytes
-	r.NotifyChange("share1", "/dir", "longfilename.txt", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "longfilename.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if receivedStatus != types.StatusNotifyEnumDir {
 		t.Errorf("expected STATUS_NOTIFY_ENUM_DIR (0x%08X), got 0x%08X",
@@ -1232,7 +1248,8 @@ func TestSendAndUnregister_UndersizedBufferYieldsEnumDir(t *testing.T) {
 		},
 	})
 
-	r.NotifyChange("share1", "/dir", "file.txt", FileActionAdded)
+	r.NotifyChange("share1", "/dir", "file.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 
 	if deliveredStatus != types.StatusNotifyEnumDir {
 		t.Errorf("expected STATUS_NOTIFY_ENUM_DIR, got 0x%08X", uint32(deliveredStatus))
@@ -1326,7 +1343,8 @@ func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
 	// Fire 100 FILE_ACTION_ADDED events on subdirs (mirroring the torture
 	// loop that creates 100 directories inside the watched root).
 	for i := 0; i < 100; i++ {
-		r.NotifyChange("share1", "/basedir_ovf", fmt.Sprintf("test%d.txt", i), FileActionAdded)
+		r.NotifyChange("share1", "/basedir_ovf", fmt.Sprintf("test%d.txt", i), FileActionAdded, FileNotifyChangeFileName)
+		r.FlushAll()
 	}
 
 	// Sticky overflow must have tripped exactly once.
@@ -1342,7 +1360,8 @@ func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
 	if !r.Disarm(fileID) {
 		t.Errorf("expected Disarm to report removal")
 	}
-	r.NotifyChange("share1", "/basedir_ovf", "post-close.txt", FileActionAdded)
+	r.NotifyChange("share1", "/basedir_ovf", "post-close.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Errorf("expected no additional OnOverflow after Disarm, got count=%d", overflowFireCount)
 	}
@@ -1377,14 +1396,16 @@ func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
 	}
 
 	// First event trips overflow.
-	r.NotifyChange("s", "/d", "a.txt", FileActionAdded)
+	r.NotifyChange("s", "/d", "a.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Fatalf("expected first event to trip overflow, count=%d", overflowFireCount)
 	}
 
 	// More events while overflowed must not re-fire OnOverflow.
 	for i := 0; i < 5; i++ {
-		r.NotifyChange("s", "/d", "b.txt", FileActionAdded)
+		r.NotifyChange("s", "/d", "b.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	}
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Errorf("expected overflow to latch (no re-fire), got count=%d", overflowFireCount)
@@ -1395,7 +1416,8 @@ func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
 	r.ResetArmedOverflow(fileID, 64*1024)
 
 	// Single small event must NOT trip overflow against the new 64KB buffer.
-	r.NotifyChange("s", "/d", "c.txt", FileActionAdded)
+	r.NotifyChange("s", "/d", "c.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Errorf("expected no overflow after reset+small event, got count=%d", overflowFireCount)
 	}
@@ -1430,18 +1452,22 @@ func TestArmedBuffer_ScopedByShareAndPath(t *testing.T) {
 	}
 
 	// Different share — must not charge.
-	r.NotifyChange("share-b", "/watched", "x.txt", FileActionAdded)
+	r.NotifyChange("share-b", "/watched", "x.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	// Subdirectory but non-recursive — must not charge.
-	r.NotifyChange("share-a", "/watched/sub", "x.txt", FileActionAdded)
+	r.NotifyChange("share-a", "/watched/sub", "x.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	// Wrong filter (Modified vs FileName) — must not charge.
-	r.NotifyChange("share-a", "/watched", "x.txt", FileActionModified)
+	r.NotifyChange("share-a", "/watched", "x.txt", FileActionModified, FileNotifyChangeAttributes)
+	r.FlushAll()
 
 	if atomic.LoadInt32(&overflowFireCount) != 0 {
 		t.Errorf("expected no overflow on unrelated events, got count=%d", overflowFireCount)
 	}
 
 	// Matching event on the watched path — overflow must trip.
-	r.NotifyChange("share-a", "/watched", "x.txt", FileActionAdded)
+	r.NotifyChange("share-a", "/watched", "x.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if atomic.LoadInt32(&overflowFireCount) != 1 {
 		t.Errorf("expected overflow trip for matching event, got count=%d", overflowFireCount)
 	}
@@ -1474,7 +1500,8 @@ func TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent(t *testing.T) {
 	// Live watcher is present; one matching event fires through the live
 	// path (which itself overflows the 16-byte buffer → OnOverflow). The
 	// armed-accounting path must NOT also charge the event and double-fire.
-	r.NotifyChange("s", "/d", "a.txt", FileActionAdded)
+	r.NotifyChange("s", "/d", "a.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if got := atomic.LoadInt32(&overflowFireCount); got != 1 {
 		t.Errorf("expected OnOverflow exactly 1× (live path only), got %d — armed path is double-counting", got)
 	}
@@ -1525,7 +1552,8 @@ func TestArmedBuffer_RecursiveWatcherChargesRelativePath(t *testing.T) {
 	// "a/b/c/d/x.txt" — 26 bytes UTF-16LE plus 12-byte header = 38, pad
 	// to 40. That single entry alone exceeds MaxOutputLength=32, so
 	// overflow must trip on this event.
-	r.NotifyChange("s", "/a/b/c/d", "x.txt", FileActionAdded)
+	r.NotifyChange("s", "/a/b/c/d", "x.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
 	if got := atomic.LoadInt32(&overflowFireCount); got != 1 {
 		t.Errorf("expected overflow to trip on first deep-path event (relative-path accounting), got count=%d — recursive watcher is undercounting", got)
 	}
@@ -1672,19 +1700,6 @@ func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
 	}
 }
 
-// encodeChangeNotifyRequest builds a wire-format CHANGE_NOTIFY request body
-// per MS-SMB2 2.2.35 (fixed size 32 bytes). Used by handler-level tests that
-// exercise Handler.ChangeNotify through its parser.
-func encodeChangeNotifyRequest(flags uint16, outputBufferLength uint32, fileID [16]byte, completionFilter uint32) []byte {
-	body := make([]byte, 32)
-	binary.LittleEndian.PutUint16(body[0:2], 32) // StructureSize
-	binary.LittleEndian.PutUint16(body[2:4], flags)
-	binary.LittleEndian.PutUint32(body[4:8], outputBufferLength)
-	copy(body[8:24], fileID[:])
-	binary.LittleEndian.PutUint32(body[24:28], completionFilter)
-	return body
-}
-
 // TestChangeNotify_HandlePermissions_GrantedAccessGate mirrors the smbtorture
 // smb2.notify.handle-permissions test (source4/torture/smb2/notify.c::
 // torture_smb2_notify_handle_permissions): a directory handle opened with only
@@ -1755,7 +1770,7 @@ func TestChangeNotify_HandlePermissions_GrantedAccessGate(t *testing.T) {
 				ReleaseAsync:    func() {},
 			}
 
-			body := encodeChangeNotifyRequest(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName|FileNotifyChangeDirName)
+			body := encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName|FileNotifyChangeDirName)
 
 			result, err := h.ChangeNotify(ctx, body)
 			if err != nil {
@@ -1982,10 +1997,15 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 		}
 	}
 
-	// First CHANGE_NOTIFY: OutputBufferLength = 0 — legal per MS-SMB2 §2.2.35.
+	// First CHANGE_NOTIFY: OutputBufferLength = 0 — returns ENUM_DIR
+	// synchronously without registering a watcher (buffer=0 fast path).
 	body1 := encodeChangeNotifyReq(0, 0, fileID, FileNotifyChangeFileName)
-	if _, err := h.ChangeNotify(makeCtx(), body1); err != nil {
+	res1, err := h.ChangeNotify(makeCtx(), body1)
+	if err != nil {
 		t.Fatalf("first CHANGE_NOTIFY (OutputBufferLength=0) error: %v", err)
+	}
+	if res1.Status != types.StatusNotifyEnumDir {
+		t.Fatalf("first CHANGE_NOTIFY status = 0x%08X, want STATUS_NOTIFY_ENUM_DIR", res1.Status)
 	}
 
 	// The capture MUST be recorded even though the value is zero.
@@ -1997,13 +2017,16 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 		t.Fatalf("NotifyMaxBufferSize after first call = %d, want 0", got)
 	}
 
-	h.NotifyRegistry.Unregister(fileID)
-
 	// Second CHANGE_NOTIFY: max_trans_size buffer. The sticky cap MUST clamp
-	// it down to zero, NOT overwrite the captured zero with the new value.
+	// effectiveMax to zero, causing another synchronous ENUM_DIR (no watcher
+	// registered). This matches Samba: buffer=0 is immediate ENUM_DIR.
 	body2 := encodeChangeNotifyReq(0, h.MaxTransactSize, fileID, FileNotifyChangeFileName)
-	if _, err := h.ChangeNotify(makeCtx(), body2); err != nil {
+	res2, err := h.ChangeNotify(makeCtx(), body2)
+	if err != nil {
 		t.Fatalf("second CHANGE_NOTIFY error: %v", err)
+	}
+	if res2.Status != types.StatusNotifyEnumDir {
+		t.Fatalf("second CHANGE_NOTIFY status = 0x%08X, want STATUS_NOTIFY_ENUM_DIR (sticky zero)", res2.Status)
 	}
 
 	got, set = openFile.NotifyMaxBufferSizeValue()
@@ -2011,20 +2034,8 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 		t.Fatalf("NotifyMaxBufferSize after second call = (%d, set=%v), want (0, true) — sticky-zero broken", got, set)
 	}
 
-	pendingMax := ^uint32(0) // poison
-	found := false
-	h.NotifyRegistry.RangeWatchers(func(p *PendingNotify) bool {
-		if p.FileID == fileID {
-			pendingMax = p.MaxOutputLength
-			found = true
-		}
-		return true
-	})
-	if !found {
-		t.Fatal("second CHANGE_NOTIFY did not register a PendingNotify")
-	}
-	if pendingMax != 0 {
-		t.Errorf("PendingNotify.MaxOutputLength = %d, want 0 (capped to first call's zero)", pendingMax)
+	if h.NotifyRegistry.WatcherCount() != 0 {
+		t.Fatal("buffer=0 fast path should NOT register a watcher")
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -399,7 +399,11 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 
 					if h.NotifyRegistry != nil {
 						parentPath := GetParentPath(openFile.Path)
-						h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, openFile.FileName, FileActionRemoved)
+						nameFilter := uint32(FileNotifyChangeFileName)
+						if openFile.IsDirectory {
+							nameFilter = FileNotifyChangeDirName
+						}
+						h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, openFile.FileName, FileActionRemoved, nameFilter)
 					}
 				}
 			}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -690,6 +690,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			nameFilter := uint32(FileNotifyChangeFileName)
 			if openFile.IsDirectory {
 				nameFilter = FileNotifyChangeDirName
+			} else if strings.Contains(baseName, ":") {
+				nameFilter = FileNotifyChangeStreamName
 			}
 			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionAdded, nameFilter)
 		case types.FileOverwritten, types.FileSuperseded:

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -687,9 +687,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		parentPath := GetParentPath(filename)
 		switch createAction {
 		case types.FileCreated:
-			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionAdded)
+			nameFilter := uint32(FileNotifyChangeFileName)
+			if openFile.IsDirectory {
+				nameFilter = FileNotifyChangeDirName
+			}
+			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionAdded, nameFilter)
 		case types.FileOverwritten, types.FileSuperseded:
-			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionModified)
+			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionRemoved, FileNotifyChangeFileName)
+			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionAdded, FileNotifyChangeFileName)
+			h.NotifyRegistry.NotifyChange(tree.ShareName, parentPath, baseName, FileActionModified, FileNotifyChangeAttributes|FileNotifyChangeLastWrite|FileNotifyChangeSize)
 		}
 	}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -423,6 +423,15 @@ type OpenFile struct {
 	// "Unset" is the all-zero value. Set once via CompareAndSwap(0, ...)
 	// and never updated after. Use `notifyMaxBufferSizeLoad` to decode.
 	NotifyMaxBufferSize atomic.Uint64
+
+	// NotifyCompletionFilter is the CompletionFilter captured from the FIRST
+	// CHANGE_NOTIFY on this handle. Subsequent requests use this stored filter
+	// regardless of the filter in their request, matching Samba's
+	// change_notify_create behavior where the notify buffer's filter is fixed
+	// at creation. The recursive (WatchTree) flag is NOT sticky — it comes
+	// from each request. Encoding mirrors NotifyMaxBufferSize: bit 32 = set,
+	// low 32 bits = filter value. Zero means unset.
+	NotifyCompletionFilter atomic.Uint64
 }
 
 // OpenID returns a unique identifier for this open file handle.
@@ -463,6 +472,17 @@ func (f *OpenFile) NotifyMaxBufferSizeValue() (value uint32, set bool) {
 		return 0, false
 	}
 	return uint32(raw), true
+}
+
+// CaptureNotifyCompletionFilter atomically records the CompletionFilter of
+// the first CHANGE_NOTIFY on this handle. Subsequent calls return the stored
+// value. Thread-safe; only the first caller wins.
+func (f *OpenFile) CaptureNotifyCompletionFilter(filter uint32) (captured uint32, didCapture bool) {
+	packed := notifyMaxBufferSizeSetBit | uint64(filter)
+	if f.NotifyCompletionFilter.CompareAndSwap(0, packed) {
+		return filter, true
+	}
+	return uint32(f.NotifyCompletionFilter.Load()), false
 }
 
 // lastDeniedLock tracks the last denied lock request per open for

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -488,9 +488,23 @@ func (h *Handler) setFileInfoFromStore(
 		// the same breakParentDirLeasesForContentChange plumbing.
 		h.breakParentDirLeasesForContentChange(authCtx, openFile)
 
-		// Notify watchers about attribute/timestamp changes
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
+			var nf uint32
+			if fileAttrs != 0 {
+				nf |= FileNotifyChangeAttributes
+			}
+			if creationFT != 0 && !isFiletimeSentinel(creationFT) {
+				nf |= FileNotifyChangeCreation
+			}
+			if atimeFT != 0 && !isFiletimeSentinel(atimeFT) {
+				nf |= FileNotifyChangeLastAccess
+			}
+			if mtimeFT != 0 && !isFiletimeSentinel(mtimeFT) {
+				nf |= FileNotifyChangeLastWrite
+			}
+			if nf != 0 {
+				h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified, nf)
+			}
 		}
 
 		return setInfoStatus(types.StatusSuccess), nil
@@ -581,7 +595,11 @@ func (h *Handler) setFileInfoFromStore(
 					if newParentPath == "" || newParentPath == "." {
 						newParentPath = "/"
 					}
-					h.NotifyRegistry.NotifyRename(tree.ShareName, oldParentPath, oldFileName, newParentPath, toName)
+					renameFilter := uint32(FileNotifyChangeFileName)
+					if openFile.IsDirectory {
+						renameFilter = FileNotifyChangeDirName
+					}
+					h.NotifyRegistry.NotifyRename(tree.ShareName, oldParentPath, oldFileName, newParentPath, toName, renameFilter)
 				}
 			}
 
@@ -855,7 +873,11 @@ func (h *Handler) setFileInfoFromStore(
 				if newParentPath == "" || newParentPath == "." {
 					newParentPath = "/"
 				}
-				h.NotifyRegistry.NotifyRename(tree.ShareName, oldParentPath, oldFileName, newParentPath, toName)
+				renameFilter := uint32(FileNotifyChangeFileName)
+				if openFile.IsDirectory {
+					renameFilter = FileNotifyChangeDirName
+				}
+				h.NotifyRegistry.NotifyRename(tree.ShareName, oldParentPath, oldFileName, newParentPath, toName, renameFilter)
 			} else {
 				logger.Debug("SET_INFO: rename notifications skipped, tree lookup failed",
 					"treeID", openFile.TreeID,
@@ -1054,9 +1076,8 @@ func (h *Handler) setFileInfoFromStore(
 		// Read + Handle caching. Parent-key suppression (C2) applies.
 		h.breakParentDirLeasesForContentChange(authCtx, openFile)
 
-		// Notify watchers about size changes
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
+			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified, FileNotifyChangeSize)
 		}
 
 		return setInfoStatus(types.StatusSuccess), nil
@@ -1087,7 +1108,7 @@ func (h *Handler) setFileInfoFromStore(
 		// but returning SUCCESS allows ChangeNotify EA tests to proceed.
 		logger.Debug("SET_INFO: FileFullEaInformation (no-op)", "path", openFile.Path)
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
+			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified, FileNotifyChangeEa)
 		}
 		return setInfoStatus(types.StatusSuccess), nil
 
@@ -1340,15 +1361,12 @@ func (h *Handler) setSecurityInfo(
 	}
 
 	if !changed {
-		// Nothing to change - accept as no-op but still notify watchers
-		// since the client considers the SET_INFO successful.
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
+			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified, FileNotifyChangeSecurity)
 		}
 		return setInfoStatus(types.StatusSuccess), nil
 	}
 
-	// Apply changes
 	metaSvc := h.Registry.GetMetadataService()
 	err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 	if err != nil {
@@ -1356,9 +1374,8 @@ func (h *Handler) setSecurityInfo(
 		return setInfoStatus(common.MapToSMB(err)), nil
 	}
 
-	// Notify watchers about security descriptor changes
 	if h.NotifyRegistry != nil {
-		h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified)
+		h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), openFile.FileName, FileActionModified, FileNotifyChangeSecurity)
 	}
 
 	return setInfoStatus(types.StatusSuccess), nil
@@ -1655,7 +1672,7 @@ func (h *Handler) handleFileLinkInformation(
 			if dstParentPath == "" || dstParentPath == "." {
 				dstParentPath = "/"
 			}
-			h.NotifyRegistry.NotifyChange(tree.ShareName, dstParentPath, linkName, FileActionAdded)
+			h.NotifyRegistry.NotifyChange(tree.ShareName, dstParentPath, linkName, FileActionAdded, FileNotifyChangeFileName)
 		}
 	}
 

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -513,6 +513,17 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		effectiveMax = stored
 	}
 
+	// Per Samba change_notify_create: the CompletionFilter is fixed by the
+	// FIRST CHANGE_NOTIFY on the handle. Subsequent requests use the stored
+	// filter regardless of what they request. The WatchTree (recursive)
+	// flag is NOT sticky — it comes fresh from each request. Captured before
+	// the buffer_size=0 fast-path so even a zero-buffer first request
+	// initializes the sticky filter state.
+	effectiveFilter := req.CompletionFilter
+	if stored, didCapture := openFile.CaptureNotifyCompletionFilter(effectiveFilter); !didCapture {
+		effectiveFilter = stored
+	}
+
 	// Per Samba: buffer_size=0 means the client cannot receive any events.
 	// Return NOTIFY_ENUM_DIR immediately without setting the sticky overflow
 	// flag and without registering a watcher. This is distinct from a real
@@ -525,15 +536,6 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 			return NewErrorResult(types.StatusInternalError), nil
 		}
 		return NewResult(types.StatusNotifyEnumDir, respBytes), nil
-	}
-
-	// Per Samba change_notify_create: the CompletionFilter is fixed by the
-	// FIRST CHANGE_NOTIFY on the handle. Subsequent requests use the stored
-	// filter regardless of what they request. The WatchTree (recursive)
-	// flag is NOT sticky — it comes fresh from each request.
-	effectiveFilter := req.CompletionFilter
-	if stored, didCapture := openFile.CaptureNotifyCompletionFilter(effectiveFilter); !didCapture {
-		effectiveFilter = stored
 	}
 
 	asyncId := h.generateAsyncId()

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -513,10 +513,29 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		effectiveMax = stored
 	}
 
-	// Generate a unique AsyncId for this pending request.
-	// Per MS-SMB2 3.3.5.15, the server assigns an AsyncId and sends an
-	// interim response with STATUS_PENDING. The same AsyncId is used in
-	// the final async response when the notification is delivered.
+	// Per Samba: buffer_size=0 means the client cannot receive any events.
+	// Return NOTIFY_ENUM_DIR immediately without setting the sticky overflow
+	// flag and without registering a watcher. This is distinct from a real
+	// overflow (buffer>0 but too small) which latches sticky overflow.
+	if effectiveMax == 0 {
+		respBytes, encErr := (&ChangeNotifyResponse{
+			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
+		}).Encode()
+		if encErr != nil {
+			return NewErrorResult(types.StatusInternalError), nil
+		}
+		return NewResult(types.StatusNotifyEnumDir, respBytes), nil
+	}
+
+	// Per Samba change_notify_create: the CompletionFilter is fixed by the
+	// FIRST CHANGE_NOTIFY on the handle. Subsequent requests use the stored
+	// filter regardless of what they request. The WatchTree (recursive)
+	// flag is NOT sticky — it comes fresh from each request.
+	effectiveFilter := req.CompletionFilter
+	if stored, didCapture := openFile.CaptureNotifyCompletionFilter(effectiveFilter); !didCapture {
+		effectiveFilter = stored
+	}
+
 	asyncId := h.generateAsyncId()
 
 	notify := &PendingNotify{
@@ -527,11 +546,15 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		AsyncId:          asyncId,
 		WatchPath:        watchPath,
 		ShareName:        openFile.ShareName,
-		CompletionFilter: req.CompletionFilter,
+		CompletionFilter: effectiveFilter,
 		WatchTree:        req.Flags&SMB2WatchTree != 0,
-		// Use the per-handle MIN-capped max (Samba notify_buffer semantics).
-		MaxOutputLength: effectiveMax,
-		AsyncCallback:   ctx.AsyncNotifyCallback,
+		MaxOutputLength:  effectiveMax,
+		AsyncCallback:    ctx.AsyncNotifyCallback,
+		OnOverflow: func(fileID [16]byte) {
+			if of, ok := h.GetOpenFile(fileID); ok {
+				of.NotifyOverflowed.Store(true)
+			}
+		},
 	}
 
 	// Per MS-SMB2 §3.3.5.2.5: enforce max_async_credits before going async.

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -430,12 +430,9 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Update cached PayloadID in OpenFile
 	openFile.PayloadID = writeOp.PayloadID
 
-	// Per MS-FSCC 2.6 / MS-SMB2 3.3.4.4: Writing to an Alternate Data Stream
-	// fires FILE_NOTIFY_CHANGE_STREAM_WRITE and FILE_NOTIFY_CHANGE_STREAM_SIZE
-	// on the parent directory so ChangeNotify watchers are notified.
 	if isADSWrite && h.NotifyRegistry != nil {
 		parentDirPath := GetParentPath(openFile.Path)
-		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, openFile.FileName, FileActionModifiedStream)
+		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, openFile.FileName, FileActionModifiedStream, FileNotifyChangeStreamWrite|FileNotifyChangeStreamSize)
 	}
 
 	logger.Debug("WRITE successful",


### PR DESCRIPTION
## Summary

- Refactor CHANGE_NOTIFY to use per-event filter flags (`NotifyChange`/`NotifyRename` take `filter uint32`) — watchers matched by `CompletionFilter & eventFilter` intersection instead of action-based `MatchesFilter` logic
- Add 100μs event buffering to batch same-goroutine events (OVERWRITE/SUPERSEDE fires REMOVED+ADDED+MODIFIED in one response)
- Sticky CompletionFilter per handle — first CHANGE_NOTIFY captures filter, subsequent requests reuse stored value (Samba `change_notify_create` parity)
- `buffer_size=0` returns `STATUS_NOTIFY_ENUM_DIR` synchronously without sticky overflow flag
- Per-field notify filter in `SET_INFO FileBasicInformation` — attributes, timestamps, size, EA, security get correct `FILE_NOTIFY_CHANGE_*` flags
- File vs directory discrimination — CREATE/DELETE use `FileName` for files, `DirName` for directories
- `OnOverflow` wired on `PendingNotify` so sticky `NotifyOverflowed` latches correctly
- `FlushAll` test helper drains buffers under lock (eliminates TOCTOU race found by code review)

## Test plan

- [x] All SMB handler unit tests pass (`go test ./internal/adapter/smb/v2/handlers/`)
- [x] Full SMB adapter suite passes (`go test ./internal/adapter/smb/...`)
- [x] `go build ./...` clean
- [ ] smbtorture `smb2.notify` suite — `valid-req` requires cross-request event batching (Samba tevent model), stays KNOWN_FAILURE; `tcon` pre-existing flaky KNOWN_FAILURE
- [ ] Full CI smbtorture run confirms no regressions