### PR TITLE
fix(smb/lock): same-owner conflict rules and zero-byte lock semantics

### DIFF
--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -351,6 +351,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 				Offset:     lockElem.Offset,
 				Length:     lockElem.Length,
 				Exclusive:  isExclusive,
+				IsZeroByte: lockElem.Length == 0,
 				AcquiredAt: time.Now(),
 				ClientAddr: ctx.ClientAddr,
 			}

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -245,15 +245,15 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// contend_level2_oplocks_begin is called from brl_lock only, not
 	// brl_unlock. Releasing a lock cannot invalidate any remote read cache.
 
-	hasLockElement := false
+	hasRangeLockElement := false
 	for _, e := range req.Locks {
-		if (e.Flags & SMB2LockFlagUnlock) == 0 {
-			hasLockElement = true
+		if (e.Flags&SMB2LockFlagUnlock) == 0 && e.Length > 0 {
+			hasRangeLockElement = true
 			break
 		}
 	}
 
-	if hasLockElement && h.LeaseManager != nil {
+	if hasRangeLockElement && h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakLeasesOnByteRangeLock(lockFileHandle, openFile.ShareName, &lock.LockOwner{
 			ExcludeLeaseKey: openFile.LeaseKey,

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -72,7 +72,8 @@ type LockElement struct {
 	// Offset is the starting byte offset of the lock.
 	Offset uint64
 
-	// Length is the number of bytes to lock (0 = to EOF).
+	// Length is the number of bytes to lock.
+	// 0 means a zero-byte lock (never conflicts, SMB2 semantics).
 	Length uint64
 
 	// Flags specifies the lock type and behavior.

--- a/pkg/metadata/lock/cross_protocol_test.go
+++ b/pkg/metadata/lock/cross_protocol_test.go
@@ -10,17 +10,37 @@ import (
 // ConflictsWith - All 4 Conflict Cases
 // ============================================================================
 
-func TestConflictsWith_SameOwnerNeverConflicts(t *testing.T) {
+func TestConflictsWith_SameOwner_NoConflict_POSIX(t *testing.T) {
 	t.Parallel()
 
+	// UnifiedLock uses POSIX semantics: same owner never conflicts.
+	// SMB-specific restrictions are in IsLockConflicting (FileLock).
 	owner := LockOwner{OwnerID: "smb:client1"}
 
-	// Exclusive vs Exclusive from same owner - no conflict
 	a := &UnifiedLock{Owner: owner, Offset: 0, Length: 100, Type: LockTypeExclusive}
 	b := &UnifiedLock{Owner: owner, Offset: 0, Length: 100, Type: LockTypeExclusive}
 
 	if a.ConflictsWith(b) {
-		t.Error("Same owner should never conflict (exclusive vs exclusive)")
+		t.Error("Same owner should never conflict in UnifiedLock (POSIX semantics)")
+	}
+}
+
+func TestConflictsWith_UnifiedLock_LengthZero_MeansEOF(t *testing.T) {
+	t.Parallel()
+
+	// In UnifiedLock, Length=0 means "to EOF" (NFS semantics), NOT zero-byte.
+	// Zero-byte lock semantics are SMB-specific via FileLock.IsZeroByte.
+	a := &UnifiedLock{
+		Owner: LockOwner{OwnerID: "smb:client1"},
+		Offset: 0, Length: 0, Type: LockTypeExclusive,
+	}
+	b := &UnifiedLock{
+		Owner: LockOwner{OwnerID: "smb:client2"},
+		Offset: 50, Length: 100, Type: LockTypeExclusive,
+	}
+
+	if !a.ConflictsWith(b) {
+		t.Error("Length=0 in UnifiedLock means to-EOF; should conflict with any overlapping range")
 	}
 }
 

--- a/pkg/metadata/lock/cross_protocol_test.go
+++ b/pkg/metadata/lock/cross_protocol_test.go
@@ -31,11 +31,11 @@ func TestConflictsWith_UnifiedLock_LengthZero_MeansEOF(t *testing.T) {
 	// In UnifiedLock, Length=0 means "to EOF" (NFS semantics), NOT zero-byte.
 	// Zero-byte lock semantics are SMB-specific via FileLock.IsZeroByte.
 	a := &UnifiedLock{
-		Owner: LockOwner{OwnerID: "smb:client1"},
+		Owner:  LockOwner{OwnerID: "smb:client1"},
 		Offset: 0, Length: 0, Type: LockTypeExclusive,
 	}
 	b := &UnifiedLock{
-		Owner: LockOwner{OwnerID: "smb:client2"},
+		Owner:  LockOwner{OwnerID: "smb:client2"},
 		Offset: 50, Length: 100, Type: LockTypeExclusive,
 	}
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -351,6 +351,12 @@ type FileLock struct {
 	// ClientAddr is the network address of the client holding the lock.
 	// Used for debugging and logging.
 	ClientAddr string
+
+	// IsZeroByte marks this as a zero-byte lock (SMB2 Length=0).
+	// Zero-byte locks never conflict with any other lock. They are stored
+	// and require explicit unlock, but do not block other lock acquisitions.
+	// NFS/NLM never sets this; NFS uses Length=0 for "to EOF" semantics.
+	IsZeroByte bool
 }
 
 // LockConflict describes a conflicting lock for error reporting.
@@ -397,32 +403,50 @@ func callerOwnerID(openID string, sessionID uint64) string {
 
 // IsLockConflicting checks if two locks conflict with each other.
 //
-// Conflict rules:
-//   - Shared locks don't conflict with other shared locks (multiple readers)
-//   - Exclusive locks conflict with all other locks
-//   - Locks from the same open (OpenID) don't conflict (allows re-locking same range)
-//   - Ranges must overlap for a conflict to occur
+// Mirrors Samba brl_conflict (source3/locking/brlock.c):
+//
+//  1. Zero-byte locks (IsZeroByte) never overlap anything.
+//  2. Read + Read → never conflict (multiple readers OK).
+//  3. Same owner (same OpenID), existing Write, new Read → no conflict
+//     ("a read lock can stack on top of a write lock", Samba comment).
+//  4. Everything else → conflict iff ranges overlap.
 //
 // Per MS-SMB2, lock ownership is per-open (per FileID), not per-session. Two
 // different opens from the same session are independent lock owners and MUST
 // conflict with each other when acquiring exclusive locks on overlapping ranges.
 func IsLockConflicting(existing, requested *FileLock) bool {
-	// Check range overlap first (common case: no overlap, avoids string allocation)
-	if !RangesOverlap(existing.Offset, existing.Length, requested.Offset, requested.Length) {
+	// Zero-byte locks never conflict with anything (SMB2 semantics).
+	// Samba brl_overlap: "zero length locks never overlap".
+	if existing.IsZeroByte || requested.IsZeroByte {
 		return false
 	}
 
-	// Same owner - no conflict (allows re-locking same range with different type)
-	if lockOwnerID(existing) == lockOwnerID(requested) {
-		return false
-	}
-
-	// Both shared (read) locks - no conflict
+	// Read locks never conflict with each other.
 	if !existing.Exclusive && !requested.Exclusive {
 		return false
 	}
 
-	// At least one is exclusive and ranges overlap - conflict
+	// Same owner handling. NFS/NLM (OpenID empty) uses session-level
+	// ownership where same-process re-locking always succeeds (POSIX).
+	// SMB (OpenID set) uses per-open ownership with restricted stacking
+	// per Samba brl_conflict: only shared-on-exclusive from same open is
+	// allowed; all other combos fall through to the overlap check.
+	if lockOwnerID(existing) == lockOwnerID(requested) {
+		if existing.OpenID == "" || requested.OpenID == "" {
+			return false // NFS/NLM: same session, no conflict
+		}
+		if existing.Exclusive && !requested.Exclusive {
+			return false // SMB: read stacks on write from same open
+		}
+		return RangesOverlap(existing.Offset, existing.Length, requested.Offset, requested.Length)
+	}
+
+	// Different owner: check range overlap.
+	if !RangesOverlap(existing.Offset, existing.Length, requested.Offset, requested.Length) {
+		return false
+	}
+
+	// At least one is exclusive and ranges overlap — conflict.
 	return true
 }
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1199,6 +1199,21 @@ func TestLock_SMB_SameOpen_SharedStacking_OK(t *testing.T) {
 	}
 }
 
+func TestLock_SMB_SameOpen_ExclusiveNonOverlapping_OK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	l1 := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l1); err != nil {
+		t.Fatal(err)
+	}
+
+	l2 := FileLock{SessionID: 1, OpenID: "open1", Offset: 10, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l2); err != nil {
+		t.Fatal("Same-open exclusive locks on non-overlapping ranges should succeed")
+	}
+}
+
 func TestLock_SMB_DifferentOpen_ExclusiveConflict(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1134,3 +1134,141 @@ func TestSetLeaseEpoch_ReturnsFalseForUnknownKey(t *testing.T) {
 		t.Fatalf("SetLeaseEpoch returned true for unknown key")
 	}
 }
+
+// ============================================================================
+// SMB-style same-open conflict rules (per Samba brl_conflict)
+// ============================================================================
+
+func TestLock_SMB_SameOpen_ExclusiveRelock_Fails(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	first := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", first); err != nil {
+		t.Fatal(err)
+	}
+
+	second := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", second); err == nil {
+		t.Fatal("Same-open exclusive re-lock on same range should fail")
+	}
+}
+
+func TestLock_SMB_SameOpen_SharedOnExclusive_OK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	excl := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", excl); err != nil {
+		t.Fatal(err)
+	}
+
+	shared := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: false}
+	if err := lm.Lock("file1", shared); err != nil {
+		t.Fatal("Shared lock should stack on exclusive from same open")
+	}
+}
+
+func TestLock_SMB_SameOpen_ExclusiveOnShared_Fails(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	shared := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: false}
+	if err := lm.Lock("file1", shared); err != nil {
+		t.Fatal(err)
+	}
+
+	excl := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", excl); err == nil {
+		t.Fatal("Exclusive lock on shared from same open should fail")
+	}
+}
+
+func TestLock_SMB_SameOpen_SharedStacking_OK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	s1 := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: false}
+	if err := lm.Lock("file1", s1); err != nil {
+		t.Fatal(err)
+	}
+
+	s2 := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: false}
+	if err := lm.Lock("file1", s2); err != nil {
+		t.Fatal("Shared re-lock from same open should succeed")
+	}
+}
+
+func TestLock_SMB_DifferentOpen_ExclusiveConflict(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	l1 := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l1); err != nil {
+		t.Fatal(err)
+	}
+
+	l2 := FileLock{SessionID: 1, OpenID: "open2", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l2); err == nil {
+		t.Fatal("Different open exclusive on same range should fail")
+	}
+}
+
+func TestLock_SMB_ZeroByte_NeverConflicts(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	normal := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", normal); err != nil {
+		t.Fatal(err)
+	}
+
+	zb := FileLock{SessionID: 2, OpenID: "open2", Offset: 5, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zb); err != nil {
+		t.Fatal("Zero-byte lock should never conflict")
+	}
+}
+
+func TestLock_SMB_TwoZeroByte_SameOffset_OK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	zb1 := FileLock{SessionID: 1, OpenID: "open1", Offset: 10, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zb1); err != nil {
+		t.Fatal(err)
+	}
+
+	zb2 := FileLock{SessionID: 2, OpenID: "open2", Offset: 10, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zb2); err != nil {
+		t.Fatal("Two zero-byte locks at same offset should not conflict")
+	}
+}
+
+func TestUnlock_SMB_ZeroByte_ExactMatch(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	zb := FileLock{SessionID: 1, OpenID: "open1", Offset: 10, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zb); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := lm.Unlock("file1", "open1", 1, 10, 0); err != nil {
+		t.Fatal("Should unlock zero-byte lock by exact offset+length match")
+	}
+}
+
+func TestLock_NFS_SameSession_ExclusiveRelock_OK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	l1 := FileLock{SessionID: 100, Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l1); err != nil {
+		t.Fatal(err)
+	}
+
+	l2 := FileLock{SessionID: 100, Offset: 0, Length: 10, Exclusive: true}
+	if err := lm.Lock("file1", l2); err != nil {
+		t.Fatal("NFS same-session exclusive re-lock should succeed (POSIX semantics)")
+	}
+}

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -292,17 +292,14 @@ func (ul *UnifiedLock) IsDelegation() bool {
 //  1. Access mode conflicts (SMB deny modes)
 //  2. OpLock vs OpLock (lease-to-lease conflicts)
 //  3. OpLock vs byte-range (cross-type conflicts)
-//  4. Byte-range vs byte-range (traditional range overlap + type check)
-//
-// Same owner never conflicts (allows re-locking and upgrading).
+//  4. Byte-range vs byte-range — mirrors Samba brl_conflict:
+//     - Zero-length byte-range locks never conflict with anything
+//     - Shared+Shared never conflict
+//     - Same owner: only shared-on-exclusive is allowed (stacking)
+//     - Everything else conflicts if ranges overlap
 //
 // Returns true if the locks conflict and one must be denied or broken.
 func (ul *UnifiedLock) ConflictsWith(other *UnifiedLock) bool {
-	// Same owner = no conflict
-	if ul.Owner.OwnerID == other.Owner.OwnerID {
-		return false
-	}
-
 	// Case 1: Access mode conflicts (SMB share modes)
 	if accessModesConflict(ul.AccessMode, other.AccessMode) {
 		return true
@@ -325,7 +322,21 @@ func (ul *UnifiedLock) ConflictsWith(other *UnifiedLock) bool {
 	if !RangesOverlap(ul.Offset, ul.Length, other.Offset, other.Length) {
 		return false
 	}
-	return ul.Type != LockTypeShared || other.Type != LockTypeShared
+
+	// Same owner = no conflict (POSIX semantics for unified locks).
+	// AddUnifiedLock handles exact-match updates separately.
+	// SMB-specific same-owner restrictions live in IsLockConflicting.
+	if ul.Owner.OwnerID == other.Owner.OwnerID {
+		return false
+	}
+
+	// Both shared = no conflict.
+	if ul.Type == LockTypeShared && other.Type == LockTypeShared {
+		return false
+	}
+
+	// Different owner, overlapping, at least one exclusive — conflict.
+	return true
 }
 
 // accessModesConflict checks if two access modes (SMB share reservations) conflict.

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -292,11 +292,13 @@ func (ul *UnifiedLock) IsDelegation() bool {
 //  1. Access mode conflicts (SMB deny modes)
 //  2. OpLock vs OpLock (lease-to-lease conflicts)
 //  3. OpLock vs byte-range (cross-type conflicts)
-//  4. Byte-range vs byte-range — mirrors Samba brl_conflict:
-//     - Zero-length byte-range locks never conflict with anything
-//     - Shared+Shared never conflict
-//     - Same owner: only shared-on-exclusive is allowed (stacking)
-//     - Everything else conflicts if ranges overlap
+//  4. Byte-range vs byte-range (POSIX same-owner semantics: same owner
+//     never conflicts; different owner conflicts when at least one is
+//     exclusive and ranges overlap)
+//
+// Note: SMB-specific same-owner restrictions (restricted stacking per
+// Samba brl_conflict) and zero-byte lock semantics live in
+// IsLockConflicting (FileLock layer), not here.
 //
 // Returns true if the locks conflict and one must be denied or broken.
 func (ul *UnifiedLock) ConflictsWith(other *UnifiedLock) bool {


### PR DESCRIPTION
## Summary

Fixes two root causes for remaining `smb2.lock.*` smbtorture failures after wave 1 (#650):

- **Same-owner conflict logic** (`IsLockConflicting`): was treating same-owner locks as never conflicting. Per Samba `brl_conflict` (source3/locking/brlock.c), same-open locks only skip conflict for READ-on-WRITE (shared stacking on exclusive). WRITE+WRITE and READ→WRITE from same handle now correctly check overlap. Scoped to SMB (OpenID set); NFS/NLM (OpenID empty) retains POSIX same-session permissive semantics.

- **Zero-byte lock semantics**: SMB zero-byte locks (`Length=0`) were treated as "to EOF" (NFS semantics). Added `IsZeroByte` flag to `FileLock`; zero-byte locks never conflict with anything per Samba `brl_overlap`.

Affects: `smb2.lock.{lock, auto-unlock, errorcode, zerobytelength, multiple-unlock, stacking, range, overlap}`.

Closes #651

## Test plan

- [x] `go test ./...` passes (zero failures)
- [x] 10 new unit tests covering SMB same-open conflict rules and zero-byte semantics
- [x] Existing NFS/NLM tests pass (POSIX same-session semantics preserved)
- [ ] CI smbtorture `smb2.lock.*` — expect flips on the 8 core-semantics tests
- [ ] Verify no regressions on other smbtorture suites