### PR TITLE
fix(smb/lock): same-owner conflict rules and zero-byte lock semantics (#653)

### DIFF
--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -200,7 +200,7 @@ const (
 
 	// StatusInvalidLockRange indicates the lock range (offset+length) overflows
 	// the maximum 64-bit value. Per MS-SMB2 3.3.5.14.
-	StatusInvalidLockRange Status = 0xC00000BE
+	StatusInvalidLockRange Status = 0xC00001A1
 )
 
 // String returns a human-readable name for the status code.

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -220,12 +220,37 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// Per MS-SMB2 3.3.5.14: When there are multiple lock elements and the
 	// first element is a lock (not unlock), it MUST have FailImmediately set.
 	// This prevents blocking lock requests in batch operations.
+	//
+	// Additionally, per MS-SMB2 §3.3.5.14.1 and Samba smbd_smb2_lock_send,
+	// a multi-element request MUST NOT mix lock and unlock elements. When
+	// first is lock and a later element is unlock → INVALID_PARAMETER
+	// immediately. When first is unlock and a later element is lock → the
+	// unlocks are processed first, then INVALID_PARAMETER is returned
+	// (Samba deferred-invalid semantics: unlock side-effects persist).
+	hasMixedUnlockThenLock := false
 	if req.LockCount > 1 {
 		firstIsLock := (req.Locks[0].Flags & SMB2LockFlagUnlock) == 0
 		firstHasFailImm := (req.Locks[0].Flags & SMB2LockFlagFailImmediately) != 0
 		if firstIsLock && !firstHasFailImm {
 			logger.Debug("LOCK: multi-element request without FailImmediately on first lock")
 			return NewErrorResult(types.StatusInvalidParameter), nil
+		}
+
+		// Detect mixed lock/unlock elements.
+		firstIsUnlock := !firstIsLock
+		for i := 1; i < len(req.Locks); i++ {
+			elemIsUnlock := (req.Locks[i].Flags & SMB2LockFlagUnlock) != 0
+			if firstIsLock && elemIsUnlock {
+				// Lock-first, unlock later → reject immediately.
+				logger.Debug("LOCK: multi-element request mixes lock then unlock",
+					"elem", i)
+				return NewErrorResult(types.StatusInvalidParameter), nil
+			}
+			if firstIsUnlock && !elemIsUnlock {
+				// Unlock-first, lock later → process unlocks, then error.
+				hasMixedUnlockThenLock = true
+				break
+			}
 		}
 	}
 
@@ -306,6 +331,16 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			"flags", fmt.Sprintf("0x%08X", lockElem.Flags),
 			"unlock", isUnlock,
 			"exclusive", isExclusive)
+
+		// Mixed unlock-then-lock: process unlocks, reject on first lock element.
+		// Per Samba smbd_smb2_lock_send, unlocks persist but the overall request
+		// returns INVALID_PARAMETER when a lock element follows.
+		if hasMixedUnlockThenLock && !isUnlock {
+			logger.Debug("LOCK: mixed unlock-then-lock, rejecting lock element",
+				"index", i)
+			rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
+			return NewErrorResult(types.StatusInvalidParameter), nil
+		}
 
 		if isUnlock {
 			// Unlock operation.

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -380,7 +380,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			// LOCK_NOT_GRANTED / FILE_LOCK_CONFLICT distinction.
 			if failImmediately {
 				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive)), nil
+				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive, storeErr.ConflictOwnerID)), nil
 			}
 
 			// Blocking conflict. Try async parking first; if parking is
@@ -423,8 +423,13 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 					rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
 					return NewErrorResult(types.StatusCancelled), nil
 				}
+				var retryStoreErr *metadata.StoreError
+				var retryConflictOwner string
+				if goerrors.As(err, &retryStoreErr) {
+					retryConflictOwner = retryStoreErr.ConflictOwnerID
+				}
 				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive)), nil
+				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive, retryConflictOwner)), nil
 			}
 
 			h.lastDeniedLocks.Delete(openID)
@@ -574,9 +579,21 @@ func rollbackLocks(
 // STATUS_FILE_LOCK_CONFLICT instead. The handler tracks the last-denied
 // triple per OpenID; on success the entry is cleared.
 //
+// Self-conflicts (conflictOwnerID == openID, i.e. the requesting open already
+// holds the blocking lock) always return LOCK_NOT_GRANTED and never escalate
+// to FILE_LOCK_CONFLICT. Per Samba behaviour and smbtorture expectations
+// (smb2.lock.auto-unlock line 572, smb2.lock.errorcode line 1253), the
+// escalation only applies to cross-handle conflicts.
+//
 // Used by the synchronous fail-immediately path, the inline-retry fallback,
 // and the async-park resume goroutine.
-func (h *Handler) mapLockConflictStatus(openID string, lockElem LockElement, isExclusive bool) types.Status {
+func (h *Handler) mapLockConflictStatus(openID string, lockElem LockElement, isExclusive bool, conflictOwnerID string) types.Status {
+	// Self-conflict: the requesting open already holds the blocking lock.
+	// Always return LOCK_NOT_GRANTED without storing or escalating.
+	if conflictOwnerID != "" && conflictOwnerID == openID {
+		return types.StatusLockNotGranted
+	}
+
 	denied := lastDeniedLock{
 		Offset:    lockElem.Offset,
 		Length:    lockElem.Length,

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -215,7 +215,10 @@ func (h *Handler) resumePendingLock(
 			// in case (a). On external cancel, the canceller owns delivery and
 			// the mutation would taint the next retry from the same OpenID.
 			if goerrors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-				finalStatus = h.mapLockConflictStatus(pending.OwnerID, lockElem, fileLock.Exclusive)
+				// Async-parked locks are always cross-handle conflicts (self-
+				// conflicts are caught synchronously before parking), so pass
+				// empty conflictOwnerID to allow normal escalation logic.
+				finalStatus = h.mapLockConflictStatus(pending.OwnerID, lockElem, fileLock.Exclusive, "")
 			}
 			finalBody = nil
 			goto deliver

--- a/pkg/metadata/errors/errors.go
+++ b/pkg/metadata/errors/errors.go
@@ -167,6 +167,13 @@ type StoreError struct {
 	Code    ErrorCode
 	Message string
 	Path    string
+
+	// ConflictOwnerID is the effective owner identifier of the lock that
+	// caused the conflict (populated only for ErrLocked). The SMB handler
+	// uses this to distinguish self-conflicts (same open re-locking its
+	// own range) from cross-handle conflicts for the LOCK_NOT_GRANTED vs
+	// FILE_LOCK_CONFLICT status mapping (MS-SMB2 3.3.5.14).
+	ConflictOwnerID string
 }
 
 // Error implements the error interface.

--- a/pkg/metadata/lock/errors.go
+++ b/pkg/metadata/lock/errors.go
@@ -7,13 +7,16 @@ import (
 // NewLockedError creates error for lock conflicts (legacy FileLock).
 func NewLockedError(path string, conflict *LockConflict) *errors.StoreError {
 	msg := "resource is locked"
+	var ownerID string
 	if conflict != nil {
 		msg = "resource is locked by another session"
+		ownerID = conflict.OwnerID
 	}
 	return &errors.StoreError{
-		Code:    errors.ErrLocked,
-		Message: msg,
-		Path:    path,
+		Code:            errors.ErrLocked,
+		Message:         msg,
+		Path:            path,
+		ConflictOwnerID: ownerID,
 	}
 }
 

--- a/pkg/metadata/lock/errors.go
+++ b/pkg/metadata/lock/errors.go
@@ -32,13 +32,20 @@ func NewLockNotFoundError(path string) *errors.StoreError {
 // NewLockConflictError creates error for unified lock conflicts.
 func NewLockConflictError(path string, conflict *UnifiedLockConflict) *errors.StoreError {
 	msg := "lock conflict"
-	if conflict != nil && conflict.Reason != "" {
-		msg = conflict.Reason
+	var ownerID string
+	if conflict != nil {
+		if conflict.Reason != "" {
+			msg = conflict.Reason
+		}
+		if conflict.Lock != nil {
+			ownerID = conflict.Lock.Owner.OwnerID
+		}
 	}
 	return &errors.StoreError{
-		Code:    errors.ErrLockConflict,
-		Message: msg,
-		Path:    path,
+		Code:            errors.ErrLockConflict,
+		Message:         msg,
+		Path:            path,
+		ConflictOwnerID: ownerID,
 	}
 }
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -405,19 +405,20 @@ func callerOwnerID(openID string, sessionID uint64) string {
 //
 // Mirrors Samba brl_conflict (source3/locking/brlock.c):
 //
-//  1. Zero-byte locks (IsZeroByte) never overlap anything.
-//  2. Read + Read → never conflict (multiple readers OK).
-//  3. Same owner (same OpenID), existing Write, new Read → no conflict
+//  1. Zero-byte + zero-byte → never conflict (regardless of offset).
+//  2. Zero-byte vs non-zero → conflict iff zero-byte offset is strictly
+//     inside the other range (Samba byte_range_overlap with last=ofs+len-1).
+//  3. Read + Read → never conflict (multiple readers OK).
+//  4. Same owner (same OpenID), existing Write, new Read → no conflict
 //     ("a read lock can stack on top of a write lock", Samba comment).
-//  4. Everything else → conflict iff ranges overlap.
+//  5. Everything else → conflict iff ranges overlap.
 //
 // Per MS-SMB2, lock ownership is per-open (per FileID), not per-session. Two
 // different opens from the same session are independent lock owners and MUST
 // conflict with each other when acquiring exclusive locks on overlapping ranges.
 func IsLockConflicting(existing, requested *FileLock) bool {
-	// Zero-byte locks never conflict with anything (SMB2 semantics).
-	// Samba brl_overlap: "zero length locks never overlap".
-	if existing.IsZeroByte || requested.IsZeroByte {
+	// Compute overlap first, including zero-byte lock semantics.
+	if !locksOverlap(existing, requested) {
 		return false
 	}
 
@@ -438,16 +439,54 @@ func IsLockConflicting(existing, requested *FileLock) bool {
 		if existing.Exclusive && !requested.Exclusive {
 			return false // SMB: read stacks on write from same open
 		}
-		return RangesOverlap(existing.Offset, existing.Length, requested.Offset, requested.Length)
-	}
-
-	// Different owner: check range overlap.
-	if !RangesOverlap(existing.Offset, existing.Length, requested.Offset, requested.Length) {
-		return false
+		// SMB same-open: exclusive+exclusive or shared+exclusive conflict
+		return true
 	}
 
 	// At least one is exclusive and ranges overlap — conflict.
 	return true
+}
+
+// locksOverlap returns true if two FileLocks have overlapping byte ranges,
+// correctly handling SMB2 zero-byte locks (IsZeroByte).
+//
+// Mirrors Samba byte_range_overlap (source3/locking/brlock.c) with
+// inclusive-end semantics: last = offset + length - 1. A zero-byte lock at
+// offset N produces an inverted range [N, N-1] that only overlaps with
+// ranges spanning strictly across N (i.e., start < N < start+length).
+//
+// Two zero-byte locks never overlap. A zero-byte lock at offset 0 never
+// overlaps anything (MS-FSA {0,0} special case).
+func locksOverlap(a, b *FileLock) bool {
+	// Two zero-byte locks never overlap each other.
+	if a.IsZeroByte && b.IsZeroByte {
+		return false
+	}
+
+	// One zero-byte, one non-zero: check if zero-byte offset is strictly
+	// inside the other range. {0, 0} never overlaps (MS-FSA special case).
+	if a.IsZeroByte || b.IsZeroByte {
+		var zb, other *FileLock
+		if a.IsZeroByte {
+			zb, other = a, b
+		} else {
+			zb, other = b, a
+		}
+
+		// {0, 0} never overlaps anything.
+		if zb.Offset == 0 {
+			return false
+		}
+
+		// Samba inclusive-end: last = offset + length - 1.
+		// For zero-byte lock: last = zb.Offset - 1 (inverted range).
+		// Overlap iff other.Offset < zb.Offset AND otherEnd > zb.Offset.
+		otherEnd := rangeEnd(other.Offset, other.Length)
+		return other.Offset < zb.Offset && otherEnd > zb.Offset
+	}
+
+	// Both non-zero-byte: standard range overlap.
+	return RangesOverlap(a.Offset, a.Length, b.Offset, b.Length)
 }
 
 // CheckIOConflict checks if an I/O operation conflicts with an existing lock.
@@ -476,6 +515,11 @@ func IsLockConflicting(existing, requested *FileLock) bool {
 //
 // Returns true if the I/O is blocked by the existing lock.
 func CheckIOConflict(existing *FileLock, openID string, sessionID uint64, offset, length uint64, isWrite bool) bool {
+	// Zero-byte locks never block I/O — they have no actual byte range.
+	if existing.IsZeroByte {
+		return false
+	}
+
 	// Check range overlap first (common case: no overlap)
 	if !RangesOverlap(existing.Offset, existing.Length, offset, length) {
 		return false
@@ -597,17 +641,23 @@ func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 		}
 	}
 
-	// Check if this exact lock already exists (same owner, offset, length)
-	// If so, update it (allows changing exclusive flag)
-	for i := range existing {
-		if lockOwnerID(&existing[i]) == lockOwnerID(&lock) &&
-			existing[i].Offset == lock.Offset &&
-			existing[i].Length == lock.Length {
-			// Update existing lock in place
-			existing[i].Exclusive = lock.Exclusive
-			existing[i].AcquiredAt = time.Now()
-			existing[i].ID = lock.ID
-			return nil
+	// NFS/NLM (OpenID empty): POSIX semantics — re-locking the same range
+	// from the same session replaces the existing lock in place.
+	// SMB (OpenID set): Windows semantics — every Lock call stacks a new
+	// entry even when (owner, offset, length, type) match. Each entry
+	// requires a separate Unlock call. Per MS-SMB2 §3.3.5.14 and Samba
+	// brl_lock_windows (source3/locking/brlock.c).
+	if lock.OpenID == "" {
+		for i := range existing {
+			if lockOwnerID(&existing[i]) == lockOwnerID(&lock) &&
+				existing[i].Offset == lock.Offset &&
+				existing[i].Length == lock.Length {
+				// Update existing lock in place (NFS/POSIX re-lock)
+				existing[i].Exclusive = lock.Exclusive
+				existing[i].AcquiredAt = time.Now()
+				existing[i].ID = lock.ID
+				return nil
+			}
 		}
 	}
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1229,18 +1229,32 @@ func TestLock_SMB_DifferentOpen_ExclusiveConflict(t *testing.T) {
 	}
 }
 
-func TestLock_SMB_ZeroByte_NeverConflicts(t *testing.T) {
+func TestLock_SMB_ZeroByte_ConflictsStrictlyInside(t *testing.T) {
 	t.Parallel()
 
 	lm := NewManager()
+	// Exclusive lock covering [0, 10) from open1.
 	normal := FileLock{SessionID: 1, OpenID: "open1", Offset: 0, Length: 10, Exclusive: true}
 	if err := lm.Lock("file1", normal); err != nil {
 		t.Fatal(err)
 	}
 
-	zb := FileLock{SessionID: 2, OpenID: "open2", Offset: 5, Length: 0, IsZeroByte: true, Exclusive: true}
-	if err := lm.Lock("file1", zb); err != nil {
-		t.Fatal("Zero-byte lock should never conflict")
+	// Zero-byte at offset 5 (strictly inside [0,10)) from different open — MUST conflict.
+	zbInside := FileLock{SessionID: 2, OpenID: "open2", Offset: 5, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zbInside); err == nil {
+		t.Fatal("Zero-byte lock at offset strictly inside existing range should conflict")
+	}
+
+	// Zero-byte at offset 10 (at boundary, NOT inside [0,10)) — no conflict.
+	zbBoundary := FileLock{SessionID: 2, OpenID: "open2", Offset: 10, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zbBoundary); err != nil {
+		t.Fatal("Zero-byte lock at range boundary should not conflict")
+	}
+
+	// Zero-byte at offset 0 — {0,0} never overlaps anything (MS-FSA).
+	zbZero := FileLock{SessionID: 2, OpenID: "open2", Offset: 0, Length: 0, IsZeroByte: true, Exclusive: true}
+	if err := lm.Lock("file1", zbZero); err != nil {
+		t.Fatal("Zero-byte lock at offset 0 should never conflict")
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 3 of smb2.lock.* conformance fixes, building on #653 (wave 2):

- **Self-conflict detection** (auto-unlock, errorcode): `mapLockConflictStatus` now detects when the blocking lock belongs to the same open and returns `LOCK_NOT_GRANTED` instead of escalating to `FILE_LOCK_CONFLICT`. Carried via new `ConflictOwnerID` field on `StoreError`.
- **Mixed lock/unlock validation** (multiple-unlock): Multi-element LOCK requests mixing locks and unlocks return `INVALID_PARAMETER` with Samba deferred-invalid semantics for unlock-then-lock ordering.
- **StatusInvalidLockRange constant** (lock): Was `0xC00000BE` (BAD_NETWORK_PATH), fixed to `0xC00001A1`.
- **Zero-byte overlap semantics** (zerobytelength): `locksOverlap()` implements Samba `byte_range_overlap` — `{N,0}` overlaps `[A,A+L)` only when `A < N < A+L`. `{0,0}` never overlaps.
- **NFS/SMB lock dedup split** (stacking): NFS (OpenID empty) replaces in place (POSIX); SMB stacks every `Lock()` call per MS-SMB2 §3.3.5.14.
- **Comment cleanup**: -111 lines of verbose comments, deduplicated test helper.

Targets: `smb2.lock.{auto-unlock, errorcode, zerobytelength, multiple-unlock, stacking, lock}`

Refs #430

## Test plan

- [x] `go test ./...` — zero failures
- [x] Code-reviewer: no critical bugs, 2 minor items addressed
- [x] Code-simplifier: -118 lines cleaned
- [ ] CI smbtorture — expect flips on target tests
- [ ] No regressions on other suites