### PR TITLE
fix(smb): reject non-binding SESSION_SETUP from unbound 3.x connection

### DIFF
--- a/internal/adapter/smb/v2/handlers/session_bind_test.go
+++ b/internal/adapter/smb/v2/handlers/session_bind_test.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 )
 
@@ -89,6 +91,69 @@ func TestSessionSetup_BindRejectsNullSession(t *testing.T) {
 	}
 	if result.Status != types.StatusNotSupported {
 		t.Fatalf("status=0x%x, want StatusNotSupported (0x%x)", result.Status, types.StatusNotSupported)
+	}
+}
+
+// TestSessionSetup_RejectsNonBindingOnUnboundConnection_SMB3 verifies that a
+// non-binding SESSION_SETUP for an existing 3.x session arriving on a
+// connection that is neither the session's origin nor a previously bound
+// channel returns STATUS_USER_SESSION_DELETED (MS-SMB2 §3.3.5.5 step 1).
+// Mirrors the assertion at smbtorture session.c:2799 in
+// test_session_bind_negative_smbXtoX after a bind has been rejected on the
+// same transport.
+func TestSessionSetup_RejectsNonBindingOnUnboundConnection_SMB3(t *testing.T) {
+	for _, dialect := range []types.Dialect{types.Dialect0300, types.Dialect0302, types.Dialect0311} {
+		t.Run(dialect.String(), func(t *testing.T) {
+			h := NewHandler()
+			sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+			sess.OriginConnID = 1 // session was created on ConnID=1
+
+			// Build a context on a different ConnID with no bound channel.
+			ctx := NewSMBHandlerContext(context.Background(),
+				"127.0.0.1:99", sess.SessionID, 0, 2)
+			ctx.ConnID = 2
+			ctx.ConnCryptoState = &mockCryptoState{dialect: dialect}
+
+			// Plain non-binding SESSION_SETUP body (no BIND flag).
+			body := buildSessionSetupRequestBody(nil)
+
+			result, err := h.SessionSetup(ctx, body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Status != types.StatusUserSessionDeleted {
+				t.Fatalf("status=0x%x, want StatusUserSessionDeleted (0x%x)", result.Status, types.StatusUserSessionDeleted)
+			}
+		})
+	}
+}
+
+// TestSessionSetup_AllowsNonBindingOnBoundChannel_SMB3 verifies the inverse —
+// a non-binding SESSION_SETUP on a connection that already holds a channel
+// for the session (e.g. for re-authentication) bypasses the cross-connection
+// gate and proceeds into the auth flow.
+func TestSessionSetup_AllowsNonBindingOnBoundChannel_SMB3(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+
+	// Register ConnID=2 as a bound channel.
+	sess.AddChannel(&session.Channel{ConnID: 2, Dialect: types.Dialect0311})
+
+	ctx := NewSMBHandlerContext(context.Background(),
+		"127.0.0.1:99", sess.SessionID, 0, 2)
+	ctx.ConnID = 2
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	body := buildSessionSetupRequestBody(nil)
+
+	result, err := h.SessionSetup(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No NTLM token + bound channel reaches the guest-session path.
+	if result.Status == types.StatusUserSessionDeleted {
+		t.Fatalf("status=StatusUserSessionDeleted, bound channel should bypass the cross-connection gate")
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -184,6 +184,27 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 				return NewErrorResult(types.StatusUserSessionDeleted), nil
 			}
 
+			// MS-SMB2 §3.3.5.5 step 1: for SMB 3.x dialects, a non-binding
+			// SESSION_SETUP that targets an existing session must arrive on a
+			// connection that already has a channel for the session (the
+			// origin connection or a previously bound channel). Otherwise the
+			// client is trying to re-authenticate on an unbound connection,
+			// which is indistinguishable from accessing a deleted session.
+			// Returning STATUS_USER_SESSION_DELETED here matches Samba
+			// (source3/smbd/smb2_sesssetup.c) and is what smbtorture's
+			// session_bind_negative_smbXtoX harness asserts at session.c:2799
+			// after the bind has already been rejected on the same transport.
+			if connDialect >= types.Dialect0300 &&
+				sess.OriginConnID != ctx.ConnID &&
+				sess.GetChannel(ctx.ConnID) == nil {
+				logger.Debug("SESSION_SETUP: SMB 3.x non-binding setup on unbound connection",
+					"sessionID", ctx.SessionID,
+					"sessionConnID", sess.OriginConnID,
+					"requestConnID", ctx.ConnID,
+					"dialect", fmt.Sprintf("0x%04x", uint16(connDialect)))
+				return NewErrorResult(types.StatusUserSessionDeleted), nil
+			}
+
 			// Re-authentication: client sends SESSION_SETUP on an existing session
 			// with no pending auth. Per MS-SMB2 3.3.5.5.2, this initiates a new
 			// authentication on the existing session (identity update).

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -481,10 +481,6 @@ TCP connections with different SMB dialect and signing/encryption combinations.
 | smb2.session.bind_negative_smb2to3d | Session binding | Multi-channel session binding not implemented | - |
 | smb2.session.bind_negative_smb3to2s | Session binding | Multi-channel session binding not implemented | - |
 | smb2.session.bind_negative_smb3to2d | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb3to3s | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb3to3d | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb3encGtoCs | Session binding | Multi-channel encryption binding not implemented | - |
-| smb2.session.bind_negative_smb3encGtoCd | Session binding | Multi-channel encryption binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoHs | Session binding | Multi-channel signing binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoHd | Session binding | Multi-channel signing binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoGs | Session binding | Multi-channel signing binding not implemented | - |


### PR DESCRIPTION
## Summary

Adds the missing MS-SMB2 §3.3.5.5 step-1 gate: for SMB 3.x, a SESSION_SETUP without the binding flag must arrive on a connection that already has a channel for the session (the origin connection or one previously bound). Otherwise the request is rejected with `STATUS_USER_SESSION_DELETED`.

Previously this check only covered SMB 2.x (per-connection scope). 3.x non-binding setups on unbound connections fell through to the re-auth path and returned `STATUS_SUCCESS`.

## Why this matters

smbtorture's negative-bind harness (`test_session_bind_negative_smbXtoX` in `source4/torture/smb2/session.c`) probes a fresh channel without the BIND flag at line 2799 after a bind has already been rejected on the same transport, expecting `STATUS_USER_SESSION_DELETED`. The 4 line-2799 failures on develop are:

- `smb2.session.bind_negative_smb3to3s` / `smb3to3d`
- `smb2.session.bind_negative_smb3encGtoCs` / `smb3encGtoCd`

Refs #483, #361 Phase 2.

## Spec / reference

- MS-SMB2 §3.3.5.5 step 1 — SMB 3.x session lookup honors per-connection channel binding
- Samba: `source3/smbd/smb2_sesssetup.c` (`smbd_smb2_session_setup_recv`)

## Test plan

- [x] Unit tests added — `TestSessionSetup_RejectsNonBindingOnUnboundConnection_SMB3` (3.0/3.0.2/3.1.1) + `TestSessionSetup_AllowsNonBindingOnBoundChannel_SMB3` covering the gate and its bypass.
- [x] Full `go test ./...` clean (race-free).
- [ ] CI smbtorture confirms 4 tests flip (`bind_negative_smb3to3{s,d}`, `bind_negative_smb3encGtoC{s,d}`).
- [ ] No regressions on currently-passing `smb2.session.*` tests.

`KNOWN_FAILURES.md` walkback will follow in a separate commit once CI confirms the flips.