### PR TITLE
fix(smb): durable handle V1 reconnect plumbing (#431)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -579,16 +579,23 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 			restored := reconnResult.OpenFile
 
 			// Reconnect succeeded: register the restored OpenFile.
-			// Per MS-SMB2 3.3.5.9.7: keep the persistent FileId (bytes 0-7)
-			// but regenerate the volatile FileId (bytes 8-15) so it is unique
-			// on this connection.  The old volatile part is stale after the
-			// server restart / disconnect.
+			// Per MS-SMB2 3.3.5.9.7: the server returns the original Open.FileId.
+			// We restore both halves (persistent + volatile) from the persisted
+			// OriginalFileID so the OpenID derived from FileID matches any
+			// byte-range locks taken before disconnect — UNLOCK after reconnect
+			// on the same volatile would otherwise fail with RANGE_NOT_LOCKED
+			// (smb2.durable-open.lock-{oplock,lease}). For older persisted
+			// handles written before OriginalFileID existed, the restore path
+			// already falls back to the volatile-zeroed FileID; regenerate the
+			// volatile half in that fallback case so the FileID is still unique
+			// on this connection.
 			restored.TreeID = ctx.TreeID
 			restored.SessionID = ctx.SessionID
 			smbFileID := restored.FileID
-			// Regenerate volatile part (bytes 8-15)
-			_, _ = rand.Read(smbFileID[8:16])
-			restored.FileID = smbFileID
+			if reconnResult.OriginalFileID == ([16]byte{}) {
+				_, _ = rand.Read(smbFileID[8:16])
+				restored.FileID = smbFileID
+			}
 
 			// Re-grant durability on reconnect. The handle was durable before
 			// disconnect, and the successful reconnect implicitly restores it.

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -221,6 +221,11 @@ type ReconnectResult struct {
 	OpenFile       *OpenFile // Restored open file state
 	PersistedLease uint32    // Lease state at disconnect time (for re-granting)
 	IsV2           bool      // True if DH2C (V2), false if DHnC (V1)
+	// OriginalFileID is the full 16-byte FileID captured at first CREATE
+	// (zero for handles persisted before the field was introduced). Callers
+	// use this to decide whether to regenerate the volatile half of the
+	// FileID on reconnect; see create.go reconnect path.
+	OriginalFileID [16]byte
 }
 
 // ProcessDurableReconnectContext processes DHnC or DH2C create contexts for reconnection.
@@ -240,21 +245,21 @@ func ProcessDurableReconnectContext(
 
 	// Determine V2 (DH2C) or V1 (DHnC) reconnect
 	if dh2cCtx := FindCreateContext(contexts, DurableHandleV2ReconnectTag); dh2cCtx != nil {
-		openFile, leaseState, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
+		openFile, leaseState, origID, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
 			sessionID, username, sessionKeyHash, shareName, filename)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
-		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: true}, types.StatusSuccess, nil
+		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: true, OriginalFileID: origID}, types.StatusSuccess, nil
 	}
 
 	if dhnCCtx := FindCreateContext(contexts, DurableHandleV1ReconnectTag); dhnCCtx != nil {
-		openFile, leaseState, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
+		openFile, leaseState, origID, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
 			sessionID, username, sessionKeyHash, shareName, filename)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
-		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: false}, types.StatusSuccess, nil
+		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: false, OriginalFileID: origID}, types.StatusSuccess, nil
 	}
 
 	// No reconnect context found
@@ -274,12 +279,12 @@ func processV1Reconnect(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
-) (*OpenFile, uint32, types.Status, error) {
+) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V1 reconnect context
 	fileID, err := DecodeDHnCReconnect(dhnCCtx.Data)
 	if err != nil {
 		logger.Debug("processV1Reconnect: invalid DHnC data", "error", err)
-		return nil, 0, types.StatusInvalidParameter, nil
+		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	logger.Debug("processV1Reconnect: starting validation",
@@ -292,25 +297,25 @@ func processV1Reconnect(
 	if FindCreateContext(contexts, DurableHandleV2RequestTag) != nil ||
 		FindCreateContext(contexts, DurableHandleV2ReconnectTag) != nil {
 		logger.Debug("processV1Reconnect: check 2 FAIL - conflicting V2 context present")
-		return nil, 0, types.StatusInvalidParameter, nil
+		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// Look up persisted handle by FileID
 	handle, err := durableStore.GetDurableHandleByFileID(ctx, fileID)
 	if err != nil {
 		logger.Warn("processV1Reconnect: store error", "error", err)
-		return nil, 0, types.StatusInternalError, err
+		return nil, 0, [16]byte{}, types.StatusInternalError, err
 	}
 	if handle == nil {
 		logger.Debug("processV1Reconnect: check 3 FAIL - handle not found by FileID",
 			"fileID", fmt.Sprintf("%x", fileID))
-		return nil, 0, types.StatusObjectNameNotFound, nil
+		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// V1 reconnect does not carry DesiredAccess/ShareAccess in the context
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
 		sessionKeyHash, shareName, filename, 0, 0)
-	return openFile, handle.LeaseState, status, restoreErr
+	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
 }
 
 // processV2Reconnect handles V2 (DH2C) reconnect validation and restoration.
@@ -326,18 +331,18 @@ func processV2Reconnect(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
-) (*OpenFile, uint32, types.Status, error) {
+) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V2 reconnect context
 	fileID, createGuid, flags, err := DecodeDH2CReconnect(dh2cCtx.Data)
 	if err != nil {
 		logger.Debug("processV2Reconnect: invalid DH2C data", "error", err)
-		return nil, 0, types.StatusInvalidParameter, nil
+		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// Reject persistent flag
 	if flags&DH2FlagPersistent != 0 {
 		logger.Debug("processV2Reconnect: persistent flag rejected")
-		return nil, 0, types.StatusInvalidParameter, nil
+		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	logger.Debug("processV2Reconnect: starting validation",
@@ -350,12 +355,12 @@ func processV2Reconnect(
 	handle, err := durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 	if err != nil {
 		logger.Warn("processV2Reconnect: store error", "error", err)
-		return nil, 0, types.StatusInternalError, err
+		return nil, 0, [16]byte{}, types.StatusInternalError, err
 	}
 	if handle == nil {
 		logger.Debug("processV2Reconnect: handle not found by CreateGuid",
 			"createGuid", fmt.Sprintf("%x", createGuid))
-		return nil, 0, types.StatusObjectNameNotFound, nil
+		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// Validate FileID from DH2C against persisted handle to prevent wrong-handle reconnect
@@ -363,13 +368,13 @@ func processV2Reconnect(
 		logger.Debug("processV2Reconnect: FileID mismatch",
 			"expected", fmt.Sprintf("%x", handle.FileID),
 			"actual", fmt.Sprintf("%x", fileID))
-		return nil, 0, types.StatusInvalidParameter, nil
+		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// V2 reconnect does not carry DesiredAccess/ShareAccess in DH2C context either
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
 		sessionKeyHash, shareName, filename, 0, 0)
-	return openFile, handle.LeaseState, status, restoreErr
+	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
 }
 
 // validateAndRestore runs the shared reconnect validation checks and restores the OpenFile.
@@ -459,8 +464,19 @@ func validateAndRestore(
 		"path", handle.Path,
 		"shareName", handle.ShareName)
 
+	// Prefer the OriginalFileID (full 16 bytes captured at first CREATE) so
+	// the restored OpenFile's OpenID matches the byte-range lock owner that
+	// was created before disconnect (smb2.durable-open.lock-{oplock,lease}).
+	// Older persisted handles written before this field existed decode with
+	// OriginalFileID == 0 — fall back to handle.FileID (volatile-zeroed) in
+	// that case so we remain forward-compatible across the upgrade boundary.
+	restoreFileID := handle.OriginalFileID
+	if restoreFileID == ([16]byte{}) {
+		restoreFileID = handle.FileID
+	}
+
 	restored := &OpenFile{
-		FileID:        handle.FileID,
+		FileID:        restoreFileID,
 		SessionID:     sessionID,
 		Path:          handle.Path,
 		ShareName:     handle.ShareName,
@@ -493,6 +509,7 @@ func validateAndRestore(
 		ParentHandle:   handle.ParentHandle,
 		FileName:       handle.FileName,
 		IsDirectory:    handle.IsDirectory,
+		PositionInfo:   handle.PositionInfo,
 		// IsDurable is NOT set on restore -- client must re-request durability
 	}
 
@@ -642,5 +659,7 @@ func buildPersistedDurableHandle(
 		ParentHandle:    parentHandle,
 		FileName:        openFile.FileName,
 		IsDirectory:     openFile.IsDirectory,
+		PositionInfo:    openFile.PositionInfo,
+		OriginalFileID:  openFile.FileID,
 	}
 }

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -892,3 +892,138 @@ func TestProcessAppInstanceId_ForceClosesOldHandles(t *testing.T) {
 		t.Error("Expected old-002 to be deleted")
 	}
 }
+
+// TestProcessDurableReconnectContext_OriginalFileIDRestored locks in the
+// contract added in #661: when a durable handle was persisted by the
+// updated handler, OriginalFileID carries the full 16-byte FileID from the
+// original CREATE response. validateAndRestore MUST use OriginalFileID for
+// the new OpenFile so byte-range locks (which key on OpenID derived from
+// FileID) stay valid across the durable disconnect. Required for
+// smb2.durable-open.lock-{oplock,lease}.
+func TestProcessDurableReconnectContext_OriginalFileIDRestored(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	// DHnC lookup uses volatile-zeroed FileID; OriginalFileID retains full bytes
+	persistentFileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
+	originalFileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22}
+	keyHash := makeSessionKeyHash("session-key-orig")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-orig",
+		FileID:         persistentFileID,
+		OriginalFileID: originalFileID,
+		Path:           "lockfile.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xCA, 0xFE},
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData, persistentFileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "lockfile.txt")
+	if err != nil || status != types.StatusSuccess {
+		t.Fatalf("reconnect: status=%s err=%v", status, err)
+	}
+	if res.OpenFile.FileID != originalFileID {
+		t.Errorf("restored FileID = %x, want %x (OriginalFileID)", res.OpenFile.FileID, originalFileID)
+	}
+	if res.OriginalFileID != originalFileID {
+		t.Errorf("ReconnectResult.OriginalFileID = %x, want %x", res.OriginalFileID, originalFileID)
+	}
+}
+
+// TestProcessDurableReconnectContext_OriginalFileIDFallback covers the
+// upgrade-boundary case: a handle persisted before OriginalFileID existed
+// decodes with OriginalFileID == 0. validateAndRestore MUST fall back to
+// handle.FileID (volatile-zeroed) so old handles still reconnect; the
+// create.go reconnect path then regenerates the volatile half (#661).
+func TestProcessDurableReconnectContext_OriginalFileIDFallback(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	persistentFileID := [16]byte{9, 9, 9, 9, 9, 9, 9, 9, 0, 0, 0, 0, 0, 0, 0, 0}
+	keyHash := makeSessionKeyHash("session-key-old")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:     "dh-legacy",
+		FileID: persistentFileID,
+		// OriginalFileID intentionally zero (pre-#661 handle)
+		Path:           "legacy.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData, persistentFileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "legacy.txt")
+	if err != nil || status != types.StatusSuccess {
+		t.Fatalf("reconnect: status=%s err=%v", status, err)
+	}
+	if res.OpenFile.FileID != persistentFileID {
+		t.Errorf("legacy restore FileID = %x, want %x (handle.FileID fallback)",
+			res.OpenFile.FileID, persistentFileID)
+	}
+	if res.OriginalFileID != ([16]byte{}) {
+		t.Errorf("ReconnectResult.OriginalFileID = %x, want zero", res.OriginalFileID)
+	}
+}
+
+// TestProcessDurableReconnectContext_PositionInfoRestored locks in the
+// FilePositionInformation persistence added in #661 — required so
+// smb2.durable-open.file-position survives reconnect.
+func TestProcessDurableReconnectContext_PositionInfoRestored(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{0xFE, 0xED, 0xFA, 0xCE, 0xBE, 0xEF, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0}
+	keyHash := makeSessionKeyHash("session-key-pos")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-pos",
+		FileID:         fileID,
+		Path:           "position.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xAA},
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		PositionInfo:   0x1000,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData, fileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "position.txt")
+	if err != nil || status != types.StatusSuccess {
+		t.Fatalf("reconnect: status=%s err=%v", status, err)
+	}
+	if res.OpenFile.PositionInfo != 0x1000 {
+		t.Errorf("restored PositionInfo = 0x%x, want 0x1000", res.OpenFile.PositionInfo)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -394,6 +394,13 @@ type OpenFile struct {
 	// The handle expires this many milliseconds after client disconnects.
 	DurableTimeoutMs uint32
 
+	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
+	// (MS-FSCC 2.4.32). Servers track this per-handle so SET/GET via
+	// FilePositionInformation round-trips even though network filesystems
+	// do not use it for I/O dispatch. Preserved across durable handle
+	// disconnect/reconnect (smb2.durable-open.file-position).
+	PositionInfo uint64
+
 	// NotifyOverflowed is the sticky overflow flag for SMB2 CHANGE_NOTIFY on
 	// this directory handle. Set when a notify completes with
 	// STATUS_NOTIFY_ENUM_DIR because the encoded change list exceeds the
@@ -743,7 +750,19 @@ func (h *Handler) closeFilesWithFilter(
 		// disconnect (not an explicit LOGOFF), persist the handle to the
 		// DurableHandleStore for later reconnection. On explicit LOGOFF the client
 		// is intentionally closing the session, so durable handles are fully closed.
-		if openFile.IsDurable && h.DurableStore != nil && isDisconnect {
+		//
+		// Refuse to persist if the handle requested FILE_DELETE_ON_CLOSE at CREATE
+		// time or marked DeletePending later via FileDispositionInformation. This
+		// mirrors Samba `vfs_default_durable_disconnect` (source3/smbd/durable.c):
+		// the disconnect path returns NT_STATUS_NOT_SUPPORTED for delete-on-close
+		// opens so the caller falls back to normal close and executes the delete.
+		// Required for smb2.durable-open.delete_on_close1 — without this, the
+		// file persists across the disconnect and a subsequent fresh CREATE sees
+		// the stale content instead of a freshly-created empty file. The matching
+		// delete_on_close2 test stays in KNOWN_FAILURES (same as Samba upstream).
+		hasDeleteOnClose := openFile.CreateOptions&types.FileDeleteOnClose != 0 ||
+			openFile.DeletePending
+		if openFile.IsDurable && h.DurableStore != nil && isDisconnect && !hasDeleteOnClose {
 			username := ""
 			var sessionKeyHash [32]byte
 			if sess != nil {

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -620,7 +620,10 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FilePositionInformation:
 		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.32 (8 bytes)
-		return make([]byte, 8), nil // CurrentByteOffset = 0 (server doesn't track position)
+		// Round-trip the per-handle CurrentByteOffset (see set_info.go).
+		w := smbenc.NewWriter(8)
+		w.WriteUint64(openFile.PositionInfo)
+		return w.Bytes(), nil
 
 	case types.FileModeInformation:
 		// FILE_MODE_INFORMATION [MS-FSCC] 2.4.24 (4 bytes)
@@ -756,7 +759,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	w.WriteUint64(fileIndex)              // InternalInformation (8 bytes) at offset 64
 	w.WriteUint32(0)                      // EaInformation (4 bytes) at offset 72
 	w.WriteUint32(openFile.GrantedAccess) // AccessInformation (4 bytes) at offset 76 — see FileAccessInformation
-	w.WriteUint64(0)                      // PositionInformation (8 bytes) at offset 80
+	w.WriteUint64(openFile.PositionInfo)  // PositionInformation (8 bytes) at offset 80
 	w.WriteUint32(0)                      // ModeInformation (4 bytes) at offset 88
 	w.WriteUint32(0)                      // AlignmentInformation (4 bytes) at offset 92
 	w.WriteUint32(uint32(len(nameBytes))) // NameInformation length at offset 96

--- a/internal/adapter/smb/v2/handlers/query_info_test.go
+++ b/internal/adapter/smb/v2/handlers/query_info_test.go
@@ -403,6 +403,67 @@ func TestFileAllInformation_AccessInformationReturnsGrantedAccess(t *testing.T) 
 	}
 }
 
+// TestFilePositionInformation_RoundTrip locks in the contract added in #661:
+// SET_INFO FilePositionInformation stores the CurrentByteOffset on OpenFile,
+// and QUERY_INFO must echo the same value both via the dedicated class and
+// via the FileAllInformation embedded PositionInformation block at offset 80.
+// Required so smb2.durable-open.file-position survives across reconnect.
+func TestFilePositionInformation_RoundTrip(t *testing.T) {
+	h := NewHandler()
+	file := &metadata.File{
+		ID: uuid.New(),
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Size: 0,
+		},
+	}
+	openFile := &OpenFile{
+		FileName: "test.txt",
+		Path:     "test.txt",
+	}
+	authCtx := &metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}}
+
+	// Drive the full SET → QUERY round-trip through the actual handlers so
+	// the regression covers the in-memory OpenFile mutation, not just the
+	// query encoding.
+	setBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(setBuf, 0x1000)
+	resp, err := h.setFileInfoFromStore(authCtx, openFile, types.FilePositionInformation, setBuf)
+	if err != nil {
+		t.Fatalf("SET FilePositionInformation: unexpected error: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("SET FilePositionInformation status = %s, want SUCCESS", resp.Status)
+	}
+	if openFile.PositionInfo != 0x1000 {
+		t.Errorf("openFile.PositionInfo after SET = 0x%x, want 0x1000", openFile.PositionInfo)
+	}
+
+	// Dedicated FilePositionInformation class returns the 8-byte offset
+	info, err := h.buildFileInfoFromStore(authCtx, file, openFile, types.FilePositionInformation)
+	if err != nil {
+		t.Fatalf("FilePositionInformation: unexpected error: %v", err)
+	}
+	if len(info) != 8 {
+		t.Fatalf("FilePositionInformation info length = %d, want 8", len(info))
+	}
+	if got := binary.LittleEndian.Uint64(info); got != 0x1000 {
+		t.Errorf("FilePositionInformation = 0x%x, want 0x1000", got)
+	}
+
+	// FileAllInformation embeds the same value at offset 80
+	all, err := h.buildFileInfoFromStore(authCtx, file, openFile, types.FileAllInformation)
+	if err != nil {
+		t.Fatalf("FileAllInformation: unexpected error: %v", err)
+	}
+	if len(all) < 88 {
+		t.Fatalf("FileAllInformation length = %d, want >= 88", len(all))
+	}
+	if got := binary.LittleEndian.Uint64(all[80:88]); got != 0x1000 {
+		t.Errorf("FileAllInformation PositionInformation @ offset 80 = 0x%x, want 0x1000", got)
+	}
+}
+
 func TestResolveAccessFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -219,7 +219,13 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 			logger.Info("SESSION_SETUP: tearing down previous session",
 				"previousSessionID", req.PreviousSessionID)
 			prevSess.LoggedOff.Store(true)
-			h.CloseAllFilesForSession(ctx.Context, req.PreviousSessionID, false)
+			// Treat PreviousSessionID supersession as a transport disconnect for
+			// durable-handle purposes: per MS-SMB2 3.3.5.5.3 / 3.3.5.9.7, the
+			// new session inherits the right to reconnect the prior session's
+			// durable handles via DHnC/DH2C. Closing with isDisconnect=false
+			// would prematurely tear down the open and break the lease-backed
+			// durable reopen paths (smb2.durable-open.reopen1a*).
+			h.CloseAllFilesForSession(ctx.Context, req.PreviousSessionID, true)
 			h.releaseSessionLeasesAndNotifies(ctx.Context, req.PreviousSessionID)
 			h.DeleteAllTreesForSession(req.PreviousSessionID)
 			h.DeleteAllPendingAuthForSession(req.PreviousSessionID)

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1090,8 +1090,11 @@ func (h *Handler) setFileInfoFromStore(
 		if len(buffer) < 8 {
 			return setInfoStatus(types.StatusInfoLengthMismatch), nil
 		}
-		// Server-side position tracking is not required for network filesystems.
-		// Accept and succeed as a no-op (SMB clients manage their own offsets).
+		// Network filesystems do not use the server-side position for I/O
+		// dispatch (READ/WRITE carry explicit offsets), but the value must
+		// round-trip through SET/GET FilePositionInformation and survive
+		// durable-handle reconnect (smb2.durable-open.file-position).
+		openFile.PositionInfo = smbenc.NewReader(buffer[:8]).ReadUint64()
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileAllocationInformation:

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -49,6 +49,20 @@ type PersistedDurableHandle struct {
 	ParentHandle  []byte // Parent directory handle for deletion
 	FileName      string // File name within parent for deletion
 	IsDirectory   bool   // Whether the file is a directory
+
+	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
+	// (MS-FSCC 2.4.32) captured at disconnect. Restored to the OpenFile
+	// on reconnect so SET/GET FilePositionInformation round-trips across
+	// the disconnect (smb2.durable-open.file-position).
+	PositionInfo uint64
+
+	// OriginalFileID is the full 16-byte FileID (persistent + volatile)
+	// from the original CREATE response. FileID above zeros the volatile
+	// half so DHnC lookup matches the spec ([MS-SMB2] 3.2.4.4: client
+	// sends Data.Volatile=0). On successful reconnect the handler restores
+	// OriginalFileID into the new OpenFile so byte-range locks (which key
+	// on OpenID derived from FileID) stay valid across the disconnect.
+	OriginalFileID [16]byte
 }
 
 // DurableHandleStore provides persistence for SMB3 durable handle state.

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -230,9 +230,15 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 		DisconnectedAt:  h.DisconnectedAt,
 		TimeoutMs:       h.TimeoutMs,
 		ServerStartTime: h.ServerStartTime,
+		DeletePending:   h.DeletePending,
+		FileName:        h.FileName,
+		IsDirectory:     h.IsDirectory,
+		PositionInfo:    h.PositionInfo,
+		OriginalFileID:  h.OriginalFileID,
 	}
 
 	clone.MetadataHandle = bytes.Clone(h.MetadataHandle)
+	clone.ParentHandle = bytes.Clone(h.ParentHandle)
 
 	return clone
 }


### PR DESCRIPTION
## Summary

Wave-2 SMB conformance fix for durable handles V1 (#431). Four targeted fixes to the disconnect/reconnect path:

1. **Lock preservation across reconnect** — persist the full 16-byte original FileID (volatile included) and restore it on reconnect so the per-handle `OpenID` derived from FileID stays stable. Without this, byte-range locks taken before disconnect become orphaned; UNLOCK after reconnect fails with `RANGE_NOT_LOCKED`. Targets `smb2.durable-open.lock-oplock` and `lock-lease`.
2. **File position round-trip** — track `FILE_POSITION_INFORMATION.CurrentByteOffset` per-handle, persist it on disconnect, restore on reconnect. `set_info` now stores it; `query_info` returns it (both the dedicated class and `FileAllInformation`). Targets `smb2.durable-open.file-position`.
3. **DELETE_ON_CLOSE handling** — refuse to persist if the open was created with `FILE_DELETE_ON_CLOSE` or later marked `DeletePending` via `FileDispositionInformation`. The handle falls through to normal close so the delete fires immediately. Mirrors Samba `vfs_default_durable_disconnect` (`source3/smbd/durable.c`). Targets `smb2.durable-open.delete_on_close1`.
4. **Session supersession via PreviousSessionID** — when a new SESSION_SETUP supersedes a prior session, treat the implicit teardown as a transport disconnect so the new session can DHnC-reconnect the prior session's durable handles. Targets `smb2.durable-open.reopen1a*`.

`PositionInfo` and `OriginalFileID` added to `PersistedDurableHandle`; memory backend's `cloneDurableHandle` wired through (and picked up missing `DeletePending`/`ParentHandle`/`FileName`/`IsDirectory` fields along the way). Badger uses JSON marshalling so it picks them up automatically. Postgres schema migration deferred — conformance CI runs on memory + badger profiles.

## Spec references

- MS-SMB2 §3.3.5.9.7 (durable reopen)
- MS-SMB2 §3.3.5.5.3 (PreviousSessionID supersession)
- MS-SMB2 §3.3.4.18 (disconnected handle state machine)
- Samba `source3/smbd/durable.c::vfs_default_durable_disconnect`

## Out of scope

`smb2.durable-open.delete_on_close2` stays in KNOWN_FAILURES — it's also in Samba's upstream `selftest/knownfail` (the test expects durable reconnect to succeed for a DELETE_ON_CLOSE-flagged open, which contradicts the disconnect-refusal Samba implements). Tracking parity with Samba upstream.

`smb2.durable-open.reopen2*` (raw transport disconnect + DHnC reconnect) likely needs additional lease coordination work to flip — that's the next bite at #431 after CI confirms what this PR's surface flips.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -s -w .` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/adapter/smb/... ./pkg/metadata/...` green
- [ ] CI smbtorture run confirms DH V1 flip count
- [ ] No regression in `smb2.durable-open.reopen1` (currently passing) or other adjacent tests