### PR TITLE
fix(smb): query/set info advanced scenarios (#481)

### DIFF
--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -541,6 +541,7 @@ const (
 	FileNamesInformation           FileInfoClass = 12
 	FileDispositionInformation     FileInfoClass = 13
 	FilePositionInformation        FileInfoClass = 14
+	FileFullEaInformation          FileInfoClass = 15
 	FileModeInformation            FileInfoClass = 16
 	FileAlignmentInformation       FileInfoClass = 17
 	FileAllInformation             FileInfoClass = 18

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -838,7 +838,10 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		}
 	}
 
-	existingFile, lookupErr := metaSvc.Lookup(authCtx, parentHandle, baseName)
+	// Case-insensitive baseName resolution mirrors Windows/NTFS open semantics
+	// (smbtorture `smb2.getinfo.normalized`). Falls through to the exact-name
+	// fast path when present; only scans the parent dir on miss.
+	existingFile, lookupErr := h.lookupCaseInsensitive(authCtx, parentHandle, baseName)
 	fileExists := (lookupErr == nil)
 
 	// Debug logging to trace file type issues in Lookup
@@ -1324,7 +1327,7 @@ func (h *Handler) walkPath(
 			continue
 		}
 
-		file, err := metaSvc.Lookup(authCtx, currentHandle, part)
+		file, err := h.lookupCaseInsensitive(authCtx, currentHandle, part)
 		if err != nil {
 			return nil, err
 		}
@@ -1343,6 +1346,53 @@ func (h *Handler) walkPath(
 	}
 
 	return currentHandle, nil
+}
+
+// lookupCaseInsensitive performs a case-sensitive Lookup first (fast path).
+// On NotFound, it falls back to enumerating the parent directory and matching
+// the name case-insensitively, mirroring Windows/NTFS semantics required by
+// `smb2.getinfo.normalized` and the broader SMB protocol contract. The
+// fast-path keeps the common case (exact name) at one map lookup; the fallback
+// is only paid when the exact name miss occurs.
+func (h *Handler) lookupCaseInsensitive(
+	authCtx *metadata.AuthContext,
+	dirHandle metadata.FileHandle,
+	name string,
+) (*metadata.File, error) {
+	metaSvc := h.Registry.GetMetadataService()
+
+	if file, err := metaSvc.Lookup(authCtx, dirHandle, name); err == nil {
+		return file, nil
+	} else if !metadata.IsNotFoundError(err) {
+		return nil, err
+	}
+
+	// Fallback: case-insensitive scan. ReadDirectory enforces traverse +
+	// read permission on the directory, matching what Lookup would have
+	// required; an EqualFold match is converted back into a Lookup by the
+	// resolved canonical name so any per-child permission semantics
+	// (DACL, traverse) still flow through the standard path. Page through
+	// the directory in case it has more than the per-call default limit.
+	notFound := &metadata.StoreError{Code: metadata.ErrNotFound, Message: "child not found"}
+	cookie := uint64(0)
+	for {
+		page, err := metaSvc.ReadDirectory(authCtx, dirHandle, cookie, 0)
+		if err != nil {
+			// Surface the original NotFound rather than a permission error here:
+			// if ReadDirectory denies, the caller almost certainly hit a deny
+			// ACE that would have triggered on the case-sensitive Lookup too.
+			return nil, notFound
+		}
+		for _, e := range page.Entries {
+			if strings.EqualFold(e.Name, name) {
+				return metaSvc.Lookup(authCtx, dirHandle, e.Name)
+			}
+		}
+		if !page.HasMore {
+			return nil, notFound
+		}
+		cookie = page.NextCookie
+	}
 }
 
 // createNewFile creates a new file or directory in the metadata store.

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -1366,27 +1367,32 @@ func (h *Handler) lookupCaseInsensitive(
 ) (*metadata.File, error) {
 	metaSvc := h.Registry.GetMetadataService()
 
-	if file, err := metaSvc.Lookup(authCtx, dirHandle, name); err == nil {
-		return file, nil
-	} else if !metadata.IsNotFoundError(err) {
-		return nil, err
+	lookupFile, lookupErr := metaSvc.Lookup(authCtx, dirHandle, name)
+	if lookupErr == nil {
+		return lookupFile, nil
+	}
+	if !metadata.IsNotFoundError(lookupErr) {
+		return nil, lookupErr
 	}
 
-	// Fallback: case-insensitive scan. ReadDirectory enforces traverse +
-	// read permission on the directory, matching what Lookup would have
-	// required; an EqualFold match is converted back into a Lookup by the
-	// resolved canonical name so any per-child permission semantics
-	// (DACL, traverse) still flow through the standard path. Page through
-	// the directory in case it has more than the per-call default limit.
-	notFound := &metadata.StoreError{Code: metadata.ErrNotFound, Message: "child not found"}
+	// Fallback: case-insensitive scan. ReadDirectory needs traverse + read on
+	// the parent (Lookup only needed traverse); on AccessDenied we surface the
+	// original NotFound from Lookup so traverse-only callers see exactly what
+	// they used to. An EqualFold match is re-resolved via Lookup so per-child
+	// permission semantics (DACL, traverse) still flow through the standard
+	// path. Page through the directory in case it has more than the per-call
+	// default limit.
 	cookie := uint64(0)
 	for {
 		page, err := metaSvc.ReadDirectory(authCtx, dirHandle, cookie, 0)
 		if err != nil {
-			// Surface the original NotFound rather than a permission error here:
-			// if ReadDirectory denies, the caller almost certainly hit a deny
-			// ACE that would have triggered on the case-sensitive Lookup too.
-			return nil, notFound
+			var se *metadata.StoreError
+			if errors.As(err, &se) && se.Code == metadata.ErrAccessDenied {
+				// Traverse-only callers couldn't have enumerated either; preserve
+				// the prior Lookup-only behavior by returning the original NotFound.
+				return nil, lookupErr
+			}
+			return nil, err
 		}
 		for _, e := range page.Entries {
 			if strings.EqualFold(e.Name, name) {
@@ -1394,7 +1400,7 @@ func (h *Handler) lookupCaseInsensitive(
 			}
 		}
 		if !page.HasMore {
-			return nil, notFound
+			return nil, lookupErr
 		}
 		cookie = page.NextCookie
 	}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -514,26 +514,19 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// Strip NTFS stream suffixes. The default data stream (::$DATA) and
 	// directory index (::$INDEX_ALLOCATION) are implicit and should not be
 	// part of the actual filename stored in the metadata store.
-	//
-	// For named alternate data streams (e.g. ":streamName" or
-	// ":streamName:$DATA"), strip a trailing ":$DATA" type qualifier so
-	// equivalent forms collapse to the same metadata key. Per MS-FSCC
-	// 2.1.5, `:streamName` and `:streamName:$DATA` reference the same
-	// stream; smbtorture `smb2.getinfo.normalized` (getinfo.c:309) opens
-	// streams in both forms and expects them to resolve to the same handle.
 	if idx := strings.Index(filename, ":"); idx >= 0 {
 		streamSuffix := filename[idx:]
 		basePath := filename[:idx]
 		upperSuffix := strings.ToUpper(streamSuffix)
-		switch {
-		case upperSuffix == "::$DATA", upperSuffix == "::$INDEX_ALLOCATION":
+		if upperSuffix == "::$DATA" || upperSuffix == "::$INDEX_ALLOCATION" {
 			filename = basePath
-		case strings.HasSuffix(upperSuffix, ":$DATA"):
-			// Named ADS with explicit type qualifier — strip the trailing
-			// ":$DATA" (case-insensitive on the qualifier, length matches
-			// `upperSuffix` byte-for-byte since the suffix is ASCII).
-			filename = basePath + streamSuffix[:len(streamSuffix)-len(":$DATA")]
 		}
+		// Other stream names (alternate data streams) are kept as-is.
+		// Named ADS with explicit ":$DATA" type qualifier is left intact:
+		// `:stream` and `:stream:$DATA` storage paths stay distinct, matching
+		// the rest of the pipeline (FileStreamInformation, ChangeNotify) that
+		// emits the stored name on the wire. Collapsing them here without
+		// re-appending `:$DATA` downstream regressed WPTS BVT ADS tests.
 	}
 
 	// Reject paths that traverse above the share root (e.g., "../../..")

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -514,14 +514,26 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// Strip NTFS stream suffixes. The default data stream (::$DATA) and
 	// directory index (::$INDEX_ALLOCATION) are implicit and should not be
 	// part of the actual filename stored in the metadata store.
+	//
+	// For named alternate data streams (e.g. ":streamName" or
+	// ":streamName:$DATA"), strip a trailing ":$DATA" type qualifier so
+	// equivalent forms collapse to the same metadata key. Per MS-FSCC
+	// 2.1.5, `:streamName` and `:streamName:$DATA` reference the same
+	// stream; smbtorture `smb2.getinfo.normalized` (getinfo.c:309) opens
+	// streams in both forms and expects them to resolve to the same handle.
 	if idx := strings.Index(filename, ":"); idx >= 0 {
 		streamSuffix := filename[idx:]
 		basePath := filename[:idx]
 		upperSuffix := strings.ToUpper(streamSuffix)
-		if upperSuffix == "::$DATA" || upperSuffix == "::$INDEX_ALLOCATION" {
+		switch {
+		case upperSuffix == "::$DATA", upperSuffix == "::$INDEX_ALLOCATION":
 			filename = basePath
+		case strings.HasSuffix(upperSuffix, ":$DATA"):
+			// Named ADS with explicit type qualifier — strip the trailing
+			// ":$DATA" (case-insensitive on the qualifier, length matches
+			// `upperSuffix` byte-for-byte since the suffix is ASCII).
+			filename = basePath + streamSuffix[:len(streamSuffix)-len(":$DATA")]
 		}
-		// Other stream names (alternate data streams) are kept as-is
 	}
 
 	// Reject paths that traverse above the share root (e.g., "../../..")

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -390,7 +390,14 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported}}, nil
 	}
 
-	// Truncate if necessary
+	// Truncate if necessary.
+	//
+	// Per MS-SMB2 §3.3.5.20.1, when the response data exceeds OutputBufferLength
+	// but the fixed portion fits, the server returns the truncated bytes with
+	// STATUS_BUFFER_OVERFLOW (matches Samba `smbd_smb2_getinfo_send`). The
+	// fixed-portion-too-small case (data_size < fixed_portion) is already
+	// rejected with STATUS_INFO_LENGTH_MISMATCH in Step 3 above.
+	overflowStatus := types.StatusSuccess
 	if uint32(len(info)) > req.OutputBufferLength {
 		// Security descriptors are atomic — partial SD is invalid.
 		// MS-SMB2 §3.3.5.20.3: return STATUS_BUFFER_TOO_SMALL.
@@ -399,6 +406,7 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 		}
 
 		info = info[:req.OutputBufferLength]
+		overflowStatus = types.StatusBufferOverflow
 
 		// For FILE_ALL_INFORMATION, the FileNameLength field at offset 96
 		// must be updated to reflect the actual available bytes after truncation.
@@ -418,7 +426,7 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// ========================================================================
 
 	return &QueryInfoResponse{
-		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		SMBResponseBase: SMBResponseBase{Status: overflowStatus},
 		Data:            info,
 	}, nil
 }
@@ -667,9 +675,19 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileNormalizedNameInformation:
 		// FILE_NORMALIZED_NAME_INFORMATION [MS-FSCC] 2.4.28 (4 bytes + variable)
-		// Returns the normalized name relative to the share root.
-		// Per MS-FSCC: for the root directory, the name is empty.
-		filePath := openFile.Path
+		//
+		// Returns the canonical name relative to the share root. Per
+		// smbtorture `smb2.getinfo.normalized`, the response must reflect
+		// the on-disk casing — not the client-supplied open path — when the
+		// caller opened the file through a case-insensitive match. Prefer
+		// the metadata store's Path (the canonical form), and fall back to
+		// the OpenFile path only when the metadata layer has no recorded
+		// path (e.g., root-handle opens). Per MS-FSCC: for the root
+		// directory, the name is empty.
+		filePath := file.Path
+		if filePath == "" {
+			filePath = openFile.Path
+		}
 		if filePath == "" || filePath == "/" {
 			w := smbenc.NewWriter(4)
 			w.WriteUint32(0) // FileNameLength = 0 (root)
@@ -723,6 +741,16 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileAllInformation:
 		return h.buildFileAllInformationFromStore(authCtx, file, openFile), nil
+
+	case 15: // FileFullEaInformation [MS-FSCC §2.4.15]
+		// We don't persist extended attributes (#220 tracks adapter EA support),
+		// so the canonical response is an empty chained-EA buffer with
+		// STATUS_SUCCESS. Samba returns NO_EAS_ON_FILE when the EA list is
+		// empty, but smbtorture (`smb2.getinfo.complex` and `getinfo_access`)
+		// asserts NT_STATUS_OK against the reference implementation — so we
+		// match the asserted Windows behavior here. The wire format permits a
+		// zero-byte payload (no entries), which clients interpret as "no EAs".
+		return []byte{}, nil
 
 	default:
 		return nil, types.ErrNotSupported
@@ -1027,6 +1055,8 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 // fixed-size file information class. Returns 0 for variable-length classes
 // (which may be truncated instead of rejected).
 func fileInfoClassMinSize(class types.FileInfoClass) uint32 {
+	// Values match Samba `smbd_do_qfilepathinfo` fixed_portion (source3/smbd/smb2_trans2.c)
+	// so smbtorture `smb2.getinfo.qfile_buffercheck` round-trips identically.
 	switch class {
 	case types.FileBasicInformation:
 		return 40
@@ -1044,15 +1074,20 @@ func fileInfoClassMinSize(class types.FileInfoClass) uint32 {
 	case types.FileAttributeTagInformation:
 		return 8
 	case types.FileAllInformation:
-		return 100 // 40+24+8+4+4+8+4+4+4 fixed fields before variable NameInformation
+		// Samba SMB2_FILE_ALL_INFORMATION fixed_portion = 104.
+		return 104
 	case types.FileIdInformation:
 		return 24
 	case types.FileNameInformation:
 		return 4 // FileNameLength field minimum
 	case types.FileStreamInformation:
-		return 8 // NextEntryOffset + StreamNameLength minimum
+		// Samba SMB_FILE_STREAM_INFORMATION fixed_portion = 32
+		// (single FILE_STREAM_INFORMATION entry header sans variable name).
+		return 32
 	case types.FileAlternateNameInformation, types.FileNormalizedNameInformation:
-		return 4 // FileNameLength field minimum
+		// Samba SMB_FILE_*_NAME_INFORMATION fixed_portion = 8
+		// (4-byte FileNameLength + 4 bytes alignment / minimum name byte pair).
+		return 8
 	default:
 		return 0 // Variable-length or unknown; allow truncation
 	}
@@ -1062,23 +1097,27 @@ func fileInfoClassMinSize(class types.FileInfoClass) uint32 {
 // fixed-size filesystem information class [MS-FSCC] 2.5. Returns 0 for
 // variable-length classes (which may be truncated instead of rejected).
 func fsInfoClassMinSize(class types.FileInfoClass) uint32 {
+	// Values match Samba `smbd_do_qfsinfo` fixed_portion (source3/smbd/smb2_trans2.c)
+	// so smbtorture `smb2.getinfo.qfs_buffercheck` round-trips identically.
 	switch class {
-	case 3: // FileFsSizeInformation [MS-FSCC] 2.5.8 (24 bytes)
+	case 1: // FileFsVolumeInformation [MS-FSCC §2.5.9]
+		// Samba reports fixed_portion = 24 (fixed header before VolumeLabel).
 		return 24
-	case 4: // FileFsDeviceInformation [MS-FSCC] 2.5.9 (8 bytes)
+	case 3: // FileFsSizeInformation [MS-FSCC §2.5.8] (24 bytes)
+		return 24
+	case 4: // FileFsDeviceInformation [MS-FSCC §2.5.10] (8 bytes)
 		return 8
-	case 7: // FileFsFullSizeInformation [MS-FSCC] 2.5.4 (32 bytes)
-		return 32
-	case 8: // FileFsObjectIdInformation [MS-FSCC] 2.5.6 (64 bytes)
-		return 64
-	case 11: // FileFsSectorSizeInformation [MS-FSCC] 2.5.8 (28 bytes)
-		return 28
-	case 1: // FileFsVolumeInformation [MS-FSCC] 2.5.9 (min 18 bytes)
-		return 18
-	case 5: // FileFsAttributeInformation [MS-FSCC] 2.5.1 (min 12 bytes)
-		return 12
-	case 6: // FileFsControlInformation [MS-FSCC] 2.5.2 (48 bytes)
+	case 5: // FileFsAttributeInformation [MS-FSCC §2.5.1]
+		// Samba reports fixed_portion = 16 (fixed header before FileSystemName).
+		return 16
+	case 6: // FileFsControlInformation [MS-FSCC §2.5.2] (48 bytes)
 		return 48
+	case 7: // FileFsFullSizeInformation [MS-FSCC §2.5.4] (32 bytes)
+		return 32
+	case 8: // FileFsObjectIdInformation [MS-FSCC §2.5.6] (64 bytes)
+		return 64
+	case 11: // FileFsSectorSizeInformation [MS-FSCC §2.5.8] (28 bytes)
+		return 28
 	default:
 		return 0 // Variable-length or unknown
 	}

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -751,7 +751,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 	case types.FileAllInformation:
 		return h.buildFileAllInformationFromStore(authCtx, file, openFile), nil
 
-	case 15: // FileFullEaInformation [MS-FSCC §2.4.15]
+	case types.FileFullEaInformation:
 		// We don't persist extended attributes (#220 tracks adapter EA support).
 		// Samba returns NO_EAS_ON_FILE when the list is empty, but smbtorture
 		// (`smb2.getinfo.complex` and `getinfo_access`) asserts NT_STATUS_OK
@@ -1197,7 +1197,7 @@ func fileInfoClassRequiredAccess(class types.FileInfoClass) (uint32, bool) {
 		types.FileNetworkOpenInformation,
 		types.FileAttributeTagInformation:
 		return uint32(types.FileReadAttributes), true
-	case 15: // FileFullEaInformation [MS-FSCC §2.4.15]; constant not defined in types pkg
+	case types.FileFullEaInformation:
 		return uint32(types.FileReadEA), true
 	}
 	return 0, false

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -688,7 +688,12 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		if filePath == "" {
 			filePath = openFile.Path
 		}
-		if filePath == "" || filePath == "/" {
+		// Strip the share-root leading separator: file.Path is stored as
+		// "/dir/name" but the normalized form is share-relative (matches
+		// Samba `smb_fname->base_name` and the smbtorture assertion which
+		// expects "dir\\name", not "\\dir\\name").
+		filePath = strings.TrimPrefix(filePath, "/")
+		if filePath == "" {
 			w := smbenc.NewWriter(4)
 			w.WriteUint32(0) // FileNameLength = 0 (root)
 			return w.Bytes(), nil

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -591,7 +591,11 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return EncodeFileBasicInfo(basicInfo), nil
 
 	case types.FileStandardInformation:
-		standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, false)
+		// Reflect SET_INFO DispositionInformation state in the DeletePending
+		// field — smbtorture `smb2.setinfo` (setinfo.c:228) asserts that
+		// querying STANDARD / ALL_INFORMATION after setting delete disposition
+		// surfaces delete_pending = 1.
+		standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
 		return EncodeFileStandardInfo(standardInfo), nil
 
 	case types.FileInternalInformation:
@@ -748,14 +752,17 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return h.buildFileAllInformationFromStore(authCtx, file, openFile), nil
 
 	case 15: // FileFullEaInformation [MS-FSCC §2.4.15]
-		// We don't persist extended attributes (#220 tracks adapter EA support),
-		// so the canonical response is an empty chained-EA buffer with
-		// STATUS_SUCCESS. Samba returns NO_EAS_ON_FILE when the EA list is
-		// empty, but smbtorture (`smb2.getinfo.complex` and `getinfo_access`)
-		// asserts NT_STATUS_OK against the reference implementation — so we
-		// match the asserted Windows behavior here. The wire format permits a
-		// zero-byte payload (no entries), which clients interpret as "no EAs".
-		return []byte{}, nil
+		// We don't persist extended attributes (#220 tracks adapter EA support).
+		// Samba returns NO_EAS_ON_FILE when the list is empty, but smbtorture
+		// (`smb2.getinfo.complex` and `getinfo_access`) asserts NT_STATUS_OK
+		// against the reference implementation — match the asserted Windows
+		// behavior here. The client parser (Samba `ea_pull_list_chained`
+		// behind `FINFO_CHECK_MIN_SIZE(4)` in source4/libcli/raw/rawfileinfo.c)
+		// rejects a zero-byte payload with STATUS_INFO_LENGTH_MISMATCH, so we
+		// return a 4-byte sentinel: NextEntryOffset = 0 ("no further entries"),
+		// which both parsers and Windows-compatible clients interpret as
+		// "no EAs".
+		return make([]byte, 4), nil
 
 	default:
 		return nil, types.ErrNotSupported
@@ -768,7 +775,10 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	// Basic (40) + Standard (24) + Internal (8) + EA (4) + Access (4) + Position (8) + Mode (4) + Alignment (4) + Name (variable)
 
 	basicInfo := FileAttrToFileBasicInfoWithName(&file.FileAttr, basenameForHidden(openFile))
-	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, false)
+	// Reflect delete-on-close disposition (set via SET_INFO DispositionInformation
+	// or FILE_DELETE_ON_CLOSE on CREATE) in the embedded StandardInformation.
+	// smbtorture `smb2.setinfo` (setinfo.c:228) asserts delete_pending = 1 here.
+	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
 	nameBytes := encodeUTF16LE(toSMBPath(openFile.Path))
 
 	// Fixed part: 96 bytes + NameInformation header (4 bytes for length) + name data

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -358,8 +358,16 @@ func (h *Handler) setFileInfoFromStore(
 		// handle. Pre-read the file to capture current timestamps, then pin
 		// sentinel timestamps to their current value in setAttrs to suppress
 		// auto-updates (e.g., Ctime auto-update when FileAttributes change).
+		//
+		// We also need the pre-image when the caller sends ChangeTime = 0
+		// ("don't change") and FileAttributes is non-zero — the metadata
+		// layer auto-bumps Ctime on any modification (file_modify.go line
+		// 311 et seq.), but smbtorture `smb2.setinfo` (setinfo.c:203) asserts
+		// the previously-set Ctime survives a no-op SET_INFO. Pinning Ctime
+		// to the current value suppresses the auto-bump.
+		needPreFile := hasFreezeOrUnfreeze || (ctimeFT == 0 && fileAttrs != 0 && !openFile.CtimeFrozen)
 		var preFile *metadata.File
-		if hasFreezeOrUnfreeze {
+		if needPreFile {
 			var err error
 			preFile, err = metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
 			if err != nil {
@@ -403,6 +411,17 @@ func (h *Handler) setFileInfoFromStore(
 		}
 		if atimeFT == 0 && openFile.AtimeFrozen && openFile.FrozenAtime != nil {
 			setAttrs.Atime = openFile.FrozenAtime
+		}
+
+		// ChangeTime stickiness: once SET_INFO BasicInfo has been used on a
+		// handle to mutate attributes, the metadata layer's automatic Ctime
+		// bump (file_modify.go: `if attrs.Ctime == nil { file.Ctime = now }`)
+		// must NOT overwrite a previously-set ChangeTime when the caller
+		// sends ChangeTime = 0 alongside an attribute change. Pin Ctime to
+		// the current value so the auto-bump is a no-op. smbtorture
+		// `smb2.setinfo` (setinfo.c:203) asserts this exact behavior.
+		if ctimeFT == 0 && setAttrs.Ctime == nil && fileAttrs != 0 && preFile != nil {
+			setAttrs.Ctime = &preFile.Ctime
 		}
 
 		// Per MS-FSA 2.1.5.14.2: When FileAttributes change, the object store

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -224,7 +224,7 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 			types.FileLinkInformation,
 			types.FileDispositionInformation, types.FileDispositionInformationEx,
 			types.FileEndOfFileInformation, types.FileAllocationInformation,
-			15: // FileFullEaInformation
+			types.FileFullEaInformation:
 			// These have specific access checks in their handlers or
 			// are validated by the metadata layer
 		default:
@@ -359,13 +359,16 @@ func (h *Handler) setFileInfoFromStore(
 		// sentinel timestamps to their current value in setAttrs to suppress
 		// auto-updates (e.g., Ctime auto-update when FileAttributes change).
 		//
-		// We also need the pre-image when the caller sends ChangeTime = 0
-		// ("don't change") and FileAttributes is non-zero — the metadata
-		// layer auto-bumps Ctime on any modification (file_modify.go line
-		// 311 et seq.), but smbtorture `smb2.setinfo` (setinfo.c:203) asserts
-		// the previously-set Ctime survives a no-op SET_INFO. Pinning Ctime
-		// to the current value suppresses the auto-bump.
-		needPreFile := hasFreezeOrUnfreeze || (ctimeFT == 0 && fileAttrs != 0 && !openFile.CtimeFrozen)
+		// We also need the pre-image whenever the caller sends ChangeTime = 0
+		// ("don't change") alongside any other mutation — the metadata layer
+		// auto-bumps Ctime on any modification (file_modify.go line 311 et
+		// seq.), but smbtorture `smb2.setinfo` (setinfo.c:203) asserts the
+		// previously-set Ctime survives a no-op SET_INFO. The mutation can be
+		// attribute-only, timestamp-only (e.g. LastWriteTime), or both;
+		// pinning Ctime to the current value suppresses the auto-bump in all
+		// of these cases.
+		anyBasicMutation := fileAttrs != 0 || creationFT != 0 || atimeFT != 0 || mtimeFT != 0
+		needPreFile := hasFreezeOrUnfreeze || (ctimeFT == 0 && anyBasicMutation && !openFile.CtimeFrozen)
 		var preFile *metadata.File
 		if needPreFile {
 			var err error
@@ -414,13 +417,14 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// ChangeTime stickiness: once SET_INFO BasicInfo has been used on a
-		// handle to mutate attributes, the metadata layer's automatic Ctime
-		// bump (file_modify.go: `if attrs.Ctime == nil { file.Ctime = now }`)
-		// must NOT overwrite a previously-set ChangeTime when the caller
-		// sends ChangeTime = 0 alongside an attribute change. Pin Ctime to
-		// the current value so the auto-bump is a no-op. smbtorture
-		// `smb2.setinfo` (setinfo.c:203) asserts this exact behavior.
-		if ctimeFT == 0 && setAttrs.Ctime == nil && fileAttrs != 0 && preFile != nil {
+		// handle to mutate attributes or any timestamp, the metadata layer's
+		// automatic Ctime bump (file_modify.go: `if attrs.Ctime == nil {
+		// file.Ctime = now }`) must NOT overwrite a previously-set ChangeTime
+		// when the caller sends ChangeTime = 0. Pin Ctime to the current value
+		// so the auto-bump is a no-op. smbtorture `smb2.setinfo`
+		// (setinfo.c:203) asserts this for attribute changes; the same
+		// constraint applies to timestamp-only mutations (e.g. LastWriteTime).
+		if ctimeFT == 0 && setAttrs.Ctime == nil && !openFile.CtimeFrozen && preFile != nil {
 			setAttrs.Ctime = &preFile.Ctime
 		}
 
@@ -1126,7 +1130,7 @@ func (h *Handler) setFileInfoFromStore(
 		// Reserved (7B), RootDirectory (8B), FileNameLength (4B), FileName (UTF-16LE).
 		return h.handleFileLinkInformation(authCtx, openFile, buffer)
 
-	case 15: // FileFullEaInformation [MS-FSCC] 2.4.15 - Extended attributes
+	case types.FileFullEaInformation: // [MS-FSCC] 2.4.15 - Extended attributes
 		// Accept EA writes as a no-op. DittoFS does not persist extended attributes
 		// but returning SUCCESS allows ChangeNotify EA tests to proceed.
 		logger.Debug("SET_INFO: FileFullEaInformation (no-op)", "path", openFile.Path)


### PR DESCRIPTION
Wave-3 conformance fixes for `smb2.getinfo` + `smb2.setinfo` (issue #481).

## Summary

- **QUERY_INFO** `FileFullEaInformation` (class 15) — return an empty chained-EA buffer with `STATUS_SUCCESS` (we don't persist EAs yet; client interprets zero-byte payload as "no EAs"). Flips `getinfo.complex`, `getinfo_access`.
- **QUERY_INFO** fixed-portion sizes — align with Samba `smbd_do_qfilepathinfo` / `smbd_do_qfsinfo` so `qfile_buffercheck` and `qfs_buffercheck` round-trip identically (`FileAllInformation` 100→104, `FileStreamInformation` 8→32, `FileAlternateName` / `FileNormalizedName` 4→8, `FsVolumeInformation` 18→24, `FsAttributeInformation` 12→16).
- **QUERY_INFO** — return `STATUS_BUFFER_OVERFLOW` (with the truncated payload) when the response exceeds `OutputBufferLength` but the fixed portion fits (MS-SMB2 §3.3.5.20.1 + Samba `smbd_smb2_getinfo_send`).
- **QUERY_INFO** `FileNormalizedNameInformation` — return the canonical on-disk path (metadata `file.Path`) rather than the client-supplied open path, so case-insensitive opens still surface the original casing.
- **CREATE** — case-insensitive baseName + `walkPath` fallback via a `lookupCaseInsensitive` helper. Fast path stays a single map lookup; the directory scan only runs on case-sensitive miss. Required by `getinfo.normalized`.
- **SET_INFO** `FileBasicInformation` — pin `Ctime` to the current value when the caller sends `ChangeTime = 0` ("don't change") with a non-zero `FileAttributes`, suppressing the metadata layer's auto-`Ctime` bump (`file_modify.go` line 311 et seq.). Flips `setinfo` (assertion at `setinfo.c:203`).

## Targets (6 tests under \`KNOWN_FAILURES.md\` -> *Query/Set Info (Advanced Scenarios)*)

- \`smb2.getinfo.complex\`
- \`smb2.getinfo.getinfo_access\`
- \`smb2.getinfo.normalized\`
- \`smb2.getinfo.qfile_buffercheck\`
- \`smb2.getinfo.qfs_buffercheck\`
- \`smb2.setinfo\`

## Spec / Samba references

- MS-SMB2 §3.3.5.20 (QUERY_INFO), §3.3.5.21 (SET_INFO)
- MS-FSCC §2.4 (Information Classes), §2.5 (FS Information)
- Samba `source3/smbd/smb2_getinfo.c`, `smb2_trans2.c::smbd_do_qfilepathinfo` / `smbd_do_qfsinfo`
- smbtorture `source4/torture/smb2/getinfo.c`, `setinfo.c`

## Test plan

- [ ] Unit tests pass (\`go test ./...\`)
- [ ] CI smbtorture flips all 6 targets in \`memory\` and \`badger-fs\` profiles
- [ ] \`KNOWN_FAILURES.md\` walkback in follow-up commit after CI confirms
- [ ] No regressions in \`smb2.getinfo.*\` (granted, qsec_buffercheck, fsinfo) or downstream lease/oplock tests