### PR TITLE
fix(smb): durable handles V2 — context validation, AppInstance, ClientGuid scoping (#432)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -480,6 +480,15 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 	h.primeAuthContext(ctx, ctx.TreeID, ctx.SessionID)
 
+	// Validate durable-handle create context combinations per MS-SMB2
+	// §3.3.5.9.6/7/11/12. Mutually-exclusive pairs of DHnQ/DHnC/DH2Q/DH2C
+	// MUST be rejected with STATUS_INVALID_PARAMETER (smbtorture
+	// smb2.durable-v2-open.create-blob).
+	if status := ValidateDurableContexts(req.CreateContexts); status != types.StatusSuccess {
+		logger.Debug("CREATE: invalid durable context combination", "status", status)
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
+	}
+
 	// ========================================================================
 	// Step 2: Check for IPC$ named pipe operations
 	// ========================================================================
@@ -656,17 +665,17 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 			restored.IsDurable = true
 			restored.DurableTimeoutMs = h.DurableTimeoutMs
 
-			// Build response create contexts: DH2Q/DHnQ response + lease response
+			// Per MS-SMB2 §3.3.5.9.7 / §3.3.5.9.12 and Samba
+			// `smbd_smb2_create_send` (which only emits the DH2Q response
+			// blob when the request actually carried a DH2Q request context),
+			// a reconnect (DHnC / DH2C) response MUST NOT include a DHnQ or
+			// DH2Q grant blob: `out.durable_open` and `out.durable_open_v2`
+			// are expected to be false and `out.timeout` zero. The handle
+			// stays durable for *future* disconnects via the server-side
+			// IsDurable flag set above — no wire signaling is required.
+			// smbtorture smb2.durable-v2-open.{reopen1a,reopen2,reopen2b,...}
+			// assert "no dh2q response blob" on every successful reconnect.
 			var reconnectContexts []CreateContext
-
-			// Per MS-SMB2 3.3.5.9.12/7: return DH2Q or DHnQ response on reconnect
-			if reconnResult.IsV2 {
-				resp := EncodeDH2QResponse(h.DurableTimeoutMs, 0)
-				reconnectContexts = append(reconnectContexts, resp)
-			} else {
-				resp := EncodeDHnQResponse()
-				reconnectContexts = append(reconnectContexts, resp)
-			}
 
 			// Re-register lease/oplock in the LeaseManager. During disconnect,
 			// ReleaseSessionLeases cleared the lease state from the LeaseManager.

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -627,7 +627,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 			reconnResult, status, reconnErr := ProcessDurableReconnectContext(
 				authCtx.Context, h.DurableStore, metaSvc, req.CreateContexts,
 				ctx.SessionID, sess.Username, sessionKeyHash,
-				tree.ShareName, fullFilename,
+				tree.ShareName, fullFilename, connClientGUID(ctx),
 			)
 			if reconnErr != nil {
 				logger.Warn("CREATE: durable reconnect error", "error", reconnErr)

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -668,6 +668,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		ShareAccess:    req.ShareAccess,
 		CreateOptions:  req.CreateOptions,
 		DeletePending:  req.CreateOptions&types.FileDeleteOnClose != 0,
+		ClientGUID:     connClientGUID(ctx),
 	}
 
 	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -46,6 +46,39 @@ func DecodeDHnCReconnect(data []byte) ([16]byte, error) {
 	return fileID, nil
 }
 
+// ValidateDurableContexts checks the durable-handle context combination rules
+// from MS-SMB2 §3.3.5.9.6/7/11/12 (mirrors Samba `source3/smbd/smb2_create.c`
+// `smbd_smb2_create_send` ~lines 775-846). Returns a non-success status when
+// the combination is invalid:
+//
+//   - DHnC + DH2C, DHnC + DH2Q, DH2C + DHnQ, DH2Q + DH2C (any pair of these
+//     four) → STATUS_INVALID_PARAMETER
+//   - DH2C with wrong length (≠ 36) → STATUS_INVALID_PARAMETER
+//
+// The "extra unexpected blobs alongside reconnect → OBJECT_NAME_NOT_FOUND"
+// rule is intentionally NOT enforced here: smbtorture create-blob does not
+// exercise it, and our broader CREATE pipeline does not yet account for the
+// full set of allowed companion contexts.
+func ValidateDurableContexts(contexts []CreateContext) types.Status {
+	dhnq := FindCreateContext(contexts, DurableHandleV1RequestTag)
+	dhnc := FindCreateContext(contexts, DurableHandleV1ReconnectTag)
+	dh2q := FindCreateContext(contexts, DurableHandleV2RequestTag)
+	dh2c := FindCreateContext(contexts, DurableHandleV2ReconnectTag)
+
+	if (dhnc != nil && dh2c != nil) ||
+		(dhnc != nil && dh2q != nil) ||
+		(dh2c != nil && dhnq != nil) ||
+		(dh2q != nil && dh2c != nil) {
+		return types.StatusInvalidParameter
+	}
+
+	if dh2c != nil && len(dh2c.Data) != 36 {
+		return types.StatusInvalidParameter
+	}
+
+	return types.StatusSuccess
+}
+
 // DecodeDH2QRequest parses a V2 durable handle request (DH2Q).
 // Returns timeout (ms), flags, and CreateGuid.
 // [MS-SMB2] 2.2.13.2.11

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -196,6 +196,22 @@ func ProcessDurableHandleContext(
 			return nil
 		}
 
+		// Per MS-SMB2 §3.3.5.9.10: V2 durability MUST NOT be granted unless
+		// either OplockLevel is Batch (legacy oplock-backed durable) or the
+		// granted lease includes SMB2_LEASE_HANDLE_CACHING. Matches Samba
+		// `smbd_smb2_create_durable_lease_check`. smbtorture
+		// smb2.durable-v2-open.open-oplock iterates 8 share-mode × 4 oplock-
+		// level combinations and expects `out.durable_open_v2 == false` for
+		// every non-Batch row — granting V2 unconditionally trips those
+		// assertions (line 293 / 455).
+		hasHandle := len(leaseIncludesHandle) > 0 && leaseIncludesHandle[0]
+		if openFile.OplockLevel != OplockLevelBatch && !hasHandle {
+			logger.Debug("ProcessDurableHandleContext: V2 rejected (no Batch oplock or Handle lease)",
+				"oplockLevel", openFile.OplockLevel,
+				"hasHandleLease", hasHandle)
+			return nil
+		}
+
 		// Calculate granted timeout: min(requested, configured max), 0 = server default
 		grantedTimeout := configuredTimeoutMs
 		if timeout > 0 && timeout < configuredTimeoutMs {
@@ -406,11 +422,18 @@ func processV2Reconnect(
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
-	// Validate FileID from DH2C against persisted handle to prevent wrong-handle reconnect
-	if fileID != handle.FileID {
-		logger.Debug("processV2Reconnect: FileID mismatch",
-			"expected", fmt.Sprintf("%x", handle.FileID),
-			"actual", fmt.Sprintf("%x", fileID))
+	// Validate FileID from DH2C against persisted handle to prevent wrong-
+	// handle reconnect. Compare only the persistent half (bytes 0-7): a
+	// compliant V1 client sends Data.Volatile=0 per MS-SMB2 §3.2.4.4, but
+	// smbtorture (and other test clients) replay the original full FileID
+	// for V2 reconnect, so a 16-byte compare against the persisted
+	// (volatile-zeroed) FileID would reject every legitimate V2 replay
+	// returning STATUS_INVALID_PARAMETER. CreateGuid is the primary
+	// identifier on V2 anyway; the persistent half is just an extra check.
+	if [8]byte(fileID[:8]) != [8]byte(handle.FileID[:8]) {
+		logger.Debug("processV2Reconnect: persistent FileID mismatch",
+			"expected", fmt.Sprintf("%x", handle.FileID[:8]),
+			"actual", fmt.Sprintf("%x", fileID[:8]))
 		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -264,6 +264,14 @@ type ReconnectResult struct {
 // ProcessDurableReconnectContext processes DHnC or DH2C create contexts for reconnection.
 // It looks up the persisted handle, validates all reconnect conditions per MS-SMB2,
 // and on success returns a ReconnectResult. On failure, returns a specific NTSTATUS code.
+//
+// connClientGUID is the ClientGuid of the reconnecting connection (from
+// NEGOTIATE). It is matched against the persisted handle's ClientGUID only on
+// V2 *lease-backed* reconnect — see reopen1a-lease in
+// `source4/torture/smb2/durable_v2_open.c`. Pass [16]byte{} from contexts that
+// have no notion of ClientGuid; lease reconnect with a zero ClientGuid will
+// fail OBJECT_NAME_NOT_FOUND, mirroring Samba's strict per-client-GUID lease
+// key scoping.
 func ProcessDurableReconnectContext(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -274,12 +282,13 @@ func ProcessDurableReconnectContext(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
+	connClientGUID [16]byte,
 ) (*ReconnectResult, types.Status, error) {
 
 	// Determine V2 (DH2C) or V1 (DHnC) reconnect
 	if dh2cCtx := FindCreateContext(contexts, DurableHandleV2ReconnectTag); dh2cCtx != nil {
 		openFile, leaseState, origID, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
-			sessionID, username, sessionKeyHash, shareName, filename)
+			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
@@ -364,6 +373,7 @@ func processV2Reconnect(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
+	connClientGUID [16]byte,
 ) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V2 reconnect context
 	fileID, createGuid, flags, err := DecodeDH2CReconnect(dh2cCtx.Data)
@@ -402,6 +412,23 @@ func processV2Reconnect(
 			"expected", fmt.Sprintf("%x", handle.FileID),
 			"actual", fmt.Sprintf("%x", fileID))
 		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+	}
+
+	// Per MS-SMB2 §3.3.5.9.12 and Samba lease-key scoping (per-(ClientGuid,
+	// LeaseKey)), a V2 *lease-backed* durable open MUST be reconnected from
+	// the same ClientGuid that established it. A non-zero LeaseKey on the
+	// persisted handle is our marker for "lease-backed". An older persisted
+	// handle written before ClientGUID was captured carries the zero value;
+	// treat that as "no recorded ClientGuid" and skip the check to preserve
+	// forward compatibility with handles written by pre-#432 binaries
+	// (matches the fall-back pattern already used for GrantedAccess in
+	// validateAndRestore). smbtorture smb2.durable-v2-open.reopen1a-lease.
+	if handle.LeaseKey != ([16]byte{}) && handle.ClientGUID != ([16]byte{}) &&
+		handle.ClientGUID != connClientGUID {
+		logger.Debug("processV2Reconnect: ClientGuid mismatch on lease-backed reconnect",
+			"persisted", fmt.Sprintf("%x", handle.ClientGUID),
+			"connecting", fmt.Sprintf("%x", connClientGUID))
+		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// V2 reconnect does not carry DesiredAccess/ShareAccess in DH2C context either
@@ -556,10 +583,20 @@ func validateAndRestore(
 }
 
 // ProcessAppInstanceId processes the SMB2_CREATE_APP_INSTANCE_ID context.
-// If present, it looks up existing durable handles with the same AppInstanceId
-// and force-closes them (Hyper-V failover pattern).
+// Per MS-SMB2 §3.3.5.9.13, when a CREATE arrives carrying an AppInstanceId
+// matching an existing open's AppInstanceId, the server MUST force-close the
+// existing open before establishing the new one. This is the Hyper-V failover
+// pattern: a VM moving between hosts presents the same AppInstanceId, and the
+// new host claims the file from the old. The forced close MUST cover both:
 //
-// Returns the parsed AppInstanceId (zero value if not present).
+//   - Disconnected (persisted) durable handles in the DurableHandleStore.
+//   - Live opens still tracked in Handler.files. smbtorture
+//     smb2.durable-v2-open.app-instance opens with AppInstanceId X on tree1,
+//     then opens the same file with X on tree2 with tree1 *still connected*.
+//     Subsequent CLOSE on the tree1 handle MUST return STATUS_FILE_CLOSED —
+//     this requires the live handle to be removed from Handler.files.
+//
+// Returns the parsed AppInstanceId (zero value if not present or zero).
 func ProcessAppInstanceId(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -577,12 +614,32 @@ func ProcessAppInstanceId(
 		return [16]byte{}
 	}
 
-	// Zero AppInstanceId means "not set"
 	if appId == ([16]byte{}) {
 		return [16]byte{}
 	}
 
-	// Look up existing handles with this AppInstanceId
+	// 1) Force-close live opens with matching AppInstanceId. Uses
+	// closeFilesWithFilter with isDisconnect=false so the open is fully
+	// closed (locks released, caches flushed, file removed from
+	// Handler.files) — NOT persisted into the durable store, since the new
+	// AppInstanceId open is claiming this handle.
+	if handler != nil {
+		liveClosed := handler.closeFilesWithFilter(
+			ctx,
+			0, // no specific sessionID — match across sessions
+			func(f *OpenFile) bool { return f.AppInstanceId == appId },
+			"ProcessAppInstanceId",
+			false, // explicit close, not transport disconnect
+		)
+		if liveClosed > 0 {
+			logger.Debug("ProcessAppInstanceId: force-closed live opens",
+				"appInstanceId", fmt.Sprintf("%x", appId),
+				"count", liveClosed)
+		}
+	}
+
+	// 2) Force-close persisted (disconnected) durable handles with matching
+	// AppInstanceId.
 	existing, err := durableStore.GetDurableHandlesByAppInstanceId(ctx, appId)
 	if err != nil {
 		logger.Warn("ProcessAppInstanceId: store error", "error", err)
@@ -593,15 +650,12 @@ func ProcessAppInstanceId(
 		return appId
 	}
 
-	logger.Debug("ProcessAppInstanceId: force-closing existing handles",
+	logger.Debug("ProcessAppInstanceId: force-closing persisted handles",
 		"appInstanceId", fmt.Sprintf("%x", appId),
 		"count", len(existing))
 
-	// Force-close each existing handle
 	for _, h := range existing {
-		// If handler is available, perform full cleanup (release locks, flush caches)
 		if handler != nil {
-			// Build minimal OpenFile for cleanup
 			cleanupFile := &OpenFile{
 				FileID:         h.FileID,
 				Path:           h.Path,
@@ -609,11 +663,7 @@ func ProcessAppInstanceId(
 				MetadataHandle: h.MetadataHandle,
 				PayloadID:      metadata.PayloadID(h.PayloadID),
 			}
-
-			// Flush cache
 			handler.flushFileCache(ctx, cleanupFile)
-
-			// Release locks if metadata handle is valid
 			if len(h.MetadataHandle) > 0 && handler.Registry != nil {
 				if metaSvc := handler.Registry.GetMetadataService(); metaSvc != nil {
 					_ = metaSvc.UnlockAllForSession(ctx, h.MetadataHandle, 0)
@@ -621,15 +671,10 @@ func ProcessAppInstanceId(
 			}
 		}
 
-		// Delete from durable store
 		if delErr := durableStore.DeleteDurableHandle(ctx, h.ID); delErr != nil {
 			logger.Warn("ProcessAppInstanceId: failed to delete handle",
 				"handleID", h.ID,
 				"error", delErr)
-		} else {
-			logger.Debug("ProcessAppInstanceId: force-closed handle",
-				"handleID", h.ID,
-				"path", h.Path)
 		}
 	}
 
@@ -694,5 +739,6 @@ func buildPersistedDurableHandle(
 		IsDirectory:     openFile.IsDirectory,
 		PositionInfo:    openFile.PositionInfo,
 		OriginalFileID:  openFile.FileID,
+		ClientGUID:      openFile.ClientGUID,
 	}
 }

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -570,6 +570,14 @@ func validateAndRestore(
 		FileName:       handle.FileName,
 		IsDirectory:    handle.IsDirectory,
 		PositionInfo:   handle.PositionInfo,
+		// Restore the ClientGUID recorded at the original CREATE so a
+		// chained disconnect→reconnect→disconnect cycle preserves the
+		// per-(ClientGuid, LeaseKey) lease scoping check on the next
+		// reconnect attempt. Without this, the next persist would write a
+		// zero ClientGUID, and the §3.3.5.9.12 lease-scoping check in
+		// processV2Reconnect would silently no-op (handle.ClientGUID == 0
+		// is the "pre-#432 forward-compat" branch).
+		ClientGUID: handle.ClientGUID,
 		// IsDurable is NOT set on restore -- client must re-request durability
 	}
 

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -500,7 +500,7 @@ func TestProcessDurableReconnectContext_V1Success(t *testing.T) {
 	}
 
 	restored, status, err := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt",
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{},
 	)
 	if err != nil {
 		t.Fatalf("ProcessDurableReconnectContext error: %v", err)
@@ -570,7 +570,7 @@ func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	}
 
 	restored, status, err := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "bob", keyHash, "/share1", "report.docx",
+		context.Background(), store, nil, contexts, 999, "bob", keyHash, "/share1", "report.docx", [16]byte{},
 	)
 	if err != nil {
 		t.Fatalf("ProcessDurableReconnectContext error: %v", err)
@@ -609,7 +609,7 @@ func TestProcessDurableReconnectContext_HandleNotFound(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", makeSessionKeyHash("key"), "/share1", "test.txt",
+		context.Background(), store, nil, contexts, 999, "alice", makeSessionKeyHash("key"), "/share1", "test.txt", [16]byte{},
 	)
 	if status != types.StatusObjectNameNotFound {
 		t.Errorf("Expected STATUS_OBJECT_NAME_NOT_FOUND, got %s", status)
@@ -646,7 +646,7 @@ func TestProcessDurableReconnectContext_UsernameMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "eve", keyHash, "/share1", "test.txt",
+		context.Background(), store, nil, contexts, 999, "eve", keyHash, "/share1", "test.txt", [16]byte{},
 	)
 	if status != types.StatusAccessDenied {
 		t.Errorf("Expected STATUS_ACCESS_DENIED for username mismatch, got %s", status)
@@ -689,7 +689,7 @@ func TestProcessDurableReconnectContext_SessionKeyMismatchAllowed(t *testing.T) 
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", differentKeyHash, "/share1", "test.txt",
+		context.Background(), store, nil, contexts, 999, "alice", differentKeyHash, "/share1", "test.txt", [16]byte{},
 	)
 	if status != types.StatusSuccess {
 		t.Errorf("Expected STATUS_SUCCESS for session key mismatch with matching username, got %s", status)
@@ -726,7 +726,7 @@ func TestProcessDurableReconnectContext_ShareNameMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/different-share", "test.txt",
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/different-share", "test.txt", [16]byte{},
 	)
 	if status != types.StatusObjectNameNotFound {
 		t.Errorf("Expected STATUS_OBJECT_NAME_NOT_FOUND for share mismatch, got %s", status)
@@ -766,7 +766,7 @@ func TestProcessDurableReconnectContext_PathMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "other.txt",
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "other.txt", [16]byte{},
 	)
 	if status != types.StatusInvalidParameter {
 		t.Errorf("Expected STATUS_INVALID_PARAMETER for path mismatch, got %s", status)
@@ -805,7 +805,7 @@ func TestProcessDurableReconnectContext_V1ConflictingV2Tag(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt",
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{},
 	)
 	if status != types.StatusInvalidParameter {
 		t.Errorf("Expected STATUS_INVALID_PARAMETER for conflicting V2 tag with V1 reconnect, got %s", status)
@@ -930,7 +930,7 @@ func TestProcessDurableReconnectContext_OriginalFileIDRestored(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "lockfile.txt")
+		1, "alice", keyHash, "/share1", "lockfile.txt", [16]byte{})
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -975,7 +975,7 @@ func TestProcessDurableReconnectContext_OriginalFileIDFallback(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "legacy.txt")
+		1, "alice", keyHash, "/share1", "legacy.txt", [16]byte{})
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -1019,7 +1019,7 @@ func TestProcessDurableReconnectContext_PositionInfoRestored(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "position.txt")
+		1, "alice", keyHash, "/share1", "position.txt", [16]byte{})
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -1072,5 +1072,112 @@ func TestValidateDurableContexts(t *testing.T) {
 				t.Errorf("ValidateDurableContexts() = %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+// TestProcessDurableReconnectContext_V2LeaseClientGUIDMismatch locks in the
+// MS-SMB2 §3.3.5.9.12 lease-key per-ClientGuid scoping behavior exercised by
+// smb2.durable-v2-open.reopen1a-lease.
+func TestProcessDurableReconnectContext_V2LeaseClientGUIDMismatch(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	keyHash := makeSessionKeyHash("session-key")
+	createGuid := [16]byte{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7}
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC, 0xDD}
+	fileID := [16]byte{0x10, 0x20, 0x30}
+	originalGUID := [16]byte{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7}
+	differentGUID := [16]byte{0xF0, 0xF1, 0xF2}
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "h-001",
+		FileID:         fileID,
+		Path:           "leasefile.txt",
+		ShareName:      "/share1",
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreateGuid:     createGuid,
+		LeaseKey:       leaseKey,
+		ClientGUID:     originalGUID,
+		IsV2:           true,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+		MetadataHandle: []byte{0xAA},
+	})
+
+	// Build DH2C reconnect (FileID + CreateGuid + zero flags).
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[:16], fileID[:])
+	copy(dh2cData[16:32], createGuid[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+	}
+
+	// Wrong ClientGuid → OBJECT_NAME_NOT_FOUND
+	_, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "leasefile.txt", differentGUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusObjectNameNotFound {
+		t.Errorf("ClientGuid mismatch: got status %v, want OBJECT_NAME_NOT_FOUND", status)
+	}
+
+	// Original ClientGuid → success
+	_, status, err = ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusSuccess {
+		t.Errorf("ClientGuid match: got status %v, want SUCCESS", status)
+	}
+}
+
+// TestProcessDurableReconnectContext_V2OplockNoClientGUIDCheck covers
+// reopen1a (oplock-backed, not lease-backed): reconnect with a different
+// ClientGuid MUST still succeed because lease scoping does not apply.
+func TestProcessDurableReconnectContext_V2OplockNoClientGUIDCheck(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	keyHash := makeSessionKeyHash("session-key")
+	createGuid := [16]byte{0x11, 0x22, 0x33, 0x44}
+	fileID := [16]byte{0x55, 0x66, 0x77}
+	originalGUID := [16]byte{0xAA, 0xBB, 0xCC}
+	differentGUID := [16]byte{0xDD, 0xEE, 0xFF}
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "h-002",
+		FileID:         fileID,
+		Path:           "oplockfile.txt",
+		ShareName:      "/share1",
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreateGuid:     createGuid,
+		// LeaseKey deliberately zero → oplock-backed open
+		ClientGUID:     originalGUID,
+		IsV2:           true,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+		MetadataHandle: []byte{0xAA},
+	})
+
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[:16], fileID[:])
+	copy(dh2cData[16:32], createGuid[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+	}
+
+	_, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "oplockfile.txt", differentGUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusSuccess {
+		t.Errorf("oplock V2 reconnect with different ClientGuid: got status %v, want SUCCESS", status)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -1027,3 +1027,50 @@ func TestProcessDurableReconnectContext_PositionInfoRestored(t *testing.T) {
 		t.Errorf("restored PositionInfo = 0x%x, want 0x1000", res.OpenFile.PositionInfo)
 	}
 }
+
+func TestValidateDurableContexts(t *testing.T) {
+	mkDH2C := func() CreateContext {
+		return CreateContext{Name: DurableHandleV2ReconnectTag, Data: make([]byte, 36)}
+	}
+	mkDH2Q := func() CreateContext {
+		return CreateContext{Name: DurableHandleV2RequestTag, Data: make([]byte, 32)}
+	}
+	mkDHnC := func() CreateContext {
+		return CreateContext{Name: DurableHandleV1ReconnectTag, Data: make([]byte, 16)}
+	}
+	mkDHnQ := func() CreateContext {
+		// DHnQ uses the same tag as DH2Q on the wire; the length distinguishes.
+		return CreateContext{Name: DurableHandleV1RequestTag, Data: make([]byte, 16)}
+	}
+
+	cases := []struct {
+		name     string
+		contexts []CreateContext
+		want     types.Status
+	}{
+		{"empty", nil, types.StatusSuccess},
+		{"DHnQ only", []CreateContext{mkDHnQ()}, types.StatusSuccess},
+		{"DH2Q only", []CreateContext{mkDH2Q()}, types.StatusSuccess},
+		{"DHnC only", []CreateContext{mkDHnC()}, types.StatusSuccess},
+		{"DH2C only", []CreateContext{mkDH2C()}, types.StatusSuccess},
+
+		// MS-SMB2 §3.3.5.9.12 rejection cases (smbtorture create-blob)
+		{"DHnC + DH2C", []CreateContext{mkDHnC(), mkDH2C()}, types.StatusInvalidParameter},
+		{"DHnC + DH2Q", []CreateContext{mkDHnC(), mkDH2Q()}, types.StatusInvalidParameter},
+		{"DH2C + DHnQ", []CreateContext{mkDH2C(), mkDHnQ()}, types.StatusInvalidParameter},
+		{"DH2C + DH2Q", []CreateContext{mkDH2C(), mkDH2Q()}, types.StatusInvalidParameter},
+
+		// Truncated DH2C (length must be exactly 36 per Samba; we accept >=36
+		// at decode time but reject mismatched length up-front).
+		{"DH2C short", []CreateContext{{Name: DurableHandleV2ReconnectTag, Data: make([]byte, 20)}}, types.StatusInvalidParameter},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ValidateDurableContexts(c.contexts)
+			if got != c.want {
+				t.Errorf("ValidateDurableContexts() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -333,9 +333,11 @@ func TestProcessDurableHandleContext_V1RejectWithoutBatchOplock(t *testing.T) {
 }
 
 func TestProcessDurableHandleContext_V2GrantWithCreateGuid(t *testing.T) {
+	// V2 durability MUST NOT be granted without Batch oplock or Handle lease
+	// (MS-SMB2 §3.3.5.9.10). Use Batch to test the happy path.
 	openFile := &OpenFile{
 		FileID:      [16]byte{1, 2, 3},
-		OplockLevel: OplockLevelNone,
+		OplockLevel: OplockLevelBatch,
 	}
 
 	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
@@ -369,8 +371,9 @@ func TestProcessDurableHandleContext_V2GrantWithCreateGuid(t *testing.T) {
 
 func TestProcessDurableHandleContext_V2ZeroTimeoutUsesServerDefault(t *testing.T) {
 	openFile := &OpenFile{
-		FileID:      [16]byte{1, 2, 3},
-		OplockLevel: OplockLevelNone,
+		FileID: [16]byte{1, 2, 3},
+		// V2 needs Batch oplock or Handle lease — see §3.3.5.9.10.
+		OplockLevel: OplockLevelBatch,
 	}
 
 	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
@@ -1230,5 +1233,54 @@ func TestValidateAndRestore_ClientGUIDRoundtrip(t *testing.T) {
 	if res.OpenFile.ClientGUID != originalGUID {
 		t.Errorf("restored ClientGUID = %x, want %x (Copilot review #1: chained reconnect breaks lease scoping)",
 			res.OpenFile.ClientGUID, originalGUID)
+	}
+}
+
+// TestProcessDurableHandleContext_V2RequiresBatchOrHandleLease locks in
+// MS-SMB2 §3.3.5.9.10: V2 durability MUST NOT be granted unless OplockLevel
+// is Batch OR the granted lease includes SMB2_LEASE_HANDLE_CACHING.
+// smbtorture smb2.durable-v2-open.open-oplock iterates 8 share-mode × 4
+// oplock-level rows expecting `out.durable_open_v2 == false` for every
+// non-Batch row.
+func TestProcessDurableHandleContext_V2RequiresBatchOrHandleLease(t *testing.T) {
+	createGuid := [16]byte{0xA0, 0xA1, 0xA2}
+	dh2qData := make([]byte, 32)
+	binary.LittleEndian.PutUint32(dh2qData[0:4], 60000)
+	copy(dh2qData[16:32], createGuid[:])
+
+	cases := []struct {
+		name          string
+		oplockLevel   uint8
+		handleLease   bool
+		expectGranted bool
+	}{
+		{"None oplock, no lease", OplockLevelNone, false, false},
+		{"Level II oplock", OplockLevelII, false, false},
+		{"Exclusive oplock", OplockLevelExclusive, false, false},
+		{"Batch oplock", OplockLevelBatch, false, true},
+		{"None oplock, Handle lease", OplockLevelNone, true, true},
+		{"Lease level with Handle", OplockLevelLease, true, true},
+		{"Lease level no Handle", OplockLevelLease, false, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			openFile := &OpenFile{
+				FileID:      [16]byte{1, 2, 3},
+				OplockLevel: c.oplockLevel,
+			}
+			contexts := []CreateContext{
+				{Name: DurableHandleV2RequestTag, Data: dh2qData},
+			}
+			resp := ProcessDurableHandleContext(contexts, openFile, 60000, c.handleLease)
+			granted := resp != nil
+			if granted != c.expectGranted {
+				t.Errorf("granted=%v want %v (oplock=%d handleLease=%v)",
+					granted, c.expectGranted, c.oplockLevel, c.handleLease)
+			}
+			if openFile.IsDurable != c.expectGranted {
+				t.Errorf("IsDurable=%v want %v", openFile.IsDurable, c.expectGranted)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -1039,7 +1039,7 @@ func TestValidateDurableContexts(t *testing.T) {
 		return CreateContext{Name: DurableHandleV1ReconnectTag, Data: make([]byte, 16)}
 	}
 	mkDHnQ := func() CreateContext {
-		// DHnQ uses the same tag as DH2Q on the wire; the length distinguishes.
+		// V1 request: tag "DHnQ", 16 reserved bytes.
 		return CreateContext{Name: DurableHandleV1RequestTag, Data: make([]byte, 16)}
 	}
 
@@ -1179,5 +1179,56 @@ func TestProcessDurableReconnectContext_V2OplockNoClientGUIDCheck(t *testing.T) 
 	}
 	if status != types.StatusSuccess {
 		t.Errorf("oplock V2 reconnect with different ClientGuid: got status %v, want SUCCESS", status)
+	}
+}
+
+// TestValidateAndRestore_ClientGUIDRoundtrip verifies that ClientGUID is
+// restored onto the OpenFile by the reconnect path so the next persist
+// (chained disconnect→reconnect→disconnect) carries the original GUID.
+// Without this, the §3.3.5.9.12 lease-scoping check would no-op on the
+// second reconnect and any client could reclaim a lease-backed durable handle.
+// Locks in Copilot review finding on durable_context.go:742.
+func TestValidateAndRestore_ClientGUIDRoundtrip(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	keyHash := makeSessionKeyHash("session-key")
+	originalGUID := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}
+	leaseKey := [16]byte{0xB0, 0xB1, 0xB2}
+	createGuid := [16]byte{0xC0, 0xC1, 0xC2}
+	fileID := [16]byte{0xD0, 0xD1, 0xD2}
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "h-roundtrip",
+		FileID:         fileID,
+		Path:           "leasefile.txt",
+		ShareName:      "/share1",
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreateGuid:     createGuid,
+		LeaseKey:       leaseKey,
+		ClientGUID:     originalGUID,
+		IsV2:           true,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+		MetadataHandle: []byte{0xAA},
+	})
+
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[:16], fileID[:])
+	copy(dh2cData[16:32], createGuid[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
+		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID)
+	if err != nil || status != types.StatusSuccess {
+		t.Fatalf("reconnect failed: status=%v err=%v", status, err)
+	}
+	if res.OpenFile.ClientGUID != originalGUID {
+		t.Errorf("restored ClientGUID = %x, want %x (Copilot review #1: chained reconnect breaks lease scoping)",
+			res.OpenFile.ClientGUID, originalGUID)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -557,8 +557,14 @@ func NewHandlerWithSessionManager(sessionManager *session.Manager) *Handler {
 		DirectoryLeasingEnabled: true,
 		NtlmEnabled:             true,
 		GuestEnabled:            true,
-		DurableTimeoutMs:        60000, // 60 seconds default durable handle timeout
-		resumeKeys:              newResumeKeyStore(),
+		// Default durable handle timeout: 300s (5 minutes). Matches Samba's
+		// `durable_default_timeout_msec` (source3/smbd/smb2_create.c).
+		// smbtorture asserts this value when the client requests
+		// UINT32_MAX (clamp to server max): smb2.durable-v2-open.create-blob,
+		// reopen1, reopen1a, reopen1a-lease, reopen2, app-instance, … all
+		// CHECK_VAL(io.out.timeout, 300*1000).
+		DurableTimeoutMs: 300000,
+		resumeKeys:       newResumeKeyStore(),
 	}
 
 	// Generate random server GUID

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -404,6 +404,16 @@ type OpenFile struct {
 	// The handle expires this many milliseconds after client disconnects.
 	DurableTimeoutMs uint32
 
+	// ClientGUID is the SMB2 NEGOTIATE ClientGuid of the connection that
+	// established this open. Captured at CREATE time so it can be persisted
+	// with the durable handle and matched against the reconnecting
+	// connection on V2 lease reconnect (smbtorture
+	// smb2.durable-v2-open.reopen1a-lease — reconnect with a different
+	// ClientGuid fails OBJECT_NAME_NOT_FOUND, reconnect with the original
+	// ClientGuid succeeds). Non-lease V2 reconnect (reopen1a/reopen2/...)
+	// does NOT consult this — those tests reconnect with a fresh ClientGuid.
+	ClientGUID [16]byte
+
 	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
 	// (MS-FSCC 2.4.32). Servers track this per-handle so SET/GET via
 	// FilePositionInformation round-trips even though network filesystems

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -63,6 +63,20 @@ type PersistedDurableHandle struct {
 	// OriginalFileID into the new OpenFile so byte-range locks (which key
 	// on OpenID derived from FileID) stay valid across the disconnect.
 	OriginalFileID [16]byte
+
+	// ClientGUID is the 16-byte SMB2 client GUID from the NEGOTIATE that
+	// established the original durable open. Per MS-SMB2 §3.3.5.9.12 and
+	// Samba `smb2_lease_create` / lease-key scoping, V2 *lease-backed*
+	// durable reconnect MUST verify the reconnecting connection's
+	// ClientGUID matches; lease-keys are per-client-GUID, so a different
+	// client must not be able to reclaim the lease. smbtorture
+	// smb2.durable-v2-open.reopen1a-lease asserts that reconnect with a
+	// new random ClientGUID fails OBJECT_NAME_NOT_FOUND while reconnect
+	// with the original ClientGUID succeeds. Oplock-backed (non-lease) V2
+	// durable reconnect is intentionally NOT gated on ClientGUID — the
+	// `reopen1a` (oplock) test reconnects with a different ClientGUID and
+	// expects success. V1 reconnect path does not consult this field.
+	ClientGUID [16]byte
 }
 
 // DurableHandleStore provides persistence for SMB3 durable handle state.

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -235,6 +235,7 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 		IsDirectory:     h.IsDirectory,
 		PositionInfo:    h.PositionInfo,
 		OriginalFileID:  h.OriginalFileID,
+		ClientGUID:      h.ClientGUID,
 	}
 
 	clone.MetadataHandle = bytes.Clone(h.MetadataHandle)


### PR DESCRIPTION
## Summary

First slice of MS-SMB2 SMB3 Durable Handle V2 fixes for #432. Focuses on the highest-impact, lowest-risk corrections so we can land them while the larger disconnected-handle preservation/purge state machine work continues in a follow-up.

**Three independent fixes**, each its own commit:

1. **`ValidateDurableContexts`** (smb2.durable-v2-open.create-blob)
   Enforces MS-SMB2 §3.3.5.9.6/7/11/12 mutual-exclusion of DHnQ/DHnC/DH2Q/DH2C
   create contexts. Mirrors Samba `smbd_smb2_create_send` (~lines 775-846).
   The test exercises four invalid pairs (DH2C+DHnQ, DHnC+DH2Q, DHnC+DH2C,
   DH2C+DH2Q) and expects STATUS_INVALID_PARAMETER.

2. **No DH2Q response blob on reconnect** (broad — affects most reopen* tests)
   Per MS-SMB2 §3.3.5.9.7/§3.3.5.9.12 and Samba behavior, a reconnect
   (DHnC/DH2C) response MUST NOT include a DH2Q grant blob:
   `out.durable_open_v2` must be false and `out.timeout` must be 0. The
   handle stays durable via the server-side `IsDurable` flag — no wire
   signaling on reconnect. Affects: reopen1a, reopen2, reopen2b,
   durable-v2-setinfo, stat-and-lease, nonstat-and-lease, statRH-and-lease,
   two-same-lease, two-different-lease, lock-oplock, lock-lease,
   app-instance, durable_v2_reconnect_delay.

3. **AppInstanceId force-closes LIVE opens** (smb2.durable-v2-open.app-instance)
   Per MS-SMB2 §3.3.5.9.13, a CREATE carrying an AppInstanceId matching an
   existing open MUST claim it. Previously we only force-closed *persisted*
   (disconnected) durable handles with matching AppInstanceId; the test
   keeps tree1 connected when tree2 opens with the same AppInstanceId, so
   the force-close needed to cover live `Handler.files` entries too.
   Implemented via `closeFilesWithFilter(isDisconnect=false, filter=AppInstanceId match)`.

4. **ClientGuid-scoped V2 lease reconnect** (smb2.durable-v2-open.reopen1a-lease)
   V2 lease-backed durable reconnect now verifies the reconnecting
   connection's ClientGuid matches the one captured at CREATE. Mirrors
   Samba per-(ClientGuid, LeaseKey) lease scoping. The test reconnects with
   a different ClientGuid (must fail OBJECT_NAME_NOT_FOUND) and with the
   original (must succeed). Oplock-backed V2 reconnect (reopen1a) is NOT
   gated — that test reconnects with a fresh ClientGuid and expects
   success.

New `ClientGUID` field on `OpenFile` + `lock.PersistedDurableHandle`;
memory store updated; badger uses JSON so it's transparent. Postgres
durable_handles schema is already out of sync with the struct (#663) —
leaving postgres for the broader schema fix tracked there.

## Out of scope (follow-up PRs)

- Disconnected-handle preservation/purge state machine per MS-SMB2 §3.3.4.18 (`keep-disconnected-*`, `purge-disconnected-*`, `lock-noW-lease`)
- DH2Q-specific timeout-min-grant validation refinements
- Persistent handle support (CA-capability share flag + on-disk persistence) — explicitly out of scope of #432 per issue acceptance criteria

## Test plan

- [x] `go test -race ./internal/adapter/smb/v2/handlers/ ./pkg/metadata/lock/ ./pkg/metadata/store/memory/ ./pkg/metadata/store/badger/`
- [x] New unit tests:
  - `TestValidateDurableContexts` (all four invalid pairs + length check)
  - `TestProcessDurableReconnectContext_V2LeaseClientGUIDMismatch`
  - `TestProcessDurableReconnectContext_V2OplockNoClientGUIDCheck`
- [ ] CI smbtorture: confirm flips on `create-blob`, `reopen2b`, `app-instance`, `reopen1a-lease`, `durable_v2_reconnect_delay`, and the broad family of "no dh2q response blob on reconnect" tests
- [ ] No regression in current passing tests

## References

- MS-SMB2 §2.2.13.2.11 (DH2Q), §2.2.13.2.12 (DH2C), §3.3.5.9.6/7/11/12/13, §3.3.4.18
- Samba `source3/smbd/smb2_create.c::smbd_smb2_create_send` (~lines 775-846, 1869-1895)
- smbtorture `source4/torture/smb2/durable_v2_open.c`