### PR TITLE
fix(smb): DH V2 disconnected-handle preservation/purge state machine (#432)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -508,6 +508,40 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	}
 
+	// Step 8a-bis: MS-SMB2 §3.3.4.18 disconnected-handle preservation/purge.
+	//
+	// Evaluate any disconnected durable handles on this metadata handle
+	// against the new open's lease/share-mode and purge those that the new
+	// open's required break_to would knock below H caching. Runs after the
+	// live-lease break (8a) so the disconnected-side check sees the same
+	// post-break view, and before lease grant (8b) so the granted state
+	// reflects only handles that survive the purge. See
+	// disconnected_state_machine.go for the predicate.
+	if fileExists && h.DurableStore != nil && len(fileHandle) > 0 {
+		var newLeaseState uint32
+		var newLeaseKey [16]byte
+		if req.OplockLevel == OplockLevelLease {
+			if lc := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); lc != nil {
+				if parsed, decErr := DecodeLeaseCreateContext(lc.Data); decErr == nil && parsed != nil {
+					newLeaseState = parsed.LeaseState
+					newLeaseKey = parsed.LeaseKey
+				}
+			}
+		}
+		if purged := h.purgeConflictingDisconnectedHandlesForOpen(
+			authCtx.Context,
+			fileHandle,
+			newLeaseState,
+			newLeaseKey,
+			connClientGUID(ctx),
+			req.ShareAccess,
+		); purged > 0 {
+			logger.Debug("CREATE: purged disconnected handles on conflicting open",
+				"path", filename,
+				"count", purged)
+		}
+	}
+
 	// Step 8b: Request oplock or lease if applicable.
 	var grantedOplock uint8
 	var leaseResponse *LeaseResponseContext

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -528,12 +528,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				}
 			}
 		}
+		// This callsite is the FRESH-CREATE path; durable reconnect early-returns
+		// in create.go before reaching here (see create.go::handleCreate, the
+		// ProcessDurableReconnectContext branch). The predicate's contract
+		// relies on this — see disconnectedConflictOnNewOpen doc.
 		if purged := h.purgeConflictingDisconnectedHandlesForOpen(
 			authCtx.Context,
 			fileHandle,
 			newLeaseState,
 			newLeaseKey,
-			connClientGUID(ctx),
 			req.ShareAccess,
 		); purged > 0 {
 			logger.Debug("CREATE: purged disconnected handles on conflicting open",

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -1,0 +1,294 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// MS-SMB2 §3.3.4.18 — Disconnected durable handle preservation/purge state machine.
+//
+// When a client transport-disconnects, an open with IsDurable set is persisted
+// to the DurableHandleStore. While disconnected, operations from OTHER opens on
+// the same underlying file may conflict with the disconnected open's persisted
+// state. This file implements the preserve/purge decision per [MS-SMB2] §3.3.4.18
+// (Server Receives an Object Store Operation) and §3.3.5.9 (Receiving an SMB2
+// CREATE Request, Step 10 share-mode/lease conflict handling) — mirroring
+// Samba's `delay_for_oplock_fn` + `share_mode_cleanup_disconnected` semantics
+// from source3/smbd/open.c and source3/smbd/scavenger.c.
+//
+// Rule summary (validated against smbtorture smb2.durable-v2-open):
+//
+//   - A disconnected open holding a lease that would need to be broken to a
+//     state lacking SMB2_LEASE_HANDLE_CACHING is purged on the spot — the
+//     disconnected client cannot ack the break, so the durable is irrecoverably
+//     lost (Samba sends the break message and the scavenger evicts the entry
+//     after timeout; we collapse the two steps).
+//
+//   - A new open with FILE_SHARE_NONE on a file with a disconnected handle
+//     purges the disconnected handle (share-mode conflict, MS-FSA 2.1.5.1.2).
+//
+//   - A WRITE from a live handle breaks Level-II (Read) leases on the same
+//     file to None per MS-SMB2 §3.3.5.16; any disconnected RH lease on the
+//     file with a different lease-key is purged (it would break to None).
+//
+//   - A RENAME from a live handle breaks Handle leases on the same file to
+//     Read (loses H) per MS-SMB2 §3.3.5.21; any disconnected lease with a
+//     different lease-key is purged (it would lose H).
+//
+// Non-rules (these MUST NOT purge — covered by smb2.durable-v2-open.keep-*):
+//
+//   - A new open with a default share (read|write|delete) on a file with a
+//     disconnected RH/RWH handle does NOT purge the disconnected handle by
+//     itself; the new open instead gets a downgraded lease grant. The grant
+//     downgrade is enforced by the LeaseManager (see bestGrantableState in
+//     pkg/metadata/lock/leases.go); this state machine only intervenes when
+//     the disconnected handle would have to lose H.
+
+// disconnectedHandleAction is the decision the state machine returns for
+// each disconnected handle inspected.
+type disconnectedHandleAction int
+
+const (
+	disconnectedActionPreserve disconnectedHandleAction = iota
+	disconnectedActionPurge
+)
+
+// SMB2 lease bits (mirrors pkg/metadata/lock constants, redefined here to
+// keep this file independent of the lock package's internal naming).
+const (
+	smbLeaseRead   uint32 = 0x01
+	smbLeaseHandle uint32 = 0x02
+	smbLeaseWrite  uint32 = 0x04
+)
+
+// SMB2 share-access bits.
+const (
+	smbShareRead   uint32 = 0x01
+	smbShareWrite  uint32 = 0x02
+	smbShareDelete uint32 = 0x04
+)
+
+// disconnectedConflictOnNewOpen evaluates whether a new CREATE on the same
+// underlying file should purge a disconnected durable handle D.
+//
+// Inputs:
+//   - dLeaseState: the lease state persisted at disconnect (R/RH/RWH bits or None).
+//   - dLeaseKey: D's lease key (for same-key reconnect detection).
+//   - dClientGUID: D's client GUID (for same-client reconnect detection).
+//   - newLeaseState: lease state requested by the new open (zero if no lease).
+//   - newLeaseKey, newClientGUID: identifiers of the new open's lease.
+//   - newShareAccess: share-mode bits from the new CREATE.
+//
+// Decision rules (see file-level comment for spec mapping):
+//
+//   - Same (clientGUID, leaseKey) as D → preserve (this is the reconnect path,
+//     handled by ProcessDurableReconnectContext, not by this predicate).
+//   - newShareAccess excludes all of {READ, WRITE, DELETE} (SHARE_NONE) →
+//     purge (MS-FSA 2.1.5.1.2 share-mode conflict).
+//   - D holds W (RWH) AND new open requests any non-None lease with a
+//     DIFFERENT lease key → purge (two W-capable cachers on different keys
+//     cannot coexist; the break_to value strips W and, per Samba's
+//     delay_for_oplock_fn lease-strip cascade, leaves W-only which is an
+//     invalid lease state → effectively break to NONE → lose H).
+//   - Otherwise → preserve.
+func disconnectedConflictOnNewOpen(
+	dLeaseState uint32,
+	dLeaseKey [16]byte,
+	dClientGUID [16]byte,
+	newLeaseState uint32,
+	newLeaseKey [16]byte,
+	newClientGUID [16]byte,
+	newShareAccess uint32,
+) disconnectedHandleAction {
+	// Same lease key + client GUID → this is the reconnect path. Let the
+	// dedicated reconnect handler decide; we MUST NOT purge here.
+	if dLeaseKey == newLeaseKey && dLeaseKey != ([16]byte{}) && dClientGUID == newClientGUID {
+		return disconnectedActionPreserve
+	}
+
+	// SHARE_NONE conflict: any disconnected handle is purged because the
+	// disconnected open held shared access and the new open denies it.
+	if newShareAccess&(smbShareRead|smbShareWrite|smbShareDelete) == 0 {
+		return disconnectedActionPurge
+	}
+
+	// W-on-W conflict on different keys: the disconnected handle held W,
+	// new open requests any non-None lease (W or RH). Even an RH request
+	// from a different key forces the W-holder to lose W; in Samba this
+	// cascades through the candidate downgrade chain (RWH → RH → R → NONE)
+	// and lands on a state lacking H because the disconnected holder cannot
+	// ack the in-flight break. Purge.
+	if dLeaseState&smbLeaseWrite != 0 && newLeaseState != 0 {
+		return disconnectedActionPurge
+	}
+
+	return disconnectedActionPreserve
+}
+
+// disconnectedConflictOnDataChange evaluates whether a WRITE or RENAME from a
+// live opener should purge a disconnected durable handle D.
+//
+// excludeLeaseKey is the lease key of the actor (writer / renamer). Handles
+// matching that key are preserved — the actor holding the lease cannot be
+// breaking its own lease.
+//
+// breakToBelowHandle is true when the action's break_to value strips
+// SMB2_LEASE_HANDLE from the broken lease. Writes break Level-II to None
+// (lose H). Renames break Handle leases to R (lose H). Both cases purge any
+// disconnected handle holding a lease whose key differs from the actor's,
+// because the disconnected client cannot ack the break.
+func disconnectedConflictOnDataChange(
+	dLeaseState uint32,
+	dLeaseKey [16]byte,
+	excludeLeaseKey [16]byte,
+	breakToBelowHandle bool,
+) disconnectedHandleAction {
+	if !breakToBelowHandle {
+		return disconnectedActionPreserve
+	}
+	// Same actor — never purge our own handle.
+	if dLeaseKey == excludeLeaseKey && dLeaseKey != ([16]byte{}) {
+		return disconnectedActionPreserve
+	}
+	// D holds no lease — there is nothing to break; preserve.
+	if dLeaseState == 0 {
+		return disconnectedActionPreserve
+	}
+	return disconnectedActionPurge
+}
+
+// purgeConflictingDisconnectedHandlesForOpen scans disconnected handles for
+// the underlying file (keyed by metadata handle) and purges those that
+// conflict with the new open under §3.3.4.18.
+//
+// Returns the number of purged handles. Errors looking up the store are
+// logged at debug — purge is best-effort and must not block CREATE.
+func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
+	ctx context.Context,
+	metaHandle []byte,
+	newLeaseState uint32,
+	newLeaseKey [16]byte,
+	newClientGUID [16]byte,
+	newShareAccess uint32,
+) int {
+	if h.DurableStore == nil || len(metaHandle) == 0 {
+		return 0
+	}
+	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
+	if err != nil {
+		logger.Debug("purgeConflictingDisconnectedHandlesForOpen: lookup failed",
+			"error", err)
+		return 0
+	}
+	if len(handles) == 0 {
+		return 0
+	}
+	var purged int
+	for _, d := range handles {
+		// Only consider handles that survived a transport disconnect — the
+		// store may transiently hold pre-disconnect rows on some backends.
+		if d.DisconnectedAt.IsZero() {
+			continue
+		}
+		action := disconnectedConflictOnNewOpen(
+			d.LeaseState, d.LeaseKey, d.ClientGUID,
+			newLeaseState, newLeaseKey, newClientGUID,
+			newShareAccess,
+		)
+		if action != disconnectedActionPurge {
+			continue
+		}
+		h.purgeOneDisconnectedHandle(ctx, d, "new-open conflict")
+		purged++
+	}
+	return purged
+}
+
+// purgeConflictingDisconnectedHandlesForDataChange scans disconnected handles
+// for the underlying file and purges those that would lose H caching due to
+// the actor's WRITE or RENAME.
+func (h *Handler) purgeConflictingDisconnectedHandlesForDataChange(
+	ctx context.Context,
+	metaHandle []byte,
+	excludeLeaseKey [16]byte,
+	breakToBelowHandle bool,
+) int {
+	if h.DurableStore == nil || len(metaHandle) == 0 || !breakToBelowHandle {
+		return 0
+	}
+	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
+	if err != nil {
+		logger.Debug("purgeConflictingDisconnectedHandlesForDataChange: lookup failed",
+			"error", err)
+		return 0
+	}
+	if len(handles) == 0 {
+		return 0
+	}
+	var purged int
+	for _, d := range handles {
+		if d.DisconnectedAt.IsZero() {
+			continue
+		}
+		action := disconnectedConflictOnDataChange(
+			d.LeaseState, d.LeaseKey, excludeLeaseKey, breakToBelowHandle,
+		)
+		if action != disconnectedActionPurge {
+			continue
+		}
+		h.purgeOneDisconnectedHandle(ctx, d, "data-change break")
+		purged++
+	}
+	return purged
+}
+
+// purgeOneDisconnectedHandle deletes a single disconnected handle and releases
+// its locks. Mirrors the cleanup half of DurableHandleScavenger.cleanupAndDelete
+// but is callable from CREATE/WRITE/RENAME hot paths without the scavenger
+// ticker overhead.
+func (h *Handler) purgeOneDisconnectedHandle(
+	ctx context.Context,
+	d *lock.PersistedDurableHandle,
+	reason string,
+) {
+	if h.Registry != nil {
+		if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil && len(d.MetadataHandle) > 0 {
+			// SessionID 0 mirrors DurableHandleScavenger: not tied to a session.
+			if err := metaSvc.UnlockAllForSession(ctx, d.MetadataHandle, 0); err != nil {
+				logger.Debug("purgeOneDisconnectedHandle: lock release failed",
+					"id", d.ID, "path", d.Path, "error", err)
+			}
+		}
+	}
+	if err := h.DurableStore.DeleteDurableHandle(ctx, d.ID); err != nil {
+		logger.Warn("purgeOneDisconnectedHandle: delete failed",
+			"id", d.ID, "path", d.Path, "error", err)
+		return
+	}
+	logger.Debug("purgeOneDisconnectedHandle: purged disconnected handle",
+		"id", d.ID,
+		"path", d.Path,
+		"leaseState", fmt.Sprintf("0x%x", d.LeaseState),
+		"reason", reason)
+}
+
+// shouldPersistDurableOnDisconnect returns false when an open MUST NOT be
+// persisted as a durable handle at transport-disconnect time, even if it
+// carries IsDurable. Per MS-SMB2 §3.3.4.18 and smb2.durable-v2-open.lock-noW-lease,
+// an open holding a byte-range lock under a lease that lacks W (write caching)
+// cannot reliably resume: the BR-lock is bound to the open's OpenID and the
+// lease cannot promote to W on reconnect without breaking other holders.
+// Samba's `vfs_default_durable_disconnect` mirrors this by returning
+// NT_STATUS_NOT_SUPPORTED, which falls through to a normal close.
+func shouldPersistDurableOnDisconnect(
+	leaseState uint32,
+	hasByteRangeLocks bool,
+) bool {
+	if hasByteRangeLocks && leaseState&smbLeaseWrite == 0 {
+		return false
+	}
+	return true
+}

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -56,12 +56,11 @@ const (
 	disconnectedActionPurge
 )
 
-// SMB2 lease bits (mirrors pkg/metadata/lock constants, redefined here to
-// keep this file independent of the lock package's internal naming).
+// SMB2 lease bits. Import from pkg/metadata/lock so we don't drift on rename.
 const (
-	smbLeaseRead   uint32 = 0x01
-	smbLeaseHandle uint32 = 0x02
-	smbLeaseWrite  uint32 = 0x04
+	smbLeaseRead   = lock.LeaseStateRead
+	smbLeaseHandle = lock.LeaseStateHandle
+	smbLeaseWrite  = lock.LeaseStateWrite
 )
 
 // SMB2 share-access bits.
@@ -71,21 +70,28 @@ const (
 	smbShareDelete uint32 = 0x04
 )
 
-// disconnectedConflictOnNewOpen evaluates whether a new CREATE on the same
-// underlying file should purge a disconnected durable handle D.
+// disconnectedConflictOnNewOpen evaluates whether a FRESH (non-reconnect)
+// CREATE on the same underlying file should purge a disconnected durable
+// handle D.
+//
+// Contract: this predicate MUST NOT be called from a durable reconnect
+// CREATE (DHnC / DH2C). Reconnect is handled by ProcessDurableReconnectContext
+// which restores the persisted handle without consulting this predicate; by
+// the time control reaches the steady-state CREATE path that calls into us,
+// the disconnect-vs-reconnect choice has already been made. The single
+// callsite (create_post_break.go::handleCreate) only runs on the fresh path
+// because create.go::handleCreate's reconnect branch early-returns before
+// reaching Step 8a-bis.
 //
 // Inputs:
 //   - dLeaseState: the lease state persisted at disconnect (R/RH/RWH bits or None).
-//   - dLeaseKey: D's lease key (for same-key reconnect detection).
-//   - dClientGUID: D's client GUID (for same-client reconnect detection).
+//   - dLeaseKey: D's lease key.
 //   - newLeaseState: lease state requested by the new open (zero if no lease).
-//   - newLeaseKey, newClientGUID: identifiers of the new open's lease.
+//   - newLeaseKey: lease key of the new open's lease (zero if no lease).
 //   - newShareAccess: share-mode bits from the new CREATE.
 //
 // Decision rules (see file-level comment for spec mapping):
 //
-//   - Same (clientGUID, leaseKey) as D → preserve (this is the reconnect path,
-//     handled by ProcessDurableReconnectContext, not by this predicate).
 //   - newShareAccess excludes all of {READ, WRITE, DELETE} (SHARE_NONE) →
 //     purge (MS-FSA 2.1.5.1.2 share-mode conflict).
 //   - D holds W (RWH) AND new open requests any non-None lease with a
@@ -97,18 +103,10 @@ const (
 func disconnectedConflictOnNewOpen(
 	dLeaseState uint32,
 	dLeaseKey [16]byte,
-	dClientGUID [16]byte,
 	newLeaseState uint32,
 	newLeaseKey [16]byte,
-	newClientGUID [16]byte,
 	newShareAccess uint32,
 ) disconnectedHandleAction {
-	// Same lease key + client GUID → this is the reconnect path. Let the
-	// dedicated reconnect handler decide; we MUST NOT purge here.
-	if dLeaseKey == newLeaseKey && dLeaseKey != ([16]byte{}) && dClientGUID == newClientGUID {
-		return disconnectedActionPreserve
-	}
-
 	// SHARE_NONE conflict: any disconnected handle is purged because the
 	// disconnected open held shared access and the new open denies it.
 	if newShareAccess&(smbShareRead|smbShareWrite|smbShareDelete) == 0 {
@@ -121,8 +119,14 @@ func disconnectedConflictOnNewOpen(
 	// cascades through the candidate downgrade chain (RWH → RH → R → NONE)
 	// and lands on a state lacking H because the disconnected holder cannot
 	// ack the in-flight break. Purge.
+	//
+	// Key comparison treats a zero lease key as "no key" — distinct from any
+	// other key, including another zero. This matters for oplock-V2 / no-lease
+	// opens on both sides: they cannot coexist with a W-holder either.
 	if dLeaseState&smbLeaseWrite != 0 && newLeaseState != 0 {
-		return disconnectedActionPurge
+		if dLeaseKey != newLeaseKey || dLeaseKey == ([16]byte{}) {
+			return disconnectedActionPurge
+		}
 	}
 
 	return disconnectedActionPreserve
@@ -171,17 +175,22 @@ func disconnectedConflictOnDataChange(
 //
 // Returns the number of purged handles. Errors looking up the store are
 // logged at debug — purge is best-effort and must not block CREATE.
+//
+// Holds Handler.durablePurgeMu across the Get→Delete window so a concurrent
+// disconnect persist (handler.go:closeFilesMatching) cannot Put a new
+// disconnected handle between our snapshot and the per-id Delete.
 func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 	ctx context.Context,
 	metaHandle []byte,
 	newLeaseState uint32,
 	newLeaseKey [16]byte,
-	newClientGUID [16]byte,
 	newShareAccess uint32,
 ) int {
 	if h.DurableStore == nil || len(metaHandle) == 0 {
 		return 0
 	}
+	h.durablePurgeMu.Lock()
+	defer h.durablePurgeMu.Unlock()
 	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
 	if err != nil {
 		logger.Debug("purgeConflictingDisconnectedHandlesForOpen: lookup failed",
@@ -199,8 +208,8 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 			continue
 		}
 		action := disconnectedConflictOnNewOpen(
-			d.LeaseState, d.LeaseKey, d.ClientGUID,
-			newLeaseState, newLeaseKey, newClientGUID,
+			d.LeaseState, d.LeaseKey,
+			newLeaseState, newLeaseKey,
 			newShareAccess,
 		)
 		if action != disconnectedActionPurge {
@@ -215,6 +224,9 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 // purgeConflictingDisconnectedHandlesForDataChange scans disconnected handles
 // for the underlying file and purges those that would lose H caching due to
 // the actor's WRITE or RENAME.
+//
+// Holds Handler.durablePurgeMu across the Get→Delete window for the same
+// reason as purgeConflictingDisconnectedHandlesForOpen.
 func (h *Handler) purgeConflictingDisconnectedHandlesForDataChange(
 	ctx context.Context,
 	metaHandle []byte,
@@ -224,6 +236,8 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForDataChange(
 	if h.DurableStore == nil || len(metaHandle) == 0 || !breakToBelowHandle {
 		return 0
 	}
+	h.durablePurgeMu.Lock()
+	defer h.durablePurgeMu.Unlock()
 	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
 	if err != nil {
 		logger.Debug("purgeConflictingDisconnectedHandlesForDataChange: lookup failed",
@@ -261,7 +275,7 @@ func (h *Handler) purgeOneDisconnectedHandle(
 		if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil && len(d.MetadataHandle) > 0 {
 			// SessionID 0 mirrors DurableHandleScavenger: not tied to a session.
 			if err := metaSvc.UnlockAllForSession(ctx, d.MetadataHandle, 0); err != nil {
-				logger.Debug("purgeOneDisconnectedHandle: lock release failed",
+				logger.Warn("purgeOneDisconnectedHandle: lock release failed",
 					"id", d.ID, "path", d.Path, "error", err)
 			}
 		}

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -140,21 +140,26 @@ func disconnectedConflictOnNewOpen(
 // (lose H). Renames break Handle leases to R (lose H). Both cases purge any
 // disconnected handle holding a lease whose key differs from the actor's,
 // because the disconnected client cannot ack the break.
+//
+// dLeaseState == 0 is treated as "no caching rights and no reconnect prospect"
+// → purge. A disconnected handle whose lease was already downgraded to None
+// pre-disconnect (e.g. a lease break the client acked before the transport
+// dropped) is unreconnectable: the persisted LeaseState=0 record cannot
+// re-establish caching on reconnect, so leaving it in place only serves to
+// block subsequent break-cascade decisions until the scavenger times it out.
+// Mirrors Samba `share_mode_cleanup_disconnected` which evicts entries
+// lacking caching bits on the same trigger paths.
+//
+// Contract: the caller (purgeConflictingDisconnectedHandlesForDataChange) is
+// responsible for the fast-path `breakToBelowHandle == false` early-return.
+// This predicate assumes the data-change WILL break to below H and only
+// distinguishes own-handle (preserve) from foreign-handle (purge).
 func disconnectedConflictOnDataChange(
-	dLeaseState uint32,
 	dLeaseKey [16]byte,
 	excludeLeaseKey [16]byte,
-	breakToBelowHandle bool,
 ) disconnectedHandleAction {
-	if !breakToBelowHandle {
-		return disconnectedActionPreserve
-	}
 	// Same actor — never purge our own handle.
 	if dLeaseKey == excludeLeaseKey && dLeaseKey != ([16]byte{}) {
-		return disconnectedActionPreserve
-	}
-	// D holds no lease — there is nothing to break; preserve.
-	if dLeaseState == 0 {
 		return disconnectedActionPreserve
 	}
 	return disconnectedActionPurge
@@ -233,9 +238,7 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForDataChange(
 		if d.DisconnectedAt.IsZero() {
 			continue
 		}
-		action := disconnectedConflictOnDataChange(
-			d.LeaseState, d.LeaseKey, excludeLeaseKey, breakToBelowHandle,
-		)
+		action := disconnectedConflictOnDataChange(d.LeaseKey, excludeLeaseKey)
 		if action != disconnectedActionPurge {
 			continue
 		}

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -273,10 +273,22 @@ func (h *Handler) purgeOneDisconnectedHandle(
 ) {
 	if h.Registry != nil {
 		if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil && len(d.MetadataHandle) > 0 {
-			// SessionID 0 mirrors DurableHandleScavenger: not tied to a session.
-			if err := metaSvc.UnlockAllForSession(ctx, d.MetadataHandle, 0); err != nil {
+			// Release byte-range locks held by the disconnected open. SMB
+			// locks are keyed by per-open OpenID (derived from the original
+			// FileID — see OpenFile.OpenID), NOT by SessionID. The persisted
+			// OriginalFileID is the full 16-byte FileID captured at the
+			// first CREATE; reconstruct the OpenID via the same formula so
+			// the release matches the recording side. Older persisted rows
+			// (pre-OriginalFileID) decode to all zeros — fall back to
+			// FileID for forward compatibility.
+			fileID := d.OriginalFileID
+			if fileID == ([16]byte{}) {
+				fileID = d.FileID
+			}
+			openID := fmt.Sprintf("%x", fileID)
+			if err := metaSvc.UnlockAllForOpen(ctx, d.MetadataHandle, openID); err != nil {
 				logger.Warn("purgeOneDisconnectedHandle: lock release failed",
-					"id", d.ID, "path", d.Path, "error", err)
+					"id", d.ID, "path", d.Path, "openID", openID, "error", err)
 			}
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -424,4 +425,49 @@ func TestShouldPersistDurableOnDisconnect(t *testing.T) {
 	if shouldPersistDurableOnDisconnect(0, true) {
 		t.Fatal("BR-locks without lease must refuse persist")
 	}
+}
+
+// TestOpenHasLocksFailClosed pins the fail-closed semantics of the
+// disconnect-time lock-noW-lease gate: any uncertainty about whether the
+// open holds byte-range locks MUST resolve to "has locks" so the caller
+// refuses to persist a durable handle that could silently bypass the gate.
+func TestOpenHasLocksFailClosed(t *testing.T) {
+	t.Run("nil open returns false (nothing to gate)", func(t *testing.T) {
+		if openHasLocks(nil, nil) {
+			t.Fatal("nil open must return false; caller short-circuits")
+		}
+	})
+
+	t.Run("optimistic flag true is authoritative", func(t *testing.T) {
+		of := &OpenFile{}
+		of.HasByteRangeLocks.Store(true)
+		if !openHasLocks(nil, of) {
+			t.Fatal("flag=true must report has-locks regardless of meta service")
+		}
+	})
+
+	t.Run("nil meta service with flag false fails closed", func(t *testing.T) {
+		of := &OpenFile{MetadataHandle: []byte("ignored-without-svc")}
+		if !openHasLocks(nil, of) {
+			t.Fatal("missing meta service must fail closed (return true)")
+		}
+	})
+
+	t.Run("empty metadata handle with svc fails closed", func(t *testing.T) {
+		svc := metadata.New()
+		of := &OpenFile{}
+		if !openHasLocks(svc, of) {
+			t.Fatal("empty metadata handle must fail closed (return true)")
+		}
+	})
+
+	t.Run("malformed handle (decode failure) fails closed", func(t *testing.T) {
+		svc := metadata.New()
+		// Garbage bytes that DecodeFileHandle will reject, forcing
+		// GetLockManagerForHandle to return an error.
+		of := &OpenFile{MetadataHandle: []byte{0xff, 0xff, 0xff, 0xff}}
+		if !openHasLocks(svc, of) {
+			t.Fatal("lock manager lookup failure must fail closed (return true)")
+		}
+	})
 }

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -1,0 +1,213 @@
+package handlers
+
+import "testing"
+
+// TestDisconnectedConflictOnNewOpen exercises the MS-SMB2 §3.3.4.18 truth
+// table for new CREATE opens against disconnected durable handles, mirroring
+// the matrix asserted by smb2.durable-v2-open.{keep,purge}-disconnected-* in
+// source4/torture/smb2/durable_v2_open.c.
+func TestDisconnectedConflictOnNewOpen(t *testing.T) {
+	const (
+		rh          = smbLeaseRead | smbLeaseHandle
+		rwh         = smbLeaseRead | smbLeaseHandle | smbLeaseWrite
+		none uint32 = 0
+
+		shareAll         = smbShareRead | smbShareWrite | smbShareDelete
+		shareNone uint32 = 0
+	)
+
+	leaseA := [16]byte{0x01}
+	leaseB := [16]byte{0x02}
+	clientA := [16]byte{0xA1}
+	clientB := [16]byte{0xB1}
+
+	tests := []struct {
+		name           string
+		dLeaseState    uint32
+		dLeaseKey      [16]byte
+		dClientGUID    [16]byte
+		newLeaseState  uint32
+		newLeaseKey    [16]byte
+		newClientGUID  [16]byte
+		newShareAccess uint32
+		want           disconnectedHandleAction
+	}{
+		{
+			// keep-disconnected-rh-with-stat-open: stat open carries no lease
+			// and default share-all. Disconnected RH must be preserved.
+			name:           "keep_RH_with_stat",
+			dLeaseState:    rh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  none,
+			newLeaseKey:    [16]byte{},
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPreserve,
+		},
+		{
+			// keep-disconnected-rwh-with-stat-open mirrors keep_RH_with_stat:
+			// disconnected RWH with stat open from a different connection
+			// must also be preserved (stat open does not break leases).
+			name:           "keep_RWH_with_stat",
+			dLeaseState:    rwh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  none,
+			newLeaseKey:    [16]byte{},
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPreserve,
+		},
+		{
+			// keep-disconnected-rh-with-rh-open: two RH leases on different
+			// keys can coexist — disconnected stays.
+			name:           "keep_RH_with_RH_diff_key",
+			dLeaseState:    rh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  rh,
+			newLeaseKey:    leaseB,
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPreserve,
+		},
+		{
+			// keep-disconnected-rh-with-rwh-open: disconnected RH stays
+			// even when the new open requests RWH — the new open just gets
+			// downgraded to RH (W denied by the H-holder), no break needed.
+			name:           "keep_RH_with_RWH_diff_key",
+			dLeaseState:    rh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  rwh,
+			newLeaseKey:    leaseB,
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPreserve,
+		},
+		{
+			// purge-disconnected-rwh-with-rwh-open: disconnected RWH and a
+			// new RWH on a different key cannot coexist; the disconnected
+			// loses W → loses H → purge.
+			name:           "purge_RWH_with_RWH_diff_key",
+			dLeaseState:    rwh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  rwh,
+			newLeaseKey:    leaseB,
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPurge,
+		},
+		{
+			// purge-disconnected-rwh-with-rh-open: disconnected RWH and a
+			// new RH on a different key. The W must be broken; cascade
+			// strips H → purge.
+			name:           "purge_RWH_with_RH_diff_key",
+			dLeaseState:    rwh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  rh,
+			newLeaseKey:    leaseB,
+			newClientGUID:  clientB,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPurge,
+		},
+		{
+			// purge-disconnected-rh-with-share-none-open: SHARE_NONE open on
+			// a file with a disconnected RH must purge.
+			name:           "purge_RH_with_share_none",
+			dLeaseState:    rh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  none,
+			newLeaseKey:    [16]byte{},
+			newClientGUID:  clientB,
+			newShareAccess: shareNone,
+			want:           disconnectedActionPurge,
+		},
+		{
+			// Reconnect path guard: the same (clientGuid, leaseKey) is the
+			// reconnect path and must NEVER be purged here.
+			name:           "reconnect_same_guid_and_key",
+			dLeaseState:    rwh,
+			dLeaseKey:      leaseA,
+			dClientGUID:    clientA,
+			newLeaseState:  rwh,
+			newLeaseKey:    leaseA,
+			newClientGUID:  clientA,
+			newShareAccess: shareAll,
+			want:           disconnectedActionPreserve,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := disconnectedConflictOnNewOpen(
+				tc.dLeaseState, tc.dLeaseKey, tc.dClientGUID,
+				tc.newLeaseState, tc.newLeaseKey, tc.newClientGUID,
+				tc.newShareAccess,
+			)
+			if got != tc.want {
+				t.Fatalf("got=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDisconnectedConflictOnDataChange covers the WRITE/RENAME break paths.
+func TestDisconnectedConflictOnDataChange(t *testing.T) {
+	leaseA := [16]byte{0x01}
+	leaseB := [16]byte{0x02}
+	rh := smbLeaseRead | smbLeaseHandle
+
+	// Writer's lease (excludeLeaseKey == leaseA) → its own disconnected D
+	// entries are never purged on its own WRITE/RENAME.
+	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseA, true); got != disconnectedActionPreserve {
+		t.Fatalf("same key: got=%v want preserve", got)
+	}
+
+	// Different lease key + break_to lacks H → purge.
+	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseB, true); got != disconnectedActionPurge {
+		t.Fatalf("diff key with break_below_H: got=%v want purge", got)
+	}
+
+	// break_to retains H (no destructive break) → preserve.
+	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseB, false); got != disconnectedActionPreserve {
+		t.Fatalf("break preserves H: got=%v want preserve", got)
+	}
+
+	// D holds no lease (lease cleared on disconnect) → nothing to break.
+	if got := disconnectedConflictOnDataChange(0, leaseA, leaseB, true); got != disconnectedActionPreserve {
+		t.Fatalf("no lease: got=%v want preserve", got)
+	}
+}
+
+// TestShouldPersistDurableOnDisconnect pins down the lock-noW-lease persist
+// gate (smb2.durable-v2-open.lock-noW-lease, MS-SMB2 §3.3.4.18).
+func TestShouldPersistDurableOnDisconnect(t *testing.T) {
+	rh := smbLeaseRead | smbLeaseHandle
+	rwh := smbLeaseRead | smbLeaseHandle | smbLeaseWrite
+
+	// No locks → always persist.
+	if !shouldPersistDurableOnDisconnect(rh, false) {
+		t.Fatal("no BR-locks must persist regardless of lease state")
+	}
+	if !shouldPersistDurableOnDisconnect(0, false) {
+		t.Fatal("no BR-locks must persist even without lease")
+	}
+
+	// BR-locks + lease has W → persist (W can re-establish on reconnect).
+	if !shouldPersistDurableOnDisconnect(rwh, true) {
+		t.Fatal("BR-locks with W lease must persist")
+	}
+
+	// BR-locks + lease lacks W → MUST refuse (lock-noW-lease).
+	if shouldPersistDurableOnDisconnect(rh, true) {
+		t.Fatal("BR-locks under non-W lease must refuse persist")
+	}
+	if shouldPersistDurableOnDisconnect(0, true) {
+		t.Fatal("BR-locks without lease must refuse persist")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -157,30 +157,38 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 }
 
 // TestDisconnectedConflictOnDataChange covers the WRITE/RENAME break paths.
+// The fast-path `breakToBelowHandle == false` early-return is the caller's
+// responsibility; the predicate here only distinguishes own-handle (preserve)
+// from foreign-handle (purge), including the LeaseState=0 case (purged
+// because such a handle has no caching rights and no reconnect prospect).
 func TestDisconnectedConflictOnDataChange(t *testing.T) {
 	leaseA := [16]byte{0x01}
 	leaseB := [16]byte{0x02}
-	rh := smbLeaseRead | smbLeaseHandle
 
 	// Writer's lease (excludeLeaseKey == leaseA) → its own disconnected D
 	// entries are never purged on its own WRITE/RENAME.
-	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseA, true); got != disconnectedActionPreserve {
+	if got := disconnectedConflictOnDataChange(leaseA, leaseA); got != disconnectedActionPreserve {
 		t.Fatalf("same key: got=%v want preserve", got)
 	}
 
-	// Different lease key + break_to lacks H → purge.
-	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseB, true); got != disconnectedActionPurge {
-		t.Fatalf("diff key with break_below_H: got=%v want purge", got)
+	// Different lease key → purge.
+	if got := disconnectedConflictOnDataChange(leaseA, leaseB); got != disconnectedActionPurge {
+		t.Fatalf("diff key: got=%v want purge", got)
 	}
 
-	// break_to retains H (no destructive break) → preserve.
-	if got := disconnectedConflictOnDataChange(rh, leaseA, leaseB, false); got != disconnectedActionPreserve {
-		t.Fatalf("break preserves H: got=%v want preserve", got)
+	// Disconnected handle with all-zero lease key (no lease persisted) is
+	// foreign to any keyed actor and gets purged. This pins the finding-#1
+	// fix: dLeaseState=0 records (which always carry zero lease keys) no
+	// longer silently preserve.
+	if got := disconnectedConflictOnDataChange([16]byte{}, leaseA); got != disconnectedActionPurge {
+		t.Fatalf("zero key vs foreign actor: got=%v want purge", got)
 	}
 
-	// D holds no lease (lease cleared on disconnect) → nothing to break.
-	if got := disconnectedConflictOnDataChange(0, leaseA, leaseB, true); got != disconnectedActionPreserve {
-		t.Fatalf("no lease: got=%v want preserve", got)
+	// Both keys zero → still purge: the same-actor short-circuit explicitly
+	// requires the key to be non-zero before treating it as "same actor",
+	// otherwise every zero-key actor would be treated as the same.
+	if got := disconnectedConflictOnDataChange([16]byte{}, [16]byte{}); got != disconnectedActionPurge {
+		t.Fatalf("both zero keys: got=%v want purge", got)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -1,11 +1,21 @@
 package handlers
 
-import "testing"
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
 
 // TestDisconnectedConflictOnNewOpen exercises the MS-SMB2 §3.3.4.18 truth
-// table for new CREATE opens against disconnected durable handles, mirroring
-// the matrix asserted by smb2.durable-v2-open.{keep,purge}-disconnected-* in
-// source4/torture/smb2/durable_v2_open.c.
+// table for FRESH (non-reconnect) CREATE opens against disconnected durable
+// handles, mirroring the matrix asserted by
+// smb2.durable-v2-open.{keep,purge}-disconnected-* in
+// source4/torture/smb2/durable_v2_open.c. The reconnect path is handled
+// upstream by ProcessDurableReconnectContext and never reaches this
+// predicate — see the contract comment on disconnectedConflictOnNewOpen.
 func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 	const (
 		rh          = smbLeaseRead | smbLeaseHandle
@@ -18,17 +28,13 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 
 	leaseA := [16]byte{0x01}
 	leaseB := [16]byte{0x02}
-	clientA := [16]byte{0xA1}
-	clientB := [16]byte{0xB1}
 
 	tests := []struct {
 		name           string
 		dLeaseState    uint32
 		dLeaseKey      [16]byte
-		dClientGUID    [16]byte
 		newLeaseState  uint32
 		newLeaseKey    [16]byte
-		newClientGUID  [16]byte
 		newShareAccess uint32
 		want           disconnectedHandleAction
 	}{
@@ -38,10 +44,8 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			name:           "keep_RH_with_stat",
 			dLeaseState:    rh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  none,
 			newLeaseKey:    [16]byte{},
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPreserve,
 		},
@@ -52,23 +56,20 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			name:           "keep_RWH_with_stat",
 			dLeaseState:    rwh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  none,
 			newLeaseKey:    [16]byte{},
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPreserve,
 		},
 		{
 			// keep-disconnected-rh-with-rh-open: two RH leases on different
-			// keys can coexist — disconnected stays.
+			// keys can coexist — disconnected stays. Reaches the W-on-W rule
+			// but D doesn't hold W, so falls through to preserve.
 			name:           "keep_RH_with_RH_diff_key",
 			dLeaseState:    rh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  rh,
 			newLeaseKey:    leaseB,
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPreserve,
 		},
@@ -76,13 +77,12 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			// keep-disconnected-rh-with-rwh-open: disconnected RH stays
 			// even when the new open requests RWH — the new open just gets
 			// downgraded to RH (W denied by the H-holder), no break needed.
+			// D doesn't hold W, so the W-on-W rule doesn't fire.
 			name:           "keep_RH_with_RWH_diff_key",
 			dLeaseState:    rh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  rwh,
 			newLeaseKey:    leaseB,
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPreserve,
 		},
@@ -93,10 +93,8 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			name:           "purge_RWH_with_RWH_diff_key",
 			dLeaseState:    rwh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  rwh,
 			newLeaseKey:    leaseB,
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPurge,
 		},
@@ -107,10 +105,8 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			name:           "purge_RWH_with_RH_diff_key",
 			dLeaseState:    rwh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  rh,
 			newLeaseKey:    leaseB,
-			newClientGUID:  clientB,
 			newShareAccess: shareAll,
 			want:           disconnectedActionPurge,
 		},
@@ -120,33 +116,32 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			name:           "purge_RH_with_share_none",
 			dLeaseState:    rh,
 			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
 			newLeaseState:  none,
 			newLeaseKey:    [16]byte{},
-			newClientGUID:  clientB,
 			newShareAccess: shareNone,
 			want:           disconnectedActionPurge,
 		},
 		{
-			// Reconnect path guard: the same (clientGuid, leaseKey) is the
-			// reconnect path and must NEVER be purged here.
-			name:           "reconnect_same_guid_and_key",
+			// Zero-key W-holder vs new lease (any key): zero key is "no key"
+			// and never matches another, including another zero. Two opens
+			// with empty lease keys cannot coexist on a W lease. This pins
+			// the finding-#4 behaviour where oplock-V2 (no lease) reconnect
+			// no longer accidentally hides behind the old reconnect-guard.
+			name:           "purge_RWH_zero_key_vs_RH",
 			dLeaseState:    rwh,
-			dLeaseKey:      leaseA,
-			dClientGUID:    clientA,
-			newLeaseState:  rwh,
-			newLeaseKey:    leaseA,
-			newClientGUID:  clientA,
+			dLeaseKey:      [16]byte{},
+			newLeaseState:  rh,
+			newLeaseKey:    leaseB,
 			newShareAccess: shareAll,
-			want:           disconnectedActionPreserve,
+			want:           disconnectedActionPurge,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := disconnectedConflictOnNewOpen(
-				tc.dLeaseState, tc.dLeaseKey, tc.dClientGUID,
-				tc.newLeaseState, tc.newLeaseKey, tc.newClientGUID,
+				tc.dLeaseState, tc.dLeaseKey,
+				tc.newLeaseState, tc.newLeaseKey,
 				tc.newShareAccess,
 			)
 			if got != tc.want {
@@ -190,6 +185,217 @@ func TestDisconnectedConflictOnDataChange(t *testing.T) {
 	if got := disconnectedConflictOnDataChange([16]byte{}, [16]byte{}); got != disconnectedActionPurge {
 		t.Fatalf("both zero keys: got=%v want purge", got)
 	}
+}
+
+// TestPurgeConflictingDisconnectedHandlesForDataChange covers the wrapper
+// behaviour: only handles with non-zero DisconnectedAt are inspected, the
+// predicate is invoked per-handle, and the durablePurgeMu critical section
+// covers the Get → Delete window. Mock store reuses durable_scavenger_test.go's
+// mockDurableStore.
+func TestPurgeConflictingDisconnectedHandlesForDataChange(t *testing.T) {
+	now := time.Now()
+	metaHandle := []byte("file-handle-1")
+
+	tests := []struct {
+		name            string
+		seed            []*lock.PersistedDurableHandle
+		excludeLeaseKey [16]byte
+		breakBelowH     bool
+		wantPurged      int
+		wantRemaining   int
+	}{
+		{
+			name: "preserves_own_handle",
+			seed: []*lock.PersistedDurableHandle{
+				{
+					ID:             "self",
+					MetadataHandle: metaHandle,
+					LeaseKey:       [16]byte{0x01},
+					LeaseState:     smbLeaseRead | smbLeaseHandle,
+					DisconnectedAt: now.Add(-time.Second),
+				},
+			},
+			excludeLeaseKey: [16]byte{0x01},
+			breakBelowH:     true,
+			wantPurged:      0,
+			wantRemaining:   1,
+		},
+		{
+			name: "purges_foreign_handle_with_R_lease",
+			seed: []*lock.PersistedDurableHandle{
+				{
+					ID:             "foreign",
+					MetadataHandle: metaHandle,
+					LeaseKey:       [16]byte{0x02},
+					LeaseState:     smbLeaseRead | smbLeaseHandle,
+					DisconnectedAt: now.Add(-time.Second),
+				},
+			},
+			excludeLeaseKey: [16]byte{0x01},
+			breakBelowH:     true,
+			wantPurged:      1,
+			wantRemaining:   0,
+		},
+		{
+			// Finding #1: a handle with LeaseState=0 (lease previously
+			// downgraded pre-disconnect) is unreconnectable and must be
+			// purged on a foreign data-change, not preserved.
+			name: "purges_foreign_handle_with_zero_lease_state",
+			seed: []*lock.PersistedDurableHandle{
+				{
+					ID:             "foreign-no-lease",
+					MetadataHandle: metaHandle,
+					LeaseKey:       [16]byte{0x03},
+					LeaseState:     0,
+					DisconnectedAt: now.Add(-time.Second),
+				},
+			},
+			excludeLeaseKey: [16]byte{0x01},
+			breakBelowH:     true,
+			wantPurged:      1,
+			wantRemaining:   0,
+		},
+		{
+			// Live (not yet disconnected) handles are skipped — they're
+			// active opens whose lease break is handled inline.
+			name: "skips_live_handles",
+			seed: []*lock.PersistedDurableHandle{
+				{
+					ID:             "live",
+					MetadataHandle: metaHandle,
+					LeaseKey:       [16]byte{0x04},
+					LeaseState:     smbLeaseRead | smbLeaseHandle,
+					DisconnectedAt: time.Time{},
+				},
+			},
+			excludeLeaseKey: [16]byte{0x01},
+			breakBelowH:     true,
+			wantPurged:      0,
+			wantRemaining:   1,
+		},
+		{
+			// Fast-path: breakBelowH=false skips the lookup entirely.
+			name: "fast_path_break_preserves_H",
+			seed: []*lock.PersistedDurableHandle{
+				{
+					ID:             "foreign",
+					MetadataHandle: metaHandle,
+					LeaseKey:       [16]byte{0x05},
+					LeaseState:     smbLeaseRead | smbLeaseHandle,
+					DisconnectedAt: now.Add(-time.Second),
+				},
+			},
+			excludeLeaseKey: [16]byte{0x01},
+			breakBelowH:     false,
+			wantPurged:      0,
+			wantRemaining:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newMockDurableStore()
+			for _, h := range tc.seed {
+				_ = store.PutDurableHandle(context.Background(), h)
+			}
+			h := &Handler{DurableStore: store}
+			got := h.purgeConflictingDisconnectedHandlesForDataChange(
+				context.Background(), metaHandle, tc.excludeLeaseKey, tc.breakBelowH,
+			)
+			if got != tc.wantPurged {
+				t.Fatalf("purged=%d want=%d", got, tc.wantPurged)
+			}
+			if c := store.count(); c != tc.wantRemaining {
+				t.Fatalf("store count=%d want=%d", c, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+// TestPurgeConflictingDisconnectedHandlesForOpen pins the wrapper behaviour
+// for the CREATE path: zero-length metaHandle is a no-op, live handles are
+// skipped, and the SHARE_NONE / W-on-W rules fire through the predicate.
+func TestPurgeConflictingDisconnectedHandlesForOpen(t *testing.T) {
+	const (
+		rh  = smbLeaseRead | smbLeaseHandle
+		rwh = smbLeaseRead | smbLeaseHandle | smbLeaseWrite
+
+		shareAll uint32 = smbShareRead | smbShareWrite | smbShareDelete
+	)
+	now := time.Now()
+	metaHandle := []byte("file-handle-2")
+
+	store := newMockDurableStore()
+	_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+		ID:             "disconnected-rwh",
+		MetadataHandle: metaHandle,
+		LeaseKey:       [16]byte{0x01},
+		LeaseState:     rwh,
+		DisconnectedAt: now.Add(-time.Second),
+	})
+	_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+		ID:             "live",
+		MetadataHandle: metaHandle,
+		LeaseKey:       [16]byte{0x02},
+		LeaseState:     rwh,
+		// Not disconnected — must be skipped.
+		DisconnectedAt: time.Time{},
+	})
+
+	h := &Handler{DurableStore: store}
+	// New RH open with a different key → purges the disconnected RWH (W
+	// must be broken; cascade strips H), leaves the live handle alone.
+	got := h.purgeConflictingDisconnectedHandlesForOpen(
+		context.Background(), metaHandle,
+		rh, [16]byte{0x99}, shareAll,
+	)
+	if got != 1 {
+		t.Fatalf("purged=%d want=1", got)
+	}
+	if c := store.count(); c != 1 {
+		t.Fatalf("remaining=%d want=1", c)
+	}
+}
+
+// TestDurablePurgeMuSerializesPersistAndPurge proves the durablePurgeMu
+// critical section serializes a disconnect-time PutDurableHandle against a
+// concurrent create-time purge, closing the finding-#3 TOCTOU. Runs under
+// `go test -race`.
+func TestDurablePurgeMuSerializesPersistAndPurge(t *testing.T) {
+	store := newMockDurableStore()
+	h := &Handler{DurableStore: store}
+	metaHandle := []byte("file-handle-3")
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			h.durablePurgeMu.Lock()
+			_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+				ID:             "disconnected",
+				MetadataHandle: metaHandle,
+				LeaseState:     smbLeaseRead | smbLeaseHandle,
+				LeaseKey:       [16]byte{0x01},
+				DisconnectedAt: time.Now(),
+			})
+			h.durablePurgeMu.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// SHARE_NONE forces purge of any disconnected handle on the file.
+			h.purgeConflictingDisconnectedHandlesForOpen(
+				context.Background(), metaHandle, 0, [16]byte{}, 0,
+			)
+		}
+	}()
+	wg.Wait()
+	// No assertion on final state — race detector is the gate.
 }
 
 // TestShouldPersistDurableOnDisconnect pins down the lock-noW-lease persist

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -464,6 +464,18 @@ type OpenFile struct {
 	// from each request. Encoding mirrors NotifyMaxBufferSize: bit 32 = set,
 	// low 32 bits = filter value. Zero means unset.
 	NotifyCompletionFilter atomic.Uint64
+
+	// HasByteRangeLocks is set the first time a LOCK request successfully
+	// records at least one byte-range lock under this open. The flag is
+	// strictly monotonic for the lifetime of the open — UNLOCK does NOT
+	// clear it, mirroring the pessimistic check Samba performs in
+	// `vfs_default_durable_disconnect`. The flag participates in the
+	// disconnect-time decision to persist a durable handle (see
+	// shouldPersistDurableOnDisconnect): an open holding any BR-lock under a
+	// lease that lacks W must NOT be persisted, because its locks cannot
+	// reliably survive an in-flight lease downgrade.
+	// smbtorture smb2.durable-v2-open.lock-noW-lease.
+	HasByteRangeLocks atomic.Bool
 }
 
 // OpenID returns a unique identifier for this open file handle.
@@ -835,22 +847,39 @@ func (h *Handler) closeFilesWithFilter(
 					leaseState = state
 				}
 			}
-			persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState)
-			if err := h.DurableStore.PutDurableHandle(ctx, persisted); err != nil {
-				logger.Warn(caller+": failed to persist durable handle",
+
+			// MS-SMB2 §3.3.4.18 persist gate: refuse to persist when the
+			// open holds a byte-range lock under a lease lacking W. The
+			// disconnected reconnect cannot reliably re-establish the lock
+			// because the BR-lock is bound to the open's OpenID and a
+			// non-W lease cannot promote to W on reconnect without breaking
+			// other holders. Mirrors Samba's vfs_default_durable_disconnect
+			// (NT_STATUS_NOT_SUPPORTED → fall through to normal close).
+			// smbtorture smb2.durable-v2-open.lock-noW-lease.
+			persistGated := !shouldPersistDurableOnDisconnect(leaseState, openFile.HasByteRangeLocks.Load())
+			if persistGated {
+				logger.Debug(caller+": durable persist refused (BR-lock without W lease)",
 					"path", openFile.Path,
-					"error", err)
-				// Fall through to normal close on persistence failure
+					"leaseState", fmt.Sprintf("0x%x", leaseState),
+					"hasBRLocks", true)
 			} else {
-				logger.Debug(caller+": durable handle persisted for reconnect",
-					"path", openFile.Path,
-					"fileID", fmt.Sprintf("%x", openFile.FileID),
-					"timeout", openFile.DurableTimeoutMs)
-				// Do NOT release locks, flush caches, or execute delete-on-close
-				// The handle lives on in the DurableHandleStore
-				toDelete = append(toDelete, openFile.FileID)
-				closed++
-				return true
+				persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState)
+				if err := h.DurableStore.PutDurableHandle(ctx, persisted); err != nil {
+					logger.Warn(caller+": failed to persist durable handle",
+						"path", openFile.Path,
+						"error", err)
+					// Fall through to normal close on persistence failure
+				} else {
+					logger.Debug(caller+": durable handle persisted for reconnect",
+						"path", openFile.Path,
+						"fileID", fmt.Sprintf("%x", openFile.FileID),
+						"timeout", openFile.DurableTimeoutMs)
+					// Do NOT release locks, flush caches, or execute delete-on-close
+					// The handle lives on in the DurableHandleStore
+					toDelete = append(toDelete, openFile.FileID)
+					closed++
+					return true
+				}
 			}
 		}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -138,6 +138,23 @@ type Handler struct {
 	sharesCacheMu    sync.RWMutex
 	sharesCacheValid bool
 
+	// durablePurgeMu serializes the read-then-mutate windows on the
+	// DurableHandleStore that would otherwise TOCTOU around each other:
+	//
+	//   (a) disconnect path: GetLeaseState → buildPersistedDurableHandle →
+	//       PutDurableHandle (the "persist" half of close).
+	//   (b) create path: purgeConflictingDisconnectedHandlesForOpen and
+	//       purgeConflictingDisconnectedHandlesForDataChange
+	//       (GetDurableHandlesByFileHandle → loop DeleteDurableHandle).
+	//
+	// Without serialization a CREATE in (b) can race against a concurrent
+	// disconnect in (a): the disconnect's PutDurableHandle lands between the
+	// CREATE's Get and Delete, leaving a phantom unreconnectable entry until
+	// the scavenger evicts it. The mutex is coarse-grained (process-wide) but
+	// covers only durable-store IO and the disconnect-time persist step,
+	// neither of which is on the steady-state hot path.
+	durablePurgeMu sync.Mutex
+
 	// KerberosProvider holds the shared Kerberos keytab/config provider.
 	// Injected by the adapter layer before Serve(). When nil, Kerberos
 	// auth returns STATUS_LOGON_FAILURE gracefully.
@@ -486,6 +503,35 @@ func (f *OpenFile) OpenID() string {
 		f.cachedOpenID = fmt.Sprintf("%x", f.FileID)
 	}
 	return f.cachedOpenID
+}
+
+// openHasLocks reports whether any byte-range lock is currently recorded
+// against the given open under the lock manager. Source of truth for the
+// MS-SMB2 §3.3.4.18 durable persist gate at disconnect time — avoids the
+// TOCTOU race between an async-parked LOCK goroutine's HasByteRangeLocks
+// flag flip and the disconnect-time read (see lock_async.go::resumePendingLock,
+// MS-SMB2 §3.3.5.14 / smb2.durable-v2-open.lock-noW-lease).
+//
+// Returns true on any unexpected lookup error to fail closed: if we cannot
+// confirm the open is lock-free we MUST not persist a durable handle that
+// might be silently bypassing the lock-noW-lease gate.
+func openHasLocks(metaSvc *metadata.MetadataService, openFile *OpenFile) bool {
+	if metaSvc == nil || openFile == nil || len(openFile.MetadataHandle) == 0 {
+		return openFile != nil && openFile.HasByteRangeLocks.Load()
+	}
+	lm, err := metaSvc.GetLockManagerForHandle(openFile.MetadataHandle)
+	if err != nil || lm == nil {
+		// Fail closed: surface the optimistic flag rather than silently
+		// claiming "no locks" on a lookup miss.
+		return openFile.HasByteRangeLocks.Load()
+	}
+	openID := openFile.OpenID()
+	for _, fl := range lm.ListLocks(string(openFile.MetadataHandle)) {
+		if fl.OpenID == openID {
+			return true
+		}
+	}
+	return false
 }
 
 // notifyMaxBufferSizeSetBit marks the NotifyMaxBufferSize uint64 as having
@@ -856,15 +902,26 @@ func (h *Handler) closeFilesWithFilter(
 			// other holders. Mirrors Samba's vfs_default_durable_disconnect
 			// (NT_STATUS_NOT_SUPPORTED → fall through to normal close).
 			// smbtorture smb2.durable-v2-open.lock-noW-lease.
-			persistGated := !shouldPersistDurableOnDisconnect(leaseState, openFile.HasByteRangeLocks.Load())
+			//
+			// Source of truth is the lock manager — not openFile.HasByteRangeLocks
+			// — to close a TOCTOU window where an async-parked LOCK goroutine
+			// could set the flag after this read. The manager carries the
+			// authoritative per-OpenID lock list (lock_async.go::resumePendingLock
+			// adds via metaSvc.LockFile, which the manager records).
+			persistGated := !shouldPersistDurableOnDisconnect(leaseState, openHasLocks(metaSvc, openFile))
 			if persistGated {
 				logger.Debug(caller+": durable persist refused (BR-lock without W lease)",
 					"path", openFile.Path,
 					"leaseState", fmt.Sprintf("0x%x", leaseState),
 					"hasBRLocks", true)
 			} else {
+				// Serialize the persist against concurrent create-time
+				// purge windows; see durablePurgeMu comment.
+				h.durablePurgeMu.Lock()
 				persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState)
-				if err := h.DurableStore.PutDurableHandle(ctx, persisted); err != nil {
+				err := h.DurableStore.PutDurableHandle(ctx, persisted)
+				h.durablePurgeMu.Unlock()
+				if err != nil {
 					logger.Warn(caller+": failed to persist durable handle",
 						"path", openFile.Path,
 						"error", err)

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -512,18 +512,34 @@ func (f *OpenFile) OpenID() string {
 // flag flip and the disconnect-time read (see lock_async.go::resumePendingLock,
 // MS-SMB2 §3.3.5.14 / smb2.durable-v2-open.lock-noW-lease).
 //
-// Returns true on any unexpected lookup error to fail closed: if we cannot
-// confirm the open is lock-free we MUST not persist a durable handle that
-// might be silently bypassing the lock-noW-lease gate.
+// Fail-closed semantics: when we cannot authoritatively confirm the open is
+// lock-free — missing metadata service, missing handle, lock-manager lookup
+// failure, or a stale optimistic flag — we MUST NOT permit durable
+// persistence. The caller treats true as "do not persist". Returning true
+// on any uncertainty preserves the lock-noW-lease gate at the cost of
+// occasionally declining to persist a genuinely lock-free handle whose
+// lock-manager is transiently unreachable.
 func openHasLocks(metaSvc *metadata.MetadataService, openFile *OpenFile) bool {
-	if metaSvc == nil || openFile == nil || len(openFile.MetadataHandle) == 0 {
-		return openFile != nil && openFile.HasByteRangeLocks.Load()
+	if openFile == nil {
+		// No open to gate; nothing to persist. Caller short-circuits.
+		return false
+	}
+	// Optimistic flag is consulted first as an inexpensive positive signal.
+	// A true here is authoritative ("a lock was recorded at some point").
+	// A false alone is NOT authoritative — the flag can lag a concurrent
+	// LOCK completion (see lock_async.go::resumePendingLock).
+	if openFile.HasByteRangeLocks.Load() {
+		return true
+	}
+	if metaSvc == nil || len(openFile.MetadataHandle) == 0 {
+		// Cannot consult the lock manager — fail closed.
+		return true
 	}
 	lm, err := metaSvc.GetLockManagerForHandle(openFile.MetadataHandle)
 	if err != nil || lm == nil {
-		// Fail closed: surface the optimistic flag rather than silently
-		// claiming "no locks" on a lookup miss.
-		return openFile.HasByteRangeLocks.Load()
+		logger.Debug("openHasLocks: lock manager lookup failed, failing closed",
+			"error", err)
+		return true
 	}
 	openID := openFile.OpenID()
 	for _, fl := range lm.ListLocks(string(openFile.MetadataHandle)) {

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -476,6 +476,19 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		"fileID", fmt.Sprintf("%x", req.FileID),
 		"lockCount", req.LockCount)
 
+	// Mark this open as having held at least one byte-range lock. The flag
+	// is consumed at disconnect by shouldPersistDurableOnDisconnect to refuse
+	// durable persistence for opens that hold BR-locks under a non-W lease
+	// (smbtorture smb2.durable-v2-open.lock-noW-lease, MS-SMB2 §3.3.4.18).
+	// Strictly monotonic — UNLOCK does NOT clear it, mirroring Samba's
+	// pessimistic `vfs_default_durable_disconnect` semantics.
+	for _, le := range req.Locks {
+		if le.Flags&SMB2LockFlagUnlock == 0 {
+			openFile.HasByteRangeLocks.Store(true)
+			break
+		}
+	}
+
 	// Build response
 	resp := &LockResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -227,6 +227,12 @@ func (h *Handler) resumePendingLock(
 				finalStatus = types.StatusSuccess
 				finalBody = encodeLockResponseBody()
 				h.lastDeniedLocks.Delete(pending.OwnerID)
+				// Mirror the sync path in lock.go: parked LOCK requests that
+				// finally succeed must also mark the open as having held a
+				// byte-range lock, so the disconnect-time durable-persist
+				// decision (shouldPersistDurableOnDisconnect, MS-SMB2 §3.3.4.18
+				// / smb2.durable-v2-open.lock-noW-lease) sees the lock.
+				openFile.HasByteRangeLocks.Store(true)
 				goto deliver
 			}
 			var storeErr *metadata.StoreError

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -228,10 +228,11 @@ func (h *Handler) resumePendingLock(
 				finalBody = encodeLockResponseBody()
 				h.lastDeniedLocks.Delete(pending.OwnerID)
 				// Mirror the sync path in lock.go: parked LOCK requests that
-				// finally succeed must also mark the open as having held a
-				// byte-range lock, so the disconnect-time durable-persist
-				// decision (shouldPersistDurableOnDisconnect, MS-SMB2 §3.3.4.18
-				// / smb2.durable-v2-open.lock-noW-lease) sees the lock.
+				// finally succeed mark the open as having held a byte-range
+				// lock. The authoritative source of truth at disconnect-time
+				// is the lock manager itself (queried by openHasLocks in
+				// handler.go); this flag is the cheap path used by call-sites
+				// that don't have the meta service handy.
 				openFile.HasByteRangeLocks.Store(true)
 				goto deliver
 			}

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -862,6 +862,38 @@ func (h *Handler) setFileInfoFromStore(
 			); err != nil {
 				logger.Debug("SET_INFO: rename lease break dispatch failed", "error", err)
 			}
+
+			// MS-SMB2 §3.3.4.18 / §3.3.5.21: RENAME breaks Handle leases on
+			// the renamed file (and on the overwrite target). Any
+			// disconnected durable handle with a different lease key loses
+			// H — the disconnected client cannot ack the break, so the
+			// durable is purged. smbtorture
+			// smb2.durable-v2-open.purge-disconnected-rh-with-rename.
+			if h.DurableStore != nil {
+				if purged := h.purgeConflictingDisconnectedHandlesForDataChange(
+					authCtx.Context,
+					openFile.MetadataHandle,
+					openFile.LeaseKey,
+					true, // RENAME break_to strips H.
+				); purged > 0 {
+					logger.Debug("SET_INFO: purged disconnected handles on rename",
+						"src", openFile.Path,
+						"dst", newPath,
+						"count", purged)
+				}
+				if isOverwrite && len(dstMetaHandle) > 0 && !bytes.Equal(dstMetaHandle, openFile.MetadataHandle) {
+					if purged := h.purgeConflictingDisconnectedHandlesForDataChange(
+						authCtx.Context,
+						dstMetaHandle,
+						[16]byte{}, // dst holder is by definition not the renamer
+						true,
+					); purged > 0 {
+						logger.Debug("SET_INFO: purged disconnected handles on rename target overwrite",
+							"dst", newPath,
+							"count", purged)
+					}
+				}
+			}
 			waitCtx, cancelWait := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
 			if waitErr := h.LeaseManager.WaitForOtherKeyBreaks(
 				waitCtx, srcMetaHandle, openFile.ShareName, openFile.LeaseKey,
@@ -1155,6 +1187,21 @@ func (h *Handler) setFileInfoFromStore(
 			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 			if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
 				logger.Debug("SET_INFO: oplock break on EOF set failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+			}
+			// MS-SMB2 §3.3.4.18: truncation is a data-modifying op that
+			// breaks Level-II Read leases to NONE — purge any disconnected
+			// durable handle whose lease holds R-caching from a different key.
+			if h.DurableStore != nil {
+				if purged := h.purgeConflictingDisconnectedHandlesForDataChange(
+					authCtx.Context,
+					openFile.MetadataHandle,
+					openFile.LeaseKey,
+					true,
+				); purged > 0 {
+					logger.Debug("SET_INFO: purged disconnected handles on EOF set",
+						"path", openFile.Path,
+						"count", purged)
+				}
 			}
 		}
 

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -346,6 +346,25 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		}
 	}
 
+	// MS-SMB2 §3.3.4.18 / §3.3.5.16: a WRITE breaks Level-II (Read) leases
+	// on the same file to NONE. Any disconnected durable handle with a
+	// lease holding R-caching on this file (and a different lease key from
+	// the writer's) loses H along with R and must be purged — the
+	// disconnected client cannot ack the break.
+	// smbtorture smb2.durable-v2-open.purge-disconnected-rh-with-write.
+	if h.DurableStore != nil && len(openFile.MetadataHandle) > 0 {
+		if purged := h.purgeConflictingDisconnectedHandlesForDataChange(
+			authCtx.Context,
+			openFile.MetadataHandle,
+			openFile.LeaseKey,
+			true, // WRITE breaks Read leases to NONE — break_to lacks H.
+		); purged > 0 {
+			logger.Debug("WRITE: purged disconnected handles on data change",
+				"path", openFile.Path,
+				"count", purged)
+		}
+	}
+
 	// ========================================================================
 	// Step 9: Prepare write operation
 	// ========================================================================


### PR DESCRIPTION
## Summary

Stacked on #667 (DH V2 base — context validation, AppInstance, ClientGuid scoping).

Implements MS-SMB2 §3.3.4.18 — disconnected durable handle preservation/purge
state machine — plus the `lock-noW-lease` persist gate. Mirrors Samba's
`source3/smbd/open.c::delay_for_oplock_fn` + `source3/smbd/scavenger.c::share_mode_cleanup_disconnected`
semantics: a disconnected handle whose lease would be broken to a state lacking
`SMB2_LEASE_HANDLE_CACHING` is purged on the spot (the disconnected client
cannot ack the break, so the durable is irrecoverably lost).

## State machine

Centralised in `disconnected_state_machine.go` with a truth-table unit test:

| Disconnected lease | New op | Decision |
|---|---|---|
| RH / RWH | stat open (no lease) | preserve |
| RH | RH on different key | preserve |
| RH | RWH on different key | preserve (new is downgraded to RH) |
| RWH | RWH on different key | **purge** |
| RWH | RH on different key | **purge** |
| RH | SHARE_NONE open | **purge** |
| RH | WRITE from different live lease key | **purge** |
| RH | RENAME from different live lease key | **purge** |

Plus: an open holding a byte-range lock under a lease lacking W is NOT
persisted at disconnect (mirrors Samba `vfs_default_durable_disconnect`
returning `NT_STATUS_NOT_SUPPORTED`).

## Hooks

- `create_post_break.go` Step 8a-bis (after live-lease break, before lease grant): purges on conflicting new open.
- `write.go` (after `BreakReadLeasesOnWrite`): purges disconnected RH on different keys.
- `set_info.go` (RENAME, EOF/truncation): same.
- `handler.go` `closeFilesWithFilter`: `shouldPersistDurableOnDisconnect` gate for `lock-noW-lease`.
- `lock.go` + `lock_async.go`: mark `OpenFile.HasByteRangeLocks` on successful LOCK.

## Tests targeted (10)

Preservation:
- smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
- smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
- smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
- smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open

Purge:
- smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
- smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
- smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
- smb2.durable-v2-open.purge-disconnected-rh-with-write
- smb2.durable-v2-open.purge-disconnected-rh-with-rename

Locks vs DH2 + lease:
- smb2.durable-v2-open.lock-noW-lease

The `keep-disconnected-rh-with-rwh-open` / `keep-disconnected-rh-with-rh-open`
pair additionally require that the new opener's lease be downgraded in the
presence of the disconnected lease. The predicate side is implemented; the
grant-side mirroring of disconnected leases into LeaseManager is a separate
follow-up if these don't flip.

## References

- MS-SMB2 §3.3.4.18 (Server Receives an Object Store Operation)
- MS-SMB2 §3.3.5.9 Step 10 (share-mode/lease conflict on CREATE)
- MS-SMB2 §3.3.5.16 (WRITE Level-II break)
- MS-SMB2 §3.3.5.21 (RENAME Handle-lease break)
- Samba: `source3/smbd/open.c::delay_for_oplock_fn`, `source3/smbd/scavenger.c::share_mode_cleanup_disconnected`, `source3/smbd/durable.c::vfs_default_durable_disconnect`

## Test plan

- [ ] smbtorture smb2.durable-v2-open preserve/purge subset (10 targets)
- [ ] WPTS BVT regression check
- [ ] `go test -race ./...` (passes locally)
- [ ] Unit truth-table covers all 8 keep/purge cases + reconnect guard

## Notes

Will rebase `--onto develop` after #667 merges.