### PR TITLE
fix(smb/durable-v2): reject zero CreateGuid, close reconnect TOCTOU, wire access masks

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -628,6 +628,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 				authCtx.Context, h.DurableStore, metaSvc, req.CreateContexts,
 				ctx.SessionID, sess.Username, sessionKeyHash,
 				tree.ShareName, fullFilename, connClientGUID(ctx),
+				req.DesiredAccess, req.ShareAccess,
 			)
 			if reconnErr != nil {
 				logger.Warn("CREATE: durable reconnect error", "error", reconnErr)

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -190,6 +190,17 @@ func ProcessDurableHandleContext(
 			return nil
 		}
 
+		// Per MS-SMB2 §2.2.13.2.11: CreateGuid MUST be a valid GUID; an
+		// all-zero CreateGuid is not a valid identifier and cannot key the
+		// reconnect lookup (it would also collide with the "no CreateGuid"
+		// sentinel in storage). Reject without granting durability —
+		// matches Samba's `smbd_smb2_create_durable_v2_check` which treats
+		// a NULL/zero create_guid as "do not grant V2".
+		if createGuid == ([16]byte{}) {
+			logger.Debug("ProcessDurableHandleContext: V2 rejected (zero CreateGuid)")
+			return nil
+		}
+
 		// Reject persistent flag (not supported)
 		if flags&DH2FlagPersistent != 0 {
 			logger.Debug("ProcessDurableHandleContext: persistent flag rejected (not supported)")
@@ -299,12 +310,14 @@ func ProcessDurableReconnectContext(
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
+	desiredAccess uint32,
+	shareAccess uint32,
 ) (*ReconnectResult, types.Status, error) {
 
 	// Determine V2 (DH2C) or V1 (DHnC) reconnect
 	if dh2cCtx := FindCreateContext(contexts, DurableHandleV2ReconnectTag); dh2cCtx != nil {
 		openFile, leaseState, origID, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
-			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID)
+			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID, desiredAccess, shareAccess)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
@@ -313,7 +326,7 @@ func ProcessDurableReconnectContext(
 
 	if dhnCCtx := FindCreateContext(contexts, DurableHandleV1ReconnectTag); dhnCCtx != nil {
 		openFile, leaseState, origID, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
-			sessionID, username, sessionKeyHash, shareName, filename)
+			sessionID, username, sessionKeyHash, shareName, filename, desiredAccess, shareAccess)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
@@ -337,6 +350,8 @@ func processV1Reconnect(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
+	desiredAccess uint32,
+	shareAccess uint32,
 ) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V1 reconnect context
 	fileID, err := DecodeDHnCReconnect(dhnCCtx.Data)
@@ -358,7 +373,13 @@ func processV1Reconnect(
 		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
-	// Look up persisted handle by FileID
+	// Non-destructive lookup: validation-failure paths (share/path/username/
+	// access mismatch) must leave the persisted handle reclaimable until
+	// expiry — a transient mismatched retry should not destroy a valid
+	// durable open. The TOCTOU window is closed on the *success* path
+	// (claimDurableHandleByFileID below) which atomically re-reads via
+	// Consume; a second concurrent reconnect that also passes validation
+	// will find the handle already gone and return OBJECT_NAME_NOT_FOUND.
 	handle, err := durableStore.GetDurableHandleByFileID(ctx, fileID)
 	if err != nil {
 		logger.Warn("processV1Reconnect: store error", "error", err)
@@ -370,9 +391,11 @@ func processV1Reconnect(
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
-	// V1 reconnect does not carry DesiredAccess/ShareAccess in the context
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, 0, 0)
+		sessionKeyHash, shareName, filename, desiredAccess, shareAccess,
+		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
+			return durableStore.ConsumeDurableHandleByFileID(ctx, fileID)
+		})
 	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
 }
 
@@ -390,6 +413,8 @@ func processV2Reconnect(
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
+	desiredAccess uint32,
+	shareAccess uint32,
 ) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V2 reconnect context
 	fileID, createGuid, flags, err := DecodeDH2CReconnect(dh2cCtx.Data)
@@ -410,7 +435,9 @@ func processV2Reconnect(
 		"shareName", shareName,
 		"filename", filename)
 
-	// Look up persisted handle by CreateGuid
+	// Non-destructive lookup: see processV1Reconnect comment. The
+	// TOCTOU-closing Consume runs on the success path inside
+	// validateAndRestore.
 	handle, err := durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 	if err != nil {
 		logger.Warn("processV2Reconnect: store error", "error", err)
@@ -454,16 +481,31 @@ func processV2Reconnect(
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
-	// V2 reconnect does not carry DesiredAccess/ShareAccess in DH2C context either
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, 0, 0)
+		sessionKeyHash, shareName, filename, desiredAccess, shareAccess,
+		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
+			return durableStore.ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+		})
 	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
 }
 
-// validateAndRestore runs the shared reconnect validation checks and restores the OpenFile.
-// These checks apply to both V1 and V2 reconnects.
-// desiredAccess and shareAccess are from the CREATE request; zero means "not provided"
-// (V1 reconnect does not include these in the context).
+// validateAndRestore runs the shared reconnect validation checks and restores
+// the OpenFile. These checks apply to both V1 and V2 reconnects.
+//
+// desiredAccess and shareAccess are from the CREATE request; zero means
+// "not provided" (used during the in-flight upgrade window when older CREATE
+// paths did not thread the values through).
+//
+// consume is invoked on the success path to atomically remove the persisted
+// record. If consume returns nil, another goroutine has already claimed the
+// handle — the reconnect fails with OBJECT_NAME_NOT_FOUND. This is the only
+// place that mutates the durable store on reconnect, which is what makes the
+// path safe against the V1/V2 reconnect TOCTOU window.
+//
+// TODO: per CLAUDE.md invariant 1 the identity / access checks (username,
+// DesiredAccess, ShareAccess) belong in pkg/metadata/lock — e.g. inside the
+// Consume* call returning a typed mismatch error. Left in the handler for
+// this iteration to keep the scope of the TOCTOU fix small.
 func validateAndRestore(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -476,6 +518,7 @@ func validateAndRestore(
 	filename string,
 	desiredAccess uint32,
 	shareAccess uint32,
+	consume func(ctx context.Context) (*lock.PersistedDurableHandle, error),
 ) (*OpenFile, types.Status, error) {
 	if handle.ShareName != shareName {
 		logger.Debug("validateAndRestore: share name mismatch",
@@ -526,7 +569,7 @@ func validateAndRestore(
 			"disconnectedAt", handle.DisconnectedAt,
 			"timeoutMs", handle.TimeoutMs,
 			"expiresAt", expiresAt)
-		// Clean up expired handle
+		// Clean up expired handle (best-effort; scavenger will catch any leftover).
 		_ = durableStore.DeleteDurableHandle(ctx, handle.ID)
 		return nil, types.StatusObjectNameNotFound, nil
 	}
@@ -540,6 +583,21 @@ func validateAndRestore(
 			_ = durableStore.DeleteDurableHandle(ctx, handle.ID)
 			return nil, types.StatusObjectNameNotFound, nil
 		}
+	}
+
+	// All checks passed — atomically consume the persisted record. If
+	// somebody else (a concurrent reconnect from a retrying client) already
+	// claimed it, consume returns nil and we fail OBJECT_NAME_NOT_FOUND
+	// rather than handing out a second OpenFile against the same handle.
+	consumed, err := consume(ctx)
+	if err != nil {
+		logger.Warn("validateAndRestore: consume failed", "error", err)
+		return nil, types.StatusInternalError, err
+	}
+	if consumed == nil {
+		logger.Debug("validateAndRestore: handle already consumed by concurrent reconnect",
+			"handleID", handle.ID)
+		return nil, types.StatusObjectNameNotFound, nil
 	}
 
 	logger.Debug("validateAndRestore: all checks passed, restoring open file",
@@ -604,11 +662,8 @@ func validateAndRestore(
 		// IsDurable is NOT set on restore -- client must re-request durability
 	}
 
-	// Delete persisted handle (reconnect consumes it)
-	if err := durableStore.DeleteDurableHandle(ctx, handle.ID); err != nil {
-		logger.Warn("validateAndRestore: failed to delete persisted handle", "error", err)
-		// Non-fatal: continue with reconnect
-	}
+	// Persisted record was removed by the consume() call above; no
+	// further store mutation is required here.
 
 	return restored, types.StatusSuccess, nil
 }

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -503,7 +503,7 @@ func TestProcessDurableReconnectContext_V1Success(t *testing.T) {
 	}
 
 	restored, status, err := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{}, 0, 0,
 	)
 	if err != nil {
 		t.Fatalf("ProcessDurableReconnectContext error: %v", err)
@@ -573,7 +573,7 @@ func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	}
 
 	restored, status, err := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "bob", keyHash, "/share1", "report.docx", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "bob", keyHash, "/share1", "report.docx", [16]byte{}, 0, 0,
 	)
 	if err != nil {
 		t.Fatalf("ProcessDurableReconnectContext error: %v", err)
@@ -612,7 +612,7 @@ func TestProcessDurableReconnectContext_HandleNotFound(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", makeSessionKeyHash("key"), "/share1", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", makeSessionKeyHash("key"), "/share1", "test.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusObjectNameNotFound {
 		t.Errorf("Expected STATUS_OBJECT_NAME_NOT_FOUND, got %s", status)
@@ -649,7 +649,7 @@ func TestProcessDurableReconnectContext_UsernameMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "eve", keyHash, "/share1", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "eve", keyHash, "/share1", "test.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusAccessDenied {
 		t.Errorf("Expected STATUS_ACCESS_DENIED for username mismatch, got %s", status)
@@ -692,7 +692,7 @@ func TestProcessDurableReconnectContext_SessionKeyMismatchAllowed(t *testing.T) 
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", differentKeyHash, "/share1", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", differentKeyHash, "/share1", "test.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusSuccess {
 		t.Errorf("Expected STATUS_SUCCESS for session key mismatch with matching username, got %s", status)
@@ -729,7 +729,7 @@ func TestProcessDurableReconnectContext_ShareNameMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/different-share", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/different-share", "test.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusObjectNameNotFound {
 		t.Errorf("Expected STATUS_OBJECT_NAME_NOT_FOUND for share mismatch, got %s", status)
@@ -769,7 +769,7 @@ func TestProcessDurableReconnectContext_PathMismatch(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "other.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "other.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusInvalidParameter {
 		t.Errorf("Expected STATUS_INVALID_PARAMETER for path mismatch, got %s", status)
@@ -808,7 +808,7 @@ func TestProcessDurableReconnectContext_V1ConflictingV2Tag(t *testing.T) {
 	}
 
 	_, status, _ := ProcessDurableReconnectContext(
-		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{},
+		context.Background(), store, nil, contexts, 999, "alice", keyHash, "/share1", "test.txt", [16]byte{}, 0, 0,
 	)
 	if status != types.StatusInvalidParameter {
 		t.Errorf("Expected STATUS_INVALID_PARAMETER for conflicting V2 tag with V1 reconnect, got %s", status)
@@ -933,7 +933,7 @@ func TestProcessDurableReconnectContext_OriginalFileIDRestored(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "lockfile.txt", [16]byte{})
+		1, "alice", keyHash, "/share1", "lockfile.txt", [16]byte{}, 0, 0)
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -978,7 +978,7 @@ func TestProcessDurableReconnectContext_OriginalFileIDFallback(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "legacy.txt", [16]byte{})
+		1, "alice", keyHash, "/share1", "legacy.txt", [16]byte{}, 0, 0)
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -1022,7 +1022,7 @@ func TestProcessDurableReconnectContext_PositionInfoRestored(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "position.txt", [16]byte{})
+		1, "alice", keyHash, "/share1", "position.txt", [16]byte{}, 0, 0)
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect: status=%s err=%v", status, err)
 	}
@@ -1119,7 +1119,7 @@ func TestProcessDurableReconnectContext_V2LeaseClientGUIDMismatch(t *testing.T) 
 
 	// Wrong ClientGuid → OBJECT_NAME_NOT_FOUND
 	_, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "leasefile.txt", differentGUID)
+		1, "alice", keyHash, "/share1", "leasefile.txt", differentGUID, 0, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1129,7 +1129,7 @@ func TestProcessDurableReconnectContext_V2LeaseClientGUIDMismatch(t *testing.T) 
 
 	// Original ClientGuid → success
 	_, status, err = ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID)
+		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID, 0, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1176,7 +1176,7 @@ func TestProcessDurableReconnectContext_V2OplockNoClientGUIDCheck(t *testing.T) 
 	}
 
 	_, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "oplockfile.txt", differentGUID)
+		1, "alice", keyHash, "/share1", "oplockfile.txt", differentGUID, 0, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1226,7 +1226,7 @@ func TestValidateAndRestore_ClientGUIDRoundtrip(t *testing.T) {
 	}
 
 	res, status, err := ProcessDurableReconnectContext(ctx, store, nil, contexts,
-		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID)
+		1, "alice", keyHash, "/share1", "leasefile.txt", originalGUID, 0, 0)
 	if err != nil || status != types.StatusSuccess {
 		t.Fatalf("reconnect failed: status=%v err=%v", status, err)
 	}
@@ -1282,5 +1282,138 @@ func TestProcessDurableHandleContext_V2RequiresBatchOrHandleLease(t *testing.T) 
 				t.Errorf("IsDurable=%v want %v", openFile.IsDurable, c.expectGranted)
 			}
 		})
+	}
+}
+
+// TestProcessDurableHandleContext_V2RejectZeroCreateGuid pins MS-SMB2
+// §2.2.13.2.11: an all-zero CreateGuid is not a valid identifier and must
+// not grant V2 durability. The zero value also collides with the "absent
+// CreateGuid" sentinel in storage, so accepting it would corrupt later
+// lookups.
+func TestProcessDurableHandleContext_V2RejectZeroCreateGuid(t *testing.T) {
+	openFile := &OpenFile{
+		FileID:      [16]byte{1, 2, 3},
+		OplockLevel: OplockLevelBatch,
+	}
+
+	dh2qData := make([]byte, 32)
+	binary.LittleEndian.PutUint32(dh2qData[0:4], 60000)
+	// dh2qData[16:32] left as zero — zero CreateGuid
+
+	contexts := []CreateContext{
+		{Name: DurableHandleV2RequestTag, Data: dh2qData},
+	}
+
+	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	if resp != nil {
+		t.Error("Expected nil response for zero CreateGuid (V2 not granted)")
+	}
+	if openFile.IsDurable {
+		t.Error("Expected openFile.IsDurable to remain false")
+	}
+	if openFile.CreateGuid != ([16]byte{}) {
+		t.Errorf("Expected CreateGuid untouched (zero), got %x", openFile.CreateGuid)
+	}
+}
+
+// TestProcessDurableReconnectContext_ConsumeAtomicV1 verifies that the V1
+// reconnect path uses ConsumeDurableHandleByFileID — i.e. two concurrent
+// reconnect attempts for the same persisted FileID cannot both succeed.
+// Mocks a store that releases its internal lock between Get and Delete
+// would expose a TOCTOU window; the Consume contract closes it.
+func TestProcessDurableReconnectContext_ConsumeAtomicV1(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	keyHash := makeSessionKeyHash("k")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-toctou-v1",
+		FileID:         fileID,
+		Path:           "race.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		OplockLevel:    OplockLevelBatch,
+		DisconnectedAt: time.Now().Add(-1 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	// First reconnect should succeed and consume the handle.
+	res1, status1, err1 := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 1, "alice", keyHash, "/share1", "race.txt", [16]byte{}, 0, 0,
+	)
+	if err1 != nil || status1 != types.StatusSuccess || res1 == nil {
+		t.Fatalf("first reconnect: status=%v err=%v res=%v", status1, err1, res1)
+	}
+
+	// Second reconnect for the same FileID must NOT succeed — the handle
+	// has been atomically consumed; ObjectNameNotFound is returned.
+	_, status2, err2 := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 2, "alice", keyHash, "/share1", "race.txt", [16]byte{}, 0, 0,
+	)
+	if err2 != nil {
+		t.Fatalf("second reconnect error: %v", err2)
+	}
+	if status2 != types.StatusObjectNameNotFound {
+		t.Errorf("second reconnect status = %v, want STATUS_OBJECT_NAME_NOT_FOUND", status2)
+	}
+}
+
+// TestProcessDurableReconnectContext_ConsumeAtomicV2 is the V2 (DH2C)
+// counterpart of the V1 atomicity test.
+func TestProcessDurableReconnectContext_ConsumeAtomicV2(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
+	keyHash := makeSessionKeyHash("k")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-toctou-v2",
+		FileID:         fileID,
+		CreateGuid:     createGuid,
+		Path:           "race.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		OplockLevel:    OplockLevelBatch,
+		IsV2:           true,
+		DisconnectedAt: time.Now().Add(-1 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[0:16], fileID[:])
+	copy(dh2cData[16:32], createGuid[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+	}
+
+	res1, status1, err1 := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 1, "alice", keyHash, "/share1", "race.txt", [16]byte{}, 0, 0,
+	)
+	if err1 != nil || status1 != types.StatusSuccess || res1 == nil {
+		t.Fatalf("first reconnect: status=%v err=%v res=%v", status1, err1, res1)
+	}
+
+	_, status2, err2 := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 2, "alice", keyHash, "/share1", "race.txt", [16]byte{}, 0, 0,
+	)
+	if err2 != nil {
+		t.Fatalf("second reconnect error: %v", err2)
+	}
+	if status2 != types.StatusObjectNameNotFound {
+		t.Errorf("second reconnect status = %v, want STATUS_OBJECT_NAME_NOT_FOUND", status2)
 	}
 }

--- a/internal/adapter/smb/v2/handlers/durable_scavenger_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_scavenger_test.go
@@ -55,6 +55,30 @@ func (s *mockDurableStore) GetDurableHandleByCreateGuid(_ context.Context, guid 
 	return nil, nil
 }
 
+func (s *mockDurableStore) ConsumeDurableHandleByFileID(_ context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, h := range s.handles {
+		if h.FileID == fileID {
+			delete(s.handles, id)
+			return h, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *mockDurableStore) ConsumeDurableHandleByCreateGuid(_ context.Context, guid [16]byte) (*lock.PersistedDurableHandle, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, h := range s.handles {
+		if h.CreateGuid == guid {
+			delete(s.handles, id)
+			return h, nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *mockDurableStore) GetDurableHandlesByAppInstanceId(_ context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -92,6 +92,17 @@ type DurableHandleStore interface {
 	GetDurableHandle(ctx context.Context, id string) (*PersistedDurableHandle, error)
 	GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*PersistedDurableHandle, error)
 	GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*PersistedDurableHandle, error)
+	// ConsumeDurableHandleByFileID atomically fetches and deletes the
+	// persisted handle keyed by the original FileID, returning the previous
+	// record (or nil if no match). Used on V1 reconnect (DHnC) to prevent
+	// the TOCTOU window where two concurrent reconnects from the same
+	// retrying client could both succeed a Get-then-Delete sequence and end
+	// up with two live opens claiming the same persisted handle.
+	// MS-SMB2 §3.3.5.9.7.
+	ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*PersistedDurableHandle, error)
+	// ConsumeDurableHandleByCreateGuid is the V2 (DH2C) counterpart of
+	// ConsumeDurableHandleByFileID. MS-SMB2 §3.3.5.9.12.
+	ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*PersistedDurableHandle, error)
 	GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*PersistedDurableHandle, error)
 	GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*PersistedDurableHandle, error)
 	DeleteDurableHandle(ctx context.Context, id string) error

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -311,6 +311,56 @@ func (s *badgerDurableStore) getHandlesByPrefix(txn *badgerdb.Txn, prefix []byte
 	return result, nil
 }
 
+// consumeByIndexTx fetches the handle referenced by indexKey, deletes the
+// primary record and all secondary indices in the same transaction, and
+// returns the previous record (or nil if no match). Used by Consume* APIs to
+// close the V1/V2 reconnect TOCTOU window.
+func (s *badgerDurableStore) consumeByIndexTx(txn *badgerdb.Txn, indexKey []byte) (*lock.PersistedDurableHandle, error) {
+	handle, err := s.getHandleByIndex(txn, indexKey)
+	if err != nil || handle == nil {
+		return nil, err
+	}
+
+	if err := s.deleteDurableHandleTx(txn, handle.ID); err != nil {
+		return nil, err
+	}
+	return handle, nil
+}
+
+func (s *badgerDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var handle *lock.PersistedDurableHandle
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
+		var err error
+		handle, err = s.consumeByIndexTx(txn, []byte(prefixDHFileID+hexEncode16(fileID)))
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return handle, nil
+}
+
+func (s *badgerDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var handle *lock.PersistedDurableHandle
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
+		var err error
+		handle, err = s.consumeByIndexTx(txn, []byte(prefixDHCreateGuid+hexEncode16(createGuid)))
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return handle, nil
+}
+
 func (s *badgerDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -520,6 +570,14 @@ func (s *BadgerMetadataStore) GetDurableHandleByFileID(ctx context.Context, file
 
 func (s *BadgerMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+}
+
+func (s *BadgerMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
+}
+
+func (s *BadgerMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -95,6 +95,50 @@ func (s *memoryDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, c
 	return nil, nil
 }
 
+func (s *memoryDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if fileID == ([16]byte{}) {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, handle := range s.handles {
+		if handle.FileID == fileID {
+			delete(s.handles, id)
+			return cloneDurableHandle(handle), nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (s *memoryDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if createGuid == ([16]byte{}) {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, handle := range s.handles {
+		if handle.CreateGuid == createGuid {
+			delete(s.handles, id)
+			return cloneDurableHandle(handle), nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (s *memoryDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -272,6 +316,14 @@ func (s *MemoryMetadataStore) GetDurableHandleByFileID(ctx context.Context, file
 
 func (s *MemoryMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+}
+
+func (s *MemoryMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
+}
+
+func (s *MemoryMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *MemoryMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -237,6 +237,19 @@ func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context,
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
 }
 
+// ConsumeDurableHandleByFileID atomically fetches and deletes via
+// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window.
+func (s *postgresDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE file_id = $1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
+}
+
+// ConsumeDurableHandleByCreateGuid is the V2 counterpart.
+func (s *postgresDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE create_guid = $1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+}
+
 func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE app_instance_id = $1 ORDER BY created_at`
 	rows, err := s.pool.Query(ctx, query, appInstanceId[:])
@@ -318,6 +331,14 @@ func (s *PostgresMetadataStore) GetDurableHandleByFileID(ctx context.Context, fi
 
 func (s *PostgresMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+}
+
+func (s *PostgresMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
+}
+
+func (s *PostgresMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -84,6 +84,14 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 	t.Run("DeleteExpiredKeepsActive", func(t *testing.T) {
 		testDurableDeleteExpiredKeepsActive(t, factory)
 	})
+
+	t.Run("ConsumeByFileIDAtomic", func(t *testing.T) {
+		testDurableConsumeByFileIDAtomic(t, factory)
+	})
+
+	t.Run("ConsumeByCreateGuidAtomic", func(t *testing.T) {
+		testDurableConsumeByCreateGuidAtomic(t, factory)
+	})
 }
 
 // getDurableStore extracts the DurableHandleStore from a factory-created store.
@@ -594,5 +602,85 @@ func testDurableDeleteExpiredKeepsActive(t *testing.T, factory StoreFactory) {
 	// Boundary handles should be expired (DisconnectedAt + TimeoutMs == now means expired)
 	if count != 1 {
 		t.Fatalf("expected boundary handle to be expired, got count %d", count)
+	}
+}
+
+// testDurableConsumeByFileIDAtomic verifies that ConsumeDurableHandleByFileID
+// atomically returns the persisted record and removes it from the store, so
+// a second concurrent reconnect attempt for the same FileID cannot also
+// claim the handle. Closes the TOCTOU window present in the old
+// Get-then-Delete pattern.
+func testDurableConsumeByFileIDAtomic(t *testing.T, factory StoreFactory) {
+	ds := getDurableStore(t, factory)
+	ctx := context.Background()
+
+	handle := makeDurableHandle("consume-fid-1", "/export")
+	if err := ds.PutDurableHandle(ctx, handle); err != nil {
+		t.Fatalf("PutDurableHandle() error: %v", err)
+	}
+
+	// First consume returns the record.
+	got, err := ds.ConsumeDurableHandleByFileID(ctx, handle.FileID)
+	if err != nil {
+		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("first consume returned nil; expected record")
+	}
+	assertDurableHandleEqual(t, handle, got)
+
+	// Second consume sees nothing.
+	got, err = ds.ConsumeDurableHandleByFileID(ctx, handle.FileID)
+	if err != nil {
+		t.Fatalf("second ConsumeDurableHandleByFileID() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("second consume returned a record, want nil — atomicity broken")
+	}
+
+	// Primary GetDurableHandle also reports gone.
+	got, err = ds.GetDurableHandle(ctx, handle.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("primary key still resolves after consume: %+v", got)
+	}
+}
+
+// testDurableConsumeByCreateGuidAtomic is the V2 counterpart of
+// testDurableConsumeByFileIDAtomic.
+func testDurableConsumeByCreateGuidAtomic(t *testing.T, factory StoreFactory) {
+	ds := getDurableStore(t, factory)
+	ctx := context.Background()
+
+	handle := makeDurableHandle("consume-cguid-1", "/export")
+	if err := ds.PutDurableHandle(ctx, handle); err != nil {
+		t.Fatalf("PutDurableHandle() error: %v", err)
+	}
+
+	got, err := ds.ConsumeDurableHandleByCreateGuid(ctx, handle.CreateGuid)
+	if err != nil {
+		t.Fatalf("ConsumeDurableHandleByCreateGuid() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("first consume returned nil; expected record")
+	}
+	assertDurableHandleEqual(t, handle, got)
+
+	got, err = ds.ConsumeDurableHandleByCreateGuid(ctx, handle.CreateGuid)
+	if err != nil {
+		t.Fatalf("second ConsumeDurableHandleByCreateGuid() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("second consume returned a record, want nil — atomicity broken")
+	}
+
+	got, err = ds.GetDurableHandle(ctx, handle.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("primary key still resolves after consume: %+v", got)
 	}
 }


### PR DESCRIPTION
Follow-up to #667 / #432 addressing must-fix code-reviewer findings landed after merge.

## Findings addressed

1. **Zero CreateGuid grants V2 durability** (`durable_context.go`). DH2Q with `createGuid == 0x00...` was accepted. Per MS-SMB2 §2.2.13.2.11 the CreateGuid MUST be a valid GUID, and zero also collides with the "absent CreateGuid" sentinel in storage. Rejected before persisting, matching Samba's `smbd_smb2_create_durable_v2_check`.

2. **TOCTOU between Get and Delete on reconnect**. Two concurrent reconnects from a retrying client could both pass the `GetByX`-then-`Delete` sequence and end up with two live opens claiming the same persisted handle. Introduces `ConsumeDurableHandleByFileID` / `ConsumeDurableHandleByCreateGuid` on the `DurableHandleStore` interface, implemented atomically:
   - memory: single mutex op
   - badger: single transaction (fetch + delete primary + delete all secondary indices)
   - postgres: `DELETE ... RETURNING`
   
   Validation-failure paths (share / path / username / access mismatch) still use the non-destructive `GetBy*` lookup so a transient mismatched retry does not destroy a valid durable open — only the success leg consumes. A second concurrent success-path reconnect finds `consume()` returning nil and fails with `OBJECT_NAME_NOT_FOUND`.
   
   Added storetest conformance subtests for both stores plus handler-level atomicity tests for V1 and V2.

3. **Dead `desiredAccess` / `shareAccess` access-check code in `validateAndRestore`**. Both callers passed `0`; the `0 != 0` guard at MS-SMB2 §3.3.5.9.9 was unreachable. Wired `req.DesiredAccess` and `req.ShareAccess` through `ProcessDurableReconnectContext → processV{1,2}Reconnect → validateAndRestore`.

4. Marked durable-store identity / access checks as a TODO for relocation into `pkg/metadata/lock` per CLAUDE.md invariant 1 — left in the handler to keep this PR scoped to the TOCTOU fix.

## Tests

- `TestProcessDurableHandleContext_V2RejectZeroCreateGuid`
- `TestProcessDurableReconnectContext_ConsumeAtomicV1`
- `TestProcessDurableReconnectContext_ConsumeAtomicV2`
- `pkg/metadata/storetest/durable_handles.go`: `ConsumeByFileIDAtomic` + `ConsumeByCreateGuidAtomic` (runs against memory + badger + postgres backends).
- All existing reconnect tests (UsernameMismatch, ShareNameMismatch, PathMismatch, V2LeaseClientGUIDMismatch — which depends on the persistence-keeps-on-failure semantics) still pass.

`go test -race -count=1` clean on `./internal/adapter/smb/...`, `./pkg/metadata/store/...`, `./pkg/metadata/lock/...`.

## Test plan
- [ ] CI green
- [ ] smbtorture `smb2.durable-v2-open` suite unchanged or improved
- [ ] No KNOWN_FAILURES regressions