### PR TITLE
refactor(blockstore): drop dead exports, rename store.go → fileblock.go

### DIFF
--- a/pkg/blockstore/fileblock.go
+++ b/pkg/blockstore/fileblock.go
@@ -244,29 +244,3 @@ type Stats struct {
 	ContentCount  uint64 // Total number of content items
 	AverageSize   uint64 // Average size of content items in bytes
 }
-
-// RemoteObjectInfo describes a single remote object listed by the GC sweep
-// phase via the RemoteStore.ListByPrefixWithMeta cursor. The full
-// interface declaration lives in pkg/blockstore/remote/remote.go alongside
-// the rest of the RemoteStore surface; this re-export documents the shape
-// at the package root for readers tracing GC plumbing.
-type RemoteObjectInfo struct {
-	Key          string
-	Size         int64
-	LastModified time.Time
-}
-
-// RemoteStoreSweepSurface is a documentation-only interface that captures
-// the subset of remote.RemoteStore methods consumed by the GC sweep phase
-// . The real interface is remote.RemoteStore
-// in pkg/blockstore/remote/remote.go — this declaration exists at the
-// blockstore package root so callers tracing the sweep plumbing can find
-// the shape without crossing package boundaries.
-//
-// Implementations (memory, s3) live alongside the real interface; this
-// type is never used as a parameter — the production code uses
-// remote.RemoteStore directly.
-type RemoteStoreSweepSurface interface {
-	Delete(ctx context.Context, key string) error
-	ListByPrefixWithMeta(ctx context.Context, prefix string) ([]RemoteObjectInfo, error)
-}


### PR DESCRIPTION
## Summary
- Delete 2 unreferenced exports (`RemoteObjectInfo`, `RemoteStoreSweepSurface`) from `pkg/blockstore/store.go`.
- Rename `pkg/blockstore/store.go` → `fileblock.go` (file holds FileBlock-shaped contracts, not a top-level `Store`).

## Audit context
v1.0 area #1 (blockstore) PR-A audit — see `.planning/v1.0-audit/blockstore/REVIEW.md` (collapse candidates C-01/C-02, file-layout finding F-02). PR #677 shipped the audit; this is sub-PR **B-A1** of the B-A zero-logic-change wave.

## Scope reductions vs original B-A1 plan
Grepped each symbol from the audit. Per the rule "if any caller exists outside the file, abort" — the following audit symbols turned out to have live callers and were **left untouched** (will be handled by sibling sub-PRs or future passes once the callers go):

| Symbol | Live caller(s) | Disposition |
| --- | --- | --- |
| `Reader` / `Writer` / `Flusher` / `Store` | `pkg/blockstore/engine/engine.go:19` (`var _ blockstore.Store = (*BlockStore)(nil)`) | Belongs to B-A3 (engine.go territory). |
| `BlockStoreError` / `NewBlockStoreError` | Defined in `pkg/blockstore/errors.go` | B-A2 territory. |
| `LocalForTest` | `internal/adapter/common/write_payload_test.go:70` (active test) | Not dead — audit reclassification needed. |
| `Options.SweepConcurrency` | `pkg/controlplane/runtime/{blockgc,runtime}.go`, `cmd/dfs/commands/start.go`, `pkg/config/config.go`, `pkg/blockstore/engine/gc.go` | Not dead — heavily used end-to-end. |

So B-A1 ships only the safe portion: the two genuinely-dead types plus the file rename.

## Test plan
- [x] `gofmt -s -w . && go vet ./...`
- [x] `go test ./pkg/blockstore/...` (all packages PASS)
- [ ] CI green
- [ ] Copilot review clean

## Verification
- `rg -n 'RemoteObjectInfo' --type go` → only self-references inside the deleted block.
- `rg -n 'RemoteStoreSweepSurface' --type go` → only self-references inside the deleted block.
- `git mv` used so blame history follows store.go → fileblock.go.