### PR TITLE
refactor(blockstore): unify parseChunkOffsetFromID as ParseChunkOffset

### DIFF
--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -1201,7 +1201,7 @@ func findRowCoveringOffset(rows []*blockstore.FileBlock, target uint64) *rowWith
 		if fb == nil {
 			continue
 		}
-		abs, ok := parseChunkOffsetFromID(fb.ID)
+		abs, ok := blockstore.ParseChunkOffset(fb.ID)
 		if !ok {
 			continue
 		}
@@ -1210,29 +1210,4 @@ func findRowCoveringOffset(rows []*blockstore.FileBlock, target uint64) *rowWith
 		}
 	}
 	return nil
-}
-
-// parseChunkOffsetFromID extracts the trailing numeric component of a
-// FileBlock ID of the form "<payloadID>/<chunkOffset>" and returns
-// (chunkOffset, true) on success. Returns (0, false) for malformed
-// IDs.
-func parseChunkOffsetFromID(id string) (uint64, bool) {
-	slash := -1
-	for i := len(id) - 1; i >= 0; i-- {
-		if id[i] == '/' {
-			slash = i
-			break
-		}
-	}
-	if slash < 0 || slash == len(id)-1 {
-		return 0, false
-	}
-	var v uint64
-	for _, c := range id[slash+1:] {
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-		v = v*10 + uint64(c-'0')
-	}
-	return v, true
 }

--- a/pkg/blockstore/engine/fetch.go
+++ b/pkg/blockstore/engine/fetch.go
@@ -49,7 +49,7 @@ func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockId
 		if fb == nil {
 			continue
 		}
-		abs, ok := parseChunkOffsetFromID(fb.ID)
+		abs, ok := blockstore.ParseChunkOffset(fb.ID)
 		if !ok {
 			continue
 		}

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -363,7 +363,7 @@ func (m *Syncer) snapshotPendingBlockRefs(ctx context.Context, payloadID string)
 		// directly in the trailing ID component (FastCDC chunk
 		// boundaries do not align to BlockSize). Use the parsed value
 		// as-is — do NOT multiply by BlockSize.
-		chunkOffset, ok := parseChunkOffsetFromID(fb.ID)
+		chunkOffset, ok := blockstore.ParseChunkOffset(fb.ID)
 		if !ok {
 			continue
 		}
@@ -463,7 +463,7 @@ func (m *Syncer) GetFileSize(ctx context.Context, payloadID string) (uint64, err
 		if !synced {
 			continue
 		}
-		chunkOffset, ok := parseChunkOffsetFromID(fb.ID)
+		chunkOffset, ok := blockstore.ParseChunkOffset(fb.ID)
 		if !ok {
 			continue
 		}

--- a/pkg/blockstore/ids.go
+++ b/pkg/blockstore/ids.go
@@ -1,0 +1,26 @@
+package blockstore
+
+// ParseChunkOffset extracts the trailing numeric component of a FileBlock
+// ID of the form "<payloadID>/<chunkOffset>" and returns
+// (chunkOffset, true) on success. Returns (0, false) for malformed IDs
+// (no slash, trailing slash, or non-digit characters after the slash).
+func ParseChunkOffset(id string) (uint64, bool) {
+	slash := -1
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '/' {
+			slash = i
+			break
+		}
+	}
+	if slash < 0 || slash == len(id)-1 {
+		return 0, false
+	}
+	var v uint64
+	for _, c := range id[slash+1:] {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		v = v*10 + uint64(c-'0')
+	}
+	return v, true
+}

--- a/pkg/blockstore/ids_test.go
+++ b/pkg/blockstore/ids_test.go
@@ -1,0 +1,38 @@
+package blockstore
+
+import "testing"
+
+func TestParseChunkOffset(t *testing.T) {
+	cases := []struct {
+		name   string
+		id     string
+		wantV  uint64
+		wantOK bool
+	}{
+		{"simple", "share/file/0", 0, true},
+		{"non-zero", "share/file/12345", 12345, true},
+		{"max-digits", "p/18446744073709551615", 18446744073709551615, true},
+		{"nested-slashes", "a/b/c/42", 42, true},
+
+		{"no-slash", "noslash", 0, false},
+		{"empty", "", 0, false},
+		{"trailing-slash", "p/", 0, false},
+		{"non-digit", "p/12a", 0, false},
+		{"leading-space", "p/ 12", 0, false},
+		{"negative-sign", "p/-1", 0, false},
+		{"plus-sign", "p/+1", 0, false},
+		{"hex", "p/0x10", 0, false},
+		{"only-slash", "/", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotOK := ParseChunkOffset(tc.id)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotV != tc.wantV {
+				t.Fatalf("v = %d, want %d", gotV, tc.wantV)
+			}
+		})
+	}
+}

--- a/pkg/blockstore/local/fs/readpayload.go
+++ b/pkg/blockstore/local/fs/readpayload.go
@@ -207,7 +207,7 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 		if fb == nil {
 			continue
 		}
-		off, ok := parsePayloadOffsetFromBlockID(fb.ID)
+		off, ok := blockstore.ParseChunkOffset(fb.ID)
 		if !ok {
 			continue
 		}
@@ -266,31 +266,4 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 		}
 	}
 	return nil
-}
-
-// parsePayloadOffsetFromBlockID extracts the trailing numeric component
-// of a FileBlock ID of the form "<payloadID>/<chunkOffset>" and returns
-// (chunkOffset, true) on success. Mirrors the engine-side
-// parseChunkOffsetFromID; duplicated here to avoid a circular import
-// (the engine package depends on this fs package, not the other way
-// around).
-func parsePayloadOffsetFromBlockID(id string) (uint64, bool) {
-	slash := -1
-	for i := len(id) - 1; i >= 0; i-- {
-		if id[i] == '/' {
-			slash = i
-			break
-		}
-	}
-	if slash < 0 || slash == len(id)-1 {
-		return 0, false
-	}
-	var v uint64
-	for _, c := range id[slash+1:] {
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-		v = v*10 + uint64(c-'0')
-	}
-	return v, true
 }


### PR DESCRIPTION
## Summary
- New `pkg/blockstore/ids.go` exporting `ParseChunkOffset(id string) (uint64, bool)`.
- Delete byte-identical private copies in `pkg/blockstore/engine/engine.go` (`parseChunkOffsetFromID`) and `pkg/blockstore/local/fs/readpayload.go` (`parsePayloadOffsetFromBlockID`, renamed-but-identical sibling that existed only to dodge a circular import that does not exist — both files already import `pkg/blockstore`).
- Update the four call sites in `engine/engine.go`, `engine/fetch.go`, `engine/syncer.go` (2x), `local/fs/readpayload.go`.

## Audit context
v1.0 area #1 (blockstore) PR-A audit collapse candidate C-03. PR #677 shipped the audit; this is sub-PR B-A3 of the B-A zero-logic-change wave.

## Verification
The two original implementations are byte-identical:
- same input domain (`<payloadID>/<chunkOffset>` strings)
- same parse strategy (last-`/` search, decimal-digit loop, `uint64` accumulator)
- same error returns (`(0, false)` on no slash / trailing slash / non-digit byte)

## Test plan
- [x] `go build ./...` (rules out import cycle)
- [x] `gofmt -s -w . && go vet ./...`
- [x] `go test ./pkg/blockstore/...` — all packages green
- [ ] CI green
- [ ] Copilot review clean