### PR TITLE
refactor(blockstore): collapse ErrBlockNotFound into ErrChunkNotFound

### DIFF
--- a/pkg/blockstore/blockstore.go
+++ b/pkg/blockstore/blockstore.go
@@ -117,10 +117,8 @@ type BlockStore interface {
 	Delete(ctx context.Context, hash ContentHash) error
 
 	// Head returns Meta for the object addressed by hash without
-	// transferring the body. Returns blockstore.ErrChunkNotFound (or
-	// blockstore.ErrBlockNotFound for remote backends — both are
-	// acceptable; callers match via errors.Is on either) when the
-	// object is absent.
+	// transferring the body. Returns blockstore.ErrChunkNotFound when
+	// the object is absent.
 	//
 	// Meta.Size MUST equal the byte length of what Get would return for
 	// the same hash. Meta.LastModified MUST be non-zero (see Meta

--- a/pkg/blockstore/blockstoretest/conformance.go
+++ b/pkg/blockstore/blockstoretest/conformance.go
@@ -130,11 +130,10 @@ func testGetNotFound(t *testing.T, factory Factory) {
 	if err == nil {
 		t.Fatalf("Get on missing hash: expected error, got nil (data len=%d)", len(data))
 	}
-	// BlockStore contract accepts either ErrChunkNotFound (local) or
-	// ErrBlockNotFound (remote) for missing-key reads — see blockstore.go
-	// Get godoc.
-	if !errors.Is(err, blockstore.ErrChunkNotFound) && !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Fatalf("Get on missing hash: want ErrChunkNotFound or ErrBlockNotFound, got %v", err)
+	// BlockStore contract: missing-key reads return ErrChunkNotFound —
+	// see blockstore.go Get godoc.
+	if !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("Get on missing hash: want ErrChunkNotFound, got %v", err)
 	}
 	if data != nil {
 		t.Fatalf("Get on missing hash: want nil data, got %d bytes", len(data))
@@ -176,8 +175,8 @@ func testDelete(t *testing.T, factory Factory) {
 		t.Fatalf("Delete: %v", err)
 	}
 
-	if _, err := bs.Get(ctx, h); !errors.Is(err, blockstore.ErrChunkNotFound) && !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Fatalf("Get after Delete: want ErrChunkNotFound or ErrBlockNotFound, got %v", err)
+	if _, err := bs.Get(ctx, h); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("Get after Delete: want ErrChunkNotFound, got %v", err)
 	}
 }
 

--- a/pkg/blockstore/compression/decorator.go
+++ b/pkg/blockstore/compression/decorator.go
@@ -150,7 +150,7 @@ func (d *Decorator) Has(ctx context.Context, hash blockstore.ContentHash) (bool,
 	if err == nil {
 		return true, nil
 	}
-	if errors.Is(err, blockstore.ErrBlockNotFound) || errors.Is(err, blockstore.ErrChunkNotFound) {
+	if errors.Is(err, blockstore.ErrChunkNotFound) {
 		return false, nil
 	}
 	return false, err

--- a/pkg/blockstore/doc.go
+++ b/pkg/blockstore/doc.go
@@ -142,8 +142,7 @@
 //     un-migrated `.blk` layout; operator must run
 //     `dfs migrate-to-cas`.
 //   - ErrChunkNotFound — content-addressed chunk is absent
-//     from the store.
-//   - ErrBlockNotFound — remote-side block-miss error.
+//     from the store (local or remote).
 //   - ErrCASContentMismatch — recomputed BLAKE3 disagreed with the
 //     expected ContentHash on read (fail-closed).
 //   - ErrCASKeyMalformed — ParseCASKey rejected an input that

--- a/pkg/blockstore/encryption/decorator.go
+++ b/pkg/blockstore/encryption/decorator.go
@@ -112,7 +112,7 @@ func (d *EncryptedRemote) Has(ctx context.Context, hash blockstore.ContentHash) 
 	if err == nil {
 		return true, nil
 	}
-	if errors.Is(err, blockstore.ErrBlockNotFound) || errors.Is(err, blockstore.ErrChunkNotFound) {
+	if errors.Is(err, blockstore.ErrChunkNotFound) {
 		return false, nil
 	}
 	return false, err

--- a/pkg/blockstore/engine/engine_dualread_test.go
+++ b/pkg/blockstore/engine/engine_dualread_test.go
@@ -210,7 +210,7 @@ func TestDualRead_CASRowMismatchSurfacesError(t *testing.T) {
 
 // TestDualRead_CASMissingObjectFailsClosed: a row
 // with a non-zero hash whose CAS object is absent from the remote MUST
-// surface as ErrBlockNotFound, NOT silently return zeros.
+// surface as ErrChunkNotFound, NOT silently return zeros.
 // fail-closed makes this state structurally impossible under correct GC
 // but if a bug ever lets a live CAS object get reaped, the read path
 // should fail loudly rather than corrupt the caller's data.
@@ -239,10 +239,10 @@ func TestDualRead_CASMissingObjectFailsClosed(t *testing.T) {
 
 	got, err := env.syncer.fetchBlock(ctx, payloadID, 0)
 	if err == nil {
-		t.Fatalf("fetchBlock: expected ErrBlockNotFound, got nil with data=%v", got)
+		t.Fatalf("fetchBlock: expected ErrChunkNotFound, got nil with data=%v", got)
 	}
-	if !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Fatalf("fetchBlock err = %v, want wrapped ErrBlockNotFound", err)
+	if !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("fetchBlock err = %v, want wrapped ErrChunkNotFound", err)
 	}
 	if got != nil {
 		t.Errorf("fetchBlock data = %v, want nil on fail-closed CAS miss", got)

--- a/pkg/blockstore/engine/fetch.go
+++ b/pkg/blockstore/engine/fetch.go
@@ -147,14 +147,14 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
 	if err != nil {
-		if errors.Is(err, blockstore.ErrBlockNotFound) {
+		if errors.Is(err, blockstore.ErrChunkNotFound) {
 			// fail-closed on the CAS path. A row
 			// with a non-zero hash is a live reference to a CAS
 			// object; if that object is missing from the remote, the
 			// invariant has been violated (GC fail-closed
 			// should make this impossible). Returning silent zeros
 			// here would corrupt the caller's read with no log trace.
-			// Surface ErrBlockNotFound so the caller sees the data
+			// Surface ErrChunkNotFound so the caller sees the data
 			// loss explicitly. Post-Phase-17 the legacy zero-hash
 			// branch is gone, so the !IsZero guard is implicit —
 			// any successful dispatchRemoteFetch return implies a
@@ -162,7 +162,7 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 			logger.Error("CAS object missing for live FileBlock — possible GC race or live-data-loss",
 				"block_id", fb.ID, "store_key", storeKey, "hash", fb.Hash.String())
 			return nil, fmt.Errorf("CAS object missing for live row %s (key %s): %w",
-				fb.ID, storeKey, blockstore.ErrBlockNotFound)
+				fb.ID, storeKey, blockstore.ErrChunkNotFound)
 		}
 		return nil, fmt.Errorf("download block %s: %w", storeKey, err)
 	}
@@ -311,7 +311,7 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 	// CAS verified-read dispatch — legacy branch has been removed.
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
 	if err != nil {
-		if errors.Is(err, blockstore.ErrBlockNotFound) {
+		if errors.Is(err, blockstore.ErrChunkNotFound) {
 			// fail-closed on the CAS path. See
 			// fetchBlock for the rationale — a non-zero-hash row that
 			// resolves to a missing CAS object is a live-data-loss
@@ -320,11 +320,11 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 			logger.Error("CAS object missing for live FileBlock — possible GC race or live-data-loss",
 				"block_id", fb.ID, "store_key", storeKey, "hash", fb.Hash.String())
 			wrapped := fmt.Errorf("CAS object missing for live row %s (key %s): %w",
-				fb.ID, storeKey, blockstore.ErrBlockNotFound)
+				fb.ID, storeKey, blockstore.ErrChunkNotFound)
 			completionErr = wrapped
 			return nil, false, wrapped
 		}
-		// Mirror the ErrBlockNotFound branch above: piggyback waiters
+		// Mirror the ErrChunkNotFound branch above: piggyback waiters
 		// read completionErr after result.done closes (via the deferred
 		// completeInFlight), so we MUST set completionErr to the same
 		// wrapped error the direct caller sees — otherwise the waiter

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -457,7 +457,7 @@ func remoteHasHash(t *testing.T, rs remote.RemoteStore, hash blockstore.ContentH
 	if err == nil {
 		return true
 	}
-	if errors.Is(err, blockstore.ErrBlockNotFound) || errors.Is(err, blockstore.ErrChunkNotFound) {
+	if errors.Is(err, blockstore.ErrChunkNotFound) {
 		return false
 	}
 	t.Fatalf("Head(%s): %v", hash, err)

--- a/pkg/blockstore/errors.go
+++ b/pkg/blockstore/errors.go
@@ -118,13 +118,8 @@ var (
 	//   - HTTP: 503 Service Unavailable
 	ErrUnavailable = errors.New("storage unavailable")
 
-	// ErrBlockNotFound is returned when a requested block doesn't exist in the
-	// remote block store.
-	ErrBlockNotFound = errors.New("block not found")
-
-	// ErrChunkNotFound indicates the requested content-addressed chunk does
-	// not exist in the local chunk store. Mirrors ErrBlockNotFound /
-	// ErrContentNotFound style.
+	// ErrChunkNotFound indicates the requested content-addressed chunk
+	// does not exist in the store (local or remote).
 	ErrChunkNotFound = errors.New("chunk not found")
 
 	// ErrStoreClosed is returned when operations are attempted on a closed store.

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -33,9 +33,6 @@ var (
 	ErrDiskFull       = errors.New("local store: disk full after eviction")
 	ErrFileNotInStore = errors.New("file not in local store")
 
-	// ErrBlockNotFound is an alias for blockstore.ErrBlockNotFound.
-	ErrBlockNotFound = blockstore.ErrBlockNotFound
-
 	// errLRUEmpty is returned by lruEvictOne when there are no candidates left.
 	errLRUEmpty = errors.New("local store: LRU empty, no eviction candidates")
 )

--- a/pkg/blockstore/remote/memory/store.go
+++ b/pkg/blockstore/remote/memory/store.go
@@ -80,7 +80,7 @@ func (s *Store) Put(_ context.Context, hash blockstore.ContentHash, data []byte)
 }
 
 // Get returns the bytes addressed by hash. Returns
-// blockstore.ErrBlockNotFound on miss. The returned slice is a defensive
+// blockstore.ErrChunkNotFound on miss. The returned slice is a defensive
 // copy.
 func (s *Store) Get(_ context.Context, hash blockstore.ContentHash) ([]byte, error) {
 	s.mu.RLock()
@@ -92,7 +92,7 @@ func (s *Store) Get(_ context.Context, hash blockstore.ContentHash) ([]byte, err
 
 	mb, ok := s.blocks[hash]
 	if !ok {
-		return nil, blockstore.ErrBlockNotFound
+		return nil, blockstore.ErrChunkNotFound
 	}
 
 	copied := make([]byte, len(mb.data))
@@ -118,7 +118,7 @@ func (s *Store) ReadBlockVerified(_ context.Context, hash blockstore.ContentHash
 
 	mb, ok := s.blocks[hash]
 	if !ok {
-		return nil, blockstore.ErrBlockNotFound
+		return nil, blockstore.ErrChunkNotFound
 	}
 
 	// Body recompute. No streaming response body here.
@@ -146,12 +146,12 @@ func (s *Store) GetRange(_ context.Context, hash blockstore.ContentHash, offset,
 
 	mb, ok := s.blocks[hash]
 	if !ok {
-		return nil, blockstore.ErrBlockNotFound
+		return nil, blockstore.ErrChunkNotFound
 	}
 
 	// Bounds checking
 	if offset < 0 || offset >= int64(len(mb.data)) {
-		return nil, blockstore.ErrBlockNotFound
+		return nil, blockstore.ErrChunkNotFound
 	}
 
 	end := offset + length
@@ -178,7 +178,7 @@ func (s *Store) Has(_ context.Context, hash blockstore.ContentHash) (bool, error
 }
 
 // Head returns blockstore.Meta{Size, LastModified} for the CAS object
-// addressed by hash. Returns blockstore.ErrBlockNotFound on miss.
+// addressed by hash. Returns blockstore.ErrChunkNotFound on miss.
 func (s *Store) Head(_ context.Context, hash blockstore.ContentHash) (blockstore.Meta, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -189,7 +189,7 @@ func (s *Store) Head(_ context.Context, hash blockstore.ContentHash) (blockstore
 
 	mb, ok := s.blocks[hash]
 	if !ok {
-		return blockstore.Meta{}, blockstore.ErrBlockNotFound
+		return blockstore.Meta{}, blockstore.ErrChunkNotFound
 	}
 
 	return blockstore.Meta{

--- a/pkg/blockstore/remote/memory/store_test.go
+++ b/pkg/blockstore/remote/memory/store_test.go
@@ -72,8 +72,8 @@ func TestStore_GetNotFound(t *testing.T) {
 
 	hash := hashOf(t, []byte("nonexistent"))
 	_, err := s.Get(ctx, hash)
-	if !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Errorf("Get returned error %v, want %v", err, blockstore.ErrBlockNotFound)
+	if !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Errorf("Get returned error %v, want %v", err, blockstore.ErrChunkNotFound)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestStore_Delete(t *testing.T) {
 	}
 
 	_, err := s.Get(ctx, hash)
-	if !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Errorf("Get after delete returned %v, want %v", err, blockstore.ErrBlockNotFound)
+	if !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Errorf("Get after delete returned %v, want %v", err, blockstore.ErrChunkNotFound)
 	}
 
 	// Delete on absent hash is idempotent.
@@ -167,8 +167,8 @@ func TestStore_Head(t *testing.T) {
 
 	// Missing hash
 	missing := hashOf(t, []byte("does-not-exist"))
-	if _, err := s.Head(ctx, missing); !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Errorf("Head on missing hash = %v, want %v", err, blockstore.ErrBlockNotFound)
+	if _, err := s.Head(ctx, missing); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Errorf("Head on missing hash = %v, want %v", err, blockstore.ErrChunkNotFound)
 	}
 }
 
@@ -300,8 +300,8 @@ func TestStore_ReadBlockVerified(t *testing.T) {
 
 	// Not found
 	missing := hashOf(t, []byte("missing"))
-	if _, err := s.ReadBlockVerified(ctx, missing, missing); !errors.Is(err, blockstore.ErrBlockNotFound) {
-		t.Fatalf("ReadBlockVerified on missing hash = %v, want wrapped ErrBlockNotFound", err)
+	if _, err := s.ReadBlockVerified(ctx, missing, missing); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("ReadBlockVerified on missing hash = %v, want wrapped ErrChunkNotFound", err)
 	}
 }
 

--- a/pkg/blockstore/remote/remote.go
+++ b/pkg/blockstore/remote/remote.go
@@ -54,9 +54,7 @@ type RemoteStore interface {
 	// implementations MUST NOT return a slice that aliases internal
 	// storage.
 	//
-	// Returns blockstore.ErrBlockNotFound (or blockstore.ErrChunkNotFound
-	// for fs-style backends — callers match via errors.Is on either) when
-	// the chunk is absent.
+	// Returns blockstore.ErrChunkNotFound when the chunk is absent.
 	//
 	// For S3, prefer ReadBlockVerified on the production read path — Get
 	// returns raw bytes WITHOUT BLAKE3 verification.
@@ -64,7 +62,7 @@ type RemoteStore interface {
 
 	// GetRange returns a byte sub-range [offset, offset+length) of the
 	// chunk addressed by hash. The returned slice is freshly allocated
-	// (same no-aliasing rule as Get). Returns blockstore.ErrBlockNotFound
+	// (same no-aliasing rule as Get). Returns blockstore.ErrChunkNotFound
 	// if the chunk is absent.
 	GetRange(ctx context.Context, hash blockstore.ContentHash, offset, length int64) ([]byte, error)
 
@@ -73,7 +71,7 @@ type RemoteStore interface {
 	Delete(ctx context.Context, hash blockstore.ContentHash) error
 
 	// Head returns blockstore.Meta for the object addressed by hash
-	// without transferring the body. Returns blockstore.ErrBlockNotFound
+	// without transferring the body. Returns blockstore.ErrChunkNotFound
 	// when the object is absent.
 	//
 	// The backend's defense-in-depth content-hash header (S3

--- a/pkg/blockstore/remote/s3/store.go
+++ b/pkg/blockstore/remote/s3/store.go
@@ -270,7 +270,7 @@ func (s *Store) Get(ctx context.Context, hash blockstore.ContentHash) ([]byte, e
 	})
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, blockstore.ErrBlockNotFound
+			return nil, blockstore.ErrChunkNotFound
 		}
 		return nil, fmt.Errorf("s3 get: %w", err)
 	}
@@ -304,7 +304,7 @@ func (s *Store) ReadBlockVerified(ctx context.Context, hash blockstore.ContentHa
 	})
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, blockstore.ErrBlockNotFound
+			return nil, blockstore.ErrChunkNotFound
 		}
 		return nil, fmt.Errorf("s3 get: %w", err)
 	}
@@ -348,7 +348,7 @@ func (s *Store) GetRange(ctx context.Context, hash blockstore.ContentHash, offse
 	})
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, blockstore.ErrBlockNotFound
+			return nil, blockstore.ErrChunkNotFound
 		}
 		return nil, fmt.Errorf("s3 get range: %w", err)
 	}
@@ -400,7 +400,7 @@ func (s *Store) Has(ctx context.Context, hash blockstore.ContentHash) (bool, err
 }
 
 // Head returns blockstore.Meta for the CAS object addressed by hash
-// without transferring the body. Returns blockstore.ErrBlockNotFound on
+// without transferring the body. Returns blockstore.ErrChunkNotFound on
 // missing keys (same convention as Get).
 //
 // The x-amz-meta-content-hash header is NOT echoed in the returned
@@ -419,7 +419,7 @@ func (s *Store) Head(ctx context.Context, hash blockstore.ContentHash) (blocksto
 	})
 	if err != nil {
 		if isNotFoundError(err) {
-			return blockstore.Meta{}, blockstore.ErrBlockNotFound
+			return blockstore.Meta{}, blockstore.ErrChunkNotFound
 		}
 		return blockstore.Meta{}, fmt.Errorf("s3 head: %w", err)
 	}

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -312,7 +312,7 @@ func TestFileBlockLastSyncAttemptAt(t *testing.T) {
 
 // TestErrCASSentinels asserts the new exported sentinels exist, are
 // distinct, self-identical via errors.Is, and have non-empty messages
-// prefixed with "blockstore:" — matching ErrInvalidHash / ErrBlockNotFound
+// prefixed with "blockstore:" — matching ErrInvalidHash / ErrChunkNotFound
 // style.
 func TestErrCASSentinels(t *testing.T) {
 	if !errors.Is(ErrCASContentMismatch, ErrCASContentMismatch) {

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -310,10 +310,10 @@ func TestFileBlockLastSyncAttemptAt(t *testing.T) {
 	}
 }
 
-// TestErrCASSentinels asserts the new exported sentinels exist, are
-// distinct, self-identical via errors.Is, and have non-empty messages
-// prefixed with "blockstore:" — matching ErrInvalidHash / ErrChunkNotFound
-// style.
+// TestErrCASSentinels asserts the CAS sentinels exist, are distinct,
+// self-identical via errors.Is, and have non-empty messages prefixed
+// with "blockstore:" (the package-qualified style used by
+// ErrCASContentMismatch and ErrCASKeyMalformed).
 func TestErrCASSentinels(t *testing.T) {
 	if !errors.Is(ErrCASContentMismatch, ErrCASContentMismatch) {
 		t.Error("errors.Is(ErrCASContentMismatch, ErrCASContentMismatch) = false")


### PR DESCRIPTION
## Summary
- Delete `ErrBlockNotFound` sentinel (and the `fs.ErrBlockNotFound` alias).
- Replace all callers with `ErrChunkNotFound` (synonym; matches CAS "chunk" terminology used everywhere else).
- Dedup follow-on `errors.Is(err, X) || errors.Is(err, X)` clauses and stale "(or X for remote backends)" godoc.

## Audit context
v1.0 area #1 (blockstore) PR-A audit collapse candidate C-04. PR #677 shipped the audit; this is sub-PR B-A2 of the B-A zero-logic-change wave.

## Test plan
- [x] `gofmt -s -w . && go vet ./...`
- [x] `go test ./pkg/blockstore/...` (conformance suite exercises the sentinel)
- [ ] CI green
- [ ] Copilot review clean