### PR TITLE
chore(blockstore): strip leftover planning IDs from comments

### DIFF
--- a/pkg/blockstore/blockstoretest/conformance.go
+++ b/pkg/blockstore/blockstoretest/conformance.go
@@ -84,7 +84,7 @@ func testPutGetRoundtrip(t *testing.T, factory Factory) {
 	// below is meaningful — never trust the slice that was handed to
 	// Put after the Put returns; backends may reference it during
 	// asynchronous flushes.
-	original := []byte("conformance: Put_Get_Roundtrip payload bytes (Phase 17 D-05)")
+	original := []byte("conformance: Put_Get_Roundtrip payload bytes")
 	stored := make([]byte, len(original))
 	copy(stored, original)
 
@@ -221,7 +221,7 @@ func testWalk(t *testing.T, factory Factory) {
 			t.Errorf("Walk Meta.Size for %s = %d, want %d", h, m.Size, wantSize)
 		}
 		if m.LastModified.IsZero() {
-			t.Errorf("Walk Meta.LastModified for %s is zero (WR-4-02 contract violation)", h)
+			t.Errorf("Walk Meta.LastModified for %s is zero (contract violation)", h)
 		}
 	}
 }
@@ -306,7 +306,7 @@ func testHead(t *testing.T, factory Factory) {
 		t.Errorf("Head Meta.Size = %d, want %d", m.Size, len(stored))
 	}
 	if m.LastModified.IsZero() {
-		t.Error("Head Meta.LastModified is zero (WR-4-02 contract violation)")
+		t.Error("Head Meta.LastModified is zero (contract violation)")
 	}
 }
 
@@ -343,7 +343,7 @@ func testPutConcurrent(t *testing.T, factory Factory) {
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 
-	stored := []byte("concurrent same-hash same-bytes payload — Phase 17 D-09")
+	stored := []byte("concurrent same-hash same-bytes payload")
 	h := blake3Sum(stored)
 
 	const writers = 8

--- a/pkg/blockstore/engine/gc.go
+++ b/pkg/blockstore/engine/gc.go
@@ -350,7 +350,7 @@ func CollectGarbage(
 func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState, stats *GCStats, hold HoldProvider, remoteEndpointID string, shares []string) error {
 	reconcilerShares := sharesForReconciler(reconciler)
 	if len(reconcilerShares) == 0 {
-		return fmt.Errorf("mark phase: reconciler reports zero shares — refusing to sweep CAS objects without a live set (INV-04 fail-closed)")
+		return fmt.Errorf("mark phase: reconciler reports zero shares — refusing to sweep CAS objects without a live set (fail-closed)")
 	}
 
 	addHash := func(h blockstore.ContentHash) error {

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -114,7 +114,7 @@ type FSStore struct {
 	// create, WriteFromRemote, Recover) and pruned on delete/evict. The
 	// write hot path and eviction consult diskIndex INSTEAD of the
 	// FileBlockStore, decoupling those paths from the underlying metadata
-	// backend (d /).
+	// backend.
 	//
 	// Entries survive pendingFBs drain so subsequent hot-path operations
 	// (e.g., a second pwrite into the same block after BadgerDB persistence)
@@ -156,18 +156,18 @@ type FSStore struct {
 	closeOnce sync.Once
 	wg        sync.WaitGroup
 
-	// --- Append-log path (/03). ---
+	// --- Append-log path. ---
 	//
-	// Append is mandatory on the local tier in — the flag-gated
-	// opt-out was deleted alongside the legacy path-keyed writer. All
-	// AppendWrite + rollup machinery runs unconditionally.
+	// Append is mandatory on the local tier — the flag-gated opt-out was
+	// deleted alongside the legacy path-keyed writer. All AppendWrite +
+	// rollup machinery runs unconditionally.
 	maxLogBytes     int64
 	stabilizationMS int
 	rollupWorkers   int
 
 	// logBytesTotal is the current total bytes of un-rolled-up log content
 	// across every payloadID in this FSStore. Incremented by AppendWrite
-	// (framed-record size) and decremented by the rollup (06).
+	// (framed-record size) and decremented by the rollup.
 	// AppendWrite blocks on pressureCh when logBytesTotal > maxLogBytes
 	logBytesTotal atomic.Int64
 

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -35,7 +35,7 @@ const maxPayloadIDLen = 4352 // metadata.MaxPathLen (4096) + 256 share-prefix sl
 // Charset is intentionally NOT restricted: metadata.ValidateName allows
 // any character (including spaces and Unicode) in filenames, so the
 // recovery walker must follow suit or it will silently orphan logs
-// for legitimate user-facing files.
+// for legitimate user-facing files (#588 follow-up).
 func isValidPayloadID(s string) bool {
 	if len(s) == 0 || len(s) > maxPayloadIDLen {
 		return false

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -35,7 +35,7 @@ const maxPayloadIDLen = 4352 // metadata.MaxPathLen (4096) + 256 share-prefix sl
 // Charset is intentionally NOT restricted: metadata.ValidateName allows
 // any character (including spaces and Unicode) in filenames, so the
 // recovery walker must follow suit or it will silently orphan logs
-// for legitimate user-facing files (#588 follow-up).
+// for legitimate user-facing files.
 func isValidPayloadID(s string) bool {
 	if len(s) == 0 || len(s) > maxPayloadIDLen {
 		return false

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -187,7 +187,7 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
-	// Tombstone re-check AFTER mutex acquire (Blocker 3). DeleteAppendLog
+	// Tombstone re-check AFTER mutex acquire. DeleteAppendLog
 	// sets the tombstone BEFORE acquiring this mutex; if we
 	// it here, delete is in flight (or completed) and we must bail out
 	// without persisting rollup state for a dead payload. The tombstones
@@ -416,7 +416,7 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		pos += uint64(b)
 	}
 
-	// Tombstone re-check IMMEDIATELY before metadata commit (Blocker 3).
+	// Tombstone re-check IMMEDIATELY before metadata commit.
 	// Even if a delete raced between the first check and now, we must not
 	// persist rollup_offset for a deleted payload. Content-addressed chunks
 	// in blocks/ are swept by GC.

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -77,13 +77,12 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 		select {
 		case pid := <-bc.rollupCh:
 			if err := bc.rollupFile(ctx, pid); err != nil {
-				// Surface (#588): a swallowed error here meant
-				// FileBlock manifest persistence failures and
-				// logIndex/tree divergence reports never reached
-				// operator logs. Log at Error so misconfigured or
-				// corrupted state is observable; the dirty
-				// interval stays in the tree and a future pass
-				// (or restart + recovery) retries.
+				// Log at Error so misconfigured or corrupted state is
+				// observable; the dirty interval stays in the tree and
+				// a future pass (or restart + recovery) retries. A
+				// swallowed error here would hide FileBlock manifest
+				// persistence failures and logIndex/tree divergence
+				// reports from operator logs.
 				slog.Error("rollupFile failed",
 					"payloadID", pid, "error", err)
 			}
@@ -123,9 +122,9 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 //
 // Concurrency: the per-file mutex (`mu`) is held through the ENTIRE
 // reconstructStream -> chunker -> StoreChunk -> CommitChunks sequence.
-// This is the fix for the plan-checker's Blocker 3: releasing the mutex
-// before StoreChunk/CommitChunks would break DeleteAppendLog's ability
-// to wait for in-flight rollup by acquiring the same mutex.
+// Releasing the mutex before StoreChunk/CommitChunks would break
+// DeleteAppendLog's ability to wait for in-flight rollup by acquiring
+// the same mutex.
 // Holding the mutex serializes same-file rollup against same-file
 // AppendWrite; this is acceptable because (a) rollup runs in a background
 // worker pool, (b) AppendWrite's mutex window is ~5 µs under
@@ -133,7 +132,7 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 // one file's rollup never stalls another, and (d) pressure-channel
 // blocking only trips when the log budget is exceeded.
 //
-// CommitChunks atomic ordering (reordered #588)
+// CommitChunks atomic ordering:
 //  1. For each emitted chunk: StoreChunk(hash, data) — idempotent, fsynced.
 //  2. ObjectIDPersister(payloadID, blocks, objectID) — writes per-chunk
 //     FileBlock manifest rows + FileAttr.Blocks. MUST land before
@@ -447,21 +446,20 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	}
 	targetPos := idx.AdvanceFence()
 
-	// CommitChunks atomic sequence (reordered #588). The on-disk
-	// CAS chunks are already durable from StoreChunk above. The remaining
-	// commit steps must land in this order so a partial failure never
-	// advances rollup_offset past records whose FileBlock manifest rows
-	// haven't been persisted
+	// CommitChunks atomic sequence. The on-disk CAS chunks are already
+	// durable from StoreChunk above. The remaining commit steps must
+	// land in this order so a partial failure never advances
+	// rollup_offset past records whose FileBlock manifest rows haven't
+	// been persisted:
 	//
 	//  1. ObjectIDPersister(payloadID, blocks, objectID) — writes the
 	//     per-chunk FileBlock rows AND the FileAttr.Blocks manifest +
 	//     ObjectID. If this fails, rollup_offset stays UNCHANGED and the
 	//     next rollup pass retries — chunks are content-addressed and
-	//     idempotent on re-store. (Prior to #588 the persister fired
-	//     AFTER SetRollupOffset, which meant a persister failure left
-	//     rollup_offset advanced past records whose manifest never
-	//     landed; the engine read path then fell into the sparse-zero
-	//     branch.)
+	//     idempotent on re-store. (Persister-after-SetRollupOffset is
+	//     the wrong ordering: a persister failure leaves rollup_offset
+	//     advanced past records whose manifest never landed, and the
+	//     engine read path falls into the sparse-zero branch.)
 	//  2. rollupStore.SetRollupOffset(payloadID, targetPos) — atomic-
 	//     monotone metadata-authoritative fence advance.
 	//  3. advanceRollupOffset(logFile, targetPos) — idempotent derived


### PR DESCRIPTION
## Summary
- Strip Phase/plan/decision IDs from inline comments and user-visible strings in `pkg/blockstore/local/fs/{fs.go,rollup.go,recovery.go}`, `pkg/blockstore/engine/gc.go`, and `pkg/blockstore/blockstoretest/conformance.go`.
- Wave 0 (PR #666) sweep misses surfaced by v1.0 area #1 audit (PR #677). Zero-logic-change comment cleanup.

## Scope
Audit-listed hits:
- `local/fs/fs.go:115` `(d /)` — leftover artifact in diskIndex comment.
- `local/fs/fs.go:159-163,170` `/03`, broken sentence, `(06)` — leftover phase refs in append-log section header.
- `local/fs/rollup.go:126,136` `plan-checker's Blocker 3`, `(reordered #588)` — planning refs in rollupFile docstring.
- `blockstoretest/conformance.go:87,346` `(Phase 17 D-05)`, `Phase 17 D-09` — planning IDs in test payload strings.

Adjacent sweep hits (same pattern):
- `local/fs/rollup.go:80,450,460` three more `#588` planning refs.
- `local/fs/recovery.go:38` `#588 follow-up`.
- `engine/gc.go:353` `INV-04 fail-closed` in user-visible error text.
- `blockstoretest/conformance.go:224,309` two `WR-4-02 contract violation` in test error text.

`FIX-NN` cross-references throughout `local/fs/` are NOT touched — they are coordinated internal codes referenced across files, not the GSD planning-ID pattern.

## Test plan
- [x] `gofmt -s -w pkg/blockstore/ && go vet ./pkg/blockstore/...` clean
- [x] `go test ./pkg/blockstore/... -short` all pass
- [ ] CI green
- [ ] Copilot review clean