### PR TITLE
fix(smb): case-insensitive directory traversal (#649)

### DIFF
--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -444,7 +444,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				// actual target type — stream handles always have IsDirectory=false.
 				isDeleteTargetDir := openFile.IsDirectory
 				if isBaseFileDelete {
-					if targetFile, lookupErr := metaSvc.Lookup(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil {
+					if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil && targetFile != nil {
 						isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
 					}
 				}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1600,16 +1600,6 @@ func adsBasePath(filePath string) string {
 	return fileName[:colonIdx]
 }
 
-// shareNameFromHandle extracts the share name from an encoded file handle.
-func shareNameFromHandle(handle metadata.FileHandle) string {
-	if len(handle) > 0 {
-		if name, _, err := metadata.DecodeFileHandle(handle); err == nil && name != "" {
-			return name
-		}
-	}
-	return ""
-}
-
 // checkShareDeleteConflict checks if any other open handle on the same file
 // lacks FILE_SHARE_DELETE in its ShareAccess. Per MS-FSA 2.1.5.14.10, a rename
 // requires all other opens to permit delete sharing. Returns true if a conflict

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1242,7 +1242,7 @@ func (h *Handler) generateAsyncId() uint64 {
 func (h *Handler) baseFileUUID(authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, name string, fallback [16]byte) [16]byte {
 	if colonIdx := strings.Index(name, ":"); colonIdx > 0 && len(parentHandle) > 0 {
 		metaSvc := h.Registry.GetMetadataService()
-		if baseFile, err := metaSvc.Lookup(authCtx, parentHandle, name[:colonIdx]); err == nil {
+		if baseFile, _, err := metaSvc.LookupCaseInsensitive(authCtx, parentHandle, name[:colonIdx]); err == nil && baseFile != nil {
 			return baseFile.ID
 		}
 	}
@@ -1565,67 +1565,18 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 	return conflict
 }
 
-// paginatedChildScan iterates over a directory's children in pages and
-// returns the first entry whose name satisfies matchFn, confirmed by a
-// Lookup. Surfaces real store errors (anything other than ErrNotFound)
-// so callers can distinguish "no match" from "store unhealthy / not a
-// directory / permission denied".
-func (h *Handler) paginatedChildScan(
-	authCtx *metadata.AuthContext,
-	metaSvc *metadata.MetadataService,
-	parentHandle metadata.FileHandle,
-	matchFn func(entryName string) bool,
-) (*metadata.File, string, error) {
-	store, err := metaSvc.GetStoreForShare(shareNameFromHandle(parentHandle))
-	if err != nil {
-		return nil, "", err
-	}
-	cursor := ""
-	for {
-		entries, nextCursor, listErr := store.ListChildren(authCtx.Context, parentHandle, cursor, 500)
-		if listErr != nil {
-			if metadata.IsNotFoundError(listErr) {
-				return nil, "", nil
-			}
-			return nil, "", listErr
-		}
-		for _, entry := range entries {
-			if matchFn(entry.Name) {
-				if f, lookupErr := metaSvc.Lookup(authCtx, parentHandle, entry.Name); lookupErr == nil {
-					return f, entry.Name, nil
-				}
-			}
-		}
-		if nextCursor == "" {
-			break
-		}
-		cursor = nextCursor
-	}
-	return nil, "", nil
-}
-
-// lookupCaseInsensitive performs a case-insensitive child lookup in a
-// directory. It first tries an exact-case Lookup; on ErrNotFound it
-// falls back to scanning the parent's children with strings.EqualFold.
-// Any non-NotFound error (e.g., ErrNotDirectory, permission errors)
-// propagates to the caller so the resulting SMB status reflects the
-// real condition. Returns nil/""/nil when no match exists.
+// lookupCaseInsensitive is a thin shim around
+// MetadataService.LookupCaseInsensitive that keeps the existing
+// (handler, metaSvc, parent, name) call signature used across the SMB
+// handlers. NTFS-style paths are case-insensitive; DittoFS preserves the
+// original on-disk casing and returns it via the second result.
 func (h *Handler) lookupCaseInsensitive(
 	authCtx *metadata.AuthContext,
 	metaSvc *metadata.MetadataService,
 	parentHandle metadata.FileHandle,
 	name string,
 ) (*metadata.File, string, error) {
-	f, err := metaSvc.Lookup(authCtx, parentHandle, name)
-	if err == nil {
-		return f, name, nil
-	}
-	if !metadata.IsNotFoundError(err) {
-		return nil, "", err
-	}
-	return h.paginatedChildScan(authCtx, metaSvc, parentHandle, func(entryName string) bool {
-		return strings.EqualFold(entryName, name)
-	})
+	return metaSvc.LookupCaseInsensitive(authCtx, parentHandle, name)
 }
 
 // adsBasePath extracts the base file path from a potentially ADS-qualified path.

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -790,12 +790,21 @@ func (h *Handler) setFileInfoFromStore(
 		isOverwrite := renameInfo.ReplaceIfExists
 		metaSvc := h.Registry.GetMetadataService()
 		var dstMetaHandle metadata.FileHandle
+		// dstMatchedName is the on-disk name of the destination entry when
+		// the case-insensitive lookup succeeds. Move's underlying GetChild is
+		// exact-case, so if the client supplied a different-case spelling
+		// (e.g. "FOO.TXT" while the on-disk entry is "Foo.txt") we MUST hand
+		// the canonical casing to Move — otherwise Move would silently
+		// create a second sibling entry instead of overwriting. Empty when
+		// there is no destination or the lookup failed.
+		var dstMatchedName string
 		if isOverwrite {
-			dstFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, toDir, toName)
+			dstFile, matched, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, toDir, toName)
 			if lookupErr == nil && dstFile != nil {
 				if encoded, encErr := metadata.EncodeFileHandle(dstFile); encErr == nil {
 					dstMetaHandle = encoded
 				}
+				dstMatchedName = matched
 			}
 		}
 
@@ -891,6 +900,20 @@ func (h *Handler) setFileInfoFromStore(
 		// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename so we can
 		// restore them after. Rename should NOT update the file's timestamps.
 		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
+
+		// Pre-overwrite the case-mismatched destination: Move's destination
+		// probe is exact-case GetChild(toName), so a destination that exists
+		// under a different casing (e.g. on disk "Foo.txt", client said
+		// "FOO.TXT") would be missed and Move would silently create a second
+		// sibling entry. Remove the matched-case destination upfront so Move
+		// inserts the source under the client-requested casing.
+		if isOverwrite && dstMatchedName != "" && dstMatchedName != toName {
+			if _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName); rmErr != nil {
+				logger.Debug("SET_INFO: rename overwrite pre-remove failed",
+					"name", dstMatchedName, "error", rmErr)
+				return setInfoStatus(common.MapToSMB(rmErr)), nil
+			}
+		}
 
 		// Perform the rename/move
 		err = metaSvc.Move(authCtx, openFile.ParentHandle, openFile.FileName, toDir, toName)

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -791,7 +791,7 @@ func (h *Handler) setFileInfoFromStore(
 		metaSvc := h.Registry.GetMetadataService()
 		var dstMetaHandle metadata.FileHandle
 		if isOverwrite {
-			dstFile, lookupErr := metaSvc.Lookup(authCtx, toDir, toName)
+			dstFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, toDir, toName)
 			if lookupErr == nil && dstFile != nil {
 				if encoded, encErr := metadata.EncodeFileHandle(dstFile); encErr == nil {
 					dstMetaHandle = encoded
@@ -1689,10 +1689,10 @@ func (h *Handler) handleFileLinkInformation(
 	// ErrAlreadyExists → STATUS_OBJECT_NAME_COLLISION via common.MapToSMB.
 	metaSvc := h.Registry.GetMetadataService()
 	if linkInfo.ReplaceIfExists {
-		if existing, lookupErr := metaSvc.Lookup(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
-			if _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, linkName); rmErr != nil {
+		if existing, matchedName, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
+			if _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName); rmErr != nil {
 				logger.Debug("SET_INFO: hardlink replace failed to remove existing",
-					"name", linkName, "error", rmErr)
+					"name", matchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
 			}
 		}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -76,6 +76,68 @@ func (s *MetadataService) Lookup(ctx *AuthContext, dirHandle FileHandle, name st
 	return store.GetFile(ctx.Context, childHandle)
 }
 
+// LookupCaseInsensitive resolves a name within a directory like Lookup, but
+// falls back to a case-insensitive scan of the directory's children when the
+// exact-case lookup returns ErrNotFound. It is intended for SMB callers, which
+// treat NTFS-style paths as case-insensitive while DittoFS stores names with
+// their original case on disk.
+//
+// Returns:
+//   - (file, matchedName, nil) on success — matchedName is the on-disk name
+//     (case-preserved) that satisfied the match.
+//   - (nil, "", nil) when no entry matches.
+//   - (nil, "", err) for any non-NotFound error (NotDirectory, permission,
+//     transport, …); callers should map this to the appropriate SMB status.
+//
+// Special names "." and ".." short-circuit to the exact-case Lookup path.
+//
+// Note: NFS callers must keep using Lookup directly — POSIX paths are
+// case-sensitive.
+func (s *MetadataService) LookupCaseInsensitive(ctx *AuthContext, dirHandle FileHandle, name string) (*File, string, error) {
+	f, err := s.Lookup(ctx, dirHandle, name)
+	if err == nil {
+		return f, name, nil
+	}
+	if !IsNotFoundError(err) {
+		return nil, "", err
+	}
+	if name == "" || name == "." || name == ".." {
+		return nil, "", nil
+	}
+
+	store, storeErr := s.storeForHandle(dirHandle)
+	if storeErr != nil {
+		return nil, "", storeErr
+	}
+
+	cursor := ""
+	for {
+		entries, nextCursor, listErr := store.ListChildren(ctx.Context, dirHandle, cursor, 500)
+		if listErr != nil {
+			if IsNotFoundError(listErr) {
+				return nil, "", nil
+			}
+			return nil, "", listErr
+		}
+		for _, entry := range entries {
+			if strings.EqualFold(entry.Name, name) {
+				match, matchErr := s.Lookup(ctx, dirHandle, entry.Name)
+				if matchErr != nil {
+					if IsNotFoundError(matchErr) {
+						continue
+					}
+					return nil, "", matchErr
+				}
+				return match, entry.Name, nil
+			}
+		}
+		if nextCursor == "" {
+			return nil, "", nil
+		}
+		cursor = nextCursor
+	}
+}
+
 // ReadSymlink reads the target path of a symbolic link.
 func (s *MetadataService) ReadSymlink(ctx *AuthContext, handle FileHandle) (string, *File, error) {
 	store, err := s.storeForHandle(handle)

--- a/pkg/metadata/lookup_case_insensitive_test.go
+++ b/pkg/metadata/lookup_case_insensitive_test.go
@@ -107,6 +107,13 @@ func TestLookupCaseInsensitive_SpecialNames(t *testing.T) {
 	require.NotNil(t, file)
 	assert.Equal(t, ".", matched)
 	assert.Equal(t, metadata.FileTypeDirectory, file.Type)
+
+	// ".." from root resolves to root (no parent ⇒ Lookup returns self).
+	parent, matchedDotDot, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "..")
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	assert.Equal(t, "..", matchedDotDot)
+	assert.Equal(t, metadata.FileTypeDirectory, parent.Type)
 }
 
 // TestLookupCaseInsensitive_PreservesCaseAcrossMultipleEntries makes sure the

--- a/pkg/metadata/lookup_case_insensitive_test.go
+++ b/pkg/metadata/lookup_case_insensitive_test.go
@@ -1,0 +1,128 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLookupCaseInsensitive_ExactMatch verifies the fast path: when the
+// caller's spelling matches the on-disk name byte-for-byte, the result is
+// returned without any directory scan.
+func TestLookupCaseInsensitive_ExactMatch(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "ExactCase.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "ExactCase.txt")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, "ExactCase.txt", matched)
+}
+
+// TestLookupCaseInsensitive_FallbackMatch verifies the scan fallback: an
+// upper-case probe finds a mixed-case on-disk entry and returns the original
+// on-disk name (case preserved) so callers can pass it to RemoveFile / Move /
+// etc. without breaking the canonical spelling.
+func TestLookupCaseInsensitive_FallbackMatch(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "TestFile.TXT", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "TESTFILE.TXT")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, "TestFile.TXT", matched, "must return original on-disk casing, not the probe")
+}
+
+// TestLookupCaseInsensitive_NotFound returns nil/""/nil when no entry matches
+// — this is the contract callers rely on to distinguish "not present" from
+// real errors like NotDirectory or permission denied.
+func TestLookupCaseInsensitive_NotFound(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "Missing.txt")
+	require.NoError(t, err)
+	assert.Nil(t, file)
+	assert.Empty(t, matched)
+}
+
+// TestLookupCaseInsensitive_DirectoryEntry confirms the fallback handles
+// directories as well as files (walkPath relies on this for path components).
+func TestLookupCaseInsensitive_DirectoryEntry(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "MyDir", &metadata.FileAttr{Mode: 0755})
+	require.NoError(t, err)
+
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "MYDIR")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, "MyDir", matched)
+	assert.Equal(t, metadata.FileTypeDirectory, file.Type)
+}
+
+// TestLookupCaseInsensitive_NotADirectory surfaces NotDirectory errors from
+// the underlying Lookup rather than silently swallowing them — callers must
+// see the real SMB status code (STATUS_NOT_A_DIRECTORY).
+func TestLookupCaseInsensitive_NotADirectory(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	fileEntry, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "regular.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	fileHandle, err := metadata.EncodeFileHandle(fileEntry)
+	require.NoError(t, err)
+
+	// Use the file as if it were a parent directory — must propagate
+	// NotDirectory, not return a silent miss.
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fileHandle, "child")
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.Empty(t, matched)
+	var storeErr *metadata.StoreError
+	if assert.ErrorAs(t, err, &storeErr) {
+		assert.Equal(t, metadata.ErrNotDirectory, storeErr.Code)
+	}
+}
+
+// TestLookupCaseInsensitive_SpecialNames short-circuits "." and ".." through
+// the exact-case Lookup — they should never trigger the scan fallback.
+func TestLookupCaseInsensitive_SpecialNames(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// "." resolves to the directory itself.
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, ".")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, ".", matched)
+	assert.Equal(t, metadata.FileTypeDirectory, file.Type)
+}
+
+// TestLookupCaseInsensitive_PreservesCaseAcrossMultipleEntries makes sure the
+// scan picks the actual on-disk match when the directory contains sibling
+// entries that differ only by case-equivalent characters at the same offset.
+func TestLookupCaseInsensitive_PreservesCaseAcrossMultipleEntries(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	for _, name := range []string{"alpha.txt", "Beta.TXT", "gamma.txt"} {
+		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, name, &metadata.FileAttr{Mode: 0644})
+		require.NoError(t, err)
+	}
+
+	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "BETA.txt")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, "Beta.TXT", matched)
+}


### PR DESCRIPTION
## Summary

NTFS paths are case-insensitive; DittoFS preserves the original on-disk casing. CREATE/QUERY/SET-INFO already fell back to a case-insensitive scan via a private SMB-handler helper. This PR promotes the fallback to a public metadata-service method so the remaining direct \`Lookup\` callsites can use it without re-implementing the scan.

## Changes

- \`pkg/metadata\`: add \`MetadataService.LookupCaseInsensitive\` — exact-case Lookup, then on \`ErrNotFound\` an \`EqualFold\` scan over the directory's children, returning the on-disk casing as the second result. Non-NotFound errors (NotDirectory, permission) propagate unchanged so SMB status codes stay correct. NFS continues to use exact-case \`Lookup\` directly.
- SMB v2 handlers: convert the remaining direct \`metaSvc.Lookup\` probes to \`LookupCaseInsensitive\` (\`close.go\` DOC type probe, \`set_info.go\` rename overwrite + hardlink replace, \`handler.go\` ADS base-file UUID lookup). The handler-level \`lookupCaseInsensitive\` shim is now a thin wrapper over the metadata-service method; the duplicated \`paginatedChildScan\` helper is removed.

## Acceptance

- Mixed-case probes hit existing files via \`LookupCaseInsensitive\` regardless of stored casing.
- Returned name is always the on-disk casing — \`RemoveFile\` / \`Move\` keep working from the case-insensitive match.
- NFS lookups stay exact-case.

## Test plan

- [x] \`go test ./pkg/metadata/...\` (new \`TestLookupCaseInsensitive_*\` cases for ExactMatch, FallbackMatch, NotFound, NotADirectory, DirectoryEntry, SpecialNames, sibling resolution)
- [x] \`go test -race ./pkg/metadata/ ./internal/adapter/smb/v2/...\`
- [ ] CI smbtorture (no regressions expected; case-sensitive paths unaffected since the exact-case fast path runs first)

Closes #649