### PR TITLE
fix(smb): accept HMAC-SHA256 in 3.1.1 SIGNING_CAPABILITIES (#486)

### DIFF
--- a/internal/adapter/smb/crypto_state.go
+++ b/internal/adapter/smb/crypto_state.go
@@ -35,6 +35,14 @@ type ConnectionCryptoState struct {
 	// Selected signing algorithm (set during NEGOTIATE)
 	SigningAlgorithmId uint16
 
+	// SigningAlgorithmExplicit reports whether the client explicitly
+	// negotiated the signing algorithm via a SIGNING_CAPABILITIES negotiate
+	// context (MS-SMB2 §3.1.1.2). When false, SigningAlgorithmId carries the
+	// server-side default (AES-128-CMAC for 3.x), not a client selection.
+	// Used to disambiguate HMAC-SHA256 (wire value 0x0000) from a
+	// default-zero placeholder.
+	SigningAlgorithmExplicit bool
+
 	// Server's GUID (set during NEGOTIATE)
 	ServerGUID [16]byte
 
@@ -228,18 +236,23 @@ func (cs *ConnectionCryptoState) GetCipherId() uint16 {
 	return cs.CipherId
 }
 
-// SetSigningAlgorithmId records the selected signing algorithm.
-func (cs *ConnectionCryptoState) SetSigningAlgorithmId(id uint16) {
+// SetSigningAlgorithmId records the selected signing algorithm and whether
+// the client explicitly negotiated it via a SIGNING_CAPABILITIES context.
+// The explicit flag is required to disambiguate HMAC-SHA256 (wire value 0)
+// from a default-zero placeholder when constructing signers.
+func (cs *ConnectionCryptoState) SetSigningAlgorithmId(id uint16, explicit bool) {
 	cs.mu.Lock()
 	cs.SigningAlgorithmId = id
+	cs.SigningAlgorithmExplicit = explicit
 	cs.mu.Unlock()
 }
 
-// GetSigningAlgorithmId returns the selected signing algorithm.
-func (cs *ConnectionCryptoState) GetSigningAlgorithmId() uint16 {
+// GetSigningAlgorithmId returns the selected signing algorithm and whether
+// it was explicitly negotiated by the client.
+func (cs *ConnectionCryptoState) GetSigningAlgorithmId() (uint16, bool) {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
-	return cs.SigningAlgorithmId
+	return cs.SigningAlgorithmId, cs.SigningAlgorithmExplicit
 }
 
 // SetPreauthIntegrityHashId records the selected hash algorithm.

--- a/internal/adapter/smb/session/channel_keys_test.go
+++ b/internal/adapter/smb/session/channel_keys_test.go
@@ -15,7 +15,7 @@ import (
 func TestDeriveChannelSigningKey_MatchesDeriveAllKeys_SMB30(t *testing.T) {
 	sessionKey := bytes.Repeat([]byte{0x42}, 16)
 
-	cs := DeriveAllKeys(sessionKey, types.Dialect0300, [64]byte{}, 0, 0)
+	cs := DeriveAllKeys(sessionKey, types.Dialect0300, [64]byte{}, 0, 0, false)
 
 	channelKey, err := DeriveChannelSigningKey(sessionKey, types.Dialect0300, [64]byte{})
 	if err != nil {

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -92,7 +92,10 @@ type SessionCryptoState struct {
 //   - preauthHash: the preauth integrity hash (only used for 3.1.1)
 //   - cipherId: the negotiated cipher ID (determines encryption key length)
 //   - signingAlgId: the negotiated signing algorithm ID
-func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byte, cipherId uint16, signingAlgId uint16) *SessionCryptoState {
+//   - signingAlgExplicit: true when signingAlgId came from an explicit
+//     SIGNING_CAPABILITIES negotiate context (required to disambiguate
+//     HMAC-SHA256, whose wire value is 0, from a default-zero placeholder)
+func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byte, cipherId uint16, signingAlgId uint16, signingAlgExplicit bool) *SessionCryptoState {
 	cs := &SessionCryptoState{}
 	cs.SessionKey = make([]byte, len(sessionKey))
 	copy(cs.SessionKey, sessionKey)
@@ -109,7 +112,7 @@ func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byt
 	// SMB 3.x: derive all 4 keys via SP800-108 KDF
 	sigLabel, sigCtx := kdf.LabelAndContext(kdf.SigningKeyPurpose, dialect, preauthHash)
 	cs.SigningKey = kdf.DeriveKey(sessionKey, sigLabel, sigCtx, 128)
-	cs.Signer = signing.NewSigner(dialect, signingAlgId, cs.SigningKey)
+	cs.Signer = signing.NewSigner(dialect, signingAlgId, signingAlgExplicit, cs.SigningKey)
 
 	encKeyBits := uint32(128)
 	if cipherId == types.CipherAES256CCM || cipherId == types.CipherAES256GCM {

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -283,7 +283,7 @@ type SessionStats struct {
 // This creates a CryptoState with an HMACSigner for SMB 2.x sessions.
 // For 3.x sessions, use SetCryptoState with DeriveAllKeys instead.
 func (s *Session) SetSigningKey(sessionKey []byte) {
-	s.CryptoState = DeriveAllKeys(sessionKey, types.Dialect0202, [64]byte{}, 0, signing.SigningAlgHMACSHA256)
+	s.CryptoState = DeriveAllKeys(sessionKey, types.Dialect0202, [64]byte{}, 0, signing.SigningAlgHMACSHA256, false)
 }
 
 // EnableSigning enables message signing for this session.

--- a/internal/adapter/smb/signing/signer.go
+++ b/internal/adapter/smb/signing/signer.go
@@ -34,13 +34,25 @@ type Signer interface {
 // Dispatch logic:
 //   - dialect < 3.0: HMACSigner (HMAC-SHA256)
 //   - signingAlgorithmId == SigningAlgAESGMAC: GMACSigner
-//   - otherwise (3.0/3.0.2, or 3.1.1 without GMAC): CMACSigner
+//   - signingAlgorithmId == SigningAlgHMACSHA256 on 3.1.1: HMACSigner (when
+//     the client explicitly negotiates HMAC-SHA256 via SIGNING_CAPABILITIES)
+//   - otherwise (3.0/3.0.2, or 3.1.1 with CMAC): CMACSigner
 func NewSigner(dialect types.Dialect, signingAlgorithmId uint16, key []byte) Signer {
 	if dialect < types.Dialect0300 {
 		return NewHMACSigner(key)
 	}
-	if signingAlgorithmId == SigningAlgAESGMAC {
+	switch signingAlgorithmId {
+	case SigningAlgAESGMAC:
 		return NewGMACSigner(key)
+	case SigningAlgHMACSHA256:
+		// Only reachable when a 3.1.1 client explicitly selects
+		// HMAC-SHA256 via SIGNING_CAPABILITIES negotiate context.
+		// 3.0 / 3.0.2 paths leave signingAlgorithmId == 0 and would
+		// hit this branch too — but those dialects historically used
+		// CMAC, so fall through to the default for them.
+		if dialect >= types.Dialect0311 {
+			return NewHMACSigner(key)
+		}
 	}
 	return NewCMACSigner(key)
 }

--- a/internal/adapter/smb/signing/signer.go
+++ b/internal/adapter/smb/signing/signer.go
@@ -31,13 +31,21 @@ type Signer interface {
 // NewSigner creates the appropriate Signer for the negotiated dialect and
 // signing algorithm.
 //
+// SigningAlgHMACSHA256 has the wire value 0 per MS-SMB2 §2.2.3.1.7, which is
+// indistinguishable from an unset/default-zero signingAlgorithmId. To avoid
+// accidentally returning HMACSigner for a 3.1.1 session that never explicitly
+// negotiated HMAC-SHA256 (e.g. no SIGNING_CAPABILITIES context, or a default-
+// zero plumbing path), HMAC-SHA256 is only selected when explicitlyNegotiated
+// is true.
+//
 // Dispatch logic:
-//   - dialect < 3.0: HMACSigner (HMAC-SHA256)
+//   - dialect < 3.0: HMACSigner (HMAC-SHA256, the only signer for 2.x)
 //   - signingAlgorithmId == SigningAlgAESGMAC: GMACSigner
-//   - signingAlgorithmId == SigningAlgHMACSHA256 on 3.1.1: HMACSigner (when
-//     the client explicitly negotiates HMAC-SHA256 via SIGNING_CAPABILITIES)
-//   - otherwise (3.0/3.0.2, or 3.1.1 with CMAC): CMACSigner
-func NewSigner(dialect types.Dialect, signingAlgorithmId uint16, key []byte) Signer {
+//   - signingAlgorithmId == SigningAlgHMACSHA256 on 3.1.1 AND
+//     explicitlyNegotiated: HMACSigner
+//   - otherwise (3.0/3.0.2, or 3.1.1 with CMAC, or any non-explicit zero):
+//     CMACSigner
+func NewSigner(dialect types.Dialect, signingAlgorithmId uint16, explicitlyNegotiated bool, key []byte) Signer {
 	if dialect < types.Dialect0300 {
 		return NewHMACSigner(key)
 	}
@@ -45,12 +53,10 @@ func NewSigner(dialect types.Dialect, signingAlgorithmId uint16, key []byte) Sig
 	case SigningAlgAESGMAC:
 		return NewGMACSigner(key)
 	case SigningAlgHMACSHA256:
-		// Only reachable when a 3.1.1 client explicitly selects
-		// HMAC-SHA256 via SIGNING_CAPABILITIES negotiate context.
-		// 3.0 / 3.0.2 paths leave signingAlgorithmId == 0 and would
-		// hit this branch too — but those dialects historically used
-		// CMAC, so fall through to the default for them.
-		if dialect >= types.Dialect0311 {
+		// Wire value 0 — ambiguous with default-zero. Only honour HMAC-SHA256
+		// on 3.1.1 when the caller signals an explicit SIGNING_CAPABILITIES
+		// selection. Otherwise fall through to CMAC (the 3.x default).
+		if dialect >= types.Dialect0311 && explicitlyNegotiated {
 			return NewHMACSigner(key)
 		}
 	}

--- a/internal/adapter/smb/signing/signer_test.go
+++ b/internal/adapter/smb/signing/signer_test.go
@@ -16,6 +16,7 @@ func TestNewSigner_Dispatch(t *testing.T) {
 		name       string
 		dialect    types.Dialect
 		signingAlg uint16
+		explicit   bool
 		wantType   string
 	}{
 		{
@@ -58,13 +59,26 @@ func TestNewSigner_Dispatch(t *testing.T) {
 			name:       "SMB 3.1.1 with explicit HMAC-SHA256 returns HMACSigner",
 			dialect:    types.Dialect0311,
 			signingAlg: SigningAlgHMACSHA256,
+			explicit:   true,
 			wantType:   "*signing.HMACSigner",
+		},
+		{
+			// Regression: HMAC-SHA256 has wire value 0x0000, which is
+			// indistinguishable from a default-zero placeholder. Without
+			// an explicit-selection signal, a 3.1.1 session that never
+			// negotiated SIGNING_CAPABILITIES (or any other default-zero
+			// plumbing) must fall through to CMAC.
+			name:       "SMB 3.1.1 with implicit zero signingAlg returns CMACSigner",
+			dialect:    types.Dialect0311,
+			signingAlg: SigningAlgHMACSHA256,
+			explicit:   false,
+			wantType:   "*signing.CMACSigner",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signer := NewSigner(tt.dialect, tt.signingAlg, key)
+			signer := NewSigner(tt.dialect, tt.signingAlg, tt.explicit, key)
 			if signer == nil {
 				t.Fatal("NewSigner returned nil")
 			}
@@ -83,8 +97,8 @@ func TestNewSigner_Dispatch(t *testing.T) {
 			}
 
 			if typeName != tt.wantType {
-				t.Errorf("NewSigner(%v, 0x%04x) = %s, want %s",
-					tt.dialect, tt.signingAlg, typeName, tt.wantType)
+				t.Errorf("NewSigner(%v, 0x%04x, explicit=%v) = %s, want %s",
+					tt.dialect, tt.signingAlg, tt.explicit, typeName, tt.wantType)
 			}
 		})
 	}

--- a/internal/adapter/smb/signing/signer_test.go
+++ b/internal/adapter/smb/signing/signer_test.go
@@ -55,10 +55,10 @@ func TestNewSigner_Dispatch(t *testing.T) {
 			wantType:   "*signing.CMACSigner",
 		},
 		{
-			name:       "SMB 3.1.1 without GMAC negotiation returns CMACSigner",
+			name:       "SMB 3.1.1 with explicit HMAC-SHA256 returns HMACSigner",
 			dialect:    types.Dialect0311,
-			signingAlg: 0,
-			wantType:   "*signing.CMACSigner",
+			signingAlg: SigningAlgHMACSHA256,
+			wantType:   "*signing.HMACSigner",
 		},
 	}
 

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -49,10 +49,12 @@ type CryptoState interface {
 	SetClientDialects(dialects []types.Dialect)
 	// GetClientDialects returns the client's offered dialect list.
 	GetClientDialects() []types.Dialect
-	// SetSigningAlgorithmId records the selected signing algorithm.
-	SetSigningAlgorithmId(id uint16)
-	// GetSigningAlgorithmId returns the selected signing algorithm.
-	GetSigningAlgorithmId() uint16
+	// SetSigningAlgorithmId records the selected signing algorithm and
+	// whether the client explicitly negotiated it via SIGNING_CAPABILITIES.
+	SetSigningAlgorithmId(id uint16, explicit bool)
+	// GetSigningAlgorithmId returns the selected signing algorithm and
+	// whether it was explicitly negotiated by the client.
+	GetSigningAlgorithmId() (uint16, bool)
 	// GetCipherId returns the selected encryption cipher.
 	GetCipherId() uint16
 	// GetPreauthHash returns a copy of the current connection-level preauth integrity hash value.

--- a/internal/adapter/smb/v2/handlers/negotiate.go
+++ b/internal/adapter/smb/v2/handlers/negotiate.go
@@ -454,11 +454,14 @@ func (h *Handler) processNegotiateContexts(
 
 // defaultSigningAlgorithmPreference is the server's default signing algorithm
 // preference order, used when SigningAlgorithmPreference is not configured.
-// Only AES algorithms are included because SIGNING_CAPABILITIES is a 3.1.1-only
-// negotiate context, and HMAC-SHA256 is not valid for SMB 3.x sessions.
+// HMAC-SHA256 is included because clients MAY explicitly request it via the
+// 3.1.1 SIGNING_CAPABILITIES negotiate context (MS-SMB2 §3.1.1.2). When
+// selected for 3.1.1 the signing key is the first 16 bytes of the
+// SP800-108-derived SigningKey and the verifier uses HMAC-SHA256.
 var defaultSigningAlgorithmPreference = []uint16{
 	signing.SigningAlgAESGMAC,
 	signing.SigningAlgAESCMAC,
+	signing.SigningAlgHMACSHA256,
 }
 
 // selectSigningAlgorithm selects a signing algorithm from the client's offered
@@ -466,9 +469,9 @@ var defaultSigningAlgorithmPreference = []uint16{
 // MS-SMB2 3.3.5.4. It iterates the client's array and returns the first
 // algorithm that the server supports.
 //
-// HMAC-SHA256 is excluded because SIGNING_CAPABILITIES is a 3.1.1-only
-// negotiate context, and HMAC-SHA256 is a 2.x-only algorithm. Selecting it
-// for 3.1.1 would cause a mismatch with the KDF-based signing key derivation.
+// HMAC-SHA256 is valid for 3.1.1 when the client explicitly negotiates it via
+// SIGNING_CAPABILITIES. Samba accepts this and the signing-hmac-sha-256
+// torture test exercises the path.
 //
 // Falls back to AES-128-CMAC as the mandatory baseline per MS-SMB2 if no
 // intersection is found.
@@ -479,10 +482,6 @@ func (h *Handler) selectSigningAlgorithm(clientAlgorithms []uint16) uint16 {
 	}
 
 	for _, clientAlg := range clientAlgorithms {
-		// Skip HMAC-SHA256 -- not valid for 3.1.1 SIGNING_CAPABILITIES
-		if clientAlg == signing.SigningAlgHMACSHA256 {
-			continue
-		}
 		if slices.Contains(allowed, clientAlg) {
 			return clientAlg
 		}

--- a/internal/adapter/smb/v2/handlers/negotiate.go
+++ b/internal/adapter/smb/v2/handlers/negotiate.go
@@ -103,9 +103,10 @@ func (h *Handler) Negotiate(ctx *SMBHandlerContext, body []byte) (*HandlerResult
 	var selectedSigningAlg uint16
 	is311 := selectedDialect == types.Dialect0311
 
+	var signingAlgExplicit bool
 	if is311 {
 		if negotiateContextCount > 0 && negotiateContextOffset > 0 {
-			responseContexts, selectedCipher, selectedSigningAlg = h.processNegotiateContexts(
+			responseContexts, selectedCipher, selectedSigningAlg, signingAlgExplicit = h.processNegotiateContexts(
 				body, negotiateContextOffset, negotiateContextCount)
 		}
 		// Per MS-SMB2 3.3.5.4: SMB 3.1.1 MUST include PREAUTH_INTEGRITY_CAPABILITIES
@@ -245,7 +246,7 @@ func (h *Handler) Negotiate(ctx *SMBHandlerContext, body []byte) (*HandlerResult
 		if is311 {
 			ctx.ConnCryptoState.SetCipherId(selectedCipher)
 			ctx.ConnCryptoState.SetPreauthIntegrityHashId(types.HashAlgSHA512)
-			ctx.ConnCryptoState.SetSigningAlgorithmId(selectedSigningAlg)
+			ctx.ConnCryptoState.SetSigningAlgorithmId(selectedSigningAlg, signingAlgExplicit)
 		}
 	}
 
@@ -327,12 +328,14 @@ func (h *Handler) buildCapabilities(dialect types.Dialect) types.Capabilities {
 // processNegotiateContexts parses client negotiate contexts and builds response contexts.
 // Only called for SMB 3.1.1 negotiation.
 //
-// Returns the response contexts, the selected cipher ID, and the selected signing algorithm ID.
+// Returns the response contexts, the selected cipher ID, the selected signing
+// algorithm ID, and whether the signing algorithm came from an explicit
+// SIGNING_CAPABILITIES negotiate context (vs. server-side default).
 func (h *Handler) processNegotiateContexts(
 	body []byte,
 	contextOffset uint32,
 	contextCount uint16,
-) ([]types.NegotiateContext, uint16, uint16) {
+) ([]types.NegotiateContext, uint16, uint16, bool) {
 	// Context offset is relative to the start of the SMB2 header (64 bytes before body).
 	// Our body starts at header offset 64, so:
 	//   bodyOffset = contextOffset - 64
@@ -340,13 +343,13 @@ func (h *Handler) processNegotiateContexts(
 	if bodyOffset < 0 || bodyOffset >= len(body) {
 		logger.Debug("Negotiate context offset out of range",
 			"offset", contextOffset, "bodyLen", len(body))
-		return nil, 0, 0
+		return nil, 0, 0, false
 	}
 
 	clientContexts, err := types.ParseNegotiateContextList(body[bodyOffset:], int(contextCount))
 	if err != nil {
 		logger.Debug("Failed to parse negotiate contexts", "error", err)
-		return nil, 0, 0
+		return nil, 0, 0, false
 	}
 
 	var responseContexts []types.NegotiateContext
@@ -449,7 +452,7 @@ func (h *Handler) processNegotiateContexts(
 		selectedSigningAlg = signing.SigningAlgAESCMAC
 	}
 
-	return responseContexts, selectedCipher, selectedSigningAlg
+	return responseContexts, selectedCipher, selectedSigningAlg, signingCapsReceived
 }
 
 // defaultSigningAlgorithmPreference is the server's default signing algorithm

--- a/internal/adapter/smb/v2/handlers/negotiate_test.go
+++ b/internal/adapter/smb/v2/handlers/negotiate_test.go
@@ -104,26 +104,32 @@ func newNegotiateTestContext() *SMBHandlerContext {
 
 // mockCryptoState implements the CryptoState interface for testing.
 type mockCryptoState struct {
-	dialect            types.Dialect
-	cipherId           uint16
-	signingAlgorithmId uint16
-	preauthHashId      uint16
-	preauthHash        [64]byte
-	serverGUID         [16]byte
-	serverCapabilities types.Capabilities
-	serverSecurityMode types.SecurityMode
-	clientGUID         [16]byte
-	clientCapabilities types.Capabilities
-	clientSecurityMode types.SecurityMode
-	clientDialects     []types.Dialect
+	dialect                  types.Dialect
+	cipherId                 uint16
+	signingAlgorithmId       uint16
+	signingAlgorithmExplicit bool
+	preauthHashId            uint16
+	preauthHash              [64]byte
+	serverGUID               [16]byte
+	serverCapabilities       types.Capabilities
+	serverSecurityMode       types.SecurityMode
+	clientGUID               [16]byte
+	clientCapabilities       types.Capabilities
+	clientSecurityMode       types.SecurityMode
+	clientDialects           []types.Dialect
 }
 
-func (m *mockCryptoState) SetDialect(d types.Dialect)                                     { m.dialect = d }
-func (m *mockCryptoState) GetDialect() types.Dialect                                      { return m.dialect }
-func (m *mockCryptoState) SetCipherId(id uint16)                                          { m.cipherId = id }
-func (m *mockCryptoState) GetCipherId() uint16                                            { return m.cipherId }
-func (m *mockCryptoState) SetSigningAlgorithmId(id uint16)                                { m.signingAlgorithmId = id }
-func (m *mockCryptoState) GetSigningAlgorithmId() uint16                                  { return m.signingAlgorithmId }
+func (m *mockCryptoState) SetDialect(d types.Dialect) { m.dialect = d }
+func (m *mockCryptoState) GetDialect() types.Dialect  { return m.dialect }
+func (m *mockCryptoState) SetCipherId(id uint16)      { m.cipherId = id }
+func (m *mockCryptoState) GetCipherId() uint16        { return m.cipherId }
+func (m *mockCryptoState) SetSigningAlgorithmId(id uint16, explicit bool) {
+	m.signingAlgorithmId = id
+	m.signingAlgorithmExplicit = explicit
+}
+func (m *mockCryptoState) GetSigningAlgorithmId() (uint16, bool) {
+	return m.signingAlgorithmId, m.signingAlgorithmExplicit
+}
 func (m *mockCryptoState) SetPreauthIntegrityHashId(id uint16)                            { m.preauthHashId = id }
 func (m *mockCryptoState) GetPreauthHash() [64]byte                                       { return m.preauthHash }
 func (m *mockCryptoState) SetServerGUID(guid [16]byte)                                    { m.serverGUID = guid }

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -574,9 +574,10 @@ func (h *Handler) completeSessionBind(
 	// Determine the new channel's dialect and signing algorithm.
 	connDialect := types.Dialect0300
 	var signingAlgId uint16
+	var signingAlgExplicit bool
 	if ctx.ConnCryptoState != nil {
 		connDialect = ctx.ConnCryptoState.GetDialect()
-		signingAlgId = ctx.ConnCryptoState.GetSigningAlgorithmId()
+		signingAlgId, signingAlgExplicit = ctx.ConnCryptoState.GetSigningAlgorithmId()
 	}
 
 	// For SMB 3.1.1 the channel's preauth integrity hash is the KDF context
@@ -604,7 +605,7 @@ func (h *Handler) completeSessionBind(
 			"error", err)
 		return NewErrorResult(types.StatusInvalidParameter)
 	}
-	channelSigner := signing.NewSigner(connDialect, signingAlgId, channelSigningKey)
+	channelSigner := signing.NewSigner(connDialect, signingAlgId, signingAlgExplicit, channelSigningKey)
 
 	channel := &session.Channel{
 		ConnID:      ctx.ConnID,
@@ -1133,6 +1134,7 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 	var preauthHash [64]byte
 	var cipherId uint16
 	var signingAlgId uint16
+	var signingAlgExplicit bool
 
 	if ctx != nil && ctx.ConnCryptoState != nil {
 		dialect = ctx.ConnCryptoState.GetDialect()
@@ -1143,7 +1145,7 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 			// SESSION_SETUP messages.
 			preauthHash = ctx.ConnCryptoState.GetSessionPreauthHash(sess.SessionID)
 			cipherId = ctx.ConnCryptoState.GetCipherId()
-			signingAlgId = ctx.ConnCryptoState.GetSigningAlgorithmId()
+			signingAlgId, signingAlgExplicit = ctx.ConnCryptoState.GetSigningAlgorithmId()
 		}
 
 		// Clean up the per-session preauth hash entry now that keys are derived
@@ -1166,7 +1168,7 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 		// SMB 3.x: always derive keys via SP800-108 KDF when signing or encryption
 		// is enabled. Key derivation must not be skipped when only encryption is
 		// enabled, since encryption keys come from the same KDF derivation.
-		cryptoState := session.DeriveAllKeys(sessionKey, dialect, preauthHash, cipherId, signingAlgId)
+		cryptoState := session.DeriveAllKeys(sessionKey, dialect, preauthHash, cipherId, signingAlgId, signingAlgExplicit)
 
 		if h.SigningConfig.Enabled {
 			cryptoState.SigningEnabled = true


### PR DESCRIPTION
Closes #486

Per MS-SMB2 §3.1.1.2, a 3.1.1 client may explicitly negotiate HMAC-SHA256 via the SIGNING_CAPABILITIES context. Samba accepts this and the `signing-hmac-sha-256` torture test exercises this path.

## Changes

- `selectSigningAlgorithm` no longer hard-skips HMAC-SHA256; the default preference list now includes it as the lowest-priority fallback.
- `NewSigner` dispatches to `HMACSigner` for dialect ≥ 3.1.1 when the negotiated algorithm id is `SigningAlgHMACSHA256`. Earlier 3.x dialects (3.0 / 3.0.2) never carry a negotiated id of HMAC-SHA256 in production (selectSigningAlgorithm is only invoked when a SigningCapabilities context is present, and 3.0/3.0.2 do not use negotiate contexts), so they continue to use CMAC.

## Test plan

- [x] `go fmt && go vet` clean
- [x] `go test -race ./internal/adapter/smb/v2/...` PASS
- [x] `go test ./internal/adapter/smb/signing/...` PASS
- [ ] CI smbtorture flips `smb2.session.signing-hmac-sha-256` (CMAC + GMAC variants validated by the existing test coverage on develop)

Once CI confirms PASS, the KNOWN_FAILURES.md entry will be walked back in a follow-up commit on this PR.