### PR TITLE
fix(smb): READ updates CurrentByteOffset and accepts FILE_EXECUTE (#488)

### DIFF
--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1753,10 +1753,15 @@ func (h *Handler) hasOpenHandleOnFile(targetMeta metadata.FileHandle, excludeFil
 }
 
 // hasReadAccess reports whether the given access mask includes read access.
-// Checks FILE_READ_DATA, GENERIC_READ, GENERIC_ALL, and MAXIMUM_ALLOWED.
+// Checks FILE_READ_DATA, FILE_EXECUTE, GENERIC_READ, GENERIC_ALL, and
+// MAXIMUM_ALLOWED. FILE_EXECUTE is treated as read access because the
+// canonical SMB clients (Samba, Windows) allow READ on a handle opened with
+// only FILE_EXECUTE — execution implies read, and the smb2.read.access
+// torture test exercises that path.
 func hasReadAccess(access uint32) bool {
 	m := types.AccessMask(access)
 	return m&types.FileReadData != 0 ||
+		m&types.FileExecute != 0 ||
 		m&types.GenericRead != 0 ||
 		m&types.GenericAll != 0 ||
 		m&types.MaximumAllowed != 0

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -131,6 +131,20 @@ func (resp *ReadResponse) Encode() ([]byte, error) {
 // Protocol Handler
 // ============================================================================
 
+// recordReadProgress advances Open.CurrentByteOffset (the PositionInfo
+// field) to offset + bytesReturned after a successful READ. Centralised so
+// every success path — regular file, zero-length read, symlink — updates
+// the same field consistently. Per MS-FSA 2.1.5.2 (Server Algorithm for
+// Reading a File): on success CurrentByteOffset := ByteOffset + BytesRead.
+// The smb2.read.position torture test asserts the value via GetInfo
+// FilePositionInformation.
+func recordReadProgress(open *OpenFile, offset uint64, bytesReturned uint64) {
+	if open == nil {
+		return
+	}
+	open.PositionInfo = offset + bytesReturned
+}
+
 // Read handles SMB2 READ command [MS-SMB2] 2.2.19, 2.2.20.
 //
 // READ allows clients to read data from an open file at a specified offset.
@@ -167,9 +181,12 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 2b: Validate read access
 	// ========================================================================
 	//
-	// Per MS-SMB2 3.3.5.15: The server MUST verify that the open was created
-	// with read access (FILE_READ_DATA). If the open lacks read access,
-	// return STATUS_ACCESS_DENIED.
+	// Per MS-SMB2 3.3.5.15: the server MUST verify that the open was created
+	// with read access. hasReadAccess treats FILE_READ_DATA, FILE_EXECUTE,
+	// GENERIC_READ, GENERIC_ALL, and MAXIMUM_ALLOWED as read access — Samba
+	// and Windows allow READ on an FILE_EXECUTE-only handle (execution
+	// implies read), and the smb2.read.access torture test exercises that
+	// path. If the open lacks any of those, return STATUS_ACCESS_DENIED.
 	//
 	// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE),
 	// not the pre-DACL DesiredAccess — otherwise a MAXIMUM_ALLOWED open whose
@@ -312,6 +329,9 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	if req.Length == 0 && req.MinimumCount == 0 {
 		logger.Debug("READ: zero-length read (success)", "path", openFile.Path,
 			"offset", req.Offset, "size", fileSize)
+		// MS-FSA 2.1.5.2: even a zero-byte successful READ advances
+		// CurrentByteOffset to req.Offset (offset + 0 bytes returned).
+		recordReadProgress(openFile, req.Offset, 0)
 		return &ReadResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
 			DataOffset:      0x50,
@@ -379,7 +399,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// return. Windows clients carry their own client-side position and do
 	// not depend on this for I/O dispatch, but the smb2.read.position
 	// torture test asserts the value.
-	openFile.PositionInfo = req.Offset + uint64(len(readResult.Data))
+	recordReadProgress(openFile, req.Offset, uint64(len(readResult.Data)))
 
 	// ========================================================================
 	// Step 12: Update LastAccessTime (MS-FSA Algorithm for Noting File Accessed)
@@ -464,6 +484,11 @@ func (h *Handler) handleSymlinkRead(
 		"offset", req.Offset,
 		"requested", req.Length,
 		"actual", len(data))
+
+	// MS-FSA 2.1.5.2: advance CurrentByteOffset on the symlink success path
+	// too. smb2.read.position asserts PositionInfo regardless of the
+	// underlying source of the returned bytes.
+	recordReadProgress(openFile, req.Offset, uint64(len(data)))
 
 	// Build response
 	return &ReadResponse{

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -369,6 +369,19 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		"actual", len(readResult.Data))
 
 	// ========================================================================
+	// Step 11b: Update CurrentByteOffset (MS-FSA 2.1.5.2 / smb2.read.position)
+	// ========================================================================
+	//
+	// Per MS-FSA Server Algorithm for Reading a File: after a successful
+	// READ at Offset O of Length L, the open's CurrentByteOffset advances to
+	// O + (bytes returned). This is what GetInfo FilePositionInformation
+	// (and FILE_ALL_INFORMATION.PositionInformation at offset 80) must
+	// return. Windows clients carry their own client-side position and do
+	// not depend on this for I/O dispatch, but the smb2.read.position
+	// torture test asserts the value.
+	openFile.PositionInfo = req.Offset + uint64(len(readResult.Data))
+
+	// ========================================================================
 	// Step 12: Update LastAccessTime (MS-FSA Algorithm for Noting File Accessed)
 	// ========================================================================
 

--- a/internal/adapter/smb/v2/handlers/read_test.go
+++ b/internal/adapter/smb/v2/handlers/read_test.go
@@ -100,3 +100,105 @@ func TestRead_SymlinkRead_LeavesReleaseDataNil(t *testing.T) {
 		t.Error("symlink read returned no data")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Position semantics — MS-FSA 2.1.5.2: every successful READ advances
+// Open.CurrentByteOffset to req.Offset + bytesReturned. The smb2.read.position
+// torture test reads that value back via GetInfo FilePositionInformation.
+// recordReadProgress() centralises the update so every success path —
+// regular file, zero-length read, symlink — applies the same rule.
+// ---------------------------------------------------------------------------
+
+func TestRecordReadProgress_AdvancesPositionInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		startPos      uint64
+		offset        uint64
+		bytesReturned uint64
+		want          uint64
+	}{
+		{"regular read advances past offset", 0, 100, 50, 150},
+		{"zero-length read pins position to offset", 0, 200, 0, 200},
+		{"successive read accumulates", 150, 150, 50, 200},
+		{"overwrites previous position", 999, 0, 10, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			of := &OpenFile{PositionInfo: tt.startPos}
+			recordReadProgress(of, tt.offset, tt.bytesReturned)
+			if of.PositionInfo != tt.want {
+				t.Errorf("PositionInfo = %d, want %d", of.PositionInfo, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordReadProgress_NilOpenFileIsSafe(t *testing.T) {
+	// Defensive — handlers always pass a non-nil OpenFile, but the helper
+	// must not panic if a future caller forgets.
+	recordReadProgress(nil, 100, 50)
+}
+
+// TestHandleSymlinkRead_AdvancesPositionInfo locks in the comment-1 fix:
+// the symlink success path must also call recordReadProgress, otherwise
+// smb2.read.position would observe a stale CurrentByteOffset on symlinks.
+func TestHandleSymlinkRead_AdvancesPositionInfo(t *testing.T) {
+	h := NewHandler()
+
+	ctx := NewSMBHandlerContext(context.TODO(), "test-client", 1, 1, 1)
+	req := &ReadRequest{
+		Length: 100,
+		Offset: 10,
+	}
+	openFile := &OpenFile{Path: "/test/link"}
+	file := &metadata.File{
+		Path: "/test/link",
+		FileAttr: metadata.FileAttr{
+			Type:       metadata.FileTypeSymlink,
+			LinkTarget: "/target",
+		},
+	}
+
+	resp, err := h.handleSymlinkRead(ctx, openFile, file, req)
+	if err != nil {
+		t.Fatalf("handleSymlinkRead: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("symlink read status = %v, want StatusSuccess", resp.Status)
+	}
+	want := req.Offset + uint64(len(resp.Data))
+	if openFile.PositionInfo != want {
+		t.Errorf("PositionInfo = %d, want %d (offset+bytesReturned)", openFile.PositionInfo, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// READ access gate — hasReadAccess accepts FILE_EXECUTE in addition to
+// FILE_READ_DATA. Samba and Windows allow READ on a handle opened with only
+// FILE_EXECUTE (execution implies read), and the smb2.read.access torture
+// test exercises that path.
+// ---------------------------------------------------------------------------
+
+func TestHasReadAccess_AcceptedMasks(t *testing.T) {
+	tests := []struct {
+		name   string
+		access uint32
+		want   bool
+	}{
+		{"FILE_READ_DATA grants read", uint32(types.FileReadData), true},
+		{"FILE_EXECUTE grants read (execution implies read)", uint32(types.FileExecute), true},
+		{"GENERIC_READ grants read", uint32(types.GenericRead), true},
+		{"GENERIC_ALL grants read", uint32(types.GenericAll), true},
+		{"MAXIMUM_ALLOWED grants read", uint32(types.MaximumAllowed), true},
+		{"FILE_WRITE_DATA alone does not grant read", uint32(types.FileWriteData), false},
+		{"DELETE alone does not grant read", uint32(types.Delete), false},
+		{"empty mask does not grant read", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasReadAccess(tt.access); got != tt.want {
+				t.Errorf("hasReadAccess(0x%x) = %v, want %v", tt.access, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #488

Two targeted fixes for advanced READ semantics, one per torture test in the Read/Write Operations (Advanced Semantics) cluster.

## Changes

### smb2.read.position

Per MS-FSA *Server Algorithm for Reading a File*, after a successful READ at offset O of length L the open's CurrentByteOffset advances to O + (bytes returned). Until now READ left \`openFile.PositionInfo\` untouched, so QueryInfo FilePositionInformation (and the embedded position in FileAllInformation @ offset 80) returned 0 after a read. The test asserts \`position == 10\` after a 10-byte read at offset 0.

### smb2.read.access

Samba and Windows allow READ on a handle opened with only \`FILE_EXECUTE\` access (execution implies read). \`hasReadAccess\` was rejecting that case with STATUS_ACCESS_DENIED. The test creates a file, then re-opens it with \`SEC_FILE_READ_ATTRIBUTE | SEC_FILE_EXECUTE\` and expects READ to succeed.

## Test plan

- [x] \`go fmt && go vet\` clean
- [x] \`go test -race ./internal/adapter/smb/v2/...\` PASS
- [ ] CI smbtorture flips \`smb2.read.position\` and \`smb2.read.access\`

Once CI confirms PASS, the KNOWN_FAILURES.md entries will be walked back in a follow-up commit on this PR.