### PR TITLE
fix(smb): enforce request TID/SID match on READ/WRITE (#487)

### DIFF
--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -222,6 +222,15 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		logger.Debug("READ: invalid session ID", "sessionID", openFile.SessionID)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
+	// Per MS-SMB2 §3.3.5.2.5: verify the request's TreeID/SessionID match
+	// the handle's owning TreeConnect/Session — mirrors the gate added to
+	// WRITE/CHANGE_NOTIFY for the smb2.tcon torture test.
+	if openFile.TreeID != ctx.TreeID || openFile.SessionID != ctx.SessionID {
+		logger.Debug("READ: handle does not belong to request's tree/session",
+			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
+			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
+		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
+	}
 	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -256,6 +256,16 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		logger.Debug("WRITE: invalid session ID", "sessionID", openFile.SessionID)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
+	// Per MS-SMB2 §3.3.5.2.5: verify the request's TreeID/SessionID match
+	// the handle's owning TreeConnect/Session. The smb2.tcon torture test
+	// exercises this by deliberately mis-setting the wire-level TID/SID
+	// and expecting an error (Samba returns FILE_CLOSED).
+	if openFile.TreeID != ctx.TreeID || openFile.SessionID != ctx.SessionID {
+		logger.Debug("WRITE: handle does not belong to request's tree/session",
+			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
+			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
+		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
+	}
 	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================


### PR DESCRIPTION
Refs #487 (does not close — maxfid not addressed)

Per MS-SMB2 §3.3.5.2.5, a server processing a request that carries a FileID MUST verify that the request's TreeID and SessionID match the TreeConnect and Session that owned the open at CREATE time. CHANGE_NOTIFY already enforces this gate.

The \`smb2.tcon\` torture test exercises this by deliberately mis-setting the wire-level TID/SID after CREATE and expecting an error on WRITE. Until now READ and WRITE only validated that the handle's *own* TreeID and SessionID still resolved to live entries, ignoring the request's fields — so a WRITE arriving with the wrong TID/SID was silently processed against the correct open.

Returns STATUS_FILE_CLOSED on mismatch, matching Samba's behavior for this class of error.

## Out of scope

\`smb2.maxfid\` opens 65520 files and exposes backend resource limits in the metadata/block stores rather than a protocol correctness bug. Leaving it under #487 for a follow-up that profiles the actual exhaustion point — likely OS fd limits, memory metadata-store growth, or block-store dirent overhead. The fix here addresses \`smb2.tcon\` only; #487 stays open until \`maxfid\` is handled.

## Test plan

- [x] \`go fmt && go vet\` clean
- [x] \`go test -race ./internal/adapter/smb/v2/...\` PASS
- [ ] CI smbtorture flips \`smb2.tcon\`