### PR TITLE
fix(smb): sparse file FSCTLs (#359)

### DIFF
--- a/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
@@ -39,6 +39,9 @@ func init() {
 		FsctlSrvCopyChunk:           (*Handler).handleSrvCopyChunk,
 		FsctlSrvCopyChunkWrite:      (*Handler).handleSrvCopyChunk,
 		FsctlQueryNetworkInterfInfo: (*Handler).handleQueryNetworkInterfaceInfo,
+		FsctlSetSparse:              (*Handler).handleSetSparse,
+		FsctlQueryAllocatedRanges:   (*Handler).handleQueryAllocatedRanges,
+		FsctlSetZeroData:            (*Handler).handleSetZeroData,
 
 		// Samba-private torture FSCTLs. Accepted as no-ops so that smbtorture
 		// fixtures (notably the multichannel.leases.test{2,3} pair) don't get

--- a/internal/adapter/smb/v2/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_sparse.go
@@ -10,6 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // Sparse-file FSCTL handlers — issue #359.
@@ -28,30 +29,6 @@ import (
 //   - FSCTL_SET_ZERO_DATA          MS-FSCC §2.3.67 / §2.3.68
 //
 // Samba reference: source3/smbd/smb2_ioctl_filesys.c
-
-// ioctlInputBuffer extracts the input buffer portion of an IOCTL request
-// using the InputOffset / InputCount fields from the SMB2 IOCTL request
-// (MS-SMB2 §2.2.31). InputOffset is relative to the SMB2 header (64 bytes
-// before the body), so the buffer starts at offset 56 inside body.
-func ioctlInputBuffer(body []byte) []byte {
-	if len(body) < 56 {
-		return nil
-	}
-	r := smbenc.NewReader(body)
-	r.Skip(4)                    // StructureSize + Reserved
-	r.Skip(4)                    // CtlCode
-	r.Skip(16)                   // FileId
-	_ = r.ReadUint32()           // InputOffset (relative to SMB2 header)
-	inputCount := r.ReadUint32() // InputCount
-	if r.Err() != nil || inputCount == 0 {
-		return nil
-	}
-	const bufStart = uint32(56)
-	if uint32(len(body)) < bufStart+inputCount {
-		return nil
-	}
-	return body[bufStart : bufStart+inputCount]
-}
 
 // handleSetSparse handles FSCTL_SET_SPARSE [MS-FSCC] 2.3.50.
 //
@@ -73,9 +50,9 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
 
-	// Per MS-FSA §2.1.5.10.34: SET_SPARSE requires FILE_WRITE_DATA. The smb2.
-	// ioctl.sparse_perms test confirms this gate by opening with read-only
-	// access and expecting STATUS_ACCESS_DENIED.
+	// Per MS-FSA §2.1.5.10.34: SET_SPARSE requires FILE_WRITE_DATA. The
+	// smb2.ioctl.sparse_perms test confirms this gate by opening with
+	// read-only access and expecting STATUS_ACCESS_DENIED.
 	if uint32(types.AccessMask(openFile.GrantedAccess))&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: handle lacks FILE_WRITE_DATA",
 			"path", openFile.Path,
@@ -83,10 +60,11 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// Input is either empty (default: set sparse) or 1 byte; reject larger
-	// buffers per Samba `fsctl_set_sparse` (returns INVALID_PARAMETER on
-	// inputs longer than 1 byte — covered by smb2.ioctl.sparse_set_oversize).
-	if input := ioctlInputBuffer(body); len(input) > 1 {
+	// Reject input buffers larger than 1 byte per Samba `fsctl_set_sparse`
+	// (covered by smb2.ioctl.sparse_set_oversize). parseIoctlInputData
+	// honours InputOffset and guards against the uint32-arithmetic overflow
+	// pattern that an ad-hoc slice would expose to malformed requests.
+	if input := parseIoctlInputData(body); len(input) > 1 {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: input too large", "len", len(input))
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
@@ -99,10 +77,10 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 
 // handleQueryAllocatedRanges handles FSCTL_QUERY_ALLOCATED_RANGES [MS-FSCC]
 // 2.3.32. The client supplies a (FileOffset, Length) window and the server
-// reports which sub-ranges are allocated. Since DittoFS does not track holes
-// independently from the payload, we report the intersection of the client's
-// window with [0, FileSize) as a single allocated range. Bytes past EOF
-// produce an empty output buffer, matching Samba `fsctl_qar`.
+// reports which sub-ranges are allocated. Since DittoFS does not track
+// holes independently from the payload, we report the intersection of the
+// client's window with [0, FileSize) as a single allocated range. Bytes
+// past EOF produce an empty output buffer, matching Samba `fsctl_qar`.
 func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	fileID, ok := parseIoctlFileID(body)
 	if !ok {
@@ -123,7 +101,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	input := ioctlInputBuffer(body)
+	input := parseIoctlInputData(body)
 	if len(input) < 16 {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: malformed input", "len", len(input))
 		return NewErrorResult(types.StatusInvalidParameter), nil
@@ -143,8 +121,10 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	// Resolve the file's logical size. PrepareWrite would mutate state, so
-	// read attributes directly via the metadata service.
+	// Prime ctx with the OpenFile's recorded session state — without this
+	// hand-off BuildAuthContext takes the ctx.User==nil arm and synthesises
+	// UID-0 (root), bypassing DACL checks on the GetFile probe (#619).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return NewErrorResult(types.StatusAccessDenied), nil
@@ -177,6 +157,15 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
+// zeroDataMaxFileSize mirrors the NTFS upper bound that the regular WRITE
+// path enforces (see write.go). Without this cap a client could request an
+// arbitrary <2^63 range and tie the handler up in a multi-hour zero-fill
+// loop while the metadata service grows file size past anything WRITE
+// would accept. Keeping the two limits identical also prevents a SET_ZERO_
+// DATA followed by a normal WRITE from refusing the write because the
+// preceding FSCTL pushed the file past the WRITE cap.
+const zeroDataMaxFileSize = uint64(0xFFFFFFF0000) // ~16 TiB, identical to WRITE handler
+
 // handleSetZeroData handles FSCTL_SET_ZERO_DATA [MS-FSCC] 2.3.67.
 //
 // Writes zeros across the [FileOffset, BeyondFinalZero) byte window. We
@@ -207,7 +196,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	input := ioctlInputBuffer(body)
+	input := parseIoctlInputData(body)
 	if len(input) < 16 {
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
@@ -225,11 +214,53 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)
 		return NewResult(types.StatusSuccess, resp), nil
 	}
+	if beyond > zeroDataMaxFileSize {
+		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: range exceeds MAXFILESIZE",
+			"path", openFile.Path, "beyond", beyond)
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
 
+	// Prime ctx with the OpenFile's session/tree so BuildAuthContext picks
+	// up the correct identity for downstream metadata permission checks.
+	// Without this, FileID-only IOCTL requests fall through to anonymous
+	// UID-0 (root) and CommitWrite skips the non-root SUID/SGID clearing
+	// path (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
+
+	// Byte-range lock check on the write window. WRITE and COPYCHUNK both
+	// gate on this; without it another handle could hold a conflicting
+	// lock over [fileOffset, beyond) and the zero-fill would silently win
+	// (smb2.ioctl.sparse_lock).
+	metaSvc := h.Registry.GetMetadataService()
+	if err := metaSvc.CheckLockForIO(
+		authCtx.Context,
+		openFile.MetadataHandle,
+		openFile.OpenID(),
+		ctx.SessionID,
+		fileOffset,
+		beyond-fileOffset,
+		true, // isWrite
+	); err != nil {
+		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: blocked by lock",
+			"path", openFile.Path, "offset", fileOffset, "length", beyond-fileOffset)
+		return NewErrorResult(types.StatusFileLockConflict), nil
+	}
+
+	// Break Level II (Read) caching leases held by other clients on the
+	// target so they invalidate stale cached data. Mirrors the WRITE and
+	// COPYCHUNK paths.
+	if h.LeaseManager != nil {
+		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
+		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
+			logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: oplock break failed (non-fatal)",
+				"path", openFile.Path, "error", breakErr)
+		}
+	}
+
 	if err := h.zeroFillRange(authCtx, openFile, fileOffset, beyond); err != nil {
 		if errors.Is(err, errZeroFillCancelled) {
 			return NewErrorResult(types.StatusCancelled), nil
@@ -237,6 +268,14 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		logger.Warn("IOCTL FSCTL_SET_ZERO_DATA: write failed",
 			"path", openFile.Path, "error", err)
 		return NewErrorResult(common.MapContentToSMB(err)), nil
+	}
+
+	// SMB requires immediate cross-session metadata visibility (unlike NFS
+	// which uses explicit COMMIT). Flush deferred metadata so a subsequent
+	// QUERY_INFO sees the new size/timestamps without waiting for CLOSE.
+	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle); flushErr != nil {
+		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: deferred metadata flush failed (non-fatal)",
+			"path", openFile.Path, "error", flushErr)
 	}
 
 	resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)

--- a/internal/adapter/smb/v2/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_sparse.go
@@ -1,0 +1,297 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Sparse-file FSCTL handlers — issue #359.
+//
+// DittoFS's block store is implicitly sparse: AppendWrite zero-grows the
+// payload buffer on demand and ReadPayloadAt copies those zero-filled
+// bytes back, so a file written at offset N with no preceding writes
+// reads as N zero bytes followed by the data. We therefore accept the
+// sparse-management FSCTLs as no-ops or "report everything as one
+// allocated extent" responses — the wire-level expectations (test passes,
+// no STATUS_NOT_SUPPORTED) match without touching the on-disk format.
+//
+// Spec references:
+//   - FSCTL_SET_SPARSE             MS-FSCC §2.3.50 / §2.3.51
+//   - FSCTL_QUERY_ALLOCATED_RANGES MS-FSCC §2.3.32 / §2.3.33
+//   - FSCTL_SET_ZERO_DATA          MS-FSCC §2.3.67 / §2.3.68
+//
+// Samba reference: source3/smbd/smb2_ioctl_filesys.c
+
+// ioctlInputBuffer extracts the input buffer portion of an IOCTL request
+// using the InputOffset / InputCount fields from the SMB2 IOCTL request
+// (MS-SMB2 §2.2.31). InputOffset is relative to the SMB2 header (64 bytes
+// before the body), so the buffer starts at offset 56 inside body.
+func ioctlInputBuffer(body []byte) []byte {
+	if len(body) < 56 {
+		return nil
+	}
+	r := smbenc.NewReader(body)
+	r.Skip(4)                    // StructureSize + Reserved
+	r.Skip(4)                    // CtlCode
+	r.Skip(16)                   // FileId
+	_ = r.ReadUint32()           // InputOffset (relative to SMB2 header)
+	inputCount := r.ReadUint32() // InputCount
+	if r.Err() != nil || inputCount == 0 {
+		return nil
+	}
+	const bufStart = uint32(56)
+	if uint32(len(body)) < bufStart+inputCount {
+		return nil
+	}
+	return body[bufStart : bufStart+inputCount]
+}
+
+// handleSetSparse handles FSCTL_SET_SPARSE [MS-FSCC] 2.3.50.
+//
+// Input is optional: empty → set sparse; 1-byte FILE_SET_SPARSE_BUFFER
+// where SetSparse=0 clears the attribute, non-zero sets it. We accept all
+// variants and return success without persisting the flag — DittoFS is
+// implicitly sparse, so there is no semantic difference between "sparse
+// set" and "sparse cleared" on the wire. The handle requires write
+// access per MS-FSA §2.1.5.10.34.
+func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		logger.Debug("IOCTL FSCTL_SET_SPARSE: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+
+	// Per MS-FSA §2.1.5.10.34: SET_SPARSE requires FILE_WRITE_DATA. The smb2.
+	// ioctl.sparse_perms test confirms this gate by opening with read-only
+	// access and expecting STATUS_ACCESS_DENIED.
+	if uint32(types.AccessMask(openFile.GrantedAccess))&uint32(types.FileWriteData) == 0 {
+		logger.Debug("IOCTL FSCTL_SET_SPARSE: handle lacks FILE_WRITE_DATA",
+			"path", openFile.Path,
+			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+
+	// Input is either empty (default: set sparse) or 1 byte; reject larger
+	// buffers per Samba `fsctl_set_sparse` (returns INVALID_PARAMETER on
+	// inputs longer than 1 byte — covered by smb2.ioctl.sparse_set_oversize).
+	if input := ioctlInputBuffer(body); len(input) > 1 {
+		logger.Debug("IOCTL FSCTL_SET_SPARSE: input too large", "len", len(input))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	logger.Debug("IOCTL FSCTL_SET_SPARSE: accepted (DittoFS is implicitly sparse)",
+		"path", openFile.Path)
+	resp := buildIoctlResponse(FsctlSetSparse, fileID, nil)
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// handleQueryAllocatedRanges handles FSCTL_QUERY_ALLOCATED_RANGES [MS-FSCC]
+// 2.3.32. The client supplies a (FileOffset, Length) window and the server
+// reports which sub-ranges are allocated. Since DittoFS does not track holes
+// independently from the payload, we report the intersection of the client's
+// window with [0, FileSize) as a single allocated range. Bytes past EOF
+// produce an empty output buffer, matching Samba `fsctl_qar`.
+func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+
+	// MS-FSA §2.1.5.10.4 / Samba `fsctl_qar`: requires FILE_READ_DATA.
+	if uint32(types.AccessMask(openFile.GrantedAccess))&uint32(types.FileReadData) == 0 {
+		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: handle lacks FILE_READ_DATA",
+			"path", openFile.Path,
+			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+
+	input := ioctlInputBuffer(body)
+	if len(input) < 16 {
+		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: malformed input", "len", len(input))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	r := smbenc.NewReader(input[:16])
+	reqOffset := r.ReadUint64()
+	reqLength := r.ReadUint64()
+	if r.Err() != nil {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Negative-as-unsigned: per MS-FSA an offset whose high bit is set
+	// (i.e. parses to a negative int64) is an error. Samba `fsctl_qar`
+	// returns INVALID_PARAMETER. The smb2.ioctl.sparse_qar_ob1 test
+	// exercises both arms.
+	if int64(reqOffset) < 0 || int64(reqLength) < 0 {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Resolve the file's logical size. PrepareWrite would mutate state, so
+	// read attributes directly via the metadata service.
+	authCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+	metaSvc := h.Registry.GetMetadataService()
+	file, err := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
+	if err != nil {
+		return NewErrorResult(common.MapToSMB(err)), nil
+	}
+	fileSize := file.Size
+
+	rangeEnd := reqOffset + reqLength
+	if rangeEnd < reqOffset { // overflow guard
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	allocStart := reqOffset
+	allocEnd := rangeEnd
+	if allocEnd > fileSize {
+		allocEnd = fileSize
+	}
+
+	// FILE_ALLOCATED_RANGE_BUFFER is 16 bytes (FileOffset + Length). Zero
+	// entries when the requested window is entirely past EOF or empty.
+	w := smbenc.NewWriter(16)
+	if allocStart < allocEnd {
+		w.WriteUint64(allocStart)
+		w.WriteUint64(allocEnd - allocStart)
+	}
+	resp := buildIoctlResponse(FsctlQueryAllocatedRanges, fileID, w.Bytes())
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// handleSetZeroData handles FSCTL_SET_ZERO_DATA [MS-FSCC] 2.3.67.
+//
+// Writes zeros across the [FileOffset, BeyondFinalZero) byte window. We
+// honour the request by issuing zero-filled writes through the standard
+// PrepareWrite / WriteAt / CommitWrite path so file size, mtime, and
+// block-store invalidation stay consistent. The range may extend past
+// EOF, in which case the file is implicitly extended (Samba parity).
+func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+	if openFile.IsDirectory || openFile.IsPipe {
+		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
+	}
+
+	// MS-FSA §2.1.5.10.35: SET_ZERO_DATA requires FILE_WRITE_DATA.
+	if uint32(types.AccessMask(openFile.GrantedAccess))&uint32(types.FileWriteData) == 0 {
+		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: handle lacks FILE_WRITE_DATA",
+			"path", openFile.Path,
+			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+
+	input := ioctlInputBuffer(body)
+	if len(input) < 16 {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	r := smbenc.NewReader(input[:16])
+	fileOffset := r.ReadUint64()
+	beyond := r.ReadUint64()
+	if r.Err() != nil {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	if int64(fileOffset) < 0 || int64(beyond) < 0 || beyond < fileOffset {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	if fileOffset == beyond {
+		// Zero-length request is a documented no-op per Samba `fsctl_zero_data`.
+		resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)
+		return NewResult(types.StatusSuccess, resp), nil
+	}
+
+	authCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+	if err := h.zeroFillRange(authCtx, openFile, fileOffset, beyond); err != nil {
+		if errors.Is(err, errZeroFillCancelled) {
+			return NewErrorResult(types.StatusCancelled), nil
+		}
+		logger.Warn("IOCTL FSCTL_SET_ZERO_DATA: write failed",
+			"path", openFile.Path, "error", err)
+		return NewErrorResult(common.MapContentToSMB(err)), nil
+	}
+
+	resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// zeroFillChunkSize is the chunk we use to issue zero-fill writes. A single
+// 1 MiB scratch buffer keeps the steady-state RAM cost bounded while still
+// amortising the per-write metadata round-trip on multi-MB zero ranges.
+const zeroFillChunkSize = 1 << 20
+
+// errZeroFillCancelled is a sentinel for context-cancelled zero fills so the
+// caller can map back to STATUS_CANCELLED instead of a generic write error.
+var errZeroFillCancelled = errors.New("zero-fill cancelled")
+
+// zeroFillRange writes [start, end) as zeros through the standard
+// PrepareWrite/WriteAt/CommitWrite chain. The write is chunked so we never
+// allocate more than zeroFillChunkSize regardless of how large the requested
+// range is — smbtorture's hole-punch tests exercise multi-MB ranges.
+func (h *Handler) zeroFillRange(authCtx *metadata.AuthContext, openFile *OpenFile, start, end uint64) error {
+	metaSvc := h.Registry.GetMetadataService()
+	blockStore, err := common.ResolveForWrite(authCtx.Context, h.Registry, openFile.MetadataHandle)
+	if err != nil {
+		return err
+	}
+
+	chunkLen := uint64(zeroFillChunkSize)
+	if total := end - start; total < chunkLen {
+		chunkLen = total
+	}
+	zeros := make([]byte, chunkLen)
+
+	for offset := start; offset < end; {
+		if err := authCtx.Context.Err(); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return errZeroFillCancelled
+			}
+			return err
+		}
+		remaining := end - offset
+		if remaining > uint64(len(zeros)) {
+			remaining = uint64(len(zeros))
+		}
+		newSize := offset + remaining
+		writeOp, err := metaSvc.PrepareWrite(authCtx, openFile.MetadataHandle, newSize)
+		if err != nil {
+			return err
+		}
+		if err := common.WriteToBlockStore(authCtx.Context, blockStore, writeOp.PayloadID, zeros[:remaining], offset); err != nil {
+			return err
+		}
+		if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+			return err
+		}
+		offset += remaining
+	}
+	return nil
+}

--- a/internal/adapter/smb/v2/handlers/ioctl_sparse_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_sparse_test.go
@@ -1,0 +1,303 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// buildSparseIoctlRequest assembles an SMB2 IOCTL request body with an
+// optional input buffer. The InputOffset is reported relative to the SMB2
+// header so the production parser (which lives at offset 56 of the body)
+// resolves to the same bytes the test wrote.
+func buildSparseIoctlRequest(ctlCode uint32, fileID [16]byte, input []byte) []byte {
+	const fixedSize = 56
+	w := smbenc.NewWriter(fixedSize + len(input))
+	w.WriteUint16(57)                     // StructureSize
+	w.WriteUint16(0)                      // Reserved
+	w.WriteUint32(ctlCode)                // CtlCode
+	w.WriteBytes(fileID[:])               // FileId
+	w.WriteUint32(uint32(64 + fixedSize)) // InputOffset (header + fixed)
+	w.WriteUint32(uint32(len(input)))     // InputCount
+	w.WriteUint32(0)                      // MaxInputResponse
+	w.WriteUint32(uint32(64 + fixedSize)) // OutputOffset
+	w.WriteUint32(0)                      // OutputCount
+	w.WriteUint32(0)                      // MaxOutputResponse
+	w.WriteUint32(0)                      // Flags
+	w.WriteUint32(0)                      // Reserved2
+	if len(input) > 0 {
+		w.WriteBytes(input)
+	}
+	return w.Bytes()
+}
+
+// TestSetSparse_NoHandle returns STATUS_FILE_CLOSED when the FileID has no
+// matching open. This guards the dispatch-time gate added in MS-SMB2 3.3.5.15
+// so smbtorture sparse tests get a clean error rather than a panic when they
+// drive an unregistered handle.
+func TestSetSparse_NoHandle(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(i + 1)
+	}
+	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, nil)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("Ioctl returned error: %v", err)
+	}
+	if result.Status != types.StatusFileClosed {
+		t.Fatalf("status = 0x%08x, want STATUS_FILE_CLOSED", uint32(result.Status))
+	}
+}
+
+// TestSetSparse_AccessDenied confirms the FILE_WRITE_DATA gate from MS-FSA
+// §2.1.5.10.34. Handles opened with FILE_READ_DATA only must not be allowed
+// to flip the sparse attribute (smb2.ioctl.sparse_perms exercises this).
+func TestSetSparse_AccessDenied(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x10 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/sparse_perms",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, nil)
+	result, err := h.handleSetSparse(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetSparse returned error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Fatalf("status = 0x%08x, want STATUS_ACCESS_DENIED", uint32(result.Status))
+	}
+}
+
+// TestSetSparse_OversizeInput rejects FILE_SET_SPARSE_BUFFER payloads larger
+// than 1 byte (Samba `fsctl_set_sparse` returns STATUS_INVALID_PARAMETER;
+// covered by smb2.ioctl.sparse_set_oversize).
+func TestSetSparse_OversizeInput(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x20 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/sparse_oversize",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileWriteData),
+		GrantedAccess: uint32(types.FileWriteData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, []byte{0x01, 0x02})
+	result, err := h.handleSetSparse(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetSparse returned error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x, want STATUS_INVALID_PARAMETER", uint32(result.Status))
+	}
+}
+
+// TestSetSparse_Accepted exercises the success path: a handle with
+// FILE_WRITE_DATA, an empty input buffer, and an open file id returns
+// STATUS_SUCCESS plus an echo IOCTL response with the matching CtlCode.
+// The test pins that DittoFS continues to advertise sparse-FSCTL support
+// to smb2.set-sparse-ioctl.
+func TestSetSparse_Accepted(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x30 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/sparse_ok",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileWriteData),
+		GrantedAccess: uint32(types.FileWriteData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, nil)
+	result, err := h.handleSetSparse(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetSparse returned error: %v", err)
+	}
+	if result.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", uint32(result.Status))
+	}
+	if len(result.Data) < 48 {
+		t.Fatalf("IOCTL response shorter than fixed header: %d bytes", len(result.Data))
+	}
+	gotCtl := smbenc.NewReader(result.Data[4:8]).ReadUint32()
+	if gotCtl != FsctlSetSparse {
+		t.Errorf("response CtlCode = 0x%08X, want 0x%08X", gotCtl, FsctlSetSparse)
+	}
+}
+
+// TestQueryAllocatedRanges_MalformedInput rejects requests whose input is
+// shorter than the 16-byte FILE_ALLOCATED_RANGE_BUFFER (smb2.ioctl.
+// sparse_qar_malformed / sparse_qar_truncated).
+func TestQueryAllocatedRanges_MalformedInput(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x40 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/qar_malformed",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	// 8 bytes is half the required size.
+	body := buildSparseIoctlRequest(FsctlQueryAllocatedRanges, fileID, make([]byte, 8))
+	result, err := h.handleQueryAllocatedRanges(ctx, body)
+	if err != nil {
+		t.Fatalf("handleQueryAllocatedRanges returned error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x, want STATUS_INVALID_PARAMETER", uint32(result.Status))
+	}
+}
+
+// TestQueryAllocatedRanges_NegativeOffset rejects high-bit-set (parses-to-
+// negative) FileOffset and Length. Matches Samba `fsctl_qar` precondition
+// check (smb2.ioctl.sparse_qar_ob1).
+func TestQueryAllocatedRanges_NegativeOffset(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x50 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/qar_ob1",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	// Set high bit on FileOffset (negative when treated as int64).
+	input := make([]byte, 16)
+	for i := 0; i < 8; i++ {
+		input[i] = 0xFF
+	}
+	body := buildSparseIoctlRequest(FsctlQueryAllocatedRanges, fileID, input)
+	result, err := h.handleQueryAllocatedRanges(ctx, body)
+	if err != nil {
+		t.Fatalf("handleQueryAllocatedRanges returned error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x, want STATUS_INVALID_PARAMETER", uint32(result.Status))
+	}
+}
+
+// TestSetZeroData_AccessDenied verifies the write-access gate. Read-only
+// handles must not be able to punch holes / zero data (MS-FSA §2.1.5.10.35).
+func TestSetZeroData_AccessDenied(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x60 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/zero_perms",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	input := make([]byte, 16) // 16 zero bytes — fileOffset = beyond = 0
+	body := buildSparseIoctlRequest(FsctlSetZeroData, fileID, input)
+	result, err := h.handleSetZeroData(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetZeroData returned error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Fatalf("status = 0x%08x, want STATUS_ACCESS_DENIED", uint32(result.Status))
+	}
+}
+
+// TestSetZeroData_InverseRange rejects ranges where BeyondFinalZero <
+// FileOffset (Samba `fsctl_zero_data` precondition).
+func TestSetZeroData_InverseRange(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x70 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/zero_inverse",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileWriteData),
+		GrantedAccess: uint32(types.FileWriteData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	// FileOffset = 100, BeyondFinalZero = 50.
+	w := smbenc.NewWriter(16)
+	w.WriteUint64(100)
+	w.WriteUint64(50)
+	body := buildSparseIoctlRequest(FsctlSetZeroData, fileID, w.Bytes())
+	result, err := h.handleSetZeroData(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetZeroData returned error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x, want STATUS_INVALID_PARAMETER", uint32(result.Status))
+	}
+}
+
+// TestSetZeroData_ZeroLengthIsNoop is a documented no-op in Samba's
+// fsctl_zero_data — FileOffset == BeyondFinalZero returns SUCCESS without
+// touching the file. Skipping the write-path keeps the unit tests
+// independent of the metadata/blockstore registry.
+func TestSetZeroData_ZeroLengthIsNoop(t *testing.T) {
+	h := NewHandler()
+	var fileID [16]byte
+	for i := range fileID {
+		fileID[i] = byte(0x80 + i)
+	}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "/zero_noop",
+		ShareName:     "share1",
+		DesiredAccess: uint32(types.FileWriteData),
+		GrantedAccess: uint32(types.FileWriteData),
+	})
+	ctx := &SMBHandlerContext{Context: context.Background()}
+
+	w := smbenc.NewWriter(16)
+	w.WriteUint64(1024)
+	w.WriteUint64(1024)
+	body := buildSparseIoctlRequest(FsctlSetZeroData, fileID, w.Bytes())
+	result, err := h.handleSetZeroData(ctx, body)
+	if err != nil {
+		t.Fatalf("handleSetZeroData returned error: %v", err)
+	}
+	if result.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", uint32(result.Status))
+	}
+}

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -43,6 +43,9 @@ const (
 	FsctlGetObjectID            uint32 = 0x0009009C // [MS-FSCC] 2.3.28 - Get object ID
 	FsctlMarkHandle             uint32 = 0x000900FC // [MS-FSCC] 2.3.36 - Mark handle
 	FsctlQueryFileRegions       uint32 = 0x00090284 // [MS-FSCC] 2.3.51 - Query file regions
+	FsctlSetSparse              uint32 = 0x000900C4 // [MS-FSCC] 2.3.50 - Set sparse attribute
+	FsctlQueryAllocatedRanges   uint32 = 0x000940CF // [MS-FSCC] 2.3.32 - Query allocated byte ranges
+	FsctlSetZeroData            uint32 = 0x000980C8 // [MS-FSCC] 2.3.67 - Zero a byte range
 
 	// FSCTL_SMBTORTURE_* are Samba's private torture control codes (see
 	// libcli/smb/smb_constants.h in samba). They have no MS-FSCC analog; the


### PR DESCRIPTION
## Summary

Implement FSCTL_SET_SPARSE, FSCTL_QUERY_ALLOCATED_RANGES, and FSCTL_SET_ZERO_DATA so smbtorture's sparse-file suite no longer short-circuits on STATUS_NOT_SUPPORTED.

DittoFS's block store is implicitly sparse — \`AppendWrite\` zero-grows the payload buffer on demand and \`ReadPayloadAt\` returns those zero-filled bytes — so the wire-level expectations of the sparse FSCTLs can be met without changing the on-disk format.

## Changes

- \`FSCTL_SET_SPARSE\` (\`0x000900C4\`): accept as a no-op with \`FILE_WRITE_DATA\` gate (MS-FSA 2.1.5.10.34). Reject input buffers longer than 1 byte per Samba \`fsctl_set_sparse\` (\`smb2.ioctl.sparse_set_oversize\`).
- \`FSCTL_QUERY_ALLOCATED_RANGES\` (\`0x000940CF\`): report the intersection of the requested window with \`[0, FileSize)\` as a single allocated range. \`FILE_READ_DATA\` gate, malformed/short input → \`INVALID_PARAMETER\`, high-bit-set offsets/lengths → \`INVALID_PARAMETER\` (\`sparse_qar_ob1\`).
- \`FSCTL_SET_ZERO_DATA\` (\`0x000980C8\`): chunk zeros (1 MiB scratch buffer) through \`PrepareWrite\` / \`WriteToBlockStore\` / \`CommitWrite\` so size, mtime, and block-store invalidation stay consistent. Honour zero-length ranges as a no-op and reject inverse ranges (BeyondFinalZero < FileOffset).

## Target tests

- \`smb2.set-sparse-ioctl\`
- \`smb2.zero-data-ioctl\`
- \`smb2.ioctl.copy_chunk_sparse_dest\`
- \`smb2.ioctl.sparse_copy_chunk\`
- \`smb2.ioctl.sparse_set_oversize\`
- \`smb2.ioctl.sparse_set_nobuf\`
- \`smb2.ioctl.sparse_perms\`
- \`smb2.ioctl.sparse_qar*\` (range / malformed / overflow / ob1)
- \`smb2.ioctl.sparse_punch\` / \`sparse_punch_invalid\`
- Several additional \`sparse_*\` tests in \`KNOWN_FAILURES.md\` may also flip — to be confirmed by CI.

## Test plan

- [x] \`go test ./internal/adapter/smb/v2/handlers/ -run 'TestSetSparse|TestQueryAllocatedRanges|TestSetZeroData' -v\` — 9 unit tests covering access-check arms, malformed input, oversize input, inverse ranges, no-handle, zero-length no-op, and the happy path
- [x] \`go test -race ./pkg/metadata/ ./internal/adapter/smb/v2/handlers/\`
- [x] \`go build ./...\` / \`go vet ./...\` clean
- [ ] CI smbtorture: confirm which sparse_* entries actually flip; walk back from \`KNOWN_FAILURES.md\` only after CI confirms

Closes #359