### PR TITLE
fix(smb/ioctl): non-sparse IOCTL coverage (#484)

### DIFF
--- a/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_dispatch.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -46,6 +47,7 @@ func init() {
 		// `test_block_smb2_transport` falls through to a hard failure.
 		// See issue #436 and the constant comment in stub_handlers.go.
 		FsctlSmbtortureForceUnackedTimeout: (*Handler).handleSmbtortureForceUnackedTimeout,
+		FsctlSmbtortureFspAsyncSleep:       (*Handler).handleSmbtortureFspAsyncSleep,
 	}
 }
 
@@ -151,6 +153,64 @@ func (h *Handler) handleSmbtortureForceUnackedTimeout(ctx *SMBHandlerContext, bo
 	}
 	logger.Debug("IOCTL FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT: accepting as no-op (smbtorture-only)")
 	resp := buildIoctlResponse(FsctlSmbtortureForceUnackedTimeout, fileID, nil)
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// handleSmbtortureFspAsyncSleep handles FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP
+// (Samba's torture-only 0x83848043). Per source3/smbd/smb2_ioctl_smbtorture.c
+// the InputBuffer is exactly 1 byte (CVAL) interpreted as a delay in
+// milliseconds; the FSCTL completes successfully once the delay elapses.
+//
+// smbtorture `smb2.ioctl.bug14769` regression-tests the property that a
+// CLOSE arriving while the FSCTL is in flight must NOT race the IOCTL to
+// completion — the handle must remain valid until the IOCTL's reply has
+// been sent. We honour this by holding the per-FileID in-flight WaitGroup
+// (via AcquireOpenFile / ReleaseOpenFile) across the sleep, so the CLOSE
+// handler's WaitAndDeleteOpenFile drains.
+//
+// Bound the sleep at 1 second to keep the test-only path from being weaponised
+// against the dispatcher: smbtorture's longest call is 200ms.
+func (h *Handler) handleSmbtortureFspAsyncSleep(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	inputData := parseIoctlInputData(body)
+	if len(inputData) != 1 {
+		logger.Debug("IOCTL FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP: bad input length",
+			"len", len(inputData))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	delayMs := uint32(inputData[0])
+	const maxDelayMs uint32 = 1000
+	if delayMs > maxDelayMs {
+		delayMs = maxDelayMs
+	}
+
+	// Pin the handle for the duration of the sleep so a concurrent CLOSE
+	// blocks in WaitAndDeleteOpenFile until we return. If AcquireOpenFile
+	// fails the handle was already gone — return FILE_CLOSED (the same
+	// status the generic IOCTL gate uses).
+	if _, ok := h.AcquireOpenFile(fileID); !ok {
+		logger.Debug("IOCTL FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP: handle gone",
+			"fileID", fmt.Sprintf("%x", fileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+	defer h.ReleaseOpenFile(fileID)
+
+	logger.Debug("IOCTL FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP: sleeping",
+		"delayMs", delayMs)
+
+	timer := time.NewTimer(time.Duration(delayMs) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Context.Done():
+		return NewErrorResult(types.StatusCancelled), nil
+	}
+
+	resp := buildIoctlResponse(FsctlSmbtortureFspAsyncSleep, fileID, nil)
 	return NewResult(types.StatusSuccess, resp), nil
 }
 

--- a/internal/adapter/smb/v2/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_fsctl.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"crypto/md5"
+	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
@@ -58,6 +59,22 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	openFile, ok := h.GetOpenFile(fileID)
 	if !ok {
 		return NewErrorResult(types.StatusFileClosed), nil
+	}
+
+	// Samba `smb2_ioctl_filesys.c::fsctl_set_cmprn` calls
+	// `check_any_access_fsp(fsp, FILE_WRITE_DATA)` — strictly FILE_WRITE_DATA,
+	// not WRITE_ATTRIBUTES or APPEND_DATA. smbtorture smb2.ioctl.compress_perms
+	// opens with SEC_RIGHTS_FILE_WRITE & ~SEC_FILE_WRITE_DATA (so APPEND_DATA
+	// and WRITE_ATTRIBUTES are still granted) and asserts ACCESS_DENIED for
+	// both COMPRESSION_FORMAT_DEFAULT and COMPRESSION_FORMAT_NONE. Use the
+	// resolved GrantedAccess snapshot from CREATE — GENERIC_* and
+	// MAXIMUM_ALLOWED are already expanded by resolveAccessFlags, so a bare
+	// FILE_WRITE_DATA bit check matches Samba's semantics.
+	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
+		logger.Debug("IOCTL FSCTL_SET_COMPRESSION: missing FILE_WRITE_DATA",
+			"path", openFile.Path,
+			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
+		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
 	// Parse InputBuffer: CompressionState (2 bytes) at InputOffset

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces.go
@@ -54,7 +54,10 @@ func (h *Handler) handleQueryNetworkInterfaceInfo(ctx *SMBHandlerContext, body [
 	if !ok {
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
-	// MS-SMB2 §3.3.5.15.13: FileID must be the all-0xFF sentinel.
+	// MS-SMB2 §3.3.5.15.13: FileID must be the all-0xFF sentinel. A
+	// non-sentinel FileID is INVALID_PARAMETER regardless of MaxOutputResponse
+	// (smbtorture smb2.ioctl.bug14788.NETWORK_INTERFACE asserts this distinct
+	// from FILE_CLOSED / BUFFER_TOO_SMALL).
 	if !bytes.Equal(fileID[:], allFFFileID) {
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
@@ -71,6 +74,13 @@ func (h *Handler) handleQueryNetworkInterfaceInfo(ctx *SMBHandlerContext, body [
 	}
 
 	output := encodeNetworkInterfaceInfoList(entries)
+	// MS-SMB2 §3.3.4.20.13: if MaxOutputResponse is insufficient for the
+	// full reply, return STATUS_BUFFER_TOO_SMALL. smbtorture bug14788
+	// exercises max_output=1 against the sentinel FileID and asserts
+	// BUFFER_TOO_SMALL distinct from INVALID_PARAMETER.
+	if maxOutput := parseIoctlMaxOutputSize(body); maxOutput < uint32(len(output)) {
+		return NewErrorResult(types.StatusBufferTooSmall), nil
+	}
 	resp := buildIoctlResponse(FsctlQueryNetworkInterfInfo, fileID, output)
 	return NewResult(types.StatusSuccess, resp), nil
 }

--- a/internal/adapter/smb/v2/handlers/ioctl_network_interfaces_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_network_interfaces_test.go
@@ -161,3 +161,81 @@ func TestHandleQueryNetworkInterfaceInfo_ShortBodyInvalidParameter(t *testing.T)
 		t.Errorf("expected StatusInvalidParameter for truncated body, got %v", result.Status)
 	}
 }
+
+// buildQueryNetworkInterfaceInfoRequestWithMaxOutput builds a full 56-byte
+// IOCTL envelope (MS-SMB2 2.2.31) with a configurable MaxOutputResponse so
+// the BUFFER_TOO_SMALL path required by smbtorture bug14788.NETWORK_INTERFACE
+// (sentinel FileID + max_output=1) can be exercised in isolation.
+func buildQueryNetworkInterfaceInfoRequestWithMaxOutput(fileID []byte, maxOutput uint32) []byte {
+	w := smbenc.NewWriter(56)
+	w.WriteUint16(57)
+	w.WriteUint16(0)
+	w.WriteUint32(FsctlQueryNetworkInterfInfo)
+	w.WriteBytes(fileID)
+	w.WriteUint32(0) // InputOffset
+	w.WriteUint32(0) // InputCount
+	w.WriteUint32(0) // MaxInputResponse
+	w.WriteUint32(0) // OutputOffset
+	w.WriteUint32(0) // OutputCount
+	w.WriteUint32(maxOutput)
+	w.WriteUint32(0) // Flags
+	w.WriteUint32(0) // Reserved2
+	return w.Bytes()
+}
+
+// TestHandleQueryNetworkInterfaceInfo_BufferTooSmall pins step 2 of
+// smbtorture bug14788.NETWORK_INTERFACE: sentinel FileID + max_output=1 must
+// be STATUS_BUFFER_TOO_SMALL (distinct from INVALID_PARAMETER, which is the
+// non-sentinel-FileID outcome — that ordering is what bug14788 specifically
+// regression-tests).
+func TestHandleQueryNetworkInterfaceInfo_BufferTooSmall(t *testing.T) {
+	// The handler short-circuits with NOT_SUPPORTED when the host has no
+	// advertisable interfaces — that's correct behaviour but not what we
+	// want to assert here.
+	if len(collectNetworkInterfaceEntries()) == 0 {
+		t.Skip("host has no advertisable interfaces; BUFFER_TOO_SMALL gate unreachable")
+	}
+
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+	body := buildQueryNetworkInterfaceInfoRequestWithMaxOutput(allFFFileID, 1)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusBufferTooSmall {
+		t.Errorf("expected StatusBufferTooSmall for sentinel FileID + max_output=1, got %v",
+			result.Status)
+	}
+}
+
+// TestHandleQueryNetworkInterfaceInfo_NonSentinelFileIDInvalidParameter pins
+// step 3 of bug14788.NETWORK_INTERFACE: a non-sentinel FileID must yield
+// INVALID_PARAMETER even when max_output is small. This is the property
+// that distinguishes "bad FileID" from "buffer issue".
+func TestHandleQueryNetworkInterfaceInfo_NonSentinelFileIDInvalidParameter(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+	// INT64_MAX persistent/volatile pair from smbtorture — the high bytes
+	// are zero so the 16-byte ID does NOT match the all-0xFF sentinel.
+	badFileID := make([]byte, 16)
+	binary.LittleEndian.PutUint64(badFileID[0:8], 0x7FFFFFFFFFFFFFFF)
+	binary.LittleEndian.PutUint64(badFileID[8:16], 0x7FFFFFFFFFFFFFFF)
+	body := buildQueryNetworkInterfaceInfoRequestWithMaxOutput(badFileID, 1)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter (not BUFFER_TOO_SMALL) for non-sentinel FileID, got %v",
+			result.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/ioctl_set_compression_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_set_compression_test.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// buildSetCompressionRequest builds a full 56-byte SMB2 IOCTL envelope plus an
+// optional InputBuffer carrying the 2-byte CompressionFormat. The InputOffset
+// uses the standard 64-byte SMB2 header convention (header + 56-byte fixed
+// envelope = 120). Pass inputData=nil to omit the InputBuffer entirely (used
+// to drive the post-gate INVALID_PARAMETER short-input branch).
+func buildSetCompressionRequest(fileID [16]byte, inputData []byte) []byte {
+	const fixed = 56
+	w := smbenc.NewWriter(fixed + len(inputData))
+	w.WriteUint16(57) // StructureSize
+	w.WriteUint16(0)  // Reserved
+	w.WriteUint32(FsctlSetCompression)
+	w.WriteBytes(fileID[:])
+	if len(inputData) > 0 {
+		w.WriteUint32(64 + fixed) // InputOffset (header is 64 bytes before body, then 56-byte envelope)
+		w.WriteUint32(uint32(len(inputData)))
+	} else {
+		w.WriteUint32(0) // InputOffset
+		w.WriteUint32(0) // InputCount
+	}
+	w.WriteUint32(0) // MaxInputResponse
+	w.WriteUint32(0) // OutputOffset
+	w.WriteUint32(0) // OutputCount
+	w.WriteUint32(0) // MaxOutputResponse
+	w.WriteUint32(0) // Flags
+	w.WriteUint32(0) // Reserved2
+	if len(inputData) > 0 {
+		w.WriteBytes(inputData)
+	}
+	return w.Bytes()
+}
+
+// TestHandleSetCompression_AccessGate_DeniesWithoutWriteData pins the
+// FILE_WRITE_DATA access gate that smbtorture smb2.ioctl.compress_perms
+// regression-tests. The test opens a handle whose GrantedAccess records
+// FILE_APPEND_DATA | FILE_WRITE_ATTRIBUTES (matching smbtorture's
+// `SEC_RIGHTS_FILE_WRITE & ~SEC_FILE_WRITE_DATA`) and asserts the FSCTL
+// returns STATUS_ACCESS_DENIED — APPEND_DATA and WRITE_ATTRIBUTES alone
+// must NOT satisfy Samba's `check_any_access_fsp(fsp, FILE_WRITE_DATA)`.
+func TestHandleSetCompression_AccessGate_DeniesWithoutWriteData(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	fileID := [16]byte{0x01, 0x02, 0x03, 0x04}
+	h.StoreOpenFile(&OpenFile{
+		FileID: fileID,
+		Path:   "compress_perms_no_write_data",
+		// FILE_APPEND_DATA | FILE_WRITE_ATTRIBUTES — the smbtorture-shaped
+		// mask that strips FILE_WRITE_DATA from SEC_RIGHTS_FILE_WRITE.
+		GrantedAccess: uint32(types.FileAppendData) | uint32(types.FileWriteAttributes),
+	})
+
+	// CompressionFormat=COMPRESSION_FORMAT_DEFAULT (matches one of the two
+	// formats smbtorture submits before asserting ACCESS_DENIED).
+	body := buildSetCompressionRequest(fileID, []byte{0x01, 0x00})
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Errorf("expected StatusAccessDenied for FILE_APPEND_DATA|FILE_WRITE_ATTRIBUTES handle, got %v",
+			result.Status)
+	}
+}
+
+// TestHandleSetCompression_AccessGate_DeniesReadOnly pins the read-only
+// handle path: a handle granted FILE_READ_DATA alone must be rejected by
+// the FILE_WRITE_DATA gate. This is the obvious case but is worth pinning
+// separately so the gate cannot regress to e.g. `(WRITE_DATA|READ_DATA)`
+// non-zero checks.
+func TestHandleSetCompression_AccessGate_DeniesReadOnly(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	fileID := [16]byte{0x05, 0x06, 0x07, 0x08}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "compress_perms_read_only",
+		GrantedAccess: uint32(types.FileReadData) | uint32(types.FileReadAttributes),
+	})
+
+	body := buildSetCompressionRequest(fileID, []byte{0x00, 0x00}) // COMPRESSION_FORMAT_NONE
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Errorf("expected StatusAccessDenied for read-only handle, got %v", result.Status)
+	}
+}
+
+// TestHandleSetCompression_AccessGate_PassesWithWriteData pins the positive
+// case: when GrantedAccess includes FILE_WRITE_DATA the access gate must
+// NOT short-circuit to STATUS_ACCESS_DENIED. We assert this by sending a
+// zero-length InputBuffer; that fails downstream with
+// STATUS_INVALID_PARAMETER from `parseIoctlInputData`, which runs only
+// after the gate. STATUS_INVALID_PARAMETER (not STATUS_ACCESS_DENIED)
+// proves the gate accepted the handle. Going further (STATUS_SUCCESS)
+// would require wiring a full metadata-service registry, which is out of
+// scope for this unit test.
+func TestHandleSetCompression_AccessGate_PassesWithWriteData(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	fileID := [16]byte{0x09, 0x0A, 0x0B, 0x0C}
+	h.StoreOpenFile(&OpenFile{
+		FileID:        fileID,
+		Path:          "compress_perms_with_write_data",
+		GrantedAccess: uint32(types.FileWriteData),
+	})
+
+	// Zero-length InputBuffer — gate must pass first, then
+	// parseIoctlInputData rejects on len < 2.
+	body := buildSetCompressionRequest(fileID, nil)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status == types.StatusAccessDenied {
+		t.Fatalf("FILE_WRITE_DATA handle must clear the access gate; got STATUS_ACCESS_DENIED")
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter from post-gate short-input branch, got %v",
+			result.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/ioctl_smbtorture_test.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_smbtorture_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -77,6 +78,115 @@ func TestIoctl_SmbtortureForceUnackedTimeout_AcceptedAsNoop(t *testing.T) {
 	if gotCtlCode != FsctlSmbtortureForceUnackedTimeout {
 		t.Errorf("response CtlCode mismatch: want 0x%08X got 0x%08X",
 			FsctlSmbtortureForceUnackedTimeout, gotCtlCode)
+	}
+}
+
+// buildSmbtortureFspAsyncSleepRequest builds an IOCTL request with a 1-byte
+// InputBuffer carrying the millisecond delay (matches Samba's
+// `state->in_input.data[0]` semantics). The bound FileID is the caller's
+// open-file ID — not the all-0xFF sentinel — because FSP_ASYNC_SLEEP is a
+// per-handle FSCTL (only valid against an open file per Samba's
+// `state->fsp == NULL` check).
+func buildSmbtortureFspAsyncSleepRequest(fileID [16]byte, delayMs uint8) []byte {
+	// 56-byte fixed envelope + 1 InputBuffer byte = 57 bytes.
+	w := smbenc.NewWriter(57)
+	w.WriteUint16(57) // StructureSize
+	w.WriteUint16(0)  // Reserved
+	w.WriteUint32(FsctlSmbtortureFspAsyncSleep)
+	w.WriteBytes(fileID[:])       // FileId
+	w.WriteUint32(64 + 56)        // InputOffset (header is 64 bytes before body, then 56-byte envelope)
+	w.WriteUint32(1)              // InputCount
+	w.WriteUint32(0)              // MaxInputResponse
+	w.WriteUint32(0)              // OutputOffset
+	w.WriteUint32(0)              // OutputCount
+	w.WriteUint32(0)              // MaxOutputResponse
+	w.WriteUint32(0)              // Flags
+	w.WriteUint32(0)              // Reserved2
+	w.WriteBytes([]byte{delayMs}) // InputBuffer
+	return w.Bytes()
+}
+
+// TestIoctl_SmbtortureFspAsyncSleep_MissingHandle pins the precondition: the
+// dispatcher's per-FileID gate must reject FSP_ASYNC_SLEEP for a handle that
+// isn't open. (smbtorture bug14769 expects the handle-bound semantics — see
+// the constant comment in stub_handlers.go.) When no handle is registered the
+// generic IOCTL gate returns FILE_CLOSED before our handler runs.
+func TestIoctl_SmbtortureFspAsyncSleep_MissingHandle(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	body := buildSmbtortureFspAsyncSleepRequest([16]byte{1, 2, 3, 4}, 1)
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusFileClosed {
+		t.Errorf("expected StatusFileClosed (no open handle), got %v", result.Status)
+	}
+}
+
+// TestIoctl_SmbtortureFspAsyncSleep_RespectsSleepDuration pins the basic
+// contract: the FSCTL completes successfully after at least the requested
+// delay has elapsed. smbtorture bug14769's CLOSE-vs-IOCTL ordering check is
+// covered end-to-end by the conformance suite; isolating that ordering here
+// would require synchronising the test against the lazy in-flight tracker
+// in a way that introduces its own races.
+func TestIoctl_SmbtortureFspAsyncSleep_RespectsSleepDuration(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	fileID := [16]byte{0xAB, 0xCD, 0xEF}
+	h.StoreOpenFile(&OpenFile{FileID: fileID, Path: "bug14769"})
+
+	const delayMs uint8 = 30
+	body := buildSmbtortureFspAsyncSleepRequest(fileID, delayMs)
+
+	start := time.Now()
+	result, err := h.Ioctl(ctx, body)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusSuccess {
+		t.Fatalf("expected StatusSuccess, got %v", result.Status)
+	}
+	if min := time.Duration(delayMs) * time.Millisecond; elapsed < min {
+		t.Errorf("FSCTL returned too fast: elapsed=%v want >=%v", elapsed, min)
+	}
+}
+
+// TestIoctl_SmbtortureFspAsyncSleep_BadInputLengthInvalidParameter pins
+// Samba's `state->in_input.length != 1` gate. The FSCTL requires exactly one
+// input byte; anything else must be INVALID_PARAMETER so smbtorture's
+// malformed-request paths exercise the right error code.
+func TestIoctl_SmbtortureFspAsyncSleep_BadInputLengthInvalidParameter(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:9999",
+	}
+
+	fileID := [16]byte{0x11, 0x22, 0x33}
+	h.StoreOpenFile(&OpenFile{FileID: fileID, Path: "bad-input"})
+
+	// 0-byte InputBuffer (InputCount=0). Envelope is just the fixed 56 bytes.
+	body := buildSmbtortureIoctlRequest(FsctlSmbtortureFspAsyncSleep)
+	// The buildSmbtortureIoctlRequest helper writes the sentinel FileID; rewrite the FileID slot.
+	copy(body[8:24], fileID[:])
+
+	result, err := h.Ioctl(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Errorf("expected StatusInvalidParameter for zero-length input, got %v", result.Status)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/stub_handlers.go
+++ b/internal/adapter/smb/v2/handlers/stub_handlers.go
@@ -69,6 +69,17 @@ const (
 	// fires from any later assertion failure, leaving clean state for test3.
 	// See issue #436.
 	FsctlSmbtortureForceUnackedTimeout uint32 = 0x83848003
+
+	// FsctlSmbtortureFspAsyncSleep is Samba's per-handle async-sleep torture
+	// FSCTL (libcli/smb/smb_constants.h FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP =
+	// FSCTL_SMBTORTURE | ACCESS_WRITE | 0x0040 | METHOD_NEITHER). smbtorture
+	// `smb2.ioctl.bug14769` issues this IOCTL with a 1-byte sleep duration
+	// (milliseconds) and IMMEDIATELY follows it with a CLOSE on the same
+	// handle. The bug being regression-tested is: the server must let the
+	// IOCTL complete before completing the CLOSE — otherwise the IOCTL gets
+	// STATUS_FILE_CLOSED. We honour this by holding the per-FileID in-flight
+	// WaitGroup across the sleep so WaitAndDeleteOpenFile in CLOSE drains.
+	FsctlSmbtortureFspAsyncSleep uint32 = 0x83848043
 )
 
 // Reparse point constants [MS-FSCC] 2.1.2.1


### PR DESCRIPTION
Closes #484.

## Summary

Wave 1 sub-task of the v1.0 SMB conformance push (umbrella #673). Implements three non-sparse IOCTL fixes:

- **FSCTL_QUERY_NETWORK_INTERFACE_INFO** — honour `MaxOutputResponse` so a too-small output buffer returns `STATUS_BUFFER_TOO_SMALL` distinct from the `INVALID_PARAMETER` non-sentinel-FileID outcome. Targets `smb2.ioctl.bug14788.NETWORK_INTERFACE`.
- **FSCTL_SET_COMPRESSION** — gate on `FILE_WRITE_DATA` from the post-CREATE `GrantedAccess` snapshot, mirroring Samba's `check_any_access_fsp(fsp, FILE_WRITE_DATA)`. `FILE_APPEND_DATA` and `WRITE_ATTRIBUTES` alone are insufficient. Targets `smb2.ioctl.compress_perms`.
- **FSCTL_SMBTORTURE_FSP_ASYNC_SLEEP** (Samba's torture-only 0x83848043) — accept with a 1-byte millisecond delay, hold the per-FileID in-flight `WaitGroup` across the sleep so a concurrent CLOSE blocks in `WaitAndDeleteOpenFile` until the IOCTL completes. Bounded at 1s. Targets `smb2.ioctl.bug14769`.

## Out of scope (deferred)

- **Sparse-family tests** (19 tests in `smb2.ioctl.sparse_*` + `smb2.set-sparse-ioctl` + `smb2.zero-data-ioctl` + `smb2.ioctl.copy_chunk_sparse_dest`) are tracked under #359 and need real sparse-file semantics (`FSCTL_SET_SPARSE`, `FSCTL_QUERY_ALLOCATED_RANGES`, hole-aware `ReadAt`), not surface FSCTL plumbing. Closing #484 with sparse routed to #359.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/adapter/smb/...` (passes)
- [x] New unit tests: `TestHandleQueryNetworkInterfaceInfo_BufferTooSmall`, `TestHandleQueryNetworkInterfaceInfo_NonSentinelFileIDInvalidParameter`, `TestIoctl_SmbtortureFspAsyncSleep_{MissingHandle,RespectsSleepDuration,BadInputLengthInvalidParameter}`
- [ ] CI smbtorture flips `smb2.ioctl.bug14788.NETWORK_INTERFACE`, `smb2.ioctl.compress_perms`, `smb2.ioctl.bug14769` (KNOWN_FAILURES walk-back follows in a separate commit after CI confirms)