### PR TITLE
fix(smb/lock): close out #430 byte-range lock failures

### DIFF
--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -91,12 +91,6 @@ type Handler struct {
 	// async-credit pool exhausted, or registry full).
 	pendingLocks sync.Map
 
-	// Per-open last denied lock request tracking for LOCK_NOT_GRANTED vs
-	// FILE_LOCK_CONFLICT distinction. Key: openID string, Value: lastDeniedLock.
-	// Per MS-SMB2 3.3.5.14: first denial returns LOCK_NOT_GRANTED, retry of
-	// the same range returns FILE_LOCK_CONFLICT.
-	lastDeniedLocks sync.Map
-
 	// Configuration
 	MaxTransactSize uint32
 	MaxReadSize     uint32
@@ -591,17 +585,6 @@ func (f *OpenFile) CaptureNotifyCompletionFilter(filter uint32) (captured uint32
 	return uint32(f.NotifyCompletionFilter.Load()), false
 }
 
-// lastDeniedLock tracks the last denied lock request per open for
-// LOCK_NOT_GRANTED vs FILE_LOCK_CONFLICT distinction per MS-SMB2 3.3.5.14.
-// The first failed lock attempt returns LOCK_NOT_GRANTED. If the same
-// request (same offset/length/exclusive flag) is retried, FILE_LOCK_CONFLICT
-// is returned instead. This is per-open state tracked in the Handler.
-type lastDeniedLock struct {
-	Offset    uint64
-	Length    uint64
-	Exclusive bool
-}
-
 // NewHandler creates a new SMB2 handler with a default session manager.
 // It initializes the pipe manager, notify registry, and generates a random
 // server GUID. For custom session management (e.g., shared across adapters),
@@ -956,8 +939,28 @@ func (h *Handler) closeFilesWithFilter(
 			}
 		}
 
-		// Release locks for this file (per-open ownership)
+		// Cancel any pending blocking LOCK requests for this handle and
+		// release held byte-range locks. Mirrors the explicit CLOSE path
+		// (close.go step 7) so callers like LOGOFF / tree-disconnect /
+		// transport drop deliver STATUS_RANGE_NOT_LOCKED to parked waiters
+		// per Samba `brl_close_fnum`. Without this, blocking locks parked
+		// on a closing handle wait for the catch-all session/tree drain
+		// which fires STATUS_CANCELLED — failing smb2.lock.cancel-logoff
+		// which expects RANGE_NOT_LOCKED or OK.
 		if !openFile.IsDirectory && len(openFile.MetadataHandle) > 0 {
+			if h.PendingLockRegistry != nil {
+				for _, parked := range h.PendingLockRegistry.UnregisterAllForOwner(openFile.OpenID()) {
+					if parked.Callback != nil {
+						if err := parked.Callback(parked.SessionID, parked.MessageID, parked.AsyncId, types.StatusRangeNotLocked, nil); err != nil {
+							logger.Debug(caller+": failed to send RANGE_NOT_LOCKED",
+								"asyncId", parked.AsyncId, "error", err)
+						}
+					}
+					if h.LockWaitGraph != nil && parked.OwnerID != "" {
+						h.LockWaitGraph.RemoveWaiter(parked.OwnerID)
+					}
+				}
+			}
 			_ = metaSvc.UnlockAllForOpen(ctx, openFile.MetadataHandle, openFile.OpenID())
 		}
 

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -217,39 +217,53 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// Per MS-SMB2 3.3.5.14: When there are multiple lock elements and the
-	// first element is a lock (not unlock), it MUST have FailImmediately set.
-	// This prevents blocking lock requests in batch operations.
+	// First-element flag validation. Per MS-SMB2 §3.3.5.14 / Samba
+	// smbd_smb2_lock_send (source3/smbd/smb2_lock.c): only five flag
+	// combinations are valid for the first element. Anything else MUST
+	// produce STATUS_INVALID_PARAMETER:
 	//
-	// Additionally, per MS-SMB2 §3.3.5.14.1 and Samba smbd_smb2_lock_send,
-	// a multi-element request MUST NOT mix lock and unlock elements. When
-	// first is lock and a later element is unlock → INVALID_PARAMETER
-	// immediately. When first is unlock and a later element is lock → the
-	// unlocks are processed first, then INVALID_PARAMETER is returned
-	// (Samba deferred-invalid semantics: unlock side-effects persist).
-	hasMixedUnlockThenLock := false
-	if req.LockCount > 1 {
-		firstIsLock := (req.Locks[0].Flags & SMB2LockFlagUnlock) == 0
-		firstHasFailImm := (req.Locks[0].Flags & SMB2LockFlagFailImmediately) != 0
-		if firstIsLock && !firstHasFailImm {
-			logger.Debug("LOCK: multi-element request without FailImmediately on first lock")
+	//   SHARED              (blocking shared, requires LockCount==1)
+	//   EXCLUSIVE           (blocking exclusive, requires LockCount==1)
+	//   SHARED | FAIL_IMM
+	//   EXCLUSIVE | FAIL_IMM
+	//   UNLOCK              (UNLOCK alone — FAIL_IMM is illegal here)
+	//
+	// Notably this rejects UNLOCK|FAIL_IMM and any unknown bits set
+	// (smbtorture smb2.lock.valid-request lines 247-256).
+	firstFlags := req.Locks[0].Flags
+	isUnlockRequest := false
+	switch firstFlags {
+	case SMB2LockFlagSharedLock, SMB2LockFlagExclusiveLock:
+		// Blocking lock — only allowed when LockCount==1.
+		if req.LockCount > 1 {
+			logger.Debug("LOCK: blocking first element requires single-element request")
 			return NewErrorResult(types.StatusInvalidParameter), nil
 		}
+	case SMB2LockFlagSharedLock | SMB2LockFlagFailImmediately,
+		SMB2LockFlagExclusiveLock | SMB2LockFlagFailImmediately:
+		// Non-blocking lock — multi-element request is allowed but every
+		// subsequent element MUST also be non-blocking (checked below).
+	case SMB2LockFlagUnlock:
+		isUnlockRequest = true
+	default:
+		logger.Debug("LOCK: invalid first-element flags",
+			"flags", fmt.Sprintf("0x%08X", firstFlags))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
 
-		// Detect mixed lock/unlock elements.
-		firstIsUnlock := !firstIsLock
+	// Multi-element validation. When the first element is a non-blocking
+	// lock, every subsequent element MUST also carry FAIL_IMM (per Samba's
+	// loop at smb2_lock.c:371). When the first element is UNLOCK, lock-typed
+	// elements after the unlock chain trigger deferred INVALID_PARAMETER —
+	// the unlocks still execute but the overall request returns the error
+	// (Samba's "invalid" defer at smb2_lock.c:425).
+	hasMixedUnlockThenLock := false
+	if req.LockCount > 1 && !isUnlockRequest {
 		for i := 1; i < len(req.Locks); i++ {
-			elemIsUnlock := (req.Locks[i].Flags & SMB2LockFlagUnlock) != 0
-			if firstIsLock && elemIsUnlock {
-				// Lock-first, unlock later → reject immediately.
-				logger.Debug("LOCK: multi-element request mixes lock then unlock",
+			if (req.Locks[i].Flags & SMB2LockFlagFailImmediately) == 0 {
+				logger.Debug("LOCK: multi-element request without FailImmediately",
 					"elem", i)
 				return NewErrorResult(types.StatusInvalidParameter), nil
-			}
-			if firstIsUnlock && !elemIsUnlock {
-				// Unlock-first, lock later → process unlocks, then error.
-				hasMixedUnlockThenLock = true
-				break
 			}
 		}
 	}
@@ -296,26 +310,49 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// Process each lock element
 	for i, lockElem := range req.Locks {
 		isUnlock := (lockElem.Flags & SMB2LockFlagUnlock) != 0
-		isShared := (lockElem.Flags & SMB2LockFlagSharedLock) != 0
 		isExclusive := (lockElem.Flags & SMB2LockFlagExclusiveLock) != 0
 
-		// Validate flag combinations per MS-SMB2 2.2.26:
-		// - SharedLock and ExclusiveLock are mutually exclusive
-		// - Unlock must not be combined with lock type flags
-		// - Lock operations must specify either SharedLock or ExclusiveLock
-		invalidFlags := (isShared && isExclusive) ||
-			(isUnlock && (isShared || isExclusive)) ||
-			(!isUnlock && !isShared && !isExclusive)
-		if invalidFlags {
-			logger.Debug("LOCK: invalid flag combination",
-				"index", i,
-				"flags", fmt.Sprintf("0x%08X", lockElem.Flags))
-			rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-			return NewErrorResult(types.StatusInvalidParameter), nil
+		// Per-element flag validation, mirroring Samba's per-element switch
+		// (source3/smbd/smb2_lock.c:382). For an UNLOCK-first request, lock-
+		// typed elements after the unlock chain are flagged as invalid but
+		// deferred: the unlocks already executed persist and the request
+		// completes with INVALID_PARAMETER. For a lock-first request, an
+		// UNLOCK element is rejected immediately.
+		switch lockElem.Flags {
+		case SMB2LockFlagSharedLock, SMB2LockFlagExclusiveLock,
+			SMB2LockFlagSharedLock | SMB2LockFlagFailImmediately,
+			SMB2LockFlagExclusiveLock | SMB2LockFlagFailImmediately:
+			if isUnlockRequest {
+				// UNLOCK-first chain followed by a lock element: defer.
+				hasMixedUnlockThenLock = true
+			}
+		case SMB2LockFlagUnlock:
+			if !isUnlockRequest {
+				logger.Debug("LOCK: UNLOCK element in lock-first request",
+					"elem", i,
+					"flags", fmt.Sprintf("0x%08X", lockElem.Flags))
+				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
+				return NewErrorResult(types.StatusInvalidParameter), nil
+			}
+		default:
+			if isUnlockRequest {
+				// Defer: keep processing pending unlocks, return error after.
+				hasMixedUnlockThenLock = true
+			} else {
+				logger.Debug("LOCK: invalid element flags",
+					"elem", i,
+					"flags", fmt.Sprintf("0x%08X", lockElem.Flags))
+				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
+				return NewErrorResult(types.StatusInvalidParameter), nil
+			}
 		}
 
-		// Per MS-SMB2 3.3.5.14: Validate offset+length doesn't overflow
-		if lockElem.Length > 0 && lockElem.Offset > ^uint64(0)-lockElem.Length {
+		// Per MS-SMB2 3.3.5.14: a range is invalid only when its last byte
+		// (offset+length-1) overflows uint64. {offset=~0, length=1} addresses
+		// exactly the byte at 2^64-1 and is valid; {offset=~0, length=2}
+		// would address byte 2^64 which overflows. Empty (length=0) ranges
+		// are always valid (zero-byte lock semantics handled downstream).
+		if lockElem.Length > 0 && lockElem.Offset > ^uint64(0)-(lockElem.Length-1) {
 			logger.Debug("LOCK: range overflow",
 				"index", i,
 				"offset", lockElem.Offset,
@@ -397,7 +434,6 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			// FailImmediately requests).
 			err := metaSvc.LockFile(authCtx, openFile.MetadataHandle, fileLock)
 			if err == nil {
-				h.lastDeniedLocks.Delete(openID)
 				acquiredLocks = append(acquiredLocks, lockElem)
 				continue
 			}
@@ -411,11 +447,13 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 				return NewErrorResult(common.MapLockToSMB(err)), nil
 			}
 
-			// Conflict path. FailImmediately → return immediately with the
-			// LOCK_NOT_GRANTED / FILE_LOCK_CONFLICT distinction.
+			// Conflict path. FailImmediately → return LOCK_NOT_GRANTED.
+			// Per MS-SMB2 §3.3.5.14, SMBv2 lock denials always surface
+			// LOCK_NOT_GRANTED (FILE_LOCK_CONFLICT is reserved for the
+			// I/O paths — see source4/torture/smb2/lock.c:1183-1186).
 			if failImmediately {
 				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive, storeErr.ConflictOwnerID)), nil
+				return NewErrorResult(types.StatusLockNotGranted), nil
 			}
 
 			// Blocking conflict. Try async parking first; if parking is
@@ -432,7 +470,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			if ctx.NextCommand == 0 && req.LockCount == 1 && len(acquiredLocks) == 0 &&
 				h.PendingLockRegistry != nil && ctx.AsyncLockCompleteCallback != nil &&
 				ctx.TryReserveAsync != nil && ctx.ReleaseAsync != nil {
-				if asyncId, parked := h.parkLockOnConflict(ctx, authCtx, openFile, fileLock, lockElem); parked {
+				if asyncId, parked := h.parkLockOnConflict(ctx, authCtx, openFile, fileLock); parked {
 					return &HandlerResult{
 						Status:  types.StatusPending,
 						AsyncId: asyncId,
@@ -458,16 +496,17 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 					rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
 					return NewErrorResult(types.StatusCancelled), nil
 				}
-				var retryStoreErr *metadata.StoreError
-				var retryConflictOwner string
-				if goerrors.As(err, &retryStoreErr) {
-					retryConflictOwner = retryStoreErr.ConflictOwnerID
-				}
 				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-				return NewErrorResult(h.mapLockConflictStatus(openID, lockElem, isExclusive, retryConflictOwner)), nil
+				// Lock conflict on retry → LOCK_NOT_GRANTED. Non-conflict
+				// errors (e.g. file deleted while parked) flow through
+				// common.MapLockToSMB.
+				var retryStoreErr *metadata.StoreError
+				if goerrors.As(err, &retryStoreErr) && retryStoreErr.Code == merrs.ErrLocked {
+					return NewErrorResult(types.StatusLockNotGranted), nil
+				}
+				return NewErrorResult(common.MapLockToSMB(err)), nil
 			}
 
-			h.lastDeniedLocks.Delete(openID)
 			acquiredLocks = append(acquiredLocks, lockElem)
 		}
 	}
@@ -618,42 +657,6 @@ func rollbackLocks(
 				"error", err)
 		}
 	}
-}
-
-// mapLockConflictStatus maps a byte-range lock conflict (ErrLocked) to the
-// correct SMB status. Per MS-SMB2 3.3.5.14: first denial of a given range
-// returns STATUS_LOCK_NOT_GRANTED; if the same client retries the same
-// (offset, length, type) on the same open and gets denied again, return
-// STATUS_FILE_LOCK_CONFLICT instead. The handler tracks the last-denied
-// triple per OpenID; on success the entry is cleared.
-//
-// Self-conflicts (conflictOwnerID == openID, i.e. the requesting open already
-// holds the blocking lock) always return LOCK_NOT_GRANTED and never escalate
-// to FILE_LOCK_CONFLICT. Per Samba behaviour and smbtorture expectations
-// (smb2.lock.auto-unlock line 572, smb2.lock.errorcode line 1253), the
-// escalation only applies to cross-handle conflicts.
-//
-// Used by the synchronous fail-immediately path, the inline-retry fallback,
-// and the async-park resume goroutine.
-func (h *Handler) mapLockConflictStatus(openID string, lockElem LockElement, isExclusive bool, conflictOwnerID string) types.Status {
-	// Self-conflict: the requesting open already holds the blocking lock.
-	// Always return LOCK_NOT_GRANTED without storing or escalating.
-	if conflictOwnerID != "" && conflictOwnerID == openID {
-		return types.StatusLockNotGranted
-	}
-
-	denied := lastDeniedLock{
-		Offset:    lockElem.Offset,
-		Length:    lockElem.Length,
-		Exclusive: isExclusive,
-	}
-	if prev, ok := h.lastDeniedLocks.Load(openID); ok {
-		if prev.(lastDeniedLock) == denied {
-			return types.StatusFileLockConflict
-		}
-	}
-	h.lastDeniedLocks.Store(openID, denied)
-	return types.StatusLockNotGranted
 }
 
 // encodeLockResponseBody encodes the canonical 4-byte SMB2 LOCK response

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -253,11 +253,9 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 
 	// Multi-element validation. When the first element is a non-blocking
 	// lock, every subsequent element MUST also carry FAIL_IMM (per Samba's
-	// loop at smb2_lock.c:371). When the first element is UNLOCK, lock-typed
-	// elements after the unlock chain trigger deferred INVALID_PARAMETER —
-	// the unlocks still execute but the overall request returns the error
-	// (Samba's "invalid" defer at smb2_lock.c:425).
-	hasMixedUnlockThenLock := false
+	// loop at smb2_lock.c:371). The UNLOCK-first deferred-invalid path is
+	// enforced per-element in the main processing loop below (Samba's
+	// "invalid" defer at smb2_lock.c:425).
 	if req.LockCount > 1 && !isUnlockRequest {
 		for i := 1; i < len(req.Locks); i++ {
 			if (req.Locks[i].Flags & SMB2LockFlagFailImmediately) == 0 {
@@ -313,18 +311,21 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		isExclusive := (lockElem.Flags & SMB2LockFlagExclusiveLock) != 0
 
 		// Per-element flag validation, mirroring Samba's per-element switch
-		// (source3/smbd/smb2_lock.c:382). For an UNLOCK-first request, lock-
-		// typed elements after the unlock chain are flagged as invalid but
-		// deferred: the unlocks already executed persist and the request
-		// completes with INVALID_PARAMETER. For a lock-first request, an
-		// UNLOCK element is rejected immediately.
+		// (source3/smbd/smb2_lock.c:382). For an UNLOCK-first request, any
+		// element with invalid flags (a lock element OR a bare-UNLOCK with
+		// extra bits set, e.g. UNLOCK|FAIL_IMM) is flagged as invalid but
+		// deferred: the prior unlocks executed persist and the request
+		// completes with INVALID_PARAMETER without processing this element.
+		// For a lock-first request, a pure UNLOCK element is rejected
+		// immediately.
+		deferredInvalid := false
 		switch lockElem.Flags {
 		case SMB2LockFlagSharedLock, SMB2LockFlagExclusiveLock,
 			SMB2LockFlagSharedLock | SMB2LockFlagFailImmediately,
 			SMB2LockFlagExclusiveLock | SMB2LockFlagFailImmediately:
 			if isUnlockRequest {
 				// UNLOCK-first chain followed by a lock element: defer.
-				hasMixedUnlockThenLock = true
+				deferredInvalid = true
 			}
 		case SMB2LockFlagUnlock:
 			if !isUnlockRequest {
@@ -336,8 +337,11 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			}
 		default:
 			if isUnlockRequest {
-				// Defer: keep processing pending unlocks, return error after.
-				hasMixedUnlockThenLock = true
+				// Defer: persist prior unlocks, error after. Critically we
+				// must NOT process this element (its flags are invalid);
+				// otherwise UNLOCK|FAIL_IMM would slip through the
+				// isUnlock=true branch and run UnlockFile.
+				deferredInvalid = true
 			} else {
 				logger.Debug("LOCK: invalid element flags",
 					"elem", i,
@@ -345,6 +349,12 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 				rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
 				return NewErrorResult(types.StatusInvalidParameter), nil
 			}
+		}
+
+		if deferredInvalid {
+			// Stop processing — prior unlocks persist, return error now.
+			rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
+			return NewErrorResult(types.StatusInvalidParameter), nil
 		}
 
 		// Per MS-SMB2 3.3.5.14: a range is invalid only when its last byte
@@ -368,16 +378,6 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			"flags", fmt.Sprintf("0x%08X", lockElem.Flags),
 			"unlock", isUnlock,
 			"exclusive", isExclusive)
-
-		// Mixed unlock-then-lock: process unlocks, reject on first lock element.
-		// Per Samba smbd_smb2_lock_send, unlocks persist but the overall request
-		// returns INVALID_PARAMETER when a lock element follows.
-		if hasMixedUnlockThenLock && !isUnlock {
-			logger.Debug("LOCK: mixed unlock-then-lock, rejecting lock element",
-				"index", i)
-			rollbackLocks(authCtx.Context, metaSvc, openFile.MetadataHandle, openID, ctx.SessionID, acquiredLocks)
-			return NewErrorResult(types.StatusInvalidParameter), nil
-		}
 
 		if isUnlock {
 			// Unlock operation.

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -39,7 +39,6 @@ func (h *Handler) parkLockOnConflict(
 	authCtx *metadata.AuthContext,
 	openFile *OpenFile,
 	fileLock metadata.FileLock,
-	lockElem LockElement,
 ) (uint64, bool) {
 	// Deadlock detection: probe the conflicting holder via TestLock and
 	// check the WFG. If granting our wait would close a cycle, refuse to
@@ -99,7 +98,7 @@ func (h *Handler) parkLockOnConflict(
 		h.LockWaitGraph.AddWaiter(fileLock.OpenID, owners)
 	}
 
-	go h.resumePendingLock(waitCtx, pending, openFile, fileLock, lockElem)
+	go h.resumePendingLock(waitCtx, pending, openFile, fileLock)
 
 	logger.Debug("LOCK: parked on conflict — sent interim STATUS_PENDING",
 		"sessionID", ctx.SessionID,
@@ -171,13 +170,12 @@ func lockOwnerOf(fl *metadata.FileLock) string {
 //   - TREE_DISCONNECT / LOGOFF → registry drains and fires its own callback
 //     with StatusRangeNotLocked; same Unregister-check short-circuits.
 //   - Timeout → fall through to StatusLockNotGranted (unless it's a
-//     repeat-of-same-range deny, in which case StatusFileLockConflict).
+//     repeat-of-same-range deny, all surface StatusLockNotGranted).
 func (h *Handler) resumePendingLock(
 	waitCtx context.Context,
 	pending *PendingLock,
 	openFile *OpenFile,
 	fileLock metadata.FileLock,
-	lockElem LockElement,
 ) {
 	defer pending.Cancel()
 	defer func() {
@@ -200,23 +198,16 @@ func (h *Handler) resumePendingLock(
 	for {
 		select {
 		case <-waitCtx.Done():
-			// waitCtx.Done can fire from either:
+			// waitCtx.Done fires from either:
 			//   (a) timeout — DeadlineExceeded; we own delivery and surface
-			//       LOCK_NOT_GRANTED / FILE_LOCK_CONFLICT.
+			//       STATUS_LOCK_NOT_GRANTED.
 			//   (b) external cancel — CANCEL / TDIS / LOGOFF called
 			//       pending.Cancel(). The canceller already drained our
 			//       registry entry and fired its own callback; the
 			//       Unregister below will return nil and we exit cleanly
 			//       without a duplicate response.
-			//
-			// Only compute the conflict status (which mutates lastDeniedLocks)
-			// in case (a). On external cancel, the canceller owns delivery and
-			// the mutation would taint the next retry from the same OpenID.
 			if goerrors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-				// Async-parked locks are always cross-handle conflicts (self-
-				// conflicts are caught synchronously before parking), so pass
-				// empty conflictOwnerID to allow normal escalation logic.
-				finalStatus = h.mapLockConflictStatus(pending.OwnerID, lockElem, fileLock.Exclusive, "")
+				finalStatus = types.StatusLockNotGranted
 			}
 			finalBody = nil
 			goto deliver
@@ -226,7 +217,6 @@ func (h *Handler) resumePendingLock(
 			if err == nil {
 				finalStatus = types.StatusSuccess
 				finalBody = encodeLockResponseBody()
-				h.lastDeniedLocks.Delete(pending.OwnerID)
 				// Mirror the sync path in lock.go: parked LOCK requests that
 				// finally succeed mark the open as having held a byte-range
 				// lock. The authoritative source of truth at disconnect-time

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -311,6 +311,11 @@ func TestRangesOverlap(t *testing.T) {
 		{"unbounded second", 100, 10, 0, 0, true},
 		{"both unbounded", 0, 0, 100, 0, true},
 		{"same range", 0, 10, 0, 10, true},
+		// Boundary: single byte at the max uint64 offset. The exclusive
+		// end (offset+length) wraps to 0 — inclusive-end arithmetic must
+		// still report self-overlap. Required for smb2.lock max/1 case.
+		{"max-byte self", ^uint64(0), 1, ^uint64(0), 1, true},
+		{"max-byte vs unbounded", ^uint64(0), 1, 0, 0, true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -370,14 +370,35 @@ func IsUnifiedLockConflicting(existing, requested *UnifiedLock) bool {
 
 // RangesOverlap returns true if two byte ranges overlap.
 // Length of 0 means "to end of file" (unbounded).
+//
+// Uses inclusive-end arithmetic (last = offset + length - 1) so single-byte
+// ranges at offset 2^64-1 do not wrap to a zero-length exclusive end. For
+// non-zero lengths, last1 = offset1 + length1 - 1 (which fits in uint64 iff
+// offset1 + length1 - 1 ≤ 2^64-1; callers above must reject ranges where
+// the last byte overflows). Unbounded ranges (length=0) use last=2^64-1.
+//
+// Overlap iff offset1 ≤ last2 AND offset2 ≤ last1.
 func RangesOverlap(offset1, length1, offset2, length2 uint64) bool {
-	end1 := rangeEnd(offset1, length1)
-	end2 := rangeEnd(offset2, length2)
-	return end1 > offset2 && end2 > offset1
+	last1 := rangeLast(offset1, length1)
+	last2 := rangeLast(offset2, length2)
+	return offset1 <= last2 && offset2 <= last1
+}
+
+// rangeLast returns the inclusive last byte of a byte range.
+// For unbounded ranges (length=0), returns max uint64 to represent infinity.
+func rangeLast(offset, length uint64) uint64 {
+	if length == 0 {
+		return ^uint64(0)
+	}
+	return offset + length - 1
 }
 
 // rangeEnd returns the exclusive end of a byte range.
 // For unbounded ranges (length=0), returns max uint64 to represent infinity.
+// Retained as a convenience helper for callers using strict inequality.
+//
+// Note: callers must guard against overflow when offset+length wraps —
+// prefer rangeLast + inclusive-end arithmetic for boundary cases.
 func rangeEnd(offset, length uint64) uint64 {
 	if length == 0 {
 		return ^uint64(0)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -367,32 +367,18 @@ incomplete break notification delivery and multi-client coordination.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 
-### Byte-Range Locks (Fix Candidate)
+### Byte-Range Locks (Replay subset — depends on multichannel #482)
 
-Byte-range locking is partially implemented but smbtorture lock tests still
-fail due to incomplete lock contention and async lock handling.
+The remaining smb2.lock failures are the replay-protection tests, which
+need LockSequence tracking + multichannel reflection support. Those land
+under #482 (multichannel session binding); track here so the parser
+recognises them.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.lock.valid-request | Locks | Lock request validation not fully working | #430 |
-| smb2.lock.auto-unlock | Locks | Auto-unlock on close not fully working | #430 |
-| smb2.lock.lock | Locks | Basic lock operation not fully working | #430 |
-| smb2.lock.cancel | Locks | Lock cancel not fully working | #430 |
-| smb2.lock.errorcode | Locks | Lock error codes not fully working | #430 |
-| smb2.lock.zerobytelength | Locks | Zero-length lock not fully working | #430 |
-| smb2.lock.unlock | Locks | Unlock operation not fully working | #430 |
-| smb2.lock.multiple-unlock | Locks | Multiple unlock not fully working | #430 |
-| smb2.lock.stacking | Locks | Lock stacking not fully working | #430 |
-| smb2.lock.range | Locks | Lock range validation not fully working | #430 |
-| smb2.lock.overlap | Locks | Overlapping locks not fully working | #430 |
-| smb2.lock.replay_broken_windows | Locks | Lock replay not fully working | #430 |
-| smb2.lock.replay_smb3_specification_durable | Locks | Lock replay with durable handles not fully working | #430 |
-| smb2.lock.replay_smb3_specification_multi | Locks | Lock replay with multi-channel not fully working | #430 |
-| smb2.lock.async | Locks | Blocking lock deadlocks dispatch goroutine (needs async LOCK with interim response) | #430 |
-| smb2.lock.cancel-logoff | Locks | Pending lock not re-acquired after logoff releases held lock — timing issue in async retry | #430 |
-| smb2.lock.cancel-tdis | Locks | Pending lock cancel on tree disconnect not fully working | #430 |
-| smb2.lock.open-brlock-deadlock | Locks | Open + byte-range lock deadlock detection not working | #430 |
-| smb2.lock.ctdb-delrec-deadlock | Locks | CTDB delete record deadlock not working | #430 |
+| smb2.replay_broken_windows | Locks | Lock replay requires LockSequence tracking | #430 |
+| smb2.replay_smb3_specification_durable | Locks | Lock replay with durable handles needs LockSequence | #430 |
+| smb2.replay_smb3_specification_multi | Locks | Lock replay across channels needs multichannel | #430 |
 
 ### Sessions (Remaining)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -376,9 +376,9 @@ recognises them.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.replay_broken_windows | Locks | Lock replay requires LockSequence tracking | #430 |
-| smb2.replay_smb3_specification_durable | Locks | Lock replay with durable handles needs LockSequence | #430 |
-| smb2.replay_smb3_specification_multi | Locks | Lock replay across channels needs multichannel | #430 |
+| smb2.lock.replay_broken_windows | Locks | Lock replay requires LockSequence tracking | #430 |
+| smb2.lock.replay_smb3_specification_durable | Locks | Lock replay with durable handles needs LockSequence | #430 |
+| smb2.lock.replay_smb3_specification_multi | Locks | Lock replay across channels needs multichannel | #430 |
 
 ### Sessions (Remaining)
 


### PR DESCRIPTION
## Summary

Final round of byte-range lock fixes for the `smb2.lock.*` smbtorture subsuite (#430). Combined with previously-merged PRs #650 and #653, all 17 runnable tests now pass; only the 3 replay-protection tests stay deferred to #482 (multichannel) per the wave plan.

### Tests flipped (4)

- `smb2.lock.valid-request`
- `smb2.lock.lock`
- `smb2.lock.errorcode`
- `smb2.lock.cancel-logoff`

### Fixes

1. **First-element flag validation** rewritten to mirror Samba `smbd_smb2_lock_send` (`source3/smbd/smb2_lock.c`). Only `{SHARED, EXCLUSIVE, SHARED|FAIL_IMM, EXCLUSIVE|FAIL_IMM, UNLOCK}` are valid. `UNLOCK|FAIL_IMM` and unknown bits now return `INVALID_PARAMETER` (was: `RANGE_NOT_LOCKED`).
2. **Range overflow** check switched to inclusive-end arithmetic. `{offset=~0, length=1}` (one byte at 2^64-1) is now correctly accepted; previously rejected with `INVALID_LOCK_RANGE`.
3. **`RangesOverlap`** rewritten with inclusive-end semantics so single-byte ranges at the max uint64 offset detect self-overlap. New `TestRangesOverlap` boundary cases.
4. **`LOCK_NOT_GRANTED` vs `FILE_LOCK_CONFLICT` escalation removed.** Per MS-SMB2 §3.3.5.14 and `source4/torture/smb2/lock.c:1183-1186`: \"SMBv2 has cleaned up these semantics and should always return NT_STATUS_LOCK_NOT_GRANTED to failed lock requests, and NT_STATUS_FILE_LOCK_CONFLICT to failed read/write requests.\" The per-open last-denied-lock tracking map is gone.
5. **`closeFilesWithFilter`** now drains `PendingLockRegistry` per closing handle (matching explicit CLOSE step 7 in `close.go`), so blocking LOCKs parked on files closed by LOGOFF / tree disconnect / transport drop complete with `STATUS_RANGE_NOT_LOCKED` instead of `STATUS_CANCELLED` from the catch-all drain.

### Deferred (KNOWN_FAILURES.md retained)

`smb2.replay_broken_windows`, `smb2.replay_smb3_specification_durable`, `smb2.replay_smb3_specification_multi` — depend on LockSequence tracking + multichannel session binding (#482). Will be walked back when #482 lands.

The two SKIPPED deadlock tests (`open-brlock-deadlock`, `ctdb-delrec-deadlock`) are not runnable in our environment; removed from KNOWN_FAILURES.md since they never matched the parser.

## Test plan

- [x] `go fmt ./... && go vet ./...` clean
- [x] `go test -race ./internal/adapter/smb/v2/... ./pkg/metadata/lock/...` passes
- [x] `go test ./...` passes
- [x] `./run.sh --profile memory --filter smb2.lock` — 20 PASS / 3 KNOWN / 3 SKIP / 0 NEW FAIL
- [ ] CI smbtorture
- [ ] CI race + lint

Closes #430