### PR TITLE
fix(smb/streams): propagate ADS DOS attrs + streams-disabled share (#471)

### DIFF
--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -27,6 +27,7 @@ var (
 	createAclCanonicalize   bool
 	createAccessBasedEnum   bool
 	createChangeNotifyOff   bool
+	createStreamsDisabled   bool
 )
 
 var createCmd = &cobra.Command{
@@ -84,6 +85,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createAclCanonicalize, "acl-canonicalize-inherited", true, "When false, preserves the SE_DACL_AUTO_INHERITED control bit verbatim on SET_INFO Security instead of applying MS-DTYP §2.5.3.4.2 canonicalization (Samba \"acl flag inherited canonicalization = no\"). Default true matches Windows.")
 	createCmd.Flags().BoolVar(&createAccessBasedEnum, "access-based-enumeration", false, "Enable Windows access-based enumeration (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM). When true, SMB clients only see directory entries they can read.")
 	createCmd.Flags().BoolVar(&createChangeNotifyOff, "change-notify-disabled", false, "Reject SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED on this share (mirrors Samba 'kernel change notify = no').")
+	createCmd.Flags().BoolVar(&createStreamsDisabled, "streams-disabled", false, "Reject SMB2 Alternate Data Stream opens with STATUS_OBJECT_NAME_INVALID on this share (mirrors Samba 'smbd:streams = no').")
 	_ = createCmd.MarkFlagRequired("local")
 }
 
@@ -178,6 +180,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("change-notify-disabled") {
 		v := createChangeNotifyOff
 		req.ChangeNotifyDisabled = &v
+	}
+	if cmd.Flags().Changed("streams-disabled") {
+		v := createStreamsDisabled
+		req.StreamsDisabled = &v
 	}
 
 	share, err := client.CreateShare(req)

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -69,6 +69,8 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Default Permission", s.DefaultPermission},
 		{"ACL Canonicalize Inherited", fmt.Sprintf("%v", s.AclFlagInheritedCanonicalization)},
 		{"Access-Based Enumeration", fmt.Sprintf("%v", s.AccessBasedEnumeration)},
+		{"Change Notify Disabled", fmt.Sprintf("%v", s.ChangeNotifyDisabled)},
+		{"Streams Disabled", fmt.Sprintf("%v", s.StreamsDisabled)},
 		{"Retention", retPolicy},
 	}
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -572,15 +572,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Per smb2.create_no_streams.no_stream (source4/torture/smb2/create.c):
-	// shares with StreamsDisabled reject CREATEs that name a data stream —
-	// the cases the test exercises and that the upstream extractor surfaces
-	// here: named ADS ("file:stream"), stream-with-type suffix
-	// ("file:stream:$DATA"), arbitrary stream-type suffix ("file::foo"),
-	// and the explicit default data stream ("file::$DATA"). Mirrors
-	// Samba `smbd:streams = no`. Directory-index syntaxes
-	// (`::$INDEX_ALLOCATION`, `:$I30:$INDEX_ALLOCATION`) are normalized away
-	// earlier and resolve to the directory itself, so they are not stream
-	// references and remain allowed.
+	// shares with StreamsDisabled reject CREATEs that name a data stream.
+	// The upstream extractor surfaces every stream syntax through one of
+	// these two predicates:
+	//
+	//   - streamSuffix != ""    — the default arm of the switch above. Set
+	//                             for named ADS ("file:stream"), named-ADS
+	//                             with type suffix ("file:stream:$DATA"),
+	//                             arbitrary stream-type suffix ("file::foo"
+	//                             or "file:foo:bar"), and the literal
+	//                             "file:$DATA" stream entity.
+	//   - explicitDataStream    — set only for the bare default data
+	//                             stream ("file::$DATA"); the extractor
+	//                             strips the suffix into filename so
+	//                             streamSuffix is empty.
+	//
+	// Directory-index syntaxes (`::$INDEX_ALLOCATION`, `:$I30:$INDEX_ALLOCATION`)
+	// are intentionally normalized away by the extractor and resolve to the
+	// directory itself, so they are not stream references and remain
+	// allowed. Mirrors Samba `smbd:streams = no`.
 	if tree.StreamsDisabled && (streamSuffix != "" || explicitDataStream) {
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameInvalid}}, nil
 	}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -572,12 +572,15 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Per smb2.create_no_streams.no_stream (source4/torture/smb2/create.c):
-	// shares configured with StreamsDisabled must reject any CREATE that
-	// references a stream — named ADS, the default ::$DATA syntax, and
-	// arbitrary stream-type suffixes — with STATUS_OBJECT_NAME_INVALID.
-	// Mirrors the Samba `smbd:streams = no` semantics. The gate runs after
-	// stream-suffix extraction so `streamSuffix != ""` covers named ADS and
-	// the default ::$DATA case toggles `explicitDataStream`.
+	// shares with StreamsDisabled reject CREATEs that name a data stream —
+	// the cases the test exercises and that the upstream extractor surfaces
+	// here: named ADS ("file:stream"), stream-with-type suffix
+	// ("file:stream:$DATA"), arbitrary stream-type suffix ("file::foo"),
+	// and the explicit default data stream ("file::$DATA"). Mirrors
+	// Samba `smbd:streams = no`. Directory-index syntaxes
+	// (`::$INDEX_ALLOCATION`, `:$I30:$INDEX_ALLOCATION`) are normalized away
+	// earlier and resolve to the directory itself, so they are not stream
+	// references and remain allowed.
 	if tree.StreamsDisabled && (streamSuffix != "" || explicitDataStream) {
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameInvalid}}, nil
 	}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -571,6 +571,17 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameInvalid}}, nil
 	}
 
+	// Per smb2.create_no_streams.no_stream (source4/torture/smb2/create.c):
+	// shares configured with StreamsDisabled must reject any CREATE that
+	// references a stream — named ADS, the default ::$DATA syntax, and
+	// arbitrary stream-type suffixes — with STATUS_OBJECT_NAME_INVALID.
+	// Mirrors the Samba `smbd:streams = no` semantics. The gate runs after
+	// stream-suffix extraction so `streamSuffix != ""` covers named ADS and
+	// the default ::$DATA case toggles `explicitDataStream`.
+	if tree.StreamsDisabled && (streamSuffix != "" || explicitDataStream) {
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameInvalid}}, nil
+	}
+
 	// Per MS-FSA 2.1.5.1, wildcard characters are invalid in path
 	// components. Note: wildcards ARE valid inside stream names (e.g.,
 	// "file:?Stream*" is legal), so this check applies only to the base

--- a/internal/adapter/smb/v2/handlers/create_streams_disabled_test.go
+++ b/internal/adapter/smb/v2/handlers/create_streams_disabled_test.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -169,5 +170,46 @@ func TestCreate_StreamsNotDisabled_AcceptsStreamSyntax(t *testing.T) {
 	}
 	if resp.Status == types.StatusObjectNameInvalid {
 		t.Fatalf("Create on streams-enabled share: STATUS_OBJECT_NAME_INVALID returned — gate fired on a streams-enabled share")
+	}
+}
+
+// TestQueryInfo_FsAttrs_NamedStreamsBit pins the FileFsAttributeInformation
+// FileSystemAttributes round-trip: streams-enabled shares advertise
+// FILE_NAMED_STREAMS (0x00040000), streams-disabled shares strip it. This
+// is the QUERY_INFO half of the StreamsDisabled contract (the CREATE half
+// is covered by TestCreate_StreamsDisabled_RejectsStreamSyntax above).
+func TestQueryInfo_FsAttrs_NamedStreamsBit(t *testing.T) {
+	const fileNamedStreams uint32 = 0x00040000
+
+	cases := []struct {
+		name            string
+		streamsDisabled bool
+		wantStreams     bool
+	}{
+		{"StreamsEnabled_AdvertisesNamedStreams", false, true},
+		{"StreamsDisabled_StripsNamedStreams", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, smbCtx, rootHandle := setupStreamsDisabledShare(t, tc.streamsDisabled)
+			metaSvc := h.Registry.GetMetadataService()
+
+			// buildFilesystemInfo needs an OpenFile to source the handle.
+			// The streams-disabled gate is applied based on tree state,
+			// which is what the call site (handler) reads — mirror that.
+			info, err := h.buildFilesystemInfo(smbCtx.Context, 5, metaSvc, rootHandle, tc.streamsDisabled)
+			if err != nil {
+				t.Fatalf("buildFilesystemInfo: %v", err)
+			}
+			if len(info) < 4 {
+				t.Fatalf("FileFsAttributeInformation buffer too short: %d", len(info))
+			}
+			fsAttrs := binary.LittleEndian.Uint32(info[0:4])
+			gotStreams := fsAttrs&fileNamedStreams != 0
+			if gotStreams != tc.wantStreams {
+				t.Fatalf("FILE_NAMED_STREAMS bit: got=%v want=%v (fsAttrs=0x%08x)", gotStreams, tc.wantStreams, fsAttrs)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/v2/handlers/create_streams_disabled_test.go
+++ b/internal/adapter/smb/v2/handlers/create_streams_disabled_test.go
@@ -1,0 +1,173 @@
+// Handler-level coverage for the per-share StreamsDisabled gate
+// (smb2.create_no_streams.no_stream, source4/torture/smb2/create.c:3960).
+//
+// The CREATE handler rejects any reference to a data stream — named ADS,
+// stream-with-type suffix, arbitrary stream-type suffix, and the explicit
+// default `::$DATA` syntax — with STATUS_OBJECT_NAME_INVALID on a tree
+// whose share has StreamsDisabled=true. Non-stream paths and the
+// directory-index syntaxes (`::$INDEX_ALLOCATION`, `:$I30:$INDEX_ALLOCATION`)
+// remain accepted because the stream-syntax extractor normalizes those away
+// before the gate.
+//
+// These tests drive `h.Create` end-to-end so the gate, the upstream
+// stream-syntax extractor, and the StreamsDisabled plumbing on
+// TreeConnection are exercised together.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupStreamsDisabledShare wires a handler + runtime + memory store with a
+// single share whose StreamsDisabled flag is set per the streamsDisabled
+// argument. Returns the handler, an SMBHandlerContext primed with a session
+// and tree, and the share's root handle (the latter is unused by these tests
+// but matches the pattern used by other handler-level integration tests in
+// this package).
+func setupStreamsDisabledShare(t *testing.T, streamsDisabled bool) (*Handler, *SMBHandlerContext, metadata.FileHandle) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("streams-test-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	const shareName = "/streams-test"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:            shareName,
+		MetadataStore:   "streams-test-meta",
+		Enabled:         true,
+		StreamsDisabled: streamsDisabled,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	const callerUID, callerGID uint32 = 1000, 1000
+	uid, gid := callerUID, callerGID
+	sess := h.CreateSession("127.0.0.1:12345", false, "test-user", "")
+	sess.User = &models.User{
+		Username: "test-user",
+		UID:      &uid,
+		Groups:   []models.Group{{GID: &gid}},
+	}
+
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:          treeID,
+		SessionID:       sess.SessionID,
+		ShareName:       shareName,
+		Permission:      models.PermissionReadWrite,
+		StreamsDisabled: streamsDisabled,
+	})
+
+	smbCtx := &SMBHandlerContext{
+		Context:   context.Background(),
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		ShareName: shareName,
+	}
+
+	return h, smbCtx, rootHandle
+}
+
+// streamCreateRequest builds a minimal CREATE request for the given path.
+// DesiredAccess SEC_FILE_ALL + share access RWD + disposition OPEN match the
+// smbtorture sequence in source4/torture/smb2/create.c::test_no_stream.
+func streamCreateRequest(fname string) *CreateRequest {
+	return &CreateRequest{
+		FileName:          fname,
+		DesiredAccess:     0x02000000, // SEC_FLAG_MAXIMUM_ALLOWED
+		FileAttributes:    types.FileAttributeNormal,
+		ShareAccess:       0x07, // R|W|D
+		CreateDisposition: types.FileOpen,
+		CreateOptions:     0,
+	}
+}
+
+// TestCreate_StreamsDisabled_RejectsStreamSyntax mirrors the four
+// stream-reference forms exercised by smbtorture
+// smb2.create_no_streams.no_stream. Each must return
+// STATUS_OBJECT_NAME_INVALID when the tree's share has StreamsDisabled=true.
+func TestCreate_StreamsDisabled_RejectsStreamSyntax(t *testing.T) {
+	h, smbCtx, _ := setupStreamsDisabledShare(t, true)
+
+	cases := []struct {
+		name  string
+		fname string
+	}{
+		{"NamedADS", "test_no_stream:stream"},
+		{"NamedADSWithDataType", "test_no_stream:stream:$DATA"},
+		{"ArbitraryStreamTypeSuffix", "test_no_stream::foooooooooooo"},
+		{"ExplicitDefaultDataStream", "test_no_stream::$DATA"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := h.Create(smbCtx, streamCreateRequest(tc.fname))
+			if err != nil {
+				t.Fatalf("Create(%q): unexpected error: %v", tc.fname, err)
+			}
+			if resp.Status != types.StatusObjectNameInvalid {
+				t.Fatalf("Create(%q): status = 0x%08x, expected STATUS_OBJECT_NAME_INVALID (0x%08x)",
+					tc.fname, uint32(resp.Status), uint32(types.StatusObjectNameInvalid))
+			}
+		})
+	}
+}
+
+// TestCreate_StreamsDisabled_AllowsNonStreamPaths confirms the gate is
+// scoped to stream syntaxes — a plain file path on a streams-disabled share
+// must not be rejected by this code path. We use FileOpen disposition on a
+// path that doesn't exist; the expected outcome is NOT
+// STATUS_OBJECT_NAME_INVALID (the gate doesn't fire). The actual status here
+// is whatever the downstream lookup returns (typically
+// STATUS_OBJECT_NAME_NOT_FOUND) — we assert only that the gate didn't fire.
+func TestCreate_StreamsDisabled_AllowsNonStreamPaths(t *testing.T) {
+	h, smbCtx, _ := setupStreamsDisabledShare(t, true)
+
+	resp, err := h.Create(smbCtx, streamCreateRequest("plain_file"))
+	if err != nil {
+		t.Fatalf("Create(plain_file): unexpected error: %v", err)
+	}
+	if resp.Status == types.StatusObjectNameInvalid {
+		t.Fatalf("Create(plain_file): unexpected STATUS_OBJECT_NAME_INVALID — gate fired on non-stream path")
+	}
+}
+
+// TestCreate_StreamsNotDisabled_AcceptsStreamSyntax confirms the gate is
+// genuinely scoped to StreamsDisabled=true shares. On a streams-enabled
+// share, a stream-named CREATE must NOT return STATUS_OBJECT_NAME_INVALID
+// from this code path (the request flows past the gate and either
+// auto-creates the base file or surfaces a downstream status — anything
+// except the gate's status is acceptable here).
+func TestCreate_StreamsNotDisabled_AcceptsStreamSyntax(t *testing.T) {
+	h, smbCtx, _ := setupStreamsDisabledShare(t, false)
+
+	resp, err := h.Create(smbCtx, streamCreateRequest("test_no_stream:stream"))
+	if err != nil {
+		t.Fatalf("Create: unexpected error: %v", err)
+	}
+	if resp.Status == types.StatusObjectNameInvalid {
+		t.Fatalf("Create on streams-enabled share: STATUS_OBJECT_NAME_INVALID returned — gate fired on a streams-enabled share")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -265,6 +265,11 @@ type TreeConnection struct {
 	// STATUS_NOT_IMPLEMENTED — matches Samba `kernel change notify = no`
 	// and the smb2.change_notify_disabled torture test.
 	ChangeNotifyDisabled bool
+	// StreamsDisabled mirrors the share-level toggle. When true, CREATE
+	// requests that reference an Alternate Data Stream are rejected with
+	// STATUS_OBJECT_NAME_INVALID — matches Samba `smbd:streams = no`
+	// and the smb2.create_no_streams.no_stream torture test.
+	StreamsDisabled bool
 }
 
 // OpenFile represents an open file handle created by the CREATE command.

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -362,7 +362,14 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	case types.SMB2InfoTypeFile:
 		info, err = h.buildFileInfoFromStore(authCtx, file, openFile, types.FileInfoClass(req.FileInfoClass))
 	case types.SMB2InfoTypeFilesystem:
-		info, err = h.buildFilesystemInfo(ctx.Context, types.FileInfoClass(req.FileInfoClass), metaSvc, openFile.MetadataHandle)
+		// FileFsAttributeInformation advertises FILE_NAMED_STREAMS iff the
+		// tree's share allows ADS. Look up StreamsDisabled from the open's
+		// tree; default to streams-enabled when the tree isn't found.
+		streamsDisabled := false
+		if tree, ok := h.GetTree(ctx.TreeID); ok {
+			streamsDisabled = tree.StreamsDisabled
+		}
+		info, err = h.buildFilesystemInfo(ctx.Context, types.FileInfoClass(req.FileInfoClass), metaSvc, openFile.MetadataHandle, streamsDisabled)
 	case types.SMB2InfoTypeSecurity:
 		// Per MS-SMB2 §3.3.5.20.3: querying OWNER, GROUP, or DACL requires
 		// READ_CONTROL on the open handle. SACL requires ACCESS_SYSTEM_SECURITY.
@@ -1029,8 +1036,12 @@ func shareNameForOpenFile(openFile *OpenFile) string {
 	return openFile.ShareName
 }
 
-// buildFilesystemInfo builds filesystem information [MS-FSCC] 2.5.
-func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoClass, metaSvc *metadata.MetadataService, handle metadata.FileHandle) ([]byte, error) {
+// buildFilesystemInfo builds filesystem information [MS-FSCC] 2.5. The
+// streamsDisabled flag suppresses FILE_NAMED_STREAMS in the
+// FileFsAttributeInformation FileSystemAttributes mask so that clients on a
+// streams-disabled share see the FS advertise no ADS support, matching the
+// CREATE-time rejection in create.go.
+func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoClass, metaSvc *metadata.MetadataService, handle metadata.FileHandle, streamsDisabled bool) ([]byte, error) {
 	switch class {
 	case 1: // FileFsVolumeInformation [MS-FSCC] 2.5.9
 		label := encodeUTF16LE("DittoFS")
@@ -1078,9 +1089,14 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 		// FILE_CASE_SENSITIVE_SEARCH(0x01) | FILE_CASE_PRESERVED_NAMES(0x02) |
 		// FILE_UNICODE_ON_DISK(0x04) | FILE_PERSISTENT_ACLS(0x08) |
 		// FILE_FILE_COMPRESSION(0x10) | FILE_SUPPORTS_SPARSE_FILES(0x40) |
-		// FILE_SUPPORTS_REPARSE_POINTS(0x80) | FILE_SUPPORTS_OBJECT_IDS(0x10000) |
-		// FILE_SUPPORTS_ENCRYPTION(0x20000)
-		w.WriteUint32(0x000300DF)
+		// FILE_SUPPORTS_REPARSE_POINTS(0x80) | FILE_NAMED_STREAMS(0x40000) |
+		// FILE_SUPPORTS_OBJECT_IDS(0x10000) | FILE_SUPPORTS_ENCRYPTION(0x20000)
+		const fileNamedStreams uint32 = 0x00040000
+		fsAttrs := uint32(0x000300DF) | fileNamedStreams
+		if streamsDisabled {
+			fsAttrs &^= fileNamedStreams
+		}
+		w.WriteUint32(fsAttrs)
 		w.WriteUint32(255)
 		w.WriteUint32(uint32(len(fsName)))
 		w.WriteBytes(fsName)

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -455,20 +455,45 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
-		// Per NTFS: only TIMESTAMPS set on an ADS propagate to the base
-		// file. FileAttributes/Mode do NOT propagate — they are per-file.
+		// Per NTFS: SET_INFO BasicInformation on an ADS handle propagates
+		// both timestamps AND DOS file attributes (Hidden + the DOS bits
+		// stored in the high mode bits) to the base file.
+		// smb2.streams.attributes2 (source4/torture/smb2/streams.c) asserts
+		// that setting attribs via the stream changes the base file's
+		// attribs too, and vice-versa — base and stream always report
+		// identical FileAttributes via QUERY_INFO. QUERY_INFO on a stream
+		// already resolves to base via resolveBaseFileAttrForADS, so the
+		// propagation here is what makes the round-trip consistent for both
+		// opens. Mode propagation only overlays the DOS bits onto the base
+		// file's existing POSIX permissions — overwriting the base's POSIX
+		// mode with the stream-derived default (0o644) would clobber any
+		// out-of-band chmod the operator applied via NFS.
 		if colonIdx := strings.Index(openFile.FileName, ":"); colonIdx > 0 && len(openFile.ParentHandle) > 0 {
-			tsAttrs := &metadata.SetAttrs{
-				Mtime:        setAttrs.Mtime,
-				Ctime:        setAttrs.Ctime,
-				Atime:        setAttrs.Atime,
-				CreationTime: setAttrs.CreationTime,
-			}
-			if tsAttrs.Mtime != nil || tsAttrs.Ctime != nil || tsAttrs.Atime != nil || tsAttrs.CreationTime != nil {
-				baseFileName := openFile.FileName[:colonIdx]
-				if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName); baseFile != nil {
+			baseFileName := openFile.FileName[:colonIdx]
+			if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName); baseFile != nil {
+				basePropagate := &metadata.SetAttrs{
+					Mtime:        setAttrs.Mtime,
+					Ctime:        setAttrs.Ctime,
+					Atime:        setAttrs.Atime,
+					CreationTime: setAttrs.CreationTime,
+					Hidden:       setAttrs.Hidden,
+				}
+				if setAttrs.Mode != nil {
+					// Strip the stream-derived POSIX bits and keep only the
+					// DOS attribute bits (Explicit/Archive/System/Readonly).
+					// modeDOSCompressed lives in the base file's mode and is
+					// FSCTL-managed, so leave it untouched.
+					const dosBits = modeDOSExplicit | modeDOSArchive | modeDOSSystem | modeDOSReadonly
+					newMode := (baseFile.Mode &^ dosBits) | (*setAttrs.Mode & dosBits)
+					if newMode != baseFile.Mode {
+						basePropagate.Mode = &newMode
+					}
+				}
+				if basePropagate.Mtime != nil || basePropagate.Ctime != nil ||
+					basePropagate.Atime != nil || basePropagate.CreationTime != nil ||
+					basePropagate.Mode != nil || basePropagate.Hidden != nil {
 					if baseHandle, encErr := metadata.EncodeFileHandle(baseFile); encErr == nil {
-						_ = metaSvc.SetFileAttributes(authCtx, baseHandle, tsAttrs)
+						_ = metaSvc.SetFileAttributes(authCtx, baseHandle, basePropagate)
 					}
 				}
 			}

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -455,19 +455,36 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
-		// Per NTFS: SET_INFO BasicInformation on an ADS handle propagates
-		// both timestamps AND DOS file attributes (Hidden + the DOS bits
-		// stored in the high mode bits) to the base file.
-		// smb2.streams.attributes2 (source4/torture/smb2/streams.c) asserts
-		// that setting attribs via the stream changes the base file's
-		// attribs too, and vice-versa — base and stream always report
-		// identical FileAttributes via QUERY_INFO. QUERY_INFO on a stream
-		// already resolves to base via resolveBaseFileAttrForADS, so the
-		// propagation here is what makes the round-trip consistent for both
-		// opens. Mode propagation only overlays the DOS bits onto the base
-		// file's existing POSIX permissions — overwriting the base's POSIX
-		// mode with the stream-derived default (0o644) would clobber any
-		// out-of-band chmod the operator applied via NFS.
+		// NTFS contract: SET_INFO BasicInformation on an ADS handle MUST be
+		// observable on the base file via QUERY_INFO, and vice-versa — base
+		// and stream always report identical FileAttributes.
+		// smb2.streams.attributes2 (source4/torture/smb2/streams.c) round-
+		// trips this both ways: setting attribs through the stream and
+		// re-querying the base must agree, and the reverse. QUERY_INFO on
+		// a stream already resolves to base via resolveBaseFileAttrForADS,
+		// so the only piece that closes the loop is propagating the writes
+		// from the stream's SET_INFO back onto the base. The propagation:
+		//
+		//   - Forwards CreationTime / LastAccessTime / LastWriteTime /
+		//     ChangeTime onto the base. nil-valued pointers are skipped,
+		//     so a "timestamp-only" SET_INFO that leaves FileAttributes=0
+		//     does not touch the base's DOS bits or Hidden flag.
+		//   - Forwards the Hidden flag when FileAttributes was set.
+		//   - Overlays only the four explicit DOS bits
+		//     (modeDOSExplicit | modeDOSArchive | modeDOSSystem |
+		//     modeDOSReadonly) from the stream's computed mode onto the
+		//     base's existing mode. All other bits in the base's mode
+		//     are preserved:
+		//       * POSIX permission bits (0o7777) — an out-of-band NFS
+		//         chmod must survive a stream SET_INFO.
+		//       * modeDOSCompressed (0x40000) — FSCTL-managed, lives on
+		//         the base file and is never derived from FileAttributes
+		//         on a stream SET_INFO.
+		//
+		// The base SetFileAttributes call is fire-and-forget: a failure to
+		// propagate is logged at the metadata layer and does not roll back
+		// the stream's own SET_INFO (the stream is the explicitly-targeted
+		// handle and its write has already succeeded above).
 		if colonIdx := strings.Index(openFile.FileName, ":"); colonIdx > 0 && len(openFile.ParentHandle) > 0 {
 			baseFileName := openFile.FileName[:colonIdx]
 			if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName); baseFile != nil {

--- a/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
@@ -179,6 +179,56 @@ func TestSetInfo_ADS_PreservesBasePOSIXMode(t *testing.T) {
 	}
 }
 
+// TestSetInfo_ADS_PreservesBaseCompressedBitWithExistingDosBits: when the
+// base file already carries explicit DOS bits (Explicit+System) plus the
+// FSCTL-managed Compressed bit, a stream SET_INFO that flips only HIDDEN
+// must (a) preserve the Compressed bit (FSCTL-managed, never derived from
+// FileAttributes), (b) overlay HIDDEN onto the base, and (c) keep the
+// base's POSIX permissions. This is the strict version of the
+// modeDOSCompressed survival assertion — the previous test only set
+// Compressed on top of a 0o644/0o700 base, this one stacks the
+// FSCTL-managed bit underneath several existing explicit DOS bits.
+func TestSetInfo_ADS_PreservesBaseCompressedBitWithExistingDosBits(t *testing.T) {
+	h, authCtx, baseHandle, _, streamOpen := setupADSAttrPropagationTest(t, 0o640)
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Seed the base file with extra DOS bits on top of the default
+	// modeDOSCompressed already set by setupADSAttrPropagationTest.
+	preBase, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base) pre: %v", err)
+	}
+	const extraDOS = modeDOSExplicit | modeDOSSystem
+	seedMode := preBase.Mode | extraDOS
+	if err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{Mode: &seedMode}); err != nil {
+		t.Fatalf("SetFileAttributes(base seed): %v", err)
+	}
+
+	// SET_INFO via stream: FileAttributes = HIDDEN.
+	buf := make([]byte, 40)
+	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
+
+	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
+	}
+
+	base, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base): %v", err)
+	}
+
+	if !base.Hidden {
+		t.Errorf("base.Hidden = false after stream SET_INFO HIDDEN; expected true")
+	}
+	if base.Mode&modeDOSCompressed == 0 {
+		t.Errorf("base.Mode lost modeDOSCompressed after stream SET_INFO; FSCTL-managed bit must survive")
+	}
+	if gotPOSIX := base.Mode & 0o7777; gotPOSIX != 0o640 {
+		t.Errorf("base POSIX mode = 0o%o after stream SET_INFO; expected 0o640", gotPOSIX)
+	}
+}
+
 // TestSetInfo_ADS_TimestampOnlyDoesNotPropagateAttrs: SET_INFO
 // BasicInformation with FileAttributes=0 (timestamp-only) must NOT touch
 // the base file's Hidden field or DOS mode bits. Only an explicit

--- a/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
@@ -1,0 +1,217 @@
+// Handler-level coverage for SET_INFO BasicInformation propagation from an
+// Alternate Data Stream handle onto the base file (smb2.streams.attributes2,
+// source4/torture/smb2/streams.c::test_stream_attributes2).
+//
+// Per NTFS semantics, base and stream report identical DOS file attributes
+// via QUERY_INFO. The handler enforces this by propagating the Hidden flag
+// and the DOS attribute bits (Explicit/Archive/System/Readonly) from a
+// stream SET_INFO onto the base file. The propagation only overlays DOS
+// bits onto the base's existing mode — POSIX permission bits and the
+// FSCTL-managed modeDOSCompressed bit must survive.
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupADSAttrPropagationTest builds a memory-backed runtime with a single
+// share that contains a base file `base.txt` and a stream `base.txt:s`. The
+// base file's mode is preserved across the SET_INFO under test, so we let
+// the caller pin its initial value via the basePOSIXMode parameter (the
+// callers exercise both the default 0o644 and a non-default 0o700 to
+// confirm POSIX bits survive).
+//
+// Returns the handler, auth context, both file metadata handles, and the
+// OpenFile that represents the stream open. The OpenFile carries a colon
+// in its FileName and a ParentHandle, which is the trigger the SET_INFO
+// propagation path keys off.
+func setupADSAttrPropagationTest(t *testing.T, basePOSIXMode uint32) (
+	*Handler,
+	*metadata.AuthContext,
+	metadata.FileHandle, // base file handle
+	metadata.FileHandle, // stream file handle
+	*OpenFile, // open on the stream
+) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("ads-attr-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	const shareName = "/ads-attr"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "ads-attr-meta",
+		Enabled:       true,
+		RootAttr:      &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	metaSvc := rt.GetMetadataService()
+
+	// Base file with the requested POSIX mode plus modeDOSCompressed set so
+	// the test can also assert that bit survives the SET_INFO propagation.
+	baseFile, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: basePOSIXMode | modeDOSCompressed,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile base: %v", err)
+	}
+	baseHandle, err := metadata.EncodeFileHandle(baseFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle base: %v", err)
+	}
+
+	// Stream as a sibling entry under the parent directory, mirroring how
+	// the CREATE handler stores ADS — name carries the colon, no special
+	// metadata flag (the colon in the name is the marker).
+	streamFile, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt:s", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile stream: %v", err)
+	}
+	streamHandle, err := metadata.EncodeFileHandle(streamFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle stream: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	streamOpen := &OpenFile{
+		FileID:         [16]byte{0xAD, 0x5A, 0x77, 0x52, 0xC0, 0x01},
+		MetadataHandle: streamHandle,
+		ParentHandle:   rootHandle,
+		FileName:       "base.txt:s",
+		Path:           "base.txt:s",
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileWriteData) | uint32(types.FileReadData),
+	}
+	h.StoreOpenFile(streamOpen)
+
+	return h, authCtx, baseHandle, streamHandle, streamOpen
+}
+
+// TestSetInfo_ADS_PropagatesDosBitsToBase: SET_INFO BasicInformation on a
+// stream handle with FileAttributes=HIDDEN must propagate HIDDEN onto the
+// base file. Mirrors the "modify attributes via stream" step of
+// smb2.streams.attributes2.
+func TestSetInfo_ADS_PropagatesDosBitsToBase(t *testing.T) {
+	h, authCtx, baseHandle, _, streamOpen := setupADSAttrPropagationTest(t, 0o644)
+	metaSvc := h.Registry.GetMetadataService()
+
+	// SET_INFO with FileAttributes = HIDDEN (0x02), all four FILETIME
+	// fields zero (no time change).
+	buf := make([]byte, 40)
+	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
+
+	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
+	}
+
+	base, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base): %v", err)
+	}
+
+	// The Hidden flag MUST be set on the base file.
+	if !base.Hidden {
+		t.Errorf("base.Hidden = false after stream SET_INFO HIDDEN; expected true")
+	}
+}
+
+// TestSetInfo_ADS_PreservesBasePOSIXMode: SET_INFO BasicInformation on a
+// stream handle MUST NOT clobber the base file's POSIX permission bits with
+// the stream-derived default (0o644). A base file previously set to 0o700
+// (e.g. via NFS chmod) must keep those bits after a stream SET_INFO.
+func TestSetInfo_ADS_PreservesBasePOSIXMode(t *testing.T) {
+	const basePOSIX = uint32(0o700)
+	h, authCtx, baseHandle, _, streamOpen := setupADSAttrPropagationTest(t, basePOSIX)
+	metaSvc := h.Registry.GetMetadataService()
+
+	buf := make([]byte, 40)
+	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
+
+	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
+	}
+
+	base, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base): %v", err)
+	}
+
+	// POSIX permission bits (the low 12 bits) must equal the original
+	// 0o700 — the propagation must not have overwritten them with the
+	// stream-derived 0o644 default that SMBModeFromAttrs would produce.
+	gotPOSIX := base.Mode & 0o7777
+	if gotPOSIX != basePOSIX {
+		t.Errorf("base POSIX mode = 0o%o after stream SET_INFO; expected 0o%o (stream default 0o644 must NOT clobber)", gotPOSIX, basePOSIX)
+	}
+
+	// modeDOSCompressed (FSCTL-managed) must also survive the propagation.
+	if base.Mode&modeDOSCompressed == 0 {
+		t.Errorf("base.Mode lost modeDOSCompressed after stream SET_INFO; expected to survive")
+	}
+}
+
+// TestSetInfo_ADS_TimestampOnlyDoesNotPropagateAttrs: SET_INFO
+// BasicInformation with FileAttributes=0 (timestamp-only) must NOT touch
+// the base file's Hidden field or DOS mode bits. Only an explicit
+// FileAttributes value carries an attribute intent.
+func TestSetInfo_ADS_TimestampOnlyDoesNotPropagateAttrs(t *testing.T) {
+	h, authCtx, baseHandle, _, streamOpen := setupADSAttrPropagationTest(t, 0o644)
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Seed: base file is NOT hidden.
+	preBase, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base) pre: %v", err)
+	}
+	if preBase.Hidden {
+		t.Fatalf("seed: base.Hidden should be false, got true")
+	}
+
+	// SET_INFO with all-zero FILETIME and FileAttributes=0 — a no-op call.
+	buf := make([]byte, 40)
+
+	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
+	}
+
+	base, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile(base): %v", err)
+	}
+
+	// Hidden must still be false — the zero-attributes SET_INFO must not
+	// have flipped it.
+	if base.Hidden {
+		t.Errorf("base.Hidden flipped to true after zero-attributes SET_INFO on stream; expected false")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/tree_connect.go
+++ b/internal/adapter/smb/v2/handlers/tree_connect.go
@@ -161,6 +161,7 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		EncryptData:            share.EncryptData,
 		AccessBasedEnumeration: share.AccessBasedEnumeration,
 		ChangeNotifyDisabled:   share.ChangeNotifyDisabled,
+		StreamsDisabled:        share.StreamsDisabled,
 	}
 	h.StoreTree(tree)
 

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -87,6 +87,9 @@ type CreateShareRequest struct {
 	// ChangeNotifyDisabled — pointer so nil keeps default false (change
 	// notify enabled).
 	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
+	// StreamsDisabled — pointer so nil keeps default false (streams
+	// supported).
+	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
 }
 
 // UpdateShareRequest is the request body for PUT /api/v1/shares/{name}.
@@ -114,6 +117,9 @@ type UpdateShareRequest struct {
 	// ChangeNotifyDisabled — nil = no change; non-nil = explicit set.
 	// Persisted on UpdateShare; takes effect on adapter restart.
 	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
+	// StreamsDisabled — nil = no change; non-nil = explicit set.
+	// Persisted on UpdateShare; takes effect on adapter restart.
+	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
 }
 
 // ShareResponse is the response body for share endpoints.
@@ -148,9 +154,11 @@ type ShareResponse struct {
 	AccessBasedEnumeration bool `json:"access_based_enumeration"`
 	// ChangeNotifyDisabled mirrors models.Share. No omitempty for the same
 	// reason.
-	ChangeNotifyDisabled bool      `json:"change_notify_disabled"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
+	ChangeNotifyDisabled bool `json:"change_notify_disabled"`
+	// StreamsDisabled mirrors models.Share. No omitempty for the same reason.
+	StreamsDisabled bool      `json:"streams_disabled"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 
 	// Status is the worst-of health report derived from the share's
 	// metadata store and block store engine. Non-omitempty so
@@ -301,6 +309,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		cnDisabled = *req.ChangeNotifyDisabled
 	}
 
+	// Streams default enabled (false = streams supported).
+	streamsDisabled := false
+	if req.StreamsDisabled != nil {
+		streamsDisabled = *req.StreamsDisabled
+	}
+
 	now := time.Now()
 	share := &models.Share{
 		ID:                               uuid.New().String(),
@@ -320,6 +334,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AclFlagInheritedCanonicalization: aclCanon,
 		AccessBasedEnumeration:           abe,
 		ChangeNotifyDisabled:             cnDisabled,
+		StreamsDisabled:                  streamsDisabled,
 		CreatedAt:                        now,
 		UpdatedAt:                        now,
 	}
@@ -362,6 +377,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
+			StreamsDisabled:                  share.StreamsDisabled,
 			DefaultPermission:                defaultPerm,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),
@@ -496,6 +512,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.ChangeNotifyDisabled != nil {
 		// Persisted to DB; takes effect on adapter restart.
 		share.ChangeNotifyDisabled = *req.ChangeNotifyDisabled
+	}
+	if req.StreamsDisabled != nil {
+		// Persisted to DB; takes effect on adapter restart.
+		share.StreamsDisabled = *req.StreamsDisabled
 	}
 	if req.DefaultPermission != nil {
 		share.DefaultPermission = *req.DefaultPermission
@@ -995,6 +1015,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 		AclFlagInheritedCanonicalization: s.AclFlagInheritedCanonicalization,
 		AccessBasedEnumeration:           s.AccessBasedEnumeration,
 		ChangeNotifyDisabled:             s.ChangeNotifyDisabled,
+		StreamsDisabled:                  s.StreamsDisabled,
 		CreatedAt:                        s.CreatedAt,
 		UpdatedAt:                        s.UpdatedAt,
 	}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -47,9 +47,12 @@ type Share struct {
 	AccessBasedEnumeration bool `json:"access_based_enumeration"`
 	// ChangeNotifyDisabled mirrors models.Share. No omitempty: `false` is
 	// the operator-meaningful "change notify enabled" state.
-	ChangeNotifyDisabled bool      `json:"change_notify_disabled"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
+	ChangeNotifyDisabled bool `json:"change_notify_disabled"`
+	// StreamsDisabled mirrors models.Share. No omitempty for the same
+	// reason as ChangeNotifyDisabled.
+	StreamsDisabled bool      `json:"streams_disabled"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // CreateShareRequest is the request to create a share.
@@ -77,6 +80,9 @@ type CreateShareRequest struct {
 	// ChangeNotifyDisabled — pointer so callers can distinguish "unset →
 	// server default (false)" from "explicit true".
 	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
+	// StreamsDisabled — pointer so callers can distinguish "unset →
+	// server default (false)" from "explicit true".
+	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
 }
 
 // UpdateShareRequest is the request to update a share.
@@ -102,6 +108,9 @@ type UpdateShareRequest struct {
 	// ChangeNotifyDisabled — nil = no change; non-nil = explicit set. Takes
 	// effect on adapter restart.
 	ChangeNotifyDisabled *bool `json:"change_notify_disabled,omitempty"`
+	// StreamsDisabled — nil = no change; non-nil = explicit set. Takes
+	// effect on adapter restart.
+	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
 }
 
 // SharePermission represents a permission on a share.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -43,17 +43,24 @@ type Share struct {
 	// STATUS_NOT_IMPLEMENTED. Mirrors Samba `kernel change notify = no` and
 	// the smb2.change_notify_disabled torture test. Default false leaves
 	// change notify enabled.
-	ChangeNotifyDisabled bool      `gorm:"default:false;not null" json:"change_notify_disabled"`
-	DefaultPermission    string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
-	Config               string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
-	BlockedOperations    string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
-	RetentionPolicy      string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
-	RetentionTTL         int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
-	LocalStoreSize       int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
-	ReadBufferSize       int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
-	QuotaBytes           int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
-	CreatedAt            time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt            time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ChangeNotifyDisabled bool `gorm:"default:false;not null" json:"change_notify_disabled"`
+	// StreamsDisabled rejects SMB2 CREATE requests that reference an
+	// Alternate Data Stream (named ADS, `::$DATA`, or any stream-type
+	// suffix past the base path) with STATUS_OBJECT_NAME_INVALID.
+	// Mirrors Samba `smbd:streams = no` and the
+	// smb2.create_no_streams.no_stream torture test. Default false leaves
+	// stream support enabled.
+	StreamsDisabled   bool      `gorm:"default:false;not null" json:"streams_disabled"`
+	DefaultPermission string    `gorm:"default:read-write;size:50" json:"default_permission"`      // none, read, read-write, admin
+	Config            string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
+	BlockedOperations string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
+	RetentionPolicy   string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
+	RetentionTTL      int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
+	LocalStoreSize    int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
+	ReadBufferSize    int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
+	QuotaBytes        int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
+	CreatedAt         time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt         time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 
 	// Relationships
 	MetadataStore    MetadataStoreConfig    `gorm:"foreignKey:MetadataStoreID" json:"metadata_store,omitempty"`

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -195,6 +195,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
+			StreamsDisabled:                  share.StreamsDisabled,
 			DefaultPermission:                share.DefaultPermission,
 			Squash:                           nfsOpts.GetSquashMode(),
 			AnonymousUID:                     nfsOpts.GetAnonymousUID(),

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -151,8 +151,7 @@ type ShareConfig struct {
 	ChangeNotifyDisabled bool
 
 	// StreamsDisabled mirrors models.Share's per-share toggle that
-	// rejects ADS opens with STATUS_OBJECT_NAME_INVALID and hides the
-	// FILE_NAMED_STREAMS attribute bit.
+	// rejects ADS opens with STATUS_OBJECT_NAME_INVALID.
 	StreamsDisabled bool
 
 	RootAttr *metadata.FileAttr

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -72,6 +72,12 @@ type Share struct {
 	// and the smb2.change_notify_disabled torture test.
 	ChangeNotifyDisabled bool
 
+	// StreamsDisabled rejects SMB2 CREATE requests that reference an
+	// Alternate Data Stream with STATUS_OBJECT_NAME_INVALID. Mirrors the
+	// Samba `smbd:streams = no` config and the
+	// smb2.create_no_streams.no_stream torture test.
+	StreamsDisabled bool
+
 	// NFS-specific options
 	DisableReaddirplus bool
 
@@ -143,6 +149,11 @@ type ShareConfig struct {
 	// ChangeNotifyDisabled mirrors models.Share's per-share toggle that
 	// rejects SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED.
 	ChangeNotifyDisabled bool
+
+	// StreamsDisabled mirrors models.Share's per-share toggle that
+	// rejects ADS opens with STATUS_OBJECT_NAME_INVALID and hides the
+	// FILE_NAMED_STREAMS attribute bit.
+	StreamsDisabled bool
 
 	RootAttr *metadata.FileAttr
 
@@ -441,6 +452,7 @@ func (s *Service) prepareShare(
 		AclFlagInheritedCanonicalization: config.AclFlagInheritedCanonicalization,
 		AccessBasedEnumeration:           config.AccessBasedEnumeration,
 		ChangeNotifyDisabled:             config.ChangeNotifyDisabled,
+		StreamsDisabled:                  config.StreamsDisabled,
 		DefaultPermission:                config.DefaultPermission,
 		Squash:                           config.Squash,
 		AnonymousUID:                     config.AnonymousUID,

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -150,8 +150,12 @@ type ShareConfig struct {
 	// rejects SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED.
 	ChangeNotifyDisabled bool
 
-	// StreamsDisabled mirrors models.Share's per-share toggle that
-	// rejects ADS opens with STATUS_OBJECT_NAME_INVALID.
+	// StreamsDisabled mirrors models.Share's per-share toggle that rejects
+	// SMB2 CREATE on Alternate Data Streams with STATUS_OBJECT_NAME_INVALID
+	// (named ADS, `::$DATA`, or any stream-type suffix). When set, the SMB
+	// handler also strips FILE_NAMED_STREAMS from the
+	// FileFsAttributeInformation FileSystemAttributes mask so the
+	// filesystem advertises no ADS support.
 	StreamsDisabled bool
 
 	RootAttr *metadata.FileAttr

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -287,6 +287,14 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to backfill shares.change_notify_disabled: %w", err)
 	}
 
+	// Backfill shares.streams_disabled for rows that predate the column.
+	if err := db.Exec(
+		"UPDATE shares SET streams_disabled = ? WHERE streams_disabled IS NULL",
+		false,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to backfill shares.streams_disabled: %w", err)
+	}
+
 	// --- Post-AutoMigrate migrations ---
 	// Step 2: Migrate legacy Share payload_store_id column to local/remote block store IDs.
 	postMigrator := db.Migrator()

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -89,6 +89,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"acl_flag_inherited_canonicalization": share.AclFlagInheritedCanonicalization,
 		"access_based_enumeration":            share.AccessBasedEnumeration,
 		"change_notify_disabled":              share.ChangeNotifyDisabled,
+		"streams_disabled":                    share.StreamsDisabled,
 		"updated_at":                          share.UpdatedAt,
 	}
 	// Handle remote_block_store_id explicitly: GORM map-based Updates may skip

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -179,6 +179,12 @@ main() {
     # smb2.acls_non_canonical.flags; verifies AUTO_INHERITED round-trips
     # verbatim through SET_INFO Security without the AUTO_INHERIT_REQ gate.
     $DFSCTL share create --name /smbnoncanon --acl-canonicalize-inherited=false $share_flags
+    # /create_no_streams rejects SMB2 Alternate Data Stream opens with
+    # STATUS_OBJECT_NAME_INVALID. Target of
+    # smb2.create_no_streams.no_stream which verifies the server rejects
+    # named ADS, ::$DATA, and arbitrary stream-type suffixes on a share
+    # configured with the Samba `smbd:streams = no` semantics.
+    $DFSCTL share create --name /create_no_streams --streams-disabled $share_flags
 
     # Create test users with DISTINCT UIDs. Without --uid each user falls back
     # to defaultUID=1000 in internal/adapter/smb/v2/handlers/auth_helper.go,
@@ -219,7 +225,7 @@ main() {
     # Wait for SMB adapter to start
     wait_for_smb localhost
 
-    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,change_notify_disabled,smbnoncanon users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
+    log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,change_notify_disabled,smbnoncanon,create_no_streams users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
 }
 
 main "$@"

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -85,17 +85,6 @@ is advertised.
 | smb2.set-sparse-ioctl | IOCTL | Sparse file IOCTL not implemented | - |
 | smb2.zero-data-ioctl | IOCTL | Zero data IOCTL not implemented | - |
 
-### Alternate Data Streams (Partial)
-
-ADS conformance brought 13/14 smb2.streams.* tests to PASS. The remaining
-attributes2 case exercises non-default-stream attribute round-trip which
-DittoFS does not yet persist independently from the base file.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.streams.attributes2 | Streams | ADS attributes not persisted independently from base file | #471 |
-| smb2.create_no_streams.no_stream | Streams | No-streams create context not implemented | - |
-
 ### Change Notify (Remaining)
 
 Phase 73 Plan 03 completed async ChangeNotify infrastructure. Wave 2 fixed

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -363,7 +363,7 @@ fi
 # 4th run_smbtorture argument because that suite requires
 # `acl flag inherited canonicalization = no` (Samba extension) on the share,
 # whereas the default smb2.acls suite requires Windows-default canonicalization.
-SMBTORTURE_DEFAULT_SHARE="smbbasic"
+SMBTORTURE_DEFAULT_SHARE="${SMBTORTURE_DEFAULT_SHARE:-smbbasic}"
 
 # run_smbtorture FILTER [PER_TEST_TIMEOUT] [SUITE_PREFIX] [SHARE]
 # Runs smbtorture with the given filter, appending output to results file.
@@ -446,7 +446,7 @@ else
         "smb2.compound_async:compound_async"
         "smb2.compound_find:compound_find"
         "smb2.create:create"
-        "smb2.create_no_streams:create_no_streams"
+        "smb2.create_no_streams:create_no_streams:create_no_streams"
         "smb2.credits:credits"
         "smb2.delete-on-close-perms:delete-on-close-perms"
         "smb2.deny:deny"


### PR DESCRIPTION
Closes #471. Refs umbrella #673 (v1.0 SMB conformance Wave 1).

## Summary

Flips the last two `smb2.streams.*` / `smb2.create_no_streams.*` known failures
on the memory profile (15/15 PASS):

- **`smb2.streams.attributes2`** — SET_INFO BasicInformation on an ADS handle
  now propagates `Hidden` plus the DOS attribute bits
  (`Explicit`/`Archive`/`System`/`Readonly` stored in the high mode bits)
  onto the base file in addition to timestamps. NTFS semantics per
  `source4/torture/smb2/streams.c`: base and stream must report identical
  `FileAttributes` via QUERY_INFO. Mode propagation overlays only the DOS bits,
  preserving the base file's POSIX permissions and `modeDOSCompressed` — an
  out-of-band NFS `chmod` survives a stream SET_INFO.

- **`smb2.create_no_streams.no_stream`** — new per-share `StreamsDisabled`
  toggle plumbed end-to-end (model, REST, apiclient, dfsctl, runtime, SMB
  tree, CREATE handler). On a streams-disabled share, CREATE rejects any ADS
  reference — named ADS, the default `::$DATA` syntax, and arbitrary
  stream-type suffixes — with `STATUS_OBJECT_NAME_INVALID`. Mirrors Samba
  `smbd:streams = no`. Bootstrap creates `/create_no_streams` for the
  conformance runner; `run.sh` honours a pre-set `SMBTORTURE_DEFAULT_SHARE`
  env var so single-filter invocations can target the right share.

## Test plan

- [x] `go fmt ./... && go vet ./...` — clean
- [x] `go test -race ./internal/adapter/smb/v2/... ./pkg/metadata/... ./pkg/controlplane/...` — all pass
- [x] smbtorture `smb2.streams` — **14/14 PASS** (was 13/14; attributes2 flipped)
- [x] smbtorture `smb2.create_no_streams` (against `/create_no_streams` share) — **1/1 PASS** (new)
- [x] smbtorture `smb2.setinfo` — no regression (1 known)
- [ ] CI green