### PR TITLE
ci(smb): bump smbtorture timeout from 30 to 45 minutes

### DIFF
--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -138,7 +138,7 @@ jobs:
   smbtorture:
     name: smbtorture / ${{ matrix.profile }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

smbtorture/memory full-suite run regularly takes 28-32 minutes on ubuntu-latest, hitting the 30-minute job timeout. Recent develop runs:

| Run | Duration | Result |
|---|---|---|
| [26579137594](https://github.com/marmos91/dittofs/actions/runs/26579137594) | 30m18s | timeout |
| [26579245912](https://github.com/marmos91/dittofs/actions/runs/26579245912) | 30m21s | timeout |
| [26579347497](https://github.com/marmos91/dittofs/actions/runs/26579347497) | 30m08s | timeout |

Wave 1 conformance PRs (#688–#696) all hit the same timeout because each walked back KNOWN_FAILURES entries, growing the runnable smbtorture set.

## Change

Bump smbtorture timeout from 30 to 45 minutes. WPTS BVT (~13m) and smbtorture Kerberos (~5m) untouched.

## Test plan

- [ ] CI completes smbtorture/memory full suite within the new 45-minute window.
- [ ] Unblocks Wave 1 PR merges.

Refs #673.