### PR TITLE
fix(smb/dirlease): single break-to-None for parent dir-lease on content change (#470)

### DIFF
--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -798,7 +798,17 @@ func (h *Handler) setFileInfoFromStore(
 		// as the renamer itself). On Phase-2 of the test, the holder's break
 		// handler closes its handle inside our wait, the post-break conflict
 		// recheck observes the close, and the rename proceeds.
-		h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
+		//
+		// Skip when toDir == srcParent (same-directory rename): the
+		// post-rename content-change break on srcParent already emits a
+		// single LEASE_BREAK to None for that dir-lease holder. Running
+		// the pre-break here would emit a separate strip-H notification
+		// FIRST, producing two break events instead of the single break
+		// the smbtorture rename samedir-* / hardlink samedir-* cases expect
+		// (Samba's contend_dirleases emits exactly one break-to-None).
+		if !bytes.Equal(toDir, openFile.ParentHandle) {
+			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
+		}
 		if conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir); conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
 				"path", openFile.Path,
@@ -1566,16 +1576,22 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 }
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
-// the rename branch (#470 C3): break Handle + Read leases on an arbitrary
-// directory handle (src-parent or dst-parent), honoring the originating
-// handle's ParentLeaseKey suppression from C2.
+// the rename branch (#470 C3): break parent directory leases to None on an
+// arbitrary directory handle (src-parent or dst-parent), honoring the
+// originating handle's ParentLeaseKey suppression from C2.
+//
+// Per Samba `contend_dirleases` / `do_dirlease_break_to_none`
+// (source3/smbd/smb2_oplock.c): a directory-content change emits a SINGLE
+// LEASE_BREAK to None per holder, not the two-step strip-H / strip-R pattern
+// used for file leases. Using `BreakParentDirLeasesOnDestructiveCreate`
+// (single break-to-None) avoids sending two break notifications for an RH
+// dir lease — required by smbtorture rename / hardlink / setinfo /
+// unlink_*_set_and_close (same-dir, wrong/no parent-leaskey cases).
 //
 // Per Samba dirlease_should_break: ClientID is NOT used for suppression —
 // a same-client SET_INFO / WRITE / CLOSE / RENAME with a mismatched (or
 // absent) ParentLeaseKey MUST still break the parent dir lease held by that
-// same client. The smbtorture dirlease tests (setinfo, rename, hardlink,
-// unlink, v2_request) all exercise same-client scenarios where the dir
-// lease is expected to break when the parent key doesn't match.
+// same client.
 func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, openFile *OpenFile) {
 	if h.LeaseManager == nil || len(parentHandle) == 0 {
 		return
@@ -1590,11 +1606,11 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthC
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
 
-	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-		logger.Debug("SET_INFO: parent directory Handle lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
-	}
-	if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-		logger.Debug("SET_INFO: parent directory Read lease break failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
+	if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(
+		authCtx.Context, parentLockHandle, openFile.ShareName, "",
+		excludeParentKey, hasExcludeKey,
+	); breakErr != nil {
+		logger.Debug("SET_INFO: parent directory lease break-to-None failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
 	}
 }
 
@@ -1775,25 +1791,21 @@ func (h *Handler) handleFileLinkInformation(
 		return setInfoStatus(common.MapToSMB(err)), nil
 	}
 
-	// Break Handle/Read leases on the destination parent (MS-FSA 2.1.5.14:
-	// directory contents changed). Parent-key suppression only — no ClientID
-	// exclusion per Samba dirlease_should_break.
+	// Break parent directory leases on the destination parent to None
+	// (MS-FSA 2.1.5.14: directory contents changed). Parent-key suppression
+	// only — no ClientID exclusion per Samba dirlease_should_break. Single
+	// break-to-None matches Samba `contend_dirleases` / `do_dirlease_break_to_none`
+	// — required by smbtorture hardlink samedir-{wrong,no}-parent-leaskey
+	// which expect exactly one LEASE_BREAK per holder.
 	if h.LeaseManager != nil {
 		dstParentLock := lock.FileHandle(dstDir)
 		excludeParentKey := openFile.ParentLeaseKey
 		hasExcludeKey := openFile.HasParentLeaseKey
-		if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(
+		if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(
 			authCtx.Context, dstParentLock, openFile.ShareName,
 			"", excludeParentKey, hasExcludeKey,
 		); breakErr != nil {
-			logger.Debug("SET_INFO: hardlink dst-parent Handle lease break failed",
-				"dst", newPath, "error", breakErr)
-		}
-		if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(
-			authCtx.Context, dstParentLock, openFile.ShareName,
-			"", excludeParentKey, hasExcludeKey,
-		); breakErr != nil {
-			logger.Debug("SET_INFO: hardlink dst-parent Read lease break failed",
+			logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None failed",
 				"dst", newPath, "error", breakErr)
 		}
 	}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -132,28 +132,23 @@ oplock break notification delivery.
 
 Note: the four `smb2.kernel-oplocks.*` tests require Linux kernel oplock integration via `F_SETLEASE` on the underlying fd — architecturally incompatible with DittoFS's userspace virtual filesystem. They are listed in the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope) appendix.
 
-### Directory Leases (Not Implemented)
+### Directory Leases (Partial Implementation)
 
 Directory leases (dirlease) are a separate feature from file leases.
-DittoFS implements file leases (Phase 37) but not directory leases.
+DittoFS implements file leases (Phase 37) and a substantial subset of
+directory leases (see #470 PR history). Remaining failures cluster on:
+(1) same-dir rename / hardlink break/ack ordering, (2) DELETE_PENDING
+visibility on initial-DOC unlink cases.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.dirlease.hardlink | Directory Leases | Directory leases not implemented | - |
+| smb2.dirlease.hardlink | Directory Leases | samedir-wrong-parent-leaskey: break/ack ordering on single-dir hardlink | #470 |
 | smb2.dirlease.oplocks | Directory Leases | Skipped by runner — smbtorture 4.22.6 client SIGSEGVs in this subtest and aborts the rest of the dirlease suite (see run.sh) | #633 |
-| smb2.dirlease.rename | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.rename_dst_parent | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.setatime | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.setbtime | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.setctime | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.setdos | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.seteof | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.setmtime | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.unlink_different_initial_and_close | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.unlink_different_set_and_close | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.unlink_same_initial_and_close | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.unlink_same_set_and_close | Directory Leases | Directory leases not implemented | - |
-| smb2.dirlease.v2_request | Directory Leases | Directory leases not implemented | - |
+| smb2.dirlease.rename | Directory Leases | samedir-wrong-parent-leaskey: break/ack ordering on single-dir rename | #470 |
+| smb2.dirlease.unlink_different_initial_and_close | Directory Leases | DELETE_PENDING returned on second open of a file with initial DOC (delete-on-close shouldn't block reopens before actual delete) | #470 |
+| smb2.dirlease.unlink_different_set_and_close | Directory Leases | smb2_lease_break_ack returns UNSUCCESSFUL — break/ack state mismatch on last-handle delete with mismatched parent keys | #470 |
+| smb2.dirlease.unlink_same_initial_and_close | Directory Leases | DELETE_PENDING returned on second open of a file with initial DOC | #470 |
+| smb2.dirlease.v2_request | Directory Leases | SHARING_VIOLATION on requeued CREATE after dir-lease holder closes during break | #470 |
 
 ### Credit Management
 


### PR DESCRIPTION
## Summary

- Switch rename / hardlink post-mutation parent dir-lease breaks to a SINGLE `BreakParentDirLeasesOnDestructiveCreate` call (break-to-None) instead of the two-step `BreakParentHandleLeasesOnCreate` + `BreakParentReadLeasesOnModify` pattern.
- Skip the rename pre-conflict dst-parent break when src == dst (same-dir rename): the post-rename content-change break on srcParent already covers that holder.

## Why

Per Samba `contend_dirleases` / `do_dirlease_break_to_none` (`source3/smbd/smb2_oplock.c`), a directory-content change emits ONE LEASE_BREAK to None per dir-lease holder, not the two-step strip-H / strip-R pattern used for file leases. Directory leases only ever reach RH (no W bit), so the two-step pattern emitted two notifications (RH→R then R→None) where Samba emits one (RH→None).

The smbtorture `rename` / `hardlink` `samedir-wrong-parent-leaskey` and `samedir-no-parent-leaskey` cases both rename/link a file in the SAME directory the dir lease covers, with a handle whose RqLs ParentLeaseKey does NOT match the dir lease key. They expect exactly ONE break notification on `srcdir` and ZERO on `dstdir` (because `dstdir == srcdir`).

## Targeted tests

- `smb2.dirlease.rename` — `samedir-wrong-parent-leaskey`, `samedir-no-parent-leaskey` (lease.c:6778)
- `smb2.dirlease.hardlink` — `samedir-wrong-parent-leaskey`, `samedir-no-parent-leaskey` (lease.c:7280)

These flow through `breakParentDirLeasesForContentChangeOn` (rename) and the dst-parent break in `handleFileLinkInformation` (hardlink).

The `rename_dst_parent` test (already passing on develop) still passes: it always uses `otherdir-*` cases, so the same-dir guard does not affect it.

## Files touched

- `internal/adapter/smb/v2/handlers/set_info.go` — `breakParentDirLeasesForContentChangeOn`, hardlink dst-parent break, rename same-dir skip.

## Test plan

- [x] `go fmt ./... && go vet ./...` clean
- [x] `go test -race ./internal/adapter/smb/v2/... ./pkg/metadata/lock/... ./internal/adapter/smb/...` all green
- [ ] CI smbtorture: expect `smb2.dirlease.rename` + `smb2.dirlease.hardlink` to flip on memory / memory-fs / badger-fs
- [ ] No regressions in `smb2.dirlease.rename_dst_parent` / `smb2.dirlease.leases` / `smb2.dirlease.overwrite` / `smb2.dirlease.v2_request_parent` (currently passing)

## References

- MS-SMB2 §3.3.4.20 (directory-lease parent-key suppression)
- Samba `contend_dirleases` and `do_dirlease_break_to_none` in `source3/smbd/smb2_oplock.c`
- Prior #470 PRs: #626, #627, #629, #630, #631, #632, #642