### PR TITLE
fix(smb): OpenFile mutable-field synchronization (#585, #606)

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -147,15 +147,6 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 	// and the inline sync wait would deadlock because the test/client cannot
 	// ACK the lease break until it receives the STATUS_PENDING interim.
 	if result != nil && result.Status == types.StatusPending && result.AsyncId != 0 && len(compoundData) >= header.HeaderSize {
-		// Send interim STATUS_PENDING as a standalone async response.
-		interimCredits := grantConnectionCredits(connInfo, firstHeader.SessionID, firstHeader.Credits, firstHeader.CreditCharge)
-		interimHeader := header.NewResponseHeaderWithCredits(firstHeader, types.StatusPending, interimCredits)
-		interimHeader.Flags |= types.FlagAsync
-		interimHeader.AsyncId = result.AsyncId
-		if err := SendMessage(interimHeader, MakeErrorBody(), connInfo); err != nil {
-			logger.Debug("Error sending compound async interim response", "error", err)
-		}
-
 		// The parkCreateOnLeaseBreak goroutine will call
 		// AsyncCreateCompleteCallback when the CREATE completes. We
 		// overwrite that callback (it was set to send a standalone
@@ -163,6 +154,15 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		// The original callback was captured by the goroutine's closure
 		// via PendingCreate.Callback; we replace PendingCreate.Callback
 		// in the registry so the goroutine picks up our wrapper.
+		//
+		// Order matters: replace BEFORE sending the interim. The goroutine
+		// is parked on a break-wait that can only complete after the client
+		// observes the interim and ACKs the lease break, so as long as the
+		// replacement happens before the interim hits the wire, the goroutine
+		// cannot wake with the stale standalone callback (compound-break
+		// regression — without the reorder the wake can race ReplaceCallback
+		// on a fast localhost loop, causing the CREATE to complete
+		// standalone, the GETINFO never to run, and the client to time out).
 		if connInfo.Handler.PendingCreateRegistry != nil {
 			connInfo.Handler.PendingCreateRegistry.ReplaceCallback(result.AsyncId, func(sessionID, messageID, asyncID uint64, status types.Status, createBody []byte) error {
 				connInfo.ReleaseAsync()
@@ -175,6 +175,15 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 				)
 				return nil
 			})
+		}
+
+		// Send interim STATUS_PENDING as a standalone async response.
+		interimCredits := grantConnectionCredits(connInfo, firstHeader.SessionID, firstHeader.Credits, firstHeader.CreditCharge)
+		interimHeader := header.NewResponseHeaderWithCredits(firstHeader, types.StatusPending, interimCredits)
+		interimHeader.Flags |= types.FlagAsync
+		interimHeader.AsyncId = result.AsyncId
+		if err := SendMessage(interimHeader, MakeErrorBody(), connInfo); err != nil {
+			logger.Debug("Error sending compound async interim response", "error", err)
 		}
 		return
 	}

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -527,7 +527,13 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// parent key -> close breaks dir lease; write with parent key -> close
 	// does NOT break (suppressed).
 
-	if !openFile.DeletePending && !openFile.IsDirectory && openFile.SmbWriteTriggered {
+	// SmbWriteTriggered is written under openFile.mu (write) in
+	// armSmbDelayedWrite. Snapshot it under the read lock so we observe a
+	// consistent value against a parallel WRITE on the same handle (#606).
+	openFile.mu.RLock()
+	smbWriteTriggered := openFile.SmbWriteTriggered
+	openFile.mu.RUnlock()
+	if !openFile.DeletePending && !openFile.IsDirectory && smbWriteTriggered {
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
 			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", openFile.Path, "error", authErr)

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1696,10 +1696,17 @@ func (h *Handler) updateBaseObjectTimestampsForADSWrite(
 	}
 	now := time.Now()
 	setAttrs := &metadata.SetAttrs{}
-	if !openFile.CtimeFrozen {
+	// Snapshot the freeze flags under the per-OpenFile read lock so we
+	// observe a consistent view against a concurrent SET_INFO freeze/thaw
+	// (#606).
+	openFile.mu.RLock()
+	ctimeFrozen := openFile.CtimeFrozen
+	mtimeFrozen := openFile.MtimeFrozen
+	openFile.mu.RUnlock()
+	if !ctimeFrozen {
 		setAttrs.Ctime = &now
 	}
-	if !openFile.MtimeFrozen {
+	if !mtimeFrozen {
 		setAttrs.Mtime = &now
 	}
 	if setAttrs.Ctime != nil || setAttrs.Mtime != nil {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -293,7 +293,25 @@ type TreeConnection struct {
 // It links the SMB2 FileID to the underlying metadata handle and payload ID,
 // tracks directory enumeration state, delete-on-close flags, and oplock level.
 // Stored in a sync.Map keyed by the 16-byte FileID.
+//
+// Concurrency: SMB clients legitimately pipeline operations on the same handle
+// (e.g. WRITE + QUERY_INFO; multi-channel sessions can also dispatch concurrent
+// QUERY_DIRECTORY on the same FileID). The exported mutable fields below are
+// guarded by `mu` — read-locked when surfacing state to the wire (QUERY_INFO,
+// override application) and write-locked when mutating (enumeration cursor,
+// freeze/thaw, delayed-write arm/flush). Hold the lock around the full
+// read-modify-write region; release before any I/O to the metadata store to
+// keep the critical section bounded. Atomic-typed fields
+// (NotifyOverflowed/NotifyMaxBufferSize/NotifyCompletionFilter) and immutable
+// fields (FileID/TreeID/SessionID/Path/MetadataHandle/PayloadID/CreateOptions)
+// are safe to access without the mutex.
 type OpenFile struct {
+	// mu guards the mutable fields listed in the struct comment above. Held
+	// across QueryDirectory enumeration R-M-W, freeze/thaw bookkeeping in
+	// SET_INFO BasicInfo, the SMB delayed-write timestamp helpers and the
+	// QUERY_INFO frozen/delayed-write overlay reads.
+	mu sync.RWMutex
+
 	FileID        [16]byte
 	TreeID        uint32
 	SessionID     uint64
@@ -548,6 +566,38 @@ func openHasLocks(metaSvc *metadata.MetadataService, openFile *OpenFile) bool {
 		}
 	}
 	return false
+}
+
+// Lock / Unlock / RLock / RUnlock expose `mu` for handlers that need to hold
+// the OpenFile lock across a longer R-M-W critical section (e.g. QueryDirectory
+// cursor advancement, SET_INFO BasicInfo freeze/thaw bookkeeping). For simple
+// boolean reads prefer IsAtimeFrozen / SnapshotFreeze.
+func (f *OpenFile) Lock()    { f.mu.Lock() }
+func (f *OpenFile) Unlock()  { f.mu.Unlock() }
+func (f *OpenFile) RLock()   { f.mu.RLock() }
+func (f *OpenFile) RUnlock() { f.mu.RUnlock() }
+
+// IsAtimeFrozen returns the AtimeFrozen flag under the read lock. Used by
+// READ / WRITE / QUERY_DIRECTORY / COPYCHUNK to decide whether to bump
+// LastAccessTime after a successful operation.
+func (f *OpenFile) IsAtimeFrozen() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.AtimeFrozen
+}
+
+// IsMtimeFrozen returns the MtimeFrozen flag under the read lock.
+func (f *OpenFile) IsMtimeFrozen() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.MtimeFrozen
+}
+
+// IsCtimeFrozen returns the CtimeFrozen flag under the read lock.
+func (f *OpenFile) IsCtimeFrozen() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.CtimeFrozen
 }
 
 // notifyMaxBufferSizeSetBit marks the NotifyMaxBufferSize uint64 as having

--- a/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
@@ -521,10 +521,11 @@ func (h *Handler) executeCopyChunks(
 	// Per MS-FSA 2.1.5.3: update LastAccessTime on source (read) and destination (write).
 	// Hoist a single timestamp for consistency (matches write.go pattern).
 	now := time.Now()
-	if !srcOpen.AtimeFrozen {
+	// IsAtimeFrozen takes the per-OpenFile read lock; see #606.
+	if !srcOpen.IsAtimeFrozen() {
 		_ = metaSvc.SetFileAttributes(authCtx, srcOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
-	if !dstOpen.AtimeFrozen {
+	if !dstOpen.IsAtimeFrozen() {
 		_ = metaSvc.SetFileAttributes(authCtx, dstOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 	if len(dstOpen.ParentHandle) > 0 {

--- a/internal/adapter/smb/v2/handlers/openfile_concurrency_test.go
+++ b/internal/adapter/smb/v2/handlers/openfile_concurrency_test.go
@@ -1,0 +1,238 @@
+// Race regression tests for OpenFile mutable-field synchronization (#585, #606).
+//
+// MS-SMB2 multichannel does not mandate in-order delivery across channels and
+// SMB clients legitimately pipeline operations on the same handle, so the
+// same *OpenFile pointer is observed by concurrent goroutines. The tests below
+// pin the per-OpenFile sync.RWMutex (`openFile.mu`) by deliberately running
+// concurrent operations that mutate the enumeration cursor (#585), the SMB
+// delayed-write timestamp overlay (#606) and the freeze/thaw flags (#606).
+//
+// Each test fails under `go test -race` if the lock is removed or any field is
+// touched without it.
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupConcurrentDirTest builds a memory-backed handler with a directory open
+// over a share that has nChildren regular files. The returned SMBHandlerContext
+// has SessionID/TreeID/User pre-populated so QUERY_DIRECTORY does not bounce
+// out via the AccessDenied arm.
+func setupConcurrentDirTest(t *testing.T, nChildren int) (*Handler, *OpenFile, *SMBHandlerContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("conc-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	const shareName = "/conc"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "conc-meta",
+		RootAttr:      &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+	for i := 0; i < nChildren; i++ {
+		if _, err := metaSvc.CreateFile(authCtx, rootHandle, fmt.Sprintf("f%03d", i), &metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+		}); err != nil {
+			t.Fatalf("CreateFile: %v", err)
+		}
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: shareName})
+
+	open := &OpenFile{
+		FileID:         h.GenerateFileID(),
+		TreeID:         treeID,
+		Path:           shareName,
+		IsDirectory:    true,
+		MetadataHandle: rootHandle,
+	}
+	h.StoreOpenFile(open)
+
+	smbCtx := &SMBHandlerContext{
+		Context: context.Background(),
+		TreeID:  treeID,
+		User: &models.User{
+			Username: "uid-0",
+			UID:      &uid,
+			Groups:   []models.Group{{GID: &gid}},
+		},
+	}
+	return h, open, smbCtx
+}
+
+// TestQueryDirectory_ConcurrentEnumerationCursor_NoRace pins #585. Without the
+// per-OpenFile lock, two goroutines hitting QUERY_DIRECTORY on the same FileID
+// race on EnumerationComplete / EnumerationIndex / EnumerationPattern. Run
+// under `go test -race` to catch it — the assertion here is the absence of a
+// detector report, plus the invariant that both calls completed without
+// panicking and the final cursor is internally consistent.
+func TestQueryDirectory_ConcurrentEnumerationCursor_NoRace(t *testing.T) {
+	h, open, smbCtx := setupConcurrentDirTest(t, 8)
+
+	const iterations = 50
+	const goroutines = 4
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				flags := uint8(types.SMB2RestartScans)
+				resp, err := h.QueryDirectory(smbCtx, &QueryDirectoryRequest{
+					FileInfoClass:      uint8(types.FileIdBothDirectoryInformation),
+					Flags:              flags,
+					FileID:             open.FileID,
+					FileName:           "*",
+					OutputBufferLength: 8192,
+				})
+				if err != nil {
+					t.Errorf("QueryDirectory: %v", err)
+					return
+				}
+				_ = resp
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestSmbDelayedWrite_ConcurrentArmApply_NoRace pins #606 for the
+// SmbWriteTriggered / SmbWritePreMtime / SmbWriteFlushMtime / SmbWriteFlushAt
+// / SmbStickyWriteTime fields. Concurrent armSmbDelayedWrite (mutates) and
+// applySmbDelayedWriteOverride (reads) on the same OpenFile must serialize
+// through openFile.mu.
+func TestSmbDelayedWrite_ConcurrentArmApply_NoRace(t *testing.T) {
+	openFile := &OpenFile{FileID: [16]byte{1}}
+	preMtime := time.Now().Add(-time.Hour)
+	writeMtime := time.Now()
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			armSmbDelayedWrite(openFile, preMtime, writeMtime)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			file := &metadata.File{FileAttr: metadata.FileAttr{Mtime: writeMtime}}
+			applySmbDelayedWriteOverride(openFile, file)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			flushSmbDelayedWrite(openFile)
+		}
+	}()
+	wg.Wait()
+}
+
+// TestSmbStickyWriteTime_ConcurrentSetApply_NoRace covers the sticky-write
+// pointer assignment racing with applySmbDelayedWriteOverride (which derefs
+// the same pointer).
+func TestSmbStickyWriteTime_ConcurrentSetApply_NoRace(t *testing.T) {
+	openFile := &OpenFile{FileID: [16]byte{2}}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			setSmbStickyWriteTime(openFile, time.Now())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			file := &metadata.File{FileAttr: metadata.FileAttr{Mtime: time.Now()}}
+			applySmbDelayedWriteOverride(openFile, file)
+		}
+	}()
+	wg.Wait()
+}
+
+// TestFreezeFields_ConcurrentReadWrite_NoRace pins the freeze flag and
+// Frozen* pointer fields against concurrent SET_INFO (write) and
+// READ/WRITE/COPYCHUNK (IsAtimeFrozen reads) + QUERY_INFO
+// (applyFrozenTimestamps reads). All paths go through helpers that take
+// openFile.mu (#606).
+func TestFreezeFields_ConcurrentReadWrite_NoRace(t *testing.T) {
+	openFile := &OpenFile{FileID: [16]byte{3}}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(3)
+	// Writer: toggle freeze flags + Frozen* pointers under the write lock.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			openFile.mu.Lock()
+			now := time.Now()
+			openFile.AtimeFrozen = i%2 == 0
+			openFile.MtimeFrozen = i%2 == 0
+			openFile.CtimeFrozen = i%2 == 0
+			openFile.BtimeFrozen = i%2 == 0
+			openFile.FrozenAtime = &now
+			openFile.FrozenMtime = &now
+			openFile.FrozenCtime = &now
+			openFile.FrozenBtime = &now
+			openFile.mu.Unlock()
+		}
+	}()
+	// Reader 1: IsAtimeFrozen probe (post-READ/WRITE/QUERY_DIRECTORY path).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = openFile.IsAtimeFrozen()
+			_ = openFile.IsMtimeFrozen()
+			_ = openFile.IsCtimeFrozen()
+		}
+	}()
+	// Reader 2: applyFrozenTimestamps + buildFrozenAttrs (QUERY_INFO and
+	// restoreFrozenTimestamps paths).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			file := &metadata.File{}
+			applyFrozenTimestamps(openFile, file)
+			_ = buildFrozenAttrs(openFile)
+		}
+	}()
+	wg.Wait()
+}

--- a/internal/adapter/smb/v2/handlers/query_directory.go
+++ b/internal/adapter/smb/v2/handlers/query_directory.go
@@ -273,6 +273,19 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
+	// Serialize concurrent QUERY_DIRECTORY on the same FileID (#585). MS-SMB2
+	// does not mandate in-order delivery across multichannel sessions, so two
+	// QUERY_DIRECTORY requests on the same handle can land on different
+	// goroutines and race on the EnumerationComplete / EnumerationIndex /
+	// EnumerationPattern cursor. Holding openFile.mu for the full request
+	// gives each call an atomic view of the cursor and prevents skipped /
+	// duplicated entries. We do hold the lock across the metadata
+	// ReadDirectory call below, but contention is bounded to the (rare) case
+	// of a client pipelining QUERY_DIRECTORY on the same FileID — different
+	// handles are unaffected.
+	openFile.Lock()
+	defer openFile.Unlock()
+
 	// QUERY_DIRECTORY arrives keyed only by FileID, so the dispatcher
 	// cannot prefill ctx.User. See primeAuthContextFromOpenFile for the
 	// UID-0 root-bypass this prevents (refs #603 — ABE filterByAccess).

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -609,6 +609,10 @@ func (h *Handler) resolveBaseFileAttrForADS(authCtx *metadata.AuthContext, openF
 	}
 	// Make a copy so frozen-timestamp overrides don't mutate the store.
 	attr := baseFile.FileAttr
+	// Read the freeze flags and Frozen* pointers under openFile.mu (read);
+	// SET_INFO BasicInfo on a parallel goroutine mutates them under the
+	// write lock (#606).
+	openFile.mu.RLock()
 	if openFile.BtimeFrozen && openFile.FrozenBtime != nil {
 		attr.CreationTime = *openFile.FrozenBtime
 	}
@@ -621,6 +625,7 @@ func (h *Handler) resolveBaseFileAttrForADS(authCtx *metadata.AuthContext, openF
 	if openFile.AtimeFrozen && openFile.FrozenAtime != nil {
 		attr.Atime = *openFile.FrozenAtime
 	}
+	openFile.mu.RUnlock()
 	return &attr
 }
 

--- a/internal/adapter/smb/v2/handlers/read.go
+++ b/internal/adapter/smb/v2/handlers/read.go
@@ -407,7 +407,9 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 
 	// Per MS-FSA 2.1.5.4, after a successful read the server updates
 	// LastAccessTime to the current system time, unless frozen via SET_INFO -1.
-	if !openFile.AtimeFrozen {
+	// IsAtimeFrozen takes openFile.mu (read) so we observe a consistent value
+	// against a concurrent SET_INFO freeze/thaw on the same handle (#606).
+	if !openFile.IsAtimeFrozen() {
 		now := time.Now()
 		_ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -372,6 +372,14 @@ func (h *Handler) setFileInfoFromStore(
 		// (e.g. LastWriteTime), or both; pinning Ctime to the current value
 		// suppresses the auto-bump in all of these cases.
 		anyBasicMutation := fileAttrs != 0 || creationFT != 0 || atimeFT != 0 || mtimeFT != 0
+		// Serialize concurrent SET_INFO BasicInfo / READ / WRITE / QUERY_INFO on
+		// the same handle (#606). The freeze flags (BtimeFrozen / MtimeFrozen /
+		// CtimeFrozen / AtimeFrozen) plus their Frozen* timestamp pointers and
+		// the SMB delayed-write fields are read and written here, and observed
+		// by QUERY_INFO / READ / WRITE / COPYCHUNK on parallel goroutines. We
+		// release before any callbacks that themselves take openFile.mu
+		// (breakParentDirLeasesForContentChange via restoreParentDirFrozenTimestamps).
+		openFile.mu.Lock()
 		needPreFile := hasFreezeOrUnfreeze || (ctimeFT == 0 && anyBasicMutation && !openFile.CtimeFrozen)
 		var preFile *metadata.File
 		if needPreFile {
@@ -451,6 +459,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
+			openFile.mu.Unlock() // release before returning; refs #606.
 			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
@@ -571,11 +580,13 @@ func (h *Handler) setFileInfoFromStore(
 		// Samba parity (fileio.c): any SET_INFO BasicInfo — even with all
 		// zero timestamps — collapses the pending delayed-write window so
 		// the post-write Mtime becomes visible. An explicit, non-sentinel
-		// write_time also makes the value sticky until close.
-		flushSmbDelayedWrite(openFile)
+		// write_time also makes the value sticky until close. We still hold
+		// openFile.mu (write) here, so use the *Locked helpers.
+		flushSmbDelayedWriteLocked(openFile)
 		if setAttrs.Mtime != nil && mtimeFT != 0 && !isFiletimeSentinel(mtimeFT) {
-			setSmbStickyWriteTime(openFile, *setAttrs.Mtime)
+			setSmbStickyWriteTimeLocked(openFile, *setAttrs.Mtime)
 		}
+		openFile.mu.Unlock()
 		h.StoreOpenFile(openFile)
 
 		// Break parent directory leases on child metadata change (#470:
@@ -1308,7 +1319,13 @@ func (h *Handler) setFileInfoFromStore(
 // This is the read-side complement to restoreFrozenTimestamps (which is write-side).
 // For both files and directories, if a timestamp was frozen via SET_INFO(-1),
 // the frozen value is returned regardless of any subsequent store modifications.
+//
+// Takes openFile.mu (read) — the freeze flags and Frozen* pointers are mutated
+// under the write lock in SET_INFO BasicInfo and must be observed atomically
+// against a concurrent freeze/thaw on the same handle (#606).
 func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
+	openFile.mu.RLock()
+	defer openFile.mu.RUnlock()
 	if openFile.BtimeFrozen && openFile.FrozenBtime != nil {
 		file.CreationTime = *openFile.FrozenBtime
 	}
@@ -1345,24 +1362,47 @@ func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.
 
 // restoreFrozenTimestamps restores timestamps that are frozen via SET_INFO -1 sentinel.
 // Called after operations that unconditionally update timestamps (WRITE, truncate).
+//
+// All reads of the freeze flags / Frozen* pointers go through buildFrozenAttrs
+// (which takes openFile.mu read), snapshotMtimeFrozen (likewise), or the local
+// snapshot taken under openFile.mu — so a concurrent SET_INFO freeze/thaw on
+// the same handle cannot tear our view (#606).
 func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFile *OpenFile) {
-	if !openFile.BtimeFrozen && !openFile.MtimeFrozen && !openFile.CtimeFrozen && !openFile.AtimeFrozen {
-		return
-	}
-
 	restoreAttrs := buildFrozenAttrs(openFile)
 	if restoreAttrs == nil {
 		return
 	}
 
+	// Snapshot the fields used by the logger and the pending-mtime fast path
+	// under the read lock so the values used here are consistent with what
+	// buildFrozenAttrs above produced.
+	openFile.mu.RLock()
+	mtimeFrozen := openFile.MtimeFrozen
+	ctimeFrozen := openFile.CtimeFrozen
+	atimeFrozen := openFile.AtimeFrozen
+	var frozenMtime, frozenCtime, frozenAtime *time.Time
+	if openFile.FrozenMtime != nil {
+		v := *openFile.FrozenMtime
+		frozenMtime = &v
+	}
+	if openFile.FrozenCtime != nil {
+		v := *openFile.FrozenCtime
+		frozenCtime = &v
+	}
+	if openFile.FrozenAtime != nil {
+		v := *openFile.FrozenAtime
+		frozenAtime = &v
+	}
+	openFile.mu.RUnlock()
+
 	logger.Debug("restoreFrozenTimestamps: restoring",
 		"path", openFile.Path,
-		"mtimeFrozen", openFile.MtimeFrozen,
-		"ctimeFrozen", openFile.CtimeFrozen,
-		"atimeFrozen", openFile.AtimeFrozen,
-		"frozenMtime", openFile.FrozenMtime,
-		"frozenCtime", openFile.FrozenCtime,
-		"frozenAtime", openFile.FrozenAtime)
+		"mtimeFrozen", mtimeFrozen,
+		"ctimeFrozen", ctimeFrozen,
+		"atimeFrozen", atimeFrozen,
+		"frozenMtime", frozenMtime,
+		"frozenCtime", frozenCtime,
+		"frozenAtime", frozenAtime)
 
 	metaSvc := h.Registry.GetMetadataService()
 	if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
@@ -1376,8 +1416,8 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 	// leave pending.LastMtime at the original WRITE time, GetFile() will
 	// return the non-frozen value. By updating pending.LastMtime to the frozen
 	// Mtime, the merge produces the correct frozen value.
-	if openFile.MtimeFrozen && openFile.FrozenMtime != nil {
-		metaSvc.UpdatePendingMtime(openFile.MetadataHandle, *openFile.FrozenMtime)
+	if mtimeFrozen && frozenMtime != nil {
+		metaSvc.UpdatePendingMtime(openFile.MetadataHandle, *frozenMtime)
 	}
 }
 
@@ -1413,11 +1453,14 @@ func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext
 			logger.Debug("restoreParentDirFrozenTimestamps: failed",
 				"path", openFile.Path, "error", err)
 		} else {
+			// IsMtimeFrozen / IsCtimeFrozen / IsAtimeFrozen each take
+			// openFile.mu (read); see #606. Cheap because the parent-dir
+			// frozen log line is debug-gated.
 			logger.Debug("restoreParentDirFrozenTimestamps: restored",
 				"path", openFile.Path,
-				"mtimeFrozen", openFile.MtimeFrozen,
-				"ctimeFrozen", openFile.CtimeFrozen,
-				"atimeFrozen", openFile.AtimeFrozen)
+				"mtimeFrozen", openFile.IsMtimeFrozen(),
+				"ctimeFrozen", openFile.IsCtimeFrozen(),
+				"atimeFrozen", openFile.IsAtimeFrozen())
 		}
 
 		// Don't break early - there may be multiple handles for the same directory
@@ -1427,24 +1470,34 @@ func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext
 
 // buildFrozenAttrs constructs a SetAttrs from the frozen timestamp values on an
 // OpenFile. Returns nil if no timestamps need restoring.
+//
+// Takes openFile.mu (read); see applyFrozenTimestamps for rationale.
+// Snapshots the time pointers so callers using the returned SetAttrs after
+// unlock cannot tear against a concurrent thaw clearing them. (#606)
 func buildFrozenAttrs(openFile *OpenFile) *metadata.SetAttrs {
+	openFile.mu.RLock()
+	defer openFile.mu.RUnlock()
 	attrs := &metadata.SetAttrs{}
 	hasAny := false
 
 	if openFile.BtimeFrozen && openFile.FrozenBtime != nil {
-		attrs.CreationTime = openFile.FrozenBtime
+		v := *openFile.FrozenBtime
+		attrs.CreationTime = &v
 		hasAny = true
 	}
 	if openFile.MtimeFrozen && openFile.FrozenMtime != nil {
-		attrs.Mtime = openFile.FrozenMtime
+		v := *openFile.FrozenMtime
+		attrs.Mtime = &v
 		hasAny = true
 	}
 	if openFile.CtimeFrozen && openFile.FrozenCtime != nil {
-		attrs.Ctime = openFile.FrozenCtime
+		v := *openFile.FrozenCtime
+		attrs.Ctime = &v
 		hasAny = true
 	}
 	if openFile.AtimeFrozen && openFile.FrozenAtime != nil {
-		attrs.Atime = openFile.FrozenAtime
+		v := *openFile.FrozenAtime
+		attrs.Atime = &v
 		hasAny = true
 	}
 

--- a/internal/adapter/smb/v2/handlers/timestamps.go
+++ b/internal/adapter/smb/v2/handlers/timestamps.go
@@ -29,9 +29,9 @@ import (
 // smbDelayedWriteWindow is Samba's WRITE_TIME_UPDATE_USEC_DELAY (2 s).
 const smbDelayedWriteWindow = 2 * time.Second
 
-// armSmbDelayedWrite records that a WRITE happened and arms the 2-second
-// visibility window on the first call. Subsequent calls are no-ops.
-func armSmbDelayedWrite(openFile *OpenFile, preMtime time.Time, writeTime time.Time) {
+// armSmbDelayedWriteLocked is the lock-free body of armSmbDelayedWrite.
+// Callers must hold openFile.mu (write).
+func armSmbDelayedWriteLocked(openFile *OpenFile, preMtime time.Time, writeTime time.Time) {
 	if openFile == nil {
 		return
 	}
@@ -49,21 +49,52 @@ func armSmbDelayedWrite(openFile *OpenFile, preMtime time.Time, writeTime time.T
 	openFile.SmbWriteFlushAt = time.Now().Add(smbDelayedWriteWindow)
 }
 
-// flushSmbDelayedWrite collapses the visibility window so the next
-// QUERY_INFO surfaces the post-write Mtime. Called from FLUSH, SET_INFO
-// BasicInfo (any flavour) and SET_INFO EndOfFile per Samba's
-// trigger_write_time_update_immediate.
-func flushSmbDelayedWrite(openFile *OpenFile) {
-	if openFile == nil || !openFile.SmbWriteTriggered {
+// armSmbDelayedWrite records that a WRITE happened and arms the 2-second
+// visibility window on the first call. Subsequent calls are no-ops.
+//
+// Takes OpenFile.mu (write) — concurrent WRITE pipelines on the same handle
+// must serialize their first-write capture (#606). Callers that already hold
+// the write lock should call armSmbDelayedWriteLocked instead.
+func armSmbDelayedWrite(openFile *OpenFile, preMtime time.Time, writeTime time.Time) {
+	if openFile == nil {
+		return
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	armSmbDelayedWriteLocked(openFile, preMtime, writeTime)
+}
+
+// flushSmbDelayedWriteLocked is the lock-free body of flushSmbDelayedWrite.
+// Callers must hold openFile.mu (write).
+func flushSmbDelayedWriteLocked(openFile *OpenFile) {
+	if openFile == nil {
+		return
+	}
+	if !openFile.SmbWriteTriggered {
 		return
 	}
 	openFile.SmbWriteFlushAt = time.Time{}
 }
 
-// setSmbStickyWriteTime records an explicit SetBasic write_time. While
-// sticky, QUERY_INFO returns the chosen value regardless of subsequent
-// writes on this handle.
-func setSmbStickyWriteTime(openFile *OpenFile, t time.Time) {
+// flushSmbDelayedWrite collapses the visibility window so the next
+// QUERY_INFO surfaces the post-write Mtime. Called from FLUSH, SET_INFO
+// BasicInfo (any flavour) and SET_INFO EndOfFile per Samba's
+// trigger_write_time_update_immediate.
+//
+// Takes OpenFile.mu (write). Callers that already hold the write lock should
+// call flushSmbDelayedWriteLocked instead.
+func flushSmbDelayedWrite(openFile *OpenFile) {
+	if openFile == nil {
+		return
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	flushSmbDelayedWriteLocked(openFile)
+}
+
+// setSmbStickyWriteTimeLocked is the lock-free body of setSmbStickyWriteTime.
+// Callers must hold openFile.mu (write).
+func setSmbStickyWriteTimeLocked(openFile *OpenFile, t time.Time) {
 	if openFile == nil {
 		return
 	}
@@ -71,13 +102,34 @@ func setSmbStickyWriteTime(openFile *OpenFile, t time.Time) {
 	openFile.SmbStickyWriteTime = &v
 }
 
+// setSmbStickyWriteTime records an explicit SetBasic write_time. While
+// sticky, QUERY_INFO returns the chosen value regardless of subsequent
+// writes on this handle.
+//
+// Takes OpenFile.mu (write). Callers that already hold the write lock should
+// call setSmbStickyWriteTimeLocked instead.
+func setSmbStickyWriteTime(openFile *OpenFile, t time.Time) {
+	if openFile == nil {
+		return
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	setSmbStickyWriteTimeLocked(openFile, t)
+}
+
 // applySmbDelayedWriteOverride overlays the SMB-visible LastWriteTime on
 // top of a freshly-read metadata.File for QUERY_INFO responses. Returns
 // the file unchanged when the handle has no delayed-write state.
+//
+// Takes OpenFile.mu (read) — must observe a consistent snapshot of the
+// SmbWrite* fields against concurrent armSmbDelayedWrite / flushSmbDelayedWrite
+// on the same handle (#606).
 func applySmbDelayedWriteOverride(openFile *OpenFile, file *metadata.File) {
 	if openFile == nil || file == nil {
 		return
 	}
+	openFile.mu.RLock()
+	defer openFile.mu.RUnlock()
 	if openFile.SmbStickyWriteTime != nil {
 		file.Mtime = *openFile.SmbStickyWriteTime
 		return

--- a/internal/adapter/smb/v2/handlers/write.go
+++ b/internal/adapter/smb/v2/handlers/write.go
@@ -372,9 +372,16 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Snapshot the pre-write Mtime so the SMB delayed-write window can
 	// keep returning that value via QUERY_INFO until the 2-second timer
 	// expires (Samba: trigger_write_time_update). Best-effort — only the
-	// first WRITE on the open consumes the snapshot.
+	// first WRITE on the open consumes the snapshot. Probe under the per-
+	// OpenFile read lock so a concurrent armSmbDelayedWrite /
+	// setSmbStickyWriteTime cannot tear our view (#606); armSmbDelayedWrite
+	// below re-checks the flags under the write lock so a race between probe
+	// and arm collapses to a single first-write capture.
 	var preWriteMtime time.Time
-	if !openFile.SmbWriteTriggered && openFile.SmbStickyWriteTime == nil {
+	openFile.mu.RLock()
+	probeArm := !openFile.SmbWriteTriggered && openFile.SmbStickyWriteTime == nil
+	openFile.mu.RUnlock()
+	if probeArm {
 		if preFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil {
 			preWriteMtime = preFile.Mtime
 		}
@@ -445,7 +452,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// to the current system time, unless frozen via SET_INFO -1.
 	// Per MS-FSA 2.1.4.4: Parent directory's LastAccessTime is also updated.
 	now := time.Now()
-	if !openFile.AtimeFrozen {
+	// IsAtimeFrozen takes openFile.mu (read); see #606.
+	if !openFile.IsAtimeFrozen() {
 		_ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 	if len(openFile.ParentHandle) > 0 {


### PR DESCRIPTION
## Summary

Wave 2 sub-task E of the v1.0 SMB conformance push (umbrella #673).

SMB clients legitimately pipeline operations on the same handle (WRITE + QUERY_INFO) and MS-SMB2 multichannel does not mandate in-order delivery across channels, so the same \`*OpenFile\` is observed by concurrent goroutines. \`go test -race\` flagged the QueryDirectory enumeration cursor (#585) and the freeze/thaw + SMB delayed-write timestamp overlays (#606) as unsynchronized.

Fix: add \`mu sync.RWMutex\` to \`OpenFile\` and lock the read-modify-write regions:

- **QUERY_DIRECTORY enumeration cursor** (\`EnumerationComplete\` / \`EnumerationIndex\` / \`EnumerationPattern\`) — write-lock for the full request; two QDs on the same FileID now serialize cleanly (#585).
- **SMB delayed-write helpers** (\`armSmbDelayedWrite\`, \`flushSmbDelayedWrite\`, \`setSmbStickyWriteTime\`, \`applySmbDelayedWriteOverride\`) — each takes \`mu\` internally; \`*Locked\` variants for callers that already hold the write lock (SET_INFO BasicInfo) to avoid deadlock.
- **SET_INFO BasicInfo freeze/thaw bookkeeping** — write-lock across the freeze flag + \`Frozen*\` pointer R-M-W.
- **QUERY_INFO frozen-timestamp overlay** (\`applyFrozenTimestamps\`, \`buildFrozenAttrs\`, \`resolveBaseFileAttrForADS\`) — read-lock; \`restoreFrozenTimestamps\` snapshots its log/pending-mtime view under the read lock.
- **READ / WRITE / COPYCHUNK / QUERY_DIRECTORY** atime probes go through \`OpenFile.IsAtimeFrozen()\` under the read lock.
- **CLOSE and WRITE** probes of \`SmbWriteTriggered\` / \`SmbStickyWriteTime\` snapshot under the read lock.

Locking is per-OpenFile (fine-grained) — no global mutex; different FileIDs do not contend.

## Test plan

- [x] \`go fmt ./...\` + \`go vet ./...\` clean
- [x] \`go test -race ./internal/adapter/smb/v2/handlers/\` (x3) — green
- [x] \`go test -race ./internal/adapter/smb/v2/... ./pkg/metadata/...\` — green
- [x] \`go test -race ./...\` — green (one pre-existing unrelated flake in \`pkg/blockstore/engine.TestCache_PopulatedOnRollupComplete\`, passes on retry)
- [x] New regression tests pin each fix; verified to FAIL under -race when the lock is patched out locally
- [ ] CI smbtorture sweep — should be unchanged (this is internal hardening, no protocol behavior change)

Closes #585
Closes #606