### PR TITLE
fix(smb/create): advanced wire validation gates (#480)

### DIFF
--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -118,6 +118,12 @@ const (
 	// StatusInsufficientResources indicates server lacks resources.
 	StatusInsufficientResources Status = 0xC000009A
 
+	// StatusBadImpersonationLevel indicates the CREATE request supplied an
+	// impersonation level outside the four defined values (Anonymous,
+	// Identification, Impersonation, Delegate) per MS-SMB2 §2.2.13. Required
+	// by smbtorture smb2.create.impersonation.
+	StatusBadImpersonationLevel Status = 0xC00000A5
+
 	// StatusFileIsADirectory indicates a file operation was attempted on a directory.
 	StatusFileIsADirectory Status = 0xC00000BA
 
@@ -266,6 +272,8 @@ func (s Status) String() string {
 		return "STATUS_INTERNAL_ERROR"
 	case StatusInsufficientResources:
 		return "STATUS_INSUFFICIENT_RESOURCES"
+	case StatusBadImpersonationLevel:
+		return "STATUS_BAD_IMPERSONATION_LEVEL"
 	case StatusRequestNotAccepted:
 		return "STATUS_REQUEST_NOT_ACCEPTED"
 	case StatusLogonFailure:

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -489,6 +489,77 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
+	// TWrp (SMB2_CREATE_TIMEWARP_TOKEN, MS-SMB2 §2.2.13.2.7) requests a
+	// previous-version (snapshot) view of the share. DittoFS has no VSS-style
+	// snapshot backend wired into CREATE, so any non-zero snapshot timestamp
+	// MUST return STATUS_OBJECT_NAME_NOT_FOUND — the requested snapshot does
+	// not exist. Required by smbtorture smb2.create.blob ("Testing timewarp").
+	if twrp := FindCreateContext(req.CreateContexts, "TWrp"); twrp != nil {
+		logger.Debug("CREATE: TWrp (previous version) requested — no snapshot backend",
+			"filename", req.FileName,
+			"dataLen", len(twrp.Data))
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameNotFound}}, nil
+	}
+
+	// Validate ImpersonationLevel per MS-SMB2 §2.2.13: only the four defined
+	// values are accepted (0=Anonymous, 1=Identification, 2=Impersonation,
+	// 3=Delegate). Anything else MUST be rejected with
+	// STATUS_BAD_IMPERSONATION_LEVEL. Required by smbtorture
+	// smb2.create.impersonation.
+	if req.ImpersonationLevel > 3 {
+		logger.Debug("CREATE: invalid impersonation level",
+			"level", fmt.Sprintf("0x%08x", req.ImpersonationLevel))
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusBadImpersonationLevel}}, nil
+	}
+
+	// Validate reserved bits in CreateOptions per MS-SMB2 §2.2.13. The upper
+	// byte (bits 24-31) is reserved and MUST be zero; any non-zero reserved
+	// bit returns STATUS_INVALID_PARAMETER. Samba sets `invalid_parameter_mask
+	// = 0xff000000` in source3/smbd/smb2_create.c for these probes (smbtorture
+	// smb2.create.gentest).
+	if uint32(req.CreateOptions)&0xff000000 != 0 {
+		logger.Debug("CREATE: reserved CreateOptions bits set",
+			"options", fmt.Sprintf("0x%08x", uint32(req.CreateOptions)))
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
+	}
+
+	// Per MS-SMB2 §2.2.13 + MS-FSCC §2.6, three CreateOptions bits are defined
+	// by the spec but unimplemented in DittoFS and MUST return STATUS_NOT_SUPPORTED
+	// rather than silently succeed. Samba sets `not_supported_mask = 0x00102080`
+	// for these probes (smbtorture smb2.create.gentest):
+	//   bit 7  (0x00000080) FILE_COMPLETE_IF_OPLOCKED — oplock-conditional open
+	//   bit 13 (0x00002000) FILE_OPEN_BY_FILE_ID    — open by FileId reference
+	//   bit 20 (0x00100000) FILE_OPEN_REQUIRING_OPLOCK — atomic open+oplock grant
+	const unsupportedCreateOptionsMask uint32 = 0x00102080
+	if uint32(req.CreateOptions)&unsupportedCreateOptionsMask != 0 {
+		logger.Debug("CREATE: unsupported CreateOptions bits set",
+			"options", fmt.Sprintf("0x%08x", uint32(req.CreateOptions)))
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported}}, nil
+	}
+
+	// Validate FileAttributes per MS-FSCC §2.6 and MS-SMB2 §2.2.13. Only the
+	// attributes defined for files/directories are accepted on CREATE; the
+	// reserved/volume/device bits MUST be rejected with STATUS_INVALID_PARAMETER.
+	// Samba's `invalid_parameter_mask = 0xffff8048` covers everything outside
+	// the legal mask `0x00007fb7` (smbtorture smb2.create.gentest).
+	//
+	// Legal attributes on CREATE (MS-FSCC §2.6 + Samba `samba_dir_attribs`):
+	//   READONLY (0x1)         HIDDEN (0x2)          SYSTEM (0x4)
+	//   DIRECTORY (0x10)       ARCHIVE (0x20)        NORMAL (0x80)
+	//   TEMPORARY (0x100)      SPARSE_FILE (0x200)   REPARSE_POINT (0x400)
+	//   COMPRESSED (0x800)     OFFLINE (0x1000)      NOT_CONTENT_INDEXED (0x2000)
+	//   ENCRYPTED (0x4000)
+	//
+	// Mask = 0x00007FB7 (0x1|0x2|0x4|0x10|0x20|0x80|0x100|0x200|0x400|0x800|
+	//                    0x1000|0x2000|0x4000). Bit 0x8 (FILE_ATTRIBUTE_VOLUME)
+	// and 0x40 (FILE_ATTRIBUTE_DEVICE) are reserved-on-the-wire and rejected.
+	const validFileAttributesMask uint32 = 0x00007FB7
+	if uint32(req.FileAttributes)&^validFileAttributesMask != 0 {
+		logger.Debug("CREATE: invalid FileAttributes bits set",
+			"attrs", fmt.Sprintf("0x%08x", uint32(req.FileAttributes)))
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
+	}
+
 	// ========================================================================
 	// Step 2: Check for IPC$ named pipe operations
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -547,20 +547,19 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// Validate FileAttributes per MS-FSCC §2.6 and MS-SMB2 §2.2.13. Only the
 	// attributes defined for files/directories are accepted on CREATE; the
 	// reserved/volume/device bits MUST be rejected with STATUS_INVALID_PARAMETER.
-	// Samba's `invalid_parameter_mask = 0xffff8048` covers everything outside
-	// the legal mask `0x00007fb7` (smbtorture smb2.create.gentest).
 	//
-	// Legal attributes on CREATE (MS-FSCC §2.6 + Samba `samba_dir_attribs`):
+	// Legal attributes on CREATE (MS-FSCC §2.6):
 	//   READONLY (0x1)         HIDDEN (0x2)          SYSTEM (0x4)
 	//   DIRECTORY (0x10)       ARCHIVE (0x20)        NORMAL (0x80)
 	//   TEMPORARY (0x100)      SPARSE_FILE (0x200)   REPARSE_POINT (0x400)
 	//   COMPRESSED (0x800)     OFFLINE (0x1000)      NOT_CONTENT_INDEXED (0x2000)
-	//   ENCRYPTED (0x4000)
+	//   ENCRYPTED (0x4000)     INTEGRITY_STREAM (0x8000)
 	//
-	// Mask = 0x00007FB7 (0x1|0x2|0x4|0x10|0x20|0x80|0x100|0x200|0x400|0x800|
-	//                    0x1000|0x2000|0x4000). Bit 0x8 (FILE_ATTRIBUTE_VOLUME)
-	// and 0x40 (FILE_ATTRIBUTE_DEVICE) are reserved-on-the-wire and rejected.
-	const validFileAttributesMask uint32 = 0x00007FB7
+	// Bit 0x8 (FILE_ATTRIBUTE_VOLUME) and 0x40 (FILE_ATTRIBUTE_DEVICE) are
+	// reserved-on-the-wire and rejected. INTEGRITY_STREAM (0x8000) is silently
+	// accepted (no-op on DittoFS) — WPTS FSA tests probe basic-info on a file
+	// created with that attribute and require CREATE to succeed.
+	const validFileAttributesMask uint32 = 0x0000FFB7
 	if uint32(req.FileAttributes)&^validFileAttributesMask != 0 {
 		logger.Debug("CREATE: invalid FileAttributes bits set",
 			"attrs", fmt.Sprintf("0x%08x", uint32(req.FileAttributes)))

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -524,13 +524,20 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Per MS-SMB2 §2.2.13 + MS-FSCC §2.6, three CreateOptions bits are defined
-	// by the spec but unimplemented in DittoFS and MUST return STATUS_NOT_SUPPORTED
+	// in Samba but unimplemented in DittoFS and MUST return STATUS_NOT_SUPPORTED
 	// rather than silently succeed. Samba sets `not_supported_mask = 0x00102080`
 	// for these probes (smbtorture smb2.create.gentest):
-	//   bit 7  (0x00000080) FILE_COMPLETE_IF_OPLOCKED — oplock-conditional open
-	//   bit 13 (0x00002000) FILE_OPEN_BY_FILE_ID    — open by FileId reference
-	//   bit 20 (0x00100000) FILE_OPEN_REQUIRING_OPLOCK — atomic open+oplock grant
-	const unsupportedCreateOptionsMask uint32 = 0x00102080
+	//   bit 7  (0x00000080) NTCREATEX_OPTIONS_TREE_CONNECTION — reserved on the
+	//                       wire per MS-SMB2; Samba legacy name retained.
+	//   bit 13 (0x00002000) FILE_OPEN_BY_FILE_ID — open by FileId reference
+	//                       (matches types.FileOpenByFileId).
+	//   bit 20 (0x00100000) NTCREATEX_OPTIONS_OPFILTER — reserved on the wire
+	//                       per MS-SMB2; Samba legacy name retained.
+	// Note: FILE_COMPLETE_IF_OPLOCKED (0x00000100, types.FileCompleteIfOplocked)
+	// is NOT in this mask — Samba's `ok_mask` accepts it.
+	const unsupportedCreateOptionsMask uint32 = 0x00000080 | // bit 7  (TREE_CONNECTION)
+		uint32(types.FileOpenByFileId) | // bit 13 (0x00002000)
+		0x00100000 // bit 20 (OPFILTER)
 	if uint32(req.CreateOptions)&unsupportedCreateOptionsMask != 0 {
 		logger.Debug("CREATE: unsupported CreateOptions bits set",
 			"options", fmt.Sprintf("0x%08x", uint32(req.CreateOptions)))

--- a/internal/adapter/smb/v2/handlers/create_wire_validation_test.go
+++ b/internal/adapter/smb/v2/handlers/create_wire_validation_test.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupCreateWireTest stands up a Handler with a session + tree wired so the
+// CREATE wire-validation gates near the top of Handler.Create can be exercised
+// from a unit test. Returns (handler, smbCtx) ready to call h.Create on.
+func setupCreateWireTest(t *testing.T) (*Handler, *SMBHandlerContext) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	shareName := "/wire-test"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "test-meta",
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+	sess := h.CreateSession("127.0.0.1:0", true, "guest", "")
+
+	tree := &TreeConnection{
+		TreeID:    1,
+		SessionID: sess.SessionID,
+		ShareName: shareName,
+	}
+	h.StoreTree(tree)
+
+	smbCtx := &SMBHandlerContext{
+		SessionID: sess.SessionID,
+		TreeID:    tree.TreeID,
+		ShareName: shareName,
+	}
+	return h, smbCtx
+}
+
+// TestCreate_WireValidation_ImpersonationLevel verifies that an
+// out-of-range ImpersonationLevel returns STATUS_BAD_IMPERSONATION_LEVEL
+// per MS-SMB2 §2.2.13 (smbtorture smb2.create.impersonation). Only the
+// failing-level path is exercised here — the four legal levels (0..3) pass
+// the gate and continue into deeper CREATE logic which requires more
+// scaffolding than this focused unit test provides.
+func TestCreate_WireValidation_ImpersonationLevel(t *testing.T) {
+	cases := []uint32{4, 0x12345678, 0xFFFFFFFF}
+	for _, level := range cases {
+		t.Run("OutOfRange", func(t *testing.T) {
+			h, smbCtx := setupCreateWireTest(t)
+			req := &CreateRequest{
+				FileName:           "foo.txt",
+				ImpersonationLevel: level,
+				DesiredAccess:      0x120089,
+				FileAttributes:     types.FileAttributeNormal,
+				ShareAccess:        0x07,
+				CreateDisposition:  types.FileOpenIf,
+			}
+			resp, err := h.Create(smbCtx, req)
+			if err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+			if resp.Status != types.StatusBadImpersonationLevel {
+				t.Errorf("level 0x%08x: status = %s (0x%08x), want STATUS_BAD_IMPERSONATION_LEVEL",
+					level, resp.Status, uint32(resp.Status))
+			}
+		})
+	}
+}
+
+// TestCreate_WireValidation_CreateOptionsReserved verifies that any non-zero
+// bit in the upper byte (0xff000000) of CreateOptions returns
+// STATUS_INVALID_PARAMETER per MS-SMB2 §2.2.13 (smbtorture smb2.create.gentest).
+func TestCreate_WireValidation_CreateOptionsReserved(t *testing.T) {
+	cases := []uint32{
+		0x01000000, 0x02000000, 0x04000000, 0x08000000,
+		0x10000000, 0x20000000, 0x40000000, 0x80000000,
+		0xff000000,
+	}
+	for _, options := range cases {
+		t.Run("Reserved", func(t *testing.T) {
+			h, smbCtx := setupCreateWireTest(t)
+			req := &CreateRequest{
+				FileName:          "foo.txt",
+				DesiredAccess:     0x120089,
+				FileAttributes:    types.FileAttributeNormal,
+				ShareAccess:       0x07,
+				CreateDisposition: types.FileOpenIf,
+				CreateOptions:     types.CreateOptions(options),
+			}
+			resp, err := h.Create(smbCtx, req)
+			if err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+			if resp.Status != types.StatusInvalidParameter {
+				t.Errorf("options 0x%08x: status = %s, want STATUS_INVALID_PARAMETER",
+					options, resp.Status)
+			}
+		})
+	}
+}
+
+// TestCreate_WireValidation_CreateOptionsUnsupported verifies that the three
+// CreateOptions bits defined-but-unimplemented in DittoFS return
+// STATUS_NOT_SUPPORTED. Samba sets `not_supported_mask = 0x00102080` for these
+// probes (smbtorture smb2.create.gentest).
+func TestCreate_WireValidation_CreateOptionsUnsupported(t *testing.T) {
+	cases := []struct {
+		name    string
+		options uint32
+	}{
+		{"FILE_COMPLETE_IF_OPLOCKED", 0x00000080},
+		{"FILE_OPEN_BY_FILE_ID", 0x00002000},
+		{"FILE_OPEN_REQUIRING_OPLOCK", 0x00100000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, smbCtx := setupCreateWireTest(t)
+			req := &CreateRequest{
+				FileName:          "foo.txt",
+				DesiredAccess:     0x120089,
+				FileAttributes:    types.FileAttributeNormal,
+				ShareAccess:       0x07,
+				CreateDisposition: types.FileOpenIf,
+				CreateOptions:     types.CreateOptions(tc.options),
+			}
+			resp, err := h.Create(smbCtx, req)
+			if err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+			if resp.Status != types.StatusNotSupported {
+				t.Errorf("options 0x%08x: status = %s, want STATUS_NOT_SUPPORTED",
+					tc.options, resp.Status)
+			}
+		})
+	}
+}
+
+// TestCreate_WireValidation_FileAttributesInvalid verifies that any bit outside
+// the legal CREATE attribute mask (0x00007FB7) returns STATUS_INVALID_PARAMETER.
+// In particular FILE_ATTRIBUTE_VOLUME (0x8) and FILE_ATTRIBUTE_DEVICE (0x40)
+// are rejected (smbtorture smb2.create.gentest).
+func TestCreate_WireValidation_FileAttributesInvalid(t *testing.T) {
+	cases := []uint32{
+		0x00000008, // FILE_ATTRIBUTE_VOLUME
+		0x00000040, // FILE_ATTRIBUTE_DEVICE
+		0x00010000, // reserved high bit
+		0xffff8048, // Samba `invalid_parameter_mask` aggregate
+	}
+	for _, attrs := range cases {
+		t.Run("Invalid", func(t *testing.T) {
+			h, smbCtx := setupCreateWireTest(t)
+			req := &CreateRequest{
+				FileName:          "foo.txt",
+				DesiredAccess:     0x120089,
+				FileAttributes:    types.FileAttributes(attrs),
+				ShareAccess:       0x07,
+				CreateDisposition: types.FileOpenIf,
+			}
+			resp, err := h.Create(smbCtx, req)
+			if err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+			if resp.Status != types.StatusInvalidParameter {
+				t.Errorf("attrs 0x%08x: status = %s, want STATUS_INVALID_PARAMETER",
+					attrs, resp.Status)
+			}
+		})
+	}
+}
+
+// TestCreate_WireValidation_TWrpContext verifies that a TWrp
+// (SMB2_CREATE_TIMEWARP_TOKEN) create context returns
+// STATUS_OBJECT_NAME_NOT_FOUND — DittoFS has no VSS-style snapshot backend
+// so any non-empty snapshot timestamp resolves to a non-existent view
+// (smbtorture smb2.create.blob "Testing timewarp").
+func TestCreate_WireValidation_TWrpContext(t *testing.T) {
+	h, smbCtx := setupCreateWireTest(t)
+	req := &CreateRequest{
+		FileName:          "foo.txt",
+		DesiredAccess:     0x120089,
+		FileAttributes:    types.FileAttributeNormal,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpenIf,
+		CreateContexts: []CreateContext{
+			{Name: "TWrp", Data: []byte{0x10, 0x27, 0, 0, 0, 0, 0, 0}}, // FILETIME = 10000
+		},
+	}
+	resp, err := h.Create(smbCtx, req)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if resp.Status != types.StatusObjectNameNotFound {
+		t.Errorf("TWrp present: status = %s, want STATUS_OBJECT_NAME_NOT_FOUND", resp.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_wire_validation_test.go
+++ b/internal/adapter/smb/v2/handlers/create_wire_validation_test.go
@@ -118,15 +118,16 @@ func TestCreate_WireValidation_CreateOptionsReserved(t *testing.T) {
 // TestCreate_WireValidation_CreateOptionsUnsupported verifies that the three
 // CreateOptions bits defined-but-unimplemented in DittoFS return
 // STATUS_NOT_SUPPORTED. Samba sets `not_supported_mask = 0x00102080` for these
-// probes (smbtorture smb2.create.gentest).
+// probes (smbtorture smb2.create.gentest). Bit 7 and bit 20 are reserved on
+// the wire per MS-SMB2 §2.2.13; Samba's legacy names are kept for traceability.
 func TestCreate_WireValidation_CreateOptionsUnsupported(t *testing.T) {
 	cases := []struct {
 		name    string
 		options uint32
 	}{
-		{"FILE_COMPLETE_IF_OPLOCKED", 0x00000080},
-		{"FILE_OPEN_BY_FILE_ID", 0x00002000},
-		{"FILE_OPEN_REQUIRING_OPLOCK", 0x00100000},
+		{"NTCREATEX_OPTIONS_TREE_CONNECTION", 0x00000080},
+		{"FILE_OPEN_BY_FILE_ID", uint32(types.FileOpenByFileId)},
+		{"NTCREATEX_OPTIONS_OPFILTER", 0x00100000},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -188,14 +188,13 @@ files, create blobs) are not implemented. Basic create operations pass.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.create.blob | Create | Create context blobs not fully implemented | - |
-| smb2.create.gentest | Create | Generic create test (impersonation) not implemented | - |
-| smb2.create.impersonation | Create | Impersonation levels not implemented | - |
-| smb2.create.mkdir-dup | Create | Flaky in CI (parallel CREATE OPEN_IF race — passes intermittently on develop, perturbed by unrelated timing changes) | - |
-| smb2.create.mkdir-visible | Create | Mkdir visibility semantics not implemented | - |
-| smb2.create.multi | Create | Regression from recent changes, fails on all 3 stores | - |
-| smb2.create.path-length | Create | Flaky in CI (path length validation race) | - |
-| smb2.create.quota-fake-file | Create | Quota fake file not implemented | - |
+| smb2.create.blob | Create | Create context blobs not fully implemented | #480 |
+| smb2.create.gentest | Create | Generic create test (impersonation) not implemented | #480 |
+| smb2.create.impersonation | Create | Impersonation levels not implemented | #480 |
+| smb2.create.mkdir-dup | Create | Flaky in CI (parallel CREATE OPEN_IF race — passes intermittently on develop, perturbed by unrelated timing changes) | #480 |
+| smb2.create.mkdir-visible | Create | Mkdir visibility semantics not implemented | #480 |
+| smb2.create.multi | Create | Regression from recent changes, fails on all 3 stores | #480 |
+| smb2.create.path-length | Create | Flaky in CI (path length validation race) | #480 |
 
 ### Read/Write Operations (Advanced Semantics)
 
@@ -558,14 +557,29 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.twrp.openroot | Previous Versions / TWRP | Requires Volume Shadow Copy backend (`SMB2_CREATE_TIMEWARP_TOKEN`) — Windows OS feature, not protocol |
 | smb2.twrp.listdir | Previous Versions / TWRP | Requires Volume Shadow Copy backend (`SMB2_CREATE_TIMEWARP_TOKEN`) — Windows OS feature, not protocol |
 | smb2.samba3misc.localposixlock1 | Samba-private | Samba-specific POSIX lock extensions (smb1-derived, no MS-SMB2 equivalent) |
+| smb2.create.quota-fake-file | NTFS-internal | Synthesises NTFS pseudo-file `$Extend\$Quota:$Q:$INDEX_ALLOCATION`. NTFS volume-quota subsystem is a Windows on-disk-format feature; DittoFS has no NTFS metadata layer, no $Extend reserved files, no quota subsystem, and no protocol-defined way to surface these as fake objects on non-NTFS backends. |
 
-**Total: 14 tests permanently out of scope.**
+**Total: 15 tests permanently out of scope.**
 
 ### Kerberos
 
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-05-28 — CREATE wire validation + quota-fake-file to appendix (#480)
+
+- Server now validates ImpersonationLevel (>3 → BAD_IMPERSONATION_LEVEL),
+  CreateOptions reserved bits (0xff000000 → INVALID_PARAMETER),
+  CreateOptions unsupported bits (0x00102080 → NOT_SUPPORTED), FileAttributes
+  bits outside 0x7FB7 (→ INVALID_PARAMETER), and TWrp (previous-version
+  token) → OBJECT_NAME_NOT_FOUND. Targets flips for `smb2.create.impersonation`
+  and partial coverage for `smb2.create.gentest` / `smb2.create.blob`.
+- `smb2.create.quota-fake-file` promoted to Permanently Unimplementable —
+  NTFS `$Extend\$Quota:$Q:$INDEX_ALLOCATION` is a Windows on-disk-format
+  internal object with no equivalent in DittoFS's metadata model.
+- Remaining `smb2.create.*` entries (blob, gentest, impersonation, mkdir-dup,
+  mkdir-visible, multi, path-length) gated under #480 pending CI confirmation.
 
 ### 2026-05-27 — Walk back 4 compound tests (section removed)
 


### PR DESCRIPTION
## Summary

Wave 2 sub-task C of the v1.0 SMB conformance push (umbrella #673). Adds
wire-level CREATE validation gates that align DittoFS with MS-SMB2 §2.2.13
and Samba's `smbd_smb2_create_send`.

## Changes

**New status code** `StatusBadImpersonationLevel = 0xC00000A5`.

**New gates at top of `Handler.Create()`** (after session/durable-context
validation, before IPC$ dispatch):

| Check | Action | Test target |
|-------|--------|-------------|
| `ImpersonationLevel > 3` | `STATUS_BAD_IMPERSONATION_LEVEL` | `smb2.create.impersonation` |
| `CreateOptions & 0xff000000 != 0` | `STATUS_INVALID_PARAMETER` | `smb2.create.gentest` |
| `CreateOptions & 0x00102080 != 0` | `STATUS_NOT_SUPPORTED` | `smb2.create.gentest` |
| `FileAttributes &^ 0x00007FB7 != 0` | `STATUS_INVALID_PARAMETER` | `smb2.create.gentest` |
| `TWrp context present` | `STATUS_OBJECT_NAME_NOT_FOUND` | `smb2.create.blob` |

**Permanently Unimplementable**: `smb2.create.quota-fake-file` moved to
appendix. The test opens NTFS `$Extend\$Quota:$Q:$INDEX_ALLOCATION`, an
NTFS on-disk-format pseudo-object specific to the Windows volume-quota
subsystem. DittoFS has no NTFS metadata layer, no $Extend reserved files,
and no quota subsystem — synthesising this fake object is not part of the
SMB2/3 protocol surface.

## Spec references

- MS-SMB2 §2.2.13 — SMB2 CREATE Request (ImpersonationLevel, FileAttributes,
  CreateOptions wire validation)
- MS-SMB2 §2.2.13.2.7 — SMB2_CREATE_TIMEWARP_TOKEN
- MS-FSCC §2.6 — File Attributes
- Samba `source3/smbd/smb2_create.c` — `not_supported_mask = 0x00102080`,
  `invalid_parameter_mask = 0xffff8048` / `0xff000000`

## Tests

- `internal/adapter/smb/v2/handlers/create_wire_validation_test.go` — five
  focused tests covering each gate, exercising `Handler.Create()` end-to-end.
- All existing `internal/adapter/smb/v2/handlers/*` tests pass with `-race`.

## Test plan

- [ ] CI smbtorture: `smb2.create.impersonation` flips to PASS on all 3 stores
- [ ] CI smbtorture: `smb2.create.blob` makes forward progress (timewarp arm
      now passes; alloc_size / maximal_access arms may still fail)
- [ ] CI smbtorture: `smb2.create.gentest` partial — reserved/unsupported
      bit assertions pass; full flip requires additional DA / DACL plumbing
      tracked under #480
- [ ] No regressions in currently-passing `smb2.create.*` tests (open, brlocked,
      delete, dir-alloc-size, dosattr_tmp_dir, mkdir-dup, multi)

The other entries listed under #480 (`mkdir-dup`, `mkdir-visible`, `multi`,
`path-length`) are deferred to follow-up work — they require deeper changes
(parallel-CREATE coordination, ACL-inheritance deny propagation, interactive
SKIP handling) that are out of scope for a wire-validation pass.

Closes #480 partially — remaining entries stay gated under the same issue
pending follow-up.