### PR TITLE
fix(blockstore/fs): race-free onChunkComplete swap (C-1)

### DIFF
--- a/pkg/blockstore/local/fs/chunkstore.go
+++ b/pkg/blockstore/local/fs/chunkstore.go
@@ -121,8 +121,8 @@ func (bc *FSStore) StoreChunk(ctx context.Context, h blockstore.ContentHash, dat
 	// an unrelated lock (the typical consumer is engine.Cache.Put, which
 	// takes its own lock). Error paths above already returned before this
 	// point — the callback is invariant on successful StoreChunk only.
-	if bc.onChunkComplete != nil {
-		bc.onChunkComplete(h, data, path)
+	if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
+		cb.fn(h, data, path)
 	}
 	return nil
 }

--- a/pkg/blockstore/local/fs/chunkstore_test.go
+++ b/pkg/blockstore/local/fs/chunkstore_test.go
@@ -215,8 +215,8 @@ func TestChunkstore_OnChunkComplete_FiresAfterSuccessfulStoreChunk(t *testing.T)
 // gated at the firing site — chunkstore.go is the producer).
 func TestChunkstore_NilOnChunkComplete_NoOp(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{})
-	if bc.onChunkComplete != nil {
-		t.Fatalf("precondition: onChunkComplete must start nil; got %T", bc.onChunkComplete)
+	if cb := bc.onChunkComplete.Load(); cb == nil || cb.fn != nil {
+		t.Fatalf("precondition: onChunkComplete.fn must start nil; holder=%v", cb)
 	}
 	h := hashFromHex(t, strings.Repeat("8b", 32))
 	data := bytes.Repeat([]byte{0x8B}, 512)

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -27,11 +27,11 @@ type retentionConfig struct {
 	ttl    time.Duration
 }
 
-// chunkCompleteCallback wraps the OnChunkComplete callback for atomic
-// swap. atomic.Pointer[T] requires T to be a struct (a bare func is not
-// addressable through the generic), so we box the func in a holder. fn
-// may itself be nil — the read path on the chunkstore hot path checks
-// fn before invocation.
+// chunkCompleteCallback boxes the OnChunkComplete callback so each
+// SetOnChunkComplete swap installs a stable addressable
+// *chunkCompleteCallback in atomic.Pointer (a func literal/parameter
+// isn't directly addressable). fn may itself be nil — the read path on
+// the chunkstore hot path checks fn before invocation.
 type chunkCompleteCallback struct {
 	fn func(hash blockstore.ContentHash, data []byte, path string)
 }
@@ -274,19 +274,19 @@ type FSStore struct {
 	// instantiated unconditionally in newFSStoreWithOptionsInternal.
 	dedupLRU *dedupLRU
 
-	// onChunkComplete fires after every successful chunkstore.lruTouch
-	// (Opt 3). Nil-safe: chunkstore.lruTouch
-	// checks for nil before invocation. Install via FSStoreOptions at
-	// construction or post-hoc via SetOnChunkComplete — the engine's
-	// Cache materializes in BlockStore.Start, AFTER cfg.Local is
-	// constructed, so the setter path is the production wire-in site.
+	// onChunkComplete fires once per successful chunkstore.StoreChunk
+	// (immediately after that path's lruTouch). The ReadChunk path also
+	// touches the LRU but does not fire the callback — only the rollup
+	// pool's StoreChunk completion is reported. Install via
+	// FSStoreOptions at construction or post-hoc via SetOnChunkComplete;
+	// the engine's Cache materializes in BlockStore.Start, AFTER
+	// cfg.Local is constructed, so the setter path is the production
+	// wire-in site.
 	//
 	// Stored via atomic.Pointer so SetOnChunkComplete can swap the
-	// callback safely while rollup workers read it on the hot path
-	// (chunkstore.StoreChunk). Holder struct is required because
-	// atomic.Pointer's type parameter must be a struct; we cannot
-	// directly atomically swap a bare func value. A non-nil holder is
-	// always installed at construction so the read path never observes
+	// callback safely while rollup workers read it on the hot path in
+	// chunkstore.StoreChunk. The pointer always holds a stable
+	// addressable *chunkCompleteCallback so the read path never observes
 	// a nil pointer — the inner fn may itself be nil and is checked
 	// there.
 	onChunkComplete atomic.Pointer[chunkCompleteCallback]

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -27,6 +27,15 @@ type retentionConfig struct {
 	ttl    time.Duration
 }
 
+// chunkCompleteCallback wraps the OnChunkComplete callback for atomic
+// swap. atomic.Pointer[T] requires T to be a struct (a bare func is not
+// addressable through the generic), so we box the func in a holder. fn
+// may itself be nil — the read path on the chunkstore hot path checks
+// fn before invocation.
+type chunkCompleteCallback struct {
+	fn func(hash blockstore.ContentHash, data []byte, path string)
+}
+
 // Errors returned by FSStore.
 var (
 	ErrStoreClosed    = errors.New("local store: closed")
@@ -271,7 +280,16 @@ type FSStore struct {
 	// construction or post-hoc via SetOnChunkComplete — the engine's
 	// Cache materializes in BlockStore.Start, AFTER cfg.Local is
 	// constructed, so the setter path is the production wire-in site.
-	onChunkComplete func(hash blockstore.ContentHash, data []byte, path string)
+	//
+	// Stored via atomic.Pointer so SetOnChunkComplete can swap the
+	// callback safely while rollup workers read it on the hot path
+	// (chunkstore.StoreChunk). Holder struct is required because
+	// atomic.Pointer's type parameter must be a struct; we cannot
+	// directly atomically swap a bare func value. A non-nil holder is
+	// always installed at construction so the read path never observes
+	// a nil pointer — the inner fn may itself be nil and is checked
+	// there.
+	onChunkComplete atomic.Pointer[chunkCompleteCallback]
 
 	// compactionThresholdBytes is the minimum number of pre-fence bytes
 	// that must accumulate in a per-payload log before the next rollup
@@ -700,7 +718,10 @@ func newFSStoreWithOptionsInternal(baseDir string, maxDisk, maxMemory int64, fil
 		size = 4096
 	}
 	bc.dedupLRU = newDedupLRU(size)
-	bc.onChunkComplete = opts.OnChunkComplete
+	// Install a non-nil holder so the hot-path Load never observes nil;
+	// opts.OnChunkComplete may itself be nil, which is checked at the
+	// firing site.
+	bc.onChunkComplete.Store(&chunkCompleteCallback{fn: opts.OnChunkComplete})
 	return bc, nil
 }
 
@@ -733,17 +754,17 @@ func (bc *FSStore) SetObjectIDPersister(p func(ctx context.Context, payloadID st
 // construction. Mirrors the SetObjectIDPersister lifecycle: callers
 // (typically engine.NewBlockStore / BlockStore.Start, where the read
 // Cache materializes AFTER cfg.Local was already constructed) install
-// once before serving traffic. Concurrent installs are not supported —
-// the field is read by chunkstore.lruTouch on the hot path
-// without locking. Nil is accepted: chunkstore.lruTouch reverts to
-// the no-callback codepath.
+// once before serving traffic. The swap is race-free — the field is
+// an atomic.Pointer read by chunkstore.StoreChunk on the hot path.
+// Nil is accepted: chunkstore reverts to the no-callback codepath
+// (the holder is always non-nil; the inner fn may be nil).
 //
 // The parameter type is spelled out as a raw func value (rather than
 // referring to FSStoreOptions.OnChunkComplete) so engine.go can call
 // the setter through a structural interface assertion without
 // importing this package's named-type spelling.
 func (bc *FSStore) SetOnChunkComplete(fn func(hash blockstore.ContentHash, data []byte, path string)) {
-	bc.onChunkComplete = fn
+	bc.onChunkComplete.Store(&chunkCompleteCallback{fn: fn})
 }
 
 // SetRetentionPolicy updates the retention policy and TTL for eviction decisions.

--- a/pkg/blockstore/local/fs/fs_race_test.go
+++ b/pkg/blockstore/local/fs/fs_race_test.go
@@ -1,0 +1,80 @@
+//go:build race
+
+package fs
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+)
+
+// TestFSStore_OnChunkComplete_RaceFreeSwap guards against regression of
+// audit finding C-1: SetOnChunkComplete used to write the field bare
+// while rollup workers read it on the hot path (chunkstore.StoreChunk),
+// which tripped go test -race.
+//
+// We don't need to exercise real rollup logic — the data race lives in
+// the bare field swap vs the bare field read. Concurrent SetOnChunkComplete
+// against goroutines that mimic chunkstore's load-and-invoke pattern is
+// sufficient to surface the race under -race.
+func TestFSStore_OnChunkComplete_RaceFreeSwap(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{})
+
+	const iterations = 500
+	const readers = 2
+	const writers = 2
+
+	var stop atomic.Bool
+	var invocations atomic.Int64
+	var writersWG sync.WaitGroup
+	var readersWG sync.WaitGroup
+
+	// Reader goroutines: mimic chunkstore.StoreChunk's load-and-invoke
+	// pattern. Run until writers signal stop.
+	for r := 0; r < readers; r++ {
+		readersWG.Add(1)
+		go func() {
+			defer readersWG.Done()
+			for !stop.Load() {
+				if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
+					cb.fn(blockstore.ContentHash{}, nil, "")
+					invocations.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Writer goroutines: continuously swap fresh callbacks via the
+	// setter, then exit. The variety of fn values (non-nil distinct
+	// closures, nil) widens the window for races on both the holder
+	// pointer and the inner fn read.
+	for w := 0; w < writers; w++ {
+		writersWG.Add(1)
+		go func(id int) {
+			defer writersWG.Done()
+			for i := 0; i < iterations; i++ {
+				localID := id
+				bc.SetOnChunkComplete(func(_ blockstore.ContentHash, _ []byte, _ string) {
+					_ = localID
+				})
+				if i%17 == 0 {
+					// Exercise the nil-fn install path too — readers must
+					// gracefully skip without panic.
+					bc.SetOnChunkComplete(nil)
+				}
+			}
+		}(w)
+	}
+
+	writersWG.Wait()
+	stop.Store(true)
+	readersWG.Wait()
+
+	// A non-flaky lower bound is hard to guarantee (scheduler-dependent),
+	// but in practice readers fire many times. We assert only that the
+	// test reached a clean end — the real signal here is -race not
+	// reporting a data race on bc.onChunkComplete.
+	_ = invocations.Load()
+}

--- a/pkg/blockstore/local/fs/fs_race_test.go
+++ b/pkg/blockstore/local/fs/fs_race_test.go
@@ -3,6 +3,7 @@
 package fs
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -41,6 +42,8 @@ func TestFSStore_OnChunkComplete_RaceFreeSwap(t *testing.T) {
 				if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
 					cb.fn(blockstore.ContentHash{}, nil, "")
 					invocations.Add(1)
+				} else {
+					runtime.Gosched()
 				}
 			}
 		}()

--- a/pkg/blockstore/local/fs/fs_test.go
+++ b/pkg/blockstore/local/fs/fs_test.go
@@ -372,8 +372,8 @@ func TestFSStore_ExplicitDedupLRUSize_Honored(t *testing.T) {
 // wire-in test.
 func TestFSStore_NilOnChunkComplete_LruTouchUnchanged(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{})
-	if bc.onChunkComplete != nil {
-		t.Fatalf("bc.onChunkComplete must be nil when option is unset; got %T", bc.onChunkComplete)
+	if cb := bc.onChunkComplete.Load(); cb == nil || cb.fn != nil {
+		t.Fatalf("bc.onChunkComplete.fn must be nil when option is unset; holder=%v", cb)
 	}
 	h := hashFromHex(t, strings.Repeat("19", 32))
 	data := bytes.Repeat([]byte{0x19}, 256)
@@ -397,13 +397,14 @@ func TestFSStore_OnChunkComplete_StoredOnConstruction(t *testing.T) {
 		calls.Add(1)
 	}
 	bc := newFSStoreForTest(t, FSStoreOptions{OnChunkComplete: cb})
-	if bc.onChunkComplete == nil {
-		t.Fatal("bc.onChunkComplete must be non-nil after construction with explicit callback")
+	holder := bc.onChunkComplete.Load()
+	if holder == nil || holder.fn == nil {
+		t.Fatal("bc.onChunkComplete.fn must be non-nil after construction with explicit callback")
 	}
 	// Fire the stored callback directly to confirm it is the value we
 	// passed in (function identity check — Go does not permit ==
 	// comparison of func values, so invoke and observe the counter).
-	bc.onChunkComplete(blockstore.ContentHash{}, nil, "")
+	holder.fn(blockstore.ContentHash{}, nil, "")
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("stored callback fired %d times; want 1", got)
 	}
@@ -430,17 +431,18 @@ func TestFSStore_DedupLRU_FieldExists(t *testing.T) {
 // via setter (mirror SetObjectIDPersister)".
 func TestFSStore_SetOnChunkComplete_PostHocInstall(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{})
-	if bc.onChunkComplete != nil {
-		t.Fatal("precondition: onChunkComplete must start nil")
+	if cb := bc.onChunkComplete.Load(); cb == nil || cb.fn != nil {
+		t.Fatal("precondition: onChunkComplete.fn must start nil")
 	}
 	var calls atomic.Int64
 	bc.SetOnChunkComplete(func(_ blockstore.ContentHash, _ []byte, _ string) {
 		calls.Add(1)
 	})
-	if bc.onChunkComplete == nil {
-		t.Fatal("SetOnChunkComplete must populate bc.onChunkComplete")
+	holder := bc.onChunkComplete.Load()
+	if holder == nil || holder.fn == nil {
+		t.Fatal("SetOnChunkComplete must populate bc.onChunkComplete.fn")
 	}
-	bc.onChunkComplete(blockstore.ContentHash{}, nil, "")
+	holder.fn(blockstore.ContentHash{}, nil, "")
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("installed callback fired %d times; want 1", got)
 	}


### PR DESCRIPTION
## Summary

- Fixes audit finding **C-1** from `.planning/v1.0-audit/blockstore/REVIEW.md`.
- `SetOnChunkComplete` was a bare field write; rollup-worker reads on `chunkstore.go:124-125` raced with it.
- Wrap callback in a holder struct and swap via `atomic.Pointer` (mirrors the existing `SetRetentionPolicy` pattern in the same file).
- Adds race-coverage test under `//go:build race`.

## Test plan

- [x] `go test ./pkg/blockstore/local/fs/...`
- [x] `go test -race ./pkg/blockstore/local/fs/...`
- [x] `go test -race ./pkg/blockstore/...`
- [x] New `fs_race_test.go` exercises concurrent Set + invoke