### PR TITLE
fix(smb/compound): close FIND+CLOSE race (#472)

### DIFF
--- a/internal/adapter/smb/request_fileid.go
+++ b/internal/adapter/smb/request_fileid.go
@@ -1,0 +1,76 @@
+package smb
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// ExtractRequestFileID returns the 16-byte FileID carried by the request body
+// for SMB2 commands that operate on an open handle. For commands without a
+// FileID (NEGOTIATE, SESSION_SETUP, LOGOFF, TREE_CONNECT, TREE_DISCONNECT,
+// CREATE, CANCEL, ECHO, OPLOCK_BREAK) it returns false.
+//
+// Used by the connection dispatcher to pre-acquire the handle's in-flight
+// counter BEFORE spawning the request goroutine. Without this, two requests
+// on the same TCP connection targeting the same FileID (e.g. QUERY_DIRECTORY
+// followed by CLOSE in smbtorture compound_find_close) race at goroutine
+// spawn: if the Go runtime schedules CLOSE first, it deletes the OpenFile
+// before the prior request has had a chance to call AcquireOpenFile, and
+// the prior request fails with STATUS_FILE_CLOSED.
+//
+// Pre-acquiring on the read loop (sequential, in wire order) makes the
+// handleOps counter visible to a later CLOSE regardless of goroutine
+// scheduling. Body offsets are fixed per MS-SMB2 §2.2.{15,17,19..22,33..39}.
+func ExtractRequestFileID(cmd types.Command, body []byte) ([16]byte, bool) {
+	var fileID [16]byte
+	off, ok := requestFileIDOffset(cmd)
+	if !ok {
+		return fileID, false
+	}
+	if len(body) < off+16 {
+		return fileID, false
+	}
+	copy(fileID[:], body[off:off+16])
+	return fileID, true
+}
+
+// requestFileIDOffset returns the byte offset of the FileID field in the
+// SMB2 request body for the given command, or false if the command has no
+// FileID. Offsets are taken from MS-SMB2 §2.2 request structures.
+func requestFileIDOffset(cmd types.Command) (int, bool) {
+	switch cmd {
+	case types.SMB2Close:
+		// StructureSize(2) + Flags(2) + Reserved(4)
+		return 8, true
+	case types.SMB2Flush:
+		// StructureSize(2) + Reserved1(2) + Reserved2(4)
+		return 8, true
+	case types.SMB2Read:
+		// StructureSize(2) + Padding(1) + Flags(1) + Length(4) + Offset(8)
+		return 16, true
+	case types.SMB2Write:
+		// StructureSize(2) + DataOffset(2) + Length(4) + Offset(8)
+		return 16, true
+	case types.SMB2Lock:
+		// StructureSize(2) + LockCount(2) + LockSequence(4)
+		return 8, true
+	case types.SMB2Ioctl:
+		// StructureSize(2) + Reserved(2) + CtlCode(4)
+		return 8, true
+	case types.SMB2QueryDirectory:
+		// StructureSize(2) + FileInfoClass(1) + Flags(1) + FileIndex(4)
+		return 8, true
+	case types.SMB2ChangeNotify:
+		// StructureSize(2) + Flags(2) + OutputBufferLength(4)
+		return 8, true
+	case types.SMB2QueryInfo:
+		// StructureSize(2) + InfoType(1) + FileInfoClass(1) + OutputBufferLength(4)
+		// + InputBufferOffset(2) + Reserved(2) + InputBufferLength(4)
+		// + AdditionalInformation(4) + Flags(4)
+		return 24, true
+	case types.SMB2SetInfo:
+		// StructureSize(2) + InfoType(1) + FileInfoClass(1) + BufferLength(4)
+		// + BufferOffset(2) + Reserved(2) + AdditionalInformation(4)
+		return 16, true
+	}
+	return 0, false
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -625,6 +625,29 @@ type handleOpTracker struct {
 	wg sync.WaitGroup
 }
 
+// BeginHandleOp registers an in-flight operation on fileID without checking
+// whether the OpenFile is currently present. It is intended for the
+// connection dispatcher to call synchronously on the read loop BEFORE
+// spawning the request goroutine, so that the handleOps counter for the
+// FileID is incremented in wire order (independent of goroutine scheduling).
+// Without this, a later CLOSE on the same TCP connection can race ahead of
+// an earlier request's goroutine, observe handleOps empty, and delete the
+// OpenFile before the prior request calls AcquireOpenFile — yielding a
+// spurious STATUS_FILE_CLOSED (smbtorture compound_find.compound_find_close).
+//
+// The returned release func MUST be called exactly once when the request
+// completes. A subsequent in-handler AcquireOpenFile/ReleaseOpenFile pair on
+// the same FileID still works correctly: the tracker is shared, so the
+// nested Add/Done cancel out and the dispatcher's outer Done fires when the
+// request finishes.
+func (h *Handler) BeginHandleOp(fileID [16]byte) func() {
+	key := string(fileID[:])
+	v, _ := h.handleOps.LoadOrStore(key, &handleOpTracker{})
+	tracker := v.(*handleOpTracker)
+	tracker.wg.Add(1)
+	return func() { tracker.wg.Done() }
+}
+
 // AcquireOpenFile retrieves an open file by FileID and registers an in-flight
 // operation on it. The caller MUST call ReleaseOpenFile when done. Returns
 // nil,false when the handle is not found. This prevents a CLOSE on a concurrent
@@ -671,9 +694,13 @@ func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
 }
 
 // DeleteOpenFile removes an open file by FileID and revokes any
-// resume keys issued for this handle (used by FSCTL_SRV_COPYCHUNK).
+// resume keys issued for this handle (used by FSCTL_SRV_COPYCHUNK and the
+// session-cleanup path closeFilesWithFilter). Also clears the handleOps
+// tracker so trackers created by BeginHandleOp on this FileID do not leak.
 func (h *Handler) DeleteOpenFile(fileID [16]byte) {
-	h.files.Delete(string(fileID[:]))
+	key := string(fileID[:])
+	h.files.Delete(key)
+	h.handleOps.Delete(key)
 	h.resumeKeys.revoke(fileID)
 }
 

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -254,6 +254,30 @@ func (c *Connection) Serve(ctx context.Context) {
 		c.requestSem <- struct{}{}
 		c.wg.Add(1)
 
+		// Pre-acquire the per-FileID in-flight counter on the read loop so
+		// that ordering is established in wire order, not goroutine-spawn
+		// order. Without this, a CLOSE goroutine for a later request on the
+		// same connection can race ahead of an earlier request's goroutine,
+		// observe an empty handleOps map for the FileID, and delete the
+		// OpenFile before the prior request reaches AcquireOpenFile —
+		// causing a spurious STATUS_FILE_CLOSED (smbtorture
+		// compound_find.compound_find_close).
+		//
+		// Skip pre-acquire for CLOSE: it is the deleter that drains the
+		// counter via WaitAndDeleteOpenFile, so bumping the counter for it
+		// would deadlock CLOSE against itself.
+		//
+		// Pre-acquire only applies to non-compound single requests. Compound
+		// chains are processed sequentially inside ProcessCompoundRequest, so
+		// no intra-chain race exists; cross-chain races for the chain's
+		// trailing command are still possible but rare in practice.
+		var releaseHandleOp func()
+		if len(remainingCompound) == 0 && hdr.Command != types.CommandClose {
+			if fid, ok := smb.ExtractRequestFileID(hdr.Command, body); ok {
+				releaseHandleOp = c.server.handler.BeginHandleOp(fid)
+			}
+		}
+
 		if len(remainingCompound) > 0 {
 			// Copy compound data to avoid races (goroutine owns this copy)
 			compoundData := make([]byte, len(remainingCompound))
@@ -265,14 +289,17 @@ func (c *Connection) Serve(ctx context.Context) {
 				smb.ProcessCompoundRequest(ctx, reqHeader, reqBody, raw, compoundData, ci, encrypted, asyncCallback)
 			}(hdr, body, rawMessage, isEncrypted)
 		} else {
-			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool) {
+			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool, release func()) {
+				if release != nil {
+					defer release()
+				}
 				defer c.handleRequestPanic(clientAddr, reqHeader.MessageID)
 
 				asyncCallback := c.makeAsyncNotifyCallback(ci)
 				if err := smb.ProcessSingleRequest(ctx, reqHeader, reqBody, raw, ci, encrypted, asyncCallback); err != nil {
 					logger.Debug("Error processing SMB request", "address", clientAddr, "messageID", reqHeader.MessageID, "error", err)
 				}
-			}(hdr, body, rawMessage, isEncrypted)
+			}(hdr, body, rawMessage, isEncrypted, releaseHandleOp)
 		}
 
 		// Reset idle timeout after reading request (read-only)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-05-28 (v1.0 conformance gate — extract 14 architecturally-unimplementable entries into Permanently Unimplementable appendix; defer 70 Kerberos entries to v1.0+kerberos milestone)
+Last updated: 2026-05-28 (close FIND+CLOSE goroutine-spawn race via dispatch-time pre-acquire of per-FileID in-flight counter — walks back `smb2.compound_find.compound_find_close` from Compound and Intermittent sections, #472)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -97,12 +97,6 @@ overflow, rec, rmdir1-4, tcon, tdis, tdis1, tcp, tree.
 | smb2.notify.valid-req | Change Notify | Needs kernel inotify for MODIFIED on WRITE (also fails on reference Samba in Docker) | - |
 | smb2.notify.session-reconnect | Change Notify | PreviousSessionID signing key derivation mismatch (not notify-specific) | - |
 | smb2.notify.mask-change | Change Notify | SHARING_VIOLATION on directory open (pre-existing, never passed individually) | - |
-
-### Compound Requests (Intermittent)
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.compound_find.compound_find_close | Compound | Intermittent race in compound FIND+CLOSE sequencing | - |
 
 ### Oplocks (Multi-Client Coordination Not Implemented)
 
@@ -275,7 +269,6 @@ Advanced connection and tree connect edge cases.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.compound_find.compound_find_close | Compound | Flaky compound FIND+CLOSE race - passes intermittently | - |
 | smb2.lease.statopen4 | Leases | Flaky stat-open lease test - passes intermittently | - |
 
 ### Character Set (Edge Cases)


### PR DESCRIPTION
## Summary

- The smbtorture `compound_find.compound_find_close` test sends FIND (QUERY_DIRECTORY) then CLOSE on the same connection as two separate non-compound requests. Wire order is preserved but DittoFS spawns one goroutine per request; if the Go scheduler ran CLOSE first, the handleOps map was empty for the FileID, CLOSE deleted the OpenFile via `WaitAndDeleteOpenFile` without waiting, and the subsequent FIND returned `STATUS_FILE_CLOSED`. Observed ~40% flake rate on develop.
- Fix: pre-acquire the per-FileID in-flight counter synchronously on the read loop (in wire order) before spawning the request goroutine, via a new `Handler.BeginHandleOp(fileID)` primitive. Goroutine defers release on exit. Skip pre-acquire for CLOSE (it is the deleter — bumping would self-deadlock against `WaitAndDeleteOpenFile`) and for compound chains (processed sequentially inside `ProcessCompoundRequest`).
- Body-offset lookup for FileID-bearing commands lives in a new `ExtractRequestFileID` helper following MS-SMB2 §2.2 layouts (CLOSE/FLUSH/READ/WRITE/LOCK/IOCTL/QUERY_DIRECTORY/CHANGE_NOTIFY/QUERY_INFO/SET_INFO).
- Also wire `handleOps.Delete` into `DeleteOpenFile` so trackers do not leak on the session-cleanup path (`closeFilesWithFilter`).

Closes #472.

## Test plan

- [x] `go fmt ./... && go vet ./...` clean
- [x] `go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/...` clean
- [x] `smb2.compound_find.compound_find_close` 8/8 PASS locally (vs baseline ~40% flake)
- [x] `smb2.compound` full suite 20/20 PASS (no regressions in `compound`/`compound_async`/`related`/`unrelated`/`invalid`/`interim`/`compound-break`/`compound-padding`/`create-write-close`)
- [x] `smb2.compound_find` family 3/3 PASS (`compound_find`, `compound_find_unrelated`, `compound_find_close`)
- [ ] CI smbtorture full suite (Linux)