### PR TITLE
fix(blockstore/engine): propagate dedup rollback refcount failures (C-2)

### DIFF
--- a/pkg/blockstore/engine/coordinator_test.go
+++ b/pkg/blockstore/engine/coordinator_test.go
@@ -97,12 +97,16 @@ func (f *fakeCoordinator) IncrementRefCount(_ context.Context, hash blockstore.C
 	return nil
 }
 
+// errInducedDecrement is a sentinel returned by failOnNthDecrement so
+// tests can assert errors.Is on the rollback path.
+var errInducedDecrement = errors.New("fakeCoordinator: induced DecrementRefCount failure")
+
 func (f *fakeCoordinator) DecrementRefCount(_ context.Context, hash blockstore.ContentHash) (uint32, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.decCallCount++
 	if f.failOnNthDecrement > 0 && f.decCallCount == f.failOnNthDecrement {
-		return 0, errors.New("fakeCoordinator: induced DecrementRefCount failure")
+		return 0, errInducedDecrement
 	}
 	f.decHashes = append(f.decHashes, hash)
 	return 0, nil

--- a/pkg/blockstore/engine/dedup.go
+++ b/pkg/blockstore/engine/dedup.go
@@ -300,7 +300,7 @@ func (m *Syncer) applyFileLevelDedupHit(
 			// both the original conflict + the rollback failure
 			// upward so the caller observes the leak window.
 			if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup race rollback"); rbErr != nil {
-				return false, fmt.Errorf("file-level dedup race: persist conflict: %w (refcount rollback also failed, retry aborted to avoid permanent refcount leak: %v)", err, rbErr)
+				return false, fmt.Errorf("file-level dedup race: persist conflict (refcount rollback also failed; retry aborted to avoid permanent refcount leak): %w", errors.Join(err, rbErr))
 			}
 			updatedTarget, ferr := m.coordinator.FindByObjectID(ctx, provisional)
 			if ferr != nil {
@@ -317,7 +317,7 @@ func (m *Syncer) applyFileLevelDedupHit(
 		// the rollback failure alongside the persist error so the leak
 		// is observable.
 		if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup hit rollback"); rbErr != nil {
-			return false, fmt.Errorf("file-level dedup persist: %w (refcount rollback also failed: %v)", err, rbErr)
+			return false, fmt.Errorf("file-level dedup persist (refcount rollback also failed): %w", errors.Join(err, rbErr))
 		}
 		return false, fmt.Errorf("file-level dedup persist: %w", err)
 	}

--- a/pkg/blockstore/engine/dedup.go
+++ b/pkg/blockstore/engine/dedup.go
@@ -215,6 +215,34 @@ func isObjectIDConflict(err error) bool {
 	return false
 }
 
+// rollbackIncrements decrements RefCount on every hash in `seen` and
+// joins all decrement failures into a single error (or returns nil if
+// every decrement succeeded). Each failure is logged at Error because
+// a swallowed decrement failure here translates directly into a
+// permanent RefCount leak — the matching CAS chunk can never be
+// reclaimed by GC, so the operator MUST see the signal even if the
+// caller chooses not to propagate it.
+//
+// `reason` is a short tag identifying which rollback site invoked the
+// helper (race-conflict pre-retry vs. non-conflict persist error); it
+// is woven into the log line so operators can tell the two leak
+// sources apart without grepping line numbers.
+func (m *Syncer) rollbackIncrements(
+	ctx context.Context,
+	seen map[blockstore.ContentHash]struct{},
+	reason string,
+) error {
+	var errs []error
+	for h := range seen {
+		if _, derr := m.coordinator.DecrementRefCount(ctx, h); derr != nil {
+			logger.Error(reason+": decrement failed (refcount leak — CAS chunk pinned against GC)",
+				"hash", h.String(), "err", derr)
+			errs = append(errs, fmt.Errorf("decrement %s: %w", h.String(), derr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // applyFileLevelDedupHit performs the metadata-side swap once
 // FindByObjectID has confirmed a file with identical Merkle root
 // already exists in the metadata store. See trySpeculativeFileLevelDedup
@@ -262,15 +290,17 @@ func (m *Syncer) applyFileLevelDedupHit(
 			// rejected it because the retry unconditionally
 			// re-increments every updatedTarget hash; skipping shared
 			// hashes here would leave them at +2 after retry instead
-			// of the intended +1. audit reconciles any
-			// transient dip while the retry runs (RefCount is
-			// non-blocking; GC keys off FileAttr.Blocks references in
-			// the persisted state, not the in-flight rollback window).
-			for h := range seen {
-				if _, derr := m.coordinator.DecrementRefCount(ctx, h); derr != nil {
-					logger.Warn("file-level dedup race rollback decrement failed",
-						"hash", h.String(), "err", derr)
-				}
+			// of the intended +1.
+			//
+			// CRITICAL: if rollback decrement fails on any hash we
+			// MUST NOT retry. A retry re-increments every target
+			// hash; combined with a failed decrement on the original
+			// pass, the surviving over-increment becomes a permanent
+			// RefCount leak that pins a CAS chunk against GC. Surface
+			// both the original conflict + the rollback failure
+			// upward so the caller observes the leak window.
+			if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup race rollback"); rbErr != nil {
+				return false, fmt.Errorf("file-level dedup race: persist conflict: %w (refcount rollback also failed, retry aborted to avoid permanent refcount leak: %v)", err, rbErr)
 			}
 			updatedTarget, ferr := m.coordinator.FindByObjectID(ctx, provisional)
 			if ferr != nil {
@@ -281,12 +311,13 @@ func (m *Syncer) applyFileLevelDedupHit(
 			}
 			return m.applyFileLevelDedupHit(ctx, payloadID, speculativeBlocks, updatedTarget, provisional, true /*isRetry*/)
 		}
-		// Best-effort rollback of refcount increments on a non-conflict error.
-		for h := range seen {
-			if _, derr := m.coordinator.DecrementRefCount(ctx, h); derr != nil {
-				logger.Warn("file-level dedup hit rollback decrement failed",
-					"hash", h.String(), "err", derr)
-			}
+		// Rollback of refcount increments on a non-conflict error. The
+		// caller does not retry on this branch, but a failed decrement
+		// still leaves a permanent +1 RefCount on a CAS chunk; surface
+		// the rollback failure alongside the persist error so the leak
+		// is observable.
+		if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup hit rollback"); rbErr != nil {
+			return false, fmt.Errorf("file-level dedup persist: %w (refcount rollback also failed: %v)", err, rbErr)
 		}
 		return false, fmt.Errorf("file-level dedup persist: %w", err)
 	}

--- a/pkg/blockstore/engine/dedup_test.go
+++ b/pkg/blockstore/engine/dedup_test.go
@@ -30,6 +30,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
@@ -477,3 +478,114 @@ func TestDedup_ConcurrentRace(t *testing.T) {
 // Compile-time check: keep errors import live even if reshapes
 // the error-handling path. Tests that need errors.Is can adopt this.
 var _ = errors.Is
+
+// TestApplyFileLevelDedupHit_RollbackPropagates_NonConflict encodes the
+// fix for audit finding C-2 on the non-conflict persist-error branch.
+//
+// PersistFileBlocks returns a generic (non-conflict) error and one of
+// the rollback DecrementRefCount calls also fails. The returned error
+// MUST wrap both signals so the caller observes the permanent
+// RefCount leak; the helper MUST NOT retry (no second persist call,
+// no FindByObjectID re-lookup) because the conflict-retry branch is
+// not in play.
+func TestApplyFileLevelDedupHit_RollbackPropagates_NonConflict(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	speculative := makeSpeculativeBlocks(0xA1, 0xA2)
+	target := makeSpeculativeBlocks(0xB1, 0xB2)
+	provisional := blockstore.ComputeObjectID(speculative)
+	fc.objectIDHits[provisional] = target
+
+	// Generic (non-conflict) persist failure.
+	persistErr := errors.New("induced non-conflict persist failure")
+	fc.persistErr = persistErr
+
+	// Fail the SECOND decrement so we exercise the "some succeed, some
+	// fail" path; errors.Join must surface the failing one.
+	fc.failOnNthDecrement = 2
+
+	hit, err := m.trySpeculativeFileLevelDedup(ctx, "pid",
+		speculative, blockstore.ObjectID{}, pendingStates(len(speculative)))
+	if hit {
+		t.Fatalf("hit=true on persist failure; want false")
+	}
+	if err == nil {
+		t.Fatalf("err=nil; want wrapped persist+rollback failure")
+	}
+	if !errors.Is(err, persistErr) {
+		t.Errorf("returned err does not wrap original persist failure via errors.Is; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "refcount rollback also failed") {
+		t.Errorf("returned err does not surface rollback failure signal; got %q", err.Error())
+	}
+
+	// No retry on the non-conflict branch: FindByObjectID stays at 1
+	// (the initial lookup), PersistFileBlocks at 1 (the failing one).
+	if got := len(fc.findCalls); got != 1 {
+		t.Errorf("FindByObjectID calls=%d; want 1 (no retry on non-conflict err)", got)
+	}
+	if got := len(fc.persistCalls); got != 1 {
+		t.Errorf("PersistFileBlocks calls=%d; want 1 (no retry on non-conflict err)", got)
+	}
+}
+
+// TestApplyFileLevelDedupHit_RollbackPropagates_ConflictNoRetry encodes
+// the fix for audit finding C-2 on the race-conflict branch.
+//
+// PersistFileBlocks returns an ErrObjectIDConflict-shaped error
+// (fakePgConflictError implements IsConflict), but one of the
+// rollback DecrementRefCount calls fails. The retry MUST be aborted
+// (a retry would re-increment over the un-rolled-back leak, doubling
+// the pinned refcount), no FindByObjectID re-lookup may fire, and the
+// returned error MUST wrap both the conflict and the rollback
+// failure.
+func TestApplyFileLevelDedupHit_RollbackPropagates_ConflictNoRetry(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	speculative := makeSpeculativeBlocks(0xA1, 0xA2)
+	target := makeSpeculativeBlocks(0xB1, 0xB2)
+	provisional := blockstore.ComputeObjectID(speculative)
+	fc.objectIDHits[provisional] = target
+
+	// Inject conflict on the first PersistFileBlocks (single-shot).
+	fc.persistErr = &fakePgConflictError{}
+
+	// Fail the FIRST decrement so rollback surfaces an error and the
+	// retry MUST be aborted.
+	fc.failOnNthDecrement = 1
+
+	hit, err := m.trySpeculativeFileLevelDedup(ctx, "pid",
+		speculative, blockstore.ObjectID{}, pendingStates(len(speculative)))
+	if hit {
+		t.Fatalf("hit=true after aborted retry; want false")
+	}
+	if err == nil {
+		t.Fatalf("err=nil; want wrapped conflict+rollback failure")
+	}
+	if !strings.Contains(err.Error(), "refcount rollback also failed") {
+		t.Errorf("returned err does not surface rollback failure signal; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "retry aborted") {
+		t.Errorf("returned err does not surface retry-aborted signal; got %q", err.Error())
+	}
+
+	// Retry MUST NOT fire: exactly ONE PersistFileBlocks (the failing
+	// initial call) and exactly ONE FindByObjectID (the initial lookup
+	// — the conflict-path re-lookup never runs).
+	if got := len(fc.persistCalls); got != 1 {
+		t.Errorf("PersistFileBlocks calls=%d; want 1 (retry must be aborted on failed rollback)", got)
+	}
+	if got := len(fc.findCalls); got != 1 {
+		t.Errorf("FindByObjectID calls=%d; want 1 (retry re-lookup must NOT fire on failed rollback)", got)
+	}
+
+	// Sanity: the persist single-shot did fire — fakeCoordinator clears
+	// persistErr after each call. If we somehow ran a second
+	// PersistFileBlocks that call would have succeeded (persistErr nil)
+	// and the test above would report 2 calls.
+	if fc.persistErr != nil {
+		t.Errorf("persistErr still armed after initial conflict; should be drained (single-shot)")
+	}
+}

--- a/pkg/blockstore/engine/dedup_test.go
+++ b/pkg/blockstore/engine/dedup_test.go
@@ -516,6 +516,9 @@ func TestApplyFileLevelDedupHit_RollbackPropagates_NonConflict(t *testing.T) {
 	if !errors.Is(err, persistErr) {
 		t.Errorf("returned err does not wrap original persist failure via errors.Is; got %v", err)
 	}
+	if !errors.Is(err, errInducedDecrement) {
+		t.Errorf("returned err does not wrap rollback decrement failure via errors.Is; got %v", err)
+	}
 	if !strings.Contains(err.Error(), "refcount rollback also failed") {
 		t.Errorf("returned err does not surface rollback failure signal; got %q", err.Error())
 	}
@@ -563,6 +566,9 @@ func TestApplyFileLevelDedupHit_RollbackPropagates_ConflictNoRetry(t *testing.T)
 	}
 	if err == nil {
 		t.Fatalf("err=nil; want wrapped conflict+rollback failure")
+	}
+	if !errors.Is(err, errInducedDecrement) {
+		t.Errorf("returned err does not wrap rollback decrement failure via errors.Is; got %v", err)
 	}
 	if !strings.Contains(err.Error(), "refcount rollback also failed") {
 		t.Errorf("returned err does not surface rollback failure signal; got %q", err.Error())


### PR DESCRIPTION
## Summary

Fixes audit finding **C-2** from `.planning/v1.0-audit/blockstore/REVIEW.md`:

> `engine/dedup.go:269,285` — `applyFileLevelDedupHit` rollback decrements logged at `Warn` and swallowed → permanent refcount leak + un-GC'd CAS

`Syncer.applyFileLevelDedupHit` increments `RefCount` for every distinct hash in `targetBlocks` in step 1, then calls `PersistFileBlocks` in step 2. Both step-2 failure rollback paths swallowed `DecrementRefCount` errors at `Warn`:

- **Race-conflict path (`~line 269`)**: a failed rollback was followed by a retry that re-increments — permanently leaking a `RefCount` and pinning a CAS chunk against GC.
- **Non-conflict path (`~line 285`)**: leak was silent.

This change extracts a `rollbackIncrements(ctx, seen, reason) error` helper that joins per-hash decrement errors with `errors.Join`, logs each failure at **Error** (not Warn) with the leak signal, and returns the joined error so callers can surface it:

- **Race-conflict path**: if rollback fails, **do not retry** (retry would re-increment over the still-bumped refcount → permanent double-count). Return an error wrapping the original conflict + rollback failures.
- **Non-conflict path**: return an error wrapping both the persist failure and the rollback failure, so the operator observes the leak window.

Step 3 (post-commit speculative-only decrements) is unchanged — documented best-effort orphan that GC reclaims, different semantics, out of scope per the audit note.

## Test plan

New unit tests in `pkg/blockstore/engine/dedup_test.go`:

- [x] `TestApplyFileLevelDedupHit_RollbackPropagates_NonConflict` — induced persist + decrement failure; asserts error wraps both and no retry occurs (1 `FindByObjectID`, 1 `PersistFileBlocks`).
- [x] `TestApplyFileLevelDedupHit_RollbackPropagates_ConflictNoRetry` — `fakePgConflictError` + failed decrement; asserts retry aborted (no re-lookup, only the failing `PersistFileBlocks` ran) and error surfaces both signals.

Validation run on the change set:

- [x] `gofmt -s -w pkg/blockstore/engine/`
- [x] `go vet ./pkg/blockstore/...`
- [x] `golangci-lint run --timeout=5m ./pkg/blockstore/engine/...` — 0 issues
- [x] `go test ./pkg/blockstore/engine/...` — PASS
- [x] `go test -race ./pkg/blockstore/engine/...` — PASS
- [x] `go test ./pkg/blockstore/...` — PASS
- [x] `go test -run 'ApplyFileLevelDedupHit' -v ./pkg/blockstore/engine/...` — both new tests PASS