### PR TITLE
fix(blockstore/engine): verify BLAKE3 before mirror upload (S-1)

### DIFF
--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -325,7 +325,7 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 				"hash", hash.String(),
 				"computed", computed.String(),
 				"bytes", len(data))
-			return fmt.Errorf("local corruption on hash %s: computed %s (refusing upload)", hash.String(), computed.String())
+			return fmt.Errorf("%w on hash %s: computed %s (refusing upload)", blockstore.ErrCASContentMismatch, hash.String(), computed.String())
 		}
 		if err := m.remoteStore.Put(ctx, hash, data); err != nil {
 			return fmt.Errorf("remote put %s: %w", hash, err)

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore/local"
 	"github.com/marmos91/dittofs/pkg/blockstore/remote"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"lukechampine.com/blake3"
 )
 
 // defaultShutdownTimeout is the maximum time to wait for the transfer queue
@@ -310,6 +311,21 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 		data, err := m.local.Get(ctx, hash)
 		if err != nil {
 			return fmt.Errorf("local get %s: %w", hash, err)
+		}
+		// Re-hash fetched bytes before upload. Local bitrot, torn
+		// writes, or hardware errors between rollup-time hashing and
+		// this read would otherwise silently propagate corrupt bytes
+		// to remote and MarkSynced them. Downstream verification via
+		// ReadBlockVerified is post-facto and useless once the local
+		// copy is evicted, so refuse the upload here and surface an
+		// error to the syncer loop.
+		computed := blockstore.ContentHash(blake3.Sum256(data))
+		if computed != hash {
+			logger.Error("local corruption detected before mirror upload — refusing to upload",
+				"hash", hash.String(),
+				"computed", computed.String(),
+				"bytes", len(data))
+			return fmt.Errorf("local corruption on hash %s: computed %s (refusing upload)", hash.String(), computed.String())
 		}
 		if err := m.remoteStore.Put(ctx, hash, data); err != nil {
 			return fmt.Errorf("remote put %s: %w", hash, err)

--- a/pkg/blockstore/engine/syncer_put_error_test.go
+++ b/pkg/blockstore/engine/syncer_put_error_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	memorylocal "github.com/marmos91/dittofs/pkg/blockstore/local/memory"
 	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	"lukechampine.com/blake3"
 )
 
 // errBoomPut is the sentinel error returned by failingPutRemote.
@@ -74,8 +75,11 @@ func (o *oneHashLocalStore) ListUnsynced(_ context.Context) iter.Seq2[blockstore
 // remote.
 func TestMirrorLoop_PropagatesPutError(t *testing.T) {
 	ctx := context.Background()
-	hash := blockstore.ContentHash{0xDE, 0xAD, 0xBE, 0xEF}
 	payload := []byte("mirror-loop-put-error")
+	// Use the real BLAKE3 hash of the payload so the pre-upload verify
+	// step in mirrorOnce passes and the test exercises the Put failure
+	// path (not the corruption-refusal path).
+	hash := blockstore.ContentHash(blake3.Sum256(payload))
 
 	local := newOneHashLocalStore(t, hash, payload)
 	rs := &failingPutRemote{}

--- a/pkg/blockstore/engine/syncer_verify_test.go
+++ b/pkg/blockstore/engine/syncer_verify_test.go
@@ -2,7 +2,7 @@ package engine
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -58,8 +58,8 @@ func TestMirrorOnce_DetectsLocalCorruption_RefusesUpload(t *testing.T) {
 	if err == nil {
 		t.Fatalf("mirrorOnce returned nil; want error reporting local corruption")
 	}
-	if !strings.Contains(err.Error(), "local corruption") {
-		t.Errorf("mirrorOnce error = %q; want substring %q", err.Error(), "local corruption")
+	if !errors.Is(err, blockstore.ErrCASContentMismatch) {
+		t.Errorf("mirrorOnce error = %v; want errors.Is(ErrCASContentMismatch)", err)
 	}
 	if got := rs.puts.Load(); got != 0 {
 		t.Errorf("remote.Put called %d times; want 0 (upload must be refused on hash mismatch)", got)

--- a/pkg/blockstore/engine/syncer_verify_test.go
+++ b/pkg/blockstore/engine/syncer_verify_test.go
@@ -1,0 +1,107 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	memorylocal "github.com/marmos91/dittofs/pkg/blockstore/local/memory"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	"lukechampine.com/blake3"
+)
+
+// countingPutRemote wraps a RemoteStore and counts Put calls so the
+// corruption test can assert that no upload happened when the local
+// bytes' BLAKE3 hash does not match the claimed CAS hash.
+type countingPutRemote struct {
+	remote.RemoteStore
+	puts atomic.Int32
+}
+
+func (r *countingPutRemote) Put(_ context.Context, _ blockstore.ContentHash, _ []byte) error {
+	r.puts.Add(1)
+	return nil
+}
+
+// TestMirrorOnce_DetectsLocalCorruption_RefusesUpload verifies that
+// mirrorOnce re-hashes the local bytes before uploading and refuses
+// to upload (and refuses to MarkSynced) when the computed BLAKE3 hash
+// does not match the claimed CAS hash. This protects against local
+// bitrot, torn writes, or hardware errors silently propagating corrupt
+// bytes to the remote.
+func TestMirrorOnce_DetectsLocalCorruption_RefusesUpload(t *testing.T) {
+	ctx := context.Background()
+
+	// Claimed hash deliberately constructed to NOT match the payload.
+	claimedHash := blockstore.ContentHash{0xDE, 0xAD, 0xBE, 0xEF}
+	corruptPayload := []byte("corrupt-bytes-that-do-not-hash-to-claimed-hash")
+
+	// Sanity-guard the fixture: if these somehow collided, the test
+	// would be a false-negative.
+	if blockstore.ContentHash(blake3.Sum256(corruptPayload)) == claimedHash {
+		t.Fatalf("test fixture invalid: corrupt payload coincidentally hashes to claimed hash")
+	}
+
+	local := newOneHashLocalStore(t, claimedHash, corruptPayload)
+	rs := &countingPutRemote{}
+	synced := newRecordingSyncedHashStore()
+
+	m := &Syncer{
+		local:           local,
+		remoteStore:     rs,
+		syncedHashStore: synced,
+	}
+
+	err := m.mirrorOnce(ctx)
+	if err == nil {
+		t.Fatalf("mirrorOnce returned nil; want error reporting local corruption")
+	}
+	if !strings.Contains(err.Error(), "local corruption") {
+		t.Errorf("mirrorOnce error = %q; want substring %q", err.Error(), "local corruption")
+	}
+	if got := rs.puts.Load(); got != 0 {
+		t.Errorf("remote.Put called %d times; want 0 (upload must be refused on hash mismatch)", got)
+	}
+	if ok, _ := synced.IsSynced(ctx, claimedHash); ok {
+		t.Errorf("MarkSynced fired for corrupt hash; want no mark on hash mismatch")
+	}
+}
+
+// TestMirrorOnce_GoodHash_Uploads verifies the happy path: when the
+// local bytes' BLAKE3 hash matches the claimed CAS hash, mirrorOnce
+// uploads via remote.Put and MarkSynced fires through the synced-hash
+// store. Confirms the new verify step does not break the legitimate
+// code path.
+func TestMirrorOnce_GoodHash_Uploads(t *testing.T) {
+	ctx := context.Background()
+
+	payload := []byte("legitimate-mirror-loop-payload-bytes-for-happy-path")
+	hash := blockstore.ContentHash(blake3.Sum256(payload))
+
+	ms := memorylocal.New()
+	if err := ms.Put(ctx, hash, payload); err != nil {
+		t.Fatalf("seed local Put: %v", err)
+	}
+	local := &oneHashLocalStore{MemoryStore: ms, hash: hash}
+
+	rs := &countingPutRemote{}
+	synced := newRecordingSyncedHashStore()
+
+	m := &Syncer{
+		local:           local,
+		remoteStore:     rs,
+		syncedHashStore: synced,
+	}
+
+	if err := m.mirrorOnce(ctx); err != nil {
+		t.Fatalf("mirrorOnce: %v", err)
+	}
+	if got := rs.puts.Load(); got != 1 {
+		t.Errorf("remote.Put called %d times; want 1", got)
+	}
+	if ok, _ := synced.IsSynced(ctx, hash); !ok {
+		t.Errorf("MarkSynced did not fire for good hash; want hash marked synced after upload")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes HIGH finding **S-1** from `.planning/v1.0-audit/blockstore/REVIEW.md`:

> `engine/syncer.go:306` — No `blake3(data) == hash` verification in `mirrorOnce` before `remoteStore.Put` — bitrot / torn-write / hw-error → silently uploads corrupt bytes to S3 + marks synced. Downstream detection via `ReadBlockVerified` is post-facto; local may have evicted.

Re-hash the fetched bytes between `local.Get` and `remote.Put`. On mismatch, log at ERROR (CLAUDE.md invariant 6 — unexpected error) and bail the mirror loop with a wrapped error. The hash is **never** uploaded and **never** marked synced, so the next pass retries against (presumably correct) local bytes — or, if the local bytes are truly corrupt, surfaces the error on every pass until an operator intervenes.

## Why

The previous `mirrorOnce` loop trusted that `local.Get(hash)` returned bytes whose BLAKE3 still matched `hash`. Local bitrot, torn-writes, or hardware errors between rollup-time hashing and the mirror call would silently:

1. Upload garbage to S3 under the (correct) CAS key.
2. `MarkSynced(hash)` so the chunk is considered authoritatively mirrored.
3. Make `ReadBlockVerified` the only line of defense — useless once the local copy is evicted.

The re-hash adds one BLAKE3 pass over the chunk bytes (cheap relative to the S3 upload it gates). Bailing matches the existing loop's bail-on-error semantics — operators see the corruption signal through the ERROR log and through the syncer's failed-sync counter.

## Test plan

- [x] `TestMirrorOnce_DetectsLocalCorruption_RefusesUpload` — local store returns payload whose BLAKE3 ≠ claimed hash. Assert `mirrorOnce` returns an error containing `"local corruption"`, `remote.Put` is called **zero** times, `MarkSynced` fires **zero** times.
- [x] `TestMirrorOnce_GoodHash_Uploads` — local store returns payload whose BLAKE3 matches the claimed hash. Assert `remote.Put` and `MarkSynced` each fire exactly once.
- [x] Existing `TestMirrorLoop_PropagatesPutError` updated to use a real BLAKE3 hash so it still exercises the Put-error path (not the new corruption-refusal path).
- [x] `go vet ./pkg/blockstore/...` clean.
- [x] `golangci-lint run --timeout=5m ./pkg/blockstore/engine/...` — 0 issues.
- [x] `go test ./pkg/blockstore/engine/...` — all pass.
- [x] `go test -race ./pkg/blockstore/engine/...` — all pass.
- [x] `go test ./pkg/blockstore/...` — all pass.

## References

- HIGH finding **S-1** in `.planning/v1.0-audit/blockstore/REVIEW.md`
- Part of v1.0 audit area #1 (blockstore) B-C wave