### PR TITLE
fix(blockstore/engine): refcount gcRootLocks entries (C-3)

### DIFF
--- a/pkg/blockstore/engine/gc.go
+++ b/pkg/blockstore/engine/gc.go
@@ -55,44 +55,73 @@ const BlockSize = blockstore.BlockSize
 // silently truncating the live set and risking (mark fail-closed)
 // violation by data path.
 //
-// Scope is per-process: a sync.Mutex keyed by absolute GCStateRoot path.
-// lock granularity is therefore PER-SHARE in practice — each
-// share owns its own gc-state directory under <localStore>/gc-state/, so
-// concurrent runs against DIFFERENT shares acquire DIFFERENT mutexes and
-// proceed in parallel; only same-share GC calls serialize. For the
-// Phase-11 single-server deployment this is sufficient; cross-process
-// safety (multi-server) requires an OS-level flock and is left as a TODO
-// for the multi-process phase.
+// Scope is per-process: a refcounted *gcRootLock keyed by absolute
+// GCStateRoot path (the empty key "" maps to its own shared lock so
+// temp-root callers still serialize against each other). Lock
+// granularity is therefore PER-SHARE in practice — each share owns its
+// own gc-state directory under <localStore>/gc-state/, so concurrent
+// runs against DIFFERENT shares acquire DIFFERENT locks and proceed in
+// parallel; only same-share GC calls serialize. For the Phase-11
+// single-server deployment this is sufficient; cross-process safety
+// (multi-server) requires an OS-level flock and is left as a TODO for
+// the multi-process phase.
 //
-// The empty key ("") receives its own mutex so callers that pass no
-// GCStateRoot (RunBlockGC's temp-root variant) still serialize against
-// each other. This is conservative: each temp root is unique per call so
-// races on the temp dir itself are impossible, but sharing one mutex
-// across all temp-root runs prevents accidental concurrent CollectGarbage
-// pile-ups against a single remote endpoint (see sketch).
+// Entries are reference-counted and deleted from the map when their
+// refcount drops to zero, so the map shrinks back to size 0 whenever no
+// GC run is in flight. Without this, a long-running server that creates
+// and destroys shares with distinct gc-state paths would accumulate
+// stale map entries indefinitely.
 var (
 	gcRootLocksMu sync.Mutex
-	gcRootLocks   = make(map[string]*sync.Mutex)
+	gcRootLocks   = make(map[string]*gcRootLock)
 )
 
-// acquireGCRootLock returns the per-root mutex (creating it on first use)
-// already locked. Callers MUST defer mu.Unlock(). The lock key is
-// filepath.Clean'd so cosmetic differences ("/a/b" vs "/a/b/") map to the
-// same mutex.
-func acquireGCRootLock(root string) *sync.Mutex {
+// gcRootLock is the map value: a serializing mutex plus a refcount
+// guarded by gcRootLocksMu. The refcount tracks live acquireGCRootLock
+// callers so releaseGCRootLock can drop the map entry when nobody else
+// is holding or waiting on it.
+type gcRootLock struct {
+	mu       sync.Mutex
+	refCount int // guarded by gcRootLocksMu
+}
+
+// acquireGCRootLock returns the per-root lock (creating it on first
+// use) already locked. Callers MUST pair this with releaseGCRootLock so
+// the refcount drops and the entry can be reclaimed when idle. The lock
+// key is filepath.Clean'd so cosmetic differences ("/a/b" vs "/a/b/")
+// map to the same lock.
+func acquireGCRootLock(root string) *gcRootLock {
 	key := root
 	if key != "" {
 		key = filepath.Clean(key)
 	}
 	gcRootLocksMu.Lock()
-	mu, ok := gcRootLocks[key]
+	entry, ok := gcRootLocks[key]
 	if !ok {
-		mu = &sync.Mutex{}
-		gcRootLocks[key] = mu
+		entry = &gcRootLock{}
+		gcRootLocks[key] = entry
+	}
+	entry.refCount++
+	gcRootLocksMu.Unlock()
+	entry.mu.Lock()
+	return entry
+}
+
+// releaseGCRootLock unlocks the per-root lock and drops the map entry
+// when no other caller is holding or waiting on it. Pairs with
+// acquireGCRootLock.
+func releaseGCRootLock(root string, entry *gcRootLock) {
+	entry.mu.Unlock()
+	key := root
+	if key != "" {
+		key = filepath.Clean(key)
+	}
+	gcRootLocksMu.Lock()
+	entry.refCount--
+	if entry.refCount <= 0 {
+		delete(gcRootLocks, key)
 	}
 	gcRootLocksMu.Unlock()
-	mu.Lock()
-	return mu
 }
 
 // GCStats holds statistics about the garbage collection run.
@@ -237,7 +266,7 @@ func CollectGarbage(
 	// (mark fail-closed) violation by data path. Lock is acquired
 	// before any disk-state work and released on return.
 	rootLock := acquireGCRootLock(options.GCStateRoot)
-	defer rootLock.Unlock()
+	defer releaseGCRootLock(options.GCStateRoot, rootLock)
 
 	// Apply defaults that the caller did not specify.
 	gracePeriod := options.GracePeriod

--- a/pkg/blockstore/engine/gc_root_lock_test.go
+++ b/pkg/blockstore/engine/gc_root_lock_test.go
@@ -1,0 +1,140 @@
+package engine
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// snapshotMapLen reads len(gcRootLocks) under gcRootLocksMu.
+func snapshotMapLen() int {
+	gcRootLocksMu.Lock()
+	defer gcRootLocksMu.Unlock()
+	return len(gcRootLocks)
+}
+
+// TestGCRootLock_MapShrinksAfterRelease verifies the refcount cleanup
+// mechanism: after acquire+release across many distinct keys, the map
+// returns to its pre-test size.
+func TestGCRootLock_MapShrinksAfterRelease(t *testing.T) {
+	startLen := snapshotMapLen()
+	const n = 100
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("/tmp/dittofs-gc-test-%d", i)
+		lock := acquireGCRootLock(key)
+		releaseGCRootLock(key, lock)
+	}
+	if got := snapshotMapLen(); got != startLen {
+		t.Fatalf("gcRootLocks map did not shrink: start=%d after=%d", startLen, got)
+	}
+}
+
+// TestGCRootLock_RefcountSerializesSameKey verifies that two goroutines
+// acquiring the same key serialize on the underlying mutex, and that
+// the map entry is reclaimed once both release.
+func TestGCRootLock_RefcountSerializesSameKey(t *testing.T) {
+	startLen := snapshotMapLen()
+	const key = "/tmp/dittofs-gc-test-serialize"
+
+	var holders int32
+	var maxConcurrent int32
+
+	criticalSection := func(t *testing.T) {
+		cur := atomic.AddInt32(&holders, 1)
+		for {
+			peak := atomic.LoadInt32(&maxConcurrent)
+			if cur <= peak || atomic.CompareAndSwapInt32(&maxConcurrent, peak, cur) {
+				break
+			}
+		}
+		// Hold briefly so the second goroutine has time to block in
+		// acquireGCRootLock if mutual exclusion were broken.
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&holders, -1)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			lock := acquireGCRootLock(key)
+			defer releaseGCRootLock(key, lock)
+			criticalSection(t)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxConcurrent); got != 1 {
+		t.Fatalf("expected mutual exclusion (maxConcurrent=1), got %d", got)
+	}
+	if got := snapshotMapLen(); got != startLen {
+		t.Fatalf("map entry not reclaimed: start=%d after=%d", startLen, got)
+	}
+}
+
+// TestGCRootLock_EmptyKey_SerializesAcrossCallers verifies the
+// documented behavior that callers passing an empty GCStateRoot (the
+// temp-root variant) share a single mutex.
+func TestGCRootLock_EmptyKey_SerializesAcrossCallers(t *testing.T) {
+	startLen := snapshotMapLen()
+
+	// Acquire the empty key twice — second acquire must hit the same
+	// map entry with refCount==2 and block on the mutex.
+	a := acquireGCRootLock("")
+
+	gcRootLocksMu.Lock()
+	entry, ok := gcRootLocks[""]
+	gcRootLocksMu.Unlock()
+	if !ok {
+		t.Fatal("empty key not present in gcRootLocks after acquire")
+	}
+	if entry != a {
+		t.Fatal("empty-key entry differs from returned lock")
+	}
+
+	// Spawn a second acquirer that should block until we release.
+	acquired := make(chan *gcRootLock, 1)
+	go func() {
+		b := acquireGCRootLock("")
+		acquired <- b
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second acquireGCRootLock(\"\") did not block — empty key not serializing")
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked on the shared mutex
+	}
+
+	// While the second acquirer is parked, refCount must reflect both
+	// holders so release-from-first does not drop the entry from the map.
+	gcRootLocksMu.Lock()
+	rc := entry.refCount
+	gcRootLocksMu.Unlock()
+	if rc != 2 {
+		t.Fatalf("expected refCount=2 with one holder + one waiter, got %d", rc)
+	}
+
+	releaseGCRootLock("", a)
+
+	var b *gcRootLock
+	select {
+	case b = <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second acquirer never unblocked after release")
+	}
+	if b != entry {
+		t.Fatal("second acquirer received a different lock object — empty key not shared")
+	}
+	releaseGCRootLock("", b)
+
+	if got := snapshotMapLen(); got != startLen {
+		t.Fatalf("empty-key entry not reclaimed: start=%d after=%d", startLen, got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes C-3 from `.planning/v1.0-audit/blockstore/REVIEW.md`.

The `gcRootLocks` package-level map keyed each `GCStateRoot` to a `*sync.Mutex` and never trimmed entries. On long-running servers that create and destroy shares with distinct gc-state paths, the map accumulated stale `*sync.Mutex` entries forever.

Note on the audit phrasing: the map is keyed by `options.GCStateRoot` (set once per call from share config), not by the materialised `makeTempGCStateRoot()` temp path — so the empty-string key still serialises temp-root callers correctly today. The real leak is persistent paths accumulating, not new mutexes per call.

## Fix

- Wrap each map value in a small `gcRootLock { mu sync.Mutex; refCount int }` holder.
- `acquireGCRootLock` increments the refcount under `gcRootLocksMu` before taking the inner mutex.
- New `releaseGCRootLock` unlocks the inner mutex, decrements the refcount, and `delete`s the map entry when it hits zero.
- `CollectGarbage` swaps `defer rootLock.Unlock()` → `defer releaseGCRootLock(...)`.
- Comment block rewritten to drop the audit's misread about temp-dir paths and explain the refcount cleanup instead.

The map shrinks back to size 0 whenever no GC run is in flight. Same-key concurrency still serialises; empty-key callers still share a single mutex.

## Test plan

- [x] `gofmt -s -w pkg/blockstore/engine/` + `go vet ./pkg/blockstore/...`
- [x] `golangci-lint run --timeout=5m ./pkg/blockstore/engine/...` — 0 issues
- [x] `go test ./pkg/blockstore/engine/...` — pass
- [x] `go test -race ./pkg/blockstore/engine/...` — pass
- [x] New `pkg/blockstore/engine/gc_root_lock_test.go`:
  - `TestGCRootLock_MapShrinksAfterRelease` — 100 distinct keys → map back to start size
  - `TestGCRootLock_RefcountSerializesSameKey` — 2 goroutines, asserts `maxConcurrent==1` and map cleanup
  - `TestGCRootLock_EmptyKey_SerializesAcrossCallers` — explicit empty-key shared-mutex check + refcount=2 with waiter

Refs: `.planning/v1.0-audit/blockstore/REVIEW.md` C-3