### PR TITLE
fix(smb/dh): postgres schema for position_info + original_file_id (#663)

### DIFF
--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -26,12 +26,14 @@ const durableHandleColumns = `
 	lease_key, lease_state, create_guid, app_instance_id,
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
-	delete_pending, parent_handle, file_name, is_directory
+	delete_pending, parent_handle, file_name, is_directory,
+	position_info, original_file_id
 `
 
 func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
-	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes []byte
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var positionInfoSigned int64
 
 	err := row.Scan(
 		&h.ID,
@@ -60,6 +62,8 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&h.ParentHandle,
 		&h.FileName,
 		&h.IsDirectory,
+		&positionInfoSigned,
+		&originalFileIDBytes,
 	)
 
 	if err == pgx.ErrNoRows {
@@ -69,8 +73,12 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		return nil, err
 	}
 
+	h.PositionInfo = uint64(positionInfoSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
 		appInstanceIdBytes, sessionKeyHashBytes)
+	if len(originalFileIDBytes) == 16 {
+		copy(h.OriginalFileID[:], originalFileIDBytes)
+	}
 	return &h, nil
 }
 
@@ -80,7 +88,8 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 	var result []*lock.PersistedDurableHandle
 	for rows.Next() {
 		var h lock.PersistedDurableHandle
-		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes []byte
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var positionInfoSigned int64
 
 		err := rows.Scan(
 			&h.ID,
@@ -109,12 +118,18 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&h.ParentHandle,
 			&h.FileName,
 			&h.IsDirectory,
+			&positionInfoSigned,
+			&originalFileIDBytes,
 		)
 		if err != nil {
 			return nil, err
 		}
 
+		h.PositionInfo = uint64(positionInfoSigned)
 		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		if len(originalFileIDBytes) == 16 {
+			copy(h.OriginalFileID[:], originalFileIDBytes)
+		}
 		result = append(result, &h)
 	}
 
@@ -160,9 +175,10 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			lease_key, lease_state, create_guid, app_instance_id,
 			username, session_key_hash, is_v2, created_at, disconnected_at,
 			timeout_ms, server_start_time,
-			delete_pending, parent_handle, file_name, is_directory
+			delete_pending, parent_handle, file_name, is_directory,
+			position_info, original_file_id
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -188,7 +204,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			delete_pending = EXCLUDED.delete_pending,
 			parent_handle = EXCLUDED.parent_handle,
 			file_name = EXCLUDED.file_name,
-			is_directory = EXCLUDED.is_directory
+			is_directory = EXCLUDED.is_directory,
+			position_info = EXCLUDED.position_info,
+			original_file_id = EXCLUDED.original_file_id
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -218,6 +236,12 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		handle.ParentHandle,
 		handle.FileName,
 		handle.IsDirectory,
+		// PositionInfo is a file offset (FILE_POSITION_INFORMATION.CurrentByteOffset,
+		// MS-FSCC 2.4.32) stored as BIGINT (signed int64). File offsets fit in
+		// int64 in practice; reinterpret the bit pattern to preserve any high-bit
+		// value. The scan path mirrors this with uint64(int64) on read.
+		int64(handle.PositionInfo),
+		handle.OriginalFileID[:],
 	)
 	return err
 }

--- a/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE durable_handles DROP CONSTRAINT IF EXISTS valid_original_file_id;
+ALTER TABLE durable_handles DROP COLUMN IF EXISTS original_file_id;
+ALTER TABLE durable_handles DROP COLUMN IF EXISTS position_info;

--- a/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.up.sql
@@ -1,0 +1,36 @@
+-- Persist PositionInfo + OriginalFileID on durable handles (#663 follow-up to #661).
+--
+-- DH V1 reconnect plumbing added two fields to lock.PersistedDurableHandle that
+-- the memory backend already round-trips and badger picks up via JSON:
+--
+--   * PositionInfo  — FILE_POSITION_INFORMATION CurrentByteOffset
+--                     (MS-FSCC 2.4.32) captured at disconnect. Restoring this
+--                     on reconnect makes SET/GET FilePositionInformation
+--                     survive the disconnect (smb2.durable-open.file-position).
+--
+--   * OriginalFileID — full 16-byte FileID (persistent + volatile) from the
+--                     original CREATE response. The primary `file_id` column
+--                     zeros the volatile half so DHnC lookup matches the spec
+--                     (MS-SMB2 §3.2.4.4 client sends Data.Volatile=0). On
+--                     successful reconnect the handler restores OriginalFileID
+--                     into the new OpenFile so byte-range locks (which key on
+--                     the OpenID derived from FileID) stay valid across the
+--                     disconnect (smb2.durable-open.lock-{oplock,lease}).
+--
+-- Without these columns the postgres profile silently regresses DH V1: file
+-- position reports 0 after reconnect and BR locks are orphaned because
+-- OriginalFileID always decodes to zero, forcing volatile-half regeneration
+-- and a fresh OpenID.
+--
+-- Pre-existing rows default to 0 / all-zero bytes. The reconnect handler
+-- already treats a zero OriginalFileID as "fall back to file_id" for
+-- backwards compatibility, so existing handles keep working.
+
+ALTER TABLE durable_handles
+    ADD COLUMN IF NOT EXISTS position_info BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE durable_handles
+    ADD COLUMN IF NOT EXISTS original_file_id BYTEA NOT NULL DEFAULT '\x00000000000000000000000000000000'::bytea;
+
+ALTER TABLE durable_handles
+    ADD CONSTRAINT valid_original_file_id CHECK (length(original_file_id) = 16);

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -121,6 +121,13 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 	var sessionKeyHash [32]byte
 	copy(sessionKeyHash[:], []byte("sessionhash-"+id))
 
+	// OriginalFileID is the full 16-byte FileID (persistent + volatile half)
+	// from the original CREATE response. The primary FileID above zeros the
+	// volatile half so DHnC lookup matches the spec; OriginalFileID preserves
+	// the original bytes so BR-lock OpenID stays stable across reconnect.
+	var originalFileID [16]byte
+	copy(originalFileID[:], []byte("origfid-"+id))
+
 	return &lock.PersistedDurableHandle{
 		ID:              id,
 		FileID:          fileID,
@@ -144,6 +151,8 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 		DisconnectedAt:  now,
 		TimeoutMs:       60000,
 		ServerStartTime: now.Add(-1 * time.Hour),
+		PositionInfo:    0xDEADBEEFCAFE,
+		OriginalFileID:  originalFileID,
 	}
 }
 
@@ -219,6 +228,12 @@ func assertDurableHandleEqual(t *testing.T, expected, actual *lock.PersistedDura
 	}
 	if !expected.ServerStartTime.Equal(actual.ServerStartTime) {
 		t.Errorf("ServerStartTime: got %v, want %v", actual.ServerStartTime, expected.ServerStartTime)
+	}
+	if expected.PositionInfo != actual.PositionInfo {
+		t.Errorf("PositionInfo: got %d, want %d", actual.PositionInfo, expected.PositionInfo)
+	}
+	if expected.OriginalFileID != actual.OriginalFileID {
+		t.Errorf("OriginalFileID: got %x, want %x", actual.OriginalFileID, expected.OriginalFileID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #663. Mirrors the in-memory `lock.PersistedDurableHandle` shape into the postgres backend so DH V1 reconnect on postgres-backed deployments matches the memory + badger backends.

PR #661 added two fields to the durable-handle shape and migrated sqlite/in-memory, but postgres was intentionally deferred. Without these columns the postgres profile silently regresses DH V1 reconnect:

- File position reports as `0` after reconnect (`smb2.durable-open.file-position`).
- BR locks taken before disconnect are orphaned because `OriginalFileID` always decodes as zero, forcing volatile-half regeneration and a fresh OpenID (`smb2.durable-open.lock-{oplock,lease}`).

Conformance CI runs on the memory profile so this gap did not show up in test counts, but the postgres-backed code path was non-functional for DH V1.

## Changes

- **Migration `000017_durable_handle_position_and_original_fileid.{up,down}.sql`** — add `position_info BIGINT NOT NULL DEFAULT 0` and `original_file_id BYTEA NOT NULL DEFAULT \x00…\x00` with `length(original_file_id) = 16` check constraint. Pre-existing rows default to zeros; the reconnect handler already treats a zero `OriginalFileID` as fall-back to `file_id`.
- **`pkg/metadata/store/postgres/durable_handles.go`** — extend `durableHandleColumns`, both `Scan` paths, and `PutDurableHandle` INSERT + UPDATE to cover the two new fields. `PositionInfo` is a file offset stored as BIGINT via `int64`/`uint64` bit reinterpretation (file offsets fit in int64 in practice; the rollup-offset and `MaxFileSize` code use the same pattern).
- **`pkg/metadata/storetest/durable_handles.go`** — seed both fields in `makeDurableHandle` and round-trip them in `assertDurableHandleEqual` so any future backend gap is caught by the conformance suite.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/metadata/store/postgres/... ./pkg/metadata/storetest/...`
- [x] `golangci-lint run --timeout=5m ./pkg/metadata/store/postgres/... ./pkg/metadata/storetest/...` — 0 issues
- [x] `go test -race ./pkg/metadata/store/memory/... ./pkg/metadata/store/badger/...` — extended conformance suite passes (memory + badger were already storing both fields)
- [x] `go test -race ./pkg/metadata/store/postgres/...` — unit tests pass
- [x] `go test -race ./internal/adapter/smb/v2/handlers/...` — pass
- [x] Live PG `TestConformance/DurableHandles` (integration tag) — all 14 sub-tests pass on a fresh DB including the two new fields. `ListAll` shows pre-existing cross-subtest contamination (no table reset between subtests) — also fails on `develop` when run after siblings, passes in isolation. Not introduced by this change.
- [x] Schema verified post-migration: `position_info bigint` and `original_file_id bytea` columns present with `valid_original_file_id CHECK (length(original_file_id) = 16)`.

## Refs

#431, #661.