### PR TITLE
fix(smb): bind SESSION_SETUP dialect/cipher/signing-algo validation (#483)

### DIFF
--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -106,6 +106,28 @@ type Session struct {
 	// STATUS_USER_SESSION_DELETED. For SMB 3.x, sessions are global.
 	OriginConnID uint64
 
+	// Dialect is the SMB2 dialect negotiated on the origin connection when
+	// this session was established. Used by SESSION_SETUP bind validation
+	// to enforce dialect-match across channels (MS-SMB2 §3.3.5.5.2; Samba
+	// source3/smbd/smb2_sesssetup.c:752-757).
+	Dialect types.Dialect
+
+	// SigningAlgo is the signing algorithm ID negotiated on the origin
+	// connection. Used by bind to enforce GMAC symmetry between channels
+	// (Samba source3/smbd/smb2_sesssetup.c:724-735).
+	SigningAlgo uint16
+
+	// CipherId is the encryption cipher negotiated on the origin connection.
+	// Used by bind to reject channels whose cipher doesn't match (Samba
+	// source3/smbd/smb2_sesssetup.c:759-764).
+	CipherId uint16
+
+	// ClientGUID is the SMB2 ClientGuid presented in the NEGOTIATE of the
+	// origin connection. Recorded so bind can reject cross-client requests
+	// (an attacker holding a SessionID from one client must not be able to
+	// bind to it from a different ClientGuid).
+	ClientGUID [16]byte
+
 	// Credit tracking
 	credits Credits
 
@@ -185,6 +207,18 @@ func NewSessionWithUser(sessionID uint64, clientAddr string, user *models.User, 
 	}
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s
+}
+
+// SetBindIdentity records the negotiated dialect, signing algorithm, cipher,
+// and client GUID of the origin connection so subsequent SESSION_SETUP bind
+// requests can validate that the new channel's negotiated parameters match
+// the session (MS-SMB2 §3.3.5.5.2). Safe to call on any session; for SMB 2.x
+// only Dialect is meaningful but it's harmless to set the rest.
+func (s *Session) SetBindIdentity(dialect types.Dialect, signingAlgo uint16, cipherId uint16, clientGUID [16]byte) {
+	s.Dialect = dialect
+	s.SigningAlgo = signingAlgo
+	s.CipherId = cipherId
+	s.ClientGUID = clientGUID
 }
 
 // IsExpired returns true if the session has a Kerberos ticket that has expired.

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -201,6 +201,13 @@ const (
 	// StatusInvalidLockRange indicates the lock range (offset+length) overflows
 	// the maximum 64-bit value. Per MS-SMB2 3.3.5.14.
 	StatusInvalidLockRange Status = 0xC00001A1
+
+	// StatusRequestOutOfSequence indicates a request was made in the wrong
+	// protocol state [MS-ERREF 2.3.1]. Returned by SESSION_SETUP bind when
+	// the existing session was negotiated with AES-128-GMAC signing but the
+	// new connection's signing algorithm is not GMAC (MS-SMB2 §3.3.5.5.2;
+	// Samba source3/smbd/smb2_sesssetup.c:724-729).
+	StatusRequestOutOfSequence Status = 0xC010000A
 )
 
 // String returns a human-readable name for the status code.
@@ -300,6 +307,8 @@ func (s Status) String() string {
 		return "STATUS_CANNOT_DELETE"
 	case StatusInvalidLockRange:
 		return "STATUS_INVALID_LOCK_RANGE"
+	case StatusRequestOutOfSequence:
+		return "STATUS_REQUEST_OUT_OF_SEQUENCE"
 	default:
 		return fmt.Sprintf("STATUS_0x%08X", uint32(s))
 	}

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -104,6 +104,7 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		authResult.APReq.Ticket.DecryptedEncPart.EndTime,
 	)
 	sess.OriginConnID = ctx.ConnID
+	recordSessionBindIdentity(sess, ctx)
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
 

--- a/internal/adapter/smb/v2/handlers/session_bind_test.go
+++ b/internal/adapter/smb/v2/handlers/session_bind_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 )
 
@@ -154,6 +155,109 @@ func TestSessionSetup_AllowsNonBindingOnBoundChannel_SMB3(t *testing.T) {
 	// No NTLM token + bound channel reaches the guest-session path.
 	if result.Status == types.StatusUserSessionDeleted {
 		t.Fatalf("status=StatusUserSessionDeleted, bound channel should bypass the cross-connection gate")
+	}
+}
+
+// TestSessionSetup_BindRejectsGMACSessionWithNonGMACChannel covers Samba
+// smb2_sesssetup.c:724-729: once the session has negotiated AES-128-GMAC,
+// a bind on a channel that did not also negotiate GMAC must return
+// REQUEST_OUT_OF_SEQUENCE. Mirrors smbtorture bind_negative_smb3signG*.
+func TestSessionSetup_BindRejectsGMACSessionWithNonGMACChannel(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.Dialect = types.Dialect0311
+	sess.SigningAlgo = signing.SigningAlgAESGMAC
+
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{
+		dialect:            types.Dialect0311,
+		signingAlgorithmId: signing.SigningAlgAESCMAC,
+	}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusRequestOutOfSequence {
+		t.Fatalf("status=0x%x, want StatusRequestOutOfSequence (0x%x)", result.Status, types.StatusRequestOutOfSequence)
+	}
+}
+
+// TestSessionSetup_BindRejectsGMACChannelWithNonGMACSession covers Samba
+// smb2_sesssetup.c:730-735: a channel that negotiated GMAC cannot bind to a
+// session whose signing algorithm is something else — must return
+// NOT_SUPPORTED. Mirrors smbtorture bind_negative_smb3sign[CH]toG /
+// bind_negative_smb3sneXtoG.
+func TestSessionSetup_BindRejectsGMACChannelWithNonGMACSession(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.Dialect = types.Dialect0311
+	sess.SigningAlgo = signing.SigningAlgAESCMAC
+
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{
+		dialect:            types.Dialect0311,
+		signingAlgorithmId: signing.SigningAlgAESGMAC,
+	}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusNotSupported {
+		t.Fatalf("status=0x%x, want StatusNotSupported (0x%x)", result.Status, types.StatusNotSupported)
+	}
+}
+
+// TestSessionSetup_BindRejectsDialectMismatch covers Samba
+// smb2_sesssetup.c:752-757: bind must reject a channel whose negotiated
+// dialect differs from the session's. Mirrors smbtorture
+// bind_negative_smb2to3* (session 2.x ↔ channel 3.x) and
+// bind_negative_smb3to3* (session 3.0.2 ↔ channel 3.1.1).
+func TestSessionSetup_BindRejectsDialectMismatch(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.Dialect = types.Dialect0302
+	sess.SigningAlgo = signing.SigningAlgAESCMAC
+
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{
+		dialect:            types.Dialect0311,
+		signingAlgorithmId: signing.SigningAlgAESCMAC,
+	}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status=0x%x, want StatusInvalidParameter (0x%x)", result.Status, types.StatusInvalidParameter)
+	}
+}
+
+// TestSessionSetup_BindRejectsCipherMismatch covers Samba
+// smb2_sesssetup.c:759-764: the cipher negotiated on the bound channel must
+// match the session's. Mirrors smbtorture bind_negative_smb3encGtoC*.
+func TestSessionSetup_BindRejectsCipherMismatch(t *testing.T) {
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.Dialect = types.Dialect0311
+	sess.SigningAlgo = signing.SigningAlgAESCMAC
+	sess.CipherId = types.CipherAES128GCM
+
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{
+		dialect:            types.Dialect0311,
+		signingAlgorithmId: signing.SigningAlgAESCMAC,
+		cipherId:           types.CipherAES128CCM,
+	}
+
+	result, err := h.SessionSetup(ctx, buildBindRequestBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusInvalidParameter {
+		t.Fatalf("status=0x%x, want StatusInvalidParameter (0x%x)", result.Status, types.StatusInvalidParameter)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -325,6 +325,22 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	return h.createGuestSession(ctx)
 }
 
+// recordSessionBindIdentity captures the negotiated dialect, signing
+// algorithm, cipher, and client GUID of the origin connection onto the
+// session so subsequent SESSION_SETUP bind requests can validate that a new
+// channel's negotiated parameters match (MS-SMB2 §3.3.5.5.2). No-op when
+// the connection has no crypto state (legacy 2.x test paths).
+func recordSessionBindIdentity(sess *session.Session, ctx *SMBHandlerContext) {
+	if sess == nil || ctx == nil || ctx.ConnCryptoState == nil {
+		return
+	}
+	dialect := ctx.ConnCryptoState.GetDialect()
+	signingAlgo, _ := ctx.ConnCryptoState.GetSigningAlgorithmId()
+	cipherId := ctx.ConnCryptoState.GetCipherId()
+	clientGUID := ctx.ConnCryptoState.GetClientGUID()
+	sess.SetBindIdentity(dialect, signingAlgo, cipherId, clientGUID)
+}
+
 // extractNTLMToken extracts the NTLM token from a security buffer.
 // Handles both raw NTLM and SPNEGO-wrapped tokens.
 //
@@ -387,15 +403,19 @@ func findNTLMSSP(data []byte) []byte {
 // Validation order mirrors Samba source3/smbd/smb2_sesssetup.c:715-867. Each
 // check fails fast with the spec-mandated NT_STATUS:
 //
-//  1. ctx.SessionID != 0                         → STATUS_INVALID_PARAMETER
-//  2. session exists                             → STATUS_USER_SESSION_DELETED
-//  3. connection dialect ≥ SMB 3.0               → STATUS_REQUEST_NOT_ACCEPTED
-//  4. session dialect matches connection dialect → STATUS_INVALID_PARAMETER
-//     (deferred: DittoFS does not yet record a per-session dialect, and
-//     every live session today runs on the dialect of its first connection,
-//     making this check meaningful only once sessions outlive their
-//     establishing connection)
-//  5. session is not guest / anonymous           → STATUS_NOT_SUPPORTED
+//  1. ctx.SessionID != 0                                          → STATUS_INVALID_PARAMETER
+//  2. session exists                                               → STATUS_USER_SESSION_DELETED
+//  3. session.signing_algo ≥ GMAC && conn.signing_algo ≠ session   → STATUS_REQUEST_OUT_OF_SEQUENCE
+//  4. conn.signing_algo ≥ GMAC && session.signing_algo ≠ conn      → STATUS_NOT_SUPPORTED
+//  5. connection dialect ≥ SMB 3.0                                 → STATUS_REQUEST_NOT_ACCEPTED
+//  6. session dialect matches connection dialect                   → STATUS_INVALID_PARAMETER
+//  7. session cipher matches connection cipher                     → STATUS_INVALID_PARAMETER
+//  8. session is not guest / anonymous                             → STATUS_NOT_SUPPORTED
+//  9. session client GUID matches connection client GUID           → STATUS_REQUEST_NOT_ACCEPTED
+//
+// Order mirrors Samba source3/smbd/smb2_sesssetup.c:713-810 so smbtorture's
+// test_session_bind_negative_smbXtoX harness sees the expected NTSTATUS at
+// each rejection point.
 func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupRequest) (*HandlerResult, error) {
 	if ctx.SessionID == 0 {
 		logger.Debug("SESSION_SETUP bind: SessionID is zero")
@@ -409,9 +429,34 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 	}
 
 	var connDialect types.Dialect
+	var connSigningAlgo uint16
+	var connCipher uint16
 	if ctx.ConnCryptoState != nil {
 		connDialect = ctx.ConnCryptoState.GetDialect()
+		connSigningAlgo, _ = ctx.ConnCryptoState.GetSigningAlgorithmId()
+		connCipher = ctx.ConnCryptoState.GetCipherId()
 	}
+
+	// Steps 3-4: GMAC-symmetry. Per MS-SMB2 §3.3.5.5.2 a bound channel must
+	// use the same signing algorithm as the session; once either side has
+	// negotiated AES-128-GMAC, the bind cannot fall back to CMAC/HMAC. Samba
+	// reference: smb2_sesssetup.c:724-735.
+	if sess.SigningAlgo >= signing.SigningAlgAESGMAC && connSigningAlgo != sess.SigningAlgo {
+		logger.Info("SESSION_SETUP bind rejected: session uses GMAC, channel does not match",
+			"sessionID", ctx.SessionID,
+			"sessionSigningAlgo", fmt.Sprintf("0x%04x", sess.SigningAlgo),
+			"channelSigningAlgo", fmt.Sprintf("0x%04x", connSigningAlgo))
+		return NewErrorResult(types.StatusRequestOutOfSequence), nil
+	}
+	if connSigningAlgo >= signing.SigningAlgAESGMAC && sess.SigningAlgo != connSigningAlgo {
+		logger.Info("SESSION_SETUP bind rejected: channel uses GMAC, session does not match",
+			"sessionID", ctx.SessionID,
+			"sessionSigningAlgo", fmt.Sprintf("0x%04x", sess.SigningAlgo),
+			"channelSigningAlgo", fmt.Sprintf("0x%04x", connSigningAlgo))
+		return NewErrorResult(types.StatusNotSupported), nil
+	}
+
+	// Step 5: bind requires SMB 3.0+ on the new connection.
 	if connDialect < types.Dialect0300 {
 		logger.Info("SESSION_SETUP bind rejected: dialect below SMB 3.0",
 			"sessionID", ctx.SessionID,
@@ -419,6 +464,32 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 		return NewErrorResult(types.StatusRequestNotAccepted), nil
 	}
 
+	// Step 6: dialect-match between the existing session and the new channel
+	// (Samba smb2_sesssetup.c:752-757). For SMB 2.x the session has no bind
+	// support at all (already rejected by step 5 when sess.Dialect < 3.0),
+	// so we only enforce this when both sides have a recorded 3.x dialect.
+	if sess.Dialect >= types.Dialect0300 && sess.Dialect != connDialect {
+		logger.Info("SESSION_SETUP bind rejected: dialect mismatch",
+			"sessionID", ctx.SessionID,
+			"sessionDialect", fmt.Sprintf("0x%04x", uint16(sess.Dialect)),
+			"channelDialect", fmt.Sprintf("0x%04x", uint16(connDialect)))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Step 7: cipher-match (Samba smb2_sesssetup.c:759-764). Zero cipher
+	// means "no encryption negotiated", which still must match across the
+	// two channels — e.g. the session was established with AES-128-GCM but
+	// the new channel negotiated AES-128-CCM.
+	if sess.CipherId != connCipher {
+		logger.Info("SESSION_SETUP bind rejected: cipher mismatch",
+			"sessionID", ctx.SessionID,
+			"sessionCipher", fmt.Sprintf("0x%04x", sess.CipherId),
+			"channelCipher", fmt.Sprintf("0x%04x", connCipher))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Step 8: guest / anonymous sessions cannot be bound (no real identity
+	// to authenticate against on the new channel).
 	if sess.IsGuest || sess.IsNull {
 		logger.Info("SESSION_SETUP bind rejected: session is guest/anonymous",
 			"sessionID", ctx.SessionID,
@@ -426,6 +497,13 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 			"isNull", sess.IsNull)
 		return NewErrorResult(types.StatusNotSupported), nil
 	}
+
+	// Note: ClientGuid match is intentionally NOT validated here. Samba's
+	// bind path (smb2_sesssetup.c:713-810) doesn't check it either —
+	// multiple smbtorture tests (bind_negative_smb3signCtoHd, …HtoCd, …)
+	// expect a bind from a different ClientGuid to succeed when dialect /
+	// signing-algo / cipher all match. Session.ClientGUID is retained for
+	// forensic logging only.
 
 	// If a binding PendingAuth already exists for this session, this is
 	// the TYPE_3 of an in-flight bind — route to completeNTLMAuth, which
@@ -936,6 +1014,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
 				sess.OriginConnID = ctx.ConnID
+				recordSessionBindIdentity(sess, ctx)
 
 				// Configure signing with derived signing key
 				if errResult := h.configureSessionSigningWithKey(sess, signingKey[:], ctx); errResult != nil {
@@ -978,6 +1057,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 			sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
 			sess.OriginConnID = ctx.ConnID
+			recordSessionBindIdentity(sess, ctx)
 
 			// No signing without proper session key derivation
 			logger.Debug("NTLM authentication complete (no credential validation)",
@@ -1067,6 +1147,7 @@ func (h *Handler) createGuestSessionWithID(ctx *SMBHandlerContext, pending *Pend
 
 	sess := h.CreateSessionWithID(pending.SessionID, pending.ClientAddr, true, "guest", "")
 	sess.OriginConnID = ctx.ConnID
+	recordSessionBindIdentity(sess, ctx)
 	ctx.IsGuest = true
 
 	logger.Info("Guest session created",
@@ -1090,6 +1171,7 @@ func (h *Handler) createGuestSession(ctx *SMBHandlerContext) (*HandlerResult, er
 
 	sess := h.CreateSession(ctx.ClientAddr, true, "guest", "")
 	sess.OriginConnID = ctx.ConnID
+	recordSessionBindIdentity(sess, ctx)
 
 	ctx.SessionID = sess.SessionID
 	ctx.IsGuest = true

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -403,10 +403,6 @@ TCP connections with different SMB dialect and signing/encryption combinations.
 |-----------|----------|--------|-------|
 | smb2.session.bind2 | Session binding | Session binding not implemented | - |
 | smb2.session.bind_invalid_auth | Session binding | Session binding auth validation not implemented | - |
-| smb2.session.bind_negative_smb2to3s | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb2to3d | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb3to2s | Session binding | Multi-channel session binding not implemented | - |
-| smb2.session.bind_negative_smb3to2d | Session binding | Multi-channel session binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoHs | Session binding | Multi-channel signing binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoHd | Session binding | Multi-channel signing binding not implemented | - |
 | smb2.session.bind_negative_smb3signCtoGs | Session binding | Multi-channel signing binding not implemented | - |


### PR DESCRIPTION
## Summary

Per MS-SMB2 §3.3.5.5.2 (Samba `smb2_sesssetup.c:713-810`), a SESSION_SETUP
bind on an SMB 3.x connection must match the existing session's negotiated
dialect, encryption cipher, and signing algorithm. The previous code only
gated on the new connection's dialect being ≥ 3.0; any other mismatch fell
through and the bind succeeded, returning `STATUS_OK` where smbtorture
expects `STATUS_INVALID_PARAMETER` / `STATUS_NOT_SUPPORTED` /
`STATUS_REQUEST_OUT_OF_SEQUENCE`.

`Session` now records `Dialect` / `SigningAlgo` / `CipherId` / `ClientGUID`
at creation (`recordSessionBindIdentity` helper, called at all five session-
create sites). `handleSessionBind` extends its validation order to mirror
Samba:

| # | Check | NTSTATUS |
|---|---|---|
| 1 | `SessionID != 0` | `INVALID_PARAMETER` |
| 2 | session exists | `USER_SESSION_DELETED` |
| 3 | session GMAC && conn algo ≠ session algo | `REQUEST_OUT_OF_SEQUENCE` |
| 4 | conn GMAC && session algo ≠ conn algo | `NOT_SUPPORTED` |
| 5 | conn.dialect < 3.0 | `REQUEST_NOT_ACCEPTED` |
| 6 | session.dialect ≠ conn.dialect | `INVALID_PARAMETER` |
| 7 | session.cipher ≠ conn.cipher | `INVALID_PARAMETER` |
| 8 | session is guest / null | `NOT_SUPPORTED` |

`ClientGuid` is intentionally **not** validated: Samba doesn't either, and
smbtorture's `bind_negative_smb3signCtoHd` / `HtoCd` explicitly expect a
cross-`ClientGuid` bind to succeed when dialect / cipher / signing match.

Also adds `StatusRequestOutOfSequence` (0xC010000A) to the status table.

## Conformance impact

Local smbtorture (`smb2.session` subsuite) confirms 4 flips:

- `smb2.session.bind_negative_smb2to3s` ✅
- `smb2.session.bind_negative_smb2to3d` ✅
- `smb2.session.bind_negative_smb3to2s` ✅ (was stale in KNOWN_FAILURES)
- `smb2.session.bind_negative_smb3to2d` ✅ (was stale in KNOWN_FAILURES)

`bind_negative_smb3to3{s,d}` were previously walked back by #660 but were
still failing post-merge — #660's gate only handled the trailing
non-binding setup at `session.c:2799`, not the bind itself at line 2757.
Those flips are also recovered by this change.

Remaining session-binding `KNOWN_FAILURES.md` rows (`smb3signC*`,
`smb3sneC*`, `smb3signC30toG*`, `smb3signGtoH2X*`, …) are blocked on the
smbtorture client running out of memory mid-suite when running
encryption-required tests (`NT_STATUS_NO_MEMORY` returned to the client
after a handful of GMAC/GCM negotiations). The new server-side gates are
correct in isolation and will be picked up automatically once the client-
side issue is worked around (out of scope for this PR).

## Test plan

- [x] `go test -race ./internal/adapter/smb/v2/handlers/... ./internal/adapter/smb/session/... ./internal/adapter/smb/types/... ./pkg/metadata/lock/...`
- [x] `go vet ./... && go fmt ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] 4 new unit cases in `session_bind_test.go` covering each new gate
- [x] Local smbtorture `smb2.session` confirms 4 flips, no regressions

Closes #483 (incremental — the full sub-suite remains blocked on smbtorture
client memory exhaustion, tracked separately).