### PR TITLE
fix(smb/wpts): walk back passing + appendix unimplementable

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1709,9 +1709,21 @@ func (h *Handler) updateBaseObjectTimestampsForADSWrite(
 	if !mtimeFrozen {
 		setAttrs.Mtime = &now
 	}
-	if setAttrs.Ctime != nil || setAttrs.Mtime != nil {
-		_ = metaSvc.SetFileAttributes(authCtx, baseHandle, setAttrs)
+	if setAttrs.Ctime == nil && setAttrs.Mtime == nil {
+		return
 	}
+	// If only one timestamp is frozen, metadata's SetFileAttributes will
+	// auto-bump Ctime to NOW because modified=true and attrs.Ctime==nil
+	// (file_modify.go: `if modified { if attrs.Ctime == nil { file.Ctime = now }}`).
+	// Per MS-FSA 2.1.5.14.2, the freeze sentinel applies to the underlying
+	// object, so an ADS write must not bump the base's frozen ChangeTime
+	// (WPTS FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime).
+	// Pin Ctime to the base's current value when the ADS handle has Ctime frozen.
+	if ctimeFrozen && setAttrs.Ctime == nil {
+		baseCtime := baseFile.Ctime
+		setAttrs.Ctime = &baseCtime
+	}
+	_ = metaSvc.SetFileAttributes(authCtx, baseHandle, setAttrs)
 }
 
 // isStatOnlyOpen returns true when DesiredAccess contains only stat-open bits:

--- a/internal/adapter/smb/v2/handlers/timestamps_test.go
+++ b/internal/adapter/smb/v2/handlers/timestamps_test.go
@@ -856,3 +856,111 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen
+// reproduces the WPTS scenario in
+// `FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime`:
+//
+//  1. The client opens an ADS handle on a base object (directory or file).
+//  2. The client freezes ChangeTime on the ADS handle via SET_INFO -1.
+//  3. The client writes data to the ADS.
+//
+// Per MS-FSA 2.1.5.14.2 the freeze sentinel applies to the underlying object,
+// so the base's ChangeTime must not be bumped by the ADS write. The metadata
+// layer auto-bumps Ctime when SetFileAttributes is called with any modified
+// attribute and attrs.Ctime == nil; updateBaseObjectTimestampsForADSWrite
+// must therefore explicitly pin the base's Ctime when the ADS handle has it
+// frozen but Mtime is not.
+func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *testing.T) {
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("ts-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	shareName := "/ts"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "ts-meta",
+		RootAttr:      &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:                context.Background(),
+		Identity:               &metadata.Identity{UID: &uid, GID: &gid},
+		BypassTraverseChecking: true,
+	}
+	metaSvc := rt.GetMetadataService()
+
+	// Create the base directory (mirrors WPTS test: directory hosts the ADS).
+	baseDir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "basedir", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	baseHandle, err := metadata.EncodeFileHandle(baseDir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle base: %v", err)
+	}
+
+	// Create the ADS as a sibling entry under root (matches CREATE handler's
+	// stream-entry layout: stream `basedir:streamname` is a root child).
+	streamFile, err := metaSvc.CreateFile(authCtx, rootHandle, "basedir:streamname", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile stream: %v", err)
+	}
+	streamHandle, err := metadata.EncodeFileHandle(streamFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle stream: %v", err)
+	}
+
+	// Pin the base directory's Ctime to a known value.
+	pinned := time.Date(2026, 1, 2, 13, 40, 49, 0, time.UTC)
+	if err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{
+		Ctime: &pinned, Mtime: &pinned, CreationTime: &pinned, Atime: &pinned,
+	}); err != nil {
+		t.Fatalf("pin base: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+	adsOpen := &OpenFile{
+		FileID:         [16]byte{0xAD, 0x5C},
+		MetadataHandle: streamHandle,
+		ParentHandle:   rootHandle,
+		FileName:       "basedir:streamname",
+		Path:           "basedir:streamname",
+		ShareName:      shareName,
+		IsDirectory:    false,
+		DesiredAccess:  uint32(types.FileWriteData) | uint32(types.FileWriteAttributes),
+		CtimeFrozen:    true, // SET_INFO -1 on ChangeTime
+		FrozenCtime:    &pinned,
+	}
+	h.StoreOpenFile(adsOpen)
+
+	// Trigger the WRITE-path base-timestamp update.
+	h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, adsOpen, "basedir")
+
+	// Verify the base directory's Ctime is unchanged but Mtime was advanced
+	// (because only Ctime is frozen on the ADS handle).
+	post, err := metaSvc.GetFile(authCtx.Context, baseHandle)
+	if err != nil {
+		t.Fatalf("GetFile post: %v", err)
+	}
+	if !post.Ctime.Equal(pinned) {
+		t.Errorf("base Ctime was bumped: got %v want %v (frozen)", post.Ctime, pinned)
+	}
+	if post.Mtime.Equal(pinned) {
+		t.Errorf("base Mtime was not advanced: got %v want != %v", post.Mtime, pinned)
+	}
+}

--- a/test/smb-conformance/KNOWN_FAILURES.md
+++ b/test/smb-conformance/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # Known Failures - SMB Conformance (WPTS BVT)
 
-Last updated: 2026-03-24 (Phase 73: ADS, ChangeNotify, timestamp freeze-thaw, compound, lease, DH fixes)
+Last updated: 2026-05-28 (Wave 4 WPTS sweep: walk back 3 confirmed PASS + ADS base ChangeTime freeze fix + Permanently Unimplementable appendix)
 
 Tests listed here are expected to fail. CI will pass (exit 0) as long as
 all failures are in this list. New failures not listed here will cause CI to fail.
@@ -9,180 +9,130 @@ The `parse-results.sh` script reads test names from the first column of the
 table below. Lines starting with `#`, `|---`, empty lines, and the header
 row (`Test Name`) are ignored.
 
+## Rules
+
+- The [Permanently Unimplementable](#permanently-unimplementable-out-of-scope) appendix at the bottom is the **only** place where entries may be added without a documented fix plan.
+- Every entry above the appendix MUST either (a) reference an open GH sub-issue, or (b) be promoted into the appendix with a documented architectural reason.
+- Goal: every non-appendix entry resolved before v1.0.
+
 ## Baseline Status
 
 - **Initial baseline (Phase 29.8):** 133/240 BVT tests passing
-- **Current baseline (Phase 73):** 58 known failures (53 permanent + 5 expected)
+- **Current baseline (Wave 4):** 224/265 PASS, 41 known failures (39 permanent + 2 expected)
 - **Target:** All BVT tests pass except genuinely unimplemented features
-
-## Phase 30-32 Improvements
-
-The following fixes from Phases 30-32 improved protocol compliance:
-
-### Phase 30: Bug Fixes
-- **BUG-01 (Sparse file READ):** Zero-fill for unwritten blocks at download level.
-- **BUG-02 (Renamed directory listing):** Path field updated before persistence on Move.
-- **BUG-03 (Parent dir navigation):** Multi-component `..` path resolution.
-- **BUG-04 (Oplock break wiring):** NFS operations trigger oplock break for SMB clients.
-- **BUG-05 (NumberOfLinks):** FileStandardInfo.NumberOfLinks reads actual link count.
-- **BUG-06 (Pipe share list caching):** Share list cached for pipe CREATE.
-
-### Phase 31: Windows ACL Support
-- **SD-01 through SD-08 (Security Descriptors):** Full DACL synthesis from POSIX mode bits with owner, group, well-known SIDs, canonical ACE ordering, inheritance flags, and SACL stub.
-
-### Phase 32 Plan 01: Protocol Compatibility
-- **MxAc create context:** Returns maximal access mask computed from POSIX permissions.
-- **QFid create context:** Returns on-disk file ID with volume ID.
-- **FileCompressionInformation (class 28):** Returns valid fixed-size buffer.
-- **FileAttributeTagInformation (class 35):** Returns valid fixed-size buffer.
-- **Updated capability flags:** FileFsAttributeInformation flags now include FILE_SUPPORTS_SPARSE_FILES.
-
-## Phase 33-39 Improvements
-
-The following SMB3 features were implemented in Phases 33-39. Tests related to
-these features have been removed from the expected failures list and are now
-tracked as **fix candidates** in `baseline-results.md` (they should pass, and if
-they do not, they need investigation and fixing -- not suppression).
-
-### Phase 33: SMB3 Encryption
-- AES-128-CCM, AES-128-GCM, AES-256-CCM, AES-256-GCM ciphers.
-- Full transform header encoding/decoding with preauth integrity hash.
-- SMB2_ENCRYPTION_CAPABILITIES negotiate context.
-- VALIDATE_NEGOTIATE_INFO IOCTL.
-
-### Phase 34: SMB3 Signing
-- AES-128-CMAC (3.0+), AES-128-GMAC (3.1.1), HMAC-SHA256 (2.x).
-- SP800-108 KDF-based session key derivation.
-- SIGNING_CAPABILITIES negotiate context.
-
-### Phase 35-37: Leases, Sessions, Kerberos
-- Lease V2 with parent key and epoch tracking.
-- Session binding, reconnect, re-authentication.
-- Kerberos authentication via SPNEGO/GSSAPI.
-
-### Phase 38: Durable Handles
-- Durable handle V1 (DHnQ/DHnC) and V2 (DH2Q/DH2C).
-- Reconnect with session key verification.
-- Handle scavenger for expired handles.
-
-### Phase 39: Cross-Protocol Integration
-- Unified caching model (SMB leases + NFS delegations).
-- Bidirectional break/recall across protocols.
-
-### Tests Re-Added as Known Failures (fix candidates)
-
-The following tests were previously removed because the underlying features
-were implemented in phases 33-39. However, the tests still fail and need
-further investigation. They are listed here to unblock CI and also tracked
-in `baseline-results.md` for prioritization.
-
-- (None remaining -- BVT_OpLockBreak and BVT_DirectoryLeasing_LeaseBreakOnMultiClients fixed)
 
 ## Expected Failures
 
+Tests below fail today on develop and are fixable in DittoFS. Each must
+either be flipped or promoted into the appendix with a reason.
+
 | Test Name | Category | Reason | Status | Issue |
 |-----------|----------|--------|--------|-------|
-| Algorithm_NotingFileModified_Dir_LastAccessTime | Timestamp | Directory LastAccessTime auto-update on child file modification | Expected | - |
-| FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime | Timestamp | Directory ChangeTime freeze not enforced during child operations | Expected | - |
-| FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime | Timestamp | Directory LastWriteTime not auto-updated after unfreeze | Expected | - |
-| BVT_ApplySnapshot | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_ChangeTracking | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Convert_VHDFile_to_VHDSetFile | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Create_Delete_Checkpoint | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Extract_VHDSet | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_FileAccess_OpenNamedPipe | NamedPipe | WPTS FSA requires SSH to SUT (unavailable in Docker) | Permanent | - |
-| BVT_FileAccess_OpenNamedPipe_InvalidPathName | NamedPipe | WPTS FSA requires SSH to SUT (unavailable in Docker) | Permanent | - |
-| BVT_DirectoryLeasing_LeaseBreakOnMultiClients | Leasing | Flaky in CI (directory lease break timing race) | Expected | - |
+| FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime | Timestamp | Directory ChangeTime freeze not enforced when ADS writes bump base timestamps. Under investigation — per-handle freeze flag does not propagate to base object across handle boundaries. | Expected | - |
 | BVT_DirectoryLeasing_ReadWriteHandleCaching | Leasing | Flaky in CI: identical SMB wire trace as develop (which passes) including the same DIRECTORY_NOT_EMPTY in cleanup; outcome depends on WPTS-framework-internal cleanup-phase exception handling. | Expected | - |
-| BVT_OpenCloseSharedVHD_V1 | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_OpenCloseSharedVHD_V2 | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_OpenSharedVHDSetByTargetSpecifier | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Optimize | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_QuerySharedVirtualDiskSupport | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_QueryVirtualDiskChanges | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Query_VHDSet_FileInfo_SnapshotEntry | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Query_VHDSet_FileInfo_SnapshotList | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_ReadSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_Resize | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_RootAndLinkReferralDomainV4ToDFSServer | DFS | DFS referrals not implemented | Permanent | - |
-| BVT_RootAndLinkReferralStandaloneV4ToDFSServer | DFS | DFS referrals not implemented | Permanent | - |
-| BVT_SWNGetInterfaceList_ClusterSingleNode | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_SWNGetInterfaceList_ScaleOutSingleNode | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_SWN_CheckProtocolVersion | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_Sqos_ProbePolicy | SQoS | Storage QoS not implemented | Permanent | - |
-| BVT_Sqos_SetPolicy | SQoS | Storage QoS not implemented | Permanent | - |
-| BVT_Sqos_UpdateCounters | SQoS | Storage QoS not implemented | Permanent | - |
-| BVT_TunnelCheckConnectionStatusToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelGetDiskInfoToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelGetFileInfoToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSCSIPersistentReserve_Preempt | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSCSIPersistentReserve_RegisterAndReserve | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSCSIPersistentReserve_ReserveAndRelease | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSCSIPersistentReserve_ReserveConflict | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSCSIToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelSRBStatusToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_TunnelValidateDiskToSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
-| BVT_WitnessrRegisterEx_SWNAsyncNotification_ClientMove | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_WitnessrRegisterEx_SWNAsyncNotification_IPChange | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_WitnessrRegister_SWNAsyncNotification_ClientMove | SWN | Service Witness Protocol not implemented | Permanent | - |
-| BVT_WriteSharedVHD | VHD/RSVD | Virtual Hard Disk not implemented | Permanent | - |
 
 ## Status Legend
 
 | Status | Meaning |
 |--------|---------|
 | **Expected** | Known failure, fix planned in a future phase |
-| **Permanent** | Feature intentionally not implemented (out of scope) |
+| **Permanent** | Feature intentionally not implemented (out of scope) — see appendix |
 
-## Permanently Out-of-Scope Categories
+## Permanently Unimplementable (Out of Scope)
 
-These test categories will remain as known failures indefinitely:
+Tests below cannot be implemented in DittoFS by design. Reasons fall into the
+following buckets:
 
-| Category | Count | Reason |
-|----------|-------|--------|
-| VHD/RSVD | 26 | Virtual Hard Disk: not a filesystem feature |
-| SWN | 6 | Service Witness Protocol: requires clustering |
-| SQoS | 3 | Storage QoS: requires storage virtualization |
-| DFS | 2 | Distributed File System: not implemented |
-| NamedPipe | 2 | WPTS FSA requires SSH to SUT (unavailable in Docker) |
+1. **Virtual Hard Disk (RSVD).** SMB-over-RSVD shared VHD/VHDX file format
+   and SCSI command tunneling. Requires a block-level VHD storage backend;
+   DittoFS is a file-level virtual filesystem, not a disk subsystem.
+2. **Service Witness Protocol (SWN).** Cluster failover notification protocol.
+   Requires a multi-node clustered file server with shared-witness coordination;
+   DittoFS is a single-node userspace server.
+3. **Storage QoS (SQOS).** Per-VHD IOPS / latency policy enforcement.
+   Requires Hyper-V Storage QoS integration on the storage layer.
+4. **Distributed File System (DFS) referrals.** DFS namespace referrals
+   require AD-integrated namespace coordination, deprecated in favor of
+   per-share access in DittoFS.
+5. **Named Pipe FSA (WPTS-internal).** The WPTS FSA Adapter Connects to
+   the SUT via SSH to drive the FSCC layer directly; the Docker harness does
+   not expose SSH to the DittoFS container, so the test cannot run regardless
+   of pipe implementation status.
 
-**Total permanently out-of-scope:** 38 tests
+These entries remain in CI's known-failure set (so they don't break the build)
+but are explicitly outside the v1.0 conformance gate.
 
-## Remaining Expected Failure Categories
+| Test Name | Category | Reason |
+|-----------|----------|--------|
+| BVT_ApplySnapshot | VHD/RSVD | RSVD shared VHD snapshot apply — block-level VHD storage not implemented |
+| BVT_ChangeTracking | VHD/RSVD | RSVD VHD block change tracking — block-level VHD storage not implemented |
+| BVT_Convert_VHDFile_to_VHDSetFile | VHD/RSVD | RSVD VHD → VHDSet conversion — block-level VHD storage not implemented |
+| BVT_Create_Delete_Checkpoint | VHD/RSVD | RSVD VHD checkpoint lifecycle — block-level VHD storage not implemented |
+| BVT_Extract_VHDSet | VHD/RSVD | RSVD VHDSet extraction — block-level VHD storage not implemented |
+| BVT_OpenCloseSharedVHD_V1 | VHD/RSVD | RSVD v1 shared-VHD open/close — block-level VHD storage not implemented |
+| BVT_OpenCloseSharedVHD_V2 | VHD/RSVD | RSVD v2 shared-VHD open/close — block-level VHD storage not implemented |
+| BVT_OpenSharedVHDSetByTargetSpecifier | VHD/RSVD | RSVD VHDSet target-specifier open — block-level VHD storage not implemented |
+| BVT_Optimize | VHD/RSVD | RSVD VHD optimize — block-level VHD storage not implemented |
+| BVT_QuerySharedVirtualDiskSupport | VHD/RSVD | RSVD shared-VHD support query — block-level VHD storage not implemented |
+| BVT_QueryVirtualDiskChanges | VHD/RSVD | RSVD VHD changed-block tracking — block-level VHD storage not implemented |
+| BVT_Query_VHDSet_FileInfo_SnapshotEntry | VHD/RSVD | RSVD VHDSet snapshot entry query — block-level VHD storage not implemented |
+| BVT_Query_VHDSet_FileInfo_SnapshotList | VHD/RSVD | RSVD VHDSet snapshot list query — block-level VHD storage not implemented |
+| BVT_ReadSharedVHD | VHD/RSVD | RSVD shared-VHD read — block-level VHD storage not implemented |
+| BVT_Resize | VHD/RSVD | RSVD VHD resize — block-level VHD storage not implemented |
+| BVT_TunnelCheckConnectionStatusToSharedVHD | VHD/RSVD | RSVD SCSI tunnel — block-level VHD storage not implemented |
+| BVT_TunnelGetDiskInfoToSharedVHD | VHD/RSVD | RSVD SCSI tunnel — block-level VHD storage not implemented |
+| BVT_TunnelGetFileInfoToSharedVHD | VHD/RSVD | RSVD SCSI tunnel — block-level VHD storage not implemented |
+| BVT_TunnelSCSIPersistentReserve_Preempt | VHD/RSVD | RSVD SCSI persistent reserve — block-level VHD storage not implemented |
+| BVT_TunnelSCSIPersistentReserve_RegisterAndReserve | VHD/RSVD | RSVD SCSI persistent reserve — block-level VHD storage not implemented |
+| BVT_TunnelSCSIPersistentReserve_ReserveAndRelease | VHD/RSVD | RSVD SCSI persistent reserve — block-level VHD storage not implemented |
+| BVT_TunnelSCSIPersistentReserve_ReserveConflict | VHD/RSVD | RSVD SCSI persistent reserve — block-level VHD storage not implemented |
+| BVT_TunnelSCSIToSharedVHD | VHD/RSVD | RSVD SCSI tunnel — block-level VHD storage not implemented |
+| BVT_TunnelSRBStatusToSharedVHD | VHD/RSVD | RSVD SCSI SRB status tunnel — block-level VHD storage not implemented |
+| BVT_TunnelValidateDiskToSharedVHD | VHD/RSVD | RSVD SCSI disk validation tunnel — block-level VHD storage not implemented |
+| BVT_WriteSharedVHD | VHD/RSVD | RSVD shared-VHD write — block-level VHD storage not implemented |
+| BVT_SWNGetInterfaceList_ClusterSingleNode | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_SWNGetInterfaceList_ScaleOutSingleNode | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_SWN_CheckProtocolVersion | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_WitnessrRegister_SWNAsyncNotification_ClientMove | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_WitnessrRegisterEx_SWNAsyncNotification_ClientMove | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_WitnessrRegisterEx_SWNAsyncNotification_IPChange | SWN | Service Witness Protocol — requires multi-node clustered file server |
+| BVT_Sqos_ProbePolicy | SQoS | Storage QoS — requires Hyper-V QoS integration on the storage layer |
+| BVT_Sqos_SetPolicy | SQoS | Storage QoS — requires Hyper-V QoS integration on the storage layer |
+| BVT_Sqos_UpdateCounters | SQoS | Storage QoS — requires Hyper-V QoS integration on the storage layer |
+| BVT_RootAndLinkReferralDomainV4ToDFSServer | DFS | DFS namespace referrals — AD-integrated namespace not implemented |
+| BVT_RootAndLinkReferralStandaloneV4ToDFSServer | DFS | DFS namespace referrals — AD-integrated namespace not implemented |
+| BVT_FileAccess_OpenNamedPipe | NamedPipe | WPTS FSA adapter requires SSH to SUT — not available in Docker harness |
+| BVT_FileAccess_OpenNamedPipe_InvalidPathName | NamedPipe | WPTS FSA adapter requires SSH to SUT — not available in Docker harness |
 
-Tests that fail for features not yet implemented:
+**Total permanently unimplementable: 39 tests.**
 
-| Category | Count | Status |
-|----------|-------|--------|
-| Timestamp | 3 | Directory timestamp edge cases (freeze-thaw, auto-update) |
-| Leasing | 1 | Directory lease break timing flake in CI |
+## Out-of-Scope Categories Summary
 
-**Total expected failures (fixable):** 4 tests
+| Category | Count |
+|----------|-------|
+| VHD/RSVD | 26 |
+| SWN | 6 |
+| SQoS | 3 |
+| DFS | 2 |
+| NamedPipe | 2 |
 
-**WPTS BVT expected failures (primary gate):** 4
+## Phase 33-39 Improvements
 
-**Grand total known failures:** 42 tests (38 permanent + 4 expected)
+The following SMB3 features were implemented in Phases 33-39:
 
-## Phase 72 Fixes (31 tests removed)
+- **Phase 30:** Bug fixes (sparse READ, renamed dir listing, parent dir navigation, oplock break wiring, NumberOfLinks, pipe share caching).
+- **Phase 31:** Windows ACL support (DACL synthesis, SD-01..SD-08).
+- **Phase 32:** MxAc / QFid / FileCompressionInformation / FileAttributeTagInformation create contexts.
+- **Phase 33:** SMB3 encryption (AES-128/256-CCM/GCM, VALIDATE_NEGOTIATE_INFO).
+- **Phase 34:** SMB3 signing (AES-CMAC, AES-GMAC, HMAC-SHA256, SP800-108 KDF).
+- **Phase 35-37:** Lease V2, session binding/reconnect, Kerberos via SPNEGO/GSSAPI.
+- **Phase 38:** Durable handles V1 + V2 (DHnQ/DHnC, DH2Q/DH2C).
+- **Phase 39:** Cross-protocol caching (SMB leases + NFS delegations).
 
-The following tests were removed from expected failures in Phase 72:
+## Phase 72-73 Improvements
 
-### Plan 01: ChangeNotify (16 tests removed)
-- Async ChangeNotify with proper AsyncId interim/completion responses
-- CANCEL command cancels pending notifications with STATUS_CANCELLED
-- Notify triggers wired into CREATE, SET_INFO, CLOSE, RENAME
-- Remaining 4 ChangeNotify tests require EA support or ADS stream notify wiring
-
-### Plan 02: Negotiate/Cipher + DH/Lease/Tree (12 tests removed)
-- Client-preference cipher and signing algorithm selection per MS-SMB2 3.3.5.4
-- Volatile FileID regenerated on durable handle V1 reconnect per MS-SMB2 3.3.5.9.7
-- TREE_DISCONNECT and LOGOFF exempted from signing verification
-- Lease V1/V2 and directory leasing fixes cascade from corrected negotiate flow
-
-### Plan 03: Timestamp Freeze/Unfreeze (3 tests removed)
-- Timestamp freeze (-1) persists across subsequent SET_INFO calls per MS-FSA 2.1.5.14.2
-- Timestamp unfreeze (-2) sets timestamp to current time per MS-FSA 2.1.5.14.2
-- Parent directory LastAccessTime updated on child file WRITE per MS-FSA 2.1.4.4
+- **v0.10.0 Phase 72:** ChangeNotify (async + CANCEL + completion filters), client-preference cipher/signing selection, DH V1 volatile FileID regen, TREE_DISCONNECT signing exemption, lease V1/V2 fixes, timestamp freeze/unfreeze per MS-FSA 2.1.5.14.2.
+- **v0.10.0 Phase 73:** ChangeNotify ADS stream notifications, ADS share access + timestamp conformance, ChangeNotify completion, session re-auth, anonymous encryption, DH/lease state machine, per-field CreationTime freeze/unfreeze.
 
 ## How to Add New Entries
 
@@ -190,24 +140,29 @@ After running the test suite, `parse-results.sh` will report new failures not
 in this table. To add them:
 
 1. Copy the exact test name from the output
-2. **Investigate the failure** -- determine if the feature is implemented
+2. **Investigate the failure** — determine if the feature is implemented
 3. If the feature IS implemented: fix the bug, do NOT add to this list
-4. If the feature is NOT implemented: add a row to the table above
-5. Set status to `Expected` (fixable) or `Permanent` (out of scope)
-6. Reference the relevant GitHub issue or future phase
+4. If the feature requires a feature not yet implemented but planned: add to "Expected Failures" with an issue link
+5. If the feature is architecturally out of scope: add to the "Permanently Unimplementable" appendix with a one-line reason
 
-Format:
+Format for Expected Failures:
 ```
-| ExactTestName | Category | Reason for expected failure | Status | #issue or Phase N |
+| ExactTestName | Category | Reason for expected failure | Expected | #issue or Phase N |
+```
+
+Format for Permanently Unimplementable:
+```
+| ExactTestName | Category | Architectural reason it cannot be implemented |
 ```
 
 ## Changelog
 
+- **Wave 4 (2026-05-28):** Walk back 3 confirmed PASS (`Algorithm_NotingFileModified_Dir_LastAccessTime`, `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime`, `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`). Fix ADS write on directory base auto-bumping frozen ChangeTime (preserve base.Ctime when ADS handle has Ctime frozen but Mtime is not). Restructure with Permanently Unimplementable appendix mirroring the smbtorture file layout.
 - **v0.10.0 Phase 73 (2026-03-24):** SMB Conformance Deep-Dive. Plan 01: ChangeNotify ADS stream notifications wired (5 tests). Plan 02: ADS share access + timestamp conformance (9 ADS + 3 timestamp tests removed). Plan 03: ChangeNotify completion, session re-auth, anonymous encryption (~25 smbtorture tests). Plan 04: DH/lease state machine fixes (~26 smbtorture tests). Plan 05: Per-field CreationTime freeze/unfreeze, ChangeEa reclassified as Permanent. Total: 56 (53 permanent + 3 expected).
 - **v0.10.0 Phase 72 (2026-03-23):** ChangeNotify fully implemented with async responses, CANCEL support, and all MS-SMB2 completion filter events (Plan 01, 16 tests fixed). Client-preference cipher/signing selection, DH V1 volatile FileID regeneration, TREE_DISCONNECT signing exemption, lease V1/V2 state transitions fixed (Plan 02, 12 tests fixed). Timestamp freeze/unfreeze per MS-FSA 2.1.5.14.2, parent directory atime on file write (Plan 03, 3 tests fixed). Total removed: 31. New total: 65 (52 permanent + 13 expected).
-- **v4.5 Phase 69 (2026-03-20):** Full MS-SMB2 3.3.x signing audit completed. Added spec section references (3.3.5.2.4, 3.3.4.1.1, 3.3.5.2.7.2) to framing.go, response.go, compound.go. Enforced NegSigningRequired for 3.1.1 NEGOTIATE and SigningRequired for 3.1.1 SESSION_SETUP. All signing paths verified compliant: incoming verification, outgoing signing, compound signing, tree connect (no signing mutation), re-auth key preservation. No signing violations found.
-- **v4.7 Phase 67 (2026-03-20):** SMB 3.1.1 preauth integrity hash chain verified correct via MS-SMB2 test vectors and conformance tests. All 4 pitfalls from issue #252 confirmed correctly handled. Negotiate response wire format validated (context alignment, security buffer offset). WPTS BVT_Negotiate_SMB311 failures require runtime WPTS verbose log diagnosis (not a preauth hash bug). Updated Negotiate test descriptions with Phase 67 findings. Total: 99 (47 permanent + 52 expected, unchanged).
-- **v3.8 Phase 42 (2026-03-09):** Updated ptfconfig to SMB 3.1.1 (MaxSmbVersionSupported, encryption, directory leasing, signing algorithms). Added 14 newly exercised tests: 5 Negotiate, 3 ChangeNotify (SMB 3.x), 2 Encryption, 2 DirectoryLeasing, 1 Leasing V2, 1 TreeMgmt. Fixed zero-mtime flush bug (5 QueryDirectory + 2 Timestamp regressions). Total: 100 (47 permanent + 53 expected).
-- **v3.8 Phase 40 (2026-03-02):** Post-SMB3 update. Removed 5 tests whose features are now implemented (durable handles V1, leasing V1, oplock break, encryption capability flag). Added Phase 33-39 improvements section. Updated permanently out-of-scope count (47, down from 48 -- encryption flag removed). Updated expected failure count (35, down from 42). Removed "Potentially fixed" status -- all entries are now either Expected or Permanent.
-- **v3.6 Phase 32 (2026-02-28):** Updated baseline after bug fixes (sparse READ, directory listing, parent dir, oplock break, link count), ACL support (SD synthesis, DACL/SACL, SID mapping), and protocol enhancements (MxAc, QFid, FileCompressionInfo, FileAttributeTagInfo, capability flags). Added status column, Phase 30-32 improvement notes, permanently out-of-scope categories section.
+- **v4.5 Phase 69 (2026-03-20):** Full MS-SMB2 3.3.x signing audit completed. Added spec section references (3.3.5.2.4, 3.3.4.1.1, 3.3.5.2.7.2) to framing.go, response.go, compound.go. Enforced NegSigningRequired for 3.1.1 NEGOTIATE and SigningRequired for 3.1.1 SESSION_SETUP. All signing paths verified compliant.
+- **v4.7 Phase 67 (2026-03-20):** SMB 3.1.1 preauth integrity hash chain verified correct via MS-SMB2 test vectors and conformance tests.
+- **v3.8 Phase 42 (2026-03-09):** Updated ptfconfig to SMB 3.1.1. Added 14 newly exercised tests.
+- **v3.8 Phase 40 (2026-03-02):** Post-SMB3 update. Removed 5 tests whose features are now implemented (durable handles V1, leasing V1, oplock break, encryption capability flag).
+- **v3.6 Phase 32 (2026-02-28):** Updated baseline after bug fixes (sparse READ, directory listing, parent dir, oplock break, link count), ACL support, and protocol enhancements.
 - **v3.6 Phase 29.8 (2026-02-26):** Initial baseline (133/240 BVT tests passing). Created expected failure list with 90 entries across 14 categories.

--- a/test/smb-conformance/run.sh
+++ b/test/smb-conformance/run.sh
@@ -376,10 +376,20 @@ run_compose() {
     PROFILE="$PROFILE" docker compose up -d dittofs
     wait_until "docker compose exec dittofs wget -q --spider http://localhost:8080/health/ready" 60 "DittoFS"
 
-    # Extract auto-generated admin password from container logs
+    # Extract auto-generated admin password from container logs.
+    # /health/ready can flip green before the admin user creation log line is
+    # emitted on cold start, so retry briefly before giving up.
     log_step "Extracting admin password from DittoFS logs..."
     local admin_password=""
-    admin_password=$(docker compose logs dittofs 2>/dev/null | grep -o 'password: [^ ]*' | head -1 | awk '{print $2}' || echo "")
+    local attempt=1
+    while [ "$attempt" -le 20 ]; do
+        admin_password=$(docker compose logs dittofs 2>/dev/null | grep -o 'password: [^ ]*' | head -1 | awk '{print $2}' || echo "")
+        if [[ -n "$admin_password" ]]; then
+            break
+        fi
+        sleep 1
+        attempt=$((attempt + 1))
+    done
     if [[ -z "$admin_password" ]]; then
         log_error "Could not extract admin password from DittoFS logs"
         return 1


### PR DESCRIPTION
## Summary

Wave 4 of #673 (v1.0 audit milestone): WPTS BVT sweep.

- Walk back 3 tests confirmed PASS on develop:
  - `Algorithm_NotingFileModified_Dir_LastAccessTime`
  - `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime`
  - `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`
- Fix `updateBaseObjectTimestampsForADSWrite`: preserve base ChangeTime when ADS handle has it frozen but Mtime is not. Without this pin, metadata's `SetFileAttributes` auto-bumps Ctime to NOW because `modified=true && attrs.Ctime==nil` even though the ADS handle's freeze sentinel should apply per MS-FSA 2.1.5.14.2. Target: `FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime`.
- Restructure `KNOWN_FAILURES.md` to mirror the smbtorture layout: Expected Failures table reserved for fixable items; 39 architecturally-unimplementable tests moved to a new `Permanently Unimplementable (Out of Scope)` appendix grouped by category (VHD/RSVD, SWN, SQoS, DFS, NamedPipe) with one-line architectural reasons.
- Harden `run.sh` password extraction with a brief retry loop (cold-start race between `/health/ready` and admin-user log emission).

## Before/after counts

| | Before | After |
|---|--------|-------|
| Expected (fixable) | 4 | 2 (1 if Dir_ChangeTime flips) |
| Permanent | 38 | 39 |
| Total in scoreboard | 42 | 41 |

Local baseline: 224 PASS / 41 KNOWN / 0 NEW failures.

## Test plan

- [x] `go fmt ./... && go vet ./...`
- [x] `go test -race ./...` (full suite green)
- [x] New unit test `TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen` PASS
- [x] `golangci-lint run --timeout=5m ./internal/adapter/smb/v2/handlers/... ./pkg/metadata/...` 0 issues
- [ ] CI WPTS BVT confirms `Algorithm_NotingFileModified_Dir_LastAccessTime`, `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime`, and `BVT_DirectoryLeasing_LeaseBreakOnMultiClients` walked-back tests pass on develop
- [ ] CI WPTS BVT confirms whether the ADS base Ctime freeze fix flips `FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime`; if so, follow-up walks it back