### PR TITLE
fix(smb/dirlease): single break-to-None + accept late ACK (#454)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -418,23 +418,24 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	}
 
-	// Step 6e: Break parent directory Handle / Read leases on
-	// create/overwrite/supersede BEFORE the actual file mutation so the
-	// metadata-layer notifyDirChange (fire-and-forget) finds the dir lease
-	// already broken and does not mark the recently-broken cache — which
-	// would block the test's lease rearm (test_rearm_dirlease). Mirrors
-	// Samba's delay_for_oplock_fn running before the actual create.
+	// Step 6e: Break parent directory leases on create/overwrite/supersede
+	// BEFORE the actual file mutation so the metadata-layer notifyDirChange
+	// (fire-and-forget) finds the dir lease already broken and does not
+	// mark the recently-broken cache — which would block the test's lease
+	// rearm (test_rearm_dirlease). Mirrors Samba's delay_for_oplock_fn
+	// running before the actual create.
 	//
 	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break,
 	// #470 C2): if this CREATE carried an RqLs with
 	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
 	// incoming request so the matching dir-lease is NOT broken.
 	//
-	// Destructive disposition split (#470 C4, smb2.dirlease.overwrite): per
-	// Samba `delay_for_oplock_fn` `will_overwrite` arm, OVERWRITE/SUPERSEDE
-	// collapses the strip-H + strip-R steps into a single break-to-None
-	// notification. CREATE (FileCreated) keeps the two-step pattern because
-	// the parent dir-lease only loses Handle caching there.
+	// Single break-to-None per Samba do_dirlease_break_to_none
+	// (source3/smbd/smb2_oplock.c): a directory-content change emits ONE
+	// LEASE_BREAK to None per dir-lease holder, not the two-step strip-H /
+	// strip-R pattern used for file leases. Applies uniformly to CREATE,
+	// OVERWRITE, and SUPERSEDE — WPTS BVT_DirectoryLeasing_ReadWriteHandleCaching
+	// (#454) asserts the break notification carries NewLeaseState=None.
 	if (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) && h.LeaseManager != nil {
 		parentLockHandle := lock.FileHandle(parentHandle)
 		// Per Samba dirlease_should_break: no ClientID exclusion for parent
@@ -450,18 +451,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				hasExcludeKey = true
 			}
 		}
-		isDestructive := createAction == types.FileOverwritten || createAction == types.FileSuperseded
-		if isDestructive {
-			if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory destructive lease break failed", "error", breakErr)
-			}
-		} else {
-			if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory Handle lease break failed", "error", breakErr)
-			}
-			if breakErr := h.LeaseManager.BreakParentReadLeasesOnModify(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-				logger.Debug("CREATE: parent directory Read lease break failed", "error", breakErr)
-			}
+		if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
+			logger.Debug("CREATE: parent directory lease break failed", "error", breakErr)
 		}
 	}
 

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -851,6 +851,27 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 	}
 
 	if !lock.Lease.Breaking {
+		// Late ACK after server-side timeout: forceCompleteBreaks already
+		// auto-revoked the lease to None and tagged BrokenViaTimeout. If
+		// the client now ACKs that same None state, the wire-visible
+		// outcome matches the desired final state — return STATUS_OK
+		// silently. BrokenViaTimeout is left untouched so the downstream
+		// grant-coercion path (OnlyTimeoutTombstoneRecords) still treats
+		// the record as a tombstone for smbtorture batch22b semantics.
+		//
+		// Required by WPTS BVT_DirectoryLeasing_ReadWriteHandleCaching
+		// (#454) where the SUT controller's synchronous CreateFile holds
+		// the test client past the 5 s parent-break timeout, so the ACK
+		// can only be sent post-force-complete. smbtorture breaking2 /
+		// breaking5 ACK within the breaking window, so their post-ack
+		// duplicate has BrokenViaTimeout=false and still surfaces as
+		// STATUS_UNSUCCESSFUL via the fall-through below.
+		if lock.Lease.BrokenViaTimeout && acknowledgedState == LeaseStateNone &&
+			lock.Lease.LeaseState == LeaseStateNone {
+			logger.Debug("AcknowledgeLeaseBreak: late ACK matches post-timeout state, treating as success",
+				"leaseKey", fmt.Sprintf("%x", leaseKey))
+			return nil
+		}
 		return ErrLeaseAckNotBreaking
 	}
 


### PR DESCRIPTION
## Summary

Fixes two correctness gaps blocking `BVT_DirectoryLeasing_ReadWriteHandleCaching` on develop.

### 1. CREATE child file emits a single break-to-None per dir-lease holder

Previously the CREATE-not-destructive path called
`BreakParentHandleLeasesOnCreate` + `BreakParentReadLeasesOnModify`,
which fired two `LEASE_BREAK_NOTIFICATION`s (RH → R, then R → None).
WPTS `BVT_DirectoryLeasing_ReadWriteHandleCaching` asserts exactly one
notification with `NewLeaseState=None` and aborts the moment the stale
RH → R arrives. Switching to the existing
`BreakParentDirLeasesOnDestructiveCreate` path collapses the two-step
pattern to one break-to-None, matching Samba `do_dirlease_break_to_none`
(`source3/smbd/smb2_oplock.c`) — the canonical pattern for any
directory-content-change event. Applies uniformly to CREATE,
OVERWRITE, and SUPERSEDE.

### 2. Accept late ACK after server-side parent-break timeout

The WPTS test sends its `LEASE_BREAK_ACK` only after the synchronous SUT
controller's `CreateFile` call returns. Because we block the child
CREATE for up to 5s waiting for the ACK, by the time the test wakes up
and acks, `forceCompleteBreaks` has already auto-revoked the lease to
None and the ACK lands on a `!Breaking` record — returning
`STATUS_UNSUCCESSFUL` via `ErrLeaseAckNotBreaking`. Accept the late ACK
silently when it matches the post-timeout state
(`BrokenViaTimeout && acknowledgedState == None == LeaseState`) without
touching `BrokenViaTimeout`, so:

- smbtorture `batch22b` tombstone semantics (LEVEL_II coercion via
  `OnlyTimeoutTombstoneRecords`) are preserved
- smbtorture `breaking2` / `breaking5` duplicate ACKs still surface as
  `STATUS_UNSUCCESSFUL` (their first in-window ACK leaves
  `BrokenViaTimeout=false`, so the duplicate falls through to the
  existing error branch)

## Local verification

- Unit tests: `pkg/metadata/lock`, `internal/adapter/smb/lease`,
  `internal/adapter/smb/v2/handlers` — all green (including `-race`)
- WPTS BVT focused: `BVT_DirectoryLeasing_ReadWriteHandleCaching` —
  **PASS 3/3** runs with fresh state each run
- WPTS BVT focused: `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`
  (the other dir-lease BVT) — still PASS, confirming the
  sharing-violation break path is unaffected
- Lint clean (`golangci-lint --timeout=5m`)

## Test plan

- [ ] CI WPTS memory: `BVT_DirectoryLeasing_ReadWriteHandleCaching` flips to PASS
- [ ] CI WPTS badger-fs / memory-fs: same flip
- [ ] CI smbtorture: no regressions in `smb2.lease.breaking2`,
  `smb2.lease.breaking5`, `smb2.lease.batch22b`, `smb2.dirlease.leases`,
  `smb2.dirlease.overwrite`, `smb2.dirlease.rename_dst_parent`
- [ ] Walk back KNOWN_FAILURES.md `BVT_DirectoryLeasing_ReadWriteHandleCaching`
  entry in a follow-up commit after CI confirms

Closes #454