### PR TITLE
fix(smb/create): DELETE_ON_CLOSE permission enforcement (#719)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -216,19 +216,6 @@ Advanced share mode enforcement and deny mode scenarios.
 |-----------|----------|--------|-------|
 | smb2.sharemode.bug14375 | Share modes | Share mode edge case not implemented | - |
 
-### Delete-on-Close (Advanced Semantics)
-
-Advanced delete-on-close permission checks and edge cases. Basic DOC works
-(3 tests pass) but permission-restricted scenarios do not.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.delete-on-close-perms.CREATE | Delete on close | DOC permission check not implemented | - |
-| smb2.delete-on-close-perms.CREATE_IF | Delete on close | DOC permission check not implemented | - |
-| smb2.delete-on-close-perms.OVERWRITE_IF | Delete on close | OVERWRITE_IF returns OBJECT_NAME_COLLISION instead of ACCESS_DENIED for DOC permission check | - |
-| smb2.delete-on-close-perms.READONLY | Delete on close | DOC on read-only files not implemented | - |
-| smb2.delete-on-close-perms.FIND_and_set_DOC | Delete on close | Cascade from the CREATE/CREATE_IF/OVERWRITE_IF Existing DOC failures above: those subtests leak `test_dir/test_create.dat` that `smb2_deltree` can't recover from, so `torture_smb2_testdir` reopens a non-empty `test_dir` and the final CLOSE correctly returns DIRECTORY_NOT_EMPTY. Pre-#388 the unlink error was silently swallowed by CLOSE so the test "passed" by accident. Will self-resolve once the upstream DOC permission checks are implemented. | - |
-
 ### Maximum Allowed Access (Partial)
 
 Maximum allowed access computation is partially implemented. Read-only


### PR DESCRIPTION
Closes #719

## Summary

Walks back the 5 `smb2.delete-on-close-perms.{CREATE,CREATE_IF,OVERWRITE_IF,READONLY,FIND_and_set_DOC}` entries from KNOWN_FAILURES.md after confirming they all PASS locally.

The MS-FSA §2.1.5.1.2.1 / MS-SMB2 §3.3.5.9 DOC permission gates are already wired into `completeCreateAfterBreak` (`internal/adapter/smb/v2/handlers/create_post_break.go:388-419`):

- `FILE_DELETE_ON_CLOSE` without `DELETE` in `DesiredAccess` returns `STATUS_ACCESS_DENIED` (Samba `smbd_set_initial_delete_on_close`).
- Opening an existing file with `FILE_ATTRIBUTE_READONLY` and DOC returns `STATUS_CANNOT_DELETE` (MS-FSA readonly veto).
- A CREATE that requests `READONLY` *and* DOC simultaneously is rejected with `STATUS_CANNOT_DELETE` before the file is materialized — and only when the disposition (CREATE / OVERWRITE / SUPERSEDE) actually propagates `req.FileAttributes` to the resulting file.
- OVERWRITE_IF runs the DOC permission gate ahead of the disposition-collision check, so a denied delete returns `STATUS_ACCESS_DENIED` rather than `STATUS_OBJECT_NAME_COLLISION`.
- `FIND_and_set_DOC` self-resolves once the upstream subtests stop leaking `test_dir/test_create.dat` (per the KF note).

Unit-level regression coverage already lives in `create_doc_perms_test.go` (added in #589).

## Test plan

- [x] `go test -race ./internal/adapter/smb/v2/handlers/...` → PASS
- [x] `go fmt ./... && go vet ./...` → clean
- [x] `golangci-lint run --timeout=5m ./internal/adapter/smb/v2/handlers/...` → 0 issues
- [x] `./run.sh --filter smb2.delete-on-close-perms` → 9/9 PASS (5 target + 4 already-passing)
- [ ] CI smbtorture green
- [ ] Copilot review clean