### PR TITLE
fix(blockstore/fs): close dedup-LRU ordering + scoping bug (#669)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v0.16.0
 milestone_name: Share Snapshots
-status: ready_to_plan
-stopped_at: Phase 24 context gathered
-last_updated: "2026-05-28T14:14:29.695Z"
-last_activity: 2026-05-28 -- Phase 24 planning complete
+status: planning
+stopped_at: Phase 25 context gathered
+last_updated: "2026-05-28T20:50:24.973Z"
+last_activity: 2026-05-28
 progress:
   total_phases: 18
-  completed_phases: 7
-  total_plans: 48
-  completed_plans: 44
-  percent: 39
+  completed_phases: 8
+  total_plans: 54
+  completed_plans: 54
+  percent: 100
 ---
 
 # Project State
@@ -135,8 +135,8 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-05-28T13:49:30.115Z
-Stopped at: Phase 24 context gathered
+Last session: 2026-05-28T20:50:24.911Z
+Stopped at: Phase 25 context gathered
 Next action: Wait for the parallel sentinel-path-mismatch fix work stream (Plan 09 SUMMARY Deviations) to land; then Phase 17 is ready for develop merge. Plan 17-10 SUMMARY at `.planning/phases/17-unified-blockstore/17-10-SUMMARY.md`. Three doc surfaces (pkg/blockstore/doc.go, docs/CONFIGURATION.md §Migration, docs/CLI.md dfs migrate-to-cas) pinned by acceptance-criteria grep gates against future flag drift. Commits: `bb97ec34`, `99b5ef58`, `9f604247`.
 
 Previous next-action (preserved for context): **Phase 14 phase-execution complete.** Two outstanding follow-ups before production rollout: (1) `openOfflineRuntime` production wiring (controlplane DB read + per-share metadata/remote-store factory dispatch) — tracked under #425, interfaces stable, runbook documents this prominently as a Known Limitation; (2) per-payload-id streaming variant of `deleteLegacyKeys` only if real workloads surface S3 LIST cost (T-14-05-04). Status surface (CLI + REST) is fully usable today against a running daemon. Once #425 closes, no runbook changes needed — the four worked transcripts will then run literally rather than aspirationally. Phase 15 (A6 — legacy cleanup) remains intentionally deferred until #425 closes and migration is rolled out across production workloads.

--- a/.planning/phases/25-cli-rest-api-documentation-parallel-with-24/25-CONTEXT.md
+++ b/.planning/phases/25-cli-rest-api-documentation-parallel-with-24/25-CONTEXT.md
@@ -1,0 +1,351 @@
+# Phase 25: CLI + REST API + Documentation (parallel with 24) - Context
+
+**Gathered:** 2026-05-28
+**Status:** Ready for planning
+**GH issue:** [#643](https://github.com/marmos91/dittofs/issues/643)
+**Milestone:** v0.16.0 Share Snapshots — Phase 6 of 6
+**Depends on:** Phase 23 (Runtime.CreateSnapshot/WaitForSnapshot + sync-gate primitive), Phase 24 (Runtime.RestoreSnapshot + 7 error sentinels)
+
+<domain>
+## Phase Boundary
+
+Ship the operator-facing surface for snapshot machinery built in Phases 20–24. **No new runtime business logic** — wraps existing `Runtime.{CreateSnapshot,WaitForSnapshot,RestoreSnapshot}` and `store.{Get,List,Delete}Snapshot`. Surfaces: 5 `dfsctl share snapshot` subcommands, 5 REST endpoints under `/api/v1/shares/{name}/snapshots`, `pkg/apiclient/snapshots.go` typed client, and 4 docs deliverables.
+
+In addition, Phase 25 carries one cross-cutting cleanup: **rename "sync gate" → "verify"** across the Phase 23-shipped surface (Go fields, package name, log fields, docstrings) and **drop the `snapshot.sync_gate_concurrency` YAML knob** in favor of hardcoded `16` parallel HEAD probes. CLI-internal vocabulary (`--no-verify`) and operator-doc vocabulary ("the verify gate") then match.
+
+**In scope:**
+- `cmd/dfsctl/commands/share/snapshot/` (new nested cobra package) — `snapshot.go` (parent Cmd + init) + `create.go` / `list.go` / `show.go` / `delete.go` / `restore.go` (one file per leaf). Pattern from `cmd/dfsctl/commands/share/permission/`.
+- `cmd/dfsctl/commands/share/share.go` — add `snapshot.Cmd` to `init()`.
+- `pkg/apiclient/snapshots.go` (new) — typed `apiclient.Snapshot` DTO + 6 client methods (Create, List, Get, Delete, Restore, Wait); reuse `getResource[T]` / `createResource[T]` / `normalizeShareNameForAPI(name)` from existing apiclient package.
+- `internal/controlplane/api/handlers/snapshot.go` (new) — 5 handler methods + `SnapshotRuntime` interface (testability seam) + `mapSnapshotError(w, err) bool` single error-to-HTTP table covering all 12 typed sentinels from Phase 23 D-23-12 + Phase 24 D-24-08.
+- `pkg/controlplane/api/router.go` — wire `r.Route("/{name}/snapshots", ...)` inside the existing `/api/v1/shares` admin group (inherits `RequireAdmin`).
+- `pkg/controlplane/runtime/snapshot.go` — extend with 4 wrapper methods: `GetSnapshot(ctx, share, snapID)`, `ListSnapshots(ctx, share)`, `DeleteSnapshot(ctx, share, snapID)` (acquire delete-lock → `store.DeleteSnapshot` → `os.RemoveAll(SnapshotDir)` → release lock), plus the rename pass.
+- **Rename pass:** `pkg/snapshot/syncgate.go` → `pkg/snapshot/verify.go`; `CreateSnapshotOpts.NoSyncGate` → `NoVerify`; YAML `snapshot.sync_gate_concurrency` → DELETED; `Runtime.VerifyRemoteDurability` already named correctly; structured-log field renames (`verify_concurrency` etc. removed entirely since knob is gone); godoc + comments updated to "verify" terminology throughout `pkg/snapshot/`, `pkg/controlplane/runtime/snapshot*.go`.
+- `docs/SNAPSHOTS.md` (new) — full operator guide, sections per Area-D decision (Overview, Snapshot model, CLI walkthrough per command, Creating, Listing & inspecting, Deleting, Restore runbook, Recovering from safety snapshot, GC hold semantics, Failure modes & recovery, Limitations, REST API reference brief). Depth mirrors `docs/BLOCKSTORE_MIGRATION.md`.
+- `docs/ARCHITECTURE.md` — full "Share Snapshots" section + GC-section update (`SnapshotHoldProvider` + manifest-on-disk filter replaces `BackupHoldProvider` mention).
+- `docs/CLI.md` — full `share snapshot` subtree section (not just tree-diagram update).
+- `README.md` — replace deprecated "backup will ship in v0.16.0" / v0.13.0 backup paragraph with a "Share Snapshots" feature paragraph + 3-line example command + link to `docs/SNAPSHOTS.md`.
+- E2E tests in `test/e2e/snapshot/`:
+  - `snapshot_http_test.go` — in-process Runtime + chi router + memory metadata + memory `RemoteStore` + memory `LocalStore`; HTTP client exercises all 5 endpoints including async-create polling, sync-restore happy path, plus fault-injection coverage of all 9 D-24-13 failure modes
+  - `snapshot_cli_test.go` — built `dfsctl` binary against a stubserver; asserts table/JSON/YAML output, confirmation-prompt + `--yes` behavior, `--no-wait` / `--no-verify` / `--retry` / `--force` flag wiring
+
+**Out of scope:**
+- New runtime/business logic — Phase 25 is plumbing + docs only.
+- Streaming progress for long-running restore — sync 200 with simple body per Area-B decision; chunked-JSON-lines variant rejected.
+- Async restore (202+poll) — explicitly violates Phase 24 D-24-02 ("no restore-tracking DB row").
+- Cross-share restore / restore-into-new-share — Phase 24 REST-01 scoped to same-share.
+- Snapshot encryption — orthogonal feature; not in v0.16.0.
+- Prometheus / OTel metrics for snapshot ops — deferred per Phase 23 D-23-16; structured `slog` only.
+- Verify-now action on `show` (`show --verify` flag re-running VerifyRemoteDurability) — listed as a possible add but cut for scope.
+- Restore-progress streaming — kept simple (single 200 response).
+- Operator/role split for read endpoints — admin-only inherited.
+- Auto-disable / auto-enable around restore (CLI bookending) — Phase 24 D-24-01 spirit preserved; CLI fails on enabled share with hint and exits.
+- Pagination (`--limit`, cursors) — snap counts per share stay in low-hundreds (Phase 23 D-23-04 comment) so no `--limit` needed.
+- Sort flag — newest-first hardcoded.
+- Refuse-to-delete `pre-restore-*` guardrail — rejected in favor of uniform Y/N-prompt + `--yes` policy.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Cross-cutting rename (sync_gate → verify)
+
+- **D-25-01:** Rename "sync gate" terminology to "verify" across Phase 23-shipped code, so internal vocabulary aligns with the already-chosen `--no-verify` CLI flag and SNAPSHOTS.md operator docs.
+  - **Go:** `pkg/snapshot/syncgate.go` → `pkg/snapshot/verify.go` (file rename + package symbol updates). `CreateSnapshotOpts.NoSyncGate bool` → `CreateSnapshotOpts.NoVerify bool`. `Runtime.VerifyRemoteDurability` already named correctly — no change. Logging fields containing "sync_gate" replaced with "verify" or removed where the per-knob context is gone.
+  - **YAML:** `snapshot.sync_gate_concurrency` DELETED (per D-25-02). No replacement key.
+  - **Docs / godoc / comments:** all "sync gate" prose → "verify" prose. SNAPSHOTS.md and ARCHITECTURE.md use "verify gate" / "the verify step" consistently.
+  - **No backwards-compat shim** per memory `feedback_no_prod_users_delete_eagerly` — DittoFS pre-1.0, no production users. Deleting the YAML key is a hard break for any operator config that set it; release notes call it out.
+
+- **D-25-02:** Drop the `snapshot.sync_gate_concurrency` YAML knob. Hardcode parallelism to 16 inside `VerifyRemoteDurability` callers (the Phase 23 default value). Rationale: nobody has tuned this knob; the rare operator with throttled-remote pain can either re-add the knob later (non-breaking) or live with 16 (still well under typical S3 rate limits). Aligns with memory `feedback_less_is_more`.
+
+### CLI UX
+
+- **D-25-03:** `dfsctl share snapshot create <share>` BLOCKS by default — runs `CreateSnapshot` then `WaitForSnapshot`, prints progress lines (creating → ready/failed), exits 0 on `ready` / non-zero on `failed`. `--no-wait` returns the new snapID immediately and exits 0. Rationale: matches operator expectation "the command finishes when the thing is done"; scripts that want fire-and-forget use `--no-wait`.
+
+- **D-25-04:** `dfsctl share snapshot restore <share> <id>` pre-flight refuses on enabled share with hint `share /<name> is enabled; run 'dfsctl share disable /<name>' first`. On disabled share, interactive `Y/N` confirmation prompts (showing share + snap-id + safety-snap-will-be-created notice). `--yes` skips the prompt. Auto-disable / auto-re-enable REJECTED per D-24-01 spirit (explicit operator intent at each step). On success, prints `Safety snap: <id> (delete with 'dfsctl share snapshot delete <share> <id>' after verifying)`.
+
+- **D-25-05:** `dfsctl share snapshot delete` uses same Y/N + `--yes` policy as restore. No special-casing of `pre-restore-*` safety snaps (rejected — uniform UX over guardrail).
+
+- **D-25-06:** Flag naming (after deliberation):
+  - **create:** `--no-verify` (= `CreateSnapshotOpts.NoVerify`, ex `NoSyncGate`); `--retry=<id>` (= `CreateSnapshotOpts.RetryOf`); `--no-wait` (CLI-local, no Runtime equivalent)
+  - **restore:** `--force` (= `RestoreSnapshotOpts.AllowNonDurable`); `--yes` (CLI-local skip-prompt)
+  - **delete:** `--yes`
+  Rationale: shorter, colloquial; `--force` is conventional "I accept the risk" verb. Less direct mapping to struct-field names but better operator UX.
+
+### REST API shape
+
+- **D-25-07:** `POST /api/v1/shares/{name}/snapshots` (create) returns `202 Accepted` with `Location: /api/v1/shares/{name}/snapshots/{id}` and JSON body `{"snapshot_id":"<id>","share":"<name>"}`. GET on the Location URL returns the full snapshot record (state, durable, error, etc.). Matches Phase 23 D-23-13.
+
+- **D-25-08:** `POST /api/v1/shares/{name}/snapshots/{id}/restore` is SYNC: handler blocks on `Runtime.RestoreSnapshot`, returns `200 OK` with body `{"snapshot_id":"<id>","safety_snapshot_id":"<id>","share":"<name>"}` on success. Handler wraps `r.Context()` with `context.WithTimeout(ctx, cfg.Snapshot.RestoreHTTPTimeout)` (D-25-10 below).
+
+- **D-25-09:** Single error-to-HTTP mapping table `mapSnapshotError(w, err) bool` in `internal/controlplane/api/handlers/snapshot.go`. Covers all 12 typed sentinels (Phase 23 D-23-12: `ErrSnapshotBackupFailed/VerifyFailed/DrainTimeout/RetryTargetNotFound/RetryTargetNotFailed`; Phase 22: `ErrSnapshotNotFound`; Phase 24 D-24-08: `ErrShareEnabled/SnapshotNotDurable/SnapshotMetadataDumpMissing/MetadataStoreNotResetable/RestoreSafetySnapFailed/RestoreAborted/RestoreVerifyFailed`). Each handler error path calls `if mapSnapshotError(w, err) { return }` before falling through to `InternalServerError`. Single source of truth — one edit when a new sentinel lands.
+  - Suggested mapping (planner finalizes against existing problem.go helpers):
+    - `ErrSnapshotNotFound` → 404
+    - `ErrShareEnabled` → 409 Conflict
+    - `ErrSnapshotNotDurable` → 412 Precondition Failed
+    - `ErrSnapshotMetadataDumpMissing` → 500
+    - `ErrMetadataStoreNotResetable` → 500 (should never happen in prod)
+    - `ErrSnapshotRetryTargetNotFound` → 404
+    - `ErrSnapshotRetryTargetNotFailed` → 409 Conflict
+    - `ErrSnapshotDrainTimeout` → 504 Gateway Timeout
+    - `ErrSnapshotBackupFailed` / `ErrSnapshotVerifyFailed` / `ErrRestoreAborted` / `ErrRestoreVerifyFailed` / `ErrRestoreSafetySnapFailed` → 500 with sanitized message (no internal-error leak per IN-2-01 / IN-4-02 precedent in `block_gc.go`)
+
+- **D-25-10:** New YAML knob `snapshot.restore_http_timeout: 30m` (server config) bounds the restore-handler's per-request context. `apiclient.RestoreSnapshot` uses a matching `http.Client.Timeout` (30m default, configurable on `apiclient.Client` builder). CLI `restore` inherits via apiclient. Rationale: operator visibility into long-running restore boundaries; protects server from runaway requests.
+
+### REST DTO + routes
+
+- **D-25-11:** Define `apiclient.Snapshot` DTO in `pkg/apiclient/snapshots.go`, decoupled from `pkg/controlplane/models/snapshot.go` GORM struct. Fields per snippet:
+  ```go
+  type Snapshot struct {
+      ID            string    `json:"id"`
+      Name          string    `json:"name,omitempty"`
+      Share         string    `json:"share"`
+      State         string    `json:"state"`           // creating | ready | failed
+      RemoteDurable bool      `json:"remote_durable"`
+      ManifestCount int       `json:"manifest_count,omitempty"`
+      DumpBytes     int64     `json:"dump_bytes,omitempty"`
+      RetryOf       string    `json:"retry_of,omitempty"`
+      Error         string    `json:"error,omitempty"`
+      CreatedAt     time.Time `json:"created_at"`
+      UpdatedAt     time.Time `json:"updated_at"`
+  }
+  ```
+  Handler converts `models.Snapshot` → `apiclient.Snapshot` before writing JSON. `ManifestCount` + `DumpBytes` are computed on demand from disk (stat + manifest hash count) for `show` and optionally `list`; nil/zero when stat fails (don't fail the list because one snap's disk vanished).
+
+- **D-25-12:** Route layout under existing `/api/v1/shares` (which already mounts `RequireAdmin` middleware) — admin-only inherited, no extra middleware:
+  - `POST   /api/v1/shares/{name}/snapshots` — create (202)
+  - `GET    /api/v1/shares/{name}/snapshots` — list
+  - `GET    /api/v1/shares/{name}/snapshots/{id}` — get/show
+  - `DELETE /api/v1/shares/{name}/snapshots/{id}` — delete (204 or 200 with body)
+  - `POST   /api/v1/shares/{name}/snapshots/{id}/restore` — restore (sync 200)
+
+### List / show output
+
+- **D-25-13:** `dfsctl share snapshot list <share>` default table columns: `ID(8-char short) NAME STATE DURABLE CREATED SIZE`. CREATED rendered relative ("2h ago") with `--no-relative` flag for ISO. SIZE = manifest hash count (`"1842 blocks"`) — the manifest is the user-meaningful unit of "what's protected" in CAS. SIZE is `-` when manifest absent (creating / failed-before-manifest).
+
+- **D-25-14:** Newest-first default sort (no `--sort` flag). Filters: `--state=<state>` and `--name-prefix=<s>` (AND together). No pagination flags. JSON/YAML output via existing `cmdutil.GetOutputFormatParsed()` + `output.PrintJSON/PrintYAML` returns the full `[]apiclient.Snapshot` slice unfiltered (filtering happens server-side or in CLI before render).
+
+- **D-25-15:** `dfsctl share snapshot show <share> <id>` table view includes full UUID + Name + Share + State + Durable + Manifest hash count + Dump bytes + Created + Updated + ManifestPath + DumpPath + RetryOf + Error (when state=failed). JSON/YAML modes return the apiclient.Snapshot DTO plus computed disk fields (paths, sizes).
+
+### Code structure + Runtime API
+
+- **D-25-16:** Nested cobra package `cmd/dfsctl/commands/share/snapshot/` with one file per leaf cmd. Mirrors `cmd/dfsctl/commands/share/permission/` exactly. Tests next to source (`list_test.go`, `restore_test.go` for prompt + flag wiring).
+
+- **D-25-17:** Add 3 thin wrappers on `*Runtime` so handlers never reach into `r.store` directly:
+  - `Runtime.GetSnapshot(ctx, share, snapID) (*models.Snapshot, error)` — delegates to `r.store.GetSnapshot`.
+  - `Runtime.ListSnapshots(ctx, share) ([]*models.Snapshot, error)` — delegates to `r.store.ListSnapshots`.
+  - `Runtime.DeleteSnapshot(ctx, share, snapID) error` — the full dance: acquire per-share delete lock via existing `snapshotDeleteLock(share)`, call `r.store.DeleteSnapshot`, `os.RemoveAll((&models.Snapshot{ID: snapID}).SnapshotDir(localStoreDir))`, release lock. Symmetric with `CreateSnapshot/RestoreSnapshot` already on Runtime.
+
+  Handler `SnapshotRuntime` interface (testability seam, mirrors `BlockGCRuntime` in `block_gc.go`):
+  ```go
+  type SnapshotRuntime interface {
+      CreateSnapshot(ctx context.Context, share string, opts CreateSnapshotOpts) (string, error)
+      WaitForSnapshot(ctx context.Context, share, snapID string) (*models.Snapshot, error)
+      RestoreSnapshot(ctx context.Context, share, snapID string, opts RestoreSnapshotOpts) error
+      GetSnapshot(ctx context.Context, share, snapID string) (*models.Snapshot, error)
+      ListSnapshots(ctx context.Context, share string) ([]*models.Snapshot, error)
+      DeleteSnapshot(ctx context.Context, share, snapID string) error
+  }
+  ```
+  Handler unit tests substitute a fake `SnapshotRuntime` that records calls and returns canned responses.
+
+### Tests + PR shape
+
+- **D-25-18:** 3-layer test strategy:
+  - **Handler unit tests:** fake `SnapshotRuntime` per `BlockGCRuntime` pattern; assert routing, DTO conversion, error mapping (every sentinel → expected HTTP code), 202+Location for create, 200 body for restore.
+  - **apiclient tests:** against existing stubserver pattern; assert each client method's URL construction, body serialization, error decoding (problem+json or generic).
+  - **CLI unit tests:** fake apiclient; assert table-renderer output, JSON/YAML modes, confirmation-prompt + `--yes`, flag wiring (`--no-wait`, `--no-verify`, `--retry`, `--force`).
+  - **E2E (test/e2e/snapshot/):**
+    - `snapshot_http_test.go`: in-process Runtime + chi router + memory metadata + memory `RemoteStore` + memory `LocalStore`. Exercises all 5 endpoints end-to-end. Polls async create. Covers all 9 D-24-13 restore failure modes via fault injection on the in-process stack.
+    - `snapshot_cli_test.go`: built `dfsctl` binary against a stubserver; asserts CLI output formats, prompts, exit codes.
+
+- **D-25-19:** PR shape — **4 plans / 2 waves / single PR against develop**, mirroring Phase 22/23/24 cadence:
+  - **Wave 1 (1 plan, sequential, foundation):**
+    - **P25-01** — Runtime wrappers (`GetSnapshot`, `ListSnapshots`, `DeleteSnapshot` per D-25-17) + sync_gate→verify rename pass across `pkg/snapshot/`, `pkg/controlplane/runtime/snapshot*.go`, config schema; delete `snapshot.sync_gate_concurrency` YAML knob; hardcode 16 in callers. All existing unit + integration tests updated to new names. **No behavior change** beyond the knob removal.
+  - **Wave 2 (3 plans, parallel after P25-01 lands):**
+    - **P25-02** — `internal/controlplane/api/handlers/snapshot.go` (5 handlers + `SnapshotRuntime` interface + `mapSnapshotError` + DTO conversion) + `pkg/controlplane/api/router.go` wiring under `/api/v1/shares/{name}/snapshots/*` + handler unit tests with fake runtime. Adds `snapshot.restore_http_timeout: 30m` YAML knob (D-25-10).
+    - **P25-03** — `pkg/apiclient/snapshots.go` (DTO + 6 client methods) + `cmd/dfsctl/commands/share/snapshot/*` (nested cobra package per D-25-16) + `cmd/dfsctl/commands/share/share.go` registration + CLI unit tests + apiclient stubserver tests. Includes the `apiclient.Client` builder change for restore http timeout override.
+    - **P25-04** — `docs/SNAPSHOTS.md` (new, full operator guide per D-25-20) + `docs/ARCHITECTURE.md` (full Snapshots section + GC section update) + `docs/CLI.md` (full snapshot subtree section) + `README.md` (replace deprecated backup paragraph with snapshots paragraph + 3-line example + link).
+  - **E2E tests in `test/e2e/snapshot/`** land in P25-02 (HTTP-layer e2e) and P25-03 (CLI-binary e2e) per their respective surfaces — both reuse the in-process memory-stack fixture.
+  - Branch: `gsd/phase-25-cli-rest-docs` (already created per current branch). Single PR against `develop`; staged commits per plan; reviewers walk commit-by-commit.
+
+### Documentation
+
+- **D-25-20:** `docs/SNAPSHOTS.md` is the new canonical operator guide; depth mirrors `docs/BLOCKSTORE_MIGRATION.md`. Sections:
+  1. Overview (what a snapshot is, what guarantees it gives)
+  2. Snapshot model (metadata dump + hash manifest + GC hold; manifest-on-disk = held)
+  3. CLI walkthrough (create, list, show, delete) with worked transcripts
+  4. Creating a snapshot (--no-wait, --no-verify, --retry semantics)
+  5. Listing & inspecting (--state, --name-prefix filters; JSON/YAML modes)
+  6. Deleting (Y/N + --yes; GC reclamation timing)
+  7. Restore runbook (disable → restore → verify → enable; --force for non-durable)
+  8. Recovering from safety snapshot (the second-restore path)
+  9. The verify gate (what it drains, what it probes, when it fires)
+  10. GC hold semantics (manifest-on-disk = held; failed-snap retention; delete vs GC race window)
+  11. Failure modes & recovery (D-24-13 taxonomy in operator language)
+  12. Limitations (no cross-share, no encryption, no auto-cleanup, sync restore, single-node v0.16.0)
+  13. REST API reference (brief — endpoint table with method+path+description; full spec lives in OpenAPI if/when added)
+  Add table-of-contents at top. Target 400–600 lines.
+
+- **D-25-21:** `docs/ARCHITECTURE.md` gets a full "Share Snapshots" subsection (architecture overview, refs SNAPSHOTS.md for operator detail) **plus** GC section update (rename `BackupHoldProvider` mention → `SnapshotHoldProvider`, describe manifest-on-disk filter + per-share RWMutex from Phase 23 D-23-04). `docs/CLI.md` gets a full `dfsctl share snapshot` subtree section (not just tree-diagram update). `README.md` replaces the deprecated v0.13.0-backup / "backup will ship in v0.16.0" paragraph with a "Share Snapshots" feature paragraph + a 3-line example command (`dfsctl share snapshot create /share && dfsctl share snapshot list /share`) + link to `docs/SNAPSHOTS.md`.
+
+### Claude's Discretion
+
+- D-25-09 specific HTTP-code mappings — the table above is a suggestion; planner finalizes against existing `problem.go` helpers (e.g., does a `problem.Conflict` exist, or should it be `WriteJSON(w, 409, ...)` directly?).
+- D-25-11 `ManifestCount` + `DumpBytes` computation — on-list (one stat per row, slower but uniform UX) vs on-show-only (faster list, asymmetric). Planner picks; default on-show-only with comment-line on `Snapshot` struct that these are optional.
+- D-25-13 SIZE column semantics — `manifest hash count` vs `metadata.dump bytes` vs both. Planner picks whichever is cheaper + more meaningful to operators; either is defensible.
+- D-25-17 `DeleteSnapshot` lock-acquisition path — direct call to `Runtime.snapshotDeleteLock(share).Lock()` vs going through `SnapshotHoldProvider.AcquireDeleteLock`. Both use the same underlying mutex per Phase 23 D-23-04; planner picks the call site that reads cleaner.
+- D-25-18 stubserver pattern for apiclient tests — reuse existing `pkg/apiclient/stubserver_test.go` if it's extensible, else add snapshot-specific stub helpers.
+- D-25-19 PR splitting — if reviewer load is too high in P25-02 (handler + router + interface + tests + new YAML knob), planner may split off the YAML knob + config plumbing as a tiny P25-02a.
+- D-25-20 SNAPSHOTS.md exact section ordering + worked-transcript verbosity — operator-doc tone judgment.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Requirements and roadmap
+- `.planning/REQUIREMENTS.md` lines 50–56 (API-01..07) + lines 65–68 (DOC-01..04) — Phase 25's eleven requirements
+- `.planning/ROADMAP.md` §"Phase 25: CLI + REST API + Documentation (parallel with 24)" (lines 721–741) — goal + success criteria + files-to-touch list
+- `.planning/REQUIREMENTS.md` lines 119–131 — requirement-to-phase coverage table (all pending → flip to done on PR merge)
+
+### Phase 24 dependency (sync restore + 7 error sentinels + RestoreSnapshotOpts)
+- `.planning/phases/24-restore-flow/24-CONTEXT.md` — all 19 Phase 24 decisions. Critical: D-24-01 (operator-bracketed restore — CLI refuses on enabled share), D-24-02 (sync restore — Phase 25 REST blocks on it, D-25-08), D-24-06 (`AllowNonDurable` → `--force` per D-25-06), D-24-08 (7 sentinels Phase 25 maps to HTTP per D-25-09), D-24-13 (failure-mode taxonomy for e2e + SNAPSHOTS.md ops doc)
+- `.planning/phases/24-restore-flow/24-VERIFICATION.md` — Phase 24 verification report (read for what's actually shipped)
+- `pkg/controlplane/runtime/snapshot.go::Runtime.RestoreSnapshot(ctx, share, snapID string, opts RestoreSnapshotOpts) error` — exact call the restore handler wraps
+- `pkg/controlplane/runtime/snapshot.go::RestoreSnapshotOpts{AllowNonDurable bool}` — CLI/REST surface `--force` / `{"allow_non_durable": true}` body field
+- `pkg/controlplane/models/errors.go` — 7 new sentinels from D-24-08: `ErrShareEnabled`, `ErrSnapshotNotDurable`, `ErrSnapshotMetadataDumpMissing`, `ErrMetadataStoreNotResetable`, `ErrRestoreSafetySnapFailed`, `ErrRestoreAborted`, `ErrRestoreVerifyFailed`
+
+### Phase 23 dependency (async create + sync-gate primitive + 5 sentinels + WaitForSnapshot)
+- `.planning/phases/23-snapshot-create-orchestration-sync-gate/23-CONTEXT.md` — all 23 Phase 23 decisions. Critical: D-23-11 (`NoSyncGate` → `NoVerify` per D-25-01; `--no-verify` per D-25-06), D-23-12 (5 sentinels), D-23-13 (async CreateSnapshot — Phase 25 REST returns 202 per D-25-07), D-23-15 (`CreateSnapshotOpts` plain struct — no functional opts), D-23-19 (`WaitForSnapshot` — Phase 25 CLI block-by-default per D-25-03), D-23-22 (`snapshot.sync_gate_concurrency` knob — DELETED per D-25-02)
+- `pkg/controlplane/runtime/snapshot.go::CreateSnapshotOpts{NoSyncGate, RetryOf}` — Phase 25 renames `NoSyncGate → NoVerify` per D-25-01; CLI surface `--no-verify` / `--retry=<id>` per D-25-06
+- `pkg/controlplane/runtime/snapshot.go::Runtime.CreateSnapshot`, `Runtime.WaitForSnapshot` — exact calls CLI create blocks on
+- `pkg/snapshot/syncgate.go::VerifyRemoteDurability(ctx, remote, manifest *HashSet, concurrency int) error` — Phase 25 renames file `syncgate.go → verify.go` per D-25-01; callers pass literal 16 per D-25-02
+
+### Phase 22 dependency (snapshot model + SnapshotStore CRUD + manifest I/O + delete-lock infra)
+- `.planning/phases/22-snapshot-records-hash-manifest-gc-hold/22-CONTEXT.md` — Phase 22 decisions. Critical: D-22-04 (manifest = ground truth), D-22-19 (atomic manifest write via temp+rename)
+- `pkg/controlplane/models/snapshot.go::Snapshot{ID, Name, Share, State, RemoteDurable, RetryOf, ...}` + path helpers `SnapshotDir(localStoreDir)`, `ManifestPath(...)`, `MetadataDumpPath(...)` — used by Phase 25 DTO mapping + Runtime.DeleteSnapshot dir wipe
+- `pkg/controlplane/store/snapshots.go::GORMStore.{GetSnapshot,ListSnapshots,DeleteSnapshot}` — wrapped by new `Runtime.GetSnapshot/ListSnapshots/DeleteSnapshot` per D-25-17
+- `pkg/snapshot/manifest.go::ReadManifest(path) (*HashSet, error)` — used by `show` to compute manifest count if not on the DB row
+- `pkg/controlplane/runtime/snapshot_hold.go::SnapshotHoldProvider.AcquireDeleteLock(shareName) func()` + `Runtime.snapshotDeleteLock(shareName)` — Phase 25 Runtime.DeleteSnapshot uses the same per-share mutex per D-25-17 / D-23-04
+
+### Reusable code patterns
+- `cmd/dfsctl/commands/share/permission/` — exact template for the nested-cobra-package layout (D-25-16): `permission.go` (parent + init) + `grant.go` / `revoke.go` / `list.go` leaves. Each leaf uses `cmdutil.GetAuthenticatedClient()` + `client.XXX()` + `cmdutil.GetOutputFormatParsed()` switch over JSON/YAML/table via `output.PrintJSON/PrintYAML/PrintTable`.
+- `cmd/dfsctl/commands/share/permission/list.go::PermissionList` — `TableRenderer` interface implementation pattern; Phase 25 mirrors with `SnapshotList` type (Headers/Rows methods).
+- `pkg/apiclient/blockstore.go::BlockStoreStatsResponse` etc. — DTO pattern + generic `getResource[T]` / `createResource[T]` helpers + `url.PathEscape(normalizeShareNameForAPI(name))`. Phase 25 reuses verbatim.
+- `internal/controlplane/api/handlers/block_gc.go::BlockGCRuntime` interface + `NewBlockStoreGCHandler(rt)` — exact template for `SnapshotRuntime` interface + `NewSnapshotHandler` per D-25-17. Also the pattern for `errors.Is(err, shares.ErrShareNotFound) → NotFound + log-at-Debug + sanitized 500 message` (D-25-09).
+- `internal/controlplane/api/handlers/shares.go::ShareHandler.Disable / Enable` (lines 678 + 715) — pattern for "POST verb on a resource, get reloaded record back" (Phase 25 restore handler mirrors).
+- `internal/controlplane/api/handlers/problem.go` — `BadRequest` / `NotFound` / `InternalServerError` / `WriteNoContent` helpers. Phase 25 also may add a `WriteJSONAccepted` (202) helper if not present (planner check).
+- `pkg/controlplane/api/router.go` lines 190–215 — share routes group with `RequireAdmin` middleware; Phase 25 adds `r.Route("/{name}/snapshots", ...)` siblings inside this same group per D-25-12.
+
+### Cobra leaf-cmd conventions
+- `cmd/dfsctl/commands/share/permission/list.go` (full file) — confirmation prompt is NOT used here (read-only); for write/destructive ops with `--yes`, see how `cmd/dfsctl/commands/share/delete.go` handles confirmation (planner reads for exact prompt-helper if one exists; else add to `cmdutil`).
+- `cmd/dfsctl/cmdutil/` — `GetAuthenticatedClient`, `GetOutputFormatParsed`. Phase 25 may add `ConfirmDestructive(prompt, yesFlag) (bool, error)` helper if no equivalent exists.
+
+### Existing docs (reference for tone + depth + cross-link style)
+- `docs/BLOCKSTORE_MIGRATION.md` — depth + tone template for `SNAPSHOTS.md` per D-25-20 (TOC at top, worked transcripts, "Recovery" / "Out of scope" / "Internals" sections)
+- `docs/CLI.md` — current `dfsctl` tree to extend (D-25-21)
+- `docs/ARCHITECTURE.md` — GC section that needs update + insertion point for new Snapshots section (D-25-21)
+- `README.md` — deprecated v0.13.0 backup paragraph to replace (D-25-21)
+
+### CLAUDE.md + standing rules
+- `CLAUDE.md` §"Architecture invariants" — invariants 6 (return `metadata.ExportError` values + Debug/Error log split — applies to handler error paths) and 7 (metadata-store contract — `Resetable` already shipped by Phase 24)
+- `CLAUDE.md` §"Commits & PRs" — no Claude/AI mentions; concise messages; sign commits
+- Memory: `feedback_no_prod_users_delete_eagerly` — justifies hard-deleting `sync_gate_concurrency` YAML key without compat shim per D-25-02
+- Memory: `feedback_less_is_more` — justifies hardcoding 16 over keeping the knob per D-25-02
+- Memory: `feedback_run_lint_before_push`, `feedback_simplifier_reviewer_before_pr`, `feedback_sign_all_commits`, `feedback_assign_prs_to_marmos91` — pre-PR gates
+
+### New files Phase 25 creates
+- `cmd/dfsctl/commands/share/snapshot/snapshot.go` (parent cmd + init)
+- `cmd/dfsctl/commands/share/snapshot/create.go`
+- `cmd/dfsctl/commands/share/snapshot/list.go`
+- `cmd/dfsctl/commands/share/snapshot/show.go`
+- `cmd/dfsctl/commands/share/snapshot/delete.go`
+- `cmd/dfsctl/commands/share/snapshot/restore.go`
+- `cmd/dfsctl/commands/share/snapshot/list_test.go`, `restore_test.go`, etc. (CLI unit tests, planner picks coverage shape)
+- `pkg/apiclient/snapshots.go` + sibling `snapshots_test.go`
+- `internal/controlplane/api/handlers/snapshot.go` + sibling `snapshot_test.go`
+- `pkg/snapshot/verify.go` (renamed from `syncgate.go`)
+- `docs/SNAPSHOTS.md`
+- `test/e2e/snapshot/snapshot_http_test.go`
+- `test/e2e/snapshot/snapshot_cli_test.go`
+
+### Files Phase 25 modifies
+- `cmd/dfsctl/commands/share/share.go` — register `snapshot.Cmd` in `init()`
+- `pkg/controlplane/api/router.go` — wire 5 snapshot routes under `/api/v1/shares/{name}/snapshots`
+- `pkg/controlplane/runtime/snapshot.go` — add `GetSnapshot/ListSnapshots/DeleteSnapshot` wrappers + rename `NoSyncGate → NoVerify`
+- `pkg/controlplane/runtime/snapshot*.go` (related files) — apply rename pass (sync gate → verify) in log fields, godoc, comments
+- `pkg/controlplane/models/errors.go` — sanity-check 12 sentinels are exported (no change expected; Phase 23+24 already shipped them)
+- `pkg/snapshot/syncgate.go` → renamed `pkg/snapshot/verify.go` (file move + symbol rename)
+- Server YAML config schema + Go binding — delete `snapshot.sync_gate_concurrency` field; add `snapshot.restore_http_timeout` (default 30m)
+- `pkg/apiclient/client.go` (or equivalent) — apiclient builder accepts optional per-call http timeout for restore
+- `docs/ARCHITECTURE.md`, `docs/CLI.md`, `README.md` — per D-25-21
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `cmdutil.GetAuthenticatedClient()` + `cmdutil.GetOutputFormatParsed()` (existing CLI infra) — every leaf cmd reuses verbatim. No new auth/output plumbing.
+- `output.PrintJSON / PrintYAML / PrintTable` + `TableRenderer` interface — Phase 25 implements `SnapshotList` (multi-row) and `SnapshotDetail` (single-record show) renderers.
+- `apiclient.getResource[T](c, url)`, `apiclient.createResource[T](c, url, body)`, `apiclient.normalizeShareNameForAPI(name)`, `url.PathEscape(...)` — every snapshot client method reuses these. Generic-based decoding handles DTO unmarshalling automatically.
+- `internal/controlplane/api/handlers/problem.go` — `BadRequest / NotFound / InternalServerError / WriteJSONOK / WriteNoContent` helpers. Likely missing: `WriteJSONAccepted(w, body)` for 202; planner adds if absent or writes inline.
+- `Runtime.snapshotDeleteLock(shareName)` (Phase 23 D-23-04, in `snapshot_hold.go`) — per-share RWMutex; Phase 25 `Runtime.DeleteSnapshot` reuses for the lock + DB delete + dir wipe sequence.
+- `models.Snapshot.SnapshotDir(localStoreDir)`, `ManifestPath`, `MetadataDumpPath` (Phase 22) — Phase 25 `show` reads via these for path/size display; `Runtime.DeleteSnapshot` wipes via `SnapshotDir`.
+- `pkg/snapshot/manifest.go::ReadManifest` — Phase 25 `show` calls for manifest hash count when computing on demand.
+
+### Established Patterns
+- **Handler-interface-for-testability pattern** (`BlockGCRuntime` in `internal/controlplane/api/handlers/block_gc.go`): Phase 25 `SnapshotRuntime` mirrors. Handler file declares the narrow interface it needs from Runtime; tests substitute a fake.
+- **Nested cobra subpackage pattern** (`cmd/dfsctl/commands/share/permission/`): Phase 25 `cmd/dfsctl/commands/share/snapshot/` mirrors exactly — parent `Cmd` + `init()` wires leaves, one file per leaf.
+- **Single error-to-HTTP mapper helper** (no exact precedent — each existing handler does inline switches; Phase 25 introduces `mapSnapshotError` as the first canonical mapper for a typed-sentinel cluster, per D-25-09). Future phases with typed-error clusters may follow.
+- **Async-create / sync-read REST pattern** (Phase 23 D-23-13 ratified; Phase 25 implements): `POST → 202 + Location + minimal body`; `GET → 200 + full record including state`. Familiar HTTP semantics.
+- **Operator-bracketed destructive ops** (D-24-01; CLI `share disable / enable` cycle around `share snapshot restore`): preserved verbatim per D-25-04.
+- **Hardcoded-after-tuning constants** (per `feedback_less_is_more`): Phase 25 hardcodes `verify` parallelism = 16, dropping a knob that nobody tunes.
+- **In-memory full-stack fixture for orchestration tests** (Phase 22 D-21 / Phase 23 P23-06 / Phase 24 P24-04): Phase 25 `test/e2e/snapshot/snapshot_http_test.go` follows the same pattern with chi router on top.
+
+### Integration Points
+- **Router** (`pkg/controlplane/api/router.go` ~line 190): new `r.Route("/{name}/snapshots", ...)` inside existing `/shares` admin group — inherits `RequireAdmin`, no extra middleware (D-25-12).
+- **CLI parent** (`cmd/dfsctl/commands/share/share.go::init()`): one line — `Cmd.AddCommand(snapshot.Cmd)` next to `permission.Cmd` (D-25-16).
+- **Runtime** (`pkg/controlplane/runtime/snapshot.go`): 3 wrapper methods added per D-25-17 + rename pass.
+- **Config** (server YAML + Go binding): delete `snapshot.sync_gate_concurrency`, add `snapshot.restore_http_timeout` (D-25-02 + D-25-10).
+- **apiclient builder** (`pkg/apiclient/client.go` or constructor): optional per-call http timeout override for restore endpoint (D-25-10).
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- **User insistence on clear naming** (mid-discussion): "sync_gate is not very clear", "verify_concurrency is pretty confusing". Drove D-25-01 (rename everywhere) and D-25-02 (delete the knob entirely rather than rename it). Phase 25 takes the cleanup cost in exchange for one coherent vocabulary across docs/CLI/code.
+- **Operator-as-primary-user lens** across CLI UX decisions: block-by-default create (D-25-03), interactive prompt + `--yes` for destructive ops (D-25-04 / D-25-05), pre-flight share-disable hint over auto-disable (D-25-04). Pattern: explicit operator intent at every step; scripts opt out via flags.
+- **`--force` over `--allow-non-durable`** (D-25-06): user picked the shorter, conventional verb over the more-precise struct-mirror name. `--force` is operator-vocabulary; SNAPSHOTS.md explains what it actually does.
+- **No streaming progress for restore** (D-25-08): user opted for sync 200 + simple body over chunked-JSON progress events. Keep the wire simple; CLI's interactive UX is already adequate since handler blocks.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Restore-progress streaming** (chunked-JSON-lines body or SSE) — kept simple per D-25-08; revisit if operators report long-restore UX pain.
+- **`--verify` flag on `show`** (re-run `VerifyRemoteDurability` on demand) — useful diagnostic, but adds a new REST endpoint; defer to a follow-up if operators ask.
+- **Pagination on `list`** (`--limit`, cursors) — snap counts per share stay in low-hundreds (Phase 23 D-23-04); revisit if a power-user share blows past that.
+- **`--sort` flag on `list`** — newest-first is enough for now.
+- **Refuse-to-delete `pre-restore-*` safety snaps** — rejected in favor of uniform UX; can re-add as `--no-safety-guard` if operators delete by mistake.
+- **Operator-role read access** (split admin-only into admin-write + operator-read for list/show) — admin-only inherited per D-25-12; revisit if dashboard/observability tooling needs read-only role.
+- **Auto-cleanup of safety snaps on restore success** — Phase 24 D-24-04 keeps operator-driven; could add `RestoreSnapshotOpts.AutoCleanupSafetySnap bool` later (non-breaking).
+- **`apiclient.Snapshot.ManifestCount` / `DumpBytes` on every list row** — currently planner-discretion (on-list vs on-show-only per D-25-11); operator feedback decides default behavior.
+- **OpenAPI spec for snapshot endpoints** — SNAPSHOTS.md ships a brief REST reference table; full OpenAPI is a future cross-cutting initiative.
+- **Prometheus / OTel metrics** — deferred per Phase 23 D-23-16 stance; structured `slog` only.
+- **Async restore (202 + poll)** — Phase 24 D-24-02 explicitly rejected for v0.16.0; revisit if HTTP-timeout pain emerges.
+- **Cross-share restore** (snapshot of share A → share B) — REST-01 scope; orthogonal feature.
+- **Snapshot encryption / per-snapshot keys** — orthogonal.
+
+</deferred>
+
+---
+
+*Phase: 25-cli-rest-api-documentation-parallel-with-24*
+*Context gathered: 2026-05-28*

--- a/.planning/phases/25-cli-rest-api-documentation-parallel-with-24/25-DISCUSSION-LOG.md
+++ b/.planning/phases/25-cli-rest-api-documentation-parallel-with-24/25-DISCUSSION-LOG.md
@@ -1,0 +1,295 @@
+# Phase 25: CLI + REST API + Documentation (parallel with 24) - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-28
+**Phase:** 25-cli-rest-api-documentation-parallel-with-24
+**Areas discussed:** CLI UX (create/restore/delete/flags), REST shape (restore sync vs async, create 202+poll, error mapping, timeout knob), List/Show output, Code structure (cobra package, Runtime wrappers, DTO, tests/PR), Docs scope, Cross-cutting rename (sync_gate → verify), Auth scope, E2E test coverage
+
+---
+
+## CLI create UX
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Block by default, --no-wait | CLI calls CreateSnapshot + WaitForSnapshot; --no-wait returns snapID immediately | ✓ |
+| Return snapID immediately, --wait | Default fire-and-forget; --wait blocks | |
+| Block always, no flag | Always block; no fire-and-forget | |
+
+**User's choice:** Block by default with `--no-wait` escape.
+**Notes:** Matches operator expectation "the command finishes when the thing is done"; scripts opt out via flag.
+
+---
+
+## CLI restore UX
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Refuse on enabled + Y/N prompt + --yes | Pre-flight refuses; interactive prompt; --yes skips | ✓ |
+| Auto-disable + auto-re-enable + --yes + --no-auto-lifecycle | CLI bookends with disable/enable | |
+| Refuse on enabled + --yes only (no interactive prompt) | Script-friendly; no interactive Y/N | |
+
+**User's choice:** Refuse on enabled + Y/N + `--yes`.
+**Notes:** Preserves D-24-01 spirit (explicit operator intent at each step). Success message includes safety snap ID + cleanup hint.
+
+---
+
+## CLI delete UX
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Y/N prompt + --yes (same as restore) | Consistent UX | ✓ |
+| No prompt, --yes is no-op | Bare delete | |
+| Refuse pre-restore-* by default + --yes override | Guardrail on recovery primitive | |
+
+**User's choice:** Y/N prompt + `--yes`.
+**Notes:** Uniform UX over special-casing safety snaps.
+
+---
+
+## CLI flag naming
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| --no-sync-gate / --retry-of=<id> / --allow-non-durable | Direct struct-field mirror | |
+| --no-verify / --retry=<id> / --force | Shorter, colloquial | ✓ |
+| --no-sync-gate / --retry-of=<id> / --force-non-durable | Mixed | |
+
+**User's choice:** `--no-verify` / `--retry=<id>` / `--force`.
+**Notes:** Operator vocabulary. `--no-verify` choice drove the cross-cutting rename of `sync_gate` → `verify` for vocabulary consistency.
+
+---
+
+## REST restore: sync vs async
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sync 200 + long handler timeout (D-24-02 verbatim) | Block on Runtime.RestoreSnapshot; configurable timeout | ✓ |
+| 202 + poll like create | Async; requires new restore-tracking DB table — violates D-24-02 | |
+| Sync 200 + streaming progress (chunked JSON lines) | Stream progress events | |
+
+**User's choice:** Sync 200 + handler timeout.
+**Notes:** Honors Phase 24 D-24-02. Caller (CLI/apiclient) sets matching http timeout.
+
+---
+
+## REST create response shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 202 + Location + body {snapshot_id, share} | Typed body + Location header | ✓ |
+| 202 + Location only (empty body) | Pure HTTP-spec form | |
+| 201 + full snapshot record | Asymmetric with async orchestration | |
+
+**User's choice:** 202 + Location + body.
+**Notes:** Matches Phase 23 D-23-13 + best for typed client decoding.
+
+---
+
+## Error mapping for 12 typed sentinels
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Per-handler inline switch | Each handler has own errors.Is chain | |
+| Single table in handlers/snapshot.go (mapSnapshotError) | One func, single source of truth | ✓ |
+| Promote to problem.go | Wider blast radius | |
+
+**User's choice:** Single `mapSnapshotError(w, err) bool` helper in handler file.
+**Notes:** One edit when a new sentinel lands in v0.17.
+
+---
+
+## REST timeout knob
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 30m default, server-side YAML config | snapshot.restore_http_timeout: 30m | ✓ |
+| No new knob — inherit ctx | apiclient/CLI set deadline | |
+| Two knobs: restore + create | Symmetric but overkill (create is fast) | |
+
+**User's choice:** YAML knob default 30m.
+**Notes:** Operator visibility into long-running restore boundaries.
+
+---
+
+## Cross-cutting rename: sync_gate → verify (user-raised mid-discussion)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| verify / NoVerify / verify_concurrency | Align with --no-verify CLI flag | ✓ |
+| durability_check / SkipDurabilityCheck / durability_check_concurrency | Maximally explicit but verbose | |
+| Keep sync_gate (do not rename) | Single divergence between internal + operator names | |
+
+**User's choice:** Rename to "verify" across Go code + YAML + docs.
+**Notes:** User: "sync_gate is not very clear". Pre-1.0 + "no compat shims" allows hard rename without aliasing.
+
+---
+
+## Verify concurrency knob (user-raised mid-discussion)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| verify_parallel_requests: 16 | Self-documenting rename | |
+| verify_workers: 16 | Short worker-pool model | |
+| Drop the knob — hardcode 16 | YAGNI; nobody tunes it | ✓ |
+
+**User's choice:** Drop the YAML knob entirely; hardcode 16 in callers.
+**Notes:** User: "verify_concurrency is pretty confusing. What is the purpose of the flag?". Aligns with `feedback_less_is_more`. Re-addable later as non-breaking change.
+
+---
+
+## List columns
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| ID(short) NAME STATE DURABLE CREATED SIZE | Most-useful at-a-glance | ✓ |
+| ID NAME STATE DURABLE CREATED (no size) | Lighter row | |
+| Full ID NAME STATE DURABLE CREATED SIZE RETRY_OF | Includes retry chain | |
+
+**User's choice:** 6-column default with short ID + relative CREATED + manifest hash count as SIZE.
+
+---
+
+## List sort + filters
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Newest-first default, --state, --name-prefix | Cover the common ops | ✓ |
+| Newest-first default, no filters | Pipe to grep/jq | |
+| --state, --name-prefix, --sort, --limit | Full surface | |
+
+**User's choice:** Newest-first + two AND-filters; no sort/limit flags.
+
+---
+
+## Show detail fields
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Full Snapshot + manifest stats + disk paths | Adds manifest count, dump bytes, paths, RetryOf, Error | ✓ |
+| DB record only (no disk lookup) | Faster, less info | |
+| Full + --verify action | Plus re-run verify; new endpoint | |
+
+**User's choice:** Full detail including disk-derived fields.
+
+---
+
+## Docs: SNAPSHOTS.md scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Full operator guide (mirror BLOCKSTORE_MIGRATION.md depth) | 400-600 lines; 13 sections | ✓ |
+| CLI-first, lean | ~150-200 lines; link to ARCHITECTURE for internals | |
+| Reference-grade (CLI + full failure matrix + internals) | Maintenance heavy | |
+
+**User's choice:** Full operator guide. Becomes canonical snapshot doc.
+
+---
+
+## Docs: ARCHITECTURE.md + CLI.md + README.md scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Minimal touches (surgical edits per doc) | Smallest correct change; heavy lifting in SNAPSHOTS.md | |
+| Full sections (architecture rewrite + dedicated CLI section + README paragraph + example) | More duplication risk but richer | ✓ |
+
+**User's choice:** Full sections in each doc.
+
+---
+
+## CLI cobra package layout
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Nested package cmd/dfsctl/commands/share/snapshot/ with one file per leaf | Mirror share/permission/ | ✓ |
+| Flat: 5 files in share/ with snapshot_* prefix | No new package | |
+| Single file snapshot.go with all 5 cmds | Compact but harder to navigate | |
+
+**User's choice:** Nested package, one file per leaf.
+
+---
+
+## Runtime API surface
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Add Runtime.{GetSnapshot,ListSnapshots,DeleteSnapshot} wrappers | Handler never reaches into r.store; symmetric with existing Runtime methods | ✓ |
+| Handler calls r.store for Get/List directly; only Delete wrapper | Asymmetric | |
+| All snapshot ops in new snapshots.Service sub-service | Phase 23 D-23-14 already rejected this | |
+
+**User's choice:** 3 Runtime wrappers; handler defines `SnapshotRuntime` interface for testability.
+
+---
+
+## REST DTO shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| apiclient.Snapshot DTO (decoupled from models.Snapshot) | Hides GORM fields; matches BlockStoreStats pattern | ✓ |
+| Expose models.Snapshot directly | One less type; risks leaking schema | |
+
+**User's choice:** Separate apiclient.Snapshot DTO.
+
+---
+
+## Test strategy + PR shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 3 layers + single PR / 4 plans / 2 waves | Handler unit + apiclient stubserver + CLI unit + e2e; 4-plan PR | ✓ |
+| Same layers, 4 separate PRs | More CI cycles | |
+| Single mega-plan, single PR | Faster to ship; harder to review | |
+
+**User's choice:** 4 plans in 2 waves, single PR.
+
+---
+
+## REST auth scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Admin-only (inherit existing /shares/{name} RequireAdmin) | Zero-config; restore is destructive enough | ✓ |
+| Admin write, admin+operator read | Two role middlewares | |
+
+**User's choice:** Admin-only via inheritance.
+
+---
+
+## E2E test coverage
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Two e2e: full HTTP↔runtime + dfsctl binary↔stubserver | Covers HTTP wiring + CLI output regressions | ✓ |
+| One e2e: HTTP↔runtime only | Skip CLI binary | |
+| No new e2e — unit tests only | Risk: handler→runtime wiring bugs caught manually | |
+
+**User's choice:** Two e2e layers under `test/e2e/snapshot/`.
+
+---
+
+## Claude's Discretion
+
+- Exact HTTP-code mapping per sentinel in `mapSnapshotError` (D-25-09 suggested table is provisional; planner finalizes against `problem.go` helpers).
+- `apiclient.Snapshot.ManifestCount` / `DumpBytes` — on every list row (one stat each) vs on-show-only (default: on-show-only, planner-overridable).
+- SIZE column unit — manifest hash count vs metadata dump bytes vs both.
+- `Runtime.DeleteSnapshot` lock-acquisition path — direct `snapshotDeleteLock` call vs `SnapshotHoldProvider.AcquireDeleteLock` (same underlying mutex).
+- Stubserver pattern reuse for apiclient tests (extend existing helper if reusable).
+- Optional P25-02a split if reviewer load on P25-02 is too high.
+- SNAPSHOTS.md exact section ordering + worked-transcript verbosity (operator-doc tone judgment).
+
+## Deferred Ideas
+
+- Restore-progress streaming (chunked JSON lines or SSE)
+- `--verify` flag on `show` (re-run VerifyRemoteDurability on demand)
+- Pagination on `list` (--limit, cursors)
+- `--sort` flag on `list`
+- Refuse-to-delete `pre-restore-*` guardrail
+- Operator-role read access (split admin-only)
+- Auto-cleanup of safety snaps on restore success
+- Manifest stats on every list row (planner-discretion default flips to on-show-only)
+- OpenAPI spec for snapshot endpoints
+- Prometheus / OTel metrics surface
+- Async restore (202+poll) — Phase 24 D-24-02 explicit rejection
+- Cross-share restore (snapshot of A → B)
+- Snapshot encryption / per-snapshot keys

--- a/pkg/blockstore/local/fs/dedup_lru.go
+++ b/pkg/blockstore/local/fs/dedup_lru.go
@@ -87,10 +87,10 @@ func newDedupLRU(maxSize int) *dedupLRU {
 	}
 }
 
-// Get reports whether (hash, payloadID) is present and promotes the
+// Hit reports whether (hash, payloadID) is present and promotes the
 // entry to MRU on hit. Returns false on miss or on a degenerate LRU
-// (nil receiver or maxSize <= 0).
-func (c *dedupLRU) Get(hash blockstore.ContentHash, payloadID string) bool {
+// (nil receiver or maxSize <= 0). Use Has for a side-effect-free probe.
+func (c *dedupLRU) Hit(hash blockstore.ContentHash, payloadID string) bool {
 	if c == nil || c.maxSize <= 0 {
 		return false
 	}
@@ -105,7 +105,7 @@ func (c *dedupLRU) Get(hash blockstore.ContentHash, payloadID string) bool {
 }
 
 // Has reports whether (hash, payloadID) is present in the LRU. Unlike
-// Get, Has does NOT promote the entry.
+// Hit, Has does NOT promote the entry.
 func (c *dedupLRU) Has(hash blockstore.ContentHash, payloadID string) bool {
 	if c == nil || c.maxSize <= 0 {
 		return false

--- a/pkg/blockstore/local/fs/dedup_lru.go
+++ b/pkg/blockstore/local/fs/dedup_lru.go
@@ -15,10 +15,31 @@ import (
 // already handled by FileBlockStore.GetByHash; this LRU's job is to
 // skip even that µs hop on hot hashes.
 //
+// Key scope (#669): compound (hash, payloadID).
+// The LRU only short-circuits AddRef for hashes a payload has written
+// itself in a prior rollup pass — cross-payload entries are NOT
+// reachable. This preserves the "idempotent rewrite of the same
+// content" fast path (the dominant case under VM workloads) while
+// guaranteeing that an LRU hit cannot reference a FileBlock row owned
+// by a DIFFERENT payload, which would let AddRef bump RefCount on the
+// wrong row. Cross-payload dedup still works via the regular CAS path
+// (StoreChunk is content-addressed and idempotent; the engine syncer
+// dedups via FileBlockStore.GetByHash + Put). The LRU short-circuit
+// is only an optimization on top of that.
+//
 // Crash semantics: RAM-only, lost on restart. The first
 // post-restart write that would have been an LRU hit falls through to
 // FileBlockStore.GetByHash + AddRef (correct, slightly slower for the
 // first hot-hash).
+//
+// Population ordering (#669): callers MUST defer Put until
+// AFTER the rollup's ObjectIDPersister callback returns nil. Populating
+// the LRU before persister writes the FileBlock row caused a concurrent
+// rollup on the same payload to hit the LRU and call AddRef before the
+// row existed — returning ErrUnknownHash and triggering a silent retry
+// storm under load. The rollup loop now collects (hash, payloadID)
+// pairs as it stores chunks and flushes them in a single post-persister
+// pass via PutMany.
 //
 // Concurrency ("Claude's discretion" — flat-mutex chosen here)
 // matches the in-package fdpool.go and chunkstore lruTouch precedent
@@ -31,67 +52,77 @@ import (
 // owning store's field.
 type dedupLRU struct {
 	mu      sync.Mutex
-	index   map[blockstore.ContentHash]*list.Element
+	index   map[dedupLRUKey]*list.Element
 	order   *list.List
 	maxSize int
 }
 
-// dedupLRUEntry is a single LRU-tracked hash → payloadID binding. Kept
-// distinct from the on-disk CAS chunk LRU entry in fs.go so the two
-// LRUs do not share a value type.
-type dedupLRUEntry struct {
+// dedupLRUKey is the compound (hash, payloadID) lookup key. Scoping
+// the LRU to payloadID is the #669 fix for "wrong-row-owner": an LRU
+// hit from a DIFFERENT payload's prior write could otherwise reach
+// AddRef, which resolves rows by hash and would bump RefCount on the
+// wrong row (legacy multi-row-per-hash data).
+type dedupLRUKey struct {
 	hash      blockstore.ContentHash
 	payloadID string
 }
 
+// dedupLRUEntry is the value stored in the LRU list. The struct survives
+// for layout symmetry with the on-disk chunk LRU; the key itself
+// already carries the (hash, payloadID) tuple.
+type dedupLRUEntry struct {
+	key dedupLRUKey
+}
+
 // newDedupLRU constructs a dedupLRU with the given slot capacity. A
-// maxSize <= 0 yields a degenerate no-op LRU (every Get returns
-// ("",false), Put is dropped). Config validation in pkg/config rejects
-// non-positive values; the no-op behavior here is a defense-in-depth
-// guard so callers can construct an LRU before validation completes.
+// maxSize <= 0 yields a degenerate no-op LRU (every Get returns false,
+// Put is dropped). Config validation in pkg/config rejects non-positive
+// values; the no-op behavior here is a defense-in-depth guard so callers
+// can construct an LRU before validation completes.
 func newDedupLRU(maxSize int) *dedupLRU {
 	return &dedupLRU{
-		index:   make(map[blockstore.ContentHash]*list.Element),
+		index:   make(map[dedupLRUKey]*list.Element),
 		order:   list.New(),
 		maxSize: maxSize,
 	}
 }
 
-// Get returns the payloadID previously bound to hash and promotes the
-// entry to MRU. Returns ("",false) on miss or on a degenerate LRU
+// Get reports whether (hash, payloadID) is present and promotes the
+// entry to MRU on hit. Returns false on miss or on a degenerate LRU
 // (nil receiver or maxSize <= 0).
-func (c *dedupLRU) Get(hash blockstore.ContentHash) (payloadID string, ok bool) {
-	if c == nil || c.maxSize <= 0 {
-		return "", false
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	el, found := c.index[hash]
-	if !found {
-		return "", false
-	}
-	c.order.MoveToFront(el)
-	return el.Value.(*dedupLRUEntry).payloadID, true
-}
-
-// Has reports whether hash is present in the LRU. Unlike Get, Has does
-// NOT promote the entry — callers using Has as a pure existence check
-// should not pay the lock-upgrade cost of a MoveToFront, and any caller
-// that wants the payloadID should call Get directly.
-func (c *dedupLRU) Has(hash blockstore.ContentHash) bool {
+func (c *dedupLRU) Get(hash blockstore.ContentHash, payloadID string) bool {
 	if c == nil || c.maxSize <= 0 {
 		return false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	_, ok := c.index[hash]
+	el, found := c.index[dedupLRUKey{hash: hash, payloadID: payloadID}]
+	if !found {
+		return false
+	}
+	c.order.MoveToFront(el)
+	return true
+}
+
+// Has reports whether (hash, payloadID) is present in the LRU. Unlike
+// Get, Has does NOT promote the entry.
+func (c *dedupLRU) Has(hash blockstore.ContentHash, payloadID string) bool {
+	if c == nil || c.maxSize <= 0 {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.index[dedupLRUKey{hash: hash, payloadID: payloadID}]
 	return ok
 }
 
-// Put binds hash → payloadID and inserts at MRU. If hash is already
-// present, the payloadID is updated and the entry is promoted (single
-// list element retained — order.Len() does not grow). When the LRU is
-// over capacity, the least-recently-used entry is evicted.
+// Put inserts (hash, payloadID) at MRU. Duplicate keys are promoted
+// without growing order.Len(). When the LRU is over capacity, the
+// least-recently-used entry is evicted.
+//
+// Callers MUST only invoke Put AFTER the rollup's ObjectIDPersister
+// callback has confirmed the FileBlock row for hash is persisted — see
+// the type-level comment for the #669 ordering rationale.
 func (c *dedupLRU) Put(hash blockstore.ContentHash, payloadID string) {
 	if c == nil || c.maxSize <= 0 {
 		return
@@ -99,9 +130,8 @@ func (c *dedupLRU) Put(hash blockstore.ContentHash, payloadID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if el, found := c.index[hash]; found {
-		entry := el.Value.(*dedupLRUEntry)
-		entry.payloadID = payloadID
+	key := dedupLRUKey{hash: hash, payloadID: payloadID}
+	if el, found := c.index[key]; found {
 		c.order.MoveToFront(el)
 		return
 	}
@@ -112,10 +142,41 @@ func (c *dedupLRU) Put(hash blockstore.ContentHash, payloadID string) {
 			break
 		}
 		victim := back.Value.(*dedupLRUEntry)
-		delete(c.index, victim.hash)
+		delete(c.index, victim.key)
 		c.order.Remove(back)
 	}
 
-	el := c.order.PushFront(&dedupLRUEntry{hash: hash, payloadID: payloadID})
-	c.index[hash] = el
+	el := c.order.PushFront(&dedupLRUEntry{key: key})
+	c.index[key] = el
+}
+
+// PutMany inserts a batch of hashes under a single payloadID at MRU.
+// Used by the rollup loop to defer LRU population until after the
+// ObjectIDPersister callback has confirmed the corresponding FileBlock
+// rows are persisted (see the type-level comment for #669). The
+// batched call avoids per-chunk lock-acquire overhead at the rollup tail.
+func (c *dedupLRU) PutMany(hashes []blockstore.ContentHash, payloadID string) {
+	if c == nil || c.maxSize <= 0 || len(hashes) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, h := range hashes {
+		key := dedupLRUKey{hash: h, payloadID: payloadID}
+		if el, found := c.index[key]; found {
+			c.order.MoveToFront(el)
+			continue
+		}
+		for c.order.Len() >= c.maxSize {
+			back := c.order.Back()
+			if back == nil {
+				break
+			}
+			victim := back.Value.(*dedupLRUEntry)
+			delete(c.index, victim.key)
+			c.order.Remove(back)
+		}
+		el := c.order.PushFront(&dedupLRUEntry{key: key})
+		c.index[key] = el
+	}
 }

--- a/pkg/blockstore/local/fs/dedup_lru_test.go
+++ b/pkg/blockstore/local/fs/dedup_lru_test.go
@@ -17,20 +17,35 @@ func makeHash(b byte) blockstore.ContentHash {
 	return h
 }
 
-func TestDedupLRU_GetMiss_ReturnsNotOk(t *testing.T) {
+func TestDedupLRU_GetMiss_ReturnsFalse(t *testing.T) {
 	lru := newDedupLRU(8)
-	if pid, ok := lru.Get(makeHash(1)); ok || pid != "" {
-		t.Fatalf("empty LRU Get: got (%q,%v), want (\"\",false)", pid, ok)
+	if lru.Get(makeHash(1), "p") {
+		t.Fatalf("empty LRU Get: got true, want false")
 	}
 }
 
-func TestDedupLRU_PutThenGet_ReturnsValue(t *testing.T) {
+func TestDedupLRU_PutThenGet_HitsForSamePayload(t *testing.T) {
 	lru := newDedupLRU(8)
 	h := makeHash(0x42)
 	lru.Put(h, "payload-1")
-	pid, ok := lru.Get(h)
-	if !ok || pid != "payload-1" {
-		t.Fatalf("after Put: got (%q,%v), want (\"payload-1\",true)", pid, ok)
+	if !lru.Get(h, "payload-1") {
+		t.Fatalf("after Put: Get(h, payload-1) = false, want true")
+	}
+}
+
+// #669: compound (hash, payloadID) keying means a cross-payload
+// lookup MUST miss. The audit prescription chose this scoping over
+// "validate ownership in AddRef" so a stale LRU entry cannot reach
+// AddRef and bump RefCount on a row owned by a different payload.
+func TestDedupLRU_CrossPayload_Misses(t *testing.T) {
+	lru := newDedupLRU(8)
+	h := makeHash(0x42)
+	lru.Put(h, "payload-1")
+	if lru.Get(h, "payload-2") {
+		t.Fatalf("cross-payload Get: got true, want false (compound key scoping)")
+	}
+	if lru.Has(h, "payload-2") {
+		t.Fatalf("cross-payload Has: got true, want false")
 	}
 }
 
@@ -38,11 +53,11 @@ func TestDedupLRU_Has_ReturnsTrueAfterPut(t *testing.T) {
 	lru := newDedupLRU(8)
 	h := makeHash(0x7)
 	lru.Put(h, "p")
-	if !lru.Has(h) {
-		t.Fatalf("Has(known) = false, want true")
+	if !lru.Has(h, "p") {
+		t.Fatalf("Has(known, p) = false, want true")
 	}
-	if lru.Has(makeHash(0xFF)) {
-		t.Fatalf("Has(unknown) = true, want false")
+	if lru.Has(makeHash(0xFF), "p") {
+		t.Fatalf("Has(unknown, p) = true, want false")
 	}
 }
 
@@ -52,16 +67,16 @@ func TestDedupLRU_EvictsLRUWhenOverCapacity(t *testing.T) {
 	h2 := makeHash(2)
 	h3 := makeHash(3)
 	h4 := makeHash(4)
-	lru.Put(h1, "p1")
-	lru.Put(h2, "p2")
-	lru.Put(h3, "p3")
-	lru.Put(h4, "p4") // forces eviction of h1 (LRU)
+	lru.Put(h1, "p")
+	lru.Put(h2, "p")
+	lru.Put(h3, "p")
+	lru.Put(h4, "p") // forces eviction of h1 (LRU)
 
-	if _, ok := lru.Get(h1); ok {
+	if lru.Get(h1, "p") {
 		t.Fatalf("h1 should have been evicted")
 	}
 	for i, h := range []blockstore.ContentHash{h2, h3, h4} {
-		if _, ok := lru.Get(h); !ok {
+		if !lru.Get(h, "p") {
 			t.Fatalf("h%d should still be present", i+2)
 		}
 	}
@@ -73,40 +88,57 @@ func TestDedupLRU_PromoteOnGet(t *testing.T) {
 	h2 := makeHash(2)
 	h3 := makeHash(3)
 	h4 := makeHash(4)
-	lru.Put(h1, "p1")
-	lru.Put(h2, "p2")
-	lru.Put(h3, "p3")
+	lru.Put(h1, "p")
+	lru.Put(h2, "p")
+	lru.Put(h3, "p")
 	// Touch h1 — promotes it to MRU.
-	if _, ok := lru.Get(h1); !ok {
+	if !lru.Get(h1, "p") {
 		t.Fatalf("h1 missing before promote")
 	}
-	lru.Put(h4, "p4") // evicts h2 (now the LRU)
+	lru.Put(h4, "p") // evicts h2 (now the LRU)
 
-	if _, ok := lru.Get(h1); !ok {
+	if !lru.Get(h1, "p") {
 		t.Fatalf("h1 should still be present after promote")
 	}
-	if _, ok := lru.Get(h2); ok {
+	if lru.Get(h2, "p") {
 		t.Fatalf("h2 should have been evicted after promoting h1")
 	}
 }
 
-func TestDedupLRU_DuplicatePut_PromotesAndUpdates(t *testing.T) {
+func TestDedupLRU_DuplicatePut_PromotesAndDeduplicates(t *testing.T) {
 	lru := newDedupLRU(8)
 	h := makeHash(0x1)
 	lru.Put(h, "p1")
-	lru.Put(h, "p2")
-	pid, ok := lru.Get(h)
-	if !ok || pid != "p2" {
-		t.Fatalf("duplicate Put should update payloadID: got (%q,%v), want (\"p2\",true)", pid, ok)
+	lru.Put(h, "p1")
+	if !lru.Get(h, "p1") {
+		t.Fatalf("duplicate Put should still hit: Get(h, p1) = false")
 	}
 	if got := lru.order.Len(); got != 1 {
 		t.Fatalf("duplicate Put should keep order.Len()==1, got %d", got)
 	}
 }
 
+// Distinct payloadIDs for the same hash occupy independent slots
+// (compound key scoping); this differs from the pre-#669 hash-only
+// scheme where a later Put overwrote the prior payloadID binding.
+func TestDedupLRU_SameHash_DistinctPayloads_IndependentSlots(t *testing.T) {
+	lru := newDedupLRU(8)
+	h := makeHash(0x1)
+	lru.Put(h, "p1")
+	lru.Put(h, "p2")
+	if !lru.Get(h, "p1") {
+		t.Fatalf("Get(h, p1) = false after distinct-payload Puts")
+	}
+	if !lru.Get(h, "p2") {
+		t.Fatalf("Get(h, p2) = false after distinct-payload Puts")
+	}
+	if got := lru.order.Len(); got != 2 {
+		t.Fatalf("distinct payload Puts should yield order.Len()==2, got %d", got)
+	}
+}
+
 func TestDedupLRU_ConcurrentAccess_NoRace(t *testing.T) {
 	lru := newDedupLRU(64)
-	// Shared key set: ensures concurrent writers contend.
 	keys := make([]blockstore.ContentHash, 32)
 	for i := range keys {
 		keys[i] = makeHash(byte(i))
@@ -129,8 +161,8 @@ func TestDedupLRU_ConcurrentAccess_NoRace(t *testing.T) {
 				if i%2 == 0 {
 					lru.Put(k, "p")
 				} else {
-					_, _ = lru.Get(k)
-					_ = lru.Has(k)
+					_ = lru.Get(k, "p")
+					_ = lru.Has(k, "p")
 				}
 				i++
 			}
@@ -143,10 +175,28 @@ func TestDedupLRU_ZeroSize_DegradesToNoop(t *testing.T) {
 	lru := newDedupLRU(0)
 	// Operations must be safe and never panic.
 	lru.Put(makeHash(1), "p")
-	if pid, ok := lru.Get(makeHash(1)); ok || pid != "" {
-		t.Fatalf("zero-size LRU Get should always return (\"\",false), got (%q,%v)", pid, ok)
+	if lru.Get(makeHash(1), "p") {
+		t.Fatalf("zero-size LRU Get should always return false")
 	}
-	if lru.Has(makeHash(1)) {
+	if lru.Has(makeHash(1), "p") {
 		t.Fatalf("zero-size LRU Has should always return false")
+	}
+	lru.PutMany([]blockstore.ContentHash{makeHash(2)}, "p")
+	if lru.Has(makeHash(2), "p") {
+		t.Fatalf("zero-size LRU PutMany should be a no-op")
+	}
+}
+
+func TestDedupLRU_PutMany_BatchPopulates(t *testing.T) {
+	lru := newDedupLRU(8)
+	hashes := []blockstore.ContentHash{makeHash(1), makeHash(2), makeHash(3)}
+	lru.PutMany(hashes, "payload-batch")
+	for i, h := range hashes {
+		if !lru.Has(h, "payload-batch") {
+			t.Fatalf("hash %d not populated by PutMany", i)
+		}
+		if lru.Has(h, "other-payload") {
+			t.Fatalf("PutMany leaked into cross-payload lookup at hash %d", i)
+		}
 	}
 }

--- a/pkg/blockstore/local/fs/dedup_lru_test.go
+++ b/pkg/blockstore/local/fs/dedup_lru_test.go
@@ -19,7 +19,7 @@ func makeHash(b byte) blockstore.ContentHash {
 
 func TestDedupLRU_GetMiss_ReturnsFalse(t *testing.T) {
 	lru := newDedupLRU(8)
-	if lru.Get(makeHash(1), "p") {
+	if lru.Hit(makeHash(1), "p") {
 		t.Fatalf("empty LRU Get: got true, want false")
 	}
 }
@@ -28,7 +28,7 @@ func TestDedupLRU_PutThenGet_HitsForSamePayload(t *testing.T) {
 	lru := newDedupLRU(8)
 	h := makeHash(0x42)
 	lru.Put(h, "payload-1")
-	if !lru.Get(h, "payload-1") {
+	if !lru.Hit(h, "payload-1") {
 		t.Fatalf("after Put: Get(h, payload-1) = false, want true")
 	}
 }
@@ -41,7 +41,7 @@ func TestDedupLRU_CrossPayload_Misses(t *testing.T) {
 	lru := newDedupLRU(8)
 	h := makeHash(0x42)
 	lru.Put(h, "payload-1")
-	if lru.Get(h, "payload-2") {
+	if lru.Hit(h, "payload-2") {
 		t.Fatalf("cross-payload Get: got true, want false (compound key scoping)")
 	}
 	if lru.Has(h, "payload-2") {
@@ -72,11 +72,11 @@ func TestDedupLRU_EvictsLRUWhenOverCapacity(t *testing.T) {
 	lru.Put(h3, "p")
 	lru.Put(h4, "p") // forces eviction of h1 (LRU)
 
-	if lru.Get(h1, "p") {
+	if lru.Hit(h1, "p") {
 		t.Fatalf("h1 should have been evicted")
 	}
 	for i, h := range []blockstore.ContentHash{h2, h3, h4} {
-		if !lru.Get(h, "p") {
+		if !lru.Hit(h, "p") {
 			t.Fatalf("h%d should still be present", i+2)
 		}
 	}
@@ -92,15 +92,15 @@ func TestDedupLRU_PromoteOnGet(t *testing.T) {
 	lru.Put(h2, "p")
 	lru.Put(h3, "p")
 	// Touch h1 — promotes it to MRU.
-	if !lru.Get(h1, "p") {
+	if !lru.Hit(h1, "p") {
 		t.Fatalf("h1 missing before promote")
 	}
 	lru.Put(h4, "p") // evicts h2 (now the LRU)
 
-	if !lru.Get(h1, "p") {
+	if !lru.Hit(h1, "p") {
 		t.Fatalf("h1 should still be present after promote")
 	}
-	if lru.Get(h2, "p") {
+	if lru.Hit(h2, "p") {
 		t.Fatalf("h2 should have been evicted after promoting h1")
 	}
 }
@@ -110,7 +110,7 @@ func TestDedupLRU_DuplicatePut_PromotesAndDeduplicates(t *testing.T) {
 	h := makeHash(0x1)
 	lru.Put(h, "p1")
 	lru.Put(h, "p1")
-	if !lru.Get(h, "p1") {
+	if !lru.Hit(h, "p1") {
 		t.Fatalf("duplicate Put should still hit: Get(h, p1) = false")
 	}
 	if got := lru.order.Len(); got != 1 {
@@ -126,10 +126,10 @@ func TestDedupLRU_SameHash_DistinctPayloads_IndependentSlots(t *testing.T) {
 	h := makeHash(0x1)
 	lru.Put(h, "p1")
 	lru.Put(h, "p2")
-	if !lru.Get(h, "p1") {
+	if !lru.Hit(h, "p1") {
 		t.Fatalf("Get(h, p1) = false after distinct-payload Puts")
 	}
-	if !lru.Get(h, "p2") {
+	if !lru.Hit(h, "p2") {
 		t.Fatalf("Get(h, p2) = false after distinct-payload Puts")
 	}
 	if got := lru.order.Len(); got != 2 {
@@ -161,7 +161,7 @@ func TestDedupLRU_ConcurrentAccess_NoRace(t *testing.T) {
 				if i%2 == 0 {
 					lru.Put(k, "p")
 				} else {
-					_ = lru.Get(k, "p")
+					_ = lru.Hit(k, "p")
 					_ = lru.Has(k, "p")
 				}
 				i++
@@ -175,7 +175,7 @@ func TestDedupLRU_ZeroSize_DegradesToNoop(t *testing.T) {
 	lru := newDedupLRU(0)
 	// Operations must be safe and never panic.
 	lru.Put(makeHash(1), "p")
-	if lru.Get(makeHash(1), "p") {
+	if lru.Hit(makeHash(1), "p") {
 		t.Fatalf("zero-size LRU Get should always return false")
 	}
 	if lru.Has(makeHash(1), "p") {

--- a/pkg/blockstore/local/fs/fs_test.go
+++ b/pkg/blockstore/local/fs/fs_test.go
@@ -417,8 +417,8 @@ func TestFSStore_DedupLRU_FieldExists(t *testing.T) {
 	if bc.dedupLRU == nil {
 		t.Fatal("bc.dedupLRU must be non-nil after construction")
 	}
-	// Sanity: the LRU is functional. Probe an unset hash.
-	if _, ok := bc.dedupLRU.Get(blockstore.ContentHash{}); ok {
+	// Sanity: the LRU is functional. Probe an unset (hash, payloadID).
+	if bc.dedupLRU.Get(blockstore.ContentHash{}, "any") {
 		t.Fatal("freshly-constructed dedupLRU must miss on Get(zero hash)")
 	}
 }

--- a/pkg/blockstore/local/fs/fs_test.go
+++ b/pkg/blockstore/local/fs/fs_test.go
@@ -418,8 +418,8 @@ func TestFSStore_DedupLRU_FieldExists(t *testing.T) {
 		t.Fatal("bc.dedupLRU must be non-nil after construction")
 	}
 	// Sanity: the LRU is functional. Probe an unset (hash, payloadID).
-	if bc.dedupLRU.Get(blockstore.ContentHash{}, "any") {
-		t.Fatal("freshly-constructed dedupLRU must miss on Get(zero hash)")
+	if bc.dedupLRU.Hit(blockstore.ContentHash{}, "any") {
+		t.Fatal("freshly-constructed dedupLRU must miss on Hit(zero hash)")
 	}
 }
 

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -363,15 +363,15 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// Offset is automatic because pos advances monotonically — that
 	// matches the canonical FileAttr.Blocks invariant the downstream
 	// ObjectID compute relies on.
+	// #669: the LRU is populated AFTER the ObjectIDPersister callback
+	// below confirms the FileBlock rows are durable. Populating before
+	// persister success let a concurrent rollup on the same payload
+	// observe the hash via the LRU and call AddRef before the row
+	// existed → ErrUnknownHash storm under load (and a silent retry
+	// loop). The hashes pushed into the LRU are derived from `blocks`
+	// at the call site below; both the LRU-hit and StoreChunk paths
+	// append to `blocks`, so no separate buffer is needed.
 	var blocks []blockstore.BlockRef
-	// #669: collect hashes that StoreChunk wrote this pass, plus
-	// hashes the LRU hit path successfully bumped. Both are pushed into
-	// the LRU AFTER the ObjectIDPersister callback below confirms the
-	// FileBlock rows are durable. Populating the LRU before persister
-	// success let a concurrent rollup on the same payload observe the
-	// hash via the LRU and call AddRef before the row existed →
-	// ErrUnknownHash storm under load (and a silent retry loop).
-	var pendingLRUPuts []blockstore.ContentHash
 	for pos < uint64(len(stream)) {
 		b, _ := ck.Next(stream[pos:], true)
 		if b <= 0 {
@@ -400,7 +400,7 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		// leaves BlockState unchanged; this hit path neither creates a
 		// row nor transitions one.
 		skipStoreChunk := false
-		if bc.dedupLRU != nil && bc.dedupLRU.Get(h, payloadID) {
+		if bc.dedupLRU != nil && bc.dedupLRU.Hit(h, payloadID) {
 			addRefErr := bc.blockStore.AddRef(ctx, h, payloadID, blockRef)
 			switch {
 			case addRefErr == nil:
@@ -424,11 +424,6 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 			}
 		}
 
-		// Queue the hash for LRU population after persister success.
-		// Either path is valid: a successful AddRef proves the row
-		// already exists for this (hash, payloadID); StoreChunk plus the
-		// persister write below is what makes a fresh row durable.
-		pendingLRUPuts = append(pendingLRUPuts, h)
 		blocks = append(blocks, blockRef)
 		pos += uint64(b)
 	}
@@ -496,8 +491,12 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// payload that observes a hash here is guaranteed to find a
 	// committed row when it calls AddRef. PutMany is keyed by
 	// (hash, payloadID) so cross-payload short-circuit cannot occur.
-	if bc.dedupLRU != nil && len(pendingLRUPuts) > 0 {
-		bc.dedupLRU.PutMany(pendingLRUPuts, payloadID)
+	if bc.dedupLRU != nil && len(blocks) > 0 {
+		hashes := make([]blockstore.ContentHash, len(blocks))
+		for i, b := range blocks {
+			hashes[i] = b.Hash
+		}
+		bc.dedupLRU.PutMany(hashes, payloadID)
 	}
 
 	// SetRollupOffset is atomic-monotone at the RollupStore layer: on

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -364,6 +364,14 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// matches the canonical FileAttr.Blocks invariant the downstream
 	// ObjectID compute relies on.
 	var blocks []blockstore.BlockRef
+	// #669: collect hashes that StoreChunk wrote this pass, plus
+	// hashes the LRU hit path successfully bumped. Both are pushed into
+	// the LRU AFTER the ObjectIDPersister callback below confirms the
+	// FileBlock rows are durable. Populating the LRU before persister
+	// success let a concurrent rollup on the same payload observe the
+	// hash via the LRU and call AddRef before the row existed →
+	// ErrUnknownHash storm under load (and a silent retry loop).
+	var pendingLRUPuts []blockstore.ContentHash
 	for pos < uint64(len(stream)) {
 		b, _ := ck.Next(stream[pos:], true)
 		if b <= 0 {
@@ -380,33 +388,33 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		}
 
 		// Consult the per-FSStore dedup LRU between FastCDC.Next() and
-		// StoreChunk. On hit, FileBlockStore.AddRef atomically bumps
-		// RefCount on the existing row and we skip the local CAS write
-		// entirely. The BlockRef append below still happens — manifest
-		// invariant: ComputeObjectID later in this function sees the
-		// same BlockRef list with or without the LRU. State
-		// preservation: AddRef leaves BlockState unchanged; this hit
-		// path neither creates a row nor transitions one.
+		// StoreChunk. The LRU is keyed by (hash, payloadID): on hit we
+		// know THIS payload's prior rollup pass stored hash h and the
+		// FileBlock row is committed, so AddRef bumps RefCount on the
+		// correct row. Cross-payload LRU short-circuit is intentionally
+		// not supported (#669 — the "wrong-row-owner" subcase);
+		// cross-payload dedup still happens via the regular CAS path.
+		// BlockRef append below still happens — manifest invariant:
+		// ComputeObjectID later in this function sees the same BlockRef
+		// list with or without the LRU. State preservation: AddRef
+		// leaves BlockState unchanged; this hit path neither creates a
+		// row nor transitions one.
 		skipStoreChunk := false
-		if bc.dedupLRU != nil {
-			if _, ok := bc.dedupLRU.Get(h); ok {
-				addRefErr := bc.blockStore.AddRef(ctx, h, payloadID, blockRef)
-				switch {
-				case addRefErr == nil:
-					skipStoreChunk = true
-					slog.Debug("rollup: LRU dedup hit",
-						"hash", h, "payloadID", payloadID, "size", b)
-				case errors.Is(addRefErr, metadata.ErrUnknownHash):
-					// TOCTOU: hash was in LRU but the row got swept by a
-					// concurrent engine.Delete cascade (or never existed
-					// — a post-restart LRU re-seed without a backing
-					// metadata row would also land here). Fall through to
-					// StoreChunk + LRU repopulate below.
-					slog.Debug("rollup: LRU stale (ErrUnknownHash); falling back to StoreChunk",
-						"hash", h, "payloadID", payloadID)
-				default:
-					return fmt.Errorf("rollup: AddRef: %w", addRefErr)
-				}
+		if bc.dedupLRU != nil && bc.dedupLRU.Get(h, payloadID) {
+			addRefErr := bc.blockStore.AddRef(ctx, h, payloadID, blockRef)
+			switch {
+			case addRefErr == nil:
+				skipStoreChunk = true
+				slog.Debug("rollup: LRU dedup hit",
+					"hash", h, "payloadID", payloadID, "size", b)
+			case errors.Is(addRefErr, metadata.ErrUnknownHash):
+				// TOCTOU: hash was in LRU but the row got swept by a
+				// concurrent engine.Delete cascade. Fall through to
+				// StoreChunk + LRU re-populate below.
+				slog.Debug("rollup: LRU stale (ErrUnknownHash); falling back to StoreChunk",
+					"hash", h, "payloadID", payloadID)
+			default:
+				return fmt.Errorf("rollup: AddRef: %w", addRefErr)
 			}
 		}
 
@@ -414,13 +422,13 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 			if err := bc.StoreChunk(ctx, h, chunkBytes); err != nil {
 				return fmt.Errorf("rollup: StoreChunk: %w", err)
 			}
-			// Opt 1: first-write seeds the LRU for subsequent
-			// idempotent rewrites of the same content.
-			if bc.dedupLRU != nil {
-				bc.dedupLRU.Put(h, payloadID)
-			}
 		}
 
+		// Queue the hash for LRU population after persister success.
+		// Either path is valid: a successful AddRef proves the row
+		// already exists for this (hash, payloadID); StoreChunk plus the
+		// persister write below is what makes a fresh row durable.
+		pendingLRUPuts = append(pendingLRUPuts, h)
 		blocks = append(blocks, blockRef)
 		pos += uint64(b)
 	}
@@ -481,6 +489,15 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		if err := persister(ctx, payloadID, blocks, objectID); err != nil {
 			return fmt.Errorf("rollup: ObjectIDPersister: %w", err)
 		}
+	}
+
+	// #669: populate the dedup LRU only AFTER persister confirms
+	// the FileBlock rows are durable. A concurrent rollup on the same
+	// payload that observes a hash here is guaranteed to find a
+	// committed row when it calls AddRef. PutMany is keyed by
+	// (hash, payloadID) so cross-payload short-circuit cannot occur.
+	if bc.dedupLRU != nil && len(pendingLRUPuts) > 0 {
+		bc.dedupLRU.PutMany(pendingLRUPuts, payloadID)
 	}
 
 	// SetRollupOffset is atomic-monotone at the RollupStore layer: on

--- a/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -167,15 +168,28 @@ func TestRollup_DedupLRU_ConcurrentRollups_NoErrUnknownHash(t *testing.T) {
 
 	const N = 8
 	var wg sync.WaitGroup
+	errCh := make(chan error, N)
 	for i := 0; i < N; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			pid := "concurrent-" + string(rune('a'+i))
-			runRollupOnce(t, bc, pid, payload)
+			// t.FailNow (via t.Fatal*) is undefined when called from
+			// a non-test goroutine — fan errors back via channel so
+			// the test goroutine reports them.
+			if err := runRollupOnceErr(bc, pid, payload); err != nil {
+				errCh <- fmt.Errorf("%s: %w", pid, err)
+			}
 		}(i)
 	}
 	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent rollup: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
 
 	if got := unknownHashSeen.Load(); got != 0 {
 		t.Fatalf("#669 regression: AddRef returned ErrUnknownHash %d times under concurrent same-content rollups across distinct payloads — the #669 storm has not been closed", got)

--- a/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
@@ -1,0 +1,201 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+)
+
+// #669 regression tests for dedup-LRU populate ordering and
+// (hash, payloadID) scoping. Two prongs:
+//
+//	Prong A — populate AFTER persister. The pre-fix code Put the hash
+//	into the LRU between StoreChunk and the ObjectIDPersister callback.
+//	A concurrent rollup on a different payload that hashed to the same
+//	content (or the same payload reentering rollup during persister)
+//	saw the LRU hit, called FileBlockStore.AddRef, and got
+//	ErrUnknownHash because the FileBlock row was not yet written.
+//
+//	Prong B — (hash, payloadID) scoping. Cross-payload LRU short-
+//	circuit is no longer reachable; the only AddRef triggered by the
+//	LRU path is for a (hash, payloadID) pair THIS payload's prior
+//	rollup pass produced, which guarantees the row's owner matches
+//	(no wrong-row-owner refcount bump).
+
+// TestRollup_DedupLRU_NotPopulatedBeforePersister asserts the Prong A
+// invariant directly: a persister whose callback observes the LRU
+// state must find that the rollup pass's hash is NOT yet present.
+// Populating the LRU before persister returns is exactly the #669
+// crash window that this fix closes.
+func TestRollup_DedupLRU_NotPopulatedBeforePersister(t *testing.T) {
+	bc, _, _ := newFSStoreForRollupLRUTest(t)
+
+	const pid = "pre-persister"
+	payload := bytes.Repeat([]byte{0x10}, 256*1024)
+	h := hashOfSingleChunk(payload)
+
+	var observedDuringPersister atomic.Bool
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		// Crucial: the LRU MUST be empty for h at this point. If the
+		// pre-fix ordering returns, this flips true.
+		if bc.dedupLRU.Has(h, pid) {
+			observedDuringPersister.Store(true)
+		}
+		return nil
+	})
+
+	runRollupOnce(t, bc, pid, payload)
+
+	if observedDuringPersister.Load() {
+		t.Fatal("#669 regression: dedupLRU populated BEFORE persister returned — concurrent rollup would observe a hash whose FileBlock row is not yet written and AddRef would return ErrUnknownHash")
+	}
+	// Sanity: after the full rollup, the LRU MUST hold the hash so
+	// subsequent idempotent rewrites can hit the AddRef fast path.
+	if !bc.dedupLRU.Has(h, pid) {
+		t.Fatal("post-rollup: LRU does not contain h — PutMany after persister did not fire")
+	}
+}
+
+// TestRollup_DedupLRU_PersisterFailure_StaysEmpty asserts that when the
+// ObjectIDPersister callback FAILS, the LRU is NOT populated for the
+// in-flight hashes. A pre-fix Put-before-persister code path would
+// leave the LRU populated for a hash whose FileBlock row never
+// landed; a subsequent rollup would hit the LRU, call AddRef, and
+// get ErrUnknownHash — the exact #669 storm.
+func TestRollup_DedupLRU_PersisterFailure_StaysEmpty(t *testing.T) {
+	bc, _, _ := newFSStoreForRollupLRUTest(t)
+
+	const pid = "persister-fail"
+	payload := bytes.Repeat([]byte{0x20}, 256*1024)
+	h := hashOfSingleChunk(payload)
+
+	simulated := errors.New("simulated persister failure")
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		return simulated
+	})
+
+	ctx := context.Background()
+	if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	// Drive stabilization, then call rollupFile directly so we can
+	// observe the propagated persister error.
+	waitForStable(t, bc, pid)
+	err := bc.rollupFile(ctx, pid)
+	if !errors.Is(err, simulated) {
+		t.Fatalf("rollupFile error: got %v, want errors.Is(simulated)", err)
+	}
+
+	if bc.dedupLRU.Has(h, pid) {
+		t.Fatal("#669 regression: dedupLRU populated for a hash whose persister callback failed — a future rollup pass would observe the LRU hit and call AddRef on a non-existent row (ErrUnknownHash storm)")
+	}
+}
+
+// TestRollup_DedupLRU_CrossPayload_NoShortCircuit asserts the Prong B
+// invariant: after payload P1 rolls up content with hash H, a second
+// payload P2 writing the same content does NOT short-circuit via
+// the LRU. The "wrong-row-owner" subcase is therefore unreachable
+// — AddRef is only called for a (hash, payloadID) pair that THIS
+// payload itself populated, so the row found by hash belongs to
+// THIS payload (modulo legacy multi-row-per-hash data; even then
+// the bump still targets a row this payload created, not a row
+// owned by a different payload).
+func TestRollup_DedupLRU_CrossPayload_NoShortCircuit(t *testing.T) {
+	bc, wrapped, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0x30}, 256*1024)
+	h := hashOfSingleChunk(payload)
+
+	// First payload: cold LRU → StoreChunk + PutMany after persister.
+	runRollupOnce(t, bc, "p1", payload)
+	if !bc.dedupLRU.Has(h, "p1") {
+		t.Fatal("precondition: p1's rollup did not populate LRU for (h, p1)")
+	}
+	if bc.dedupLRU.Has(h, "p2") {
+		t.Fatal("LRU compound-key scoping violated: p1's Put leaked to p2's lookup")
+	}
+
+	addRefBefore := wrapped.addRefCalls.Load()
+
+	// Second payload, same content, DIFFERENT payloadID. With compound
+	// (hash, payloadID) keying the LRU misses → StoreChunk path runs
+	// — AddRef MUST NOT be invoked for cross-payload short-circuit.
+	runRollupOnce(t, bc, "p2", payload)
+
+	if got := wrapped.addRefCalls.Load() - addRefBefore; got != 0 {
+		t.Fatalf("#669 regression: cross-payload LRU short-circuit triggered AddRef (calls delta=%d, want 0). The 'wrong-row-owner' subcase would let AddRef bump RefCount on p1's row.", got)
+	}
+	// p2's rollup must independently populate its own (h, p2) slot.
+	if !bc.dedupLRU.Has(h, "p2") {
+		t.Fatal("post-rollup: LRU missing (h, p2) — p2's own PutMany did not fire")
+	}
+}
+
+// TestRollup_DedupLRU_ConcurrentRollups_NoErrUnknownHash drives two
+// concurrent rollups on different payloads with identical content
+// and asserts no ErrUnknownHash escapes the rollup pipeline. Under
+// the pre-fix ordering, a tight enough race would let payload B
+// observe payload A's pre-persister LRU populate, call AddRef, and
+// hit ErrUnknownHash (silent retry storm under load — the #669
+// production signature).
+//
+// Compound-key scoping (Prong B) means cross-payload LRU short-
+// circuit cannot happen at all, which is the strongest possible
+// regression guard: even if Prong A regresses, B cannot wedge the
+// pipeline cross-payload.
+func TestRollup_DedupLRU_ConcurrentRollups_NoErrUnknownHash(t *testing.T) {
+	bc, wrapped, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0x40}, 256*1024)
+
+	// Force AddRef to record any ErrUnknownHash escape. If it sees
+	// one, the test fails — the production signature of #669.
+	var unknownHashSeen atomic.Int64
+	wrapped.addRefOverride = func(ctx context.Context, h blockstore.ContentHash, pid string, ref blockstore.BlockRef) error {
+		err := wrapped.inner.AddRef(ctx, h, pid, ref)
+		if errors.Is(err, blockstore.ErrUnknownHash) {
+			unknownHashSeen.Add(1)
+		}
+		return err
+	}
+
+	const N = 8
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			pid := "concurrent-" + string(rune('a'+i))
+			runRollupOnce(t, bc, pid, payload)
+		}(i)
+	}
+	wg.Wait()
+
+	if got := unknownHashSeen.Load(); got != 0 {
+		t.Fatalf("#669 regression: AddRef returned ErrUnknownHash %d times under concurrent same-content rollups across distinct payloads — the #669 storm has not been closed", got)
+	}
+}
+
+// waitForStable polls EarliestStableForTest until the dirty interval
+// for payloadID becomes available (matches the helper pattern used
+// elsewhere in this test file). Fails the test if it does not
+// stabilize within 500 ms.
+func waitForStable(t *testing.T, bc *FSStore, payloadID string) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if bc.EarliestStableForTest(payloadID) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !bc.EarliestStableForTest(payloadID) {
+		t.Fatal("dirty interval did not stabilize within 500 ms")
+	}
+}

--- a/pkg/blockstore/local/fs/rollup_idempotent_dedup_bench_test.go
+++ b/pkg/blockstore/local/fs/rollup_idempotent_dedup_bench_test.go
@@ -1,11 +1,16 @@
 // BenchmarkRandWriteCAS_IdempotentBytes measures the in-memory hash
 // dedup LRU's effectiveness on idempotent rewrites: K rollup passes
-// of identical content. On the first pass the LRU is cold;
-// StoreChunk fires once per emitted chunk, and the LRU is seeded
-// (rollup.go:371-373 — Put(h, payloadID) after successful StoreChunk).
+// of identical content under the SAME payloadID. On the first pass
+// the LRU is cold; StoreChunk fires once per emitted chunk, and the
+// LRU is seeded by PutMany after the ObjectIDPersister callback
+// confirms the FileBlock row is durable (#669 ordering).
 // On every subsequent pass the LRU hit path takes over: AddRef bumps
 // RefCount on the existing FileBlock row and StoreChunk is skipped
 // entirely.
+//
+// #669: the LRU is keyed by (hash, payloadID). This bench drives
+// repeated rewrites against ONE payload so the steady-state hot path
+// fires; cross-payload short-circuit is intentionally not supported.
 //
 // Reported metric: stores_per_chunk = StoreChunk invocations / total
 // chunks emitted. Expected at K rewrites: 1/K (only the first pass
@@ -23,7 +28,6 @@ package fs
 import (
 	"bytes"
 	"context"
-	"strconv"
 	"testing"
 	"time"
 
@@ -78,11 +82,10 @@ func runRollupOncePB(b *testing.B, bc *FSStore, payloadID string, payload []byte
 	}
 }
 
-// BenchmarkRandWriteCAS_IdempotentBytes — Opt 1 yellow-flag bench
-// . Drives b.N rollup passes of identical content across
-// distinct payload IDs (the LRU is hash-keyed; cross-payload
-// idempotency is the same hit-path as same-payload re-writes) and
-// reports the stores_per_chunk ratio.
+// BenchmarkRandWriteCAS_IdempotentBytes — Opt 1 yellow-flag bench.
+// Drives b.N rollup passes of identical content under the SAME
+// payloadID — the supported LRU hit pattern post-#669 — and reports
+// the stores_per_chunk ratio.
 //
 // Yellow-flag: this bench reports custom metrics via
 // b.ReportMetric and never gates (no b.Fatal on perf regression). The
@@ -123,7 +126,11 @@ func BenchmarkRandWriteCAS_IdempotentBytes(b *testing.B) {
 	// hot loop measures the steady-state LRU-hit ratio rather than
 	// including a one-iteration cold-start. (Cold-start behavior is
 	// exercised by TestRollup_FirstChunk_PopulatesLRU.)
-	bc.dedupLRU.Put(contentHash, "bench-seed")
+	//
+	// #669: LRU key is now (hash, payloadID). Seed the same
+	// payloadID the hot loop will reuse.
+	const benchPID = "bench-idempotent"
+	bc.dedupLRU.Put(contentHash, benchPID)
 
 	startDisk := bc.diskUsed.Load()
 	baseAddRef := wrapped.addRefCalls.Load()
@@ -132,7 +139,7 @@ func BenchmarkRandWriteCAS_IdempotentBytes(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		runRollupOncePB(b, bc, benchPayloadID(i), payload)
+		runRollupOncePB(b, bc, benchPID, payload)
 	}
 
 	b.StopTimer()
@@ -158,11 +165,4 @@ func BenchmarkRandWriteCAS_IdempotentBytes(b *testing.B) {
 	// fingerprint.
 	b.ReportMetric(float64(addRefDelta), "addref_calls_total")
 	b.ReportMetric(float64(chunksStored), "stores_total")
-}
-
-// benchPayloadID generates short distinct payload IDs. Supports any
-// b.N — uses strconv.Itoa so the bench can run with -benchtime=1000x
-// or longer.
-func benchPayloadID(i int) string {
-	return "p-" + strconv.Itoa(i)
 }

--- a/pkg/blockstore/local/fs/rollup_test.go
+++ b/pkg/blockstore/local/fs/rollup_test.go
@@ -667,36 +667,44 @@ func hashOfSingleChunk(payload []byte) blockstore.ContentHash {
 }
 
 // TestRollup_FirstChunk_PopulatesLRU: empty LRU; rollup a payload that
-// produces hash H; afterwards bc.dedupLRU.Has(H) is true (first-
-// write seeding).
+// produces hash H; afterwards bc.dedupLRU.Has(H, payloadID) is true
+// (first-write seeding, scoped to the writing payload — #669).
 func TestRollup_FirstChunk_PopulatesLRU(t *testing.T) {
 	bc, _, _ := newFSStoreForRollupLRUTest(t)
 
+	const pid = "first-pop"
 	payload := bytes.Repeat([]byte{0xAA}, 256*1024)
 	expectedHash := hashOfSingleChunk(payload)
 
-	if bc.dedupLRU.Has(expectedHash) {
+	if bc.dedupLRU.Has(expectedHash, pid) {
 		t.Fatal("precondition: dedupLRU should not contain hash before rollup")
 	}
 
-	runRollupOnce(t, bc, "first-pop", payload)
+	runRollupOnce(t, bc, pid, payload)
 
-	if !bc.dedupLRU.Has(expectedHash) {
-		t.Fatal("post-rollup: dedupLRU.Has(H) is false — first-write LRU seeding did not run")
+	if !bc.dedupLRU.Has(expectedHash, pid) {
+		t.Fatal("post-rollup: dedupLRU.Has(H, pid) is false — first-write LRU seeding did not run")
 	}
 }
 
-// TestRollup_LRUHit_SkipsStoreChunk: seed dedupLRU with hash H mapped to
-// "payload-prev"; pre-populate FBS with a FileBlock row for H so AddRef
-// succeeds; rollup a second payload with the same content. Assert
+// TestRollup_LRUHit_SkipsStoreChunk: seed dedupLRU with (hash H,
+// payloadID="hitfile") (the payload that will run rollup);
+// pre-populate FBS with a FileBlock row for H so AddRef succeeds;
+// rollup the payload. Assert
 //   - AddRef invoked exactly once with hash=H (counter +1)
 //   - StoreChunk skipped: pre-deleted CAS file is NOT recreated on disk
 //   - blocks slice still contains a BlockRef{Hash:H,Offset:..,Size:..}
 //     (verified via the ObjectIDPersister capture)
+//
+// #669: the LRU is keyed by (hash, payloadID); the seed payloadID
+// MUST match the rollup payloadID for the hit path to fire. Cross-payload
+// short-circuit is intentionally not supported (see
+// TestRollup_CrossPayload_LRUMisses below).
 func TestRollup_LRUHit_SkipsStoreChunk(t *testing.T) {
 	bc, wrapped, mem := newFSStoreForRollupLRUTest(t)
 	ctx := context.Background()
 
+	const pid = "hitfile"
 	payload := bytes.Repeat([]byte{0xBE}, 256*1024)
 	h := hashOfSingleChunk(payload)
 
@@ -712,11 +720,10 @@ func TestRollup_LRUHit_SkipsStoreChunk(t *testing.T) {
 		t.Fatalf("seed Put: %v", err)
 	}
 
-	// Seed the LRU with the hash mapped to a different payloadID — the
-	// PRECONDITION the hit path consults.
-	bc.dedupLRU.Put(h, "payload-prev")
-	if !bc.dedupLRU.Has(h) {
-		t.Fatal("precondition: LRU.Has(h) is false after Put")
+	// Seed the LRU with (h, pid) — the PRECONDITION the hit path consults.
+	bc.dedupLRU.Put(h, pid)
+	if !bc.dedupLRU.Has(h, pid) {
+		t.Fatal("precondition: LRU.Has(h, pid) is false after Put")
 	}
 
 	// Install a persister to capture the BlockRef manifest — proves the
@@ -740,7 +747,7 @@ func TestRollup_LRUHit_SkipsStoreChunk(t *testing.T) {
 
 	baseAddRef := wrapped.addRefCalls.Load()
 
-	runRollupOnce(t, bc, "hitfile", payload)
+	runRollupOnce(t, bc, pid, payload)
 
 	gotAddRef := wrapped.addRefCalls.Load() - baseAddRef
 	if gotAddRef != 1 {
@@ -769,16 +776,19 @@ func TestRollup_LRUHit_SkipsStoreChunk(t *testing.T) {
 	}
 }
 
-// TestRollup_AddRefReturnsErrUnknownHash_FallsBackToStoreChunk: LRU has h
-// programmable FBS returns ErrUnknownHash on every AddRef (simulating
-// TOCTOU eviction); rollup must proceed to StoreChunk normally.
+// TestRollup_AddRefReturnsErrUnknownHash_FallsBackToStoreChunk: LRU has
+// (h, pid); programmable FBS returns ErrUnknownHash on every AddRef
+// (simulating a TOCTOU sweep by engine.Delete cascade between
+// LRU populate and the next rollup pass); rollup must proceed to
+// StoreChunk normally.
 func TestRollup_AddRefReturnsErrUnknownHash_FallsBackToStoreChunk(t *testing.T) {
 	bc, wrapped, _ := newFSStoreForRollupLRUTest(t)
 
+	const pid = "fallback"
 	payload := bytes.Repeat([]byte{0xCA}, 256*1024)
 	h := hashOfSingleChunk(payload)
 
-	bc.dedupLRU.Put(h, "stale-payload")
+	bc.dedupLRU.Put(h, pid)
 	wrapped.addRefOverride = func(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 		return blockstore.ErrUnknownHash
 	}
@@ -788,7 +798,7 @@ func TestRollup_AddRefReturnsErrUnknownHash_FallsBackToStoreChunk(t *testing.T) 
 		_ = os.Remove(casPath)
 	}
 
-	runRollupOnce(t, bc, "fallback", payload)
+	runRollupOnce(t, bc, pid, payload)
 
 	if wrapped.addRefCalls.Load() != 1 {
 		t.Fatalf("AddRef calls: got %d want 1 (LRU hit triggered AddRef)", wrapped.addRefCalls.Load())
@@ -796,8 +806,8 @@ func TestRollup_AddRefReturnsErrUnknownHash_FallsBackToStoreChunk(t *testing.T) 
 	if _, err := os.Stat(casPath); err != nil {
 		t.Fatalf("CAS chunk %s missing post-rollup; ErrUnknownHash fallback did NOT call StoreChunk: %v", casPath, err)
 	}
-	if !bc.dedupLRU.Has(h) {
-		t.Fatal("LRU not (re-)populated after StoreChunk fallback path — Put step missing")
+	if !bc.dedupLRU.Has(h, pid) {
+		t.Fatal("LRU not (re-)populated after StoreChunk fallback path — post-persister PutMany missing")
 	}
 }
 
@@ -810,7 +820,7 @@ func TestRollup_AddRefError_OtherThan_ErrUnknownHash_Propagates(t *testing.T) {
 
 	payload := bytes.Repeat([]byte{0xDE}, 256*1024)
 	h := hashOfSingleChunk(payload)
-	bc.dedupLRU.Put(h, "any-payload")
+	bc.dedupLRU.Put(h, "errpath")
 
 	simulated := errors.New("metadata: postgres down")
 	wrapped.addRefOverride = func(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
@@ -840,11 +850,20 @@ func TestRollup_AddRefError_OtherThan_ErrUnknownHash_Propagates(t *testing.T) {
 	}
 }
 
-// TestRollup_ComputeObjectID_UnaffectedByLRUHit: write two payloads with
-// identical content; ObjectID and BlockRefs of each match. Verifies the
-// manifest invariant: LRU hit does NOT mutate the manifest seen
-// by ComputeObjectID.
-func TestRollup_ComputeObjectID_UnaffectedByLRUHit(t *testing.T) {
+// TestRollup_ComputeObjectID_StableAcrossPayloads: write two payloads
+// with identical content; ObjectID and BlockRefs of each match.
+// Verifies the manifest invariant: the chunker and ComputeObjectID
+// produce identical output across payloads regardless of LRU outcome.
+//
+// #669: under compound-key LRU scoping both passes MISS the LRU
+// (each payload only ever hits LRU entries IT populated). The test
+// therefore exercises the StoreChunk path twice for the same content;
+// content-addressed CAS makes the second Put idempotent. The pre-#669
+// version of this test conflated cross-payload dedup with LRU
+// short-circuit — the LRU short-circuit is now intentionally scoped to
+// same-payload idempotent rewrites; cross-payload dedup happens via
+// the regular CAS + FileBlockStore.GetByHash path.
+func TestRollup_ComputeObjectID_StableAcrossPayloads(t *testing.T) {
 	bc, _, _ := newFSStoreForRollupLRUTest(t)
 
 	payload := bytes.Repeat([]byte{0xF1}, 256*1024)
@@ -860,10 +879,11 @@ func TestRollup_ComputeObjectID_UnaffectedByLRUHit(t *testing.T) {
 		return nil
 	})
 
-	// First payload — LRU miss → StoreChunk + LRU seeding.
+	// First payload — LRU miss → StoreChunk + post-persister LRU seed.
 	runRollupOnce(t, bc, "oid-A", payload)
-	// Second payload — same content → LRU hit → AddRef. Manifest must
-	// still be identical.
+	// Second payload — different payloadID, same content. LRU miss
+	// under compound-key scoping → StoreChunk again (idempotent under
+	// CAS). Manifest must still be identical.
 	runRollupOnce(t, bc, "oid-B", payload)
 
 	mu.Lock()
@@ -910,9 +930,12 @@ func TestRollup_LRUHit_NoBlockStateMutation(t *testing.T) {
 		t.Fatalf("seed Put: %v", err)
 	}
 
-	bc.dedupLRU.Put(h, "prev-payload")
+	// #669: LRU keyed by (hash, payloadID). Seed under the SAME
+	// payloadID the rollup will run on so the hit path fires.
+	const pid = "no-state-mutation"
+	bc.dedupLRU.Put(h, pid)
 
-	runRollupOnce(t, bc, "no-state-mutation", payload)
+	runRollupOnce(t, bc, pid, payload)
 
 	// Read the row back via GetByHash (the row might be looked up via
 	// any matching ID; GetByHash is the public path).

--- a/pkg/blockstore/local/fs/rollup_test.go
+++ b/pkg/blockstore/local/fs/rollup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -406,12 +407,24 @@ type capturedPersist struct {
 // runRollupOnce triggers exactly one rollupFile pass for payloadID after
 // AppendWrite-ing the supplied payload and giving the dirty interval time
 // to stabilize. Mirrors the test pattern used by TestRollup_CommitChunks_
-// MonotoneEnforced.
+// MonotoneEnforced. NOT safe to call from a goroutine other than the
+// test's own — uses t.Fatal*. Use runRollupOnceErr for concurrent tests.
 func runRollupOnce(t *testing.T, bc *FSStore, payloadID string, payload []byte) {
 	t.Helper()
+	if err := runRollupOnceErr(bc, payloadID, payload); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runRollupOnceErr is the goroutine-safe variant: it returns errors
+// instead of calling t.Fatal*. Concurrent tests must use this and
+// fan errors back to the test goroutine via a channel; t.FailNow
+// (which t.Fatal* call) is undefined when invoked from a non-test
+// goroutine.
+func runRollupOnceErr(bc *FSStore, payloadID string, payload []byte) error {
 	ctx := context.Background()
 	if err := bc.AppendWrite(ctx, payloadID, payload, 0); err != nil {
-		t.Fatalf("AppendWrite: %v", err)
+		return fmt.Errorf("AppendWrite: %w", err)
 	}
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
@@ -421,11 +434,12 @@ func runRollupOnce(t *testing.T, bc *FSStore, payloadID string, payload []byte) 
 		time.Sleep(2 * time.Millisecond)
 	}
 	if !bc.EarliestStableForTest(payloadID) {
-		t.Fatal("dirty interval did not stabilize within 500 ms")
+		return fmt.Errorf("dirty interval did not stabilize within 500 ms")
 	}
 	if err := bc.rollupFile(ctx, payloadID); err != nil {
-		t.Fatalf("rollupFile: %v", err)
+		return fmt.Errorf("rollupFile: %w", err)
 	}
+	return nil
 }
 
 // TestRollup_CommitChunks_PersistsObjectID covers the rollup-time


### PR DESCRIPTION
Fixes #669 — v1.0 audit finding I-2 (file-level dedup refcount-on-missing-row).

## Two prongs

**A. Populate `dedupLRU` AFTER `ObjectIDPersister` returns.**
Previously the LRU was Put between StoreChunk and the persister callback (`rollup.go:420` pre-fix), so a concurrent rollup that observed the hash called AddRef before the FileBlock row was written → `ErrUnknownHash` storm. The rollup loop now batches (hash) entries into `pendingLRUPuts` during chunk emission and flushes them via `dedupLRU.PutMany` only after the persister callback returns nil. On persister failure (or earlier rollup failure) the LRU stays empty for those hashes.

**B. Scope the LRU to `(hash, payloadID)`.** Chose **option (i)** from the audit prescription (compound LRU key, not "validate ownership in AddRef") for two reasons:

- Smallest blast radius — confined to `dedup_lru.go` + the rollup call site. No change to the public `FileBlockStore.AddRef` contract or backend implementations (memory/badger/postgres).
- Cross-payload "wrong-row-owner" subcase becomes structurally unreachable: AddRef can only ever be invoked for a `(hash, payloadID)` pair THIS payload itself populated, so the row found by hash belongs to THIS payload. Option (ii) would have required a backend-level ownership check across three implementations and a new sentinel.

Cross-payload dedup still happens via the regular CAS path (content-addressed `StoreChunk` is idempotent; the engine's `FileBlockStore.GetByHash` short-circuit handles cross-file dedup). The LRU short-circuit is intentionally narrowed to same-payload idempotent rewrites — the dominant VM-workload pattern that motivated the LRU in the first place.

## Regression tests (both prongs)

`pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go`:
- `TestRollup_DedupLRU_NotPopulatedBeforePersister` — Prong A direct: a persister callback observing the LRU mid-rollup finds the in-flight hash absent.
- `TestRollup_DedupLRU_PersisterFailure_StaysEmpty` — Prong A failure path: persister error leaves the LRU untouched for those hashes.
- `TestRollup_DedupLRU_CrossPayload_NoShortCircuit` — Prong B direct: two payloads with identical content; `addRefCalls` delta is 0 on the second pass.
- `TestRollup_DedupLRU_ConcurrentRollups_NoErrUnknownHash` — 8 concurrent rollups on the same content, distinct payloadIDs; asserts zero `ErrUnknownHash` escapes (the #669 production signature).

Existing `dedup_lru_test.go` updated for the compound-key surface (`Get`/`Has` take `payloadID`, new `PutMany` batched populate). Existing `rollup_test.go` LRU-hit tests updated to seed under the same payloadID the rollup runs on. The idempotent-bytes bench now drives repeated rewrites on a single payloadID (the post-#669 hit pattern).

## Tested with

- `gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m` clean
- `go test -race -count=5 ./pkg/blockstore/local/fs/... ./pkg/blockstore/engine/...` green
- `go test ./...` green