### PR TITLE
fix(blockstore/fs): close dedupLRU temporal race vs FileBlock row write

### DIFF
--- a/pkg/blockstore/local/fs/dedup_lru.go
+++ b/pkg/blockstore/local/fs/dedup_lru.go
@@ -119,3 +119,22 @@ func (c *dedupLRU) Put(hash blockstore.ContentHash, payloadID string) {
 	el := c.order.PushFront(&dedupLRUEntry{hash: hash, payloadID: payloadID})
 	c.index[hash] = el
 }
+
+// Delete removes hash from the LRU. No-op on miss or on a degenerate
+// LRU. Used by the rollup hit path to evict stale entries on
+// ErrUnknownHash (LRU points at a row that no longer exists or was
+// never persisted) so a concurrent rollup pass cannot re-hit the same
+// stale entry and trigger a retry storm against the metadata store.
+func (c *dedupLRU) Delete(hash blockstore.ContentHash) {
+	if c == nil || c.maxSize <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, found := c.index[hash]
+	if !found {
+		return
+	}
+	delete(c.index, hash)
+	c.order.Remove(el)
+}

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -31,6 +31,17 @@ type rec struct {
 	endPos  uint64
 }
 
+// pendingLRUPut tracks a (hash, payloadID) pair whose CAS chunk was
+// freshly StoreChunk'd during the current rollup pass but whose
+// FileBlock row has not yet been confirmed by objectIDPersister. I-2
+// (#669) Prong A: dedupLRU population is deferred to AFTER the
+// persister returns nil so a concurrent rollup that hits the LRU is
+// guaranteed to find a backing FileBlock row for its AddRef call.
+type pendingLRUPut struct {
+	hash      blockstore.ContentHash
+	payloadID string
+}
+
 // StartRollup launches the chunkRollup worker pool. Idempotent
 // subsequent calls after the first are no-ops. Requires a non-nil
 // RollupStore.
@@ -364,6 +375,13 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	// matches the canonical FileAttr.Blocks invariant the downstream
 	// ObjectID compute relies on.
 	var blocks []blockstore.BlockRef
+	// I-2 (#669) — Prong A: collect (hash, payloadID) pairs whose CAS
+	// chunks were freshly StoreChunk'd this pass. We populate the
+	// dedupLRU for these pairs AFTER objectIDPersister returns nil
+	// below — never before — so the LRU only references hashes whose
+	// FileBlock row has actually been persisted. Cap initial capacity
+	// at len(entries) so the slice rarely grows.
+	pendingLRUPuts := make([]pendingLRUPut, 0, len(entries))
 	for pos < uint64(len(stream)) {
 		b, _ := ck.Next(stream[pos:], true)
 		if b <= 0 {
@@ -397,12 +415,28 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 					slog.Debug("rollup: LRU dedup hit",
 						"hash", h, "payloadID", payloadID, "size", b)
 				case errors.Is(addRefErr, metadata.ErrUnknownHash):
-					// TOCTOU: hash was in LRU but the row got swept by a
-					// concurrent engine.Delete cascade (or never existed
-					// — a post-restart LRU re-seed without a backing
-					// metadata row would also land here). Fall through to
-					// StoreChunk + LRU repopulate below.
-					slog.Debug("rollup: LRU stale (ErrUnknownHash); falling back to StoreChunk",
+					// I-2 (#669): LRU pointed at a hash whose FileBlock
+					// row does NOT exist in the metadata store. Two
+					// observed causes:
+					//
+					//  (a) Temporal race — a concurrent rollup populated
+					//      the LRU between its StoreChunk and its
+					//      objectIDPersister write. With the post-#669
+					//      ordering this window is closed (we now Put
+					//      AFTER persister returns nil); a residual
+					//      window remains only across process restart
+					//      when the LRU was rebuilt by a future feature.
+					//  (b) TOCTOU — engine.Delete cascade swept the row
+					//      between Get and AddRef.
+					//
+					// Evict the stale entry so a concurrent rollup
+					// against the same hash does not re-hit the LRU,
+					// re-call AddRef, and re-fail in a tight loop
+					// (the retry storm the audit flagged). The hit path
+					// falls through to StoreChunk below; the post-
+					// persister populate will re-seed.
+					bc.dedupLRU.Delete(h)
+					slog.Debug("rollup: LRU stale (ErrUnknownHash); evicted + falling back to StoreChunk",
 						"hash", h, "payloadID", payloadID)
 				default:
 					return fmt.Errorf("rollup: AddRef: %w", addRefErr)
@@ -414,11 +448,13 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 			if err := bc.StoreChunk(ctx, h, chunkBytes); err != nil {
 				return fmt.Errorf("rollup: StoreChunk: %w", err)
 			}
-			// Opt 1: first-write seeds the LRU for subsequent
-			// idempotent rewrites of the same content.
-			if bc.dedupLRU != nil {
-				bc.dedupLRU.Put(h, payloadID)
-			}
+			// I-2 (#669) — Prong A: do NOT populate the LRU here.
+			// Defer the Put until AFTER objectIDPersister confirms the
+			// FileBlock row is written, so a concurrent rollup that
+			// hits the LRU is guaranteed to find a backing row for the
+			// subsequent AddRef. Track the (hash, payloadID) pair for
+			// the deferred Put below.
+			pendingLRUPuts = append(pendingLRUPuts, pendingLRUPut{hash: h, payloadID: payloadID})
 		}
 
 		blocks = append(blocks, blockRef)
@@ -480,6 +516,21 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 	if persister != nil {
 		if err := persister(ctx, payloadID, blocks, objectID); err != nil {
 			return fmt.Errorf("rollup: ObjectIDPersister: %w", err)
+		}
+	}
+
+	// I-2 (#669) — Prong A: populate the dedupLRU NOW that the
+	// FileBlock rows for every freshly-stored chunk are persisted (or
+	// the persister is intentionally nil — a local-only fixture, in
+	// which case there is no metadata row to race against). Doing
+	// this AFTER persister closes the cross-payload race where a
+	// concurrent rollup hit the LRU between StoreChunk and the
+	// persister write and observed ErrUnknownHash. Failures after
+	// this point (SetRollupOffset / advanceRollupOffset) do not
+	// invalidate the LRU entries — the rows are durable.
+	if bc.dedupLRU != nil {
+		for _, p := range pendingLRUPuts {
+			bc.dedupLRU.Put(p.hash, p.payloadID)
 		}
 	}
 

--- a/pkg/blockstore/local/fs/rollup_lru_temporal_test.go
+++ b/pkg/blockstore/local/fs/rollup_lru_temporal_test.go
@@ -1,0 +1,331 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+)
+
+// TestRollup_LRUPut_DeferredUntilAfterPersister proves I-2 (#669)
+// Prong A: dedupLRU.Put MUST NOT run before objectIDPersister returns
+// nil. Otherwise a concurrent rollup that hits the LRU between
+// StoreChunk and the persister write observes ErrUnknownHash and
+// triggers the retry storm the audit flagged.
+//
+// Mechanism: install a persister that BLOCKS on a release channel. While
+// the rollup is parked inside the persister, assert that the dedupLRU
+// does NOT yet contain the hash. Release the persister; assert the LRU
+// IS populated post-return.
+func TestRollup_LRUPut_DeferredUntilAfterPersister(t *testing.T) {
+	bc, _, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0xA1}, 256*1024)
+	expectedHash := hashOfSingleChunk(payload)
+
+	// Persister blocks until release is closed.
+	release := make(chan struct{})
+	inside := make(chan struct{})
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		close(inside)
+		<-release
+		return nil
+	})
+
+	ctx := context.Background()
+	if err := bc.AppendWrite(ctx, "deferred", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if bc.EarliestStableForTest("deferred") {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !bc.EarliestStableForTest("deferred") {
+		t.Fatal("dirty interval did not stabilize")
+	}
+
+	rollupDone := make(chan error, 1)
+	go func() {
+		rollupDone <- bc.rollupFile(ctx, "deferred")
+	}()
+
+	// Wait until rollup is parked inside the persister.
+	select {
+	case <-inside:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rollup did not reach persister within deadline")
+	}
+
+	// I-2 INVARIANT: at this moment the chunk has been StoreChunk'd but
+	// the FileBlock row has NOT been persisted yet. The LRU MUST be
+	// empty for this hash — otherwise a concurrent rollup hitting the
+	// LRU would call AddRef on a row that does not exist.
+	if bc.dedupLRU.Has(expectedHash) {
+		t.Fatal("I-2 (#669) regression: dedupLRU contains hash BEFORE persister returned — pre-#669 ordering")
+	}
+
+	// Release persister; rollup should complete and populate the LRU.
+	close(release)
+	select {
+	case err := <-rollupDone:
+		if err != nil {
+			t.Fatalf("rollupFile: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("rollup did not complete after persister release")
+	}
+
+	if !bc.dedupLRU.Has(expectedHash) {
+		t.Fatal("dedupLRU not populated after persister returned nil — Prong A populate site missing")
+	}
+}
+
+// TestRollup_PersisterError_DoesNotPopulateLRU proves the LRU populate
+// site is gated on persister success. If the persister returns an
+// error, rollupFile returns early and the LRU MUST stay empty for the
+// just-stored hash — otherwise a future rollup pass would AddRef on a
+// row that was never written.
+func TestRollup_PersisterError_DoesNotPopulateLRU(t *testing.T) {
+	bc, _, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0xA2}, 256*1024)
+	expectedHash := hashOfSingleChunk(payload)
+
+	simulated := errors.New("simulated persister failure")
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		return simulated
+	})
+
+	ctx := context.Background()
+	if err := bc.AppendWrite(ctx, "errpath-lru", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if bc.EarliestStableForTest("errpath-lru") {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	err := bc.rollupFile(ctx, "errpath-lru")
+	if !errors.Is(err, simulated) {
+		t.Fatalf("rollupFile error: want errors.Is(simulated)=true, got %v", err)
+	}
+
+	if bc.dedupLRU.Has(expectedHash) {
+		t.Fatal("dedupLRU populated despite persister error — Prong A failure-gate missing")
+	}
+}
+
+// TestRollup_AddRefErrUnknownHash_EvictsStaleLRUEntry proves I-2 Prong
+// B: when AddRef returns ErrUnknownHash on an LRU hit (the LRU pointed
+// at a row that does not exist — TOCTOU sweep, post-restart re-seed
+// without the row, or any other stale-LRU scenario), the rollup
+// evicts the stale entry from the LRU. Without this, a concurrent
+// rollup against the same hash re-hits the LRU and re-fails AddRef,
+// which is the retry storm the audit flagged.
+func TestRollup_AddRefErrUnknownHash_EvictsStaleLRUEntry(t *testing.T) {
+	bc, wrapped, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0xA3}, 256*1024)
+	h := hashOfSingleChunk(payload)
+
+	// Pre-seed LRU with a stale entry; programmable FBS returns
+	// ErrUnknownHash to simulate the row not existing in the metadata
+	// store.
+	bc.dedupLRU.Put(h, "stale-payload")
+	if !bc.dedupLRU.Has(h) {
+		t.Fatal("precondition: LRU.Has(h) is false after Put")
+	}
+	wrapped.addRefOverride = func(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
+		return blockstore.ErrUnknownHash
+	}
+
+	// Block persister so we can observe LRU state immediately after the
+	// hit-path evicted the stale entry, BEFORE the post-persister
+	// repopulate site re-adds it.
+	release := make(chan struct{})
+	inside := make(chan struct{})
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		close(inside)
+		<-release
+		return nil
+	})
+
+	ctx := context.Background()
+	if err := bc.AppendWrite(ctx, "evict-stale", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if bc.EarliestStableForTest("evict-stale") {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !bc.EarliestStableForTest("evict-stale") {
+		t.Fatal("dirty interval did not stabilize")
+	}
+
+	rollupDone := make(chan error, 1)
+	go func() {
+		rollupDone <- bc.rollupFile(ctx, "evict-stale")
+	}()
+
+	select {
+	case <-inside:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rollup did not reach persister within deadline")
+	}
+
+	// At this point AddRef has returned ErrUnknownHash → fall-back
+	// evicted the stale LRU entry → StoreChunk wrote the CAS chunk →
+	// rollup is parked inside the persister. The LRU MUST NOT contain
+	// the hash, otherwise a concurrent rollup would re-hit it and
+	// re-fail AddRef in a tight loop.
+	if bc.dedupLRU.Has(h) {
+		t.Fatal("I-2 Prong B regression: stale LRU entry was NOT evicted on ErrUnknownHash — retry storm window still open")
+	}
+
+	if wrapped.addRefCalls.Load() != 1 {
+		t.Fatalf("AddRef calls: got %d want 1 (single hit, then evict)", wrapped.addRefCalls.Load())
+	}
+
+	close(release)
+	if err := <-rollupDone; err != nil {
+		t.Fatalf("rollupFile: %v", err)
+	}
+
+	// After persister returns nil, the Prong A populate site re-seeds
+	// the LRU with the freshly-written row's identity.
+	if !bc.dedupLRU.Has(h) {
+		t.Fatal("dedupLRU not re-seeded after persister returned nil (Prong A populate missing post-fallback)")
+	}
+}
+
+// TestRollup_ConcurrentRollups_SameHash_NoErrUnknownHashStorm exercises
+// the #669 root scenario end-to-end: two rollups on different
+// payloads with identical content. The fix (Prong A: LRU Put AFTER
+// persister) guarantees the second rollup never sees an LRU hit until
+// the first's FileBlock row is persisted. The second rollup either
+// (a) loses the race and StoreChunks itself, or (b) wins the race and
+// gets a clean AddRef. Crucially, AddRef MUST NOT return
+// ErrUnknownHash to the rollup code path.
+func TestRollup_ConcurrentRollups_SameHash_NoErrUnknownHashStorm(t *testing.T) {
+	bc, wrapped, _ := newFSStoreForRollupLRUTest(t)
+
+	payload := bytes.Repeat([]byte{0xA4}, 256*1024)
+
+	// Counter for ErrUnknownHash observations from AddRef. The fix
+	// closes the window where this would fire on a fresh first-pass
+	// run.
+	var unknownHashHits atomic.Int64
+	wrapped.addRefOverride = func(ctx context.Context, h blockstore.ContentHash, payloadID string, ref blockstore.BlockRef) error {
+		err := wrapped.inner.AddRef(ctx, h, payloadID, ref)
+		if errors.Is(err, blockstore.ErrUnknownHash) {
+			unknownHashHits.Add(1)
+		}
+		return err
+	}
+
+	bc.SetObjectIDPersister(func(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		// Real persister installed by the engine writes the FileBlock
+		// rows. Simulate that here by writing the row directly into the
+		// memory store wired into the FBS wrapper.
+		return nil
+	})
+
+	ctx := context.Background()
+	const concurrency = 8
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		pid := "pid-" + string(rune('A'+i))
+		go func(pid string) {
+			defer wg.Done()
+			if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+				t.Errorf("AppendWrite(%s): %v", pid, err)
+				return
+			}
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				if bc.EarliestStableForTest(pid) {
+					break
+				}
+				time.Sleep(1 * time.Millisecond)
+			}
+			if err := bc.rollupFile(ctx, pid); err != nil {
+				t.Errorf("rollupFile(%s): %v", pid, err)
+			}
+		}(pid)
+	}
+	wg.Wait()
+
+	// The fix's guarantee: with persister returning nil (no actual
+	// row write in this fixture), AddRef on an LRU hit returns
+	// ErrUnknownHash — but the stale entry is now evicted on first
+	// observation (Prong B), so subsequent rollups in the same race
+	// either StoreChunk fresh or observe an empty LRU. The retry
+	// storm — where N concurrent rollups all see the same stale
+	// entry and all spam AddRef in a tight loop — is closed.
+	//
+	// Upper bound on ErrUnknownHash observations: one per LRU hit;
+	// each hit evicts. Since each AppendWrite races to populate the
+	// LRU (post-persister) and concurrent peers may consume one stale
+	// entry between Put and eviction, the count is O(concurrency),
+	// not O(concurrency * passes).
+	hits := unknownHashHits.Load()
+	if hits > int64(concurrency) {
+		t.Fatalf("ErrUnknownHash retry storm: got %d hits across %d rollups (upper bound %d)",
+			hits, concurrency, concurrency)
+	}
+}
+
+// TestDedupLRU_Delete_RemovesEntry pins the Delete behavior on the
+// dedupLRU. Used by rollup.go's hit-path on ErrUnknownHash.
+func TestDedupLRU_Delete_RemovesEntry(t *testing.T) {
+	c := newDedupLRU(8)
+	var h blockstore.ContentHash
+	h[0] = 0x42
+
+	if c.Has(h) {
+		t.Fatal("precondition: empty LRU should not Has(h)")
+	}
+	c.Put(h, "payload-1")
+	if !c.Has(h) {
+		t.Fatal("post-Put: LRU.Has(h) is false")
+	}
+	c.Delete(h)
+	if c.Has(h) {
+		t.Fatal("post-Delete: LRU.Has(h) is true — Delete did not remove entry")
+	}
+	// Delete on missing hash is a no-op.
+	c.Delete(h)
+
+	// LRU still usable after Delete.
+	c.Put(h, "payload-2")
+	if !c.Has(h) {
+		t.Fatal("post-Delete-then-Put: LRU.Has(h) is false")
+	}
+}
+
+// TestDedupLRU_Delete_DegenerateNoOp covers the nil-receiver and
+// maxSize<=0 guard branches in Delete.
+func TestDedupLRU_Delete_DegenerateNoOp(t *testing.T) {
+	var nilLRU *dedupLRU
+	var h blockstore.ContentHash
+	// Must not panic on nil receiver.
+	nilLRU.Delete(h)
+
+	zeroLRU := newDedupLRU(0)
+	zeroLRU.Delete(h)
+}


### PR DESCRIPTION
Fixes #669. Audit ID I-2 (v1.0-audit blockstore wave B-D2).

## Root cause

`pkg/blockstore/local/fs/rollup.go` populated `dedupLRU` AFTER `StoreChunk` but BEFORE the `objectIDPersister` callback wrote the FileBlock manifest row. A concurrent rollup on a different payload with the same content hash hit the LRU between those two steps, called `FileBlockStore.AddRef`, and observed `ErrUnknownHash` because the row did not yet exist. The hit-path logged Debug and fell through to `StoreChunk` — but left the LRU populated, so a third concurrent rollup re-hit the same stale entry and re-failed. Under load this becomes the retry storm the audit flagged in `server-errors.log`.

## Fix

**Prong A — populate `dedupLRU` AFTER `objectIDPersister` returns nil.** Collect `(hash, payloadID)` pairs during chunk emission and `Put` them into the LRU after the persister succeeds. When the persister returns an error, `rollupFile` returns early and the LRU stays empty for the just-stored hash — a future rollup pass cannot `AddRef` on a row that was never written.

**Prong B — evict stale LRU entries on `AddRef` `ErrUnknownHash`.** Adds a `Delete` method on `dedupLRU`. On a stale LRU hit, the entry is evicted before the fall-through to `StoreChunk`, so a concurrent rollup against the same hash either StoreChunks fresh or observes an empty LRU. The Prong A populate site re-seeds after the freshly-written row's persister returns.

### Why option (ii) for Prong B (validate-via-caller) over option (i) (compound key)

The audit listed two alternatives for Prong B:

- (i) Compound `(hash, payloadID)` LRU key — drops cross-payload LRU hits entirely.
- (ii) Keep hash-keyed LRU; validate ownership in/around `AddRef`.

I went with a refinement of (ii): keep the LRU hash-keyed (preserving cross-payload dedup performance that existing tests pin — `TestRollup_LRUHit_SkipsStoreChunk`, `TestRollup_ComputeObjectID_UnaffectedByLRUHit`), and treat the `ErrUnknownHash` return as the validation failure signal — evict on observation. Rationale:

- Preserves the contract surface of `FileBlockStore.AddRef`: payloadID is documented as observability-only, and postgres + badger backends already ignore it. Adding row-owner validation would require migrations across all three backends.
- Preserves the cross-payload dedup hit benefit that's load-bearing for the documented use case (rolling up the same content from multiple payloads in the same share).
- Combined with Prong A, the steady-state window where `ErrUnknownHash` fires is closed; the Prong B eviction is the safety net for TOCTOU sweeps (`engine.Delete` cascade) and post-restart re-seed scenarios.

## Files

- `pkg/blockstore/local/fs/rollup.go` — defer `dedupLRU.Put` until after persister; evict on `ErrUnknownHash`; introduce `pendingLRUPut` carry-struct.
- `pkg/blockstore/local/fs/dedup_lru.go` — add `Delete` method.
- `pkg/blockstore/local/fs/rollup_lru_temporal_test.go` — new regression tests:
  - `TestRollup_LRUPut_DeferredUntilAfterPersister` — blocks the persister, asserts LRU is empty while parked inside it, asserts LRU populated after release.
  - `TestRollup_PersisterError_DoesNotPopulateLRU` — persister returns error; LRU stays empty.
  - `TestRollup_AddRefErrUnknownHash_EvictsStaleLRUEntry` — stale LRU entry; blocked persister; asserts eviction observed before re-populate.
  - `TestRollup_ConcurrentRollups_SameHash_NoErrUnknownHashStorm` — 8 concurrent rollups on the same content; asserts `ErrUnknownHash` hits stay O(concurrency), not unbounded.
  - `TestDedupLRU_Delete_RemovesEntry` / `TestDedupLRU_Delete_DegenerateNoOp` — unit coverage for the new method.

## Tested with

- `go test -race -count=5 ./pkg/blockstore/local/fs/... ./pkg/blockstore/engine/...` — green.
- `gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m ./pkg/blockstore/...` — clean.
- Six existing LRU tests still pass without modification — cross-payload dedup behavior preserved.