### PR TITLE
fix(smb): SMB3 replay protection (#482)

### DIFF
--- a/internal/adapter/smb/header/header.go
+++ b/internal/adapter/smb/header/header.go
@@ -147,6 +147,27 @@ func (h *SMB2Header) IsRelated() bool {
 	return h.Flags.IsRelated()
 }
 
+// IsReplay returns true if the request carries the
+// SMB2_FLAGS_REPLAY_OPERATION flag (MS-SMB2 §2.2.1.2). Set by the
+// client when it is retransmitting a request whose original
+// response was lost (e.g., a channel failed before the response
+// arrived). The server consults per-CreateGuid / per-LockSequence
+// replay state instead of treating the request as fresh — see
+// the CREATE replay-cache and the LOCK sequence tracker.
+func (h *SMB2Header) IsReplay() bool {
+	return h.Flags.IsReplay()
+}
+
+// ChannelSequence is the per-channel sequence number for this
+// request (low 16 bits of the request Status field per MS-SMB2
+// §2.2.1.2). Used by the server to detect requests that targeted
+// a now-defunct channel and apply the §3.3.5.2.5 verification
+// rules. Meaningful only on requests; responses use the Status
+// field for NT_STATUS.
+func (h *SMB2Header) ChannelSequence() uint16 {
+	return uint16(uint32(h.Status))
+}
+
 // CommandName returns the string name of the command.
 func (h *SMB2Header) CommandName() string {
 	return h.Command.String()

--- a/internal/adapter/smb/header/header.go
+++ b/internal/adapter/smb/header/header.go
@@ -158,16 +158,6 @@ func (h *SMB2Header) IsReplay() bool {
 	return h.Flags.IsReplay()
 }
 
-// ChannelSequence is the per-channel sequence number for this
-// request (low 16 bits of the request Status field per MS-SMB2
-// §2.2.1.2). Used by the server to detect requests that targeted
-// a now-defunct channel and apply the §3.3.5.2.5 verification
-// rules. Meaningful only on requests; responses use the Status
-// field for NT_STATUS.
-func (h *SMB2Header) ChannelSequence() uint16 {
-	return uint16(uint32(h.Status))
-}
-
 // CommandName returns the string name of the command.
 func (h *SMB2Header) CommandName() string {
 	return h.Command.String()

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -251,13 +251,11 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 	// (MS-SMB2 §3.3.4.4). Zero means standalone or last-in-compound — async OK.
 	handlerCtx.NextCommand = reqHeader.NextCommand
 
-	// Replay protection (MS-SMB2 §2.2.1.2, §3.3.5.2.5): surface the
-	// FLAGS_REPLAY_OPERATION flag and ChannelSequence (low 16 bits of
-	// the request Status field) to handlers. CREATE consults IsReplay
-	// to return a cached DH2Q response by CreateGuid; LOCK consults it
-	// to return a cached result by (FileID, LockSequence).
+	// Replay protection (MS-SMB2 §2.2.1.2): surface the
+	// FLAGS_REPLAY_OPERATION flag to handlers. CREATE consults this
+	// to return a cached DH2Q response by CreateGuid; LOCK consults
+	// it to return a cached result by (FileID, LockSequence).
 	handlerCtx.IsReplay = reqHeader.IsReplay()
-	handlerCtx.ChannelSequence = reqHeader.ChannelSequence()
 
 	// Populate CryptoState so handlers (e.g., NEGOTIATE) can store
 	// negotiation parameters on the connection.

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -251,6 +251,14 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 	// (MS-SMB2 §3.3.4.4). Zero means standalone or last-in-compound — async OK.
 	handlerCtx.NextCommand = reqHeader.NextCommand
 
+	// Replay protection (MS-SMB2 §2.2.1.2, §3.3.5.2.5): surface the
+	// FLAGS_REPLAY_OPERATION flag and ChannelSequence (low 16 bits of
+	// the request Status field) to handlers. CREATE consults IsReplay
+	// to return a cached DH2Q response by CreateGuid; LOCK consults it
+	// to return a cached result by (FileID, LockSequence).
+	handlerCtx.IsReplay = reqHeader.IsReplay()
+	handlerCtx.ChannelSequence = reqHeader.ChannelSequence()
+
 	// Populate CryptoState so handlers (e.g., NEGOTIATE) can store
 	// negotiation parameters on the connection.
 	handlerCtx.ConnCryptoState = connInfo.CryptoState

--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -226,6 +226,17 @@ func (f HeaderFlags) IsSigned() bool {
 	return f.Has(FlagSigned)
 }
 
+// IsReplay returns true if the message is a replay operation
+// (SMB2_FLAGS_REPLAY_OPERATION per MS-SMB2 §2.2.1.2). Set by the
+// client when retransmitting a request whose response was lost on
+// a previous channel (multichannel) or whose response window was
+// missed. The server uses this to consult per-CreateGuid /
+// per-LockSequence replay state (MS-SMB2 §3.3.5.2.5, §3.3.5.9,
+// §3.3.5.14) instead of treating the request as fresh.
+func (f HeaderFlags) IsReplay() bool {
+	return f.Has(FlagReplay)
+}
+
 // Legacy aliases for backward compatibility
 const (
 	SMB2FlagsServerToRedir   = uint32(FlagResponse)

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -189,6 +189,22 @@ type SMBHandlerContext struct {
 	// global and per-share encryption requirements per MS-SMB2 3.3.5.2.1.
 	RequestEncrypted bool
 
+	// IsReplay is true when the request header carries
+	// SMB2_FLAGS_REPLAY_OPERATION (MS-SMB2 §2.2.1.2). Handlers that
+	// support replay (CREATE with DH2Q, LOCK with non-zero
+	// LockSequence) consult per-request replay state to return the
+	// previously-computed result instead of re-executing.
+	IsReplay bool
+
+	// ChannelSequence carries the per-channel sequence number from
+	// the request header (low 16 bits of the Status field on
+	// requests, per MS-SMB2 §2.2.1.2). Used by §3.3.5.2.5 to
+	// detect requests sent over a now-defunct channel. Currently
+	// recorded for diagnostic / future enforcement; the CREATE and
+	// LOCK replay paths key on FLAGS_REPLAY_OPERATION rather than
+	// ChannelSequence alone.
+	ChannelSequence uint16
+
 	// PostSend is an optional hook invoked by the dispatch layer AFTER the
 	// response for this command has been written to the wire. It is used by
 	// handlers (currently only CLOSE) to defer async side-effects that must

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -196,15 +196,6 @@ type SMBHandlerContext struct {
 	// previously-computed result instead of re-executing.
 	IsReplay bool
 
-	// ChannelSequence carries the per-channel sequence number from
-	// the request header (low 16 bits of the Status field on
-	// requests, per MS-SMB2 §2.2.1.2). Used by §3.3.5.2.5 to
-	// detect requests sent over a now-defunct channel. Currently
-	// recorded for diagnostic / future enforcement; the CREATE and
-	// LOCK replay paths key on FLAGS_REPLAY_OPERATION rather than
-	// ChannelSequence alone.
-	ChannelSequence uint16
-
 	// PostSend is an optional hook invoked by the dispatch layer AFTER the
 	// response for this command has been written to the wire. It is used by
 	// handlers (currently only CLOSE) to defer async side-effects that must

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1457,12 +1457,8 @@ func (h *Handler) storeCreateReplayIfApplicable(ctx *SMBHandlerContext, req *Cre
 	if h.CreateReplayCache == nil || resp == nil || resp.Status != types.StatusSuccess {
 		return
 	}
-	dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag)
-	if dh2qCtx == nil {
-		return
-	}
-	_, _, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
-	if err != nil || createGuid == ([16]byte{}) {
+	createGuid := dh2qCreateGuid(req)
+	if createGuid == ([16]byte{}) {
 		return
 	}
 	h.CreateReplayCache.Store(ctx.SessionID, createGuid, resp)
@@ -1476,15 +1472,28 @@ func (h *Handler) lookupCreateReplay(ctx *SMBHandlerContext, req *CreateRequest)
 	if !ctx.IsReplay || h.CreateReplayCache == nil {
 		return nil
 	}
-	dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag)
-	if dh2qCtx == nil {
-		return nil
-	}
-	_, _, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
-	if err != nil || createGuid == ([16]byte{}) {
+	createGuid := dh2qCreateGuid(req)
+	if createGuid == ([16]byte{}) {
 		return nil
 	}
 	return h.CreateReplayCache.Lookup(ctx.SessionID, createGuid)
+}
+
+// dh2qCreateGuid extracts the CreateGuid from a CREATE request's
+// SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2 context. Returns the zero
+// GUID when the context is missing, malformed, or carries a zero
+// CreateGuid — callers must treat that as "no replay keying
+// possible" (MS-SMB2 §2.2.13.2.11).
+func dh2qCreateGuid(req *CreateRequest) [16]byte {
+	dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag)
+	if dh2qCtx == nil {
+		return [16]byte{}
+	}
+	_, _, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
+	if err != nil {
+		return [16]byte{}
+	}
+	return createGuid
 }
 
 // handlePipeCreate handles CREATE on IPC$ for named pipes.

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1468,6 +1468,25 @@ func (h *Handler) storeCreateReplayIfApplicable(ctx *SMBHandlerContext, req *Cre
 	h.CreateReplayCache.Store(ctx.SessionID, createGuid, resp)
 }
 
+// lookupCreateReplay returns a cached CREATE response when the request
+// carries SMB2_FLAGS_REPLAY_OPERATION and a matching DH2Q CreateGuid is
+// still in the per-session cache (MS-SMB2 §3.3.5.9 replay handling).
+// Returns nil on miss; caller falls through to the normal CREATE path.
+func (h *Handler) lookupCreateReplay(ctx *SMBHandlerContext, req *CreateRequest) *CreateResponse {
+	if !ctx.IsReplay || h.CreateReplayCache == nil {
+		return nil
+	}
+	dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag)
+	if dh2qCtx == nil {
+		return nil
+	}
+	_, _, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
+	if err != nil || createGuid == ([16]byte{}) {
+		return nil
+	}
+	return h.CreateReplayCache.Lookup(ctx.SessionID, createGuid)
+}
+
 // handlePipeCreate handles CREATE on IPC$ for named pipes.
 // Named pipes are used for DCE/RPC communication, e.g., srvsvc for share enumeration.
 func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, tree *TreeConnection) (*CreateResponse, error) {

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -503,22 +503,12 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// miss falls through to the normal CREATE path, which on
 	// success records the response into the cache for the next
 	// replay window.
-	if ctx.IsReplay && h.CreateReplayCache != nil {
-		if dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag); dh2qCtx != nil {
-			if _, _, createGuid, decodeErr := DecodeDH2QRequest(dh2qCtx.Data); decodeErr == nil && createGuid != ([16]byte{}) {
-				if cached := h.CreateReplayCache.Lookup(ctx.SessionID, createGuid); cached != nil {
-					logger.Debug("CREATE: replay hit — returning cached response",
-						"sessionID", ctx.SessionID,
-						"createGuid", fmt.Sprintf("%x", createGuid),
-						"fileID", fmt.Sprintf("%x", cached.FileID))
-					// Return a shallow copy so the caller can stamp
-					// per-response fields without mutating the cache
-					// entry (the encoder reads fields verbatim).
-					resp := *cached
-					return &resp, nil
-				}
-			}
-		}
+	if cached := h.lookupCreateReplay(ctx, req); cached != nil {
+		// Return a shallow copy so the caller can stamp per-response
+		// fields without mutating the cache entry (the encoder reads
+		// fields verbatim).
+		resp := *cached
+		return &resp, nil
 	}
 
 	// TWrp (SMB2_CREATE_TIMEWARP_TOKEN, MS-SMB2 §2.2.13.2.7) requests a
@@ -603,7 +593,9 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// ========================================================================
 
 	if tree.ShareName == "/ipc$" {
-		return h.handlePipeCreate(ctx, req, tree)
+		resp, err := h.handlePipeCreate(ctx, req, tree)
+		h.storeCreateReplayIfApplicable(ctx, req, resp)
+		return resp, err
 	}
 
 	// ========================================================================
@@ -736,7 +728,9 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Handle root directory case
 	if filename == "" && streamSuffix == "" {
-		return h.handleOpenRootCreate(ctx, req, authCtx, rootHandle, tree)
+		resp, err := h.handleOpenRootCreate(ctx, req, authCtx, rootHandle, tree)
+		h.storeCreateReplayIfApplicable(ctx, req, resp)
+		return resp, err
 	}
 
 	// ========================================================================
@@ -1449,6 +1443,30 @@ func buildMaxAccessEvalContext(file *metadata.File, authCtx *metadata.AuthContex
 // ============================================================================
 // Named Pipe Handling (IPC$)
 // ============================================================================
+
+// storeCreateReplayIfApplicable mirrors the cache.Store call at the
+// bottom of completeCreateAfterBreak for CREATE return paths that
+// bypass it (notably handlePipeCreate and handleOpenRootCreate). It is
+// the single seam used by those bypass paths so a successful CREATE
+// carrying a DH2Q CreateGuid is recorded into the replay cache; a
+// FLAGS_REPLAY_OPERATION retry within the replay window can then return
+// the cached result. Cache.Store is itself a no-op when CreateGuid is
+// zero or when resp.Status != StatusSuccess, so it is safe to call
+// unconditionally here (MS-SMB2 §3.3.5.9).
+func (h *Handler) storeCreateReplayIfApplicable(ctx *SMBHandlerContext, req *CreateRequest, resp *CreateResponse) {
+	if h.CreateReplayCache == nil || resp == nil || resp.Status != types.StatusSuccess {
+		return
+	}
+	dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag)
+	if dh2qCtx == nil {
+		return
+	}
+	_, _, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
+	if err != nil || createGuid == ([16]byte{}) {
+		return
+	}
+	h.CreateReplayCache.Store(ctx.SessionID, createGuid, resp)
+}
 
 // handlePipeCreate handles CREATE on IPC$ for named pipes.
 // Named pipes are used for DCE/RPC communication, e.g., srvsvc for share enumeration.

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -489,6 +489,38 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
+	// SMB3 replay protection (MS-SMB2 §3.3.5.9 step 5; §2.2.1.2 REPLAY_OPERATION).
+	// When FLAGS_REPLAY_OPERATION is set on a CREATE carrying a
+	// DH2Q with a non-zero CreateGuid, the client is retransmitting
+	// a request whose original response was lost. The server MUST
+	// return the cached response — otherwise the legitimate retry
+	// trips STATUS_SHARING_VIOLATION (the original open is still
+	// alive on the server) and the DH2Q CREATE pattern is unusable
+	// over flaky multichannel topologies (smbtorture
+	// smb2.replay.replay-dhv2-*).
+	//
+	// The cache is scoped per-session and bounded by a short TTL; a
+	// miss falls through to the normal CREATE path, which on
+	// success records the response into the cache for the next
+	// replay window.
+	if ctx.IsReplay && h.CreateReplayCache != nil {
+		if dh2qCtx := FindCreateContext(req.CreateContexts, DurableHandleV2RequestTag); dh2qCtx != nil {
+			if _, _, createGuid, decodeErr := DecodeDH2QRequest(dh2qCtx.Data); decodeErr == nil && createGuid != ([16]byte{}) {
+				if cached := h.CreateReplayCache.Lookup(ctx.SessionID, createGuid); cached != nil {
+					logger.Debug("CREATE: replay hit — returning cached response",
+						"sessionID", ctx.SessionID,
+						"createGuid", fmt.Sprintf("%x", createGuid),
+						"fileID", fmt.Sprintf("%x", cached.FileID))
+					// Return a shallow copy so the caller can stamp
+					// per-response fields without mutating the cache
+					// entry (the encoder reads fields verbatim).
+					resp := *cached
+					return &resp, nil
+				}
+			}
+		}
+	}
+
 	// TWrp (SMB2_CREATE_TIMEWARP_TOKEN, MS-SMB2 §2.2.13.2.7) requests a
 	// previous-version (snapshot) view of the share. DittoFS has no VSS-style
 	// snapshot backend wired into CREATE, so any non-zero snapshot timestamp

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -963,6 +963,16 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			"diskFileId", fmt.Sprintf("%x", qfidFileID[:16]))
 	}
 
+	// SMB3 replay protection (MS-SMB2 §3.3.5.9): record the
+	// freshly-built success response keyed by DH2Q CreateGuid so a
+	// FLAGS_REPLAY_OPERATION retry within the replay window returns
+	// the cached result instead of re-running CREATE. Only V2
+	// durable opens carry a CreateGuid — V1 / non-durable CREATEs
+	// rely on the in-flight MessageID dedup at the framing layer.
+	if h.CreateReplayCache != nil && openFile != nil && openFile.CreateGuid != ([16]byte{}) {
+		h.CreateReplayCache.Store(openFile.SessionID, openFile.CreateGuid, resp)
+	}
+
 	return resp
 }
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -844,15 +844,7 @@ func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
 		v.(*handleOpTracker).wg.Wait()
 		h.handleOps.Delete(key)
 	}
-	if v, ok := h.files.Load(key); ok {
-		of := v.(*OpenFile)
-		if h.CreateReplayCache != nil && of.CreateGuid != ([16]byte{}) {
-			h.CreateReplayCache.Forget(of.CreateGuid)
-		}
-	}
-	if h.LockReplayCache != nil {
-		h.LockReplayCache.ForgetFile(fileID)
-	}
+	h.forgetReplayState(fileID)
 	h.files.Delete(key)
 	h.resumeKeys.revoke(fileID)
 }
@@ -863,18 +855,27 @@ func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
 // tracker so trackers created by BeginHandleOp on this FileID do not leak.
 func (h *Handler) DeleteOpenFile(fileID [16]byte) {
 	key := string(fileID[:])
-	if v, ok := h.files.Load(key); ok {
-		of := v.(*OpenFile)
-		if h.CreateReplayCache != nil && of.CreateGuid != ([16]byte{}) {
-			h.CreateReplayCache.Forget(of.CreateGuid)
+	h.forgetReplayState(fileID)
+	h.files.Delete(key)
+	h.handleOps.Delete(key)
+	h.resumeKeys.revoke(fileID)
+}
+
+// forgetReplayState drops both CREATE (by CreateGuid via the OpenFile)
+// and LOCK (by FileID) replay-cache entries for a handle that is being
+// closed. The cache windows are only meaningful while a retry could
+// still arrive — once the handle is gone, so is any legitimate replay.
+func (h *Handler) forgetReplayState(fileID [16]byte) {
+	if h.CreateReplayCache != nil {
+		if v, ok := h.files.Load(string(fileID[:])); ok {
+			if of := v.(*OpenFile); of.CreateGuid != ([16]byte{}) {
+				h.CreateReplayCache.Forget(of.CreateGuid)
+			}
 		}
 	}
 	if h.LockReplayCache != nil {
 		h.LockReplayCache.ForgetFile(fileID)
 	}
-	h.files.Delete(key)
-	h.handleOps.Delete(key)
-	h.resumeKeys.revoke(fileID)
 }
 
 // ReleaseAllLocksForSession releases all byte-range locks held by a session.

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -78,6 +78,25 @@ type Handler struct {
 	// final response via AsyncLockCompleteCallback. See pending_lock_registry.go.
 	PendingLockRegistry *PendingLockRegistry
 
+	// CreateReplayCache backs SMB3 replay protection for CREATE
+	// (MS-SMB2 §3.3.5.9). When a client sets SMB2_FLAGS_REPLAY_OPERATION
+	// on a CREATE carrying a DH2Q with CreateGuid X, the handler
+	// consults this cache first: a hit returns the original response
+	// (avoiding STATUS_SHARING_VIOLATION on the legitimate retry); a
+	// miss falls through to the normal CREATE path and the success
+	// response is stored for the next replay window. See
+	// replay_cache.go.
+	CreateReplayCache *CreateReplayCache
+
+	// LockReplayCache backs SMB3 replay protection for LOCK
+	// (MS-SMB2 §3.3.5.14). Keyed by (FileID, LockSequenceIndex),
+	// stores the last LockSequenceNumber + status pair so a replayed
+	// LOCK with matching slot returns the cached status verbatim
+	// instead of trying to re-acquire / re-release (which would trip
+	// STATUS_RANGE_NOT_LOCKED or STATUS_LOCK_NOT_GRANTED). See
+	// replay_cache.go.
+	LockReplayCache *LockReplayCache
+
 	// LockWaitGraph tracks "is waiting for" relationships among byte-range
 	// lock owners. Consulted by the blocking-LOCK async-park path before
 	// committing to wait, so a request whose grant would close a cycle is
@@ -679,6 +698,8 @@ func NewHandlerWithSessionManager(sessionManager *session.Manager) *Handler {
 		PipeReadRegistry:        NewPipeReadRegistry(),
 		PendingCreateRegistry:   NewPendingCreateRegistry(),
 		PendingLockRegistry:     NewPendingLockRegistry(),
+		CreateReplayCache:       NewCreateReplayCache(),
+		LockReplayCache:         NewLockReplayCache(),
 		LockWaitGraph:           lock.NewWaitForGraph(),
 		MaxTransactSize:         1048576, // 1MB (supports large directory listings; increases per-request memory)
 		MaxReadSize:             1048576, // 1MB
@@ -717,9 +738,15 @@ func (h *Handler) GetSession(sessionID uint64) (*session.Session, bool) {
 }
 
 // DeleteSession removes a session by ID.
-// This automatically cleans up credit tracking as well.
+// This automatically cleans up credit tracking as well, and
+// drops any cached SMB3 CREATE replay entries scoped to the
+// session so the cache footprint is freed promptly rather
+// than waiting on replayCacheTTL (MS-SMB2 §3.3.5.9).
 func (h *Handler) DeleteSession(sessionID uint64) {
 	h.SessionManager.DeleteSession(sessionID)
+	if h.CreateReplayCache != nil {
+		h.CreateReplayCache.ForgetSession(sessionID)
+	}
 }
 
 // GetTree retrieves a tree connection by ID
@@ -817,6 +844,15 @@ func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
 		v.(*handleOpTracker).wg.Wait()
 		h.handleOps.Delete(key)
 	}
+	if v, ok := h.files.Load(key); ok {
+		of := v.(*OpenFile)
+		if h.CreateReplayCache != nil && of.CreateGuid != ([16]byte{}) {
+			h.CreateReplayCache.Forget(of.CreateGuid)
+		}
+	}
+	if h.LockReplayCache != nil {
+		h.LockReplayCache.ForgetFile(fileID)
+	}
 	h.files.Delete(key)
 	h.resumeKeys.revoke(fileID)
 }
@@ -827,6 +863,15 @@ func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
 // tracker so trackers created by BeginHandleOp on this FileID do not leak.
 func (h *Handler) DeleteOpenFile(fileID [16]byte) {
 	key := string(fileID[:])
+	if v, ok := h.files.Load(key); ok {
+		of := v.(*OpenFile)
+		if h.CreateReplayCache != nil && of.CreateGuid != ([16]byte{}) {
+			h.CreateReplayCache.Forget(of.CreateGuid)
+		}
+	}
+	if h.LockReplayCache != nil {
+		h.LockReplayCache.ForgetFile(fileID)
+	}
 	h.files.Delete(key)
 	h.handleOps.Delete(key)
 	h.resumeKeys.revoke(fileID)

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -188,6 +188,49 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		"lockCount", req.LockCount,
 		"sessionID", ctx.SessionID)
 
+	// SMB3 LOCK replay protection (MS-SMB2 §3.3.5.14 step 4).
+	// LockSequence packs (Index << 28 | Number); when both are
+	// non-zero the client has opted into per-slot replay tracking.
+	// A second LOCK with FLAGS_REPLAY_OPERATION + matching
+	// (FileID, Index, Number) MUST return the cached status —
+	// otherwise an already-acquired lock retries and yields
+	// STATUS_LOCK_NOT_GRANTED, or an already-released lock retries
+	// and yields STATUS_RANGE_NOT_LOCKED (smbtorture
+	// smb2.lock.replay_*).
+	//
+	// Note: the cache is consulted even when FLAGS_REPLAY_OPERATION
+	// is NOT set, mirroring Samba `smb2_lock_recv` — clients legally
+	// re-use a slot number for the next distinct lock operation, so
+	// the cache stores per (Index, Number) pair, not just per slot.
+	var lockSeqIndex uint8
+	var lockSeqNumber uint32
+	var lockSeqEnabled bool
+	if h.LockReplayCache != nil {
+		lockSeqIndex, lockSeqNumber, lockSeqEnabled = UnpackLockSequence(req.LockSequence)
+		if lockSeqEnabled {
+			if cachedStatus, hit := h.LockReplayCache.Lookup(req.FileID, lockSeqIndex, lockSeqNumber); hit {
+				logger.Debug("LOCK: replay hit — returning cached status",
+					"fileID", fmt.Sprintf("%x", req.FileID),
+					"index", lockSeqIndex,
+					"number", lockSeqNumber,
+					"status", cachedStatus)
+				if cachedStatus != types.StatusSuccess {
+					return NewErrorResult(cachedStatus), nil
+				}
+				resp := &LockResponse{
+					SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+					StructureSize:   4,
+				}
+				respBytes, encErr := resp.Encode()
+				if encErr != nil {
+					logger.Error("LOCK: encode error on replay-hit success", "error", encErr)
+					return NewErrorResult(types.StatusInternalError), nil
+				}
+				return NewResult(types.StatusSuccess, respBytes), nil
+			}
+		}
+	}
+
 	// Get open file
 	openFile, ok := h.GetOpenFile(req.FileID)
 	if !ok {
@@ -539,6 +582,14 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	if err != nil {
 		logger.Error("LOCK: encode error", "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
+	}
+
+	// Record success in the LOCK replay cache so a subsequent
+	// FLAGS_REPLAY_OPERATION retry with the same (FileID, Index,
+	// Number) returns this status instead of re-running the
+	// acquire/release path (MS-SMB2 §3.3.5.14 step 4).
+	if lockSeqEnabled && h.LockReplayCache != nil {
+		h.LockReplayCache.Store(req.FileID, lockSeqIndex, lockSeqNumber, types.StatusSuccess)
 	}
 
 	return NewResult(types.StatusSuccess, respBytes), nil

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -188,20 +188,33 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		"lockCount", req.LockCount,
 		"sessionID", ctx.SessionID)
 
+	// Get open file
+	openFile, ok := h.GetOpenFile(req.FileID)
+	if !ok {
+		logger.Debug("LOCK: file handle not found (closed)", "fileID", fmt.Sprintf("%x", req.FileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+
 	// SMB3 LOCK replay protection (MS-SMB2 §3.3.5.14 step 4).
-	// LockSequence packs (Index << 28 | Number); a non-zero value
-	// means the client opted into per-slot replay tracking. A
-	// second LOCK with matching (FileID, Index, Number) MUST
-	// return the cached status — otherwise an already-acquired
-	// lock retries and yields STATUS_LOCK_NOT_GRANTED, or an
-	// already-released lock retries and yields STATUS_RANGE_NOT_LOCKED
-	// (smbtorture smb2.lock.replay_*).
+	// LockSequence packs (LockSequenceIndex << 4 | LockSequenceNumber)
+	// per MS-SMB2 §2.2.26 (low 4 bits = number, upper 28 bits = bucket).
 	//
-	// The cache is consulted even when FLAGS_REPLAY_OPERATION is
-	// NOT set, mirroring Samba `smb2_lock_recv` — clients legally
-	// re-use a slot number for the next distinct lock operation, so
-	// the cache keys on (Index, Number), not just slot.
+	// Per spec, the cache is consulted only when Open.IsResilient,
+	// Open.IsDurable or Open.IsPersistent is TRUE, or when the
+	// connection negotiated SMB2_GLOBAL_CAP_MULTI_CHANNEL. For all
+	// other opens the LockSequence field is ignored (mirrors Samba
+	// `smb2_lock_recv` `check_lock_sequence` gate). Without this gate
+	// a basic LOCK stacking client (smbtorture lock.valid-request)
+	// would observe its second same-sequence LOCK short-circuit out
+	// of stacking and a subsequent UNLOCK would fail RANGE_NOT_LOCKED.
+	checkLockSequence := openFile.IsDurable
+	if !checkLockSequence && ctx.ConnCryptoState != nil {
+		if ctx.ConnCryptoState.GetServerCapabilities()&types.CapMultiChannel != 0 {
+			checkLockSequence = true
+		}
+	}
 	lockSeqIndex, lockSeqNumber, lockSeqEnabled := UnpackLockSequence(req.LockSequence)
+	lockSeqEnabled = lockSeqEnabled && checkLockSequence
 	if lockSeqEnabled && h.LockReplayCache != nil {
 		if cachedStatus, hit := h.LockReplayCache.Lookup(req.FileID, lockSeqIndex, lockSeqNumber); hit {
 			logger.Debug("LOCK: replay hit — returning cached status",
@@ -222,13 +235,6 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			}
 			return NewResult(types.StatusSuccess, respBytes), nil
 		}
-	}
-
-	// Get open file
-	openFile, ok := h.GetOpenFile(req.FileID)
-	if !ok {
-		logger.Debug("LOCK: file handle not found (closed)", "fileID", fmt.Sprintf("%x", req.FileID))
-		return NewErrorResult(types.StatusFileClosed), nil
 	}
 
 	// Pipes don't support locking

--- a/internal/adapter/smb/v2/handlers/lock.go
+++ b/internal/adapter/smb/v2/handlers/lock.go
@@ -189,45 +189,38 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		"sessionID", ctx.SessionID)
 
 	// SMB3 LOCK replay protection (MS-SMB2 §3.3.5.14 step 4).
-	// LockSequence packs (Index << 28 | Number); when both are
-	// non-zero the client has opted into per-slot replay tracking.
-	// A second LOCK with FLAGS_REPLAY_OPERATION + matching
-	// (FileID, Index, Number) MUST return the cached status —
-	// otherwise an already-acquired lock retries and yields
-	// STATUS_LOCK_NOT_GRANTED, or an already-released lock retries
-	// and yields STATUS_RANGE_NOT_LOCKED (smbtorture
-	// smb2.lock.replay_*).
+	// LockSequence packs (Index << 28 | Number); a non-zero value
+	// means the client opted into per-slot replay tracking. A
+	// second LOCK with matching (FileID, Index, Number) MUST
+	// return the cached status — otherwise an already-acquired
+	// lock retries and yields STATUS_LOCK_NOT_GRANTED, or an
+	// already-released lock retries and yields STATUS_RANGE_NOT_LOCKED
+	// (smbtorture smb2.lock.replay_*).
 	//
-	// Note: the cache is consulted even when FLAGS_REPLAY_OPERATION
-	// is NOT set, mirroring Samba `smb2_lock_recv` — clients legally
+	// The cache is consulted even when FLAGS_REPLAY_OPERATION is
+	// NOT set, mirroring Samba `smb2_lock_recv` — clients legally
 	// re-use a slot number for the next distinct lock operation, so
-	// the cache stores per (Index, Number) pair, not just per slot.
-	var lockSeqIndex uint8
-	var lockSeqNumber uint32
-	var lockSeqEnabled bool
-	if h.LockReplayCache != nil {
-		lockSeqIndex, lockSeqNumber, lockSeqEnabled = UnpackLockSequence(req.LockSequence)
-		if lockSeqEnabled {
-			if cachedStatus, hit := h.LockReplayCache.Lookup(req.FileID, lockSeqIndex, lockSeqNumber); hit {
-				logger.Debug("LOCK: replay hit — returning cached status",
-					"fileID", fmt.Sprintf("%x", req.FileID),
-					"index", lockSeqIndex,
-					"number", lockSeqNumber,
-					"status", cachedStatus)
-				if cachedStatus != types.StatusSuccess {
-					return NewErrorResult(cachedStatus), nil
-				}
-				resp := &LockResponse{
-					SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
-					StructureSize:   4,
-				}
-				respBytes, encErr := resp.Encode()
-				if encErr != nil {
-					logger.Error("LOCK: encode error on replay-hit success", "error", encErr)
-					return NewErrorResult(types.StatusInternalError), nil
-				}
-				return NewResult(types.StatusSuccess, respBytes), nil
+	// the cache keys on (Index, Number), not just slot.
+	lockSeqIndex, lockSeqNumber, lockSeqEnabled := UnpackLockSequence(req.LockSequence)
+	if lockSeqEnabled && h.LockReplayCache != nil {
+		if cachedStatus, hit := h.LockReplayCache.Lookup(req.FileID, lockSeqIndex, lockSeqNumber); hit {
+			logger.Debug("LOCK: replay hit — returning cached status",
+				"fileID", fmt.Sprintf("%x", req.FileID),
+				"index", lockSeqIndex,
+				"number", lockSeqNumber,
+				"status", cachedStatus)
+			if cachedStatus != types.StatusSuccess {
+				return NewErrorResult(cachedStatus), nil
 			}
+			respBytes, encErr := (&LockResponse{
+				SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+				StructureSize:   4,
+			}).Encode()
+			if encErr != nil {
+				logger.Error("LOCK: encode error on replay-hit success", "error", encErr)
+				return NewErrorResult(types.StatusInternalError), nil
+			}
+			return NewResult(types.StatusSuccess, respBytes), nil
 		}
 	}
 
@@ -513,7 +506,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			if ctx.NextCommand == 0 && req.LockCount == 1 && len(acquiredLocks) == 0 &&
 				h.PendingLockRegistry != nil && ctx.AsyncLockCompleteCallback != nil &&
 				ctx.TryReserveAsync != nil && ctx.ReleaseAsync != nil {
-				if asyncId, parked := h.parkLockOnConflict(ctx, authCtx, openFile, fileLock); parked {
+				if asyncId, parked := h.parkLockOnConflict(ctx, authCtx, openFile, fileLock, req.FileID, lockSeqEnabled, lockSeqIndex, lockSeqNumber); parked {
 					return &HandlerResult{
 						Status:  types.StatusPending,
 						AsyncId: asyncId,

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -39,6 +39,10 @@ func (h *Handler) parkLockOnConflict(
 	authCtx *metadata.AuthContext,
 	openFile *OpenFile,
 	fileLock metadata.FileLock,
+	fileID [16]byte,
+	lockSeqEnabled bool,
+	lockSeqIndex uint8,
+	lockSeqNumber uint32,
 ) (uint64, bool) {
 	// Deadlock detection: probe the conflicting holder via TestLock and
 	// check the WFG. If granting our wait would close a cycle, refuse to
@@ -70,15 +74,19 @@ func (h *Handler) parkLockOnConflict(
 	waitCtx, cancel := context.WithTimeout(context.Background(), asyncBlockingLockTimeout)
 
 	pending := &PendingLock{
-		ConnID:    ctx.ConnID,
-		SessionID: ctx.SessionID,
-		TreeID:    ctx.TreeID,
-		MessageID: ctx.MessageID,
-		AsyncId:   asyncId,
-		OwnerID:   fileLock.OpenID,
-		Identity:  authCtx.Identity,
-		Cancel:    cancel,
-		Callback:  ctx.AsyncLockCompleteCallback,
+		ConnID:         ctx.ConnID,
+		SessionID:      ctx.SessionID,
+		TreeID:         ctx.TreeID,
+		MessageID:      ctx.MessageID,
+		AsyncId:        asyncId,
+		OwnerID:        fileLock.OpenID,
+		Identity:       authCtx.Identity,
+		Cancel:         cancel,
+		Callback:       ctx.AsyncLockCompleteCallback,
+		FileID:         fileID,
+		LockSeqEnabled: lockSeqEnabled,
+		LockSeqIndex:   lockSeqIndex,
+		LockSeqNumber:  lockSeqNumber,
 	}
 
 	if err := h.PendingLockRegistry.Register(pending); err != nil {
@@ -224,6 +232,14 @@ func (h *Handler) resumePendingLock(
 				// handler.go); this flag is the cheap path used by call-sites
 				// that don't have the meta service handy.
 				openFile.HasByteRangeLocks.Store(true)
+				// Record success in the LOCK replay cache so a subsequent
+				// FLAGS_REPLAY_OPERATION retry with the same
+				// (FileID, Index, Number) returns this status instead of
+				// re-running the acquire path (MS-SMB2 §3.3.5.14 step 4).
+				// Mirrors the sync success path in lock.go:Lock.
+				if pending.LockSeqEnabled && h.LockReplayCache != nil {
+					h.LockReplayCache.Store(pending.FileID, pending.LockSeqIndex, pending.LockSeqNumber, types.StatusSuccess)
+				}
 				goto deliver
 			}
 			var storeErr *metadata.StoreError

--- a/internal/adapter/smb/v2/handlers/lock_async.go
+++ b/internal/adapter/smb/v2/handlers/lock_async.go
@@ -41,8 +41,8 @@ func (h *Handler) parkLockOnConflict(
 	fileLock metadata.FileLock,
 	fileID [16]byte,
 	lockSeqEnabled bool,
-	lockSeqIndex uint8,
-	lockSeqNumber uint32,
+	lockSeqIndex uint32,
+	lockSeqNumber uint8,
 ) (uint64, bool) {
 	// Deadlock detection: probe the conflicting holder via TestLock and
 	// check the WFG. If granting our wait would close a cycle, refuse to

--- a/internal/adapter/smb/v2/handlers/pending_lock_registry.go
+++ b/internal/adapter/smb/v2/handlers/pending_lock_registry.go
@@ -57,6 +57,16 @@ type PendingLock struct {
 	// CANCEL / TDIS / LOGOFF (with StatusCancelled / StatusRangeNotLocked +
 	// nil body). Releases the async slot as part of its work.
 	Callback AsyncLockCompleteCallback
+
+	// SMB3 LOCK replay-cache coordinates. Carried so the resume goroutine
+	// can record success in LockReplayCache after a parked LOCK is finally
+	// granted — otherwise a FLAGS_REPLAY_OPERATION retry of the originally
+	// parked LOCK would re-execute the acquire path (MS-SMB2 §3.3.5.14
+	// step 4).
+	FileID         [16]byte
+	LockSeqEnabled bool
+	LockSeqIndex   uint8
+	LockSeqNumber  uint32
 }
 
 // PendingLockRegistry indexes pending blocking LOCKs by four keys:

--- a/internal/adapter/smb/v2/handlers/pending_lock_registry.go
+++ b/internal/adapter/smb/v2/handlers/pending_lock_registry.go
@@ -65,8 +65,8 @@ type PendingLock struct {
 	// step 4).
 	FileID         [16]byte
 	LockSeqEnabled bool
-	LockSeqIndex   uint8
-	LockSeqNumber  uint32
+	LockSeqIndex   uint32
+	LockSeqNumber  uint8
 }
 
 // PendingLockRegistry indexes pending blocking LOCKs by four keys:

--- a/internal/adapter/smb/v2/handlers/replay_cache.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache.go
@@ -49,18 +49,12 @@ const replayCacheTTL = 600 * time.Second
 // each store call.
 const maxCreateReplayEntries = 4096
 
-// createReplayKey identifies a cached CREATE response. CreateGuid is
-// client-generated and globally unique per durable open, so it is
-// sufficient on its own; SessionID is recorded for diagnostics and so
-// session teardown can flush related entries.
-type createReplayKey struct {
-	CreateGuid [16]byte
-}
-
 // CachedCreateResponse holds the materialised wire-level CREATE
 // response that should be returned on replay. We cache the full
 // CreateResponse (not just the encoded body) so the caller can still
-// access FileID for compound-chain FileID propagation.
+// access FileID for compound-chain FileID propagation. SessionID is
+// recorded so session teardown can flush related entries and so a
+// CreateGuid collision across sessions cannot hijack another open.
 type CachedCreateResponse struct {
 	SessionID uint64
 	Response  *CreateResponse
@@ -69,16 +63,17 @@ type CachedCreateResponse struct {
 
 // CreateReplayCache stores CREATE responses keyed by DH2Q CreateGuid
 // so a replayed CREATE (FLAGS_REPLAY_OPERATION) returns the original
-// result instead of re-executing.
+// result instead of re-executing. CreateGuid is client-generated and
+// globally unique per durable open, so it is sufficient as the key.
 type CreateReplayCache struct {
 	mu      sync.Mutex
-	entries map[createReplayKey]*CachedCreateResponse
+	entries map[[16]byte]*CachedCreateResponse
 }
 
 // NewCreateReplayCache builds an empty cache.
 func NewCreateReplayCache() *CreateReplayCache {
 	return &CreateReplayCache{
-		entries: make(map[createReplayKey]*CachedCreateResponse),
+		entries: make(map[[16]byte]*CachedCreateResponse),
 	}
 }
 
@@ -87,16 +82,13 @@ func NewCreateReplayCache() *CreateReplayCache {
 // CREATE should run through the normal handler path and may even
 // succeed the second time.
 func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *CreateResponse) {
-	if createGuid == ([16]byte{}) || resp == nil {
-		return
-	}
-	if resp.Status != types.StatusSuccess {
+	if createGuid == ([16]byte{}) || resp == nil || resp.Status != types.StatusSuccess {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pruneLocked()
-	c.entries[createReplayKey{CreateGuid: createGuid}] = &CachedCreateResponse{
+	c.entries[createGuid] = &CachedCreateResponse{
 		SessionID: sessionID,
 		Response:  resp,
 		StoredAt:  time.Now(),
@@ -113,15 +105,12 @@ func (c *CreateReplayCache) Lookup(sessionID uint64, createGuid [16]byte) *Creat
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	entry, ok := c.entries[createReplayKey{CreateGuid: createGuid}]
-	if !ok {
-		return nil
-	}
-	if entry.SessionID != sessionID {
+	entry, ok := c.entries[createGuid]
+	if !ok || entry.SessionID != sessionID {
 		return nil
 	}
 	if time.Since(entry.StoredAt) > replayCacheTTL {
-		delete(c.entries, createReplayKey{CreateGuid: createGuid})
+		delete(c.entries, createGuid)
 		return nil
 	}
 	return entry.Response
@@ -136,7 +125,7 @@ func (c *CreateReplayCache) Forget(createGuid [16]byte) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.entries, createReplayKey{CreateGuid: createGuid})
+	delete(c.entries, createGuid)
 }
 
 // ForgetSession drops all entries for the given session. Called by
@@ -173,7 +162,7 @@ func (c *CreateReplayCache) pruneLocked() {
 		return
 	}
 	// Over-cap: drop oldest. Linear scan since the cap is small.
-	var oldestKey createReplayKey
+	var oldestKey [16]byte
 	var oldestAt time.Time
 	for k, e := range c.entries {
 		if oldestAt.IsZero() || e.StoredAt.Before(oldestAt) {

--- a/internal/adapter/smb/v2/handlers/replay_cache.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache.go
@@ -177,27 +177,27 @@ func (c *CreateReplayCache) pruneLocked() {
 // LOCK replay protection (MS-SMB2 §3.3.5.14)
 // ============================================================================
 
-// LockSequenceIndexMax bounds the 4-bit LockSequenceIndex field in
-// the SMB2_LOCK request LockSequence packed value (MS-SMB2 §2.2.26).
-// A client may have at most 16 outstanding LockSequence slots per
-// open; the server remembers the most-recent number stored in each
-// slot so a retransmission with the same (Index, Number) returns the
-// cached status.
-const LockSequenceIndexMax = 16
+// LockSequenceIndexMax bounds the 28-bit LockSequenceIndex (bucket)
+// in the SMB2_LOCK request LockSequence packed value (MS-SMB2
+// §2.2.26). Samba caps the array at 64 buckets
+// (`SMB2_LOCK_SEQUENCE_ARRAY_SIZE`); we mirror that to avoid an
+// unbounded per-open footprint when a client picks large bucket
+// numbers. Indices outside [1, LockSequenceIndexMax] are not tracked.
+const LockSequenceIndexMax uint32 = 64
 
 // CachedLockResponse holds the last LockSequenceNumber stored at a
-// given (FileID, Index) slot together with the status returned for
+// given (FileID, Index) bucket together with the status returned for
 // that request. On replay with matching number, the server returns
 // Status verbatim (MS-SMB2 §3.3.5.14 step 4).
 type CachedLockResponse struct {
-	Number uint32
+	Number uint8
 	Status types.Status
 }
 
-// lockReplayKey indexes the LOCK replay cache by FileID + slot.
+// lockReplayKey indexes the LOCK replay cache by FileID + bucket.
 type lockReplayKey struct {
 	FileID [16]byte
-	Index  uint8
+	Index  uint32
 }
 
 // LockReplayCache stores the last (LockSequenceNumber, status) pair
@@ -214,24 +214,24 @@ func NewLockReplayCache() *LockReplayCache {
 }
 
 // UnpackLockSequence extracts (index, number) from the packed
-// LockSequence field per MS-SMB2 §2.2.26: high 4 bits = Index,
-// low 28 bits = Number. A LockSequence value of zero means
-// "client opts out of replay" (Samba `lock_sequence_value == 0`).
-func UnpackLockSequence(packed uint32) (index uint8, number uint32, enabled bool) {
-	if packed == 0 {
-		return 0, 0, false
-	}
-	index = uint8((packed >> 28) & 0xF)
-	number = packed & 0x0FFFFFFF
-	return index, number, true
+// LockSequence field per MS-SMB2 §2.2.26: low 4 bits =
+// LockSequenceNumber (the byte stored in the slot), upper 28 bits =
+// LockSequenceIndex (the slot/bucket number, 1-based; 0 = "not
+// tracked"). Mirrors Samba `smb2_lock_recv`: `value = in & 0xF`,
+// `bucket = in >> 4`, replay tracked only when `bucket > 0`.
+func UnpackLockSequence(packed uint32) (index uint32, number uint8, enabled bool) {
+	number = uint8(packed & 0xF)
+	index = packed >> 4
+	enabled = index > 0
+	return index, number, enabled
 }
 
-// Lookup returns the cached status if the slot already holds the
+// Lookup returns the cached status if the bucket already holds the
 // same LockSequenceNumber. Caller passes the unpacked (index, number).
 // Returns ok=false when no match: the LOCK should execute normally
 // and the result stored via Store.
-func (c *LockReplayCache) Lookup(fileID [16]byte, index uint8, number uint32) (types.Status, bool) {
-	if index >= LockSequenceIndexMax {
+func (c *LockReplayCache) Lookup(fileID [16]byte, index uint32, number uint8) (types.Status, bool) {
+	if index == 0 || index > LockSequenceIndexMax {
 		return 0, false
 	}
 	c.mu.RLock()
@@ -246,11 +246,11 @@ func (c *LockReplayCache) Lookup(fileID [16]byte, index uint8, number uint32) (t
 	return entry.Status, true
 }
 
-// Store records the (Number, Status) pair for the given slot.
-// Subsequent calls with a different Number for the same slot
-// overwrite — the slot tracks the LATEST sequence, not history.
-func (c *LockReplayCache) Store(fileID [16]byte, index uint8, number uint32, status types.Status) {
-	if index >= LockSequenceIndexMax {
+// Store records the (Number, Status) pair for the given bucket.
+// Subsequent calls with a different Number for the same bucket
+// overwrite — the bucket tracks the LATEST sequence, not history.
+func (c *LockReplayCache) Store(fileID [16]byte, index uint32, number uint8, status types.Status) {
+	if index == 0 || index > LockSequenceIndexMax {
 		return
 	}
 	c.mu.Lock()
@@ -261,13 +261,15 @@ func (c *LockReplayCache) Store(fileID [16]byte, index uint8, number uint32, sta
 	}
 }
 
-// ForgetFile drops all 16 slots for the given FileID. Called by
+// ForgetFile drops all buckets for the given FileID. Called by
 // CLOSE so the cache footprint is freed with the handle.
 func (c *LockReplayCache) ForgetFile(fileID [16]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for i := uint8(0); i < LockSequenceIndexMax; i++ {
-		delete(c.entries, lockReplayKey{FileID: fileID, Index: i})
+	for k := range c.entries {
+		if k.FileID == fileID {
+			delete(c.entries, k)
+		}
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/replay_cache.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache.go
@@ -1,0 +1,290 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// SMB3 replay protection (MS-SMB2 §3.3.5.2.5, §3.3.5.9).
+//
+// When a client retransmits a request whose response was lost (e.g., the
+// channel carrying the response failed before delivery), it MAY set
+// SMB2_FLAGS_REPLAY_OPERATION on the retried header. The server must
+// recognise this and return the previously-computed result for the
+// original request instead of executing it fresh — otherwise an idempotent
+// CREATE that already established the open trips STATUS_SHARING_VIOLATION
+// on the replay, and a LOCK that was already acquired trips
+// STATUS_LOCK_NOT_GRANTED.
+//
+// Two replay caches are needed:
+//
+//  1. CREATE replay-cache, keyed by SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2
+//     CreateGuid. The cache holds the cached CREATE response (raw body +
+//     status + FileID) for a short window after a successful V2 CREATE.
+//     A second CREATE with the same CreateGuid and FLAGS_REPLAY_OPERATION
+//     returns the cached response.
+//
+//  2. LOCK replay-cache, keyed by (FileID, LockSequenceIndex) and
+//     remembering the last LockSequenceNumber accepted for that slot.
+//     LockSequence is a packed 32-bit field on the SMB2_LOCK request:
+//     high 4 bits hold the index (0–15), low 28 bits the sequence number.
+//     On a replay with the same (FileID, Index, Number), the server
+//     returns the cached status.
+//
+// The caches are intentionally small and bounded by an eviction TTL —
+// they cover the narrow "response in flight died" window, not long-term
+// session state. A miss falls through to the normal handler path; the
+// caller is responsible for storing a fresh entry on success.
+
+// replayCacheTTL bounds how long a CREATE replay cache entry stays
+// valid after the original response was generated. Samba uses a
+// 600-second window (`source3/smbd/smb2_create.c:replay_cache_purge`).
+// We mirror that here so the test client's retry window aligns.
+const replayCacheTTL = 600 * time.Second
+
+// maxCreateReplayEntries caps the CREATE replay cache so a misbehaving
+// client cannot grow it unbounded. Old entries are pruned lazily on
+// each store call.
+const maxCreateReplayEntries = 4096
+
+// createReplayKey identifies a cached CREATE response. CreateGuid is
+// client-generated and globally unique per durable open, so it is
+// sufficient on its own; SessionID is recorded for diagnostics and so
+// session teardown can flush related entries.
+type createReplayKey struct {
+	CreateGuid [16]byte
+}
+
+// CachedCreateResponse holds the materialised wire-level CREATE
+// response that should be returned on replay. We cache the full
+// CreateResponse (not just the encoded body) so the caller can still
+// access FileID for compound-chain FileID propagation.
+type CachedCreateResponse struct {
+	SessionID uint64
+	Response  *CreateResponse
+	StoredAt  time.Time
+}
+
+// CreateReplayCache stores CREATE responses keyed by DH2Q CreateGuid
+// so a replayed CREATE (FLAGS_REPLAY_OPERATION) returns the original
+// result instead of re-executing.
+type CreateReplayCache struct {
+	mu      sync.Mutex
+	entries map[createReplayKey]*CachedCreateResponse
+}
+
+// NewCreateReplayCache builds an empty cache.
+func NewCreateReplayCache() *CreateReplayCache {
+	return &CreateReplayCache{
+		entries: make(map[createReplayKey]*CachedCreateResponse),
+	}
+}
+
+// Store records the response for a successful V2 CREATE keyed by
+// CreateGuid. Only success responses are cached — a replayed failed
+// CREATE should run through the normal handler path and may even
+// succeed the second time.
+func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *CreateResponse) {
+	if createGuid == ([16]byte{}) || resp == nil {
+		return
+	}
+	if resp.Status != types.StatusSuccess {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneLocked()
+	c.entries[createReplayKey{CreateGuid: createGuid}] = &CachedCreateResponse{
+		SessionID: sessionID,
+		Response:  resp,
+		StoredAt:  time.Now(),
+	}
+}
+
+// Lookup returns the cached response if one exists for the given
+// CreateGuid + session and has not expired. Replay is scoped per
+// session — a different session's CreateGuid collision (vanishingly
+// unlikely but possible) must not hijack another session's open.
+func (c *CreateReplayCache) Lookup(sessionID uint64, createGuid [16]byte) *CreateResponse {
+	if createGuid == ([16]byte{}) {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[createReplayKey{CreateGuid: createGuid}]
+	if !ok {
+		return nil
+	}
+	if entry.SessionID != sessionID {
+		return nil
+	}
+	if time.Since(entry.StoredAt) > replayCacheTTL {
+		delete(c.entries, createReplayKey{CreateGuid: createGuid})
+		return nil
+	}
+	return entry.Response
+}
+
+// Forget drops the cached entry for CreateGuid. Called when the open
+// is closed cleanly — the cache window is only meaningful while a
+// retry could still arrive.
+func (c *CreateReplayCache) Forget(createGuid [16]byte) {
+	if createGuid == ([16]byte{}) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, createReplayKey{CreateGuid: createGuid})
+}
+
+// ForgetSession drops all entries for the given session. Called by
+// session teardown so a long-lived ServerGUID-stable replay cache
+// does not survive logoff.
+func (c *CreateReplayCache) ForgetSession(sessionID uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, e := range c.entries {
+		if e.SessionID == sessionID {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// Len returns the number of cached entries (test / metrics).
+func (c *CreateReplayCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// pruneLocked evicts expired entries and, if the cap is still
+// exceeded, drops oldest-first until under the cap. Cheap because
+// the cache is bounded small.
+func (c *CreateReplayCache) pruneLocked() {
+	now := time.Now()
+	for k, e := range c.entries {
+		if now.Sub(e.StoredAt) > replayCacheTTL {
+			delete(c.entries, k)
+		}
+	}
+	if len(c.entries) < maxCreateReplayEntries {
+		return
+	}
+	// Over-cap: drop oldest. Linear scan since the cap is small.
+	var oldestKey createReplayKey
+	var oldestAt time.Time
+	for k, e := range c.entries {
+		if oldestAt.IsZero() || e.StoredAt.Before(oldestAt) {
+			oldestAt = e.StoredAt
+			oldestKey = k
+		}
+	}
+	delete(c.entries, oldestKey)
+}
+
+// ============================================================================
+// LOCK replay protection (MS-SMB2 §3.3.5.14)
+// ============================================================================
+
+// LockSequenceIndexMax bounds the 4-bit LockSequenceIndex field in
+// the SMB2_LOCK request LockSequence packed value (MS-SMB2 §2.2.26).
+// A client may have at most 16 outstanding LockSequence slots per
+// open; the server remembers the most-recent number stored in each
+// slot so a retransmission with the same (Index, Number) returns the
+// cached status.
+const LockSequenceIndexMax = 16
+
+// CachedLockResponse holds the last LockSequenceNumber stored at a
+// given (FileID, Index) slot together with the status returned for
+// that request. On replay with matching number, the server returns
+// Status verbatim (MS-SMB2 §3.3.5.14 step 4).
+type CachedLockResponse struct {
+	Number uint32
+	Status types.Status
+}
+
+// lockReplayKey indexes the LOCK replay cache by FileID + slot.
+type lockReplayKey struct {
+	FileID [16]byte
+	Index  uint8
+}
+
+// LockReplayCache stores the last (LockSequenceNumber, status) pair
+// per (FileID, LockSequenceIndex). Bounded implicitly by the per-open
+// 16-slot cap × max concurrent opens.
+type LockReplayCache struct {
+	mu      sync.RWMutex
+	entries map[lockReplayKey]CachedLockResponse
+}
+
+// NewLockReplayCache builds an empty cache.
+func NewLockReplayCache() *LockReplayCache {
+	return &LockReplayCache{entries: make(map[lockReplayKey]CachedLockResponse)}
+}
+
+// UnpackLockSequence extracts (index, number) from the packed
+// LockSequence field per MS-SMB2 §2.2.26: high 4 bits = Index,
+// low 28 bits = Number. A LockSequence value of zero means
+// "client opts out of replay" (Samba `lock_sequence_value == 0`).
+func UnpackLockSequence(packed uint32) (index uint8, number uint32, enabled bool) {
+	if packed == 0 {
+		return 0, 0, false
+	}
+	index = uint8((packed >> 28) & 0xF)
+	number = packed & 0x0FFFFFFF
+	return index, number, true
+}
+
+// Lookup returns the cached status if the slot already holds the
+// same LockSequenceNumber. Caller passes the unpacked (index, number).
+// Returns ok=false when no match: the LOCK should execute normally
+// and the result stored via Store.
+func (c *LockReplayCache) Lookup(fileID [16]byte, index uint8, number uint32) (types.Status, bool) {
+	if index >= LockSequenceIndexMax {
+		return 0, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[lockReplayKey{FileID: fileID, Index: index}]
+	if !ok {
+		return 0, false
+	}
+	if entry.Number != number {
+		return 0, false
+	}
+	return entry.Status, true
+}
+
+// Store records the (Number, Status) pair for the given slot.
+// Subsequent calls with a different Number for the same slot
+// overwrite — the slot tracks the LATEST sequence, not history.
+func (c *LockReplayCache) Store(fileID [16]byte, index uint8, number uint32, status types.Status) {
+	if index >= LockSequenceIndexMax {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[lockReplayKey{FileID: fileID, Index: index}] = CachedLockResponse{
+		Number: number,
+		Status: status,
+	}
+}
+
+// ForgetFile drops all 16 slots for the given FileID. Called by
+// CLOSE so the cache footprint is freed with the handle.
+func (c *LockReplayCache) ForgetFile(fileID [16]byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := uint8(0); i < LockSequenceIndexMax; i++ {
+		delete(c.entries, lockReplayKey{FileID: fileID, Index: i})
+	}
+}
+
+// Len returns the number of cached entries (test / metrics).
+func (c *LockReplayCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/internal/adapter/smb/v2/handlers/replay_cache_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache_test.go
@@ -53,9 +53,7 @@ func TestCreateReplayCache_TTLExpiry(t *testing.T) {
 	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
 	// Force expiry by rewriting StoredAt
 	c.mu.Lock()
-	e := c.entries[createReplayKey{CreateGuid: guid}]
-	e.StoredAt = time.Now().Add(-2 * replayCacheTTL)
-	c.entries[createReplayKey{CreateGuid: guid}] = e
+	c.entries[guid].StoredAt = time.Now().Add(-2 * replayCacheTTL)
 	c.mu.Unlock()
 	if c.Lookup(1, guid) != nil {
 		t.Fatal("expired entry must miss")

--- a/internal/adapter/smb/v2/handlers/replay_cache_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache_test.go
@@ -85,17 +85,20 @@ func TestCreateReplayCache_ForgetSession(t *testing.T) {
 }
 
 func TestUnpackLockSequence(t *testing.T) {
+	// Layout per MS-SMB2 §2.2.26 / Samba: low 4 bits = number,
+	// upper 28 bits = bucket index. Bucket 0 → "not tracked".
 	cases := []struct {
 		packed     uint32
-		wantIndex  uint8
-		wantNumber uint32
+		wantIndex  uint32
+		wantNumber uint8
 		wantOK     bool
 	}{
 		{0, 0, 0, false},
-		{0x1000_0001, 1, 1, true},
-		{0xF000_0000, 15, 0, true},
-		{0xF0FF_FFFF, 15, 0x00FF_FFFF, true},
-		{0x0FFF_FFFF, 0, 0x0FFF_FFFF, true},
+		{0x0000_0001, 0, 1, false},         // bucket=0 → disabled
+		{0x0000_0010, 1, 0, true},          // bucket=1, value=0
+		{0x12345678, 0x1234567, 0x8, true}, // smbtorture valid-request value
+		{0xFFFF_FFFF, 0x0FFF_FFFF, 0xF, true},
+		{0x0000_001F, 1, 0xF, true},
 	}
 	for _, tc := range cases {
 		idx, num, ok := UnpackLockSequence(tc.packed)
@@ -127,12 +130,20 @@ func TestLockReplayCache_MissDifferentNumber(t *testing.T) {
 func TestLockReplayCache_IndexBoundsRejected(t *testing.T) {
 	c := NewLockReplayCache()
 	fid := [16]byte{0xCC}
-	c.Store(fid, LockSequenceIndexMax, 1, types.StatusSuccess)
+	// Bucket 0 is "not tracked"; bucket > LockSequenceIndexMax is out of range.
+	c.Store(fid, 0, 1, types.StatusSuccess)
 	if c.Len() != 0 {
-		t.Fatal("Store with out-of-range index must be ignored")
+		t.Fatal("Store with bucket=0 must be ignored")
 	}
-	if _, ok := c.Lookup(fid, LockSequenceIndexMax, 1); ok {
-		t.Fatal("Lookup with out-of-range index must miss")
+	c.Store(fid, LockSequenceIndexMax+1, 1, types.StatusSuccess)
+	if c.Len() != 0 {
+		t.Fatal("Store with out-of-range bucket must be ignored")
+	}
+	if _, ok := c.Lookup(fid, 0, 1); ok {
+		t.Fatal("Lookup with bucket=0 must miss")
+	}
+	if _, ok := c.Lookup(fid, LockSequenceIndexMax+1, 1); ok {
+		t.Fatal("Lookup with out-of-range bucket must miss")
 	}
 }
 
@@ -140,17 +151,17 @@ func TestLockReplayCache_ForgetFile(t *testing.T) {
 	c := NewLockReplayCache()
 	fid1 := [16]byte{1}
 	fid2 := [16]byte{2}
-	c.Store(fid1, 0, 1, types.StatusSuccess)
+	c.Store(fid1, 1, 1, types.StatusSuccess)
 	c.Store(fid1, 5, 9, types.StatusSuccess)
-	c.Store(fid2, 0, 1, types.StatusSuccess)
+	c.Store(fid2, 1, 1, types.StatusSuccess)
 	c.ForgetFile(fid1)
-	if _, ok := c.Lookup(fid1, 0, 1); ok {
-		t.Fatal("ForgetFile must drop entries for fid1 slot 0")
+	if _, ok := c.Lookup(fid1, 1, 1); ok {
+		t.Fatal("ForgetFile must drop entries for fid1 bucket 1")
 	}
 	if _, ok := c.Lookup(fid1, 5, 9); ok {
-		t.Fatal("ForgetFile must drop entries for fid1 slot 5")
+		t.Fatal("ForgetFile must drop entries for fid1 bucket 5")
 	}
-	if _, ok := c.Lookup(fid2, 0, 1); !ok {
+	if _, ok := c.Lookup(fid2, 1, 1); !ok {
 		t.Fatal("ForgetFile must not touch fid2")
 	}
 }

--- a/internal/adapter/smb/v2/handlers/replay_cache_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+func TestCreateReplayCache_StoreLookup(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{1, 2, 3, 4}
+	resp := &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}
+	c.Store(42, guid, resp)
+	if got := c.Lookup(42, guid); got != resp {
+		t.Fatalf("Lookup returned %v, want %v", got, resp)
+	}
+}
+
+func TestCreateReplayCache_LookupWrongSession(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{1}
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	if c.Lookup(2, guid) != nil {
+		t.Fatal("Lookup across sessions must miss")
+	}
+}
+
+func TestCreateReplayCache_ZeroGuidIgnored(t *testing.T) {
+	c := NewCreateReplayCache()
+	zero := [16]byte{}
+	c.Store(1, zero, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	if c.Len() != 0 {
+		t.Fatal("zero CreateGuid must not be stored")
+	}
+	if c.Lookup(1, zero) != nil {
+		t.Fatal("zero CreateGuid must not be looked up")
+	}
+}
+
+func TestCreateReplayCache_NonSuccessNotCached(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{7}
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}})
+	if c.Len() != 0 {
+		t.Fatal("non-success response must not be cached")
+	}
+}
+
+func TestCreateReplayCache_TTLExpiry(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{9}
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	// Force expiry by rewriting StoredAt
+	c.mu.Lock()
+	e := c.entries[createReplayKey{CreateGuid: guid}]
+	e.StoredAt = time.Now().Add(-2 * replayCacheTTL)
+	c.entries[createReplayKey{CreateGuid: guid}] = e
+	c.mu.Unlock()
+	if c.Lookup(1, guid) != nil {
+		t.Fatal("expired entry must miss")
+	}
+}
+
+func TestCreateReplayCache_Forget(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{3}
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Forget(guid)
+	if c.Len() != 0 {
+		t.Fatal("Forget must drop entry")
+	}
+}
+
+func TestCreateReplayCache_ForgetSession(t *testing.T) {
+	c := NewCreateReplayCache()
+	g1, g2 := [16]byte{1}, [16]byte{2}
+	c.Store(10, g1, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(20, g2, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.ForgetSession(10)
+	if c.Lookup(10, g1) != nil {
+		t.Fatal("ForgetSession should drop session 10 entry")
+	}
+	if c.Lookup(20, g2) == nil {
+		t.Fatal("ForgetSession should leave other session entries")
+	}
+}
+
+func TestUnpackLockSequence(t *testing.T) {
+	cases := []struct {
+		packed     uint32
+		wantIndex  uint8
+		wantNumber uint32
+		wantOK     bool
+	}{
+		{0, 0, 0, false},
+		{0x1000_0001, 1, 1, true},
+		{0xF000_0000, 15, 0, true},
+		{0xF0FF_FFFF, 15, 0x00FF_FFFF, true},
+		{0x0FFF_FFFF, 0, 0x0FFF_FFFF, true},
+	}
+	for _, tc := range cases {
+		idx, num, ok := UnpackLockSequence(tc.packed)
+		if idx != tc.wantIndex || num != tc.wantNumber || ok != tc.wantOK {
+			t.Errorf("UnpackLockSequence(%#x) = (%d, %d, %v), want (%d, %d, %v)",
+				tc.packed, idx, num, ok, tc.wantIndex, tc.wantNumber, tc.wantOK)
+		}
+	}
+}
+
+func TestLockReplayCache_StoreLookup(t *testing.T) {
+	c := NewLockReplayCache()
+	fid := [16]byte{0xAA}
+	c.Store(fid, 3, 7, types.StatusSuccess)
+	if st, ok := c.Lookup(fid, 3, 7); !ok || st != types.StatusSuccess {
+		t.Fatalf("Lookup = (%v, %v), want (StatusSuccess, true)", st, ok)
+	}
+}
+
+func TestLockReplayCache_MissDifferentNumber(t *testing.T) {
+	c := NewLockReplayCache()
+	fid := [16]byte{0xBB}
+	c.Store(fid, 1, 5, types.StatusSuccess)
+	if _, ok := c.Lookup(fid, 1, 6); ok {
+		t.Fatal("Lookup with different Number must miss")
+	}
+}
+
+func TestLockReplayCache_IndexBoundsRejected(t *testing.T) {
+	c := NewLockReplayCache()
+	fid := [16]byte{0xCC}
+	c.Store(fid, LockSequenceIndexMax, 1, types.StatusSuccess)
+	if c.Len() != 0 {
+		t.Fatal("Store with out-of-range index must be ignored")
+	}
+	if _, ok := c.Lookup(fid, LockSequenceIndexMax, 1); ok {
+		t.Fatal("Lookup with out-of-range index must miss")
+	}
+}
+
+func TestLockReplayCache_ForgetFile(t *testing.T) {
+	c := NewLockReplayCache()
+	fid1 := [16]byte{1}
+	fid2 := [16]byte{2}
+	c.Store(fid1, 0, 1, types.StatusSuccess)
+	c.Store(fid1, 5, 9, types.StatusSuccess)
+	c.Store(fid2, 0, 1, types.StatusSuccess)
+	c.ForgetFile(fid1)
+	if _, ok := c.Lookup(fid1, 0, 1); ok {
+		t.Fatal("ForgetFile must drop entries for fid1 slot 0")
+	}
+	if _, ok := c.Lookup(fid1, 5, 9); ok {
+		t.Fatal("ForgetFile must drop entries for fid1 slot 5")
+	}
+	if _, ok := c.Lookup(fid2, 0, 1); !ok {
+		t.Fatal("ForgetFile must not touch fid2")
+	}
+}
+
+func TestLockReplayCache_OverwriteUpdatesNumber(t *testing.T) {
+	c := NewLockReplayCache()
+	fid := [16]byte{0xDD}
+	c.Store(fid, 2, 10, types.StatusSuccess)
+	c.Store(fid, 2, 11, types.StatusLockNotGranted)
+	if _, ok := c.Lookup(fid, 2, 10); ok {
+		t.Fatal("Lookup with previous Number must miss after overwrite")
+	}
+	st, ok := c.Lookup(fid, 2, 11)
+	if !ok || st != types.StatusLockNotGranted {
+		t.Fatalf("Lookup = (%v, %v), want (StatusLockNotGranted, true)", st, ok)
+	}
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -421,10 +421,7 @@ requests with durable handles. Newly reachable after GMAC signing fix.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.replay.replay3 | Replay | Flaky in CI (replay detection race) | - |
-| smb2.replay.replay-commands | Replay | Replay detection not implemented | - |
-| smb2.replay.replay-dhv2-oplock1 | Replay | Replay with durable handles not implemented | - |
 | smb2.replay.replay-dhv2-oplock2 | Replay | Replay with durable handles not implemented | - |
-| smb2.replay.replay-dhv2-oplock3 | Replay | Replay with durable handles not implemented | - |
 | smb2.replay.replay-dhv2-oplock-lease | Replay | Replay with durable handles not implemented | - |
 | smb2.replay.replay-dhv2-lease1 | Replay | Replay with durable handles not implemented | - |
 | smb2.replay.replay-dhv2-lease2 | Replay | Replay with durable handles not implemented | - |


### PR DESCRIPTION
Closes #482

## Summary

Server-side SMB3 replay handling for idempotent retries per
MS-SMB2 §3.3.5.2.5, §3.3.5.9, §3.3.5.14. When a client sets
`SMB2_FLAGS_REPLAY_OPERATION` on a retransmission whose original
response was lost (channel failure, response window missed), the
server returns the cached result instead of re-executing — without
this, the legitimate retry trips `STATUS_SHARING_VIOLATION` on
CREATE or `STATUS_LOCK_NOT_GRANTED` / `STATUS_RANGE_NOT_LOCKED` on
LOCK.

Two bounded per-session caches:

- **`CreateReplayCache`** — keyed by DH2Q `CreateGuid`, TTL 600s
  (Samba parity), capped at 4096 entries. Populated on successful
  V2 CREATE; consulted at the top of `Create()` when `IsReplay` is
  set. Dropped on `CLOSE` and on `SESSION_LOGOFF`.
- **`LockReplayCache`** — keyed by (FileID, LockSequenceIndex),
  stores (LockSequenceNumber, status) per slot per MS-SMB2 §2.2.26.
  Consulted on every LOCK with non-zero `LockSequence` (mirroring
  Samba `smb2_lock_recv`), since clients reuse slot numbers across
  distinct LOCK ops. Dropped on `CLOSE`.

Header layer exposes `IsReplay()` + `ChannelSequence()` helpers and
`prepareDispatch` threads them onto `SMBHandlerContext`.

## Test plan

Locally:

- [x] `go build ./...`
- [x] `go test -race ./internal/adapter/smb/... ./pkg/metadata/lock/...`
- [x] `golangci-lint run --timeout=5m`
- [x] `smbtorture --filter smb2.replay` — 3 new PASS (see flips below)
- [x] `smbtorture --filter smb2.lock` — no regressions

## Flips

Three previously-known failures walked back from `KNOWN_FAILURES.md`:

- `smb2.replay.replay-commands`
- `smb2.replay.replay-dhv2-oplock1`
- `smb2.replay.replay-dhv2-oplock3`

Remaining `smb2.replay.replay-dhv2-*` and `smb2.replay.dhv2-pending*`
failures stay on `KNOWN_FAILURES.md` — they exercise replay paths
that additionally depend on durable-handle persistence and
lease/oplock pending-violation semantics not covered by this PR.