### PR TITLE
fix(smb/session): per-algo signing+encryption negotiation (#717)

### DIFF
--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -142,6 +142,15 @@ var _ session.ChannelTransport = (*ConnInfo)(nil)
 type SessionTracker interface {
 	TrackSession(sessionID uint64)
 	UntrackSession(sessionID uint64)
+
+	// AnyTrackedSession returns one of the session IDs currently tracked on
+	// this connection (zero if none). Used by SendErrorResponse for the
+	// wrong-SessionId path so a STATUS_USER_SESSION_DELETED reply can still
+	// be signed with a valid session's key — per Samba
+	// source3/smbd/smb2_server.c::smbd_smb2_request_dispatch, "fallback to
+	// a session of another process in order to get the signing correct"
+	// (MS-SMB2 §3.2.5.1.4 / smbtorture smb2.session-id).
+	AnyTrackedSession() uint64
 }
 
 // NewSequenceWindowForConnection creates a CommandSequenceWindow sized for the

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -13,6 +13,14 @@ import (
 // relying on string matching.
 var ErrDecryptFailed = errors.New("SMB3 decryption failed")
 
+// ErrUnknownSession is a sentinel error indicating that a transform-header
+// message was received for a SessionId not present in the session table.
+// Returned wrapped together with ErrDecryptFailed so existing error-matching
+// continues to work; callers can use errors.Is to branch on this distinct
+// case and synthesize a plaintext STATUS_USER_SESSION_DELETED response
+// (MS-SMB2 §3.3.5.2.7) instead of silently dropping the message.
+var ErrUnknownSession = errors.New("encrypted message for unknown session")
+
 // EncryptableSession is the minimal interface for a session that supports encryption.
 // This decouples the middleware from the full session.Session type to avoid circular imports.
 type EncryptableSession interface {
@@ -75,7 +83,13 @@ func (m *sessionEncryptionMiddleware) DecryptRequest(transformMessage []byte) ([
 
 	sess, ok := m.sessionLookup(th.SessionId)
 	if !ok {
-		return nil, 0, fmt.Errorf("session 0x%x not found for decryption: %w", th.SessionId, ErrDecryptFailed)
+		// Return th.SessionId so the caller can build a synthetic
+		// STATUS_USER_SESSION_DELETED plaintext reply. This is the common
+		// race when a parallel connection has previously-session-IDed
+		// the session via SESSION_SETUP.PreviousSessionId (reconnect1,
+		// MS-SMB2 §3.3.5.5.1).
+		return nil, th.SessionId, fmt.Errorf("session 0x%x not found for decryption: %w: %w",
+			th.SessionId, ErrUnknownSession, ErrDecryptFailed)
 	}
 
 	// Extract encrypted data (everything after the 52-byte transform header)

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -3,6 +3,7 @@ package smb
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,15 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/v2/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// ErrUnknownEncryptedSession is returned by ReadRequest when an encrypted
+// transform-header message references a SessionId the server does not know.
+// The connection loop uses errors.Is to detect this and send a plaintext
+// STATUS_USER_SESSION_DELETED response via the synthesized SMB2 header that
+// is also returned. Without this sentinel the caller can't distinguish a
+// recoverable post-LOGOFF race from a genuine AEAD authentication failure
+// (which should drop the connection after 5 attempts).
+var ErrUnknownEncryptedSession = errors.New("encrypted message for unknown session")
 
 // SigningVerifier verifies SMB2 message signatures during request reading.
 // This decouples the framing layer from session management.
@@ -78,6 +88,31 @@ func ReadRequest(
 		}
 		decrypted, transformSessionID, err := encMiddleware.DecryptRequest(message)
 		if err != nil {
+			// Per MS-SMB2 §3.3.5.2.7: an encrypted message addressed to a
+			// SessionId the server no longer knows about (typical race:
+			// reconnect1 issues SESSION_SETUP with PreviousSessionId on a
+			// parallel connection, which tears down the original session
+			// while the original connection still has an in-flight request)
+			// must be answered with a plaintext STATUS_USER_SESSION_DELETED
+			// rather than silently dropped. Without the synthetic reply the
+			// peer waits the full client-side timeout, and the cascading
+			// "Establishing SMB2 connection failed / NT_STATUS_NO_MEMORY"
+			// errors that flow out of an overrun smbtorture client mask
+			// downstream per-algorithm crypto tests (#717).
+			//
+			// Synthesize a minimal SMB2 request header so the connection
+			// layer can dispatch through SendErrorResponse — MessageID is
+			// unknowable post-AEAD, so use 0xFFFFFFFFFFFFFFFF as Samba does
+			// for spontaneous server-originated replies.
+			if errors.Is(err, encryption.ErrUnknownSession) {
+				synthetic := &header.SMB2Header{
+					ProtocolID: [4]byte{0xFE, 'S', 'M', 'B'},
+					Command:    types.SMB2SessionSetup,
+					MessageID:  ^uint64(0),
+					SessionID:  transformSessionID,
+				}
+				return synthetic, nil, nil, true, ErrUnknownEncryptedSession
+			}
 			return nil, nil, nil, false, fmt.Errorf("decrypt transform message: %w", err)
 		}
 

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -472,7 +472,11 @@ func SendResponseWithHooks(reqHeader *header.SMB2Header, ctx *handlers.SMBHandle
 		RunAfterHooks(connInfo, reqHeader.Command, wirePlaintext)
 	}
 	requestEncrypted := ctx != nil && ctx.RequestEncrypted
-	err := sendMessage(respHeader, body, connInfo, requestEncrypted, preWrite)
+	// Channel-bind SESSION_SETUP responses MUST be sent plaintext-signed even
+	// when the underlying session has encryption — the peer has no derivable
+	// keys for the new channel yet (MS-SMB2 §3.3.5.5.2).
+	suppressSetupEncryption := result.IsBinding
+	err := sendMessage(respHeader, body, connInfo, requestEncrypted, suppressSetupEncryption, preWrite)
 	// Fire ReleaseData AFTER the wire write completes, regardless of
 	// write success. The pooled buffer is no longer referenced once the
 	// write attempt returns, so release is safe whether or not the bytes
@@ -487,7 +491,8 @@ func SendResponseWithHooks(reqHeader *header.SMB2Header, ctx *handlers.SMBHandle
 func SendResponse(reqHeader *header.SMB2Header, ctx *handlers.SMBHandlerContext, result *HandlerResult, connInfo *ConnInfo) error {
 	respHeader, body := buildResponseHeaderAndBody(reqHeader, ctx, result, connInfo)
 	requestEncrypted := ctx != nil && ctx.RequestEncrypted
-	err := sendMessage(respHeader, body, connInfo, requestEncrypted, nil)
+	suppressSetupEncryption := result.IsBinding
+	err := sendMessage(respHeader, body, connInfo, requestEncrypted, suppressSetupEncryption, nil)
 	// See SendResponseWithHooks — release pooled buffer after wire write.
 	if result.ReleaseData != nil {
 		result.ReleaseData()
@@ -596,11 +601,16 @@ func SendErrorResponse(reqHeader *header.SMB2Header, status types.Status, connIn
 // the server MUST sign the response using the session's signing key. Encrypted
 // sessions use AEAD for integrity instead of signing (MS-SMB2 3.3.4.1.3).
 //
-// Per MS-SMB2 3.3.5.5.3: the initial SESSION_SETUP SUCCESS response for a newly
-// created session MUST NOT be encrypted (client hasn't derived keys yet), but
-// MUST be signed. Re-authentication SESSION_SETUP responses ARE encrypted.
+// Per MS-SMB2 3.3.5.5.3 / 3.3.5.5.2: the initial SESSION_SETUP SUCCESS response
+// for a newly created session and the channel-bind SESSION_SETUP response MUST
+// NOT be encrypted (peer has no derivable keys for that channel yet) but MUST
+// be signed. Re-authentication SESSION_SETUP responses ARE encrypted when the
+// existing session has encryption available. SendMessage cannot distinguish
+// re-auth from bind because it has no HandlerResult context, so it always
+// treats SESSION_SETUP as bind/new-session (skip encryption). Re-auth must go
+// through SendResponse/SendResponseWithHooks which thread the IsBinding flag.
 func SendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo) error {
-	return sendMessage(hdr, body, connInfo, false, nil)
+	return sendMessage(hdr, body, connInfo, false, true, nil)
 }
 
 // sendMessage is the internal implementation used by SendMessage and
@@ -609,25 +619,32 @@ func SendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo) error 
 // written to the TCP connection. SendResponseWithHooks uses this to run the
 // preauth integrity hash update in the window where the client cannot yet have
 // observed the response — see the SendResponseWithHooks docstring.
-func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, responseEncrypted bool, preWrite func(wirePlaintext []byte)) error {
+//
+// suppressSessionSetupEncryption=true forces the SESSION_SETUP response to go
+// out plaintext-signed even if the session has encryption keys. Callers set
+// it for newly-created sessions, channel-bind responses, and the synthetic
+// SendMessage path (no IsBinding context available).
+func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, responseEncrypted bool, suppressSessionSetupEncryption bool, preWrite func(wirePlaintext []byte)) error {
 	smbPayload := append(hdr.Encode(), body...)
 
 	if hdr.SessionID != 0 {
 		sess, ok := connInfo.Handler.GetSession(hdr.SessionID)
 		if ok {
-			// Per MS-SMB2 3.3.5.5.3 and 3.3.5.5.2: SESSION_SETUP responses
-			// MUST be signed and MUST NOT be encrypted, in all three cases:
-			// new session (client has no encryption keys yet), re-auth, and
-			// channel bind (client must validate Channel.SigningKey from the
-			// plaintext response before treating the channel as bound).
-			// Applies to both the final SUCCESS response AND interim
-			// STATUS_MORE_PROCESSING_REQUIRED challenges — the bind peer has
-			// no channel-scoped keys yet, so encrypting the challenge makes
-			// the client drop the connection with ACCESS_DENIED (#361).
+			// Per MS-SMB2 3.3.5.5.3 and 3.3.5.5.2: the initial SESSION_SETUP
+			// SUCCESS response for a newly created session and the channel-bind
+			// response MUST be signed and MUST NOT be encrypted — the peer has
+			// no derivable keys for that channel yet, so encrypting causes the
+			// client to drop the connection with ACCESS_DENIED (#361).
+			// Re-authentication SESSION_SETUP on an existing session DOES get
+			// encrypted with the existing session keys (the peer can decrypt).
+			// Interim STATUS_MORE_PROCESSING_REQUIRED responses also stay
+			// plaintext for the same reason.
 			isSessionSetup := hdr.Command == types.SMB2SessionSetup
 			isSessionSetupSuccess := isSessionSetup && hdr.Status == types.StatusSuccess
+			isInterim := isSessionSetup && hdr.Status != types.StatusSuccess
 			if isSessionSetupSuccess && sess.NewlyCreated {
 				sess.NewlyCreated = false // Clear so subsequent messages get encrypted
+				suppressSessionSetupEncryption = true
 			}
 			// Encrypt when the session forces it (mode=required), the
 			// per-share tree forces it (Share.EncryptData via TREE_CONNECT),
@@ -645,7 +662,8 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, respon
 					shouldEncrypt = true
 				}
 			}
-			if shouldEncrypt && connInfo.EncryptionMiddleware != nil && !isSessionSetup {
+			suppressForSetup := isInterim || (isSessionSetup && suppressSessionSetupEncryption)
+			if shouldEncrypt && connInfo.EncryptionMiddleware != nil && !suppressForSetup {
 				// Run pre-write hook on the PLAINTEXT bytes — the preauth chain
 				// hashes plaintext on both sides, not the encrypted wire form.
 				if preWrite != nil {

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -98,6 +98,16 @@ func ProcessSingleRequest(
 	// for preauth integrity hash chaining (SESSION_SETUP). See #362.
 	handlerCtx.RawRequest = rawMessage
 
+	// Sticky-track that the peer is using encryption on this session so that
+	// async completion responses (CHANGE_NOTIFY CANCELLED in particular)
+	// can mirror the peer's encryption stance even when Session.EncryptData
+	// stays false in preferred mode. See Session.PeerUsedEncryption.
+	if isEncrypted && reqHeader.SessionID != 0 {
+		if sess, ok := connInfo.Handler.GetSession(reqHeader.SessionID); ok {
+			sess.PeerUsedEncryption.Store(true)
+		}
+	}
+
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
 		return SendErrorResponse(reqHeader, errStatus, connInfo)
@@ -315,6 +325,13 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 	// input the client hashed — including compound framing fields like
 	// NextCommand. Re-encoding reqHeader would diverge on those fields.
 	handlerCtx.RawRequest = rawMessage
+
+	// Sticky-track peer encryption usage; see ProcessSingleRequest.
+	if isEncrypted && reqHeader.SessionID != 0 {
+		if sess, ok := connInfo.Handler.GetSession(reqHeader.SessionID); ok {
+			sess.PeerUsedEncryption.Store(true)
+		}
+	}
 
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
@@ -802,7 +819,15 @@ func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, respons
 			"bufferLen", len(response.Buffer))
 	}
 
-	return SendMessage(respHeader, body, connInfo)
+	// Async completion must mirror the peer's encryption stance per MS-SMB2
+	// §3.3.4.1.4 — if any prior request on this session arrived encrypted,
+	// the peer expects this response encrypted too, even when
+	// Session.EncryptData=false (preferred mode without per-share enforcement).
+	mirrorEncryption := false
+	if sess, ok := connInfo.Handler.GetSession(sessionID); ok {
+		mirrorEncryption = sess.PeerUsedEncryption.Load()
+	}
+	return sendMessage(respHeader, body, connInfo, mirrorEncryption, true, nil)
 }
 
 // SendAsyncCompletionResponse sends a standalone async completion response for
@@ -853,7 +878,12 @@ func SendAsyncCompletionResponse(sessionID uint64, messageID uint64, asyncId uin
 		"messageID", messageID,
 		"asyncId", asyncId)
 
-	return SendMessage(respHeader, body, connInfo)
+	// Mirror the peer's encryption stance (see SendAsyncChangeNotifyResponse).
+	mirrorEncryption := false
+	if sess, ok := connInfo.Handler.GetSession(sessionID); ok {
+		mirrorEncryption = sess.PeerUsedEncryption.Load()
+	}
+	return sendMessage(respHeader, body, connInfo, mirrorEncryption, true, nil)
 }
 
 // encodeReadResponseBody encodes a READ response body for async pipe-read completion.

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -604,10 +604,49 @@ func grantConnectionCredits(connInfo *ConnInfo, sessionID uint64, requested, cre
 // SendErrorResponse sends an SMB2 error response.
 // Per user decision: all responses on encrypted sessions are encrypted,
 // including error responses.
+//
+// Special case STATUS_USER_SESSION_DELETED: per Samba
+// source3/smbd/smb2_server.c::smbd_smb2_request_dispatch ("We fallback to a
+// session of another process in order to get the signing correct"), when the
+// inbound request carries a SessionId that no longer maps to a session, the
+// outbound USER_SESSION_DELETED reply MUST still be signed with the keys of
+// some valid session on this transport so the client accepts it under
+// SigningRequired. Otherwise the unsigned reply is mapped to
+// NT_STATUS_ACCESS_DENIED by Samba's smbXcli verifier and smb2.session-id
+// reports the wrong status code. The wire SessionId stays the original
+// (wrong) value the client used; only the signing key is borrowed.
 func SendErrorResponse(reqHeader *header.SMB2Header, status types.Status, connInfo *ConnInfo) error {
 	credits := grantConnectionCredits(connInfo, reqHeader.SessionID, reqHeader.Credits, reqHeader.CreditCharge)
 	respHeader := header.NewResponseHeaderWithCredits(reqHeader, status, credits)
+	if status == types.StatusUserSessionDeleted && connInfo.SessionTracker != nil {
+		if fallback := connInfo.SessionTracker.AnyTrackedSession(); fallback != 0 {
+			if _, ok := connInfo.Handler.GetSession(fallback); ok {
+				return sendMessageWithSigner(respHeader, MakeErrorBody(), connInfo, fallback)
+			}
+		}
+	}
 	return SendMessage(respHeader, MakeErrorBody(), connInfo)
+}
+
+// sendMessageWithSigner sends an SMB2 message whose wire SessionId differs
+// from the session whose key is used to sign it. Used by SendErrorResponse
+// on the wrong-SessionId USER_SESSION_DELETED path.
+func sendMessageWithSigner(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, signingSessionID uint64) error {
+	smbPayload := append(hdr.Encode(), body...)
+	sess, ok := connInfo.Handler.GetSession(signingSessionID)
+	if !ok || sess.CryptoState == nil {
+		// Falls back to plain unsigned send.
+		return WriteNetBIOSFrame(connInfo.Conn, connInfo.WriteMu, connInfo.WriteTimeout, smbPayload)
+	}
+	if sess.ShouldSign() {
+		sess.SignMessageOnChannel(connInfo.ConnID, smbPayload)
+		copy(hdr.Signature[:], smbPayload[48:64])
+		logger.Debug("Signed outgoing SMB2 message with fallback session",
+			"command", hdr.Command.String(),
+			"wireSessionID", hdr.SessionID,
+			"signerSessionID", signingSessionID)
+	}
+	return WriteNetBIOSFrame(connInfo.Conn, connInfo.WriteMu, connInfo.WriteTimeout, smbPayload)
 }
 
 // SendMessage sends an SMB2 message with NetBIOS framing, optional encryption,

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -471,7 +471,8 @@ func SendResponseWithHooks(reqHeader *header.SMB2Header, ctx *handlers.SMBHandle
 	preWrite := func(wirePlaintext []byte) {
 		RunAfterHooks(connInfo, reqHeader.Command, wirePlaintext)
 	}
-	err := sendMessage(respHeader, body, connInfo, preWrite)
+	requestEncrypted := ctx != nil && ctx.RequestEncrypted
+	err := sendMessage(respHeader, body, connInfo, requestEncrypted, preWrite)
 	// Fire ReleaseData AFTER the wire write completes, regardless of
 	// write success. The pooled buffer is no longer referenced once the
 	// write attempt returns, so release is safe whether or not the bytes
@@ -485,7 +486,8 @@ func SendResponseWithHooks(reqHeader *header.SMB2Header, ctx *handlers.SMBHandle
 // SendResponse sends an SMB2 response with credit management and signing.
 func SendResponse(reqHeader *header.SMB2Header, ctx *handlers.SMBHandlerContext, result *HandlerResult, connInfo *ConnInfo) error {
 	respHeader, body := buildResponseHeaderAndBody(reqHeader, ctx, result, connInfo)
-	err := SendMessage(respHeader, body, connInfo)
+	requestEncrypted := ctx != nil && ctx.RequestEncrypted
+	err := sendMessage(respHeader, body, connInfo, requestEncrypted, nil)
 	// See SendResponseWithHooks — release pooled buffer after wire write.
 	if result.ReleaseData != nil {
 		result.ReleaseData()
@@ -598,7 +600,7 @@ func SendErrorResponse(reqHeader *header.SMB2Header, status types.Status, connIn
 // created session MUST NOT be encrypted (client hasn't derived keys yet), but
 // MUST be signed. Re-authentication SESSION_SETUP responses ARE encrypted.
 func SendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo) error {
-	return sendMessage(hdr, body, connInfo, nil)
+	return sendMessage(hdr, body, connInfo, false, nil)
 }
 
 // sendMessage is the internal implementation used by SendMessage and
@@ -607,7 +609,7 @@ func SendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo) error 
 // written to the TCP connection. SendResponseWithHooks uses this to run the
 // preauth integrity hash update in the window where the client cannot yet have
 // observed the response — see the SendResponseWithHooks docstring.
-func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWrite func(wirePlaintext []byte)) error {
+func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, responseEncrypted bool, preWrite func(wirePlaintext []byte)) error {
 	smbPayload := append(hdr.Encode(), body...)
 
 	if hdr.SessionID != 0 {
@@ -627,7 +629,23 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, preWri
 			if isSessionSetupSuccess && sess.NewlyCreated {
 				sess.NewlyCreated = false // Clear so subsequent messages get encrypted
 			}
-			if sess.ShouldEncrypt() && connInfo.EncryptionMiddleware != nil && !isSessionSetup {
+			// Encrypt when the session forces it (mode=required), the
+			// per-share tree forces it (Share.EncryptData via TREE_CONNECT),
+			// or the inbound request was itself encrypted (MS-SMB2 §3.3.4.1.4).
+			// In preferred mode Session.EncryptData stays false so signing-only
+			// torture tests can run, but encrypted shares and clients that
+			// opt-in to encryption per-connection (e.g. smbtorture's
+			// encryption-aes-128-ccm with SMB_ENCRYPTION_REQUIRED credentials)
+			// must still get encrypted responses — pull the tree-level flag
+			// and honour responseEncrypted.
+			shouldEncrypt := sess.ShouldEncrypt() || responseEncrypted
+			if !shouldEncrypt && hdr.TreeID != 0 && sess.CryptoState != nil &&
+				sess.CryptoState.Encryptor != nil {
+				if tree, ok := connInfo.Handler.GetTree(hdr.TreeID); ok && tree.EncryptData {
+					shouldEncrypt = true
+				}
+			}
+			if shouldEncrypt && connInfo.EncryptionMiddleware != nil && !isSessionSetup {
 				// Run pre-write hook on the PLAINTEXT bytes — the preauth chain
 				// hashes plaintext on both sides, not the encrypted wire form.
 				if preWrite != nil {

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -140,6 +140,20 @@ type Session struct {
 	// signature" rejection at reauth1-5).
 	PreauthIntegrityHash [64]byte
 
+	// PeerUsedEncryption is sticky-set to true the first time we receive an
+	// encrypted (Transform Header) request on this session. Per MS-SMB2
+	// §3.3.4.1.4 the response to an encrypted request MUST be encrypted; the
+	// synchronous response path already honours this via SMBHandlerContext
+	// .RequestEncrypted, but ASYNC completions (e.g. CHANGE_NOTIFY
+	// CANCELLED) lose that context once they're dispatched from the registry
+	// goroutine. Reading this sticky flag in SendAsyncChangeNotifyResponse /
+	// SendAsyncCompletionResponse lets them mirror the peer's encryption
+	// stance even when Session.EncryptData stays false (preferred mode
+	// without per-share enforcement). Smbtorture's
+	// encryption-aes-128-{ccm,gcm} forces encryption per-connection but does
+	// not set the session flag, so this is the only signal we have.
+	PeerUsedEncryption atomic.Bool
+
 	// Credit tracking
 	credits Credits
 

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -128,6 +128,18 @@ type Session struct {
 	// bind to it from a different ClientGuid).
 	ClientGUID [16]byte
 
+	// PreauthIntegrityHash is the per-session SHA-512 preauth hash captured
+	// at the end of the ORIGINAL SESSION_SETUP that established this session
+	// (MS-SMB2 §3.3.5.5.3 Session.PreauthIntegrityHashValue). The spec freezes
+	// this value once the session is established: on re-authentication the
+	// server MUST re-derive Session.SigningKey / EncryptionKey / DecryptionKey
+	// from the NEW SessionBaseKey combined with this UNCHANGED preauth hash.
+	// Without this snapshot the server would have to reset the per-connection
+	// per-session hash entry from the fresh NEGOTIATE hash, producing a
+	// different key than the client computes ("Bad SMB2 (sign_algo_id=2)
+	// signature" rejection at reauth1-5).
+	PreauthIntegrityHash [64]byte
+
 	// Credit tracking
 	credits Credits
 

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -214,11 +214,16 @@ const (
 	StatusInvalidLockRange Status = 0xC00001A1
 
 	// StatusRequestOutOfSequence indicates a request was made in the wrong
-	// protocol state [MS-ERREF 2.3.1]. Returned by SESSION_SETUP bind when
-	// the existing session was negotiated with AES-128-GMAC signing but the
-	// new connection's signing algorithm is not GMAC (MS-SMB2 §3.3.5.5.2;
-	// Samba source3/smbd/smb2_sesssetup.c:724-729).
-	StatusRequestOutOfSequence Status = 0xC010000A
+	// protocol state. Per MS-ERREF (Samba libcli/util/ntstatus_err_table.txt
+	// section "MS-ERREF 2.3.1") the value is 0xC000042A — NOT the
+	// MS-ERREF section 2.4 (RPC facility) "STATUS_REQUEST_OUT_OF_SEQUENCE"
+	// 0xC010000A, which is RPC-scoped and smbtorture's nt_errstr() displays
+	// as "HRES code 0xc010000a" because that code is in the HRESULT facility
+	// table, not the NTSTATUS one. Returned by SESSION_SETUP bind when the
+	// existing session was negotiated with AES-128-GMAC signing but the new
+	// connection's signing algorithm is not GMAC (MS-SMB2 §3.3.5.5.2; Samba
+	// source3/smbd/smb2_sesssetup.c:724-729).
+	StatusRequestOutOfSequence Status = 0xC000042A
 )
 
 // String returns a human-readable name for the status code.

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -1218,14 +1218,30 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 	var signingAlgId uint16
 	var signingAlgExplicit bool
 
+	// Detect re-authentication: the session was previously established and
+	// has a captured Session.PreauthIntegrityHashValue. Per MS-SMB2
+	// §3.3.5.5.3, on re-auth the preauth hash is UNCHANGED from the original
+	// setup — the new SigningKey / EncryptionKey / DecryptionKey are derived
+	// from the new SessionBaseKey combined with that frozen hash. Resetting
+	// from the per-connection preauth chain would diverge from the client and
+	// produce "Bad SMB2 (sign_algo_id=2) signature" rejections on the next
+	// signed message (smb2.session.reauth1-5).
+	var zeroHash [64]byte
+	isReauth := sess.PreauthIntegrityHash != zeroHash
+
 	if ctx != nil && ctx.ConnCryptoState != nil {
 		dialect = ctx.ConnCryptoState.GetDialect()
 		if dialect >= types.Dialect0300 {
-			// Per [MS-SMB2] 3.3.5.5: use the per-session preauth hash for key
-			// derivation, not the connection-level hash. Each session maintains
-			// its own hash chain including only that session's NEGOTIATE and
-			// SESSION_SETUP messages.
-			preauthHash = ctx.ConnCryptoState.GetSessionPreauthHash(sess.SessionID)
+			if isReauth {
+				// Frozen preauth hash from the original SESSION_SETUP.
+				preauthHash = sess.PreauthIntegrityHash
+			} else {
+				// Per [MS-SMB2] 3.3.5.5: use the per-session preauth hash for
+				// key derivation, not the connection-level hash. Each session
+				// maintains its own hash chain including only that session's
+				// NEGOTIATE and SESSION_SETUP messages.
+				preauthHash = ctx.ConnCryptoState.GetSessionPreauthHash(sess.SessionID)
+			}
 			cipherId = ctx.ConnCryptoState.GetCipherId()
 			signingAlgId, signingAlgExplicit = ctx.ConnCryptoState.GetSigningAlgorithmId()
 		}
@@ -1314,6 +1330,15 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 		}
 
 		sess.SetCryptoState(cryptoState)
+
+		// Snapshot the frozen Session.PreauthIntegrityHashValue per MS-SMB2
+		// §3.3.5.5.3 on first establishment so re-authentication can re-derive
+		// keys from this same value instead of resetting the per-connection
+		// per-session hash entry. Skipped on re-auth (we already used the
+		// stored value above).
+		if !isReauth {
+			sess.PreauthIntegrityHash = preauthHash
+		}
 	} else {
 		// SMB 2.x: cannot encrypt. Reject in required mode.
 		if h.EncryptionConfig.Mode == "required" {

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -1280,7 +1280,6 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 			}
 
 			if encCipherId != 0 {
-				cryptoState.EncryptData = true
 				if err := cryptoState.CreateEncryptors(encCipherId); err != nil {
 					if h.EncryptionConfig.Mode == "required" {
 						logger.Warn("Failed to create session encryptors in required mode, rejecting session",
@@ -1289,14 +1288,26 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 						return NewErrorResult(types.StatusAccessDenied)
 					}
 					// Preferred mode: degrade gracefully
-					logger.Warn("Failed to create session encryptors, disabling encryption",
+					logger.Warn("Failed to create session encryptors, available=false",
 						"sessionID", sess.SessionID, "error", err)
-					cryptoState.EncryptData = false
 				} else {
-					logger.Info("SMB3 encryption enabled for session",
+					// Per MS-SMB2 §3.3.5.5.3: Session.EncryptData is forced on
+					// only when the server requires encryption globally; in
+					// preferred mode the encryptors are available but enforce-
+					// ment is gated per-share at TREE_CONNECT (Share.EncryptData).
+					// Forcing EncryptData=true here causes smbtorture signing
+					// tests (signing-hmac-sha-256, signing-aes-128-{cmac,gmac})
+					// to skip with "Can't test signing only if encryption is
+					// required" because the outer tcon then advertises
+					// session-level encryption regardless of share config.
+					if h.EncryptionConfig.Mode == "required" {
+						cryptoState.EncryptData = true
+					}
+					logger.Info("SMB3 encryption available for session",
 						"sessionID", sess.SessionID,
 						"cipherId", fmt.Sprintf("0x%04x", encCipherId),
-						"dialect", dialect.String())
+						"dialect", dialect.String(),
+						"sessionEnforced", cryptoState.EncryptData)
 				}
 			}
 			// encCipherId == 0 && preferred mode: no encryption for this session

--- a/internal/adapter/smb/v2/handlers/session_setup_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_test.go
@@ -962,7 +962,11 @@ func TestConfigureSessionSigningWithKey_Encryption(t *testing.T) {
 		wantError   bool
 		wantStatus  types.Status
 	}{
-		{"PreferredMode_3x", "preferred", types.Dialect0311, types.CipherAES128GCM, true, false, 0},
+		// Preferred mode derives encryptors so the per-share Share.EncryptData
+		// path can use them, but Session.EncryptData stays false — otherwise
+		// signing-only torture tests skip with "Can't test signing only if
+		// encryption is required" (#717).
+		{"PreferredMode_3x", "preferred", types.Dialect0311, types.CipherAES128GCM, false, false, 0},
 		{"RequiredMode_3x", "required", types.Dialect0300, types.CipherAES128GCM, true, false, 0},
 		{"DisabledMode_3x", "disabled", types.Dialect0311, types.CipherAES128GCM, false, false, 0},
 		{"Dialect2xRejectedInRequired", "required", types.Dialect0210, 0, false, true, types.StatusAccessDenied},
@@ -1003,6 +1007,35 @@ func TestConfigureSessionSigningWithKey_Encryption(t *testing.T) {
 			}
 		})
 	}
+
+	// Preferred mode must still derive encryptors so per-share tcons that
+	// negotiate Share.EncryptData can wrap their responses with the
+	// session-level cipher.
+	t.Run("PreferredMode_3x_EncryptorsDerived", func(t *testing.T) {
+		h := NewHandler()
+		h.EncryptionConfig = EncryptionConfig{
+			Mode:           "preferred",
+			AllowedCiphers: []uint16{types.CipherAES128GCM},
+		}
+		sess := h.CreateSession("127.0.0.1:12345", false, "testuser", "DOMAIN")
+		ctx := newTestContext(sess.SessionID)
+		ctx.ConnCryptoState = &mockCryptoState{
+			dialect:  types.Dialect0311,
+			cipherId: types.CipherAES128GCM,
+		}
+		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
+			t.Fatalf("unexpected error result: %v", errResult.Status)
+		}
+		if sess.CryptoState == nil || sess.CryptoState.Encryptor == nil {
+			t.Error("Encryptor not created in preferred mode (per-share enforcement needs it)")
+		}
+		if sess.CryptoState.Decryptor == nil {
+			t.Error("Decryptor not created in preferred mode")
+		}
+		if sess.ShouldEncrypt() {
+			t.Error("Session.EncryptData unexpectedly set in preferred mode (would skip signing-only torture tests)")
+		}
+	})
 }
 
 func TestSessionSetupConstants(t *testing.T) {

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -291,7 +291,14 @@ func (s *Adapter) SetRuntime(rtAny any) {
 // torture tests that run inside the poll window.
 func (s *Adapter) applySMBSettings(rt *runtime.Runtime) {
 	if sw := rt.GetSettingsWatcher(); sw != nil {
-		if err := sw.RefreshSMBSettings(context.Background()); err != nil {
+		// Bound the synchronous refresh — a stuck DB/store must not block the
+		// adapter enable/restart path. 5s is generous for a single SELECT but
+		// short enough that operators see a degraded-mode log instead of a
+		// hung process if the metadata store is unhealthy.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := sw.RefreshSMBSettings(ctx)
+		cancel()
+		if err != nil {
 			logger.Debug("SMB adapter: settings refresh failed, using cached values",
 				"error", err)
 		}

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -280,8 +280,23 @@ func (s *Adapter) SetRuntime(rtAny any) {
 }
 
 // applySMBSettings reads current SMB adapter settings from the runtime's
-// SettingsWatcher and applies them. Called during SetRuntime (startup).
+// SettingsWatcher and applies them. Called during SetRuntime (startup) and
+// on each settings-watcher change callback.
+//
+// To close the window between a settings PATCH and the next 10s poll, this
+// performs a synchronous DB refresh first. Without it, an
+// `adapter disable smb && adapter enable smb` sequence issued immediately
+// after `--enable-encryption true` reads the stale cached settings and
+// leaves Mode="disabled", which breaks the SMB 3.1.1 per-algorithm crypto
+// torture tests that run inside the poll window.
 func (s *Adapter) applySMBSettings(rt *runtime.Runtime) {
+	if sw := rt.GetSettingsWatcher(); sw != nil {
+		if err := sw.RefreshSMBSettings(context.Background()); err != nil {
+			logger.Debug("SMB adapter: settings refresh failed, using cached values",
+				"error", err)
+		}
+	}
+
 	settings := rt.GetSMBSettings()
 	if settings == nil {
 		logger.Debug("SMB adapter: no live settings available, using defaults")

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -200,6 +200,22 @@ func (c *Connection) Serve(ctx context.Context) {
 			c.server.config.Timeouts.Read, verifier, ci.EncryptionMiddleware, handleSMB1,
 		)
 		if err != nil {
+			// Encrypted message for a SessionId the server no longer knows
+			// (typical post-LOGOFF / reconnect-supersede race per MS-SMB2
+			// §3.3.5.2.7). Respond with a plaintext STATUS_USER_SESSION_DELETED
+			// using the synthetic header returned by the framing layer, then
+			// keep reading. Do NOT count this against DecryptFailures — a
+			// brute-force AEAD attack can't get a synthetic header back.
+			if errors.Is(err, smb.ErrUnknownEncryptedSession) && hdr != nil {
+				if sendErr := smb.SendErrorResponse(hdr, types.StatusUserSessionDeleted, ci); sendErr != nil {
+					logger.Debug("Failed to send synthetic USER_SESSION_DELETED",
+						"address", clientAddr,
+						"sessionID", hdr.SessionID,
+						"error", sendErr)
+				}
+				continue
+			}
+
 			// Track consecutive decryption failures. After 5, drop the connection
 			// to prevent brute-force attacks on the AEAD authentication.
 			if isDecryptionError(err) {

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -113,6 +113,18 @@ func (c *Connection) UntrackSession(sessionID uint64) {
 	}
 }
 
+// AnyTrackedSession returns one of the session IDs currently tracked on this
+// connection (zero if none). Used by SendErrorResponse on the wrong-
+// SessionId path — see SessionTracker docstring.
+func (c *Connection) AnyTrackedSession() uint64 {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	for id := range c.sessions {
+		return id
+	}
+	return 0
+}
+
 // connInfo builds the ConnInfo struct used by internal/ dispatch functions.
 func (c *Connection) connInfo() *smb.ConnInfo {
 	ci := &smb.ConnInfo{

--- a/pkg/adapter/smb/lease_notifier.go
+++ b/pkg/adapter/smb/lease_notifier.go
@@ -266,3 +266,8 @@ func (t *connRegistryTracker) UntrackSession(sessionID uint64) {
 		}
 	}
 }
+
+// AnyTrackedSession delegates to the inner tracker.
+func (t *connRegistryTracker) AnyTrackedSession() uint64 {
+	return t.inner.AnyTrackedSession()
+}

--- a/pkg/controlplane/runtime/settings_watcher.go
+++ b/pkg/controlplane/runtime/settings_watcher.go
@@ -200,6 +200,15 @@ func (w *SettingsWatcher) pollNFSSettings(ctx context.Context) error {
 	return nil
 }
 
+// RefreshSMBSettings forces a synchronous re-read of SMB adapter settings
+// from the database, bypassing the periodic poll cadence. Use when adapter
+// lifecycle events (enable/disable, restart) must see settings updates that
+// happened within the current poll window. Returns the same errors as the
+// internal poll and is a no-op if the settings version is unchanged.
+func (w *SettingsWatcher) RefreshSMBSettings(ctx context.Context) error {
+	return w.pollSMBSettings(ctx)
+}
+
 // pollSMBSettings checks the DB for SMB adapter settings changes.
 // If the version has changed, swaps the cached settings atomically.
 func (w *SettingsWatcher) pollSMBSettings(ctx context.Context) error {


### PR DESCRIPTION
Closes #717.

## What

Five interlocking changes so the SMB 3.1.1 per-algorithm crypto torture tests in `smb2.session` (`signing-hmac-sha-256`, `signing-aes-128-{cmac,gmac}`, `encryption-aes-{128,256}-{ccm,gcm}`, `anon-signing{1,2}`) can negotiate signing-only vs encrypted sessions correctly.

1. **`session_setup`**: in `preferred` mode, derive encryptors but leave `Session.EncryptData=false`. Per-share `Share.EncryptData` still triggers encryption at `TREE_CONNECT`, but signing-only torture tests no longer skip with *"Can't test signing only if encryption is required"*.
2. **`response`/`sendMessage`**: encrypt when (a) the session forces it, (b) the per-share `tree.EncryptData` is set, or (c) the inbound request was itself encrypted (MS-SMB2 §3.3.4.1.4). Threads a new `RequestEncrypted` from `SMBHandlerContext` through `SendResponse`/`SendResponseWithHooks` into a single unified `sendMessage` path. Removed the redundant `SendMessageEncrypted` wrapper after the simplifier pass.
3. **`framing`**: surface `ErrUnknownEncryptedSession` plus a synthetic SMB2 header when `DecryptRequest` fails with `ErrUnknownSession`, so the post-LOGOFF / reconnect-supersede race (MS-SMB2 §3.3.5.2.7) can be answered with a plaintext `STATUS_USER_SESSION_DELETED` instead of silently dropped.
4. **`encryption/middleware`**: add `ErrUnknownSession` sentinel and return `th.SessionId` on lookup miss so callers can build the synthetic reply.
5. **`connection`**: handle `ErrUnknownEncryptedSession` by replying with `STATUS_USER_SESSION_DELETED` and continuing the read loop — does not count against the 5-strike AEAD-failure connection-drop counter (synthetic headers are not brute-forceable).
6. **`adapter`/`settings_watcher`**: synchronous `RefreshSMBSettings()` on enable/restart so `adapter disable smb && adapter enable smb` immediately after a settings `PATCH` sees the new encryption mode rather than the stale 10s-cached value.

## Test

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -timeout 5m ./internal/adapter/smb/...` — all pass, including new sub-test `PreferredMode_3x_EncryptorsDerived`
- `golangci-lint run --timeout=5m ./...` — 0 issues
- `KNOWN_FAILURES.md` left untouched (no test walk-back without CI confirmation).

## Spec

- MS-SMB2 §2.2.3.1 — preauth integrity capabilities
- MS-SMB2 §3.1.1.2 — algorithm negotiation
- MS-SMB2 §3.1.4.1 — signing
- MS-SMB2 §3.3.4.1.4 — encrypt-iff-request-was-encrypted
- MS-SMB2 §3.3.5.2.7 — synthetic plaintext reply on unknown session
- MS-SMB2 §3.3.5.5.3 — `Session.EncryptData` semantics