### PR TITLE
fix(smb/read): edge-case access+position (#729)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -184,16 +184,6 @@ files, create blobs) are not implemented. Basic create operations pass.
 | smb2.create.multi | Create | Regression from recent changes, fails on all 3 stores | #480 |
 | smb2.create.path-length | Create | Flaky in CI (path length validation race) | #480 |
 
-### Read/Write Operations (Advanced Semantics)
-
-Advanced read/write scenarios requiring access check enforcement or protocol
-edge cases.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.read.access | Read | Read access enforcement not fully implemented (needs DesiredAccess from CREATE) | - |
-| smb2.read.position | Read | Read position tracking not implemented | - |
-
 ### Query/Set Info (Advanced Scenarios)
 
 Advanced getinfo scenarios requiring security descriptor queries, buffer size


### PR DESCRIPTION
Closes #729.

## Summary

Walks back two KNOWN_FAILURES entries — both tests already pass against
the implementation on develop:

  - **smb2.read.access**: gated on `Open.GrantedAccess` (post-DACL
    intersection at CREATE) via `hasReadAccess`, which accepts
    FILE_READ_DATA, FILE_EXECUTE, GENERIC_READ, GENERIC_ALL,
    MAXIMUM_ALLOWED — Samba/Windows-aligned (execution implies read).
  - **smb2.read.position**: `recordReadProgress` advances
    `Open.CurrentByteOffset` to `offset + bytesReturned` on every
    successful READ (regular file, zero-length, symlink) per MS-FSA
    2.1.5.2. Asserted by GetInfo FilePositionInformation.

Also drops the now-empty "Read/Write Operations (Advanced Semantics)"
subsection.

## Conformance

```
test: eof         -> success
test: position    -> success
test: dir         -> success
test: access      -> success
test: bug14607    -> skip (FSCTL_SMBTORTURE_GLOBAL_READ_RESPONSE_BODY_PADDING8)
```

4/4 PASS, +2 flips vs KNOWN_FAILURES.

## Test plan

- [x] `go test -race ./internal/adapter/smb/v2/handlers/`
- [x] `golangci-lint run --timeout=5m` clean
- [x] `./run.sh --filter smb2.read` — all known failures cleared