### PR TITLE
fix(blockstore): bound AppendWrite pressure wait + document Flush retry contract

### DIFF
--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -242,11 +242,11 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 //
 // Return contract — see blockstore.Flusher godoc for the full state
 // machine and caller-retry guidance. In brief:
-//   - Finalized=true, err=nil: durable on remote (or no remote configured
-//     and local quiesce complete).
-//   - Finalized=false, err=nil: SOFT condition (remote unhealthy OR another
-//     in-flight mirror pass holds the `uploading` CAS gate). Callers MUST
-//     NOT tight-loop retry — see #670 below.
+//   - Finalized=true, err=nil: durable on the configured remote.
+//   - Finalized=false, err=nil: SOFT condition (no remote configured,
+//     remote unhealthy, OR another in-flight mirror pass holds the
+//     `uploading` CAS gate). Callers MUST NOT tight-loop retry — see
+//     #670 below.
 //   - err != nil: hard failure, do not retry until addressed.
 //
 // #670: callers driving NFS COMMIT or SMB Flush loops over this method

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -246,11 +246,11 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 //     and local quiesce complete).
 //   - Finalized=false, err=nil: SOFT condition (remote unhealthy OR another
 //     in-flight mirror pass holds the `uploading` CAS gate). Callers MUST
-//     NOT tight-loop retry — see I-3 / #670 below.
+//     NOT tight-loop retry — see #670 below.
 //   - err != nil: hard failure, do not retry until addressed.
 //
-// I-3 / #670: callers driving NFS COMMIT or SMB Flush loops over this
-// method must rate-limit retries on Finalized=false. The `uploading`
+// #670: callers driving NFS COMMIT or SMB Flush loops over this method
+// must rate-limit retries on Finalized=false. The `uploading`
 // CompareAndSwap gate below makes the EXPLICIT Flush caller lose every
 // attempt that races the periodic uploader's tick, so a tight
 // in-handler retry loop pegs the CPU without ever making progress and
@@ -281,7 +281,7 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*blockstore.Flush
 	// tick body. Both paths take the uploading atomic gate; whichever
 	// holds it runs and the other observes Finalized=false.
 	//
-	// I-3 / #670: the contention branch returns Finalized=false WITHOUT
+	// #670: the contention branch returns Finalized=false WITHOUT
 	// waiting for the in-flight pass to complete. This is intentional —
 	// blocking the explicit caller until the periodic uploader's tick
 	// finishes could span minutes of remote I/O and translate into

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -240,10 +240,23 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 // per the unified BlockStore contract, so the next Flush pass re-Puts
 // the same hash and proceeds to MarkSynced.
 //
-// Returns Finalized=true when the mirror loop ran to completion (or
-// there was nothing to mirror) and Finalized=false when the local
-// store is configured without a healthy remote, in which case the
-// caller treats the payload as still-local-only.
+// Return contract — see blockstore.Flusher godoc for the full state
+// machine and caller-retry guidance. In brief:
+//   - Finalized=true, err=nil: durable on remote (or no remote configured
+//     and local quiesce complete).
+//   - Finalized=false, err=nil: SOFT condition (remote unhealthy OR another
+//     in-flight mirror pass holds the `uploading` CAS gate). Callers MUST
+//     NOT tight-loop retry — see I-3 / #670 below.
+//   - err != nil: hard failure, do not retry until addressed.
+//
+// I-3 / #670: callers driving NFS COMMIT or SMB Flush loops over this
+// method must rate-limit retries on Finalized=false. The `uploading`
+// CompareAndSwap gate below makes the EXPLICIT Flush caller lose every
+// attempt that races the periodic uploader's tick, so a tight
+// in-handler retry loop pegs the CPU without ever making progress and
+// starves the uploading goroutine. Recommended pattern: surface the
+// soft-fail to the protocol client (NFS3_COMMITTED=false; SMB Flush
+// returns success after a bounded attempt) instead of spinning.
 func (m *Syncer) Flush(ctx context.Context, payloadID string) (*blockstore.FlushResult, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return nil, err
@@ -266,9 +279,14 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*blockstore.Flush
 	}
 	// Serialize the explicit mirror against the periodic uploader's
 	// tick body. Both paths take the uploading atomic gate; whichever
-	// holds it runs and the other observes Finalized=false (explicit
-	// caller will retry on the next Flush; periodic caller will retry
-	// on the next tick).
+	// holds it runs and the other observes Finalized=false.
+	//
+	// I-3 / #670: the contention branch returns Finalized=false WITHOUT
+	// waiting for the in-flight pass to complete. This is intentional —
+	// blocking the explicit caller until the periodic uploader's tick
+	// finishes could span minutes of remote I/O and translate into
+	// protocol-client D-state. Callers MUST NOT spin-retry: see godoc
+	// above and the Flusher.Flush contract in pkg/blockstore.
 	if !m.uploading.CompareAndSwap(false, true) {
 		return &blockstore.FlushResult{Finalized: false}, nil
 	}

--- a/pkg/blockstore/fileblock.go
+++ b/pkg/blockstore/fileblock.go
@@ -203,7 +203,40 @@ type Writer interface {
 
 // Flusher defines flush/sync operations on the block store.
 type Flusher interface {
-	// Flush ensures all dirty data for a payload is persisted.
+	// Flush quiesces the payload's local-side state and (when a healthy
+	// remote is configured) mirrors every locally stored CAS chunk to
+	// the remote store. Return-value contract:
+	//
+	//   - (Finalized=true, nil)
+	//     All locally-mirrored data for payloadID is durable on the
+	//     configured remote (or no remote is configured and the local
+	//     quiesce completed). Callers may report COMMIT/Flush success
+	//     to the client.
+	//
+	//   - (Finalized=false, nil)
+	//     A NON-fatal soft condition prevented finalization THIS call:
+	//     either the remote is configured but currently unhealthy, or
+	//     another in-flight mirror pass (periodic uploader or
+	//     overlapping Flush) is already running. The dirty state is
+	//     unchanged and will be re-attempted on the next Flush or the
+	//     next periodic uploader tick.
+	//
+	//     Callers driving NFS COMMIT or SMB Flush loops MUST rate-limit
+	//     their retries against this branch. A tight retry storm on
+	//     Finalized=false starves the uploading goroutine (the
+	//     CompareAndSwap gate in syncer.Flush makes the explicit caller
+	//     LOSE every retry attempt against the periodic uploader's
+	//     in-flight tick) and pegs the CPU without making progress.
+	//     Recommended pattern: surface the soft-fail to the protocol
+	//     client (NFS3_COMMITTED=false → client reissues COMMIT on its
+	//     own schedule; SMB Flush returns success after a bounded
+	//     attempt) rather than spin in-handler.
+	//
+	//   - (nil, err)
+	//     Hard failure (I/O error, remote.Put rejection, MarkSynced
+	//     metadata error). Do NOT retry until the underlying condition
+	//     is addressed; the caller should surface a protocol-level
+	//     error to the client.
 	Flush(ctx context.Context, payloadID string) (*FlushResult, error)
 
 	// DrainAllUploads waits for all pending uploads to complete.
@@ -230,9 +263,16 @@ type Store interface {
 	Close() error
 }
 
-// FlushResult indicates the outcome of a flush operation.
+// FlushResult indicates the outcome of a flush operation. See the Flush
+// method on Flusher for the full (Finalized, err) state-machine and
+// caller-retry guidance.
 type FlushResult struct {
-	// Finalized indicates all blocks have been synced to the backend store.
+	// Finalized indicates all blocks have been synced to the backend
+	// store. When false alongside a nil error, the call hit a soft
+	// non-fatal condition (remote unhealthy or another mirror pass
+	// already in flight); the dirty state is unchanged and will be
+	// re-attempted by the next Flush or the periodic uploader. Callers
+	// MUST NOT spin-retry on Finalized=false — see Flusher.Flush godoc.
 	Finalized bool
 }
 

--- a/pkg/blockstore/fileblock.go
+++ b/pkg/blockstore/fileblock.go
@@ -209,17 +209,18 @@ type Flusher interface {
 	//
 	//   - (Finalized=true, nil)
 	//     All locally-mirrored data for payloadID is durable on the
-	//     configured remote (or no remote is configured and the local
-	//     quiesce completed). Callers may report COMMIT/Flush success
+	//     configured remote. Callers may report COMMIT/Flush success
 	//     to the client.
 	//
 	//   - (Finalized=false, nil)
 	//     A NON-fatal soft condition prevented finalization THIS call:
-	//     either the remote is configured but currently unhealthy, or
-	//     another in-flight mirror pass (periodic uploader or
-	//     overlapping Flush) is already running. The dirty state is
-	//     unchanged and will be re-attempted on the next Flush or the
-	//     next periodic uploader tick.
+	//     no remote is configured (local-only mode — local quiesce
+	//     completed but no remote durability target exists), the remote
+	//     is configured but currently unhealthy, or another in-flight
+	//     mirror pass (periodic uploader or overlapping Flush) is
+	//     already running. The dirty state is unchanged and will be
+	//     re-attempted on the next Flush or the next periodic uploader
+	//     tick.
 	//
 	//     Callers driving NFS COMMIT or SMB Flush loops MUST rate-limit
 	//     their retries against this branch. A tight retry storm on

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -180,6 +180,14 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 // mutex window itself is bounded to pwrite + fsync + tree.Insert (~5µs
 // on NVMe).
 //
+// Deadline (I-3 / #670 defense-in-depth): the pressure wait is bounded
+// by bc.pressureMaxWait (FSStoreOptions.PressureMaxWait; default 30s).
+// On expiry AppendWrite returns ErrPressureTimeout — distinguishable
+// from ctx.Err() (caller-side deadline) and ErrStoreClosed (store
+// shutdown). This bound prevents a wedged rollup pool from translating
+// into NFS-client D-state when the caller (NFS COMMIT / SMB Flush)
+// arrived with no usable deadline. Set PressureMaxWait < 0 to disable.
+//
 // On successful append the interval tree gains a single entry covering
 // [offset, offset+len(data)) with Touched=now; the rollup later consumes
 // it after the stabilization window.
@@ -216,14 +224,38 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// Pressure loop. Re-check under the loop in case the
 	// rollup pulsed pressureCh but another writer consumed the freed
 	// budget before this goroutine could proceed.
+	//
+	// I-3 / #670: bound the wait with bc.pressureMaxWait so a wedged
+	// rollup cannot translate into NFS-client D-state. The timer is
+	// allocated lazily — only when we actually need to block — and is
+	// shared across pressureCh wake-ups so a sequence of false-wakes
+	// (rollup pulses + another writer immediately consumes the freed
+	// budget) still respects the cumulative deadline. Using time.NewTimer
+	// + defer Stop() instead of time.After avoids leaking the underlying
+	// timer goroutine when pressureCh or bc.done fires first.
+	var pressureTimer *time.Timer
+	var pressureC <-chan time.Time
+	defer func() {
+		if pressureTimer != nil {
+			pressureTimer.Stop()
+		}
+	}()
 	for bc.logBytesTotal.Load() > bc.maxLogBytes {
+		if pressureTimer == nil && bc.pressureMaxWait > 0 {
+			pressureTimer = time.NewTimer(bc.pressureMaxWait)
+			pressureC = pressureTimer.C
+		}
 		select {
 		case <-bc.pressureCh:
-			// rollup (future plan) or test freed space; re-check budget.
+			// rollup or test freed space; re-check budget. Timer keeps
+			// running so a writer that loses the budget race repeatedly
+			// still surfaces ErrPressureTimeout at the cumulative deadline.
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-bc.done:
 			return ErrStoreClosed
+		case <-pressureC:
+			return ErrPressureTimeout
 		}
 	}
 

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -180,8 +180,8 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 // mutex window itself is bounded to pwrite + fsync + tree.Insert (~5µs
 // on NVMe).
 //
-// Deadline (I-3 / #670 defense-in-depth): the pressure wait is bounded
-// by bc.pressureMaxWait (FSStoreOptions.PressureMaxWait; default 30s).
+// Deadline (#670 defense-in-depth): the pressure wait is bounded by
+// bc.pressureMaxWait (FSStoreOptions.PressureMaxWait; default 30s).
 // On expiry AppendWrite returns ErrPressureTimeout — distinguishable
 // from ctx.Err() (caller-side deadline) and ErrStoreClosed (store
 // shutdown). This bound prevents a wedged rollup pool from translating
@@ -225,14 +225,14 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// rollup pulsed pressureCh but another writer consumed the freed
 	// budget before this goroutine could proceed.
 	//
-	// I-3 / #670: bound the wait with bc.pressureMaxWait so a wedged
-	// rollup cannot translate into NFS-client D-state. The timer is
-	// allocated lazily — only when we actually need to block — and is
-	// shared across pressureCh wake-ups so a sequence of false-wakes
-	// (rollup pulses + another writer immediately consumes the freed
-	// budget) still respects the cumulative deadline. Using time.NewTimer
-	// + defer Stop() instead of time.After avoids leaking the underlying
-	// timer goroutine when pressureCh or bc.done fires first.
+	// #670: bound the wait with bc.pressureMaxWait so a wedged rollup
+	// cannot translate into NFS-client D-state. The timer is allocated
+	// lazily — only when we actually need to block — and is shared across
+	// pressureCh wake-ups so a sequence of false-wakes (rollup pulses +
+	// another writer immediately consumes the freed budget) still
+	// respects the cumulative deadline. Using time.NewTimer + defer Stop()
+	// instead of time.After avoids leaking the underlying timer goroutine
+	// when pressureCh or bc.done fires first.
 	var pressureTimer *time.Timer
 	var pressureC <-chan time.Time
 	defer func() {

--- a/pkg/blockstore/local/fs/appendwrite_pressure_timeout_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_pressure_timeout_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 // TestAppendWrite_PressureTimeout_FiresWhenRollupStuck exercises the
-// I-3 / #670 defense-in-depth deadline added to AppendWrite's pressure
-// loop. Configures a tiny PressureMaxWait, primes the budget so the
-// second write would block, then withholds the pressureCh pulse and
-// expects ErrPressureTimeout within roughly PressureMaxWait + jitter.
+// defense-in-depth deadline added to AppendWrite's pressure loop (#670).
+// Configures a tiny PressureMaxWait, primes the budget so the second
+// write would block, then withholds the pressureCh pulse and expects
+// ErrPressureTimeout within roughly PressureMaxWait + jitter.
 //
 // No rollup worker runs here (StartRollup is not invoked); the test
 // simulates a wedged rollup by simply never pulsing pressureCh.
@@ -74,9 +74,9 @@ func TestAppendWrite_PressureTimeout_ContextDeadlinePreferredOverTimer(t *testin
 }
 
 // TestAppendWrite_PressureTimeout_DisabledByNegativeOption keeps the
-// pre-I-3 "block forever" semantics when PressureMaxWait < 0. The test
-// proves the disable path actually disables: the writer stays blocked
-// past what would have been the default deadline, then unblocks when
+// "block forever" semantics when PressureMaxWait < 0. The test proves
+// the disable path actually disables: the writer stays blocked past
+// what would have been the default deadline, then unblocks when
 // pressureCh is pulsed.
 func TestAppendWrite_PressureTimeout_DisabledByNegativeOption(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{

--- a/pkg/blockstore/local/fs/appendwrite_pressure_timeout_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_pressure_timeout_test.go
@@ -1,0 +1,119 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestAppendWrite_PressureTimeout_FiresWhenRollupStuck exercises the
+// I-3 / #670 defense-in-depth deadline added to AppendWrite's pressure
+// loop. Configures a tiny PressureMaxWait, primes the budget so the
+// second write would block, then withholds the pressureCh pulse and
+// expects ErrPressureTimeout within roughly PressureMaxWait + jitter.
+//
+// No rollup worker runs here (StartRollup is not invoked); the test
+// simulates a wedged rollup by simply never pulsing pressureCh.
+func TestAppendWrite_PressureTimeout_FiresWhenRollupStuck(t *testing.T) {
+	const wait = 200 * time.Millisecond
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1,
+		PressureMaxWait: wait,
+	})
+
+	// Prime: first write already pushes logBytesTotal past maxLogBytes=1.
+	if err := bc.AppendWrite(context.Background(), "file1", []byte("x"), 0); err != nil {
+		t.Fatalf("seed AppendWrite: %v", err)
+	}
+
+	// Second call enters the pressure loop and must return
+	// ErrPressureTimeout after ~wait (no pulse, no ctx deadline, no Close).
+	start := time.Now()
+	err := bc.AppendWrite(context.Background(), "file1", []byte("y"), 4096)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrPressureTimeout) {
+		t.Fatalf("AppendWrite err = %v, want ErrPressureTimeout", err)
+	}
+
+	// Lower bound: must have actually waited ~PressureMaxWait (no
+	// degenerate immediate-return regression). Allow a small slack for
+	// scheduler jitter on the timer fire.
+	if elapsed < wait/2 {
+		t.Fatalf("AppendWrite returned ErrPressureTimeout after only %v; expected ~%v", elapsed, wait)
+	}
+	// Upper bound: catch a regression that lets the loop block far past
+	// the configured deadline. Generous slack because race+CI runners
+	// can stall arbitrarily — the point is to fail-loud on "blocked
+	// forever", not to enforce a tight SLA.
+	if elapsed > wait+5*time.Second {
+		t.Fatalf("AppendWrite blocked %v past PressureMaxWait=%v", elapsed-wait, wait)
+	}
+}
+
+// TestAppendWrite_PressureTimeout_ContextDeadlinePreferredOverTimer
+// verifies that when both ctx.Done() and the pressure-timeout fire, the
+// caller still observes ctx.Err() preferentially when it lands first —
+// the new deadline must NOT swallow caller-side cancellation semantics.
+func TestAppendWrite_PressureTimeout_ContextDeadlinePreferredOverTimer(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1,
+		PressureMaxWait: 5 * time.Second, // far longer than the ctx
+	})
+	if err := bc.AppendWrite(context.Background(), "file1", []byte("x"), 0); err != nil {
+		t.Fatalf("seed AppendWrite: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := bc.AppendWrite(ctx, "file1", []byte("y"), 4096)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("AppendWrite err = %v, want context.DeadlineExceeded (ctx must win when it fires first)", err)
+	}
+}
+
+// TestAppendWrite_PressureTimeout_DisabledByNegativeOption keeps the
+// pre-I-3 "block forever" semantics when PressureMaxWait < 0. The test
+// proves the disable path actually disables: the writer stays blocked
+// past what would have been the default deadline, then unblocks when
+// pressureCh is pulsed.
+func TestAppendWrite_PressureTimeout_DisabledByNegativeOption(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1,
+		PressureMaxWait: -1, // explicitly disable
+	})
+	if err := bc.AppendWrite(context.Background(), "file1", []byte("x"), 0); err != nil {
+		t.Fatalf("seed AppendWrite: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- bc.AppendWrite(context.Background(), "file1", []byte("y"), 4096)
+	}()
+
+	// Wait longer than the default 30s would allow if disable were
+	// broken — we don't actually wait 30s, just long enough that an
+	// accidentally-enabled tiny default would have fired.
+	select {
+	case err := <-done:
+		t.Fatalf("AppendWrite returned %v while disabled; should be still blocking", err)
+	case <-time.After(300 * time.Millisecond):
+		// Still blocked — as expected.
+	}
+
+	// Release.
+	bc.logBytesTotal.Store(0)
+	select {
+	case bc.pressureCh <- struct{}{}:
+	default:
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AppendWrite after release: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AppendWrite did not unblock after pressure release")
+	}
+}

--- a/pkg/blockstore/local/fs/errors.go
+++ b/pkg/blockstore/local/fs/errors.go
@@ -19,4 +19,19 @@ var (
 	// ). Writers that observe the tombstone short-circuit before
 	// touching the log so a deleted payload never gains new records.
 	ErrDeleted = errors.New("append log: payload deleted")
+
+	// ErrPressureTimeout is returned by AppendWrite when its pressure
+	// loop has waited longer than FSStoreOptions.PressureMaxWait without
+	// rollup freeing enough log budget to admit the write. Distinguished
+	// from ctx.Err() (caller-imposed deadline) and ErrStoreClosed (the
+	// store is shutting down): ErrPressureTimeout specifically means the
+	// rollup pool is making no forward progress.
+	//
+	// I-3 / #670 — defense-in-depth. NFS COMMIT and SMB Flush typically
+	// arrive with no caller-supplied deadline (or one measured in
+	// minutes), so a wedged rollup translated into D-state on the client.
+	// Surfacing this sentinel lets the protocol adapter decide whether
+	// to map it to NFS3ERR_SERVERFAULT / STATUS_INTERNAL_ERROR, log, and
+	// release the goroutine instead of blocking indefinitely.
+	ErrPressureTimeout = errors.New("append log: pressure wait timed out")
 )

--- a/pkg/blockstore/local/fs/errors.go
+++ b/pkg/blockstore/local/fs/errors.go
@@ -25,13 +25,13 @@ var (
 	// rollup freeing enough log budget to admit the write. Distinguished
 	// from ctx.Err() (caller-imposed deadline) and ErrStoreClosed (the
 	// store is shutting down): ErrPressureTimeout specifically means the
-	// rollup pool is making no forward progress.
+	// rollup pool is making no forward progress (#670).
 	//
-	// I-3 / #670 — defense-in-depth. NFS COMMIT and SMB Flush typically
-	// arrive with no caller-supplied deadline (or one measured in
-	// minutes), so a wedged rollup translated into D-state on the client.
-	// Surfacing this sentinel lets the protocol adapter decide whether
-	// to map it to NFS3ERR_SERVERFAULT / STATUS_INTERNAL_ERROR, log, and
-	// release the goroutine instead of blocking indefinitely.
+	// NFS COMMIT and SMB Flush typically arrive with no caller-supplied
+	// deadline (or one measured in minutes), so a wedged rollup translates
+	// into D-state on the client. Surfacing this sentinel lets the protocol
+	// adapter decide whether to map it to NFS3ERR_SERVERFAULT /
+	// STATUS_INTERNAL_ERROR, log, and release the goroutine instead of
+	// blocking indefinitely.
 	ErrPressureTimeout = errors.New("append log: pressure wait timed out")
 )

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -173,11 +173,16 @@ type FSStore struct {
 
 	// pressureMaxWait caps how long AppendWrite blocks in the pressure
 	// loop before returning ErrPressureTimeout. Defense-in-depth against
-	// a wedged rollup (I-3 / #670): NFS COMMIT and SMB Flush callers
-	// commonly arrive with no usable deadline, so without an upper bound
-	// here a stuck rollup translates directly into D-state on the client.
-	// Default is set in newFSStoreInternal; FSStoreOptions.PressureMaxWait
-	// overrides it.
+	// a wedged rollup (#670): NFS COMMIT and SMB Flush callers commonly
+	// arrive with no usable deadline, so without an upper bound here a
+	// stuck rollup translates directly into D-state on the client.
+	//
+	// Internal encoding: 0 means "deadline disabled" (no timer armed in
+	// AppendWrite's pressure loop). The default 30s is installed by
+	// newFSStoreInternal before any option override runs; the only way
+	// this field is 0 post-construction is via an explicit negative
+	// FSStoreOptions.PressureMaxWait (test-only). Direct struct-literal
+	// construction of FSStore is not supported.
 	pressureMaxWait time.Duration
 
 	// logBytesTotal is the current total bytes of un-rolled-up log content
@@ -403,7 +408,7 @@ func newFSStoreInternal(baseDir string, maxDisk int64, maxMemory int64, fileBloc
 	bc.maxLogBytes = 1 << 30              // 1 GiB default
 	bc.stabilizationMS = 250              // default
 	bc.rollupWorkers = 2                  // default
-	bc.pressureMaxWait = 30 * time.Second // default — I-3 / #670 defense-in-depth
+	bc.pressureMaxWait = 30 * time.Second // default — #670 defense-in-depth
 	// rollupCh buffered so AppendWrite's non-blocking send rarely drops
 	// on drop, the ticker arm in chunkRollupWorker picks up the payload
 	// on the next scan.
@@ -641,14 +646,14 @@ type FSStoreOptions struct {
 	// PressureMaxWait bounds how long AppendWrite blocks in its pressure
 	// loop (logBytesTotal > maxLogBytes) before returning
 	// ErrPressureTimeout. Zero defers to the 30s default. A negative
-	// value disables the deadline (block indefinitely — pre-I-3 behavior,
-	// not recommended in production).
+	// value disables the deadline (block indefinitely; not recommended
+	// in production).
 	//
-	// Defense-in-depth against a wedged rollup pool (I-3 / #670). NFS
-	// COMMIT and SMB Flush adapters frequently arrive with no usable
-	// deadline, so without this bound a stuck rollup wedges the client
-	// process in D-state. Pick an upper-bound value clearly larger than
-	// any legitimate rollup latency under load — this is NOT an SLA.
+	// Defense-in-depth against a wedged rollup pool (#670). NFS COMMIT
+	// and SMB Flush adapters frequently arrive with no usable deadline,
+	// so without this bound a stuck rollup wedges the client process in
+	// D-state. Pick an upper-bound value clearly larger than any
+	// legitimate rollup latency under load — this is NOT an SLA.
 	PressureMaxWait time.Duration
 
 	// CompactionThresholdBytes controls when physical log compaction
@@ -709,8 +714,8 @@ func newFSStoreWithOptionsInternal(baseDir string, maxDisk, maxMemory int64, fil
 	case opts.PressureMaxWait > 0:
 		bc.pressureMaxWait = opts.PressureMaxWait
 	case opts.PressureMaxWait < 0:
-		// Negative explicitly disables the deadline (block forever — pre-I-3
-		// behavior). Required for tests that drive the pressure loop directly
+		// Negative explicitly disables the deadline (block forever).
+		// Required for tests that drive the pressure loop directly
 		// without a rollup worker; not recommended in production.
 		bc.pressureMaxWait = 0
 	}

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -171,6 +171,15 @@ type FSStore struct {
 	stabilizationMS int
 	rollupWorkers   int
 
+	// pressureMaxWait caps how long AppendWrite blocks in the pressure
+	// loop before returning ErrPressureTimeout. Defense-in-depth against
+	// a wedged rollup (I-3 / #670): NFS COMMIT and SMB Flush callers
+	// commonly arrive with no usable deadline, so without an upper bound
+	// here a stuck rollup translates directly into D-state on the client.
+	// Default is set in newFSStoreInternal; FSStoreOptions.PressureMaxWait
+	// overrides it.
+	pressureMaxWait time.Duration
+
 	// logBytesTotal is the current total bytes of un-rolled-up log content
 	// across every payloadID in this FSStore. Incremented by AppendWrite
 	// (framed-record size) and decremented by the rollup.
@@ -391,9 +400,10 @@ func newFSStoreInternal(baseDir string, maxDisk int64, maxMemory int64, fileBloc
 	bc.logIndices = make(map[string]*logIndex)
 	bc.tombstones = make(map[string]struct{})
 	bc.truncations = make(map[string]uint64)
-	bc.maxLogBytes = 1 << 30 // 1 GiB default
-	bc.stabilizationMS = 250 // default
-	bc.rollupWorkers = 2     // default
+	bc.maxLogBytes = 1 << 30              // 1 GiB default
+	bc.stabilizationMS = 250              // default
+	bc.rollupWorkers = 2                  // default
+	bc.pressureMaxWait = 30 * time.Second // default — I-3 / #670 defense-in-depth
 	// rollupCh buffered so AppendWrite's non-blocking send rarely drops
 	// on drop, the ticker arm in chunkRollupWorker picks up the payload
 	// on the next scan.
@@ -628,6 +638,19 @@ type FSStoreOptions struct {
 	// via pkg/config as blockstore.local.dedup_lru_size.
 	DedupLRUSize int
 
+	// PressureMaxWait bounds how long AppendWrite blocks in its pressure
+	// loop (logBytesTotal > maxLogBytes) before returning
+	// ErrPressureTimeout. Zero defers to the 30s default. A negative
+	// value disables the deadline (block indefinitely — pre-I-3 behavior,
+	// not recommended in production).
+	//
+	// Defense-in-depth against a wedged rollup pool (I-3 / #670). NFS
+	// COMMIT and SMB Flush adapters frequently arrive with no usable
+	// deadline, so without this bound a stuck rollup wedges the client
+	// process in D-state. Pick an upper-bound value clearly larger than
+	// any legitimate rollup latency under load — this is NOT an SLA.
+	PressureMaxWait time.Duration
+
 	// CompactionThresholdBytes controls when physical log compaction
 	// runs (#579). After a rollup pass advances idx.compactionFence
 	// the rewrite is invoked if the fence sits more than this many
@@ -681,6 +704,15 @@ func newFSStoreWithOptionsInternal(baseDir string, maxDisk, maxMemory int64, fil
 	}
 	if opts.StabilizationMS > 0 {
 		bc.stabilizationMS = opts.StabilizationMS
+	}
+	switch {
+	case opts.PressureMaxWait > 0:
+		bc.pressureMaxWait = opts.PressureMaxWait
+	case opts.PressureMaxWait < 0:
+		// Negative explicitly disables the deadline (block forever — pre-I-3
+		// behavior). Required for tests that drive the pressure loop directly
+		// without a rollup worker; not recommended in production.
+		bc.pressureMaxWait = 0
 	}
 	bc.rollupStore = opts.RollupStore
 	bc.syncedHashStore = opts.SyncedHashStore


### PR DESCRIPTION
v1.0 audit B-D3 — fixes engine-side defects feeding NFS COMMIT D-state hang.

Closes the v1.0 audit finding **I-3** (`.planning/v1.0-audit/blockstore/REVIEW.md` §3b, §6, §8 B-D3).

## Defect A — `pkg/blockstore/local/fs/appendwrite.go` pressure loop had no deadline

If the rollup pool ever wedged for any reason, every WRITE blocked forever. NFS RPCs without per-request deadlines (most adapters pass `context.Background()` or very long timeouts) translate directly into D-state on the client.

**Fix:** bound the pressure wait with a new `FSStoreOptions.PressureMaxWait` (default 30s — conservative upper bound on legitimate rollup latency, not an SLA). On timeout returns a new exported sentinel `ErrPressureTimeout` so callers can distinguish "stuck rollup" from `ctx.Err()` and `ErrStoreClosed`. Implementation uses `time.NewTimer` + `defer Stop()` (not `time.After`) to avoid goroutine leak under pressureCh-fires-first; timer is allocated lazily and shared across pressureCh wake-ups so a sequence of false-wakes still respects the cumulative deadline. `PressureMaxWait < 0` disables (pre-I-3 behavior, test-only).

## Defect B — `pkg/blockstore/engine/syncer.go` Flush returned Finalized=false with no retry contract

The contention branch (`uploading` CompareAndSwap loss) and the remote-unhealthy branch both returned `Finalized=false` immediately, but the Flush contract was under-documented. NFS COMMIT loops interpreted `Finalized=false` as "not yet done, retry" — and a tight retry storm against the `uploading` CAS gate makes the explicit caller lose every race against the periodic uploader and starve the upload goroutine.

**Fix:** doc-only — full `(Finalized, err)` state machine on `Flusher.Flush` godoc, `FlushResult.Finalized` comment, and explicit caller-guidance at the contention branch in `syncer.go` pointing to the I-3 / #670 starvation pattern with the recommended pattern: "surface the soft-fail to the protocol client (NFS3_COMMITTED=false; SMB Flush returns success after a bounded attempt) instead of spinning."

Chose doc-only over widening `FlushResult` with `RetryAfter`: every Flush implementation and caller would need to change otherwise, with no concrete consumer plan today. Trade-off noted in the audit prescription.

## Defense-in-depth context

B-D1 (#713) closed the actual production wedge cause (#668 rollup divergence), so this isn't an active-fire fix — but the engine should never block indefinitely on rollup regardless of cause. Defects A and B both apply.

## Tested with

- `go test -race -count=5 ./pkg/blockstore/local/fs/... ./pkg/blockstore/engine/...` — green
- `gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m` — clean
- Three new regression tests in `pkg/blockstore/local/fs/appendwrite_pressure_timeout_test.go`:
  - `TestAppendWrite_PressureTimeout_FiresWhenRollupStuck` — wedged rollup, expect `ErrPressureTimeout` within `PressureMaxWait + jitter`
  - `TestAppendWrite_PressureTimeout_ContextDeadlinePreferredOverTimer` — ctx.Err() still wins when it fires first
  - `TestAppendWrite_PressureTimeout_DisabledByNegativeOption` — `PressureMaxWait<0` truly disables the deadline (pre-I-3 behavior)

Fixes #670