### PR TITLE
docs(blockstore): address Copilot review (post-#735)

### DIFF
--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -255,8 +255,11 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 // attempt that races the periodic uploader's tick, so a tight
 // in-handler retry loop pegs the CPU without ever making progress and
 // starves the uploading goroutine. Recommended pattern: surface the
-// soft-fail to the protocol client (NFS3_COMMITTED=false; SMB Flush
-// returns success after a bounded attempt) instead of spinning.
+// soft-fail to the protocol adapter and let the client drive the next
+// attempt on its own schedule (e.g. NFSv3 reports the WRITE's
+// "committed" enum as UNSTABLE rather than DATASYNC/FILESYNC so the
+// client reissues COMMIT later; SMB Flush returns success after a
+// bounded attempt) instead of spinning in-handler.
 func (m *Syncer) Flush(ctx context.Context, payloadID string) (*blockstore.FlushResult, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return nil, err

--- a/pkg/blockstore/fileblock.go
+++ b/pkg/blockstore/fileblock.go
@@ -229,8 +229,10 @@ type Flusher interface {
 	//     LOSE every retry attempt against the periodic uploader's
 	//     in-flight tick) and pegs the CPU without making progress.
 	//     Recommended pattern: surface the soft-fail to the protocol
-	//     client (NFS3_COMMITTED=false → client reissues COMMIT on its
-	//     own schedule; SMB Flush returns success after a bounded
+	//     adapter and let the client drive the next attempt on its own
+	//     schedule (e.g. NFSv3 reports the WRITE's "committed" enum as
+	//     UNSTABLE rather than DATASYNC/FILESYNC so the client reissues
+	//     COMMIT later; SMB Flush returns success after a bounded
 	//     attempt) rather than spin in-handler.
 	//
 	//   - (nil, err)

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -231,8 +231,10 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// pressureCh wake-ups so a sequence of false-wakes (rollup pulses +
 	// another writer immediately consumes the freed budget) still
 	// respects the cumulative deadline. Using time.NewTimer + defer Stop()
-	// instead of time.After avoids leaking the underlying timer goroutine
-	// when pressureCh or bc.done fires first.
+	// instead of time.After lets the runtime release the timer slot as
+	// soon as pressureCh or bc.done fires first; time.After otherwise
+	// keeps the underlying runtime timer armed until the original deadline
+	// expires.
 	var pressureTimer *time.Timer
 	var pressureC <-chan time.Time
 	defer func() {

--- a/pkg/blockstore/local/fs/errors.go
+++ b/pkg/blockstore/local/fs/errors.go
@@ -15,9 +15,15 @@ var (
 	ErrLogBadHeaderCRC = errors.New("append log: bad header CRC")
 
 	// ErrDeleted is returned by AppendWrite when the payload's append log
-	// has been tombstoned by a concurrent DeleteAppendLog call (/
-	// ). Writers that observe the tombstone short-circuit before
-	// touching the log so a deleted payload never gains new records.
+	// has been tombstoned by a concurrent DeleteAppendLog call. Writers
+	// that observe the tombstone short-circuit before touching the log so
+	// a deleted payload never gains new records.
+	//
+	// Known limitation (#670): writers already blocked in AppendWrite's
+	// pressure loop do not observe the tombstone synchronously. They
+	// unblock on the next pressureCh pulse, ctx.Done(), bc.done, or
+	// PressureMaxWait expiry — whichever fires first. A delete may
+	// therefore surface as ErrPressureTimeout rather than ErrDeleted.
 	ErrDeleted = errors.New("append log: payload deleted")
 
 	// ErrPressureTimeout is returned by AppendWrite when its pressure


### PR DESCRIPTION
## Summary

Follow-up doc fixes addressing Copilot review on the bound-pressure-wait work (which shipped via #735).

The original scope of this PR was identical to #735, which was already merged to develop. After rebasing onto develop, only these incremental Copilot-driven doc fixes remain:

- **errors.go**: clean `ErrDeleted` godoc placeholder (`(/` stray text + empty line); document known limitation that writers blocked in AppendWrite's pressure loop surface as `ErrPressureTimeout` rather than `ErrDeleted` when a delete races (tombstone is observed only on the next pressureCh pulse, ctx.Done, bc.done, or PressureMaxWait expiry).
- **appendwrite.go**: reword `time.NewTimer` vs `time.After` rationale. `time.After` does NOT spawn a goroutine per call; the concern is the underlying runtime timer slot remaining armed until the original deadline expires.
- **fileblock.go**, **syncer.go**: replace fictional `NFS3_COMMITTED=false` retry-guidance with protocol-accurate wording. NFSv3 WRITE has a `committed` enum (UNSTABLE / DATASYNC / FILESYNC); COMMIT itself returns status+verifier with no boolean by that name.

## Test plan

- [x] go test -race -count=1 ./pkg/blockstore/local/fs/... ./pkg/blockstore/engine/... — green
- [x] gofmt / go vet / golangci-lint — clean
- [ ] Full CI green

Doc-only — no functional change.