### PR TITLE
refactor(blockstore): embed BlockStore in RemoteStore interface

### DIFF
--- a/pkg/blockstore/engine/gc_test.go
+++ b/pkg/blockstore/engine/gc_test.go
@@ -649,6 +649,9 @@ func (p *prefixDeleteFailerRemote) Delete(ctx context.Context, h blockstore.Cont
 	}
 	return p.inner.Delete(ctx, h)
 }
+func (p *prefixDeleteFailerRemote) Has(ctx context.Context, h blockstore.ContentHash) (bool, error) {
+	return p.inner.Has(ctx, h)
+}
 func (p *prefixDeleteFailerRemote) Head(ctx context.Context, h blockstore.ContentHash) (blockstore.Meta, error) {
 	return p.inner.Head(ctx, h)
 }
@@ -685,6 +688,9 @@ func (d *deleteCountingRemote) GetRange(ctx context.Context, h blockstore.Conten
 func (d *deleteCountingRemote) Delete(ctx context.Context, h blockstore.ContentHash) error {
 	d.deletes.Add(1)
 	return d.inner.Delete(ctx, h)
+}
+func (d *deleteCountingRemote) Has(ctx context.Context, h blockstore.ContentHash) (bool, error) {
+	return d.inner.Has(ctx, h)
 }
 func (d *deleteCountingRemote) Head(ctx context.Context, h blockstore.ContentHash) (blockstore.Meta, error) {
 	return d.inner.Head(ctx, h)

--- a/pkg/blockstore/remote/remote.go
+++ b/pkg/blockstore/remote/remote.go
@@ -4,13 +4,9 @@
 // storage. All operations are keyed by blockstore.ContentHash. The CAS
 // object key shape (cas/{hh}/{hh}/{hex}) is derived from the hash via
 // blockstore.FormatCASKey and is an implementation detail backends may
-// not expose. The interface is structurally compatible with
-// blockstore.BlockStore — future work retargets engine consumers onto
-// that unified type and this package becomes the s3 / memory backend
-// home. The methods on this interface match the unified BlockStore
-// method set verbatim, with two backend-specific additions
-// (ReadBlockVerified for production CAS reads, Close + HealthCheck +
-// Healthcheck for backend lifecycle / health).
+// not expose. The interface embeds blockstore.BlockStore and adds
+// backend-specific extras (ReadBlockVerified for production CAS reads,
+// Close + HealthCheck + Healthcheck for backend lifecycle / health).
 package remote
 
 import (
@@ -30,80 +26,17 @@ import (
 // strings appear on this surface. Backends derive their on-disk / on-wire
 // key shape via blockstore.FormatCASKey internally.
 //
-// The Put/Get/GetRange/Delete/Head/Walk method set matches the
-// unified blockstore.BlockStore contract byte-for-byte;
-// ReadBlockVerified is a backend-specific extension (NOT part of
-// BlockStore) used by the engine's verified-read path. Callers
-// type-assert to access it on the s3 backend; the memory backend
-// implements it as the trivial body-recompute case so test fixtures
-// can exercise the same code path.
+// The Put / Get / GetRange / Has / Delete / Head / Walk method set comes
+// from the embedded blockstore.BlockStore contract — byte-for-byte the
+// same semantics as the unified type. ReadBlockVerified is a
+// backend-specific extension (NOT part of BlockStore) used by the
+// engine's verified-read path; callers type-assert to access it on the
+// s3 backend, and the memory backend implements it as the trivial
+// body-recompute case so test fixtures can exercise the same code path.
+// Close / HealthCheck / Healthcheck cover backend lifecycle and health
+// probes — also outside the BlockStore contract.
 type RemoteStore interface {
-	// Put writes data under the CAS-shaped key derived from hash. Backends
-	// MUST stamp the content hash atomically with the PUT (S3
-	// x-amz-meta-content-hash header) — defense-in-depth.
-	// Idempotent on the same (hash, data) pair; a Put with the same hash
-	// but different bytes is undefined behavior — callers MUST NOT rely
-	// on either outcome.
-	//
-	// Returns an error if the backend is closed, the I/O fails, or the
-	// hash is zero (callers must compute the hash before calling).
-	Put(ctx context.Context, hash blockstore.ContentHash, data []byte) error
-
-	// Get returns the chunk bytes addressed by the given content hash.
-	// The returned []byte is freshly allocated and owned by the caller —
-	// implementations MUST NOT return a slice that aliases internal
-	// storage.
-	//
-	// Returns blockstore.ErrChunkNotFound when the chunk is absent.
-	//
-	// For S3, prefer ReadBlockVerified on the production read path — Get
-	// returns raw bytes WITHOUT BLAKE3 verification.
-	Get(ctx context.Context, hash blockstore.ContentHash) ([]byte, error)
-
-	// GetRange returns a byte sub-range [offset, offset+length) of the
-	// chunk addressed by hash. The returned slice is freshly allocated
-	// (same no-aliasing rule as Get). Returns blockstore.ErrChunkNotFound
-	// if the chunk is absent.
-	GetRange(ctx context.Context, hash blockstore.ContentHash, offset, length int64) ([]byte, error)
-
-	// Delete removes the object addressed by hash. Returns nil if the
-	// object does not exist (Delete is idempotent).
-	Delete(ctx context.Context, hash blockstore.ContentHash) error
-
-	// Head returns blockstore.Meta for the object addressed by hash
-	// without transferring the body. Returns blockstore.ErrChunkNotFound
-	// when the object is absent.
-	//
-	// The backend's defense-in-depth content-hash header (S3
-	// x-amz-meta-content-hash) is verified internally during
-	// ReadBlockVerified but is NOT echoed via Meta —
-	// the lookup key (ContentHash) is the input, not output, and Meta
-	// stays minimal {Size, LastModified}.
-	//
-	// Meta.LastModified MUST be non-zero (GC
-	// sweep fails closed otherwise). Backends that cannot natively report
-	// a timestamp MUST stamp time.Now() at Put time and surface that
-	// value here.
-	Head(ctx context.Context, hash blockstore.ContentHash) (blockstore.Meta, error)
-
-	// Walk enumerates every CAS object in the store. The callback
-	// receives the content hash and Meta for each object; ordering is
-	// unspecified (backends MAY parallelize internally; the conformance
-	// suite does not pin a traversal order).
-	//
-	// Returning blockstore.ErrStopWalk from the callback exits cleanly
-	// — Walk returns nil to the outer caller. Any other non-nil
-	// callback error halts the walk and Walk returns it wrapped with
-	//
-	//   fmt.Errorf("walk halted at %s: %w", hash, err)
-	//
-	// Context cancellation aborts immediately; the callback is NOT
-	// re-invoked after ctx.Err() != nil (Walk MUST surface ctx.Err()
-	// without one final spurious callback). Contract mirrors
-	// filepath.SkipDir / fs.SkipAll.
-	//
-	// See blockstore.ErrStopWalk for the sentinel doc.
-	Walk(ctx context.Context, fn func(hash blockstore.ContentHash, meta blockstore.Meta) error) error
+	blockstore.BlockStore
 
 	// ReadBlockVerified GETs the object addressed by hash and verifies
 	// that the body's BLAKE3 hash matches expected before returning

--- a/pkg/controlplane/runtime/snapshot_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_integration_test.go
@@ -649,6 +649,10 @@ func (r *interceptingRemote) Delete(ctx context.Context, hash blockstore.Content
 	return r.inner.Delete(ctx, hash)
 }
 
+func (r *interceptingRemote) Has(ctx context.Context, hash blockstore.ContentHash) (bool, error) {
+	return r.inner.Has(ctx, hash)
+}
+
 func (r *interceptingRemote) Head(ctx context.Context, hash blockstore.ContentHash) (blockstore.Meta, error) {
 	return r.inner.Head(ctx, hash)
 }

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -788,6 +788,10 @@ func (r *restoreRemote) Delete(ctx context.Context, hash blockstore.ContentHash)
 	return r.inner.Delete(ctx, hash)
 }
 
+func (r *restoreRemote) Has(ctx context.Context, hash blockstore.ContentHash) (bool, error) {
+	return r.inner.Has(ctx, hash)
+}
+
 func (r *restoreRemote) Head(ctx context.Context, hash blockstore.ContentHash) (blockstore.Meta, error) {
 	r.mu.Lock()
 	count := r.hashCallCounts[hash]

--- a/pkg/snapshot/syncgate_test.go
+++ b/pkg/snapshot/syncgate_test.go
@@ -267,6 +267,9 @@ func (e *errRemote) Get(context.Context, blockstore.ContentHash) ([]byte, error)
 func (e *errRemote) GetRange(context.Context, blockstore.ContentHash, int64, int64) ([]byte, error) {
 	return nil, e.err
 }
+func (e *errRemote) Has(context.Context, blockstore.ContentHash) (bool, error) {
+	return false, e.err
+}
 func (e *errRemote) Delete(context.Context, blockstore.ContentHash) error { return e.err }
 func (e *errRemote) Head(context.Context, blockstore.ContentHash) (blockstore.Meta, error) {
 	return blockstore.Meta{}, e.err
@@ -313,6 +316,9 @@ func (b *blockingRemote) Get(context.Context, blockstore.ContentHash) ([]byte, e
 }
 func (b *blockingRemote) GetRange(context.Context, blockstore.ContentHash, int64, int64) ([]byte, error) {
 	return nil, nil
+}
+func (b *blockingRemote) Has(context.Context, blockstore.ContentHash) (bool, error) {
+	return false, nil
 }
 func (b *blockingRemote) Delete(context.Context, blockstore.ContentHash) error { return nil }
 func (b *blockingRemote) Walk(context.Context, func(blockstore.ContentHash, blockstore.Meta) error) error {
@@ -372,6 +378,9 @@ func (c *countingRemote) Get(context.Context, blockstore.ContentHash) ([]byte, e
 func (c *countingRemote) GetRange(context.Context, blockstore.ContentHash, int64, int64) ([]byte, error) {
 	return nil, nil
 }
+func (c *countingRemote) Has(context.Context, blockstore.ContentHash) (bool, error) {
+	return false, nil
+}
 func (c *countingRemote) Delete(context.Context, blockstore.ContentHash) error { return nil }
 func (c *countingRemote) Walk(context.Context, func(blockstore.ContentHash, blockstore.Meta) error) error {
 	return nil
@@ -415,6 +424,9 @@ func (s *slowMissingRemote) Get(context.Context, blockstore.ContentHash) ([]byte
 }
 func (s *slowMissingRemote) GetRange(context.Context, blockstore.ContentHash, int64, int64) ([]byte, error) {
 	return nil, nil
+}
+func (s *slowMissingRemote) Has(context.Context, blockstore.ContentHash) (bool, error) {
+	return false, nil
 }
 func (s *slowMissingRemote) Delete(context.Context, blockstore.ContentHash) error { return nil }
 func (s *slowMissingRemote) Walk(context.Context, func(blockstore.ContentHash, blockstore.Meta) error) error {


### PR DESCRIPTION
## Summary

- Embed `blockstore.BlockStore` in `remote.RemoteStore` instead of redeclaring 6 methods (Put/Get/GetRange/Delete/Head/Walk).
- Keep the 4 backend-specific extras: `ReadBlockVerified`, `Close`, `HealthCheck`, `Healthcheck`.
- `Has` (already on `BlockStore`) is now part of the `RemoteStore` surface; both prod backends (`s3.Store`, `remotememory.Store`) already implement it.
- Test fixtures that manually forwarded every method now also forward `Has` (latent gap, not exercised before).

Net: 39 insertions, 80 deletions in 5 files. No behavior change.

Audit ref: `.planning/v1.0-audit/blockstore/REVIEW.md` C-09 / wave B-E2.

## Test plan

- [x] `gofmt -s -w .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` clean for changed files
- [x] `go build ./...`
- [x] `go test -race -count=1 ./pkg/blockstore/...`
- [x] `go test -race -count=1 ./pkg/snapshot/... ./pkg/controlplane/runtime/...`