### PR TITLE
refactor(blockstore): alias apiclient.BlockStoreStats to engine type

### DIFF
--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -7,32 +7,12 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 )
 
-// BlockStoreStats holds block store statistics returned by the server.
-// Mirrors pkg/blockstore/engine.BlockStoreStats.
-type BlockStoreStats struct {
-	FileCount         int   `json:"file_count"`
-	BlocksDirty       int   `json:"blocks_dirty"`
-	BlocksLocal       int   `json:"blocks_local"`
-	BlocksRemote      int   `json:"blocks_remote"`
-	BlocksTotal       int   `json:"blocks_total"`
-	LocalDiskUsed     int64 `json:"local_disk_used"`
-	LocalDiskMax      int64 `json:"local_disk_max"`
-	LocalMemUsed      int64 `json:"local_mem_used"`
-	LocalMemMax       int64 `json:"local_mem_max"`
-	ReadBufferEntries int   `json:"read_buffer_entries"`
-	ReadBufferUsed    int64 `json:"read_buffer_used"`
-	ReadBufferMax     int64 `json:"read_buffer_max"`
-	HasRemote         bool  `json:"has_remote"`
-	PendingSyncs      int   `json:"pending_syncs"`
-	PendingUploads    int   `json:"pending_uploads"`
-	CompletedSyncs    int   `json:"completed_syncs"`
-	FailedSyncs       int   `json:"failed_syncs"`
-
-	RemoteHealthy       bool    `json:"remote_healthy"`
-	EvictionSuspended   bool    `json:"eviction_suspended"`
-	OutageDurationSecs  float64 `json:"outage_duration_seconds"`
-	OfflineReadsBlocked int64   `json:"offline_reads_blocked"`
-}
+// BlockStoreStats is the wire-shape for block store statistics returned by
+// the server. It is a type alias of engine.BlockStoreStats so the client and
+// server share a single canonical definition (identical fields, identical
+// json tags). The alias preserves the JSON wire shape and lets callers pass
+// values across the apiclient/engine boundary without conversion.
+type BlockStoreStats = engine.BlockStoreStats
 
 // ShareBlockStoreStats holds block store statistics for a single share.
 type ShareBlockStoreStats struct {

--- a/pkg/apiclient/blockstore_stats_alias_test.go
+++ b/pkg/apiclient/blockstore_stats_alias_test.go
@@ -1,0 +1,62 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockStoreStats_IsEngineAlias asserts that the apiclient surface
+// BlockStoreStats is the literal same type as engine.BlockStoreStats — not a
+// look-alike struct. A type alias keeps the wire shape and lets values cross
+// the apiclient/engine boundary without a conversion shim.
+func TestBlockStoreStats_IsEngineAlias(t *testing.T) {
+	var a BlockStoreStats
+	var b engine.BlockStoreStats
+	assert.Equal(t,
+		reflect.TypeOf(a),
+		reflect.TypeOf(b),
+		"apiclient.BlockStoreStats must be a type alias of engine.BlockStoreStats",
+	)
+}
+
+// TestBlockStoreStats_WireShapeRoundTrip captures the JSON wire shape so any
+// future drift between server emission and client consumption is caught by
+// the test suite. Field names + json tags are load-bearing for REST clients.
+func TestBlockStoreStats_WireShapeRoundTrip(t *testing.T) {
+	src := engine.BlockStoreStats{
+		FileCount:           1,
+		BlocksDirty:         2,
+		BlocksLocal:         3,
+		BlocksRemote:        4,
+		BlocksTotal:         5,
+		LocalDiskUsed:       6,
+		LocalDiskMax:        7,
+		LocalMemUsed:        8,
+		LocalMemMax:         9,
+		ReadBufferEntries:   10,
+		ReadBufferUsed:      11,
+		ReadBufferMax:       12,
+		HasRemote:           true,
+		PendingSyncs:        13,
+		PendingUploads:      14,
+		CompletedSyncs:      15,
+		FailedSyncs:         16,
+		RemoteHealthy:       true,
+		EvictionSuspended:   true,
+		OutageDurationSecs:  1.5,
+		OfflineReadsBlocked: 17,
+	}
+
+	wire, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var dst BlockStoreStats
+	require.NoError(t, json.Unmarshal(wire, &dst))
+
+	assert.Equal(t, src, engine.BlockStoreStats(dst))
+}


### PR DESCRIPTION
## Summary

- `apiclient.BlockStoreStats` was a hand-maintained mirror of `engine.BlockStoreStats` — identical fields, identical json tags. Replace the duplicate struct with a Go type alias (`type BlockStoreStats = engine.BlockStoreStats`).
- Eliminates a future drift surface where the REST wire shape could silently diverge between server emission and client consumption.
- No new import edge: `pkg/apiclient` already depends on `pkg/blockstore/engine` (for `engine.GCStats`, `engine.GCRunSummary`, `engine.AuditRefcountsResult`).

## Wire-compat verification

- Field-by-field diff of the two structs pre-change: same names, same json tags, same Go types — wire shape unchanged.
- New `TestBlockStoreStats_WireShapeRoundTrip` pins JSON marshal/unmarshal across the alias boundary.
- New `TestBlockStoreStats_IsEngineAlias` asserts via `reflect.TypeOf` that the alias is the same type — guards against future regression that re-introduces a divergent struct.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1` across `pkg/apiclient/...`, `pkg/blockstore/engine/...`, `internal/controlplane/api/handlers/...`, `cmd/dfsctl/...`, `pkg/controlplane/runtime/shares/...`
- [ ] CI (smbtorture, full unit + integration)