### PR TITLE
refactor(blockstore): tighten engine surface and drop dead error type

### DIFF
--- a/pkg/blockstore/engine/cache.go
+++ b/pkg/blockstore/engine/cache.go
@@ -27,10 +27,10 @@ const defaultPrefetchWorkers = 4
 // worker pool (T-12-24 mitigation: non-blocking submit drops when full).
 const reqQueueSize = 64
 
-// CacheInterface is the narrow surface engine code depends on. The
+// cacheInterface is the narrow surface engine code depends on. The
 // concrete *Cache and the nullCache{} Null Object both satisfy it
 // eliminating defensive nil-checks across the engine package.
-type CacheInterface interface {
+type cacheInterface interface {
 	Get(hash blockstore.ContentHash) ([]byte, bool)
 	Put(hash blockstore.ContentHash, data []byte)
 	OnRead(payloadID string, hashes []blockstore.ContentHash, fileSize uint64)
@@ -40,8 +40,8 @@ type CacheInterface interface {
 }
 
 // Compile-time interface satisfaction checks.
-var _ CacheInterface = (*Cache)(nil)
-var _ CacheInterface = nullCache{}
+var _ cacheInterface = (*Cache)(nil)
+var _ cacheInterface = nullCache{}
 
 // TRANSITIONAL-NEXT-MILESTONE: cold-cache prefetch (see #519 "Deferred
 // to v0.17+"). When cold-cache prefetch lands, the Cache will be
@@ -86,7 +86,7 @@ type Cache struct {
 	trackerMu sync.Mutex
 	trackers  map[string]*seqTracker // payloadID -> tracker
 	reqCh     chan prefetchReq
-	loadFn    LoadByHashFn
+	loadFn    loadByHashFn
 	ctx       context.Context
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
@@ -101,13 +101,13 @@ type cacheEntry struct {
 	data []byte
 }
 
-// LoadByHashFn loads a block by ContentHash from the underlying store
+// loadByHashFn loads a block by ContentHash from the underlying store
 // (local FS or remote S3). Injected at NewCache time; called by the
 // prefetch worker pool when sequential detection triggers.
 //
 // Signature is CAS-keyed. The engine bridges to the local/remote
 // stores using FormatCASKey.
-type LoadByHashFn func(ctx context.Context, hash blockstore.ContentHash) ([]byte, error)
+type loadByHashFn func(ctx context.Context, hash blockstore.ContentHash) ([]byte, error)
 
 // seqTracker — per-payloadID sequential-read state machine. lastHashes
 // is a ring of the most recent OnRead hashes (capped at seqThreshold)
@@ -135,7 +135,7 @@ type CacheStats struct {
 	MaxBytes int64 `json:"max_bytes"`
 }
 
-// nullCache is a no-op CacheInterface implementation. The BlockStore
+// nullCache is a no-op cacheInterface implementation. The BlockStore
 // constructor substitutes nullCache{} when the cache budget is zero
 // eliminating defensive nil-checks across the engine (Null Object
 // pattern).
@@ -173,7 +173,7 @@ func newCacheNoWorkers(maxBytes int64) *Cache {
 //     drop requests (no-loader path).
 //   - The bounded reqCh has capacity reqQueueSize (64); submit is
 //     non-blocking and silently drops on full queue (T-12-24).
-func NewCache(maxBytes int64, workers int, loadFn LoadByHashFn) *Cache {
+func NewCache(maxBytes int64, workers int, loadFn loadByHashFn) *Cache {
 	if maxBytes <= 0 {
 		return nil
 	}

--- a/pkg/blockstore/engine/cache_test.go
+++ b/pkg/blockstore/engine/cache_test.go
@@ -135,7 +135,7 @@ func TestCache_InvalidateFile_Surgical(t *testing.T) {
 
 // --- Task 2: OnRead + sequential detection + worker pool ---
 
-// recordingLoader returns a LoadByHashFn that records every (hash) it
+// recordingLoader returns a loadByHashFn that records every (hash) it
 // is called with and lets the test inspect concurrency via an atomic
 // "in-flight" counter.
 type recordingLoader struct {

--- a/pkg/blockstore/engine/eager_dedup_test.go
+++ b/pkg/blockstore/engine/eager_dedup_test.go
@@ -30,7 +30,7 @@ import (
 	"lukechampine.com/blake3"
 )
 
-// recordingPutCache is a CacheInterface that records every Put so eager
+// recordingPutCache is a cacheInterface that records every Put so eager
 // dedup tests can assert cache warming (the existing recordingCache
 // has a no-op Put, which can't observe the warming).
 type recordingPutCache struct {

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -95,7 +95,7 @@ type BlockStore struct {
 	// Cache type. Never nil — the constructor substitutes nullCache{}
 	// for a disabled budget so engine code does not need defensive
 	// nil-checks (Null Object pattern).
-	cache CacheInterface
+	cache cacheInterface
 
 	readBufferBytes int64 // budget for the cache (0 = disabled / Null Object)
 	prefetchWorkers int   // stored from config, used in Start()
@@ -257,7 +257,7 @@ func New(cfg Config) (*BlockStore, error) {
 	// wire the BlockStore back-reference onto the Syncer so
 	// the file-level dedup short-circuit can reach BlockStore.cache for
 	// surgical invalidation of orphaned speculative chunks. Reading
-	// through the back-reference (instead of caching a CacheInterface
+	// through the back-reference (instead of caching a cacheInterface
 	// field on the Syncer at construction time) lets test code swap
 	// `bs.cache = rec` post-construction and still observe the
 	// invalidation — mirrors the TestClose_ClosesCache pattern.
@@ -316,7 +316,7 @@ func (bs *BlockStore) Start(ctx context.Context) error {
 	return nil
 }
 
-// loadByHash is the LoadByHashFn the Cache's prefetch workers call to
+// loadByHash is the loadByHashFn the Cache's prefetch workers call to
 // pull a block by ContentHash. It performs a single content-addressed
 // local read; local.Get is the only primitive (no mmap fast-path, no
 // legacy FileBlock → GetBlockData fallback).
@@ -365,10 +365,6 @@ func (bs *BlockStore) Close() error {
 // admin paths against the concrete *fs.FSStore via a type assertion.
 // Do not use in production code.
 func (bs *BlockStore) LocalForTest() local.LocalStore { return bs.local }
-
-// LocalForTest is the package-level counterpart used when the bs
-// receiver is shadowed; mirrors RemoteForTesting on the same wire.
-func LocalForTest(bs *BlockStore) local.LocalStore { return bs.local }
 
 // RemoteForTesting returns the remote store for cross-package test verification
 // (e.g., shared remote store identity). Do not use in production code.

--- a/pkg/blockstore/engine/engine_test.go
+++ b/pkg/blockstore/engine/engine_test.go
@@ -297,7 +297,7 @@ func TestEngine_NullCache_NoNilChecks(t *testing.T) {
 // TestEngine_NullCache_Methods_NoOp — Task 3 behavior 3.
 // Direct unit test: every nullCache method is a safe no-op.
 func TestEngine_NullCache_Methods_NoOp(t *testing.T) {
-	var c CacheInterface = nullCache{}
+	var c cacheInterface = nullCache{}
 
 	got, ok := c.Get(hashN(1))
 	if got != nil || ok {
@@ -315,7 +315,7 @@ func TestEngine_NullCache_Methods_NoOp(t *testing.T) {
 	}
 }
 
-// recordingCache is a CacheInterface impl used by Task 3 tests to
+// recordingCache is a cacheInterface impl used by Task 3 tests to
 // observe engine -> cache calls.
 type recordingCache struct {
 	mu              sync.Mutex

--- a/pkg/blockstore/engine/sync_health.go
+++ b/pkg/blockstore/engine/sync_health.go
@@ -9,9 +9,9 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// HealthTransitionCallback is invoked when the health state changes.
+// healthTransitionCallback is invoked when the health state changes.
 // The healthy parameter is true when transitioning to healthy, false when transitioning to unhealthy.
-type HealthTransitionCallback func(healthy bool)
+type healthTransitionCallback func(healthy bool)
 
 // HealthMonitor periodically probes a remote store and manages a healthy/unhealthy
 // state machine. It is the single source of truth for remote store availability.
@@ -33,7 +33,7 @@ type HealthMonitor struct {
 	consecutiveFailures atomic.Int32
 	unhealthySince      atomic.Int64 // Unix nanos; 0 when healthy
 
-	onTransition HealthTransitionCallback
+	onTransition healthTransitionCallback
 	mu           gosync.Mutex // Protects onTransition
 
 	stopCh   chan struct{}
@@ -106,7 +106,7 @@ func (hm *HealthMonitor) IsHealthy() bool {
 }
 
 // SetTransitionCallback sets the callback invoked on health state changes.
-func (hm *HealthMonitor) SetTransitionCallback(fn HealthTransitionCallback) {
+func (hm *HealthMonitor) SetTransitionCallback(fn healthTransitionCallback) {
 	hm.mu.Lock()
 	defer hm.mu.Unlock()
 	hm.onTransition = fn

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -83,7 +83,7 @@ type Syncer struct {
 	uploading       atomic.Bool // Guards against overlapping periodic upload ticks
 
 	healthMonitor   *HealthMonitor           // Monitors remote store health (nil when no remote)
-	onHealthChanged HealthTransitionCallback // Callback invoked on health state transitions
+	onHealthChanged healthTransitionCallback // Callback invoked on health state transitions
 
 	firstOfflineRead    atomic.Bool  // Tracks if WARN was already logged since last healthy->unhealthy transition
 	offlineReadsBlocked atomic.Int64 // Count of read operations blocked by remote unavailability
@@ -155,7 +155,7 @@ func (m *Syncer) SetSyncedHashStore(s metadata.SyncedHashStore) {
 
 // SetHealthCallback sets the callback invoked when the remote store health state changes.
 // If the HealthMonitor is already running, the callback is forwarded to it immediately.
-func (m *Syncer) SetHealthCallback(fn HealthTransitionCallback) {
+func (m *Syncer) SetHealthCallback(fn healthTransitionCallback) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.onHealthChanged = fn

--- a/pkg/blockstore/errors.go
+++ b/pkg/blockstore/errors.go
@@ -2,8 +2,6 @@ package blockstore
 
 import (
 	"errors"
-	"fmt"
-	"time"
 )
 
 // Standard block store errors. Protocol handlers should check for these errors
@@ -211,71 +209,3 @@ var (
 	// docs/CONFIGURATION.md §migration..
 	ErrLegacyLayoutDetected = errors.New("blockstore: legacy .blk layout detected (run `dfs migrate-to-cas`)")
 )
-
-// BlockStoreError wraps sentinel block store errors with structured debugging context.
-//
-// It provides rich operational metadata for diagnosing block storage issues
-// without losing compatibility with errors.Is() checks on the underlying sentinel.
-// For example
-//
-//	err := NewBlockStoreError("upload", "/archive", "abc123", 5, "s3", ErrUnavailable)
-//	errors.Is(err, ErrUnavailable) // true
-//
-// Fields capture the operation type, affected share, payload identifier, block
-// index, backend type, and the wrapped sentinel error. Optional fields (Size
-// Duration, Retries) can be set after construction for performance debugging.
-type BlockStoreError struct {
-	// Op describes the operation that failed: "upload", "download", "dedup", or "gc".
-	Op string
-
-	// Share is the share name providing routing context for the error.
-	Share string
-
-	// PayloadID is the content identifier of the affected payload.
-	PayloadID string
-
-	// BlockIdx is the block index within the chunk that failed.
-	BlockIdx uint32
-
-	// Size is the data size involved in the operation (bytes).
-	Size int64
-
-	// Duration is how long the operation ran before failing.
-	Duration time.Duration
-
-	// Retries is the number of retry attempts made before the final failure.
-	Retries int
-
-	// Backend identifies the storage backend type: "s3" or "memory".
-	Backend string
-
-	// Err is the wrapped sentinel error (e.g., ErrContentNotFound, ErrUnavailable).
-	Err error
-}
-
-// Error returns a human-readable description of the block store error including
-// the operation, underlying error, and key context fields.
-func (e *BlockStoreError) Error() string {
-	return fmt.Sprintf("blockstore %s: %s (share=%s, payload=%s, block=%d, backend=%s)",
-		e.Op, e.Err, e.Share, e.PayloadID, e.BlockIdx, e.Backend)
-}
-
-// Unwrap returns the underlying sentinel error, enabling errors.Is() and
-// errors.As() to match through BlockStoreError wrapping.
-func (e *BlockStoreError) Unwrap() error {
-	return e.Err
-}
-
-// NewBlockStoreError creates a BlockStoreError wrapping the given sentinel error
-// with operational context. Optional fields (Size, Duration, Retries) default
-// to zero and can be set on the returned pointer after construction.
-func NewBlockStoreError(op, share, payloadID string, blockIdx uint32, backend string, err error) *BlockStoreError {
-	return &BlockStoreError{
-		Op:        op,
-		Share:     share,
-		PayloadID: payloadID,
-		BlockIdx:  blockIdx,
-		Backend:   backend,
-		Err:       err,
-	}
-}


### PR DESCRIPTION
## Summary

Pure refactor sweep over `pkg/blockstore/` surface. Zero behaviour change. Five sub-changes:

1. `engine.CacheInterface` -> `engine.cacheInterface` (engine-internal; no external impls — verified via grep).
2. `engine.LoadByHashFn` -> `engine.loadByHashFn` (only consumer is `NewCache`).
3. `engine.HealthTransitionCallback` -> `engine.healthTransitionCallback` (consumed only by `HealthMonitor` / `Syncer`).
4. Delete the package-level `engine.LocalForTest(bs)` duplicate; the method form `(bs *BlockStore) LocalForTest()` is the sole caller path (`internal/adapter/common/write_payload_test.go` already uses the method).
5. Delete `blockstore.BlockStoreError` + `blockstore.NewBlockStoreError` — zero callers in the entire tree (`grep -rn 'BlockStoreError' --include='*.go'` confirmed empty outside the definition). Frees up `fmt` + `time` imports in `errors.go`.

Closes the B-A1 follow-up flagged in PR #682 and audit findings L-02 / V-2.

LoC delta: +22 / -96.

## Test plan

- [x] `gofmt -s -w . && go vet ./...`
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...` (full tree green)