### PR TITLE
refactor(blockstore/gc): drop ignored SweepConcurrency and deprecate empty stats fields

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -185,7 +185,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// and the engine falls back to hardcoded defaults.
 	rt.SetGCDefaults(&runtime.GCDefaults{
 		GracePeriod:      cfg.GC.GracePeriod,
-		SweepConcurrency: cfg.GC.SweepConcurrency,
 		DryRunSampleSize: cfg.GC.DryRunSampleSize,
 	})
 	// Wire operator-configured snapshot knobs into the runtime so

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -378,12 +378,12 @@ shares pointing at the same remote.
    identity** (`bucket+endpoint+prefix`), not share name (D-03), so an
    object reachable from any share that targets the same remote is
    considered live.
-2. **Sweep phase.** A bounded worker pool (default
-   `gc.sweep_concurrency=16`, max 32) walks the 256 top-level
-   `cas/{XX}/` prefixes in parallel (D-04). For each S3 key, the worker
-   keeps the object iff the hash is present in the live set OR the
-   object's `LastModified` is newer than `T − gc.grace_period` (default
-   1h, D-05). Otherwise the worker issues a DELETE.
+2. **Sweep phase.** A single `RemoteStore.Walk` enumerates every CAS
+   object cluster-wide; the backend (e.g. S3) paginates internally. For
+   each key, the engine keeps the object iff the hash is present in the
+   live set OR the object's `LastModified` is newer than
+   `T − gc.grace_period` (default 1h, D-05). Otherwise the engine issues
+   a DELETE.
 
 ### Fail-closed posture (INV-04)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -292,8 +292,7 @@ dfsctl store block gc-status /archive
 **Output:** the `GCRunSummary` JSON: `run_id`, `started_at`,
 `finished_at`, `hashes_marked`, `objects_swept`, `bytes_freed`,
 `duration_ms`, `error_count`, `error_samples`, plus the
-configuration snapshot (`grace_period`, `sweep_concurrency`,
-`dry_run`) used for the run.
+configuration snapshot (`grace_period`, `dry_run`) used for the run.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md#garbage-collection-mark-sweep-v0150-phase-11)
 for the full mark-sweep design and [CONFIGURATION.md](CONFIGURATION.md)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -365,10 +365,6 @@ blockstore:
                                 # WARN and is otherwise ignored. Schedule
                                 # via cron until the periodic scheduler
                                 # ships in a follow-up phase.
-    sweep_concurrency: 16       # Parallel cas/{XX}/ prefix workers.
-                                # Default 16, max 32. Higher values
-                                # accelerate sweep on large buckets but
-                                # increase risk of S3 503 SlowDown.
     grace_period: 1h            # Objects whose LastModified is newer than
                                 # (snapshot - grace_period) are NEVER
                                 # deleted. Default 1h. Values in (0, 5m)
@@ -400,9 +396,6 @@ blockstore:
 - `gc.grace_period` MUST be longer than your worst-case
   metadata-commit latency after a successful PUT. The default 1h is
   comfortable for any commit path that completes in seconds.
-- `gc.sweep_concurrency=16` is the validated default. Increase only
-  if you observe sweep-phase wall time as a bottleneck; back off on
-  S3 503 SlowDown. The hard cap is 32.
 
 Env-var mapping (dot-path convention; viper binds the top-level `syncer`
 and `gc` blocks directly, with no `blockstore.` prefix):
@@ -411,7 +404,6 @@ and `gc` blocks directly, with no `blockstore.` prefix):
 `DITTOFS_SYNCER_UPLOAD_CONCURRENCY`,
 `DITTOFS_SYNCER_CLAIM_TIMEOUT`,
 `DITTOFS_GC_INTERVAL`,
-`DITTOFS_GC_SWEEP_CONCURRENCY`,
 `DITTOFS_GC_GRACE_PERIOD`,
 `DITTOFS_GC_DRY_RUN_SAMPLE_SIZE`.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -202,8 +202,8 @@ fail-closed mark-sweep over the union of every live block's
    `bucket+endpoint+prefix`, not share name). The live set is built on
    disk under `<localStore>/gc-state/<runID>/db/` (memory-bounded
    regardless of metadata size).
-2. **Sweep.** Bounded worker pool (default `gc.sweep_concurrency=16`)
-   walks the 256 `cas/{XX}/` prefixes in parallel. An object is kept
+2. **Sweep.** A single `RemoteStore.Walk` enumerates every CAS object
+   cluster-wide (the backend paginates internally). An object is kept
    iff its hash is in the live set OR its `LastModified` is newer than
    `snapshot − gc.grace_period` (default 1h). Otherwise it is deleted.
 

--- a/pkg/blockstore/engine/gc.go
+++ b/pkg/blockstore/engine/gc.go
@@ -5,10 +5,11 @@
 //  1. MARK: stream every live FileBlock's ContentHash into a disk-backed
 //     live set (see GCState in gcstate.go). Memory is bounded regardless
 //     of metadata size.
-//  2. SWEEP: enumerate the 256 cas/XX/* prefixes via a bounded worker
-//     pool. For each object: parse the CAS key, skip foreign keys, apply
-//     the snapshot - GracePeriod TTL filter, and DELETE iff absent from
-//     the live set.
+//  2. SWEEP: enumerate the unified CAS namespace via a single
+//     RemoteStore.Walk call (the backend paginates internally). For each
+//     object: parse the CAS key, skip foreign keys, apply the
+//     snapshot - GracePeriod TTL filter, and DELETE iff absent from the
+//     live set.
 //
 // Invariants
 //   - (mark fail-closed): any error during EnumerateFileBlocks
@@ -127,9 +128,9 @@ func releaseGCRootLock(root string, entry *gcRootLock) {
 // GCStats holds statistics about the garbage collection run.
 //
 // The mark-sweep fields are authoritative; the legacy aggregator fields
-// (SharesScanned, BlocksScanned, OrphanFiles, OrphanBlocks, BytesReclaimed
-// Errors) are preserved for Runtime.RunBlockGC and the dfsctl gc-status
-// surface and are populated by finalizeStats as aliases of the new ones.
+// (OrphanFiles, OrphanBlocks, BytesReclaimed, Errors) are preserved for
+// Runtime.RunBlockGC and the dfsctl gc-status surface and are populated
+// by finalizeStats as aliases of the new ones.
 type GCStats struct {
 	RunID            string
 	HashesMarked     int64
@@ -142,8 +143,17 @@ type GCStats struct {
 	DryRunCandidates []string
 
 	// Legacy aggregator fields (compat aliases — see finalizeStats).
-	SharesScanned  int   // Always 0 in mark-sweep.
-	BlocksScanned  int   // Always 0 in mark-sweep.
+
+	// Deprecated: SharesScanned is retained on the REST/dfsctl wire for
+	// compatibility with older clients but is never populated by the
+	// mark-sweep engine and will always be zero. New consumers should
+	// rely on HashesMarked / the per-share log lines instead.
+	SharesScanned int
+	// Deprecated: BlocksScanned is retained on the REST/dfsctl wire for
+	// compatibility with older clients but is never populated by the
+	// mark-sweep engine and will always be zero. New consumers should
+	// rely on ObjectsSwept / HashesMarked instead.
+	BlocksScanned  int
 	OrphanFiles    int   // = ObjectsSwept.
 	OrphanBlocks   int   // = ObjectsSwept.
 	BytesReclaimed int64 // = BytesFreed.
@@ -170,10 +180,6 @@ type Options struct {
 	// LastModified is within snapshot - GracePeriod is preserved.
 	// Zero defaults to one hour.
 	GracePeriod time.Duration
-
-	// SweepConcurrency bounds the worker pool walking the 256 cas/XX/*
-	// prefixes. Zero defaults to 16; values above 32 are clamped.
-	SweepConcurrency int
 
 	// DryRunSampleSize bounds the count of candidate keys captured in
 	// GCStats.DryRunCandidates. Zero defaults to 1000.
@@ -273,13 +279,6 @@ func CollectGarbage(
 	if gracePeriod <= 0 {
 		gracePeriod = time.Hour
 	}
-	sweepConcurrency := options.SweepConcurrency
-	if sweepConcurrency <= 0 {
-		sweepConcurrency = 16
-	}
-	if sweepConcurrency > 32 {
-		sweepConcurrency = 32
-	}
 	dryRunSample := options.DryRunSampleSize
 	if dryRunSample <= 0 {
 		dryRunSample = 1000
@@ -322,7 +321,6 @@ func CollectGarbage(
 		"snapshot_time", snapshotTime,
 		"dry_run", options.DryRun,
 		"grace_period", gracePeriod,
-		"sweep_concurrency", sweepConcurrency,
 		"remote_endpoint_id", options.RemoteEndpointID,
 		"shares", options.Shares,
 		"hold_provider", options.HoldProvider != nil,
@@ -442,10 +440,9 @@ func sharesForReconciler(r MetadataReconciler) []string {
 // skipped (T-11-C-07). Objects within snapshot - GracePeriod are
 // preserved.
 //
-// sweepConcurrency is accepted for backward-compatibility with the
-// Options surface and ignored — collapsed the 256-way prefix
-// sharding onto RemoteStore.Walk, which paginates internally at the
-// backend layer. A future re-sharding extension (per-prefix Walk
+// There is no caller-side concurrency knob: the 256-way prefix sharding
+// has been collapsed onto RemoteStore.Walk, which paginates internally
+// at the backend layer. A future re-sharding extension (per-prefix Walk
 // fan-out) is expected to re-wire concurrency at the backend, not
 // here. Callers wanting per-prefix parallelism should file against
 // the backend.

--- a/pkg/blockstore/engine/gc_test.go
+++ b/pkg/blockstore/engine/gc_test.go
@@ -205,9 +205,8 @@ func TestGCMarkSweep_SweepHappyPath(t *testing.T) {
 
 	root := t.TempDir()
 	stats := CollectGarbage(ctx, rs, rec, &Options{
-		GCStateRoot:      root,
-		GracePeriod:      time.Minute, // < 2h so the seeded objects are eligible
-		SweepConcurrency: 4,
+		GCStateRoot: root,
+		GracePeriod: time.Minute, // < 2h so the seeded objects are eligible
 	})
 
 	if stats.HashesMarked != 3 {
@@ -606,9 +605,9 @@ func TestGCMarkSweep_StaleDirCleanup(t *testing.T) {
 // TestGCMarkSweep_ConcurrencyBound has been removed: the engine GC
 // sweep no longer shards work across 256 prefix workers (the
 // RemoteStore.Walk-based replacement enumerates every CAS object in
-// a single call, with sharding now an internal backend concern). The
-// SweepConcurrency Option remains as a tunable for a future
-// per-shard Walk extension but exposes no observable knob today.
+// a single call, with sharding now an internal backend concern).
+// Any future per-shard Walk extension can be driven by the backend
+// without re-introducing a caller-side concurrency knob.
 
 // ---------------------------------------------------------------------------
 // Test wrappers: failing reconciler, prefix-failing remote, concurrency tracker.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,9 +132,9 @@ func (c *SyncerConfig) Validate() error {
 }
 
 // GCConfig configures the engine.CollectGarbage mark-sweep run. Knobs
-// cover sweep concurrency, the grace TTL, the fail-closed mark
-// semantics, the continue-and-capture sweep, and the
-// disabled-by-default interval (operator opt-in).
+// cover the grace TTL, the fail-closed mark semantics, the
+// continue-and-capture sweep, and the disabled-by-default interval
+// (operator opt-in).
 type GCConfig struct {
 	// Interval is reserved for a future periodic-GC scheduler. v0.15.0
 	// ships only on-demand GC (dfsctl/REST). The field is parsed and
@@ -143,11 +143,6 @@ type GCConfig struct {
 	// scheduler is tracked for a follow-up. Schedule via cron in the
 	// meantime.
 	Interval time.Duration `mapstructure:"interval" yaml:"interval"`
-
-	// SweepConcurrency bounds the worker pool that walks the 256
-	// cas/XX/* prefixes during the sweep phase. Defaults to 16,
-	// capped at 32 to prevent storming the remote endpoint.
-	SweepConcurrency int `mapstructure:"sweep_concurrency" yaml:"sweep_concurrency"`
 
 	// GracePeriod is the TTL applied during sweep: an object whose
 	// LastModified is within snapshot - GracePeriod is preserved.
@@ -163,9 +158,6 @@ type GCConfig struct {
 // ApplyDefaults fills any zero-valued field with the defaults.
 func (c *GCConfig) ApplyDefaults() {
 	// Interval default is 0 (disabled — operator opt-in).
-	if c.SweepConcurrency <= 0 {
-		c.SweepConcurrency = 16
-	}
 	if c.GracePeriod <= 0 {
 		c.GracePeriod = time.Hour
 	}
@@ -184,12 +176,6 @@ func (c *GCConfig) ApplyDefaults() {
 // same sweep. Values in [5m, 10m) are accepted but emit a warn —
 // they're inside spec but tighter than the recommended floor.
 func (c *GCConfig) Validate() error {
-	if c.SweepConcurrency > 32 {
-		return fmt.Errorf("gc.sweep_concurrency must be <= 32 (got %d)", c.SweepConcurrency)
-	}
-	if c.SweepConcurrency < 0 {
-		return fmt.Errorf("gc.sweep_concurrency must be >= 0 (got %d)", c.SweepConcurrency)
-	}
 	if c.GracePeriod < 0 {
 		return fmt.Errorf("gc.grace_period must be >= 0 (got %v)", c.GracePeriod)
 	}

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -67,7 +67,6 @@ func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun boo
 			"shares", entry.Shares,
 			"dryRun", dryRun,
 			"gracePeriod", opts.GracePeriod,
-			"sweepConcurrency", opts.SweepConcurrency,
 			"dryRunSampleSize", opts.DryRunSampleSize)
 
 		// Per-remote MultiShareReconciler: the mark phase enumerates
@@ -148,7 +147,6 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 			"dryRun", dryRun,
 			"gcStateRoot", gcRoot,
 			"gracePeriod", opts.GracePeriod,
-			"sweepConcurrency", opts.SweepConcurrency,
 			"dryRunSampleSize", opts.DryRunSampleSize,
 		)
 
@@ -176,10 +174,10 @@ func (r *Runtime) GCStateDirForShare(name string) (string, error) {
 }
 
 // applyGCDefaults overlays operator-configured GC defaults onto opts.
-// Without this, the gc.grace_period / gc.sweep_concurrency /
-// gc.dry_run_sample_size knobs surfaced in pkg/config and validated at
-// startup would be silently ignored — every CollectGarbage invocation
-// would fall back to the engine's hardcoded defaults (1h, 16, 1000).
+// Without this, the gc.grace_period / gc.dry_run_sample_size knobs
+// surfaced in pkg/config and validated at startup would be silently
+// ignored — every CollectGarbage invocation would fall back to the
+// engine's hardcoded defaults (1h, 1000).
 //
 // Per-call opts fields take precedence over defaults so a future caller
 // can still override on a single run.
@@ -189,9 +187,6 @@ func applyGCDefaults(opts *engine.Options, defaults *GCDefaults) {
 	}
 	if opts.GracePeriod == 0 && defaults.GracePeriod > 0 {
 		opts.GracePeriod = defaults.GracePeriod
-	}
-	if opts.SweepConcurrency == 0 && defaults.SweepConcurrency > 0 {
-		opts.SweepConcurrency = defaults.SweepConcurrency
 	}
 	if opts.DryRunSampleSize == 0 && defaults.DryRunSampleSize > 0 {
 		opts.DryRunSampleSize = defaults.DryRunSampleSize
@@ -217,8 +212,9 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 	total.ObjectsSwept += s.ObjectsSwept
 	total.BytesFreed += s.BytesFreed
 	total.ErrorCount += s.ErrorCount
-	total.SharesScanned += s.SharesScanned
-	total.BlocksScanned += s.BlocksScanned
+	// SharesScanned / BlocksScanned are deprecated REST wire fields that
+	// are never populated by the mark-sweep engine — accumulation would
+	// always be zero, so it is skipped here. See engine.GCStats godoc.
 	total.OrphanFiles += s.OrphanFiles
 	total.OrphanBlocks += s.OrphanBlocks
 	total.BytesReclaimed += s.BytesReclaimed

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -582,11 +582,10 @@ func (r *Runtime) SetSyncerDefaults(cfg *shares.SyncerDefaults) {
 // GCDefaults captures the operator-configured GC knobs the runtime threads
 // into engine.Options on every CollectGarbage invocation. Without this
 // wiring the engine silently falls back to its hardcoded defaults (1h
-// grace, 16-way sweep, 1000-sample dry run) regardless of what the
-// operator put in gc.* config.
+// grace, 1000-sample dry run) regardless of what the operator put in
+// gc.* config.
 type GCDefaults struct {
 	GracePeriod      time.Duration
-	SweepConcurrency int
 	DryRunSampleSize int
 }
 


### PR DESCRIPTION
## Summary

- Delete `engine.Options.SweepConcurrency` end-to-end — the field was accepted by `engine.Options`, `pkg/config.GCConfig`, `runtime.GCDefaults`, and `cmd/dfs/commands/start.go`, but `engine.sweepPhase` collapsed to a single `RemoteStore.Walk` in Phase 17 and never actually paralellized anything. The knob has been inert scaffolding ever since.
- Mark `GCStats.SharesScanned` / `GCStats.BlocksScanned` as `// Deprecated:` — they were always zero under mark-sweep but stayed on the wire for REST compat. They keep their JSON shape and are no longer accumulated in `runtime.accumulateGCStats` (zero-valued accumulation was dead code).
- Refresh `docs/CONFIGURATION.md`, `docs/CLI.md`, `docs/ARCHITECTURE.md`, `docs/FAQ.md` and remove `DITTOFS_GC_SWEEP_CONCURRENCY` from the env-var mapping.

## Breaking change for operators

`gc.sweep_concurrency` and `DITTOFS_GC_SWEEP_CONCURRENCY` are removed from the config schema. Pre-1.0 DittoFS has no production operators; per project policy the legacy knob is dropped eagerly with no shim. **Please call this out in the v1.0 CHANGELOG.**

Audit refs: C-11 (delete) + C-12 (deprecate). REVIEW.md item B-E5.

## Test plan

- [x] `gofmt -s -w . && go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `golangci-lint run --timeout=5m` — clean (the 5 issues reported are in an unrelated sibling worktree's lint cache)
- [x] CI smoke