### PR TITLE
fix(smb/lock): walk back stale replay-protection KF rows (#744)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -306,19 +306,6 @@ incomplete break notification delivery and multi-client coordination.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 
-### Byte-Range Locks (Replay subset — depends on multichannel #482)
-
-The remaining smb2.lock failures are the replay-protection tests, which
-need LockSequence tracking + multichannel reflection support. Those land
-under #482 (multichannel session binding); track here so the parser
-recognises them.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.lock.replay_broken_windows | Locks | Lock replay requires LockSequence tracking | #744 |
-| smb2.lock.replay_smb3_specification_durable | Locks | Lock replay with durable handles needs LockSequence | #744 |
-| smb2.lock.replay_smb3_specification_multi | Locks | Lock replay across channels needs multichannel | #744 |
-
 ### Sessions (Remaining)
 
 Phase 73 Plan 03 implemented session re-authentication with key re-derivation


### PR DESCRIPTION
Closes #744.

## Summary

The 3 `smb2.lock.replay_*` tests tracked by #744 already pass on develop after #725 (`fix(smb): SMB3 replay protection`) shipped the `LockReplayCache` + `UnpackLockSequence` + LOCK-handler wiring. The KNOWN_FAILURES.md rows pre-dated #725 landing and were never walked back.

This PR removes the 3 stale rows (and the now-empty "Byte-Range Locks (Replay subset)" section header) from `test/smb-conformance/smbtorture/KNOWN_FAILURES.md`.

## CI evidence (develop tip before this PR)

From SMB Conformance Tests run 26622667939 (head commit `a438a54b` on develop), across all three storage backends:

```
smb2.lock.replay_broken_windows                                      SKIP
smb2.lock.replay_smb3_specification_durable                          PASS
smb2.lock.replay_smb3_specification_multi                            PASS
```

`SKIP` is the spec-correct outcome for `replay_broken_windows` against an SMB3 server that implements LockSequence for all handles (per the test's own `torture_skip_goto` branch at `source4/torture/smb2/lock.c:2958`).

## Tests flipped

- `smb2.lock.replay_broken_windows` -> SKIP (counts as PASS in the parser)
- `smb2.lock.replay_smb3_specification_durable` -> PASS
- `smb2.lock.replay_smb3_specification_multi` -> PASS

## Test plan

- [x] CI conformance run confirms PASS/PASS/SKIP on develop tip across memory, memory-fs, badger-fs.
- [ ] CI on this branch must stay green (smbtorture parser must not flag the 3 tests as NEW failures).