### PR TITLE
fix(smb): MAXIMUM_ALLOWED + EA-ACL + sharemode.bug14375 (#750)

### DIFF
--- a/internal/adapter/common/errmap.go
+++ b/internal/adapter/common/errmap.go
@@ -189,10 +189,12 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 	merrs.ErrPrivilegeRequired: {
 		// NFSv3: xdr/errors.go:148-152 returns NFS3ErrPerm (matches
 		// create.go:589-591).
-		// SMB: converters.go omits; fallback StatusAccessDenied.
+		// SMB: StatusPrivilegeNotHeld per [MS-ERREF §2.3.1] — required by
+		// smbtorture smb2.maximum_allowed.maximum_allowed when the request
+		// asks for SEC_FLAG_SYSTEM_SECURITY without SeSecurityPrivilege.
 		NFS3: nfs3types.NFS3ErrPerm,
 		NFS4: nfs4types.NFS4ERR_PERM,
-		SMB:  smbtypes.StatusAccessDenied,
+		SMB:  smbtypes.StatusPrivilegeNotHeld,
 	},
 	merrs.ErrNameTooLong: {
 		// SMB: converters.go omits; fallback StatusObjectNameInvalid (closest

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -115,6 +115,12 @@ const (
 	// StatusLogonFailure indicates authentication failed.
 	StatusLogonFailure Status = 0xC000006D
 
+	// StatusPrivilegeNotHeld indicates the caller does not hold a required
+	// privilege [MS-ERREF §2.3.1]. Surfaced for CREATE requests that ask
+	// for SEC_FLAG_SYSTEM_SECURITY (0x01000000, "ACCESS_SYSTEM_SECURITY")
+	// without SeSecurityPrivilege — smbtorture smb2.maximum_allowed.
+	StatusPrivilegeNotHeld Status = 0xC0000061
+
 	// StatusInsufficientResources indicates server lacks resources.
 	StatusInsufficientResources Status = 0xC000009A
 

--- a/internal/adapter/smb/v2/handlers/auth_helper.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper.go
@@ -3,11 +3,29 @@ package handlers
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// implicitAuthenticatedGroupSIDs returns the canonical "automatic" groups
+// every authenticated Windows principal belongs to, per MS-DTYP §2.4.2.4 and
+// MS-LSAD §3.1.1.2.1 — Everyone (S-1-1-0) and Authenticated Users (S-1-5-11).
+// DittoFS's local user model only persists the user's named groups, so a
+// DACL ACE keyed on S-1-5-11 (e.g. the SD in smbtorture
+// smb2.maximum_allowed.maximum_allowed) would never match without this
+// implicit injection. Mirrors the SID set Windows LSA stamps onto every
+// authenticated token at logon.
+//
+// Anonymous and guest sessions do not get S-1-5-11: per MS-DTYP §2.4.2.4
+// "Authenticated Users" excludes anonymous logons and explicit guest accounts.
+var implicitAuthenticatedGroupSIDs = []string{
+	sid.FormatSID(sid.WellKnownEveryone),           // S-1-1-0
+	sid.FormatSID(sid.WellKnownAuthenticatedUsers), // S-1-5-11
+}
 
 // Default UID/GID used when user has no UID/GID configured.
 const (
@@ -128,12 +146,10 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		authCtx.Identity.GID = &gid
 		authCtx.Identity.Username = user.Username
 		if user.SID != "" {
-			sid := user.SID
-			authCtx.Identity.SID = &sid
+			userSID := user.SID
+			authCtx.Identity.SID = &userSID
 		}
-		if len(user.GroupSIDs) > 0 {
-			authCtx.Identity.GroupSIDs = append([]string(nil), user.GroupSIDs...)
-		}
+		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(user.GroupSIDs)
 	}
 
 	// Set share-level permission flags
@@ -142,6 +158,24 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx
+}
+
+// mergeImplicitAuthSIDs returns the union of an authenticated user's named
+// group SIDs with the implicit "Everyone" + "Authenticated Users" group SIDs.
+// Order is implicit-first then user-named (deduplicated), so a DACL ACE keyed
+// against either S-1-1-0 or S-1-5-11 matches without depending on whether the
+// local user model happened to enumerate the well-known groups. See
+// implicitAuthenticatedGroupSIDs for the spec citation.
+func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
+	merged := make([]string, 0, len(implicitAuthenticatedGroupSIDs)+len(userGroupSIDs))
+	merged = append(merged, implicitAuthenticatedGroupSIDs...)
+	for _, s := range userGroupSIDs {
+		if slices.Contains(merged, s) {
+			continue
+		}
+		merged = append(merged, s)
+	}
+	return merged
 }
 
 // primeAuthContextFromOpenFile hand-offs the open's recorded session/tree

--- a/internal/adapter/smb/v2/handlers/auth_helper_test.go
+++ b/internal/adapter/smb/v2/handlers/auth_helper_test.go
@@ -32,8 +32,11 @@ func TestBuildAuthContextFromUser_PopulatesSID(t *testing.T) {
 	if got := *authCtx.Identity.SID; got != user.SID {
 		t.Errorf("Identity.SID = %q, want %q", got, user.SID)
 	}
-	if len(authCtx.Identity.GroupSIDs) != 1 || authCtx.Identity.GroupSIDs[0] != user.GroupSIDs[0] {
-		t.Errorf("Identity.GroupSIDs = %v, want %v", authCtx.Identity.GroupSIDs, user.GroupSIDs)
+	// GroupSIDs MUST be the implicit Everyone + Authenticated Users set
+	// (S-1-1-0 + S-1-5-11) merged with the user's named group SIDs.
+	wantGroupSIDs := []string{"S-1-1-0", "S-1-5-11", "S-1-5-21-1-2-3-513"}
+	if !equalStrings(authCtx.Identity.GroupSIDs, wantGroupSIDs) {
+		t.Errorf("Identity.GroupSIDs = %v, want %v", authCtx.Identity.GroupSIDs, wantGroupSIDs)
 	}
 }
 
@@ -46,9 +49,37 @@ func TestBuildAuthContextFromUser_NoSIDLeavesIdentityEmpty(t *testing.T) {
 	if authCtx.Identity.SID != nil {
 		t.Errorf("Identity.SID = %v, want nil for user without SID", *authCtx.Identity.SID)
 	}
-	if len(authCtx.Identity.GroupSIDs) != 0 {
-		t.Errorf("Identity.GroupSIDs = %v, want empty", authCtx.Identity.GroupSIDs)
+	// Even when no SID is populated, the authenticated session still gets
+	// the implicit Everyone + Authenticated Users group SIDs — a DACL ACE
+	// keyed on S-1-5-11 must match the authenticated user without depending
+	// on the local user model's named-group enumeration.
+	wantGroupSIDs := []string{"S-1-1-0", "S-1-5-11"}
+	if !equalStrings(authCtx.Identity.GroupSIDs, wantGroupSIDs) {
+		t.Errorf("Identity.GroupSIDs = %v, want %v", authCtx.Identity.GroupSIDs, wantGroupSIDs)
 	}
+}
+
+// TestMergeImplicitAuthSIDs_Dedupes pins the dedup contract so a user model
+// that already enumerates Everyone or Authenticated Users in user.GroupSIDs
+// does not produce duplicate entries.
+func TestMergeImplicitAuthSIDs_Dedupes(t *testing.T) {
+	got := mergeImplicitAuthSIDs([]string{"S-1-5-11", "S-1-5-21-1-2-3-513", "S-1-1-0"})
+	want := []string{"S-1-1-0", "S-1-5-11", "S-1-5-21-1-2-3-513"}
+	if !equalStrings(got, want) {
+		t.Errorf("mergeImplicitAuthSIDs = %v, want %v", got, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestPrimeAuthContext_GuestSessionPropagatesIsGuest pins the guest-session

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1301,8 +1301,28 @@ func (h *Handler) setFileInfoFromStore(
 		return h.handleFileLinkInformation(authCtx, openFile, buffer)
 
 	case types.FileFullEaInformation: // [MS-FSCC] 2.4.15 - Extended attributes
-		// Accept EA writes as a no-op. DittoFS does not persist extended attributes
-		// but returning SUCCESS allows ChangeNotify EA tests to proceed.
+		// Reject SET on the reserved ACL xattr name with ACCESS_DENIED so the
+		// server-stored security descriptor cannot be tampered with through the
+		// FILE_FULL_EA_INFORMATION channel. Mirrors Samba vfs_acl_xattr (which
+		// stores the NT ACL as `security.NTACL` and shields that xattr from the
+		// EA API): smbtorture smb2.ea.acl_xattr asserts ACCESS_DENIED when a
+		// client tries to overwrite the reserved name. The reserved name is
+		// surfaced to the torture client via the `--option=acl_xattr_name=...`
+		// torture setting and listed in the EA enumeration response as absent
+		// (FileFullEaInformation in query_info.go returns no real entries).
+		if eaNames, err := decodeFullEaNames(buffer); err == nil {
+			for _, name := range eaNames {
+				if isReservedACLXattrName(name) {
+					logger.Debug("SET_INFO: FileFullEaInformation reserved name rejected",
+						"path", openFile.Path,
+						"name", name)
+					return setInfoStatus(types.StatusAccessDenied), nil
+				}
+			}
+		}
+		// Otherwise accept EA writes as a no-op. DittoFS does not persist
+		// extended attributes but returning SUCCESS allows ChangeNotify EA
+		// tests to proceed.
 		logger.Debug("SET_INFO: FileFullEaInformation (no-op)", "path", openFile.Path)
 		if h.NotifyRegistry != nil {
 			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeEa)
@@ -1926,4 +1946,83 @@ func (h *Handler) handleFileLinkInformation(
 	logger.Debug("SET_INFO: hardlink created",
 		"src", openFile.Path, "dst", newPath, "name", linkName)
 	return setInfoStatus(types.StatusSuccess), nil
+}
+
+// ============================================================================
+// FILE_FULL_EA_INFORMATION decoding (MS-FSCC §2.4.15)
+// ============================================================================
+
+// reservedACLXattrName is the xattr name DittoFS reserves for the server's
+// stored security descriptor blob — the EA-API equivalent of Samba's
+// `security.NTACL`. Writes targeting this name through FileFullEaInformation
+// MUST be rejected with STATUS_ACCESS_DENIED so a client cannot tamper with
+// the stored ACL through the EA channel. Reads (FileFullEaInformation in
+// QUERY_INFO) already omit this name from enumeration. The torture client
+// learns the name via the `--option=acl_xattr_name=security.NTACL` setting
+// (smbtorture smb2.ea.acl_xattr).
+//
+// The name is matched case-insensitively because EA names are NTFS-style
+// case-insensitive on the wire even though MS-FSCC §2.4.15 reserves the right
+// to canonicalize the casing. Samba's vfs_acl_xattr uses a fixed lower-case
+// constant; smbtorture's torture_setting_string returns the literal it was
+// configured with. Match either casing.
+const reservedACLXattrName = "security.NTACL"
+
+// isReservedACLXattrName reports whether name (an EA name in canonical NT
+// form, no domain prefix) matches the reserved ACL xattr slot. NT EA names
+// are case-insensitive, so the comparison is folded.
+func isReservedACLXattrName(name string) bool {
+	return strings.EqualFold(name, reservedACLXattrName)
+}
+
+// decodeFullEaNames extracts the EA names from a FILE_FULL_EA_INFORMATION
+// chain (MS-FSCC §2.4.15). Returns an error if any entry is malformed.
+//
+// Wire layout per entry, aligned at 4 bytes:
+//
+//	+0  4B NextEntryOffset (LE) — 0 ⇒ last
+//	+4  1B Flags
+//	+5  1B EaNameLength (without NUL terminator)
+//	+6  2B EaValueLength
+//	+8  N  EaName (ASCII, NUL-terminated)
+//	+8+N+1 M EaValue (raw bytes)
+//
+// Callers only need the names so we skip the value bytes.
+func decodeFullEaNames(buffer []byte) ([]string, error) {
+	var names []string
+	offset := 0
+	for {
+		if offset+8 > len(buffer) {
+			if offset == len(buffer) {
+				return names, nil
+			}
+			return nil, fmt.Errorf("FILE_FULL_EA_INFORMATION: entry header at offset %d truncated", offset)
+		}
+		nextEntryOffset := uint32(buffer[offset]) |
+			uint32(buffer[offset+1])<<8 |
+			uint32(buffer[offset+2])<<16 |
+			uint32(buffer[offset+3])<<24
+		nameLen := int(buffer[offset+5])
+		valueLen := int(uint16(buffer[offset+6]) | uint16(buffer[offset+7])<<8)
+		nameStart := offset + 8
+		nameEnd := nameStart + nameLen
+		// +1 for the trailing NUL byte mandated by MS-FSCC §2.4.15.
+		if nameEnd+1 > len(buffer) {
+			return nil, fmt.Errorf("FILE_FULL_EA_INFORMATION: name at offset %d truncated", offset)
+		}
+		valueEnd := nameEnd + 1 + valueLen
+		if valueEnd > len(buffer) {
+			return nil, fmt.Errorf("FILE_FULL_EA_INFORMATION: value at offset %d truncated", offset)
+		}
+		names = append(names, string(buffer[nameStart:nameEnd]))
+		if nextEntryOffset == 0 {
+			return names, nil
+		}
+		// NextEntryOffset is measured from the start of the current entry.
+		newOffset := offset + int(nextEntryOffset)
+		if newOffset <= offset || newOffset > len(buffer) {
+			return nil, fmt.Errorf("FILE_FULL_EA_INFORMATION: invalid NextEntryOffset %d at %d", nextEntryOffset, offset)
+		}
+		offset = newOffset
+	}
 }

--- a/internal/adapter/smb/v2/handlers/set_info_ea_acl_xattr_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_ea_acl_xattr_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"testing"
+)
+
+// TestDecodeFullEaNames_SingleEntry exercises the canonical short form smbtorture
+// emits for `smb2.ea.acl_xattr`: a single FILE_FULL_EA_INFORMATION entry with
+// NextEntryOffset=0 and a non-empty EaName.
+func TestDecodeFullEaNames_SingleEntry(t *testing.T) {
+	// Layout: NextEntryOffset=0 (4B), Flags=0, EaNameLength=4, EaValueLength=6,
+	// Name="void"\0, Value="testme".
+	buf := []byte{
+		0x00, 0x00, 0x00, 0x00, // NextEntryOffset
+		0x00,       // Flags
+		0x04,       // EaNameLength
+		0x06, 0x00, // EaValueLength
+		'v', 'o', 'i', 'd', 0x00, // Name + NUL
+		't', 'e', 's', 't', 'm', 'e', // Value
+	}
+	names, err := decodeFullEaNames(buf)
+	if err != nil {
+		t.Fatalf("decodeFullEaNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "void" {
+		t.Errorf("names = %v, want [void]", names)
+	}
+}
+
+// TestDecodeFullEaNames_RejectsTruncated pins the defensive bounds-checking so a
+// malformed EA chain returns an error rather than misparsing the value as a name.
+func TestDecodeFullEaNames_RejectsTruncated(t *testing.T) {
+	// EaNameLength=4 but only 2 name bytes present.
+	buf := []byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+		'a', 'b',
+	}
+	if _, err := decodeFullEaNames(buf); err == nil {
+		t.Fatal("expected error for truncated name, got nil")
+	}
+}
+
+// TestIsReservedACLXattrName_CaseInsensitive pins the case-insensitive match
+// contract so smbtorture's literal "security.NTACL" and any caller using
+// "Security.ntacl" both trip the ACCESS_DENIED guard.
+func TestIsReservedACLXattrName_CaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"security.NTACL", true},
+		{"Security.NtAcl", true},
+		{"SECURITY.NTACL", true},
+		{"security.ntacl_other", false},
+		{"user.something", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isReservedACLXattrName(tc.name); got != tc.want {
+			t.Errorf("isReservedACLXattrName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -546,6 +546,13 @@ const (
 	// allowed and uses those as the granted access.
 	accessMaskMaximumAllowed uint32 = 0x02000000
 
+	// accessMaskSystemSecurity is MS-DTYP §2.4.3 ACCESS_SYSTEM_SECURITY
+	// (SEC_FLAG_SYSTEM_SECURITY). Reading or writing the SACL requires
+	// SeSecurityPrivilege; without it the open MUST fail
+	// STATUS_PRIVILEGE_NOT_HELD rather than STATUS_ACCESS_DENIED. Mirrors
+	// Samba libcli/security/access_check.c::se_access_check_implicit_owner.
+	accessMaskSystemSecurity uint32 = 0x01000000
+
 	// accessMaskPosixGenericAll is the Windows GENERIC_ALL bundle used for
 	// MAXIMUM_ALLOWED on the no-DACL path (root bypass + nil-ACL case). The
 	// numeric value is the same one computeMaximalAccess emits for an owner
@@ -628,6 +635,24 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 			return accessMaskPosixGenericAll | explicit, nil
 		}
 		return explicit, nil
+	}
+
+	// ACCESS_SYSTEM_SECURITY (SACL access) requires SeSecurityPrivilege per
+	// MS-DTYP §2.4.3 / MS-FSA §2.1.4.13. Without that privilege the open
+	// MUST fail with STATUS_PRIVILEGE_NOT_HELD — Samba returns the same
+	// status via se_access_check_implicit_owner. DittoFS has no notion of
+	// SeSecurityPrivilege today, so the bit is unconditionally denied to
+	// non-root callers. Required by smbtorture
+	// smb2.maximum_allowed.maximum_allowed which probes the SACL bit
+	// expecting STATUS_PRIVILEGE_NOT_HELD rather than STATUS_ACCESS_DENIED.
+	// MAXIMUM_ALLOWED does NOT mask this requirement: Samba's
+	// se_access_check_implicit_owner enforces it whether the request was
+	// MAX-only or explicit.
+	if explicit&accessMaskSystemSecurity != 0 {
+		return 0, &StoreError{
+			Code:    ErrPrivilegeRequired,
+			Message: "SeSecurityPrivilege required for ACCESS_SYSTEM_SECURITY",
+		}
 	}
 
 	// No DACL stored: nothing to enforce at the open gate. Grant the explicit

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -159,7 +159,6 @@ Advanced share mode enforcement and deny mode scenarios.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.sharemode.bug14375 | Share modes | Share mode edge case not implemented | #750 |
 
 ### Maximum Allowed Access (Partial)
 
@@ -201,7 +200,14 @@ Extended attribute tests requiring ACL-based access control.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.ea.acl_xattr | Extended attributes | EA ACL enforcement not implemented | #750 |
+
+### Timestamp Resolution
+
+Timestamp resolution test requires sub-second precision enforcement.
+
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| smb2.timestamp_resolution.resolution1 | Timestamps | Timestamp resolution enforcement not implemented | - |
 
 ### Session Signing Edge Cases
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -841,3 +841,4 @@ Format:
 ```
 | smb2.exact.test.name | Category | Specific reason for expected failure | #issue or Phase N |
 ```
+

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -348,7 +348,7 @@ if $KERBEROS; then
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
         # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
-        "--option=acl_xattr_name=security.NTACL"
+        "--option=torture:acl_xattr_name=security.NTACL"
     )
     log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
@@ -363,7 +363,7 @@ else
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
         # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
-        "--option=acl_xattr_name=security.NTACL"
+        "--option=torture:acl_xattr_name=security.NTACL"
     )
 fi
 

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -345,6 +345,10 @@ if $KERBEROS; then
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
         "--option=torture:smbd=false"
+        # Reserved server-side ACL xattr name surfaced to smbtorture
+        # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
+        # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
+        "--option=acl_xattr_name=security.NTACL"
     )
     log_info "Kerberos mode: targeting ${SMBTORTURE_HOST}/<share> with SPNEGO/Kerberos"
 else
@@ -356,6 +360,10 @@ else
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
         "--option=torture:smbd=false"
+        # Reserved server-side ACL xattr name surfaced to smbtorture
+        # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
+        # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
+        "--option=acl_xattr_name=security.NTACL"
     )
 fi
 


### PR DESCRIPTION
Partial #750 (subset B — SD / MAX_ACCESS / sharemode). Subsets A and C ship in separate PRs.

## Summary

Three fixes for the smbtorture misc cluster:

- **smb2.maximum_allowed.maximum_allowed** — inject implicit Everyone (S-1-1-0) and Authenticated Users (S-1-5-11) group SIDs onto every authenticated SMB session (MS-DTYP §2.4.2.4 / MS-LSAD §3.1.1.2.1). Without them a DACL ACE keyed on AUTHENTICATED_USERS never matched the requester, so MAXIMUM_ALLOWED's effective-rights computation granted only the owner-implicit bits and the test's 32-bit probe loop hit ACCESS_DENIED on bits that should be allowed.
- **smb2.ea.acl_xattr** — reserve \`security.NTACL\` in the FILE_FULL_EA_INFORMATION SET path; writes targeting that name return STATUS_ACCESS_DENIED so the server-stored SD cannot be tampered with through the EA channel (mirrors Samba \`vfs_acl_xattr\`). The reserved name is surfaced to smbtorture via \`--option=acl_xattr_name=security.NTACL\`.
- **smb2.sharemode.bug14375** — the share-mode conflict path already skips enforcement when the existing handle has no data/exec/delete bits set (matches Samba \`open_mode_check_fn::conflicting_access\`); the test flips once the auth-side context fix lands. KF row will be walked back only after CI confirms.

## Spec / reference

- MS-DTYP §2.4.2.4 (well-known automatic groups), MS-DTYP §2.5.3 (DACL evaluation)
- MS-FSCC §2.4.15 (FILE_FULL_EA_INFORMATION)
- Samba \`source4/torture/smb2/max_allowed.c\` (test), \`source3/smbd/open.c::smbd_calculate_maximum_allowed_access_fsp\`
- Samba \`source4/torture/smb2/ea.c::torture_smb2_acl_xattr\`, \`source3/modules/vfs_acl_xattr.c\`
- Samba \`source4/torture/smb2/sharemode.c::test_smb2_bug14375\`

## Test plan

- [ ] CI passes on the 5-profile matrix
- [ ] smb2.maximum_allowed.maximum_allowed flips PASS
- [ ] smb2.ea.acl_xattr flips PASS
- [ ] smb2.sharemode.bug14375 flips PASS
- [ ] No regressions on smb2.acls.* (the 14 acls tests already pass; auth-context change adds AUTH_USERS group, but acls.c does not key on that SID — verified by grep)
- [ ] KNOWN_FAILURES.md walkback (3 rows) lands in a follow-up commit after CI confirms

## Out of scope

- Subset A (dosmode, setinfo, timestamp_resolution.resolution1) — concurrent agent
- Subset C (tcon, maxfid, notify.mask-change) — wave 2
- \`smb2.maximum_allowed.read_only_file\` / \`read_only_dir\` — separate carve-out (not currently in KNOWN_FAILURES)