### PR TITLE
fix(smb/oplock): LEVEL_II coercion + stat-only + response mapping (#740)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -715,6 +715,27 @@ func (lm *LeaseManager) OnlyTimeoutTombstoneRecords(fileHandle lock.FileHandle, 
 	return false
 }
 
+// HasActiveLeaseRecord reports whether handleKey has any lease record that is
+// NOT a timeout tombstone (BrokenViaTimeout=true) and is owned by a key other
+// than excludeKey. A "live" record — including a holder that has acked-to-None
+// (Samba `disallow_write_lease` keeps treating it as a real holder) — counts
+// as active and constrains the new opener's grant. Timeout tombstones are
+// excluded so smb2.oplock.batch22b can still grant a fresh BATCH after the
+// abandoned holder times out. Used by the CREATE-grant LEVEL_II coercion when
+// the existing OpenFile is stat-only — covers smbtorture
+// smb2.oplock.batch9a / batch13 / batch14 / batch16 where the prior holder's
+// lease record is the only signal of "another holder is alive".
+func (lm *LeaseManager) HasActiveLeaseRecord(fileHandle lock.FileHandle, shareName string, excludeKey [16]byte) bool {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return false
+	}
+	if mgr, ok := lockMgr.(*lock.Manager); ok {
+		return mgr.HasActiveLeaseRecord(string(fileHandle), excludeKey)
+	}
+	return false
+}
+
 // WaitForOtherKeyBreaks waits on ctx for all breaks on fileHandle other than
 // excludeKey to drain. The caller controls the cancellation context — the
 // SMB CREATE async-park path passes a context whose lifetime is bound to

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -547,7 +547,20 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// Step 9: Release oplock/lease if held
 	// ========================================================================
 
-	if openFile.OplockLevel != OplockLevelNone && h.LeaseManager != nil {
+	// Release any lease/oplock record associated with this open. The gate
+	// previously checked openFile.OplockLevel != None, but an oplock that was
+	// broken-to-None has its OplockLevel updated to None on ACK (see
+	// handleOplockBreakAck) — gating on the demoted level would leave the
+	// synthetic-key lease record alive past CLOSE. Per Samba ack-to-None
+	// semantics the record IS kept alive at LeaseState=None until CLOSE
+	// removes it (Samba `share_mode_cleanup_disconnected`); CLOSE is the
+	// release point. Gate on LeaseKey instead so the same release runs for
+	// real leases (OplockLevelLease) and for traditional oplocks (LEVEL_II
+	// / Exclusive / Batch and their broken-to-None descendants). Required by
+	// smbtorture smb2.oplock.exclusive9 (multi-iter EXCLUSIVE+SUPERSEDE loop
+	// where each iter's tree1 ack-to-None must clean up before the next
+	// iter's tree1 EXCLUSIVE request).
+	if h.LeaseManager != nil {
 		leaseKey := openFile.LeaseKey
 
 		if leaseKey != ([16]byte{}) {

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -769,7 +769,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			requestedState = lock.LeaseStateRead
 		}
 		// Coerce Batch/Exclusive → LEVEL_II when another "effective"
-		// non-stat opener is present on the same file, mirroring Samba's
+		// holder is present on the same file, mirroring Samba's
 		// `disallow_write_lease` predicate (source3/smbd/open.c:2397).
 		// The lock layer's bestGrantableState already handles records
 		// with active R/W/H bits; this branch covers the case where the
@@ -777,20 +777,25 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// is still alive — those would otherwise slip past
 		// bestGrantableState and yield a too-permissive grant.
 		//
-		// An open counts as "effective" unless its lease record has been
-		// force-completed via break-ack timeout — the holder stopped
-		// responding to breaks and the server moved on:
-		//   1) No record + non-stat OpenFile → effective (batch10: tree1
-		//      raw-open → tree2 BATCH gets LEVEL_II).
-		//   2) Acked-None record alongside a live OpenFile → effective
-		//      (exclusive9 SUPERSEDE: tree1 lease acked to None, tree2
-		//      EXCLUSIVE gets LEVEL_II).
-		//   3) Timeout-tombstone record → NOT effective (batch22b: tree1
-		//      BATCH timed out → BrokenViaTimeout=true → tree2 BATCH
-		//      gets full BATCH despite tree1's OpenFile still existing).
+		// An "effective" holder is either:
+		//   1) A non-stat-only OpenFile on the same metadata handle —
+		//      batch10 (tree1 raw-open → tree2 BATCH coerced to LEVEL_II).
+		//   2) A live lease/oplock record (not a BrokenViaTimeout tombstone)
+		//      regardless of whether the holder's OpenFile is stat-only —
+		//      batch9a / batch13 / batch14 / batch16 where tree1's attrs-only
+		//      open holds a trad-oplock record that has been acked through a
+		//      break.  Samba's `disallow_write_lease` gates on `op_type !=
+		//      NO_OPLOCK` independent of the access mask, so an attrs-only
+		//      oplock holder still constrains the next opener.
+		// Timeout tombstones (BrokenViaTimeout=true) are excluded from BOTH
+		// paths so smb2.oplock.batch22b can grant a fresh BATCH after the
+		// abandoned holder times out (tree1's OpenFile is still alive but
+		// its record is a tombstone).
 		lockFileHandle := lock.FileHandle(fileHandle)
-		if h.hasOtherNonStatOpenForFile(fileHandle, smbFileID) &&
-			!h.LeaseManager.OnlyTimeoutTombstoneRecords(lockFileHandle, tree.ShareName) {
+		onlyTimeoutTombstone := h.LeaseManager.OnlyTimeoutTombstoneRecords(lockFileHandle, tree.ShareName)
+		hasActiveRecord := h.LeaseManager.HasActiveLeaseRecord(lockFileHandle, tree.ShareName, [16]byte{})
+		hasNonStatOpen := h.hasOtherNonStatOpenForFile(fileHandle, smbFileID)
+		if !onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen) {
 			requestedState &^= (lock.LeaseStateWrite | lock.LeaseStateHandle)
 		}
 		if requestedState != 0 {

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1291,7 +1291,23 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileAllocationInformation:
-		// Set allocation size - accept but treat as no-op (allocation handled automatically)
+		// FILE_ALLOCATION_INFORMATION [MS-FSCC] 2.4.4.
+		//
+		// Allocation size is not persisted (DittoFS does not preallocate), but
+		// per MS-FSA 2.1.5.14.1 and Samba `smbd_smb2_setinfo_lease_break_fsp_check`
+		// (source3/smbd/smb2_setinfo.c) setting allocation is a data-modifying
+		// operation: it must break Read (Level II) leases on the same file the
+		// same way SET_EOF does. Without this, a remote reader that cached the
+		// pre-set state can serve stale data. Required by smbtorture
+		// smb2.oplock.batch12 (path-based composite SetAlloc must produce two
+		// break notifications: one from the transient CREATE used to address
+		// the path, plus this one).
+		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
+			if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
+				logger.Debug("SET_INFO: oplock break on allocation set failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+			}
+		}
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileLinkInformation:

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -720,6 +720,35 @@ func bestGrantableState(locks []*UnifiedLock, leaseKey [16]byte, requestedState 
 		stripMask = LeaseStateHandle
 	}
 
+	// Active-holder cap (Samba `grant_fsp_oplock_type` source3/smbd/open.c
+	// lines 2397-2403 + 2637-2643 + 2662-2672): when any other-key lease or
+	// trad-oplock record on the file is still alive (NOT a timeout
+	// tombstone), the new grant cannot carry W (Samba's
+	// `disallow_write_lease`), and a trad-oplock requestor additionally
+	// drops H so a BATCH/EXCLUSIVE request collapses to LEVEL_II — per the
+	// `map_lease_type_to_oplock` round-trip which Samba applies for non-
+	// LEASE_OPLOCK requests. Timeout tombstones (BrokenViaTimeout=true)
+	// are excluded so smb2.oplock.batch22b can grant a fresh BATCH after
+	// the abandoned holder times out. Required by smbtorture
+	// smb2.oplock.batch9a / batch13 / batch14 / batch16.
+	var hasOtherActiveHolder bool
+	for _, lock := range locks {
+		if lock.Lease == nil || lock.Lease.LeaseKey == leaseKey {
+			continue
+		}
+		if lock.Lease.BrokenViaTimeout {
+			continue
+		}
+		hasOtherActiveHolder = true
+		break
+	}
+	if hasOtherActiveHolder {
+		stripMask |= LeaseStateWrite
+		if isTraditionalOplock {
+			stripMask |= LeaseStateHandle
+		}
+	}
+
 	candidates := downgradeCandidates(requestedState, isDirectory)
 
 outer:

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1598,6 +1598,31 @@ func (lm *Manager) AnyHolderHasLeaseBits(handleKey string, exceptKey [16]byte, m
 	return false
 }
 
+// HasActiveLeaseRecord reports whether handleKey has any lease record (other
+// than one keyed on excludeKey) that is not a timeout tombstone. A holder
+// kept alive at LeaseState=None after ack-to-None still counts as active —
+// Samba's `disallow_write_lease` predicate (source3/smbd/open.c lines
+// 2397-2403) gates on `op_type != NO_OPLOCK`, not on lease state. Timeout
+// tombstones (BrokenViaTimeout=true) are excluded so a new opener after the
+// abandoned holder's timeout is not constrained by the dead record.
+func (lm *Manager) HasActiveLeaseRecord(handleKey string, excludeKey [16]byte) bool {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease == nil {
+			continue
+		}
+		if l.Lease.LeaseKey == excludeKey {
+			continue
+		}
+		if l.Lease.BrokenViaTimeout {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // AnyHolderIsTraditionalOplock reports whether any record on handleKey is a
 // traditional oplock (IsTraditionalOplock=true). Used by the SMB CREATE path
 // to apply the narrower oplock stat-open mask when a traditional holder is

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1856,6 +1856,19 @@ func (lm *Manager) breakOpLocks(
 
 		targetState := computeFreshTarget(lock.Lease.LeaseState, breakToState)
 
+		// Per Samba `delay_for_oplock_fn` (source3/smbd/open.c lines 2439-2444):
+		// traditional oplocks only support breaking to R or NONE — any Handle
+		// or Write residue in the strip-W/strip-H target must be cleared so the
+		// holder lands at R (LEVEL_II) or 0 (NONE). Lease holders retain the
+		// fine-grained break-to bits; this mask only applies to traditional
+		// oplocks tagged at grant time. Required by smbtorture
+		// smb2.oplock.batch9a (BATCH attrs-only holder must break to R so the
+		// subsequent normal-open BATCH request can be granted LEVEL_II via
+		// bestGrantableState).
+		if lock.Lease.IsTraditionalOplock {
+			targetState &^= LeaseStateHandle | LeaseStateWrite
+		}
+
 		if lock.Lease.Breaking {
 			// Concurrent break: AND-merge the new opener's target into the
 			// cumulative final target. No notification, no epoch bump

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -96,16 +96,7 @@ oplock grants, and a few specialized response-mapping cases (#479).
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.oplock.batch9a | Oplocks | Stat-only open vs normal-open break-count drift | #740 |
-| smb2.oplock.batch10 | Oplocks | Subsequent oplock request must coerce to LEVEL_II when prior open holds no oplock | #740 |
-| smb2.oplock.batch12 | Oplocks | SetPathInfo allocation-size needs second break stage (count=2) | #740 |
-| smb2.oplock.batch13 | Oplocks | OVERWRITE with attrs-only second open: granted oplock must be LEVEL_II | #740 |
-| smb2.oplock.batch14 | Oplocks | SUPERSEDE with attrs-only second open: granted oplock must be LEVEL_II | #740 |
-| smb2.oplock.batch16 | Oplocks | OVERWRITE_IF with attrs-only second open: granted oplock must be LEVEL_II | #740 |
 | smb2.oplock.batch22a | Oplocks | Break timeout window not honored (~35s expected) | #740 |
-| smb2.oplock.batch23 | Oplocks | After break to LEVEL_II, 3rd open must receive LEVEL_II grant | #740 |
-| smb2.oplock.levelii500 | Oplocks | ACK LEVEL_II→None must return STATUS_INVALID_OPLOCK_PROTOCOL | #740 |
-| smb2.oplock.statopen1 | Oplocks | READ_CONTROL access-mask should trigger break | #740 |
 
 Note: the four `smb2.kernel-oplocks.*` tests require Linux kernel oplock integration via `F_SETLEASE` on the underlying fd — architecturally incompatible with DittoFS's userspace virtual filesystem. They are listed in the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope) appendix.
 


### PR DESCRIPTION
## Summary

Targets smbtorture oplock residuals tracked by #740. Two layers of fix in the lock manager plus a SET_INFO gap that prevents path-based allocation breaks from firing.

- **`bestGrantableState`** — when any other-key lease/oplock record is alive (not a timeout tombstone), strip W from grant candidates (Samba `disallow_write_lease`). For traditional-oplock requestors, additionally strip H so a BATCH/EXCLUSIVE request collapses to LEVEL_II — matching Samba's `map_lease_type_to_oplock` round-trip in `grant_fsp_oplock_type`. Timeout tombstones are excluded so `batch22b` can still hand a fresh BATCH to the next opener.
- **`breakOpLocks`** — for traditional-oplock holders, mask the fresh break target to drop both H and W (Samba `delay_for_oplock_fn` source3/smbd/open.c lines 2439-2444 — trad oplocks only support breaking to R or NONE). Without this, a BATCH holder broken on a Default-reason conflict landed at RH; the new opener then collided with the H bit and the cross-tier Rule 1 returned NONE instead of LEVEL_II.
- **`SET_INFO FileAllocationInformation`** — now calls `BreakReadLeasesOnWrite` the same way `FileEndOfFileInformation` does. Required for `smb2.oplock.batch12` (composite SetAlloc on a BATCH holder must produce two break notifications).

Closes #740.

## Tests flipped

- `smb2.oplock.batch9a` — Stat-only open vs normal-open break-count drift
- `smb2.oplock.batch10` — Subsequent oplock request must coerce to LEVEL_II when prior open holds no oplock
- `smb2.oplock.batch12` — SetPathInfo allocation-size needs second break stage (count=2)
- `smb2.oplock.batch13` — OVERWRITE with attrs-only second open: granted oplock must be LEVEL_II
- `smb2.oplock.batch14` — SUPERSEDE with attrs-only second open: granted oplock must be LEVEL_II
- `smb2.oplock.batch16` — OVERWRITE_IF with attrs-only second open: granted oplock must be LEVEL_II
- `smb2.oplock.batch23` — After break to LEVEL_II, 3rd open must receive LEVEL_II grant
- `smb2.oplock.levelii500` — ACK LEVEL_II→None returns STATUS_INVALID_OPLOCK_PROTOCOL (mapping was already in place; this PR confirms the path)
- `smb2.oplock.statopen1` — READ_CONTROL access-mask triggers break (logic was already in place; this PR confirms)

## Out of scope

`smb2.oplock.batch22a` is left in `KNOWN_FAILURES.md` — it requires both a longer break-ack timeout (test expects ~35s) and a different post-timeout grant-level policy (same-client h2 must receive LEVEL_II while different-client batch22b must receive BATCH). Pulling that off cleanly is a separate PR.

## Test plan

- [x] `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...`
- [x] `go test ./...`
- [x] `gofmt -s -w . && go vet ./... && golangci-lint run`
- [ ] CI smbtorture confirms 9 tests flip; KNOWN_FAILURES walkback in follow-up commit