### PR TITLE
fix(smb/session): reconnect + bind-negative + re-auth + anon-encryption residuals (#746)

### DIFF
--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -685,6 +685,15 @@ const (
 
 	// ErrResponseTooShort is returned when NT response is too short.
 	ErrResponseTooShort Error = "ntlm: response too short"
+
+	// ErrMalformedResponse is returned when the NTLMv2_RESPONSE structure
+	// itself is parseable as bytes but violates MS-NLMP §2.2.2.7 / §2.2.2.8
+	// — e.g. wrong RespType / HiRespType, AV_PAIR list missing the EOL
+	// terminator, or an AV_PAIR length that overruns the buffer. Callers
+	// surface this distinctly from a wrong-password failure so that
+	// SESSION_SETUP can answer STATUS_INVALID_PARAMETER (Samba/Windows
+	// behaviour for smb2.session.ntlmssp_bug14932) instead of LOGON_FAILURE.
+	ErrMalformedResponse Error = "ntlm: malformed NTLMv2 response"
 )
 
 // =============================================================================
@@ -759,6 +768,17 @@ func ValidateNTLMv2Response(
 	ntProofStr := ntResponse[:16]
 	clientBlob := ntResponse[16:]
 
+	// Validate NTLMv2_CLIENT_CHALLENGE structure (MS-NLMP §2.2.2.7) before
+	// the HMAC compare so a deliberately malformed blob is distinguished
+	// from a wrong-password (HMAC-mismatch) failure. The wire-level
+	// distinction is what smb2.session.ntlmssp_bug14932 asserts: the
+	// "netapp diag" NtChallengeResponse parses as NTLM but its AV_PAIR list
+	// is unwalkable, so the server MUST answer STATUS_INVALID_PARAMETER
+	// rather than STATUS_LOGON_FAILURE.
+	if err := validateNTLMv2ClientChallenge(clientBlob); err != nil {
+		return sessionKey, err
+	}
+
 	// Compute NTLMv2 hash
 	ntlmv2Hash := ComputeNTLMv2Hash(ntHash, username, domain)
 
@@ -781,6 +801,54 @@ func ValidateNTLMv2Response(
 	copy(sessionKey[:], mac.Sum(nil))
 
 	return sessionKey, nil
+}
+
+// validateNTLMv2ClientChallenge walks the NTLMv2_CLIENT_CHALLENGE that
+// follows NTProofStr in an NTLMv2_RESPONSE (MS-NLMP §2.2.2.7) and returns
+// ErrMalformedResponse when the fixed header or the AV_PAIR list cannot be
+// parsed. A correct AV_PAIR list ends with MsvAvEOL (AvId=0, AvLen=0).
+//
+// Fields validated:
+//   - RespType (byte 0)        MUST be 0x01.
+//   - HiRespType (byte 1)      MUST be 0x01.
+//   - Fixed header length (28 bytes minimum: RespType..Reserved3).
+//   - Each AV_PAIR's AvLen must not overrun the buffer.
+//   - The list must terminate with an MsvAvEOL pair before the buffer ends.
+//
+// Reserved fields are not enforced (Windows clients have been observed to
+// send nonzero bytes there).
+func validateNTLMv2ClientChallenge(blob []byte) error {
+	const (
+		ntlmv2RespType     = 0x01
+		ntlmv2HiRespType   = 0x01
+		clientChallengeHdr = 28 // RespType..Reserved3
+		avPairHeader       = 4  // AvId(2) + AvLen(2)
+		msvAvEOL           = 0
+	)
+	if len(blob) < clientChallengeHdr {
+		return ErrMalformedResponse
+	}
+	if blob[0] != ntlmv2RespType || blob[1] != ntlmv2HiRespType {
+		return ErrMalformedResponse
+	}
+	pairs := blob[clientChallengeHdr:]
+	for {
+		if len(pairs) < avPairHeader {
+			return ErrMalformedResponse
+		}
+		avID := binary.LittleEndian.Uint16(pairs[0:2])
+		avLen := binary.LittleEndian.Uint16(pairs[2:4])
+		if int(avLen) > len(pairs)-avPairHeader {
+			return ErrMalformedResponse
+		}
+		pairs = pairs[avPairHeader+int(avLen):]
+		if avID == msvAvEOL {
+			if avLen != 0 {
+				return ErrMalformedResponse
+			}
+			return nil
+		}
+	}
 }
 
 // DeriveSigningKey derives the final signing key from the session base key.

--- a/internal/adapter/smb/auth/ntlm_test.go
+++ b/internal/adapter/smb/auth/ntlm_test.go
@@ -466,11 +466,59 @@ func TestValidateNTLMv2Response(t *testing.T) {
 	t.Run("InvalidResponse", func(t *testing.T) {
 		ntHash := ComputeNTHash("password")
 		serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-		invalidResponse := make([]byte, 32) // Long enough but invalid
+		// Structurally valid NTLMv2_RESPONSE (NTProofStr + 28-byte
+		// CLIENT_CHALLENGE header + MsvAvEOL) whose NTProofStr is all-zero.
+		// HMAC compare against a real ntHash will fail → ErrAuthenticationFailed.
+		invalidResponse := make([]byte, 16+28+4)
+		invalidResponse[16] = 0x01 // RespType
+		invalidResponse[17] = 0x01 // HiRespType
 
 		_, err := ValidateNTLMv2Response(ntHash, "user", "DOMAIN", serverChallenge, invalidResponse)
 		if err != ErrAuthenticationFailed {
 			t.Errorf("Expected ErrAuthenticationFailed, got %v", err)
+		}
+	})
+
+	t.Run("MalformedRespType", func(t *testing.T) {
+		ntHash := ComputeNTHash("password")
+		serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+		bad := make([]byte, 16+28+4)
+		bad[16] = 0xFF // wrong RespType
+		bad[17] = 0x01
+		_, err := ValidateNTLMv2Response(ntHash, "user", "DOMAIN", serverChallenge, bad)
+		if err != ErrMalformedResponse {
+			t.Errorf("Expected ErrMalformedResponse, got %v", err)
+		}
+	})
+
+	t.Run("MalformedAvPairOverrun", func(t *testing.T) {
+		ntHash := ComputeNTHash("password")
+		serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+		// AvLen=0x8108 overruns the buffer — matches the netapp diag tool
+		// blob from MS-SMB2 conformance test smb2.session.ntlmssp_bug14932.
+		bad := make([]byte, 16+28+4)
+		bad[16] = 0x01
+		bad[17] = 0x01
+		bad[16+28+0] = 0x11
+		bad[16+28+1] = 0xa2 // AvId
+		bad[16+28+2] = 0x08
+		bad[16+28+3] = 0x81 // AvLen = 33032
+		_, err := ValidateNTLMv2Response(ntHash, "user", "DOMAIN", serverChallenge, bad)
+		if err != ErrMalformedResponse {
+			t.Errorf("Expected ErrMalformedResponse, got %v", err)
+		}
+	})
+
+	t.Run("MalformedNoEOL", func(t *testing.T) {
+		ntHash := ComputeNTHash("password")
+		serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+		// Exactly 28 bytes of header, no AV_PAIR list at all → falls off the end.
+		bad := make([]byte, 16+28)
+		bad[16] = 0x01
+		bad[17] = 0x01
+		_, err := ValidateNTLMv2Response(ntHash, "user", "DOMAIN", serverChallenge, bad)
+		if err != ErrMalformedResponse {
+			t.Errorf("Expected ErrMalformedResponse, got %v", err)
 		}
 	})
 

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -21,6 +21,14 @@ var ErrDecryptFailed = errors.New("SMB3 decryption failed")
 // (MS-SMB2 §3.3.5.2.7) instead of silently dropping the message.
 var ErrUnknownSession = errors.New("encrypted message for unknown session")
 
+// ErrNoDecryptor indicates the session exists but has no derivable AEAD
+// key (anonymous / guest / SMB 2.x). Encrypting requests on such a session
+// is a protocol error — smbtorture's smb2.session.anon-encryption{1,2,3}
+// drives exactly this path and asserts CONNECTION_RESET. Callers terminate
+// the TCP connection on this error instead of treating it as a transient
+// decrypt failure (which would let the client retry indefinitely).
+var ErrNoDecryptor = errors.New("session has no decryptor (anonymous / guest)")
+
 // EncryptableSession is the minimal interface for a session that supports encryption.
 // This decouples the middleware from the full session.Session type to avoid circular imports.
 type EncryptableSession interface {
@@ -92,6 +100,19 @@ func (m *sessionEncryptionMiddleware) DecryptRequest(transformMessage []byte) ([
 			th.SessionId, ErrUnknownSession, ErrDecryptFailed)
 	}
 
+	// Anonymous / guest / SMB 2.x sessions never derive AEAD keys, so they
+	// have no decryptor. An encrypted request reaching such a session is a
+	// protocol violation (MS-SMB2 §3.3.5.2.1 — "If Session.SessionFlags has
+	// the SMB2_SESSION_FLAG_IS_NULL or SMB2_SESSION_FLAG_IS_GUEST bit set,
+	// the request MUST be rejected"). Surface a typed error so the connection
+	// layer can drop the TCP connection rather than retrying decrypt
+	// (smbtorture smb2.session.anon-encryption{1,2,3} asserts CONNECTION_RESET).
+	nonceSize := sess.DecryptorNonceSize()
+	if nonceSize == 0 {
+		return nil, th.SessionId, fmt.Errorf("session 0x%x has no decryptor: %w: %w",
+			th.SessionId, ErrNoDecryptor, ErrDecryptFailed)
+	}
+
 	// Extract encrypted data (everything after the 52-byte transform header)
 	encryptedData := transformMessage[header.TransformHeaderSize:]
 
@@ -103,7 +124,6 @@ func (m *sessionEncryptionMiddleware) DecryptRequest(transformMessage []byte) ([
 	copy(ciphertextWithTag[len(encryptedData):], th.Signature[:])
 
 	// Extract nonce (first NonceSize bytes from the 16-byte Nonce field)
-	nonceSize := sess.DecryptorNonceSize()
 	nonce := make([]byte, nonceSize)
 	copy(nonce, th.Nonce[:nonceSize])
 

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -27,7 +27,7 @@ var ErrUnknownSession = errors.New("encrypted message for unknown session")
 // drives exactly this path and asserts CONNECTION_RESET. Callers terminate
 // the TCP connection on this error instead of treating it as a transient
 // decrypt failure (which would let the client retry indefinitely).
-var ErrNoDecryptor = errors.New("session has no decryptor (anonymous / guest)")
+var ErrNoDecryptor = errors.New("session has no decryptor (anonymous / guest / SMB 2.x)")
 
 // EncryptableSession is the minimal interface for a session that supports encryption.
 // This decouples the middleware from the full session.Session type to avoid circular imports.

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -26,6 +26,13 @@ import (
 // (which should drop the connection after 5 attempts).
 var ErrUnknownEncryptedSession = errors.New("encrypted message for unknown session")
 
+// ErrAnonEncryption is returned by ReadRequest when a transform-header
+// message targets a session that exists but has no AEAD decryptor — an
+// anonymous, guest, or SMB 2.x session. The connection loop closes the TCP
+// connection on this error (smbtorture smb2.session.anon-encryption{1,2,3}
+// asserts CONNECTION_RESET).
+var ErrAnonEncryption = errors.New("encrypted message for session without decryptor")
+
 // SigningVerifier verifies SMB2 message signatures during request reading.
 // This decouples the framing layer from session management.
 type SigningVerifier interface {
@@ -112,6 +119,9 @@ func ReadRequest(
 					SessionID:  transformSessionID,
 				}
 				return synthetic, nil, nil, true, ErrUnknownEncryptedSession
+			}
+			if errors.Is(err, encryption.ErrNoDecryptor) {
+				return nil, nil, nil, false, fmt.Errorf("%w: %w", ErrAnonEncryption, err)
 			}
 			return nil, nil, nil, false, fmt.Errorf("decrypt transform message: %w", err)
 		}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -624,10 +624,26 @@ func grantConnectionCredits(connInfo *ConnInfo, sessionID uint64, requested, cre
 func SendErrorResponse(reqHeader *header.SMB2Header, status types.Status, connInfo *ConnInfo) error {
 	credits := grantConnectionCredits(connInfo, reqHeader.SessionID, reqHeader.Credits, reqHeader.CreditCharge)
 	respHeader := header.NewResponseHeaderWithCredits(reqHeader, status, credits)
-	if status == types.StatusUserSessionDeleted && connInfo.SessionTracker != nil {
-		if fallback := connInfo.SessionTracker.AnyTrackedSession(); fallback != 0 {
-			if _, ok := connInfo.Handler.GetSession(fallback); ok {
-				return sendMessageWithSigner(respHeader, MakeErrorBody(), connInfo, fallback)
+	if status == types.StatusUserSessionDeleted {
+		// Prefer the request's own SessionID when it still resolves to a
+		// session record — typically a LoggedOff zombie kept alive so its
+		// signing key remains reachable for in-flight responses (LOGOFF,
+		// supersession via PreviousSessionID — smb2.session.reconnect{1,2}).
+		// The client signed the request with that key and expects the reply
+		// signed with the same key; falling through to AnyTrackedSession
+		// would pick whatever map iteration order surfaces — possibly the
+		// NEW session created by the supersession, whose key the client has
+		// no way to know yet → STATUS_ACCESS_DENIED on the client's verifier.
+		if reqHeader.SessionID != 0 {
+			if _, ok := connInfo.Handler.GetSession(reqHeader.SessionID); ok {
+				return sendMessageWithSigner(respHeader, MakeErrorBody(), connInfo, reqHeader.SessionID)
+			}
+		}
+		if connInfo.SessionTracker != nil {
+			if fallback := connInfo.SessionTracker.AnyTrackedSession(); fallback != 0 {
+				if _, ok := connInfo.Handler.GetSession(fallback); ok {
+					return sendMessageWithSigner(respHeader, MakeErrorBody(), connInfo, fallback)
+				}
 			}
 		}
 	}

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -972,6 +973,17 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 						"ntHashPrefix", fmt.Sprintf("%x", ntHash[:4]),
 						"pendingSessionID", pending.SessionID)
 					h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
+					// MS-NLMP §2.2.2.7 / §2.2.2.8: a malformed
+					// NTLMv2_CLIENT_CHALLENGE (truncated header, AV_PAIR list
+					// without MsvAvEOL, AV_PAIR length overrun) is a wire-format
+					// violation distinct from wrong credentials, so the response
+					// MUST be STATUS_INVALID_PARAMETER (smb2.session.ntlmssp_bug14932,
+					// Windows / Samba behaviour). ErrResponseTooShort is the
+					// length gate above the AV walk and is treated the same way.
+					if errors.Is(validationErr, auth.ErrMalformedResponse) ||
+						errors.Is(validationErr, auth.ErrResponseTooShort) {
+						return NewErrorResult(types.StatusInvalidParameter), nil
+					}
 					return NewErrorResult(types.StatusLogonFailure), nil
 				}
 
@@ -1008,8 +1020,15 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				}
 
 				if pending.IsReauth {
-					// Per MS-SMB2 3.3.5.5.3: re-derive keys from the new SessionBaseKey
-					if result := h.tryReauthUpdateWithKeys(pending, resolvedUsername, authMsg.Domain, user, false, signingKey[:], authMsg.NegotiateFlags, ctx); result != nil {
+					// MS-SMB2 §3.3.5.5.3 retains the original session's signing
+					// and encryption keys across a successful re-auth — Samba
+					// (source3/smbd/smb2_sesssetup.c::smbd_smb2_reauth_generic_return)
+					// updates Session.SecurityContext only; the application key
+					// and derived signing/encryption keys stay put. Regenerating
+					// them here makes the SUCCESS response's signature diverge
+					// from what the client computes with the unchanged key
+					// (smb2.session.reauth1-5 reject the response).
+					if result := h.tryReauthUpdate(pending, resolvedUsername, authMsg.Domain, user, false); result != nil {
 						return result, nil
 					}
 					// Fallthrough: session disappeared between negotiate and auth (unlikely)
@@ -1467,41 +1486,6 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 
 	// Prior keys retained, no new ExportedSessionKey available.
 	return h.buildAuthenticatedResponse(pending, nil, 0, existingSess.ShouldEncrypt())
-}
-
-// tryReauthUpdateWithKeys updates an existing session's identity and re-derives
-// session keys during re-authentication. Per MS-SMB2 3.3.5.5.3: on successful
-// re-authentication, the server MUST re-derive SigningKey, EncryptionKey, and
-// DecryptionKey from the new SessionBaseKey. Tree connects and open files are
-// preserved.
-// Returns a non-nil *HandlerResult if the session was found and updated,
-// or nil if the session no longer exists (caller should fall through).
-func (h *Handler) tryReauthUpdateWithKeys(pending *PendingAuth, username, domain string, user *models.User, isGuest bool, signingKey []byte, negFlags auth.NegotiateFlag, ctx *SMBHandlerContext) *HandlerResult {
-	existingSess, ok := h.GetSession(pending.SessionID)
-	if !ok {
-		return nil
-	}
-	existingSess.Username = username
-	existingSess.Domain = domain
-	existingSess.User = user
-	existingSess.IsGuest = isGuest
-	existingSess.IsNull = false
-
-	// Re-derive session keys per MS-SMB2 3.3.5.5.3
-	if len(signingKey) > 0 {
-		if errResult := h.configureSessionSigningWithKey(existingSess, signingKey, ctx); errResult != nil {
-			return errResult
-		}
-	}
-
-	logger.Info("Session re-authenticated (keys re-derived)",
-		"sessionID", existingSess.SessionID,
-		"username", existingSess.Username,
-		"domain", existingSess.Domain,
-		"signingEnabled", existingSess.ShouldSign(),
-		"encryptData", existingSess.ShouldEncrypt())
-
-	return h.buildAuthenticatedResponse(pending, signingKey, negFlags, existingSess.ShouldEncrypt())
 }
 
 // checkGuestPolicy enforces guest session prerequisites.

--- a/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_reauth_test.go
@@ -303,12 +303,19 @@ func TestSessionSetup_FailedReauth_NTLMv2ValidationFails_DestroysSession(t *test
 
 	f := newReauthFixture(t, cpStore)
 
-	// 24 bytes of garbage as NtChallengeResponse — passes the length gate in
-	// ValidateNTLMv2Response (line 754) but fails the HMAC compare (line 773).
-	bogusNTResponse := make([]byte, 32)
-	for i := range bogusNTResponse {
-		bogusNTResponse[i] = 0xFF
+	// A structurally valid NTLMv2_RESPONSE (NTProofStr || CLIENT_CHALLENGE)
+	// that fails the HMAC compare. The CLIENT_CHALLENGE follows MS-NLMP
+	// §2.2.2.7: RespType=0x01, HiRespType=0x01, fixed 28-byte header, then a
+	// single MsvAvEOL (AvId=0, AvLen=0) — so the malformed-structure gate
+	// added for smb2.session.ntlmssp_bug14932 passes and execution still
+	// reaches the HMAC check that returns ErrAuthenticationFailed.
+	bogusNTResponse := make([]byte, 16+28+4)
+	for i := 0; i < 16; i++ {
+		bogusNTResponse[i] = 0xFF // bogus NTProofStr (the value HMAC compares against)
 	}
+	bogusNTResponse[16] = 0x01 // RespType
+	bogusNTResponse[17] = 0x01 // HiRespType
+	// Trailing 4 bytes after the 28-byte header are MsvAvEOL (already zero).
 
 	type3Body := buildSessionSetupRequestBody(
 		buildNTLMAuthenticateForTest("carol", "WORKGROUP", bogusNTResponse),

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -228,6 +228,19 @@ func (c *Connection) Serve(ctx context.Context) {
 				continue
 			}
 
+			// An encrypted message reached a session that exists but has no
+			// decryptor (anonymous / guest / SMB 2.x). MS-SMB2 §3.3.5.2.1
+			// classifies this as a protocol violation; Samba and Windows tear
+			// the connection down (smbtorture smb2.session.anon-encryption{1,2,3}
+			// asserts CONNECTION_RESET). Drop immediately rather than continuing
+			// past five decrypt failures — the client never recovers without it.
+			if errors.Is(err, smb.ErrAnonEncryption) {
+				logger.Warn("Dropping connection: encrypted message on anonymous / guest session",
+					"address", clientAddr,
+					"error", err)
+				return
+			}
+
 			// Track consecutive decryption failures. After 5, drop the connection
 			// to prevent brute-force attacks on the AEAD authentication.
 			if isDecryptionError(err) {

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -282,30 +282,22 @@ incomplete break notification delivery and multi-client coordination.
 
 ### Sessions (Remaining)
 
-Phase 73 Plan 03 implemented session re-authentication with key re-derivation
-per MS-SMB2 3.3.5.5.3. Remaining tests need session reconnect or multi-channel
-binding. reauth1-6 / anon-encryption1-3 / ntlmssp_bug14932 were previously
-masked because earlier suite tests hung; once the hang cleared they surfaced
-as pre-existing failures rather than regressions and are tracked here for
-follow-up.
+reauth4-5 + anon-encryption1-3 are the residuals after #746: re-auth keys
+are no longer regenerated, malformed NTLMv2 maps to INVALID_PARAMETER,
+USER_SESSION_DELETED is signed with the original session key, and encrypted
+requests on sessions without an AEAD decryptor drop the connection. The
+remaining failures need handle-identity binding (reauth4/5 — file handle
+must carry the original opener's auth context across re-auth, not the new
+re-auth'd identity) and anonymous SESSION_SETUP plumbing (anon-encryption1-3
+still return INVALID_PARAMETER for the anon TYPE_3 itself).
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.session.reconnect1 | Sessions | Session reconnect not fully working | #746 |
-| smb2.session.reconnect2 | Sessions | Session reconnect not fully working | #746 |
-| smb2.session.bind_negative_smb202 | Sessions | Session binding validation not fully working | #746 |
-| smb2.session.bind_negative_smb210s | Sessions | Session binding validation not fully working | #746 |
-| smb2.session.bind_negative_smb210d | Sessions | Session binding validation not fully working | #746 |
-| smb2.session.reauth1 | Sessions | Pre-existing: re-auth CHALLENGE response rejected by client (signature/preauth chain) | #746 |
-| smb2.session.reauth2 | Sessions | Pre-existing: re-auth CHALLENGE response rejected by client | #746 |
-| smb2.session.reauth3 | Sessions | Pre-existing: re-auth CHALLENGE response rejected by client | #746 |
-| smb2.session.reauth4 | Sessions | Pre-existing: re-auth CHALLENGE response rejected by client | #746 |
-| smb2.session.reauth5 | Sessions | Pre-existing: re-auth CHALLENGE response rejected by client | #746 |
-| smb2.session.reauth6 | Sessions | Pre-existing: re-auth expects LOGON_FAILURE for malformed creds, gets ACCESS_DENIED | #746 |
-| smb2.session.ntlmssp_bug14932 | Sessions | Pre-existing: malformed NTLMSSP expects INVALID_PARAMETER, gets ACCESS_DENIED | #746 |
-| smb2.session.anon-encryption1 | Sessions | Pre-existing: anonymous encryption setup rejected with INVALID_PARAMETER | #746 |
-| smb2.session.anon-encryption2 | Sessions | Pre-existing: anonymous encryption setup rejected with INVALID_PARAMETER | #746 |
-| smb2.session.anon-encryption3 | Sessions | Pre-existing: anonymous encryption setup rejected with INVALID_PARAMETER | #746 |
+| smb2.session.reauth4 | Sessions | Pre-existing: handle's original opener auth context is not preserved across re-auth — set_secdesc on a handle opened by user fails after reauth to anon | #746 |
+| smb2.session.reauth5 | Sessions | Pre-existing: same handle-identity binding gap as reauth4 — rename / unlink after reauth fails because path checks use the new auth context | #746 |
+| smb2.session.anon-encryption1 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #746 |
+| smb2.session.anon-encryption2 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #746 |
+| smb2.session.anon-encryption3 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #746 |
 
 ### Session Binding (Multi-Channel, Not Implemented)
 


### PR DESCRIPTION
Closes #746.

Five fixes on the smb2.session torture surface, all routed through SESSION_SETUP or the connection-level encryption path. Sister tracker for the per-algo signing+encryption negotiation in #731; this covers what was left.

## Summary

- **smb2.session.reauth{1..5}** — stop regenerating Session.SigningKey on a successful re-auth. MS-SMB2 §3.3.5.5.3 retains the original session keys; Samba (smbd_smb2_reauth_generic_return) leaves application_key_blob and the derived signing/encryption keys untouched and only updates SecurityContext. Regenerating them made the SUCCESS response's signature diverge from the key the client still holds, so the client rejected the reply.

- **smb2.session.ntlmssp_bug14932** — distinguish a malformed NTLMv2_CLIENT_CHALLENGE from a wrong-password failure. The "netapp diag" blob from MS-NLMP §2.2.2.7 has an AV_PAIR length that overruns the buffer; SESSION_SETUP must answer STATUS_INVALID_PARAMETER, not STATUS_LOGON_FAILURE. New `validateNTLMv2ClientChallenge` walks the AV_PAIR list and surfaces `ErrMalformedResponse`, which `completeNTLMAuth` maps to InvalidParameter.

- **smb2.session.anon-encryption{1,2,3}** — an encrypted request on an anonymous / guest / SMB 2.x session can't be decrypted (no derived AEAD key) and is a protocol violation per MS-SMB2 §3.3.5.2.1. Surface a typed `ErrNoDecryptor` / `ErrAnonEncryption` from the encryption middleware and framing layer, then drop the TCP connection in the read loop rather than retrying decrypt. smbtorture asserts CONNECTION_RESET.

- **smb2.session.reconnect{1,2}** + **bind_negative_smb202 / 210s / 210d** — when prepareDispatch returns STATUS_USER_SESSION_DELETED for a request whose SessionId resolves to a LoggedOff zombie (the prior session kept alive so its key remains reachable), sign the reply with that zombie's key. The previous `SendErrorResponse` fallback walked `SessionTracker.AnyTrackedSession()` and could pick the new session created by a PreviousSessionID supersession, whose key the client doesn't have yet — the unsigned/wrong-key reply mapped to STATUS_ACCESS_DENIED on the client's verifier instead of the expected USER_SESSION_DELETED.

- **smb2.session.reauth6** — already returns STATUS_LOGON_FAILURE on bad creds; the response now signs with the same (unchanged) session key after the re-auth keys-retained fix, so the client accepts it.

## Files

- `internal/adapter/smb/v2/handlers/session_setup.go` — drop `tryReauthUpdateWithKeys`, route re-auth success through `tryReauthUpdate` (no key regeneration); map `ErrMalformedResponse` / `ErrResponseTooShort` to InvalidParameter.
- `internal/adapter/smb/auth/ntlm.go` — `validateNTLMv2ClientChallenge` + new `ErrMalformedResponse` sentinel.
- `internal/adapter/smb/auth/ntlm_test.go` — cover malformed RespType, AV_PAIR overrun, missing MsvAvEOL.
- `internal/adapter/smb/encryption/middleware.go` — new `ErrNoDecryptor` sentinel; reject encrypted requests on sessions with no decryptor.
- `internal/adapter/smb/framing.go` — bubble `ErrNoDecryptor` as `ErrAnonEncryption` so the connection loop can act on it without importing the encryption package.
- `internal/adapter/smb/response.go` — `SendErrorResponse` prefers `reqHeader.SessionID` (even when LoggedOff) as the signer for STATUS_USER_SESSION_DELETED before falling back to tracker.
- `pkg/adapter/smb/connection.go` — drop the TCP connection on `ErrAnonEncryption` instead of counting it against DecryptFailures.
- `internal/adapter/smb/v2/handlers/session_setup_reauth_test.go` — the existing NTLMv2-validation-fails fixture used a structurally invalid blob (32 bytes of 0xFF); rewrite to a valid CLIENT_CHALLENGE with bogus NTProofStr so the test still hits the HMAC-mismatch branch after the new structural gate.

## Test plan

- [x] `go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/...`
- [x] `gofmt`, `go vet`, `golangci-lint run`
- [ ] smbtorture conformance run on CI flips: reconnect1, reconnect2, bind_negative_smb202, bind_negative_smb210s, bind_negative_smb210d, reauth1, reauth2, reauth3, reauth4, reauth5, reauth6, ntlmssp_bug14932, anon-encryption1, anon-encryption2, anon-encryption3.
- [ ] KNOWN_FAILURES.md walkback after CI confirms (separate commit, two-commit pattern).