### PR TITLE
fix(smb/compound): close oplock-break race in compound dispatcher

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -408,13 +408,15 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 			lastCmdStatus = 0
 		}
 
-		// A subsequent compound subcommand that returns STATUS_PENDING + AsyncId
+		// A tail-of-chain compound subcommand that returns STATUS_PENDING + AsyncId
 		// (parked CREATE) inherits the original standalone-completion callback —
 		// no ReplaceCallback redirect happens here, since the subcommand is
 		// already the tail of the chain. Release its resume-goroutine gate so
 		// the deferred completion is not blocked waiting for a swap that will
-		// never arrive.
-		if cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
+		// never arrive. Non-tail parked CREATEs MUST NOT be released here:
+		// trailing related commands still need to defer behind the CREATE
+		// completion, so the chain is not split.
+		if isLastCommand && cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
 			connInfo.Handler.PendingCreateRegistry != nil {
 			connInfo.Handler.PendingCreateRegistry.MarkStarted(cmdResult.AsyncId)
 		}
@@ -1011,11 +1013,11 @@ func completeCompoundAfterAsyncCreate(
 			lastCmdStatus = 0
 		}
 
-		// Release any parked-CREATE goroutine for this subcommand (see same
-		// guard in ProcessCompoundRequest's subcommand loop). The deferred
-		// continue-compound wrapper already owns the chain bookkeeping, so
-		// the resume goroutine just delivers the original callback.
-		if cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
+		// Release any parked-CREATE goroutine for this subcommand only when it is
+		// the tail of the chain — non-tail parked CREATEs still need trailing
+		// related commands deferred behind their completion (see same guard in
+		// ProcessCompoundRequest's subcommand loop).
+		if isLastCommand && cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
 			connInfo.Handler.PendingCreateRegistry != nil {
 			connInfo.Handler.PendingCreateRegistry.MarkStarted(cmdResult.AsyncId)
 		}

--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -175,6 +175,14 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 				)
 				return nil
 			})
+			// Release the resume goroutine NOW that the callback has been
+			// swapped. The goroutine was parked on PendingCreate.started
+			// (initialized in parkCreateOnLeaseBreak) precisely so this
+			// ReplaceCallback could land before the original standalone
+			// callback fired. Skipping the release would deadlock the CREATE
+			// after the wait drains (smbtorture compound.compound-break
+			// IO_TIMEOUT race).
+			connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
 		}
 
 		// Send interim STATUS_PENDING as a standalone async response.
@@ -186,6 +194,16 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 			logger.Debug("Error sending compound async interim response", "error", err)
 		}
 		return
+	}
+
+	// Fall-through path: the first command returned STATUS_PENDING + AsyncId
+	// AND there were no more commands in the compound. The interim is sent
+	// as part of the compound response below; the resume goroutine fires the
+	// original (standalone-completion) callback with the final response, so
+	// release its started gate now.
+	if result != nil && result.Status == types.StatusPending && result.AsyncId != 0 &&
+		connInfo.Handler.PendingCreateRegistry != nil {
+		connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
 	}
 
 	if fileID != [16]byte{} {
@@ -388,6 +406,17 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 			lastCmdSessionFailed = false
 			lastCmdFailed = false
 			lastCmdStatus = 0
+		}
+
+		// A subsequent compound subcommand that returns STATUS_PENDING + AsyncId
+		// (parked CREATE) inherits the original standalone-completion callback —
+		// no ReplaceCallback redirect happens here, since the subcommand is
+		// already the tail of the chain. Release its resume-goroutine gate so
+		// the deferred completion is not blocked waiting for a swap that will
+		// never arrive.
+		if cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
+			connInfo.Handler.PendingCreateRegistry != nil {
+			connInfo.Handler.PendingCreateRegistry.MarkStarted(cmdResult.AsyncId)
 		}
 
 		rh, rb := buildResponseHeaderAndBody(hdr, cmdCtx, cmdResult, connInfo)
@@ -980,6 +1009,15 @@ func completeCompoundAfterAsyncCreate(
 			lastCmdSessionFailed = false
 			lastCmdFailed = false
 			lastCmdStatus = 0
+		}
+
+		// Release any parked-CREATE goroutine for this subcommand (see same
+		// guard in ProcessCompoundRequest's subcommand loop). The deferred
+		// continue-compound wrapper already owns the chain bookkeeping, so
+		// the resume goroutine just delivers the original callback.
+		if cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
+			connInfo.Handler.PendingCreateRegistry != nil {
+			connInfo.Handler.PendingCreateRegistry.MarkStarted(cmdResult.AsyncId)
 		}
 
 		rh, rb := buildResponseHeaderAndBody(hdr, cmdCtx, cmdResult, connInfo)

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -202,6 +202,18 @@ func ProcessSingleRequest(
 	// Track session lifecycle for connection cleanup
 	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, result.IsBinding, connInfo.SessionTracker)
 
+	// Release any parked-CREATE resume goroutine now that the standalone
+	// callback assignment is final. Non-compound CREATEs use the original
+	// callback installed in prepareDispatch — there is no ReplaceCallback
+	// to wait on, so the started gate can fire immediately. Without this,
+	// the resume goroutine deadlocks on PendingCreate.started after the
+	// break drains (smbtorture compound.compound-break IO_TIMEOUT race).
+	if reqHeader.Command == types.SMB2Create &&
+		result.Status == types.StatusPending && result.AsyncId != 0 &&
+		connInfo.Handler.PendingCreateRegistry != nil {
+		connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
+	}
+
 	// Send response and run after-hooks with the response bytes. If the
 	// write fails, return early — any registered PostSend hook is
 	// intentionally dropped because the connection is likely dead and the

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1051,6 +1051,13 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				"error", err)
 		}
 
+		// Wait for the dispatcher to finalize the callback assignment before
+		// any release path. Done BEFORE Unregister so a CANCEL/teardown that
+		// pulls the entry first can still hand off via markStarted — otherwise
+		// the gate would never close and this goroutine would block forever.
+		// See PendingCreate.started doc for the race this closes.
+		<-pending.started
+
 		// Ensure our entry is still live (not preempted by CANCEL or teardown).
 		// If it was, CANCEL / teardown already sent the final response.
 		if h.PendingCreateRegistry.Unregister(asyncId) == nil {
@@ -1066,7 +1073,6 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				"messageID", messageID,
 				"asyncId", asyncId,
 				"treeID", ctx.TreeID)
-			<-pending.started
 			if err := pending.Callback(pending.SessionID, messageID, asyncId, types.StatusNetworkNameDeleted, nil); err != nil {
 				logger.Debug("CREATE async: failed to send tree-deleted response", "error", err)
 			}
@@ -1086,9 +1092,6 @@ func (h *Handler) parkCreateOnLeaseBreak(
 			}
 		}
 
-		// Wait for the dispatcher to finalize the callback assignment before
-		// firing. See PendingCreate.started doc for the race this closes.
-		<-pending.started
 		if err := pending.Callback(pending.SessionID, messageID, asyncId, status, body); err != nil {
 			logger.Warn("CREATE async: failed to send final response",
 				"messageID", messageID,

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1014,6 +1014,14 @@ func (h *Handler) parkCreateOnLeaseBreak(
 		AsyncId:   asyncId,
 		Cancel:    cancel,
 		Callback:  ctx.AsyncCreateCompleteCallback,
+		// started is closed by the dispatcher (response.go single-cmd path
+		// or compound.go after ReplaceCallback) once the Callback has been
+		// finalized. The resume goroutine waits on it before invoking
+		// Callback so a fast localhost break ACK can't fire the original
+		// callback before the compound dispatcher has had a chance to swap
+		// it for the continue-compound wrapper (smb2.compound.compound-break
+		// IO_TIMEOUT race observed in CI).
+		started: make(chan struct{}),
 	}
 
 	if err := h.PendingCreateRegistry.Register(pending); err != nil {
@@ -1058,6 +1066,7 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				"messageID", messageID,
 				"asyncId", asyncId,
 				"treeID", ctx.TreeID)
+			<-pending.started
 			if err := pending.Callback(pending.SessionID, messageID, asyncId, types.StatusNetworkNameDeleted, nil); err != nil {
 				logger.Debug("CREATE async: failed to send tree-deleted response", "error", err)
 			}
@@ -1077,6 +1086,9 @@ func (h *Handler) parkCreateOnLeaseBreak(
 			}
 		}
 
+		// Wait for the dispatcher to finalize the callback assignment before
+		// firing. See PendingCreate.started doc for the race this closes.
+		<-pending.started
 		if err := pending.Callback(pending.SessionID, messageID, asyncId, status, body); err != nil {
 			logger.Warn("CREATE async: failed to send final response",
 				"messageID", messageID,

--- a/internal/adapter/smb/v2/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/v2/handlers/pending_create_registry.go
@@ -34,6 +34,19 @@ type PendingCreate struct {
 	// goroutine on normal completion OR by the registry on CANCEL (with
 	// StatusCancelled + nil body). Releases the async slot as part of its work.
 	Callback AsyncCreateCompleteCallback
+
+	// started is closed by MarkStarted once the dispatch layer has finalized
+	// the Callback assignment for this entry. The resume goroutine MUST wait
+	// on it before invoking Callback. Without this gate, a fast localhost
+	// break ACK can let the resume goroutine fire the original callback
+	// BEFORE the compound dispatcher has had a chance to swap in the
+	// continue-compound wrapper, sending the CREATE response standalone and
+	// stranding the remaining compound subcommands (smbtorture
+	// smb2.compound.compound-break IO_TIMEOUT, observed flake).
+	//
+	// CANCEL / session-teardown paths invoke Callback directly without going
+	// through the resume goroutine, so they do NOT need to wait on this gate.
+	started chan struct{}
 }
 
 // PendingCreateRegistry indexes pending CREATEs by three keys: per-connection
@@ -152,6 +165,10 @@ func (r *PendingCreateRegistry) UnregisterByMessageID(connID, messageID uint64) 
 	}
 	r.removeLocked(p.AsyncId)
 	r.mu.Unlock()
+	// Release the started gate so any resume goroutine racing the cancel
+	// path past its Unregister check will not deadlock waiting on dispatch
+	// to MarkStarted (CANCEL/teardown bypass the dispatcher).
+	markStarted(p)
 	if p.Cancel != nil {
 		p.Cancel()
 	}
@@ -164,8 +181,11 @@ func (r *PendingCreateRegistry) UnregisterByAsyncId(asyncId uint64) *PendingCrea
 	r.mu.Lock()
 	p := r.removeLocked(asyncId)
 	r.mu.Unlock()
-	if p != nil && p.Cancel != nil {
-		p.Cancel()
+	if p != nil {
+		markStarted(p)
+		if p.Cancel != nil {
+			p.Cancel()
+		}
 	}
 	return p
 }
@@ -188,6 +208,7 @@ func (r *PendingCreateRegistry) UnregisterAllForSession(sessionID uint64) []*Pen
 	}
 	r.mu.Unlock()
 	for _, p := range removed {
+		markStarted(p)
 		if p.Cancel != nil {
 			p.Cancel()
 		}
@@ -227,6 +248,43 @@ func (r *PendingCreateRegistry) ReplaceCallback(asyncId uint64, cb AsyncCreateCo
 	}
 	p.Callback = cb
 	return true
+}
+
+// MarkStarted releases the resume goroutine for the pending CREATE identified
+// by asyncId so it may invoke its (possibly replaced) Callback. Callers MUST
+// invoke MarkStarted after they have finished any callback reassignment
+// (e.g. compound dispatcher's ReplaceCallback). Idempotent: safe to call
+// even after the entry has been unregistered by CANCEL / teardown.
+//
+// Returns true if the gate was successfully signalled, false if the entry
+// was no longer in the registry. The latter is not an error — CANCEL /
+// teardown already drove the callback synchronously and the gate is moot.
+func (r *PendingCreateRegistry) MarkStarted(asyncId uint64) bool {
+	r.mu.Lock()
+	p, ok := r.byAsyncId[asyncId]
+	r.mu.Unlock()
+	if !ok {
+		return false
+	}
+	markStarted(p)
+	return true
+}
+
+// markStarted closes the started gate exactly once. Called both by the
+// public MarkStarted (dispatch-layer release) and by internal cleanup paths
+// (CANCEL / teardown) that pull entries directly and need to unblock any
+// resume goroutine still parked on the wait — without the unblock, the
+// goroutine would leak when CANCEL runs after MarkStarted's window closes.
+func markStarted(p *PendingCreate) {
+	if p == nil || p.started == nil {
+		return
+	}
+	select {
+	case <-p.started:
+		// Already closed.
+	default:
+		close(p.started)
+	}
 }
 
 // Len returns the number of pending CREATEs.

--- a/internal/adapter/smb/v2/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/v2/handlers/pending_create_registry.go
@@ -46,7 +46,8 @@ type PendingCreate struct {
 	//
 	// CANCEL / session-teardown paths invoke Callback directly without going
 	// through the resume goroutine, so they do NOT need to wait on this gate.
-	started chan struct{}
+	started     chan struct{}
+	startedOnce sync.Once
 }
 
 // PendingCreateRegistry indexes pending CREATEs by three keys: per-connection
@@ -279,12 +280,7 @@ func markStarted(p *PendingCreate) {
 	if p == nil || p.started == nil {
 		return
 	}
-	select {
-	case <-p.started:
-		// Already closed.
-	default:
-		close(p.started)
-	}
+	p.startedOnce.Do(func() { close(p.started) })
 }
 
 // Len returns the number of pending CREATEs.

--- a/internal/adapter/smb/v2/handlers/pending_create_registry_test.go
+++ b/internal/adapter/smb/v2/handlers/pending_create_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 )
@@ -205,5 +206,123 @@ func TestPendingCreateRegistry_UnregisterByMessageID_DifferentConnsCollidingMess
 	}
 	if got := r.UnregisterByMessageID(2, 42); got != p2 {
 		t.Errorf("UnregisterByMessageID(conn=2) = %v, want p2", got)
+	}
+}
+
+// newGatedPendingCreate wires a `started` channel onto the test entry so the
+// gate behaviour matches what parkCreateOnLeaseBreak actually constructs at
+// runtime.
+func newGatedPendingCreate(asyncId uint64, calls *atomic.Int32) *PendingCreate {
+	p := newTestPendingCreate(1, 100, 42, asyncId, calls)
+	p.started = make(chan struct{})
+	return p
+}
+
+// TestPendingCreateRegistry_MarkStartedClosesGate verifies the public
+// MarkStarted entry point unblocks a goroutine waiting on PendingCreate.started.
+// This is the race that smb2.compound.compound-break exposes when the resume
+// goroutine fires before the compound dispatcher has had a chance to swap
+// the Callback for the continue-compound wrapper.
+func TestPendingCreateRegistry_MarkStartedClosesGate(t *testing.T) {
+	r := NewPendingCreateRegistry()
+	var calls atomic.Int32
+	p := newGatedPendingCreate(7, &calls)
+
+	if err := r.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		<-p.started
+		close(released)
+	}()
+
+	// MarkStarted must wake the waiter.
+	if !r.MarkStarted(7) {
+		t.Fatalf("MarkStarted(7) = false, want true (entry registered)")
+	}
+
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("MarkStarted did not unblock waiter within 1s")
+	}
+
+	// Second call is idempotent — does not panic on already-closed channel.
+	if !r.MarkStarted(7) {
+		t.Errorf("second MarkStarted(7) = false, want true (still registered)")
+	}
+}
+
+// TestPendingCreateRegistry_CancelReleasesGate verifies CANCEL-style
+// unregistration also closes the gate so a resume goroutine racing the
+// cancel cannot deadlock waiting for a dispatcher MarkStarted that never
+// arrives (CANCEL bypasses the dispatcher).
+func TestPendingCreateRegistry_CancelReleasesGate(t *testing.T) {
+	cases := []struct {
+		name   string
+		cancel func(*PendingCreateRegistry, *PendingCreate)
+	}{
+		{
+			name: "UnregisterByMessageID",
+			cancel: func(r *PendingCreateRegistry, p *PendingCreate) {
+				r.UnregisterByMessageID(p.ConnID, p.MessageID)
+			},
+		},
+		{
+			name: "UnregisterByAsyncId",
+			cancel: func(r *PendingCreateRegistry, p *PendingCreate) {
+				r.UnregisterByAsyncId(p.AsyncId)
+			},
+		},
+		{
+			name: "UnregisterAllForSession",
+			cancel: func(r *PendingCreateRegistry, p *PendingCreate) {
+				r.UnregisterAllForSession(p.SessionID)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewPendingCreateRegistry()
+			var calls atomic.Int32
+			p := newGatedPendingCreate(7, &calls)
+			if err := r.Register(p); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+
+			released := make(chan struct{})
+			go func() {
+				<-p.started
+				close(released)
+			}()
+
+			tc.cancel(r, p)
+
+			select {
+			case <-released:
+			case <-time.After(time.Second):
+				t.Fatalf("%s did not release started gate within 1s", tc.name)
+			}
+		})
+	}
+}
+
+// TestPendingCreateRegistry_MarkStartedAfterUnregister exercises the
+// idempotency of the gate path: once the entry has been removed, MarkStarted
+// returns false (the dispatcher already lost the race to CANCEL/teardown,
+// which has its own callback fan-out).
+func TestPendingCreateRegistry_MarkStartedAfterUnregister(t *testing.T) {
+	r := NewPendingCreateRegistry()
+	var calls atomic.Int32
+	p := newGatedPendingCreate(7, &calls)
+	if err := r.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	r.Unregister(7)
+	if r.MarkStarted(7) {
+		t.Errorf("MarkStarted after Unregister = true, want false")
 	}
 }


### PR DESCRIPTION
## Summary

- The compound dispatcher's STATUS_PENDING+AsyncId branch relied on `ReplaceCallback` landing before the `parkCreateOnLeaseBreak` resume goroutine fired the original (standalone-completion) callback. On a fast localhost loop the OPLOCK_BREAK ACK could drain the break wait first, so the CREATE was completed standalone, the trailing GETINFO never ran, and the test client hit `NT_STATUS_IO_TIMEOUT` — observed as a `smb2.compound.compound-break` flake (failure on run https://github.com/marmos91/dittofs/actions/runs/26627694648/job/78468382323).
- Add a `started` gate on `PendingCreate`: the resume goroutine waits on it before invoking `Callback`. Dispatcher paths release the gate once the callback assignment is final (single-cmd in `response.go`, compound after `ReplaceCallback`, both compound subcommand loops). CANCEL / session-teardown paths also release the gate so a racing goroutine past its `Unregister` check cannot deadlock.
- Regression tests cover the primitive: `MarkStarted` unblocks the waiter, every Unregister-via-CANCEL/teardown helper still releases, and a late `MarkStarted` on an already-unregistered entry is a no-op.

## Test plan

- [x] `go test -race -count=20 ./internal/adapter/smb/v2/handlers/ -run TestPendingCreateRegistry`
- [x] `go test -race ./internal/adapter/smb/... ./pkg/metadata/lock/...`
- [x] `gofmt -s -w` + `go vet ./...` + `golangci-lint run --timeout=5m`
- [ ] CI smbtorture run shows `smb2.compound.compound-break` in PASS section
- [ ] WPTS BVT still green