### PR TITLE
refactor(blockstore/engine): rename EvictReadBuffer to DestroyCache

### DIFF
--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -391,12 +391,11 @@ func (bs *BlockStore) EvictLocal(ctx context.Context, payloadID string) error {
 	return bs.local.DeleteLog(ctx, payloadID)
 }
 
-// EvictReadBuffer clears all entries from the cache (legacy method
-// name retained for the controlplane runtime's blockStores.evict REST
-// path; behavior post-Plan-12-09 closes the cache, which Plan-12-10
-// will rework once mmap-backed entries change the eviction story).
-// Returns the number of entries that were present before close.
-func (bs *BlockStore) EvictReadBuffer() int {
+// DestroyCache closes the in-memory read cache and replaces it with a
+// no-op implementation. Intended for shutdown / share-removal teardown
+// and for the REST evict path that drops the read buffer wholesale.
+// Returns the number of entries that were present before destruction.
+func (bs *BlockStore) DestroyCache() int {
 	entries := bs.cache.Stats().Entries
 	_ = bs.cache.Close()
 	// Replace closed cache with the Null Object so subsequent operations

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1377,7 +1377,7 @@ func (s *Service) EvictBlockStore(ctx context.Context, shareName string, opts Ev
 		}
 
 		if !opts.LocalOnly {
-			result.ReadBufferEntriesCleared += bs.EvictReadBuffer()
+			result.ReadBufferEntriesCleared += bs.DestroyCache()
 		}
 
 		if !opts.ReadBufferOnly {


### PR DESCRIPTION
## Summary

- `EvictReadBuffer` on `*engine.BlockStore` was a misnomer: it does not evict cache entries — it closes the cache and replaces it with the `nullCache{}` no-op.
- Rename to `DestroyCache` and rewrite the godoc to describe the actual behaviour and its intended use sites (shutdown / share-removal teardown / REST evict path that drops the read buffer wholesale).
- Drops the planning-ID leftover from the comment.
- Updates the sole caller (`pkg/controlplane/runtime/shares/service.go`). REST/CLI naming (`ReadBufferOnly`, `ReadBufferEntriesCleared`) is unchanged — outside this audit item's scope.

Caller count: 1. Chose rename (option A) over inline because the method touches engine-private fields (`bs.cache`, `nullCache{}`) and inlining would leak those internals across the engine/controlplane boundary.

## Test plan

- [x] `gofmt -s`, `go vet`, `golangci-lint run` clean
- [x] `go build ./...`
- [x] `go test -race -count=1 ./pkg/blockstore/... ./internal/... ./pkg/controlplane/...`
- [ ] CI green