### PR TITLE
refactor(blockstore/engine): formalize ChunkLifecycleHooks interface

### DIFF
--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -140,22 +140,28 @@ func New(cfg Config) (*BlockStore, error) {
 	if cfg.SyncedHashStore != nil {
 		cfg.Syncer.SetSyncedHashStore(cfg.SyncedHashStore)
 	}
-	// Install the rollup-completion ObjectIDPersister callback on the
-	// local store if it supports the setter. The callback (1) writes
-	// per-block FileBlock rows so the engine's CAS read path
-	// (readLocalByHash → resolveFileBlock) can resolve
-	// (payloadID, blockIdx) → hash and (2) delegates to the
-	// coordinator's PersistFileBlocks so FileAttr.Blocks and
-	// FileAttr.ObjectID land in a single metadata txn at rollup time.
-	// Local stores that don't implement the setter (in-memory /
-	// fixtures use the parallel ChunkEmitter hook below) silently skip
-	// the install — ObjectID compute still runs inside rollup but the
-	// persist step is no-op.
-	if setter, ok := cfg.Local.(interface {
-		SetObjectIDPersister(p func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error)
-	}); ok {
+	// Wire the per-store chunk-lifecycle callbacks via the named
+	// [local.ChunkLifecycleHooks] capability surface. Three setters
+	// install closures that downstream FileBlock metadata and the read
+	// cache depend on; each implementation may treat any setter as a
+	// no-op when its data path doesn't reach that hook (FSStore's
+	// rollup-completion path covers ObjectIDPersister + OnChunkComplete;
+	// the in-memory backend covers ChunkEmitter). Foreign local stores
+	// that don't satisfy the interface silently skip all three installs.
+	hooks, hasHooks := cfg.Local.(local.ChunkLifecycleHooks)
+	if hasHooks {
+		// (1) Install the rollup-completion ObjectIDPersister callback.
+		// The callback writes per-block FileBlock rows so the engine's
+		// CAS read path (readLocalByHash → resolveFileBlock) can
+		// resolve (payloadID, blockIdx) → hash and delegates to the
+		// coordinator's PersistFileBlocks so FileAttr.Blocks and
+		// FileAttr.ObjectID land in a single metadata txn at rollup
+		// time. Stores that don't drive a rollup-completion path
+		// (in-memory / fixtures use the parallel ChunkEmitter hook
+		// below) install a no-op setter — ObjectID compute still runs
+		// inside rollup but the persist step is no-op.
 		fbs := cfg.FileBlockStore
-		setter.SetObjectIDPersister(func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
+		hooks.SetObjectIDPersister(func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
 			// (1) Per-chunk FileBlock rows. The row ID encodes the
 			//     chunk's absolute byte Offset directly (rather than
 			//     a synthetic blockIdx = Offset / BlockSize); the
@@ -193,66 +199,59 @@ func New(cfg Config) (*BlockStore, error) {
 			}
 			return bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID)
 		})
-	}
-	// Install the chunk-completion callback on local stores that
-	// expose the setter (production *fs.FSStore does; the in-memory
-	// backend does not — its writes go through SetChunkEmitter below
-	// and don't materialize through the CAS chunkstore.StoreChunk +
-	// lruTouch path hooks). The closure delegates every successful
-	// chunkstore write to bs.cache.Put: the engine Cache becomes warm
-	// on the write side, so the NFS COMMIT-then-READ pattern never
-	// goes back to disk for the just-written chunk. The closure
-	// captures bs (not bs.cache) so the Null-Object→real-Cache swap
-	// performed by BlockStore.Start at engine.go:267-270 is observed
-	// transparently. The path arg is intentionally discarded
-	// (`_ string`) — Cache.Put doesn't consume it; the firing-site
-	// contract still passes it to enable future mmap-or-copy
-	// strategies (cache.go docstring). Cache.Put is nil-safe,
-	// closed-safe, and max-bytes-safe (cache.go:229-235), so this
-	// binding is the canonical safe wiring (RAM ceiling bounded by
-	// Cache's existing LRU). Same lifecycle precedent as
-	// SetObjectIDPersister above — install once at construction;
-	// FSStore guarantees no chunk activity fires before Start
-	// completes.
-	if setter, ok := cfg.Local.(interface {
-		SetOnChunkComplete(fn func(hash blockstore.ContentHash, data []byte, path string))
-	}); ok {
-		setter.SetOnChunkComplete(func(hash blockstore.ContentHash, data []byte, _ string) {
+
+		// (2) Install the chunk-completion callback (production
+		// *fs.FSStore wires this on the chunkstore hot path; the
+		// in-memory backend no-ops since its writes don't materialize
+		// through the CAS chunkstore.StoreChunk + lruTouch path). The
+		// closure delegates every successful chunkstore write to
+		// bs.cache.Put: the engine Cache becomes warm on the write
+		// side, so the NFS COMMIT-then-READ pattern never goes back to
+		// disk for the just-written chunk. The closure captures bs
+		// (not bs.cache) so the Null-Object→real-Cache swap performed
+		// by BlockStore.Start is observed transparently. The path arg
+		// is intentionally discarded (`_ string`) — Cache.Put doesn't
+		// consume it; the firing-site contract still passes it to
+		// enable future mmap-or-copy strategies. Cache.Put is
+		// nil-safe, closed-safe, and max-bytes-safe, so this binding
+		// is the canonical safe wiring (RAM ceiling bounded by Cache's
+		// existing LRU). Same lifecycle precedent as the persister
+		// above — install once at construction; FSStore guarantees no
+		// chunk activity fires before Start completes.
+		hooks.SetOnChunkComplete(func(hash blockstore.ContentHash, data []byte, _ string) {
 			bs.cache.Put(hash, data)
 		})
-	}
-	// Install a per-chunk emitter on local stores that expose one (the
-	// in-memory backend uses this; *fs.FSStore drives the equivalent
-	// rollup-side path through the ObjectIDPersister callback above).
-	// The emitter mirrors each freshly-emitted CAS chunk into a
-	// FileBlock row keyed by {payloadID}/{blockIdx} so the engine's
-	// CAS read path (readLocalByHash) can resolve (payloadID, offset)
-	// → hash without a separate manifest. blockIdx is derived from
-	// chunkStart / blockstore.BlockSize — works correctly for the
-	// in-memory backend's small / aligned test workloads. Production
-	// FSStore writes its own FileBlock rows through the
-	// rollup.PersistFileBlocks path and never installs the emitter.
-	if emitter, ok := cfg.Local.(interface {
-		SetChunkEmitter(emit func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash))
-	}); ok && cfg.FileBlockStore != nil {
-		fbs := cfg.FileBlockStore
-		emitter.SetChunkEmitter(func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash) {
-			fb := &blockstore.FileBlock{
-				ID:       fmt.Sprintf("%s/%d", payloadID, chunkStart),
-				Hash:     hash,
-				DataSize: size,
-				State:    blockstore.BlockStatePending,
-			}
-			// Crash-consistency (#583): emitter signature is void by
-			// contract; a put failure here means the manifest row never
-			// landed and reads will sparse-zero that range. Log at Error
-			// so operators see the loss instead of silently swallowing
-			// it. Follow-up: promote emitter to return an error so the
-			// caller can fail the rollup pass.
-			if err := fbs.Put(context.Background(), fb); err != nil {
-				logger.Error("ChunkEmitter: FileBlock.Put failed", "id", fb.ID, "error", err)
-			}
-		})
+
+		// (3) Install the per-chunk emitter (the in-memory backend
+		// uses this; *fs.FSStore no-ops since it drives the equivalent
+		// rollup-side path through the ObjectIDPersister callback
+		// above). The emitter mirrors each freshly-emitted CAS chunk
+		// into a FileBlock row keyed by {payloadID}/{chunkStart} so the
+		// engine's CAS read path (readLocalByHash) can resolve
+		// (payloadID, offset) → hash without a separate manifest.
+		// Requires a FileBlockStore — fixtures running without one
+		// rely on the no-op default.
+		if cfg.FileBlockStore != nil {
+			fbs := cfg.FileBlockStore
+			hooks.SetChunkEmitter(func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash) {
+				fb := &blockstore.FileBlock{
+					ID:       fmt.Sprintf("%s/%d", payloadID, chunkStart),
+					Hash:     hash,
+					DataSize: size,
+					State:    blockstore.BlockStatePending,
+				}
+				// Crash-consistency (#583): emitter signature is void
+				// by contract; a put failure here means the manifest
+				// row never landed and reads will sparse-zero that
+				// range. Log at Error so operators see the loss
+				// instead of silently swallowing it. Follow-up:
+				// promote emitter to return an error so the caller
+				// can fail the rollup pass.
+				if err := fbs.Put(context.Background(), fb); err != nil {
+					logger.Error("ChunkEmitter: FileBlock.Put failed", "id", fb.ID, "error", err)
+				}
+			})
+		}
 	}
 	// wire the BlockStore back-reference onto the Syncer so
 	// the file-level dedup short-circuit can reach BlockStore.cache for

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -47,7 +47,10 @@ var (
 )
 
 // Compile-time interface satisfaction check.
-var _ local.LocalStore = (*FSStore)(nil)
+var (
+	_ local.LocalStore          = (*FSStore)(nil)
+	_ local.ChunkLifecycleHooks = (*FSStore)(nil)
+)
 
 // ObjectIDPersister is invoked after a rollup quiesces successfully.
 // It receives the payloadID, the BlockRef manifest collected during
@@ -802,6 +805,16 @@ func (bc *FSStore) SetObjectIDPersister(p func(ctx context.Context, payloadID st
 // importing this package's named-type spelling.
 func (bc *FSStore) SetOnChunkComplete(fn func(hash blockstore.ContentHash, data []byte, path string)) {
 	bc.onChunkComplete.Store(&chunkCompleteCallback{fn: fn})
+}
+
+// SetChunkEmitter is a no-op on FSStore. FSStore drives FileBlock row
+// writes through the rollup-completion persister installed via
+// SetObjectIDPersister; the per-chunk emitter is only used by the
+// in-memory backend whose writes don't materialize through the CAS
+// chunkstore + rollup persister path. Implemented to satisfy
+// [local.ChunkLifecycleHooks] so engine.New can wire all three hooks
+// through a single named-interface assertion.
+func (bc *FSStore) SetChunkEmitter(_ func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash)) {
 }
 
 // SetRetentionPolicy updates the retention policy and TTL for eviction decisions.

--- a/pkg/blockstore/local/hooks.go
+++ b/pkg/blockstore/local/hooks.go
@@ -1,0 +1,61 @@
+package local
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+)
+
+// ChunkLifecycleHooks is the optional capability surface a [LocalStore]
+// may expose to let the engine wire callbacks for rollup-time and
+// chunk-emission events. Engine.New probes for this interface on
+// cfg.Local at construction; implementations that don't need a given
+// callback may install no-op setters (so the assertion always succeeds)
+// and rely on engine.New supplying nil-safe closures.
+//
+// Implementations:
+//
+//   - *fs.FSStore — installs the rollup-completion FileBlock + ObjectID
+//     persister and the synchronous chunk-completion cache-warming
+//     callback. The chunk emitter is a no-op (FSStore drives FileBlock
+//     rows through the rollup persister path instead).
+//
+//   - *memory.MemoryStore — installs the per-chunk emitter (in-memory
+//     rollup fires this on every CAS chunk). The rollup-completion
+//     persister and chunk-completion callbacks are no-ops; in-memory
+//     callers don't materialize through the CAS chunkstore + cache hot
+//     path that those two hooks support.
+//
+// The interface is defined here (alongside [LocalStore]) rather than at
+// the engine consumer site because the contract is naturally a
+// store-side capability surface: a foreign LocalStore implementation
+// (e.g. a future backend) declares its participation by satisfying this
+// interface, and the engine asserts once on the named type instead of
+// three anonymous structural probes.
+type ChunkLifecycleHooks interface {
+	// SetObjectIDPersister installs the rollup-completion callback. The
+	// engine wires a closure that delegates to the metadata coordinator's
+	// PersistFileBlocks and writes per-block FileBlock rows so the
+	// engine's CAS read path can resolve (payloadID, offset) -> hash.
+	// Called once at engine.New; implementations that don't drive a
+	// rollup-completion path may treat this as a no-op.
+	SetObjectIDPersister(p func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error)
+
+	// SetOnChunkComplete installs the chunk-completion callback fired
+	// once per successful chunkstore write. The engine wires a closure
+	// that warms the read Cache on the write side so NFS COMMIT-then-
+	// READ never falls back to disk for just-written chunks. The path
+	// argument is informational (firing site contract); current
+	// callers discard it. Implementations that don't materialize
+	// through a hot-path chunkstore may treat this as a no-op.
+	SetOnChunkComplete(fn func(hash blockstore.ContentHash, data []byte, path string))
+
+	// SetChunkEmitter installs the per-chunk emitter fired once per
+	// freshly-emitted CAS chunk during synchronous rollup. The engine
+	// wires a closure that mirrors each chunk into a FileBlock row so
+	// the CAS read path can resolve (payloadID, offset) -> hash without
+	// a separate manifest. Implementations that drive FileBlock rows
+	// through a different path (e.g. rollup-completion persister) may
+	// treat this as a no-op.
+	SetChunkEmitter(emit func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash))
+}

--- a/pkg/blockstore/local/memory/memory.go
+++ b/pkg/blockstore/local/memory/memory.go
@@ -19,7 +19,10 @@ import (
 // Compile-time interface satisfaction check. -07 restored the
 // assertion after MemoryStore gained the BlockStoreAppend-contributed
 // methods (Put/Get/GetRange/Has/Delete/Head/Walk/AppendWrite/DeleteLog).
-var _ local.LocalStore = (*MemoryStore)(nil)
+var (
+	_ local.LocalStore          = (*MemoryStore)(nil)
+	_ local.ChunkLifecycleHooks = (*MemoryStore)(nil)
+)
 
 // ErrStoreClosed is an alias for blockstore.ErrStoreClosed for backward compatibility.
 var ErrStoreClosed = blockstore.ErrStoreClosed
@@ -83,6 +86,26 @@ func (s *MemoryStore) SetChunkEmitter(emit func(payloadID string, chunkStart uin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.chunkEmitter = emit
+}
+
+// SetObjectIDPersister is a no-op on MemoryStore. MemoryStore mirrors
+// FileBlock rows through the per-chunk emitter installed via
+// SetChunkEmitter; the rollup-completion persister is only used by the
+// FSStore backend whose writes drive the engine's CAS read path through
+// the rollup-persisted FileBlock manifest. Implemented to satisfy
+// [local.ChunkLifecycleHooks] so engine.New can wire all three hooks
+// through a single named-interface assertion.
+func (s *MemoryStore) SetObjectIDPersister(_ func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error) {
+}
+
+// SetOnChunkComplete is a no-op on MemoryStore. MemoryStore's writes
+// don't materialize through the CAS chunkstore + read-Cache hot path
+// that this callback warms; the in-memory rollup keeps everything in
+// the MemoryStore's CAS map and FileBlock rows are emitted via
+// SetChunkEmitter. Implemented to satisfy [local.ChunkLifecycleHooks]
+// so engine.New can wire all three hooks through a single
+// named-interface assertion.
+func (s *MemoryStore) SetOnChunkComplete(_ func(hash blockstore.ContentHash, data []byte, path string)) {
 }
 
 // appendLog is the per-payload write-absorber buffer. AppendWrite


### PR DESCRIPTION
## Summary

`engine.New` previously did **three anonymous structural type assertions** on `cfg.Local`:

```go
if setter, ok := cfg.Local.(interface{ SetObjectIDPersister(...) }); ok { ... }
if setter, ok := cfg.Local.(interface{ SetOnChunkComplete(...) }); ok { ... }
if emitter, ok := cfg.Local.(interface{ SetChunkEmitter(...) }); ok { ... }
```

The audit (`.planning/v1.0-audit/blockstore/REVIEW.md` §2b/§3b) flagged these as an auditability smell and recommended formalizing a named interface.

This PR introduces `local.ChunkLifecycleHooks`:

```go
type ChunkLifecycleHooks interface {
    SetObjectIDPersister(p func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error)
    SetOnChunkComplete(fn func(hash blockstore.ContentHash, data []byte, path string))
    SetChunkEmitter(emit func(payloadID string, chunkStart uint64, size uint32, hash blockstore.ContentHash))
}
```

- Defined in `pkg/blockstore/local/hooks.go` alongside `LocalStore` — the contract is naturally a store-side capability surface, and grouping it with the implementer-facing types keeps the documented capability map discoverable from the package that ships the implementers.
- `engine.New` collapses the 3 anonymous probes into a single `hooks, ok := cfg.Local.(local.ChunkLifecycleHooks)` assertion; the three setter calls become branches of that one block.
- Both production stores satisfy the full surface:
  - `*fs.FSStore` already implemented `SetObjectIDPersister` + `SetOnChunkComplete`; adds a no-op `SetChunkEmitter` (FSStore's FileBlock rows land via the rollup-completion persister, not the emitter).
  - `*memory.MemoryStore` already implemented `SetChunkEmitter`; adds no-op `SetObjectIDPersister` + `SetOnChunkComplete` (in-memory writes don't traverse the CAS chunkstore + read-cache hot path).
- Compile-time `var _ local.ChunkLifecycleHooks = (*FSStore)(nil)` / `(*MemoryStore)(nil)` assertions added.

**Zero behavior change** — the wiring closures and call sites are byte-identical to before; only the interface plumbing collapses.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m ./pkg/blockstore/...`
- [x] `go test -race -count=1 ./pkg/blockstore/...`
- [x] `go test -race -count=1 ./internal/... ./pkg/controlplane/...`