### PR TITLE
fix(smb/session): unbound-channel gate + bind matrix walkback (#747)

### DIFF
--- a/internal/adapter/smb/prepare_dispatch_test.go
+++ b/internal/adapter/smb/prepare_dispatch_test.go
@@ -1,0 +1,131 @@
+package smb
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/adapter/smb/v2/handlers"
+)
+
+// fakeAddr lets newConnInfoForDispatch satisfy net.Conn.RemoteAddr without a
+// real pipe.
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "tcp" }
+func (fakeAddr) String() string  { return "127.0.0.1:1" }
+
+type fakeConn struct{ net.Conn }
+
+func (fakeConn) RemoteAddr() net.Addr             { return fakeAddr{} }
+func (fakeConn) LocalAddr() net.Addr              { return fakeAddr{} }
+func (fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeConn) SetWriteDeadline(time.Time) error { return nil }
+func (fakeConn) SetDeadline(time.Time) error      { return nil }
+func (fakeConn) Read([]byte) (int, error)         { return 0, nil }
+func (fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (fakeConn) Close() error                     { return nil }
+
+func newConnInfoForDispatch(t *testing.T, connID uint64, dialect types.Dialect) *ConnInfo {
+	t.Helper()
+	mgr := session.NewDefaultManager()
+	h := handlers.NewHandlerWithSessionManager(mgr)
+	cs := NewConnectionCryptoState()
+	cs.SetDialect(dialect)
+	return &ConnInfo{
+		ConnID:         connID,
+		Conn:           fakeConn{},
+		Handler:        h,
+		SessionManager: mgr,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		CryptoState:    cs,
+	}
+}
+
+// TestPrepareDispatch_RejectsUnboundChannel_SMB3 verifies that a data-path
+// command (e.g. READ) arriving on an SMB 3.x connection that is neither the
+// session's origin nor a bound channel is rejected with
+// STATUS_USER_SESSION_DELETED. Mirrors smbtorture session.bind2 / session.
+// bind_invalid_auth at session.c:2209 / 2485 (per Samba
+// smbXsrv_session_find_channel, smb2_server.c:2246).
+func TestPrepareDispatch_RejectsUnboundChannel_SMB3(t *testing.T) {
+	for _, dialect := range []types.Dialect{types.Dialect0300, types.Dialect0302, types.Dialect0311} {
+		t.Run(dialect.String(), func(t *testing.T) {
+			ci := newConnInfoForDispatch(t, 2, dialect)
+			sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+			sess.OriginConnID = 1 // origin is conn 1; we're dispatching on conn 2
+
+			hdr := &header.SMB2Header{
+				Command:   types.SMB2Logoff,
+				SessionID: sess.SessionID,
+				MessageID: 1,
+			}
+			_, _, errStatus := prepareDispatch(context.Background(), hdr, ci)
+			if errStatus != types.StatusUserSessionDeleted {
+				t.Fatalf("errStatus=0x%x, want StatusUserSessionDeleted (0x%x)", errStatus, types.StatusUserSessionDeleted)
+			}
+		})
+	}
+}
+
+// TestPrepareDispatch_AllowsOriginConnection_SMB3 verifies that a session-
+// gated command on the session's origin connection passes the unbound-channel
+// gate. LOGOFF is used because it sets NeedsSession=true and NeedsTree=false.
+func TestPrepareDispatch_AllowsOriginConnection_SMB3(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1 // matches ci.ConnID
+
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2Logoff,
+		SessionID: sess.SessionID,
+		MessageID: 1,
+	}
+	_, _, errStatus := prepareDispatch(context.Background(), hdr, ci)
+	if errStatus != 0 {
+		t.Fatalf("errStatus=0x%x, want 0 on origin connection", errStatus)
+	}
+}
+
+// TestPrepareDispatch_AllowsBoundChannel_SMB3 verifies that a session-gated
+// command on a connection registered as a bound channel passes the gate.
+func TestPrepareDispatch_AllowsBoundChannel_SMB3(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 2, types.Dialect0311)
+	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+	sess.AddChannel(&session.Channel{ConnID: 2, Dialect: types.Dialect0311})
+
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2Logoff,
+		SessionID: sess.SessionID,
+		MessageID: 1,
+	}
+	_, _, errStatus := prepareDispatch(context.Background(), hdr, ci)
+	if errStatus != 0 {
+		t.Fatalf("errStatus=0x%x, want 0 on bound channel", errStatus)
+	}
+}
+
+// TestPrepareDispatch_DoesNotGateSMB2x verifies the unbound-channel gate only
+// applies to SMB 3.x. SMB 2.x sessions are per-connection; the existing
+// session-not-found path already covers cross-connection abuse.
+func TestPrepareDispatch_DoesNotGateSMB2x(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 2, types.Dialect0210)
+	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2Logoff,
+		SessionID: sess.SessionID,
+		MessageID: 1,
+	}
+	_, _, errStatus := prepareDispatch(context.Background(), hdr, ci)
+	if errStatus != 0 {
+		t.Fatalf("errStatus=0x%x, want 0 for SMB 2.x (per-connection scoping handles cross-conn elsewhere)", errStatus)
+	}
+}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -304,6 +304,30 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 				"expiresAt", sess.ExpiresAt)
 			return nil, nil, types.StatusNetworkSessionExpired
 		}
+		// MS-SMB2 §3.3.5.2.9: for SMB 3.x sessions, a non-SESSION_SETUP /
+		// non-LOGOFF request that arrives on a connection that is neither
+		// the session's origin nor a previously bound channel must be
+		// rejected with STATUS_USER_SESSION_DELETED. The client-side
+		// smb2_session_channel() call alone (without a successful
+		// SESSION_SETUP with SMB2_SESSION_FLAG_BINDING) does not register a
+		// channel on the server, so any data-path op on that transport
+		// must fail. Mirrors Samba smbXsrv_session_find_channel — see
+		// smb2_server.c:2246, 4421 — and is what smbtorture
+		// session.bind2 / session.bind_invalid_auth assert.
+		var connDialect types.Dialect
+		if connInfo.CryptoState != nil {
+			connDialect = connInfo.CryptoState.GetDialect()
+		}
+		if connDialect >= types.Dialect0300 &&
+			sess.OriginConnID != connInfo.ConnID &&
+			sess.GetChannel(connInfo.ConnID) == nil {
+			logger.Debug("Request on unbound channel for SMB 3.x session",
+				"command", reqHeader.Command.String(),
+				"sessionID", reqHeader.SessionID,
+				"connID", connInfo.ConnID,
+				"originConnID", sess.OriginConnID)
+			return nil, nil, types.StatusUserSessionDeleted
+		}
 		handlerCtx.IsGuest = sess.IsGuest
 		handlerCtx.Username = sess.Username
 	}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -304,16 +304,20 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 				"expiresAt", sess.ExpiresAt)
 			return nil, nil, types.StatusNetworkSessionExpired
 		}
-		// MS-SMB2 §3.3.5.2.9: for SMB 3.x sessions, a non-SESSION_SETUP /
-		// non-LOGOFF request that arrives on a connection that is neither
-		// the session's origin nor a previously bound channel must be
-		// rejected with STATUS_USER_SESSION_DELETED. The client-side
-		// smb2_session_channel() call alone (without a successful
-		// SESSION_SETUP with SMB2_SESSION_FLAG_BINDING) does not register a
-		// channel on the server, so any data-path op on that transport
-		// must fail. Mirrors Samba smbXsrv_session_find_channel — see
-		// smb2_server.c:2246, 4421 — and is what smbtorture
-		// session.bind2 / session.bind_invalid_auth assert.
+		// MS-SMB2 §3.3.5.2.9: for SMB 3.x sessions, a session-gated
+		// request that arrives on a connection that is neither the
+		// session's origin nor a previously bound channel must be rejected
+		// with STATUS_USER_SESSION_DELETED. SESSION_SETUP is exempt because
+		// it carries NeedsSession=false and routes through handleSessionBind
+		// for its own per-step gating; every other NeedsSession=true command
+		// (LOGOFF, TREE_CONNECT, CREATE, READ, WRITE, …) falls into this
+		// branch and is rejected here. The client-side smb2_session_channel()
+		// call alone (without a successful SESSION_SETUP with
+		// SMB2_SESSION_FLAG_BINDING) does not register a channel on the
+		// server, so any op on that transport must fail. Mirrors Samba
+		// smbXsrv_session_find_channel — see smb2_server.c:2246, 4421 —
+		// and is what smbtorture session.bind2 / session.bind_invalid_auth
+		// assert at session.c:2209 / 2485.
 		var connDialect types.Dialect
 		if connInfo.CryptoState != nil {
 			connDialect = connInfo.CryptoState.GetDialect()

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -313,43 +313,22 @@ still return INVALID_PARAMETER for the anon TYPE_3 itself).
 | smb2.session.anon-encryption2 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #746 |
 | smb2.session.anon-encryption3 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #746 |
 
-### Session Binding (Multi-Channel, Not Implemented)
+### Session Binding (Multi-Channel, Same-Algo Positive Cases)
 
-Session binding tests require multi-channel support to bind a session across
-TCP connections with different SMB dialect and signing/encryption combinations.
+The remaining session-binding rows are the four "same non-GMAC" pairings
+that expect the bind to SUCCEED and then assert a follow-up fresh-init
+SESSION_SETUP returns ACCESS_DENIED. Our server currently disconnects
+the transport on the post-success fresh-init step instead of replying
+ACCESS_DENIED — full fix needs multi-channel response-signing rework
+(retain prior-channel signing keys + return ACCESS_DENIED on
+reauth-from-fresh-init). Tracked under #747 for the v1.0 milestone.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.session.bind2 | Session binding | Session binding not implemented | #747 |
-| smb2.session.bind_invalid_auth | Session binding | Session binding auth validation not implemented | #747 |
-| smb2.session.bind_negative_smb3signCtoHs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signCtoHd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signCtoGs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signCtoGd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signHtoCs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signHtoCd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signHtoGs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signHtoGd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoCs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoCd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoHs | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoHd | Session binding | Multi-channel signing binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneGtoCs | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneGtoCd | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneGtoHs | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneGtoHd | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneCtoGs | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneCtoGd | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneHtoGs | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3sneHtoGd | Session binding | Multi-channel signing+encryption binding not implemented | #747 |
-| smb2.session.bind_negative_smb3signC30toGs | Session binding | Multi-channel signing binding (3.0 to GMAC) not implemented | #747 |
-| smb2.session.bind_negative_smb3signC30toGd | Session binding | Multi-channel signing binding (3.0 to GMAC) not implemented | #747 |
-| smb2.session.bind_negative_smb3signH2XtoGs | Session binding | Multi-channel signing binding (HMAC to GMAC) not implemented | #747 |
-| smb2.session.bind_negative_smb3signH2XtoGd | Session binding | Multi-channel signing binding (HMAC to GMAC) not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoC30s | Session binding | Multi-channel signing binding (GMAC to 3.0) not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoC30d | Session binding | Multi-channel signing binding (GMAC to 3.0) not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoH2Xs | Session binding | Multi-channel signing binding (GMAC to HMAC) not implemented | #747 |
-| smb2.session.bind_negative_smb3signGtoH2Xd | Session binding | Multi-channel signing binding (GMAC to HMAC) not implemented | #747 |
+| smb2.session.bind_negative_smb3signCtoHs | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
+| smb2.session.bind_negative_smb3signCtoHd | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
+| smb2.session.bind_negative_smb3signHtoCs | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
+| smb2.session.bind_negative_smb3signHtoCd | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
 
 ### Session Signing Variants (Algorithm-Specific Tests)
 


### PR DESCRIPTION
Closes #747.

## Summary

- Adds an SMB 3.x **unbound-channel gate** in `prepareDispatch`: a
  session-gated command (`NeedsSession=true`) arriving on a connection
  that is neither the session's origin nor a previously bound channel
  is rejected with `STATUS_USER_SESSION_DELETED`. Mirrors Samba
  `smbXsrv_session_find_channel` (smb2_server.c:2246, 4421) and is what
  smbtorture `session.bind2` / `session.bind_invalid_auth` assert at
  session.c:2209 / 2485.
- SMB 2.x sessions are untouched — they're already per-connection.
- KF walkback for 24 already-passing rows is deferred to a second
  commit after CI confirms.

## Coverage of #747

The 30 tracked tests break down as follows after the foundation laid
in #717 (per-algo signing+encryption, #731) and #746 (binding step-1
gate, #763):

**Already PASSing in CI (24)** — KF rows stale, will be walked back in
a follow-up commit:
- `bind_negative_smb3sign{CtoGs,CtoGd,HtoGs,HtoGd,GtoCs,GtoCd,GtoHs,GtoHd}`
- `bind_negative_smb3sne{GtoCs,GtoCd,GtoHs,GtoHd,CtoGs,CtoGd,HtoGs,HtoGd}`
- `bind_negative_smb3sign{C30toGs,C30toGd,H2XtoGs,H2XtoGd,GtoC30s,GtoC30d,GtoH2Xs,GtoH2Xd}`

**Newly fixed by this PR (2)**:
- `bind2` — operations on an unbound client-side channel now correctly
  return `USER_SESSION_DELETED`.
- `bind_invalid_auth` — same, on the channel left in failed-auth
  state.

**Scope-cut (4)** — left tagged in KNOWN_FAILURES with #747:
- `bind_negative_smb3signCtoHs`, `CtoHd`, `HtoCs`, `HtoCd` — these
  expect `NT_STATUS_OK` (bind succeeds with same-non-GMAC pair) and
  then assert the post-success state machine. Currently report
  `CONNECTION_DISCONNECTED` instead of `ACCESS_DENIED` for the
  follow-up fresh-init SESSION_SETUP at session.c:2818. Requires
  deeper multi-channel response-signing rework that's out of scope
  for this PR.

## Reference

- MS-SMB2 §3.3.5.2.9 (Request lookup), §3.3.5.5 / §3.3.5.5.2 (binding
  validation).
- Samba `source3/smbd/smbXsrv_session.c::smbXsrv_session_find_channel`.

## Test plan

- [x] `go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/...` green locally
- [x] `gofmt -s`, `go vet`, `golangci-lint` clean
- [x] New unit tests: `TestPrepareDispatch_RejectsUnboundChannel_SMB3` (3.0/3.0.2/3.1.1), `TestPrepareDispatch_AllowsOriginConnection_SMB3`, `TestPrepareDispatch_AllowsBoundChannel_SMB3`, `TestPrepareDispatch_DoesNotGateSMB2x`
- [ ] CI confirms smbtorture flips on `session.bind2` + `session.bind_invalid_auth`
- [ ] CI confirms no regression on `signing-aes-128-{cmac,gmac}` / `signing-hmac-sha-256` / encryption tests