### PR TITLE
fix(blockstore/engine): promote mirrorOnce upload failure to Warn

### DIFF
--- a/pkg/blockstore/engine/upload.go
+++ b/pkg/blockstore/engine/upload.go
@@ -23,7 +23,16 @@ func (m *Syncer) syncLocalBlocks(ctx context.Context) {
 	m.local.SyncFileBlocks(ctx)
 
 	if err := m.mirrorOnce(ctx); err != nil {
-		logger.Debug("Periodic mirror pass failed", "error", err)
+		// Shutdown paths (context cancelled, syncer closed) are expected
+		// during graceful Close and stay at Debug. A genuine remote
+		// upload failure (network, auth, quota, S3 5xx, local bitrot) is
+		// unexpected: log at Warn so it is visible before the next
+		// health-check interval rather than silent for a tick.
+		if ctx.Err() != nil || errors.Is(err, ErrClosed) {
+			logger.Debug("Periodic mirror pass aborted during shutdown", "error", err)
+		} else {
+			logger.Warn("Periodic mirror pass failed", "error", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

REVIEW.md §3b **L-1**. `mirrorOnce` S3 PUT failure logged at `Debug` — invisible for one health-check interval. Per CLAUDE.md invariant 6 unexpected errors should be `Warn`/`Error`.

## Changes

- Promote the S3 PUT failure log to `Warn` with the same fields + wrapped err.
- Shutdown-context paths (`ctx.Err() != nil` or `errors.Is(err, ErrClosed)`) stay at `Debug` (expected during graceful Close).

## Test plan

- [x] `go test ./pkg/blockstore/engine/...`
- [x] `go test -race ./pkg/blockstore/engine/...`
- [x] `gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m`