### PR TITLE
fix(blockstore): SyncNow ticker + S3 HTTP timeout + processDownload ctx

### DIFF
--- a/pkg/blockstore/engine/sync_queue.go
+++ b/pkg/blockstore/engine/sync_queue.go
@@ -29,6 +29,13 @@ type SyncQueue struct {
 	stoppedCh       chan struct{}
 	started         bool // tracks whether Start() was called
 
+	// workerCtx is the parent context for per-request contexts created in
+	// processRequest. It is cancelled when stopCh is closed so that in-flight
+	// downloads/uploads abort promptly during Stop() instead of blocking on a
+	// slow or hung remote (e.g. S3).
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
+
 	// Metrics
 	mu              gosync.Mutex
 	pendingDownload int
@@ -72,7 +79,19 @@ func (q *SyncQueue) Start(ctx context.Context) {
 		return
 	}
 	q.started = true
+	// Derive the worker context from the caller's ctx and arrange for it to
+	// be cancelled when stopCh closes. processRequest uses this as parent so
+	// in-flight transfers abort during Stop() instead of pinning goroutines
+	// on a hung remote.
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	q.workerCtx = workerCtx
+	q.workerCancel = workerCancel
 	q.mu.Unlock()
+
+	go func() {
+		<-q.stopCh
+		workerCancel()
+	}()
 
 	logger.Info("Starting transfer queue",
 		"download_workers", q.downloadWorkers, "upload_workers", q.uploadWorkers)
@@ -263,8 +282,15 @@ func (q *SyncQueue) drainUploads() {
 }
 
 // processRequest handles a single transfer request with a fresh context.
+// The per-request context is derived from workerCtx so that Stop() cancels
+// in-flight transfers and they release worker goroutines promptly even when
+// the remote (e.g. S3) is slow or hung.
 func (q *SyncQueue) processRequest(req TransferRequest) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	parent := q.workerCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 	defer cancel()
 
 	var err error

--- a/pkg/blockstore/engine/sync_queue_test.go
+++ b/pkg/blockstore/engine/sync_queue_test.go
@@ -73,6 +73,31 @@ func TestSyncQueue_DoubleStart(t *testing.T) {
 	q.Stop(time.Second)
 }
 
+// TestSyncQueue_StopCancelsWorkerCtx asserts that closing stopCh propagates
+// cancellation to the workerCtx used by processRequest. Without this, an
+// in-flight processDownload would block on a hung remote and leak the worker
+// goroutine past Close()/Stop() deadlines.
+func TestSyncQueue_StopCancelsWorkerCtx(t *testing.T) {
+	cfg := DefaultSyncQueueConfig()
+	q := NewSyncQueue(nil, cfg)
+
+	ctx := context.Background()
+	q.Start(ctx)
+
+	wctx := q.workerCtx
+	if wctx == nil {
+		t.Fatal("workerCtx is nil after Start")
+	}
+
+	q.Stop(time.Second)
+
+	select {
+	case <-wctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("workerCtx was not cancelled within 1s of Stop")
+	}
+}
+
 func TestSyncQueueConfig_Defaults(t *testing.T) {
 	cfg := DefaultSyncQueueConfig()
 

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -686,11 +686,15 @@ func (m *Syncer) SyncNow(ctx context.Context) error {
 	if m.remoteStore == nil {
 		return nil
 	}
-	for !m.uploading.CompareAndSwap(false, true) {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(10 * time.Millisecond):
+	if !m.uploading.CompareAndSwap(false, true) {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for !m.uploading.CompareAndSwap(false, true) {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+			}
 		}
 	}
 	defer m.uploading.Store(false)

--- a/pkg/blockstore/remote/s3/store.go
+++ b/pkg/blockstore/remote/s3/store.go
@@ -33,6 +33,12 @@ const maxBlockReadSize = 8 * 1024 * 1024
 // blockstore.FormatCASKey output ("cas/{hh}/{hh}/{hex}").
 const casPrefix = "cas/"
 
+// s3HTTPRequestTimeout bounds the entire HTTP request lifecycle (connect +
+// request + body read). Prevents a hung S3 endpoint from pinning syncer
+// goroutines indefinitely; without it Close()/DrainAllUploads cannot honour
+// their drain deadlines.
+const s3HTTPRequestTimeout = 2 * time.Minute
+
 // Compile-time interface satisfaction check.
 var _ remote.RemoteStore = (*Store)(nil)
 
@@ -128,7 +134,7 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 
 	httpClient := &http.Client{
 		Transport: httpTransport,
-		Timeout:   0,
+		Timeout:   s3HTTPRequestTimeout,
 	}
 	opts = append(opts, awsconfig.WithHTTPClient(httpClient))
 


### PR DESCRIPTION
## Summary

REVIEW.md §3b **I-6** + **R-1**. Three coupled hygiene fixes around remote sync:

- \`engine/syncer.go::SyncNow\` spin-wait \`time.After(10ms)\` allocated a timer per iter -> single \`time.Ticker\`.
- \`remote/s3/store.go\` HTTP client \`Timeout: 0\` -> \`2m\` constant. Bounds connect + request + body read.
- \`engine/sync_queue.go\` \`processDownload\` ctx now cancels on \`stopCh\` close so \`BlockStore.Close()\` honours its drain deadline instead of leaking goroutines on hung S3.

## Test plan

- [x] \`go test ./pkg/blockstore/engine/... ./pkg/blockstore/remote/s3/...\`
- [x] \`go test -race ./pkg/blockstore/engine/... ./pkg/blockstore/remote/s3/...\`
- [x] \`gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m\`