### PR TITLE
fix(blockstore/fs): private sentinel for internal Walk stop

### DIFF
--- a/pkg/blockstore/local/fs/blockstore_methods.go
+++ b/pkg/blockstore/local/fs/blockstore_methods.go
@@ -172,13 +172,22 @@ func (bc *FSStore) Walk(ctx context.Context, fn func(hash blockstore.ContentHash
 		}
 		if cbErr := fn(h, meta); cbErr != nil {
 			if errors.Is(cbErr, blockstore.ErrStopWalk) {
-				return io.EOF // sentinel for clean exit out of WalkDir
+				// Translate the public clean-exit sentinel into an
+				// unexported one so we can distinguish "callback
+				// asked to stop cleanly" from "filepath.WalkDir or
+				// the callback returned ErrStopWalk-wrapped-or-not
+				// for some other reason". Using a private sentinel
+				// also keeps io.EOF reserved for its real meaning:
+				// a callback that legitimately returns io.EOF (or
+				// wraps it) must halt with the wrapped error, not
+				// be silently treated as a clean exit.
+				return errStopWalkInternal
 			}
 			return fmt.Errorf("walk halted at %s: %w", h, cbErr)
 		}
 		return nil
 	})
-	if walkErr == io.EOF {
+	if errors.Is(walkErr, errStopWalkInternal) {
 		return nil
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
@@ -186,6 +195,16 @@ func (bc *FSStore) Walk(ctx context.Context, fn func(hash blockstore.ContentHash
 	}
 	return walkErr
 }
+
+// errStopWalkInternal is the unexported short-circuit sentinel
+// FSStore.Walk hands to filepath.WalkDir to abort enumeration when the
+// caller's callback returned blockstore.ErrStopWalk. It is never
+// surfaced to the caller — Walk maps it back to nil — and is never
+// observed by the callback. Keeping it private means a callback that
+// returns io.EOF (closed reader, exhausted iterator, …) is treated as
+// a halting error and wrapped via the public contract, instead of
+// being mistaken for the internal short-circuit token.
+var errStopWalkInternal = errors.New("blockstore.fs: stop walk (internal)")
 
 // ListUnsynced returns a push iterator over every CAS hash present in
 // the local store that has not yet been marked synced. The iterator

--- a/pkg/blockstore/local/fs/blockstore_methods_test.go
+++ b/pkg/blockstore/local/fs/blockstore_methods_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"testing"
 
@@ -209,6 +210,93 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 		}
 		if !sawCtxErr {
 			t.Fatalf("expected context.Canceled to be yielded after cancel, got none")
+		}
+	})
+}
+
+// TestFSStore_Walk_StopWalkSentinel pins the public Walk contract:
+//
+//   - returning blockstore.ErrStopWalk from the callback (raw or wrapped
+//     via %w) causes Walk to exit cleanly (nil).
+//   - returning io.EOF from the callback must NOT be mistaken for a
+//     clean exit — io.EOF is just another error and must halt Walk with
+//     the wrapped "walk halted at %s: %w" form.
+//   - returning any other non-nil error halts Walk and propagates the
+//     wrapped error.
+//
+// Regression guard for the I-7 bug: using io.EOF as the internal
+// short-circuit token silently swallowed legitimate io.EOF returns
+// from callbacks.
+func TestFSStore_Walk_StopWalkSentinel(t *testing.T) {
+	t.Run("CleanExitOnErrStopWalk", func(t *testing.T) {
+		bc := newFSStoreForTest(t, FSStoreOptions{})
+		_ = seedChunks(t, bc, 5)
+
+		var seen int
+		err := bc.Walk(context.Background(), func(_ blockstore.ContentHash, _ blockstore.Meta) error {
+			seen++
+			if seen == 2 {
+				return blockstore.ErrStopWalk
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("ErrStopWalk should cause clean nil exit; got %v", err)
+		}
+		if seen != 2 {
+			t.Fatalf("expected callback to stop after 2 calls, got %d", seen)
+		}
+	})
+
+	t.Run("CleanExitOnWrappedErrStopWalk", func(t *testing.T) {
+		// Callers idiomatically wrap ErrStopWalk via fmt.Errorf("%w", ...)
+		// (see pkg/blockstore/errors.go). errors.Is must detect through
+		// the wrap and still trigger clean exit.
+		bc := newFSStoreForTest(t, FSStoreOptions{})
+		_ = seedChunks(t, bc, 3)
+
+		err := bc.Walk(context.Background(), func(h blockstore.ContentHash, _ blockstore.Meta) error {
+			return fmt.Errorf("gc target %s: %w", h, blockstore.ErrStopWalk)
+		})
+		if err != nil {
+			t.Fatalf("wrapped ErrStopWalk should cause clean nil exit; got %v", err)
+		}
+	})
+
+	t.Run("EOFHaltsWithWrappedError", func(t *testing.T) {
+		// Regression guard: a callback returning io.EOF must NOT be
+		// confused with the public ErrStopWalk sentinel. It is just
+		// another error and must halt Walk with the wrapped form.
+		bc := newFSStoreForTest(t, FSStoreOptions{})
+		_ = seedChunks(t, bc, 3)
+
+		err := bc.Walk(context.Background(), func(_ blockstore.ContentHash, _ blockstore.Meta) error {
+			return io.EOF
+		})
+		if err == nil {
+			t.Fatalf("io.EOF from callback must halt Walk with a wrapped error, got nil")
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("returned error must wrap io.EOF; got %v", err)
+		}
+		if errors.Is(err, blockstore.ErrStopWalk) {
+			t.Fatalf("returned error must NOT match ErrStopWalk; got %v", err)
+		}
+	})
+
+	t.Run("ArbitraryErrorHaltsWithWrappedError", func(t *testing.T) {
+		bc := newFSStoreForTest(t, FSStoreOptions{})
+		_ = seedChunks(t, bc, 3)
+
+		boom := errors.New("boom")
+		err := bc.Walk(context.Background(), func(_ blockstore.ContentHash, _ blockstore.Meta) error {
+			return boom
+		})
+		if err == nil {
+			t.Fatalf("non-ErrStopWalk error must halt Walk, got nil")
+		}
+		if !errors.Is(err, boom) {
+			t.Fatalf("returned error must wrap the callback's error; got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

REVIEW.md §3b **I-7**. `FSStore.Walk` used `io.EOF` as the internal early-stop token handed to `filepath.WalkDir` after the callback returned `ErrStopWalk`. The exit check was a bare `walkErr == io.EOF`. That conflation is fragile: a callback that legitimately returns `io.EOF` (closed reader, exhausted iterator) lived only one accidental wrap-removal away from being silently treated as a clean exit. The public contract (per `pkg/blockstore/doc.go` and `pkg/blockstore/errors.go`) requires only `ErrStopWalk` to mean "stop cleanly".

## Changes

- Internal short-circuit uses an unexported package-local sentinel `errStopWalkInternal`; the `errors.Is(cbErr, ErrStopWalk)` check on the callback return is preserved.
- Outer check switched from `walkErr == io.EOF` to `errors.Is(walkErr, errStopWalkInternal)` for sentinel-discipline robustness.
- Tests extend Walk coverage with four cases:
  - callback returns `ErrStopWalk` -> `nil`;
  - callback returns wrapped `ErrStopWalk` (`fmt.Errorf("...: %w", ErrStopWalk)`) -> `nil`;
  - callback returns `io.EOF` -> halts with `walk halted at %s: %w` wrapped error (regression guard for I-7);
  - callback returns arbitrary error -> halts with wrapped error.

## Test plan

- [x] `go test ./pkg/blockstore/local/fs/... ./pkg/blockstore/blockstoretest/...`
- [x] `go test -race ./pkg/blockstore/local/fs/...`
- [x] `gofmt -s -w . && go vet ./pkg/blockstore/... && golangci-lint run --timeout=5m ./pkg/blockstore/...`