### PR TITLE
docs(blockstore): document compression+encryption composition order

### DIFF
--- a/pkg/blockstore/compression/doc.go
+++ b/pkg/blockstore/compression/doc.go
@@ -24,4 +24,37 @@
 // Absence of the compression block means no wrapping (zero behavior
 // change). Algorithm defaults to zstd when the block is present without
 // an explicit algo key.
+//
+// # Composition order
+//
+// When the encryption decorator is also enabled for a remote, compression
+// is the OUTERMOST wrapper and encryption is INNERMOST, so the on-Put
+// data flow is
+//
+//	caller plaintext
+//	  → compression.Decorator (compress)
+//	  → encryption.EncryptedRemote (encrypt compressed bytes)
+//	  → inner remote.RemoteStore
+//
+// Get inverts the order: fetch ciphertext, decrypt, then decompress.
+//
+// Rationale for compressing first: AEAD output has near-maximum entropy,
+// so attempting to compress ciphertext yields a ratio of ~1.0 and burns
+// CPU for nothing. Compressing plaintext is the only ordering that
+// preserves any space saving.
+//
+// The CAS key is BLAKE3 over the PLAINTEXT bytes for both decorators —
+// neither compression framing nor per-block encryption keys influence
+// the hash. Dedup therefore works across remotes that differ in
+// compression algorithm, encryption key, or AEAD choice: identical
+// plaintexts always map to the same content hash. Get path verification
+// hashes the recovered plaintext (after decrypt + decompress) against
+// the requested hash; see [Decorator.ReadBlockVerified] and
+// [encryption.EncryptedRemote.ReadBlockVerified].
+//
+// Composition is fixed in the controlplane share service — there is no
+// runtime toggle to flip the order. The order is established once at
+// remote-store construction and immutable for the lifetime of the
+// remote. The example wiring snippet lives in the encryption package
+// doc, since that is where both decorators are visible together.
 package compression

--- a/pkg/blockstore/encryption/doc.go
+++ b/pkg/blockstore/encryption/doc.go
@@ -48,4 +48,70 @@
 // Absence of the encryption block means no wrapping (zero behavior
 // change). AEAD defaults to AES-256-GCM when the encryption block is
 // present without an explicit aead key.
+//
+// # Composition order
+//
+// When the compression decorator is also enabled for a remote, encryption
+// is the INNERMOST wrapper and compression is OUTERMOST, so the on-Put
+// data flow is
+//
+//	caller plaintext
+//	  → compression.Decorator (compress)
+//	  → encryption.EncryptedRemote (encrypt compressed bytes)
+//	  → inner remote.RemoteStore
+//
+// Get inverts the order: fetch ciphertext, decrypt, then decompress.
+// Encryption operates on whatever bytes the compression layer hands it —
+// the compressed body when the block was compressible, the raw
+// plaintext otherwise (the compression layer skips its frame when the
+// body would not shrink). EncryptedRemote does not know or care which
+// shape it sees; it simply encrypts the bytes presented on Put.
+//
+// Rationale: AEAD output has near-maximum entropy, so compressing
+// ciphertext yields a ratio of ~1.0 and wastes CPU. Compressing first
+// is the only ordering that preserves space savings.
+//
+// The CAS key is BLAKE3 over the PLAINTEXT bytes — not over the
+// compressed body, not over the ciphertext. Both decorators preserve
+// that invariant: compression keeps the hash key untouched on the way
+// down, and encryption binds the plaintext hash into the AEAD's
+// additional-authenticated-data (the hash[:] argument to Seal / Open in
+// [EncryptedRemote.Put] and the package-internal decrypt path). A swapped block
+// at the inner store fails authentication on Get because its declared
+// hash will not match the AAD bound at Put time. Dedup works across
+// remotes with different keys, AEADs, or compression policies because
+// identical plaintexts always hash to the same content key.
+//
+// Per-Put cryptographic material
+//
+//   - Block key: 32 random bytes from crypto/rand, fresh per Put,
+//     wrapped under the share's master key by the configured
+//     [keyprovider.KeyProvider] and stored in the frame header.
+//   - Nonce: AEAD-specific length from crypto/rand, fresh per Put,
+//     stored alongside the ciphertext (12 bytes for AES-256-GCM and
+//     ChaCha20-Poly1305; 24 bytes for XChaCha20-Poly1305). XChaCha's
+//     larger nonce is safe to draw at random at very high block counts;
+//     the 12-byte variants assume a per-share block budget well inside
+//     the birthday bound for random nonces.
+//
+// Composition is fixed in the controlplane share service — there is no
+// runtime toggle to flip the order. The order is established once at
+// remote-store construction and immutable for the lifetime of the
+// remote.
+//
+// Example wiring (showing the canonical composition)
+//
+//	// inner is any concrete remote.RemoteStore (S3, on-disk, …).
+//	encrypted, err := encryption.NewRemote(inner, encPolicy, keyProvider)
+//	if err != nil {
+//	    return nil, err
+//	}
+//	compressed, err := compression.NewRemote(encrypted, compPolicy)
+//	if err != nil {
+//	    _ = encrypted.Close()
+//	    return nil, err
+//	}
+//	// Hand `compressed` to the engine as the BlockStore for the share.
+//	// On Put the engine sees only plaintext; bytes are compressed first,
+//	// then encrypted, then handed to inner.
 package encryption


### PR DESCRIPTION
## Summary

REVIEW.md §2e identified the compression/encryption composition order as undocumented. This PR adds a \`# Composition order\` section to both decorator packages.

## Documented contract

Write path: \`data → hash(plaintext) → compress → encrypt → store ciphertext under hash\`.
Read path: inverse, with \`blake3(plaintext) == hash\` verification at the tail.

Rationale: compression on ciphertext is wasted (encrypted bytes have ~maximum entropy); hash over plaintext lets dedup work across keys/policies.

## Test plan

- [x] \`gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m\`
- [x] \`go test ./pkg/blockstore/compression/... ./pkg/blockstore/encryption/...\`
- [x] \`go doc\` on both packages — new sections render cleanly.