### PR TITLE
fix(blockstore/fs): validate payloadID at getOrCreateLog entry

### DIFF
--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -79,6 +79,18 @@ func (bc *FSStore) logPath(payloadID string) string {
 // tree.Insert and the logIndex re-read, producing a tree/logIndex
 // divergence that wedged rollup (#668).
 func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *intervalTree, *logIndex, error) {
+	// Defense-in-depth (REVIEW.md §3b S-4): reject malformed payloadIDs at
+	// the FIRST line, before any mutex acquisition or fd open. logPath
+	// joins payloadID into filepath.Join, so a '../'-bearing id would
+	// otherwise place a log file outside <baseDir>/logs. Recovery already
+	// validates filenames read from disk (recovery.go ~line 254); this
+	// guard closes the symmetric write-path gap. The check is intentionally
+	// upstream of bc.logsMu so a malicious id can't take the global RLock
+	// either.
+	if !isValidPayloadID(payloadID) {
+		return nil, nil, nil, nil, fmt.Errorf("%w: %q", ErrInvalidPayloadID, payloadID)
+	}
+
 	// Fast path: all four already present.
 	bc.logsMu.RLock()
 	lf, lfOk := bc.logFDs[payloadID]

--- a/pkg/blockstore/local/fs/appendwrite_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_test.go
@@ -417,6 +417,85 @@ func TestAppendWrite_CtxCancel_StillFsyncs(t *testing.T) {
 	}
 }
 
+// TestAppendWrite_InvalidPayloadID_RejectedBeforeFS asserts the
+// defense-in-depth guard at getOrCreateLog's entry (REVIEW.md §3b S-4):
+// malformed payloadIDs (path-traversal, absolute, separator-bearing,
+// empty, NUL-bearing) must be rejected with ErrInvalidPayloadID BEFORE
+// any FS state is touched — no <baseDir>/logs/<id>.log file, no
+// <baseDir>/logs/* parent directory entry, no FSStore map entries.
+func TestAppendWrite_InvalidPayloadID_RejectedBeforeFS(t *testing.T) {
+	cases := []struct {
+		name      string
+		payloadID string
+	}{
+		{"dotdot-only", ".."},
+		{"dot-only", "."},
+		{"empty", ""},
+		{"interior-dotdot", "../etc/passwd"},
+		{"trailing-dotdot", "share/.."},
+		{"leading-slash", "/absolute/path"},
+		{"double-slash", "share//file"},
+		{"nul-byte", "share/file\x00name"},
+		{"single-dot-segment", "share/./file"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+
+			err := bc.AppendWrite(context.Background(), tc.payloadID, []byte("hello"), 0)
+			if !errors.Is(err, ErrInvalidPayloadID) {
+				t.Fatalf("AppendWrite(%q): got err=%v, want errors.Is(err, ErrInvalidPayloadID)", tc.payloadID, err)
+			}
+
+			// No FS state was touched: the logs/ directory was not created,
+			// and no file under baseDir matches the would-be log name.
+			// MkdirAll runs INSIDE getOrCreateLog after the validation guard
+			// so it must not have created logs/ either.
+			if _, statErr := os.Stat(filepath.Join(bc.baseDir, "logs")); !os.IsNotExist(statErr) {
+				// Either it exists (which would be a leak) or some other
+				// unexpected error.
+				if statErr == nil {
+					t.Fatalf("baseDir/logs was created despite invalid payloadID %q", tc.payloadID)
+				}
+				t.Fatalf("unexpected stat error on baseDir/logs: %v", statErr)
+			}
+
+			// No FSStore map entries for the invalid payloadID.
+			bc.logsMu.RLock()
+			_, lfOk := bc.logFDs[tc.payloadID]
+			_, muOk := bc.logLocks[tc.payloadID]
+			_, treeOk := bc.dirtyIntervals[tc.payloadID]
+			_, idxOk := bc.logIndices[tc.payloadID]
+			bc.logsMu.RUnlock()
+			if lfOk || muOk || treeOk || idxOk {
+				t.Fatalf("FSStore created map entries for invalid payloadID %q: lf=%v mu=%v tree=%v idx=%v",
+					tc.payloadID, lfOk, muOk, treeOk, idxOk)
+			}
+		})
+	}
+}
+
+// TestAppendWrite_ValidPayloadID_StillWorks is the happy-path
+// companion of TestAppendWrite_InvalidPayloadID_RejectedBeforeFS:
+// legitimate payloadIDs (plain, path-keyed, unicode) still succeed.
+func TestAppendWrite_ValidPayloadID_StillWorks(t *testing.T) {
+	cases := []string{
+		"plain",
+		"share/file.txt",
+		"share/sub1/sub2/file.bin",
+		"share/file with spaces.txt",
+		"share/日本語.txt",
+	}
+	for _, payloadID := range cases {
+		t.Run(payloadID, func(t *testing.T) {
+			bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+			if err := bc.AppendWrite(context.Background(), payloadID, []byte("hello"), 0); err != nil {
+				t.Fatalf("AppendWrite(%q): %v", payloadID, err)
+			}
+		})
+	}
+}
+
 // TestAppendWrite_LockOrder_PerFileMuStillHeldAcrossSync runs concurrent
 // writers under -race and asserts no race detection. The per-file mu
 // (bc.logLocks[payloadID]) is held by AppendWrite across the

--- a/pkg/blockstore/local/fs/errors.go
+++ b/pkg/blockstore/local/fs/errors.go
@@ -26,6 +26,17 @@ var (
 	// therefore surface as ErrPressureTimeout rather than ErrDeleted.
 	ErrDeleted = errors.New("append log: payload deleted")
 
+	// ErrInvalidPayloadID is returned by write-path entry points when the
+	// caller supplies a payloadID that fails isValidPayloadID's structural
+	// rules (empty, contains '..' / '.' / '' segments, leading '/', NUL
+	// byte, or exceeds maxPayloadIDLen). Surfaced as a defense-in-depth
+	// guard at getOrCreateLog: recovery already validates names read from
+	// disk, but the write path previously accepted any string and passed it
+	// straight to filepath.Join. A malicious or buggy caller with a '../'-
+	// bearing payloadID could otherwise place a log file outside <baseDir>/
+	// logs before recovery's check ever ran.
+	ErrInvalidPayloadID = errors.New("append log: invalid payloadID")
+
 	// ErrPressureTimeout is returned by AppendWrite when its pressure
 	// loop has waited longer than FSStoreOptions.PressureMaxWait without
 	// rollup freeing enough log budget to admit the write. Distinguished


### PR DESCRIPTION
## Summary

REVIEW.md §3b **S-4**. `logPath` joined `payloadID` into `filepath.Join` without a `../` guard at write time — validation ran only at recovery. Defense-in-depth gap.

## Changes

- `isValidPayloadID` now runs at the first line of `getOrCreateLog`, before mutex acquisition or fd open.
- Recovery-time check is preserved (untouched).
- Sentinel: added `ErrInvalidPayloadID` in `errors.go` for caller-side `errors.Is` matching.
- Test table covers `../`, absolute, separator-bearing, and empty payloadIDs; asserts no `<baseDir>/logs/` directory is created.

## Test plan

- [x] `go test ./pkg/blockstore/local/fs/...`
- [x] `go test -race ./pkg/blockstore/local/fs/...`
- [x] `gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m`