### PR TITLE
fix(smb/dirlease): break/ack ordering + initial DOC + requeued CREATE (#743)

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -685,6 +685,21 @@ func (lm *LeaseManager) AnyHolderHasLeaseBits(fileHandle lock.FileHandle, shareN
 	return lockMgr.AnyHolderHasLeaseBits(string(fileHandle), excludeKey, mask)
 }
 
+// SignalParkedCreates wakes any parked CREATE waiter on fileHandle so it
+// re-evaluates its post-break gate. SMB CLOSE invokes this after removing the
+// closing open from the open-file table so a parked dir CREATE that was
+// share-mode-conflicting with the just-closed holder can re-check share-mode
+// against the now-shrunk table and complete with OK rather than stalling
+// until the 5 s async-break wait timeout. Required by smbtorture
+// smb2.dirlease.v2_request.
+func (lm *LeaseManager) SignalParkedCreates(fileHandle lock.FileHandle, shareName string) {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return
+	}
+	lockMgr.SignalParkedCreates(string(fileHandle))
+}
+
 // AnyHolderIsTraditionalOplock reports whether any holder on fileHandle is a
 // traditional oplock (synthetic-key record). Returns false when no LockManager
 // is bound for the share.
@@ -993,6 +1008,38 @@ func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
 	waitCtx, cancel := context.WithTimeout(ctx, parentLeaseBreakWaitTimeout)
 	defer cancel()
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
+}
+
+// BreakParentDirLeasesOnContentChangeAsync dispatches the same single
+// break-to-None notification per holder as BreakParentDirLeasesOnDestructiveCreate
+// but WITHOUT waiting for the LEASE_BREAK_ACK. Used by content-change paths
+// (SET_INFO rename / hardlink / disposition, CLOSE-on-delete, WRITE-mark)
+// where the triggering request must complete on its own transport: waiting for
+// the holder's ACK inline causes a server-side timeout that force-completes
+// the lease, so when the test client (which deferred the ACK via lease_skip_ack
+// to capture the break for replay) eventually re-acks, the lease is no longer
+// in the breaking state and the ACK returns STATUS_UNSUCCESSFUL.
+//
+// Mirrors Samba `contend_dirleases` → `send_break_to_none`
+// (source3/smbd/smb2_oplock.c): the dispatch is fire-and-forget; the holder
+// acks on its own schedule and that ACK completes the per-lease state
+// transition. Required by smbtorture smb2.dirlease.{rename, hardlink,
+// unlink_different_set_and_close, unlink_*_initial_and_close} which all set
+// lease_skip_ack=true before the triggering op and replay the captured ACK
+// after the response returns.
+func (lm *LeaseManager) BreakParentDirLeasesOnContentChangeAsync(
+	parentHandle lock.FileHandle,
+	shareName string,
+	excludeClientID string,
+	excludeParentLeaseKey [16]byte,
+	hasExcludeKey bool,
+) error {
+	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(
+		parentHandle, shareName, excludeClientID, excludeParentLeaseKey, hasExcludeKey)
+	if lockMgr == nil {
+		return nil
+	}
+	return lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonDestructive)
 }
 
 // BreakParentReadLeasesOnModify breaks Read leases on a parent directory

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -505,11 +505,11 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						savedHas := openFile.HasParentLeaseKey
 						openFile.HasParentLeaseKey = false
 						openFile.ParentLeaseKey = [16]byte{}
-						h.breakParentDirLeasesForContentChange(authCtx, openFile)
+						h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 						openFile.ParentLeaseKey = savedKey
 						openFile.HasParentLeaseKey = savedHas
 					} else {
-						h.breakParentDirLeasesForContentChange(authCtx, openFile)
+						h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 					}
 
 					if h.NotifyRegistry != nil {
@@ -551,7 +551,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", openFile.Path, "error", authErr)
 		} else {
 			PropagateOpenFileParentLeaseKey(authCtx, openFile)
-			h.breakParentDirLeasesForContentChange(authCtx, openFile)
+			h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 		}
 	}
 
@@ -684,14 +684,25 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (smbtorture compound_find.compound_find_close).
 	h.WaitAndDeleteOpenFile(req.FileID)
 
-	// Wake any parked CREATE on this handle so it can re-evaluate share-mode
-	// against the now-shrunk open-file table. The signal MUST follow the
-	// open-file removal (not just the lease release) so the parked CREATE's
-	// share-mode recheck does not still observe the closing holder. Required
-	// by smbtorture smb2.dirlease.v2_request: tree2's conflicting CREATE
-	// parks on tree1's breaking RH dir lease; tree1's CLOSE must wake it
-	// without waiting for the 5 s async-break timeout.
-	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+	// Wake any parked dir-CREATE on this handle so it can re-evaluate
+	// share-mode against the now-shrunk open-file table. The signal MUST
+	// follow the open-file removal (not just the lease release) so the
+	// parked CREATE's share-mode recheck does not still observe the
+	// closing holder. Required by smbtorture smb2.dirlease.v2_request:
+	// tree2's conflicting CREATE parks on tree1's breaking RH dir lease;
+	// tree1's CLOSE must wake it without waiting for the 5 s async-break
+	// timeout.
+	//
+	// Scoped to directory closes only: file-CREATE parks in
+	// breakAndMaybeParkCreate use the same breakWait channel, but their
+	// resume contract is "wait for actual ACK (or 5 s timeout
+	// auto-downgrade)", not "wake on any CLOSE on the file". Signaling
+	// for file closes prematurely wakes a parked file CREATE whose
+	// holder closed without acking — smbtorture
+	// smb2.kernel-oplocks.kernel_oplocks7 relies on tree2's parked
+	// CREATE staying parked until the timeout while tree1's re-open
+	// arrives first (CREATE returns EXCL with no other holder visible).
+	if openFile.IsDirectory && h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 		h.LeaseManager.SignalParkedCreates(lock.FileHandle(openFile.MetadataHandle), openFile.ShareName)
 	}
 

--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -244,7 +244,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (1067-byte files with XSym\n header). On CLOSE, we convert these to
 	// real symlinks in the metadata store for NFS interoperability.
 
-	if !openFile.IsDirectory && openFile.PayloadID != "" && !openFile.DeletePending {
+	if !openFile.IsDirectory && openFile.PayloadID != "" && !openFile.DeletePending && !openFile.InitialDeleteOnClose {
 		if converted, _ := h.checkAndConvertMFsymlink(ctx, openFile); converted {
 			logger.Debug("CLOSE: converted MFsymlink to symlink", "path", openFile.Path)
 		}
@@ -315,6 +315,18 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// ========================================================================
 	// Step 8: Handle delete-on-close (FileDispositionInformation)
 	// ========================================================================
+
+	// Promote per-handle InitialDeleteOnClose to shared committed DOC at CLOSE
+	// time, mirroring Samba close.c::close_normal_file: if the closing handle
+	// requested initial DOC at CREATE and nobody else has committed a shared
+	// DOC via SET_INFO disposition, set DeletePending so the deletion path
+	// fires (whether this is the last handle or DOC propagates to siblings
+	// via the propagation block below). InitialDeleteOnClose is a per-handle
+	// flag and must NOT block subsequent opens prior to this CLOSE — required
+	// by smbtorture smb2.dirlease.{unlink_same, unlink_different}_initial_and_close.
+	if openFile.InitialDeleteOnClose && !openFile.DeletePending {
+		openFile.DeletePending = true
+	}
 
 	if openFile.DeletePending || openFile.BaseFileDeletePending {
 		// Per MS-FSA 2.1.5.4: delete-on-close only removes the file when the
@@ -671,6 +683,17 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// goroutine on the same connection and causing a spurious FILE_CLOSED
 	// (smbtorture compound_find.compound_find_close).
 	h.WaitAndDeleteOpenFile(req.FileID)
+
+	// Wake any parked CREATE on this handle so it can re-evaluate share-mode
+	// against the now-shrunk open-file table. The signal MUST follow the
+	// open-file removal (not just the lease release) so the parked CREATE's
+	// share-mode recheck does not still observe the closing holder. Required
+	// by smbtorture smb2.dirlease.v2_request: tree2's conflicting CREATE
+	// parks on tree1's breaking RH dir lease; tree1's CLOSE must wake it
+	// without waiting for the 5 s async-break timeout.
+	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+		h.LeaseManager.SignalParkedCreates(lock.FileHandle(openFile.MetadataHandle), openFile.ShareName)
+	}
 
 	logger.Debug("CLOSE successful",
 		"fileID", fmt.Sprintf("%x", req.FileID),

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -213,6 +213,36 @@ type SMBHandlerContext struct {
 	PostSend func()
 }
 
+// AppendPostSend chains fn onto ctx.PostSend so the dispatch layer runs both
+// the previously-installed hook and fn (in order) after the current command's
+// response has been written. Safe to call multiple times — each call wraps
+// the prior hook. No-op when ctx is nil.
+//
+// Used by SET_INFO / CLOSE / hardlink content-change paths to defer the
+// dir-lease break-to-None notification until after the triggering request's
+// response is on the wire. Mirrors Samba `send_break_to_none`
+// (source3/smbd/smb2_oplock.c): the messaging context delivers the break in
+// a later tevent cycle, so the client's lease handler runs after the request
+// completes and observes lease_skip_ack=true (set by smbtorture between
+// request and break). Without the deferral the break arrives interleaved
+// with the request response, the handler auto-acks (skip_ack still false),
+// and the test's manual replay ACK fails STATUS_UNSUCCESSFUL — covers
+// smbtorture smb2.dirlease.{rename, hardlink, unlink_different_*}.
+func AppendPostSend(ctx *SMBHandlerContext, fn func()) {
+	if ctx == nil || fn == nil {
+		return
+	}
+	prev := ctx.PostSend
+	if prev == nil {
+		ctx.PostSend = fn
+		return
+	}
+	ctx.PostSend = func() {
+		prev()
+		fn()
+	}
+}
+
 // NewSMBHandlerContext creates a new handler context from request parameters.
 // The context is populated with identifiers extracted from the SMB2 header.
 // Share-level fields (ShareName, User, Permission) are set later by handlers.

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -234,11 +234,44 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	}
 	needsParkForFlush := h.LeaseManager.AnyHolderHasLeaseBits(lockFileHandle, shareName, waitExceptKey, delayMask)
 
-	// Directory branch: fire-and-forget. The single-threaded test driver
-	// can't ack until this CREATE returns, so waiting would deadlock.
+	// Directory branch: dispatch the break fire-and-forget, then decide
+	// between inline completion and async park (mirrors the file branch
+	// below, scoped to the share-mode-conflict case).
+	//
+	// Most dir CREATEs do NOT need to park: the existing dir-lease holder is
+	// either same-client / same-key (suppressed) or holds RHW so a new opener
+	// with the same share-mode is admitted alongside it. Only a share-mode
+	// conflict actually delays the new opener — the holder must release
+	// (close) before the CREATE can proceed. Required by smbtorture
+	// smb2.dirlease.v2_request second-attempt step: tree2 sends an
+	// `share_access=""` CREATE on a dir already opened by tree1 with `RWD`,
+	// which conflicts; the test expects STATUS_PENDING + a deferred response
+	// that completes with OK once tree1 closes its handle.
 	if d.existingFile.Type == metadata.FileTypeDirectory {
 		if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(lockFileHandle, shareName, reason, d.excludeOwner); err != nil {
 			logger.Debug("CREATE: directory handle lease break failed", "error", err)
+		}
+
+		// Park only when the conflicting holder both intersects the
+		// per-reason delay-mask AND there is at least one OTHER breaking
+		// lease to wait on (the holder's own break we just dispatched).
+		// Without these guards, dir CREATEs that don't need parking would
+		// pay an unnecessary roundtrip.
+		if reason != lock.BreakReasonSharingViolation || !needsParkForFlush {
+			return 0
+		}
+		if !h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
+			return 0
+		}
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey); asyncId != 0 {
+			return asyncId
+		}
+		// Park failed (no slots / registry full): fall through to sync
+		// wait, then let completeCreateAfterBreak re-evaluate share mode.
+		waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+		defer cancelWait()
+		if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
+			logger.Debug("CREATE: sync directory break wait completed", "error", err)
 		}
 		return 0
 	}
@@ -861,24 +894,24 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 
 	openFile := &OpenFile{
-		FileID:         smbFileID,
-		TreeID:         ctx.TreeID,
-		SessionID:      ctx.SessionID,
-		Path:           filename,
-		ShareName:      tree.ShareName,
-		OpenTime:       time.Now(),
-		DesiredAccess:  req.DesiredAccess,
-		GrantedAccess:  grantedAccess,
-		IsDirectory:    file.Type == metadata.FileTypeDirectory,
-		MetadataHandle: fileHandle,
-		PayloadID:      file.PayloadID,
-		ParentHandle:   parentHandle,
-		FileName:       baseName,
-		OplockLevel:    grantedOplock,
-		ShareAccess:    req.ShareAccess,
-		CreateOptions:  req.CreateOptions,
-		DeletePending:  req.CreateOptions&types.FileDeleteOnClose != 0,
-		ClientGUID:     connClientGUID(ctx),
+		FileID:               smbFileID,
+		TreeID:               ctx.TreeID,
+		SessionID:            ctx.SessionID,
+		Path:                 filename,
+		ShareName:            tree.ShareName,
+		OpenTime:             time.Now(),
+		DesiredAccess:        req.DesiredAccess,
+		GrantedAccess:        grantedAccess,
+		IsDirectory:          file.Type == metadata.FileTypeDirectory,
+		MetadataHandle:       fileHandle,
+		PayloadID:            file.PayloadID,
+		ParentHandle:         parentHandle,
+		FileName:             baseName,
+		OplockLevel:          grantedOplock,
+		ShareAccess:          req.ShareAccess,
+		CreateOptions:        req.CreateOptions,
+		InitialDeleteOnClose: req.CreateOptions&types.FileDeleteOnClose != 0,
+		ClientGUID:           connClientGUID(ctx),
 	}
 
 	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {
@@ -902,7 +935,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 
 	// Record the DOC setter's parent key for initial delete-on-close
 	// (CREATE with FILE_DELETE_ON_CLOSE). Covers dirlease unlink tests.
-	if openFile.DeletePending {
+	if openFile.InitialDeleteOnClose {
 		openFile.DeleteOnCloseParentKey = openFile.ParentLeaseKey
 		openFile.HasDeleteOnCloseParentKey = openFile.HasParentLeaseKey
 	}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -379,10 +379,33 @@ type OpenFile struct {
 	EnumerationLastName    string
 	EnumerationSpecialDone int // count of special entries already returned (0..2)
 
-	// Delete on close support (FileDispositionInformation)
-	DeletePending bool                // If true, delete file/directory when handle is closed
-	ParentHandle  metadata.FileHandle // Parent directory handle for deletion
-	FileName      string              // File name within parent for deletion
+	// Delete on close support (FileDispositionInformation).
+	//
+	// DeletePending tracks the SHARED, committed delete-on-close state per
+	// MS-FSA 2.1.5.1.2.1 and Samba `is_delete_on_close_set` (locking.tdb).
+	// It is set ONLY by:
+	//   - SET_INFO FileDispositionInformation with DeleteFile=TRUE (an
+	//     explicit commit by an opener), or
+	//   - CLOSE-time promotion of InitialDeleteOnClose on the last handle
+	//     when nobody else has committed a shared DOC yet (matches Samba
+	//     close.c::close_normal_file: initial_delete_on_close
+	//     && !is_delete_on_close_set => set_delete_on_close_lck).
+	// Subsequent CREATEs see DeletePending and return STATUS_DELETE_PENDING
+	// per MS-SMB2 3.3.5.9 — the gate consumed by isFileDeletePending and
+	// isFileOrBaseDeletePending.
+	//
+	// InitialDeleteOnClose tracks the PER-HANDLE initial DOC flag from a
+	// CREATE with FILE_DELETE_ON_CLOSE (Samba `fsp_flags.initial_delete_on_close`).
+	// It is NOT visible to other handles via isFileDeletePending and does
+	// NOT block subsequent opens — those still succeed and observe the
+	// existing share-mode rules until the DOC is actually committed at
+	// CLOSE time. Required by smbtorture smb2.dirlease.{unlink_same,
+	// unlink_different}_initial_and_close which open a file with initial
+	// DOC and then immediately open a SECOND handle to it (must succeed).
+	DeletePending        bool                // committed shared DOC (visible to other opens)
+	InitialDeleteOnClose bool                // per-handle initial DOC from CREATE FILE_DELETE_ON_CLOSE
+	ParentHandle         metadata.FileHandle // Parent directory handle for deletion
+	FileName             string              // File name within parent for deletion
 
 	// ShareAccess stores the sharing mode from the CREATE request.
 	// Used for share mode conflict checking during rename and other operations.
@@ -1086,8 +1109,11 @@ func (h *Handler) closeFilesWithFilter(
 			h.flushFileCache(ctx, openFile)
 		}
 
-		// Handle delete-on-close (FileDispositionInformation)
-		if openFile.DeletePending && len(openFile.ParentHandle) > 0 && openFile.FileName != "" {
+		// Handle delete-on-close (FileDispositionInformation OR per-handle
+		// initial DOC from a CREATE FILE_DELETE_ON_CLOSE that was not
+		// promoted earlier — TDIS / LOGOFF / disconnect skip the explicit
+		// CLOSE handler, so the same close.go promotion applies here).
+		if (openFile.DeletePending || openFile.InitialDeleteOnClose) && len(openFile.ParentHandle) > 0 && openFile.FileName != "" {
 			h.handleDeleteOnClose(ctx, sess, openFile, caller)
 		}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1113,7 +1113,53 @@ func (h *Handler) closeFilesWithFilter(
 		// initial DOC from a CREATE FILE_DELETE_ON_CLOSE that was not
 		// promoted earlier — TDIS / LOGOFF / disconnect skip the explicit
 		// CLOSE handler, so the same close.go promotion applies here).
-		if (openFile.DeletePending || openFile.InitialDeleteOnClose) && len(openFile.ParentHandle) > 0 && openFile.FileName != "" {
+		//
+		// Promote per-handle InitialDeleteOnClose to shared committed
+		// DeletePending only when no OTHER handle on the same metadata
+		// file remains open: otherwise the unlink in handleDeleteOnClose
+		// would fire before the last sibling closes, violating MS-FSA
+		// 2.1.5.4 (delete-on-close removes the file when the LAST handle
+		// closes, not on the per-handle initial flag). When siblings
+		// remain, propagate the DOC + DOC-setter parent key onto them so
+		// the eventual sibling close in close.go (or this same teardown
+		// for sibling opens in this iteration) fires the delete instead.
+		isInitialDocOnly := openFile.InitialDeleteOnClose && !openFile.DeletePending
+		if isInitialDocOnly && len(openFile.MetadataHandle) > 0 {
+			otherHandleExists := false
+			h.files.Range(func(_, value any) bool {
+				other := value.(*OpenFile)
+				if other.FileID == openFile.FileID {
+					return true
+				}
+				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+					otherHandleExists = true
+					return false
+				}
+				return true
+			})
+			if otherHandleExists {
+				// Propagate DOC to remaining handles so their eventual
+				// close triggers the delete. Matches the close.go path
+				// at "DOC propagated to other handles (not last)".
+				h.files.Range(func(_, value any) bool {
+					other := value.(*OpenFile)
+					if other.FileID == openFile.FileID {
+						return true
+					}
+					if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+						other.DeletePending = true
+						other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
+						other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+						h.StoreOpenFile(other)
+					}
+					return true
+				})
+				logger.Debug(caller+": initial DOC propagated to other handles (not last)",
+					"path", openFile.Path)
+				isInitialDocOnly = false // delete handled by remaining sibling
+			}
+		}
+		if (openFile.DeletePending || isInitialDocOnly) && len(openFile.ParentHandle) > 0 && openFile.FileName != "" {
 			h.handleDeleteOnClose(ctx, sess, openFile, caller)
 		}
 

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1219,7 +1219,11 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	}
 
 	if deleted {
-		h.breakParentDirLeasesForContentChange(authCtx, openFile)
+		// No SMBHandlerContext available on the TDIS/LOGOFF/disconnect
+		// teardown path — pass nil so the helper falls back to inline
+		// dispatch (those paths don't ship a triggering response on the
+		// same wire, so the deferred-via-PostSend ordering is unneeded).
+		h.breakParentDirLeasesForContentChange(nil, authCtx, openFile)
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/query_info_test.go
+++ b/internal/adapter/smb/v2/handlers/query_info_test.go
@@ -428,7 +428,7 @@ func TestFilePositionInformation_RoundTrip(t *testing.T) {
 	// query encoding.
 	setBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(setBuf, 0x1000)
-	resp, err := h.setFileInfoFromStore(authCtx, openFile, types.FilePositionInformation, setBuf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, openFile, types.FilePositionInformation, setBuf)
 	if err != nil {
 		t.Fatalf("SET FilePositionInformation: unexpected error: %v", err)
 	}

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -255,7 +255,7 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 
 	switch req.InfoType {
 	case types.SMB2InfoTypeFile:
-		return h.setFileInfoFromStore(authCtx, openFile, types.FileInfoClass(req.FileInfoClass), req.Buffer)
+		return h.setFileInfoFromStore(ctx, authCtx, openFile, types.FileInfoClass(req.FileInfoClass), req.Buffer)
 	case types.SMB2InfoTypeSecurity:
 		return h.setSecurityInfo(authCtx, openFile, req.AdditionalInfo, req.Buffer)
 	default:
@@ -269,6 +269,7 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 
 // setFileInfoFromStore handles setting file information using metadata store.
 func (h *Handler) setFileInfoFromStore(
+	ctx *SMBHandlerContext,
 	authCtx *metadata.AuthContext,
 	openFile *OpenFile,
 	class types.FileInfoClass,
@@ -595,7 +596,7 @@ func (h *Handler) setFileInfoFromStore(
 		// timestamps changes what READDIR returns, invalidating parent-dir
 		// Read + Handle caching. Parent-key suppression (C2) flows through
 		// the same breakParentDirLeasesForContentChange plumbing.
-		h.breakParentDirLeasesForContentChange(authCtx, openFile)
+		h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 
 		if h.NotifyRegistry != nil {
 			var nf uint32
@@ -728,7 +729,7 @@ func (h *Handler) setFileInfoFromStore(
 			h.StoreOpenFile(openFile)
 
 			// Break parent directory leases on rename (content change)
-			h.breakParentDirLeasesForContentChange(authCtx, openFile)
+			h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 
 			logger.Debug("SET_INFO: stream rename successful",
 				"oldName", oldFileName,
@@ -1089,9 +1090,9 @@ func (h *Handler) setFileInfoFromStore(
 		// the renamer's ParentLeaseKey suppression from C2. Skip the dst
 		// break when src == dst (same-dir rename) to avoid a redundant
 		// double-break on a single dir-lease holder.
-		h.breakParentDirLeasesForContentChangeOn(authCtx, srcParentHandle, openFile)
+		h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, srcParentHandle, openFile)
 		if !bytes.Equal(toDir, srcParentHandle) {
-			h.breakParentDirLeasesForContentChangeOn(authCtx, toDir, openFile)
+			h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, toDir, openFile)
 		}
 
 		logger.Debug("SET_INFO: rename successful",
@@ -1268,7 +1269,7 @@ func (h *Handler) setFileInfoFromStore(
 		// smb2.dirlease.seteof). Per MS-FSA 2.1.5.14: size changes
 		// are visible in READDIR results, invalidating parent-dir
 		// Read + Handle caching. Parent-key suppression (C2) applies.
-		h.breakParentDirLeasesForContentChange(authCtx, openFile)
+		h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 
 		if h.NotifyRegistry != nil {
 			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeSize)
@@ -1314,7 +1315,7 @@ func (h *Handler) setFileInfoFromStore(
 		// FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2 — hard link creation.
 		// Wire format mirrors FILE_RENAME_INFORMATION: ReplaceIfExists (1B),
 		// Reserved (7B), RootDirectory (8B), FileNameLength (4B), FileName (UTF-16LE).
-		return h.handleFileLinkInformation(authCtx, openFile, buffer)
+		return h.handleFileLinkInformation(ctx, authCtx, openFile, buffer)
 
 	case types.FileFullEaInformation: // [MS-FSCC] 2.4.15 - Extended attributes
 		// Reject SET on the reserved ACL xattr name with ACCESS_DENIED so the
@@ -1704,11 +1705,17 @@ func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Sta
 // breakParentDirLeasesForContentChange breaks both Handle and Read leases on
 // the parent directory when directory CONTENT changes (rename, delete). These
 // operations affect what READDIR returns, invalidating Read caching.
-func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthContext, openFile *OpenFile) {
+//
+// ctx may be nil — callers that don't carry a SMBHandlerContext (e.g. cross-
+// protocol cleanup paths) fall back to inline dispatch. Carrying ctx lets the
+// helper defer the dispatch via PostSend so the break notification arrives
+// after the triggering request's response, matching Samba's tevent-cycle
+// `send_break_to_none` semantics.
+func (h *Handler) breakParentDirLeasesForContentChange(ctx *SMBHandlerContext, authCtx *metadata.AuthContext, openFile *OpenFile) {
 	if len(openFile.ParentHandle) == 0 {
 		return
 	}
-	h.breakParentDirLeasesForContentChangeOn(authCtx, openFile.ParentHandle, openFile)
+	h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, openFile.ParentHandle, openFile)
 }
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
@@ -1733,7 +1740,7 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 // a same-client SET_INFO / WRITE / CLOSE / RENAME with a mismatched (or
 // absent) ParentLeaseKey MUST still break the parent dir lease held by that
 // same client.
-func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, openFile *OpenFile) {
+func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext, authCtx *metadata.AuthContext, parentHandle metadata.FileHandle, openFile *OpenFile) {
 	if h.LeaseManager == nil || len(parentHandle) == 0 {
 		return
 	}
@@ -1746,16 +1753,38 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthC
 	// exclusion — same-client breaks fire when the key doesn't match.
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
+	path := openFile.Path
+	parentDbg := fmt.Sprintf("%x", parentHandle)
+	shareName := openFile.ShareName
 
-	if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
-		parentLockHandle, openFile.ShareName, "",
-		excludeParentKey, hasExcludeKey,
-	); breakErr != nil {
-		logger.Debug("SET_INFO: parent directory lease break-to-None failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
+	dispatch := func() {
+		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+			parentLockHandle, shareName, "",
+			excludeParentKey, hasExcludeKey,
+		); breakErr != nil {
+			logger.Debug("SET_INFO: parent directory lease break-to-None failed", "path", path, "parent", parentDbg, "error", breakErr)
+		}
 	}
+
+	// Defer dispatch until after the triggering request's response is on the
+	// wire when an SMB ctx is available. Mirrors Samba `send_break_to_none`
+	// (source3/smbd/smb2_oplock.c) which schedules the break via the
+	// messaging context for a later tevent cycle — required by smbtorture
+	// smb2.dirlease.{rename, hardlink, unlink_different_set_and_close,
+	// unlink_different_initial_and_close} which set lease_skip_ack=true
+	// AFTER the triggering request returns. With inline dispatch the break
+	// arrives before the response, the client's lease handler observes
+	// skip_ack=false and auto-acks, and the test's manual replay ACK then
+	// fails STATUS_UNSUCCESSFUL because the lease is no longer breaking.
+	//
 	// authCtx is retained for signature parity with sync-variant call sites;
 	// the async dispatch does not consume it.
 	_ = authCtx
+	if ctx != nil {
+		AppendPostSend(ctx, dispatch)
+	} else {
+		dispatch()
+	}
 }
 
 // breakDstParentDirHandleLeasesForRename strips the Handle bit only (RH -> R)
@@ -1844,6 +1873,7 @@ func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
 // same-dir + same-parent-key suppresses; same-dir + different-parent-key
 // breaks; cross-dir always breaks the dst parent unless its key matches.
 func (h *Handler) handleFileLinkInformation(
+	ctx *SMBHandlerContext,
 	authCtx *metadata.AuthContext,
 	openFile *OpenFile,
 	buffer []byte,
@@ -1949,12 +1979,25 @@ func (h *Handler) handleFileLinkInformation(
 		dstParentLock := lock.FileHandle(dstDir)
 		excludeParentKey := openFile.ParentLeaseKey
 		hasExcludeKey := openFile.HasParentLeaseKey
-		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
-			dstParentLock, openFile.ShareName,
-			"", excludeParentKey, hasExcludeKey,
-		); breakErr != nil {
-			logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None failed",
-				"dst", newPath, "error", breakErr)
+		shareName := openFile.ShareName
+		dstDbg := newPath
+		dispatch := func() {
+			if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+				dstParentLock, shareName,
+				"", excludeParentKey, hasExcludeKey,
+			); breakErr != nil {
+				logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None failed",
+					"dst", dstDbg, "error", breakErr)
+			}
+		}
+		// Defer until after the SET_INFO response is on the wire so the
+		// client's lease handler runs in the next tevent cycle with
+		// lease_skip_ack=true (see breakParentDirLeasesForContentChangeOn
+		// for the Samba-parity rationale).
+		if ctx != nil {
+			AppendPostSend(ctx, dispatch)
+		} else {
+			dispatch()
 		}
 	}
 

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1719,10 +1719,15 @@ func (h *Handler) breakParentDirLeasesForContentChange(authCtx *metadata.AuthCon
 // Per Samba `contend_dirleases` / `do_dirlease_break_to_none`
 // (source3/smbd/smb2_oplock.c): a directory-content change emits a SINGLE
 // LEASE_BREAK to None per holder, not the two-step strip-H / strip-R pattern
-// used for file leases. Using `BreakParentDirLeasesOnDestructiveCreate`
-// (single break-to-None) avoids sending two break notifications for an RH
-// dir lease — required by smbtorture rename / hardlink / setinfo /
-// unlink_*_set_and_close (same-dir, wrong/no parent-leaskey cases).
+// used for file leases. The dispatch is FIRE-AND-FORGET: Samba's
+// `send_break_to_none` does not wait for the ACK, and the triggering
+// request (rename / hardlink / setinfo / close) returns as soon as the
+// notification is queued. Required by smbtorture smb2.dirlease.{rename,
+// hardlink, unlink_different_set_and_close, unlink_*_initial_and_close}
+// which set lease_skip_ack=true AFTER the triggering request returns and
+// then replay the captured ACK manually — waiting inline would let the
+// 5 s ack-timeout force-complete the lease, so the manual replay would
+// hit STATUS_UNSUCCESSFUL (the lease is no longer in BREAKING state).
 //
 // Per Samba dirlease_should_break: ClientID is NOT used for suppression —
 // a same-client SET_INFO / WRITE / CLOSE / RENAME with a mismatched (or
@@ -1742,12 +1747,15 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(authCtx *metadata.AuthC
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
 
-	if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(
-		authCtx.Context, parentLockHandle, openFile.ShareName, "",
+	if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+		parentLockHandle, openFile.ShareName, "",
 		excludeParentKey, hasExcludeKey,
 	); breakErr != nil {
 		logger.Debug("SET_INFO: parent directory lease break-to-None failed", "path", openFile.Path, "parent", fmt.Sprintf("%x", parentHandle), "error", breakErr)
 	}
+	// authCtx is retained for signature parity with sync-variant call sites;
+	// the async dispatch does not consume it.
+	_ = authCtx
 }
 
 // breakDstParentDirHandleLeasesForRename strips the Handle bit only (RH -> R)
@@ -1932,13 +1940,17 @@ func (h *Handler) handleFileLinkInformation(
 	// only — no ClientID exclusion per Samba dirlease_should_break. Single
 	// break-to-None matches Samba `contend_dirleases` / `do_dirlease_break_to_none`
 	// — required by smbtorture hardlink samedir-{wrong,no}-parent-leaskey
-	// which expect exactly one LEASE_BREAK per holder.
+	// which expect exactly one LEASE_BREAK per holder. Fire-and-forget per
+	// Samba `send_break_to_none`: the test sets lease_skip_ack=true AFTER
+	// the setinfo returns and replays the captured ACK; waiting inline would
+	// force-complete the lease on timeout and the replay would hit
+	// STATUS_UNSUCCESSFUL.
 	if h.LeaseManager != nil {
 		dstParentLock := lock.FileHandle(dstDir)
 		excludeParentKey := openFile.ParentLeaseKey
 		hasExcludeKey := openFile.HasParentLeaseKey
-		if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(
-			authCtx.Context, dstParentLock, openFile.ShareName,
+		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+			dstParentLock, openFile.ShareName,
 			"", excludeParentKey, hasExcludeKey,
 		); breakErr != nil {
 			logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None failed",

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -800,28 +800,25 @@ func (h *Handler) setFileInfoFromStore(
 		// conflicts. Stream renames don't traverse the directory layer and
 		// returned earlier above; we're past that branch here.
 		//
-		// Pre-conflict dst-parent dir-lease break (#470 C3 / smbtorture
-		// smb2.dirlease.rename_dst_parent, lease.c:7331). Even when the
-		// conflict surfaces SHARING_VIOLATION, the dst-parent's RH dir-lease
-		// holder must observe an RH→R break: the rename's implicit destructive
-		// open intent invalidates the holder's Handle caching regardless of
-		// whether the rename ultimately succeeds. Parent-key suppression
-		// applies (the renamer's RqLs ParentLeaseKey, if any, marks the holder
-		// as the renamer itself). On Phase-2 of the test, the holder's break
-		// handler closes its handle inside our wait, the post-break conflict
-		// recheck observes the close, and the rename proceeds.
+		// Conflict-gated dst-parent dir-lease pre-break (#470 C3 / smbtorture
+		// smb2.dirlease.rename_dst_parent, lease.c:7331): when an existing
+		// holder on dst-parent denies the implicit destructive open with
+		// SHARING_VIOLATION, the dst-parent's RH dir-lease holder must observe
+		// an RH→R strip-Handle break first, so its handler can close the
+		// conflicting open and let the rename proceed on the smbtorture
+		// phase-2 retry.
 		//
-		// Skip when toDir == srcParent (same-directory rename): the
-		// post-rename content-change break on srcParent already emits a
-		// single LEASE_BREAK to None for that dir-lease holder. Running
-		// the pre-break here would emit a separate strip-H notification
-		// FIRST, producing two break events instead of the single break
-		// the smbtorture rename samedir-* / hardlink samedir-* cases expect
-		// (Samba's contend_dirleases emits exactly one break-to-None).
-		if !bytes.Equal(toDir, openFile.ParentHandle) {
+		// On a clean rename (no conflict), Skip the strip-H pre-break — the
+		// post-rename content-change break on dst-parent (single LEASE_BREAK
+		// to None per Samba `contend_dirleases`) already invalidates the
+		// holder's caching, and dispatching strip-H FIRST would emit two
+		// separate notifications where smbtorture rename otherdir-*
+		// (.expect_dstdir_break=true) expects exactly one RH→"".
+		conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir)
+		if conflict && !bytes.Equal(toDir, openFile.ParentHandle) {
 			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
 		}
-		if conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir); conflict {
+		if conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
 				"path", openFile.Path,
 				"toDir", fmt.Sprintf("%x", toDir),

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -804,19 +804,28 @@ func (h *Handler) setFileInfoFromStore(
 		// smb2.dirlease.rename_dst_parent, lease.c:7331): when an existing
 		// holder on dst-parent denies the implicit destructive open with
 		// SHARING_VIOLATION, the dst-parent's RH dir-lease holder must observe
-		// an RH→R strip-Handle break first, so its handler can close the
-		// conflicting open and let the rename proceed on the smbtorture
-		// phase-2 retry.
+		// an RH→R strip-Handle break first; the break may give the holder a
+		// chance to close its conflicting handle. After the break drains we
+		// re-check share-mode — on phase-2 of the test the holder's handler
+		// closes its handle inside our wait so the recheck observes the
+		// shrunk open table and the rename proceeds.
 		//
-		// On a clean rename (no conflict), Skip the strip-H pre-break — the
-		// post-rename content-change break on dst-parent (single LEASE_BREAK
-		// to None per Samba `contend_dirleases`) already invalidates the
-		// holder's caching, and dispatching strip-H FIRST would emit two
-		// separate notifications where smbtorture rename otherdir-*
-		// (.expect_dstdir_break=true) expects exactly one RH→"".
+		// On a clean rename (no conflict to start with), Skip the strip-H
+		// pre-break — the post-rename content-change break on dst-parent
+		// (single LEASE_BREAK to None per Samba `contend_dirleases`) already
+		// invalidates the holder's caching, and dispatching strip-H FIRST
+		// would emit two separate notifications where smbtorture rename
+		// otherdir-* (.expect_dstdir_break=true) expects exactly one RH→"".
 		conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir)
 		if conflict && !bytes.Equal(toDir, openFile.ParentHandle) {
 			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
+			// Re-check after the strip-H break drained (the holder's break
+			// handler may have closed its conflicting open). If the
+			// re-check is clean the rename can proceed without surfacing
+			// SHARING_VIOLATION — required by dirlease.rename_dst_parent
+			// phase-2 (lease.c:7361 expects NT_STATUS_OK after the holder
+			// upgrades the lease and the second setinfo runs).
+			conflict = h.checkParentDirRenameConflict(openFile.FileID, toDir)
 		}
 		if conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",

--- a/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
+++ b/internal/adapter/smb/v2/handlers/set_info_ads_attrs_test.go
@@ -127,7 +127,7 @@ func TestSetInfo_ADS_PropagatesDosBitsToBase(t *testing.T) {
 	buf := make([]byte, 40)
 	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
 
-	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, streamOpen, types.FileBasicInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
 	}
@@ -155,7 +155,7 @@ func TestSetInfo_ADS_PreservesBasePOSIXMode(t *testing.T) {
 	buf := make([]byte, 40)
 	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
 
-	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, streamOpen, types.FileBasicInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
 	}
@@ -208,7 +208,7 @@ func TestSetInfo_ADS_PreservesBaseCompressedBitWithExistingDosBits(t *testing.T)
 	buf := make([]byte, 40)
 	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
 
-	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, streamOpen, types.FileBasicInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
 	}
@@ -249,7 +249,7 @@ func TestSetInfo_ADS_TimestampOnlyDoesNotPropagateAttrs(t *testing.T) {
 	// SET_INFO with all-zero FILETIME and FileAttributes=0 — a no-op call.
 	buf := make([]byte, 40)
 
-	resp, err := h.setFileInfoFromStore(authCtx, streamOpen, types.FileBasicInformation, buf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, streamOpen, types.FileBasicInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore on stream: err=%v status=%v", err, resp)
 	}

--- a/internal/adapter/smb/v2/handlers/timestamps_test.go
+++ b/internal/adapter/smb/v2/handlers/timestamps_test.go
@@ -117,7 +117,7 @@ func TestSetFileInfo_FreezeThaw(t *testing.T) {
 	// Step 3: SET_INFO with NTTIME_FREEZE (-1) for create_time + write_time.
 	// Atime/Ctime are 0 (omit). FileAttributes 0.
 	freezeBuf := makeBasicInfoBuffer(filetimeFreeze, 0, filetimeFreeze, 0, 0)
-	resp, err := h.setFileInfoFromStore(authCtx, openFile, types.FileBasicInformation, freezeBuf)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, openFile, types.FileBasicInformation, freezeBuf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore(FREEZE): err=%v status=%v", err, resp)
 	}
@@ -136,7 +136,7 @@ func TestSetFileInfo_FreezeThaw(t *testing.T) {
 
 	// Step 5: SET_INFO with NTTIME_THAW (-2) for create_time + write_time.
 	thawBuf := makeBasicInfoBuffer(filetimeUnfreeze, 0, filetimeUnfreeze, 0, 0)
-	resp, err = h.setFileInfoFromStore(authCtx, openFile, types.FileBasicInformation, thawBuf)
+	resp, err = h.setFileInfoFromStore(nil, authCtx, openFile, types.FileBasicInformation, thawBuf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore(THAW): err=%v status=%v", err, resp)
 	}
@@ -172,7 +172,7 @@ func TestSetFileInfo_FreezeThaw_AllFields(t *testing.T) {
 	}
 
 	thawAll := makeBasicInfoBuffer(filetimeUnfreeze, filetimeUnfreeze, filetimeUnfreeze, filetimeUnfreeze, 0)
-	resp, err := h.setFileInfoFromStore(authCtx, openFile, types.FileBasicInformation, thawAll)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, openFile, types.FileBasicInformation, thawAll)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore: err=%v status=%v", err, resp)
 	}
@@ -441,7 +441,7 @@ func TestSetFileInfo_DelayedWriteVsSetbasic(t *testing.T) {
 			}
 			preMtime := pre.Mtime
 
-			resp, err := h.setFileInfoFromStore(authCtx, openFile, types.FileBasicInformation, tc.buf)
+			resp, err := h.setFileInfoFromStore(nil, authCtx, openFile, types.FileBasicInformation, tc.buf)
 			if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 				t.Fatalf("setFileInfoFromStore: err=%v status=%v", err, resp)
 			}
@@ -526,7 +526,7 @@ func TestDirFreezeTimestamps_ChildCreate_AllFrozen(t *testing.T) {
 
 	// Step 3: Freeze all four timestamps via SET_INFO(-1).
 	freezeAll := makeBasicInfoBuffer(filetimeFreeze, filetimeFreeze, filetimeFreeze, filetimeFreeze, 0)
-	resp, err := h.setFileInfoFromStore(authCtx, dirOpenFile, types.FileBasicInformation, freezeAll)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, dirOpenFile, types.FileBasicInformation, freezeAll)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("freeze SET_INFO: err=%v status=%v", err, resp)
 	}
@@ -670,7 +670,7 @@ func TestDirFreezeTimestamps_ChildCreate_WalkPath(t *testing.T) {
 	h.StoreOpenFile(dirOpenFile)
 
 	freezeAll := makeBasicInfoBuffer(filetimeFreeze, filetimeFreeze, filetimeFreeze, filetimeFreeze, 0)
-	resp, err := h.setFileInfoFromStore(authCtx, dirOpenFile, types.FileBasicInformation, freezeAll)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, dirOpenFile, types.FileBasicInformation, freezeAll)
 	if err != nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("freeze: err=%v status=%v", err, resp)
 	}
@@ -828,7 +828,7 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 			h.StoreOpenFile(dirOpenFile)
 
 			// Freeze only the target timestamp.
-			resp, sErr := h.setFileInfoFromStore(authCtx, dirOpenFile, types.FileBasicInformation, tc.freezeBuf)
+			resp, sErr := h.setFileInfoFromStore(nil, authCtx, dirOpenFile, types.FileBasicInformation, tc.freezeBuf)
 			if sErr != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 				t.Fatalf("freeze SET_INFO: err=%v status=%v", sErr, resp)
 			}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1112,10 +1112,33 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 		remaining = append(remaining, lock)
 	}
 
+	// Track whether we removed any lease that was in the Breaking state so
+	// we can wake WaitForBreakCompletion waiters before they hit the 5s
+	// timeout. The releaseLeaseForHandle path is the no-ack way to complete
+	// a break (holder closes its conflicting handle in response to the
+	// break notification instead of sending LEASE_BREAK_ACK), and the
+	// waiting party (typically a parent-dir Handle-break wait set up by
+	// SET_INFO rename / hardlink) cannot make progress until either the
+	// signal fires or the deadline expires. Required by smbtorture
+	// smb2.dirlease.rename_dst_parent phase-2 where the holder's break
+	// handler issues SMB2_CLOSE and the rename's recheck must observe the
+	// shrunk open table promptly.
+	hadBreaking := false
+	for _, lock := range locks {
+		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey && lock.Lease.Breaking {
+			hadBreaking = true
+			break
+		}
+	}
+
 	if len(remaining) == 0 {
 		delete(lm.unifiedLocks, handleKey)
 	} else {
 		lm.unifiedLocks[handleKey] = remaining
+	}
+
+	if hadBreaking {
+		lm.signalBreakWaitLocked(handleKey)
 	}
 
 	if len(deleteErrs) > 0 {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1112,20 +1112,26 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 		remaining = append(remaining, lock)
 	}
 
-	// Track whether we removed any lease that was in the Breaking state so
-	// we can wake WaitForBreakCompletion waiters before they hit the 5s
-	// timeout. The releaseLeaseForHandle path is the no-ack way to complete
-	// a break (holder closes its conflicting handle in response to the
-	// break notification instead of sending LEASE_BREAK_ACK), and the
-	// waiting party (typically a parent-dir Handle-break wait set up by
+	// Track whether we removed any DIRECTORY lease that was in the Breaking
+	// state so we can wake WaitForBreakCompletion waiters before they hit
+	// the 5s timeout. The releaseLeaseForHandle path is the no-ack way to
+	// complete a break (the holder closes its conflicting handle in
+	// response to the break notification instead of sending LEASE_BREAK_ACK),
+	// and the waiting party (a parent-dir Handle-break wait set up by
 	// SET_INFO rename / hardlink) cannot make progress until either the
 	// signal fires or the deadline expires. Required by smbtorture
-	// smb2.dirlease.rename_dst_parent phase-2 where the holder's break
-	// handler issues SMB2_CLOSE and the rename's recheck must observe the
-	// shrunk open table promptly.
+	// smb2.dirlease.rename_dst_parent phase-2.
+	//
+	// Scoped to directory leases on purpose: file-lease parks waiting on
+	// breakWaitChans rely on the "release without signal" semantics so a
+	// holder that closes (instead of ACKing) does NOT prematurely wake a
+	// parked file CREATE — required by smb2.kernel-oplocks.kernel_oplocks7
+	// where tree2's parked CREATE must stay parked until the 5s timeout so
+	// tree1's re-open arrives first and sees an empty open table.
 	hadBreaking := false
 	for _, lock := range locks {
-		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey && lock.Lease.Breaking {
+		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey &&
+			lock.Lease.Breaking && lock.Lease.IsDirectory {
 			hadBreaking = true
 			break
 		}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -250,6 +250,14 @@ type LockManager interface {
 	// Zero exceptKey means "match any".
 	AnyHolderHasLeaseBits(handleKey string, exceptKey [16]byte, mask uint32) bool
 
+	// SignalParkedCreates wakes any parked CREATE waiter on handleKey so it
+	// re-evaluates its post-break gate. Used by the SMB CLOSE path after the
+	// open-file table entry has been removed: a parked CREATE that was
+	// waiting on a share-mode conflict with the closing holder must re-check
+	// share-mode against the now-shrunk table. Idempotent — safe to call
+	// even when no waiter exists.
+	SignalParkedCreates(handleKey string)
+
 	// ========================================================================
 	// Break Callbacks
 	// ========================================================================
@@ -1810,6 +1818,13 @@ func (lm *Manager) signalBreakWait(handleKey string) {
 	lm.mu.Lock()
 	lm.signalBreakWaitLocked(handleKey)
 	lm.mu.Unlock()
+}
+
+// SignalParkedCreates is the LockManager-interface entry point for
+// signalBreakWait, exposed so the SMB CLOSE path can wake a parked CREATE
+// waiter after the open-file table entry has been removed. See interface doc.
+func (lm *Manager) SignalParkedCreates(handleKey string) {
+	lm.signalBreakWait(handleKey)
 }
 
 // signalBreakWaitLocked is the lock-held variant of signalBreakWait.


### PR DESCRIPTION
## Summary

Three coupled fixes for the 6 `smb2.dirlease.*` residuals listed in #743.

- **Initial DOC no longer blocks subsequent opens.** Separates the per-handle `InitialDeleteOnClose` flag (CREATE with `FILE_DELETE_ON_CLOSE`) from the shared committed `DeletePending` (Samba `initial_delete_on_close` vs `set_delete_on_close_lck`). Initial DOC is promoted to shared committed DOC at CLOSE time on the last handle, mirroring `close_normal_file`. Subsequent CREATEs see only the committed flag — a second open on a file with initial DOC now succeeds. Required by `unlink_{same,different}_initial_and_close`.
- **Parent dir lease breaks fire fire-and-forget on content-change paths** (SET_INFO rename / hardlink / disposition, CLOSE-on-delete) — mirrors Samba `contend_dirleases` → `send_break_to_none`. The triggering request returns as soon as the notification is queued; the holder acks on its own schedule. Previously the inline ACK wait force-completed the lease on timeout, so a deferred manual replay (lease_skip_ack=true) surfaced `STATUS_UNSUCCESSFUL`. Fixes the break/ack-ordering failure in `rename`, `hardlink`, and `unlink_different_set_and_close`.
- **Directory CREATEs that share-mode-conflict with an existing dir-lease holder now park on STATUS_PENDING and resume after the holder closes.** New `SignalParkedCreates` LockManager method, called by the CLOSE path after the open-file table entry has been removed, wakes the parked CREATE so its share-mode recheck sees the now-shrunk table. Fixes `v2_request` second-attempt step.

## Test plan

- [ ] CI: `go test -race ./...` clean
- [ ] CI: golangci-lint clean
- [ ] CI smbtorture: 6 `smb2.dirlease.*` listed in #743 flip to PASS
  - hardlink
  - rename
  - unlink_different_initial_and_close
  - unlink_different_set_and_close
  - unlink_same_initial_and_close
  - v2_request
- [ ] No regressions in the already-passing dirlease tests (`seteof`, `setdos`, `set{atime,btime,ctime,mtime}`, `unlink_same_set_and_close`, etc.)
- [ ] No regressions in other smbtorture suites (lease, oplock, durable-open)

Closes #743