### PR TITLE
docs(blockstore/engine): deprecate HealthCheck in favour of Healthcheck

### DIFF
--- a/pkg/blockstore/engine/health.go
+++ b/pkg/blockstore/engine/health.go
@@ -11,9 +11,10 @@ import (
 // HealthCheck verifies the store is operational by checking the syncer health
 // (which in turn checks the remote store).
 //
-// Legacy error-returning probe. New callers should prefer Healthcheck
-// (lowercase 'c') which returns a structured [health.Report] derived
-// from both the local and remote stores and satisfies [health.Checker].
+// Deprecated: use [BlockStore.Healthcheck] (lowercase 'c'), which returns a
+// structured [health.Report] derived from both the local and remote stores
+// and satisfies [health.Checker]. This method only collapses the structured
+// state into a single error and is retained for backward compatibility.
 func (bs *BlockStore) HealthCheck(ctx context.Context) error {
 	return bs.syncer.HealthCheck(ctx)
 }


### PR DESCRIPTION
## Summary

REVIEW.md §8 Wave B-G **N-04**. Add a `// Deprecated:` godoc tag to `BlockStore.HealthCheck(ctx) error` directing callers to the structured `BlockStore.Healthcheck` (lowercase `c`) surface that returns a `health.Report`. Behaviour unchanged; staticcheck SA1019 will surface call sites for organic migration.

The prompt suggested `HealthMonitor.State`/`Subscribe`, but those do not exist on `*engine.HealthMonitor` (it exposes `IsHealthy()`/`OutageDuration()`/`SetTransitionCallback()`). The real structured replacement is `BlockStore.Healthcheck`, which the prior godoc already mentioned and which production code (`internal/controlplane/api/handlers/block_stores.go`, `pkg/controlplane/runtime/shares/healthcheck.go`) already uses.

No production call sites of the capital-C `BlockStore.HealthCheck` outside tests, so SA1019 noise will be limited to legacy test helpers, which is the intent.

## Test plan

- [x] `gofmt -s -w .`
- [x] `go vet ./pkg/blockstore/engine/...`
- [x] `golangci-lint run --timeout=5m ./pkg/blockstore/engine/...` (0 issues)
- [x] `go build ./...`
- [x] `go doc ./pkg/blockstore/engine BlockStore.HealthCheck` renders the Deprecated section.