### PR TITLE
refactor(blockstore/engine): rename Config to BlockStoreConfig

### DIFF
--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -292,7 +292,7 @@ func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatam
 
 	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
 
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
 		Syncer:          syncer,

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -42,7 +42,7 @@ func newTestEngine(t *testing.T) *engine.BlockStore {
 
 	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
 
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
 		Syncer:          syncer,

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -84,7 +84,7 @@ func NewHandlerFixture(t *testing.T) *HandlerTestFixture {
 	t.Cleanup(func() { _ = localStore.Close() })
 	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
 
-	blockSvc, err := engine.New(engine.Config{
+	blockSvc, err := engine.New(engine.BlockStoreConfig{
 		Local:  localStore,
 		Syncer: syncer,
 	})

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -48,7 +48,7 @@ func newIOTestFixture(t *testing.T, shareName string) *ioTestFixture {
 	t.Cleanup(func() { _ = localStore.Close() })
 	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
 
-	blockSvc, err := engine.New(engine.Config{
+	blockSvc, err := engine.New(engine.BlockStoreConfig{
 		Local:  localStore,
 		Syncer: syncer,
 	})

--- a/internal/bench/phase19_test.go
+++ b/internal/bench/phase19_test.go
@@ -175,7 +175,7 @@ func newPhase19BlockStore(t *testing.T) *engine.BlockStore {
 	localStore := memory.New()
 	fbs := newAggregateStubFileBlockStore()
 	syncer := engine.NewSyncer(localStore, nil, fbs, engine.DefaultConfig())
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
 		Syncer:         syncer,

--- a/pkg/blockstore/engine/cache_populated_on_rollup_test.go
+++ b/pkg/blockstore/engine/cache_populated_on_rollup_test.go
@@ -53,7 +53,7 @@ func newRollupCacheFixture(t *testing.T) (*BlockStore, *fs.FSStore, *recordingPu
 	}
 
 	syncer := NewSyncer(localStore, nil, ms, DefaultConfig())
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Syncer:          syncer,
 		FileBlockStore:  ms,

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -15,8 +15,8 @@ import (
 // Compile-time interface satisfaction check.
 var _ blockstore.Store = (*BlockStore)(nil)
 
-// Config holds the components that make up a BlockStore.
-type Config struct {
+// BlockStoreConfig holds the components that make up a BlockStore.
+type BlockStoreConfig struct {
 	// Local is the on-node block store (required).
 	Local local.LocalStore
 
@@ -103,7 +103,7 @@ type BlockStore struct {
 
 // New creates a new BlockStore from the given configuration.
 // Local store and syncer are required; remote may be nil for local-only mode.
-func New(cfg Config) (*BlockStore, error) {
+func New(cfg BlockStoreConfig) (*BlockStore, error) {
 	if cfg.Local == nil {
 		return nil, errors.New("local store is required")
 	}

--- a/pkg/blockstore/engine/engine_delete_test.go
+++ b/pkg/blockstore/engine/engine_delete_test.go
@@ -152,7 +152,7 @@ func buildCascadeFixture(t *testing.T, coord MetadataCoordinator, syncedStore me
 	fbs := newStubFileBlockStore()
 	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
 		Syncer:          syncer,

--- a/pkg/blockstore/engine/engine_health_test.go
+++ b/pkg/blockstore/engine/engine_health_test.go
@@ -94,7 +94,7 @@ func newHealthTestEngine(t *testing.T) (*BlockStore, *fakeRemoteStore) {
 
 	syncer := NewSyncer(localStore, fakeRemote, ms, syncCfg)
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          fakeRemote,
 		Syncer:          syncer,

--- a/pkg/blockstore/engine/engine_offline_test.go
+++ b/pkg/blockstore/engine/engine_offline_test.go
@@ -189,7 +189,7 @@ func TestPrefetchSuppressedWhenUnhealthy(t *testing.T) {
 
 	syncer := NewSyncer(localStore, fakeRemote, ms, syncCfg)
 
-	bsEngine, err := New(Config{
+	bsEngine, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          fakeRemote,
 		Syncer:          syncer,

--- a/pkg/blockstore/engine/engine_test.go
+++ b/pkg/blockstore/engine/engine_test.go
@@ -112,7 +112,7 @@ func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *Bl
 	fbs := newStubFileBlockStore()
 	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
 		Syncer:          syncer,
@@ -140,7 +140,7 @@ func newTestEngineWithCoordinator(t *testing.T, c MetadataCoordinator) *BlockSto
 	fbs := newStubFileBlockStore()
 	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
 		Syncer:         syncer,
@@ -355,7 +355,7 @@ func TestClose_ClosesCache(t *testing.T) {
 	fbs := newStubFileBlockStore()
 	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:  localStore,
 		Remote: nil,
 		Syncer: syncer,

--- a/pkg/blockstore/engine/loadbyhash_test.go
+++ b/pkg/blockstore/engine/loadbyhash_test.go
@@ -23,7 +23,7 @@ func newLoadByHashFixture(t *testing.T) (*BlockStore, *fs.FSStore) {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	syncer := NewSyncer(localStore, nil, ms, DefaultConfig())
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:          localStore,
 		Syncer:         syncer,
 		FileBlockStore: ms,

--- a/pkg/blockstore/engine/onchunkcomplete_test.go
+++ b/pkg/blockstore/engine/onchunkcomplete_test.go
@@ -24,7 +24,7 @@ func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*BlockStore
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	syncer := NewSyncer(localStore, nil, ms, DefaultConfig())
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Syncer:          syncer,
 		FileBlockStore:  ms,

--- a/pkg/blockstore/engine/perf_bench_phase12_test.go
+++ b/pkg/blockstore/engine/perf_bench_phase12_test.go
@@ -138,7 +138,7 @@ func newPerfTestEngine(tb testing.TB, readBufferBytes int64, prefetchWorkers int
 	fbs := newStubFileBlockStore()
 	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
 
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
 		Syncer:          syncer,

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -398,7 +398,7 @@ func newIntegrationFixture(t *testing.T, rs remote.RemoteStore, synced metadata.
 
 	syncer := engine.NewSyncer(local, rs, fbs, engine.DefaultConfig())
 
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           local,
 		Remote:          rs,
 		Syncer:          syncer,
@@ -797,7 +797,7 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 		coord := newCascadeCoordinator()
 
 		syncer := engine.NewSyncer(local, rs, fbs, engine.DefaultConfig())
-		bs, err := engine.New(engine.Config{
+		bs, err := engine.New(engine.BlockStoreConfig{
 			Local:           local,
 			Remote:          rs,
 			Syncer:          syncer,

--- a/pkg/controlplane/runtime/runtime_test.go
+++ b/pkg/controlplane/runtime/runtime_test.go
@@ -561,7 +561,7 @@ func TestGetBlockStoreForHandle(t *testing.T) {
 	localStore := localmemory.New()
 	localStore.Start(context.Background())
 	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:  localStore,
 		Syncer: syncer,
 	})

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -563,7 +563,7 @@ func (s *Service) createBlockStoreForShare(
 		coordinator = newMetadataCoordinator(metadataStore)
 	}
 
-	engineCfg := engine.Config{
+	engineCfg := engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         engineRemote,
 		Syncer:         syncer,

--- a/pkg/controlplane/runtime/snapshot_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_integration_test.go
@@ -486,7 +486,7 @@ func newOrchestrationFixture(t *testing.T) *orchestrationFixture {
 		ParallelUploads:   1,
 		ParallelDownloads: 1,
 	})
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         wrappedRemote,
 		Syncer:         syncer,

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -563,7 +563,7 @@ func newRestoreFixture(t *testing.T, opts restoreFixtureOpts) *restoreFixture {
 		ParallelUploads:   1,
 		ParallelDownloads: 1,
 	})
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         wrappedRemote,
 		Syncer:         syncer,


### PR DESCRIPTION
## Summary

REVIEW.md Wave B-G **N-01**. Bare \`engine.Config\` is hard to grep against the dozen other \`Config\` types in the repo. Rename to \`engine.BlockStoreConfig\`.

## Changes

- Type \`engine.Config\` → \`engine.BlockStoreConfig\`.
- All callsites updated (1 prod + 18 tests across pkg/blockstore, internal/adapter, pkg/controlplane).
- Godoc references updated.
- Pure rename, no behaviour change.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/blockstore/... ./internal/adapter/...\`
- [x] \`go test -race ./pkg/blockstore/engine/...\`
- [x] \`gofmt -s -w . && go vet ./... && golangci-lint run --timeout=5m\`