### PR TITLE
refactor(blockstore/engine): rename BlockStore to Store

### DIFF
--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -40,7 +40,7 @@ import (
 // same txn through the coordinator's per-impl mechanism.
 func CopyPayload(
 	ctx context.Context,
-	blockStore *engine.BlockStore,
+	blockStore *engine.Store,
 	metadataStore metadata.MetadataStore,
 	cache CacheInvalidator,
 	srcFileHandle, dstFileHandle metadata.FileHandle,

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -281,7 +281,7 @@ func TestCopyPayload_NilCacheTolerated(t *testing.T) {
 // newCopyTestEngineWithMS constructs an engine wired against a caller-
 // supplied MemoryMetadataStore so the test can both seed files and observe
 // post-txn state via the same store.
-func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatamemory.MemoryMetadataStore) *engine.BlockStore {
+func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatamemory.MemoryMetadataStore) *engine.Store {
 	t.Helper()
 
 	tmpDir := t.TempDir()

--- a/internal/adapter/common/doc.go
+++ b/internal/adapter/common/doc.go
@@ -33,7 +33,7 @@
 //
 // The helpers ReadFromBlockStore, WriteToBlockStore, and CommitBlockStore are
 // the canonical fan-in points for []BlockRef plumbing. The engine wires
-// engine.BlockStore.ReadAt / WriteAt with `[]BlockRef` parameter on ReadAt
+// engine.Store.ReadAt / WriteAt with `[]BlockRef` parameter on ReadAt
 // and `[]BlockRef` returned from WriteAt, plus a post-transaction
 // CacheInvalidator interface and the CopyPayload helper.
 //

--- a/internal/adapter/common/read_payload.go
+++ b/internal/adapter/common/read_payload.go
@@ -42,13 +42,13 @@ func (r *BlockReadResult) Release() {
 // (clientIP, handle bytes) are logged at the call site, not here, because
 // they are protocol-specific and common/ cannot couple to those types.
 //
-// When FileAttr.Blocks becomes []BlockRef and engine.BlockStore.ReadAt
+// When FileAttr.Blocks becomes []BlockRef and engine.Store.ReadAt
 // takes []BlockRef, this function body gains the "fetch FileAttr.Blocks →
 // slice to [offset, offset+len) → pass resolved refs" logic. Call-site
 // code (protocol handlers) does not change.
 func ReadFromBlockStore(
 	ctx context.Context,
-	blockStore *engine.BlockStore,
+	blockStore *engine.Store,
 	payloadID metadata.PayloadID,
 	offset uint64,
 	count uint32,

--- a/internal/adapter/common/resolve.go
+++ b/internal/adapter/common/resolve.go
@@ -13,7 +13,7 @@ import (
 // Declared here (not in runtime) so common/ does not import runtime
 // and stays testable with trivial mocks.
 type BlockStoreRegistry interface {
-	GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.BlockStore, error)
+	GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.Store, error)
 }
 
 // ResolveForRead returns the per-share BlockStore for the given handle.
@@ -21,7 +21,7 @@ type BlockStoreRegistry interface {
 // (CLAUDE.md invariant 3); this helper never inspects the handle bytes.
 // A nil registry produces a typed error rather than a panic so mis-wired
 // handler tests fail with a readable message.
-func ResolveForRead(ctx context.Context, reg BlockStoreRegistry, handle metadata.FileHandle) (*engine.BlockStore, error) {
+func ResolveForRead(ctx context.Context, reg BlockStoreRegistry, handle metadata.FileHandle) (*engine.Store, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("common.ResolveForRead: nil BlockStoreRegistry")
 	}
@@ -32,7 +32,7 @@ func ResolveForRead(ctx context.Context, reg BlockStoreRegistry, handle metadata
 // identical today; kept as a separate named helper so the call-site seam
 // is already in place for when the signatures diverge to take
 // []BlockRef. One edit later, not two.
-func ResolveForWrite(ctx context.Context, reg BlockStoreRegistry, handle metadata.FileHandle) (*engine.BlockStore, error) {
+func ResolveForWrite(ctx context.Context, reg BlockStoreRegistry, handle metadata.FileHandle) (*engine.Store, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("common.ResolveForWrite: nil BlockStoreRegistry")
 	}

--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -15,7 +15,7 @@ import (
 // handler (NFSv3, NFSv4, SMB v2) calls this function and therefore stays
 // unchanged.
 //
-// Returns error only — mirrors engine.BlockStore.WriteAt. The engine contract
+// Returns error only — mirrors engine.Store.WriteAt. The engine contract
 // guarantees that a nil error means the full `data` slice was persisted at
 // `offset`; partial writes surface as an error.
 //
@@ -31,7 +31,7 @@ import (
 // layer), and common/ never retains a reference past the engine.WriteAt call.
 func WriteToBlockStore(
 	ctx context.Context,
-	blockStore *engine.BlockStore,
+	blockStore *engine.Store,
 	payloadID metadata.PayloadID,
 	data []byte,
 	offset uint64,
@@ -55,7 +55,7 @@ func WriteToBlockStore(
 // needed, widen the signature then.
 func CommitBlockStore(
 	ctx context.Context,
-	blockStore *engine.BlockStore,
+	blockStore *engine.Store,
 	payloadID metadata.PayloadID,
 ) error {
 	_, err := blockStore.Flush(ctx, string(payloadID))

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -11,9 +11,9 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newTestEngine constructs an engine.BlockStore backed by an on-disk
+// newTestEngine constructs an engine.Store backed by an on-disk
 // FSStore rooted at a temp dir, mirroring the engine package's test
-// helper. Used here instead of a mock because *engine.BlockStore is a
+// helper. Used here instead of a mock because *engine.Store is a
 // concrete struct and the helper under test takes it directly.
 //
 // The FSStore is constructed with an inline RollupStore +
@@ -21,7 +21,7 @@ import (
 // invoked so AppendWrite-staged bytes flow through the
 // rollup → CAS chunk → FileBlock-row pipeline that the engine's CAS
 // read path consumes.
-func newTestEngine(t *testing.T) *engine.BlockStore {
+func newTestEngine(t *testing.T) *engine.Store {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -65,7 +65,7 @@ func newTestEngine(t *testing.T) *engine.BlockStore {
 // the engine so AppendWrite-staged bytes land in the CAS chunk store +
 // FileBlock rows before the test reads them back. Mirrors the helper
 // used by the engine-package offline tests.
-func forceRollup(t *testing.T, bs *engine.BlockStore, payloadID string) {
+func forceRollup(t *testing.T, bs *engine.Store, payloadID string) {
 	t.Helper()
 	fsLocal, ok := bs.LocalForTest().(*fs.FSStore)
 	if !ok {

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -498,7 +498,7 @@ func createNewFile(
 //   - Updated file attributes and error
 func truncateExistingFile(
 	authCtx *metadata.AuthContext,
-	blockStore *engine.BlockStore,
+	blockStore *engine.Store,
 	metaSvc *metadata.MetadataService,
 	existingFile *metadata.File,
 	req *CreateRequest,

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -49,7 +49,7 @@ type HandlerTestFixture struct {
 	MetadataService *metadata.MetadataService
 
 	// BlockStore provides block storage for content operations.
-	BlockStore *engine.BlockStore
+	BlockStore *engine.Store
 
 	// ShareName is the name of the test share.
 	ShareName string

--- a/internal/adapter/nfs/v3/handlers/utils.go
+++ b/internal/adapter/nfs/v3/handlers/utils.go
@@ -30,7 +30,7 @@ var ErrMetadataServiceNotInitialized = errors.New("metadata service not initiali
 // getServicesForHandle returns both the metadata service and the per-share block store
 // resolved from the given file handle.
 // Returns an error if either service is not initialized or handle resolution fails.
-func getServicesForHandle(reg *runtime.Runtime, ctx context.Context, handle metadata.FileHandle) (*metadata.MetadataService, *engine.BlockStore, error) {
+func getServicesForHandle(reg *runtime.Runtime, ctx context.Context, handle metadata.FileHandle) (*metadata.MetadataService, *engine.Store, error) {
 	metaSvc := reg.GetMetadataService()
 	if metaSvc == nil {
 		return nil, nil, ErrMetadataServiceNotInitialized

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -26,7 +26,7 @@ import (
 type ioTestFixture struct {
 	handler    *Handler
 	metaSvc    *metadata.MetadataService
-	blockStore *engine.BlockStore
+	blockStore *engine.Store
 	store      metadata.MetadataStore
 	rootHandle metadata.FileHandle
 	shareName  string

--- a/internal/bench/phase19_test.go
+++ b/internal/bench/phase19_test.go
@@ -85,7 +85,7 @@ func TestPhase19_AggregateRandWriteGate_LeqOne(t *testing.T) {
 	}
 
 	// Run the canonical benchmark fixture on the WRITE side. The fixture
-	// seeds an engine.BlockStore with one phase19FixtureFileSize-byte
+	// seeds an engine.Store with one phase19FixtureFileSize-byte
 	// payload (warm cache already established by the seeding writes),
 	// then performs rand-write IOs at phase19RandSeed-driven offsets
 	// and measures ns/op.
@@ -167,10 +167,10 @@ func runPhase19RandWriteWarmCache(t *testing.T) float64 {
 	return float64(elapsed.Nanoseconds()) / float64(iterations)
 }
 
-// newPhase19BlockStore builds the in-tree microbench engine.BlockStore
+// newPhase19BlockStore builds the in-tree microbench engine.Store
 // for the aggregate gate. Memory metadata + memory local store match
 // the canonical perf-gate fixture shape.
-func newPhase19BlockStore(t *testing.T) *engine.BlockStore {
+func newPhase19BlockStore(t *testing.T) *engine.Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newAggregateStubFileBlockStore()

--- a/pkg/blockstore/engine/cache.go
+++ b/pkg/blockstore/engine/cache.go
@@ -65,8 +65,8 @@ var _ cacheInterface = nullCache{}
 // with cache hits/puts.
 //
 // Per-share isolation (CLAUDE.md rule 4): the Cache lives inside
-// *engine.BlockStore which is per-share by construction. Cross-share
-// cache sharing is impossible without going through the BlockStore
+// *engine.Store which is per-share by construction. Cross-share
+// cache sharing is impossible without going through the Store
 // boundary, so T-12-25 is "accept" by design.
 //
 // CACHE-02 cross-file dedup: two payloads referencing the same
@@ -135,7 +135,7 @@ type CacheStats struct {
 	MaxBytes int64 `json:"max_bytes"`
 }
 
-// nullCache is a no-op cacheInterface implementation. The BlockStore
+// nullCache is a no-op cacheInterface implementation. The Store
 // constructor substitutes nullCache{} when the cache budget is zero
 // eliminating defensive nil-checks across the engine (Null Object
 // pattern).

--- a/pkg/blockstore/engine/cache_populated_on_rollup_test.go
+++ b/pkg/blockstore/engine/cache_populated_on_rollup_test.go
@@ -27,7 +27,7 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newRollupCacheFixture builds a full engine.BlockStore + FSStore +
+// newRollupCacheFixture builds a full engine.Store + FSStore +
 // recordingPutCache stack so we can observe OnChunkComplete-driven
 // cache population end-to-end through engine.WriteAt → rollup →
 // StoreChunk → OnChunkComplete → Cache.Put.
@@ -35,7 +35,7 @@ import (
 // The recordingPutCache replaces the realCache AFTER bs.Start so the
 // engine.New wiring (closure-captures-bs, reads-bs.cache-at-fire-time
 // 07's setter pattern) lands every Put on the recorder.
-func newRollupCacheFixture(t *testing.T) (*BlockStore, *fs.FSStore, *recordingPutCache) {
+func newRollupCacheFixture(t *testing.T) (*Store, *fs.FSStore, *recordingPutCache) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
@@ -78,7 +78,7 @@ func newRollupCacheFixture(t *testing.T) (*BlockStore, *fs.FSStore, *recordingPu
 
 // waitForChunks polls ListFileBlocks until at least one row is present
 // or the deadline elapses. Returns the post-rollup blocks slice.
-func waitForChunks(t *testing.T, bs *BlockStore, payloadID string, timeout time.Duration) []*blockstore.FileBlock {
+func waitForChunks(t *testing.T, bs *Store, payloadID string, timeout time.Duration) []*blockstore.FileBlock {
 	t.Helper()
 	ctx := context.Background()
 	deadline := time.Now().Add(timeout)

--- a/pkg/blockstore/engine/coordinator.go
+++ b/pkg/blockstore/engine/coordinator.go
@@ -81,7 +81,7 @@ type MetadataCoordinator interface {
 }
 
 // ErrMetadataCoordinatorNotWired is returned when an engine method
-// requiring metadata coordination is invoked on a BlockStore that was
+// requiring metadata coordination is invoked on a Store that was
 // constructed with a nil coordinator. Production wiring (per-share
 // runtime service in pkg/controlplane/runtime/shares/) MUST inject a
 // real coordinator; unit tests tolerate nil for ReadAt-only fixtures

--- a/pkg/blockstore/engine/coordinator_test.go
+++ b/pkg/blockstore/engine/coordinator_test.go
@@ -159,7 +159,7 @@ func (f *fakeCoordinator) GetFileObjectID(_ context.Context, payloadID string) (
 // Compile-time assertion: fakeCoordinator satisfies MetadataCoordinator.
 var _ MetadataCoordinator = (*fakeCoordinator)(nil)
 
-// TestMetadataCoordinator_NilTolerated asserts that a *BlockStore can be
+// TestMetadataCoordinator_NilTolerated asserts that a *Store can be
 // constructed with coordinator=nil (test ergonomics — production wiring
 // always passes a real coordinator). The struct field exists and is
 // nil; the ErrMetadataCoordinatorNotWired sentinel is non-nil and
@@ -181,7 +181,7 @@ func TestMetadataCoordinator_NilTolerated(t *testing.T) {
 	}
 }
 
-// TestMetadataCoordinator_AcceptsFakeCoordinator asserts that a *BlockStore
+// TestMetadataCoordinator_AcceptsFakeCoordinator asserts that a *Store
 // can be constructed with a non-nil coordinator and that the field is
 // stored verbatim. Full integration assertions (the engine actually
 // invoking IncrementRefCount/DecrementRefCount/PersistFileBlocks during
@@ -191,10 +191,10 @@ func TestMetadataCoordinator_AcceptsFakeCoordinator(t *testing.T) {
 	bs := newTestEngineWithCoordinator(t, fc)
 
 	if bs.coordinator == nil {
-		t.Fatal("BlockStore.coordinator is nil after construction with non-nil fakeCoordinator")
+		t.Fatal("Store.coordinator is nil after construction with non-nil fakeCoordinator")
 	}
 	if bs.coordinator != MetadataCoordinator(fc) {
-		t.Fatal("BlockStore.coordinator does not equal injected fakeCoordinator")
+		t.Fatal("Store.coordinator does not equal injected fakeCoordinator")
 	}
 }
 

--- a/pkg/blockstore/engine/dedup.go
+++ b/pkg/blockstore/engine/dedup.go
@@ -99,7 +99,7 @@ func (m *Syncer) tryEagerSmallFileDedup(
 	// cache warming: populate engine Cache with the bytes we just
 	// hashed (we already have them in RAM). MISS case is handled by the
 	// regular rollup path's OnChunkComplete wiring. Reading
-	// through the BlockStore back-reference so post-construction
+	// through the Store back-reference so post-construction
 	// `bs.cache = rec` swaps (TestClose_ClosesCache pattern) are
 	// observed; bs.cache is never nil thanks to the Null Object pattern
 	// installed by engine.New.
@@ -365,7 +365,7 @@ func (m *Syncer) applyFileLevelDedupHit(
 	// 4. Cache invalidation for orphaned speculative chunks (step
 	// 5 /). Build the removed-hash list in BlockRef order
 	// (preserves multiplicity expectations of the surgical-invalidate
-	// contract). Read through the BlockStore back-reference so that
+	// contract). Read through the Store back-reference so that
 	// post-construction `bs.cache = rec` swaps (TestClose_ClosesCache
 	// pattern) are observed; bs.cache is never nil thanks to the Null
 	// Object pattern installed by engine.New.

--- a/pkg/blockstore/engine/dedup_test.go
+++ b/pkg/blockstore/engine/dedup_test.go
@@ -48,7 +48,7 @@ func dedupTestSetup(t *testing.T) (*Syncer, *fakeCoordinator) {
 	fc := newFakeCoordinator()
 	bs := newTestEngineWithCoordinator(t, fc)
 	if bs.syncer == nil {
-		t.Fatalf("BlockStore.syncer is nil after construction with fakeCoordinator")
+		t.Fatalf("Store.syncer is nil after construction with fakeCoordinator")
 	}
 	return bs.syncer, fc
 }
@@ -352,11 +352,11 @@ func TestDedup_CacheInvalidation(t *testing.T) {
 	_, fc := dedupTestSetup(t)
 
 	rec := &recordingCache{}
-	// BlockStore.cache is package-private; the helper exposed it earlier
+	// Store.cache is package-private; the helper exposed it earlier
 	// (see TestClose_ClosesCache pattern in engine_test.go). The Syncer
-	// cannot invalidate without the BlockStore reference; will
+	// cannot invalidate without the Store reference; will
 	// thread the call site appropriately. We attach the recorder via the
-	// *BlockStore that owns the syncer.
+	// *Store that owns the syncer.
 	bs := newTestEngineWithCoordinator(t, fc)
 	bs.cache = rec
 	m := bs.syncer

--- a/pkg/blockstore/engine/doc.go
+++ b/pkg/blockstore/engine/doc.go
@@ -1,4 +1,4 @@
-// Package engine provides the BlockStore orchestrator that composes local
+// Package engine provides the Store orchestrator that composes local
 // store, remote store, syncer, read buffer / prefetcher, and block garbage
 // collection into the blockstore.Store interface.
 //
@@ -21,7 +21,7 @@
 // mutations take WLock. Eviction is synchronous and inline during Put
 // (dropping a []byte reference is O(1), no I/O needed).
 //
-// Each per-share BlockStore gets its own ReadBuffer instance, ensuring one
+// Each per-share Store gets its own ReadBuffer instance, ensuring one
 // share's sequential scan cannot evict another share's working set. Setting
 // maxBytes to 0 disables the read buffer entirely (NewReadBuffer returns nil).
 //

--- a/pkg/blockstore/engine/eager_dedup_flush_test.go
+++ b/pkg/blockstore/engine/eager_dedup_flush_test.go
@@ -27,10 +27,10 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore/chunker"
 )
 
-// flushTestSetup wires a BlockStore + fakeCoordinator + recordingPutCache.
+// flushTestSetup wires a Store + fakeCoordinator + recordingPutCache.
 // Returns all three so tests can seed objectIDHits, write bytes via
 // WriteAt, drive Flush, and assert the eager/speculative call signals.
-func flushTestSetup(t *testing.T) (*BlockStore, *fakeCoordinator, *recordingPutCache) {
+func flushTestSetup(t *testing.T) (*Store, *fakeCoordinator, *recordingPutCache) {
 	t.Helper()
 	fc := newFakeCoordinator()
 	bs := newTestEngineWithCoordinator(t, fc)

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -13,9 +13,9 @@ import (
 )
 
 // Compile-time interface satisfaction check.
-var _ blockstore.Store = (*BlockStore)(nil)
+var _ blockstore.Store = (*Store)(nil)
 
-// BlockStoreConfig holds the components that make up a BlockStore.
+// BlockStoreConfig holds the components that make up a Store.
 type BlockStoreConfig struct {
 	// Local is the on-node block store (required).
 	Local local.LocalStore
@@ -58,15 +58,15 @@ type BlockStoreConfig struct {
 	PrefetchWorkers int
 }
 
-// BlockStore is the central orchestrator for block storage. It composes a local
+// Store is the central orchestrator for block storage. It composes a local
 // store, optional remote store, and syncer into the blockstore.Store
-// interface. All protocol adapters and runtime code use BlockStore for I/O.
+// interface. All protocol adapters and runtime code use Store for I/O.
 //
 // Read operations check the read buffer first, then the local store, falling
 // back to remote download via the syncer on miss. Write operations go
 // directly to the local store and invalidate the read buffer; the syncer
 // handles background upload to remote.
-type BlockStore struct {
+type Store struct {
 	local  local.LocalStore
 	remote remote.RemoteStore
 	syncer *Syncer
@@ -101,9 +101,9 @@ type BlockStore struct {
 	prefetchWorkers int   // stored from config, used in Start()
 }
 
-// New creates a new BlockStore from the given configuration.
+// New creates a new Store from the given configuration.
 // Local store and syncer are required; remote may be nil for local-only mode.
-func New(cfg BlockStoreConfig) (*BlockStore, error) {
+func New(cfg BlockStoreConfig) (*Store, error) {
 	if cfg.Local == nil {
 		return nil, errors.New("local store is required")
 	}
@@ -111,7 +111,7 @@ func New(cfg BlockStoreConfig) (*BlockStore, error) {
 		return nil, errors.New("syncer is required")
 	}
 
-	bs := &BlockStore{
+	bs := &Store{
 		local:           cfg.Local,
 		remote:          cfg.Remote,
 		syncer:          cfg.Syncer,
@@ -209,7 +209,7 @@ func New(cfg BlockStoreConfig) (*BlockStore, error) {
 		// side, so the NFS COMMIT-then-READ pattern never goes back to
 		// disk for the just-written chunk. The closure captures bs
 		// (not bs.cache) so the Null-Object→real-Cache swap performed
-		// by BlockStore.Start is observed transparently. The path arg
+		// by Store.Start is observed transparently. The path arg
 		// is intentionally discarded (`_ string`) — Cache.Put doesn't
 		// consume it; the firing-site contract still passes it to
 		// enable future mmap-or-copy strategies. Cache.Put is
@@ -253,8 +253,8 @@ func New(cfg BlockStoreConfig) (*BlockStore, error) {
 			})
 		}
 	}
-	// wire the BlockStore back-reference onto the Syncer so
-	// the file-level dedup short-circuit can reach BlockStore.cache for
+	// wire the Store back-reference onto the Syncer so
+	// the file-level dedup short-circuit can reach Store.cache for
 	// surgical invalidation of orphaned speculative chunks. Reading
 	// through the back-reference (instead of caching a cacheInterface
 	// field on the Syncer at construction time) lets test code swap
@@ -268,14 +268,14 @@ func New(cfg BlockStoreConfig) (*BlockStore, error) {
 // Recovery runs on the local store first (if supported), then the syncer
 // and local store background goroutines are started. Finally, the prefetcher
 // is created if both the read buffer and prefetch workers are configured.
-func (bs *BlockStore) Start(ctx context.Context) error {
+func (bs *Store) Start(ctx context.Context) error {
 	// Run recovery on local store if it supports it (FSStore has Recover).
 	type recoverer interface {
 		Recover(ctx context.Context) error
 	}
 	if r, ok := bs.local.(recoverer); ok {
 		if err := r.Recover(ctx); err != nil {
-			logger.Warn("BlockStore: local store recovery encountered errors", "error", err)
+			logger.Warn("Store: local store recovery encountered errors", "error", err)
 		}
 	}
 
@@ -303,7 +303,7 @@ func (bs *BlockStore) Start(ctx context.Context) error {
 	// the legacy ReadBuffer + Prefetcher pair. readBufferBytes is read
 	// out of cfg via a stash because cfg lives only inside New; we
 	// recover it from bs's own state. Engine constructor stashes the
-	// budget on the BlockStore so Start can read it; if the budget is
+	// budget on the Store so Start can read it; if the budget is
 	// 0 we keep the Null Object.
 	if bs.readBufferBytes > 0 {
 		realCache := NewCache(bs.readBufferBytes, bs.prefetchWorkers, bs.loadByHash)
@@ -329,14 +329,14 @@ func (bs *BlockStore) Start(ctx context.Context) error {
 // best-effort and shouldn't block on a remote round-trip; if the
 // block isn't local, the next on-path read will pull it via the
 // syncer.
-func (bs *BlockStore) loadByHash(ctx context.Context, hash blockstore.ContentHash) ([]byte, error) {
+func (bs *Store) loadByHash(ctx context.Context, hash blockstore.ContentHash) ([]byte, error) {
 	return bs.local.Get(ctx, hash)
 }
 
 // Close releases resources held by the store. Closes the cache (stops
 // prefetch workers and drops entries), then syncer (drains uploads)
 // local store, and remote store.
-func (bs *BlockStore) Close() error {
+func (bs *Store) Close() error {
 	// Cache is never nil thanks to the Null Object pattern.
 	_ = bs.cache.Close()
 
@@ -363,27 +363,27 @@ func (bs *BlockStore) Close() error {
 // (e.g. internal/adapter/common) that need to drive rollup or other
 // admin paths against the concrete *fs.FSStore via a type assertion.
 // Do not use in production code.
-func (bs *BlockStore) LocalForTest() local.LocalStore { return bs.local }
+func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 
 // RemoteForTesting returns the remote store for cross-package test verification
 // (e.g., shared remote store identity). Do not use in production code.
-func (bs *BlockStore) RemoteForTesting() remote.RemoteStore { return bs.remote }
+func (bs *Store) RemoteForTesting() remote.RemoteStore { return bs.remote }
 
 // RemoteStore returns the per-share remote object store, or nil if the
 // share is local-only. Used by the snapshot sync-gate verify step
 // (Phase 23) to drive VerifyRemoteDurability after DrainAllUploads.
 // RemoteForTesting above remains as the documented test alias.
-func (bs *BlockStore) RemoteStore() remote.RemoteStore { return bs.remote }
+func (bs *Store) RemoteStore() remote.RemoteStore { return bs.remote }
 
 // ListFiles returns the payloadIDs of all files tracked in the local store.
-func (bs *BlockStore) ListFiles() []string { return bs.local.ListFiles() }
+func (bs *Store) ListFiles() []string { return bs.local.ListFiles() }
 
 // EvictLocal removes all local per-file state (memory tracking, files
 // map, accessTracker, append log) for a file. CAS chunks are NOT
 // removed here — they may be shared with other files via file-level
 // dedup and are reclaimed via the refcount → GC path (engine.Delete
 // decrements per dropped hash and the mark-sweep GC reaps orphans).
-func (bs *BlockStore) EvictLocal(ctx context.Context, payloadID string) error {
+func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
 	if err := bs.local.EvictMemory(ctx, payloadID); err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func (bs *BlockStore) EvictLocal(ctx context.Context, payloadID string) error {
 // no-op implementation. Intended for shutdown / share-removal teardown
 // and for the REST evict path that drops the read buffer wholesale.
 // Returns the number of entries that were present before destruction.
-func (bs *BlockStore) DestroyCache() int {
+func (bs *Store) DestroyCache() int {
 	entries := bs.cache.Stats().Entries
 	_ = bs.cache.Close()
 	// Replace closed cache with the Null Object so subsequent operations

--- a/pkg/blockstore/engine/engine_delete_test.go
+++ b/pkg/blockstore/engine/engine_delete_test.go
@@ -134,7 +134,7 @@ func (s *recordingSyncedHashStore) deletedHashes() []blockstore.ContentHash {
 
 var _ metadata.SyncedHashStore = (*recordingSyncedHashStore)(nil)
 
-// buildCascadeFixture wires a BlockStore with the supplied coordinator
+// buildCascadeFixture wires a Store with the supplied coordinator
 // and (optional) SyncedHashStore. Local store is in-memory so the test
 // can focus on engine.Delete's coordinator + syncedHashStore loop
 // without filesystem state.
@@ -146,7 +146,7 @@ var _ metadata.SyncedHashStore = (*recordingSyncedHashStore)(nil)
 // runs, local.Get errors and the mirror loop surfaces the error rather
 // than re-marking. If the chunk survives momentarily, the marker race
 // is benign because the cascade cleans it up post-race.
-func buildCascadeFixture(t *testing.T, coord MetadataCoordinator, syncedStore metadata.SyncedHashStore) *BlockStore {
+func buildCascadeFixture(t *testing.T, coord MetadataCoordinator, syncedStore metadata.SyncedHashStore) *Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileBlockStore()

--- a/pkg/blockstore/engine/engine_health_test.go
+++ b/pkg/blockstore/engine/engine_health_test.go
@@ -52,13 +52,13 @@ func (f *fakeRemoteStore) Healthcheck(ctx context.Context) health.Report {
 
 func (f *fakeRemoteStore) SetHealthy(h bool) { f.healthy.Store(h) }
 
-// newHealthTestEngine creates an engine.BlockStore with an FSStore
+// newHealthTestEngine creates an engine.Store with an FSStore
 // local store, a controllable fake remote store, and a syncer with
 // short health intervals. The FSStore is constructed with an inline
 // RollupStore + a tight stabilization window so the
 // AppendWrite → rollup → CAS chunk → FileBlock-row pipeline runs
 // promptly inside the test.
-func newHealthTestEngine(t *testing.T) (*BlockStore, *fakeRemoteStore) {
+func newHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 	t.Helper()
 
 	tmpDir := t.TempDir()

--- a/pkg/blockstore/engine/engine_offline_test.go
+++ b/pkg/blockstore/engine/engine_offline_test.go
@@ -18,7 +18,7 @@ import (
 // engine.Flush deliberately does not synchronously drive rollup — the
 // production code path relies on the periodic rollup workers and the
 // stabilization window. Tests bypass that timing with this hook.
-func forceRollupOnEngineLocal(t *testing.T, bs *BlockStore, payloadID string) {
+func forceRollupOnEngineLocal(t *testing.T, bs *Store, payloadID string) {
 	t.Helper()
 	if fsLocal, ok := bs.local.(*fs.FSStore); ok {
 		// Wait past the test config's 50ms stabilization window so
@@ -44,7 +44,7 @@ func forceRollupOnEngineLocal(t *testing.T, bs *BlockStore, payloadID string) {
 }
 
 // waitForUnhealthy polls until the syncer reports unhealthy or timeout.
-func waitForUnhealthy(t *testing.T, bs *BlockStore, timeout time.Duration) {
+func waitForUnhealthy(t *testing.T, bs *Store, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/pkg/blockstore/engine/engine_test.go
+++ b/pkg/blockstore/engine/engine_test.go
@@ -102,11 +102,11 @@ func (s *stubFileBlockStore) ListFileBlocks(_ context.Context, payloadID string)
 	return out, nil
 }
 
-// newTestEngine creates an engine.BlockStore with memory local store, nil remote
+// newTestEngine creates an engine.Store with memory local store, nil remote
 // optional cache budget and prefetch settings. Coordinator is left nil — tests
 // that exercise Coordinator-dependent paths (CopyPayload/Delete/Truncate
 // with non-empty BlockRef list) should use newTestEngineWithCoordinator.
-func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *BlockStore {
+func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileBlockStore()
@@ -130,11 +130,11 @@ func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *Bl
 	return bs
 }
 
-// newTestEngineWithCoordinator creates an engine.BlockStore with the
+// newTestEngineWithCoordinator creates an engine.Store with the
 // supplied MetadataCoordinator wired in (Task 0).
 // Used by tests that assert engine-coordinator integration without
 // touching the heavier Syncer/Remote setup.
-func newTestEngineWithCoordinator(t *testing.T, c MetadataCoordinator) *BlockStore {
+func newTestEngineWithCoordinator(t *testing.T, c MetadataCoordinator) *Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileBlockStore()
@@ -263,7 +263,7 @@ func TestReadAt_InvokesCacheOnRead(t *testing.T) {
 }
 
 // TestEngine_NullCache_NoNilChecks — Task 3 behavior 2.
-// Construct BlockStore with nil/zero ReadBufferBytes; constructor
+// Construct Store with nil/zero ReadBufferBytes; constructor
 // substitutes nullCache; ReadAt + WriteAt + Truncate + Delete run
 // without panicking. The "no nil-checks" enforcement is asserted by
 // the package-level grep in the done criteria; this test verifies the
@@ -348,7 +348,7 @@ func (r *recordingCache) InvalidateFile(payloadID string, removed []blockstore.C
 func (r *recordingCache) Stats() CacheStats { return CacheStats{} }
 func (r *recordingCache) Close() error      { r.closed.Store(true); return nil }
 
-// TestClose_ClosesCache verifies BlockStore.Close calls the cache's
+// TestClose_ClosesCache verifies Store.Close calls the cache's
 // Close. Uses a recording fake so we can observe it.
 func TestClose_ClosesCache(t *testing.T) {
 	localStore := memory.New()
@@ -374,7 +374,7 @@ func TestClose_ClosesCache(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 	if !rec.closed.Load() {
-		t.Fatal("BlockStore.Close must invoke cache.Close")
+		t.Fatal("Store.Close must invoke cache.Close")
 	}
 }
 

--- a/pkg/blockstore/engine/flush.go
+++ b/pkg/blockstore/engine/flush.go
@@ -22,7 +22,7 @@ import (
 // Auto-promote into the read buffer is intentionally NOT done here
 // the Cache is CAS-keyed and Flush has no BlockRef snapshot at this
 // layer to translate flushed bytes into hash-keyed cache entries.
-func (bs *BlockStore) Flush(ctx context.Context, payloadID string) (*blockstore.FlushResult, error) {
+func (bs *Store) Flush(ctx context.Context, payloadID string) (*blockstore.FlushResult, error) {
 	// Both pre-rollup dedup hooks require a coordinator; gate them
 	// jointly so the nil-check isn't repeated.
 	if bs.coordinator != nil {
@@ -96,6 +96,6 @@ func (bs *BlockStore) Flush(ctx context.Context, payloadID string) (*blockstore.
 }
 
 // DrainAllUploads waits for all pending uploads to complete.
-func (bs *BlockStore) DrainAllUploads(ctx context.Context) error {
+func (bs *Store) DrainAllUploads(ctx context.Context) error {
 	return bs.syncer.DrainAllUploads(ctx)
 }

--- a/pkg/blockstore/engine/health.go
+++ b/pkg/blockstore/engine/health.go
@@ -11,11 +11,11 @@ import (
 // HealthCheck verifies the store is operational by checking the syncer health
 // (which in turn checks the remote store).
 //
-// Deprecated: use [BlockStore.Healthcheck] (lowercase 'c'), which returns a
+// Deprecated: use [Store.Healthcheck] (lowercase 'c'), which returns a
 // structured [health.Report] derived from both the local and remote stores
 // and satisfies [health.Checker]. This method only collapses the structured
 // state into a single error and is retained for backward compatibility.
-func (bs *BlockStore) HealthCheck(ctx context.Context) error {
+func (bs *Store) HealthCheck(ctx context.Context) error {
 	return bs.syncer.HealthCheck(ctx)
 }
 
@@ -35,7 +35,7 @@ func (bs *BlockStore) HealthCheck(ctx context.Context) error {
 //
 // The combined message preserves the worst-status component's message
 // so operators can see exactly which subsystem is at fault.
-func (bs *BlockStore) Healthcheck(ctx context.Context) health.Report {
+func (bs *Store) Healthcheck(ctx context.Context) health.Report {
 	start := time.Now()
 
 	if err := ctx.Err(); err != nil {
@@ -64,19 +64,19 @@ func (bs *BlockStore) Healthcheck(ctx context.Context) health.Report {
 	return health.NewHealthyReport(time.Since(start))
 }
 
-// HasRemoteStore returns true if this BlockStore has a remote store configured.
-func (bs *BlockStore) HasRemoteStore() bool {
+// HasRemoteStore returns true if this Store has a remote store configured.
+func (bs *Store) HasRemoteStore() bool {
 	return bs.remote != nil
 }
 
 // SetRetentionPolicy updates the retention policy on the underlying local store.
 // Delegates to the local store's SetRetentionPolicy method.
-func (bs *BlockStore) SetRetentionPolicy(policy blockstore.RetentionPolicy, ttl time.Duration) {
+func (bs *Store) SetRetentionPolicy(policy blockstore.RetentionPolicy, ttl time.Duration) {
 	bs.local.SetRetentionPolicy(policy, ttl)
 }
 
 // SetEvictionEnabled controls whether the local store can evict blocks to free disk space.
 // Delegates to the local store's SetEvictionEnabled method.
-func (bs *BlockStore) SetEvictionEnabled(enabled bool) {
+func (bs *Store) SetEvictionEnabled(enabled bool) {
 	bs.local.SetEvictionEnabled(enabled)
 }

--- a/pkg/blockstore/engine/loadbyhash_test.go
+++ b/pkg/blockstore/engine/loadbyhash_test.go
@@ -11,11 +11,11 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newLoadByHashFixture builds an FS-backed engine.BlockStore plus the
+// newLoadByHashFixture builds an FS-backed engine.Store plus the
 // underlying *fs.FSStore for tests that stage CAS chunks directly via
 // StoreChunk. The memory local store used by newTestEngine has no CAS
 // layer, so the loadByHash pin tests need this FS-backed variant.
-func newLoadByHashFixture(t *testing.T) (*BlockStore, *fs.FSStore) {
+func newLoadByHashFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{})

--- a/pkg/blockstore/engine/onchunkcomplete_test.go
+++ b/pkg/blockstore/engine/onchunkcomplete_test.go
@@ -10,13 +10,13 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newOnChunkCompleteFixture builds an FS-backed engine.BlockStore with a
+// newOnChunkCompleteFixture builds an FS-backed engine.Store with a
 // configurable cache budget so the Cache materializes in Start (when
 // readBufferBytes > 0) or remains the Null Object (when 0). The
 // wire-in is expected to install OnChunkComplete from engine.New via a
 // structural-interface assertion on cfg.Local; the fixture is the canonical
 // integration site because only the FSStore exposes SetOnChunkComplete.
-func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*BlockStore, *fs.FSStore) {
+func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{})
@@ -41,7 +41,7 @@ func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*BlockStore
 }
 
 // TestEngine_OnChunkComplete_WiredToCache pins the consumer-side
-// contract: when the engine's BlockStore is constructed with a non-zero
+// contract: when the engine's Store is constructed with a non-zero
 // cache budget, every successful StoreChunk on the underlying FSStore
 // populates bs.cache via the wired OnChunkComplete callback. The
 // subsequent bs.cache.Get(hash) hit proves the chunk is in RAM —

--- a/pkg/blockstore/engine/perf_bench_phase12_test.go
+++ b/pkg/blockstore/engine/perf_bench_phase12_test.go
@@ -49,15 +49,15 @@ const phase12ReadSize = 4096
 // sequence so re-runs are comparable.
 const phase12RandSeed = 42
 
-// phase12Fixture wraps a primed engine.BlockStore + the corresponding
+// phase12Fixture wraps a primed engine.Store + the corresponding
 // []BlockRef list covering the seeded file. Tests/benches run
-// rand-reads through BlockStore.ReadAt(payloadID, blocks, dest, offset)
+// rand-reads through Store.ReadAt(payloadID, blocks, dest, offset)
 // so the new binary-search + Cache-OnRead + mmap path is exercised.
 type phase12Fixture struct {
-	BlockStore *BlockStore
-	PayloadID  string
-	FileSize   uint64
-	blocks     []blockstore.BlockRef
+	Store     *Store
+	PayloadID string
+	FileSize  uint64
+	blocks    []blockstore.BlockRef
 }
 
 // AllBlockRefs returns the sorted []BlockRef list covering the seeded
@@ -68,7 +68,7 @@ func (f *phase12Fixture) AllBlockRefs() []blockstore.BlockRef { return f.blocks 
 // t.Cleanup hooks attached to newTestEngine.
 func (f *phase12Fixture) Close() {}
 
-// setupPerfFixture seeds an engine.BlockStore with one
+// setupPerfFixture seeds an engine.Store with one
 // phase12FixtureFileSize-byte payload split into N
 // phase12FixtureBlockSize chunks. Each chunk's BlockRef carries a
 // stable BLAKE3 hash of its (deterministic) payload so the OnRead hint
@@ -120,10 +120,10 @@ func setupPerfFixture(tb testing.TB) *phase12Fixture {
 	}
 
 	return &phase12Fixture{
-		BlockStore: bs,
-		PayloadID:  payloadID,
-		FileSize:   phase12FixtureFileSize,
-		blocks:     blocks,
+		Store:     bs,
+		PayloadID: payloadID,
+		FileSize:  phase12FixtureFileSize,
+		blocks:    blocks,
 	}
 }
 
@@ -132,7 +132,7 @@ func setupPerfFixture(tb testing.TB) *phase12Fixture {
 // local store + nil remote + stub fileBlockStore — the bench measures
 // the engine's read-path overhead (binary search, OnRead, copy out)
 // without any network or remote-store latency.
-func newPerfTestEngine(tb testing.TB, readBufferBytes int64, prefetchWorkers int) *BlockStore {
+func newPerfTestEngine(tb testing.TB, readBufferBytes int64, prefetchWorkers int) *Store {
 	tb.Helper()
 	localStore := memory.New()
 	fbs := newStubFileBlockStore()
@@ -179,7 +179,7 @@ func BenchmarkRandRead_Phase12(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		offset := uint64(rng.Intn(maxOffset))
-		if _, err := fixture.BlockStore.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
+		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
 			b.Fatalf("ReadAt: %v", err)
 		}
 	}
@@ -224,7 +224,7 @@ func BenchmarkPerfGate_Phase12RandReadRegression(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		offset := uint64(rng.Intn(maxOffset))
-		if _, err := fixture.BlockStore.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
+		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
 			b.Fatalf("ReadAt: %v", err)
 		}
 	}

--- a/pkg/blockstore/engine/read_internal.go
+++ b/pkg/blockstore/engine/read_internal.go
@@ -48,7 +48,7 @@ func computeFileSize(refs []blockstore.BlockRef) uint64 {
 // but the LocalStore did not surface — e.g., post-eviction reads where
 // only the metadata row survived) and finally to remote-fetch via the
 // syncer.
-func (bs *BlockStore) readAtInternal(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
+func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
@@ -82,7 +82,7 @@ func (bs *BlockStore) readAtInternal(ctx context.Context, payloadID string, data
 }
 
 // ensureAndReadFromLocal downloads blocks from remote if needed and reads from local store.
-func (bs *BlockStore) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
+func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
 	length := uint32(len(dest))
 
 	// Fast path: direct-serve copies S3 data directly to dest, skipping a second read.
@@ -127,7 +127,7 @@ func (bs *BlockStore) ensureAndReadFromLocal(ctx context.Context, payloadID stri
 // N) and for the steady-state production stream where N is bounded
 // by the payload's total size divided by the average chunk size
 // (~4 MiB).
-func (bs *BlockStore) readLocalByHash(ctx context.Context, payloadID string, dest []byte, offset uint64) (bool, error) {
+func (bs *Store) readLocalByHash(ctx context.Context, payloadID string, dest []byte, offset uint64) (bool, error) {
 	if len(dest) == 0 {
 		return true, nil
 	}

--- a/pkg/blockstore/engine/readwrite.go
+++ b/pkg/blockstore/engine/readwrite.go
@@ -17,7 +17,7 @@ import (
 // blockHashes, fileSize) so the Cache's sequential-detection state
 // machine can fire prefetch on upcoming hashes. The cache is hint-only
 // here; reads always go through local/remote stores.
-func (bs *BlockStore) ReadAt(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, data []byte, offset uint64) (int, error) {
+func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, data []byte, offset uint64) (int, error) {
 	n, err := bs.readAtInternal(ctx, payloadID, data, offset)
 	if err != nil {
 		return n, err
@@ -34,7 +34,7 @@ func (bs *BlockStore) ReadAt(ctx context.Context, payloadID string, blocks []blo
 
 // GetSize returns the stored size of a payload.
 // Checks local store first, falls back to syncer (remote).
-func (bs *BlockStore) GetSize(ctx context.Context, payloadID string) (uint64, error) {
+func (bs *Store) GetSize(ctx context.Context, payloadID string) (uint64, error) {
 	if size, found := bs.local.GetFileSize(ctx, payloadID); found {
 		return size, nil
 	}
@@ -43,7 +43,7 @@ func (bs *BlockStore) GetSize(ctx context.Context, payloadID string) (uint64, er
 
 // Exists checks whether a payload exists.
 // Checks local store first, falls back to syncer (remote).
-func (bs *BlockStore) Exists(ctx context.Context, payloadID string) (bool, error) {
+func (bs *Store) Exists(ctx context.Context, payloadID string) (bool, error) {
 	if _, found := bs.local.GetFileSize(ctx, payloadID); found {
 		return true, nil
 	}
@@ -71,7 +71,7 @@ func (bs *BlockStore) Exists(ctx context.Context, payloadID string) (bool, error
 //
 // Returns currentBlocks unchanged — the canonical projection happens
 // at Flush time, not WriteAt time.
-func (bs *BlockStore) WriteAt(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, data []byte, offset uint64) ([]blockstore.BlockRef, error) {
+func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, data []byte, offset uint64) ([]blockstore.BlockRef, error) {
 	if len(data) == 0 {
 		return currentBlocks, nil
 	}
@@ -109,7 +109,7 @@ func (bs *BlockStore) WriteAt(ctx context.Context, payloadID string, currentBloc
 // hash. The new []BlockRef list is returned for the caller to persist
 // via PutFile. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
-func (bs *BlockStore) Truncate(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, newSize uint64) ([]blockstore.BlockRef, error) {
+func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, newSize uint64) ([]blockstore.BlockRef, error) {
 	// coordinator decrements run FIRST so a refcount-bookkeeping
 	// failure leaves the file untouched on disk and remote. Previous
 	// order (local → cache → syncer → coordinator) could leave 4-of-5
@@ -181,7 +181,7 @@ func (bs *BlockStore) Truncate(ctx context.Context, payloadID string, currentBlo
 //
 // Subsequent steps (cache invalidate, coordinator refcount decrements
 // optional remote sweep) are unchanged.
-func (bs *BlockStore) Delete(ctx context.Context, payloadID string, blocks []blockstore.BlockRef) error {
+func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []blockstore.BlockRef) error {
 	bs.local.SyncFileBlocksForFile(ctx, payloadID)
 	if err := bs.local.EvictMemory(ctx, payloadID); err != nil {
 		return fmt.Errorf("local evict memory failed: %w", err)
@@ -272,7 +272,7 @@ func (bs *BlockStore) Delete(ctx context.Context, payloadID string, blocks []blo
 // RefCount only once per CopyPayload call (per-call seen-hash set).
 // The destination's []BlockRef preserves the original sequence so
 // subsequent reads still resolve every offset correctly.
-func (bs *BlockStore) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string, srcBlocks []blockstore.BlockRef) ([]blockstore.BlockRef, error) {
+func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string, srcBlocks []blockstore.BlockRef) ([]blockstore.BlockRef, error) {
 	// Empty src => no work, nothing to coordinate.
 	if len(srcBlocks) == 0 {
 		return nil, nil

--- a/pkg/blockstore/engine/stats.go
+++ b/pkg/blockstore/engine/stats.go
@@ -8,7 +8,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/blockstore/local"
 )
 
-// BlockStoreStats holds comprehensive block store statistics for a BlockStore.
+// BlockStoreStats holds comprehensive block store statistics for a Store.
 type BlockStoreStats struct {
 	FileCount    int `json:"file_count"`
 	BlocksDirty  int `json:"blocks_dirty"`
@@ -38,7 +38,7 @@ type BlockStoreStats struct {
 }
 
 // Stats returns storage statistics from the local store.
-func (bs *BlockStore) Stats() (*blockstore.Stats, error) {
+func (bs *Store) Stats() (*blockstore.Stats, error) {
 	localStats := bs.local.Stats()
 	files := bs.local.ListFiles()
 	used := uint64(localStats.DiskUsed)
@@ -62,7 +62,7 @@ func (bs *BlockStore) Stats() (*blockstore.Stats, error) {
 }
 
 // GetStats returns comprehensive block store statistics.
-func (bs *BlockStore) GetStats() BlockStoreStats {
+func (bs *Store) GetStats() BlockStoreStats {
 	localStats := bs.local.Stats()
 	files := bs.local.ListFiles()
 
@@ -100,7 +100,7 @@ func (bs *BlockStore) GetStats() BlockStoreStats {
 }
 
 // populateBlockCounts fills block count fields from the metadata store.
-func (bs *BlockStore) populateBlockCounts(stats *BlockStoreStats, files []string) {
+func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
 	if bs.fileBlockStore == nil {
 		return
 	}
@@ -135,4 +135,4 @@ func (bs *BlockStore) populateBlockCounts(stats *BlockStoreStats, files []string
 }
 
 // LocalStats returns a snapshot of local store statistics.
-func (bs *BlockStore) LocalStats() local.Stats { return bs.local.Stats() }
+func (bs *Store) LocalStats() local.Stats { return bs.local.Stats() }

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -58,15 +58,15 @@ type Syncer struct {
 	// SetSyncedHashStore.
 	syncedHashStore metadata.SyncedHashStore
 
-	// bs is a back-reference to the owning BlockStore.
+	// bs is a back-reference to the owning Store.
 	// the file-level dedup short-circuit needs to reach
-	// BlockStore.cache to fire InvalidateFile on orphaned speculative
+	// Store.cache to fire InvalidateFile on orphaned speculative
 	// chunks. Reading through the back-reference (rather than copying a
 	// `cache` field on the Syncer at construction time) lets test code
 	// swap `bs.cache = rec` after construction and still observe the
 	// invalidation — mirrors the TestClose_ClosesCache pattern. May be
 	// nil in pre-wiring tests; callers must nil-check before use.
-	bs *BlockStore
+	bs *Store
 
 	config SyncerConfig
 
@@ -134,7 +134,7 @@ func (m *Syncer) Queue() *SyncQueue { return m.queue }
 
 // SetCoordinator wires the MetadataCoordinator the file-level dedup
 // short-circuit reaches into (FindByObjectID, GetFileObjectID
-// IncrementRefCount). engine.New plumbs the BlockStore's coordinator
+// IncrementRefCount). engine.New plumbs the Store's coordinator
 // into the syncer at construction. Idempotent.
 func (m *Syncer) SetCoordinator(c MetadataCoordinator) {
 	m.mu.Lock()
@@ -237,7 +237,7 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 // written to remote.Put first, and only on success does the
 // SyncedHashStore.MarkSynced call fire. A crash between the two steps
 // is safe because remote.Put is idempotent on (hash, identical bytes)
-// per the unified BlockStore contract, so the next Flush pass re-Puts
+// per the unified Store contract, so the next Flush pass re-Puts
 // the same hash and proceeds to MarkSynced.
 //
 // Return contract — see blockstore.Flusher godoc for the full state
@@ -308,7 +308,7 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*blockstore.Flush
 //
 // Ordering is Put-then-Mark. A crash between remote.Put and MarkSynced
 // is safe because remote.Put is idempotent on (hash, identical bytes)
-// per the unified BlockStore contract; the next pass re-Puts the same
+// per the unified Store contract; the next pass re-Puts the same
 // hash and proceeds to MarkSynced. MarkSynced fires only after Put
 // returns nil — Mark never precedes Put, so a marked-synced hash is
 // always actually present remotely.

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -35,7 +35,7 @@ import (
 //  2. Put-then-Mark crash window — a remote that fails MarkSynced ONCE
 //     after a successful Put surfaces an error from Flush; the next
 //     Flush completes idempotently because Put on identical bytes is a
-//     no-op contract per the unified BlockStore surface.
+//     no-op contract per the unified Store surface.
 //  3. ListUnsynced snapshot semantics — chunks rolled up mid-Flush land
 //     in the NEXT pass, not the current one.
 //  4. Refcount cascade — engine.Delete on a fully-synced file drops the
@@ -381,7 +381,7 @@ func (s *stubFBS) ListFileBlocks(_ context.Context, payloadID string) ([]*blocks
 // through MemoryStore.AppendWrite + synchronous rollup), then exercise
 // bs.Flush + assertions.
 type integrationFixture struct {
-	bs     *engine.BlockStore
+	bs     *engine.Store
 	local  *casLocalStore
 	remote remote.RemoteStore
 	synced metadata.SyncedHashStore

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	Kerberos KerberosConfig `mapstructure:"kerberos" yaml:"kerberos"`
 
 	// Syncer configures the engine.Syncer claim/upload cycle.
-	// These knobs apply globally to every share's *engine.BlockStore syncer.
+	// These knobs apply globally to every share's *engine.Store syncer.
 	Syncer SyncerConfig `mapstructure:"syncer" yaml:"syncer"`
 
 	// Blockstore configures local/remote blockstore tunables.

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -443,7 +443,7 @@ func (r *Runtime) GetShareUsage(shareName string) (usedBytes int64, physicalByte
 }
 
 // GetBlockStoreForHandle resolves the per-share BlockStore from a file handle.
-func (r *Runtime) GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.BlockStore, error) {
+func (r *Runtime) GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.Store, error) {
 	return r.sharesSvc.GetBlockStoreForHandle(ctx, handle)
 }
 

--- a/pkg/controlplane/runtime/shares/healthcheck.go
+++ b/pkg/controlplane/runtime/shares/healthcheck.go
@@ -54,7 +54,7 @@ import (
 // purely on the metadata store's status.
 //
 // A share with a remote-less block store (local-only) is handled
-// transparently because [engine.BlockStore.Healthcheck] already
+// transparently because [engine.Store.Healthcheck] already
 // returns healthy when there is no remote configured.
 func (s *Share) Healthcheck(ctx context.Context, metaStore metadata.MetadataStore) health.Report {
 	// `start` carries the monotonic reading used to compute latency.

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -94,7 +94,7 @@ type Share struct {
 
 	// BlockStore is the per-share block store orchestrator.
 	// Nil only for metadata-only shares (unlikely in practice).
-	BlockStore *engine.BlockStore
+	BlockStore *engine.Store
 
 	// remoteConfigID tracks which remote store config this share uses (for ref counting).
 	remoteConfigID string
@@ -252,7 +252,7 @@ type sharedRemote struct {
 }
 
 // nonClosingRemote wraps a remote.RemoteStore and makes Close() a no-op.
-// This prevents engine.BlockStore.Close() from closing the shared remote;
+// This prevents engine.Store.Close() from closing the shared remote;
 // the shares.Service.releaseRemoteStore handles actual closing via ref counting.
 type nonClosingRemote struct {
 	remote.RemoteStore
@@ -1118,7 +1118,7 @@ func (s *Service) CountShares() int {
 // GetBlockStoreForHandle decodes a file handle and resolves the per-share
 // BlockStore in a single mutex acquisition, avoiding the two-RLock overhead of
 // calling GetShareNameForHandle followed by GetBlockStoreForShare separately.
-func (s *Service) GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.BlockStore, error) {
+func (s *Service) GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.Store, error) {
 	shareName, _, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode file handle: %w", err)
@@ -1138,7 +1138,7 @@ func (s *Service) GetBlockStoreForHandle(ctx context.Context, handle metadata.Fi
 }
 
 // GetBlockStoreForShare returns the BlockStore for a named share.
-func (s *Service) GetBlockStoreForShare(name string) (*engine.BlockStore, error) {
+func (s *Service) GetBlockStoreForShare(name string) (*engine.Store, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	share, exists := s.registry[name]
@@ -1212,7 +1212,7 @@ func (s *Service) DistinctRemoteStores() []RemoteStoreEntry {
 //
 // Test-only: panics if the share does not exist. Intended for runtime-
 // package tests that need to exercise RunBlockGC's enumeration without
-// standing up a full engine.BlockStore. Not safe for production callers.
+// standing up a full engine.Store. Not safe for production callers.
 func (s *Service) SetShareRemoteForTest(shareName string, rs remote.RemoteStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1239,7 +1239,7 @@ func (s *Service) SetShareRemoteForTest(shareName string, rs remote.RemoteStore)
 // DrainAllBlockStores drains all pending uploads across all per-share BlockStores.
 func (s *Service) DrainAllBlockStores(ctx context.Context) error {
 	s.mu.RLock()
-	blockStores := make([]*engine.BlockStore, 0, len(s.registry))
+	blockStores := make([]*engine.Store, 0, len(s.registry))
 	for _, share := range s.registry {
 		if share.BlockStore != nil {
 			blockStores = append(blockStores, share.BlockStore)

--- a/pkg/controlplane/runtime/snapshot_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_integration_test.go
@@ -428,7 +428,7 @@ func testStartupRecovery(t *testing.T) {
 
 // orchestrationFixture composes every moving part the seven sub-tests
 // need: cpstore, runtime, memory metadata store wrapped in a controlled
-// Backupable, memory remote, real engine.BlockStore wiring the local +
+// Backupable, memory remote, real engine.Store wiring the local +
 // remote, and an injected Share that ties them together.
 type orchestrationFixture struct {
 	t             *testing.T
@@ -436,7 +436,7 @@ type orchestrationFixture struct {
 	store         cpstore.Store
 	backup        *controlledBackupable
 	remote        *interceptingRemote
-	bs            *engine.BlockStore
+	bs            *engine.Store
 	localStoreDir string
 	shareName     string
 }
@@ -472,7 +472,7 @@ func newOrchestrationFixture(t *testing.T) *orchestrationFixture {
 	localStoreDir := t.TempDir()
 	shareName := "data"
 
-	// Build a minimal real engine.BlockStore. The memory local store +
+	// Build a minimal real engine.Store. The memory local store +
 	// memory remote + memory metadata as FileBlockStore have empty
 	// ListUnsynced semantics so DrainAllUploads is a fast no-op and
 	// mirrorOnce short-circuits — exactly what the orchestration

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -490,7 +490,7 @@ type restoreFixture struct {
 	meta          *metadatamemory.MemoryMetadataStore
 	failable      *failableResetable // non-nil only when opts.useFailableResetable
 	remote        *restoreRemote
-	bs            *engine.BlockStore
+	bs            *engine.Store
 	localStoreDir string
 	shareName     string
 	rootHandle    metadata.FileHandle


### PR DESCRIPTION
## Summary

Rename concrete type `engine.BlockStore` → `engine.Store`. Matches the existing `engine.Cache` / `engine.Syncer` naming and drops the redundant qualifier that only made sense before the package was named `engine`.

The `blockstore.Store` interface is untouched. `BlockStoreStats` (separate type) is untouched.

## Scope

- Type definition + compile-time interface assertion in `pkg/blockstore/engine/engine.go`.
- All method receivers in `pkg/blockstore/engine/` (receiver name `bs` kept for minimal-diff).
- Internal type field on `Syncer` (back-reference, kept field name `bs`).
- 46 callsites across `pkg/`, `internal/`, `cmd/` rewritten from `engine.BlockStore` to `engine.Store`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m` → 0 issues
- [x] `gofmt -s -w .`
- [x] `go test ./...` (pre-existing flake: `TestAPIServer_HealthEndpoint_NoRuntime` also fails on develop baseline; unrelated to this rename)
- [x] `go test -race ./pkg/blockstore/engine/... ./pkg/controlplane/runtime/...`
- [x] grep verified zero remaining `engine.BlockStore` references; `BlockStoreStats` and `blockstore.Store` interface preserved.

41 files changed, 141 insertions / 141 deletions — line-symmetric, pure rename.