### PR TITLE
chore(smb/kf): split alloc-size/read-only off #738

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -222,8 +222,8 @@ still fail due to incomplete reconnect and lease coordination.
 | smb2.durable-open.file-position | Durable handles V1 | Durable file position not fully working | #738 |
 | smb2.durable-open.lock-oplock | Durable handles V1 | Durable lock + oplock not fully working | #738 |
 | smb2.durable-open.lock-lease | Durable handles V1 | Durable lock + lease not fully working | #738 |
-| smb2.durable-open.alloc-size | Durable handles V1 | Pre-existing: out.alloc_size returned 0 instead of expected non-zero | #738 |
-| smb2.durable-open.read-only | Durable handles V1 | Pre-existing: OBJECT_NAME_NOT_FOUND on durable read-only reopen | #738 |
+| smb2.durable-open.alloc-size | CREATE allocation | Pre-existing non-DH bug: out.alloc_size=0 on CREATE with in.alloc_size set (fails before any reconnect) | #792 |
+| smb2.durable-open.read-only | READONLY attribute | OBJECT_NAME_NOT_FOUND on durable reopen of FILE_ATTRIBUTE_READONLY file (attribute-restore gap) | #793 |
 
 ### Durable Handles V2 (Fix Candidate)
 


### PR DESCRIPTION
Two of the 14 KF rows currently tagged to #738 are not pure DH-V1-reconnect bugs:

- `smb2.durable-open.alloc-size` fails on the **initial CREATE** (line 2788 of Samba `source4/torture/smb2/durable_open.c`) with `CHECK_NOT_VAL(out.alloc_size, 0)` — server returns `out.alloc_size=0` instead of honouring `in.alloc_size`. The test never reaches the disconnect path. Filed as #792.

- `smb2.durable-open.read-only` fails on durable reopen of a file created with `FILE_ATTRIBUTE_READONLY` with `OBJECT_NAME_NOT_FOUND`. Root cause is most likely the attribute being lost / mis-evaluated on the persist+restore boundary, not the V1 reconnect plumbing itself. Filed as #793.

This PR re-tags the two KF rows from #738 to their respective trackers and updates their reason text and category. #738 scope narrows from 14 → 12 tests (reconnect / DOC / file-position / lock-{oplock,lease}).

Refs #738