### PR TITLE
fix(smb/dh): V1 DHnC ignores filename on oplock reconnect

### DIFF
--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -391,8 +391,50 @@ func processV1Reconnect(
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
+	// MS-SMB2 §3.3.5.9.7 / Samba `smbd_smb2_create_durable_lease_check`
+	// (source3/smbd/smb2_create.c): the filename in a V1 DHnC reconnect is
+	// IGNORED by the server when the open is oplock-backed (no lease). The
+	// lease/path matching rules only apply to lease-backed reopens. Compute
+	// the V1 lease-context gate before path validation so the per-test
+	// expectations of smbtorture smb2.durable-open.reopen2 hold:
+	//
+	//   - lease_ptr==nil, persisted no-lease  → skip path check, proceed
+	//   - lease_ptr==nil, persisted lease     → OBJECT_NAME_NOT_FOUND
+	//   - lease_ptr!=nil, persisted no-lease  → OBJECT_NAME_NOT_FOUND
+	//   - lease_ptr!=nil, persisted lease:
+	//       * lease key mismatch              → OBJECT_NAME_NOT_FOUND
+	//       * path mismatch                   → INVALID_PARAMETER
+	//       * else                            → proceed
+	leaseCtx := FindCreateContext(contexts, LeaseContextTagRequest)
+	persistedHasLease := handle.OplockLevel == OplockLevelLease && handle.LeaseKey != ([16]byte{})
+	checkPath := true
+	if leaseCtx == nil {
+		if persistedHasLease {
+			logger.Debug("processV1Reconnect: persisted handle has lease but request omits lease ctx")
+			return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		}
+		// Oplock-backed reopen: filename is ignored by the server.
+		checkPath = false
+	} else {
+		if !persistedHasLease {
+			logger.Debug("processV1Reconnect: lease ctx provided but persisted handle has no lease")
+			return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		}
+		leaseReq, decErr := DecodeLeaseCreateContext(leaseCtx.Data)
+		if decErr != nil || leaseReq == nil {
+			logger.Debug("processV1Reconnect: invalid lease ctx", "error", decErr)
+			return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		}
+		if leaseReq.LeaseKey != handle.LeaseKey {
+			logger.Debug("processV1Reconnect: lease key mismatch",
+				"expected", fmt.Sprintf("%x", handle.LeaseKey),
+				"actual", fmt.Sprintf("%x", leaseReq.LeaseKey))
+			return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		}
+	}
+
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, desiredAccess, shareAccess,
+		sessionKeyHash, shareName, filename, desiredAccess, shareAccess, checkPath,
 		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
 			return durableStore.ConsumeDurableHandleByFileID(ctx, fileID)
 		})
@@ -481,8 +523,11 @@ func processV2Reconnect(
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
+	// V2 reconnect always checks the path against the persisted handle
+	// (no Samba-style oplock-only fallthrough). The CreateGuid is the
+	// primary identifier; the path check is an extra integrity gate.
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, desiredAccess, shareAccess,
+		sessionKeyHash, shareName, filename, desiredAccess, shareAccess, true,
 		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
 			return durableStore.ConsumeDurableHandleByCreateGuid(ctx, createGuid)
 		})
@@ -518,6 +563,7 @@ func validateAndRestore(
 	filename string,
 	desiredAccess uint32,
 	shareAccess uint32,
+	checkPath bool,
 	consume func(ctx context.Context) (*lock.PersistedDurableHandle, error),
 ) (*OpenFile, types.Status, error) {
 	if handle.ShareName != shareName {
@@ -527,7 +573,10 @@ func validateAndRestore(
 		return nil, types.StatusObjectNameNotFound, nil
 	}
 
-	if handle.Path != filename {
+	// V1 oplock-backed reconnect ignores the filename per MS-SMB2 §3.3.5.9.7
+	// (mirrors Samba `smbd_smb2_create_durable_lease_check` which only path-
+	// checks lease-backed reopens). Caller passes checkPath=false in that case.
+	if checkPath && handle.Path != filename {
 		logger.Debug("validateAndRestore: path mismatch",
 			"expected", handle.Path,
 			"actual", filename)

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -1417,3 +1417,203 @@ func TestProcessDurableReconnectContext_ConsumeAtomicV2(t *testing.T) {
 		t.Errorf("second reconnect status = %v, want STATUS_OBJECT_NAME_NOT_FOUND", status2)
 	}
 }
+
+// TestProcessDurableReconnectContext_V1OplockIgnoresPath verifies that a V1
+// DHnC reconnect on an oplock-backed durable handle (no lease) IGNORES the
+// CREATE request's filename — matching MS-SMB2 §3.3.5.9.7 and Samba's
+// `smbd_smb2_create_durable_lease_check` which only path-checks lease-backed
+// reopens. smbtorture smb2.durable-open.reopen2 step 3 deliberately passes
+// "__non_existing_fname__" to prove this.
+func TestProcessDurableReconnectContext_V1OplockIgnoresPath(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	keyHash := makeSessionKeyHash("session-key-v1path")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-v1-path-ignore",
+		FileID:         fileID,
+		Path:           "real.dat",
+		ShareName:      "/share1",
+		DesiredAccess:  0x12019F,
+		ShareAccess:    0x07,
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelBatch,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		IsV2:           false,
+		CreatedAt:      time.Now().Add(-5 * time.Minute),
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash,
+		"/share1", "__non_existing_fname__", [16]byte{}, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusSuccess {
+		t.Fatalf("Expected STATUS_SUCCESS for V1 oplock reconnect with wrong fname, got %s", status)
+	}
+	if res == nil || res.OpenFile == nil {
+		t.Fatal("Expected restored OpenFile")
+	}
+	if res.OpenFile.Path != "real.dat" {
+		t.Errorf("Restored Path = %q, want %q", res.OpenFile.Path, "real.dat")
+	}
+}
+
+// TestProcessDurableReconnectContext_V1LeasedRejectsMissingLease verifies that
+// a V1 reconnect for a lease-backed persisted handle MUST carry a lease
+// context; absent that, the server returns OBJECT_NAME_NOT_FOUND
+// (smb2.durable-open.reopen2_lease "without lease attached" cases).
+func TestProcessDurableReconnectContext_V1LeasedRejectsMissingLease(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
+	leaseKey := [16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00}
+	keyHash := makeSessionKeyHash("session-key-v1lease")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-v1-leased",
+		FileID:         fileID,
+		Path:           "leased.dat",
+		ShareName:      "/share1",
+		DesiredAccess:  0x12019F,
+		ShareAccess:    0x07,
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelLease,
+		LeaseKey:       leaseKey,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	_, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash,
+		"/share1", "leased.dat", [16]byte{}, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusObjectNameNotFound {
+		t.Errorf("Expected OBJECT_NAME_NOT_FOUND for V1 reconnect of leased handle without RqLs, got %s", status)
+	}
+}
+
+// TestProcessDurableReconnectContext_V1LeasedWrongLeaseKey verifies that a V1
+// reconnect with a lease context carrying a non-matching lease key returns
+// OBJECT_NAME_NOT_FOUND (smb2.durable-open.reopen2_lease "wrong lease key" case).
+func TestProcessDurableReconnectContext_V1LeasedWrongLeaseKey(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
+	leaseKey := [16]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	wrongKey := [16]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+	keyHash := makeSessionKeyHash("session-key-v1wrongkey")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-v1-wrongkey",
+		FileID:         fileID,
+		Path:           "leased.dat",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelLease,
+		LeaseKey:       leaseKey,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+
+	// V1 lease context (32 bytes: 16 LeaseKey + 4 LeaseState + 4 Flags + 8 Duration)
+	leaseCtxData := make([]byte, 32)
+	copy(leaseCtxData[0:16], wrongKey[:])
+	binary.LittleEndian.PutUint32(leaseCtxData[16:20], 0x7) // RWH requested
+
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+		{Name: LeaseContextTagRequest, Data: leaseCtxData},
+	}
+
+	_, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash,
+		"/share1", "leased.dat", [16]byte{}, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusObjectNameNotFound {
+		t.Errorf("Expected OBJECT_NAME_NOT_FOUND for wrong lease key, got %s", status)
+	}
+}
+
+// TestProcessDurableReconnectContext_V1UnleasedRejectsLeaseCtx verifies that
+// a V1 reconnect carrying a lease context against an oplock-only persisted
+// handle returns OBJECT_NAME_NOT_FOUND (mirror of the inverse asymmetry).
+func TestProcessDurableReconnectContext_V1UnleasedRejectsLeaseCtx(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	keyHash := makeSessionKeyHash("session-key-v1nolease")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-v1-nolease",
+		FileID:         fileID,
+		Path:           "plain.dat",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelBatch,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+
+	someLeaseKey := [16]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}
+	leaseCtxData := make([]byte, 32)
+	copy(leaseCtxData[0:16], someLeaseKey[:])
+
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+		{Name: LeaseContextTagRequest, Data: leaseCtxData},
+	}
+
+	_, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash,
+		"/share1", "plain.dat", [16]byte{}, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusObjectNameNotFound {
+		t.Errorf("Expected OBJECT_NAME_NOT_FOUND for lease ctx vs oplock-only persisted handle, got %s", status)
+	}
+}


### PR DESCRIPTION
First fix-slice on #738. Targets `smb2.durable-open.reopen2` (and likely the related `reopen2a`/`reopen4`/`reopen2_lease` step assertions that exercise the same code path).

## Root cause

MS-SMB2 §3.3.5.9.7 and Samba `smbd_smb2_create_durable_lease_check` (`source3/smbd/smb2_create.c:568-668`) only check the request filename against the persisted handle for **lease-backed** durable reopens. For oplock-backed V1 DHnC reconnects, the filename in the CREATE request is **genuinely ignored**. The smbtorture `smb2.durable-open.reopen2` step 3 deliberately sets `io.in.fname = "__non_existing_fname__"` to prove this contract.

Today our `validateAndRestore` unconditionally compares `handle.Path` against the request filename and returns `STATUS_INVALID_PARAMETER` on mismatch, breaking `reopen2` and any test exercising the "fname ignored" path.

## Fix

1. Add a `checkPath` parameter to `validateAndRestore`.
2. In `processV1Reconnect`, apply the full MS-SMB2 §3.3.5.9.7 lease combination matrix **before** calling `validateAndRestore`, mirroring Samba's `smbd_smb2_create_durable_lease_check`:

   | lease_ctx | persisted lease | result |
   |---|---|---|
   | nil | no | proceed, `checkPath=false` |
   | nil | yes | OBJECT_NAME_NOT_FOUND |
   | present | no | OBJECT_NAME_NOT_FOUND |
   | present | yes, wrong key | OBJECT_NAME_NOT_FOUND |
   | present | yes, matching | proceed, `checkPath=true` |

3. V2 (DH2C) still passes `checkPath=true` — V2 always carries CreateGuid as the primary identifier, so the path check remains an integrity gate.

## Tests

New unit tests cover:
- V1 oplock-backed reconnect succeeds with wrong fname
- V1 reconnect on lease-backed handle without RqLs → `OBJECT_NAME_NOT_FOUND`
- V1 reconnect with RqLs against oplock-only persisted handle → `OBJECT_NAME_NOT_FOUND`
- V1 reconnect with wrong lease key → `OBJECT_NAME_NOT_FOUND`

Existing `TestProcessDurableReconnectContext_PathMismatch` continues to pass (it uses V2 which still checks path).

Refs #738