### PR TITLE
feat(cmd/blockstore-perf): seeded workload harness for v1.0 perf audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ temp/
 benchmark_results/
 *.prof
 
+# blockstore-perf pprof output
+_profiles/
+
 # POSIX test results
 test/posix/results/*.txt
 test/posix/results/*.log

--- a/cmd/blockstore-perf/main.go
+++ b/cmd/blockstore-perf/main.go
@@ -90,13 +90,29 @@ func run(cfg config) error {
 	if err != nil {
 		return err
 	}
-	defer cpuStop()
+	cpuStopped := false
+	defer func() {
+		if !cpuStopped {
+			cpuStop()
+		}
+	}()
+
+	ctx := context.Background()
+	// Pre-seed any working-set state BEFORE timing — seedAndOffsetCap
+	// writes 32–64 MiB per file and must not pollute throughput numbers.
+	workload, err := prepareWorkload(ctx, bs, cfg)
+	if err != nil {
+		return err
+	}
 
 	statsBefore := bs.GetStats()
-	ctx := context.Background()
 	start := time.Now()
-	bytesWritten, err := driveWorkload(ctx, bs, cfg)
+	bytesWritten, err := runLoop(cfg, workload)
 	dur := time.Since(start)
+	// Stop CPU profile right after the timed region — heap snapshot and
+	// runtime.GC below must not appear in the workload CPU profile.
+	cpuStop()
+	cpuStopped = true
 	if err != nil {
 		return err
 	}
@@ -149,7 +165,8 @@ func newBlockStore(baseDir string) (*engine.BlockStore, func(), error) {
 	if err := bs.Start(context.Background()); err != nil {
 		return nil, nil, fmt.Errorf("engine.Start: %w", err)
 	}
-	return bs, func() { _ = bs.Close(); _ = remoteStore.Close() }, nil
+	// engine.BlockStore.Close already closes the remote — no double close here.
+	return bs, func() { _ = bs.Close() }, nil
 }
 
 // startProfiles creates the per-run profile dir and begins CPU
@@ -184,78 +201,93 @@ func writeHeapProfile(dir string) error {
 	return nil
 }
 
-// driveWorkload runs the selected workload and returns bytes written.
-func driveWorkload(ctx context.Context, bs *engine.BlockStore, cfg config) (int64, error) {
+// prepareWorkload seeds any pre-workload state (outside the timed
+// region) and returns the per-op step function consumed by runLoop.
+// Seeding is excluded from timing because seedAndOffsetCap writes
+// 32–64 MiB per file that would otherwise pollute throughput numbers
+// without being counted in ops/bytes.
+func prepareWorkload(ctx context.Context, bs *engine.BlockStore, cfg config) (func(i int) (int, error), error) {
 	files := max(cfg.workingSet, 1)
-	buf := seededBytes(cfg.seed, cfg.blockSize)
+	buf := make([]byte, cfg.blockSize)
+	// PRNG drives both per-op offset selection and per-op buffer fill.
+	// Filling buf per-iteration (rng.Read) defeats CAS dedup that would
+	// otherwise swallow most ops when only buf[0] varied across writes.
 	rng := rand.New(rand.NewPCG(cfg.seed, 0))
 
 	switch cfg.workload {
 	case "sequential-write":
-		var off uint64
-		return runLoop(cfg, func(i int) (int, error) {
-			buf[0] = byte(i)
-			pid := fmt.Sprintf("perf/seq/%d", i%files)
-			_, err := bs.WriteAt(ctx, pid, nil, buf, off)
-			off += uint64(len(buf))
+		// Per-file offsets — when working-set > 1, each payloadID must
+		// track its own monotonic offset; a shared `off` would smear
+		// writes across files at correlated positions.
+		offs := make([]int64, files)
+		return func(i int) (int, error) {
+			fillRandom(rng, buf)
+			idx := i % files
+			pid := fmt.Sprintf("perf/seq/%d", idx)
+			_, err := bs.WriteAt(ctx, pid, nil, buf, uint64(offs[idx]))
+			offs[idx] += int64(len(buf))
 			return len(buf), err
-		})
+		}, nil
 	case "random-write":
 		const fileSize = 64 * 1024 * 1024
 		maxOff, err := seedAndOffsetCap(ctx, bs, files, "perf/rand", cfg, fileSize)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		return runLoop(cfg, func(i int) (int, error) {
-			buf[0] = byte(i)
+		return func(i int) (int, error) {
+			fillRandom(rng, buf)
 			pid := fmt.Sprintf("perf/rand/%d", i%files)
 			_, err := bs.WriteAt(ctx, pid, nil, buf, rng.Uint64N(maxOff+1))
 			return len(buf), err
-		})
+		}, nil
 	case "dedup-heavy":
-		// Same block bytes -> distinct file per op exercises file-level dedup.
-		return runLoop(cfg, func(i int) (int, error) {
+		// Same block bytes across distinct files exercises file-level
+		// dedup; deliberately fill buf once before the loop.
+		fillRandom(rng, buf)
+		return func(i int) (int, error) {
 			pid := fmt.Sprintf("perf/dedup/%d", i)
 			if _, err := bs.WriteAt(ctx, pid, nil, buf, 0); err != nil {
 				return 0, err
 			}
 			_, err := bs.Flush(ctx, pid)
 			return len(buf), err
-		})
+		}, nil
 	case "mixed-rw":
 		const fileSize = 32 * 1024 * 1024
 		maxOff, err := seedAndOffsetCap(ctx, bs, files, "perf/mixed", cfg, fileSize)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
 		rbuf := make([]byte, cfg.blockSize)
-		return runLoop(cfg, func(i int) (int, error) {
+		return func(i int) (int, error) {
 			off := rng.Uint64N(maxOff + 1)
 			pid := fmt.Sprintf("perf/mixed/%d", i%files)
 			if i%2 == 0 {
-				buf[0] = byte(i)
+				fillRandom(rng, buf)
 				_, err := bs.WriteAt(ctx, pid, nil, buf, off)
 				return len(buf), err
 			}
 			_, err := bs.ReadAt(ctx, pid, nil, rbuf, off)
 			return 0, err
-		})
+		}, nil
 	case "flush-churn":
-		var off uint64
-		return runLoop(cfg, func(i int) (int, error) {
-			buf[0] = byte(i)
-			pid := fmt.Sprintf("perf/churn/%d", i%files)
-			if _, err := bs.WriteAt(ctx, pid, nil, buf, off); err != nil {
+		// Per-file offsets — same rationale as sequential-write.
+		offs := make([]int64, files)
+		return func(i int) (int, error) {
+			fillRandom(rng, buf)
+			idx := i % files
+			pid := fmt.Sprintf("perf/churn/%d", idx)
+			if _, err := bs.WriteAt(ctx, pid, nil, buf, uint64(offs[idx])); err != nil {
 				return 0, err
 			}
 			if _, err := bs.Flush(ctx, pid); err != nil {
 				return 0, err
 			}
-			off += uint64(len(buf))
+			offs[idx] += int64(len(buf))
 			return len(buf), nil
-		})
+		}, nil
 	default:
-		return 0, fmt.Errorf("unknown workload %q", cfg.workload)
+		return nil, fmt.Errorf("unknown workload %q", cfg.workload)
 	}
 }
 
@@ -292,8 +324,32 @@ func seedAndOffsetCap(ctx context.Context, bs *engine.BlockStore, files int, pre
 func seededBytes(seed uint64, size int) []byte {
 	rng := rand.New(rand.NewPCG(seed, 0))
 	out := make([]byte, size)
-	for i := range out {
-		out[i] = byte(rng.Uint32())
-	}
+	fillRandom(rng, out)
 	return out
+}
+
+// fillRandom overwrites buf with PRNG bytes drawn 8 at a time. Used
+// per-op in the timed loop so payload bytes are unique across ops —
+// otherwise CAS dedup would short-circuit most writes and the workload
+// would not reflect realistic block churn.
+func fillRandom(rng *rand.Rand, buf []byte) {
+	i := 0
+	for ; i+8 <= len(buf); i += 8 {
+		v := rng.Uint64()
+		buf[i] = byte(v)
+		buf[i+1] = byte(v >> 8)
+		buf[i+2] = byte(v >> 16)
+		buf[i+3] = byte(v >> 24)
+		buf[i+4] = byte(v >> 32)
+		buf[i+5] = byte(v >> 40)
+		buf[i+6] = byte(v >> 48)
+		buf[i+7] = byte(v >> 56)
+	}
+	if i < len(buf) {
+		v := rng.Uint64()
+		for ; i < len(buf); i++ {
+			buf[i] = byte(v)
+			v >>= 8
+		}
+	}
 }

--- a/cmd/blockstore-perf/main.go
+++ b/cmd/blockstore-perf/main.go
@@ -1,0 +1,299 @@
+// blockstore-perf is a seeded workload harness for pkg/blockstore/engine.
+// Composes FSStore local + memory remote + in-memory metadata + Syncer
+// and drives one of: sequential-write, random-write, dedup-heavy,
+// mixed-rw, flush-churn. Captures wall-clock, throughput, and CPU + heap
+// pprof to <profile-dir>/<workload>-<timestamp>/.
+//
+// Example: go run ./cmd/blockstore-perf --workload random-write --ops 5000
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+const (
+	defaultSeqBlockSize    = 8 * 1024 * 1024
+	defaultRandomBlockSize = 4 * 1024
+	logBudget              = 256 * 1024 * 1024
+	memBudget              = 64 * 1024 * 1024
+)
+
+type config struct {
+	workload   string
+	ops        int
+	blockSize  int
+	workingSet int
+	profileDir string
+	seed       uint64
+}
+
+func main() {
+	cfg := parseFlags()
+	if err := run(cfg); err != nil {
+		log.Fatalf("blockstore-perf: %v", err)
+	}
+}
+
+func parseFlags() config {
+	var c config
+	flag.StringVar(&c.workload, "workload", "", "workload name (sequential-write|random-write|dedup-heavy|mixed-rw|flush-churn)")
+	flag.IntVar(&c.ops, "ops", 10000, "operation count")
+	bs := flag.Int("block-size", 0, "per-op block size in bytes (default: 8 MiB for sequential/dedup, 4 KiB for the rest)")
+	flag.IntVar(&c.workingSet, "working-set", 1, "number of files in the working set")
+	flag.StringVar(&c.profileDir, "profile-dir", "_profiles", "directory for pprof output")
+	flag.Uint64Var(&c.seed, "seed", 1, "PRNG seed for randomized workloads")
+	flag.Parse()
+	if c.workload == "" {
+		fmt.Fprintln(os.Stderr, "--workload is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	switch {
+	case *bs > 0:
+		c.blockSize = *bs
+	case c.workload == "sequential-write" || c.workload == "dedup-heavy":
+		c.blockSize = defaultSeqBlockSize
+	default:
+		c.blockSize = defaultRandomBlockSize
+	}
+	return c
+}
+
+func run(cfg config) error {
+	tmpDir, err := os.MkdirTemp("", "blockstore-perf-")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	bs, closeFn, err := newBlockStore(tmpDir)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	profDir, cpuStop, err := startProfiles(cfg)
+	if err != nil {
+		return err
+	}
+	defer cpuStop()
+
+	statsBefore := bs.GetStats()
+	ctx := context.Background()
+	start := time.Now()
+	bytesWritten, err := driveWorkload(ctx, bs, cfg)
+	dur := time.Since(start)
+	if err != nil {
+		return err
+	}
+	statsAfter := bs.GetStats()
+
+	if err := writeHeapProfile(profDir); err != nil {
+		return err
+	}
+
+	fmt.Printf("workload=%s ops=%d dur=%.3fms ops_per_sec=%.2f bytes_per_sec=%.2f profiles=%s\n",
+		cfg.workload, cfg.ops, float64(dur.Microseconds())/1000.0,
+		float64(cfg.ops)/dur.Seconds(), float64(bytesWritten)/dur.Seconds(), profDir)
+	fmt.Printf("stats before/after: files=%d/%d dirty=%d/%d disk=%d/%d pending=%d completed=%d\n",
+		statsBefore.FileCount, statsAfter.FileCount,
+		statsBefore.BlocksDirty, statsAfter.BlocksDirty,
+		statsBefore.LocalDiskUsed, statsAfter.LocalDiskUsed,
+		statsAfter.PendingUploads, statsAfter.CompletedSyncs)
+	return nil
+}
+
+// newBlockStore wires production-equivalent FSStore + memory remote +
+// memory metadata + Syncer, sized for short-lived benchmark runs.
+func newBlockStore(baseDir string) (*engine.BlockStore, func(), error) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(baseDir, 0, memBudget, ms, fs.FSStoreOptions{
+		MaxLogBytes:     logBudget,
+		RollupWorkers:   2,
+		StabilizationMS: 5,
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("fs.NewWithOptions: %w", err)
+	}
+	if err := local.StartRollup(context.Background()); err != nil {
+		return nil, nil, fmt.Errorf("StartRollup: %w", err)
+	}
+	remoteStore := remotememory.New()
+	syncer := engine.NewSyncer(local, remoteStore, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           local,
+		Remote:          remoteStore,
+		Syncer:          syncer,
+		FileBlockStore:  ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("engine.New: %w", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		return nil, nil, fmt.Errorf("engine.Start: %w", err)
+	}
+	return bs, func() { _ = bs.Close(); _ = remoteStore.Close() }, nil
+}
+
+// startProfiles creates the per-run profile dir and begins CPU
+// profiling. The returned closure stops the profile and closes the file.
+func startProfiles(cfg config) (string, func(), error) {
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	dir := filepath.Join(cfg.profileDir, fmt.Sprintf("%s-%s", cfg.workload, ts))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", func() {}, fmt.Errorf("mkdir profiles: %w", err)
+	}
+	f, err := os.Create(filepath.Join(dir, "cpu.pprof"))
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create cpu.pprof: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return "", func() {}, fmt.Errorf("StartCPUProfile: %w", err)
+	}
+	return dir, func() { pprof.StopCPUProfile(); _ = f.Close() }, nil
+}
+
+func writeHeapProfile(dir string) error {
+	runtime.GC()
+	f, err := os.Create(filepath.Join(dir, "heap.pprof"))
+	if err != nil {
+		return fmt.Errorf("create heap.pprof: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("WriteHeapProfile: %w", err)
+	}
+	return nil
+}
+
+// driveWorkload runs the selected workload and returns bytes written.
+func driveWorkload(ctx context.Context, bs *engine.BlockStore, cfg config) (int64, error) {
+	files := max(cfg.workingSet, 1)
+	buf := seededBytes(cfg.seed, cfg.blockSize)
+	rng := rand.New(rand.NewPCG(cfg.seed, 0))
+
+	switch cfg.workload {
+	case "sequential-write":
+		var off uint64
+		return runLoop(cfg, func(i int) (int, error) {
+			buf[0] = byte(i)
+			pid := fmt.Sprintf("perf/seq/%d", i%files)
+			_, err := bs.WriteAt(ctx, pid, nil, buf, off)
+			off += uint64(len(buf))
+			return len(buf), err
+		})
+	case "random-write":
+		const fileSize = 64 * 1024 * 1024
+		maxOff, err := seedAndOffsetCap(ctx, bs, files, "perf/rand", cfg, fileSize)
+		if err != nil {
+			return 0, err
+		}
+		return runLoop(cfg, func(i int) (int, error) {
+			buf[0] = byte(i)
+			pid := fmt.Sprintf("perf/rand/%d", i%files)
+			_, err := bs.WriteAt(ctx, pid, nil, buf, rng.Uint64N(maxOff+1))
+			return len(buf), err
+		})
+	case "dedup-heavy":
+		// Same block bytes -> distinct file per op exercises file-level dedup.
+		return runLoop(cfg, func(i int) (int, error) {
+			pid := fmt.Sprintf("perf/dedup/%d", i)
+			if _, err := bs.WriteAt(ctx, pid, nil, buf, 0); err != nil {
+				return 0, err
+			}
+			_, err := bs.Flush(ctx, pid)
+			return len(buf), err
+		})
+	case "mixed-rw":
+		const fileSize = 32 * 1024 * 1024
+		maxOff, err := seedAndOffsetCap(ctx, bs, files, "perf/mixed", cfg, fileSize)
+		if err != nil {
+			return 0, err
+		}
+		rbuf := make([]byte, cfg.blockSize)
+		return runLoop(cfg, func(i int) (int, error) {
+			off := rng.Uint64N(maxOff + 1)
+			pid := fmt.Sprintf("perf/mixed/%d", i%files)
+			if i%2 == 0 {
+				buf[0] = byte(i)
+				_, err := bs.WriteAt(ctx, pid, nil, buf, off)
+				return len(buf), err
+			}
+			_, err := bs.ReadAt(ctx, pid, nil, rbuf, off)
+			return 0, err
+		})
+	case "flush-churn":
+		var off uint64
+		return runLoop(cfg, func(i int) (int, error) {
+			buf[0] = byte(i)
+			pid := fmt.Sprintf("perf/churn/%d", i%files)
+			if _, err := bs.WriteAt(ctx, pid, nil, buf, off); err != nil {
+				return 0, err
+			}
+			if _, err := bs.Flush(ctx, pid); err != nil {
+				return 0, err
+			}
+			off += uint64(len(buf))
+			return len(buf), nil
+		})
+	default:
+		return 0, fmt.Errorf("unknown workload %q", cfg.workload)
+	}
+}
+
+func runLoop(cfg config, step func(i int) (int, error)) (int64, error) {
+	var total int64
+	for i := 0; i < cfg.ops; i++ {
+		n, err := step(i)
+		if err != nil {
+			return total, fmt.Errorf("%s op=%d: %w", cfg.workload, i, err)
+		}
+		total += int64(n)
+	}
+	return total, nil
+}
+
+// seedAndOffsetCap seeds N payloads of `size` bytes and returns the max
+// legal write offset (size-blockSize). Errors when blockSize > size
+// (would otherwise underflow when cast to uint64).
+func seedAndOffsetCap(ctx context.Context, bs *engine.BlockStore, files int, prefix string, cfg config, size int) (uint64, error) {
+	if cfg.blockSize > size {
+		return 0, fmt.Errorf("%s: --block-size %d exceeds seeded file size %d", cfg.workload, cfg.blockSize, size)
+	}
+	data := seededBytes(cfg.seed^0x9E3779B97F4A7C15, size)
+	for i := 0; i < files; i++ {
+		pid := fmt.Sprintf("%s/%d", prefix, i)
+		if _, err := bs.WriteAt(ctx, pid, nil, data, 0); err != nil {
+			return 0, fmt.Errorf("seed %s: %w", pid, err)
+		}
+	}
+	return uint64(size - cfg.blockSize), nil
+}
+
+// seededBytes returns `size` deterministic PRNG bytes for the given seed.
+func seededBytes(seed uint64, size int) []byte {
+	rng := rand.New(rand.NewPCG(seed, 0))
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = byte(rng.Uint32())
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Implements wave B-H1 of the v1.0 audit (see `.planning/v1.0-audit/blockstore/REVIEW.md` §8 Wave B-H, line 264-267): a standalone benchmark harness for `pkg/blockstore/engine` that composes production-equivalent wiring (FSStore local + memory remote + in-memory metadata + Syncer) and drives one of five deterministic workloads, capturing wall-clock duration, throughput, and CPU + heap pprof.

## Workloads

| name | shape |
|------|-------|
| `sequential-write` | N × 8 MiB sequential writes to one file |
| `random-write` | N × 4 KiB writes at PRNG-seeded offsets — macOS NFS pattern |
| `dedup-heavy` | N writes of the same block to N distinct files (file-level dedup path) |
| `mixed-rw` | 50/50 random reads/writes over a working set |
| `flush-churn` | tight write → flush → write loops (syncer mirror loop) |

## Flags

```
--workload <name>          required
--ops <N>                  default 10000
--block-size <bytes>       default 8 MiB for seq/dedup, 4 KiB for the rest
--working-set <files>      default 1
--profile-dir <path>       default _profiles/
--seed <int>               default 1 (deterministic PRNG)
```

## Sample invocation

```sh
go run ./cmd/blockstore-perf --workload random-write --ops 5000 --seed 17
```

Output:

```
workload=random-write ops=5000 dur=633.422ms ops_per_sec=78.94 bytes_per_sec=323322.82 profiles=_profiles/random-write-20260529T135617Z
stats before/after: files=0/0 dirty=0/0 disk=0/0 pending=0 completed=0
```

## Notes

- pprof output (`cpu.pprof`, `heap.pprof`) lands in `_profiles/<workload>-<timestamp>/` — `_profiles/` added to `.gitignore`.
- 299 LoC, under the 300-line cap.
- Single-file binary using the stdlib `flag` package — no Cobra to keep the surface lean.

## Test plan

- [x] `gofmt -s -w` clean
- [x] `go vet ./cmd/blockstore-perf/...` clean
- [x] `golangci-lint run ./cmd/blockstore-perf/... --timeout=5m` clean
- [x] `go build ./cmd/blockstore-perf/...` succeeds
- [x] Smoke: `go run ./cmd/blockstore-perf --workload sequential-write --ops 100` — pprof dir created, both `cpu.pprof` and `heap.pprof` non-empty
- [x] Smoke: `go run ./cmd/blockstore-perf --workload random-write --ops 50` — completes with stats output