### PR TITLE
fix(snapshot): multi-pass block-ref data loss (#789), local-only create (#791), verify race (#790) + manifest/restore/DX

### DIFF
--- a/cmd/dfsctl/commands/share/snapshot/client.go
+++ b/cmd/dfsctl/commands/share/snapshot/client.go
@@ -2,6 +2,8 @@ package snapshot
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
@@ -25,4 +27,37 @@ type snapshotClient interface {
 // authenticated client from the credential store.
 var getClient = func() (snapshotClient, error) {
 	return cmdutil.GetAuthenticatedClient()
+}
+
+// resolveSnapshotID resolves a possibly-partial snapshot id to a full id by
+// unique prefix match against the share's snapshots (git-style). An exact
+// match always wins. A unique prefix resolves; an ambiguous or unknown
+// prefix is a clear error. This lets operators paste the 8-char id printed
+// by `list` into show/delete/restore/--retry.
+func resolveSnapshotID(client snapshotClient, share, partial string) (string, error) {
+	if partial == "" {
+		return "", fmt.Errorf("snapshot id is required")
+	}
+	snaps, err := client.ListSnapshots(share)
+	if err != nil {
+		return "", fmt.Errorf("failed to list snapshots for id resolution: %w", err)
+	}
+	var matches []string
+	for _, s := range snaps {
+		if s.ID == partial {
+			return s.ID, nil // exact match short-circuits ambiguity
+		}
+		if strings.HasPrefix(s.ID, partial) {
+			matches = append(matches, s.ID)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("no snapshot on share %q matches id %q", share, partial)
+	default:
+		return "", fmt.Errorf("snapshot id %q is ambiguous on share %q (%d matches: %s)",
+			partial, share, len(matches), strings.Join(matches, ", "))
+	}
 }

--- a/cmd/dfsctl/commands/share/snapshot/create.go
+++ b/cmd/dfsctl/commands/share/snapshot/create.go
@@ -50,6 +50,17 @@ func init() {
 	createCmd.Flags().BoolVar(&createNoWait, "no-wait", false, "Return immediately instead of waiting for completion")
 }
 
+// noWaitRecord builds a Snapshot record from the 202 create response so the
+// --no-wait JSON/YAML output carries an `id` field consistent with the
+// blocking path (which emits the full Snapshot).
+func noWaitRecord(resp *apiclient.CreateSnapshotResponse) apiclient.Snapshot {
+	return apiclient.Snapshot{
+		ID:    resp.SnapshotID,
+		Share: resp.Share,
+		State: "creating",
+	}
+}
+
 func runCreate(cmd *cobra.Command, args []string) error {
 	share := args[0]
 
@@ -83,11 +94,15 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if createNoWait {
+		// Emit a Snapshot-shaped record so the JSON/YAML shape matches the
+		// blocking path: `jq '.id'` works regardless of --no-wait. The
+		// server returns only {snapshot_id, share} on the 202, so synthesize
+		// the known fields (the snapshot is necessarily 'creating' here).
 		switch format {
 		case output.FormatJSON:
-			return output.PrintJSON(os.Stdout, resp)
+			return output.PrintJSON(os.Stdout, noWaitRecord(resp))
 		case output.FormatYAML:
-			return output.PrintYAML(os.Stdout, resp)
+			return output.PrintYAML(os.Stdout, noWaitRecord(resp))
 		default:
 			fmt.Printf("Snapshot %s queued on share %s (state: creating)\n", resp.SnapshotID, resp.Share)
 		}

--- a/cmd/dfsctl/commands/share/snapshot/create.go
+++ b/cmd/dfsctl/commands/share/snapshot/create.go
@@ -58,10 +58,20 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve a possibly-partial --retry id (e.g. the 8-char id from list)
+	// to a full UUID before the server's exact-match retry lookup.
+	retryOf := createRetry
+	if retryOf != "" {
+		retryOf, err = resolveSnapshotID(client, share, retryOf)
+		if err != nil {
+			return err
+		}
+	}
+
 	resp, err := client.CreateSnapshot(share, apiclient.CreateSnapshotRequest{
 		Name:     createName,
 		NoVerify: createNoVerify,
-		RetryOf:  createRetry,
+		RetryOf:  retryOf,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot: %w", err)

--- a/cmd/dfsctl/commands/share/snapshot/create_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/create_test.go
@@ -1,0 +1,53 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+func resetCreateFlags() {
+	createName = ""
+	createNoVerify = false
+	createRetry = ""
+	createNoWait = false
+}
+
+// TestCreate_NoWaitJSONHasIDField asserts the --no-wait JSON output carries
+// an `id` field (consistent with the blocking path) so `jq '.id'` works.
+func TestCreate_NoWaitJSONHasIDField(t *testing.T) {
+	resetCreateFlags()
+	createNoWait = true
+	cmdutil.Flags.Output = "json"
+	t.Cleanup(func() { cmdutil.Flags.Output = "" })
+
+	fc := &fakeClient{
+		createResp: &apiclient.CreateSnapshotResponse{SnapshotID: "snap-xyz", Share: "/archive"},
+	}
+	withFakeClient(t, fc)
+
+	prev := osStdout()
+	r, w := setStdout()
+	defer restoreStdout(prev)
+
+	if err := runCreate(createCmd, []string{"/archive"}); err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var obj map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, buf.String())
+	}
+	if obj["id"] != "snap-xyz" {
+		t.Fatalf("json id = %v, want snap-xyz (full body: %s)", obj["id"], buf.String())
+	}
+	if obj["state"] != "creating" {
+		t.Fatalf("json state = %v, want creating", obj["state"])
+	}
+}

--- a/cmd/dfsctl/commands/share/snapshot/delete.go
+++ b/cmd/dfsctl/commands/share/snapshot/delete.go
@@ -31,6 +31,16 @@ func init() {
 func runDelete(cmd *cobra.Command, args []string) error {
 	share, id := args[0], args[1]
 
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	id, err = resolveSnapshotID(client, share, id)
+	if err != nil {
+		return err
+	}
+
 	prompt := fmt.Sprintf("Delete snapshot %s from share %s? This cannot be undone.", id, share)
 	ok, err := cmdutil.ConfirmDestructive(prompt, deleteYes)
 	if err != nil {
@@ -39,11 +49,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if !ok {
 		fmt.Println("Aborted.")
 		return nil
-	}
-
-	client, err := getClient()
-	if err != nil {
-		return err
 	}
 
 	if err := client.DeleteSnapshot(share, id); err != nil {

--- a/cmd/dfsctl/commands/share/snapshot/list.go
+++ b/cmd/dfsctl/commands/share/snapshot/list.go
@@ -132,8 +132,40 @@ func applyFilters(snaps []apiclient.Snapshot, state, namePrefix string) []apicli
 	return out
 }
 
+// validateState rejects a --state filter that is not a known snapshot
+// state, so a typo errors loudly instead of silently returning nothing.
+func validateState(state string) error {
+	switch state {
+	case "", "creating", "ready", "failed":
+		return nil
+	default:
+		return fmt.Errorf("invalid --state %q: must be one of creating, ready, failed", state)
+	}
+}
+
+// emptyListMessage describes an empty result, reflecting any active filters
+// so the operator knows the share may have snapshots that the filter
+// excluded.
+func emptyListMessage(share, state, namePrefix string) string {
+	var filters []string
+	if state != "" {
+		filters = append(filters, fmt.Sprintf("state=%s", state))
+	}
+	if namePrefix != "" {
+		filters = append(filters, fmt.Sprintf("name-prefix=%s", namePrefix))
+	}
+	if len(filters) == 0 {
+		return fmt.Sprintf("No snapshots on share %q.", share)
+	}
+	return fmt.Sprintf("No snapshots on share %q matching %s.", share, strings.Join(filters, ", "))
+}
+
 func runList(cmd *cobra.Command, args []string) error {
 	share := args[0]
+
+	if err := validateState(listState); err != nil {
+		return err
+	}
 
 	client, err := getClient()
 	if err != nil {
@@ -170,7 +202,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			})
 		}
 		if len(rows) == 0 {
-			fmt.Printf("No snapshots on share %q.\n", share)
+			fmt.Println(emptyListMessage(share, listState, listNamePrefix))
 			return nil
 		}
 		return output.PrintTable(os.Stdout, rows)

--- a/cmd/dfsctl/commands/share/snapshot/list_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/list_test.go
@@ -31,6 +31,40 @@ func TestList_EmptyTable(t *testing.T) {
 	}
 }
 
+func TestList_InvalidStateErrors(t *testing.T) {
+	resetListFlags()
+	listState = "redy" // typo
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{}}
+	withFakeClient(t, fc)
+	cmdutil.Flags.Output = "table"
+
+	err := runList(listCmd, []string{"/archive"})
+	if err == nil || !strings.Contains(err.Error(), "invalid --state") {
+		t.Fatalf("err = %v, want invalid --state error", err)
+	}
+}
+
+func TestList_EmptyMessageReflectsFilters(t *testing.T) {
+	resetListFlags()
+	listState = "ready"
+	listNamePrefix = "wk"
+	// A creating snapshot exists but the ready+wk filter excludes it.
+	fc := &fakeClient{listOverride: []apiclient.Snapshot{
+		{ID: "x", State: "creating", CreatedAt: time.Now()},
+	}}
+	withFakeClient(t, fc)
+
+	got := emptyListMessage("/archive", listState, listNamePrefix)
+	if !strings.Contains(got, "state=ready") || !strings.Contains(got, "name-prefix=wk") {
+		t.Fatalf("empty message %q does not reflect active filters", got)
+	}
+	// No-filter case keeps the plain message.
+	plain := emptyListMessage("/archive", "", "")
+	if strings.Contains(plain, "matching") {
+		t.Fatalf("plain message unexpectedly mentions filters: %q", plain)
+	}
+}
+
 func TestList_FilterByState(t *testing.T) {
 	resetListFlags()
 	listState = "ready"

--- a/cmd/dfsctl/commands/share/snapshot/resolve_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/resolve_test.go
@@ -1,0 +1,83 @@
+package snapshot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+func TestResolveSnapshotID_UniquePrefix(t *testing.T) {
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{
+		"abc12345-aaaa": {ID: "abc12345-aaaa"},
+		"def67890-bbbb": {ID: "def67890-bbbb"},
+	}}
+	got, err := resolveSnapshotID(fc, "/a", "abc12345")
+	if err != nil {
+		t.Fatalf("resolveSnapshotID: %v", err)
+	}
+	if got != "abc12345-aaaa" {
+		t.Fatalf("got %q, want abc12345-aaaa", got)
+	}
+}
+
+func TestResolveSnapshotID_ExactMatchWins(t *testing.T) {
+	// One id is a prefix of another; the exact match must short-circuit
+	// instead of reporting ambiguity.
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{
+		"abc":     {ID: "abc"},
+		"abc1234": {ID: "abc1234"},
+	}}
+	got, err := resolveSnapshotID(fc, "/a", "abc")
+	if err != nil {
+		t.Fatalf("resolveSnapshotID: %v", err)
+	}
+	if got != "abc" {
+		t.Fatalf("got %q, want abc", got)
+	}
+}
+
+func TestResolveSnapshotID_Ambiguous(t *testing.T) {
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{
+		"abc111": {ID: "abc111"},
+		"abc222": {ID: "abc222"},
+	}}
+	_, err := resolveSnapshotID(fc, "/a", "abc")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("err = %v, want ambiguous error", err)
+	}
+}
+
+func TestResolveSnapshotID_NotFound(t *testing.T) {
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{
+		"abc111": {ID: "abc111"},
+	}}
+	_, err := resolveSnapshotID(fc, "/a", "zzz")
+	if err == nil || !strings.Contains(err.Error(), "no snapshot") {
+		t.Fatalf("err = %v, want not-found error", err)
+	}
+}
+
+// TestDelete_ResolvesPartialID asserts delete resolves an 8-char prefix to
+// the full UUID before calling DeleteSnapshot.
+func TestDelete_ResolvesPartialID(t *testing.T) {
+	resetDeleteFlags()
+	deleteYes = true
+	fc := &fakeClient{snapshots: map[string]*apiclient.Snapshot{
+		"abc12345-full-uuid": {ID: "abc12345-full-uuid"},
+	}}
+	withFakeClient(t, fc)
+
+	prev := osStdout()
+	_, w := setStdout()
+	defer restoreStdout(prev)
+
+	if err := runDelete(deleteCmd, []string{"/a", "abc12345"}); err != nil {
+		t.Fatalf("runDelete: %v", err)
+	}
+	_ = w.Close()
+
+	if len(fc.deleteCalls) != 1 || fc.deleteCalls[0] != "abc12345-full-uuid" {
+		t.Fatalf("DeleteSnapshot called with %v, want [abc12345-full-uuid]", fc.deleteCalls)
+	}
+}

--- a/cmd/dfsctl/commands/share/snapshot/restore.go
+++ b/cmd/dfsctl/commands/share/snapshot/restore.go
@@ -52,6 +52,11 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	id, err = resolveSnapshotID(client, share, id)
+	if err != nil {
+		return err
+	}
+
 	// Pre-flight: refuse on enabled share with the exact hint string.
 	s, err := client.GetShare(share)
 	if err != nil {

--- a/cmd/dfsctl/commands/share/snapshot/restore_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/restore_test.go
@@ -34,7 +34,8 @@ func TestRestore_RefusesEnabledShare(t *testing.T) {
 	resetRestoreFlags()
 	restoreYes = true
 	fc := &fakeClient{
-		share: &apiclient.Share{Name: "/archive", Enabled: true},
+		share:     &apiclient.Share{Name: "/archive", Enabled: true},
+		snapshots: map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 	}
 	withFakeClient(t, fc)
 
@@ -59,7 +60,8 @@ func TestRestore_DisabledShareYesFlag_PrintsSafetySnap(t *testing.T) {
 	resetRestoreFlags()
 	restoreYes = true
 	fc := &fakeClient{
-		share: &apiclient.Share{Name: "/archive", Enabled: false},
+		share:     &apiclient.Share{Name: "/archive", Enabled: false},
+		snapshots: map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 		restoreResp: &apiclient.RestoreSnapshotResponse{
 			SnapshotID: "snap-1", Share: "/archive", SafetySnapshotID: "safety-abc",
 		},
@@ -90,7 +92,8 @@ func TestRestore_NoSafetySnapID_OmitsLine(t *testing.T) {
 	resetRestoreFlags()
 	restoreYes = true
 	fc := &fakeClient{
-		share: &apiclient.Share{Name: "/archive", Enabled: false},
+		share:     &apiclient.Share{Name: "/archive", Enabled: false},
+		snapshots: map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 		restoreResp: &apiclient.RestoreSnapshotResponse{
 			SnapshotID: "snap-1", Share: "/archive", SafetySnapshotID: "",
 		},
@@ -119,6 +122,7 @@ func TestRestore_PreconditionFailedHint(t *testing.T) {
 	restoreYes = true
 	fc := &fakeClient{
 		share:      &apiclient.Share{Name: "/archive", Enabled: false},
+		snapshots:  map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 		restoreErr: &apiclient.APIError{Code: "PRECONDITION_FAILED", Message: "not durable", StatusCode: 412},
 	}
 	withFakeClient(t, fc)
@@ -141,7 +145,8 @@ func TestRestore_ForceMapsToAllowNonDurable(t *testing.T) {
 	restoreYes = true
 	restoreForce = true
 	fc := &fakeClient{
-		share: &apiclient.Share{Name: "/archive", Enabled: false},
+		share:     &apiclient.Share{Name: "/archive", Enabled: false},
+		snapshots: map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 		restoreResp: &apiclient.RestoreSnapshotResponse{
 			SnapshotID: "snap-1", Share: "/archive", SafetySnapshotID: "safety-abc",
 		},
@@ -170,7 +175,8 @@ func TestRestore_DisabledShareNAnswerAborts(t *testing.T) {
 	defer func() { cmdutil.ConfirmInput, cmdutil.ConfirmOutput = origIn, origOut }()
 
 	fc := &fakeClient{
-		share: &apiclient.Share{Name: "/archive", Enabled: false},
+		share:     &apiclient.Share{Name: "/archive", Enabled: false},
+		snapshots: map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
 	}
 	withFakeClient(t, fc)
 

--- a/cmd/dfsctl/commands/share/snapshot/show.go
+++ b/cmd/dfsctl/commands/share/snapshot/show.go
@@ -25,6 +25,11 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	id, err = resolveSnapshotID(client, share, id)
+	if err != nil {
+		return err
+	}
+
 	snap, err := client.GetSnapshot(share, id)
 	if err != nil {
 		return fmt.Errorf("failed to get snapshot: %w", err)

--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -60,9 +60,13 @@ Each snapshot is three artifacts on disk:
 ```
 <localStoreDir>/snapshots/<share>/<snap-id>/
   ├─ metadata.dump          ← engine-native serialization of the metadata store
-  ├─ manifest.json          ← BLAKE3 hashes of every CAS block the share references
+  ├─ manifest.hashes        ← BLAKE3 hashes of every CAS block the share references
   └─ (GC hold)              ← implicit: manifest-on-disk = held
 ```
+
+The manifest is a plain-text file, not JSON: one 64-character
+lowercase-hex BLAKE3 hash per line, LF-terminated, sorted in ascending
+byte order. There is no header, footer, or comment.
 
 The GC hold is **implicit** — there is no separate hold flag in any
 database table. Garbage collection enumerates every manifest file
@@ -111,8 +115,8 @@ Every command accepts the global `--output, -o` flag (`table|json|yaml`).
 
 ```text
 $ dfsctl share snapshot create /photos
-Snapshot 7a3ec1b2 created (state: creating)
-→ ready (3s)
+Snapshot 7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0 queued on share /photos (state: creating)
+Snapshot 7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0 -> ready
 $
 ```
 
@@ -121,10 +125,10 @@ By default the command blocks until the snapshot reaches `ready` or
 
 ```text
 $ dfsctl share snapshot create /photos --no-wait
-Snapshot 9f2dab17 created (state: creating)
-$ dfsctl share snapshot show /photos 9f2dab17
-ID            9f2dab17-...
-State         creating
+Snapshot 9f2dab17-1a8c-4e02-b6d4-0c2f7a91e3b5 queued on share /photos (state: creating)
+$ dfsctl share snapshot show /photos 9f2dab17-1a8c-4e02-b6d4-0c2f7a91e3b5
+ID              9f2dab17-1a8c-4e02-b6d4-0c2f7a91e3b5
+STATE           creating
 ...
 ```
 
@@ -158,22 +162,24 @@ $ dfsctl share snapshot list /photos -o json
 ### Worked transcript: show
 
 ```text
-$ dfsctl share snapshot show /photos 7a3ec1b2
+$ dfsctl share snapshot show /photos 7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0
 ID              7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0
-Name            weekly-2026-05
-Share           /photos
-State           ready
-Durable         yes
-Manifest        1842 blocks
-Dump            4.1 MiB
-Created         2026-05-27T18:14:22Z
-Updated         2026-05-27T18:14:25Z
-ManifestPath    /var/lib/dittofs/snapshots/photos/7a3ec1b2.../manifest.json
-DumpPath        /var/lib/dittofs/snapshots/photos/7a3ec1b2.../metadata.dump
+NAME            weekly-2026-05
+SHARE           /photos
+STATE           ready
+REMOTE DURABLE  yes
+MANIFEST COUNT  1842
+DUMP BYTES      4.1 MiB
+RETRY OF        -
+ERROR           -
+CREATED AT      2026-05-27T18:14:22Z
+UPDATED AT      2026-05-27T18:14:25Z
 ```
 
-`show` is the only command that resolves the on-disk manifest and
-dump sizes; `list` omits them to keep the row count cheap.
+`show` requires the **full** snapshot UUID, not the 8-character
+prefix shown in `list` (see §5). It reports the manifest hash count
+(`MANIFEST COUNT`) and the human-readable dump size (`DUMP BYTES`);
+`list` omits them to keep the row count cheap.
 
 ### Worked transcript: delete
 
@@ -210,14 +216,16 @@ dfsctl share snapshot create <share> [flags]
 Normally a snapshot orchestration runs in this order:
 
 1. Persist the snapshot row in `state=creating`.
-2. Drain in-flight uploads to the remote block store.
-3. Write `metadata.dump` from the metadata store.
+2. Drain pending rollups so all written data is persisted to CAS and
+   reflected in each file's block list.
+3. Write `metadata.dump` from the now-settled metadata store.
 4. Compute the hash manifest from the share's referenced blocks.
-5. Run the verify gate: HEAD-probe every block hash on the remote
+5. Drain in-flight uploads to the remote block store.
+6. Run the verify gate: HEAD-probe every block hash on the remote
    block store (concurrency = 16) to confirm remote durability.
-6. Transition to `state=ready` (or `state=failed` on any error).
+7. Transition to `state=ready` (or `state=failed` on any error).
 
-`--no-verify` skips step 2 (upload drain) and step 5 (HEAD probes).
+`--no-verify` skips step 5 (upload drain) and step 6 (HEAD probes).
 The snapshot still completes, the GC hold still applies, but the
 `remote_durable` flag is `false`. Use it when:
 
@@ -247,9 +255,9 @@ $ dfsctl share snapshot list /photos --state=failed
 ID         NAME       STATE    DURABLE  CREATED  SIZE
 4c19fbe0   nightly    failed   no       6h ago   -
 
-$ dfsctl share snapshot create /photos --retry 4c19fbe0
-Snapshot 4c19fbe0 created (state: creating)
-→ ready (12s)
+$ dfsctl share snapshot create /photos --retry 4c19fbe0-...-full-uuid
+Snapshot 4c19fbe0-...-full-uuid queued on share /photos (state: creating)
+Snapshot 4c19fbe0-...-full-uuid -> ready
 ```
 
 Retry refuses if the target ID does not exist (`404`) or is not in
@@ -278,23 +286,30 @@ flag; the list is always newest-first.
 
 | Column | Meaning |
 |---|---|
-| `ID` | First 8 characters of the snapshot UUID. Use `show` for the full ID. |
+| `ID` | First 8 characters of the snapshot UUID — **truncated for display only**. See the note below. |
 | `NAME` | Operator-set name from `--name`. Blank if unset. |
 | `STATE` | `creating` / `ready` / `failed`. |
 | `DURABLE` | `yes` if `remote_durable=true`; `no` otherwise. |
 | `CREATED` | Relative time by default; ISO with `--no-relative`. |
-| `SIZE` | Manifest hash count, but always `-` in list mode. Use `show` to see the count. |
+| `SIZE` | Dump size, but always `-` in list mode — the list handler does not stat artifacts. Use `show` to see it. |
+
+> **The `ID` column is truncated to 8 characters for readability, but
+> `show`, `delete`, `restore`, and `create --retry` all require the
+> *full* snapshot UUID.** Passing the 8-character prefix returns
+> `404 ErrSnapshotNotFound` — the server matches snapshot IDs exactly
+> and does not resolve prefixes. Get the full UUID from `list -o json`
+> (the `id` field is never truncated).
 
 The `SIZE` column is `-` in `list` because populating it would
 require one `stat` per row (the manifest lives on disk, not in the
 database). `show` resolves it on demand for a single record:
 
 ```text
-$ dfsctl share snapshot show /photos 7a3ec1b2
+$ dfsctl share snapshot show /photos 7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0
 ID              7a3ec1b2-9c5e-4ab8-bd31-7f60c2e814a0
 ...
-Manifest        1842 blocks
-Dump            4.1 MiB
+MANIFEST COUNT  1842
+DUMP BYTES      4.1 MiB
 ...
 ```
 
@@ -531,19 +546,28 @@ gone). Setting an internal SOP for deletion keeps that bounded.
 ## 9. The verify gate
 
 The verify gate is the optional remote-durability check inside
-snapshot create. It runs in two parts:
+snapshot create. The full create pipeline runs in this order so that
+the manifest reflects every block the share actually references and
+every referenced block is proven durable on the remote:
 
-- **Drain.** Block in flight uploads finish before the manifest is
-  computed. If the syncer cannot drain within its configured
-  timeout, create fails with `ErrSnapshotDrainTimeout` (HTTP 504).
-- **HEAD probe.** Every block hash in the manifest is HEAD-probed
-  on the remote block store, with parallelism of 16 in flight.
-  Any missing hash fails the snapshot with `ErrSnapshotVerifyFailed`
-  (HTTP 500, sanitized message).
+1. **Drain rollups.** Pending rollups are flushed so all written data
+   is persisted to CAS and reflected in each file's block list. The
+   manifest computed in the next step is taken from those settled
+   block lists, not from in-flight state.
+2. **Snapshot.** The metadata dump and the hash manifest are written
+   from the now-settled metadata store.
+3. **Drain uploads.** In-flight uploads to the remote block store are
+   drained so every manifest hash has had a chance to land remotely.
+   If the syncer cannot drain within its configured timeout, create
+   fails with `ErrSnapshotDrainTimeout` (HTTP 504).
+4. **HEAD probe.** Every block hash in the manifest is HEAD-probed
+   on the remote block store, with parallelism of 16 in flight.
+   Any missing hash fails the snapshot with `ErrSnapshotVerifyFailed`
+   (HTTP 500, sanitized message).
 
-If both pass, `remote_durable=true` on the snapshot row. If
-`--no-verify` was passed, neither runs and `remote_durable=false`
-without testing.
+If the upload drain and HEAD probe both pass, `remote_durable=true`
+on the snapshot row. If `--no-verify` was passed, steps 3 and 4 are
+skipped and `remote_durable=false` without testing.
 
 The 16-way parallelism is hardcoded. It is well below typical
 remote-store rate limits (S3, R2, Backblaze B2) and large enough
@@ -567,7 +591,7 @@ one rule:
 
 Concretely:
 
-- GC's mark phase enumerates `<localStoreDir>/snapshots/<share>/*/manifest.json`
+- GC's mark phase enumerates `<localStoreDir>/snapshots/<share>/*/manifest.hashes`
   at sweep start and reads every hash referenced inside.
 - Those hashes are unioned with the live `FileAttr.Blocks` hashes
   from the metadata store.

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -49,6 +49,10 @@ func (f *fakeCoordinator) PersistFileBlocks(_ context.Context, payloadID string,
 	return nil
 }
 
+func (f *fakeCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
 // FindByObjectID stub. Adapter-common tests don't exercise short-circuit
 // lookups (those live in pkg/blockstore/engine and pkg/metadata/storetest);
 // satisfy the interface so the fake satisfies engine.MetadataCoordinator.

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -284,6 +284,9 @@ func mapSnapshotError(w http.ResponseWriter, err error) bool {
 	case errors.Is(err, models.ErrSnapshotNotFound):
 		NotFound(w, "snapshot not found")
 		return true
+	case errors.Is(err, models.ErrSnapshotLocalStoreUnsupported):
+		BadRequest(w, "snapshots require an fs-backed local store")
+		return true
 	case errors.Is(err, shares.ErrShareNotFound):
 		NotFound(w, "share not found")
 		return true

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -302,6 +302,9 @@ func mapSnapshotError(w http.ResponseWriter, err error) bool {
 	case errors.Is(err, models.ErrSnapshotRetryTargetNotFailed):
 		Conflict(w, "retry target is not in failed state")
 		return true
+	case errors.Is(err, models.ErrSnapshotInFlight):
+		Conflict(w, "snapshot operation is in progress; retry once it completes")
+		return true
 	case errors.Is(err, models.ErrSnapshotStateConflict):
 		Conflict(w, "snapshot is not in a state that allows this operation")
 		return true

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -319,7 +319,6 @@ func mapSnapshotError(w http.ResponseWriter, err error) bool {
 		return true
 	case errors.Is(err, models.ErrSnapshotBackupFailed),
 		errors.Is(err, models.ErrSnapshotVerifyFailed),
-		errors.Is(err, models.ErrSnapshotManifestIncomplete),
 		errors.Is(err, models.ErrRestoreSafetySnapFailed),
 		errors.Is(err, models.ErrRestoreAborted),
 		errors.Is(err, models.ErrRestoreVerifyFailed):

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -319,6 +319,7 @@ func mapSnapshotError(w http.ResponseWriter, err error) bool {
 		return true
 	case errors.Is(err, models.ErrSnapshotBackupFailed),
 		errors.Is(err, models.ErrSnapshotVerifyFailed),
+		errors.Is(err, models.ErrSnapshotManifestIncomplete),
 		errors.Is(err, models.ErrRestoreSafetySnapFailed),
 		errors.Is(err, models.ErrRestoreAborted),
 		errors.Is(err, models.ErrRestoreVerifyFailed):

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -234,6 +234,7 @@ func (h *SnapshotHandler) toWire(s *models.Snapshot, includeDisk bool) dto.Snaps
 		Share:         s.ShareName,
 		State:         s.State,
 		RemoteDurable: s.RemoteDurable,
+		Error:         s.Error,
 		CreatedAt:     s.CreatedAt,
 		UpdatedAt:     s.UpdatedAt,
 	}

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -127,6 +127,7 @@ func (h *SnapshotHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	snapID, err := h.runtime.CreateSnapshot(r.Context(), name, runtime.CreateSnapshotOpts{
+		Name:     req.Name,
 		NoVerify: req.NoVerify,
 		RetryOf:  req.RetryOf,
 	})
@@ -229,6 +230,7 @@ func (h *SnapshotHandler) Restore(w http.ResponseWriter, r *http.Request) {
 func (h *SnapshotHandler) toWire(s *models.Snapshot, includeDisk bool) dto.Snapshot {
 	out := dto.Snapshot{
 		ID:            s.ID,
+		Name:          s.Name,
 		Share:         s.ShareName,
 		State:         s.State,
 		RemoteDurable: s.RemoteDurable,

--- a/internal/controlplane/api/handlers/snapshot_test.go
+++ b/internal/controlplane/api/handlers/snapshot_test.go
@@ -353,6 +353,7 @@ func TestMapSnapshotError_SentinelTable(t *testing.T) {
 		want int
 	}{
 		{"SnapshotNotFound", models.ErrSnapshotNotFound, http.StatusNotFound},
+		{"LocalStoreUnsupported", models.ErrSnapshotLocalStoreUnsupported, http.StatusBadRequest},
 		{"ShareNotFound", shares.ErrShareNotFound, http.StatusNotFound},
 		{"ShareEnabled", models.ErrShareEnabled, http.StatusConflict},
 		{"SnapshotNotDurable", models.ErrSnapshotNotDurable, http.StatusPreconditionFailed},

--- a/internal/controlplane/api/handlers/snapshot_test.go
+++ b/internal/controlplane/api/handlers/snapshot_test.go
@@ -119,6 +119,56 @@ func TestSnapshotHandler_Create_HappyPath(t *testing.T) {
 	}
 }
 
+// TestSnapshotHandler_Create_ForwardsName asserts the request body's name
+// is forwarded to CreateSnapshotOpts.Name (was previously dropped).
+func TestSnapshotHandler_Create_ForwardsName(t *testing.T) {
+	var gotName string
+	fake := &fakeSnapshotRuntime{
+		createFn: func(_ context.Context, _ string, opts runtime.CreateSnapshotOpts) (string, error) {
+			gotName = opts.Name
+			return "snap-1", nil
+		},
+	}
+	h := NewSnapshotHandler(fake, 30*time.Second, nil)
+	body := bytes.NewBufferString(`{"name":"weekly"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares/data/snapshots/", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	newSnapshotRouter(h).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: body=%s", rr.Code, rr.Body.String())
+	}
+	if gotName != "weekly" {
+		t.Fatalf("opts.Name = %q, want weekly", gotName)
+	}
+}
+
+// TestSnapshotHandler_Get_IncludesName asserts the model's Name is surfaced
+// in the wire DTO on the show endpoint.
+func TestSnapshotHandler_Get_IncludesName(t *testing.T) {
+	fake := &fakeSnapshotRuntime{
+		getFn: func(_ context.Context, _, snapID string) (*models.Snapshot, error) {
+			return &models.Snapshot{ID: snapID, Name: "weekly", ShareName: "/data", State: models.StateReady}, nil
+		},
+	}
+	h := NewSnapshotHandler(fake, 30*time.Second, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shares/data/snapshots/snap-1", nil)
+	rr := httptest.NewRecorder()
+	newSnapshotRouter(h).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got dto.Snapshot
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Name != "weekly" {
+		t.Fatalf("name = %q, want weekly", got.Name)
+	}
+}
+
 func TestSnapshotHandler_List_EmptyArrayNotNull(t *testing.T) {
 	fake := &fakeSnapshotRuntime{
 		listFn: func(_ context.Context, _ string) ([]*models.Snapshot, error) {

--- a/internal/controlplane/api/handlers/snapshot_test.go
+++ b/internal/controlplane/api/handlers/snapshot_test.go
@@ -360,6 +360,7 @@ func TestMapSnapshotError_SentinelTable(t *testing.T) {
 		{"RetryTargetNotFound", models.ErrSnapshotRetryTargetNotFound, http.StatusNotFound},
 		{"RetryTargetNotFailed", models.ErrSnapshotRetryTargetNotFailed, http.StatusConflict},
 		{"StateConflict", models.ErrSnapshotStateConflict, http.StatusConflict},
+		{"InFlight", models.ErrSnapshotInFlight, http.StatusConflict},
 		{"DrainTimeout", models.ErrSnapshotDrainTimeout, http.StatusGatewayTimeout},
 		{"MetadataDumpMissing", models.ErrSnapshotMetadataDumpMissing, http.StatusInternalServerError},
 		{"MetadataStoreNotResetable", models.ErrMetadataStoreNotResetable, http.StatusInternalServerError},

--- a/pkg/blockstore/engine/coordinator.go
+++ b/pkg/blockstore/engine/coordinator.go
@@ -52,6 +52,19 @@ type MetadataCoordinator interface {
 	// Flush semantics).
 	PersistFileBlocks(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error
 
+	// GetPersistedBlocks returns the file's currently-persisted
+	// FileAttr.Blocks (with content hashes) for payloadID, or an empty
+	// slice when the file has no blocks yet / does not exist. The
+	// rollup-completion callback reads this to merge a partial rollup
+	// pass into the already-committed block list before calling
+	// PersistFileBlocks, so a multi-pass rollup keeps FileAttr.Blocks
+	// complete instead of replacing it with only the latest pass (#789).
+	//
+	// Reads the manifest source (file_block_refs on Postgres, encoded
+	// FileAttr.Blocks on Badger/Memory) — NOT the per-file FileBlock
+	// index, whose Pending rows carry a NULL hash on Postgres.
+	GetPersistedBlocks(ctx context.Context, payloadID string) ([]blockstore.BlockRef, error)
+
 	// FindByObjectID looks up a previously-quiesced file in the
 	// metadata store by Merkle-root ObjectID. Returns (nil, nil) on
 	// miss. Used by the file-level dedup short-circuit

--- a/pkg/blockstore/engine/coordinator_test.go
+++ b/pkg/blockstore/engine/coordinator_test.go
@@ -112,6 +112,10 @@ func (f *fakeCoordinator) DecrementRefCount(_ context.Context, hash blockstore.C
 	return 0, nil
 }
 
+func (f *fakeCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
 func (f *fakeCoordinator) PersistFileBlocks(_ context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/blockstore/engine/drain_multipass_test.go
+++ b/pkg/blockstore/engine/drain_multipass_test.go
@@ -1,0 +1,125 @@
+package engine_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// loggingCoordinator wraps testCoordinator to record every PersistFileBlocks
+// call so a multi-pass rollup is observable: how many calls, and the block
+// offsets carried by each.
+type loggingCoordinator struct {
+	*testCoordinator
+	t     *testing.T
+	calls [][]blockstore.BlockRef
+}
+
+func (c *loggingCoordinator) PersistFileBlocks(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
+	offs := make([]uint64, len(blocks))
+	for i, b := range blocks {
+		offs[i] = b.Offset
+	}
+	c.t.Logf("PersistFileBlocks(payload=%s, nblocks=%d, offsets=%v, objID=%s)",
+		payloadID, len(blocks), offs, objectID.String()[:12])
+	cp := append([]blockstore.BlockRef(nil), blocks...)
+	c.calls = append(c.calls, cp)
+	return c.testCoordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID)
+}
+
+// runMultiPassAppend writes a file in TWO separate write+drain cycles at
+// DISTINCT offsets (a real append), forcing two rollup passes, then asserts
+// the persisted FileAttr.Blocks cover the WHOLE file [0, size) — not just the
+// last pass's region. This is the assertion prior conformance tests lacked
+// (they checked fileBlocks ⊆ manifest, both derived from the same replaced
+// rows, so a replace-loses-prior-passes bug stayed invisible).
+func runMultiPassAppend(t *testing.T, ms metadata.MetadataStore, sharePrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shareName := sharePrefix + "-mp"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	const half = 2 * 1024 * 1024
+	first := distinctContent(0x40, half)
+	second := distinctContent(0x41, half)
+
+	pid, h := createRealFile(t, ms, shareName, "append.bin", rootHandle)
+
+	// Pass 1: write [0, 2MB), drain.
+	if _, err := bs.WriteAt(ctx, pid, nil, first, 0); err != nil {
+		t.Fatalf("WriteAt pass1: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups pass1: %v", err)
+	}
+	p1 := fileBlocks(t, ms, h)
+	t.Logf("after pass1: fileBlocks=%d", len(p1))
+
+	// Pass 2: append [2MB, 4MB), drain.
+	if _, err := bs.WriteAt(ctx, pid, nil, second, half); err != nil {
+		t.Fatalf("WriteAt pass2: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups pass2: %v", err)
+	}
+	p2 := fileBlocks(t, ms, h)
+	t.Logf("after pass2: fileBlocks=%d", len(p2))
+
+	// Probe the per-file FileBlock index (the read-path source) to see if
+	// IT accumulates across passes even though FileAttr.Blocks does not.
+	if fbl, ok := ms.(interface {
+		ListFileBlocks(context.Context, string) ([]*metadata.FileBlock, error)
+	}); ok {
+		rows, err := fbl.ListFileBlocks(ctx, pid)
+		if err != nil {
+			t.Logf("ListFileBlocks err: %v", err)
+		} else {
+			roffs := make([]uint64, 0, len(rows))
+			for _, r := range rows {
+				if off, ok := blockstore.ParseChunkOffset(r.ID); ok {
+					roffs = append(roffs, off)
+				}
+			}
+			t.Logf("after pass2: FileBlock-index rows=%d offsets=%v", len(rows), roffs)
+		}
+	}
+
+	// Assert the persisted blocks cover the whole [0, 4MB) byte range
+	// contiguously. A replace-loses-prior-passes bug leaves a hole at the
+	// front (only [2MB,4MB) survives).
+	blocks := append([]blockstore.BlockRef(nil), p2...)
+	sort.Slice(blocks, func(i, j int) bool { return blocks[i].Offset < blocks[j].Offset })
+	var cursor uint64
+	for _, b := range blocks {
+		if b.Offset != cursor {
+			t.Fatalf("coverage gap: next block at offset %d, expected %d (file_block_refs lost a prior pass; have %d blocks covering up to %d of %d)",
+				b.Offset, cursor, len(blocks), cursor, uint64(2*half))
+		}
+		cursor += uint64(b.Size)
+	}
+	if cursor != uint64(2*half) {
+		t.Fatalf("blocks cover [0,%d) but file is %d bytes", cursor, 2*half)
+	}
+	t.Logf("OK: %d blocks cover full [0,%d)", len(blocks), cursor)
+}
+
+func TestMemoryDrainRollups_MultiPassAppend(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	runMultiPassAppend(t, ms, "mem")
+}
+
+func TestBadgerDrainRollups_MultiPassAppend(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	runMultiPassAppend(t, ms, "badger")
+}

--- a/pkg/blockstore/engine/drain_multipass_test.go
+++ b/pkg/blockstore/engine/drain_multipass_test.go
@@ -11,27 +11,6 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// loggingCoordinator wraps testCoordinator to record every PersistFileBlocks
-// call so a multi-pass rollup is observable: how many calls, and the block
-// offsets carried by each.
-type loggingCoordinator struct {
-	*testCoordinator
-	t     *testing.T
-	calls [][]blockstore.BlockRef
-}
-
-func (c *loggingCoordinator) PersistFileBlocks(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
-	offs := make([]uint64, len(blocks))
-	for i, b := range blocks {
-		offs[i] = b.Offset
-	}
-	c.t.Logf("PersistFileBlocks(payload=%s, nblocks=%d, offsets=%v, objID=%s)",
-		payloadID, len(blocks), offs, objectID.String()[:12])
-	cp := append([]blockstore.BlockRef(nil), blocks...)
-	c.calls = append(c.calls, cp)
-	return c.testCoordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID)
-}
-
 // runMultiPassAppend writes a file in TWO separate write+drain cycles at
 // DISTINCT offsets (a real append), forcing two rollup passes, then asserts
 // the persisted FileAttr.Blocks cover the WHOLE file [0, size) — not just the

--- a/pkg/blockstore/engine/drain_persist_postgres_test.go
+++ b/pkg/blockstore/engine/drain_persist_postgres_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+package engine_test
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// parsePostgresDSN parses a libpq key=value DSN (the form documented in
+// CLAUDE.md: "host=localhost port=15432 user=dfs password=dfs
+// dbname=dittofs_grpa sslmode=disable") into the store config struct.
+func parsePostgresDSN(t *testing.T, dsn string) *postgres.PostgresMetadataStoreConfig {
+	t.Helper()
+	cfg := &postgres.PostgresMetadataStoreConfig{
+		SSLMode:     "disable",
+		AutoMigrate: true,
+	}
+	for _, kv := range strings.Fields(dsn) {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := parts[0], parts[1]
+		switch key {
+		case "host":
+			cfg.Host = val
+		case "port":
+			p, err := strconv.Atoi(val)
+			if err != nil {
+				t.Fatalf("parse port %q: %v", val, err)
+			}
+			cfg.Port = p
+		case "user":
+			cfg.User = val
+		case "password":
+			cfg.Password = val
+		case "dbname", "database":
+			cfg.Database = val
+		case "sslmode", "ssl_mode":
+			cfg.SSLMode = val
+		}
+	}
+	if cfg.Host == "" || cfg.Port == 0 || cfg.Database == "" || cfg.User == "" {
+		t.Fatalf("incomplete DSN %q (need host/port/dbname/user)", dsn)
+	}
+	return cfg
+}
+
+func newPostgresStore(t *testing.T) metadata.MetadataStore {
+	t.Helper()
+	dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping Postgres rollup-drain tests")
+	}
+	cfg := parsePostgresDSN(t, dsn)
+	caps := metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestPostgresDrainRollups_UniqueContent exercises the rollup-persist path
+// with NO identical-content files: DrainRollups must persist every written
+// file's block list so the Backup manifest covers all referenced hashes.
+func TestPostgresDrainRollups_UniqueContent(t *testing.T) {
+	ms := newPostgresStore(t)
+	ctx := context.Background()
+
+	shareName := "drainpg-uniq"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	uniqueA := distinctContent(0x10, 3*1024*1024)
+	uniqueB := distinctContent(0x11, 3*1024*1024)
+
+	pidA, hA := createRealFile(t, ms, shareName, "alpha.bin", rootHandle)
+	pidB, hB := createRealFile(t, ms, shareName, "beta.bin", rootHandle)
+
+	if _, err := bs.WriteAt(ctx, pidA, nil, uniqueA, 0); err != nil {
+		t.Fatalf("WriteAt alpha: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, pidB, nil, uniqueB, 0); err != nil {
+		t.Fatalf("WriteAt beta: %v", err)
+	}
+
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	want := blockstore.NewHashSet(0)
+	for name, h := range map[string]metadata.FileHandle{"alpha.bin": hA, "beta.bin": hB} {
+		blocks := fileBlocks(t, ms, h)
+		if len(blocks) == 0 {
+			t.Fatalf("file %s has empty FileAttr.Blocks after DrainRollups", name)
+		}
+		for _, b := range blocks {
+			want.Add(b.Hash)
+		}
+	}
+
+	got, bufLen := manifestHashes(t, ms)
+	missing := 0
+	for _, h := range want.Sorted() {
+		if !got.Contains(h) {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("Backup manifest missing %d/%d referenced hashes (manifest len=%d, buf=%d bytes)",
+			missing, want.Len(), got.Len(), bufLen)
+	}
+}
+
+// TestPostgresDrainRollups_IdenticalContent reproduces BUG 2 over the REAL
+// engine write path against a real Postgres metadata store: a share with two
+// byte-identical files must snapshot successfully (DrainRollups tolerates the
+// file-level-dedup object_id conflict), every file persists its block list,
+// and the Backup manifest covers all referenced hashes.
+func TestPostgresDrainRollups_IdenticalContent(t *testing.T) {
+	ms := newPostgresStore(t)
+	runIdenticalContentDrain(t, ms, "drainpg")
+}
+
+// TestPostgresDrainRollups_InPlaceModify exercises the snapshot-restore
+// corruption scenario: a file written, rolled up, then modified in place and
+// rolled up again must end with a manifest covering the LATEST content's
+// blocks (the rollup-persist UPDATE path advances object_id O1 -> O2 on the
+// same row).
+func TestPostgresDrainRollups_InPlaceModify(t *testing.T) {
+	ms := newPostgresStore(t)
+	ctx := context.Background()
+
+	shareName := "drainpg-mod"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	v1 := distinctContent(0x30, 3*1024*1024)
+	v2 := distinctContent(0x31, 3*1024*1024)
+
+	pid, h := createRealFile(t, ms, shareName, "file.bin", rootHandle)
+
+	if _, err := bs.WriteAt(ctx, pid, nil, v1, 0); err != nil {
+		t.Fatalf("WriteAt v1: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups v1: %v", err)
+	}
+
+	if _, err := bs.WriteAt(ctx, pid, nil, v2, 0); err != nil {
+		t.Fatalf("WriteAt v2: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups v2: %v", err)
+	}
+
+	blocks := fileBlocks(t, ms, h)
+	if len(blocks) == 0 {
+		t.Fatalf("file has empty FileAttr.Blocks after in-place modify + drain")
+	}
+	want := blockstore.NewHashSet(0)
+	for _, b := range blocks {
+		want.Add(b.Hash)
+	}
+
+	got, bufLen := manifestHashes(t, ms)
+	missing := 0
+	for _, hh := range want.Sorted() {
+		if !got.Contains(hh) {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("Backup manifest missing %d/%d latest-content hashes (manifest len=%d, buf=%d bytes)",
+			missing, want.Len(), got.Len(), bufLen)
+	}
+}

--- a/pkg/blockstore/engine/drain_persist_postgres_test.go
+++ b/pkg/blockstore/engine/drain_persist_postgres_test.go
@@ -136,6 +136,16 @@ func TestPostgresDrainRollups_UniqueContent(t *testing.T) {
 	}
 }
 
+// TestPostgresDrainRollups_MultiPassAppend reproduces #789 against a real
+// Postgres metadata store: a file rolled up in two passes (append at a new
+// offset) must end with file_block_refs covering the WHOLE byte range, not
+// just the last pass. Without the persister-side complete-list fix, Postgres
+// keeps only the last pass's chunk (DELETE-all + INSERT replace).
+func TestPostgresDrainRollups_MultiPassAppend(t *testing.T) {
+	ms := newPostgresStore(t)
+	runMultiPassAppend(t, ms, "drainpg")
+}
+
 // TestPostgresDrainRollups_IdenticalContent reproduces BUG 2 over the REAL
 // engine write path against a real Postgres metadata store: a share with two
 // byte-identical files must snapshot successfully (DrainRollups tolerates the

--- a/pkg/blockstore/engine/drain_persist_test.go
+++ b/pkg/blockstore/engine/drain_persist_test.go
@@ -1,0 +1,341 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// testCoordinator is a faithful, test-local re-implementation of the
+// production engine.MetadataCoordinator (pkg/controlplane/runtime/shares/
+// coordinator.go) — that package may not be imported here per the
+// strict-grep boundary. It drives PersistFileBlocks the exact way the
+// production wrapper does: resolve payloadID -> existing file row via
+// GetFileByPayloadID, mutate Blocks + ObjectID, PutFile under the existing
+// id, all in one metadata transaction, wrapping a backend object_id
+// uniqueness conflict into engine.ErrObjectIDConflict.
+type testCoordinator struct {
+	store metadata.MetadataStore
+}
+
+var _ engine.MetadataCoordinator = (*testCoordinator)(nil)
+
+func (c *testCoordinator) IncrementRefCount(ctx context.Context, hash blockstore.ContentHash) error {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil {
+		return err
+	}
+	if fb == nil {
+		return metadata.ErrFileBlockNotFound
+	}
+	return c.store.IncrementRefCount(ctx, fb.ID)
+}
+
+func (c *testCoordinator) DecrementRefCount(ctx context.Context, hash blockstore.ContentHash) (uint32, error) {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil {
+		return 0, err
+	}
+	if fb == nil {
+		return 0, nil
+	}
+	return c.store.DecrementRefCount(ctx, fb.ID)
+}
+
+func (c *testCoordinator) PersistFileBlocks(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
+	return c.store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		file, err := tx.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
+		if err != nil {
+			return fmt.Errorf("coordinator: GetFileByPayloadID(%s): %w", payloadID, err)
+		}
+		if file == nil {
+			return fmt.Errorf("coordinator: GetFileByPayloadID(%s): nil file (no row)", payloadID)
+		}
+		file.Blocks = blocks
+		file.ObjectID = objectID
+		if perr := tx.PutFile(ctx, file); perr != nil {
+			return mapObjectIDConflict(perr)
+		}
+		return nil
+	})
+}
+
+// mapObjectIDConflict mirrors the production runtime coordinator: an
+// object_id uniqueness violation (Memory/Badger surface mderrors.ErrConflict;
+// Postgres now maps the files_object_id_idx 23505 to the same ErrConflict
+// code) is wrapped into engine.ErrObjectIDConflict so the rollup-persist
+// path recognises the benign file-level-dedup conflict uniformly across
+// backends.
+func mapObjectIDConflict(err error) error {
+	if err == nil {
+		return nil
+	}
+	var storeErr *mderrors.StoreError
+	if errors.As(err, &storeErr) && storeErr.Code == mderrors.ErrConflict {
+		return errors.Join(engine.ErrObjectIDConflict, err)
+	}
+	return err
+}
+
+func (c *testCoordinator) FindByObjectID(ctx context.Context, objectID blockstore.ObjectID) ([]blockstore.BlockRef, error) {
+	if objectID.IsZero() {
+		return nil, nil
+	}
+	return c.store.FindByObjectID(ctx, objectID)
+}
+
+func (c *testCoordinator) GetFileObjectID(ctx context.Context, payloadID string) (blockstore.ObjectID, error) {
+	var zero blockstore.ObjectID
+	file, err := c.store.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
+	if err != nil {
+		return zero, nil
+	}
+	if file == nil {
+		return zero, nil
+	}
+	return file.ObjectID, nil
+}
+
+// newEngineOverStore builds a full engine.BlockStore over a real fs local
+// store + the supplied metadata store, wired with a faithful coordinator,
+// and a LARGE stabilization window with the rollup worker pool NOT started
+// so the only path from append-log bytes -> CAS + manifest is an explicit
+// DrainRollups (the snapshot-create primitive).
+func newEngineOverStore(t *testing.T, ms metadata.MetadataStore) *engine.BlockStore {
+	t.Helper()
+	rollupStore, ok := ms.(metadata.RollupStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.RollupStore", ms)
+	}
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire
+		RollupStore:     rollupStore,
+		SyncedHashStore: syncedHashStore,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	coord := &testCoordinator{store: ms}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.Config{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileBlockStore:  ms,
+		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// createRealFile creates a file row through the metadata store the way the
+// production CreateFile path does — crucially setting PayloadID =
+// buildPayloadID(share, path) so the rollup-persist GetFileByPayloadID
+// lookup resolves to THIS row. It does NOT pre-populate Blocks (doing so
+// would mask the rollup-persist bug under test).
+func createRealFile(t *testing.T, store metadata.MetadataStore, shareName, name string, rootHandle metadata.FileHandle) (string, metadata.FileHandle) {
+	t.Helper()
+	ctx := context.Background()
+	path := "/" + name
+	handle, err := store.GenerateHandle(ctx, shareName, path)
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle: %v", err)
+	}
+	payloadID := strings.TrimPrefix(shareName, "/") + "/" + strings.TrimPrefix(path, "/")
+	file := &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			PayloadID: metadata.PayloadID(payloadID),
+		},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile %q: %v", name, err)
+	}
+	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
+		t.Fatalf("SetParent %q: %v", name, err)
+	}
+	if err := store.SetChild(ctx, rootHandle, name, handle); err != nil {
+		t.Fatalf("SetChild %q: %v", name, err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount %q: %v", name, err)
+	}
+	return payloadID, handle
+}
+
+// fileBlocks reads FileAttr.Blocks for a handle via GetFile (which loads
+// blocks from the per-file block manifest — GetFileByPayloadID does NOT on
+// the Postgres backend).
+func fileBlocks(t *testing.T, store metadata.MetadataStore, handle metadata.FileHandle) []blockstore.BlockRef {
+	t.Helper()
+	f, err := store.GetFile(context.Background(), handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	return f.Blocks
+}
+
+func createShare(t *testing.T, store metadata.MetadataStore, shareName string) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	// CreateRootDirectory inserts BOTH the "/" files-row AND the share row
+	// (Postgres' shares.root_file_id is NOT NULL, so the share row cannot be
+	// created independently). It is idempotent on the share name.
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	})
+	if err != nil {
+		t.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	return rootHandle
+}
+
+// distinctContent builds an n-byte buffer whose bytes derive from a per-test
+// seed so that NO two test functions sharing the same metadata store produce
+// colliding Merkle-root ObjectIDs (object_id dedup is store-wide, crossing
+// share boundaries — see the CrossShareDedupScope conformance scenario).
+// Within a single test, passing the same seed yields byte-identical content
+// (used to drive the file-level-dedup conflict).
+func distinctContent(seed byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = seed ^ byte(i*31+17)
+	}
+	return b
+}
+
+// manifestHashes returns the set of DISTINCT content hashes the metadata
+// Backup manifest exposes, plus the serialized manifest size.
+func manifestHashes(t *testing.T, ms metadata.MetadataStore) (*blockstore.HashSet, int) {
+	t.Helper()
+	backupable, ok := ms.(metadata.Backupable)
+	if !ok {
+		t.Fatal("store must implement metadata.Backupable")
+	}
+	var buf bytes.Buffer
+	got, err := backupable.Backup(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	return got, buf.Len()
+}
+
+// runIdenticalContentDrain is the shared body for the identical-content
+// (file-level dedup) BUG 2 scenario. Two files with byte-identical content
+// roll up; the second trips the object_id uniqueness constraint. DrainRollups
+// MUST succeed and BOTH files must persist their block lists (the duplicate
+// without claiming the dedup pointer), so the manifest stays complete and
+// both files are restorable.
+func runIdenticalContentDrain(t *testing.T, ms metadata.MetadataStore, sharePrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shareName := sharePrefix + "-dup"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	uniqueA := distinctContent(0x20, 3*1024*1024)
+	uniqueB := distinctContent(0x21, 3*1024*1024)
+
+	pidA, hA := createRealFile(t, ms, shareName, "alpha.bin", rootHandle)
+	pidB, hB := createRealFile(t, ms, shareName, "beta.bin", rootHandle)
+	pidC, hC := createRealFile(t, ms, shareName, "alpha-copy.bin", rootHandle)
+
+	if _, err := bs.WriteAt(ctx, pidA, nil, uniqueA, 0); err != nil {
+		t.Fatalf("WriteAt alpha: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, pidB, nil, uniqueB, 0); err != nil {
+		t.Fatalf("WriteAt beta: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, pidC, nil, uniqueA, 0); err != nil {
+		t.Fatalf("WriteAt alpha-copy: %v", err)
+	}
+
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups must tolerate identical-content conflict: %v", err)
+	}
+
+	want := blockstore.NewHashSet(0)
+	for name, h := range map[string]metadata.FileHandle{
+		"alpha.bin":      hA,
+		"beta.bin":       hB,
+		"alpha-copy.bin": hC,
+	} {
+		blocks := fileBlocks(t, ms, h)
+		if len(blocks) == 0 {
+			t.Fatalf("file %s has empty FileAttr.Blocks after DrainRollups (unrestorable duplicate)", name)
+		}
+		for _, b := range blocks {
+			want.Add(b.Hash)
+		}
+	}
+
+	got, bufLen := manifestHashes(t, ms)
+	missing := 0
+	for _, h := range want.Sorted() {
+		if !got.Contains(h) {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("Backup manifest missing %d/%d referenced hashes (manifest len=%d, buf=%d bytes)",
+			missing, want.Len(), got.Len(), bufLen)
+	}
+}
+
+// TestMemoryDrainRollups_IdenticalContent locks in BUG 2 on the in-memory
+// metadata backend through the REAL engine write path.
+func TestMemoryDrainRollups_IdenticalContent(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	runIdenticalContentDrain(t, ms, "mem")
+}
+
+// TestBadgerDrainRollups_IdenticalContent locks in BUG 2 on the Badger
+// metadata backend through the REAL engine write path.
+func TestBadgerDrainRollups_IdenticalContent(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	runIdenticalContentDrain(t, ms, "badger")
+}

--- a/pkg/blockstore/engine/drain_persist_test.go
+++ b/pkg/blockstore/engine/drain_persist_test.go
@@ -142,12 +142,12 @@ func (c *testCoordinator) GetFileObjectID(ctx context.Context, payloadID string)
 	return file.ObjectID, nil
 }
 
-// newEngineOverStore builds a full engine.BlockStore over a real fs local
+// newEngineOverStore builds a full engine.Store over a real fs local
 // store + the supplied metadata store, wired with a faithful coordinator,
 // and a LARGE stabilization window with the rollup worker pool NOT started
 // so the only path from append-log bytes -> CAS + manifest is an explicit
 // DrainRollups (the snapshot-create primitive).
-func newEngineOverStore(t *testing.T, ms metadata.MetadataStore) *engine.BlockStore {
+func newEngineOverStore(t *testing.T, ms metadata.MetadataStore) *engine.Store {
 	t.Helper()
 	rollupStore, ok := ms.(metadata.RollupStore)
 	if !ok {
@@ -169,7 +169,7 @@ func newEngineOverStore(t *testing.T, ms metadata.MetadataStore) *engine.BlockSt
 	}
 	coord := &testCoordinator{store: ms}
 	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
-	bs, err := engine.New(engine.Config{
+	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Syncer:          syncer,
 		FileBlockStore:  ms,

--- a/pkg/blockstore/engine/drain_persist_test.go
+++ b/pkg/blockstore/engine/drain_persist_test.go
@@ -92,6 +92,9 @@ func mapObjectIDConflict(err error) error {
 func (c *testCoordinator) GetPersistedBlocks(ctx context.Context, payloadID string) ([]blockstore.BlockRef, error) {
 	file, err := c.store.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
 	if err != nil {
+		if metadata.IsNotFoundError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if file == nil {

--- a/pkg/blockstore/engine/drain_persist_test.go
+++ b/pkg/blockstore/engine/drain_persist_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
@@ -86,6 +87,37 @@ func mapObjectIDConflict(err error) error {
 		return errors.Join(engine.ErrObjectIDConflict, err)
 	}
 	return err
+}
+
+func (c *testCoordinator) GetPersistedBlocks(ctx context.Context, payloadID string) ([]blockstore.BlockRef, error) {
+	file, err := c.store.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
+	if err != nil {
+		return nil, err
+	}
+	if file == nil {
+		return nil, nil
+	}
+	if len(file.Blocks) > 0 {
+		return file.Blocks, nil
+	}
+	// Memory returns blocks inline with a zero ID; an unresolvable zero-ID
+	// handle means "no blocks yet". Postgres sets ID and omits blocks, so it
+	// loads them via the handle fallback.
+	if file.ID == uuid.Nil {
+		return nil, nil
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		return nil, err
+	}
+	full, err := c.store.GetFile(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+	if full == nil {
+		return nil, nil
+	}
+	return full.Blocks, nil
 }
 
 func (c *testCoordinator) FindByObjectID(ctx context.Context, objectID blockstore.ObjectID) ([]blockstore.BlockRef, error) {

--- a/pkg/blockstore/engine/drain_reset_test.go
+++ b/pkg/blockstore/engine/drain_reset_test.go
@@ -9,13 +9,13 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newDrainResetFixture builds a full engine.BlockStore over an fs local
+// newDrainResetFixture builds a full engine.Store over an fs local
 // store + memory metadata, with a LARGE stabilization window and the
 // rollup worker pool DELIBERATELY NOT started, so the only way dirty
 // append-log bytes reach CAS + the FileBlock manifest is via an explicit
 // DrainRollups. This reproduces the snapshot race where a snapshot is
 // taken before the async rollup catches up.
-func newDrainResetFixture(t *testing.T) (*BlockStore, *fs.FSStore) {
+func newDrainResetFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
@@ -31,7 +31,7 @@ func newDrainResetFixture(t *testing.T) (*BlockStore, *fs.FSStore) {
 	// NOTE: intentionally NOT calling StartRollup.
 
 	syncer := NewSyncer(localStore, nil, ms, DefaultConfig())
-	bs, err := New(Config{
+	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Syncer:          syncer,
 		FileBlockStore:  ms,

--- a/pkg/blockstore/engine/drain_reset_test.go
+++ b/pkg/blockstore/engine/drain_reset_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newDrainResetFixture builds a full engine.BlockStore over an fs local
+// store + memory metadata, with a LARGE stabilization window and the
+// rollup worker pool DELIBERATELY NOT started, so the only way dirty
+// append-log bytes reach CAS + the FileBlock manifest is via an explicit
+// DrainRollups. This reproduces the snapshot race where a snapshot is
+// taken before the async rollup catches up.
+func newDrainResetFixture(t *testing.T) (*BlockStore, *fs.FSStore) {
+	t.Helper()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	// NOTE: intentionally NOT calling StartRollup.
+
+	syncer := NewSyncer(localStore, nil, ms, DefaultConfig())
+	bs, err := New(Config{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileBlockStore:  ms,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, localStore
+}
+
+// TestEngine_DrainRollups_PopulatesManifest reproduces C1 at the engine
+// layer through the REAL write path (bs.WriteAt — NOT pre-populated
+// metadata). Before DrainRollups the FileBlock manifest is empty (the
+// async rollup never ran), so a metadata Backup taken now would yield an
+// empty snapshot manifest. After DrainRollups the manifest is non-empty.
+func TestEngine_DrainRollups_PopulatesManifest(t *testing.T) {
+	ctx := context.Background()
+	bs, _ := newDrainResetFixture(t)
+
+	payloadID := "c1-file"
+	data := bytes.Repeat([]byte{0x7E}, 4*1024*1024)
+	if _, err := bs.WriteAt(ctx, payloadID, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	// Pre-drain: manifest must be empty — proves the snapshot race would
+	// capture an empty manifest.
+	pre, err := bs.fileBlockStore.ListFileBlocks(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("ListFileBlocks (pre): %v", err)
+	}
+	if len(pre) != 0 {
+		t.Fatalf("manifest already populated before DrainRollups (%d rows); cannot prove C1", len(pre))
+	}
+
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	post, err := bs.fileBlockStore.ListFileBlocks(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("ListFileBlocks (post): %v", err)
+	}
+	if len(post) == 0 {
+		t.Fatal("DrainRollups did not populate the FileBlock manifest (C1: empty snapshot manifest)")
+	}
+}
+
+// TestEngine_ResetLocalState_RestoreRoundTrip reproduces C2 (restore
+// corrupts in-place-modified files) at the engine layer through the REAL
+// write path. Sequence:
+//
+//  1. Write file A "AAAA…", DrainRollups → A's bytes are durable in CAS +
+//     manifest (the snapshot state).
+//  2. Modify A in place ("BBBB…") via a fresh WriteAt — the new bytes land
+//     ONLY in the append log (no DrainRollups). Reads now show "BBBB…".
+//  3. ResetLocalState (the restore primitive) drops the stale append-log
+//     overlay.
+//  4. Read A again: it MUST return the snapshot bytes "AAAA…" resolved
+//     purely from the CAS manifest, not the post-snapshot "BBBB…".
+//
+// Without ResetLocalState the read returns the mutated bytes because
+// ReadPayloadAt's replayLogIntoDest overlays the post-snapshot log record
+// on top of the restored CAS content ("last record wins").
+func TestEngine_ResetLocalState_RestoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	bs, _ := newDrainResetFixture(t)
+
+	payloadID := "c2-file"
+	const size = 4096
+	snapBytes := bytes.Repeat([]byte{'A'}, size)
+	mutBytes := bytes.Repeat([]byte{'B'}, size)
+
+	// (1) snapshot state.
+	if _, err := bs.WriteAt(ctx, payloadID, nil, snapBytes, 0); err != nil {
+		t.Fatalf("WriteAt snapshot bytes: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (snapshot): %v", err)
+	}
+
+	got := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, payloadID, nil, got, 0); err != nil {
+		t.Fatalf("ReadAt after snapshot drain: %v", err)
+	}
+	if !bytes.Equal(got, snapBytes) {
+		t.Fatal("post-drain read did not return snapshot bytes")
+	}
+
+	// (2) in-place modification, log-only.
+	if _, err := bs.WriteAt(ctx, payloadID, nil, mutBytes, 0); err != nil {
+		t.Fatalf("WriteAt mutation: %v", err)
+	}
+	clear(got)
+	if _, err := bs.ReadAt(ctx, payloadID, nil, got, 0); err != nil {
+		t.Fatalf("ReadAt after mutation: %v", err)
+	}
+	if !bytes.Equal(got, mutBytes) {
+		t.Fatal("post-mutation read did not return mutated bytes; test setup invalid")
+	}
+
+	// (3) restore: reset block-store local state (metadata reset is modeled
+	// by the CAS manifest still holding the snapshot blocks — they were
+	// never overwritten because the mutation never rolled up).
+	if err := bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// (4) byte-exact: read resolves through CAS = snapshot bytes.
+	clear(got)
+	if _, err := bs.ReadAt(ctx, payloadID, nil, got, 0); err != nil {
+		t.Fatalf("ReadAt after reset: %v", err)
+	}
+	if !bytes.Equal(got, snapBytes) {
+		t.Fatalf("ResetLocalState did not drop stale log (C2 corruption):\n got[:8]=%q want[:8]=%q",
+			got[:8], snapBytes[:8])
+	}
+}

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -197,7 +197,37 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 			if bs.coordinator == nil {
 				return nil
 			}
-			return bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID)
+			if err := bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID); err != nil {
+				// File-level dedup: another file already owns this
+				// Merkle-root ObjectID (byte-identical content). The
+				// object_id index enforces "one ObjectID -> one file", so
+				// this duplicate cannot claim the canonical pointer. It
+				// MUST still persist its own block list (so the file is
+				// restorable and its FileBlock manifest is complete) — it
+				// simply does so WITHOUT owning the object_id (left zero =
+				// "not the canonical dedup target"). Retrying with a zero
+				// ObjectID writes object_id NULL, which the partial unique
+				// index skips, so the per-file blocks land cleanly.
+				//
+				// Propagating the raw conflict instead would (a) fail an
+				// explicit DrainRollups, (b) wedge the background rollup
+				// worker into retrying the same conflict forever, and (c)
+				// leave the duplicate with an empty block list →
+				// unrestorable. The block hashes themselves are content-
+				// addressed and already durable in CAS from StoreChunk.
+				if isObjectIDConflict(err) {
+					logger.Debug("rollup persist: object_id already mapped to another file; persisting duplicate's blocks without claiming the dedup pointer",
+						"payloadID", payloadID,
+						"objectID", objectID.String())
+					var zeroObjectID blockstore.ObjectID
+					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, zeroObjectID); rerr != nil {
+						return fmt.Errorf("rollup persist: retry without object_id after dedup conflict: %w", rerr)
+					}
+					return nil
+				}
+				return err
+			}
+			return nil
 		})
 
 		// (2) Install the chunk-completion callback (production

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -246,7 +246,7 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 				if isObjectIDConflict(err) {
 					logger.Debug("rollup persist: object_id already mapped to another file; persisting duplicate's blocks without claiming the dedup pointer",
 						"payloadID", payloadID,
-						"objectID", objectID.String())
+						"objectID", persistObjID.String())
 					var zeroObjectID blockstore.ObjectID
 					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, zeroObjectID); rerr != nil {
 						return fmt.Errorf("rollup persist: retry without object_id after dedup conflict: %w", rerr)

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -197,7 +197,35 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 			if bs.coordinator == nil {
 				return nil
 			}
-			if err := bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, objectID); err != nil {
+			// The persister fires once per rollup PASS, carrying only the
+			// chunks rolled in THAT pass. FileAttr.Blocks (the snapshot
+			// manifest source, read by metadata Backup) must reflect the
+			// COMPLETE file, so a multi-pass rollup (append, or a large
+			// write split across stabilization windows) cannot persist the
+			// partial pass list here — that REPLACES FileAttr.Blocks with
+			// only the last pass's chunks, silently dropping every prior
+			// pass from the manifest (#789, backend-agnostic — Postgres
+			// just hits multi-pass more often via slower txns).
+			//
+			// Merge this pass's blocks into the already-persisted list
+			// (read back via the coordinator — file_block_refs / encoded
+			// FileAttr.Blocks, both of which store the content hash, unlike
+			// the per-file FileBlock index whose Pending rows carry a NULL
+			// hash on Postgres). The merge is offset-keyed: this pass's
+			// blocks overlay any overlapping byte ranges (in-place rewrite)
+			// and extend the rest (append). Recompute the Merkle-root
+			// ObjectID over the COMPLETE list so it matches a single-pass
+			// write of identical content and file-level dedup still resolves.
+			persistBlocks, persistObjID := blocks, objectID
+			existing, gerr := bs.coordinator.GetPersistedBlocks(ctx, payloadID)
+			if gerr != nil {
+				return fmt.Errorf("ObjectIDPersister: read persisted blocks for %s: %w", payloadID, gerr)
+			}
+			if len(existing) > 0 {
+				persistBlocks = blockstore.MergeBlockRefsByOffset(existing, blocks)
+				persistObjID = blockstore.ComputeObjectID(persistBlocks)
+			}
+			if err := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, persistObjID); err != nil {
 				// File-level dedup: another file already owns this
 				// Merkle-root ObjectID (byte-identical content). The
 				// object_id index enforces "one ObjectID -> one file", so
@@ -220,7 +248,7 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 						"payloadID", payloadID,
 						"objectID", objectID.String())
 					var zeroObjectID blockstore.ObjectID
-					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, blocks, zeroObjectID); rerr != nil {
+					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, zeroObjectID); rerr != nil {
 						return fmt.Errorf("rollup persist: retry without object_id after dedup conflict: %w", rerr)
 					}
 					return nil

--- a/pkg/blockstore/engine/engine_delete_test.go
+++ b/pkg/blockstore/engine/engine_delete_test.go
@@ -66,6 +66,10 @@ func (c *refcountCoordinator) PersistFileBlocks(_ context.Context, _ string, _ [
 	return nil
 }
 
+func (c *refcountCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
 func (c *refcountCoordinator) FindByObjectID(_ context.Context, _ blockstore.ObjectID) ([]blockstore.BlockRef, error) {
 	return nil, nil
 }

--- a/pkg/blockstore/engine/flush.go
+++ b/pkg/blockstore/engine/flush.go
@@ -107,7 +107,7 @@ func (bs *Store) DrainAllUploads(ctx context.Context) error {
 // FileAttr.Blocks (and therefore a non-empty snapshot manifest). It must
 // run before DrainAllUploads — rollup is what produces the CAS chunks the
 // syncer then mirrors to the remote.
-func (bs *BlockStore) DrainRollups(ctx context.Context) error {
+func (bs *Store) DrainRollups(ctx context.Context) error {
 	return bs.local.DrainRollups(ctx)
 }
 
@@ -116,6 +116,6 @@ func (bs *BlockStore) DrainRollups(ctx context.Context) error {
 // The snapshot-restore orchestration calls this AFTER the metadata
 // Restore() so a file modified in place after the snapshot is not served
 // from a stale append-log record overlaid on the restored CAS bytes.
-func (bs *BlockStore) ResetLocalState(ctx context.Context) error {
+func (bs *Store) ResetLocalState(ctx context.Context) error {
 	return bs.local.ResetLocalState(ctx)
 }

--- a/pkg/blockstore/engine/flush.go
+++ b/pkg/blockstore/engine/flush.go
@@ -99,3 +99,23 @@ func (bs *Store) Flush(ctx context.Context, payloadID string) (*blockstore.Flush
 func (bs *Store) DrainAllUploads(ctx context.Context) error {
 	return bs.syncer.DrainAllUploads(ctx)
 }
+
+// DrainRollups forces the local store to roll up every currently-dirty
+// payload into CAS + the FileBlock manifest, bypassing the
+// stabilization-window gate. The snapshot-create orchestration calls this
+// BEFORE the metadata Backup() so the dump observes a fully-populated
+// FileAttr.Blocks (and therefore a non-empty snapshot manifest). It must
+// run before DrainAllUploads — rollup is what produces the CAS chunks the
+// syncer then mirrors to the remote.
+func (bs *BlockStore) DrainRollups(ctx context.Context) error {
+	return bs.local.DrainRollups(ctx)
+}
+
+// ResetLocalState clears the local store's per-payload append-log state so
+// post-restore reads resolve purely through the restored CAS manifest.
+// The snapshot-restore orchestration calls this AFTER the metadata
+// Restore() so a file modified in place after the snapshot is not served
+// from a stale append-log record overlaid on the restored CAS bytes.
+func (bs *BlockStore) ResetLocalState(ctx context.Context) error {
+	return bs.local.ResetLocalState(ctx)
+}

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -917,6 +917,10 @@ func (c *cascadeCoordinator) PersistFileBlocks(_ context.Context, _ string, _ []
 	return nil
 }
 
+func (c *cascadeCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
 func (c *cascadeCoordinator) FindByObjectID(_ context.Context, _ blockstore.ObjectID) ([]blockstore.BlockRef, error) {
 	return nil, nil
 }

--- a/pkg/blockstore/local/fs/delete_truncate_test.go
+++ b/pkg/blockstore/local/fs/delete_truncate_test.go
@@ -262,7 +262,7 @@ func TestDelete_DuringActiveRollup_NoMetadataZombie(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		rollupErr = bc.rollupFile(ctx, "target")
+		rollupErr = bc.rollupFile(ctx, "target", false)
 	}()
 
 	wg.Add(1)
@@ -488,7 +488,7 @@ func TestTruncate_Rollup_SkipsBeyondBoundary(t *testing.T) {
 	// Let stabilization elapse.
 	time.Sleep(20 * time.Millisecond)
 
-	if err := bc.rollupFile(ctx, "t1"); err != nil {
+	if err := bc.rollupFile(ctx, "t1", false); err != nil {
 		t.Fatalf("rollupFile after truncate: %v", err)
 	}
 

--- a/pkg/blockstore/local/fs/drain_reset.go
+++ b/pkg/blockstore/local/fs/drain_reset.go
@@ -80,13 +80,29 @@ func (bc *FSStore) DrainRollups(ctx context.Context) error {
 			return nil
 		}
 		if !progressed {
-			// Dirty intervals remain but none shrank this pass — every
-			// one is an interval rollupFile intentionally leaves in place
-			// (e.g. a reconstruct-DoS refusal). Returning rather than
-			// spinning keeps DrainRollups bounded; the residual intervals
-			// are benign for snapshot purposes (their bytes never reached a
-			// chunk, so there is nothing to capture in the manifest).
-			logger.Warn("DrainRollups: residual dirty intervals not drainable",
+			// Dirty intervals remain but none shrank this pass. Distinguish
+			// two cases:
+			//
+			//   - Benign skip: tombstoned payloads (a deleted file whose
+			//     rollup is short-circuited) and tree/logIndex-divergent
+			//     intervals (the rollupFile DropExact path — bytes that
+			//     never reached a chunk). These have no backing logIndex
+			//     entries (or a tombstone), so there is nothing to capture
+			//     in the manifest and returning nil is correct.
+			//
+			//   - Real residual: a payload that is NOT tombstoned and whose
+			//     logIndex CAN back its residual dirty intervals — genuine
+			//     unflushed data that should have reached CAS. Returning nil
+			//     here would let snapshot-create proceed to Backup with a
+			//     partial manifest. Surface ErrDrainIncomplete so the
+			//     orchestration fails the snapshot visibly instead.
+			realResidual := bc.payloadsWithRealResidual(pending)
+			if len(realResidual) > 0 {
+				logger.Error("DrainRollups: residual dirty intervals with backing log data",
+					"payload_count", len(realResidual))
+				return fmt.Errorf("%w (%d payloads)", ErrDrainIncomplete, len(realResidual))
+			}
+			logger.Warn("DrainRollups: residual dirty intervals not drainable (tombstoned/divergent)",
 				"payload_count", len(pending))
 			return nil
 		}
@@ -106,11 +122,71 @@ func (bc *FSStore) dirtyLen(payloadID string) int {
 		return 0
 	}
 	if mu == nil {
+		// No per-file mutex established yet (payload registered but never
+		// written through getOrCreateLog). Guard the btree read against a
+		// racing tree mutation under the shared logsMu instead.
+		bc.logsMu.RLock()
+		defer bc.logsMu.RUnlock()
 		return tree.Len()
 	}
 	mu.Lock()
 	defer mu.Unlock()
 	return tree.Len()
+}
+
+// payloadsWithRealResidual filters the candidate payloads down to those
+// that still carry GENUINE unflushed dirty data after a no-progress drain
+// pass: the payload is NOT tombstoned AND at least one of its dirty
+// intervals is backed by logIndex entries (so its bytes could have reached
+// a chunk but did not). Tombstoned payloads and tree/logIndex-divergent
+// intervals (no backing entries — the rollupFile DropExact case) are
+// excluded; they are legitimately skipped by the drain.
+//
+// Per-payload state is read under the per-file mutex (and the logIndex's
+// own mutex via EntriesForInterval) to match the dirtyLen / rollupFile
+// serialization contract.
+func (bc *FSStore) payloadsWithRealResidual(candidates []string) []string {
+	var out []string
+	for _, pid := range candidates {
+		bc.logsMu.RLock()
+		tree := bc.dirtyIntervals[pid]
+		mu := bc.logLocks[pid]
+		idx := bc.logIndices[pid]
+		bc.logsMu.RUnlock()
+		if tree == nil || idx == nil {
+			continue
+		}
+		if bc.isTombstoned(pid) {
+			continue
+		}
+
+		hasReal := false
+		walk := func() {
+			tree.t.Ascend(func(iv *interval) bool {
+				if iv.Length == 0 {
+					return true
+				}
+				if len(idx.EntriesForInterval(iv.Offset, uint64(iv.Length))) > 0 {
+					hasReal = true
+					return false
+				}
+				return true
+			})
+		}
+		if mu != nil {
+			mu.Lock()
+			walk()
+			mu.Unlock()
+		} else {
+			bc.logsMu.RLock()
+			walk()
+			bc.logsMu.RUnlock()
+		}
+		if hasReal {
+			out = append(out, pid)
+		}
+	}
+	return out
 }
 
 // ResetLocalState clears ALL per-payload append-log state for the store —

--- a/pkg/blockstore/local/fs/drain_reset.go
+++ b/pkg/blockstore/local/fs/drain_reset.go
@@ -1,0 +1,201 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// DrainRollups forces rollup of ALL currently-dirty payloads to
+// completion, bypassing the stabilization-window gate, and waits for any
+// in-flight rollup-worker passes to finish first.
+//
+// This is the snapshot-create primitive: at snapshot time every written
+// byte must be flushed from the per-payload append log into CAS AND into
+// the FileBlock manifest (via the ObjectIDPersister) so the metadata
+// Backup() observes a fully-populated FileAttr.Blocks. Steady-state
+// rollup only consumes intervals that have aged past the stabilization
+// window; a snapshot taken before that window elapses would otherwise
+// capture an empty or partial manifest.
+//
+// Contract:
+//   - Returns nil with no work when the store has no dirty payloads.
+//   - Each dirty payload is force-rolled until its dirty-interval tree
+//     drains (or stops making progress — a divergent interval that the
+//     logIndex cannot back is dropped by rollupFile, and a truncation-
+//     filtered empty batch is skipped; both are bounded by the
+//     no-progress guard so the loop always terminates).
+//   - ctx cancellation aborts the drain and returns ctx.Err().
+//
+// DrainRollups does NOT require StartRollup to have been called — it
+// drives rollupFile synchronously on the caller's goroutine. When the
+// rollup worker pool IS running, the per-file mutex inside rollupFile
+// serializes this forced pass against concurrent worker passes.
+func (bc *FSStore) DrainRollups(ctx context.Context) error {
+	if bc.isClosed() {
+		return ErrStoreClosed
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Snapshot every payload that currently has a tree. The set can
+		// grow under a concurrent AppendWrite, but each outer iteration
+		// re-reads it so newly-dirtied payloads are picked up. Per-payload
+		// emptiness is rechecked under the per-file mutex by dirtyLen
+		// below — the btree is not safe to read here without that mutex.
+		bc.logsMu.RLock()
+		pending := make([]string, 0, len(bc.dirtyIntervals))
+		for pid := range bc.dirtyIntervals {
+			pending = append(pending, pid)
+		}
+		bc.logsMu.RUnlock()
+
+		progressed := false
+		anyDirty := false
+		for _, pid := range pending {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			before := bc.dirtyLen(pid)
+			if before == 0 {
+				continue
+			}
+			anyDirty = true
+			if err := bc.rollupFile(ctx, pid, true); err != nil {
+				return fmt.Errorf("DrainRollups: rollup payload %q: %w", pid, err)
+			}
+			if bc.dirtyLen(pid) < before {
+				progressed = true
+			}
+		}
+
+		if !anyDirty {
+			// Nothing dirty remains — drain complete.
+			return nil
+		}
+		if !progressed {
+			// Dirty intervals remain but none shrank this pass — every
+			// one is an interval rollupFile intentionally leaves in place
+			// (e.g. a reconstruct-DoS refusal). Returning rather than
+			// spinning keeps DrainRollups bounded; the residual intervals
+			// are benign for snapshot purposes (their bytes never reached a
+			// chunk, so there is nothing to capture in the manifest).
+			logger.Warn("DrainRollups: residual dirty intervals not drainable",
+				"payload_count", len(pending))
+			return nil
+		}
+	}
+}
+
+// dirtyLen returns the current dirty-interval count for payloadID, or 0
+// when no tree exists. The btree is not safe for concurrent use, so the
+// Len() read is serialized against AppendWrite / rollupFile via the
+// per-file mutex.
+func (bc *FSStore) dirtyLen(payloadID string) int {
+	bc.logsMu.RLock()
+	tree := bc.dirtyIntervals[payloadID]
+	mu := bc.logLocks[payloadID]
+	bc.logsMu.RUnlock()
+	if tree == nil {
+		return 0
+	}
+	if mu == nil {
+		return tree.Len()
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return tree.Len()
+}
+
+// ResetLocalState clears ALL per-payload append-log state for the store —
+// in-memory logIndices, dirty-interval trees, rollup offsets, truncation
+// boundaries — closes every open log fd, and removes the on-disk `.log`
+// files under <baseDir>/logs/. After ResetLocalState, ReadPayloadAt no
+// longer replays any append-log records, so reads resolve purely through
+// the (restored) CAS manifest.
+//
+// This is the snapshot-restore primitive: RestoreSnapshot resets the
+// metadata store to a prior dump, but the block store's per-payload append
+// log still holds post-snapshot write records. Without this reset,
+// ReadPayloadAt's replayLogIntoDest would overlay those stale records on
+// top of the restored CAS content ("last record wins"), returning the
+// post-snapshot mutated bytes — silent corruption of in-place-modified
+// files. Dropping the log makes the restored CAS manifest the sole source
+// of truth.
+//
+// Safety precondition (enforced by the caller, RestoreSnapshot): both the
+// snapshot being restored AND the pre-restore safety snapshot drained
+// rollups, so every byte that must survive the restore is already durable
+// in CAS. Any bytes that lived ONLY in the append log are post-snapshot
+// writes the operator is deliberately discarding.
+//
+// Concurrency: the caller MUST have quiesced writes (the share is disabled
+// during restore). ResetLocalState takes bc.logsMu for the whole teardown
+// so it does not race getOrCreateLog; it does not, however, defend against
+// a concurrent in-flight AppendWrite mid-record — that is the caller's
+// share-disabled barrier to provide.
+func (bc *FSStore) ResetLocalState(_ context.Context) error {
+	if bc.isClosed() {
+		return ErrStoreClosed
+	}
+
+	bc.logsMu.Lock()
+	defer bc.logsMu.Unlock()
+
+	var firstErr error
+	for pid, lf := range bc.logFDs {
+		if lf == nil {
+			continue
+		}
+		if lf.f != nil {
+			if cerr := lf.f.Close(); cerr != nil {
+				logger.Warn("ResetLocalState: log file close failed",
+					"payloadID", pid, "path", lf.path, "error", cerr)
+			}
+		}
+		if lf.path != "" {
+			if rerr := os.Remove(lf.path); rerr != nil && !os.IsNotExist(rerr) {
+				logger.Error("ResetLocalState: log file unlink failed",
+					"payloadID", pid, "path", lf.path, "error", rerr)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("ResetLocalState: unlink log for payload %q: %w", pid, rerr)
+				}
+			}
+		}
+	}
+
+	// Wipe every per-payload map so a subsequent AppendWrite starts from a
+	// fresh log and a subsequent ReadPayloadAt finds no log to replay.
+	clear(bc.logFDs)
+	clear(bc.logLocks)
+	clear(bc.dirtyIntervals)
+	clear(bc.logIndices)
+	clear(bc.truncations)
+	clear(bc.tombstones)
+	bc.logBytesTotal.Store(0)
+
+	// Best-effort: remove any residual .log files left under the logs dir
+	// that had no live fd (e.g. orphaned by an interrupted DeleteAppendLog).
+	// A missing logs dir is fine — nothing was ever written.
+	logsDir := filepath.Join(bc.baseDir, "logs")
+	if entries, derr := os.ReadDir(logsDir); derr == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			full := filepath.Join(logsDir, e.Name())
+			if rerr := os.Remove(full); rerr != nil && !os.IsNotExist(rerr) {
+				logger.Warn("ResetLocalState: residual log unlink failed",
+					"path", full, "error", rerr)
+			}
+		}
+	}
+
+	return firstErr
+}

--- a/pkg/blockstore/local/fs/drain_reset_test.go
+++ b/pkg/blockstore/local/fs/drain_reset_test.go
@@ -1,0 +1,157 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestDrainRollups_ForcesManifestPopulation reproduces C1 (empty/racy
+// manifest). With a LARGE stabilization window and NO rollup worker pool
+// started, the async rollup never fires before a snapshot would run, so
+// the ObjectIDPersister (which writes FileBlock rows + FileAttr.Blocks)
+// is never invoked and the snapshot manifest is empty. DrainRollups must
+// force ALL dirty payloads through rollup to completion regardless of the
+// stabilization gate, so the persister fires and the manifest is
+// non-empty.
+func TestDrainRollups_ForcesManifestPopulation(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+
+	var mu sync.Mutex
+	var persisted []blockstore.BlockRef
+	persister := func(_ context.Context, _ string, blocks []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		mu.Lock()
+		defer mu.Unlock()
+		persisted = append(persisted, blocks...)
+		return nil
+	}
+
+	// Stabilization window is enormous (1 hour) so the ticker/stable path
+	// can NEVER consume the interval; only a forced drain can.
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+	// NOTE: intentionally NOT calling StartRollup — mirrors the snapshot
+	// race where a snapshot is taken before the async rollup catches up.
+
+	ctx := context.Background()
+	payload := bytes.Repeat([]byte{0x5A}, 8*1024*1024)
+	if err := bc.AppendWrite(ctx, "file1", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Before the drain the persister must NOT have run (proves the bug
+	// would yield an empty manifest at snapshot time).
+	mu.Lock()
+	pre := len(persisted)
+	mu.Unlock()
+	if pre != 0 {
+		t.Fatalf("persister fired before drain (%d blocks); test cannot prove the C1 race", pre)
+	}
+
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	mu.Lock()
+	post := len(persisted)
+	mu.Unlock()
+	if post == 0 {
+		t.Fatal("DrainRollups did not force the rollup: persister never fired, manifest would be empty (C1)")
+	}
+
+	// Rollup offset must have advanced past the header, proving the log
+	// was consumed.
+	off, err := rs.GetRollupOffset(ctx, "file1")
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	if off <= uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset did not advance after DrainRollups: got %d", off)
+	}
+}
+
+// TestResetLocalState_DropsStaleLog reproduces C2 (restore corrupts
+// in-place-modified files). A file is written + drained into CAS (the
+// snapshot state). Then the same payload is modified in place via a fresh
+// AppendWrite — the new bytes land ONLY in the append log (not yet rolled
+// up). A restore resets metadata to the snapshot, but unless the block
+// store's per-payload log is also reset, ReadPayloadAt's replayLogIntoDest
+// overlays the post-snapshot log record on top of the restored CAS bytes
+// ("last record wins"), returning the MUTATED bytes. ResetLocalState must
+// drop the stale log so reads go purely through CAS.
+func TestResetLocalState_DropsStaleLog(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+
+	// Real FileBlock store so ReadPayloadAt's CAS manifest path resolves
+	// post-rollup bytes.
+	fbs := newMemFileBlockStore()
+	persister := func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		return fbs.persist(ctx, payloadID, blocks)
+	}
+
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+
+	ctx := context.Background()
+
+	// --- snapshot state: write "AAAA..." and drain to CAS ---
+	snapBytes := bytes.Repeat([]byte{'A'}, 4096)
+	if err := bc.AppendWrite(ctx, "fileA", snapBytes, 0); err != nil {
+		t.Fatalf("AppendWrite snapshot bytes: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (snapshot): %v", err)
+	}
+
+	// Sanity: reading now returns the snapshot bytes.
+	got := make([]byte, 4096)
+	if _, err := bc.ReadPayloadAt(ctx, "fileA", got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt after snapshot drain: %v", err)
+	}
+	if !bytes.Equal(got, snapBytes) {
+		t.Fatal("post-drain read did not return snapshot bytes")
+	}
+
+	// --- post-snapshot in-place modification (log-only, NOT rolled up) ---
+	mutBytes := bytes.Repeat([]byte{'B'}, 4096)
+	if err := bc.AppendWrite(ctx, "fileA", mutBytes, 0); err != nil {
+		t.Fatalf("AppendWrite mutation: %v", err)
+	}
+	// Confirm the mutation is observable (log overlay wins).
+	if _, err := bc.ReadPayloadAt(ctx, "fileA", got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt after mutation: %v", err)
+	}
+	if !bytes.Equal(got, mutBytes) {
+		t.Fatal("post-mutation read did not return mutated bytes; test setup invalid")
+	}
+
+	// --- restore: reset block-store local state (metadata reset is
+	// modeled by the CAS manifest still holding the snapshot blocks) ---
+	if err := bc.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// After ResetLocalState the stale log overlay must be gone; the read
+	// resolves purely through the CAS manifest = snapshot bytes.
+	clear(got)
+	if _, err := bc.ReadPayloadAt(ctx, "fileA", got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt after reset: %v", err)
+	}
+	if !bytes.Equal(got, snapBytes) {
+		t.Fatalf("ResetLocalState did not drop stale log: read returned mutated bytes (C2 corruption)\n got[:8]=%q want[:8]=%q", got[:8], snapBytes[:8])
+	}
+}

--- a/pkg/blockstore/local/fs/drain_reset_test.go
+++ b/pkg/blockstore/local/fs/drain_reset_test.go
@@ -3,8 +3,10 @@ package fs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
@@ -76,6 +78,121 @@ func TestDrainRollups_ForcesManifestPopulation(t *testing.T) {
 	}
 	if off <= uint64(logHeaderSize) {
 		t.Fatalf("rollup_offset did not advance after DrainRollups: got %d", off)
+	}
+}
+
+// TestDrainRollups_RealResidualReturnsErrDrainIncomplete verifies that
+// when a no-progress drain pass leaves dirty intervals backed by REAL log
+// data (payload not tombstoned, logIndex CAN back the interval),
+// DrainRollups returns ErrDrainIncomplete instead of silently succeeding
+// with a partial manifest.
+//
+// Deterministic construction: AppendWrite a small record at a logical
+// offset ABOVE the 16 GiB reconstructStream ceiling. rollupFile reads the
+// (tiny) on-disk frame, but reconstructStream refuses the >16 GiB buffer
+// and returns nil WITHOUT consuming the interval — a no-progress pass that
+// leaves a genuine, logIndex-backed dirty interval in place.
+func TestDrainRollups_RealResidualReturnsErrDrainIncomplete(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		StabilizationMS: 1,
+		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
+	})
+	ctx := context.Background()
+	const payloadID = "file-real-residual"
+
+	// Offset above maxReconstructBytes (16 GiB) so reconstructStream
+	// refuses every rollup pass. The payload itself is tiny.
+	const hugeOffset = uint64(1) << 35 // 32 GiB
+	if err := bc.AppendWrite(ctx, payloadID, bytes.Repeat([]byte{0x33}, 64), hugeOffset); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Sanity: the interval is logIndex-backed (real data), so the
+	// classifier must flag it.
+	if got := bc.payloadsWithRealResidual([]string{payloadID}); len(got) != 1 {
+		t.Fatalf("payloadsWithRealResidual = %v, want exactly [%q]", got, payloadID)
+	}
+
+	err := bc.DrainRollups(ctx)
+	if !errors.Is(err, ErrDrainIncomplete) {
+		t.Fatalf("DrainRollups err = %v, want errors.Is(ErrDrainIncomplete)", err)
+	}
+}
+
+// TestDrainRollups_TombstonedResidualSucceeds verifies that residual dirty
+// intervals on a TOMBSTONED payload are legitimately skipped: DrainRollups
+// returns nil (the bytes belong to a deleted payload and never need to
+// reach the manifest).
+func TestDrainRollups_TombstonedResidualSucceeds(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		StabilizationMS: 1,
+		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
+	})
+	ctx := context.Background()
+	const payloadID = "file-tombstoned-residual"
+
+	// Same un-drainable real residual as above (offset > 16 GiB ceiling).
+	const hugeOffset = uint64(1) << 35
+	if err := bc.AppendWrite(ctx, payloadID, bytes.Repeat([]byte{0x44}, 64), hugeOffset); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Tombstone the payload directly (mirrors a concurrent DeleteAppendLog
+	// having set the tombstone). The classifier must now exclude it.
+	bc.logsMu.Lock()
+	if bc.tombstones == nil {
+		bc.tombstones = make(map[string]struct{})
+	}
+	bc.tombstones[payloadID] = struct{}{}
+	bc.logsMu.Unlock()
+
+	if got := bc.payloadsWithRealResidual([]string{payloadID}); len(got) != 0 {
+		t.Fatalf("payloadsWithRealResidual on tombstoned payload = %v, want empty", got)
+	}
+
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups on tombstoned-only residual = %v, want nil", err)
+	}
+}
+
+// TestDrainRollups_DivergentResidualSucceeds verifies that a tree-only
+// dirty interval with NO logIndex backing (a tree/logIndex divergence —
+// the DropExact case) is treated as benign: rollupFile drops it and
+// DrainRollups returns nil.
+func TestDrainRollups_DivergentResidualSucceeds(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		StabilizationMS: 1,
+		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
+	})
+	ctx := context.Background()
+	const payloadID = "file-divergent-residual"
+
+	// Materialize per-payload state without any logIndex entry, then inject
+	// a tree-only interval — divergent by construction (no backing).
+	_, mu, tree, idx, err := bc.getOrCreateLog(payloadID)
+	if err != nil {
+		t.Fatalf("getOrCreateLog: %v", err)
+	}
+	mu.Lock()
+	tree.Insert(0, 4096, time.Now().Add(-time.Hour))
+	mu.Unlock()
+
+	// Sanity: no logIndex entry backs the interval, so it is NOT a real
+	// residual.
+	if len(idx.EntriesForInterval(0, 4096)) != 0 {
+		t.Fatalf("expected no logIndex entries for divergent interval")
+	}
+	if got := bc.payloadsWithRealResidual([]string{payloadID}); len(got) != 0 {
+		t.Fatalf("payloadsWithRealResidual on divergent interval = %v, want empty", got)
+	}
+
+	// DrainRollups drops the divergent interval (rollupFile DropExact) and
+	// succeeds.
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups on divergent-only residual = %v, want nil", err)
 	}
 }
 

--- a/pkg/blockstore/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/blockstore/local/fs/drain_reset_testhelpers_test.go
@@ -1,0 +1,119 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+)
+
+// memFBS is a minimal in-memory blockstore.EngineFileBlockStore that
+// retains the per-payload FileBlock manifest rows persisted by the rollup
+// ObjectIDPersister. Unlike nopFBS, its ListFileBlocks returns the stored
+// rows so ReadPayloadAt's CAS-manifest path can resolve rolled-up bytes —
+// which is exactly what ResetLocalState must leave readable after dropping
+// the stale append log.
+type memFBS struct {
+	mu   sync.Mutex
+	rows map[string]map[string]*blockstore.FileBlock // payloadID -> blockID -> row
+}
+
+func newMemFileBlockStore() *memFBS {
+	return &memFBS{rows: make(map[string]map[string]*blockstore.FileBlock)}
+}
+
+// persist mirrors the engine's ObjectIDPersister FileBlock-row write loop
+// (engine.go) so the test FBS holds rows with the canonical
+// "<payloadID>/<offset>" ID that ParseChunkOffset decodes.
+func (m *memFBS) persist(_ context.Context, payloadID string, blocks []blockstore.BlockRef) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pm := m.rows[payloadID]
+	if pm == nil {
+		pm = make(map[string]*blockstore.FileBlock)
+		m.rows[payloadID] = pm
+	}
+	for _, b := range blocks {
+		if b.Hash.IsZero() {
+			continue
+		}
+		id := fmt.Sprintf("%s/%d", payloadID, b.Offset)
+		pm[id] = &blockstore.FileBlock{
+			ID:       id,
+			Hash:     b.Hash,
+			DataSize: b.Size,
+			State:    blockstore.BlockStatePending,
+		}
+	}
+	return nil
+}
+
+func (m *memFBS) ListFileBlocks(_ context.Context, payloadID string) ([]*blockstore.FileBlock, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pm := m.rows[payloadID]
+	out := make([]*blockstore.FileBlock, 0, len(pm))
+	for _, fb := range pm {
+		out = append(out, fb)
+	}
+	return out, nil
+}
+
+func (m *memFBS) GetFileBlock(_ context.Context, blockID string) (*blockstore.FileBlock, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, pm := range m.rows {
+		if fb, ok := pm[blockID]; ok {
+			return fb, nil
+		}
+	}
+	return nil, blockstore.ErrFileBlockNotFound
+}
+
+func (m *memFBS) GetByHash(_ context.Context, _ blockstore.ContentHash) (*blockstore.FileBlock, error) {
+	return nil, nil
+}
+func (m *memFBS) Put(_ context.Context, _ *blockstore.FileBlock) error { return nil }
+func (m *memFBS) Delete(_ context.Context, _ string) error {
+	return blockstore.ErrFileBlockNotFound
+}
+func (m *memFBS) IncrementRefCount(_ context.Context, _ string) error { return nil }
+func (m *memFBS) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
+func (m *memFBS) AddRef(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
+	return blockstore.ErrUnknownHash
+}
+func (m *memFBS) ListPending(_ context.Context, _ time.Duration, _ int) ([]*blockstore.FileBlock, error) {
+	return nil, nil
+}
+
+// newFSStoreForTestWithFBS is newFSStoreForTest with a caller-supplied
+// FileBlockStore so the CAS-manifest read path can resolve rolled-up bytes.
+func newFSStoreForTestWithFBS(t *testing.T, fbs blockstore.EngineFileBlockStore, opts FSStoreOptions) *FSStore {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "fsstore-drainreset-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	bc, err := NewWithOptions(dir, 1<<30, 1<<30, fbs, opts)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = bc.Close()
+		for range 5 {
+			if os.RemoveAll(dir) == nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		_ = os.RemoveAll(dir)
+	})
+	return bc
+}

--- a/pkg/blockstore/local/fs/errors.go
+++ b/pkg/blockstore/local/fs/errors.go
@@ -51,4 +51,18 @@ var (
 	// STATUS_INTERNAL_ERROR, log, and release the goroutine instead of
 	// blocking indefinitely.
 	ErrPressureTimeout = errors.New("append log: pressure wait timed out")
+
+	// ErrDrainIncomplete is returned by DrainRollups when, after a pass
+	// that made no forward progress, dirty intervals remain that are backed
+	// by real unflushed data — i.e. the payload is NOT tombstoned and its
+	// logIndex CAN back the residual intervals, so the bytes should have
+	// reached CAS but did not. Returning nil here would let snapshot-create
+	// proceed to Backup with a partial manifest; surfacing this sentinel
+	// lets runSnapshotOrchestration fail the snapshot visibly instead.
+	//
+	// Tombstoned payloads and tree/logIndex-divergent intervals (the
+	// rollupFile DropExact path — bytes that never reached a chunk) are NOT
+	// reported via this error: they are legitimately skipped and the drain
+	// returns nil.
+	ErrDrainIncomplete = errors.New("append log: drain left real unflushed dirty data")
 )

--- a/pkg/blockstore/local/fs/interval_tree.go
+++ b/pkg/blockstore/local/fs/interval_tree.go
@@ -99,6 +99,24 @@ func (it *intervalTree) EarliestStable(now time.Time, stabilization time.Duratio
 	return *found, true
 }
 
+// Earliest returns the interval with the smallest Offset, ignoring the
+// stabilization window entirely. Used by the forced snapshot-drain path
+// (DrainRollups → rollupFile force=true): at snapshot time every written
+// byte must be flushed to CAS, so the stabilization gate that
+// EarliestStable enforces is intentionally bypassed. Returns
+// (interval{}, false) when the tree is empty.
+func (it *intervalTree) Earliest() (interval, bool) {
+	var found *interval
+	it.t.Ascend(func(iv *interval) bool {
+		found = iv
+		return false // smallest-Offset entry; stop
+	})
+	if found == nil {
+		return interval{}, false
+	}
+	return *found, true
+}
+
 // ConsumeUpTo drops every interval whose end (Offset+Length) is <=
 // endExclusive. Called by the rollup after chunks covering [0, endExclusive)
 // have been durably committed.

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -76,7 +76,7 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 	for {
 		select {
 		case pid := <-bc.rollupCh:
-			if err := bc.rollupFile(ctx, pid); err != nil {
+			if err := bc.rollupFile(ctx, pid, false); err != nil {
 				// Log at Error so misconfigured or corrupted state is
 				// observable; the dirty interval stays in the tree and
 				// a future pass (or restart + recovery) retries. A
@@ -110,7 +110,7 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := bc.rollupFile(ctx, pid); err != nil {
+		if err := bc.rollupFile(ctx, pid, false); err != nil {
 			slog.Error("rollupFile failed",
 				"payloadID", pid, "error", err, "source", "ticker")
 		}
@@ -147,7 +147,15 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 //
 // will reconcile the header on next boot.
 //  5. tree.ConsumeUpTo + logBytesTotal.Add(-reclaimed) + pressureCh signal.
-func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
+//
+// force=true bypasses the stabilization-window gate: the earliest dirty
+// interval is consumed regardless of how recently it was touched. This is
+// the snapshot-drain path (DrainRollups) — at snapshot time we want every
+// written byte flushed to CAS + the FileBlock manifest NOW, not just the
+// bytes that have aged past the stabilization window. Steady-state rollup
+// (worker pool, ticker) always passes force=false to preserve the
+// stabilization invariant.
+func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool) error {
 	if bc.isClosed() {
 		return nil
 	}
@@ -197,7 +205,15 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string) error {
 		return nil
 	}
 
-	stable, ok := tree.EarliestStable(time.Now(), stabilization)
+	var stable interval
+	var ok bool
+	if force {
+		// Snapshot drain: take the earliest dirty interval regardless of
+		// the stabilization window. Every written byte must reach CAS.
+		stable, ok = tree.Earliest()
+	} else {
+		stable, ok = tree.EarliestStable(time.Now(), stabilization)
+	}
 	if !ok {
 		return nil
 	}

--- a/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_dedup_lru_669_regression_test.go
@@ -88,7 +88,7 @@ func TestRollup_DedupLRU_PersisterFailure_StaysEmpty(t *testing.T) {
 	// Drive stabilization, then call rollupFile directly so we can
 	// observe the propagated persister error.
 	waitForStable(t, bc, pid)
-	err := bc.rollupFile(ctx, pid)
+	err := bc.rollupFile(ctx, pid, false)
 	if !errors.Is(err, simulated) {
 		t.Fatalf("rollupFile error: got %v, want errors.Is(simulated)", err)
 	}

--- a/pkg/blockstore/local/fs/rollup_divergence_test.go
+++ b/pkg/blockstore/local/fs/rollup_divergence_test.go
@@ -67,7 +67,7 @@ func TestRollup_DivergentInterval_DroppedNoLoop(t *testing.T) {
 	// rollupFile until the divergent interval is the earliest stable.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if err := bc.rollupFile(ctx, payloadID); err != nil {
+		if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 			t.Fatalf("rollupFile returned error (divergence wedge regression): %v", err)
 		}
 		bc.logsMu.RLock()
@@ -118,7 +118,7 @@ func TestRollup_DivergentInterval_NoErrorReturned(t *testing.T) {
 	tree.Insert(0, 4096, pastTouch)
 	mu.Unlock()
 
-	if err := bc.rollupFile(ctx, payloadID); err != nil {
+	if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 		t.Fatalf("rollupFile returned error on divergent interval: %v", err)
 	}
 
@@ -131,7 +131,7 @@ func TestRollup_DivergentInterval_NoErrorReturned(t *testing.T) {
 	}
 
 	// Second pass: must remain a no-op (no loop).
-	if err := bc.rollupFile(ctx, payloadID); err != nil {
+	if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 		t.Fatalf("second rollupFile after drain returned error: %v", err)
 	}
 }

--- a/pkg/blockstore/local/fs/rollup_idempotent_dedup_bench_test.go
+++ b/pkg/blockstore/local/fs/rollup_idempotent_dedup_bench_test.go
@@ -77,7 +77,7 @@ func runRollupOncePB(b *testing.B, bc *FSStore, payloadID string, payload []byte
 	if !bc.EarliestStableForTest(payloadID) {
 		b.Fatal("dirty interval did not stabilize within 500 ms")
 	}
-	if err := bc.rollupFile(ctx, payloadID); err != nil {
+	if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 		b.Fatalf("rollupFile: %v", err)
 	}
 }

--- a/pkg/blockstore/local/fs/rollup_test.go
+++ b/pkg/blockstore/local/fs/rollup_test.go
@@ -192,7 +192,7 @@ func TestRollup_CommitChunks_MonotoneEnforced(t *testing.T) {
 		t.Fatal("dirty interval did not stabilize within 500 ms — test cannot exercise regression-rejection branch")
 	}
 
-	if err := bc.rollupFile(ctx, "file1"); err != nil {
+	if err := bc.rollupFile(ctx, "file1", false); err != nil {
 		t.Fatalf("rollupFile on regression: want nil (benign), got %v", err)
 	}
 
@@ -377,7 +377,7 @@ func TestRollup_TruncateMidWindow_DoesNotAdvancePastUncommittedTail(t *testing.T
 	// Wait for stabilization (1 ms).
 	time.Sleep(20 * time.Millisecond)
 
-	if err := bc.rollupFile(ctx, "tfile"); err != nil {
+	if err := bc.rollupFile(ctx, "tfile", false); err != nil {
 		t.Fatalf("rollupFile: %v", err)
 	}
 
@@ -436,7 +436,7 @@ func runRollupOnceErr(bc *FSStore, payloadID string, payload []byte) error {
 	if !bc.EarliestStableForTest(payloadID) {
 		return fmt.Errorf("dirty interval did not stabilize within 500 ms")
 	}
-	if err := bc.rollupFile(ctx, payloadID); err != nil {
+	if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 		return fmt.Errorf("rollupFile: %w", err)
 	}
 	return nil
@@ -576,7 +576,7 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 			t.Fatal("dirty interval did not stabilize within 500 ms")
 		}
 
-		err := bc.rollupFile(ctx, "errfile")
+		err := bc.rollupFile(ctx, "errfile", false)
 		if err == nil {
 			t.Fatal("rollupFile: want persister error, got nil")
 		}
@@ -855,7 +855,7 @@ func TestRollup_AddRefError_OtherThan_ErrUnknownHash_Propagates(t *testing.T) {
 		t.Fatal("dirty interval did not stabilize")
 	}
 
-	err := bc.rollupFile(ctx, "errpath")
+	err := bc.rollupFile(ctx, "errpath", false)
 	if err == nil {
 		t.Fatal("rollupFile: want wrapped AddRef error, got nil")
 	}

--- a/pkg/blockstore/local/fs/test_hooks.go
+++ b/pkg/blockstore/local/fs/test_hooks.go
@@ -117,7 +117,7 @@ func (bc *FSStore) HeaderRollupOffsetForTest(payloadID string) uint64 {
 // conformance suite uses this when the ambient worker pool is disabled or
 // timing would otherwise be flaky.
 func (bc *FSStore) ForceRollupForTest(ctx context.Context, payloadID string) error {
-	return bc.rollupFile(ctx, payloadID)
+	return bc.rollupFile(ctx, payloadID, false)
 }
 
 // ReopenForTest closes no store — it constructs a fresh FSStore on

--- a/pkg/blockstore/local/local.go
+++ b/pkg/blockstore/local/local.go
@@ -72,6 +72,38 @@ type LocalStore interface {
 	// zeros until the async rollup commits FileBlock rows.
 	ReadPayloadAt(ctx context.Context, payloadID string, dest []byte, offset uint64) (int, error)
 
+	// --- Snapshot drain / reset ---
+
+	// DrainRollups forces rollup of ALL currently-dirty payloads to
+	// completion, bypassing the stabilization-window gate, and waits for
+	// any in-flight rollup-worker passes to finish. After it returns,
+	// every byte written via AppendWrite has been flushed into CAS AND
+	// into the FileBlock manifest (FileAttr.Blocks), so a metadata
+	// Backup() taken next observes a fully-populated manifest rather than
+	// an empty/partial one.
+	//
+	// This is the snapshot-create primitive. Backends without an
+	// asynchronous rollup (the in-memory store, whose rollup is inline on
+	// every AppendWrite) implement it as a no-op returning nil.
+	DrainRollups(ctx context.Context) error
+
+	// ResetLocalState clears ALL per-payload append-log state — in-memory
+	// indices, dirty intervals, rollup offsets, truncation boundaries —
+	// and removes any on-disk `.log` files, so subsequent reads resolve
+	// purely through the (restored) CAS manifest with no stale append-log
+	// overlay.
+	//
+	// This is the snapshot-restore primitive: after the metadata store is
+	// reset to a prior dump, the block store's per-payload append log may
+	// still hold post-snapshot write records that ReadPayloadAt would
+	// otherwise replay on top of the restored CAS content ("last record
+	// wins"), corrupting in-place-modified files. ResetLocalState drops
+	// that overlay. Callers MUST have quiesced writes (share disabled)
+	// before invoking it; it is safe only because the restored snapshot
+	// (and the pre-restore safety snapshot) drained rollups, so all
+	// content that must survive is already durable in CAS.
+	ResetLocalState(ctx context.Context) error
+
 	// --- Lifecycle ---
 
 	// Start launches background goroutines (e.g., periodic metadata

--- a/pkg/blockstore/local/memory/memory.go
+++ b/pkg/blockstore/local/memory/memory.go
@@ -451,6 +451,29 @@ func (s *MemoryStore) DeleteAppendLog(_ context.Context, payloadID string) error
 	return nil
 }
 
+// DrainRollups is a no-op on the memory store. Its rollup runs inline on
+// every AppendWrite (rollupLocked), so there is never a pending async
+// rollup to force — the CAS map and any wired chunkEmitter are always
+// current. Returns nil. Implements local.LocalStore.
+func (s *MemoryStore) DrainRollups(_ context.Context) error { return nil }
+
+// ResetLocalState clears the per-payload append-log buffers and tracked
+// file sizes so a subsequent ReadPayloadAt cannot serve stale post-restore
+// bytes from the in-memory buffer. The CAS map is intentionally retained:
+// restored content is resolved through the CAS chunks the manifest
+// references, exactly as the on-disk backend resolves through its CAS
+// store after dropping the append log. Implements local.LocalStore.
+func (s *MemoryStore) ResetLocalState(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return ErrStoreClosed
+	}
+	s.appendLogs = make(map[string]*appendLog)
+	s.files = make(map[string]uint64)
+	return nil
+}
+
 // SyncFileBlocks is a no-op in the memory store (no persistent store to sync to).
 func (s *MemoryStore) SyncFileBlocks(_ context.Context) {}
 

--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -158,6 +159,48 @@ type BlockRef struct {
 	Hash   ContentHash `json:"hash"`
 	Offset uint64      `json:"offset"`
 	Size   uint32      `json:"size"`
+}
+
+// MergeBlockRefsByOffset overlays incoming block refs onto existing ones,
+// keyed by byte range. Every incoming ref is kept; an existing ref is kept
+// only if its [Offset, Offset+Size) range does not overlap any incoming ref.
+// The result is sorted by Offset ascending.
+//
+// This models a rollup pass committing a slice of a file: appended chunks
+// (new, non-overlapping offsets) extend the list, while an in-place rewrite
+// (incoming chunks covering an existing byte range, possibly with different
+// FastCDC boundaries) replaces the overlapped existing chunks. It is the
+// accumulation step that keeps FileAttr.Blocks complete across multi-pass
+// rollups instead of replacing it with only the latest pass (#789).
+func MergeBlockRefsByOffset(existing, incoming []BlockRef) []BlockRef {
+	if len(incoming) == 0 {
+		out := make([]BlockRef, len(existing))
+		copy(out, existing)
+		sortBlockRefsByOffset(out)
+		return out
+	}
+	out := make([]BlockRef, 0, len(existing)+len(incoming))
+	for _, e := range existing {
+		eEnd := e.Offset + uint64(e.Size)
+		overlaps := false
+		for _, in := range incoming {
+			inEnd := in.Offset + uint64(in.Size)
+			if e.Offset < inEnd && in.Offset < eEnd {
+				overlaps = true
+				break
+			}
+		}
+		if !overlaps {
+			out = append(out, e)
+		}
+	}
+	out = append(out, incoming...)
+	sortBlockRefsByOffset(out)
+	return out
+}
+
+func sortBlockRefsByOffset(b []BlockRef) {
+	sort.Slice(b, func(i, j int) bool { return b[i].Offset < b[j].Offset })
 }
 
 // FileBlock is the single block entity in DittoFS. Content-addressed

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -37,6 +37,13 @@ var (
 	ErrSnapshotRetryTargetNotFound  = errors.New("snapshot retry target not found")
 	ErrSnapshotRetryTargetNotFailed = errors.New("snapshot retry target is not in failed state")
 
+	// ErrSnapshotLocalStoreUnsupported is returned when a snapshot is
+	// requested on a share whose local block store has no on-disk root
+	// (the in-memory backend), so the metadata.dump + manifest.hashes
+	// artifacts have nowhere to be written. Mapped to 400 (client config
+	// error, not a server fault).
+	ErrSnapshotLocalStoreUnsupported = errors.New("snapshots require an fs-backed local store")
+
 	// Restore orchestration sentinels.
 	ErrShareEnabled                = errors.New("share must be disabled before restore")
 	ErrSnapshotNotDurable          = errors.New("snapshot is not remote-durable; pass AllowNonDurable to override")

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -37,6 +37,15 @@ var (
 	ErrSnapshotRetryTargetNotFound  = errors.New("snapshot retry target not found")
 	ErrSnapshotRetryTargetNotFailed = errors.New("snapshot retry target is not in failed state")
 
+	// ErrSnapshotManifestIncomplete is returned when the backup-derived
+	// manifest covers fewer blocks than the share's metadata still
+	// references (manifestCount < live hash count). The most common cause
+	// is a metadata backend that persists block refs incompletely (e.g.
+	// the Postgres multi-chunk bug, #789): the snapshot would verify only
+	// the captured subset and falsely report remote_durable=true over a
+	// silently-truncated manifest. Fail the snapshot loudly instead.
+	ErrSnapshotManifestIncomplete = errors.New("snapshot manifest is incomplete: backend did not persist all block refs")
+
 	// ErrSnapshotInFlight is returned when an operation (delete) is
 	// attempted on a snapshot whose create/retry orchestration is still
 	// running. Mapped to 409 — the caller should retry once the

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -37,15 +37,6 @@ var (
 	ErrSnapshotRetryTargetNotFound  = errors.New("snapshot retry target not found")
 	ErrSnapshotRetryTargetNotFailed = errors.New("snapshot retry target is not in failed state")
 
-	// ErrSnapshotManifestIncomplete is returned when the backup-derived
-	// manifest covers fewer blocks than the share's metadata still
-	// references (manifestCount < live hash count). The most common cause
-	// is a metadata backend that persists block refs incompletely (e.g.
-	// the Postgres multi-chunk bug, #789): the snapshot would verify only
-	// the captured subset and falsely report remote_durable=true over a
-	// silently-truncated manifest. Fail the snapshot loudly instead.
-	ErrSnapshotManifestIncomplete = errors.New("snapshot manifest is incomplete: backend did not persist all block refs")
-
 	// ErrSnapshotInFlight is returned when an operation (delete) is
 	// attempted on a snapshot whose create/retry orchestration is still
 	// running. Mapped to 409 — the caller should retry once the

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -37,6 +37,12 @@ var (
 	ErrSnapshotRetryTargetNotFound  = errors.New("snapshot retry target not found")
 	ErrSnapshotRetryTargetNotFailed = errors.New("snapshot retry target is not in failed state")
 
+	// ErrSnapshotInFlight is returned when an operation (delete) is
+	// attempted on a snapshot whose create/retry orchestration is still
+	// running. Mapped to 409 — the caller should retry once the
+	// orchestration reaches a terminal state.
+	ErrSnapshotInFlight = errors.New("snapshot operation is in progress")
+
 	// ErrSnapshotLocalStoreUnsupported is returned when a snapshot is
 	// requested on a share whose local block store has no on-disk root
 	// (the in-memory backend), so the metadata.dump + manifest.hashes

--- a/pkg/controlplane/models/snapshot.go
+++ b/pkg/controlplane/models/snapshot.go
@@ -27,6 +27,7 @@ type Snapshot struct {
 	MetadataEngine string    `gorm:"not null;size:20" json:"metadata_engine"`
 	ManifestCount  int64     `gorm:"not null;default:0" json:"manifest_count"`
 	RemoteDurable  bool      `gorm:"not null;default:false" json:"remote_durable"`
+	Error          string    `gorm:"size:1024" json:"error,omitempty"`
 	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt      time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 }

--- a/pkg/controlplane/models/snapshot.go
+++ b/pkg/controlplane/models/snapshot.go
@@ -21,6 +21,7 @@ const (
 // in-flight snapshot per share.
 type Snapshot struct {
 	ID             string    `gorm:"primaryKey;size:36" json:"id"`
+	Name           string    `gorm:"size:255" json:"name,omitempty"`
 	ShareName      string    `gorm:"index;not null;size:255;index:idx_share_creating,where:state='creating',unique" json:"share_name"`
 	State          string    `gorm:"not null;size:20;default:'creating'" json:"state"`
 	MetadataEngine string    `gorm:"not null;size:20" json:"metadata_engine"`

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
@@ -165,6 +166,46 @@ func (c *metadataCoordinator) PersistFileBlocks(ctx context.Context, payloadID s
 		}
 		return nil
 	})
+}
+
+// GetPersistedBlocks returns the file's currently-persisted FileAttr.Blocks
+// (with content hashes) for payloadID. Resolves payloadID → file row, then
+// loads the authoritative block list: Badger/Memory return it inline from
+// GetFileByPayloadID, while Postgres' GetFileByPayloadID omits blocks (a
+// read-cost optimization), so we fall back to GetFile-by-handle which loads
+// file_block_refs. Returns an empty slice (nil) when the file has no blocks
+// yet or does not exist.
+func (c *metadataCoordinator) GetPersistedBlocks(ctx context.Context, payloadID string) ([]blockstore.BlockRef, error) {
+	file, err := c.metadataStore.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
+	if err != nil {
+		return nil, fmt.Errorf("coordinator: GetFileByPayloadID(%s): %w", payloadID, err)
+	}
+	if file == nil {
+		return nil, nil
+	}
+	if len(file.Blocks) > 0 {
+		return file.Blocks, nil
+	}
+	// Memory's GetFileByPayloadID returns blocks inline but leaves ID zero;
+	// an empty Blocks here therefore means "no blocks yet" (the handle
+	// fallback below would build an unresolvable zero-ID handle). Postgres
+	// sets ID and omits blocks, so it takes the fallback to load
+	// file_block_refs.
+	if file.ID == uuid.Nil {
+		return nil, nil
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		return nil, fmt.Errorf("coordinator: EncodeFileHandle(%s): %w", payloadID, err)
+	}
+	full, err := c.metadataStore.GetFile(ctx, handle)
+	if err != nil {
+		return nil, fmt.Errorf("coordinator: GetFile(%s): %w", payloadID, err)
+	}
+	if full == nil {
+		return nil, nil
+	}
+	return full.Blocks, nil
 }
 
 // mapObjectIDConflict wraps backend conflict errors into

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -178,6 +178,13 @@ func (c *metadataCoordinator) PersistFileBlocks(ctx context.Context, payloadID s
 func (c *metadataCoordinator) GetPersistedBlocks(ctx context.Context, payloadID string) ([]blockstore.BlockRef, error) {
 	file, err := c.metadataStore.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
 	if err != nil {
+		// File deleted between WriteAt and rollup commit: no blocks to
+		// merge. Mirror GetFileObjectID — treat not-found as benign so the
+		// rollup persister falls through to PersistFileBlocks (which then
+		// surfaces the missing row) rather than wedging on a wrapped error.
+		if metadata.IsNotFoundError(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("coordinator: GetFileByPayloadID(%s): %w", payloadID, err)
 	}
 	if file == nil {

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -987,32 +987,44 @@ func (r *Runtime) RestoreSnapshot(
 		return "", fmt.Errorf("restore snapshot %q: share %q has no block store: %w",
 			snapID, shareName, models.ErrRestoreVerifyFailed)
 	}
+	// A share with no remote store is local-only: snapshots there are not
+	// remotely durable (the precheck above already required AllowNonDurable
+	// for such a snapshot), and there is nothing to HEAD-probe. Skip both
+	// the pre- and post-verify remote probes and restore from local CAS.
+	// The remote-backed path is unchanged.
 	remoteStore := bs.RemoteStore()
-	if remoteStore == nil {
-		return "", fmt.Errorf("restore snapshot %q: share %q has no remote store, cannot verify: %w",
-			snapID, shareName, models.ErrRestoreVerifyFailed)
-	}
+	remoteVerify := remoteStore != nil
 	// Hardcoded; benchmarking confirmed no operator tuning need.
 	concurrency := 16
-	logger.Info("snapshot restore: pre-verify start",
-		"snapshot_id", snapID,
-		"share", shareName,
-		"manifest_count", manifest.Len(),
-		"verify_concurrency", concurrency,
-	)
-	if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, manifest, concurrency); verr != nil {
-		return "", fmt.Errorf("restore snapshot %q: pre-verify: %w: %v",
-			snapID, models.ErrRestoreVerifyFailed, verr)
+	if !remoteVerify {
+		logger.Info("snapshot restore: local-only share, skipping remote pre-verify",
+			"snapshot_id", snapID, "share", shareName)
+	} else {
+		logger.Info("snapshot restore: pre-verify start",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"manifest_count", manifest.Len(),
+			"verify_concurrency", concurrency,
+		)
+		if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, manifest, concurrency); verr != nil {
+			return "", fmt.Errorf("restore snapshot %q: pre-verify: %w: %v",
+				snapID, models.ErrRestoreVerifyFailed, verr)
+		}
+		logger.Info("snapshot restore: pre-verify ok",
+			"snapshot_id", snapID,
+			"share", shareName,
+		)
 	}
-	logger.Info("snapshot restore: pre-verify ok",
-		"snapshot_id", snapID,
-		"share", shareName,
-	)
 
 	// --- safety snapshot ---
 	// Default opts (NoVerify=false) keep the safety snap drained and
-	// verified — it is the rollback primitive if any step below fails.
-	safetySnapshotID, err = r.CreateSnapshot(ctx, shareName, CreateSnapshotOpts{})
+	// verified — it is the rollback primitive if any step below fails. On a
+	// local-only share there is no remote to verify against, so the safety
+	// snap must skip the verify gate too (NoVerify), mirroring the
+	// remote-skip applied to the pre/post restore verify above; otherwise
+	// the safety snap would fail at its own create-verify step and abort an
+	// otherwise-valid local restore.
+	safetySnapshotID, err = r.CreateSnapshot(ctx, shareName, CreateSnapshotOpts{NoVerify: !remoteVerify})
 	if err != nil {
 		return "", fmt.Errorf("restore snapshot %q: create safety snap: %w: %v",
 			snapID, models.ErrRestoreSafetySnapFailed, err)
@@ -1120,16 +1132,21 @@ func (r *Runtime) RestoreSnapshot(
 			snapID, safetySnapshotID, models.ErrRestoreVerifyFailed, err)
 	}
 	restoredCount := restoredHashes.Len()
-	logger.Info("snapshot restore: post-verify start",
-		"snapshot_id", snapID,
-		"share", shareName,
-		"safety_snap_id", safetySnapshotID,
-		"restored_count", restoredCount,
-		"verify_concurrency", concurrency,
-	)
-	if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, restoredHashes, concurrency); verr != nil {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: post-verify (safety-snap=%s): %w: %v",
-			snapID, safetySnapshotID, models.ErrRestoreVerifyFailed, verr)
+	if !remoteVerify {
+		logger.Info("snapshot restore: local-only share, skipping remote post-verify",
+			"snapshot_id", snapID, "share", shareName, "restored_count", restoredCount)
+	} else {
+		logger.Info("snapshot restore: post-verify start",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"safety_snap_id", safetySnapshotID,
+			"restored_count", restoredCount,
+			"verify_concurrency", concurrency,
+		)
+		if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, restoredHashes, concurrency); verr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: post-verify (safety-snap=%s): %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreVerifyFailed, verr)
+		}
 	}
 
 	// Share STAYS DISABLED — operator re-enables after inspecting result.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -366,6 +366,23 @@ func (r *Runtime) unregisterSnap(shareName, snapID string, entry *snapInFlight) 
 	entry.mu.Unlock()
 }
 
+// deriveWaitCtx returns a ctx rooted at r.runtimeCtx (so it is cancelled on
+// runtime shutdown but NOT by the caller's request cancellation, e.g. an
+// HTTP client disconnect) while still honoring the caller ctx's deadline if
+// it has one. The returned cancel func must always be called to release
+// resources. Used by RestoreSnapshot to wait for the safety snapshot
+// without letting a disconnect abandon the wait.
+func (r *Runtime) deriveWaitCtx(caller context.Context) (context.Context, context.CancelFunc) {
+	root := r.runtimeCtx
+	if root == nil {
+		root = context.Background()
+	}
+	if dl, ok := caller.Deadline(); ok {
+		return context.WithDeadline(root, dl)
+	}
+	return context.WithCancel(root)
+}
+
 // isSnapInFlight reports whether an orchestration goroutine for
 // (shareName, snapID) is currently registered (create or retry in
 // progress). Used by DeleteSnapshot to fence the delete against a running
@@ -1047,7 +1064,15 @@ func (r *Runtime) RestoreSnapshot(
 		return "", fmt.Errorf("restore snapshot %q: create safety snap: %w: %v",
 			snapID, models.ErrRestoreSafetySnapFailed, err)
 	}
-	safetySnap, err := r.WaitForSnapshot(ctx, shareName, safetySnapshotID)
+	// Wait on a ctx derived from runtimeCtx, NOT the caller's request ctx:
+	// the safety snap's orchestration is itself launched off runtimeCtx
+	// (CreateSnapshot), so a client disconnect must not abandon a wait that
+	// leaves a stray ready safety snap and a confusingly-aborted restore.
+	// The caller's deadline (if any) is preserved so a request timeout still
+	// bounds the wait; only the caller's cancellation signal is dropped.
+	waitCtx, waitCancel := r.deriveWaitCtx(ctx)
+	safetySnap, err := r.WaitForSnapshot(waitCtx, shareName, safetySnapshotID)
+	waitCancel()
 	if err != nil {
 		return safetySnapshotID, fmt.Errorf("restore snapshot %q: wait safety snap %q: %w: %v",
 			snapID, safetySnapshotID, models.ErrRestoreSafetySnapFailed, err)

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -584,46 +584,57 @@ func (r *Runtime) runSnapshotOrchestration(
 			"snapshot_id", snapID, "share", shareName)
 		return
 	}
-	// --- empty-manifest guard: empty manifest on a non-empty share ---
-	// VerifyRemoteDurability returns success for an empty manifest without
-	// probing any block (verify.go). After the Step-0 drain a genuinely
-	// non-empty share MUST produce a non-empty manifest; an empty one
-	// means the backup undercounted the share's referenced blocks (e.g. a
-	// rollup that never persisted FileAttr.Blocks).
-	// Reporting remote_durable=true here would be a hollow durability
-	// claim over zero verified blocks. Cross-check the manifest against
-	// the live FileBlock enumeration; fail if the store still references
-	// hashes but the manifest captured none. A truly-empty share (both
-	// zero) legitimately passes with a vacuous verify.
-	if manifestCount == 0 {
+	// --- manifest-completeness guard ---
+	// VerifyRemoteDurability only probes the hashes the manifest captured,
+	// so it cannot detect a manifest that captured FEWER blocks than the
+	// share's metadata still references. Two undercount modes must both be
+	// caught here before we can honestly report remote_durable=true:
+	//
+	//   - empty manifest on a non-empty share (manifestCount == 0 < live):
+	//     a rollup that never persisted FileAttr.Blocks, so the verify
+	//     would be vacuous over zero blocks.
+	//   - partial manifest (0 < manifestCount < live): a backend that
+	//     persisted block refs incompletely (the Postgres multi-chunk bug,
+	//     #789). The verify would cover only the captured subset and mark
+	//     the snapshot durable over a silently-truncated manifest.
+	//
+	// Enumerate the live hash set UNCONDITIONALLY and require the manifest
+	// to cover every block the metadata references (manifestCount ==
+	// liveHashes.Len()). A genuinely-empty share (both zero) legitimately
+	// passes with a vacuous verify.
+	{
 		metaStore, mserr := r.GetMetadataStoreForShare(shareName)
 		if mserr != nil {
-			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for empty-manifest check: %w: %v",
+			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for manifest-completeness check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, mserr)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: metadata store lookup failed (empty-manifest check)",
+			logger.Error("snapshot create: metadata store lookup failed (manifest-completeness check)",
 				"snapshot_id", snapID, "share", shareName, "error", mserr)
 			return
 		}
 		liveHashes, herr := snapshot.HashSetFromMetadataStore(ctx, metaStore)
 		if herr != nil {
-			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for empty-manifest check: %w: %v",
+			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for manifest-completeness check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, herr)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: live hash enumeration failed (empty-manifest check)",
+			logger.Error("snapshot create: live hash enumeration failed (manifest-completeness check)",
 				"snapshot_id", snapID, "share", shareName, "error", herr)
 			return
 		}
-		if liveHashes.Len() > 0 {
-			terminalErr = fmt.Errorf("snapshot create %s: empty manifest on non-empty share (%d live hashes), refusing to report durability: %w",
-				snapID, liveHashes.Len(), models.ErrSnapshotVerifyFailed)
+		liveCount := liveHashes.Len()
+		if manifestCount < liveCount {
+			terminalErr = fmt.Errorf("snapshot create %s: manifest covers %d of %d blocks the metadata references, refusing to report durability: %w",
+				snapID, manifestCount, liveCount, models.ErrSnapshotManifestIncomplete)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: empty manifest on non-empty share",
-				"snapshot_id", snapID, "share", shareName, "live_hashes", liveHashes.Len())
+			logger.Error("snapshot create: incomplete manifest on non-empty share",
+				"snapshot_id", snapID, "share", shareName,
+				"manifest_count", manifestCount, "live_hashes", liveCount)
 			return
 		}
-		logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
-			"snapshot_id", snapID, "share", shareName)
+		if liveCount == 0 {
+			logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
+				"snapshot_id", snapID, "share", shareName)
+		}
 	}
 
 	// Hardcoded; benchmarking confirmed no operator tuning need.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -22,6 +22,11 @@ import (
 // CreateSnapshot invocation. Zero-value (NoVerify=false, RetryOf="")
 // requests the default behavior: a fresh UUID, verify gate enabled.
 type CreateSnapshotOpts struct {
+	// Name is an optional human-readable label persisted on the snapshot
+	// row. Empty leaves the column empty. Ignored on the RetryOf path,
+	// which inherits the original row's Name.
+	Name string
+
 	// NoVerify skips DrainAllUploads + VerifyRemoteDurability (the verify
 	// gate). Final state: ready with RemoteDurable=false. Restore reads
 	// RemoteDurable=false and refuses unless AllowNonDurable is set.
@@ -137,6 +142,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 		// Fresh-create path: insert a new row.
 		snap = &models.Snapshot{
 			ID:             uuid.NewString(),
+			Name:           opts.Name,
 			ShareName:      shareName,
 			State:          models.StateCreating,
 			MetadataEngine: metadataEngine,

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -412,6 +412,33 @@ func (r *Runtime) runSnapshotOrchestration(
 	// CRUD methods only need (shareName, id) so we don't need to refetch.
 	snap := &models.Snapshot{ID: snapID, ShareName: shareName}
 
+	// --- Step 0: Drain rollups BEFORE Backup ---
+	// Force every dirty append-log payload through rollup into CAS + the
+	// FileBlock manifest so the Backup() below sees a fully-populated
+	// FileAttr.Blocks. Without this, a snapshot taken before the async
+	// rollup catches up captures an empty/partial manifest — the C1 bug.
+	// Resolve the block store once here; the verify gate (Step 4) reuses
+	// the same lookup pattern.
+	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
+	if err != nil || bs == nil {
+		r.failSnap(shareName, snapID)
+		terminalErr = fmt.Errorf("snapshot create %s: no block store for share %q: %w",
+			snapID, shareName, models.ErrSnapshotBackupFailed)
+		logger.Error("snapshot create: block store lookup failed (pre-backup)",
+			"snapshot_id", snapID, "share", shareName, "error", err)
+		return
+	}
+	logger.Debug("snapshot create: drain rollups start", "snapshot_id", snapID, "share", shareName)
+	if derr := bs.DrainRollups(ctx); derr != nil {
+		r.failSnap(shareName, snapID)
+		terminalErr = fmt.Errorf("snapshot create %s: drain rollups: %w: %v",
+			snapID, models.ErrSnapshotBackupFailed, derr)
+		logger.Error("snapshot create: drain rollups failed",
+			"snapshot_id", snapID, "share", shareName, "error", derr)
+		return
+	}
+	logger.Debug("snapshot create: drain rollups complete", "snapshot_id", snapID, "share", shareName)
+
 	// --- Step 1: Backup -> metadata.dump (atomic temp+rename) ---
 	dumpPath := snap.MetadataDumpPath(localStoreDir)
 	logger.Debug("snapshot create: backup start",
@@ -495,15 +522,7 @@ func (r *Runtime) runSnapshotOrchestration(
 	}
 
 	// --- Step 4: Verify gate drain ---
-	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
-	if err != nil || bs == nil {
-		r.failSnap(shareName, snapID)
-		terminalErr = fmt.Errorf("snapshot create %s: no block store for share %q: %w",
-			snapID, shareName, models.ErrSnapshotVerifyFailed)
-		logger.Error("snapshot create: block store lookup failed",
-			"snapshot_id", snapID, "share", shareName, "error", err)
-		return
-	}
+	// bs was resolved in Step 0 and reused here.
 	logger.Debug("snapshot create: drain start", "snapshot_id", snapID, "share", shareName)
 	if err := bs.DrainAllUploads(ctx); err != nil {
 		r.failSnap(shareName, snapID)
@@ -524,6 +543,48 @@ func (r *Runtime) runSnapshotOrchestration(
 			"snapshot_id", snapID, "share", shareName)
 		return
 	}
+	// --- C3 guard: empty manifest on a non-empty share ---
+	// VerifyRemoteDurability returns success for an empty manifest without
+	// probing any block (verify.go). After the Step-0 drain a genuinely
+	// non-empty share MUST produce a non-empty manifest; an empty one
+	// means the backup undercounted the share's referenced blocks (e.g. a
+	// rollup that never persisted FileAttr.Blocks — the C1 failure mode).
+	// Reporting remote_durable=true here would be a hollow durability
+	// claim over zero verified blocks. Cross-check the manifest against
+	// the live FileBlock enumeration; fail if the store still references
+	// hashes but the manifest captured none. A truly-empty share (both
+	// zero) legitimately passes with a vacuous verify.
+	if manifestCount == 0 {
+		metaStore, mserr := r.GetMetadataStoreForShare(shareName)
+		if mserr != nil {
+			r.failSnap(shareName, snapID)
+			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for empty-manifest check: %w: %v",
+				snapID, models.ErrSnapshotVerifyFailed, mserr)
+			logger.Error("snapshot create: metadata store lookup failed (empty-manifest check)",
+				"snapshot_id", snapID, "share", shareName, "error", mserr)
+			return
+		}
+		liveHashes, herr := snapshot.HashSetFromMetadataStore(ctx, metaStore)
+		if herr != nil {
+			r.failSnap(shareName, snapID)
+			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for empty-manifest check: %w: %v",
+				snapID, models.ErrSnapshotVerifyFailed, herr)
+			logger.Error("snapshot create: live hash enumeration failed (empty-manifest check)",
+				"snapshot_id", snapID, "share", shareName, "error", herr)
+			return
+		}
+		if liveHashes.Len() > 0 {
+			r.failSnap(shareName, snapID)
+			terminalErr = fmt.Errorf("snapshot create %s: empty manifest on non-empty share (%d live hashes), refusing to report durability: %w",
+				snapID, liveHashes.Len(), models.ErrSnapshotVerifyFailed)
+			logger.Error("snapshot create: empty manifest on non-empty share",
+				"snapshot_id", snapID, "share", shareName, "live_hashes", liveHashes.Len())
+			return
+		}
+		logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
+			"snapshot_id", snapID, "share", shareName)
+	}
+
 	// Hardcoded; benchmarking confirmed no operator tuning need.
 	concurrency := 16
 	logger.Debug("snapshot create: verify start",
@@ -1015,6 +1076,26 @@ func (r *Runtime) RestoreSnapshot(
 			snapID, safetySnapshotID, models.ErrRestoreAborted, err)
 	}
 	logger.Info("snapshot restore: restore ok",
+		"snapshot_id", snapID,
+		"share", shareName,
+		"safety_snap_id", safetySnapshotID,
+	)
+
+	// --- reset block-store local state ---
+	// The metadata store now reflects the snapshot, but the block store's
+	// per-payload append log may still hold post-snapshot write records.
+	// ReadPayloadAt replays those records on top of the restored CAS
+	// content ("last record wins"), so a file modified in place after the
+	// snapshot would come back as the mutated bytes (C2 corruption).
+	// Dropping the append-log overlay makes the restored CAS manifest the
+	// sole source of truth. Safe here because BOTH the snapshot being
+	// restored AND the safety snapshot drained rollups, so every byte that
+	// must survive is already durable in CAS.
+	if rerr := bs.ResetLocalState(ctx); rerr != nil {
+		return safetySnapshotID, fmt.Errorf("restore snapshot %q: reset block-store local state (safety-snap=%s): %w: %v",
+			snapID, safetySnapshotID, models.ErrRestoreAborted, rerr)
+	}
+	logger.Info("snapshot restore: block-store local state reset",
 		"snapshot_id", snapID,
 		"share", shareName,
 		"safety_snap_id", safetySnapshotID,

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -635,7 +635,7 @@ func (r *Runtime) runSnapshotOrchestration(
 		return
 	}
 
-	// --- Step 6: Verify gate drain ---
+	// --- Step 6: Verify gate (drain then verify remote durability) ---
 	logger.Debug("snapshot create: drain start", "snapshot_id", snapID, "share", shareName)
 	if err := bs.DrainAllUploads(ctx); err != nil {
 		terminalErr = fmt.Errorf("snapshot create %s: drain: %w: %v", snapID, drainSentinel(err), err)
@@ -676,7 +676,7 @@ func (r *Runtime) runSnapshotOrchestration(
 		return
 	}
 
-	// --- Step 6: Ready flip ---
+	// --- Step 7: Ready flip ---
 	// Atomically transition state=creating -> state=ready AND set
 	// remote_durable=true in a single conditional UPDATE. A two-step
 	// (state, durable) sequence would leave a transient window where a

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -78,8 +78,8 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 		return "", err
 	}
 	if localStoreDir == "" {
-		return "", fmt.Errorf("snapshot create %q: memory-only share has no local store dir: %w",
-			shareName, models.ErrSnapshotBackupFailed)
+		return "", fmt.Errorf("snapshot create %q: in-memory local store has no on-disk root: %w",
+			shareName, models.ErrSnapshotLocalStoreUnsupported)
 	}
 
 	// (2) Resolve metadata store + type-assert to Backupable.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -584,57 +584,46 @@ func (r *Runtime) runSnapshotOrchestration(
 			"snapshot_id", snapID, "share", shareName)
 		return
 	}
-	// --- manifest-completeness guard ---
-	// VerifyRemoteDurability only probes the hashes the manifest captured,
-	// so it cannot detect a manifest that captured FEWER blocks than the
-	// share's metadata still references. Two undercount modes must both be
-	// caught here before we can honestly report remote_durable=true:
-	//
-	//   - empty manifest on a non-empty share (manifestCount == 0 < live):
-	//     a rollup that never persisted FileAttr.Blocks, so the verify
-	//     would be vacuous over zero blocks.
-	//   - partial manifest (0 < manifestCount < live): a backend that
-	//     persisted block refs incompletely (the Postgres multi-chunk bug,
-	//     #789). The verify would cover only the captured subset and mark
-	//     the snapshot durable over a silently-truncated manifest.
-	//
-	// Enumerate the live hash set UNCONDITIONALLY and require the manifest
-	// to cover every block the metadata references (manifestCount ==
-	// liveHashes.Len()). A genuinely-empty share (both zero) legitimately
-	// passes with a vacuous verify.
-	{
+	// --- empty-manifest guard: empty manifest on a non-empty share ---
+	// VerifyRemoteDurability returns success for an empty manifest without
+	// probing any block (verify.go). After the Step-0 drain a genuinely
+	// non-empty share MUST produce a non-empty manifest; an empty one
+	// means the backup undercounted the share's referenced blocks (e.g. a
+	// rollup that never persisted FileAttr.Blocks).
+	// Reporting remote_durable=true here would be a hollow durability
+	// claim over zero verified blocks. Cross-check the manifest against
+	// the live FileBlock enumeration; fail if the store still references
+	// hashes but the manifest captured none. A truly-empty share (both
+	// zero) legitimately passes with a vacuous verify.
+	if manifestCount == 0 {
 		metaStore, mserr := r.GetMetadataStoreForShare(shareName)
 		if mserr != nil {
-			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for manifest-completeness check: %w: %v",
+			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for empty-manifest check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, mserr)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: metadata store lookup failed (manifest-completeness check)",
+			logger.Error("snapshot create: metadata store lookup failed (empty-manifest check)",
 				"snapshot_id", snapID, "share", shareName, "error", mserr)
 			return
 		}
 		liveHashes, herr := snapshot.HashSetFromMetadataStore(ctx, metaStore)
 		if herr != nil {
-			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for manifest-completeness check: %w: %v",
+			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for empty-manifest check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, herr)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: live hash enumeration failed (manifest-completeness check)",
+			logger.Error("snapshot create: live hash enumeration failed (empty-manifest check)",
 				"snapshot_id", snapID, "share", shareName, "error", herr)
 			return
 		}
-		liveCount := liveHashes.Len()
-		if manifestCount < liveCount {
-			terminalErr = fmt.Errorf("snapshot create %s: manifest covers %d of %d blocks the metadata references, refusing to report durability: %w",
-				snapID, manifestCount, liveCount, models.ErrSnapshotManifestIncomplete)
+		if liveHashes.Len() > 0 {
+			terminalErr = fmt.Errorf("snapshot create %s: empty manifest on non-empty share (%d live hashes), refusing to report durability: %w",
+				snapID, liveHashes.Len(), models.ErrSnapshotVerifyFailed)
 			r.failSnap(shareName, snapID, terminalErr)
-			logger.Error("snapshot create: incomplete manifest on non-empty share",
-				"snapshot_id", snapID, "share", shareName,
-				"manifest_count", manifestCount, "live_hashes", liveCount)
+			logger.Error("snapshot create: empty manifest on non-empty share",
+				"snapshot_id", snapID, "share", shareName, "live_hashes", liveHashes.Len())
 			return
 		}
-		if liveCount == 0 {
-			logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
-				"snapshot_id", snapID, "share", shareName)
-		}
+		logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
+			"snapshot_id", snapID, "share", shareName)
 	}
 
 	// Hardcoded; benchmarking confirmed no operator tuning need.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -457,7 +457,7 @@ func (r *Runtime) runSnapshotOrchestration(
 	// Force every dirty append-log payload through rollup into CAS + the
 	// FileBlock manifest so the Backup() below sees a fully-populated
 	// FileAttr.Blocks. Without this, a snapshot taken before the async
-	// rollup catches up captures an empty/partial manifest — the C1 bug.
+	// rollup catches up captures an empty/partial manifest.
 	// Resolve the block store once here; the verify gate (Step 4) reuses
 	// the same lookup pattern.
 	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
@@ -584,12 +584,12 @@ func (r *Runtime) runSnapshotOrchestration(
 			"snapshot_id", snapID, "share", shareName)
 		return
 	}
-	// --- C3 guard: empty manifest on a non-empty share ---
+	// --- empty-manifest guard: empty manifest on a non-empty share ---
 	// VerifyRemoteDurability returns success for an empty manifest without
 	// probing any block (verify.go). After the Step-0 drain a genuinely
 	// non-empty share MUST produce a non-empty manifest; an empty one
 	// means the backup undercounted the share's referenced blocks (e.g. a
-	// rollup that never persisted FileAttr.Blocks — the C1 failure mode).
+	// rollup that never persisted FileAttr.Blocks).
 	// Reporting remote_durable=true here would be a hollow durability
 	// claim over zero verified blocks. Cross-check the manifest against
 	// the live FileBlock enumeration; fail if the store still references
@@ -1153,7 +1153,7 @@ func (r *Runtime) RestoreSnapshot(
 	// per-payload append log may still hold post-snapshot write records.
 	// ReadPayloadAt replays those records on top of the restored CAS
 	// content ("last record wins"), so a file modified in place after the
-	// snapshot would come back as the mutated bytes (C2 corruption).
+	// snapshot would come back as the mutated bytes (silent corruption).
 	// Dropping the append-log overlay makes the restored CAS manifest the
 	// sole source of truth. Safe here because BOTH the snapshot being
 	// restored AND the safety snapshot drained rollups, so every byte that

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -366,6 +366,24 @@ func (r *Runtime) unregisterSnap(shareName, snapID string, entry *snapInFlight) 
 	entry.mu.Unlock()
 }
 
+// isSnapInFlight reports whether an orchestration goroutine for
+// (shareName, snapID) is currently registered (create or retry in
+// progress). Used by DeleteSnapshot to fence the delete against a running
+// orchestration. Honors the registry lock ordering: registry mutex
+// outermost, per-entry mutex inside.
+func (r *Runtime) isSnapInFlight(shareName, snapID string) bool {
+	r.snapInFlightMu.Lock()
+	defer r.snapInFlightMu.Unlock()
+	entry, ok := r.snapInFlight[shareName]
+	if !ok {
+		return false
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	_, inFlight := entry.done[snapID]
+	return inFlight
+}
+
 // abortSnapInFlight releases a registry entry created via
 // registerSnapInFlight when CreateSnapshot fails synchronously BEFORE
 // launching the orchestration goroutine. It is the synchronous-failure
@@ -1202,6 +1220,16 @@ func (r *Runtime) DeleteSnapshot(ctx context.Context, share, snapID string) erro
 	release := r.snapshotDeleteLock(share)
 	release.Lock()
 	defer release.Unlock()
+
+	// Fence against an in-flight create/retry orchestration for the same
+	// snapID: deleting the row + dir out from under a running goroutine
+	// would leave it writing dump/manifest into a wiped directory or flip
+	// the state of a row that no longer exists. Refuse with a 409-mapped
+	// sentinel so the caller retries once the orchestration is terminal.
+	if r.isSnapInFlight(share, snapID) {
+		return fmt.Errorf("delete snapshot %q on share %q: %w",
+			snapID, share, models.ErrSnapshotInFlight)
+	}
 
 	if err := r.store.DeleteSnapshot(ctx, share, snapID); err != nil {
 		return err

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -427,18 +427,18 @@ func (r *Runtime) runSnapshotOrchestration(
 	// the same lookup pattern.
 	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
 	if err != nil || bs == nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: no block store for share %q: %w",
 			snapID, shareName, models.ErrSnapshotBackupFailed)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: block store lookup failed (pre-backup)",
 			"snapshot_id", snapID, "share", shareName, "error", err)
 		return
 	}
 	logger.Debug("snapshot create: drain rollups start", "snapshot_id", snapID, "share", shareName)
 	if derr := bs.DrainRollups(ctx); derr != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: drain rollups: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, derr)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: drain rollups failed",
 			"snapshot_id", snapID, "share", shareName, "error", derr)
 		return
@@ -456,9 +456,9 @@ func (r *Runtime) runSnapshotOrchestration(
 		return backupable.Backup(ctx, w)
 	})
 	if err != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: backup: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, err)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: backup failed",
 			"snapshot_id", snapID,
 			"share", shareName,
@@ -486,9 +486,9 @@ func (r *Runtime) runSnapshotOrchestration(
 		hashSet = blockstore.NewHashSet(0)
 	}
 	if err := snapshot.WriteManifestAtomic(manifestPath, hashSet); err != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: write manifest: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, err)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: manifest write failed",
 			"snapshot_id", snapID,
 			"share", shareName,
@@ -511,9 +511,9 @@ func (r *Runtime) runSnapshotOrchestration(
 		// state is fully deterministic on success and not subject to
 		// schema-default drift.
 		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount)); err != nil {
-			r.failSnap(shareName, snapID)
 			terminalErr = fmt.Errorf("snapshot create %s: mark ready (no-verify): %w: %v",
 				snapID, models.ErrSnapshotBackupFailed, err)
+			r.failSnap(shareName, snapID, terminalErr)
 			logger.Error("snapshot create: mark ready failed (no-verify)",
 				"snapshot_id", snapID, "share", shareName, "error", err)
 			return
@@ -531,8 +531,8 @@ func (r *Runtime) runSnapshotOrchestration(
 	// bs was resolved in Step 0 and reused here.
 	logger.Debug("snapshot create: drain start", "snapshot_id", snapID, "share", shareName)
 	if err := bs.DrainAllUploads(ctx); err != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: drain: %w: %v", snapID, drainSentinel(err), err)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: drain failed",
 			"snapshot_id", snapID, "share", shareName, "error", err)
 		return
@@ -542,9 +542,9 @@ func (r *Runtime) runSnapshotOrchestration(
 	// --- Step 5: Verify ---
 	remoteStore := bs.RemoteStore()
 	if remoteStore == nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: share %q has no remote store, cannot verify: %w",
 			snapID, shareName, models.ErrSnapshotVerifyFailed)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: no remote store",
 			"snapshot_id", snapID, "share", shareName)
 		return
@@ -563,26 +563,26 @@ func (r *Runtime) runSnapshotOrchestration(
 	if manifestCount == 0 {
 		metaStore, mserr := r.GetMetadataStoreForShare(shareName)
 		if mserr != nil {
-			r.failSnap(shareName, snapID)
 			terminalErr = fmt.Errorf("snapshot create %s: metadata store lookup for empty-manifest check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, mserr)
+			r.failSnap(shareName, snapID, terminalErr)
 			logger.Error("snapshot create: metadata store lookup failed (empty-manifest check)",
 				"snapshot_id", snapID, "share", shareName, "error", mserr)
 			return
 		}
 		liveHashes, herr := snapshot.HashSetFromMetadataStore(ctx, metaStore)
 		if herr != nil {
-			r.failSnap(shareName, snapID)
 			terminalErr = fmt.Errorf("snapshot create %s: enumerate live hashes for empty-manifest check: %w: %v",
 				snapID, models.ErrSnapshotVerifyFailed, herr)
+			r.failSnap(shareName, snapID, terminalErr)
 			logger.Error("snapshot create: live hash enumeration failed (empty-manifest check)",
 				"snapshot_id", snapID, "share", shareName, "error", herr)
 			return
 		}
 		if liveHashes.Len() > 0 {
-			r.failSnap(shareName, snapID)
 			terminalErr = fmt.Errorf("snapshot create %s: empty manifest on non-empty share (%d live hashes), refusing to report durability: %w",
 				snapID, liveHashes.Len(), models.ErrSnapshotVerifyFailed)
+			r.failSnap(shareName, snapID, terminalErr)
 			logger.Error("snapshot create: empty manifest on non-empty share",
 				"snapshot_id", snapID, "share", shareName, "live_hashes", liveHashes.Len())
 			return
@@ -603,9 +603,9 @@ func (r *Runtime) runSnapshotOrchestration(
 		logger.Debug("snapshot create: verify miss, retrying drain+verify",
 			"snapshot_id", snapID, "share", shareName, "first_error", verr)
 		if derr := bs.DrainAllUploads(ctx); derr != nil {
-			r.failSnap(shareName, snapID)
 			terminalErr = fmt.Errorf("snapshot create %s: re-drain after verify miss: %w: %v",
 				snapID, drainSentinel(derr), derr)
+			r.failSnap(shareName, snapID, terminalErr)
 			logger.Error("snapshot create: re-drain failed",
 				"snapshot_id", snapID, "share", shareName, "error", derr)
 			return
@@ -613,9 +613,9 @@ func (r *Runtime) runSnapshotOrchestration(
 		verr = snapshot.VerifyRemoteDurability(ctx, remoteStore, hashSet, concurrency)
 	}
 	if verr != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: verify: %w: %v",
 			snapID, models.ErrSnapshotVerifyFailed, verr)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: verify failed",
 			"snapshot_id", snapID, "share", shareName, "error", verr)
 		return
@@ -629,9 +629,9 @@ func (r *Runtime) runSnapshotOrchestration(
 	// indistinguishable from the intentional --no-verify result and
 	// a false negative for restore's durability gate.
 	if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, true, int64(manifestCount)); err != nil {
-		r.failSnap(shareName, snapID)
 		terminalErr = fmt.Errorf("snapshot create %s: mark ready: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, err)
+		r.failSnap(shareName, snapID, terminalErr)
 		logger.Error("snapshot create: mark ready failed",
 			"snapshot_id", snapID, "share", shareName, "error", err)
 		return
@@ -656,18 +656,23 @@ func drainSentinel(err error) error {
 	return models.ErrSnapshotBackupFailed
 }
 
-// failSnap flips the snapshot row to state='failed'. Best-effort: if the
-// row update itself fails (e.g., DB unavailable), we log but do not
-// double-fail the orchestration error — the wrapped sentinel posted to
-// doneCh is still the authoritative signal for callers, and the
-// startup-recovery scan will reconcile orphaned creating rows on the
-// next restart.
+// failSnap flips the snapshot row to state='failed' and persists cause's
+// message onto the row's Error column so show/list surface the reason
+// instead of "(no error message)". Best-effort: if the row update itself
+// fails (e.g., DB unavailable), we log but do not double-fail the
+// orchestration error — the wrapped sentinel posted to doneCh is still the
+// authoritative signal for callers, and the startup-recovery scan will
+// reconcile orphaned creating rows on the next restart.
 //
 // Uses context.Background so a cancelled parent ctx (the very common
 // reason orchestration is bailing out) does not also prevent the failed
 // flip.
-func (r *Runtime) failSnap(shareName, snapID string) {
-	if err := r.store.UpdateSnapshotState(context.Background(), shareName, snapID, models.StateFailed); err != nil {
+func (r *Runtime) failSnap(shareName, snapID string, cause error) {
+	var msg string
+	if cause != nil {
+		msg = cause.Error()
+	}
+	if err := r.store.MarkSnapshotFailed(context.Background(), shareName, snapID, msg); err != nil {
 		logger.Error("snapshot create: failed to flip state=failed (will reconcile on next restart)",
 			"snapshot_id", snapID,
 			"share", shareName,
@@ -847,7 +852,8 @@ func (r *Runtime) recoverOrphanedSnapshots(ctx context.Context) error {
 			if snap.State != models.StateCreating {
 				continue
 			}
-			if uerr := r.store.UpdateSnapshotState(ctx, shareName, snap.ID, models.StateFailed); uerr != nil {
+			if uerr := r.store.MarkSnapshotFailed(ctx, shareName, snap.ID,
+				"abandoned: server restarted while snapshot was still creating"); uerr != nil {
 				logger.Error("snapshot recovery: flip to failed",
 					"snapshot_id", snap.ID,
 					"share", shareName,

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -562,28 +562,12 @@ func (r *Runtime) runSnapshotOrchestration(
 		return
 	}
 
-	// --- Step 4: Verify gate drain ---
-	// bs was resolved in Step 0 and reused here.
-	logger.Debug("snapshot create: drain start", "snapshot_id", snapID, "share", shareName)
-	if err := bs.DrainAllUploads(ctx); err != nil {
-		terminalErr = fmt.Errorf("snapshot create %s: drain: %w: %v", snapID, drainSentinel(err), err)
-		r.failSnap(shareName, snapID, terminalErr)
-		logger.Error("snapshot create: drain failed",
-			"snapshot_id", snapID, "share", shareName, "error", err)
-		return
-	}
-	logger.Info("snapshot create: drain complete", "snapshot_id", snapID, "share", shareName)
-
-	// --- Step 5: Verify ---
+	// --- Step 4: resolve the remote durability target ---
+	// bs was resolved in Step 0 and reused here. A local-only share (no
+	// remote) cannot be remote-verified; it is handled after the
+	// manifest-completeness guard below (#791).
 	remoteStore := bs.RemoteStore()
-	if remoteStore == nil {
-		terminalErr = fmt.Errorf("snapshot create %s: share %q has no remote store, cannot verify: %w",
-			snapID, shareName, models.ErrSnapshotVerifyFailed)
-		r.failSnap(shareName, snapID, terminalErr)
-		logger.Error("snapshot create: no remote store",
-			"snapshot_id", snapID, "share", shareName)
-		return
-	}
+
 	// --- empty-manifest guard: empty manifest on a non-empty share ---
 	// VerifyRemoteDurability returns success for an empty manifest without
 	// probing any block (verify.go). After the Step-0 drain a genuinely
@@ -625,6 +609,42 @@ func (r *Runtime) runSnapshotOrchestration(
 		logger.Info("snapshot create: empty manifest on genuinely-empty share (verify vacuously ok)",
 			"snapshot_id", snapID, "share", shareName)
 	}
+
+	// --- Step 5: local-only shares skip remote durability ---
+	// A share with no remote store cannot be remote-verified, but its
+	// snapshot still protects against accidental in-share writes/deletes
+	// (the metadata dump + local CAS hold). Mark it ready with
+	// remote_durable=false rather than failing (#791). Mirrors the
+	// restore-side no-remote skip so create and restore agree.
+	if remoteStore == nil {
+		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount)); err != nil {
+			terminalErr = fmt.Errorf("snapshot create %s: mark ready (local-only): %w: %v",
+				snapID, models.ErrSnapshotBackupFailed, err)
+			r.failSnap(shareName, snapID, terminalErr)
+			logger.Error("snapshot create: mark ready failed (local-only)",
+				"snapshot_id", snapID, "share", shareName, "error", err)
+			return
+		}
+		logger.Info("snapshot create: ready (local-only, no remote durability)",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"manifest_count", manifestCount,
+			"final_state", "ready",
+			"remote_durable", false,
+		)
+		return
+	}
+
+	// --- Step 6: Verify gate drain ---
+	logger.Debug("snapshot create: drain start", "snapshot_id", snapID, "share", shareName)
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		terminalErr = fmt.Errorf("snapshot create %s: drain: %w: %v", snapID, drainSentinel(err), err)
+		r.failSnap(shareName, snapID, terminalErr)
+		logger.Error("snapshot create: drain failed",
+			"snapshot_id", snapID, "share", shareName, "error", err)
+		return
+	}
+	logger.Info("snapshot create: drain complete", "snapshot_id", snapID, "share", shareName)
 
 	// Hardcoded; benchmarking confirmed no operator tuning need.
 	concurrency := 16

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -945,9 +945,12 @@ func (r *Runtime) recoverOrphanedSnapshots(ctx context.Context) error {
 //     has run yet).
 //  3. create a verified safety snapshot and wait for StateReady.
 //  4. open the metadata dump.
-//  5. Reset the metadata store.
-//  6. Restore from the dump.
-//  7. post-verify the restored hashes against the remote.
+//  5. reset the block store's local append-log overlay (BEFORE the
+//     metadata Reset, so no concurrent rollup can flush post-snapshot
+//     FileBlock rows into the restored metadata).
+//  6. Reset the metadata store.
+//  7. Restore from the dump.
+//  8. post-verify the restored hashes against the remote.
 //
 // Return values: safetySnapshotID carries the ID of the pre-restore safety
 // snapshot. It is empty on precheck or pre-verify failure paths (no safety
@@ -1127,6 +1130,37 @@ func (r *Runtime) RestoreSnapshot(
 		return safetySnapshotID, fmt.Errorf("restore snapshot %q: metadata engine missing Backupable: %w",
 			snapID, models.ErrRestoreAborted)
 	}
+	// --- reset block-store local state (BEFORE the metadata Reset) ---
+	// The block store's per-payload append log may still hold post-snapshot
+	// write records. ReadPayloadAt replays those records on top of the
+	// restored CAS content ("last record wins"), so a file modified in
+	// place after the snapshot would come back as the mutated bytes (silent
+	// corruption). Dropping the append-log overlay makes the restored CAS
+	// manifest the sole source of truth.
+	//
+	// This MUST run BEFORE resetable.Reset + backupable.Restore (not after):
+	// background rollup workers run throughout the restore. If we cleared
+	// the overlay only after Restore repopulated the metadata, a rollup
+	// worker could call PersistFileBlocks against the freshly-restored
+	// metadata in the window between Restore and the clear, injecting
+	// post-snapshot FileBlock rows into the restored tree. Clearing the
+	// overlay first leaves no dirty intervals for a worker to flush.
+	//
+	// Safe here because BOTH the snapshot being restored AND the pre-restore
+	// safety snapshot drained rollups (CreateSnapshot is synchronous via the
+	// WaitForSnapshot above, so the safety snap's DrainRollups completed),
+	// so every byte that must survive is already durable in CAS and there
+	// are no dirty intervals left to flush.
+	if rerr := bs.ResetLocalState(ctx); rerr != nil {
+		return safetySnapshotID, fmt.Errorf("restore snapshot %q: reset block-store local state (safety-snap=%s): %w: %v",
+			snapID, safetySnapshotID, models.ErrRestoreAborted, rerr)
+	}
+	logger.Info("snapshot restore: block-store local state reset",
+		"snapshot_id", snapID,
+		"share", shareName,
+		"safety_snap_id", safetySnapshotID,
+	)
+
 	logger.Info("snapshot restore: reset start",
 		"snapshot_id", snapID,
 		"share", shareName,
@@ -1154,26 +1188,6 @@ func (r *Runtime) RestoreSnapshot(
 			snapID, safetySnapshotID, models.ErrRestoreAborted, err)
 	}
 	logger.Info("snapshot restore: restore ok",
-		"snapshot_id", snapID,
-		"share", shareName,
-		"safety_snap_id", safetySnapshotID,
-	)
-
-	// --- reset block-store local state ---
-	// The metadata store now reflects the snapshot, but the block store's
-	// per-payload append log may still hold post-snapshot write records.
-	// ReadPayloadAt replays those records on top of the restored CAS
-	// content ("last record wins"), so a file modified in place after the
-	// snapshot would come back as the mutated bytes (silent corruption).
-	// Dropping the append-log overlay makes the restored CAS manifest the
-	// sole source of truth. Safe here because BOTH the snapshot being
-	// restored AND the safety snapshot drained rollups, so every byte that
-	// must survive is already durable in CAS.
-	if rerr := bs.ResetLocalState(ctx); rerr != nil {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: reset block-store local state (safety-snap=%s): %w: %v",
-			snapID, safetySnapshotID, models.ErrRestoreAborted, rerr)
-	}
-	logger.Info("snapshot restore: block-store local state reset",
 		"snapshot_id", snapID,
 		"share", shareName,
 		"safety_snap_id", safetySnapshotID,

--- a/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
+++ b/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
@@ -40,14 +40,89 @@ func TestCreateSnapshot_EmptyManifestOnNonEmptyShareFails(t *testing.T) {
 		t.Fatalf("CreateSnapshot (sync part): %v", err)
 	}
 	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
-	if !errors.Is(werr, models.ErrSnapshotVerifyFailed) {
-		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotVerifyFailed)", werr)
+	// An empty manifest on a non-empty share is the manifestCount==0 edge
+	// of the broader incomplete-manifest guard, so it surfaces the more
+	// precise ErrSnapshotManifestIncomplete sentinel.
+	if !errors.Is(werr, models.ErrSnapshotManifestIncomplete) {
+		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotManifestIncomplete)", werr)
 	}
 	if snap == nil || snap.State != models.StateFailed {
 		t.Fatalf("snapshot state = %v, want failed", snap)
 	}
 	if snap.RemoteDurable {
 		t.Fatal("RemoteDurable=true on a snapshot that captured zero hashes for a non-empty share (hollow durability)")
+	}
+}
+
+// TestCreateSnapshot_PartialManifestFails covers the #789 guard: a
+// metadata backend that persists block refs incompletely yields a manifest
+// that covers SOME but not ALL of the blocks the metadata still references
+// (0 < manifestCount < liveHashes). VerifyRemoteDurability would only probe
+// the captured subset and the snapshot would be marked remote_durable=true
+// over a silently-truncated manifest. The orchestration must refuse with
+// ErrSnapshotManifestIncomplete.
+//
+// Scenario: populate three files {a,b,c} (each seeds a File.Blocks entry
+// AND a standalone FileBlock row). Delete ONLY the File entry for c,
+// leaving its FileBlock row in place. Backup builds the manifest from
+// File.Blocks -> {a,b}; HashSetFromMetadataStore enumerates FileBlock rows
+// -> {a,b,c}. The completeness cross-check detects 2 < 3 and fails.
+func TestCreateSnapshot_PartialManifestFails(t *testing.T) {
+	t.Parallel()
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"a.bin", "b.bin", "c.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	// Delete ONLY the File for c.bin, NOT its standalone FileBlock row.
+	if err := fx.meta.DeleteFile(ctx, files[2].handle); err != nil {
+		t.Fatalf("DeleteFile c.bin: %v", err)
+	}
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot (sync part): %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if !errors.Is(werr, models.ErrSnapshotManifestIncomplete) {
+		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotManifestIncomplete)", werr)
+	}
+	if snap == nil || snap.State != models.StateFailed {
+		t.Fatalf("snapshot state = %v, want failed", snap)
+	}
+	if snap.RemoteDurable {
+		t.Fatal("RemoteDurable=true on a snapshot whose manifest dropped a referenced block")
+	}
+}
+
+// TestCreateSnapshot_CompleteManifestSucceeds is the positive counterpart:
+// when the manifest covers EVERY block the metadata references
+// (manifestCount == liveHashes), the completeness guard passes and the
+// snapshot reaches ready+remote_durable=true.
+func TestCreateSnapshot_CompleteManifestSucceeds(t *testing.T) {
+	t.Parallel()
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	fx.populateFiles(ctx, []string{"a.bin", "b.bin", "c.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot (sync part): %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot on complete manifest: %v", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snapshot state = %q, want ready", snap.State)
+	}
+	if !snap.RemoteDurable {
+		t.Fatal("RemoteDurable=false on a complete-manifest snapshot")
 	}
 }
 

--- a/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
+++ b/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestCreateSnapshot_EmptyManifestOnNonEmptyShareFails covers the C3
+// guard: VerifyRemoteDurability short-circuits to success on an empty
+// manifest without probing any block, so a snapshot whose backup captured
+// ZERO hashes while the share still references blocks would otherwise be
+// reported remote_durable=true over an unverified empty set (hollow
+// durability). The orchestration must refuse that case.
+//
+// Scenario: seed a file (which also seeds a standalone FileBlock row),
+// then delete ONLY the File entry — leaving the FileBlock row in place.
+// The Backup-derived manifest is now empty (no file references any
+// hash), but EnumerateFileBlocks still returns the orphan hash. The C3
+// cross-check detects the mismatch and fails the snapshot rather than
+// claiming durability.
+func TestCreateSnapshot_EmptyManifestOnNonEmptyShareFails(t *testing.T) {
+	t.Parallel()
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"c3.bin"})
+
+	// Delete ONLY the File, NOT the standalone FileBlock row. This is the
+	// exact inconsistency C3 protects against: manifest (from file.Blocks)
+	// is empty, but the store still references a hash via EnumerateFileBlocks.
+	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
+		t.Fatalf("DeleteFile: %v", err)
+	}
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot (sync part): %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if !errors.Is(werr, models.ErrSnapshotVerifyFailed) {
+		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotVerifyFailed)", werr)
+	}
+	if snap == nil || snap.State != models.StateFailed {
+		t.Fatalf("snapshot state = %v, want failed", snap)
+	}
+	if snap.RemoteDurable {
+		t.Fatal("RemoteDurable=true on a snapshot that captured zero hashes for a non-empty share (hollow durability)")
+	}
+}
+
+// TestCreateSnapshot_EmptyShareVacuousVerify is the legitimate-empty
+// counterpart: a share with NO files and NO FileBlock rows produces an
+// empty manifest, and the C3 guard must let it pass with a vacuous verify
+// (remote_durable=true over zero blocks is honest here — there is nothing
+// to verify).
+func TestCreateSnapshot_EmptyShareVacuousVerify(t *testing.T) {
+	t.Parallel()
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	// No populateFiles — the share is genuinely empty.
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot (sync part): %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot on empty share: %v", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snapshot state = %q, want ready", snap.State)
+	}
+	if !snap.RemoteDurable {
+		t.Fatal("RemoteDurable=false on a genuinely-empty share; vacuous verify should pass")
+	}
+}

--- a/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
+++ b/pkg/controlplane/runtime/snapshot_c3_empty_manifest_test.go
@@ -40,89 +40,14 @@ func TestCreateSnapshot_EmptyManifestOnNonEmptyShareFails(t *testing.T) {
 		t.Fatalf("CreateSnapshot (sync part): %v", err)
 	}
 	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
-	// An empty manifest on a non-empty share is the manifestCount==0 edge
-	// of the broader incomplete-manifest guard, so it surfaces the more
-	// precise ErrSnapshotManifestIncomplete sentinel.
-	if !errors.Is(werr, models.ErrSnapshotManifestIncomplete) {
-		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotManifestIncomplete)", werr)
+	if !errors.Is(werr, models.ErrSnapshotVerifyFailed) {
+		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotVerifyFailed)", werr)
 	}
 	if snap == nil || snap.State != models.StateFailed {
 		t.Fatalf("snapshot state = %v, want failed", snap)
 	}
 	if snap.RemoteDurable {
 		t.Fatal("RemoteDurable=true on a snapshot that captured zero hashes for a non-empty share (hollow durability)")
-	}
-}
-
-// TestCreateSnapshot_PartialManifestFails covers the #789 guard: a
-// metadata backend that persists block refs incompletely yields a manifest
-// that covers SOME but not ALL of the blocks the metadata still references
-// (0 < manifestCount < liveHashes). VerifyRemoteDurability would only probe
-// the captured subset and the snapshot would be marked remote_durable=true
-// over a silently-truncated manifest. The orchestration must refuse with
-// ErrSnapshotManifestIncomplete.
-//
-// Scenario: populate three files {a,b,c} (each seeds a File.Blocks entry
-// AND a standalone FileBlock row). Delete ONLY the File entry for c,
-// leaving its FileBlock row in place. Backup builds the manifest from
-// File.Blocks -> {a,b}; HashSetFromMetadataStore enumerates FileBlock rows
-// -> {a,b,c}. The completeness cross-check detects 2 < 3 and fails.
-func TestCreateSnapshot_PartialManifestFails(t *testing.T) {
-	t.Parallel()
-	fx := newRestoreFixture(t, restoreFixtureOpts{})
-	defer fx.close()
-
-	ctx := fx.ctx()
-	files := fx.populateFiles(ctx, []string{"a.bin", "b.bin", "c.bin"})
-	fx.seedRemoteAll(fx.allHashes())
-
-	// Delete ONLY the File for c.bin, NOT its standalone FileBlock row.
-	if err := fx.meta.DeleteFile(ctx, files[2].handle); err != nil {
-		t.Fatalf("DeleteFile c.bin: %v", err)
-	}
-
-	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
-	if err != nil {
-		t.Fatalf("CreateSnapshot (sync part): %v", err)
-	}
-	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
-	if !errors.Is(werr, models.ErrSnapshotManifestIncomplete) {
-		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotManifestIncomplete)", werr)
-	}
-	if snap == nil || snap.State != models.StateFailed {
-		t.Fatalf("snapshot state = %v, want failed", snap)
-	}
-	if snap.RemoteDurable {
-		t.Fatal("RemoteDurable=true on a snapshot whose manifest dropped a referenced block")
-	}
-}
-
-// TestCreateSnapshot_CompleteManifestSucceeds is the positive counterpart:
-// when the manifest covers EVERY block the metadata references
-// (manifestCount == liveHashes), the completeness guard passes and the
-// snapshot reaches ready+remote_durable=true.
-func TestCreateSnapshot_CompleteManifestSucceeds(t *testing.T) {
-	t.Parallel()
-	fx := newRestoreFixture(t, restoreFixtureOpts{})
-	defer fx.close()
-
-	ctx := fx.ctx()
-	fx.populateFiles(ctx, []string{"a.bin", "b.bin", "c.bin"})
-	fx.seedRemoteAll(fx.allHashes())
-
-	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
-	if err != nil {
-		t.Fatalf("CreateSnapshot (sync part): %v", err)
-	}
-	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
-	if werr != nil {
-		t.Fatalf("WaitForSnapshot on complete manifest: %v", werr)
-	}
-	if snap.State != models.StateReady {
-		t.Fatalf("snapshot state = %q, want ready", snap.State)
-	}
-	if !snap.RemoteDurable {
-		t.Fatal("RemoteDurable=false on a complete-manifest snapshot")
 	}
 }
 

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -37,6 +37,58 @@ func TestRestoreSnapshot_Integration(t *testing.T) {
 	t.Run("PreVerifyFailsFast", testRestorePreVerifyFailsFast)
 	t.Run("PostVerifyFails", testRestorePostVerifyFails)
 	t.Run("InterruptedRestore", testRestoreInterruptedReset)
+	t.Run("LocalOnlyRestore", testRestoreLocalOnly)
+}
+
+// testRestoreLocalOnly asserts a share with no remote store can snapshot
+// (NoVerify) and restore: the pre/post remote HEAD-probe verify is skipped
+// rather than erroring out, and data is recovered from local CAS.
+func testRestoreLocalOnly(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{localOnly: true})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"lo.bin"})
+
+	// No remote → snapshot must use NoVerify (RemoteDurable=false).
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snap.State = %q, want ready", snap.State)
+	}
+	if snap.RemoteDurable {
+		t.Fatal("snap.RemoteDurable = true, want false on a local-only share")
+	}
+
+	// Mutate: delete the file.
+	fx.deleteFileCascade(ctx, files[0])
+
+	// Restore must succeed despite no remote (AllowNonDurable required since
+	// the snapshot is not remote-durable).
+	safetyID, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{AllowNonDurable: true})
+	if err != nil {
+		t.Fatalf("RestoreSnapshot(local-only): %v", err)
+	}
+	if safetyID == "" {
+		t.Fatal("RestoreSnapshot: safetySnapshotID empty on success")
+	}
+
+	// Data restored.
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr != nil {
+		t.Fatalf("GetFile post-restore: deleted file not recovered: %v", gerr)
+	}
+
+	// Share stays disabled.
+	enabled, _ := fx.rt.sharesSvc.IsShareEnabled(fx.shareName)
+	if enabled {
+		t.Fatal("share enabled after local-only restore — must stay disabled")
+	}
 }
 
 // ----- Sub-tests -----
@@ -510,6 +562,11 @@ type restoreFixtureOpts struct {
 	// Reset failure mid-orchestration. Other sub-tests use the plain
 	// MemoryMetadataStore directly.
 	useFailableResetable bool
+
+	// localOnly builds the share with no remote block store (RemoteStore()
+	// returns nil). Exercises the local-only restore path that skips the
+	// remote HEAD-probe pre/post verify.
+	localOnly bool
 }
 
 func newRestoreFixture(t *testing.T, opts restoreFixtureOpts) *restoreFixture {
@@ -548,16 +605,21 @@ func newRestoreFixture(t *testing.T, opts restoreFixtureOpts) *restoreFixture {
 	shareName := "restore-data"
 
 	localStore := bsmemory.New()
-	innerRemote := remotememory.New()
-	t.Cleanup(func() { _ = innerRemote.Close() })
-	wrappedRemote := newRestoreRemote(innerRemote)
-	syncer := engine.NewSyncer(localStore, wrappedRemote, mem, engine.SyncerConfig{
+	var wrappedRemote *restoreRemote
+	var engineRemote remote.RemoteStore
+	if !opts.localOnly {
+		innerRemote := remotememory.New()
+		t.Cleanup(func() { _ = innerRemote.Close() })
+		wrappedRemote = newRestoreRemote(innerRemote)
+		engineRemote = wrappedRemote
+	}
+	syncer := engine.NewSyncer(localStore, engineRemote, mem, engine.SyncerConfig{
 		ParallelUploads:   1,
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
-		Remote:         wrappedRemote,
+		Remote:         engineRemote,
 		Syncer:         syncer,
 		FileBlockStore: mem,
 	})

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -267,9 +267,7 @@ func testRestoreAllowNonDurable(t *testing.T) {
 	fx.seedRemoteAll(fx.allHashes())
 
 	// Mutate: delete the file.
-	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
-		t.Fatalf("delete pre-restore: %v", err)
-	}
+	fx.deleteFileCascade(ctx, files[0])
 
 	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{AllowNonDurable: true}); err != nil {
 		t.Fatalf("RestoreSnapshot(AllowNonDurable): %v", err)
@@ -307,9 +305,7 @@ func testRestorePreVerifyFailsFast(t *testing.T) {
 	// Mutate so pre-Reset state has something distinct (witness for the
 	// metadata-unchanged invariant). Then arm the head-failure for ONE
 	// hash on every subsequent call (threshold=0).
-	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
-		t.Fatalf("delete pre-restore witness: %v", err)
-	}
+	fx.deleteFileCascade(ctx, files[0])
 	preCount := fx.countFiles(ctx)
 	fx.remote.failHashAfterCount(files[1].hashes[0], 0) // every Head() for this hash fails
 
@@ -364,9 +360,7 @@ func testRestorePostVerifyFails(t *testing.T) {
 	// Mutate AFTER snapshot create: delete files[0]. files[0].hashes[0]
 	// is now only in the source manifest (the safety snap will capture
 	// the mutated state without it).
-	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
-		t.Fatalf("delete files[0]: %v", err)
-	}
+	fx.deleteFileCascade(ctx, files[0])
 
 	// Arm head-failure for files[0].hashes[0] starting at the 2nd call.
 	// Sequence:
@@ -426,9 +420,7 @@ func testRestoreInterruptedReset(t *testing.T) {
 	// intermediate state. We delete files[0] — the safety snap will
 	// reflect "only files[1] survives" and recovery must put us back to
 	// that state.
-	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
-		t.Fatalf("delete files[0]: %v", err)
-	}
+	fx.deleteFileCascade(ctx, files[0])
 
 	// Arm Reset failure (one-shot).
 	fx.failable.setFailNextReset(true)
@@ -697,6 +689,28 @@ func (f *restoreFixture) populateFiles(ctx context.Context, names []string) []fi
 		out = append(out, ff)
 	}
 	return out
+}
+
+// deleteFileCascade deletes the file AND the standalone FileBlock row the
+// fixture seeded alongside it (ID "<fileID>-blk-0"). Production deletes
+// cascade FileBlock rows via the engine's refcount→GC path, so the test
+// must mirror that — otherwise an orphaned FileBlock row makes the
+// post-delete snapshot's empty manifest disagree with EnumerateFileBlocks
+// and trips the C3 "empty-manifest-on-non-empty-share" guard in
+// CreateSnapshot.
+func (f *restoreFixture) deleteFileCascade(ctx context.Context, ff fileFixture) {
+	f.t.Helper()
+	if err := f.meta.DeleteFile(ctx, ff.handle); err != nil {
+		f.t.Fatalf("deleteFileCascade DeleteFile: %v", err)
+	}
+	_, fileID, err := metadata.DecodeFileHandle(ff.handle)
+	if err != nil {
+		f.t.Fatalf("deleteFileCascade DecodeFileHandle: %v", err)
+	}
+	if derr := f.meta.Delete(ctx, fileID.String()+"-blk-0"); derr != nil &&
+		!errors.Is(derr, blockstore.ErrFileBlockNotFound) {
+		f.t.Fatalf("deleteFileCascade Delete FileBlock: %v", derr)
+	}
 }
 
 func (f *restoreFixture) allHashes() []blockstore.ContentHash {

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -120,10 +120,13 @@ func testRestoreHappyPath(t *testing.T) {
 	}
 
 	// Mutate: delete one of the files so restore has something to recover.
+	// Use the cascade helper (File + its standalone FileBlock row) so the
+	// safety snapshot's manifest stays consistent with EnumerateFileBlocks
+	// — otherwise the orphaned FileBlock row leaves the manifest covering
+	// fewer blocks than the metadata references and trips the
+	// manifest-completeness guard in CreateSnapshot.
 	deletedFile := files[0]
-	if err := fx.meta.DeleteFile(ctx, deletedFile.handle); err != nil {
-		t.Fatalf("delete file alpha pre-restore: %v", err)
-	}
+	fx.deleteFileCascade(ctx, deletedFile)
 
 	// Restore — must complete with no error.
 	safetyID, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -120,13 +120,10 @@ func testRestoreHappyPath(t *testing.T) {
 	}
 
 	// Mutate: delete one of the files so restore has something to recover.
-	// Use the cascade helper (File + its standalone FileBlock row) so the
-	// safety snapshot's manifest stays consistent with EnumerateFileBlocks
-	// — otherwise the orphaned FileBlock row leaves the manifest covering
-	// fewer blocks than the metadata references and trips the
-	// manifest-completeness guard in CreateSnapshot.
 	deletedFile := files[0]
-	fx.deleteFileCascade(ctx, deletedFile)
+	if err := fx.meta.DeleteFile(ctx, deletedFile.handle); err != nil {
+		t.Fatalf("delete file alpha pre-restore: %v", err)
+	}
 
 	// Restore — must complete with no error.
 	safetyID, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -201,6 +201,51 @@ func TestRuntimeSnapshot_NamePersists(t *testing.T) {
 	}
 }
 
+// TestRuntimeFailSnap_RecordsError asserts failSnap persists the cause's
+// message onto the row so show/list surface the reason instead of
+// "(no error message)", and that a failed->creating retry clears it.
+func TestRuntimeFailSnap_RecordsError(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const shareName = "alpha"
+	snapID, err := rt.store.CreateSnapshot(ctx, &models.Snapshot{
+		ShareName:      shareName,
+		State:          models.StateCreating,
+		MetadataEngine: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	cause := errors.New("backup: disk full")
+	rt.failSnap(shareName, snapID, cause)
+
+	got, err := rt.GetSnapshot(ctx, shareName, snapID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got.State != models.StateFailed {
+		t.Fatalf("State = %q, want failed", got.State)
+	}
+	if got.Error != "backup: disk full" {
+		t.Fatalf("Error = %q, want %q", got.Error, "backup: disk full")
+	}
+
+	// A retry (failed -> creating) clears the stale error.
+	if err := rt.store.UpdateSnapshotState(ctx, shareName, snapID, models.StateCreating); err != nil {
+		t.Fatalf("UpdateSnapshotState->creating: %v", err)
+	}
+	got, err = rt.GetSnapshot(ctx, shareName, snapID)
+	if err != nil {
+		t.Fatalf("GetSnapshot after retry: %v", err)
+	}
+	if got.Error != "" {
+		t.Fatalf("Error after retry = %q, want empty", got.Error)
+	}
+}
+
 // TestRuntimeGetSnapshot_NotFound asserts ErrSnapshotNotFound propagates
 // from the store through the Runtime wrapper.
 func TestRuntimeGetSnapshot_NotFound(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -173,6 +173,34 @@ func newTestRuntime(t *testing.T) *Runtime {
 	return New(cp)
 }
 
+// TestRuntimeSnapshot_NamePersists asserts a snapshot's Name column
+// round-trips through the store layer (the column was previously absent so
+// --name was silently dropped).
+func TestRuntimeSnapshot_NamePersists(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const shareName = "alpha"
+	snapID, err := rt.store.CreateSnapshot(ctx, &models.Snapshot{
+		Name:           "weekly",
+		ShareName:      shareName,
+		State:          models.StateCreating,
+		MetadataEngine: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	got, err := rt.GetSnapshot(ctx, shareName, snapID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got.Name != "weekly" {
+		t.Fatalf("Name = %q, want weekly", got.Name)
+	}
+}
+
 // TestRuntimeGetSnapshot_NotFound asserts ErrSnapshotNotFound propagates
 // from the store through the Runtime wrapper.
 func TestRuntimeGetSnapshot_NotFound(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -246,6 +246,25 @@ func TestRuntimeFailSnap_RecordsError(t *testing.T) {
 	}
 }
 
+// TestRuntimeCreateSnapshot_MemoryLocalStore asserts a snapshot on a share
+// whose local block store has no on-disk root fails up front with the typed
+// ErrSnapshotLocalStoreUnsupported sentinel (mapped to 400) rather than an
+// opaque 500.
+func TestRuntimeCreateSnapshot_MemoryLocalStore(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const shareName = "alpha"
+	// Inject a share with no local store dir (the in-memory backend case).
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{Name: shareName})
+
+	_, err := rt.CreateSnapshot(ctx, shareName, CreateSnapshotOpts{})
+	if !errors.Is(err, models.ErrSnapshotLocalStoreUnsupported) {
+		t.Fatalf("CreateSnapshot err = %v, want errors.Is(ErrSnapshotLocalStoreUnsupported)", err)
+	}
+}
+
 // TestRuntimeGetSnapshot_NotFound asserts ErrSnapshotNotFound propagates
 // from the store through the Runtime wrapper.
 func TestRuntimeGetSnapshot_NotFound(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -369,6 +369,47 @@ func TestRuntimeDeleteSnapshot_HappyPath(t *testing.T) {
 	}
 }
 
+// TestRuntimeDeleteSnapshot_RefusesInFlight asserts DeleteSnapshot refuses
+// with ErrSnapshotInFlight when an orchestration goroutine is registered for
+// the same snapID, so a delete cannot race a running create/retry.
+func TestRuntimeDeleteSnapshot_RefusesInFlight(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const shareName = "alpha"
+	localStoreDir := t.TempDir()
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{Name: shareName})
+	if err := rt.sharesSvc.SetLocalStoreDirForTesting(shareName, localStoreDir); err != nil {
+		t.Fatalf("SetLocalStoreDirForTesting: %v", err)
+	}
+
+	snap := &models.Snapshot{ShareName: shareName, State: models.StateCreating, MetadataEngine: "memory"}
+	snapID, err := rt.store.CreateSnapshot(ctx, snap)
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	// Plant an in-flight registry entry (mimics a running orchestration).
+	_, _, entry := rt.registerSnapInFlight(shareName, snapID)
+
+	if derr := rt.DeleteSnapshot(ctx, shareName, snapID); !errors.Is(derr, models.ErrSnapshotInFlight) {
+		t.Fatalf("DeleteSnapshot err = %v, want errors.Is(ErrSnapshotInFlight)", derr)
+	}
+
+	// Row must still exist (delete refused).
+	if _, gerr := rt.store.GetSnapshot(ctx, shareName, snapID); gerr != nil {
+		t.Fatalf("row deleted despite in-flight refusal: %v", gerr)
+	}
+
+	// Drain the planted entry, then delete succeeds.
+	rt.unregisterSnap(shareName, snapID, entry)
+	entry.wg.Done()
+	if derr := rt.DeleteSnapshot(ctx, shareName, snapID); derr != nil {
+		t.Fatalf("DeleteSnapshot after drain: %v", derr)
+	}
+}
+
 // TestRuntimeDeleteSnapshot_NotFound asserts ErrSnapshotNotFound from the
 // store propagates verbatim and the on-disk wipe step is NOT attempted.
 func TestRuntimeDeleteSnapshot_NotFound(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -265,6 +265,43 @@ func TestRuntimeCreateSnapshot_MemoryLocalStore(t *testing.T) {
 	}
 }
 
+// TestRuntimeDeriveWaitCtx_IgnoresCallerCancel asserts the safety-snap wait
+// ctx is rooted at runtimeCtx, so a cancelled caller (client disconnect)
+// does not abort it, while runtime shutdown does. A caller deadline is
+// preserved.
+func TestRuntimeDeriveWaitCtx_IgnoresCallerCancel(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	// Caller cancelled, no deadline → derived ctx stays alive.
+	callerCtx, callerCancel := context.WithCancel(context.Background())
+	callerCancel()
+	waitCtx, waitCancel := rt.deriveWaitCtx(callerCtx)
+	if waitCtx.Err() != nil {
+		t.Fatalf("waitCtx already cancelled by caller cancel: %v", waitCtx.Err())
+	}
+
+	// Runtime shutdown DOES cancel it.
+	rt.runtimeCancel()
+	select {
+	case <-waitCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitCtx not cancelled after runtime shutdown")
+	}
+	waitCancel()
+
+	// Caller deadline is preserved on the derived ctx.
+	rt2 := newTestRuntime(t)
+	dl := time.Now().Add(123 * time.Hour)
+	withDL, dlCancel := context.WithDeadline(context.Background(), dl)
+	defer dlCancel()
+	got, gotCancel := rt2.deriveWaitCtx(withDL)
+	defer gotCancel()
+	gotDL, ok := got.Deadline()
+	if !ok || !gotDL.Equal(dl) {
+		t.Fatalf("derived deadline = (%v, %v), want %v", gotDL, ok, dl)
+	}
+}
+
 // TestRuntimeGetSnapshot_NotFound asserts ErrSnapshotNotFound propagates
 // from the store through the Runtime wrapper.
 func TestRuntimeGetSnapshot_NotFound(t *testing.T) {

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -479,6 +479,14 @@ type SnapshotStore interface {
 	// including same-state updates.
 	UpdateSnapshotState(ctx context.Context, shareName, id, state string) error
 
+	// MarkSnapshotFailed flips a snapshot to state='failed' and persists
+	// errMsg onto its Error column in a single UPDATE so show/list can
+	// surface the failure reason. Not gated on prior state (the
+	// orchestration goroutine may call it from any pipeline step). errMsg
+	// is truncated to fit the column. Returns models.ErrSnapshotNotFound
+	// if no row matches (shareName, id).
+	MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg string) error
+
 	// UpdateSnapshotDurable flips the RemoteDurable bit on the snapshot
 	// row matching (shareName, id). Called by the orchestration goroutine
 	// (Phase 23 D-23-03) after VerifyRemoteDurability passes (durable=true)

--- a/pkg/controlplane/store/snapshots.go
+++ b/pkg/controlplane/store/snapshots.go
@@ -90,13 +90,20 @@ func (s *GORMStore) UpdateSnapshotState(ctx context.Context, shareName, id, stat
 	if len(priors) == 0 {
 		return models.ErrSnapshotStateConflict
 	}
+	updates := map[string]any{
+		"state":      state,
+		"updated_at": time.Now(),
+	}
+	// A failed->creating retry clears the stale error from the prior
+	// attempt so a subsequent success leaves the row error-free and an
+	// in-flight retry never surfaces the previous failure's message.
+	if state == models.StateCreating {
+		updates["error"] = ""
+	}
 	db := s.db.WithContext(ctx)
 	res := db.Model(&models.Snapshot{}).
 		Where("share_name = ? AND id = ? AND state IN ?", shareName, id, priors).
-		Updates(map[string]any{
-			"state":      state,
-			"updated_at": time.Now(),
-		})
+		Updates(updates)
 	if res.Error != nil {
 		// failed -> creating retries can collide with idx_share_creating
 		// when another snapshot is already in flight for this share. The
@@ -122,6 +129,37 @@ func (s *GORMStore) UpdateSnapshotState(ctx context.Context, shareName, id, stat
 		return models.ErrSnapshotNotFound
 	}
 	return models.ErrSnapshotStateConflict
+}
+
+// MarkSnapshotFailed flips a snapshot to state='failed' and persists errMsg
+// onto the row's Error column in a single UPDATE, so show/list surface the
+// failure reason instead of "(no error message)". Unlike UpdateSnapshotState
+// it does not gate on the prior state: the orchestration goroutine calls this
+// from any pipeline step (still 'creating', or a retry that already flipped
+// back to 'creating'), and the recovery scan must be able to record a reason
+// regardless. errMsg is truncated to fit the column.
+//
+// Returns models.ErrSnapshotNotFound if no row matches (shareName, id).
+func (s *GORMStore) MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg string) error {
+	const maxErrLen = 1024
+	if len(errMsg) > maxErrLen {
+		errMsg = errMsg[:maxErrLen]
+	}
+	db := s.db.WithContext(ctx)
+	res := db.Model(&models.Snapshot{}).
+		Where("share_name = ? AND id = ?", shareName, id).
+		Updates(map[string]any{
+			"state":      models.StateFailed,
+			"error":      errMsg,
+			"updated_at": time.Now(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return models.ErrSnapshotNotFound
+	}
+	return nil
 }
 
 // UpdateSnapshotDurable flips the RemoteDurable bit on the snapshot row

--- a/pkg/metadata/store/postgres/errors.go
+++ b/pkg/metadata/store/postgres/errors.go
@@ -51,6 +51,26 @@ func mapPgErrorCode(pgErr *pgconn.PgError, operation, path string) error {
 	switch pgErr.Code {
 	// 23505: unique_violation
 	case "23505":
+		// Distinguish the object_id (file-level dedup) uniqueness
+		// violation from a path-hash collision. The files_object_id_idx
+		// partial unique index enforces "one ObjectID -> one file"; a
+		// second file with byte-identical content (same Merkle-root
+		// ObjectID) trips it. Callers (the rollup persist path) treat
+		// this as a BENIGN conflict — the duplicate's blocks are already
+		// covered by the canonical file's manifest — so it must surface
+		// as ErrConflict, NOT the generic ErrAlreadyExists. The defensive
+		// message-text fallback mirrors the runtime coordinator's
+		// detection for drivers that strip ConstraintName. Path-hash
+		// collisions (unique_share_path_hash_active) stay ErrAlreadyExists
+		// so the path uniqueness contract is preserved.
+		if pgErr.ConstraintName == "files_object_id_idx" ||
+			(pgErr.ConstraintName == "" && contains(pgErr.Message, "object_id")) {
+			return &metadata.StoreError{
+				Code:    metadata.ErrConflict,
+				Message: fmt.Sprintf("%s: object_id already mapped to another file", operation),
+				Path:    path,
+			}
+		}
 		return &metadata.StoreError{
 			Code:    metadata.ErrAlreadyExists,
 			Message: fmt.Sprintf("%s: already exists", operation),

--- a/pkg/metadata/store/postgres/objectid_conflict_test.go
+++ b/pkg/metadata/store/postgres/objectid_conflict_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// isAlreadyExists reports whether err is a StoreError carrying the
+// ErrAlreadyExists code.
+func isAlreadyExists(err error) bool {
+	var se *metadata.StoreError
+	return errors.As(err, &se) && se.Code == metadata.ErrAlreadyExists
+}
+
+// newConflictTestStore builds a PostgresMetadataStore from
+// DITTOFS_TEST_POSTGRES_DSN. Separate from the legacy hardcoded factory so
+// it can run against the dedicated test database.
+func newConflictTestStore(t *testing.T) *postgres.PostgresMetadataStore {
+	t.Helper()
+	dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping object_id conflict mapping test")
+	}
+	cfg := &postgres.PostgresMetadataStoreConfig{SSLMode: "disable", AutoMigrate: true}
+	for _, kv := range strings.Fields(dsn) {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		switch parts[0] {
+		case "host":
+			cfg.Host = parts[1]
+		case "port":
+			p, err := strconv.Atoi(parts[1])
+			if err != nil {
+				t.Fatalf("parse port: %v", err)
+			}
+			cfg.Port = p
+		case "user":
+			cfg.User = parts[1]
+		case "password":
+			cfg.Password = parts[1]
+		case "dbname", "database":
+			cfg.Database = parts[1]
+		case "sslmode", "ssl_mode":
+			cfg.SSLMode = parts[1]
+		}
+	}
+	caps := metadata.FilesystemCapabilities{
+		MaxReadSize: 1048576, PreferredReadSize: 1048576,
+		MaxWriteSize: 1048576, PreferredWriteSize: 1048576,
+		MaxFileSize: 9223372036854775807, MaxFilenameLen: 255,
+		MaxPathLen: 4096, MaxHardLinkCount: 32767,
+		SupportsHardLinks: true, SupportsSymlinks: true,
+		CaseSensitive: true, CasePreserving: true, TimestampResolution: 1,
+	}
+	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func conflictTestRoot(t *testing.T, store *postgres.PostgresMetadataStore, shareName string) {
+	t.Helper()
+	// CreateRootDirectory inserts BOTH the "/" files-row and the share row
+	// (Postgres' shares.root_file_id is NOT NULL).
+	if _, err := store.CreateRootDirectory(context.Background(), shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	}); err != nil {
+		t.Fatalf("CreateRootDirectory: %v", err)
+	}
+}
+
+func conflictTestFile(t *testing.T, store *postgres.PostgresMetadataStore, shareName, name string) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	handle, err := store.GenerateHandle(ctx, shareName, "/"+name)
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle: %v", err)
+	}
+	file := &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      "/" + name,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			PayloadID: metadata.PayloadID(strings.TrimPrefix(shareName, "/") + "/" + name),
+		},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile %q: %v", name, err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount %q: %v", name, err)
+	}
+	return handle
+}
+
+// TestPostgresPutFile_ObjectIDConflictMapsToErrConflict verifies that a
+// files_object_id_idx uniqueness violation (two files claiming the same
+// Merkle-root ObjectID — the file-level dedup contention) surfaces as
+// mderrors.ErrConflict, NOT the generic ErrAlreadyExists. The rollup-persist
+// path depends on this code so it can recognise the benign conflict and
+// persist the duplicate's blocks without claiming the dedup pointer.
+func TestPostgresPutFile_ObjectIDConflictMapsToErrConflict(t *testing.T) {
+	store := newConflictTestStore(t)
+	ctx := context.Background()
+
+	const shareName = "oidconf"
+	conflictTestRoot(t, store, shareName)
+
+	hA := conflictTestFile(t, store, shareName, "a.bin")
+	hB := conflictTestFile(t, store, shareName, "b.bin")
+
+	contested := blockstore.ComputeObjectID([]blockstore.BlockRef{
+		{Hash: blockstore.ContentHash{1, 2, 3, 4}, Offset: 0, Size: 4096},
+	})
+
+	// First claimant wins.
+	fA, err := store.GetFile(ctx, hA)
+	if err != nil {
+		t.Fatalf("GetFile A: %v", err)
+	}
+	fA.ObjectID = contested
+	fA.Blocks = []blockstore.BlockRef{{Hash: blockstore.ContentHash{1, 2, 3, 4}, Offset: 0, Size: 4096}}
+	if err := store.PutFile(ctx, fA); err != nil {
+		t.Fatalf("PutFile A (first claimant): %v", err)
+	}
+
+	// Second claimant must lose with ErrConflict (NOT ErrAlreadyExists).
+	fB, err := store.GetFile(ctx, hB)
+	if err != nil {
+		t.Fatalf("GetFile B: %v", err)
+	}
+	fB.ObjectID = contested
+	fB.Blocks = []blockstore.BlockRef{{Hash: blockstore.ContentHash{1, 2, 3, 4}, Offset: 0, Size: 4096}}
+	err = store.PutFile(ctx, fB)
+	if err == nil {
+		t.Fatal("PutFile B should have failed with object_id conflict")
+	}
+	if !mderrors.IsConflictError(err) {
+		t.Fatalf("object_id conflict must map to ErrConflict, got %v", err)
+	}
+	if isAlreadyExists(err) {
+		t.Fatalf("object_id conflict must NOT map to ErrAlreadyExists (would be indistinguishable from a path collision): %v", err)
+	}
+}
+
+// TestPostgresPutFile_PathConflictStaysErrAlreadyExists verifies the path-hash
+// uniqueness contract is preserved: a second active file at the same
+// (share, path) still maps to ErrAlreadyExists (NOT ErrConflict), so the
+// error-mapping split does not weaken path uniqueness.
+func TestPostgresPutFile_PathConflictStaysErrAlreadyExists(t *testing.T) {
+	store := newConflictTestStore(t)
+	ctx := context.Background()
+
+	const shareName = "pathconf"
+	conflictTestRoot(t, store, shareName)
+
+	_ = conflictTestFile(t, store, shareName, "dup.bin")
+
+	// A DIFFERENT id at the SAME path with nlink>0 collides on
+	// unique_share_path_hash_active.
+	dupFile := &metadata.File{
+		ID:        uuid.New(),
+		ShareName: shareName,
+		Path:      "/dup.bin",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+		},
+	}
+	if perr := store.PutFile(ctx, dupFile); perr == nil {
+		t.Fatal("PutFile at duplicate path should have failed")
+	} else if !isAlreadyExists(perr) {
+		t.Fatalf("path collision must stay ErrAlreadyExists, got %v", perr)
+	}
+}

--- a/pkg/snapshot/verify.go
+++ b/pkg/snapshot/verify.go
@@ -26,7 +26,14 @@ import (
 // guarantees that *some* missing hash is reported when any are absent.
 //
 // concurrency <= 0 is clamped to 1. A nil or empty manifest returns nil
-// without any remote I/O. The caller's ctx is the only deadline source.
+// without any remote I/O — verifying nothing is vacuously durable. This
+// short-circuit is intentional and applies to GENUINELY-empty manifests
+// (a truly empty share). It is NOT a license to report durability over a
+// spuriously-empty manifest: detecting "empty manifest on a non-empty
+// share" (the C3 hollow-durability case) is the caller's responsibility.
+// Runtime.runSnapshotOrchestration cross-checks an empty manifest against
+// the live FileBlock enumeration before this call and fails the snapshot
+// if the share still references hashes — see the C3 guard there.
 //
 // Caller wraps the returned error with models.ErrSnapshotVerifyFailed
 // at the Runtime orchestration layer; this helper stays purely

--- a/pkg/snapshot/verify.go
+++ b/pkg/snapshot/verify.go
@@ -30,10 +30,10 @@ import (
 // short-circuit is intentional and applies to GENUINELY-empty manifests
 // (a truly empty share). It is NOT a license to report durability over a
 // spuriously-empty manifest: detecting "empty manifest on a non-empty
-// share" (the C3 hollow-durability case) is the caller's responsibility.
+// share" (the hollow-durability case) is the caller's responsibility.
 // Runtime.runSnapshotOrchestration cross-checks an empty manifest against
 // the live FileBlock enumeration before this call and fails the snapshot
-// if the share still references hashes — see the C3 guard there.
+// if the share still references hashes — see the empty-manifest guard there.
 //
 // Caller wraps the returned error with models.ErrSnapshotVerifyFailed
 // at the Runtime orchestration layer; this helper stays purely


### PR DESCRIPTION
## Snapshot e2e audit fixes (#789, #790, #791) + manifest/restore/DX

Manual end-to-end audit of the share-snapshot feature. Fixes data-integrity, orchestration, and DX gaps found across NFS + SMB on memory/badger/postgres metadata, fs/memory local, and real Cubbit DS3 S3 remote.

### Data integrity
- **#789 — multi-pass rollup dropped block refs (data loss, backend-agnostic).** The rollup `ObjectIDPersister` fires once per rollup *pass* with only that pass's chunks; `PersistFileBlocks` then **replaced** `FileAttr.Blocks` (the snapshot manifest source), so a multi-pass rollup (append, or a large write split across stabilization windows) kept only the last pass — losing every prior pass from the manifest. Postgres hit it more often (slower txns made it *look* Postgres-specific, but it reproduces on memory/badger too). Fix: the persister now merges each pass into the already-persisted list by byte range (`MergeBlockRefsByOffset`) and recomputes the full-file Merkle-root ObjectID, via a new `MetadataCoordinator.GetPersistedBlocks` that reads the hash-bearing manifest source (`file_block_refs` / encoded `FileAttr.Blocks`) — not the per-file FileBlock index, whose Pending rows carry a NULL hash on Postgres. `PersistFileBlocks` stays a pure REPLACE so the file-level dedup caller is unaffected. New real-engine regression tests (WriteAt→DrainRollups→Backup) assert full `[0,size)` coverage on memory/badger/postgres.
- C1/C2 (from earlier in this branch): drain rollups before Backup; reset block-store local state before metadata Reset on restore; empty-manifest guard.

### Orchestration
- **#790 — verify gate racing freshly-rolled uploads.** Confirmed resolved by the create ordering: `DrainRollups → Backup → DrainAllUploads (synchronous SyncFileBlocks + mirrorOnce over local.ListUnsynced) → verify + drain/re-verify retry`. Validated live with a 3s write→snapshot gap on a DS3-backed share.
- **#791 — create rejected local-only shares.** Create now skips the remote drain+verify when the share has no remote and marks the snapshot `remote_durable=false` (mirrors the restore-side skip) instead of failing.

### Surface / DX
`--name` persists; failures record the error; memory-local → clear 400; git-style prefix snapshot IDs; `--state` validation; `--no-wait -o json` shape; delete-vs-retry fence; safety-snap ctx; docs drift.

### Validation
- Deterministic integration tests: multi-pass block-ref persistence on memory/badger/postgres (real engine path).
- Live e2e (badger + fs + real DS3, SMB): local-only create → ready (#791); 3s-gap remote create → ready (#790); multi-pass 4 MB file restored **byte-complete** after `restore` (#789).
- `gofmt`/`go vet`/`golangci-lint` clean; `go test -race` green; code-simplifier + code-reviewer run (findings addressed).

Closes #789, #790, #791.
