### PR TITLE
fix(smb/oplock): batch22a — 35s break-ack timeout + same-client LEVEL_II coercion

### DIFF
--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -41,6 +41,23 @@ const parentLeaseBreakWaitTimeout = 5 * time.Second
 // use the same 5 s as the parent break for consistency.
 const handleLeaseBreakWaitTimeout = 5 * time.Second
 
+// TraditionalOplockBreakWaitTimeout bounds the CREATE wait when the existing
+// holder is a traditional SMB1/SMB2 oplock (LEVEL_II / Exclusive / Batch)
+// rather than an SMB2.1+ lease. Per MS-SMB2 §3.3.4.6 step 4 the server
+// "waits for an implementation-specific default value, typically 35 seconds"
+// before declaring the break failed and granting the conflicting open.
+//
+// Traditional-oplock clients often DO ack within the standard 5 s lease
+// window (most smbtorture batch* tests), but a non-acking holder must be
+// given the spec-mandated 35 s grace before the server moves on. The
+// smbtorture batch22a / batch22b tests assert this directly: the second open
+// must succeed only AFTER `te ∈ [timeout-1, timeout+15]` where timeout=35.
+//
+// Leases keep the shorter handleLeaseBreakWaitTimeout — MS-SMB2 §3.3.4.7
+// lease-break flow has different timing semantics and existing tests
+// (timeout-disconnect, breaking3, etc.) rely on the shorter bound.
+const TraditionalOplockBreakWaitTimeout = 35 * time.Second
+
 // clientLeaseKey scopes lease-key bindings by (Owner.ClientID, lease-key
 // hex) because lock.Manager allows two distinct clients to each hold a
 // record under the same numeric LeaseKey on different files (per round-3

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -145,6 +145,70 @@ func (h *Handler) hasOtherNonStatOpenForFile(fileHandle metadata.FileHandle, sel
 	return found
 }
 
+// hasSameClientNonStatOpenForFile is the ClientGUID-scoped variant of
+// hasOtherNonStatOpenForFile. It reports whether any open in h.files on the
+// same metadata handle (excluding selfFileID) is owned by the SAME SMB
+// ClientGUID AND has a non-stat-only access mask.
+//
+// Used by the post-break trad-oplock grant path to distinguish the two arms
+// of smbtorture smb2.oplock.batch22{a,b}:
+//
+//   - batch22b (different ClientGUID, tree2 opens after tree1's batch break
+//     times out): tree2 must receive a fresh BATCH grant — the abandoned
+//     holder is on a different client, so its still-alive OpenFile does not
+//     invalidate batch caching semantics for the new client.
+//   - batch22a (same ClientGUID, h2 opens on tree1 after h1's batch break
+//     times out): h2 must receive LEVEL_II — h1 is still alive on this
+//     client and may hold dirty cached data, so exclusive batch caching
+//     cannot be granted again to the same client.
+//
+// The all-tombstones gate (OnlyTimeoutTombstoneRecords) handles the
+// different-client side by skipping the strip when only timeout tombstones
+// remain. This helper carves out the same-client exception: even after
+// timeout, a same-ClientGUID non-stat open constrains the new grant.
+//
+// Mirrors Samba's `disallow_write_lease` predicate (source3/smbd/open.c
+// lines 2397-2403) which gates on whether the existing entry's connection
+// matches the requestor's client — Samba's share entries carry the open's
+// connection identity directly; we approximate via ClientGUID equality.
+func (h *Handler) hasSameClientNonStatOpenForFile(
+	fileHandle metadata.FileHandle,
+	selfFileID [16]byte,
+	clientGUID [16]byte,
+) bool {
+	if len(fileHandle) == 0 {
+		return false
+	}
+	// A zero ClientGUID is never a "real" client identity (NEGOTIATE always
+	// generates a non-zero GUID); short-circuit so a missing GUID does not
+	// false-match other zero-GUID opens.
+	if clientGUID == ([16]byte{}) {
+		return false
+	}
+	found := false
+	h.files.Range(func(_, value any) bool {
+		other := value.(*OpenFile)
+		if other.FileID == selfFileID {
+			return true
+		}
+		if len(other.MetadataHandle) == 0 {
+			return true
+		}
+		if !bytes.Equal(other.MetadataHandle, fileHandle) {
+			return true
+		}
+		if other.ClientGUID != clientGUID {
+			return true
+		}
+		if isOplockStatOpen(other.DesiredAccess) {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
+}
+
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
 // the post-break share-mode check, then decides between parking the CREATE on
 // an interim STATUS_PENDING (returning a non-zero AsyncId) or waiting
@@ -290,6 +354,18 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		return 0
 	}
 
+	// Per MS-SMB2 §3.3.4.6 step 4: when the existing holder is a traditional
+	// SMB oplock (LEVEL_II / Exclusive / Batch), the server waits for the
+	// implementation-specific default of ~35 s before declaring the break
+	// failed. SMB2.1+ leases keep the shorter 5 s bound (different timing
+	// semantics; existing breaking3 / timeout-disconnect tests rely on it).
+	// smbtorture batch22a / batch22b assert te ∈ [34, 50] when the holder
+	// does not ack — verifying the 35 s grace.
+	breakWaitTimeout := lease.AsyncCreateBreakWaitTimeout
+	if h.LeaseManager.AnyHolderIsTraditionalOplock(lockFileHandle, shareName) {
+		breakWaitTimeout = lease.TraditionalOplockBreakWaitTimeout
+	}
+
 	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
 	// When a compound CREATE needs to wait for a lease break, it MUST go async
 	// (STATUS_PENDING) even if it is not the last command in the compound.
@@ -299,14 +375,14 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// the test (and real clients) cannot ACK the lease break until they
 	// receive the STATUS_PENDING interim response.
 	if h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey); asyncId != 0 {
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout); asyncId != 0 {
 			return asyncId
 		}
 	}
 
 	// Sync fallback: bounded wait. On timeout forceCompleteBreaks auto-downgrades
 	// other-key leases so the post-break recheck runs against deterministic state.
-	waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+	waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, breakWaitTimeout)
 	defer cancelWait()
 	if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
 		logger.Debug("CREATE: sync break wait completed", "error", err)
@@ -824,11 +900,22 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// paths so smb2.oplock.batch22b can grant a fresh BATCH after the
 		// abandoned holder times out (tree1's OpenFile is still alive but
 		// its record is a tombstone).
+		//
+		// Same-client carve-out (smbtorture smb2.oplock.batch22a, MS-SMB2
+		// §3.3.4.6): even when only timeout tombstones remain, if another
+		// non-stat OpenFile on the same ClientGUID is still alive, the new
+		// grant for THIS client must collapse to LEVEL_II. The abandoned
+		// holder may still hold dirty cached state on the client side, so
+		// exclusive batch caching cannot be regranted to the same client.
+		// Cross-client re-opens (batch22b) bypass this since the new client
+		// has no caching relationship with the abandoned holder.
 		lockFileHandle := lock.FileHandle(fileHandle)
 		onlyTimeoutTombstone := h.LeaseManager.OnlyTimeoutTombstoneRecords(lockFileHandle, tree.ShareName)
 		hasActiveRecord := h.LeaseManager.HasActiveLeaseRecord(lockFileHandle, tree.ShareName, [16]byte{})
 		hasNonStatOpen := h.hasOtherNonStatOpenForFile(fileHandle, smbFileID)
-		if !onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen) {
+		hasSameClientOpen := h.hasSameClientNonStatOpenForFile(fileHandle, smbFileID, connClientGUID(ctx))
+		if (!onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen)) ||
+			(onlyTimeoutTombstone && hasSameClientOpen) {
 			requestedState &^= (lock.LeaseStateWrite | lock.LeaseStateHandle)
 		}
 		if requestedState != 0 {
@@ -1078,11 +1165,17 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 // completes the CREATE via AsyncCreateCompleteCallback. Returns the generated
 // AsyncId on success, or 0 when async parking is not possible (e.g. no async
 // slots left; registry rejected the entry). Callers fall back to sync wait.
+//
+// breakWaitTimeout bounds the server-side wait for the break to drain (or
+// auto-downgrade on expiry). Callers pass TraditionalOplockBreakWaitTimeout
+// (~35 s, MS-SMB2 §3.3.4.6) when the holder is a traditional oplock and
+// AsyncCreateBreakWaitTimeout (~5 s) otherwise.
 func (h *Handler) parkCreateOnLeaseBreak(
 	ctx *SMBHandlerContext,
 	d *createDraft,
 	lockFileHandle lock.FileHandle,
 	waitExceptKey [16]byte,
+	breakWaitTimeout time.Duration,
 ) uint64 {
 	if h.PendingCreateRegistry == nil || ctx.AsyncCreateCompleteCallback == nil ||
 		ctx.TryReserveAsync == nil || ctx.ReleaseAsync == nil {
@@ -1100,9 +1193,9 @@ func (h *Handler) parkCreateOnLeaseBreak(
 
 	// Wait context: independent of the request's Context (which would be torn
 	// down as soon as we return StatusPending). Cancellable by SMB2_CANCEL and
-	// session teardown, bounded by AsyncCreateBreakWaitTimeout so a missing ACK
+	// session teardown, bounded by breakWaitTimeout so a missing ACK
 	// auto-downgrades other-key leases and lets the CREATE proceed.
-	waitCtx, cancel := context.WithTimeout(context.Background(), lease.AsyncCreateBreakWaitTimeout)
+	waitCtx, cancel := context.WithTimeout(context.Background(), breakWaitTimeout)
 
 	pending := &PendingCreate{
 		ConnID:    ctx.ConnID,

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -907,7 +907,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		onlyTimeoutTombstone := h.LeaseManager.OnlyTimeoutTombstoneRecords(lockFileHandle, tree.ShareName)
 		hasActiveRecord := h.LeaseManager.HasActiveLeaseRecord(lockFileHandle, tree.ShareName, [16]byte{})
 		hasNonStatOpen := h.hasOtherNonStatOpenForFile(fileHandle, smbFileID)
-		hasSameClientOpen := h.hasSameClientNonStatOpenForFile(fileHandle, smbFileID, connClientGUID(ctx))
+		// Only consult the same-client carve-out once NEGOTIATE has
+		// established a connection identity. Without CryptoState the
+		// requestor's identity is unknown — falling through would zero-
+		// vs-zero match unrelated pre-NEGOTIATE opens (regressed
+		// smb2.compound.interim2 when the early gate was removed).
+		hasSameClientOpen := false
+		if ctx != nil && ctx.ConnCryptoState != nil {
+			hasSameClientOpen = h.hasSameClientNonStatOpenForFile(fileHandle, smbFileID, connClientGUID(ctx))
+		}
 		if (!onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen)) ||
 			(onlyTimeoutTombstone && hasSameClientOpen) {
 			requestedState &^= (lock.LeaseStateWrite | lock.LeaseStateHandle)

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -321,7 +321,7 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		if !h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
 			return 0
 		}
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey); asyncId != 0 {
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout); asyncId != 0 {
 			return asyncId
 		}
 		// Park failed (no slots / registry full): fall through to sync

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -179,12 +179,6 @@ func (h *Handler) hasSameClientNonStatOpenForFile(
 	if len(fileHandle) == 0 {
 		return false
 	}
-	// A zero ClientGUID is never a "real" client identity (NEGOTIATE always
-	// generates a non-zero GUID); short-circuit so a missing GUID does not
-	// false-match other zero-GUID opens.
-	if clientGUID == ([16]byte{}) {
-		return false
-	}
 	found := false
 	h.files.Range(func(_, value any) bool {
 		other := value.(*OpenFile)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -86,18 +86,14 @@ overflow, rec, rmdir1-4, tcon, tdis, tdis1, tcp, tree.
 |-----------|----------|--------|-------|
 | smb2.notify.valid-req | Change Notify | Needs kernel inotify for MODIFIED on WRITE (also fails on reference Samba in Docker) | #750 |
 
-### Oplocks (Multi-Client Coordination Not Implemented)
+### Oplocks
 
-Oplock tests require multi-client coordination (oplock break notifications to
-other clients). DittoFS has basic oplock support; the residual failures cluster
-around stat-only-open conflict suppression, LEVEL_II coercion of subsequent
-oplock grants, and a few specialized response-mapping cases (#479).
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.oplock.batch22a | Oplocks | Break-ack timeout (~35s) + post-timeout grant-level policy diverges from batch22b | #775 |
-
-Note: the four `smb2.kernel-oplocks.*` tests require Linux kernel oplock integration via `F_SETLEASE` on the underlying fd — architecturally incompatible with DittoFS's userspace virtual filesystem. They are listed in the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope) appendix.
+All remaining oplock residuals have been resolved. The four
+`smb2.kernel-oplocks.*` tests require Linux kernel oplock integration via
+`F_SETLEASE` on the underlying fd — architecturally incompatible with
+DittoFS's userspace virtual filesystem. They are listed in the
+[Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
+appendix.
 
 ### Directory Leases (Partial Implementation)
 


### PR DESCRIPTION
Closes #775

## Problem

`smb2.oplock.batch22a` asserts two things the current implementation gets wrong:

1. Break-ack timeout follows MS-SMB2 §3.3.4.6 step 4 (~35 s default for traditional oplocks). DittoFS used the lease 5 s bound for both tiers, so the second open returned well before the spec-mandated grace window. The test asserts `te ∈ [timeout-1, timeout+15]` with `timeout=35` — 5 s fails on both ends.
2. Post-timeout grant level diverges by ClientGUID equality between the new requestor and the abandoned holder's still-alive `OpenFile`:
   - **batch22b** (different ClientGUID, transport blocked): the new client has no caching relationship with the abandoned holder → fresh BATCH grant. Already PASSES.
   - **batch22a** (same ClientGUID): the holder may still hold dirty cached data on the client side → second open must coerce to LEVEL_II.

The all-tombstones gate (`OnlyTimeoutTombstoneRecords`) was bypassing the strip for both cases since it can't see the per-client connection identity.

## Changes

- `lease.TraditionalOplockBreakWaitTimeout = 35 * time.Second` (per MS-SMB2 §3.3.4.6). Leases keep `handleLeaseBreakWaitTimeout` (5 s) — `breaking3` / `timeout-disconnect` rely on the shorter bound.
- `breakAndMaybeParkCreate` selects the timeout via `AnyHolderIsTraditionalOplock`.
- `parkCreateOnLeaseBreak` takes the timeout as a parameter so sync + async paths stay aligned.
- `hasSameClientNonStatOpenForFile` carves out the same-ClientGUID exception in the trad-oplock grant block: when only timeout tombstones remain but a same-client non-stat open is alive, strip `W|H` from the candidate.

## Reference

- MS-SMB2 §3.3.4.6 step 4 (oplock break-ack timeout).
- Samba `source3/smbd/open.c::delay_for_oplock_fn` lines 2397-2403 (`disallow_write_lease`) and `grant_fsp_oplock_type` lines 2637-2673 (W-strip + trad-oplock H-strip).

## Test plan

- [x] `go test ./...` — all green
- [x] `gofmt -s -w .` + `go vet ./...` + `golangci-lint run` — clean
- [ ] Conformance CI: `smb2.oplock.batch22a` flips to PASS, batch22b stays PASS, no other regressions