### PR TITLE
fix(smb/create): per-kind parent-DACL bit for ADD_FILE vs ADD_SUBDIRECTORY

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1042,17 +1042,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Pre-disposition parent-DACL gate: any non-pure-OPEN disposition mutates
 	// the parent directory's contents (creating, overwriting, or superseding a
-	// child). MS-FSA 2.1.5.1.1 + MS-SMB2 §3.3.5.9 require parent-write
+	// child). MS-FSA 2.1.5.1.1 + MS-SMB2 §3.3.5.9 require parent-create
 	// permission to be evaluated before failing on disposition collisions, so
 	// a deny ACE on the parent surfaces as ACCESS_DENIED rather than
 	// OBJECT_NAME_COLLISION / DELETE_PENDING. FILE_OPEN is the only pure-open
 	// disposition; everything else (CREATE, CREATE_IF, OVERWRITE,
 	// OVERWRITE_IF, SUPERSEDE) is gated.
+	//
+	// The check evaluates the precise ACL bit for the child kind (ADD_FILE
+	// vs ADD_SUBDIRECTORY) so a parent DACL that denies only one variant
+	// does not also block the other — required by smbtorture
+	// smb2.create.mkdir-visible (deny-WORLD-ADD_FILE inherited ACE must
+	// not block subdirectory creation).
 	if req.CreateDisposition != types.FileOpen {
-		if err := metaSvc.CheckParentWriteAccess(authCtx, parentHandle); err != nil {
-			logger.Debug("CREATE: parent DACL denies write",
+		isDirCreate := req.CreateOptions&types.FileDirectoryFile != 0
+		if err := metaSvc.CheckParentCreateAccess(authCtx, parentHandle, isDirCreate); err != nil {
+			logger.Debug("CREATE: parent DACL denies create",
 				"path", filename,
 				"disposition", req.CreateDisposition,
+				"isDirectory", isDirCreate,
 				"error", err)
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 		}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -478,9 +478,114 @@ func (s *MetadataService) checkWritePermission(ctx *AuthContext, handle FileHand
 // rather than OBJECT_NAME_COLLISION / DELETE_PENDING.
 //
 // The check is exactly POSIX WRITE on the parent directory; ACL evaluation
-// runs through the same code path as in-process write checks.
+// runs through the same code path as in-process write checks. Use
+// CheckParentCreateAccess when the caller knows whether a file or
+// subdirectory is being created so the precise ACL bit (ADD_FILE vs
+// ADD_SUBDIRECTORY) can be evaluated.
 func (s *MetadataService) CheckParentWriteAccess(ctx *AuthContext, parentHandle FileHandle) error {
 	return s.checkWritePermission(ctx, parentHandle)
+}
+
+// CheckParentCreateAccess verifies the caller may create a new file or
+// subdirectory in the given directory. Unlike CheckParentWriteAccess, this
+// evaluates the precise NFSv4 ACL bit corresponding to the kind of child
+// being created:
+//
+//   - File create  -> ACE4_ADD_FILE         (0x02, alias of WRITE_DATA)
+//   - Dir create   -> ACE4_ADD_SUBDIRECTORY (0x04, alias of APPEND_DATA)
+//
+// MS-FSA 2.1.5.1.1 and Samba's mkdir_internal()/open_file_ntcreate() check
+// each bit independently. A parent DACL that denies SEC_DIR_ADD_FILE only
+// (no ADD_SUBDIRECTORY deny) must still allow subdirectory creation —
+// required by smbtorture smb2.create.mkdir-visible.
+//
+// For files that do not carry an ACL we fall back to the generic
+// PermissionWrite path so POSIX mode bits, share-level overrides, and
+// DOS-READONLY enforcement are honored.
+func (s *MetadataService) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHandle, isDirectory bool) error {
+	store, err := s.storeForHandle(parentHandle)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Context.Err(); err != nil {
+		return err
+	}
+
+	file, err := store.GetFile(ctx.Context, parentHandle)
+	if err != nil {
+		return err
+	}
+
+	// Without an ACL there's nothing to refine — fall back to the generic
+	// POSIX-write check so mode bits / share-level grants apply uniformly.
+	if file.ACL == nil {
+		return s.checkWritePermission(ctx, parentHandle)
+	}
+
+	shareOpts, _ := store.GetShareOptions(ctx.Context, file.ShareName)
+
+	// Share-level read-only beats any ACL grant.
+	if shareOpts != nil && shareOpts.ReadOnly {
+		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
+	}
+
+	// Share-level write bypass mirrors checkFilePermissions: an ALLOW-only
+	// DACL plus ctx.ShareWritable still permits writes (load-bearing for
+	// stream-inherit-perms and create.multi). Only an explicit DENY ACE
+	// disables the bypass.
+	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
+		return nil
+	}
+
+	identity := ctx.Identity
+
+	// Root bypass aligns with calculatePermissions/evaluateACLPermissions:
+	// UID 0 gets all permissions except on read-only shares (handled above).
+	if identity != nil && identity.UID != nil && *identity.UID == 0 {
+		return nil
+	}
+
+	var evalCtx *acl.EvaluateContext
+	if identity == nil || identity.UID == nil {
+		// Anonymous: pin owner UID to the anonymous sentinel so OWNER@
+		// can't accidentally match a root-owned file (mirror of
+		// evaluateACLPermissions).
+		evalCtx = &acl.EvaluateContext{
+			FileOwnerUID: acl.AnonymousFileOwnerUID,
+			FileOwnerGID: file.GID,
+		}
+	} else {
+		evalCtx = &acl.EvaluateContext{
+			UID:          *identity.UID,
+			GIDs:         identity.GIDs,
+			FileOwnerUID: file.UID,
+			FileOwnerGID: file.GID,
+		}
+		if identity.GID != nil {
+			evalCtx.GID = *identity.GID
+		}
+		switch {
+		case identity.Username != "" && identity.Domain != "":
+			evalCtx.Who = identity.Username + "@" + identity.Domain
+		case identity.Username != "":
+			evalCtx.Who = identity.Username
+		}
+		if identity.SID != nil {
+			evalCtx.SID = *identity.SID
+		}
+		evalCtx.GroupSIDs = identity.GroupSIDs
+		evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
+	}
+
+	mask := uint32(acl.ACE4_ADD_FILE)
+	if isDirectory {
+		mask = acl.ACE4_ADD_SUBDIRECTORY
+	}
+
+	if !acl.Evaluate(file.ACL, evalCtx, mask) {
+		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
+	}
+	return nil
 }
 
 // checkDeletePermission checks permission to unlink an entry from a parent directory.

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -537,45 +537,16 @@ func (s *MetadataService) CheckParentCreateAccess(ctx *AuthContext, parentHandle
 		return nil
 	}
 
-	identity := ctx.Identity
-
 	// Root bypass aligns with calculatePermissions/evaluateACLPermissions:
 	// UID 0 gets all permissions except on read-only shares (handled above).
-	if identity != nil && identity.UID != nil && *identity.UID == 0 {
+	if ctx.Identity != nil && ctx.Identity.UID != nil && *ctx.Identity.UID == 0 {
 		return nil
 	}
 
-	var evalCtx *acl.EvaluateContext
-	if identity == nil || identity.UID == nil {
-		// Anonymous: pin owner UID to the anonymous sentinel so OWNER@
-		// can't accidentally match a root-owned file (mirror of
-		// evaluateACLPermissions).
-		evalCtx = &acl.EvaluateContext{
-			FileOwnerUID: acl.AnonymousFileOwnerUID,
-			FileOwnerGID: file.GID,
-		}
-	} else {
-		evalCtx = &acl.EvaluateContext{
-			UID:          *identity.UID,
-			GIDs:         identity.GIDs,
-			FileOwnerUID: file.UID,
-			FileOwnerGID: file.GID,
-		}
-		if identity.GID != nil {
-			evalCtx.GID = *identity.GID
-		}
-		switch {
-		case identity.Username != "" && identity.Domain != "":
-			evalCtx.Who = identity.Username + "@" + identity.Domain
-		case identity.Username != "":
-			evalCtx.Who = identity.Username
-		}
-		if identity.SID != nil {
-			evalCtx.SID = *identity.SID
-		}
-		evalCtx.GroupSIDs = identity.GroupSIDs
-		evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
-	}
+	// Reuse the canonical EvaluateContext builder so anonymous-owner
+	// handling, Who/SID population, and SeTakeOwnership derivation stay in
+	// one place with CheckFileAccess.
+	evalCtx := buildFileAccessEvalContext(file, ctx)
 
 	mask := uint32(acl.ACE4_ADD_FILE)
 	if isDirectory {

--- a/pkg/metadata/auth_permissions_parent_check_test.go
+++ b/pkg/metadata/auth_permissions_parent_check_test.go
@@ -75,3 +75,137 @@ func TestCheckParentWriteAccess_NoACLAllowsAdd(t *testing.T) {
 		t.Fatalf("CheckParentWriteAccess on POSIX-only writable parent err = %v, want nil", err)
 	}
 }
+
+// TestCheckParentCreateAccess_DenyAddFileBlocksFileAllowsDir verifies that
+// a parent DACL denying only SEC_DIR_ADD_FILE (ACE4_ADD_FILE, 0x02) blocks
+// file creates but still permits subdirectory creates. Regresses the
+// smb2.create.mkdir-visible fix: PermissionWrite lumps ADD_FILE and
+// ADD_SUBDIRECTORY together (mask 0x06), so the old combined check
+// incorrectly denied directory creates whenever ADD_FILE was denied.
+func TestCheckParentCreateAccess_DenyAddFileBlocksFileAllowsDir(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	denyAddFile := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: acl.ACE4_ADD_FILE,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-file",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  denyAddFile,
+		})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	sid := requesterSID
+	authCtx.Identity.SID = &sid
+	// Disable the share-level write bypass so the ACL is the sole gate
+	// (the bypass would short-circuit deny-ACL evaluation otherwise).
+	authCtx.ShareWritable = false
+
+	// File create: must be denied by the ADD_FILE deny ACE.
+	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, false)
+	if err == nil {
+		t.Fatalf("CheckParentCreateAccess(file) returned nil, want ErrAccessDenied")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+		t.Fatalf("CheckParentCreateAccess(file) err = %v, want StoreError{Code: ErrAccessDenied}", err)
+	}
+
+	// Directory create: ADD_SUBDIRECTORY is not denied, must succeed.
+	if err := f.service.CheckParentCreateAccess(authCtx, dirHandle, true); err != nil {
+		t.Fatalf("CheckParentCreateAccess(dir) err = %v, want nil (ADD_SUBDIRECTORY not denied)", err)
+	}
+}
+
+// TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile is the
+// symmetric case: deny ADD_SUBDIRECTORY only, expect file create to
+// succeed and subdirectory create to be denied.
+func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	denyAddSubdir := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: acl.ACE4_ADD_SUBDIRECTORY,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-subdir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			UID:  requesterUID,
+			GID:  1001,
+			ACL:  denyAddSubdir,
+		})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	sid := requesterSID
+	authCtx.Identity.SID = &sid
+	authCtx.ShareWritable = false
+
+	// Directory create: must be denied by the ADD_SUBDIRECTORY deny ACE.
+	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, true)
+	if err == nil {
+		t.Fatalf("CheckParentCreateAccess(dir) returned nil, want ErrAccessDenied")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+		t.Fatalf("CheckParentCreateAccess(dir) err = %v, want StoreError{Code: ErrAccessDenied}", err)
+	}
+
+	// File create: ADD_FILE is not denied, must succeed.
+	if err := f.service.CheckParentCreateAccess(authCtx, dirHandle, false); err != nil {
+		t.Fatalf("CheckParentCreateAccess(file) err = %v, want nil (ADD_FILE not denied)", err)
+	}
+}
+
+// TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck verifies the
+// POSIX fallback path: when the parent has no ACL, evaluation falls
+// through to the shared PermissionWrite check so mode bits and
+// share-level grants still govern.
+func TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck(t *testing.T) {
+	f := newTestFixture(t)
+	authCtx := f.authContext(1001, 1001)
+	authCtx.ShareWritable = true
+
+	if err := f.service.CheckParentCreateAccess(authCtx, f.rootHandle, false); err != nil {
+		t.Fatalf("CheckParentCreateAccess(file, no-ACL) err = %v, want nil", err)
+	}
+	if err := f.service.CheckParentCreateAccess(authCtx, f.rootHandle, true); err != nil {
+		t.Fatalf("CheckParentCreateAccess(dir, no-ACL) err = %v, want nil", err)
+	}
+}

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -200,8 +200,11 @@ func (s *MetadataService) createEntry(
 		return nil, err
 	}
 
-	// Check write permission on parent
-	if err := s.checkWritePermission(ctx, parentHandle); err != nil {
+	// Check create permission on parent. Use the precise NFSv4 mask for the
+	// child being created (ADD_FILE vs ADD_SUBDIRECTORY) so a DACL that
+	// denies only one variant does not also block the other — required by
+	// MS-FSA 2.1.5.1.1 and smbtorture smb2.create.mkdir-visible.
+	if err := s.CheckParentCreateAccess(ctx, parentHandle, fileType == FileTypeDirectory); err != nil {
 		return nil, err
 	}
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -128,18 +128,6 @@ counter already matched. The `2conn_notify_max_async_credits` failure that
 remained here was a cross-connection MessageID collision in
 `NotifyRegistry`, fixed in #416.
 
-### Create Contexts (Advanced Semantics Not Implemented)
-
-Advanced CREATE context features (impersonation, ACL-based create, quota fake
-files, create blobs) are not implemented. Basic create operations pass.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.create.impersonation | Create | Impersonation levels not implemented | #771 |
-| smb2.create.mkdir-visible | Create | Mkdir visibility semantics not implemented | #771 |
-| smb2.create.multi | Create | Regression from recent changes, fails on all 3 stores | #771 |
-| smb2.create.path-length | Create | Flaky in CI (path length validation race) | #771 |
-
 ### Query/Set Info (Advanced Scenarios)
 
 Advanced getinfo scenarios requiring security descriptor queries, buffer size
@@ -420,6 +408,29 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-05-29 — #771 closed: 4 `smb2.create.*` residuals walked back
+
+PR with per-kind parent-DACL bit (`ADD_FILE` vs `ADD_SUBDIRECTORY`) in
+`CheckParentCreateAccess` flips `smb2.create.mkdir-visible`. The other
+three rows tracked under #771 were already PASS / SKIP against the
+develop tip and the KF entries were stale:
+
+- **`smb2.create.impersonation`** — already PASSes; `create.go` rejects
+  `ImpersonationLevel > 3` with `STATUS_BAD_IMPERSONATION_LEVEL`
+  (added in PR #480, baseline 2026-05-28).
+- **`smb2.create.mkdir-visible`** — newly flipped. Parent DACL with
+  inheritable deny-WORLD-`SEC_DIR_ADD_FILE` no longer blocks
+  subdirectory creation (MS-FSA 2.1.5.1.1 / Samba `mkdir_internal`).
+- **`smb2.create.multi`** — already PASSes; 3 concurrent CREATEs on the
+  same name resolve to 1 OK + 2 `OBJECT_NAME_COLLISION` via the
+  existing transactional TOCTOU guard in `createEntry`.
+- **`smb2.create.path-length`** — `--interactive`-only test (returns
+  `TORTURE_SKIP` in non-interactive runs per Samba
+  `source4/torture/smb2/create.c:3806`). Not a failure; KF row was
+  stale.
+
+Umbrella #771 closed.
 
 ### 2026-05-29 — #741 residual triage: blob+gentest → appendix; split into #771; close #741
 


### PR DESCRIPTION
## Summary

CREATE evaluated the parent DACL with the lumped PermissionWrite mask (`ACE4_WRITE_DATA | ACE4_APPEND_DATA` = 0x06). A deny ACE targeting only `SEC_DIR_ADD_FILE` (0x02) therefore blocked subdirectory creation as well, contrary to MS-FSA 2.1.5.1.1 and Samba's `mkdir_internal` which uses `SEC_DIR_ADD_SUBDIR` (0x04) for directory creates.

Add `MetadataService.CheckParentCreateAccess(isDirectory)` that evaluates `ACE4_ADD_FILE` or `ACE4_ADD_SUBDIRECTORY` in isolation, mirroring the share-bypass, root-bypass, and anonymous-owner handling already used by `evaluateACLPermissions`. Fall back to the existing POSIX-write check when the parent has no ACL so mode bits, share-level overrides, and DOS-READONLY enforcement remain authoritative.

Route both the pre-disposition SMB CREATE gate and the in-process `createEntry()` check through the new method, threading `isDirectory` from `CreateOptions & FILE_DIRECTORY_FILE` / `FileType` respectively.

## Tests flipped (vs `smb2.create` filter on memory profile)

- `smb2.create.mkdir-visible` — FAIL → PASS (real protocol fix)
- `smb2.create.impersonation` — was already PASS in baseline; stale KF row removed
- `smb2.create.multi` — was already PASS in baseline; stale KF row removed
- `smb2.create.path-length` — interactive-only test (SKIP); stale KF row removed

## Test plan

- [x] `go test ./pkg/metadata/...` PASS
- [x] `go test ./internal/adapter/smb/...` PASS
- [x] `gofmt -s -w .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` clean (0 issues)
- [x] smbtorture `smb2.create` suite: target 4 tests pass, no regressions
- [x] smbtorture `smb2.acls` suite: 14/14 PASS (no regression in DACL-bearing paths)
- [x] smbtorture `smb2.delete-on-close-perms` suite: 9/9 PASS
- [x] smbtorture `smb2.deny` suite: 2/2 PASS
- [ ] CI smbtorture full suite confirms flip + no regression — KF walk-back commit follows

Closes #771