### PR TITLE
chore(smb/kf): broaden DH V1 intro to flag #792/#793 non-DH rows

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -205,8 +205,10 @@ Session signing edge cases requiring multi-channel binding.
 
 ### Durable Handles V1 (Fix Candidate)
 
-Durable handle V1 open/reopen operations partially implemented but tests
-still fail due to incomplete reconnect and lease coordination.
+Durable handle V1 open/reopen operations partially implemented; most rows
+fail at the reconnect / lease coordination layer. Two trailing rows
+(`alloc-size`, `read-only`) are CREATE / attribute-restore gaps unrelated
+to the DH state machine — tracked under #792 / #793.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|


### PR DESCRIPTION
Copilot follow-up on #794. The Durable Handles V1 section intro stated all rows fail at the reconnect/lease layer, but `alloc-size` and `read-only` are CREATE/attribute-restore gaps tracked separately (#792, #793). Broaden the intro to reflect that.

Doc-only — no smbtorture impact.