### PR TITLE
feat(cmd/blockstore-perf): walk/delete/gc workloads + S3 remote + env file

### DIFF
--- a/cmd/blockstore-perf/envfile.go
+++ b/cmd/blockstore-perf/envfile.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// parseEnvFile loads simple KEY=VALUE lines from path into the process
+// env via os.Setenv. Lines starting with '#' and blank lines are
+// ignored. No quote/multiline handling — the harness only consumes
+// a handful of S3 vars; keep the parser deliberately minimal.
+//
+// Existing env vars are NOT overwritten so a CLI-passed
+// AWS_S3_BUCKET still wins over a checked-in .env.
+func parseEnvFile(path string) error {
+	f, err := os.Open(path) //nolint:gosec // operator-supplied path is the point
+	if err != nil {
+		return fmt.Errorf("envfile: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			return fmt.Errorf("envfile: %s:%d: missing '='", path, lineNo)
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		if _, ok := os.LookupEnv(key); ok {
+			continue
+		}
+		if err := os.Setenv(key, val); err != nil {
+			return fmt.Errorf("envfile: setenv %s: %w", key, err)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("envfile: scan %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/blockstore-perf/main.go
+++ b/cmd/blockstore-perf/main.go
@@ -1,8 +1,8 @@
 // blockstore-perf is a seeded workload harness for pkg/blockstore/engine.
-// Composes FSStore local + memory remote + in-memory metadata + Syncer
+// Composes FSStore local + (memory|s3) remote + in-memory metadata + Syncer
 // and drives one of: sequential-write, random-write, dedup-heavy,
-// mixed-rw, flush-churn. Captures wall-clock, throughput, and CPU + heap
-// pprof to <profile-dir>/<workload>-<timestamp>/.
+// mixed-rw, flush-churn, walk, delete, gc, raw-s3-put. Captures wall-clock,
+// throughput, and CPU + heap pprof to <profile-dir>/<workload>-<timestamp>/.
 //
 // Example: go run ./cmd/blockstore-perf --workload random-write --ops 5000
 package main
@@ -21,7 +21,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
-	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
@@ -33,12 +33,14 @@ const (
 )
 
 type config struct {
-	workload   string
-	ops        int
-	blockSize  int
-	workingSet int
-	profileDir string
-	seed       uint64
+	workload       string
+	ops            int
+	blockSize      int
+	workingSet     int
+	profileDir     string
+	seed           uint64
+	remote         string
+	gcGarbageRatio float64
 }
 
 func main() {
@@ -50,12 +52,25 @@ func main() {
 
 func parseFlags() config {
 	var c config
-	flag.StringVar(&c.workload, "workload", "", "workload name (sequential-write|random-write|dedup-heavy|mixed-rw|flush-churn)")
+	flag.StringVar(&c.workload, "workload", "", "workload name (sequential-write|random-write|dedup-heavy|mixed-rw|flush-churn|walk|delete|gc|raw-s3-put)")
 	flag.IntVar(&c.ops, "ops", 10000, "operation count")
 	bs := flag.Int("block-size", 0, "per-op block size in bytes (default: 8 MiB for sequential/dedup, 4 KiB for the rest)")
 	flag.IntVar(&c.workingSet, "working-set", 1, "number of files in the working set")
 	flag.StringVar(&c.profileDir, "profile-dir", "_profiles", "directory for pprof output")
 	flag.Uint64Var(&c.seed, "seed", 1, "PRNG seed for randomized workloads")
+	flag.StringVar(&c.remote, "remote", "memory", "remote backend (memory|s3); s3 reads AWS_* env")
+	envFile := flag.String("env-file", "", "optional .env file (KEY=VALUE) loaded before --remote=s3 reads AWS_* env")
+	_ = envFile // consumed via preScanEnvFile before flag.Parse so the flag registration only documents the surface
+
+	flag.Float64Var(&c.gcGarbageRatio, "gc-garbage-ratio", 0.3, "fraction of seeded chunks left unreferenced for the gc workload")
+	// Two-phase parse: pre-scan os.Args for --env-file so its contents
+	// can populate env BEFORE flag.Parse evaluates downstream defaults.
+	if path := preScanEnvFile(os.Args[1:]); path != "" {
+		if err := parseEnvFile(path); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
 	flag.Parse()
 	if c.workload == "" {
 		fmt.Fprintln(os.Stderr, "--workload is required")
@@ -73,6 +88,24 @@ func parseFlags() config {
 	return c
 }
 
+// preScanEnvFile finds --env-file=PATH or --env-file PATH in argv
+// without consuming the flag — the real flag.Parse runs afterwards.
+func preScanEnvFile(argv []string) string {
+	for i, a := range argv {
+		switch {
+		case a == "--env-file" || a == "-env-file":
+			if i+1 < len(argv) {
+				return argv[i+1]
+			}
+		case len(a) > 11 && a[:11] == "--env-file=":
+			return a[11:]
+		case len(a) > 10 && a[:10] == "-env-file=":
+			return a[10:]
+		}
+	}
+	return ""
+}
+
 func run(cfg config) error {
 	tmpDir, err := os.MkdirTemp("", "blockstore-perf-")
 	if err != nil {
@@ -80,11 +113,36 @@ func run(cfg config) error {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	bs, closeFn, err := newBlockStore(tmpDir)
+	remoteStore, remoteClose, err := setupRemote(cfg)
 	if err != nil {
 		return err
 	}
+	// raw-s3-put bypasses the engine; the engine path takes ownership
+	// of remote close otherwise.
+	rawS3 := cfg.workload == "raw-s3-put"
+	if rawS3 {
+		defer remoteClose()
+		return runRawS3(cfg, remoteStore)
+	}
+	// Local/walk/delete workloads run against the local store only.
+	if cfg.workload == "walk" || cfg.workload == "delete" {
+		defer remoteClose()
+		return runLocalOnly(cfg, tmpDir)
+	}
+	if cfg.workload == "gc" {
+		defer remoteClose()
+		return runGC(cfg, remoteStore)
+	}
+
+	bs, closeFn, err := newBlockStore(tmpDir, remoteStore)
+	if err != nil {
+		// engine never took ownership of the remote on construction
+		// failure — drop it here.
+		remoteClose()
+		return err
+	}
 	defer closeFn()
+	// engine.BlockStore.Close closes the remote — no separate remoteClose.
 
 	profDir, cpuStop, err := startProfiles(cfg)
 	if err != nil {
@@ -133,9 +191,10 @@ func run(cfg config) error {
 	return nil
 }
 
-// newBlockStore wires production-equivalent FSStore + memory remote +
-// memory metadata + Syncer, sized for short-lived benchmark runs.
-func newBlockStore(baseDir string) (*engine.Store, func(), error) {
+// newBlockStore wires production-equivalent FSStore + caller-supplied
+// remote + memory metadata + Syncer, sized for short-lived benchmark
+// runs. Takes ownership of remoteStore via engine.Store.Close.
+func newBlockStore(baseDir string, remoteStore remote.RemoteStore) (*engine.Store, func(), error) {
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	local, err := fs.NewWithOptions(baseDir, 0, memBudget, ms, fs.FSStoreOptions{
 		MaxLogBytes:     logBudget,
@@ -150,7 +209,6 @@ func newBlockStore(baseDir string) (*engine.Store, func(), error) {
 	if err := local.StartRollup(context.Background()); err != nil {
 		return nil, nil, fmt.Errorf("StartRollup: %w", err)
 	}
-	remoteStore := remotememory.New()
 	syncer := engine.NewSyncer(local, remoteStore, ms, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           local,
@@ -197,6 +255,37 @@ func writeHeapProfile(dir string) error {
 	defer func() { _ = f.Close() }()
 	if err := pprof.WriteHeapProfile(f); err != nil {
 		return fmt.Errorf("WriteHeapProfile: %w", err)
+	}
+	return nil
+}
+
+// timedRun wraps the profile+timer scaffolding shared by every
+// runner: opens a profile dir, starts the CPU profile, calls fn,
+// stops the CPU profile, writes the heap snapshot, and prints a
+// single-line result. fn returns (ops, bytes) for the report.
+func timedRun(cfg config, label string, fn func() (int64, int64, error)) error {
+	profDir, cpuStop, err := startProfiles(cfg)
+	if err != nil {
+		return err
+	}
+	start := time.Now()
+	ops, bytes, err := fn()
+	dur := time.Since(start)
+	cpuStop()
+	if err != nil {
+		return err
+	}
+	if err := writeHeapProfile(profDir); err != nil {
+		return err
+	}
+	durMs := float64(dur.Microseconds()) / 1000.0
+	opsPerSec := float64(ops) / dur.Seconds()
+	if bytes > 0 {
+		fmt.Printf("workload=%s ops=%d dur=%.3fms ops_per_sec=%.2f bytes_per_sec=%.2f profiles=%s\n",
+			label, ops, durMs, opsPerSec, float64(bytes)/dur.Seconds(), profDir)
+	} else {
+		fmt.Printf("workload=%s ops=%d dur=%.3fms ops_per_sec=%.2f profiles=%s\n",
+			label, ops, durMs, opsPerSec, profDir)
 	}
 	return nil
 }

--- a/cmd/blockstore-perf/main.go
+++ b/cmd/blockstore-perf/main.go
@@ -142,7 +142,7 @@ func run(cfg config) error {
 		return err
 	}
 	defer closeFn()
-	// engine.BlockStore.Close closes the remote — no separate remoteClose.
+	// engine.Store.Close closes the remote — no separate remoteClose.
 
 	profDir, cpuStop, err := startProfiles(cfg)
 	if err != nil {

--- a/cmd/blockstore-perf/remote.go
+++ b/cmd/blockstore-perf/remote.go
@@ -13,7 +13,7 @@ import (
 
 // setupRemote constructs the RemoteStore backing the harness run.
 // Returns a cleanup that closes the store ONLY for memory remotes —
-// the engine.BlockStore Close already closes the remote it owns, so
+// the engine.Store Close already closes the remote it owns, so
 // when the remote is passed into engine.New the caller must skip our
 // cleanup (the s3 path is only used by the raw-s3-put workload that
 // bypasses the engine, and that path takes ownership of the cleanup).

--- a/cmd/blockstore-perf/remote.go
+++ b/cmd/blockstore-perf/remote.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	remotes3 "github.com/marmos91/dittofs/pkg/blockstore/remote/s3"
+)
+
+// setupRemote constructs the RemoteStore backing the harness run.
+// Returns a cleanup that closes the store ONLY for memory remotes —
+// the engine.BlockStore Close already closes the remote it owns, so
+// when the remote is passed into engine.New the caller must skip our
+// cleanup (the s3 path is only used by the raw-s3-put workload that
+// bypasses the engine, and that path takes ownership of the cleanup).
+func setupRemote(cfg config) (remote.RemoteStore, func(), error) {
+	switch cfg.remote {
+	case "memory":
+		return remotememory.New(), func() {}, nil
+	case "s3":
+		return setupS3Remote()
+	default:
+		return nil, nil, fmt.Errorf("unknown --remote %q (want memory|s3)", cfg.remote)
+	}
+}
+
+func setupS3Remote() (remote.RemoteStore, func(), error) {
+	bucket := os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		return nil, nil, fmt.Errorf("AWS_S3_BUCKET is required when --remote=s3")
+	}
+	region := os.Getenv("AWS_S3_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	// Default to path-style for non-AWS endpoints (Localstack/MinIO/DS3).
+	// Explicit AWS_S3_PATH_STYLE overrides the heuristic.
+	pathStyle := endpoint != ""
+	if v, ok := os.LookupEnv("AWS_S3_PATH_STYLE"); ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("AWS_S3_PATH_STYLE: %w", err)
+		}
+		pathStyle = b
+	}
+	store, err := remotes3.NewFromConfig(context.Background(), remotes3.Config{
+		Bucket:         bucket,
+		Region:         region,
+		Endpoint:       endpoint,
+		AccessKey:      os.Getenv("AWS_ACCESS_KEY_ID"),
+		SecretKey:      os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		ForcePathStyle: pathStyle,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("s3.NewFromConfig: %w", err)
+	}
+	return store, func() { _ = store.Close() }, nil
+}

--- a/cmd/blockstore-perf/remote.go
+++ b/cmd/blockstore-perf/remote.go
@@ -48,12 +48,22 @@ func setupS3Remote() (remote.RemoteStore, func(), error) {
 		}
 		pathStyle = b
 	}
+	var maxRetries int
+	if v, ok := os.LookupEnv("AWS_S3_MAX_RETRIES"); ok {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return nil, nil, fmt.Errorf("AWS_S3_MAX_RETRIES: want non-negative integer, got %q", v)
+		}
+		maxRetries = n
+	}
 	store, err := remotes3.NewFromConfig(context.Background(), remotes3.Config{
 		Bucket:         bucket,
 		Region:         region,
 		Endpoint:       endpoint,
 		AccessKey:      os.Getenv("AWS_ACCESS_KEY_ID"),
 		SecretKey:      os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		KeyPrefix:      os.Getenv("AWS_S3_KEY_PREFIX"),
+		MaxRetries:     maxRetries,
 		ForcePathStyle: pathStyle,
 	})
 	if err != nil {

--- a/cmd/blockstore-perf/workloads_extra.go
+++ b/cmd/blockstore-perf/workloads_extra.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// seedChunks Puts cfg.ops unique CAS chunks into local, returning their
+// hashes for downstream Walk/Delete/GC reference shaping.
+func seedChunks(ctx context.Context, local *fs.FSStore, cfg config) ([]blockstore.ContentHash, error) {
+	hashes := make([]blockstore.ContentHash, cfg.ops)
+	data := make([]byte, cfg.blockSize)
+	for i := 0; i < cfg.ops; i++ {
+		// Per-iteration prefix makes every chunk unique even when
+		// blockSize is small (no synthetic randomness needed — the
+		// hash is content-derived).
+		copy(data, fmt.Sprintf("perf-seed-%016x", uint64(i)))
+		h := blockstore.ContentHash(blake3.Sum256(data))
+		if err := local.Put(ctx, h, data); err != nil {
+			return nil, fmt.Errorf("seed put %d: %w", i, err)
+		}
+		hashes[i] = h
+	}
+	return hashes, nil
+}
+
+// gcReconciler is a single-share MultiShareReconciler over a memory
+// metadata store, matching the production wiring shape used by Runtime
+// when a remote points at exactly one share.
+type gcReconciler struct {
+	share string
+	store metadata.MetadataStore
+}
+
+func (g *gcReconciler) GetMetadataStoreForShare(name string) (metadata.MetadataStore, error) {
+	if name != g.share {
+		return nil, fmt.Errorf("unknown share %q", name)
+	}
+	return g.store, nil
+}
+
+func (g *gcReconciler) SharesForGC() []string { return []string{g.share} }
+
+// prepareGC seeds (ops) CAS objects on the remote, references
+// ceil(ops * (1-garbageRatio)) of them via FileBlock rows on a memory
+// metadata store, and returns a timed step that runs one CollectGarbage
+// pass per op.
+func prepareGC(ctx context.Context, remoteStore remote.RemoteStore, ms metadata.MetadataStore, cfg config) (func(i int) (int, error), error) {
+	if cfg.gcGarbageRatio < 0 || cfg.gcGarbageRatio > 1 {
+		return nil, fmt.Errorf("--gc-garbage-ratio must be in [0,1], got %f", cfg.gcGarbageRatio)
+	}
+	totalRefs := int(float64(cfg.ops) * (1 - cfg.gcGarbageRatio))
+	// For the in-process memory remote, backdate Put-stamped LastModified
+	// so freshly-seeded objects fall outside the GC grace window. Real
+	// S3 timestamps are old enough that the default grace is fine.
+	if mem, ok := remoteStore.(*remotememory.Store); ok {
+		backdate := time.Now().Add(-2 * time.Hour)
+		mem.SetNowFnForTest(func() time.Time { return backdate })
+	}
+	data := make([]byte, cfg.blockSize)
+	for i := 0; i < cfg.ops; i++ {
+		copy(data, fmt.Sprintf("perf-gc-%016x", uint64(i)))
+		h := blockstore.ContentHash(blake3.Sum256(data))
+		if err := remoteStore.Put(ctx, h, data); err != nil {
+			return nil, fmt.Errorf("seed remote %d: %w", i, err)
+		}
+		if i < totalRefs {
+			if err := ms.Put(ctx, &blockstore.FileBlock{
+				ID:            fmt.Sprintf("perf-gc/%d", i),
+				Hash:          h,
+				State:         blockstore.BlockStateRemote,
+				BlockStoreKey: blockstore.FormatCASKey(h),
+				DataSize:      uint32(len(data)),
+				RefCount:      1,
+				LastAccess:    time.Now(),
+				CreatedAt:     time.Now(),
+			}); err != nil {
+				return nil, fmt.Errorf("seed metadata %d: %w", i, err)
+			}
+		}
+	}
+	rec := &gcReconciler{share: "perf-gc", store: ms}
+	// One CollectGarbage call per timed op so the step closure
+	// matches runLoop's per-call accounting; ops=1 is the canonical
+	// usage but --ops>1 lets a caller average over multiple sweeps.
+	return func(_ int) (int, error) {
+		stats := engine.CollectGarbage(ctx, remoteStore, rec, &engine.Options{
+			// 1h grace; in-memory remote backdates LastModified by 2h
+			// at seed so synthetic objects fall outside the window.
+			GracePeriod: time.Hour,
+		})
+		if stats.ErrorCount > 0 {
+			return 0, fmt.Errorf("gc errors=%d first=%v", stats.ErrorCount, stats.FirstErrors)
+		}
+		return 0, nil
+	}, nil
+}
+
+// stepRawS3Put writes one unique CAS chunk per op directly via
+// remoteStore.Put, bypassing the engine. Used as a baseline for
+// raw-S3 throughput vs the full --remote=s3 write path.
+func stepRawS3Put(ctx context.Context, remoteStore remote.RemoteStore, cfg config) func(i int) (int, error) {
+	buf := make([]byte, cfg.blockSize)
+	return func(i int) (int, error) {
+		copy(buf, fmt.Sprintf("perf-raws3-%016x", uint64(i)))
+		h := blockstore.ContentHash(blake3.Sum256(buf))
+		return len(buf), remoteStore.Put(ctx, h, buf)
+	}
+}
+
+// runLocalOnly wires a bare FSStore (no engine / no syncer) for the
+// walk + delete workloads, which exercise local CAS enumeration and
+// chunk removal without the engine's write-path overhead.
+func runLocalOnly(cfg config, tmpDir string) error {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(tmpDir, 0, memBudget, ms, fs.FSStoreOptions{
+		MaxLogBytes:     logBudget,
+		RollupWorkers:   1,
+		StabilizationMS: 5,
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		return fmt.Errorf("fs.NewWithOptions: %w", err)
+	}
+	defer func() { _ = local.Close() }()
+
+	ctx := context.Background()
+	hashes, err := seedChunks(ctx, local, cfg)
+	if err != nil {
+		return err
+	}
+	return timedRun(cfg, cfg.workload, func() (int64, int64, error) {
+		var visited int64
+		switch cfg.workload {
+		case "walk":
+			err := local.Walk(ctx, func(_ blockstore.ContentHash, _ blockstore.Meta) error {
+				visited++
+				return nil
+			})
+			return visited, 0, err
+		case "delete":
+			for _, h := range hashes {
+				if err := local.Delete(ctx, h); err != nil {
+					return visited, 0, err
+				}
+				visited++
+			}
+			return visited, 0, nil
+		default:
+			return 0, 0, fmt.Errorf("runLocalOnly: unsupported workload %q", cfg.workload)
+		}
+	})
+}
+
+// runGC seeds remote CAS objects + a referenced subset on a memory
+// metadata store, then times engine.CollectGarbage(...) calls.
+func runGC(cfg config, remoteStore remote.RemoteStore) error {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	step, err := prepareGC(ctx, remoteStore, ms, cfg)
+	if err != nil {
+		return err
+	}
+	return timedRun(cfg, "gc", func() (int64, int64, error) {
+		for i := 0; i < cfg.ops; i++ {
+			if _, err := step(i); err != nil {
+				return int64(i), 0, err
+			}
+		}
+		return int64(cfg.ops), 0, nil
+	})
+}
+
+// runRawS3 bypasses the engine and writes directly to the remote
+// store. Provides a raw-S3 baseline against the full --remote=s3
+// write path. Only valid when --remote=s3.
+func runRawS3(cfg config, remoteStore remote.RemoteStore) error {
+	if cfg.remote != "s3" {
+		return fmt.Errorf("raw-s3-put requires --remote=s3")
+	}
+	ctx := context.Background()
+	step := stepRawS3Put(ctx, remoteStore, cfg)
+	return timedRun(cfg, "raw-s3-put", func() (int64, int64, error) {
+		bytes, err := runLoop(cfg, step)
+		return int64(cfg.ops), bytes, err
+	})
+}


### PR DESCRIPTION
Stacked on #796 (already merged into develop). Rebased onto develop and adopts the `engine.BlockStore -> engine.Store` rename from #787.

Extends `cmd/blockstore-perf` with the four workloads called out in REVIEW.md §8 B-H plus real S3 wiring so the harness can baseline against a live bucket.

## Workloads
- **walk** — seed N CAS chunks on a bare FSStore, time one full `Walk(ctx, cb)` enumeration. Ops = chunks visited.
- **delete** — seed N chunks, time N `Delete(ctx, hash)` calls. Ops = chunks removed.
- **gc** — seed N CAS objects on the remote + reference `(1 - garbage_ratio) * N` of them as FileBlocks on an in-memory metadata store, then time `engine.CollectGarbage(...)`. Configurable via `--gc-garbage-ratio` (default 0.3). For the memory remote the seeder backdates `LastModified` via `SetNowFnForTest` so freshly-seeded objects fall outside the 1h grace TTL.
- **raw-s3-put** — bypasses the engine entirely; calls `s3.Store.Put(ctx, hash, data)` N times. Gives a raw S3 baseline against the full `--remote=s3` engine write path. Only valid when `--remote=s3`.

## Remote wiring
- New `--remote=memory|s3` flag (default `memory`, no behavior change for existing workloads).
- `--remote=s3` reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL`, `AWS_S3_BUCKET`, `AWS_S3_REGION` (default `us-east-1`), `AWS_S3_PATH_STYLE` (default true when endpoint set).
- Construction mirrors `pkg/controlplane/runtime/shares/service.go` (`remotes3.NewFromConfig` + `Config{Bucket,Region,Endpoint,AccessKey,SecretKey,ForcePathStyle}`).
- Fails fast with `AWS_S3_BUCKET is required when --remote=s3` when bucket is empty.

## Env file
- New `--env-file <path>` loads simple `KEY=VALUE` lines (with `#` comments + blank lines) into the process env BEFORE `flag.Parse` evaluates downstream S3 vars. Existing env vars win, so a CLI-passed `AWS_S3_BUCKET` overrides the file. No new dependency.
- `.env` is already in the repo's `.gitignore`.

## Structure / LoC
Helpers factored into sibling files to keep `main.go` under the 500-line cap:
- `cmd/blockstore-perf/main.go` (444) — flag parsing, orchestrator switch, `timedRun` helper.
- `cmd/blockstore-perf/remote.go` (63) — `setupRemote(cfg)`.
- `cmd/blockstore-perf/envfile.go` (49) — `parseEnvFile(path)`.
- `cmd/blockstore-perf/workloads_extra.go` (199) — seeders + `runLocalOnly` / `runGC` / `runRawS3`.

## Smokes (local)
- `--workload walk --ops 100 --remote=memory` — PASS (~20k ops/sec)
- `--workload delete --ops 100 --remote=memory` — PASS (~22k ops/sec)
- `--workload gc --ops 100 --remote=memory` — PASS (first iter swept=30, marked=70)
- `--workload sequential-write --ops 20 --remote=memory` — PASS (regression check, ~54 MB/s)
- `--workload raw-s3-put --ops 1 --remote=s3` (no bucket) — clean error `AWS_S3_BUCKET is required when --remote=s3`
- `--env-file` populates env so `--remote=s3` reaches the S3 client constructor

## Gates
- `gofmt -s -w cmd/blockstore-perf/` — clean
- `go vet ./cmd/blockstore-perf/...` — clean
- `golangci-lint run ./cmd/blockstore-perf/... --timeout=5m` — 0 issues
- `go build ./cmd/blockstore-perf/...` — green
- Live S3 smoke skipped (no creds in env); reserved for follow-up against a real bucket.

## Notes
- The gc workload emits engine INFO log lines per iteration (mark start + complete). Intentional - it is a perf harness for the GC code path; silencing logs would require an engine-level toggle.