### PR TITLE
fix(smb/dh): V1 DHnC accepts non-zero volatile FileID

### DIFF
--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -354,10 +354,25 @@ func processV1Reconnect(
 	shareAccess uint32,
 ) (*OpenFile, uint32, [16]byte, types.Status, error) {
 	// Parse V1 reconnect context
-	fileID, err := DecodeDHnCReconnect(dhnCCtx.Data)
+	wireFileID, err := DecodeDHnCReconnect(dhnCCtx.Data)
 	if err != nil {
 		logger.Debug("processV1Reconnect: invalid DHnC data", "error", err)
 		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+	}
+
+	// MS-SMB2 §3.2.4.4 mandates Data.Volatile=0 on DHnC, but smbtorture's
+	// `smb2_push_handle` (source4/libcli/smb2/request.c) replays the full
+	// original 16-byte FileID — persistent half plus the server-issued
+	// volatile half — without zeroing the volatile. Since
+	// `buildPersistedDurableHandle` zeroes the volatile half before storing,
+	// an exact 16-byte lookup against the smbtorture wire FileID misses and
+	// returns OBJECT_NAME_NOT_FOUND on the first DHnC reconnect. Match the
+	// V2 (DH2C) path which already compares persistent-half only — zero the
+	// volatile half here before delegating to the store. smbtorture
+	// smb2.durable-open.reopen2 step 1 (and every other DHnC reopen test).
+	fileID := wireFileID
+	for i := 8; i < 16; i++ {
+		fileID[i] = 0
 	}
 
 	logger.Debug("processV1Reconnect: starting validation",

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -471,7 +471,10 @@ func TestProcessDurableReconnectContext_V1Success(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("session-key-1")
 
 	// Persist a V1 durable handle
@@ -538,7 +541,10 @@ func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
 	keyHash := makeSessionKeyHash("session-key-2")
 
@@ -623,7 +629,10 @@ func TestProcessDurableReconnectContext_UsernameMismatch(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("session-key-1")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -665,7 +674,10 @@ func TestProcessDurableReconnectContext_SessionKeyMismatchAllowed(t *testing.T) 
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	originalKeyHash := makeSessionKeyHash("original-key")
 	differentKeyHash := makeSessionKeyHash("different-key")
 
@@ -703,7 +715,10 @@ func TestProcessDurableReconnectContext_ShareNameMismatch(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("key")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -741,7 +756,10 @@ func TestProcessDurableReconnectContext_PathMismatch(t *testing.T) {
 	ctx := context.Background()
 
 	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("key")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -780,7 +798,10 @@ func TestProcessDurableReconnectContext_V1ConflictingV2Tag(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("key")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -1325,7 +1346,10 @@ func TestProcessDurableReconnectContext_ConsumeAtomicV1(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("k")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -1374,7 +1398,10 @@ func TestProcessDurableReconnectContext_ConsumeAtomicV2(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
 	keyHash := makeSessionKeyHash("k")
 
@@ -1428,7 +1455,10 @@ func TestProcessDurableReconnectContext_V1OplockIgnoresPath(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	// Persisted FileIDs always carry zeroed volatile half — see
+	// `buildPersistedDurableHandle`. Tests must match this to model the
+	// real store contents.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("session-key-v1path")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -1481,7 +1511,7 @@ func TestProcessDurableReconnectContext_V1LeasedRejectsMissingLease(t *testing.T
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
+	fileID := [16]byte{2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0}
 	leaseKey := [16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00}
 	keyHash := makeSessionKeyHash("session-key-v1lease")
 
@@ -1527,7 +1557,7 @@ func TestProcessDurableReconnectContext_V1LeasedWrongLeaseKey(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
+	fileID := [16]byte{3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0}
 	leaseKey := [16]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
 	wrongKey := [16]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
 	keyHash := makeSessionKeyHash("session-key-v1wrongkey")
@@ -1578,7 +1608,7 @@ func TestProcessDurableReconnectContext_V1UnleasedRejectsLeaseCtx(t *testing.T) 
 	store := newMockDurableStore()
 	ctx := context.Background()
 
-	fileID := [16]byte{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	fileID := [16]byte{4, 5, 6, 7, 8, 9, 10, 11, 0, 0, 0, 0, 0, 0, 0, 0}
 	keyHash := makeSessionKeyHash("session-key-v1nolease")
 
 	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
@@ -1615,5 +1645,63 @@ func TestProcessDurableReconnectContext_V1UnleasedRejectsLeaseCtx(t *testing.T) 
 	}
 	if status != types.StatusObjectNameNotFound {
 		t.Errorf("Expected OBJECT_NAME_NOT_FOUND for lease ctx vs oplock-only persisted handle, got %s", status)
+	}
+}
+
+// TestProcessDurableReconnectContext_V1WireReplaysFullFileID verifies that a
+// V1 DHnC reconnect succeeds when the wire FileID carries a non-zero volatile
+// half (replaying the full 16 bytes returned at original CREATE). MS-SMB2
+// §3.2.4.4 mandates Data.Volatile=0 on DHnC, but smbtorture's `smb2_push_handle`
+// (source4/libcli/smb2/request.c) does not zero the volatile — it replays the
+// full handle. The server must tolerate this by matching on the persistent
+// half only. Without this fix, smbtorture's smb2.durable-open.reopen2 step 1
+// returns OBJECT_NAME_NOT_FOUND on the first reconnect.
+func TestProcessDurableReconnectContext_V1WireReplaysFullFileID(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	// Persisted handle: volatile half is zero (matches buildPersistedDurableHandle).
+	persistedFileID := [16]byte{0xAB, 0xCD, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0, 0, 0, 0, 0, 0, 0, 0}
+	keyHash := makeSessionKeyHash("session-key-replay")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-wire-replay",
+		FileID:         persistedFileID,
+		Path:           "x.dat",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelBatch,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreatedAt:      time.Now().Add(-5 * time.Minute),
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	// Wire FileID has the SAME persistent half but a non-zero volatile half
+	// (the value the server originally returned at CREATE time).
+	wireFileID := persistedFileID
+	for i := 8; i < 16; i++ {
+		wireFileID[i] = byte(0x80 + i)
+	}
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], wireFileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash,
+		"/share1", "x.dat", [16]byte{}, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != types.StatusSuccess {
+		t.Fatalf("Expected STATUS_SUCCESS when wire replays full FileID, got %s", status)
+	}
+	if res == nil || res.OpenFile == nil {
+		t.Fatal("Expected restored OpenFile")
 	}
 }

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -226,6 +226,9 @@ to the DH state machine — tracked under #792 / #793.
 | smb2.durable-open.lock-lease | Durable handles V1 | Durable lock + lease not fully working | #738 |
 | smb2.durable-open.alloc-size | CREATE allocation | Pre-existing non-DH bug: out.alloc_size=0 on CREATE with in.alloc_size set (fails before any reconnect) | #792 |
 | smb2.durable-open.read-only | READONLY attribute | OBJECT_NAME_NOT_FOUND on durable reopen of FILE_ATTRIBUTE_READONLY file (attribute-restore gap) | #793 |
+| smb2.durable-open.oplock | Disconnected-DH purge | Intervening conflicting open should purge disconnected DH; surfaced after V1 DHnC FileID lookup fix | #808 |
+| smb2.durable-open.open2-lease | Disconnected-DH purge | Intervening conflicting open should purge disconnected DH; surfaced after V1 DHnC FileID lookup fix | #808 |
+| smb2.durable-open.open2-oplock | Disconnected-DH purge | Intervening conflicting open should purge disconnected DH; surfaced after V1 DHnC FileID lookup fix | #808 |
 
 ### Durable Handles V2 (Fix Candidate)
 


### PR DESCRIPTION
Second fix-slice on #738. Targets the family of `smb2.durable-open.reopen*` tests that share the same root cause.

## Root cause (confirmed by CI on #795)

After #795 (path-check fix) merged, smbtorture CI on the next run showed `reopen2` still failing at `source4/torture/smb2/durable_open.c:773` with `OBJECT_NAME_NOT_FOUND` on the **very first** `smb2_create` after disconnect — i.e. the wire DHnC lookup is missing the persisted handle.

The bug:

- MS-SMB2 §3.2.4.4 mandates `Data.Volatile = 0` on DHnC.
- smbtorture's `smb2_push_handle` (`source4/libcli/smb2/request.c:704`) does NOT zero the volatile half — it replays the **full 16-byte FileID** returned by the server at original CREATE.
- Our `buildPersistedDurableHandle` (`durable_context.go:~860`) correctly zeroes the volatile half before storing.
- `processV1Reconnect` then does an exact 16-byte lookup against the smbtorture wire FileID `[persistent, ORIGINAL_volatile]`, but the store holds `[persistent, 0]` → no match → `OBJECT_NAME_NOT_FOUND`.

## Fix

Match the V2 (DH2C) path which already compares persistent-half only: zero the volatile half in `processV1Reconnect` before delegating to `durableStore.GetDurableHandleByFileID`. The `consume` callback closes over the same zeroed FileID, so atomic removal still hits the persisted record.

## Tests

- New `TestProcessDurableReconnectContext_V1WireReplaysFullFileID` covers the smbtorture replay pattern (wire FileID with non-zero volatile half but matching persistent half).
- Existing V1 tests updated to store FileIDs with volatile half already zeroed, matching real persistence.

Refs #738

Expected smbtorture flips after merge: `reopen2`, `reopen2a`, `reopen4`, `reopen1a`, `reopen2-lease`, `reopen2-lease-v2`, `reopen1a-lease`, `file-position` — every test that relies on a V1 DHnC reconnect against an oplock-backed (or lease-backed) persisted handle replayed via the original full FileID.