### PR TITLE
fix(snapshot): prune stale-tail block refs on truncate (#817)

### DIFF
--- a/pkg/blockstore/types.go
+++ b/pkg/blockstore/types.go
@@ -203,6 +203,31 @@ func sortBlockRefsByOffset(b []BlockRef) {
 	sort.Slice(b, func(i, j int) bool { return b[i].Offset < b[j].Offset })
 }
 
+// PruneBlockRefsToSize drops block refs that lie entirely at or beyond size,
+// so the list never over-references content past EOF. A ref that straddles
+// the new EOF (Offset < size <= Offset+Size) is kept intact — block payloads
+// are content-addressed and immutable, so the tail bytes past EOF are simply
+// ignored on read; only fully-past-EOF refs are removed. The input slice is
+// not mutated; the result is sorted by Offset ascending.
+//
+// This is the truncate counterpart to MergeBlockRefsByOffset: a size-down
+// SetAttr must trim FileAttr.Blocks the same way a rewrite would, otherwise
+// stale-tail refs survive, the GC holds extra blocks, and a restore would
+// emit a file longer than the current size.
+func PruneBlockRefsToSize(refs []BlockRef, size uint64) []BlockRef {
+	out := make([]BlockRef, 0, len(refs))
+	for _, r := range refs {
+		if r.Offset < size {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sortBlockRefsByOffset(out)
+	return out
+}
+
 // FileBlock is the single block entity in DittoFS. Content-addressed
 // blocks with the same hash are shared across files for dedup.
 //

--- a/pkg/blockstore/types_test.go
+++ b/pkg/blockstore/types_test.go
@@ -528,3 +528,80 @@ func TestErrBlockRefMissing(t *testing.T) {
 		t.Errorf("ErrBlockRefMissing.Error() = %q, want it to mention %q", msg, "block ref")
 	}
 }
+
+func TestPruneBlockRefsToSize(t *testing.T) {
+	ref := func(off uint64, sz uint32) BlockRef { return BlockRef{Offset: off, Size: sz} }
+	const mib = uint64(1 << 20)
+
+	tests := []struct {
+		name    string
+		refs    []BlockRef
+		size    uint64
+		want    []uint64 // expected surviving offsets, sorted
+		wantNil bool
+	}{
+		{
+			name: "truncate 4MiB to 1MiB keeps only first block",
+			refs: []BlockRef{ref(0, uint32(mib)), ref(mib, uint32(mib)), ref(2*mib, uint32(mib)), ref(3*mib, uint32(mib))},
+			size: mib,
+			want: []uint64{0},
+		},
+		{
+			name: "block straddling new EOF is kept",
+			refs: []BlockRef{ref(0, uint32(mib)), ref(mib, uint32(mib))},
+			size: mib + 100,
+			want: []uint64{0, mib},
+		},
+		{
+			name: "ref starting exactly at new size is dropped",
+			refs: []BlockRef{ref(0, uint32(mib)), ref(mib, uint32(mib))},
+			size: mib,
+			want: []uint64{0},
+		},
+		{
+			name:    "truncate to zero drops all and returns nil",
+			refs:    []BlockRef{ref(0, uint32(mib))},
+			size:    0,
+			wantNil: true,
+		},
+		{
+			name: "result is sorted by offset",
+			refs: []BlockRef{ref(2*mib, uint32(mib)), ref(0, uint32(mib)), ref(mib, uint32(mib))},
+			size: 3 * mib,
+			want: []uint64{0, mib, 2 * mib},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := make([]BlockRef, len(tc.refs))
+			copy(in, tc.refs)
+
+			got := PruneBlockRefsToSize(tc.refs, tc.size)
+
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("PruneBlockRefsToSize() = %v, want nil", got)
+				}
+				return
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tc.want), got)
+			}
+			for i, off := range tc.want {
+				if got[i].Offset != off {
+					t.Errorf("got[%d].Offset = %d, want %d", i, got[i].Offset, off)
+				}
+				if got[i].Offset >= tc.size {
+					t.Errorf("got[%d].Offset %d is at/past size %d", i, got[i].Offset, tc.size)
+				}
+			}
+			// Input must not be mutated.
+			for i := range in {
+				if tc.refs[i] != in[i] {
+					t.Errorf("input mutated at %d", i)
+				}
+			}
+		})
+	}
+}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -316,6 +317,14 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		// Size change requires write permission
 		if err := s.checkWritePermission(ctx, handle); err != nil {
 			return err
+		}
+		// A size-down truncate must trim the content-addressed block list to
+		// the new size, otherwise stale-tail refs past EOF survive in
+		// FileAttr.Blocks: the GC then holds extra blocks and a restore would
+		// emit a file longer than the current size (#817). Refs straddling the
+		// new EOF are kept — the tail bytes past EOF are ignored on read.
+		if *attrs.Size < file.Size && len(file.Blocks) > 0 {
+			file.Blocks = blockstore.PruneBlockRefsToSize(file.Blocks, *attrs.Size)
 		}
 		file.Size = *attrs.Size
 		modified = true

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -320,11 +320,25 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		}
 		// A size-down truncate must trim the content-addressed block list to
 		// the new size, otherwise stale-tail refs past EOF survive in
-		// FileAttr.Blocks: the GC then holds extra blocks and a restore would
-		// emit a file longer than the current size (#817). Refs straddling the
-		// new EOF are kept — the tail bytes past EOF are ignored on read.
+		// FileAttr.Blocks: the snapshot manifest (built from FileAttr.Blocks)
+		// over-references them, the block-store GC holds them, and a restore
+		// would emit a file longer than the current size (#817). Refs
+		// straddling the new EOF are kept — the tail bytes past EOF are
+		// ignored on read. Block refcounts are reconciled by the block-store
+		// GC, the same as RemoveFile, which drops a file's entire block list
+		// without inline decrements.
 		if *attrs.Size < file.Size && len(file.Blocks) > 0 {
 			file.Blocks = blockstore.PruneBlockRefsToSize(file.Blocks, *attrs.Size)
+			// Keep ObjectID (the Merkle root over Blocks) consistent with the
+			// trimmed list, or zero it when no blocks remain so the file reads
+			// as "never quiesced" instead of carrying a stale dedup pointer.
+			if !file.ObjectID.IsZero() {
+				if len(file.Blocks) == 0 {
+					file.ObjectID = blockstore.ObjectID{}
+				} else {
+					file.ObjectID = blockstore.ComputeObjectID(file.Blocks)
+				}
+			}
 		}
 		file.Size = *attrs.Size
 		modified = true

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -50,6 +50,13 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runBlockRefOpsTests(t, factory)
 	})
 
+	// TruncateBlockRefOps asserts that a size-down SetAttr prunes
+	// FileAttr.Blocks / file_block_refs past the new EOF, so the snapshot
+	// manifest never over-references content past the current size (#817).
+	t.Run("TruncateBlockRefOps", func(t *testing.T) {
+		runTruncateBlockRefTests(t, factory)
+	})
+
 	// ObjectIDOps conformance for FileAttr.ObjectID round-trip,
 	// FindByObjectID lookup, mutation lifecycle, and the first-
 	// committer-wins concurrent-quiesce race. All

--- a/pkg/metadata/storetest/truncate_block_refs.go
+++ b/pkg/metadata/storetest/truncate_block_refs.go
@@ -1,0 +1,112 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// runTruncateBlockRefTests dispatches the truncate-down block-ref pruning
+// scenario against the provided factory. It runs against Memory, Badger, and
+// Postgres via RunConformanceSuite, so every backend is held to the same
+// "no stale-tail refs past EOF" contract.
+func runTruncateBlockRefTests(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	t.Run("TruncateDownPrunesBlockRefs", func(t *testing.T) {
+		testTruncateDownPrunesBlockRefs(t, factory)
+	})
+}
+
+// testTruncateDownPrunesBlockRefs reproduces the snapshot over-reference bug:
+// a 4 MiB file is reduced to 1 MiB via a size-down SetAttr, then the surviving
+// FileAttr.Blocks must cover only [0, 1 MiB). Higher-offset blocks from the old
+// size must not linger — otherwise the snapshot manifest (built from
+// FileAttr.Blocks) over-references content past EOF, the GC holds extra blocks,
+// and a restore would emit a file longer than the current size.
+//
+// The scenario drives the real SetFileAttributes truncate path through
+// MetadataService over the backend store, so it validates pruning on every
+// backend's FileAttr.Blocks / file_block_refs representation.
+func testTruncateDownPrunesBlockRefs(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+
+	const shareName = "/trunc"
+	rootHandle := createTestShare(t, store, shareName)
+	handle := createTestFile(t, store, shareName, rootHandle, "big.bin", 0644)
+
+	ctx := t.Context()
+
+	const mib = uint64(1 << 20)
+
+	// Simulate the post-rollup state: a 4 MiB file with four 1 MiB blocks at
+	// offsets 0, 1M, 2M, 3M (distinct hashes so each ref is identifiable).
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.Size = 4 * mib
+	file.Blocks = make([]blockstore.BlockRef, 4)
+	for i := range file.Blocks {
+		var h blockstore.ContentHash
+		h[0] = byte(i + 1)
+		file.Blocks[i] = blockstore.BlockRef{
+			Hash:   h,
+			Offset: uint64(i) * mib,
+			Size:   uint32(mib),
+		}
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() with 4 MiB block list failed: %v", err)
+	}
+
+	// Truncate down to 1 MiB through the service's SetFileAttributes path.
+	svc := metadata.New()
+	if err := svc.RegisterStoreForShare(shareName, store); err != nil {
+		t.Fatalf("RegisterStoreForShare() failed: %v", err)
+	}
+	rootUID := uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &rootUID, GID: &rootUID},
+	}
+	newSize := mib
+	if err := svc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Size: &newSize}); err != nil {
+		t.Fatalf("SetFileAttributes(size=1MiB) failed: %v", err)
+	}
+
+	// The surviving block list must cover only [0, 1 MiB): exactly the single
+	// block at offset 0, with nothing at or beyond the new EOF.
+	got, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() after truncate failed: %v", err)
+	}
+	if got.Size != newSize {
+		t.Errorf("Size = %d, want %d", got.Size, newSize)
+	}
+	if len(got.Blocks) != 1 {
+		t.Fatalf("len(Blocks) = %d, want 1 (only the [0,1MiB) block)", len(got.Blocks))
+	}
+	if got.Blocks[0].Offset != 0 {
+		t.Errorf("Blocks[0].Offset = %d, want 0", got.Blocks[0].Offset)
+	}
+	for _, b := range got.Blocks {
+		if b.Offset >= newSize {
+			t.Errorf("stale-tail ref survived truncate: offset %d >= new size %d", b.Offset, newSize)
+		}
+	}
+
+	// The snapshot manifest is the union of every file's FileAttr.Blocks
+	// hashes (see each backend's Backup implementation). The pruned-away tail
+	// blocks must therefore no longer be referenced by the file.
+	referenced := make(map[blockstore.ContentHash]struct{}, len(got.Blocks))
+	for _, b := range got.Blocks {
+		referenced[b.Hash] = struct{}{}
+	}
+	for _, b := range file.Blocks[1:] {
+		if _, found := referenced[b.Hash]; found {
+			t.Errorf("pruned tail block %x still referenced after truncate", b.Hash[:4])
+		}
+	}
+}

--- a/pkg/metadata/storetest/truncate_block_refs.go
+++ b/pkg/metadata/storetest/truncate_block_refs.go
@@ -57,6 +57,9 @@ func testTruncateDownPrunesBlockRefs(t *testing.T, factory StoreFactory) {
 			Size:   uint32(mib),
 		}
 	}
+	// Quiesce the file: a non-zero ObjectID (Merkle root over Blocks) means the
+	// truncate must keep it consistent with the trimmed list, not leave it stale.
+	file.ObjectID = blockstore.ComputeObjectID(file.Blocks)
 	if err := store.PutFile(ctx, file); err != nil {
 		t.Fatalf("PutFile() with 4 MiB block list failed: %v", err)
 	}
@@ -108,5 +111,12 @@ func testTruncateDownPrunesBlockRefs(t *testing.T, factory StoreFactory) {
 		if _, found := referenced[b.Hash]; found {
 			t.Errorf("pruned tail block %x still referenced after truncate", b.Hash[:4])
 		}
+	}
+
+	// ObjectID must stay consistent with the trimmed block list (the dedup
+	// invariant: a non-zero ObjectID equals ComputeObjectID(Blocks)).
+	if want := blockstore.ComputeObjectID(got.Blocks); got.ObjectID != want {
+		t.Errorf("ObjectID = %s, want recompute(Blocks) %s after truncate",
+			got.ObjectID.String(), want.String())
 	}
 }


### PR DESCRIPTION
Closes #817

## Problem

`MergeBlockRefsByOffset` (the #789 fix) keeps existing block refs whose byte range doesn't overlap the current rollup pass. On a **truncating** write (file shrinks), the higher-offset blocks from the old size are not overlapped by the new pass, so they survive in `FileAttr.Blocks`.

The snapshot manifest is built from the union of every file's `FileAttr.Blocks`, so it over-referenced content past EOF: the GC held extra blocks and a restore could emit a file longer than the current size.

## Fix

`SetFileAttributes` now trims `FileAttr.Blocks` to the new size on a size-down truncate, via the new `blockstore.PruneBlockRefsToSize` helper (the truncate counterpart to `MergeBlockRefsByOffset`):

- Refs starting at/after the new EOF are dropped.
- A ref straddling the new EOF is kept intact — block payloads are content-addressed and immutable, and the tail bytes past EOF are ignored on read.

The pruning lives in the service-layer `SetFileAttributes`, which is the single choke point for all backends, so it applies uniformly to **memory / badger / postgres** (postgres persists the shorter list via the existing `file_block_refs` DELETE+INSERT).

## Pruning was missing

The truncate path set the new size but never touched the block-ref list on any backend. Pruning is added (not previously present anywhere).

## Tests

- `TruncateBlockRefOps` storetest conformance scenario: write 4 MiB, truncate to 1 MiB via the real `SetFileAttributes` path, assert surviving `FileAttr.Blocks` cover only `[0, 1 MiB)` and pruned tail hashes are no longer referenced. Runs on memory/badger/postgres.
- `TestPruneBlockRefsToSize` unit test (straddle/exact-boundary/zero/sort/no-mutation cases).