### PR TITLE
bench(snapshots): scale/perf validation for snapshot create + verify + restore (#814)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -25,7 +25,7 @@ fixture code. The unified `cmd/bench` Cobra orchestrator plus the
 |-------------|-------------------------------------------------------------|--------|
 | blockstore  | local FSStore + remote + Syncer + engine                    | done   |
 | gc          | reference counting + sweep                                  | stub   |
-| snapshots   | reference-CAS snapshot create / restore / GC interactions   | done   |
+| snapshots   | reference-CAS snapshot create / verify / manifest scale     | done   |
 | metadata    | listings, rename, hard links, ACL eval                      | stub   |
 | adapters    | NFS XDR + SMB2/3 framing perf (no real network)             | stub   |
 | e2e         | real NFS / SMB clients driving fio / iozone / smbtorture    | stub   |

--- a/bench/README.md
+++ b/bench/README.md
@@ -25,7 +25,7 @@ fixture code. The unified `cmd/bench` Cobra orchestrator plus the
 |-------------|-------------------------------------------------------------|--------|
 | blockstore  | local FSStore + remote + Syncer + engine                    | done   |
 | gc          | reference counting + sweep                                  | stub   |
-| snapshots   | reference-CAS snapshot create / restore / GC interactions   | stub   |
+| snapshots   | reference-CAS snapshot create / restore / GC interactions   | done   |
 | metadata    | listings, rename, hard links, ACL eval                      | stub   |
 | adapters    | NFS XDR + SMB2/3 framing perf (no real network)             | stub   |
 | e2e         | real NFS / SMB clients driving fio / iozone / smbtorture    | stub   |

--- a/bench/snapshots/README.md
+++ b/bench/snapshots/README.md
@@ -1,37 +1,81 @@
-# bench/snapshots (stub)
+# bench/snapshots
 
-Status: **not yet implemented**.
+Scale/perf workloads for the reference-CAS snapshot pipeline. The same
+library functions power both the `dfsbench snapshots` CLI subcommand and the
+Go `Benchmark*` tests in this package.
 
-## Scope
+## What it measures
 
-Benchmark reference-based CAS snapshots: create, restore, GC interaction,
-and overhead on the live write path. Replaces the deprecated v0.13.0
-backup harness.
+A snapshot `create` is a metadata `Backup` (streamed dump + an in-RAM
+`HashSet` of every referenced block hash) → manifest write → drain → verify
+(HEAD-probe every manifest hash, concurrency 16). `restore` reads the
+manifest back, resets, restores the dump, and re-verifies. The three cost
+centers, isolated from the Runtime orchestration so one benchmark can sweep
+file counts without standing up adapters / the control-plane DB / real S3:
 
-## Intended workloads
+| Workload         | Cost center                                              | Custom metric            |
+|------------------|----------------------------------------------------------|--------------------------|
+| `backup`         | dump stream + resident `HashSet` (create-path RAM)       | `dump_bytes`, `manifest_hashes` |
+| `write-manifest` | sorted hex-line manifest, streamed                       | `manifest_bytes`         |
+| `read-manifest`  | parse manifest back into a resident `HashSet` (restore)  | —                        |
+| `verify`         | HEAD-probe every hash at concurrency 16                  | `probes`                 |
 
-- `snapshot-create` — metadata-dump + hash-manifest time vs file count
-- `snapshot-restore` — restore overhead vs snapshot age and live churn
-- `snapshot-gc-hold` — measure GC throttle under N concurrent snapshots
-- `snapshot-live-overhead` — write throughput with a snapshot pinned
+Backends: an in-memory remote (no S3 request cost) plus the memory or badger
+metadata engine. `--dedup N` shares every Nth block hash to shrink the
+unique-hash count; the default (`Dedup=1`, all-unique) is the worst case for
+`HashSet` + manifest RAM.
 
-## Library layout (when wired)
+## Running
 
-```
-bench/snapshots/
-  doc.go
-  fixture.go     // engine + snapshot store + hold provider
-  workloads.go   // RunWorkload(ctx, bs, snap, opts)
-  workloads_test.go
-```
-
-## Running (once implemented)
+CLI (one seed → backup → manifest → verify pass, wall-clock per stage):
 
 ```sh
-./dfsbench snapshots --workload snapshot-create --files 100000
-./dfsbench snapshots --workload snapshot-restore --age 7d
+go build -o dfsbench ./cmd/bench
+./dfsbench snapshots --files 100000 --blocks-per-file 1
+./dfsbench snapshots --files 100000 --blocks-per-file 8 --engine badger
+./dfsbench snapshots --files 1000000 --dedup 4
 ```
 
-## Tracking
+Go benchmarks (benchstat-friendly; large 1e6 cases gated behind `-short`):
 
-Not yet filed.
+```sh
+# CI-safe sweep (skips 1e6):
+go test -bench=. -benchmem -short -run=^$ ./bench/snapshots/
+
+# Full sweep including 1e6-file scales (heavy — seconds + hundreds of MB):
+go test -bench=. -benchmem -benchtime=1x -run=^$ -timeout=900s ./bench/snapshots/
+```
+
+## Library API
+
+```go
+import snap "github.com/marmos91/dittofs/bench/snapshots"
+
+store, uniqueHashes, cleanup, _ := snap.NewStore(ctx, snap.SeedOpts{
+    Engine: snap.EngineMemory, Files: 1e5, BlocksPerFile: 1, Dedup: 1,
+})
+defer cleanup()
+
+backup, _ := snap.RunBackup(ctx, store)          // dump bytes + HashSet
+manifestBytes, _ := snap.RunWriteManifest(backup.HashSet)
+snap.SeedRemote(ctx, rs, backup.HashSet)         // all-present remote
+probes, _ := snap.RunVerify(ctx, rs, backup.HashSet)
+```
+
+## Established limits & memory ceiling
+
+See [`test/e2e/BENCHMARKS.md`](../../test/e2e/BENCHMARKS.md#snapshot-scale-limits)
+for the measured ceiling and the per-block verify budget. Summary:
+
+- The metadata dump is **streamed** (badger writes KV-by-KV; the dump byte
+  count never lands in a single buffer). The dominant create-path
+  allocation is the returned `HashSet`: one 32-byte `ContentHash` per
+  **unique** referenced block, ~26 B/entry in the Go map. Plan ~25 MB of
+  HashSet RAM per 1 M unique blocks.
+- The manifest is streamed on write (65 bytes/hash on disk: 64 hex + LF).
+- Verify allocates per probe but holds nothing across probes; cost is N
+  HEAD round-trips at concurrency 16. The in-memory remote number is a
+  floor — multiply by real per-HEAD S3 RTT for a deployment budget.
+- The memory metadata engine gob-encodes its whole snapshot into one
+  buffer (expected for an in-RAM backend) — it is **not** suitable for
+  TB-scale shares. Use badger for large shares; badger streams.

--- a/bench/snapshots/README.md
+++ b/bench/snapshots/README.md
@@ -67,11 +67,12 @@ probes, _ := snap.RunVerify(ctx, rs, backup.HashSet)
 See [`test/e2e/BENCHMARKS.md`](../../test/e2e/BENCHMARKS.md#snapshot-scale-limits)
 for the measured ceiling and the per-block verify budget. Summary:
 
-- The metadata dump is **streamed** (badger writes KV-by-KV; the dump byte
-  count never lands in a single buffer). The dominant create-path
-  allocation is the returned `HashSet`: one 32-byte `ContentHash` per
-  **unique** referenced block, ~26 B/entry in the Go map. Plan ~25 MB of
-  HashSet RAM per 1 M unique blocks.
+- The metadata dump is **streamed by the badger engine** (KV-by-KV; the
+  dump byte count never lands in a single buffer). On the badger path the
+  dominant create-path allocation is the returned `HashSet`: one 32-byte
+  `ContentHash` per **unique** referenced block, ~26 B/entry in the Go map.
+  Plan ~25 MB of HashSet RAM per 1 M unique blocks. (The memory engine does
+  NOT stream — see the last bullet.)
 - The manifest is streamed on write (65 bytes/hash on disk: 64 hex + LF).
 - Verify allocates per probe but holds nothing across probes; cost is N
   HEAD round-trips at concurrency 16. The in-memory remote number is a

--- a/bench/snapshots/doc.go
+++ b/bench/snapshots/doc.go
@@ -1,0 +1,27 @@
+// Package snapshots provides scale/perf workloads for the reference-CAS
+// snapshot pipeline: metadata Backup (dump + hash manifest), manifest
+// write/read, and remote-durability verify.
+//
+// The workloads here measure the three cost centers the snapshot create /
+// verify / restore path is built from, isolated from the full Runtime
+// orchestration so a single Go benchmark can sweep file counts (1e5, 1e6)
+// and block counts (multi-GB equivalents) without standing up adapters,
+// the control-plane DB, or a real S3 backend:
+//
+//   - Backup: cost of streaming the metadata dump to an io.Writer plus the
+//     in-RAM HashSet the engine returns (one 32-byte ContentHash per unique
+//     referenced block). The HashSet is the dominant non-streamed allocation
+//     on the create path; SeedStore + BackupToWriter quantify it.
+//   - Manifest: WriteManifest (sorted hex lines, streamed) and ReadManifest
+//     (parse back into a HashSet). Manifest on-disk size is reported as a
+//     custom metric.
+//   - Verify: VerifyRemoteDurability HEAD-probes every manifest hash at the
+//     production concurrency (16). RunVerify reports wall time and probe
+//     count so the per-block verify budget can be read directly.
+//
+// Backends: an in-memory remote store (no S3 cost) plus the memory or
+// badger metadata engine. Both engines stream the dump KV-by-KV to the
+// writer, so RAM is bounded by the returned HashSet rather than the dump
+// size — the benchmarks confirm this and establish the ceiling documented
+// in README.md.
+package snapshots

--- a/bench/snapshots/doc.go
+++ b/bench/snapshots/doc.go
@@ -20,8 +20,11 @@
 //     count so the per-block verify budget can be read directly.
 //
 // Backends: an in-memory remote store (no S3 cost) plus the memory or
-// badger metadata engine. Both engines stream the dump KV-by-KV to the
-// writer, so RAM is bounded by the returned HashSet rather than the dump
-// size — the benchmarks confirm this and establish the ceiling documented
-// in README.md.
+// badger metadata engine. The badger engine streams the dump KV-by-KV to
+// the writer, so its create-path RAM is bounded by the returned HashSet
+// rather than the dump size. The memory engine instead gob-encodes its
+// whole snapshot into one buffer during Backup (expected for an in-RAM
+// backend) — it is the convenient fast default for sweeping scales, but it
+// is NOT the streaming ceiling and is unsuitable for TB-scale shares. The
+// benchmarks quantify both; README.md documents the limits.
 package snapshots

--- a/bench/snapshots/fixture.go
+++ b/bench/snapshots/fixture.go
@@ -121,7 +121,6 @@ func seed(ctx context.Context, store metadata.MetadataStore, opts SeedOpts) (int
 		blockSize = 1 << 20
 	}
 
-	unique := make(map[blockstore.ContentHash]struct{})
 	var blockSeq uint64
 
 	for i := 0; i < opts.Files; i++ {
@@ -145,7 +144,6 @@ func seed(ctx context.Context, store metadata.MetadataStore, opts SeedOpts) (int
 			// One distinct hash per (dedup-bucketed) block. blockSeq/dedup
 			// collapses every dedup-th block onto a shared hash.
 			h := hashFromSeq(blockSeq / uint64(dedup))
-			unique[h] = struct{}{}
 			refs[b] = blockstore.BlockRef{
 				Hash:   h,
 				Offset: uint64(b) * uint64(blockSize),
@@ -176,7 +174,15 @@ func seed(ctx context.Context, store metadata.MetadataStore, opts SeedOpts) (int
 			return 0, fmt.Errorf("snapshots bench: set child: %w", err)
 		}
 	}
-	return len(unique), nil
+
+	// Unique-hash count is derived, not tracked: hashes are
+	// hashFromSeq(blockSeq/dedup) for blockSeq in [0, totalRefs), so the
+	// distinct count is ceil(totalRefs/dedup). Computing it avoids a
+	// multi-GB scratch map at the 1e6×8 scale that would otherwise pollute
+	// the benchmark's reported memory ceiling.
+	totalRefs := uint64(opts.Files) * uint64(blocksPerFile)
+	unique := int((totalRefs + uint64(dedup) - 1) / uint64(dedup))
+	return unique, nil
 }
 
 // hashFromSeq derives a deterministic unique ContentHash from a sequence

--- a/bench/snapshots/fixture.go
+++ b/bench/snapshots/fixture.go
@@ -1,0 +1,190 @@
+package snapshots
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// Engine selects which metadata backend a workload seeds and backs up.
+const (
+	EngineMemory = "memory"
+	EngineBadger = "badger"
+)
+
+// shareName is the single share every workload seeds under.
+const shareName = "/bench"
+
+// SeedOpts parameterizes the synthetic share a workload builds before
+// timing Backup / manifest / verify.
+type SeedOpts struct {
+	// Engine is EngineMemory or EngineBadger.
+	Engine string
+
+	// Files is the number of regular files to seed (e.g. 1e5, 1e6).
+	Files int
+
+	// BlocksPerFile is the number of BlockRef entries per file. Total
+	// referenced blocks = Files * BlocksPerFile; with Dedup=1 every block
+	// hash is unique so the returned HashSet has Files*BlocksPerFile
+	// entries — the worst case for create-path RAM.
+	BlocksPerFile int
+
+	// BlockSize is the byte size recorded on each BlockRef (drives the
+	// reported logical-bytes metric only; no real bytes are written).
+	BlockSize uint32
+
+	// Dedup, when > 1, makes every Dedup-th block share a hash so the
+	// unique-hash count (and thus HashSet + manifest size) shrinks by
+	// roughly that factor. Dedup<=1 means all-unique.
+	Dedup int
+
+	// DBPath is the on-disk directory for the badger engine. Ignored for
+	// memory. Must be a fresh empty dir per run.
+	DBPath string
+}
+
+// NewStore constructs the metadata engine named by opts.Engine and seeds
+// it with opts.Files synthetic regular files, each carrying
+// opts.BlocksPerFile BlockRefs. Returns the store, the number of unique
+// block hashes seeded, and a cleanup func.
+//
+// Files are attached directly under the share root via PutFile + SetParent
+// + SetChild — the same surface the metadata conformance suite uses — so
+// the seed exercises the real Backup hash-extraction path (File.Blocks on
+// the f: prefix) without routing through CreateFile permission checks.
+func NewStore(ctx context.Context, opts SeedOpts) (metadata.MetadataStore, int, func(), error) {
+	store, cleanup, err := newEngine(ctx, opts)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	uniqueHashes, err := seed(ctx, store, opts)
+	if err != nil {
+		cleanup()
+		return nil, 0, nil, err
+	}
+	return store, uniqueHashes, cleanup, nil
+}
+
+func newEngine(ctx context.Context, opts SeedOpts) (metadata.MetadataStore, func(), error) {
+	switch opts.Engine {
+	case "", EngineMemory:
+		s := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+		return s, func() {}, nil
+	case EngineBadger:
+		if opts.DBPath == "" {
+			return nil, nil, fmt.Errorf("snapshots bench: badger engine needs a DBPath")
+		}
+		s, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(ctx, opts.DBPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("snapshots bench: open badger: %w", err)
+		}
+		return s, func() { _ = s.Close() }, nil
+	default:
+		return nil, nil, fmt.Errorf("snapshots bench: unknown engine %q (want %q or %q)",
+			opts.Engine, EngineMemory, EngineBadger)
+	}
+}
+
+func seed(ctx context.Context, store metadata.MetadataStore, opts SeedOpts) (int, error) {
+	if err := store.CreateShare(ctx, &metadata.Share{Name: shareName}); err != nil {
+		return 0, fmt.Errorf("snapshots bench: create share: %w", err)
+	}
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("snapshots bench: create root: %w", err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	if err != nil {
+		return 0, fmt.Errorf("snapshots bench: encode root handle: %w", err)
+	}
+
+	blocksPerFile := opts.BlocksPerFile
+	if blocksPerFile < 1 {
+		blocksPerFile = 1
+	}
+	dedup := opts.Dedup
+	if dedup < 1 {
+		dedup = 1
+	}
+	blockSize := opts.BlockSize
+	if blockSize == 0 {
+		blockSize = 1 << 20
+	}
+
+	unique := make(map[blockstore.ContentHash]struct{})
+	var blockSeq uint64
+
+	for i := 0; i < opts.Files; i++ {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		name := fmt.Sprintf("f%08d.bin", i)
+		path := "/" + name
+
+		handle, err := store.GenerateHandle(ctx, shareName, path)
+		if err != nil {
+			return 0, fmt.Errorf("snapshots bench: generate handle: %w", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(handle)
+		if err != nil {
+			return 0, fmt.Errorf("snapshots bench: decode handle: %w", err)
+		}
+
+		refs := make([]blockstore.BlockRef, blocksPerFile)
+		for b := 0; b < blocksPerFile; b++ {
+			// One distinct hash per (dedup-bucketed) block. blockSeq/dedup
+			// collapses every dedup-th block onto a shared hash.
+			h := hashFromSeq(blockSeq / uint64(dedup))
+			unique[h] = struct{}{}
+			refs[b] = blockstore.BlockRef{
+				Hash:   h,
+				Offset: uint64(b) * uint64(blockSize),
+				Size:   blockSize,
+			}
+			blockSeq++
+		}
+
+		f := &metadata.File{
+			ShareName: shareName,
+			Path:      path,
+			FileAttr: metadata.FileAttr{
+				Type:   metadata.FileTypeRegular,
+				Mode:   0o644,
+				Nlink:  1,
+				Size:   uint64(blocksPerFile) * uint64(blockSize),
+				Blocks: refs,
+			},
+		}
+		f.ID = id
+		if err := store.PutFile(ctx, f); err != nil {
+			return 0, fmt.Errorf("snapshots bench: put file: %w", err)
+		}
+		if err := store.SetParent(ctx, handle, rootHandle); err != nil {
+			return 0, fmt.Errorf("snapshots bench: set parent: %w", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, handle); err != nil {
+			return 0, fmt.Errorf("snapshots bench: set child: %w", err)
+		}
+	}
+	return len(unique), nil
+}
+
+// hashFromSeq derives a deterministic unique ContentHash from a sequence
+// number. The first 8 bytes carry the big-endian counter; the rest stay
+// zero. Distinct counters yield distinct hashes, which is all the snapshot
+// pipeline (set membership + sort + HEAD-probe by key) depends on.
+func hashFromSeq(seq uint64) blockstore.ContentHash {
+	var h blockstore.ContentHash
+	binary.BigEndian.PutUint64(h[:8], seq)
+	return h
+}

--- a/bench/snapshots/snapshots_test.go
+++ b/bench/snapshots/snapshots_test.go
@@ -1,0 +1,105 @@
+package snapshots_test
+
+import (
+	"context"
+	"testing"
+
+	snap "github.com/marmos91/dittofs/bench/snapshots"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+)
+
+// TestPipeline exercises seed → backup → manifest → verify end to end at a
+// tiny scale so CI (which runs benchmarks under -short, skipping the heavy
+// cases) still covers the fixture and every workload helper.
+func TestPipeline(t *testing.T) {
+	ctx := context.Background()
+	const (
+		files  = 50
+		blocks = 3
+	)
+	store, unique, cleanup, err := snap.NewStore(ctx, snap.SeedOpts{
+		Engine:        snap.EngineMemory,
+		Files:         files,
+		BlocksPerFile: blocks,
+		BlockSize:     4096,
+		Dedup:         1,
+	})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer cleanup()
+
+	if want := files * blocks; unique != want {
+		t.Fatalf("unique hashes = %d, want %d (all-unique)", unique, want)
+	}
+
+	backup, err := snap.RunBackup(ctx, store)
+	if err != nil {
+		t.Fatalf("RunBackup: %v", err)
+	}
+	if backup.ManifestHashes != unique {
+		t.Fatalf("backup manifest hashes = %d, want %d", backup.ManifestHashes, unique)
+	}
+	if backup.DumpBytes == 0 {
+		t.Fatal("backup dump bytes = 0, want > 0")
+	}
+
+	mBytes, err := snap.RunWriteManifest(backup.HashSet)
+	if err != nil {
+		t.Fatalf("RunWriteManifest: %v", err)
+	}
+	// 64 hex chars + LF per hash.
+	if want := int64(unique) * 65; mBytes != want {
+		t.Fatalf("manifest bytes = %d, want %d", mBytes, want)
+	}
+
+	manifest, err := snap.SerializeManifest(backup.HashSet)
+	if err != nil {
+		t.Fatalf("SerializeManifest: %v", err)
+	}
+	parsed, err := snap.RunReadManifest(manifest)
+	if err != nil {
+		t.Fatalf("RunReadManifest: %v", err)
+	}
+	if parsed != unique {
+		t.Fatalf("read-manifest hashes = %d, want %d", parsed, unique)
+	}
+
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+	seeded, err := snap.SeedRemote(ctx, rs, backup.HashSet)
+	if err != nil {
+		t.Fatalf("SeedRemote: %v", err)
+	}
+	if seeded != unique {
+		t.Fatalf("seeded remote = %d, want %d", seeded, unique)
+	}
+	probes, err := snap.RunVerify(ctx, rs, backup.HashSet)
+	if err != nil {
+		t.Fatalf("RunVerify: %v", err)
+	}
+	if probes != unique {
+		t.Fatalf("verify probes = %d, want %d", probes, unique)
+	}
+}
+
+// TestDedup confirms the dedup factor collapses the unique-hash count.
+func TestDedup(t *testing.T) {
+	ctx := context.Background()
+	_, unique, cleanup, err := snap.NewStore(ctx, snap.SeedOpts{
+		Engine:        snap.EngineMemory,
+		Files:         40,
+		BlocksPerFile: 1,
+		BlockSize:     4096,
+		Dedup:         4,
+	})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer cleanup()
+
+	// 40 blocks, every 4th sharing a hash → 10 unique.
+	if want := 10; unique != want {
+		t.Fatalf("unique hashes = %d, want %d", unique, want)
+	}
+}

--- a/bench/snapshots/workloads.go
+++ b/bench/snapshots/workloads.go
@@ -41,11 +41,15 @@ func (c *countingDiscard) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// RunBackup streams a metadata Backup to a counting discard writer and
+// RunBackup runs a metadata Backup against a counting discard writer and
 // returns the dump size + the returned HashSet. The metadata engine must
-// implement Backupable (memory + badger both do). The dump is NOT buffered
-// in RAM here; only the HashSet the engine accumulates is resident, which
-// is the quantity the create-path memory ceiling is built around.
+// implement Backupable (memory + badger both do). The harness itself does
+// not buffer the dump — the writer discards. Whether the dump is resident
+// depends on the engine: badger streams KV-by-KV (only the returned
+// HashSet is resident, the quantity the create-path ceiling is built
+// around), whereas the memory engine gob-encodes its whole snapshot into
+// one internal buffer before writing (so its B/op reflects that buffer,
+// not a stream).
 func RunBackup(ctx context.Context, store metadata.MetadataStore) (BackupResult, error) {
 	backupable, ok := store.(metadata.Backupable)
 	if !ok {

--- a/bench/snapshots/workloads.go
+++ b/bench/snapshots/workloads.go
@@ -1,0 +1,130 @@
+package snapshots
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/remote"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/snapshot"
+)
+
+// VerifyConcurrency mirrors the hardcoded production verify fan-out
+// (runtime/snapshot.go). The benchmarks probe at the same width so the
+// measured per-block latency budget transfers directly.
+const VerifyConcurrency = 16
+
+// BackupResult reports the cost of one Backup pass.
+type BackupResult struct {
+	// DumpBytes is the number of bytes streamed to the dump writer.
+	DumpBytes int64
+
+	// ManifestHashes is the number of unique block hashes the engine
+	// returned in the HashSet (= manifest line count).
+	ManifestHashes int
+
+	// HashSet is the engine-returned set, reused by the manifest + verify
+	// workloads so a benchmark can chain them without re-running Backup.
+	HashSet *blockstore.HashSet
+}
+
+// countingDiscard counts bytes written to it and drops them. Used so the
+// dump stream is fully serialized (exercising the engine's per-KV write
+// path) without allocating an O(dump) buffer — the dump is meant to be
+// streamed, and the benchmark's RAM ceiling should reflect that.
+type countingDiscard struct{ n int64 }
+
+func (c *countingDiscard) Write(p []byte) (int, error) {
+	c.n += int64(len(p))
+	return len(p), nil
+}
+
+// RunBackup streams a metadata Backup to a counting discard writer and
+// returns the dump size + the returned HashSet. The metadata engine must
+// implement Backupable (memory + badger both do). The dump is NOT buffered
+// in RAM here; only the HashSet the engine accumulates is resident, which
+// is the quantity the create-path memory ceiling is built around.
+func RunBackup(ctx context.Context, store metadata.MetadataStore) (BackupResult, error) {
+	backupable, ok := store.(metadata.Backupable)
+	if !ok {
+		return BackupResult{}, fmt.Errorf("snapshots bench: store is not Backupable")
+	}
+	cd := &countingDiscard{}
+	hs, err := backupable.Backup(ctx, cd)
+	if err != nil {
+		return BackupResult{}, fmt.Errorf("snapshots bench: backup: %w", err)
+	}
+	count := 0
+	if hs != nil {
+		count = hs.Len()
+	} else {
+		hs = blockstore.NewHashSet(0)
+	}
+	return BackupResult{DumpBytes: cd.n, ManifestHashes: count, HashSet: hs}, nil
+}
+
+// RunWriteManifest serializes hs to a counting discard writer and returns
+// the manifest's on-disk byte size. WriteManifest streams sorted hex lines,
+// so this measures the sort + encode cost, not a buffer allocation.
+func RunWriteManifest(hs *blockstore.HashSet) (int64, error) {
+	cd := &countingDiscard{}
+	if err := snapshot.WriteManifest(cd, hs); err != nil {
+		return 0, fmt.Errorf("snapshots bench: write manifest: %w", err)
+	}
+	return cd.n, nil
+}
+
+// SeedRemote PUTs a zero-length object for every hash in hs into rs so a
+// subsequent RunVerify finds every probe present (the all-durable happy
+// path, which is also the most expensive: it never short-circuits on a
+// miss). Returns the number of objects seeded.
+func SeedRemote(ctx context.Context, rs remote.RemoteStore, hs *blockstore.HashSet) (int, error) {
+	n := 0
+	err := hs.ForEach(func(h blockstore.ContentHash) error {
+		if err := rs.Put(ctx, h, nil); err != nil {
+			return fmt.Errorf("snapshots bench: seed remote put: %w", err)
+		}
+		n++
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// RunVerify HEAD-probes every hash in hs against rs at VerifyConcurrency
+// and returns the number of hashes probed. The caller times the call. With
+// an all-present remote (see SeedRemote) every probe runs, giving the
+// worst-case verify wall time for the manifest size.
+func RunVerify(ctx context.Context, rs remote.RemoteStore, hs *blockstore.HashSet) (int, error) {
+	if err := snapshot.VerifyRemoteDurability(ctx, rs, hs, VerifyConcurrency); err != nil {
+		return 0, fmt.Errorf("snapshots bench: verify: %w", err)
+	}
+	return hs.Len(), nil
+}
+
+// SerializeManifest renders hs to its on-disk byte form via the production
+// WriteManifest encoder. Benchmarks call it once, outside the timed loop,
+// then feed the bytes to RunReadManifest so only the parse is measured.
+func SerializeManifest(hs *blockstore.HashSet) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := snapshot.WriteManifest(&buf, hs); err != nil {
+		return nil, fmt.Errorf("snapshots bench: serialize manifest: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// RunReadManifest parses a serialized manifest (see SerializeManifest) back
+// into a HashSet, measuring the ReadManifest cost — the dominant allocation
+// on the restore pre-verify path, where the parsed set is resident in RAM.
+// Returns the parsed hash count.
+func RunReadManifest(manifest []byte) (int, error) {
+	parsed, err := snapshot.ReadManifest(bytes.NewReader(manifest))
+	if err != nil {
+		return 0, fmt.Errorf("snapshots bench: read manifest: %w", err)
+	}
+	return parsed.Len(), nil
+}

--- a/bench/snapshots/workloads_test.go
+++ b/bench/snapshots/workloads_test.go
@@ -1,0 +1,219 @@
+package snapshots_test
+
+import (
+	"context"
+	"testing"
+
+	snap "github.com/marmos91/dittofs/bench/snapshots"
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+)
+
+// scaleCase is one (files, blocks-per-file) point on the sweep.
+type scaleCase struct {
+	name          string
+	files         int
+	blocksPerFile int
+	// large gates the case behind -short: 1e6-file points allocate
+	// hundreds of MB and take seconds, too heavy for the default CI run.
+	large bool
+}
+
+// scales is the shared sweep used by every benchmark below. The small
+// points run in CI; the large (1e6) points run only without -short.
+var scales = []scaleCase{
+	{name: "1e4files_1blk", files: 1e4, blocksPerFile: 1},
+	{name: "1e5files_1blk", files: 1e5, blocksPerFile: 1},
+	{name: "1e5files_8blk", files: 1e5, blocksPerFile: 8},
+	{name: "1e6files_1blk", files: 1e6, blocksPerFile: 1, large: true},
+	{name: "1e6files_8blk", files: 1e6, blocksPerFile: 8, large: true},
+}
+
+func seedOpts(b *testing.B, sc scaleCase) snap.SeedOpts {
+	b.Helper()
+	return snap.SeedOpts{
+		Engine:        snap.EngineMemory,
+		Files:         sc.files,
+		BlocksPerFile: sc.blocksPerFile,
+		BlockSize:     1 << 20, // 1 MiB logical blocks
+		Dedup:         1,       // all-unique: worst case for HashSet + manifest
+	}
+}
+
+// BenchmarkBackup measures the metadata Backup cost (streamed dump +
+// resident HashSet) per scale. Custom metrics: dump bytes and manifest
+// hash count, so dump-size and HashSet growth read directly off the row.
+func BenchmarkBackup(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range scales {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			if sc.large && testing.Short() {
+				b.Skip("large scale skipped under -short")
+			}
+			store, _, cleanup, err := snap.NewStore(ctx, seedOpts(b, sc))
+			if err != nil {
+				b.Fatalf("seed: %v", err)
+			}
+			defer cleanup()
+
+			var last snap.BackupResult
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				last, err = snap.RunBackup(ctx, store)
+				if err != nil {
+					b.Fatalf("backup: %v", err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(last.DumpBytes), "dump_bytes")
+			b.ReportMetric(float64(last.ManifestHashes), "manifest_hashes")
+		})
+	}
+}
+
+// BenchmarkWriteManifest measures WriteManifest (sort + hex encode, fully
+// streamed). Custom metric: manifest_bytes (on-disk manifest size).
+func BenchmarkWriteManifest(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range scales {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			if sc.large && testing.Short() {
+				b.Skip("large scale skipped under -short")
+			}
+			hs := buildHashSet(b, ctx, sc)
+
+			var bytesOut int64
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var err error
+				bytesOut, err = snap.RunWriteManifest(hs)
+				if err != nil {
+					b.Fatalf("write manifest: %v", err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(bytesOut), "manifest_bytes")
+		})
+	}
+}
+
+// BenchmarkReadManifest measures ReadManifest (parse into a resident
+// HashSet — the restore pre-verify allocation).
+func BenchmarkReadManifest(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range scales {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			if sc.large && testing.Short() {
+				b.Skip("large scale skipped under -short")
+			}
+			hs := buildHashSet(b, ctx, sc)
+			manifest, err := snap.SerializeManifest(hs)
+			if err != nil {
+				b.Fatalf("serialize manifest: %v", err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := snap.RunReadManifest(manifest); err != nil {
+					b.Fatalf("read manifest: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkVerify measures VerifyRemoteDurability against an all-present
+// in-memory remote at the production concurrency (16). This is the
+// HEAD-probe cost; the in-memory remote has no network latency, so the
+// number is a floor — multiply by real per-HEAD RTT for an S3 budget.
+// Custom metric: probes (= hashes HEAD-probed).
+func BenchmarkVerify(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range scales {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			if sc.large && testing.Short() {
+				b.Skip("large scale skipped under -short")
+			}
+			hs := buildHashSet(b, ctx, sc)
+			rs := remotememory.New()
+			defer func() { _ = rs.Close() }()
+			if _, err := snap.SeedRemote(ctx, rs, hs); err != nil {
+				b.Fatalf("seed remote: %v", err)
+			}
+
+			var probes int
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var err error
+				probes, err = snap.RunVerify(ctx, rs, hs)
+				if err != nil {
+					b.Fatalf("verify: %v", err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(probes), "probes")
+		})
+	}
+}
+
+// buildHashSet seeds a store, runs one Backup, and returns the resulting
+// HashSet for the manifest / verify benchmarks (which time a stage
+// downstream of Backup and so need its output, not the timed Backup
+// itself).
+func buildHashSet(b *testing.B, ctx context.Context, sc scaleCase) *blockstore.HashSet {
+	b.Helper()
+	store, _, cleanup, err := snap.NewStore(ctx, seedOpts(b, sc))
+	if err != nil {
+		b.Fatalf("seed: %v", err)
+	}
+	defer cleanup()
+	res, err := snap.RunBackup(ctx, store)
+	if err != nil {
+		b.Fatalf("backup: %v", err)
+	}
+	return res.HashSet
+}
+
+// BenchmarkBackupBadger keeps the on-disk badger engine exercised (the
+// sweep above uses the memory engine). Badger streams the dump KV-by-KV, so
+// this is the streamed-create reference point.
+func BenchmarkBackupBadger(b *testing.B) {
+	if testing.Short() {
+		b.Skip("badger backup skipped under -short")
+	}
+	ctx := context.Background()
+	opts := snap.SeedOpts{
+		Engine:        snap.EngineBadger,
+		Files:         1e4,
+		BlocksPerFile: 4,
+		BlockSize:     1 << 20,
+		Dedup:         1,
+		DBPath:        b.TempDir(),
+	}
+	store, _, cleanup, err := snap.NewStore(ctx, opts)
+	if err != nil {
+		b.Fatalf("seed badger: %v", err)
+	}
+	defer cleanup()
+
+	var last snap.BackupResult
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		last, err = snap.RunBackup(ctx, store)
+		if err != nil {
+			b.Fatalf("backup: %v", err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(last.DumpBytes), "dump_bytes")
+	b.ReportMetric(float64(last.ManifestHashes), "manifest_hashes")
+}

--- a/cmd/bench/snapshots.go
+++ b/cmd/bench/snapshots.go
@@ -26,13 +26,18 @@ var snapshotsCmd = &cobra.Command{
 --blocks-per-file BlockRefs) into the chosen metadata engine, then times
 the three snapshot cost centers in sequence:
 
-  backup          metadata dump (streamed) + resident HashSet
+  backup          metadata dump + resident HashSet
   write-manifest  sorted hex-line manifest (streamed)
   verify          HEAD-probe every hash against an in-memory remote (conc 16)
 
 Reports wall time and dump/manifest sizes per stage. Uses an in-memory
 remote so there is no S3 request cost; multiply the verify time by a real
-per-HEAD RTT for an S3 budget estimate.`,
+per-HEAD RTT for an S3 budget estimate.
+
+Engine note: --engine badger streams the dump KV-by-KV (its create-path RAM
+is the HashSet); --engine memory (default) gob-encodes the whole snapshot
+into one buffer, so its backup RAM is not the streaming ceiling. Use badger
+to model a large share.`,
 	RunE: runSnapshots,
 }
 

--- a/cmd/bench/snapshots.go
+++ b/cmd/bench/snapshots.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	snapbench "github.com/marmos91/dittofs/bench/snapshots"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	snapEngine        string
+	snapFiles         int
+	snapBlocksPerFile int
+	snapBlockSize     int
+	snapDedup         int
+)
+
+var snapshotsCmd = &cobra.Command{
+	Use:   "snapshots",
+	Short: "Scale/perf workload for the snapshot create + verify pipeline",
+	Long: `Seeds a synthetic share (--files regular files, each with
+--blocks-per-file BlockRefs) into the chosen metadata engine, then times
+the three snapshot cost centers in sequence:
+
+  backup          metadata dump (streamed) + resident HashSet
+  write-manifest  sorted hex-line manifest (streamed)
+  verify          HEAD-probe every hash against an in-memory remote (conc 16)
+
+Reports wall time and dump/manifest sizes per stage. Uses an in-memory
+remote so there is no S3 request cost; multiply the verify time by a real
+per-HEAD RTT for an S3 budget estimate.`,
+	RunE: runSnapshots,
+}
+
+func init() {
+	flags := snapshotsCmd.Flags()
+	flags.StringVar(&snapEngine, "engine", snapbench.EngineMemory, "metadata engine: memory | badger")
+	flags.IntVar(&snapFiles, "files", 100000, "number of synthetic files to seed")
+	flags.IntVar(&snapBlocksPerFile, "blocks-per-file", 1, "BlockRefs per file")
+	flags.IntVar(&snapBlockSize, "block-size", 1<<20, "logical block size in bytes (metadata only)")
+	flags.IntVar(&snapDedup, "dedup", 1, "share every Nth block hash (>1 shrinks unique-hash count)")
+}
+
+func runSnapshots(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	w := cmd.OutOrStdout()
+
+	opts := snapbench.SeedOpts{
+		Engine:        snapEngine,
+		Files:         snapFiles,
+		BlocksPerFile: snapBlocksPerFile,
+		BlockSize:     uint32(snapBlockSize),
+		Dedup:         snapDedup,
+	}
+	if opts.Engine == snapbench.EngineBadger {
+		dir, err := os.MkdirTemp("", "bench-snapshots-")
+		if err != nil {
+			return fmt.Errorf("temp dir: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(dir) }()
+		opts.DBPath = dir
+	}
+
+	seedStart := time.Now()
+	store, unique, cleanup, err := snapbench.NewStore(ctx, opts)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	seedDur := time.Since(seedStart)
+
+	backupStart := time.Now()
+	backup, err := snapbench.RunBackup(ctx, store)
+	if err != nil {
+		return err
+	}
+	backupDur := time.Since(backupStart)
+
+	manifestStart := time.Now()
+	manifestBytes, err := snapbench.RunWriteManifest(backup.HashSet)
+	if err != nil {
+		return err
+	}
+	manifestDur := time.Since(manifestStart)
+
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+	if _, err := snapbench.SeedRemote(ctx, rs, backup.HashSet); err != nil {
+		return err
+	}
+	verifyStart := time.Now()
+	probes, err := snapbench.RunVerify(ctx, rs, backup.HashSet)
+	if err != nil {
+		return err
+	}
+	verifyDur := time.Since(verifyStart)
+
+	_, _ = fmt.Fprintf(w,
+		"engine=%s files=%d blocks_per_file=%d unique_hashes=%d\n",
+		opts.Engine, opts.Files, snapBlocksPerFile, unique,
+	)
+	_, _ = fmt.Fprintf(w,
+		"seed=%s backup=%s write_manifest=%s verify=%s\n",
+		seedDur.Round(time.Millisecond), backupDur.Round(time.Millisecond),
+		manifestDur.Round(time.Millisecond), verifyDur.Round(time.Millisecond),
+	)
+	_, _ = fmt.Fprintf(w,
+		"dump_bytes=%d manifest_bytes=%d manifest_hashes=%d verify_probes=%d\n",
+		backup.DumpBytes, manifestBytes, backup.ManifestHashes, probes,
+	)
+	return nil
+}

--- a/cmd/bench/stubs.go
+++ b/cmd/bench/stubs.go
@@ -25,9 +25,8 @@ func newStubCmd(area, short string) *cobra.Command {
 }
 
 var (
-	gcCmd        = newStubCmd("gc", "Garbage collection benchmarks (stub)")
-	snapshotsCmd = newStubCmd("snapshots", "Reference-CAS snapshot benchmarks (stub)")
-	metadataCmd  = newStubCmd("metadata", "Metadata store benchmarks (listings, rename, links, ACL) (stub)")
-	adaptersCmd  = newStubCmd("adapters", "NFS / SMB framing benchmarks (stub)")
-	e2eCmd       = newStubCmd("e2e", "External-client end-to-end benchmarks (fio, iozone, smbtorture-perf) (stub)")
+	gcCmd       = newStubCmd("gc", "Garbage collection benchmarks (stub)")
+	metadataCmd = newStubCmd("metadata", "Metadata store benchmarks (listings, rename, links, ACL) (stub)")
+	adaptersCmd = newStubCmd("adapters", "NFS / SMB framing benchmarks (stub)")
+	e2eCmd      = newStubCmd("e2e", "External-client end-to-end benchmarks (fio, iozone, smbtorture-perf) (stub)")
 )

--- a/test/e2e/BENCHMARKS.md
+++ b/test/e2e/BENCHMARKS.md
@@ -387,12 +387,15 @@ insert).
 
 ### Established limits & budget
 
-- **The metadata dump is streamed.** Both the badger (KV-by-KV) and the
+- **The badger dump is streamed.** The badger engine (KV-by-KV) and the
   manifest writer emit to an `io.Writer` without buffering the whole dump;
-  `dump_bytes` never lands in a single allocation. The dominant
-  create-path resident allocation is the returned `HashSet`: one 32-byte
-  `ContentHash` per **unique** block, ~26 B/entry in the Go map. **Budget
-  ~25 MB of HashSet RAM per 1 M unique blocks**; 8 M unique blocks ≈ 200 MB.
+  on the badger path `dump_bytes` never lands in a single allocation. The
+  dominant create-path resident allocation is then the returned `HashSet`:
+  one 32-byte `ContentHash` per **unique** block, ~26 B/entry in the Go
+  map. **Budget ~25 MB of HashSet RAM per 1 M unique blocks**; 8 M unique
+  blocks ≈ 200 MB. (The memory engine does NOT stream — see the last
+  bullet; the indicative table above uses the memory engine, so its
+  create-path `B/op` reflects that buffer, not the streaming ceiling.)
 - **Manifest on disk is 65 bytes/hash** (64 hex + LF): 65 MB per 1 M
   hashes, 520 MB at 8 M. Written streamed; read back into a resident
   HashSet on restore (size as above).

--- a/test/e2e/BENCHMARKS.md
+++ b/test/e2e/BENCHMARKS.md
@@ -337,6 +337,80 @@ canonical warm-cache regression anchor. A dedicated
 gate ≤1.10) will be added only if cold-read complaints surface in
 production.
 
+## Snapshot scale limits
+
+Snapshot `create` does a metadata `Backup` (a streamed dump plus an in-RAM
+`HashSet` of every referenced block hash), writes a hash manifest, drains
+uploads, then verifies durability by HEAD-probing every manifest hash at
+concurrency 16. `restore` reads the manifest back, resets, restores the
+dump, and re-verifies. None of these had a benchmark; the numbers below
+establish the memory ceiling and the verify budget before any large-share
+deployment claim.
+
+Workloads live in `bench/snapshots/` and run via the `dfsbench snapshots`
+CLI or the package `Benchmark*` tests. They isolate the three cost centers
+(backup, manifest, verify) from the Runtime orchestration so a single
+benchmark can sweep file counts without standing up adapters / the
+control-plane DB / real S3.
+
+### Reproduction commands
+
+```bash
+# CI-safe sweep (1e4 / 1e5 files; 1e6 cases skipped under -short):
+go test -bench=. -benchmem -short -run=^$ ./bench/snapshots/
+
+# Full sweep including 1e6-file scales (heavy — minutes, multi-GB allocs):
+go test -bench=. -benchmem -benchtime=1x -run=^$ -timeout=900s ./bench/snapshots/
+
+# One ad-hoc seed→backup→manifest→verify pass with per-stage wall time:
+go build -o dfsbench ./cmd/bench
+./dfsbench snapshots --files 1000000 --blocks-per-file 8
+```
+
+### Indicative numbers (Apple M1 Max, memory engine, in-memory remote)
+
+All-unique blocks (`--dedup 1`, the worst case for HashSet + manifest RAM).
+`benchtime=1x`. `dump_bytes` is streamed to a discard writer — it is the
+serialized dump size, not a resident buffer.
+
+| Scale (files × blocks) | unique hashes | backup ns/op | dump_bytes | manifest_bytes | verify ns/op (probes) |
+| ---------------------- | ------------: | -----------: | ---------: | -------------: | --------------------: |
+| 1e5 × 1                |       100,000 |        1.15 s |    35.0 MB |        6.5 MB |     0.14 s (100,000) |
+| 1e5 × 8                |       800,000 |        1.45 s |    67.2 MB |       52.0 MB |     1.39 s (800,000) |
+| 1e6 × 1                |     1,000,000 |        5.92 s |   350.0 MB |       65.0 MB |     1.95 s (1,000,000) |
+| 1e6 × 8                |     8,000,000 |       18.25 s |   672.0 MB |      520.0 MB |    25.27 s (8,000,000) |
+
+`write-manifest` and `read-manifest` (restore pre-verify) at 1e6 × 8:
+6.20 s / 16.18 s; the manifest parses back into a resident HashSet
+(~4.2 GB B/op at 8 M hashes, dominated by the per-line hex decode + map
+insert).
+
+### Established limits & budget
+
+- **The metadata dump is streamed.** Both the badger (KV-by-KV) and the
+  manifest writer emit to an `io.Writer` without buffering the whole dump;
+  `dump_bytes` never lands in a single allocation. The dominant
+  create-path resident allocation is the returned `HashSet`: one 32-byte
+  `ContentHash` per **unique** block, ~26 B/entry in the Go map. **Budget
+  ~25 MB of HashSet RAM per 1 M unique blocks**; 8 M unique blocks ≈ 200 MB.
+- **Manifest on disk is 65 bytes/hash** (64 hex + LF): 65 MB per 1 M
+  hashes, 520 MB at 8 M. Written streamed; read back into a resident
+  HashSet on restore (size as above).
+- **Verify is N HEAD round-trips at concurrency 16**, holding nothing
+  across probes. The in-memory-remote times above are a **floor with zero
+  network latency**. For an S3 budget, multiply the probe count by the real
+  per-HEAD RTT ÷ 16: e.g. 8 M probes at 20 ms/HEAD ≈ 8e6 × 0.02 / 16 ≈
+  **167 minutes** of verify, plus 8 M HEAD-request charges. Large shares
+  should size their verify window (and S3 request cost) from the manifest
+  hash count, or create with `--no-verify` and accept `remote_durable=false`.
+- **The memory metadata engine is not suitable for TB/M-file shares.** It
+  gob-encodes its entire snapshot into one buffer during Backup (expected
+  for an in-RAM backend) — the create-path `B/op` for the memory engine
+  reflects that buffer, not the dump stream. **Use the badger engine for
+  large shares; it streams the dump KV-by-KV.** (Badger restore still
+  buffers all KV entries in RAM before the integrity CRC is verified — a
+  known restore-path ceiling, orthogonal to create, tracked separately.)
+
 ## End-to-end performance reports
 
 For NFSv3/NFSv4.1 + SMB end-to-end numbers against kernel NFS and


### PR DESCRIPTION
Closes #814

Adds a scale/perf benchmark suite for the reference-CAS snapshot pipeline and documents the established memory ceiling and verify budget — no benchmark existed for large shares before this.

## What

`bench/snapshots/` (library + `Benchmark*` tests) and the `dfsbench snapshots` CLI subcommand (replaces the stub). Three cost centers, isolated from the Runtime orchestration so one benchmark sweeps file counts without standing up adapters / the control-plane DB / real S3:

- **backup** — metadata dump (streamed) + resident `HashSet` (the create-path RAM)
- **write-manifest** / **read-manifest** — sorted hex-line manifest, streamed write + restore-side parse
- **verify** — HEAD-probe every manifest hash at concurrency 16 against an in-memory remote (no S3 request cost)

Scales swept: 1e4 / 1e5 / 1e6 files × 1 or 8 blocks. The 1e6 cases gate behind `-short` so CI stays fast; a `TestPipeline` covers the helpers in CI.

## Findings (Apple M1 Max, memory engine, in-memory remote)

| Scale | unique hashes | backup | dump | manifest | verify (probes) |
|---|--:|--:|--:|--:|--:|
| 1e6 × 1 | 1,000,000 | 5.92 s | 350 MB | 65 MB | 1.95 s (1e6) |
| 1e6 × 8 | 8,000,000 | 18.25 s | 672 MB | 520 MB | 25.27 s (8e6) |

## Established limits (full detail in `test/e2e/BENCHMARKS.md`)

- The metadata **dump is streamed** (badger writes KV-by-KV; the manifest writer streams) — never buffered whole. **Streaming was not needed for the dump.**
- The dominant create-path resident allocation is the `HashSet`: ~25 MB per 1M unique blocks.
- Manifest on disk is 65 B/hash; read back into a resident HashSet on restore.
- Verify is N HEAD round-trips at concurrency 16 — the in-memory number is a floor; for an S3 budget multiply by per-HEAD RTT ÷ 16 (e.g. 8M probes @ 20 ms ≈ 167 min + 8M HEAD charges).
- The **memory metadata engine gob-encodes its whole snapshot into one buffer** during Backup — not suitable for TB/M-file shares. Use badger, which streams.