### PR TITLE
test(snapshot): point-in-time consistency of create vs concurrent writes (#811)

### DIFF
--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -218,14 +218,41 @@ Normally a snapshot orchestration runs in this order:
 1. Persist the snapshot row in `state=creating`.
 2. Drain pending rollups so all written data is persisted to CAS and
    reflected in each file's block list.
-3. Write `metadata.dump` from the now-settled metadata store.
-4. Compute the hash manifest from the share's referenced blocks.
-5. Drain in-flight uploads to the remote block store.
-6. Run the verify gate: HEAD-probe every block hash on the remote
+3. Write `metadata.dump` AND compute the hash manifest from a single
+   consistent read-view of the metadata store (see "Point-in-time
+   consistency" below).
+4. Drain in-flight uploads to the remote block store.
+5. Run the verify gate: HEAD-probe every block hash on the remote
    block store (concurrency = 16) to confirm remote durability.
-7. Transition to `state=ready` (or `state=failed` on any error).
+6. Transition to `state=ready` (or `state=failed` on any error).
 
-`--no-verify` skips step 5 (upload drain) and step 6 (HEAD probes).
+### Point-in-time consistency
+
+DittoFS blocks are immutable and content-addressed: once written, a block
+never changes. The only way a snapshot could capture an inconsistent image
+is if the metadata dump and the hash manifest were read at different logical
+instants while a client was writing — a file could end up in the dump
+referencing a block missing from the manifest, or a multi-chunk file could
+be torn.
+
+To prevent this, the metadata store captures the dump and the manifest from
+**a single consistent read-view**:
+
+- **postgres** — one `REPEATABLE READ` transaction; all table `COPY`s and
+  the block-hash query observe the same MVCC snapshot.
+- **badger** — one managed read transaction (`db.View`); the whole
+  key-space iteration and hash extraction share that snapshot.
+- **memory** — the in-memory maps are read under the store write lock,
+  which every mutation also takes, so the dump and manifest reflect the
+  same instant.
+
+Client writes are **not** quiesced or stalled during create: they proceed
+concurrently and are simply ordered relative to the snapshot's read-view. A
+write that lands during create is either fully visible in both the dump and
+the manifest, or in neither — never half-captured. The result is a true
+point-in-time image under active load.
+
+`--no-verify` skips step 4 (upload drain) and step 5 (HEAD probes).
 The snapshot still completes, the GC hold still applies, but the
 `remote_durable` flag is `false`. Use it when:
 

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -199,12 +199,13 @@ func (f *realBackupFixture) assertNoTornFiles(t *testing.T, store metadata.Metad
 	t.Helper()
 	ctx := context.Background()
 
+	// The fixture creates the share before any snapshot and the dump always
+	// captures shares, so the root must be present in every restored image.
+	// A genuine not-found would mean the share was dropped from the dump (a
+	// real consistency bug); any other error is an unexpected store failure.
 	root, err := store.GetRootHandle(ctx, f.shareName)
 	if err != nil {
-		// The share may not yet exist in the dump if the very first
-		// snapshot raced ahead of CreateShare; that is itself consistent
-		// (empty image), so treat absence as a clean empty snapshot.
-		return
+		t.Fatalf("snapshot %d: root handle missing from restored dump: %v", n, err)
 	}
 
 	entries, _, err := store.ListChildren(ctx, root, "", 0)
@@ -355,13 +356,18 @@ func (f *realBackupFixture) tryPutMultiChunkFile(ctx context.Context, name strin
 
 	// Reuse the existing handle on overwrite (real-client semantics) so the
 	// working set stays bounded; only mint a fresh handle for a new name.
+	// A not-found error means the child does not exist yet; any other error
+	// is a real store failure that must propagate.
 	h, err := f.mem.GetChild(ctx, root, name)
-	isNew := err != nil
-	if isNew {
+	isNew := err != nil && metadata.IsNotFoundError(err)
+	switch {
+	case isNew:
 		h, err = f.mem.GenerateHandle(ctx, f.shareName, "/"+name)
 		if err != nil {
 			return fmt.Errorf("generate handle: %w", err)
 		}
+	case err != nil:
+		return fmt.Errorf("get child %q: %w", name, err)
 	}
 	_, id, err := metadata.DecodeFileHandle(h)
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -1,0 +1,420 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	bsmemory "github.com/marmos91/dittofs/pkg/blockstore/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/marmos91/dittofs/pkg/snapshot"
+)
+
+// TestCreateSnapshot_PointInTimeConsistency drives the real CreateSnapshot
+// orchestration against the real metadata-store Backup() while a continuous
+// background writer hammers the share, then asserts the captured snapshot is
+// internally consistent: every block hash referenced by the metadata dump is
+// present in the manifest, and no file is torn across a multi-chunk write.
+//
+// This is the orchestration-level analogue of the store-layer
+// ConcurrentWriter backup conformance test (pkg/metadata/storetest). The
+// store-layer test isolates Backup() under controlled timing; this test
+// exercises the full DrainRollups -> Backup -> manifest pipeline under
+// sustained concurrent mutation, which is exactly the window issue #811
+// flagged as undefined.
+//
+// Consistency model under test (immutable CAS blocks + a single consistent
+// metadata read-view): the metadata dump and the hash manifest are captured
+// from the same logical instant, so a write landing mid-create is either
+// fully present in both or absent from both — never half-captured. No global
+// write quiesce is required.
+func TestCreateSnapshot_PointInTimeConsistency(t *testing.T) {
+	fx := newRealBackupFixture(t)
+	defer fx.close()
+
+	ctx := fx.ctx()
+
+	// Seed an initial multi-chunk file so the very first snapshot already
+	// has block refs to capture.
+	fx.putMultiChunkFile(ctx, "seed.bin", 4)
+
+	// Continuous background writer: keep mutating the share (create new
+	// multi-chunk files, overwrite existing ones with a different chunk
+	// count) until the test signals stop. Every write goes through the
+	// real metadata store under its real locking, exactly like a live
+	// client under load.
+	stop := make(chan struct{})
+	var writerErr atomic.Pointer[error]
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			name := fmt.Sprintf("hot-%d.bin", i%8)
+			// Vary chunk count so multi-chunk files churn their BlockRef
+			// list — the torn-file failure mode #811 describes.
+			chunks := 2 + (i % 5)
+			if err := fx.tryPutMultiChunkFile(ctx, name, chunks); err != nil {
+				e := err
+				writerErr.Store(&e)
+				return
+			}
+			i++
+			// Throttle so the captured metadata stays a realistic working
+			// set rather than an unbounded hash explosion. The pause is
+			// short enough that many writes still land inside each
+			// capture window, which is what stresses point-in-time
+			// consistency.
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+
+	// Take a series of snapshots while the writer churns. NoVerify keeps
+	// the test off the remote-durability gate (orthogonal to #811); we
+	// assert dump<->manifest consistency directly from the on-disk
+	// artifacts.
+	const snapshots = 12
+	for n := 0; n < snapshots; n++ {
+		snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+		if err != nil {
+			t.Fatalf("snapshot %d: CreateSnapshot: %v", n, err)
+		}
+		snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+		if werr != nil {
+			t.Fatalf("snapshot %d: WaitForSnapshot: %v", n, werr)
+		}
+		if snap.State != models.StateReady {
+			t.Fatalf("snapshot %d: state = %q, want ready", n, snap.State)
+		}
+
+		fx.assertSnapshotConsistent(t, snap, n)
+	}
+
+	close(stop)
+	wg.Wait()
+	if ep := writerErr.Load(); ep != nil {
+		t.Fatalf("background writer failed: %v", *ep)
+	}
+}
+
+// ----- consistency assertion -----
+
+// assertSnapshotConsistent restores the snapshot's metadata dump into a
+// fresh, isolated memory store and verifies that the set of block hashes
+// intrinsically referenced by that restored metadata matches the on-disk
+// manifest exactly. A mismatch in either direction is the metadata-vs-block
+// skew #811 warned about:
+//   - dump references a hash the manifest lacks  => dangling block ref
+//   - manifest carries a hash no restored file references => phantom hold
+//
+// It also verifies that every regular file in the restored dump is whole:
+// its BlockRefs tile [0, size) contiguously with no gap or overlap (a torn
+// multi-chunk file would fail this).
+func (f *realBackupFixture) assertSnapshotConsistent(t *testing.T, snap *models.Snapshot, n int) {
+	t.Helper()
+
+	dumpPath := snap.MetadataDumpPath(f.localStoreDir)
+	manifestPath := snap.ManifestPath(f.localStoreDir)
+
+	dumpFile, err := os.Open(dumpPath)
+	if err != nil {
+		t.Fatalf("snapshot %d: open dump: %v", n, err)
+	}
+	defer func() { _ = dumpFile.Close() }()
+
+	// Restore the dump into a brand-new store. This reconstructs exactly
+	// the point-in-time metadata image the snapshot captured.
+	restored := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := restored.Restore(context.Background(), dumpFile); err != nil {
+		t.Fatalf("snapshot %d: restore dump into fresh store: %v", n, err)
+	}
+
+	// Intrinsic hash set of the restored image: re-run Backup on the
+	// restored store (to a discard sink) and take the HashSet it derives
+	// from the restored files' BlockRefs. This is backend-agnostic and
+	// uses the same extraction path the manifest was built from.
+	dumpHashes, err := restored.Backup(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatalf("snapshot %d: re-backup restored store: %v", n, err)
+	}
+
+	manifestFile, err := os.Open(manifestPath)
+	if err != nil {
+		t.Fatalf("snapshot %d: open manifest: %v", n, err)
+	}
+	defer func() { _ = manifestFile.Close() }()
+	manifestHashes, err := snapshot.ReadManifest(manifestFile)
+	if err != nil {
+		t.Fatalf("snapshot %d: read manifest: %v", n, err)
+	}
+
+	// Direction 1: every hash the restored metadata references must be in
+	// the manifest. A failure here means the dump captured a file whose
+	// blocks are absent from the manifest — the snapshot would restore a
+	// file pointing at blocks no hold protects.
+	_ = dumpHashes.ForEach(func(h blockstore.ContentHash) error {
+		if !manifestHashes.Contains(h) {
+			t.Errorf("snapshot %d: dump references hash %x absent from manifest (metadata/block skew)", n, h[:8])
+		}
+		return nil
+	})
+
+	// Direction 2: every manifest hash must be referenced by the restored
+	// metadata. A phantom manifest hash means the manifest was captured
+	// from a later view than the dump.
+	_ = manifestHashes.ForEach(func(h blockstore.ContentHash) error {
+		if !dumpHashes.Contains(h) {
+			t.Errorf("snapshot %d: manifest carries hash %x not referenced by dump (manifest/metadata skew)", n, h[:8])
+		}
+		return nil
+	})
+
+	// Whole-file check: walk every regular file in the restored image and
+	// confirm its BlockRefs tile [0, size) with no gap/overlap.
+	f.assertNoTornFiles(t, restored, n)
+}
+
+// assertNoTornFiles walks the share's directory tree in the restored store
+// and verifies each regular file's BlockRefs form a contiguous,
+// non-overlapping tiling of [0, size).
+func (f *realBackupFixture) assertNoTornFiles(t *testing.T, store metadata.MetadataStore, n int) {
+	t.Helper()
+	ctx := context.Background()
+
+	root, err := store.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		// The share may not yet exist in the dump if the very first
+		// snapshot raced ahead of CreateShare; that is itself consistent
+		// (empty image), so treat absence as a clean empty snapshot.
+		return
+	}
+
+	entries, _, err := store.ListChildren(ctx, root, "", 0)
+	if err != nil {
+		t.Fatalf("snapshot %d: list children: %v", n, err)
+	}
+	for _, e := range entries {
+		file, err := store.GetFile(ctx, e.Handle)
+		if err != nil {
+			t.Fatalf("snapshot %d: get file %q: %v", n, e.Name, err)
+		}
+		if file.Type != metadata.FileTypeRegular || len(file.Blocks) == 0 {
+			continue
+		}
+		var covered uint64
+		for bi, br := range file.Blocks {
+			if br.Offset != covered {
+				t.Errorf("snapshot %d: file %q block %d offset = %d, want %d (torn file: gap/overlap)",
+					n, e.Name, bi, br.Offset, covered)
+			}
+			covered += uint64(br.Size)
+		}
+		if covered != file.Size {
+			t.Errorf("snapshot %d: file %q blocks cover %d bytes, size = %d (torn file: short/long tiling)",
+				n, e.Name, covered, file.Size)
+		}
+	}
+}
+
+// ----- fixture (real Backup, real writer) -----
+
+// realBackupFixture wires CreateSnapshot against the real memory metadata
+// store's Backup() (not the controlled mock used elsewhere in this package)
+// so that the actual consistent-read-view capture is exercised end to end.
+type realBackupFixture struct {
+	t             *testing.T
+	rt            *Runtime
+	store         cpstore.Store
+	mem           *metadatamemory.MemoryMetadataStore
+	localStoreDir string
+	shareName     string
+
+	hctr uint64 // monotonically increments to mint distinct block hashes
+}
+
+func newRealBackupFixture(t *testing.T) *realBackupFixture {
+	t.Helper()
+
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+
+	mem := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("memory", mem); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	if _, err := cp.CreateMetadataStore(context.Background(), &models.MetadataStoreConfig{
+		Name: "memory",
+		Type: "memory",
+	}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+
+	localStoreDir := t.TempDir()
+	shareName := "data"
+
+	if err := mem.CreateShare(context.Background(), &metadata.Share{Name: shareName}); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+
+	localStore := bsmemory.New()
+	innerRemote := remotememory.New()
+	t.Cleanup(func() { _ = innerRemote.Close() })
+	syncer := engine.NewSyncer(localStore, innerRemote, mem, engine.SyncerConfig{
+		ParallelUploads:   1,
+		ParallelDownloads: 1,
+	})
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:          localStore,
+		Remote:         innerRemote,
+		Syncer:         syncer,
+		FileBlockStore: mem,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{
+		Name:          shareName,
+		MetadataStore: "memory",
+		BlockStore:    bs,
+	})
+	if err := rt.sharesSvc.SetLocalStoreDirForTesting(shareName, localStoreDir); err != nil {
+		t.Fatalf("SetLocalStoreDirForTesting: %v", err)
+	}
+
+	return &realBackupFixture{
+		t:             t,
+		rt:            rt,
+		store:         cp,
+		mem:           mem,
+		localStoreDir: localStoreDir,
+		shareName:     shareName,
+	}
+}
+
+func (f *realBackupFixture) close() {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := f.rt.Shutdown(ctx); err != nil {
+		f.t.Logf("Shutdown: %v", err)
+	}
+}
+
+func (f *realBackupFixture) ctx() context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	f.t.Cleanup(cancel)
+	return ctx
+}
+
+// putMultiChunkFile creates/overwrites a regular file under the share root
+// with the given number of contiguous block refs and fails the test on
+// error. Used for the deterministic seed.
+func (f *realBackupFixture) putMultiChunkFile(ctx context.Context, name string, chunks int) {
+	f.t.Helper()
+	if err := f.tryPutMultiChunkFile(ctx, name, chunks); err != nil {
+		f.t.Fatalf("putMultiChunkFile %q: %v", name, err)
+	}
+}
+
+// tryPutMultiChunkFile is the goroutine-safe variant: it returns errors
+// instead of calling t.Fatalf (forbidden off the test goroutine). Each
+// chunk gets a freshly minted unique hash so the file's BlockRef list is a
+// genuine multi-chunk tiling.
+func (f *realBackupFixture) tryPutMultiChunkFile(ctx context.Context, name string, chunks int) error {
+	root, err := f.mem.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		return fmt.Errorf("root handle: %w", err)
+	}
+
+	// Reuse the existing handle on overwrite (real-client semantics) so the
+	// working set stays bounded; only mint a fresh handle for a new name.
+	h, err := f.mem.GetChild(ctx, root, name)
+	isNew := err != nil
+	if isNew {
+		h, err = f.mem.GenerateHandle(ctx, f.shareName, "/"+name)
+		if err != nil {
+			return fmt.Errorf("generate handle: %w", err)
+		}
+	}
+	_, id, err := metadata.DecodeFileHandle(h)
+	if err != nil {
+		return fmt.Errorf("decode handle: %w", err)
+	}
+
+	const chunkSize = uint32(1 << 20)
+	blocks := make([]blockstore.BlockRef, chunks)
+	for i := 0; i < chunks; i++ {
+		ctr := atomic.AddUint64(&f.hctr, 1)
+		blocks[i] = blockstore.BlockRef{
+			Hash:   mintHash(ctr),
+			Offset: uint64(i) * uint64(chunkSize),
+			Size:   chunkSize,
+		}
+	}
+
+	file := &metadata.File{
+		ShareName: f.shareName,
+		FileAttr: metadata.FileAttr{
+			Type:   metadata.FileTypeRegular,
+			Mode:   0o644,
+			UID:    1000,
+			GID:    1000,
+			Size:   uint64(chunks) * uint64(chunkSize),
+			Blocks: blocks,
+		},
+	}
+	file.ID = id
+	if err := f.mem.PutFile(ctx, file); err != nil {
+		return fmt.Errorf("put file: %w", err)
+	}
+	if isNew {
+		if err := f.mem.SetParent(ctx, h, root); err != nil {
+			return fmt.Errorf("set parent: %w", err)
+		}
+		if err := f.mem.SetChild(ctx, root, name, h); err != nil {
+			return fmt.Errorf("set child: %w", err)
+		}
+	}
+	return nil
+}
+
+// ----- small helpers -----
+
+// mintHash deterministically derives a unique ContentHash from a counter so
+// every chunk across the whole test references a distinct block.
+func mintHash(ctr uint64) blockstore.ContentHash {
+	var h blockstore.ContentHash
+	for i := 0; i < 8; i++ {
+		h[i] = byte(ctr >> (8 * i))
+	}
+	// Tag the tail so two counters that share low bytes still differ.
+	h[blockstore.HashSize-1] = 0xA5
+	return h
+}

--- a/pkg/metadata/backupable.go
+++ b/pkg/metadata/backupable.go
@@ -28,9 +28,24 @@ import (
 // Restore reads a previously-backed-up stream from r and rebuilds the
 // metadata state. The destination store must be empty (no existing share
 // data); otherwise ErrRestoreDestinationNotEmpty is returned.
+//
+// Consistency contract (issue #811): blocks are immutable and
+// content-addressed, so the only source of metadata-vs-block skew is the
+// dump and the returned hash set being read at different logical instants.
+// Implementations MUST therefore capture BOTH the serialized metadata
+// written to w AND the returned HashSet from a single consistent read-view
+// — e.g. a single MVCC/REPEATABLE READ transaction (postgres), one managed
+// read txn (badger), or a copy-on-read under the write lock (memory). The
+// hash set MUST be derived from that same view (enumerating the captured
+// files' block refs), never from a later live re-read. Writes may proceed
+// concurrently; no global quiesce is required. The result is a true
+// point-in-time image: a file present in the dump always has its blocks in
+// the manifest, and vice versa. The ConcurrentWriter case in the storetest
+// backup conformance suite enforces this.
 type Backupable interface {
 	// Backup serializes all metadata into w and returns the set of
-	// content-addressed block hashes referenced by the snapshot.
+	// content-addressed block hashes referenced by the snapshot, both
+	// captured from a single consistent read-view (see contract above).
 	Backup(ctx context.Context, w io.Writer) (*blockstore.HashSet, error)
 
 	// Restore reads a backup stream from r and rebuilds metadata state.


### PR DESCRIPTION
Closes #811

## Consistency model implemented

DittoFS blocks are immutable and content-addressed, so the only possible source of metadata-vs-block skew during snapshot create is the metadata dump and the hash manifest being read at different logical instants. The chosen model: **capture both the dump and the manifest from a single consistent metadata read-view, with no global write quiesce** — production load is never stalled.

This property was already correctly implemented across all three backends (verified during this work):

- **postgres** — one `REPEATABLE READ` transaction wraps every table `COPY` and the `file_block_refs` hash query, so dump and manifest share the same MVCC snapshot.
- **badger** — one managed read transaction (`db.View`); the full key-space iteration and inline hash extraction share that snapshot.
- **memory** — the in-memory maps are read under the store write lock through the entire serialize + hash-extraction + encode; every mutation also takes that lock, so dump and manifest reflect the same instant.

No backend needed a quiesce fallback. The manifest is derived from the **same view** as the dump in all three (issue requirement confirmed): the returned `HashSet` is built by enumerating the captured files' block refs, never from a later live re-read.

## What this PR adds

`#811` flagged the create window as **undefined** and asked for a regression test. This PR:

1. Adds `TestCreateSnapshot_PointInTimeConsistency` — drives the real `CreateSnapshot` orchestration (`DrainRollups -> Backup -> manifest`) against the **real** metadata-store `Backup` (not the mock used by the existing orchestration tests) while a continuous background writer hammers the share. After each of 12 snapshots it restores the dump into a fresh store and asserts:
   - every block hash referenced by the restored metadata is present in the manifest (no dangling block ref),
   - every manifest hash is referenced by the restored metadata (no phantom hold),
   - no regular file is torn — its block refs tile `[0, size)` contiguously.
   Runs clean under `-race`, stable over repeated iterations. Fault-injected during development (manifest from a later live view) to confirm the assertion has teeth.
2. Documents the consistency contract on the `Backupable` interface and the per-backend mechanism in `docs/SNAPSHOTS.md`, including the explicit "writes proceed concurrently, no quiesce" guarantee.

The per-backend snapshot-isolation property is already enforced for memory/badger/postgres by the `ConcurrentWriter` case in the storetest backup conformance suite; this PR adds the end-to-end orchestration-level coverage that case did not exercise.

Scoped to the create/Backup path + docs to minimize churn for the follow-up restore-atomicity work (#810).