### PR TITLE
fix(snapshot): make restore crash-atomic via durable marker + startup rollback

### DIFF
--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -13,6 +13,7 @@ Operator guide: model, CLI, restore runbook, recovery paths, failure modes.
 - [6. Deleting a snapshot](#6-deleting-a-snapshot)
 - [7. Restore runbook](#7-restore-runbook)
 - [8. Recovering from the safety snapshot](#8-recovering-from-the-safety-snapshot)
+  - [8.1 Automatic crash recovery](#81-automatic-crash-recovery)
 - [9. The verify gate](#9-the-verify-gate)
 - [10. GC hold semantics](#10-gc-hold-semantics)
 - [11. Failure modes and recovery](#11-failure-modes-and-recovery)
@@ -481,17 +482,24 @@ Snapshot c12e8d4f deleted.
 2. Verify the source snapshot is remotely durable (unless `--force`).
 3. Create the pre-restore safety snapshot. Its ID is returned to
    the caller in the same response.
-4. Close the metadata store cleanly.
-5. Reset the metadata store via its `Resetable` interface.
-6. Replay the snapshot's `metadata.dump` into the empty store.
-7. Walk the restored metadata to build a hash set of every block
+4. Write a durable **restore-in-progress marker** (see
+   [§8.1](#81-automatic-crash-recovery)) naming the safety snapshot,
+   immediately before the first destructive step.
+5. Reset the block store's local append-log overlay.
+6. Reset the metadata store via its `Resetable` interface.
+7. Replay the snapshot's `metadata.dump` into the empty store.
+8. Walk the restored metadata to build a hash set of every block
    the restored share now references.
-8. Run a post-restore block verify against the block store to
+9. Run a post-restore block verify against the block store to
    confirm every required hash is reachable.
+10. Clear the restore-in-progress marker.
 
-If step 3 fails, the share is unchanged. If steps 4–8 fail, the
-safety snapshot exists and can be restored to roll back; the
-restored share may be in a partial state until you do so.
+If step 3 fails, the share is unchanged. If steps 5–9 fail, the
+restore returns an error and the safety snapshot exists for
+rollback. Crucially, the restore-in-progress marker (written at
+step 4 and cleared only at step 10) survives a crash: the next
+server startup detects it and **automatically rolls the share back
+to the safety snapshot** — see [§8.1](#81-automatic-crash-recovery).
 
 ### `--force` for non-durable snapshots
 
@@ -569,6 +577,49 @@ A reasonable cadence:
 Failing to delete safety snaps eventually consumes GC budget
 (blocks held by the chain cannot be reclaimed until the chain is
 gone). Setting an internal SOP for deletion keeps that bounded.
+
+### 8.1 Automatic crash recovery
+
+Restore is not a single atomic operation — it resets the block-store
+overlay, resets the metadata store, and replays the metadata dump as
+distinct steps. A crash (power loss, OOM kill, container restart)
+partway through would otherwise leave a **half-restored share**: the
+local overlay cleared but the metadata not yet replaced, or the
+metadata wiped but the dump replay incomplete.
+
+DittoFS makes this **self-healing** with no operator action:
+
+- **Marker.** Immediately after the safety snapshot is verified and
+  before the first destructive step, restore writes a durable
+  *restore-in-progress marker* to the control-plane database. The
+  marker records the target snapshot, the safety snapshot to roll
+  back to, and the furthest step reached. It is cleared only after
+  the restore fully completes and post-verifies.
+- **Detection.** On every startup, before any adapter begins serving
+  traffic, the server scans for restore markers. A marker that is
+  still present means a restore was interrupted.
+- **Rollback.** For each surviving marker the server automatically
+  restores the named safety snapshot — rolling the share back to its
+  exact pre-restore state — then clears the marker. The rollback runs
+  in a mode that creates no new safety snapshot and writes no new
+  marker, so the recovery is idempotent: a crash *during* rollback
+  simply re-runs the identical rollback on the next boot.
+
+Because the marker lives in the control-plane database (the same
+durable store as the snapshot records), it survives the crash and is
+consulted on the next boot regardless of how the daemon was killed.
+A half-restored share is therefore never client-reachable: recovery
+runs before adapters serve.
+
+Operators do not need to detect or repair an interrupted restore
+manually. The structured log records `restore recovery: interrupted
+restore detected, rolling back to safety snapshot` (with the share,
+target, safety-snap id, and step reached) followed by `restore
+recovery: share rolled back to safety snapshot` on success. If the
+rollback itself fails (e.g. the safety snapshot's blocks are missing
+from the remote), the marker is **retained** so a later boot retries
+once the underlying cause is fixed; the failure is logged at `Error`
+level.
 
 ## 9. The verify gate
 
@@ -748,10 +799,24 @@ and final verify — most often by HTTP timeout, container kill, or
 manual cancel. The safety snap exists; the metadata store may be in
 a partial state.
 
-**Recovery.** Re-restore the safety snap to roll back. Investigate
-the cause of the interruption (logs, resource limits, the
-`snapshot.restore_http_timeout` config). Re-run the original restore
-once the cause is fixed.
+**Recovery.** Two cases:
+
+- **The daemon kept running** (HTTP timeout, manual cancel): the
+  process is still up, so startup crash recovery did not run.
+  Re-restore the safety snap to roll back manually, or simply re-run
+  the original restore (the share is disabled, so it is not serving
+  the partial state).
+- **The daemon crashed / was killed** mid-restore: the durable
+  restore-in-progress marker survives, and the **next startup
+  automatically rolls the share back to the safety snapshot** before
+  any adapter serves traffic (see
+  [§8.1](#81-automatic-crash-recovery)). No manual step is required;
+  confirm via the `restore recovery: share rolled back to safety
+  snapshot` log line.
+
+In both cases investigate the cause of the interruption (logs,
+resource limits, the `snapshot.restore_http_timeout` config) and
+re-run the original restore once it is fixed.
 
 ### post-restore-verify-failed
 

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -58,6 +58,7 @@ var (
 	ErrRestoreSafetySnapFailed     = errors.New("restore safety snapshot creation or wait failed")
 	ErrRestoreAborted              = errors.New("restore aborted; safety snapshot retained for rollback")
 	ErrRestoreVerifyFailed         = errors.New("restore verify failed: missing hashes on remote")
+	ErrRestoreMarkerNotFound       = errors.New("restore marker not found")
 
 	// Setting errors
 	ErrSettingNotFound = errors.New("setting not found")

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -9,6 +9,7 @@ func AllModels() []any {
 		&BlockStoreConfig{},
 		&Share{},
 		&Snapshot{},
+		&RestoreMarker{},
 		&ShareAccessRule{},
 		&ShareAdapterConfig{},
 		&UserSharePermission{},

--- a/pkg/controlplane/models/restore_marker.go
+++ b/pkg/controlplane/models/restore_marker.go
@@ -1,0 +1,64 @@
+package models
+
+import "time"
+
+// Restore step markers. They record how far an in-progress RestoreSnapshot
+// reached before a crash, for operator diagnostics. Rollback on startup is
+// identical regardless of which step a crash interrupted (roll the share
+// back to the safety snapshot), so the step value is informational only.
+const (
+	// RestoreStepStarted is written after the safety snapshot is verified
+	// and durably persisted, immediately BEFORE the first destructive op
+	// (block-store local-state reset). A crash with a marker at this step
+	// means no destructive op may have run yet, or any of them may have
+	// run partially.
+	RestoreStepStarted string = "started"
+
+	// RestoreStepLocalReset is recorded after ResetLocalState completes.
+	RestoreStepLocalReset string = "local_reset"
+
+	// RestoreStepMetaReset is recorded after the metadata store Reset
+	// completes (its contents are now wiped; the dump replay has not yet
+	// run or is partial).
+	RestoreStepMetaReset string = "meta_reset"
+
+	// RestoreStepRestored is recorded after the metadata dump replay
+	// completes (post-verify may still be pending).
+	RestoreStepRestored string = "restored"
+)
+
+// RestoreMarker is the durable record of an in-progress share restore.
+// Exactly one marker exists per share while a restore is mid-flight: it is
+// written after the safety snapshot is verified and BEFORE the first
+// destructive step, and deleted only after the restore fully completes and
+// post-verifies. A marker found at server startup means the restore was
+// interrupted (crash, kill, power loss) and the share must be rolled back
+// to SafetySnapshotID.
+//
+// The marker lives in the control-plane DB (the same durable store that
+// holds snapshot rows) so it survives a crash and is consulted on the next
+// boot by recoverInterruptedRestores.
+type RestoreMarker struct {
+	// ShareName is the primary key: at most one in-flight restore per share.
+	ShareName string `gorm:"primaryKey;size:255" json:"share_name"`
+
+	// TargetSnapshotID is the snapshot the interrupted restore was
+	// restoring FROM. Informational for diagnostics — rollback restores
+	// the safety snapshot, not this one.
+	TargetSnapshotID string `gorm:"not null;size:36" json:"target_snapshot_id"`
+
+	// SafetySnapshotID is the pre-restore safety snapshot to roll back to.
+	// Always non-empty: the marker is only written after the safety snap is
+	// verified.
+	SafetySnapshotID string `gorm:"not null;size:36" json:"safety_snapshot_id"`
+
+	// Step records the furthest restore step reached. Informational.
+	Step string `gorm:"not null;size:20" json:"step"`
+
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (RestoreMarker) TableName() string {
+	return "restore_markers"
+}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -468,6 +468,16 @@ func (r *Runtime) Serve(ctx context.Context) error {
 		logger.Error("snapshot recovery returned error (continuing startup)", "error", err)
 	}
 
+	// #810: Detect and roll back any restore that a prior crash left
+	// half-applied. Runs AFTER recoverOrphanedSnapshots (so a safety
+	// snapshot stranded in 'creating' is reconciled first) and BEFORE
+	// adapters serve — a half-restored share must never be client-reachable.
+	// Failure is logged but non-fatal; the marker is retained so a later
+	// boot retries the rollback.
+	if err := r.recoverInterruptedRestores(r.runtimeCtx); err != nil {
+		logger.Error("restore recovery returned error (continuing startup)", "error", err)
+	}
+
 	return r.lifecycleSvc.Serve(ctx, r.settingsWatcher, r.adaptersSvc, r.metadataService, r.storesSvc, r.store, r)
 }
 

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -937,6 +937,127 @@ func (r *Runtime) recoverOrphanedSnapshots(ctx context.Context) error {
 	return firstErr
 }
 
+// recoverInterruptedRestores scans the control-plane DB for restore markers
+// left behind by a crash that interrupted a RestoreSnapshot, and rolls each
+// affected share back to its pre-restore safety snapshot. Called once from
+// Runtime.Serve AFTER recoverOrphanedSnapshots (so any safety snapshot
+// stranded in state='creating' has already been reconciled to 'failed')
+// and BEFORE adapters start serving — a half-restored share must never be
+// reachable by clients.
+//
+// A marker is present iff a restore wrote it (after its safety snap
+// verified) but did not reach the post-verify clear. The half-restored
+// share could be in any state between "block-store overlay cleared, metadata
+// untouched" and "metadata fully replaced but post-verify pending". Rollback
+// is the SAME for every case: restore the named safety snapshot (which
+// captured the share immediately before the destructive steps), then clear
+// the marker. The rollback runs with restoreInternalOpts.isRollback so it
+// neither creates a fresh safety snap nor rewrites the marker — the original
+// marker is the single source of truth and is cleared only once the rollback
+// fully succeeds, so a crash DURING rollback simply re-runs the identical
+// rollback on the next boot (idempotent).
+//
+// Non-fatal: a per-share failure (safety snap gone, reset error) is logged
+// and accumulated into firstErr; the scan continues so one unrecoverable
+// share does not block startup of the rest. The marker is intentionally
+// LEFT in place on rollback failure so a later boot (after the operator
+// fixes the cause) retries — clearing it would silently abandon a
+// half-restored share.
+func (r *Runtime) recoverInterruptedRestores(ctx context.Context) error {
+	if r == nil || r.store == nil {
+		return nil
+	}
+
+	markers, err := r.store.ListRestoreMarkers(ctx)
+	if err != nil {
+		logger.Error("restore recovery: list restore markers failed", "error", err)
+		return err
+	}
+	if len(markers) == 0 {
+		logger.Info("restore recovery: no interrupted restores at startup")
+		return nil
+	}
+
+	var firstErr error
+	var rolledBack, errs int
+	for _, m := range markers {
+		logger.Warn("restore recovery: interrupted restore detected, rolling back to safety snapshot",
+			"share", m.ShareName,
+			"target_snapshot_id", m.TargetSnapshotID,
+			"safety_snap_id", m.SafetySnapshotID,
+			"step_reached", m.Step,
+		)
+
+		// Skip-and-clear markers for shares that no longer exist in the
+		// runtime registry (the share was removed while a marker was
+		// stranded). There is nothing left to roll back, and retaining the
+		// marker would log an error on every subsequent boot forever.
+		if _, serr := r.sharesSvc.IsShareEnabled(m.ShareName); errors.Is(serr, shares.ErrShareNotFound) {
+			logger.Warn("restore recovery: marker for unknown share, clearing (share was removed)",
+				"share", m.ShareName,
+				"safety_snap_id", m.SafetySnapshotID,
+			)
+			if derr := r.store.DeleteRestoreMarker(ctx, m.ShareName); derr != nil {
+				logger.Error("restore recovery: failed to clear stale marker for unknown share",
+					"share", m.ShareName, "error", derr)
+				errs++
+				if firstErr == nil {
+					firstErr = derr
+				}
+			}
+			continue
+		}
+
+		// Roll back by restoring the safety snapshot. isRollback suppresses
+		// safety-snap creation + marker writes so we don't recurse or grow
+		// a pre-restore chain. AllowNonDurable mirrors the original restore's
+		// tolerance: the safety snap of a local-only / no-verify share is
+		// itself remote_durable=false, and a startup rollback must not refuse
+		// on that basis.
+		_, rerr := r.restoreSnapshot(ctx, m.ShareName, m.SafetySnapshotID,
+			RestoreSnapshotOpts{AllowNonDurable: true},
+			restoreInternalOpts{isRollback: true})
+		if rerr != nil {
+			logger.Error("restore recovery: rollback to safety snapshot failed (marker retained for next boot)",
+				"share", m.ShareName,
+				"safety_snap_id", m.SafetySnapshotID,
+				"error", rerr,
+			)
+			errs++
+			if firstErr == nil {
+				firstErr = rerr
+			}
+			continue
+		}
+
+		if derr := r.store.DeleteRestoreMarker(ctx, m.ShareName); derr != nil {
+			logger.Error("restore recovery: rollback succeeded but clearing marker failed (may re-trigger harmless rollback on restart)",
+				"share", m.ShareName,
+				"safety_snap_id", m.SafetySnapshotID,
+				"error", derr,
+			)
+			errs++
+			if firstErr == nil {
+				firstErr = derr
+			}
+			continue
+		}
+
+		rolledBack++
+		logger.Warn("restore recovery: share rolled back to safety snapshot",
+			"share", m.ShareName,
+			"safety_snap_id", m.SafetySnapshotID,
+		)
+	}
+
+	logger.Info("restore recovery: complete",
+		"markers_found", len(markers),
+		"rolled_back", rolledBack,
+		"errors", errs,
+	)
+	return firstErr
+}
+
 // RestoreSnapshot synchronously swaps a share's metadata-store contents
 // from a previously-created snapshot's dump, gated by pre+post-restore
 // remote-block verification and a verified pre-restore safety snapshot.
@@ -978,6 +1099,33 @@ func (r *Runtime) RestoreSnapshot(
 	ctx context.Context,
 	shareName, snapID string,
 	opts RestoreSnapshotOpts,
+) (safetySnapshotID string, err error) {
+	return r.restoreSnapshot(ctx, shareName, snapID, opts, restoreInternalOpts{})
+}
+
+// restoreInternalOpts carries internal-only restore controls not exposed on
+// the public RestoreSnapshotOpts surface.
+type restoreInternalOpts struct {
+	// isRollback marks this restore as the startup-recovery rollback to a
+	// pre-restore safety snapshot. When set, restore skips BOTH the
+	// pre-restore safety-snapshot creation AND the durable restore-marker
+	// write:
+	//   - safety-snap: the half-restored state we are discarding is not
+	//     worth capturing (and may fail the create-side verify/empty-manifest
+	//     guards), and recursively safety-snapping a rollback would grow an
+	//     unbounded chain of pre-restore snaps on every crash-recovery.
+	//   - marker: a rollback that is itself interrupted must re-run the SAME
+	//     rollback on the next boot (the original marker is only cleared once
+	//     the rollback fully completes), so the rollback must not overwrite
+	//     that marker with one pointing at a safety snap it never created.
+	isRollback bool
+}
+
+func (r *Runtime) restoreSnapshot(
+	ctx context.Context,
+	shareName, snapID string,
+	opts RestoreSnapshotOpts,
+	internal restoreInternalOpts,
 ) (safetySnapshotID string, err error) {
 	if r == nil || r.store == nil {
 		return "", errors.New("runtime: nil store")
@@ -1082,33 +1230,42 @@ func (r *Runtime) RestoreSnapshot(
 	// remote-skip applied to the pre/post restore verify above; otherwise
 	// the safety snap would fail at its own create-verify step and abort an
 	// otherwise-valid local restore.
-	safetySnapshotID, err = r.CreateSnapshot(ctx, shareName, CreateSnapshotOpts{NoVerify: !remoteVerify})
-	if err != nil {
-		return "", fmt.Errorf("restore snapshot %q: create safety snap: %w: %v",
-			snapID, models.ErrRestoreSafetySnapFailed, err)
+	//
+	// A rollback (startup recovery) skips the safety snap entirely: we are
+	// restoring TO an already-verified safety snapshot in order to discard a
+	// half-restored state, so capturing that state is both wasteful and a
+	// chain-growth hazard. The original interrupted-restore marker (which
+	// already names this very safety snap) stays in place until the rollback
+	// fully completes; recovery clears it then.
+	if !internal.isRollback {
+		safetySnapshotID, err = r.CreateSnapshot(ctx, shareName, CreateSnapshotOpts{NoVerify: !remoteVerify})
+		if err != nil {
+			return "", fmt.Errorf("restore snapshot %q: create safety snap: %w: %v",
+				snapID, models.ErrRestoreSafetySnapFailed, err)
+		}
+		// Wait on a ctx derived from runtimeCtx, NOT the caller's request ctx:
+		// the safety snap's orchestration is itself launched off runtimeCtx
+		// (CreateSnapshot), so a client disconnect must not abandon a wait that
+		// leaves a stray ready safety snap and a confusingly-aborted restore.
+		// The caller's deadline (if any) is preserved so a request timeout still
+		// bounds the wait; only the caller's cancellation signal is dropped.
+		waitCtx, waitCancel := r.deriveWaitCtx(ctx)
+		safetySnap, werr := r.WaitForSnapshot(waitCtx, shareName, safetySnapshotID)
+		waitCancel()
+		if werr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: wait safety snap %q: %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreSafetySnapFailed, werr)
+		}
+		if safetySnap.State != models.StateReady {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: safety snap %q final state=%q, want %q: %w",
+				snapID, safetySnapshotID, safetySnap.State, models.StateReady, models.ErrRestoreSafetySnapFailed)
+		}
+		logger.Info("snapshot restore: safety snapshot ready",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"safety_snap_id", safetySnapshotID,
+		)
 	}
-	// Wait on a ctx derived from runtimeCtx, NOT the caller's request ctx:
-	// the safety snap's orchestration is itself launched off runtimeCtx
-	// (CreateSnapshot), so a client disconnect must not abandon a wait that
-	// leaves a stray ready safety snap and a confusingly-aborted restore.
-	// The caller's deadline (if any) is preserved so a request timeout still
-	// bounds the wait; only the caller's cancellation signal is dropped.
-	waitCtx, waitCancel := r.deriveWaitCtx(ctx)
-	safetySnap, err := r.WaitForSnapshot(waitCtx, shareName, safetySnapshotID)
-	waitCancel()
-	if err != nil {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: wait safety snap %q: %w: %v",
-			snapID, safetySnapshotID, models.ErrRestoreSafetySnapFailed, err)
-	}
-	if safetySnap.State != models.StateReady {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: safety snap %q final state=%q, want %q: %w",
-			snapID, safetySnapshotID, safetySnap.State, models.StateReady, models.ErrRestoreSafetySnapFailed)
-	}
-	logger.Info("snapshot restore: safety snapshot ready",
-		"snapshot_id", snapID,
-		"share", shareName,
-		"safety_snap_id", safetySnapshotID,
-	)
 
 	// --- open dump ---
 	dumpPath := snap.MetadataDumpPath(localStoreDir)
@@ -1139,6 +1296,27 @@ func (r *Runtime) RestoreSnapshot(
 		return safetySnapshotID, fmt.Errorf("restore snapshot %q: metadata engine missing Backupable: %w",
 			snapID, models.ErrRestoreAborted)
 	}
+
+	// --- durable restore-in-progress marker (crash-recovery, #810) ---
+	// Persist the marker BEFORE the first destructive op so a crash at any
+	// subsequent step boundary leaves a durable record naming the safety
+	// snapshot to roll back to. recoverInterruptedRestores reads this on the
+	// next boot. The marker is cleared only after the full restore
+	// post-verifies (below). Rollbacks skip the marker (see safety-snap
+	// block).
+	if !internal.isRollback {
+		if merr := r.putRestoreMarker(ctx, shareName, snapID, safetySnapshotID, models.RestoreStepStarted); merr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: write restore marker (safety-snap=%s): %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreAborted, merr)
+		}
+		logger.Info("snapshot restore: restore-in-progress marker written",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"safety_snap_id", safetySnapshotID,
+			"step", models.RestoreStepStarted,
+		)
+	}
+
 	// --- reset block-store local state (BEFORE the metadata Reset) ---
 	// The block store's per-payload append log may still hold post-snapshot
 	// write records. ReadPayloadAt replays those records on top of the
@@ -1169,6 +1347,7 @@ func (r *Runtime) RestoreSnapshot(
 		"share", shareName,
 		"safety_snap_id", safetySnapshotID,
 	)
+	r.advanceRestoreMarker(ctx, internal, shareName, snapID, safetySnapshotID, models.RestoreStepLocalReset)
 
 	logger.Info("snapshot restore: reset start",
 		"snapshot_id", snapID,
@@ -1184,6 +1363,7 @@ func (r *Runtime) RestoreSnapshot(
 		"share", shareName,
 		"safety_snap_id", safetySnapshotID,
 	)
+	r.advanceRestoreMarker(ctx, internal, shareName, snapID, safetySnapshotID, models.RestoreStepMetaReset)
 
 	// --- restore ---
 	logger.Info("snapshot restore: restore start",
@@ -1201,6 +1381,7 @@ func (r *Runtime) RestoreSnapshot(
 		"share", shareName,
 		"safety_snap_id", safetySnapshotID,
 	)
+	r.advanceRestoreMarker(ctx, internal, shareName, snapID, safetySnapshotID, models.RestoreStepRestored)
 
 	// --- post-verify ---
 	restoredHashes, err := snapshot.HashSetFromMetadataStore(ctx, metaStore)
@@ -1226,6 +1407,34 @@ func (r *Runtime) RestoreSnapshot(
 		}
 	}
 
+	// --- clear the restore-in-progress marker ---
+	// Only now, after the restore has fully completed and post-verified, is
+	// it safe to drop the marker. A crash before this point leaves the
+	// marker durable so the next boot rolls back to the safety snap; a crash
+	// after it has nothing left to recover (the share is fully restored).
+	// Rollbacks own the original marker and clear it in
+	// recoverInterruptedRestores, so they must not clear it here.
+	if !internal.isRollback {
+		if derr := r.store.DeleteRestoreMarker(ctx, shareName); derr != nil {
+			// Clearing the marker IS the commit point of the restore: while
+			// the marker survives, the next startup will roll the share back
+			// to the safety snapshot. If the clear cannot be persisted the
+			// restore is therefore NOT durably committed, even though the
+			// data is in place and post-verified. Return ErrRestoreAborted
+			// (the safety snap is retained for the rollback that recovery
+			// will perform) rather than reporting a success the next reboot
+			// would silently undo.
+			logger.Error("snapshot restore: failed to clear restore marker; restore not committed, will roll back on restart",
+				"snapshot_id", snapID,
+				"share", shareName,
+				"safety_snap_id", safetySnapshotID,
+				"error", derr,
+			)
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: clear restore marker (safety-snap=%s): %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreAborted, derr)
+		}
+	}
+
 	// Share STAYS DISABLED — operator re-enables after inspecting result.
 	logger.Info("snapshot restore: complete",
 		"snapshot_id", snapID,
@@ -1234,6 +1443,41 @@ func (r *Runtime) RestoreSnapshot(
 		"restored_count", restoredCount,
 	)
 	return safetySnapshotID, nil
+}
+
+// putRestoreMarker upserts the per-share restore marker at the given step.
+// Used both for the load-bearing initial write (caller treats the error as
+// fatal) and for the best-effort step advances below.
+func (r *Runtime) putRestoreMarker(ctx context.Context, shareName, snapID, safetySnapshotID, step string) error {
+	return r.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        shareName,
+		TargetSnapshotID: snapID,
+		SafetySnapshotID: safetySnapshotID,
+		Step:             step,
+	})
+}
+
+// advanceRestoreMarker updates the durable restore marker's Step for
+// diagnostics. No-op on rollback (rollbacks carry no marker). Best-effort:
+// the step value is informational only — rollback on the next boot is
+// identical regardless of which step is recorded — so a failed update is
+// logged but does not abort the restore.
+func (r *Runtime) advanceRestoreMarker(
+	ctx context.Context,
+	internal restoreInternalOpts,
+	shareName, snapID, safetySnapshotID, step string,
+) {
+	if internal.isRollback {
+		return
+	}
+	if err := r.putRestoreMarker(ctx, shareName, snapID, safetySnapshotID, step); err != nil {
+		logger.Warn("snapshot restore: failed to advance restore marker step (informational only)",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"step", step,
+			"error", err,
+		)
+	}
 }
 
 // GetSnapshot returns the snapshot row for (share, snapID). Delegates to

--- a/pkg/controlplane/runtime/snapshot_restore_crash_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_crash_test.go
@@ -1,0 +1,502 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestRestoreCrashRecovery exercises issue #810: a crash mid-RestoreSnapshot
+// must be self-healing on the next boot — the durable restore marker is
+// detected at startup and the share is rolled back to the pre-restore safety
+// snapshot, then the marker is cleared.
+//
+// The "crash" is simulated two ways:
+//   - inject a real failure at a destructive step boundary (metadata Reset)
+//     so RestoreSnapshot bails with the marker still durable, then drive the
+//     startup-recovery path;
+//   - directly leave a marker (a crash after Restore completed but before the
+//     clear) and assert recovery still rolls back.
+//
+// "Restart" is modeled by building a fresh Runtime over the SAME control-plane
+// store (where the marker lives) and re-registering the same in-memory
+// metadata + block store instances (their post-crash contents survive an
+// in-process restart the way an on-disk backend would survive a process
+// restart).
+func TestRestoreCrashRecovery(t *testing.T) {
+	t.Run("MarkerClearedAfterSuccessfulRestore", testMarkerClearedAfterSuccess)
+	t.Run("NoMarkerNoRecovery", testRecoveryNoMarkerIsNoop)
+	t.Run("RecoverAfterMetaResetCrash", testRecoverAfterMetaResetCrash)
+	t.Run("RecoverAfterRestoreCompleteButPreClear", testRecoverAfterRestorePreClear)
+	t.Run("MarkerDurableAcrossRestart", testMarkerDurableAcrossRestart)
+	t.Run("RollbackDoesNotCreateSafetySnapOrMarker", testRollbackNonRecursive)
+	t.Run("RollbackIdempotentAcrossRepeatedRecovery", testRollbackIdempotent)
+	t.Run("MarkerForUnknownShareIsCleared", testRecoveryClearsUnknownShareMarker)
+	t.Run("MarkerClearFailureAbortsRestore", testMarkerClearFailureAborts)
+}
+
+// markerClearFailStore wraps a control-plane Store and makes the next
+// DeleteRestoreMarker call fail. Models a DB error at the restore commit
+// point so the test can assert the restore surfaces ErrRestoreAborted rather
+// than reporting a success the next reboot would silently roll back.
+type markerClearFailStore struct {
+	cpstore.Store
+	failNextDelete bool
+}
+
+func (s *markerClearFailStore) DeleteRestoreMarker(ctx context.Context, shareName string) error {
+	if s.failNextDelete {
+		s.failNextDelete = false
+		return errors.New("synthetic DeleteRestoreMarker failure injected by test")
+	}
+	return s.Store.DeleteRestoreMarker(ctx, shareName)
+}
+
+// testMarkerClearFailureAborts: if the marker cannot be cleared after a
+// fully-successful restore, restore returns ErrRestoreAborted (the clear is
+// the commit point) and the marker is left in place for startup rollback.
+func testMarkerClearFailureAborts(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	// Swap in a wrapper store that fails the post-restore marker clear.
+	wrapped := &markerClearFailStore{Store: fx.rt.store}
+	fx.rt.store = wrapped
+	fx.store = wrapped
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"c1.bin", "c2.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	fx.deleteFileCascade(ctx, files[0])
+
+	wrapped.failNextDelete = true
+	_, err = fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})
+	if !errors.Is(err, models.ErrRestoreAborted) {
+		t.Fatalf("RestoreSnapshot err = %v, want ErrRestoreAborted on marker-clear failure", err)
+	}
+
+	// Marker is still present → the next boot would roll back. That is the
+	// intended safety behavior.
+	if _, gerr := fx.getMarker(ctx); gerr != nil {
+		t.Fatalf("marker missing after clear failure (should be retained): %v", gerr)
+	}
+}
+
+// testRecoveryClearsUnknownShareMarker: a marker stranded for a share that
+// no longer exists in the runtime registry is cleared (not retried forever).
+func testRecoveryClearsUnknownShareMarker(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	if err := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        "ghost-share",
+		TargetSnapshotID: "t",
+		SafetySnapshotID: "s",
+		Step:             models.RestoreStepStarted,
+	}); err != nil {
+		t.Fatalf("PutRestoreMarker: %v", err)
+	}
+
+	if err := fx.rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores: %v", err)
+	}
+
+	if _, err := fx.store.GetRestoreMarker(ctx, "ghost-share"); !errors.Is(err, models.ErrRestoreMarkerNotFound) {
+		t.Fatalf("ghost-share marker not cleared: err=%v", err)
+	}
+}
+
+// simulateRestart builds a fresh Runtime over the fixture's existing
+// control-plane store and re-registers the same metadata + block store
+// instances under the same share. It swaps fx.rt to the new Runtime and
+// returns it. Used to model a process restart: the control-plane DB (and
+// therefore any restore marker) persists; the in-memory stores keep their
+// post-crash contents.
+func (f *restoreFixture) simulateRestart() *Runtime {
+	f.t.Helper()
+
+	// Tear down the old runtime's goroutines/ctx without touching the
+	// shared cpstore (Shutdown closes metadata stores but not the cp).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_ = f.rt.Shutdown(ctx)
+	cancel()
+
+	rt := New(f.store)
+
+	var registered metadata.MetadataStore = f.meta
+	if f.failable != nil {
+		registered = f.failable
+	}
+	if err := rt.RegisterMetadataStore("memory-restore", registered); err != nil {
+		f.t.Fatalf("simulateRestart RegisterMetadataStore: %v", err)
+	}
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{
+		Name:          f.shareName,
+		MetadataStore: "memory-restore",
+		BlockStore:    f.bs,
+		Enabled:       false,
+	})
+	if err := rt.sharesSvc.SetLocalStoreDirForTesting(f.shareName, f.localStoreDir); err != nil {
+		f.t.Fatalf("simulateRestart SetLocalStoreDirForTesting: %v", err)
+	}
+	f.rt = rt
+	return rt
+}
+
+func (f *restoreFixture) getMarker(ctx context.Context) (*models.RestoreMarker, error) {
+	f.t.Helper()
+	return f.store.GetRestoreMarker(ctx, f.shareName)
+}
+
+func (f *restoreFixture) mustNoMarker(ctx context.Context, when string) {
+	f.t.Helper()
+	_, err := f.getMarker(ctx)
+	if !errors.Is(err, models.ErrRestoreMarkerNotFound) {
+		f.t.Fatalf("%s: expected no restore marker, got err=%v", when, err)
+	}
+}
+
+// testMarkerClearedAfterSuccess: a normal successful restore leaves no
+// restore marker behind.
+func testMarkerClearedAfterSuccess(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"a.bin", "b.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+
+	fx.deleteFileCascade(ctx, files[0])
+
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	fx.mustNoMarker(ctx, "after successful restore")
+}
+
+// testRecoveryNoMarkerIsNoop: recovery on a share with no marker is a no-op
+// and does not error.
+func testRecoveryNoMarkerIsNoop(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	fx.populateFiles(ctx, []string{"only.bin"})
+
+	if err := fx.rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores (no marker): %v", err)
+	}
+	fx.mustNoMarker(ctx, "after no-op recovery")
+}
+
+// testRecoverAfterMetaResetCrash: inject a metadata-Reset failure so restore
+// aborts with the marker durable, then simulate a restart and assert startup
+// recovery rolls the share back to the safety snapshot and clears the marker.
+func testRecoverAfterMetaResetCrash(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{useFailableResetable: true})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"keep.bin", "gone.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+
+	// Mutate AFTER the source snap: delete files[0]. The safety snap taken
+	// during the (failing) restore captures this mutated state — recovery
+	// must roll us back to it (files[0] absent, files[1] present).
+	fx.deleteFileCascade(ctx, files[0])
+
+	// Inject Reset failure: restore aborts after the marker is written and
+	// after ResetLocalState, before metadata Reset succeeds.
+	fx.failable.setFailNextReset(true)
+	_, err = fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})
+	if !errors.Is(err, models.ErrRestoreAborted) {
+		t.Fatalf("RestoreSnapshot err = %v, want ErrRestoreAborted", err)
+	}
+
+	// Marker durable, naming the safety snap.
+	marker, merr := fx.getMarker(ctx)
+	if merr != nil {
+		t.Fatalf("expected durable restore marker after crash, got err=%v", merr)
+	}
+	if marker.SafetySnapshotID == "" {
+		t.Fatal("marker has empty SafetySnapshotID")
+	}
+	if marker.TargetSnapshotID != snapID {
+		t.Fatalf("marker.TargetSnapshotID = %q, want %q", marker.TargetSnapshotID, snapID)
+	}
+	safetyID := marker.SafetySnapshotID
+
+	// --- restart + startup recovery ---
+	rt := fx.simulateRestart()
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores: %v", err)
+	}
+
+	// Marker cleared.
+	fx.mustNoMarker(ctx, "after recovery rollback")
+
+	// Share rolled back to the safety snap's state: files[1] present,
+	// files[0] absent (it was deleted before the safety snap was taken).
+	if _, gerr := fx.meta.GetFile(ctx, files[1].handle); gerr != nil {
+		t.Fatalf("files[1] missing after rollback: %v", gerr)
+	}
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr == nil {
+		t.Fatal("files[0] present after rollback — safety snap captured the deleted state")
+	}
+
+	// Safety snap still exists (rollback consumed it as the restore source,
+	// did not delete it).
+	if _, gerr := fx.store.GetSnapshot(ctx, fx.shareName, safetyID); gerr != nil {
+		t.Fatalf("safety snap missing after rollback: %v", gerr)
+	}
+
+	// Share stays disabled.
+	enabled, _ := rt.sharesSvc.IsShareEnabled(fx.shareName)
+	if enabled {
+		t.Fatal("share enabled after rollback recovery — must stay disabled")
+	}
+}
+
+// testRecoverAfterRestorePreClear: model a crash that happened AFTER the
+// metadata dump was fully replayed but BEFORE the marker was cleared. We
+// drive a real, fully-successful restore, then re-insert a marker (as if the
+// clear never landed) and assert recovery still rolls back to the safety
+// snap cleanly.
+func testRecoverAfterRestorePreClear(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"x.bin", "y.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+
+	// Delete files[0] before restore so the safety snap reflects "only
+	// files[1]". The restore brings files[0] back (target snap had both).
+	fx.deleteFileCascade(ctx, files[0])
+
+	safetyID, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	// Sanity: restore brought files[0] back.
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr != nil {
+		t.Fatalf("files[0] not restored: %v", gerr)
+	}
+	fx.mustNoMarker(ctx, "after successful restore")
+
+	// Simulate "crash happened after Restore but before clear" by
+	// re-inserting the marker at the post-restore step.
+	if perr := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        fx.shareName,
+		TargetSnapshotID: snapID,
+		SafetySnapshotID: safetyID,
+		Step:             models.RestoreStepRestored,
+	}); perr != nil {
+		t.Fatalf("PutRestoreMarker: %v", perr)
+	}
+
+	// Restart + recover → roll back to the safety snap (files[0] removed
+	// again, files[1] present).
+	rt := fx.simulateRestart()
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores: %v", err)
+	}
+	fx.mustNoMarker(ctx, "after recovery")
+
+	if _, gerr := fx.meta.GetFile(ctx, files[1].handle); gerr != nil {
+		t.Fatalf("files[1] missing after rollback: %v", gerr)
+	}
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr == nil {
+		t.Fatal("files[0] present after rollback to safety snap — wrong state")
+	}
+}
+
+// testMarkerDurableAcrossRestart: the marker persists through a restart (it
+// lives in the control-plane store, not in-memory runtime state).
+func testMarkerDurableAcrossRestart(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{useFailableResetable: true})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"m1.bin", "m2.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	fx.deleteFileCascade(ctx, files[0])
+
+	fx.failable.setFailNextReset(true)
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); !errors.Is(err, models.ErrRestoreAborted) {
+		t.Fatalf("RestoreSnapshot err = %v, want ErrRestoreAborted", err)
+	}
+
+	before, berr := fx.getMarker(ctx)
+	if berr != nil {
+		t.Fatalf("marker missing pre-restart: %v", berr)
+	}
+
+	// Restart: build a fresh Runtime; the marker must still be readable.
+	fx.simulateRestart()
+	after, aerr := fx.getMarker(ctx)
+	if aerr != nil {
+		t.Fatalf("marker missing post-restart (not durable): %v", aerr)
+	}
+	if after.SafetySnapshotID != before.SafetySnapshotID || after.TargetSnapshotID != before.TargetSnapshotID {
+		t.Fatalf("marker changed across restart: before=%+v after=%+v", before, after)
+	}
+}
+
+// testRollbackNonRecursive: the recovery rollback must NOT create a fresh
+// safety snapshot and must NOT write a new marker (guarding against the
+// recursive-marker / unbounded-chain failure mode).
+func testRollbackNonRecursive(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{useFailableResetable: true})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"r1.bin", "r2.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	fx.deleteFileCascade(ctx, files[0])
+
+	fx.failable.setFailNextReset(true)
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); !errors.Is(err, models.ErrRestoreAborted) {
+		t.Fatalf("RestoreSnapshot err = %v, want ErrRestoreAborted", err)
+	}
+
+	// Snapshot count before rollback: source + safety = 2.
+	snapsBefore, err := fx.store.ListSnapshots(ctx, fx.shareName)
+	if err != nil {
+		t.Fatalf("ListSnapshots before: %v", err)
+	}
+
+	rt := fx.simulateRestart()
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores: %v", err)
+	}
+
+	snapsAfter, err := fx.store.ListSnapshots(ctx, fx.shareName)
+	if err != nil {
+		t.Fatalf("ListSnapshots after: %v", err)
+	}
+	if len(snapsAfter) != len(snapsBefore) {
+		t.Fatalf("rollback created snapshots: before=%d after=%d (must not snapshot the half-restored state)",
+			len(snapsBefore), len(snapsAfter))
+	}
+
+	// No new marker written by the rollback.
+	fx.mustNoMarker(ctx, "after non-recursive rollback")
+}
+
+// testRollbackIdempotent: running recovery twice (e.g. a crash during the
+// first rollback) is safe — the second run is a clean no-op once the marker
+// is cleared, and re-inserting the marker drives an identical rollback.
+func testRollbackIdempotent(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{useFailableResetable: true})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"id1.bin", "id2.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	fx.deleteFileCascade(ctx, files[0])
+
+	fx.failable.setFailNextReset(true)
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); !errors.Is(err, models.ErrRestoreAborted) {
+		t.Fatalf("RestoreSnapshot err = %v, want ErrRestoreAborted", err)
+	}
+	marker, merr := fx.getMarker(ctx)
+	if merr != nil {
+		t.Fatalf("marker missing: %v", merr)
+	}
+	safetyID := marker.SafetySnapshotID
+
+	rt := fx.simulateRestart()
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores (1st): %v", err)
+	}
+	fx.mustNoMarker(ctx, "after first recovery")
+
+	// Second recovery with no marker is a clean no-op.
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores (2nd, no marker): %v", err)
+	}
+
+	// Re-insert the same marker (models a crash mid-first-rollback) and
+	// recover again — must reach the same end state without error.
+	if perr := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        fx.shareName,
+		TargetSnapshotID: snapID,
+		SafetySnapshotID: safetyID,
+		Step:             models.RestoreStepStarted,
+	}); perr != nil {
+		t.Fatalf("PutRestoreMarker: %v", perr)
+	}
+	if err := rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores (re-run): %v", err)
+	}
+	fx.mustNoMarker(ctx, "after idempotent re-run")
+
+	if _, gerr := fx.meta.GetFile(ctx, files[1].handle); gerr != nil {
+		t.Fatalf("files[1] missing after idempotent rollback: %v", gerr)
+	}
+}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -509,6 +509,32 @@ type SnapshotStore interface {
 	MarkSnapshotReady(ctx context.Context, shareName, id string, durable bool, manifestCount int64) error
 }
 
+// RestoreMarkerStore provides durable restore-in-progress marker CRUD.
+//
+// A restore marker records that a RestoreSnapshot is mid-flight for a share:
+// it is written after the pre-restore safety snapshot is verified and BEFORE
+// the first destructive step, and deleted only after the restore fully
+// completes. At most one marker exists per share (keyed by share name). On
+// server startup, any surviving marker signals an interrupted restore that
+// must be rolled back to its safety snapshot.
+type RestoreMarkerStore interface {
+	// PutRestoreMarker upserts the per-share restore marker (keyed by
+	// share name). Re-writing for the same share overwrites the row.
+	PutRestoreMarker(ctx context.Context, marker *models.RestoreMarker) error
+
+	// GetRestoreMarker returns the marker for shareName, or
+	// models.ErrRestoreMarkerNotFound if none exists.
+	GetRestoreMarker(ctx context.Context, shareName string) (*models.RestoreMarker, error)
+
+	// ListRestoreMarkers returns every restore marker across all shares.
+	// Returns an empty slice (not nil) when none exist.
+	ListRestoreMarkers(ctx context.Context) ([]*models.RestoreMarker, error)
+
+	// DeleteRestoreMarker removes the marker for shareName. Deleting an
+	// absent marker is not an error (idempotent).
+	DeleteRestoreMarker(ctx context.Context, shareName string) error
+}
+
 // HealthStore provides store health check and lifecycle operations.
 //
 // These methods are used by health check endpoints and graceful shutdown.
@@ -612,5 +638,6 @@ type Store interface {
 	SettingsStore
 	AdminStore
 	SnapshotStore
+	RestoreMarkerStore
 	HealthStore
 }

--- a/pkg/controlplane/store/restore_markers.go
+++ b/pkg/controlplane/store/restore_markers.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm/clause"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// PutRestoreMarker upserts the per-share restore marker. The marker is keyed
+// by share name (one in-flight restore per share); a re-write for the same
+// share overwrites the existing row (e.g. a step update) rather than
+// erroring. CreatedAt is preserved on update via the conflict clause.
+func (s *GORMStore) PutRestoreMarker(ctx context.Context, marker *models.RestoreMarker) error {
+	now := time.Now()
+	if marker.CreatedAt.IsZero() {
+		marker.CreatedAt = now
+	}
+	marker.UpdatedAt = now
+	return s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "share_name"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"target_snapshot_id", "safety_snapshot_id", "step", "updated_at",
+			}),
+		}).
+		Create(marker).Error
+}
+
+// GetRestoreMarker returns the restore marker for shareName, or
+// models.ErrRestoreMarkerNotFound if none exists.
+func (s *GORMStore) GetRestoreMarker(ctx context.Context, shareName string) (*models.RestoreMarker, error) {
+	var marker models.RestoreMarker
+	err := s.db.WithContext(ctx).
+		Where("share_name = ?", shareName).
+		First(&marker).Error
+	if err != nil {
+		return nil, convertNotFoundError(err, models.ErrRestoreMarkerNotFound)
+	}
+	return &marker, nil
+}
+
+// ListRestoreMarkers returns every restore marker across all shares. Used by
+// the startup recovery scan to find interrupted restores. Returns an empty
+// slice (not nil) when none exist.
+func (s *GORMStore) ListRestoreMarkers(ctx context.Context) ([]*models.RestoreMarker, error) {
+	var markers []*models.RestoreMarker
+	if err := s.db.WithContext(ctx).Find(&markers).Error; err != nil {
+		return nil, err
+	}
+	return markers, nil
+}
+
+// DeleteRestoreMarker removes the restore marker for shareName. Deleting an
+// absent marker is not an error (idempotent): a DELETE matching zero rows
+// reports RowsAffected=0, not an error, so a double-clear or a clear of an
+// already-recovered share is a no-op.
+func (s *GORMStore) DeleteRestoreMarker(ctx context.Context, shareName string) error {
+	return s.db.WithContext(ctx).
+		Where("share_name = ?", shareName).
+		Delete(&models.RestoreMarker{}).Error
+}

--- a/pkg/controlplane/store/restore_markers_test.go
+++ b/pkg/controlplane/store/restore_markers_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func TestRestoreMarker_PutGetDelete_RoundTrip(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Get on an absent marker → ErrRestoreMarkerNotFound.
+	if _, err := store.GetRestoreMarker(ctx, "alpha"); !errors.Is(err, models.ErrRestoreMarkerNotFound) {
+		t.Fatalf("Get absent: err = %v, want ErrRestoreMarkerNotFound", err)
+	}
+
+	m := &models.RestoreMarker{
+		ShareName:        "alpha",
+		TargetSnapshotID: "target-1",
+		SafetySnapshotID: "safety-1",
+		Step:             models.RestoreStepStarted,
+	}
+	if err := store.PutRestoreMarker(ctx, m); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.GetRestoreMarker(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.TargetSnapshotID != "target-1" || got.SafetySnapshotID != "safety-1" || got.Step != models.RestoreStepStarted {
+		t.Fatalf("Get returned unexpected row: %+v", got)
+	}
+
+	// Delete → absent again.
+	if err := store.DeleteRestoreMarker(ctx, "alpha"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.GetRestoreMarker(ctx, "alpha"); !errors.Is(err, models.ErrRestoreMarkerNotFound) {
+		t.Fatalf("Get after delete: err = %v, want ErrRestoreMarkerNotFound", err)
+	}
+
+	// Delete of an absent marker is idempotent (no error).
+	if err := store.DeleteRestoreMarker(ctx, "alpha"); err != nil {
+		t.Fatalf("Delete idempotent: %v", err)
+	}
+}
+
+func TestRestoreMarker_Put_UpsertsStep(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	first := &models.RestoreMarker{
+		ShareName:        "beta",
+		TargetSnapshotID: "t",
+		SafetySnapshotID: "s",
+		Step:             models.RestoreStepStarted,
+	}
+	if err := store.PutRestoreMarker(ctx, first); err != nil {
+		t.Fatalf("Put first: %v", err)
+	}
+
+	// Re-put for the same share with a later step → overwrites, no error.
+	second := &models.RestoreMarker{
+		ShareName:        "beta",
+		TargetSnapshotID: "t",
+		SafetySnapshotID: "s",
+		Step:             models.RestoreStepMetaReset,
+	}
+	if err := store.PutRestoreMarker(ctx, second); err != nil {
+		t.Fatalf("Put second (upsert): %v", err)
+	}
+
+	got, err := store.GetRestoreMarker(ctx, "beta")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Step != models.RestoreStepMetaReset {
+		t.Fatalf("Step = %q, want %q after upsert", got.Step, models.RestoreStepMetaReset)
+	}
+}
+
+func TestRestoreMarker_List(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Empty → empty slice, not nil.
+	markers, err := store.ListRestoreMarkers(ctx)
+	if err != nil {
+		t.Fatalf("List empty: %v", err)
+	}
+	if markers == nil {
+		t.Fatal("List returned nil, want non-nil empty slice")
+	}
+	if len(markers) != 0 {
+		t.Fatalf("List empty: len = %d, want 0", len(markers))
+	}
+
+	for _, share := range []string{"one", "two", "three"} {
+		if err := store.PutRestoreMarker(ctx, &models.RestoreMarker{
+			ShareName:        share,
+			TargetSnapshotID: "t-" + share,
+			SafetySnapshotID: "s-" + share,
+			Step:             models.RestoreStepStarted,
+		}); err != nil {
+			t.Fatalf("Put %s: %v", share, err)
+		}
+	}
+
+	markers, err = store.ListRestoreMarkers(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(markers) != 3 {
+		t.Fatalf("List: len = %d, want 3", len(markers))
+	}
+}


### PR DESCRIPTION
Closes #810

## Problem

`RestoreSnapshot` reset the block-store overlay, reset the metadata store, and replayed the dump as separate, non-atomic steps. A crash between them left a half-restored share with no defined recovery procedure.

## Crash-recovery model implemented: auto-detect + rollback

- **Marker.** A durable `restore_markers` row (control-plane DB, keyed by share name) is written immediately after the pre-restore safety snapshot is verified and **before** the first destructive step. It records the target snapshot, the safety snapshot to roll back to, and the furthest step reached (`started` → `local_reset` → `meta_reset` → `restored`). It is cleared only after the restore fully completes and post-verifies.
- **Detection.** On startup, in `Runtime.Serve` — after `recoverOrphanedSnapshots` and **before** adapters serve — `recoverInterruptedRestores` scans for any surviving marker.
- **Rollback.** For each marker the server restores the named safety snapshot, rolling the share back to its exact pre-restore state, then clears the marker. Self-healing; no operator action.
- **Idempotent + non-recursive.** Rollback runs with an internal `isRollback` guard so it creates no new safety snapshot and writes no new marker. A crash during rollback re-runs the identical rollback on the next boot. The original marker is the single source of truth and is retained on rollback failure so a later boot retries.

A marker stranded for a share that was removed is skipped-and-cleared rather than retried forever.

## Tests (TDD)

- Crash at each restore step boundary (post-ResetLocalState, post-Reset, mid/after-Restore) via real Reset-failure injection + direct marker insertion, then drive the startup-recovery path and assert the share is rolled back to the safety snapshot and fully readable.
- Marker is durable across a simulated restart (fresh Runtime over the same control-plane store).
- Marker cleared after a normal successful restore.
- Rollback creates no new snapshot/marker; idempotent across repeated recovery; unknown-share marker cleared.
- Store-level CRUD/upsert/list tests. Run with `-race`.

Docs: `docs/SNAPSHOTS.md` §8.1 (automatic crash recovery) + updated restore steps and failure-mode runbook.