### PR TITLE
fix(smb/session): anonymous encryption per-connection AEAD gate (#773)

### DIFF
--- a/internal/adapter/smb/crypto_state.go
+++ b/internal/adapter/smb/crypto_state.go
@@ -79,6 +79,20 @@ type ConnectionCryptoState struct {
 	// chain initialized from the connection hash after NEGOTIATE completes.
 	// Key: session ID, Value: current preauth hash for that session.
 	sessionPreauthHashes map[uint64][64]byte
+
+	// hasAuthenticatedSession is the sticky per-connection flag mirroring
+	// Samba's xconn->smb2.got_authenticated_session (source3/smbd/
+	// smb2_sesssetup.c:282). It flips to true once a non-anonymous,
+	// non-guest session completes SESSION_SETUP on this connection and
+	// stays true for the connection's lifetime. The flag gates AEAD key
+	// derivation for subsequent anonymous (IsNull) sessions: without a
+	// prior real session, anonymous sessions must NOT derive encryption
+	// keys (smbtorture smb2.session.anon-encryption1/3 assert
+	// CONNECTION_RESET on encrypted requests in that state); with one,
+	// they MUST derive them so the client's torture
+	// anonymous_encryption flow (smb2.session.anon-encryption2) can
+	// piggyback an encrypted anonymous tcon over the same TCP.
+	hasAuthenticatedSession bool
 }
 
 // NewConnectionCryptoState creates a new ConnectionCryptoState with all
@@ -362,4 +376,28 @@ func (cs *ConnectionCryptoState) GetClientDialects() []types.Dialect {
 	cp := make([]types.Dialect, len(cs.ClientDialects))
 	copy(cp, cs.ClientDialects)
 	return cp
+}
+
+// SetHasAuthenticatedSession records that a non-anonymous, non-guest session
+// has completed SESSION_SETUP on this connection. The flag is sticky for the
+// connection's lifetime; callers only ever set it to true.
+//
+// Mirrors Samba's xconn->smb2.got_authenticated_session
+// (source3/smbd/smb2_sesssetup.c:282). Used by configureSessionSigningWithKey
+// to decide whether anonymous (IsNull) sessions should derive AEAD keys: only
+// after a real authenticated session exists on the connection — otherwise an
+// encrypted request on an anonymous session must drop the connection
+// (MS-SMB2 §3.3.5.2.1.1; smbtorture smb2.session.anon-encryption1/3).
+func (cs *ConnectionCryptoState) SetHasAuthenticatedSession() {
+	cs.mu.Lock()
+	cs.hasAuthenticatedSession = true
+	cs.mu.Unlock()
+}
+
+// HasAuthenticatedSession returns whether a non-anonymous, non-guest session
+// has completed SESSION_SETUP on this connection.
+func (cs *ConnectionCryptoState) HasAuthenticatedSession() bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.hasAuthenticatedSession
 }

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -142,13 +142,16 @@ func (m *sessionEncryptionMiddleware) DecryptRequest(transformMessage []byte) ([
 	if err != nil {
 		// Decryption failures on anonymous (IsNull) sessions are treated as
 		// catastrophic — Samba's smb2_server.c terminates the connection on
-		// any non-OK status from inbuf_parse_compound. Map to ErrNoDecryptor
+		// any non-OK status from inbuf_parse_compound. Wrap ErrNoDecryptor
 		// so the connection layer drops the TCP socket immediately
 		// (smbtorture smb2.session.anon-encryption3, where a forced-wrong
 		// client session key forces decrypt failure on the encrypted tcon).
+		// The underlying AEAD error is preserved in the chain to keep logs
+		// actionable; errors.Is(err, ErrNoDecryptor) still selects the
+		// drop-on-anon path.
 		if sess.IsNullSession() {
-			return nil, th.SessionId, fmt.Errorf("decrypt failed on anonymous session 0x%x: %w: %w",
-				th.SessionId, ErrNoDecryptor, ErrDecryptFailed)
+			return nil, th.SessionId, fmt.Errorf("decrypt failed on anonymous session 0x%x: %w: %w: %w",
+				th.SessionId, err, ErrNoDecryptor, ErrDecryptFailed)
 		}
 		return nil, th.SessionId, fmt.Errorf("decrypt message for session 0x%x: %w: %w", th.SessionId, err, ErrDecryptFailed)
 	}

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -38,6 +38,14 @@ type EncryptableSession interface {
 	EncryptorNonceSize() int
 	DecryptorNonceSize() int
 	EncryptorOverhead() int
+	// IsNullSession reports whether the session was created with anonymous
+	// NTLM credentials (SMB2_SESSION_FLAG_IS_NULL). Used by the framing
+	// layer to map any decryption failure on such a session to
+	// ErrAnonEncryption — Samba treats decrypt errors on anonymous sessions
+	// as catastrophic and drops the TCP connection (smbtorture
+	// smb2.session.anon-encryption3 with a forced-wrong client session key
+	// expects CONNECTION_RESET, not the regular 5-failures-then-drop path).
+	IsNullSession() bool
 }
 
 // EncryptionMiddleware handles transparent encryption/decryption of SMB3 messages.
@@ -132,6 +140,16 @@ func (m *sessionEncryptionMiddleware) DecryptRequest(transformMessage []byte) ([
 
 	plaintext, err := sess.DecryptMessage(nonce, ciphertextWithTag, aad)
 	if err != nil {
+		// Decryption failures on anonymous (IsNull) sessions are treated as
+		// catastrophic — Samba's smb2_server.c terminates the connection on
+		// any non-OK status from inbuf_parse_compound. Map to ErrNoDecryptor
+		// so the connection layer drops the TCP socket immediately
+		// (smbtorture smb2.session.anon-encryption3, where a forced-wrong
+		// client session key forces decrypt failure on the encrypted tcon).
+		if sess.IsNullSession() {
+			return nil, th.SessionId, fmt.Errorf("decrypt failed on anonymous session 0x%x: %w: %w",
+				th.SessionId, ErrNoDecryptor, ErrDecryptFailed)
+		}
 		return nil, th.SessionId, fmt.Errorf("decrypt message for session 0x%x: %w: %w", th.SessionId, err, ErrDecryptFailed)
 	}
 

--- a/internal/adapter/smb/encryption/middleware_test.go
+++ b/internal/adapter/smb/encryption/middleware_test.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/header"
@@ -12,6 +13,7 @@ type testSession struct {
 	encryptor   Encryptor
 	decryptor   Encryptor
 	encryptData bool
+	isNull      bool
 }
 
 func (s *testSession) ShouldEncrypt() bool {
@@ -29,7 +31,7 @@ func (s *testSession) DecryptMessage(nonce, ciphertext, aad []byte) ([]byte, err
 func (s *testSession) EncryptorNonceSize() int { return s.encryptor.NonceSize() }
 func (s *testSession) DecryptorNonceSize() int { return s.decryptor.NonceSize() }
 func (s *testSession) EncryptorOverhead() int  { return s.encryptor.Overhead() }
-func (s *testSession) IsNullSession() bool     { return false }
+func (s *testSession) IsNullSession() bool     { return s.isNull }
 
 func makeTestSession(t *testing.T, cipherId uint16) *testSession {
 	t.Helper()
@@ -180,6 +182,72 @@ func TestMiddleware_DecryptRequest_UnknownSession(t *testing.T) {
 
 	if _, _, err := mw.DecryptRequest(encoded); err == nil {
 		t.Fatal("expected error for unknown session, got nil")
+	}
+}
+
+// TestMiddleware_DecryptRequest_IsNullSession_TamperedMapsToNoDecryptor
+// asserts that a decrypt failure on a session flagged IsNull (the
+// anonymous-encryption case smbtorture smb2.session.anon-encryption3
+// drives with a forced wrong client session key) wraps ErrNoDecryptor so
+// the connection layer can drop the TCP socket immediately rather than
+// counting against the 5-failure threshold.
+func TestMiddleware_DecryptRequest_IsNullSession_TamperedMapsToNoDecryptor(t *testing.T) {
+	sessionID := uint64(0x1234)
+	sess := makeTestSession(t, types.CipherAES128GCM)
+	sess.isNull = true
+	mw := makeMiddleware(sessionID, sess)
+
+	original := []byte("test message")
+	encrypted, err := mw.EncryptResponse(sessionID, original)
+	if err != nil {
+		t.Fatalf("EncryptResponse: %v", err)
+	}
+
+	// Flip a ciphertext byte so the AEAD tag check fails.
+	if len(encrypted) > header.TransformHeaderSize+1 {
+		encrypted[header.TransformHeaderSize+1] ^= 0xFF
+	}
+
+	_, _, decErr := mw.DecryptRequest(encrypted)
+	if decErr == nil {
+		t.Fatal("expected error on tampered ciphertext, got nil")
+	}
+	if !errors.Is(decErr, ErrNoDecryptor) {
+		t.Errorf("err = %v, expected to wrap ErrNoDecryptor", decErr)
+	}
+	if !errors.Is(decErr, ErrDecryptFailed) {
+		t.Errorf("err = %v, expected to wrap ErrDecryptFailed", decErr)
+	}
+}
+
+// TestMiddleware_DecryptRequest_NonNullSession_TamperedNoAnonMap asserts
+// the IsNull error-mapping is gated on IsNullSession()==true. A normal
+// session's decrypt failure stays a regular ErrDecryptFailed so the
+// 5-failure brute-force threshold still applies.
+func TestMiddleware_DecryptRequest_NonNullSession_TamperedNoAnonMap(t *testing.T) {
+	sessionID := uint64(0x1234)
+	sess := makeTestSession(t, types.CipherAES128GCM)
+	sess.isNull = false
+	mw := makeMiddleware(sessionID, sess)
+
+	original := []byte("test message")
+	encrypted, err := mw.EncryptResponse(sessionID, original)
+	if err != nil {
+		t.Fatalf("EncryptResponse: %v", err)
+	}
+	if len(encrypted) > header.TransformHeaderSize+1 {
+		encrypted[header.TransformHeaderSize+1] ^= 0xFF
+	}
+
+	_, _, decErr := mw.DecryptRequest(encrypted)
+	if decErr == nil {
+		t.Fatal("expected error on tampered ciphertext, got nil")
+	}
+	if errors.Is(decErr, ErrNoDecryptor) {
+		t.Errorf("err = %v, must NOT wrap ErrNoDecryptor on non-null session", decErr)
+	}
+	if !errors.Is(decErr, ErrDecryptFailed) {
+		t.Errorf("err = %v, expected to wrap ErrDecryptFailed", decErr)
 	}
 }
 

--- a/internal/adapter/smb/encryption/middleware_test.go
+++ b/internal/adapter/smb/encryption/middleware_test.go
@@ -29,6 +29,7 @@ func (s *testSession) DecryptMessage(nonce, ciphertext, aad []byte) ([]byte, err
 func (s *testSession) EncryptorNonceSize() int { return s.encryptor.NonceSize() }
 func (s *testSession) DecryptorNonceSize() int { return s.decryptor.NonceSize() }
 func (s *testSession) EncryptorOverhead() int  { return s.encryptor.Overhead() }
+func (s *testSession) IsNullSession() bool     { return false }
 
 func makeTestSession(t *testing.T, cipherId uint16) *testSession {
 	t.Helper()

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -404,6 +404,14 @@ func (s *Session) EncryptorOverhead() int {
 	return s.CryptoState.Encryptor.Overhead()
 }
 
+// IsNullSession reports whether this session was created with anonymous
+// NTLM credentials (SMB2_SESSION_FLAG_IS_NULL). Mirrors Session.IsNull but
+// is exposed through the encryption.EncryptableSession interface to
+// avoid leaking the full Session type across packages.
+func (s *Session) IsNullSession() bool {
+	return s != nil && s.IsNull
+}
+
 // ShouldSign returns true if outgoing messages should be signed.
 func (s *Session) ShouldSign() bool {
 	return s.CryptoState.ShouldSign()

--- a/internal/adapter/smb/v2/handlers/context.go
+++ b/internal/adapter/smb/v2/handlers/context.go
@@ -74,6 +74,16 @@ type CryptoState interface {
 	DeleteSessionPreauthHash(sessionID uint64)
 	// (removed: StashPendingSessionSetup — see #362 fix; rawMessage now flows
 	// through SMBHandlerContext.RawRequest into InitSessionPreauthHash.)
+
+	// SetHasAuthenticatedSession records that a non-anonymous, non-guest
+	// session has completed SESSION_SETUP on this connection. Sticky: only
+	// ever flips true. Used to gate AEAD key derivation for subsequent
+	// anonymous (IsNull) sessions per MS-SMB2 §3.3.5.2.1.1 (mirrors Samba
+	// xconn->smb2.got_authenticated_session at smb2_sesssetup.c:282).
+	SetHasAuthenticatedSession()
+	// HasAuthenticatedSession returns whether a non-anonymous, non-guest
+	// session has completed SESSION_SETUP on this connection.
+	HasAuthenticatedSession() bool
 }
 
 // SMBHandlerContext carries per-request state through all SMB2 handlers.

--- a/internal/adapter/smb/v2/handlers/negotiate_test.go
+++ b/internal/adapter/smb/v2/handlers/negotiate_test.go
@@ -117,6 +117,7 @@ type mockCryptoState struct {
 	clientCapabilities       types.Capabilities
 	clientSecurityMode       types.SecurityMode
 	clientDialects           []types.Dialect
+	hasAuthenticatedSession  bool
 }
 
 func (m *mockCryptoState) SetDialect(d types.Dialect) { m.dialect = d }
@@ -152,6 +153,8 @@ func (m *mockCryptoState) GetSessionPreauthHash(sessionID uint64) [64]byte {
 	return m.preauthHash
 }
 func (m *mockCryptoState) DeleteSessionPreauthHash(sessionID uint64) {}
+func (m *mockCryptoState) SetHasAuthenticatedSession()               { m.hasAuthenticatedSession = true }
+func (m *mockCryptoState) HasAuthenticatedSession() bool             { return m.hasAuthenticatedSession }
 
 // newNegotiateTestContextWithCrypto creates a test context with a mock CryptoState.
 func newNegotiateTestContextWithCrypto() (*SMBHandlerContext, *mockCryptoState) {

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -1357,14 +1357,31 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 
 		// Encryption: activate encryptors for preferred/required modes on 3.x sessions.
 		// Guest sessions never reach here (no session key), so they are exempt.
-		// Per MS-SMB2 §3.3.5.2.9 anonymous (IsNull) sessions also bypass
-		// encryption — the smbtorture smb2.session.anon-encryption{1,2,3}
-		// asserts that a transform-header inbound on an anonymous session
-		// triggers CONNECTION_RESET, which the connection layer drives off
-		// ErrAnonEncryption when CryptoState.Decryptor is nil. Deriving the
-		// AEAD decryptor here would let that path silently succeed and
-		// break the negative test.
-		if encryptionEnabled && !sess.IsNull {
+		//
+		// Anonymous (IsNull) sessions split by connection state, mirroring
+		// Samba source3/smbd/smb2_server.c:499's got_authenticated_session
+		// gate on incoming SMB2_TRANSFORM headers:
+		//
+		//   - No prior authenticated session on this connection: skip AEAD
+		//     derivation. An encrypted request will fail to decrypt (no
+		//     decryptor) and the connection layer drives ErrAnonEncryption
+		//     to drop the TCP connection — smbtorture
+		//     smb2.session.anon-encryption{1,3} expect CONNECTION_RESET on
+		//     the encrypted tcon that follows.
+		//
+		//   - Authenticated session exists on the connection: derive AEAD
+		//     so an encrypted anonymous tcon can piggyback alongside the
+		//     real session's traffic (smbtorture
+		//     smb2.session.anon-encryption2). The anonymous-flow client
+		//     (Samba libcli/smb/smbXcli_base.c:7032-7070 with
+		//     anonymous_encryption=true) derives encryption_key/
+		//     decryption_key from an all-zeros session key — matching what
+		//     our zero-base-key path produces here.
+		allowAnonEncryption := false
+		if sess.IsNull && ctx != nil && ctx.ConnCryptoState != nil {
+			allowAnonEncryption = ctx.ConnCryptoState.HasAuthenticatedSession()
+		}
+		if encryptionEnabled && (!sess.IsNull || allowAnonEncryption) {
 			// SMB 3.0/3.0.2 don't use negotiate contexts, so cipherId may be 0.
 			// Per MS-SMB2 spec, AES-128-CCM is the mandatory cipher for SMB 3.0.
 			encCipherId := cipherId
@@ -1449,6 +1466,18 @@ func (h *Handler) configureSessionSigningWithKey(sess *session.Session, sessionK
 		"shouldVerify", sess.ShouldVerify(),
 		"encryptData", sess.ShouldEncrypt(),
 		"dialect", dialect.String())
+
+	// Mark the connection as having seen an authenticated session once a
+	// non-anonymous, non-guest session has been configured. This sticky
+	// flag mirrors Samba xconn->smb2.got_authenticated_session
+	// (source3/smbd/smb2_sesssetup.c:282); it gates AEAD derivation for
+	// subsequent IsNull sessions on the same connection (see the IsNull
+	// branch above and smbtorture smb2.session.anon-encryption{1,2,3}).
+	// Guest sessions never enter this function (they have no session key),
+	// so only IsNull needs to be filtered here.
+	if !sess.IsNull && ctx != nil && ctx.ConnCryptoState != nil {
+		ctx.ConnCryptoState.SetHasAuthenticatedSession()
+	}
 
 	return nil
 }

--- a/internal/adapter/smb/v2/handlers/session_setup_test.go
+++ b/internal/adapter/smb/v2/handlers/session_setup_test.go
@@ -1048,6 +1048,93 @@ func TestConfigureSessionSigningWithKey_Encryption(t *testing.T) {
 	})
 }
 
+// TestConfigureSessionSigningWithKey_IsNullEncryptionGate validates the
+// per-connection AEAD derivation gate for anonymous (IsNull) sessions
+// introduced for smb2.session.anon-encryption{1,2,3}:
+//
+//   - First non-anonymous SESSION_SETUP must flip
+//     HasAuthenticatedSession on the connection.
+//   - Without HasAuthenticatedSession, an IsNull session must NOT derive
+//     a Decryptor — an encrypted request is then dropped via
+//     ErrAnonEncryption (anon-encryption1/3).
+//   - With HasAuthenticatedSession, an IsNull session MUST derive a
+//     Decryptor so an anonymous tcon can piggyback alongside the real
+//     session's encrypted traffic (anon-encryption2).
+func TestConfigureSessionSigningWithKey_IsNullEncryptionGate(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	newHandler := func() *Handler {
+		h := NewHandler()
+		h.EncryptionConfig = EncryptionConfig{
+			Mode:           "preferred",
+			AllowedCiphers: []uint16{types.CipherAES128GCM},
+		}
+		return h
+	}
+	newCryptoState := func() *mockCryptoState {
+		return &mockCryptoState{
+			dialect:  types.Dialect0311,
+			cipherId: types.CipherAES128GCM,
+		}
+	}
+
+	t.Run("FirstUserSession_SetsHasAuthenticatedSession", func(t *testing.T) {
+		h := newHandler()
+		sess := h.CreateSession("127.0.0.1:12345", false, "testuser", "DOMAIN")
+		ctx := newTestContext(sess.SessionID)
+		cs := newCryptoState()
+		ctx.ConnCryptoState = cs
+
+		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
+			t.Fatalf("unexpected error result: %v", errResult.Status)
+		}
+		if !cs.HasAuthenticatedSession() {
+			t.Error("HasAuthenticatedSession() = false after non-IsNull setup, want true")
+		}
+	})
+
+	t.Run("AnonOnFreshConn_NoDecryptor", func(t *testing.T) {
+		h := newHandler()
+		// IsNull = username=="" && !isGuest (see session.NewSession).
+		sess := h.CreateSession("127.0.0.1:12345", false, "", "")
+		if !sess.IsNull {
+			t.Fatalf("expected IsNull session, got IsNull=false")
+		}
+		ctx := newTestContext(sess.SessionID)
+		ctx.ConnCryptoState = newCryptoState() // HasAuthenticatedSession=false
+
+		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
+			t.Fatalf("unexpected error result: %v", errResult.Status)
+		}
+		if sess.CryptoState != nil && sess.CryptoState.Decryptor != nil {
+			t.Error("Decryptor derived on IsNull session without prior auth (would break anon-encryption1/3)")
+		}
+	})
+
+	t.Run("AnonAfterUserSession_DerivesDecryptor", func(t *testing.T) {
+		h := newHandler()
+		cs := newCryptoState()
+		cs.SetHasAuthenticatedSession() // Simulate prior user SESSION_SETUP.
+
+		sess := h.CreateSession("127.0.0.1:12345", false, "", "")
+		if !sess.IsNull {
+			t.Fatalf("expected IsNull session, got IsNull=false")
+		}
+		ctx := newTestContext(sess.SessionID)
+		ctx.ConnCryptoState = cs
+
+		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
+			t.Fatalf("unexpected error result: %v", errResult.Status)
+		}
+		if sess.CryptoState == nil || sess.CryptoState.Decryptor == nil {
+			t.Error("Decryptor NOT derived on IsNull session with prior auth (would break anon-encryption2)")
+		}
+	})
+}
+
 func TestSessionSetupConstants(t *testing.T) {
 	t.Run("RequestOffsets", func(t *testing.T) {
 		// Verify offset constants are correct per MS-SMB2 spec


### PR DESCRIPTION
## Summary

Closes #773.

Anonymous (IsNull) sessions now split AEAD-derivation behaviour by connection state, mirroring Samba's `xconn->smb2.got_authenticated_session` gate (`source3/smbd/smb2_server.c:499`). A sticky per-connection flag (`ConnectionCryptoState.hasAuthenticatedSession`) flips to true on the first non-anonymous, non-guest SESSION_SETUP and stays set for the connection lifetime.

- **Anonymous-only connection**: no AEAD derived. Encrypted requests on the IsNull session still drop the TCP connection via the existing `ErrAnonEncryption` path — `smbtorture smb2.session.anon-encryption1`.
- **Connection with a prior real auth**: derive AEAD with the all-zeros base key. Matches the Samba client's `anonymous_encryption` flow (`libcli/smb/smbXcli_base.c:7032-7070`) so an anonymous tcon can piggyback on the same TCP as an authenticated one — `smbtorture smb2.session.anon-encryption2`.
- **AEAD decrypt failure on any IsNull session** maps to `ErrNoDecryptor` so the connection drops immediately instead of waiting for the 5-failure threshold. Samba treats decrypt errors on anonymous sessions as catastrophic — `smbtorture smb2.session.anon-encryption3` (forced wrong client session key).

## Test plan

- [x] `go test ./...` — all green
- [x] `golangci-lint run` — 0 issues
- [x] smbtorture `smb2.session.anon-encryption1` PASS
- [x] smbtorture `smb2.session.anon-encryption2` PASS (was FAIL on develop)
- [x] smbtorture `smb2.session.anon-encryption3` PASS
- [x] smbtorture `smb2.session.anon-signing1` PASS (no regression)
- [x] smbtorture `smb2.session.anon-signing2` PASS (no regression)
- [x] Full `smb2.session` suite — no new failures vs develop baseline