### PR TITLE
fix(postgres): persist FileBlock hash for non-finalized rows (#838)

### DIFF
--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -307,11 +307,46 @@ func (s *PostgresMetadataStore) Restore(ctx context.Context, r io.Reader) error 
 		return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
 	}
 
+	// Reconcile file_blocks.hash from file_block_refs before commit.
+	// Backups produced before the Put hash-gate fix carry NULL hashes on
+	// every file_blocks row (the hash was only written for finalized
+	// rows). After a restore clears local state, the engine's CAS read
+	// path resolves chunks through file_blocks.hash and a NULL there
+	// makes the file read as zeros. file_block_refs always carries the
+	// correct hash, so backfill the per-file read index from it. New
+	// backups already carry the hash; the UPDATE is a no-op for them.
+	if err := reconcileFileBlockHashes(ctx, pgRaw); err != nil {
+		return fmt.Errorf("%w: reconcile file_blocks hashes: %v", metadata.ErrRestoreCorrupt, err)
+	}
+
 	// CRC verified — commit the restore transaction.
 	if _, err := pgRaw.Exec(ctx, "COMMIT").ReadAll(); err != nil {
 		return fmt.Errorf("restore: commit: %w", err)
 	}
 
+	return nil
+}
+
+// reconcileFileBlockHashes backfills file_blocks.hash from
+// file_block_refs for rows whose hash is NULL. The file_blocks row ID is
+// "{files.content_id}/{offset}" and file_block_refs is keyed by
+// (file_id, offset); the join recovers each block's content hash. The
+// hash column is hex TEXT (ContentHash.String()), so the BYTEA ref hash
+// is encoded with encode(..., 'hex'), which produces the same lowercase
+// hex string. Only the hash is touched — block state and remote-durability
+// tracking (synced_hashes) are left as restored.
+func reconcileFileBlockHashes(ctx context.Context, raw *pgconn.PgConn) error {
+	const sql = `
+		UPDATE file_blocks fb
+		SET hash = encode(r.hash, 'hex')
+		FROM file_block_refs r
+		JOIN files f ON f.id = r.file_id
+		WHERE fb.hash IS NULL
+		  AND f.content_id IS NOT NULL
+		  AND fb.id = f.content_id || '/' || r."offset"`
+	if _, err := raw.Exec(ctx, sql).ReadAll(); err != nil {
+		return fmt.Errorf("UPDATE file_blocks: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/metadata/store/postgres/file_block_refs.go
+++ b/pkg/metadata/store/postgres/file_block_refs.go
@@ -162,6 +162,16 @@ type RawSQLAccessor interface {
 	// CountFileBlockRefs returns the number of file_block_refs rows for
 	// fileID. Test-only — never call this from production code.
 	CountFileBlockRefs(ctx context.Context, fileID uuid.UUID) (int, error)
+
+	// InsertNullHashFileBlock inserts a file_blocks row with a NULL hash
+	// column, simulating a legacy backup produced before the Put
+	// hash-gate fix. Test-only — never call this from production code.
+	InsertNullHashFileBlock(ctx context.Context, id string, dataSize uint32) error
+
+	// FileBlockHashHex returns the hex hash string stored on the
+	// file_blocks row for id, or "" when the hash column is NULL.
+	// Test-only — never call this from production code.
+	FileBlockHashHex(ctx context.Context, id string) (string, error)
 }
 
 // CountFileBlockRefs implements RawSQLAccessor for *PostgresMetadataStore.
@@ -172,4 +182,30 @@ func (s *PostgresMetadataStore) CountFileBlockRefs(ctx context.Context, fileID u
 		return 0, fmt.Errorf("count file_block_refs: %w", err)
 	}
 	return n, nil
+}
+
+// InsertNullHashFileBlock implements RawSQLAccessor for *PostgresMetadataStore.
+func (s *PostgresMetadataStore) InsertNullHashFileBlock(ctx context.Context, id string, dataSize uint32) error {
+	_, err := s.exec(ctx, `
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, state)
+		VALUES ($1, NULL, $2, 1, 0)
+		ON CONFLICT (id) DO UPDATE SET hash = NULL`,
+		id, int32(dataSize))
+	if err != nil {
+		return fmt.Errorf("insert null-hash file_block: %w", err)
+	}
+	return nil
+}
+
+// FileBlockHashHex implements RawSQLAccessor for *PostgresMetadataStore.
+func (s *PostgresMetadataStore) FileBlockHashHex(ctx context.Context, id string) (string, error) {
+	var hash *string
+	err := s.queryRow(ctx, `SELECT hash FROM file_blocks WHERE id = $1`, id).Scan(&hash)
+	if err != nil {
+		return "", fmt.Errorf("read file_block hash: %w", err)
+	}
+	if hash == nil {
+		return "", nil
+	}
+	return *hash, nil
 }

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -57,11 +57,21 @@ func (s *PostgresMetadataStore) GetFileBlock(ctx context.Context, id string) (*m
 	return block, nil
 }
 
-// Put stores or updates a file block. Renamed from PutFileBlock to
-// match the narrowed interface.
+// Put stores or updates a file block.
+//
+// The hash column is persisted whenever the block carries a non-zero
+// content hash, regardless of block state. The content hash is derived
+// at rollup time (long before the block reaches the remote) and is the
+// key the engine's CAS read path uses to resolve a chunk. Gating the
+// write on IsFinalized() left every Pending row with a NULL hash; reads
+// then survived only while the bytes stayed in the local append log or
+// RAM cache, and broke the moment local state went cold (restart +
+// cache eviction, or a snapshot restore's ResetLocalState). The memory
+// and badger backends always store the hash inline on the row, so this
+// matches their behavior.
 func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileBlock) error {
 	var hashStr *string
-	if block.IsFinalized() {
+	if !block.Hash.IsZero() {
 		h := block.Hash.String()
 		hashStr = &h
 	}
@@ -179,8 +189,16 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash blockstore.Cont
 	// payloadID + blockRef accepted for future GC traceability;
 	// postgres backend records ref count only — parameters intentionally
 	// blanked.
+	//
+	// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger
+	// backends, whose AddRef resolves the hash only through the finalized
+	// hash index. The dedup hit path references a block already confirmed
+	// on the remote; a Pending row (which now also carries its hash) is
+	// not a valid dedup donor, so AddRef must miss it and return
+	// ErrUnknownHash exactly as before, letting the caller fall back to
+	// the full Put path.
 	result, err := s.exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1`,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
 		hash.String())
 	if err != nil {
 		return fmt.Errorf("add ref: %w", err)
@@ -420,7 +438,7 @@ func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileBloc
 		return err
 	}
 	var hashStr *string
-	if block.IsFinalized() {
+	if !block.Hash.IsZero() {
 		h := block.Hash.String()
 		hashStr = &h
 	}
@@ -520,8 +538,10 @@ func (tx *postgresTransaction) AddRef(ctx context.Context, hash blockstore.Conte
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// state = 2 (Remote) scoping mirrors the pool-path AddRef and the
+	// memory/badger backends — a Pending row is not a valid dedup donor.
 	result, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1`,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
 		hash.String())
 	if err != nil {
 		return fmt.Errorf("add ref: %w", err)

--- a/pkg/metadata/store/postgres/postgres_blockref_test.go
+++ b/pkg/metadata/store/postgres/postgres_blockref_test.go
@@ -359,3 +359,86 @@ func blockRefsEqual(x, y []blockstore.BlockRef) bool {
 	}
 	return true
 }
+
+// TestPostgres_Restore_ReconcilesNullHashFileBlocks pins the data-loss fix:
+// a backup that carries NULL-hash file_blocks rows (the shape every backup
+// had before the Put hash-gate fix) must, after restore, have those hashes
+// backfilled from file_block_refs. Otherwise the engine's CAS read path
+// resolves the per-file read index to a NULL hash and the restored file
+// reads as zeros once local cache state is cold.
+func TestPostgres_Restore_ReconcilesNullHashFileBlocks(t *testing.T) {
+	store := newTestStore(t)
+	ctx := t.Context()
+
+	handle := createShareAndFile(t, store, "/restore-reconcile", "vm.img")
+
+	want := hashOfSeed("reconcile-block-0")
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	// content_id (PayloadID) is the prefix of the file_blocks row ID. The
+	// engine derives it from share + path; set it explicitly here so the
+	// reconcile join (file_blocks.id = content_id || '/' || offset) lands.
+	payloadID := "restore-reconcile/vm.img"
+	file.PayloadID = metadata.PayloadID(payloadID)
+	file.Blocks = []blockstore.BlockRef{
+		{Hash: want, Offset: 0, Size: 4 << 20},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile with Blocks: %v", err)
+	}
+
+	// The file_blocks read-index row ID is "{content_id}/{offset}".
+	blockID := payloadID + "/0"
+
+	rawSQL, ok := store.(postgres.RawSQLAccessor)
+	if !ok {
+		t.Fatalf("store does not implement RawSQLAccessor")
+	}
+
+	// Simulate a legacy backup: a NULL-hash file_blocks row.
+	if err := rawSQL.InsertNullHashFileBlock(ctx, blockID, 4<<20); err != nil {
+		t.Fatalf("InsertNullHashFileBlock: %v", err)
+	}
+	if got, herr := rawSQL.FileBlockHashHex(ctx, blockID); herr != nil {
+		t.Fatalf("FileBlockHashHex (pre-backup): %v", herr)
+	} else if got != "" {
+		t.Fatalf("pre-backup file_blocks.hash = %q, want NULL", got)
+	}
+
+	backupable, ok := store.(metadata.Backupable)
+	if !ok {
+		t.Fatalf("store does not implement Backupable")
+	}
+
+	var buf bytes.Buffer
+	if _, err := backupable.Backup(ctx, &buf); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+
+	resetable, ok := store.(interface {
+		Reset(ctx context.Context) error
+	})
+	if !ok {
+		t.Fatalf("store does not implement Reset")
+	}
+	if err := resetable.Reset(ctx); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	if err := backupable.Restore(ctx, &buf); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	// After restore, the NULL hash must be reconciled from file_block_refs.
+	got, err := rawSQL.FileBlockHashHex(ctx, blockID)
+	if err != nil {
+		t.Fatalf("FileBlockHashHex (post-restore): %v", err)
+	}
+	if got != want.String() {
+		t.Errorf("post-restore file_blocks.hash = %q, want %q "+
+			"(restore must backfill NULL hashes from file_block_refs so the "+
+			"CAS read path can resolve restored chunks)", got, want.String())
+	}
+}

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -162,6 +162,18 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("AddRef_Concurrent_With_DecrementRefCountCascade", func(t *testing.T) {
 		testAddRef_Concurrent_With_DecrementRefCountCascade(t, factory)
 	})
+
+	// A FileBlock's content hash is valid the moment the chunk is hashed
+	// at rollup time, long before it reaches the remote (BlockStateRemote).
+	// The engine's CAS read path resolves (payloadID, offset) -> Hash via
+	// ListFileBlocks / GetFileBlock, so a Pending row MUST round-trip its
+	// hash. A backend that only persists the hash for finalized rows leaves
+	// the per-file read index hash-less; once the local cache is cold
+	// (restart + eviction, or a snapshot restore that resets local state)
+	// reads can no longer resolve the chunk and the file reads as zeros.
+	t.Run("PutGet_PendingHashRoundTrips", func(t *testing.T) {
+		testPutGet_PendingHashRoundTrips(t, factory)
+	})
 }
 
 // ============================================================================
@@ -602,6 +614,55 @@ func testPut_TwoIDsSameHash(t *testing.T, factory StoreFactory) {
 	if found.ID != a.ID && found.ID != b.ID {
 		t.Errorf("FindFileBlockByHash returned ID %q; want one of [%q, %q]",
 			found.ID, a.ID, b.ID)
+	}
+}
+
+// testPutGet_PendingHashRoundTrips pins the contract that a FileBlock's
+// content hash survives a Put/Get round-trip regardless of block state.
+// Both per-file read accessors (ListFileBlocks and GetFileBlock) must
+// surface the hash for a Pending row, because the engine CAS read path
+// resolves chunks through that index, not just through finalized rows.
+func testPutGet_PendingHashRoundTrips(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	hash := hashOfSeed("pending-hash-roundtrip")
+	fb := &blockstore.FileBlock{
+		ID:         "file-pending/0",
+		Hash:       hash,
+		State:      blockstore.BlockStatePending,
+		DataSize:   4096,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Put(ctx, fb); err != nil {
+		t.Fatalf("Put(pending) failed: %v", err)
+	}
+
+	legacy := asLegacy(t, store)
+
+	got, err := legacy.GetFileBlock(ctx, fb.ID)
+	if err != nil {
+		t.Fatalf("GetFileBlock failed: %v", err)
+	}
+	if got.Hash != hash {
+		t.Errorf("GetFileBlock: Pending row Hash = %x, want %x "+
+			"(the content hash must persist for Pending blocks — the CAS "+
+			"read path resolves chunks via this hash even before the block "+
+			"reaches the remote)", got.Hash[:8], hash[:8])
+	}
+
+	rows, err := legacy.ListFileBlocks(ctx, "file-pending")
+	if err != nil {
+		t.Fatalf("ListFileBlocks failed: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListFileBlocks returned %d rows, want 1", len(rows))
+	}
+	if rows[0].Hash != hash {
+		t.Errorf("ListFileBlocks: Pending row Hash = %x, want %x",
+			rows[0].Hash[:8], hash[:8])
 	}
 }
 


### PR DESCRIPTION
Closes #838

## Root cause

On a postgres-metadata share with a remote block store, the read-path FileBlock index (`file_blocks` table) stored `hash=NULL` for every block, so a snapshot restore (or any cold local state) made restored files read as 0 bytes with `legacy zero-hash FileBlock encountered post-migration — refusing read` (`pkg/blockstore/engine/fetch.go`).

The postgres `FileBlock.Put` (`pkg/metadata/store/postgres/objects.go`) only wrote the `hash` column when `block.IsFinalized()` (State==Remote). But the engine's rollup persister / chunk emitter create `file_blocks` rows with `State=Pending` and a populated `Hash`, and they are **never re-Put as Remote** — the CAS sync model tracks remote durability in the separate `synced_hashes` table via `MarkSynced`, not by transitioning `file_blocks.state`. So `file_blocks.hash` stayed NULL forever.

`file_block_refs` (the FileAttr.Blocks manifest source) always carried the correct hash — this bug is distinct from #789/#815, which fixed `file_block_refs`/FileAttr.Blocks only. This is the same null-hash family, but on the **read-path index**, exposed by restore.

memory and badger store the entire FileBlock struct inline (struct copy / `json.Marshal`), so the hash is preserved on Pending rows regardless of state — the bug was **postgres-only**.

## Was plain restart + eviction also affected?

**Yes.** The local read path (`fillFromCASManifest`, `readLocalByHash`) and the remote-fetch path (`dispatchRemoteFetch`) both resolve chunks through `file_blocks.hash`. On postgres that was NULL, so reads worked only while the bytes were still in the local append log or the RAM cache. A plain server restart with a cold cache (no snapshot involved) bricked postgres reads the same way restore did. The fix covers both because it corrects the write at the source.

## Fix

1. **Finalize-path (root cause):** `Put` (pool + tx variants) now persists the hash whenever `!block.Hash.IsZero()`, not only when finalized. The content hash is valid the moment the chunk is hashed at rollup time; it is not a property of remote durability. This matches memory/badger and covers restart + eviction.
2. **AddRef parity:** scoped the postgres `AddRef` by-hash UPDATE to `state = 2 (Remote)` so a Pending row (which now carries its hash) is not treated as a dedup donor — preserving the exact prior behavior and cross-backend parity (memory/badger resolve AddRef only through the finalized hash index).
3. **Restore-reconcile (recover broken dumps):** `Restore` backfills `file_blocks.hash` from `file_block_refs` (join on `content_id`/`offset`) for NULL-hash rows, so backups produced before this fix recover. No-op for new backups.

## Tests (TDD, failing-first)

- `pkg/metadata/storetest` conformance: `PutGet_PendingHashRoundTrips` — a Pending FileBlock with a non-zero hash must round-trip its hash through `Put` → `GetFileBlock`/`ListFileBlocks`. Failed on postgres pre-fix (hash read back as zero), passes on memory/badger, now passes on postgres.
- `pkg/metadata/store/postgres`: `TestPostgres_Restore_ReconcilesNullHashFileBlocks` — inject a NULL-hash `file_blocks` row → Backup → Reset → Restore → assert the hash is reconciled from `file_block_refs`. Failed pre-reconcile, passes after.

Verified live against a throwaway postgres DB (badger/memory via local conformance). `go test -race ./pkg/metadata/... ./pkg/blockstore/...` green; gofmt/vet/golangci-lint clean on the changed code.