### PR TITLE
fix(smb/session): verify re-auth signature on bound channel (#747)

### DIFF
--- a/internal/adapter/smb/v2/handlers/session_reauth_signature_test.go
+++ b/internal/adapter/smb/v2/handlers/session_reauth_signature_test.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// buildSignedReauthRequest builds the raw wire bytes (header + body) of a
+// non-binding SESSION_SETUP request targeting sessionID, signs the header+body
+// with signKey using CMAC, and sets the SMB2_FLAGS_SIGNED bit. When signKey is
+// nil the request is left with the SIGNED bit set but a zero signature (the
+// "fresh-init client signed with a key the server cannot match" case).
+func buildSignedReauthRequest(t *testing.T, sessionID uint64, signKey []byte) []byte {
+	t.Helper()
+
+	body := buildSessionSetupRequestBody(wrapInSPNEGO(validNTLMNegotiateMessage()))
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2SessionSetup,
+		Flags:     types.FlagSigned,
+		MessageID: 4,
+		SessionID: sessionID,
+	}
+	raw := append(hdr.Encode(), body...)
+
+	if signKey != nil {
+		signer := signing.NewCMACSigner(signKey)
+		sig := signer.Sign(raw)
+		copy(raw[48:64], sig[:])
+	}
+	return raw
+}
+
+// newReauthContext builds a handler context on connID carrying the raw request
+// bytes, mirroring how the dispatch layer threads ctx.RawRequest.
+func newReauthContext(sessionID uint64, connID uint64, raw []byte) *SMBHandlerContext {
+	ctx := NewSMBHandlerContext(context.Background(), "127.0.0.1:99", sessionID, 0, connID)
+	ctx.ConnID = connID
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+	ctx.RawRequest = raw
+	return ctx
+}
+
+// addSignedChannel registers a bound channel on sess for connID with a CMAC
+// signer keyed by channelKey.
+func addSignedChannel(sess *session.Session, connID uint64, channelKey []byte) {
+	sess.AddChannel(&session.Channel{
+		ConnID:      connID,
+		Dialect:     types.Dialect0311,
+		SigningAlgo: signing.SigningAlgAESCMAC,
+		SigningKey:  channelKey,
+		Signer:      signing.NewCMACSigner(channelKey),
+	})
+}
+
+// TestSessionSetup_ReauthOnBoundChannel_BadSignature_AccessDenied verifies the
+// MS-SMB2 §3.3.5.2.4 gate (Samba smb2_server.c:3189-3255, has_channel==true):
+// a non-binding re-auth SESSION_SETUP that arrives on a bound channel and is
+// signed with a key that does not match the channel key is rejected with
+// STATUS_ACCESS_DENIED — the case smb2.session.bind_negative_smb3sign{CtoH,HtoC}
+// exercises after a successful CMAC<->HMAC bind.
+func TestSessionSetup_ReauthOnBoundChannel_BadSignature_AccessDenied(t *testing.T) {
+	channelKey := make([]byte, 16)
+	for i := range channelKey {
+		channelKey[i] = 0x11
+	}
+	wrongKey := make([]byte, 16)
+	for i := range wrongKey {
+		wrongKey[i] = 0x22
+	}
+
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+	addSignedChannel(sess, 2, channelKey)
+
+	raw := buildSignedReauthRequest(t, sess.SessionID, wrongKey)
+	ctx := newReauthContext(sess.SessionID, 2, raw)
+
+	result, err := h.SessionSetup(ctx, raw[64:])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Fatalf("status=0x%x, want StatusAccessDenied (0x%x)", result.Status, types.StatusAccessDenied)
+	}
+}
+
+// TestSessionSetup_ReauthOnBoundChannel_GoodSignature_Proceeds verifies the
+// inverse: a re-auth request correctly signed with the channel key passes the
+// signature gate and proceeds into the NTLM handshake (interim
+// STATUS_MORE_PROCESSING_REQUIRED), so a legitimate channel re-auth is not
+// broken.
+func TestSessionSetup_ReauthOnBoundChannel_GoodSignature_Proceeds(t *testing.T) {
+	channelKey := make([]byte, 16)
+	for i := range channelKey {
+		channelKey[i] = 0x33
+	}
+
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+	addSignedChannel(sess, 2, channelKey)
+
+	raw := buildSignedReauthRequest(t, sess.SessionID, channelKey)
+	ctx := newReauthContext(sess.SessionID, 2, raw)
+
+	result, err := h.SessionSetup(ctx, raw[64:])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status == types.StatusAccessDenied {
+		t.Fatalf("status=StatusAccessDenied, a correctly-signed channel re-auth must not be rejected by the signature gate")
+	}
+}
+
+// TestSessionSetup_ReauthOnOriginConnection_NoChannel_NotGated verifies the
+// gate is scoped to bound channels: a re-auth on the origin connection (which
+// has no Channel entry) is not signature-gated here, preserving the existing
+// reauth1-6 behaviour.
+func TestSessionSetup_ReauthOnOriginConnection_NoChannel_NotGated(t *testing.T) {
+	wrongKey := make([]byte, 16)
+	for i := range wrongKey {
+		wrongKey[i] = 0x44
+	}
+
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1 // origin connection; no bound Channel registered
+
+	raw := buildSignedReauthRequest(t, sess.SessionID, wrongKey)
+	ctx := newReauthContext(sess.SessionID, 1, raw)
+
+	result, err := h.SessionSetup(ctx, raw[64:])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status == types.StatusAccessDenied {
+		t.Fatalf("status=StatusAccessDenied, origin-connection re-auth must not be signature-gated")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -368,12 +368,23 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 // passes or the gate does not apply.
 //
 // Scope conditions (all required):
+//   - the request did not arrive inside an SMB3 Transform Header — AEAD already
+//     provides integrity for encrypted messages and they carry no SMB2
+//     signature, so the framing layer (framing.go) skips signature
+//     verification for them and so must this gate;
 //   - the connection owns a registered bound channel for the session with a
 //     valid signer — origin-connection re-auth (no Channel entry) is excluded
 //     so the existing reauth1-6 path is untouched;
-//   - the inbound request is signed OR the session requires signing;
+//   - the inbound request is signed OR the session requires signing (mirroring
+//     Samba's `signing_required || (flags & SIGNED)` condition at
+//     smb2_server.c:3189 — a session where signing is merely enabled but not
+//     required must not have an unsigned re-auth rejected);
 //   - the raw request bytes are available to verify.
 func (h *Handler) verifyReauthChannelSignature(ctx *SMBHandlerContext, sess *session.Session) *HandlerResult {
+	if ctx.RequestEncrypted {
+		return nil
+	}
+
 	ch := sess.GetChannel(ctx.ConnID)
 	if ch == nil || ch.Signer == nil {
 		return nil
@@ -394,7 +405,8 @@ func (h *Handler) verifyReauthChannelSignature(ctx *SMBHandlerContext, sess *ses
 			verifyBytes = verifyBytes[:hdr.NextCommand]
 		}
 	}
-	if !requestSigned && !sess.ShouldVerify() {
+	signingRequired := sess.CryptoState != nil && sess.CryptoState.SigningRequired
+	if !requestSigned && !signingRequired {
 		return nil
 	}
 
@@ -402,7 +414,7 @@ func (h *Handler) verifyReauthChannelSignature(ctx *SMBHandlerContext, sess *ses
 		return nil
 	}
 
-	logger.Info("SESSION_SETUP re-auth on bound channel: signature mismatch",
+	logger.Warn("SESSION_SETUP re-auth on bound channel: signature mismatch",
 		"sessionID", ctx.SessionID,
 		"connID", ctx.ConnID,
 		"channelSigningAlgo", fmt.Sprintf("0x%04x", ch.SigningAlgo))

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
 	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
@@ -219,6 +220,35 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 				return NewErrorResult(types.StatusUserSessionDeleted), nil
 			}
 
+			// MS-SMB2 §3.3.5.2.4 (Samba source3/smbd/smb2_server.c:3189-3255):
+			// a re-authentication SESSION_SETUP that arrives on a connection
+			// which already owns a bound channel with a valid signing key MUST
+			// have its signature verified against that channel key. When the
+			// channel exists Samba's `has_channel` is true, so the "skip
+			// signing on SESSION_SETUP" recovery (smb2_server.c:3226-3252) does
+			// NOT apply and a bad signature fails the request with
+			// STATUS_ACCESS_DENIED — the connection stays alive.
+			//
+			// This is the multi-channel re-auth case exercised by
+			// smb2.session.bind_negative_smb3sign{CtoH,HtoC}{s,d}: after a
+			// successful CMAC<->HMAC bind, the harness re-initialises a fresh
+			// client session (session.c:2808) that derives a different signing
+			// key, then issues a non-binding SESSION_SETUP on the bound
+			// transport. Without this gate the server proceeds into a fresh
+			// NTLM handshake and replies with a CHALLENGE signed by the bound
+			// channel key; the fresh client cannot match it and drops the
+			// transport (CONNECTION_DISCONNECTED) instead of observing
+			// ACCESS_DENIED.
+			//
+			// Scoped to a registered bound channel (GetChannel != nil) so the
+			// origin-connection re-auth path (smb2.session.reauth1-6, which is
+			// not signature-verified here today) is unaffected. The TYPE_3 of a
+			// legitimate in-flight handshake never reaches this branch — it is
+			// routed to completeNTLMAuth by the pending-auth check above.
+			if reauthRejected := h.verifyReauthChannelSignature(ctx, sess); reauthRejected != nil {
+				return reauthRejected, nil
+			}
+
 			// Re-authentication: client sends SESSION_SETUP on an existing session
 			// with no pending auth. Per MS-SMB2 3.3.5.5.2, this initiates a new
 			// authentication on the existing session (identity update).
@@ -327,6 +357,56 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	// No recognized auth mechanism - create guest session
 	return h.createGuestSession(ctx)
+}
+
+// verifyReauthChannelSignature enforces the SESSION_SETUP request-signature
+// check for a re-authentication that arrives on a bound secondary channel
+// (MS-SMB2 §3.3.5.2.4; Samba source3/smbd/smb2_server.c:3189-3255 with
+// has_channel == true). It returns a non-nil ACCESS_DENIED result when the
+// request is signed (or the session requires signing) but its signature does
+// not verify against the channel's signing key, and nil when verification
+// passes or the gate does not apply.
+//
+// Scope conditions (all required):
+//   - the connection owns a registered bound channel for the session with a
+//     valid signer — origin-connection re-auth (no Channel entry) is excluded
+//     so the existing reauth1-6 path is untouched;
+//   - the inbound request is signed OR the session requires signing;
+//   - the raw request bytes are available to verify.
+func (h *Handler) verifyReauthChannelSignature(ctx *SMBHandlerContext, sess *session.Session) *HandlerResult {
+	ch := sess.GetChannel(ctx.ConnID)
+	if ch == nil || ch.Signer == nil {
+		return nil
+	}
+	if len(ctx.RawRequest) == 0 {
+		return nil
+	}
+
+	// Verify only the first command's bytes for a compound request, mirroring
+	// the framing verifier (framing.go) so a legitimately signed SESSION_SETUP
+	// chained ahead of other subcommands is not rejected over its trailing
+	// bytes.
+	verifyBytes := ctx.RawRequest
+	requestSigned := false
+	if hdr, err := header.Parse(ctx.RawRequest); err == nil {
+		requestSigned = hdr.IsSigned()
+		if hdr.NextCommand > 0 && int(hdr.NextCommand) <= len(verifyBytes) {
+			verifyBytes = verifyBytes[:hdr.NextCommand]
+		}
+	}
+	if !requestSigned && !sess.ShouldVerify() {
+		return nil
+	}
+
+	if sess.VerifyMessageOnChannel(ctx.ConnID, verifyBytes) {
+		return nil
+	}
+
+	logger.Info("SESSION_SETUP re-auth on bound channel: signature mismatch",
+		"sessionID", ctx.SessionID,
+		"connID", ctx.ConnID,
+		"channelSigningAlgo", fmt.Sprintf("0x%04x", ch.SigningAlgo))
+	return NewErrorResult(types.StatusAccessDenied)
 }
 
 // recordSessionBindIdentity captures the negotiated dialect, signing

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -275,23 +275,6 @@ shape that reauth4 actually exercises.
 | smb2.session.anon-encryption2 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #773 |
 | smb2.session.anon-encryption3 | Sessions | Pre-existing: anonymous SESSION_SETUP returns INVALID_PARAMETER instead of OK | #773 |
 
-### Session Binding (Multi-Channel, Same-Algo Positive Cases)
-
-The remaining session-binding rows are the four "same non-GMAC" pairings
-that expect the bind to SUCCEED and then assert a follow-up fresh-init
-SESSION_SETUP returns ACCESS_DENIED. Our server currently disconnects
-the transport on the post-success fresh-init step instead of replying
-ACCESS_DENIED — full fix needs multi-channel response-signing rework
-(retain prior-channel signing keys + return ACCESS_DENIED on
-reauth-from-fresh-init). Tracked under #747 for the v1.0 milestone.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.session.bind_negative_smb3signCtoHs | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
-| smb2.session.bind_negative_smb3signCtoHd | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
-| smb2.session.bind_negative_smb3signHtoCs | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
-| smb2.session.bind_negative_smb3signHtoCd | Session binding | Post-bind fresh-init reauth returns CONNECTION_DISCONNECTED instead of ACCESS_DENIED | #747 |
-
 ### Replay Protection (Not Implemented)
 
 Replay protection requires tracking channel sequences and detecting replayed


### PR DESCRIPTION
## Summary

Closes the last 4 residuals of #747 (session binding). PR #774 flipped 26/30; these four "same non-GMAC" pairings remained:

- `smb2.session.bind_negative_smb3signCtoHs`
- `smb2.session.bind_negative_smb3signCtoHd`
- `smb2.session.bind_negative_smb3signHtoCs`
- `smb2.session.bind_negative_smb3signHtoCd`

## Root cause

These tests bind a second channel with a different non-GMAC signing algo (CMAC↔HMAC) — the bind is expected to **succeed**. The harness then re-initialises a fresh client session (`session.c:2808`) that derives a *different* signing key and issues a non-binding `SESSION_SETUP` on the bound transport, expecting `ACCESS_DENIED`.

DittoFS exempted all `SESSION_SETUP` from request-signature verification, so it proceeded into a fresh NTLM handshake and replied with a `CHALLENGE` signed by the bound channel key. The fresh client could not match it and dropped the transport → `NT_STATUS_CONNECTION_DISCONNECTED` (observed at `session.c:2818`) instead of `ACCESS_DENIED`.

## Fix

Mirror Samba `source3/smbd/smb2_server.c:3189-3255` (the `has_channel == true` path): when a non-binding re-auth `SESSION_SETUP` arrives on a connection that already owns a **bound channel with a valid signing key**, verify the request signature against that channel key. On mismatch, return `STATUS_ACCESS_DENIED` and keep the connection alive.

- Scoped to a registered bound channel (`GetChannel != nil`), so the origin-connection re-auth path (`reauth1-6`) is untouched.
- The `TYPE_3` of a legitimate in-flight handshake is routed to `completeNTLMAuth` by the pending-auth check before reaching the gate.
- Compound-aware: verifies only the first command's bytes, matching the framing verifier.

## Verification

- All 4 target tests flip to PASS (smbtorture, memory profile).
- Full `smb2.session` suite: 63 pass, no regression. The only "new failure" reported is the pre-existing `reauth5` (#772 upstream Samba knownfail; a runner suite-prefix artifact, unrelated `smb2_util_unlink` assertion).
- New unit tests: bad-signature → ACCESS_DENIED, good-signature → proceeds, origin-connection → not gated.
- `go test -race`, `go vet`, `golangci-lint` clean.

Closes #747