### PR TITLE
fix(smb): DH V1 durable reconnect — reopen2 + lease re-association (#738)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -524,20 +524,23 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// MS-SMB2 §3.3.5.9.7/12: a DHnC/DH2C reconnect is keyed solely by the
-	// reconnect blob (FileId / CreateGuid). The server MUST ignore the other
-	// CREATE fields — ImpersonationLevel, CreateOptions, FileAttributes,
-	// DesiredAccess, ShareAccess, CreateDisposition. smbtorture
+	// reconnect blob (FileId / CreateGuid). The server ignores the wire-format
+	// CREATE fields validated below — ImpersonationLevel, CreateOptions reserved
+	// bits, FileAttributes. (DesiredAccess / ShareAccess are NOT ignored: the
+	// reconnect path re-validates them against the persisted handle in
+	// validateAndRestore per §3.3.5.9.9 privilege-escalation checks.) smbtorture
 	// smb2.durable-open.reopen2 reconnects a third time with every such field
-	// set to garbage (0x12345678 / 0x78) to prove they are ignored; running
-	// the standard wire-validation gates below against that garbage would
-	// wrongly return STATUS_INVALID_PARAMETER / STATUS_BAD_IMPERSONATION_LEVEL
-	// / STATUS_NOT_SUPPORTED before the reconnect path (Step 4b) is reached.
-	// Skip those gates when a reconnect context is present. Gated on a
-	// configured DurableStore so the bypass only applies on the path that
-	// actually reaches the reconnect handler (Step 4b) — without a durable
-	// store a stray reconnect blob falls through to normal CREATE and the
-	// standard wire validation must still apply.
+	// set to garbage (0x12345678 / 0x78) to prove the wire gates are skipped;
+	// running them against that garbage would wrongly return
+	// STATUS_INVALID_PARAMETER / STATUS_BAD_IMPERSONATION_LEVEL /
+	// STATUS_NOT_SUPPORTED before the reconnect path (Step 4b) is reached.
+	//
+	// Gated on a configured DurableStore so the bypass only applies on the path
+	// that reaches the reconnect handler, and excluded on IPC$ — durable handles
+	// are disk-share only, so a stray reconnect blob on a named pipe must still
+	// run full wire validation rather than fall into handlePipeCreate unchecked.
 	isDurableReconnect := h.DurableStore != nil &&
+		tree.ShareName != "/ipc$" &&
 		(FindCreateContext(req.CreateContexts, DurableHandleV1ReconnectTag) != nil ||
 			FindCreateContext(req.CreateContexts, DurableHandleV2ReconnectTag) != nil)
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -523,12 +523,30 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameNotFound}}, nil
 	}
 
+	// MS-SMB2 §3.3.5.9.7/12: a DHnC/DH2C reconnect is keyed solely by the
+	// reconnect blob (FileId / CreateGuid). The server MUST ignore the other
+	// CREATE fields — ImpersonationLevel, CreateOptions, FileAttributes,
+	// DesiredAccess, ShareAccess, CreateDisposition. smbtorture
+	// smb2.durable-open.reopen2 reconnects a third time with every such field
+	// set to garbage (0x12345678 / 0x78) to prove they are ignored; running
+	// the standard wire-validation gates below against that garbage would
+	// wrongly return STATUS_INVALID_PARAMETER / STATUS_BAD_IMPERSONATION_LEVEL
+	// / STATUS_NOT_SUPPORTED before the reconnect path (Step 4b) is reached.
+	// Skip those gates when a reconnect context is present. Gated on a
+	// configured DurableStore so the bypass only applies on the path that
+	// actually reaches the reconnect handler (Step 4b) — without a durable
+	// store a stray reconnect blob falls through to normal CREATE and the
+	// standard wire validation must still apply.
+	isDurableReconnect := h.DurableStore != nil &&
+		(FindCreateContext(req.CreateContexts, DurableHandleV1ReconnectTag) != nil ||
+			FindCreateContext(req.CreateContexts, DurableHandleV2ReconnectTag) != nil)
+
 	// Validate ImpersonationLevel per MS-SMB2 §2.2.13: only the four defined
 	// values are accepted (0=Anonymous, 1=Identification, 2=Impersonation,
 	// 3=Delegate). Anything else MUST be rejected with
 	// STATUS_BAD_IMPERSONATION_LEVEL. Required by smbtorture
 	// smb2.create.impersonation.
-	if req.ImpersonationLevel > 3 {
+	if !isDurableReconnect && req.ImpersonationLevel > 3 {
 		logger.Debug("CREATE: invalid impersonation level",
 			"level", fmt.Sprintf("0x%08x", req.ImpersonationLevel))
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusBadImpersonationLevel}}, nil
@@ -539,7 +557,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// bit returns STATUS_INVALID_PARAMETER. Samba sets `invalid_parameter_mask
 	// = 0xff000000` in source3/smbd/smb2_create.c for these probes (smbtorture
 	// smb2.create.gentest).
-	if uint32(req.CreateOptions)&0xff000000 != 0 {
+	if !isDurableReconnect && uint32(req.CreateOptions)&0xff000000 != 0 {
 		logger.Debug("CREATE: reserved CreateOptions bits set",
 			"options", fmt.Sprintf("0x%08x", uint32(req.CreateOptions)))
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
@@ -560,7 +578,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	const unsupportedCreateOptionsMask uint32 = 0x00000080 | // bit 7  (TREE_CONNECTION)
 		uint32(types.FileOpenByFileId) | // bit 13 (0x00002000)
 		0x00100000 // bit 20 (OPFILTER)
-	if uint32(req.CreateOptions)&unsupportedCreateOptionsMask != 0 {
+	if !isDurableReconnect && uint32(req.CreateOptions)&unsupportedCreateOptionsMask != 0 {
 		logger.Debug("CREATE: unsupported CreateOptions bits set",
 			"options", fmt.Sprintf("0x%08x", uint32(req.CreateOptions)))
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported}}, nil
@@ -582,7 +600,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// accepted (no-op on DittoFS) — WPTS FSA tests probe basic-info on a file
 	// created with that attribute and require CREATE to succeed.
 	const validFileAttributesMask uint32 = 0x0000FFB7
-	if uint32(req.FileAttributes)&^validFileAttributesMask != 0 {
+	if !isDurableReconnect && uint32(req.FileAttributes)&^validFileAttributesMask != 0 {
 		logger.Debug("CREATE: invalid FileAttributes bits set",
 			"attrs", fmt.Sprintf("0x%08x", uint32(req.FileAttributes)))
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -293,12 +293,13 @@ type ReconnectResult struct {
 // and on success returns a ReconnectResult. On failure, returns a specific NTSTATUS code.
 //
 // connClientGUID is the ClientGuid of the reconnecting connection (from
-// NEGOTIATE). It is matched against the persisted handle's ClientGUID only on
-// V2 *lease-backed* reconnect — see reopen1a-lease in
-// `source4/torture/smb2/durable_v2_open.c`. Pass [16]byte{} from contexts that
-// have no notion of ClientGuid; lease reconnect with a zero ClientGuid will
-// fail OBJECT_NAME_NOT_FOUND, mirroring Samba's strict per-client-GUID lease
-// key scoping.
+// NEGOTIATE). It is matched against the persisted handle's ClientGUID on both
+// V1 (DHnC) and V2 (DH2C) *lease-backed* reconnect — see reopen1a-lease in
+// `source4/torture/smb2/durable_open.c` (V1) and `durable_v2_open.c` (V2).
+// Per-(ClientGuid, LeaseKey) lease scoping means a lease-backed durable open
+// must be reconnected from the ClientGuid that established it; a mismatch
+// fails OBJECT_NAME_NOT_FOUND. Persisted handles written before ClientGUID
+// was captured carry the zero value and skip the check (forward compat).
 func ProcessDurableReconnectContext(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -326,7 +327,7 @@ func ProcessDurableReconnectContext(
 
 	if dhnCCtx := FindCreateContext(contexts, DurableHandleV1ReconnectTag); dhnCCtx != nil {
 		openFile, leaseState, origID, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
-			sessionID, username, sessionKeyHash, shareName, filename, desiredAccess, shareAccess)
+			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID, desiredAccess, shareAccess)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
@@ -335,6 +336,20 @@ func ProcessDurableReconnectContext(
 
 	// No reconnect context found
 	return nil, types.StatusInvalidParameter, fmt.Errorf("no reconnect context found")
+}
+
+// leaseReconnectClientGUIDMismatch reports whether a lease-backed durable
+// reconnect must be rejected because it arrives on a different ClientGuid than
+// the one that established the open. Per MS-SMB2 §3.3.5.9.7/12 and Samba
+// per-(ClientGuid, LeaseKey) lease scoping, a lease-backed handle (non-zero
+// LeaseKey) MUST be reconnected from its originating ClientGuid. A persisted
+// handle written before ClientGUID was captured carries the zero value and is
+// treated as "no recorded ClientGuid" (forward compat with pre-#432 binaries).
+// Shared by the V1 (DHnC) and V2 (DH2C) reconnect paths.
+func leaseReconnectClientGUIDMismatch(handle *lock.PersistedDurableHandle, connClientGUID [16]byte) bool {
+	return handle.LeaseKey != ([16]byte{}) &&
+		handle.ClientGUID != ([16]byte{}) &&
+		handle.ClientGUID != connClientGUID
 }
 
 // processV1Reconnect handles V1 (DHnC) reconnect validation and restoration.
@@ -350,6 +365,7 @@ func processV1Reconnect(
 	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
+	connClientGUID [16]byte,
 	desiredAccess uint32,
 	shareAccess uint32,
 ) (*OpenFile, uint32, [16]byte, types.Status, error) {
@@ -446,6 +462,17 @@ func processV1Reconnect(
 				"actual", fmt.Sprintf("%x", leaseReq.LeaseKey))
 			return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 		}
+
+		// Reject a lease reconnect arriving on a different ClientGuid than the
+		// one that established the open. smbtorture
+		// smb2.durable-open.reopen1a-lease attempts a lease reconnect from a
+		// fresh ClientGuid and expects OBJECT_NAME_NOT_FOUND.
+		if leaseReconnectClientGUIDMismatch(handle, connClientGUID) {
+			logger.Debug("processV1Reconnect: ClientGuid mismatch on lease-backed reconnect",
+				"persisted", fmt.Sprintf("%x", handle.ClientGUID),
+				"connecting", fmt.Sprintf("%x", connClientGUID))
+			return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		}
 	}
 
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
@@ -521,17 +548,10 @@ func processV2Reconnect(
 		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
-	// Per MS-SMB2 §3.3.5.9.12 and Samba lease-key scoping (per-(ClientGuid,
-	// LeaseKey)), a V2 *lease-backed* durable open MUST be reconnected from
-	// the same ClientGuid that established it. A non-zero LeaseKey on the
-	// persisted handle is our marker for "lease-backed". An older persisted
-	// handle written before ClientGUID was captured carries the zero value;
-	// treat that as "no recorded ClientGuid" and skip the check to preserve
-	// forward compatibility with handles written by pre-#432 binaries
-	// (matches the fall-back pattern already used for GrantedAccess in
-	// validateAndRestore). smbtorture smb2.durable-v2-open.reopen1a-lease.
-	if handle.LeaseKey != ([16]byte{}) && handle.ClientGUID != ([16]byte{}) &&
-		handle.ClientGUID != connClientGUID {
+	// Reject a V2 lease reconnect arriving on a different ClientGuid than the
+	// one that established the open. smbtorture
+	// smb2.durable-v2-open.reopen1a-lease.
+	if leaseReconnectClientGUIDMismatch(handle, connClientGUID) {
 		logger.Debug("processV2Reconnect: ClientGuid mismatch on lease-backed reconnect",
 			"persisted", fmt.Sprintf("%x", handle.ClientGUID),
 			"connecting", fmt.Sprintf("%x", connClientGUID))

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -537,6 +537,85 @@ func TestProcessDurableReconnectContext_V1Success(t *testing.T) {
 	}
 }
 
+// encodeV1LeaseRequestContext builds a minimal 32-byte SMB2_CREATE_REQUEST_LEASE
+// (V1) context carrying leaseKey + leaseState.
+func encodeV1LeaseRequestContext(leaseKey [16]byte, leaseState uint32) []byte {
+	data := make([]byte, LeaseV1ContextSize)
+	copy(data[:16], leaseKey[:])
+	binary.LittleEndian.PutUint32(data[16:20], leaseState)
+	return data
+}
+
+// TestProcessDurableReconnectContext_V1LeaseClientGuidMismatch verifies that a
+// V1 (DHnC) lease-backed reconnect from a different ClientGuid than the one
+// that established the durable open fails OBJECT_NAME_NOT_FOUND, mirroring
+// Samba per-(ClientGuid, LeaseKey) lease scoping. smbtorture
+// smb2.durable-open.reopen1a-lease.
+func TestProcessDurableReconnectContext_V1LeaseClientGuidMismatch(t *testing.T) {
+	store := newMockDurableStore()
+	ctx := context.Background()
+
+	fileID := [16]byte{9, 8, 7, 6, 5, 4, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0}
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC, 0xDD}
+	origClientGUID := [16]byte{0x11, 0x22, 0x33, 0x44}
+	keyHash := makeSessionKeyHash("session-key-lease")
+
+	_ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:             "dh-lease-001",
+		FileID:         fileID,
+		Path:           "leased.txt",
+		ShareName:      "/share1",
+		MetadataHandle: []byte{0xDE, 0xAD},
+		OplockLevel:    OplockLevelLease,
+		LeaseKey:       leaseKey,
+		LeaseState:     uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle),
+		ClientGUID:     origClientGUID,
+		Username:       "alice",
+		SessionKeyHash: keyHash,
+		CreatedAt:      time.Now().Add(-5 * time.Minute),
+		DisconnectedAt: time.Now().Add(-10 * time.Second),
+		TimeoutMs:      60000,
+	})
+
+	dhnCData := make([]byte, 16)
+	copy(dhnCData[:], fileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV1ReconnectTag, Data: dhnCData},
+		{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, 0)},
+	}
+
+	// Reconnect with a DIFFERENT ClientGuid → OBJECT_NAME_NOT_FOUND.
+	wrongClientGUID := [16]byte{0x99, 0x88, 0x77, 0x66}
+	_, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash, "/share1", "leased.txt", wrongClientGUID, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("ProcessDurableReconnectContext error: %v", err)
+	}
+	if status != types.StatusObjectNameNotFound {
+		t.Fatalf("wrong ClientGuid: expected OBJECT_NAME_NOT_FOUND, got %s", status)
+	}
+
+	// Handle must survive a failed (non-destructive) reconnect attempt.
+	if h, _ := store.GetDurableHandle(ctx, "dh-lease-001"); h == nil {
+		t.Fatal("handle should remain after failed ClientGuid-mismatch reconnect")
+	}
+
+	// Reconnect with the ORIGINAL ClientGuid → success.
+	restored, status, err := ProcessDurableReconnectContext(
+		ctx, store, nil, contexts, 999, "alice", keyHash, "/share1", "leased.txt", origClientGUID, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("ProcessDurableReconnectContext (correct GUID) error: %v", err)
+	}
+	if status != types.StatusSuccess {
+		t.Fatalf("correct ClientGuid: expected STATUS_SUCCESS, got %s", status)
+	}
+	if restored == nil || restored.OpenFile.LeaseKey != leaseKey {
+		t.Fatal("expected restored lease-backed open with matching lease key")
+	}
+}
+
 func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -194,7 +194,6 @@ to the DH state machine — tracked under #792 / #793.
 | smb2.durable-open.reopen2-lease | Durable handles V1 | Durable reopen with lease not fully working | #738 |
 | smb2.durable-open.reopen2-lease-v2 | Durable handles V1 | Durable reopen with lease V2 not fully working | #738 |
 | smb2.durable-open.reopen4 | Durable handles V1 | Durable reopen not fully working | #738 |
-| smb2.durable-open.delete_on_close2 | Durable handles V1 | Durable DOC not fully working | #738 |
 | smb2.durable-open.alloc-size | CREATE allocation | Pre-existing non-DH bug: out.alloc_size=0 on CREATE with in.alloc_size set (fails before any reconnect) | #792 |
 | smb2.durable-open.oplock | Disconnected-DH purge | Intervening conflicting open should purge disconnected DH; surfaced after V1 DHnC FileID lookup fix | #808 |
 | smb2.durable-open.open2-lease | Disconnected-DH purge | Intervening conflicting open should purge disconnected DH; surfaced after V1 DHnC FileID lookup fix | #808 |
@@ -374,16 +373,30 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.timestamp_resolution.resolution1 | Timing-dependent (upstream-skipped) | Test source documents `~15ms` Windows timestamp resolution and warns of a `1/15` false-fail rate even on a low-latency reference SMB connection. Explicitly skipped by Samba's own selftest (`selftest/skip:69-70`: `^samba3.smb2.timestamp_resolution` / `^samba4.smb2.timestamp_resolution`) "preserved here for future SMB2 timestamps behaviour archaeologists". DittoFS classifies the same way upstream does. |
 | smb2.create.blob | Create-context coverage (upstream-skipped) | Walks 20+ adversarial CreateContext tag/length combinations against a file-backed share. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.create.blob`) — fails against Samba's own smb3-file backend, not just DittoFS. Implementing all variants requires duplicating Samba's smb1-derived create-context corner cases that have no MS-SMB2 spec mapping. |
 | smb2.create.gentest | Generative impersonation matrix (upstream-skipped) | Brute-forces hundreds of `(create_disposition × create_options × ImpersonationLevel × attribute)` combinations expecting Windows-exact status codes. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.create.gentest`) — fails on Samba file-backed shares. The status-code surface mirrors Windows-internal IRP_MJ_CREATE behaviour, not MS-FSA. |
+| smb2.durable-open.delete_on_close2 | Durable DOC (upstream-skipped) | Reopens a durable handle that was opened with FILE_DELETE_ON_CLOSE, then asserts the post-reconnect delete-on-close + truncate-on-overwrite interaction matches Windows verbatim. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.durable-open.delete_on_close2`) — fails against Samba's own file-backed share, not just DittoFS. The disconnect path intentionally does NOT persist a durable handle carrying delete-on-close (the open is fully closed instead, so the stored content is not resurrected on reconnect); reproducing the exact Windows ordering of DOC-survives-reconnect has no MS-SMB2 spec mapping and is upstream-skipped. |
 | smb2.maxfid | smbtorture wall-clock budget | Test issues up to 65520 sequential synchronous CREATEs (Samba `source4/torture/smb2/maxfid.c:100`, controlled by `torture:maxopenfiles`). Total RTT-bound runtime exceeds the 60s per-test wall set by `run.sh` (STANDALONE_TESTS). DittoFS keeps CREATE succeeding throughout (no protocol-level handle-table cap), so the suite is killed mid-loop before reaching the cleanup phase. Raising the per-test wall to accommodate one stress test inflates full-suite runtime substantially without exercising a protocol gap. |
 | smb2.notify.mask-change | Samba notify-mask quirk | Asserts that, once a CHANGE_NOTIFY completion-filter mask has been armed on a directory handle, re-issuing CHANGE_NOTIFY with a different mask MUST observe the original mask only until the handle is closed (test source: `source4/torture/smb2/notify.c:771-772` — "Now try and change the mask to include other events. This should not work - once the mask is set on a directory h1 it seems to be fixed until the fnum is closed"). MS-SMB2 §3.3.5.19 does not specify mask-coalescing across separate CHANGE_NOTIFY requests on the same handle, and the test has a long-standing "never passed individually" history against DittoFS independent of test order. Surrounding scenarios (cross-tree dir/file rename plumbing, recursion-flag-mixed reqs on the same FID) are also Samba implementation conventions. |
 
-**Total: 24 tests permanently out of scope.**
+**Total: 25 tests permanently out of scope.**
 
 ### Kerberos
 
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-05-30 — #738: `delete_on_close2` → Permanently Unimplementable
+
+`smb2.durable-open.delete_on_close2` promoted from the Durable Handles V1
+(Fix Candidate) table to the Permanently Unimplementable appendix. The test
+is explicitly listed in Samba's own `selftest/knownfail`
+(`^samba3.smb2.durable-open.delete_on_close2`) and fails against Samba's
+file-backed share. DittoFS intentionally fully closes (does not persist) a
+durable handle carrying delete-on-close, so the DOC-survives-reconnect
+ordering the test asserts has no spec mapping. Doc reclassification only —
+the test still fails, just expected. The remaining #738 rows (reopen2,
+reopen1a-lease, reopen2-lease, reopen2-lease-v2) stay as Fix Candidates;
+reopen4 remains referencing #738.
 
 ### 2026-05-29 — #771 closed: 4 `smb2.create.*` residuals walked back
 


### PR DESCRIPTION
## Summary

Fixes the V1 durable-handle (DH V1) reconnect path for #738.

### Tests targeted (CODE fix — KF walkback deferred to post-CI)
- **smb2.durable-open.reopen2** — root cause: the third reconnect in the test replays garbage `ImpersonationLevel` / `CreateOptions` / `FileAttributes` (`0x12345678` / `0x78`) to prove they are ignored. DittoFS ran its standard wire-validation gates against that garbage and returned `STATUS_INVALID_PARAMETER` / `STATUS_BAD_IMPERSONATION_LEVEL` / `STATUS_NOT_SUPPORTED` *before* reaching the Step 4b reconnect handler. CREATE now skips those gates when a DHnC/DH2C reconnect context is present (MS-SMB2 §3.3.5.9.7/12: a reconnect is keyed solely by the FileId/CreateGuid blob). Gated on a configured `DurableStore` so the bypass only applies on the path that actually routes to the reconnect handler.
- **smb2.durable-open.reopen1a-lease** — V1 (DHnC) lease-backed reconnect did not enforce per-`(ClientGuid, LeaseKey)` scoping; a reconnect from a different ClientGuid must fail `OBJECT_NAME_NOT_FOUND`. Added the same scoping the V2 path already had, via a shared `leaseReconnectClientGUIDMismatch` predicate.
- **smb2.durable-open.reopen2-lease** / **reopen2-lease-v2** — lease variants of the reopen2 flow; their final reconnect blocks replay the same garbage fields, so the validation-gate bypass above unblocks them. Lease re-association on DHnC reconnect already restores the V1/V2 lease context.

### Doc reclassification (allowed in this PR — not a flip claim)
- **smb2.durable-open.delete_on_close2** promoted to the **Permanently Unimplementable** appendix, citing Samba upstream `selftest/knownfail` (`^samba3.smb2.durable-open.delete_on_close2`). DittoFS intentionally fully closes (does not persist) a durable handle carrying delete-on-close, so the DOC-survives-reconnect ordering has no spec mapping. Total bumped 24 → 25.

### Out of scope
- **reopen4** left referencing #738 (LOGOFF-preserves-DH design risk — untouched).

## Tests
`go test ./internal/adapter/smb/... ./pkg/metadata/...` green. Added `TestProcessDurableReconnectContext_V1LeaseClientGuidMismatch` covering the new V1 ClientGuid scoping (wrong GUID → `OBJECT_NAME_NOT_FOUND`, non-destructive; correct GUID → success).

KNOWN_FAILURES walkback for the code-fixed rows (reopen2, reopen1a-lease, reopen2-lease, reopen2-lease-v2) is **deferred to post-CI** per the code-only workflow.
