### PR TITLE
fix(smb): ignore client AllocationSize for directories (#792 follow-up)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_alloc_size_test.go
+++ b/internal/adapter/smb/v2/handlers/create_alloc_size_test.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// makeNewFileDraft assembles a createDraft for a fresh (not-yet-existing) file
+// or directory under the given parent, ready for completeCreateAfterBreak.
+// It mirrors what Create() produces after path resolution + the pre-break
+// share-mode check on the FileCreated branch.
+func makeNewFileDraft(
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	req *CreateRequest,
+	isDir bool,
+) *createDraft {
+	return &createDraft{
+		req:                req,
+		tree:               tree,
+		authCtx:            authCtx,
+		parentHandle:       parentHandle,
+		filename:           req.FileName,
+		baseName:           req.FileName,
+		fileExists:         false,
+		createAction:       types.FileCreated,
+		isDirectoryRequest: isDir,
+	}
+}
+
+// TestCreate_AllocSize_HonouredForNewFile reproduces the assertion in Samba
+// smb2.durable-open.alloc-size (source4/torture/smb2/durable_open.c:2754): a
+// fresh CREATE that carries an "AlSi" SMB2_CREATE_ALLOCATION_SIZE create
+// context with a non-zero requested allocation MUST report a non-zero
+// out.alloc_size, cluster-aligned. The create uses a batch oplock + durable
+// request to match the smbtorture wire shape.
+func TestCreate_AllocSize_HonouredForNewFile(t *testing.T) {
+	h, _, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	req := &CreateRequest{
+		FileName:          "alloc.txt",
+		OplockLevel:       OplockLevelBatch,
+		DesiredAccess:     0x001F01FF, // GENERIC_ALL expanded
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileCreate,
+		CreateOptions:     0,
+		AllocationSize:    0x1000, // requested via AlSi context
+	}
+
+	draft := makeNewFileDraft(tree, rootAuth, rootHandle, req, false)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("CREATE status = 0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+	if resp.AllocationSize == 0 {
+		t.Fatalf("out.alloc_size = 0, expected non-zero (requested 0x1000)")
+	}
+	if resp.AllocationSize != 0x1000 {
+		t.Fatalf("out.alloc_size = 0x%x, expected 0x1000", resp.AllocationSize)
+	}
+	if resp.EndOfFile != 0 {
+		t.Fatalf("out.size = %d, expected 0 for fresh empty file", resp.EndOfFile)
+	}
+}
+
+// TestCreate_AllocSize_IgnoredForDirectory reproduces Samba
+// smb2.create.dir_alloc_size (source4/torture/smb2/create.c:2064): a directory
+// created with a large requested allocation MUST ignore it and report only its
+// own (zero) cluster-aligned size — never the client reservation.
+func TestCreate_AllocSize_IgnoredForDirectory(t *testing.T) {
+	h, _, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	req := &CreateRequest{
+		FileName:          "allocdir",
+		OplockLevel:       OplockLevelNone,
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileCreate,
+		CreateOptions:     types.FileDirectoryFile,
+		AllocationSize:    1 << 30, // 1 GiB requested — must be ignored
+	}
+
+	draft := makeNewFileDraft(tree, rootAuth, rootHandle, req, true)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("CREATE status = 0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+	const oneMiB = 1 << 20
+	if resp.AllocationSize > oneMiB {
+		t.Fatalf("dir out.alloc_size = 0x%x, expected <= 1MiB (reservation must be ignored)", resp.AllocationSize)
+	}
+}
+
+// TestCreate_AllocSize_EndToEndDurableBatch reproduces the full wire path of
+// Samba smb2.durable-open.alloc-size end-to-end through Handler.Create: a fresh
+// CREATE with a batch oplock, a DHnQ durable request, and an "AlSi" allocation
+// create context (0x1000). The first assertion of the smbtorture test is
+// out.alloc_size != 0. This drives the real decode → Create → response build
+// chain (not just completeCreateAfterBreak in isolation) so any upstream
+// zeroing of req.AllocationSize is caught.
+func TestCreate_AllocSize_EndToEndDurableBatch(t *testing.T) {
+	h, smbCtx := setupCreateWireTest(t)
+	smbCtx.Context = context.Background()
+	smbCtx.Permission = models.PermissionReadWrite
+	if tree, ok := h.GetTree(smbCtx.TreeID); ok {
+		tree.Permission = models.PermissionReadWrite
+		h.StoreTree(tree)
+	}
+	h.DurableStore = newMockDurableStore()
+
+	contexts := []CreateContext{
+		// DHnQ durable handle request: 16-byte reserved blob per MS-SMB2
+		// §2.2.13.2.3.
+		{Name: DurableHandleV1RequestTag, Data: make([]byte, 16)},
+		// AlSi allocation-size request: 8-byte LE = 0x1000.
+		{Name: "AlSi", Data: []byte{0x00, 0x10, 0, 0, 0, 0, 0, 0}},
+	}
+	body := buildCreateRequestBodyWithContexts("durable_alloc.txt", types.FileCreate, 0, contexts)
+
+	req, err := DecodeCreateRequest(body)
+	if err != nil {
+		t.Fatalf("DecodeCreateRequest: %v", err)
+	}
+	if req.AllocationSize != 0x1000 {
+		t.Fatalf("decode: req.AllocationSize = 0x%x, expected 0x1000", req.AllocationSize)
+	}
+	req.OplockLevel = OplockLevelBatch
+	req.DesiredAccess = 0x001F01FF
+
+	resp, err := h.Create(smbCtx, req)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("CREATE status = 0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+	if resp.AllocationSize == 0 {
+		t.Fatalf("out.alloc_size = 0, expected non-zero (requested 0x1000 via AlSi)")
+	}
+	if resp.AllocationSize != 0x1000 {
+		t.Fatalf("out.alloc_size = 0x%x, expected 0x1000", resp.AllocationSize)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1092,7 +1092,17 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// allocation is the larger of the file's own cluster-aligned size and the
 	// (cluster-aligned) requested reservation. This lets a freshly-created empty
 	// file report a non-zero out.alloc_size when the client asked for one.
-	allocationSize := effectiveAllocationSize(size, req.AllocationSize)
+	//
+	// Directories MUST ignore the client-requested reservation and report only
+	// their own cluster-aligned size (0 for an empty directory). The "AlSi"
+	// create context applies to data files only — smbtorture
+	// smb2.create.dir_alloc_size (source4/torture/smb2/create.c:2064) creates a
+	// directory with alloc_size=1GB and asserts out.alloc_size <= 1MB.
+	requestedAlloc := req.AllocationSize
+	if openFile.IsDirectory {
+		requestedAlloc = 0
+	}
+	allocationSize := effectiveAllocationSize(size, requestedAlloc)
 
 	resp := &CreateResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},


### PR DESCRIPTION
Follow-up to #845 (merged), which added the SMB2 CREATE \"AlSi\" allocation-size
create-context decode and reflected the client-requested reservation in
\`out.alloc_size\`. That fix correctly resolves the initial assertion of
\`smb2.durable-open.alloc-size\` (out.alloc_size != 0 on a fresh
durable+batch-oplock CREATE), but it applied the reservation **unconditionally**
— including to directories.

## Bug

\`effectiveAllocationSize(size, req.AllocationSize)\` is used for every CREATE
success response. A directory created with \`in.alloc_size = 1GB\` then reports
~1GB. Per MS-FSCC, directories report only their own cluster-aligned size (0
when empty); the AlSi reservation applies to data files only. This regressed
\`smb2.create.dir_alloc_size\` (source4/torture/smb2/create.c:2064 — asserts
\`out.alloc_size <= 1MB\`), which reddens the broader smbtorture suite.

## Fix

Gate the client reservation on \`openFile.IsDirectory\` in the shared CREATE
response builder (\`completeCreateAfterBreak\`, which serves both the synchronous
and async lease-break-park paths). Directories pass requested=0 so they report
\`calculateAllocationSize(size)\`; regular files keep the #845 behaviour. The
durable-reconnect and IPC/pipe builders already used \`calculateAllocationSize\`
/ 0, so they were never affected.

## Investigation note (durable alloc=0)

Reproduced the full wire path end-to-end (decode → \`h.Create\` → response) with a
batch oplock + DHnQ durable request + AlSi context: the initial create now
returns \`out.alloc_size = 0x1000\`. The original \`out.alloc_size was 0\` failure
was the pre-AlSi-decode state already fixed by #845 (an earlier iteration read
offset 16 / Reserved, which never carries the value). No additional zeroing
point exists on the durable path.

## Tests

\`internal/adapter/smb/v2/handlers/create_alloc_size_test.go\`:
- file CREATE with AlSi honours the reservation (0x1000)
- directory CREATE ignores a 1GB reservation (<= 1MB)
- full end-to-end \`h.Create\` with batch oplock + DHnQ durable + AlSi → 0x1000

## Gates

\`gofmt\`, \`go vet\`, \`golangci-lint\` (0 issues), \`go test ./internal/adapter/smb/...\` all pass.

## Notes

- #845 is **merged**, not open — nothing to close there.
- The \`smb2.durable-open.alloc-size\` row in KNOWN_FAILURES.md (referencing #792)
  is intentionally left in place; only CI smbtorture can confirm the flip.