### PR TITLE
Revert #845: CREATE AllocationSize honouring (regressed create.open + dir-alloc-size, #792 unfixed)

### DIFF
--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -79,28 +79,8 @@ func isFiletimeSentinel(ft uint64) bool {
 }
 
 // calculateAllocationSize returns the size rounded up to the nearest cluster boundary.
-// The round-up addition is saturated: a client-controlled requested allocation
-// [MS-SMB2] 2.2.13 within clusterSize-1 of the uint64 max would otherwise wrap
-// to a small value, so such inputs clamp to the largest cluster-aligned uint64.
 func calculateAllocationSize(size uint64) uint64 {
-	const maxAligned = (^uint64(0) / clusterSize) * clusterSize
-	if size > maxAligned {
-		return maxAligned
-	}
 	return ((size + clusterSize - 1) / clusterSize) * clusterSize
-}
-
-// effectiveAllocationSize returns the allocation size to report for a file,
-// honouring a client-requested reservation [MS-SMB2] 2.2.13. It is the larger
-// of the file's own cluster-aligned size and the cluster-aligned requested
-// allocation, so an empty file opened with a non-zero requested allocation
-// reports a non-zero AllocationSize.
-func effectiveAllocationSize(size, requested uint64) uint64 {
-	alloc := calculateAllocationSize(size)
-	if reqAlloc := calculateAllocationSize(requested); reqAlloc > alloc {
-		return reqAlloc
-	}
-	return alloc
 }
 
 // getSMBSize returns the appropriate size for SMB reporting.

--- a/internal/adapter/smb/v2/handlers/converters_test.go
+++ b/internal/adapter/smb/v2/handlers/converters_test.go
@@ -8,38 +8,6 @@ import (
 )
 
 // =============================================================================
-// effectiveAllocationSize Tests
-// =============================================================================
-
-func TestEffectiveAllocationSize(t *testing.T) {
-	cases := []struct {
-		name      string
-		size      uint64
-		requested uint64
-		want      uint64
-	}{
-		{"empty file no request", 0, 0, 0},
-		// An empty file opened with a requested allocation must report a
-		// non-zero, cluster-aligned AllocationSize (smb2.durable-open.alloc-size).
-		{"empty file requested 0x1000", 0, 0x1000, 0x1000},
-		{"requested rounds up to cluster", 0, 0x1001, 0x2000},
-		{"file size exceeds request", 0x3000, 0x1000, 0x3000},
-		{"request exceeds file size", 0x1000, 0x5000, 0x5000},
-		// A client-controlled requested allocation within clusterSize-1 of the
-		// uint64 max must saturate, not wrap to a small value.
-		{"requested near-max saturates", 0, ^uint64(0), 0xFFFFFFFFFFFFF000},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := effectiveAllocationSize(tc.size, tc.requested); got != tc.want {
-				t.Errorf("effectiveAllocationSize(%d, %d) = %d, want %d",
-					tc.size, tc.requested, got, tc.want)
-			}
-		})
-	}
-}
-
-// =============================================================================
 // FileAttrToFileStandardInfo Tests
 // =============================================================================
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -65,13 +65,6 @@ type CreateRequest struct {
 	// See types.CreateOptions for bit flags.
 	CreateOptions types.CreateOptions
 
-	// AllocationSize is the client-requested initial allocation size in bytes
-	// [MS-SMB2] 2.2.13. We do not preallocate backing storage; the value only
-	// raises the (cluster-aligned) AllocationSize reported in the CREATE
-	// response so a freshly-created empty file reports a non-zero allocation.
-	// The QueryInfo FileStandardInformation path is unaffected.
-	AllocationSize uint64
-
 	// FileName is the name/path of the file to create or open.
 	// Uses backslash separators (Windows-style).
 	FileName string
@@ -188,7 +181,7 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 	oplockLevel := r.ReadUint8()         // OplockLevel (1)
 	impersonationLevel := r.ReadUint32() // ImpersonationLevel (4)
 	r.Skip(8)                            // SmbCreateFlags (8)
-	r.Skip(8)                            // Reserved (8) — SMB2 has no fixed AllocationSize field
+	r.Skip(8)                            // Reserved (8)
 	desiredAccess := r.ReadUint32()      // DesiredAccess (4)
 	// Per MS-DTYP §2.4.3 / §2.5.3, GENERIC_* bits in DesiredAccess MUST be
 	// expanded to file-object-specific rights before access-check
@@ -269,15 +262,6 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 				req.CreateContexts = ctxs
 			}
 		}
-	}
-
-	// SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create context [MS-SMB2] 2.2.13.2.2:
-	// SMB2 has no fixed AllocationSize request field, so the client conveys the
-	// requested initial allocation as an 8-byte little-endian value in this
-	// context's Data. The server reflects it (cluster-aligned) in the CREATE
-	// response AllocationSize. Required by smbtorture smb2.durable-open.alloc-size.
-	if alsi := FindCreateContext(req.CreateContexts, "AlSi"); alsi != nil && len(alsi.Data) >= 8 {
-		req.AllocationSize = smbenc.NewReader(alsi.Data).ReadUint64()
 	}
 
 	return req, nil

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1088,11 +1088,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 	creation, access, write, change := FileAttrToSMBTimes(respAttr)
 	size := getSMBSize(&file.FileAttr)
-	// Honour the client-requested AllocationSize [MS-SMB2] 2.2.13: the reported
-	// allocation is the larger of the file's own cluster-aligned size and the
-	// (cluster-aligned) requested reservation. This lets a freshly-created empty
-	// file report a non-zero out.alloc_size when the client asked for one.
-	allocationSize := effectiveAllocationSize(size, req.AllocationSize)
+	allocationSize := calculateAllocationSize(size)
 
 	resp := &CreateResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -97,39 +97,6 @@ func TestDecodeCreateRequest_ShortBody(t *testing.T) {
 		}
 	})
 
-	t.Run("ParsesAllocationSizeFromAlSiContext", func(t *testing.T) {
-		// SMB2 has no fixed AllocationSize request field; the client sends it
-		// in the SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create context [MS-SMB2]
-		// 2.2.13.2.2 as an 8-byte little-endian value.
-		data := make([]byte, 8)
-		binary.LittleEndian.PutUint64(data, 0x1000)
-		body := buildCreateRequestBodyWithContexts("file.txt", types.FileCreate, 0,
-			[]CreateContext{{Name: "AlSi", Data: data}})
-
-		req, err := DecodeCreateRequest(body)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if req.AllocationSize != 0x1000 {
-			t.Errorf("AllocationSize = %d, expected 0x1000", req.AllocationSize)
-		}
-	})
-
-	t.Run("IgnoresReservedFieldForAllocationSize", func(t *testing.T) {
-		// The 8-byte field at offset 16 is Reserved in the SMB2 CREATE request;
-		// a value there must NOT be interpreted as AllocationSize.
-		body := buildCreateRequestBody("file.txt", types.FileCreate, 0)
-		binary.LittleEndian.PutUint64(body[16:24], 0x9999)
-
-		req, err := DecodeCreateRequest(body)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if req.AllocationSize != 0 {
-			t.Errorf("AllocationSize = %d, expected 0 (Reserved must be ignored)", req.AllocationSize)
-		}
-	})
-
 	t.Run("NilBody", func(t *testing.T) {
 		_, err := DecodeCreateRequest(nil)
 		if err == nil {


### PR DESCRIPTION
Reverts #845 (`27a4f8b2`).

## Why

#845 aimed to fix `smb2.durable-open.alloc-size` (#792) by decoding the `AlSi` SMB2_CREATE_ALLOCATION_SIZE create context and reflecting the requested allocation in the CREATE response. CI on the merged commit proves it is **net-negative**:

- **Target not fixed**: `smb2.durable-open.alloc-size` still returns `out.alloc_size=0` on the real wire path (remains KNOWN). The unit test passed but the live durable+batch-oplock CREATE path does not reflect the decoded reservation.
- **Regression `smb2.create.open`**: creates a file with `in.alloc_size=1MB` and asserts the CREATE `out.alloc_size` matches the QUERY_INFO value. Before #845 both paths consistently reported `calculateAllocationSize(size)`; #845 made CREATE alone honour the reservation (buggily — returns 4096, not 1MB), breaking CREATE↔QUERY consistency.
- **Regression `smb2.create.dir-alloc-size`**: directories reported the requested allocation instead of ≤1MB (a separate follow-up, #848, fixed only this one).

Net: develop went RED (`create.open` + `dir-alloc-size` new failures) with no test flipped. Reverting restores the green baseline; `durable-open.alloc-size` returns to its prior KNOWN state.

## Follow-up

Properly honouring `in.alloc_size` requires persisting the reservation in file metadata and reflecting it **consistently** across CREATE, QUERY_INFO (FILE_ALL_INFORMATION / FILE_STANDARD_INFORMATION), and durable reconnect — a real feature, tracked under #792. The naive CREATE-only response change is insufficient.

#848 (dir-guard on top of #845) is superseded by this revert and will be closed.