### PR TITLE
fix(smb): preserve durable handles across explicit LOGOFF (#738 reopen4)

### DIFF
--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -955,8 +955,11 @@ func (h *Handler) ReleaseAllLocksForSession(ctx context.Context, sessionID uint6
 
 // CloseAllFilesForSession closes all open files for a session.
 // This releases locks, flushes caches, handles delete-on-close, and removes file handles.
-// When isDisconnect is true (transport drop), durable handles are persisted for reconnection.
-// When isDisconnect is false (explicit LOGOFF), durable handles are fully closed.
+// When isDisconnect is true, durable handles are persisted for reconnection. Both a
+// transport drop and an explicit LOGOFF pass true: a durable handle is owned by the
+// durable scope, not the session, so it survives logoff and stays reconnectable via
+// DHnC/DH2C (smb2.durable-open.reopen4). Only a TREE_DISCONNECT destroys durable handles
+// (isDisconnect=false in CloseAllFilesForTree).
 // Returns the number of files closed.
 func (h *Handler) CloseAllFilesForSession(ctx context.Context, sessionID uint64, isDisconnect bool) int {
 	filter := func(f *OpenFile) bool {

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -954,12 +954,16 @@ func (h *Handler) ReleaseAllLocksForSession(ctx context.Context, sessionID uint6
 }
 
 // CloseAllFilesForSession closes all open files for a session.
-// This releases locks, flushes caches, handles delete-on-close, and removes file handles.
-// When isDisconnect is true, durable handles are persisted for reconnection. Both a
-// transport drop and an explicit LOGOFF pass true: a durable handle is owned by the
-// durable scope, not the session, so it survives logoff and stays reconnectable via
-// DHnC/DH2C (smb2.durable-open.reopen4). Only a TREE_DISCONNECT destroys durable handles
-// (isDisconnect=false in CloseAllFilesForTree).
+// For non-persisted opens this releases locks, flushes caches, handles delete-on-close,
+// and removes file handles. When isDisconnect is true, eligible durable handles are
+// instead persisted for reconnection (locks retained, caches NOT flushed, delete-on-close
+// NOT executed). Both a transport drop and an explicit LOGOFF pass true: a durable handle
+// is owned by the durable scope, not the session, so it survives logoff and stays
+// reconnectable via DHnC/DH2C (smb2.durable-open.reopen4). Callers that pass
+// isDisconnect=false — a TREE_DISCONNECT (CloseAllFilesForTree) or a session teardown
+// that is not a reconnectable drop — fully close durable handles instead. Eligibility is
+// further gated inside closeFilesWithFilter: delete-on-close opens and BR-lock-without-W
+// opens are closed, not persisted.
 // Returns the number of files closed.
 func (h *Handler) CloseAllFilesForSession(ctx context.Context, sessionID uint64, isDisconnect bool) int {
 	filter := func(f *OpenFile) bool {

--- a/internal/adapter/smb/v2/handlers/logoff.go
+++ b/internal/adapter/smb/v2/handlers/logoff.go
@@ -187,7 +187,19 @@ func (h *Handler) Logoff(ctx *SMBHandlerContext, req *LogoffRequest) (*LogoffRes
 	// pending blocking LOCKs from other handles retry and potentially
 	// succeed before we cancel them. Matches Samba's brl_close_fnum
 	// ordering where lock release precedes waiter cancellation.
-	filesClosed := h.CloseAllFilesForSession(ctx.Context, ctx.SessionID, false)
+	//
+	// isDisconnect=true: a durable handle MUST survive an explicit LOGOFF
+	// and remain reconnectable on a fresh session via DHnC/DH2C. Per the
+	// MS-SMB2 durable-handle model the open is owned by the durable scope,
+	// not the session — Samba preserves it across logoff exactly as across a
+	// transport drop. smb2.durable-open.reopen4 logs off, sets up a new
+	// session on the same transport, and asserts the V1 reconnect succeeds
+	// (EXISTED, oplock_level=BATCH). A plain TREE_DISCONNECT (reopen3) still
+	// destroys the handle — that path keeps isDisconnect=false in
+	// CloseAllFilesForTree. Non-durable opens, and durable opens carrying
+	// delete-on-close, are unaffected: closeFilesWithFilter only diverges for
+	// IsDurable && !hasDeleteOnClose, fully closing everything else as before.
+	filesClosed := h.CloseAllFilesForSession(ctx.Context, ctx.SessionID, true)
 
 	// Drain any remaining pending blocking LOCKs for this session.
 	// After file close, most pending locks on this session's handles are

--- a/internal/adapter/smb/v2/handlers/logoff.go
+++ b/internal/adapter/smb/v2/handlers/logoff.go
@@ -183,10 +183,14 @@ func (h *Handler) Logoff(ctx *SMBHandlerContext, req *LogoffRequest) (*LogoffRes
 	logger.Debug("Logoff: partial cleanup (session kept for response signing)",
 		"sessionID", ctx.SessionID)
 
-	// Close files FIRST to release held byte-range locks. This lets
-	// pending blocking LOCKs from other handles retry and potentially
-	// succeed before we cancel them. Matches Samba's brl_close_fnum
-	// ordering where lock release precedes waiter cancellation.
+	// Close files FIRST to release held byte-range locks for the opens that
+	// are actually closing. This lets pending blocking LOCKs from other
+	// handles retry and potentially succeed before we cancel them. Matches
+	// Samba's brl_close_fnum ordering where lock release precedes waiter
+	// cancellation. Opens that persist as durable reconnectable handles
+	// (see below) intentionally RETAIN their byte-range locks — the locks
+	// travel with the handle and are restored on reconnect, so they are not
+	// released here.
 	//
 	// isDisconnect=true: a durable handle MUST survive an explicit LOGOFF
 	// and remain reconnectable on a fresh session via DHnC/DH2C. Per the


### PR DESCRIPTION
Part of #738 (Durable Handles V1 reopen residuals).

## Change
`smb2.durable-open.reopen4` opens a durable handle, logs off, sets up a new session on the same transport, and asserts the V1 durable reconnect succeeds (create_action=EXISTED, oplock_level=BATCH). DittoFS previously fully closed durable handles on explicit LOGOFF.

Per the MS-SMB2 durable-handle model the open is owned by the durable scope, not the session — Samba preserves it across logoff exactly as across a transport drop. `Logoff` now passes `isDisconnect=true` to `CloseAllFilesForSession` so durable (non-delete-on-close) opens persist for reconnect.

## Safety
The persist branch is gated on `IsDurable && DurableStore != nil && isDisconnect && !hasDeleteOnClose`. Non-durable opens and delete-on-close durable opens close exactly as before. A plain TREE_DISCONNECT still destroys the handle (`CloseAllFilesForTree` keeps `isDisconnect=false`).

## Verification
Expect `smb2.durable-open.reopen4` to flip. Could NOT verify smbtorture locally (CI-only) — CI must confirm the flip AND no regression before the KNOWN_FAILURES row is walked back (left untouched here per two-commit discipline). The deeper reopen2-family persistence race (reopen2 / reopen2-lease / reopen2-lease-v2) is NOT addressed here and remains open under #738.