### PR TITLE
fix(postgres): production-ready + CI-verified backend (store_id reopen, CreateShare, rollup prev) + byte-verify snapshot matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,6 +27,24 @@ jobs:
       matrix:
         go-version: ["1.25.x"]
 
+    # PostgreSQL service so the metadata-store integration + conformance
+    # suites actually run in CI. The postgres test factory connects to
+    # localhost:5432, database dittofs_test, postgres/postgres.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: dittofs_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,8 +58,14 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      # -p 1 serializes package test binaries: several packages (metadata
+      # store conformance, blockstore engine drain) share the single
+      # dittofs_test database, and the conformance suite truncates it
+      # between subtests — running their binaries concurrently would race.
       - name: Run all integration tests
-        run: go test -tags=integration -v -timeout=15m ./...
+        env:
+          DITTOFS_TEST_POSTGRES_DSN: "host=localhost port=5432 dbname=dittofs_test user=postgres password=postgres sslmode=disable"
+        run: go test -tags=integration -v -timeout=20m -p 1 ./...
 
       - name: Install and start rpcbind
         run: |

--- a/pkg/apiclient/snapshots_test.go
+++ b/pkg/apiclient/snapshots_test.go
@@ -198,6 +198,44 @@ func TestRestoreSnapshot(t *testing.T) {
 	assert.True(t, sent.AllowNonDurable)
 }
 
+// TestRestoreSnapshot_UsesRestoreTimeoutNotBaseClient is the behavioral
+// regression for #842: a remote-backed restore whose server-side
+// safety-snapshot drain runs longer than the base 30s http.Client timeout
+// must NOT be killed client-side. The fix routes RestoreSnapshot through a
+// per-call client whose Timeout is restoreHTTPTimeout (30m default), not the
+// 30s base client.
+//
+// We prove the restore call is governed by restoreHTTPTimeout — not the base
+// 30s client — without waiting 30s: point a SHORT restore timeout at a server
+// that delays slightly longer and assert it times out. If restore wrongly
+// used the 30s base client, the short delay would succeed; the timeout error
+// proves restoreHTTPTimeout is the authority.
+func TestRestoreSnapshot_UsesRestoreTimeoutNotBaseClient(t *testing.T) {
+	const serverDelay = 250 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(serverDelay)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RestoreSnapshotResponse{SnapshotID: "s", Share: "/a"})
+	}))
+	defer srv.Close()
+
+	// (a) Restore timeout SHORTER than the server delay -> must fail. This is
+	// only possible because the restore call honors restoreHTTPTimeout; the
+	// 30s base client would have waited out the 250ms delay and succeeded.
+	cShort := New(srv.URL, WithRestoreTimeout(40*time.Millisecond))
+	_, err := cShort.RestoreSnapshot("/a", "s", RestoreSnapshotRequest{})
+	require.Error(t, err, "restore must honor the short restoreHTTPTimeout, not the 30s base client")
+
+	// (b) Restore timeout LONGER than the server delay -> must succeed,
+	// confirming the per-call client is wired and not capped at the base 30s
+	// in a way that would matter here.
+	cLong := New(srv.URL, WithRestoreTimeout(10*time.Second))
+	resp, err := cLong.RestoreSnapshot("/a", "s", RestoreSnapshotRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 func TestRestoreSnapshot_PreconditionFailed(t *testing.T) {
 	s := newStubServer(t)
 	defer s.Close()

--- a/pkg/blockstore/remote/s3/ds3_consistency_probe_test.go
+++ b/pkg/blockstore/remote/s3/ds3_consistency_probe_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"lukechampine.com/blake3"
+)
+
+// ds3ProbeConfig builds an s3.Config from the DS3_* env vars used by the
+// live validation harness (see /tmp/ds3.env). Skips when unset.
+func ds3ProbeConfig(t *testing.T) Config {
+	t.Helper()
+	endpoint := os.Getenv("DS3_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("DS3_ENDPOINT not set; skipping DS3 consistency probe")
+	}
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = "https://" + endpoint
+	}
+	region := os.Getenv("DS3_REGION")
+	if region == "" {
+		region = "eu-central-1"
+	}
+	return Config{
+		Bucket:    os.Getenv("DS3_BUCKET"),
+		Region:    region,
+		Endpoint:  endpoint,
+		AccessKey: os.Getenv("DS3_ACCESS_KEY"),
+		SecretKey: os.Getenv("DS3_SECRET_KEY"),
+		KeyPrefix: "probe/" + t.Name() + "/",
+	}
+}
+
+// TestDS3_ReadAfterWriteConsistency measures the read-after-write window:
+// PUT a fresh random block, then HEAD it in a tight loop, recording how
+// many HEAD attempts (not wall time — the round-trip itself is tens of ms)
+// elapse before the object becomes visible. attempts==1 on every iteration
+// means DS3 is strongly read-after-write consistent for a single
+// PUT→HEAD, which rules eventual consistency OUT as the cause of the
+// snapshot "verify chunk not found" failure (that must instead be a hash
+// that was never uploaded). attempts>1 would implicate a propagation
+// window the snapshot verify must tolerate with a HEAD retry/backoff.
+func TestDS3_ReadAfterWriteConsistency(t *testing.T) {
+	cfg := ds3ProbeConfig(t)
+	store, err := NewFromConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFromConfig: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const iterations = 12
+	var maxLag time.Duration
+	lagged := 0 // iterations needing >1 HEAD attempt (true propagation lag)
+
+	for i := 0; i < iterations; i++ {
+		data := make([]byte, 64*1024)
+		if _, err := rand.Read(data); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		hash := blockstore.ContentHash(blake3.Sum256(data))
+		ctx := context.Background()
+
+		putStart := time.Now()
+		if err := store.Put(ctx, hash, data); err != nil {
+			t.Fatalf("iter %d: Put: %v", i, err)
+		}
+		putDur := time.Since(putStart)
+
+		// Tight HEAD loop, measuring time-to-visible.
+		deadline := time.Now().Add(15 * time.Second)
+		var lag time.Duration
+		visStart := time.Now()
+		attempts := 0
+		for {
+			attempts++
+			_, herr := store.Head(ctx, hash)
+			if herr == nil {
+				lag = time.Since(visStart)
+				break
+			}
+			if !errors.Is(herr, blockstore.ErrChunkNotFound) {
+				t.Fatalf("iter %d: Head non-404 error: %v", i, herr)
+			}
+			if time.Now().After(deadline) {
+				t.Errorf("iter %d: hash %s NEVER became visible within 15s (%d HEAD attempts) — durability gap, not lag", i, hash, attempts)
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		if attempts > 1 {
+			lagged++
+			if lag > maxLag {
+				maxLag = lag
+			}
+		}
+		t.Logf("iter %2d: put=%6s  head-attempts=%2d  head-rtt=%8s", i, putDur.Round(time.Millisecond), attempts, lag.Round(time.Millisecond))
+		_ = store.Delete(ctx, hash)
+	}
+
+	t.Logf("SUMMARY: %d/%d iterations needed >1 HEAD attempt (true propagation lag); max settle=%s", lagged, iterations, maxLag.Round(time.Millisecond))
+	if lagged > 0 {
+		fmt.Printf("DS3 SHOWS PROPAGATION LAG: %d/%d PUTs not visible on first HEAD (max settle %s) — snapshot verify needs HEAD retry/backoff\n", lagged, iterations, maxLag.Round(time.Millisecond))
+	} else {
+		fmt.Printf("DS3 strongly consistent: all %d PUTs visible on first HEAD — 'verify chunk not found' is a never-uploaded hash, not a lag\n", iterations)
+	}
+}
+
+// TestDS3_PutThenGetBytes confirms a PUT is byte-faithful once visible, and
+// that GET returns the exact bytes (rules out silent truncation/corruption
+// on the DS3 path independent of the consistency window).
+func TestDS3_PutThenGetBytes(t *testing.T) {
+	cfg := ds3ProbeConfig(t)
+	store, err := NewFromConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFromConfig: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	data := make([]byte, 256*1024+777) // non-block-aligned
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	hash := blockstore.ContentHash(blake3.Sum256(data))
+	if err := store.Put(ctx, hash, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	defer func() { _ = store.Delete(ctx, hash) }()
+
+	// Poll until visible (consistency window), then byte-compare.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		got, gerr := store.Get(ctx, hash)
+		if gerr == nil {
+			if !bytes.Equal(got, data) {
+				t.Fatalf("GET bytes differ: got %d bytes, want %d", len(got), len(data))
+			}
+			return
+		}
+		if !errors.Is(gerr, blockstore.ErrChunkNotFound) {
+			t.Fatalf("Get error: %v", gerr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("hash never became visible for GET within 15s")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -59,6 +59,7 @@ var (
 	ErrRestoreAborted              = errors.New("restore aborted; safety snapshot retained for rollback")
 	ErrRestoreVerifyFailed         = errors.New("restore verify failed: missing hashes on remote")
 	ErrRestoreMarkerNotFound       = errors.New("restore marker not found")
+	ErrRestoreInProgress           = errors.New("a restore is already in progress for this share")
 
 	// Setting errors
 	ErrSettingNotFound = errors.New("setting not found")

--- a/pkg/controlplane/models/errors_restore_test.go
+++ b/pkg/controlplane/models/errors_restore_test.go
@@ -23,6 +23,7 @@ func restoreSentinels() []struct {
 		{"ErrRestoreSafetySnapFailed", models.ErrRestoreSafetySnapFailed},
 		{"ErrRestoreAborted", models.ErrRestoreAborted},
 		{"ErrRestoreVerifyFailed", models.ErrRestoreVerifyFailed},
+		{"ErrRestoreInProgress", models.ErrRestoreInProgress},
 	}
 }
 

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -90,6 +90,17 @@ type Runtime struct {
 	snapDeleteLocks   map[string]*sync.RWMutex
 	snapDeleteLocksMu sync.Mutex
 
+	// restoreLocks serializes RestoreSnapshot per share. Restore requires
+	// the share be disabled, but two concurrent restore calls both observe
+	// "disabled" and would otherwise interleave their destructive metadata
+	// Reset + dump-replay (the single-`creating`-slot DB index only
+	// serializes the safety-snap create, which frees between steps). A
+	// per-share mutex held for the whole restore makes a second concurrent
+	// restore fail fast with models.ErrRestoreInProgress. Keyed by share
+	// name; the same pointer is reused per share via restoreLock().
+	restoreLocks   map[string]*sync.Mutex
+	restoreLocksMu sync.Mutex
+
 	// runtimeCtx is a long-lived ctx cancelled by Runtime.Shutdown
 	// (plan 23-05). Snapshot orchestration goroutines derive their
 	// child ctx from this so they outlive any caller request ctx
@@ -117,6 +128,7 @@ func New(s store.Store) *Runtime {
 		adapterProviders: make(map[string]any),
 		snapInFlight:     make(map[string]*snapInFlight),
 		snapDeleteLocks:  make(map[string]*sync.RWMutex),
+		restoreLocks:     make(map[string]*sync.Mutex),
 		storesSvc:        stores.New(),
 		sharesSvc:        shares.New(),
 		lifecycleSvc:     lifecycle.New(DefaultShutdownTimeout),

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1131,6 +1131,20 @@ func (r *Runtime) restoreSnapshot(
 		return "", errors.New("runtime: nil store")
 	}
 
+	// --- serialize restores per share ---
+	// Two concurrent restores both pass the share-disabled precheck below
+	// and would otherwise interleave their destructive metadata Reset +
+	// dump replay (corrupting both). Hold a per-share mutex for the whole
+	// restore; a second concurrent restore fails fast. TryLock (not Lock)
+	// so the caller gets an immediate, actionable error instead of blocking
+	// behind a multi-minute restore.
+	rlock := r.restoreLock(shareName)
+	if !rlock.TryLock() {
+		return "", fmt.Errorf("restore snapshot %q on share %q: %w",
+			snapID, shareName, models.ErrRestoreInProgress)
+	}
+	defer rlock.Unlock()
+
 	// --- precheck ---
 	enabled, err := r.sharesSvc.IsShareEnabled(shareName)
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_byteverify_postgres_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_postgres_test.go
@@ -20,9 +20,30 @@ import (
 // runnable without a database.
 func init() {
 	postgresByteVerifyBackend = &byteVerifyBackend{
-		name: "postgres",
-		open: openPostgresByteVerify,
+		name:   "postgres",
+		open:   openPostgresByteVerify,
+		reopen: reopenPostgresByteVerify,
 	}
+}
+
+// reopenPostgresByteVerify reopens the postgres store from the same DSN
+// WITHOUT a Reset, so the persisted schema + data survive the simulated
+// restart. This also re-exercises the ensureStoreID self-heal on reopen
+// (the singleton store_id row must round-trip, not deadlock the open).
+func reopenPostgresByteVerify(t *testing.T) metadata.MetadataStore {
+	t.Helper()
+	dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping postgres reopen")
+	}
+	cfg := parsePostgresDSN(t, dsn)
+	cfg.AutoMigrate = true
+	store, err := metadatapostgres.NewPostgresMetadataStore(context.Background(), cfg, byteVerifyPostgresCaps())
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore (restart reopen): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
 }
 
 func openPostgresByteVerify(t *testing.T) (metadata.MetadataStore, string) {

--- a/pkg/controlplane/runtime/snapshot_byteverify_postgres_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_postgres_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatapostgres "github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// init installs the postgres backend into the byte-verify matrix. Built only
+// under -tags=integration so the memory+badger cases stay runnable under plain
+// `go test`. The actual DSN gate lives in open(): if DITTOFS_TEST_POSTGRES_DSN
+// is unset the case Skips rather than fails, keeping the integration binary
+// runnable without a database.
+func init() {
+	postgresByteVerifyBackend = &byteVerifyBackend{
+		name: "postgres",
+		open: openPostgresByteVerify,
+	}
+}
+
+func openPostgresByteVerify(t *testing.T) (metadata.MetadataStore, string) {
+	t.Helper()
+	dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping postgres byte-verify case")
+	}
+	cfg := parsePostgresDSN(t, dsn)
+	cfg.AutoMigrate = true
+	caps := byteVerifyPostgresCaps()
+	ctx := context.Background()
+
+	// Reset-then-reopen for a clean isolated schema (mirrors the postgres
+	// conformance factory): open, truncate any prior data, re-open so the
+	// singleton capability/store_id rows are re-seeded on the empty schema.
+	seed, err := metadatapostgres.NewPostgresMetadataStore(ctx, cfg, caps)
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore (seed): %v", err)
+	}
+	if err := seed.Reset(ctx); err != nil {
+		_ = seed.Close()
+		t.Fatalf("postgres Reset: %v", err)
+	}
+	_ = seed.Close()
+
+	store, err := metadatapostgres.NewPostgresMetadataStore(ctx, cfg, caps)
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore (reopen): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, "postgres"
+}
+
+// parsePostgresDSN turns a libpq key=value DSN
+// ("host=localhost port=5432 dbname=... user=... password=... sslmode=...")
+// into the typed config the postgres store constructor expects. The store
+// factory hardcodes dittofs_test elsewhere, so this test reads the dbname
+// straight from the DSN env to keep its usage isolated to the dedicated
+// dittofs_test_matrix database.
+func parsePostgresDSN(t *testing.T, dsn string) *metadatapostgres.PostgresMetadataStoreConfig {
+	t.Helper()
+	cfg := &metadatapostgres.PostgresMetadataStoreConfig{
+		Host:    "localhost",
+		Port:    5432,
+		SSLMode: "disable",
+	}
+	for _, field := range strings.Fields(dsn) {
+		kv := strings.SplitN(field, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key, val := kv[0], kv[1]
+		switch key {
+		case "host":
+			cfg.Host = val
+		case "port":
+			p, err := strconv.Atoi(val)
+			if err != nil {
+				t.Fatalf("parse DSN port %q: %v", val, err)
+			}
+			cfg.Port = p
+		case "dbname", "database":
+			cfg.Database = val
+		case "user":
+			cfg.User = val
+		case "password":
+			cfg.Password = val
+		case "sslmode", "ssl_mode":
+			cfg.SSLMode = val
+		}
+	}
+	if cfg.Database == "" {
+		t.Fatalf("DITTOFS_TEST_POSTGRES_DSN %q has no dbname", dsn)
+	}
+	return cfg
+}
+
+func byteVerifyPostgresCaps() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+}

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -424,7 +424,6 @@ func runByteVerifyCycle(t *testing.T, fx *byteVerifyFixture) {
 	if enabled, _ := fx.rt.sharesSvc.IsShareEnabled(fx.shareName); enabled {
 		t.Fatal("share enabled after restore — must stay disabled")
 	}
-	_ = pidC
 }
 
 // TestSnapshotByteVerify_Matrix is the table-driven matrix over metadata-store

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -31,12 +31,27 @@ type byteVerifyFixture struct {
 	bs            *engine.Store
 	shareName     string
 	localStoreDir string
+
+	// Captured so simulateRestart can rebuild the Runtime over the SAME
+	// control-plane store and re-register the reopened metadata store.
+	metaStoreName string
+	localID       string
+	remoteID      string
 }
 
 // newByteVerifyFixture builds the fixture for the given metadata store. The
 // metaType is the engine label recorded in the cpstore ("memory" | "badger" |
 // "postgres") — it drives snapshot/restore's per-engine Restoreable dispatch.
 func newByteVerifyFixture(t *testing.T, meta metadata.MetadataStore, metaType string) *byteVerifyFixture {
+	return newByteVerifyFixtureOpts(t, meta, metaType, nil)
+}
+
+// newByteVerifyFixtureOpts is newByteVerifyFixture with an optional remote
+// block store. When remoteCfg is non-nil it is persisted as a remote
+// BlockStoreConfig and wired onto the share (RemoteBlockStoreID), so the
+// engine gets a real syncer + remote target and snapshot create runs the
+// full drain -> VerifyRemoteDurability gate. nil keeps the share local-only.
+func newByteVerifyFixtureOpts(t *testing.T, meta metadata.MetadataStore, metaType string, remoteCfg *models.BlockStoreConfig) *byteVerifyFixture {
 	t.Helper()
 
 	cp, err := cpstore.New(&cpstore.Config{
@@ -83,6 +98,17 @@ func newByteVerifyFixture(t *testing.T, meta metadata.MetadataStore, metaType st
 		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
+	// Optional remote block store: persist it and capture its ID so the
+	// share is wired with a real syncer + remote target.
+	var remoteID string
+	if remoteCfg != nil {
+		rid, rerr := cp.CreateBlockStore(context.Background(), remoteCfg)
+		if rerr != nil {
+			t.Fatalf("CreateBlockStore(remote): %v", rerr)
+		}
+		remoteID = rid
+	}
+
 	shareName := "/bv-share"
 	// AddShare creates the root directory but not the Share record itself;
 	// the metadata store needs the Share row so GetRootHandle can resolve it.
@@ -92,19 +118,24 @@ func newByteVerifyFixture(t *testing.T, meta metadata.MetadataStore, metaType st
 	// Persist the cpstore Share row so DisableShare (which writes
 	// shares.enabled in the DB) resolves it. AddShare only populates the
 	// runtime registry, not this row.
-	if _, err := cp.CreateShare(context.Background(), &models.Share{
+	cpShare := &models.Share{
 		Name:              shareName,
 		MetadataStoreID:   metaID,
 		LocalBlockStoreID: localID,
 		Enabled:           true,
-	}); err != nil {
+	}
+	if remoteID != "" {
+		cpShare.RemoteBlockStoreID = &remoteID
+	}
+	if _, err := cp.CreateShare(context.Background(), cpShare); err != nil {
 		t.Fatalf("cpstore CreateShare: %v", err)
 	}
 	if err := rt.AddShare(context.Background(), &shares.ShareConfig{
-		Name:              shareName,
-		MetadataStore:     metaStoreName,
-		LocalBlockStoreID: localID,
-		Enabled:           true,
+		Name:               shareName,
+		MetadataStore:      metaStoreName,
+		LocalBlockStoreID:  localID,
+		RemoteBlockStoreID: remoteID,
+		Enabled:            true,
 	}); err != nil {
 		t.Fatalf("AddShare: %v", err)
 	}
@@ -130,7 +161,56 @@ func newByteVerifyFixture(t *testing.T, meta metadata.MetadataStore, metaType st
 		bs:            share.BlockStore,
 		shareName:     shareName,
 		localStoreDir: localStoreDir,
+		metaStoreName: metaStoreName,
+		localID:       localID,
+		remoteID:      remoteID,
 	}
+}
+
+// simulateRestart models a process restart for an on-disk metadata backend:
+// it shuts the current Runtime down, closes the old metadata store, reopens it
+// from its durable location via reopen(), and builds a FRESH Runtime over the
+// SAME control-plane store (where the restore marker lives) with the share
+// re-added. Used by the crash-recovery test to prove startup recovery rolls
+// back after a genuine reopen — not just an in-memory re-register. The cp
+// store is intentionally NOT closed (it is the durable marker home).
+func (f *byteVerifyFixture) simulateRestart(reopen func(*testing.T) metadata.MetadataStore) {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	_ = f.rt.Shutdown(ctx)
+	cancel()
+
+	// Close the old store before reopening: an on-disk backend (badger) holds
+	// an exclusive lock on its directory, so the reopen would fail until the
+	// prior handle is released. The first open()'s t.Cleanup will later call
+	// Close() again on this now-closed handle at test teardown — harmless: the
+	// error is ignored here and there, and neither badger nor postgres
+	// corrupts state on a double Close.
+	_ = f.meta.Close()
+
+	meta := reopen(f.t)
+
+	rt := New(f.store)
+	rt.SetLocalStoreDefaults(&shares.LocalStoreDefaults{MaxSize: 0})
+	if err := rt.RegisterMetadataStore(f.metaStoreName, meta); err != nil {
+		f.t.Fatalf("simulateRestart RegisterMetadataStore: %v", err)
+	}
+	if err := rt.AddShare(context.Background(), &shares.ShareConfig{
+		Name:               f.shareName,
+		MetadataStore:      f.metaStoreName,
+		LocalBlockStoreID:  f.localID,
+		RemoteBlockStoreID: f.remoteID,
+		Enabled:            false, // restore requires the share disabled
+	}); err != nil {
+		f.t.Fatalf("simulateRestart AddShare: %v", err)
+	}
+	share, err := rt.GetShare(f.shareName)
+	if err != nil {
+		f.t.Fatalf("simulateRestart GetShare: %v", err)
+	}
+	f.rt = rt
+	f.meta = meta
+	f.bs = share.BlockStore
 }
 
 func (f *byteVerifyFixture) close() {
@@ -450,6 +530,10 @@ type byteVerifyBackend struct {
 	name string
 	// open constructs the metadata store and returns it + its engine label.
 	open func(t *testing.T) (metadata.MetadataStore, string)
+	// reopen re-opens the SAME durable store (badger dir / postgres DSN)
+	// after a simulated restart. nil for backends that cannot survive a
+	// restart (memory) — the crash-recovery-reopen test skips those.
+	reopen func(t *testing.T) metadata.MetadataStore
 	// skip, when non-empty, marks the case as skipped with this reason.
 	skip string
 }
@@ -471,17 +555,7 @@ func byteVerifyBackends(t *testing.T) []byteVerifyBackend {
 				return metadatamemory.NewMemoryMetadataStoreWithDefaults(), "memory"
 			},
 		},
-		{
-			name: "badger",
-			open: func(t *testing.T) (metadata.MetadataStore, string) {
-				store, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
-				if err != nil {
-					t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
-				}
-				t.Cleanup(func() { _ = store.Close() })
-				return store, "badger"
-			},
-		},
+		newBadgerByteVerifyBackend(t),
 	}
 	if postgresByteVerifyBackend != nil {
 		backends = append(backends, *postgresByteVerifyBackend)
@@ -492,6 +566,28 @@ func byteVerifyBackends(t *testing.T) []byteVerifyBackend {
 		})
 	}
 	return backends
+}
+
+// newBadgerByteVerifyBackend builds the badger matrix entry with reopen
+// support: open and reopen both target the SAME captured directory, so a
+// simulateRestart reopens the persisted KV state (badger replays its WAL),
+// modeling a real process restart rather than an in-memory re-register.
+func newBadgerByteVerifyBackend(t *testing.T) byteVerifyBackend {
+	t.Helper()
+	dir := t.TempDir()
+	openAt := func(t *testing.T) metadata.MetadataStore {
+		store, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), dir)
+		if err != nil {
+			t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	}
+	return byteVerifyBackend{
+		name:   "badger",
+		open:   func(t *testing.T) (metadata.MetadataStore, string) { return openAt(t), "badger" },
+		reopen: openAt,
+	}
 }
 
 // firstDiff returns a human-readable description of the first differing byte

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -1,0 +1,520 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// byteVerifyFixture wires a Runtime over the REAL production write path: a
+// real local-fs CAS block store created via rt.AddShare (so the engine gets
+// its metadata coordinator + rollup worker), backed by a pluggable metadata
+// store. Unlike the inject-FileAttr.Blocks fixtures elsewhere in this
+// package, every byte here flows engine.WriteAt -> rollup chunker -> CAS, and
+// FileAttr.Blocks is persisted by the post-flush coordinator, not by the test.
+type byteVerifyFixture struct {
+	t             *testing.T
+	rt            *Runtime
+	store         cpstore.Store
+	meta          metadata.MetadataStore
+	bs            *engine.Store
+	shareName     string
+	localStoreDir string
+}
+
+// newByteVerifyFixture builds the fixture for the given metadata store. The
+// metaType is the engine label recorded in the cpstore ("memory" | "badger" |
+// "postgres") — it drives snapshot/restore's per-engine Restoreable dispatch.
+func newByteVerifyFixture(t *testing.T, meta metadata.MetadataStore, metaType string) *byteVerifyFixture {
+	t.Helper()
+
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+	rt.SetLocalStoreDefaults(&shares.LocalStoreDefaults{MaxSize: 0})
+
+	const metaStoreName = "bv-meta"
+	metaID, err := cp.CreateMetadataStore(context.Background(), &models.MetadataStoreConfig{
+		Name: metaStoreName,
+		Type: metaType,
+	})
+	if err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	if err := rt.RegisterMetadataStore(metaStoreName, meta); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	// Real local-fs CAS block store. The "fs" type drives the mandatory
+	// append-log + rollup worker; chunks land in <dir>/shares/<share>/blocks/
+	// and survive ResetLocalState (which only clears the append-log).
+	fsDir := t.TempDir()
+	localCfg := &models.BlockStoreConfig{
+		Name: "bv-local",
+		Kind: models.BlockStoreKindLocal,
+		Type: "fs",
+	}
+	// SetConfig serializes into the persisted JSON blob; GetBlockStoreByID
+	// reloads from the DB where only that blob survives (ParsedConfig is
+	// gorm:"-" and is dropped on the round-trip).
+	if err := localCfg.SetConfig(map[string]any{"path": fsDir}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	localID, err := cp.CreateBlockStore(context.Background(), localCfg)
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	shareName := "/bv-share"
+	// AddShare creates the root directory but not the Share record itself;
+	// the metadata store needs the Share row so GetRootHandle can resolve it.
+	if err := meta.CreateShare(context.Background(), &metadata.Share{Name: shareName}); err != nil {
+		t.Fatalf("metadata CreateShare: %v", err)
+	}
+	// Persist the cpstore Share row so DisableShare (which writes
+	// shares.enabled in the DB) resolves it. AddShare only populates the
+	// runtime registry, not this row.
+	if _, err := cp.CreateShare(context.Background(), &models.Share{
+		Name:              shareName,
+		MetadataStoreID:   metaID,
+		LocalBlockStoreID: localID,
+		Enabled:           true,
+	}); err != nil {
+		t.Fatalf("cpstore CreateShare: %v", err)
+	}
+	if err := rt.AddShare(context.Background(), &shares.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     metaStoreName,
+		LocalBlockStoreID: localID,
+		Enabled:           true,
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.RemoveShare(shareName) })
+
+	share, err := rt.GetShare(shareName)
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if share.BlockStore == nil {
+		t.Fatal("share.BlockStore nil after AddShare with fs local store")
+	}
+	localStoreDir, err := rt.sharesSvc.LocalStoreDir(shareName)
+	if err != nil || localStoreDir == "" {
+		t.Fatalf("LocalStoreDir: dir=%q err=%v (snapshot needs an on-disk root)", localStoreDir, err)
+	}
+
+	return &byteVerifyFixture{
+		t:             t,
+		rt:            rt,
+		store:         cp,
+		meta:          meta,
+		bs:            share.BlockStore,
+		shareName:     shareName,
+		localStoreDir: localStoreDir,
+	}
+}
+
+func (f *byteVerifyFixture) close() {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := f.rt.Shutdown(ctx); err != nil {
+		f.t.Logf("Shutdown: %v", err)
+	}
+}
+
+// createEmptyFile creates a regular file inode under the share root with its
+// Path + PayloadID set the way the production create path does. It does NOT
+// set FileAttr.Blocks — the engine's post-flush coordinator owns that.
+func (f *byteVerifyFixture) createEmptyFile(ctx context.Context, name string) metadata.PayloadID {
+	f.t.Helper()
+	root, err := f.meta.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		f.t.Fatalf("GetRootHandle: %v", err)
+	}
+	path := "/" + name
+	handle, err := f.meta.GenerateHandle(ctx, f.shareName, path)
+	if err != nil {
+		f.t.Fatalf("GenerateHandle %q: %v", name, err)
+	}
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		f.t.Fatalf("DecodeFileHandle %q: %v", name, err)
+	}
+	payloadID := metadata.PayloadID(metadata.BuildPayloadID(f.shareName, path))
+	file := &metadata.File{
+		ID:        fileID,
+		ShareName: f.shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			Size:      0,
+			PayloadID: payloadID,
+		},
+	}
+	if err := f.meta.PutFile(ctx, file); err != nil {
+		f.t.Fatalf("PutFile %q: %v", name, err)
+	}
+	if err := f.meta.SetParent(ctx, handle, root); err != nil {
+		f.t.Fatalf("SetParent %q: %v", name, err)
+	}
+	if err := f.meta.SetChild(ctx, root, name, handle); err != nil {
+		f.t.Fatalf("SetChild %q: %v", name, err)
+	}
+	if err := f.meta.SetLinkCount(ctx, handle, 1); err != nil {
+		f.t.Fatalf("SetLinkCount %q: %v", name, err)
+	}
+	return payloadID
+}
+
+// writeFile writes the full payload at offset 0 through the real engine path
+// then flushes so the rollup chunker emits CAS blocks and the post-flush
+// coordinator persists FileAttr.Blocks + ObjectID.
+func (f *byteVerifyFixture) writeFile(ctx context.Context, payloadID metadata.PayloadID, data []byte) {
+	f.t.Helper()
+	if err := common.WriteToBlockStore(ctx, f.bs, payloadID, data, 0); err != nil {
+		f.t.Fatalf("WriteToBlockStore %q: %v", payloadID, err)
+	}
+	if err := common.CommitBlockStore(ctx, f.bs, payloadID); err != nil {
+		f.t.Fatalf("CommitBlockStore %q: %v", payloadID, err)
+	}
+	// Force the async rollup worker to roll the just-flushed payload into CAS
+	// + the FileBlock manifest NOW, bypassing the stabilization window. This
+	// is what the post-rollup coordinator hook uses to persist
+	// FileAttr.Blocks + ObjectID — the snapshot-create orchestration drains
+	// the same way before Backup(). Without it the bytes live only in the
+	// append-log and FileAttr.Blocks stays empty.
+	if err := f.bs.DrainRollups(ctx); err != nil {
+		f.t.Fatalf("DrainRollups %q: %v", payloadID, err)
+	}
+}
+
+// readFile reads count bytes at offset 0 back through the real engine path.
+func (f *byteVerifyFixture) readFile(ctx context.Context, payloadID metadata.PayloadID, count int) []byte {
+	f.t.Helper()
+	res, err := common.ReadFromBlockStore(ctx, f.bs, payloadID, 0, uint32(count))
+	if err != nil {
+		f.t.Fatalf("ReadFromBlockStore %q: %v", payloadID, err)
+	}
+	out := make([]byte, len(res.Data))
+	copy(out, res.Data)
+	res.Release()
+	return out
+}
+
+// getFile re-loads the file inode so callers see the persisted
+// FileAttr.Blocks the post-flush coordinator wrote.
+func (f *byteVerifyFixture) getFile(ctx context.Context, name string) *metadata.File {
+	f.t.Helper()
+	root, err := f.meta.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		f.t.Fatalf("GetRootHandle: %v", err)
+	}
+	handle, err := f.meta.GetChild(ctx, root, name)
+	if err != nil {
+		f.t.Fatalf("GetChild %q: %v", name, err)
+	}
+	file, err := f.meta.GetFile(ctx, handle)
+	if err != nil {
+		f.t.Fatalf("GetFile %q: %v", name, err)
+	}
+	return file
+}
+
+// fileExists reports whether `name` is still a child of the share root.
+func (f *byteVerifyFixture) fileExists(ctx context.Context, name string) bool {
+	f.t.Helper()
+	root, err := f.meta.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		f.t.Fatalf("GetRootHandle: %v", err)
+	}
+	_, err = f.meta.GetChild(ctx, root, name)
+	if err == nil {
+		return true
+	}
+	if metadata.IsNotFoundError(err) {
+		return false
+	}
+	f.t.Fatalf("GetChild %q: %v", name, err)
+	return false
+}
+
+// deleteFile removes the file the production way: unlink the inode, then drive
+// engine.Delete with the file's persisted FileAttr.Blocks so the coordinator
+// decrements refcounts and the file_blocks rows are reclaimed (mirrors the
+// NFS/SMB remove handlers). Passing the real Blocks avoids leaving orphaned
+// file_blocks rows that would skew the next snapshot's manifest.
+func (f *byteVerifyFixture) deleteFile(ctx context.Context, name string) {
+	f.t.Helper()
+	file := f.getFile(ctx, name)
+	root, err := f.meta.GetRootHandle(ctx, f.shareName)
+	if err != nil {
+		f.t.Fatalf("GetRootHandle: %v", err)
+	}
+	handle, err := f.meta.GetChild(ctx, root, name)
+	if err != nil {
+		f.t.Fatalf("GetChild %q: %v", name, err)
+	}
+	if err := f.meta.DeleteFile(ctx, handle); err != nil {
+		f.t.Fatalf("DeleteFile %q: %v", name, err)
+	}
+	if err := f.bs.Delete(ctx, string(file.PayloadID), file.Blocks); err != nil {
+		f.t.Fatalf("bs.Delete %q: %v", name, err)
+	}
+}
+
+// distinctBytes returns n bytes of non-repeating content seeded by `seed`, so
+// FastCDC produces real content-defined chunk boundaries on multi-MiB inputs.
+func distinctBytes(n int, seed uint64) []byte {
+	out := make([]byte, n)
+	x := seed*2654435761 + 0x9E3779B97F4A7C15
+	for i := range out {
+		// xorshift64* — cheap, non-repeating, content varies enough for CDC.
+		x ^= x >> 12
+		x ^= x << 25
+		x ^= x >> 27
+		out[i] = byte((x * 0x2545F4914F6CDD1D) >> 56)
+	}
+	return out
+}
+
+// TestSnapshotByteVerify_MinimalProof is the de-risk step: prove a single
+// small file round-trips byte-identical through the REAL write/flush/read path
+// on the memory backend before layering on snapshot/restore.
+func TestSnapshotByteVerify_MinimalProof(t *testing.T) {
+	meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	fx := newByteVerifyFixture(t, meta, "memory")
+	defer fx.close()
+
+	ctx := context.Background()
+	want := distinctBytes(4096, 1)
+	pid := fx.createEmptyFile(ctx, "hello.bin")
+	fx.writeFile(ctx, pid, want)
+
+	got := fx.readFile(ctx, pid, len(want))
+	if !bytes.Equal(got, want) {
+		t.Fatalf("minimal proof byte mismatch: %s", firstDiff(want, got))
+	}
+}
+
+// runByteVerifyCycle drives the full snapshot -> mutate -> drop-cache ->
+// restore cycle against one metadata backend and asserts byte-identical
+// recovery. Every byte flows through the real engine write/flush/read path;
+// FileAttr.Blocks is owned by the coordinator, never injected.
+func runByteVerifyCycle(t *testing.T, fx *byteVerifyFixture) {
+	ctx := context.Background()
+
+	// (1) Create 3 files with distinct real bytes. fileA is multi-chunk
+	// (3 MiB of non-repeating bytes) so FastCDC produces several CAS chunks.
+	const mib = 1 << 20
+	origA := distinctBytes(3*mib, 0xA)
+	origB := distinctBytes(8192, 0xB)
+	origC := distinctBytes(64*1024, 0xC) // created during mutation, asserted gone after restore
+
+	pidA := fx.createEmptyFile(ctx, "fileA.bin")
+	fx.writeFile(ctx, pidA, origA)
+	pidB := fx.createEmptyFile(ctx, "fileB.bin")
+	fx.writeFile(ctx, pidB, origB)
+
+	// Sanity: both files read back byte-identical pre-snapshot (proves the
+	// real write path before we even snapshot).
+	if got := fx.readFile(ctx, pidA, len(origA)); !bytes.Equal(got, origA) {
+		t.Fatalf("pre-snapshot fileA mismatch: %s", firstDiff(origA, got))
+	}
+	if got := fx.readFile(ctx, pidB, len(origB)); !bytes.Equal(got, origB) {
+		t.Fatalf("pre-snapshot fileB mismatch: %s", firstDiff(origB, got))
+	}
+	// Confirm fileA really is multi-chunk through the engine (FastCDC split).
+	if fa := fx.getFile(ctx, "fileA.bin"); len(fa.Blocks) < 2 {
+		t.Fatalf("fileA produced %d CAS block(s), want >= 2 (multi-chunk path not exercised)", len(fa.Blocks))
+	}
+
+	// (2) Snapshot the populated state. Local-only share -> NoVerify.
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snap.State = %q, want ready", snap.State)
+	}
+
+	// (3) Mutate. (a) overwrite fileA in place with different bytes of the
+	// SAME length (the C2 in-place-overwrite rollback case), (b) delete
+	// fileB, (c) create a new fileC.
+	mutA := distinctBytes(3*mib, 0xA11) // same length, different content
+	if len(mutA) != len(origA) {
+		t.Fatalf("test bug: mutA len %d != origA len %d", len(mutA), len(origA))
+	}
+	fx.writeFile(ctx, pidA, mutA)
+	if got := fx.readFile(ctx, pidA, len(mutA)); !bytes.Equal(got, mutA) {
+		t.Fatalf("post-mutate fileA should read the NEW bytes pre-restore: %s", firstDiff(mutA, got))
+	}
+	fx.deleteFile(ctx, "fileB.bin")
+	pidC := fx.createEmptyFile(ctx, "fileC.bin")
+	fx.writeFile(ctx, pidC, origC)
+
+	// (4) Drop local cache so reads must resolve through the restored CAS
+	// manifest (the cold-state path that exposed #838 on postgres).
+	if err := fx.bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// (5) Restore. Share must be disabled first; the snapshot is non-durable
+	// (local-only) so AllowNonDurable is required.
+	if err := fx.rt.DisableShare(ctx, fx.shareName); err != nil {
+		t.Fatalf("DisableShare: %v", err)
+	}
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{AllowNonDurable: true}); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	// (6) Re-read every file through the engine and assert byte-identical
+	// recovery.
+	//  - fileA: in-place overwrite rolled back -> original bytes (C2).
+	//  - fileB: deleted post-snapshot -> recovered -> original bytes.
+	//  - fileC: created post-snapshot -> gone.
+	if !fx.fileExists(ctx, "fileA.bin") {
+		t.Fatal("fileA missing after restore")
+	}
+	gotA := fx.readFile(ctx, pidA, len(origA))
+	if !bytes.Equal(gotA, origA) {
+		t.Fatalf("RESTORE fileA NOT byte-identical (in-place overwrite not rolled back / C2): %s", firstDiff(origA, gotA))
+	}
+
+	if !fx.fileExists(ctx, "fileB.bin") {
+		t.Fatal("fileB not recovered after restore (deleted file should be back)")
+	}
+	pidB2 := fx.getFile(ctx, "fileB.bin").PayloadID
+	gotB := fx.readFile(ctx, pidB2, len(origB))
+	if !bytes.Equal(gotB, origB) {
+		t.Fatalf("RESTORE fileB NOT byte-identical: %s", firstDiff(origB, gotB))
+	}
+
+	if fx.fileExists(ctx, "fileC.bin") {
+		t.Fatal("fileC still present after restore (created post-snapshot, should be gone)")
+	}
+
+	// Share stays disabled after restore.
+	if enabled, _ := fx.rt.sharesSvc.IsShareEnabled(fx.shareName); enabled {
+		t.Fatal("share enabled after restore — must stay disabled")
+	}
+	_ = pidC
+}
+
+// TestSnapshotByteVerify_Matrix is the table-driven matrix over metadata-store
+// backends. memory + badger always run; postgres runs only when
+// DITTOFS_TEST_POSTGRES_DSN is set (the integration-tagged file supplies the
+// postgres case constructor).
+func TestSnapshotByteVerify_Matrix(t *testing.T) {
+	for _, bk := range byteVerifyBackends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			if bk.skip != "" {
+				t.Skip(bk.skip)
+			}
+			meta, metaType := bk.open(t)
+			fx := newByteVerifyFixture(t, meta, metaType)
+			defer fx.close()
+			runByteVerifyCycle(t, fx)
+		})
+	}
+}
+
+// byteVerifyBackend describes one metadata-store backend in the matrix.
+type byteVerifyBackend struct {
+	name string
+	// open constructs the metadata store and returns it + its engine label.
+	open func(t *testing.T) (metadata.MetadataStore, string)
+	// skip, when non-empty, marks the case as skipped with this reason.
+	skip string
+}
+
+// postgresByteVerifyBackend is installed by the integration-tagged
+// companion file's init(). Under plain `go test` it stays nil and the
+// postgres matrix row is skipped with a build-tag hint.
+var postgresByteVerifyBackend *byteVerifyBackend
+
+// byteVerifyBackends returns the backend matrix: memory + badger always,
+// postgres only when the integration-tagged companion installed it (and the
+// DSN env is set, checked inside its open()).
+func byteVerifyBackends(t *testing.T) []byteVerifyBackend {
+	t.Helper()
+	backends := []byteVerifyBackend{
+		{
+			name: "memory",
+			open: func(t *testing.T) (metadata.MetadataStore, string) {
+				return metadatamemory.NewMemoryMetadataStoreWithDefaults(), "memory"
+			},
+		},
+		{
+			name: "badger",
+			open: func(t *testing.T) (metadata.MetadataStore, string) {
+				store, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+				if err != nil {
+					t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+				}
+				t.Cleanup(func() { _ = store.Close() })
+				return store, "badger"
+			},
+		},
+	}
+	if postgresByteVerifyBackend != nil {
+		backends = append(backends, *postgresByteVerifyBackend)
+	} else {
+		backends = append(backends, byteVerifyBackend{
+			name: "postgres",
+			skip: "postgres case requires -tags=integration and DITTOFS_TEST_POSTGRES_DSN",
+		})
+	}
+	return backends
+}
+
+// firstDiff returns a human-readable description of the first differing byte
+// offset between want and got (or a length-mismatch note).
+func firstDiff(want, got []byte) string {
+	if len(want) != len(got) {
+		n := len(want)
+		if len(got) < n {
+			n = len(got)
+		}
+		for i := 0; i < n; i++ {
+			if want[i] != got[i] {
+				return fmt.Sprintf("len want=%d got=%d; first byte diff at offset %d (want 0x%02x got 0x%02x)",
+					len(want), len(got), i, want[i], got[i])
+			}
+		}
+		return fmt.Sprintf("length mismatch: want=%d got=%d (shorter is a prefix of longer)", len(want), len(got))
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			return fmt.Sprintf("first byte diff at offset %d (want 0x%02x got 0x%02x)", i, want[i], got[i])
+		}
+	}
+	return "no difference"
+}

--- a/pkg/controlplane/runtime/snapshot_ds3_durable_test.go
+++ b/pkg/controlplane/runtime/snapshot_ds3_durable_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/marmos91/dittofs/pkg/snapshot"
+)
+
+// ds3RemoteConfig builds a remote s3 BlockStoreConfig from the DS3_* env
+// vars (see /tmp/ds3.env). Each test gets a unique key prefix so parallel
+// runs and reruns don't collide on the bucket. Skips when DS3_ENDPOINT is
+// unset. force_path_style is left to the production default
+// (CreateRemoteStoreFromConfig forces it true when a custom endpoint is set)
+// so this test exercises the SAME wiring the live `dfsctl store block remote
+// add` path produces.
+func ds3RemoteConfig(t *testing.T, prefix string) *models.BlockStoreConfig {
+	t.Helper()
+	endpoint := os.Getenv("DS3_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("DS3_ENDPOINT not set; skipping DS3 durable snapshot test")
+	}
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = "https://" + endpoint
+	}
+	region := os.Getenv("DS3_REGION")
+	if region == "" {
+		region = "eu-central-1"
+	}
+	cfg := &models.BlockStoreConfig{
+		Name: "ds3-bv",
+		Kind: models.BlockStoreKindRemote,
+		Type: "s3",
+	}
+	if err := cfg.SetConfig(map[string]any{
+		"bucket":            os.Getenv("DS3_BUCKET"),
+		"region":            region,
+		"endpoint":          endpoint,
+		"prefix":            prefix,
+		"access_key_id":     os.Getenv("DS3_ACCESS_KEY"),
+		"secret_access_key": os.Getenv("DS3_SECRET_KEY"),
+	}); err != nil {
+		t.Fatalf("SetConfig(remote): %v", err)
+	}
+	return cfg
+}
+
+// TestSnapshotByteVerify_DS3Durable drives the FULL remote-durable path
+// against a real Cubbit/DS3 bucket: write a multi-chunk file through the
+// engine -> DrainRollups -> DrainAllUploads -> VerifyRemoteDurability, then
+// mutate + ResetLocalState (drop ALL local CAS so reads MUST pull from DS3)
+// + restore, and assert byte-identical recovery.
+//
+// Crucially the snapshot is created WITHOUT NoVerify, so CreateSnapshot runs
+// the actual remote durability gate that produced the "verify chunk not
+// found" failure. A miss here reproduces the bug. RemoteDurable MUST be true.
+//
+// Repeated subtests hammer the upload->verify window to catch any
+// nondeterministic miss.
+func TestSnapshotByteVerify_DS3Durable(t *testing.T) {
+	const iterations = 3
+	for i := 0; i < iterations; i++ {
+		i := i
+		t.Run(fmt.Sprintf("iter-%d", i), func(t *testing.T) {
+			prefix := fmt.Sprintf("bvtest/%s/iter-%d/", t.Name(), i)
+			remoteCfg := ds3RemoteConfig(t, prefix)
+			meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+			fx := newByteVerifyFixtureOpts(t, meta, "memory", remoteCfg)
+			defer fx.close()
+			runDS3DurableCycle(t, fx)
+		})
+	}
+}
+
+// runDS3DurableCycle is the remote-durable analogue of runByteVerifyCycle.
+func runDS3DurableCycle(t *testing.T, fx *byteVerifyFixture) {
+	ctx := context.Background()
+	const mib = 1 << 20
+
+	// Multi-chunk file (4 MiB non-repeating) + a small one.
+	origA := distinctBytes(4*mib, 0xD53)
+	origB := distinctBytes(9000, 0xB0B)
+
+	pidA := fx.createEmptyFile(ctx, "fileA.bin")
+	fx.writeFile(ctx, pidA, origA)
+	pidB := fx.createEmptyFile(ctx, "fileB.bin")
+	fx.writeFile(ctx, pidB, origB)
+
+	if fa := fx.getFile(ctx, "fileA.bin"); len(fa.Blocks) < 2 {
+		t.Fatalf("fileA produced %d CAS block(s), want >= 2 (multi-chunk path)", len(fa.Blocks))
+	}
+
+	// Sanity: the engine HAS a remote wired.
+	if fx.bs.RemoteStore() == nil {
+		t.Fatal("share has no remote store — DS3 not wired into engine")
+	}
+
+	// (2) DURABLE snapshot: NoVerify=false runs DrainAllUploads +
+	// VerifyRemoteDurability against real DS3. This is the path that
+	// produced "verify chunk not found".
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: false})
+	if err != nil {
+		t.Fatalf("CreateSnapshot(durable): %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snap.State = %q, want ready (durable verify failed)", snap.State)
+	}
+	if !snap.RemoteDurable {
+		t.Fatalf("snap.RemoteDurable = false, want true — remote durability gate did not pass")
+	}
+
+	// Independently re-verify every manifest hash is HEAD-visible on DS3
+	// (belt-and-braces beyond the orchestration's own gate).
+	if err := reverifyManifestOnRemote(ctx, fx, snap); err != nil {
+		t.Fatalf("post-create manifest re-verify on DS3 failed: %v", err)
+	}
+
+	// (3) Mutate: overwrite A in place (same length), delete B, add C.
+	mutA := distinctBytes(4*mib, 0xD54)
+	fx.writeFile(ctx, pidA, mutA)
+	fx.deleteFile(ctx, "fileB.bin")
+	pidC := fx.createEmptyFile(ctx, "fileC.bin")
+	fx.writeFile(ctx, pidC, distinctBytes(32*1024, 0xC0C))
+
+	// (4) Drop ALL local CAS state so restore-time reads MUST pull bytes
+	// back from DS3 — the true remote round-trip.
+	if err := fx.bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// (5) Restore. Durable snapshot -> no AllowNonDurable needed.
+	if err := fx.rt.DisableShare(ctx, fx.shareName); err != nil {
+		t.Fatalf("DisableShare: %v", err)
+	}
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); err != nil {
+		t.Fatalf("RestoreSnapshot(durable): %v", err)
+	}
+
+	// (6) Byte-verify recovery — reads resolve through DS3 (local was reset).
+	if !fx.fileExists(ctx, "fileA.bin") {
+		t.Fatal("fileA missing after restore")
+	}
+	gotA := fx.readFile(ctx, pidA, len(origA))
+	if !bytes.Equal(gotA, origA) {
+		t.Fatalf("RESTORE fileA NOT byte-identical from DS3: %s", firstDiff(origA, gotA))
+	}
+	if !fx.fileExists(ctx, "fileB.bin") {
+		t.Fatal("fileB not recovered after restore")
+	}
+	pidB2 := fx.getFile(ctx, "fileB.bin").PayloadID
+	gotB := fx.readFile(ctx, pidB2, len(origB))
+	if !bytes.Equal(gotB, origB) {
+		t.Fatalf("RESTORE fileB NOT byte-identical from DS3: %s", firstDiff(origB, gotB))
+	}
+	if fx.fileExists(ctx, "fileC.bin") {
+		t.Fatal("fileC still present after restore (created post-snapshot)")
+	}
+}
+
+// reverifyManifestOnRemote re-reads the snapshot manifest from disk and HEADs
+// every hash against the live remote, independent of the orchestration's own
+// verify pass. Returns the first miss (wrapping ErrChunkNotFound) so a
+// nondeterministic gap is surfaced even if the create-time gate passed.
+func reverifyManifestOnRemote(ctx context.Context, fx *byteVerifyFixture, snap *models.Snapshot) error {
+	manifestPath := snap.ManifestPath(fx.localStoreDir)
+	f, err := os.Open(manifestPath)
+	if err != nil {
+		return fmt.Errorf("open manifest %s: %w", manifestPath, err)
+	}
+	defer func() { _ = f.Close() }()
+	hs, err := snapshot.ReadManifest(f)
+	if err != nil {
+		return fmt.Errorf("read manifest %s: %w", manifestPath, err)
+	}
+	rs := fx.bs.RemoteStore()
+	if rs == nil {
+		return errors.New("no remote store")
+	}
+	hctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	for _, h := range hs.Sorted() {
+		if _, herr := rs.Head(hctx, h); herr != nil {
+			return fmt.Errorf("manifest hash %s HEAD failed (%w)", h, herr)
+		}
+	}
+	return nil
+}

--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"runtime"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/blockstore"
@@ -99,6 +102,12 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 			}
 			count, err := streamManifest(manifestPath, fn)
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// TOCTOU: the manifest passed the Stat above but was
+					// removed (snapshot delete) before the open. Same
+					// "no manifest = no hold" outcome as the Stat miss.
+					continue
+				}
 				return fmt.Errorf("snapshot hold: stream manifest for share %q snapshot %q at %q: %w",
 					shareName, snap.ID, manifestPath, err)
 			}
@@ -115,9 +124,13 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 }
 
 // streamManifest opens the manifest at path, parses it, and forwards
-// every hash through fn. Returns the count for logging.
+// every hash through fn. Returns the count for logging. A Windows
+// sharing violation (another handle/rename mid-flight, or a real-world
+// AV/indexer transiently locking the file) is retried before failing;
+// fs.ErrNotExist propagates unchanged so the caller can treat a TOCTOU
+// delete as "no hold".
 func streamManifest(path string, fn func(blockstore.ContentHash) error) (int, error) {
-	f, err := os.Open(path)
+	f, err := openManifestWithRetry(path)
 	if err != nil {
 		return 0, err
 	}
@@ -131,6 +144,48 @@ func streamManifest(path string, fn func(blockstore.ContentHash) error) (int, er
 		return 0, err
 	}
 	return hs.Len(), nil
+}
+
+// openManifestWithRetry opens path, retrying briefly on a Windows sharing
+// violation. The GC mark phase RLocks out concurrent snapshot deletes, but a
+// concurrent create's atomic rename — or, on real Windows deployments, an
+// antivirus / search-indexer momentarily holding the file — can surface
+// ERROR_SHARING_VIOLATION on open. That is transient: a short bounded retry
+// lets it clear rather than aborting the whole GC pass (which would skip
+// every later share's holds and risk deleting a still-held block).
+// fs.ErrNotExist is returned immediately (a TOCTOU delete is the caller's to
+// interpret, and is not resolved by waiting).
+func openManifestWithRetry(path string) (*os.File, error) {
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		f, err := os.Open(path)
+		if err == nil {
+			return f, nil
+		}
+		if errors.Is(err, fs.ErrNotExist) || !isTransientSharingViolation(err) {
+			return nil, err
+		}
+		lastErr = err
+		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+	}
+	return nil, lastErr
+}
+
+// isTransientSharingViolation reports whether err is a Windows
+// ERROR_SHARING_VIOLATION (32) or ERROR_LOCK_VIOLATION (33) — a transient
+// "file in use by another process" condition. Guarded by GOOS so the same
+// numeric errnos on Unix (EPIPE/...) are never misread; on non-Windows this
+// is always false.
+func isTransientSharingViolation(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == 32 || errno == 33
+	}
+	return false
 }
 
 // AcquireDeleteLock is the write-side counterpart used by the snapshot

--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -194,3 +194,23 @@ func (r *Runtime) snapshotDeleteLock(shareName string) *sync.RWMutex {
 	}
 	return lock
 }
+
+// restoreLock returns the shared per-share mutex that serializes
+// RestoreSnapshot. Allocated on first lookup and reused thereafter so every
+// restore for the same share contends on the SAME pointer. Held for the
+// whole restore (via TryLock in restoreSnapshot); a second concurrent
+// restore fails fast with models.ErrRestoreInProgress rather than
+// interleaving the destructive metadata Reset + dump replay.
+func (r *Runtime) restoreLock(shareName string) *sync.Mutex {
+	r.restoreLocksMu.Lock()
+	defer r.restoreLocksMu.Unlock()
+	if r.restoreLocks == nil {
+		r.restoreLocks = make(map[string]*sync.Mutex)
+	}
+	lock, ok := r.restoreLocks[shareName]
+	if !ok {
+		lock = &sync.Mutex{}
+		r.restoreLocks[shareName] = lock
+	}
+	return lock
+}

--- a/pkg/controlplane/runtime/snapshot_restore_concurrent_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_concurrent_test.go
@@ -1,0 +1,129 @@
+package runtime
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestRestore_ConcurrentRejectedWhileLocked is the deterministic guard test
+// for the per-share restore lock: while a restore holds the lock, any second
+// RestoreSnapshot on the same share fails fast with ErrRestoreInProgress
+// rather than interleaving the destructive metadata Reset + dump replay.
+//
+// We hold the lock directly (modeling an in-flight restore) so the assertion
+// is timing-independent, then release and confirm a subsequent restore
+// proceeds normally.
+func TestRestore_ConcurrentRejectedWhileLocked(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"a.bin", "b.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	fx.deleteFileCascade(ctx, files[0])
+
+	// Simulate an in-flight restore by holding the same per-share lock the
+	// restore path would take.
+	lock := fx.rt.restoreLock(fx.shareName)
+	lock.Lock()
+
+	_, err = fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})
+	if !errors.Is(err, models.ErrRestoreInProgress) {
+		lock.Unlock()
+		t.Fatalf("RestoreSnapshot while locked: err = %v, want ErrRestoreInProgress", err)
+	}
+
+	// Release; a subsequent restore must succeed and bring files[0] back.
+	lock.Unlock()
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); err != nil {
+		t.Fatalf("RestoreSnapshot after unlock: %v", err)
+	}
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr != nil {
+		t.Fatalf("files[0] not restored after unlock: %v", gerr)
+	}
+}
+
+// TestRestore_ConcurrentFanout launches several RestoreSnapshot calls on the
+// same share at once. The per-share lock serializes them: a call either wins
+// the lock and runs to completion, or fails fast with ErrRestoreInProgress —
+// never a third error class, and never two restores interleaving their
+// destructive Reset+replay. Because the lock is released between runs and each
+// restore is idempotent on the snapshot, MORE THAN ONE call may succeed (in
+// sequence) when an earlier one finishes before a later goroutine reaches the
+// TryLock; that is expected and safe. The invariants asserted are therefore:
+// at least one success, every outcome is success-or-ErrRestoreInProgress, and
+// the final state is the consistent restored state. Run with -race to catch
+// data races in the restore path under contention.
+func TestRestore_ConcurrentFanout(t *testing.T) {
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"x.bin", "y.bin"})
+	fx.seedRemoteAll(fx.allHashes())
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+		t.Fatalf("WaitForSnapshot: %v", werr)
+	}
+	// Mutate: delete files[0]; every successful restore must bring it back.
+	fx.deleteFileCascade(ctx, files[0])
+
+	const goroutines = 6
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var succeeded, rejected int
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximize overlap
+			_, rerr := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{})
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case rerr == nil:
+				succeeded++
+			case errors.Is(rerr, models.ErrRestoreInProgress):
+				rejected++
+			default:
+				t.Errorf("unexpected restore error class: %v", rerr)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if succeeded < 1 {
+		t.Fatalf("no restore succeeded (succeeded=%d rejected=%d)", succeeded, rejected)
+	}
+	if succeeded+rejected != goroutines {
+		t.Fatalf("accounting mismatch: succeeded=%d rejected=%d total!=%d", succeeded, rejected, goroutines)
+	}
+	t.Logf("concurrent restores: %d succeeded, %d rejected with ErrRestoreInProgress", succeeded, rejected)
+
+	// Final state must be the restored state regardless of how the race
+	// resolved: files[0] (deleted post-snapshot) is back, files[1] present.
+	if _, gerr := fx.meta.GetFile(ctx, files[0].handle); gerr != nil {
+		t.Fatalf("files[0] not present in final restored state: %v", gerr)
+	}
+	if _, gerr := fx.meta.GetFile(ctx, files[1].handle); gerr != nil {
+		t.Fatalf("files[1] missing in final restored state: %v", gerr)
+	}
+}

--- a/pkg/controlplane/runtime/snapshot_restore_crash_reopen_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_crash_reopen_test.go
@@ -1,0 +1,129 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestRestoreCrashRecovery_AcrossRealReopen proves #810 startup recovery rolls
+// back a half-finished restore after a REAL metadata-store reopen — not the
+// in-memory re-register the memory-only crash suite uses. The marker lives in
+// the control-plane store (kept alive across the simulated restart); the
+// metadata store is closed and reopened from its durable location (badger
+// dir / postgres DSN), so this also guards the postgres ensureStoreID reopen
+// path that previously deadlocked an unbootable store and blocked recovery.
+//
+// Flow (real write path, mutation = ADD so it is backend-robust):
+//  1. write a.bin + b.bin, snapshot S (local-only, NoVerify)
+//  2. add c.bin  → the safety snap taken during the restore captures the
+//     {a,b,c} state
+//  3. restore S successfully → c.bin is gone again ({a,b})
+//  4. re-insert the restore marker at RestoreStepRestored (models a crash
+//     after replay, before the marker clear)
+//  5. simulate restart: close + reopen the metadata store, rebuild the Runtime
+//  6. recoverInterruptedRestores → rolls back to the safety snap, so c.bin
+//     REAPPEARS (proving the rollback actually ran, not just a marker clear),
+//     and a.bin/b.bin remain byte-identical through the reopened store.
+func TestRestoreCrashRecovery_AcrossRealReopen(t *testing.T) {
+	for _, bk := range byteVerifyBackends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			if bk.skip != "" {
+				t.Skip(bk.skip)
+			}
+			if bk.reopen == nil {
+				t.Skipf("%s cannot survive a restart (no durable reopen)", bk.name)
+			}
+			meta, metaType := bk.open(t)
+			fx := newByteVerifyFixtureOpts(t, meta, metaType, nil)
+			defer fx.close()
+
+			ctx := context.Background()
+			origA := distinctBytes(64*1024, 0xA)
+			origB := distinctBytes(48*1024, 0xB)
+			origC := distinctBytes(32*1024, 0xC)
+
+			pidA := fx.createEmptyFile(ctx, "a.bin")
+			fx.writeFile(ctx, pidA, origA)
+			pidB := fx.createEmptyFile(ctx, "b.bin")
+			fx.writeFile(ctx, pidB, origB)
+
+			snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+			if err != nil {
+				t.Fatalf("CreateSnapshot: %v", err)
+			}
+			if _, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID); werr != nil {
+				t.Fatalf("WaitForSnapshot: %v", werr)
+			}
+
+			// Mutate AFTER the snapshot: add c.bin. The safety snap taken
+			// during the restore below captures this {a,b,c} state.
+			pidC := fx.createEmptyFile(ctx, "c.bin")
+			fx.writeFile(ctx, pidC, origC)
+
+			// Restore requires the share disabled.
+			if err := fx.rt.DisableShare(ctx, fx.shareName); err != nil {
+				t.Fatalf("DisableShare: %v", err)
+			}
+
+			safetyID, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{AllowNonDurable: true})
+			if err != nil {
+				t.Fatalf("RestoreSnapshot: %v", err)
+			}
+			if fx.fileExists(ctx, "c.bin") {
+				t.Fatal("c.bin still present after restore to the pre-c snapshot")
+			}
+
+			// Model a crash AFTER replay but BEFORE the marker clear.
+			if perr := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+				ShareName:        fx.shareName,
+				TargetSnapshotID: snapID,
+				SafetySnapshotID: safetyID,
+				Step:             models.RestoreStepRestored,
+			}); perr != nil {
+				t.Fatalf("PutRestoreMarker: %v", perr)
+			}
+
+			// --- REAL restart: close + reopen the metadata store ---
+			fx.simulateRestart(bk.reopen)
+
+			if err := fx.rt.recoverInterruptedRestores(ctx); err != nil {
+				t.Fatalf("recoverInterruptedRestores: %v", err)
+			}
+
+			// Marker cleared.
+			if _, gerr := fx.store.GetRestoreMarker(ctx, fx.shareName); !errors.Is(gerr, models.ErrRestoreMarkerNotFound) {
+				t.Fatalf("marker not cleared after recovery: err=%v", gerr)
+			}
+
+			// Rolled back to the safety snap: c.bin REAPPEARS (proves the
+			// rollback restore actually ran across the reopen, not a bare
+			// marker clear), and a.bin/b.bin are byte-identical through the
+			// reopened store + persisted CAS.
+			if !fx.fileExists(ctx, "c.bin") {
+				t.Fatal("c.bin missing after rollback — recovery cleared the marker without restoring the safety snap")
+			}
+			pidC2 := fx.getFile(ctx, "c.bin").PayloadID
+			if gotC := fx.readFile(ctx, pidC2, len(origC)); !bytes.Equal(gotC, origC) {
+				t.Fatalf("c.bin NOT byte-identical after rollback+reopen: %s", firstDiff(origC, gotC))
+			}
+			pidA2 := fx.getFile(ctx, "a.bin").PayloadID
+			if gotA := fx.readFile(ctx, pidA2, len(origA)); !bytes.Equal(gotA, origA) {
+				t.Fatalf("a.bin NOT byte-identical after rollback+reopen: %s", firstDiff(origA, gotA))
+			}
+			pidB2 := fx.getFile(ctx, "b.bin").PayloadID
+			if gotB := fx.readFile(ctx, pidB2, len(origB)); !bytes.Equal(gotB, origB) {
+				t.Fatalf("b.bin NOT byte-identical after rollback+reopen: %s", firstDiff(origB, gotB))
+			}
+
+			// Share stays disabled after recovery.
+			if enabled, _ := fx.rt.sharesSvc.IsShareEnabled(fx.shareName); enabled {
+				t.Fatal("share enabled after recovery rollback — must stay disabled")
+			}
+		})
+	}
+}

--- a/pkg/metadata/store/postgres/createshare_contract_test.go
+++ b/pkg/metadata/store/postgres/createshare_contract_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestPostgres_CreateShare_MaterializesRootAndOptions pins the fix for the
+// CreateShare contract violation. The shares.root_file_id column is NOT NULL
+// (FK to files), so the previous bare INSERT INTO shares (...) could never
+// succeed — it always raised a not_null_violation. The store interface
+// documents CreateShare as "Also creates the root directory for the share"
+// (the memory/badger backends do), so postgres must materialize the root and
+// persist the caller's options. This was invisible because CI never ran the
+// postgres integration suite.
+func TestPostgres_CreateShare_MaterializesRootAndOptions(t *testing.T) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL CreateShare test")
+	}
+
+	store := newPostgresStore(t)
+	ctx := context.Background()
+
+	// Clean slate so the fixed share name does not collide with prior runs.
+	if err := store.Reset(ctx); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	const shareName = "/cs-contract-test"
+	share := &metadata.Share{
+		Name:    shareName,
+		Options: metadata.ShareOptions{ReadOnly: true},
+	}
+
+	// CreateShare must succeed (the bug: it always failed on root_file_id).
+	if err := store.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+
+	// The root directory must exist (contract: "Also creates the root
+	// directory for the share").
+	if _, err := store.GetRootHandle(ctx, shareName); err != nil {
+		t.Fatalf("GetRootHandle after CreateShare: root not materialized: %v", err)
+	}
+
+	// The caller's options must be persisted, not left at column defaults.
+	opts, err := store.GetShareOptions(ctx, shareName)
+	if err != nil {
+		t.Fatalf("GetShareOptions: %v", err)
+	}
+	if !opts.ReadOnly {
+		t.Fatal("CreateShare did not persist Options.ReadOnly=true")
+	}
+
+	// A second CreateShare for the same name must report ErrAlreadyExists.
+	err = store.CreateShare(ctx, share)
+	var se *metadata.StoreError
+	if !errors.As(err, &se) || se.Code != metadata.ErrAlreadyExists {
+		t.Fatalf("duplicate CreateShare: got %v, want StoreError{Code: ErrAlreadyExists}", err)
+	}
+}

--- a/pkg/metadata/store/postgres/postgres_conformance_test.go
+++ b/pkg/metadata/store/postgres/postgres_conformance_test.go
@@ -15,10 +15,14 @@ import (
 // postgresTestConfig returns the config + capabilities every Postgres test
 // store is opened with. Centralized so the connection params stay consistent.
 func postgresTestConfig() (*postgres.PostgresMetadataStoreConfig, metadata.FilesystemCapabilities) {
+	dbName := os.Getenv("DITTOFS_TEST_PG_DBNAME")
+	if dbName == "" {
+		dbName = "dittofs_test"
+	}
 	cfg := &postgres.PostgresMetadataStoreConfig{
 		Host:        "localhost",
 		Port:        5432,
-		Database:    "dittofs_test",
+		Database:    dbName,
 		User:        "postgres",
 		Password:    "postgres",
 		SSLMode:     "disable",

--- a/pkg/metadata/store/postgres/postgres_conformance_test.go
+++ b/pkg/metadata/store/postgres/postgres_conformance_test.go
@@ -12,44 +12,79 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/storetest"
 )
 
-// newPostgresStoreFactory returns a factory that creates a fresh
-// PostgresMetadataStore for each subtest. Shared by both conformance
-// suites so the config and capabilities stay consistent.
+// postgresTestConfig returns the config + capabilities every Postgres test
+// store is opened with. Centralized so the connection params stay consistent.
+func postgresTestConfig() (*postgres.PostgresMetadataStoreConfig, metadata.FilesystemCapabilities) {
+	cfg := &postgres.PostgresMetadataStoreConfig{
+		Host:        "localhost",
+		Port:        5432,
+		Database:    "dittofs_test",
+		User:        "postgres",
+		Password:    "postgres",
+		SSLMode:     "disable",
+		AutoMigrate: true,
+	}
+	caps := metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+	return cfg, caps
+}
+
+// newPostgresStore opens a Postgres store WITHOUT resetting it. Used by
+// dedicated tests that manage their own data lifecycle (store_id stability,
+// CreateShare contract). The store is closed via t.Cleanup.
+func newPostgresStore(t *testing.T) *postgres.PostgresMetadataStore {
+	t.Helper()
+	cfg, caps := postgresTestConfig()
+	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+	if err != nil {
+		t.Fatalf("NewPostgresMetadataStore() failed: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// newPostgresStoreFactory returns a factory that hands each conformance
+// subtest a CLEAN store. The conformance subtests share one database and
+// reuse fixed share names ("/test"), so per-subtest isolation is mandatory:
+// open to ensure the schema is migrated, Reset to truncate any data a prior
+// subtest left behind, then re-open. The re-open re-seeds
+// filesystem_capabilities and server_config (store_id) on the now-empty
+// singleton tables, exercising the post-reset reopen path the restore
+// orchestration depends on.
 func newPostgresStoreFactory() func(t *testing.T) metadata.MetadataStore {
 	return func(t *testing.T) metadata.MetadataStore {
-		cfg := &postgres.PostgresMetadataStoreConfig{
-			Host:        "localhost",
-			Port:        5432,
-			Database:    "dittofs_test",
-			User:        "postgres",
-			Password:    "postgres",
-			SSLMode:     "disable",
-			AutoMigrate: true,
-		}
+		t.Helper()
+		cfg, caps := postgresTestConfig()
+		ctx := context.Background()
 
-		caps := metadata.FilesystemCapabilities{
-			MaxReadSize:         1048576,
-			PreferredReadSize:   1048576,
-			MaxWriteSize:        1048576,
-			PreferredWriteSize:  1048576,
-			MaxFileSize:         9223372036854775807,
-			MaxFilenameLen:      255,
-			MaxPathLen:          4096,
-			MaxHardLinkCount:    32767,
-			SupportsHardLinks:   true,
-			SupportsSymlinks:    true,
-			CaseSensitive:       true,
-			CasePreserving:      true,
-			TimestampResolution: 1,
-		}
-
-		store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+		seed, err := postgres.NewPostgresMetadataStore(ctx, cfg, caps)
 		if err != nil {
 			t.Fatalf("NewPostgresMetadataStore() failed: %v", err)
 		}
-		t.Cleanup(func() {
-			store.Close()
-		})
+		if err := seed.Reset(ctx); err != nil {
+			seed.Close()
+			t.Fatalf("Reset() failed: %v", err)
+		}
+		seed.Close()
+
+		store, err := postgres.NewPostgresMetadataStore(ctx, cfg, caps)
+		if err != nil {
+			t.Fatalf("NewPostgresMetadataStore() reopen failed: %v", err)
+		}
+		t.Cleanup(func() { store.Close() })
 		return store
 	}
 }

--- a/pkg/metadata/store/postgres/rollup.go
+++ b/pkg/metadata/store/postgres/rollup.go
@@ -47,16 +47,17 @@ func validateStoredOffset(v int64) (uint64, error) {
 // On monotone violation (newOffset < stored), returns (storedOffset,
 // metadata.ErrRollupOffsetRegression); the stored value is UNCHANGED.
 //
-// Atomicity: a transaction reads the prior row under FOR UPDATE (row lock)
-// and then conditionally upserts under that same lock, so the returned
-// `prev` always reflects the value the upsert observed — never a stale
-// snapshot from a parallel transaction.
+// Atomicity: the monotone invariant (INV-03) is enforced by the conditional
+// WHERE predicate on the ON CONFLICT DO UPDATE branch — a regression performs
+// no write and reports RowsAffected()==0. This holds even for concurrent
+// first-inserts (no row to FOR UPDATE-lock): they converge under the
+// unique-key conflict and the WHERE guard rejects the lower offset.
 //
-// The prior value is read explicitly rather than projected out of an
-// INSERT ... ON CONFLICT ... RETURNING (SELECT rollup_offset FROM cte):
-// the CTE and the conflict target are the same row, and the RETURNING
-// subquery resolves to NULL there, so that single-statement form always
-// reported prev=0 on the update path (it only worked on first insert).
+// The prior value is read separately (FOR UPDATE) only to return `prev` on
+// success. It is NOT projected out of an
+// INSERT ... ON CONFLICT ... RETURNING (SELECT rollup_offset FROM cte): the
+// CTE and the conflict target are the same row, so that subquery resolves to
+// NULL and reported prev=0 on every update.
 func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID string, newOffset uint64) (uint64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -77,14 +78,18 @@ func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID s
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Lock + read the prior value. ErrNoRows means no row yet (prev == 0).
+	// Lock + read the prior value for the returned `prev`. ErrNoRows means no
+	// row yet (prev == 0); FOR UPDATE then locks nothing, so the monotone
+	// invariant for that case CANNOT rely on this read — two concurrent
+	// first-inserts both see no row. The conditional WHERE predicate on the
+	// upsert below is the authority (see migration 000009 / INV-03).
 	var prev uint64
 	var prevSigned int64
 	switch err := tx.QueryRow(ctx,
 		`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = $1 FOR UPDATE`,
 		payloadID).Scan(&prevSigned); {
 	case errors.Is(err, pgx.ErrNoRows):
-		// No prior row: prev stays 0, fall through to the insert path.
+		// No prior row yet: prev stays 0.
 	case err != nil:
 		return 0, fmt.Errorf("postgres rollup select-for-update: %w", err)
 	default:
@@ -93,21 +98,41 @@ func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID s
 			return 0, verr
 		}
 		prev = v
-		// Monotone guard: a strictly-lower offset is a regression. Leave the
-		// stored value untouched (deferred Rollback releases the lock) and
-		// surface the sentinel with the unchanged prior value.
-		if newOffset < prev {
-			return prev, metadata.ErrRollupOffsetRegression
-		}
 	}
 
-	if _, err := tx.Exec(ctx,
+	// Monotone upsert: the WHERE predicate rejects a strictly-lower offset on
+	// the conflict branch, so a regression performs no write and reports
+	// RowsAffected()==0. This is the single point that enforces INV-03 and is
+	// safe even when no row existed at the SELECT above (concurrent
+	// first-inserts converge here under the unique-key conflict).
+	tag, err := tx.Exec(ctx,
 		`INSERT INTO rollup_offsets (payload_id, rollup_offset)
 		 VALUES ($1, $2)
-		 ON CONFLICT (payload_id) DO UPDATE SET rollup_offset = EXCLUDED.rollup_offset`,
-		payloadID, int64(newOffset)); err != nil {
+		 ON CONFLICT (payload_id) DO UPDATE SET rollup_offset = EXCLUDED.rollup_offset
+		 WHERE rollup_offsets.rollup_offset <= EXCLUDED.rollup_offset`,
+		payloadID, int64(newOffset))
+	if err != nil {
 		return 0, fmt.Errorf("postgres rollup upsert: %w", err)
 	}
+
+	if tag.RowsAffected() == 0 {
+		// Regression: a row exists with a strictly-higher offset (this caller's
+		// newOffset < stored, possibly written by a racing first-insert). Read
+		// the committed value to report; the stored value is left UNCHANGED
+		// (deferred Rollback releases the lock without writing).
+		var stored int64
+		if err := tx.QueryRow(ctx,
+			`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = $1`,
+			payloadID).Scan(&stored); err != nil {
+			return 0, fmt.Errorf("postgres rollup read after regression: %w", err)
+		}
+		v, verr := validateStoredOffset(stored)
+		if verr != nil {
+			return 0, verr
+		}
+		return v, metadata.ErrRollupOffsetRegression
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return 0, fmt.Errorf("postgres rollup commit: %w", err)
 	}

--- a/pkg/metadata/store/postgres/rollup.go
+++ b/pkg/metadata/store/postgres/rollup.go
@@ -16,10 +16,10 @@ import (
 // ============================================================================
 //
 // Persists the per-file rollup_offset for the hybrid append-log tier. The
-// atomic-monotone contract is enforced at the DATABASE layer via
-// a conditional WHERE predicate on the ON CONFLICT DO UPDATE branch — no
-// read-modify-write race window exists application-side, because the
-// engine itself rejects regressions.
+// atomic-monotone contract is enforced by reading the prior value under a
+// FOR UPDATE row lock and rejecting a strictly-lower offset before the
+// upsert commits — the lock closes the read-modify-write race window, so a
+// concurrent writer cannot interleave between the check and the write.
 //
 // Schema lives in migration 000009 (rollup_offsets table). The migration
 // is idempotent (`CREATE TABLE IF NOT EXISTS`), so a re-run on an
@@ -78,19 +78,16 @@ func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID s
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Lock + read the prior value. ErrNoRows means no row yet (prev == 0).
+	var prev uint64
 	var prevSigned int64
-	hasPrev := true
 	switch err := tx.QueryRow(ctx,
 		`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = $1 FOR UPDATE`,
 		payloadID).Scan(&prevSigned); {
 	case errors.Is(err, pgx.ErrNoRows):
-		hasPrev = false
+		// No prior row: prev stays 0, fall through to the insert path.
 	case err != nil:
 		return 0, fmt.Errorf("postgres rollup select-for-update: %w", err)
-	}
-
-	var prev uint64
-	if hasPrev {
+	default:
 		v, verr := validateStoredOffset(prevSigned)
 		if verr != nil {
 			return 0, verr

--- a/pkg/metadata/store/postgres/rollup.go
+++ b/pkg/metadata/store/postgres/rollup.go
@@ -47,17 +47,16 @@ func validateStoredOffset(v int64) (uint64, error) {
 // On monotone violation (newOffset < stored), returns (storedOffset,
 // metadata.ErrRollupOffsetRegression); the stored value is UNCHANGED.
 //
-// Atomicity: a single CTE-wrapped statement captures the prior row under
-// FOR UPDATE (row lock) BEFORE the conditional upsert fires. The
-// row-level lock excludes any concurrent writer for the duration of the
-// statement, so the returned `prev` always reflects the value the upsert
-// observed — never a stale snapshot from a parallel transaction.
+// Atomicity: a transaction reads the prior row under FOR UPDATE (row lock)
+// and then conditionally upserts under that same lock, so the returned
+// `prev` always reflects the value the upsert observed — never a stale
+// snapshot from a parallel transaction.
 //
-// The conflict branch's WHERE predicate
-// (rollup_offsets.rollup_offset <= EXCLUDED.rollup_offset) enforces the
-// monotone invariant: if it rejects, neither INSERT nor UPDATE fires and
-// the RETURNING clause yields no rows — we surface that as the
-// regression sentinel and return the locked prior value.
+// The prior value is read explicitly rather than projected out of an
+// INSERT ... ON CONFLICT ... RETURNING (SELECT rollup_offset FROM cte):
+// the CTE and the conflict target are the same row, and the RETURNING
+// subquery resolves to NULL there, so that single-statement form always
+// reported prev=0 on the update path (it only worked on first insert).
 func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID string, newOffset uint64) (uint64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -72,63 +71,50 @@ func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID s
 		return 0, fmt.Errorf("postgres: rollup offset %d exceeds BIGINT range", newOffset)
 	}
 
-	// Single-statement atomic upsert: the `prev` CTE locks the existing
-	// row (if any) with FOR UPDATE, then the INSERT ... ON CONFLICT runs
-	// in the same statement under that lock. RETURNING yields the prior
-	// value (or NULL on first insert) alongside the new value when the
-	// monotone guard accepts the write.
-	//
-	// On regression (WHERE predicate false on the conflict branch),
-	// neither INSERT nor UPDATE fires, RETURNING yields zero rows, and
-	// the row-lock release exposes the unchanged prior value to the
-	// follow-up read below.
-	const upsertSQL = `
-		WITH prev AS (
-			SELECT rollup_offset FROM rollup_offsets
-			WHERE payload_id = $1
-			FOR UPDATE
-		)
-		INSERT INTO rollup_offsets (payload_id, rollup_offset)
-		VALUES ($1, $2)
-		ON CONFLICT (payload_id) DO UPDATE
-			SET rollup_offset = EXCLUDED.rollup_offset
-			WHERE rollup_offsets.rollup_offset <= EXCLUDED.rollup_offset
-		RETURNING (SELECT rollup_offset FROM prev), rollup_offset
-	`
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("postgres rollup begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
 
-	var (
-		prevSigned    *int64 // nullable: NULL on first insert
-		currentSigned int64
-	)
-	row := s.queryRow(ctx, upsertSQL, payloadID, int64(newOffset))
-	switch err := row.Scan(&prevSigned, &currentSigned); {
+	// Lock + read the prior value. ErrNoRows means no row yet (prev == 0).
+	var prevSigned int64
+	hasPrev := true
+	switch err := tx.QueryRow(ctx,
+		`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = $1 FOR UPDATE`,
+		payloadID).Scan(&prevSigned); {
 	case errors.Is(err, pgx.ErrNoRows):
-		// Regression: monotone guard rejected the update. Read the
-		// locked-and-released prior value to surface in the sentinel
-		// error. The lock from the CTE has been released by the time
-		// this query runs, but a concurrent writer at this point would
-		// only ever advance the value monotonically — the regression
-		// sentinel remains correct (newOffset < stored holds).
-		var stored int64
-		row2 := s.queryRow(ctx,
-			`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = $1`,
-			payloadID)
-		if err2 := row2.Scan(&stored); err2 != nil {
-			return 0, fmt.Errorf("postgres rollup read after regression: %w", err2)
-		}
-		v, verr := validateStoredOffset(stored)
+		hasPrev = false
+	case err != nil:
+		return 0, fmt.Errorf("postgres rollup select-for-update: %w", err)
+	}
+
+	var prev uint64
+	if hasPrev {
+		v, verr := validateStoredOffset(prevSigned)
 		if verr != nil {
 			return 0, verr
 		}
-		return v, metadata.ErrRollupOffsetRegression
-	case err != nil:
-		return 0, fmt.Errorf("postgres rollup upsert: %w", err)
+		prev = v
+		// Monotone guard: a strictly-lower offset is a regression. Leave the
+		// stored value untouched (deferred Rollback releases the lock) and
+		// surface the sentinel with the unchanged prior value.
+		if newOffset < prev {
+			return prev, metadata.ErrRollupOffsetRegression
+		}
 	}
 
-	if prevSigned == nil {
-		return 0, nil
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO rollup_offsets (payload_id, rollup_offset)
+		 VALUES ($1, $2)
+		 ON CONFLICT (payload_id) DO UPDATE SET rollup_offset = EXCLUDED.rollup_offset`,
+		payloadID, int64(newOffset)); err != nil {
+		return 0, fmt.Errorf("postgres rollup upsert: %w", err)
 	}
-	return validateStoredOffset(*prevSigned)
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("postgres rollup commit: %w", err)
+	}
+	return prev, nil
 }
 
 // GetRollupOffset returns the persisted rollup_offset for payloadID, or

--- a/pkg/metadata/store/postgres/rollup_test.go
+++ b/pkg/metadata/store/postgres/rollup_test.go
@@ -8,50 +8,25 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
 )
 
 // TestPostgresRollupStore_Suite exercises the shared RollupStore conformance
 // suite against the Postgres backend. Requires a live PostgreSQL at
 // DITTOFS_TEST_POSTGRES_DSN (the same env-var gate used by the Postgres
-// conformance suite). Atomic-monotone semantics are enforced by
-// the ON CONFLICT ... WHERE clause — see pkg/metadata/store/postgres/rollup.go.
+// conformance suite). Atomic-monotone semantics are enforced by reading the
+// prior offset under a FOR UPDATE row lock — see SetRollupOffset in
+// pkg/metadata/store/postgres/rollup.go.
 func TestPostgresRollupStore_Suite(t *testing.T) {
 	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
 		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL rollup tests")
 	}
 
-	cfg := &postgres.PostgresMetadataStoreConfig{
-		Host:        "localhost",
-		Port:        5432,
-		Database:    "dittofs_test",
-		User:        "postgres",
-		Password:    "postgres",
-		SSLMode:     "disable",
-		AutoMigrate: true,
+	// Reset first: this package's tests share one database, and the suite
+	// uses fixed payload IDs — start from a known-empty rollup_offsets table.
+	store := newPostgresStore(t)
+	if err := store.Reset(context.Background()); err != nil {
+		t.Fatalf("Reset: %v", err)
 	}
-
-	caps := metadata.FilesystemCapabilities{
-		MaxReadSize:         1048576,
-		PreferredReadSize:   1048576,
-		MaxWriteSize:        1048576,
-		PreferredWriteSize:  1048576,
-		MaxFileSize:         9223372036854775807,
-		MaxFilenameLen:      255,
-		MaxPathLen:          4096,
-		MaxHardLinkCount:    32767,
-		SupportsHardLinks:   true,
-		SupportsSymlinks:    true,
-		CaseSensitive:       true,
-		CasePreserving:      true,
-		TimestampResolution: 1,
-	}
-
-	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
-	if err != nil {
-		t.Fatalf("NewPostgresMetadataStore: %v", err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
 
 	metadata.RunRollupStoreSuite(t, store)
 }

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -117,6 +117,13 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 	// existing root in place (no orphaned inode).
 
 	// Duplicate detection: a share is "created" once its root inode exists.
+	// This read is the common-case fast path; it is not the integrity
+	// authority. Two creators racing the same name both pass this check and
+	// reach CreateRootDirectory, but the partial unique index
+	// unique_share_path_hash_active on files(share_name, path_hash) admits
+	// only one root inode at path "/" — the loser's insert fails rather than
+	// silently orphaning an inode. (Production also serializes share creation
+	// upstream in the control plane.)
 	if existing, err := s.getExistingRootDirectory(ctx, share.Name); err == nil && existing != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrAlreadyExists,

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -104,28 +104,41 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 		return err
 	}
 
-	query := `
-		INSERT INTO shares (share_name, options, block_layout)
-		VALUES ($1, $2, $3)
-	`
+	// The shares.root_file_id column is NOT NULL with an FK to files(id), so
+	// a share row cannot exist before its root inode — a bare
+	// INSERT INTO shares (share_name, options, ...) is structurally
+	// impossible (it raises a not_null_violation on root_file_id) and never
+	// once succeeded. Honour the documented contract ("Also creates the root
+	// directory for the share", matching the memory/badger backends) by
+	// materializing a default root directory, which inserts the shares row
+	// via CreateRootDirectory's ON CONFLICT upsert, then persisting the
+	// caller's options. Callers wanting specific root attrs invoke
+	// CreateRootDirectory afterward; it is idempotent and updates the
+	// existing root in place (no orphaned inode).
 
-	optionsData, err := json.Marshal(share.Options)
-	if err != nil {
-		return err
+	// Duplicate detection: a share is "created" once its root inode exists.
+	if existing, err := s.getExistingRootDirectory(ctx, share.Name); err == nil && existing != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrAlreadyExists,
+			Message: "share already exists",
+			Path:    share.Name,
+		}
 	}
 
-	// Normalize on write so a caller passing an empty-string zero
-	// value lands as 'legacy' in the column, not an empty TEXT (which
-	// the NOT NULL DEFAULT would catch but only if the column is
-	// omitted entirely from the INSERT).
-	layout, err := metadata.ParseBlockLayout(string(share.Options.BlockLayout))
-	if err != nil {
-		return fmt.Errorf("share %q: %w", share.Name, err)
+	rootAttr := &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	}
+	if _, err := s.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
+		return fmt.Errorf("create share %q root directory: %w", share.Name, err)
 	}
 
-	_, err = s.exec(ctx, query, share.Name, optionsData, string(layout))
-	if err != nil {
-		return err
+	// Persist the requested options + block layout on the freshly-inserted
+	// row (CreateRootDirectory seeds only share_name + root_file_id, leaving
+	// options/block_layout at their column defaults). UpdateShareOptions
+	// applies the same ParseBlockLayout normalization the old INSERT did.
+	if err := s.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
+		return fmt.Errorf("create share %q options: %w", share.Name, err)
 	}
 
 	return nil

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -116,6 +116,13 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 	// CreateRootDirectory afterward; it is idempotent and updates the
 	// existing root in place (no orphaned inode).
 
+	// Validate the block layout BEFORE creating any rows so an invalid value
+	// can't leave a half-created share (root inode materialized, options
+	// rejected). UpdateShareOptions re-parses it; this is the early guard.
+	if _, err := metadata.ParseBlockLayout(string(share.Options.BlockLayout)); err != nil {
+		return fmt.Errorf("create share %q: %w", share.Name, err)
+	}
+
 	// Duplicate detection: a share is "created" once its root inode exists.
 	// This read is the common-case fast path; it is not the integrity
 	// authority. Two creators racing the same name both pass this check and
@@ -124,7 +131,11 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 	// only one root inode at path "/" — the loser's insert fails rather than
 	// silently orphaning an inode. (Production also serializes share creation
 	// upstream in the control plane.)
-	if existing, err := s.getExistingRootDirectory(ctx, share.Name); err == nil && existing != nil {
+	existing, err := s.getExistingRootDirectory(ctx, share.Name)
+	if err != nil {
+		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
+	}
+	if existing != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrAlreadyExists,
 			Message: "share already exists",

--- a/pkg/metadata/store/postgres/shares_test.go
+++ b/pkg/metadata/store/postgres/shares_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
 	"github.com/marmos91/dittofs/pkg/metadata/storetest"
 )
 
@@ -23,38 +22,13 @@ func TestBlockLayoutConformance(t *testing.T) {
 		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL BlockLayout conformance")
 	}
 
+	// Per-subtest clean store: the suite uses fixed share names and this
+	// package's tests share one database, so reset each store on open.
 	storetest.RunBlockLayoutSuite(t, func(t *testing.T) metadata.MetadataStore {
-		cfg := &postgres.PostgresMetadataStoreConfig{
-			Host:        "localhost",
-			Port:        5432,
-			Database:    "dittofs_test",
-			User:        "postgres",
-			Password:    "postgres",
-			SSLMode:     "disable",
-			AutoMigrate: true,
+		store := newPostgresStore(t)
+		if err := store.Reset(context.Background()); err != nil {
+			t.Fatalf("Reset: %v", err)
 		}
-		caps := metadata.FilesystemCapabilities{
-			MaxReadSize:         1048576,
-			PreferredReadSize:   1048576,
-			MaxWriteSize:        1048576,
-			PreferredWriteSize:  1048576,
-			MaxFileSize:         9223372036854775807,
-			MaxFilenameLen:      255,
-			MaxPathLen:          4096,
-			MaxHardLinkCount:    32767,
-			SupportsHardLinks:   true,
-			SupportsSymlinks:    true,
-			CaseSensitive:       true,
-			CasePreserving:      true,
-			TimestampResolution: 1,
-		}
-		store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
-		if err != nil {
-			t.Fatalf("NewPostgresMetadataStore() failed: %v", err)
-		}
-		t.Cleanup(func() {
-			_ = store.Close()
-		})
 		return store
 	})
 }

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -178,24 +178,34 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if
-// empty (migration 000008 default or a hand-cleared row), writes a fresh
-// ULID atomically and returns it. Safe to call on every open — idempotent
-// after bootstrap.
+// the row is missing or carries the empty sentinel, writes a fresh ULID
+// atomically and returns it. Safe to call on every open — idempotent after
+// bootstrap.
 //
-// The UPDATE ... RETURNING form performs the check-and-set in a single
-// round-trip: COALESCE + NULLIF treats an empty string as NULL and then
-// substitutes the fresh ULID; any existing non-empty value is preserved.
+// The INSERT ... ON CONFLICT ... RETURNING form performs the check-and-set
+// in a single round-trip AND recreates the singleton row when it is absent.
+// The row can be absent legitimately: truncateAllTables (Reset and the
+// pre-COPY phase of Restore) clears server_config, and AutoMigrate does not
+// re-seed it on a reopen (migration 000001 already recorded). An UPDATE-only
+// form matched zero rows in that state and failed store open with
+// "no rows in result set" — bricking the store after a Reset/restore crash,
+// which in turn prevents the boot-time restore-marker recovery from ever
+// running. ON CONFLICT preserves any existing non-empty store_id (COALESCE +
+// NULLIF treat an empty string as NULL); config and updated_at fall back to
+// their column defaults on the insert path and are left untouched on
+// conflict. Concurrency-safe: two racing opens converge on one row.
 func (s *PostgresMetadataStore) ensureStoreID(ctx context.Context) (string, error) {
 	fresh := ulid.Make().String()
 	var existing string
 	err := s.pool.QueryRow(ctx, `
-		UPDATE server_config
-		SET store_id = COALESCE(NULLIF(store_id, ''), $1)
-		WHERE id = 1
+		INSERT INTO server_config (id, store_id)
+		VALUES (1, $1)
+		ON CONFLICT (id) DO UPDATE
+		SET store_id = COALESCE(NULLIF(server_config.store_id, ''), EXCLUDED.store_id)
 		RETURNING store_id
 	`, fresh).Scan(&existing)
 	if err != nil {
-		return "", fmt.Errorf("ensure store_id: %w", err)
+		return "", fmt.Errorf("upsert store_id row: %w", err)
 	}
 	return existing, nil
 }

--- a/pkg/metadata/store/postgres/store_id_test.go
+++ b/pkg/metadata/store/postgres/store_id_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestPostgres_StoreID_SurvivesResetAndReopen pins the fix for the store-open
+// deadlock: Reset (and the pre-COPY truncate inside Restore) clears
+// server_config, including the singleton id=1 row. AutoMigrate does not
+// re-seed it on a reopen (migration 000001 is already recorded), so the
+// store-bootstrap ensureStoreID step must recreate the row itself. The
+// previous UPDATE-only form matched zero rows and failed every reopen with
+// "no rows in result set" — which bricked the store after a Reset/restore
+// crash and, fatally, blocked the boot-time restore-marker recovery from
+// ever opening the store to run.
+func TestPostgres_StoreID_SurvivesResetAndReopen(t *testing.T) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL store_id test")
+	}
+
+	ctx := context.Background()
+
+	// First open seeds id=1 with a fresh store_id.
+	a := newPostgresStore(t)
+	sid1 := storeID(t, a)
+	if sid1 == "" {
+		t.Fatal("first open: store_id is empty, want a generated ULID")
+	}
+
+	// Reset truncates every table, including server_config — the exact
+	// production trigger (restore orchestration resets metadata before COPY).
+	if err := a.Reset(ctx); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	// Reopen MUST succeed (the bug: it failed here) and re-seed a store_id.
+	// newPostgresStore calls t.Fatalf internally if the open errors.
+	b := newPostgresStore(t)
+	sid2 := storeID(t, b)
+	if sid2 == "" {
+		t.Fatal("reopen after reset: store_id is empty, want a freshly generated ULID")
+	}
+
+	// A subsequent reopen must preserve the now-seeded value (COALESCE/NULLIF
+	// keeps a non-empty store_id stable across opens).
+	c := newPostgresStore(t)
+	sid3 := storeID(t, c)
+	if sid3 != sid2 {
+		t.Fatalf("store_id not stable across reopen: got %q, want %q", sid3, sid2)
+	}
+}
+
+// storeID extracts the engine-persistent store identifier via the
+// GetStoreID() surface the Postgres engine exposes.
+func storeID(t *testing.T, store metadata.MetadataStore) string {
+	t.Helper()
+	getter, ok := store.(interface{ GetStoreID() string })
+	if !ok {
+		t.Fatalf("store does not expose GetStoreID()")
+	}
+	return getter.GetStoreID()
+}

--- a/pkg/metadata/storetest/backup_conformance.go
+++ b/pkg/metadata/storetest/backup_conformance.go
@@ -289,6 +289,7 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 		}
 		f := &metadata.File{
 			ShareName: shareName,
+			Path:      "/concurrent-new.bin",
 			FileAttr: metadata.FileAttr{
 				Type: metadata.FileTypeRegular,
 				Mode: 0o644,

--- a/pkg/metadata/storetest/inv02_fuzz.go
+++ b/pkg/metadata/storetest/inv02_fuzz.go
@@ -291,6 +291,7 @@ func fuzzCreateFile(ctx context.Context, store metadata.MetadataStore, shareName
 	file := &metadata.File{
 		ID:        fileID,
 		ShareName: shareName,
+		Path:      "/" + name,
 		FileAttr: metadata.FileAttr{
 			Type:   metadata.FileTypeRegular,
 			Mode:   0o644,
@@ -397,6 +398,7 @@ func fuzzCopyFile(ctx context.Context, store metadata.MetadataStore, shareName s
 	dst := &metadata.File{
 		ID:        fileID,
 		ShareName: shareName,
+		Path:      "/" + name,
 		FileAttr: metadata.FileAttr{
 			Type:   metadata.FileTypeRegular,
 			Mode:   0o644,

--- a/pkg/metadata/storetest/permissions.go
+++ b/pkg/metadata/storetest/permissions.go
@@ -68,6 +68,7 @@ func testDirectoryPermissionAttributes(t *testing.T, factory StoreFactory) {
 
 	dir := &metadata.File{
 		ShareName: "/test",
+		Path:      "/restricted",
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0700,

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -6,6 +6,28 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
+// childFullPath derives the full share-relative path for a child entry,
+// joining the parent directory's stored Path with the child name. Root
+// children become "/name"; nested entries become "/parent/.../name". This
+// mirrors production (file_create.go) so path-keyed backends (Postgres) see
+// a unique, non-empty path per entry instead of all-"" collisions.
+func childFullPath(t *testing.T, store metadata.MetadataStore, parentHandle metadata.FileHandle, name string) string {
+	t.Helper()
+
+	parent, err := store.GetFile(t.Context(), parentHandle)
+	if err != nil {
+		t.Fatalf("GetFile(parent) failed: %v", err)
+	}
+	parentPath := parent.Path
+	if parentPath == "" {
+		parentPath = "/"
+	}
+	if parentPath == "/" {
+		return "/" + name
+	}
+	return parentPath + "/" + name
+}
+
 // StoreFactory creates a fresh MetadataStore instance for each test.
 // The factory receives *testing.T so it can use t.TempDir() for stores
 // that need filesystem paths and t.Cleanup() for teardown.
@@ -124,8 +146,14 @@ func createTestFile(t *testing.T, store metadata.MetadataStore, shareName string
 
 	ctx := t.Context()
 
+	// Derive the full path from the parent directory, mirroring production
+	// (file_create.go), so path-keyed backends (Postgres) get a unique,
+	// non-empty path per entry. Root children are "/name"; nested entries
+	// join the parent's path.
+	fullPath := childFullPath(t, store, dirHandle, name)
+
 	// Generate handle
-	handle, err := store.GenerateHandle(ctx, shareName, "/"+name)
+	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
 	if err != nil {
 		t.Fatalf("GenerateHandle() failed: %v", err)
 	}
@@ -133,6 +161,7 @@ func createTestFile(t *testing.T, store metadata.MetadataStore, shareName string
 	// Create file entry
 	file := &metadata.File{
 		ShareName: shareName,
+		Path:      fullPath,
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: mode,
@@ -177,8 +206,12 @@ func createTestDir(t *testing.T, store metadata.MetadataStore, shareName string,
 
 	ctx := t.Context()
 
+	// Derive the full path from the parent directory so path-keyed backends
+	// (Postgres) get a unique, non-empty path per entry.
+	fullPath := childFullPath(t, store, parentHandle, name)
+
 	// Generate handle
-	handle, err := store.GenerateHandle(ctx, shareName, "/"+name)
+	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
 	if err != nil {
 		t.Fatalf("GenerateHandle() failed: %v", err)
 	}
@@ -186,6 +219,7 @@ func createTestDir(t *testing.T, store metadata.MetadataStore, shareName string,
 	// Create dir entry
 	dir := &metadata.File{
 		ShareName: shareName,
+		Path:      fullPath,
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0755,


### PR DESCRIPTION
## Summary

Makes the **PostgreSQL metadata backend production-ready and CI-verified** — and adds a deterministic, cross-backend byte-verify proof for the share-snapshot feature. The postgres integration suite was **never run in CI** (no DB/DSN in the workflow), which hid several real defects. This branch fixes them, wires postgres into CI, reconciles the conformance suite, and proves snapshot→mutate→restore is byte-identical on memory, badger, and postgres.

## Real bugs fixed (all were CI-invisible)

1. **`ensureStoreID` store-reopen deadlock (HIGH).** Bootstrap used `UPDATE server_config ... WHERE id=1`, which matched zero rows once `server_config` was truncated — which `Reset` and the pre-COPY phase of `Restore` do. `AutoMigrate` does not re-seed the singleton on reopen, so the store could **never reopen** after a restore/Reset — bricking it and, fatally, preventing the boot-time restore-marker recovery from ever opening the store to run. Now an idempotent, concurrency-safe `INSERT ... ON CONFLICT DO UPDATE` upsert that self-heals the row.

2. **`CreateShare` could never succeed on postgres.** It issued a bare `INSERT INTO shares (...)` that omitted the `NOT NULL root_file_id` FK. Now honours its documented contract (create the share *and* its root directory, like memory/badger) by materializing a default root via the idempotent `CreateRootDirectory`, then persisting options.

3. **`SetRollupOffset` always returned `prev=0` on updates.** The single-statement `INSERT ... ON CONFLICT ... RETURNING (SELECT rollup_offset FROM cte)` could not surface the pre-update value — the CTE and the conflict target are the same row, so the subquery resolves to NULL (verified at the SQL level). Now reads the prior value under a `FOR UPDATE` row lock in an explicit transaction, then conditionally upserts.

## Test/CI hardening

4. **CI now runs postgres.** `integration-tests.yml` gains a `postgres:16` service + `DITTOFS_TEST_POSTGRES_DSN`, and runs with `-p 1` so package binaries sharing the single `dittofs_test` database don't race against the conformance suite's truncations.

5. **Conformance suite reconciled for path-keyed backends.** The shared helpers built `metadata.File` without `Path`; postgres keys files on `(share_name, path)` and collided on the 2nd empty path (memory tolerates it — handle-keyed). Production always sets `Path` (`file_create.go`), so the helpers now derive the correct full path from the parent. Memory + badger conformance remain green.

6. **Byte-verify snapshot matrix.** New `snapshot_byteverify_test.go` (+ postgres companion) drives the **real** engine write path — `WriteToBlockStore → CommitBlockStore → DrainRollups` (Blocks persisted by the coordinator, never injected) — then snapshots, overwrites a file in place, deletes another, adds a third, drops the local cache (`ResetLocalState`, exercising the #838 cold-read path), restores, and asserts **byte-identical** across memory/badger/postgres. Includes a multi-chunk (3 MiB FastCDC) file and a negative-control check so the pass is not vacuous.

## Verification

- Full postgres integration suite: `ok` (conformance + backup + reset-restore + rollup + regression tests), fresh DB, `-p 1`.
- memory + badger conformance, runtime snapshot suite: green, no regressions.
- byte-verify matrix: memory/badger/postgres all byte-identical; `-race -count=2` clean.
- `gofmt`, `go vet` (both tag sets), `golangci-lint`: clean.

## Notes
- The standalone metadata `CreateShare` dup-check is a fast path, not the integrity authority: the `unique_share_path_hash_active` partial index on `files` admits only one root inode per share, so concurrent same-name creates can't orphan an inode (and the control plane serializes share creation upstream).
