### PR TITLE
fix(smb): durable reopen2-family — gate root open on reconnect, restore CreateGuid (#738/#739)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -747,8 +747,15 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		fullFilename = filename + streamSuffix
 	}
 
-	// Handle root directory case
-	if filename == "" && streamSuffix == "" {
+	// Handle root directory case. A durable-reconnect request (DHnC/DH2C) that
+	// carries an empty filename must NOT open the share root — it has to fall
+	// through to Step 4b so the reconnect path rejects it with
+	// OBJECT_NAME_NOT_FOUND. smbtorture durable-open.reopen2_lease / _lease_v2
+	// and the V2 reopen2 family send an empty-fname reconnect as a negative case.
+	hasReconnectCtx := h.DurableStore != nil &&
+		(FindCreateContext(req.CreateContexts, DurableHandleV1ReconnectTag) != nil ||
+			FindCreateContext(req.CreateContexts, DurableHandleV2ReconnectTag) != nil)
+	if filename == "" && streamSuffix == "" && !hasReconnectCtx {
 		resp, err := h.handleOpenRootCreate(ctx, req, authCtx, rootHandle, tree)
 		h.storeCreateReplayIfApplicable(ctx, req, resp)
 		return resp, err

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -749,9 +749,10 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Handle root directory case. A durable-reconnect request (DHnC/DH2C) that
 	// carries an empty filename must NOT open the share root — it has to fall
-	// through to Step 4b so the reconnect path rejects it with
-	// OBJECT_NAME_NOT_FOUND. smbtorture durable-open.reopen2_lease / _lease_v2
-	// and the V2 reopen2 family send an empty-fname reconnect as a negative case.
+	// through to Step 4b so the reconnect path validates it (and rejects a stale
+	// or mismatched reconnect rather than silently opening the root). smbtorture
+	// durable-open.reopen2_lease / _lease_v2 and the V2 reopen2 family send an
+	// empty-fname reconnect as a negative case.
 	hasReconnectCtx := h.DurableStore != nil &&
 		(FindCreateContext(req.CreateContexts, DurableHandleV1ReconnectTag) != nil ||
 			FindCreateContext(req.CreateContexts, DurableHandleV2ReconnectTag) != nil)

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -729,12 +729,21 @@ func validateAndRestore(
 		CreateOptions:  types.CreateOptions(handle.CreateOptions),
 		OplockLevel:    handle.OplockLevel,
 		LeaseKey:       handle.LeaseKey,
-		OpenTime:       handle.CreatedAt,
-		DeletePending:  handle.DeletePending,
-		ParentHandle:   handle.ParentHandle,
-		FileName:       handle.FileName,
-		IsDirectory:    handle.IsDirectory,
-		PositionInfo:   handle.PositionInfo,
+		// Restore the V2 CreateGuid recorded at the original CREATE so a
+		// chained disconnect→reconnect→disconnect cycle keeps the handle's
+		// V2 identity. Without this, the reconnected OpenFile carries a zero
+		// CreateGuid, so the next buildPersistedDurableHandle records IsV2=false
+		// with a zero guid, and the subsequent DH2C reconnect's
+		// GetDurableHandleByCreateGuid lookup fails — breaking the multi-cycle
+		// reconnect that smbtorture durable-v2-open.reopen2* exercises. V1
+		// handles persist CreateGuid == 0, so this is a no-op for them.
+		CreateGuid:    handle.CreateGuid,
+		OpenTime:      handle.CreatedAt,
+		DeletePending: handle.DeletePending,
+		ParentHandle:  handle.ParentHandle,
+		FileName:      handle.FileName,
+		IsDirectory:   handle.IsDirectory,
+		PositionInfo:  handle.PositionInfo,
 		// Restore the ClientGUID recorded at the original CREATE so a
 		// chained disconnect→reconnect→disconnect cycle preserves the
 		// per-(ClientGuid, LeaseKey) lease scoping check on the next

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -675,6 +675,14 @@ func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	if !restored.IsV2 {
 		t.Error("Expected IsV2=true for V2 reconnect")
 	}
+	// The restored OpenFile must carry the original CreateGuid so a chained
+	// disconnect→reconnect→disconnect cycle keeps the handle's V2 identity:
+	// without it the next buildPersistedDurableHandle records IsV2=false with a
+	// zero guid and the following DH2C by-CreateGuid lookup fails (the
+	// reopen2-family multi-cycle regression this fix addresses).
+	if restored.OpenFile.CreateGuid != createGuid {
+		t.Errorf("restored CreateGuid = %x, want %x", restored.OpenFile.CreateGuid, createGuid)
+	}
 
 	// Verify handle was deleted from store
 	h, _ := store.GetDurableHandle(ctx, "dh-002")


### PR DESCRIPTION
Addresses the durable-handle **reopen2** family across #738 (DH V1) and #739 (DH V2). Root-caused via an end-to-end reproduction that drives the real persist→reconnect handler path (memory metadata + DurableStore + LeaseManager), not an isolated decode test.

## Bugs fixed
1. **Empty-fname reconnect bypassed the durable path.** The root-directory short-circuit in `Create` ran *before* the DHnC/DH2C reconnect block, so a reconnect request with `fname=""` opened the share root and returned SUCCESS instead of `OBJECT_NAME_NOT_FOUND`. `reopen2_lease` / `reopen2_lease_v2` and the V2 reopen2 family send an empty-fname reconnect as a negative case. Fix: gate the short-circuit on the absence of a reconnect context (only when a DurableStore is present).
2. **Restored handle dropped its V2 CreateGuid.** `validateAndRestore` rebuilt the `OpenFile` without copying `CreateGuid`, so a reconnected V2 handle lost its identity → the next disconnect persisted `IsV2=false` with a zero guid → the following DH2C reconnect's by-CreateGuid lookup failed, breaking the multi-cycle reconnect. Fix: restore `CreateGuid` (no-op for V1, which persists 0).

## Expected to flip (CI must confirm)
- V2: `durable-v2-open.reopen2`, `reopen2b`, `reopen2-lease`, `reopen2-lease-v2` (Bug B is the common V2-family defect — may also advance V2 reopen1/reopen1a).
- V1: `durable-open.reopen2-lease`, `reopen2-lease-v2` (empty-fname case via Bug A).

## Not addressed / needs CI
- Plain `smb2.durable-open.reopen2` (V1 oplock): the 4-cycle handler repro PASSES locally, so if it still fails it is a wire-level issue (SPNEGO/error-body/context-encoding) needing the pcap-diff playbook — not a handler defect.
- Lease-state bytes/epoch and the INVALID_PARAMETER-vs-OBJECT_NAME_NOT_FOUND wrong-fname distinction can only be confirmed on the wire.

Could NOT run smbtorture locally (CI-only). KNOWN_FAILURES.md left untouched (two-commit discipline) — walk back rows only after CI logs the specific tests as PASS. No regression to reopen1/reopen1a (they carry no empty fname; V1 handles persist CreateGuid=0). Gates: gofmt, vet, golangci-lint (0 issues), `go test -race` all green.

No file overlap with #850 (reopen4: logoff.go/handler.go).