### PR TITLE
fix(lock): synchronous persist under mutex + close 5 restart-corruption bugs (PR-B1 round 3)

### DIFF
--- a/pkg/metadata/lock/errors.go
+++ b/pkg/metadata/lock/errors.go
@@ -1,8 +1,21 @@
 package lock
 
 import (
+	stderrors "errors"
+
 	"github.com/marmos91/dittofs/pkg/metadata/errors"
 )
+
+// isLockNotFound reports whether err is a store "lock not found" error. Used by
+// the synchronous delete path to ignore an already-absent record (idempotent
+// delete) without logging a spurious durability alarm.
+func isLockNotFound(err error) bool {
+	var se *errors.StoreError
+	if stderrors.As(err, &se) {
+		return se.Code == errors.ErrLockNotFound
+	}
+	return false
+}
 
 // NewLockedError creates error for lock conflicts (legacy FileLock).
 func NewLockedError(path string, conflict *LockConflict) *errors.StoreError {

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -609,7 +609,6 @@ type Manager struct {
 	lockStore      LockStore                 // persistent lock store (optional)
 	epoch          uint64                    // current server epoch (stamped on persisted locks)
 	shareName      string                    // share this manager serves (stamped on persisted byte-range locks)
-	lockSeq        uint64                    // monotonic counter for unique byte-range persist IDs (stacking)
 	recentlyBroken *recentlyBrokenCache      // prevents directory lease storms
 
 	// Delegation-related fields
@@ -620,6 +619,12 @@ type Manager struct {
 // DefaultDelegationRecallTimeout is the default delegation recall timeout.
 // NFS uses a longer timeout than SMB leases (90s vs 35s).
 const DefaultDelegationRecallTimeout = 90 * time.Second
+
+// persistTimeout bounds every synchronous lock-store call made under lm.mu.
+// Persistence runs inline (mutex order == store order, see putLockLocked) so a
+// hung backend would otherwise wedge the lock manager indefinitely; the timeout
+// turns that into a bounded best-effort failure that logs and proceeds.
+const persistTimeout = 3 * time.Second
 
 // newBaseManager creates a Manager with all common fields initialized.
 // Callers customize the returned Manager before use.
@@ -658,20 +663,12 @@ func NewManagerWithGracePeriod(gracePeriod *GracePeriodManager) *Manager {
 // performed by the caller.
 //
 // Returns nil on success, or ErrLocked if a conflict exists.
+//
+// Persistence is synchronous under lm.mu: the in-memory mutation and the
+// PutLock run while the mutex is held so the store sees mutations in the same
+// order the mutex serializes them. Two concurrent ops on the same persistID can
+// no longer reach the store out of order (the reorder/resurrection bug class).
 func (lm *Manager) Lock(handleKey string, lock FileLock) error {
-	op, err := lm.lockInner(handleKey, lock)
-	if err != nil {
-		return err
-	}
-	lm.runPersistOp(op)
-	return nil
-}
-
-// lockInner performs the in-memory portion of Lock under lm.mu and returns the
-// deferred persist op (if any) for the caller to execute after the mutex is
-// released. Splitting the IO out keeps a slow lock store from stalling other
-// lock operations (MS-SMB2 lock paths are latency-sensitive).
-func (lm *Manager) lockInner(handleKey string, lock FileLock) (*persistOp, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -680,7 +677,7 @@ func (lm *Manager) lockInner(handleKey string, lock FileLock) (*persistOp, error
 	// Check for conflicts with existing locks
 	for i := range existing {
 		if IsLockConflicting(&existing[i], &lock) {
-			return nil, NewLockedError("", conflictFrom(&existing[i]))
+			return NewLockedError("", conflictFrom(&existing[i]))
 		}
 	}
 
@@ -699,8 +696,9 @@ func (lm *Manager) lockInner(handleKey string, lock FileLock) (*persistOp, error
 				existing[i].Exclusive = lock.Exclusive
 				existing[i].AcquiredAt = time.Now()
 				existing[i].ID = lock.ID
-				lm.assignPersistIDLocked(handleKey, &existing[i])
-				return lm.persistFileLockLocked(handleKey, &existing[i]), nil
+				lm.assignPersistIDLocked(&existing[i])
+				lm.persistFileLockLocked(handleKey, &existing[i])
+				return nil
 			}
 		}
 	}
@@ -712,9 +710,10 @@ func (lm *Manager) lockInner(handleKey string, lock FileLock) (*persistOp, error
 
 	// Add new lock. A distinct persistID per stacked entry keeps the persisted
 	// record 1:1 with this slice entry (SMB shared-lock stacking).
-	lm.assignPersistIDLocked(handleKey, &lock)
+	lm.assignPersistIDLocked(&lock)
 	lm.locks[handleKey] = append(existing, lock)
-	return lm.persistFileLockLocked(handleKey, &lock), nil
+	lm.persistFileLockLocked(handleKey, &lock)
+	return nil
 }
 
 // Unlock releases a specific byte-range lock.
@@ -724,23 +723,12 @@ func (lm *Manager) lockInner(handleKey string, lock FileLock) (*persistOp, error
 //
 // Returns nil on success, or ErrLockNotFound if the lock wasn't found.
 func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, offset, length uint64) error {
-	op, err := lm.unlockInner(handleKey, openID, sessionID, offset, length)
-	if err != nil {
-		return err
-	}
-	lm.runPersistOp(op)
-	return nil
-}
-
-// unlockInner performs the in-memory removal under lm.mu and returns the
-// deferred delete op for the caller to run after releasing the mutex.
-func (lm *Manager) unlockInner(handleKey string, openID string, sessionID uint64, offset, length uint64) (*persistOp, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
-		return nil, NewLockNotFoundError("")
+		return NewLockNotFoundError("")
 	}
 
 	// Find and remove the matching lock. For stacked identical SMB shared
@@ -751,7 +739,7 @@ func (lm *Manager) unlockInner(handleKey string, openID string, sessionID uint64
 		if lockOwnerID(&existing[i]) == owner &&
 			existing[i].Offset == offset &&
 			existing[i].Length == length {
-			op := lm.deleteFileLockLocked(&existing[i])
+			lm.deleteFileLockLocked(&existing[i])
 			// Remove this lock
 			lm.locks[handleKey] = append(existing[:i], existing[i+1:]...)
 
@@ -759,11 +747,11 @@ func (lm *Manager) unlockInner(handleKey string, openID string, sessionID uint64
 			if len(lm.locks[handleKey]) == 0 {
 				delete(lm.locks, handleKey)
 			}
-			return op, nil
+			return nil
 		}
 	}
 
-	return nil, NewLockNotFoundError("")
+	return NewLockNotFoundError("")
 }
 
 // UnlockAllForOpen releases all locks held by a specific open on a file.
@@ -773,27 +761,20 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 	if openID == "" {
 		return 0 // empty openID would match all unset locks — guard against misuse
 	}
-	removed, ops := lm.unlockAllForOpenInner(handleKey, openID)
-	lm.runPersistOps(ops)
-	return removed
-}
-
-func (lm *Manager) unlockAllForOpenInner(handleKey string, openID string) (int, []*persistOp) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	// Filter out locks belonging to this open
 	remaining := make([]FileLock, 0, len(existing))
-	var ops []*persistOp
 	removed := 0
 	for i := range existing {
 		if existing[i].OpenID == openID {
-			ops = append(ops, lm.deleteFileLockLocked(&existing[i]))
+			lm.deleteFileLockLocked(&existing[i])
 			removed++
 		} else {
 			remaining = append(remaining, existing[i])
@@ -807,34 +788,27 @@ func (lm *Manager) unlockAllForOpenInner(handleKey string, openID string) (int, 
 		lm.locks[handleKey] = remaining
 	}
 
-	return removed, ops
+	return removed
 }
 
 // UnlockAllForSession releases all locks held by a session on a file.
 //
 // Returns the number of locks released.
 func (lm *Manager) UnlockAllForSession(handleKey string, sessionID uint64) int {
-	removed, ops := lm.unlockAllForSessionInner(handleKey, sessionID)
-	lm.runPersistOps(ops)
-	return removed
-}
-
-func (lm *Manager) unlockAllForSessionInner(handleKey string, sessionID uint64) (int, []*persistOp) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	// Filter out locks belonging to this session
 	remaining := make([]FileLock, 0, len(existing))
-	var ops []*persistOp
 	removed := 0
 	for i := range existing {
 		if existing[i].SessionID == sessionID {
-			ops = append(ops, lm.deleteFileLockLocked(&existing[i]))
+			lm.deleteFileLockLocked(&existing[i])
 			removed++
 		} else {
 			remaining = append(remaining, existing[i])
@@ -848,7 +822,7 @@ func (lm *Manager) unlockAllForSessionInner(handleKey string, sessionID uint64) 
 		lm.locks[handleKey] = remaining
 	}
 
-	return removed, ops
+	return removed
 }
 
 // TestLock checks if a lock would succeed without acquiring it.
@@ -976,26 +950,29 @@ func (lm *Manager) SetShareName(shareName string) {
 	lm.shareName = shareName
 }
 
-// persistOp is a deferred lock-store mutation collected under lm.mu and
-// executed after the mutex is released. Keeping store IO out of the critical
-// section avoids stalling concurrent lock operations on a slow backend.
-// Exactly one of put/del is set: put persists a record, del deletes by ID.
-type persistOp struct {
-	put *PersistedLock
-	del string
-}
-
-// assignPersistIDLocked stamps a unique persistent ID on a byte-range lock if
-// it does not already have one. The ID embeds the owner identity and range for
-// debuggability plus a monotonic sequence so stacked identical locks (SMB
-// shared-lock stacking) each get a distinct record. Caller must hold lm.mu.
-func (lm *Manager) assignPersistIDLocked(handleKey string, fl *FileLock) {
+// assignPersistIDLocked stamps a fresh UUID persistent ID on a byte-range lock
+// if it does not already have one. A UUID (rather than a deterministic
+// handleKey:owner:range#seq format backed by an in-memory counter) is required
+// for restart safety: the counter reset to 0 on a fresh Manager and was never
+// restored, so a new stacked lock after a restart regenerated a persistID
+// identical to a restored one — the id-keyed PutLock upsert then overwrote the
+// restored record, resurfacing the stacked-unlock data-loss bug (R3-2). A UUID
+// has no collision surface across restarts. The id round-trips through
+// PersistedLock.ID (fileLockFromPersisted restores it), so a later Unlock still
+// deletes exactly the matching record. Caller must hold lm.mu.
+func (lm *Manager) assignPersistIDLocked(fl *FileLock) {
 	if fl.persistID != "" {
 		return
 	}
-	lm.lockSeq++
-	fl.persistID = fmt.Sprintf("%s:%d:%s:%d:%d#%d",
-		handleKey, fl.SessionID, fl.OpenID, fl.Offset, fl.Length, lm.lockSeq)
+	fl.persistID = uuid.New().String()
+}
+
+// withPersistTimeout returns a context bounded by persistTimeout so a hung
+// backend can never wedge the lock manager: the store call runs synchronously
+// under lm.mu (mutex order == store order), but the timeout caps how long it
+// can block the critical section.
+func withPersistTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), persistTimeout)
 }
 
 // fileLockToPersisted builds a PersistedLock from a byte-range FileLock.
@@ -1021,26 +998,27 @@ func (lm *Manager) fileLockToPersisted(handleKey string, fl *FileLock) *Persiste
 	}
 }
 
-// persistFileLockLocked returns the deferred op that persists a byte-range
-// lock, or nil if persistence is disabled. Caller must hold lm.mu.
-func (lm *Manager) persistFileLockLocked(handleKey string, fl *FileLock) *persistOp {
+// persistFileLockLocked synchronously persists a byte-range lock. No-op if
+// persistence is disabled. Caller must hold lm.mu.
+func (lm *Manager) persistFileLockLocked(handleKey string, fl *FileLock) {
 	if lm.lockStore == nil {
-		return nil
+		return
 	}
-	return &persistOp{put: lm.fileLockToPersisted(handleKey, fl)}
+	lm.putLockLocked(lm.fileLockToPersisted(handleKey, fl))
 }
 
-// deleteFileLockLocked returns the deferred op that removes a persisted
-// byte-range lock, or nil if persistence is disabled. Caller must hold lm.mu.
-func (lm *Manager) deleteFileLockLocked(fl *FileLock) *persistOp {
+// deleteFileLockLocked synchronously removes a persisted byte-range lock. No-op
+// if persistence is disabled or the lock was never persisted. Caller must hold
+// lm.mu.
+func (lm *Manager) deleteFileLockLocked(fl *FileLock) {
 	if lm.lockStore == nil || fl.persistID == "" {
-		return nil
+		return
 	}
-	return &persistOp{del: fl.persistID}
+	lm.deletePersistedLocked(fl.persistID)
 }
 
-// persistUnifiedLockLocked returns the deferred op that persists a unified
-// lock, or nil if persistence is disabled. Caller must hold lm.mu.
+// persistUnifiedLockLocked synchronously persists a unified lock. No-op if
+// persistence is disabled. Caller must hold lm.mu.
 //
 // The share name is stamped from lm.shareName rather than trusting the
 // producer's Owner.ShareName: NFSv4/NLM byte-range producers build LockOwner
@@ -1051,71 +1029,65 @@ func (lm *Manager) deleteFileLockLocked(fl *FileLock) *persistOp {
 // how the legacy byte-range path (fileLockToPersisted) already stamps it. The
 // override is skipped when lm.shareName is empty so a directly-constructed
 // manager preserves a producer-set Owner.ShareName.
-func (lm *Manager) persistUnifiedLockLocked(ul *UnifiedLock) *persistOp {
+func (lm *Manager) persistUnifiedLockLocked(ul *UnifiedLock) {
 	if lm.lockStore == nil {
-		return nil
+		return
 	}
 	pl := ToPersistedLock(ul, lm.epoch)
 	if lm.shareName != "" {
 		pl.ShareName = lm.shareName
 	}
-	return &persistOp{put: pl}
+	lm.putLockLocked(pl)
 }
 
-// deleteUnifiedLockLocked returns the deferred op that removes a persisted
-// unified lock, or nil if persistence is disabled. Caller must hold lm.mu.
-func (lm *Manager) deleteUnifiedLockLocked(ul *UnifiedLock) *persistOp {
+// deleteUnifiedLockLocked synchronously removes a persisted unified lock. No-op
+// if persistence is disabled. Caller must hold lm.mu.
+func (lm *Manager) deleteUnifiedLockLocked(ul *UnifiedLock) {
 	if lm.lockStore == nil {
-		return nil
-	}
-	return &persistOp{del: ul.ID}
-}
-
-// runPersistOp executes a single deferred lock-store mutation. MUST be called
-// AFTER lm.mu is released so backend IO never blocks the in-memory critical
-// section (MS-SMB2 lock paths are latency-sensitive; blocking Lock() on store
-// IO was the bug this deferral fixed).
-//
-// Persistence is BEST-EFFORT. The in-memory lock map is authoritative for the
-// running server, so a failed PutLock/DeleteLock must NOT fail the lock op —
-// the client is told the (advisory) lock is held and it is, in this process.
-// The only consequence of a failed persist is durability across restart:
-//   - failed PutLock  → the lock survives in memory but is lost on restart,
-//     after which a conflicting lock could be granted. The operator MUST treat
-//     these ERROR logs as a durability alarm.
-//   - failed DeleteLock → a released lock may resurrect on restart until the
-//     next successful overwrite/cleanup.
-//
-// Errors are logged at ERROR with file/owner context so they are observable.
-func (lm *Manager) runPersistOp(op *persistOp) {
-	if lm.lockStore == nil || op == nil {
 		return
 	}
-	ctx := context.Background()
-	switch {
-	case op.put != nil:
-		if err := lm.lockStore.PutLock(ctx, op.put); err != nil {
-			logger.Error("lock persistence failed: lock held in memory but NOT durable across restart",
-				"lockID", op.put.ID,
-				"share", op.put.ShareName,
-				"fileID", op.put.FileID,
-				"ownerID", op.put.OwnerID,
-				"error", err)
-		}
-	case op.del != "":
-		if err := lm.lockStore.DeleteLock(ctx, op.del); err != nil {
-			logger.Error("lock-delete persistence failed: released lock may resurrect on restart",
-				"lockID", op.del,
-				"error", err)
-		}
+	lm.deletePersistedLocked(ul.ID)
+}
+
+// putLockLocked persists one record synchronously under lm.mu, bounded by
+// persistTimeout. Caller must hold lm.mu and must have already applied the
+// in-memory mutation, so the store observes mutations in mutex order — this is
+// what eliminates the reorder/resurrection bug class (R3-1).
+//
+// Persistence is BEST-EFFORT. The in-memory lock map is authoritative for the
+// running server, so a failed PutLock must NOT fail the lock op — the client is
+// told the (advisory) lock is held and it is, in this process. The only
+// consequence of a failed persist is durability across restart: the lock
+// survives in memory but is lost on restart, after which a conflicting lock
+// could be granted. The operator MUST treat these ERROR logs as a durability
+// alarm. Errors are logged with file/owner context so they are observable.
+func (lm *Manager) putLockLocked(pl *PersistedLock) {
+	ctx, cancel := withPersistTimeout()
+	defer cancel()
+	if err := lm.lockStore.PutLock(ctx, pl); err != nil {
+		logger.Error("lock persistence failed: lock held in memory but NOT durable across restart",
+			"lockID", pl.ID,
+			"share", pl.ShareName,
+			"fileID", pl.FileID,
+			"ownerID", pl.OwnerID,
+			"error", err)
 	}
 }
 
-// runPersistOps executes a batch of deferred lock-store mutations. Same
-// post-unlock contract as runPersistOp.
-func (lm *Manager) runPersistOps(ops []*persistOp) {
-	for _, op := range ops {
-		lm.runPersistOp(op)
+// deletePersistedLocked removes one record by ID synchronously under lm.mu,
+// bounded by persistTimeout. Caller must hold lm.mu and must have already
+// applied the in-memory removal (mutex order == store order).
+//
+// Best-effort with the same contract as putLockLocked: a failed DeleteLock
+// means a released lock may resurrect on restart until the next successful
+// overwrite/cleanup. ErrLockNotFound is ignored — the record is already gone.
+func (lm *Manager) deletePersistedLocked(id string) {
+	ctx, cancel := withPersistTimeout()
+	defer cancel()
+	if err := lm.lockStore.DeleteLock(ctx, id); err != nil && !isLockNotFound(err) {
+		logger.Error("lock-delete persistence failed: released lock may resurrect on restart",
+			"lockID", id,
+			"error", err)
 	}
 }
 
@@ -1162,6 +1134,14 @@ func fileLockFromPersisted(pl *PersistedLock) FileLock {
 	if sid, ok := sessionIDFromOwnerID(pl.OwnerID); ok {
 		fl.SessionID = sid
 	} else {
+		// SMB per-open lock: OpenID is recovered from OwnerID. SessionID is
+		// NOT restored (it is not a PersistedLock field) and stays 0 (R3-6).
+		// This is latent, not a live bug: SMB lock teardown keys on OpenID
+		// (UnlockAllForOpen) and ClientID (RemoveClientLocks), both of which
+		// ARE preserved. SessionID-keyed cleanup (UnlockAllForSession) is an
+		// NFS/NLM path and those locks restore their SessionID above. Adding a
+		// session_id column purely to round-trip an unused field is not worth
+		// the schema churn at this stage.
 		fl.OpenID = pl.OwnerID
 	}
 	return fl
@@ -1556,6 +1536,11 @@ func (lm *Manager) UpgradeLock(handleKey string, owner LockOwner, offset, length
 	// Step 3: Atomically upgrade the lock
 	unifiedLocks[ownLockIndex].Type = LockTypeExclusive
 
+	// Persist the upgraded type under lm.mu so the change survives a restart.
+	// Without this the in-memory lock reverted to shared on restart and a
+	// reader could be wrongly granted against an intended-exclusive lock (R3-3).
+	lm.persistUnifiedLockLocked(unifiedLocks[ownLockIndex])
+
 	return unifiedLocks[ownLockIndex].Clone(), nil
 }
 
@@ -1569,15 +1554,6 @@ func (lm *Manager) getUnifiedLocksLocked(handleKey string) []*UnifiedLock {
 // Checks for conflicts using the ConflictsWith method which handles all 4
 // conflict cases: access modes, oplock-oplock, oplock-byterange, byterange-byterange.
 func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
-	op, err := lm.addUnifiedLockInner(handleKey, lock)
-	if err != nil {
-		return err
-	}
-	lm.runPersistOp(op)
-	return nil
-}
-
-func (lm *Manager) addUnifiedLockInner(handleKey string, lock *UnifiedLock) (*persistOp, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -1586,7 +1562,7 @@ func (lm *Manager) addUnifiedLockInner(handleKey string, lock *UnifiedLock) (*pe
 	// Check for conflicts with existing locks using ConflictsWith
 	for _, el := range existing {
 		if lock.ConflictsWith(el) {
-			return nil, NewLockConflictError("", &UnifiedLockConflict{
+			return NewLockConflictError("", &UnifiedLockConflict{
 				Lock:   el,
 				Reason: "lock conflict",
 			})
@@ -1602,7 +1578,8 @@ func (lm *Manager) addUnifiedLockInner(handleKey string, lock *UnifiedLock) (*pe
 			// Update existing lock in place
 			existing[i].Type = lock.Type
 			existing[i].AcquiredAt = time.Now()
-			return lm.persistUnifiedLockLocked(existing[i]), nil
+			lm.persistUnifiedLockLocked(existing[i])
+			return nil
 		}
 	}
 
@@ -1613,30 +1590,21 @@ func (lm *Manager) addUnifiedLockInner(handleKey string, lock *UnifiedLock) (*pe
 
 	// Add new lock
 	lm.unifiedLocks[handleKey] = append(existing, lock)
-	return lm.persistUnifiedLockLocked(lock), nil
+	lm.persistUnifiedLockLocked(lock)
+	return nil
 }
 
 // RemoveUnifiedLock removes a unified lock using POSIX splitting semantics.
 func (lm *Manager) RemoveUnifiedLock(handleKey string, owner LockOwner, offset, length uint64) error {
-	ops, err := lm.removeUnifiedLockInner(handleKey, owner, offset, length)
-	if err != nil {
-		return err
-	}
-	lm.runPersistOps(ops)
-	return nil
-}
-
-func (lm *Manager) removeUnifiedLockInner(handleKey string, owner LockOwner, offset, length uint64) ([]*persistOp, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
 	existing := lm.unifiedLocks[handleKey]
 	if len(existing) == 0 {
-		return nil, NewLockNotFoundError("")
+		return NewLockNotFoundError("")
 	}
 
 	var newLocks []*UnifiedLock
-	var ops []*persistOp
 	found := false
 
 	for _, lock := range existing {
@@ -1653,18 +1621,20 @@ func (lm *Manager) removeUnifiedLockInner(handleKey string, owner LockOwner, off
 			continue
 		}
 
-		// Overlaps - split the lock
+		// Overlaps - split the lock. Delete the original record, then persist
+		// each fragment (each carries a fresh UUID from SplitLock). Done under
+		// lm.mu so the store sees delete-then-puts in mutation order.
 		found = true
-		ops = append(ops, lm.deleteUnifiedLockLocked(lock))
+		lm.deleteUnifiedLockLocked(lock)
 		splitResult := SplitLock(lock, offset, length)
 		for _, frag := range splitResult {
-			ops = append(ops, lm.persistUnifiedLockLocked(frag))
+			lm.persistUnifiedLockLocked(frag)
 		}
 		newLocks = append(newLocks, splitResult...)
 	}
 
 	if !found {
-		return nil, NewLockNotFoundError("")
+		return NewLockNotFoundError("")
 	}
 
 	// Update or clean up
@@ -1674,7 +1644,7 @@ func (lm *Manager) removeUnifiedLockInner(handleKey string, owner LockOwner, off
 		lm.unifiedLocks[handleKey] = newLocks
 	}
 
-	return ops, nil
+	return nil
 }
 
 // ListUnifiedLocks returns all unified locks on a file.
@@ -2657,39 +2627,31 @@ func (lm *Manager) RegisterBreakCallbacks(callbacks BreakCallbacks) {
 // ============================================================================
 
 // RemoveAllLocks removes all locks (legacy, unified, and delegations) for a file.
+//
+// The persisted bulk-delete runs synchronously under lm.mu (handleKey is the
+// FileID used when persisting): keeping it ordered with single-record PutLock/
+// DeleteLock prevents a concurrent acquire on the same file from racing this
+// delete to the store and leaving an orphaned record behind (R3-1 class).
 func (lm *Manager) RemoveAllLocks(handleKey string) {
-	lm.removeAllLocksInner(handleKey)
-	// Best-effort: drop all persisted locks for this file, after releasing
-	// lm.mu so backend IO does not stall concurrent lock operations.
-	// handleKey is the FileID used when persisting (see persist helpers).
-	if lm.lockStore != nil {
-		if _, err := lm.lockStore.DeleteLocksByFile(context.Background(), handleKey); err != nil {
-			logger.Error("RemoveAllLocks: failed to delete persisted locks", "handleKey", handleKey, "error", err)
-		}
-	}
-}
-
-func (lm *Manager) removeAllLocksInner(handleKey string) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 	delete(lm.locks, handleKey)
 	delete(lm.unifiedLocks, handleKey)
 	delete(lm.breakWaitChans, handleKey)
-}
 
-// RemoveClientLocks removes all unified locks held by a specific client.
-func (lm *Manager) RemoveClientLocks(clientID string) {
-	lm.removeClientLocksInner(clientID)
-	// Drop persisted locks after releasing lm.mu to keep backend IO out of
-	// the critical section.
 	if lm.lockStore != nil {
-		if _, err := lm.lockStore.DeleteLocksByClient(context.Background(), clientID); err != nil {
-			logger.Error("RemoveClientLocks: failed to delete persisted locks", "clientID", clientID, "error", err)
+		ctx, cancel := withPersistTimeout()
+		defer cancel()
+		if _, err := lm.lockStore.DeleteLocksByFile(ctx, handleKey); err != nil {
+			logger.Error("RemoveAllLocks: failed to delete persisted locks", "handleKey", handleKey, "error", err)
 		}
 	}
 }
 
-func (lm *Manager) removeClientLocksInner(clientID string) {
+// RemoveClientLocks removes all unified locks held by a specific client. The
+// persisted bulk-delete runs synchronously under lm.mu for the same ordering
+// reason as RemoveAllLocks.
+func (lm *Manager) RemoveClientLocks(clientID string) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -2704,6 +2666,14 @@ func (lm *Manager) removeClientLocksInner(clientID string) {
 			delete(lm.unifiedLocks, handleKey)
 		} else {
 			lm.unifiedLocks[handleKey] = remaining
+		}
+	}
+
+	if lm.lockStore != nil {
+		ctx, cancel := withPersistTimeout()
+		defer cancel()
+		if _, err := lm.lockStore.DeleteLocksByClient(ctx, clientID); err != nil {
+			logger.Error("RemoveClientLocks: failed to delete persisted locks", "clientID", clientID, "error", err)
 		}
 	}
 }

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1485,6 +1485,18 @@ func mergeTwoLocks(a, b *UnifiedLock) *UnifiedLock {
 // Returns:
 //   - *UnifiedLock: The upgraded lock on success
 //   - error: ErrLockConflict if other readers exist, ErrLockNotFound if no lock to upgrade
+//
+// PRECONDITION — whole-lock upgrade only. Step 3 flips the ENTIRE matched
+// shared lock to exclusive, not just the [offset,length) sub-range, and that
+// whole-range promotion is what gets persisted. This is correct ONLY because
+// every caller upgrades a lock at exactly the range it was granted at: the
+// NFSv4 LOCK upgrade path promotes the lock-owner's existing lock as a whole,
+// never a strict sub-range of a larger shared lock. If a caller ever passes a
+// sub-range of a wider shared lock, the surrounding bytes would be silently
+// promoted to exclusive (and persisted that way) — split the matched lock into
+// the upgraded sub-range plus shared remainder(s) before changing this. There
+// are currently no production callers (NFSv4/NLM upgrade is not yet wired); the
+// invariant is enforced by TestUpgradeLock_WholeLockOnly.
 func (lm *Manager) UpgradeLock(handleKey string, owner LockOwner, offset, length uint64) (*UnifiedLock, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()

--- a/pkg/metadata/lock/persist_test.go
+++ b/pkg/metadata/lock/persist_test.go
@@ -2,6 +2,9 @@ package lock
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -366,6 +369,251 @@ func TestLock_StampsClientIDForCleanup(t *testing.T) {
 	persisted, err = store.ListLocks(ctx, LockQuery{})
 	require.NoError(t, err)
 	require.Empty(t, persisted, "DeleteLocksByClient must match and remove the byte-range lock")
+}
+
+// TestLock_StackedAfterRestart_NoPersistIDCollision pins R3-2: lockSeq reset
+// to 0 on a fresh Manager and RestoreLocks never restored it, so a new stacked
+// lock regenerated a persistID identical to a restored one. The id-keyed
+// PutLock upsert then overwrote the restored record, resurrecting the
+// stacked-unlock data-loss bug. With UUID persist IDs there is no collision
+// surface across restarts.
+//
+// Scenario: stack 2 identical SMB shared locks pre-restart, restore into a
+// fresh manager, stack a 3rd identical lock, then unlock one — the store must
+// hold 3 distinct records before the unlock and exactly 2 after.
+func TestLock_StackedAfterRestart_NoPersistIDCollision(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	const handleKey = "share-a:file-stack-restart"
+	fl := FileLock{
+		SessionID: 7,
+		OpenID:    "open-1", // SMB per-open => stacking semantics
+		Offset:    100,
+		Length:    50,
+		Exclusive: false, // shared locks stack
+	}
+	// Pre-restart: stack two identical shared locks.
+	require.NoError(t, mgr.Lock(handleKey, fl))
+	require.NoError(t, mgr.Lock(handleKey, fl))
+
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 2, "two stacked records pre-restart")
+
+	// Simulate restart: fresh manager (lockSeq would reset to 0), restore.
+	fresh := NewManager()
+	fresh.SetLockStore(store)
+	fresh.SetShareName("share-a")
+	require.NoError(t, fresh.RestoreLocks(persisted))
+	require.Len(t, fresh.ListLocks(handleKey), 2, "two restored stacked locks")
+
+	// Stack a 3rd identical lock post-restart. A deterministic seq-based
+	// persistID would collide with a restored record here and overwrite it.
+	require.NoError(t, fresh.Lock(handleKey, fl))
+	require.Len(t, fresh.ListLocks(handleKey), 3, "three stacked locks in memory")
+
+	persisted, err = store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 3, "all three stacked locks must persist as DISTINCT records (no collision)")
+
+	ids := map[string]bool{}
+	for _, pl := range persisted {
+		ids[pl.ID] = true
+	}
+	require.Len(t, ids, 3, "persist IDs must be distinct across the restart boundary")
+
+	// Unlock ONE: two in-memory entries remain, so exactly two persisted too.
+	require.NoError(t, fresh.Unlock(handleKey, "open-1", 7, 100, 50))
+	require.Len(t, fresh.ListLocks(handleKey), 2, "two stacked locks remain in memory")
+
+	persisted, err = store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 2, "exactly two persisted records survive the partial unlock")
+}
+
+// TestUpgradeLock_PersistsAndReloads pins R3-3: UpgradeLock flipped a shared
+// lock to exclusive in memory but emitted no persist, so the upgrade was lost
+// on restart — the lock reverted to shared and a reader could be wrongly
+// granted against an intended-exclusive lock.
+func TestUpgradeLock_PersistsAndReloads(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	const handleKey = "share-a:file-upgrade"
+	owner := LockOwner{OwnerID: "nlm:client-u", ClientID: "client-u", ShareName: "share-a"}
+	ul := &UnifiedLock{
+		ID:         "upgrade-lock-1",
+		Owner:      owner,
+		FileHandle: FileHandle(handleKey),
+		Offset:     0,
+		Length:     100,
+		Type:       LockTypeShared,
+	}
+	require.NoError(t, mgr.AddUnifiedLock(handleKey, ul))
+
+	// Upgrade shared -> exclusive.
+	upgraded, err := mgr.UpgradeLock(handleKey, owner, 0, 100)
+	require.NoError(t, err)
+	require.Equal(t, LockTypeExclusive, upgraded.Type)
+
+	// The persisted record must reflect the upgraded (exclusive) type.
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 1)
+	require.Equal(t, int(LockTypeExclusive), persisted[0].LockType,
+		"persisted lock must reflect the upgrade, not the pre-upgrade shared type")
+
+	// After restart the lock must still be exclusive.
+	fresh := NewManager()
+	fresh.SetLockStore(store)
+	require.NoError(t, fresh.RestoreLocks(persisted))
+	restored := fresh.ListUnifiedLocks(handleKey)
+	require.Len(t, restored, 1)
+	require.Equal(t, LockTypeExclusive, restored[0].Type,
+		"upgraded lock must restore as exclusive, not revert to shared")
+}
+
+// TestLockManager_ConcurrentStorm_StoreMatchesMemory is the permanent net for
+// the ordering bug class (R3-1). N goroutines concurrently Lock/Unlock/Upgrade/
+// AddUnifiedLock/RemoveUnifiedLock on overlapping ranges of the same handle
+// through a Manager backed by a real (mock) LockStore. A restart is then
+// simulated (snapshot store -> fresh Manager -> RestoreLocks) and the invariant
+// is asserted: for every in-memory lock there is exactly one matching store
+// record and vice versa (no orphans, no resurrections).
+//
+// Run under -race repeatedly. Because persistence is synchronous under lm.mu,
+// the store can never diverge from memory by reorder.
+func TestLockManager_ConcurrentStorm_StoreMatchesMemory(t *testing.T) {
+	store := newMockLockStore()
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-storm")
+
+	const handleKey = "share-storm:file-storm"
+
+	const (
+		goroutines = 12
+		iterations = 200
+	)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(seed)))
+			openID := fmt.Sprintf("open-%d", seed)
+			owner := LockOwner{
+				OwnerID:   fmt.Sprintf("nlm:client-%d", seed),
+				ClientID:  fmt.Sprintf("client-%d", seed),
+				ShareName: "share-storm",
+			}
+			for i := 0; i < iterations; i++ {
+				off := uint64(rng.Intn(8)) * 10
+				length := uint64(rng.Intn(4)+1) * 10
+				switch rng.Intn(5) {
+				case 0:
+					_ = mgr.Lock(handleKey, FileLock{
+						SessionID: uint64(seed),
+						OpenID:    openID,
+						Offset:    off,
+						Length:    length,
+						Exclusive: rng.Intn(2) == 0,
+						ClientID:  owner.ClientID,
+					})
+				case 1:
+					_ = mgr.Unlock(handleKey, openID, uint64(seed), off, length)
+				case 2:
+					_ = mgr.AddUnifiedLock(handleKey, &UnifiedLock{
+						ID:         fmt.Sprintf("ul-%d-%d", seed, i),
+						Owner:      owner,
+						FileHandle: FileHandle(handleKey),
+						Offset:     off,
+						Length:     length,
+						Type:       LockTypeShared,
+					})
+				case 3:
+					_ = mgr.RemoveUnifiedLock(handleKey, owner, off, length)
+				case 4:
+					_, _ = mgr.UpgradeLock(handleKey, owner, off, length)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Simulate a restart: snapshot the store, restore into a fresh manager,
+	// and assert the restored in-memory state matches the store exactly.
+	ctx := context.Background()
+	snapshot, err := store.ListLocks(ctx, LockQuery{ShareName: "share-storm"})
+	require.NoError(t, err)
+
+	fresh := NewManager()
+	fresh.SetLockStore(store)
+	fresh.SetShareName("share-storm")
+	require.NoError(t, fresh.RestoreLocks(snapshot))
+
+	// Collect persist IDs from the store snapshot.
+	storeIDs := map[string]bool{}
+	for _, pl := range snapshot {
+		require.False(t, storeIDs[pl.ID], "store must not hold duplicate persist IDs")
+		storeIDs[pl.ID] = true
+	}
+
+	// Collect persist IDs the live manager currently holds in memory. Each
+	// in-memory lock must have exactly one matching store record (no orphans),
+	// and every store record must map to an in-memory lock (no resurrections).
+	memIDs := liveManagerPersistIDs(mgr, handleKey)
+
+	for id := range memIDs {
+		require.True(t, storeIDs[id],
+			"in-memory lock %s has no store record (lost persist / reorder)", id)
+	}
+	for id := range storeIDs {
+		require.True(t, memIDs[id],
+			"store record %s has no in-memory lock (orphan / resurrection)", id)
+	}
+	require.Equal(t, len(memIDs), len(storeIDs),
+		"store record count must equal in-memory lock count after the storm")
+}
+
+// legacyPersistIDsForTest returns the persist IDs of the legacy byte-range
+// locks held for handleKey. Same-package test accessor for the unexported
+// persistID field, used by the concurrency-storm invariant check.
+func (lm *Manager) legacyPersistIDsForTest(handleKey string) []string {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	var ids []string
+	for i := range lm.locks[handleKey] {
+		ids = append(ids, lm.locks[handleKey][i].persistID)
+	}
+	return ids
+}
+
+// liveManagerPersistIDs returns the set of persist IDs the manager currently
+// holds in memory for handleKey, across both the legacy byte-range map and the
+// unified-lock map. Byte-range entries expose their persist ID via the
+// unexported persistID field, which this same-package test can read through a
+// helper on Manager.
+func liveManagerPersistIDs(mgr *Manager, handleKey string) map[string]bool {
+	ids := map[string]bool{}
+	for _, id := range mgr.legacyPersistIDsForTest(handleKey) {
+		ids[id] = true
+	}
+	for _, ul := range mgr.ListUnifiedLocks(handleKey) {
+		ids[ul.ID] = true
+	}
+	return ids
 }
 
 // TestRestoreLocks_ByteRangeEnforcedAfterRestart verifies HIGH-5: byte-range

--- a/pkg/metadata/lock/persist_test.go
+++ b/pkg/metadata/lock/persist_test.go
@@ -482,78 +482,254 @@ func TestUpgradeLock_PersistsAndReloads(t *testing.T) {
 		"upgraded lock must restore as exclusive, not revert to shared")
 }
 
-// TestLockManager_ConcurrentStorm_StoreMatchesMemory is the permanent net for
-// the ordering bug class (R3-1). N goroutines concurrently Lock/Unlock/Upgrade/
-// AddUnifiedLock/RemoveUnifiedLock on overlapping ranges of the same handle
-// through a Manager backed by a real (mock) LockStore. A restart is then
-// simulated (snapshot store -> fresh Manager -> RestoreLocks) and the invariant
-// is asserted: for every in-memory lock there is exactly one matching store
-// record and vice versa (no orphans, no resurrections).
+// TestUpgradeLock_WholeLockOnly pins the documented UpgradeLock precondition:
+// callers upgrade a lock at exactly the range it was granted at (NFSv4 LOCK
+// upgrades the lock-owner's whole existing lock), so promoting the entire
+// matched range to exclusive — and persisting that whole range — is correct.
+// This test asserts the whole-lock upgrade case: the matched lock keeps its
+// original [offset,length) and flips to exclusive in memory and in the store.
 //
-// Run under -race repeatedly. Because persistence is synchronous under lm.mu,
-// the store can never diverge from memory by reorder.
+// It also documents the boundary: there are no production sub-range upgrade
+// callers. If one is ever added (upgrading a strict sub-range of a wider shared
+// lock), UpgradeLock must split before promoting; see the precondition comment
+// on UpgradeLock.
+func TestUpgradeLock_WholeLockOnly(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	const handleKey = "share-a:file-whole-upgrade"
+	owner := LockOwner{OwnerID: "nlm:client-w", ClientID: "client-w", ShareName: "share-a"}
+	ul := &UnifiedLock{
+		ID:         "whole-upgrade-1",
+		Owner:      owner,
+		FileHandle: FileHandle(handleKey),
+		Offset:     10,
+		Length:     90,
+		Type:       LockTypeShared,
+	}
+	require.NoError(t, mgr.AddUnifiedLock(handleKey, ul))
+
+	// Upgrade at exactly the granted range (whole-lock upgrade).
+	upgraded, err := mgr.UpgradeLock(handleKey, owner, 10, 90)
+	require.NoError(t, err)
+	require.Equal(t, LockTypeExclusive, upgraded.Type)
+	require.Equal(t, uint64(10), upgraded.Offset, "upgrade must not move the range")
+	require.Equal(t, uint64(90), upgraded.Length, "upgrade must not resize the range")
+
+	// In memory there is still exactly one lock, now exclusive at [10,100).
+	live := mgr.ListUnifiedLocks(handleKey)
+	require.Len(t, live, 1, "whole-lock upgrade must not split or duplicate the lock")
+	require.Equal(t, LockTypeExclusive, live[0].Type)
+	require.Equal(t, uint64(10), live[0].Offset)
+	require.Equal(t, uint64(90), live[0].Length)
+
+	// Exactly one persisted record, reflecting the whole-range exclusive upgrade.
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 1, "whole-lock upgrade persists a single record")
+	require.Equal(t, int(LockTypeExclusive), persisted[0].LockType)
+	require.Equal(t, uint64(10), persisted[0].Offset)
+	require.Equal(t, uint64(90), persisted[0].Length)
+}
+
+// TestLockManager_ConcurrentStorm_StoreMatchesMemory is the permanent net for
+// the persist-ordering / resurrection bug class (R3-1): if a PutLock/DeleteLock
+// were ever dispatched OUTSIDE lm.mu (async), the store could observe two
+// mutations on the SAME persisted key in a different order than memory did,
+// leaving a record present in the store but absent in memory (resurrection) or
+// absent in the store but present in memory (lost persist). The current design
+// persists synchronously inside lm.mu, so mutex order == store order and the
+// class is closed; this test exists to FAIL the moment that guarantee regresses.
+//
+// To exercise that class the storm must (a) hammer the SAME persisted store key
+// with interleaved put/delete, and (b) observe the store at a restart boundary
+// WHILE the storm is still running — not only after it quiesces. We do both:
+//
+//   - SAME-KEY CONTENTION. We drive a SMALL, fixed set of owners over a SMALL,
+//     fixed set of OVERLAPPING ranges on ONE handle, via two paths whose persist
+//     key is stable across a lock→unlock→re-lock cycle (so put and delete race
+//     the same store row, not fresh UUIDs that can never collide):
+//   - NLM/POSIX byte-range (OpenID==""): Lock re-locks the same
+//     (owner,offset,length) IN PLACE, reusing the same persistID; Unlock
+//     deletes that same persistID. Re-Lock-after-Unlock from another
+//     goroutine reuses it again.
+//   - Unified locks with a deterministic ID keyed only by (owner,range):
+//     AddUnifiedLock upserts that ID, RemoveUnifiedLock deletes it,
+//     UpgradeLock rewrites it — all on the one store key.
+//   - MID-STORM RESTART. A snapshotter goroutine periodically snapshots the
+//     LockStore, restores it into a brand-new Manager, and asserts each snapshot
+//     is INTERNALLY CONSISTENT (no duplicate keys, every restored record is a
+//     well-formed lock) — i.e. the store is never caught in a half-written state
+//     that violates an invariant, at an arbitrary instant during the storm.
+//
+// After quiesce we assert the strong bijection: every in-memory lock has exactly
+// one store record and every store record has exactly one in-memory lock — no
+// orphans, no resurrections, no lost stacked entries.
+//
+// HOW THIS CATCHES A persist-outside-mutex REGRESSION. Suppose persistence were
+// moved back to an async goroutine. Take one stable key K (e.g. the NLM re-lock
+// at a fixed owner+range). Goroutine A does Unlock(K) -> enqueues DeleteLock(K);
+// goroutine B does re-Lock(K) -> enqueues PutLock(K). In-memory the final state
+// is whatever ran last under lm.mu, but the async dispatcher can apply
+// PutLock(K) then DeleteLock(K) (or vice-versa) in the opposite order. The store
+// then either holds K with no in-memory lock (orphan) or lacks K while memory
+// holds it (lost persist). The post-quiesce bijection flags exactly that:
+// len(memIDs) != len(storeIDs) or a key present on one side only. The mid-storm
+// snapshotter additionally catches a transient half-applied batch. Under the
+// synchronous-under-mutex design the two mutations on K are serialized by lm.mu
+// in the same order memory sees them, so neither divergence can arise and the
+// test stays green. It is scheduler-probabilistic (it relies on goroutines
+// actually interleaving on K), so we loop it; see the subtest loop below.
 func TestLockManager_ConcurrentStorm_StoreMatchesMemory(t *testing.T) {
+	// Loop so the scheduler gets many chances to interleave put/delete on the
+	// same key. Each round is a fresh store+manager. Running the whole test
+	// under `go test -race -run ConcurrentStorm -count=N` multiplies this.
+	const rounds = 20
+	for r := 0; r < rounds; r++ {
+		t.Run(fmt.Sprintf("round-%d", r), func(t *testing.T) {
+			runConcurrentStormRound(t, int64(r))
+		})
+	}
+}
+
+func runConcurrentStormRound(t *testing.T, seedBase int64) {
+	t.Helper()
+
 	store := newMockLockStore()
 
 	mgr := NewManager()
 	mgr.SetLockStore(store)
 	mgr.SetShareName("share-storm")
 
-	const handleKey = "share-storm:file-storm"
+	const handleKey = handleKeyStorm
 
 	const (
 		goroutines = 12
 		iterations = 200
+		// Small fixed cardinalities force collisions on the SAME store key:
+		// distinct (owner,range) pairs map to a stable, reused persist key.
+		numOwners = 3
+		numRanges = 4
 	)
+
+	// Fixed overlapping ranges on the one handle. They overlap heavily so
+	// conflict checks, upgrades and POSIX splits all fire on shared rows.
+	ranges := [numRanges][2]uint64{{0, 40}, {20, 40}, {0, 100}, {30, 30}}
+
+	// Stable unified-lock ID per (owner,range): this is the store key that
+	// AddUnifiedLock / RemoveUnifiedLock / UpgradeLock all contend on.
+	ulID := func(ownerIdx, rangeIdx int) string {
+		return fmt.Sprintf("ul-o%d-r%d", ownerIdx, rangeIdx)
+	}
+
+	stop := make(chan struct{})
+
+	// Snapshotter: mid-storm, repeatedly snapshot the store, restore into a
+	// fresh manager, and check each snapshot is internally consistent. The first
+	// inconsistency is captured into snapErr and asserted on the main goroutine
+	// after snapWG.Wait() — testify's require.* calls t.FailNow (runtime.Goexit),
+	// which must run on the test goroutine, not here.
+	var (
+		snapWG  sync.WaitGroup
+		snapErr error
+	)
+	snapWG.Add(1)
+	go func() {
+		defer snapWG.Done()
+		ctx := context.Background()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			snap, err := store.ListLocks(ctx, LockQuery{ShareName: "share-storm"})
+			if err != nil {
+				snapErr = fmt.Errorf("mid-storm ListLocks: %w", err)
+				return
+			}
+			if err := snapshotInternalConsistencyErr(snap); err != nil {
+				snapErr = err
+				return
+			}
+
+			fresh := NewManager()
+			fresh.SetLockStore(store)
+			fresh.SetShareName("share-storm")
+			if err := fresh.RestoreLocks(snap); err != nil {
+				snapErr = fmt.Errorf("mid-storm RestoreLocks: %w", err)
+				return
+			}
+			// The restore must reproduce exactly the snapshot's records, with no
+			// half-written/orphaned state surviving into the fresh manager.
+			if got := len(liveManagerPersistIDs(fresh, handleKey)); got != len(snap) {
+				snapErr = fmt.Errorf("mid-storm restore reproduced %d records, snapshot had %d", got, len(snap))
+				return
+			}
+		}
+	}()
 
 	var wg sync.WaitGroup
 	for g := 0; g < goroutines; g++ {
 		wg.Add(1)
 		go func(seed int) {
 			defer wg.Done()
-			rng := rand.New(rand.NewSource(int64(seed)))
-			openID := fmt.Sprintf("open-%d", seed)
-			owner := LockOwner{
-				OwnerID:   fmt.Sprintf("nlm:client-%d", seed),
-				ClientID:  fmt.Sprintf("client-%d", seed),
-				ShareName: "share-storm",
-			}
+			rng := rand.New(rand.NewSource(seedBase*1000 + int64(seed)))
 			for i := 0; i < iterations; i++ {
-				off := uint64(rng.Intn(8)) * 10
-				length := uint64(rng.Intn(4)+1) * 10
-				switch rng.Intn(5) {
-				case 0:
+				ownerIdx := rng.Intn(numOwners)
+				rangeIdx := rng.Intn(numRanges)
+				off, length := ranges[rangeIdx][0], ranges[rangeIdx][1]
+				owner := LockOwner{
+					OwnerID:   fmt.Sprintf("nlm:client-%d", ownerIdx),
+					ClientID:  fmt.Sprintf("client-%d", ownerIdx),
+					ShareName: "share-storm",
+				}
+				switch rng.Intn(6) {
+				case 0, 1:
+					// NLM/POSIX byte-range (OpenID==""): re-lock in place reuses
+					// the SAME persistID -> put/delete contend the same store key.
 					_ = mgr.Lock(handleKey, FileLock{
-						SessionID: uint64(seed),
-						OpenID:    openID,
+						SessionID: uint64(ownerIdx),
 						Offset:    off,
 						Length:    length,
 						Exclusive: rng.Intn(2) == 0,
 						ClientID:  owner.ClientID,
 					})
-				case 1:
-					_ = mgr.Unlock(handleKey, openID, uint64(seed), off, length)
 				case 2:
+					_ = mgr.Unlock(handleKey, "", uint64(ownerIdx), off, length)
+				case 3:
+					// Unified lock with a STABLE id per (owner,range): upsert and
+					// delete hammer the same store key as RemoveUnifiedLock/Upgrade.
 					_ = mgr.AddUnifiedLock(handleKey, &UnifiedLock{
-						ID:         fmt.Sprintf("ul-%d-%d", seed, i),
+						ID:         ulID(ownerIdx, rangeIdx),
 						Owner:      owner,
 						FileHandle: FileHandle(handleKey),
 						Offset:     off,
 						Length:     length,
 						Type:       LockTypeShared,
 					})
-				case 3:
-					_ = mgr.RemoveUnifiedLock(handleKey, owner, off, length)
 				case 4:
+					_ = mgr.RemoveUnifiedLock(handleKey, owner, off, length)
+				case 5:
 					_, _ = mgr.UpgradeLock(handleKey, owner, off, length)
 				}
 			}
 		}(g)
 	}
 	wg.Wait()
+	close(stop)
+	snapWG.Wait()
 
-	// Simulate a restart: snapshot the store, restore into a fresh manager,
-	// and assert the restored in-memory state matches the store exactly.
+	// Surface any mid-storm inconsistency on the test goroutine (require.* must
+	// not run inside the snapshotter goroutine).
+	require.NoError(t, snapErr, "mid-storm snapshot was internally inconsistent")
+
+	// Simulate a final restart: snapshot the store, restore into a fresh
+	// manager, and assert the restored in-memory state matches the store exactly.
 	ctx := context.Background()
 	snapshot, err := store.ListLocks(ctx, LockQuery{ShareName: "share-storm"})
 	require.NoError(t, err)
@@ -563,16 +739,17 @@ func TestLockManager_ConcurrentStorm_StoreMatchesMemory(t *testing.T) {
 	fresh.SetShareName("share-storm")
 	require.NoError(t, fresh.RestoreLocks(snapshot))
 
-	// Collect persist IDs from the store snapshot.
+	// Collect persist IDs from the store snapshot (no duplicate keys allowed).
 	storeIDs := map[string]bool{}
 	for _, pl := range snapshot {
 		require.False(t, storeIDs[pl.ID], "store must not hold duplicate persist IDs")
 		storeIDs[pl.ID] = true
 	}
 
-	// Collect persist IDs the live manager currently holds in memory. Each
-	// in-memory lock must have exactly one matching store record (no orphans),
-	// and every store record must map to an in-memory lock (no resurrections).
+	// Bijection: each in-memory lock has exactly one matching store record (no
+	// orphans), and every store record maps to an in-memory lock (no
+	// resurrections). A persist-outside-mutex reorder on a shared key shows up
+	// here as a one-sided key or a count mismatch.
 	memIDs := liveManagerPersistIDs(mgr, handleKey)
 
 	for id := range memIDs {
@@ -586,6 +763,36 @@ func TestLockManager_ConcurrentStorm_StoreMatchesMemory(t *testing.T) {
 	require.Equal(t, len(memIDs), len(storeIDs),
 		"store record count must equal in-memory lock count after the storm")
 }
+
+// snapshotInternalConsistencyErr checks that a mid-storm store snapshot is not
+// caught in a state that violates a record-level invariant: no duplicate persist
+// keys, and every record is a well-formed lock (non-empty key, share stamped,
+// a routable shape). A half-written/orphaned record trips this and returns an
+// error. It returns (rather than asserting) so it is safe to call from the
+// snapshotter goroutine; the caller surfaces the error on the test goroutine.
+func snapshotInternalConsistencyErr(snap []*PersistedLock) error {
+	seen := map[string]bool{}
+	for _, pl := range snap {
+		if pl.ID == "" {
+			return fmt.Errorf("snapshot record has empty persist id")
+		}
+		if seen[pl.ID] {
+			return fmt.Errorf("snapshot holds duplicate persist id %s", pl.ID)
+		}
+		seen[pl.ID] = true
+		if pl.ShareName != "share-storm" {
+			return fmt.Errorf("snapshot record %s has share %q, want share-storm", pl.ID, pl.ShareName)
+		}
+		if pl.FileID != handleKeyStorm {
+			return fmt.Errorf("snapshot record %s has handle %q, want %s", pl.ID, pl.FileID, handleKeyStorm)
+		}
+	}
+	return nil
+}
+
+// handleKeyStorm mirrors the storm test's single handle so the snapshot
+// consistency check can assert every persisted record belongs to it.
+const handleKeyStorm = "share-storm:file-storm"
 
 // legacyPersistIDsForTest returns the persist IDs of the legacy byte-range
 // locks held for handleKey. Same-package test accessor for the unexported

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -125,6 +125,16 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 // initLockManagerFromStore stamps a fresh server epoch and replays any locks
 // persisted by a previous run back into the lock manager. Errors are logged
 // and swallowed so a recovery failure never blocks share registration.
+//
+// Epoch double-bump on a lost-publish race (R3-5): RegisterStoreForShare runs
+// this on a local manager before publishing under s.mu, and the loser of a
+// concurrent registration drops its manager. The loser still incremented the
+// store epoch here, so two concurrent registrations of the same share advance
+// the persisted epoch by 2 instead of 1. This is harmless: the epoch is only a
+// monotonic split-brain/stale-lock marker, the surviving manager uses whatever
+// epoch it observed, and every lock it restores predates that epoch regardless
+// of the gap. Moving IncrementServerEpoch under s.mu would serialize backend IO
+// inside the service lock for no correctness gain, so the increment stays here.
 func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName string) {
 	ctx := context.Background()
 

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -97,8 +97,12 @@ func putLockArgs(lk *lock.PersistedLock) []interface{} {
 		lk.OwnerID,
 		lk.ClientID,
 		lk.LockType,
-		lk.Offset,
-		lk.Length,
+		// byte_offset/byte_length are NUMERIC(20) to hold the full uint64 range
+		// (NFSv4 unbounded = 0xFFFFFFFFFFFFFFFF > MaxInt64). pgx cannot encode a
+		// Go uint64 above MaxInt64 into a numeric param directly, so pass the
+		// decimal string form; postgres parses it into NUMERIC losslessly.
+		strconv.FormatUint(lk.Offset, 10),
+		strconv.FormatUint(lk.Length, 10),
 		lk.IsZeroByte,
 		lk.IsLegacyByteRange,
 		lk.AccessMode,
@@ -146,9 +150,39 @@ func (s *postgresLockStore) putLockTx(ctx context.Context, tx pgx.Tx, lk *lock.P
 // shares the scanLock destination layout.
 const selectByID = `SELECT ` + lockColumns + ` FROM locks WHERE id = $1`
 
-// scanArgs returns the Scan destination pointers for lk in lockColumns order.
-// Shared by every read path so a new column is wired in exactly one place.
-func scanArgs(lk *lock.PersistedLock) []interface{} {
+// rowScanner is satisfied by both pgx.Row (QueryRow) and pgx.Rows so a single
+// scanLock helper serves every read path.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+// scanLock scans one row into a PersistedLock. byte_offset/byte_length are
+// NUMERIC(20) (full uint64 range) and are scanned as decimal strings, then
+// parsed: pgx cannot scan a numeric above MaxInt64 into a Go uint64 directly.
+func scanLock(row rowScanner) (*lock.PersistedLock, error) {
+	var lk lock.PersistedLock
+	var offsetStr, lengthStr string
+	if err := row.Scan(scanArgs(&lk, &offsetStr, &lengthStr)...); err != nil {
+		return nil, err
+	}
+	off, err := strconv.ParseUint(offsetStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	length, err := strconv.ParseUint(lengthStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	lk.Offset = off
+	lk.Length = length
+	return &lk, nil
+}
+
+// scanArgs returns the Scan destination pointers in lockColumns order. The
+// byte_offset/byte_length NUMERIC columns scan into the caller's string holders
+// (offsetStr/lengthStr); scanLock parses them into lk.Offset/lk.Length. A new
+// column is wired in exactly one place here.
+func scanArgs(lk *lock.PersistedLock, offsetStr, lengthStr *string) []interface{} {
 	return []interface{}{
 		&lk.ID,
 		&lk.ShareName,
@@ -156,8 +190,8 @@ func scanArgs(lk *lock.PersistedLock) []interface{} {
 		&lk.OwnerID,
 		&lk.ClientID,
 		&lk.LockType,
-		&lk.Offset,
-		&lk.Length,
+		offsetStr,
+		lengthStr,
 		&lk.IsZeroByte,
 		&lk.IsLegacyByteRange,
 		&lk.AccessMode,
@@ -183,8 +217,7 @@ func scanArgs(lk *lock.PersistedLock) []interface{} {
 
 // GetLock retrieves a lock by ID.
 func (s *postgresLockStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	var lk lock.PersistedLock
-	err := s.pool.QueryRow(ctx, selectByID, lockID).Scan(scanArgs(&lk)...)
+	lk, err := scanLock(s.pool.QueryRow(ctx, selectByID, lockID))
 	if err == pgx.ErrNoRows {
 		return nil, &errors.StoreError{
 			Code:    errors.ErrLockNotFound,
@@ -196,13 +229,12 @@ func (s *postgresLockStore) GetLock(ctx context.Context, lockID string) (*lock.P
 		return nil, err
 	}
 
-	return &lk, nil
+	return lk, nil
 }
 
 // getLockTx retrieves a lock within an existing transaction.
 func (s *postgresLockStore) getLockTx(ctx context.Context, tx pgx.Tx, lockID string) (*lock.PersistedLock, error) {
-	var lk lock.PersistedLock
-	err := tx.QueryRow(ctx, selectByID, lockID).Scan(scanArgs(&lk)...)
+	lk, err := scanLock(tx.QueryRow(ctx, selectByID, lockID))
 	if err == pgx.ErrNoRows {
 		return nil, &errors.StoreError{
 			Code:    errors.ErrLockNotFound,
@@ -214,7 +246,7 @@ func (s *postgresLockStore) getLockTx(ctx context.Context, tx pgx.Tx, lockID str
 		return nil, err
 	}
 
-	return &lk, nil
+	return lk, nil
 }
 
 // DeleteLock removes a lock by ID.
@@ -298,11 +330,11 @@ func (s *postgresLockStore) ListLocks(ctx context.Context, query lock.LockQuery)
 
 	var locks []*lock.PersistedLock
 	for rows.Next() {
-		var lk lock.PersistedLock
-		if err := rows.Scan(scanArgs(&lk)...); err != nil {
+		lk, err := scanLock(rows)
+		if err != nil {
 			return nil, err
 		}
-		locks = append(locks, &lk)
+		locks = append(locks, lk)
 	}
 
 	return locks, rows.Err()
@@ -320,11 +352,11 @@ func (s *postgresLockStore) listLocksTx(ctx context.Context, tx pgx.Tx, query lo
 
 	var locks []*lock.PersistedLock
 	for rows.Next() {
-		var lk lock.PersistedLock
-		if err := rows.Scan(scanArgs(&lk)...); err != nil {
+		lk, err := scanLock(rows)
+		if err != nil {
 			return nil, err
 		}
-		locks = append(locks, &lk)
+		locks = append(locks, lk)
 	}
 
 	return locks, rows.Err()

--- a/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.down.sql
@@ -1,0 +1,7 @@
+-- Revert byte_offset/byte_length to BIGINT. Values above MaxInt64 (unbounded
+-- uint64 ranges) cannot be represented and would overflow; this down migration
+-- assumes no such rows exist.
+
+ALTER TABLE locks
+    ALTER COLUMN byte_offset TYPE BIGINT USING byte_offset::BIGINT,
+    ALTER COLUMN byte_length TYPE BIGINT USING byte_length::BIGINT;

--- a/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.down.sql
@@ -1,6 +1,19 @@
--- Revert byte_offset/byte_length to BIGINT. Values above MaxInt64 (unbounded
--- uint64 ranges) cannot be represented and would overflow; this down migration
--- assumes no such rows exist.
+-- Revert byte_offset/byte_length to BIGINT (signed int64, max
+-- 9223372036854775807). The up migration widened these to NUMERIC(20)
+-- specifically so unbounded NFSv4 byte-range locks (Offset/Length =
+-- 0xFFFFFFFFFFFFFFFF) and SMB high-bit offsets could be persisted — values that
+-- BIGINT cannot represent. A naive ALTER ... USING ::BIGINT would overflow and
+-- abort the migration on any such row, making the down step unrunnable.
+--
+-- Locks are advisory and recoverable: a dropped lock is re-acquired by the
+-- client on the next operation (and never survives a server restart past its
+-- owner's reconnect). So we DELETE the rows that BIGINT cannot hold before the
+-- ALTER, keeping the down migration runnable. The only consequence is that an
+-- in-flight unbounded-range lock is forgotten across this schema rollback.
+
+DELETE FROM locks
+WHERE byte_offset > 9223372036854775807
+   OR byte_length > 9223372036854775807;
 
 ALTER TABLE locks
     ALTER COLUMN byte_offset TYPE BIGINT USING byte_offset::BIGINT,

--- a/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000020_lock_offset_length_numeric.up.sql
@@ -1,0 +1,10 @@
+-- Widen byte_offset/byte_length to NUMERIC(20) so they hold the full uint64
+-- range. NFSv4 expresses an unbounded byte-range lock as
+-- Offset/Length = 0xFFFFFFFFFFFFFFFF (18446744073709551615), and SMB permits
+-- high-bit offsets. BIGINT is signed int64 (max 9223372036854775807), so pgx
+-- rejected any uint64 > MaxInt64 at PutLock and the lock was never persisted.
+-- NUMERIC(20) holds every 20-digit value, covering the full uint64 range.
+
+ALTER TABLE locks
+    ALTER COLUMN byte_offset TYPE NUMERIC(20) USING byte_offset::NUMERIC(20),
+    ALTER COLUMN byte_length TYPE NUMERIC(20) USING byte_length::NUMERIC(20);

--- a/pkg/metadata/storetest/lock_persistence.go
+++ b/pkg/metadata/storetest/lock_persistence.go
@@ -65,6 +65,60 @@ func RunLockPersistenceSuite(t *testing.T, factory LockStoreFactory) {
 	t.Run("ZeroByteVsEOFSemantics", func(t *testing.T) {
 		testLock_ZeroByteVsEOFSemantics(t, factory)
 	})
+
+	t.Run("MaxUint64OffsetLength", func(t *testing.T) {
+		testLock_MaxUint64OffsetLength(t, factory)
+	})
+}
+
+// testLock_MaxUint64OffsetLength pins R3-4: NFSv4 expresses an unbounded range
+// as Offset/Length = 0xFFFFFFFFFFFFFFFF and SMB allows high-bit offsets. A
+// backend storing these in a signed 64-bit column (postgres BIGINT) rejects any
+// uint64 > MaxInt64 at PutLock, silently dropping the lock so it is never
+// persisted nor recovered. The store must round-trip the full uint64 range.
+func testLock_MaxUint64OffsetLength(t *testing.T, factory LockStoreFactory) {
+	store := factory(t)
+	ctx := context.Background()
+
+	const maxU64 = ^uint64(0) // 0xFFFFFFFFFFFFFFFF, > math.MaxInt64
+
+	lk := &lock.PersistedLock{
+		ID:                "max-u64",
+		ShareName:         shapeShareName,
+		FileID:            shapeFileID,
+		OwnerID:           "nfs4:1:deadbeef",
+		ClientID:          "nfs4:1",
+		LockType:          int(lock.LockTypeExclusive),
+		Offset:            maxU64,
+		Length:            maxU64,
+		IsLegacyByteRange: false,
+		AcquiredAt:        time.Unix(1, 0).UTC(),
+		ServerEpoch:       1,
+	}
+
+	if err := store.PutLock(ctx, lk); err != nil {
+		t.Fatalf("PutLock with uint64 max Offset/Length failed (signed-column overflow class): %v", err)
+	}
+
+	got, err := store.GetLock(ctx, lk.ID)
+	if err != nil {
+		t.Fatalf("GetLock: %v", err)
+	}
+	if got.Offset != maxU64 {
+		t.Errorf("Offset round-trip: got %d, want %d (uint64 max)", got.Offset, maxU64)
+	}
+	if got.Length != maxU64 {
+		t.Errorf("Length round-trip: got %d, want %d (uint64 max)", got.Length, maxU64)
+	}
+
+	// The per-share recovery query must also recover it.
+	byShare, err := store.ListLocks(ctx, lock.LockQuery{ShareName: shapeShareName})
+	if err != nil {
+		t.Fatalf("ListLocks{ShareName}: %v", err)
+	}
+	if findByID(byShare, lk.ID) == nil {
+		t.Fatalf("max-uint64 lock not recovered by per-share query (dropped on persist)")
+	}
 }
 
 // lockShape is one entry in the persist matrix: a fully-formed PersistedLock


### PR DESCRIPTION
Round-3 follow-up to #852 (merged). A high-effort review found 3 HIGH restart-corruption bugs + 3 MED/LOW, all rooted in ONE design flaw: the round-1 "persist outside the mutex" mechanism (persistOp deferral) has no per-ID ordering. This PR fixes the **mechanism**, not just instances.

#852 was already squash-merged before this work began, so this lands as a follow-up PR rather than a push to the (closed) original.

## R3-1 (mechanism) — synchronous persist under `lm.mu`
Two concurrent ops on the same persistID could reach the store in the opposite order of the mutex-serialized in-memory mutation, diverging store from memory (lock resurrected or lost on restart). Fix: the in-memory mutation **and** the PutLock/DeleteLock now run while `lm.mu` is held, so mutex order == store order by construction. Each store call is bounded by a 3s `context.WithTimeout` so a hung backend can't wedge the manager. Best-effort ERROR-log-on-failure contract preserved (advisory locks; in-memory authoritative). Removes `persistOp` + `runPersistOp`/`runPersistOps` + all `*Inner` split funcs — **net -200 LOC** in manager.go. Store layers use their own `s.mu` and never re-enter the manager → no deadlock (verified).

## R3-2 — byte-range persistID is now a fresh UUID
`lockSeq` reset to 0 on a fresh Manager and `RestoreLocks` never restored it, so a post-restart stacked lock regenerated a persistID identical to a restored one and the id-keyed upsert overwrote it (stacked-unlock data loss). `lockSeq` deleted.

## R3-3 — UpgradeLock now persists
shared→exclusive upgrade was memory-only → reverted to shared on restart. Now persisted under `lm.mu`.

## R3-4 — postgres BIGINT → NUMERIC(20) (migration 20)
BIGINT is signed int64; pgx rejected NFSv4 unbounded ranges (`0xFFFFFFFFFFFFFFFF` > MaxInt64) at PutLock → lock silently not persisted. Widened `byte_offset`/`byte_length`; encode/scan via decimal string. **Reproduced + fixed against a real postgres 16.**

## R3-5 / R3-6 (documented, no behavior change)
- R3-5: epoch double-bump on a lost-publish registration race is harmless (monotonic split-brain marker; gap is inert).
- R3-6: SMB SessionID not restored is latent (teardown keys on OpenID/ClientID, both preserved).

## Tests
- UUID collision-across-restart (pinned: fails with old seq logic)
- UpgradeLock persist + restore
- `-race` concurrency storm: N goroutines × mixed Lock/Unlock/Upgrade/AddUnifiedLock/RemoveUnifiedLock, then simulated restart, asserting in-memory == store (no orphans, no resurrections) — the permanent net for the ordering class
- cross-backend MaxUint64 offset/length conformance case (R3-4)

Gates: `go build ./...`, `go test ./pkg/metadata/...`, `go test -race ./pkg/metadata/lock/...` (3×), gofmt -s + go vet all clean. Postgres R3-4 verified locally against postgres 16; full pg lock conformance passes per-subtest with a fresh DB.