### PR TITLE
perf/durability(lock): grace period + reclaim — wire H-1/H7/H15 (PR-B2)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -244,7 +244,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// Write PID file if specified
 	if pidFile != "" {
-		if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		if err := os.WriteFile(pidFile, fmt.Appendf(nil, "%d", os.Getpid()), 0644); err != nil {
 			return fmt.Errorf("failed to write PID file: %w", err)
 		}
 		defer func() { _ = os.Remove(pidFile) }()

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/sysinfo"
@@ -198,6 +199,22 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if cfg.GC.Interval > 0 {
 		logger.Warn("gc.interval is configured but no periodic-GC scheduler ships in v0.15.0 — the value is ignored. Trigger GC on demand via `dfsctl store block gc <share>` (or schedule via cron). Periodic scheduling is tracked for a follow-up phase.",
 			"configured_interval", cfg.GC.Interval)
+	}
+
+	// Thread the operator-configured lock-manager grace period into the
+	// MetadataService BEFORE loading shares: AddShare registers each share's
+	// lock manager and enters the post-restart grace window, so the duration
+	// must be set first. LoadInitial is idempotent (the lifecycle Serve loop
+	// loads settings again); a nil/zero value falls back to the 90s default,
+	// which matches the DB default for grace_period.
+	if sw := rt.GetSettingsWatcher(); sw != nil {
+		if err := sw.LoadInitial(ctx); err != nil {
+			logger.Warn("Failed to load initial adapter settings for lock grace period", "error", err)
+		}
+		if nfsSettings := rt.GetNFSSettings(); nfsSettings != nil && nfsSettings.GracePeriod > 0 {
+			rt.GetMetadataService().SetLockGracePeriod(
+				time.Duration(nfsSettings.GracePeriod) * time.Second)
+		}
 	}
 
 	// Load shares (per-share BlockStores are created during AddShare).

--- a/internal/adapter/nfs/nlm/handlers/lock.go
+++ b/internal/adapter/nfs/nlm/handlers/lock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
 	nlm_xdr "github.com/marmos91/dittofs/internal/adapter/nfs/nlm/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
+	metaerrors "github.com/marmos91/dittofs/pkg/metadata/errors"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -120,6 +121,17 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 	)
 
 	if err != nil {
+		// Grace period: a non-reclaim lock attempted during the post-restart
+		// grace window is rejected so a prior owner can reclaim first.
+		if metaerrors.IsGracePeriodError(err) {
+			logger.Debug("NLM LOCK denied: grace period",
+				"client", ctx.ClientAddr,
+				"owner", ownerID)
+			return &LockResponse{
+				Cookie: req.Cookie,
+				Status: types.NLM4DeniedGrace,
+			}, nil
+		}
 		// System error
 		logger.Warn("NLM LOCK failed",
 			"client", ctx.ClientAddr,

--- a/internal/adapter/nfs/nlm/handlers/lock.go
+++ b/internal/adapter/nfs/nlm/handlers/lock.go
@@ -103,10 +103,13 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 	// Convert file handle
 	handle := req.Lock.FH
 
-	// Build lock owner
+	// Build lock owner. ClientID is the NSM caller_name (stable client hostname),
+	// NOT the transport address: it is the identity key for grace-period reclaim
+	// tracking and for NSM crash cleanup (FREE_ALL / SM_NOTIFY carry caller_name,
+	// and a reconnecting client's transport port differs after a restart).
 	owner := lock.LockOwner{
 		OwnerID:  ownerID,
-		ClientID: ctx.ClientAddr,
+		ClientID: req.Lock.CallerName,
 	}
 
 	// Call NLMService to acquire lock (cross-protocol lease checks happen at lock manager level)

--- a/internal/adapter/nfs/nlm/handlers/lock_clientid_test.go
+++ b/internal/adapter/nfs/nlm/handlers/lock_clientid_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// captureLockService records the owner passed to LockFileNLM so a test can
+// assert the identity the handler derives from the request.
+type captureLockService struct {
+	gotOwner lock.LockOwner
+}
+
+func (c *captureLockService) LockFileNLM(_ context.Context, _ []byte, owner lock.LockOwner, _, _ uint64, _, _ bool) (*lock.LockResult, error) {
+	c.gotOwner = owner
+	return &lock.LockResult{Success: true}, nil
+}
+
+func (c *captureLockService) TestLockNLM(_ context.Context, _ []byte, _ lock.LockOwner, _, _ uint64, _ bool) (bool, *lock.UnifiedLockConflict, error) {
+	return true, nil, nil
+}
+
+func (c *captureLockService) UnlockFileNLM(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	return nil
+}
+
+func (c *captureLockService) CancelBlockingLock(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	return nil
+}
+
+// TestLock_OwnerClientIDIsCallerName pins the grace/crash identity fix: the
+// handler must key a lock's ClientID by the NSM caller_name (stable client
+// hostname), NOT the transport address. The transport port changes when a
+// client reconnects after a restart, which would make the grace-period reclaim
+// roster and NSM crash cleanup (FREE_ALL carries caller_name) miss entirely.
+func TestLock_OwnerClientIDIsCallerName(t *testing.T) {
+	svc := &captureLockService{}
+	h := &Handler{nlmService: svc}
+
+	ctx := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.7:51234", // ephemeral port — must NOT become the ClientID
+	}
+	req := &LockRequest{
+		Exclusive: true,
+		Lock: types.NLM4Lock{
+			CallerName: "host-a",
+			FH:         []byte("share-a:file-1"),
+			OH:         []byte{0x01},
+			Svid:       42,
+			Offset:     0,
+			Length:     100,
+		},
+	}
+
+	if _, err := h.Lock(ctx, req); err != nil {
+		t.Fatalf("Lock returned error: %v", err)
+	}
+
+	if svc.gotOwner.ClientID != "host-a" {
+		t.Errorf("owner.ClientID = %q, want caller_name %q (transport addr %q must not leak in)",
+			svc.gotOwner.ClientID, "host-a", ctx.ClientAddr)
+	}
+}

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -389,6 +389,20 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	nlmSvc := s.createRoutingNLMService(metadataService)
 	s.nlmHandler = nlm_handlers.NewHandler(nlmSvc, s.blockingQueue)
 
+	// Couple the NFSv4 StateManager grace machine to the per-share lock-manager
+	// grace machine so both enter/exit the post-restart window together. Shares
+	// loaded at boot are registered BEFORE this adapter exists, so the lock
+	// manager may already be in grace; we both (a) register the coordinator for
+	// any share added later and (b) catch up the v4 machine for shares already
+	// in grace at startup.
+	graceCoord := &nfsGraceCoordinator{sm: v4StateManager}
+	metadataService.SetGraceCoordinator(graceCoord)
+	for _, shareName := range rt.ListShares() {
+		if lm := metadataService.GetLockManagerForShare(shareName); lm != nil && lm.IsInGracePeriod() {
+			graceCoord.OnLockGraceStart(lm.GetExpectedClients())
+		}
+	}
+
 	// Initialize NSM handler for crash recovery
 	// NSM uses the ConnectionTracker from the MetadataService and ClientRegistrationStore
 	s.initNSMHandler(rt, metadataService)

--- a/pkg/adapter/nfs/grace_coordinator.go
+++ b/pkg/adapter/nfs/grace_coordinator.go
@@ -1,0 +1,61 @@
+package nfs
+
+import (
+	v4state "github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// nfsGraceCoordinator couples the per-share lock-manager grace machine (NLM /
+// SMB leases, owned by MetadataService) with the SEPARATE NFSv4 StateManager
+// grace machine. When a share recovers persisted locks at registration the
+// lock manager enters grace and OnLockGraceStart fires; this coordinator drives
+// the NFSv4 StateManager into grace in lockstep, and ends it together on
+// OnLockGraceEnd. It implements metadata.GraceCoordinator.
+//
+// Why two machines exist: NLM/SMB byte-range + lease state lives in the
+// lock.Manager, while NFSv4 open/lock state lives in the v4 StateManager. Both
+// must reject conflicting NEW state during the post-restart window so a prior
+// owner can reclaim first (X/Open NLMv4, RFC 7530 §9.6.2). Coupling them here
+// is the single seam that keeps the two windows aligned.
+//
+// NFSv4-client-persistence dependency (honest seam note): StateManager grace
+// only meaningfully activates when it is told which v4 client IDs are expected
+// to reclaim — StartGracePeriod with an empty set is a no-op by design
+// (grace.go StartGrace). DittoFS does not yet persist NFSv4 confirmed clients
+// across restart (SaveClientState/LoadPreviousClients are unwired), so today
+// the v4 expected set is empty and the v4 window is a no-op even though this
+// coordinator drives it. The coupling is wired end-to-end so that the moment
+// v4 client persistence lands, both machines enter and exit together with no
+// further change here. The lock-manager + NLM grace window (the area-5 H-1 /
+// NFS H15 fix) is fully live regardless.
+type nfsGraceCoordinator struct {
+	sm *v4state.StateManager
+}
+
+// OnLockGraceStart drives the NFSv4 StateManager into its grace period when a
+// share's lock-manager grace begins. The lock manager's expected clients are
+// NLM/SMB opaque client IDs, which do not map onto NFSv4 numeric client IDs;
+// the v4 expected-reclaim roster is the v4 confirmed-client set, which the
+// StateManager derives from its own persisted state (empty until v4 client
+// persistence is wired — see the type doc).
+func (c *nfsGraceCoordinator) OnLockGraceStart(expectedClients []string) {
+	if c.sm == nil {
+		return
+	}
+	if c.sm.IsInGrace() {
+		return // already coupled in by an earlier share's recovery
+	}
+	v4Clients := c.sm.GetConfirmedClientIDs()
+	logger.Info("NFSv4 grace coupled to lock-manager grace",
+		"lock_clients", len(expectedClients), "v4_clients", len(v4Clients))
+	c.sm.StartGracePeriod(v4Clients)
+}
+
+// OnLockGraceEnd ends the NFSv4 grace period when the lock-manager grace window
+// closes (timer, early-exit, or sweep), keeping the two windows aligned.
+func (c *nfsGraceCoordinator) OnLockGraceEnd() {
+	if c.sm == nil {
+		return
+	}
+	c.sm.ForceEndGrace()
+}

--- a/pkg/adapter/nfs/grace_coordinator.go
+++ b/pkg/adapter/nfs/grace_coordinator.go
@@ -28,6 +28,18 @@ import (
 // v4 client persistence lands, both machines enter and exit together with no
 // further change here. The lock-manager + NLM grace window (the area-5 H-1 /
 // NFS H15 fix) is fully live regardless.
+//
+// Per-share vs global asymmetry (documented seam): lock-manager grace is
+// per-share, while the NFSv4 StateManager grace machine is global (one per
+// server). The coordinator couples them with a "first share in starts v4
+// grace, first share out ends it" policy: OnLockGraceStart is a no-op once v4
+// grace is already active, and OnLockGraceEnd ends v4 grace outright. With the
+// conventional boot flow all shares load together and enter the same ~90s
+// window, so this approximation holds; a per-share early-exit could end v4
+// grace while another share's window is still open. Because v4 grace is a no-op
+// today (see above), this is latent and becomes relevant only alongside v4
+// client persistence, at which point the coupling should refcount active
+// lock-manager grace windows before ending v4 grace.
 type nfsGraceCoordinator struct {
 	sm *v4state.StateManager
 }

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -90,9 +90,26 @@ func (s *nlmService) LockFileNLM(
 	unifiedLock := lock.NewUnifiedLock(owner, lock.FileHandle(handle), offset, length, lockTypeFromExclusive(exclusive))
 	unifiedLock.Reclaim = reclaim
 
+	// Grace period gating: during the post-restart grace window the server only
+	// admits reclaims so a prior owner can recover before a third party steals
+	// the range (X/Open NLMv4, RFC 7530 §9.6.2). A non-reclaim request is
+	// rejected with ErrGracePeriod, which the handler maps to NLM4_DENIED_GRACE_PERIOD.
+	allowed, graceErr := s.lockMgr.IsOperationAllowed(lock.Operation{
+		IsNew:     !reclaim,
+		IsReclaim: reclaim,
+	})
+	if !allowed {
+		return nil, graceErr
+	}
+
 	handleKey := string(handle)
 	err := s.lockMgr.AddUnifiedLock(handleKey, unifiedLock)
 	if err == nil {
+		// A successful reclaim records the client so grace can exit early once
+		// every expected client has recovered its locks.
+		if reclaim {
+			s.lockMgr.MarkReclaimed(owner.ClientID)
+		}
 		return &lock.LockResult{
 			Success: true,
 			Lock:    unifiedLock,

--- a/pkg/adapter/nfs/nlm_grace_test.go
+++ b/pkg/adapter/nfs/nlm_grace_test.go
@@ -1,0 +1,59 @@
+package nfs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/require"
+)
+
+// graceFileChecker is a fileChecker stub that reports every handle as an
+// existing regular file, so the NLM lock path proceeds to the grace gate.
+type graceFileChecker struct{}
+
+func (graceFileChecker) GetFile(_ context.Context, _ []byte) (bool, bool, error) {
+	return true, false, nil
+}
+
+// newGraceNLMService builds an nlmService backed by a grace-aware lock manager
+// already in the grace period, with the given expected reclaim clients.
+func newGraceNLMService(expectedClients []string) (*nlmService, *lock.Manager) {
+	gpm := lock.NewGracePeriodManager(time.Hour, nil)
+	lm := lock.NewManagerWithGracePeriod(gpm)
+	lm.EnterGracePeriod(expectedClients)
+	return newNLMService(lm, graceFileChecker{}), lm
+}
+
+// TestGracePeriod_NLMLockDenied asserts a non-reclaim NLM lock attempted during
+// the grace window is rejected with ErrGracePeriod (which the handler maps to
+// NLM4_DENIED_GRACE_PERIOD), not granted.
+func TestGracePeriod_NLMLockDenied(t *testing.T) {
+	svc, _ := newGraceNLMService([]string{"client-1"})
+
+	owner := lock.LockOwner{OwnerID: "nlm:client-1", ClientID: "client-1", ShareName: "share-a"}
+	_, err := svc.LockFileNLM(context.Background(), []byte("share-a:file-1"), owner, 0, 100, true, false)
+
+	require.Error(t, err, "new lock during grace must be denied")
+	require.True(t, errors.IsGracePeriodError(err),
+		"denial must be ErrGracePeriod so the handler maps it to NLM4_DENIED_GRACE_PERIOD, got %v", err)
+}
+
+// TestGracePeriod_NLMReclaimAllowed asserts a reclaim NLM lock is granted during
+// the grace window and records the client so grace can exit early.
+func TestGracePeriod_NLMReclaimAllowed(t *testing.T) {
+	svc, lm := newGraceNLMService([]string{"client-1"})
+
+	owner := lock.LockOwner{OwnerID: "nlm:client-1", ClientID: "client-1", ShareName: "share-a"}
+	res, err := svc.LockFileNLM(context.Background(), []byte("share-a:file-1"), owner, 0, 100, true, true)
+
+	require.NoError(t, err, "reclaim during grace must be allowed")
+	require.NotNil(t, res)
+	require.True(t, res.Success, "reclaim lock must be granted")
+
+	// The reclaim must have been recorded against the client.
+	require.Contains(t, lm.GetReclaimedClients(), "client-1",
+		"a successful reclaim must MarkReclaimed the owning client")
+}

--- a/pkg/metadata/grace_registration_test.go
+++ b/pkg/metadata/grace_registration_test.go
@@ -133,3 +133,40 @@ func TestGracePeriod_BothMachinesEnterTogether(t *testing.T) {
 	require.True(t, secondMachineActive,
 		"the second grace machine must enter grace together with the lock manager")
 }
+
+// TestGracePeriod_EndNotifiesCoordinatorInstalledAfterRegistration pins the
+// production wiring order: shares register at startup BEFORE the NFS adapter
+// installs the grace coordinator (during SetRuntime). A lock manager built with
+// no coordinator must still notify the coordinator when its grace window ends,
+// or the NFSv4 grace machine would never be ended in lockstep. The grace-end
+// callback therefore reads the coordinator live rather than capturing it at
+// construction.
+func TestGracePeriod_EndNotifiesCoordinatorInstalledAfterRegistration(t *testing.T) {
+	const shareName = "/coord-late"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, store, shareName, "client-1")
+
+	// Register the store FIRST — no coordinator installed yet (startup order).
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod(), "lock-manager grace must be active")
+
+	// Install the coordinator AFTER the manager was built (adapter SetRuntime).
+	coord := &graceSpyCoordinator{
+		started: make(chan []string, 1),
+		ended:   make(chan struct{}, 1),
+	}
+	svc.SetGraceCoordinator(coord)
+
+	// End grace by reclaiming the sole expected client (synchronous early exit).
+	lm.MarkReclaimed("client-1")
+
+	select {
+	case <-coord.ended:
+	case <-time.After(time.Second):
+		t.Fatal("OnLockGraceEnd was not fired for a coordinator installed after the manager was built")
+	}
+}

--- a/pkg/metadata/grace_registration_test.go
+++ b/pkg/metadata/grace_registration_test.go
@@ -1,0 +1,135 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// persistNLMLock writes a single NLM/unified byte-range lock into the store so a
+// subsequent RegisterStoreForShare recovers it and treats its client as an
+// expected reclaimer.
+func persistNLMLock(t *testing.T, store *memory.MemoryMetadataStore, shareName, clientID string) {
+	t.Helper()
+	require.NoError(t, store.PutLock(context.Background(), &lock.PersistedLock{
+		ID:        "nlm-lock-1",
+		ShareName: shareName,
+		FileID:    shareName + ":file-1",
+		OwnerID:   "nlm:" + clientID,
+		ClientID:  clientID,
+		LockType:  int(lock.LockTypeExclusive),
+		Offset:    0,
+		Length:    100,
+	}))
+}
+
+// TestRegisterStoreForShare_EntersGraceWhenPersistedLocksExist asserts that a
+// fresh service registering a store that carries persisted locks enters the
+// grace period with the persisted clients as the expected reclaim roster.
+func TestRegisterStoreForShare_EntersGraceWhenPersistedLocksExist(t *testing.T) {
+	const shareName = "/graced"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	// Simulate a previous run that left an NLM lock for client-1 persisted.
+	persistNLMLock(t, store, shareName, "client-1")
+
+	// Fresh service: register the store carrying the persisted lock.
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm, "lock manager must exist for the registered share")
+	require.True(t, lm.IsInGracePeriod(),
+		"a share recovering persisted locks must enter the grace period")
+	require.ElementsMatch(t, []string{"client-1"}, lm.GetExpectedClients(),
+		"the expected reclaim roster must be the persisted clients")
+}
+
+// TestRegisterStoreForShare_NoGraceWhenNoPersistedLocks asserts a fresh server
+// with no persisted locks starts in normal operation (no grace).
+func TestRegisterStoreForShare_NoGraceWhenNoPersistedLocks(t *testing.T) {
+	const shareName = "/fresh"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.False(t, lm.IsInGracePeriod(),
+		"a fresh server with no persisted locks must NOT enter grace")
+}
+
+// graceSpyCoordinator records the lock-manager grace start/end callbacks and,
+// for the two-machine coordination test, drives a v4-like grace machine in
+// lockstep.
+type graceSpyCoordinator struct {
+	started chan []string
+	ended   chan struct{}
+	onStart func(expected []string)
+	onEnd   func()
+}
+
+func (c *graceSpyCoordinator) OnLockGraceStart(expected []string) {
+	if c.onStart != nil {
+		c.onStart(expected)
+	}
+	select {
+	case c.started <- expected:
+	default:
+	}
+}
+
+func (c *graceSpyCoordinator) OnLockGraceEnd() {
+	if c.onEnd != nil {
+		c.onEnd()
+	}
+	select {
+	case c.ended <- struct{}{}:
+	default:
+	}
+}
+
+// TestGracePeriod_BothMachinesEnterTogether asserts the GraceCoordinator fires
+// OnLockGraceStart when a share's lock-manager grace begins, so the NFS adapter
+// can drive the SEPARATE NFSv4 StateManager grace machine into grace in
+// lockstep. A second grace machine wired through the coordinator must also be
+// active once registration completes.
+func TestGracePeriod_BothMachinesEnterTogether(t *testing.T) {
+	const shareName = "/coord"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, store, shareName, "client-1")
+
+	// A stand-in for the NFSv4 grace machine, flipped on by the coordinator.
+	var secondMachineActive bool
+	coord := &graceSpyCoordinator{
+		started: make(chan []string, 1),
+		ended:   make(chan struct{}, 1),
+		onStart: func(_ []string) { secondMachineActive = true },
+		onEnd:   func() { secondMachineActive = false },
+	}
+
+	svc := metadata.New()
+	svc.SetGraceCoordinator(coord)
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod(), "lock-manager grace must be active")
+
+	// The coordinator must have been driven at registration time.
+	select {
+	case expected := <-coord.started:
+		require.ElementsMatch(t, []string{"client-1"}, expected,
+			"coordinator must receive the same expected reclaim roster")
+	case <-time.After(time.Second):
+		t.Fatal("OnLockGraceStart was not fired when lock-manager grace began")
+	}
+	require.True(t, secondMachineActive,
+		"the second grace machine must enter grace together with the lock manager")
+}

--- a/pkg/metadata/lock/grace_phase2_test.go
+++ b/pkg/metadata/lock/grace_phase2_test.go
@@ -1,0 +1,71 @@
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGracePeriod_EarlyExitWhenAllReclaim asserts the grace window exits before
+// its timer fires once every expected client has reclaimed.
+func TestGracePeriod_EarlyExitWhenAllReclaim(t *testing.T) {
+	done := make(chan struct{}, 1)
+	gpm := NewGracePeriodManager(time.Hour, func() { done <- struct{}{} })
+
+	gpm.EnterGracePeriod([]string{"client-1", "client-2"})
+	require.Equal(t, GraceStateActive, gpm.GetState())
+
+	gpm.MarkReclaimed("client-1")
+	require.Equal(t, GraceStateActive, gpm.GetState(),
+		"grace must stay active until ALL expected clients reclaim")
+
+	gpm.MarkReclaimed("client-2")
+	require.Equal(t, GraceStateNormal, gpm.GetState(),
+		"grace must exit early once all expected clients have reclaimed")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("onGraceEnd was not invoked on early exit")
+	}
+}
+
+// TestReclaimLease_MarksClientReclaimed pins Phase-2 item 4 (SMB side): a
+// successful lease reclaim during grace must MarkReclaimed the owning client so
+// grace can exit early once every expected client has recovered.
+func TestReclaimLease_MarksClientReclaimed(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	gpm := NewGracePeriodManager(time.Hour, nil)
+	lm := NewManagerWithGracePeriod(gpm)
+	lm.SetLockStore(store)
+	lm.SetShareName("share-a")
+
+	// Persist a lease held by client-1 before the restart.
+	leaseKey := [16]byte{1, 2, 3, 4}
+	persisted := &PersistedLock{
+		ID:         "lease-1",
+		ShareName:  "share-a",
+		FileID:     "share-a:dir-1",
+		ClientID:   "client-1",
+		LeaseKey:   leaseKey[:],
+		LeaseState: LeaseStateRead | LeaseStateHandle,
+	}
+	require.NoError(t, store.PutLock(ctx, persisted))
+
+	// Enter grace expecting client-1 to reclaim.
+	lm.EnterGracePeriod([]string{"client-1"})
+	require.True(t, lm.IsInGracePeriod(), "grace must be active after EnterGracePeriod")
+
+	// Reclaim the lease.
+	_, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false)
+	require.NoError(t, err, "lease reclaim during grace must succeed")
+
+	// The reclaim must have recorded the client; with the only expected client
+	// reclaimed, grace exits early.
+	require.Equal(t, GraceStateNormal, gpm.GetState(),
+		"reclaiming the sole expected client's lease must MarkReclaimed and end grace early")
+}

--- a/pkg/metadata/lock/grace_phase2_test.go
+++ b/pkg/metadata/lock/grace_phase2_test.go
@@ -32,6 +32,31 @@ func TestGracePeriod_EarlyExitWhenAllReclaim(t *testing.T) {
 	}
 }
 
+// TestAbortGracePeriod_StopsTimerWithoutCallback pins the dropped-loser fix: a
+// manager that loses a registration race must abort its armed grace timer
+// WITHOUT firing onGraceEnd. If onGraceEnd ran on the orphan it would sweep the
+// shared lock store (RemoveClientLocks) and end the surviving NFSv4 grace
+// machine. AbortGracePeriod must leave the manager in normal state and never
+// invoke the callback even after the original duration elapses.
+func TestAbortGracePeriod_StopsTimerWithoutCallback(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	gpm := NewGracePeriodManager(20*time.Millisecond, func() { fired <- struct{}{} })
+	lm := NewManagerWithGracePeriod(gpm)
+
+	lm.EnterGracePeriod([]string{"client-1"})
+	require.True(t, lm.IsInGracePeriod(), "grace must be active after EnterGracePeriod")
+
+	lm.AbortGracePeriod()
+	require.False(t, lm.IsInGracePeriod(), "AbortGracePeriod must leave the manager out of grace")
+
+	select {
+	case <-fired:
+		t.Fatal("onGraceEnd fired after AbortGracePeriod; orphan timer would corrupt the surviving manager")
+	case <-time.After(80 * time.Millisecond):
+		// Timer never fired the callback — correct.
+	}
+}
+
 // TestReclaimLease_MarksClientReclaimed pins Phase-2 item 4 (SMB side): a
 // successful lease reclaim during grace must MarkReclaimed the owning client so
 // grace can exit early once every expected client has recovered.

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2595,6 +2595,18 @@ func (lm *Manager) ExitGracePeriod() {
 	}
 }
 
+// AbortGracePeriod cancels a pending grace timer WITHOUT firing the onGraceEnd
+// callback. Used to discard a manager that lost a registration race: its
+// orphaned timer must never run, because onGraceEnd sweeps the shared lock
+// store (RemoveClientLocks) and ends the surviving NFSv4 grace machine — both
+// would corrupt the published manager's state. If no grace period manager is
+// configured, this is a no-op.
+func (lm *Manager) AbortGracePeriod() {
+	if lm.gracePeriod != nil {
+		lm.gracePeriod.Close()
+	}
+}
+
 // IsOperationAllowed checks if a lock operation is allowed in the current state.
 // If no grace period manager is configured, all operations are allowed.
 func (lm *Manager) IsOperationAllowed(op Operation) (bool, error) {

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2620,6 +2620,24 @@ func (lm *Manager) IsInGracePeriod() bool {
 	return false
 }
 
+// GetExpectedClients returns the client IDs the grace period is waiting on to
+// reclaim. Returns nil if no grace period manager is configured.
+func (lm *Manager) GetExpectedClients() []string {
+	if lm.gracePeriod != nil {
+		return lm.gracePeriod.GetExpectedClients()
+	}
+	return nil
+}
+
+// GetReclaimedClients returns the client IDs that have reclaimed during the
+// current grace period. Returns nil if no grace period manager is configured.
+func (lm *Manager) GetReclaimedClients() []string {
+	if lm.gracePeriod != nil {
+		return lm.gracePeriod.GetReclaimedClients()
+	}
+	return nil
+}
+
 // ============================================================================
 // Break Callback Registration
 // ============================================================================

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -75,6 +75,13 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 					LeaseStateToString(pl.LeaseState))
 			}
 
+			// Record the reclaim so grace can exit early once every expected
+			// client has recovered (X/Open NLMv4 / RFC 7530 §9.6.2). Both the
+			// fresh-restore and already-in-memory branches below are successful
+			// reclaims, so mark here once for both. MarkReclaimed takes the grace
+			// manager's own mutex, not lm.mu, so it is safe outside lm.mu.
+			lm.MarkReclaimed(pl.ClientID)
+
 			// Step 5: Restore in memory (idempotent: skip if already reclaimed)
 			lock := FromPersistedLock(pl)
 			lock.Lease.LeaseState = requestedState
@@ -87,19 +94,12 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				existing.Lease.LeaseState = requestedState
 				existing.Reclaim = true
 				lm.mu.Unlock()
-				// Record the reclaim so grace can exit early once every expected
-				// client has recovered (X/Open NLMv4 / RFC 7530 §9.6.2).
-				lm.MarkReclaimed(pl.ClientID)
 				logger.Debug("ReclaimLease: lease already in memory, updated",
 					"leaseKey", fmt.Sprintf("%x", leaseKey))
 				return existing.Clone(), nil
 			}
 			lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], lock)
 			lm.mu.Unlock()
-
-			// Record the reclaim so grace can exit early once every expected
-			// client has recovered (X/Open NLMv4 / RFC 7530 §9.6.2).
-			lm.MarkReclaimed(pl.ClientID)
 
 			logger.Debug("ReclaimLease: lease reclaimed",
 				"leaseKey", fmt.Sprintf("%x", leaseKey),

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -87,12 +87,19 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				existing.Lease.LeaseState = requestedState
 				existing.Reclaim = true
 				lm.mu.Unlock()
+				// Record the reclaim so grace can exit early once every expected
+				// client has recovered (X/Open NLMv4 / RFC 7530 §9.6.2).
+				lm.MarkReclaimed(pl.ClientID)
 				logger.Debug("ReclaimLease: lease already in memory, updated",
 					"leaseKey", fmt.Sprintf("%x", leaseKey))
 				return existing.Clone(), nil
 			}
 			lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], lock)
 			lm.mu.Unlock()
+
+			// Record the reclaim so grace can exit early once every expected
+			// client has recovered (X/Open NLMv4 / RFC 7530 §9.6.2).
+			lm.MarkReclaimed(pl.ClientID)
 
 			logger.Debug("ReclaimLease: lease reclaimed",
 				"leaseKey", fmt.Sprintf("%x", leaseKey),

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -108,8 +108,10 @@ func (s *MetadataService) SetLockGracePeriod(d time.Duration) {
 }
 
 // SetGraceCoordinator registers the coordinator that couples lock-manager grace
-// with the NFSv4 StateManager grace machine. Must be called before
-// RegisterStoreForShare to participate in a given share's recovery.
+// with the NFSv4 StateManager grace machine. It may be installed after shares
+// register (the NFS adapter does so during SetRuntime): the grace-end callback
+// reads the coordinator live, and the adapter catches up the start side for
+// shares already in grace, so registration order does not matter.
 func (s *MetadataService) SetGraceCoordinator(c GraceCoordinator) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -164,7 +166,7 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	// locks but not yet entered grace (it would admit a stealing new lock).
 	var lm *LockManager
 	if ls, ok := store.(lock.LockStore); ok {
-		lm = newGraceAwareLockManager(graceDuration, graceCoordinator)
+		lm = s.newGraceAwareLockManager(graceDuration)
 		lm.SetLockStore(ls)
 		lm.SetShareName(shareName)
 		expectedClients := initLockManagerFromStore(lm, ls, shareName)
@@ -261,14 +263,20 @@ func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName stri
 }
 
 // newGraceAwareLockManager builds a lock manager whose grace period sweeps any
-// locks left unreclaimed when the grace window ends and notifies the optional
+// locks left unreclaimed when the grace window ends and notifies the grace
 // coordinator so the NFSv4 StateManager grace machine exits in lockstep.
 //
 // The onGraceEnd callback is best-effort: a client that did not reclaim within
 // the window has its stale persisted+in-memory locks dropped (RemoveClientLocks),
 // matching the X/Open NLMv4 contract that unreclaimed state is forfeited once
 // grace ends.
-func newGraceAwareLockManager(duration time.Duration, coordinator GraceCoordinator) *LockManager {
+//
+// The coordinator is read LIVE from the service when the window ends, not
+// captured at construction: the NFS adapter installs it (SetGraceCoordinator)
+// during SetRuntime, which runs AFTER shares register at startup. A manager
+// built before the adapter exists must still notify the coordinator once it is
+// installed, or the v4 grace machine would never be ended in lockstep.
+func (s *MetadataService) newGraceAwareLockManager(duration time.Duration) *LockManager {
 	// lm and gpm are captured by the onGraceEnd closure below. The closure only
 	// runs after EnterGracePeriod arms the timer, by which point both are set.
 	var lm *LockManager
@@ -287,6 +295,9 @@ func newGraceAwareLockManager(duration time.Duration, coordinator GraceCoordinat
 				lm.RemoveClientLocks(c)
 			}
 		}
+		s.mu.RLock()
+		coordinator := s.graceCoordinator
+		s.mu.RUnlock()
 		if coordinator != nil {
 			coordinator.OnLockGraceEnd()
 		}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -185,6 +185,11 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	// Re-check: another caller may have raced us to register this share while
 	// we recovered outside the lock. First publisher wins; drop our manager.
 	if _, exists := s.lockManagers[shareName]; exists {
+		// Our manager may have armed a grace timer above. It was never
+		// published, so abort that timer without firing onGraceEnd — letting it
+		// run would sweep the surviving manager's locks from the shared store
+		// and prematurely end the NFSv4 grace machine.
+		lm.AbortGracePeriod()
 		return nil
 	}
 	s.lockManagers[shareName] = lm

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// DefaultLockGracePeriod is the fallback lock-manager grace period applied when
+// no duration is configured. Mirrors the conventional NLM/NFSv4 grace window.
+const DefaultLockGracePeriod = 90 * time.Second
 
 // MetadataService provides all metadata operations for the filesystem.
 //
@@ -41,6 +46,30 @@ type MetadataService struct {
 	deferredCommit     bool                              // if true, use deferred commits (default: true)
 	cookies            *CookieManager                    // NFS/SMB cookie to store token translation
 	quotas             map[string]int64                  // shareName -> quota in bytes (0 = unlimited)
+
+	// graceDuration is the lock-manager grace period applied to shares whose
+	// stores carry persisted locks at registration. Zero means use the default.
+	graceDuration time.Duration
+
+	// graceCoordinator, if set, is invoked when a share's lock-manager grace
+	// period starts and ends. It lets the NFS adapter drive the SEPARATE NFSv4
+	// StateManager grace machine in lockstep with the lock-manager grace machine
+	// so both enter and exit together. Registered via SetGraceCoordinator.
+	graceCoordinator GraceCoordinator
+}
+
+// GraceCoordinator couples the lock-manager grace period with another grace
+// machine (the NFSv4 StateManager). When a share recovers persisted locks at
+// registration the lock manager enters grace and OnLockGraceStart fires; when
+// that grace window ends (timer, early-exit, or sweep) OnLockGraceEnd fires.
+// Implementations must be safe for concurrent use and must not block.
+type GraceCoordinator interface {
+	// OnLockGraceStart is called when a share's lock-manager grace period begins.
+	// expectedClients are the client IDs recovered from persisted locks.
+	OnLockGraceStart(expectedClients []string)
+
+	// OnLockGraceEnd is called when a share's lock-manager grace period ends.
+	OnLockGraceEnd()
 }
 
 // New creates a new empty MetadataService instance.
@@ -66,6 +95,25 @@ func (s *MetadataService) SetDeferredCommit(enabled bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.deferredCommit = enabled
+}
+
+// SetLockGracePeriod sets the grace period applied to per-share lock managers
+// that recover persisted locks at registration. A non-positive duration falls
+// back to DefaultLockGracePeriod. Must be called before RegisterStoreForShare
+// to affect a given share.
+func (s *MetadataService) SetLockGracePeriod(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graceDuration = d
+}
+
+// SetGraceCoordinator registers the coordinator that couples lock-manager grace
+// with the NFSv4 StateManager grace machine. Must be called before
+// RegisterStoreForShare to participate in a given share's recovery.
+func (s *MetadataService) SetGraceCoordinator(c GraceCoordinator) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graceCoordinator = c
 }
 
 // RegisterStoreForShare associates a metadata store with a share.
@@ -94,17 +142,42 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 		return nil
 	}
 
+	// Snapshot grace config under s.mu (read once; both fields are set before
+	// any RegisterStoreForShare call per their doc contract).
+	s.mu.Lock()
+	graceDuration := s.graceDuration
+	graceCoordinator := s.graceCoordinator
+	s.mu.Unlock()
+	if graceDuration <= 0 {
+		graceDuration = DefaultLockGracePeriod
+	}
+
 	// Build and fully recover the lock manager on a local var BEFORE publishing
 	// it into s.lockManagers. Recovery (epoch bump + ListLocks + replay) issues
 	// backend IO, so it runs outside s.mu — but it must complete before the
 	// manager is observable: a concurrent GetLockManagerForShare that saw an
 	// empty, unrecovered manager could grant a lock conflicting with a
 	// not-yet-restored one. Publishing only after recovery closes that window.
-	lm := NewLockManager()
+	//
+	// Grace is built on this same local manager before publishing: a manager
+	// must never be observable in a window where it has restored conflicting
+	// locks but not yet entered grace (it would admit a stealing new lock).
+	var lm *LockManager
 	if ls, ok := store.(lock.LockStore); ok {
+		lm = newGraceAwareLockManager(graceDuration, graceCoordinator)
 		lm.SetLockStore(ls)
 		lm.SetShareName(shareName)
-		initLockManagerFromStore(lm, ls, shareName)
+		expectedClients := initLockManagerFromStore(lm, ls, shareName)
+		// Only enter grace if a previous run left locks to reclaim. A fresh
+		// server (no persisted locks) starts in normal operation.
+		if len(expectedClients) > 0 {
+			lm.EnterGracePeriod(expectedClients)
+			if graceCoordinator != nil {
+				graceCoordinator.OnLockGraceStart(expectedClients)
+			}
+		}
+	} else {
+		lm = NewLockManager()
 	}
 
 	s.mu.Lock()
@@ -135,7 +208,11 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 // epoch it observed, and every lock it restores predates that epoch regardless
 // of the gap. Moving IncrementServerEpoch under s.mu would serialize backend IO
 // inside the service lock for no correctness gain, so the increment stays here.
-func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName string) {
+//
+// It returns the unique set of client IDs recovered from the persisted locks.
+// The caller uses this set as the grace period's expected-reclaim roster: grace
+// is entered only when it is non-empty (a previous run left locks to reclaim).
+func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName string) []string {
 	ctx := context.Background()
 
 	epoch, err := ls.IncrementServerEpoch(ctx)
@@ -148,16 +225,70 @@ func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName stri
 	persisted, err := ls.ListLocks(ctx, lock.LockQuery{ShareName: shareName})
 	if err != nil {
 		logger.Error("lock recovery: failed to list persisted locks", "share", shareName, "error", err)
-		return
+		return nil
 	}
 	if len(persisted) == 0 {
-		return
+		return nil
 	}
 	if err := lm.RestoreLocks(persisted); err != nil {
 		logger.Error("lock recovery: failed to restore persisted locks", "share", shareName, "error", err)
-		return
+		return nil
 	}
-	logger.Info("lock recovery: restored persisted locks", "share", shareName, "count", len(persisted), "epoch", epoch)
+
+	// Collect the unique client IDs that held locks before the restart; these
+	// are the clients the grace period waits on for reclaim.
+	seen := make(map[string]struct{}, len(persisted))
+	clients := make([]string, 0, len(persisted))
+	for _, pl := range persisted {
+		if pl.ClientID == "" {
+			continue
+		}
+		if _, dup := seen[pl.ClientID]; dup {
+			continue
+		}
+		seen[pl.ClientID] = struct{}{}
+		clients = append(clients, pl.ClientID)
+	}
+
+	logger.Info("lock recovery: restored persisted locks",
+		"share", shareName, "count", len(persisted), "epoch", epoch, "clients", len(clients))
+	return clients
+}
+
+// newGraceAwareLockManager builds a lock manager whose grace period sweeps any
+// locks left unreclaimed when the grace window ends and notifies the optional
+// coordinator so the NFSv4 StateManager grace machine exits in lockstep.
+//
+// The onGraceEnd callback is best-effort: a client that did not reclaim within
+// the window has its stale persisted+in-memory locks dropped (RemoveClientLocks),
+// matching the X/Open NLMv4 contract that unreclaimed state is forfeited once
+// grace ends.
+func newGraceAwareLockManager(duration time.Duration, coordinator GraceCoordinator) *LockManager {
+	// lm and gpm are captured by the onGraceEnd closure below. The closure only
+	// runs after EnterGracePeriod arms the timer, by which point both are set.
+	var lm *LockManager
+
+	gpm := lock.NewGracePeriodManager(duration, func() {
+		if lm != nil {
+			reclaimed := make(map[string]struct{})
+			for _, c := range lm.GetReclaimedClients() {
+				reclaimed[c] = struct{}{}
+			}
+			for _, c := range lm.GetExpectedClients() {
+				if _, ok := reclaimed[c]; ok {
+					continue
+				}
+				logger.Info("grace period: sweeping unreclaimed locks", "client", c)
+				lm.RemoveClientLocks(c)
+			}
+		}
+		if coordinator != nil {
+			coordinator.OnLockGraceEnd()
+		}
+	})
+
+	lm = lock.NewManagerWithGracePeriod(gpm)
+	return lm
 }
 
 // GetStoreForShare returns the metadata store for a specific share.


### PR DESCRIPTION
## What

Phase 2 of lock durability. Closes **area-5 H-1**, **NFS H7** (reclaim completes), and **NFS H15** (`NLM4_DENIED_GRACE_PERIOD` reachable).

Phase 1 built the `GracePeriodManager`, `EnterGracePeriod`/`IsOperationAllowed`/`MarkReclaimed`, and per-share `RestoreLocks`, but production constructed the lock manager via the no-grace path — so `gracePeriod` was nil, `IsInGracePeriod` always false, every reclaim rejected, and `NLM4_DENIED_GRACE_PERIOD` unreachable. This PR wires it.

## What got wired

- **Grace construction + enter-on-restart** (`service.go`): each share's lock manager is now built via `NewManagerWithGracePeriod` (`newGraceAwareLockManager`). After recovering persisted locks, the unique set of recovered `ClientID`s becomes the expected-reclaim roster, and grace is entered only when that set is non-empty (a fresh server with no persisted locks starts in normal operation). `onGraceEnd` sweeps any client that did not reclaim within the window (`RemoveClientLocks`). Grace is built and entered on the local manager **before** it is published into `s.lockManagers`, preserving the Phase-1 recover-before-publish + synchronous-persist invariants (a manager is never observable having restored conflicting locks but not yet entered grace).
- **NLM grace gating + status** (`nlm.go`, `nlm/handlers/lock.go`): non-reclaim `LockFileNLM` is gated on `IsOperationAllowed`; the `ErrGracePeriod` sentinel maps to `NLM4_DENIED_GRACE_PERIOD` (previously every error → `NLM4Failed`). Reclaims are allowed during grace and call `MarkReclaimed` on grant.
- **MarkReclaimed wiring** (`reclaim.go`): a successful lease reclaim records the owning client so grace can early-exit once every expected client recovers.
- **NFSv4 grace coordination** (`grace_coordinator.go`, `adapter.go`): a `GraceCoordinator` couples the NFSv4 `StateManager` grace machine to the per-share lock-manager grace machine (enter together, exit together). Registered for shares added after adapter startup, with a catch-up pass for shares already in grace when the adapter starts (boot shares register before the adapter exists).
- **Config** (`start.go`): the operator-configured NFS `grace_period` is threaded into the `MetadataService` before shares register (defaults to 90s, matching the DB default).

## NFSv4 two-machine coordination — honest status

The lock-manager + NLM grace window is **fully live** (the H-1/H7/H15 fix). The NFSv4 coordination **seam is wired end-to-end** (the coordinator drives `StateManager.StartGracePeriod`/`ForceEndGrace`), and a unit test asserts both machines enter together via the coordinator. But NFSv4 grace only meaningfully activates when given the v4 confirmed-client set, and DittoFS does not yet **persist** NFSv4 clients across restart (`SaveClientState`/`LoadPreviousClients` are unwired) — so the v4 expected set is empty and the v4 window is a no-op today even though it is driven. The coupling lands so that once v4 client persistence exists, both machines enter/exit together with no further change. The per-share-vs-global v4 asymmetry (first share in starts v4 grace, first out ends it) is documented in `grace_coordinator.go` as the seam to refcount once v4 grace goes live.

## Tests (TDD, RED→GREEN)

- `TestGracePeriod_NLMLockDenied` — non-reclaim NLM lock during grace → `ErrGracePeriod` → `NLM4_DENIED_GRACE_PERIOD`.
- `TestGracePeriod_NLMReclaimAllowed` — reclaim granted + `MarkReclaimed`.
- `TestGracePeriod_EarlyExitWhenAllReclaim` — both expected clients reclaim → grace exits before timer.
- `TestReclaimLease_MarksClientReclaimed` — lease reclaim marks client + early-exits (the RED→GREEN bug this PR fixed).
- `TestRegisterStoreForShare_EntersGraceWhenPersistedLocksExist` / `_NoGraceWhenNoPersistedLocks` — restart enters grace with the persisted roster; fresh server does not.
- `TestGracePeriod_BothMachinesEnterTogether` — coordinator drives a second grace machine in lockstep.

All Phase-1 storetest/property/storm tests stay green. `go test -race ./pkg/metadata/lock/...` clean.

## Next wave (separate)

Byte-range-map unification (xproto H1/H2) is a **separate** next wave that supersedes the old PR-B3 cross-scan.