### PR TITLE
test(smb/dh): V1-lease reopen2 wire-context coverage — V1-vs-V2 lease asymmetry (#738)

### DIFF
--- a/internal/adapter/smb/v2/handlers/reopen2_v1lease_repro_test.go
+++ b/internal/adapter/smb/v2/handlers/reopen2_v1lease_repro_test.go
@@ -1,0 +1,210 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestRepro_V1Lease_V1WireContext mirrors smbtorture smb2.durable-open.reopen2-lease
+// AS FAITHFULLY AS THE HANDLER ALLOWS: the initial open uses a V1 (32-byte) RqLs
+// lease context (smb2_lease_create) + a V1 DHnQ durable request (io.in.durable_open
+// = true), then disconnects and reconnects via DHnC + a V1 (32-byte) RqLs context.
+//
+// This is distinct from the existing TestReopen2_V1Lease_* tests which inject a
+// V2 (52-byte) RqLs context. The goal is to find any handler-reachable divergence
+// caused by the V1 lease wire shape.
+func TestRepro_V1Lease_V1WireContext(t *testing.T) {
+	e := setupReopen2Env(t)
+
+	leaseKey := [16]byte{0xAB, 0xCD, 0xEF, 0x01}
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+
+	const sessionID = uint64(220)
+	_, of := e.initialLeaseDurableOpenV1Wire(t, sessionID, leaseKey, []CreateContext{dhnqContext()})
+
+	if of.OplockLevel != OplockLevelLease {
+		t.Fatalf("initial open: OplockLevel = 0x%02x, want Lease", of.OplockLevel)
+	}
+	if !of.IsDurable {
+		t.Fatal("initial open: V1 durability NOT granted (lease with Handle, V1 wire) — handle will never persist")
+	}
+	persistedFileID := of.FileID
+
+	e.disconnect(sessionID)
+
+	const sessionID2 = uint64(221)
+	e.h.CreateSessionWithID(sessionID2, "127.0.0.1:2", false, "alice", "WORKGROUP")
+	rcCtx := e.makeSMBCtx(sessionID2)
+	rcResp, err := e.h.Create(rcCtx, &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		OplockLevel:       OplockLevelLease,
+		CreateContexts: []CreateContext{
+			dhncContext(persistedFileID),
+			{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, rwh)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconnect Create error: %v", err)
+	}
+	if rcResp.Status != types.StatusSuccess {
+		t.Fatalf("V1-lease (V1 wire ctx) reconnect: status=0x%08x, want SUCCESS", uint32(rcResp.Status))
+	}
+}
+
+// TestRepro_V1Lease_NegativeLadder_V1WireContext is the closest handler-level
+// model of smbtorture smb2.durable-open.reopen2-lease: a single persisted V1
+// durable+lease handle, then the EXACT negative ladder (ONF, ONF, ONF, ONF,
+// INVALID_PARAMETER) followed by the positive reconnect (OK) — all using V1
+// (32-byte) RqLs lease contexts (smb2_lease_create), against ONE persisted
+// handle. The handle must survive every non-destructive negative attempt.
+func TestRepro_V1Lease_NegativeLadder_V1WireContext(t *testing.T) {
+	e := setupReopen2Env(t)
+
+	leaseKey := [16]byte{0x71, 0x72, 0x73}
+	wrongLeaseKey := [16]byte{0x81, 0x82, 0x83}
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+
+	const sessionID = uint64(260)
+	_, of := e.initialLeaseDurableOpenV1Wire(t, sessionID, leaseKey, []CreateContext{dhnqContext()})
+	if !of.IsDurable {
+		t.Fatal("initial open: V1 durability not granted")
+	}
+	persistedFileID := of.FileID
+	e.disconnect(sessionID)
+
+	v1rwh := func(k [16]byte) CreateContext {
+		return CreateContext{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(k, rwh)}
+	}
+
+	cases := []struct {
+		name      string
+		fileName  string
+		leaseKey  [16]byte
+		omitLease bool
+		want      types.Status
+	}{
+		{"empty-fname-no-lease", "", leaseKey, true, types.StatusObjectNameNotFound},
+		{"nonexisting-no-lease", "__non_existing_fname__", leaseKey, true, types.StatusObjectNameNotFound},
+		{"correct-fname-no-lease", "durable.txt", leaseKey, true, types.StatusObjectNameNotFound},
+		{"wrong-lease-key", "durable.txt", wrongLeaseKey, false, types.StatusObjectNameNotFound},
+		{"wrong-fname-with-lease", "__non_existing_fname__", leaseKey, false, types.StatusInvalidParameter},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid := sessionID + 100 + uint64(len(tc.name))
+			e.h.CreateSessionWithID(sid, "127.0.0.1:7", false, "alice", "WORKGROUP")
+			rcCtx := e.makeSMBCtx(sid)
+			contexts := []CreateContext{dhncContext(persistedFileID)}
+			if !tc.omitLease {
+				contexts = append(contexts, v1rwh(tc.leaseKey))
+			}
+			rcResp, err := e.h.Create(rcCtx, &CreateRequest{
+				FileName:          tc.fileName,
+				DesiredAccess:     0x001F01FF,
+				ShareAccess:       0x07,
+				CreateDisposition: types.FileOpen,
+				OplockLevel:       OplockLevelLease,
+				CreateContexts:    contexts,
+			})
+			if err != nil {
+				t.Fatalf("%s: Create error: %v", tc.name, err)
+			}
+			if rcResp.Status != tc.want {
+				t.Errorf("%s: status=0x%08x, want 0x%08x", tc.name, uint32(rcResp.Status), uint32(tc.want))
+			}
+		})
+	}
+
+	// Positive reconnect (OK) — same persisted handle, V1 RqLs, correct fname+key.
+	const finalSID = uint64(997)
+	e.h.CreateSessionWithID(finalSID, "127.0.0.1:8", false, "alice", "WORKGROUP")
+	rcResp, err := e.h.Create(e.makeSMBCtx(finalSID), &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		OplockLevel:       OplockLevelLease,
+		CreateContexts:    []CreateContext{dhncContext(persistedFileID), v1rwh(leaseKey)},
+	})
+	if err != nil {
+		t.Fatalf("final reopen: Create error: %v", err)
+	}
+	if rcResp.Status != types.StatusSuccess {
+		t.Fatalf("final V1-lease reopen (V1 wire ctx): status=0x%08x, want SUCCESS", uint32(rcResp.Status))
+	}
+	if rcResp.OplockLevel != OplockLevelLease {
+		t.Errorf("final reopen OplockLevel = 0x%02x, want Lease", rcResp.OplockLevel)
+	}
+}
+
+// initialLeaseDurableOpenV1Wire is initialLeaseDurableOpen but with a V1 (32-byte)
+// RqLs context instead of a V2 (52-byte) one.
+func (e *reopen2Env) initialLeaseDurableOpenV1Wire(
+	t *testing.T,
+	sessionID uint64,
+	leaseKey [16]byte,
+	durableCtx []CreateContext,
+) (*CreateResponse, *OpenFile) {
+	t.Helper()
+
+	metaSvc := e.h.Registry.GetMetadataService()
+	rootHandle, err := e.h.Registry.GetRootHandle(e.tree.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	file, _, err := e.h.lookupCaseInsensitive(rootAuthCtx(), metaSvc, rootHandle, "durable.txt")
+	if err != nil || file == nil {
+		t.Fatalf("lookup durable.txt: file=%v err=%v", file, err)
+	}
+	existingHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+	contexts := []CreateContext{
+		{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, rwh)},
+	}
+	contexts = append(contexts, durableCtx...)
+
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "durable.txt",
+			DesiredAccess:     0x001F01FF,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpen,
+			CreateOptions:     0,
+			OplockLevel:       OplockLevelLease,
+			CreateContexts:    contexts,
+		},
+		tree:           e.tree,
+		authCtx:        rootAuthCtx(),
+		filename:       "durable.txt",
+		baseName:       "durable.txt",
+		parentHandle:   rootHandle,
+		existingFile:   file,
+		existingHandle: existingHandle,
+		fileExists:     true,
+		createAction:   types.FileOpened,
+	}
+
+	smbCtx := e.makeSMBCtx(sessionID)
+	e.h.CreateSessionWithID(sessionID, "127.0.0.1:1", false, "alice", "WORKGROUP")
+
+	resp := e.h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("initial open: status=0x%08x, want SUCCESS", uint32(resp.Status))
+	}
+	openFile, ok := e.h.GetOpenFile(resp.FileID)
+	if !ok {
+		t.Fatal("initial open: OpenFile not registered")
+	}
+	return resp, openFile
+}

--- a/internal/adapter/smb/v2/handlers/reopen2_wire_repro_test.go
+++ b/internal/adapter/smb/v2/handlers/reopen2_wire_repro_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// buildCreateRequestWire assembles a full SMB2 CREATE request BODY (the bytes
+// after the 64-byte SMB2 header) for the given fields + create contexts, exactly
+// as a real client would put them on the wire. It then runs DecodeCreateRequest
+// over those bytes so the test exercises the real wire-decode path (the layer the
+// reopen2_e2e_test.go harness bypasses by injecting []CreateContext directly).
+func buildCreateRequestWire(
+	oplockLevel uint8,
+	desiredAccess, shareAccess, disposition, createOptions uint32,
+	filename string,
+	contexts []CreateContext,
+) []byte {
+	nameUTF16 := encodeUTF16LE(filename)
+
+	// Fixed part is 56 bytes; name follows at body offset 56 (header+56 = 120).
+	const fixedSize = 56
+	nameOffsetFromHeader := uint16(64 + fixedSize) // 120
+
+	// Encode contexts; they follow the (8-byte-aligned) name.
+	ctxBuf, _, _ := EncodeCreateContexts(contexts)
+
+	// Lay out: [56 fixed][name][pad to 8][contexts]
+	body := make([]byte, fixedSize)
+	binary.LittleEndian.PutUint16(body[0:2], 57) // StructureSize (always 57 for request)
+	body[2] = 0                                  // SecurityFlags
+	body[3] = oplockLevel                        // OplockLevel
+	binary.LittleEndian.PutUint32(body[4:8], 0)  // ImpersonationLevel
+	// SmbCreateFlags (8) + Reserved (8) at 8..24 = zero
+	binary.LittleEndian.PutUint32(body[24:28], desiredAccess)
+	binary.LittleEndian.PutUint32(body[28:32], 0) // FileAttributes
+	binary.LittleEndian.PutUint32(body[32:36], shareAccess)
+	binary.LittleEndian.PutUint32(body[36:40], disposition)
+	binary.LittleEndian.PutUint32(body[40:44], createOptions)
+	binary.LittleEndian.PutUint16(body[44:46], nameOffsetFromHeader)
+	binary.LittleEndian.PutUint16(body[46:48], uint16(len(nameUTF16)))
+	// CreateContextsOffset (48..52) + CreateContextsLength (52..56) filled below.
+
+	// Append name.
+	body = append(body, nameUTF16...)
+	// Pad to 8-byte boundary before contexts.
+	for len(body)%8 != 0 {
+		body = append(body, 0)
+	}
+
+	if len(ctxBuf) > 0 {
+		ctxOffsetFromHeader := uint32(64 + len(body))
+		binary.LittleEndian.PutUint32(body[48:52], ctxOffsetFromHeader)
+		binary.LittleEndian.PutUint32(body[52:56], uint32(len(ctxBuf)))
+		body = append(body, ctxBuf...)
+	}
+
+	return body
+}
+
+// TestRepro_WireDecode_V1LeaseReconnect drives the FULL wire-decode path for the
+// V1-lease reopen2 reconnect: build the on-wire CREATE body that smbtorture
+// smb2.durable-open.reopen2-lease sends on the positive reconnect (DHnC + a V1
+// 32-byte RqLs with the correct lease key + fname), decode it via
+// DecodeCreateRequest, and assert the decoded contexts survive intact.
+func TestRepro_WireDecode_V1LeaseReconnect(t *testing.T) {
+	leaseKey := [16]byte{0xAB, 0xCD, 0xEF, 0x01}
+	persistentFileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+
+	contexts := []CreateContext{
+		dhncContext(persistentFileID),
+		{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, rwh)},
+	}
+
+	body := buildCreateRequestWire(
+		OplockLevelLease,
+		0x001F01FF, 0x07, 0x01 /* FILE_OPEN */, 0,
+		"durable.txt",
+		contexts,
+	)
+
+	req, err := DecodeCreateRequest(body)
+	if err != nil {
+		t.Fatalf("DecodeCreateRequest failed on V1-lease reconnect wire body: %v", err)
+	}
+	if req.FileName != "durable.txt" {
+		t.Errorf("decoded FileName = %q, want durable.txt", req.FileName)
+	}
+	dhnc := FindCreateContext(req.CreateContexts, DurableHandleV1ReconnectTag)
+	if dhnc == nil {
+		t.Fatal("decoded request LOST the DHnC reconnect context")
+	}
+	gotFileID, derr := DecodeDHnCReconnect(dhnc.Data)
+	if derr != nil {
+		t.Fatalf("decode DHnC: %v", derr)
+	}
+	if gotFileID != persistentFileID {
+		t.Errorf("decoded DHnC FileID = %x, want %x", gotFileID, persistentFileID)
+	}
+	rqls := FindCreateContext(req.CreateContexts, LeaseContextTagRequest)
+	if rqls == nil {
+		t.Fatal("decoded request LOST the V1 RqLs lease context")
+	}
+	lc, lerr := DecodeLeaseCreateContext(rqls.Data)
+	if lerr != nil || lc == nil {
+		t.Fatalf("decode V1 RqLs: %v", lerr)
+	}
+	if lc.LeaseKey != leaseKey {
+		t.Errorf("decoded lease key = %x, want %x", lc.LeaseKey, leaseKey)
+	}
+	t.Logf("decoded %d contexts: DHnC fileID=%x, RqLs leaseKey=%x state=0x%x",
+		len(req.CreateContexts), gotFileID, lc.LeaseKey, lc.LeaseState)
+}


### PR DESCRIPTION
## Summary

Investigates the 2 remaining V1-**lease** durable reopen2 residuals
(`smb2.durable-open.reopen2-lease` / `-lease-v2`, #738) after #861 fixed the
reopen2 access-revalidation gate.

**Finding: the V1-lease reconnect path is already correct in DittoFS's handler
and wire-decode layers.** Every code-reachable layer of the V1-lease
disconnect→reconnect cycle was reproduced and passes. This PR closes the one
coverage gap #861 left — its V1-lease repros used a V2 (52-byte) `RqLs` lease
context, whereas smbtorture's V1 `reopen2-lease` sends a **V1 (32-byte) `RqLs`**
(`smb2_lease_create`) with a V1 `DHnQ`/`DHnC` durable blob.

## The V1-vs-V2 lease asymmetry, resolved

The only wire difference between the failing V1-lease tests and the passing
V2-lease test (`durable-v2-open.reopen2-lease`) is the **durable** layer
(`DHnQ`/`DHnC` keyed on FileID vs `DH2Q`/`DH2C` keyed on CreateGuid) — **not**
the lease context. The V1 reconnect (`processV1Reconnect`) and the shared
`checkLeaseReconnectGate` were verified to handle the lease-backed V1 path
identically to V2: lookup by volatile-zeroed FileID, lease-key + ClientGUID
gate before the path check, non-destructive negative ladder.

## What was verified (all green, real `Create()` + real `DecodeCreateRequest`)

- Initial V1-lease durable open with a **32-byte RqLs** + `DHnQ` → durability
  granted, handle persists with `OplockLevel=Lease` + lease key.
- Cross-connection reconnect (fresh session) via `DHnC` + 32-byte `RqLs` → OK.
- The exact smbtorture negative ladder against ONE persisted handle:
  ONF, ONF, ONF, ONF (wrong key), INVALID_PARAMETER (wrong fname + lease),
  then OK — handle survives every non-destructive negative attempt.
- Wire round-trip: `buildCreateRequestWire` → `DecodeCreateRequest` preserves
  both the `DHnC` (FileID intact) and the V1 `RqLs` (lease key intact) contexts.

## Honest confidence

- **`smb2.durable-open.reopen2-lease`** — high confidence the handler/wire path
  is correct; cannot run smbtorture (no Docker) to flip the KNOWN_FAILURES row.
  Strongly suspect the fix already shipped with #861 and the KF row is stale.
- **`smb2.durable-open.reopen2-lease-v2`** — same; the only delta vs the above
  is the 52-byte `RqLs` shape, which the existing #861 repros + this wire-decode
  test both cover.

If CI smbtorture still reports ONF after this lands, the divergence is below the
handler + wire-decode layers (NEGOTIATE/dispatch dialect framing) — not in
`durable_context.go` / `create.go`, both of which are exercised end-to-end here.

No production code changed — tests only. KNOWN_FAILURES intentionally left for
the orchestrator to walk back after a CI smbtorture run confirms.

Refs #738.
