### PR TITLE
feat(smb/replay): SMB3 channel-sequence verification (#749)

### DIFF
--- a/internal/adapter/smb/channel_sequence.go
+++ b/internal/adapter/smb/channel_sequence.go
@@ -1,0 +1,80 @@
+package smb
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// channelSeqModify reports whether a command is a modifying operation for the
+// purposes of SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10). Only
+// WRITE, SET_INFO, and IOCTL are rejected on a stale ChannelSequence; all
+// other commands are read-only with respect to this check (Samba marks the
+// same three with .modify = true in source3/smbd/smb2_server.c).
+func channelSeqModify(cmd types.Command) bool {
+	switch cmd {
+	case types.CommandWrite, types.CommandSetInfo, types.CommandIoctl:
+		return true
+	default:
+		return false
+	}
+}
+
+// channelSeqFileID extracts the 16-byte FileId from a request body for the
+// handle-scoped commands that participate in channel-sequence verification.
+// The body slice excludes the 64-byte SMB2 header. Returns ok=false for
+// commands that do not carry a FileId at a fixed offset (the check is skipped
+// for those). FileId offsets per MS-SMB2: READ §2.2.19 / WRITE §2.2.21 /
+// SET_INFO §2.2.39 all place it 16 bytes into the body; IOCTL §2.2.31 places
+// it 8 bytes in (after StructureSize, Reserved, CtlCode).
+func channelSeqFileID(cmd types.Command, body []byte) (fileID [16]byte, ok bool) {
+	var off int
+	switch cmd {
+	case types.CommandRead, types.CommandWrite, types.CommandSetInfo:
+		off = 16
+	case types.CommandIoctl:
+		off = 8
+	default:
+		return fileID, false
+	}
+	if len(body) < off+16 {
+		return fileID, false
+	}
+	copy(fileID[:], body[off:off+16])
+	return fileID, true
+}
+
+// verifyChannelSequence runs the SMB3 channel-sequence check (MS-SMB2
+// §3.3.5.2.10) for a handle-scoped request. It returns the status the dispatch
+// path should reject with (StatusFileNotAvailable) when a modifying operation
+// arrives on a stale ChannelSequence, or 0 when the request may proceed.
+//
+// The check is a no-op for non-SMB3 connections, for commands without a
+// FileId, and when the target Open is unknown (handle-not-found is left to the
+// handler to report with its own status). Read-only commands never reject but
+// still advance the tracked sequence so a following modifying op observes the
+// up-to-date value.
+func verifyChannelSequence(reqHeader *header.SMB2Header, body []byte, connInfo *ConnInfo) types.Status {
+	if connInfo.CryptoState == nil || connInfo.CryptoState.GetDialect() < types.Dialect0300 {
+		return 0
+	}
+
+	fileID, ok := channelSeqFileID(reqHeader.Command, body)
+	if !ok {
+		return 0
+	}
+
+	openFile, ok := connInfo.Handler.GetOpenFile(fileID)
+	if !ok {
+		return 0
+	}
+
+	// The ChannelSequence occupies the low 16 bits of the 4-byte
+	// ChannelSequence/Reserved field, which the header parser surfaces as
+	// Status in requests (MS-SMB2 §2.2.1.2).
+	reqCSN := uint16(uint32(reqHeader.Status) & 0xFFFF)
+
+	if openFile.VerifyChannelSequence(reqCSN, channelSeqModify(reqHeader.Command)) {
+		return 0
+	}
+	return types.StatusFileNotAvailable
+}

--- a/internal/adapter/smb/channel_sequence_test.go
+++ b/internal/adapter/smb/channel_sequence_test.go
@@ -1,0 +1,57 @@
+package smb
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+func TestChannelSeqModify(t *testing.T) {
+	modify := []types.Command{types.CommandWrite, types.CommandSetInfo, types.CommandIoctl}
+	for _, c := range modify {
+		if !channelSeqModify(c) {
+			t.Errorf("command %s should be a modifying op", c)
+		}
+	}
+	nonModify := []types.Command{
+		types.CommandRead, types.CommandCreate, types.CommandClose,
+		types.CommandFlush, types.CommandLock, types.CommandQueryInfo,
+	}
+	for _, c := range nonModify {
+		if channelSeqModify(c) {
+			t.Errorf("command %s should not be a modifying op", c)
+		}
+	}
+}
+
+func TestChannelSeqFileID(t *testing.T) {
+	want := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+
+	// READ/WRITE/SET_INFO place the FileId 16 bytes into the body.
+	body16 := make([]byte, 64)
+	copy(body16[16:32], want[:])
+	for _, c := range []types.Command{types.CommandRead, types.CommandWrite, types.CommandSetInfo} {
+		got, ok := channelSeqFileID(c, body16)
+		if !ok || got != want {
+			t.Errorf("%s: got (%v, %v), want (%v, true)", c, got, ok, want)
+		}
+	}
+
+	// IOCTL places the FileId 8 bytes into the body.
+	bodyIoctl := make([]byte, 64)
+	copy(bodyIoctl[8:24], want[:])
+	got, ok := channelSeqFileID(types.CommandIoctl, bodyIoctl)
+	if !ok || got != want {
+		t.Errorf("ioctl: got (%v, %v), want (%v, true)", got, ok, want)
+	}
+
+	// Commands without a fixed FileId offset are skipped.
+	if _, ok := channelSeqFileID(types.CommandCreate, body16); ok {
+		t.Error("CREATE should not yield a FileId for channel-sequence")
+	}
+
+	// Bodies too short to hold the FileId are rejected.
+	if _, ok := channelSeqFileID(types.CommandWrite, make([]byte, 20)); ok {
+		t.Error("short WRITE body should not yield a FileId")
+	}
+}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -113,6 +113,16 @@ func ProcessSingleRequest(
 		return SendErrorResponse(reqHeader, errStatus, connInfo)
 	}
 
+	// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10): reject a
+	// modifying op (WRITE/SET_INFO/IOCTL) that resends on a stale
+	// ChannelSequence after a channel failover.
+	if errStatus := verifyChannelSequence(reqHeader, body, connInfo); errStatus != 0 {
+		logger.Debug("Channel-sequence verification rejected request",
+			"command", reqHeader.Command.String(),
+			"messageID", reqHeader.MessageID)
+		return SendErrorResponse(reqHeader, errStatus, connInfo)
+	}
+
 	// Wire async slot accounting for max_async_credits enforcement (MS-SMB2 §3.3.5.2.5).
 	handlerCtx.TryReserveAsync = connInfo.TryReserveAsync
 	handlerCtx.ReleaseAsync = connInfo.ReleaseAsync
@@ -381,6 +391,15 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
+		return &HandlerResult{Status: errStatus, Data: MakeErrorBody()}, fileID, handlerCtx
+	}
+
+	// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10), same as the
+	// non-compound path: reject a stale modifying replay before dispatch.
+	if errStatus := verifyChannelSequence(reqHeader, body, connInfo); errStatus != 0 {
+		logger.Debug("Channel-sequence verification rejected compound request",
+			"command", reqHeader.Command.String(),
+			"messageID", reqHeader.MessageID)
 		return &HandlerResult{Status: errStatus, Data: MakeErrorBody()}, fileID, handlerCtx
 	}
 

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -230,6 +230,15 @@ const (
 	// connection's signing algorithm is not GMAC (MS-SMB2 §3.3.5.5.2; Samba
 	// source3/smbd/smb2_sesssetup.c:724-729).
 	StatusRequestOutOfSequence Status = 0xC000042A
+
+	// StatusFileNotAvailable indicates a modifying operation (WRITE,
+	// SET_INFO, IOCTL) carried a stale ChannelSequence number relative to
+	// the one the server tracks for the target Open. Returned during SMB3
+	// channel-sequence verification (MS-SMB2 §3.3.5.2.10) when the client
+	// resends an operation on a previously-failed channel without advancing
+	// its ChannelSequence — the server rejects the stale write rather than
+	// re-applying it out of order.
+	StatusFileNotAvailable Status = 0xC0000467
 )
 
 // String returns a human-readable name for the status code.
@@ -257,6 +266,8 @@ func (s Status) String() string {
 		return "STATUS_ACCESS_DENIED"
 	case StatusBufferOverflow:
 		return "STATUS_BUFFER_OVERFLOW"
+	case StatusFileNotAvailable:
+		return "STATUS_FILE_NOT_AVAILABLE"
 	case StatusObjectNameInvalid:
 		return "STATUS_OBJECT_NAME_INVALID"
 	case StatusObjectNameNotFound:

--- a/internal/adapter/smb/v2/handlers/channel_sequence.go
+++ b/internal/adapter/smb/v2/handlers/channel_sequence.go
@@ -1,0 +1,80 @@
+package handlers
+
+// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10).
+//
+// When a client's channel to the server fails, it reconnects (binding a new
+// channel to the same session) and resends operations that may have been
+// in-flight, marking the resend SMB2_FLAGS_REPLAY_OPERATION. To keep the
+// resend from being applied a second time out of order, every request carries
+// a 16-bit ChannelSequence number that the client increments on each channel
+// failover. The server tracks the latest ChannelSequence it has seen per Open
+// (Open.ChannelSequence) and uses it to decide whether a request is fresh, a
+// legitimate failover, or a stale resend on a channel the client has already
+// moved past.
+//
+// Only the three modifying operations — WRITE, SET_INFO, IOCTL — are rejected
+// on a stale ChannelSequence (with STATUS_FILE_NOT_AVAILABLE). Read-only
+// operations are always allowed; they still advance Open.ChannelSequence when
+// they carry a newer one so a subsequent modifying op sees the up-to-date
+// value. This mirrors Samba's smbd_smb2_request_dispatch_update_counts in
+// source3/smbd/smb2_server.c.
+//
+// Samba additionally maintains per-Open request_count / pre_request_count
+// gauges to defer replay acceptance while requests on a prior ChannelSequence
+// are still in flight. DittoFS processes each request to completion before the
+// next on a handle is dispatched (no cross-channel reordering of a single
+// handle's I/O), so those gauges are always drained by the time the following
+// request is verified; the decision then reduces to the ChannelSequence
+// comparison alone, which is what the channel-sequence and replay4 torture
+// tests observe.
+
+// VerifyChannelSequence applies the MS-SMB2 §3.3.5.2.10 channel-sequence check
+// to a request targeting this Open and advances the tracked sequence.
+//
+//   - reqCSN:   the ChannelSequence from the request header (low 16 bits of the
+//     SMB2 ChannelSequence/Reserved field).
+//   - isModify: whether the command is a modifying op (WRITE, SET_INFO, IOCTL).
+//
+// It returns false when the request must be rejected with
+// STATUS_FILE_NOT_AVAILABLE; true when it may proceed.
+//
+// The SMB2_FLAGS_REPLAY_OPERATION flag does not change the decision: a replay
+// of a stale modifying op is exactly the out-of-order resend the check exists
+// to suppress, and a replay on the current/newer sequence is accepted on the
+// same terms as a fresh request (see the package note on request_count).
+func (f *OpenFile) VerifyChannelSequence(reqCSN uint16, isModify bool) bool {
+	f.csMu.Lock()
+	defer f.csMu.Unlock()
+
+	// Seed the tracked sequence from the first request seen on this Open so an
+	// initial nonzero ChannelSequence is not misread as a failover.
+	if !f.channelSeqSet {
+		f.channelSeq = reqCSN
+		f.channelSeqSet = true
+		return true
+	}
+
+	// Full-width difference between the request's ChannelSequence and the one
+	// tracked for this Open, matching Samba: compute as plain integers (range
+	// -65535..65535), then treat a magnitude greater than 0x7FFF as a 16-bit
+	// wraparound of the client counter (an actual forward step) by flipping the
+	// sign. cmp == 0 → same channel; cmp > 0 → newer channel (failover);
+	// cmp < 0 → older/stale channel.
+	cmp := int32(reqCSN) - int32(f.channelSeq)
+	if cmp > 0x7FFF || cmp < -0x7FFF {
+		cmp = -cmp
+	}
+
+	switch {
+	case cmp == 0:
+		return true
+	case cmp > 0:
+		f.channelSeq = reqCSN
+		return true
+	case isModify:
+		// Stale ChannelSequence on a modifying op: reject.
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/adapter/smb/v2/handlers/channel_sequence_test.go
+++ b/internal/adapter/smb/v2/handlers/channel_sequence_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import "testing"
+
+// TestVerifyChannelSequence_SambaTable replays the exact ChannelSequence
+// table from Samba's source4/torture/smb2/replay.c test_channel_sequence_table
+// for a modifying opcode (WRITE/SET_INFO/IOCTL) and asserts the accept/reject
+// decision matches the upstream expected NT_STATUS at every step. This is the
+// authoritative spec for smb2.replay.channel-sequence.
+func TestVerifyChannelSequence_SambaTable(t *testing.T) {
+	// allow == true means the op is expected to succeed (NT_STATUS_OK);
+	// allow == false means it must be rejected (NT_STATUS_FILE_NOT_AVAILABLE).
+	steps := []struct {
+		csn   uint16
+		allow bool
+	}{
+		{csn: 0, allow: true},           // i0: seeds stored=0
+		{csn: 0x7fff + 1, allow: false}, // i1
+		{csn: 0x7fff + 2, allow: false}, // i2
+		{csn: 0x8000, allow: false},     // i3: csn_rand_high substitute (stale)
+		{csn: 0xffff, allow: false},     // i4
+		{csn: 0x7fff, allow: true},      // i5: advances stored=0x7fff
+		{csn: 0x7ffe, allow: false},     // i6
+		{csn: 0, allow: false},          // i7
+		{csn: 0, allow: false},          // i8: csn_rand_low substitute (stale)
+		{csn: 0x7fff + 1, allow: true},  // i9: advances stored=0x8000
+		{csn: 0xffff, allow: true},      // i10: advances stored=0xffff
+		{csn: 0, allow: true},           // i11: wrap-forward, advances stored=0
+		{csn: 1, allow: true},           // i12: advances stored=1
+		{csn: 0, allow: false},          // i13
+		{csn: 1, allow: true},           // i14
+		{csn: 0xffff, allow: false},     // i15
+	}
+
+	f := &OpenFile{}
+	for i, s := range steps {
+		got := f.VerifyChannelSequence(s.csn, true /*modify*/)
+		if got != s.allow {
+			t.Fatalf("step %d csn=0x%04x: got allow=%v, want %v (stored=0x%04x)",
+				i, s.csn, got, s.allow, f.channelSeq)
+		}
+	}
+}
+
+// TestVerifyChannelSequence_ReadAdvancesModifyRejects reproduces the core of
+// smb2.replay.replay4: a READ on an incremented ChannelSequence advances the
+// Open's tracked sequence, after which a WRITE that resends on the original
+// (now-stale) sequence must be rejected, while a READ on the stale sequence is
+// still allowed.
+func TestVerifyChannelSequence_ReadAdvancesModifyRejects(t *testing.T) {
+	f := &OpenFile{}
+
+	// Initial WRITE at csn=0 seeds the Open.
+	if !f.VerifyChannelSequence(0, true) {
+		t.Fatal("initial write at csn=0 should be allowed")
+	}
+	// READ at csn=1 (channel failover) advances the tracked sequence.
+	if !f.VerifyChannelSequence(1, false) {
+		t.Fatal("read at csn=1 should be allowed")
+	}
+	// WRITE resent at stale csn=0 must be rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("write at stale csn=0 should be rejected")
+	}
+	// SET_INFO at stale csn=0 must also be rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("set_info at stale csn=0 should be rejected")
+	}
+	// READ at stale csn=0 is allowed (read-only ops never reject).
+	if !f.VerifyChannelSequence(0, false) {
+		t.Fatal("read at stale csn=0 should be allowed")
+	}
+}
+
+// TestVerifyChannelSequence_ReplayResend covers the resend semantics from
+// replay4: a write resent on the correct (current) ChannelSequence is allowed,
+// and a write resent on a stale ChannelSequence is rejected. The
+// REPLAY_OPERATION flag does not alter the decision, so these assertions hold
+// for both replayed and fresh requests.
+func TestVerifyChannelSequence_ReplayResend(t *testing.T) {
+	f := &OpenFile{}
+
+	// Seed at csn=0, then advance to csn=5 via a write on the new channel.
+	if !f.VerifyChannelSequence(0, true) {
+		t.Fatal("seed write should be allowed")
+	}
+	if !f.VerifyChannelSequence(5, true) {
+		t.Fatal("write at csn=5 should be allowed")
+	}
+
+	// Write resent on the current sequence (csn=5) is allowed.
+	if !f.VerifyChannelSequence(5, true) {
+		t.Fatal("write resend on current csn should be allowed")
+	}
+	// Write resent on a stale sequence (csn=0) is rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("write resend on stale csn should be rejected")
+	}
+}
+
+// TestVerifyChannelSequence_NonSMB3GateNoop documents that a fresh Open seeds
+// from whatever the first request's ChannelSequence is, so an initial nonzero
+// sequence is not mistaken for a failover.
+func TestVerifyChannelSequence_SeedNonZero(t *testing.T) {
+	f := &OpenFile{}
+	if !f.VerifyChannelSequence(0x1234, true) {
+		t.Fatal("first modify at nonzero csn should seed and be allowed")
+	}
+	if f.channelSeq != 0x1234 {
+		t.Fatalf("expected seeded channelSeq=0x1234, got 0x%04x", f.channelSeq)
+	}
+	// A stale write below the seed is rejected.
+	if f.VerifyChannelSequence(0x1233, true) {
+		t.Fatal("write below seeded csn should be rejected")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -511,6 +511,23 @@ type OpenFile struct {
 	// does NOT consult this — those tests reconnect with a fresh ClientGuid.
 	ClientGUID [16]byte
 
+	// csMu guards the SMB3 channel-sequence tracking fields below. It is a
+	// dedicated lock (not the struct mu) so the verification step in the
+	// dispatch hot path never contends with QUERY_INFO/enumeration R-M-W.
+	csMu sync.Mutex
+
+	// channelSeq is the ChannelSequence number the server currently tracks
+	// for this Open (MS-SMB2 §3.3.5.2.10 Open.ChannelSequence). Advanced when
+	// a request arrives with a strictly newer ChannelSequence (a channel
+	// failover), used to reject stale modifying replays.
+	channelSeq uint16
+
+	// channelSeqSet records whether channelSeq has been initialized from a
+	// request yet. The first request on the Open seeds channelSeq with its
+	// own ChannelSequence so an initial nonzero CSN is not mistaken for a
+	// failover.
+	channelSeqSet bool
+
 	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
 	// (MS-FSCC 2.4.32). Servers track this per-handle so SET/GET via
 	// FilePositionInformation round-trips even though network filesystems


### PR DESCRIPTION
Implements basic SMB2/3 replay protection via **channel-sequence verification** (MS-SMB2 §3.3.5.2.10), the independent (non-durable-handle) subset of #749.

## Mechanism
- New `StatusFileNotAvailable` (0xC0000467).
- Each `OpenFile` tracks `Open.ChannelSequence` (`channelSeq`/`channelSeqSet`, guarded by a dedicated `csMu`).
- `OpenFile.VerifyChannelSequence` mirrors Samba's `smbd_smb2_request_dispatch_update_counts` (`source3/smbd/smb2_server.c`): a newer ChannelSequence advances the tracked value; a **stale** ChannelSequence on a **modifying** op (WRITE/SET_INFO/IOCTL) is rejected with `STATUS_FILE_NOT_AVAILABLE`; read-only ops never reject but still advance. Full-width 16-bit wraparound handling matches Samba's `abs(cmp) > 0x7FFF` sign-flip.
- The check runs centrally in both dispatch paths (`ProcessSingleRequest` and `ProcessRequestWithFileIDAndCallback`), gated to SMB3+ and to commands carrying a FileId at a fixed body offset (READ/WRITE/SET_INFO at 16, IOCTL at 8).
- The `SMB2_FLAGS_REPLAY_OPERATION` flag does not change the decision: in DittoFS each handle's I/O completes before the next request is verified, so Samba's `request_count`/`pre_request_count` gauges are always drained — the decision reduces to the ChannelSequence comparison, which is exactly what the torture tests observe.

## Tests targeted (honest confidence)
| Test | Confidence | Notes |
|------|-----------|-------|
| `smb2.replay.channel-sequence` | **HIGH** | Pure single-channel CSN validation. Unit test encodes the exact Samba `test_channel_sequence_table` and matches every expected status. |
| `smb2.replay.replay4` | **MEDIUM-HIGH** | Needs CSN tracking (this PR) + multi-channel session bind (already works). Unit test reproduces the read-advances / stale-write-rejects core. |
| `smb2.replay.replay5` | **N/A (skips)** | Requires `SMB2_CAP_PERSISTENT_HANDLES` + CA share, which DittoFS does not advertise -> `torture_skip`. |
| `smb2.replay.replay3` | **LOW** | Flaky per the issue; depends on the DH2Q CreateGuid replay cache in the fenced `create.go` path (not touched here). |
| `smb2.replay.replay6` | **OUT OF SCOPE** | Driven by DH2Q create de-dup semantics (`DUPLICATE_OBJECTID` without the replay flag) living in the fenced durable-create handler. |

## Scope / non-goals
- Does **not** touch `create.go` / `durable_*.go` (DH-create path owned by a concurrent PR).
- Does not implement the DH-V2-replay matrix (`replay-dhv2-*`, `pending*`).
- Related-compound ops (FlagRelated, inherited FileId) are intentionally not CSN-checked — they chain off a prior CREATE and use the sentinel FileId.

KNOWN_FAILURES.md is intentionally untouched; the CI smbtorture log is the source of truth for any walkback.

## Verification
- `go build ./...`, `go vet ./internal/adapter/smb/...`, `golangci-lint` — clean.
- `go test -race` on `internal/adapter/smb/...` — green, including the new unit tests.