### PR TITLE
fix(lock): cross-check SMB and NLM/NFSv4 byte-range maps (area-5 H-3 / xproto H1+H2)

### DIFF
--- a/.planning/v1.0-audit/PLAN.md
+++ b/.planning/v1.0-audit/PLAN.md
@@ -77,7 +77,8 @@ Each area gets PR-A (REVIEW.md) → triage → PR-B (fixes + simplifier + review
 | 2 | Syncer | ✅ folded into #1 | ✅ folded into #1 | "subset of #1"; engine+syncer covered by #677 PR-A + I-1/2/3 (`#713`/`#723`/`#735`) + B1 (`#840`). No standalone pass — covered. |
 | 4 | NFS handlers | ✅ **#844 MERGED** `2dd0e8b5` | — | 8 agents/3 batches: v3, v4-state, RPC/GSS, NLM/NSM/portmap, v4-types/XDR, 2nd-pass handlers, + DESIGN/perf/bloat/versions/interfaces. **19 HIGH/32 MED/33 LOW** + DESIGN-AUDIT.md. Invariants clean. Design rec: Option A auth-unify (PR-B0) → Option B collapse-dispatch; rewrite NOT warranted. Perf: top hotspot unsized bytes.Buffer compound.go:600 (27%). Bloat: ~1.3-2.4k LOC/~53 files removable. PR-B split in REVIEW §7. |
 | 3 | SMB handlers | ⏸ deferred | — | Active parallel conformance track (#843 + roadmap-v2 waves) collides with an audit pass; audit after conformance settles. |
-| 5–11 | Lock/ACL, Metadata, Runtime, Snapshot, Config, CLI, Operator | ⏳ queued | — | Per perf-leverage order. |
+| 5 | Lock manager + ACL | ✅ **#851 MERGED** `e302663d` | 🔄 PR-B1 `#852`+`#856` (persistence) + PR-B2 **`#860 MERGED`** `cfc2f7d1` (grace/reclaim) done; **PR-B3 two-store cross-scan in progress** | 3 HIGH/4 MED/12 LOW; ACL clean (0 HIGH). H-2 persistence + H-1 grace CLOSED. PR-B1: 4 review rounds/14 bugs/0 stayed-buggy (field-drop + ordering generators sealed). PR-B2: 3 HIGH found post-impl (orphan grace timer, NLM ClientID ephemeral-port, coordinator capture-vs-live) all fixed. PR-B3 closes H-3 (`lm.locks` vs `lm.unifiedLocks` never cross-checked) + xproto H1/H2. |
+| 6–11 | Metadata, Runtime, Snapshot, Config, CLI, Operator | ⏳ queued | — | Per perf-leverage order. |
 
 Real NFS LOC measured 2026-05-29 ≈ 56K (table's 52.9K was the Wave-0 estimate).
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1798,35 +1798,34 @@ func (sm *StateManager) TestLock(
 		Type:   mappedType,
 	}
 
-	// Query existing locks on this file
+	// TestUnifiedLock cross-checks the SMB byte-range map (lm.locks) too, so
+	// NFSv4 LOCKT reports the same conflict an actual LOCK would be denied by
+	// when an overlapping SMB byte-range lock exists (xproto H1).
 	handleKey := string(fileHandle)
-	existingLocks := sm.lockManager.ListUnifiedLocks(handleKey)
-
-	// Check each existing lock for conflict
-	for _, el := range existingLocks {
-		if lock.IsUnifiedLockConflicting(el, testLock) {
-			// Build LOCK4denied from the conflicting lock
-			var conflictType uint32
-			if el.Type == lock.LockTypeExclusive {
-				conflictType = types.WRITE_LT
-			} else {
-				conflictType = types.READ_LT
-			}
-
-			denied := &LOCK4denied{
-				Offset:   el.Offset,
-				Length:   el.Length,
-				LockType: conflictType,
-			}
-
-			// Parse OwnerID to extract clientID and ownerData
-			// Format: "nfs4:{clientid}:{owner_hex}"
-			denied.Owner.ClientID = 0    // Default
-			denied.Owner.OwnerData = nil // Default
-			parseConflictOwner(el.Owner.OwnerID, denied)
-
-			return denied, nil
+	conflict := sm.lockManager.TestUnifiedLock(handleKey, testLock)
+	if conflict != nil {
+		el := conflict.Lock
+		// Build LOCK4denied from the conflicting lock
+		var conflictType uint32
+		if el.Type == lock.LockTypeExclusive {
+			conflictType = types.WRITE_LT
+		} else {
+			conflictType = types.READ_LT
 		}
+
+		denied := &LOCK4denied{
+			Offset:   el.Offset,
+			Length:   el.Length,
+			LockType: conflictType,
+		}
+
+		// Parse OwnerID to extract clientID and ownerData
+		// Format: "nfs4:{clientid}:{owner_hex}"
+		denied.Owner.ClientID = 0    // Default
+		denied.Owner.OwnerData = nil // Default
+		parseConflictOwner(el.Owner.OwnerID, denied)
+
+		return denied, nil
 	}
 
 	return nil, nil

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -151,12 +151,11 @@ func (s *nlmService) TestLockNLM(
 
 	testLock := lock.NewUnifiedLock(owner, lock.FileHandle(handle), offset, length, lockTypeFromExclusive(exclusive))
 
+	// TestUnifiedLock cross-checks the SMB byte-range map too, so NLM TEST
+	// reports the same conflict LockFileNLM would enforce (xproto H1).
 	handleKey := string(handle)
-	existing := s.lockMgr.ListUnifiedLocks(handleKey)
-	for _, el := range existing {
-		if lock.IsUnifiedLockConflicting(el, testLock) {
-			return false, &lock.UnifiedLockConflict{Lock: el, Reason: "conflict"}, nil
-		}
+	if conflict := s.lockMgr.TestUnifiedLock(handleKey, testLock); conflict != nil {
+		return false, conflict, nil
 	}
 	return true, nil, nil
 }

--- a/pkg/metadata/lock/cross_store_test.go
+++ b/pkg/metadata/lock/cross_store_test.go
@@ -1,0 +1,193 @@
+package lock
+
+import "testing"
+
+// These tests pin area-5 H-3 / xproto H1+H2: SMB byte-range locks (lm.locks,
+// via Manager.Lock) and NLM/NFSv4 byte-range locks (lm.unifiedLocks, via
+// Manager.AddUnifiedLock) live in two separate maps. Each acquisition / IO path
+// must cross-check the other map so a lock taken via one protocol blocks a
+// conflicting lock or write via the other (MS-FSA §2.1.5).
+
+const xHandle = "share-a:file-1"
+
+func smbExclusive(openID string, offset, length uint64) FileLock {
+	return FileLock{OpenID: openID, SessionID: 7, Offset: offset, Length: length, Exclusive: true}
+}
+
+func nlmLock(ownerID string, offset, length uint64, exclusive bool) *UnifiedLock {
+	lt := LockTypeShared
+	if exclusive {
+		lt = LockTypeExclusive
+	}
+	return &UnifiedLock{
+		Owner:  LockOwner{OwnerID: ownerID},
+		Offset: offset, Length: length, Type: lt,
+	}
+}
+
+// TestCrossStore_NLMLockBlocksSMB: an NLM exclusive byte-range lock must block a
+// later overlapping SMB exclusive lock.
+func TestCrossStore_NLMLockBlocksSMB(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, true)); err != nil {
+		t.Fatalf("AddUnifiedLock (NLM) failed: %v", err)
+	}
+
+	err := lm.Lock(xHandle, smbExclusive("smb:open-1", 50, 100))
+	if err == nil {
+		t.Fatal("SMB lock overlapping an existing NLM exclusive lock must be denied")
+	}
+}
+
+// TestCrossStore_SMBLockBlocksNLM: an SMB exclusive byte-range lock must block a
+// later overlapping NLM lock.
+func TestCrossStore_SMBLockBlocksNLM(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.Lock(xHandle, smbExclusive("smb:open-1", 0, 100)); err != nil {
+		t.Fatalf("SMB Lock failed: %v", err)
+	}
+
+	err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 50, 100, true))
+	if err == nil {
+		t.Fatal("NLM lock overlapping an existing SMB exclusive lock must be denied")
+	}
+}
+
+// TestCrossStore_SharedRangesCoexist: two shared (read) byte-range locks from
+// different protocols on the same range must both be granted.
+func TestCrossStore_SharedRangesCoexist(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, false)); err != nil {
+		t.Fatalf("AddUnifiedLock (NLM shared) failed: %v", err)
+	}
+
+	// SMB shared lock on the same range.
+	smbShared := FileLock{OpenID: "smb:open-1", SessionID: 7, Offset: 0, Length: 100, Exclusive: false}
+	if err := lm.Lock(xHandle, smbShared); err != nil {
+		t.Fatalf("two cross-protocol shared locks on the same range must coexist, got %v", err)
+	}
+}
+
+// TestCrossStore_NonOverlappingCoexist: cross-protocol locks on disjoint ranges
+// never conflict.
+func TestCrossStore_NonOverlappingCoexist(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, true)); err != nil {
+		t.Fatalf("AddUnifiedLock failed: %v", err)
+	}
+	if err := lm.Lock(xHandle, smbExclusive("smb:open-1", 200, 100)); err != nil {
+		t.Fatalf("disjoint-range SMB lock must be granted, got %v", err)
+	}
+}
+
+// TestCrossStore_CheckForIO_NLMLockBlocksSMBWrite pins xproto H2: an NLM
+// exclusive byte-range lock must block an SMB write to the overlapping range.
+func TestCrossStore_CheckForIO_NLMLockBlocksSMBWrite(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, true)); err != nil {
+		t.Fatalf("AddUnifiedLock failed: %v", err)
+	}
+
+	conflict := lm.CheckForIO(xHandle, "smb:open-1", 7, 50, 10, true)
+	if conflict == nil {
+		t.Fatal("SMB write overlapping an NLM exclusive lock must be blocked (xproto H2)")
+	}
+}
+
+// TestCrossStore_CheckForIO_NLMSharedBlocksSMBWrite: a shared (read) NLM lock
+// blocks writes from a different protocol (mandatory-lock semantics), but not
+// reads.
+func TestCrossStore_CheckForIO_NLMSharedBlocksSMBWrite(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, false)); err != nil {
+		t.Fatalf("AddUnifiedLock failed: %v", err)
+	}
+
+	if c := lm.CheckForIO(xHandle, "smb:open-1", 7, 50, 10, true); c == nil {
+		t.Fatal("SMB write overlapping an NLM shared lock must be blocked")
+	}
+	if c := lm.CheckForIO(xHandle, "smb:open-1", 7, 50, 10, false); c != nil {
+		t.Fatal("SMB read overlapping an NLM shared lock must be allowed")
+	}
+}
+
+// TestCrossStore_LeaseDoesNotBlockByteRange: a whole-file lease in unifiedLocks
+// is a caching primitive resolved via the break path, not a byte-range lock,
+// and must not block a cross-protocol byte-range acquisition.
+func TestCrossStore_LeaseDoesNotBlockByteRange(t *testing.T) {
+	lm := NewManager()
+
+	lease := &UnifiedLock{
+		Owner: LockOwner{OwnerID: "smb:open-lease"},
+		Type:  LockTypeExclusive,
+		Lease: &OpLock{},
+	}
+	if err := lm.AddUnifiedLock(xHandle, lease); err != nil {
+		t.Fatalf("AddUnifiedLock (lease) failed: %v", err)
+	}
+
+	if err := lm.Lock(xHandle, smbExclusive("smb:open-1", 0, 100)); err != nil {
+		t.Fatalf("a whole-file lease must not block a byte-range lock, got %v", err)
+	}
+}
+
+// TestCrossStore_TestUnifiedLockSeesSMBLock pins the NLM/NFSv4 TEST (LOCKT)
+// path: TestUnifiedLock must report a conflict when an overlapping SMB
+// byte-range lock exists, matching what AddUnifiedLock would enforce. Without
+// the cross-store scan a LOCKT would falsely report the range grantable.
+func TestCrossStore_TestUnifiedLockSeesSMBLock(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.Lock(xHandle, smbExclusive("smb:open-1", 0, 100)); err != nil {
+		t.Fatalf("SMB Lock failed: %v", err)
+	}
+
+	conflict := lm.TestUnifiedLock(xHandle, nlmLock("nlm:host-a", 50, 10, true))
+	if conflict == nil {
+		t.Fatal("NLM/NFSv4 TEST must see an overlapping SMB byte-range lock (xproto H1)")
+	}
+
+	// A disjoint NLM range must report grantable.
+	if c := lm.TestUnifiedLock(xHandle, nlmLock("nlm:host-a", 500, 10, true)); c != nil {
+		t.Fatalf("disjoint NLM range must be grantable, got conflict %+v", c)
+	}
+}
+
+// TestCrossStore_ZeroByteSMBLockDoesNotBlockNLM: an SMB2 zero-byte lock has no
+// real byte range and must never block a cross-protocol NLM lock.
+func TestCrossStore_ZeroByteSMBLockDoesNotBlockNLM(t *testing.T) {
+	lm := NewManager()
+
+	zb := FileLock{OpenID: "smb:open-1", SessionID: 7, Offset: 10, Length: 0, Exclusive: true, IsZeroByte: true}
+	if err := lm.Lock(xHandle, zb); err != nil {
+		t.Fatalf("SMB zero-byte Lock failed: %v", err)
+	}
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, true)); err != nil {
+		t.Fatalf("a zero-byte SMB lock must not block an NLM lock, got %v", err)
+	}
+}
+
+// TestCrossStore_TestLockAgreesWithLock: the TestLock preview must report the
+// same cross-protocol conflict that Lock would enforce.
+func TestCrossStore_TestLockAgreesWithLock(t *testing.T) {
+	lm := NewManager()
+
+	if err := lm.AddUnifiedLock(xHandle, nlmLock("nlm:host-a", 0, 100, true)); err != nil {
+		t.Fatalf("AddUnifiedLock failed: %v", err)
+	}
+
+	conflict, err := lm.TestLock(xHandle, smbExclusive("smb:open-1", 50, 10))
+	if err != nil {
+		t.Fatalf("TestLock returned error: %v", err)
+	}
+	if conflict == nil {
+		t.Fatal("TestLock must report the cross-protocol conflict that Lock would enforce")
+	}
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -41,6 +41,9 @@ type LockManager interface {
 
 	// ListUnifiedLocks returns all unified locks on a file.
 	ListUnifiedLocks(handleKey string) []*UnifiedLock
+	// TestUnifiedLock previews whether a prospective NLM/NFSv4 byte-range lock
+	// would conflict, checking BOTH the unified and SMB byte-range maps.
+	TestUnifiedLock(handleKey string, want *UnifiedLock) *UnifiedLockConflict
 
 	// RemoveFileUnifiedLocks removes all unified locks for a file.
 	RemoveFileUnifiedLocks(handleKey string)
@@ -588,6 +591,80 @@ func conflictFrom(fl *FileLock) *LockConflict {
 	}
 }
 
+// Byte-range locks live in two maps that the protocol adapters populate
+// separately: SMB byte-range locks in lm.locks (Manager.Lock) and NLM/NFSv4
+// byte-range locks in lm.unifiedLocks (Manager.AddUnifiedLock). The helpers
+// below let each acquisition/IO path cross-check the OTHER map so a lock taken
+// via one protocol blocks a conflicting lock or write via the other
+// (MS-FSA §2.1.5 cross-protocol byte-range conflict). Without this an NFS lock
+// and an SMB lock on the same overlapping range could both be granted.
+
+// fileLockConflictsWithUnified reports whether an SMB byte-range FileLock and a
+// byte-range UnifiedLock on the same file conflict. Cross-protocol byte-range
+// locks are always different owners, so the test reduces to range overlap plus
+// exclusivity. Whole-file leases and delegations are caching primitives
+// resolved through the break path, not byte-range conflicts, so they never
+// participate; SMB2 zero-byte locks never conflict.
+func fileLockConflictsWithUnified(fl *FileLock, ul *UnifiedLock) bool {
+	if ul.IsLease() || ul.IsDelegation() {
+		return false
+	}
+	if fl.IsZeroByte {
+		return false
+	}
+	if !RangesOverlap(fl.Offset, fl.Length, ul.Offset, ul.Length) {
+		return false
+	}
+	// Two shared (read) locks coexist; an exclusive on either side conflicts.
+	return fl.Exclusive || ul.IsExclusive()
+}
+
+// unifiedLockBlocksIO reports whether a byte-range UnifiedLock held by another
+// protocol blocks an SMB I/O at [offset, length). Cross-protocol I/O is always
+// a different owner: a write is blocked by any overlapping lock; a read is
+// blocked only by an overlapping exclusive lock (MS-FSA §2.1.4.10).
+func unifiedLockBlocksIO(ul *UnifiedLock, offset, length uint64, isWrite bool) bool {
+	if ul.IsLease() || ul.IsDelegation() {
+		return false
+	}
+	if !ul.Overlaps(offset, length) {
+		return false
+	}
+	if isWrite {
+		return true
+	}
+	return ul.IsExclusive()
+}
+
+// conflictFromUnified renders a byte-range UnifiedLock as the LockConflict the
+// SMB byte-range path reports.
+func conflictFromUnified(ul *UnifiedLock) *LockConflict {
+	return &LockConflict{
+		Offset:    ul.Offset,
+		Length:    ul.Length,
+		Exclusive: ul.IsExclusive(),
+		OwnerID:   ul.Owner.OwnerID,
+	}
+}
+
+// unifiedConflictFromFileLock renders a conflicting SMB FileLock as the
+// UnifiedLockConflict the NLM/NFSv4 byte-range path reports.
+func unifiedConflictFromFileLock(fl *FileLock) *UnifiedLockConflict {
+	lt := LockTypeShared
+	if fl.Exclusive {
+		lt = LockTypeExclusive
+	}
+	return &UnifiedLockConflict{
+		Lock: &UnifiedLock{
+			Owner:  LockOwner{OwnerID: lockOwnerID(fl)},
+			Offset: fl.Offset,
+			Length: fl.Length,
+			Type:   lt,
+		},
+		Reason: "cross-protocol byte-range conflict",
+	}
+}
+
 // Manager manages byte-range file locks for SMB/NLM protocols.
 //
 // This is a shared, in-memory implementation that can be embedded in any
@@ -678,6 +755,14 @@ func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 	for i := range existing {
 		if IsLockConflicting(&existing[i], &lock) {
 			return NewLockedError("", conflictFrom(&existing[i]))
+		}
+	}
+
+	// Cross-protocol: an overlapping NLM/NFSv4 byte-range lock must also block
+	// this SMB lock (area-5 H-3 / xproto H1).
+	for _, ul := range lm.unifiedLocks[handleKey] {
+		if fileLockConflictsWithUnified(&lock, ul) {
+			return NewLockedError("", conflictFromUnified(ul))
 		}
 	}
 
@@ -840,6 +925,13 @@ func (lm *Manager) TestLock(handleKey string, lock FileLock) (*LockConflict, err
 		}
 	}
 
+	// Mirror Lock()'s cross-protocol check so the preview agrees with acquire.
+	for _, ul := range lm.unifiedLocks[handleKey] {
+		if fileLockConflictsWithUnified(&lock, ul) {
+			return conflictFromUnified(ul), nil
+		}
+	}
+
 	return nil, nil
 }
 
@@ -873,6 +965,15 @@ func (lm *Manager) CheckForIO(handleKey string, openID string, sessionID uint64,
 	for i := range existing {
 		if CheckIOConflict(&existing[i], openID, sessionID, offset, length, isWrite) {
 			return conflictFrom(&existing[i])
+		}
+	}
+
+	// Cross-protocol: a byte-range lock held via NLM/NFSv4 must also gate SMB
+	// I/O (xproto H2). Without this an NFS exclusive lock never blocks an SMB
+	// write to the same range.
+	for _, ul := range lm.unifiedLocks[handleKey] {
+		if unifiedLockBlocksIO(ul, offset, length, isWrite) {
+			return conflictFromUnified(ul)
 		}
 	}
 
@@ -1581,6 +1682,18 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 		}
 	}
 
+	// Cross-protocol: an overlapping SMB byte-range lock must also block this
+	// NLM/NFSv4 lock (area-5 H-3 / xproto H1). Skip for whole-file leases and
+	// delegations, which are not byte-range locks.
+	if !lock.IsLease() && !lock.IsDelegation() {
+		smbLocks := lm.locks[handleKey]
+		for i := range smbLocks {
+			if fileLockConflictsWithUnified(&smbLocks[i], lock) {
+				return NewLockConflictError("", unifiedConflictFromFileLock(&smbLocks[i]))
+			}
+		}
+	}
+
 	// Check if this exact lock already exists (same owner, offset, length)
 	// If so, update it (allows changing lock type)
 	for i, el := range existing {
@@ -1603,6 +1716,35 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 	// Add new lock
 	lm.unifiedLocks[handleKey] = append(existing, lock)
 	lm.persistUnifiedLockLocked(lock)
+	return nil
+}
+
+// TestUnifiedLock previews whether a prospective NLM/NFSv4 byte-range lock would
+// conflict, checking BOTH the unified lock map and the SMB byte-range map
+// (lm.locks). Returns the conflicting lock, or nil if grantable. This keeps the
+// NLM/NFSv4 TEST/LOCKT preview consistent with AddUnifiedLock enforcement: a
+// preview that only scanned unifiedLocks would report a range grantable while
+// an overlapping SMB byte-range lock in lm.locks would deny the acquire
+// (area-5 H-3 / xproto H1).
+func (lm *Manager) TestUnifiedLock(handleKey string, want *UnifiedLock) *UnifiedLockConflict {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	for _, el := range lm.unifiedLocks[handleKey] {
+		if want.ConflictsWith(el) {
+			return &UnifiedLockConflict{Lock: el, Reason: "lock conflict"}
+		}
+	}
+
+	if !want.IsLease() && !want.IsDelegation() {
+		smbLocks := lm.locks[handleKey]
+		for i := range smbLocks {
+			if fileLockConflictsWithUnified(&smbLocks[i], want) {
+				return unifiedConflictFromFileLock(&smbLocks[i])
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Area-5 PR-B3 — two-store byte-range cross-scan

Closes **area-5 H-3** + **xproto H1/H2**. Final HIGH from the lock-manager audit (#851).

### Problem
Byte-range locks live in **two maps** the protocol adapters populate separately:
- SMB → `lm.locks` (`Manager.Lock`), holding `FileLock`
- NLM/NFSv4 → `lm.unifiedLocks` (`Manager.AddUnifiedLock`), holding `*UnifiedLock` (also stores whole-file leases/delegations)

They were never cross-checked. Consequences (MS-FSA §2.1.5 violations):
- An NFS lock and an SMB lock on the same overlapping range could **both be granted**.
- An NFS exclusive lock **never blocked an SMB write** to the same range.
- NLM/NFSv4 `LOCKT`/TEST reported a range grantable when an SMB lock would deny it.

### Fix
Each acquisition / IO / preview path now scans the **other** map:
| Path | Added cross-scan |
|------|------------------|
| `Lock` / `TestLock` | scan `unifiedLocks` |
| `CheckForIO` | scan `unifiedLocks` → NLM lock gates SMB writes (**H2**) |
| `AddUnifiedLock` | scan `lm.locks` |
| new `Manager.TestUnifiedLock` | checks **both** maps; `TestLockNLM` + NFSv4 `TestLock` route through it so LOCKT/TEST agrees with LOCK |

Cross-protocol owners are always distinct → conflict = range overlap + exclusivity. Whole-file **leases/delegations** are caching primitives (break path), never participate; SMB2 **zero-byte** locks never conflict.

### Scope note
The NFS **WRITE** path does not call `CheckForIO`, so NFS writes are still not gated by SMB byte-range locks *via the IO path* (pre-existing; NFS byte-range locking is advisory per POSIX). Acquisition-time cross-conflict **is** enforced for both directions.

### Review discipline
Adversarial reviewer found 1 real gap (NLM/v4 TEST bypassing the cross-scan) — **fixed** via `TestUnifiedLock`; 4 candidate findings self-refuted on code read. Simplifier: clean. 10 cross-store tests; `go test -race ./pkg/metadata/lock/...` + nlm + v4-state suites green; vet + lint clean.