### PR TITLE
feat(smb/replay): DH2Q durable-V2 create-replay protection (#749)

### DIFF
--- a/internal/adapter/smb/channel_sequence.go
+++ b/internal/adapter/smb/channel_sequence.go
@@ -1,0 +1,80 @@
+package smb
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// channelSeqModify reports whether a command is a modifying operation for the
+// purposes of SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10). Only
+// WRITE, SET_INFO, and IOCTL are rejected on a stale ChannelSequence; all
+// other commands are read-only with respect to this check (Samba marks the
+// same three with .modify = true in source3/smbd/smb2_server.c).
+func channelSeqModify(cmd types.Command) bool {
+	switch cmd {
+	case types.CommandWrite, types.CommandSetInfo, types.CommandIoctl:
+		return true
+	default:
+		return false
+	}
+}
+
+// channelSeqFileID extracts the 16-byte FileId from a request body for the
+// handle-scoped commands that participate in channel-sequence verification.
+// The body slice excludes the 64-byte SMB2 header. Returns ok=false for
+// commands that do not carry a FileId at a fixed offset (the check is skipped
+// for those). FileId offsets per MS-SMB2: READ §2.2.19 / WRITE §2.2.21 /
+// SET_INFO §2.2.39 all place it 16 bytes into the body; IOCTL §2.2.31 places
+// it 8 bytes in (after StructureSize, Reserved, CtlCode).
+func channelSeqFileID(cmd types.Command, body []byte) (fileID [16]byte, ok bool) {
+	var off int
+	switch cmd {
+	case types.CommandRead, types.CommandWrite, types.CommandSetInfo:
+		off = 16
+	case types.CommandIoctl:
+		off = 8
+	default:
+		return fileID, false
+	}
+	if len(body) < off+16 {
+		return fileID, false
+	}
+	copy(fileID[:], body[off:off+16])
+	return fileID, true
+}
+
+// verifyChannelSequence runs the SMB3 channel-sequence check (MS-SMB2
+// §3.3.5.2.10) for a handle-scoped request. It returns the status the dispatch
+// path should reject with (StatusFileNotAvailable) when a modifying operation
+// arrives on a stale ChannelSequence, or 0 when the request may proceed.
+//
+// The check is a no-op for non-SMB3 connections, for commands without a
+// FileId, and when the target Open is unknown (handle-not-found is left to the
+// handler to report with its own status). Read-only commands never reject but
+// still advance the tracked sequence so a following modifying op observes the
+// up-to-date value.
+func verifyChannelSequence(reqHeader *header.SMB2Header, body []byte, connInfo *ConnInfo) types.Status {
+	if connInfo.CryptoState == nil || connInfo.CryptoState.GetDialect() < types.Dialect0300 {
+		return 0
+	}
+
+	fileID, ok := channelSeqFileID(reqHeader.Command, body)
+	if !ok {
+		return 0
+	}
+
+	openFile, ok := connInfo.Handler.GetOpenFile(fileID)
+	if !ok {
+		return 0
+	}
+
+	// The ChannelSequence occupies the low 16 bits of the 4-byte
+	// ChannelSequence/Reserved field, which the header parser surfaces as
+	// Status in requests (MS-SMB2 §2.2.1.2).
+	reqCSN := uint16(uint32(reqHeader.Status) & 0xFFFF)
+
+	if openFile.VerifyChannelSequence(reqCSN, channelSeqModify(reqHeader.Command)) {
+		return 0
+	}
+	return types.StatusFileNotAvailable
+}

--- a/internal/adapter/smb/channel_sequence_test.go
+++ b/internal/adapter/smb/channel_sequence_test.go
@@ -1,0 +1,57 @@
+package smb
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+func TestChannelSeqModify(t *testing.T) {
+	modify := []types.Command{types.CommandWrite, types.CommandSetInfo, types.CommandIoctl}
+	for _, c := range modify {
+		if !channelSeqModify(c) {
+			t.Errorf("command %s should be a modifying op", c)
+		}
+	}
+	nonModify := []types.Command{
+		types.CommandRead, types.CommandCreate, types.CommandClose,
+		types.CommandFlush, types.CommandLock, types.CommandQueryInfo,
+	}
+	for _, c := range nonModify {
+		if channelSeqModify(c) {
+			t.Errorf("command %s should not be a modifying op", c)
+		}
+	}
+}
+
+func TestChannelSeqFileID(t *testing.T) {
+	want := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+
+	// READ/WRITE/SET_INFO place the FileId 16 bytes into the body.
+	body16 := make([]byte, 64)
+	copy(body16[16:32], want[:])
+	for _, c := range []types.Command{types.CommandRead, types.CommandWrite, types.CommandSetInfo} {
+		got, ok := channelSeqFileID(c, body16)
+		if !ok || got != want {
+			t.Errorf("%s: got (%v, %v), want (%v, true)", c, got, ok, want)
+		}
+	}
+
+	// IOCTL places the FileId 8 bytes into the body.
+	bodyIoctl := make([]byte, 64)
+	copy(bodyIoctl[8:24], want[:])
+	got, ok := channelSeqFileID(types.CommandIoctl, bodyIoctl)
+	if !ok || got != want {
+		t.Errorf("ioctl: got (%v, %v), want (%v, true)", got, ok, want)
+	}
+
+	// Commands without a fixed FileId offset are skipped.
+	if _, ok := channelSeqFileID(types.CommandCreate, body16); ok {
+		t.Error("CREATE should not yield a FileId for channel-sequence")
+	}
+
+	// Bodies too short to hold the FileId are rejected.
+	if _, ok := channelSeqFileID(types.CommandWrite, make([]byte, 20)); ok {
+		t.Error("short WRITE body should not yield a FileId")
+	}
+}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -113,6 +113,16 @@ func ProcessSingleRequest(
 		return SendErrorResponse(reqHeader, errStatus, connInfo)
 	}
 
+	// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10): reject a
+	// modifying op (WRITE/SET_INFO/IOCTL) that resends on a stale
+	// ChannelSequence after a channel failover.
+	if errStatus := verifyChannelSequence(reqHeader, body, connInfo); errStatus != 0 {
+		logger.Debug("Channel-sequence verification rejected request",
+			"command", reqHeader.Command.String(),
+			"messageID", reqHeader.MessageID)
+		return SendErrorResponse(reqHeader, errStatus, connInfo)
+	}
+
 	// Wire async slot accounting for max_async_credits enforcement (MS-SMB2 §3.3.5.2.5).
 	handlerCtx.TryReserveAsync = connInfo.TryReserveAsync
 	handlerCtx.ReleaseAsync = connInfo.ReleaseAsync
@@ -381,6 +391,15 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
+		return &HandlerResult{Status: errStatus, Data: MakeErrorBody()}, fileID, handlerCtx
+	}
+
+	// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10), same as the
+	// non-compound path: reject a stale modifying replay before dispatch.
+	if errStatus := verifyChannelSequence(reqHeader, body, connInfo); errStatus != 0 {
+		logger.Debug("Channel-sequence verification rejected compound request",
+			"command", reqHeader.Command.String(),
+			"messageID", reqHeader.MessageID)
 		return &HandlerResult{Status: errStatus, Data: MakeErrorBody()}, fileID, handlerCtx
 	}
 

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -239,6 +239,16 @@ const (
 	// its ChannelSequence — the server rejects the stale write rather than
 	// re-applying it out of order.
 	StatusFileNotAvailable Status = 0xC0000467
+
+	// StatusDuplicateObjectid indicates a CREATE arrived carrying a
+	// DH2Q CreateGuid that matches an open the server is still tracking
+	// in its CREATE replay cache, but WITHOUT SMB2_FLAGS_REPLAY_OPERATION
+	// set. A second non-replay CREATE for an in-flight CreateGuid is a
+	// protocol violation (MS-SMB2 §3.3.5.9.12; Samba returns
+	// NT_STATUS_DUPLICATE_OBJECTID from smb2srv_open_lookup_replay_cache
+	// in source3/smbd/smb2_create.c). Required by smbtorture
+	// smb2.replay.replay-dhv2-* duplicate-CreateGuid coverage.
+	StatusDuplicateObjectid Status = 0xC000022A
 )
 
 // String returns a human-readable name for the status code.
@@ -268,6 +278,8 @@ func (s Status) String() string {
 		return "STATUS_BUFFER_OVERFLOW"
 	case StatusFileNotAvailable:
 		return "STATUS_FILE_NOT_AVAILABLE"
+	case StatusDuplicateObjectid:
+		return "STATUS_DUPLICATE_OBJECTID"
 	case StatusObjectNameInvalid:
 		return "STATUS_OBJECT_NAME_INVALID"
 	case StatusObjectNameNotFound:

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -230,6 +230,15 @@ const (
 	// connection's signing algorithm is not GMAC (MS-SMB2 §3.3.5.5.2; Samba
 	// source3/smbd/smb2_sesssetup.c:724-729).
 	StatusRequestOutOfSequence Status = 0xC000042A
+
+	// StatusFileNotAvailable indicates a modifying operation (WRITE,
+	// SET_INFO, IOCTL) carried a stale ChannelSequence number relative to
+	// the one the server tracks for the target Open. Returned during SMB3
+	// channel-sequence verification (MS-SMB2 §3.3.5.2.10) when the client
+	// resends an operation on a previously-failed channel without advancing
+	// its ChannelSequence — the server rejects the stale write rather than
+	// re-applying it out of order.
+	StatusFileNotAvailable Status = 0xC0000467
 )
 
 // String returns a human-readable name for the status code.
@@ -257,6 +266,8 @@ func (s Status) String() string {
 		return "STATUS_ACCESS_DENIED"
 	case StatusBufferOverflow:
 		return "STATUS_BUFFER_OVERFLOW"
+	case StatusFileNotAvailable:
+		return "STATUS_FILE_NOT_AVAILABLE"
 	case StatusObjectNameInvalid:
 		return "STATUS_OBJECT_NAME_INVALID"
 	case StatusObjectNameNotFound:

--- a/internal/adapter/smb/v2/handlers/channel_sequence.go
+++ b/internal/adapter/smb/v2/handlers/channel_sequence.go
@@ -1,0 +1,80 @@
+package handlers
+
+// SMB3 channel-sequence verification (MS-SMB2 §3.3.5.2.10).
+//
+// When a client's channel to the server fails, it reconnects (binding a new
+// channel to the same session) and resends operations that may have been
+// in-flight, marking the resend SMB2_FLAGS_REPLAY_OPERATION. To keep the
+// resend from being applied a second time out of order, every request carries
+// a 16-bit ChannelSequence number that the client increments on each channel
+// failover. The server tracks the latest ChannelSequence it has seen per Open
+// (Open.ChannelSequence) and uses it to decide whether a request is fresh, a
+// legitimate failover, or a stale resend on a channel the client has already
+// moved past.
+//
+// Only the three modifying operations — WRITE, SET_INFO, IOCTL — are rejected
+// on a stale ChannelSequence (with STATUS_FILE_NOT_AVAILABLE). Read-only
+// operations are always allowed; they still advance Open.ChannelSequence when
+// they carry a newer one so a subsequent modifying op sees the up-to-date
+// value. This mirrors Samba's smbd_smb2_request_dispatch_update_counts in
+// source3/smbd/smb2_server.c.
+//
+// Samba additionally maintains per-Open request_count / pre_request_count
+// gauges to defer replay acceptance while requests on a prior ChannelSequence
+// are still in flight. DittoFS processes each request to completion before the
+// next on a handle is dispatched (no cross-channel reordering of a single
+// handle's I/O), so those gauges are always drained by the time the following
+// request is verified; the decision then reduces to the ChannelSequence
+// comparison alone, which is what the channel-sequence and replay4 torture
+// tests observe.
+
+// VerifyChannelSequence applies the MS-SMB2 §3.3.5.2.10 channel-sequence check
+// to a request targeting this Open and advances the tracked sequence.
+//
+//   - reqCSN:   the ChannelSequence from the request header (low 16 bits of the
+//     SMB2 ChannelSequence/Reserved field).
+//   - isModify: whether the command is a modifying op (WRITE, SET_INFO, IOCTL).
+//
+// It returns false when the request must be rejected with
+// STATUS_FILE_NOT_AVAILABLE; true when it may proceed.
+//
+// The SMB2_FLAGS_REPLAY_OPERATION flag does not change the decision: a replay
+// of a stale modifying op is exactly the out-of-order resend the check exists
+// to suppress, and a replay on the current/newer sequence is accepted on the
+// same terms as a fresh request (see the package note on request_count).
+func (f *OpenFile) VerifyChannelSequence(reqCSN uint16, isModify bool) bool {
+	f.csMu.Lock()
+	defer f.csMu.Unlock()
+
+	// Seed the tracked sequence from the first request seen on this Open so an
+	// initial nonzero ChannelSequence is not misread as a failover.
+	if !f.channelSeqSet {
+		f.channelSeq = reqCSN
+		f.channelSeqSet = true
+		return true
+	}
+
+	// Full-width difference between the request's ChannelSequence and the one
+	// tracked for this Open, matching Samba: compute as plain integers (range
+	// -65535..65535), then treat a magnitude greater than 0x7FFF as a 16-bit
+	// wraparound of the client counter (an actual forward step) by flipping the
+	// sign. cmp == 0 → same channel; cmp > 0 → newer channel (failover);
+	// cmp < 0 → older/stale channel.
+	cmp := int32(reqCSN) - int32(f.channelSeq)
+	if cmp > 0x7FFF || cmp < -0x7FFF {
+		cmp = -cmp
+	}
+
+	switch {
+	case cmp == 0:
+		return true
+	case cmp > 0:
+		f.channelSeq = reqCSN
+		return true
+	case isModify:
+		// Stale ChannelSequence on a modifying op: reject.
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/adapter/smb/v2/handlers/channel_sequence_test.go
+++ b/internal/adapter/smb/v2/handlers/channel_sequence_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import "testing"
+
+// TestVerifyChannelSequence_SambaTable replays the exact ChannelSequence
+// table from Samba's source4/torture/smb2/replay.c test_channel_sequence_table
+// for a modifying opcode (WRITE/SET_INFO/IOCTL) and asserts the accept/reject
+// decision matches the upstream expected NT_STATUS at every step. This is the
+// authoritative spec for smb2.replay.channel-sequence.
+func TestVerifyChannelSequence_SambaTable(t *testing.T) {
+	// allow == true means the op is expected to succeed (NT_STATUS_OK);
+	// allow == false means it must be rejected (NT_STATUS_FILE_NOT_AVAILABLE).
+	steps := []struct {
+		csn   uint16
+		allow bool
+	}{
+		{csn: 0, allow: true},           // i0: seeds stored=0
+		{csn: 0x7fff + 1, allow: false}, // i1
+		{csn: 0x7fff + 2, allow: false}, // i2
+		{csn: 0x8000, allow: false},     // i3: csn_rand_high substitute (stale)
+		{csn: 0xffff, allow: false},     // i4
+		{csn: 0x7fff, allow: true},      // i5: advances stored=0x7fff
+		{csn: 0x7ffe, allow: false},     // i6
+		{csn: 0, allow: false},          // i7
+		{csn: 0, allow: false},          // i8: csn_rand_low substitute (stale)
+		{csn: 0x7fff + 1, allow: true},  // i9: advances stored=0x8000
+		{csn: 0xffff, allow: true},      // i10: advances stored=0xffff
+		{csn: 0, allow: true},           // i11: wrap-forward, advances stored=0
+		{csn: 1, allow: true},           // i12: advances stored=1
+		{csn: 0, allow: false},          // i13
+		{csn: 1, allow: true},           // i14
+		{csn: 0xffff, allow: false},     // i15
+	}
+
+	f := &OpenFile{}
+	for i, s := range steps {
+		got := f.VerifyChannelSequence(s.csn, true /*modify*/)
+		if got != s.allow {
+			t.Fatalf("step %d csn=0x%04x: got allow=%v, want %v (stored=0x%04x)",
+				i, s.csn, got, s.allow, f.channelSeq)
+		}
+	}
+}
+
+// TestVerifyChannelSequence_ReadAdvancesModifyRejects reproduces the core of
+// smb2.replay.replay4: a READ on an incremented ChannelSequence advances the
+// Open's tracked sequence, after which a WRITE that resends on the original
+// (now-stale) sequence must be rejected, while a READ on the stale sequence is
+// still allowed.
+func TestVerifyChannelSequence_ReadAdvancesModifyRejects(t *testing.T) {
+	f := &OpenFile{}
+
+	// Initial WRITE at csn=0 seeds the Open.
+	if !f.VerifyChannelSequence(0, true) {
+		t.Fatal("initial write at csn=0 should be allowed")
+	}
+	// READ at csn=1 (channel failover) advances the tracked sequence.
+	if !f.VerifyChannelSequence(1, false) {
+		t.Fatal("read at csn=1 should be allowed")
+	}
+	// WRITE resent at stale csn=0 must be rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("write at stale csn=0 should be rejected")
+	}
+	// SET_INFO at stale csn=0 must also be rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("set_info at stale csn=0 should be rejected")
+	}
+	// READ at stale csn=0 is allowed (read-only ops never reject).
+	if !f.VerifyChannelSequence(0, false) {
+		t.Fatal("read at stale csn=0 should be allowed")
+	}
+}
+
+// TestVerifyChannelSequence_ReplayResend covers the resend semantics from
+// replay4: a write resent on the correct (current) ChannelSequence is allowed,
+// and a write resent on a stale ChannelSequence is rejected. The
+// REPLAY_OPERATION flag does not alter the decision, so these assertions hold
+// for both replayed and fresh requests.
+func TestVerifyChannelSequence_ReplayResend(t *testing.T) {
+	f := &OpenFile{}
+
+	// Seed at csn=0, then advance to csn=5 via a write on the new channel.
+	if !f.VerifyChannelSequence(0, true) {
+		t.Fatal("seed write should be allowed")
+	}
+	if !f.VerifyChannelSequence(5, true) {
+		t.Fatal("write at csn=5 should be allowed")
+	}
+
+	// Write resent on the current sequence (csn=5) is allowed.
+	if !f.VerifyChannelSequence(5, true) {
+		t.Fatal("write resend on current csn should be allowed")
+	}
+	// Write resent on a stale sequence (csn=0) is rejected.
+	if f.VerifyChannelSequence(0, true) {
+		t.Fatal("write resend on stale csn should be rejected")
+	}
+}
+
+// TestVerifyChannelSequence_NonSMB3GateNoop documents that a fresh Open seeds
+// from whatever the first request's ChannelSequence is, so an initial nonzero
+// sequence is not mistaken for a failover.
+func TestVerifyChannelSequence_SeedNonZero(t *testing.T) {
+	f := &OpenFile{}
+	if !f.VerifyChannelSequence(0x1234, true) {
+		t.Fatal("first modify at nonzero csn should seed and be allowed")
+	}
+	if f.channelSeq != 0x1234 {
+		t.Fatalf("expected seeded channelSeq=0x1234, got 0x%04x", f.channelSeq)
+	}
+	// A stale write below the seed is rejected.
+	if f.VerifyChannelSequence(0x1233, true) {
+		t.Fatal("write below seeded csn should be rejected")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -490,20 +490,13 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
-	// SMB3 replay protection (MS-SMB2 §3.3.5.9 step 5; §2.2.1.2 REPLAY_OPERATION).
-	// When FLAGS_REPLAY_OPERATION is set on a CREATE carrying a
-	// DH2Q with a non-zero CreateGuid, the client is retransmitting
-	// a request whose original response was lost. The server MUST
-	// return the cached response — otherwise the legitimate retry
-	// trips STATUS_SHARING_VIOLATION (the original open is still
-	// alive on the server) and the DH2Q CREATE pattern is unusable
-	// over flaky multichannel topologies (smbtorture
-	// smb2.replay.replay-dhv2-*).
-	//
-	// The cache is scoped per-session and bounded by a short TTL; a
-	// miss falls through to the normal CREATE path, which on
-	// success records the response into the cache for the next
-	// replay window.
+	// SMB3 DH2Q replay protection (MS-SMB2 §3.3.5.9; §2.2.1.2
+	// REPLAY_OPERATION). A CREATE whose DH2Q CreateGuid matches a live
+	// open is resolved here — replayed (with the original FileId and the
+	// open's current lease/oplock state), rejected as a duplicate, or
+	// failed fast while the original is still parked. A miss falls through
+	// to the normal CREATE path, which records the response on success.
+	// See resolveCreateReplay for the full per-case contract.
 	if resp, handled := h.resolveCreateReplay(ctx, req); handled {
 		return resp, nil
 	}
@@ -1535,17 +1528,20 @@ func (h *Handler) resolveCreateReplay(ctx *SMBHandlerContext, req *CreateRequest
 		return nil, false
 	}
 
-	// A replay that arrives while the original CREATE for this CreateGuid
-	// is still parked on a pending oplock/lease break must fail fast with
-	// STATUS_FILE_NOT_AVAILABLE rather than block on the same break (Samba
-	// FWP_RESERVED/FILE_NOT_AVAILABLE slot states). The original (parked)
-	// request keeps running and completes on its own timeline.
-	if ctx.IsReplay && h.CreateReplayCache.IsReserved(ctx.SessionID, createGuid) {
-		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileNotAvailable}}, true
-	}
-
 	entry := h.CreateReplayCache.LookupEntry(ctx.SessionID, createGuid)
 	if entry == nil {
+		// No completed entry yet. A replay that arrives while the original
+		// CREATE for this CreateGuid is still parked on a pending
+		// oplock/lease break must fail fast with STATUS_FILE_NOT_AVAILABLE
+		// rather than block on the same break (Samba FWP_RESERVED /
+		// FILE_NOT_AVAILABLE slot states). The original parked request keeps
+		// running and completes on its own timeline. Checked after the
+		// completed-entry lookup so a parked CREATE that has just finished
+		// (entry present, reservation not yet cleared) replays the open
+		// rather than returning FILE_NOT_AVAILABLE.
+		if ctx.IsReplay && h.CreateReplayCache.IsReserved(ctx.SessionID, createGuid) {
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileNotAvailable}}, true
+		}
 		return nil, false
 	}
 
@@ -1615,11 +1611,18 @@ func (h *Handler) refreshReplayLease(ctx *SMBHandlerContext, req *CreateRequest,
 	if !found {
 		return types.StatusSuccess
 	}
+	// resp is a shallow copy of the cached response, so resp.CreateContexts
+	// still shares the cached entry's backing array. Clone the slice before
+	// rewriting an element so we never mutate (or race another replay on)
+	// the cached entry. rewriteLeaseResponseState itself returns fresh bytes.
 	for i := range resp.CreateContexts {
 		if resp.CreateContexts[i].Name != LeaseContextTagResponse {
 			continue
 		}
-		resp.CreateContexts[i].Data = rewriteLeaseResponseState(resp.CreateContexts[i].Data, state, epoch)
+		contexts := make([]CreateContext, len(resp.CreateContexts))
+		copy(contexts, resp.CreateContexts)
+		contexts[i].Data = rewriteLeaseResponseState(contexts[i].Data, state, epoch)
+		resp.CreateContexts = contexts
 		break
 	}
 	return types.StatusSuccess

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"path"
@@ -503,12 +504,8 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// miss falls through to the normal CREATE path, which on
 	// success records the response into the cache for the next
 	// replay window.
-	if cached := h.lookupCreateReplay(ctx, req); cached != nil {
-		// Return a shallow copy so the caller can stamp per-response
-		// fields without mutating the cache entry (the encoder reads
-		// fields verbatim).
-		resp := *cached
-		return &resp, nil
+	if resp, handled := h.resolveCreateReplay(ctx, req); handled {
+		return resp, nil
 	}
 
 	// TWrp (SMB2_CREATE_TIMEWARP_TOKEN, MS-SMB2 §2.2.13.2.7) requests a
@@ -1499,22 +1496,158 @@ func (h *Handler) storeCreateReplayIfApplicable(ctx *SMBHandlerContext, req *Cre
 	if createGuid == ([16]byte{}) {
 		return
 	}
-	h.CreateReplayCache.Store(ctx.SessionID, createGuid, resp)
+	// These bypass paths (pipe / open-root) have no lease- or oplock-bearing
+	// Open to refresh on replay, so the cached snapshot is replayed verbatim.
+	h.CreateReplayCache.Store(ctx.SessionID, createGuid, resp, nil)
 }
 
-// lookupCreateReplay returns a cached CREATE response when the request
-// carries SMB2_FLAGS_REPLAY_OPERATION and a matching DH2Q CreateGuid is
-// still in the per-session cache (MS-SMB2 §3.3.5.9 replay handling).
-// Returns nil on miss; caller falls through to the normal CREATE path.
-func (h *Handler) lookupCreateReplay(ctx *SMBHandlerContext, req *CreateRequest) *CreateResponse {
-	if !ctx.IsReplay || h.CreateReplayCache == nil {
-		return nil
+// resolveCreateReplay applies the SMB3 DH2Q CreateGuid de-duplication
+// contract (MS-SMB2 §3.3.5.9; Samba smb2srv_open_lookup_replay_cache +
+// the replay block in source3/smbd/smb2_create.c). It returns
+// (resp, true) when the CREATE has been handled by the replay path and
+// the caller must return resp verbatim; (nil, false) when the request
+// should fall through to the normal CREATE path.
+//
+// Three outcomes for a CREATE whose DH2Q CreateGuid matches a live open
+// in the per-session cache:
+//
+//   - FLAGS_REPLAY_OPERATION set → replay. The original open is returned
+//     (same FileId). The lease/oplock state in the response is rebuilt
+//     from the CURRENT open state, not the create-time snapshot, so a
+//     lease upgraded after the original CREATE replays back the upgraded
+//     state (replay-dhv2-lease1/2). Lease replays additionally validate
+//     against the live open: a replay request carrying a lease whose key
+//     differs from the open's, or replaying a lease over an open that is
+//     not lease-backed, returns ACCESS_DENIED (replay-dhv2-lease3 /
+//     oplock-lease).
+//
+//   - FLAGS_REPLAY_OPERATION clear but CreateGuid matches a cached open →
+//     DUPLICATE_OBJECTID. A second non-replay CREATE for an in-flight
+//     CreateGuid is a protocol violation.
+//
+//   - No cache match → fall through.
+func (h *Handler) resolveCreateReplay(ctx *SMBHandlerContext, req *CreateRequest) (*CreateResponse, bool) {
+	if h.CreateReplayCache == nil {
+		return nil, false
 	}
 	createGuid := dh2qCreateGuid(req)
 	if createGuid == ([16]byte{}) {
-		return nil
+		return nil, false
 	}
-	return h.CreateReplayCache.Lookup(ctx.SessionID, createGuid)
+
+	// A replay that arrives while the original CREATE for this CreateGuid
+	// is still parked on a pending oplock/lease break must fail fast with
+	// STATUS_FILE_NOT_AVAILABLE rather than block on the same break (Samba
+	// FWP_RESERVED/FILE_NOT_AVAILABLE slot states). The original (parked)
+	// request keeps running and completes on its own timeline.
+	if ctx.IsReplay && h.CreateReplayCache.IsReserved(ctx.SessionID, createGuid) {
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileNotAvailable}}, true
+	}
+
+	entry := h.CreateReplayCache.LookupEntry(ctx.SessionID, createGuid)
+	if entry == nil {
+		return nil, false
+	}
+
+	// A duplicate CreateGuid without the replay flag is rejected
+	// (MS-SMB2 §3.3.5.9.12 / Samba NT_STATUS_DUPLICATE_OBJECTID).
+	if !ctx.IsReplay {
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDuplicateObjectid}}, true
+	}
+
+	// Shallow copy so per-response stamping never mutates the cache entry.
+	resp := *entry.Response
+
+	// Lease replays are validated and state-refreshed against the live
+	// open. Non-lease (plain oplock) replays return the cached response
+	// verbatim: Samba echoes the request's oplock level back on replay
+	// without touching the held oplock, which the cached snapshot already
+	// reflects (replay-dhv2-oplock1/2/3).
+	if status := h.refreshReplayLease(ctx, req, entry, &resp); status != types.StatusSuccess {
+		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, true
+	}
+	return &resp, true
+}
+
+// refreshReplayLease applies Samba's replay-with-lease rules to a DH2Q
+// CREATE replay (the `if (state->rqls != NULL)` block in
+// source3/smbd/smb2_create.c). When the replay request carries an RqLs
+// (lease) context it:
+//
+//   - requires the live open to be lease-backed (else ACCESS_DENIED);
+//   - requires the replay's lease key to equal the open's (else
+//     ACCESS_DENIED);
+//   - rewrites the lease response context to the CURRENT lease state and
+//     epoch read from the LeaseManager, so an upgrade applied after the
+//     original CREATE is reflected on replay.
+//
+// It returns StatusSuccess when the response may be returned (possibly
+// mutated) or the ACCESS_DENIED status to reject with. A replay request
+// without a lease context, or an entry with no associated open, is a
+// no-op success — the cached snapshot stands.
+func (h *Handler) refreshReplayLease(ctx *SMBHandlerContext, req *CreateRequest, entry *CachedCreateResponse, resp *CreateResponse) types.Status {
+	leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest)
+	if leaseCtx == nil || entry.OpenFile == nil {
+		return types.StatusSuccess
+	}
+	lcc, err := DecodeLeaseCreateContext(leaseCtx.Data)
+	if err != nil {
+		// Malformed lease context on a replay is treated like the
+		// non-lease path (the cached snapshot stands); the original
+		// CREATE already validated the lease.
+		return types.StatusSuccess
+	}
+
+	open := entry.OpenFile
+
+	// Samba: replay with a lease is only allowed against an open that
+	// itself holds a lease, and only with the same lease key.
+	if open.OplockLevel != OplockLevelLease || open.LeaseKey != lcc.LeaseKey {
+		return types.StatusAccessDenied
+	}
+
+	// Refresh the RqLs response context to the open's CURRENT lease state
+	// (e.g. RH→RWH after a later upgrading CREATE on the same key).
+	if h.LeaseManager == nil {
+		return types.StatusSuccess
+	}
+	state, epoch, found := h.LeaseManager.GetLeaseState(ctx.Context, open.LeaseKey)
+	if !found {
+		return types.StatusSuccess
+	}
+	for i := range resp.CreateContexts {
+		if resp.CreateContexts[i].Name != LeaseContextTagResponse {
+			continue
+		}
+		resp.CreateContexts[i].Data = rewriteLeaseResponseState(resp.CreateContexts[i].Data, state, epoch)
+		break
+	}
+	return types.StatusSuccess
+}
+
+// rewriteLeaseResponseState patches the LeaseState (and, for a V2
+// response, the Epoch) of an already-encoded RqLs response context in
+// place without disturbing the lease key, flags, parent key, or wire
+// version. Both the V1 (32-byte) and V2 (52-byte) layouts place the
+// 32-bit LeaseState at offset 16; the V2 layout places the 16-bit Epoch
+// at offset 48 (MS-SMB2 §2.2.14.2.10). A buffer too short for either
+// layout is returned unchanged. It returns a fresh slice so the cached
+// entry's bytes are never mutated.
+func rewriteLeaseResponseState(data []byte, state uint32, epoch uint16) []byte {
+	const (
+		leaseStateOff = 16
+		v2EpochOff    = 48
+	)
+	if len(data) < leaseStateOff+4 {
+		return data
+	}
+	out := make([]byte, len(data))
+	copy(out, data)
+	binary.LittleEndian.PutUint32(out[leaseStateOff:leaseStateOff+4], state)
+	if len(out) >= v2EpochOff+2 {
+		binary.LittleEndian.PutUint16(out[v2EpochOff:v2EpochOff+2], epoch)
+	}
+	return out
 }
 
 // dh2qCreateGuid extracts the CreateGuid from a CREATE request's

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1156,7 +1156,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// durable opens carry a CreateGuid — V1 / non-durable CREATEs
 	// rely on the in-flight MessageID dedup at the framing layer.
 	if h.CreateReplayCache != nil && openFile != nil && openFile.CreateGuid != ([16]byte{}) {
-		h.CreateReplayCache.Store(openFile.SessionID, openFile.CreateGuid, resp)
+		h.CreateReplayCache.Store(openFile.SessionID, openFile.CreateGuid, resp, openFile)
 	}
 
 	return resp
@@ -1229,8 +1229,24 @@ func (h *Handler) parkCreateOnLeaseBreak(
 	shareName := d.tree.ShareName
 	messageID := ctx.MessageID
 
+	// Reserve the DH2Q CreateGuid for the lifetime of the parked CREATE so a
+	// replayed CREATE on the same CreateGuid fails fast with
+	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break
+	// (smbtorture replay-dhv2-pending* / *-vs-{oplock,lease}). Released by
+	// the resume goroutine when the original reaches a terminal state. A
+	// zero CreateGuid (non-V2 / no DH2Q) is a no-op in Reserve/Release.
+	replayGuid := dh2qCreateGuid(d.req)
+	if h.CreateReplayCache != nil {
+		h.CreateReplayCache.Reserve(ctx.SessionID, replayGuid)
+	}
+
 	go func() {
 		defer cancel()
+		defer func() {
+			if h.CreateReplayCache != nil {
+				h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
+			}
+		}()
 
 		// Wait for the other-key break to drain (or timeout auto-downgrade).
 		// Errors here are logged but not propagated: on timeout the lease

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -511,6 +511,23 @@ type OpenFile struct {
 	// does NOT consult this — those tests reconnect with a fresh ClientGuid.
 	ClientGUID [16]byte
 
+	// csMu guards the SMB3 channel-sequence tracking fields below. It is a
+	// dedicated lock (not the struct mu) so the verification step in the
+	// dispatch hot path never contends with QUERY_INFO/enumeration R-M-W.
+	csMu sync.Mutex
+
+	// channelSeq is the ChannelSequence number the server currently tracks
+	// for this Open (MS-SMB2 §3.3.5.2.10 Open.ChannelSequence). Advanced when
+	// a request arrives with a strictly newer ChannelSequence (a channel
+	// failover), used to reject stale modifying replays.
+	channelSeq uint16
+
+	// channelSeqSet records whether channelSeq has been initialized from a
+	// request yet. The first request on the Open seeds channelSeq with its
+	// own ChannelSequence so an initial nonzero CSN is not mistaken for a
+	// failover.
+	channelSeqSet bool
+
 	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
 	// (MS-FSCC 2.4.32). Servers track this per-handle so SET/GET via
 	// FilePositionInformation round-trips even though network filesystems

--- a/internal/adapter/smb/v2/handlers/replay_cache.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache.go
@@ -55,33 +55,101 @@ const maxCreateReplayEntries = 4096
 // access FileID for compound-chain FileID propagation. SessionID is
 // recorded so session teardown can flush related entries and so a
 // CreateGuid collision across sessions cannot hijack another open.
+//
+// OpenFile references the live Open established by the original CREATE.
+// A replayed DH2Q CREATE must reflect the CURRENT state of that Open,
+// not a create-time snapshot — Samba rebuilds the lease response from
+// op->compat->lease->lease (source3/smbd/smb2_create.c). In particular
+// a lease that was upgraded (RH→RWH) by a later CREATE on the same key
+// must replay back the upgraded state (smbtorture replay-dhv2-lease1/2).
+// The reference also carries the original oplock type and lease key so
+// the replay path can apply Samba's lease/oplock-mismatch ACCESS_DENIED
+// gates (replay-dhv2-lease3 / oplock-lease).
 type CachedCreateResponse struct {
 	SessionID uint64
 	Response  *CreateResponse
+	OpenFile  *OpenFile
 	StoredAt  time.Time
+}
+
+// reserveKey scopes an in-progress CreateGuid reservation per session,
+// so a CreateGuid collision across sessions cannot make one session's
+// parked CREATE shadow another's.
+type reserveKey struct {
+	SessionID  uint64
+	CreateGuid [16]byte
 }
 
 // CreateReplayCache stores CREATE responses keyed by DH2Q CreateGuid
 // so a replayed CREATE (FLAGS_REPLAY_OPERATION) returns the original
 // result instead of re-executing. CreateGuid is client-generated and
 // globally unique per durable open, so it is sufficient as the key.
+//
+// It also tracks CreateGuids whose original CREATE is still in progress
+// — parked on a pending oplock/lease break (MS-SMB2 §3.3.5.9). A replay
+// that arrives while the original is still parked must return
+// STATUS_FILE_NOT_AVAILABLE immediately rather than block or time out
+// (smbtorture smb2.replay.replay-dhv2-pending* / *-vs-{oplock,lease}).
+// Samba models this with the FWP_RESERVED / FILE_NOT_AVAILABLE slot
+// states in smb2srv_open_lookup_replay_cache.
 type CreateReplayCache struct {
-	mu      sync.Mutex
-	entries map[[16]byte]*CachedCreateResponse
+	mu       sync.Mutex
+	entries  map[[16]byte]*CachedCreateResponse
+	reserved map[reserveKey]struct{}
 }
 
 // NewCreateReplayCache builds an empty cache.
 func NewCreateReplayCache() *CreateReplayCache {
 	return &CreateReplayCache{
-		entries: make(map[[16]byte]*CachedCreateResponse),
+		entries:  make(map[[16]byte]*CachedCreateResponse),
+		reserved: make(map[reserveKey]struct{}),
 	}
+}
+
+// Reserve marks a CreateGuid as having an in-progress (parked) original
+// CREATE for the given session. While reserved, a replayed CREATE for
+// the same CreateGuid resolves to STATUS_FILE_NOT_AVAILABLE. A zero
+// CreateGuid is ignored.
+func (c *CreateReplayCache) Reserve(sessionID uint64, createGuid [16]byte) {
+	if createGuid == ([16]byte{}) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reserved[reserveKey{SessionID: sessionID, CreateGuid: createGuid}] = struct{}{}
+}
+
+// Release clears an in-progress reservation once the parked CREATE has
+// reached a terminal state (success stored, or failed). Idempotent.
+func (c *CreateReplayCache) Release(sessionID uint64, createGuid [16]byte) {
+	if createGuid == ([16]byte{}) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.reserved, reserveKey{SessionID: sessionID, CreateGuid: createGuid})
+}
+
+// IsReserved reports whether a CreateGuid's original CREATE is currently
+// parked for the given session.
+func (c *CreateReplayCache) IsReserved(sessionID uint64, createGuid [16]byte) bool {
+	if createGuid == ([16]byte{}) {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.reserved[reserveKey{SessionID: sessionID, CreateGuid: createGuid}]
+	return ok
 }
 
 // Store records the response for a successful V2 CREATE keyed by
 // CreateGuid. Only success responses are cached — a replayed failed
 // CREATE should run through the normal handler path and may even
-// succeed the second time.
-func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *CreateResponse) {
+// succeed the second time. openFile is the live Open the CREATE
+// established; it is consulted on replay to rebuild the current
+// lease/oplock state (may be nil for paths that have no Open, in which
+// case the cached snapshot is replayed verbatim).
+func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *CreateResponse, openFile *OpenFile) {
 	if createGuid == ([16]byte{}) || resp == nil || resp.Status != types.StatusSuccess {
 		return
 	}
@@ -91,6 +159,7 @@ func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *C
 	c.entries[createGuid] = &CachedCreateResponse{
 		SessionID: sessionID,
 		Response:  resp,
+		OpenFile:  openFile,
 		StoredAt:  time.Now(),
 	}
 }
@@ -100,6 +169,18 @@ func (c *CreateReplayCache) Store(sessionID uint64, createGuid [16]byte, resp *C
 // session — a different session's CreateGuid collision (vanishingly
 // unlikely but possible) must not hijack another session's open.
 func (c *CreateReplayCache) Lookup(sessionID uint64, createGuid [16]byte) *CreateResponse {
+	if e := c.LookupEntry(sessionID, createGuid); e != nil {
+		return e.Response
+	}
+	return nil
+}
+
+// LookupEntry returns the full cache entry (response + live Open) for
+// the given CreateGuid + session, or nil on miss/expiry. The create
+// path uses this to rebuild the current lease/oplock state on replay
+// and to distinguish a replay (FLAGS_REPLAY_OPERATION set) from a
+// duplicate non-replay CREATE (→ DUPLICATE_OBJECTID).
+func (c *CreateReplayCache) LookupEntry(sessionID uint64, createGuid [16]byte) *CachedCreateResponse {
 	if createGuid == ([16]byte{}) {
 		return nil
 	}
@@ -113,7 +194,7 @@ func (c *CreateReplayCache) Lookup(sessionID uint64, createGuid [16]byte) *Creat
 		delete(c.entries, createGuid)
 		return nil
 	}
-	return entry.Response
+	return entry
 }
 
 // Forget drops the cached entry for CreateGuid. Called when the open
@@ -137,6 +218,11 @@ func (c *CreateReplayCache) ForgetSession(sessionID uint64) {
 	for k, e := range c.entries {
 		if e.SessionID == sessionID {
 			delete(c.entries, k)
+		}
+	}
+	for k := range c.reserved {
+		if k.SessionID == sessionID {
+			delete(c.reserved, k)
 		}
 	}
 }

--- a/internal/adapter/smb/v2/handlers/replay_cache_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache_test.go
@@ -11,7 +11,7 @@ func TestCreateReplayCache_StoreLookup(t *testing.T) {
 	c := NewCreateReplayCache()
 	guid := [16]byte{1, 2, 3, 4}
 	resp := &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}
-	c.Store(42, guid, resp)
+	c.Store(42, guid, resp, nil)
 	if got := c.Lookup(42, guid); got != resp {
 		t.Fatalf("Lookup returned %v, want %v", got, resp)
 	}
@@ -20,7 +20,7 @@ func TestCreateReplayCache_StoreLookup(t *testing.T) {
 func TestCreateReplayCache_LookupWrongSession(t *testing.T) {
 	c := NewCreateReplayCache()
 	guid := [16]byte{1}
-	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
 	if c.Lookup(2, guid) != nil {
 		t.Fatal("Lookup across sessions must miss")
 	}
@@ -29,7 +29,7 @@ func TestCreateReplayCache_LookupWrongSession(t *testing.T) {
 func TestCreateReplayCache_ZeroGuidIgnored(t *testing.T) {
 	c := NewCreateReplayCache()
 	zero := [16]byte{}
-	c.Store(1, zero, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(1, zero, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
 	if c.Len() != 0 {
 		t.Fatal("zero CreateGuid must not be stored")
 	}
@@ -41,7 +41,7 @@ func TestCreateReplayCache_ZeroGuidIgnored(t *testing.T) {
 func TestCreateReplayCache_NonSuccessNotCached(t *testing.T) {
 	c := NewCreateReplayCache()
 	guid := [16]byte{7}
-	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}})
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil)
 	if c.Len() != 0 {
 		t.Fatal("non-success response must not be cached")
 	}
@@ -50,7 +50,7 @@ func TestCreateReplayCache_NonSuccessNotCached(t *testing.T) {
 func TestCreateReplayCache_TTLExpiry(t *testing.T) {
 	c := NewCreateReplayCache()
 	guid := [16]byte{9}
-	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
 	// Force expiry by rewriting StoredAt
 	c.mu.Lock()
 	c.entries[guid].StoredAt = time.Now().Add(-2 * replayCacheTTL)
@@ -63,7 +63,7 @@ func TestCreateReplayCache_TTLExpiry(t *testing.T) {
 func TestCreateReplayCache_Forget(t *testing.T) {
 	c := NewCreateReplayCache()
 	guid := [16]byte{3}
-	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(1, guid, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
 	c.Forget(guid)
 	if c.Len() != 0 {
 		t.Fatal("Forget must drop entry")
@@ -73,14 +73,58 @@ func TestCreateReplayCache_Forget(t *testing.T) {
 func TestCreateReplayCache_ForgetSession(t *testing.T) {
 	c := NewCreateReplayCache()
 	g1, g2 := [16]byte{1}, [16]byte{2}
-	c.Store(10, g1, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
-	c.Store(20, g2, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}})
+	c.Store(10, g1, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
+	c.Store(20, g2, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil)
 	c.ForgetSession(10)
 	if c.Lookup(10, g1) != nil {
 		t.Fatal("ForgetSession should drop session 10 entry")
 	}
 	if c.Lookup(20, g2) == nil {
 		t.Fatal("ForgetSession should leave other session entries")
+	}
+}
+
+func TestCreateReplayCache_Reservation(t *testing.T) {
+	c := NewCreateReplayCache()
+	guid := [16]byte{0x5A}
+
+	if c.IsReserved(1, guid) {
+		t.Fatal("fresh cache must not report a reservation")
+	}
+	c.Reserve(1, guid)
+	if !c.IsReserved(1, guid) {
+		t.Fatal("Reserve must make IsReserved true")
+	}
+	// Reservation is per-session.
+	if c.IsReserved(2, guid) {
+		t.Fatal("reservation must be scoped to its session")
+	}
+	c.Release(1, guid)
+	if c.IsReserved(1, guid) {
+		t.Fatal("Release must clear the reservation")
+	}
+}
+
+func TestCreateReplayCache_ZeroGuidReservationIgnored(t *testing.T) {
+	c := NewCreateReplayCache()
+	zero := [16]byte{}
+	c.Reserve(1, zero)
+	if c.IsReserved(1, zero) {
+		t.Fatal("zero CreateGuid must never be reserved")
+	}
+}
+
+func TestCreateReplayCache_ForgetSessionClearsReservations(t *testing.T) {
+	c := NewCreateReplayCache()
+	g1, g2 := [16]byte{1}, [16]byte{2}
+	c.Reserve(10, g1)
+	c.Reserve(20, g2)
+	c.ForgetSession(10)
+	if c.IsReserved(10, g1) {
+		t.Fatal("ForgetSession must clear reservations for that session")
+	}
+	if !c.IsReserved(20, g2) {
+		t.Fatal("ForgetSession must leave other sessions' reservations")
 	}
 }
 

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -1,0 +1,312 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// encodeDH2QContext builds a 32-byte SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2
+// payload carrying the given CreateGuid (offset 16), matching DecodeDH2QRequest.
+func encodeDH2QContext(createGuid [16]byte) []byte {
+	buf := make([]byte, 32)
+	copy(buf[16:32], createGuid[:])
+	return buf
+}
+
+// dh2qCreateReq builds a CREATE request carrying a DH2Q context with createGuid
+// and, when leaseCtx is non-nil, an RqLs request context.
+func dh2qCreateReq(createGuid [16]byte, leaseCtx []byte) *CreateRequest {
+	req := &CreateRequest{
+		CreateContexts: []CreateContext{
+			{Name: DurableHandleV2RequestTag, Data: encodeDH2QContext(createGuid)},
+		},
+	}
+	if leaseCtx != nil {
+		req.CreateContexts = append(req.CreateContexts,
+			CreateContext{Name: LeaseContextTagRequest, Data: leaseCtx})
+	}
+	return req
+}
+
+// leaseResponseStateFromResp reads the LeaseState out of the RqLs response
+// context of a CreateResponse (offset 16, uint32 LE). Returns (0, false) when
+// no RqLs response context is present.
+func leaseResponseStateFromResp(resp *CreateResponse) (uint32, bool) {
+	for i := range resp.CreateContexts {
+		if resp.CreateContexts[i].Name == LeaseContextTagResponse {
+			data := resp.CreateContexts[i].Data
+			if len(data) < 20 {
+				return 0, false
+			}
+			return binary.LittleEndian.Uint32(data[16:20]), true
+		}
+	}
+	return 0, false
+}
+
+func TestRewriteLeaseResponseState_V2(t *testing.T) {
+	leaseKey := [16]byte{0x11, 0x22}
+	// Original encoded V2 response at RH (0x3), epoch 5.
+	orig := (&LeaseResponseContext{
+		LeaseKey:   leaseKey,
+		LeaseState: lock.LeaseStateRead | lock.LeaseStateHandle,
+		Epoch:      5,
+	}).Encode()
+
+	out := rewriteLeaseResponseState(orig, lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle, 9)
+
+	if got := binary.LittleEndian.Uint32(out[16:20]); got != 0x7 {
+		t.Fatalf("rewritten state = 0x%x, want RWH (0x7)", got)
+	}
+	if got := binary.LittleEndian.Uint16(out[48:50]); got != 9 {
+		t.Fatalf("rewritten epoch = %d, want 9", got)
+	}
+	// Lease key must be preserved.
+	for i := 0; i < 16; i++ {
+		if out[i] != orig[i] {
+			t.Fatalf("lease key byte %d changed: got 0x%x want 0x%x", i, out[i], orig[i])
+		}
+	}
+	// Source slice must not be mutated.
+	if binary.LittleEndian.Uint32(orig[16:20]) != 0x3 {
+		t.Fatal("rewriteLeaseResponseState mutated its input")
+	}
+}
+
+func TestRewriteLeaseResponseState_V1NoEpoch(t *testing.T) {
+	// 32-byte V1 layout: rewrite state but never touch bytes past the buffer.
+	v1 := make([]byte, LeaseV1ContextSize)
+	binary.LittleEndian.PutUint32(v1[16:20], 0x3)
+	out := rewriteLeaseResponseState(v1, 0x7, 9)
+	if got := binary.LittleEndian.Uint32(out[16:20]); got != 0x7 {
+		t.Fatalf("V1 rewritten state = 0x%x, want 0x7", got)
+	}
+	if len(out) != LeaseV1ContextSize {
+		t.Fatalf("V1 buffer length changed: %d", len(out))
+	}
+}
+
+// newReplayTestHandler builds a Handler wired with a real LeaseManager and an
+// empty CreateReplayCache, plus the backing lock Manager for direct lease
+// grants.
+func newReplayTestHandler() (*Handler, *lock.Manager, *lease.LeaseManager) {
+	mgr := lock.NewManager()
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+	h := &Handler{
+		LeaseManager:      leaseMgr,
+		CreateReplayCache: NewCreateReplayCache(),
+	}
+	return h, mgr, leaseMgr
+}
+
+// newReplayCtx builds an SMBHandlerContext with the replay flag set as given.
+func newReplayCtx(sessionID uint64, isReplay bool) *SMBHandlerContext {
+	c := NewSMBHandlerContext(context.Background(), "test", sessionID, 1, 1)
+	c.IsReplay = isReplay
+	return c
+}
+
+// TestResolveCreateReplay_DuplicateObjectid: a non-replay CREATE whose
+// CreateGuid matches a cached open returns STATUS_DUPLICATE_OBJECTID.
+func TestResolveCreateReplay_DuplicateObjectid(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0xAB, 0xCD}
+
+	h.CreateReplayCache.Store(sessionID,
+		guid,
+		&CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}},
+		&OpenFile{},
+	)
+
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, false), dh2qCreateReq(guid, nil))
+	if !handled {
+		t.Fatal("non-replay duplicate CreateGuid must be handled")
+	}
+	if resp.Status != types.StatusDuplicateObjectid {
+		t.Fatalf("status = %s, want STATUS_DUPLICATE_OBJECTID", resp.Status)
+	}
+}
+
+// TestResolveCreateReplay_PendingFileNotAvailable: a replay arriving while the
+// original CREATE for the CreateGuid is still parked returns
+// STATUS_FILE_NOT_AVAILABLE.
+func TestResolveCreateReplay_PendingFileNotAvailable(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x01, 0x02, 0x03}
+
+	h.CreateReplayCache.Reserve(sessionID, guid)
+
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	if !handled {
+		t.Fatal("replay against a reserved (parked) CreateGuid must be handled")
+	}
+	if resp.Status != types.StatusFileNotAvailable {
+		t.Fatalf("status = %s, want STATUS_FILE_NOT_AVAILABLE", resp.Status)
+	}
+
+	// Once the original completes (reservation released), the same replay
+	// falls through (no cached entry yet) rather than returning FILE_NOT_AVAILABLE.
+	h.CreateReplayCache.Release(sessionID, guid)
+	if _, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil)); handled {
+		t.Fatal("after release with no cached entry the replay must fall through")
+	}
+}
+
+// TestResolveCreateReplay_OplockSnapshot: a plain (non-lease) oplock replay
+// returns the cached snapshot verbatim — covers replay-dhv2-oplock1/3.
+func TestResolveCreateReplay_OplockSnapshot(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x09}
+
+	cached := &CreateResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		OplockLevel:     OplockLevelBatch,
+		FileID:          [16]byte{0xDE, 0xAD},
+	}
+	h.CreateReplayCache.Store(sessionID, guid, cached,
+		&OpenFile{OplockLevel: OplockLevelBatch})
+
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	if !handled {
+		t.Fatal("oplock replay must be handled")
+	}
+	if resp.Status != types.StatusSuccess || resp.OplockLevel != OplockLevelBatch {
+		t.Fatalf("oplock replay = (%s, 0x%x), want (SUCCESS, BATCH)", resp.Status, resp.OplockLevel)
+	}
+	if resp.FileID != cached.FileID {
+		t.Fatal("oplock replay must return the original FileID")
+	}
+}
+
+// grantRWHLease seeds the LeaseManager with an RWH lease for leaseKey and
+// returns the live OpenFile representing the original lease open.
+func grantRWHLease(t *testing.T, leaseMgr *lease.LeaseManager, leaseKey [16]byte, sessionID uint64) *OpenFile {
+	t.Helper()
+	ctx := context.Background()
+	fh := lock.FileHandle("file-1")
+	rwh := lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle
+	reqCtx := encodeV2LeaseContext(leaseKey, rwh, 1)
+	resp, err := ProcessLeaseCreateContext(ctx, leaseMgr, reqCtx, fh, sessionID, [16]byte{}, "smb:7", "share1", false)
+	if err != nil {
+		t.Fatalf("granting RWH lease failed: %v", err)
+	}
+	if resp.LeaseState != rwh {
+		t.Fatalf("granted lease state 0x%x, want RWH (0x7)", resp.LeaseState)
+	}
+	return &OpenFile{
+		SessionID:   sessionID,
+		OplockLevel: OplockLevelLease,
+		LeaseKey:    leaseKey,
+	}
+}
+
+// TestResolveCreateReplay_LeaseReturnsCurrentState: the original CREATE
+// returned RH (0x3); the lease was later upgraded to RWH (0x7). The replay must
+// return the CURRENT upgraded state, not the create-time snapshot
+// (replay-dhv2-lease1/2, replay.c:918 "lease_state 0x7 should not be 0x3").
+func TestResolveCreateReplay_LeaseReturnsCurrentState(t *testing.T) {
+	h, _, leaseMgr := newReplayTestHandler()
+	const sessionID = uint64(7)
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+
+	open := grantRWHLease(t, leaseMgr, leaseKey, sessionID)
+
+	// Cache a response whose RqLs context encodes the ORIGINAL RH (0x3).
+	cached := &CreateResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		OplockLevel:     OplockLevelLease,
+		CreateContexts: []CreateContext{{
+			Name: LeaseContextTagResponse,
+			Data: (&LeaseResponseContext{
+				LeaseKey:   leaseKey,
+				LeaseState: lock.LeaseStateRead | lock.LeaseStateHandle, // RH 0x3
+				Epoch:      1,
+			}).Encode(),
+		}},
+	}
+	h.CreateReplayCache.Store(sessionID, leaseKey16Guid(leaseKey), cached, open)
+
+	// Replay the original RH request.
+	rhReq := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateHandle, 1)
+	resp, handled := h.resolveCreateReplay(
+		newReplayCtx(sessionID, true),
+		dh2qCreateReq(leaseKey16Guid(leaseKey), rhReq),
+	)
+	if !handled {
+		t.Fatal("lease replay must be handled")
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("lease replay status = %s, want SUCCESS", resp.Status)
+	}
+	state, ok := leaseResponseStateFromResp(resp)
+	if !ok {
+		t.Fatal("lease replay response missing RqLs context")
+	}
+	rwh := lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle
+	if state != rwh {
+		t.Fatalf("replay lease_state = 0x%x, want CURRENT RWH (0x7) not snapshot RH (0x3)", state)
+	}
+}
+
+// TestResolveCreateReplay_LeaseKeyMismatch: a replay carrying a different
+// lease key than the open returns ACCESS_DENIED (replay-dhv2-lease3).
+func TestResolveCreateReplay_LeaseKeyMismatch(t *testing.T) {
+	h, _, leaseMgr := newReplayTestHandler()
+	const sessionID = uint64(7)
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+	open := grantRWHLease(t, leaseMgr, leaseKey, sessionID)
+
+	cached := &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}, OplockLevel: OplockLevelLease}
+	h.CreateReplayCache.Store(sessionID, leaseKey16Guid(leaseKey), cached, open)
+
+	otherKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	mismatchReq := encodeV2LeaseContext(otherKey, lock.LeaseStateRead|lock.LeaseStateHandle, 1)
+	resp, handled := h.resolveCreateReplay(
+		newReplayCtx(sessionID, true),
+		dh2qCreateReq(leaseKey16Guid(leaseKey), mismatchReq),
+	)
+	if !handled {
+		t.Fatal("lease-key-mismatch replay must be handled")
+	}
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("status = %s, want STATUS_ACCESS_DENIED", resp.Status)
+	}
+}
+
+// TestResolveCreateReplay_OplockReplayedAsLease: the original open is an oplock
+// (not a lease); a replay carrying a lease context returns ACCESS_DENIED
+// (replay-dhv2-oplock-lease).
+func TestResolveCreateReplay_OplockReplayedAsLease(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x42}
+
+	cached := &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}, OplockLevel: OplockLevelBatch}
+	h.CreateReplayCache.Store(sessionID, guid, cached, &OpenFile{OplockLevel: OplockLevelBatch})
+
+	leaseReq := encodeV2LeaseContext([16]byte{0x55}, lock.LeaseStateRead|lock.LeaseStateHandle, 1)
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, leaseReq))
+	if !handled {
+		t.Fatal("oplock-replayed-as-lease must be handled")
+	}
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("status = %s, want STATUS_ACCESS_DENIED", resp.Status)
+	}
+}
+
+// leaseKey16Guid reuses a lease key's bytes as a distinct CreateGuid for tests
+// (the two are independent identifiers; reusing keeps the fixtures compact).
+func leaseKey16Guid(leaseKey [16]byte) [16]byte {
+	var g [16]byte
+	copy(g[:], leaseKey[:])
+	g[15] ^= 0xFF // perturb so guid != leaseKey, exercising independence
+	return g
+}

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -256,6 +256,51 @@ func TestResolveCreateReplay_LeaseReturnsCurrentState(t *testing.T) {
 	}
 }
 
+// TestResolveCreateReplay_LeaseReplayDoesNotMutateCache: a lease replay that
+// refreshes the response state must not mutate the cached entry's stored
+// bytes (the shallow-copy shares the CreateContexts backing array). A second
+// replay must still observe the original cached snapshot as its starting point
+// and re-derive the current state.
+func TestResolveCreateReplay_LeaseReplayDoesNotMutateCache(t *testing.T) {
+	h, _, leaseMgr := newReplayTestHandler()
+	const sessionID = uint64(7)
+	leaseKey := [16]byte{0xAA, 0xBB, 0xCC}
+	open := grantRWHLease(t, leaseMgr, leaseKey, sessionID)
+
+	origData := (&LeaseResponseContext{
+		LeaseKey:   leaseKey,
+		LeaseState: lock.LeaseStateRead | lock.LeaseStateHandle, // RH 0x3
+		Epoch:      1,
+	}).Encode()
+	cached := &CreateResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		OplockLevel:     OplockLevelLease,
+		CreateContexts:  []CreateContext{{Name: LeaseContextTagResponse, Data: origData}},
+	}
+	guid := leaseKey16Guid(leaseKey)
+	h.CreateReplayCache.Store(sessionID, guid, cached, open)
+
+	rhReq := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateHandle, 1)
+	for i := 0; i < 2; i++ {
+		resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, rhReq))
+		if !handled {
+			t.Fatalf("replay %d not handled", i)
+		}
+		state, ok := leaseResponseStateFromResp(resp)
+		if !ok || state != lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle {
+			t.Fatalf("replay %d state = 0x%x, want RWH (0x7)", i, state)
+		}
+	}
+
+	// Cached snapshot bytes must be untouched (still RH 0x3).
+	if got := binary.LittleEndian.Uint32(origData[16:20]); got != 0x3 {
+		t.Fatalf("cached response bytes mutated: state = 0x%x, want RH (0x3)", got)
+	}
+	if cached.CreateContexts[0].Data[16] != origData[16] {
+		t.Fatal("cached entry's context Data was swapped")
+	}
+}
+
 // TestResolveCreateReplay_LeaseKeyMismatch: a replay carrying a different
 // lease key than the open returns ACCESS_DENIED (replay-dhv2-lease3).
 func TestResolveCreateReplay_LeaseKeyMismatch(t *testing.T) {


### PR DESCRIPTION
Implements SMB2/3 **durable-V2 (DH2Q) CREATE replay protection** (MS-SMB2 §3.3.5.9; modelled on Samba `smb2srv_open_lookup_replay_cache` + the replay block in `source3/smbd/smb2_create.c`). Targets the `smb2.replay.replay-dhv2-*` matrix (#749).

Builds on / **supersedes #864** (SMB3 channel-sequence verification) — this branch was cut from `feat/smb-basic-replay-protection-749`, so its range against `develop` includes #864's commit. Merging this closes out both.

## Mechanisms

1. **DH2Q create-replay cache (state-restoring).** A CREATE whose DH2Q `CreateGuid` matches a live open is no longer replayed as a static create-time snapshot:
   - `FLAGS_REPLAY_OPERATION` + matching `CreateGuid` → return the original open (same `FileId`). The lease/oplock state is rebuilt from the **current** open state (via `LeaseManager.GetLeaseState`), so a lease upgraded RH→RWH by a later CREATE on the same key replays back the upgraded `0x7`, not the snapshot `0x3`.
   - Lease replay validates against the live open: a non-lease open replayed with a lease, or a lease key ≠ the open's, → `ACCESS_DENIED`.
   - Duplicate `CreateGuid` **without** the replay flag → `STATUS_DUPLICATE_OBJECTID` (new `0xC000022A`).
2. **Pending-break → `FILE_NOT_AVAILABLE`.** A replay arriving while the original CREATE for the `CreateGuid` is still parked on a pending oplock/lease break fails fast with `STATUS_FILE_NOT_AVAILABLE` (per-session `CreateGuid` reservation around `parkCreateOnLeaseBreak`), extending #864's FILE_NOT_AVAILABLE machinery.

## Files
- `types/status.go` — add `StatusDuplicateObjectid` (0xC000022A)
- `v2/handlers/replay_cache.go` — live-Open reference on cache entry; `Reserve`/`Release`/`IsReserved`; `LookupEntry`
- `v2/handlers/create.go` — `resolveCreateReplay` / `refreshReplayLease` / `rewriteLeaseResponseState`
- `v2/handlers/create_post_break.go` — reserve on park, release on completion; store live Open

## Before/after repro (unit)
- `TestResolveCreateReplay_LeaseReturnsCurrentState`: replay returns current RWH (0x7), proving the snapshot-RH (0x3) bug is fixed (replay.c:918).
- `TestResolveCreateReplay_PendingFileNotAvailable`: replay-while-parked → FILE_NOT_AVAILABLE (replay.c:2228).
- Plus DUPLICATE_OBJECTID, lease-key / oplock-vs-lease ACCESS_DENIED gates, reservation lifecycle, no-cache-mutation regression, and the in-place lease-state rewrite helper.

## Target tests & honest per-test confidence
Cannot run smbtorture locally (no Docker) — confidence is from Samba source + unit repro; CI smbtorture log is authoritative.

**Replay-cache cluster (high confidence):**
- `replay-dhv2-lease1`, `replay-dhv2-lease2` — current-state lease refresh: **high**
- `replay-dhv2-lease3` (lease-key mismatch → ACCESS_DENIED): **high**
- `replay-dhv2-oplock-lease` (oplock open, lease replay → ACCESS_DENIED): **high**
- `replay-dhv2-oplock1`, `replay-dhv2-lease-oplock` (verbatim snapshot replay): **high**
- `replay-dhv2-oplock2`, `replay-dhv2-oplock3` (echo requested oplock / ignore share_access): **medium** — relies on the cached snapshot already echoing the original; oplock2 requests a different level on replay, which the snapshot reflects.

**Pending-break cluster (medium / lower confidence):**
- `dhv2-pending*-vs-{oplock,lease}-sane` (replay → FILE_NOT_AVAILABLE): **medium** — the replay leg is implemented and unit-proven; the original parked CREATE's final status depends on pre-existing share-mode/break logic not changed here.
- `*-windows` variants (expect SHARING_VIOLATION/ACCESS_DENIED): **low** — these encode Windows-specific behavior Samba itself does not pass; likely remain failing.
- `dhv2-pending2*` (multi-channel, transport disconnect between replays): **low** — depends on reservation surviving channel teardown within a session; untested without smbtorture.

## Verification
`go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test -race ./internal/adapter/smb/...` all green. 24 handler-level replay unit tests pass under -race.