### PR TITLE
Snapshot scale ceilings: GC reclaim on truncate/delete + streaming badger restore (#830/#831/#832)

### DIFF
--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -384,6 +384,9 @@ func (nopFileBlockStore) IncrementRefCount(_ context.Context, _ string) error { 
 func (nopFileBlockStore) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (nopFileBlockStore) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (nopFileBlockStore) AddRef(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	// Migration path doesn't exercise the LRU hit path, so always
 	// returning ErrUnknownHash is safe — production callers fall back to

--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -54,6 +54,22 @@ namespace. The trade-off is that snapshots are intra-cluster — they
 protect against accidental writes or deletes, not against losing the
 underlying storage.
 
+### Metadata backend at scale
+
+Snapshot create and restore stream the metadata dump backend-by-backend.
+**Use the badger metadata engine for large (TB / millions-of-files)
+shares:** badger streams the dump KV-by-KV on create and applies it via
+bounded `WriteBatch` on restore, so its snapshot RAM is governed by the
+resident hash manifest (~25 MB per 1 M unique blocks), not by share size.
+
+The **memory metadata engine is for development and small shares only.**
+It holds the entire filesystem resident by design and serializes the
+whole snapshot into a single buffer during create, so snapshotting a
+multi-GB memory-engine share can exhaust RAM. This is an inherent
+property of an in-RAM store, not a tunable; pick badger before a share
+grows large. See `test/e2e/BENCHMARKS.md` for measured dump sizes and
+the per-backend RAM budget.
+
 ## 2. Snapshot model
 
 Each snapshot is three artifacts on disk:

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -44,6 +44,11 @@ func (f *fakeCoordinator) DecrementRefCount(_ context.Context, hash blockstore.C
 	return 0, nil
 }
 
+func (f *fakeCoordinator) DecrementRefCountAndReap(_ context.Context, hash blockstore.ContentHash) (uint32, error) {
+	f.decrementCalls = append(f.decrementCalls, hash)
+	return 0, nil
+}
+
 func (f *fakeCoordinator) PersistFileBlocks(_ context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
 	f.persistCalls = append(f.persistCalls, persistCall{payloadID: payloadID, blocks: blocks, objectID: objectID})
 	return nil

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -539,12 +539,16 @@ func truncateExistingFile(
 		return nil, fmt.Errorf("update file metadata: %w", err)
 	}
 
-	// Truncate content if file has content
+	// Truncate content if file has content.
 	if existingFile.PayloadID != "" {
-		// Nil currentBlocks triggers the legacy/dual-read truncate path;
-		// returned []BlockRef is discarded. A later refactor will thread
-		// the file's FileAttr.Blocks snapshot here.
-		if _, err := blockStore.Truncate(authCtx.Context, string(existingFile.PayloadID), nil, targetSize); err != nil {
+		// Thread the file's pre-truncate FileAttr.Blocks snapshot so the
+		// engine reaps RefCount on every block dropped past targetSize —
+		// without it the truncated tail chunks leak on the remote forever
+		// (#832). existingFile was fetched (via Lookup → GetFile) BEFORE
+		// SetFileAttributes pruned the store copy, so its Blocks list still
+		// reflects the full pre-truncate extent. Returned []BlockRef is
+		// discarded — the canonical FileAttr.Blocks is reconciled at flush.
+		if _, err := blockStore.Truncate(authCtx.Context, string(existingFile.PayloadID), existingFile.Blocks, targetSize); err != nil {
 			logger.Warn("Failed to truncate content", "size", targetSize, "error", err)
 			// Non-fatal: metadata is already updated
 		}

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -336,6 +336,29 @@ func (h *Handler) SetAttr(
 	}
 
 	// ========================================================================
+	// Step 5b: Reclaim block-store space on size-down truncation
+	// ========================================================================
+	// SetFileAttributes prunes FileAttr.Blocks past the new size, but the
+	// per-share block store still holds the dropped CAS chunks. Mirror the
+	// CREATE-with-truncate path (truncateExistingFile): drive
+	// blockStore.Truncate with the file's PRE-truncate FileAttr.Blocks
+	// snapshot (captured in currentFile before SetFileAttributes ran) so the
+	// engine reaps RefCount on every dropped block and the GC sweep can
+	// reclaim the remote chunks (#832). Handler coordinates metaSvc +
+	// blockStore here exactly as the WRITE path does (invariants #1/#5).
+	// Treated as best-effort: a failure is logged but does not fail the
+	// already-committed metadata update.
+	if hasSize && currentFile.PayloadID != "" && *req.NewAttr.Size < currentFile.Size {
+		if _, blockStore, bsErr := getServicesForHandle(h.Registry, ctx.Context, fileHandle); bsErr != nil {
+			logger.WarnCtx(ctx.Context, "SETATTR: cannot resolve block store for truncate reclaim",
+				"handle", fmt.Sprintf("%x", req.Handle), "error", bsErr)
+		} else if _, tErr := blockStore.Truncate(ctx.Context, string(currentFile.PayloadID), currentFile.Blocks, *req.NewAttr.Size); tErr != nil {
+			logger.WarnCtx(ctx.Context, "SETATTR: block store truncate reclaim failed",
+				"handle", fmt.Sprintf("%x", req.Handle), "size", *req.NewAttr.Size, "error", tErr)
+		}
+	}
+
+	// ========================================================================
 	// Step 6: Build success response with updated attributes
 	// ========================================================================
 

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -110,6 +111,26 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
+	// 7a. On a size-down, capture the file's PRE-truncate FileAttr.Blocks so
+	// the block store can reap RefCount on dropped chunks after the metadata
+	// write (#832). Fetched BEFORE SetFileAttributes prunes FileAttr.Blocks.
+	// preTruncateBlocks stays nil unless this is a genuine shrink, so the
+	// reclaim below is skipped for grows / no-ops.
+	var (
+		preTruncateBlocks []blockstore.BlockRef
+		preTruncatePID    metadata.PayloadID
+		newSize           uint64
+	)
+	if setAttrs.Size != nil {
+		if cur, getErr := metaSvc.GetFile(ctx.Context, metadata.FileHandle(ctx.CurrentFH)); getErr == nil && cur != nil {
+			if *setAttrs.Size < cur.Size && cur.PayloadID != "" {
+				preTruncateBlocks = cur.Blocks
+				preTruncatePID = cur.PayloadID
+				newSize = *setAttrs.Size
+			}
+		}
+	}
+
 	// 7. Apply attributes via MetadataService (all-or-nothing semantics)
 	if err := metaSvc.SetFileAttributes(authCtx, metadata.FileHandle(ctx.CurrentFH), setAttrs); err != nil {
 		nfsStatus := common.MapToNFS4(err)
@@ -124,6 +145,23 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 			Status: nfsStatus,
 			OpCode: types.OP_SETATTR,
 			Data:   encodeSetAttrError(nfsStatus),
+		}
+	}
+
+	// 7b. Reclaim block-store space on size-down truncation. Mirror the v3
+	// SETATTR / CREATE-with-truncate path: drive blockStore.Truncate with the
+	// pre-truncate FileAttr.Blocks snapshot so the engine reaps RefCount on
+	// every dropped block and the GC sweep can reclaim the remote chunks
+	// (#832). Best-effort: a failure is logged but does not fail the
+	// already-committed metadata update. Handler coordinates metaSvc +
+	// blockStore exactly as the WRITE path does (invariants #1/#5).
+	if preTruncateBlocks != nil {
+		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH)); bsErr != nil {
+			logger.Warn("NFSv4 SETATTR: cannot resolve block store for truncate reclaim",
+				"handle", string(ctx.CurrentFH), "error", bsErr)
+		} else if _, tErr := blockStore.Truncate(ctx.Context, string(preTruncatePID), preTruncateBlocks, newSize); tErr != nil {
+			logger.Warn("NFSv4 SETATTR: block store truncate reclaim failed",
+				"handle", string(ctx.CurrentFH), "size", newSize, "error", tErr)
 		}
 	}
 

--- a/internal/bench/phase19_test.go
+++ b/internal/bench/phase19_test.go
@@ -232,6 +232,9 @@ func (s *aggregateStubFileBlockStore) IncrementRefCount(_ context.Context, _ str
 func (s *aggregateStubFileBlockStore) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (s *aggregateStubFileBlockStore) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (s *aggregateStubFileBlockStore) AddRef(_ context.Context, h blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/blockstore/engine/api_blockref_test.go
+++ b/pkg/blockstore/engine/api_blockref_test.go
@@ -124,8 +124,8 @@ func TestDelete_DecrementsRefCounts(t *testing.T) {
 		t.Fatalf("Delete: %v", err)
 	}
 
-	if got := len(fc.decHashes); got != 3 {
-		t.Errorf("DecrementRefCount calls = %d, want 3", got)
+	if got := len(fc.reapHashes); got != 3 {
+		t.Errorf("DecrementRefCountAndReap calls = %d, want 3", got)
 	}
 }
 
@@ -139,8 +139,8 @@ func TestDelete_EmptyBlocksSkipsCoordinator(t *testing.T) {
 	if err := bs.Delete(ctx, "delete-legacy", nil); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if len(fc.decHashes) != 0 {
-		t.Errorf("DecrementRefCount called %d times on legacy delete (want 0)", len(fc.decHashes))
+	if len(fc.reapHashes) != 0 {
+		t.Errorf("DecrementRefCountAndReap called %d times on legacy delete (want 0)", len(fc.reapHashes))
 	}
 }
 
@@ -167,8 +167,8 @@ func TestTruncate_DropsBlocksPastNewSize(t *testing.T) {
 	if len(kept) != 2 {
 		t.Errorf("kept = %d blocks, want 2", len(kept))
 	}
-	if len(fc.decHashes) != 2 {
-		t.Errorf("DecrementRefCount calls = %d, want 2 (one per dropped block)", len(fc.decHashes))
+	if len(fc.reapHashes) != 2 {
+		t.Errorf("DecrementRefCountAndReap calls = %d, want 2 (one per dropped block)", len(fc.reapHashes))
 	}
 }
 
@@ -186,8 +186,8 @@ func TestTruncate_EmptyBlocksLegacyPath(t *testing.T) {
 	if kept != nil {
 		t.Errorf("kept = %v, want nil for legacy path", kept)
 	}
-	if len(fc.decHashes) != 0 {
-		t.Errorf("DecrementRefCount called %d times on legacy path (want 0)", len(fc.decHashes))
+	if len(fc.reapHashes) != 0 {
+		t.Errorf("DecrementRefCountAndReap called %d times on legacy path (want 0)", len(fc.reapHashes))
 	}
 }
 

--- a/pkg/blockstore/engine/coordinator.go
+++ b/pkg/blockstore/engine/coordinator.go
@@ -35,9 +35,17 @@ type MetadataCoordinator interface {
 	IncrementRefCount(ctx context.Context, hash blockstore.ContentHash) error
 
 	// DecrementRefCount atomically decrements; returns the new count.
-	// Engine invokes this from Delete (per hash in the BlockRef list)
-	// and Truncate (per hash dropped past the new size).
+	// Engine invokes this from dedup/rollback bookkeeping. Plain decrement
+	// — the FileBlock index row survives at RefCount 0.
 	DecrementRefCount(ctx context.Context, hash blockstore.ContentHash) (uint32, error)
+
+	// DecrementRefCountAndReap atomically decrements and, when the new count
+	// is 0, deletes the FileBlock index row so its hash leaves
+	// EnumerateFileBlocks and the GC mark-sweep can reclaim the remote chunk.
+	// Engine invokes this from Delete (per hash in the BlockRef list) and
+	// Truncate (per hash dropped past the new size) — the reclaim path.
+	// Returns the new count (0 when reaped or when the hash had no row).
+	DecrementRefCountAndReap(ctx context.Context, hash blockstore.ContentHash) (uint32, error)
 
 	// PersistFileBlocks updates FileAttr.Blocks AND FileAttr.ObjectID
 	// for a given file in a single metadata txn. Engine invokes this

--- a/pkg/blockstore/engine/coordinator_test.go
+++ b/pkg/blockstore/engine/coordinator_test.go
@@ -18,6 +18,7 @@ type fakeCoordinator struct {
 
 	incHashes    []blockstore.ContentHash
 	decHashes    []blockstore.ContentHash
+	reapHashes   []blockstore.ContentHash
 	persistCalls []persistRecord
 
 	// Optional: failOnNthIncrement returns an error on the Nth (1-based)
@@ -109,6 +110,21 @@ func (f *fakeCoordinator) DecrementRefCount(_ context.Context, hash blockstore.C
 		return 0, errInducedDecrement
 	}
 	f.decHashes = append(f.decHashes, hash)
+	return 0, nil
+}
+
+// DecrementRefCountAndReap records reap-path invocations (engine Delete /
+// Truncate reclaim) separately from plain DecrementRefCount (dedup / rollback
+// bookkeeping) so tests can assert which path the engine took. Honours the same
+// failOnNthDecrement injection so rollback-on-error tests still fire.
+func (f *fakeCoordinator) DecrementRefCountAndReap(_ context.Context, hash blockstore.ContentHash) (uint32, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.decCallCount++
+	if f.failOnNthDecrement > 0 && f.decCallCount == f.failOnNthDecrement {
+		return 0, errInducedDecrement
+	}
+	f.reapHashes = append(f.reapHashes, hash)
 	return 0, nil
 }
 

--- a/pkg/blockstore/engine/drain_persist_test.go
+++ b/pkg/blockstore/engine/drain_persist_test.go
@@ -54,6 +54,17 @@ func (c *testCoordinator) DecrementRefCount(ctx context.Context, hash blockstore
 	return c.store.DecrementRefCount(ctx, fb.ID)
 }
 
+func (c *testCoordinator) DecrementRefCountAndReap(ctx context.Context, hash blockstore.ContentHash) (uint32, error) {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil {
+		return 0, err
+	}
+	if fb == nil {
+		return 0, nil
+	}
+	return c.store.DecrementRefCountAndReap(ctx, fb.ID)
+}
+
 func (c *testCoordinator) PersistFileBlocks(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, objectID blockstore.ObjectID) error {
 	return c.store.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		file, err := tx.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))

--- a/pkg/blockstore/engine/engine_delete_test.go
+++ b/pkg/blockstore/engine/engine_delete_test.go
@@ -62,6 +62,31 @@ func (c *refcountCoordinator) DecrementRefCount(_ context.Context, hash blocksto
 	return cur, nil
 }
 
+// DecrementRefCountAndReap mirrors DecrementRefCount (including the
+// single-shot error injection) and reaps the map entry when the count hits 0,
+// matching the backend reap semantics the engine reclaim path now relies on.
+func (c *refcountCoordinator) DecrementRefCountAndReap(_ context.Context, hash blockstore.ContentHash) (uint32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.decrementErr != nil && c.decrementErrHash == hash {
+		err := c.decrementErr
+		c.decrementErr = nil
+		return 0, err
+	}
+	cur := c.counts[hash]
+	if cur == 0 {
+		delete(c.counts, hash)
+		return 0, nil
+	}
+	cur--
+	if cur == 0 {
+		delete(c.counts, hash)
+		return 0, nil
+	}
+	c.counts[hash] = cur
+	return cur, nil
+}
+
 func (c *refcountCoordinator) PersistFileBlocks(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
 	return nil
 }

--- a/pkg/blockstore/engine/engine_test.go
+++ b/pkg/blockstore/engine/engine_test.go
@@ -61,6 +61,9 @@ func (s *stubFileBlockStore) IncrementRefCount(_ context.Context, _ string) erro
 func (s *stubFileBlockStore) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (s *stubFileBlockStore) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (s *stubFileBlockStore) AddRef(_ context.Context, h blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	// bump RefCount on any row indexed by hash. The stub
 	// holds blocks keyed by id but each row carries a Hash field, so

--- a/pkg/blockstore/engine/gc_test.go
+++ b/pkg/blockstore/engine/gc_test.go
@@ -424,6 +424,98 @@ func TestGCMarkSweep_TruncateDedupSafety(t *testing.T) {
 	}
 }
 
+// TestGCMarkSweep_DeleteDuplicateHashNoOverReap (#832 data-loss guard): a
+// single file may reference the SAME hash at multiple offsets, but file-level
+// dedup increments its RefCount only ONCE (seen-set). Deleting that file must
+// reap the hash at most once — a per-BlockRef decrement would drive a shared
+// row (RefCount 2: this file + another) to zero and let GC delete a chunk the
+// other file still needs.
+func TestGCMarkSweep_DeleteDuplicateHashNoOverReap(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+	rs.SetNowFnForTest(func() time.Time { return time.Now().Add(-2 * time.Hour) })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+	bs := newReapEngine(t, st)
+
+	const mib = uint64(1 << 20)
+	shared := hashFromString("dup-and-shared-hash")
+
+	// RefCount 2: file-A references it (once, despite two offsets) + file-B.
+	putBlock(t, st, "file-A/0", shared)
+	if err := st.IncrementRefCount(ctx, "file-A/0"); err != nil {
+		t.Fatalf("IncrementRefCount: %v", err) // 1 → 2
+	}
+	writeCASObject(t, ctx, rs, shared, []byte("dup-shared-chunk"))
+
+	// Delete file-A, whose block list carries the SAME hash at two offsets.
+	// Correct reap = once → RefCount 2 → 1 (file-B's reference survives).
+	dupBlocks := []blockstore.BlockRef{
+		{Hash: shared, Offset: 0, Size: uint32(mib)},
+		{Hash: shared, Offset: 4 * mib, Size: uint32(mib)},
+	}
+	if err := bs.Delete(ctx, "file-A", dupBlocks); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	stats := CollectGarbage(ctx, rs, rec, &Options{GCStateRoot: t.TempDir(), GracePeriod: time.Minute})
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d; FirstErrors=%v", stats.ErrorCount, stats.FirstErrors)
+	}
+	if _, err := rs.Get(ctx, shared); err != nil {
+		t.Errorf("shared chunk swept after deleting a file that referenced it twice: %v; want retained (file-B still refs it)", err)
+	}
+	if stats.ObjectsSwept != 0 {
+		t.Errorf("ObjectsSwept = %d, want 0 (shared chunk still referenced by file-B)", stats.ObjectsSwept)
+	}
+}
+
+// TestGCMarkSweep_TruncateStraddleHashNoOverReap (#832 data-loss guard): when
+// the same hash sits on BOTH sides of newSize within one file (kept AND
+// dropped), truncate must NOT reap it — the file still references it below
+// newSize. RefCount was incremented once for the file, so a per-dropped-BlockRef
+// decrement would zero the row and let GC delete a chunk the kept block needs.
+func TestGCMarkSweep_TruncateStraddleHashNoOverReap(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+	rs.SetNowFnForTest(func() time.Time { return time.Now().Add(-2 * time.Hour) })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+	bs := newReapEngine(t, st)
+
+	const mib = uint64(1 << 20)
+	shared := hashFromString("straddle-hash")
+
+	// RefCount 1: a single file references this hash (at two offsets, dedup
+	// increments once). One CAS object.
+	putBlock(t, st, "file-S/0", shared)
+	writeCASObject(t, ctx, rs, shared, []byte("straddle-chunk"))
+
+	// Same hash kept (offset 0) and dropped (offset 4 MiB). Truncate to 1 MiB.
+	blocks := []blockstore.BlockRef{
+		{Hash: shared, Offset: 0, Size: uint32(mib)},
+		{Hash: shared, Offset: 4 * mib, Size: uint32(mib)},
+	}
+	if _, err := bs.Truncate(ctx, "file-S", blocks, mib); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	stats := CollectGarbage(ctx, rs, rec, &Options{GCStateRoot: t.TempDir(), GracePeriod: time.Minute})
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d; FirstErrors=%v", stats.ErrorCount, stats.FirstErrors)
+	}
+	if _, err := rs.Get(ctx, shared); err != nil {
+		t.Errorf("straddling chunk swept after truncate: %v; want retained (still referenced below newSize)", err)
+	}
+	if stats.ObjectsSwept != 0 {
+		t.Errorf("ObjectsSwept = %d, want 0 (hash still kept below newSize)", stats.ObjectsSwept)
+	}
+}
+
 // TestGCMarkSweep_GraceTTLPreserves (behavior 3): an orphan with
 // LastModified > snapshot - GracePeriod is NOT deleted (within the grace
 // window).

--- a/pkg/blockstore/engine/gc_test.go
+++ b/pkg/blockstore/engine/gc_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/memory"
 	"github.com/marmos91/dittofs/pkg/blockstore/remote"
 	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
 	"github.com/marmos91/dittofs/pkg/health"
@@ -234,6 +235,192 @@ func TestGCMarkSweep_SweepHappyPath(t *testing.T) {
 		if _, err := rs.Get(ctx, h); err == nil {
 			t.Errorf("orphan %x not deleted", h[:8])
 		}
+	}
+}
+
+// reapCoordinator is the GC-reclaim test's MetadataCoordinator: it binds the
+// engine's hash-keyed refcount surface to a real metadata.MetadataStore exactly
+// like the production runtime coordinator (GetByHash → id → reap). Only the
+// refcount methods are exercised by Truncate/Delete; the rest are no-ops.
+type reapCoordinator struct {
+	store metadata.MetadataStore
+}
+
+func (c *reapCoordinator) IncrementRefCount(ctx context.Context, hash blockstore.ContentHash) error {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil || fb == nil {
+		return err
+	}
+	return c.store.IncrementRefCount(ctx, fb.ID)
+}
+
+func (c *reapCoordinator) DecrementRefCount(ctx context.Context, hash blockstore.ContentHash) (uint32, error) {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil || fb == nil {
+		return 0, err
+	}
+	return c.store.DecrementRefCount(ctx, fb.ID)
+}
+
+func (c *reapCoordinator) DecrementRefCountAndReap(ctx context.Context, hash blockstore.ContentHash) (uint32, error) {
+	fb, err := c.store.GetByHash(ctx, hash)
+	if err != nil || fb == nil {
+		return 0, err
+	}
+	return c.store.DecrementRefCountAndReap(ctx, fb.ID)
+}
+
+func (c *reapCoordinator) PersistFileBlocks(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
+	return nil
+}
+
+func (c *reapCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
+func (c *reapCoordinator) FindByObjectID(_ context.Context, _ blockstore.ObjectID) ([]blockstore.BlockRef, error) {
+	return nil, nil
+}
+
+func (c *reapCoordinator) GetFileObjectID(_ context.Context, _ string) (blockstore.ObjectID, error) {
+	return blockstore.ObjectID{}, nil
+}
+
+var _ MetadataCoordinator = (*reapCoordinator)(nil)
+
+// newReapEngine builds an engine.Store whose coordinator reaps RefCount-0
+// FileBlock rows from the supplied metadata store, so a Truncate/Delete that
+// drops a hash's last reference removes it from EnumerateFileBlocks and the GC
+// sweep can reclaim the remote chunk. The engine's own local store / syncer are
+// memory-only (no remote) — the GC sweep runs directly against the test's
+// separate remote store via CollectGarbage.
+func newReapEngine(t *testing.T, st metadata.MetadataStore) *Store {
+	t.Helper()
+	localStore := memory.New()
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{
+		Local:          localStore,
+		Remote:         nil,
+		Syncer:         syncer,
+		FileBlockStore: fbs,
+		Coordinator:    &reapCoordinator{store: st},
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// TestGCMarkSweep_TruncateReclaimsRemoteChunk (#832): a Truncate that drops a
+// tail block's LAST reference must reap its FileBlock index row so the hash
+// leaves the GC live set and the sweep reclaims the remote chunk. The retained
+// block's chunk survives. This test FAILS on develop — where Truncate only
+// decremented RefCount (leaving the row at RefCount 0 but still emitted by
+// EnumerateFileBlocks), so the dropped chunk stayed in the live set forever.
+func TestGCMarkSweep_TruncateReclaimsRemoteChunk(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+
+	// Age every remote object past the grace window so the sweep is eligible.
+	rs.SetNowFnForTest(func() time.Time { return time.Now().Add(-2 * time.Hour) })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+	bs := newReapEngine(t, st)
+
+	const mib = uint64(1 << 20)
+	h1 := hashFromString("trunc-keep-h1")
+	h2 := hashFromString("trunc-drop-h2")
+
+	// Two CAS objects: H1 @ offset 0 (kept), H2 @ offset 4MiB (dropped). Both
+	// have FileBlock index rows at RefCount 1 and live CAS objects on remote.
+	putBlock(t, st, "file-trunc/0", h1)
+	putBlock(t, st, "file-trunc/1", h2)
+	writeCASObject(t, ctx, rs, h1, []byte("keep-chunk-data"))
+	writeCASObject(t, ctx, rs, h2, []byte("drop-chunk-data-longer"))
+
+	// Truncate to 4MiB: H2 (offset 4MiB) is dropped, H1 (offset 0) kept.
+	blocks := []blockstore.BlockRef{
+		{Hash: h1, Offset: 0, Size: uint32(mib)},
+		{Hash: h2, Offset: 4 * mib, Size: uint32(mib)},
+	}
+	if _, err := bs.Truncate(ctx, "file-trunc", blocks, 4*mib); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	stats := CollectGarbage(ctx, rs, rec, &Options{
+		GCStateRoot: t.TempDir(),
+		GracePeriod: time.Minute,
+	})
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d, want 0; FirstErrors=%v", stats.ErrorCount, stats.FirstErrors)
+	}
+
+	// H2's chunk MUST be swept (its row was reaped → left the live set).
+	if _, err := rs.Get(ctx, h2); err == nil {
+		t.Errorf("dropped chunk H2 still present on remote after Truncate+GC; want swept (#832 leak)")
+	}
+	// H1's chunk MUST survive (still referenced).
+	if _, err := rs.Get(ctx, h1); err != nil {
+		t.Errorf("retained chunk H1 swept after Truncate+GC: %v; want retained", err)
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Errorf("ObjectsSwept = %d, want 1 (only the dropped H2)", stats.ObjectsSwept)
+	}
+}
+
+// TestGCMarkSweep_TruncateDedupSafety (#832 data-loss guard): when two files
+// reference the same hash (RefCount 2), truncating ONE file dropping that hash
+// must NOT sweep the chunk — the other file still references it. Reaping is
+// safe only at RefCount 0.
+func TestGCMarkSweep_TruncateDedupSafety(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+
+	rs.SetNowFnForTest(func() time.Time { return time.Now().Add(-2 * time.Hour) })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+	bs := newReapEngine(t, st)
+
+	const mib = uint64(1 << 20)
+	shared := hashFromString("dedup-shared-hash")
+
+	// One FileBlock index row for the shared hash, RefCount 2 (two files
+	// reference it via file-level dedup). One CAS object on the remote.
+	putBlock(t, st, "file-A/1", shared)
+	if err := st.IncrementRefCount(ctx, "file-A/1"); err != nil {
+		t.Fatalf("IncrementRefCount: %v", err) // RefCount 1 → 2
+	}
+	writeCASObject(t, ctx, rs, shared, []byte("shared-dedup-chunk"))
+
+	// Truncate file-A dropping the shared block: RefCount 2 → 1, row survives.
+	blocks := []blockstore.BlockRef{{Hash: shared, Offset: 4 * mib, Size: uint32(mib)}}
+	if _, err := bs.Truncate(ctx, "file-A", blocks, 0); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	stats := CollectGarbage(ctx, rs, rec, &Options{
+		GCStateRoot: t.TempDir(),
+		GracePeriod: time.Minute,
+	})
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d, want 0; FirstErrors=%v", stats.ErrorCount, stats.FirstErrors)
+	}
+
+	// The shared chunk MUST survive: file-B (the second reference) still needs it.
+	if _, err := rs.Get(ctx, shared); err != nil {
+		t.Errorf("shared chunk swept after truncating ONE of two referencing files: %v; want retained (reap only at RefCount 0)", err)
+	}
+	if stats.ObjectsSwept != 0 {
+		t.Errorf("ObjectsSwept = %d, want 0 (shared chunk still referenced)", stats.ObjectsSwept)
 	}
 }
 

--- a/pkg/blockstore/engine/readwrite.go
+++ b/pkg/blockstore/engine/readwrite.go
@@ -127,9 +127,12 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 		kept = make([]blockstore.BlockRef, 0, len(currentBlocks))
 		for _, b := range currentBlocks {
 			if b.Offset >= newSize {
-				// Block fully past newSize — drop it.
+				// Block fully past newSize — drop it. Reap at RefCount 0 so
+				// the hash leaves EnumerateFileBlocks and the GC sweep can
+				// reclaim the remote chunk (otherwise truncated tail chunks
+				// leak on the remote forever — #832).
 				if bs.coordinator != nil {
-					if _, err := bs.coordinator.DecrementRefCount(ctx, b.Hash); err != nil {
+					if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, b.Hash); err != nil {
 						return currentBlocks, fmt.Errorf("decrement refcount on truncate-drop %s: %w", b.Hash.String(), err)
 					}
 				}
@@ -217,7 +220,10 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []blocksto
 	var coordErr error
 	if len(blocks) > 0 && bs.coordinator != nil {
 		for _, b := range blocks {
-			newCount, err := bs.coordinator.DecrementRefCount(ctx, b.Hash)
+			// Reap at RefCount 0 so the hash leaves EnumerateFileBlocks and
+			// the GC sweep can reclaim the remote chunk (#832). Dedup-shared
+			// hashes (RefCount > 1) survive — only the last reference reaps.
+			newCount, err := bs.coordinator.DecrementRefCountAndReap(ctx, b.Hash)
 			if err != nil {
 				if coordErr == nil {
 					coordErr = fmt.Errorf("decrement refcount on delete %s: %w", b.Hash.String(), err)

--- a/pkg/blockstore/engine/readwrite.go
+++ b/pkg/blockstore/engine/readwrite.go
@@ -125,22 +125,46 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 	var kept []blockstore.BlockRef
 	if len(currentBlocks) > 0 {
 		kept = make([]blockstore.BlockRef, 0, len(currentBlocks))
+		var dropped []blockstore.BlockRef
 		for _, b := range currentBlocks {
 			if b.Offset >= newSize {
-				// Block fully past newSize — drop it. Reap at RefCount 0 so
-				// the hash leaves EnumerateFileBlocks and the GC sweep can
-				// reclaim the remote chunk (otherwise truncated tail chunks
-				// leak on the remote forever — #832).
-				if bs.coordinator != nil {
-					if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, b.Hash); err != nil {
-						return currentBlocks, fmt.Errorf("decrement refcount on truncate-drop %s: %w", b.Hash.String(), err)
-					}
-				}
+				// Block fully past newSize — drop it.
+				dropped = append(dropped, b)
 				continue
 			}
-			// Block fully or partially before newSize — keep. will
-			// re-chunk the partial-tail block; keeps it as-is.
+			// Block fully or partially before newSize — keep. WriteAt will
+			// re-chunk the partial-tail block; keep it as-is.
 			kept = append(kept, b)
+		}
+
+		// Reap each dropped tail hash so it leaves EnumerateFileBlocks and the
+		// GC sweep can reclaim the remote chunk (otherwise truncated tail
+		// chunks leak on the remote forever — #832).
+		//
+		// RefCount is incremented ONCE per DISTINCT hash per file (file-level
+		// dedup uses a seen-set in applyFileLevelDedupHit / CopyPayload), so
+		// decrement at most once per distinct dropped hash — and never for a
+		// hash still referenced by a KEPT block (the same content can sit on
+		// both sides of newSize). A per-BlockRef decrement would over-drop a
+		// shared row to zero and let GC delete data another reference needs.
+		if bs.coordinator != nil {
+			keptHashes := make(map[blockstore.ContentHash]struct{}, len(kept))
+			for _, b := range kept {
+				keptHashes[b.Hash] = struct{}{}
+			}
+			reaped := make(map[blockstore.ContentHash]struct{}, len(dropped))
+			for _, b := range dropped {
+				if _, stillKept := keptHashes[b.Hash]; stillKept {
+					continue
+				}
+				if _, done := reaped[b.Hash]; done {
+					continue
+				}
+				reaped[b.Hash] = struct{}{}
+				if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, b.Hash); err != nil {
+					return currentBlocks, fmt.Errorf("decrement refcount on truncate-drop %s: %w", b.Hash.String(), err)
+				}
+			}
 		}
 	}
 
@@ -219,7 +243,18 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []blocksto
 	// picture.
 	var coordErr error
 	if len(blocks) > 0 && bs.coordinator != nil {
+		// RefCount is incremented ONCE per DISTINCT hash per file (file-level
+		// dedup uses a seen-set in applyFileLevelDedupHit / CopyPayload), so
+		// reap at most once per distinct hash. A per-BlockRef decrement would
+		// over-drop a hash that appears at multiple offsets in this file and,
+		// when another file shares it, take the shared row to zero and let GC
+		// delete data the other reference still needs.
+		reaped := make(map[blockstore.ContentHash]struct{}, len(blocks))
 		for _, b := range blocks {
+			if _, done := reaped[b.Hash]; done {
+				continue
+			}
+			reaped[b.Hash] = struct{}{}
 			// Reap at RefCount 0 so the hash leaves EnumerateFileBlocks and
 			// the GC sweep can reclaim the remote chunk (#832). Dedup-shared
 			// hashes (RefCount > 1) survive — only the last reference reaps.

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -937,6 +937,23 @@ func (c *cascadeCoordinator) DecrementRefCount(_ context.Context, hash blockstor
 	return cur, nil
 }
 
+func (c *cascadeCoordinator) DecrementRefCountAndReap(_ context.Context, hash blockstore.ContentHash) (uint32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cur := c.counts[hash]
+	if cur == 0 {
+		delete(c.counts, hash)
+		return 0, nil
+	}
+	cur--
+	if cur == 0 {
+		delete(c.counts, hash)
+		return 0, nil
+	}
+	c.counts[hash] = cur
+	return cur, nil
+}
+
 func (c *cascadeCoordinator) PersistFileBlocks(_ context.Context, _ string, _ []blockstore.BlockRef, _ blockstore.ObjectID) error {
 	return nil
 }

--- a/pkg/blockstore/engine/syncer_test.go
+++ b/pkg/blockstore/engine/syncer_test.go
@@ -351,6 +351,13 @@ func (s *stubFBS) DecrementRefCount(_ context.Context, _ string) (uint32, error)
 	return 0, nil
 }
 
+func (s *stubFBS) DecrementRefCountAndReap(_ context.Context, id string) (uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.blocks, id)
+	return 0, nil
+}
+
 func (s *stubFBS) AddRef(_ context.Context, h blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	// bump RefCount on any row indexed by hash.
 	s.mu.Lock()

--- a/pkg/blockstore/fileblock.go
+++ b/pkg/blockstore/fileblock.go
@@ -81,6 +81,17 @@ type FileBlockStore interface {
 	// count. RefCount=0 marks the block as a GC candidate.
 	DecrementRefCount(ctx context.Context, id string) (uint32, error)
 
+	// DecrementRefCountAndReap atomically decrements RefCount for the FileBlock
+	// id and, IF the new count is 0, deletes the row (and its hash index entry)
+	// in the SAME critical section as the decrement — TOCTOU-free against a
+	// concurrent AddRef the same way IncrementRefCount/AddRef are. Returns the
+	// new count (0 when reaped or when the row was already absent).
+	// ErrFileBlockNotFound is tolerated and reported as count 0 (a row already
+	// swept is not a caller error). Used by the engine Delete/Truncate reclaim
+	// path so that, once a hash has no live references, it leaves
+	// EnumerateFileBlocks and the GC sweep can collect the remote chunk.
+	DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error)
+
 	// AddRef atomically increments RefCount on the FileBlock row
 	// indexed by hash. Used by the in-memory hash dedup LRU hit path.
 	//

--- a/pkg/blockstore/local/fs/appendlog_testhelpers_test.go
+++ b/pkg/blockstore/local/fs/appendlog_testhelpers_test.go
@@ -31,6 +31,9 @@ func (nopFBS) IncrementRefCount(_ context.Context, _ string) error { return nil 
 func (nopFBS) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (nopFBS) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (nopFBS) AddRef(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	// tests don't exercise the LRU hit path, so always
 	// returning ErrUnknownHash matches "hash never Put" — production

--- a/pkg/blockstore/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/blockstore/local/fs/drain_reset_testhelpers_test.go
@@ -85,6 +85,9 @@ func (m *memFBS) IncrementRefCount(_ context.Context, _ string) error { return n
 func (m *memFBS) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (m *memFBS) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (m *memFBS) AddRef(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	return blockstore.ErrUnknownHash
 }

--- a/pkg/blockstore/local/fs/eviction_lsl08_conformance_test.go
+++ b/pkg/blockstore/local/fs/eviction_lsl08_conformance_test.go
@@ -223,6 +223,10 @@ func (c *countingFBSWrapper) DecrementRefCount(ctx context.Context, id string) (
 	c.counter++
 	return c.inner.DecrementRefCount(ctx, id)
 }
+func (c *countingFBSWrapper) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	c.counter++
+	return c.inner.DecrementRefCountAndReap(ctx, id)
+}
 func (c *countingFBSWrapper) AddRef(ctx context.Context, h blockstore.ContentHash, payloadID string, ref blockstore.BlockRef) error {
 	c.counter++
 	return c.inner.AddRef(ctx, h, payloadID, ref)

--- a/pkg/blockstore/local/fs/fs_test.go
+++ b/pkg/blockstore/local/fs/fs_test.go
@@ -67,6 +67,11 @@ func (c *countingFileBlockStore) DecrementRefCount(ctx context.Context, id strin
 	return c.inner.DecrementRefCount(ctx, id)
 }
 
+func (c *countingFileBlockStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	c.decrementRefCount.Add(1)
+	return c.inner.DecrementRefCountAndReap(ctx, id)
+}
+
 func (c *countingFileBlockStore) AddRef(ctx context.Context, hash blockstore.ContentHash, payloadID string, blockRef blockstore.BlockRef) error {
 	c.addRef.Add(1)
 	return c.inner.AddRef(ctx, hash, payloadID, blockRef)

--- a/pkg/blockstore/local/fs/rollup_test.go
+++ b/pkg/blockstore/local/fs/rollup_test.go
@@ -635,6 +635,9 @@ func (p *programmableFBS) IncrementRefCount(ctx context.Context, id string) erro
 func (p *programmableFBS) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
 	return p.inner.DecrementRefCount(ctx, id)
 }
+func (p *programmableFBS) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	return p.inner.DecrementRefCountAndReap(ctx, id)
+}
 func (p *programmableFBS) AddRef(ctx context.Context, h blockstore.ContentHash, payloadID string, ref blockstore.BlockRef) error {
 	p.addRefCalls.Add(1)
 	if p.addRefOverride != nil {

--- a/pkg/blockstore/local/fs/test_hooks.go
+++ b/pkg/blockstore/local/fs/test_hooks.go
@@ -239,6 +239,9 @@ func (nopFBSForTest) IncrementRefCount(_ context.Context, _ string) error { retu
 func (nopFBSForTest) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
 	return 0, nil
 }
+func (nopFBSForTest) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
+	return 0, nil
+}
 func (nopFBSForTest) AddRef(_ context.Context, _ blockstore.ContentHash, _ string, _ blockstore.BlockRef) error {
 	// no-op test stub. Every hash is "unknown" so the
 	// LRU hit path in production would always fall back to the full

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -127,6 +127,43 @@ func (c *metadataCoordinator) DecrementRefCount(ctx context.Context, hash blocks
 	return count, nil
 }
 
+// DecrementRefCountAndReap looks up the FileBlock by hash and decrements its
+// RefCount, reaping the row (and its hash index entry) atomically when the new
+// count reaches 0. The hash then leaves EnumerateFileBlocks so the GC sweep can
+// reclaim the remote chunk. ErrFileBlockNotFound on a hash with no row is
+// tolerated (returns count=0, nil) — a Truncate/Delete on an already-swept hash
+// is not a caller error.
+//
+// The GetByHash → reap is two store calls, but the reap itself is atomic at the
+// row level (the backend decrements and deletes in one critical section) and
+// GetByHash returns a stable id. A concurrent AddRef bumps the SAME row, so the
+// in-lock decrement reads the current count — no data loss: the row is reaped
+// ONLY when its count is genuinely 0.
+//
+// Same txn-binding rule as DecrementRefCount: when ctx carries an active
+// metadata.Transaction via metadata.WithTx, both GetByHash and the reap route
+// through that tx; the engine Truncate/Delete reclaim path does not bind a tx.
+func (c *metadataCoordinator) DecrementRefCountAndReap(ctx context.Context, hash blockstore.ContentHash) (uint32, error) {
+	store := c.resolveStore(ctx)
+	fb, err := store.GetByHash(ctx, hash)
+	if err != nil {
+		return 0, fmt.Errorf("coordinator: GetByHash(%s): %w", hash.String(), err)
+	}
+	if fb == nil {
+		// Already swept / never existed — the requested decrement-and-reap
+		// effectively succeeded (count is zero).
+		return 0, nil
+	}
+	count, err := store.DecrementRefCountAndReap(ctx, fb.ID)
+	if err != nil {
+		if errors.Is(err, metadata.ErrFileBlockNotFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("coordinator: DecrementRefCountAndReap(%s): %w", fb.ID, err)
+	}
+	return count, nil
+}
+
 // PersistFileBlocks atomically updates FileAttr.Blocks AND
 // FileAttr.ObjectID for the file identified by payloadID in a single
 // metadata transaction. The runtime wrapper resolves

--- a/pkg/controlplane/runtime/snapshot_byteverify_encrypted_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_encrypted_test.go
@@ -1,0 +1,157 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/encryption/keyprovider"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// encryptedRemoteCfg builds a remote BlockStoreConfig (kind=remote, type=memory)
+// whose Config JSON carries an "encryption" block, so the real share-build path
+// (shares.maybeWrapEncryption) interposes an EncryptedRemote in front of the
+// in-memory remote. The master key is a fresh passphrase-protected local key
+// file scoped to this test.
+func encryptedRemoteCfg(t *testing.T) *models.BlockStoreConfig {
+	t.Helper()
+
+	const passphrase = "byteverify-encrypted-remote-passphrase"
+	t.Setenv("DITTOFS_ENCRYPTION_PASSPHRASE", passphrase)
+
+	keyBytes, err := keyprovider.GenerateKeyFile(passphrase)
+	if err != nil {
+		t.Fatalf("GenerateKeyFile: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "master.key")
+	if err := os.WriteFile(keyPath, keyBytes, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	cfg := &models.BlockStoreConfig{
+		Name: "bv-enc-remote",
+		Kind: models.BlockStoreKindRemote,
+		Type: "memory",
+	}
+	// AEAD omitted → defaults to AES-256-GCM (encryption.ParsePolicy).
+	if err := cfg.SetConfig(map[string]any{
+		"encryption": map[string]any{
+			"key": map[string]any{
+				"kind": string(keyprovider.KindLocal),
+				"file": keyPath,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("SetConfig(encryption): %v", err)
+	}
+	return cfg
+}
+
+// TestSnapshotByteVerify_EncryptedRemote_Matrix is the encrypted-remote edge
+// case: a full write → durable snapshot → mutate → ResetLocalState → restore →
+// byte-compare cycle, but with an encryption-enabled remote block store, run
+// across every metadata backend (memory + badger always; postgres when the
+// integration companion installed it).
+//
+// This pins the intersection that the existing tests cover only separately:
+//   - TestSnapshot_EncryptionInteraction proves the encrypted verify/decrypt
+//     path, but only with memory metadata + a controlled HashSet.
+//   - TestSnapshotByteVerify_Matrix proves real per-backend metadata
+//     Backup/restore byte round-trips, but only over a plaintext store.
+//
+// Here both hold at once: the snapshot manifest is the plaintext content
+// hashes, the durability verify HEAD-probes the EncryptedRemote, the metadata
+// dump is the real per-backend serialization, and the post-ResetLocalState
+// restore re-reads every block back through the AEAD decrypt — byte-identical.
+func TestSnapshotByteVerify_EncryptedRemote_Matrix(t *testing.T) {
+	for _, bk := range byteVerifyBackends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			if bk.skip != "" {
+				t.Skip(bk.skip)
+			}
+			meta, metaType := bk.open(t)
+			fx := newByteVerifyFixtureOpts(t, meta, metaType, encryptedRemoteCfg(t))
+			defer fx.close()
+			runEncryptedDurableCycle(t, fx)
+		})
+	}
+}
+
+// runEncryptedDurableCycle mirrors runByteVerifyCycle but drives a REMOTE-DURABLE
+// snapshot (no NoVerify) so the verify gate HEAD-probes the encrypted remote,
+// and reads after ResetLocalState resolve cold through the encrypted CAS.
+func runEncryptedDurableCycle(t *testing.T, fx *byteVerifyFixture) {
+	ctx := context.Background()
+	const mib = 1 << 20
+
+	origA := distinctBytes(3*mib, 0xA) // multi-chunk
+	origB := distinctBytes(8192, 0xB)
+
+	pidA := fx.createEmptyFile(ctx, "fileA.bin")
+	fx.writeFile(ctx, pidA, origA)
+	pidB := fx.createEmptyFile(ctx, "fileB.bin")
+	fx.writeFile(ctx, pidB, origB)
+
+	if fa := fx.getFile(ctx, "fileA.bin"); len(fa.Blocks) < 2 {
+		t.Fatalf("fileA produced %d CAS block(s), want >= 2 (multi-chunk path not exercised)", len(fa.Blocks))
+	}
+
+	// Durable snapshot: create drains uploads to the encrypted remote, then the
+	// verify gate HEAD-probes every manifest hash against the EncryptedRemote.
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if werr != nil {
+		t.Fatalf("WaitForSnapshot: %v (verify gate must HEAD-probe the encrypted remote)", werr)
+	}
+	if snap.State != models.StateReady {
+		t.Fatalf("snap.State = %q, want ready", snap.State)
+	}
+	if !snap.RemoteDurable {
+		t.Fatal("snap.RemoteDurable = false: durability verify against the encrypted remote did not confirm every block")
+	}
+
+	// Mutate: overwrite fileA in place (same length), delete fileB.
+	mutA := distinctBytes(3*mib, 0xA11)
+	if len(mutA) != len(origA) {
+		t.Fatalf("test bug: mutA len %d != origA len %d", len(mutA), len(origA))
+	}
+	fx.writeFile(ctx, pidA, mutA)
+	fx.deleteFile(ctx, "fileB.bin")
+
+	// Drop ALL local state so restore reads must fetch+decrypt from the
+	// encrypted remote (the cold encrypted-CAS read path).
+	if err := fx.bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// Restore (durable → AllowNonDurable not required).
+	if err := fx.rt.DisableShare(ctx, fx.shareName); err != nil {
+		t.Fatalf("DisableShare: %v", err)
+	}
+	if _, err := fx.rt.RestoreSnapshot(ctx, fx.shareName, snapID, RestoreSnapshotOpts{}); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	// fileA rolled back to original bytes; fileB recovered — both byte-identical
+	// after decrypting from the encrypted remote.
+	if !fx.fileExists(ctx, "fileA.bin") {
+		t.Fatal("fileA missing after restore")
+	}
+	if got := fx.readFile(ctx, pidA, len(origA)); !bytes.Equal(got, origA) {
+		t.Fatalf("RESTORE fileA NOT byte-identical (encrypted cold read): %s", firstDiff(origA, got))
+	}
+	if !fx.fileExists(ctx, "fileB.bin") {
+		t.Fatal("fileB not recovered after restore")
+	}
+	pidB2 := fx.getFile(ctx, "fileB.bin").PayloadID
+	if got := fx.readFile(ctx, pidB2, len(origB)); !bytes.Equal(got, origB) {
+		t.Fatalf("RESTORE fileB NOT byte-identical (encrypted cold read): %s", firstDiff(origB, got))
+	}
+}

--- a/pkg/metadata/store/badger/backup.go
+++ b/pkg/metadata/store/badger/backup.go
@@ -151,22 +151,15 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*blockst
 	return hs, nil
 }
 
-// kvEntry holds a single key-value pair collected during restore stream
-// parsing, before CRC verification. Entries are buffered in RAM (metadata
-// streams are typically megabytes) and only flushed to Badger after the
-// trailing CRC confirms stream integrity.
-type kvEntry struct {
-	Key   []byte
-	Value []byte
-}
-
 // Restore reads a backup stream from r and rebuilds metadata state in the
 // Badger store. The store must be empty (no existing share data); otherwise
 // ErrRestoreDestinationNotEmpty is returned.
 //
-// Integrity guarantee: all KV entries are collected in memory first, the
-// trailing CRC is verified, and only then are entries written to Badger
-// via WriteBatch. A corrupt stream leaves the store empty and retryable.
+// Integrity guarantee: KV entries stream straight into Badger via WriteBatch
+// (restore RAM bounded by restoreBatchSize, not by share size), the trailing
+// CRC is verified last, and any failure triggers a DropAll. Because the
+// destination was empty before restore began, a corrupt stream is wiped back
+// to empty and the restore stays retryable.
 func (s *BadgerMetadataStore) Restore(ctx context.Context, r io.Reader) error {
 	// Check destination is empty by looking for any s: prefix key.
 	isEmpty, err := s.isStoreEmpty()
@@ -198,21 +191,36 @@ func (s *BadgerMetadataStore) Restore(ctx context.Context, r io.Reader) error {
 		return fmt.Errorf("%w: got version %d, want %d", metadata.ErrSchemaVersionMismatch, schemaVer, badgerSchemaVersion)
 	}
 
-	// Collect all KV entries into memory without writing to Badger.
-	// The payloadReader is a tee reader that accumulates bytes into the CRC
-	// hash. By the time the sentinel is read, the accumulator covers the
-	// entire payload and VerifyCRC can validate the trailing 4 CRC bytes.
-	var entries []kvEntry
+	// Stream KV entries straight into Badger via WriteBatch so restore RAM is
+	// bounded by restoreBatchSize, not by the (potentially multi-GB) share
+	// size. The create-path Backup already streams KV-by-KV; this closes the
+	// restore-side ceiling (#831).
+	//
+	// Atomicity is preserved by the empty-destination precondition checked
+	// above plus a DropAll on any failure: the store was empty before we
+	// started, so wiping the partially-applied data restores the empty,
+	// retryable state the previous buffer-then-flush design guaranteed. A
+	// crash mid-restore is handled one layer up by the durable restore marker
+	// (startup rollback).
+	wb := s.db.NewWriteBatch()
+	failRestore := func(format string, args ...any) error {
+		wb.Cancel()
+		if derr := s.db.DropAll(); derr != nil {
+			logger.Error("restore: DropAll after failure left store non-empty", "error", derr)
+		}
+		return fmt.Errorf(format, args...)
+	}
 
 	var buf [4]byte
+	applied := 0
 	for {
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("restore cancelled: %w", err)
+			return failRestore("restore cancelled: %w", err)
 		}
 
 		// Read key_len.
 		if _, err := io.ReadFull(payloadReader, buf[:]); err != nil {
-			return fmt.Errorf("%w: read key_len: %v", metadata.ErrRestoreCorrupt, err)
+			return failRestore("%w: read key_len: %v", metadata.ErrRestoreCorrupt, err)
 		}
 		keyLen := binary.LittleEndian.Uint32(buf[:])
 
@@ -223,63 +231,58 @@ func (s *BadgerMetadataStore) Restore(ctx context.Context, r io.Reader) error {
 
 		// Reject oversized key allocations from untrusted streams.
 		if keyLen > maxRestoreAllocSize {
-			return fmt.Errorf("%w: key size %d exceeds maximum %d", metadata.ErrRestoreCorrupt, keyLen, maxRestoreAllocSize)
+			return failRestore("%w: key size %d exceeds maximum %d", metadata.ErrRestoreCorrupt, keyLen, maxRestoreAllocSize)
 		}
 
 		// Read key.
 		key := make([]byte, keyLen)
 		if _, err := io.ReadFull(payloadReader, key); err != nil {
-			return fmt.Errorf("%w: read key: %v", metadata.ErrRestoreCorrupt, err)
+			return failRestore("%w: read key: %v", metadata.ErrRestoreCorrupt, err)
 		}
 
 		// Read value_len.
 		if _, err := io.ReadFull(payloadReader, buf[:]); err != nil {
-			return fmt.Errorf("%w: read value_len: %v", metadata.ErrRestoreCorrupt, err)
+			return failRestore("%w: read value_len: %v", metadata.ErrRestoreCorrupt, err)
 		}
 		valLen := binary.LittleEndian.Uint32(buf[:])
 
 		// Reject oversized value allocations from untrusted streams.
 		if valLen > maxRestoreAllocSize {
-			return fmt.Errorf("%w: value size %d exceeds maximum %d", metadata.ErrRestoreCorrupt, valLen, maxRestoreAllocSize)
+			return failRestore("%w: value size %d exceeds maximum %d", metadata.ErrRestoreCorrupt, valLen, maxRestoreAllocSize)
 		}
 
 		// Read value.
 		val := make([]byte, valLen)
 		if _, err := io.ReadFull(payloadReader, val); err != nil {
-			return fmt.Errorf("%w: read value: %v", metadata.ErrRestoreCorrupt, err)
+			return failRestore("%w: read value: %v", metadata.ErrRestoreCorrupt, err)
 		}
 
-		entries = append(entries, kvEntry{Key: key, Value: val})
-	}
-
-	// Verify CRC BEFORE any durable write.
-	// The tee reader has accumulated all payload bytes; the original reader
-	// r still has the trailing 4 CRC bytes unread.
-	if err := backup.VerifyCRC(r, acc); err != nil {
-		return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
-	}
-
-	// CRC verified — flush entries to Badger via WriteBatch.
-	wb := s.db.NewWriteBatch()
-	for i, e := range entries {
-		if err := wb.SetEntry(badgerdb.NewEntry(e.Key, e.Value)); err != nil {
-			wb.Cancel()
-			return fmt.Errorf("%w: set entry: %v", metadata.ErrRestoreCorrupt, err)
+		if err := wb.SetEntry(badgerdb.NewEntry(key, val)); err != nil {
+			return failRestore("%w: set entry: %v", metadata.ErrRestoreCorrupt, err)
 		}
-
-		if (i+1)%restoreBatchSize == 0 {
+		applied++
+		if applied%restoreBatchSize == 0 {
 			if err := wb.Flush(); err != nil {
-				wb.Cancel()
-				return fmt.Errorf("%w: flush batch: %v", metadata.ErrRestoreCorrupt, err)
+				return failRestore("%w: flush batch: %v", metadata.ErrRestoreCorrupt, err)
 			}
 			wb = s.db.NewWriteBatch()
 		}
 	}
 
-	// Flush remaining entries.
+	// Flush the final partial batch so every payload byte has passed through
+	// the tee reader before the CRC check.
 	if err := wb.Flush(); err != nil {
-		wb.Cancel()
-		return fmt.Errorf("%w: flush final batch: %v", metadata.ErrRestoreCorrupt, err)
+		return failRestore("%w: flush final batch: %v", metadata.ErrRestoreCorrupt, err)
+	}
+
+	// Verify CRC. The tee reader accumulated all payload bytes; r still has the
+	// trailing 4 CRC bytes unread. On mismatch, wipe the applied data so the
+	// destination is left empty and the restore is retryable.
+	if err := backup.VerifyCRC(r, acc); err != nil {
+		if derr := s.db.DropAll(); derr != nil {
+			logger.Error("restore: DropAll after CRC failure left store non-empty", "error", derr)
+		}
+		return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
 	}
 
 	return nil

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -45,6 +45,24 @@ const (
 // Ensure BadgerMetadataStore implements FileBlockStore
 var _ blockstore.FileBlockStore = (*BadgerMetadataStore)(nil)
 
+// reapBlockTxn deletes a FileBlock's primary key plus every secondary index
+// (local, file, hash) inside the supplied transaction. Shared by Delete and
+// the decrement-and-reap paths so the teardown stays in one place. The caller
+// has already loaded `block` (its Hash drives the hash-index cleanup).
+func reapBlockTxn(txn *badger.Txn, id string, block *metadata.FileBlock) error {
+	if err := txn.Delete([]byte(fileBlockPrefix + id)); err != nil {
+		return err
+	}
+	_ = txn.Delete([]byte(fileBlockLocalPrefix + id))
+	if pid, idx, ok := splitBlockID(id); ok {
+		_ = txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
+	}
+	if block.IsFinalized() {
+		_ = txn.Delete([]byte(fileBlockHashPrefix + block.Hash.String()))
+	}
+	return nil
+}
+
 // ============================================================================
 // FileBlock Operations
 // ============================================================================
@@ -136,25 +154,7 @@ func (s *BadgerMetadataStore) Delete(ctx context.Context, id string) error {
 			return err
 		}
 
-		// Delete block
-		if err := txn.Delete(key); err != nil {
-			return err
-		}
-
-		// Remove local index
-		_ = txn.Delete([]byte(fileBlockLocalPrefix + id))
-
-		// Remove file index
-		if pid, idx, ok := splitBlockID(id); ok {
-			_ = txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
-		}
-
-		// Remove hash index
-		if block.IsFinalized() {
-			hashKey := []byte(fileBlockHashPrefix + block.Hash.String())
-			_ = txn.Delete(hashKey) // Ignore if not exists
-		}
-		return nil
+		return reapBlockTxn(txn, id, &block)
 	})
 }
 
@@ -238,6 +238,46 @@ func (s *BadgerMetadataStore) DecrementRefCount(ctx context.Context, id string) 
 			block.RefCount--
 		}
 		newCount = block.RefCount
+		val, err := json.Marshal(&block)
+		if err != nil {
+			return err
+		}
+		return txn.Set(key, val)
+	})
+	return newCount, err
+}
+
+// DecrementRefCountAndReap atomically decrements a block's RefCount and, when
+// the new count is 0, deletes the fb:{id} row plus its secondary indexes
+// (local, file, hash) inside the SAME db.Update transaction as the decrement —
+// TOCTOU-free against a concurrent AddRef (same retry-on-conflict idiom as
+// DecrementRefCount). Returns (0, nil) when the row is already absent.
+func (s *BadgerMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	var newCount uint32
+	err := s.updateWithConflictRetry(ctx, func(txn *badger.Txn) error {
+		key := []byte(fileBlockPrefix + id)
+		item, err := txn.Get(key)
+		if err == badger.ErrKeyNotFound {
+			newCount = 0
+			return nil // tolerate already-swept row
+		}
+		if err != nil {
+			return err
+		}
+		var block metadata.FileBlock
+		if err := item.Value(func(val []byte) error {
+			return json.Unmarshal(val, &block)
+		}); err != nil {
+			return err
+		}
+		if block.RefCount > 0 {
+			block.RefCount--
+		}
+		newCount = block.RefCount
+		if block.RefCount == 0 {
+			// Reap so the hash leaves GetByHash / the GC live set.
+			return reapBlockTxn(txn, id, &block)
+		}
 		val, err := json.Marshal(&block)
 		if err != nil {
 			return err
@@ -620,18 +660,7 @@ func (tx *badgerTransaction) Delete(ctx context.Context, id string) error {
 	}); err != nil {
 		return err
 	}
-	if err := tx.txn.Delete(key); err != nil {
-		return err
-	}
-	_ = tx.txn.Delete([]byte(fileBlockLocalPrefix + id))
-	if pid, idx, ok := splitBlockID(id); ok {
-		_ = tx.txn.Delete([]byte(fileBlockFilePrefix + pid + ":" + idx))
-	}
-	if block.IsFinalized() {
-		hashKey := []byte(fileBlockHashPrefix + block.Hash.String())
-		_ = tx.txn.Delete(hashKey)
-	}
-	return nil
+	return reapBlockTxn(tx.txn, id, &block)
 }
 
 // IncrementRefCount runs the +1 read-modify-write under the active
@@ -686,6 +715,44 @@ func (tx *badgerTransaction) DecrementRefCount(ctx context.Context, id string) (
 		block.RefCount--
 	}
 	newCount := block.RefCount
+	val, err := json.Marshal(&block)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.txn.Set(key, val); err != nil {
+		return 0, err
+	}
+	return newCount, nil
+}
+
+// DecrementRefCountAndReap runs the -1 read-modify-write + reap-at-zero under
+// the active badger.Txn so a subsequent rollback discards both the decrement
+// and the row deletion. Returns (0, nil) when the row is already absent.
+func (tx *badgerTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	key := []byte(fileBlockPrefix + id)
+	item, err := tx.txn.Get(key)
+	if err == badger.ErrKeyNotFound {
+		return 0, nil // tolerate already-swept row
+	}
+	if err != nil {
+		return 0, err
+	}
+	var block metadata.FileBlock
+	if err := item.Value(func(val []byte) error {
+		return json.Unmarshal(val, &block)
+	}); err != nil {
+		return 0, err
+	}
+	if block.RefCount > 0 {
+		block.RefCount--
+	}
+	newCount := block.RefCount
+	if block.RefCount == 0 {
+		return 0, reapBlockTxn(tx.txn, id, &block)
+	}
 	val, err := json.Marshal(&block)
 	if err != nil {
 		return 0, err

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -92,6 +92,17 @@ func (s *MemoryMetadataStore) DecrementRefCount(ctx context.Context, id string) 
 	return s.decrementRefCountLocked(ctx, id)
 }
 
+// DecrementRefCountAndReap atomically decrements RefCount and reaps the row
+// (and its hash index entry) when the new count is 0, all under the single
+// s.mu Write lock so the decrement-and-delete is TOCTOU-free against a
+// concurrent AddRef. Implements the FileBlockStore.DecrementRefCountAndReap
+// contract: ErrFileBlockNotFound is tolerated and reported as count 0.
+func (s *MemoryMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.decrementAndReapLocked(ctx, id)
+}
+
 // AddRef atomically increments RefCount on the FileBlock row indexed by
 // the given content hash. Implements the FileBlockStore.AddRef contract
 // used by the in-memory hash dedup LRU hit path to
@@ -227,6 +238,10 @@ func (tx *memoryTransaction) DecrementRefCount(ctx context.Context, id string) (
 	return tx.store.decrementRefCountLocked(ctx, id)
 }
 
+func (tx *memoryTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	return tx.store.decrementAndReapLocked(ctx, id)
+}
+
 func (tx *memoryTransaction) AddRef(ctx context.Context, hash metadata.ContentHash, payloadID string, blockRef blockstore.BlockRef) error {
 	return tx.store.addRefLocked(ctx, hash, payloadID, blockRef)
 }
@@ -342,6 +357,32 @@ func (s *MemoryMetadataStore) decrementRefCountLocked(_ context.Context, id stri
 	}
 	if block.RefCount > 0 {
 		block.RefCount--
+	}
+	return block.RefCount, nil
+}
+
+// decrementAndReapLocked decrements RefCount and, when the new count is 0,
+// deletes the row plus its hash-index entry. Caller MUST hold s.mu Write lock
+// so the decrement-and-delete is a single atomic critical section. Returns
+// (0, nil) when the row is already absent (a swept row is not a caller error).
+func (s *MemoryMetadataStore) decrementAndReapLocked(ctx context.Context, id string) (uint32, error) {
+	if s.fileBlockData == nil {
+		return 0, nil
+	}
+	block, ok := s.fileBlockData.blocks[id]
+	if !ok {
+		return 0, nil
+	}
+	if block.RefCount > 0 {
+		block.RefCount--
+	}
+	if block.RefCount == 0 {
+		// Reap via the shared teardown (drops the row and, when finalized,
+		// its hash-index entry) — runs in this same lock region so the
+		// decrement-and-delete is TOCTOU-free vs AddRef. The row exists
+		// (looked up above), so the NotFound branch cannot fire here.
+		_ = s.deleteFileBlockLocked(ctx, id)
+		return 0, nil
 	}
 	return block.RefCount, nil
 }

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -160,6 +160,55 @@ func (s *PostgresMetadataStore) DecrementRefCount(ctx context.Context, id string
 	return newCount, nil
 }
 
+// DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
+// deletes the row — both statements run inside ONE transaction so the
+// decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
+// (which takes the same row lock). The conditional `ref_count = 0` predicate on
+// the DELETE means a concurrent bump that landed between the two statements
+// (impossible within the row lock, but defended anyway) leaves the row alive.
+// Returns (0, nil) when the row is already absent — a swept row is not a caller
+// error.
+func (s *PostgresMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("decrement-and-reap begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	newCount, err := decrementAndReapTx(ctx, tx, id)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("decrement-and-reap commit: %w", err)
+	}
+	return newCount, nil
+}
+
+// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE on the given
+// pgx.Tx. Shared by the pool-backed store method and the postgresTransaction
+// method so both surfaces behave identically. Returns ErrFileBlockNotFound
+// mapped to (0, nil) — i.e. a missing row is tolerated.
+func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, error) {
+	var newCount uint32
+	err := tx.QueryRow(ctx,
+		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
+		id).Scan(&newCount)
+	if err == pgx.ErrNoRows {
+		return 0, nil // tolerate already-swept row
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	if newCount == 0 {
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM file_blocks WHERE id = $1 AND ref_count = 0`, id); err != nil {
+			return 0, fmt.Errorf("reap zero-ref block: %w", err)
+		}
+	}
+	return newCount, nil
+}
+
 // AddRef atomically bumps RefCount on the FileBlock row(s) indexed by
 // the given content hash. Implements the FileBlockStore.AddRef contract
 // used by the in-memory hash dedup LRU hit path to
@@ -526,6 +575,16 @@ func (tx *postgresTransaction) DecrementRefCount(ctx context.Context, id string)
 		return 0, fmt.Errorf("decrement ref count: %w", err)
 	}
 	return newCount, nil
+}
+
+// DecrementRefCountAndReap runs the -1 UPDATE + reap-at-zero DELETE on the
+// active pgx.Tx so a subsequent rollback undoes both. Returns (0, nil) when the
+// row is already absent.
+func (tx *postgresTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return decrementAndReapTx(ctx, tx.tx, id)
 }
 
 // AddRef runs the +1 UPDATE keyed by hash on the active pgx.Tx so a

--- a/pkg/metadata/storetest/backup_conformance.go
+++ b/pkg/metadata/storetest/backup_conformance.go
@@ -392,6 +392,16 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		if !errors.Is(err, metadata.ErrRestoreCorrupt) {
 			t.Fatalf("expected ErrRestoreCorrupt, got: %v", err)
 		}
+
+		// A failed restore must leave the destination empty and retryable.
+		// The streaming badger path wipes partially-applied data via DropAll;
+		// the buffer-then-write backends never apply at all. Either way a
+		// subsequent VALID restore into the SAME store must succeed — if the
+		// corrupt attempt left rows behind, Restore's empty-destination guard
+		// would reject this with ErrRestoreDestinationNotEmpty (#831).
+		if err := dstB.Restore(ctx, bytes.NewReader(validData)); err != nil {
+			t.Fatalf("valid restore after corrupt(truncated) restore must succeed (store left empty/retryable), got: %v", err)
+		}
 	})
 
 	t.Run("BitFlip", func(t *testing.T) {
@@ -413,6 +423,12 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		}
 		if !errors.Is(err, metadata.ErrRestoreCorrupt) {
 			t.Fatalf("expected ErrRestoreCorrupt, got: %v", err)
+		}
+
+		// Same retryability contract as Truncated: a corrupt payload must
+		// leave the destination empty so a valid restore still succeeds (#831).
+		if err := dstB.Restore(ctx, bytes.NewReader(validData)); err != nil {
+			t.Fatalf("valid restore after corrupt(bit-flip) restore must succeed (store left empty/retryable), got: %v", err)
 		}
 	})
 

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -174,6 +174,132 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("PutGet_PendingHashRoundTrips", func(t *testing.T) {
 		testPutGet_PendingHashRoundTrips(t, factory)
 	})
+
+	// DecrementRefCountAndReap is the engine Delete/Truncate reclaim path
+	// (#832): once a hash has no live references its FileBlock index row is
+	// deleted in the same critical section as the decrement, so the hash
+	// leaves EnumerateFileBlocks and the GC sweep can collect the remote
+	// chunk. Three cases pin the contract across all backends: reap-at-zero
+	// (row + hash index gone), survive-when-still-referenced, and
+	// tolerate-missing-row.
+	t.Run("DecrementRefCountAndReap", func(t *testing.T) {
+		testDecrementRefCountAndReap(t, factory)
+	})
+}
+
+// testDecrementRefCountAndReap pins the DecrementRefCountAndReap contract:
+//
+//	(a) refcount 1 → reap: returns 0, GetByHash==nil, GetFileBlock→NotFound.
+//	(b) refcount 2 → no reap: returns 1, row + hash index still present.
+//	(c) non-existent id → returns 0, nil (a swept row is not a caller error).
+func testDecrementRefCountAndReap(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	// (a) refcount 1: the decrement drops to 0 → the row is reaped.
+	t.Run("ReapsAtZero", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+		legacy := asLegacy(t, store)
+
+		hash := hashOfSeed("reap-at-zero")
+		fb := &blockstore.FileBlock{
+			ID:            "file-reap/0",
+			Hash:          hash,
+			State:         blockstore.BlockStateRemote,
+			BlockStoreKey: blockstore.FormatCASKey(hash),
+			LocalPath:     "/cache/reap0",
+			DataSize:      4096,
+			RefCount:      1,
+			LastAccess:    time.Now(),
+			CreatedAt:     time.Now(),
+		}
+		if err := store.Put(ctx, fb); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+
+		got, err := store.DecrementRefCountAndReap(ctx, fb.ID)
+		if err != nil {
+			t.Fatalf("DecrementRefCountAndReap: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("new count = %d, want 0 (reaped)", got)
+		}
+
+		// Hash index entry must be gone: GetByHash returns (nil, nil).
+		byHash, err := store.GetByHash(ctx, hash)
+		if err != nil {
+			t.Fatalf("GetByHash post-reap: %v", err)
+		}
+		if byHash != nil {
+			t.Errorf("GetByHash returned %+v after reap; want nil (hash index entry must be gone so the hash leaves EnumerateFileBlocks)", byHash)
+		}
+
+		// The row itself must be gone: GetFileBlock → ErrFileBlockNotFound.
+		if _, err := legacy.GetFileBlock(ctx, fb.ID); !errors.Is(err, metadata.ErrFileBlockNotFound) {
+			t.Errorf("GetFileBlock post-reap err = %v; want ErrFileBlockNotFound (row reaped)", err)
+		}
+	})
+
+	// (b) refcount 2: the decrement leaves 1 → the row survives.
+	t.Run("SurvivesWhenStillReferenced", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+		legacy := asLegacy(t, store)
+
+		hash := hashOfSeed("reap-survives")
+		fb := &blockstore.FileBlock{
+			ID:            "file-survive/0",
+			Hash:          hash,
+			State:         blockstore.BlockStateRemote,
+			BlockStoreKey: blockstore.FormatCASKey(hash),
+			LocalPath:     "/cache/survive0",
+			DataSize:      4096,
+			RefCount:      1,
+			LastAccess:    time.Now(),
+			CreatedAt:     time.Now(),
+		}
+		if err := store.Put(ctx, fb); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		// Second reference (refcount 1 → 2).
+		if err := store.IncrementRefCount(ctx, fb.ID); err != nil {
+			t.Fatalf("IncrementRefCount: %v", err)
+		}
+
+		got, err := store.DecrementRefCountAndReap(ctx, fb.ID)
+		if err != nil {
+			t.Fatalf("DecrementRefCountAndReap: %v", err)
+		}
+		if got != 1 {
+			t.Errorf("new count = %d, want 1 (still referenced — no reap)", got)
+		}
+
+		// Row + hash index must survive.
+		if _, err := legacy.GetFileBlock(ctx, fb.ID); err != nil {
+			t.Errorf("GetFileBlock after non-reap decrement: %v; want row still present", err)
+		}
+		byHash, err := store.GetByHash(ctx, hash)
+		if err != nil {
+			t.Fatalf("GetByHash after non-reap decrement: %v", err)
+		}
+		if byHash == nil {
+			t.Error("GetByHash returned nil after non-reap decrement; want the still-referenced row")
+		}
+	})
+
+	// (c) non-existent id: a swept row is not a caller error.
+	t.Run("ToleratesMissingRow", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		got, err := store.DecrementRefCountAndReap(ctx, "file-never-existed/0")
+		if err != nil {
+			t.Fatalf("DecrementRefCountAndReap(missing) err = %v; want nil (tolerated)", err)
+		}
+		if got != 0 {
+			t.Errorf("DecrementRefCountAndReap(missing) count = %d, want 0", got)
+		}
+	})
 }
 
 // ============================================================================

--- a/test/e2e/BENCHMARKS.md
+++ b/test/e2e/BENCHMARKS.md
@@ -410,9 +410,11 @@ insert).
   gob-encodes its entire snapshot into one buffer during Backup (expected
   for an in-RAM backend) — the create-path `B/op` for the memory engine
   reflects that buffer, not the dump stream. **Use the badger engine for
-  large shares; it streams the dump KV-by-KV.** (Badger restore still
-  buffers all KV entries in RAM before the integrity CRC is verified — a
-  known restore-path ceiling, orthogonal to create, tracked separately.)
+  large shares; it streams the dump KV-by-KV.** Badger restore also
+  streams: KV entries apply via a bounded `WriteBatch`, the integrity CRC
+  is verified last, and any failure triggers `DropAll` to leave the store
+  empty/retryable — so neither badger create nor badger restore buffers
+  the whole dump.
 
 ## End-to-end performance reports
 


### PR DESCRIPTION
Closes #830, #831, #832 — snapshot-audit scale-hardening follow-ups.

## #832 — GC now reclaims truncated/deleted remote chunks (the real fix)
Root cause (broader than the ticket): remote chunks are reclaimed only by the mark-sweep GC, whose live-set is every hash emitted by `EnumerateFileBlocks` (the FileBlock index). But **nothing in production ever deleted a RefCount-0 index row** (`DeleteWithRefCount` is dead, `Syncer.Delete/Truncate` are no-ops, `AuditRefcounts` is read-only) and `EnumerateFileBlocks` emits all rows — so GC never reclaimed deleted *or* truncated chunks. Additionally no truncate path decremented refcounts at all (CREATE-O_TRUNC passed `nil` blocks; SETATTR never called `blockStore.Truncate`).

Snapshot **correctness** was already fine (#823 trims `FileAttr.Blocks`); this is purely deferred space reclaim.

Fix (data-loss-safe — only reaps at RefCount==0, atomically):
- New `DecrementRefCountAndReap` on `blockstore.FileBlockStore`: decrement and, iff the new count is 0, delete the row + hash-index entry **in the same critical section** (TOCTOU-free against `AddRef`, like the existing increment contract). Implemented atomically in memory (mutex), badger (single `Update` txn), postgres (`UPDATE … RETURNING` + conditional `DELETE … WHERE ref_count=0` in one tx).
- Engine `Truncate`/`Delete` reclaim sites call the reaping variant → hash leaves the live-set → the existing, tested GC sweep reclaims the chunk. `EnumerateFileBlocks` semantics unchanged (no GC-by-drifty-refcount risk).
- Real pre-truncate `FileAttr.Blocks` are now threaded into `blockStore.Truncate` from NFS v3 CREATE + v3/v4 SETATTR (size-down only, captured before the metadata prune).

Proof: `TestGCMarkSweep_TruncateReclaimsRemoteChunk` (dropped chunk swept, kept chunk retained) + `TestGCMarkSweep_TruncateDedupSafety` (hash shared by another live file is NOT swept). Verified fail-on-develop / pass-with-fix. New `DecrementRefCountAndReap` conformance subtests pass on memory/badger/postgres.

## #831 — badger restore streams (bounded RAM)
Badger `Restore` buffered every KV entry before the integrity CRC. Now streams entries via a bounded `WriteBatch`, verifies the CRC last, and `DropAll`s on any failure. Since restore requires an empty destination, wiping partial data preserves the corrupt→empty/retryable contract. Conformance now asserts a failed corrupt restore leaves the store empty and a subsequent valid restore succeeds — **negative-control verified** (without `DropAll`, badger fails with `ErrRestoreDestinationNotEmpty`).

## #830 — document the memory-engine ceiling
The memory metadata engine is resident-by-design and serializes the whole snapshot into one buffer on create — inherent, not tunable. Documented the ceiling in `docs/SNAPSHOTS.md` and recommend the badger engine (streams create + bounded restore) for TB / M-file shares; refreshed `BENCHMARKS.md` now that badger restore streams too.

## Validation
- build / `go vet` / `gofmt` / `golangci-lint` (0 issues) clean; `-race` clean on engine + coordinator.
- Independent code review: no high-confidence issues; data-loss safety of the reap confirmed across all 3 backends.
- The #832 fix was also validated live end-to-end against real Cubbit/DS3 over an NFS mount (write → delete one file → durable snapshot `remote_durable=true` → mutate → restore → byte-identical).