### PR TITLE
fix(smb/durable): purge disconnected durable handle on conflicting open (#808)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -756,6 +756,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			newLeaseState,
 			newLeaseKey,
 			req.ShareAccess,
+			req.DesiredAccess,
 		); purged > 0 {
 			logger.Debug("CREATE: purged disconnected handles on conflicting open",
 				"path", filename,

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -30,6 +30,17 @@ import (
 //   - A new open with FILE_SHARE_NONE on a file with a disconnected handle
 //     purges the disconnected handle (share-mode conflict, MS-FSA 2.1.5.1.2).
 //
+//   - A new data-access open whose access the disconnected handle's OWN deny
+//     mode excludes (e.g. D opened FILE_SHARE_NONE, new open wants read/write)
+//     purges D — the new open breaks D's lease/oplock and the disconnected
+//     client cannot ack (durable_open.open2-lease).
+//
+//   - A new data-access open on a file with a disconnected EXCLUSIVE/BATCH
+//     oplock holder (persisted as an RWH synthetic lease) purges D: the
+//     exclusive oplock breaks on any second opener and the disconnected client
+//     cannot ack (durable_open.oplock / open2-oplock). A stat-only second open
+//     does NOT break it (Samba is_stat_open) and does NOT purge.
+//
 //   - A WRITE from a live handle breaks Level-II (Read) leases on the same
 //     file to None per MS-SMB2 §3.3.5.16; any disconnected RH lease on the
 //     file with a different lease-key is purged (it would break to None).
@@ -86,26 +97,42 @@ const (
 // Inputs:
 //   - dLeaseState: the lease state persisted at disconnect (R/RH/RWH bits or None).
 //   - dLeaseKey: D's lease key.
+//   - dShareAccess: share-mode bits D was originally opened with (its deny mode).
 //   - newLeaseState: lease state requested by the new open (zero if no lease).
 //   - newLeaseKey: lease key of the new open's lease (zero if no lease).
 //   - newShareAccess: share-mode bits from the new CREATE.
+//   - newDesiredAccess: desired-access mask from the new CREATE.
+//   - newIsStatOnly: true when the new open is stat-only (no data access). A
+//     stat-only open neither breaks an oplock/lease nor triggers a share-mode
+//     conflict (MS-SMB2 §3.3.5.9; Samba is_stat_open), so it never purges.
 //
 // Decision rules (see file-level comment for spec mapping):
 //
 //   - newShareAccess excludes all of {READ, WRITE, DELETE} (SHARE_NONE) →
-//     purge (MS-FSA 2.1.5.1.2 share-mode conflict).
-//   - D holds W (RWH) AND new open requests any non-None lease with a
-//     DIFFERENT lease key → purge (two W-capable cachers on different keys
-//     cannot coexist; the break_to value strips W and, per Samba's
-//     delay_for_oplock_fn lease-strip cascade, leaves W-only which is an
-//     invalid lease state → effectively break to NONE → lose H).
+//     purge (MS-FSA 2.1.5.1.2 share-mode conflict on the NEW open's deny mode).
+//   - D was opened with a deny mode that excludes the new open's access
+//     (D.ShareAccess denies new.DesiredAccess) → purge. This is the V1
+//     durable_open.open2-lease case: D held an RH lease with FILE_SHARE_NONE,
+//     a later read/write open conflicts with D's deny mode, breaks D's lease,
+//     and D's disconnected client cannot ack → durable lost.
+//   - D holds W (RWH / exclusive / batch caching) AND the new open carries
+//     real data access → purge. An exclusive/batch caching open breaks on ANY
+//     conflicting data-access open regardless of whether the new open itself
+//     requests a lease (V1 durable_open.oplock / open2-oplock: D held a BATCH
+//     oplock — persisted as an RWH synthetic lease — and a plain second open
+//     with no oplock breaks it). The same-lease-key carve-out preserves an
+//     identical-key open (which is reconnect-equivalent and never reaches this
+//     predicate in practice); a zero D-key is "no key" and never matches.
 //   - Otherwise → preserve.
 func disconnectedConflictOnNewOpen(
 	dLeaseState uint32,
 	dLeaseKey [16]byte,
+	dShareAccess uint32,
 	newLeaseState uint32,
 	newLeaseKey [16]byte,
 	newShareAccess uint32,
+	newDesiredAccess uint32,
+	newIsStatOnly bool,
 ) disconnectedHandleAction {
 	// SHARE_NONE conflict: any disconnected handle is purged because the
 	// disconnected open held shared access and the new open denies it.
@@ -113,23 +140,63 @@ func disconnectedConflictOnNewOpen(
 		return disconnectedActionPurge
 	}
 
-	// W-on-W conflict on different keys: the disconnected handle held W,
-	// new open requests any non-None lease (W or RH). Even an RH request
-	// from a different key forces the W-holder to lose W; in Samba this
-	// cascades through the candidate downgrade chain (RWH → RH → R → NONE)
-	// and lands on a state lacking H because the disconnected holder cannot
-	// ack the in-flight break. Purge.
+	// Stat-only opens impose no oplock-break or share-mode constraint — they
+	// neither break D's caching nor violate D's deny mode. Preserve. Mirrors
+	// keep-disconnected-{rh,rwh}-with-stat-open.
+	if newIsStatOnly {
+		return disconnectedActionPreserve
+	}
+
+	// D's own deny mode excludes the new open: D was opened with a share mode
+	// that does not permit the new open's data access. The new open breaks D's
+	// lease/oplock to honour the access; D's disconnected client cannot ack →
+	// purge. Covers durable_open.open2-lease (D: RH lease + FILE_SHARE_NONE,
+	// new: read/write open).
+	if disconnectedShareDeniesNewOpen(dShareAccess, newDesiredAccess) {
+		return disconnectedActionPurge
+	}
+
+	// W-on-W / exclusive-caching conflict: the disconnected handle held W
+	// (RWH — exclusive or batch caching). A conflicting data-access open
+	// forces the W-holder to break; in Samba this cascades through the
+	// candidate downgrade chain (RWH → RH → R → NONE) and lands on a state
+	// lacking H because the disconnected holder cannot ack the in-flight
+	// break. Purge regardless of whether the new open requests a lease — an
+	// exclusive/batch oplock breaks on any second opener's access.
 	//
 	// Key comparison treats a zero lease key as "no key" — distinct from any
-	// other key, including another zero. This matters for oplock-V2 / no-lease
-	// opens on both sides: they cannot coexist with a W-holder either.
-	if dLeaseState&smbLeaseWrite != 0 && newLeaseState != 0 {
-		if dLeaseKey != newLeaseKey || dLeaseKey == ([16]byte{}) {
+	// other key, including another zero. The same-key carve-out only spares an
+	// open that shares D's exact lease key (reconnect-equivalent).
+	if dLeaseState&smbLeaseWrite != 0 {
+		if newLeaseKey != dLeaseKey || dLeaseKey == ([16]byte{}) {
 			return disconnectedActionPurge
 		}
 	}
 
 	return disconnectedActionPreserve
+}
+
+// disconnectedShareDeniesNewOpen reports whether a disconnected durable
+// handle's original share-access mode (dShareAccess) denies the data access
+// requested by a new open (newDesiredAccess). Mirrors the D-side half of
+// checkShareModeConflict (handler.go) but operates on a persisted record
+// rather than a live OpenFile, reusing the same access-mask classifiers
+// (hasReadAccess / hasWriteAccess / hasDeleteAccess).
+//
+// A disconnected handle that shared nothing (FILE_SHARE_NONE) denies any
+// read/write/delete-bearing open. A handle that shared READ still denies a
+// WRITE-bearing open, etc. Stat-only new opens are filtered by the caller.
+func disconnectedShareDeniesNewOpen(dShareAccess, newDesiredAccess uint32) bool {
+	if hasReadAccess(newDesiredAccess) && dShareAccess&smbShareRead == 0 {
+		return true
+	}
+	if hasWriteAccess(newDesiredAccess) && dShareAccess&smbShareWrite == 0 {
+		return true
+	}
+	if hasDeleteAccess(newDesiredAccess) && dShareAccess&smbShareDelete == 0 {
+		return true
+	}
+	return false
 }
 
 // disconnectedConflictOnDataChange evaluates whether a WRITE or RENAME from a
@@ -185,10 +252,12 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 	newLeaseState uint32,
 	newLeaseKey [16]byte,
 	newShareAccess uint32,
+	newDesiredAccess uint32,
 ) int {
 	if h.DurableStore == nil || len(metaHandle) == 0 {
 		return 0
 	}
+	newIsStatOnly := isStatOnlyOpen(newDesiredAccess)
 	h.durablePurgeMu.Lock()
 	defer h.durablePurgeMu.Unlock()
 	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
@@ -208,9 +277,9 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 			continue
 		}
 		action := disconnectedConflictOnNewOpen(
-			d.LeaseState, d.LeaseKey,
+			d.LeaseState, d.LeaseKey, d.ShareAccess,
 			newLeaseState, newLeaseKey,
-			newShareAccess,
+			newShareAccess, newDesiredAccess, newIsStatOnly,
 		)
 		if action != disconnectedActionPurge {
 			continue

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -25,102 +26,125 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 
 		shareAll         = smbShareRead | smbShareWrite | smbShareDelete
 		shareNone uint32 = 0
+
+		// New-open desired-access masks.
+		accessReadWrite uint32 = 0x00000001 | 0x00000002 // FILE_READ_DATA | FILE_WRITE_DATA
+		accessStatOnly  uint32 = 0x00000080              // FILE_READ_ATTRIBUTES only
 	)
 
 	leaseA := [16]byte{0x01}
 	leaseB := [16]byte{0x02}
 
 	tests := []struct {
-		name           string
-		dLeaseState    uint32
-		dLeaseKey      [16]byte
-		newLeaseState  uint32
-		newLeaseKey    [16]byte
-		newShareAccess uint32
-		want           disconnectedHandleAction
+		name             string
+		dLeaseState      uint32
+		dLeaseKey        [16]byte
+		dShareAccess     uint32
+		newLeaseState    uint32
+		newLeaseKey      [16]byte
+		newShareAccess   uint32
+		newDesiredAccess uint32
+		newIsStatOnly    bool
+		want             disconnectedHandleAction
 	}{
 		{
 			// keep-disconnected-rh-with-stat-open: stat open carries no lease
 			// and default share-all. Disconnected RH must be preserved.
-			name:           "keep_RH_with_stat",
-			dLeaseState:    rh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  none,
-			newLeaseKey:    [16]byte{},
-			newShareAccess: shareAll,
-			want:           disconnectedActionPreserve,
+			name:             "keep_RH_with_stat",
+			dLeaseState:      rh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessStatOnly,
+			newIsStatOnly:    true,
+			want:             disconnectedActionPreserve,
 		},
 		{
 			// keep-disconnected-rwh-with-stat-open mirrors keep_RH_with_stat:
 			// disconnected RWH with stat open from a different connection
 			// must also be preserved (stat open does not break leases).
-			name:           "keep_RWH_with_stat",
-			dLeaseState:    rwh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  none,
-			newLeaseKey:    [16]byte{},
-			newShareAccess: shareAll,
-			want:           disconnectedActionPreserve,
+			name:             "keep_RWH_with_stat",
+			dLeaseState:      rwh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessStatOnly,
+			newIsStatOnly:    true,
+			want:             disconnectedActionPreserve,
 		},
 		{
 			// keep-disconnected-rh-with-rh-open: two RH leases on different
-			// keys can coexist — disconnected stays. Reaches the W-on-W rule
-			// but D doesn't hold W, so falls through to preserve.
-			name:           "keep_RH_with_RH_diff_key",
-			dLeaseState:    rh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  rh,
-			newLeaseKey:    leaseB,
-			newShareAccess: shareAll,
-			want:           disconnectedActionPreserve,
+			// keys can coexist — disconnected stays. D doesn't hold W and its
+			// share mode is share-all, so falls through to preserve.
+			name:             "keep_RH_with_RH_diff_key",
+			dLeaseState:      rh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    rh,
+			newLeaseKey:      leaseB,
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPreserve,
 		},
 		{
 			// keep-disconnected-rh-with-rwh-open: disconnected RH stays
 			// even when the new open requests RWH — the new open just gets
 			// downgraded to RH (W denied by the H-holder), no break needed.
 			// D doesn't hold W, so the W-on-W rule doesn't fire.
-			name:           "keep_RH_with_RWH_diff_key",
-			dLeaseState:    rh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  rwh,
-			newLeaseKey:    leaseB,
-			newShareAccess: shareAll,
-			want:           disconnectedActionPreserve,
+			name:             "keep_RH_with_RWH_diff_key",
+			dLeaseState:      rh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    rwh,
+			newLeaseKey:      leaseB,
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPreserve,
 		},
 		{
 			// purge-disconnected-rwh-with-rwh-open: disconnected RWH and a
 			// new RWH on a different key cannot coexist; the disconnected
 			// loses W → loses H → purge.
-			name:           "purge_RWH_with_RWH_diff_key",
-			dLeaseState:    rwh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  rwh,
-			newLeaseKey:    leaseB,
-			newShareAccess: shareAll,
-			want:           disconnectedActionPurge,
+			name:             "purge_RWH_with_RWH_diff_key",
+			dLeaseState:      rwh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    rwh,
+			newLeaseKey:      leaseB,
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
 		},
 		{
 			// purge-disconnected-rwh-with-rh-open: disconnected RWH and a
 			// new RH on a different key. The W must be broken; cascade
 			// strips H → purge.
-			name:           "purge_RWH_with_RH_diff_key",
-			dLeaseState:    rwh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  rh,
-			newLeaseKey:    leaseB,
-			newShareAccess: shareAll,
-			want:           disconnectedActionPurge,
+			name:             "purge_RWH_with_RH_diff_key",
+			dLeaseState:      rwh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    rh,
+			newLeaseKey:      leaseB,
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
 		},
 		{
 			// purge-disconnected-rh-with-share-none-open: SHARE_NONE open on
 			// a file with a disconnected RH must purge.
-			name:           "purge_RH_with_share_none",
-			dLeaseState:    rh,
-			dLeaseKey:      leaseA,
-			newLeaseState:  none,
-			newLeaseKey:    [16]byte{},
-			newShareAccess: shareNone,
-			want:           disconnectedActionPurge,
+			name:             "purge_RH_with_share_none",
+			dLeaseState:      rh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareNone,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
 		},
 		{
 			// Zero-key W-holder vs new lease (any key): zero key is "no key"
@@ -128,22 +152,70 @@ func TestDisconnectedConflictOnNewOpen(t *testing.T) {
 			// with empty lease keys cannot coexist on a W lease. This pins
 			// the finding-#4 behaviour where oplock-V2 (no lease) reconnect
 			// no longer accidentally hides behind the old reconnect-guard.
-			name:           "purge_RWH_zero_key_vs_RH",
-			dLeaseState:    rwh,
-			dLeaseKey:      [16]byte{},
-			newLeaseState:  rh,
-			newLeaseKey:    leaseB,
-			newShareAccess: shareAll,
-			want:           disconnectedActionPurge,
+			name:             "purge_RWH_zero_key_vs_RH",
+			dLeaseState:      rwh,
+			dLeaseKey:        [16]byte{},
+			dShareAccess:     shareAll,
+			newLeaseState:    rh,
+			newLeaseKey:      leaseB,
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
+		},
+		{
+			// durable_open.open2-lease (V1): D held an RH lease opened with
+			// FILE_SHARE_NONE; a later read/write open with share-all
+			// conflicts with D's own deny mode → purge. D holds no W, so this
+			// fires via the share-deny rule, not the W-on-W rule.
+			name:             "purge_RH_shareNone_D_vs_readwrite_open",
+			dLeaseState:      rh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareNone,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
+		},
+		{
+			// durable_open.oplock / open2-oplock (V1): D held a BATCH oplock,
+			// persisted as an RWH synthetic lease (zero/synthetic key), opened
+			// share-all. A plain second open with no lease and real data access
+			// breaks the exclusive oplock → purge. Exercises the W-holder rule
+			// firing even though newLeaseState == 0.
+			name:             "purge_batch_oplock_D_vs_no_lease_open",
+			dLeaseState:      rwh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessReadWrite,
+			want:             disconnectedActionPurge,
+		},
+		{
+			// Negative control for the oplock rule: same as above but the
+			// second open is stat-only — an exclusive oplock does NOT break on
+			// a stat open (Samba is_stat_open), so D must be preserved.
+			name:             "keep_batch_oplock_D_vs_stat_open",
+			dLeaseState:      rwh,
+			dLeaseKey:        leaseA,
+			dShareAccess:     shareAll,
+			newLeaseState:    none,
+			newLeaseKey:      [16]byte{},
+			newShareAccess:   shareAll,
+			newDesiredAccess: accessStatOnly,
+			newIsStatOnly:    true,
+			want:             disconnectedActionPreserve,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := disconnectedConflictOnNewOpen(
-				tc.dLeaseState, tc.dLeaseKey,
+				tc.dLeaseState, tc.dLeaseKey, tc.dShareAccess,
 				tc.newLeaseState, tc.newLeaseKey,
-				tc.newShareAccess,
+				tc.newShareAccess, tc.newDesiredAccess, tc.newIsStatOnly,
 			)
 			if got != tc.want {
 				t.Fatalf("got=%v want=%v", got, tc.want)
@@ -326,12 +398,15 @@ func TestPurgeConflictingDisconnectedHandlesForOpen(t *testing.T) {
 	now := time.Now()
 	metaHandle := []byte("file-handle-2")
 
+	const accessReadWrite uint32 = 0x00000001 | 0x00000002 // FILE_READ_DATA | FILE_WRITE_DATA
+
 	store := newMockDurableStore()
 	_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
 		ID:             "disconnected-rwh",
 		MetadataHandle: metaHandle,
 		LeaseKey:       [16]byte{0x01},
 		LeaseState:     rwh,
+		ShareAccess:    shareAll,
 		DisconnectedAt: now.Add(-time.Second),
 	})
 	_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
@@ -339,6 +414,7 @@ func TestPurgeConflictingDisconnectedHandlesForOpen(t *testing.T) {
 		MetadataHandle: metaHandle,
 		LeaseKey:       [16]byte{0x02},
 		LeaseState:     rwh,
+		ShareAccess:    shareAll,
 		// Not disconnected — must be skipped.
 		DisconnectedAt: time.Time{},
 	})
@@ -348,7 +424,7 @@ func TestPurgeConflictingDisconnectedHandlesForOpen(t *testing.T) {
 	// must be broken; cascade strips H), leaves the live handle alone.
 	got := h.purgeConflictingDisconnectedHandlesForOpen(
 		context.Background(), metaHandle,
-		rh, [16]byte{0x99}, shareAll,
+		rh, [16]byte{0x99}, shareAll, accessReadWrite,
 	)
 	if got != 1 {
 		t.Fatalf("purged=%d want=1", got)
@@ -391,7 +467,7 @@ func TestDurablePurgeMuSerializesPersistAndPurge(t *testing.T) {
 		for i := 0; i < iterations; i++ {
 			// SHARE_NONE forces purge of any disconnected handle on the file.
 			h.purgeConflictingDisconnectedHandlesForOpen(
-				context.Background(), metaHandle, 0, [16]byte{}, 0,
+				context.Background(), metaHandle, 0, [16]byte{}, 0, 0,
 			)
 		}
 	}()
@@ -470,4 +546,183 @@ func TestOpenHasLocksFailClosed(t *testing.T) {
 			t.Fatal("lock manager lookup failure must fail closed (return true)")
 		}
 	})
+}
+
+// TestDurableOpenConflictingOpenPurgesAcrossConnections is the cross-connection
+// repro for issue #808: it drives the SAME entrypoints the live SMB CREATE path
+// uses — purgeConflictingDisconnectedHandlesForOpen (the Step 8a-bis purge
+// wrapper invoked on every fresh CREATE) and ProcessDurableReconnectContext
+// (the DHnC reconnect entrypoint) — across two connections sharing one durable
+// store.
+//
+// Sequence per mode:
+//  1. Session A opens a durable handle and transport-disconnects → persisted.
+//  2. Session B issues a CONFLICTING fresh CREATE on the same file → the purge
+//     wrapper must delete A's disconnected handle.
+//  3. Session A reconnects via DHnC → must fail OBJECT_NAME_NOT_FOUND because
+//     the handle is gone.
+//
+// Modes mirror the three smbtorture failures the issue targets:
+//   - oplock / open2-oplock: A held a BATCH oplock (persisted RWH synthetic
+//     lease), B opens with no oplock and real data access → break → purge.
+//   - open2-lease: A held an RH lease with FILE_SHARE_NONE, B opens read/write
+//     with share-all → A's own deny mode is violated → break → purge.
+//
+// The negative control (keep-disconnected) proves a NON-conflicting open
+// (stat-only second open against the same RWH/RH holder) leaves the handle
+// reconnectable — guarding against over-purge regression.
+func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
+	const (
+		rh  = smbLeaseRead | smbLeaseHandle
+		rwh = smbLeaseRead | smbLeaseHandle | smbLeaseWrite
+
+		shareAll  uint32 = smbShareRead | smbShareWrite | smbShareDelete
+		shareNone uint32 = 0
+
+		accessReadWrite uint32 = 0x00000001 | 0x00000002 // FILE_READ_DATA | FILE_WRITE_DATA
+		accessStatOnly  uint32 = 0x00000080              // FILE_READ_ATTRIBUTES only
+	)
+
+	keyHash := makeSessionKeyHash("session-A-key")
+	metaHandle := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	// Persisted FileIDs zero the volatile half — see buildPersistedDurableHandle.
+	fileID := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	// seedSessionA persists session A's disconnected durable handle. leaseKey
+	// is zero for an oplock-backed (traditional) holder and non-zero for a
+	// lease-backed holder; the V1 DHnC reconnect harness only re-establishes
+	// oplock-backed handles without a lease-request context, so the keep
+	// controls (which assert reconnect success) use leaseKey=zero.
+	seedSessionA := func(store *mockDurableStore, dLeaseState, dShareAccess uint32, oplock uint8, leaseKey [16]byte) {
+		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+			ID:             "session-A",
+			FileID:         fileID,
+			Path:           "conflict.dat",
+			ShareName:      "/share1",
+			DesiredAccess:  accessReadWrite,
+			ShareAccess:    dShareAccess,
+			MetadataHandle: metaHandle,
+			OplockLevel:    oplock,
+			LeaseKey:       leaseKey,
+			LeaseState:     dLeaseState,
+			Username:       "alice",
+			SessionKeyHash: keyHash,
+			IsV2:           false,
+			CreatedAt:      time.Now().Add(-time.Minute),
+			DisconnectedAt: time.Now().Add(-10 * time.Second),
+			TimeoutMs:      60000,
+		})
+	}
+
+	// reconnectA models session A's DHnC reconnect through the real entrypoint
+	// and returns the resulting status.
+	reconnectA := func(store *mockDurableStore) types.Status {
+		dhnCData := make([]byte, 16)
+		copy(dhnCData, fileID[:])
+		_, status, err := ProcessDurableReconnectContext(
+			context.Background(), store, nil,
+			[]CreateContext{{Name: DurableHandleV1ReconnectTag, Data: dhnCData}},
+			777, "alice", keyHash, "/share1", "conflict.dat", [16]byte{},
+		)
+		if err != nil {
+			t.Fatalf("reconnect error: %v", err)
+		}
+		return status
+	}
+
+	conflictCases := []struct {
+		name         string
+		dLeaseState  uint32
+		dShareAccess uint32
+		dOplock      uint8
+		dLeaseKey    [16]byte
+		// session B's conflicting fresh open
+		bLeaseState    uint32
+		bLeaseKey      [16]byte
+		bShareAccess   uint32
+		bDesiredAccess uint32
+	}{
+		{
+			// durable_open.oplock + open2-oplock: BATCH oplock holder
+			// (oplock-backed, zero lease key), non-stat second open with no
+			// lease breaks the exclusive oplock.
+			name:           "oplock_batch_holder_broken_by_plain_open",
+			dLeaseState:    rwh,
+			dShareAccess:   shareAll,
+			dOplock:        OplockLevelBatch,
+			dLeaseKey:      [16]byte{},
+			bLeaseState:    0,
+			bLeaseKey:      [16]byte{},
+			bShareAccess:   shareAll,
+			bDesiredAccess: accessReadWrite,
+		},
+		{
+			// durable_open.open2-lease: RH lease holder opened FILE_SHARE_NONE;
+			// a read/write open violates A's own deny mode.
+			name:           "rh_lease_shareNone_holder_broken_by_readwrite",
+			dLeaseState:    rh,
+			dShareAccess:   shareNone,
+			dOplock:        OplockLevelLease,
+			dLeaseKey:      [16]byte{0xA1},
+			bLeaseState:    0,
+			bLeaseKey:      [16]byte{},
+			bShareAccess:   shareAll,
+			bDesiredAccess: accessReadWrite,
+		},
+	}
+
+	for _, tc := range conflictCases {
+		t.Run("purge/"+tc.name, func(t *testing.T) {
+			store := newMockDurableStore()
+			h := &Handler{DurableStore: store}
+			seedSessionA(store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, tc.dLeaseKey)
+
+			// BEFORE the fix this purge was a no-op and reconnect returned
+			// SUCCESS. Assert the conflicting open purges exactly one handle.
+			purged := h.purgeConflictingDisconnectedHandlesForOpen(
+				context.Background(), metaHandle,
+				tc.bLeaseState, tc.bLeaseKey, tc.bShareAccess, tc.bDesiredAccess,
+			)
+			if purged != 1 {
+				t.Fatalf("conflicting open purged=%d, want 1", purged)
+			}
+			if status := reconnectA(store); status != types.StatusObjectNameNotFound {
+				t.Fatalf("reconnect after conflicting open: got %s, want OBJECT_NAME_NOT_FOUND", status)
+			}
+		})
+	}
+
+	// Negative control: a stat-only second open must NOT purge the disconnected
+	// handle, so reconnect still succeeds. Covers keep-disconnected-* and guards
+	// against over-purge.
+	keepCases := []struct {
+		name         string
+		dLeaseState  uint32
+		dShareAccess uint32
+		dOplock      uint8
+	}{
+		// Both oplock-backed (zero lease key) so the V1 DHnC harness can
+		// re-establish them without a lease-request context. rwh exercises the
+		// W-holder preserve-on-stat path; rh the non-W preserve path.
+		{"keep/rwh_holder_with_stat_open", rwh, shareAll, OplockLevelBatch},
+		{"keep/rh_holder_with_stat_open", rh, shareAll, OplockLevelII},
+	}
+	for _, tc := range keepCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newMockDurableStore()
+			h := &Handler{DurableStore: store}
+			seedSessionA(store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, [16]byte{})
+
+			purged := h.purgeConflictingDisconnectedHandlesForOpen(
+				context.Background(), metaHandle,
+				0, [16]byte{}, shareAll, accessStatOnly,
+			)
+			if purged != 0 {
+				t.Fatalf("stat-only open purged=%d, want 0 (no over-purge)", purged)
+			}
+			if status := reconnectA(store); status != types.StatusSuccess {
+				t.Fatalf("reconnect after non-conflicting stat open: got %s, want SUCCESS", status)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem (#808)

Three smbtorture cases were inverse-failing — a durable reconnect that *should* fail was wrongly returning `NT_STATUS_OK`:

- `smb2.durable-open.oplock` → expected `OBJECT_NAME_NOT_FOUND` (Samba `durable_open.c`)
- `smb2.durable-open.open2-lease` → expected `OBJECT_NAME_NOT_FOUND`
- `smb2.durable-open.open2-oplock` → expected `OBJECT_NAME_NOT_FOUND`

Each test: open a durable handle, transport-disconnect (handle persisted), then a **conflicting** open arrives from another connection while the first is disconnected. Per MS-SMB2 §3.3.4.18 / Samba `share_mode_cleanup_disconnected`, that intervening open must **purge** the disconnected handle; the later DHnC reconnect then fails `OBJECT_NAME_NOT_FOUND`. DittoFS did not purge, so the handle survived and the reconnect wrongly succeeded.

## Root cause

The disconnected-handle purge predicate (`disconnectedConflictOnNewOpen`) handled only the V2 lease scenarios:
- new open with `FILE_SHARE_NONE`, or
- disconnected **W**-holder vs a new open that **requests a lease**.

The three failing V1 cases don't match either:

| test | disconnected handle | conflicting open | why it must purge |
|------|--------------------|------------------|-------------------|
| `oplock` / `open2-oplock` | BATCH oplock, share=RWD (persisted as an RWH synthetic lease) | plain open, **no lease/oplock**, share=RWD | an exclusive/batch oplock breaks on *any* second opener; disconnected client can't ack |
| `open2-lease` | RH lease, **share=NONE** | read/write open, share=RWD | new open violates the disconnected handle's **own** deny mode → its lease breaks |

The old W-holder rule required the new open to itself request a lease (`newLeaseState != 0`), so a plain second open never triggered it. And there was no rule for the disconnected handle's *own* share-deny mode (it lives in the durable store, invisible to `checkShareModeConflict` which only scans live opens).

## Fix

In `disconnectedConflictOnNewOpen`:

1. **Stat-only opens never purge** (early return) — guards `keep-disconnected-{rh,rwh}-with-stat-open` against over-purge (Samba `is_stat_open`).
2. **Disconnected handle's deny mode vs new open** — purge when `D.ShareAccess` denies the new open's data access (covers `open2-lease`). New helper `disconnectedShareDeniesNewOpen` reuses the existing `hasReadAccess`/`hasWriteAccess`/`hasDeleteAccess` classifiers.
3. **W-holder rule** — drop the `newLeaseState != 0` condition: a disconnected exclusive/batch caching holder is purged by any conflicting data-access open regardless of whether the new open requests a lease (covers `oplock` / `open2-oplock`).

The CREATE-path wrapper now threads `req.DesiredAccess` through and computes the stat-only flag once.

## Repro (cross-connection, through the real entrypoints)

`TestDurableOpenConflictingOpenPurgesAcrossConnections` drives the actual Step-8a-bis purge wrapper (`purgeConflictingDisconnectedHandlesForOpen`) and the real DHnC reconnect entrypoint (`ProcessDurableReconnectContext`) across two connections sharing one durable store, for all three modes plus stat-only keep controls.

Verified the repro is genuine: with the predicate reverted to its pre-fix form, both purge cases fail (`purged=0` → reconnect would succeed); the keep controls pass either way (no over-purge).

## Per-test confidence

- `open2-oplock` — **high**: batch-oplock holder vs plain open is the cleanest W-holder-rule case; repro green.
- `oplock` — **high**: same mechanism (second open also requests batch but breaks identically).
- `open2-lease` — **high** on the purge logic (share-deny rule, repro green); the live-mount reconnect also depends on the lease-backed DHnC path already in develop.

## Gates

`go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test -race ./internal/adapter/smb/...` all green. Reused existing access-mask helpers (simplifier pass removed 9 redundant constants).

Targets `smb2.durable-open.{oplock,open2-lease,open2-oplock}`; KNOWN_FAILURES walkback left for the orchestrator post-CI.