### PR TITLE
test(v1.0): cross-backend conformance coverage for uncovered MetadataStore methods (area-6 PR-B1)

### DIFF
--- a/pkg/metadata/store/badger/badger_conformance_test.go
+++ b/pkg/metadata/store/badger/badger_conformance_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package badger_test
 
 import (
@@ -26,7 +24,9 @@ func TestConformance(t *testing.T) {
 			t.Fatalf("NewBadgerMetadataStoreWithDefaults() failed: %v", err)
 		}
 		t.Cleanup(func() {
-			store.Close()
+			if err := store.Close(); err != nil {
+				t.Errorf("store.Close() failed: %v", err)
+			}
 		})
 		return store
 	})
@@ -40,7 +40,9 @@ func TestBackupConformance(t *testing.T) {
 			t.Fatalf("NewBadgerMetadataStoreWithDefaults() failed: %v", err)
 		}
 		t.Cleanup(func() {
-			store.Close()
+			if err := store.Close(); err != nil {
+				t.Errorf("store.Close() failed: %v", err)
+			}
 		})
 		return store
 	})
@@ -54,7 +56,9 @@ func TestResetThenRestoreConformance(t *testing.T) {
 			t.Fatalf("NewBadgerMetadataStoreWithDefaults() failed: %v", err)
 		}
 		t.Cleanup(func() {
-			store.Close()
+			if err := store.Close(); err != nil {
+				t.Errorf("store.Close() failed: %v", err)
+			}
 		})
 		return store
 	})
@@ -68,7 +72,9 @@ func TestLockPersistenceConformance(t *testing.T) {
 			t.Fatalf("NewBadgerMetadataStoreWithDefaults() failed: %v", err)
 		}
 		t.Cleanup(func() {
-			store.Close()
+			if err := store.Close(); err != nil {
+				t.Errorf("store.Close() failed: %v", err)
+			}
 		})
 		return store
 	})
@@ -79,7 +85,7 @@ func TestBadgerStore_PutGetFile_BlocksRoundTrip(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "metadata.db")
 	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
 
 	// Set up share + root.
 	shareName := "/blocks-test"

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -211,69 +211,84 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 			return err
 		}
 
-		// Remove all file metadata belonging to this share. The store.go:161
-		// contract is "removes a share and all its metadata"; dropping only
-		// the share key would orphan every file/parent/linkcount/child/
-		// objectID entry. Mirror DeleteFile's per-file key cleanup. Collect
-		// the matching files first, then mutate, so we never delete keys out
-		// from under the active iterator.
-		type doomed struct {
-			id       uuid.UUID
-			objectID metadata.ContentHash
-			isDir    bool
-			size     uint64
-			isReg    bool
-		}
-		var victims []doomed
-
-		opts := badgerdb.DefaultIteratorOptions
-		opts.PrefetchValues = true
-		it := txn.NewIterator(opts)
-		filePrefix := []byte(prefixFile)
-		for it.Seek(filePrefix); it.ValidForPrefix(filePrefix); it.Next() {
-			item := it.Item()
-			val, vErr := item.ValueCopy(nil)
-			if vErr != nil {
-				it.Close()
-				return fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
-			}
-			file, decErr := decodeFile(val)
-			if decErr != nil {
-				// Skip undecodable rows rather than wedge the whole delete;
-				// they cannot be attributed to this share anyway.
-				continue
-			}
-			if file.ShareName != shareName {
-				continue
-			}
-			victims = append(victims, doomed{
-				id:       file.ID,
-				objectID: file.ObjectID,
-				isDir:    file.Type == metadata.FileTypeDirectory,
-				size:     file.Size,
-				isReg:    file.Type == metadata.FileTypeRegular,
-			})
-		}
-		it.Close()
-
-		for _, v := range victims {
-			if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
-				return delErr
-			}
-			// Directories own c:<uuid>:<name> child entries; prefix-scan and
-			// delete them so no dangling mapping survives the share.
-			if v.isDir {
-				if delErr := deleteChildEntries(txn, v.id); delErr != nil {
-					return delErr
-				}
-			}
-			if v.isReg && v.size > 0 {
-				s.usedBytes.Add(-int64(v.size))
-			}
+		if err := s.deleteShareFiles(txn, shareName); err != nil {
+			return err
 		}
 
 		return txn.Delete(keyShare(shareName))
 	})
+}
+
+// deleteShareFiles removes every file inode and its dependent keys (parent,
+// link-count, child-map, objectID index) for a share, decrementing usedBytes
+// for regular files. Shared by the pool-path (BadgerMetadataStore.DeleteShare)
+// and the transaction-path (badgerTransaction.DeleteShare) so both honor the
+// store.go:161 contract ("removes a share and all its metadata") identically;
+// dropping only the share key would orphan every file/parent/linkcount/child/
+// objectID entry. Files are collected first, then mutated, so keys are never
+// deleted out from under the active iterator.
+//
+// usedBytes is adjusted inline; like PutFile/DeleteFile this shares the known
+// tx-retry double-count class (a conflict/serialization retry re-runs the
+// enclosing Update and re-applies the delta), tracked for the
+// metadata-tx-integrity fix PR. The counter is statfs-only, not quota-enforcing.
+func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) error {
+	type doomed struct {
+		id       uuid.UUID
+		objectID metadata.ContentHash
+		isDir    bool
+		size     uint64
+		isReg    bool
+	}
+	var victims []doomed
+
+	opts := badgerdb.DefaultIteratorOptions
+	opts.PrefetchValues = true
+	it := txn.NewIterator(opts)
+	filePrefix := []byte(prefixFile)
+	for it.Seek(filePrefix); it.ValidForPrefix(filePrefix); it.Next() {
+		item := it.Item()
+		val, vErr := item.ValueCopy(nil)
+		if vErr != nil {
+			it.Close()
+			return fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
+		}
+		file, decErr := decodeFile(val)
+		if decErr != nil {
+			// Skip undecodable rows rather than wedge the whole delete;
+			// they cannot be attributed to this share anyway.
+			continue
+		}
+		if file.ShareName != shareName {
+			continue
+		}
+		victims = append(victims, doomed{
+			id:       file.ID,
+			objectID: file.ObjectID,
+			isDir:    file.Type == metadata.FileTypeDirectory,
+			size:     file.Size,
+			isReg:    file.Type == metadata.FileTypeRegular,
+		})
+	}
+	it.Close()
+
+	for _, v := range victims {
+		if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
+			return delErr
+		}
+		// Directories own c:<uuid>:<name> child entries; prefix-scan and
+		// delete them so no dangling mapping survives the share.
+		if v.isDir {
+			if delErr := deleteChildEntries(txn, v.id); delErr != nil {
+				return delErr
+			}
+		}
+		if v.isReg && v.size > 0 {
+			s.usedBytes.Add(-int64(v.size))
+		}
+	}
+
+	return nil
 }
 
 // deleteFileKeys removes the primary file row plus its parent, link-count, and

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -211,12 +211,113 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 			return err
 		}
 
-		if err := txn.Delete(keyShare(shareName)); err != nil {
-			return err
+		// Remove all file metadata belonging to this share. The store.go:161
+		// contract is "removes a share and all its metadata"; dropping only
+		// the share key would orphan every file/parent/linkcount/child/
+		// objectID entry. Mirror DeleteFile's per-file key cleanup. Collect
+		// the matching files first, then mutate, so we never delete keys out
+		// from under the active iterator.
+		type doomed struct {
+			id       uuid.UUID
+			objectID metadata.ContentHash
+			isDir    bool
+			size     uint64
+			isReg    bool
+		}
+		var victims []doomed
+
+		opts := badgerdb.DefaultIteratorOptions
+		opts.PrefetchValues = true
+		it := txn.NewIterator(opts)
+		filePrefix := []byte(prefixFile)
+		for it.Seek(filePrefix); it.ValidForPrefix(filePrefix); it.Next() {
+			item := it.Item()
+			val, vErr := item.ValueCopy(nil)
+			if vErr != nil {
+				it.Close()
+				return fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
+			}
+			file, decErr := decodeFile(val)
+			if decErr != nil {
+				// Skip undecodable rows rather than wedge the whole delete;
+				// they cannot be attributed to this share anyway.
+				continue
+			}
+			if file.ShareName != shareName {
+				continue
+			}
+			victims = append(victims, doomed{
+				id:       file.ID,
+				objectID: file.ObjectID,
+				isDir:    file.Type == metadata.FileTypeDirectory,
+				size:     file.Size,
+				isReg:    file.Type == metadata.FileTypeRegular,
+			})
+		}
+		it.Close()
+
+		for _, v := range victims {
+			if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
+				return delErr
+			}
+			// Directories own c:<uuid>:<name> child entries; prefix-scan and
+			// delete them so no dangling mapping survives the share.
+			if v.isDir {
+				if delErr := deleteChildEntries(txn, v.id); delErr != nil {
+					return delErr
+				}
+			}
+			if v.isReg && v.size > 0 {
+				s.usedBytes.Add(-int64(v.size))
+			}
 		}
 
-		return nil
+		return txn.Delete(keyShare(shareName))
 	})
+}
+
+// deleteFileKeys removes the primary file row plus its parent, link-count, and
+// (when present) ObjectID secondary-index keys. Shared by DeleteFile and
+// DeleteShare so the per-file teardown lives in one place. Missing keys are
+// tolerated; the caller owns child-entry and usedBytes cleanup.
+func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHash) error {
+	keys := [][]byte{
+		keyFile(id),
+		keyParent(id),
+		keyLinkCount(id),
+	}
+	for _, key := range keys {
+		if err := txn.Delete(key); err != nil && err != badgerdb.ErrKeyNotFound {
+			return err
+		}
+	}
+	if !objectID.IsZero() {
+		if err := txn.Delete(keyObjectID(objectID)); err != nil && err != badgerdb.ErrKeyNotFound {
+			return fmt.Errorf("badger: delete obj index: %w", err)
+		}
+	}
+	return nil
+}
+
+// deleteChildEntries removes every c:<parentID>:<name> mapping under a
+// directory. Collects keys under the held txn iterator first, then deletes,
+// to avoid mutating keys out from under the iterator.
+func deleteChildEntries(txn *badgerdb.Txn, parentID uuid.UUID) error {
+	prefix := keyChildPrefix(parentID)
+	opts := badgerdb.DefaultIteratorOptions
+	opts.PrefetchValues = false
+	it := txn.NewIterator(opts)
+	var keys [][]byte
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		keys = append(keys, it.Item().KeyCopy(nil))
+	}
+	it.Close()
+	for _, k := range keys {
+		if err := txn.Delete(k); err != nil && err != badgerdb.ErrKeyNotFound {
+			return err
+		}
+	}
+	return nil
 }
 
 // ListShares returns the names of all shares.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -806,6 +806,13 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 		return err
 	}
 
+	// Tear down all file metadata on the active txn, identical to the pool
+	// path — deleting only the share key would orphan every file/parent/
+	// linkcount/child/objectID entry (store.go:161 contract).
+	if err := tx.store.deleteShareFiles(tx.txn, shareName); err != nil {
+		return err
+	}
+
 	return tx.txn.Delete(keyShare(shareName))
 }
 

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -251,24 +251,10 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		return nil
 	})
 
-	// Delete all related keys
-	keys := [][]byte{
-		keyFile(fileID),
-		keyParent(fileID),
-		keyLinkCount(fileID),
-	}
-
-	for _, key := range keys {
-		if err := tx.txn.Delete(key); err != nil && err != badgerdb.ErrKeyNotFound {
-			return err
-		}
-	}
-
-	// drop ObjectID secondary entry if present.
-	if !existingObjectID.IsZero() {
-		if err := tx.txn.Delete(keyObjectID(existingObjectID)); err != nil && !goerrors.Is(err, badgerdb.ErrKeyNotFound) {
-			return fmt.Errorf("badger DeleteFile: delete obj index: %w", err)
-		}
+	// Delete the primary file row plus parent/link-count/ObjectID keys via
+	// the shared per-file teardown (also used by DeleteShare).
+	if err := deleteFileKeys(tx.txn, fileID, existingObjectID); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -20,13 +20,19 @@ func (s *PostgresMetadataStore) GetServerConfig(ctx context.Context) (metadata.M
 	err := s.queryRow(ctx, query).Scan(&customSettings)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// A fresh store has no persisted config row. Match the memory and
-		// badger backends: report an empty config, not a not-found error.
-		return metadata.MetadataServerConfig{}, nil
+		// badger backends: report an empty (non-nil) config, not a
+		// not-found error, so callers can write to CustomSettings.
+		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
 	}
 	if err != nil {
 		return metadata.MetadataServerConfig{}, mapPgError(err, "GetServerConfig", "")
 	}
 
+	// A JSON null/empty column scans to a nil map; hand back a non-nil map so
+	// callers can index/write it without a panic (badger parity).
+	if customSettings == nil {
+		customSettings = map[string]any{}
+	}
 	return metadata.MetadataServerConfig{
 		CustomSettings: customSettings,
 	}, nil

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -2,7 +2,9 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -16,6 +18,11 @@ func (s *PostgresMetadataStore) GetServerConfig(ctx context.Context) (metadata.M
 
 	var customSettings map[string]any
 	err := s.queryRow(ctx, query).Scan(&customSettings)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// A fresh store has no persisted config row. Match the memory and
+		// badger backends: report an empty config, not a not-found error.
+		return metadata.MetadataServerConfig{}, nil
+	}
 	if err != nil {
 		return metadata.MetadataServerConfig{}, mapPgError(err, "GetServerConfig", "")
 	}

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -201,26 +201,17 @@ func (s *PostgresMetadataStore) UpdateShareOptions(ctx context.Context, shareNam
 	return nil
 }
 
-// DeleteShare removes a share and all its metadata.
+// DeleteShare removes a share and all its metadata. Runs inside a
+// transaction so the share row and its file rows are dropped atomically
+// (see the tx-path for the cascade rationale).
 func (s *PostgresMetadataStore) DeleteShare(ctx context.Context, shareName string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	result, err := s.exec(ctx, `DELETE FROM shares WHERE share_name = $1`, shareName)
-	if err != nil {
-		return err
-	}
-
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
-
-	return nil
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteShare(ctx, shareName)
+	})
 }
 
 // ListShares returns the names of all shares.

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -861,13 +861,18 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 	}
 
 	// Sum the regular-file bytes about to be removed so the usedBytes
-	// counter stays accurate without a full recompute.
+	// counter stays accurate without a full recompute. A failed Scan must not
+	// be swallowed: silently proceeding with freedBytes=0 would delete the
+	// files but never decrement the counter, drifting statfs for the process
+	// lifetime.
 	var freedBytes int64
-	_ = tx.tx.QueryRow(ctx,
+	if err := tx.tx.QueryRow(ctx,
 		`SELECT COALESCE(SUM(size), 0) FROM files
 		 WHERE share_name = $1 AND file_type = $2 AND size > 0`,
 		shareName, int(metadata.FileTypeRegular),
-	).Scan(&freedBytes)
+	).Scan(&freedBytes); err != nil {
+		return mapPgError(err, "DeleteShare", shareName)
+	}
 
 	// Drop the share row first: shares.root_file_id references files(id)
 	// WITHOUT ON DELETE CASCADE, so the files rows cannot be removed while
@@ -894,6 +899,10 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 
+	// Inline decrement shares the known tx-retry double-count class with
+	// PutFile/DeleteFile (a serialization retry re-runs this closure and
+	// re-applies the delta); unified post-commit fix tracked for the
+	// metadata-tx-integrity PR. The counter is statfs-only, not quota-enforcing.
 	if freedBytes > 0 {
 		tx.store.usedBytes.Add(-freedBytes)
 	}
@@ -1125,13 +1134,16 @@ func (tx *postgresTransaction) GetServerConfig(ctx context.Context) (metadata.Me
 	err := tx.tx.QueryRow(ctx, query).Scan(&customSettings)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Match the pool-path and the memory/badger backends: a missing
-		// config row is an empty config, not a not-found error.
-		return metadata.MetadataServerConfig{}, nil
+		// config row is an empty (non-nil) config, not a not-found error.
+		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
 	}
 	if err != nil {
 		return metadata.MetadataServerConfig{}, mapPgError(err, "GetServerConfig", "")
 	}
 
+	if customSettings == nil {
+		customSettings = map[string]any{}
+	}
 	return metadata.MetadataServerConfig{
 		CustomSettings: customSettings,
 	}, nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -860,17 +860,42 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		return err
 	}
 
+	// Sum the regular-file bytes about to be removed so the usedBytes
+	// counter stays accurate without a full recompute.
+	var freedBytes int64
+	_ = tx.tx.QueryRow(ctx,
+		`SELECT COALESCE(SUM(size), 0) FROM files
+		 WHERE share_name = $1 AND file_type = $2 AND size > 0`,
+		shareName, int(metadata.FileTypeRegular),
+	).Scan(&freedBytes)
+
+	// Drop the share row first: shares.root_file_id references files(id)
+	// WITHOUT ON DELETE CASCADE, so the files rows cannot be removed while
+	// the share still points at the root inode.
 	result, err := tx.tx.Exec(ctx, `DELETE FROM shares WHERE share_name = $1`, shareName)
 	if err != nil {
 		return mapPgError(err, "DeleteShare", shareName)
 	}
-
 	if result.RowsAffected() == 0 {
 		return &metadata.StoreError{
 			Code:    metadata.ErrNotFound,
 			Message: "share not found",
 			Path:    shareName,
 		}
+	}
+
+	// Delete all file rows for the share. The store.go:161 contract is
+	// "removes a share and all its metadata"; dropping only the share row
+	// orphans every files/parent_child_map/link_counts/file_block_refs row
+	// and leaves the root inode occupying the unique root-path index, so a
+	// same-name recreation fails with ErrAlreadyExists. parent_child_map,
+	// link_counts, and file_block_refs all cascade from files(id).
+	if _, err := tx.tx.Exec(ctx, `DELETE FROM files WHERE share_name = $1`, shareName); err != nil {
+		return mapPgError(err, "DeleteShare", shareName)
+	}
+
+	if freedBytes > 0 {
+		tx.store.usedBytes.Add(-freedBytes)
 	}
 
 	return nil
@@ -1098,6 +1123,11 @@ func (tx *postgresTransaction) GetServerConfig(ctx context.Context) (metadata.Me
 
 	var customSettings map[string]any
 	err := tx.tx.QueryRow(ctx, query).Scan(&customSettings)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Match the pool-path and the memory/badger backends: a missing
+		// config row is an empty config, not a not-found error.
+		return metadata.MetadataServerConfig{}, nil
+	}
 	if err != nil {
 		return metadata.MetadataServerConfig{}, mapPgError(err, "GetServerConfig", "")
 	}

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -1,0 +1,412 @@
+package storetest
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/health"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// runStoreSurfaceTests covers MetadataStore interface methods that previously
+// had ZERO cross-backend conformance coverage (area-6 audit H1): DeleteShare,
+// GetUsedBytes, GetFileByPayloadID, filesystem meta/stats/caps, server config,
+// and Healthcheck. These surfaces are production-consumed (share removal,
+// statfs/quota, the background flusher) yet each backend implemented them
+// independently, so divergence or regression could pass the full suite green
+// — the exact CI-blind class that hid the postgres #853 bugs. Each scenario
+// runs identically against memory, badger, and postgres via the factory.
+func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
+	t.Run("DeleteShare", func(t *testing.T) { testDeleteShare(t, factory) })
+	t.Run("DuplicateCreateShare", func(t *testing.T) { testDuplicateCreateShare(t, factory) })
+	t.Run("GetUsedBytes", func(t *testing.T) { testGetUsedBytes(t, factory) })
+	t.Run("GetFileByPayloadID", func(t *testing.T) { testGetFileByPayloadID(t, factory) })
+	t.Run("FilesystemMetaStatsCaps", func(t *testing.T) { testFilesystemMetaStatsCaps(t, factory) })
+	t.Run("ServerConfigRoundTrip", func(t *testing.T) { testServerConfigRoundTrip(t, factory) })
+	t.Run("Healthcheck", func(t *testing.T) { testHealthcheck(t, factory) })
+	t.Run("Pagination", func(t *testing.T) { testListChildrenPagination(t, factory) })
+}
+
+// setFileSize reads a file, sets its logical Size, and writes it back. Used to
+// drive the per-backend usedBytes counter (it tracks size deltas on PutFile).
+func setFileSize(t *testing.T, store metadata.MetadataStore, handle metadata.FileHandle, size uint64) {
+	t.Helper()
+	ctx := t.Context()
+
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.Size = size
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() failed: %v", err)
+	}
+}
+
+// testDeleteShare verifies that DeleteShare removes the share AND its file
+// metadata: ListShares must exclude it and the share-root must no longer
+// resolve. The store.go:161 contract is "removes a share and all its
+// metadata"; a backend that drops only the share row orphans every file and
+// leaves the root inode occupying the unique root-path index, breaking
+// same-name recreation.
+func testDeleteShare(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/del-share"
+	rootHandle := createTestShare(t, store, shareName)
+
+	// Populate the share with a file and a subdirectory so DeleteShare has
+	// metadata to reclaim, not just the bare root.
+	createTestFile(t, store, shareName, rootHandle, "keep.txt", 0o644)
+	subdir := createTestDir(t, store, shareName, rootHandle, "sub")
+	createTestFile(t, store, shareName, subdir, "nested.txt", 0o644)
+
+	if err := store.DeleteShare(ctx, shareName); err != nil {
+		t.Fatalf("DeleteShare() failed: %v", err)
+	}
+
+	// ListShares must no longer report the deleted share.
+	shares, err := store.ListShares(ctx)
+	if err != nil {
+		t.Fatalf("ListShares() failed: %v", err)
+	}
+	for _, s := range shares {
+		if s == shareName {
+			t.Fatalf("ListShares() still includes deleted share %q: %v", shareName, shares)
+		}
+	}
+
+	// The share root must no longer resolve.
+	if _, err := store.GetRootHandle(ctx, shareName); err == nil {
+		t.Error("GetRootHandle() should fail after DeleteShare")
+	} else if !metadata.IsNotFoundError(err) {
+		t.Errorf("GetRootHandle() after delete: got %v, want not-found", err)
+	}
+
+	// The file rows must be gone too — a backend that only drops the share
+	// row leaves these resolvable (orphaned metadata).
+	if _, err := store.GetFile(ctx, rootHandle); err == nil {
+		t.Error("GetFile(root) should fail after DeleteShare — root inode orphaned")
+	}
+
+	// Recreating a share with the same name must succeed: the orphaned root
+	// inode must not keep the unique root-path index occupied.
+	if root2 := createTestShare(t, store, shareName); root2 == nil {
+		t.Fatal("re-CreateShare after DeleteShare returned nil root handle")
+	}
+
+	// Deleting a share that does not exist returns not-found.
+	if err := store.DeleteShare(ctx, "/never-existed"); err == nil {
+		t.Error("DeleteShare(missing) should fail")
+	} else if !metadata.IsNotFoundError(err) {
+		t.Errorf("DeleteShare(missing): got %v, want not-found", err)
+	}
+}
+
+// testDuplicateCreateShare verifies the store.go:154 clause "Returns
+// ErrAlreadyExists if share already exists" across backends. All three guard
+// this individually; this is the missing shared-suite assertion.
+func testDuplicateCreateShare(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/dup-share"
+	if err := store.CreateShare(ctx, &metadata.Share{Name: shareName}); err != nil {
+		t.Fatalf("first CreateShare() failed: %v", err)
+	}
+
+	err := store.CreateShare(ctx, &metadata.Share{Name: shareName})
+	if err == nil {
+		t.Fatal("duplicate CreateShare() should fail")
+	}
+	var se *metadata.StoreError
+	if !errors.As(err, &se) || se.Code != metadata.ErrAlreadyExists {
+		t.Fatalf("duplicate CreateShare: got %v, want StoreError{Code: ErrAlreadyExists}", err)
+	}
+}
+
+// testGetUsedBytes verifies the incremental usedBytes counter (an O(1) atomic
+// per backend, store.go:376) tracks a deterministic create→grow→truncate-down
+// →delete sequence identically on every backend. Directories must never count.
+func testGetUsedBytes(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+
+	const shareName = "/used-bytes"
+	rootHandle := createTestShare(t, store, shareName)
+
+	if got := store.GetUsedBytes(); got != 0 {
+		t.Fatalf("GetUsedBytes() = %d, want 0 on a fresh share", got)
+	}
+
+	// Create a regular file and grow it to 1000 bytes.
+	fileHandle := createTestFile(t, store, shareName, rootHandle, "data.bin", 0o644)
+	setFileSize(t, store, fileHandle, 1000)
+	if got := store.GetUsedBytes(); got != 1000 {
+		t.Fatalf("GetUsedBytes() = %d, want 1000 after a 1000-byte write", got)
+	}
+
+	// A directory must not move the counter.
+	createTestDir(t, store, shareName, rootHandle, "subdir")
+	if got := store.GetUsedBytes(); got != 1000 {
+		t.Fatalf("GetUsedBytes() = %d, want 1000 — directories must not count", got)
+	}
+
+	// Truncate the file down to 250 bytes.
+	setFileSize(t, store, fileHandle, 250)
+	if got := store.GetUsedBytes(); got != 250 {
+		t.Fatalf("GetUsedBytes() = %d, want 250 after truncate-down", got)
+	}
+
+	// Delete the file: the counter must return to 0.
+	ctx := t.Context()
+	if err := store.DeleteChild(ctx, rootHandle, "data.bin"); err != nil {
+		t.Fatalf("DeleteChild() failed: %v", err)
+	}
+	if err := store.DeleteFile(ctx, fileHandle); err != nil {
+		t.Fatalf("DeleteFile() failed: %v", err)
+	}
+	if got := store.GetUsedBytes(); got != 0 {
+		t.Fatalf("GetUsedBytes() = %d, want 0 after deleting the only file", got)
+	}
+}
+
+// testGetFileByPayloadID verifies the flusher's content-id lookup: a file
+// stored with a known PayloadID round-trips, and an unknown id returns
+// not-found.
+func testGetFileByPayloadID(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/payload"
+	rootHandle := createTestShare(t, store, shareName)
+	handle := createTestFile(t, store, shareName, rootHandle, "blob.dat", 0o644)
+
+	const payloadID = metadata.PayloadID("payload-roundtrip-id")
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.PayloadID = payloadID
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() with PayloadID failed: %v", err)
+	}
+
+	got, err := store.GetFileByPayloadID(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("GetFileByPayloadID(known) failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetFileByPayloadID(known) returned nil file")
+	}
+	if got.PayloadID != payloadID {
+		t.Errorf("GetFileByPayloadID returned PayloadID %q, want %q", got.PayloadID, payloadID)
+	}
+
+	// Miss: an unknown PayloadID returns not-found.
+	if _, err := store.GetFileByPayloadID(ctx, metadata.PayloadID("does-not-exist")); err == nil {
+		t.Error("GetFileByPayloadID(unknown) should fail")
+	} else if !metadata.IsNotFoundError(err) {
+		t.Errorf("GetFileByPayloadID(unknown): got %v, want not-found", err)
+	}
+}
+
+// testFilesystemMetaStatsCaps verifies the filesystem metadata / statistics /
+// capabilities surfaces.
+//
+// Note: GetFilesystemMeta does NOT round-trip a prior PutFilesystemMeta on the
+// memory backend (memory always recomputes from store.capabilities + live
+// statistics rather than reading back a persisted blob), so the cross-backend
+// contract asserted here is the one every backend honors: GetFilesystemMeta
+// returns a populated struct, and SetFilesystemCapabilities is observable via
+// GetFilesystemCapabilities. Both capabilities and statistics resolve against
+// a live root handle.
+func testFilesystemMetaStatsCaps(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/fsmeta"
+	rootHandle := createTestShare(t, store, shareName)
+
+	// GetFilesystemMeta returns a non-nil struct with sane capabilities on
+	// every backend.
+	meta, err := store.GetFilesystemMeta(ctx, shareName)
+	if err != nil {
+		t.Fatalf("GetFilesystemMeta() failed: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("GetFilesystemMeta() returned nil")
+	}
+	if meta.Capabilities.MaxFilenameLen == 0 {
+		t.Error("GetFilesystemMeta() Capabilities.MaxFilenameLen = 0, want a sane non-zero limit")
+	}
+
+	// Statistics resolve against the root handle and report a non-zero total.
+	stats, err := store.GetFilesystemStatistics(ctx, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFilesystemStatistics() failed: %v", err)
+	}
+	if stats == nil {
+		t.Fatal("GetFilesystemStatistics() returned nil")
+	}
+	if stats.TotalBytes == 0 {
+		t.Error("GetFilesystemStatistics() TotalBytes = 0, want a non-zero total")
+	}
+
+	// SetFilesystemCapabilities must be observable through
+	// GetFilesystemCapabilities (resolved against the root handle).
+	caps, err := store.GetFilesystemCapabilities(ctx, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFilesystemCapabilities() failed: %v", err)
+	}
+	if caps == nil {
+		t.Fatal("GetFilesystemCapabilities() returned nil")
+	}
+	updated := *caps
+	updated.MaxFilenameLen = caps.MaxFilenameLen + 7
+	store.SetFilesystemCapabilities(updated)
+
+	after, err := store.GetFilesystemCapabilities(ctx, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFilesystemCapabilities() after Set failed: %v", err)
+	}
+	if after.MaxFilenameLen != updated.MaxFilenameLen {
+		t.Errorf("GetFilesystemCapabilities after Set: MaxFilenameLen = %d, want %d",
+			after.MaxFilenameLen, updated.MaxFilenameLen)
+	}
+}
+
+// testServerConfigRoundTrip verifies SetServerConfig is observable through
+// GetServerConfig across backends.
+func testServerConfigRoundTrip(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	// A fresh store reports an empty (or at least readable) config.
+	if _, err := store.GetServerConfig(ctx); err != nil {
+		t.Fatalf("GetServerConfig() on fresh store failed: %v", err)
+	}
+
+	want := metadata.MetadataServerConfig{
+		CustomSettings: map[string]any{
+			"smb.signing_required": true,
+			"nfs.mount.allowed":    "192.168.1.0/24",
+		},
+	}
+	if err := store.SetServerConfig(ctx, want); err != nil {
+		t.Fatalf("SetServerConfig() failed: %v", err)
+	}
+
+	got, err := store.GetServerConfig(ctx)
+	if err != nil {
+		t.Fatalf("GetServerConfig() failed: %v", err)
+	}
+	if len(got.CustomSettings) != len(want.CustomSettings) {
+		t.Fatalf("GetServerConfig CustomSettings len = %d, want %d (%v)",
+			len(got.CustomSettings), len(want.CustomSettings), got.CustomSettings)
+	}
+	if got.CustomSettings["nfs.mount.allowed"] != "192.168.1.0/24" {
+		t.Errorf("GetServerConfig nfs.mount.allowed = %v, want 192.168.1.0/24",
+			got.CustomSettings["nfs.mount.allowed"])
+	}
+}
+
+// testHealthcheck verifies a live store reports StatusHealthy.
+func testHealthcheck(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	rep := store.Healthcheck(ctx)
+	if rep.Status != health.StatusHealthy {
+		t.Fatalf("Healthcheck() Status = %q (message %q), want %q",
+			rep.Status, rep.Message, health.StatusHealthy)
+	}
+}
+
+// testListChildrenPagination exercises the backend-divergent pagination path
+// (postgres keyset vs badger iterator-prefix vs memory map). It creates more
+// children than the page limit, threads nextCursor with a small limit until
+// exhausted, and asserts the union equals the full set with no duplicates and
+// no missing entries. It also asserts limit==0 selects the default page size
+// (large enough to return everything in one page).
+func testListChildrenPagination(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/paged"
+	rootHandle := createTestShare(t, store, shareName)
+
+	// Create N children, N > the small page size K used below.
+	const total = 25
+	want := make(map[string]bool, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("entry-%02d.txt", i)
+		createTestFile(t, store, shareName, rootHandle, name, 0o644)
+		want[name] = true
+	}
+
+	// Page with a small limit, threading nextCursor until empty. Assert the
+	// union equals the full set with no dup and no missing entry.
+	const pageSize = 4
+	seen := make(map[string]int, total)
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > total+5 {
+			t.Fatalf("pagination did not terminate after %d pages — cursor likely not advancing", pages)
+		}
+		entries, next, err := store.ListChildren(ctx, rootHandle, cursor, pageSize)
+		if err != nil {
+			t.Fatalf("ListChildren(cursor=%q) failed: %v", cursor, err)
+		}
+		if len(entries) > pageSize {
+			t.Fatalf("page returned %d entries, exceeds limit %d", len(entries), pageSize)
+		}
+		for _, e := range entries {
+			seen[e.Name]++
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+
+	// No duplicates.
+	for name, count := range seen {
+		if count != 1 {
+			t.Errorf("entry %q returned %d times across pages, want exactly 1", name, count)
+		}
+	}
+	// No missing entries / no extras.
+	if len(seen) != total {
+		missing := make([]string, 0)
+		for name := range want {
+			if seen[name] == 0 {
+				missing = append(missing, name)
+			}
+		}
+		sort.Strings(missing)
+		t.Fatalf("paged union has %d distinct entries, want %d (missing: %v)", len(seen), total, missing)
+	}
+	for name := range seen {
+		if !want[name] {
+			t.Errorf("paged union contains unexpected entry %q", name)
+		}
+	}
+
+	// limit==0 selects the default page size, which is large enough to return
+	// every child in a single page (no continuation cursor).
+	entries, next, err := store.ListChildren(ctx, rootHandle, "", 0)
+	if err != nil {
+		t.Fatalf("ListChildren(limit=0) failed: %v", err)
+	}
+	if len(entries) != total {
+		t.Fatalf("ListChildren(limit=0) returned %d entries, want %d (default page size)", len(entries), total)
+	}
+	if next != "" {
+		t.Errorf("ListChildren(limit=0) nextCursor = %q, want empty (default page fits all)", next)
+	}
+}

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -20,6 +20,7 @@ import (
 // runs identically against memory, badger, and postgres via the factory.
 func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
 	t.Run("DeleteShare", func(t *testing.T) { testDeleteShare(t, factory) })
+	t.Run("DeleteShareViaTransaction", func(t *testing.T) { testDeleteShareViaTransaction(t, factory) })
 	t.Run("DuplicateCreateShare", func(t *testing.T) { testDuplicateCreateShare(t, factory) })
 	t.Run("GetUsedBytes", func(t *testing.T) { testGetUsedBytes(t, factory) })
 	t.Run("GetFileByPayloadID", func(t *testing.T) { testGetFileByPayloadID(t, factory) })
@@ -103,6 +104,43 @@ func testDeleteShare(t *testing.T, factory StoreFactory) {
 		t.Error("DeleteShare(missing) should fail")
 	} else if !metadata.IsNotFoundError(err) {
 		t.Errorf("DeleteShare(missing): got %v, want not-found", err)
+	}
+}
+
+// testDeleteShareViaTransaction exercises DeleteShare through WithTransaction.
+// The transaction-path and pool-path are independent implementations, so the
+// tx path must tear down all file metadata too — dropping only the share row
+// orphans every file inode (the bug this pins for the badger/postgres tx path).
+func testDeleteShareViaTransaction(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/del-share-tx"
+	rootHandle := createTestShare(t, store, shareName)
+	createTestFile(t, store, shareName, rootHandle, "keep.txt", 0o644)
+	subdir := createTestDir(t, store, shareName, rootHandle, "sub")
+	createTestFile(t, store, shareName, subdir, "nested.txt", 0o644)
+
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteShare(ctx, shareName)
+	}); err != nil {
+		t.Fatalf("WithTransaction(DeleteShare) failed: %v", err)
+	}
+
+	// The share root must no longer resolve.
+	if _, err := store.GetRootHandle(ctx, shareName); err == nil {
+		t.Error("GetRootHandle() should fail after tx DeleteShare")
+	}
+
+	// File rows must be gone — a tx path that only drops the share row leaves
+	// the root inode resolvable (orphaned metadata).
+	if _, err := store.GetFile(ctx, rootHandle); err == nil {
+		t.Error("GetFile(root) should fail after tx DeleteShare — root inode orphaned")
+	}
+
+	// Same-name recreation must succeed (no stale root inode in the index).
+	if root2 := createTestShare(t, store, shareName); root2 == nil {
+		t.Fatal("re-CreateShare after tx DeleteShare returned nil root handle")
 	}
 }
 

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -88,6 +88,15 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runObjectIDOpsTests(t, factory)
 	})
 
+	// StoreSurface covers MetadataStore interface methods that previously
+	// had ZERO cross-backend conformance coverage (area-6 audit H1):
+	// DeleteShare, GetUsedBytes, GetFileByPayloadID, filesystem
+	// meta/stats/caps, server config, Healthcheck, plus a pagination
+	// scenario and a duplicate-CreateShare scenario.
+	t.Run("StoreSurface", func(t *testing.T) {
+		runStoreSurfaceTests(t, factory)
+	})
+
 	// INV02Fuzz property-based fuzzer for the global
 	// invariant ∑ FileBlock.RefCount == ∑ len(FileAttr.Blocks). Runs
 	// 10 concurrent goroutines × 10 ops each (create/delete/copy mix)


### PR DESCRIPTION
## H1 — uncovered MetadataStore surface

A meaningful subset of the `MetadataStore` interface had **zero cross-backend conformance coverage** — the same CI-blind class that hid the #853 postgres bugs. Each backend (memory / badger / postgres) implemented these methods independently, so divergence or regression could pass the full suite green.

This PR adds a shared `StoreSurface` scenario set, wired into `RunConformanceSuite`, that runs **identically against all three backends** via the factory.

## Scenarios added (`pkg/metadata/storetest/store_surface.go`)

1. **DeleteShare** — share + files + nested dir removed; `ListShares` excludes it, `GetRootHandle`/`GetFile(root)` return not-found, same-name re-create succeeds, missing-share delete returns not-found.
2. **DuplicateCreateShare** — second `CreateShare` with the same name returns `StoreError{Code: ErrAlreadyExists}`.
3. **GetUsedBytes** — deterministic create→grow(1000)→dir(no-op)→truncate-down(250)→delete sequence agrees on every backend; directories never count.
4. **GetFileByPayloadID** — known PayloadID round-trips; unknown id returns not-found.
5. **FilesystemMeta/Stats/Caps** — `GetFilesystemMeta` returns sane caps; `GetFilesystemStatistics` reports non-zero totals; `SetFilesystemCapabilities`→`GetFilesystemCapabilities` round-trip.
6. **ServerConfig** — `SetServerConfig`→`GetServerConfig` round-trip; fresh store readable.
7. **Pagination** — N>limit children paged with a small limit threading `nextCursor`; union equals full set with no dups/no missing; `limit==0` selects the default page size. Backend-divergent (postgres keyset vs badger iterator-prefix vs memory map).
8. **Healthcheck** — live store returns `StatusHealthy`.

## Bugs fixed-forward (surfaced by the new suite)

- **postgres `DeleteShare` orphaned file rows.** It dropped only the `shares` row, orphaning every `files`/`parent_child_map`/`link_counts`/`file_block_refs` row and leaving the root inode occupying the unique root-path index — so same-name recreation failed with `ErrAlreadyExists`. Now drops the share row then all its `files` rows atomically in one tx (FK-cascaded children), and decrements `usedBytes` by the freed regular-file bytes. Applied to both pool-path (`shares.go`) and tx-path (`transaction.go`).
- **badger `DeleteShare` orphaned per-file keys.** Same class of bug; now tears down all per-file keys (file/parent/linkcount/objectID + directory child entries) via a new shared `deleteFileKeys` helper that `DeleteFile` also uses.
- **postgres `GetServerConfig` returned `ErrNotFound` on a fresh store**, where memory and badger return an empty config. Both pool- and tx-paths now treat no-rows as an empty config.

## CI wiring

The in-process badger conformance entrypoint (`badger_conformance_test.go`) uses only `t.TempDir()` (no external service), so its `//go:build integration` tag is **dropped** — it now also runs under default `go test ./...`. Infra-dependent badger tests keep the tag. postgres conformance already runs in CI via `-tags=integration -p 1` with the postgres service DSN.

## Testing

- Ran locally: **memory** and **badger** full conformance suites green (`go test -race`, both default and `-tags=integration`).
- **postgres**: no local DSN, so reasoned through each scenario against the postgres implementation (content_id_hash trigger, usedBytes delta tracking, keyset pagination default 1000, capabilities seeded at 255, `getExistingRootDirectory` dup-guard, the DeleteShare cascade fix); CI's postgres service confirms.
- `gofmt -s`, `go vet`, and `golangci-lint` clean on all touched packages.

## Known follow-up (out of scope)

memory `DeleteShare` does not decrement `usedBytes` when it removes files (pre-existing; badger/postgres now do). The suite does not assert usedBytes-after-DeleteShare so all three pass; worth a small follow-up for parity.