### PR TITLE
fix(ci): supply localstack s3 credentials in smb-conformance bootstrap

### DIFF
--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -118,7 +118,7 @@ create_block_stores() {
         *-s3)
             $DFSCTL store block local add --name default --type memory
             $DFSCTL store block remote add --name default --type s3 \
-                --config '{"bucket":"dittofs-test","region":"us-east-1","endpoint":"http://localstack:4566","force_path_style":true}'
+                --config '{"bucket":"dittofs-test","region":"us-east-1","endpoint":"http://localstack:4566","force_path_style":true,"access_key_id":"test","secret_access_key":"test"}'
             ;;
         *)
             log_error "Unknown profile payload pattern: ${PROFILE}"

--- a/test/smb-conformance/run.sh
+++ b/test/smb-conformance/run.sh
@@ -364,6 +364,13 @@ run_compose() {
         *-s3)
             PROFILE="$PROFILE" docker compose "${profiles[@]}" up -d localstack
             wait_until "docker compose exec localstack curl -sf http://localhost:4566/_localstack/health" 30 "Localstack"
+            # The S3 remote block store never auto-creates its bucket, so the
+            # CAS bucket must exist before DittoFS issues its first PUT.
+            # awslocal ships in the localstack image and targets the local
+            # endpoint with throwaway credentials.
+            log_step "Creating S3 bucket dittofs-test in Localstack..."
+            docker compose exec -T localstack \
+                awslocal s3api create-bucket --bucket dittofs-test >/dev/null 2>&1 || true
             ;;
     esac
     case "$PROFILE" in


### PR DESCRIPTION
## Root cause

The control plane now requires `access_key_id` and `secret_access_key` for s3 remote block stores (`ValidateBlockStoreConfig` at `pkg/controlplane/runtime/blockstore_init.go:74-80`, and `shares/service.go:1662-1665`). The smb-conformance bootstrap predates that validation and registered the localstack store with no credentials, so the `badger-s3` and `postgres-s3` WPTS BVT jobs failed persistently at `store block remote add` with:

```
Error: failed to create remote block store: ... s3 remote block store requires access_key_id in config
```

## Fix

- Add localstack's throwaway `test`/`test` credentials to the bootstrap s3 `--config` JSON (`bootstrap.sh`). Keys verified snake_case (`access_key_id`/`secret_access_key`) against the store config parsing.
- Pre-create the CAS bucket `dittofs-test` via `awslocal` in `run.sh` after localstack is healthy. The s3 store never auto-creates its bucket (confirmed: no `CreateBucket` in `pkg/blockstore/remote/s3/store.go`), so the first PUT would otherwise fail with `NoSuchBucket`.

## Verification

Dispatched the `badger-s3` and `postgres-s3` WPTS BVT profiles via `workflow_dispatch` on this branch. Run links and green status to be confirmed in PR checks.