### PR TITLE
fix(smb): honour CREATE AllocationSize consistently across CREATE+QUERY (#792)

### DIFF
--- a/internal/adapter/smb/v2/handlers/converters.go
+++ b/internal/adapter/smb/v2/handlers/converters.go
@@ -78,9 +78,49 @@ func isFiletimeSentinel(ft uint64) bool {
 	return ft == filetimeFreeze || ft == filetimeUnfreeze
 }
 
-// calculateAllocationSize returns the size rounded up to the nearest cluster boundary.
+// calculateAllocationSize returns the size rounded up to the nearest cluster
+// boundary. The round-up addition saturates: a size within clusterSize-1 of the
+// uint64 max (e.g. a client-supplied AllocationSize reservation [MS-SMB2]
+// 2.2.13.2.2) would otherwise wrap to a small value, so such inputs clamp to the
+// largest cluster-aligned uint64.
 func calculateAllocationSize(size uint64) uint64 {
+	const maxAligned = (^uint64(0) / clusterSize) * clusterSize
+	if size > maxAligned {
+		return maxAligned
+	}
 	return ((size + clusterSize - 1) / clusterSize) * clusterSize
+}
+
+// effectiveAllocationSize returns the AllocationSize to report for a file,
+// honouring a client-requested initial allocation [MS-SMB2] 2.2.13.2.2. It is
+// the larger of the file's own cluster-aligned size and the cluster-aligned
+// requested reservation, so an empty file opened with a non-zero requested
+// allocation reports a non-zero AllocationSize (smb2.durable-open.alloc-size).
+//
+// DittoFS does not preallocate backing storage; the reservation is tracked
+// per-open-handle (OpenFile.RequestedAllocSize) so the CREATE response and a
+// subsequent QUERY_INFO on the same handle report a consistent value
+// (smb2.create.open asserts CREATE out.alloc_size == QUERY alloc_size).
+// Directories ignore the request — callers pass requested=0 for them
+// (smb2.create.dir-alloc-size).
+func effectiveAllocationSize(size, requested uint64) uint64 {
+	alloc := calculateAllocationSize(size)
+	if reqAlloc := calculateAllocationSize(requested); reqAlloc > alloc {
+		return reqAlloc
+	}
+	return alloc
+}
+
+// allocReservationFor returns the per-handle allocation reservation to record
+// for a file. Directories never honour a client-requested AllocationSize
+// (smb2.create.dir-alloc-size, which sets a 1 GiB request on a directory and
+// asserts the reported allocation stays small), so the request is dropped for
+// them; regular files keep it.
+func allocReservationFor(isDirectory bool, requested uint64) uint64 {
+	if isDirectory {
+		return 0
+	}
+	return requested
 }
 
 // getSMBSize returns the appropriate size for SMB reporting.

--- a/internal/adapter/smb/v2/handlers/converters_test.go
+++ b/internal/adapter/smb/v2/handlers/converters_test.go
@@ -8,6 +8,51 @@ import (
 )
 
 // =============================================================================
+// effectiveAllocationSize / allocReservationFor Tests
+// =============================================================================
+
+func TestEffectiveAllocationSize(t *testing.T) {
+	cases := []struct {
+		name      string
+		size      uint64
+		requested uint64
+		want      uint64
+	}{
+		{"empty file no request", 0, 0, 0},
+		// An empty file opened with a requested allocation must report a
+		// non-zero, cluster-aligned AllocationSize (smb2.durable-open.alloc-size
+		// sets in.alloc_size=0x1000 and asserts out.alloc_size != 0).
+		{"empty file requested 0x1000", 0, 0x1000, 0x1000},
+		{"requested rounds up to cluster", 0, 0x1001, 0x2000},
+		{"file size exceeds request", 0x3000, 0x1000, 0x3000},
+		{"request exceeds file size", 0x1000, 0x5000, 0x5000},
+		// A client-controlled requested allocation within clusterSize-1 of the
+		// uint64 max must saturate, not wrap to a small value.
+		{"requested near-max saturates", 0, ^uint64(0), 0xFFFFFFFFFFFFF000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveAllocationSize(tc.size, tc.requested); got != tc.want {
+				t.Errorf("effectiveAllocationSize(%d, %d) = %d, want %d",
+					tc.size, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllocReservationFor(t *testing.T) {
+	// Directories ignore the requested reservation (smb2.create.dir-alloc-size
+	// sets a 1 GiB request on a directory and asserts the reported allocation
+	// stays small); regular files keep it.
+	if got := allocReservationFor(true, 1<<30); got != 0 {
+		t.Errorf("directory reservation = %d, want 0", got)
+	}
+	if got := allocReservationFor(false, 0x1000); got != 0x1000 {
+		t.Errorf("regular-file reservation = %d, want 0x1000", got)
+	}
+}
+
+// =============================================================================
 // FileAttrToFileStandardInfo Tests
 // =============================================================================
 

--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -25,6 +25,11 @@ import (
 // Request and Response Structures
 // ============================================================================
 
+// CreateContextTagAllocationSize is the SMB2_CREATE_ALLOCATION_SIZE create
+// context tag ("AlSi") [MS-SMB2] 2.2.13.2.2. Its 8-byte little-endian Data is
+// the client-requested initial allocation size for the file.
+const CreateContextTagAllocationSize = "AlSi"
+
 // CreateRequest represents an SMB2 CREATE request from a client [MS-SMB2] 2.2.13.
 //
 // CREATE is the primary mechanism for clients to open existing files or
@@ -65,6 +70,15 @@ type CreateRequest struct {
 	// CreateOptions specifies options for the create operation.
 	// See types.CreateOptions for bit flags.
 	CreateOptions types.CreateOptions
+
+	// RequestedAllocSize is the client-requested initial allocation size in
+	// bytes, decoded from the SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create
+	// context [MS-SMB2] 2.2.13.2.2. SMB2 CREATE has no fixed AllocationSize
+	// request field — the 8-byte field at request offset 16 is Reserved — so
+	// the client conveys the reservation via this context. DittoFS does not
+	// preallocate; the value only raises the (cluster-aligned) AllocationSize
+	// reported in the CREATE response (smb2.durable-open.alloc-size).
+	RequestedAllocSize uint64
 
 	// FileName is the name/path of the file to create or open.
 	// Uses backslash separators (Windows-style).
@@ -263,6 +277,15 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 				req.CreateContexts = ctxs
 			}
 		}
+	}
+
+	// SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create context [MS-SMB2] 2.2.13.2.2:
+	// the client conveys its requested initial allocation as an 8-byte
+	// little-endian value in the context Data. SMB2 has no fixed AllocationSize
+	// request field (request offset 16 is Reserved), so this is the only place
+	// the reservation is carried. Required by smb2.durable-open.alloc-size.
+	if alsi := FindCreateContext(req.CreateContexts, CreateContextTagAllocationSize); alsi != nil && len(alsi.Data) >= 8 {
+		req.RequestedAllocSize = smbenc.NewReader(alsi.Data).ReadUint64()
 	}
 
 	return req, nil

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1002,6 +1002,12 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		CreateOptions:        req.CreateOptions,
 		InitialDeleteOnClose: req.CreateOptions&types.FileDeleteOnClose != 0,
 		ClientGUID:           connClientGUID(ctx),
+		// Honour the client-requested AllocationSize [MS-SMB2] 2.2.13.2.2 for
+		// regular files only. Directories never report the requested reservation
+		// (smb2.create.dir-alloc-size), so leave it zero for them. Tracked
+		// per-handle so the CREATE response and a later QUERY_INFO on this handle
+		// agree (smb2.create.open).
+		RequestedAllocSize: allocReservationFor(file.Type == metadata.FileTypeDirectory, req.RequestedAllocSize),
 	}
 
 	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {
@@ -1089,7 +1095,11 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 	creation, access, write, change := FileAttrToSMBTimes(respAttr)
 	size := getSMBSize(&file.FileAttr)
-	allocationSize := calculateAllocationSize(size)
+	// Report the larger of the file's cluster-aligned size and the per-handle
+	// requested reservation [MS-SMB2] 2.2.13.2.2 (zero for directories), so a
+	// freshly-created empty file opened with in.alloc_size reports a non-zero
+	// out.alloc_size (smb2.durable-open.alloc-size).
+	allocationSize := effectiveAllocationSize(size, openFile.RequestedAllocSize)
 
 	resp := &CreateResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},

--- a/internal/adapter/smb/v2/handlers/create_test.go
+++ b/internal/adapter/smb/v2/handlers/create_test.go
@@ -1045,6 +1045,39 @@ func TestDecodeCreateRequest_WithCreateContexts(t *testing.T) {
 			t.Errorf("Expected 0 create contexts, got %d", len(req.CreateContexts))
 		}
 	})
+
+	t.Run("ParsesAllocationSizeFromAlSiContext", func(t *testing.T) {
+		// SMB2 has no fixed AllocationSize request field; the client sends it in
+		// the SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create context [MS-SMB2]
+		// 2.2.13.2.2 as an 8-byte little-endian value.
+		data := make([]byte, 8)
+		binary.LittleEndian.PutUint64(data, 0x1000)
+		body := buildCreateRequestBodyWithContexts("file.txt", types.FileCreate, 0,
+			[]CreateContext{{Name: CreateContextTagAllocationSize, Data: data}})
+
+		req, err := DecodeCreateRequest(body)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if req.RequestedAllocSize != 0x1000 {
+			t.Errorf("RequestedAllocSize = %d, expected 0x1000", req.RequestedAllocSize)
+		}
+	})
+
+	t.Run("IgnoresReservedFieldForAllocationSize", func(t *testing.T) {
+		// The 8-byte field at offset 16 is Reserved in the SMB2 CREATE request;
+		// a value there must NOT be interpreted as AllocationSize.
+		body := buildCreateRequestBody("file.txt", types.FileCreate, 0)
+		binary.LittleEndian.PutUint64(body[16:24], 0x9999)
+
+		req, err := DecodeCreateRequest(body)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if req.RequestedAllocSize != 0 {
+			t.Errorf("RequestedAllocSize = %d, expected 0 (Reserved must be ignored)", req.RequestedAllocSize)
+		}
+	})
 }
 
 // =============================================================================

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -416,6 +416,17 @@ type OpenFile struct {
 	// used to populate FileModeInformation (FILE_WRITE_THROUGH, FILE_SEQUENTIAL_ONLY, etc.)
 	CreateOptions types.CreateOptions
 
+	// RequestedAllocSize is the client-requested initial allocation in bytes
+	// from the CREATE SMB2_CREATE_ALLOCATION_SIZE ("AlSi") create context
+	// [MS-SMB2] 2.2.13.2.2, or from a later SET_INFO FileAllocationInformation
+	// [MS-FSCC] 2.4.4. DittoFS does not preallocate backing storage; this value
+	// only raises the (cluster-aligned) AllocationSize reported in the CREATE
+	// response and subsequent QUERY_INFO on this handle, keeping the two
+	// consistent (smb2.create.open, smb2.durable-open.alloc-size). Always 0 for
+	// directories — directories never honour the request
+	// (smb2.create.dir-alloc-size). Per-handle, in-memory, lost on close.
+	RequestedAllocSize uint64
+
 	// Timestamp freeze/unfreeze state per MS-FSA 2.1.5.14.2.
 	// When a client sends SET_INFO with FILETIME -1, the corresponding timestamp
 	// is "frozen" and MUST NOT be auto-updated by subsequent operations (WRITE, etc.).

--- a/internal/adapter/smb/v2/handlers/query_info.go
+++ b/internal/adapter/smb/v2/handlers/query_info.go
@@ -661,6 +661,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		// querying STANDARD / ALL_INFORMATION after setting delete disposition
 		// surfaces delete_pending = 1.
 		standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
+		standardInfo.AllocationSize = effectiveAllocationSize(standardInfo.EndOfFile, openFile.RequestedAllocSize)
 		return EncodeFileStandardInfo(standardInfo), nil
 
 	case types.FileInternalInformation:
@@ -702,13 +703,14 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 				LastAccessTime: access,
 				LastWriteTime:  write,
 				ChangeTime:     change,
-				AllocationSize: calculateAllocationSize(size),
+				AllocationSize: effectiveAllocationSize(size, openFile.RequestedAllocSize),
 				EndOfFile:      size,
 				FileAttributes: FileAttrToSMBAttributesWithName(baseAttr, basenameForHidden(openFile)),
 			}
 			return EncodeFileNetworkOpenInfo(networkInfo), nil
 		}
 		networkInfo := FileAttrToFileNetworkOpenInfoWithName(&file.FileAttr, basenameForHidden(openFile))
+		networkInfo.AllocationSize = effectiveAllocationSize(networkInfo.EndOfFile, openFile.RequestedAllocSize)
 		return EncodeFileNetworkOpenInfo(networkInfo), nil
 
 	case types.FilePositionInformation:
@@ -884,6 +886,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	}
 	basicInfo := FileAttrToFileBasicInfoWithName(attr, basenameForHidden(openFile))
 	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
+	standardInfo.AllocationSize = effectiveAllocationSize(standardInfo.EndOfFile, openFile.RequestedAllocSize)
 	nameBytes := encodeUTF16LE(toSMBPath(openFile.Path))
 
 	// Fixed part: 96 bytes + NameInformation header (4 bytes for length) + name data

--- a/internal/adapter/smb/v2/handlers/set_info.go
+++ b/internal/adapter/smb/v2/handlers/set_info.go
@@ -1328,6 +1328,15 @@ func (h *Handler) setFileInfoFromStore(
 				logger.Debug("SET_INFO: oplock break on allocation set failed (non-fatal)", "path", openFile.Path, "error", breakErr)
 			}
 		}
+		// Record the requested reservation per-handle so a later QUERY_INFO on
+		// this handle reports a consistent AllocationSize. We do not preallocate;
+		// this only raises the reported allocation, never the file's EndOfFile.
+		// AllocationSize is an 8-byte LE value at offset 0 [MS-FSCC] 2.4.4.
+		// allocReservationFor drops the request for directories.
+		if len(buffer) >= 8 {
+			requested := smbenc.NewReader(buffer[:8]).ReadUint64()
+			openFile.RequestedAllocSize = allocReservationFor(openFile.IsDirectory, requested)
+		}
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileLinkInformation:


### PR DESCRIPTION
## What

Fixes `smb2.durable-open.alloc-size` (#792): a CREATE that sets `in.alloc_size` returned `out.alloc_size = 0`. This is a pre-existing non-durable-handle bug — it fails on the **initial CREATE**, before any reconnect.

## Why the previous attempt (#845) regressed

#845 was reverted (#849) because it honoured the request on CREATE but left QUERY_INFO at `calculateAllocationSize(size)`, breaking the CREATE↔QUERY consistency invariant:

- `smb2.create.open` creates with `in.alloc_size=1MB` and asserts the CREATE `out.alloc_size` equals a subsequent QUERY_INFO `FILE_ALL_INFORMATION` alloc on the **same handle**. #845 made CREATE alone report the reservation → CREATE ≠ QUERY → regression.
- `smb2.create.dir-alloc-size` sets a 1 GiB request on a **directory** and asserts the reported allocation stays small. #845 had no directory guard → regression.

## This fix

- Decode `in.alloc_size` from the `SMB2_CREATE_ALLOCATION_SIZE` ("AlSi") create context [MS-SMB2] 2.2.13.2.2 (SMB2 has no fixed AllocationSize request field — request offset 16 is Reserved).
- Track the reservation **per open handle** (`OpenFile.RequestedAllocSize`), dropped for directories via `allocReservationFor`.
- Report `effectiveAllocationSize(size, requested)` (the larger of the file's cluster-aligned size and the cluster-aligned reservation) **consistently** across the CREATE response and QUERY_INFO `FILE_STANDARD` / `FILE_ALL` / `FILE_NETWORK_OPEN` on that handle. This satisfies the CREATE↔QUERY invariant (`smb2.create.open`) and the non-zero requirement (`smb2.durable-open.alloc-size`).
- Directories never honour the request (`smb2.create.dir-alloc-size`).
- `SET_INFO FileAllocationInformation` updates the same per-handle reservation so a later QUERY stays consistent.
- Round-up saturates near uint64 max.

DittoFS does not preallocate backing storage; the reservation is in-memory per-handle only. Durable-reconnect response is intentionally **unchanged** (the test never reaches reconnect; no persisted reservation).

## Tests

- Unit: `effectiveAllocationSize` (incl. saturation), `allocReservationFor` (directory drop), `AlSi` decode + Reserved-field-ignored.
- `go build ./...`, `go test ./internal/adapter/smb/...`, `go test -race ./internal/adapter/smb/v2/handlers/...` all green.

KNOWN_FAILURES.md intentionally left untouched — to be walked back after CI confirms the flip.