### PR TITLE
fix(smb/create): replay share-mode + DACL gates on create-race recovery (#765)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -384,6 +384,147 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	return 0
 }
 
+// recheckExistingFileGates runs the share-mode conflict check, the DACL
+// access-rights gate, and the delete-on-close (read-only) checks against the
+// CURRENT draft view (d.existingFile / d.existingHandle / d.fileExists /
+// d.createAction). It is intentionally view-driven rather than closing over
+// the caller's local snapshot so it can be re-run after the draft is resynced
+// to the winner of a metadata-store TOCTOU create race (completeCreateAfterBreak
+// ErrAlreadyExists branch): the pre-break invocation evaluated these gates
+// against the (nil) draft view, so a race winner must be re-gated before the
+// overwrite/open path proceeds (#765).
+//
+// Returns:
+//   - grantedAccess / grantedComputed: the effective rights for the open,
+//     computed from the existing file's DACL (per MS-SMB2 §3.3.5.9 paragraph 8).
+//     grantedComputed is false on the new-file path where no existing DACL gate
+//     runs; the caller falls back to resolveAccessFlags(DesiredAccess).
+//   - failResp: non-nil when a gate denies the open; the caller returns it
+//     verbatim. nil on success.
+func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint32) (grantedAccess uint32, grantedComputed bool, failResp *CreateResponse) {
+	req := d.req
+	authCtx := d.authCtx
+	filename := d.filename
+	parentHandle := d.parentHandle
+	existingFile := d.existingFile
+	fileExists := d.fileExists
+	createAction := d.createAction
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Share-mode recheck (fileExists path) after any lease breaks have drained.
+	// A pre-break violation selected the Handle-strip break mask so the holder
+	// could close cached handles on ack; the recheck runs against the post-break
+	// open table to decide the final CREATE outcome.
+	//
+	// Uses effectiveAccess (not raw req.DesiredAccess) so a destructive
+	// disposition with a read-only DesiredAccess (e.g. SUPERSEDE+READ_DATA)
+	// still trips the SHARE_WRITE deny check against an existing SHARE_READ-only
+	// holder, returning STATUS_SHARING_VIOLATION. Covers
+	// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases arm (#575).
+	if fileExists && d.existingHandle != nil {
+		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, filename); shareConflict {
+			logger.Debug("CREATE: sharing violation",
+				"path", filename,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
+				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess),
+				"disposition", req.CreateDisposition)
+			return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSharingViolation}}
+		}
+	}
+
+	// Step 6c-bis: Enforce DesiredAccess against the existing file's DACL.
+	//
+	// Per MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1, the server MUST evaluate
+	// the requested access bits against the object's security descriptor and
+	// fail the open with STATUS_ACCESS_DENIED when any non-MAXIMUM_ALLOWED bit
+	// is denied. New files (createAction == FileCreated) inherit their ACL from
+	// the parent at create time and don't need this check — parent write was
+	// already gated via CheckParentWriteAccess in Create(). Tracking #529.
+	//
+	// grantedAccess captures the effective rights for the open per
+	// MS-SMB2 §3.3.5.9 paragraph 8: the per-bit intersection of the
+	// requested mask with the file's DACL. Carried onto OpenFile.GrantedAccess
+	// below and consumed by FileAccessInformation (#548, MS-FSCC §2.4.1) and
+	// the QUERY_INFO open-level access gate (MS-SMB2 §3.3.5.20.1).
+	if fileExists && existingFile != nil {
+		// Fetch parent so CheckFileAccessWithParent can apply the
+		// FILE_DELETE_CHILD override per MS-FSA §2.1.4.13 (Samba
+		// parent_override_delete). Best-effort: a parent-lookup failure
+		// falls back to file-only DACL evaluation (nil parent is safe).
+		var parentFile *metadata.File
+		if parentHandle != nil {
+			if pf, err := metaSvc.GetFile(authCtx.Context, parentHandle); err == nil {
+				parentFile = pf
+			}
+		}
+
+		// effectiveAccess (computed by the caller) folds the
+		// disposition-implied FILE_WRITE_DATA into the mask. The DACL check
+		// uses the same augmented mask Samba's smbd_check_access_rights_fsp
+		// receives, so a DACL that grants only READ_DATA fails OVERWRITE /
+		// OVERWRITE_IF / SUPERSEDE with STATUS_ACCESS_DENIED. Covers
+		// smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm (#565).
+		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
+		if err != nil {
+			logger.Debug("CREATE: DesiredAccess denied by DACL",
+				"path", filename,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
+				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
+				"granted", fmt.Sprintf("0x%x", granted),
+				"disposition", req.CreateDisposition,
+				"error", err)
+			return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
+		}
+		// Preserve the client-visible grant: clear the disposition-implied
+		// bit before propagating so QUERY_INFO / FileAccessInformation report
+		// only what was actually requested (Samba `fsp->access_mask` mirrors
+		// the original DesiredAccess after the open succeeds — see
+		// open_file_ntcreate line where access_mask is restored).
+		if effectiveAccess != req.DesiredAccess {
+			granted &^= (effectiveAccess &^ req.DesiredAccess)
+		}
+		grantedAccess = granted
+		grantedComputed = true
+	}
+
+	// Step 6d: Validate delete-on-close requirements per MS-FSA 2.1.5.1.2.1.
+	if req.CreateOptions&types.FileDeleteOnClose != 0 {
+		if !hasDeleteAccess(req.DesiredAccess) {
+			logger.Debug("CREATE: delete-on-close without DELETE access",
+				"path", filename,
+				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess))
+			return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}
+		}
+		if fileExists && existingFile.Type != metadata.FileTypeDirectory {
+			attrs := FileAttrToSMBAttributes(&existingFile.FileAttr)
+			if attrs&types.FileAttributeReadonly != 0 {
+				logger.Debug("CREATE: delete-on-close on read-only file", "path", filename)
+				return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
+			}
+		}
+		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.2.1: the resulting file
+		// would be marked DOC and READONLY simultaneously, but READONLY blocks
+		// the eventual unlink. Only fires when req.FileAttributes actually
+		// propagates to the resulting file — dispositions that create or
+		// rewrite (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF). For
+		// FILE_OPEN / FILE_OPEN_IF on an existing file the request attrs are
+		// ignored and the disk attrs apply; that path is covered by the
+		// existing-file arm above.
+		propagatesReqAttrs := createAction == types.FileCreated ||
+			createAction == types.FileOverwritten ||
+			createAction == types.FileSuperseded
+		if propagatesReqAttrs && req.FileAttributes&types.FileAttributeReadonly != 0 {
+			logger.Debug("CREATE: delete-on-close with read-only attribute in request",
+				"path", filename,
+				"createAction", createAction)
+			return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
+		}
+	}
+
+	return grantedAccess, grantedComputed, nil
+}
+
 // completeCreateAfterBreak runs the CREATE flow from the share-mode recheck
 // through the final response build. Split out of Create() so the same code
 // path serves both the synchronous break-wait path and the async-park resume
@@ -407,118 +548,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// augmented mask for BOTH checks. See effectiveAccessForOpen for spec refs.
 	effectiveAccess := effectiveAccessForOpen(req.DesiredAccess, req.CreateDisposition)
 
-	// Share-mode recheck (fileExists path) after any lease breaks have drained.
-	// A pre-break violation selected the Handle-strip break mask so the holder
-	// could close cached handles on ack; the recheck runs against the post-break
-	// open table to decide the final CREATE outcome.
-	//
-	// Uses effectiveAccess (not raw req.DesiredAccess) so a destructive
-	// disposition with a read-only DesiredAccess (e.g. SUPERSEDE+READ_DATA)
-	// still trips the SHARE_WRITE deny check against an existing SHARE_READ-only
-	// holder, returning STATUS_SHARING_VIOLATION. Covers
-	// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases arm (#575).
-	if fileExists && d.existingHandle != nil {
-		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, filename); shareConflict {
-			logger.Debug("CREATE: sharing violation",
-				"path", filename,
-				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
-				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
-				"shareAccess", fmt.Sprintf("0x%x", req.ShareAccess),
-				"disposition", req.CreateDisposition)
-			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSharingViolation}}
-		}
-	}
-
-	// Step 6c-bis: Enforce DesiredAccess against the existing file's DACL.
-	//
-	// Per MS-SMB2 §3.3.5.9 and MS-FSA §2.1.5.1.2.1, the server MUST evaluate
-	// the requested access bits against the object's security descriptor and
-	// fail the open with STATUS_ACCESS_DENIED when any non-MAXIMUM_ALLOWED bit
-	// is denied. New files (createAction == FileCreated) inherit their ACL from
-	// the parent at create time and don't need this check — parent write was
-	// already gated via CheckParentWriteAccess in Create(). Tracking #529.
-	//
-	// grantedAccess captures the effective rights for the open per
-	// MS-SMB2 §3.3.5.9 paragraph 8: the per-bit intersection of the
-	// requested mask with the file's DACL. Carried onto OpenFile.GrantedAccess
-	// below and consumed by FileAccessInformation (#548, MS-FSCC §2.4.1) and
-	// the QUERY_INFO open-level access gate (MS-SMB2 §3.3.5.20.1).
+	// Share-mode recheck + DACL access gate + delete-on-close (read-only)
+	// checks, evaluated against the existing-file draft view after any lease
+	// breaks have drained. Lifted into a helper so the race-recovery branch
+	// (ErrAlreadyExists resync below) can replay the SAME gates against the
+	// winner's view before the overwrite/open path proceeds (#765).
 	metaSvc := h.Registry.GetMetadataService()
-	var grantedAccess uint32
-	var grantedComputed bool
-	if fileExists && existingFile != nil {
-		// Fetch parent so CheckFileAccessWithParent can apply the
-		// FILE_DELETE_CHILD override per MS-FSA §2.1.4.13 (Samba
-		// parent_override_delete). Best-effort: a parent-lookup failure
-		// falls back to file-only DACL evaluation (nil parent is safe).
-		var parentFile *metadata.File
-		if parentHandle != nil {
-			if pf, err := metaSvc.GetFile(authCtx.Context, parentHandle); err == nil {
-				parentFile = pf
-			}
-		}
-
-		// effectiveAccess (computed above the share-mode check) folds the
-		// disposition-implied FILE_WRITE_DATA into the mask. The DACL check
-		// uses the same augmented mask Samba's smbd_check_access_rights_fsp
-		// receives, so a DACL that grants only READ_DATA fails OVERWRITE /
-		// OVERWRITE_IF / SUPERSEDE with STATUS_ACCESS_DENIED. Covers
-		// smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm (#565).
-		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
-		if err != nil {
-			logger.Debug("CREATE: DesiredAccess denied by DACL",
-				"path", filename,
-				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
-				"effectiveAccess", fmt.Sprintf("0x%x", effectiveAccess),
-				"granted", fmt.Sprintf("0x%x", granted),
-				"disposition", req.CreateDisposition,
-				"error", err)
-			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}
-		}
-		// Preserve the client-visible grant: clear the disposition-implied
-		// bit before propagating so QUERY_INFO / FileAccessInformation report
-		// only what was actually requested (Samba `fsp->access_mask` mirrors
-		// the original DesiredAccess after the open succeeds — see
-		// open_file_ntcreate line where access_mask is restored).
-		if effectiveAccess != req.DesiredAccess {
-			granted &^= (effectiveAccess &^ req.DesiredAccess)
-		}
-		grantedAccess = granted
-		grantedComputed = true
-	}
-
-	// Step 6d: Validate delete-on-close requirements per MS-FSA 2.1.5.1.2.1.
-	if req.CreateOptions&types.FileDeleteOnClose != 0 {
-		if !hasDeleteAccess(req.DesiredAccess) {
-			logger.Debug("CREATE: delete-on-close without DELETE access",
-				"path", filename,
-				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess))
-			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}
-		}
-		if fileExists && existingFile.Type != metadata.FileTypeDirectory {
-			attrs := FileAttrToSMBAttributes(&existingFile.FileAttr)
-			if attrs&types.FileAttributeReadonly != 0 {
-				logger.Debug("CREATE: delete-on-close on read-only file", "path", filename)
-				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
-			}
-		}
-		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.2.1: the resulting file
-		// would be marked DOC and READONLY simultaneously, but READONLY blocks
-		// the eventual unlink. Only fires when req.FileAttributes actually
-		// propagates to the resulting file — dispositions that create or
-		// rewrite (CREATE/CREATE_IF/SUPERSEDE/OVERWRITE/OVERWRITE_IF). For
-		// FILE_OPEN / FILE_OPEN_IF on an existing file the request attrs are
-		// ignored and the disk attrs apply; that path is covered by the
-		// existing-file arm above.
-		propagatesReqAttrs := createAction == types.FileCreated ||
-			createAction == types.FileOverwritten ||
-			createAction == types.FileSuperseded
-		if propagatesReqAttrs && req.FileAttributes&types.FileAttributeReadonly != 0 {
-			logger.Debug("CREATE: delete-on-close with read-only attribute in request",
-				"path", filename,
-				"createAction", createAction)
-			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
-		}
+	grantedAccess, grantedComputed, failResp := h.recheckExistingFileGates(d, effectiveAccess)
+	if failResp != nil {
+		return failResp
 	}
 
 	// Step 6e: Break parent directory leases on create/overwrite/supersede
@@ -595,8 +633,10 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 						// share-mode + DACL gates and the lease/open
 						// bookkeeping run against the real file. The
 						// original pre-break share-mode recheck ran on
-						// our stale (nil) view; rerun it now.
-						existingFile = winner
+						// our stale (nil) view; rerun it now. The local
+						// existingFile snapshot is not touched: from here the
+						// race branch drives file/fileHandle directly and the
+						// replayed gates read the winner from d.existingFile.
 						fileExists = true
 						d.existingFile = winner
 						d.fileExists = true
@@ -611,6 +651,26 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 							return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(dispErr)}}
 						}
 						createAction = newAction
+						d.createAction = newAction
+						// Replay the share-mode + DACL + delete-on-close
+						// gates against the winner BEFORE the overwrite/open
+						// proceeds. The first invocation (top of
+						// completeCreateAfterBreak) ran against the stale nil
+						// draft, so a winner with an incompatible share-mode
+						// or denying DACL — surfaced only under real path
+						// contention on OVERWRITE_IF / SUPERSEDE — would
+						// otherwise slip past every access gate (#765). On the
+						// OPEN_IF dir-mkdir-dup path the winner is a fresh
+						// share-compatible directory, so this is a no-op there.
+						// effectiveAccess is immutable across the resync
+						// (DesiredAccess / CreateDisposition don't change), so
+						// the value computed at the top still applies.
+						rg, rc, raceFail := h.recheckExistingFileGates(d, effectiveAccess)
+						if raceFail != nil {
+							return raceFail
+						}
+						grantedAccess = rg
+						grantedComputed = rc
 						if createAction == types.FileOpened {
 							file = winner
 							fileHandle = d.existingHandle

--- a/internal/adapter/smb/v2/handlers/create_race_recovery_gates_test.go
+++ b/internal/adapter/smb/v2/handlers/create_race_recovery_gates_test.go
@@ -1,0 +1,387 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// Coverage for #765: the metadata-store TOCTOU create-race recovery branch in
+// completeCreateAfterBreak must replay the share-mode + DACL access gates
+// against the RACE WINNER before the destructive overwrite/open proceeds.
+//
+// The first gate invocation at the top of completeCreateAfterBreak runs against
+// the draft's pre-race view (fileExists=false / existingFile=nil), so it is a
+// no-op for a FILE_CREATED draft. When createNewFile then loses the race with
+// ErrAlreadyExists for OVERWRITE_IF / SUPERSEDE, the draft is resynced to the
+// winner. Without the replay, a winner carrying an incompatible share-mode or a
+// denying DACL would slip past every access check and be silently overwritten.
+//
+// These tests drive the branch directly: they pre-seed the winner in the store,
+// then hand completeCreateAfterBreak a FILE_CREATED draft for the same name so
+// createNewFile fails with ErrAlreadyExists and the recovery path runs.
+
+// raceParentDir creates a world-writable subdirectory under the share root so a
+// non-root requester passes the parent create-access check inside createNewFile
+// (letting the create reach the ErrAlreadyExists race instead of failing early
+// on parent permissions).
+func raceParentDir(
+	t *testing.T,
+	metaSvc *metadata.MetadataService,
+	rootAuth *metadata.AuthContext,
+	rootHandle metadata.FileHandle,
+	name string,
+) (metadata.FileHandle, *metadata.File) {
+	t.Helper()
+	dir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, name,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		})
+	if err != nil {
+		t.Fatalf("CreateDirectory parent: %v", err)
+	}
+	h, err := metadata.EncodeFileHandle(dir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle parent: %v", err)
+	}
+	return h, dir
+}
+
+// raceWinnerDraft builds a FILE_CREATED draft (pre-race view: no existing file)
+// for the given disposition. completeCreateAfterBreak will attempt createNewFile,
+// hit the pre-seeded winner, and enter the ErrAlreadyExists recovery branch.
+func raceWinnerDraft(
+	tree *TreeConnection,
+	authCtx *metadata.AuthContext,
+	parentHandle metadata.FileHandle,
+	baseName string,
+	desiredAccess uint32,
+	shareAccess uint32,
+	disposition types.CreateDisposition,
+) *createDraft {
+	return &createDraft{
+		req: &CreateRequest{
+			FileName:          baseName,
+			DesiredAccess:     desiredAccess,
+			ShareAccess:       shareAccess,
+			CreateDisposition: disposition,
+			CreateOptions:     0,
+		},
+		tree:         tree,
+		authCtx:      authCtx,
+		filename:     baseName,
+		baseName:     baseName,
+		parentHandle: parentHandle,
+		// Pre-race view: the draft believed the target did not exist, so it
+		// resolved to FILE_CREATED with no existing file. This is the state
+		// Create() hands completeCreateAfterBreak before the metadata-store
+		// transaction reveals the concurrent winner.
+		existingFile:   nil,
+		existingHandle: nil,
+		fileExists:     false,
+		createAction:   types.FileCreated,
+	}
+}
+
+// TestCreate_RaceRecovery_SupersedeDeniedByWinnerDACL asserts that a SUPERSEDE
+// that loses the create race against a winner whose DACL explicitly denies
+// WRITE to the requester is rejected with STATUS_ACCESS_DENIED — and that the
+// winner's content is NOT destroyed.
+//
+// The winner carries an explicit ACE4_ACCESS_DENIED for WRITE_DATA. With the
+// #765 replay the SMB DACL gate refuses the destructive open up front. (The
+// metadata layer's own write-permission check provides defense-in-depth on this
+// path, so the *content* survives either way — the load-bearing discriminator
+// for the gate replay itself is the share-mode test below, which exercises a
+// pure SMB-handler concern the metadata layer knows nothing about.) This test
+// pins the open-time status and the no-truncation guarantee for the DACL arm.
+func TestCreate_RaceRecovery_SupersedeDeniedByWinnerDACL(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "race-dacl")
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Pre-seed the winner: owned by the requester (so the POSIX overwrite check
+	// passes) but carrying an explicit DENY for WRITE_DATA. The open-time DACL
+	// gate must still refuse the destructive open. Seeded with a non-zero size
+	// so a successful supersede would be observable as truncation to zero.
+	denyWriteACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_WRITE_DATA,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE,
+			},
+		},
+	}
+	winner, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o700,
+			UID:  requesterUID,
+			GID:  2001,
+			ACL:  denyWriteACL,
+		})
+	if err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+	winnerHandle, err := metadata.EncodeFileHandle(winner)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle winner: %v", err)
+	}
+	// CreateFile forces Size=0 (ApplyCreateDefaults); set a non-zero size as
+	// root so a successful supersede would be observable as truncation to zero.
+	winnerSize := uint64(4096)
+	if err := metaSvc.SetFileAttributes(rootAuth, winnerHandle, &metadata.SetAttrs{Size: &winnerSize}); err != nil {
+		t.Fatalf("seed winner size: %v", err)
+	}
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+		BypassTraverseChecking: true, // mirror real SMB sessions
+	}
+
+	// SUPERSEDE with attrs-only DesiredAccess. The implied FILE_WRITE_DATA from
+	// the destructive disposition is what the DACL must deny.
+	const fileReadAttributes uint32 = 0x00000080
+	draft := raceWinnerDraft(tree, requesterAuth, parentHandle, "winner.txt",
+		fileReadAttributes, 0x07, types.FileSupersede)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("SUPERSEDE losing race vs denying DACL: status = 0x%08x, expected STATUS_ACCESS_DENIED (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusAccessDenied))
+	}
+
+	// The denied open must not have truncated the winner.
+	after, err := metaSvc.GetFile(context.Background(), winnerHandle)
+	if err != nil {
+		t.Fatalf("GetFile winner after denial: %v", err)
+	}
+	if after.Size != 4096 {
+		t.Fatalf("winner content destroyed despite ACCESS_DENIED: size = %d, expected 4096", after.Size)
+	}
+}
+
+// TestCreate_RaceRecovery_OverwriteIfDeniedByShareMode asserts that an
+// OVERWRITE_IF that loses the create race against a winner already opened with
+// a SHARE_READ-only share mode is rejected with STATUS_SHARING_VIOLATION — the
+// destructive (write-implying) open conflicts with the existing reader that did
+// not grant SHARE_WRITE.
+func TestCreate_RaceRecovery_OverwriteIfDeniedByShareMode(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "race-share")
+
+	// Pre-seed a permissive winner (nil DACL → no DACL denial) so the rejection
+	// is unambiguously from the share-mode gate, not the DACL gate.
+	winner, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+		})
+	if err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+	winnerHandle, err := metadata.EncodeFileHandle(winner)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle winner: %v", err)
+	}
+
+	// Existing open on the winner: READ access, SHARE_READ only (no SHARE_WRITE).
+	const (
+		fileReadData      uint32 = 0x00000001
+		fileShareReadOnly uint32 = 0x00000001
+	)
+	h.StoreOpenFile(&OpenFile{
+		FileID:         h.GenerateFileID(),
+		TreeID:         smbCtx.TreeID,
+		SessionID:      smbCtx.SessionID,
+		Path:           "winner.txt",
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  fileReadData,
+		ShareAccess:    fileShareReadOnly,
+		MetadataHandle: winnerHandle,
+	})
+
+	requesterUID := uint32(0)
+	requesterGID := uint32(0)
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+		},
+	}
+
+	// OVERWRITE_IF with READ_DATA. The destructive disposition folds in
+	// FILE_WRITE_DATA, so the new open implies write and conflicts with the
+	// SHARE_READ-only existing holder.
+	draft := raceWinnerDraft(tree, requesterAuth, parentHandle, "winner.txt",
+		fileReadData, 0x07, types.FileOverwriteIf)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSharingViolation {
+		t.Fatalf("OVERWRITE_IF losing race vs SHARE_READ holder: status = 0x%08x, expected STATUS_SHARING_VIOLATION (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusSharingViolation))
+	}
+}
+
+// TestCreate_RaceRecovery_OpenIfMkdirDupStillSucceeds is the regression guard
+// for the asserted smbtorture path (smb2.create.mkdir-dup): two parallel
+// OPEN_IF on the same directory name must still yield a successful open for the
+// loser. The replayed gate runs against a fresh, share-compatible directory
+// winner with no denying DACL, so it must be a no-op here.
+func TestCreate_RaceRecovery_OpenIfMkdirDupStillSucceeds(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "race-mkdir")
+
+	// Pre-seed the winning directory (the "other" parallel OPEN_IF that won).
+	if _, err := metaSvc.CreateDirectory(rootAuth, parentHandle, "dup-dir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		}); err != nil {
+		t.Fatalf("seed winner dir: %v", err)
+	}
+
+	requesterUID := uint32(0)
+	requesterGID := uint32(0)
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+		},
+	}
+
+	// OPEN_IF directory CREATE that loses the race. DesiredAccess READ_DATA,
+	// permissive share mode → resolves to FILE_OPENED on the winner.
+	const fileReadData uint32 = 0x00000001
+	draft := raceWinnerDraft(tree, requesterAuth, parentHandle, "dup-dir",
+		fileReadData, 0x07, types.FileOpenIf)
+	draft.isDirectoryRequest = true
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("OPEN_IF mkdir-dup loser: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+	if resp.CreateAction != types.FileOpened {
+		t.Fatalf("OPEN_IF mkdir-dup loser: createAction = %d, expected FileOpened (%d)",
+			resp.CreateAction, types.FileOpened)
+	}
+}
+
+// TestCreate_RaceRecovery_OpenIfNonRootInheritedACLSucceeds guards the replay
+// against regressing the realistic (non-root) mkdir-dup path. The winner is a
+// directory whose ACL was inherited from a parent that grants the requester
+// full inheritable access, so the newly-added DACL gate on the OPEN_IF race
+// path must still grant the open — the replay must not turn a legitimate loser
+// into STATUS_ACCESS_DENIED.
+func TestCreate_RaceRecovery_OpenIfNonRootInheritedACLSucceeds(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	metaSvc := rt.GetMetadataService()
+
+	requesterUID := uint32(2001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Parent directory grants the requester full access, inheritable to
+	// children (so the winning directory's inherited ACL grants the requester).
+	fullInheritACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:  "sid:" + requesterSID,
+				AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_READ_ATTRIBUTES |
+					acl.ACE4_WRITE_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_ADD_FILE |
+					acl.ACE4_ADD_SUBDIRECTORY | acl.ACE4_SYNCHRONIZE,
+				Flag: acl.ACE4_FILE_INHERIT_ACE | acl.ACE4_DIRECTORY_INHERIT_ACE,
+			},
+		},
+	}
+	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "race-inherit",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+			ACL:  fullInheritACL,
+		})
+	if err != nil {
+		t.Fatalf("CreateDirectory parent: %v", err)
+	}
+	parentHandle, err := metadata.EncodeFileHandle(parentDir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle parent: %v", err)
+	}
+
+	requesterGID := uint32(2001)
+	sidStr := requesterSID
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+		// Mirror real SMB sessions, which set this so a parent DACL lacking
+		// FILE_TRAVERSE does not block resolution of a child the requester may
+		// open (MS-FSA §2.1.5.1.1; handler.go sets it on every SMB AuthContext).
+		BypassTraverseChecking: true,
+	}
+
+	// Pre-seed the winning directory as the requester so it inherits the
+	// parent's ACL granting the requester full access.
+	if _, err := metaSvc.CreateDirectory(requesterAuth, parentHandle, "dup-dir",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		}); err != nil {
+		t.Fatalf("seed winner dir: %v", err)
+	}
+
+	const fileReadData uint32 = 0x00000001
+	draft := raceWinnerDraft(tree, requesterAuth, parentHandle, "dup-dir",
+		fileReadData, 0x07, types.FileOpenIf)
+	draft.isDirectoryRequest = true
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("non-root OPEN_IF mkdir-dup loser w/ inherited grant: status = 0x%08x, expected STATUS_SUCCESS",
+			uint32(resp.Status))
+	}
+	if resp.CreateAction != types.FileOpened {
+		t.Fatalf("non-root OPEN_IF mkdir-dup loser: createAction = %d, expected FileOpened (%d)",
+			resp.CreateAction, types.FileOpened)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the TOCTOU create-race hardening gap from the Copilot finding on #760 (#765).

In `completeCreateAfterBreak`, when the metadata-store create race surfaces `ErrAlreadyExists` for OPEN_IF / OVERWRITE_IF / SUPERSEDE, the recovery branch resynced `existingFile` / `fileExists` / `d.existingHandle` to the winner and re-resolved `createAction` — but the **share-mode recheck, DACL access gate, and delete-on-close (read-only) checks** had already run earlier against the pre-race (nil) draft view and were **not** replayed against the winner. Under real path contention an OVERWRITE_IF / SUPERSEDE loser could overwrite a winner with an incompatible share mode or a denying DACL.

## Fix

- Lift the three gates (share-mode conflict, DACL `CheckFileAccessWithParent`, delete-on-close) into a single view-driven helper `recheckExistingFileGates(d, effectiveAccess)` that operates over `d.existingFile` / `d.existingHandle` / `d.fileExists` / `d.createAction` and returns `(grantedAccess, grantedComputed, failResp)`.
- The top-of-function (non-race) call is behavior-preserving — it evaluates the same logic against the same draft view it always did.
- In the recovery branch, set `d.createAction` to the re-resolved action and **replay** the helper against the winner before the overwrite/open proceeds. A denial returns the proper open-time status; the OPEN_IF dir-mkdir-dup path (the asserted smbtorture case) is a no-op since the winner is share-compatible with no denying DACL.

## Tests

New `create_race_recovery_gates_test.go` drives the `ErrAlreadyExists` resync path directly:

- `SupersedeDeniedByWinnerDACL` — SUPERSEDE loser vs explicit DENY-WRITE winner → `STATUS_ACCESS_DENIED`, winner content preserved (no truncation).
- `OverwriteIfDeniedByShareMode` — OVERWRITE_IF loser vs SHARE_READ-only existing open → `STATUS_SHARING_VIOLATION`. **Load-bearing discriminator**: fails without the replay (file silently overwritten, `STATUS_SUCCESS`), passes with it. (Share-mode is a pure SMB-handler concern the metadata layer cannot guard.)
- `OpenIfMkdirDupStillSucceeds` + `OpenIfNonRootInheritedACLSucceeds` — regression guards for the asserted smbtorture `smb2.create.mkdir-dup` path (root and non-root w/ inherited grant); the replay must stay a no-op.

`go build ./...`, `go test ./internal/adapter/smb/...`, and `go test -race ./internal/adapter/smb/v2/handlers/...` all green. `gofmt`, `go vet`, `golangci-lint` clean.

This is a correctness/security hardening — it may not flip a new smbtorture test (the asserted OPEN_IF path already passes); the win is closing the contention hole. No `KNOWN_FAILURES.md` change.