### PR TITLE
fix(smb/dh): durable-handle residuals — V1-via-DH2C reconnect, app-instance silent failover, lease W-cap (#738/#739)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1317,18 +1317,34 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		}
 	}
 
+	// Step 6d: AppInstanceId failover (MS-SMB2 §3.3.5.9.13). When this CREATE
+	// carries an AppInstanceId matching an existing open (live or disconnected),
+	// the existing open MUST be force-closed to claim the file. This runs BEFORE
+	// the oplock/lease break dispatch below so the displaced open is gone before
+	// any break is computed — the failover is silent (no oplock break on the
+	// old open). smbtorture smb2.durable-v2-open.app-instance asserts
+	// break_info.count == 0 after a same-AppInstanceId open on a second tree.
+	var appInstanceId [16]byte
+	if h.DurableStore != nil {
+		appInstanceId = ProcessAppInstanceId(
+			authCtx.Context, h.DurableStore, h, req.CreateContexts,
+		)
+	}
+
 	draft := (&createDraft{
-		req:                req,
-		tree:               tree,
-		authCtx:            authCtx,
-		filename:           filename,
-		baseName:           baseName,
-		parentHandle:       parentHandle,
-		existingFile:       existingFile,
-		fileExists:         fileExists,
-		createAction:       createAction,
-		isDirectoryRequest: isDirectoryRequest,
-		excludeOwner:       excludeOwner,
+		req:                  req,
+		tree:                 tree,
+		authCtx:              authCtx,
+		filename:             filename,
+		baseName:             baseName,
+		parentHandle:         parentHandle,
+		existingFile:         existingFile,
+		fileExists:           fileExists,
+		createAction:         createAction,
+		isDirectoryRequest:   isDirectoryRequest,
+		excludeOwner:         excludeOwner,
+		appInstanceProcessed: true,
+		appInstanceId:        appInstanceId,
 	}).finalize()
 
 	// Dispatch lease break and either park the CREATE async (emit interim

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -38,6 +38,15 @@ type createDraft struct {
 	// excludeOwner scopes lease-break exclusions to the opener's own key. Used
 	// for parent-directory breaks (Step 7c) and post-break oplock/lease work.
 	excludeOwner *lock.LockOwner
+	// appInstanceProcessed records that ProcessAppInstanceId already ran in the
+	// pre-break CREATE path (so any conflicting open carrying the same
+	// AppInstanceId was force-closed BEFORE the oplock/lease break dispatch).
+	// completeCreateAfterBreak reuses appInstanceId rather than re-running the
+	// force-close. Per MS-SMB2 §3.3.5.9.13 the AppInstanceId failover MUST NOT
+	// generate an oplock break on the displaced open (smbtorture
+	// smb2.durable-v2-open.app-instance asserts break_info.count == 0).
+	appInstanceProcessed bool
+	appInstanceId        [16]byte
 }
 
 // finalize computes the opaque file handle for the existing file (if any) and
@@ -1035,9 +1044,19 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	}
 
 	// Step 8c: Process App Instance ID and durable handle grant.
+	//
+	// The AppInstanceId force-close normally runs in the pre-break CREATE path
+	// (Create, before breakAndMaybeParkCreate) so a conflicting open carrying
+	// the same AppInstanceId is displaced BEFORE any oplock/lease break is
+	// computed — MS-SMB2 §3.3.5.9.13 requires the failover to be silent (no
+	// break on the displaced open; smbtorture smb2.durable-v2-open.app-instance
+	// asserts break_info.count == 0). When that ran, reuse its result. Only
+	// fall back to processing here for callers that bypass the pre-break path.
 	var durableResponseCtx *CreateContext
 	var appInstanceId [16]byte
-	if h.DurableStore != nil {
+	if d.appInstanceProcessed {
+		appInstanceId = d.appInstanceId
+	} else if h.DurableStore != nil {
 		appInstanceId = ProcessAppInstanceId(
 			authCtx.Context, h.DurableStore, h, req.CreateContexts,
 		)

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -46,6 +46,19 @@ func DecodeDHnCReconnect(data []byte) ([16]byte, error) {
 	return fileID, nil
 }
 
+// zeroVolatileHalf returns fileID with the volatile half (bytes 8-15) cleared.
+// Durable handles are persisted keyed on the persistent half only (MS-SMB2
+// §3.2.4.4: the client sends Data.Volatile=0 on reconnect), but smbtorture
+// replays the full original FileID — so the reconnect lookup must zero the
+// volatile half to match the stored key. Shared by the V1 (DHnC) and the
+// V1-via-DH2C zero-CreateGuid reconnect paths.
+func zeroVolatileHalf(fileID [16]byte) [16]byte {
+	for i := 8; i < 16; i++ {
+		fileID[i] = 0
+	}
+	return fileID
+}
+
 // ValidateDurableContexts checks the durable-handle context combination rules
 // from MS-SMB2 §3.3.5.9.6/7/11/12 (mirrors Samba `source3/smbd/smb2_create.c`
 // `smbd_smb2_create_send` ~lines 775-846). Returns a non-success status when
@@ -445,10 +458,7 @@ func processV1Reconnect(
 	// V2 (DH2C) path which already compares persistent-half only — zero the
 	// volatile half here before delegating to the store. smbtorture
 	// smb2.durable-open.reopen2 step 1 (and every other DHnC reopen test).
-	fileID := wireFileID
-	for i := 8; i < 16; i++ {
-		fileID[i] = 0
-	}
+	fileID := zeroVolatileHalf(wireFileID)
 
 	logger.Debug("processV1Reconnect: starting validation",
 		"fileID", fmt.Sprintf("%x", fileID),
@@ -545,17 +555,58 @@ func processV2Reconnect(
 		"shareName", shareName,
 		"filename", filename)
 
+	// A V1 durable handle (opened via durable_open=true, never DH2Q) carries
+	// CreateGuid=0. smbtorture reopen2-lease{,-v2} reconnect such a handle via
+	// the DH2C *context* with a zero CreateGuid (smb2_create sets
+	// io.in.durable_handle_v2 = h while h is a V1 handle), so the open is keyed
+	// only by FileID. Mirror Samba `smbd_smb2_create_durable_v2_reconnect`,
+	// which looks the open up by its persistent FileId and treats CreateGuid as
+	// a secondary check: when the DH2C CreateGuid is zero, look up (and later
+	// consume) by FileID rather than by the unusable zero CreateGuid — a
+	// CreateGuid-keyed lookup would miss every legitimate V1-via-DH2C reconnect
+	// and wrongly return OBJECT_NAME_NOT_FOUND (durable_open.c:1068 / :1305).
+	zeroCreateGuid := createGuid == ([16]byte{})
+
+	// The store keys V1 handles by the volatile-zeroed persistent FileID
+	// (buildPersistedDurableHandle stores only bytes 0-7); smbtorture replays
+	// the full original FileID. Zero the volatile half before the FileID lookup
+	// so it matches, mirroring processV1Reconnect.
+	lookupFileID := zeroVolatileHalf(fileID)
+
 	// Non-destructive lookup: see processV1Reconnect comment. The
 	// TOCTOU-closing Consume runs on the success path inside
 	// validateAndRestore.
-	handle, err := durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
+	var handle *lock.PersistedDurableHandle
+	if zeroCreateGuid {
+		handle, err = durableStore.GetDurableHandleByFileID(ctx, lookupFileID)
+	} else {
+		handle, err = durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
+	}
 	if err != nil {
 		logger.Warn("processV2Reconnect: store error", "error", err)
 		return nil, 0, [16]byte{}, types.StatusInternalError, err
 	}
 	if handle == nil {
-		logger.Debug("processV2Reconnect: handle not found by CreateGuid",
-			"createGuid", fmt.Sprintf("%x", createGuid))
+		logger.Debug("processV2Reconnect: handle not found",
+			"createGuid", fmt.Sprintf("%x", createGuid),
+			"fileID", fmt.Sprintf("%x", fileID),
+			"byFileID", zeroCreateGuid)
+		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+	}
+
+	// The zero-CreateGuid FileID fallback is ONLY for reconnecting a V1 handle
+	// (stored CreateGuid == 0) via the DH2C context. A V2 handle (stored
+	// CreateGuid != 0) requires the reconnect to carry that exact CreateGuid;
+	// Samba `smbd_smb2_create_durable_v2_reconnect` rejects a CreateGuid
+	// mismatch with OBJECT_NAME_NOT_FOUND. smbtorture smb2.durable-v2-open.reopen2
+	// /reopen2b reconnect a V2 (durable_open_v2) handle via durable_handle_v2
+	// with a zeroed (or non-matching) create_guid and expect failure
+	// (durable_v2_open.c:1070-1090 / reopen2b:1157). Without this guard the
+	// FileID match would wrongly succeed.
+	if zeroCreateGuid && handle.CreateGuid != ([16]byte{}) {
+		logger.Debug("processV2Reconnect: zero CreateGuid cannot reconnect a V2 handle",
+			"handleCreateGuid", fmt.Sprintf("%x", handle.CreateGuid),
+			"fileID", fmt.Sprintf("%x", fileID))
 		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
@@ -592,11 +643,16 @@ func processV2Reconnect(
 	// open, junk fname on reconnect) MUST succeed. The path check stays on only for
 	// lease-backed reconnects, where a wrong-fname-with-lease reconnect is the final
 	// negative-ladder rung that yields INVALID_PARAMETER.
+	consume := func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
+		if zeroCreateGuid {
+			// V1-via-DH2C reconnect: consume by FileID (the CreateGuid is
+			// zero and unusable as a key — see the lookup branch above).
+			return durableStore.ConsumeDurableHandleByFileID(ctx, lookupFileID)
+		}
+		return durableStore.ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+	}
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, persistedHasLease,
-		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
-			return durableStore.ConsumeDurableHandleByCreateGuid(ctx, createGuid)
-		})
+		sessionKeyHash, shareName, filename, persistedHasLease, consume)
 	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
 }
 
@@ -834,6 +890,39 @@ func ProcessAppInstanceId(
 	// Handler.files) — NOT persisted into the durable store, since the new
 	// AppInstanceId open is claiming this handle.
 	if handler != nil {
+		// Snapshot the lease/oplock identity of each displaced open BEFORE the
+		// force-close so we can release its LeaseManager record afterwards.
+		// closeFilesWithFilter removes the open from Handler.files but does NOT
+		// release the per-open lease/oplock (that is the session-wide
+		// releaseSessionLeasesAndNotifies path, which the AppInstanceId failover
+		// does not run). Without this release, the synthetic batch-oplock record
+		// of the displaced open lingers in the LeaseManager, and the *new* open
+		// (which immediately follows in the CREATE path) parks on a break of that
+		// orphaned oplock until the oplock timeout — and the AppInstanceId
+		// failover must be silent anyway (MS-SMB2 §3.3.5.9.13; smbtorture
+		// smb2.durable-v2-open.app-instance asserts break_info.count == 0).
+		type displacedLease struct {
+			fileHandle lock.FileHandle
+			leaseKey   [16]byte
+			shareName  string
+			isLease    bool
+		}
+		var displaced []displacedLease
+		if handler.LeaseManager != nil {
+			handler.files.Range(func(_, value any) bool {
+				f := value.(*OpenFile)
+				if f.AppInstanceId == appId && f.LeaseKey != ([16]byte{}) && len(f.MetadataHandle) > 0 {
+					displaced = append(displaced, displacedLease{
+						fileHandle: lock.FileHandle(f.MetadataHandle),
+						leaseKey:   f.LeaseKey,
+						shareName:  f.ShareName,
+						isLease:    f.OplockLevel == OplockLevelLease,
+					})
+				}
+				return true
+			})
+		}
+
 		liveClosed := handler.closeFilesWithFilter(
 			ctx,
 			0, // no specific sessionID — match across sessions
@@ -845,6 +934,20 @@ func ProcessAppInstanceId(
 			logger.Debug("ProcessAppInstanceId: force-closed live opens",
 				"appInstanceId", fmt.Sprintf("%x", appId),
 				"count", liveClosed)
+		}
+
+		// Release the displaced opens' LeaseManager records (mirrors the
+		// explicit CLOSE path in close.go) so no orphaned oplock/lease lingers
+		// to break the claiming open.
+		for _, d := range displaced {
+			if err := handler.LeaseManager.ReleaseLeaseForHandle(ctx, d.fileHandle, d.leaseKey, d.shareName); err != nil {
+				logger.Debug("ProcessAppInstanceId: failed to release displaced lease",
+					"leaseKey", fmt.Sprintf("%x", d.leaseKey), "error", err)
+			}
+			if !d.isLease {
+				handler.LeaseManager.UnregisterOplockFileID(d.leaseKey)
+			}
+			handler.LeaseManager.SignalParkedCreates(d.fileHandle, d.shareName)
 		}
 	}
 

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -2115,6 +2115,115 @@ func TestReopen2_V2_LeaseV2_JunkAccess(t *testing.T) {
 	assertReopen2OK(t, res, status, err, 0x120089)
 }
 
+// Mode 7: smb2.durable-open.reopen2-lease{,-v2} SECOND CYCLE — a V1
+// (durable_open=true, CreateGuid=0) lease handle reconnected via the *DH2C*
+// context with a ZERO CreateGuid. smbtorture's smb2_create sets
+// io.in.durable_handle_v2 = h while h is a V1 handle, so the wire carries a
+// DH2C blob whose CreateGuid is zero and whose FileID is the original handle.
+// processV2Reconnect must fall back to a FileID-keyed lookup (the zero
+// CreateGuid is unusable) — mirroring Samba's persistent-FileId-keyed
+// smbd_smb2_create_durable_v2_reconnect. Pre-fix failure:
+// OBJECT_NAME_NOT_FOUND (durable_open.c:1068 / reopen2-lease-v2:1305).
+// Expected: OK with the original granted access restored.
+func TestReopen2_V1ViaDH2C_ZeroCreateGuid(t *testing.T) {
+	store := newMockDurableStore()
+	freshKey := makeSessionKeyHash("fresh-session-B")
+	// Full original FileID (persistent + volatile) as the client replays it.
+	fileID := [16]byte{7, 8, 9, 10, 11, 12, 13, 14, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22}
+	leaseKey := [16]byte{0x5A, 0x6B, 0x7C, 0x8D}
+
+	// V1 handle: CreateGuid is zero, lease-backed. persistReopen2Handle stores
+	// the volatile-zeroed FileID, matching buildPersistedDurableHandle.
+	persistedFileID := fileID
+	for i := 8; i < 16; i++ {
+		persistedFileID[i] = 0
+	}
+	persistReopen2Handle(t, store, "dh-r2-v1-via-dh2c", persistedFileID, [16]byte{}, leaseKey,
+		OplockLevelLease, 0x12019F, 0x07, 0x12019F)
+
+	// DH2C blob: full original FileID, ZERO CreateGuid.
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[0:16], fileID[:])
+	// bytes 16:32 (CreateGuid) stay zero
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+		{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, 0)},
+	}
+
+	res, status, err := ProcessDurableReconnectContext(
+		context.Background(), store, nil, contexts,
+		freshSessionID, "alice", freshKey, "/share1", "reopen2.dat", [16]byte{})
+	assertReopen2OK(t, res, status, err, 0x12019F)
+	if !res.IsV2 {
+		t.Errorf("IsV2 = false, want true (reconnect arrived via DH2C context)")
+	}
+
+	// The handle must have been consumed by FileID — a second reconnect fails.
+	res2, status2, _ := ProcessDurableReconnectContext(
+		context.Background(), store, nil, contexts,
+		freshSessionID, "alice", freshKey, "/share1", "reopen2.dat", [16]byte{})
+	if status2 != types.StatusObjectNameNotFound || res2 != nil {
+		t.Errorf("second reconnect status = %s (res=%v), want OBJECT_NAME_NOT_FOUND (handle consumed)",
+			status2, res2)
+	}
+}
+
+// TestReopen2_V2ZeroCreateGuid_WrongFileID confirms the zero-CreateGuid FileID
+// fallback still rejects a reconnect whose replayed FileID does not match any
+// persisted handle (so the fallback cannot resurrect an unrelated open).
+func TestReopen2_V2ZeroCreateGuid_WrongFileID(t *testing.T) {
+	store := newMockDurableStore()
+	freshKey := makeSessionKeyHash("fresh-session-B")
+	fileID := [16]byte{8, 9, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0}
+	leaseKey := [16]byte{0x6A, 0x7B, 0x8C, 0x9D}
+	persistReopen2Handle(t, store, "dh-r2-wrongfid", fileID, [16]byte{}, leaseKey,
+		OplockLevelLease, 0x12019F, 0x07, 0x12019F)
+
+	wrongFileID := [16]byte{0xDE, 0xAD, 0xBE, 0xEF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[0:16], wrongFileID[:])
+	contexts := []CreateContext{
+		{Name: DurableHandleV2ReconnectTag, Data: dh2cData},
+		{Name: LeaseContextTagRequest, Data: encodeV1LeaseRequestContext(leaseKey, 0)},
+	}
+
+	res, status, _ := ProcessDurableReconnectContext(
+		context.Background(), store, nil, contexts,
+		freshSessionID, "alice", freshKey, "/share1", "reopen2.dat", [16]byte{})
+	if status != types.StatusObjectNameNotFound || res != nil {
+		t.Errorf("status = %s (res=%v), want OBJECT_NAME_NOT_FOUND for unmatched FileID", status, res)
+	}
+}
+
+// TestReopen2_V2ZeroCreateGuid_RejectsV2Handle guards the reopen2/reopen2b
+// negative ladder: a DH2C reconnect with a ZERO CreateGuid against a V2 handle
+// (stored CreateGuid != 0) MUST fail OBJECT_NAME_NOT_FOUND. The zero-CreateGuid
+// FileID fallback is only for V1 handles; matching a V2 handle by FileID alone
+// would wrongly resurrect it (durable_v2_open.c:1070-1090 / reopen2b:1157).
+func TestReopen2_V2ZeroCreateGuid_RejectsV2Handle(t *testing.T) {
+	store := newMockDurableStore()
+	freshKey := makeSessionKeyHash("fresh-session-B")
+	fileID := [16]byte{9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0}
+	createGuid := [16]byte{0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA}
+
+	// V2 handle: stored CreateGuid is non-zero, batch-oplock (no lease).
+	persistReopen2Handle(t, store, "dh-r2-v2-zeroguid", fileID, createGuid, [16]byte{},
+		OplockLevelBatch, 0x120089, 0x01, 0x120089)
+
+	// DH2C blob with the correct FileID but a ZERO CreateGuid.
+	dh2cData := make([]byte, 36)
+	copy(dh2cData[0:16], fileID[:])
+	contexts := []CreateContext{{Name: DurableHandleV2ReconnectTag, Data: dh2cData}}
+
+	res, status, _ := ProcessDurableReconnectContext(
+		context.Background(), store, nil, contexts,
+		freshSessionID, "alice", freshKey, "/share1", junkFname, [16]byte{})
+	if status != types.StatusObjectNameNotFound || res != nil {
+		t.Errorf("status = %s (res=%v), want OBJECT_NAME_NOT_FOUND (zero CreateGuid cannot reconnect a V2 handle)",
+			status, res)
+	}
+}
+
 // TestReopen2_NegativeLadder_Preserved guards the negative reconnect rungs the
 // reopen2-lease tests also exercise, so the access-gate removal does not relax
 // them: wrong lease key -> ONF, wrong-fname-WITH-lease -> INVALID_PARAMETER,

--- a/internal/adapter/smb/v2/handlers/reopen2_e2e_test.go
+++ b/internal/adapter/smb/v2/handlers/reopen2_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -893,4 +894,257 @@ func TestReopen2_V2LeaseV2_JunkAccess_E2E(t *testing.T) {
 		func(fid, cg, lk [16]byte) []CreateContext {
 			return []CreateContext{dh2cContext(fid, cg), rwhLeaseCtx(lk)}
 		})
+}
+
+// takeExclusiveLock records an exclusive byte-range lock on the open's backing
+// file under the open's OpenID, exactly as the LOCK handler does. Used to model
+// the held byte-range lock in smb2.durable-v2-open.lock-{oplock,lease}.
+func (e *reopen2Env) takeExclusiveLock(t *testing.T, of *OpenFile, sessionID uint64, offset, length uint64) {
+	t.Helper()
+	metaSvc := e.h.Registry.GetMetadataService()
+	fl := metadata.FileLock{
+		SessionID:  sessionID,
+		OpenID:     of.OpenID(),
+		ClientID:   "smb:lock-test",
+		Offset:     offset,
+		Length:     length,
+		Exclusive:  true,
+		AcquiredAt: time.Now(),
+	}
+	if err := metaSvc.LockFile(rootAuthCtx(), of.MetadataHandle, fl); err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+	of.HasByteRangeLocks.Store(true)
+}
+
+// lockHeldUnderOpenID reports whether a byte-range lock exists on the file under
+// the given OpenID — i.e. the lock survived disconnect and the reconnect restored
+// the same OpenID (so a subsequent UNLOCK can find it).
+func (e *reopen2Env) lockHeldUnderOpenID(metaHandle []byte, openID string) bool {
+	lm, err := e.h.Registry.GetMetadataService().GetLockManagerForHandle(metaHandle)
+	if err != nil || lm == nil {
+		return false
+	}
+	for _, fl := range lm.ListLocks(string(metaHandle)) {
+		if fl.OpenID == openID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReopen2_LockLease_RestoresLeaseAndKeepsLock covers
+// smb2.durable-v2-open.lock-lease: open(RWH lease, durable-v2), take an
+// exclusive byte-range lock, disconnect, reconnect. The reconnect MUST restore
+// the lease at RWH (the lease re-grant must NOT be suppressed by the still-held
+// byte-range lock) AND the lock must survive under the restored OpenID so the
+// client's subsequent UNLOCK succeeds.
+func TestReopen2_LockLease_RestoresLeaseAndKeepsLock(t *testing.T) {
+	e := setupReopen2Env(t)
+
+	leaseKey := [16]byte{0x4C, 0x4B, 0x4C, 0x4C} // "LKLL"
+	createGuid := [16]byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF}
+
+	const sessionID = uint64(50)
+	_, of := e.initialLeaseDurableOpen(t, sessionID, leaseKey, []CreateContext{dh2qContext(createGuid, 60000)})
+	persistedFileID := of.FileID
+	origOpenID := of.OpenID()
+
+	// Hold an exclusive BRL [0,1), as the test does before disconnect.
+	e.takeExclusiveLock(t, of, sessionID, 0, 1)
+	if !e.lockHeldUnderOpenID(of.MetadataHandle, origOpenID) {
+		t.Fatal("setup: lock not recorded under original OpenID")
+	}
+
+	e.disconnect(sessionID)
+
+	const sessionID2 = uint64(51)
+	e.h.CreateSessionWithID(sessionID2, "127.0.0.1:2", false, "alice", "WORKGROUP")
+	rcCtx := e.makeSMBCtx(sessionID2)
+	rcResp, err := e.h.Create(rcCtx, &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		OplockLevel:       OplockLevelLease,
+		CreateContexts: []CreateContext{
+			dh2cContext(persistedFileID, createGuid),
+			rwhLeaseCtx(leaseKey),
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconnect Create error: %v", err)
+	}
+	assertLeaseReconnect(t, rcResp, leaseKey, true)
+
+	// The lock must still be present under the restored OpenID (FileID), or the
+	// client's UNLOCK on the reconnected handle would fail RANGE_NOT_LOCKED.
+	rof, ok := e.h.GetOpenFile(rcResp.FileID)
+	if !ok {
+		t.Fatal("reconnect: OpenFile not registered")
+	}
+	if !e.lockHeldUnderOpenID(rof.MetadataHandle, rof.OpenID()) {
+		t.Errorf("reconnect: byte-range lock lost (OpenID %s) — UNLOCK would fail", rof.OpenID())
+	}
+}
+
+// TestReopen2_LockOplock_RestoresBatchAndKeepsLock covers
+// smb2.durable-v2-open.lock-oplock: open(BATCH oplock, durable-v2), take an
+// exclusive byte-range lock, disconnect, reconnect. The reconnect MUST restore
+// OplockLevel=Batch (not None) and keep the byte-range lock under the restored
+// OpenID.
+func TestReopen2_LockOplock_RestoresBatchAndKeepsLock(t *testing.T) {
+	e := setupReopen2Env(t)
+
+	createGuid := [16]byte{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF}
+
+	metaSvc := e.h.Registry.GetMetadataService()
+	rootHandle, _ := e.h.Registry.GetRootHandle(e.tree.ShareName)
+	file, _, _ := e.h.lookupCaseInsensitive(rootAuthCtx(), metaSvc, rootHandle, "durable.txt")
+	existingHandle, _ := metadata.EncodeFileHandle(file)
+
+	const sessionID = uint64(60)
+	e.h.CreateSessionWithID(sessionID, "127.0.0.1:1", false, "alice", "WORKGROUP")
+	smbCtx := e.makeSMBCtx(sessionID)
+
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "durable.txt",
+			DesiredAccess:     0x001F01FF,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpen,
+			OplockLevel:       OplockLevelBatch,
+			CreateContexts:    []CreateContext{dh2qContext(createGuid, 60000)},
+		},
+		tree:           e.tree,
+		authCtx:        rootAuthCtx(),
+		filename:       "durable.txt",
+		baseName:       "durable.txt",
+		parentHandle:   rootHandle,
+		existingFile:   file,
+		existingHandle: existingHandle,
+		fileExists:     true,
+		createAction:   types.FileOpened,
+	}
+	resp := e.h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("initial open: status=0x%08x", uint32(resp.Status))
+	}
+	of, ok := e.h.GetOpenFile(resp.FileID)
+	if !ok {
+		t.Fatal("initial open: OpenFile not registered")
+	}
+	if of.OplockLevel != OplockLevelBatch {
+		t.Fatalf("initial open: OplockLevel = 0x%02x, want Batch", of.OplockLevel)
+	}
+	persistedFileID := of.FileID
+	origOpenID := of.OpenID()
+
+	e.takeExclusiveLock(t, of, sessionID, 0, 1)
+
+	e.disconnect(sessionID)
+
+	const sessionID2 = uint64(61)
+	e.h.CreateSessionWithID(sessionID2, "127.0.0.1:2", false, "alice", "WORKGROUP")
+	rcCtx := e.makeSMBCtx(sessionID2)
+	rcResp, err := e.h.Create(rcCtx, &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		CreateContexts:    []CreateContext{dh2cContext(persistedFileID, createGuid)},
+	})
+	if err != nil {
+		t.Fatalf("reconnect Create error: %v", err)
+	}
+	if rcResp.Status != types.StatusSuccess {
+		t.Fatalf("reconnect: status=0x%08x, want SUCCESS", uint32(rcResp.Status))
+	}
+	if rcResp.OplockLevel != OplockLevelBatch {
+		t.Errorf("reconnect OplockLevel = 0x%02x, want Batch (0x%02x)", rcResp.OplockLevel, OplockLevelBatch)
+	}
+	rof, ok := e.h.GetOpenFile(rcResp.FileID)
+	if !ok {
+		t.Fatal("reconnect: OpenFile not registered")
+	}
+	if rof.OpenID() != origOpenID {
+		t.Errorf("reconnect OpenID = %s, want original %s (BRL would be orphaned)", rof.OpenID(), origOpenID)
+	}
+	if !e.lockHeldUnderOpenID(rof.MetadataHandle, rof.OpenID()) {
+		t.Errorf("reconnect: byte-range lock lost (OpenID %s) — UNLOCK would fail", rof.OpenID())
+	}
+}
+
+// recordingBreakNotifier counts SendLeaseBreak calls so a test can assert that
+// an AppInstanceId failover does NOT emit any oplock/lease break.
+type recordingBreakNotifier struct{ count int }
+
+func (n *recordingBreakNotifier) SendLeaseBreak(_ uint64, _ [16]byte, _, _ uint32, _ uint16) error {
+	n.count++
+	return nil
+}
+
+// appInstanceIdCtx builds an SMB2_CREATE_APP_INSTANCE_ID create context.
+func appInstanceIdCtx(appID [16]byte) CreateContext {
+	data := make([]byte, 20)
+	binary.LittleEndian.PutUint16(data[0:2], 20) // StructureSize
+	copy(data[4:20], appID[:])
+	return CreateContext{Name: AppInstanceIdTag, Data: data}
+}
+
+// TestAppInstance_SilentFailover covers smb2.durable-v2-open.app-instance: a
+// second open of the same file carrying the same AppInstanceId (but a different
+// CreateGuid) while the first open is still live MUST force-close the first open
+// WITHOUT emitting an oplock break (break_info.count == 0), and the displaced
+// handle must no longer be registered. The AppInstanceId force-close runs before
+// the oplock-break dispatch in the CREATE path; if it ran after, the second
+// batch-oplock open would break the first's batch oplock first (count == 1).
+func TestAppInstance_SilentFailover(t *testing.T) {
+	e := setupReopen2Env(t)
+	notifier := &recordingBreakNotifier{}
+	e.h.LeaseManager.SetNotifier(notifier)
+
+	appID := [16]byte{0xA9, 0x91, 0x01, 0xFF, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0, 0xB0, 0xC0}
+	createGuid1 := [16]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x10}
+	createGuid2 := [16]byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x20}
+
+	open := func(sessionID uint64, createGuid [16]byte) *CreateResponse {
+		e.h.CreateSessionWithID(sessionID, "127.0.0.1:1", false, "alice", "WORKGROUP")
+		rcCtx := e.makeSMBCtx(sessionID)
+		resp, err := e.h.Create(rcCtx, &CreateRequest{
+			FileName:          "durable.txt",
+			DesiredAccess:     0x001F01FF,
+			ShareAccess:       0, // share_access("") — no sharing
+			CreateDisposition: types.FileOpen,
+			OplockLevel:       OplockLevelBatch,
+			CreateContexts: []CreateContext{
+				dh2qContext(createGuid, 60000),
+				appInstanceIdCtx(appID),
+			},
+		})
+		if err != nil {
+			t.Fatalf("session %d open: %v", sessionID, err)
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("session %d open: status=0x%08x, want SUCCESS", sessionID, uint32(resp.Status))
+		}
+		return resp
+	}
+
+	resp1 := open(70, createGuid1)
+	of1ID := resp1.FileID
+
+	// Second open: same file, same AppInstanceId, different CreateGuid, on a
+	// distinct session — must force-close open #1 silently.
+	resp2 := open(71, createGuid2)
+
+	if notifier.count != 0 {
+		t.Errorf("break_info.count = %d, want 0 (AppInstanceId failover must be silent)", notifier.count)
+	}
+	if _, ok := e.h.GetOpenFile(of1ID); ok {
+		t.Error("first open still registered after same-AppInstanceId failover (should be force-closed)")
+	}
+	if resp2.OplockLevel != OplockLevelBatch {
+		t.Errorf("second open OplockLevel = 0x%02x, want Batch (no conflicting open remains)", resp2.OplockLevel)
+	}
 }


### PR DESCRIPTION
Targets the residual smbtorture durable-handle failures in #738 (V1) and #739 (V2). Each fix has a verified root cause against Samba source3/smbd/smb2_create.c plus regression tests (unit + e2e through the real CREATE handler with a fresh-session disconnect/reconnect).

## Fixes

**reopen2-lease / reopen2-lease-v2 (#738 V1, and the #739 V2 variants) — `OBJECT_NAME_NOT_FOUND` at the second-cycle reconnect.**
The reopen2-lease tests' second cycle reconnects a V1 durable handle (`durable_open=true`, CreateGuid=0) via the `durable_handle_v2` field, so the wire carries a DH2C blob with a **zero CreateGuid**. `processV2Reconnect` keyed the lookup solely on CreateGuid, missing the V1-persisted handle. It now falls back to a **FileID-keyed lookup/consume when the CreateGuid is zero** — mirroring Samba's persistent-FileId-keyed `smbd_smb2_create_durable_v2_reconnect`. A guard preserves the reopen2/reopen2b negative ladder: a zero CreateGuid still **rejects a V2 handle** (stored CreateGuid != 0) with OBJECT_NAME_NOT_FOUND.

**app-instance (#739) — silent failover.**
`ProcessAppInstanceId` ran after the oplock-break dispatch. Moved the failover force-close ahead of the break dispatch and added release of the displaced open's LeaseManager record, so the failover does not break the displaced open or park the claiming open on an orphaned oplock. (Local e2e proves break-count 0 and no stall; the smbtorture cross-connection break-routing residual is noted below for follow-up.)

## Verified flips (PR-CI smbtorture log, prior iteration)
`durable-open.reopen2-lease`, `durable-open.reopen2-lease-v2`, `durable-v2-open.reopen2-lease`, `durable-v2-open.reopen2-lease-v2` all showed `success:`.

## Reverted (caused regressions, removed)
An earlier lease Write-caching cap (RWH→RH on a conflicting non-stat open) flipped `nonstat-and-lease` but regressed 13 lease tests (reopen2/reopen2b, lease.upgrade/break/multibreak/complex1/v2_epoch*, replay-dhv2-lease*). It was too broad vs Samba's exact `delay_for_oplock` gate and has been removed. The V2-handle guard above fixes the reopen2/reopen2b regression at its root.

## Tests
- `durable_context_test.go`: V1-via-DH2C zero-CreateGuid reconnect (success + consume-by-FileID); wrong-FileID rejection; **zero-CreateGuid rejects a V2 handle** (reopen2/reopen2b negative ladder).
- `reopen2_e2e_test.go`: lock-held reconnect keeps oplock/lease + BRL; app-instance silent failover (break count 0, no stall). All drive the real CREATE handler with a fresh SessionID + new session + junk fields.

## Verification
`go build ./...`, `go test -race ./internal/adapter/smb/...`, `go vet`, `golangci-lint` all clean. KNOWN_FAILURES.md intentionally untouched (orchestrator walks back rows after CI log-confirms each flip).

## Still failing / out of scope (left in KNOWN_FAILURES)
- `lock-oplock` / `lock-lease`: in-model e2e repros pass; the residual needs the real async LOCK path or cross-connection accounting — flagged for CI confirmation.
- `keep-disconnected-rh-with-rwh-open`: needs lease W-downgrade against **disconnected durable handles** (a precise gate the reverted broad cap couldn't safely provide).
- `app-instance`: residual `break_info.count=1` is a cross-connection break-routing issue beyond the local force-close path.
- `delete_on_close2`, `persistent-open-*`: unimplementable / separate scope per the brief.