### PR TITLE
fix(nfs/gss): verify RPCSEC_GSS call-header MIC — close krb5 auth bypass (area-4 H1)

### DIFF
--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/types"
 
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
@@ -389,7 +390,11 @@ func NewGSSProcessor(verifier Verifier, mapper nfsidentity.IdentityMapper, maxCo
 //
 // It decodes the credential, determines the GSS procedure type, and routes
 // to the appropriate handler (INIT, DATA, or DESTROY).
-func (p *GSSProcessor) Process(ctx context.Context, credBody []byte, verifBody []byte, requestBody []byte) *GSSProcessResult {
+//
+// headerPreimage is the marshalled RPC call header (XID..end-of-credential)
+// over which the client computed the call verifier MIC for DATA requests
+// (RFC 2203 Section 5.3.3.2). It is unused for INIT/DESTROY control messages.
+func (p *GSSProcessor) Process(ctx context.Context, credBody []byte, verifBody []byte, headerPreimage []byte, requestBody []byte) *GSSProcessResult {
 	// Decode the RPCSEC_GSS credential
 	cred, err := DecodeGSSCred(credBody)
 	if err != nil {
@@ -403,7 +408,7 @@ func (p *GSSProcessor) Process(ctx context.Context, credBody []byte, verifBody [
 	case RPCGSSInit, RPCGSSContinueInit:
 		return p.handleInit(cred, requestBody)
 	case RPCGSSData:
-		return p.handleData(ctx, cred, verifBody, requestBody)
+		return p.handleData(ctx, cred, verifBody, headerPreimage, requestBody)
 	case RPCGSSDestroy:
 		return p.handleDestroy(cred)
 	default:
@@ -565,13 +570,15 @@ func lastN(b []byte, n int) []byte {
 // handleData processes RPCSEC_GSS_DATA calls.
 //
 // DATA handling:
-// 1. Look up the context by handle (RPCSEC_GSS_CREDPROBLEM if not found)
-// 2. Validate the sequence number (silent discard if invalid per RFC 2203 Section 5.3.3.1)
-// 3. Check for MAXSEQ exceeded (context must be destroyed per RFC 2203)
-// 4. Unwrap based on service level (svc_none / svc_integrity / svc_privacy)
-// 5. Map principal to Unix identity via IdentityMapper
-// 6. Return unwrapped procedure arguments and identity
-func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verifBody []byte, requestBody []byte) *GSSProcessResult {
+//  1. Look up the context by handle (RPCSEC_GSS_CREDPROBLEM if not found)
+//  2. Verify the call-header MIC (RPCSEC_GSS_CREDPROBLEM on failure)
+//  3. Enforce the negotiated service level (no downgrade)
+//  4. Check for MAXSEQ exceeded (context must be destroyed per RFC 2203)
+//  5. Validate the sequence number (silent discard if invalid per RFC 2203 Section 5.3.3.1)
+//  6. Unwrap based on service level (svc_none / svc_integrity / svc_privacy)
+//  7. Map principal to Unix identity via IdentityMapper
+//  8. Return unwrapped procedure arguments and identity
+func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verifBody []byte, headerPreimage []byte, requestBody []byte) *GSSProcessResult {
 	// 1. Look up context by handle
 	gssCtx, found := p.contexts.Lookup(cred.Handle)
 	if !found {
@@ -585,13 +592,49 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		}
 	}
 
-	// Log service level comparison for debugging krb5i issues
-	if cred.Service != gssCtx.Service {
-		logger.Warn("GSS DATA: service level mismatch",
+	// 2. Verify the RPCSEC_GSS call-header MIC.
+	//
+	// Per RFC 2203 Section 5.3.3.2 the client signs the marshalled RPC call
+	// header (XID..end-of-credential) with a GSS MIC token using the context
+	// session key. The server MUST verify it before trusting ANY field in the
+	// credential (gss_proc/service/seq_num/handle) or processing the body.
+	//
+	// This is the authentication gate for svc_none (krb5), which performs no
+	// body crypto; without it a stolen 16-byte context handle would let an
+	// attacker forge requests under the victim principal. For svc_integrity /
+	// svc_privacy it additionally authenticates the header, complementing the
+	// body MIC/Wrap. Mirrors Linux sunrpc svcauth_gss_verify_header /
+	// gss_verify_mic. On failure return RPCSEC_GSS_CREDPROBLEM.
+	if err := verifyHeaderMIC(gssCtx.SessionKey, headerPreimage, verifBody); err != nil {
+		logger.Debug("GSS DATA: call-header MIC verification failed",
+			"principal", gssCtx.Principal,
+			"cred_service", cred.Service,
+			"error", err,
+		)
+		return &GSSProcessResult{
+			Err:      fmt.Errorf("RPCSEC_GSS_CREDPROBLEM: call-header MIC verification failed: %w", err),
+			AuthStat: AuthStatCredProblem,
+		}
+	}
+
+	// 3. Enforce the negotiated service level (no downgrade).
+	//
+	// RFC 2203 Section 5.3.3.4 permits per-call service selection, but a
+	// context established at a stronger level (e.g. krb5p privacy) must not
+	// accept a weaker per-call service (e.g. svc_none), which would be a
+	// confidentiality/integrity downgrade. Reject any call requesting a
+	// service weaker than the one negotiated at context establishment.
+	// Service ordering: none(1) < integrity(2) < privacy(3).
+	if cred.Service < gssCtx.Service {
+		logger.Warn("GSS DATA: rejecting service downgrade",
 			"cred_service", cred.Service,
 			"ctx_service", gssCtx.Service,
 			"principal", gssCtx.Principal,
 		)
+		return &GSSProcessResult{
+			Err:      fmt.Errorf("RPCSEC_GSS_CREDPROBLEM: service downgrade from %d to %d not permitted", gssCtx.Service, cred.Service),
+			AuthStat: AuthStatCredProblem,
+		}
 	}
 	logger.Debug("GSS DATA: credential and context info",
 		"cred_service", cred.Service,
@@ -600,7 +643,7 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		"principal", gssCtx.Principal,
 	)
 
-	// 2. Check for MAXSEQ exceeded -- context must be destroyed per RFC 2203
+	// 4. Check for MAXSEQ exceeded -- context must be destroyed per RFC 2203
 	if cred.SeqNum >= MAXSEQ {
 		logger.Debug("GSS DATA: sequence number exceeds MAXSEQ, destroying context",
 			"seq_num", cred.SeqNum,
@@ -613,7 +656,7 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		}
 	}
 
-	// 3. Validate sequence number via sliding window
+	// 5. Validate sequence number via sliding window
 	if !gssCtx.SeqWindow.Accept(cred.SeqNum) {
 		// Per RFC 2203 Section 5.3.3.1: silent discard for sequence violations
 		logger.Debug("GSS DATA: sequence number rejected (duplicate or out of window)",
@@ -625,7 +668,7 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		}
 	}
 
-	// 4. Unwrap based on credential's service level (per-call, per RFC 2203 Section 5.3.3.4).
+	// 6. Unwrap based on credential's service level (per-call, per RFC 2203 Section 5.3.3.4).
 	// The session key from the context is used for cryptographic operations.
 	var processedData []byte
 	switch cred.Service {
@@ -666,7 +709,7 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		}
 	}
 
-	// 5. Map principal to Unix identity via centralized resolver or legacy mapper.
+	// 7. Map principal to Unix identity via centralized resolver or legacy mapper.
 	ident, identErr := p.resolveIdentity(ctx, gssCtx.Principal, gssCtx.Realm)
 	if identErr != nil {
 		return &GSSProcessResult{Err: identErr}
@@ -687,6 +730,49 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 		Service:       cred.Service,
 		SessionKey:    gssCtx.SessionKey,
 	}
+}
+
+// verifyHeaderMIC verifies the RPCSEC_GSS call-header verifier.
+//
+// Per RFC 2203 Section 5.3.3.2, the verifier on a DATA request is a GSS-API
+// MIC token (RFC 4121) the client computed over the marshalled RPC call header
+// (XID..end-of-credential) using the context session key with initiator-sign
+// key usage. The server recomputes the checksum and compares it constant-time
+// (gokrb5 MICToken.Verify uses hmac.Equal). Any mismatch — including a forged
+// gss_proc/service/seq_num/handle — fails verification.
+//
+// A non-RPCSEC_GSS verifier flavor, a missing/empty MIC, or a nil preimage are
+// all rejected: a DATA request MUST carry a header MIC.
+func verifyHeaderMIC(sessionKey types.EncryptionKey, headerPreimage []byte, verifBody []byte) error {
+	if len(headerPreimage) == 0 {
+		return fmt.Errorf("missing RPC header preimage for MIC verification")
+	}
+	if len(verifBody) == 0 {
+		return fmt.Errorf("missing RPCSEC_GSS call verifier")
+	}
+	if len(sessionKey.KeyValue) == 0 {
+		return fmt.Errorf("context has no session key")
+	}
+
+	// Unmarshal the verifier as a MIC token emitted by the initiator (client).
+	var micToken gssapi.MICToken
+	if err := micToken.Unmarshal(verifBody, false /* expectFromAcceptor */); err != nil {
+		return fmt.Errorf("unmarshal call verifier MIC token: %w", err)
+	}
+
+	// The payload is the call header the client signed.
+	micToken.Payload = headerPreimage
+
+	// Verify with initiator-sign key usage (RFC 4121). MICToken.Verify uses a
+	// constant-time HMAC comparison internally.
+	ok, err := micToken.Verify(sessionKey, KeyUsageInitiatorSign)
+	if err != nil {
+		return fmt.Errorf("verify call verifier MIC: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("call verifier MIC mismatch")
+	}
+	return nil
 }
 
 // resolveIdentity maps a Kerberos principal to a Unix identity using the

--- a/internal/adapter/nfs/rpc/gss/framework_test.go
+++ b/internal/adapter/nfs/rpc/gss/framework_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/types"
 	identity "github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -105,6 +106,46 @@ func extractContextHandle(t *testing.T, proc *GSSProcessor) []byte {
 	return handle
 }
 
+// mockVerifierSessionKey is the session key the mock verifier installs into every
+// context it establishes. Tests sign header MICs with this key so the
+// processor's verifyHeaderMIC check passes. aes128-cts-hmac-sha1-96 (etype 17)
+// requires a 16-byte key; "test-session-key" is exactly 16 bytes.
+var mockVerifierSessionKey = types.EncryptionKey{
+	KeyType:  17,
+	KeyValue: []byte("test-session-key"),
+}
+
+// signHeaderMIC produces an RPCSEC_GSS call verifier: a GSS-API MIC token
+// (RFC 4121) computed by the initiator (client) over the given RPC call-header
+// preimage using the context session key with initiator-sign key usage. This
+// is what verifyHeaderMIC expects on every DATA request.
+func signHeaderMIC(t *testing.T, sessionKey types.EncryptionKey, preimage []byte) []byte {
+	t.Helper()
+	tok := gssapi.MICToken{
+		Flags:     0x00, // sent by initiator (acceptor flag clear)
+		SndSeqNum: 0,
+		Payload:   preimage,
+	}
+	if err := tok.SetChecksum(sessionKey, KeyUsageInitiatorSign); err != nil {
+		t.Fatalf("sign header MIC: %v", err)
+	}
+	mic, err := tok.Marshal()
+	if err != nil {
+		t.Fatalf("marshal header MIC: %v", err)
+	}
+	return mic
+}
+
+// processDATA establishes a valid header MIC over credBody (used as the
+// header preimage for test purposes) and runs a DATA request through the
+// processor. Using credBody as the preimage is sufficient for unit tests:
+// verifyHeaderMIC only requires the MIC to match whatever preimage is supplied.
+func processDATA(t *testing.T, proc *GSSProcessor, sessionKey types.EncryptionKey, credBody, requestBody []byte) *GSSProcessResult {
+	t.Helper()
+	mic := signHeaderMIC(t, sessionKey, credBody)
+	return proc.Process(context.Background(), credBody, mic, credBody, requestBody)
+}
+
 // encodeOpaqueToken wraps raw bytes as XDR opaque data (length-prefixed with padding).
 func encodeOpaqueToken(data []byte) []byte {
 	length := uint32(len(data))
@@ -128,7 +169,7 @@ func TestProcessINITReturnsControl(t *testing.T) {
 	credBody := buildINITCredBody(t)
 	gssToken := encodeOpaqueToken([]byte("mock-ap-req-token"))
 
-	result := proc.Process(context.Background(), credBody, nil, gssToken)
+	result := proc.Process(context.Background(), credBody, nil, nil, gssToken)
 
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -150,7 +191,7 @@ func TestProcessINITStoresContextBeforeReply(t *testing.T) {
 	credBody := buildINITCredBody(t)
 	gssToken := encodeOpaqueToken([]byte("mock-ap-req-token"))
 
-	result := proc.Process(context.Background(), credBody, nil, gssToken)
+	result := proc.Process(context.Background(), credBody, nil, nil, gssToken)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
 	}
@@ -171,7 +212,7 @@ func TestProcessINITCreatesContextWithCorrectFields(t *testing.T) {
 	credBody := buildINITCredBody(t)
 	gssToken := encodeOpaqueToken([]byte("mock-ap-req-token"))
 
-	result := proc.Process(context.Background(), credBody, nil, gssToken)
+	result := proc.Process(context.Background(), credBody, nil, nil, gssToken)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
 	}
@@ -216,7 +257,7 @@ func TestProcessINITVerificationFailure(t *testing.T) {
 	credBody := buildINITCredBody(t)
 	gssToken := encodeOpaqueToken([]byte("bad-token"))
 
-	result := proc.Process(context.Background(), credBody, nil, gssToken)
+	result := proc.Process(context.Background(), credBody, nil, nil, gssToken)
 
 	// Should have an error
 	if result.Err == nil {
@@ -247,7 +288,7 @@ func TestProcessDESTROYRemovesContext(t *testing.T) {
 
 	// First, establish a context via INIT
 	credBody := buildINITCredBody(t)
-	initResult := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
+	initResult := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -261,7 +302,7 @@ func TestProcessDESTROYRemovesContext(t *testing.T) {
 
 	// Send DESTROY
 	destroyCredBody := buildDESTROYCredBody(t, handle, 1)
-	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil)
+	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil, nil)
 
 	if destroyResult.Err != nil {
 		t.Fatalf("DESTROY failed: %v", destroyResult.Err)
@@ -287,7 +328,7 @@ func TestProcessDESTROYUnknownContext(t *testing.T) {
 
 	// DESTROY a context that doesn't exist -- should still succeed per RFC
 	destroyCredBody := buildDESTROYCredBody(t, []byte("nonexistent-handle"), 1)
-	result := proc.Process(context.Background(), destroyCredBody, nil, nil)
+	result := proc.Process(context.Background(), destroyCredBody, nil, nil, nil)
 
 	if result.Err != nil {
 		t.Fatalf("DESTROY of unknown context should succeed, got error: %v", result.Err)
@@ -303,9 +344,19 @@ func TestProcessDATAWithValidContext(t *testing.T) {
 	proc := NewGSSProcessor(verifier, mapper, 100, 10*time.Minute)
 	defer proc.Stop()
 
-	// Establish a context via INIT
-	credBody := buildINITCredBody(t)
-	initResult := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
+	// Establish a context via INIT at svc_none so a svc_none DATA call below
+	// is not treated as a service downgrade.
+	initCred := &RPCGSSCredV1{
+		GSSProc: RPCGSSInit,
+		SeqNum:  0,
+		Service: RPCGSSSvcNone,
+		Handle:  nil,
+	}
+	credBody, err := EncodeGSSCred(initCred)
+	if err != nil {
+		t.Fatalf("encode INIT cred: %v", err)
+	}
+	initResult := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -325,7 +376,7 @@ func TestProcessDATAWithValidContext(t *testing.T) {
 	}
 
 	procedureArgs := []byte("test-procedure-arguments")
-	result := proc.Process(context.Background(), dataCredBody, nil, procedureArgs)
+	result := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, procedureArgs)
 
 	if result.Err != nil {
 		t.Fatalf("DATA failed: %v", result.Err)
@@ -353,6 +404,184 @@ func TestProcessDATAWithValidContext(t *testing.T) {
 	}
 }
 
+// establishContext runs an INIT at the given service level and returns the
+// resulting context handle. Used by the call-header MIC security tests.
+func establishContext(t *testing.T, proc *GSSProcessor, service uint32) []byte {
+	t.Helper()
+	initCred := &RPCGSSCredV1{
+		GSSProc: RPCGSSInit,
+		SeqNum:  0,
+		Service: service,
+		Handle:  nil,
+	}
+	initCredBody, err := EncodeGSSCred(initCred)
+	if err != nil {
+		t.Fatalf("encode INIT cred: %v", err)
+	}
+	res := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
+	if res.Err != nil {
+		t.Fatalf("INIT failed: %v", res.Err)
+	}
+	return extractContextHandle(t, proc)
+}
+
+// TestProcessDATAForgedHeaderRejected is the core H1 regression: an attacker
+// who learns a valid context handle but cannot produce a correct call-header
+// MIC must be rejected with CREDPROBLEM. This covers svc_none (krb5), where no
+// body crypto exists and the header MIC is the ONLY authentication gate.
+func TestProcessDATAForgedHeaderRejected(t *testing.T) {
+	verifier := newMockVerifier("alice", "EXAMPLE.COM")
+	proc := NewGSSProcessor(verifier, newTestMapper(), 100, 10*time.Minute)
+	defer proc.Stop()
+
+	handle := establishContext(t, proc, RPCGSSSvcNone)
+
+	dataCred := &RPCGSSCredV1{
+		GSSProc: RPCGSSData,
+		SeqNum:  1,
+		Service: RPCGSSSvcNone,
+		Handle:  handle,
+	}
+	dataCredBody, err := EncodeGSSCred(dataCred)
+	if err != nil {
+		t.Fatalf("encode DATA cred: %v", err)
+	}
+
+	t.Run("no verifier", func(t *testing.T) {
+		// Stolen handle, no MIC at all: the old code accepted this for svc_none.
+		res := proc.Process(context.Background(), dataCredBody, nil, dataCredBody, []byte("forged-args"))
+		if res.Err == nil {
+			t.Fatal("expected rejection for missing call-header MIC")
+		}
+		if res.AuthStat != AuthStatCredProblem {
+			t.Fatalf("expected AuthStatCredProblem (%d), got %d", AuthStatCredProblem, res.AuthStat)
+		}
+		if res.ProcessedData != nil || res.Identity != nil {
+			t.Fatal("rejected DATA must not yield processed data or identity")
+		}
+	})
+
+	t.Run("MIC over different header", func(t *testing.T) {
+		// Attacker forges the header (e.g. a different seq_num / handle) but can
+		// only sign a DIFFERENT preimage — the MIC will not match the real header.
+		mic := signHeaderMIC(t, mockVerifierSessionKey, []byte("attacker-chosen-preimage"))
+		res := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, []byte("forged-args"))
+		if res.Err == nil {
+			t.Fatal("expected rejection for MIC over a different header preimage")
+		}
+		if res.AuthStat != AuthStatCredProblem {
+			t.Fatalf("expected AuthStatCredProblem (%d), got %d", AuthStatCredProblem, res.AuthStat)
+		}
+	})
+
+	t.Run("MIC under wrong key", func(t *testing.T) {
+		// Attacker signs the correct preimage but with a key they do not hold.
+		wrongKey := types.EncryptionKey{KeyType: 17, KeyValue: []byte("WRONG-session-ky")}
+		mic := signHeaderMIC(t, wrongKey, dataCredBody)
+		res := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, []byte("forged-args"))
+		if res.Err == nil {
+			t.Fatal("expected rejection for MIC computed under the wrong key")
+		}
+		if res.AuthStat != AuthStatCredProblem {
+			t.Fatalf("expected AuthStatCredProblem (%d), got %d", AuthStatCredProblem, res.AuthStat)
+		}
+	})
+
+	t.Run("missing preimage", func(t *testing.T) {
+		// A malformed RPC header yields a nil preimage; DATA must be rejected.
+		mic := signHeaderMIC(t, mockVerifierSessionKey, dataCredBody)
+		res := proc.Process(context.Background(), dataCredBody, mic, nil, []byte("forged-args"))
+		if res.Err == nil {
+			t.Fatal("expected rejection when header preimage is missing")
+		}
+		if res.AuthStat != AuthStatCredProblem {
+			t.Fatalf("expected AuthStatCredProblem (%d), got %d", AuthStatCredProblem, res.AuthStat)
+		}
+	})
+}
+
+// TestProcessDATAGenuineMICAccepted confirms a correctly-signed header MIC
+// passes for svc_none (the previously-unauthenticated path).
+func TestProcessDATAGenuineMICAccepted(t *testing.T) {
+	verifier := newMockVerifier("alice", "EXAMPLE.COM")
+	proc := NewGSSProcessor(verifier, newTestMapper(), 100, 10*time.Minute)
+	defer proc.Stop()
+
+	handle := establishContext(t, proc, RPCGSSSvcNone)
+	dataCred := &RPCGSSCredV1{
+		GSSProc: RPCGSSData,
+		SeqNum:  1,
+		Service: RPCGSSSvcNone,
+		Handle:  handle,
+	}
+	dataCredBody, err := EncodeGSSCred(dataCred)
+	if err != nil {
+		t.Fatalf("encode DATA cred: %v", err)
+	}
+
+	res := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("genuine-args"))
+	if res.Err != nil {
+		t.Fatalf("genuine MIC should pass: %v", res.Err)
+	}
+	if string(res.ProcessedData) != "genuine-args" {
+		t.Fatalf("unexpected processed data: %q", res.ProcessedData)
+	}
+	if res.Identity == nil || res.Identity.UID == nil || *res.Identity.UID != 1000 {
+		t.Fatalf("expected resolved identity uid=1000, got %+v", res.Identity)
+	}
+}
+
+// TestProcessDATAServiceDowngradeRejected covers C-MED: a context established
+// at a stronger service (privacy/integrity) must not accept a weaker per-call
+// service. A valid header MIC is supplied so the rejection is attributable to
+// the downgrade, not the MIC.
+func TestProcessDATAServiceDowngradeRejected(t *testing.T) {
+	cases := []struct {
+		name      string
+		ctxSvc    uint32
+		callSvc   uint32
+		wantError bool
+	}{
+		{"privacy->none", RPCGSSSvcPrivacy, RPCGSSSvcNone, true},
+		{"privacy->integrity", RPCGSSSvcPrivacy, RPCGSSSvcIntegrity, true},
+		{"integrity->none", RPCGSSSvcIntegrity, RPCGSSSvcNone, true},
+		{"none->none (no downgrade)", RPCGSSSvcNone, RPCGSSSvcNone, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verifier := newMockVerifier("alice", "EXAMPLE.COM")
+			proc := NewGSSProcessor(verifier, newTestMapper(), 100, 10*time.Minute)
+			defer proc.Stop()
+
+			handle := establishContext(t, proc, tc.ctxSvc)
+			dataCred := &RPCGSSCredV1{
+				GSSProc: RPCGSSData,
+				SeqNum:  1,
+				Service: tc.callSvc,
+				Handle:  handle,
+			}
+			dataCredBody, err := EncodeGSSCred(dataCred)
+			if err != nil {
+				t.Fatalf("encode DATA cred: %v", err)
+			}
+
+			mic := signHeaderMIC(t, mockVerifierSessionKey, dataCredBody)
+			res := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, []byte("args"))
+
+			if tc.wantError {
+				if res.Err == nil {
+					t.Fatalf("expected service-downgrade rejection (ctx=%d call=%d)", tc.ctxSvc, tc.callSvc)
+				}
+				if res.AuthStat != AuthStatCredProblem {
+					t.Fatalf("expected AuthStatCredProblem (%d), got %d", AuthStatCredProblem, res.AuthStat)
+				}
+			} else if res.Err != nil {
+				t.Fatalf("unexpected error for equal service level: %v", res.Err)
+			}
+		})
+	}
+}
+
 func TestProcessDATAUnknownContext(t *testing.T) {
 	verifier := newMockVerifier("alice", "EXAMPLE.COM")
 	mapper := newTestMapper()
@@ -372,7 +601,8 @@ func TestProcessDATAUnknownContext(t *testing.T) {
 		t.Fatalf("encode cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), credBody, nil, []byte("args"))
+	// Context lookup fails before the MIC check, so no verifier is needed.
+	result := proc.Process(context.Background(), credBody, nil, nil, []byte("args"))
 
 	if result.Err == nil {
 		t.Fatal("expected error for unknown context")
@@ -393,7 +623,7 @@ func TestProcessDATASilentDiscardForDuplicate(t *testing.T) {
 		Handle:  nil,
 	}
 	initCredBody, _ := EncodeGSSCred(initCred)
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -408,13 +638,14 @@ func TestProcessDATASilentDiscardForDuplicate(t *testing.T) {
 		Handle:  handle,
 	}
 	dataCredBody, _ := EncodeGSSCred(dataCred)
-	result1 := proc.Process(context.Background(), dataCredBody, nil, []byte("args"))
+	result1 := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("args"))
 	if result1.Err != nil {
 		t.Fatalf("first DATA failed: %v", result1.Err)
 	}
 
-	// Second DATA with same seq_num=1 should be silently discarded (duplicate)
-	result2 := proc.Process(context.Background(), dataCredBody, nil, []byte("args"))
+	// Second DATA with same seq_num=1 should be silently discarded (duplicate).
+	// The header MIC still verifies; the duplicate is caught by the seq window.
+	result2 := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("args"))
 	if !result2.SilentDiscard {
 		t.Fatal("expected SilentDiscard=true for duplicate sequence number")
 	}
@@ -434,7 +665,7 @@ func TestProcessDATAMaxSeqDestroysContext(t *testing.T) {
 		Handle:  nil,
 	}
 	initCredBody, _ := EncodeGSSCred(initCred)
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -449,7 +680,7 @@ func TestProcessDATAMaxSeqDestroysContext(t *testing.T) {
 		Handle:  handle,
 	}
 	dataCredBody, _ := EncodeGSSCred(dataCred)
-	result := proc.Process(context.Background(), dataCredBody, nil, []byte("args"))
+	result := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("args"))
 
 	if result.Err == nil {
 		t.Fatal("expected error for MAXSEQ exceeded")
@@ -475,7 +706,7 @@ func TestProcessDATASvcIntegrityRequiresValidIntegData(t *testing.T) {
 		Handle:  nil,
 	}
 	initCredBody, _ := EncodeGSSCred(initCred)
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -491,7 +722,8 @@ func TestProcessDATASvcIntegrityRequiresValidIntegData(t *testing.T) {
 		Handle:  handle,
 	}
 	dataCredBody, _ := EncodeGSSCred(dataCred)
-	result := proc.Process(context.Background(), dataCredBody, nil, []byte("raw-args-not-integ-format"))
+	// Header MIC passes; integrity body unwrap fails on the raw (non-integ) args.
+	result := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("raw-args-not-integ-format"))
 
 	if result.Err == nil {
 		t.Fatal("expected error for svc_integrity with invalid integ data format")
@@ -515,7 +747,7 @@ func TestProcessInvalidCredentialVersion(t *testing.T) {
 	badCredBody[15] = 1
 	// handle_len = 0 (bytes 16-19)
 
-	result := proc.Process(context.Background(), badCredBody, nil, nil)
+	result := proc.Process(context.Background(), badCredBody, nil, nil, nil)
 
 	if result.Err == nil {
 		t.Fatal("expected error for invalid credential version")
@@ -540,7 +772,7 @@ func TestProcessUnknownGSSProc(t *testing.T) {
 		t.Fatalf("encode cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), credBody, nil, nil)
+	result := proc.Process(context.Background(), credBody, nil, nil, nil)
 
 	if result.Err == nil {
 		t.Fatal("expected error for unknown GSS procedure")
@@ -553,7 +785,7 @@ func TestProcessINITNoVerifier(t *testing.T) {
 	defer proc.Stop()
 
 	credBody := buildINITCredBody(t)
-	result := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	result := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 
 	if result.Err == nil {
 		t.Fatal("expected error when no verifier configured")
@@ -569,7 +801,7 @@ func TestProcessINITMultipleContexts(t *testing.T) {
 	// Create 5 contexts
 	for i := 0; i < 5; i++ {
 		credBody := buildINITCredBody(t)
-		result := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
+		result := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
 		if result.Err != nil {
 			t.Fatalf("INIT %d failed: %v", i, result.Err)
 		}
@@ -588,7 +820,7 @@ func TestProcessSetVerifier(t *testing.T) {
 
 	// First INIT with original verifier
 	credBody := buildINITCredBody(t)
-	result := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	result := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if result.Err != nil {
 		t.Fatalf("INIT with verifier1 failed: %v", result.Err)
 	}
@@ -599,7 +831,7 @@ func TestProcessSetVerifier(t *testing.T) {
 
 	// Second INIT with new verifier
 	credBody2 := buildINITCredBody(t)
-	result2 := proc.Process(context.Background(), credBody2, nil, encodeOpaqueToken([]byte("mock-token")))
+	result2 := proc.Process(context.Background(), credBody2, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if result2.Err != nil {
 		t.Fatalf("INIT with verifier2 failed: %v", result2.Err)
 	}
@@ -640,7 +872,7 @@ func TestProcessContinueInitRoutesToInit(t *testing.T) {
 		t.Fatalf("encode cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("continue-token")))
+	result := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("continue-token")))
 
 	// Should succeed (routes to handleInit)
 	if result.Err != nil {
@@ -703,7 +935,7 @@ func TestGSSProcessResultIdentityNilForControl(t *testing.T) {
 	defer proc.Stop()
 
 	credBody := buildINITCredBody(t)
-	result := proc.Process(context.Background(), credBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	result := proc.Process(context.Background(), credBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -785,7 +1017,7 @@ func TestGSSLifecycle_Full(t *testing.T) {
 		t.Fatalf("encode INIT cred: %v", err)
 	}
 
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
 
 	// Verify INIT result
 	if initResult.Err != nil {
@@ -813,7 +1045,7 @@ func TestGSSLifecycle_Full(t *testing.T) {
 	}
 	dataCredBody1, _ := EncodeGSSCred(dataCred1)
 	procedureArgs1 := []byte("GETATTR-request-args")
-	dataResult1 := proc.Process(context.Background(), dataCredBody1, nil, procedureArgs1)
+	dataResult1 := processDATA(t, proc, mockVerifierSessionKey, dataCredBody1, procedureArgs1)
 
 	if dataResult1.Err != nil {
 		t.Fatalf("Step 2: DATA(seq=1) failed: %v", dataResult1.Err)
@@ -849,7 +1081,7 @@ func TestGSSLifecycle_Full(t *testing.T) {
 	}
 	dataCredBody2, _ := EncodeGSSCred(dataCred2)
 	procedureArgs2 := []byte("READ-request-args")
-	dataResult2 := proc.Process(context.Background(), dataCredBody2, nil, procedureArgs2)
+	dataResult2 := processDATA(t, proc, mockVerifierSessionKey, dataCredBody2, procedureArgs2)
 
 	if dataResult2.Err != nil {
 		t.Fatalf("Step 3: DATA(seq=2) failed: %v", dataResult2.Err)
@@ -862,7 +1094,7 @@ func TestGSSLifecycle_Full(t *testing.T) {
 	}
 
 	// ---- Step 4: Duplicate DATA with SeqNum=1 (should be silently discarded) ----
-	dupResult := proc.Process(context.Background(), dataCredBody1, nil, procedureArgs1)
+	dupResult := processDATA(t, proc, mockVerifierSessionKey, dataCredBody1, procedureArgs1)
 
 	if !dupResult.SilentDiscard {
 		t.Fatal("Step 4: expected SilentDiscard=true for duplicate seq_num=1")
@@ -876,7 +1108,7 @@ func TestGSSLifecycle_Full(t *testing.T) {
 		Handle:  handle,
 	}
 	destroyCredBody, _ := EncodeGSSCred(destroyCred)
-	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil)
+	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil, nil)
 
 	if destroyResult.Err != nil {
 		t.Fatalf("Step 5: DESTROY failed: %v", destroyResult.Err)
@@ -899,7 +1131,8 @@ func TestGSSLifecycle_Full(t *testing.T) {
 		Handle:  handle,
 	}
 	dataCredBody3, _ := EncodeGSSCred(dataCred3)
-	staleResult := proc.Process(context.Background(), dataCredBody3, nil, []byte("stale-request"))
+	// Context was destroyed; lookup fails before the MIC check.
+	staleResult := proc.Process(context.Background(), dataCredBody3, nil, nil, []byte("stale-request"))
 
 	if staleResult.Err == nil {
 		t.Fatal("Step 6: expected error for stale context handle after DESTROY")

--- a/internal/adapter/nfs/rpc/gss/integrity_test.go
+++ b/internal/adapter/nfs/rpc/gss/integrity_test.go
@@ -337,7 +337,7 @@ func TestHandleDataWithIntegrity(t *testing.T) {
 		t.Fatalf("encode INIT cred: %v", err)
 	}
 
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -362,7 +362,9 @@ func TestHandleDataWithIntegrity(t *testing.T) {
 		t.Fatalf("encode DATA cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), dataCredBody, nil, requestBody)
+	// Sign the call-header MIC (the credBody stands in as the header preimage).
+	mic := signHeaderMIC(t, key, dataCredBody)
+	result := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, requestBody)
 
 	if result.Err != nil {
 		t.Fatalf("DATA with integrity failed: %v", result.Err)
@@ -405,7 +407,7 @@ func TestHandleDataWithIntegrityAfterAuthOnlyInit(t *testing.T) {
 		t.Fatalf("encode INIT cred: %v", err)
 	}
 
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -437,7 +439,9 @@ func TestHandleDataWithIntegrityAfterAuthOnlyInit(t *testing.T) {
 		t.Fatalf("encode DATA cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), dataCredBody, nil, requestBody)
+	// Sign the call-header MIC (the credBody stands in as the header preimage).
+	mic := signHeaderMIC(t, key, dataCredBody)
+	result := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, requestBody)
 
 	// This is the key assertion: should succeed even though INIT was svc_none
 	if result.Err != nil {

--- a/internal/adapter/nfs/rpc/gss/privacy_test.go
+++ b/internal/adapter/nfs/rpc/gss/privacy_test.go
@@ -449,7 +449,7 @@ func TestHandleDataWithPrivacy(t *testing.T) {
 		t.Fatalf("encode INIT cred: %v", err)
 	}
 
-	initResult := proc.Process(context.Background(), initCredBody, nil, encodeOpaqueToken([]byte("mock-token")))
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-token")))
 	if initResult.Err != nil {
 		t.Fatalf("INIT failed: %v", initResult.Err)
 	}
@@ -474,7 +474,9 @@ func TestHandleDataWithPrivacy(t *testing.T) {
 		t.Fatalf("encode DATA cred: %v", err)
 	}
 
-	result := proc.Process(context.Background(), dataCredBody, nil, requestBody)
+	// Sign the call-header MIC (the credBody stands in as the header preimage).
+	mic := signHeaderMIC(t, key, dataCredBody)
+	result := proc.Process(context.Background(), dataCredBody, mic, dataCredBody, requestBody)
 
 	if result.Err != nil {
 		t.Fatalf("DATA with privacy failed: %v", result.Err)

--- a/internal/adapter/nfs/rpc/parser.go
+++ b/internal/adapter/nfs/rpc/parser.go
@@ -106,7 +106,8 @@ func ReadCall(data []byte) (*RPCCallMessage, error) {
 //
 // Returns:
 //   - []byte: Procedure-specific parameter bytes (empty if none)
-//   - error: Always returns nil (kept for interface compatibility)
+//   - error: Non-nil if the credential/verifier lengths are malformed and
+//     would run past the end of the message (a truncated/forged header)
 //
 // Example usage:
 //
@@ -127,43 +128,39 @@ func ReadCall(data []byte) (*RPCCallMessage, error) {
 //	    xdr.Unmarshal(bytes.NewReader(params), &req)
 //	}
 func ReadData(message []byte, call *RPCCallMessage) ([]byte, error) {
-	// Start after the fixed RPC header
-	// XID, MsgType, RPCVersion, Program, Version, Procedure = 6 × 4 bytes = 24 bytes
-	offset := 24
+	// The credential (XID..end-of-credential) is exactly the call-header MIC
+	// preimage; reuse the bounds-checked helper to find where the verifier
+	// begins, then skip the verifier to reach the procedure arguments.
+	header, err := HeaderMICPreimage(message)
+	if err != nil {
+		return nil, err
+	}
+	offset := len(header)
 
-	// Skip credentials (flavor + length + data + padding)
-	// Read the credential flavor and length to know how much to skip
-	offset += 4 // Skip flavor field
-	credLen := binary.BigEndian.Uint32(message[offset : offset+4])
-	offset += 4            // Skip length field
-	offset += int(credLen) // Skip credential body
-
-	// Add XDR padding for credential body (align to 4-byte boundary)
-	// Formula: padding = (4 - (length % 4)) % 4
-	// Examples: length=5 -> padding=3, length=8 -> padding=0
-	padding := (4 - (credLen % 4)) % 4
-	offset += int(padding)
-
-	// Skip verifier (flavor + length + data + padding)
-	// Same structure as credentials
+	// Skip verifier (flavor + length + data + padding), same structure as the
+	// credential. Bounds-check each field read against the buffer.
+	if offset+8 > len(message) {
+		return nil, fmt.Errorf("rpc message too short for verifier: %d bytes", len(message))
+	}
 	offset += 4 // Skip flavor field
 	verfLen := binary.BigEndian.Uint32(message[offset : offset+4])
-	offset += 4            // Skip length field
-	offset += int(verfLen) // Skip verifier body
+	offset += 4 // Skip length field
 
-	// Add XDR padding for verifier body
-	padding = (4 - (verfLen % 4)) % 4
-	offset += int(padding)
+	padding := (4 - (verfLen % 4)) % 4
+	end := offset + int(verfLen) + int(padding)
+	if verfLen > uint32(len(message)) || end < offset || end > len(message) {
+		return nil, fmt.Errorf("rpc verifier length %d overruns message of %d bytes", verfLen, len(message))
+	}
+	offset = end
 
-	// If we've consumed the entire message, return empty data
-	// This can happen for procedures that take no parameters (like NULL)
+	// If we've consumed the entire message, return empty data.
+	// This can happen for procedures that take no parameters (like NULL).
 	if offset >= len(message) {
 		return []byte{}, nil
 	}
 
-	// Return the remaining bytes, which contain procedure-specific parameters
-	remaining := message[offset:]
-	return remaining, nil
+	// Return the remaining bytes, which contain procedure-specific parameters.
+	return message[offset:], nil
 }
 
 // HeaderMICPreimage returns the RPC call-header bytes over which an

--- a/internal/adapter/nfs/rpc/parser.go
+++ b/internal/adapter/nfs/rpc/parser.go
@@ -166,6 +166,48 @@ func ReadData(message []byte, call *RPCCallMessage) ([]byte, error) {
 	return remaining, nil
 }
 
+// HeaderMICPreimage returns the RPC call-header bytes over which an
+// RPCSEC_GSS call verifier MIC is computed.
+//
+// Per RFC 2203 Section 5.3.3.2, the call verifier for an RPCSEC_GSS DATA
+// request is a GSS MIC token computed by the client over the marshalled RPC
+// call header through the credential — i.e. the XDR stream from the XID up to
+// and including the credential (flavor + length + body + padding), but NOT
+// including the verifier. This mirrors Linux sunrpc
+// svcauth_gss_verify_header, which verifies the MIC over the buffer spanning
+// xid..end-of-credential.
+//
+// The returned slice aliases the underlying message bytes; callers must not
+// mutate it.
+//
+// Returns an error if the message is too short or its embedded credential
+// length runs past the end of the buffer (i.e. a malformed/truncated header).
+func HeaderMICPreimage(message []byte) ([]byte, error) {
+	// Fixed RPC header: XID, MsgType, RPCVersion, Program, Version, Procedure
+	// = 6 × 4 bytes = 24 bytes, followed by the credential.
+	const fixedHeaderLen = 24
+
+	// Need at least the fixed header + credential flavor (4) + length (4).
+	if len(message) < fixedHeaderLen+8 {
+		return nil, fmt.Errorf("rpc message too short for credential: %d bytes", len(message))
+	}
+
+	offset := fixedHeaderLen
+	offset += 4 // credential flavor
+	credLen := binary.BigEndian.Uint32(message[offset : offset+4])
+	offset += 4 // credential length field
+
+	// Bound the credential body length against the actual buffer to avoid a
+	// slice-out-of-range and to reject truncated/forged headers.
+	padding := (4 - (credLen % 4)) % 4
+	end := offset + int(credLen) + int(padding)
+	if credLen > uint32(len(message)) || end < offset || end > len(message) {
+		return nil, fmt.Errorf("rpc credential length %d overruns message of %d bytes", credLen, len(message))
+	}
+
+	return message[:end], nil
+}
+
 // MakeSuccessReply constructs an RPC success reply message.
 //
 // Builds a complete RPC reply indicating successful execution

--- a/internal/adapter/nfs/rpc/rpc_test.go
+++ b/internal/adapter/nfs/rpc/rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	xdr "github.com/rasky/go-xdr/xdr2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -333,5 +334,84 @@ func TestMakeProgMismatchReply(t *testing.T) {
 		// So AcceptStat is at bytes 24-27
 		acceptStat := binary.BigEndian.Uint32(reply[24:28])
 		assert.Equal(t, uint32(RPCProgMismatch), acceptStat, "AcceptStat should be PROG_MISMATCH")
+	})
+}
+
+// marshalCall encodes a complete RPC call message (XID..Verf) plus procedure
+// data, the way a client would put it on the wire.
+func marshalCall(t *testing.T, call *RPCCallMessage, procData []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := xdr.Marshal(&buf, call); err != nil {
+		t.Fatalf("marshal call: %v", err)
+	}
+	buf.Write(procData)
+	return buf.Bytes()
+}
+
+func TestHeaderMICPreimage(t *testing.T) {
+	// The MIC preimage must be XID..end-of-credential, NOT including the
+	// verifier or the procedure data (RFC 2203 Section 5.3.3.2).
+	t.Run("excludes verifier and body", func(t *testing.T) {
+		call := &RPCCallMessage{
+			XID:        0xdeadbeef,
+			MsgType:    RPCCall,
+			RPCVersion: 2,
+			Program:    100003,
+			Version:    3,
+			Procedure:  1,
+			Cred:       OpaqueAuth{Flavor: AuthRPCSECGSS, Body: []byte("the-gss-credential!")}, // 19 bytes -> 1 pad
+			Verf:       OpaqueAuth{Flavor: AuthRPCSECGSS, Body: []byte("the-mic-token")},
+		}
+		message := marshalCall(t, call, []byte("procedure-arguments"))
+
+		preimage, err := HeaderMICPreimage(message)
+		require.NoError(t, err)
+
+		// Expected end: 24 (fixed header) + 4 (cred flavor) + 4 (cred len) +
+		// 19 (cred body) + 1 (XDR pad) = 52.
+		require.Equal(t, 52, len(preimage))
+		// Preimage must be a prefix of the message.
+		require.Equal(t, message[:52], preimage)
+		// Must contain the credential body...
+		require.Contains(t, string(preimage), "the-gss-credential!")
+		// ...but NOT the verifier MIC or the procedure args.
+		require.NotContains(t, string(preimage), "the-mic-token")
+		require.NotContains(t, string(preimage), "procedure-arguments")
+	})
+
+	t.Run("matches ReadData boundary", func(t *testing.T) {
+		// The preimage end must equal where ReadData starts the procedure body
+		// minus the verifier, i.e. preimage covers exactly through the cred.
+		call := &RPCCallMessage{
+			XID:        1,
+			MsgType:    RPCCall,
+			RPCVersion: 2,
+			Program:    100003,
+			Version:    3,
+			Procedure:  8,
+			Cred:       OpaqueAuth{Flavor: AuthUnix, Body: []byte{1, 2, 3, 4}}, // aligned
+			Verf:       OpaqueAuth{Flavor: AuthNull, Body: nil},
+		}
+		message := marshalCall(t, call, []byte("WRITE-args"))
+
+		preimage, err := HeaderMICPreimage(message)
+		require.NoError(t, err)
+		// 24 + 4 + 4 + 4 = 36.
+		require.Equal(t, 36, len(preimage))
+		require.Equal(t, message[:36], preimage)
+	})
+
+	t.Run("rejects truncated message", func(t *testing.T) {
+		_, err := HeaderMICPreimage([]byte{0, 0, 0, 1})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects overrunning credential length", func(t *testing.T) {
+		// Fixed header (24) + cred flavor (4) + a bogus huge cred length.
+		msg := make([]byte, 32)
+		binary.BigEndian.PutUint32(msg[28:32], 0xffffffff) // cred len overruns
+		_, err := HeaderMICPreimage(msg)
+		require.Error(t, err)
 	})
 }

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -237,7 +237,7 @@ func (c *NFSConnection) processRequest(ctx context.Context, call *rpc.RPCCallMes
 		return fmt.Errorf("extract procedure data: %w", err)
 	}
 
-	return c.handleRPCCall(ctx, call, procedureData)
+	return c.handleRPCCall(ctx, call, rawMessage, procedureData)
 }
 
 // handleUnsupportedVersion sends an RFC 5531 PROG_MISMATCH reply for

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -24,7 +24,7 @@ import (
 // - Context is cancelled during processing
 // - Handler returns an error
 // - Reply cannot be sent
-func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMessage, procedureData []byte) error {
+func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMessage, rawMessage []byte, procedureData []byte) error {
 	var replyData []byte
 	var err error
 
@@ -50,7 +50,19 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 	// GSS DATA messages have their procedureData replaced with the unwrapped
 	// arguments and GSS identity injected into the context.
 	if call.GetAuthFlavor() == rpc.AuthRPCSECGSS && c.server.gssProcessor != nil {
-		gssResult := c.server.gssProcessor.Process(ctx, call.GetAuthBody(), call.GetVerifierBody(), procedureData)
+		// The RPCSEC_GSS DATA call verifier is a MIC over the marshalled RPC
+		// call header (XID..end-of-credential). Capture that exact byte range
+		// so the GSS processor can verify it (RFC 2203 Section 5.3.3.2). A
+		// malformed header yields an empty preimage, which the processor
+		// rejects with CREDPROBLEM for DATA requests.
+		headerPreimage, preimageErr := rpc.HeaderMICPreimage(rawMessage)
+		if preimageErr != nil {
+			logger.Debug("GSS: failed to extract call-header MIC preimage",
+				"xid", fmt.Sprintf("0x%x", call.XID),
+				"error", preimageErr)
+			headerPreimage = nil
+		}
+		gssResult := c.server.gssProcessor.Process(ctx, call.GetAuthBody(), call.GetVerifierBody(), headerPreimage, procedureData)
 
 		// Handle GSS processing errors (CREDPROBLEM / CTXPROBLEM)
 		if gssResult.Err != nil {


### PR DESCRIPTION
## Summary

Closes **H1**, the highest-priority security finding of the NFS area-4 audit: **RPCSEC_GSS DATA requests never verified the call-header MIC**, a complete krb5 authentication bypass.

### The bypass

Per RFC 2203 §5.3.3.2 the RPC call verifier on a DATA request is a GSS MIC token the client computes over the marshalled RPC call header (XID..end-of-credential) with the context session key. `handleData` plumbed `verifBody` in but **never used it**. Consequences:

- **krb5 (svc_none):** zero cryptographic checks on a DATA request. A 16-byte context handle is sent in cleartext on every call — anyone who observes one could forge arbitrary requests under the victim principal. Full auth bypass.
- **krb5i/krb5p:** the body MIC/Wrap was verified, but the call *header* (gss_proc / service / seq_num / handle) stayed unauthenticated.

The sequence window only stops exact replays; it authenticates nothing.

## Fix

1. **Verify the call-header MIC** (`internal/adapter/nfs/rpc/gss/framework.go`). New `verifyHeaderMIC` unmarshals the verifier as an initiator MIC token, sets the payload to the marshalled header preimage, and `gss_verify_mic`s it with the context session key + `KeyUsageInitiatorSign`. Constant-time comparison (gokrb5 `MICToken.Verify` → `hmac.Equal`). Runs **before** any credential field is trusted. Reject → `RPCSEC_GSS_CREDPROBLEM`. This is now the authentication gate for svc_none, and complements body crypto for krb5i/krb5p.
2. **Thread the raw header preimage** through the call path. New `rpc.HeaderMICPreimage` slices the exact XID..end-of-credential byte range out of the on-wire message (zero-copy); `pkg/adapter/nfs/dispatch.go` captures it and passes it into `Process` → `handleData`. A malformed header yields a nil preimage → CREDPROBLEM (safe reject).
3. **C-MED service-downgrade enforced.** Reject a per-call service weaker than the one negotiated at context establishment (none < integrity < privacy) → CREDPROBLEM. A sniffed krb5p handle can no longer be replayed at svc_none.
4. **Bonus hardening:** `ReadData` now reuses the bounds-checked `HeaderMICPreimage` and bounds-checks the verifier length, closing the latent unchecked-length slice panic the audit flagged as C-MED (`parser.go:129`).

## Canonical cross-check

Matches Linux `net/sunrpc/auth_gss/svcauth_gss.c`: `svcauth_gss_verify_header` / `gss_verify_mic` compute the MIC over the buffer spanning xid..end-of-credential (the verifier itself excluded), look the context up by handle, and return `rpcsec_gsserr_credproblem` on MIC failure. The preimage boundary and reject status here mirror that exactly.

## Tests

`internal/adapter/nfs/rpc/gss/framework_test.go`:
- **Forged-header DATA rejected** (valid handle): no verifier, MIC over a different preimage, MIC under the wrong key, missing preimage — all → CREDPROBLEM, no processed data/identity leaked.
- **Genuine MIC passes** for svc_none (the previously-unauthenticated path), with identity resolved.
- **Service-downgrade matrix**: privacy→none, privacy→integrity, integrity→none rejected; equal level allowed.
- krb5i/krb5p existing round-trip tests updated to carry a valid header MIC and still pass.

`internal/adapter/nfs/rpc/rpc_test.go`:
- `HeaderMICPreimage` boundary: excludes verifier + body, matches the credential end, rejects truncated/overrunning headers.

`go test -race ./internal/adapter/nfs/...` and `./pkg/adapter/nfs/...` green. gofmt/vet/golangci-lint clean on touched packages.

## Compounding items

- **C-MED service-downgrade — INCLUDED** (enforced, with the downgrade matrix test).
- **C-LOW GSS handle not connection-scoped — DEFERRED** (defense-in-depth). The audit downgrades this to LOW once the MIC is enforced: a stolen handle is now useless without the session key. Strict connection-binding would also be *incorrect* — NFS clients legitimately reuse a GSS context across TCP reconnects/trunking (Linux does not bind contexts to a connection), so enforcing it would cause spurious CREDPROBLEM storms. Left as a future hardening item.
