### PR TITLE
fix(metadata/memory): deep-copy FileAttr.ACL to stop caller/store aliasing (area-6 PR-B2)

### DIFF
--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // cloneBlocks returns a deep copy of a []blockstore.BlockRef. BlockRef is a
@@ -24,6 +25,31 @@ func cloneBlocks(in []blockstore.BlockRef) []blockstore.BlockRef {
 	out := make([]blockstore.BlockRef, len(in))
 	copy(out, in)
 	return out
+}
+
+// cloneACL returns a deep copy of a *acl.ACL, including a fresh copy of its
+// ACEs slice. acl.ACL holds a single reference-bearing field (the ACEs slice);
+// acl.ACE is a flat value type (uint32 fields + a string Who), so an
+// element-wise slice copy fully detaches the clone — no nested pointers remain.
+//
+// Used by PutFile/GetFile/ListChildren in the Memory backend to prevent ACL
+// aliasing between the caller's view and the stored view. Without this, an
+// in-place edit of an ACE by either side silently corrupts the other (the
+// Badger backend round-trips through JSON and never aliases, so this restores
+// cross-backend parity).
+//
+// Returns nil if the input is nil so the round-trip preserves the
+// "no ACL set" semantics (json:"acl,omitempty" on FileAttr.ACL).
+func cloneACL(in *acl.ACL) *acl.ACL {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.ACEs != nil {
+		out.ACEs = make([]acl.ACE, len(in.ACEs))
+		copy(out.ACEs, in.ACEs)
+	}
+	return &out
 }
 
 // ============================================================================
@@ -295,8 +321,10 @@ func (store *MemoryMetadataStore) ListChildren(ctx context.Context, dirHandle me
 			} else {
 				attr.Nlink = 1
 			}
-			// Deep-copy slice fields (T-12-09).
+			// Deep-copy reference-bearing fields (Blocks, ACL) so a
+			// caller-side in-place mutation cannot leak into the stored view.
 			attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
+			attr.ACL = cloneACL(fileData.Attr.ACL)
 			entry.Attr = &attr
 		}
 
@@ -359,6 +387,7 @@ func (store *MemoryMetadataStore) GetFileByPayloadID(
 			// ID and Path aren't needed by the flusher (only Size is used)
 			attr := *fileData.Attr
 			attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
+			attr.ACL = cloneACL(fileData.Attr.ACL)
 			return &metadata.File{
 				ShareName: fileData.ShareName,
 				FileAttr:  attr,

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -495,9 +495,11 @@ func (store *MemoryMetadataStore) buildFileWithNlink(
 	// Copy attributes and set Nlink
 	attr := *fileData.Attr
 	attr.Nlink = nlink
-	// Deep-copy slice fields so a caller-side mutation of the returned
-	// slice cannot leak into the stored view (T-12-09).
+	// Deep-copy reference-bearing fields (Blocks, ACL) so a caller-side
+	// in-place mutation of the returned value cannot leak into the
+	// stored view.
 	attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
+	attr.ACL = cloneACL(fileData.Attr.ACL)
 
 	return &metadata.File{
 		ID:        id,

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -79,9 +79,10 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 
 	key := handleToKey(handle)
 	attrCopy := file.FileAttr
-	// Deep-copy slice fields so the stored view cannot be mutated by
-	// later caller-side mutation of the input slice.
+	// Deep-copy reference-bearing fields (Blocks, ACL) so the stored view
+	// cannot be mutated by a later caller-side in-place mutation of the input.
 	attrCopy.Blocks = cloneBlocks(file.Blocks)
+	attrCopy.ACL = cloneACL(file.ACL)
 
 	// Track size delta for regular files.
 	if file.Type == metadata.FileTypeRegular {
@@ -302,11 +303,12 @@ func (tx *memoryTransaction) ListChildren(ctx context.Context, dirHandle metadat
 			Handle: childHandle,
 		}
 
-		// Try to get attributes (deep-copy Blocks per T-12-09).
+		// Try to get attributes (deep-copy reference-bearing fields).
 		childKey := handleToKey(childHandle)
 		if fileData, exists := tx.store.files[childKey]; exists {
 			attr := *fileData.Attr
 			attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
+			attr.ACL = cloneACL(fileData.Attr.ACL)
 			entry.Attr = &attr
 		}
 

--- a/pkg/metadata/storetest/acl_aliasing.go
+++ b/pkg/metadata/storetest/acl_aliasing.go
@@ -1,0 +1,125 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// runACLAliasingTests asserts that backends deep-copy FileAttr.ACL on both the
+// store-from-caller (PutFile) and return-to-caller (GetFile) paths, so neither
+// side can corrupt the other's view by mutating an ACE in place.
+//
+// This pins the cross-backend parity gap the area-6 audit found: the memory
+// backend used to copy only FileAttr.Blocks and left FileAttr.ACL (a *acl.ACL
+// holding an []ACE) shared by pointer, while Badger/Postgres round-trip through
+// JSON and never alias. Identical inputs, divergent aliasing — an in-place ACE
+// edit silently corrupted stored permissions on memory only.
+func runACLAliasingTests(t *testing.T, factory StoreFactory) {
+	t.Run("PutDoesNotAliasCallerACL", func(t *testing.T) { testPutDoesNotAliasCallerACL(t, factory) })
+	t.Run("GetDoesNotAliasStoredACL", func(t *testing.T) { testGetDoesNotAliasStoredACL(t, factory) })
+}
+
+// putFileWithACL creates a regular file carrying the supplied ACL and returns
+// its handle. The caller retains ownership of acl (it is set on the File passed
+// to PutFile) so tests can mutate it afterwards to probe for aliasing.
+func putFileWithACL(t *testing.T, store metadata.MetadataStore, handle metadata.FileHandle, a *acl.ACL) {
+	t.Helper()
+
+	ctx := t.Context()
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	file.ACL = a
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile with ACL: %v", err)
+	}
+}
+
+// newTestACL builds a single-ACE ALLOW ACL granting READ_DATA to the owner.
+func newTestACL() *acl.ACL {
+	return &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: acl.ACE4_READ_DATA,
+				Who:        acl.SpecialOwner,
+			},
+		},
+	}
+}
+
+// testPutDoesNotAliasCallerACL: PutFile a file with a non-empty ACL, then mutate
+// the caller's ACE slice in place; re-GetFile must return the ORIGINAL ACL.
+// If the store aliased the caller's slice, the in-place edit would leak into
+// the stored row.
+func testPutDoesNotAliasCallerACL(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	handle := createTestFile(t, store, "/test", rootHandle, "put-alias.txt", 0o600)
+
+	callerACL := newTestACL()
+	putFileWithACL(t, store, handle, callerACL)
+
+	// Mutate the caller's ACL in place AFTER the store accepted it.
+	callerACL.ACEs[0].AccessMask = acl.ACE4_WRITE_DATA
+	callerACL.ACEs[0].Who = "evil@localdomain"
+	callerACL.Protected = true
+
+	got, err := store.GetFile(t.Context(), handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if got.ACL == nil {
+		t.Fatalf("stored ACL is nil after PutFile")
+	}
+	if len(got.ACL.ACEs) != 1 {
+		t.Fatalf("expected 1 stored ACE, got %d", len(got.ACL.ACEs))
+	}
+	ace := got.ACL.ACEs[0]
+	if ace.AccessMask != acl.ACE4_READ_DATA || ace.Who != acl.SpecialOwner || got.ACL.Protected {
+		t.Fatalf("store aliased caller's ACL — a caller-side mutation corrupted the stored row: "+
+			"got mask=%#x who=%q protected=%v, want mask=%#x who=%q protected=false",
+			ace.AccessMask, ace.Who, got.ACL.Protected, acl.ACE4_READ_DATA, acl.SpecialOwner)
+	}
+}
+
+// testGetDoesNotAliasStoredACL: GetFile, mutate the returned ACE slice in place,
+// then re-GetFile; the second read must return the ORIGINAL ACL. If the store
+// handed back its own backing slice, the caller's edit would corrupt it.
+func testGetDoesNotAliasStoredACL(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	handle := createTestFile(t, store, "/test", rootHandle, "get-alias.txt", 0o600)
+
+	putFileWithACL(t, store, handle, newTestACL())
+
+	first, err := store.GetFile(t.Context(), handle)
+	if err != nil {
+		t.Fatalf("GetFile (first): %v", err)
+	}
+	if first.ACL == nil || len(first.ACL.ACEs) != 1 {
+		t.Fatalf("first GetFile returned unexpected ACL: %+v", first.ACL)
+	}
+
+	// Mutate the returned ACL in place.
+	first.ACL.ACEs[0].AccessMask = acl.ACE4_WRITE_DATA
+	first.ACL.ACEs[0].Who = "evil@localdomain"
+	first.ACL.Protected = true
+
+	second, err := store.GetFile(t.Context(), handle)
+	if err != nil {
+		t.Fatalf("GetFile (second): %v", err)
+	}
+	if second.ACL == nil || len(second.ACL.ACEs) != 1 {
+		t.Fatalf("second GetFile returned unexpected ACL: %+v", second.ACL)
+	}
+	ace := second.ACL.ACEs[0]
+	if ace.AccessMask != acl.ACE4_READ_DATA || ace.Who != acl.SpecialOwner || second.ACL.Protected {
+		t.Fatalf("store aliased the returned ACL — a caller-side mutation corrupted the store: "+
+			"got mask=%#x who=%q protected=%v, want mask=%#x who=%q protected=false",
+			ace.AccessMask, ace.Who, second.ACL.Protected, acl.ACE4_READ_DATA, acl.SpecialOwner)
+	}
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -59,6 +59,14 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		RunDurableHandleStoreTests(t, factory)
 	})
 
+	// ACLAliasing asserts both directions of FileAttr.ACL deep-copy
+	// discipline: PutFile must not alias the caller's ACE slice, and
+	// GetFile must not hand back the store's backing slice. Pins the
+	// cross-backend parity gap the area-6 audit found in the memory backend.
+	t.Run("ACLAliasing", func(t *testing.T) {
+		runACLAliasingTests(t, factory)
+	})
+
 	t.Run("FileBlockOps", func(t *testing.T) {
 		runFileBlockOpsTests(t, factory)
 	})


### PR DESCRIPTION
## Area-6 metadata PR-B2 — `v1.0/metadata-deepcopy`

Closes the area-6 MED finding: *"memory store shares `FileAttr.ACL` by pointer (incomplete deep-copy)"* (`.planning/v1.0-audit/6-metadata/REVIEW.md` §4, memory+badger). Same class as the area-5 `cloneLock` field-drop bug.

### The aliasing bug
The memory backend's `GetFile` / `ListChildren` / `PutFile` / `GetFileByPayloadID` deep-copied **only** `FileAttr.Blocks` (via `cloneBlocks`) and left `FileAttr.ACL` — a `*acl.ACL` holding an `[]ACE` slice — **shared by pointer** between the caller and the stored row.

Badger and Postgres round-trip through JSON and never alias, so identical inputs produced divergent aliasing across backends. On memory, an in-place ACE edit by a caller silently corrupted the stored permissions (or a returned-ACL edit corrupted the store), with no test catching it.

### Fix
- Add `cloneACL` (`store/memory/files.go`): deep-copies the `*acl.ACL` value **and** its `ACEs` slice. `acl.ACE` is a flat value type (uint32 fields + string `Who`), so an element-wise slice copy fully detaches the clone — no nested pointers remain. `nil`→`nil`; preserves the empty-but-non-nil `ACEs` distinction (the "explicit empty ACL" semantics).
- Apply `cloneACL` alongside `cloneBlocks` at **all five** deep-copy sites:
  - `store.go` `buildFileWithNlink` (backs `GetFile`, store + tx)
  - `files.go` `ListChildren` (store path)
  - `files.go` `GetFileByPayloadID`
  - `transaction.go` `PutFile`
  - `transaction.go` `ListChildren` (tx path)
- **Other reference-bearing `FileAttr` fields:** audited the struct — `ACL` is the only reference field besides `Blocks` (already cloned). `PayloadID`, `ObjectID`, `LinkTarget` are value types (string / `[32]byte`). No third field needed cloning.

### Regression net (both directions, all backends)
New cross-backend conformance scenario `storetest/acl_aliasing.go`, wired into `RunConformanceSuite` as `ACLAliasing`:
- **PutDoesNotAliasCallerACL** — PutFile a file with a non-empty ACL, mutate the caller's ACE slice in place, re-GetFile → assert the stored ACL is unchanged.
- **GetDoesNotAliasStoredACL** — GetFile, mutate the returned ACL in place, re-GetFile → assert unchanged.

Verified to **FAIL on the unfixed memory backend in both directions** and **PASS on memory + badger after the fix** (badger already passed via JSON round-trip; memory was the broken one).

### Gates
- `go test -race ./pkg/metadata/...` green (incl. `-tags=integration` badger conformance).
- `gofmt -s` + `go vet` + `golangci-lint run` clean on touched packages (0 issues).
- code-simplifier + code-reviewer: no findings.