### PR TITLE
fix(nfs/v4): enforce share reservations + stateid share-access (area-4 H2/H3/H19)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -78,6 +78,24 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 	}
 	logger.Debug("NFSv4 OPEN share", "access", shareAccess, "deny", shareDeny)
 
+	// Validate the share_access / share_deny modes (RFC 7530 Section 16.16).
+	// The access mode (low 2 bits) must be exactly READ, WRITE, or BOTH; the
+	// deny mode must be a subset of {READ, WRITE}. Reject anything else with
+	// NFS4ERR_INVAL before touching state. The server ignores any higher
+	// share_access bits (e.g. the v4.1 want-delegation hints), so the access
+	// mode is masked to OPEN4_SHARE_ACCESS_BOTH and the masked value carried
+	// forward consistently with the rest of the handler.
+	accessMode := shareAccess & uint32(types.OPEN4_SHARE_ACCESS_BOTH)
+	if accessMode == 0 {
+		logger.Debug("NFSv4 OPEN invalid share_access", "access", shareAccess, "client", ctx.ClientAddr)
+		return openError(types.NFS4ERR_INVAL)
+	}
+	if shareDeny&^uint32(types.OPEN4_SHARE_DENY_BOTH) != 0 {
+		logger.Debug("NFSv4 OPEN invalid share_deny", "deny", shareDeny, "client", ctx.ClientAddr)
+		return openError(types.NFS4ERR_INVAL)
+	}
+	shareAccess = accessMode
+
 	// 4. open_owner4: clientid (uint64) + owner (XDR opaque)
 	clientID, err := xdr.DecodeUint64(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -65,10 +66,13 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 		}
 	}
 
-	// Validate stateid via StateManager
-	// Special stateids (all-zeros, all-ones) bypass validation.
-	// Real stateids are validated for correctness (seqid, epoch, filehandle match).
-	if _, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH); stateErr != nil {
+	// Validate stateid via StateManager.
+	// The anonymous (all-zeros) and READ-bypass (all-ones) special stateids are
+	// permitted on READ and return a nil openState. Real open stateids are
+	// validated for correctness (seqid, epoch, filehandle match) and carry the
+	// open's share-access bits.
+	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead)
+	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 READ stateid validation failed",
 			"error", stateErr,
@@ -78,6 +82,21 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 			Status: nfsStatus,
 			OpCode: types.OP_READ,
 			Data:   encodeStatusOnly(nfsStatus),
+		}
+	}
+
+	// Enforce the open's share-access mode: a regular open stateid must have
+	// been opened with OPEN4_SHARE_ACCESS_READ to be usable on READ
+	// (RFC 7530 Section 16.25.4). Special stateids (openState == nil) bypass
+	// this check.
+	if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_READ == 0 {
+		logger.Debug("NFSv4 READ rejected: write-only open",
+			"share_access", openState.ShareAccess,
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_OPENMODE,
+			OpCode: types.OP_READ,
+			Data:   encodeStatusOnly(types.NFS4ERR_OPENMODE),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -51,7 +51,9 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
-	// Log stateid at debug level (StateManager validates separately)
+	// Log stateid at debug level (full open-mode/lease validation is handled by
+	// the dedicated stateid slice; this slice enforces only the special-stateid
+	// rule below).
 	logger.Debug("NFSv4 SETATTR stateid",
 		"seqid", stateid.Seqid,
 		"special", stateid.IsSpecialStateid(),
@@ -77,6 +79,22 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_SETATTR,
 			Data:   encodeSetAttrError(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	// 4b. A SETATTR that changes the file size is a write-family operation:
+	// reject the READ-bypass (all-ones) special stateid with NFS4ERR_BAD_STATEID
+	// (RFC 7530 Section 9.1.4.3). Without this, a client could truncate/extend a
+	// file using the READ-only special stateid, bypassing share-mode and lock
+	// enforcement.
+	if setAttrs.Size != nil && stateid.IsReadBypassStateid() {
+		logger.Debug("NFSv4 SETATTR rejected: READ-bypass stateid on size change",
+			"handle", string(ctx.CurrentFH),
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_BAD_STATEID,
+			OpCode: types.OP_SETATTR,
+			Data:   encodeSetAttrError(types.NFS4ERR_BAD_STATEID),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/shareres_test.go
+++ b/internal/adapter/nfs/v4/handlers/shareres_test.go
@@ -1,0 +1,267 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// readBypassStateidH returns the all-ones READ-bypass special stateid.
+func readBypassStateidH() *types.Stateid4 {
+	sid := &types.Stateid4{Seqid: 0xFFFFFFFF}
+	for i := range sid.Other {
+		sid.Other[i] = 0xFF
+	}
+	return sid
+}
+
+// openFileAndGetStateid creates+opens a file via the OPEN handler with the given
+// share_access and returns the file handle and the real (confirmed) open stateid.
+// It drives OPEN then OPEN_CONFIRM through the handler so the returned stateid is
+// usable on subsequent READ/WRITE ops.
+func openFileAndGetStateid(t *testing.T, fx *ioTestFixture, owner string, shareAccess uint32) (metadata.FileHandle, *types.Stateid4) {
+	t.Helper()
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgs(
+		1,
+		shareAccess,
+		types.OPEN4_SHARE_DENY_NONE,
+		0x1111,
+		[]byte(owner),
+		types.OPEN4_CREATE,
+		types.UNCHECKED4,
+		types.CLAIM_NULL,
+		owner+".txt",
+	)
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN(%s) status = %d, want NFS4_OK", owner, result.Status)
+	}
+
+	// Decode the stateid from the OPEN response.
+	reader := bytes.NewReader(result.Data)
+	if _, err := xdr.DecodeUint32(reader); err != nil { // status
+		t.Fatalf("decode OPEN status: %v", err)
+	}
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		t.Fatalf("decode OPEN stateid: %v", err)
+	}
+
+	// CurrentFH now points at the opened file.
+	fileHandle := make(metadata.FileHandle, len(ctx.CurrentFH))
+	copy(fileHandle, ctx.CurrentFH)
+
+	// Confirm the new owner so the stateid seqid advances to a usable value.
+	confirmArgs := encodeOpenConfirmArgs(stateid, 2)
+	confirmResult := fx.handler.handleOpenConfirm(ctx, bytes.NewReader(confirmArgs))
+	if confirmResult.Status != types.NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM(%s) status = %d, want NFS4_OK", owner, confirmResult.Status)
+	}
+	creader := bytes.NewReader(confirmResult.Data)
+	if _, err := xdr.DecodeUint32(creader); err != nil { // status
+		t.Fatalf("decode OPEN_CONFIRM status: %v", err)
+	}
+	confirmed, err := types.DecodeStateid4(creader)
+	if err != nil {
+		t.Fatalf("decode OPEN_CONFIRM stateid: %v", err)
+	}
+
+	return fileHandle, confirmed
+}
+
+// ============================================================================
+// H3 — all-ones (READ-bypass) special stateid on write-family ops
+// ============================================================================
+
+func TestWrite_ReadBypassStateid_ReturnsBadStateid(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "wbypass.txt", 0o644, 0, 0)
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeWriteArgs(readBypassStateidH(), 0, types.UNSTABLE4, []byte("nope"))
+	result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("WRITE with all-ones stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
+			result.Status, types.NFS4ERR_BAD_STATEID)
+	}
+}
+
+func TestSetAttr_ReadBypassStateid_OnSizeChange_ReturnsBadStateid(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "sbypass.txt", 0o644, 0, 0)
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	var attrVals bytes.Buffer
+	_ = xdr.WriteUint64(&attrVals, 0) // truncate to 0
+	var bitmap []uint32
+	attrs.SetBit(&bitmap, attrs.FATTR4_SIZE)
+
+	args := encodeSetAttrArgs(t, readBypassStateidH(), bitmap, attrVals.Bytes())
+	result := fx.handler.handleSetAttr(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("SETATTR(size) with all-ones stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
+			result.Status, types.NFS4ERR_BAD_STATEID)
+	}
+}
+
+func TestRead_ReadBypassStateid_Allowed(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "rbypass.txt", 0o644, 0, 0)
+	fx.writeContent(t, fileHandle, []byte("readable"))
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeReadArgs(readBypassStateidH(), 0, 1024)
+	result := fx.handler.handleRead(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4_OK {
+		t.Errorf("READ with all-ones stateid status = %d, want NFS4_OK", result.Status)
+	}
+}
+
+func TestWrite_AnonymousStateid_Allowed(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "anon.txt", 0o644, 0, 0)
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeWriteArgs(&anonymousStateid, 0, types.UNSTABLE4, []byte("data"))
+	result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4_OK {
+		t.Errorf("WRITE with anonymous stateid status = %d, want NFS4_OK", result.Status)
+	}
+}
+
+// ============================================================================
+// H19 — READ enforces SHARE_ACCESS_READ on the open stateid
+// ============================================================================
+
+func TestRead_WriteOnlyOpenStateid_ReturnsOpenMode(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	// Open write-only and grab the real stateid.
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "writeonly", types.OPEN4_SHARE_ACCESS_WRITE)
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeReadArgs(stateid, 0, 1024)
+	result := fx.handler.handleRead(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_OPENMODE {
+		t.Errorf("READ with write-only open stateid status = %d, want NFS4ERR_OPENMODE (%d)",
+			result.Status, types.NFS4ERR_OPENMODE)
+	}
+}
+
+func TestRead_ReadWriteOpenStateid_Allowed(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "readwrite", types.OPEN4_SHARE_ACCESS_BOTH)
+	fx.writeContent(t, fileHandle, []byte("content"))
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeReadArgs(stateid, 0, 1024)
+	result := fx.handler.handleRead(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4_OK {
+		t.Errorf("READ with read-write open stateid status = %d, want NFS4_OK", result.Status)
+	}
+}
+
+// ============================================================================
+// H2 — OPEN decode validation of share_access / share_deny
+// ============================================================================
+
+func TestOpen_InvalidShareAccess_ReturnsInval(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+
+	// share_access = 0 is illegal.
+	args := encodeOpenArgs(
+		1, 0, types.OPEN4_SHARE_DENY_NONE,
+		0x2222, []byte("badaccess"),
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_NULL, "bad.txt",
+	)
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_INVAL {
+		t.Errorf("OPEN with share_access=0 status = %d, want NFS4ERR_INVAL (%d)",
+			result.Status, types.NFS4ERR_INVAL)
+	}
+}
+
+func TestOpen_InvalidShareDeny_ReturnsInval(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+
+	// share_deny with an out-of-range bit (0x04) is illegal.
+	args := encodeOpenArgs(
+		1, types.OPEN4_SHARE_ACCESS_READ, 0x04,
+		0x3333, []byte("baddeny"),
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_NULL, "bad.txt",
+	)
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_INVAL {
+		t.Errorf("OPEN with illegal share_deny status = %d, want NFS4ERR_INVAL (%d)",
+			result.Status, types.NFS4ERR_INVAL)
+	}
+}
+
+// ============================================================================
+// H2 — share reservation enforcement end-to-end through the OPEN handler
+// ============================================================================
+
+func TestOpen_ShareDenyWrite_BlocksSecondWriterAcrossOwners(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+
+	// Owner A creates+opens "shared.txt" WRITE with DENY_WRITE.
+	argsA := encodeOpenArgs(
+		1, types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE,
+		0x4444, []byte("ownerA"),
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_NULL, "shared.txt",
+	)
+	resA := fx.handler.handleOpen(ctx, bytes.NewReader(argsA))
+	if resA.Status != types.NFS4_OK {
+		t.Fatalf("OPEN ownerA status = %d, want NFS4_OK", resA.Status)
+	}
+
+	// Owner B opens the same file WRITE — must be refused with SHARE_DENIED.
+	setCurrentFH(ctx, fx.rootHandle)
+	argsB := encodeOpenArgs(
+		1, types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE,
+		0x5555, []byte("ownerB"),
+		types.OPEN4_NOCREATE, 0, types.CLAIM_NULL, "shared.txt",
+	)
+	resB := fx.handler.handleOpen(ctx, bytes.NewReader(argsB))
+	if resB.Status != types.NFS4ERR_SHARE_DENIED {
+		t.Errorf("OPEN ownerB status = %d, want NFS4ERR_SHARE_DENIED (%d)",
+			resB.Status, types.NFS4ERR_SHARE_DENIED)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -122,11 +123,13 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
-	// Validate stateid via StateManager
-	// Special stateids (all-zeros, all-ones) bypass validation.
-	// Real stateids are validated for correctness (seqid, epoch, filehandle match).
-	// Implicit lease renewal happens inside ValidateStateid for real stateids.
-	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH)
+	// Validate stateid via StateManager for a write-family operation.
+	// The anonymous (all-zeros) special stateid is permitted; the READ-bypass
+	// (all-ones) special stateid is rejected with NFS4ERR_BAD_STATEID because it
+	// is READ-only (RFC 7530 Section 9.1.4.3). Real stateids are validated for
+	// correctness (seqid, epoch, filehandle match); implicit lease renewal
+	// happens inside ValidateStateid for real stateids.
+	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 WRITE stateid validation failed",

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -228,7 +228,7 @@ func TestImplicitRenewal_ViaValidateStateid(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// ValidateStateid should implicitly renew the lease
-	openState, err := sm.ValidateStateid(confirmedStateid, []byte("fh-implicit-renew"))
+	openState, err := sm.ValidateStateid(confirmedStateid, []byte("fh-implicit-renew"), StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestLeaseExpired_ReturnsError(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// ValidateStateid should return NFS4ERR_EXPIRED
-	_, err = sm.ValidateStateid(confirmedStateid, []byte("fh-expired"))
+	_, err = sm.ValidateStateid(confirmedStateid, []byte("fh-expired"), StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for expired lease")
 	}

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -803,7 +803,7 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	}
 
 	// Verify open state is also removed
-	_, openValErr := sm.ValidateStateid(openStateid, fileHandle)
+	_, openValErr := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead)
 	if openValErr == nil {
 		t.Fatal("expected error for open stateid after lease expiry")
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -977,6 +977,22 @@ func (sm *StateManager) OpenFile(
 	ownerKey := makeOwnerKey(clientID, ownerData)
 	owner, ownerExists := sm.openOwners[ownerKey]
 
+	// Enforce share reservations across open-owners (RFC 7530 Section 9.7 /
+	// Section 16.16.5; Linux nfsd nfs4_share_conflict). Reclaim (CLAIM_PREVIOUS)
+	// re-establishes state the client previously held and is exempt. The scan
+	// runs under sm.mu so it observes a consistent snapshot of every live open;
+	// opens by THIS owner are skipped because share bits accumulate per owner.
+	if claimType != types.CLAIM_PREVIOUS {
+		if conflict := sm.shareConflictLocked(ownerKey, fileHandle, shareAccess, shareDeny); conflict {
+			logger.Debug("OpenFile: share reservation conflict",
+				"client_id", clientID,
+				"owner", string(ownerData),
+				"req_access", shareAccess,
+				"req_deny", shareDeny)
+			return nil, ErrShareDenied
+		}
+	}
+
 	if ownerExists {
 		// Existing owner: validate seqid
 		// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
@@ -1086,6 +1102,35 @@ func (sm *StateManager) OpenFile(
 		Stateid: resultStateid,
 		RFlags:  rflags,
 	}, nil
+}
+
+// shareConflictLocked reports whether granting an OPEN with the requested
+// share_access / share_deny on fileHandle would conflict with an open held by a
+// DIFFERENT open-owner. A conflict exists when the requested access is denied by
+// an existing open, or the requested deny would exclude an existing open's
+// access (RFC 7530 Section 9.7; mirrors Linux nfsd nfs4_share_conflict /
+// test_share). Opens by the requesting owner (ownerKey) are skipped because
+// share bits accumulate per owner on the same file.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) shareConflictLocked(
+	ownerKey openOwnerKey,
+	fileHandle []byte,
+	reqAccess, reqDeny uint32,
+) bool {
+	for _, os := range sm.openStateByOther {
+		if !bytes.Equal(os.FileHandle, fileHandle) {
+			continue
+		}
+		// Same owner: bits are OR-merged, never in conflict with themselves.
+		if os.Owner != nil && makeOwnerKey(os.Owner.ClientID, os.Owner.OwnerData) == ownerKey {
+			continue
+		}
+		if reqAccess&os.ShareDeny != 0 || reqDeny&os.ShareAccess != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // CacheOpenResult stores the cached result for an open-owner so that

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -977,22 +977,6 @@ func (sm *StateManager) OpenFile(
 	ownerKey := makeOwnerKey(clientID, ownerData)
 	owner, ownerExists := sm.openOwners[ownerKey]
 
-	// Enforce share reservations across open-owners (RFC 7530 Section 9.7 /
-	// Section 16.16.5; Linux nfsd nfs4_share_conflict). Reclaim (CLAIM_PREVIOUS)
-	// re-establishes state the client previously held and is exempt. The scan
-	// runs under sm.mu so it observes a consistent snapshot of every live open;
-	// opens by THIS owner are skipped because share bits accumulate per owner.
-	if claimType != types.CLAIM_PREVIOUS {
-		if conflict := sm.shareConflictLocked(ownerKey, fileHandle, shareAccess, shareDeny); conflict {
-			logger.Debug("OpenFile: share reservation conflict",
-				"client_id", clientID,
-				"owner", string(ownerData),
-				"req_access", shareAccess,
-				"req_deny", shareDeny)
-			return nil, ErrShareDenied
-		}
-	}
-
 	if ownerExists {
 		// Existing owner: validate seqid
 		// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
@@ -1033,6 +1017,26 @@ func (sm *StateManager) OpenFile(
 		// Register with client record if available
 		if clientRecord != nil {
 			clientRecord.OpenOwners[string(ownerData)] = owner
+		}
+	}
+
+	// Enforce share reservations across open-owners (RFC 7530 Section 9.7 /
+	// Section 16.16.5; Linux nfsd nfs4_share_conflict). This runs AFTER the
+	// owner seqid/replay gate above: a replayed OPEN must return its cached
+	// result and a bad seqid must return NFS4ERR_BAD_SEQID — neither may be
+	// turned into NFS4ERR_SHARE_DENIED by a conflict that arose after the
+	// original request. Reclaim (CLAIM_PREVIOUS) re-establishes prior state and
+	// is exempt. The scan runs under sm.mu so it observes a consistent snapshot
+	// of every live open; opens by THIS owner are skipped (share bits
+	// accumulate per owner).
+	if claimType != types.CLAIM_PREVIOUS {
+		if conflict := sm.shareConflictLocked(ownerKey, fileHandle, shareAccess, shareDeny); conflict {
+			logger.Debug("OpenFile: share reservation conflict",
+				"client_id", clientID,
+				"owner", string(ownerData),
+				"req_access", shareAccess,
+				"req_deny", shareDeny)
+			return nil, ErrShareDenied
 		}
 	}
 

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -1,0 +1,197 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// ============================================================================
+// H2 — share reservation conflict enforcement across open-owners
+// ============================================================================
+
+// openConfirmed opens fileHandle for (clientID, owner) and confirms the owner so
+// subsequent opens by the same owner don't trip the seqid machinery. It returns
+// the confirmed stateid.
+func openConfirmed(t *testing.T, sm *StateManager, clientID uint64, owner, fileHandle []byte, access, deny uint32) types.Stateid4 {
+	t.Helper()
+	res, err := sm.OpenFile(clientID, owner, 1, fileHandle, access, deny, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile(%s): %v", owner, err)
+	}
+	confirmed, err := sm.ConfirmOpen(&res.Stateid, 2)
+	if err != nil {
+		t.Fatalf("ConfirmOpen(%s): %v", owner, err)
+	}
+	return *confirmed
+}
+
+func expectShareDenied(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("OpenFile should have returned NFS4ERR_SHARE_DENIED")
+	}
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("expected *NFS4StateError, got %T", err)
+	}
+	if stateErr.Status != types.NFS4ERR_SHARE_DENIED {
+		t.Errorf("status = %d, want NFS4ERR_SHARE_DENIED (%d)", stateErr.Status, types.NFS4ERR_SHARE_DENIED)
+	}
+}
+
+func TestOpenFile_ShareDeny_BlocksConflictingAccessAcrossOwners(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-deny-write")
+
+	// Owner A opens WRITE and denies WRITE to everyone else.
+	openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
+
+	// Owner B's OPEN requesting WRITE access must be refused.
+	_, err := sm.OpenFile(0, []byte("ownerB"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	expectShareDenied(t, err)
+}
+
+func TestOpenFile_ShareDeny_RequestedDenyExcludesExistingAccess(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-existing-read")
+
+	// Owner A holds a plain READ open with no deny.
+	openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+
+	// Owner B tries to open and DENY_READ — its requested deny excludes A's
+	// existing read access, so the OPEN must be refused.
+	_, err := sm.OpenFile(0, []byte("ownerB"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_READ, types.CLAIM_NULL)
+	expectShareDenied(t, err)
+}
+
+func TestOpenFile_ShareDeny_NonConflictingCombosSucceed(t *testing.T) {
+	t.Run("read_deny_none_then_read", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-ok-read-read")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+		// Second reader, no deny — no conflict.
+		if _, err := sm.OpenFile(0, []byte("ownerB"), 1, fh,
+			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+			t.Fatalf("non-conflicting OPEN should succeed: %v", err)
+		}
+	})
+
+	t.Run("deny_write_then_read", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-ok-denywrite-read")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_WRITE)
+		// B requests READ only; A denies WRITE, not READ — no conflict.
+		if _, err := sm.OpenFile(0, []byte("ownerB"), 1, fh,
+			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+			t.Fatalf("non-conflicting OPEN should succeed: %v", err)
+		}
+	})
+}
+
+func TestOpenFile_ShareDeny_SameOwnerAccumulatesNoConflict(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-same-owner")
+
+	// Owner A opens WRITE + DENY_WRITE.
+	openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
+
+	// The SAME owner re-opening the same file with WRITE must NOT self-conflict;
+	// bits accumulate per owner (RFC 7530 Section 9.1.7).
+	if _, err := sm.OpenFile(0, []byte("ownerA"), 3, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("same-owner re-open should not conflict: %v", err)
+	}
+}
+
+func TestOpenFile_ShareDeny_ReleasedAfterClose(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-deny-released")
+
+	// Owner A opens with DENY_WRITE then closes.
+	aStateid := openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
+	if _, err := sm.CloseFile(&aStateid, 3); err != nil {
+		t.Fatalf("CloseFile: %v", err)
+	}
+
+	// With A's reservation gone, owner B may now open WRITE.
+	if _, err := sm.OpenFile(0, []byte("ownerB"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("OPEN after conflicting open closed should succeed: %v", err)
+	}
+}
+
+func TestOpenFile_ShareDeny_DifferentFilesDoNotConflict(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	openConfirmed(t, sm, 0, []byte("ownerA"), []byte("fh-file-1"),
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
+
+	// A deny on file-1 must not affect an OPEN of file-2.
+	if _, err := sm.OpenFile(0, []byte("ownerB"), 1, []byte("fh-file-2"),
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("OPEN of a different file should succeed: %v", err)
+	}
+}
+
+// ============================================================================
+// H3 — special-stateid op-family gating in ValidateStateid
+// ============================================================================
+
+func readBypassStateid() *types.Stateid4 {
+	sid := &types.Stateid4{Seqid: 0xFFFFFFFF}
+	for i := range sid.Other {
+		sid.Other[i] = 0xFF
+	}
+	return sid
+}
+
+func TestValidateStateid_ReadBypass_AllowedOnReadRejectedOnWrite(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	// READ: all-ones is permitted (returns nil openState, nil error).
+	openState, err := sm.ValidateStateid(readBypassStateid(), nil, StateidOpRead)
+	if err != nil {
+		t.Fatalf("read-bypass on READ should be allowed: %v", err)
+	}
+	if openState != nil {
+		t.Error("special stateid should return nil openState")
+	}
+
+	// WRITE: all-ones MUST be rejected with NFS4ERR_BAD_STATEID.
+	_, err = sm.ValidateStateid(readBypassStateid(), nil, StateidOpWrite)
+	if err == nil {
+		t.Fatal("read-bypass on WRITE should be rejected")
+	}
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("expected *NFS4StateError, got %T", err)
+	}
+	if stateErr.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID (%d)", stateErr.Status, types.NFS4ERR_BAD_STATEID)
+	}
+}
+
+func TestValidateStateid_Anonymous_AllowedOnReadAndWrite(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	anon := &types.Stateid4{Seqid: 0} // all-zeros other
+
+	for _, op := range []StateidOp{StateidOpRead, StateidOpWrite} {
+		openState, err := sm.ValidateStateid(anon, nil, op)
+		if err != nil {
+			t.Fatalf("anonymous stateid (op=%d) should be allowed: %v", op, err)
+		}
+		if openState != nil {
+			t.Errorf("anonymous stateid (op=%d) should return nil openState", op)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -50,6 +50,23 @@ var (
 	ErrStaleStateid = &NFS4StateError{Status: types.NFS4ERR_STALE_STATEID, Message: "stale stateid"}
 	ErrExpired      = &NFS4StateError{Status: types.NFS4ERR_EXPIRED, Message: "lease expired"}
 	ErrBadSeqid     = &NFS4StateError{Status: types.NFS4ERR_BAD_SEQID, Message: "bad seqid"}
+	ErrShareDenied  = &NFS4StateError{Status: types.NFS4ERR_SHARE_DENIED, Message: "share reservation conflict"}
+)
+
+// StateidOp identifies the operation family using a stateid. It controls which
+// special stateids are accepted: per RFC 7530 Section 9.1.4.3 the all-ones
+// "READ bypass" stateid is valid only on READ; using it on a write-family
+// operation (WRITE / SETATTR-size / LOCK) MUST yield NFS4ERR_BAD_STATEID.
+type StateidOp uint8
+
+const (
+	// StateidOpRead is a READ-family operation. Both the anonymous (all-zeros)
+	// and the READ-bypass (all-ones) special stateids are permitted.
+	StateidOpRead StateidOp = iota
+
+	// StateidOpWrite is a write-family operation (WRITE, SETATTR size change,
+	// LOCK). The anonymous stateid is permitted; the READ-bypass stateid is not.
+	StateidOpWrite
 )
 
 // ============================================================================
@@ -107,10 +124,14 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 // Stateid Validation
 // ============================================================================
 
-// ValidateStateid validates a stateid and returns the associated OpenState.
+// ValidateStateid validates a stateid for the given operation family and
+// returns the associated OpenState.
 //
 // Per RFC 7530 Section 9.1.4, validation checks:
-//  1. Special stateids bypass validation (return nil, nil)
+//  1. Special stateids: the anonymous (all-zeros) stateid bypasses validation
+//     on any op; the READ-bypass (all-ones) stateid is accepted ONLY when
+//     op == StateidOpRead and otherwise rejected with NFS4ERR_BAD_STATEID
+//     (RFC 7530 Section 9.1.4.3). Both return (nil, nil) when accepted.
 //  2. Route by type tag: open stateids -> openStateByOther, delegation -> delegByOther
 //  3. If not found -> NFS4ERR_BAD_STATEID (or NFS4ERR_STALE_STATEID for wrong epoch)
 //  4. Compare seqid: < current -> NFS4ERR_OLD_STATEID; > current -> NFS4ERR_BAD_STATEID
@@ -122,9 +143,19 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 // layer (PrepareWrite) still apply.
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
-	// Step 1: Special stateids bypass validation
-	if stateid.IsSpecialStateid() {
+func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byte, op StateidOp) (*OpenState, error) {
+	// Step 1: Special stateids.
+	// The READ-bypass (all-ones) stateid is READ-only: reject it on
+	// write-family operations so a client cannot use it to bypass share-mode
+	// enforcement and byte-range locks (RFC 7530 Section 9.1.4.3).
+	if stateid.IsReadBypassStateid() {
+		if op != StateidOpRead {
+			return nil, ErrBadStateid
+		}
+		return nil, nil
+	}
+	// The anonymous (all-zeros) stateid is permitted on READ and WRITE.
+	if stateid.IsAnonymousStateid() {
 		return nil, nil
 	}
 

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -117,7 +117,7 @@ func TestValidateStateid_SpecialStateid_AllZeros(t *testing.T) {
 
 	stateid := &types.Stateid4{Seqid: 0}
 	// Other is default zero
-	openState, err := sm.ValidateStateid(stateid, nil)
+	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid for all-zeros: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestValidateStateid_SpecialStateid_AllOnes(t *testing.T) {
 		stateid.Other[i] = 0xFF
 	}
 
-	openState, err := sm.ValidateStateid(stateid, nil)
+	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid for all-ones READ bypass: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestValidateStateid_NotFound(t *testing.T) {
 	other := sm.generateStateidOther(StateTypeOpen)
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for unknown stateid")
 	}
@@ -178,7 +178,7 @@ func TestValidateStateid_StaleStateid(t *testing.T) {
 	other[3] = 0xFF
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for stale epoch")
 	}
@@ -204,7 +204,7 @@ func TestValidateStateid_Success(t *testing.T) {
 	}
 
 	// Validate the returned stateid
-	openState, err := sm.ValidateStateid(&result.Stateid, fileHandle)
+	openState, err := sm.ValidateStateid(&result.Stateid, fileHandle, StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestValidateStateid_OldSeqid(t *testing.T) {
 
 	// Now use the OLD seqid (1), current is 2
 	oldStateid := result.Stateid // has seqid=1
-	_, err = sm.ValidateStateid(&oldStateid, nil)
+	_, err = sm.ValidateStateid(&oldStateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for old seqid")
 	}
@@ -260,7 +260,7 @@ func TestValidateStateid_FutureSeqid(t *testing.T) {
 	// Use a seqid higher than current
 	futureStateid := result.Stateid
 	futureStateid.Seqid = 99
-	_, err = sm.ValidateStateid(&futureStateid, nil)
+	_, err = sm.ValidateStateid(&futureStateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for future seqid")
 	}
@@ -286,7 +286,7 @@ func TestValidateStateid_FilehandleMismatch(t *testing.T) {
 
 	// Validate with different filehandle
 	wrongFH := []byte("wrong-handle-456")
-	_, err = sm.ValidateStateid(&result.Stateid, wrongFH)
+	_, err = sm.ValidateStateid(&result.Stateid, wrongFH, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for filehandle mismatch")
 	}
@@ -312,7 +312,7 @@ func TestValidateStateid_DelegationStateid_Success(t *testing.T) {
 	deleg := sm.GrantDelegation(100, fileHandle, types.OPEN_DELEGATE_WRITE)
 
 	// Validate the delegation stateid
-	openState, err := sm.ValidateStateid(&deleg.Stateid, fileHandle)
+	openState, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid for delegation: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestValidateStateid_DelegationStateid_NotFound(t *testing.T) {
 	other := sm.generateStateidOther(StateTypeDeleg)
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for unknown delegation stateid")
 	}
@@ -353,7 +353,7 @@ func TestValidateStateid_DelegationStateid_Revoked(t *testing.T) {
 	deleg.Revoked = true
 	sm.mu.Unlock()
 
-	_, err := sm.ValidateStateid(&deleg.Stateid, fileHandle)
+	_, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for revoked delegation")
 	}
@@ -373,7 +373,7 @@ func TestValidateStateid_DelegationStateid_FilehandleMismatch(t *testing.T) {
 	deleg := sm.GrantDelegation(100, []byte("fh-deleg-mismatch"), types.OPEN_DELEGATE_READ)
 
 	wrongFH := []byte("fh-wrong-handle")
-	_, err := sm.ValidateStateid(&deleg.Stateid, wrongFH)
+	_, err := sm.ValidateStateid(&deleg.Stateid, wrongFH, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for filehandle mismatch")
 	}
@@ -396,7 +396,7 @@ func TestValidateStateid_DelegationStateid_OldSeqid(t *testing.T) {
 	// to trigger OLD_STATEID. We manually bump the delegation seqid first.
 	deleg.Stateid.Seqid = 3 // simulate the server having advanced the seqid
 	oldStateid := types.Stateid4{Seqid: 1, Other: deleg.Stateid.Other}
-	_, err := sm.ValidateStateid(&oldStateid, nil)
+	_, err := sm.ValidateStateid(&oldStateid, nil, StateidOpRead)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for old delegation seqid")
 	}
@@ -428,7 +428,7 @@ func TestValidateStateid_Seqid0_AcceptedAsAny(t *testing.T) {
 	// Per RFC 8881 Section 8.2.2, seqid=0 means "any seqid" and
 	// MUST be accepted regardless of the current seqid value.
 	anyStateid := types.Stateid4{Seqid: 0, Other: result.Stateid.Other}
-	_, err = sm.ValidateStateid(&anyStateid, nil)
+	_, err = sm.ValidateStateid(&anyStateid, nil, StateidOpRead)
 	if err != nil {
 		t.Errorf("ValidateStateid should accept seqid=0 (any), got: %v", err)
 	}
@@ -1057,7 +1057,7 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	}
 
 	// Validate the confirmed stateid
-	openState, err := sm.ValidateStateid(confirmedStateid, []byte("file-handle-test"))
+	openState, err := sm.ValidateStateid(confirmedStateid, []byte("file-handle-test"), StateidOpRead)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -194,6 +194,22 @@ func (s *Stateid4) IsSpecialStateid() bool {
 	return s.isAnonymous() || s.isReadBypass()
 }
 
+// IsAnonymousStateid reports whether the stateid is the anonymous special
+// stateid (seqid=0, other=all-zeros). Per RFC 7530 Section 9.1.4.3 it requests
+// a standard access check with no associated open/lock state and is permitted
+// on both READ and WRITE.
+func (s *Stateid4) IsAnonymousStateid() bool {
+	return s.isAnonymous()
+}
+
+// IsReadBypassStateid reports whether the stateid is the READ-bypass special
+// stateid (seqid=0xFFFFFFFF, other=all-ones). Per RFC 7530 Section 9.1.4.3 it
+// bypasses share-mode and byte-range-lock checks and is valid ONLY on READ;
+// callers MUST reject it on write-family operations with NFS4ERR_BAD_STATEID.
+func (s *Stateid4) IsReadBypassStateid() bool {
+	return s.isReadBypass()
+}
+
 // isAnonymous returns true if the stateid is the anonymous stateid
 // (seqid=0, other=all-zeros).
 func (s *Stateid4) isAnonymous() bool {


### PR DESCRIPTION
Area-4 NFSv4 PR-B2. Three interlocking share-access / share-reservation enforcement gaps, all in `internal/adapter/nfs/v4`.

## H2 — `share_deny` never enforced across open-owners
`NFS4ERR_SHARE_DENIED` was defined but had **zero call sites**; OPEN only OR-merged share bits for the *same* owner and never scanned for a conflicting deny held by another owner. DENY_* was a silent no-op — concurrent writers could corrupt a file an owner believed reserved, and cross-protocol SMB/NFS deny semantics were broken.

**Fix:** `StateManager.OpenFile` now calls `shareConflictLocked` under `sm.mu` before creating/merging state. A conflict exists when `requestedAccess & existingDeny != 0` or `requestedDeny & existingAccess != 0` for an open held by a *different* open-owner on the same file → `NFS4ERR_SHARE_DENIED`. Reclaim (`CLAIM_PREVIOUS`) is exempt. The OPEN handler also validates `share_access ∈ {READ,WRITE,BOTH}` and `share_deny ⊆ {READ,WRITE}` at decode → `NFS4ERR_INVAL`.

**Cross-check:** RFC 7530 §9.7 / §16.16.5; Linux nfsd `nfs4_share_conflict` / `test_share`.

## H3 — all-ones (READ-bypass) special stateid accepted on WRITE/SETATTR
`ValidateStateid` short-circuited *any* special stateid to `(nil, nil)`, so a `nil` openState skipped the `SHARE_ACCESS_WRITE` check and a client could write/truncate with the READ-only all-ones stateid, bypassing share-mode and byte-range locks.

**Fix:** `ValidateStateid` now takes a `StateidOp` (read vs write family). The all-ones READ-bypass stateid is permitted only on READ and rejected with `NFS4ERR_BAD_STATEID` on write-family ops; the all-zeros anonymous stateid stays valid on both. WRITE passes `StateidOpWrite`; SETATTR rejects the read-bypass stateid when a size change is requested. LOCK already looks up real open stateids in `openStateByOther`, so special stateids fail there naturally.

**Cross-check:** RFC 7530 §9.1.4.3.

## H19 — v4 READ discarded openState → no `SHARE_ACCESS_READ` check
`read.go` threw away the `ValidateStateid` openState, so a write-only open could READ via its stateid.

**Fix:** READ now captures the openState and returns `NFS4ERR_OPENMODE` when a regular open stateid lacks `OPEN4_SHARE_ACCESS_READ`. Special stateids (nil openState) bypass the check, as required.

**Cross-check:** RFC 7530 §16.25.4 (symmetric to the WRITE `OPENMODE` guard).

## Tests
State layer (`v4/state/shareres_test.go`): cross-owner deny→`SHARE_DENIED`; requested-deny-excludes-existing-access; non-conflicting combos succeed; same-owner accumulation never self-conflicts; reservation released after CLOSE; different files don't conflict; read-bypass allowed on READ / rejected on WRITE; anonymous allowed on both.

Handler layer (`v4/handlers/shareres_test.go`): WRITE/SETATTR(size) with all-ones → `BAD_STATEID`; READ with all-ones → OK; WRITE with anonymous → OK; write-only open READ → `OPENMODE`; read-write open READ → OK; bad `share_access`/`share_deny` → `INVAL`; end-to-end cross-owner DENY_WRITE blocks a second writer.

`go test -race ./internal/adapter/nfs/...` green; `gofmt -s` / `go vet` / `golangci-lint` clean. Scoped to `internal/adapter/nfs/v4` only.