### PR TITLE
fix(metadata): transaction atomicity — RemoveFile TOCTOU, Move rollback, badger txn reads, memory rollback, usedBytes retry (area-6 PR-B3)

### DIFF
--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -566,14 +566,18 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 				// POSIX: ctime must be updated when link count changes
 				linkCount, _ := tx.GetLinkCount(ctx.Context, dstHandle)
 				now := time.Now()
-				if linkCount <= 1 {
-					_ = tx.SetLinkCount(ctx.Context, dstHandle, 0)
-				} else {
-					_ = tx.SetLinkCount(ctx.Context, dstHandle, linkCount-1)
+				newCount := uint32(0)
+				if linkCount > 1 {
+					newCount = linkCount - 1
+				}
+				if err := tx.SetLinkCount(ctx.Context, dstHandle, newCount); err != nil {
+					return err
 				}
 				// Update ctime on the file being unlinked (affects remaining hard links)
 				dstFile.Ctime = now
-				_ = tx.PutFile(ctx.Context, dstFile)
+				if err := tx.PutFile(ctx.Context, dstFile); err != nil {
+					return err
+				}
 			}
 
 			// Remove destination from children
@@ -592,48 +596,68 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 			return err
 		}
 
-		// Update parent reference if directories are different
+		// Update parent reference if directories are different. These are
+		// tx-critical: a failed SetParent/SetLinkCount leaves the entry
+		// relinked but the parent pointer or directory nlink wrong, which a
+		// dir move can skew permanently. Return the error so the whole rename
+		// rolls back atomically.
 		if string(fromDir) != string(toDir) {
-			// Non-fatal error, ignore
-			_ = tx.SetParent(ctx.Context, srcHandle, toDir)
+			if err := tx.SetParent(ctx.Context, srcHandle, toDir); err != nil {
+				return err
+			}
 
 			// Update link counts for directory moves
 			if srcFile.Type == FileTypeDirectory {
 				// Decrement source parent's link count
 				srcLinkCount, _ := tx.GetLinkCount(ctx.Context, fromDir)
 				if srcLinkCount > 0 {
-					_ = tx.SetLinkCount(ctx.Context, fromDir, srcLinkCount-1)
+					if err := tx.SetLinkCount(ctx.Context, fromDir, srcLinkCount-1); err != nil {
+						return err
+					}
 				}
 				// Increment destination parent's link count
 				dstLinkCount, _ := tx.GetLinkCount(ctx.Context, toDir)
-				_ = tx.SetLinkCount(ctx.Context, toDir, dstLinkCount+1)
+				if err := tx.SetLinkCount(ctx.Context, toDir, dstLinkCount+1); err != nil {
+					return err
+				}
 			}
 		}
 
-		// Update path and timestamps (non-fatal errors, ignore)
+		// Update path and timestamps. PutFile(srcFile) is tx-critical: a stale
+		// File.Path breaks the Path-keyed postgres snapshot/restore and the
+		// descendant-path rewrite below. Return the error so a failure rolls
+		// the whole rename back rather than committing a relinked entry with
+		// the old Path.
 		now := time.Now()
 		oldPath := srcFile.Path
 		srcFile.Path = destPath
 		srcFile.Ctime = now
-		_ = tx.PutFile(ctx.Context, srcFile)
+		if err := tx.PutFile(ctx.Context, srcFile); err != nil {
+			return err
+		}
 
-		// For directory renames, recursively update all descendants' paths
+		// For directory renames, recursively update all descendants' paths.
+		// Propagate the error: a partial descendant rewrite leaves stale
+		// child Paths that diverge from the parent, corrupting the Path-keyed
+		// postgres namespace. Roll the rename back instead.
 		if srcFile.Type == FileTypeDirectory {
 			if err := s.updateDescendantPaths(ctx.Context, tx, srcHandle, oldPath, destPath); err != nil {
-				logger.Debug("Move: failed to update descendant paths (non-fatal)",
-					"error", err, "oldPrefix", oldPath, "newPrefix", destPath)
+				return err
 			}
 		}
 
 		srcDir.Mtime = now
 		srcDir.Ctime = now
-		_ = tx.PutFile(ctx.Context, srcDir)
+		if err := tx.PutFile(ctx.Context, srcDir); err != nil {
+			return err
+		}
 
 		if string(fromDir) != string(toDir) {
 			dstDir.Mtime = now
 			dstDir.Ctime = now
-			// Non-fatal error, ignore
-			_ = tx.PutFile(ctx.Context, dstDir)
+			if err := tx.PutFile(ctx.Context, dstDir); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -563,8 +563,14 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 				}
 			} else {
 				// For files, decrement link count or set to 0
-				// POSIX: ctime must be updated when link count changes
-				linkCount, _ := tx.GetLinkCount(ctx.Context, dstHandle)
+				// POSIX: ctime must be updated when link count changes.
+				// The read is tx-critical: a failed GetLinkCount must roll the
+				// rename back, not fall through with count 0 and commit a wrong
+				// link count.
+				linkCount, err := tx.GetLinkCount(ctx.Context, dstHandle)
+				if err != nil {
+					return err
+				}
 				now := time.Now()
 				newCount := uint32(0)
 				if linkCount > 1 {
@@ -608,15 +614,23 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 
 			// Update link counts for directory moves
 			if srcFile.Type == FileTypeDirectory {
-				// Decrement source parent's link count
-				srcLinkCount, _ := tx.GetLinkCount(ctx.Context, fromDir)
+				// Decrement source parent's link count. The read is tx-critical
+				// (a failed GetLinkCount must abort the rename, not silently
+				// skip the parent-nlink update).
+				srcLinkCount, err := tx.GetLinkCount(ctx.Context, fromDir)
+				if err != nil {
+					return err
+				}
 				if srcLinkCount > 0 {
 					if err := tx.SetLinkCount(ctx.Context, fromDir, srcLinkCount-1); err != nil {
 						return err
 					}
 				}
-				// Increment destination parent's link count
-				dstLinkCount, _ := tx.GetLinkCount(ctx.Context, toDir)
+				// Increment destination parent's link count.
+				dstLinkCount, err := tx.GetLinkCount(ctx.Context, toDir)
+				if err != nil {
+					return err
+				}
 				if err := tx.SetLinkCount(ctx.Context, toDir, dstLinkCount+1); err != nil {
 					return err
 				}

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -81,13 +81,6 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 		return nil, err
 	}
 
-	// Get current link count
-	linkCount, err := store.GetLinkCount(ctx.Context, fileHandle)
-	if err != nil {
-		// If we can't get link count, assume 1
-		linkCount = 1
-	}
-
 	now := time.Now()
 
 	// Prepare return value
@@ -100,6 +93,20 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 
 	// Execute all write operations in a single transaction for better performance.
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Read the link count INSIDE the transaction so the read, the
+		// branch decision, and the write are atomic. Reading it outside the
+		// tx is a TOCTOU race with CreateHardLink: a concurrent link bump in
+		// the window would leave us writing a stale (decremented) count and
+		// dropping nlink to 0 while a valid link still references the file,
+		// making the content eligible for deletion. Reading via tx.GetLinkCount
+		// also registers the key for the backend's read-write conflict
+		// detection so a racing writer triggers an automatic retry.
+		linkCount, lcErr := tx.GetLinkCount(ctx.Context, fileHandle)
+		if lcErr != nil {
+			// If we can't get link count, assume 1.
+			linkCount = 1
+		}
+
 		// Handle link count
 		if linkCount > 1 {
 			// File has other hard links, just decrement count

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -414,50 +414,10 @@ func (s *BadgerMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 // Uses the fb-local: secondary index for O(local) iteration instead of
 // scanning all fb: entries. This eliminates the BadgerDB full-table scan
 // that was the root cause of sequential write throughput degradation.
-func (s *BadgerMetadataStore) ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
-	// olderThan <= 0 means "no age filter" — return every local block.
-	var cutoff time.Time
-	filterByAge := olderThan > 0
-	if filterByAge {
-		cutoff = time.Now().Add(-olderThan)
-	}
+func (s *BadgerMetadataStore) ListPending(_ context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
 	var result []*metadata.FileBlock
 	err := s.db.View(func(txn *badger.Txn) error {
-		prefix := []byte(fileBlockLocalPrefix)
-		opts := badger.DefaultIteratorOptions
-		opts.Prefix = prefix
-		opts.PrefetchValues = false // Keys only — values are empty
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			// Extract block ID from key: "fb-local:{id}" → "{id}"
-			id := string(it.Item().Key()[len(prefix):])
-
-			// Look up the actual FileBlock
-			fbItem, err := txn.Get([]byte(fileBlockPrefix + id))
-			if err != nil {
-				continue // Index stale, block deleted
-			}
-
-			var block metadata.FileBlock
-			if err := fbItem.Value(func(val []byte) error {
-				return json.Unmarshal(val, &block)
-			}); err != nil {
-				continue
-			}
-
-			if !block.HasLocalFile() {
-				continue
-			}
-			if filterByAge && !block.LastAccess.Before(cutoff) {
-				continue
-			}
-			result = append(result, &block)
-			if limit > 0 && len(result) >= limit {
-				break
-			}
-		}
+		result = listPendingTxn(txn, olderThan, limit)
 		return nil
 	})
 	return result, err
@@ -467,52 +427,14 @@ func (s *BadgerMetadataStore) ListPending(ctx context.Context, olderThan time.Du
 // Uses the fb-file:{payloadID}: secondary index for efficient O(file_blocks) queries.
 // Not on the narrowed FileBlockStore interface;
 // kept as a backend method for engine-internal callers.
-func (s *BadgerMetadataStore) ListFileBlocks(ctx context.Context, payloadID string) ([]*metadata.FileBlock, error) {
+func (s *BadgerMetadataStore) ListFileBlocks(_ context.Context, payloadID string) ([]*metadata.FileBlock, error) {
 	var result []*metadata.FileBlock
 	err := s.db.View(func(txn *badger.Txn) error {
-		prefix := []byte(fileBlockFilePrefix + payloadID + ":")
-		opts := badger.DefaultIteratorOptions
-		opts.Prefix = prefix
-		opts.PrefetchValues = true
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			// Value is the block ID
-			var blockID string
-			if err := it.Item().Value(func(val []byte) error {
-				blockID = string(val)
-				return nil
-			}); err != nil {
-				continue
-			}
-
-			// Fetch the actual FileBlock
-			fbItem, err := txn.Get([]byte(fileBlockPrefix + blockID))
-			if err != nil {
-				continue // Index stale, block deleted
-			}
-
-			var block metadata.FileBlock
-			if err := fbItem.Value(func(val []byte) error {
-				return json.Unmarshal(val, &block)
-			}); err != nil {
-				continue
-			}
-			result = append(result, &block)
-		}
+		result = listFileBlocksTxn(txn, payloadID)
 		return nil
 	})
 	if err != nil {
 		return nil, err
-	}
-	// Keys are lexicographically sorted (fb-file:{payloadID}:0, :1, :10, :2...)
-	// which gives wrong numeric order for multi-digit indices. Sort by parsed index.
-	sort.Slice(result, func(i, j int) bool {
-		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
-	})
-	if result == nil {
-		return []*metadata.FileBlock{}, nil
 	}
 	return result, nil
 }
@@ -524,30 +446,120 @@ func (s *BadgerMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 // implementation unchanged.
 func (s *BadgerMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error {
 	return s.db.View(func(txn *badger.Txn) error {
-		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = true
-		opts.PrefetchSize = 256
-		prefix := []byte(fileBlockPrefix)
-		opts.Prefix = prefix
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("enumerate file blocks: %w", err)
-			}
-			var block metadata.FileBlock
-			if err := it.Item().Value(func(val []byte) error {
-				return json.Unmarshal(val, &block)
-			}); err != nil {
-				return fmt.Errorf("decode file block: %w", err)
-			}
-			if err := fn(block.Hash); err != nil {
-				return err
-			}
-		}
-		return nil
+		return enumerateFileBlocksTxn(ctx, txn, fn)
 	})
+}
+
+// listPendingTxn / listFileBlocksTxn / enumerateFileBlocksTxn iterate a given
+// *badger.Txn so the store-level methods (over a db.View snapshot) and the
+// transaction-level methods (over the active write txn, for read-after-write)
+// share one implementation. Binding to the caller's txn is what lets a
+// tx.Put be observed by a later tx.ListFileBlocks in the same WithTransaction.
+func listPendingTxn(txn *badger.Txn, olderThan time.Duration, limit int) []*metadata.FileBlock {
+	// olderThan <= 0 means "no age filter" — return every local block.
+	var cutoff time.Time
+	filterByAge := olderThan > 0
+	if filterByAge {
+		cutoff = time.Now().Add(-olderThan)
+	}
+	var result []*metadata.FileBlock
+	prefix := []byte(fileBlockLocalPrefix)
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = prefix
+	opts.PrefetchValues = false // Keys only — values are empty
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		id := string(it.Item().Key()[len(prefix):])
+		fbItem, err := txn.Get([]byte(fileBlockPrefix + id))
+		if err != nil {
+			continue // Index stale, block deleted
+		}
+		var block metadata.FileBlock
+		if err := fbItem.Value(func(val []byte) error {
+			return json.Unmarshal(val, &block)
+		}); err != nil {
+			continue
+		}
+		if !block.HasLocalFile() {
+			continue
+		}
+		if filterByAge && !block.LastAccess.Before(cutoff) {
+			continue
+		}
+		result = append(result, &block)
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+func listFileBlocksTxn(txn *badger.Txn, payloadID string) []*metadata.FileBlock {
+	var result []*metadata.FileBlock
+	prefix := []byte(fileBlockFilePrefix + payloadID + ":")
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = prefix
+	opts.PrefetchValues = true
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		var blockID string
+		if err := it.Item().Value(func(val []byte) error {
+			blockID = string(val)
+			return nil
+		}); err != nil {
+			continue
+		}
+		fbItem, err := txn.Get([]byte(fileBlockPrefix + blockID))
+		if err != nil {
+			continue // Index stale, block deleted
+		}
+		var block metadata.FileBlock
+		if err := fbItem.Value(func(val []byte) error {
+			return json.Unmarshal(val, &block)
+		}); err != nil {
+			continue
+		}
+		result = append(result, &block)
+	}
+	// Keys are lexicographically sorted (fb-file:{payloadID}:0, :1, :10, :2...)
+	// which gives wrong numeric order for multi-digit indices. Sort by parsed index.
+	sort.Slice(result, func(i, j int) bool {
+		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
+	})
+	if result == nil {
+		return []*metadata.FileBlock{}
+	}
+	return result
+}
+
+func enumerateFileBlocksTxn(ctx context.Context, txn *badger.Txn, fn func(blockstore.ContentHash) error) error {
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchValues = true
+	opts.PrefetchSize = 256
+	prefix := []byte(fileBlockPrefix)
+	opts.Prefix = prefix
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file blocks: %w", err)
+		}
+		var block metadata.FileBlock
+		if err := it.Item().Value(func(val []byte) error {
+			return json.Unmarshal(val, &block)
+		}); err != nil {
+			return fmt.Errorf("decode file block: %w", err)
+		}
+		if err := fn(block.Hash); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // splitBlockID splits a block ID into (payloadID, blockIdx) on the LAST
@@ -854,17 +866,27 @@ func (tx *badgerTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 	return &block, nil
 }
 
-// ListPending, ListFileBlocks, EnumerateFileBlocks are read-only and
-// don't require tx-binding for correctness; keep them on the public
-// store path.
+// ListPending, ListFileBlocks, EnumerateFileBlocks iterate the active txn
+// (tx.txn) rather than opening a fresh db.View snapshot. Delegating to the
+// store path took a snapshot at call time, so a tx.Put followed by
+// tx.ListFileBlocks in the same WithTransaction missed the uncommitted write —
+// a cross-backend divergence vs memory, whose list helpers read live maps
+// under the held lock. Binding to tx.txn gives read-after-write within the tx
+// (BadgerDB transactions see their own pending writes).
 func (tx *badgerTransaction) ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
-	return tx.store.ListPending(ctx, olderThan, limit)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return listPendingTxn(tx.txn, olderThan, limit), nil
 }
 
 func (tx *badgerTransaction) ListFileBlocks(ctx context.Context, payloadID string) ([]*metadata.FileBlock, error) {
-	return tx.store.ListFileBlocks(ctx, payloadID)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return listFileBlocksTxn(tx.txn, payloadID), nil
 }
 
 func (tx *badgerTransaction) EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error {
-	return tx.store.EnumerateFileBlocks(ctx, fn)
+	return enumerateFileBlocksTxn(ctx, tx.txn, fn)
 }

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -198,7 +198,8 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 		return err
 	}
 
-	return s.db.Update(func(txn *badgerdb.Txn) error {
+	var freedBytes int64
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
 		if err == badgerdb.ErrKeyNotFound {
 			return &metadata.StoreError{
@@ -211,12 +212,22 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 			return err
 		}
 
-		if err := s.deleteShareFiles(txn, shareName); err != nil {
+		freed, err := s.deleteShareFiles(txn, shareName)
+		if err != nil {
 			return err
 		}
+		freedBytes = freed
 
 		return txn.Delete(keyShare(shareName))
 	})
+	if err != nil {
+		return err
+	}
+	// Apply the usedBytes decrement once, after a successful commit.
+	if freedBytes > 0 {
+		s.usedBytes.Add(-freedBytes)
+	}
+	return nil
 }
 
 // deleteShareFiles removes every file inode and its dependent keys (parent,
@@ -228,11 +239,13 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 // objectID entry. Files are collected first, then mutated, so keys are never
 // deleted out from under the active iterator.
 //
-// usedBytes is adjusted inline; like PutFile/DeleteFile this shares the known
-// tx-retry double-count class (a conflict/serialization retry re-runs the
-// enclosing Update and re-applies the delta), tracked for the
-// metadata-tx-integrity fix PR. The counter is statfs-only, not quota-enforcing.
-func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) error {
+// deleteShareFiles returns the total regular-file bytes it removed (freedBytes)
+// rather than mutating usedBytes inline. The caller applies the decrement once
+// after a successful commit — the tx-path accumulates it into the transaction's
+// pendingDelta and the pool-path applies it after db.Update returns nil — so a
+// conflict/serialization retry that re-runs the enclosing Update never
+// double-counts. The counter is statfs-only, not quota-enforcing.
+func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, err error) {
 	type doomed struct {
 		id       uuid.UUID
 		objectID metadata.ContentHash
@@ -251,7 +264,7 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 		val, vErr := item.ValueCopy(nil)
 		if vErr != nil {
 			it.Close()
-			return fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
+			return 0, fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
 		}
 		file, decErr := decodeFile(val)
 		if decErr != nil {
@@ -274,21 +287,21 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 
 	for _, v := range victims {
 		if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
-			return delErr
+			return 0, delErr
 		}
 		// Directories own c:<uuid>:<name> child entries; prefix-scan and
 		// delete them so no dangling mapping survives the share.
 		if v.isDir {
 			if delErr := deleteChildEntries(txn, v.id); delErr != nil {
-				return delErr
+				return 0, delErr
 			}
 		}
 		if v.isReg && v.size > 0 {
-			s.usedBytes.Add(-int64(v.size))
+			freedBytes += int64(v.size)
 		}
 	}
 
-	return nil
+	return freedBytes, nil
 }
 
 // deleteFileKeys removes the primary file row plus its parent, link-count, and

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -18,9 +18,16 @@ import (
 // ============================================================================
 
 // badgerTransaction wraps a BadgerDB transaction for the Base interface.
+//
+// pendingDelta accumulates the usedBytes change made by mutations inside the
+// closure. It is applied to the store's atomic counter exactly once after a
+// successful commit (see WithTransaction). BadgerDB retries the closure on
+// ErrConflict; accumulating per-attempt and applying post-commit prevents the
+// counter from double-counting across retries.
 type badgerTransaction struct {
-	store *BadgerMetadataStore
-	txn   *badgerdb.Txn
+	store        *BadgerMetadataStore
+	txn          *badgerdb.Txn
+	pendingDelta int64
 }
 
 // Maximum number of retries for conflict errors
@@ -39,12 +46,24 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 
 	var lastErr error
 	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+		// pendingDelta is captured outside db.Update so it is read after a
+		// successful commit and reset per attempt (a retried attempt starts
+		// from zero, so a conflict-retry cannot double-count usedBytes).
+		var pendingDelta int64
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
-			return fn(tx)
+			if fnErr := fn(tx); fnErr != nil {
+				return fnErr
+			}
+			pendingDelta = tx.pendingDelta
+			return nil
 		})
 
 		if err == nil {
+			// Apply the accumulated usedBytes delta exactly once, after commit.
+			if pendingDelta != 0 {
+				s.usedBytes.Add(pendingDelta)
+			}
 			return nil // Success
 		}
 
@@ -155,12 +174,10 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		})
 	}
 
-	// Track size delta for regular files.
+	// Track size delta for regular files. Accumulated on the tx and applied
+	// once after a successful commit so a conflict-retry never double-counts.
 	if file.Type == metadata.FileTypeRegular {
-		delta := int64(file.Size) - int64(oldSize)
-		if delta != 0 {
-			tx.store.usedBytes.Add(delta)
-		}
+		tx.pendingDelta += int64(file.Size) - int64(oldSize)
 	}
 
 	data, err := encodeFile(file)
@@ -244,7 +261,7 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		file, decErr := decodeFile(val)
 		if decErr == nil {
 			if file.Type == metadata.FileTypeRegular && file.Size > 0 {
-				tx.store.usedBytes.Add(-int64(file.Size))
+				tx.pendingDelta -= int64(file.Size)
 			}
 			existingObjectID = file.ObjectID
 		}
@@ -809,9 +826,13 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 	// Tear down all file metadata on the active txn, identical to the pool
 	// path — deleting only the share key would orphan every file/parent/
 	// linkcount/child/objectID entry (store.go:161 contract).
-	if err := tx.store.deleteShareFiles(tx.txn, shareName); err != nil {
+	freed, err := tx.store.deleteShareFiles(tx.txn, shareName)
+	if err != nil {
 		return err
 	}
+	// Accumulate into the tx pending delta; applied once after a successful
+	// commit so a conflict-retry never double-counts.
+	tx.pendingDelta -= freed
 
 	return tx.txn.Delete(keyShare(shareName))
 }

--- a/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
+++ b/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package badger_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// TestBadger_UsedBytes_RetryNoDoubleCount exercises the conflict-retry path:
+// many goroutines repeatedly UPDATE the SAME file's size, which provokes
+// BadgerDB ErrConflict and forces WithTransaction to re-run the closure. With
+// the usedBytes delta accumulated on the tx (pendingDelta) and applied once
+// after a successful commit, the counter must end exactly equal to the final
+// file size — never inflated by a retried closure re-applying its delta.
+func TestBadger_UsedBytes_RetryNoDoubleCount(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	defer store.Close()
+
+	const shareName = "testshare"
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	if err != nil {
+		t.Fatalf("CreateRootDirectory: %v", err)
+	}
+
+	// Create one regular file.
+	handle, err := store.GenerateHandle(ctx, shareName, "/f.bin")
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle: %v", err)
+	}
+	mkFile := func(size uint64) *metadata.File {
+		now := time.Now()
+		return &metadata.File{
+			ID: fileID, ShareName: shareName, Path: "/f.bin",
+			FileAttr: metadata.FileAttr{
+				Type: metadata.FileTypeRegular, Mode: 0o644, Size: size,
+				Atime: now, Mtime: now, Ctime: now,
+			},
+		}
+	}
+	if err := store.PutFile(ctx, mkFile(0)); err != nil {
+		t.Fatalf("initial PutFile: %v", err)
+	}
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	if err != nil {
+		t.Fatalf("EncodeShareHandle: %v", err)
+	}
+	if err := store.SetChild(ctx, rootHandle, "f.bin", handle); err != nil {
+		t.Fatalf("SetChild: %v", err)
+	}
+
+	// Hammer the same file's size from many goroutines to provoke conflicts
+	// and retries. The last writer (by value) is racy, but whatever the final
+	// committed size is, usedBytes MUST equal it exactly.
+	const workers = 16
+	const itersPerWorker = 40
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(base uint64) {
+			defer wg.Done()
+			for i := 0; i < itersPerWorker; i++ {
+				size := base*1000 + uint64(i)*7
+				_ = store.PutFile(ctx, mkFile(size))
+			}
+		}(uint64(w + 1))
+	}
+	wg.Wait()
+
+	// The counter must equal the final stored file size, with no double-count
+	// from any conflict retry.
+	final, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if got := store.GetUsedBytes(); got != int64(final.Size) {
+		t.Fatalf("usedBytes=%d but final file size=%d (conflict-retry double-count)", got, final.Size)
+	}
+}

--- a/pkg/metadata/store/memory/counter_test.go
+++ b/pkg/metadata/store/memory/counter_test.go
@@ -2,6 +2,7 @@ package memory_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -95,6 +96,59 @@ func TestCounter_CreateFile(t *testing.T) {
 
 	if got := store.GetUsedBytes(); got != 1000 {
 		t.Fatalf("expected usedBytes == 1000 after creating 1000-byte file, got %d", got)
+	}
+}
+
+// TestCounter_RolledBackTxDoesNotDrift verifies the usedBytes counter is only
+// applied after a successful commit. A transaction that PutFiles a regular file
+// then returns an error must leave usedBytes unchanged — the delta is staged on
+// the tx (pendingDelta) and applied once post-commit, so a rolled-back (or
+// conflict-retried) closure never drifts or double-counts the counter.
+func TestCounter_RolledBackTxDoesNotDrift(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	injected := errors.New("rollback trigger")
+	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		h, err := tx.GenerateHandle(ctx, "/test", "/ghost.txt")
+		if err != nil {
+			return err
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		if err := tx.PutFile(ctx, &metadata.File{
+			ID:        id,
+			ShareName: "/test",
+			Path:      "/ghost.txt",
+			FileAttr: metadata.FileAttr{
+				Type: metadata.FileTypeRegular, Mode: 0o644, Size: 4096,
+				Atime: now, Mtime: now, Ctime: now,
+			},
+		}); err != nil {
+			return err
+		}
+		// Abort: the 4096-byte delta must NOT reach the counter.
+		return injected
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("WithTransaction returned %v, want injected error", err)
+	}
+
+	if got := store.GetUsedBytes(); got != 0 {
+		t.Fatalf("usedBytes drifted on rolled-back tx: got %d, want 0", got)
+	}
+
+	// And the file itself must be rolled back (snapshot/restore buffer).
+	rootHandle, err := store.GetRootHandle(ctx, "/test")
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	if _, err := store.GetChild(ctx, rootHandle, "ghost.txt"); err == nil {
+		t.Fatalf("ghost.txt survived a rolled-back transaction")
 	}
 }
 

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -159,14 +159,28 @@ func (s *MemoryMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 // implementation unchanged.
 func (s *MemoryMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error {
 	s.mu.RLock()
-	var snapshot []blockstore.ContentHash
-	if s.fileBlockData != nil {
-		snapshot = make([]blockstore.ContentHash, 0, len(s.fileBlockData.blocks))
-		for _, b := range s.fileBlockData.blocks {
-			snapshot = append(snapshot, b.Hash)
-		}
-	}
+	snapshot := s.snapshotBlockHashesLocked()
 	s.mu.RUnlock()
+	return enumerateBlockHashes(ctx, snapshot, fn)
+}
+
+// snapshotBlockHashesLocked copies every FileBlock hash. Caller MUST hold at
+// least the read lock.
+func (s *MemoryMetadataStore) snapshotBlockHashesLocked() []blockstore.ContentHash {
+	if s.fileBlockData == nil {
+		return nil
+	}
+	snapshot := make([]blockstore.ContentHash, 0, len(s.fileBlockData.blocks))
+	for _, b := range s.fileBlockData.blocks {
+		snapshot = append(snapshot, b.Hash)
+	}
+	return snapshot
+}
+
+// enumerateBlockHashes streams the snapshot through fn, honoring ctx
+// cancellation. Shared by the public store method and the transaction method
+// so the latter does not re-lock (WithTransaction already holds the lock).
+func enumerateBlockHashes(ctx context.Context, snapshot []blockstore.ContentHash, fn func(blockstore.ContentHash) error) error {
 	for _, h := range snapshot {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("enumerate file blocks: %w", err)
@@ -259,7 +273,11 @@ func (tx *memoryTransaction) ListFileBlocks(ctx context.Context, payloadID strin
 }
 
 func (tx *memoryTransaction) EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error {
-	return tx.store.EnumerateFileBlocks(ctx, fn)
+	// WithTransaction already holds the write lock; snapshot without
+	// re-locking (the public method's RLock would deadlock) so the enumerate
+	// observes uncommitted tx writes.
+	snapshot := tx.store.snapshotBlockHashesLocked()
+	return enumerateBlockHashes(ctx, snapshot, fn)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/memory/objects_test.go
+++ b/pkg/metadata/store/memory/objects_test.go
@@ -16,6 +16,40 @@ import (
 // FileBlock Reference Counting Tests
 // ============================================================================
 
+// TestWithTransaction_RollbackReinitsLazyFileBlockData regresses a snapshot
+// restore edge: when fileBlockData is nil at the start of a transaction and the
+// closure lazily allocates it (via Put) then fails, the rollback must reset
+// fileBlockData to nil rather than leaving it non-nil with nil maps — otherwise
+// a subsequent Put panics writing to a nil map.
+func TestWithTransaction_RollbackReinitsLazyFileBlockData(t *testing.T) {
+	store := NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+
+	// fileBlockData starts nil. Put a block inside a tx that then fails.
+	injected := errAlways
+	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		blk := &metadata.FileBlock{ID: uuid.New().String(), DataSize: 1024, RefCount: 1}
+		if putErr := tx.Put(ctx, blk); putErr != nil {
+			return putErr
+		}
+		return injected
+	})
+	require.ErrorIs(t, err, injected)
+
+	// A subsequent committed Put must succeed (no nil-map panic) and persist.
+	id := uuid.New().String()
+	require.NoError(t, store.Put(ctx, &metadata.FileBlock{ID: id, DataSize: 1024, RefCount: 1}))
+	got, err := store.GetFileBlock(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), got.RefCount)
+}
+
+var errAlways = errTest("synthetic failure")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
 func TestFileBlockStore_RefCount_Basic(t *testing.T) {
 	store := NewMemoryMetadataStoreWithDefaults()
 	ctx := context.Background()

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -66,7 +66,11 @@ type txSnapshot struct {
 // leak through a shared inner map or pointer.
 func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
 	snap := &txSnapshot{
-		shares:        maps.Clone(store.shares),
+		// shares holds *shareData mutated in place (UpdateShareOptions,
+		// CreateRootDirectory set RootHandle) — a shallow map clone would share
+		// those pointers and let the mutation leak into the snapshot, defeating
+		// rollback. Copy each struct (same discipline as fileBlockData.blocks).
+		shares:        make(map[string]*shareData, len(store.shares)),
 		files:         maps.Clone(store.files),
 		parents:       maps.Clone(store.parents),
 		children:      make(map[string]map[string]metadata.FileHandle, len(store.children)),
@@ -76,6 +80,10 @@ func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
 		objectIndex:   maps.Clone(store.objectIndex),
 		serverConfig:  store.serverConfig,
 		capabilities:  store.capabilities,
+	}
+	for k, v := range store.shares {
+		sc := *v
+		snap.shares[k] = &sc
 	}
 	for k, inner := range store.children {
 		snap.children[k] = maps.Clone(inner)

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -3,8 +3,10 @@ package memory
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
@@ -16,20 +18,132 @@ import (
 // memoryTransaction wraps the store for transactional operations.
 // Since the memory store uses a global mutex, the transaction
 // holds the lock for the duration of all operations.
+//
+// pendingDelta accumulates the usedBytes change made by mutations inside
+// the closure. It is applied to the store's atomic counter exactly once
+// after a successful commit (see WithTransaction), so a rolled-back
+// closure never touches the counter and a retried closure cannot
+// double-count.
 type memoryTransaction struct {
-	store *MemoryMetadataStore
+	store        *MemoryMetadataStore
+	pendingDelta int64
+}
+
+// txSnapshot captures the mutable state of the memory store so a failed
+// transaction can be rolled back to all-or-nothing. The memory store mutates
+// its maps directly under the global write lock; without a snapshot a closure
+// that fails midway leaves partial mutations behind, violating the
+// WithTransaction contract (interface.go: error → roll back).
+//
+// Map entries are cloned one level deep. fileData / FileBlock pointer values
+// are copied because incrementRefCountLocked mutates *FileBlock in place;
+// the rest are replaced (not mutated) by the tx methods, but copying keeps
+// the snapshot robust against future in-place edits.
+type txSnapshot struct {
+	shares        map[string]*shareData
+	files         map[string]*fileData
+	parents       map[string]metadata.FileHandle
+	children      map[string]map[string]metadata.FileHandle
+	linkCounts    map[string]uint32
+	deviceNumbers map[string]*deviceNumber
+	sortedDirs    map[string][]string
+	objectIndex   map[blockstore.ContentHash]string
+	// hadFileBlockData records whether fileBlockData was allocated at snapshot
+	// time. If the closure lazily allocated it (initFileBlockData) and then
+	// failed, restore must reset the struct's maps to non-nil empties (or it
+	// would leave fileBlockData non-nil with nil maps → a later Put panics on
+	// a nil-map write).
+	hadFileBlockData bool
+	blocks           map[string]*metadata.FileBlock
+	hashIndex        map[metadata.ContentHash]string
+	serverConfig     metadata.MetadataServerConfig
+	capabilities     metadata.FilesystemCapabilities
+}
+
+// snapshotLocked captures the store's mutable maps. Caller MUST hold the
+// write lock. Top-level maps are shallow-cloned; nested children maps and the
+// in-place-mutated FileBlock values are copied so a rolled-back closure cannot
+// leak through a shared inner map or pointer.
+func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
+	snap := &txSnapshot{
+		shares:        maps.Clone(store.shares),
+		files:         maps.Clone(store.files),
+		parents:       maps.Clone(store.parents),
+		children:      make(map[string]map[string]metadata.FileHandle, len(store.children)),
+		linkCounts:    maps.Clone(store.linkCounts),
+		deviceNumbers: maps.Clone(store.deviceNumbers),
+		sortedDirs:    maps.Clone(store.sortedDirCache),
+		objectIndex:   maps.Clone(store.objectIndex),
+		serverConfig:  store.serverConfig,
+		capabilities:  store.capabilities,
+	}
+	for k, inner := range store.children {
+		snap.children[k] = maps.Clone(inner)
+	}
+	if store.fileBlockData != nil {
+		snap.hadFileBlockData = true
+		snap.blocks = make(map[string]*metadata.FileBlock, len(store.fileBlockData.blocks))
+		snap.hashIndex = maps.Clone(store.fileBlockData.hashIndex)
+		for k, v := range store.fileBlockData.blocks {
+			// Copy the struct so an in-place RefCount mutation inside the
+			// closure does not leak into the snapshot.
+			bc := *v
+			snap.blocks[k] = &bc
+		}
+	}
+	return snap
+}
+
+// restoreLocked reverts the store's mutable maps to the snapshot. Caller MUST
+// hold the write lock.
+func (store *MemoryMetadataStore) restoreLocked(snap *txSnapshot) {
+	store.shares = snap.shares
+	store.files = snap.files
+	store.parents = snap.parents
+	store.children = snap.children
+	store.linkCounts = snap.linkCounts
+	store.deviceNumbers = snap.deviceNumbers
+	store.sortedDirCache = snap.sortedDirs
+	store.objectIndex = snap.objectIndex
+	store.serverConfig = snap.serverConfig
+	store.capabilities = snap.capabilities
+	switch {
+	case snap.hadFileBlockData:
+		// fileBlockData existed at snapshot time — restore its maps to the
+		// captured copies (snap.blocks/hashIndex are non-nil).
+		store.fileBlockData.blocks = snap.blocks
+		store.fileBlockData.hashIndex = snap.hashIndex
+	case store.fileBlockData != nil:
+		// The closure lazily allocated fileBlockData then failed. Drop it back
+		// to its pre-tx (nil) state so it is re-initialized cleanly on the next
+		// use — never left non-nil with nil maps.
+		store.fileBlockData = nil
+	}
 }
 
 // WithTransaction executes fn within a transaction.
 //
 // For the memory store, this acquires the write lock and holds it for the
-// entire duration of fn. If fn returns an error, no rollback is needed since
-// operations are performed directly on the maps (no separate transaction buffer).
+// entire duration of fn. The store mutates its maps directly under the lock;
+// to honor the all-or-nothing contract a snapshot of every mutable map is
+// taken before fn runs and restored if fn returns an error, so a failed
+// closure leaves no partial mutations behind.
 //
-// Note: The memory store doesn't support true transaction rollback. If fn
-// performs multiple operations and fails midway, partial changes will persist.
-// This is acceptable for testing but not for production use with strict
-// atomicity requirements.
+// usedBytes is tracked as a pending delta on the transaction and applied to
+// the atomic counter only after the closure succeeds, so a rollback never
+// drifts the counter.
+//
+// The snapshot shallow-clones the top-level maps, so a transaction is O(store
+// size) rather than O(keys touched). The memory store is the
+// testing/development/ephemeral backend (badger and postgres are the
+// persistent backends with native rollback), where correctness and simplicity
+// outweigh the clone cost; a write-heavy production workload uses a durable
+// backend.
+//
+// Scope: the snapshot covers the file/directory/share/fileblock metadata maps.
+// The separately-mutexed lock store (memoryLockStore, area-5) is NOT snapshotted
+// — lock persistence runs in its own transactions and is not mixed with
+// file-metadata mutations in a single WithTransaction.
 func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -38,8 +152,18 @@ func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(t
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
+	snap := store.snapshotLocked()
 	tx := &memoryTransaction{store: store}
-	return fn(tx)
+	if err := fn(tx); err != nil {
+		store.restoreLocked(snap)
+		return err
+	}
+
+	// Commit succeeded — apply the accumulated usedBytes delta once.
+	if tx.pendingDelta != 0 {
+		store.usedBytes.Add(tx.pendingDelta)
+	}
+	return nil
 }
 
 // ============================================================================
@@ -90,10 +214,9 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		if existing, exists := tx.store.files[key]; exists && existing.Attr.Type == metadata.FileTypeRegular {
 			oldSize = existing.Attr.Size
 		}
-		delta := int64(file.Size) - int64(oldSize)
-		if delta != 0 {
-			tx.store.usedBytes.Add(delta)
-		}
+		// Accumulate into the tx-scoped pending delta; applied once after a
+		// successful commit so a rollback/retry never drifts the counter.
+		tx.pendingDelta += int64(file.Size) - int64(oldSize)
 	}
 
 	// Maintain ObjectID secondary index BEFORE overwriting
@@ -168,9 +291,9 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		}
 	}
 
-	// Subtract size from counter for regular files.
+	// Subtract size from the pending delta for regular files.
 	if existing.Attr.Type == metadata.FileTypeRegular && existing.Attr.Size > 0 {
-		tx.store.usedBytes.Add(-int64(existing.Attr.Size))
+		tx.pendingDelta -= int64(existing.Attr.Size)
 	}
 
 	// drop ObjectID secondary entry. The "only if mapped
@@ -526,9 +649,9 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 	// Remove all files belonging to this share
 	for key, fd := range tx.store.files {
 		if fd.ShareName == shareName {
-			// Subtract size from counter for regular files.
+			// Subtract size from the pending delta for regular files.
 			if fd.Attr.Type == metadata.FileTypeRegular && fd.Attr.Size > 0 {
-				tx.store.usedBytes.Add(-int64(fd.Attr.Size))
+				tx.pendingDelta -= int64(fd.Attr.Size)
 			}
 			// drop ObjectID secondary entry too.
 			if fd.Attr != nil && !fd.Attr.ObjectID.IsZero() {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -628,20 +628,89 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 	return block, nil
 }
 
-// ListPending and ListFileBlocks are read-only helpers; no caller
-// mutates state through them, so they keep the pool path. Same for
-// EnumerateFileBlocks — the GC mark phase audit don't require
-// txn binding (they tolerate concurrent mutation).
+// ListPending / ListFileBlocks / EnumerateFileBlocks run on the active
+// transaction (tx.tx), NOT the pool. Delegating to the pool opens a separate
+// connection that cannot see this transaction's uncommitted writes, so a Put
+// followed by a List in the same WithTransaction would miss the pending row
+// (read-after-write violation; the SQL is otherwise identical to the
+// store-level methods).
 func (tx *postgresTransaction) ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
-	return tx.store.ListPending(ctx, olderThan, limit)
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE state = 0 /* Pending */ AND cache_path IS NOT NULL`
+	args := make([]any, 0, 2)
+	if olderThan > 0 {
+		args = append(args, time.Now().Add(-olderThan))
+		query += fmt.Sprintf(" AND created_at < $%d", len(args))
+	}
+	query += " ORDER BY created_at ASC"
+	if limit > 0 {
+		args = append(args, limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	rows, err := tx.tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending blocks: %w", err)
+	}
+	defer rows.Close()
+	return scanFileBlockRows(rows)
 }
 
 func (tx *postgresTransaction) ListFileBlocks(ctx context.Context, payloadID string) ([]*metadata.FileBlock, error) {
-	return tx.store.ListFileBlocks(ctx, payloadID)
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE id LIKE $1
+		ORDER BY id ASC`
+	rows, err := tx.tx.Query(ctx, query, payloadID+"/%")
+	if err != nil {
+		return nil, fmt.Errorf("list file blocks: %w", err)
+	}
+	defer rows.Close()
+	result, err := scanFileBlockRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	// Lexicographic SQL order mis-sorts multi-digit indices ("10" < "2");
+	// sort by parsed numeric index, matching the store-level method.
+	sort.Slice(result, func(i, j int) bool {
+		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
+	})
+	if result == nil {
+		return []*metadata.FileBlock{}, nil
+	}
+	return result, nil
 }
 
 func (tx *postgresTransaction) EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error {
-	return tx.store.EnumerateFileBlocks(ctx, fn)
+	rows, err := tx.tx.Query(ctx, `SELECT hash FROM file_blocks ORDER BY id`)
+	if err != nil {
+		return fmt.Errorf("enumerate file blocks: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file blocks: %w", err)
+		}
+		var hashStr sql.NullString
+		if err := rows.Scan(&hashStr); err != nil {
+			return fmt.Errorf("enumerate file blocks: scan: %w", err)
+		}
+		var h blockstore.ContentHash
+		if hashStr.Valid {
+			parsed, perr := metadata.ParseContentHash(hashStr.String)
+			if perr != nil {
+				return fmt.Errorf("enumerate file blocks: parse hash %q: %w", hashStr.String, perr)
+			}
+			h = parsed
+		}
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate file blocks: rows: %w", err)
+	}
+	return nil
 }
 
 // The file_blocks table schema lives in

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -24,9 +24,16 @@ const maxTransactionRetries = 3
 // ============================================================================
 
 // postgresTransaction wraps a PostgreSQL transaction for the Transaction interface.
+//
+// pendingDelta accumulates the usedBytes change made by mutations inside the
+// closure. It is applied to the store's atomic counter exactly once after a
+// successful Commit (see WithTransaction). WithTransaction retries the closure
+// on 40P01/40001; accumulating per-attempt and applying post-commit prevents
+// the counter from double-counting across retries.
 type postgresTransaction struct {
-	store *PostgresMetadataStore
-	tx    pgx.Tx
+	store        *PostgresMetadataStore
+	tx           pgx.Tx
+	pendingDelta int64
 }
 
 // isRetryableError checks if a PostgreSQL error is retryable (deadlock or serialization failure)
@@ -110,6 +117,10 @@ func (s *PostgresMetadataStore) WithTransaction(ctx context.Context, fn func(tx 
 		}
 		commitCancel()
 
+		// Apply the accumulated usedBytes delta exactly once, after commit.
+		if ptx.pendingDelta != 0 {
+			s.usedBytes.Add(ptx.pendingDelta)
+		}
 		return nil // Success
 	}
 
@@ -269,12 +280,11 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	}
 
 	// Track size delta for regular files after successful update/insert.
+	// Accumulated on the tx and applied once after a successful commit so a
+	// serialization/deadlock retry never double-counts.
 	if file.Type == metadata.FileTypeRegular {
 		if result.RowsAffected() > 0 {
-			delta := int64(file.Size) - int64(oldSize)
-			if delta != 0 {
-				tx.store.usedBytes.Add(delta)
-			}
+			tx.pendingDelta += int64(file.Size) - int64(oldSize)
 		}
 	}
 
@@ -303,7 +313,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 
 		// Track new regular file size.
 		if file.Type == metadata.FileTypeRegular && file.Size > 0 {
-			tx.store.usedBytes.Add(int64(file.Size))
+			tx.pendingDelta += int64(file.Size)
 		}
 
 		// Debug logging for new file inserts
@@ -370,9 +380,9 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		}
 	}
 
-	// Subtract size from counter for regular files.
+	// Subtract size from the pending delta for regular files.
 	if metadata.FileType(fileType) == metadata.FileTypeRegular && fileSize > 0 {
-		tx.store.usedBytes.Add(-fileSize)
+		tx.pendingDelta -= fileSize
 	}
 
 	return nil
@@ -899,12 +909,11 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 
-	// Inline decrement shares the known tx-retry double-count class with
-	// PutFile/DeleteFile (a serialization retry re-runs this closure and
-	// re-applies the delta); unified post-commit fix tracked for the
-	// metadata-tx-integrity PR. The counter is statfs-only, not quota-enforcing.
+	// Accumulate the decrement on the tx and apply it once after a successful
+	// commit so a serialization/deadlock retry never double-counts. The
+	// counter is statfs-only, not quota-enforcing.
 	if freedBytes > 0 {
-		tx.store.usedBytes.Add(-freedBytes)
+		tx.pendingDelta -= freedBytes
 	}
 
 	return nil

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -135,14 +135,21 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 		testEnumerateFileBlocks_CorruptHashFailsClosed(t, factory)
 	})
 
-	// (review iteration 1): IncrementRefCount /
-	// DecrementRefCount called via a metadata.Transaction MUST roll back
-	// when the wrapping WithTransaction returns an error. Memory backend
-	// has documented best-effort semantics (single mutex, no rollback
-	// buffer) so its expected behavior differs; Postgres + Badger MUST
-	// honor durable rollback.
+	// IncrementRefCount / DecrementRefCount called via a
+	// metadata.Transaction MUST roll back when the wrapping WithTransaction
+	// returns an error. All backends — memory, badger, postgres — honor the
+	// unconditional all-or-nothing contract (interface.go: error → roll
+	// back); memory does so via a snapshot/restore buffer.
 	t.Run("Tx_IncrementRefCount_RollsBack", func(t *testing.T) {
 		testTx_IncrementRefCount_RollsBack(t, factory)
+	})
+
+	// A tx.Put followed by tx.ListFileBlocks / tx.EnumerateFileBlocks in the
+	// SAME WithTransaction MUST observe the uncommitted write (read-after-write
+	// within the tx). Badger previously delegated these list methods to a fresh
+	// db.View snapshot taken at call time, so the pending Put was invisible.
+	t.Run("Tx_ListReadAfterWrite", func(t *testing.T) {
+		testTx_ListReadAfterWrite(t, factory)
 	})
 
 	// AddRef is the LRU-hit refcount path for the
@@ -1152,19 +1159,12 @@ func testEnumerateFileBlocks_CorruptHashFailsClosed(t *testing.T, factory StoreF
 // the same property that pkg/controlplane/runtime/shares/coordinator_test
 // exercises at the coordinator layer.
 //
-// Memory backend documented limitation: the memory tx has no rollback
-// buffer (see memory/transaction.go). The test detects this and adjusts
-// expectations — memory leaves the increments stuck on rollback (best-
-// effort txn). Postgres and Badger must roll back durably.
+// All backends are held to the same all-or-nothing contract: memory rolls
+// back via a snapshot/restore buffer in WithTransaction, badger and postgres
+// via native transaction rollback.
 func testTx_IncrementRefCount_RollsBack(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()
-
-	// Detect best-effort txn backends (memory) by name. The memory store
-	// has WithTransaction that holds a global mutex but does not maintain
-	// a rollback buffer; durable rollback is impossible by construction.
-	storeType := fmt.Sprintf("%T", store)
-	bestEffortTxn := storeType == "*memory.MemoryMetadataStore"
 
 	// Seed three FileBlocks with RefCount=1 each.
 	type seed struct {
@@ -1205,9 +1205,8 @@ func testTx_IncrementRefCount_RollsBack(t *testing.T, factory StoreFactory) {
 		t.Fatalf("WithTransaction returned %v, want injected %v", err, injected)
 	}
 
-	// Post-rollback: every refcount MUST equal its seeded value (1) on
-	// durable backends. Memory tolerates the documented best-effort
-	// semantics.
+	// Post-rollback: every refcount MUST equal its seeded value (1) on all
+	// backends — the transaction must undo the increment.
 	for _, s := range seeds {
 		got, err := store.GetByHash(ctx, s.hash)
 		if err != nil {
@@ -1216,19 +1215,89 @@ func testTx_IncrementRefCount_RollsBack(t *testing.T, factory StoreFactory) {
 		if got == nil {
 			t.Fatalf("GetByHash(%x) returned nil after rollback", s.hash[:4])
 		}
-		if bestEffortTxn {
-			// Memory: increment stuck (no rollback). RefCount=2.
-			if got.RefCount != 2 {
-				t.Errorf("memory backend: RefCount(%s)=%d, want 2 (best-effort txn leaves the increment in place)", s.id, got.RefCount)
-			}
-			continue
-		}
-		// Durable backends MUST roll back.
 		if got.RefCount != 1 {
 			t.Errorf("RefCount(%s)=%d after rollback; want 1 (txn must undo IncrementRefCount)", s.id, got.RefCount)
 		}
 	}
 }
+
+// testTx_ListReadAfterWrite pins read-after-write within a transaction: a
+// FileBlock Put through the tx MUST be visible to ListFileBlocks and
+// EnumerateFileBlocks issued later in the same WithTransaction. Backends that
+// open a fresh snapshot per list call (the original badger behavior) miss the
+// pending write and fail here.
+func testTx_ListReadAfterWrite(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const payloadID = "raw-tx-file"
+	hash := blockstore.ContentHash{0xa1, 0xb2, 0xc3, 0xd4}
+
+	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		// ListFileBlocks / EnumerateFileBlocks live on each backend's tx
+		// struct but not on the narrowed metadata.Transaction interface; the
+		// engine-internal callers reach them via the concrete type. Assert to
+		// a local interface so the conformance test can drive them.
+		lister, ok := tx.(interface {
+			ListFileBlocks(ctx context.Context, payloadID string) ([]*blockstore.FileBlock, error)
+			EnumerateFileBlocks(ctx context.Context, fn func(blockstore.ContentHash) error) error
+		})
+		if !ok {
+			return errTxListUnsupported
+		}
+
+		block := &blockstore.FileBlock{
+			ID:            payloadID + "/0",
+			Hash:          hash,
+			State:         blockstore.BlockStateRemote,
+			LocalPath:     "/cache/raw",
+			BlockStoreKey: "cas/a1/b2/" + hash.String(),
+			DataSize:      4096,
+			RefCount:      1,
+			LastAccess:    time.Now(),
+			CreatedAt:     time.Now(),
+		}
+		if putErr := tx.Put(ctx, block); putErr != nil {
+			return fmt.Errorf("tx.Put: %w", putErr)
+		}
+
+		// ListFileBlocks must see the just-Put block.
+		listed, listErr := lister.ListFileBlocks(ctx, payloadID)
+		if listErr != nil {
+			return fmt.Errorf("tx.ListFileBlocks: %w", listErr)
+		}
+		if len(listed) != 1 {
+			return fmt.Errorf("tx.ListFileBlocks returned %d blocks; want 1 (uncommitted write invisible)", len(listed))
+		}
+
+		// EnumerateFileBlocks must also see it.
+		var seen bool
+		enumErr := lister.EnumerateFileBlocks(ctx, func(h blockstore.ContentHash) error {
+			if h == hash {
+				seen = true
+			}
+			return nil
+		})
+		if enumErr != nil {
+			return fmt.Errorf("tx.EnumerateFileBlocks: %w", enumErr)
+		}
+		if !seen {
+			return fmt.Errorf("tx.EnumerateFileBlocks did not yield the uncommitted block hash")
+		}
+		return nil
+	})
+	if errors.Is(err, errTxListUnsupported) {
+		t.Skip("backend tx does not expose ListFileBlocks/EnumerateFileBlocks")
+	}
+	if err != nil {
+		t.Fatalf("read-after-write within tx failed: %v", err)
+	}
+}
+
+// errTxListUnsupported signals testTx_ListReadAfterWrite that the backend's
+// transaction does not expose the engine-internal ListFileBlocks /
+// EnumerateFileBlocks methods, so the scenario is skipped rather than failed.
+var errTxListUnsupported = errors.New("backend tx does not expose ListFileBlocks/EnumerateFileBlocks")
 
 // ============================================================================
 // AddRef Tests

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -1,0 +1,204 @@
+package metadata_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// RemoveFile link-count TOCTOU (read inside the transaction)
+// ============================================================================
+
+// TestRemoveFile_HardLinkSurvives is the baseline: removing one of two hard
+// links must decrement nlink to 1 and leave the content referenced (empty
+// PayloadID return so the caller does not delete content).
+func TestRemoveFile_HardLinkSurvives(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	ctx := context.Background()
+
+	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	target, err := fx.store.GetChild(ctx, fx.rootHandle, "a.txt")
+	require.NoError(t, err)
+
+	// Add a second link → nlink=2.
+	require.NoError(t, fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "b.txt", target))
+
+	// Removing one link drops nlink to 1, content stays referenced.
+	removed, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), removed.Nlink, "one surviving link expected")
+	assert.Empty(t, removed.PayloadID, "content must not be eligible for deletion while a link remains")
+
+	// The surviving link still resolves and reports nlink=1.
+	survivor, err := fx.store.GetChild(ctx, fx.rootHandle, "b.txt")
+	require.NoError(t, err)
+	lc, err := fx.store.GetLinkCount(ctx, survivor)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), lc)
+}
+
+// TestRemoveFile_ConcurrentCreateHardLink stresses the TOCTOU window between
+// the link-count read and the decrement. With the read now INSIDE the
+// transaction, a concurrent CreateHardLink can never cause RemoveFile to drop
+// nlink to 0 while a valid link still references the file. Run under -race.
+//
+// Invariant under test: after a RemoveFile of one link and a concurrent
+// CreateHardLink of another, the remaining link's count is consistent with the
+// links that actually exist in the directory (never 0 while a link is present).
+func TestRemoveFile_ConcurrentCreateHardLink(t *testing.T) {
+	t.Parallel()
+
+	for iter := 0; iter < 200; iter++ {
+		fx := newTestFixture(t)
+		ctx := context.Background()
+
+		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "orig.txt", &metadata.FileAttr{Mode: 0644})
+		require.NoError(t, err)
+		target, err := fx.store.GetChild(ctx, fx.rootHandle, "orig.txt")
+		require.NoError(t, err)
+
+		// Pre-create a second link so the file starts at nlink=2.
+		require.NoError(t, fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link1.txt", target))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		// Goroutine A: add a third link concurrently.
+		go func() {
+			defer wg.Done()
+			_ = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link2.txt", target)
+		}()
+		// Goroutine B: remove the original link concurrently.
+		go func() {
+			defer wg.Done()
+			_, _ = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "orig.txt")
+		}()
+		wg.Wait()
+
+		// Count the links that actually still exist in the directory.
+		var present int
+		for _, name := range []string{"orig.txt", "link1.txt", "link2.txt"} {
+			if _, gcErr := fx.store.GetChild(ctx, fx.rootHandle, name); gcErr == nil {
+				present++
+			}
+		}
+		// The file must still be referenced by the surviving links and its
+		// stored nlink must equal the number of present directory entries —
+		// never 0 while links exist.
+		lc, lcErr := fx.store.GetLinkCount(ctx, target)
+		require.NoError(t, lcErr)
+		if present > 0 {
+			assert.Equalf(t, uint32(present), lc,
+				"iter %d: nlink=%d but %d links present (TOCTOU drop)", iter, lc, present)
+		}
+	}
+}
+
+// ============================================================================
+// Move atomicity (full rollback on a mid-rename failure)
+// ============================================================================
+
+// errPutFileInjected is returned by the fault-injecting tx when PutFile is
+// called for the targeted file ID.
+var errPutFileInjected = errors.New("injected PutFile failure")
+
+// faultyStore wraps a MetadataStore and, inside WithTransaction, makes
+// tx.PutFile fail for a single targeted ShareName/Path. Everything else
+// delegates to the real store so the rest of the rename runs normally up to
+// the injected failure.
+type faultyStore struct {
+	metadata.MetadataStore
+	failPath string // File.Path that should fail PutFile
+}
+
+func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	return f.MetadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return fn(&faultyTx{Transaction: tx, failPath: f.failPath})
+	})
+}
+
+type faultyTx struct {
+	metadata.Transaction
+	failPath string
+}
+
+func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
+	if file.Path == t.failPath {
+		return errPutFileInjected
+	}
+	return t.Transaction.PutFile(ctx, file)
+}
+
+// TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when
+// PutFile(srcFile) (the new-path write) fails mid-transaction, the whole Move
+// rolls back — the source stays at its original name/path and the destination
+// name is not created. Previously Move discarded these errors with `_ =` and
+// committed a partial rename (entry relinked, File.Path stale).
+func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	shareName := "/test"
+
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	// Register a store that fails PutFile for the moved file's NEW path.
+	faulty := &faultyStore{MetadataStore: store, failPath: "/dest/moved.txt"}
+	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
+
+	rootCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+
+	_, err = svc.CreateFile(rootCtx, rootHandle, "myfile.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	_, err = svc.CreateDirectory(rootCtx, rootHandle, "dest", &metadata.FileAttr{Mode: 0755})
+	require.NoError(t, err)
+	destHandle, err := store.GetChild(ctx, rootHandle, "dest")
+	require.NoError(t, err)
+
+	srcHandle, err := store.GetChild(ctx, rootHandle, "myfile.txt")
+	require.NoError(t, err)
+
+	// The move must fail with the injected error.
+	err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")
+	require.Error(t, err, "Move must surface the injected PutFile failure, not swallow it")
+	require.ErrorIs(t, err, errPutFileInjected)
+
+	// Full rollback: source still at its original name/path...
+	stillThere, err := store.GetChild(ctx, rootHandle, "myfile.txt")
+	require.NoError(t, err, "source entry must survive the rolled-back rename")
+	assert.Equal(t, string(srcHandle), string(stillThere))
+
+	srcFile, err := store.GetFile(ctx, srcHandle)
+	require.NoError(t, err)
+	assert.Equal(t, "/myfile.txt", srcFile.Path, "File.Path must not be left at the new (uncommitted) path")
+
+	// ...and the destination name was NOT created.
+	_, err = store.GetChild(ctx, destHandle, "moved.txt")
+	require.Error(t, err, "destination entry must not exist after rollback")
+}


### PR DESCRIPTION
Area-6 metadata PR-B3 — the four transaction-atomicity MEDs from `.planning/v1.0-audit/6-metadata/REVIEW.md` §4 plus the deferred usedBytes-retry double-count. Largest area-6 PR (5 grouped fixes); all are transaction-atomicity correctness, so they ship together. Scope: `pkg/metadata` only.

## Fixes

1. **RemoveFile link-count TOCTOU** (`file_remove.go`). The link count was read via `store.GetLinkCount` BEFORE `WithTransaction`; the tx then branched on / wrote the stale value. A concurrent `CreateHardLink` (atomic Get+Set in its own tx) could bump the count in the window → RemoveFile sets `nlink=0` while a valid link still references the file (data loss), and because the count was never read inside the tx, badger's conflict detection had no key to trip. Fix: read via `tx.GetLinkCount` inside the closure so read+decision+write are atomic and the key participates in conflict detection.

2. **Move swallows tx-critical errors → partial-commit rename** (`file_modify.go`). `tx.SetParent`, the dir link-count `SetLinkCount`s, `tx.PutFile(srcFile/srcDir/dstDir)` were discarded with `_ =` and `updateDescendantPaths` errors logged-and-ignored, so the closure returned nil unconditionally and committed regardless. A failed `PutFile(srcFile)` left the entry relinked with the OLD Path (breaks the postgres path-keyed snapshot/restore + descendant rewrite; dir moves skew parent nlink). Fix: return the error from every tx call (including the destination-unlink path and `updateDescendantPaths`) so any failure rolls the whole rename back.

3. **badger tx list/enumerate read a fresh snapshot instead of the active txn** (`store/badger/objects.go`). `tx.ListPending`/`tx.ListFileBlocks`/`tx.EnumerateFileBlocks` delegated to the store path, each opening its own `db.View` snapshot → a `tx.Put` then `tx.ListFileBlocks` in the same `WithTransaction` missed the uncommitted write (cross-backend divergence vs memory). Fix: extracted `listPendingTxn`/`listFileBlocksTxn`/`enumerateFileBlocksTxn` helpers taking `*badger.Txn`; both store-level (`db.View`) and tx-level methods share one implementation, with the tx versions binding to `tx.txn` for read-after-write.

4. **memory WithTransaction had no rollback buffer** (`store/memory/transaction.go`). The memory tx mutated live maps directly, so a returned error left partial mutations — and the conformance suite codified this by string-matching `*memory.MemoryMetadataStore` and relaxing `testTx_IncrementRefCount_RollsBack`. Fix: snapshot/restore buffer over all file/dir/share/fileblock maps (`maps.Clone` + nested-map / FileBlock-value copies), restored on error; removed the type-name carve-out so memory is held to the same all-or-nothing contract. Also fixed a re-lock deadlock in `memoryTransaction.EnumerateFileBlocks` (was delegating to the RLock-taking public method while the write lock was held) and the lazy-`fileBlockData` restore edge (don't leave it non-nil with nil maps).

5. **usedBytes tx-retry double-count** (postgres + badger + memory). A serialization/conflict retry re-ran the closure and re-applied the in-memory usedBytes delta. Fix: accumulate a per-tx `pendingDelta` and apply `usedBytes.Add` ONCE after a successful commit; `PutFile`/`DeleteFile`/`DeleteShare` on all three backends record into pendingDelta instead of mutating the counter inside the closure (badger `deleteShareFiles` now returns freedBytes for both pool- and tx-paths). Removed the "deferred to metadata-tx-integrity" comments.

## Tests
- `TestRemoveFile_HardLinkSurvives` + `TestRemoveFile_ConcurrentCreateHardLink` (200× under -race): a concurrently-linked file is never dropped to nlink=0 while links exist.
- `TestMove_RollsBackOnPutFileFailure`: fault-injecting tx fails `PutFile(srcFile)` → assert full rollback (source stays at old name/path, dest not created).
- `Tx_ListReadAfterWrite` conformance scenario: tx.Put → tx.ListFileBlocks/EnumerateFileBlocks see the uncommitted write (all backends).
- `Tx_IncrementRefCount_RollsBack` carve-out removed → memory now passes the unconditional rollback assertion.
- `TestCounter_RolledBackTxDoesNotDrift` (memory) + `TestBadger_UsedBytes_RetryNoDoubleCount` (real ErrConflict retries): delta applied exactly once.
- `TestWithTransaction_RollbackReinitsLazyFileBlockData`: lazy-fileBlockData rollback no longer panics a later Put.

## Gates
- `gofmt -s` / `go vet` / `golangci-lint run` clean.
- `go test -race ./pkg/metadata/...` green; `go test -race -tags=integration ./pkg/metadata/store/badger/...` green.
- Postgres conformance not run locally (no DSN); the pendingDelta change mirrors badger/memory and is exercised by the shared suite in CI (pg wired in #853).