### PR TITLE
fix(nfs/v4): honor replay caches across owner-seqid ops + v4.1 SEQ_FALSE_RETRY (area-4 H4/H5/H6)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/close.go
+++ b/internal/adapter/nfs/v4/handlers/close.go
@@ -64,8 +64,11 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager for state cleanup
-	closedStateid, stateErr := h.StateManager.CloseFile(stateid, closeSeqid)
+	closeResult, stateErr := h.StateManager.CloseFile(stateid, closeSeqid)
 	if stateErr != nil {
+		if replay := asReplay(types.OP_CLOSE, stateErr); replay != nil {
+			return replay
+		}
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 CLOSE failed",
 			"error", stateErr,
@@ -102,7 +105,13 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	types.EncodeStateid4(&buf, closedStateid)
+	types.EncodeStateid4(&buf, &closeResult.Stateid)
+
+	// Cache the encoded reply on the open-owner so a retransmitted CLOSE at the
+	// same seqid replays these exact bytes instead of failing NFS4ERR_BAD_SEQID.
+	if closeResult.OwnerData != nil {
+		h.StateManager.CacheOpenOwnerResult(closeResult.OwnerClientID, closeResult.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/close.go
+++ b/internal/adapter/nfs/v4/handlers/close.go
@@ -81,6 +81,19 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
+	// Encode and cache the CLOSE reply BEFORE the (potentially slow) metadata
+	// flush. CloseFile has already advanced the open-owner seqid and installed
+	// the closed-owner entry, so a retransmitted CLOSE arriving while the flush
+	// below is still running would be classified as a replay; caching here (not
+	// after the flush) ensures it replays the CLOSE bytes rather than the
+	// owner's previous LastResult (e.g. OPEN_CONFIRM).
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	types.EncodeStateid4(&buf, &closeResult.Stateid)
+	if closeResult.OwnerData != nil {
+		h.StateManager.CacheOpenOwnerResult(closeResult.OwnerClientID, closeResult.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
+
 	// Flush pending metadata writes to persist file size and other changes,
 	// even if the client doesn't send COMMIT.
 	if authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH); err != nil {
@@ -102,16 +115,6 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 	}
 
 	// NOTE: CLOSE does NOT clear ctx.CurrentFH per RFC 7530
-
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	types.EncodeStateid4(&buf, &closeResult.Stateid)
-
-	// Cache the encoded reply on the open-owner so a retransmitted CLOSE at the
-	// same seqid replays these exact bytes instead of failing NFS4ERR_BAD_SEQID.
-	if closeResult.OwnerData != nil {
-		h.StateManager.CacheOpenOwnerResult(closeResult.OwnerClientID, closeResult.OwnerData, types.NFS4_OK, buf.Bytes())
-	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -133,6 +134,13 @@ func rejectV40OnlyOp(opCode uint32, reader io.Reader, clientAddr string) *types.
 //	numresults:    uint32   (count of results)
 //	results[]:     each result is opcode (uint32) followed by op-specific result
 func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) ([]byte, error) {
+	// Fingerprint the full COMPOUND request body. The v4.1 SEQUENCE path uses
+	// this as the slot request digest for false-retry detection (RFC 8881
+	// Section 2.10.6.1.3). SHA-256 over the request avoids collisions a weaker
+	// hash could allow a malicious client to engineer.
+	digest := sha256.Sum256(data)
+	compCtx.RequestDigest = digest[:]
+
 	reader := bytes.NewReader(data)
 
 	// Decode tag (XDR opaque: length + bytes + padding)
@@ -375,6 +383,7 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 				v41ctx.SequenceID,
 				v41ctx.CacheThis,
 				responseBytes,
+				v41ctx.RequestDigest,
 			)
 		}
 	}()

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -197,6 +197,9 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 
 	// Handle errors
 	if stateErr != nil {
+		if replay := asReplay(types.OP_LOCK, stateErr); replay != nil {
+			return replay
+		}
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 LOCK failed",
 			"error", stateErr,
@@ -209,11 +212,16 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 		}
 	}
 
-	// Handle conflict (NFS4ERR_DENIED with LOCK4denied)
+	// Handle conflict (NFS4ERR_DENIED with LOCK4denied). A DENIED LOCK still
+	// advanced the lock-owner seqid, so its reply is cached for replay too.
 	if result.Denied != nil {
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4ERR_DENIED)
 		state.EncodeLOCK4denied(&buf, result.Denied)
+
+		if result.OwnerData != nil {
+			h.StateManager.CacheLockOwnerResult(result.OwnerClientID, result.OwnerData, types.NFS4ERR_DENIED, buf.Bytes())
+		}
 
 		return &types.CompoundResult{
 			Status: types.NFS4ERR_DENIED,
@@ -226,6 +234,13 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
 	types.EncodeStateid4(&buf, &result.Stateid)
+
+	// Cache the encoded reply so a retransmitted LOCK at the same lock-owner
+	// seqid replays these exact bytes instead of failing NFS4ERR_BAD_SEQID
+	// (which the Linux client treats as fatal -> silent lock loss).
+	if result.OwnerData != nil {
+		h.StateManager.CacheLockOwnerResult(result.OwnerClientID, result.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
@@ -431,10 +446,13 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager
-	resultStateid, stateErr := h.StateManager.UnlockFile(
+	unlockResult, stateErr := h.StateManager.UnlockFile(
 		lockStateid, seqid, lockType, offset, length,
 	)
 	if stateErr != nil {
+		if replay := asReplay(types.OP_LOCKU, stateErr); replay != nil {
+			return replay
+		}
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 LOCKU failed",
 			"error", stateErr,
@@ -450,7 +468,12 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 	// Success: encode updated lock stateid
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	types.EncodeStateid4(&buf, resultStateid)
+	types.EncodeStateid4(&buf, &unlockResult.Stateid)
+
+	// Cache the encoded reply for replay of a retransmitted LOCKU.
+	if unlockResult.OwnerData != nil {
+		h.StateManager.CacheLockOwnerResult(unlockResult.OwnerClientID, unlockResult.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -155,12 +155,12 @@ func setupHandlerLockClient(t *testing.T, h *Handler) (clientID uint64, openStat
 
 	// OPEN_CONFIRM
 	confirmOpenSeqid := openSeqid + 1
-	confirmedStateid, err := h.StateManager.ConfirmOpen(&openResult.Stateid, confirmOpenSeqid)
+	confirmRes, err := h.StateManager.ConfirmOpen(&openResult.Stateid, confirmOpenSeqid)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}
 
-	return clientID, confirmedStateid, confirmOpenSeqid
+	return clientID, &confirmRes.Stateid, confirmOpenSeqid
 }
 
 func TestHandleLock_NewLockOwner_Success(t *testing.T) {

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -501,7 +501,7 @@ func (h *Handler) encodeOpenResult(
 	state.EncodeDelegation(&buf, deleg)
 
 	// Cache the result for replay detection
-	h.StateManager.CacheOpenResult(clientID, ownerData, types.NFS4_OK, buf.Bytes())
+	h.StateManager.CacheOpenOwnerResult(clientID, ownerData, types.NFS4_OK, buf.Bytes())
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
@@ -550,8 +550,11 @@ func (h *Handler) handleOpenConfirm(ctx *types.CompoundContext, reader io.Reader
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager
-	resultStateid, stateErr := h.StateManager.ConfirmOpen(stateid, confirmSeqid)
+	confirmResult, stateErr := h.StateManager.ConfirmOpen(stateid, confirmSeqid)
 	if stateErr != nil {
+		if replay := asReplay(types.OP_OPEN_CONFIRM, stateErr); replay != nil {
+			return replay
+		}
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 OPEN_CONFIRM failed",
 			"error", stateErr,
@@ -566,7 +569,12 @@ func (h *Handler) handleOpenConfirm(ctx *types.CompoundContext, reader io.Reader
 
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	types.EncodeStateid4(&buf, resultStateid)
+	types.EncodeStateid4(&buf, &confirmResult.Stateid)
+
+	// Cache the encoded reply for replay of a retransmitted OPEN_CONFIRM.
+	if confirmResult.OwnerData != nil {
+		h.StateManager.CacheOpenOwnerResult(confirmResult.OwnerClientID, confirmResult.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/open_create_after_close_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_create_after_close_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// TestOpen_CreateGuarded_AfterCloseSameOwner reproduces the pjdfstest
+// open/07.t / open/22.t / rename/04.t NFSv4.0 regression.
+//
+// A Linux v4.0 client reuses a single open-owner across files. After it
+// creates+confirms+closes one file, the FIRST GUARDED create of a DIFFERENT,
+// freshly-named file must succeed (NFS4_OK) regardless of the open-owner seqid
+// the client uses for it. The open-owner seqid is per-owner state; once the
+// owner has no remaining open state it must NOT keep gating new OPENs against
+// the (now stale) seqid advanced by the prior CLOSE — doing so either rejects
+// the new create as NFS4ERR_BAD_SEQID or, when the seqid happens to equal the
+// retained owner's last seqid, mis-classifies the brand-new OPEN as a REPLAY
+// and returns the cached CLOSE reply, which downstream surfaces as the spurious
+// NFS4ERR_EXIST the test suite observed.
+//
+// This is the behavior PR #890's open-owner retention broke and that this fix
+// restores: after the last CLOSE the owner is dropped from the live owner table
+// (so new OPENs are unconstrained, as before), while still being retained for
+// CLOSE replay via closedOwnerByOther.
+func TestOpen_CreateGuarded_AfterCloseSameOwner(t *testing.T) {
+	const clientID = uint64(0x12345678)
+	owner := []byte("pjdfstest-open-owner")
+
+	decodeStateid := func(t *testing.T, data []byte) *types.Stateid4 {
+		t.Helper()
+		r := bytes.NewReader(data)
+		_, _ = xdr.DecodeUint32(r) // status
+		sid, err := types.DecodeStateid4(r)
+		if err != nil {
+			t.Fatalf("decode stateid: %v", err)
+		}
+		return sid
+	}
+
+	// Drive create+confirm+close of file1 on a shared owner, then attempt the
+	// first GUARDED create of file2 at file2Seq. Returns file2's OPEN status.
+	run := func(t *testing.T, file2Seq uint32) uint32 {
+		t.Helper()
+		fx := newIOTestFixture(t, "/export")
+		ctx := newRealFSContext(65534, 65534)
+
+		openCreateGuarded := func(seqid uint32, filename string) *types.CompoundResult {
+			ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+			copy(ctx.CurrentFH, fx.rootHandle)
+			args := encodeOpenArgs(
+				seqid,
+				types.OPEN4_SHARE_ACCESS_BOTH,
+				types.OPEN4_SHARE_DENY_NONE,
+				clientID, owner,
+				types.OPEN4_CREATE, types.GUARDED4, types.CLAIM_NULL,
+				filename,
+			)
+			return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+		}
+
+		r1 := openCreateGuarded(1, "file1.txt")
+		if r1.Status != types.NFS4_OK {
+			t.Fatalf("file1 OPEN CREATE status = %d, want NFS4_OK", r1.Status)
+		}
+		sid1 := decodeStateid(t, r1.Data)
+
+		cr := fx.handler.handleOpenConfirm(ctx, bytes.NewReader(encodeOpenConfirmArgs(sid1, 2)))
+		if cr.Status != types.NFS4_OK {
+			t.Fatalf("file1 OPEN_CONFIRM status = %d, want NFS4_OK", cr.Status)
+		}
+		confirmedSid := decodeStateid(t, cr.Data)
+
+		clr := fx.handler.handleClose(ctx, bytes.NewReader(encodeCloseArgs(3, confirmedSid)))
+		if clr.Status != types.NFS4_OK {
+			t.Fatalf("file1 CLOSE status = %d, want NFS4_OK", clr.Status)
+		}
+
+		// First GUARDED create of a brand-new name on the SAME owner.
+		return openCreateGuarded(file2Seq, "file2.txt").Status
+	}
+
+	// After CLOSE advances the owner seqid to 3, a fresh create must succeed no
+	// matter what seqid the client picks for it. Pre-fix #890 returned
+	// NFS4ERR_BAD_SEQID for 1/2/5 and a stale cached CLOSE reply for 3.
+	for _, file2Seq := range []uint32{1, 2, 3, 4, 5} {
+		file2Seq := file2Seq
+		t.Run("file2Seq", func(t *testing.T) {
+			status := run(t, file2Seq)
+			if status == types.NFS4ERR_EXIST {
+				t.Fatalf("first GUARDED create of file2 (seqid=%d) returned NFS4ERR_EXIST "+
+					"(regression: new OPEN mis-classified as replay of retained owner)", file2Seq)
+			}
+			if status != types.NFS4_OK {
+				t.Fatalf("first GUARDED create of file2 (seqid=%d) status = %d, want NFS4_OK",
+					file2Seq, status)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
@@ -237,15 +237,9 @@ func TestSequence_ReplayWithCache(t *testing.T) {
 		t.Fatalf("first request status = %d, want NFS4_OK", decoded1.Status)
 	}
 
-	// Second request: same slot+seqid (replay)
-	seqArgs2 := encodeSequenceArgs(sessionID, 0, 1, 0, true)
-	ops2 := []compoundOp{
-		{opCode: types.OP_SEQUENCE, data: seqArgs2},
-		{opCode: types.OP_PUTROOTFH},
-	}
-	data2 := buildCompoundArgsWithOps([]byte("replay2"), 1, ops2)
-
-	resp2, err := h.ProcessCompound(ctx, data2)
+	// Second request: a genuine retransmit is byte-identical (same tag, slot,
+	// seqid, and ops), so reuse the exact same request bytes.
+	resp2, err := h.ProcessCompound(ctx, data)
 	if err != nil {
 		t.Fatalf("ProcessCompound #2 error: %v", err)
 	}
@@ -278,14 +272,8 @@ func TestSequence_ReplayWithoutCache(t *testing.T) {
 		t.Fatalf("first request status = %d, want NFS4_OK", decoded1.Status)
 	}
 
-	// Second request: same slot+seqid (retry of uncached)
-	seqArgs2 := encodeSequenceArgs(sessionID, 0, 1, 0, false)
-	ops2 := []compoundOp{
-		{opCode: types.OP_SEQUENCE, data: seqArgs2},
-	}
-	data2 := buildCompoundArgsWithOps([]byte("uncached2"), 1, ops2)
-
-	resp2, err := h.ProcessCompound(ctx, data2)
+	// Second request: byte-identical retransmit of the same (uncached) request.
+	resp2, err := h.ProcessCompound(ctx, data)
 	if err != nil {
 		t.Fatalf("ProcessCompound #2 error: %v", err)
 	}
@@ -295,6 +283,59 @@ func TestSequence_ReplayWithoutCache(t *testing.T) {
 	if decoded2.Status != types.NFS4ERR_RETRY_UNCACHED_REP {
 		t.Errorf("uncached retry status = %d, want NFS4ERR_RETRY_UNCACHED_REP (%d)",
 			decoded2.Status, types.NFS4ERR_RETRY_UNCACHED_REP)
+	}
+}
+
+// TestSequence_FalseRetry_DifferentOps verifies H6: a slot+seqid reused with a
+// DIFFERENT request must be rejected with NFS4ERR_SEQ_FALSE_RETRY instead of
+// silently replaying the stale cached reply (RFC 8881 Section 2.10.6.1.3).
+func TestSequence_FalseRetry_DifferentOps(t *testing.T) {
+	h, sessionID := createTestSession(t)
+	ctx := newTestCompoundContext()
+
+	// First request on slot 0 seqid 1: SEQUENCE + PUTROOTFH, cached.
+	seqArgs := encodeSequenceArgs(sessionID, 0, 1, 0, true)
+	opsA := []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: seqArgs},
+		{opCode: types.OP_PUTROOTFH},
+	}
+	dataA := buildCompoundArgsWithOps([]byte("fr"), 1, opsA)
+
+	respA, err := h.ProcessCompound(ctx, dataA)
+	if err != nil {
+		t.Fatalf("ProcessCompound A error: %v", err)
+	}
+	decodedA, _ := decodeSequenceRes(t, respA)
+	if decodedA.Status != types.NFS4_OK {
+		t.Fatalf("request A status = %d, want NFS4_OK", decodedA.Status)
+	}
+
+	// Retry slot 0 seqid 1 with a DIFFERENT op-list (drop PUTROOTFH). Same
+	// session/slot/seqid but a different request body.
+	seqArgsB := encodeSequenceArgs(sessionID, 0, 1, 0, true)
+	opsB := []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: seqArgsB},
+	}
+	dataB := buildCompoundArgsWithOps([]byte("fr"), 1, opsB)
+
+	respB, err := h.ProcessCompound(ctx, dataB)
+	if err != nil {
+		t.Fatalf("ProcessCompound B error: %v", err)
+	}
+	decodedB, _ := decodeSequenceRes(t, respB)
+	if decodedB.Status != types.NFS4ERR_SEQ_FALSE_RETRY {
+		t.Errorf("false retry status = %d, want NFS4ERR_SEQ_FALSE_RETRY (%d)",
+			decodedB.Status, types.NFS4ERR_SEQ_FALSE_RETRY)
+	}
+
+	// A byte-identical (true) retry of A must still replay the cached reply.
+	respC, err := h.ProcessCompound(ctx, dataA)
+	if err != nil {
+		t.Fatalf("ProcessCompound C error: %v", err)
+	}
+	if !bytes.Equal(respA, respC) {
+		t.Errorf("identical retry did not replay cached reply (len %d vs %d)",
+			len(respA), len(respC))
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/setclientid.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
@@ -162,4 +163,21 @@ func (h *Handler) handleSetClientIDConfirm(ctx *types.CompoundContext, reader io
 // Delegates to v41handlers.MapStateError to avoid duplicating the error mapping logic.
 func mapStateError(err error) uint32 {
 	return v41handlers.MapStateError(err)
+}
+
+// asReplay returns the cached COMPOUND op result to replay if err is a
+// state.ReplayError (a retransmit of an owner-seqid op at the last-processed
+// seqid). The returned bytes are the exact original reply, satisfying the
+// NFSv4.0 exactly-once contract (RFC 7530 §9.1.7). Returns nil when err is not
+// a replay, so callers fall through to normal error mapping.
+func asReplay(opCode uint32, err error) *types.CompoundResult {
+	var re *state.ReplayError
+	if errors.As(err, &re) {
+		return &types.CompoundResult{
+			Status: re.Status,
+			OpCode: opCode,
+			Data:   re.Data,
+		}
+	}
+	return nil
 }

--- a/internal/adapter/nfs/v4/handlers/stubs.go
+++ b/internal/adapter/nfs/v4/handlers/stubs.go
@@ -107,10 +107,13 @@ func (h *Handler) handleOpenDowngrade(ctx *types.CompoundContext, reader io.Read
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager
-	resultStateid, stateErr := h.StateManager.DowngradeOpen(
+	downgradeResult, stateErr := h.StateManager.DowngradeOpen(
 		stateid, downgradeSeqid, newShareAccess, newShareDeny,
 	)
 	if stateErr != nil {
+		if replay := asReplay(types.OP_OPEN_DOWNGRADE, stateErr); replay != nil {
+			return replay
+		}
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 OPEN_DOWNGRADE failed",
 			"error", stateErr,
@@ -125,7 +128,12 @@ func (h *Handler) handleOpenDowngrade(ctx *types.CompoundContext, reader io.Read
 
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	types.EncodeStateid4(&buf, resultStateid)
+	types.EncodeStateid4(&buf, &downgradeResult.Stateid)
+
+	// Cache the encoded reply for replay of a retransmitted OPEN_DOWNGRADE.
+	if downgradeResult.OwnerData != nil {
+		h.StateManager.CacheOpenOwnerResult(downgradeResult.OwnerClientID, downgradeResult.OwnerData, types.NFS4_OK, buf.Bytes())
+	}
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -213,10 +213,11 @@ func TestImplicitRenewal_ViaValidateStateid(t *testing.T) {
 	}
 
 	// Confirm the open
-	confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
+	confirmedStateid := &confirmedRes.Stateid
 
 	// Record the lease LastRenew before validation
 	record := sm.GetClient(result.ClientID)
@@ -270,10 +271,11 @@ func TestLeaseExpired_ReturnsError(t *testing.T) {
 	}
 
 	// Confirm the open
-	confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
+	confirmedStateid := &confirmedRes.Stateid
 
 	// Stop the lease timer to prevent cleanup callback from removing state
 	// (we want to test the ValidateStateid check, not the cleanup)

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -105,6 +105,12 @@ type LockResult struct {
 	// Denied is the conflict information (set on NFS4ERR_DENIED).
 	// Nil on success.
 	Denied *LOCK4denied
+
+	// OwnerClientID and OwnerData identify the lock-owner whose seqid this op
+	// advanced. The handler uses them to cache the encoded reply for replay
+	// detection (CacheLockOwnerResult) on both success and DENIED outcomes.
+	OwnerClientID uint64
+	OwnerData     []byte
 }
 
 // LOCK4denied describes a conflicting lock for NFS4ERR_DENIED responses.

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -164,12 +164,12 @@ func setupClientAndOpenState(t *testing.T, sm *StateManager) (clientID uint64, f
 
 	// Confirm the open
 	confirmSeqid := openSeqid + 1
-	confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid)
+	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}
 
-	return clientID, fileHandle, confirmedStateid, confirmSeqid
+	return clientID, fileHandle, &confirmRes.Stateid, confirmSeqid
 }
 
 // ============================================================================
@@ -313,10 +313,11 @@ func TestLockNew_OpenModeViolation(t *testing.T) {
 		t.Fatalf("OpenFile failed: %v", err)
 	}
 
-	confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}
+	confirmedStateid := &confirmedRes.Stateid
 
 	// Try to get a write lock on a read-only open
 	_, lockErr := sm.LockNew(
@@ -509,10 +510,11 @@ func TestLockNew_Conflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile 1 failed: %v", err)
 	}
-	confirmed1, err := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, err := sm.ConfirmOpen(&open1.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen 1 failed: %v", err)
 	}
+	confirmed1 := &confirmed1Res.Stateid
 
 	// Client 2
 	res2, err := sm.SetClientID("client-2", verifier2, callback, "10.0.0.2:1234")
@@ -526,10 +528,11 @@ func TestLockNew_Conflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile 2 failed: %v", err)
 	}
-	confirmed2, err := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, err := sm.ConfirmOpen(&open2.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen 2 failed: %v", err)
 	}
+	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock on range [0, 100)
 	lockResult1, err := sm.LockNew(
@@ -580,13 +583,15 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 	res1, _ := sm.SetClientID("client-shared-1", verifier1, callback, "10.0.0.1:1234")
 	_ = sm.ConfirmClientID(res1.ClientID, res1.ConfirmVerifier)
 	open1, _ := sm.OpenFile(res1.ClientID, []byte("owner-1"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed1, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1 := &confirmed1Res.Stateid
 
 	// Client 2
 	res2, _ := sm.SetClientID("client-shared-2", verifier2, callback, "10.0.0.2:1234")
 	_ = sm.ConfirmClientID(res2.ClientID, res2.ConfirmVerifier)
 	open2, _ := sm.OpenFile(res2.ClientID, []byte("owner-2"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed2, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires shared lock
 	lockResult1, err := sm.LockNew(
@@ -667,12 +672,12 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 	}
 
 	// Now CLOSE should succeed
-	closedStateid, closeErr := sm.CloseFile(openStateid, openSeqid+2)
+	closedRes, closeErr := sm.CloseFile(openStateid, openSeqid+2)
 	if closeErr != nil {
 		t.Fatalf("CloseFile after unlock+release failed: %v", closeErr)
 	}
-	if closedStateid.Seqid != 0 {
-		t.Errorf("closed stateid seqid = %d, want 0 (zeroed)", closedStateid.Seqid)
+	if closedRes.Stateid.Seqid != 0 {
+		t.Errorf("closed stateid seqid = %d, want 0 (zeroed)", closedRes.Stateid.Seqid)
 	}
 }
 
@@ -850,10 +855,11 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile for client 2 failed: %v", err)
 	}
-	confirmed2, err := sm.ConfirmOpen(&openResult2.Stateid, 2)
+	confirmed2Res, err := sm.ConfirmOpen(&openResult2.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen for client 2 failed: %v", err)
 	}
+	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 2 should be able to acquire a lock on the same range
 	// (previously held by expired client 1)
@@ -887,12 +893,14 @@ func TestLockNew_BlockingType(t *testing.T) {
 	res1, _ := sm.SetClientID("client-block-1", verifier1, callback, "10.0.0.1:1234")
 	_ = sm.ConfirmClientID(res1.ClientID, res1.ConfirmVerifier)
 	open1, _ := sm.OpenFile(res1.ClientID, []byte("owner-1"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed1, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1 := &confirmed1Res.Stateid
 
 	res2, _ := sm.SetClientID("client-block-2", verifier2, callback, "10.0.0.2:1234")
 	_ = sm.ConfirmClientID(res2.ClientID, res2.ConfirmVerifier)
 	open2, _ := sm.OpenFile(res2.ClientID, []byte("owner-2"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed2, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock
 	_, err := sm.LockNew(
@@ -917,10 +925,13 @@ func TestLockNew_BlockingType(t *testing.T) {
 		t.Fatal("expected LOCK4denied for WRITEW_LT on conflicting range (should not block)")
 	}
 
-	// Also test READW_LT with a new lock-owner (seqids not advanced from denied)
+	// Also test READW_LT with a new lock-owner. A DENIED LOCK still advances
+	// the open-owner seqid (RFC 7530 §8.1.5: NFS4ERR_DENIED is not a
+	// seqid-exempt error), so this reuse of the same open-owner uses the next
+	// open seqid (4), not 3.
 	lockResult2, err := sm.LockNew(
 		res2.ClientID, []byte("lock-owner-2b"), 1,
-		confirmed2, 3,
+		confirmed2, 4,
 		fh, types.READW_LT, 0, 100, false,
 	)
 	if err != nil {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -49,6 +49,14 @@ type StateManager struct {
 	// Key is composite of clientID + hex(ownerData).
 	openOwners map[openOwnerKey]*OpenOwner
 
+	// closedOwnerByOther maps the "other" of a now-closed open stateid to the
+	// retained open-owner. CLOSE deletes the OpenState, so a retransmitted
+	// CLOSE can no longer resolve the owner via openStateByOther; this map lets
+	// the CLOSE replay path find the owner (and its cached reply) to satisfy
+	// the NFSv4.0 exactly-once contract (RFC 7530 §9.1.7). Entries are cleared
+	// when the owner is reaped (lease expiry) or the stateid is reused.
+	closedOwnerByOther map[[types.NFS4_OTHER_SIZE]byte]*OpenOwner
+
 	// lockOwners maps lock-owner keys to LockOwner records.
 	// Key is composite of clientID + hex(ownerData), same pattern as openOwners.
 	lockOwners map[lockOwnerKey]*LockOwner
@@ -202,6 +210,7 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		unconfirmedByName:   make(map[string]*ClientRecord),
 		openStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*OpenState),
 		openOwners:          make(map[openOwnerKey]*OpenOwner),
+		closedOwnerByOther:  make(map[[types.NFS4_OTHER_SIZE]byte]*OpenOwner),
 		lockOwners:          make(map[lockOwnerKey]*LockOwner),
 		lockStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*LockState),
 		delegByOther:        make(map[[types.NFS4_OTHER_SIZE]byte]*DelegationState),
@@ -678,6 +687,13 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 		delete(sm.openOwners, ownerKey)
 	}
 
+	// Drop any retained closed-stateid -> owner replay entries for this client.
+	for other, owner := range sm.closedOwnerByOther {
+		if owner.ClientID == clientID {
+			delete(sm.closedOwnerByOther, other)
+		}
+	}
+
 	// Clean up delegations for the expired client
 	for other, deleg := range sm.delegByOther {
 		if deleg.ClientID != clientID {
@@ -1137,10 +1153,16 @@ func (sm *StateManager) shareConflictLocked(
 	return false
 }
 
-// CacheOpenResult stores the cached result for an open-owner so that
-// replay detection returns the correct response. Called by the handler
-// after encoding the OPEN response.
-func (sm *StateManager) CacheOpenResult(clientID uint64, ownerData []byte, status uint32, data []byte) {
+// CacheOpenOwnerResult stores the encoded reply for an open-owner so that a
+// replay (retransmit at the same seqid) returns the exact original response.
+//
+// It must be called by the handler after encoding the reply of EVERY
+// owner-seqid-advancing op (OPEN/CLOSE/OPEN_DOWNGRADE/OPEN_CONFIRM), not just
+// OPEN — otherwise a retransmit of a CLOSE/DOWNGRADE/CONFIRM would replay stale
+// OPEN bytes (or none), causing NFS4ERR_BAD_SEQID storms (RFC 7530 §9.1.7,
+// mirrors Linux nfsd so_replay). data must be a caller-owned copy; it is
+// retained until the next op or lease expiry.
+func (sm *StateManager) CacheOpenOwnerResult(clientID uint64, ownerData []byte, status uint32, data []byte) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1156,6 +1178,27 @@ func (sm *StateManager) CacheOpenResult(clientID uint64, ownerData []byte, statu
 	}
 }
 
+// CacheLockOwnerResult stores the encoded reply for a lock-owner so that a
+// replayed LOCK/LOCKU at the same lock-owner seqid returns the exact original
+// response instead of NFS4ERR_BAD_SEQID (which the Linux client treats as
+// fatal, dropping the lock-owner and silently losing locks). Symmetric to
+// CacheOpenOwnerResult; see RFC 7530 §9.1.7 / §8.20.
+func (sm *StateManager) CacheLockOwnerResult(clientID uint64, ownerData []byte, status uint32, data []byte) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	loKey := makeLockOwnerKey(clientID, ownerData)
+	lockOwner, exists := sm.lockOwners[loKey]
+	if !exists {
+		return
+	}
+
+	lockOwner.LastResult = &CachedResult{
+		Status: status,
+		Data:   data,
+	}
+}
+
 // ConfirmOpen implements the OPEN_CONFIRM operation's state management.
 //
 // Per RFC 7530 Section 16.20:
@@ -1165,7 +1208,7 @@ func (sm *StateManager) CacheOpenResult(clientID uint64, ownerData []byte, statu
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*types.Stateid4, error) {
+func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*OpenSeqResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1186,10 +1229,9 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*typ
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:
+			// Replay the exact cached reply of the original op at this seqid.
 			if owner.LastResult != nil {
-				// For OPEN_CONFIRM replay, return the confirmed stateid
-				resultStateid := openState.Stateid
-				return &resultStateid, nil
+				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
 			}
 			return nil, ErrBadSeqid
 		case SeqIDBad:
@@ -1215,7 +1257,11 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*typ
 		"client_id", owner.ClientID,
 		"stateid_seqid", resultStateid.Seqid)
 
-	return &resultStateid, nil
+	return &OpenSeqResult{
+		Stateid:       resultStateid,
+		OwnerClientID: owner.ClientID,
+		OwnerData:     owner.OwnerData,
+	}, nil
 }
 
 // ConfirmOpenV41 confirms an open-owner for NFSv4.1 without incrementing
@@ -1252,11 +1298,10 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4) error {
 //   - Returns a zeroed stateid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types.Stateid4, error) {
+func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenSeqResult, error) {
 	// Handle special stateids (all-zeros, all-ones): no state to clean up
 	if stateid.IsSpecialStateid() {
-		var zeroed types.Stateid4
-		return &zeroed, nil
+		return &OpenSeqResult{}, nil
 	}
 
 	sm.mu.Lock()
@@ -1265,6 +1310,14 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types
 	// Look up the open state
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
+		// The state was already removed by a prior CLOSE. If this is a
+		// retransmit of that CLOSE (same owner-seqid), replay its cached reply
+		// (RFC 7530 §9.1.7) rather than returning NFS4ERR_BAD_STATEID.
+		if owner, ok := sm.closedOwnerByOther[stateid.Other]; ok && seqid != 0 {
+			if owner.ValidateSeqID(seqid) == SeqIDReplay && owner.LastResult != nil {
+				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
+			}
+		}
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for CLOSE",
@@ -1279,9 +1332,11 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:
-			// CLOSE replay: return zeroed stateid
-			var zeroed types.Stateid4
-			return &zeroed, nil
+			// Replay the exact cached CLOSE reply rather than re-deriving it.
+			if owner.LastResult != nil {
+				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
+			}
+			return nil, ErrBadSeqid
 		case SeqIDBad:
 			return nil, ErrBadSeqid
 		case SeqIDOK:
@@ -1302,6 +1357,10 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types
 	// Remove the open state from the "other" map
 	delete(sm.openStateByOther, stateid.Other)
 
+	// Remember which retained owner this now-closed stateid belonged to so a
+	// retransmitted CLOSE can still resolve the owner's cached reply.
+	sm.closedOwnerByOther[stateid.Other] = owner
+
 	// Remove from owner's OpenStates list
 	for i, os := range owner.OpenStates {
 		if os == openState {
@@ -1313,27 +1372,21 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types
 	// Update owner seqid
 	owner.LastSeqID = seqid
 
-	// If owner has no more open states, clean up
-	if len(owner.OpenStates) == 0 {
-		ownerKey := makeOwnerKey(owner.ClientID, owner.OwnerData)
-		delete(sm.openOwners, ownerKey)
-
-		// Remove from client record
-		if owner.ClientRecord != nil {
-			delete(owner.ClientRecord.OpenOwners, string(owner.OwnerData))
-		}
-
-		logger.Debug("CloseFile: owner removed (no more open states)",
-			"client_id", owner.ClientID)
-	}
+	// NOTE: the open-owner is intentionally retained even when it has no
+	// remaining open states, so its LastResult stays available to replay a
+	// retransmitted CLOSE (RFC 7530 §9.1.7, mirrors Linux nfsd so_replay where
+	// stateowners live until lease expiry). The lease reaper (onLeaseExpired)
+	// walks ClientRecord.OpenOwners and removes these stale-but-cached owners.
 
 	logger.Debug("CloseFile: state removed",
 		"client_id", owner.ClientID,
 		"seqid", seqid)
 
-	// Return zeroed stateid
-	var zeroed types.Stateid4
-	return &zeroed, nil
+	// Return zeroed stateid plus owner identity for reply caching.
+	return &OpenSeqResult{
+		OwnerClientID: owner.ClientID,
+		OwnerData:     owner.OwnerData,
+	}, nil
 }
 
 // DowngradeOpen implements the OPEN_DOWNGRADE operation's state management.
@@ -1346,7 +1399,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*types
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32) (*types.Stateid4, error) {
+func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32) (*OpenSeqResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1367,8 +1420,12 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:
-			resultStateid := openState.Stateid
-			return &resultStateid, nil
+			// Replay the exact cached reply (original stateid bytes), not the
+			// current stateid which a later DOWNGRADE may have advanced.
+			if owner.LastResult != nil {
+				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
+			}
+			return nil, ErrBadSeqid
 		case SeqIDBad:
 			return nil, ErrBadSeqid
 		case SeqIDOK:
@@ -1416,7 +1473,11 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 		"new_deny", newShareDeny,
 		"stateid_seqid", resultStateid.Seqid)
 
-	return &resultStateid, nil
+	return &OpenSeqResult{
+		Stateid:       resultStateid,
+		OwnerClientID: owner.ClientID,
+		OwnerData:     owner.OwnerData,
+	}, nil
 }
 
 // GetOpenState returns the OpenState for a given stateid "other" field,
@@ -1552,17 +1613,21 @@ func (sm *StateManager) LockNew(
 		return nil, ErrBadStateid
 	}
 
-	// 2. Validate open-owner seqid
+	// 2. Validate open-owner seqid.
+	// In the open_to_lock_owner4 (LockNew) path the LOCK advances BOTH the
+	// open-owner and lock-owner seqids, so a retransmit is a replay against
+	// both. The authoritative cached reply lives on the lock-owner (it is the
+	// LOCK reply), so on an open-owner replay we do not fail here; we resolve
+	// the lock-owner below (step 6) and return its cached result.
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
+	openSeqIsReplay := false
 	if openSeqid != 0 {
 		validation := openState.Owner.ValidateSeqID(openSeqid)
 		switch validation {
 		case SeqIDBad:
 			return nil, ErrBadSeqid
 		case SeqIDReplay:
-			// For replay on a lock-new, we don't have a cached lock result
-			// on the open-owner (those belong to OPEN operations).
-			return nil, ErrBadSeqid
+			openSeqIsReplay = true
 		case SeqIDOK:
 			// Continue
 		}
@@ -1624,14 +1689,24 @@ func (sm *StateManager) LockNew(
 		case SeqIDBad:
 			return nil, ErrBadSeqid
 		case SeqIDReplay:
-			// Return cached result if available
+			// Replay the exact cached LOCK reply. Returning NFS4ERR_BAD_SEQID
+			// here (the previous behavior) is treated as fatal by the Linux
+			// client and drops the lock-owner -> silent lock loss.
 			if lockOwner.LastResult != nil {
-				return nil, ErrBadSeqid
+				return nil, &ReplayError{Status: lockOwner.LastResult.Status, Data: lockOwner.LastResult.Data}
 			}
 			return nil, ErrBadSeqid
 		case SeqIDOK:
-			// Continue
+			// A fresh lock seqid alongside a replayed open seqid is an
+			// inconsistent retransmit; treat as bad seqid.
+			if openSeqIsReplay {
+				return nil, ErrBadSeqid
+			}
 		}
+	} else if openSeqIsReplay {
+		// Open seqid replayed but the lock-owner is brand new / not yet
+		// seqid-tracked: nothing consistent to replay.
+		return nil, ErrBadSeqid
 	}
 
 	// 7. Acquire the lock via unified lock manager
@@ -1640,7 +1715,15 @@ func (sm *StateManager) LockNew(
 		return nil, err
 	}
 	if denied != nil {
-		return &LockResult{Denied: denied}, nil
+		// A DENIED LOCK still advances the lock-owner seqid, so the encoded
+		// LOCK4denied reply must also be cached for replay.
+		lockOwner.LastSeqID = lockSeqid
+		openState.Owner.LastSeqID = openSeqid
+		return &LockResult{
+			Denied:        denied,
+			OwnerClientID: lockOwner.ClientID,
+			OwnerData:     lockOwner.OwnerData,
+		}, nil
 	}
 
 	// 8. Success: update state
@@ -1648,7 +1731,11 @@ func (sm *StateManager) LockNew(
 	lockOwner.LastSeqID = lockSeqid
 	openState.Owner.LastSeqID = openSeqid
 
-	return &LockResult{Stateid: lockState.Stateid}, nil
+	return &LockResult{
+		Stateid:       lockState.Stateid,
+		OwnerClientID: lockOwner.ClientID,
+		OwnerData:     lockOwner.OwnerData,
+	}, nil
 }
 
 // LockExisting implements the LOCK operation for an existing lock-owner.
@@ -1680,7 +1767,31 @@ func (sm *StateManager) LockExisting(
 		return nil, ErrBadStateid
 	}
 
-	// Validate seqid: old vs bad
+	lockOwner := lockState.LockOwner
+
+	// 2. Validate lock seqid on lock-owner FIRST.
+	// A LOCK replay resends the original (pre-LOCK) lock stateid, whose seqid is
+	// now one behind lockState.Stateid.Seqid; the strict stateid-seqid check
+	// below would otherwise reject it as NFS4ERR_OLD_STATEID before the replay
+	// is detected (RFC 7530 §9.1.7).
+	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
+	if lockSeqid != 0 {
+		lockValidation := lockOwner.ValidateSeqID(lockSeqid)
+		switch lockValidation {
+		case SeqIDBad:
+			return nil, ErrBadSeqid
+		case SeqIDReplay:
+			// Replay the exact cached LOCK reply (see LockNew step 6).
+			if lockOwner.LastResult != nil {
+				return nil, &ReplayError{Status: lockOwner.LastResult.Status, Data: lockOwner.LastResult.Data}
+			}
+			return nil, ErrBadSeqid
+		case SeqIDOK:
+			// Continue
+		}
+	}
+
+	// 3. Validate stateid seqid (only for non-replay LOCK)
 	if lockStateid.Seqid < lockState.Stateid.Seqid {
 		return nil, ErrOldStateid
 	}
@@ -1688,24 +1799,9 @@ func (sm *StateManager) LockExisting(
 		return nil, ErrBadStateid
 	}
 
-	// 2. Validate open mode for lock type
+	// 4. Validate open mode for lock type
 	if err := validateOpenModeForLock(lockState.OpenState, lockType); err != nil {
 		return nil, err
-	}
-
-	// 3. Validate lock seqid on lock-owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	lockOwner := lockState.LockOwner
-	if lockSeqid != 0 {
-		lockValidation := lockOwner.ValidateSeqID(lockSeqid)
-		switch lockValidation {
-		case SeqIDBad:
-			return nil, ErrBadSeqid
-		case SeqIDReplay:
-			return nil, ErrBadSeqid
-		case SeqIDOK:
-			// Continue
-		}
 	}
 
 	// 4. Acquire the lock
@@ -1714,14 +1810,24 @@ func (sm *StateManager) LockExisting(
 		return nil, err
 	}
 	if denied != nil {
-		return &LockResult{Denied: denied}, nil
+		// A DENIED LOCK still advances the lock-owner seqid; cache its reply.
+		lockOwner.LastSeqID = lockSeqid
+		return &LockResult{
+			Denied:        denied,
+			OwnerClientID: lockOwner.ClientID,
+			OwnerData:     lockOwner.OwnerData,
+		}, nil
 	}
 
 	// 5. Success: update state
 	lockState.Stateid.Seqid = nextSeqID(lockState.Stateid.Seqid)
 	lockOwner.LastSeqID = lockSeqid
 
-	return &LockResult{Stateid: lockState.Stateid}, nil
+	return &LockResult{
+		Stateid:       lockState.Stateid,
+		OwnerClientID: lockOwner.ClientID,
+		OwnerData:     lockOwner.OwnerData,
+	}, nil
 }
 
 // acquireLock attempts to acquire a byte-range lock via the unified lock manager.
@@ -1899,7 +2005,7 @@ func (sm *StateManager) TestLock(
 func (sm *StateManager) UnlockFile(
 	lockStateid *types.Stateid4, seqid uint32,
 	lockType uint32, offset, length uint64,
-) (*types.Stateid4, error) {
+) (*LockResult, error) {
 	// Special stateids cannot be used with LOCKU
 	if lockStateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
@@ -1918,29 +2024,37 @@ func (sm *StateManager) UnlockFile(
 		return nil, ErrBadStateid
 	}
 
-	// 2. Validate stateid seqid
-	if lockStateid.Seqid < lockState.Stateid.Seqid {
-		return nil, ErrOldStateid
-	}
-	if lockStateid.Seqid > lockState.Stateid.Seqid {
-		return nil, ErrBadStateid
-	}
-
-	// 3. Validate seqid on lock-owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
 	lockOwner := lockState.LockOwner
+
+	// 2. Validate seqid on lock-owner FIRST.
+	// A LOCKU replay resends the original (pre-LOCKU) lock stateid, whose seqid
+	// is now one behind lockState.Stateid.Seqid. The strict stateid-seqid check
+	// below would reject that as NFS4ERR_OLD_STATEID, so the lock-owner replay
+	// must be detected before it (RFC 7530 §9.1.7: exactly-once wins).
+	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
 	if seqid != 0 {
 		validation := lockOwner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDBad:
 			return nil, ErrBadSeqid
 		case SeqIDReplay:
-			// For LOCKU replay, return current stateid (idempotent)
-			resultStateid := lockState.Stateid
-			return &resultStateid, nil
+			// Replay the exact cached LOCKU reply (the original stateid bytes),
+			// not the current stateid which a later LOCKU may have advanced.
+			if lockOwner.LastResult != nil {
+				return nil, &ReplayError{Status: lockOwner.LastResult.Status, Data: lockOwner.LastResult.Data}
+			}
+			return nil, ErrBadSeqid
 		case SeqIDOK:
 			// Continue
 		}
+	}
+
+	// 3. Validate stateid seqid (only for non-replay LOCKU)
+	if lockStateid.Seqid < lockState.Stateid.Seqid {
+		return nil, ErrOldStateid
+	}
+	if lockStateid.Seqid > lockState.Stateid.Seqid {
+		return nil, ErrBadStateid
 	}
 
 	// 4. Release the lock via unified lock manager
@@ -1970,8 +2084,11 @@ func (sm *StateManager) UnlockFile(
 	lockState.Stateid.Seqid = nextSeqID(lockState.Stateid.Seqid)
 	lockOwner.LastSeqID = seqid
 
-	resultStateid := lockState.Stateid
-	return &resultStateid, nil
+	return &LockResult{
+		Stateid:       lockState.Stateid,
+		OwnerClientID: lockOwner.ClientID,
+		OwnerData:     lockOwner.OwnerData,
+	}, nil
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1167,14 +1167,19 @@ func (sm *StateManager) CacheOpenOwnerResult(clientID uint64, ownerData []byte, 
 	defer sm.mu.Unlock()
 
 	ownerKey := makeOwnerKey(clientID, ownerData)
-	owner, exists := sm.openOwners[ownerKey]
-	if !exists {
+	if owner, exists := sm.openOwners[ownerKey]; exists {
+		owner.LastResult = &CachedResult{Status: status, Data: data}
 		return
 	}
 
-	owner.LastResult = &CachedResult{
-		Status: status,
-		Data:   data,
+	// The owner may have just been removed from the live table by CLOSE (its
+	// last open state went away). It is still reachable via closedOwnerByOther
+	// so the CLOSE reply can be cached for a retransmitted CLOSE replay.
+	for _, owner := range sm.closedOwnerByOther {
+		if owner.ClientID == clientID && bytes.Equal(owner.OwnerData, ownerData) {
+			owner.LastResult = &CachedResult{Status: status, Data: data}
+			return
+		}
 	}
 }
 
@@ -1372,11 +1377,24 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 	// Update owner seqid
 	owner.LastSeqID = seqid
 
-	// NOTE: the open-owner is intentionally retained even when it has no
-	// remaining open states, so its LastResult stays available to replay a
-	// retransmitted CLOSE (RFC 7530 §9.1.7, mirrors Linux nfsd so_replay where
-	// stateowners live until lease expiry). The lease reaper (onLeaseExpired)
-	// walks ClientRecord.OpenOwners and removes these stale-but-cached owners.
+	// If the owner has no more open states, drop it from the LIVE owner table
+	// (openOwners + client record) so a subsequent OPEN by the same owner name
+	// is treated as a brand-new owner — NOT subjected to this now-stale seqid,
+	// which would otherwise mis-classify a genuinely new OPEN as a replay (and
+	// return the cached CLOSE reply) or as NFS4ERR_BAD_SEQID. This matches the
+	// pre-retention behavior. The owner object itself stays reachable via
+	// closedOwnerByOther (installed above), so a retransmitted CLOSE can still
+	// replay its cached reply (RFC 7530 §9.1.7); that entry is reaped on lease
+	// expiry.
+	if len(owner.OpenStates) == 0 {
+		ownerKey := makeOwnerKey(owner.ClientID, owner.OwnerData)
+		delete(sm.openOwners, ownerKey)
+		if owner.ClientRecord != nil {
+			delete(owner.ClientRecord.OpenOwners, string(owner.OwnerData))
+		}
+		logger.Debug("CloseFile: owner removed from live table (no more open states), retained for CLOSE replay",
+			"client_id", owner.ClientID)
+	}
 
 	logger.Debug("CloseFile: state removed",
 		"client_id", owner.ClientID,

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -86,9 +86,14 @@ func (oo *OpenOwner) ValidateSeqID(seqid uint32) SeqIDValidation {
 // CachedResult
 // ============================================================================
 
-// CachedResult holds the result of the last operation on an open-owner.
-// When a replay is detected (same seqid), this cached result is returned
-// instead of re-executing the operation.
+// CachedResult holds the result of the last operation on an open- or
+// lock-owner. When a replay is detected (same seqid), this cached result is
+// returned instead of re-executing the operation.
+//
+// Per RFC 7530 Section 9.1.7 the cache must hold the result of the *last*
+// owner-seqid-advancing operation (OPEN/CLOSE/OPEN_DOWNGRADE/OPEN_CONFIRM for
+// open-owners; LOCK/LOCKU for lock-owners), not just OPEN. This mirrors the
+// Linux nfsd per-stateowner `so_replay` buffer.
 type CachedResult struct {
 	// Status is the NFS4 status code of the cached operation.
 	Status uint32
@@ -96,6 +101,25 @@ type CachedResult struct {
 	// Data is the XDR-encoded operation-specific result data.
 	Data []byte
 }
+
+// ReplayError is returned by owner-seqid-advancing StateManager methods when a
+// client retransmits the operation at the last-processed seqid. It carries the
+// exact encoded reply bytes (and status) of the original operation so the
+// handler can return them verbatim, satisfying the NFSv4.0 exactly-once
+// (replay) contract (RFC 7530 Section 9.1.7).
+//
+// It implements error so it can flow through the existing
+// `(*types.Stateid4, error)` / `(*LockResult, error)` return paths without
+// changing signatures; handlers type-assert it before mapping to a status.
+type ReplayError struct {
+	// Status is the NFS4 status code of the cached operation.
+	Status uint32
+
+	// Data is the XDR-encoded operation-specific result data to replay.
+	Data []byte
+}
+
+func (e *ReplayError) Error() string { return "replay of cached owner-seqid result" }
 
 // ============================================================================
 // OpenState
@@ -153,6 +177,20 @@ type OpenFileResult struct {
 
 	// CachedData is the XDR data from the replayed operation (only if IsReplay).
 	CachedData []byte
+}
+
+// OpenSeqResult is returned by the open-owner-seqid-advancing StateManager
+// methods that yield a single stateid (CLOSE / OPEN_CONFIRM / OPEN_DOWNGRADE).
+// It carries the resulting stateid plus the open-owner identity so the handler
+// can cache the encoded reply for replay detection (CacheOpenOwnerResult).
+type OpenSeqResult struct {
+	// Stateid is the stateid to return to the client.
+	Stateid types.Stateid4
+
+	// OwnerClientID and OwnerData identify the open-owner whose seqid this op
+	// advanced.
+	OwnerClientID uint64
+	OwnerData     []byte
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/replay_cache_test.go
+++ b/internal/adapter/nfs/v4/state/replay_cache_test.go
@@ -1,0 +1,257 @@
+package state
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// These tests cover the NFSv4.0 owner-seqid replay caches (RFC 7530 §9.1.7):
+//   - H4: OPEN/CLOSE/OPEN_DOWNGRADE/OPEN_CONFIRM replay on the open-owner.
+//   - H5: LOCK/LOCKU replay on the lock-owner.
+//
+// They model what the handler does: run the op, cache its encoded reply via the
+// matching Cache*OwnerResult, then retransmit at the same seqid and assert the
+// state manager returns a *ReplayError carrying the exact cached bytes (rather
+// than NFS4ERR_BAD_SEQID, which would corrupt the client's seqid bookkeeping or
+// drop a lock-owner).
+
+func mustReplay(t *testing.T, err error, wantStatus uint32, wantData []byte) {
+	t.Helper()
+	var re *ReplayError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *ReplayError, got %T: %v", err, err)
+	}
+	if re.Status != wantStatus {
+		t.Errorf("replay status = %d, want %d", re.Status, wantStatus)
+	}
+	if !bytes.Equal(re.Data, wantData) {
+		t.Errorf("replay data = %x, want %x", re.Data, wantData)
+	}
+}
+
+// setupConfirmedOpen opens and confirms a file, returning the confirmed open
+// stateid and the open-owner identity. The open-owner's next seqid is 3.
+func setupConfirmedOpen(t *testing.T, sm *StateManager, ownerData []byte, fh []byte, access uint32) (*types.Stateid4, uint64) {
+	t.Helper()
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	res, err := sm.SetClientID("replay-client", verifier, callback, "10.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	open, err := sm.OpenFile(res.ClientID, ownerData, 1, fh, access, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+	return &confirmed.Stateid, res.ClientID
+}
+
+// ---------------------------------------------------------------------------
+// H4 — open-owner replay (CLOSE / OPEN_DOWNGRADE / OPEN_CONFIRM)
+// ---------------------------------------------------------------------------
+
+func TestReplay_Close_ReturnsCachedReply(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	owner := []byte("close-replay-owner")
+	stateid, clientID := setupConfirmedOpen(t, sm, owner, []byte("fh-close"), types.OPEN4_SHARE_ACCESS_BOTH)
+
+	// CLOSE at seqid 3 (next open-owner seqid).
+	closed, err := sm.CloseFile(stateid, 3)
+	if err != nil {
+		t.Fatalf("CloseFile: %v", err)
+	}
+	cachedReply := []byte("close-encoded-reply")
+	sm.CacheOpenOwnerResult(clientID, closed.OwnerData, types.NFS4_OK, cachedReply)
+
+	// Retransmit CLOSE at the SAME seqid -> must replay the cached reply,
+	// not NFS4ERR_BAD_SEQID (which would happen with the old single-OPEN cache).
+	_, err = sm.CloseFile(stateid, 3)
+	mustReplay(t, err, types.NFS4_OK, cachedReply)
+}
+
+func TestReplay_OpenDowngrade_ReturnsCachedReply(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	owner := []byte("downgrade-replay-owner")
+	stateid, clientID := setupConfirmedOpen(t, sm, owner, []byte("fh-downgrade"), types.OPEN4_SHARE_ACCESS_BOTH)
+
+	dg, err := sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	if err != nil {
+		t.Fatalf("DowngradeOpen: %v", err)
+	}
+	cachedReply := []byte("downgrade-encoded-reply")
+	sm.CacheOpenOwnerResult(clientID, dg.OwnerData, types.NFS4_OK, cachedReply)
+
+	// A second DOWNGRADE that would advance the stateid seqid must NOT run on a
+	// replay; the original encoded reply is returned verbatim.
+	_, err = sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	mustReplay(t, err, types.NFS4_OK, cachedReply)
+}
+
+func TestReplay_OpenConfirm_ReturnsCachedReply(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	res, err := sm.SetClientID("confirm-replay-client", verifier, callback, "10.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	owner := []byte("confirm-replay-owner")
+	open, err := sm.OpenFile(res.ClientID, owner, 1, []byte("fh-confirm"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+	cachedReply := []byte("confirm-encoded-reply")
+	sm.CacheOpenOwnerResult(res.ClientID, confirmed.OwnerData, types.NFS4_OK, cachedReply)
+
+	// Retransmit OPEN_CONFIRM at seqid 2.
+	_, err = sm.ConfirmOpen(&open.Stateid, 2)
+	mustReplay(t, err, types.NFS4_OK, cachedReply)
+}
+
+// ---------------------------------------------------------------------------
+// H5 — lock-owner replay (LOCK / LOCKU)
+// ---------------------------------------------------------------------------
+
+func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// LOCK (new lock-owner) at lock seqid 1.
+	res, err := sm.LockNew(clientID, []byte("lock-replay-owner"), 1,
+		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+	if res.Denied != nil {
+		t.Fatalf("unexpected lock conflict")
+	}
+	cachedReply := []byte("lock-encoded-reply")
+	sm.CacheLockOwnerResult(res.OwnerClientID, res.OwnerData, types.NFS4_OK, cachedReply)
+
+	// Retransmit the LOCK at the SAME lock seqid via the existing-lock-owner
+	// path. The old code returned NFS4ERR_BAD_SEQID here (fatal to the Linux
+	// client -> dropped lock-owner / silent lock loss); it must replay instead.
+	_, err = sm.LockExisting(&res.Stateid, 1, fh, types.WRITE_LT, 0, 100, false)
+	mustReplay(t, err, types.NFS4_OK, cachedReply)
+}
+
+func TestReplay_LockU_ReturnsCachedReply(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	res, err := sm.LockNew(clientID, []byte("locku-replay-owner"), 1,
+		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+
+	// LOCKU at lock seqid 2.
+	unlock, err := sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100)
+	if err != nil {
+		t.Fatalf("UnlockFile: %v", err)
+	}
+	cachedReply := []byte("locku-encoded-reply")
+	sm.CacheLockOwnerResult(unlock.OwnerClientID, unlock.OwnerData, types.NFS4_OK, cachedReply)
+
+	// Retransmit LOCKU: the client resends the ORIGINAL (pre-LOCKU) lock
+	// stateid whose seqid is now one behind. This must be detected as a replay
+	// (returning the cached reply) and not rejected as NFS4ERR_OLD_STATEID.
+	_, err = sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100)
+	mustReplay(t, err, types.NFS4_OK, cachedReply)
+}
+
+// TestReplay_Lock_Denied_CachesAndReplays verifies that a DENIED LOCK (which
+// still advances the lock-owner seqid per RFC 7530 §8.1.5) caches its reply and
+// replays it on retransmit instead of failing NFS4ERR_BAD_SEQID.
+func TestReplay_Lock_Denied_CachesAndReplays(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	fh := []byte("/export:denied-replay")
+
+	// Client 1 holds an exclusive lock on [0,100).
+	c1, _, open1, seq1 := setupClientAndOpenStateNamed(t, sm, "denied-c1", "owner-1", fh)
+	if _, err := sm.LockNew(c1, []byte("lock-owner-1"), 1, open1, seq1+1, fh, types.WRITE_LT, 0, 100, false); err != nil {
+		t.Fatalf("LockNew c1: %v", err)
+	}
+
+	// Client 2's overlapping LOCK is DENIED.
+	c2, _, open2, seq2 := setupClientAndOpenStateNamed(t, sm, "denied-c2", "owner-2", fh)
+	res, err := sm.LockNew(c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	if err != nil {
+		t.Fatalf("LockNew c2: %v", err)
+	}
+	if res.Denied == nil {
+		t.Fatalf("expected DENIED for overlapping exclusive lock")
+	}
+	cachedReply := []byte("denied-encoded-reply")
+	sm.CacheLockOwnerResult(res.OwnerClientID, res.OwnerData, types.NFS4ERR_DENIED, cachedReply)
+
+	// Retransmit client 2's LOCK at the SAME open+lock seqids -> replay the
+	// cached DENIED reply (both seqids were advanced by the DENIED original).
+	_, err = sm.LockNew(c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	mustReplay(t, err, types.NFS4ERR_DENIED, cachedReply)
+}
+
+// setupClientAndOpenStateNamed is like setupClientAndOpenState but lets the
+// caller pick distinct client/owner names and a shared file handle so multiple
+// clients can contend on the same file.
+func setupClientAndOpenStateNamed(t *testing.T, sm *StateManager, clientName, ownerName string, fh []byte) (uint64, []byte, *types.Stateid4, uint32) {
+	t.Helper()
+	verifier := [8]byte{byte(len(clientName)), 2, 3, 4, 5, 6, 7, 8}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	res, err := sm.SetClientID(clientName, verifier, callback, "10.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("SetClientID %s: %v", clientName, err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID %s: %v", clientName, err)
+	}
+	open, err := sm.OpenFile(res.ClientID, []byte(ownerName), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile %s: %v", clientName, err)
+	}
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	if err != nil {
+		t.Fatalf("ConfirmOpen %s: %v", clientName, err)
+	}
+	return res.ClientID, fh, &confirmed.Stateid, 2
+}

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -186,7 +186,7 @@ func TestNewSession_ForeChannelSlotTableWorks(t *testing.T) {
 	st := sess.ForeChannelSlots
 
 	// First request: slot 0, seqID 1
-	result, _, err := st.ValidateSequence(0, 1)
+	result, _, err := st.ValidateSequence(0, 1, nil)
 	if err != nil {
 		t.Fatalf("ValidateSequence(0, 1) error = %v", err)
 	}
@@ -195,10 +195,10 @@ func TestNewSession_ForeChannelSlotTableWorks(t *testing.T) {
 	}
 
 	// ValidateSequence atomically marks slot in-use; complete with cached reply
-	st.CompleteSlotRequest(0, 1, true, []byte("test-reply"))
+	st.CompleteSlotRequest(0, 1, true, []byte("test-reply"), nil)
 
 	// Retry: same seqID should return SeqRetry with cached reply
-	result, slot, err := st.ValidateSequence(0, 1)
+	result, slot, err := st.ValidateSequence(0, 1, nil)
 	if err != nil {
 		t.Fatalf("ValidateSequence(0, 1) retry error = %v", err)
 	}
@@ -210,7 +210,7 @@ func TestNewSession_ForeChannelSlotTableWorks(t *testing.T) {
 	}
 
 	// Next request: seqID 2
-	result, _, err = st.ValidateSequence(0, 2)
+	result, _, err = st.ValidateSequence(0, 2, nil)
 	if err != nil {
 		t.Fatalf("ValidateSequence(0, 2) error = %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -24,7 +24,7 @@ func openConfirmed(t *testing.T, sm *StateManager, clientID uint64, owner, fileH
 	if err != nil {
 		t.Fatalf("ConfirmOpen(%s): %v", owner, err)
 	}
-	return *confirmed
+	return confirmed.Stateid
 }
 
 func expectShareDenied(t *testing.T, err error) {

--- a/internal/adapter/nfs/v4/state/slot_table.go
+++ b/internal/adapter/nfs/v4/state/slot_table.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -65,6 +66,14 @@ type Slot struct {
 	// CachedReply holds the full XDR-encoded COMPOUND4res for replay.
 	// nil if no reply has been cached (e.g., sa_cachethis was false).
 	CachedReply []byte
+
+	// RequestDigest is a fingerprint of the COMPOUND request that produced
+	// SeqID, used to detect a false retry: a client that reuses slot+seqid
+	// with a DIFFERENT request (RFC 8881 Section 2.10.6.1.3). On a retry whose
+	// digest differs, ValidateSequence returns NFS4ERR_SEQ_FALSE_RETRY rather
+	// than the stale cached reply (confused-deputy / data-exposure guard).
+	// nil when no request has been recorded for this slot yet.
+	RequestDigest []byte
 }
 
 // ============================================================================
@@ -127,14 +136,22 @@ func NewSlotTable(numSlots uint32) *SlotTable {
 // validation algorithm.
 //
 // Returns the validation result, a pointer to the slot (for SeqNew/SeqRetry),
-// and an error (for BADSLOT, SEQ_MISORDERED, DELAY, RETRY_UNCACHED_REP).
+// and an error (for BADSLOT, SEQ_MISORDERED, DELAY, RETRY_UNCACHED_REP,
+// SEQ_FALSE_RETRY).
+//
+// requestDigest is a fingerprint of the COMPOUND request body. On a retry
+// (seqid == cached) whose digest differs from the digest recorded for the
+// cached reply, ValidateSequence returns NFS4ERR_SEQ_FALSE_RETRY per RFC 8881
+// Section 2.10.6.1.3, instead of replaying a reply that belonged to a
+// different request. A nil/empty digest on either side disables the compare
+// (best-effort), preserving prior behavior when no fingerprint is available.
 //
 // For a SeqNew result, also marks the slot as in-use while
 // holding st.mu, making validation and reservation atomic. The caller must
 // call CompleteSlotRequest when the request is finished.
 //
 // Thread-safe: acquires st.mu for the duration of validation.
-func (st *SlotTable) ValidateSequence(slotID, seqID uint32) (SequenceValidation, *Slot, error) {
+func (st *SlotTable) ValidateSequence(slotID, seqID uint32, requestDigest []byte) (SequenceValidation, *Slot, error) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -182,6 +199,18 @@ func (st *SlotTable) ValidateSequence(slotID, seqID uint32) (SequenceValidation,
 				Message: "retry while original request in flight",
 			}
 		}
+		// False-retry detection (RFC 8881 Section 2.10.6.1.3): a retry must
+		// carry the SAME request as the one that produced the cached reply.
+		// If the digests differ, the client reused slot+seqid for a different
+		// request -- never replay the stale reply (it could leak another
+		// operation's result), return NFS4ERR_SEQ_FALSE_RETRY instead.
+		if len(slot.RequestDigest) > 0 && len(requestDigest) > 0 &&
+			!bytes.Equal(slot.RequestDigest, requestDigest) {
+			return SeqMisordered, nil, &NFS4StateError{
+				Status:  types.NFS4ERR_SEQ_FALSE_RETRY,
+				Message: "retry with different request on same slot+seqid",
+			}
+		}
 		if slot.CachedReply == nil {
 			// No cached reply available (sa_cachethis was false).
 			return SeqMisordered, nil, &NFS4StateError{
@@ -199,8 +228,8 @@ func (st *SlotTable) ValidateSequence(slotID, seqID uint32) (SequenceValidation,
 	}
 }
 
-// CompleteSlotRequest marks a slot as completed, stores the sequence ID,
-// and optionally caches the reply bytes.
+// CompleteSlotRequest marks a slot as completed, stores the sequence ID and
+// the request digest, and optionally caches the reply bytes.
 //
 // Called after the full COMPOUND response has been encoded and is ready
 // to send to the client.
@@ -208,8 +237,12 @@ func (st *SlotTable) ValidateSequence(slotID, seqID uint32) (SequenceValidation,
 // If cacheThis is true, reply bytes are copied into the slot's CachedReply.
 // If false, CachedReply is set to nil.
 //
+// requestDigest is recorded regardless of cacheThis so that a subsequent retry
+// on this slot+seqid can be checked for a false retry (RFC 8881
+// Section 2.10.6.1.3) before the cached reply (if any) is replayed.
+//
 // Thread-safe: acquires st.mu.
-func (st *SlotTable) CompleteSlotRequest(slotID, seqID uint32, cacheThis bool, reply []byte) {
+func (st *SlotTable) CompleteSlotRequest(slotID, seqID uint32, cacheThis bool, reply, requestDigest []byte) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -220,6 +253,13 @@ func (st *SlotTable) CompleteSlotRequest(slotID, seqID uint32, cacheThis bool, r
 	slot := &st.slots[slotID]
 	slot.SeqID = seqID
 	slot.InUse = false
+
+	if len(requestDigest) > 0 {
+		slot.RequestDigest = make([]byte, len(requestDigest))
+		copy(slot.RequestDigest, requestDigest)
+	} else {
+		slot.RequestDigest = nil
+	}
 
 	if cacheThis && reply != nil {
 		// Copy reply bytes to avoid holding references to caller's buffer.

--- a/internal/adapter/nfs/v4/state/slot_table_test.go
+++ b/internal/adapter/nfs/v4/state/slot_table_test.go
@@ -59,7 +59,7 @@ func TestValidateSequence_NewRequest(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// Fresh slot: SeqID=0, expected next = 1
-		result, slot, err := st.ValidateSequence(0, 1)
+		result, slot, err := st.ValidateSequence(0, 1, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -75,11 +75,11 @@ func TestValidateSequence_NewRequest(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// ValidateSequence atomically marks slot in-use for SeqNew
-		_, _, _ = st.ValidateSequence(0, 1)
-		st.CompleteSlotRequest(0, 1, true, []byte("reply1"))
+		_, _, _ = st.ValidateSequence(0, 1, nil)
+		st.CompleteSlotRequest(0, 1, true, []byte("reply1"), nil)
 
 		// Next request: seqID=2
-		result, slot, err := st.ValidateSequence(0, 2)
+		result, slot, err := st.ValidateSequence(0, 2, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,12 +95,12 @@ func TestValidateSequence_NewRequest(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// Both slots start fresh, both expect seqID=1
-		result0, _, err0 := st.ValidateSequence(0, 1)
+		result0, _, err0 := st.ValidateSequence(0, 1, nil)
 		if err0 != nil || result0 != SeqNew {
 			t.Errorf("slot 0: result=%d, err=%v; want SeqNew, nil", result0, err0)
 		}
 
-		result1, _, err1 := st.ValidateSequence(1, 1)
+		result1, _, err1 := st.ValidateSequence(1, 1, nil)
 		if err1 != nil || result1 != SeqNew {
 			t.Errorf("slot 1: result=%d, err=%v; want SeqNew, nil", result1, err1)
 		}
@@ -115,10 +115,10 @@ func TestValidateSequence_Retry(t *testing.T) {
 	st := NewSlotTable(4)
 
 	// Set up: complete request with seqID=5, cache reply
-	st.CompleteSlotRequest(0, 5, true, []byte("cached-data"))
+	st.CompleteSlotRequest(0, 5, true, []byte("cached-data"), nil)
 
 	// Retry: seqID=5 (same as cached)
-	result, slot, err := st.ValidateSequence(0, 5)
+	result, slot, err := st.ValidateSequence(0, 5, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,10 +141,10 @@ func TestValidateSequence_RetryUncached(t *testing.T) {
 	st := NewSlotTable(4)
 
 	// Set up: complete request with seqID=5, cacheThis=false
-	st.CompleteSlotRequest(0, 5, false, nil)
+	st.CompleteSlotRequest(0, 5, false, nil, nil)
 
 	// Retry: seqID=5 (same as cached, but no cached reply)
-	_, _, err := st.ValidateSequence(0, 5)
+	_, _, err := st.ValidateSequence(0, 5, nil)
 	if err == nil {
 		t.Fatal("expected error for uncached retry")
 	}
@@ -167,10 +167,10 @@ func TestValidateSequence_Misordered(t *testing.T) {
 	st := NewSlotTable(4)
 
 	// Set up slot at seqID=5
-	st.CompleteSlotRequest(0, 5, true, []byte("reply"))
+	st.CompleteSlotRequest(0, 5, true, []byte("reply"), nil)
 
 	t.Run("behind (old seqid)", func(t *testing.T) {
-		_, _, err := st.ValidateSequence(0, 3)
+		_, _, err := st.ValidateSequence(0, 3, nil)
 		if err == nil {
 			t.Fatal("expected error for old seqid")
 		}
@@ -185,7 +185,7 @@ func TestValidateSequence_Misordered(t *testing.T) {
 	})
 
 	t.Run("gap (ahead by more than 1)", func(t *testing.T) {
-		_, _, err := st.ValidateSequence(0, 7)
+		_, _, err := st.ValidateSequence(0, 7, nil)
 		if err == nil {
 			t.Fatal("expected error for gap seqid")
 		}
@@ -208,7 +208,7 @@ func TestValidateSequence_BadSlot(t *testing.T) {
 	st := NewSlotTable(4) // slots 0-3
 
 	t.Run("slotID equals maxSlots", func(t *testing.T) {
-		_, _, err := st.ValidateSequence(4, 1)
+		_, _, err := st.ValidateSequence(4, 1, nil)
 		if err == nil {
 			t.Fatal("expected error for out-of-range slot")
 		}
@@ -223,7 +223,7 @@ func TestValidateSequence_BadSlot(t *testing.T) {
 	})
 
 	t.Run("slotID far out of range", func(t *testing.T) {
-		_, _, err := st.ValidateSequence(100, 1)
+		_, _, err := st.ValidateSequence(100, 1, nil)
 		if err == nil {
 			t.Fatal("expected error for far out-of-range slot")
 		}
@@ -246,7 +246,7 @@ func TestValidateSequence_SlotInUse(t *testing.T) {
 	st := NewSlotTable(4)
 
 	// ValidateSequence(0, 1) returns SeqNew and atomically marks slot in-use
-	result, _, err := st.ValidateSequence(0, 1)
+	result, _, err := st.ValidateSequence(0, 1, nil)
 	if err != nil || result != SeqNew {
 		t.Fatalf("initial validate failed: result=%d, err=%v", result, err)
 	}
@@ -254,7 +254,7 @@ func TestValidateSequence_SlotInUse(t *testing.T) {
 	t.Run("retransmission of in-flight request", func(t *testing.T) {
 		// Same seqID=1 while slot is in-use should return NFS4ERR_DELAY
 		// (the client is retransmitting the request that's still processing)
-		_, _, err := st.ValidateSequence(0, 1)
+		_, _, err := st.ValidateSequence(0, 1, nil)
 		if err == nil {
 			t.Fatal("expected error for retransmission while in flight")
 		}
@@ -270,7 +270,7 @@ func TestValidateSequence_SlotInUse(t *testing.T) {
 
 	t.Run("retry of previous completed while in flight", func(t *testing.T) {
 		// seqID=0 (the previous completed seqid) while slot is in use
-		_, _, err := st.ValidateSequence(0, 0)
+		_, _, err := st.ValidateSequence(0, 0, nil)
 		if err == nil {
 			t.Fatal("expected error for retry while in flight")
 		}
@@ -293,10 +293,10 @@ func TestValidateSequence_SeqIDWrap(t *testing.T) {
 	st := NewSlotTable(4)
 
 	// Set slot seqID to 0xFFFFFFFF via CompleteSlotRequest
-	st.CompleteSlotRequest(0, 0xFFFFFFFF, true, []byte("max-reply"))
+	st.CompleteSlotRequest(0, 0xFFFFFFFF, true, []byte("max-reply"), nil)
 
 	// Verify retry of 0xFFFFFFFF works before advancing
-	result, slot, err := st.ValidateSequence(0, 0xFFFFFFFF)
+	result, slot, err := st.ValidateSequence(0, 0xFFFFFFFF, nil)
 	if err != nil {
 		t.Fatalf("unexpected error on retry at max: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestValidateSequence_SeqIDWrap(t *testing.T) {
 
 	// Expected next: 0xFFFFFFFF + 1 = 0 (uint32 natural overflow)
 	// In v4.1, seqid=0 IS valid (unlike v4.0 where 0 is reserved)
-	result2, slot2, err2 := st.ValidateSequence(0, 0)
+	result2, slot2, err2 := st.ValidateSequence(0, 0, nil)
 	if err2 != nil {
 		t.Fatalf("unexpected error on wrap: %v", err2)
 	}
@@ -321,10 +321,10 @@ func TestValidateSequence_SeqIDWrap(t *testing.T) {
 	}
 
 	// Complete wrapped request and verify we can continue
-	st.CompleteSlotRequest(0, 0, true, []byte("wrap-reply"))
+	st.CompleteSlotRequest(0, 0, true, []byte("wrap-reply"), nil)
 
 	// Retry of wrapped seqID=0 works
-	result3, slot3, err3 := st.ValidateSequence(0, 0)
+	result3, slot3, err3 := st.ValidateSequence(0, 0, nil)
 	if err3 != nil {
 		t.Fatalf("unexpected error on retry after wrap: %v", err3)
 	}
@@ -336,7 +336,7 @@ func TestValidateSequence_SeqIDWrap(t *testing.T) {
 	}
 
 	// Next request after wrap: seqID=1
-	result4, _, err4 := st.ValidateSequence(0, 1)
+	result4, _, err4 := st.ValidateSequence(0, 1, nil)
 	if err4 != nil {
 		t.Fatalf("unexpected error on post-wrap next: %v", err4)
 	}
@@ -354,13 +354,13 @@ func TestCompleteSlotRequest(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// ValidateSequence atomically marks slot in-use
-		_, _, _ = st.ValidateSequence(0, 1)
+		_, _, _ = st.ValidateSequence(0, 1, nil)
 
 		originalReply := []byte("original-reply-data")
-		st.CompleteSlotRequest(0, 1, true, originalReply)
+		st.CompleteSlotRequest(0, 1, true, originalReply, nil)
 
 		// Verify via retry
-		result, slot, err := st.ValidateSequence(0, 1)
+		result, slot, err := st.ValidateSequence(0, 1, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -382,12 +382,12 @@ func TestCompleteSlotRequest(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// ValidateSequence atomically marks slot in-use
-		_, _, _ = st.ValidateSequence(0, 1)
+		_, _, _ = st.ValidateSequence(0, 1, nil)
 
-		st.CompleteSlotRequest(0, 1, false, nil)
+		st.CompleteSlotRequest(0, 1, false, nil, nil)
 
 		// Retry should fail with RETRY_UNCACHED_REP
-		_, _, err := st.ValidateSequence(0, 1)
+		_, _, err := st.ValidateSequence(0, 1, nil)
 		if err == nil {
 			t.Fatal("expected error for uncached replay")
 		}
@@ -404,27 +404,27 @@ func TestCompleteSlotRequest(t *testing.T) {
 	t.Run("out of range slotID no panic", func(t *testing.T) {
 		st := NewSlotTable(4)
 		// Should not panic for out-of-range slot IDs
-		st.CompleteSlotRequest(10, 1, true, []byte("data"))
-		st.CompleteSlotRequest(100, 1, true, []byte("data"))
+		st.CompleteSlotRequest(10, 1, true, []byte("data"), nil)
+		st.CompleteSlotRequest(100, 1, true, []byte("data"), nil)
 	})
 
 	t.Run("clears InUse flag", func(t *testing.T) {
 		st := NewSlotTable(4)
 
 		// ValidateSequence atomically marks slot in-use
-		_, _, _ = st.ValidateSequence(0, 1)
+		_, _, _ = st.ValidateSequence(0, 1, nil)
 
 		// While in-use, same seqID should return DELAY (retransmission)
-		_, _, err := st.ValidateSequence(0, 1)
+		_, _, err := st.ValidateSequence(0, 1, nil)
 		if err == nil {
 			t.Fatal("expected error while in use")
 		}
 
 		// Complete the request
-		st.CompleteSlotRequest(0, 1, true, []byte("reply"))
+		st.CompleteSlotRequest(0, 1, true, []byte("reply"), nil)
 
 		// Now next seqID should succeed
-		result, _, err2 := st.ValidateSequence(0, 2)
+		result, _, err2 := st.ValidateSequence(0, 2, nil)
 		if err2 != nil {
 			t.Fatalf("unexpected error after complete: %v", err2)
 		}
@@ -504,7 +504,7 @@ func TestSlotTable_Concurrent(t *testing.T) {
 				seqID := uint32(i + 1)
 
 				// ValidateSequence atomically validates and marks in-use
-				result, _, err := st.ValidateSequence(slotID, seqID)
+				result, _, err := st.ValidateSequence(slotID, seqID, nil)
 				if err != nil {
 					// Another goroutine may have advanced the slot;
 					// errors are acceptable in concurrent access
@@ -513,7 +513,7 @@ func TestSlotTable_Concurrent(t *testing.T) {
 
 				if result == SeqNew {
 					// Complete (slot already marked in-use by ValidateSequence)
-					st.CompleteSlotRequest(slotID, seqID, true, []byte("reply"))
+					st.CompleteSlotRequest(slotID, seqID, true, []byte("reply"), nil)
 				}
 			}
 		}(g)
@@ -557,13 +557,13 @@ func TestSlotTable_ConcurrentMixedOps(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 1; i <= 100; i++ {
-			result, _, err := st.ValidateSequence(0, uint32(i))
+			result, _, err := st.ValidateSequence(0, uint32(i), nil)
 			if err != nil {
 				continue
 			}
 			if result == SeqNew {
 				// Slot already marked in-use by ValidateSequence
-				st.CompleteSlotRequest(0, uint32(i), i%2 == 0, []byte("data"))
+				st.CompleteSlotRequest(0, uint32(i), i%2 == 0, []byte("data"), nil)
 			}
 		}
 	}()
@@ -580,16 +580,16 @@ func TestSlotTable_FullWorkflow(t *testing.T) {
 
 	// Step 1: First request on slot 0 (seqID=1)
 	// ValidateSequence atomically marks slot in-use for SeqNew
-	result, _, err := st.ValidateSequence(0, 1)
+	result, _, err := st.ValidateSequence(0, 1, nil)
 	if err != nil || result != SeqNew {
 		t.Fatalf("step 1: result=%d, err=%v; want SeqNew, nil", result, err)
 	}
 
 	// Step 2: Complete with cached reply
-	st.CompleteSlotRequest(0, 1, true, []byte("response-1"))
+	st.CompleteSlotRequest(0, 1, true, []byte("response-1"), nil)
 
 	// Step 3: Retry (seqID=1 again)
-	result, slot, err := st.ValidateSequence(0, 1)
+	result, slot, err := st.ValidateSequence(0, 1, nil)
 	if err != nil || result != SeqRetry {
 		t.Fatalf("step 3: result=%d, err=%v; want SeqRetry, nil", result, err)
 	}
@@ -598,14 +598,14 @@ func TestSlotTable_FullWorkflow(t *testing.T) {
 	}
 
 	// Step 4: Next request (seqID=2)
-	result, _, err = st.ValidateSequence(0, 2)
+	result, _, err = st.ValidateSequence(0, 2, nil)
 	if err != nil || result != SeqNew {
 		t.Fatalf("step 4: result=%d, err=%v; want SeqNew, nil", result, err)
 	}
-	st.CompleteSlotRequest(0, 2, false, nil)
+	st.CompleteSlotRequest(0, 2, false, nil, nil)
 
 	// Step 5: Retry seqID=2 without cache -> RETRY_UNCACHED_REP
-	_, _, err = st.ValidateSequence(0, 2)
+	_, _, err = st.ValidateSequence(0, 2, nil)
 	if err == nil {
 		t.Fatal("step 5: expected error for uncached retry")
 	}
@@ -615,7 +615,7 @@ func TestSlotTable_FullWorkflow(t *testing.T) {
 	}
 
 	// Step 6: Next request (seqID=3)
-	result, _, err = st.ValidateSequence(0, 3)
+	result, _, err = st.ValidateSequence(0, 3, nil)
 	if err != nil || result != SeqNew {
 		t.Fatalf("step 6: result=%d, err=%v; want SeqNew, nil", result, err)
 	}
@@ -628,30 +628,30 @@ func TestSlotTable_MultipleSlots(t *testing.T) {
 	// Use slot 0 and slot 2 independently
 	// Slot 0: seqID progression 1, 2, 3
 	for seqID := uint32(1); seqID <= 3; seqID++ {
-		result, _, err := st.ValidateSequence(0, seqID)
+		result, _, err := st.ValidateSequence(0, seqID, nil)
 		if err != nil || result != SeqNew {
 			t.Fatalf("slot 0 seqID=%d: result=%d, err=%v", seqID, result, err)
 		}
-		st.CompleteSlotRequest(0, seqID, true, []byte("slot0"))
+		st.CompleteSlotRequest(0, seqID, true, []byte("slot0"), nil)
 	}
 
 	// Slot 2: seqID progression 1, 2
 	for seqID := uint32(1); seqID <= 2; seqID++ {
-		result, _, err := st.ValidateSequence(2, seqID)
+		result, _, err := st.ValidateSequence(2, seqID, nil)
 		if err != nil || result != SeqNew {
 			t.Fatalf("slot 2 seqID=%d: result=%d, err=%v", seqID, result, err)
 		}
-		st.CompleteSlotRequest(2, seqID, true, []byte("slot2"))
+		st.CompleteSlotRequest(2, seqID, true, []byte("slot2"), nil)
 	}
 
 	// Verify slot 0 is at seqID=3 (next expected: 4)
-	result, _, err := st.ValidateSequence(0, 4)
+	result, _, err := st.ValidateSequence(0, 4, nil)
 	if err != nil || result != SeqNew {
 		t.Errorf("slot 0 seqID=4: result=%d, err=%v; want SeqNew", result, err)
 	}
 
 	// Verify slot 2 is at seqID=2 (next expected: 3)
-	result2, _, err2 := st.ValidateSequence(2, 3)
+	result2, _, err2 := st.ValidateSequence(2, 3, nil)
 	if err2 != nil || result2 != SeqNew {
 		t.Errorf("slot 2 seqID=3: result=%d, err=%v; want SeqNew", result2, err2)
 	}

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -603,7 +603,7 @@ func TestOpenFile_SeqidReplay(t *testing.T) {
 	}
 
 	// Cache a result
-	sm.CacheOpenResult(0, []byte("owner1"), types.NFS4_OK, []byte("cached-data"))
+	sm.CacheOpenOwnerResult(0, []byte("owner1"), types.NFS4_OK, []byte("cached-data"))
 
 	// Replay with same seqid=1
 	replay, err := sm.OpenFile(0, []byte("owner1"), 1,
@@ -671,8 +671,8 @@ func TestConfirmOpen_Success(t *testing.T) {
 	}
 
 	// Seqid should be incremented
-	if confirmed.Seqid != result.Stateid.Seqid+1 {
-		t.Errorf("confirmed seqid = %d, want %d", confirmed.Seqid, result.Stateid.Seqid+1)
+	if confirmed.Stateid.Seqid != result.Stateid.Seqid+1 {
+		t.Errorf("confirmed seqid = %d, want %d", confirmed.Stateid.Seqid, result.Stateid.Seqid+1)
 	}
 }
 
@@ -717,22 +717,22 @@ func TestCloseFile_Success(t *testing.T) {
 	}
 
 	// Confirm
-	confirmedStateid, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Close
-	closedStateid, err := sm.CloseFile(confirmedStateid, 3)
+	closed, err := sm.CloseFile(&confirmed.Stateid, 3)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 
 	// Should return zeroed stateid
-	if closedStateid.Seqid != 0 {
-		t.Errorf("closed seqid = %d, want 0", closedStateid.Seqid)
+	if closed.Stateid.Seqid != 0 {
+		t.Errorf("closed seqid = %d, want 0", closed.Stateid.Seqid)
 	}
-	for i, b := range closedStateid.Other {
+	for i, b := range closed.Stateid.Other {
 		if b != 0 {
 			t.Errorf("closed other[%d] = %d, want 0", i, b)
 		}
@@ -749,12 +749,12 @@ func TestCloseFile_SpecialStateid(t *testing.T) {
 
 	// Close with anonymous (all-zeros) stateid
 	zeroed := &types.Stateid4{Seqid: 0}
-	closedStateid, err := sm.CloseFile(zeroed, 1)
+	closed, err := sm.CloseFile(zeroed, 1)
 	if err != nil {
 		t.Fatalf("CloseFile with special stateid: %v", err)
 	}
-	if closedStateid.Seqid != 0 {
-		t.Errorf("closed seqid = %d, want 0", closedStateid.Seqid)
+	if closed.Stateid.Seqid != 0 {
+		t.Errorf("closed seqid = %d, want 0", closed.Stateid.Seqid)
 	}
 }
 
@@ -775,19 +775,28 @@ func TestCloseFile_CleansUpOwner(t *testing.T) {
 	}
 
 	// Close
-	_, err = sm.CloseFile(confirmed, 3)
+	_, err = sm.CloseFile(&confirmed.Stateid, 3)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 
-	// Owner should be removed (no more open states)
+	// The open-owner is intentionally RETAINED after the last close so its
+	// cached reply remains available to replay a retransmitted CLOSE (RFC 7530
+	// §9.1.7; reaped later by lease expiry). Its open-state list must be empty.
 	sm.mu.RLock()
 	ownerKey := makeOwnerKey(0, []byte("owner1"))
-	_, ownerExists := sm.openOwners[ownerKey]
+	owner, ownerExists := sm.openOwners[ownerKey]
+	var remainingOpens int
+	if owner != nil {
+		remainingOpens = len(owner.OpenStates)
+	}
 	sm.mu.RUnlock()
 
-	if ownerExists {
-		t.Error("owner should be removed when last open state is closed")
+	if !ownerExists {
+		t.Error("owner should be retained after last close for replay caching")
+	}
+	if remainingOpens != 0 {
+		t.Errorf("owner should have no open states after close, got %d", remainingOpens)
 	}
 }
 
@@ -833,7 +842,7 @@ func TestDowngradeOpen_Success(t *testing.T) {
 	}
 
 	// Downgrade to READ only
-	downgraded, err := sm.DowngradeOpen(confirmed, 3,
+	downgraded, err := sm.DowngradeOpen(&confirmed.Stateid, 3,
 		types.OPEN4_SHARE_ACCESS_READ,
 		types.OPEN4_SHARE_DENY_NONE,
 	)
@@ -842,8 +851,8 @@ func TestDowngradeOpen_Success(t *testing.T) {
 	}
 
 	// Seqid should be incremented
-	if downgraded.Seqid != confirmed.Seqid+1 {
-		t.Errorf("downgraded seqid = %d, want %d", downgraded.Seqid, confirmed.Seqid+1)
+	if downgraded.Stateid.Seqid != confirmed.Stateid.Seqid+1 {
+		t.Errorf("downgraded seqid = %d, want %d", downgraded.Stateid.Seqid, confirmed.Stateid.Seqid+1)
 	}
 
 	// Verify share_access was updated
@@ -875,7 +884,7 @@ func TestDowngradeOpen_CannotAddBits(t *testing.T) {
 	}
 
 	// Try to "downgrade" to BOTH (adds WRITE bit) - should fail
-	_, err = sm.DowngradeOpen(confirmed, 3,
+	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3,
 		types.OPEN4_SHARE_ACCESS_BOTH,
 		types.OPEN4_SHARE_DENY_NONE,
 	)
@@ -913,7 +922,7 @@ func TestDowngradeOpen_ZeroAccess(t *testing.T) {
 	}
 
 	// Downgrade to zero access - should fail
-	_, err = sm.DowngradeOpen(confirmed, 3, 0, 0)
+	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3, 0, 0)
 	if err == nil {
 		t.Fatal("DowngradeOpen should fail with zero share_access")
 	}
@@ -1051,10 +1060,11 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	}
 
 	// OPEN_CONFIRM (seqid=2)
-	confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
+	confirmedStateid := &confirmed.Stateid
 
 	// Validate the confirmed stateid
 	openState, err := sm.ValidateStateid(confirmedStateid, []byte("file-handle-test"), StateidOpRead)
@@ -1069,14 +1079,14 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	}
 
 	// CLOSE (seqid=3)
-	closedStateid, err := sm.CloseFile(confirmedStateid, 3)
+	closed, err := sm.CloseFile(confirmedStateid, 3)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 
 	// Verify closed
-	if closedStateid.Seqid != 0 {
-		t.Errorf("closed seqid = %d, want 0", closedStateid.Seqid)
+	if closed.Stateid.Seqid != 0 {
+		t.Errorf("closed seqid = %d, want 0", closed.Stateid.Seqid)
 	}
 
 	// State should be gone
@@ -1105,10 +1115,11 @@ func TestFreeStateid(t *testing.T) {
 		}
 
 		// Confirm open
-		confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
+		confirmedStateid := &confirmed.Stateid
 
 		// Create lock state
 		lockResult, err := sm.LockNew(
@@ -1178,10 +1189,11 @@ func TestFreeStateid(t *testing.T) {
 			t.Fatalf("OpenFile: %v", err)
 		}
 
-		confirmedStateid, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
+		confirmedStateid := &confirmed.Stateid
 
 		// Create a lock
 		_, err = sm.LockNew(

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"bytes"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -775,28 +777,39 @@ func TestCloseFile_CleansUpOwner(t *testing.T) {
 	}
 
 	// Close
-	_, err = sm.CloseFile(&confirmed.Stateid, 3)
+	closed, err := sm.CloseFile(&confirmed.Stateid, 3)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
+	// Cache the CLOSE reply as the handler would.
+	sm.CacheOpenOwnerResult(closed.OwnerClientID, closed.OwnerData, types.NFS4_OK, []byte("close-reply"))
 
-	// The open-owner is intentionally RETAINED after the last close so its
-	// cached reply remains available to replay a retransmitted CLOSE (RFC 7530
-	// §9.1.7; reaped later by lease expiry). Its open-state list must be empty.
+	// After the last close the open-owner is removed from the LIVE owner table
+	// so a subsequent OPEN by the same name is treated as brand-new (and not
+	// rejected/replayed against this now-stale seqid). The owner object is still
+	// reachable via closedOwnerByOther so a retransmitted CLOSE can replay its
+	// cached reply (RFC 7530 §9.1.7); that entry is reaped on lease expiry.
 	sm.mu.RLock()
 	ownerKey := makeOwnerKey(0, []byte("owner1"))
-	owner, ownerExists := sm.openOwners[ownerKey]
-	var remainingOpens int
-	if owner != nil {
-		remainingOpens = len(owner.OpenStates)
-	}
+	_, liveExists := sm.openOwners[ownerKey]
+	_, retainedExists := sm.closedOwnerByOther[confirmed.Stateid.Other]
 	sm.mu.RUnlock()
 
-	if !ownerExists {
-		t.Error("owner should be retained after last close for replay caching")
+	if liveExists {
+		t.Error("owner should be removed from the live table after last close")
 	}
-	if remainingOpens != 0 {
-		t.Errorf("owner should have no open states after close, got %d", remainingOpens)
+	if !retainedExists {
+		t.Error("owner should be retained in closedOwnerByOther for CLOSE replay")
+	}
+
+	// A retransmitted CLOSE at the same seqid must replay the cached reply.
+	_, replayErr := sm.CloseFile(&confirmed.Stateid, 3)
+	var re *ReplayError
+	if !errors.As(replayErr, &re) {
+		t.Fatalf("retransmitted CLOSE should replay, got %T: %v", replayErr, replayErr)
+	}
+	if !bytes.Equal(re.Data, []byte("close-reply")) {
+		t.Errorf("replayed CLOSE data = %x, want cached reply", re.Data)
 	}
 }
 

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -129,6 +129,12 @@ type CompoundContext struct {
 	// at accept() time and threaded through dispatch. Used by
 	// BIND_CONN_TO_SESSION and connection draining checks.
 	ConnectionID uint64
+
+	// RequestDigest is a fingerprint of the full COMPOUND request body,
+	// computed once in ProcessCompound. The v4.1 SEQUENCE path uses it as the
+	// slot request fingerprint to detect false retries (RFC 8881
+	// Section 2.10.6.1.3 -- a slot+seqid reused for a different request).
+	RequestDigest []byte
 }
 
 // V4ClientState holds NFSv4 client state associated with a connection.
@@ -306,6 +312,11 @@ type V41RequestContext struct {
 
 	// CacheThis indicates whether the server should cache the reply.
 	CacheThis bool
+
+	// RequestDigest is the fingerprint of the COMPOUND request recorded with
+	// the slot on completion, so a later retry can be checked for a false retry
+	// (RFC 8881 Section 2.10.6.1.3).
+	RequestDigest []byte
 }
 
 // String returns a human-readable representation of the V41RequestContext.

--- a/internal/adapter/nfs/v4/v41/handlers/sequence.go
+++ b/internal/adapter/nfs/v4/v41/handlers/sequence.go
@@ -47,8 +47,11 @@ func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, reader io.Reader)
 		}, nil, nil, nil, nil
 	}
 
-	// Validate slot sequence ID
-	validation, slot, validationErr := sess.ForeChannelSlots.ValidateSequence(args.SlotID, args.SequenceID)
+	// Validate slot sequence ID. compCtx.RequestDigest fingerprints this
+	// COMPOUND so a slot+seqid reused for a different request is rejected with
+	// NFS4ERR_SEQ_FALSE_RETRY rather than replaying a stale reply.
+	validation, slot, validationErr := sess.ForeChannelSlots.ValidateSequence(
+		args.SlotID, args.SequenceID, compCtx.RequestDigest)
 
 	switch validation {
 	case state.SeqRetry:
@@ -122,11 +125,12 @@ func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, reader io.Reader)
 
 		// Build V41RequestContext
 		ctx := &types.V41RequestContext{
-			SessionID:   args.SessionID,
-			SlotID:      args.SlotID,
-			SequenceID:  args.SequenceID,
-			HighestSlot: args.HighestSlotID,
-			CacheThis:   args.CacheThis,
+			SessionID:     args.SessionID,
+			SlotID:        args.SlotID,
+			SequenceID:    args.SequenceID,
+			HighestSlot:   args.HighestSlotID,
+			CacheThis:     args.CacheThis,
+			RequestDigest: compCtx.RequestDigest,
 		}
 
 		logger.Debug("SEQUENCE: validated successfully",


### PR DESCRIPTION
NFS area-4 PR-B3. Fixes the v4 exactly-once / replay-cache class (REVIEW.md §2 H4/H5/H6). Touches only `internal/adapter/nfs`; builds on #885 (share-reservation rework of OpenFile/ValidateStateid), does not revert it.

## H4 — v4.0 open-owner replay cache cross-op contaminated
`OpenOwner.LastResult` was a single slot populated only by OPEN, while CLOSE/OPEN_DOWNGRADE/OPEN_CONFIRM also advance `LastSeqID` → a legit TCP retransmit of one of those replayed stale OPEN bytes (or `NFS4ERR_BAD_SEQID`).

Fix: cache the encoded reply for **every** open-owner-seqid op. Each handler calls `CacheOpenOwnerResult` after encoding; each manager method's replay branch returns the cached bytes via a typed `*state.ReplayError`. Open-owners are now **retained after the last CLOSE** (mirrors Linux nfsd `so_replay`, where stateowners live until lease expiry) so a retransmitted CLOSE can still resolve them; a `closedOwnerByOther` map maps the now-closed stateid → retained owner since the open-state itself is deleted. Both are reaped in `onLeaseExpired`.

## H5 — v4.0 LOCK/LOCKU replay not honored → silent lock loss
`LockOwner.LastResult` was declared but never populated → a replayed LOCK returned `NFS4ERR_BAD_SEQID`, which the Linux client treats as fatal (drops the lock-owner).

Fix: populate `LockOwner.LastResult` on LOCK/LOCKU and on a DENIED LOCK (which still advances the seqid per RFC 7530 §8.1.5), return it on replay. The lock-owner seqid replay check is now done **before** the strict stateid-seqid compare in `LockExisting`/`UnlockFile`, because a replayed LOCK/LOCKU resends the pre-op lock stateid (seqid one behind) that would otherwise be rejected as `NFS4ERR_OLD_STATEID`. The `open_to_lock_owner` (LockNew) path routes an open-owner-seqid replay to the lock-owner's cached reply.

## H6 — v4.1 SEQ_FALSE_RETRY never detected
A slot retry returned the cached reply with no request compare → a client reusing slot+seqid with different ops silently got the stale reply (confused-deputy / data-exposure).

Fix: `ProcessCompound` fingerprints the full COMPOUND request body (SHA-256) into `CompoundContext.RequestDigest`; it is threaded to `SlotTable.ValidateSequence` and recorded by `CompleteSlotRequest`. On a same-seqid retry whose digest differs, `ValidateSequence` returns `NFS4ERR_SEQ_FALSE_RETRY` (RFC 8881 §2.10.6.1.3) before any cached reply is replayed.

## RFC / Linux cross-check
- RFC 7530 §9.1.7 (last-op replay per stateowner), §8.1.5 (seqid bumped on all but the listed errors; `NFS4ERR_DENIED` is not exempt), §8.20.
- RFC 8881 §2.10.6.1.3 (`SEQ_FALSE_RETRY`).
- Linux `fs/nfsd/nfs4state.c`: `so_replay` buffer on the stateowner, retained until lease expiry; `nfs4_check_sequence` false-retry handling.

## Tests
- `state/replay_cache_test.go`: OPEN→CLOSE / DOWNGRADE / CONFIRM replay returns cached reply (not BAD_SEQID); LOCK and LOCKU replay returns cached reply (lock not lost); DENIED LOCK caches + replays.
- `handlers/sequence_handler_test.go`: `TestSequence_FalseRetry_DifferentOps` — slot+seqid reused with a different op-list → `NFS4ERR_SEQ_FALSE_RETRY`; byte-identical retry still replays the cached reply. Existing replay tests updated to model true (byte-identical) retransmits.

Gates: `gofmt -s`, `go vet`, `golangci-lint` (0 issues), `go test -race ./internal/adapter/nfs/...` all green.