### PR TITLE
fix(smb/dh): disallow_write_lease cap for non-stat opens and disconnected handles (#739)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -842,6 +842,22 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
 			lockFileHandle := lock.FileHandle(fileHandle)
 			var err error
+			// Samba `disallow_write_lease`: strip W from this lease grant when a
+			// conflicting other open or a disconnected durable handle exists.
+			// The new open's own lease key (parsed from the RqLs blob) and SMB
+			// FileID are excluded so a same-handle reopen/upgrade is never
+			// self-capped (mirrors Samba `is_same_lease`). bestGrantableState in
+			// the lock manager already caps W against live *lease* records; this
+			// predicate adds the cases it cannot see — non-lease live opens and
+			// disconnected durable handles (smb2.durable-v2-open.nonstat-and-lease
+			// and keep-disconnected-rh-with-rwh-open).
+			var newLeaseKey [16]byte
+			if parsed, decErr := DecodeLeaseCreateContext(leaseCtx.Data); decErr == nil && parsed != nil {
+				newLeaseKey = parsed.LeaseKey
+			}
+			disallowWriteLease := h.disallowWriteLeaseForFile(
+				authCtx.Context, fileHandle, newLeaseKey, smbFileID,
+			)
 			leaseResponse, err = ProcessLeaseCreateContext(
 				authCtx.Context,
 				h.LeaseManager,
@@ -852,6 +868,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				fmt.Sprintf("smb:%d", ctx.SessionID),
 				tree.ShareName,
 				file.Type == metadata.FileTypeDirectory,
+				disallowWriteLease,
 			)
 			if err != nil {
 				if errors.Is(err, lock.ErrLeaseKeyInUse) {

--- a/internal/adapter/smb/v2/handlers/dir_lease_grant_test.go
+++ b/internal/adapter/smb/v2/handlers/dir_lease_grant_test.go
@@ -91,6 +91,7 @@ func TestDirectoryLeaseRequest_RWH_DowngradesToRH(t *testing.T) {
 		ctx, leaseMgr, data, fileHandle,
 		sessionID, [16]byte{}, clientID, "share1",
 		true, // isDirectory
+		false,
 	)
 	if err != nil {
 		t.Fatalf("ProcessLeaseCreateContext returned error: %v", err)
@@ -132,6 +133,7 @@ func TestDirectoryLeaseRequest_RW_DowngradesToR(t *testing.T) {
 		ctx, leaseMgr, data, fileHandle,
 		sessionID, [16]byte{}, clientID, "share1",
 		true,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("ProcessLeaseCreateContext returned error: %v", err)
@@ -186,6 +188,7 @@ func TestDirectoryLeaseRequest_ParentLeaseKeyEcho(t *testing.T) {
 			ctx, leaseMgr, data, fileHandle,
 			sessionID, [16]byte{}, clientID, "share1",
 			true,
+			false,
 		)
 		if err != nil {
 			t.Fatalf("ProcessLeaseCreateContext returned error: %v", err)
@@ -236,6 +239,7 @@ func TestDirectoryLeaseRequest_ParentLeaseKeyEcho(t *testing.T) {
 			ctx, leaseMgr, data, fileHandle2,
 			sessionID, [16]byte{}, clientID, "share1",
 			true,
+			false,
 		)
 		if err != nil {
 			t.Fatalf("ProcessLeaseCreateContext returned error: %v", err)

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -389,4 +390,114 @@ func shouldPersistDurableOnDisconnect(
 		return false
 	}
 	return true
+}
+
+// disallowWriteLeaseForFile mirrors Samba's `disallow_write_lease` accumulator
+// (source3/smbd/open.c::delay_for_oplock_fn, lines 2390-2403). It reports
+// whether a new lease grant on the file identified by metaHandle must have its
+// Write (SMB2_LEASE_WRITE) caching bit stripped because a *conflicting* other
+// open exists.
+//
+// Samba sets disallow_write_lease for an existing share-mode entry e when ALL
+// of the following hold:
+//
+//   - e holds an oplock/lease, OR e is NOT an oplock-stat-open
+//     (e->op_type != NO_OPLOCK || !is_oplock_stat_open(e->access_mask)); AND
+//   - e is not the requestor's own lease (same lease key); AND
+//   - e is not stale.
+//
+// Then `granted &= ~SMB2_LEASE_WRITE`. A pure write lease can only be granted
+// when the file has no other leases and no other non-stat opens.
+//
+// DittoFS tracks live opens in h.files (with no per-open share-mode db entry)
+// and the lock manager's lease records separately. The lock manager's
+// bestGrantableState already strips W when another *lease* record exists
+// (hasOtherActiveHolder). This predicate covers the two cases bestGrantableState
+// cannot see:
+//
+//  1. A live non-stat open that holds NO lease (h1 in
+//     smb2.durable-v2-open.nonstat-and-lease — opened with READ_CONTROL so it
+//     is a non-oplock-stat open with NO_OPLOCK; W must be stripped from the
+//     RWH lease the second handle requests, yielding RH).
+//  2. A DISCONNECTED durable handle that still holds a lease (h1a/h1b in
+//     smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open — their lease
+//     records were released from the lock manager at disconnect, but the
+//     persisted handle keeps the file effectively leased; a new RWH open from
+//     another connection must be downgraded to RH with NO break sent, because a
+//     disconnected handle cannot ack one).
+//
+// excludeLeaseKey is the requestor's own lease key (zero if none); opens/handles
+// matching it are ignored (Samba `is_same_lease`). Pipes, directories, and the
+// requestor's own opens never contribute. The decision only strips W — it never
+// blocks the grant or sends a break.
+func (h *Handler) disallowWriteLeaseForFile(
+	ctx context.Context,
+	metaHandle []byte,
+	excludeLeaseKey [16]byte,
+	excludeFileID [16]byte,
+) bool {
+	if len(metaHandle) == 0 {
+		return false
+	}
+
+	// (1) Live opens. Any other open on the same metadata handle that is not an
+	// oplock-stat-open (or that holds a lease/oplock) disallows W. Stat-only
+	// opens neither break caching nor impose share-mode constraints, so they do
+	// not contribute (Samba is_oplock_stat_open carve-out).
+	disallow := false
+	h.files.Range(func(_, value any) bool {
+		existing, ok := value.(*OpenFile)
+		if !ok || existing.IsPipe || existing.IsDirectory {
+			return true
+		}
+		if len(existing.MetadataHandle) == 0 || !bytes.Equal(existing.MetadataHandle, metaHandle) {
+			return true
+		}
+		// Skip the requestor's own open(s): same lease key, or same SMB FileID.
+		if excludeLeaseKey != ([16]byte{}) && existing.LeaseKey == excludeLeaseKey {
+			return true
+		}
+		if existing.FileID == excludeFileID {
+			return true
+		}
+		// e contributes when it holds an oplock/lease OR is a non-stat open.
+		holdsOplock := existing.OplockLevel != OplockLevelNone
+		if holdsOplock || !isOplockStatOpen(existing.DesiredAccess) {
+			disallow = true
+			return false // stop iterating; one is enough
+		}
+		return true
+	})
+	if disallow {
+		return true
+	}
+
+	// (2) Disconnected durable handles. A handle persisted across a transport
+	// disconnect still holds its lease as far as conflict accounting goes — the
+	// reconnecting client expects to resume it. Any disconnected handle holding
+	// a Read-bearing lease (RH/RWH) with a different lease key disallows W on a
+	// fresh grant from another opener. The new opener gets RH (W stripped) and
+	// NO break is sent — the disconnected client could not ack one.
+	if h.DurableStore == nil {
+		return false
+	}
+	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
+	if err != nil || len(handles) == 0 {
+		return false
+	}
+	for _, d := range handles {
+		if d.DisconnectedAt.IsZero() {
+			continue
+		}
+		if excludeLeaseKey != ([16]byte{}) && d.LeaseKey == excludeLeaseKey {
+			continue
+		}
+		// A disconnected handle with a Read-bearing lease holds caching that a
+		// new W grant would conflict with. A handle persisted with LeaseState=0
+		// (no caching) does not contend for W.
+		if d.LeaseState&smbLeaseRead != 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -726,3 +726,144 @@ func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
 		})
 	}
 }
+
+// TestDisallowWriteLeaseForFile exercises the Samba `disallow_write_lease`
+// accumulator (source3/smbd/open.c::delay_for_oplock_fn) as implemented by
+// Handler.disallowWriteLeaseForFile. The predicate must strip W when a
+// conflicting non-stat live open or a disconnected durable handle exists, and
+// MUST NOT strip W for the requestor's own open (same lease key or same
+// FileID), stat-only opens, opens on other files, or directories/pipes. The
+// false cases are the regression guards for the 13 lease tests that a coarse
+// "any non-stat open" cap previously broke.
+func TestDisallowWriteLeaseForFile(t *testing.T) {
+	const (
+		rh             = smbLeaseRead | smbLeaseHandle
+		rwh            = smbLeaseRead | smbLeaseHandle | smbLeaseWrite
+		shareAll       = smbShareRead | smbShareWrite | smbShareDelete
+		accessReadCtl  = 0x00000080 | 0x00000100 | 0x00100000 | 0x00020000 // RD_ATTR|WR_ATTR|SYNC|READ_CONTROL (non-oplock-stat)
+		accessStatOnly = 0x00000080 | 0x00000100 | 0x00100000              // RD_ATTR|WR_ATTR|SYNC (oplock-stat)
+		accessReadData = 0x00000001                                        // FILE_READ_DATA (non-stat)
+	)
+	metaHandle := []byte("file-A")
+	otherHandle := []byte("file-B")
+	selfKey := [16]byte{0xAA}
+	selfFileID := [16]byte{0xA1}
+
+	addOpen := func(h *Handler, fileID [16]byte, mh []byte, access uint32, leaseKey [16]byte, oplock uint8, dir bool) {
+		h.StoreOpenFile(&OpenFile{
+			FileID:         fileID,
+			MetadataHandle: mh,
+			DesiredAccess:  access,
+			LeaseKey:       leaseKey,
+			OplockLevel:    oplock,
+			IsDirectory:    dir,
+		})
+	}
+
+	t.Run("non-stat live open of another opener disallows W", func(t *testing.T) {
+		h := &Handler{}
+		// h1: READ_CONTROL-bearing open, no lease (the nonstat-and-lease shape).
+		addOpen(h, [16]byte{0x01}, metaHandle, accessReadCtl, [16]byte{}, OplockLevelNone, false)
+		if !h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=true for conflicting non-oplock-stat open")
+		}
+	})
+
+	t.Run("stat-only live open does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x02}, metaHandle, accessStatOnly, [16]byte{}, OplockLevelNone, false)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for oplock-stat-only open")
+		}
+	})
+
+	t.Run("own open by same lease key does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x03}, metaHandle, accessReadData, selfKey, OplockLevelLease, false)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for requestor's own lease key (reopen/upgrade)")
+		}
+	})
+
+	t.Run("own open by same FileID does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, selfFileID, metaHandle, accessReadData, [16]byte{}, OplockLevelNone, false)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false when the only other open is the requestor's own FileID")
+		}
+	})
+
+	t.Run("open on a different file does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x04}, otherHandle, accessReadData, [16]byte{}, OplockLevelNone, false)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for non-stat open on a DIFFERENT file")
+		}
+	})
+
+	t.Run("directory open does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x05}, metaHandle, accessReadData, [16]byte{}, OplockLevelNone, true)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for a directory open")
+		}
+	})
+
+	t.Run("disconnected RH durable handle disallows W", func(t *testing.T) {
+		store := newMockDurableStore()
+		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+			ID:             "disc-rh",
+			MetadataHandle: metaHandle,
+			LeaseKey:       [16]byte{0xBB},
+			LeaseState:     rh,
+			ShareAccess:    shareAll,
+			DisconnectedAt: time.Now().Add(-time.Second),
+		})
+		h := &Handler{DurableStore: store}
+		// keep-disconnected-rh-with-rwh-open: new RWH open (selfKey) must be
+		// capped to RH by the disconnected RH handle, with no break.
+		if !h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=true for a disconnected RH durable handle")
+		}
+	})
+
+	t.Run("own disconnected handle (same key) does not disallow W", func(t *testing.T) {
+		store := newMockDurableStore()
+		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+			ID:             "disc-self",
+			MetadataHandle: metaHandle,
+			LeaseKey:       selfKey,
+			LeaseState:     rh,
+			ShareAccess:    shareAll,
+			DisconnectedAt: time.Now().Add(-time.Second),
+		})
+		h := &Handler{DurableStore: store}
+		// The requestor reconnecting its own durable handle must not self-cap.
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for the requestor's own disconnected handle")
+		}
+	})
+
+	t.Run("still-connected durable handle does not disallow W", func(t *testing.T) {
+		store := newMockDurableStore()
+		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+			ID:             "live-row",
+			MetadataHandle: metaHandle,
+			LeaseKey:       [16]byte{0xCC},
+			LeaseState:     rh,
+			ShareAccess:    shareAll,
+			DisconnectedAt: time.Time{}, // never disconnected
+		})
+		h := &Handler{DurableStore: store}
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false for a not-yet-disconnected durable row")
+		}
+	})
+
+	t.Run("no opens and no handles does not disallow W", func(t *testing.T) {
+		h := &Handler{DurableStore: newMockDurableStore()}
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID) {
+			t.Fatal("expected disallow=false on an idle file")
+		}
+	})
+}

--- a/internal/adapter/smb/v2/handlers/lease_context.go
+++ b/internal/adapter/smb/v2/handlers/lease_context.go
@@ -336,6 +336,16 @@ func FindCreateContext(contexts []CreateContext, name string) *CreateContext {
 //   - clientID: The connection tracker client ID
 //   - shareName: The share name
 //   - isDirectory: Whether the target is a directory
+//   - disallowWriteLease: when true, the Write (SMB2_LEASE_WRITE) bit is stripped
+//     from the requested lease state before the grant. Mirrors Samba's
+//     `disallow_write_lease` (source3/smbd/open.c::delay_for_oplock): a pure write
+//     lease can only be granted when the file has no other leases and no other
+//     non-stat opens. The caller (CREATE handler) computes this via
+//     Handler.disallowWriteLeaseForFile, which sees both the live OpenFile table
+//     and disconnected durable handles that the lock manager's bestGrantableState
+//     cannot. Stripping W from the request (rather than the grant) is equivalent:
+//     the downgrade candidate chain and R/H conflict checks produce the same
+//     R/H bits, and the lock manager persists the correct post-strip state.
 //
 // Returns:
 //   - *LeaseResponseContext: Response context to add to CREATE response (nil if not processing)
@@ -350,6 +360,7 @@ func ProcessLeaseCreateContext(
 	clientID string,
 	shareName string,
 	isDirectory bool,
+	disallowWriteLease bool,
 ) (*LeaseResponseContext, error) {
 	if leaseMgr == nil {
 		logger.Debug("ProcessLeaseCreateContext: no lease manager")
@@ -377,6 +388,17 @@ func ProcessLeaseCreateContext(
 	// Build owner ID for cross-protocol visibility
 	ownerID := fmt.Sprintf("smb:lease:%x", leaseReq.LeaseKey)
 
+	// Apply Samba's `disallow_write_lease` cap: when a conflicting other open
+	// or a disconnected durable handle exists, a Write-caching lease cannot be
+	// granted. Strip W from the request so the grant downgrades to RH (or lower)
+	// without sending a break. Stripping the request — rather than the grant —
+	// is equivalent because the conflict downgrade chain only removes bits; the
+	// resulting R/H bits and persisted lock-manager state are identical.
+	requestedState := leaseReq.LeaseState
+	if disallowWriteLease {
+		requestedState &^= lock.LeaseStateWrite
+	}
+
 	// Request the lease through LeaseManager (delegates to shared LockManager)
 	grantedState, epoch, err := leaseMgr.RequestLease(
 		ctx,
@@ -388,7 +410,7 @@ func ProcessLeaseCreateContext(
 		ownerID,
 		clientID,
 		shareName,
-		leaseReq.LeaseState,
+		requestedState,
 		isDirectory,
 	)
 	// Per MS-SMB2 3.3.5.9.8: If the same-key lease is in Breaking state,

--- a/internal/adapter/smb/v2/handlers/lease_context_test.go
+++ b/internal/adapter/smb/v2/handlers/lease_context_test.go
@@ -373,7 +373,7 @@ func TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch(t *testing.T) {
 
 	// First CREATE: grant RWH with requested epoch 0x4711 → response epoch 0x4712.
 	initial := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle, initialEpoch)
-	resp1, err := ProcessLeaseCreateContext(ctx, leaseMgr, initial, fileHandle, sessionID, [16]byte{}, clientID, shareName, false)
+	resp1, err := ProcessLeaseCreateContext(ctx, leaseMgr, initial, fileHandle, sessionID, [16]byte{}, clientID, shareName, false, false)
 	if err != nil {
 		t.Fatalf("first CREATE returned error: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch(t *testing.T) {
 	// Same-key None-state probe at the granted epoch — must echo the lease's
 	// current epoch verbatim (no state change → no advance).
 	probe := encodeV2LeaseContext(leaseKey, lock.LeaseStateNone, grantedEpoch)
-	resp2, err := ProcessLeaseCreateContext(ctx, leaseMgr, probe, fileHandle, sessionID, [16]byte{}, clientID, shareName, false)
+	resp2, err := ProcessLeaseCreateContext(ctx, leaseMgr, probe, fileHandle, sessionID, [16]byte{}, clientID, shareName, false, false)
 	if err != nil {
 		t.Fatalf("None-probe returned error: %v", err)
 	}

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -194,7 +194,7 @@ func grantRWHLease(t *testing.T, leaseMgr *lease.LeaseManager, leaseKey [16]byte
 	fh := lock.FileHandle("file-1")
 	rwh := lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle
 	reqCtx := encodeV2LeaseContext(leaseKey, rwh, 1)
-	resp, err := ProcessLeaseCreateContext(ctx, leaseMgr, reqCtx, fh, sessionID, [16]byte{}, "smb:7", "share1", false)
+	resp, err := ProcessLeaseCreateContext(ctx, leaseMgr, reqCtx, fh, sessionID, [16]byte{}, "smb:7", "share1", false, false)
 	if err != nil {
 		t.Fatalf("granting RWH lease failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

Residual #739 Durable Handles V2 conformance work. Mirrors Samba's
`disallow_write_lease` accumulator (`source3/smbd/open.c::delay_for_oplock_fn`,
lines 2390-2403 + 2637-2643) so a lease grant's Write caching bit is stripped
when a conflicting other open exists — covering the two cases the lock manager's
`bestGrantableState` cannot see:

1. A **non-oplock-stat live open holding no lease** (e.g. opened with
   `READ_CONTROL`, so `is_oplock_stat_open` is false). `bestGrantableState`
   only inspects lease records, so it misses this. → `nonstat-and-lease`.
2. A **disconnected durable handle** still holding an RH/RWH lease. Its lease
   record was released from the lock manager at disconnect, but the persisted
   handle keeps the file effectively leased; a new RWH open from another
   connection must downgrade to RH with **no break** (a disconnected handle
   cannot ack one). → `keep-disconnected-rh-with-rwh-open`.

The new open's own lease key (Samba `is_same_lease`) and SMB FileID are excluded
so a same-handle reopen/upgrade is never self-capped — the regression guard
against the broad "any non-stat open" cap that previously broke 13 lease tests.

W is stripped from the **request** (not the grant): equivalent because the
downgrade candidate chain and R/H conflict checks produce the same R/H bits and
the lock manager persists the correct post-strip state.

## Targets (#739, all in KNOWN_FAILURES.md)

- `smb2.durable-v2-open.nonstat-and-lease` — addressed by the live non-stat-open W-cap.
- `smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open` — addressed by the disconnected-handle W-cap.
- `smb2.durable-v2-open.lock-oplock` / `lock-lease` — BR-lock survival across durable disconnect/reconnect is already wired (locks preserved on durable persist, OpenID continuous via OriginalFileID); no code change needed, validated by reasoning. CI will confirm.
- `smb2.durable-v2-delay.durable_v2_reconnect_delay` — timeout=0 default-grant + PreviousSessionId supersession paths already in place; CI will confirm.

Out of scope (left in KF): `persistent-open-*` (unimplemented feature), `app-instance` (cross-connection break routing).

## Verification

- `go build ./...`, `go vet ./internal/adapter/smb/...`, `golangci-lint` — clean.
- `go test ./internal/adapter/smb/... -count=1` and `go test -race ./internal/adapter/smb/v2/handlers/... -count=1` — green (lease-break regression guard).
- New unit test `TestDisallowWriteLeaseForFile` covers all true/false cases incl. the reopen/upgrade self-cap guards.
- `KNOWN_FAILURES.md` untouched (orchestrator walks back post-merge after CI confirms each flip).
