### PR TITLE
fix(nfs/nsm): authenticate SM_NOTIFY (monitored-list + source-addr gate) + state monotonicity (area-4 H16/H17)

### DIFF
--- a/internal/adapter/nfs/nsm/handlers/handler.go
+++ b/internal/adapter/nfs/nsm/handlers/handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -43,6 +44,19 @@ type Handler struct {
 	// maxClients is the maximum number of monitored clients.
 	// SM_MON returns STAT_FAIL if this limit is reached.
 	maxClients int
+
+	// peerStateMu guards peerState.
+	peerStateMu sync.Mutex
+
+	// peerState records the last-seen NSM state number for each monitored
+	// host (keyed by mon_name). NSM state numbers are monotonically
+	// increasing per the protocol, so an SM_NOTIFY is acted on only when its
+	// state strictly exceeds the stored value; equal-or-lower states are
+	// replays/stale and are ignored. This is the H17 monotonicity gate.
+	//
+	// Note: this is the last-seen state of the *peer* (the host that
+	// rebooted), distinct from the server's own serverState counter.
+	peerState map[string]int32
 }
 
 // HandlerConfig configures the NSM handler.
@@ -93,6 +107,7 @@ func NewHandler(config HandlerConfig) *Handler {
 		clientStore: config.ClientStore,
 		serverName:  config.ServerName,
 		maxClients:  config.MaxClients,
+		peerState:   make(map[string]int32),
 	}
 	h.serverState.Store(config.InitialState)
 	return h
@@ -145,4 +160,23 @@ func (h *Handler) GetClientStore() lock.ClientRegistrationStore {
 // GetServerName returns the configured server hostname.
 func (h *Handler) GetServerName() string {
 	return h.serverName
+}
+
+// admitPeerState enforces SM_NOTIFY state-number monotonicity for a monitored
+// host (H17). It returns true and records incoming as the new last-seen state
+// only when incoming strictly exceeds the previously stored state for monName.
+// An equal-or-lower state is a replay/stale notification and returns false
+// without mutating stored state.
+//
+// The first NOTIFY ever seen for a monName is admitted (any positive state is
+// greater than the zero-value default), then recorded.
+func (h *Handler) admitPeerState(monName string, incoming int32) bool {
+	h.peerStateMu.Lock()
+	defer h.peerStateMu.Unlock()
+
+	if incoming <= h.peerState[monName] {
+		return false
+	}
+	h.peerState[monName] = incoming
+	return true
 }

--- a/internal/adapter/nfs/nsm/handlers/notify.go
+++ b/internal/adapter/nfs/nsm/handlers/notify.go
@@ -1,53 +1,140 @@
 package handlers
 
 import (
+	"net"
+
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// Notify handles NSM NOTIFY (RFC 1813, SM procedure 6).
-// Receives state-change notification from a remote NSM when a monitored host restarts.
-// No delegation yet; logs the notification (callback dispatch deferred to future plan).
-// No side effects currently; will eventually trigger SM_NOTIFY callbacks to local clients.
-// Errors: none (one-way procedure; decode errors are logged but do not fail).
+// Notify handles NSM NOTIFY (X/Open NSM, SM procedure 6).
+//
+// An inbound SM_NOTIFY claims that a peer host (stat_chge.mon_name) has changed
+// state (typically rebooted) and is the trigger for relaying lock-recovery
+// callbacks to local clients and releasing the rebooted host's stale NLM locks.
+//
+// Because acting on a NOTIFY drops locks, an UNAUTHENTICATED NOTIFY is the
+// classic rpc.statd spoofing primitive: any reachable host could forge
+// SM_NOTIFY mon_name=<victim> and cause the server to drop the victim's
+// byte-range locks, after which another client grabs the range -> silent
+// corruption. Notify therefore gates every NOTIFY behind BOTH:
+//
+//	(1) monitored-list membership + source-address match (H16): the mon_name
+//	    must correspond to a host we are actually monitoring (an SM_MON
+//	    registration), AND the RPC source address must match that host's
+//	    recorded address; and
+//	(2) state-number monotonicity (H17): the incoming state must strictly
+//	    exceed the last-seen state for that mon_name, otherwise it is a
+//	    replay/stale notification.
+//
+// A NOTIFY that fails either gate is dropped silently (no side effects).
+//
+// SM_NOTIFY is a one-way procedure; it returns no meaningful result. Decode
+// errors and rejected notifications are logged but never fail the RPC.
 func (h *Handler) Notify(ctx *NSMHandlerContext, data []byte) (*HandlerResult, error) {
-	// Decode stat_chge argument
+	// SM_NOTIFY returns no result regardless of outcome.
+	ack := &HandlerResult{
+		Data:      []byte{},
+		NSMStatus: types.StatSucc,
+	}
+
+	// Decode stat_chge argument.
 	r := newBytesReader(data)
 	statChge, err := xdr.DecodeStatChge(r)
 	if err != nil {
 		logger.Warn("NSM NOTIFY decode error",
 			"client", ctx.ClientAddr,
 			"error", err)
-		// SM_NOTIFY doesn't return a result, just log the error
-		return &HandlerResult{
-			Data:      []byte{},
-			NSMStatus: types.StatSucc,
-		}, nil
+		return ack, nil
 	}
 
-	logger.Info("NSM NOTIFY received",
+	logger.Debug("NSM NOTIFY received",
 		"client", ctx.ClientAddr,
 		"mon_name", statChge.MonName,
 		"new_state", statChge.State)
 
-	// TODO : Dispatch callbacks to local clients monitoring this host
-	//
-	// The full implementation should:
-	// 1. Find all local registrations where MonName matches statChge.MonName
-	// 2. For each registration, send SM_NOTIFY callback with:
-	//    - MonName: statChge.MonName
-	//    - State: statChge.State
-	//    - Priv: The client's stored priv data
-	// 3. Track callback success/failure for observability
-	//
-	// For now, we log the notification. This is enough for basic operation
-	// since our own crash recovery (notifying clients of OUR restart) is
-	// more critical than relaying third-party notifications.
+	// ---- Gate 1: monitored-list membership + source-address match (H16) ----
+	if !h.isMonitoredFromSource(statChge.MonName, ctx.ClientAddr) {
+		// Either we are not monitoring this host (unknown mon_name) or the
+		// NOTIFY arrived from an address that does not match the monitored
+		// host's recorded address. Treat as a spoofing attempt: drop silently.
+		logger.Warn("NSM NOTIFY rejected: failed monitored-list/source-addr gate",
+			"client", ctx.ClientAddr,
+			"mon_name", statChge.MonName)
+		return ack, nil
+	}
 
-	// SM_NOTIFY doesn't return a meaningful result
-	return &HandlerResult{
-		Data:      []byte{},
-		NSMStatus: types.StatSucc,
-	}, nil
+	// ---- Gate 2: state-number monotonicity (H17) ----
+	if !h.admitPeerState(statChge.MonName, statChge.State) {
+		// Replay or stale notification (state did not advance). Drop silently.
+		logger.Warn("NSM NOTIFY ignored: non-monotonic state (replay/stale)",
+			"client", ctx.ClientAddr,
+			"mon_name", statChge.MonName,
+			"new_state", statChge.State)
+		return ack, nil
+	}
+
+	logger.Info("NSM NOTIFY accepted",
+		"client", ctx.ClientAddr,
+		"mon_name", statChge.MonName,
+		"new_state", statChge.State)
+
+	// Relay / lock-recovery dispatch is intentionally NOT implemented here.
+	//
+	// This PR establishes the security gates (above) so that a future relay is
+	// safe by construction: any relay implementation MUST run only after BOTH
+	// gates have passed. When the relay ships it should, for the validated
+	// mon_name:
+	//   1. find local registrations monitoring this host,
+	//   2. send SM_NOTIFY callbacks to those clients, and
+	//   3. release the rebooted host's stale NLM locks,
+	// all gated by the checks performed above.
+
+	return ack, nil
+}
+
+// isMonitoredFromSource enforces the H16 gate. It returns true only when:
+//
+//	(1) monName is on the monitored list (some SM_MON registration records
+//	    MonName == monName), AND
+//	(2) the NOTIFY's source address (srcAddr) matches the source IP of at
+//	    least one of those monitoring registrations.
+//
+// Both srcAddr and the recorded registration address are "host:port" strings
+// (net.Conn.RemoteAddr().String()); only the host (IP) portion is compared,
+// because an NSM peer sends NOTIFY from a different ephemeral port than it used
+// for SM_MON.
+//
+// A monName with no matching registration (unmonitored host) or whose
+// registrations all have a different source IP (spoofed source) returns false.
+func (h *Handler) isMonitoredFromSource(monName, srcAddr string) bool {
+	srcIP := hostOf(srcAddr)
+	if srcIP == "" {
+		return false
+	}
+
+	for _, reg := range h.tracker.GetNSMClients() {
+		if reg.MonName == monName && hostOf(reg.RemoteAddr) == srcIP {
+			return true
+		}
+	}
+
+	// Either monName is unknown (unmonitored host) or every monitoring
+	// registration for it has a different source IP (spoofed source). Reject.
+	return false
+}
+
+// hostOf extracts the host (IP) portion of a "host:port" address. If the input
+// has no port it is returned unchanged. An empty input returns "".
+func hostOf(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Not in host:port form; treat the whole string as the host.
+		return addr
+	}
+	return host
 }

--- a/internal/adapter/nfs/nsm/handlers/notify_test.go
+++ b/internal/adapter/nfs/nsm/handlers/notify_test.go
@@ -1,0 +1,239 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/xdr"
+	xdrcore "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// newTestHandler builds a Handler backed by a real ConnectionTracker.
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	tracker := lock.NewConnectionTracker(lock.DefaultConnectionTrackerConfig())
+	t.Cleanup(tracker.Close)
+	return NewHandler(HandlerConfig{
+		Tracker:    tracker,
+		ServerName: "test-server",
+	})
+}
+
+// monitor registers a monitored host via SM_MON so that subsequent NOTIFYs for
+// monName arriving from clientAddr pass the H16 gate. clientAddr is the RPC
+// source address ("host:port"); callbackHost is the my_id.my_name.
+func monitor(t *testing.T, h *Handler, clientAddr, monName, callbackHost string) {
+	t.Helper()
+	mon := &types.Mon{
+		MonID: types.MonID{
+			MonName: monName,
+			MyID: types.MyID{
+				MyName: callbackHost,
+				MyProg: 100021,
+				MyVers: 4,
+				MyProc: 23,
+			},
+		},
+	}
+	data := encodeMon(t, mon)
+	ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: clientAddr}
+	if _, err := h.Mon(ctx, data); err != nil {
+		t.Fatalf("Mon failed: %v", err)
+	}
+}
+
+// encodeMon hand-encodes a mon argument matching xdr.DecodeMon's layout:
+// mon_id { mon_name<>, my_id { my_name<>, prog, vers, proc } }, priv[16].
+func encodeMon(t *testing.T, mon *types.Mon) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	must(t, xdrcore.WriteXDRString(&buf, mon.MonID.MonName))
+	must(t, xdrcore.WriteXDRString(&buf, mon.MonID.MyID.MyName))
+	must(t, xdrcore.WriteUint32(&buf, mon.MonID.MyID.MyProg))
+	must(t, xdrcore.WriteUint32(&buf, mon.MonID.MyID.MyVers))
+	must(t, xdrcore.WriteUint32(&buf, mon.MonID.MyID.MyProc))
+	buf.Write(mon.Priv[:]) // fixed opaque[16], no length prefix
+	return buf.Bytes()
+}
+
+// encodeStatChge hand-encodes a stat_chge argument: mon_name<>, state.
+func encodeStatChge(t *testing.T, monName string, state int32) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	must(t, xdrcore.WriteXDRString(&buf, monName))
+	must(t, xdrcore.WriteInt32(&buf, state))
+	return buf.Bytes()
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+}
+
+// notify drives a single SM_NOTIFY through the handler from srcAddr.
+func notify(t *testing.T, h *Handler, srcAddr, monName string, state int32) {
+	t.Helper()
+	data := encodeStatChge(t, monName, state)
+	ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: srcAddr}
+	if _, err := h.Notify(ctx, data); err != nil {
+		t.Fatalf("Notify returned error: %v", err)
+	}
+}
+
+// recordedState returns the last-seen peer state for monName, or (0,false) if
+// the handler never recorded one (i.e. no NOTIFY was ever acted on for it).
+func recordedState(h *Handler, monName string) (int32, bool) {
+	h.peerStateMu.Lock()
+	defer h.peerStateMu.Unlock()
+	v, ok := h.peerState[monName]
+	return v, ok
+}
+
+// sanity check that the hand-rolled encoder round-trips through the decoder.
+func TestEncodeStatChge_RoundTrips(t *testing.T) {
+	data := encodeStatChge(t, "peer.example", 7)
+	got, err := xdr.DecodeStatChge(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.MonName != "peer.example" || got.State != 7 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H16 — monitored-list membership + source-address gate
+// ---------------------------------------------------------------------------
+
+func TestNotify_UnmonitoredHost_Ignored(t *testing.T) {
+	h := newTestHandler(t)
+	// No SM_MON for "ghost.example".
+	notify(t, h, "10.0.0.9:55000", "ghost.example", 5)
+
+	if _, ok := recordedState(h, "ghost.example"); ok {
+		t.Fatal("unmonitored NOTIFY must not be acted on (no state recorded)")
+	}
+}
+
+func TestNotify_SourceAddrMismatch_Rejected(t *testing.T) {
+	h := newTestHandler(t)
+	// We monitor peer.example as seen from 10.0.0.5.
+	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+
+	// NOTIFY for peer.example arrives from a DIFFERENT source IP.
+	notify(t, h, "10.0.0.66:55000", "peer.example", 5)
+
+	if _, ok := recordedState(h, "peer.example"); ok {
+		t.Fatal("source-addr mismatch NOTIFY must be rejected (no state recorded)")
+	}
+}
+
+func TestNotify_MonitoredHostRightAddr_Accepted(t *testing.T) {
+	h := newTestHandler(t)
+	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+
+	// Legitimate NOTIFY: monitored mon_name, matching source IP (ephemeral
+	// NOTIFY port differs from the SM_MON port — only the IP must match).
+	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
+
+	got, ok := recordedState(h, "peer.example")
+	if !ok {
+		t.Fatal("legitimate NOTIFY must pass the gate and record state")
+	}
+	if got != 5 {
+		t.Fatalf("expected recorded state 5, got %d", got)
+	}
+}
+
+// isMonitoredFromSource focused unit coverage.
+func TestIsMonitoredFromSource(t *testing.T) {
+	h := newTestHandler(t)
+	monitor(t, h, "192.168.1.10:700", "host-a", "host-a")
+
+	if !h.isMonitoredFromSource("host-a", "192.168.1.10:40000") {
+		t.Error("monitored host + matching IP should pass")
+	}
+	if h.isMonitoredFromSource("host-a", "192.168.1.11:40000") {
+		t.Error("monitored host + wrong IP must fail")
+	}
+	if h.isMonitoredFromSource("host-b", "192.168.1.10:40000") {
+		t.Error("unmonitored mon_name must fail")
+	}
+	if h.isMonitoredFromSource("host-a", "") {
+		t.Error("empty source addr must fail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H17 — state-number monotonicity
+// ---------------------------------------------------------------------------
+
+func TestNotify_Monotonicity_OnlyHigherActs(t *testing.T) {
+	h := newTestHandler(t)
+	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+
+	// First NOTIFY at state 5 -> accepted, recorded.
+	notify(t, h, "10.0.0.5:40001", "peer.example", 5)
+	if got, _ := recordedState(h, "peer.example"); got != 5 {
+		t.Fatalf("after first NOTIFY want state 5, got %d", got)
+	}
+
+	// Replay of the SAME state 5 -> ignored, stored state unchanged.
+	notify(t, h, "10.0.0.5:40002", "peer.example", 5)
+	if got, _ := recordedState(h, "peer.example"); got != 5 {
+		t.Fatalf("replay must not change stored state; got %d", got)
+	}
+
+	// Lower state 3 -> ignored.
+	notify(t, h, "10.0.0.5:40003", "peer.example", 3)
+	if got, _ := recordedState(h, "peer.example"); got != 5 {
+		t.Fatalf("decreasing state must not change stored state; got %d", got)
+	}
+
+	// Strictly higher state 6 -> accepted, stored advances.
+	notify(t, h, "10.0.0.5:40004", "peer.example", 6)
+	if got, _ := recordedState(h, "peer.example"); got != 6 {
+		t.Fatalf("increasing state must advance stored state; got %d", got)
+	}
+}
+
+func TestAdmitPeerState(t *testing.T) {
+	h := newTestHandler(t)
+
+	if !h.admitPeerState("p", 1) {
+		t.Error("first state should be admitted")
+	}
+	if h.admitPeerState("p", 1) {
+		t.Error("equal state (replay) must be rejected")
+	}
+	if h.admitPeerState("p", 0) {
+		t.Error("lower state must be rejected")
+	}
+	if !h.admitPeerState("p", 2) {
+		t.Error("higher state must be admitted")
+	}
+	// Independent key.
+	if !h.admitPeerState("q", 1) {
+		t.Error("first state for a different key must be admitted")
+	}
+}
+
+// Replay that passes H16 but fails H17 must remain a no-op (defence in depth):
+// the monotonicity gate sits AFTER the address gate, so a monitored host
+// replaying an old state still does nothing.
+func TestNotify_MonitoredReplay_NoOp(t *testing.T) {
+	h := newTestHandler(t)
+	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+
+	notify(t, h, "10.0.0.5:40001", "peer.example", 9)
+	notify(t, h, "10.0.0.5:40002", "peer.example", 9) // duplicate
+
+	if got, _ := recordedState(h, "peer.example"); got != 9 {
+		t.Fatalf("monitored replay must be a no-op; got %d", got)
+	}
+}


### PR DESCRIPTION
## Area-4 NFS PR-B4 — H16/H17 (NSM statd security)

This is a **security fix** that must land before any SM_NOTIFY relay is implemented.

### The statd spoofing primitive
`SM_NOTIFY` tells the server a peer host (`stat_chge.mon_name`) has rebooted. Acting on a NOTIFY is what triggers NLM lock-recovery — including releasing the rebooted host's stale byte-range locks. NSM procedures are registered `NeedsAuth:false`. Without authentication, **any reachable host can forge `SM_NOTIFY mon_name=<victim>`**, the server drops the victim's locks, another client grabs the range → **silent corruption**. The handler was previously an inert TODO stub: it logged and returned, with zero source validation and no replay protection. Flagging now (HIGH) because the gate must exist *before* the relay ships, not after.

### Fix — two gates, both required before any side effect

**H16 — monitored-list + source-address gate.** Before acting, a NOTIFY must satisfy:
1. `mon_name` is on the monitored list (a host we actually `SM_MON`'d — i.e. some registration in the connection tracker records `MonName == mon_name`), AND
2. the RPC source IP matches that monitored host's recorded address. Only the IP is compared (an NSM peer sends NOTIFY from a different ephemeral port than its SM_MON), via `net.SplitHostPort`.

Unmonitored `mon_name` or address mismatch → dropped silently. This matches the rpc.statd trust model: a host can only report *its own* reboot, never forge a victim's `mon_name`.

**H17 — state-number monotonicity.** NSM state numbers increase monotonically per host. The handler now stores the last-seen state per `mon_name` (mutex-guarded map on the `Handler`) and acts only when `incoming_state > stored_state`, then updates. Equal/lower states are replays/stale and are dropped. Previously `Mon` recorded the *server's own* state, never the peer's, so a replay re-fired release every time.

### Relay status
The lock-drop relay is **NOT wired** in this PR (deferred). The priority is that the gates exist so a future relay is safe by construction. `Notify` has exactly one path to the point where a relay would run, and it sits past **both** gate checks (gate order: H16 then H17). The relay-to-be is documented inline as requiring both gates. No change to `pkg/adapter/nfs/nlm.go` was needed.

### Scope
Touches only `internal/adapter/nfs/nsm/handlers/` (`notify.go`, `handler.go`, new `notify_test.go`). Does not touch `internal/adapter/nfs/v4` or `pkg/metadata` (owned by parallel PRs); per-peer state is kept local to the NSM `Handler` rather than extending the shared `ConnectionTracker`.

### Tests (`notify_test.go`, `-race` green)
- H16: unmonitored host → ignored; source-addr mismatch → rejected; monitored host at matching IP → accepted. Plus focused `isMonitoredFromSource` matrix.
- H17: same/decreasing state → no-op; strictly-increasing → acts and advances stored state; replay → no-op. Plus `admitPeerState` unit coverage and a monitored-replay end-to-end no-op (defence in depth).
- XDR round-trip sanity for the hand-rolled `stat_chge` test encoder.

### Gates
`gofmt -s -w` + `go vet` + `golangci-lint run` (0 issues) + `go test -race ./internal/adapter/nfs/...` all green. Code-simplifier and code-reviewer angles run by hand at high rigor (Agent tool unavailable in this environment): verified no path acts on a NOTIFY without passing **both** the monitored-list/source-addr gate and the monotonicity check.
