### PR TITLE
fix(metadata): deregister per-share store/lockmgr/notifier on RemoveShare (area-6 PR-B5)

### DIFF
--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -379,7 +379,15 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 // (D-23-02) returns false once the snapshots/ tree is gone. D-23-17.
 func (r *Runtime) RemoveShare(name string) error {
 	r.cancelAndWaitInFlightSnaps(name) // D-23-17: drain BEFORE tree wipe
-	return r.sharesSvc.RemoveShare(name)
+	if err := r.sharesSvc.RemoveShare(name); err != nil {
+		return err
+	}
+	// Deregister the share's per-share store / lock manager / unified view /
+	// notifier / quota from the metadata service, mirroring the AddShare
+	// registration above. Without this the service maps grow unbounded across
+	// add/remove churn and a same-name re-add reuses the stale lock manager.
+	r.metadataService.RemoveStoreForShare(name)
+	return nil
 }
 
 func (r *Runtime) UpdateShare(name string, readOnly *bool, defaultPermission *string, retentionPolicy *blockstore.RetentionPolicy, retentionTTL *time.Duration) error {

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -202,6 +202,41 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	return nil
 }
 
+// RemoveStoreForShare deregisters a share from the MetadataService, deleting
+// its entry from every per-share map populated by RegisterStoreForShare and the
+// AddShare path (stores, lockManagers, unifiedViews, dirChangeNotifiers,
+// quotas). Without this, those maps grow unbounded across AddShare/RemoveShare
+// churn and leave stale routing: a removed-share handle would still resolve to a
+// live store, and re-adding a same-name share would silently reuse the stale
+// lock manager (RegisterStoreForShare early-returns when one already exists).
+//
+// Before dropping the lock manager its grace timer is aborted so the orphaned
+// timer never fires onGraceEnd against a now-removed share. Idempotent: removing
+// a share that was never registered (or already removed) is a no-op.
+//
+// This is the symmetric counterpart of RegisterStoreForShare and must be called
+// from the control-plane RemoveShare path after the share's stores are torn
+// down.
+//
+// Thread safety: Safe to call concurrently.
+func (s *MetadataService) RemoveStoreForShare(shareName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if lm, ok := s.lockManagers[shareName]; ok && lm != nil {
+		// Abort the grace timer (if armed) so it never fires onGraceEnd against
+		// a removed share. AbortGracePeriod stops the timer synchronously and
+		// does not block, so holding s.mu across it is safe.
+		lm.AbortGracePeriod()
+	}
+
+	delete(s.stores, shareName)
+	delete(s.lockManagers, shareName)
+	delete(s.unifiedViews, shareName)
+	delete(s.dirChangeNotifiers, shareName)
+	delete(s.quotas, shareName)
+}
+
 // initLockManagerFromStore stamps a fresh server epoch and replays any locks
 // persisted by a previous run back into the lock manager. Errors are logged
 // and swallowed so a recovery failure never blocks share registration.

--- a/pkg/metadata/service_remove_share_test.go
+++ b/pkg/metadata/service_remove_share_test.go
@@ -1,0 +1,99 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveStoreForShare_DeregistersAllMaps asserts that RemoveStoreForShare
+// drops the share from every per-share map (store, lock manager, unified view,
+// quota) so removed shares no longer route and the maps do not grow unbounded
+// across add/remove churn.
+func TestRemoveStoreForShare_DeregistersAllMaps(t *testing.T) {
+	const shareName = "/churn"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+	svc.SetQuotaForShare(shareName, 4096)
+
+	// Sanity: everything is registered.
+	gotStore, err := svc.GetStoreForShare(shareName)
+	require.NoError(t, err)
+	require.NotNil(t, gotStore)
+	require.NotNil(t, svc.GetLockManagerForShare(shareName))
+	require.Equal(t, int64(4096), svc.GetQuotaForShare(shareName))
+
+	svc.RemoveStoreForShare(shareName)
+
+	// Store routing is gone.
+	_, err = svc.GetStoreForShare(shareName)
+	require.Error(t, err, "removed share must not resolve to a live store")
+
+	// Lock manager is gone.
+	require.Nil(t, svc.GetLockManagerForShare(shareName),
+		"removed share must not retain a lock manager")
+
+	// Unified view is gone.
+	require.Nil(t, svc.GetUnifiedLockView(shareName),
+		"removed share must not retain a unified lock view")
+
+	// Quota entry is gone (GetQuotaForShare returns the zero value for a
+	// missing key, same as unlimited).
+	require.Equal(t, int64(0), svc.GetQuotaForShare(shareName),
+		"removed share must not retain a quota entry")
+}
+
+// TestRemoveStoreForShare_ReAddGetsFreshLockManager asserts that after a
+// remove, re-adding a same-name share gets a FRESH lock manager rather than
+// silently reusing the stale one (RegisterStoreForShare early-returns when a
+// lock manager already exists, so a leaked entry would be reused).
+//
+// This is the regression that fails before the fix: without
+// RemoveStoreForShare, the second RegisterStoreForShare sees the surviving
+// lockManagers[name] entry and returns the SAME *LockManager.
+func TestRemoveStoreForShare_ReAddGetsFreshLockManager(t *testing.T) {
+	const shareName = "/reused"
+
+	svc := metadata.New()
+
+	store1 := memory.NewMemoryMetadataStoreWithDefaults()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store1))
+	lm1 := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm1)
+
+	svc.RemoveStoreForShare(shareName)
+
+	store2 := memory.NewMemoryMetadataStoreWithDefaults()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store2))
+	lm2 := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm2)
+
+	require.NotSame(t, lm1, lm2,
+		"re-adding a same-name share must allocate a fresh lock manager, not reuse the stale one")
+
+	// And the re-added store must be the new one, not the stale routing target.
+	gotStore, err := svc.GetStoreForShare(shareName)
+	require.NoError(t, err)
+	require.Same(t, store2, gotStore,
+		"re-added share must route to the newly registered store")
+}
+
+// TestRemoveStoreForShare_Idempotent asserts removing an unregistered or
+// already-removed share is a harmless no-op (no panic, no nil deref).
+func TestRemoveStoreForShare_Idempotent(t *testing.T) {
+	svc := metadata.New()
+
+	// Never registered.
+	require.NotPanics(t, func() { svc.RemoveStoreForShare("/never") })
+
+	// Registered then removed twice.
+	const shareName = "/twice"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+	require.NotPanics(t, func() { svc.RemoveStoreForShare(shareName) })
+	require.NotPanics(t, func() { svc.RemoveStoreForShare(shareName) })
+}


### PR DESCRIPTION
## Bug

`MetadataService` holds five per-share maps — `stores`, `lockManagers`, `unifiedViews`, `dirChangeNotifiers`, `quotas` — with a registration path (`RegisterStoreForShare` + `SetUnifiedLockView`/`SetQuotaForShare`) but **no symmetric removal**. `RemoveShare` deleted only the shares-registry entry, leaving every metadata-service entry forever:

- maps grow unbounded across AddShare/RemoveShare churn (lock managers hold grace timers);
- stale routing — a removed-share handle still resolves to a live store;
- same-name re-add silently reuses the **stale** lock manager, because `RegisterStoreForShare` early-returns when `lockManagers[name]` already exists.

## Fix

Add `MetadataService.RemoveStoreForShare(shareName)`: under `s.mu` it aborts the lock manager's grace timer (`AbortGracePeriod`, non-blocking) so the orphaned timer never fires `onGraceEnd` against a removed share, then deletes the share from all five maps. Idempotent for never-registered / already-removed shares.

Wire it into the control-plane `Runtime.RemoveShare` after `sharesSvc.RemoveShare` succeeds, mirroring the `AddShare` registration/quota site.

## Test

White-box tests (`pkg/metadata/service_remove_share_test.go`) prove: all five maps drop the share after remove; a same-name re-add gets a **fresh** lock manager (`NotSame`) and routes to the newly registered store; removal is idempotent. Verified the regression tests FAIL before the fix and PASS after.

## Scope

Only `pkg/metadata/` + `pkg/controlplane/runtime/`. No lock/ACL internals, no postgres DeleteShare cascade, no NFS code.

`go test -race ./pkg/metadata/... ./pkg/controlplane/...` (incl. `-tags=integration` for metadata) green.