### PR TITLE
fix(nfs/nlm): release crashed-client locks on SM_NOTIFY (area-4 H14)

### DIFF
--- a/internal/adapter/nfs/nlm/blocking/queue.go
+++ b/internal/adapter/nfs/nlm/blocking/queue.go
@@ -157,6 +157,45 @@ func (bq *BlockingQueue) RemoveWaiter(fileHandle string, waiter *Waiter) {
 	}
 }
 
+// RemoveClientWaiters drains every queued waiter whose CallerName matches the
+// given client and returns the number removed.
+//
+// This is used for NSM crash cleanup: when a client crashes, any blocking-lock
+// requests it left queued must be dropped so the server never fires an
+// NLM_GRANTED callback to a dead client. Each matching waiter is marked
+// cancelled (so an in-flight grant goroutine observing IsCancelled() bails)
+// before removal.
+//
+// CallerName is the NSM caller_name (client hostname), the same identity NSM
+// uses for SM_NOTIFY. Calling with a clientID that has no queued waiters is
+// safe and returns 0.
+//
+// Thread safety: Safe to call concurrently.
+func (bq *BlockingQueue) RemoveClientWaiters(clientID string) int {
+	bq.mu.Lock()
+	defer bq.mu.Unlock()
+
+	removed := 0
+	for fileHandle, queue := range bq.queues {
+		remaining := queue[:0:0] // new backing array; never alias the original
+		for _, w := range queue {
+			if w.CallerName == clientID {
+				w.Cancel()
+				removed++
+				continue
+			}
+			remaining = append(remaining, w)
+		}
+		if len(remaining) == 0 {
+			delete(bq.queues, fileHandle)
+		} else {
+			bq.queues[fileHandle] = remaining
+		}
+	}
+
+	return removed
+}
+
 // TotalWaiters returns the total number of waiters across all files.
 //
 // This is used for metrics (nlm_blocking_queue_size gauge).

--- a/internal/adapter/nfs/nlm/blocking/queue_test.go
+++ b/internal/adapter/nfs/nlm/blocking/queue_test.go
@@ -1,0 +1,102 @@
+package blocking
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+func newWaiter(caller, ownerID string, off uint64) *Waiter {
+	return &Waiter{
+		Lock: &lock.UnifiedLock{
+			Owner:  lock.LockOwner{OwnerID: ownerID},
+			Offset: off,
+			Length: 10,
+		},
+		CallerName: caller,
+	}
+}
+
+func TestBlockingQueue_RemoveClientWaiters(t *testing.T) {
+	t.Parallel()
+
+	bq := NewBlockingQueue(100)
+
+	// clientA queues waiters on two files; clientB queues one on file1.
+	if err := bq.Enqueue("file1", newWaiter("clientA", "nlm:clientA:1:aa", 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := bq.Enqueue("file2", newWaiter("clientA", "nlm:clientA:2:bb", 0)); err != nil {
+		t.Fatal(err)
+	}
+	bWaiter := newWaiter("clientB", "nlm:clientB:1:cc", 50)
+	if err := bq.Enqueue("file1", bWaiter); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := bq.TotalWaiters(); got != 3 {
+		t.Fatalf("want 3 waiters before drain, got %d", got)
+	}
+
+	removed := bq.RemoveClientWaiters("clientA")
+	if removed != 2 {
+		t.Fatalf("want 2 waiters drained, got %d", removed)
+	}
+
+	// Only clientB's waiter remains, and it is not cancelled.
+	if got := bq.TotalWaiters(); got != 1 {
+		t.Fatalf("want 1 waiter after drain, got %d", got)
+	}
+	if bWaiter.IsCancelled() {
+		t.Fatal("clientB waiter must not be cancelled")
+	}
+	rem := bq.GetWaiters("file1")
+	if len(rem) != 1 || rem[0] != bWaiter {
+		t.Fatalf("file1 should retain only clientB waiter, got %+v", rem)
+	}
+	// file2 had only clientA, so it must be fully removed.
+	if got := bq.GetWaiters("file2"); got != nil {
+		t.Fatalf("file2 should be empty after drain, got %+v", got)
+	}
+}
+
+func TestBlockingQueue_RemoveClientWaiters_CancelsDrained(t *testing.T) {
+	t.Parallel()
+
+	bq := NewBlockingQueue(100)
+	w := newWaiter("clientA", "nlm:clientA:1:aa", 0)
+	if err := bq.Enqueue("file1", w); err != nil {
+		t.Fatal(err)
+	}
+
+	if w.IsCancelled() {
+		t.Fatal("waiter should not be cancelled before drain")
+	}
+	if removed := bq.RemoveClientWaiters("clientA"); removed != 1 {
+		t.Fatalf("want 1 removed, got %d", removed)
+	}
+	if !w.IsCancelled() {
+		t.Fatal("drained waiter must be marked cancelled so in-flight grants bail")
+	}
+}
+
+func TestBlockingQueue_RemoveClientWaiters_NoMatchIsSafe(t *testing.T) {
+	t.Parallel()
+
+	bq := NewBlockingQueue(100)
+	if err := bq.Enqueue("file1", newWaiter("clientA", "nlm:clientA:1:aa", 0)); err != nil {
+		t.Fatal(err)
+	}
+
+	if removed := bq.RemoveClientWaiters("ghost"); removed != 0 {
+		t.Fatalf("want 0 removed for unknown client, got %d", removed)
+	}
+	if got := bq.TotalWaiters(); got != 1 {
+		t.Fatalf("untouched waiter should remain, got %d", got)
+	}
+
+	empty := NewBlockingQueue(100)
+	if removed := empty.RemoveClientWaiters("anyone"); removed != 0 {
+		t.Fatalf("want 0 removed on empty queue, got %d", removed)
+	}
+}

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/callback"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm"
 	nsm_handlers "github.com/marmos91/dittofs/internal/adapter/nfs/nsm/handlers"
@@ -492,9 +493,37 @@ func (s *NFSAdapter) initNSMHandler(rt *runtime.Runtime, metadataService *metada
 //   - ctx: Context for cancellation
 //   - clientID: The NSM client hostname (mon_name from SM_MON)
 //   - metadataService: Access to lock managers for all shares
-func (s *NFSAdapter) handleClientCrash(ctx context.Context, clientID string, metadataService *metadata.MetadataService) error {
-	// Build NLM owner ID prefix pattern
-	// NLM locks have owner IDs formatted as nlm:{caller_name}:{svid}:{oh_hex}
+func (s *NFSAdapter) handleClientCrash(_ context.Context, clientID string, metadataService *metadata.MetadataService) error {
+	releaseCrashedClientLocks(
+		clientID,
+		s.Registry.ListShares(),
+		metadataService.GetLockManagerForShare,
+		s.blockingQueue,
+	)
+	return nil
+}
+
+// releaseCrashedClientLocks performs the actual NSM crash cleanup, decoupled
+// from the Runtime so it is unit-testable. It releases every NLM byte-range
+// lock held by the crashed client across all shares and drains any blocking
+// waiters it left queued.
+//
+//   - clientID: the NSM caller_name (mon_name) of the crashed client.
+//   - shares: every share name to scan (lock managers are per-share).
+//   - lockMgrFor: resolves a share name to its lock manager (may return nil).
+//   - blockingQueue: the adapter-wide NLM blocking queue (may be nil).
+//
+// NLM locks have owner IDs formatted as "nlm:{caller_name}:{svid}:{oh_hex}", so
+// the prefix "nlm:{clientID}:" releases exactly this client's NLM locks: SMB and
+// NFSv4 use different OwnerID prefixes, and the trailing ":" prevents
+// "nlm:client1:" from matching "nlm:client10:". Idempotent and safe when the
+// client held no locks.
+func releaseCrashedClientLocks(
+	clientID string,
+	shares []string,
+	lockMgrFor func(string) *metadata.LockManager,
+	blockingQueue *blocking.BlockingQueue,
+) {
 	clientPrefix := "nlm:" + clientID + ":"
 	totalReleased := 0
 
@@ -502,37 +531,37 @@ func (s *NFSAdapter) handleClientCrash(ctx context.Context, clientID string, met
 		"client", clientID,
 		"prefix", clientPrefix)
 
-	// Iterate all shares and release matching locks
-	shares := s.Registry.ListShares()
+	// Iterate ALL shares and release every byte-range lock the crashed client
+	// held. A single client can hold locks across multiple shares.
 	for _, shareName := range shares {
-		lockMgr := metadataService.GetLockManagerForShare(shareName)
+		lockMgr := lockMgrFor(shareName)
 		if lockMgr == nil {
 			continue
 		}
 
-		// Get all locks and release those matching the client prefix
-		// Note: This is a simplified implementation. A more efficient approach
-		// would be to add a ReleaseByOwnerPrefix method to the LockManager.
-		// For now, we use best-effort cleanup via the existing infrastructure.
-		//
-		// The actual lock cleanup happens when:
-		// 1. NSM notifier detects crash and calls this callback
-		// 2. This callback logs the event for audit
-		// 3. The grace period mechanism from handles reclaims
-		//
-		// A production enhancement would be to iterate the LockStore
-		// and explicitly release all locks matching the prefix.
+		released := lockMgr.ReleaseByOwnerPrefix(clientPrefix)
+		totalReleased += released
+		if released > 0 {
+			logger.Debug("NSM: released crashed-client locks on share",
+				"share", shareName,
+				"client", clientID,
+				"released", released)
+		}
+	}
 
-		logger.Debug("NSM: checking share for crashed client locks",
-			"share", shareName,
-			"client", clientID)
+	// Drain any blocking-lock waiters the crashed client left queued so we never
+	// fire an NLM_GRANTED callback to a dead client. The blocking queue is a
+	// single adapter-wide structure keyed by file handle (which already encodes
+	// share identity), so this one call covers all shares.
+	drainedWaiters := 0
+	if blockingQueue != nil {
+		drainedWaiters = blockingQueue.RemoveClientWaiters(clientID)
 	}
 
 	logger.Info("NSM: completed lock cleanup for crashed client",
 		"client", clientID,
-		"total_released", totalReleased)
-
-	return nil
+		"locks_released", totalReleased,
+		"waiters_drained", drainedWaiters)
 }
 
 // performNSMStartup handles NSM-related startup tasks.

--- a/pkg/adapter/nfs/nlm_crash_test.go
+++ b/pkg/adapter/nfs/nlm_crash_test.go
@@ -1,0 +1,124 @@
+package nfs
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/require"
+)
+
+// addNLMLock seeds an NLM byte-range lock on lm with the given owner ID.
+func addNLMLock(t *testing.T, lm *metadata.LockManager, file, ownerID string, off uint64) {
+	t.Helper()
+	err := lm.AddUnifiedLock(file, &lock.UnifiedLock{
+		ID:         ownerID,
+		Owner:      lock.LockOwner{OwnerID: ownerID, ClientID: "ignored"},
+		FileHandle: lock.FileHandle(file),
+		Offset:     off,
+		Length:     10,
+		Type:       lock.LockTypeExclusive,
+	})
+	require.NoError(t, err)
+}
+
+func enqueueWaiter(t *testing.T, bq *blocking.BlockingQueue, file, caller, ownerID string) *blocking.Waiter {
+	t.Helper()
+	w := &blocking.Waiter{
+		Lock:       &lock.UnifiedLock{Owner: lock.LockOwner{OwnerID: ownerID}},
+		CallerName: caller,
+	}
+	require.NoError(t, bq.Enqueue(file, w))
+	return w
+}
+
+// TestReleaseCrashedClientLocks proves that when client A crashes, all of A's
+// NLM locks (across multiple shares) and its queued waiters are released, while
+// client B's locks/waiters survive and B can subsequently acquire the range A
+// had held.
+func TestReleaseCrashedClientLocks(t *testing.T) {
+	t.Parallel()
+
+	// Two shares, each with its own lock manager.
+	lmShareA := lock.NewManager()
+	lmShareB := lock.NewManager()
+	lockMgrFor := func(share string) *metadata.LockManager {
+		switch share {
+		case "share-a":
+			return lmShareA
+		case "share-b":
+			return lmShareB
+		default:
+			return nil
+		}
+	}
+
+	// Client A holds locks on both shares; client B holds one on share-a.
+	addNLMLock(t, lmShareA, "share-a:file1", "nlm:clientA:1:aa", 0)
+	addNLMLock(t, lmShareB, "share-b:file9", "nlm:clientA:2:bb", 0)
+	addNLMLock(t, lmShareA, "share-a:file1", "nlm:clientB:1:cc", 100)
+	// Prefix-collision client that MUST survive (no trailing-colon false match).
+	addNLMLock(t, lmShareA, "share-a:file1", "nlm:clientA10:1:dd", 200)
+
+	// Blocking queue: A and B each have a queued waiter.
+	bq := blocking.NewBlockingQueue(100)
+	aWaiter := enqueueWaiter(t, bq, "share-a:file1", "clientA", "nlm:clientA:3:ee")
+	bWaiter := enqueueWaiter(t, bq, "share-a:file1", "clientB", "nlm:clientB:2:ff")
+
+	// Sanity: A's locks are held BEFORE the crash.
+	require.Len(t, lmShareA.ListUnifiedLocks("share-a:file1"), 3)
+	require.Len(t, lmShareB.ListUnifiedLocks("share-b:file9"), 1)
+	require.Equal(t, 2, bq.TotalWaiters())
+
+	// Simulate the crash of client A.
+	releaseCrashedClientLocks("clientA", []string{"share-a", "share-b"}, lockMgrFor, bq)
+
+	// A's locks gone on both shares; B and the prefix-collision client survive.
+	remA := lmShareA.ListUnifiedLocks("share-a:file1")
+	require.Len(t, remA, 2, "only clientB and clientA10 should remain on share-a")
+	for _, l := range remA {
+		require.NotEqual(t, "nlm:clientA:1:aa", l.Owner.OwnerID, "clientA lock must be released")
+	}
+	require.Empty(t, lmShareB.ListUnifiedLocks("share-b:file9"), "clientA's share-b lock must be released")
+
+	// A's waiter drained + cancelled; B's waiter survives intact.
+	require.Equal(t, 1, bq.TotalWaiters(), "only clientB's waiter should remain")
+	require.True(t, aWaiter.IsCancelled(), "clientA's drained waiter must be cancelled")
+	require.False(t, bWaiter.IsCancelled(), "clientB's waiter must not be cancelled")
+
+	// Client B can now acquire the exact range clientA had held on share-a.
+	err := lmShareA.AddUnifiedLock("share-a:file1", &lock.UnifiedLock{
+		ID:         "nlm:clientB:9:gg",
+		Owner:      lock.LockOwner{OwnerID: "nlm:clientB:9:gg"},
+		FileHandle: "share-a:file1",
+		Offset:     0, // the range clientA held
+		Length:     10,
+		Type:       lock.LockTypeExclusive,
+	})
+	require.NoError(t, err, "B must be able to acquire the freed range after A's crash")
+}
+
+// TestReleaseCrashedClientLocks_NoLocksHeld proves idempotency / safety when the
+// crashed client held nothing and a share has no lock manager.
+func TestReleaseCrashedClientLocks_NoLocksHeld(t *testing.T) {
+	t.Parallel()
+
+	lm := lock.NewManager()
+	addNLMLock(t, lm, "share-a:file1", "nlm:other:1:aa", 0)
+
+	lockMgrFor := func(share string) *metadata.LockManager {
+		if share == "share-a" {
+			return lm
+		}
+		return nil // share-b has no lock manager
+	}
+
+	bq := blocking.NewBlockingQueue(100)
+
+	// Crash of a client that holds nothing; nil blocking queue tolerated too.
+	releaseCrashedClientLocks("ghost", []string{"share-a", "share-b"}, lockMgrFor, bq)
+	releaseCrashedClientLocks("ghost", []string{"share-a"}, lockMgrFor, nil)
+
+	require.Len(t, lm.ListUnifiedLocks("share-a:file1"), 1, "unrelated lock must survive")
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2862,6 +2862,45 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 	}
 }
 
+// ReleaseByOwnerPrefix removes every unified lock whose Owner.OwnerID begins
+// with the given prefix and returns the number of locks released.
+//
+// This is used for NSM crash cleanup: when a client crashes, NLM must release
+// all locks it held. NLM owner IDs are formatted as
+// "nlm:{caller_name}:{svid}:{oh_hex}", so passing "nlm:{caller_name}:" releases
+// every byte-range lock the crashed client held across all files in this share
+// without touching locks from other protocols (SMB/NFSv4 use different prefixes)
+// or other NLM clients. The trailing ":" in the caller-supplied prefix prevents
+// "nlm:client1:" from matching "nlm:client10:".
+//
+// The persisted bulk-delete runs synchronously under lm.mu for the same
+// ordering reason as RemoveClientLocks. Calling with a prefix that matches no
+// locks is safe and returns 0.
+func (lm *Manager) ReleaseByOwnerPrefix(prefix string) int {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	released := 0
+	for handleKey, locks := range lm.unifiedLocks {
+		var remaining []*UnifiedLock
+		for _, lock := range locks {
+			if strings.HasPrefix(lock.Owner.OwnerID, prefix) {
+				lm.deleteUnifiedLockLocked(lock)
+				released++
+				continue
+			}
+			remaining = append(remaining, lock)
+		}
+		if len(remaining) == 0 {
+			delete(lm.unifiedLocks, handleKey)
+		} else {
+			lm.unifiedLocks[handleKey] = remaining
+		}
+	}
+
+	return released
+}
+
 // GetStats returns current lock manager statistics.
 func (lm *Manager) GetStats() ManagerStats {
 	lm.mu.RLock()

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1306,3 +1306,94 @@ func TestLock_NFS_SameSession_ExclusiveRelock_OK(t *testing.T) {
 		t.Fatal("NFS same-session exclusive re-lock should succeed (POSIX semantics)")
 	}
 }
+
+// ============================================================================
+// ReleaseByOwnerPrefix (NSM crash cleanup, area-4 H14)
+// ============================================================================
+
+func TestManager_ReleaseByOwnerPrefix(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	// Client A (caller_name "clientA") holds two locks across two files.
+	addLock := func(id, ownerID, file string, off uint64) {
+		l := &UnifiedLock{
+			ID:         id,
+			Owner:      LockOwner{OwnerID: ownerID, ClientID: "ignored"},
+			FileHandle: FileHandle(file),
+			Offset:     off,
+			Length:     10,
+			Type:       LockTypeExclusive,
+		}
+		if err := lm.AddUnifiedLock(file, l); err != nil {
+			t.Fatalf("AddUnifiedLock(%s) failed: %v", id, err)
+		}
+	}
+
+	addLock("a1", "nlm:clientA:1:aa", "file1", 0)
+	addLock("a2", "nlm:clientA:2:bb", "file2", 0)
+	// Client B and a same-prefix-collision client must NOT be released.
+	addLock("b1", "nlm:clientB:1:cc", "file1", 100)
+	addLock("a10", "nlm:clientA10:1:dd", "file1", 200) // "nlm:clientA" prefix WITHOUT trailing ':' would wrongly match
+	// A non-NLM (SMB) lock that happens to share the bare token must be untouched.
+	addLock("smb1", "smb:clientA:5:ee", "file2", 100)
+
+	// Prove the locks are held before release.
+	if got := len(lm.ListUnifiedLocks("file1")); got != 3 {
+		t.Fatalf("file1: want 3 locks before release, got %d", got)
+	}
+	if got := len(lm.ListUnifiedLocks("file2")); got != 2 {
+		t.Fatalf("file2: want 2 locks before release, got %d", got)
+	}
+
+	released := lm.ReleaseByOwnerPrefix("nlm:clientA:")
+	if released != 2 {
+		t.Fatalf("want 2 locks released, got %d", released)
+	}
+
+	// clientA's locks gone; clientB, clientA10, and the SMB lock remain.
+	remainingF1 := lm.ListUnifiedLocks("file1")
+	if len(remainingF1) != 2 {
+		t.Fatalf("file1: want 2 locks after release, got %d", len(remainingF1))
+	}
+	for _, l := range remainingF1 {
+		if l.Owner.OwnerID == "nlm:clientA:1:aa" {
+			t.Fatalf("file1: clientA lock was not released")
+		}
+	}
+	remainingF2 := lm.ListUnifiedLocks("file2")
+	if len(remainingF2) != 1 || remainingF2[0].Owner.OwnerID != "smb:clientA:5:ee" {
+		t.Fatalf("file2: want only the SMB lock to remain, got %+v", remainingF2)
+	}
+}
+
+func TestManager_ReleaseByOwnerPrefix_NoMatchIsSafe(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	l := &UnifiedLock{
+		ID:         "x",
+		Owner:      LockOwner{OwnerID: "nlm:other:1:aa"},
+		FileHandle: "file1",
+		Offset:     0,
+		Length:     10,
+		Type:       LockTypeExclusive,
+	}
+	if err := lm.AddUnifiedLock("file1", l); err != nil {
+		t.Fatal(err)
+	}
+
+	// No-match prefix and empty-manager both return 0 without disturbing state.
+	if released := lm.ReleaseByOwnerPrefix("nlm:ghost:"); released != 0 {
+		t.Fatalf("want 0 released for non-matching prefix, got %d", released)
+	}
+	if got := len(lm.ListUnifiedLocks("file1")); got != 1 {
+		t.Fatalf("untouched lock should remain, got %d", got)
+	}
+
+	empty := NewManager()
+	if released := empty.ReleaseByOwnerPrefix("nlm:anyone:"); released != 0 {
+		t.Fatalf("want 0 released on empty manager, got %d", released)
+	}
+}


### PR DESCRIPTION
## Bug (area-4 NFS audit, HIGH H14)

NLM `handleClientCrash` was a no-op stub. When statd delivered an SM_NOTIFY that an NLM client rebooted/crashed, the server logged the event but **never released the locks that client held**. Locks stayed held forever, permanently denying the byte ranges to all other clients (a DoS).

## Fix

The SM_NOTIFY → `Notifier.handleClientCrash` → `onClientCrash` wiring was already in place; only the release path was missing. Implemented it:

- **`lock.Manager.ReleaseByOwnerPrefix(prefix) int`** — prefix-scoped scan that releases every unified byte-range lock whose `Owner.OwnerID` starts with the prefix, returning the count. Crash cleanup passes `nlm:{clientID}:`, so it releases exactly the crashed client's NLM locks. SMB/NFSv4 use different OwnerID prefixes, and the **trailing `:`** prevents `nlm:client1:` from matching `nlm:client10:`.
- **`blocking.BlockingQueue.RemoveClientWaiters(clientID) int`** — drains and `Cancel()`-marks any blocking-lock waiters the crashed client left queued, so an NLM_GRANTED callback is never fired to a dead client (the grant path already skips cancelled waiters).
- `handleClientCrash` now iterates **all shares** (lock managers are per-share) and drains the adapter-wide blocking queue. The core was extracted into a Runtime-free helper `releaseCrashedClientLocks` for unit testing.

Idempotent and safe when the crashed client held no locks. No re-entrant locking: `ReleaseByOwnerPrefix` holds `lm.mu` and only calls `*Locked` persistence helpers; `RemoveClientWaiters` holds `bq.mu` and takes only the per-waiter mutex.

## Tests

- `TestManager_ReleaseByOwnerPrefix` (+ no-match/empty) — proves clientA's locks across files are released while clientB, a prefix-collision `clientA10`, and an SMB lock all survive.
- `TestBlockingQueue_RemoveClientWaiters` (+ cancel/no-match) — proves drained waiters are removed and cancelled; others untouched.
- `TestReleaseCrashedClientLocks` — end-to-end: client A holds locks on **two shares** + a queued waiter; B holds a lock + waiter. After A's crash, all of A's locks/waiters are gone (prove held-before / released-after), B's survive, and **B can acquire the exact range A had held**.

## Scope

Only NLM + lock-manager release surface + the notify-path glue. No changes to NSM gating (#892), v4 state, metadata stores, or SMB.