### PR TITLE
fix(postgres): lossless timestamps + DOS-attr mode bits for SMB parity (#882)

### DIFF
--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -123,19 +123,21 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		pgCfg.AutoMigrate = true
 
 		capabilities := metadata.FilesystemCapabilities{
-			MaxReadSize:         1024 * 1024,
-			PreferredReadSize:   64 * 1024,
-			MaxWriteSize:        1024 * 1024,
-			PreferredWriteSize:  64 * 1024,
-			MaxFileSize:         1024 * 1024 * 1024 * 100, // 100 GB
-			MaxFilenameLen:      255,
-			MaxPathLen:          4096,
-			MaxHardLinkCount:    32767,
-			SupportsHardLinks:   true,
-			SupportsSymlinks:    true,
-			CaseSensitive:       true,
-			CasePreserving:      true,
-			SupportsACLs:        false,
+			MaxReadSize:        1024 * 1024,
+			PreferredReadSize:  64 * 1024,
+			MaxWriteSize:       1024 * 1024,
+			PreferredWriteSize: 64 * 1024,
+			MaxFileSize:        1024 * 1024 * 1024 * 100, // 100 GB
+			MaxFilenameLen:     255,
+			MaxPathLen:         4096,
+			MaxHardLinkCount:   32767,
+			SupportsHardLinks:  true,
+			SupportsSymlinks:   true,
+			CaseSensitive:      true,
+			CasePreserving:     true,
+			SupportsACLs:       false,
+			// File timestamps are stored as BIGINT unix nanoseconds (lossless),
+			// so nanosecond resolution is accurate for the postgres backend.
 			TimestampResolution: time.Nanosecond,
 		}
 

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -33,6 +33,33 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 }
 
 // ============================================================================
+// Timestamp Encoding (BIGINT nanoseconds, lossless FILETIME parity)
+// ============================================================================
+//
+// File timestamps are stored as BIGINT unix nanoseconds rather than TIMESTAMPTZ
+// (microsecond) so sub-microsecond FILETIME values round-trip losslessly, on
+// par with the memory/badger backends (#882). A zero time.Time maps to 0 and
+// back, matching the zero-value semantics those backends use.
+
+// timeToPGNanos converts a time.Time to the BIGINT unix-nanosecond value stored
+// in the files timestamp columns. The zero time maps to 0.
+func timeToPGNanos(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// pgNanosToTime converts a stored BIGINT unix-nanosecond value back to a UTC
+// time.Time. 0 maps to the zero time.Time.
+func pgNanosToTime(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n).UTC()
+}
+
+// ============================================================================
 // Database Row Serialization
 // ============================================================================
 
@@ -49,10 +76,10 @@ func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 		uid          int32
 		gid          int32
 		size         int64
-		atime        time.Time
-		mtime        time.Time
-		ctime        time.Time
-		creationTime time.Time
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
 		payloadID    sql.NullString
 		linkTarget   sql.NullString
 		deviceMajor  sql.NullInt32
@@ -106,10 +133,10 @@ func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 			GID:          uint32(gid),
 			Nlink:        nlink,
 			Size:         uint64(size),
-			Atime:        atime,
-			Mtime:        mtime,
-			Ctime:        ctime,
-			CreationTime: creationTime,
+			Atime:        pgNanosToTime(atime),
+			Mtime:        pgNanosToTime(mtime),
+			Ctime:        pgNanosToTime(ctime),
+			CreationTime: pgNanosToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -247,7 +246,7 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		var fileType int16
 		var mode, uid, gid int32
 		var size int64
-		var atime, mtime, ctime, creationTime time.Time
+		var atime, mtime, ctime, creationTime int64
 		var hidden bool
 		var aclJSON []byte
 		var objectIDRaw []byte
@@ -301,10 +300,10 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        atime,
-			Mtime:        mtime,
-			Ctime:        ctime,
-			CreationTime: creationTime,
+			Atime:        pgNanosToTime(atime),
+			Mtime:        pgNanosToTime(mtime),
+			Ctime:        pgNanosToTime(ctime),
+			CreationTime: pgNanosToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {

--- a/pkg/metadata/store/postgres/migrations/000022_widen_valid_mode.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000022_widen_valid_mode.down.sql
@@ -1,0 +1,3 @@
+-- Restore the original POSIX-only valid_mode upper bound.
+ALTER TABLE files DROP CONSTRAINT IF EXISTS valid_mode;
+ALTER TABLE files ADD CONSTRAINT valid_mode CHECK (mode >= 0 AND mode <= 4095);

--- a/pkg/metadata/store/postgres/migrations/000022_widen_valid_mode.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000022_widen_valid_mode.up.sql
@@ -1,0 +1,24 @@
+-- Widen the files.mode CHECK constraint to admit DittoFS high mode bits.
+--
+-- The SMB adapter stores DOS file attributes (ARCHIVE, SYSTEM, READONLY,
+-- COMPRESSED, SPARSE, plus the "DOS attributes were explicitly set" marker) in
+-- high bits of the Unix mode field rather than mutating POSIX permission bits.
+-- See internal/adapter/smb/v2/handlers/converters.go: modeDOSExplicit (0x10000),
+-- modeDOSArchive (0x20000), modeDOSCompressed (0x40000), modeDOSSystem
+-- (0x80000), modeDOSReadonly (0x100000), modeDOSSparse (0x200000).
+--
+-- The original valid_mode CHECK (mode <= 4095 / 0o7777) only admitted POSIX
+-- permission bits, so a SET_INFO FILE_BASIC_INFORMATION that sets any DOS
+-- attribute produced a mode such as 0x101A4 and tripped the constraint
+-- (SQLSTATE 23514). mapPgError surfaces that as ErrInvalidArgument, which the
+-- SMB layer maps to STATUS_INVALID_PARAMETER — the 4 WPTS BVT ChangeNotify
+-- tests fail on postgres while passing on the memory/badger backends, which
+-- store the full uint32 mode without any range check (#882).
+--
+-- The mode column is INTEGER (signed 31-bit positive range); the DOS bits top
+-- out around 0x3F0FFF, well within it. Keep only the non-negative lower bound
+-- so the postgres backend matches the memory/badger fidelity for the full mode
+-- value DittoFS uses.
+
+ALTER TABLE files DROP CONSTRAINT IF EXISTS valid_mode;
+ALTER TABLE files ADD CONSTRAINT valid_mode CHECK (mode >= 0);

--- a/pkg/metadata/store/postgres/migrations/000023_file_timestamps_nanos.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000023_file_timestamps_nanos.down.sql
@@ -1,0 +1,25 @@
+-- Revert file timestamp columns from BIGINT nanoseconds back to TIMESTAMPTZ.
+-- Sub-microsecond precision written while on BIGINT is truncated to microsecond
+-- on the way back, matching the original column fidelity.
+
+ALTER TABLE files
+    ALTER COLUMN atime DROP DEFAULT,
+    ALTER COLUMN mtime DROP DEFAULT,
+    ALTER COLUMN ctime DROP DEFAULT,
+    ALTER COLUMN creation_time DROP DEFAULT;
+
+ALTER TABLE files
+    ALTER COLUMN atime TYPE TIMESTAMPTZ
+        USING to_timestamp(atime / 1000000000.0),
+    ALTER COLUMN mtime TYPE TIMESTAMPTZ
+        USING to_timestamp(mtime / 1000000000.0),
+    ALTER COLUMN ctime TYPE TIMESTAMPTZ
+        USING to_timestamp(ctime / 1000000000.0),
+    ALTER COLUMN creation_time TYPE TIMESTAMPTZ
+        USING to_timestamp(creation_time / 1000000000.0);
+
+ALTER TABLE files
+    ALTER COLUMN atime SET DEFAULT NOW(),
+    ALTER COLUMN mtime SET DEFAULT NOW(),
+    ALTER COLUMN ctime SET DEFAULT NOW(),
+    ALTER COLUMN creation_time SET DEFAULT NOW();

--- a/pkg/metadata/store/postgres/migrations/000023_file_timestamps_nanos.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000023_file_timestamps_nanos.up.sql
@@ -1,0 +1,41 @@
+-- Store file timestamps as BIGINT nanoseconds for lossless FILETIME parity.
+--
+-- TIMESTAMPTZ stores at most microsecond precision, but SMB FILETIME (and the
+-- memory/badger backends) carry 100-nanosecond granularity. Setting a sub-
+-- microsecond timestamp via SET_INFO then re-querying it returned a truncated
+-- value on postgres only, failing WPTS BVT_SMB2Basic_QueryAndSet_FileInfo
+-- (the FILETIME assert) while passing on memory/badger which keep full
+-- nanosecond fidelity (#882).
+--
+-- Convert the four files timestamp columns to BIGINT holding unix nanoseconds.
+-- Existing rows are already microsecond-truncated, so the EXTRACT conversion is
+-- lossless for them; new writes store the full nanosecond value via the Go
+-- layer (timeToPGNanos / pgNanosToTime). A NULL/zero time.Time maps to 0
+-- nanoseconds, matching the zero-value semantics the scan path reconstructs.
+--
+-- Range: int64 nanoseconds covers years 1678..2262 (time.Time.UnixNano range).
+-- FILETIME values outside that range are already clamped to the zero time by
+-- internal/adapter/smb/types.FiletimeToTime, so no SMB-reachable value
+-- overflows.
+
+ALTER TABLE files
+    ALTER COLUMN atime DROP DEFAULT,
+    ALTER COLUMN mtime DROP DEFAULT,
+    ALTER COLUMN ctime DROP DEFAULT,
+    ALTER COLUMN creation_time DROP DEFAULT;
+
+ALTER TABLE files
+    ALTER COLUMN atime TYPE BIGINT
+        USING (EXTRACT(EPOCH FROM atime) * 1000000000)::BIGINT,
+    ALTER COLUMN mtime TYPE BIGINT
+        USING (EXTRACT(EPOCH FROM mtime) * 1000000000)::BIGINT,
+    ALTER COLUMN ctime TYPE BIGINT
+        USING (EXTRACT(EPOCH FROM ctime) * 1000000000)::BIGINT,
+    ALTER COLUMN creation_time TYPE BIGINT
+        USING (EXTRACT(EPOCH FROM creation_time) * 1000000000)::BIGINT;
+
+ALTER TABLE files
+    ALTER COLUMN atime SET DEFAULT 0,
+    ALTER COLUMN mtime SET DEFAULT 0,
+    ALTER COLUMN ctime SET DEFAULT 0,
+    ALTER COLUMN creation_time SET DEFAULT 0;

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -311,7 +311,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 				int32(existingRoot.Mode),
 				int32(existingRoot.UID),
 				int32(existingRoot.GID),
-				now,
+				timeToPGNanos(now),
 				existingRoot.ID,
 			)
 			if err != nil {
@@ -366,10 +366,10 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		now,                               // atime
-		now,                               // mtime
-		now,                               // ctime
-		now,                               // creation_time
+		timeToPGNanos(now),                // atime
+		timeToPGNanos(now),                // mtime
+		timeToPGNanos(now),                // ctime
+		timeToPGNanos(now),                // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)
@@ -451,10 +451,10 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		uid          int32
 		gid          int32
 		size         int64
-		atime        time.Time
-		mtime        time.Time
-		ctime        time.Time
-		creationTime time.Time
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
 		hidden       bool
 	)
 
@@ -489,10 +489,10 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        atime,
-			Mtime:        mtime,
-			Ctime:        ctime,
-			CreationTime: creationTime,
+			Atime:        pgNanosToTime(atime),
+			Mtime:        pgNanosToTime(mtime),
+			Ctime:        pgNanosToTime(ctime),
+			CreationTime: pgNanosToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}, nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -270,7 +270,8 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// Try UPDATE first (most common case for existing files)
 	result, err := tx.tx.Exec(ctx, updateQuery,
 		file.Type, file.Mode, file.UID, file.GID, file.Size,
-		file.Atime, file.Mtime, file.Ctime, file.CreationTime,
+		timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
+		timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
 		payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 		file.Hidden, aclJSON, objectIDArg,
 		file.ID, file.ShareName,
@@ -303,7 +304,8 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		_, err = tx.tx.Exec(ctx, insertQuery,
 			file.ID, file.ShareName, file.Path,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			file.Atime, file.Mtime, file.Ctime, file.CreationTime,
+			timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
+			timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
 			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 			file.Hidden, aclJSON, objectIDArg,
 		)
@@ -525,7 +527,7 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 		var fileType int16
 		var mode, uid, gid int32
 		var size int64
-		var atime, mtime, ctime, creationTime time.Time
+		var atime, mtime, ctime, creationTime int64
 		var hidden bool
 		var aclJSON []byte
 		var objectIDRaw []byte
@@ -564,10 +566,10 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        atime,
-			Mtime:        mtime,
-			Ctime:        ctime,
-			CreationTime: creationTime,
+			Atime:        pgNanosToTime(atime),
+			Mtime:        pgNanosToTime(mtime),
+			Ctime:        pgNanosToTime(ctime),
+			CreationTime: pgNanosToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {
@@ -978,10 +980,10 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		existingUID  int32
 		existingGID  int32
 		size         int64
-		atime        time.Time
-		mtime        time.Time
-		ctime        time.Time
-		creationTime time.Time
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
 		hidden       bool
 		linkCount    sql.NullInt32
 	)
@@ -1013,10 +1015,10 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 				UID:          uint32(existingUID),
 				GID:          uint32(existingGID),
 				Size:         uint64(size),
-				Atime:        atime,
-				Mtime:        mtime,
-				Ctime:        ctime,
-				CreationTime: creationTime,
+				Atime:        pgNanosToTime(atime),
+				Mtime:        pgNanosToTime(mtime),
+				Ctime:        pgNanosToTime(ctime),
+				CreationTime: pgNanosToTime(creationTime),
 				Hidden:       hidden,
 			},
 		}, nil
@@ -1052,10 +1054,10 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		now,                               // atime
-		now,                               // mtime
-		now,                               // ctime
-		now,                               // creation_time
+		timeToPGNanos(now),                // atime
+		timeToPGNanos(now),                // mtime
+		timeToPGNanos(now),                // ctime
+		timeToPGNanos(now),                // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -16,6 +17,94 @@ func runFileOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("Rename", func(t *testing.T) { testRename(t, factory) })
 	t.Run("GetFileNotFound", func(t *testing.T) { testGetFileNotFound(t, factory) })
 	t.Run("GetChildNotFound", func(t *testing.T) { testGetChildNotFound(t, factory) })
+	t.Run("TimestampPrecision", func(t *testing.T) { testTimestampPrecision(t, factory) })
+	t.Run("HighModeBits", func(t *testing.T) { testHighModeBits(t, factory) })
+}
+
+// testTimestampPrecision verifies file timestamps round-trip with full
+// nanosecond (sub-microsecond) fidelity through PutFile/GetFile on every
+// backend. SMB FILETIME carries 100ns granularity; a backend that truncates to
+// microseconds (the postgres TIMESTAMPTZ default) returns a different FILETIME
+// on QUERY than was set, failing WPTS BVT_SMB2Basic_QueryAndSet_FileInfo
+// while memory/badger pass (#882). This is the deterministic CI replacement for
+// that WPTS assertion's precision class (#869).
+func testTimestampPrecision(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	handle := createTestFile(t, store, "/test", rootHandle, "ts.txt", 0644)
+	ctx := t.Context()
+
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+
+	// 100ns-granular, sub-microsecond components (123456700ns has a 700ns
+	// remainder a microsecond column would truncate). Use UTC so the
+	// comparison is location-independent.
+	mtime := time.Unix(1700000000, 123456700).UTC()
+	atime := time.Unix(1699999999, 987654300).UTC()
+	ctime := time.Unix(1700000001, 100).UTC()
+	creation := time.Unix(1699999998, 999999900).UTC()
+
+	file.Mtime = mtime
+	file.Atime = atime
+	file.Ctime = ctime
+	file.CreationTime = creation
+
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() failed: %v", err)
+	}
+
+	got, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() after put failed: %v", err)
+	}
+
+	check := func(name string, want, have time.Time) {
+		if !have.Equal(want) {
+			t.Errorf("%s = %d ns, want %d ns (delta %d ns) — backend truncates sub-microsecond precision",
+				name, have.UnixNano(), want.UnixNano(), want.UnixNano()-have.UnixNano())
+		}
+	}
+	check("Mtime", mtime, got.Mtime)
+	check("Atime", atime, got.Atime)
+	check("Ctime", ctime, got.Ctime)
+	check("CreationTime", creation, got.CreationTime)
+}
+
+// testHighModeBits verifies a file mode carrying high bits above the POSIX
+// permission range round-trips through PutFile/GetFile on every backend. The
+// SMB adapter stores DOS attributes (e.g. modeDOSExplicit = 0x10000) in high
+// mode bits; a backend that range-checks mode to <= 0o7777 rejects a SET_INFO
+// FILE_BASIC_INFORMATION with attributes as STATUS_INVALID_PARAMETER, failing
+// the WPTS BVT ChangeNotify tests on postgres while memory/badger pass (#882).
+func testHighModeBits(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	handle := createTestFile(t, store, "/test", rootHandle, "mode.txt", 0644)
+	ctx := t.Context()
+
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+
+	// 0x10000 | 0o644: modeDOSExplicit set plus POSIX rw-r--r--, the shape
+	// SMBModeFromAttrs produces for a SET_INFO with FileAttributes.
+	const highMode = uint32(0x10000 | 0o644)
+	file.Mode = highMode
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() with high mode bits 0x%X failed: %v", highMode, err)
+	}
+
+	got, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() after put failed: %v", err)
+	}
+	if got.Mode != highMode {
+		t.Errorf("Mode = 0x%X, want 0x%X — backend dropped high mode bits", got.Mode, highMode)
+	}
 }
 
 // testCreateFile verifies that creating a file results in a retrievable entry with correct attributes.


### PR DESCRIPTION
Fixes #882 — 5 WPTS BVT tests fail on the **postgres** metadata backend while passing on memory/badger. Two distinct root causes, both reproduced locally against the live pg container before fixing.

## Root cause 1 (4 tests) — `STATUS_INVALID_PARAMETER` on SET_INFO

`BVT_SMB2Basic_ChangeNotify_{ChangeAttributes,ChangeLastWrite,ChangeCreation,ChangeLastAccess}`

Each does SET_INFO `FILE_BASIC_INFORMATION`. When FileAttributes are set, `SMBModeFromAttrs` encodes DOS attributes (`modeDOSExplicit = 0x10000`, ARCHIVE/SYSTEM/READONLY/COMPRESSED/SPARSE) in **high mode bits**, producing a mode like `0x101A4`. The `files.valid_mode` CHECK admitted only POSIX bits (`mode <= 0o7777`), so `PutFile` failed with SQLSTATE **23514** → `mapPgError` → `ErrInvalidArgument` → `STATUS_INVALID_PARAMETER`. Memory/badger store the full `uint32` mode without any range check, hence the divergence.

Reproduced: `PutFile` with mode `0x101A4` → `InvalidArgument: PutFile: invalid value`.

**Fix:** migration `000022` widens the CHECK to `mode >= 0`.

## Root cause 2 (1 test) — FILETIME round-trip mismatch

`BVT_SMB2Basic_QueryAndSet_FileInfo`

`TIMESTAMPTZ` is microsecond-precision; SMB FILETIME (and memory/badger) carry 100ns granularity. A sub-µs SET then QUERY returned a truncated FILETIME → assert fail.

Reproduced: setting `…123456700` ns read back as `…123456000` (700ns lost), on postgres only.

**Fix:** migration `000023` converts the four `files` timestamp columns to **BIGINT unix nanoseconds** (lossless; existing µs data converts exactly via `numeric` EXTRACT). Go encode/decode is centralized in `timeToPGNanos`/`pgNanosToTime`. Memory/badger keep their nanosecond fidelity unchanged. `runtime/init.go` postgres `TimestampResolution: time.Nanosecond` is now accurate (commented).

## Tests (deterministic CI coverage for the class, per #869)

New cross-backend conformance subtests in `pkg/metadata/storetest/file_ops.go`:
- `TimestampPrecision` — 100ns sub-µs round-trip on all four file timestamps.
- `HighModeBits` — `0x10000 | 0o644` mode round-trip.

Verified: both **FAIL on postgres at schema v21 (pre-fix)** — TimestampPrecision shows 100–900ns deltas, HighModeBits shows `invalid value` — and **PASS on memory + badger + postgres after**. Full postgres conformance incl. backup + reset-then-restore (BIGINT CSV round-trip) is green.

## WPTS verification

`WPTS BVT / postgres-s3` run: https://github.com/marmos91/dittofs/actions/runs/26715936057 (in progress — will confirm all 5 tests green and `badger-s3` no-regression before merge).