### PR TITLE
fix(metadata/badger): make Close idempotent (Copilot follow-up to #896)

### DIFF
--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -67,6 +67,12 @@ type BadgerMetadataStore struct {
 	gcStopOnce sync.Once
 	gcWG       sync.WaitGroup
 
+	// closeOnce makes the whole Close() idempotent: GC is stopped+waited
+	// and the underlying DB is closed exactly once. Second and later calls
+	// are a safe no-op returning the first call's result (closeErr).
+	closeOnce sync.Once
+	closeErr  error
+
 	// capabilities stores static filesystem capabilities and limits.
 	// These are set at creation time and define what the filesystem supports.
 	capabilities metadata.FilesystemCapabilities
@@ -541,22 +547,30 @@ func (s *BadgerMetadataStore) initializeSingletons(ctx context.Context) error {
 // The close operation waits for all pending transactions to complete and
 // flushes all data to disk.
 //
+// Close is idempotent: the GC goroutine is stopped and waited, and the
+// underlying BadgerDB is closed, exactly once. A second (or later) call is a
+// safe no-op that returns the first call's result without touching the DB
+// again — badger's db.Close() is not safe to call twice.
+//
 // Returns:
-//   - error: Error if closing the database fails
+//   - error: Error if closing the database fails (on the first call)
 func (s *BadgerMetadataStore) Close() error {
-	// Stop the value-log GC goroutine and wait for it to drain before
-	// closing the DB, so no GC pass runs against a closed database.
-	// gcStopOnce makes Close idempotent.
-	s.gcStopOnce.Do(func() {
-		close(s.gcStop)
+	s.closeOnce.Do(func() {
+		// Stop the value-log GC goroutine and wait for it to drain before
+		// closing the DB, so no GC pass runs against a closed database.
+		// gcStopOnce guards the channel close in case the GC stop is ever
+		// signalled from another path.
+		s.gcStopOnce.Do(func() {
+			close(s.gcStop)
+		})
+		s.gcWG.Wait()
+
+		if err := s.db.Close(); err != nil {
+			s.closeErr = fmt.Errorf("failed to close BadgerDB: %w", err)
+		}
 	})
-	s.gcWG.Wait()
 
-	if err := s.db.Close(); err != nil {
-		return fmt.Errorf("failed to close BadgerDB: %w", err)
-	}
-
-	return nil
+	return s.closeErr
 }
 
 // GetStoreID returns the Badger-persistent store identifier (stored at key

--- a/pkg/metadata/store/badger/valuelog_gc_test.go
+++ b/pkg/metadata/store/badger/valuelog_gc_test.go
@@ -38,4 +38,21 @@ func TestValueLogGC_CloseDoesNotHang(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Close did not return promptly — GC goroutine likely leaked or Close blocked")
 	}
+
+	// Close is idempotent: a second Close must be a safe no-op — return nil
+	// promptly without erroring, hanging, or panicking (badger's db.Close()
+	// is not safe to call twice, so the second call must not reach it).
+	done2 := make(chan error, 1)
+	go func() {
+		done2 <- store.Close()
+	}()
+
+	select {
+	case err := <-done2:
+		if err != nil {
+			t.Fatalf("second Close returned error, want nil: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("second Close did not return promptly — not a safe no-op")
+	}
 }


### PR DESCRIPTION
## Finding (Copilot, on merged #896)

`BadgerMetadataStore.Close()` was not truly idempotent. #896 added `gcStopOnce` so the GC stop-channel is closed only once, but `s.db.Close()` still ran on **every** `Close()` call. badger's `db.Close()` is not safe to call twice — a second `Close()` returned an error / behaved unexpectedly. The method doc and the GC test claimed "a second Close must be a safe no-op", but the test never actually called Close twice and the code didn't honor it.

## Fix

- Wrap the whole `Close()` body in a `sync.Once` (`closeOnce`), caching the first call's result in `closeErr`. First call is unchanged: stop GC, wait WG, close DB, wrap error. Second and later calls return `closeErr` immediately — no second `db.Close()`, no double channel close. `gcStopOnce` retained as belt-and-suspenders.
- Updated the `Close()` doc to state the idempotency contract.

## Test

- `TestValueLogGC_CloseDoesNotHang` now calls `Close()` **twice** and asserts the second returns nil promptly (no error, no hang, no panic), enforcing the "safe no-op" claim. Existing "Close doesn't hang" coverage kept.

`go test -race -tags=integration ./pkg/metadata/store/badger/...` green. gofmt/vet/golangci-lint clean.

Scope: `pkg/metadata/store/badger/` only.