### PR TITLE
fix(smb): set NTLMSSP_NEGOTIATE_128/56 in NTLM challenge for Linux CIFS client

### DIFF
--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -352,11 +352,17 @@ func BuildChallenge() (message []byte, serverChallenge [8]byte) {
 	targetName := encodeUTF16LE(strings.ToUpper(hostname))
 
 	// Flags for server capabilities.
-	// Note: Flag128, Flag56, and FlagSeal are intentionally NOT set.
-	// NTLM-level sealing (RC4) will not be implemented — SMB3 AES
-	// transport encryption is the only confidentiality path.
-	// If a client requests FlagSeal in Type 1, we silently omit it
-	// from Type 2; the client falls back to SMB3 transport encryption.
+	//
+	// Flag128/Flag56 advertise the key strength of the negotiated session key.
+	// They are mandatory for native clients: the Linux kernel CIFS client
+	// refuses a CHALLENGE that lacks NTLMSSP_NEGOTIATE_128 and aborts the mount
+	// with EINVAL, and Windows/Samba always set both. They describe key
+	// strength only — they do not require NTLM-level RC4 sealing.
+	//
+	// FlagSeal is intentionally NOT set: NTLM-level sealing (RC4 over message
+	// data) is not implemented; SMB3 AES transport encryption is the only
+	// confidentiality path. If a client requests FlagSeal in Type 1, we omit
+	// it from Type 2 and the client falls back to SMB3 transport encryption.
 	flags := FlagUnicode | // Support UTF-16LE strings
 		FlagRequestTarget | // We can provide target info
 		FlagNTLM | // Support NTLM authentication
@@ -365,6 +371,8 @@ func BuildChallenge() (message []byte, serverChallenge [8]byte) {
 		FlagTargetTypeServer | // We are a server (not domain controller)
 		FlagExtendedSecurity | // Support NTLMv2 session security
 		FlagTargetInfo | // Include AV_PAIR list
+		Flag128 | // 128-bit session key strength (required by Linux CIFS client)
+		Flag56 | // 56-bit session key strength (set alongside 128 like Windows/Samba)
 		FlagKeyExch // Support session key exchange (required for signing)
 
 	// Build target info with required AV_PAIRs for Windows compatibility.

--- a/internal/adapter/smb/auth/ntlm_test.go
+++ b/internal/adapter/smb/auth/ntlm_test.go
@@ -204,6 +204,11 @@ func TestBuildChallenge(t *testing.T) {
 			{FlagExtendedSecurity, "ExtendedSecurity"},
 			{FlagTargetInfo, "TargetInfo"},
 			{FlagKeyExch, "KeyExch"},
+			// Key-strength flags. The Linux kernel CIFS client refuses a
+			// CHALLENGE lacking NTLMSSP_NEGOTIATE_128 and aborts the mount
+			// with EINVAL; Windows and Samba always set both.
+			{Flag128, "128-bit"},
+			{Flag56, "56-bit"},
 		}
 
 		for _, ef := range expectedFlags {
@@ -213,25 +218,15 @@ func TestBuildChallenge(t *testing.T) {
 		}
 	})
 
-	t.Run("DoesNotAdvertiseEncryptionFlags", func(t *testing.T) {
+	t.Run("DoesNotAdvertiseSealFlag", func(t *testing.T) {
 		flags := binary.LittleEndian.Uint32(msg[20:24])
 
-		// NTLM-level sealing (RC4) is not implemented.
-		// SMB3 AES transport encryption is the confidentiality path.
-		// These flags MUST NOT be advertised to avoid capability mismatch.
-		absentFlags := []struct {
-			flag NegotiateFlag
-			name string
-		}{
-			{FlagSeal, "Seal"},
-			{Flag128, "128-bit"},
-			{Flag56, "56-bit"},
-		}
-
-		for _, af := range absentFlags {
-			if flags&uint32(af.flag) != 0 {
-				t.Errorf("Flag %s (0x%x) MUST NOT be set — NTLM encryption not implemented", af.name, af.flag)
-			}
+		// NTLM-level sealing (RC4 over message data) is not implemented.
+		// SMB3 AES transport encryption is the confidentiality path, so
+		// FlagSeal MUST NOT be advertised. Flag128/Flag56 are key-strength
+		// indicators (asserted present above) and are unrelated to sealing.
+		if flags&uint32(FlagSeal) != 0 {
+			t.Errorf("Flag Seal (0x%x) MUST NOT be set — NTLM sealing not implemented", FlagSeal)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Native Linux `mount.cifs` could never mount a DittoFS SMB share — it failed with `mount error(22): Invalid argument`. macOS `mount_smbfs` worked against the same server. Fixes #878.

## Root cause (byte-level pcap diff vs Samba)

The failure is **not** at NEGOTIATE — NEGOTIATE and the first SESSION_SETUP leg complete fine. The Linux kernel CIFS client aborts (FIN) immediately after receiving the server's `NTLMSSP_CHALLENGE`, before sending the AUTHENTICATE message.

`tshark` diff of the `NTLMSSP_CHALLENGE` NegotiateFlags, same Linux mount.cifs client against both servers:

| Server | Challenge NegotiateFlags | NEGOTIATE_128 | NEGOTIATE_56 | mount |
|--------|--------------------------|---------------|--------------|-------|
| Samba (`dperson/samba`) | `0xe28a8235` | set | set | rc=0 |
| DittoFS (before) | `0x408a8215` | **absent** | **absent** | `mount error(22)` |
| DittoFS (after) | `0xe08a8215` | set | set | rc=0 |

The Linux kernel CIFS client refuses a CHALLENGE that lacks `NTLMSSP_NEGOTIATE_128` and aborts the mount with EINVAL. `BuildChallenge` in `internal/adapter/smb/auth/ntlm.go` omitted `Flag128`/`Flag56`, conflating the **key-strength** advertisement (128/56-bit session key) with NTLM **RC4 sealing** (`FlagSeal`). They are independent: Windows and Samba always set 128/56 while not requiring NTLM sealing.

## Fix

Set `Flag128` and `Flag56` in the NTLM CHALLENGE (key strength only). `FlagSeal` stays unset — NTLM-level RC4 sealing is still not implemented; SMB3 AES transport encryption remains the only confidentiality path. The NTLMv2 session key was already 128-bit, and the KEY_EXCH/RC4-of-session-key path is unaffected.

## Verification

- Local repro confirmed `mount error(22)` at vers=2.1, then `rc=0` + full create/read/mkdir/list/rename/delete/umount after the fix (mount.cifs from a Linux docker container against the host's DittoFS on 12445).
- Confirming pcap shows challenge flags `0x408a8215` → `0xe08a8215`.
- Unit tests: `TestBuildChallenge` updated to assert 128/56 present and Seal absent; full `./internal/adapter/smb/...` suite green.
- macOS `mount_smbfs` unaffected (key-strength flags are standard; macOS already mounted).
- Linux smb-client-compat dispatch: https://github.com/marmos91/dittofs/actions/runs/26717843007

Note: vers=3.1.1 from Linux still returns `error(95)` only because the CI/e2e setup caps the server at `--max-dialect SMB2.1`; that is expected and separate from #879 (Windows).