### PR TITLE
fix(smb/dh2): scope same-client lease-cap bypass to lease holders (#739)

### DIFF
--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine.go
@@ -482,7 +482,15 @@ func (h *Handler) disallowWriteLeaseForFile(
 		if existing.FileID == excludeFileID {
 			return true
 		}
-		if excludeClientGUID != ([16]byte{}) && existing.ClientGUID == excludeClientGUID {
+		// Mirror Samba is_same_lease: only LEASE_OPLOCK entries are same-client
+		// bypassed. A NO_OPLOCK same-client open (e.g. a non-stat handle) still
+		// disallows W — this is what nonstat-and-lease requires. Bypassing it would
+		// wrongly grant RWH instead of RH. (upgrade2/upgrade3/break holders are
+		// leases, so they remain bypassed and do not regress.)
+		isSameClientLease := excludeClientGUID != ([16]byte{}) &&
+			existing.ClientGUID == excludeClientGUID &&
+			existing.OplockLevel == OplockLevelLease
+		if isSameClientLease {
 			return true
 		}
 		// e contributes when it holds an oplock/lease OR is a non-stat open.

--- a/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/v2/handlers/disconnected_state_machine_test.go
@@ -889,6 +889,29 @@ func TestDisallowWriteLeaseForFile(t *testing.T) {
 		}
 	})
 
+	// nonstat-and-lease (#739): a same-client NO_OPLOCK non-stat open (the h1
+	// handle: READ_CONTROL-style access, no lease) must STILL disallow W, even
+	// though it shares the requestor's ClientGuid. Samba is_same_lease bypasses
+	// only LEASE_OPLOCK entries; a NO_OPLOCK entry is never same-client bypassed.
+	// Bypassing it would wrongly grant the h2 lease RWH instead of RH.
+	t.Run("same-client NO_OPLOCK non-stat open disallows W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x07}, metaHandle, accessReadCtl, [16]byte{}, OplockLevelNone, false, selfClientGUID)
+		if !h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID, selfClientGUID) {
+			t.Fatal("expected disallow=true for a same-client NO_OPLOCK non-stat open (nonstat-and-lease)")
+		}
+	})
+
+	// Contrast / regression guard: the same-client open holding a LEASE is still
+	// bypassed (is_same_lease) — this preserves smb2.lease.upgrade2/upgrade3/break.
+	t.Run("same-client LEASE open on a different key does not disallow W", func(t *testing.T) {
+		h := &Handler{}
+		addOpen(h, [16]byte{0x08}, metaHandle, accessReadData, [16]byte{0xDC}, OplockLevelLease, false, selfClientGUID)
+		if h.disallowWriteLeaseForFile(context.Background(), metaHandle, selfKey, selfFileID, selfClientGUID) {
+			t.Fatal("expected disallow=false for a same-client LEASE open (still is_same_lease bypassed)")
+		}
+	})
+
 	t.Run("same-client disconnected handle on a different key does not disallow W", func(t *testing.T) {
 		store := newMockDurableStore()
 		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{


### PR DESCRIPTION
## Summary

Fixes the `smb2.durable-v2-open.nonstat-and-lease` conformance failure (#739).

The test opens two handles on the same tree (same ClientGuid):
- **h1** — a non-stat handle (READ_CONTROL-style access, `OplockLevel=None`, no lease)
- **h2** — a durable RWH lease

Expected: h1 disallows the write-cap, so h2 is granted **RH** (W stripped). DittoFS was granting **RWH**.

## Root cause

`disallowWriteLeaseForFile` (`internal/adapter/smb/v2/handlers/disconnected_state_machine.go`) had an over-broad same-client guard in the live-opens scan:

```go
if excludeClientGUID != ([16]byte{}) && existing.ClientGUID == excludeClientGUID {
    return true // skip — never contributes
}
```

This skipped **any** open owned by the same ClientGuid, including NO_OPLOCK (non-lease) opens. h1 was therefore skipped, W was never stripped, and h2 got RWH.

## The fix

Root-caused against Samba `source3/smbd/open.c`: the `disallow_write_lease` accumulator bypasses an existing share-mode entry only when `is_same_lease()` is true, and `is_same_lease()` returns false for any entry with `op_type != LEASE_OPLOCK`. A NO_OPLOCK entry is never bypassed by same-client identity.

The guard is narrowed to fire only for lease-holding opens:

```go
isSameClientLease := excludeClientGUID != ([16]byte{}) &&
    existing.ClientGUID == excludeClientGUID &&
    existing.OplockLevel == OplockLevelLease
if isSameClientLease {
    return true
}
```

The same-lease-key and same-FileID guards immediately above are unchanged. The disconnected-durable-handle path (section 2) is unchanged: durable handles are leases by definition and only contend when `LeaseState & smbLeaseRead != 0`, so its same-client bypass is already effectively lease-scoped.

## Regression reasoning

The same-client bypass was added to protect `smb2.lease.upgrade2` / `upgrade3` / `break` (a prior coarse attempt regressed exactly these). In those tests the same-client holder is a **lease** (`OplockLevel == OplockLevelLease`), so it remains bypassed by the narrowed guard — no regression. A new contrast unit test pins this.

## Tests

Added to `TestDisallowWriteLeaseForFile`:
- `same-client NO_OPLOCK non-stat open disallows W` → returns **true** (the #739 shape)
- `same-client LEASE open on a different key does not disallow W` → returns **false** (regression guard for lease.upgrade*/break)

`go test ./internal/adapter/smb/v2/handlers/...`, `go vet`, and `golangci-lint` are clean.

Target test: `smb2.durable-v2-open.nonstat-and-lease`. Refs #739.
