### PR TITLE
fix(nfs): enter grace on unclean restart via durable clean-shutdown marker (area-4 H7)

### DIFF
--- a/pkg/metadata/grace_registration_test.go
+++ b/pkg/metadata/grace_registration_test.go
@@ -50,11 +50,16 @@ func TestRegisterStoreForShare_EntersGraceWhenPersistedLocksExist(t *testing.T) 
 		"the expected reclaim roster must be the persisted clients")
 }
 
-// TestRegisterStoreForShare_NoGraceWhenNoPersistedLocks asserts a fresh server
-// with no persisted locks starts in normal operation (no grace).
-func TestRegisterStoreForShare_NoGraceWhenNoPersistedLocks(t *testing.T) {
+// TestRegisterStoreForShare_NoGraceAfterCleanDrain asserts the fast path: a
+// store whose previous run recorded a clean shutdown (clean marker == true) and
+// has NO persisted locks starts in normal operation (no grace). This is the
+// only path that skips grace under the H7 predicate (unclean OR locks>0).
+func TestRegisterStoreForShare_NoGraceAfterCleanDrain(t *testing.T) {
 	const shareName = "/fresh"
 	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	// Simulate a previous graceful Close(): the clean-shutdown marker is set.
+	require.NoError(t, store.SetCleanShutdown(context.Background(), true))
 
 	svc := metadata.New()
 	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
@@ -62,7 +67,72 @@ func TestRegisterStoreForShare_NoGraceWhenNoPersistedLocks(t *testing.T) {
 	lm := svc.GetLockManagerForShare(shareName)
 	require.NotNil(t, lm)
 	require.False(t, lm.IsInGracePeriod(),
-		"a fresh server with no persisted locks must NOT enter grace")
+		"a cleanly-drained server with no persisted locks must NOT enter grace")
+
+	// And the boot path must have cleared the marker for the running session,
+	// so a kill -9 now (before the next graceful Close) is read as unclean next
+	// boot.
+	clean, err := store.GetCleanShutdown(context.Background())
+	require.NoError(t, err)
+	require.False(t, clean,
+		"boot must clear the clean-shutdown marker so an in-session crash is detected next boot")
+}
+
+// TestRegisterStoreForShare_EntersGraceOnUncleanRestartEmptyLockSet is the core
+// area-4 H7 regression test. After a kill -9 / crash the clean-shutdown marker
+// is false (or absent — a fresh store defaults to unclean). The server may have
+// orphaned client state that never made it into the persisted byte-range locks
+// (e.g. a client holding only NFSv4 opens, or a best-effort persist that never
+// landed). Grace MUST be entered on the FACT of an unclean restart even though
+// the recovered lock set is EMPTY — otherwise a conflicting new lock is granted
+// before the prior owner can reclaim.
+//
+// Before the predicate change (enter grace iff locks>0) this asserted false:
+// the empty lock set skipped grace. After the change (unclean OR locks>0) it
+// must enter grace with an empty expected-reclaim roster.
+func TestRegisterStoreForShare_EntersGraceOnUncleanRestartEmptyLockSet(t *testing.T) {
+	const shareName = "/crashed"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	// Fresh store: clean-shutdown marker is absent -> reported false (unclean).
+	// No locks persisted -> empty recovered set.
+	clean, err := store.GetCleanShutdown(context.Background())
+	require.NoError(t, err)
+	require.False(t, clean, "precondition: unclean marker (kill -9 / crash / fresh)")
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod(),
+		"an unclean restart must enter grace even with an EMPTY recovered lock set (H7)")
+	require.Empty(t, lm.GetExpectedClients(),
+		"the expected reclaim roster is empty on an unclean restart with no recovered locks")
+}
+
+// TestRegisterStoreForShare_GraceLiftsAfterTimeoutBackstop asserts the hard
+// timer backstop: an unclean restart with an empty lock set enters grace, but
+// grace must always lift after the configured graceDuration so an always-on
+// grace never wedges new-state creation (design §7 regression guard).
+func TestRegisterStoreForShare_GraceLiftsAfterTimeoutBackstop(t *testing.T) {
+	const shareName = "/crashed-backstop"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	svc := metadata.New()
+	// Tiny grace window so the backstop is observable without a slow test.
+	svc.SetLockGracePeriod(50 * time.Millisecond)
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod(),
+		"unclean restart must enter grace (empty lock set)")
+
+	require.Eventually(t, func() bool {
+		return !lm.IsInGracePeriod()
+	}, 2*time.Second, 5*time.Millisecond,
+		"grace must lift after the timeout backstop even with no reclaiming clients (no permanent wedge)")
 }
 
 // graceSpyCoordinator records the lock-manager grace start/end callbacks and,

--- a/pkg/metadata/lock/oplock_break_test.go
+++ b/pkg/metadata/lock/oplock_break_test.go
@@ -123,6 +123,14 @@ func (s *mockLockStore) IncrementServerEpoch(ctx context.Context) (uint64, error
 	return 2, nil
 }
 
+func (s *mockLockStore) GetCleanShutdown(_ context.Context) (bool, error) {
+	return false, nil
+}
+
+func (s *mockLockStore) SetCleanShutdown(_ context.Context, _ bool) error {
+	return nil
+}
+
 func (s *mockLockStore) ReclaimLease(_ context.Context, _ FileHandle, _ [16]byte, _ string) (*UnifiedLock, error) {
 	// Mock implementation returns not found - reclaim not supported in mock
 	return nil, nil

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -270,6 +270,30 @@ type LockStore interface {
 	IncrementServerEpoch(ctx context.Context) (uint64, error)
 
 	// ========================================================================
+	// Clean-Shutdown Marker
+	// ========================================================================
+
+	// GetCleanShutdown reports whether the previous run terminated through a
+	// fully-graceful shutdown.
+	//
+	// It returns false whenever the marker is absent or has never been written
+	// (fresh store, or a store that crashed before SetCleanShutdown(true) ran).
+	// This is the fail-safe default: an unknown shutdown state is treated as
+	// UNCLEAN so the boot path enters the lock-recovery grace period rather than
+	// risk granting a conflicting lock before a prior owner can reclaim.
+	//
+	// Called once per share on boot, before deciding whether to enter grace.
+	GetCleanShutdown(ctx context.Context) (bool, error)
+
+	// SetCleanShutdown records the clean-shutdown marker durably.
+	//
+	// The boot path sets it false immediately after reading it (so a kill -9
+	// before the next graceful Stop leaves the marker false = unclean for the
+	// following boot). A fully-graceful Close() of the store sets it true, last,
+	// after every other flush, so only a clean drain is observed as clean.
+	SetCleanShutdown(ctx context.Context, clean bool) error
+
+	// ========================================================================
 	// Lease Reclaim Operations
 	// ========================================================================
 

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -169,10 +169,16 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 		lm = s.newGraceAwareLockManager(graceDuration)
 		lm.SetLockStore(ls)
 		lm.SetShareName(shareName)
-		expectedClients := initLockManagerFromStore(lm, ls, shareName)
-		// Only enter grace if a previous run left locks to reclaim. A fresh
-		// server (no persisted locks) starts in normal operation.
-		if len(expectedClients) > 0 {
+		expectedClients, enterGrace := initLockManagerFromStore(lm, ls, shareName)
+		// Enter grace whenever the prior run MAY have left orphaned client state:
+		// either the previous shutdown was not verified-clean (kill -9 / crash /
+		// power-loss → unclean marker) OR persisted locks were recovered. A
+		// genuinely fresh / cleanly-drained store with no locks skips grace and
+		// starts in normal operation (the fast path). expectedClients may be
+		// empty on an unclean restart with no recovered locks — that is correct:
+		// grace still arms its hard timer backstop and lifts after graceDuration,
+		// never wedging new-state creation.
+		if enterGrace {
 			lm.EnterGracePeriod(expectedClients)
 			if graceCoordinator != nil {
 				graceCoordinator.OnLockGraceStart(expectedClients)
@@ -251,11 +257,45 @@ func (s *MetadataService) RemoveStoreForShare(shareName string) {
 // of the gap. Moving IncrementServerEpoch under s.mu would serialize backend IO
 // inside the service lock for no correctness gain, so the increment stays here.
 //
-// It returns the unique set of client IDs recovered from the persisted locks.
-// The caller uses this set as the grace period's expected-reclaim roster: grace
-// is entered only when it is non-empty (a previous run left locks to reclaim).
-func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName string) []string {
+// It returns the unique set of client IDs recovered from the persisted locks
+// (the grace period's expected-reclaim roster) and a boolean reporting whether
+// grace should be entered for this share.
+//
+// Grace-entry decision (area-4 H7): grace is entered when the previous run MAY
+// have orphaned client state — i.e. the prior shutdown was NOT verified-clean
+// (unclean marker: kill -9 / crash / power-loss, or a fresh store whose marker
+// defaults to false) OR persisted locks were recovered. This replaces the old
+// "enter grace only if persisted locks exist" predicate, which silently skipped
+// grace after a crash that left no recoverable byte-range lock (e.g. a client
+// holding only NFSv4 opens, or a best-effort persist that never landed),
+// letting a conflicting new lock be granted before the prior owner reclaimed.
+//
+// The clean-shutdown marker is read first to make the decision, then
+// immediately set FALSE for the running session: if this process is killed
+// without a graceful Close() (which is the only writer of true), the NEXT boot
+// reads false and conservatively enters grace. The flag is set false as early
+// as possible — before any traffic can be served — so the crash window in which
+// a kill would be misread as clean is effectively zero.
+func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName string) (clients []string, enterGrace bool) {
 	ctx := context.Background()
+
+	// Read the clean-shutdown marker, then immediately clear it for this run.
+	// A read error is treated as unclean (fail-safe): we would rather impose a
+	// grace window than risk granting a stealing lock.
+	clean, err := ls.GetCleanShutdown(ctx)
+	if err != nil {
+		logger.Error("lock recovery: failed to read clean-shutdown marker (treating as unclean)",
+			"share", shareName, "error", err)
+		clean = false
+	}
+	unclean := !clean
+	if err := ls.SetCleanShutdown(ctx, false); err != nil {
+		// Could not arm the unclean marker for this session. Logged but not
+		// fatal: durability of the marker is best-effort, mirroring the lock
+		// persistence contract.
+		logger.Error("lock recovery: failed to clear clean-shutdown marker",
+			"share", shareName, "error", err)
+	}
 
 	epoch, err := ls.IncrementServerEpoch(ctx)
 	if err != nil {
@@ -267,20 +307,20 @@ func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName stri
 	persisted, err := ls.ListLocks(ctx, lock.LockQuery{ShareName: shareName})
 	if err != nil {
 		logger.Error("lock recovery: failed to list persisted locks", "share", shareName, "error", err)
-		return nil
+		// We could not enumerate locks; if the prior shutdown was unclean still
+		// enter grace (empty roster, timer backstop) rather than risk a steal.
+		return nil, unclean
 	}
-	if len(persisted) == 0 {
-		return nil
-	}
-	if err := lm.RestoreLocks(persisted); err != nil {
-		logger.Error("lock recovery: failed to restore persisted locks", "share", shareName, "error", err)
-		return nil
+	if len(persisted) > 0 {
+		if err := lm.RestoreLocks(persisted); err != nil {
+			logger.Error("lock recovery: failed to restore persisted locks", "share", shareName, "error", err)
+			return nil, unclean
+		}
 	}
 
 	// Collect the unique client IDs that held locks before the restart; these
 	// are the clients the grace period waits on for reclaim.
 	seen := make(map[string]struct{}, len(persisted))
-	clients := make([]string, 0, len(persisted))
 	for _, pl := range persisted {
 		if pl.ClientID == "" {
 			continue
@@ -292,9 +332,11 @@ func initLockManagerFromStore(lm *LockManager, ls lock.LockStore, shareName stri
 		clients = append(clients, pl.ClientID)
 	}
 
-	logger.Info("lock recovery: restored persisted locks",
-		"share", shareName, "count", len(persisted), "epoch", epoch, "clients", len(clients))
-	return clients
+	enterGrace = unclean || len(persisted) > 0
+	logger.Info("lock recovery: completed",
+		"share", shareName, "restored_locks", len(persisted), "epoch", epoch,
+		"clients", len(clients), "prior_shutdown_clean", clean, "enter_grace", enterGrace)
+	return clients, enterGrace
 }
 
 // newGraceAwareLockManager builds a lock manager whose grace period sweeps any

--- a/pkg/metadata/store/badger/badger_conformance_test.go
+++ b/pkg/metadata/store/badger/badger_conformance_test.go
@@ -80,6 +80,46 @@ func TestLockPersistenceConformance(t *testing.T) {
 	})
 }
 
+// TestBadgerStore_CleanShutdownMarkerDurable pins the area-4 H7 marker on the
+// real on-disk path: a fresh DB defaults to unclean (false); a graceful Close
+// records clean=true and that value SURVIVES a reopen (the durable property the
+// in-memory store cannot exercise); and the boot-path clear (SetCleanShutdown
+// false) is itself durable, so a process that clears-then-crashes is read as
+// unclean on the following open.
+//
+// A true kill -9 cannot be emulated in-process (Badger holds an OS directory
+// lock released only by Close or process exit), so the unclean path is verified
+// by persisting the boot-clear and then performing a graceful Close BUT reading
+// the value the boot-clear wrote BEFORE Close re-marks it — i.e. the clear is
+// durable on its own write.
+func TestBadgerStore_CleanShutdownMarkerDurable(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	// Open #1: fresh store must default to unclean. Then graceful Close records
+	// clean=true.
+	s1, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+	require.NoError(t, err)
+	clean, err := s1.GetCleanShutdown(ctx)
+	require.NoError(t, err)
+	require.False(t, clean, "fresh on-disk store must default to unclean (false)")
+	require.NoError(t, s1.Close())
+
+	// Open #2: the clean marker must have survived the close+reopen.
+	s2, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+	require.NoError(t, err)
+	clean, err = s2.GetCleanShutdown(ctx)
+	require.NoError(t, err)
+	require.True(t, clean, "graceful Close must durably record clean=true across reopen")
+	// The boot path clears the marker for the running session; that clear is a
+	// durable write (verified by reading it back within the same open).
+	require.NoError(t, s2.SetCleanShutdown(ctx, false))
+	clean, err = s2.GetCleanShutdown(ctx)
+	require.NoError(t, err)
+	require.False(t, clean, "boot-clear of the marker must be durable (read-back within session)")
+	require.NoError(t, s2.Close())
+}
+
 func TestBadgerStore_PutGetFile_BlocksRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "metadata.db")

--- a/pkg/metadata/store/badger/locks.go
+++ b/pkg/metadata/store/badger/locks.go
@@ -22,6 +22,7 @@ const (
 	prefixLockByOwner  = "lkowner:"  // Index: lkowner:{ownerID}:{lockID}
 	prefixLockByClient = "lkclient:" // Index: lkclient:{clientID}:{lockID}
 	prefixServerEpoch  = "srvepoch"  // Single key for epoch
+	keyCleanShutdown   = "srvclean"  // Single key for clean-shutdown marker
 )
 
 // badgerLockStore implements lock.LockStore using BadgerDB.
@@ -414,6 +415,46 @@ func (s *badgerLockStore) IncrementServerEpoch(ctx context.Context) (uint64, err
 	return newEpoch, err
 }
 
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+// A missing key (fresh store, or a crash before SetCleanShutdown ran) is
+// reported as false (unclean) — the fail-safe default.
+func (s *badgerLockStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	var clean bool
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get([]byte(keyCleanShutdown))
+		if err == badgerdb.ErrKeyNotFound {
+			return nil // absent -> unclean (clean stays false)
+		}
+		if err != nil {
+			return err
+		}
+		return item.Value(func(val []byte) error {
+			clean = len(val) == 1 && val[0] == 1
+			return nil
+		})
+	})
+	return clean, err
+}
+
+// SetCleanShutdown records the clean-shutdown marker durably.
+func (s *badgerLockStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return s.db.Update(func(txn *badgerdb.Txn) error {
+		val := []byte{0}
+		if clean {
+			val = []byte{1}
+		}
+		return txn.Set([]byte(keyCleanShutdown), val)
+	})
+}
+
 // ReclaimLease reclaims an existing lease during grace period.
 // Searches for a persisted lease with matching file handle and lease key.
 func (s *badgerLockStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
@@ -524,6 +565,18 @@ func (s *BadgerMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64,
 	return s.lockStore.IncrementServerEpoch(ctx)
 }
 
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+func (s *BadgerMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	s.initLockStore()
+	return s.lockStore.GetCleanShutdown(ctx)
+}
+
+// SetCleanShutdown records the clean-shutdown marker durably.
+func (s *BadgerMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	s.initLockStore()
+	return s.lockStore.SetCleanShutdown(ctx, clean)
+}
+
 // ReclaimLease reclaims an existing lease during grace period.
 func (s *BadgerMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
 	s.initLockStore()
@@ -601,6 +654,22 @@ func (tx *badgerTransaction) IncrementServerEpoch(ctx context.Context) (uint64, 
 	}
 	tx.store.initLockStore()
 	return tx.store.lockStore.IncrementServerEpoch(ctx)
+}
+
+func (tx *badgerTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	tx.store.initLockStore()
+	return tx.store.lockStore.GetCleanShutdown(ctx)
+}
+
+func (tx *badgerTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	tx.store.initLockStore()
+	return tx.store.lockStore.SetCleanShutdown(ctx, clean)
 }
 
 func (tx *badgerTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -565,6 +565,15 @@ func (s *BadgerMetadataStore) Close() error {
 		})
 		s.gcWG.Wait()
 
+		// Record a clean-shutdown marker LAST, after the GC goroutine has
+		// drained and before closing the DB, so the lock-recovery boot path can
+		// distinguish a graceful drain from a kill -9 / crash. Close is the
+		// single graceful teardown site for the store. A persist failure is
+		// intentionally swallowed: leaving the marker unwritten makes the next
+		// boot conservatively treat the start as unclean and enter grace, which
+		// is the fail-safe direction.
+		_ = s.SetCleanShutdown(context.Background(), true)
+
 		if err := s.db.Close(); err != nil {
 			s.closeErr = fmt.Errorf("failed to close BadgerDB: %w", err)
 		}

--- a/pkg/metadata/store/memory/locks.go
+++ b/pkg/metadata/store/memory/locks.go
@@ -29,6 +29,14 @@ type memoryLockStore struct {
 
 	// serverEpoch tracks server restarts
 	serverEpoch uint64
+
+	// cleanShutdown records whether the previous Close() completed gracefully.
+	// It defaults to false (unclean) so a fresh store is treated as
+	// uncertain-on-boot, matching the fail-safe contract of GetCleanShutdown.
+	// The memory store is non-durable across processes, so this only ever
+	// reflects state within the current process — correct for the conformance
+	// semantics, which exercise the marker entirely in-process.
+	cleanShutdown bool
 }
 
 // newMemoryLockStore creates a new in-memory lock store.
@@ -179,6 +187,31 @@ func (s *memoryLockStore) IncrementServerEpoch(ctx context.Context) (uint64, err
 
 	s.serverEpoch++
 	return s.serverEpoch, nil
+}
+
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+func (s *memoryLockStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.cleanShutdown, nil
+}
+
+// SetCleanShutdown records the clean-shutdown marker.
+func (s *memoryLockStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cleanShutdown = clean
+	return nil
 }
 
 // ============================================================================
@@ -359,6 +392,31 @@ func (s *MemoryMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64,
 	defer s.mu.Unlock()
 	s.initLockStore()
 	return s.incrementServerEpochLocked(ctx)
+}
+
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+func (s *MemoryMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.lockStore == nil {
+		return false, nil
+	}
+	return s.lockStore.cleanShutdown, nil
+}
+
+// SetCleanShutdown records the clean-shutdown marker.
+func (s *MemoryMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initLockStore()
+	s.lockStore.cleanShutdown = clean
+	return nil
 }
 
 // ReclaimLease reclaims an existing lease during grace period.
@@ -556,6 +614,19 @@ func (tx *memoryTransaction) GetServerEpoch(ctx context.Context) (uint64, error)
 func (tx *memoryTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
 	tx.store.initLockStore()
 	return tx.store.incrementServerEpochLocked(ctx)
+}
+
+func (tx *memoryTransaction) GetCleanShutdown(_ context.Context) (bool, error) {
+	if tx.store.lockStore == nil {
+		return false, nil
+	}
+	return tx.store.lockStore.cleanShutdown, nil
+}
+
+func (tx *memoryTransaction) SetCleanShutdown(_ context.Context, clean bool) error {
+	tx.store.initLockStore()
+	tx.store.lockStore.cleanShutdown = clean
+	return nil
 }
 
 func (tx *memoryTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {

--- a/pkg/metadata/store/memory/locks_test.go
+++ b/pkg/metadata/store/memory/locks_test.go
@@ -396,6 +396,38 @@ func TestMemoryLockStore_ServerEpoch(t *testing.T) {
 	}
 }
 
+// TestMemoryLockStore_CleanShutdownDefaultsUnclean pins the fail-safe default
+// (area-4 H7): a fresh store that never had SetCleanShutdown(true) written must
+// report false (unclean), so the boot grace decision treats an unknown/absent
+// marker as a crash. The shared lock-persistence conformance suite cannot assert
+// the never-written default for all backends (some factories gracefully Close a
+// seed store, persisting clean=true), so the absent-default property is pinned
+// here per backend.
+func TestMemoryLockStore_CleanShutdownDefaultsUnclean(t *testing.T) {
+	store := NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+
+	clean, err := store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown failed: %v", err)
+	}
+	if clean {
+		t.Fatalf("fresh store reported clean shutdown=true; absent marker must default to false (unclean / fail-safe)")
+	}
+
+	// A graceful Close records the clean marker.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	clean, err = store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown after Close failed: %v", err)
+	}
+	if !clean {
+		t.Fatalf("after graceful Close, clean shutdown marker = false; Close must record clean=true")
+	}
+}
+
 func TestMemoryLockStore_PutOverwrites(t *testing.T) {
 	store := NewMemoryMetadataStoreWithDefaults()
 	ctx := context.Background()

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -312,7 +312,16 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 }
 
 // Close releases any resources held by the store.
-// For memory store, this is a no-op.
+//
+// For the memory store there are no OS resources to release, but Close is the
+// graceful-shutdown site for the lock subsystem: it records the clean-shutdown
+// marker so the lock-recovery boot path treats this drain as clean. The marker
+// is in-process only (memory is non-durable across restarts), which is correct
+// — a new process always starts with a fresh, unclean-by-default store.
 func (store *MemoryMetadataStore) Close() error {
+	store.mu.Lock()
+	store.initLockStore()
+	store.lockStore.cleanShutdown = true
+	store.mu.Unlock()
 	return nil
 }

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -464,6 +464,64 @@ func (s *postgresLockStore) incrementServerEpochTx(ctx context.Context, tx pgx.T
 	return newEpoch, err
 }
 
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+// An absent singleton row (fresh store) is reported as false (unclean) — the
+// fail-safe default.
+func (s *postgresLockStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	query := `SELECT clean_shutdown FROM server_epoch WHERE id = 1`
+	var clean bool
+	err := s.pool.QueryRow(ctx, query).Scan(&clean)
+	if err == pgx.ErrNoRows {
+		return false, nil // fresh start -> unclean
+	}
+	if err != nil {
+		return false, err
+	}
+	return clean, nil
+}
+
+// SetCleanShutdown records the clean-shutdown marker on the server_epoch
+// singleton row. It upserts so the marker can be written before any
+// IncrementServerEpoch has created the row.
+func (s *postgresLockStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	query := `
+		INSERT INTO server_epoch (id, epoch, clean_shutdown, updated_at)
+		VALUES (1, 0, $1, NOW())
+		ON CONFLICT (id) DO UPDATE SET
+			clean_shutdown = EXCLUDED.clean_shutdown,
+			updated_at = NOW()
+	`
+	_, err := s.pool.Exec(ctx, query, clean)
+	return err
+}
+
+// getCleanShutdownTx reads the marker within an existing transaction.
+func (s *postgresLockStore) getCleanShutdownTx(ctx context.Context, tx pgx.Tx) (bool, error) {
+	query := `SELECT clean_shutdown FROM server_epoch WHERE id = 1`
+	var clean bool
+	err := tx.QueryRow(ctx, query).Scan(&clean)
+	if err == pgx.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return clean, nil
+}
+
+// setCleanShutdownTx writes the marker within an existing transaction.
+func (s *postgresLockStore) setCleanShutdownTx(ctx context.Context, tx pgx.Tx, clean bool) error {
+	query := `
+		INSERT INTO server_epoch (id, epoch, clean_shutdown, updated_at)
+		VALUES (1, 0, $1, NOW())
+		ON CONFLICT (id) DO UPDATE SET
+			clean_shutdown = EXCLUDED.clean_shutdown,
+			updated_at = NOW()
+	`
+	_, err := tx.Exec(ctx, query, clean)
+	return err
+}
+
 // ReclaimLease reclaims an existing lease during grace period.
 // Searches for a persisted lease with matching file handle and lease key.
 func (s *postgresLockStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, _ string) (*lock.UnifiedLock, error) {
@@ -599,6 +657,18 @@ func (s *PostgresMetadataStore) IncrementServerEpoch(ctx context.Context) (uint6
 	return s.lockStore.IncrementServerEpoch(ctx)
 }
 
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+func (s *PostgresMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	s.initLockStore()
+	return s.lockStore.GetCleanShutdown(ctx)
+}
+
+// SetCleanShutdown records the clean-shutdown marker durably.
+func (s *PostgresMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	s.initLockStore()
+	return s.lockStore.SetCleanShutdown(ctx, clean)
+}
+
 // ReclaimLease reclaims an existing lease during grace period.
 func (s *PostgresMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
 	s.initLockStore()
@@ -650,6 +720,16 @@ func (ptx *postgresTransaction) GetServerEpoch(ctx context.Context) (uint64, err
 func (ptx *postgresTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
 	ptx.store.initLockStore()
 	return ptx.store.lockStore.incrementServerEpochTx(ctx, ptx.tx)
+}
+
+func (ptx *postgresTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.getCleanShutdownTx(ctx, ptx.tx)
+}
+
+func (ptx *postgresTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.setCleanShutdownTx(ctx, ptx.tx, clean)
 }
 
 func (ptx *postgresTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {

--- a/pkg/metadata/store/postgres/migrations/000024_server_clean_shutdown.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000024_server_clean_shutdown.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_epoch DROP COLUMN IF EXISTS clean_shutdown;

--- a/pkg/metadata/store/postgres/migrations/000024_server_clean_shutdown.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000024_server_clean_shutdown.up.sql
@@ -1,0 +1,14 @@
+-- Migration: clean-shutdown marker for lock-recovery grace entry (area-4 H7).
+--
+-- clean_shutdown records whether the previous run terminated through a
+-- fully-graceful Close(). On boot the lock subsystem enters its grace period
+-- when the marker is FALSE (crash / kill -9 / power-loss) even if no locks were
+-- recovered — fixing the bug where grace was entered only when recovered lock
+-- state existed. The marker is stored on the existing single-row server_epoch
+-- singleton (id = 1), mirroring how the server epoch is persisted.
+--
+-- Default FALSE: any row that predates this column, or a fresh row, is treated
+-- as UNCLEAN, which is the fail-safe direction (enter grace rather than risk
+-- granting a conflicting lock before a prior owner reclaims).
+
+ALTER TABLE server_epoch ADD COLUMN IF NOT EXISTS clean_shutdown BOOLEAN NOT NULL DEFAULT FALSE;

--- a/pkg/metadata/store/postgres/postgres_conformance_test.go
+++ b/pkg/metadata/store/postgres/postgres_conformance_test.go
@@ -128,3 +128,56 @@ func TestLockPersistenceConformance(t *testing.T) {
 		return factory(t).(lock.LockStore)
 	})
 }
+
+// TestPostgres_CleanShutdownMarkerDurable pins the area-4 H7 marker on the real
+// database across a close+reopen: a freshly-Reset store defaults to unclean
+// (clean_shutdown column DEFAULT FALSE on the server_epoch singleton); a
+// graceful Close records clean=true and that value SURVIVES reopening a NEW
+// store against the same database (the durable property the in-memory store
+// cannot exercise).
+func TestPostgres_CleanShutdownMarkerDurable(t *testing.T) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL clean-shutdown durability test")
+	}
+
+	cfg, caps := postgresTestConfig()
+	ctx := context.Background()
+
+	// Reset to a known-empty database, then close (Close records clean=true).
+	seed, err := postgres.NewPostgresMetadataStore(ctx, cfg, caps)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	if err := seed.Reset(ctx); err != nil {
+		seed.Close()
+		t.Fatalf("Reset: %v", err)
+	}
+	// After Reset the marker must be unclean (fresh singleton, DEFAULT FALSE).
+	clean, err := seed.GetCleanShutdown(ctx)
+	if err != nil {
+		seed.Close()
+		t.Fatalf("GetCleanShutdown (post-reset): %v", err)
+	}
+	if clean {
+		seed.Close()
+		t.Fatalf("post-reset store reported clean=true; the DEFAULT FALSE column must read unclean")
+	}
+	// Graceful Close records clean=true.
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed Close: %v", err)
+	}
+
+	// Reopen a fresh store against the same DB: the clean marker must persist.
+	store, err := postgres.NewPostgresMetadataStore(ctx, cfg, caps)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	clean, err = store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown (reopen): %v", err)
+	}
+	if !clean {
+		t.Fatalf("graceful Close must durably record clean=true across reopen; got false")
+	}
+}

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -223,6 +223,19 @@ var _ interface{ GetStoreID() string } = (*PostgresMetadataStore)(nil)
 func (s *PostgresMetadataStore) Close() error {
 	s.logger.Info("Closing PostgreSQL metadata store...")
 
+	// Record a clean-shutdown marker BEFORE cancelling the store context and
+	// closing the pool, so the lock-recovery boot path can distinguish a
+	// graceful drain from a kill -9 / crash. Close is the single graceful
+	// teardown site for the store. A dedicated short-lived context is used
+	// because s.cancel() below tears down s.ctx. A persist failure is logged but
+	// does not block close — the next boot then conservatively treats the start
+	// as unclean and enters grace, which is the fail-safe direction.
+	markCtx, markCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	if err := s.SetCleanShutdown(markCtx, true); err != nil {
+		s.logger.Error("failed to persist clean-shutdown marker on close", "error", err)
+	}
+	markCancel()
+
 	// Cancel context
 	s.cancel()
 

--- a/pkg/metadata/storetest/lock_persistence.go
+++ b/pkg/metadata/storetest/lock_persistence.go
@@ -69,6 +69,80 @@ func RunLockPersistenceSuite(t *testing.T, factory LockStoreFactory) {
 	t.Run("MaxUint64OffsetLength", func(t *testing.T) {
 		testLock_MaxUint64OffsetLength(t, factory)
 	})
+
+	t.Run("CleanShutdownMarker", func(t *testing.T) {
+		testLock_CleanShutdownMarker(t, factory)
+	})
+}
+
+// testLock_CleanShutdownMarker pins the clean-shutdown marker round-trip across
+// every backend (area-4 H7). The marker drives the grace-entry decision on
+// boot, so a backend that fails to round-trip it would either never enter grace
+// after a crash (lock-steal window) or always enter grace (90s wedge on every
+// restart). The contract this suite enforces on all three backends:
+//
+//   - SetCleanShutdown(false) then GetCleanShutdown reports false (the boot path
+//     clears the marker for the running session immediately after reading it;
+//     this also establishes the fail-safe unclean baseline a fresh store has).
+//   - SetCleanShutdown(true) then GetCleanShutdown reports true (graceful Close).
+//   - Toggling back to false reads false again.
+//   - The marker is INDEPENDENT of the server epoch: bumping the epoch must not
+//     flip it (a real divergence risk on backends — like postgres — that store
+//     both on one singleton row).
+//
+// The "absent marker defaults to false" property is asserted by the per-backend
+// unit tests rather than here, because some backend conformance factories open,
+// reset, then gracefully Close() a seed store before handing back a reopened
+// one — which legitimately leaves a persisted clean=true marker, not an absent
+// one.
+func testLock_CleanShutdownMarker(t *testing.T, factory LockStoreFactory) {
+	store := factory(t)
+	ctx := context.Background()
+
+	// Boot clears the marker for the running session -> false (unclean baseline).
+	if err := store.SetCleanShutdown(ctx, false); err != nil {
+		t.Fatalf("SetCleanShutdown(false): %v", err)
+	}
+	got, err := store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown (after false): %v", err)
+	}
+	if got {
+		t.Fatalf("after SetCleanShutdown(false), GetCleanShutdown = true; unclean marker not persisted")
+	}
+
+	// Mark clean (graceful Close) -> true.
+	if err := store.SetCleanShutdown(ctx, true); err != nil {
+		t.Fatalf("SetCleanShutdown(true): %v", err)
+	}
+	got, err = store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown (after true): %v", err)
+	}
+	if !got {
+		t.Fatalf("after SetCleanShutdown(true), GetCleanShutdown = false; clean marker not persisted")
+	}
+
+	// Toggle back -> false.
+	if err := store.SetCleanShutdown(ctx, false); err != nil {
+		t.Fatalf("SetCleanShutdown(false) #2: %v", err)
+	}
+
+	// Marker must be independent of the server epoch on backends that share a
+	// singleton row (postgres): bumping the epoch must not flip the marker.
+	if err := store.SetCleanShutdown(ctx, true); err != nil {
+		t.Fatalf("SetCleanShutdown(true) pre-epoch: %v", err)
+	}
+	if _, err := store.IncrementServerEpoch(ctx); err != nil {
+		t.Fatalf("IncrementServerEpoch: %v", err)
+	}
+	got, err = store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown (after epoch bump): %v", err)
+	}
+	if !got {
+		t.Fatalf("IncrementServerEpoch cleared the clean-shutdown marker; marker and epoch must be independent")
+	}
 }
 
 // testLock_MaxUint64OffsetLength pins R3-4: NFSv4 expresses an unbounded range

--- a/pkg/metadata/unified_view_test.go
+++ b/pkg/metadata/unified_view_test.go
@@ -10,8 +10,9 @@ import (
 
 // mockLockStore implements lock.LockStore for testing UnifiedLockView.
 type mockLockStore struct {
-	locks []*lock.PersistedLock
-	epoch uint64
+	locks         []*lock.PersistedLock
+	epoch         uint64
+	cleanShutdown bool
 }
 
 func newMockLockStore() *mockLockStore {
@@ -97,6 +98,15 @@ func (m *mockLockStore) GetServerEpoch(_ context.Context) (uint64, error) {
 func (m *mockLockStore) IncrementServerEpoch(_ context.Context) (uint64, error) {
 	m.epoch++
 	return m.epoch, nil
+}
+
+func (m *mockLockStore) GetCleanShutdown(_ context.Context) (bool, error) {
+	return m.cleanShutdown, nil
+}
+
+func (m *mockLockStore) SetCleanShutdown(_ context.Context, clean bool) error {
+	m.cleanShutdown = clean
+	return nil
 }
 
 func (m *mockLockStore) ReclaimLease(_ context.Context, _ lock.FileHandle, _ [16]byte, _ string) (*lock.UnifiedLock, error) {


### PR DESCRIPTION
## H7 bug

The NFSv4 + NLM lock-recovery grace period was entered only when **recovered lock state existed**, not on the **fact of an unclean restart**. After a kill -9 / crash that left no recoverable byte-range lock (a client holding only NFSv4 opens, or a best-effort persist that never landed), grace was skipped and a conflicting new lock could be granted before the prior owner reclaimed. The previous boot predicate in `service.go` was effectively `len(persisted) > 0`.

## Fix (Slice 0 of DURABLE-STATE-DESIGN.md)

Store-independent; covers 4.0 + 4.1 + NLM. No `ClientRecoveryStore`, no v4 `StateManager` persistence, no v4 handler changes (those are later slices).

1. **Durable clean-shutdown marker on `LockStore`** — `GetCleanShutdown` / `SetCleanShutdown`. Absent/unknown defaults to **FALSE = unclean** (fail-safe).
2. **Grace-entry predicate** changes from `locks>0` to **`unclean OR locks>0`**. On boot the marker is read to decide grace, then **immediately set FALSE** for the running session (so a kill -9 before the next graceful `Close()` is read as unclean next boot). It is set **TRUE only on a fully-graceful store `Close()`** (the single graceful teardown site for the lock subsystem, reached via `Runtime.Shutdown` -> `CloseMetadataStores`).
3. **Timeout backstop preserved** — an empty expected-client set never early-exits, so grace always lifts after `graceDuration` (~90s) and never wedges new-state creation.

The NLM half is already wired (`LockFileNLM` consults `IsOperationAllowed` -> `NLM4_DENIED_GRACE_PERIOD`); this change makes that grace actually fire on every unclean restart.

## Per-backend flag persistence

| Backend | Mechanism |
|---|---|
| memory | in-struct `bool` (in-process; correct conformance semantics — a new process always starts unclean-by-default) |
| badger | sentinel key `srvclean` (1-byte value), written last in `Close()` before `db.Close()` |
| postgres | `clean_shutdown BOOLEAN NOT NULL DEFAULT FALSE` column on the `server_epoch` singleton row (migration `000024`), independent of epoch; written before pool teardown in `Close()` |

Mirrors how the server epoch singleton is persisted in each backend.

## Tests

- **Cross-backend conformance** (`storetest/lock_persistence.go` `CleanShutdownMarker`): set/get round-trip + marker-is-independent-of-epoch, run for memory + badger + postgres.
- **Per-backend** fresh-default (= false) and reopen-durability unit tests (memory in-process; badger + postgres on-disk survive close+reopen).
- **Service-level grace-entry** (`grace_registration_test.go`): unclean restart with an **EMPTY** lock set **enters** grace; cleanly-drained store with no locks **skips** grace (fast path) and the boot clears the marker; grace **lifts via the timeout backstop**. The unclean-empty test **fails before** the predicate change and **passes after** (verified).
- `go test -race ./pkg/metadata/...` green; badger + postgres lock-persistence conformance green under `-tags=integration` against a real DB (migration applies to version 24, not dirty; down/up idempotent).

## Scope

Only `pkg/metadata/lock/`, `pkg/metadata/store/{memory,badger,postgres}/` (flag + migration), `pkg/metadata/service.go` (boot decision + clear), and the graceful-`Close()` sites. No deviation from the design doc.

Closes the H7 / H15-NLM-residual half. Do not merge — Slice 0 of a stacked series.