### PR TITLE
fix(smb/replay): echo requested oplock level on non-lease DH2 create replay (#749)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1602,10 +1602,17 @@ func (h *Handler) resolveCreateReplay(ctx *SMBHandlerContext, req *CreateRequest
 	resp := *entry.Response
 
 	// Lease replays are validated and state-refreshed against the live
-	// open. Non-lease (plain oplock) replays return the cached response
-	// verbatim: Samba echoes the request's oplock level back on replay
-	// without touching the held oplock, which the cached snapshot already
-	// reflects (replay-dhv2-oplock1/2/3).
+	// open (refreshReplayLease). Non-lease (plain oplock) replays echo the
+	// REPLAY REQUEST's requested oplock level back in the response — Samba
+	// sets io.out.oplock_level = io.in.oplock_level on the replay path
+	// (source3/smbd/smb2_create.c; MS-SMB2 §3.3.5.9) — without touching the
+	// open's actually-held oplock. The replay request may request a
+	// different level than the original grant (replay-dhv2-oplock2). resp is
+	// a shallow copy, so this stamps only the returned response, never the
+	// cache entry (entry.Response) or the live open.
+	if req.OplockLevel != OplockLevelLease {
+		resp.OplockLevel = req.OplockLevel
+	}
 	if status := h.refreshReplayLease(ctx, req, entry, &resp); status != types.StatusSuccess {
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, true
 	}

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -174,7 +174,12 @@ func TestResolveCreateReplay_OplockSnapshot(t *testing.T) {
 	h.CreateReplayCache.Store(sessionID, guid, cached,
 		&OpenFile{OplockLevel: OplockLevelBatch})
 
-	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	// Replay request asks for the same level it was originally granted, so the
+	// echoed level matches the cached snapshot.
+	req := dh2qCreateReq(guid, nil)
+	req.OplockLevel = OplockLevelBatch
+
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), req)
 	if !handled {
 		t.Fatal("oplock replay must be handled")
 	}
@@ -183,6 +188,51 @@ func TestResolveCreateReplay_OplockSnapshot(t *testing.T) {
 	}
 	if resp.FileID != cached.FileID {
 		t.Fatal("oplock replay must return the original FileID")
+	}
+}
+
+// TestResolveCreateReplay_OplockEchoesRequestedLevel: a non-lease replay whose
+// request carries a DIFFERENT requested oplock level than the original grant
+// must echo the REQUEST's level in the response (Samba sets
+// io.out.oplock_level = io.in.oplock_level on the replay path; MS-SMB2
+// §3.3.5.9) while leaving the cached entry and the live open untouched — covers
+// replay-dhv2-oplock2.
+func TestResolveCreateReplay_OplockEchoesRequestedLevel(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x0A}
+
+	cached := &CreateResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		OplockLevel:     OplockLevelBatch,
+		FileID:          [16]byte{0xBE, 0xEF},
+	}
+	h.CreateReplayCache.Store(sessionID, guid, cached,
+		&OpenFile{OplockLevel: OplockLevelBatch})
+
+	// Replay request asks for None instead of the originally granted Batch.
+	req := dh2qCreateReq(guid, nil)
+	req.OplockLevel = OplockLevelNone
+
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), req)
+	if !handled {
+		t.Fatal("oplock replay must be handled")
+	}
+	if resp.OplockLevel != OplockLevelNone {
+		t.Fatalf("replay response oplock = 0x%x, want NONE (echoes request)", resp.OplockLevel)
+	}
+
+	// The cached entry must be left unmodified so a subsequent replay still
+	// reflects the original grant.
+	if cached.OplockLevel != OplockLevelBatch {
+		t.Fatalf("cached entry oplock mutated to 0x%x, want BATCH (cache must not be touched)", cached.OplockLevel)
+	}
+	entry := h.CreateReplayCache.LookupEntry(sessionID, guid)
+	if entry == nil || entry.Response.OplockLevel != OplockLevelBatch {
+		t.Fatal("cached entry response oplock must remain BATCH")
+	}
+	if entry.OpenFile == nil || entry.OpenFile.OplockLevel != OplockLevelBatch {
+		t.Fatal("live open's held oplock must remain BATCH")
 	}
 }
 


### PR DESCRIPTION
## Problem

In \`resolveCreateReplay\` (internal/adapter/smb/v2/handlers/create.go), a non-lease (traditional oplock) DH2Q CREATE replay returned the cached CREATE response **verbatim**, echoing the oplock level that was originally *granted*. The \`replay-dhv2-oplock2\` test replays a DH2Q CREATE whose replay request carries a **different** requested OplockLevel than the original grant, and expects the server to echo the *request's* level in the replay response.

## Fix

On the non-lease replay path, after the shallow copy of the cached response, stamp the returned copy's \`OplockLevel\` with the replay request's requested level:

\`\`\`go
if req.OplockLevel != OplockLevelLease {
    resp.OplockLevel = req.OplockLevel
}
\`\`\`

This mirrors Samba, which sets \`io.out.oplock_level = io.in.oplock_level\` on the replay path (\`source3/smbd/smb2_create.c\`), per MS-SMB2 §3.3.5.9.

### Guarantees preserved
- **Cache not mutated** — operates only on \`resp\`, the shallow copy; \`entry.Response\` and the cached entry are untouched (asserted by the new test).
- **Live open's held oplock unchanged** — only the wire response field is stamped; the \`OpenFile\`'s actual oplock state is not modified.
- **Lease path unchanged** — the guard skips lease replays (\`OplockLevel == 0xFF\`), which continue through \`refreshReplayLease\` (RqLs context refresh / ACCESS_DENIED validation).

## Tests
- New \`TestResolveCreateReplay_OplockEchoesRequestedLevel\`: caches a CREATE granted Batch, replays a request asking None, asserts the response echoes None **and** the cached entry + live open both remain Batch.
- Updated \`TestResolveCreateReplay_OplockSnapshot\` so its replay request asks for the same level it was granted (Batch), keeping its matching-level coverage intact.

Target test: \`smb2.replay-dhv2-oplock2\`. Refs #749.

\`go build\`, \`go vet\`, \`golangci-lint\`, and \`go test ./internal/adapter/smb/v2/handlers/...\` all pass.