### PR TITLE
fix(metadata): balance grace-end on remove + guard register/remove TOCTOU (Copilot follow-up to #897)

### DIFF
--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -190,13 +190,51 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Re-check: another caller may have raced us to register this share while
-	// we recovered outside the lock. First publisher wins; drop our manager.
-	if _, exists := s.lockManagers[shareName]; exists {
+	// Re-check under the SAME s.mu acquisition that performs the publish, so the
+	// decision-to-publish and the publish itself are atomic. Two distinct races
+	// can land between our initial store-publish and this point:
+	//
+	//  1. Another caller raced us to register this same share. First publisher
+	//     wins; drop our manager.
+	//  2. A concurrent RemoveStoreForShare deleted this share while we recovered
+	//     outside the lock (TOCTOU). If we published our lock manager + notifier
+	//     now, we would RESURRECT entries for a removed share — the store map
+	//     stays deleted but lockManagers/dirChangeNotifiers come back, leaving
+	//     stale routing and a lock manager that is never torn down (leak).
+	//
+	// We detect a removal-mid-flight by checking that OUR store is still the one
+	// registered for this share. RemoveStoreForShare deletes s.stores[shareName];
+	// a same-name re-register installs a DIFFERENT store value. Either way, if
+	// the entry is gone or no longer ours, we must abort the publish.
+	cur, stillOurs := s.stores[shareName]
+	_, lmExists := s.lockManagers[shareName]
+	removedMidFlight := !lmExists && (!stillOurs || cur != store)
+	if lmExists || removedMidFlight {
 		// Our manager may have armed a grace timer above. It was never
 		// published, so abort that timer without firing onGraceEnd — letting it
-		// run would sweep the surviving manager's locks from the shared store
-		// and prematurely end the NFSv4 grace machine.
+		// run would sweep a surviving manager's locks from the shared store and
+		// prematurely end the NFSv4 grace machine. We hold s.mu here, and
+		// AbortGracePeriod (Close) does not block, so this is deadlock-free.
+		//
+		// Grace-coordinator balance is asymmetric between the two abort cases:
+		//
+		//   lmExists (lost a concurrent register for the SAME share): the WINNER
+		//   published its manager and, if it entered grace, signalled
+		//   OnLockGraceStart. The global NFSv4 grace machine is now coupled to
+		//   the WINNER. We must NOT signal OnLockGraceEnd here — doing so would
+		//   prematurely end the surviving manager's grace window. Our own
+		//   (redundant) start signal was a no-op at the coordinator because v4
+		//   grace was already active (first-in-wins policy).
+		//
+		//   removedMidFlight (a concurrent RemoveStoreForShare deleted this share
+		//   while we recovered outside the lock): Remove ran BEFORE we published,
+		//   so it never saw our lock manager and never fired OnLockGraceEnd for
+		//   the OnLockGraceStart we signalled. If we entered grace, the
+		//   coordinator is now wedged in grace for a share that no longer exists;
+		//   we must balance it with exactly one OnLockGraceEnd.
+		if removedMidFlight && lm.IsInGracePeriod() && graceCoordinator != nil {
+			graceCoordinator.OnLockGraceEnd()
+		}
 		lm.AbortGracePeriod()
 		return nil
 	}
@@ -230,6 +268,24 @@ func (s *MetadataService) RemoveStoreForShare(shareName string) {
 	defer s.mu.Unlock()
 
 	if lm, ok := s.lockManagers[shareName]; ok && lm != nil {
+		// If the manager is still in grace, it had signalled OnLockGraceStart to
+		// the grace coordinator at registration. AbortGracePeriod (below) stops
+		// the timer WITHOUT firing onGraceEnd, which is exactly what suppresses
+		// the coordinator's balancing OnLockGraceEnd. Left unbalanced, the
+		// coordinator (NFSv4 StateManager) would stay wedged in grace
+		// indefinitely after this share is removed. Fire the balancing end here,
+		// mirroring how the normal timer/early-exit path ends grace.
+		//
+		// Capturing IsInGracePeriod before AbortGracePeriod is required: Abort
+		// transitions the state to Normal, after which IsInGracePeriod would read
+		// false. The coordinator is read under the s.mu we already hold, and
+		// OnLockGraceEnd must not block (interface contract), so this is
+		// deadlock-free. Exactly-once: if grace had already lifted naturally the
+		// onGraceEnd closure already fired OnLockGraceEnd and IsInGracePeriod is
+		// false here, so we do not double-fire.
+		if lm.IsInGracePeriod() && s.graceCoordinator != nil {
+			s.graceCoordinator.OnLockGraceEnd()
+		}
 		// Abort the grace timer (if armed) so it never fires onGraceEnd against
 		// a removed share. AbortGracePeriod stops the timer synchronously and
 		// does not block, so holding s.mu across it is safe.

--- a/pkg/metadata/service_register_race_test.go
+++ b/pkg/metadata/service_register_race_test.go
@@ -1,0 +1,227 @@
+package metadata_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCoordinator wraps the package's graceSpyCoordinator with atomic
+// start/end counters so the exactly-once grace-balance invariant can be asserted
+// across the registration/removal lifecycle. It reuses graceSpyCoordinator's
+// callback seams rather than reimplementing the GraceCoordinator interface.
+func countingCoordinator() (*graceSpyCoordinator, *int32, *int32) {
+	var starts, ends int32
+	coord := &graceSpyCoordinator{
+		started: make(chan []string, 1),
+		ended:   make(chan struct{}, 1),
+		onStart: func(_ []string) { atomic.AddInt32(&starts, 1) },
+		onEnd:   func() { atomic.AddInt32(&ends, 1) },
+	}
+	return coord, &starts, &ends
+}
+
+// TestRemoveStoreForShare_BalancesGraceCoordinator is the Finding-1 regression.
+// A share that enters grace at registration signals OnLockGraceStart to the
+// coordinator (coupling the NFSv4 StateManager grace machine in lockstep).
+// RemoveStoreForShare aborts the grace timer WITHOUT firing the timer's
+// onGraceEnd closure, so without an explicit balancing call the coordinator
+// would stay wedged in grace forever after the share is gone.
+//
+// Asserts: start fired once at registration; after RemoveStoreForShare the
+// coordinator saw exactly one OnLockGraceEnd; and the start/end counts are
+// symmetric (the coordinator is fully balanced, not left in grace).
+func TestRemoveStoreForShare_BalancesGraceCoordinator(t *testing.T) {
+	const shareName = "/graced-remove"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, store, shareName, "client-1")
+
+	coord, starts, ends := countingCoordinator()
+
+	svc := metadata.New()
+	svc.SetGraceCoordinator(coord)
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod(), "share with persisted locks must enter grace")
+	require.Equal(t, int32(1), atomic.LoadInt32(starts),
+		"OnLockGraceStart must fire exactly once at registration")
+	require.Equal(t, int32(0), atomic.LoadInt32(ends),
+		"OnLockGraceEnd must not fire while the share is still in grace")
+
+	// Remove the share while it is still in grace.
+	svc.RemoveStoreForShare(shareName)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(ends),
+		"RemoveStoreForShare during grace must fire OnLockGraceEnd exactly once "+
+			"(coordinator must not be left wedged in grace)")
+	require.Equal(t, atomic.LoadInt32(starts), atomic.LoadInt32(ends),
+		"grace start/end must be balanced after removal (symmetric invariant)")
+
+	// The share is fully gone: no lock manager, no resurrected routing.
+	require.Nil(t, svc.GetLockManagerForShare(shareName),
+		"lock manager must be removed")
+}
+
+// TestRemoveStoreForShare_NoDoubleEndWhenGraceLiftedNaturally guards the
+// exactly-once contract from the other side: if grace already lifted naturally
+// (all expected clients reclaimed) before removal, the onGraceEnd closure
+// already fired OnLockGraceEnd. RemoveStoreForShare must NOT fire a second time —
+// IsInGracePeriod is read before AbortGracePeriod and is false here.
+func TestRemoveStoreForShare_NoDoubleEndWhenGraceLiftedNaturally(t *testing.T) {
+	const shareName = "/graced-natural"
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, store, shareName, "client-1")
+
+	coord, starts, ends := countingCoordinator()
+
+	svc := metadata.New()
+	svc.SetGraceCoordinator(coord)
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod())
+
+	// Reclaim the sole expected client: grace lifts naturally and the onGraceEnd
+	// closure fires OnLockGraceEnd synchronously.
+	lm.MarkReclaimed("client-1")
+	require.False(t, lm.IsInGracePeriod(), "grace must lift after the sole client reclaims")
+	require.Equal(t, int32(1), atomic.LoadInt32(ends),
+		"natural grace lift fires OnLockGraceEnd once")
+
+	// Removing the (no-longer-in-grace) share must NOT fire a second end.
+	svc.RemoveStoreForShare(shareName)
+	require.Equal(t, int32(1), atomic.LoadInt32(ends),
+		"RemoveStoreForShare must not double-fire OnLockGraceEnd after a natural lift")
+	require.Equal(t, atomic.LoadInt32(starts), atomic.LoadInt32(ends),
+		"grace start/end balanced (exactly-once across natural lift + remove)")
+}
+
+// removeMidFlightStore is a test-only MetadataStore+LockStore decorator that
+// fires a RemoveStoreForShare DURING the unlocked recovery phase of
+// RegisterStoreForShare. Recovery calls ListLocks (initLockManagerFromStore,
+// outside s.mu); intercepting that call lets us land a concurrent removal
+// deterministically in the exact TOCTOU window between the initial
+// store-publish and the final publish re-check — no goroutines or sleeps.
+//
+// It embeds *memory.MemoryMetadataStore so it satisfies both MetadataStore and
+// lock.LockStore (the recovery path type-asserts the store to lock.LockStore),
+// overriding only ListLocks. After firing the removal once it returns the real
+// persisted locks so the manager still enters grace (signalling
+// OnLockGraceStart) before the re-check observes the removal and must balance it.
+type removeMidFlightStore struct {
+	*memory.MemoryMetadataStore
+	svc       *metadata.MetadataService
+	shareName string
+	fired     bool
+}
+
+func (s *removeMidFlightStore) ListLocks(ctx context.Context, q lock.LockQuery) ([]*lock.PersistedLock, error) {
+	if !s.fired {
+		s.fired = true
+		// Simulate a concurrent RemoveStoreForShare landing while we recover
+		// outside s.mu. This deletes s.stores[shareName] before our publish.
+		s.svc.RemoveStoreForShare(s.shareName)
+	}
+	return s.MemoryMetadataStore.ListLocks(ctx, q)
+}
+
+// TestRegisterStoreForShare_RemovedMidFlightDoesNotResurrect is the Finding-2
+// regression: a RemoveStoreForShare that lands between the initial store-publish
+// and the final publish re-check must NOT resurrect the share. Before the fix,
+// RegisterStoreForShare would unconditionally publish its lock manager +
+// dirChangeNotifier under the final s.mu, re-adding routing for a removed share
+// (stale routing + a lock manager that is never torn down = leak), and the
+// OnLockGraceStart it signalled would be left unbalanced (coordinator wedged in
+// grace for a share that no longer exists).
+//
+// The decorator fires the removal during recovery (ListLocks), then returns a
+// persisted lock so the manager enters grace and signals OnLockGraceStart. The
+// re-check must then detect removedMidFlight, fire exactly one balancing
+// OnLockGraceEnd, abort the (unpublished) manager's grace timer, and decline to
+// publish.
+func TestRegisterStoreForShare_RemovedMidFlightDoesNotResurrect(t *testing.T) {
+	const shareName = "/raced-remove"
+	base := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, base, shareName, "client-1")
+
+	coord, starts, ends := countingCoordinator()
+
+	svc := metadata.New()
+	svc.SetGraceCoordinator(coord)
+
+	store := &removeMidFlightStore{
+		MemoryMetadataStore: base,
+		svc:                 svc,
+		shareName:           shareName,
+	}
+
+	// Registration must succeed (nil) — the removal is absorbed silently.
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+	require.True(t, store.fired, "the mid-flight removal must have been exercised")
+
+	// The share must NOT be resurrected: no lock manager re-published.
+	require.Nil(t, svc.GetLockManagerForShare(shareName),
+		"a share removed mid-flight must NOT have its lock manager resurrected")
+
+	// The manager DID enter grace during recovery, so OnLockGraceStart fired once.
+	require.Equal(t, int32(1), atomic.LoadInt32(starts),
+		"recovery entered grace and signalled OnLockGraceStart once")
+	// removedMidFlight must balance that start with exactly one OnLockGraceEnd —
+	// the prior RemoveStoreForShare ran before publish and never saw our manager,
+	// so the register re-check owns the balancing end.
+	require.Equal(t, int32(1), atomic.LoadInt32(ends),
+		"removed-mid-flight register must fire exactly one balancing OnLockGraceEnd")
+	require.Equal(t, atomic.LoadInt32(starts), atomic.LoadInt32(ends),
+		"coordinator must not be left wedged in grace for a removed share")
+}
+
+// TestRegisterStoreForShare_LostRaceDoesNotEndWinnerGrace pins the asymmetric
+// branch: when a register loses a concurrent register for the SAME share
+// (lmExists), the WINNER owns the coordinator's grace. The loser must abort its
+// own unpublished timer WITHOUT firing OnLockGraceEnd — firing would prematurely
+// end the surviving winner's grace window.
+//
+// We synthesize the lost-race deterministically: register a first store (the
+// winner) so a lock manager is published and grace begins, then register a
+// SECOND, different store for the same share. The second call sees lmExists on
+// the re-check and must drop its manager without touching the coordinator's end.
+func TestRegisterStoreForShare_LostRaceDoesNotEndWinnerGrace(t *testing.T) {
+	const shareName = "/raced-same"
+	winner := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, winner, shareName, "client-1")
+
+	coord, starts, ends := countingCoordinator()
+
+	svc := metadata.New()
+	svc.SetGraceCoordinator(coord)
+
+	// Winner registers first: manager published, grace begins, start fires once.
+	require.NoError(t, svc.RegisterStoreForShare(shareName, winner))
+	lm := svc.GetLockManagerForShare(shareName)
+	require.NotNil(t, lm)
+	require.True(t, lm.IsInGracePeriod())
+	require.Equal(t, int32(1), atomic.LoadInt32(starts))
+	require.Equal(t, int32(0), atomic.LoadInt32(ends))
+
+	// A second register for the SAME share with a DIFFERENT store loses the race:
+	// lmExists is true on the re-check, so it drops its manager and must NOT fire
+	// OnLockGraceEnd (the winner still owns grace).
+	loser := memory.NewMemoryMetadataStoreWithDefaults()
+	persistNLMLock(t, loser, shareName, "client-2")
+	require.NoError(t, svc.RegisterStoreForShare(shareName, loser))
+
+	require.Equal(t, int32(0), atomic.LoadInt32(ends),
+		"losing a same-share register must NOT end the winner's grace")
+	require.True(t, lm.IsInGracePeriod(),
+		"the winner's grace window must survive a lost concurrent register")
+	require.Same(t, lm, svc.GetLockManagerForShare(shareName),
+		"the published lock manager must remain the winner's (no replacement)")
+}


### PR DESCRIPTION
Follow-up to merged #897 addressing two Copilot findings in the per-share lock-manager grace-coordinator coupling.

## Findings

**1. RemoveStoreForShare left the grace coordinator wedged.**
A share that enters grace at registration signals OnLockGraceStart, coupling the NFSv4 StateManager grace machine. RemoveStoreForShare aborted the grace timer via AbortGracePeriod, which stops the timer WITHOUT firing its onGraceEnd closure — so the coordinator never received the balancing OnLockGraceEnd and stayed in grace forever after the share was gone. Fix: fire one balancing OnLockGraceEnd in RemoveStoreForShare when the manager is still in grace, capturing IsInGracePeriod before Abort (exactly-once: a natural lift already fired end and reads false here).

**2. Register/Remove TOCTOU could resurrect a removed share.**
RegisterStoreForShare recovers the lock manager outside s.mu, then publishes under s.mu. A concurrent RemoveStoreForShare landing in that window left the store map deleted but allowed the register to re-publish lockManagers/dirChangeNotifiers — stale routing plus a lock manager that is never torn down (leak), and an unbalanced OnLockGraceStart. Fix: the final publish re-check (under the same s.mu hold as the write) now detects removed-mid-flight by confirming our store is still the registered one; if not, it aborts the publish and, for the removed-mid-flight case only, fires one balancing OnLockGraceEnd. The lost-same-share-register case must NOT end grace (the winner owns it).

## Tests (pkg/metadata/service_register_race_test.go)
- RemoveStoreForShare during grace fires OnLockGraceEnd exactly once (start==end).
- No double-end when grace lifted naturally before removal.
- Removed-mid-flight register does not resurrect the share and fires exactly one balancing end (deterministic TOCTOU via a ListLocks decorator that removes the share during recovery — no goroutines/sleeps).
- Lost same-share register does not end the winner's grace.

Reuses the existing graceSpyCoordinator. go test -race clean (incl. -tags=integration); vet + golangci-lint clean.

## Scope
pkg/metadata/service.go (RegisterStoreForShare publish re-check + RemoveStoreForShare grace balance) and the new test file only.