### PR TITLE
fix(smb/replay): reserve DH2 create-guid across no-oplock share conflicts (#749)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1355,16 +1355,46 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		appInstanceId:        appInstanceId,
 	}).finalize()
 
+	// SMB3 replay protection (MS-SMB2 §3.3.5.9): reserve the DH2Q CreateGuid for
+	// the entire window during which this second open is blocked/pending on a
+	// share-mode conflict — covering BOTH the async lease-park path AND the
+	// inline no-oplock sharing-violation/sync-wait path. A replay
+	// (FLAGS_REPLAY_OPERATION) arriving while the original is still in this
+	// window must return STATUS_FILE_NOT_AVAILABLE (resolveCreateReplay), which
+	// requires the guid to be reserved. The no-oplock "n" variant (conflicting
+	// holder with no Write/Handle lease bits) takes the inline path and so was
+	// previously never reserved (smbtorture replay-dhv2-pending1n-*-sane). The
+	// reservation is held only across the break+complete window below and is
+	// always released:
+	//   - async park (asyncId != 0): the parked resume goroutine owns the
+	//     Release (parkCreateOnLeaseBreak), so we MUST NOT release here.
+	//   - inline (asyncId == 0): released after completeCreateAfterBreak.
+	// Reserve is the single site (parkCreateOnLeaseBreak no longer reserves); a
+	// zero CreateGuid or no share conflict is left unreserved (Reserve is a
+	// no-op on a zero guid). Gated on fileExists since a conflict requires a
+	// pre-existing open to contend with.
+	replayGuid := dh2qCreateGuid(req)
+	reservedReplay := false
+	if h.CreateReplayCache != nil && fileExists && replayGuid != ([16]byte{}) {
+		h.CreateReplayCache.Reserve(ctx.SessionID, replayGuid)
+		reservedReplay = true
+	}
+
 	// Dispatch lease break and either park the CREATE async (emit interim
 	// STATUS_PENDING) or wait for the break to drain inline.
 	if asyncId := h.breakAndMaybeParkCreate(ctx, draft); asyncId != 0 {
+		// Parked: the resume goroutine releases the reservation on completion.
 		return &CreateResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusPending},
 			AsyncId:         asyncId,
 		}, nil
 	}
 
-	return h.completeCreateAfterBreak(ctx, draft), nil
+	resp := h.completeCreateAfterBreak(ctx, draft)
+	if reservedReplay {
+		h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
+	}
+	return resp, nil
 }
 
 // computeMaximalAccess computes the maximal access mask for a file used in

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1336,16 +1336,15 @@ func (h *Handler) parkCreateOnLeaseBreak(
 	shareName := d.tree.ShareName
 	messageID := ctx.MessageID
 
-	// Reserve the DH2Q CreateGuid for the lifetime of the parked CREATE so a
-	// replayed CREATE on the same CreateGuid fails fast with
-	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break
-	// (smbtorture replay-dhv2-pending* / *-vs-{oplock,lease}). Released by
-	// the resume goroutine when the original reaches a terminal state. A
-	// zero CreateGuid (non-V2 / no DH2Q) is a no-op in Reserve/Release.
+	// The DH2Q CreateGuid was already Reserved by the caller (Create, before the
+	// breakAndMaybeParkCreate dispatch) so a replayed CREATE fails fast with
+	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break (smbtorture
+	// replay-dhv2-pending* / *-vs-{oplock,lease}). Since this CREATE is parking
+	// async, ownership of the matching Release transfers to the resume goroutine
+	// below: the caller returns STATUS_PENDING immediately and does NOT release.
+	// This keeps exactly one Reserve (in Create) and one Release (here for the
+	// parked path) per CREATE attempt. A zero CreateGuid is a no-op in Release.
 	replayGuid := dh2qCreateGuid(d.req)
-	if h.CreateReplayCache != nil {
-		h.CreateReplayCache.Reserve(ctx.SessionID, replayGuid)
-	}
 
 	go func() {
 		defer cancel()

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -347,6 +347,91 @@ func TestResolveCreateReplay_OplockReplayedAsLease(t *testing.T) {
 	}
 }
 
+// TestResolveCreateReplay_NoOplockPendingReserved models the no-oplock
+// share-conflict "n" variant (smbtorture replay-dhv2-pending1n-*-sane): the
+// conflicting first open holds NO oplock/lease, so the second CREATE takes the
+// inline (non-park) path. Create now reserves the DH2Q CreateGuid across that
+// inline break+complete window. While reserved, a concurrent replay
+// (FLAGS_REPLAY_OPERATION) must return STATUS_FILE_NOT_AVAILABLE rather than
+// fall through the full CREATE path (the bug fixed for #749). After the original
+// finishes (reservation released) and with no cached entry, a fresh replay must
+// fall through cleanly — proving the reservation was not leaked.
+func TestResolveCreateReplay_NoOplockPendingReserved(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x4E, 0x4F} // "NO"
+
+	// Create's inline-conflict path reserves the guid (no async park, no cached
+	// entry yet — the original open has not completed).
+	h.CreateReplayCache.Reserve(sessionID, guid)
+
+	// Concurrent replay while reserved → FILE_NOT_AVAILABLE.
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	if !handled {
+		t.Fatal("replay against a reserved no-oplock CREATE must be handled")
+	}
+	if resp.Status != types.StatusFileNotAvailable {
+		t.Fatalf("status = %s, want STATUS_FILE_NOT_AVAILABLE", resp.Status)
+	}
+
+	// A non-replay duplicate while reserved must NOT be hijacked into
+	// FILE_NOT_AVAILABLE: with no cached entry it simply falls through to the
+	// normal CREATE path (IsReserved is gated on ctx.IsReplay).
+	if _, handled := h.resolveCreateReplay(newReplayCtx(sessionID, false), dh2qCreateReq(guid, nil)); handled {
+		t.Fatal("non-replay CREATE on a reserved-but-uncached guid must fall through")
+	}
+
+	// Original completes: Create releases the reservation. A fresh replay now
+	// finds neither a reservation nor a cached entry and falls through — no leak.
+	h.CreateReplayCache.Release(sessionID, guid)
+	if h.CreateReplayCache.IsReserved(sessionID, guid) {
+		t.Fatal("reservation leaked after Release")
+	}
+	if _, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil)); handled {
+		t.Fatal("after release with no cached entry the replay must fall through")
+	}
+}
+
+// TestCreateReplayCache_ReserveReleaseSingleReservation proves the
+// single-logical-reservation invariant the #749 fix relies on: Reserve is
+// idempotent (set semantics) and one Release clears the guid regardless of how
+// many Reserves preceded it. This guards the design where Create reserves the
+// guid before dispatch and — on the async-park path — parkCreateOnLeaseBreak's
+// resume goroutine performs the single Release. Even if both sites were to
+// Reserve, a single Release must fully clear the guid (no stuck reservation
+// that would wrongly FILE_NOT_AVAILABLE all future opens) and an extra Release
+// must be a harmless no-op (no panic / no negative refcount).
+func TestCreateReplayCache_ReserveReleaseSingleReservation(t *testing.T) {
+	c := NewCreateReplayCache()
+	const sessionID = uint64(11)
+	guid := [16]byte{0xC0, 0xDE}
+
+	// Idempotent Reserve: two reserves still collapse to one logical entry.
+	c.Reserve(sessionID, guid)
+	c.Reserve(sessionID, guid)
+	if !c.IsReserved(sessionID, guid) {
+		t.Fatal("guid must be reserved after Reserve")
+	}
+
+	// A single Release clears it.
+	c.Release(sessionID, guid)
+	if c.IsReserved(sessionID, guid) {
+		t.Fatal("a single Release must fully clear the reservation (no stuck reservation)")
+	}
+
+	// An extra Release is a harmless no-op.
+	c.Release(sessionID, guid)
+	if c.IsReserved(sessionID, guid) {
+		t.Fatal("double Release must not resurrect the reservation")
+	}
+
+	// A zero CreateGuid is never tracked (non-V2 / no DH2Q creates).
+	c.Reserve(sessionID, [16]byte{})
+	if c.IsReserved(sessionID, [16]byte{}) {
+		t.Fatal("zero CreateGuid must never be reserved")
+	}
+}
+
 // leaseKey16Guid reuses a lease key's bytes as a distinct CreateGuid for tests
 // (the two are independent identifiers; reusing keeps the fixtures compact).
 func leaseKey16Guid(leaseKey [16]byte) [16]byte {


### PR DESCRIPTION
## Problem (#749)

SMB2 CREATE replay protection (MS-SMB2 §3.3.5.9) parks the DH2Q `CreateGuid` in
the replay cache's `reserved` set while the original open is blocked, so a
retransmitted CREATE carrying `FLAGS_REPLAY_OPERATION` returns
`STATUS_FILE_NOT_AVAILABLE` instead of racing the original.

The reservation was only ever taken inside `parkCreateOnLeaseBreak` — the
**async lease-park** path. When the conflicting first open holds **no
oplock/lease** (the `pending1n-*-sane` "n" variant — e.g. a non-stat open whose
`share_access` causes a sharing conflict), `breakAndMaybeParkCreate` computes
`needsParkForFlush = false` (no Write/Handle lease bits to flush), returns 0, and
the CREATE completes **inline** via `completeCreateAfterBreak`. That inline path
never reserved the guid, so a concurrent replay found nothing in `reserved`,
fell through the full CREATE path, and returned the wrong status.

## Fix

Move the reservation to a **single site** in `Create`, covering the whole
break+complete window for both paths:

- `Create` calls `Reserve(sessionID, createGuid)` just before the
  `breakAndMaybeParkCreate` dispatch when the request carries a non-zero DH2Q
  `CreateGuid` **and** the target file exists (a share-mode conflict requires a
  pre-existing open to contend with).
- `parkCreateOnLeaseBreak` **no longer reserves** — that Reserve is now
  redundant. Every park path requires `fileExists`, so `Create`'s gate is a
  superset of all park conditions.

### Reservation-lifetime design (exactly one Reserve / one Release per attempt)

- **Inline path** (`breakAndMaybeParkCreate` → 0): `Create` releases right after
  `completeCreateAfterBreak` returns. Covers the no-oplock `pending1n` case.
- **Async park path** (`breakAndMaybeParkCreate` → non-zero asyncId): ownership
  of the Release transfers to the parked resume goroutine (which already had a
  `defer Release`). `Create` returns `STATUS_PENDING` and does **not** release.

`asyncId != 0` ⟺ `parkCreateOnLeaseBreak` spawned the resume goroutine (which
always carries the deferred Release). So the Release responsibility is split
cleanly on `asyncId != 0`, with no path that reserves but never releases (no
leak — a leaked reservation would wrongly `FILE_NOT_AVAILABLE` all future opens
of that guid) and no path that releases twice. The cache's set semantics keep
`Reserve` idempotent and `Release` a safe idempotent delete, so even a coalesced
double-reserve clears on a single Release.

### Regression reasoning for the lease-park replay tests

`replay-dhv2-lease1/2/3`, `oplock-lease`, `lease-oplock`, and `pending1l-sane`
rely on the guid staying reserved across the async lease break. They still do:
those CREATEs hit the park path, where `Create` now reserves before dispatch and
the resume goroutine releases on completion — the reservation window is
unchanged in extent, only its Reserve call moved up one frame. Verified with the
existing replay unit suite (all green) and `go test -race`.

## Tests

`internal/adapter/smb/v2/handlers/replay_dhv2_test.go`:

- `TestResolveCreateReplay_NoOplockPendingReserved` — models the no-oplock
  inline conflict: reserve the guid, assert a concurrent replay returns
  `STATUS_FILE_NOT_AVAILABLE`, a non-replay duplicate falls through, and after
  Release (no cached entry) a fresh replay falls through — proving no leak.
- `TestCreateReplayCache_ReserveReleaseSingleReservation` — proves the
  single-logical-reservation invariant: idempotent Reserve, one Release fully
  clears, an extra Release is a harmless no-op, zero guid never tracked.

All existing replay tests stay green; `go vet`, `golangci-lint`, and
`go test -race ./internal/adapter/smb/v2/handlers/...` all pass.

Targets the `smb2.durable-v2-open` / `replay-dhv2-pending1n-*-sane` family.
Refs #749.
