### PR TITLE
feat(metadata): add ClientRecoveryStore for v4 reboot recovery (area-4 H8 slice 1)

### DIFF
--- a/pkg/metadata/lock/client_recovery_store.go
+++ b/pkg/metadata/lock/client_recovery_store.go
@@ -1,0 +1,89 @@
+package lock
+
+import (
+	"context"
+	"time"
+)
+
+// ============================================================================
+// NFSv4 Client Recovery Persistence (reboot/grace recovery)
+// ============================================================================
+
+// V4ClientRecoveryRecord is the durable representation of a confirmed NFSv4
+// client identity. It is the DittoFS analog of the Linux nfsd client-record:
+// intentionally tiny — id + boot verifier + principal — with NO opens, NO
+// locks, and NO stateids. After an ungraceful restart the server reads the set
+// of recovery records to know which clients may reclaim their prior state
+// during the grace period (RFC 7530 §9.1.4 / RFC 8881 §8.4.2).
+//
+// Records are server-GLOBAL. The NFSv4 clientid namespace is not owned by any
+// share, so the record is keyed by ClientIDString (the stable client identity
+// from nfs_client_id4.id), not by share.
+type V4ClientRecoveryRecord struct {
+	// ClientID is the server-assigned clientid (epoch<<32 | seq) minted at
+	// confirm time. Stored for diagnostics and stale-record correlation.
+	ClientID uint64
+
+	// ClientIDString is nfs_client_id4.id, the stable client identity. This
+	// is the primary key for the record across all backends.
+	ClientIDString string
+
+	// BootVerifier is the client boot verifier captured at confirm time.
+	// A reclaiming client whose verifier changed rebooted and must NOT
+	// reclaim old state (SETCLIENTID Case-3 path). Round-trips byte-exact
+	// through every backend.
+	BootVerifier [8]byte
+
+	// Principal is the RPCSEC_GSS / AUTH_SYS principal that confirmed the
+	// client. Used as a lease-stealing guard at reclaim time.
+	Principal string
+
+	// ConfirmedAt is when the client was confirmed.
+	ConfirmedAt time.Time
+
+	// ServerEpoch is the epoch under which the client confirmed. Used to GC
+	// stale records from previous server instances.
+	ServerEpoch uint64
+
+	// ReclaimComplete records that this client finished reclaim (v4.1
+	// RECLAIM_COMPLETE, or first successful CLAIM_PREVIOUS for v4.0). It is
+	// the minimal representation of the "reclaim done" marker: persisting it
+	// means a SECOND restart inside one grace window does not wait on a
+	// client that already reclaimed. Set via RecordReclaimComplete and
+	// reported back through ListClientRecovery.
+	ReclaimComplete bool
+}
+
+// ClientRecoveryStore provides server-global persistence for confirmed NFSv4
+// client identities, enabling grace/reclaim after a server restart.
+// Implementations exist in memory, badger, and postgres stores.
+//
+// Recovery flow:
+//  1. On SETCLIENTID_CONFIRM (v4.0) / EXCHANGE_ID-confirm (v4.1):
+//     PutClientRecovery records the confirmed client.
+//  2. On lease expiry / DESTROY_CLIENTID: DeleteClientRecovery removes it.
+//  3. On RECLAIM_COMPLETE (or first CLAIM_PREVIOUS for v4.0):
+//     RecordReclaimComplete marks reclaim done.
+//  4. On boot: ListClientRecovery returns the expected reclaim set.
+//
+// This slice adds ONLY the store; the v4 state manager wiring lands separately.
+type ClientRecoveryStore interface {
+	// PutClientRecovery stores or replaces the recovery record for a
+	// confirmed client. Keyed by ClientIDString: a second Put with the same
+	// ClientIDString replaces the prior record (latest wins, one row).
+	PutClientRecovery(ctx context.Context, rec *V4ClientRecoveryRecord) error
+
+	// DeleteClientRecovery removes the recovery record for a client.
+	// Returns nil if no record exists.
+	DeleteClientRecovery(ctx context.Context, clientIDString string) error
+
+	// ListClientRecovery returns all stored recovery records. An empty store
+	// returns an empty slice (not an error). Used on boot to compute the
+	// expected reclaim set.
+	ListClientRecovery(ctx context.Context) ([]*V4ClientRecoveryRecord, error)
+
+	// RecordReclaimComplete persists that the client finished reclaim by
+	// setting ReclaimComplete on its record. Returns nil if no record
+	// exists for the client (nothing to mark).
+	RecordReclaimComplete(ctx context.Context, clientIDString string) error
+}

--- a/pkg/metadata/store/badger/client_recovery.go
+++ b/pkg/metadata/store/badger/client_recovery.go
@@ -1,0 +1,186 @@
+package badger
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// BadgerDB ClientRecoveryStore Implementation
+// ============================================================================
+
+// Key prefix for NFSv4 client-recovery storage.
+//
+//	crec:{clientIDString} -> JSON(V4ClientRecoveryRecord)
+//
+// The JSON encoding of BootVerifier [8]byte is a numeric array, which
+// round-trips byte-exact. List is a prefix scan.
+const prefixV4ClientRecovery = "crec:"
+
+// badgerRecoveryStore implements lock.ClientRecoveryStore using BadgerDB.
+//
+// Storage Model:
+//   - crec:{clientIDString} -> JSON(V4ClientRecoveryRecord)
+//
+// Thread Safety:
+// All operations use BadgerDB's transaction support for atomicity.
+type badgerRecoveryStore struct {
+	db *badgerdb.DB
+}
+
+// newBadgerRecoveryStore creates a new BadgerDB client recovery store.
+func newBadgerRecoveryStore(db *badgerdb.DB) *badgerRecoveryStore {
+	return &badgerRecoveryStore{db: db}
+}
+
+// PutClientRecovery stores or replaces the record for a confirmed client.
+func (s *badgerRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal client recovery record: %w", err)
+	}
+
+	return s.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set([]byte(prefixV4ClientRecovery+rec.ClientIDString), data)
+	})
+}
+
+// DeleteClientRecovery removes the record for a client.
+func (s *badgerRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return s.db.Update(func(txn *badgerdb.Txn) error {
+		err := txn.Delete([]byte(prefixV4ClientRecovery + clientIDString))
+		if err == badgerdb.ErrKeyNotFound {
+			return nil
+		}
+		return err
+	})
+}
+
+// ListClientRecovery returns all stored records via a prefix scan.
+func (s *badgerRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]*lock.V4ClientRecoveryRecord, 0)
+
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.Prefix = []byte(prefixV4ClientRecovery)
+
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			err := it.Item().Value(func(val []byte) error {
+				rec := &lock.V4ClientRecoveryRecord{}
+				if err := json.Unmarshal(val, rec); err != nil {
+					return err
+				}
+				result = append(result, rec)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// RecordReclaimComplete marks the client's record reclaim-complete. The
+// read-modify-write happens inside one transaction for atomicity. Missing
+// record => no-op, not an error.
+func (s *badgerRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return s.db.Update(func(txn *badgerdb.Txn) error {
+		key := []byte(prefixV4ClientRecovery + clientIDString)
+		item, err := txn.Get(key)
+		if err == badgerdb.ErrKeyNotFound {
+			return nil // Nothing to mark
+		}
+		if err != nil {
+			return err
+		}
+
+		var rec lock.V4ClientRecoveryRecord
+		if err := item.Value(func(val []byte) error {
+			return json.Unmarshal(val, &rec)
+		}); err != nil {
+			return err
+		}
+
+		if rec.ReclaimComplete {
+			return nil // Already marked
+		}
+		rec.ReclaimComplete = true
+
+		data, err := json.Marshal(&rec)
+		if err != nil {
+			return fmt.Errorf("failed to marshal client recovery record: %w", err)
+		}
+		return txn.Set(key, data)
+	})
+}
+
+// ============================================================================
+// BadgerMetadataStore ClientRecoveryStore Integration
+// ============================================================================
+
+// Ensure BadgerMetadataStore implements ClientRecoveryStore.
+var _ lock.ClientRecoveryStore = (*BadgerMetadataStore)(nil)
+
+// getRecoveryStore returns the recovery store, initializing if needed.
+func (s *BadgerMetadataStore) getRecoveryStore() *badgerRecoveryStore {
+	s.recoveryStoreMu.Lock()
+	defer s.recoveryStoreMu.Unlock()
+	if s.recoveryStore == nil {
+		s.recoveryStore = newBadgerRecoveryStore(s.db)
+	}
+	return s.recoveryStore
+}
+
+// PutClientRecovery stores or replaces a client recovery record.
+func (s *BadgerMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+}
+
+// DeleteClientRecovery removes a client recovery record.
+func (s *BadgerMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+}
+
+// ListClientRecovery returns all stored client recovery records.
+func (s *BadgerMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	return s.getRecoveryStore().ListClientRecovery(ctx)
+}
+
+// RecordReclaimComplete marks a client's recovery record reclaim-complete.
+func (s *BadgerMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+}
+
+// ClientRecoveryStore returns this store as a ClientRecoveryStore.
+// This allows direct access to the interface for handler initialization.
+func (s *BadgerMetadataStore) ClientRecoveryStore() lock.ClientRecoveryStore {
+	return s
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -109,6 +109,10 @@ type BadgerMetadataStore struct {
 	durableStore   *badgerDurableStore
 	durableStoreMu sync.Mutex
 
+	// recoveryStore provides NFSv4 client-recovery persistence
+	recoveryStore   *badgerRecoveryStore
+	recoveryStoreMu sync.Mutex
+
 	// usedBytes tracks the total logical bytes used by regular files.
 	// Updated atomically on every size-changing operation (create, update, truncate, delete).
 	// Initialized from a full file scan on startup.

--- a/pkg/metadata/store/memory/client_recovery.go
+++ b/pkg/metadata/store/memory/client_recovery.go
@@ -1,0 +1,174 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// Memory ClientRecoveryStore Implementation
+// ============================================================================
+
+// memoryRecoveryStore implements lock.ClientRecoveryStore using in-memory
+// storage. Records are server-global, keyed by ClientIDString.
+//
+// Thread Safety:
+// All operations are protected by a read-write mutex. Returned records are
+// deep copies so callers can never alias or mutate the stored record.
+type memoryRecoveryStore struct {
+	mu sync.RWMutex
+
+	// records maps ClientIDString to its recovery record.
+	records map[string]*lock.V4ClientRecoveryRecord
+}
+
+// newMemoryRecoveryStore creates a new in-memory client recovery store.
+func newMemoryRecoveryStore() *memoryRecoveryStore {
+	return &memoryRecoveryStore{
+		records: make(map[string]*lock.V4ClientRecoveryRecord),
+	}
+}
+
+// cloneRecoveryRecord deep-copies a recovery record. BootVerifier is a value
+// array so the struct copy duplicates it; there are no reference fields, but
+// the explicit clone documents the no-aliasing contract.
+func cloneRecoveryRecord(rec *lock.V4ClientRecoveryRecord) *lock.V4ClientRecoveryRecord {
+	if rec == nil {
+		return nil
+	}
+	cp := *rec
+	return &cp
+}
+
+// PutClientRecovery stores or replaces the record for a confirmed client.
+func (s *memoryRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Store a clone so a later mutation of the caller's record does not
+	// leak into the store.
+	s.records[rec.ClientIDString] = cloneRecoveryRecord(rec)
+	return nil
+}
+
+// DeleteClientRecovery removes the record for a client.
+func (s *memoryRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.records, clientIDString)
+	return nil
+}
+
+// ListClientRecovery returns all stored records as deep copies.
+func (s *memoryRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]*lock.V4ClientRecoveryRecord, 0, len(s.records))
+	for _, rec := range s.records {
+		result = append(result, cloneRecoveryRecord(rec))
+	}
+	return result, nil
+}
+
+// RecordReclaimComplete marks the client's record as reclaim-complete.
+func (s *memoryRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if rec, ok := s.records[clientIDString]; ok {
+		rec.ReclaimComplete = true
+	}
+	// No record => nothing to mark, not an error.
+	return nil
+}
+
+// ============================================================================
+// MemoryMetadataStore ClientRecoveryStore Integration
+// ============================================================================
+
+// Ensure MemoryMetadataStore implements ClientRecoveryStore.
+var _ lock.ClientRecoveryStore = (*MemoryMetadataStore)(nil)
+
+// initRecoveryStore ensures the recovery store is initialized.
+// Must be called with the store's write lock held.
+func (s *MemoryMetadataStore) initRecoveryStore() {
+	if s.recoveryStore == nil {
+		s.recoveryStore = newMemoryRecoveryStore()
+	}
+}
+
+// PutClientRecovery stores or replaces a client recovery record.
+func (s *MemoryMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initRecoveryStore()
+	return s.recoveryStore.PutClientRecovery(ctx, rec)
+}
+
+// DeleteClientRecovery removes a client recovery record.
+func (s *MemoryMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.recoveryStore == nil {
+		return nil // Nothing to delete
+	}
+	return s.recoveryStore.DeleteClientRecovery(ctx, clientIDString)
+}
+
+// ListClientRecovery returns all stored client recovery records.
+func (s *MemoryMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.recoveryStore == nil {
+		return []*lock.V4ClientRecoveryRecord{}, nil
+	}
+	return s.recoveryStore.ListClientRecovery(ctx)
+}
+
+// RecordReclaimComplete marks a client's recovery record reclaim-complete.
+func (s *MemoryMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.recoveryStore == nil {
+		return nil // Nothing to mark
+	}
+	return s.recoveryStore.RecordReclaimComplete(ctx, clientIDString)
+}
+
+// ClientRecoveryStore returns this store as a ClientRecoveryStore.
+// This allows direct access to the interface for handler initialization.
+func (s *MemoryMetadataStore) ClientRecoveryStore() lock.ClientRecoveryStore {
+	return s
+}

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -41,6 +41,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.lockStore = nil
 	s.clientStore = nil
 	s.durableStore = nil
+	s.recoveryStore = nil
 
 	s.usedBytes.Store(0)
 

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -223,6 +223,10 @@ type MemoryMetadataStore struct {
 	// Initialized lazily on first use.
 	durableStore *memoryDurableStore
 
+	// recoveryStore holds NFSv4 client-recovery records for reboot/grace
+	// recovery. Initialized lazily on first use.
+	recoveryStore *memoryRecoveryStore
+
 	// usedBytes tracks the total logical bytes used by regular files.
 	// Updated atomically on every size-changing operation (create, update, truncate, delete).
 	// Only regular files count toward usage; directories, symlinks, etc. do not.

--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -26,7 +26,8 @@ const (
 	// postgresSchemaVersion is the backup payload schema version.
 	// Increment when the payload layout changes (new table, changed
 	// framing, etc.) and add a migration path in Restore.
-	postgresSchemaVersion = uint32(1)
+	// v2 adds the v4_client_recovery table section.
+	postgresSchemaVersion = uint32(2)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order
@@ -50,6 +51,7 @@ var backupTables = []string{
 	"server_epoch",
 	"nsm_client_registrations",
 	"durable_handles",
+	"v4_client_recovery",
 	"rollup_offsets",
 	"synced_hashes",
 }

--- a/pkg/metadata/store/postgres/client_recovery.go
+++ b/pkg/metadata/store/postgres/client_recovery.go
@@ -1,0 +1,181 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// PostgreSQL ClientRecoveryStore Implementation
+// ============================================================================
+
+// postgresRecoveryStore implements lock.ClientRecoveryStore using PostgreSQL.
+//
+// Storage Model:
+//   - v4_client_recovery table: stores V4ClientRecoveryRecord
+//   - keyed by clientid_string (server-global; share is not part of the key)
+//
+// Thread Safety:
+// All operations are single statements executed against the connection pool.
+type postgresRecoveryStore struct {
+	pool *pgxpool.Pool
+}
+
+// newPostgresRecoveryStore creates a new PostgreSQL client recovery store.
+func newPostgresRecoveryStore(pool *pgxpool.Pool) *postgresRecoveryStore {
+	return &postgresRecoveryStore{pool: pool}
+}
+
+// PutClientRecovery stores or replaces the record for a confirmed client using
+// an upsert keyed by clientid_string (latest wins, one row).
+//
+// Put REPLACES the full record, reclaim_complete included, to stay byte-for-byte
+// identical to the memory/badger backends (which overwrite the whole struct).
+// Semantically a re-confirm means the client's state is fresh, so reclaim starts
+// over; callers persist reclaim completion through RecordReclaimComplete, not
+// through Put.
+func (s *postgresRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	query := `
+		INSERT INTO v4_client_recovery (
+			clientid_string, clientid, boot_verifier, principal,
+			confirmed_at, server_epoch, reclaim_complete
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (clientid_string) DO UPDATE SET
+			clientid = EXCLUDED.clientid,
+			boot_verifier = EXCLUDED.boot_verifier,
+			principal = EXCLUDED.principal,
+			confirmed_at = EXCLUDED.confirmed_at,
+			server_epoch = EXCLUDED.server_epoch,
+			reclaim_complete = EXCLUDED.reclaim_complete
+	`
+
+	_, err := s.pool.Exec(ctx, query,
+		rec.ClientIDString,
+		int64(rec.ClientID),
+		rec.BootVerifier[:], // [8]byte -> BYTEA
+		rec.Principal,
+		rec.ConfirmedAt,
+		int64(rec.ServerEpoch),
+		rec.ReclaimComplete,
+	)
+	return err
+}
+
+// DeleteClientRecovery removes the record for a client.
+func (s *postgresRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	query := `DELETE FROM v4_client_recovery WHERE clientid_string = $1`
+	_, err := s.pool.Exec(ctx, query, clientIDString)
+	return err
+}
+
+// scanRecoveryRecord scans one row into a V4ClientRecoveryRecord, copying the
+// BYTEA boot_verifier into the fixed [8]byte array.
+func scanRecoveryRecord(row pgx.Row) (*lock.V4ClientRecoveryRecord, error) {
+	var rec lock.V4ClientRecoveryRecord
+	var clientID, serverEpoch int64
+	var bootVerifier []byte
+
+	err := row.Scan(
+		&rec.ClientIDString,
+		&clientID,
+		&bootVerifier,
+		&rec.Principal,
+		&rec.ConfirmedAt,
+		&serverEpoch,
+		&rec.ReclaimComplete,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rec.ClientID = uint64(clientID)
+	rec.ServerEpoch = uint64(serverEpoch)
+	if len(bootVerifier) == 8 {
+		copy(rec.BootVerifier[:], bootVerifier)
+	}
+	return &rec, nil
+}
+
+// ListClientRecovery returns all stored records.
+func (s *postgresRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	query := `
+		SELECT clientid_string, clientid, boot_verifier, principal,
+		       confirmed_at, server_epoch, reclaim_complete
+		FROM v4_client_recovery
+		ORDER BY confirmed_at
+	`
+
+	rows, err := s.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]*lock.V4ClientRecoveryRecord, 0)
+	for rows.Next() {
+		rec, err := scanRecoveryRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// RecordReclaimComplete marks the client's record reclaim-complete. A missing
+// record is a no-op (RowsAffected == 0), not an error.
+func (s *postgresRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	query := `UPDATE v4_client_recovery SET reclaim_complete = TRUE WHERE clientid_string = $1`
+	_, err := s.pool.Exec(ctx, query, clientIDString)
+	return err
+}
+
+// ============================================================================
+// PostgresMetadataStore ClientRecoveryStore Integration
+// ============================================================================
+
+// Ensure PostgresMetadataStore implements ClientRecoveryStore.
+var _ lock.ClientRecoveryStore = (*PostgresMetadataStore)(nil)
+
+// getRecoveryStore returns the recovery store, initializing if needed.
+func (s *PostgresMetadataStore) getRecoveryStore() *postgresRecoveryStore {
+	s.recoveryStoreMu.Lock()
+	defer s.recoveryStoreMu.Unlock()
+	if s.recoveryStore == nil {
+		s.recoveryStore = newPostgresRecoveryStore(s.pool)
+	}
+	return s.recoveryStore
+}
+
+// PutClientRecovery stores or replaces a client recovery record.
+func (s *PostgresMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+}
+
+// DeleteClientRecovery removes a client recovery record.
+func (s *PostgresMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+}
+
+// ListClientRecovery returns all stored client recovery records.
+func (s *PostgresMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	return s.getRecoveryStore().ListClientRecovery(ctx)
+}
+
+// RecordReclaimComplete marks a client's recovery record reclaim-complete.
+func (s *PostgresMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+}
+
+// ClientRecoveryStore returns this store as a ClientRecoveryStore.
+// This allows direct access to the interface for handler initialization.
+func (s *PostgresMetadataStore) ClientRecoveryStore() lock.ClientRecoveryStore {
+	return s
+}

--- a/pkg/metadata/store/postgres/migrations/000025_v4_client_recovery.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000025_v4_client_recovery.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS v4_client_recovery;

--- a/pkg/metadata/store/postgres/migrations/000025_v4_client_recovery.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000025_v4_client_recovery.up.sql
@@ -1,0 +1,30 @@
+-- Migration: NFSv4 client-recovery records for reboot/grace recovery (area-4 H8).
+--
+-- Persists the set of confirmed NFSv4 client identities so that after a server
+-- restart the grace machinery knows which clients may reclaim their prior state
+-- (RFC 7530 §9.1.4 / RFC 8881 §8.4.2). This is the DittoFS analog of the Linux
+-- nfsd client-record: id + boot verifier + principal only — no opens, no locks,
+-- no stateids.
+--
+-- Records are server-GLOBAL (the v4 clientid namespace is not owned by any
+-- share), keyed by clientid_string (nfs_client_id4.id, the stable client
+-- identity). reclaim_complete records that a client finished reclaim so a
+-- SECOND restart inside one grace window does not wait on an already-done
+-- client; it defaults FALSE.
+--
+-- This slice adds only the table; the v4 state-manager wiring lands separately.
+
+CREATE TABLE IF NOT EXISTS v4_client_recovery (
+    clientid_string  TEXT PRIMARY KEY,
+    clientid         BIGINT NOT NULL,
+    boot_verifier    BYTEA NOT NULL,
+    principal        TEXT NOT NULL,
+    confirmed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    server_epoch     BIGINT NOT NULL,
+    reclaim_complete BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT valid_boot_verifier_length CHECK (length(boot_verifier) = 8)
+);
+
+-- Index on server_epoch for stale-record GC across server instances.
+CREATE INDEX IF NOT EXISTS idx_v4_client_recovery_server_epoch ON v4_client_recovery(server_epoch);

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -53,6 +53,11 @@ type PostgresMetadataStore struct {
 	durableStore   *postgresDurableStore
 	durableStoreMu sync.Mutex
 
+	// recoveryStore holds NFSv4 client-recovery persistence.
+	// Initialized lazily via getRecoveryStore().
+	recoveryStore   *postgresRecoveryStore
+	recoveryStoreMu sync.Mutex
+
 	// usedBytes tracks the total logical bytes used by regular files.
 	// Updated atomically on every size-changing operation (create, update, truncate, delete).
 	// Initialized from a SQL SUM query on startup.

--- a/pkg/metadata/storetest/client_recovery.go
+++ b/pkg/metadata/storetest/client_recovery.go
@@ -1,0 +1,298 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ClientRecoveryStoreProvider is implemented by metadata stores that expose a
+// ClientRecoveryStore. The conformance suite type-asserts the store to this
+// interface and skips if unimplemented.
+type ClientRecoveryStoreProvider interface {
+	ClientRecoveryStore() lock.ClientRecoveryStore
+}
+
+// recoveryTimeTolerance bounds ConfirmedAt round-trip drift. Postgres stores
+// TIMESTAMPTZ at microsecond resolution, so values must be chosen at that
+// granularity; the tolerance absorbs any residual rounding.
+const recoveryTimeTolerance = time.Millisecond
+
+// RunClientRecoveryStoreTests runs the cross-backend conformance suite for
+// ClientRecoveryStore. The factory creates a fresh MetadataStore per subtest.
+func RunClientRecoveryStoreTests(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	store := factory(t)
+	provider, ok := store.(ClientRecoveryStoreProvider)
+	if !ok {
+		t.Skip("store does not implement ClientRecoveryStoreProvider")
+		return
+	}
+	_ = provider.ClientRecoveryStore()
+
+	t.Run("PutListRoundTrip", func(t *testing.T) {
+		testRecoveryPutListRoundTrip(t, factory)
+	})
+	t.Run("PutUpsert", func(t *testing.T) {
+		testRecoveryPutUpsert(t, factory)
+	})
+	t.Run("Delete", func(t *testing.T) {
+		testRecoveryDelete(t, factory)
+	})
+	t.Run("RecordReclaimComplete", func(t *testing.T) {
+		testRecoveryRecordReclaimComplete(t, factory)
+	})
+	t.Run("ListEmpty", func(t *testing.T) {
+		testRecoveryListEmpty(t, factory)
+	})
+	t.Run("DeleteNonExistent", func(t *testing.T) {
+		testRecoveryDeleteNonExistent(t, factory)
+	})
+	t.Run("ReclaimCompleteNonExistent", func(t *testing.T) {
+		testRecoveryReclaimCompleteNonExistent(t, factory)
+	})
+}
+
+// recoveryStoreFromFactory builds a store and returns its ClientRecoveryStore.
+func recoveryStoreFromFactory(t *testing.T, factory StoreFactory) lock.ClientRecoveryStore {
+	t.Helper()
+	store := factory(t)
+	provider, ok := store.(ClientRecoveryStoreProvider)
+	if !ok {
+		t.Skip("store does not implement ClientRecoveryStoreProvider")
+	}
+	return provider.ClientRecoveryStore()
+}
+
+// assertRecoveryEqual asserts every field of a recovery record matches, with a
+// tolerance on the ConfirmedAt timestamp.
+func assertRecoveryEqual(t *testing.T, want, got *lock.V4ClientRecoveryRecord) {
+	t.Helper()
+	if want.ClientID != got.ClientID {
+		t.Errorf("ClientID: want %d, got %d", want.ClientID, got.ClientID)
+	}
+	if want.ClientIDString != got.ClientIDString {
+		t.Errorf("ClientIDString: want %q, got %q", want.ClientIDString, got.ClientIDString)
+	}
+	if want.BootVerifier != got.BootVerifier {
+		t.Errorf("BootVerifier: want %v, got %v", want.BootVerifier, got.BootVerifier)
+	}
+	if want.Principal != got.Principal {
+		t.Errorf("Principal: want %q, got %q", want.Principal, got.Principal)
+	}
+	if want.ServerEpoch != got.ServerEpoch {
+		t.Errorf("ServerEpoch: want %d, got %d", want.ServerEpoch, got.ServerEpoch)
+	}
+	if want.ReclaimComplete != got.ReclaimComplete {
+		t.Errorf("ReclaimComplete: want %v, got %v", want.ReclaimComplete, got.ReclaimComplete)
+	}
+	diff := want.ConfirmedAt.Sub(got.ConfirmedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > recoveryTimeTolerance {
+		t.Errorf("ConfirmedAt: want %v, got %v (diff %v)", want.ConfirmedAt, got.ConfirmedAt, diff)
+	}
+}
+
+// findRecovery returns the record with the given clientIDString, or nil.
+func findRecovery(recs []*lock.V4ClientRecoveryRecord, clientIDString string) *lock.V4ClientRecoveryRecord {
+	for _, r := range recs {
+		if r.ClientIDString == clientIDString {
+			return r
+		}
+	}
+	return nil
+}
+
+func testRecoveryPutListRoundTrip(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	want := &lock.V4ClientRecoveryRecord{
+		ClientID:        0x0000000100000007,
+		ClientIDString:  "linux-client-aabbccdd",
+		BootVerifier:    [8]byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04},
+		Principal:       "user@EXAMPLE.COM",
+		ConfirmedAt:     time.Date(2026, 1, 2, 3, 4, 5, 6000, time.UTC),
+		ServerEpoch:     42,
+		ReclaimComplete: false,
+	}
+	if err := store.PutClientRecovery(ctx, want); err != nil {
+		t.Fatalf("PutClientRecovery() failed: %v", err)
+	}
+
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() failed: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("ListClientRecovery() returned %d records, want 1", len(recs))
+	}
+	assertRecoveryEqual(t, want, recs[0])
+}
+
+func testRecoveryPutUpsert(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	const id = "client-upsert"
+	first := &lock.V4ClientRecoveryRecord{
+		ClientID:       1,
+		ClientIDString: id,
+		BootVerifier:   [8]byte{1, 1, 1, 1, 1, 1, 1, 1},
+		Principal:      "first@REALM",
+		ConfirmedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ServerEpoch:    1,
+	}
+	if err := store.PutClientRecovery(ctx, first); err != nil {
+		t.Fatalf("PutClientRecovery(first) failed: %v", err)
+	}
+
+	second := &lock.V4ClientRecoveryRecord{
+		ClientID:       2,
+		ClientIDString: id, // same key
+		BootVerifier:   [8]byte{2, 2, 2, 2, 2, 2, 2, 2},
+		Principal:      "second@REALM",
+		ConfirmedAt:    time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
+		ServerEpoch:    2,
+	}
+	if err := store.PutClientRecovery(ctx, second); err != nil {
+		t.Fatalf("PutClientRecovery(second) failed: %v", err)
+	}
+
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() failed: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("upsert produced %d rows, want 1 (latest wins)", len(recs))
+	}
+	assertRecoveryEqual(t, second, recs[0])
+}
+
+func testRecoveryDelete(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	a := &lock.V4ClientRecoveryRecord{
+		ClientID: 1, ClientIDString: "del-a", BootVerifier: [8]byte{9},
+		Principal: "a", ConfirmedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), ServerEpoch: 1,
+	}
+	b := &lock.V4ClientRecoveryRecord{
+		ClientID: 2, ClientIDString: "del-b", BootVerifier: [8]byte{8},
+		Principal: "b", ConfirmedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), ServerEpoch: 1,
+	}
+	if err := store.PutClientRecovery(ctx, a); err != nil {
+		t.Fatalf("Put(a) failed: %v", err)
+	}
+	if err := store.PutClientRecovery(ctx, b); err != nil {
+		t.Fatalf("Put(b) failed: %v", err)
+	}
+
+	if err := store.DeleteClientRecovery(ctx, "del-a"); err != nil {
+		t.Fatalf("DeleteClientRecovery() failed: %v", err)
+	}
+
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() failed: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("after delete got %d records, want 1", len(recs))
+	}
+	if findRecovery(recs, "del-a") != nil {
+		t.Errorf("deleted record del-a still present")
+	}
+	if findRecovery(recs, "del-b") == nil {
+		t.Errorf("record del-b unexpectedly removed")
+	}
+}
+
+func testRecoveryRecordReclaimComplete(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	rec := &lock.V4ClientRecoveryRecord{
+		ClientID: 7, ClientIDString: "reclaim-client", BootVerifier: [8]byte{5, 5, 5},
+		Principal: "p@R", ConfirmedAt: time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC), ServerEpoch: 3,
+	}
+	if err := store.PutClientRecovery(ctx, rec); err != nil {
+		t.Fatalf("PutClientRecovery() failed: %v", err)
+	}
+
+	// Before marking: ReclaimComplete is false.
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() failed: %v", err)
+	}
+	got := findRecovery(recs, "reclaim-client")
+	if got == nil {
+		t.Fatalf("record not found before reclaim")
+	}
+	if got.ReclaimComplete {
+		t.Errorf("ReclaimComplete true before RecordReclaimComplete")
+	}
+
+	if err := store.RecordReclaimComplete(ctx, "reclaim-client"); err != nil {
+		t.Fatalf("RecordReclaimComplete() failed: %v", err)
+	}
+
+	recs, err = store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() after reclaim failed: %v", err)
+	}
+	got = findRecovery(recs, "reclaim-client")
+	if got == nil {
+		t.Fatalf("record not found after reclaim")
+	}
+	if !got.ReclaimComplete {
+		t.Errorf("ReclaimComplete not reflected in List after RecordReclaimComplete")
+	}
+	// Other fields must be intact after the in-place mark.
+	if got.Principal != rec.Principal || got.ServerEpoch != rec.ServerEpoch ||
+		got.BootVerifier != rec.BootVerifier || got.ClientID != rec.ClientID {
+		t.Errorf("RecordReclaimComplete mutated unrelated fields: got %+v", got)
+	}
+}
+
+func testRecoveryListEmpty(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() on empty store errored: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("empty store returned %d records, want 0", len(recs))
+	}
+}
+
+func testRecoveryDeleteNonExistent(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	if err := store.DeleteClientRecovery(ctx, "does-not-exist"); err != nil {
+		t.Fatalf("DeleteClientRecovery(missing) errored: %v", err)
+	}
+}
+
+func testRecoveryReclaimCompleteNonExistent(t *testing.T, factory StoreFactory) {
+	store := recoveryStoreFromFactory(t, factory)
+	ctx := context.Background()
+
+	if err := store.RecordReclaimComplete(ctx, "does-not-exist"); err != nil {
+		t.Fatalf("RecordReclaimComplete(missing) errored: %v", err)
+	}
+	recs, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		t.Fatalf("ListClientRecovery() failed: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("RecordReclaimComplete on missing client created a row: got %d", len(recs))
+	}
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -59,6 +59,15 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		RunDurableHandleStoreTests(t, factory)
 	})
 
+	// ClientRecovery covers the server-global NFSv4 client-recovery store
+	// (Put/List round-trip incl. BootVerifier bytes, upsert, Delete,
+	// RecordReclaimComplete, empty-list). Cross-backend parity is the point:
+	// the shared suite catches divergence (e.g. upsert producing dup rows,
+	// or List erroring on empty). Stores lacking ClientRecoveryStore skip.
+	t.Run("ClientRecovery", func(t *testing.T) {
+		RunClientRecoveryStoreTests(t, factory)
+	})
+
 	// ACLAliasing asserts both directions of FileAttr.ACL deep-copy
 	// discipline: PutFile must not alias the caller's ACE slice, and
 	// GetFile must not hand back the store's backing slice. Pins the


### PR DESCRIPTION
## What

Foundation for **H8 (NFSv4 state durability)** from the area-4 durable-state audit. Implements the `ClientRecoveryStore` exactly as specified in `DURABLE-STATE-DESIGN.md` §3.2–3.3: a server-global store that persists confirmed NFSv4 **client identities** (id + boot verifier + principal) so the grace machinery knows which clients may reclaim prior state after a restart.

Intentionally tiny — the DittoFS analog of the Linux nfsd client-record: **no opens, no locks, no stateids.**

## Interface (`pkg/metadata/lock/client_recovery_store.go`)

`V4ClientRecoveryRecord` { ClientID, ClientIDString, BootVerifier [8]byte, Principal, ConfirmedAt, ServerEpoch, **ReclaimComplete bool** }

```go
type ClientRecoveryStore interface {
    PutClientRecovery(ctx, *V4ClientRecoveryRecord) error
    DeleteClientRecovery(ctx, clientIDString string) error
    ListClientRecovery(ctx) ([]*V4ClientRecoveryRecord, error)
    RecordReclaimComplete(ctx, clientIDString string) error
}
```

- Keyed by **ClientIDString** (stable client identity); server-global, share is not part of the key.
- **`RecordReclaimComplete` is represented as a `ReclaimComplete bool` on the record** — the simplest representation across all 3 backends and directly reportable through `ListClientRecovery`. A second restart inside one grace window can skip already-reclaimed clients.

## Backends

- **memory** — in-struct map keyed by ClientIDString, mutex-guarded, deep-copy on return (no aliasing).
- **badger** — `crec:` key prefix, JSON-encoded value (BootVerifier round-trips byte-exact as a numeric array); List = prefix scan.
- **postgres** — new table `v4_client_recovery` (clientid_string PK, BYTEA boot_verifier with length=8 CHECK, reclaim_complete BOOLEAN DEFAULT FALSE), `ON CONFLICT` upsert. **Migration 000025** (up/down, idempotent; develop topped at 000024). Table added to the backup/restore + reset table set; backup schema version bumped to 2.

## Conformance

Cross-backend `ClientRecovery` scenario added to the shared `storetest` suite (runs for memory + badger + postgres): Put→List round-trip (all fields incl. BootVerifier bytes, Principal, ServerEpoch, ConfirmedAt), upsert (one row, latest wins), Delete, RecordReclaimComplete reflected in List, empty-list→empty (not error), missing-key no-ops.

## Verification

- `gofmt`, `go vet`, `golangci-lint` — clean.
- `go test -race ./pkg/metadata/...` — green.
- Conformance passes for **memory + badger + postgres** (verified locally against a Postgres 16 container; migration 000025 applies cleanly and the down reverses it).

## Scope

**Store only — NO v4-layer wiring** (state manager, handlers, NSM untouched). That is slice 2, a later PR. DO NOT MERGE-coupled with anything else.