### PR TITLE
fix(smb/replay): cross-request DH2 reservation + two-phase status for pending1 (#749)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -1392,9 +1392,39 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	resp := h.completeCreateAfterBreak(ctx, draft)
 	if reservedReplay {
-		h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
+		h.resolveCreateReplayReservation(ctx.SessionID, replayGuid, resp.GetStatus())
 	}
 	return resp, nil
+}
+
+// resolveCreateReplayReservation closes out a CreateGuid reservation taken for
+// a conflicting (pending) original CREATE once that CREATE reaches a terminal
+// state, applying the two-phase MS-SMB2 §3.3.5.9 rule (Samba bug 14449
+// smb2.replay.dhv2-pending1*):
+//
+//   - success: the success response was just cached via Store, so the
+//     reservation is released; a later replay returns the cached open.
+//   - terminal share-mode failure (STATUS_SHARING_VIOLATION / ACCESS_DENIED):
+//     the reservation transitions to Phase B carrying that status, so a later
+//     replay returns the SAME terminal status instead of re-running CREATE and
+//     re-parking (replay.dhv2-pending1n-vs-violation-lease-ack-* replay23). The
+//     Phase-B reservation is reaped by session teardown / the TTL backstop.
+//   - any other failure (transient / internal): released, matching the prior
+//     behaviour so a genuine retry can re-run the CREATE fresh.
+//
+// It is the single seam shared by the inline-completion path (Create) and the
+// async-park resume goroutine (parkCreateOnLeaseBreak) so the reservation
+// lifetime is identical on both. A zero CreateGuid is a no-op throughout.
+func (h *Handler) resolveCreateReplayReservation(sessionID uint64, createGuid [16]byte, status types.Status) {
+	if h.CreateReplayCache == nil {
+		return
+	}
+	switch status {
+	case types.StatusSharingViolation, types.StatusAccessDenied:
+		h.CreateReplayCache.UpdateReservedStatus(sessionID, createGuid, status)
+	default:
+		h.CreateReplayCache.Release(sessionID, createGuid)
+	}
 }
 
 // computeMaximalAccess computes the maximal access mask for a file used in
@@ -1607,17 +1637,25 @@ func (h *Handler) resolveCreateReplay(ctx *SMBHandlerContext, req *CreateRequest
 
 	entry := h.CreateReplayCache.LookupEntry(ctx.SessionID, createGuid)
 	if entry == nil {
-		// No completed entry yet. A replay that arrives while the original
-		// CREATE for this CreateGuid is still parked on a pending
-		// oplock/lease break must fail fast with STATUS_FILE_NOT_AVAILABLE
-		// rather than block on the same break (Samba FWP_RESERVED /
-		// FILE_NOT_AVAILABLE slot states). The original parked request keeps
-		// running and completes on its own timeline. Checked after the
-		// completed-entry lookup so a parked CREATE that has just finished
-		// (entry present, reservation not yet cleared) replays the open
-		// rather than returning FILE_NOT_AVAILABLE.
-		if ctx.IsReplay && h.CreateReplayCache.IsReserved(ctx.SessionID, createGuid) {
-			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileNotAvailable}}, true
+		// No completed (success) entry yet. A replay that arrives while the
+		// original conflicting CREATE for this CreateGuid is still unresolved
+		// returns the reservation's two-phase status (MS-SMB2 §3.3.5.9; Samba
+		// FWP_RESERVED / FILE_NOT_AVAILABLE slot states, bug 14449):
+		//   - Phase A (original still pending on a share-mode conflict) →
+		//     STATUS_FILE_NOT_AVAILABLE. The original keeps running and
+		//     completes on its own timeline.
+		//   - Phase B (original resolved to a terminal share-mode violation but
+		//     the holder kept the file open via break-ack) → the stored
+		//     terminal status (STATUS_SHARING_VIOLATION). Returned from the
+		//     reservation so the replay does not re-run CREATE and re-park
+		//     (smbtorture replay.dhv2-pending1n-vs-violation-lease-ack-sane
+		//     replay23). Checked after the completed-entry lookup so a CREATE
+		//     that just succeeded (entry present, reservation released)
+		//     replays the open rather than a stale pending status.
+		if ctx.IsReplay {
+			if status, reserved := h.CreateReplayCache.ReservedStatus(ctx.SessionID, createGuid); reserved {
+				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, true
+			}
 		}
 		return nil, false
 	}

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -1338,20 +1338,26 @@ func (h *Handler) parkCreateOnLeaseBreak(
 
 	// The DH2Q CreateGuid was already Reserved by the caller (Create, before the
 	// breakAndMaybeParkCreate dispatch) so a replayed CREATE fails fast with
-	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break (smbtorture
-	// replay-dhv2-pending* / *-vs-{oplock,lease}). Since this CREATE is parking
-	// async, ownership of the matching Release transfers to the resume goroutine
-	// below: the caller returns STATUS_PENDING immediately and does NOT release.
-	// This keeps exactly one Reserve (in Create) and one Release (here for the
-	// parked path) per CREATE attempt. A zero CreateGuid is a no-op in Release.
+	// STATUS_FILE_NOT_AVAILABLE while the original is still parked (Phase A;
+	// smbtorture replay-dhv2-pending* / *-vs-{oplock,lease}). Since this CREATE
+	// is parking async, ownership of resolving the reservation transfers to the
+	// resume goroutine below: the caller returns STATUS_PENDING immediately and
+	// does NOT touch it. The reservation is resolved exactly once here, keyed by
+	// the CREATE's terminal status (resolveCreateReplayReservation): SUCCESS /
+	// transient → Release; a terminal share-mode violation → Phase B so a later
+	// replay returns that status (replay.dhv2-pending1n-vs-violation-lease-ack-*
+	// replay23). A zero CreateGuid is a no-op throughout.
+	//
+	// finalStatus defaults to StatusCancelled so EVERY early-return path below
+	// (dispatcher preemption, tree disconnect) still resolves to a plain Release
+	// — a reservation can never leak out of this goroutine.
 	replayGuid := dh2qCreateGuid(d.req)
 
 	go func() {
+		finalStatus := types.StatusCancelled
 		defer cancel()
 		defer func() {
-			if h.CreateReplayCache != nil {
-				h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
-			}
+			h.resolveCreateReplayReservation(ctx.SessionID, replayGuid, finalStatus)
 		}()
 
 		// Wait for the other-key break to drain (or timeout auto-downgrade).
@@ -1395,6 +1401,9 @@ func (h *Handler) parkCreateOnLeaseBreak(
 
 		resp := h.completeCreateAfterBreak(ctx, d)
 		status := resp.GetStatus()
+		// Resolve the reservation against the CREATE's real terminal status
+		// (the deferred resolveCreateReplayReservation reads finalStatus).
+		finalStatus = status
 		var body []byte
 		if status == types.StatusSuccess {
 			encoded, err := resp.Encode()

--- a/internal/adapter/smb/v2/handlers/replay_cache.go
+++ b/internal/adapter/smb/v2/handlers/replay_cache.go
@@ -80,6 +80,33 @@ type reserveKey struct {
 	CreateGuid [16]byte
 }
 
+// reservedState is the per-reservation phase status returned to a replay
+// (FLAGS_REPLAY_OPERATION) that arrives while the original conflicting CREATE
+// for the same CreateGuid has not yet established a cached open. The
+// reservation is two-phase (MS-SMB2 §3.3.5.9; Samba bug 14449
+// smb2.replay.dhv2-pending1*):
+//
+//   - Phase A — the original CREATE is still pending on a share-mode conflict
+//     (parked on a lease/oplock break, or waiting inline). A replay returns
+//     Status = STATUS_FILE_NOT_AVAILABLE.
+//
+//   - Phase B — the conflict resolved to a terminal *failure* (the holder
+//     released the cached handle via a break-ack but kept the file open, so the
+//     share-mode violation stands). The original CREATE returned
+//     STATUS_SHARING_VIOLATION. A replay must keep returning that SAME terminal
+//     status from the reservation rather than re-running the full CREATE (which
+//     would re-park and time out). UpdateReservedStatus performs the A→B
+//     transition; the reservation is then cleared at session teardown
+//     (ForgetSession) or by the TTL backstop below, never leaking.
+//
+// At is the time the reservation was taken or last transitioned, used by the
+// TTL backstop so a Phase-B reservation that is somehow never explicitly
+// cleared cannot brick all future opens of that CreateGuid indefinitely.
+type reservedState struct {
+	Status types.Status
+	At     time.Time
+}
+
 // CreateReplayCache stores CREATE responses keyed by DH2Q CreateGuid
 // so a replayed CREATE (FLAGS_REPLAY_OPERATION) returns the original
 // result instead of re-executing. CreateGuid is client-generated and
@@ -95,32 +122,61 @@ type reserveKey struct {
 type CreateReplayCache struct {
 	mu       sync.Mutex
 	entries  map[[16]byte]*CachedCreateResponse
-	reserved map[reserveKey]struct{}
+	reserved map[reserveKey]reservedState
 }
 
 // NewCreateReplayCache builds an empty cache.
 func NewCreateReplayCache() *CreateReplayCache {
 	return &CreateReplayCache{
 		entries:  make(map[[16]byte]*CachedCreateResponse),
-		reserved: make(map[reserveKey]struct{}),
+		reserved: make(map[reserveKey]reservedState),
 	}
 }
 
-// Reserve marks a CreateGuid as having an in-progress (parked) original
-// CREATE for the given session. While reserved, a replayed CREATE for
-// the same CreateGuid resolves to STATUS_FILE_NOT_AVAILABLE. A zero
-// CreateGuid is ignored.
+// Reserve marks a CreateGuid as having an in-progress (Phase A, pending)
+// original CREATE for the given session. While reserved in Phase A, a replayed
+// CREATE for the same CreateGuid resolves to STATUS_FILE_NOT_AVAILABLE. A zero
+// CreateGuid is ignored. Reserve is idempotent: re-reserving an already-reserved
+// guid resets it to Phase A (it never clobbers a Phase-B terminal status into
+// existence, but a fresh original CREATE attempt legitimately restarts Phase A).
 func (c *CreateReplayCache) Reserve(sessionID uint64, createGuid [16]byte) {
 	if createGuid == ([16]byte{}) {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.reserved[reserveKey{SessionID: sessionID, CreateGuid: createGuid}] = struct{}{}
+	c.reserved[reserveKey{SessionID: sessionID, CreateGuid: createGuid}] = reservedState{
+		Status: types.StatusFileNotAvailable,
+		At:     time.Now(),
+	}
+}
+
+// UpdateReservedStatus transitions an existing reservation from Phase A
+// (pending → STATUS_FILE_NOT_AVAILABLE) to Phase B (the original conflicting
+// CREATE resolved to a terminal failure status, e.g. STATUS_SHARING_VIOLATION).
+// A subsequent replay then returns that terminal status from the reservation
+// instead of re-running CREATE. It is a no-op when the guid is not currently
+// reserved (the reservation was already released on a success path), so it can
+// never resurrect a cleared reservation. The timestamp is refreshed so the TTL
+// backstop applies to the Phase-B window from its start.
+func (c *CreateReplayCache) UpdateReservedStatus(sessionID uint64, createGuid [16]byte, status types.Status) {
+	if createGuid == ([16]byte{}) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := reserveKey{SessionID: sessionID, CreateGuid: createGuid}
+	if _, ok := c.reserved[key]; !ok {
+		return
+	}
+	c.reserved[key] = reservedState{Status: status, At: time.Now()}
 }
 
 // Release clears an in-progress reservation once the parked CREATE has
-// reached a terminal state (success stored, or failed). Idempotent.
+// reached a terminal SUCCESS state (response stored). Idempotent. Phase-B
+// (terminal-failure) reservations are NOT released here — they persist so a
+// later replay returns the cached terminal status — and are reaped instead by
+// ForgetSession (session teardown) or the TTL backstop.
 func (c *CreateReplayCache) Release(sessionID uint64, createGuid [16]byte) {
 	if createGuid == ([16]byte{}) {
 		return
@@ -131,15 +187,34 @@ func (c *CreateReplayCache) Release(sessionID uint64, createGuid [16]byte) {
 }
 
 // IsReserved reports whether a CreateGuid's original CREATE is currently
-// parked for the given session.
+// reserved (Phase A or B) for the given session and has not aged past the TTL
+// backstop. Expired reservations are reaped on access.
 func (c *CreateReplayCache) IsReserved(sessionID uint64, createGuid [16]byte) bool {
+	_, ok := c.ReservedStatus(sessionID, createGuid)
+	return ok
+}
+
+// ReservedStatus returns the phase status a replay must receive while the
+// CreateGuid is reserved (STATUS_FILE_NOT_AVAILABLE in Phase A, the stored
+// terminal status in Phase B), or ok=false on no/expired reservation. A
+// reservation older than replayCacheTTL is reaped and treated as absent so a
+// Phase-B reservation can never brick the guid indefinitely.
+func (c *CreateReplayCache) ReservedStatus(sessionID uint64, createGuid [16]byte) (types.Status, bool) {
 	if createGuid == ([16]byte{}) {
-		return false
+		return 0, false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	_, ok := c.reserved[reserveKey{SessionID: sessionID, CreateGuid: createGuid}]
-	return ok
+	key := reserveKey{SessionID: sessionID, CreateGuid: createGuid}
+	st, ok := c.reserved[key]
+	if !ok {
+		return 0, false
+	}
+	if time.Since(st.At) > replayCacheTTL {
+		delete(c.reserved, key)
+		return 0, false
+	}
+	return st.Status, true
 }
 
 // Store records the response for a successful V2 CREATE keyed by

--- a/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/v2/handlers/replay_dhv2_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -430,6 +431,169 @@ func TestCreateReplayCache_ReserveReleaseSingleReservation(t *testing.T) {
 	if c.IsReserved(sessionID, [16]byte{}) {
 		t.Fatal("zero CreateGuid must never be reserved")
 	}
+}
+
+// TestResolveCreateReplay_TwoPhase_ViolationAckSurvivesAcrossRequests models the
+// smbtorture replay.dhv2-pending1n-vs-violation-lease-ack-sane sequence: client1
+// holds an RWH lease with share_access=0; client2's conflicting CREATE
+// (create_guid2, share_access=0) parks on the handle-lease break. The reservation
+// must SURVIVE across requests:
+//
+//	Phase A (parked)            → replay22 returns STATUS_FILE_NOT_AVAILABLE
+//	orig21 resolves to SHARING_VIOLATION (holder acked break, kept file open)
+//	Phase B (violation, pre-completion) → replay23 returns STATUS_SHARING_VIOLATION
+//
+// The prior single-phase reservation released on the original's failure, so
+// replay23 fell through to a fresh CREATE (wrong status / re-park). #749.
+func TestResolveCreateReplay_TwoPhase_ViolationAckSurvivesAcrossRequests(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x21, 0x22}
+
+	// Phase A: Create reserves the guid for the parked conflicting open.
+	h.CreateReplayCache.Reserve(sessionID, guid)
+
+	// replay22 while parked → FILE_NOT_AVAILABLE.
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	if !handled || resp.Status != types.StatusFileNotAvailable {
+		t.Fatalf("Phase-A replay = (%v, %s), want (true, FILE_NOT_AVAILABLE)", handled, resp.Status)
+	}
+
+	// Original conflicting CREATE resolves to a terminal SHARING_VIOLATION
+	// (holder kept the file open after the break-ack). The terminal resolver
+	// transitions the reservation to Phase B rather than releasing it.
+	h.resolveCreateReplayReservation(sessionID, guid, types.StatusSharingViolation)
+
+	// replay23 after the violation → the SAME cached terminal status, NOT a
+	// fall-through to a fresh CREATE.
+	resp, handled = h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	if !handled || resp.Status != types.StatusSharingViolation {
+		t.Fatalf("Phase-B replay = (%v, %s), want (true, SHARING_VIOLATION)", handled, resp.Status)
+	}
+
+	// The reservation is still held (Phase B) — proven by IsReserved — until
+	// session teardown / TTL backstop clears it. It does not leak into a stuck
+	// FILE_NOT_AVAILABLE: it carries the resolved terminal status.
+	if status, ok := h.CreateReplayCache.ReservedStatus(sessionID, guid); !ok || status != types.StatusSharingViolation {
+		t.Fatalf("Phase-B ReservedStatus = (%s, %v), want (SHARING_VIOLATION, true)", status, ok)
+	}
+
+	// Session teardown clears it (no permanent leak of the guid).
+	h.CreateReplayCache.ForgetSession(sessionID)
+	if h.CreateReplayCache.IsReserved(sessionID, guid) {
+		t.Fatal("Phase-B reservation must be cleared by session teardown (no leak)")
+	}
+}
+
+// TestResolveCreateReplay_TwoPhase_SuccessReleasesReservation models the close
+// variant and the -vs-{oplock,lease} hold variants: the parked original CREATE
+// ultimately SUCCEEDS once the holder releases. The terminal resolver must
+// Release the reservation (the success response is what serves later replays via
+// the cached entry), never transition it to a Phase-B failure status.
+func TestResolveCreateReplay_TwoPhase_SuccessReleasesReservation(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x33}
+
+	h.CreateReplayCache.Reserve(sessionID, guid)
+	if !h.CreateReplayCache.IsReserved(sessionID, guid) {
+		t.Fatal("guid must be reserved in Phase A")
+	}
+
+	// Original completes successfully → reservation released.
+	h.resolveCreateReplayReservation(sessionID, guid, types.StatusSuccess)
+	if h.CreateReplayCache.IsReserved(sessionID, guid) {
+		t.Fatal("a successful original CREATE must release the reservation (no Phase-B)")
+	}
+}
+
+// TestResolveCreateReplay_TwoPhase_TransientFailureReleases proves a non-share
+// terminal failure (e.g. internal error / cancelled — the async early-return
+// default) releases the reservation rather than wedging it in Phase B. This is
+// the leak-proof guarantee for the resume goroutine's preemption / tree-deleted
+// early returns.
+func TestResolveCreateReplay_TwoPhase_TransientFailureReleases(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x44}
+
+	for _, st := range []types.Status{types.StatusCancelled, types.StatusInternalError, types.StatusNetworkNameDeleted} {
+		h.CreateReplayCache.Reserve(sessionID, guid)
+		h.resolveCreateReplayReservation(sessionID, guid, st)
+		if h.CreateReplayCache.IsReserved(sessionID, guid) {
+			t.Fatalf("terminal status %s must release the reservation (no leak)", st)
+		}
+	}
+}
+
+// TestUpdateReservedStatus_NoResurrect proves UpdateReservedStatus never creates
+// a reservation for a guid that was already released (e.g. a success path that
+// released first, followed by a stale terminal resolution). A stuck reservation
+// would brick all future opens of the guid.
+func TestUpdateReservedStatus_NoResurrect(t *testing.T) {
+	c := NewCreateReplayCache()
+	const sessionID = uint64(11)
+	guid := [16]byte{0x55}
+
+	// No prior Reserve → UpdateReservedStatus must be a no-op.
+	c.UpdateReservedStatus(sessionID, guid, types.StatusSharingViolation)
+	if c.IsReserved(sessionID, guid) {
+		t.Fatal("UpdateReservedStatus must not resurrect an unreserved guid")
+	}
+
+	// Reserve, release, then a late Update must not resurrect either.
+	c.Reserve(sessionID, guid)
+	c.Release(sessionID, guid)
+	c.UpdateReservedStatus(sessionID, guid, types.StatusSharingViolation)
+	if c.IsReserved(sessionID, guid) {
+		t.Fatal("UpdateReservedStatus after Release must not resurrect the reservation")
+	}
+}
+
+// TestReservedStatus_TTLBackstop proves a Phase-B reservation that is never
+// explicitly cleared still cannot brick the guid forever: once it ages past the
+// TTL it is reaped on the next ReservedStatus access and treated as absent.
+func TestReservedStatus_TTLBackstop(t *testing.T) {
+	c := NewCreateReplayCache()
+	const sessionID = uint64(11)
+	guid := [16]byte{0x66}
+
+	c.Reserve(sessionID, guid)
+	c.UpdateReservedStatus(sessionID, guid, types.StatusSharingViolation)
+
+	// Force the reservation's age past the TTL.
+	c.mu.Lock()
+	st := c.reserved[reserveKey{SessionID: sessionID, CreateGuid: guid}]
+	st.At = time.Now().Add(-replayCacheTTL - time.Second)
+	c.reserved[reserveKey{SessionID: sessionID, CreateGuid: guid}] = st
+	c.mu.Unlock()
+
+	if _, ok := c.ReservedStatus(sessionID, guid); ok {
+		t.Fatal("a reservation older than the TTL must be reaped and treated as absent")
+	}
+}
+
+// TestReservedStatus_ConcurrentSameGuid exercises concurrent Reserve / Update /
+// ReservedStatus / Release on the same guid for the race detector. The cache
+// must not panic or corrupt its map under contention.
+func TestReservedStatus_ConcurrentSameGuid(t *testing.T) {
+	c := NewCreateReplayCache()
+	const sessionID = uint64(11)
+	guid := [16]byte{0x77}
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			c.Reserve(sessionID, guid)
+			c.UpdateReservedStatus(sessionID, guid, types.StatusSharingViolation)
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_, _ = c.ReservedStatus(sessionID, guid)
+		c.Release(sessionID, guid)
+	}
+	<-done
 }
 
 // leaseKey16Guid reuses a lease key's bytes as a distinct CreateGuid for tests


### PR DESCRIPTION
## What & why

`#908` reserved/released the DH2 CREATE-replay slot within a single CREATE call, which flipped **zero** `pending1` rows. Root cause: for the `pending1n` / violation variants the conflicting open's status is only known **across multiple requests** — the reservation must survive past the synchronous violation CREATE until the conflict resolves, and must carry a *two-phase* status. This PR makes the reservation cross-request and status-bearing.

Closes the protocol gap for `#749`.

## Ground truth (extracted from `source4/torture/smb2/replay.c`)

Two test families drive `dhv2-pending1*`:

### `_test_dhv2_pending1_vs_hold` — the `-vs-{oplock,lease}` rows
client1 holds BATCH oplock or RWH lease with `share_access="RWD"`; client2 (`create_guid2`, also `RWD`) is share-compatible, so it only parks on the oplock/lease break and ultimately **succeeds**.

| client1 / client2 | replay22 & replay23 (while parked) | io24 (after orig21 OK) |
|---|---|---|
| BATCH / NONE (`pending1n-vs-oplock`) | sane=`FILE_NOT_AVAILABLE`, windows=`ACCESS_DENIED` | `OK` (cached) |
| LEASE / NONE (`pending1n-vs-lease`) | sane=`FILE_NOT_AVAILABLE`, windows=`ACCESS_DENIED` | `OK` |
| BATCH/LEASE / LEASE (`pending1l-vs-*`) | sane=`FILE_NOT_AVAILABLE`, windows=`ACCESS_DENIED` | `OK` |
| BATCH/LEASE / BATCH (`pending1o-vs-*`) | sane=`FILE_NOT_AVAILABLE`, windows=`ACCESS_DENIED` | `OK` |

### `_test_dhv2_pending1_vs_violation` — the `-vs-violation-lease-{close,ack}` rows
client1 holds an RWH lease with `share_access=0`; client2 (`create_guid2`, `share_access=0`) **conflicts**. Server breaks the handle lease first and parks `req21` (defers the violation).

| variant | release_op | orig21 | replay22 (parked) | replay23 (post-resolve) |
|---|---|---|---|---|
| `violation-lease-close-sane` | CLOSE | `OK` | `FILE_NOT_AVAILABLE` | `OK` |
| `violation-lease-close-windows` | CLOSE | `OK` | `SHARING_VIOLATION` | `OK` |
| `violation-lease-ack-sane` | BREAK-ack | `SHARING_VIOLATION` | `FILE_NOT_AVAILABLE` | `SHARING_VIOLATION` |
| `violation-lease-ack-windows` | BREAK-ack | `SHARING_VIOLATION` | `SHARING_VIOLATION` | `SHARING_VIOLATION` |

The **ack** rows are the load-bearing case: client1 acks the break but keeps the file open with `share_access=0`, so the conflict stands, orig21 fails `SHARING_VIOLATION`, and `replay23` must return that **same** status from the reservation — not re-run CREATE.

## Design — cross-request, two-phase reservation

`CreateReplayCache` reservations now carry a `reservedState{ Status, At }` instead of a bare set membership:

- **Phase A** (original pending on a share-mode conflict) → replay returns `STATUS_FILE_NOT_AVAILABLE` (the "sane" status).
- **Phase B** (original resolved to a terminal share-mode violation) → `UpdateReservedStatus` transitions the reservation to the terminal status; replay returns it from the reservation.

New API on `CreateReplayCache`: `UpdateReservedStatus`, `ReservedStatus`; `Reserve` now stamps Phase A; `IsReserved` delegates to `ReservedStatus`.

A single shared seam, `resolveCreateReplayReservation(sessionID, guid, terminalStatus)`, closes out the reservation on the original CREATE's terminal status, used by **both** the inline-completion path (`Create`) and the async-park resume goroutine (`parkCreateOnLeaseBreak`):
- `SUCCESS` / transient → `Release` (the cached success entry serves later replays).
- `SHARING_VIOLATION` / `ACCESS_DENIED` → Phase B.

`resolveCreateReplay` consults the reservation status only when no cached success entry exists, preserving the existing "entry-first" ordering (a just-completed success replays the open, not a stale pending status).

## Leak / double-release proof

A reservation can never leak or be cleared twice:

- **Inline path:** `Create` reserves before dispatch; after `completeCreateAfterBreak` returns it calls the resolver exactly once with the real terminal status.
- **Async path:** the resume goroutine resolves the reservation in a `defer` driven by `finalStatus`, which **defaults to `StatusCancelled`** — so every early-return path (dispatcher preemption after `Unregister`, tree-disconnect → `NETWORK_NAME_DELETED`) still resolves to a plain `Release`. `finalStatus` is set to the real status only after `completeCreateAfterBreak`.
- **Phase-B persistence** is bounded twice over: `ForgetSession` clears all reserved entries at session teardown (the test ends with `smbXcli_conn_disconnect`), and a TTL backstop (`replayCacheTTL`) reaps any reservation aged past the window on the next `ReservedStatus` access — so a Phase-B reservation can never brick future opens of the guid indefinitely.
- **No-resurrect:** `UpdateReservedStatus` is a no-op when the guid is not currently reserved, so a late terminal resolution after a success-path `Release` cannot recreate a stuck reservation.
- `Release` / `UpdateReservedStatus` are idempotent map ops; a double call is harmless.

## Target rows (`KNOWN_FAILURES.md`, untouched — walkback is post-CI)

`dhv2-pending1n-vs-{oplock,lease}-{sane,windows}`, `dhv2-pending1n-vs-violation-lease-{close,ack}-{sane,windows}`, `dhv2-pending1o-vs-{oplock,lease}-{sane,windows}`, `dhv2-pending1l-vs-{oplock,lease}-windows`.

Note: DittoFS is a single server and returns the **sane** (Samba) statuses (`FILE_NOT_AVAILABLE` while pending, `SHARING_VIOLATION` on violation). The `*-windows` rows expect Windows-policy statuses (`ACCESS_DENIED` / immediate `SHARING_VIOLATION`) and are mutually exclusive with the sane rows by construction — the sane variants are the ones this PR targets to flip; the windows variants remain expected-fail.

## Regression safety

`pending1l-vs-{oplock,lease}-sane`, `pending1o-vs-lease-sane`, `replay-dhv2-lease1/2/3`, `lease-oplock`, `oplock-lease` are unaffected: the entry-first lookup ordering in `resolveCreateReplay` is preserved, success still caches via `Store`, and the reservation is only consulted on a replay with no cached entry.

## Tests (`replay_dhv2_test.go`)

- `TestResolveCreateReplay_TwoPhase_ViolationAckSurvivesAcrossRequests` — Phase A `FILE_NOT_AVAILABLE` → Phase B `SHARING_VIOLATION` across requests; cleared by `ForgetSession`.
- `TestResolveCreateReplay_TwoPhase_SuccessReleasesReservation` — success → Release (no Phase B).
- `TestResolveCreateReplay_TwoPhase_TransientFailureReleases` — cancelled / internal / network-name-deleted all Release (leak-proof early returns).
- `TestUpdateReservedStatus_NoResurrect` — no resurrect after Release / never-reserved.
- `TestReservedStatus_TTLBackstop` — aged Phase-B reservation reaped.
- `TestReservedStatus_ConcurrentSameGuid` — `-race` Reserve/Update/Lookup/Release contention.

Existing replay tests stay green; `go test -race ./internal/adapter/smb/v2/handlers/` clean.
