### PR TITLE
feat(nfs/v4): persist+restore client-recovery records for reboot grace (area-4 H8 slice 2)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/setclientid.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid.go
@@ -82,7 +82,7 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 	}
 
 	// Delegate to StateManager for the five-case algorithm
-	result, err := h.StateManager.SetClientID(clientIDStr, verifier, callback, ctx.ClientAddr)
+	result, err := h.StateManager.SetClientID(clientIDStr, verifier, callback, ctx.ClientAddr, ctx.Principal())
 	if err != nil {
 		// Map state errors to NFS4 error codes
 		nfsStatus := mapStateError(err)

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -59,6 +59,12 @@ type ClientRecord struct {
 	// ClientAddr is the network address of the client (for logging/debugging).
 	ClientAddr string
 
+	// Principal is the RPCSEC_GSS / AUTH_SYS principal that established this
+	// client (best-effort; "uid:N" for AUTH_SYS, the GSS principal otherwise,
+	// "" when unknown). Captured at SETCLIENTID and persisted into the durable
+	// client-recovery record at confirm time as a lease-stealing guard.
+	Principal string
+
 	// CreatedAt is when this record was created.
 	CreatedAt time.Time
 

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -1,0 +1,227 @@
+package state
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// recoveryPersistTimeout bounds every synchronous client-recovery store call.
+// Mirrors the lock manager's persistTimeout so a hung backend cannot wedge a
+// confirm/expiry under sm.mu. The in-memory state is authoritative for the
+// running process; persistence is best-effort for cross-restart durability.
+const recoveryPersistTimeout = 3 * time.Second
+
+// SetClientRecoveryStore wires the server-global durable client-recovery store
+// and the current server epoch. Called once by the NFS adapter after picking
+// the first share's metadata store that implements lock.ClientRecoveryStore
+// (mirroring the NSM ClientRegistrationStore designation).
+//
+// When never called (or called with a nil store), the StateManager behaves
+// exactly as before: no records are persisted, boot-load is a no-op, and
+// CLAIM_PREVIOUS is not verifier-gated. This keeps bare test constructions and
+// the develop fast-path working unchanged.
+//
+// Thread-safe: acquires sm.mu.Lock.
+func (sm *StateManager) SetClientRecoveryStore(store lock.ClientRecoveryStore, serverEpoch uint64) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.recoveryStore = store
+	sm.serverEpoch = serverEpoch
+}
+
+// HasClientRecoveryStore reports whether a durable recovery store is wired.
+// Thread-safe: acquires sm.mu.RLock.
+func (sm *StateManager) HasClientRecoveryStore() bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.recoveryStore != nil
+}
+
+// v41RecoveryKey derives the stable recovery-record key for a v4.1 client.
+// v4.1 has no nfs_client_id4 string; the stable identity is co_ownerid, so we
+// hex-encode it (prefixed to keep it disjoint from any v4.0 nfs_client_id4
+// string, which is the raw client-supplied identifier).
+func v41RecoveryKey(ownerID []byte) string {
+	return "v41:" + hex.EncodeToString(ownerID)
+}
+
+// recoveryKeyForClientLocked resolves the durable recovery key for a confirmed
+// client by numeric clientID, checking the v4.0 then v4.1 tables. Returns ""
+// when the client is unknown. Caller must hold sm.mu (R or W).
+func (sm *StateManager) recoveryKeyForClientLocked(clientID uint64) string {
+	if rec, ok := sm.clientsByID[clientID]; ok {
+		return rec.ClientIDString
+	}
+	if rec, ok := sm.v41ClientsByID[clientID]; ok {
+		return v41RecoveryKey(rec.OwnerID)
+	}
+	return ""
+}
+
+// persistClientRecoveryLocked stores a durable recovery record for a confirmed
+// client. Best-effort under sm.mu, bounded by recoveryPersistTimeout: a failure
+// logs a durability ALARM but the confirm STILL succeeds (the in-memory record
+// is authoritative for this process). No-op when no recovery store is wired.
+// Caller must hold sm.mu.
+func (sm *StateManager) persistClientRecoveryLocked(clientID uint64, clientIDString string, bootVerifier [8]byte, principal string) {
+	if sm.recoveryStore == nil {
+		return
+	}
+	rec := &lock.V4ClientRecoveryRecord{
+		ClientID:       clientID,
+		ClientIDString: clientIDString,
+		BootVerifier:   bootVerifier,
+		Principal:      principal,
+		ConfirmedAt:    time.Now(),
+		ServerEpoch:    sm.serverEpoch,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
+	defer cancel()
+	if err := sm.recoveryStore.PutClientRecovery(ctx, rec); err != nil {
+		logger.Error("client-recovery persistence failed: client confirmed in memory but NOT durable across restart",
+			"client_id", clientID,
+			"client_id_str", clientIDString,
+			"error", err)
+	}
+}
+
+// deleteClientRecoveryLocked removes a client's durable recovery record on
+// lease expiry / eviction / DESTROY_CLIENTID. Best-effort, bounded timeout.
+// No-op when no recovery store is wired. Caller must hold sm.mu.
+func (sm *StateManager) deleteClientRecoveryLocked(clientIDString string) {
+	if sm.recoveryStore == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
+	defer cancel()
+	if err := sm.recoveryStore.DeleteClientRecovery(ctx, clientIDString); err != nil {
+		logger.Error("client-recovery delete failed: stale recovery record may linger across restart",
+			"client_id_str", clientIDString,
+			"error", err)
+	}
+}
+
+// recordReclaimCompleteLocked marks a client's recovery record reclaim-complete
+// (v4.1 RECLAIM_COMPLETE, or first CLAIM_PREVIOUS for v4.0) so a second restart
+// inside one grace window does not wait on an already-reclaimed client.
+// Best-effort, bounded timeout. No-op when no recovery store is wired.
+// Caller must hold sm.mu.
+func (sm *StateManager) recordReclaimCompleteLocked(clientIDString string) {
+	if sm.recoveryStore == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
+	defer cancel()
+	if err := sm.recoveryStore.RecordReclaimComplete(ctx, clientIDString); err != nil {
+		logger.Error("client-recovery reclaim-complete persistence failed: a second restart may re-wait on this client",
+			"client_id_str", clientIDString,
+			"error", err)
+	}
+}
+
+// validateReclaimVerifier rejects a CLAIM_PREVIOUS reclaim whose boot verifier
+// does not match the PRE-RESTART durable verifier (RFC 7530 §9.1.4, area-4 H8
+// §3.4): a changed verifier means the client rebooted and must NOT reclaim prior
+// state.
+//
+// It compares against the boot-load snapshot (bootRecoveryVerifiers), not the
+// live store: a rebooting client's SETCLIENTID_CONFIRM overwrites its live
+// recovery record with the NEW verifier before the CLAIM_PREVIOUS reaches here,
+// so the live store would always "match" and the reboot would go undetected.
+//
+//   - snapshot has identity + verifier matches -> nil (valid reclaimer)
+//   - snapshot has identity + verifier differs -> ErrNoGrace (rebooted; reject)
+//   - identity absent from snapshot              -> nil (nothing to gate on)
+//
+// Caller must NOT hold sm.mu.
+func (sm *StateManager) validateReclaimVerifier(clientIDString string, bootVerifier [8]byte) error {
+	sm.mu.RLock()
+	want, ok := sm.bootRecoveryVerifiers[clientIDString]
+	sm.mu.RUnlock()
+	if !ok {
+		// No pre-restart record for this identity: nothing to gate on.
+		return nil
+	}
+	if want == bootVerifier {
+		return nil // valid reclaimer
+	}
+	logger.Warn("CLAIM_PREVIOUS rejected: boot verifier changed since prior confirm (client rebooted)",
+		"client_id_str", clientIDString)
+	return ErrNoGrace
+}
+
+// LoadClientRecovery reads the durable recovery records on boot and starts the
+// v4 grace period seeded with the prior clients' stable identity strings (the
+// area-4 H8 core: today the v4 roster is empty on a fresh process so v4 grace
+// is a no-op; now it is the durable prior-client set).
+//
+// Records whose ReclaimComplete is already true are NOT waited on (a second
+// restart inside one grace window must not re-wait on a client that already
+// finished reclaim — §3.2 RecordReclaimComplete rationale).
+//
+// Returns the number of clients added to the expected reclaim roster. When no
+// recovery store is wired, or the store has no waitable records, this is a
+// no-op and grace behaves exactly as on develop (empty roster -> skipped),
+// which preserves the fresh-CI fast path. The hard grace timer remains the
+// backstop regardless.
+//
+// Caller must NOT hold sm.mu.
+func (sm *StateManager) LoadClientRecovery(ctx context.Context) int {
+	sm.mu.RLock()
+	store := sm.recoveryStore
+	sm.mu.RUnlock()
+	if store == nil {
+		return 0
+	}
+
+	records, err := store.ListClientRecovery(ctx)
+	if err != nil {
+		logger.Error("client-recovery boot load failed: v4 grace roster will be empty",
+			"error", err)
+		return 0
+	}
+
+	expectedStrings := make([]string, 0, len(records))
+	verifiers := make(map[string][8]byte, len(records))
+	for _, rec := range records {
+		// Snapshot every prior verifier (including reclaim-complete ones) so the
+		// CLAIM_PREVIOUS verifier gate can detect a rebooted client regardless of
+		// whether it is still on the waitable roster.
+		verifiers[rec.ClientIDString] = rec.BootVerifier
+		if rec.ReclaimComplete {
+			// Already reclaimed in a prior (very recent) grace window; do not
+			// wait on it again.
+			continue
+		}
+		expectedStrings = append(expectedStrings, rec.ClientIDString)
+	}
+
+	// Record the verifier snapshot regardless of whether grace is seeded: a
+	// reclaim attempt is only honored during grace, but the gate must be armed
+	// even when the only prior records are already reclaim-complete.
+	sm.mu.Lock()
+	sm.bootRecoveryVerifiers = verifiers
+	sm.mu.Unlock()
+
+	if len(expectedStrings) == 0 {
+		logger.Info("client-recovery boot load: no waitable prior clients; v4 grace not seeded")
+		return 0
+	}
+
+	sm.mu.Lock()
+	gp := NewGracePeriodState(sm.graceDuration, func() {
+		logger.Info("NFSv4 grace period ended (boot-loaded roster)")
+	})
+	sm.gracePeriod = gp
+	sm.mu.Unlock()
+
+	gp.StartGraceWithRoster(nil, expectedStrings)
+
+	logger.Info("client-recovery boot load: v4 grace period seeded",
+		"expected_clients", len(expectedStrings))
+	return len(expectedStrings)
+}

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -1,0 +1,461 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// spyRecoveryStore is a test double for lock.ClientRecoveryStore that records
+// every call and lets a test seed records and inject errors.
+type spyRecoveryStore struct {
+	mu sync.Mutex
+
+	records map[string]*lock.V4ClientRecoveryRecord
+
+	puts         []*lock.V4ClientRecoveryRecord
+	deletes      []string
+	reclaimMarks []string
+	lists        int
+	putErr       error
+	deleteErr    error
+	listErr      error
+	reclaimErr   error
+}
+
+func newSpyRecoveryStore() *spyRecoveryStore {
+	return &spyRecoveryStore{records: make(map[string]*lock.V4ClientRecoveryRecord)}
+}
+
+func (s *spyRecoveryStore) PutClientRecovery(_ context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.putErr != nil {
+		return s.putErr
+	}
+	cp := *rec
+	s.puts = append(s.puts, &cp)
+	s.records[rec.ClientIDString] = &cp
+	return nil
+}
+
+func (s *spyRecoveryStore) DeleteClientRecovery(_ context.Context, clientIDString string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.deletes = append(s.deletes, clientIDString)
+	delete(s.records, clientIDString)
+	return nil
+}
+
+func (s *spyRecoveryStore) ListClientRecovery(_ context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lists++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	out := make([]*lock.V4ClientRecoveryRecord, 0, len(s.records))
+	for _, r := range s.records {
+		cp := *r
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *spyRecoveryStore) RecordReclaimComplete(_ context.Context, clientIDString string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reclaimErr != nil {
+		return s.reclaimErr
+	}
+	s.reclaimMarks = append(s.reclaimMarks, clientIDString)
+	if r, ok := s.records[clientIDString]; ok {
+		r.ReclaimComplete = true
+	}
+	return nil
+}
+
+func (s *spyRecoveryStore) snapshotPuts() []*lock.V4ClientRecoveryRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*lock.V4ClientRecoveryRecord(nil), s.puts...)
+}
+
+func (s *spyRecoveryStore) snapshotDeletes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deletes...)
+}
+
+func (s *spyRecoveryStore) snapshotReclaims() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.reclaimMarks...)
+}
+
+// ---------------------------------------------------------------------------
+// Persist on confirm (v4.0 SETCLIENTID_CONFIRM)
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_PersistOnConfirmV40(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	sm := NewStateManager(5 * time.Second)
+	sm.SetClientRecoveryStore(spy, 42)
+
+	verf := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	res, err := sm.SetClientID("client-A", verf, CallbackInfo{}, "10.0.0.1:1", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	puts := spy.snapshotPuts()
+	if len(puts) != 1 {
+		t.Fatalf("expected 1 PutClientRecovery, got %d", len(puts))
+	}
+	got := puts[0]
+	if got.ClientIDString != "client-A" {
+		t.Errorf("ClientIDString = %q, want client-A", got.ClientIDString)
+	}
+	if got.ClientID != res.ClientID {
+		t.Errorf("ClientID = %d, want %d", got.ClientID, res.ClientID)
+	}
+	if got.BootVerifier != verf {
+		t.Errorf("BootVerifier = %x, want %x", got.BootVerifier, verf)
+	}
+	if got.Principal != "uid:1000" {
+		t.Errorf("Principal = %q, want uid:1000", got.Principal)
+	}
+	if got.ServerEpoch != 42 {
+		t.Errorf("ServerEpoch = %d, want 42", got.ServerEpoch)
+	}
+	if got.ConfirmedAt.IsZero() {
+		t.Error("ConfirmedAt is zero")
+	}
+}
+
+// A persist failure must NOT fail the confirm (best-effort durability).
+func TestClientRecovery_ConfirmSucceedsDespitePersistError(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.putErr = errors.New("backend down")
+	sm := NewStateManager(5 * time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	res, err := sm.SetClientID("client-B", [8]byte{9}, CallbackInfo{}, "10.0.0.2:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID must succeed despite persist error, got: %v", err)
+	}
+	if sm.GetClient(res.ClientID) == nil {
+		t.Fatal("client must be confirmed in memory despite persist error")
+	}
+}
+
+// nil recovery store => behave as today, no panic, no calls.
+func TestClientRecovery_NilStore(t *testing.T) {
+	sm := NewStateManager(5 * time.Second)
+	res, err := sm.SetClientID("client-C", [8]byte{1}, CallbackInfo{}, "10.0.0.3:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	if sm.HasClientRecoveryStore() {
+		t.Fatal("HasClientRecoveryStore should be false with no store wired")
+	}
+	// Boot-load with no store is a no-op returning 0.
+	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+		t.Fatalf("LoadClientRecovery with nil store = %d, want 0", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete on lease expiry
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_DeleteOnLeaseExpiry(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	sm := NewStateManager(5 * time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	res, err := sm.SetClientID("client-exp", [8]byte{7}, CallbackInfo{}, "10.0.0.4:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	// Directly trigger the lease-expiry callback (deterministic, no timer wait).
+	sm.onLeaseExpired(res.ClientID)
+
+	dels := spy.snapshotDeletes()
+	if len(dels) != 1 || dels[0] != "client-exp" {
+		t.Fatalf("expected DeleteClientRecovery(client-exp), got %v", dels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Boot load seeds the grace roster; ReclaimComplete records excluded
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_BootLoadSeedsRoster(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	// Two waitable clients + one already reclaim-complete (must be excluded).
+	spy.records["client-1"] = &lock.V4ClientRecoveryRecord{ClientIDString: "client-1", BootVerifier: [8]byte{1}}
+	spy.records["client-2"] = &lock.V4ClientRecoveryRecord{ClientIDString: "client-2", BootVerifier: [8]byte{2}}
+	spy.records["client-done"] = &lock.V4ClientRecoveryRecord{ClientIDString: "client-done", ReclaimComplete: true}
+
+	sm := NewStateManager(5*time.Second, 5*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	n := sm.LoadClientRecovery(context.Background())
+	if n != 2 {
+		t.Fatalf("LoadClientRecovery seeded %d clients, want 2 (reclaim-complete excluded)", n)
+	}
+	if !sm.IsInGrace() {
+		t.Fatal("server should be in grace after boot-load with waitable clients")
+	}
+	gp := sm.gracePeriod
+	if got := len(gp.expectedClientStrings); got != 2 {
+		t.Fatalf("expected 2 roster strings, got %d", got)
+	}
+	if gp.expectedClientStrings["client-done"] {
+		t.Error("reclaim-complete client must not be on the roster")
+	}
+	if !gp.expectedClientStrings["client-1"] || !gp.expectedClientStrings["client-2"] {
+		t.Error("waitable clients missing from roster")
+	}
+}
+
+// Empty store (fresh boot) => no grace, behaves as develop.
+func TestClientRecovery_BootLoadEmptySkipsGrace(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	sm := NewStateManager(5*time.Second, 5*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+		t.Fatalf("empty store should seed 0, got %d", n)
+	}
+	if sm.IsInGrace() {
+		t.Fatal("fresh boot with empty roster must NOT enter grace")
+	}
+}
+
+// All-reclaim-complete store => nothing waitable => no grace.
+func TestClientRecovery_BootLoadAllCompleteSkipsGrace(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.records["c"] = &lock.V4ClientRecoveryRecord{ClientIDString: "c", ReclaimComplete: true}
+	sm := NewStateManager(5*time.Second, 5*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+		t.Fatalf("all-complete store should seed 0, got %d", n)
+	}
+	if sm.IsInGrace() {
+		t.Fatal("all-reclaim-complete roster must NOT enter grace")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reclaim: matching verifier allowed + early-exits; changed verifier rejected
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_ReclaimMatchingVerifierAndEarlyExit(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	verf := [8]byte{0xaa}
+	spy.records["reclaimer"] = &lock.V4ClientRecoveryRecord{ClientIDString: "reclaimer", BootVerifier: verf}
+
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+	if !sm.IsInGrace() {
+		t.Fatal("should be in grace")
+	}
+
+	// The reclaiming client re-establishes its identity (fresh numeric clientID)
+	// with the SAME boot verifier, then reclaims via CLAIM_PREVIOUS.
+	res, err := sm.SetClientID("reclaimer", verf, CallbackInfo{}, "10.0.0.9:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	if _, err := sm.OpenFile(res.ClientID, []byte("owner"), 1, []byte("fh"), 1, 0, types.CLAIM_PREVIOUS); err != nil {
+		t.Fatalf("CLAIM_PREVIOUS with matching verifier should be allowed, got: %v", err)
+	}
+
+	// Roster drained by the single reclaimer => grace early-exits.
+	if sm.IsInGrace() {
+		t.Fatal("grace should early-exit once the only expected client reclaimed")
+	}
+	// First CLAIM_PREVIOUS is the v4.0 reclaim marker.
+	if marks := spy.snapshotReclaims(); len(marks) == 0 || marks[len(marks)-1] != "reclaimer" {
+		t.Fatalf("expected RecordReclaimComplete(reclaimer), got %v", marks)
+	}
+}
+
+func TestClientRecovery_ReclaimChangedVerifierRejected(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.records["rebooter"] = &lock.V4ClientRecoveryRecord{ClientIDString: "rebooter", BootVerifier: [8]byte{0x11}}
+
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+
+	// Client comes back with a DIFFERENT boot verifier (it rebooted).
+	changed := [8]byte{0x22}
+	res, err := sm.SetClientID("rebooter", changed, CallbackInfo{}, "10.0.0.10:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	_, err = sm.OpenFile(res.ClientID, []byte("owner"), 1, []byte("fh"), 1, 0, types.CLAIM_PREVIOUS)
+	if !errors.Is(err, ErrNoGrace) {
+		t.Fatalf("CLAIM_PREVIOUS with changed verifier must be rejected with ErrNoGrace, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grace still lifts via the hard timer backstop even if the roster never drains
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_GraceTimerBackstopLifts(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.records["never-comes-back"] = &lock.V4ClientRecoveryRecord{ClientIDString: "never-comes-back", BootVerifier: [8]byte{5}}
+
+	sm := NewStateManager(5*time.Second, 100*time.Millisecond)
+	sm.SetClientRecoveryStore(spy, 1)
+	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+	if !sm.IsInGrace() {
+		t.Fatal("should be in grace")
+	}
+
+	// No reclaim happens; the hard timer must still lift grace.
+	deadline := time.After(2 * time.Second)
+	for sm.IsInGrace() {
+		select {
+		case <-deadline:
+			t.Fatal("grace did not lift via timer backstop")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// v4.1: CREATE_SESSION persists; RECLAIM_COMPLETE marks + drains roster
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	owner := []byte("v41-owner")
+	verf := [8]byte{0x42}
+	exch, err := sm.ExchangeID(owner, verf, 0, nil, "10.0.0.20:1", "uid:0")
+	if err != nil {
+		t.Fatalf("ExchangeID: %v", err)
+	}
+	// First CREATE_SESSION confirms + persists.
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	key := v41RecoveryKey(owner)
+	puts := spy.snapshotPuts()
+	if len(puts) != 1 || puts[0].ClientIDString != key {
+		t.Fatalf("expected v4.1 Put keyed by %q, got %v", key, puts)
+	}
+	if puts[0].BootVerifier != verf || puts[0].Principal != "uid:0" || puts[0].ServerEpoch != 7 {
+		t.Errorf("v4.1 record fields wrong: %+v", puts[0])
+	}
+
+	// Now simulate a restart roster containing this client, then RECLAIM_COMPLETE.
+	sm2 := NewStateManager(5*time.Second, 30*time.Second)
+	sm2.SetClientRecoveryStore(spy, 8)
+	if n := sm2.LoadClientRecovery(context.Background()); n != 1 {
+		t.Fatalf("post-restart seeded %d, want 1", n)
+	}
+	// Re-establish identity and a session, then RECLAIM_COMPLETE.
+	exch2, err := sm2.ExchangeID(owner, verf, 0, nil, "10.0.0.20:2")
+	if err != nil {
+		t.Fatalf("ExchangeID(2): %v", err)
+	}
+	cs, _, err := sm2.CreateSession(exch2.ClientID, exch2.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil)
+	if err != nil {
+		t.Fatalf("CreateSession(2): %v", err)
+	}
+	_ = cs
+	if err := sm2.ReclaimComplete(exch2.ClientID); err != nil {
+		t.Fatalf("ReclaimComplete: %v", err)
+	}
+	if sm2.IsInGrace() {
+		t.Fatal("grace should early-exit after the only expected v4.1 client RECLAIM_COMPLETEs")
+	}
+	marks := spy.snapshotReclaims()
+	if len(marks) == 0 || marks[len(marks)-1] != key {
+		t.Fatalf("expected RecordReclaimComplete(%q), got %v", key, marks)
+	}
+}
+
+// DESTROY_CLIENTID deletes the v4.1 recovery record.
+func TestClientRecovery_V41DestroyDeletes(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	sm := NewStateManager(5 * time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	owner := []byte("destroy-owner")
+	exch, err := sm.ExchangeID(owner, [8]byte{1}, 0, nil, "10.0.0.30:1")
+	if err != nil {
+		t.Fatalf("ExchangeID: %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	// Destroy requires no active sessions; tear them down first.
+	for _, s := range sm.ListSessionsForClient(exch.ClientID) {
+		if err := sm.DestroySession(s.SessionID); err != nil {
+			t.Fatalf("DestroySession: %v", err)
+		}
+	}
+	if err := sm.DestroyV41ClientID(exch.ClientID); err != nil {
+		t.Fatalf("DestroyV41ClientID: %v", err)
+	}
+
+	key := v41RecoveryKey(owner)
+	dels := spy.snapshotDeletes()
+	found := false
+	for _, d := range dels {
+		if d == key {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected DeleteClientRecovery(%q), got %v", key, dels)
+	}
+}

--- a/internal/adapter/nfs/v4/state/grace.go
+++ b/internal/adapter/nfs/v4/state/grace.go
@@ -66,6 +66,17 @@ type GracePeriodState struct {
 	// reclaimedClients maps clients that have completed reclaim.
 	reclaimedClients map[uint64]bool
 
+	// expectedClientStrings is the durable boot-loaded reclaim roster keyed by
+	// stable client identity (nfs_client_id4 string for v4.0, co_ownerid for
+	// v4.1). After an ungraceful restart the reclaiming clients are assigned
+	// FRESH numeric clientIDs, so the numeric expectedClients set cannot match
+	// them; the string roster is the one that early-exits on real reclaim.
+	// Empty when grace was started from the legacy numeric-only path.
+	expectedClientStrings map[string]bool
+
+	// reclaimedClientStrings tracks which expected client strings have reclaimed.
+	reclaimedClientStrings map[string]bool
+
 	// reclaimCompleted tracks per-client RECLAIM_COMPLETE tracking (RFC 8881).
 	// Separate from reclaimedClients which tracks grace period early-exit.
 	reclaimCompleted map[uint64]bool
@@ -79,11 +90,13 @@ type GracePeriodState struct {
 // and end callback. The grace period starts inactive; call StartGrace() to begin.
 func NewGracePeriodState(duration time.Duration, onGraceEnd func()) *GracePeriodState {
 	return &GracePeriodState{
-		duration:         duration,
-		expectedClients:  make(map[uint64]bool),
-		reclaimedClients: make(map[uint64]bool),
-		reclaimCompleted: make(map[uint64]bool),
-		onGraceEnd:       onGraceEnd,
+		duration:               duration,
+		expectedClients:        make(map[uint64]bool),
+		reclaimedClients:       make(map[uint64]bool),
+		reclaimCompleted:       make(map[uint64]bool),
+		expectedClientStrings:  make(map[string]bool),
+		reclaimedClientStrings: make(map[string]bool),
+		onGraceEnd:             onGraceEnd,
 	}
 }
 
@@ -93,6 +106,23 @@ func NewGracePeriodState(duration time.Duration, onGraceEnd func()) *GracePeriod
 // to reclaim state from). Otherwise, sets active=true and starts a timer for
 // automatic grace period exit after duration.
 func (g *GracePeriodState) StartGrace(expectedClientIDs []uint64) {
+	g.startGrace(expectedClientIDs, nil)
+}
+
+// StartGraceWithRoster begins the grace period with a durable boot-loaded
+// reclaim roster keyed by stable client identity string (the area-4 H8 path),
+// optionally alongside any same-epoch numeric client IDs.
+//
+// The string roster is authoritative for early-exit after an ungraceful restart:
+// reclaiming clients get fresh numeric clientIDs, so only the string keys can be
+// matched back to the expected set. If BOTH expected sets are empty the grace
+// period is skipped (preserves the fresh-boot fast path — behaves exactly like
+// develop today, where the v4 roster is empty and grace is a no-op).
+func (g *GracePeriodState) StartGraceWithRoster(expectedClientIDs []uint64, expectedClientStrings []string) {
+	g.startGrace(expectedClientIDs, expectedClientStrings)
+}
+
+func (g *GracePeriodState) startGrace(expectedClientIDs []uint64, expectedClientStrings []string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -100,8 +130,8 @@ func (g *GracePeriodState) StartGrace(expectedClientIDs []uint64) {
 		return // Already active
 	}
 
-	// No expected clients: skip grace period entirely
-	if len(expectedClientIDs) == 0 {
+	// No expected clients (numeric OR string): skip grace period entirely.
+	if len(expectedClientIDs) == 0 && len(expectedClientStrings) == 0 {
 		logger.Info("NFSv4 grace period skipped: no previous clients to reclaim")
 		return
 	}
@@ -117,14 +147,35 @@ func (g *GracePeriodState) StartGrace(expectedClientIDs []uint64) {
 	g.reclaimedClients = make(map[uint64]bool)
 	g.reclaimCompleted = make(map[uint64]bool)
 
+	g.expectedClientStrings = make(map[string]bool, len(expectedClientStrings))
+	for _, s := range expectedClientStrings {
+		g.expectedClientStrings[s] = true
+	}
+	g.reclaimedClientStrings = make(map[string]bool)
+
 	logger.Info("NFSv4 grace period started",
 		"duration", g.duration,
-		"expected_clients", len(expectedClientIDs))
+		"expected_clients", len(expectedClientIDs),
+		"expected_client_strings", len(expectedClientStrings))
 
-	// Start timer for automatic exit
+	// Start timer for automatic exit. This hard timer is the backstop: grace
+	// ALWAYS lifts at g.duration regardless of roster state, so a bug in the
+	// reclaim accounting can never wedge new-state creation indefinitely.
 	g.timer = time.AfterFunc(g.duration, func() {
 		g.endGraceWithReason("ended")
 	})
+}
+
+// allReclaimedLocked reports whether every expected client (numeric AND string)
+// has reclaimed. Caller must hold g.mu.
+func (g *GracePeriodState) allReclaimedLocked() bool {
+	if len(g.reclaimedClients) < len(g.expectedClients) {
+		return false
+	}
+	if len(g.reclaimedClientStrings) < len(g.expectedClientStrings) {
+		return false
+	}
+	return true
 }
 
 // IsInGrace returns true if the grace period is currently active.
@@ -158,27 +209,61 @@ func (g *GracePeriodState) ClientReclaimed(clientID uint64) {
 		"reclaimed", len(g.reclaimedClients),
 		"expected", len(g.expectedClients))
 
-	// Check if all expected clients have reclaimed
-	if len(g.reclaimedClients) >= len(g.expectedClients) {
-		logger.Info("NFSv4 grace period ending early: all expected clients reclaimed",
-			"reclaimed", len(g.reclaimedClients))
+	g.maybeEndEarlyLocked() // unlocks g.mu
+}
 
-		// Stop timer, set inactive, and call callback outside lock
-		if g.timer != nil {
-			g.timer.Stop()
-			g.timer = nil
-		}
-		g.active = false
-		callback := g.onGraceEnd
+// ClientReclaimedByString marks an expected client (identified by stable
+// identity string from the durable boot-loaded roster) as having reclaimed.
+// This is the post-restart early-exit path: a reclaiming client carries a fresh
+// numeric clientID, so only its stable string maps back to the expected set.
+// If ALL expected clients have now reclaimed, the grace period ends early.
+func (g *GracePeriodState) ClientReclaimedByString(clientIDString string) {
+	g.mu.Lock()
+
+	if !g.active {
 		g.mu.Unlock()
-
-		if callback != nil {
-			callback()
-		}
 		return
 	}
 
+	if !g.expectedClientStrings[clientIDString] {
+		g.mu.Unlock()
+		return
+	}
+
+	g.reclaimedClientStrings[clientIDString] = true
+
+	logger.Debug("NFSv4 grace period: client reclaimed (by identity)",
+		"client_id_str", clientIDString,
+		"reclaimed_strings", len(g.reclaimedClientStrings),
+		"expected_strings", len(g.expectedClientStrings))
+
+	g.maybeEndEarlyLocked() // unlocks g.mu
+}
+
+// maybeEndEarlyLocked ends the grace period early when every expected client
+// (numeric AND string) has reclaimed. It always releases g.mu before returning,
+// invoking the end callback outside the lock. Caller must hold g.mu.
+func (g *GracePeriodState) maybeEndEarlyLocked() {
+	if !g.allReclaimedLocked() {
+		g.mu.Unlock()
+		return
+	}
+
+	logger.Info("NFSv4 grace period ending early: all expected clients reclaimed",
+		"reclaimed", len(g.reclaimedClients),
+		"reclaimed_strings", len(g.reclaimedClientStrings))
+
+	if g.timer != nil {
+		g.timer.Stop()
+		g.timer = nil
+	}
+	g.active = false
+	callback := g.onGraceEnd
 	g.mu.Unlock()
+
+	if callback != nil {
+		callback()
+	}
 }
 
 // Stop cleanly shuts down the grace period state, stopping any pending timer.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -125,6 +125,30 @@ type StateManager struct {
 	// Defaults to leaseDuration if not explicitly set.
 	graceDuration time.Duration
 
+	// recoveryStore provides server-global durable persistence of confirmed
+	// client identities for reboot/grace recovery (area-4 H8). Optional: when
+	// nil the StateManager behaves exactly as before (no durable recovery),
+	// which keeps bare test constructions working. Set via
+	// SetClientRecoveryStore, wired by the NFS adapter to the first share's
+	// metadata store implementing lock.ClientRecoveryStore (mirroring the NSM
+	// ClientRegistrationStore designation).
+	recoveryStore lock.ClientRecoveryStore
+
+	// serverEpoch is the epoch under which this server instance is running.
+	// Stamped into every client-recovery record so stale records from prior
+	// instances can be GC'd. Set alongside recoveryStore.
+	serverEpoch uint64
+
+	// bootRecoveryVerifiers snapshots, at boot-load time, the BootVerifier of
+	// every prior-instance recovery record keyed by ClientIDString. CLAIM_PREVIOUS
+	// is validated against THIS snapshot (RFC 7530 §9.1.4): a reclaiming client
+	// whose verifier differs from its pre-restart durable verifier rebooted and
+	// must not reclaim. Validating against the snapshot (not the live store) is
+	// essential — a rebooting client's SETCLIENTID_CONFIRM overwrites its live
+	// record with the new verifier before it reaches CLAIM_PREVIOUS. Populated
+	// only by LoadClientRecovery; nil/empty otherwise (reclaim ungated).
+	bootRecoveryVerifiers map[string][8]byte
+
 	// ============================================================================
 	// NFSv4.1 State
 	// ============================================================================
@@ -290,47 +314,59 @@ func (sm *StateManager) generateConfirmVerifier() [8]byte {
 //   - Case 5: Confirmed exists, same verifier -- re-SETCLIENTID (callback update)
 //
 // Returns the client ID and confirm verifier on success, or an error.
-func (sm *StateManager) SetClientID(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string) (*SetClientIDResult, error) {
+// The trailing principal is variadic so existing callers/tests that do not
+// thread an auth principal keep compiling; production passes ctx.Principal().
+func (sm *StateManager) SetClientID(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string, principal ...string) (*SetClientIDResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
+	princ := firstOrEmpty(principal)
 	confirmed := sm.clientsByName[clientIDStr]
 	unconfirmed := sm.unconfirmedByName[clientIDStr]
 
 	switch {
 	case confirmed == nil && unconfirmed == nil:
 		// Case 1: Completely new client
-		return sm.createNewClient(clientIDStr, verifier, callback, clientAddr)
+		return sm.createNewClient(clientIDStr, verifier, callback, clientAddr, princ)
 
 	case confirmed != nil && confirmed.VerifierMatches(verifier):
 		// Case 5: Same client, same verifier (re-SETCLIENTID, maybe callback update)
 		// This handles the case where the client sends SETCLIENTID again with
 		// the same verifier. We update the callback and return a new unconfirmed
 		// record that, when confirmed, will replace the existing confirmed record.
-		return sm.reuseConfirmedClient(confirmed, clientIDStr, verifier, callback, clientAddr)
+		return sm.reuseConfirmedClient(confirmed, clientIDStr, verifier, callback, clientAddr, princ)
 
 	case confirmed != nil && !confirmed.VerifierMatches(verifier):
 		// Case 3: Same client ID string, different verifier (client reboot)
 		// The client has restarted. Create a new unconfirmed record.
 		// The old confirmed record is NOT removed yet -- it gets replaced
 		// when the new record is confirmed.
-		return sm.handleClientReboot(clientIDStr, verifier, callback, clientAddr)
+		return sm.handleClientReboot(clientIDStr, verifier, callback, clientAddr, princ)
 
 	case confirmed == nil && unconfirmed != nil:
 		// Case 4: No confirmed record, unconfirmed exists -- replace unconfirmed
-		return sm.replaceUnconfirmed(unconfirmed, clientIDStr, verifier, callback, clientAddr)
+		return sm.replaceUnconfirmed(unconfirmed, clientIDStr, verifier, callback, clientAddr, princ)
 
 	default:
 		// Case 2: Confirmed exists AND unconfirmed exists -- replace unconfirmed
 		// This is a retransmit or new SETCLIENTID while another is pending.
-		return sm.replaceUnconfirmed(unconfirmed, clientIDStr, verifier, callback, clientAddr)
+		return sm.replaceUnconfirmed(unconfirmed, clientIDStr, verifier, callback, clientAddr, princ)
 	}
+}
+
+// firstOrEmpty returns the first element of ss, or "" if ss is empty. Helper
+// for the variadic principal parameter on SetClientID / ExchangeID.
+func firstOrEmpty(ss []string) string {
+	if len(ss) > 0 {
+		return ss[0]
+	}
+	return ""
 }
 
 // createNewClient handles Case 1: completely new client.
 // Creates a new unconfirmed record with a fresh client ID and confirm verifier.
 // Caller must hold sm.mu.
-func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string) (*SetClientIDResult, error) {
+func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	clientID := sm.generateClientID()
 	confirmVerf := sm.generateConfirmVerifier()
 
@@ -342,6 +378,7 @@ func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, ca
 		Confirmed:       false,
 		Callback:        callback,
 		ClientAddr:      clientAddr,
+		Principal:       principal,
 		CreatedAt:       time.Now(),
 		OpenOwners:      make(map[string]*OpenOwner),
 	}
@@ -365,7 +402,7 @@ func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, ca
 // The confirmed record exists with a matching verifier. Create a new
 // unconfirmed record that will replace the confirmed one when confirmed.
 // Caller must hold sm.mu.
-func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string) (*SetClientIDResult, error) {
+func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	// Remove any existing unconfirmed record for this name
 	if old := sm.unconfirmedByName[clientIDStr]; old != nil {
 		// Only delete from clientsByID if it's a different ID than the confirmed client.
@@ -389,6 +426,7 @@ func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDSt
 		Confirmed:       false,
 		Callback:        callback,
 		ClientAddr:      clientAddr,
+		Principal:       principal,
 		CreatedAt:       time.Now(),
 		OpenOwners:      make(map[string]*OpenOwner),
 	}
@@ -412,7 +450,7 @@ func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDSt
 // Creates a new unconfirmed record. The old confirmed record stays until
 // the new one is confirmed in SETCLIENTID_CONFIRM.
 // Caller must hold sm.mu.
-func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string) (*SetClientIDResult, error) {
+func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	// Remove any existing unconfirmed record for this name
 	if old := sm.unconfirmedByName[clientIDStr]; old != nil {
 		delete(sm.clientsByID, old.ClientID)
@@ -431,6 +469,7 @@ func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte,
 		Confirmed:       false,
 		Callback:        callback,
 		ClientAddr:      clientAddr,
+		Principal:       principal,
 		CreatedAt:       time.Now(),
 		OpenOwners:      make(map[string]*OpenOwner),
 	}
@@ -452,7 +491,7 @@ func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte,
 // replaceUnconfirmed handles Case 2 and Case 4: replace existing unconfirmed.
 // Removes the old unconfirmed record and creates a new one.
 // Caller must hold sm.mu.
-func (sm *StateManager) replaceUnconfirmed(old *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr string) (*SetClientIDResult, error) {
+func (sm *StateManager) replaceUnconfirmed(old *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	// Remove old unconfirmed record
 	delete(sm.clientsByID, old.ClientID)
 	delete(sm.unconfirmedByName, clientIDStr)
@@ -469,6 +508,7 @@ func (sm *StateManager) replaceUnconfirmed(old *ClientRecord, clientIDStr string
 		Confirmed:       false,
 		Callback:        callback,
 		ClientAddr:      clientAddr,
+		Principal:       principal,
 		CreatedAt:       time.Now(),
 		OpenOwners:      make(map[string]*OpenOwner),
 	}
@@ -560,6 +600,13 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 		"client_id_str", record.ClientIDString,
 		"client_addr", record.ClientAddr)
 
+	// Persist a durable client-recovery record so this client can reclaim its
+	// state after an ungraceful server restart (area-4 H8). Best-effort under
+	// sm.mu: a persist failure logs a durability alarm but the confirm STILL
+	// succeeds (the in-memory record is authoritative for this process). No-op
+	// when no recovery store is wired.
+	sm.persistClientRecoveryLocked(record.ClientID, record.ClientIDString, record.Verifier, record.Principal)
+
 	// Verify callback path asynchronously via CB_NULL.
 	// This runs in a goroutine so SETCLIENTID_CONFIRM returns immediately.
 	if record.Callback.Addr != "" {
@@ -648,6 +695,11 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 		"client_id", clientID,
 		"client_id_str", record.ClientIDString,
 		"client_addr", record.ClientAddr)
+
+	// The client's lease lapsed without renewal: it no longer holds reclaimable
+	// state, so drop its durable recovery record (area-4 H8). Best-effort; no-op
+	// when no recovery store is wired.
+	sm.deleteClientRecoveryLocked(record.ClientIDString)
 
 	// Remove all open states AND lock states for all owners
 	for _, owner := range record.OpenOwners {
@@ -872,7 +924,20 @@ func (sm *StateManager) ForceEndGrace() {
 func (sm *StateManager) ReclaimComplete(clientID uint64) error {
 	sm.mu.RLock()
 	gp := sm.gracePeriod
+	// Resolve the durable recovery key for this client (v4.1 = co_ownerid,
+	// v4.0 = nfs_client_id4 string) so the boot-loaded string roster early-exits
+	// and the reclaim-done marker is persisted.
+	recoveryKey := sm.recoveryKeyForClientLocked(clientID)
 	sm.mu.RUnlock()
+
+	if recoveryKey != "" {
+		if gp != nil {
+			gp.ClientReclaimedByString(recoveryKey)
+		}
+		sm.mu.Lock()
+		sm.recordReclaimCompleteLocked(recoveryKey)
+		sm.mu.Unlock()
+	}
 
 	if gp == nil {
 		// Not in grace period, but RECLAIM_COMPLETE outside grace is OK per RFC 8881
@@ -977,12 +1042,37 @@ func (sm *StateManager) OpenFile(
 		if !sm.IsInGrace() {
 			return nil, ErrNoGrace
 		}
-		// Notify the grace period that this client has reclaimed
+		// Verifier-gated reclaim (RFC 7530 §9.1.4, area-4 H8 §3.4): a reclaiming
+		// client whose ClientIDString matches a pre-restart record but whose
+		// BootVerifier changed rebooted and must NOT reclaim prior state.
+		// validateReclaimVerifier self-gates on the boot-load snapshot, so it is
+		// a no-op when no durable prior record exists (reclaim allowed as before).
 		sm.mu.RLock()
 		gp := sm.gracePeriod
+		rec := sm.clientsByID[clientID]
 		sm.mu.RUnlock()
+		if rec != nil {
+			if err := sm.validateReclaimVerifier(rec.ClientIDString, rec.Verifier); err != nil {
+				return nil, err
+			}
+		}
+		// Notify the grace period that this client has reclaimed. Mark both by
+		// numeric clientID (same-epoch reclaim) and by ClientIDString (the
+		// boot-loaded roster is keyed by string since reclaiming clients get a
+		// fresh clientID after restart).
 		if gp != nil {
 			gp.ClientReclaimed(clientID)
+			if rec != nil {
+				gp.ClientReclaimedByString(rec.ClientIDString)
+			}
+		}
+		// v4.0 has no RECLAIM_COMPLETE; the first successful CLAIM_PREVIOUS is
+		// the analog reclaim marker (area-4 H8 §3.3). Persist it so a second
+		// restart inside one grace window does not wait on this client again.
+		if rec != nil {
+			sm.mu.Lock()
+			sm.recordReclaimCompleteLocked(rec.ClientIDString)
+			sm.mu.Unlock()
 		}
 	}
 
@@ -2368,6 +2458,11 @@ func (sm *StateManager) CreateSession(
 		record.Confirmed = true
 		record.Lease = NewLeaseState(record.ClientID, sm.leaseDuration, nil)
 		record.LastRenewal = time.Now()
+
+		// Persist a durable client-recovery record (area-4 H8). v4.1 has no
+		// nfs_client_id4 string; the stable identity is co_ownerid, so the
+		// record is keyed by its string form. Best-effort under sm.mu.
+		sm.persistClientRecoveryLocked(record.ClientID, v41RecoveryKey(record.OwnerID), record.Verifier, record.Principal)
 	}
 
 	// Increment sequence ID

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -56,6 +56,11 @@ type V41ClientRecord struct {
 	// ClientAddr is the network address of the client (for logging/debugging).
 	ClientAddr string
 
+	// Principal is the RPCSEC_GSS / AUTH_SYS principal that established this
+	// client (best-effort). Persisted into the durable client-recovery record
+	// at CREATE_SESSION confirm time as a lease-stealing guard.
+	Principal string
+
 	// CreatedAt is when this record was created.
 	CreatedAt time.Time
 
@@ -165,16 +170,20 @@ type ExchangeIDResult struct {
 // if the record has been confirmed via CREATE_SESSION.
 //
 // Caller must NOT hold sm.mu.
+// The trailing principal is variadic so existing callers/tests that do not
+// thread an auth principal keep compiling; production passes ctx.Principal().
 func (sm *StateManager) ExchangeID(
 	ownerID []byte,
 	verifier [8]byte,
 	_ uint32,
 	clientImplId []types.NfsImplId4,
 	clientAddr string,
+	principal ...string,
 ) (*ExchangeIDResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
+	princ := firstOrEmpty(principal)
 	existing := sm.v41ClientsByOwner[string(ownerID)]
 
 	var record *V41ClientRecord
@@ -182,7 +191,7 @@ func (sm *StateManager) ExchangeID(
 	switch {
 	case existing == nil:
 		// Case 1: New client -- no existing record for this owner
-		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr)
+		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
 		logger.Info("EXCHANGE_ID: new v4.1 client registered",
 			"client_id", record.ClientID,
 			"client_addr", clientAddr)
@@ -190,6 +199,7 @@ func (sm *StateManager) ExchangeID(
 	case existing.Verifier == verifier:
 		// Case 2: Same owner + same verifier -- idempotent (update impl info)
 		existing.ClientAddr = clientAddr
+		existing.Principal = princ
 		existing.LastRenewal = time.Now()
 		applyImplInfo(existing, clientImplId)
 		record = existing
@@ -206,7 +216,7 @@ func (sm *StateManager) ExchangeID(
 			reason = "replaced unconfirmed"
 		}
 		sm.purgeV41Client(existing)
-		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr)
+		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
 		logger.Info("EXCHANGE_ID: new v4.1 client",
 			"reason", reason,
 			"old_client_id", existing.ClientID,
@@ -241,6 +251,7 @@ func (sm *StateManager) createV41Client(
 	verifier [8]byte,
 	clientImplId []types.NfsImplId4,
 	clientAddr string,
+	principal string,
 ) *V41ClientRecord {
 	now := time.Now()
 
@@ -250,6 +261,7 @@ func (sm *StateManager) createV41Client(
 		Verifier:    verifier,
 		SequenceID:  0,
 		ClientAddr:  clientAddr,
+		Principal:   principal,
 		CreatedAt:   now,
 		LastRenewal: now,
 	}
@@ -284,6 +296,13 @@ func applyImplInfo(record *V41ClientRecord, clientImplId []types.NfsImplId4) {
 // record (guards against a concurrent createV41Client having already replaced it).
 // Caller must hold sm.mu.
 func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
+	// Drop the durable recovery record: a purged client (eviction, DESTROY_CLIENTID,
+	// or reboot-replace) cannot reclaim under this identity. Best-effort; no-op when
+	// the client was never confirmed (no record was ever persisted) or no store wired.
+	if record.Confirmed {
+		sm.deleteClientRecoveryLocked(v41RecoveryKey(record.OwnerID))
+	}
+
 	if record.Lease != nil {
 		record.Lease.Stop()
 	}
@@ -421,6 +440,9 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 	if !exists {
 		return fmt.Errorf("v4.0 client %d not found", clientID)
 	}
+
+	// Drop the durable recovery record: an evicted client cannot reclaim.
+	sm.deleteClientRecoveryLocked(record.ClientIDString)
 
 	// Stop lease timer
 	if record.Lease != nil {

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -137,6 +137,17 @@ type CompoundContext struct {
 	RequestDigest []byte
 }
 
+// Principal returns a best-effort string identity of the authenticated caller,
+// used as a lease-stealing guard in durable client-recovery records. For
+// AUTH_UNIX it is "uid:N"; otherwise "" (the GSS principal is not threaded onto
+// the compound context today). It is informational, not an authorization input.
+func (c *CompoundContext) Principal() string {
+	if c.UID != nil {
+		return fmt.Sprintf("uid:%d", *c.UID)
+	}
+	return ""
+}
+
 // V4ClientState holds NFSv4 client state associated with a connection.
 // Carries the client ID for state lookups.
 type V4ClientState struct {

--- a/internal/adapter/nfs/v4/v41/handlers/exchange_id.go
+++ b/internal/adapter/nfs/v4/v41/handlers/exchange_id.go
@@ -50,6 +50,7 @@ func HandleExchangeID(d *Deps, ctx *types.CompoundContext, _ *types.V41RequestCo
 		args.Flags,
 		args.ClientImplId,
 		ctx.ClientAddr,
+		ctx.Principal(),
 	)
 	if err != nil {
 		nfsStatus := MapStateError(err)

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -372,6 +372,32 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	// Expose StateManager to REST API via runtime (for /clients endpoint and /health server info)
 	rt.SetNFSClientProvider(v4StateManager)
 
+	// Designate a server-global durable client-recovery store (area-4 H8): the
+	// first share's metadata store implementing lock.ClientRecoveryStore,
+	// mirroring the NSM ClientRegistrationStore designation. NFSv4 clientids are
+	// not owned by any one share, so the chosen store backs the whole server.
+	var recoveryStore lock.ClientRecoveryStore
+	for _, shareName := range rt.ListShares() {
+		store, err := rt.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			continue
+		}
+		if crs, ok := store.(lock.ClientRecoveryStore); ok {
+			recoveryStore = crs
+			break
+		}
+	}
+	if recoveryStore != nil {
+		v4StateManager.SetClientRecoveryStore(recoveryStore, uint64(v4StateManager.BootEpoch()))
+		// On boot, load the durable prior-client set and seed the v4 grace
+		// expected-reclaim roster (records already reclaim-complete are excluded).
+		// This is what gives the previously-no-op v4 grace a real expected set
+		// after an ungraceful restart. With an empty/fresh store the roster is
+		// empty and grace is skipped, exactly as on develop today.
+		n := v4StateManager.LoadClientRecovery(context.Background())
+		logger.Debug("NFSv4 client-recovery store designated", "boot_loaded_clients", n)
+	}
+
 	// Register callback to rebuild pseudo-fs when shares change (add/remove).
 	// Registered before the initial share loop so no share created between the
 	// loop and subscription is missed.


### PR DESCRIPTION
## What

Wires the NFSv4 `StateManager` to the `lock.ClientRecoveryStore` shipped in slice 1 (#909), so NFSv4 reboot recovery (H8 core) actually works. Implements §3.3 / §3.4 / §4.2 of `DURABLE-STATE-DESIGN.md`. No full open/lock/stateid serialization — standard grace + reclaim with tiny durable client-recovery records (the Linux nfsd / RFC 7530 §9.6 model).

## Wiring (per §3.3)

- **Designate the recovery store** (server-global): NFS adapter picks the first share's metadata store implementing `lock.ClientRecoveryStore`, mirroring the NSM `ClientRegistrationStore` designation. `StateManager.recoveryStore` is optional — nil = today's behavior (bare test constructions unaffected).
- **Persist on confirm:** SETCLIENTID_CONFIRM (v4.0) and first CREATE_SESSION (v4.1, EXCHANGE_ID-confirm) → `PutClientRecovery`, synchronously under `sm.mu`, best-effort + 3s bounded timeout. A persist failure logs a durability ALARM but the confirm STILL succeeds (same contract as the lock manager). Record = clientid + identity string + boot verifier + principal (AUTH_SYS `uid:N`) + ConfirmedAt + ServerEpoch. v4.1 has no `nfs_client_id4` string, so its record is keyed by `co_ownerid`.
- **Delete on teardown:** `onLeaseExpired` / `EvictV40Client` (v4.0) and `purgeV41Client` (v4.1 lease-expiry reaper, eviction, DESTROY_CLIENTID) → `DeleteClientRecovery`.
- **Boot-load roster (H8 core):** `LoadClientRecovery` reads `ListClientRecovery` and seeds the v4 grace **expected-reclaim roster** keyed by stable identity string. Records already `ReclaimComplete` are excluded (a second restart inside one grace window must not re-wait on a done client, §3.2).
- **Reclaim markers:** RECLAIM_COMPLETE (v4.1) and first CLAIM_PREVIOUS (v4.0 analog) → `RecordReclaimComplete`.
- **Verifier validation (§3.4):** CLAIM_PREVIOUS is gated against the **boot-load verifier snapshot** (not the live store — a rebooting client's CONFIRM overwrites its live record with the new verifier before reclaim). Matching verifier = valid reclaimer; changed verifier = rebooted client → `NFS4ERR_NO_GRACE`.

v4 byte-range ranges stay in the lock manager; reclaim re-LOCKs with `reclaim=true`. No opens/stateids/locks persisted here.

## Grace-lift safety

The boot roster is keyed by identity string because reclaiming clients get fresh numeric clientIDs after restart. `GracePeriodState` gains an additive string roster (`StartGraceWithRoster` / `ClientReclaimedByString`); the legacy numeric path is untouched. Grace lifts on the earlier of:

- **early-exit** when every expected client (numeric AND string) has reclaimed, and
- **hard timer backstop** at `graceDuration`, which ALWAYS fires regardless of roster state — a reclaim-accounting bug can never wedge new-state creation.

A fresh server with an empty recovery list does NOT enter grace (identical to develop today), so pjdfstest and the fresh-CI fast path are preserved.

## Scope

`internal/adapter/nfs/v4/state/` + v4 handlers (setclientid / exchange_id) + the adapter wiring that designates the store. Slice-1 backends and lock-manager internals untouched. The coordinator refcount + explicit global boot-entry is slice 3.

## Tests

`internal/adapter/nfs/v4/state/client_recovery_test.go`: persist-on-confirm field assertions (incl. BootVerifier + Principal + ServerEpoch); confirm-succeeds-despite-persist-error; nil-store no-op; delete-on-lease-expiry; boot-load seeds roster (ReclaimComplete excluded); empty/all-complete skip grace; matching-verifier reclaim allowed + early-exit; changed-verifier reclaim rejected; timer backstop lifts; v4.1 CREATE_SESSION persist + RECLAIM_COMPLETE drains roster; v4.1 DESTROY_CLIENTID deletes. `go test -race ./internal/adapter/nfs/... ./pkg/metadata/...` green; gofmt/vet/golangci-lint clean.

DO NOT MERGE — slice 2 of the area-4 H8 series; slice 3 (global boot-entry + coordinator refcount) stacks on top.