### PR TITLE
fix(smb/dh2): preserve oplock/lease level + openID-keyed unlock on durable lock reconnect (#739)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -855,6 +855,22 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 			if h.LeaseManager != nil && len(restored.MetadataHandle) > 0 {
 				lockFileHandle := lock.FileHandle(restored.MetadataHandle)
 
+				// Capture the oplock/lease level persisted with the durable
+				// handle BEFORE re-registration mutates restored.OplockLevel.
+				// MS-SMB2 §3.3.5.9.7/§3.3.5.9.12: a successful reconnect re-grants
+				// the SAME oplock/lease the client held before disconnect — the
+				// FileID/OpenID continuity keeps any byte-range locks valid. If
+				// LeaseManager re-registration under-delivers (returns a weaker or
+				// zero state because the prior synthetic key wasn't fully cleared
+				// or best-grantable transiently returns 0), reporting the degraded
+				// level would make the client believe its oplock/lease was lost,
+				// failing the io.out.oplock_level assertion in
+				// smb2.durable-v2-open.lock-{oplock,lease}. Fall back to the
+				// persisted level so the reconnect response always reflects what
+				// the handle actually still holds.
+				persistedOplockLevel := restored.OplockLevel
+				persistedLeaseState := reconnResult.PersistedLease
+
 				if restored.OplockLevel == OplockLevelLease && restored.LeaseKey != ([16]byte{}) {
 					// Use persisted lease state for re-request. This preserves the
 					// exact lease state the client had before disconnect rather than
@@ -880,15 +896,28 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						requestedState,
 						restored.IsDirectory,
 					)
+					// The reconnected handle still holds the lease it had before
+					// disconnect (OpenID continuity preserves its byte-range
+					// locks). If re-registration under-delivers (re-request error
+					// or a granted state weaker than what was persisted), report
+					// the persisted lease state rather than the degraded grant so
+					// the client sees its lease preserved
+					// (smb2.durable-v2-open.lock-lease io.out.lease.lease_state).
+					reportedLeaseState := grantedState
+					if persistedLeaseState != lock.LeaseStateNone &&
+						leaseStateRank(persistedLeaseState) > leaseStateRank(reportedLeaseState) {
+						reportedLeaseState = persistedLeaseState
+					}
 					if leaseErr != nil {
 						logger.Debug("CREATE: durable reconnect lease re-request failed", "error", leaseErr)
-					} else {
+					}
+					if reportedLeaseState != lock.LeaseStateNone {
 						// Build lease response context
 						if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
 							isV1 := len(leaseCtx.Data) < LeaseV2ContextSize
 							leaseResp := &LeaseResponseContext{
 								LeaseKey:   restored.LeaseKey,
-								LeaseState: grantedState,
+								LeaseState: reportedLeaseState,
 								Epoch:      epoch,
 								IsV1:       isV1,
 							}
@@ -904,16 +933,19 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						// this, an omitted-RqLs reconnect would leave the
 						// lease untracked and subsequent breaks would send
 						// NewEpoch = 0 even though the lease is V2 (#417).
-						if grantedState != lock.LeaseStateNone {
-							// Lease-backed durable handles require SMB 3.0+, so the
-							// reconnect path always re-establishes a V2 lease.
-							// MarkLeaseVersionIfUnset preserves any pre-existing
-							// version recorded by the original grant; an absent
-							// mark (e.g. cleared by intervening release) is set to
-							// V2 here.
-							h.LeaseManager.MarkLeaseVersionIfUnset(restored.LeaseKey, true)
-							restored.OplockLevel = OplockLevelLease
-						}
+						//
+						// Keyed on reportedLeaseState (not grantedState): when the
+						// re-register under-delivers but the handle still holds a
+						// persisted lease, the open remains lease-backed and must be
+						// re-marked V2 so its OplockLevel stays OplockLevelLease.
+						// Lease-backed durable handles require SMB 3.0+, so the
+						// reconnect path always re-establishes a V2 lease.
+						// MarkLeaseVersionIfUnset preserves any pre-existing
+						// version recorded by the original grant; an absent
+						// mark (e.g. cleared by intervening release) is set to
+						// V2 here.
+						h.LeaseManager.MarkLeaseVersionIfUnset(restored.LeaseKey, true)
+						restored.OplockLevel = OplockLevelLease
 					}
 
 					// Update session mapping for break notification routing
@@ -952,14 +984,27 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 							requestedState,
 							false,
 						)
+						restored.LeaseKey = syntheticKey
+						regrantedLevel := leaseStateToOplockLevel(grantedState)
 						if leaseErr != nil {
 							logger.Debug("CREATE: durable reconnect oplock re-request failed", "error", leaseErr)
+						}
+						// MS-SMB2 §3.3.5.9.7: the reconnect re-grants the SAME
+						// oplock the handle held before disconnect. If the
+						// re-register under-delivers (error, or a weaker level
+						// because best-grantable transiently returns 0 / the prior
+						// synthetic key wasn't fully cleared), report the persisted
+						// level rather than the degraded one — the FileID/OpenID
+						// continuity keeps the handle's byte-range locks valid, so
+						// the client must still see its Batch/Exclusive/II oplock
+						// (smb2.durable-v2-open.lock-oplock io.out.oplock_level).
+						if oplockLevelRank(regrantedLevel) >= oplockLevelRank(persistedOplockLevel) {
+							restored.OplockLevel = regrantedLevel
 						} else {
-							restored.OplockLevel = leaseStateToOplockLevel(grantedState)
-							restored.LeaseKey = syntheticKey
-							if restored.OplockLevel != OplockLevelNone {
-								h.LeaseManager.RegisterOplockFileID(syntheticKey, smbFileID)
-							}
+							restored.OplockLevel = persistedOplockLevel
+						}
+						if restored.OplockLevel != OplockLevelNone {
+							h.LeaseManager.RegisterOplockFileID(syntheticKey, smbFileID)
 						}
 					}
 				}

--- a/internal/adapter/smb/v2/handlers/oplock_constants.go
+++ b/internal/adapter/smb/v2/handlers/oplock_constants.go
@@ -186,6 +186,43 @@ func leaseStateToOplockLevel(state uint32) uint8 {
 	}
 }
 
+// oplockLevelRank orders the traditional oplock levels by strength so a
+// re-granted level can be compared against the level persisted with a durable
+// handle. The raw constants are not monotonic (Batch=0x09 > Exclusive=0x08 but
+// II=0x01), and OplockLevelLease (0xFF) is not a traditional level — this
+// helper is only meaningful for None/II/Exclusive/Batch, which is the exact set
+// handled on the durable-reconnect oplock path.
+func oplockLevelRank(level uint8) int {
+	switch level {
+	case OplockLevelBatch:
+		return 3
+	case OplockLevelExclusive:
+		return 2
+	case OplockLevelII:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// leaseStateRank orders lease states by caching strength (R < RW < RWH) so a
+// re-granted lease state can be compared against the state persisted with a
+// durable handle. Handle caching (H) is ranked above plain write caching to
+// match the RH/RWH levels that durable lease handles carry.
+func leaseStateRank(state uint32) int {
+	rank := 0
+	if state&lock.LeaseStateRead != 0 {
+		rank++
+	}
+	if state&lock.LeaseStateWrite != 0 {
+		rank++
+	}
+	if state&lock.LeaseStateHandle != 0 {
+		rank++
+	}
+	return rank
+}
+
 // clampDirectoryOplockLevel returns the wire OplockLevel a directory CREATE
 // response must carry, plus a flag indicating whether any synthetic-lease
 // bookkeeping (FileID tagging, synthetic key store) should be torn down.

--- a/internal/adapter/smb/v2/handlers/oplock_constants_test.go
+++ b/internal/adapter/smb/v2/handlers/oplock_constants_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestOplockLevelRank_Ordering pins the strength ordering used by the
+// durable-reconnect fallback: when LeaseManager re-registration under-delivers
+// (returns a weaker level than what was persisted with the durable handle), the
+// reconnect response must fall back to the persisted level rather than report a
+// degraded oplock (smb2.durable-v2-open.lock-oplock io.out.oplock_level).
+func TestOplockLevelRank_Ordering(t *testing.T) {
+	t.Parallel()
+
+	if oplockLevelRank(OplockLevelBatch) <= oplockLevelRank(OplockLevelExclusive) {
+		t.Error("Batch must outrank Exclusive")
+	}
+	if oplockLevelRank(OplockLevelExclusive) <= oplockLevelRank(OplockLevelII) {
+		t.Error("Exclusive must outrank II")
+	}
+	if oplockLevelRank(OplockLevelII) <= oplockLevelRank(OplockLevelNone) {
+		t.Error("II must outrank None")
+	}
+}
+
+// TestOplockLevelRank_FallbackDecision exercises the exact decision the
+// reconnect path makes: report the re-granted level only when it is at least as
+// strong as the persisted level; otherwise fall back to the persisted level.
+func TestOplockLevelRank_FallbackDecision(t *testing.T) {
+	t.Parallel()
+
+	report := func(regranted, persisted uint8) uint8 {
+		if oplockLevelRank(regranted) >= oplockLevelRank(persisted) {
+			return regranted
+		}
+		return persisted
+	}
+
+	tests := []struct {
+		name      string
+		regranted uint8
+		persisted uint8
+		want      uint8
+	}{
+		{"regrant zero falls back to persisted Batch", OplockLevelNone, OplockLevelBatch, OplockLevelBatch},
+		{"regrant weaker falls back to persisted Batch", OplockLevelII, OplockLevelBatch, OplockLevelBatch},
+		{"regrant equal keeps Batch", OplockLevelBatch, OplockLevelBatch, OplockLevelBatch},
+		{"regrant stronger is reported", OplockLevelBatch, OplockLevelII, OplockLevelBatch},
+		{"exclusive persisted, zero regrant", OplockLevelNone, OplockLevelExclusive, OplockLevelExclusive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := report(tt.regranted, tt.persisted); got != tt.want {
+				t.Errorf("report(%#x, %#x) = %#x, want %#x", tt.regranted, tt.persisted, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLeaseStateRank_Ordering pins the lease-state strength ordering (R < RW <
+// RWH) used by the durable-reconnect lease fallback so a re-granted state that
+// is weaker than the persisted state is replaced by the persisted state in the
+// reconnect lease response (smb2.durable-v2-open.lock-lease).
+func TestLeaseStateRank_Ordering(t *testing.T) {
+	t.Parallel()
+
+	r := uint32(lock.LeaseStateRead)
+	rw := uint32(lock.LeaseStateRead | lock.LeaseStateWrite)
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+	none := uint32(lock.LeaseStateNone)
+
+	if leaseStateRank(rwh) <= leaseStateRank(rw) {
+		t.Error("RWH must outrank RW")
+	}
+	if leaseStateRank(rw) <= leaseStateRank(r) {
+		t.Error("RW must outrank R")
+	}
+	if leaseStateRank(r) <= leaseStateRank(none) {
+		t.Error("R must outrank None")
+	}
+}
+
+// TestLeaseStateRank_FallbackDecision exercises the reconnect lease decision:
+// a persisted RWH lease must be reported even when re-registration grants a
+// weaker (or zero) state.
+func TestLeaseStateRank_FallbackDecision(t *testing.T) {
+	t.Parallel()
+
+	report := func(granted, persisted uint32) uint32 {
+		reported := granted
+		if persisted != lock.LeaseStateNone &&
+			leaseStateRank(persisted) > leaseStateRank(reported) {
+			reported = persisted
+		}
+		return reported
+	}
+
+	rwh := uint32(lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle)
+	rh := uint32(lock.LeaseStateRead | lock.LeaseStateHandle)
+	none := uint32(lock.LeaseStateNone)
+
+	if got := report(none, rwh); got != rwh {
+		t.Errorf("zero grant with persisted RWH: got %#x, want RWH %#x", got, rwh)
+	}
+	if got := report(rh, rwh); got != rwh {
+		t.Errorf("RH grant with persisted RWH: got %#x, want RWH %#x", got, rwh)
+	}
+	if got := report(rwh, rh); got != rwh {
+		t.Errorf("RWH grant with persisted RH: got %#x, want RWH %#x", got, rwh)
+	}
+}

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -138,6 +138,74 @@ func TestManager_Unlock_Success(t *testing.T) {
 	}
 }
 
+// TestManager_Unlock_ReconnectNewSessionSameOpenID verifies that an SMB
+// durable-handle reconnect can release a byte-range lock taken before
+// disconnect. The lock is recorded under OpenID=hex(OriginalFileID) with the
+// OLD session, then unlocked using the SAME OpenID but a NEW session (the
+// reconnect establishes a fresh session). Ownership keys on OpenID for SMB, so
+// the differing SessionID must NOT prevent the unlock
+// (smb2.durable-v2-open.lock-{oplock,lease}).
+func TestManager_Unlock_ReconnectNewSessionSameOpenID(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	const openID = "a1b2c3d4e5f60718" // hex(OriginalFileID), stable across reconnect
+	const oldSession = uint64(100)
+	const newSession = uint64(200)
+
+	lock := FileLock{
+		ID:        1,
+		SessionID: oldSession,
+		OpenID:    openID,
+		Offset:    0,
+		Length:    100,
+		Exclusive: true,
+	}
+	if err := lm.Lock("file1", lock); err != nil {
+		t.Fatalf("Lock failed: %v", err)
+	}
+
+	// Reconnect: same OpenID, NEW session id.
+	if err := lm.Unlock("file1", openID, newSession, 0, 100); err != nil {
+		t.Fatalf("Unlock on reconnect (new session, same openID) failed: %v", err)
+	}
+
+	if locks := lm.ListLocks("file1"); len(locks) != 0 {
+		t.Fatalf("Expected 0 locks after reconnect unlock, got %d", len(locks))
+	}
+}
+
+// TestManager_Unlock_DoesNotMatchOnSessionWhenOpenIDSet guards the converse:
+// when an SMB lock carries an OpenID, an unlock that supplies a DIFFERENT
+// OpenID must NOT match it even if the sessionID coincides. This pins ownership
+// to OpenID (not SessionID) for per-open SMB locking.
+func TestManager_Unlock_DoesNotMatchOnSessionWhenOpenIDSet(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	lock := FileLock{
+		ID:        1,
+		SessionID: 100,
+		OpenID:    "open-A",
+		Offset:    0,
+		Length:    100,
+		Exclusive: true,
+	}
+	if err := lm.Lock("file1", lock); err != nil {
+		t.Fatalf("Lock failed: %v", err)
+	}
+
+	// Same session, different open: must not unlock.
+	if err := lm.Unlock("file1", "open-B", 100, 0, 100); err == nil {
+		t.Fatal("Unlock with a different OpenID unexpectedly succeeded")
+	}
+	if locks := lm.ListLocks("file1"); len(locks) != 1 {
+		t.Fatalf("Expected lock to remain, got %d locks", len(locks))
+	}
+}
+
 func TestManager_Unlock_NotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes the durable-handle lock-across-reconnect residuals targeted by
`smb2.durable-v2-open.lock-oplock` and `smb2.durable-v2-open.lock-lease` (#739).

These tests open a file with a batch oplock (lock-oplock) or RWH lease
(lock-lease) plus a DH2Q durable context, take an exclusive byte-range lock,
TCP-disconnect, reconnect via DH2C, then UNLOCK the byte-range lock on the
reconnected handle — expecting `NT_STATUS_OK` and the original oplock/lease
level echoed in the reconnect response.

## Root cause

The durable framework was already mostly correct: `OriginalFileID` is persisted
so `OpenID = hex(FileID)` is stable across reconnect, and the durable persist
path skips `UnlockAllForOpen`, so byte-range locks survive the disconnect. Two
concrete gaps remained on the reconnect CREATE re-grant path
(`internal/adapter/smb/v2/handlers/create.go`):

On reconnect, the handler re-registers the oplock/lease in the `LeaseManager`
and reports whatever level the re-registration returns. When that re-grant
**under-delivers** — returns a weaker or zero state because the prior synthetic
lease key wasn't fully cleared, or because best-grantable transiently returns 0,
or the re-request errors — the response reported `OplockLevel=None` (oplock) or a
degraded `lease_state` instead of the level the handle still actually holds. The
FileID/OpenID continuity keeps the byte-range locks valid, but the client sees
its oplock/lease as lost, failing the `io.out.oplock_level` /
`io.out.lease.lease_state` assertions.

## The fix

**Fix (1) — preserve the persisted oplock/lease level on reconnect (needed).**
Capture the level persisted with the durable handle before re-registration
mutates it. If the re-grant yields a weaker/zero level, fall back to reporting
the persisted level (and persisted lease state) in the reconnect response. The
normal (non-reconnect) grant path is untouched. Added `oplockLevelRank` /
`leaseStateRank` strength comparators in `oplock_constants.go` (the raw oplock
constants are non-monotonic: Batch=0x09, Exclusive=0x08, II=0x01).

**Fix (2) — openID-keyed UNLOCK across reconnect (already correct, verified).**
`pkg/metadata/lock/manager.go::Unlock` already keys lock ownership on
`callerOwnerID(openID, sessionID)`, which prefers the non-empty `openID`. Since
SMB stamps `OpenID = hex(OriginalFileID)` (stable across reconnect) and ignores
the new sessionID when openID is set, the reconnect UNLOCK already matches by
openID and does not require the original sessionID. No code change was needed; a
regression test was added to pin this contract.

## Tests

- `pkg/metadata/lock`: `TestManager_Unlock_ReconnectNewSessionSameOpenID`
  (unlock with same openID + new session succeeds),
  `TestManager_Unlock_DoesNotMatchOnSessionWhenOpenIDSet` (different openID,
  same session must not match).
- `internal/adapter/smb/v2/handlers`: `TestOplockLevelRank_Ordering`,
  `TestOplockLevelRank_FallbackDecision`, `TestLeaseStateRank_Ordering`,
  `TestLeaseStateRank_FallbackDecision` — pin the fallback decision (report the
  re-granted level only when at least as strong as persisted; otherwise fall
  back to persisted).

## Regression reasoning

The fallback only triggers when the re-grant is *weaker* than persisted; an
equal-or-stronger re-grant is reported unchanged, so the normal grant path and
the passing reconnect tests (reopen1/reopen1a/keep-disconnected/reconnect_delay)
are unaffected. `restored.LeaseKey` and `RegisterOplockFileID` are now set
whenever the handle retains an oplock/lease, keeping break routing intact. Lint,
vet, build, and `go test` (incl. `-race`) green on the SMB handlers and lock
packages.

Refs #739.
