### PR TITLE
test(smb): walk back #739 lock-oplock KF row (CI-confirmed)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -197,7 +197,6 @@ still fail due to incomplete reconnect, lease coordination, and persistence.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-v2-open.lock-oplock | Durable handles V2 | DH2 lock with oplock not fully working | #739 |
 | smb2.durable-v2-open.lock-lease | Durable handles V2 | DH2 lock with lease not fully working | #739 |
 | smb2.durable-v2-open.app-instance | Durable handles V2 | App instance ID not fully working | #739 |
 | smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Persistent handles not implemented | #739 |
@@ -332,6 +331,18 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-05-31 — #739 lock-oplock: 1 row flipped
+
+PR #913 preserves the persisted oplock/lease level on durable reconnect when the
+LeaseManager re-grant under-delivers (reports the persisted Batch level rather
+than degrading to None), so a byte-range lock taken before disconnect unlocks
+cleanly on the reconnected handle. CI smbtorture confirmed `success:` for:
+
+- `smb2.durable-v2-open.lock-oplock`
+
+#739 stays open: `lock-lease` (the lease variant still degrades), `app-instance`,
+and the persistent-handle rows still fail.
 
 ### 2026-05-31 — stale-row harvest: 4 rows already passing
 


### PR DESCRIPTION
Removes `smb2.durable-v2-open.lock-oplock` — PR #913 (merged) made durable reconnect preserve the persisted oplock level when re-grant under-delivers; CI smbtorture confirmed `success: durable-v2-open.lock-oplock` with no regression. #739 stays open (lock-lease/app-instance/persistent-* remain).