### PR TITLE
fix(blockstore): drain in-flight ops on Store.Close (area-7 H-A use-after-close)

### DIFF
--- a/internal/adapter/common/content_errmap.go
+++ b/internal/adapter/common/content_errmap.go
@@ -7,6 +7,7 @@ import (
 	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 )
 
 // Content-error mapping.
@@ -27,6 +28,12 @@ import (
 func MapContentToNFS3(err error) uint32 {
 	if err == nil {
 		return nfs3types.NFS3OK
+	}
+	// The block store was Closed under the in-flight op — the share was
+	// removed/hot-reloaded mid-transfer (area-7 H-A). STALE tells the
+	// client the handle no longer refers to a live object.
+	if goerrors.Is(err, engine.ErrStoreClosed) {
+		return nfs3types.NFS3ErrStale
 	}
 	// CAS key parse failure indicates corrupted metadata; surfaced as
 	// invalid argument.
@@ -58,6 +65,10 @@ func MapContentToNFS4(err error) uint32 {
 	if err == nil {
 		return nfs4types.NFS4_OK
 	}
+	// Closed store under an in-flight op (area-7 H-A) → STALE.
+	if goerrors.Is(err, engine.ErrStoreClosed) {
+		return nfs4types.NFS4ERR_STALE
+	}
 	if goerrors.Is(err, blockstore.ErrCASKeyMalformed) {
 		return nfs4types.NFS4ERR_INVAL
 	}
@@ -78,6 +89,12 @@ func MapContentToNFS4(err error) uint32 {
 func MapContentToSMB(err error) smbtypes.Status {
 	if err == nil {
 		return smbtypes.StatusSuccess
+	}
+	// Closed store under an in-flight op (area-7 H-A): the share went away
+	// mid-transfer. STATUS_FILE_CLOSED is the closest SMB stale-handle
+	// signal (matches the merrs.ErrStaleHandle row in errmap.go).
+	if goerrors.Is(err, engine.ErrStoreClosed) {
+		return smbtypes.StatusFileClosed
 	}
 	if goerrors.Is(err, blockstore.ErrCASKeyMalformed) {
 		return smbtypes.StatusInvalidParameter

--- a/internal/adapter/common/errmap.go
+++ b/internal/adapter/common/errmap.go
@@ -6,6 +6,7 @@ import (
 	nfs3types "github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
@@ -258,6 +259,15 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 // accessor so each protocol returns its own SUCCESS constant (NFS3OK / NFS4_OK
 // / StatusSuccess) instead of defaultCodes.
 func lookupErrorRow(err error) protoCodes {
+	// engine.ErrStoreClosed is a block-store-lifecycle sentinel (not a
+	// merrs.StoreError) returned when a data op hits a Store that an admin
+	// removed/hot-reloaded mid-transfer (area-7 H-A). Map it to the same
+	// stale-handle row as merrs.ErrStaleHandle so the client observes the
+	// share going away (NFS *_STALE / SMB STATUS_FILE_CLOSED) rather than a
+	// generic I/O / server fault.
+	if goerrors.Is(err, engine.ErrStoreClosed) {
+		return errorMap[merrs.ErrStaleHandle]
+	}
 	var storeErr *merrs.StoreError
 	if !goerrors.As(err, &storeErr) {
 		return defaultCodes

--- a/internal/adapter/common/errmap_test.go
+++ b/internal/adapter/common/errmap_test.go
@@ -9,6 +9,7 @@ import (
 	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
@@ -413,5 +414,43 @@ func TestCrossProtocolUnitConformance(t *testing.T) {
 		if inE2E && inUnit {
 			t.Errorf("code %v is listed in BOTH e2eTriggerableCodes and exoticCodes() — pick one tier so coverage drift is detectable", code)
 		}
+	}
+}
+
+// TestErrStoreClosedMapsToStale verifies engine.ErrStoreClosed (block store
+// Closed under an in-flight op — area-7 H-A) maps to a stale-handle status on
+// every adapter path: NFS *_STALE and SMB STATUS_FILE_CLOSED. Both the
+// general (errmap.go) and content (content_errmap.go) tables are covered,
+// plus wrapped forms via fmt.Errorf, since the data path returns wrapped
+// errors from the engine.
+func TestErrStoreClosedMapsToStale(t *testing.T) {
+	wrapped := fmt.Errorf("write content: %w", engine.ErrStoreClosed)
+
+	for name, err := range map[string]error{
+		"direct":  engine.ErrStoreClosed,
+		"wrapped": wrapped,
+	} {
+		t.Run(name, func(t *testing.T) {
+			// General table (MapTo*).
+			if got := MapToNFS3(err); got != nfs3types.NFS3ErrStale {
+				t.Errorf("MapToNFS3 = %d, want NFS3ErrStale", got)
+			}
+			if got := MapToNFS4(err); got != nfs4types.NFS4ERR_STALE {
+				t.Errorf("MapToNFS4 = %d, want NFS4ERR_STALE", got)
+			}
+			if got := MapToSMB(err); got != smbtypes.StatusFileClosed {
+				t.Errorf("MapToSMB = %v, want StatusFileClosed", got)
+			}
+			// Content table (MapContentTo*) — the data-path WRITE/READ seam.
+			if got := MapContentToNFS3(err); got != nfs3types.NFS3ErrStale {
+				t.Errorf("MapContentToNFS3 = %d, want NFS3ErrStale", got)
+			}
+			if got := MapContentToNFS4(err); got != nfs4types.NFS4ERR_STALE {
+				t.Errorf("MapContentToNFS4 = %d, want NFS4ERR_STALE", got)
+			}
+			if got := MapContentToSMB(err); got != smbtypes.StatusFileClosed {
+				t.Errorf("MapContentToSMB = %v, want StatusFileClosed", got)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/v2/handlers/flush.go
+++ b/internal/adapter/smb/v2/handlers/flush.go
@@ -237,7 +237,15 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	_, flushErr := blockStore.Flush(ctx.Context, string(file.PayloadID))
 	if flushErr != nil {
 		logger.Warn("FLUSH: failed", "path", openFile.Path, "error", flushErr)
-		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUnexpectedIOError}}, nil
+		// Route through common.MapToSMB so a closed-store error (the share
+		// was removed/hot-reloaded mid-flush, area-7 H-A) surfaces as
+		// STATUS_FILE_CLOSED rather than a generic I/O error. Non-mapped
+		// errors still fall back to the I/O-class default.
+		status := common.MapToSMB(flushErr)
+		if status == types.StatusInternalError {
+			status = types.StatusUnexpectedIOError
+		}
+		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/flush.go
+++ b/internal/adapter/smb/v2/handlers/flush.go
@@ -237,15 +237,12 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	_, flushErr := blockStore.Flush(ctx.Context, string(file.PayloadID))
 	if flushErr != nil {
 		logger.Warn("FLUSH: failed", "path", openFile.Path, "error", flushErr)
-		// Route through common.MapToSMB so a closed-store error (the share
-		// was removed/hot-reloaded mid-flush, area-7 H-A) surfaces as
-		// STATUS_FILE_CLOSED rather than a generic I/O error. Non-mapped
-		// errors still fall back to the I/O-class default.
-		status := common.MapToSMB(flushErr)
-		if status == types.StatusInternalError {
-			status = types.StatusUnexpectedIOError
-		}
-		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
+		// FLUSH is a content-path op (same as NFS COMMIT): MapContentToSMB
+		// maps a closed-store error (the share was removed/hot-reloaded
+		// mid-flush, area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+		// CAS-corruption / remote-unavailable mappings, defaulting to the
+		// I/O-class status for opaque failures.
+		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: common.MapContentToSMB(flushErr)}}, nil
 	}
 
 	// ========================================================================

--- a/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
@@ -456,15 +456,13 @@ func (h *Handler) executeCopyChunks(
 		if err != nil {
 			logger.Warn("COPYCHUNK: source read failed",
 				"chunk", i, "srcPath", srcOpen.Path, "error", err)
-			// Route through common.MapToSMB so a closed-store error (source
-			// share removed mid-copy, area-7 H-A) surfaces as
-			// STATUS_FILE_CLOSED; other errors keep the I/O-class default.
-			status := common.MapToSMB(err)
-			if status == types.StatusInternalError {
-				status = types.StatusUnexpectedIOError
-			}
+			// COPYCHUNK source read is a content-path op: MapContentToSMB
+			// maps a closed-store error (source share removed mid-copy,
+			// area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+			// CAS-corruption / remote-unavailable mappings, defaulting to
+			// the I/O-class status for opaque failures.
 			return copyChunkPartialResponse(ctlCode, dstFileID,
-				status, chunksWritten, totalBytesWritten), nil
+				common.MapContentToSMB(err), chunksWritten, totalBytesWritten), nil
 		}
 
 		// Reject short reads (TOCTOU: source may have been truncated concurrently)
@@ -495,15 +493,13 @@ func (h *Handler) executeCopyChunks(
 		if _, err := dstBlockStore.WriteAt(ctx.Context, string(writeOp.PayloadID), nil, data, chunk.TargetOffset); err != nil {
 			logger.Warn("COPYCHUNK: destination write failed",
 				"chunk", i, "dstPath", dstOpen.Path, "error", err)
-			// Route through common.MapToSMB so a closed-store error (dest
-			// share removed mid-copy, area-7 H-A) surfaces as
-			// STATUS_FILE_CLOSED; other errors keep the I/O-class default.
-			status := common.MapToSMB(err)
-			if status == types.StatusInternalError {
-				status = types.StatusUnexpectedIOError
-			}
+			// COPYCHUNK destination write is a content-path op:
+			// MapContentToSMB maps a closed-store error (dest share removed
+			// mid-copy, area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+			// CAS-corruption / remote-unavailable mappings, defaulting to
+			// the I/O-class status for opaque failures.
 			return copyChunkPartialResponse(ctlCode, dstFileID,
-				status, chunksWritten, totalBytesWritten), nil
+				common.MapContentToSMB(err), chunksWritten, totalBytesWritten), nil
 		}
 
 		// Commit write metadata

--- a/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/v2/handlers/ioctl_copychunk.go
@@ -456,8 +456,15 @@ func (h *Handler) executeCopyChunks(
 		if err != nil {
 			logger.Warn("COPYCHUNK: source read failed",
 				"chunk", i, "srcPath", srcOpen.Path, "error", err)
+			// Route through common.MapToSMB so a closed-store error (source
+			// share removed mid-copy, area-7 H-A) surfaces as
+			// STATUS_FILE_CLOSED; other errors keep the I/O-class default.
+			status := common.MapToSMB(err)
+			if status == types.StatusInternalError {
+				status = types.StatusUnexpectedIOError
+			}
 			return copyChunkPartialResponse(ctlCode, dstFileID,
-				types.StatusInternalError, chunksWritten, totalBytesWritten), nil
+				status, chunksWritten, totalBytesWritten), nil
 		}
 
 		// Reject short reads (TOCTOU: source may have been truncated concurrently)
@@ -488,8 +495,15 @@ func (h *Handler) executeCopyChunks(
 		if _, err := dstBlockStore.WriteAt(ctx.Context, string(writeOp.PayloadID), nil, data, chunk.TargetOffset); err != nil {
 			logger.Warn("COPYCHUNK: destination write failed",
 				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+			// Route through common.MapToSMB so a closed-store error (dest
+			// share removed mid-copy, area-7 H-A) surfaces as
+			// STATUS_FILE_CLOSED; other errors keep the I/O-class default.
+			status := common.MapToSMB(err)
+			if status == types.StatusInternalError {
+				status = types.StatusUnexpectedIOError
+			}
 			return copyChunkPartialResponse(ctlCode, dstFileID,
-				types.StatusInternalError, chunksWritten, totalBytesWritten), nil
+				status, chunksWritten, totalBytesWritten), nil
 		}
 
 		// Commit write metadata

--- a/pkg/blockstore/engine/close_gate_test.go
+++ b/pkg/blockstore/engine/close_gate_test.go
@@ -54,9 +54,13 @@ func TestStore_CloseDrainsInFlightReadAt(t *testing.T) {
 		bs := newTestEngine(t, 0, 0)
 		ctx := context.Background()
 		payloadID := "race-read-file"
-		// Seed some data so ReadAt has something to walk (best-effort; the
-		// race is on the lifecycle, not on the content).
-		_, _ = bs.WriteAt(ctx, payloadID, nil, []byte("0123456789"), 0)
+		// Seed some data so ReadAt has something to walk. Assert the seed
+		// succeeds so a seed failure can't make the lifecycle assertion
+		// below pass/fail for the wrong reason — the seed runs before any
+		// Close, so it must never error.
+		if _, err := bs.WriteAt(ctx, payloadID, nil, []byte("0123456789"), 0); err != nil {
+			t.Fatalf("iter %d: seed WriteAt failed: %v", i, err)
+		}
 
 		var wg sync.WaitGroup
 		wg.Add(2)
@@ -74,11 +78,16 @@ func TestStore_CloseDrainsInFlightReadAt(t *testing.T) {
 
 		wg.Wait()
 
-		// A read may legitimately miss (closed store, or content not yet
-		// durable) — we only assert it never panics/races and that any
-		// lifecycle error is the typed ErrStoreClosed. Content-level read
-		// misses surface their own errors and are out of scope here.
-		_ = readErr
+		// The in-flight ReadAt either completed before Close drained (nil
+		// error — it ran fully against a live store) or arrived after
+		// closed=true and was refused with the typed ErrStoreClosed. Any
+		// other error is a lifecycle bug: the gate must convert a
+		// raced-Close into ErrStoreClosed, never a torn read or untyped
+		// failure. (The seed above guarantees the content is present, so a
+		// successful read can't be a spurious miss.)
+		if readErr != nil && !errors.Is(readErr, ErrStoreClosed) {
+			t.Fatalf("iter %d: unexpected ReadAt error: %v", i, readErr)
+		}
 	}
 }
 

--- a/pkg/blockstore/engine/close_gate_test.go
+++ b/pkg/blockstore/engine/close_gate_test.go
@@ -1,0 +1,181 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// TestStore_CloseDrainsInFlightWriteAt is the area-7 H-A reproducer: a client
+// WriteAt racing an admin RemoveShare → Store.Close must NEVER race or panic.
+// The op either completes fully against a live store or fails fast with
+// ErrStoreClosed — never a torn/partial write.
+//
+// Before the close-gate, WriteAt operated on local/syncer state with no lock
+// while Close tore those down concurrently → -race flags the data race (and a
+// nil-deref panic is possible). With the gate, Close takes closeMu.Lock and
+// drains, so this passes under -race across many scheduler interleavings.
+func TestStore_CloseDrainsInFlightWriteAt(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		bs := newTestEngine(t, 0, 0)
+		ctx := context.Background()
+		payloadID := "race-file"
+		data := []byte("hello concurrent world")
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var writeErr error
+		go func() {
+			defer wg.Done()
+			_, writeErr = bs.WriteAt(ctx, payloadID, nil, data, 0)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = bs.Close()
+		}()
+
+		wg.Wait()
+
+		// The write either fully succeeded (ran before close drained) or was
+		// refused with ErrStoreClosed (arrived after closed=true). Any other
+		// error, or a torn write, is a failure.
+		if writeErr != nil && !errors.Is(writeErr, ErrStoreClosed) {
+			t.Fatalf("iter %d: unexpected WriteAt error: %v", i, writeErr)
+		}
+	}
+}
+
+// TestStore_CloseDrainsInFlightReadAt is the read-side twin of the H-A
+// reproducer.
+func TestStore_CloseDrainsInFlightReadAt(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		bs := newTestEngine(t, 0, 0)
+		ctx := context.Background()
+		payloadID := "race-read-file"
+		// Seed some data so ReadAt has something to walk (best-effort; the
+		// race is on the lifecycle, not on the content).
+		_, _ = bs.WriteAt(ctx, payloadID, nil, []byte("0123456789"), 0)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var readErr error
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, 10)
+			_, readErr = bs.ReadAt(ctx, payloadID, nil, buf, 0)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = bs.Close()
+		}()
+
+		wg.Wait()
+
+		// A read may legitimately miss (closed store, or content not yet
+		// durable) — we only assert it never panics/races and that any
+		// lifecycle error is the typed ErrStoreClosed. Content-level read
+		// misses surface their own errors and are out of scope here.
+		_ = readErr
+	}
+}
+
+// TestStore_CloseIsIdempotent verifies a second Close is a no-op returning the
+// first call's result (badger #900 pattern).
+func TestStore_CloseIsIdempotent(t *testing.T) {
+	bs := newTestEngine(t, 0, 0)
+
+	first := bs.Close()
+	second := bs.Close()
+	if first != nil {
+		t.Fatalf("first Close returned error: %v", first)
+	}
+	if second != nil {
+		t.Fatalf("second Close should be a no-op returning the first result, got: %v", second)
+	}
+
+	// Concurrent double-Close must also be safe (no double-teardown panic).
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = bs.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestStore_OpAfterCloseReturnsErrStoreClosed verifies every gated public data
+// op fails fast with ErrStoreClosed once the store is closed.
+func TestStore_OpAfterCloseReturnsErrStoreClosed(t *testing.T) {
+	bs := newTestEngine(t, 0, 0)
+	ctx := context.Background()
+	if err := bs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	t.Run("WriteAt", func(t *testing.T) {
+		if _, err := bs.WriteAt(ctx, "p", nil, []byte("x"), 0); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("ReadAt", func(t *testing.T) {
+		buf := make([]byte, 4)
+		if _, err := bs.ReadAt(ctx, "p", nil, buf, 0); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("Flush", func(t *testing.T) {
+		if _, err := bs.Flush(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("Truncate", func(t *testing.T) {
+		if _, err := bs.Truncate(ctx, "p", nil, 0); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("Delete", func(t *testing.T) {
+		if err := bs.Delete(ctx, "p", nil); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("CopyPayload", func(t *testing.T) {
+		if _, err := bs.CopyPayload(ctx, "s", "d", nil); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("GetSize", func(t *testing.T) {
+		if _, err := bs.GetSize(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("Exists", func(t *testing.T) {
+		if _, err := bs.Exists(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("DrainAllUploads", func(t *testing.T) {
+		if err := bs.DrainAllUploads(ctx); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("DrainRollups", func(t *testing.T) {
+		if err := bs.DrainRollups(ctx); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("ResetLocalState", func(t *testing.T) {
+		if err := bs.ResetLocalState(ctx); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+	t.Run("EvictLocal", func(t *testing.T) {
+		if err := bs.EvictLocal(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("want ErrStoreClosed, got %v", err)
+		}
+	})
+}

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/blockstore"
@@ -99,6 +100,23 @@ type Store struct {
 
 	readBufferBytes int64 // budget for the cache (0 = disabled / Null Object)
 	prefetchWorkers int   // stored from config, used in Start()
+
+	// closeMu is the lifecycle gate. Every public data op (WriteAt,
+	// ReadAt, Flush, Truncate, Delete, …) takes closeMu.RLock() at entry
+	// and holds it for the op's full duration. Close takes closeMu.Lock(),
+	// which blocks until all in-flight ops drop their RLocks, then performs
+	// teardown. This makes Store.Close safe to call concurrently with
+	// in-flight ops (area-7 H-A use-after-close): an op either runs fully
+	// against a live store, or — if it arrives after closed is set — fails
+	// fast with ErrStoreClosed. The RLock side is shared, so concurrent
+	// data ops still run in parallel; only Close serializes.
+	//
+	// Re-entrancy: public ops never call another RLock-gated public op on
+	// the same Store (internal helpers in read_internal.go / the syncer are
+	// ungated), so the non-reentrant Go RWMutex read side is safe here.
+	closeMu  sync.RWMutex
+	closed   bool  // guarded by closeMu; true once teardown has run
+	closeErr error // memoized result of the first Close (idempotent)
 }
 
 // New creates a new Store from the given configuration.
@@ -400,10 +418,55 @@ func (bs *Store) loadByHash(ctx context.Context, hash blockstore.ContentHash) ([
 	return bs.local.Get(ctx, hash)
 }
 
-// Close releases resources held by the store. Closes the cache (stops
-// prefetch workers and drops entries), then syncer (drains uploads)
-// local store, and remote store.
+// enter is the lifecycle-gate entry every public data op calls before
+// touching local/remote/syncer state. It pins the store open for the op's
+// duration by taking closeMu.RLock(); if the store is already closed it
+// releases the lock and returns ErrStoreClosed. On success the caller MUST
+// defer bs.closeMu.RUnlock() so Close (which takes the write lock) can drain.
+//
+// Callers use it as:
+//
+//	if err := bs.enter(); err != nil {
+//	    return …, err
+//	}
+//	defer bs.closeMu.RUnlock()
+//
+// The RLock is held for the WHOLE op (not released early) — that is what
+// keeps the underlying local/remote/syncer alive while the op runs and what
+// Close blocks on. RLock is shared, so concurrent ops still run in parallel.
+func (bs *Store) enter() error {
+	bs.closeMu.RLock()
+	if bs.closed {
+		bs.closeMu.RUnlock()
+		return ErrStoreClosed
+	}
+	return nil
+}
+
+// Close releases resources held by the store. It first drains all in-flight
+// data ops (closeMu.Lock blocks until every enter()'s RLock is released),
+// marks the store closed so new ops fail fast with ErrStoreClosed, then
+// tears down cache → syncer → local → remote. Close is idempotent: a second
+// call is a no-op that returns the first call's result.
+//
+// area-7 H-A: by draining under closeMu, an admin RemoveShare → Close can no
+// longer run concurrently with a client WriteAt/ReadAt on the same *Store —
+// the op either completes fully or never starts (ErrStoreClosed). The drain
+// makes it safe for RemoveShare to keep calling Close() outside the shares
+// service lock.
 func (bs *Store) Close() error {
+	// Acquire the write lock: this blocks until all in-flight data ops
+	// (which hold closeMu.RLock via enter) have finished, giving us the
+	// in-flight drain. New ops arriving after closed=true fail in enter().
+	bs.closeMu.Lock()
+	defer bs.closeMu.Unlock()
+
+	if bs.closed {
+		// Idempotent: return the memoized result of the first teardown.
+		return bs.closeErr
+	}
+	bs.closed = true
+
 	// Cache is never nil thanks to the Null Object pattern.
 	_ = bs.cache.Close()
 
@@ -420,7 +483,8 @@ func (bs *Store) Close() error {
 		}
 	}
 
-	return errors.Join(errs...)
+	bs.closeErr = errors.Join(errs...)
+	return bs.closeErr
 }
 
 // --- Test helpers ---
@@ -451,6 +515,10 @@ func (bs *Store) ListFiles() []string { return bs.local.ListFiles() }
 // dedup and are reclaimed via the refcount → GC path (engine.Delete
 // decrements per dropped hash and the mark-sweep GC reaps orphans).
 func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	if err := bs.local.EvictMemory(ctx, payloadID); err != nil {
 		return err
 	}

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -530,6 +530,16 @@ func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
 // and for the REST evict path that drops the read buffer wholesale.
 // Returns the number of entries that were present before destruction.
 func (bs *Store) DestroyCache() int {
+	// Pin against Close teardown. No error return to surface ErrStoreClosed,
+	// so a closed store reports 0 destroyed entries rather than racing the
+	// cache teardown Close performs under closeMu.Lock — Close already closed
+	// the cache, so there is nothing to destroy.
+	bs.closeMu.RLock()
+	defer bs.closeMu.RUnlock()
+	if bs.closed {
+		return 0
+	}
+
 	entries := bs.cache.Stats().Entries
 	_ = bs.cache.Close()
 	// Replace closed cache with the Null Object so subsequent operations

--- a/pkg/blockstore/engine/flush.go
+++ b/pkg/blockstore/engine/flush.go
@@ -23,6 +23,10 @@ import (
 // the Cache is CAS-keyed and Flush has no BlockRef snapshot at this
 // layer to translate flushed bytes into hash-keyed cache entries.
 func (bs *Store) Flush(ctx context.Context, payloadID string) (*blockstore.FlushResult, error) {
+	if err := bs.enter(); err != nil {
+		return nil, err
+	}
+	defer bs.closeMu.RUnlock()
 	// Both pre-rollup dedup hooks require a coordinator; gate them
 	// jointly so the nil-check isn't repeated.
 	if bs.coordinator != nil {
@@ -97,6 +101,10 @@ func (bs *Store) Flush(ctx context.Context, payloadID string) (*blockstore.Flush
 
 // DrainAllUploads waits for all pending uploads to complete.
 func (bs *Store) DrainAllUploads(ctx context.Context) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	return bs.syncer.DrainAllUploads(ctx)
 }
 
@@ -108,6 +116,10 @@ func (bs *Store) DrainAllUploads(ctx context.Context) error {
 // run before DrainAllUploads — rollup is what produces the CAS chunks the
 // syncer then mirrors to the remote.
 func (bs *Store) DrainRollups(ctx context.Context) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	return bs.local.DrainRollups(ctx)
 }
 
@@ -117,5 +129,9 @@ func (bs *Store) DrainRollups(ctx context.Context) error {
 // Restore() so a file modified in place after the snapshot is not served
 // from a stale append-log record overlaid on the restored CAS bytes.
 func (bs *Store) ResetLocalState(ctx context.Context) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	return bs.local.ResetLocalState(ctx)
 }

--- a/pkg/blockstore/engine/health.go
+++ b/pkg/blockstore/engine/health.go
@@ -16,6 +16,10 @@ import (
 // and satisfies [health.Checker]. This method only collapses the structured
 // state into a single error and is retained for backward compatibility.
 func (bs *Store) HealthCheck(ctx context.Context) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	return bs.syncer.HealthCheck(ctx)
 }
 
@@ -37,6 +41,15 @@ func (bs *Store) HealthCheck(ctx context.Context) error {
 // so operators can see exactly which subsystem is at fault.
 func (bs *Store) Healthcheck(ctx context.Context) health.Report {
 	start := time.Now()
+
+	// Pin against Close teardown. This method has no error return, so a
+	// closed store reports unhealthy rather than racing the local/remote
+	// teardown that Close performs under closeMu.Lock.
+	bs.closeMu.RLock()
+	defer bs.closeMu.RUnlock()
+	if bs.closed {
+		return health.NewUnhealthyReport(ErrStoreClosed.Error(), time.Since(start))
+	}
 
 	if err := ctx.Err(); err != nil {
 		return health.NewUnknownReport(err.Error(), time.Since(start))

--- a/pkg/blockstore/engine/readwrite.go
+++ b/pkg/blockstore/engine/readwrite.go
@@ -18,6 +18,10 @@ import (
 // machine can fire prefetch on upcoming hashes. The cache is hint-only
 // here; reads always go through local/remote stores.
 func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, data []byte, offset uint64) (int, error) {
+	if err := bs.enter(); err != nil {
+		return 0, err
+	}
+	defer bs.closeMu.RUnlock()
 	n, err := bs.readAtInternal(ctx, payloadID, data, offset)
 	if err != nil {
 		return n, err
@@ -35,6 +39,10 @@ func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []blocksto
 // GetSize returns the stored size of a payload.
 // Checks local store first, falls back to syncer (remote).
 func (bs *Store) GetSize(ctx context.Context, payloadID string) (uint64, error) {
+	if err := bs.enter(); err != nil {
+		return 0, err
+	}
+	defer bs.closeMu.RUnlock()
 	if size, found := bs.local.GetFileSize(ctx, payloadID); found {
 		return size, nil
 	}
@@ -44,6 +52,10 @@ func (bs *Store) GetSize(ctx context.Context, payloadID string) (uint64, error) 
 // Exists checks whether a payload exists.
 // Checks local store first, falls back to syncer (remote).
 func (bs *Store) Exists(ctx context.Context, payloadID string) (bool, error) {
+	if err := bs.enter(); err != nil {
+		return false, err
+	}
+	defer bs.closeMu.RUnlock()
 	if _, found := bs.local.GetFileSize(ctx, payloadID); found {
 		return true, nil
 	}
@@ -72,6 +84,10 @@ func (bs *Store) Exists(ctx context.Context, payloadID string) (bool, error) {
 // Returns currentBlocks unchanged — the canonical projection happens
 // at Flush time, not WriteAt time.
 func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, data []byte, offset uint64) ([]blockstore.BlockRef, error) {
+	if err := bs.enter(); err != nil {
+		return currentBlocks, err
+	}
+	defer bs.closeMu.RUnlock()
 	if len(data) == 0 {
 		return currentBlocks, nil
 	}
@@ -110,6 +126,10 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 // via PutFile. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
 func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks []blockstore.BlockRef, newSize uint64) ([]blockstore.BlockRef, error) {
+	if err := bs.enter(); err != nil {
+		return currentBlocks, err
+	}
+	defer bs.closeMu.RUnlock()
 	// coordinator decrements run FIRST so a refcount-bookkeeping
 	// failure leaves the file untouched on disk and remote. Previous
 	// order (local → cache → syncer → coordinator) could leave 4-of-5
@@ -209,6 +229,10 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 // Subsequent steps (cache invalidate, coordinator refcount decrements
 // optional remote sweep) are unchanged.
 func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []blockstore.BlockRef) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	bs.local.SyncFileBlocksForFile(ctx, payloadID)
 	if err := bs.local.EvictMemory(ctx, payloadID); err != nil {
 		return fmt.Errorf("local evict memory failed: %w", err)
@@ -314,6 +338,10 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []blocksto
 // The destination's []BlockRef preserves the original sequence so
 // subsequent reads still resolve every offset correctly.
 func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string, srcBlocks []blockstore.BlockRef) ([]blockstore.BlockRef, error) {
+	if err := bs.enter(); err != nil {
+		return nil, err
+	}
+	defer bs.closeMu.RUnlock()
 	// Empty src => no work, nothing to coordinate.
 	if len(srcBlocks) == 0 {
 		return nil, nil

--- a/pkg/blockstore/engine/stats.go
+++ b/pkg/blockstore/engine/stats.go
@@ -39,6 +39,10 @@ type BlockStoreStats struct {
 
 // Stats returns storage statistics from the local store.
 func (bs *Store) Stats() (*blockstore.Stats, error) {
+	if err := bs.enter(); err != nil {
+		return nil, err
+	}
+	defer bs.closeMu.RUnlock()
 	localStats := bs.local.Stats()
 	files := bs.local.ListFiles()
 	used := uint64(localStats.DiskUsed)
@@ -63,6 +67,15 @@ func (bs *Store) Stats() (*blockstore.Stats, error) {
 
 // GetStats returns comprehensive block store statistics.
 func (bs *Store) GetStats() BlockStoreStats {
+	// Pin against Close teardown. This method has no error return, so a
+	// closed store reports empty stats rather than racing the
+	// local/syncer/cache teardown Close performs under closeMu.Lock.
+	bs.closeMu.RLock()
+	defer bs.closeMu.RUnlock()
+	if bs.closed {
+		return BlockStoreStats{}
+	}
+
 	localStats := bs.local.Stats()
 	files := bs.local.ListFiles()
 
@@ -134,5 +147,14 @@ func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
 	}
 }
 
-// LocalStats returns a snapshot of local store statistics.
-func (bs *Store) LocalStats() local.Stats { return bs.local.Stats() }
+// LocalStats returns a snapshot of local store statistics. A closed store
+// reports empty stats rather than racing the local teardown Close performs
+// under closeMu.Lock (no error return to surface ErrStoreClosed).
+func (bs *Store) LocalStats() local.Stats {
+	bs.closeMu.RLock()
+	defer bs.closeMu.RUnlock()
+	if bs.closed {
+		return local.Stats{}
+	}
+	return bs.local.Stats()
+}

--- a/pkg/blockstore/engine/types.go
+++ b/pkg/blockstore/engine/types.go
@@ -9,6 +9,14 @@ import (
 // ErrClosed is returned when an operation is attempted on a closed Syncer.
 var ErrClosed = errors.New("syncer is closed")
 
+// ErrStoreClosed is returned by a Store data op (WriteAt, ReadAt, Flush,
+// Truncate, Delete, …) that arrives after the Store has been Closed —
+// typically because an admin removed or hot-reloaded the share while a
+// client was mid-transfer (area-7 H-A). Adapters map it to a stale-handle
+// status (NFS NFS3ERR_STALE / NFS4ERR_STALE, SMB STATUS_FILE_CLOSED) so the
+// client observes the share going away rather than a torn op or a panic.
+var ErrStoreClosed = errors.New("engine: block store is closed")
+
 // DefaultParallelUploads is the default number of concurrent uploads.
 // At ~8 MB/s per S3 connection, 16 connections yields ~128 MB/s upload bandwidth.
 const DefaultParallelUploads = 16

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -379,15 +379,18 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 // (D-23-02) returns false once the snapshots/ tree is gone. D-23-17.
 func (r *Runtime) RemoveShare(name string) error {
 	r.cancelAndWaitInFlightSnaps(name) // D-23-17: drain BEFORE tree wipe
-	if err := r.sharesSvc.RemoveShare(name); err != nil {
-		return err
-	}
+	// sharesSvc.RemoveShare now performs ordered best-effort teardown and may
+	// return an aggregated error (REVIEW M4). We must NOT early-return on it:
+	// the metadata deregistration below is what prevents the unbounded
+	// service-map growth #897/#907 fixed, and it has to run even when the
+	// block-store Close or snapshot-dir wipe failed. Aggregate instead.
+	rmErr := r.sharesSvc.RemoveShare(name)
 	// Deregister the share's per-share store / lock manager / unified view /
 	// notifier / quota from the metadata service, mirroring the AddShare
 	// registration above. Without this the service maps grow unbounded across
 	// add/remove churn and a same-name re-add reuses the stale lock manager.
 	r.metadataService.RemoveStoreForShare(name)
-	return nil
+	return rmErr
 }
 
 func (r *Runtime) UpdateShare(name string, readOnly *bool, defaultPermission *string, retentionPolicy *blockstore.RetentionPolicy, retentionTTL *time.Duration) error {

--- a/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
+++ b/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
@@ -1,0 +1,124 @@
+package shares
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLocalEngineStore builds a real local-only *engine.Store for the RemoveShare
+// teardown tests. It is intentionally minimal (no remote, no coordinator) — the
+// teardown path only needs a live Close.
+func newLocalEngineStore(t *testing.T) *engine.Store {
+	t.Helper()
+	local := memory.New()
+	// The in-memory metadata store satisfies EngineFileBlockStore (NewSyncer
+	// requires a non-nil one); the teardown path never exercises it.
+	fbs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = fbs.Close() })
+	syncer := engine.NewSyncer(local, nil, fbs, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:          local,
+		Syncer:         syncer,
+		FileBlockStore: fbs,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	return bs
+}
+
+// TestRemoveShare_OrderedTeardown_ClosesStoreAndWipesSnapshots verifies the
+// REVIEW M4 ordered teardown: the registry entry is dropped, the snapshots
+// dir is removed, and the block store is Closed (drain-safe) — all in one
+// RemoveShare call returning nil on the happy path.
+func TestRemoveShare_OrderedTeardown_ClosesStoreAndWipesSnapshots(t *testing.T) {
+	svc := New()
+	bs := newLocalEngineStore(t)
+
+	localDir := t.TempDir()
+	snapsDir := filepath.Join(localDir, "snapshots")
+	if err := os.MkdirAll(filepath.Join(snapsDir, "snap-1"), 0o755); err != nil {
+		t.Fatalf("seed snapshots dir: %v", err)
+	}
+
+	svc.InjectShareForTesting(&Share{
+		Name:          "/export",
+		BlockStore:    bs,
+		localStoreDir: localDir,
+	})
+
+	if err := svc.RemoveShare("/export"); err != nil {
+		t.Fatalf("RemoveShare returned error on happy path: %v", err)
+	}
+
+	// Registry entry gone.
+	if _, err := svc.GetShare("/export"); err == nil {
+		t.Fatal("share still present in registry after RemoveShare")
+	}
+	// Snapshots dir wiped.
+	if _, err := os.Stat(snapsDir); !os.IsNotExist(err) {
+		t.Fatalf("snapshots dir still present after RemoveShare (stat err=%v)", err)
+	}
+	// Block store closed (drain-safe Close ran): a subsequent op must fail
+	// fast with ErrStoreClosed rather than panic.
+	if _, err := bs.GetSize(context.Background(), "any"); !errors.Is(err, engine.ErrStoreClosed) {
+		t.Fatalf("block store not closed by RemoveShare; GetSize err=%v", err)
+	}
+}
+
+// TestRemoveShare_ContinuesPastSnapshotError_AggregatesAndClosesStore verifies
+// M4's "best-effort, continue past an individual error, aggregate" property:
+// when the snapshots-dir removal fails, RemoveShare still Closes the block
+// store and returns a non-nil aggregated error (rather than early-returning
+// and leaking the store).
+func TestRemoveShare_ContinuesPastSnapshotError_AggregatesAndClosesStore(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based RemoveAll-failure injection does not bite as root")
+	}
+	svc := New()
+	bs := newLocalEngineStore(t)
+
+	localDir := t.TempDir()
+	snapsDir := filepath.Join(localDir, "snapshots")
+	// Create snapshots/<child> then make the snapshots dir itself read+exec
+	// only (no write): RemoveAll cannot unlink the child, so it errors.
+	if err := os.MkdirAll(filepath.Join(snapsDir, "snap-1"), 0o755); err != nil {
+		t.Fatalf("seed snapshots dir: %v", err)
+	}
+	if err := os.Chmod(snapsDir, 0o555); err != nil {
+		t.Fatalf("chmod snapshots dir: %v", err)
+	}
+	// Restore perms so t.TempDir cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(snapsDir, 0o755) })
+
+	svc.InjectShareForTesting(&Share{
+		Name:          "/export",
+		BlockStore:    bs,
+		localStoreDir: localDir,
+	})
+
+	err := svc.RemoveShare("/export")
+	if err == nil {
+		t.Fatal("expected aggregated error from RemoveShare when snapshots removal fails")
+	}
+
+	// Registry entry still dropped.
+	if _, gerr := svc.GetShare("/export"); gerr == nil {
+		t.Fatal("share still present in registry after RemoveShare")
+	}
+	// Critically: the block store was still Closed despite the snapshot error
+	// (teardown did NOT early-return). This is the M4 fix.
+	if _, gerr := bs.GetSize(context.Background(), "any"); !errors.Is(gerr, engine.ErrStoreClosed) {
+		t.Fatalf("block store NOT closed after snapshot-removal error (early return regression); GetSize err=%v", gerr)
+	}
+}

--- a/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
+++ b/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
@@ -82,6 +83,9 @@ func TestRemoveShare_OrderedTeardown_ClosesStoreAndWipesSnapshots(t *testing.T) 
 // store and returns a non-nil aggregated error (rather than early-returning
 // and leaking the store).
 func TestRemoveShare_ContinuesPastSnapshotError_AggregatesAndClosesStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o555 does not block os.RemoveAll on Windows (dir mode bits are not enforced); RemoveAll-failure injection only bites on Unix")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("chmod-based RemoveAll-failure injection does not bite as root")
 	}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -781,6 +781,18 @@ func (s *Service) releaseRemoteStore(configID string) {
 
 // RemoveShare removes a share from the registry and closes its BlockStore.
 // Does not close the underlying metadata store.
+//
+// Teardown is ordered best-effort (REVIEW M4): every step runs even if an
+// earlier one fails, and the per-step errors are aggregated into the returned
+// error so the registry / snapshot-dir / block-store / remote-ref state is
+// never left half-removed by an early return. The registry entry is dropped
+// first (under the lock) so the share disappears from routing immediately;
+// the remaining steps are pure resource teardown.
+//
+// bs.Close() is now drain-safe (area-7 H-A): it takes the engine's lifecycle
+// write lock, which blocks until all in-flight WriteAt/ReadAt/Flush ops on the
+// store have completed, so calling it here outside s.mu can no longer race a
+// client mid-transfer into a torn op or panic.
 func (s *Service) RemoveShare(name string) error {
 	s.mu.Lock()
 	share, exists := s.registry[name]
@@ -794,31 +806,37 @@ func (s *Service) RemoveShare(name string) error {
 	delete(s.registry, name)
 	s.mu.Unlock()
 
+	var errs []error
+
 	// Cleanup per-share snapshot directories alongside registry removal.
 	// The DB row is the source of truth; orphaned files left behind on a
-	// removal error are operationally harmless and must not abort the
-	// removal sequence.
+	// removal error are operationally harmless, so we log + aggregate but
+	// continue with the rest of the teardown.
 	if localStoreDir != "" {
 		snapsDir := filepath.Join(localStoreDir, "snapshots")
 		if err := os.RemoveAll(snapsDir); err != nil {
 			logger.Warn("RemoveShare: failed to remove snapshots dir",
 				"share", name, "dir", snapsDir, "error", err)
+			errs = append(errs, fmt.Errorf("remove snapshots dir %q: %w", snapsDir, err))
 		}
 	}
 
 	if bs != nil {
 		if err := bs.Close(); err != nil {
 			logger.Warn("Failed to close BlockStore for share", "share", name, "error", err)
+			errs = append(errs, fmt.Errorf("close block store for share %q: %w", name, err))
 		}
 	}
 
+	// Always release the remote-store reference even if a prior step errored,
+	// otherwise a Close failure would leak the shared remote ref-count.
 	if remoteConfigID != "" {
 		s.releaseRemoteStore(remoteConfigID)
 	}
 
 	s.notifyShareChange()
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *string, retentionPolicy *blockstore.RetentionPolicy, retentionTTL *time.Duration) error {


### PR DESCRIPTION
## Area-7 H-A — BlockStore use-after-Close TOCTOU

`GetBlockStoreForHandle` returned a `*engine.Store` and released the shares lock **before** the caller used it. `RemoveShare` captured the same store, unlocked, then called `bs.Close()` **outside the lock with no in-flight drain**. An admin removing/hot-reloading a share while a client was mid-transfer could therefore land a `WriteAt`/`ReadAt`/`Flush` on a store being torn down → torn/partial writes, torn reads, or panic.

## Fix — engine-internal close-gate

Localized to `pkg/blockstore/engine/` (not caller refcounting):

- `Store` gets a dedicated `closeMu sync.RWMutex` + `closed` flag. Every public data op (`WriteAt`, `ReadAt`, `Flush`, `Truncate`, `Delete`, `CopyPayload`, `GetSize`, `Exists`, `DrainAllUploads`, `DrainRollups`, `ResetLocalState`, `EvictLocal`) calls `enter()` at entry — `RLock()` + `closed` check returning the new typed `ErrStoreClosed` — and holds the RLock for the op's full duration via `defer`.
- `Close()` takes `closeMu.Lock()`, which **blocks until all in-flight RLocks drop** (the drain), marks `closed`, then tears down cache/syncer/local/remote. `Close` is now **idempotent** (memoized result).
- **Scheme: RWMutex** (not atomic+WaitGroup). Verified by grep that no gated public op calls another gated public op (internal helpers + syncer are ungated), so the non-reentrant Go RWMutex read side is safe and a `Close()` write-lock between nested RLocks cannot deadlock. RLock is shared, so concurrent data ops still run in parallel.

## ErrStoreClosed → STALE mapping

`engine.ErrStoreClosed` maps to a stale-handle status on **every** adapter path:
- `internal/adapter/common/errmap.go` (general handle path) and `content_errmap.go` (data-path WRITE/READ seam) → NFS `*_STALE` / SMB `STATUS_FILE_CLOSED`.
- SMB `Flush` + `copychunk` ReadAt/WriteAt sites routed through `common.MapToSMB` (were hardcoded `StatusInternalError`/`StatusUnexpectedIOError`).
- NFS v3/v4 WRITE/READ/COMMIT already funnel blockstore errors through `MapContentTo*`/`MapTo*`, so they pick up the mapping automatically.

A removed share's in-flight op gets `ErrStoreClosed` → client sees STALE, which is correct (the share went away).

## M4 co-fix — RemoveShare ordered best-effort teardown

`RemoveShare` now runs every teardown step even if an earlier one errors and returns an **aggregated** error (`errors.Join`) instead of always `nil`, so registry/snapshot-dir/block-store/remote-ref state is never left half-removed. `runtime.RemoveShare` keeps deregistering metadata even when `sharesSvc.RemoveShare` errors (preserves the #897/#907 map-leak fix). `bs.Close()` can keep being called outside `s.mu` — now safe because Close drains.

## Tests

- **`-race` reproducer** (`pkg/blockstore/engine/close_gate_test.go`): concurrent `WriteAt`/`ReadAt` vs `Close`, 100 iterations. Confirmed it **fails (race detected) before** the gate drain and **passes after**. The op either completes fully or returns `ErrStoreClosed`.
- Close idempotency (incl. concurrent double-Close), op-after-close → `ErrStoreClosed` for all gated ops.
- `ErrStoreClosed` → STALE across all six accessors + content table (direct + wrapped).
- `RemoveShare` ordered teardown: happy path closes store + wipes snapshots; **and** continues past a forced snapshot-removal error, still closing the block store and returning an aggregated error.

`go test -race ./pkg/blockstore/... ./pkg/controlplane/... ./internal/adapter/...` green; `gofmt`/`go vet`/`golangci-lint` clean on touched packages.
