### PR TITLE
fix(runtime): AddShare-sameName metadata mismatch + netgroup deny diagnostics + grace refcount (area-7 M2/M3 + slice-3)

### DIFF
--- a/pkg/adapter/nfs/grace_coordinator.go
+++ b/pkg/adapter/nfs/grace_coordinator.go
@@ -1,6 +1,8 @@
 package nfs
 
 import (
+	"sync"
+
 	v4state "github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/logger"
 )
@@ -18,56 +20,116 @@ import (
 // owner can reclaim first (X/Open NLMv4, RFC 7530 §9.6.2). Coupling them here
 // is the single seam that keeps the two windows aligned.
 //
-// NFSv4-client-persistence dependency (honest seam note): StateManager grace
-// only meaningfully activates when it is told which v4 client IDs are expected
-// to reclaim — StartGracePeriod with an empty set is a no-op by design
-// (grace.go StartGrace). DittoFS does not yet persist NFSv4 confirmed clients
-// across restart (SaveClientState/LoadPreviousClients are unwired), so today
-// the v4 expected set is empty and the v4 window is a no-op even though this
-// coordinator drives it. The coupling is wired end-to-end so that the moment
-// v4 client persistence lands, both machines enter and exit together with no
-// further change here. The lock-manager + NLM grace window (the area-5 H-1 /
-// NFS H15 fix) is fully live regardless.
+// Per-share vs global asymmetry, REFCOUNTED (REVIEW slice-3): lock-manager
+// grace is PER-SHARE, while the NFSv4 StateManager grace machine is GLOBAL (one
+// per server). The coordinator counts open lock-manager grace windows: each
+// OnLockGraceStart increments, each OnLockGraceEnd decrements, and the global
+// v4 grace is only force-ended when the count returns to zero (the LAST share's
+// lock-grace window closes). The OLD "first share in starts, first share out
+// ends" policy let one share's early grace-end — e.g. via RemoveStoreForShare
+// or that one share's reclaim/timer — prematurely lift global v4 grace while
+// OTHER shares' windows were still open, admitting conflicting new v4 state
+// before those shares' prior owners could reclaim. With slice-2 wiring real v4
+// client persistence (LoadClientRecovery seeds a boot roster), that latent bug
+// is now live, hence the refcount.
 //
-// Per-share vs global asymmetry (documented seam): lock-manager grace is
-// per-share, while the NFSv4 StateManager grace machine is global (one per
-// server). The coordinator couples them with a "first share in starts v4
-// grace, first share out ends it" policy: OnLockGraceStart is a no-op once v4
-// grace is already active, and OnLockGraceEnd ends v4 grace outright. With the
-// conventional boot flow all shares load together and enter the same ~90s
-// window, so this approximation holds; a per-share early-exit could end v4
-// grace while another share's window is still open. Because v4 grace is a no-op
-// today (see above), this is latent and becomes relevant only alongside v4
-// client persistence, at which point the coupling should refcount active
-// lock-manager grace windows before ending v4 grace.
+// Interaction with the boot-loaded v4 roster: LoadClientRecovery may seed the
+// v4 grace machine with a durable reclaim roster on boot, INDEPENDENT of this
+// coordinator. In that case the very first OnLockGraceStart observes v4 grace
+// already active and the coordinator does NOT claim ownership of it
+// (startedByCoordinator stays false). At refcount zero the coordinator then
+// leaves the lift to the v4 machine's OWN governance — its reclaim early-exit
+// and its hard grace timer — rather than force-ending and bypassing the roster.
+// The v4 grace timer is the always-on backstop (grace.go startGrace), so v4
+// grace can never wedge regardless. The coordinator only force-ends v4 grace
+// when IT started it (coupled, no independent roster); then refcount-zero is
+// the correct lockstep lift.
 type nfsGraceCoordinator struct {
 	sm *v4state.StateManager
+
+	mu sync.Mutex
+	// active counts open per-share lock-manager grace windows coupled through
+	// this coordinator. v4 grace is lifted only when this returns to zero.
+	active int
+	// startedByCoordinator is true when THIS coordinator started the v4 grace
+	// machine (v4 grace was not already active at the first start). Only then
+	// does the coordinator force-end v4 grace at refcount zero; when v4 grace
+	// was boot-seeded with a roster the coordinator defers to the v4 machine's
+	// own timer/reclaim lift.
+	startedByCoordinator bool
 }
 
 // OnLockGraceStart drives the NFSv4 StateManager into its grace period when a
-// share's lock-manager grace begins. The lock manager's expected clients are
-// NLM/SMB opaque client IDs, which do not map onto NFSv4 numeric client IDs;
-// the v4 expected-reclaim roster is the v4 confirmed-client set, which the
-// StateManager derives from its own persisted state (empty until v4 client
-// persistence is wired — see the type doc).
+// share's lock-manager grace begins, and increments the open-window refcount.
+// The lock manager's expected clients are NLM/SMB opaque client IDs, which do
+// not map onto NFSv4 numeric client IDs; the v4 expected-reclaim roster is the
+// v4 confirmed-client set, which the StateManager derives from its own state
+// (boot-loaded via LoadClientRecovery, else the confirmed-client set).
 func (c *nfsGraceCoordinator) OnLockGraceStart(expectedClients []string) {
 	if c.sm == nil {
 		return
 	}
-	if c.sm.IsInGrace() {
-		return // already coupled in by an earlier share's recovery
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.active++
+
+	// Only the FIRST open window starts (or couples to) v4 grace; subsequent
+	// shares just add to the refcount so the window stays open until the last
+	// one closes.
+	if c.active > 1 {
+		return
 	}
+
+	if c.sm.IsInGrace() {
+		// v4 grace already active — boot-seeded by LoadClientRecovery with a
+		// durable roster, or coupled in by a prior cycle. We do NOT own it, so
+		// at refcount zero we will leave the lift to the v4 machine's own
+		// timer/reclaim governance rather than force-ending.
+		c.startedByCoordinator = false
+		return
+	}
+
 	v4Clients := c.sm.GetConfirmedClientIDs()
 	logger.Info("NFSv4 grace coupled to lock-manager grace",
 		"lock_clients", len(expectedClients), "v4_clients", len(v4Clients))
 	c.sm.StartGracePeriod(v4Clients)
+	c.startedByCoordinator = true
 }
 
-// OnLockGraceEnd ends the NFSv4 grace period when the lock-manager grace window
-// closes (timer, early-exit, or sweep), keeping the two windows aligned.
+// OnLockGraceEnd decrements the open-window refcount and ends the NFSv4 grace
+// period only when the LAST coupled lock-manager grace window closes (refcount
+// reaches zero) AND this coordinator owns the v4 grace window. When v4 grace
+// was boot-seeded with a durable roster the coordinator defers to the v4
+// machine's own timer/reclaim lift, so an early lock-manager grace-end (timer,
+// reclaim, or RemoveStoreForShare) can never prematurely lift global v4 grace
+// while other shares — or the v4 reclaim roster — are still outstanding.
 func (c *nfsGraceCoordinator) OnLockGraceEnd() {
 	if c.sm == nil {
 		return
 	}
-	c.sm.ForceEndGrace()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.active == 0 {
+		// Unbalanced end (already at zero): ignore rather than underflow. The v4
+		// machine's hard timer remains the backstop, so this cannot wedge.
+		return
+	}
+	c.active--
+	if c.active > 0 {
+		// Other shares' lock-manager grace windows are still open; keep v4 grace
+		// up so their prior owners can still reclaim.
+		return
+	}
+
+	// Last window closed. Force-end v4 grace only if WE started it; otherwise the
+	// v4 machine was independently boot-seeded with a roster and governs its own
+	// lift (reclaim early-exit + hard timer backstop).
+	if c.startedByCoordinator {
+		c.sm.ForceEndGrace()
+		c.startedByCoordinator = false
+	}
 }

--- a/pkg/adapter/nfs/grace_coordinator_test.go
+++ b/pkg/adapter/nfs/grace_coordinator_test.go
@@ -1,0 +1,134 @@
+package nfs
+
+import (
+	"testing"
+	"time"
+
+	v4state "github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+)
+
+// newConfirmedSM returns a StateManager with one confirmed v4 client, so
+// GetConfirmedClientIDs is non-empty and the coordinator's StartGracePeriod
+// actually activates v4 grace (an empty client set is skipped by design).
+func newConfirmedSM(t *testing.T) *v4state.StateManager {
+	t.Helper()
+	sm := v4state.NewStateManager(time.Hour)
+	verf := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	res, err := sm.SetClientID("client-A", verf, v4state.CallbackInfo{}, "10.0.0.1:1", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	return sm
+}
+
+// TestGraceCoordinator_RefcountKeepsV4GraceUntilLastShare is the REVIEW slice-3
+// regression. N shares enter lock-manager grace and couple through the
+// coordinator. Removing/ending ONE share must NOT lift global v4 grace while
+// other shares' windows are still open; v4 grace lifts only when the LAST
+// share's window closes (refcount zero). Under the old "first in, first out"
+// policy a single OnLockGraceEnd force-ended v4 grace outright.
+func TestGraceCoordinator_RefcountKeepsV4GraceUntilLastShare(t *testing.T) {
+	sm := newConfirmedSM(t)
+	c := &nfsGraceCoordinator{sm: sm}
+
+	// Three shares enter lock-manager grace.
+	c.OnLockGraceStart([]string{"nlm-1"})
+	if !sm.IsInGrace() {
+		t.Fatal("first share's grace start must couple v4 into grace")
+	}
+	c.OnLockGraceStart([]string{"nlm-2"})
+	c.OnLockGraceStart([]string{"nlm-3"})
+	if !sm.IsInGrace() {
+		t.Fatal("v4 grace must remain active across multiple coupled shares")
+	}
+
+	// Remove the first two shares (early lock-manager grace-end, e.g. via
+	// RemoveStoreForShare or per-share reclaim). v4 grace must stay up.
+	c.OnLockGraceEnd()
+	if !sm.IsInGrace() {
+		t.Fatal("v4 grace lifted after ONE share ended while others outstanding (premature lift)")
+	}
+	c.OnLockGraceEnd()
+	if !sm.IsInGrace() {
+		t.Fatal("v4 grace lifted while one share still in grace (premature lift)")
+	}
+
+	// Last share ends: refcount hits zero and this coordinator OWNS v4 grace
+	// (it started it), so v4 grace lifts now.
+	c.OnLockGraceEnd()
+	if sm.IsInGrace() {
+		t.Fatal("v4 grace must lift once the LAST coupled share's window closes")
+	}
+}
+
+// TestGraceCoordinator_BootSeededRosterNotForceEnded asserts that when v4 grace
+// was independently boot-seeded (LoadClientRecovery roster, slice-2), the
+// coordinator does NOT force-end it at refcount zero. The v4 machine governs its
+// own lift via its reclaim early-exit and hard timer, so an early
+// lock-manager grace-end can never prematurely bypass the v4 reclaim roster.
+func TestGraceCoordinator_BootSeededRosterNotForceEnded(t *testing.T) {
+	sm := v4state.NewStateManager(time.Hour)
+	// Simulate LoadClientRecovery seeding v4 grace with a durable roster BEFORE
+	// any coordinator coupling (boot order: recovery load, then adapter wires
+	// the coordinator and catches up shares already in grace).
+	sm.StartGracePeriod([]uint64{42})
+	if !sm.IsInGrace() {
+		t.Fatal("precondition: boot-seeded v4 grace must be active")
+	}
+
+	c := &nfsGraceCoordinator{sm: sm}
+
+	// Adapter catch-up: two shares already in lock-manager grace couple in.
+	c.OnLockGraceStart([]string{"nlm-1"})
+	c.OnLockGraceStart([]string{"nlm-2"})
+
+	// Both shares' lock-manager grace windows end. Even at refcount zero, the
+	// coordinator must DEFER to the v4 machine (it did not start it), so v4 grace
+	// stays up under its own roster/timer governance.
+	c.OnLockGraceEnd()
+	c.OnLockGraceEnd()
+	if !sm.IsInGrace() {
+		t.Fatal("coordinator force-ended boot-seeded v4 grace at refcount zero (must defer to v4 timer/roster)")
+	}
+
+	// The v4 machine's own hard timer remains the backstop, so v4 grace can be
+	// ended through its own path without wedging.
+	sm.ForceEndGrace()
+	if sm.IsInGrace() {
+		t.Fatal("v4 machine's own ForceEndGrace must still lift grace")
+	}
+}
+
+// TestGraceCoordinator_EndUnderflowIgnored guards against refcount underflow: an
+// unbalanced OnLockGraceEnd (more ends than starts) must be ignored, never
+// driving the count negative or panicking.
+func TestGraceCoordinator_EndUnderflowIgnored(t *testing.T) {
+	sm := newConfirmedSM(t)
+	c := &nfsGraceCoordinator{sm: sm}
+
+	// End with no outstanding starts: no-op, no panic.
+	c.OnLockGraceEnd()
+	c.OnLockGraceEnd()
+
+	// A subsequent start/end cycle must still behave correctly (count not stuck
+	// negative).
+	c.OnLockGraceStart([]string{"nlm-1"})
+	if !sm.IsInGrace() {
+		t.Fatal("start after spurious ends must still couple v4 grace")
+	}
+	c.OnLockGraceEnd()
+	if sm.IsInGrace() {
+		t.Fatal("balanced end after start must lift coordinator-owned v4 grace")
+	}
+}
+
+// TestGraceCoordinator_NilStateManagerNoPanic confirms the coordinator is a
+// safe no-op when no StateManager is wired (defensive).
+func TestGraceCoordinator_NilStateManagerNoPanic(t *testing.T) {
+	c := &nfsGraceCoordinator{sm: nil}
+	c.OnLockGraceStart([]string{"x"})
+	c.OnLockGraceEnd()
+}

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -130,7 +130,7 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 	if err != nil {
 		logger.Warn("Netgroup access denied: share not found in runtime registry",
 			"share", shareName, "error", err)
-		return false, fmt.Errorf("%w: %q", shares.ErrShareNotFound, shareName)
+		return false, fmt.Errorf("%w: %q: %w", shares.ErrShareNotFound, shareName, err)
 	}
 
 	// 2. If share has no netgroup -> allow all

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
@@ -117,10 +118,19 @@ func (c *dnsCache) cleanExpiredLocked(now time.Time) {
 // 5-minute positive TTL and 1-minute negative TTL. Falls back to IP matching
 // if DNS lookup fails (does not block).
 func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, clientIP net.IP) (bool, error) {
-	// 1. Get share from runtime state
+	// 1. Get share from runtime state.
+	//
+	// A lookup miss here (unknown / renamed / partially-loaded share) is NOT a
+	// legitimate netgroup deny: it signals config drift between the requested
+	// share and the runtime registry. Returning a bare (false, nil) would be
+	// indistinguishable from "client not in allowlist" and silently invisible.
+	// Surface it as a wrapped ErrShareNotFound so it is diagnosable while still
+	// denying access (the mount handler treats any error as fail-closed).
 	share, err := r.sharesSvc.GetShare(shareName)
 	if err != nil {
-		return false, nil
+		logger.Warn("Netgroup access denied: share not found in runtime registry",
+			"share", shareName, "error", err)
+		return false, fmt.Errorf("%w: %q", shares.ErrShareNotFound, shareName)
 	}
 
 	// 2. If share has no netgroup -> allow all

--- a/pkg/controlplane/runtime/netgroups_test.go
+++ b/pkg/controlplane/runtime/netgroups_test.go
@@ -4,12 +4,14 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
@@ -60,16 +62,25 @@ func TestCheckNetgroupAccess_NoNetgroup_AllowAll(t *testing.T) {
 	}
 }
 
+// TestCheckNetgroupAccess_ShareNotFound is the REVIEW M3 regression. A share
+// lookup miss (unknown / renamed / partially-loaded share) must be a fail-CLOSED
+// deny that is also OBSERVABLE: it returns a wrapped shares.ErrShareNotFound so
+// config drift is diagnosable, instead of the old silent (false, nil) that was
+// indistinguishable from a legitimate netgroup deny. The mount handler already
+// treats any non-nil error as fail-closed, so the deny semantics are preserved.
 func TestCheckNetgroupAccess_ShareNotFound(t *testing.T) {
 	rt, _, _ := createTestRuntimeWithStore(t)
 	ctx := context.Background()
 
 	allowed, err := rt.CheckNetgroupAccess(ctx, "/nonexistent", net.ParseIP("10.0.0.1"))
-	if err != nil {
-		t.Fatalf("Expected no error for missing share, got: %v", err)
-	}
 	if allowed {
 		t.Error("Expected access denied for nonexistent share")
+	}
+	if err == nil {
+		t.Fatal("Expected an observable error for missing share, got nil (silent deny)")
+	}
+	if !errors.Is(err, shares.ErrShareNotFound) {
+		t.Fatalf("Expected error to wrap shares.ErrShareNotFound, got: %v", err)
 	}
 }
 

--- a/pkg/controlplane/runtime/shares/add_share_race_test.go
+++ b/pkg/controlplane/runtime/shares/add_share_race_test.go
@@ -1,0 +1,121 @@
+package shares
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// fixedStoreProvider returns one specific metadata store for every lookup. Two
+// racing AddShare calls each get their OWN provider+store so we can detect a
+// metadata-store/registry mismatch: if the loser's store ends up registered
+// while the winner's share is in the registry, the two layers disagree.
+type fixedStoreProvider struct{ store metadata.MetadataStore }
+
+func (p fixedStoreProvider) GetMetadataStore(string) (metadata.MetadataStore, error) {
+	return p.store, nil
+}
+
+// TestAddShare_ConcurrentSameName_NoMetadataMismatch is the REVIEW M2
+// regression. Two goroutines race AddShare for the SAME name, each carrying a
+// DISTINCT metadata store, against a shared real MetadataService. Exactly one
+// must win; afterward the MetadataService's registered store for the name must
+// be the SAME store the winning share exposes, and the loser must leave NO
+// leaked metadata registration. Under the old ordering the loser's
+// RegisterStoreForShare could win the last-writer-wins race on the metadata
+// store map while losing the registry recheck, leaving the two layers pointing
+// at different stores.
+func TestAddShare_ConcurrentSameName_NoMetadataMismatch(t *testing.T) {
+	const name = "/raced"
+
+	for iter := 0; iter < 200; iter++ {
+		ctx := context.Background()
+
+		// Each contender gets its own distinct metadata store so a mismatch is
+		// observable by pointer identity.
+		storeA := metamem.NewMemoryMetadataStoreWithDefaults()
+		storeB := metamem.NewMemoryMetadataStoreWithDefaults()
+
+		svc := New()
+		metaSvc := metadata.New()
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		winners := 0
+		var winnerStore metadata.MetadataStore
+
+		run := func(store metadata.MetadataStore) {
+			defer wg.Done()
+			cfg := &ShareConfig{Name: name, MetadataStore: "m", Enabled: true}
+			err := svc.AddShare(ctx, cfg, fixedStoreProvider{store: store}, metaSvc, nil, nil, nil)
+			if err == nil {
+				mu.Lock()
+				winners++
+				winnerStore = store
+				mu.Unlock()
+			}
+		}
+
+		wg.Add(2)
+		go run(storeA)
+		go run(storeB)
+		wg.Wait()
+
+		if winners != 1 {
+			t.Fatalf("iter %d: expected exactly one AddShare to win, got %d", iter, winners)
+		}
+
+		// The registry must expose the winner's share.
+		if _, err := svc.GetShare(name); err != nil {
+			t.Fatalf("iter %d: winner share not in registry: %v", iter, err)
+		}
+
+		// INVARIANT: the MetadataService's registered store for the name must be
+		// the SAME store the winning AddShare used — no loser-store leak.
+		got, err := metaSvc.GetStoreForShare(name)
+		if err != nil {
+			t.Fatalf("iter %d: MetadataService has no store for winner share: %v", iter, err)
+		}
+		if got != winnerStore {
+			t.Fatalf("iter %d: metadata/registry MISMATCH: MetadataService store != winner's store", iter)
+		}
+
+		_ = storeA.Close()
+		_ = storeB.Close()
+	}
+}
+
+// TestAddShare_ConcurrentSameName_SecondCallerRejected pins the simpler
+// invariant that a second AddShare for a name already (or concurrently) added
+// is rejected, and the first caller's share survives intact.
+func TestAddShare_ConcurrentSameName_SecondCallerRejected(t *testing.T) {
+	const name = "/once"
+	ctx := context.Background()
+
+	store := metamem.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := New()
+	metaSvc := metadata.New()
+
+	cfg := &ShareConfig{Name: name, MetadataStore: "m", Enabled: true}
+	if err := svc.AddShare(ctx, cfg, fixedStoreProvider{store: store}, metaSvc, nil, nil, nil); err != nil {
+		t.Fatalf("first AddShare: %v", err)
+	}
+
+	// Second add for the same name must fail.
+	if err := svc.AddShare(ctx, cfg, fixedStoreProvider{store: store}, metaSvc, nil, nil, nil); err == nil {
+		t.Fatal("second AddShare for existing name: want error, got nil")
+	}
+
+	// The share must still resolve in both layers.
+	if _, err := svc.GetShare(name); err != nil {
+		t.Fatalf("share missing after rejected re-add: %v", err)
+	}
+	if _, err := metaSvc.GetStoreForShare(name); err != nil {
+		t.Fatalf("metadata store missing after rejected re-add: %v", err)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -202,6 +202,14 @@ type MetadataServiceRegistrar interface {
 	RegisterStoreForShare(shareName string, store metadata.MetadataStore) error
 }
 
+// MetadataServiceDeregistrar deregisters a metadata store for a share. The
+// concrete *metadata.MetadataService satisfies it. AddShare's defensive
+// finalize-failure path uses it to avoid leaking a metadata registration for a
+// share it refuses to finalize.
+type MetadataServiceDeregistrar interface {
+	RemoveStoreForShare(shareName string)
+}
+
 // BlockStoreConfigProvider resolves block store configurations from the control plane DB.
 type BlockStoreConfigProvider interface {
 	GetBlockStoreByID(ctx context.Context, id string) (*models.BlockStoreConfig, error)
@@ -262,8 +270,17 @@ func (n *nonClosingRemote) Close() error { return nil }
 
 // Service manages share registration, lookup, and configuration.
 type Service struct {
-	mu              sync.RWMutex
-	registry        map[string]*Share
+	mu       sync.RWMutex
+	registry map[string]*Share
+	// reservations holds share names that an in-flight AddShare has claimed but
+	// not yet finalized into registry. It closes the AddShare(sameName) race
+	// (REVIEW M2): the name is reserved under s.mu BEFORE any side-effecting
+	// metadata/block-store init, so a concurrent AddShare for the same name
+	// fails early — before it can RegisterStoreForShare and leave a
+	// metadata-store/registry mismatch when it later loses the registry recheck.
+	// A reserved name is NOT yet in registry, so handlers never observe a
+	// half-built share.
+	reservations    map[string]struct{}
 	remoteStores    map[string]*sharedRemote // configID -> shared remote
 	nextCallbackID  int
 	changeCallbacks map[int]func(shares []string)
@@ -272,6 +289,7 @@ type Service struct {
 func New() *Service {
 	return &Service{
 		registry:        make(map[string]*Share),
+		reservations:    make(map[string]struct{}),
 		remoteStores:    make(map[string]*sharedRemote),
 		changeCallbacks: make(map[int]func(shares []string)),
 	}
@@ -349,6 +367,32 @@ func (s *Service) AddShare(
 		return fmt.Errorf("metadata service registrar is required for share %q", config.Name)
 	}
 
+	// Phase 0: Reserve the share name under s.mu BEFORE any side-effecting init
+	// (root-dir create, block-store start, metadata RegisterStoreForShare). This
+	// closes the AddShare(sameName) race (REVIEW M2): the OLD ordering let two
+	// racing callers both run RegisterStoreForShare (last writer wins on the
+	// MetadataService store map) and only THEN recheck the registry under the
+	// lock — so the loser would tear down its block store yet leave its metadata
+	// store registered, pointing the MetadataService at a different store than
+	// the registry exposes. Reserving here serializes on the name first: the
+	// loser fails before touching any shared store, so no mismatch can form.
+	//
+	// The reservation is NOT inserted into registry, so a half-built share is
+	// never visible to handlers; it is converted to a registry entry only in
+	// Phase 4 after all init succeeds.
+	if err := s.reserveShareName(config.Name); err != nil {
+		return err
+	}
+	// Track whether the reservation still needs releasing. Phase 4 hands the
+	// reservation off to the registry entry (under the same lock) and clears
+	// this flag; every failure path releases it.
+	reservationHeld := true
+	defer func() {
+		if reservationHeld {
+			s.releaseShareName(config.Name)
+		}
+	}()
+
 	// Phase 1: Build share struct (resolves metadata store, creates root dir).
 	// Does NOT insert into registry yet -- share is invisible to handlers.
 	share, metadataStore, err := s.prepareShare(ctx, config, storeProvider)
@@ -373,26 +417,62 @@ func (s *Service) AddShare(
 		}
 	}
 
-	// Phase 3: Register metadata store.
+	// Phase 3: Register metadata store. Safe to call unconditionally now: the
+	// Phase-0 reservation guarantees no other AddShare for this name is in
+	// flight, so this RegisterStoreForShare cannot be raced into a
+	// last-writer-wins mismatch.
 	if err := metadataSvc.RegisterStoreForShare(config.Name, metadataStore); err != nil {
 		cleanupShare()
 		return fmt.Errorf("failed to configure metadata for share: %w", err)
 	}
 
-	// Phase 4: Insert fully-initialized share into registry.
-	// Only now is the share visible to protocol handlers.
+	// Phase 4: Convert the reservation into a registry entry under s.mu.
+	// Only now is the share visible to protocol handlers. The reservation has
+	// held the name exclusively since Phase 0, so registry[name] cannot already
+	// exist here; we assert it defensively and hand off the reservation.
 	s.mu.Lock()
 	if _, exists := s.registry[config.Name]; exists {
+		// Should be unreachable while the reservation is held, but stay
+		// fail-safe: tear down rather than overwrite an existing share.
 		s.mu.Unlock()
 		cleanupShare()
+		// Deregister the metadata store we just published so we do not leak a
+		// registration for a share we are refusing to finalize.
+		if remover, ok := metadataSvc.(MetadataServiceDeregistrar); ok {
+			remover.RemoveStoreForShare(config.Name)
+		}
 		return fmt.Errorf("share %q already exists", config.Name)
 	}
 	s.registry[config.Name] = share
+	delete(s.reservations, config.Name)
+	reservationHeld = false
 	s.mu.Unlock()
 
 	s.notifyShareChange()
 
 	return nil
+}
+
+// reserveShareName claims a share name for an in-flight AddShare. It fails if
+// the name is already registered or already reserved by a concurrent AddShare.
+func (s *Service) reserveShareName(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.registry[name]; exists {
+		return fmt.Errorf("share %q already exists", name)
+	}
+	if _, reserved := s.reservations[name]; reserved {
+		return fmt.Errorf("share %q is already being added", name)
+	}
+	s.reservations[name] = struct{}{}
+	return nil
+}
+
+// releaseShareName drops an in-flight AddShare reservation. Idempotent.
+func (s *Service) releaseShareName(name string) {
+	s.mu.Lock()
+	delete(s.reservations, name)
+	s.mu.Unlock()
 }
 
 // prepareShare validates config, resolves the metadata store, and creates the


### PR DESCRIPTION
Fixes three area-7 runtime lifecycle-race findings plus the durable-state slice-3 grace-coordinator refcount.

## M2 — concurrent AddShare(sameName) metadata/registry mismatch (HIGH-ish)
**What:** Two racing `AddShare(name)` calls both reached Phase-3 `RegisterStoreForShare` (which unconditionally writes `MetadataService.s.stores[name]`, last-writer-wins) BEFORE the Phase-4 registry duplicate recheck under `s.mu`. The loser failed the recheck and ran `cleanupShare` (closes block store + releases remote ref) but never deregistered its metadata store — so `MetadataService` could point at the loser's store while the shares registry exposed the winner's.

**Fix (approach a — reserve-the-name):** `AddShare` now claims the share name in a new `reservations` set under `s.mu` in a new Phase-0, BEFORE any side-effecting init (root-dir create, block-store start, RegisterStoreForShare). The loser fails at reservation, before touching any shared store, so no mismatch can form. The reservation is NOT in the registry (handlers never see a half-built share); Phase-4 converts it to a registry entry under the same lock. A defensive (unreachable-while-reserved) finalize-failure branch also deregisters the just-published store via a new `MetadataServiceDeregistrar` seam — it only ever removes the store it itself registered, so the winner is never clobbered.

**Winner protection / lock ordering:** Reservation serializes name ownership, so only one AddShare ever registers a store for a name — the winner. `shares.Service.mu` and `MetadataService.mu` are never held simultaneously (reservation releases `s.mu` before RegisterStoreForShare; the defensive RemoveStoreForShare runs after `s.mu.Unlock()`), matching the existing RemoveShare/Register ordering — no inversion, no deadlock.

**Test:** `TestAddShare_ConcurrentSameName_NoMetadataMismatch` (200 iters, two goroutines, distinct stores, `-race`): exactly one wins, `MetadataService.GetStoreForShare(name)` == the winner's store, loser leaks no registration. Plus `TestAddShare_ConcurrentSameName_SecondCallerRejected`.

## M3 — CheckNetgroupAccess silent deny on share-lookup miss
**What:** A share-lookup miss returned bare `(false, nil)` — indistinguishable from a legitimate netgroup deny, with no log/error, while every other branch errors or logs.

**Fix:** On the share-miss branch, log at Warn and return a wrapped `shares.ErrShareNotFound` so config drift (unknown/renamed/partially-loaded share) is diagnosable. Stays fail-closed — the mount handler already maps any non-nil error to deny.

**Test:** `TestCheckNetgroupAccess_ShareNotFound` updated to assert deny + `errors.Is(err, shares.ErrShareNotFound)`.

## slice-3 — grace-coordinator refcount (REAL; now live with slice-2 v4 persistence)
**Verdict: FIXED with a refcount.** The old `nfsGraceCoordinator` used a "first share in starts v4 grace, first share out ends it" policy: any single `OnLockGraceEnd` (RemoveStoreForShare, a per-share reclaim/timer) called `ForceEndGrace()` and lifted GLOBAL v4 grace outright — even while other shares' lock-manager grace windows were still open. The type doc called this latent "until v4 client persistence lands"; slice-2 (`LoadClientRecovery` + `StartGraceWithRoster`) landed it, so the bug is now live.

**Fix:** The coordinator refcounts open per-share lock-manager grace windows — `OnLockGraceStart` increments, `OnLockGraceEnd` decrements — and lifts global v4 grace only when the LAST window closes (refcount zero). When v4 grace was independently boot-seeded with a durable roster, the coordinator does NOT own it (`startedByCoordinator=false`) and at refcount zero DEFERS to the v4 machine's own reclaim early-exit + hard timer rather than force-ending and bypassing the roster. The v4 hard grace timer remains the always-on backstop (no wedge). Underflow guarded.

**Tests:** `TestGraceCoordinator_RefcountKeepsV4GraceUntilLastShare` (3 shares; ending 2 keeps v4 grace up; last lifts it), `TestGraceCoordinator_BootSeededRosterNotForceEnded` (refcount-zero does NOT force-end boot-seeded grace), `TestGraceCoordinator_EndUnderflowIgnored`, `TestGraceCoordinator_NilStateManagerNoPanic`.

## M1-residual — NOT hardened (benign, by design)
`runtime.RemoveShare` calls `sharesSvc.RemoveShare` then `metadataService.RemoveStoreForShare`. The lazy getters (GetLockManagerForShare/ForHandle, GetStoreForShare) are pure reads (nil/StaleHandle, no create), so they cannot resurrect — #907's removedMidFlight guard closed that vector. The inter-call window only exposes ephemeral lock-manager state that is about to be discarded; the data plane is drain-gated by #918's block-store close-gate. No real residual window, so no speculative code added.

## Tests / CI
`go test -race ./pkg/controlplane/... ./pkg/metadata/... ./pkg/adapter/nfs/...` green. Integration `TestCheckNetgroupAccess_*` green. `gofmt`/`go vet`/`golangci-lint` clean; full `go build ./...` green. (Note: a pre-existing `-race`-only flake in unrelated `TestSettingsWatcher_AtomicSwap` — untouched here — panics on the integration tag under `-race` parallelism; it passes in isolation and without `-race`.)