### PR TITLE
feat(smb/dh2): persist lease-V2 epoch across durable reconnect (#739 lock-lease)

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -870,6 +870,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 				// the handle actually still holds.
 				persistedOplockLevel := restored.OplockLevel
 				persistedLeaseState := reconnResult.PersistedLease
+				persistedLeaseEpoch := reconnResult.PersistedEpoch
 
 				if restored.OplockLevel == OplockLevelLease && restored.LeaseKey != ([16]byte{}) {
 					// Use persisted lease state for re-request. This preserves the
@@ -908,17 +909,34 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						leaseStateRank(persistedLeaseState) > leaseStateRank(reportedLeaseState) {
 						reportedLeaseState = persistedLeaseState
 					}
+					// Mirror the lease-state fallback for the epoch. The lease-V2
+					// epoch is monotonic across the handle's life; a fresh
+					// re-registration on reconnect restarts it at 0, which would
+					// make the reconnect response report Epoch=0 and leak a stale
+					// NewEpoch on the next break. Restore the persisted epoch when
+					// the re-grant under-delivers (returns 0 or an older value)
+					// (smb2.durable-v2-open.lock-lease asserts lease_epoch==1).
+					reportedLeaseEpoch := epoch
+					if persistedLeaseEpoch > reportedLeaseEpoch {
+						reportedLeaseEpoch = persistedLeaseEpoch
+					}
 					if leaseErr != nil {
 						logger.Debug("CREATE: durable reconnect lease re-request failed", "error", leaseErr)
 					}
 					if reportedLeaseState != lock.LeaseStateNone {
+						// Push the restored epoch back into the lock layer so
+						// subsequent break notifications carry the correct
+						// NewEpoch rather than the re-registration's reset value.
+						if reportedLeaseEpoch != epoch {
+							h.LeaseManager.SetLeaseEpoch(restored.LeaseKey, reportedLeaseEpoch)
+						}
 						// Build lease response context
 						if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
 							isV1 := len(leaseCtx.Data) < LeaseV2ContextSize
 							leaseResp := &LeaseResponseContext{
 								LeaseKey:   restored.LeaseKey,
 								LeaseState: reportedLeaseState,
-								Epoch:      epoch,
+								Epoch:      reportedLeaseEpoch,
 								IsV1:       isV1,
 							}
 							reconnectContexts = append(reconnectContexts, CreateContext{

--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -293,6 +293,7 @@ func ProcessDurableHandleContext(
 type ReconnectResult struct {
 	OpenFile       *OpenFile // Restored open file state
 	PersistedLease uint32    // Lease state at disconnect time (for re-granting)
+	PersistedEpoch uint16    // Lease-V2 epoch at disconnect time (lock layer); 0 if none
 	IsV2           bool      // True if DH2C (V2), false if DHnC (V1)
 	// OriginalFileID is the full 16-byte FileID captured at first CREATE
 	// (zero for handles persisted before the field was introduced). Callers
@@ -328,21 +329,21 @@ func ProcessDurableReconnectContext(
 
 	// Determine V2 (DH2C) or V1 (DHnC) reconnect
 	if dh2cCtx := FindCreateContext(contexts, DurableHandleV2ReconnectTag); dh2cCtx != nil {
-		openFile, leaseState, origID, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
+		openFile, leaseState, leaseEpoch, origID, status, err := processV2Reconnect(ctx, durableStore, metaSvc, contexts, dh2cCtx,
 			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
-		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: true, OriginalFileID: origID}, types.StatusSuccess, nil
+		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, PersistedEpoch: leaseEpoch, IsV2: true, OriginalFileID: origID}, types.StatusSuccess, nil
 	}
 
 	if dhnCCtx := FindCreateContext(contexts, DurableHandleV1ReconnectTag); dhnCCtx != nil {
-		openFile, leaseState, origID, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
+		openFile, leaseState, leaseEpoch, origID, status, err := processV1Reconnect(ctx, durableStore, metaSvc, contexts, dhnCCtx,
 			sessionID, username, sessionKeyHash, shareName, filename, connClientGUID)
 		if err != nil || status != types.StatusSuccess {
 			return nil, status, err
 		}
-		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, IsV2: false, OriginalFileID: origID}, types.StatusSuccess, nil
+		return &ReconnectResult{OpenFile: openFile, PersistedLease: leaseState, PersistedEpoch: leaseEpoch, IsV2: false, OriginalFileID: origID}, types.StatusSuccess, nil
 	}
 
 	// No reconnect context found
@@ -440,12 +441,12 @@ func processV1Reconnect(
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
-) (*OpenFile, uint32, [16]byte, types.Status, error) {
+) (*OpenFile, uint32, uint16, [16]byte, types.Status, error) {
 	// Parse V1 reconnect context
 	wireFileID, err := DecodeDHnCReconnect(dhnCCtx.Data)
 	if err != nil {
 		logger.Debug("processV1Reconnect: invalid DHnC data", "error", err)
-		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// MS-SMB2 §3.2.4.4 mandates Data.Volatile=0 on DHnC, but smbtorture's
@@ -470,7 +471,7 @@ func processV1Reconnect(
 	if FindCreateContext(contexts, DurableHandleV2RequestTag) != nil ||
 		FindCreateContext(contexts, DurableHandleV2ReconnectTag) != nil {
 		logger.Debug("processV1Reconnect: check 2 FAIL - conflicting V2 context present")
-		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// Non-destructive lookup: validation-failure paths (share/path/username/
@@ -483,12 +484,12 @@ func processV1Reconnect(
 	handle, err := durableStore.GetDurableHandleByFileID(ctx, fileID)
 	if err != nil {
 		logger.Warn("processV1Reconnect: store error", "error", err)
-		return nil, 0, [16]byte{}, types.StatusInternalError, err
+		return nil, 0, 0, [16]byte{}, types.StatusInternalError, err
 	}
 	if handle == nil {
 		logger.Debug("processV1Reconnect: check 3 FAIL - handle not found by FileID",
 			"fileID", fmt.Sprintf("%x", fileID))
-		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		return nil, 0, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// MS-SMB2 §3.3.5.9.7 / Samba `smbd_smb2_create_durable_lease_check`
@@ -507,7 +508,7 @@ func processV1Reconnect(
 	//       * else                            → proceed
 	gateStatus, persistedHasLease := checkLeaseReconnectGate(contexts, handle, connClientGUID, "processV1Reconnect")
 	if gateStatus != types.StatusSuccess {
-		return nil, 0, [16]byte{}, gateStatus, nil
+		return nil, 0, 0, [16]byte{}, gateStatus, nil
 	}
 	// V1 oplock-backed reconnect ignores the filename (MS-SMB2 §3.3.5.9.7); a
 	// lease-backed reconnect path-checks via validateAndRestore.
@@ -518,7 +519,7 @@ func processV1Reconnect(
 		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
 			return durableStore.ConsumeDurableHandleByFileID(ctx, fileID)
 		})
-	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
+	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
 // processV2Reconnect handles V2 (DH2C) reconnect validation and restoration.
@@ -535,18 +536,18 @@ func processV2Reconnect(
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
-) (*OpenFile, uint32, [16]byte, types.Status, error) {
+) (*OpenFile, uint32, uint16, [16]byte, types.Status, error) {
 	// Parse V2 reconnect context
 	fileID, createGuid, flags, err := DecodeDH2CReconnect(dh2cCtx.Data)
 	if err != nil {
 		logger.Debug("processV2Reconnect: invalid DH2C data", "error", err)
-		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// Reject persistent flag
 	if flags&DH2FlagPersistent != 0 {
 		logger.Debug("processV2Reconnect: persistent flag rejected")
-		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	logger.Debug("processV2Reconnect: starting validation",
@@ -584,14 +585,14 @@ func processV2Reconnect(
 	}
 	if err != nil {
 		logger.Warn("processV2Reconnect: store error", "error", err)
-		return nil, 0, [16]byte{}, types.StatusInternalError, err
+		return nil, 0, 0, [16]byte{}, types.StatusInternalError, err
 	}
 	if handle == nil {
 		logger.Debug("processV2Reconnect: handle not found",
 			"createGuid", fmt.Sprintf("%x", createGuid),
 			"fileID", fmt.Sprintf("%x", fileID),
 			"byFileID", zeroCreateGuid)
-		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		return nil, 0, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// The zero-CreateGuid FileID fallback is ONLY for reconnecting a V1 handle
@@ -607,7 +608,7 @@ func processV2Reconnect(
 		logger.Debug("processV2Reconnect: zero CreateGuid cannot reconnect a V2 handle",
 			"handleCreateGuid", fmt.Sprintf("%x", handle.CreateGuid),
 			"fileID", fmt.Sprintf("%x", fileID))
-		return nil, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
+		return nil, 0, 0, [16]byte{}, types.StatusObjectNameNotFound, nil
 	}
 
 	// Validate FileID from DH2C against persisted handle to prevent wrong-
@@ -622,7 +623,7 @@ func processV2Reconnect(
 		logger.Debug("processV2Reconnect: persistent FileID mismatch",
 			"expected", fmt.Sprintf("%x", handle.FileID[:8]),
 			"actual", fmt.Sprintf("%x", fileID[:8]))
-		return nil, 0, [16]byte{}, types.StatusInvalidParameter, nil
+		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 
 	// MS-SMB2 §3.3.5.9.12 / Samba `smbd_smb2_create_durable_lease_check`: the V2
@@ -632,7 +633,7 @@ func processV2Reconnect(
 	// INVALID_PARAMETER a path mismatch would yield).
 	gateStatus, persistedHasLease := checkLeaseReconnectGate(contexts, handle, connClientGUID, "processV2Reconnect")
 	if gateStatus != types.StatusSuccess {
-		return nil, 0, [16]byte{}, gateStatus, nil
+		return nil, 0, 0, [16]byte{}, gateStatus, nil
 	}
 
 	// Symmetric with V1: a non-lease (oplock-backed) V2 reconnect IGNORES the
@@ -653,7 +654,7 @@ func processV2Reconnect(
 	}
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
 		sessionKeyHash, shareName, filename, persistedHasLease, consume)
-	return openFile, handle.LeaseState, handle.OriginalFileID, status, restoreErr
+	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
 // validateAndRestore runs the shared reconnect validation checks and restores
@@ -1003,14 +1004,16 @@ func ProcessAppInstanceId(
 
 // buildPersistedDurableHandle creates a PersistedDurableHandle from an OpenFile
 // and session information. Used when persisting durable handles during disconnect.
-// leaseState is the current lease state (R/W/H flags) at disconnect time,
-// used to restore the lease on reconnect.
+// leaseState is the current lease state (R/W/H flags) at disconnect time, and
+// leaseEpoch the live lease-V2 epoch (lock layer), both used to restore the
+// lease on reconnect.
 func buildPersistedDurableHandle(
 	openFile *OpenFile,
 	username string,
 	sessionKeyHash [32]byte,
 	serverStartTime time.Time,
 	leaseState uint32,
+	leaseEpoch uint16,
 ) *lock.PersistedDurableHandle {
 	// Clone MetadataHandle to avoid aliasing the live OpenFile's slice
 	metaHandle := make([]byte, len(openFile.MetadataHandle))
@@ -1044,6 +1047,7 @@ func buildPersistedDurableHandle(
 		OplockLevel:     openFile.OplockLevel,
 		LeaseKey:        openFile.LeaseKey,
 		LeaseState:      leaseState,
+		LeaseEpoch:      leaseEpoch,
 		CreateGuid:      openFile.CreateGuid,
 		AppInstanceId:   openFile.AppInstanceId,
 		Username:        username,

--- a/internal/adapter/smb/v2/handlers/handler.go
+++ b/internal/adapter/smb/v2/handlers/handler.go
@@ -1082,11 +1082,16 @@ func (h *Handler) closeFilesWithFilter(
 				sessionKeyHash = computeSessionKeyHash(sess)
 			}
 
-			// Capture current lease state from LeaseManager for reconnect restoration
+			// Capture current lease state + epoch from LeaseManager for reconnect
+			// restoration. The epoch is the live OpLock.Lease.Epoch (lock layer);
+			// persisting it lets the reconnect CREATE response restore the exact
+			// epoch the client last saw (smb2.durable-v2-open.lock-lease).
 			var leaseState uint32
+			var leaseEpoch uint16
 			if h.LeaseManager != nil && openFile.LeaseKey != ([16]byte{}) {
-				if state, _, found := h.LeaseManager.GetLeaseState(ctx, openFile.LeaseKey); found {
+				if state, epoch, found := h.LeaseManager.GetLeaseState(ctx, openFile.LeaseKey); found {
 					leaseState = state
+					leaseEpoch = epoch
 				}
 			}
 
@@ -1114,7 +1119,7 @@ func (h *Handler) closeFilesWithFilter(
 				// Serialize the persist against concurrent create-time
 				// purge windows; see durablePurgeMu comment.
 				h.durablePurgeMu.Lock()
-				persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState)
+				persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState, leaseEpoch)
 				err := h.DurableStore.PutDurableHandle(ctx, persisted)
 				h.durablePurgeMu.Unlock()
 				if err != nil {

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -24,14 +24,25 @@ type PersistedDurableHandle struct {
 	// the file's DACL has changed since open. Mirrors Samba's
 	// smbXsrv_open_global semantics where the access_mask field is
 	// preserved verbatim across reconnect.
-	GrantedAccess   uint32
-	ShareAccess     uint32
-	CreateOptions   uint32
-	MetadataHandle  []byte
-	PayloadID       string
-	OplockLevel     uint8
-	LeaseKey        [16]byte
-	LeaseState      uint32
+	GrantedAccess  uint32
+	ShareAccess    uint32
+	CreateOptions  uint32
+	MetadataHandle []byte
+	PayloadID      string
+	OplockLevel    uint8
+	LeaseKey       [16]byte
+	LeaseState     uint32
+	// LeaseEpoch is the SMB3 lease-V2 epoch (state-change counter,
+	// MS-SMB2 2.2.13.2.8 / 2.2.23.2) captured at disconnect. Lives in the
+	// protocol-agnostic lock layer as the durable counterpart to the live
+	// OpLock.Lease.Epoch; persisted so a durable reconnect restores the
+	// exact epoch the client last saw rather than resetting to 0. Without
+	// it, the lease-response context on reconnect reports Epoch=0 and the
+	// next break notification leaks a stale NewEpoch
+	// (smb2.durable-v2-open.lock-lease asserts lease_epoch==1 on reconnect).
+	// Pre-existing rows carry 0, which the reconnect handler treats as
+	// "no persisted epoch" and falls back to the re-granted value.
+	LeaseEpoch      uint16
 	CreateGuid      [16]byte // V2 only; zero for V1
 	AppInstanceId   [16]byte // Zero if not set
 	Username        string

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -265,6 +265,7 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 		OplockLevel:        h.OplockLevel,
 		LeaseKey:           h.LeaseKey,
 		LeaseState:         h.LeaseState,
+		LeaseEpoch:         h.LeaseEpoch,
 		CreateGuid:         h.CreateGuid,
 		AppInstanceId:      h.AppInstanceId,
 		Username:           h.Username,

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -23,7 +23,7 @@ func newPostgresDurableStore(pool *pgxpool.Pool) *postgresDurableStore {
 const durableHandleColumns = `
 	id, file_id, path, share_name, desired_access, granted_access, share_access,
 	create_options, metadata_handle, payload_id, oplock_level,
-	lease_key, lease_state, create_guid, app_instance_id,
+	lease_key, lease_state, lease_epoch, create_guid, app_instance_id,
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
@@ -34,6 +34,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
 	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
 	var positionInfoSigned, requestedAllocSizeSigned int64
+	var leaseEpochSigned int32
 
 	err := row.Scan(
 		&h.ID,
@@ -49,6 +50,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&h.OplockLevel,
 		&leaseKeyBytes,
 		&h.LeaseState,
+		&leaseEpochSigned,
 		&createGuidBytes,
 		&appInstanceIdBytes,
 		&h.Username,
@@ -74,6 +76,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		return nil, err
 	}
 
+	h.LeaseEpoch = uint16(leaseEpochSigned)
 	h.PositionInfo = uint64(positionInfoSigned)
 	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
@@ -92,6 +95,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 		var h lock.PersistedDurableHandle
 		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
 		var positionInfoSigned, requestedAllocSizeSigned int64
+		var leaseEpochSigned int32
 
 		err := rows.Scan(
 			&h.ID,
@@ -107,6 +111,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&h.OplockLevel,
 			&leaseKeyBytes,
 			&h.LeaseState,
+			&leaseEpochSigned,
 			&createGuidBytes,
 			&appInstanceIdBytes,
 			&h.Username,
@@ -128,6 +133,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			return nil, err
 		}
 
+		h.LeaseEpoch = uint16(leaseEpochSigned)
 		h.PositionInfo = uint64(positionInfoSigned)
 		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
@@ -180,9 +186,10 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			username, session_key_hash, is_v2, created_at, disconnected_at,
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
-			position_info, original_file_id, requested_alloc_size
+			position_info, original_file_id, requested_alloc_size,
+			lease_epoch
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -211,7 +218,8 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			is_directory = EXCLUDED.is_directory,
 			position_info = EXCLUDED.position_info,
 			original_file_id = EXCLUDED.original_file_id,
-			requested_alloc_size = EXCLUDED.requested_alloc_size
+			requested_alloc_size = EXCLUDED.requested_alloc_size,
+			lease_epoch = EXCLUDED.lease_epoch
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -252,6 +260,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		// the bit pattern like PositionInfo. The scan path mirrors this with
 		// uint64(int64) on read.
 		int64(handle.RequestedAllocSize),
+		// LeaseEpoch is the SMB3 lease-V2 epoch (uint16) stored as INTEGER.
+		// The scan path mirrors this with uint16(int32) on read.
+		int32(handle.LeaseEpoch),
 	)
 	return err
 }

--- a/pkg/metadata/store/postgres/migrations/000026_durable_handle_lease_epoch.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000026_durable_handle_lease_epoch.down.sql
@@ -1,0 +1,4 @@
+-- Revert: drop the durable-handle lease_epoch column (#739 lock-lease).
+
+ALTER TABLE durable_handles
+    DROP COLUMN IF EXISTS lease_epoch;

--- a/pkg/metadata/store/postgres/migrations/000026_durable_handle_lease_epoch.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000026_durable_handle_lease_epoch.up.sql
@@ -1,0 +1,19 @@
+-- Persist LeaseEpoch on durable handles (#739 lock-lease).
+--
+-- An SMB3 lease-V2 carries an Epoch (state-change counter, [MS-SMB2]
+-- 2.2.13.2.8 / 2.2.23.2) that the server increments on every lease state
+-- change and echoes in the lease-response create context. The live counter
+-- lives in the protocol-agnostic lock layer (OpLock.Lease.Epoch); on a
+-- durable disconnect it must be persisted so the reconnect CREATE response
+-- restores the same epoch the client last saw. Without it, reconnect reports
+-- Epoch=0 and the next break notification leaks a stale NewEpoch
+-- (smb2.durable-v2-open.lock-lease asserts lease_epoch==1 on reconnect).
+--
+-- The memory backend round-trips this field via cloneDurableHandle and badger
+-- picks it up automatically via JSON; only the postgres profile needs an
+-- explicit column. Stored as INTEGER (the epoch is a uint16). Pre-existing
+-- rows default to 0, which the reconnect handler treats as "no persisted
+-- epoch" and falls back to the re-granted value.
+
+ALTER TABLE durable_handles
+    ADD COLUMN IF NOT EXISTS lease_epoch INTEGER NOT NULL DEFAULT 0;

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -142,6 +142,7 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 		OplockLevel:        0x09,
 		LeaseKey:           leaseKey,
 		LeaseState:         0x07,
+		LeaseEpoch:         0x2a,
 		CreateGuid:         createGuid,
 		AppInstanceId:      appInstanceId,
 		Username:           "user-" + id,
@@ -199,6 +200,9 @@ func assertDurableHandleEqual(t *testing.T, expected, actual *lock.PersistedDura
 	}
 	if expected.LeaseKey != actual.LeaseKey {
 		t.Errorf("LeaseKey: got %x, want %x", actual.LeaseKey, expected.LeaseKey)
+	}
+	if expected.LeaseEpoch != actual.LeaseEpoch {
+		t.Errorf("LeaseEpoch: got %d, want %d", actual.LeaseEpoch, expected.LeaseEpoch)
 	}
 	if expected.LeaseState != actual.LeaseState {
 		t.Errorf("LeaseState: got %d, want %d", actual.LeaseState, expected.LeaseState)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -197,7 +197,6 @@ still fail due to incomplete reconnect, lease coordination, and persistence.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-v2-open.lock-lease | Durable handles V2 | DH2 lock with lease not fully working | #739 |
 | smb2.durable-v2-open.app-instance | Durable handles V2 | App instance ID not fully working | #739 |
 | smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
 | smb2.durable-v2-open.persistent-open-lease | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
@@ -331,6 +330,20 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-06-01 — #739 lock-lease: 1 row flipped (lease-V2 epoch persistence)
+
+PR #920 persists the live lease-V2 epoch (`OpLock.Lease.Epoch`, the
+protocol-agnostic lock layer) across a durable disconnect — previously it was
+discarded, so reconnect re-registered the lease at epoch 0 and the response
+reported `Epoch=0`, failing the `lease_epoch==1` assertion. The epoch is now a
+durable field on `lock.PersistedDurableHandle` (memory/badger/postgres), and
+the SMB adapter restores it on reconnect and pushes it back via the existing
+`SetLeaseEpoch`. CI smbtorture confirmed `success:` for:
+
+- `smb2.durable-v2-open.lock-lease`
+
+#739 stays open: `app-instance`; persistent-open rows stay deferred.
 
 ### 2026-05-31 — #739 persistent-open: deferred past v1.0 (CA-share infra)
 


### PR DESCRIPTION
## What

Persists the SMB3 lease-V2 **epoch** across a durable-handle reconnect.

The live lease epoch lives in the protocol-agnostic lock layer (`OpLock.Lease.Epoch`). On a durable disconnect it was discarded, so the reconnect re-registered the lease at epoch 0 — the reconnect CREATE response then reported `Epoch=0` and the next break notification leaked a stale `NewEpoch`. smbtorture `smb2.durable-v2-open.lock-lease` asserts `lease_epoch==1` on reconnect.

## How (wire existing, no new lock machinery)

- **Lock layer** (`pkg/metadata/lock/durable_store.go`): new `LeaseEpoch uint16` on `PersistedDurableHandle` — the durable counterpart to the live `OpLock.Lease.Epoch`.
- **Backends**: memory clone, badger JSON (auto), postgres column via migration `000026` (+down). storetest round-trips `LeaseEpoch` so every backend must persist it.
- **SMB adapter only wires it**: captures the epoch from the *existing* `GetLeaseState` return (previously discarded with `_`), threads it through `buildPersistedDurableHandle` → `ReconnectResult.PersistedEpoch`, restores it on reconnect, and pushes it back via the *existing* `SetLeaseEpoch` so later breaks carry the right `NewEpoch`. Mirrors the lease-**state** fallback already in `create.go`.

## Verification

- `GOWORK=off go build ./...` clean; `go vet` clean.
- memory + badger durable-handle conformance, smb handler durable/lease/reconnect tests, lock + lease pkg tests — all pass locally.
- The smbtorture `lock-lease` flip is gated on CI; the KNOWN_FAILURES row will be walked back only after CI confirms `success:`.

Part of #739 (DH2 residuals). `app-instance` (the spurious-break sibling) follows separately.