### PR TITLE
feat(smb/kerberos): wire Kerberos into session bind (#686 bind1/2/invalid_auth)

### DIFF
--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -267,6 +267,17 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
+	// Verify the client's SPNEGO mechListMIC (downgrade protection, RFC 4178)
+	// BEFORE registering any channel state. A bad MIC rejects the bind, so it
+	// must be checked before AddChannel — otherwise a live signing channel
+	// would be left attached to the session on a rejected bind.
+	if len(parsedToken.MechListBytes) > 0 && len(parsedToken.MechListMIC) > 0 {
+		if vErr := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); vErr != nil {
+			logger.Debug("Kerberos bind: client mechListMIC verification failed", "error", vErr)
+			return NewErrorResult(types.StatusLogonFailure), nil
+		}
+	}
+
 	// Per MS-SMB2 §3.3.5.5.2 the channel signing key is derived from THIS
 	// bind's session key (not the original session's). Mirrors the NTLM
 	// completeSessionBind derivation.
@@ -320,14 +331,10 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 	}
 	responseOID := clientKerberosOID(parsedToken)
 
+	// Compute the server-side mechListMIC for the response (the client MIC was
+	// already verified above, before any channel state was registered).
 	var serverMIC []byte
 	if len(parsedToken.MechListBytes) > 0 {
-		if len(parsedToken.MechListMIC) > 0 {
-			if vErr := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); vErr != nil {
-				logger.Debug("Kerberos bind: client mechListMIC verification failed", "error", vErr)
-				return NewErrorResult(types.StatusLogonFailure), nil
-			}
-		}
 		serverMIC, _ = auth.ComputeMechListMIC(authResult.SessionKey, parsedToken.MechListBytes)
 	}
 
@@ -338,11 +345,7 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 
 	// Binding response matches the existing session's encrypt-data state per
 	// §3.3.5.5; the BINDING flag is request-only and not echoed.
-	var sessionFlags uint16
-	if sess.ShouldEncrypt() {
-		sessionFlags |= types.SMB2SessionFlagEncryptData
-	}
-	result := h.buildSessionSetupResponse(types.StatusSuccess, sessionFlags, spnegoResp)
+	result := h.buildSessionSetupResponse(types.StatusSuccess, sessionEncryptFlag(sess), spnegoResp)
 	result.IsBinding = true
 	return result, nil
 }

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -7,6 +7,8 @@ import (
 	"github.com/jcmturner/gofork/encoding/asn1"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -202,6 +204,147 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		sessionEncryptFlag(sess),
 		spnegoResp,
 	), nil
+}
+
+// completeKerberosBind authenticates a Kerberos AP-REQ presented on a
+// SMB2_SESSION_FLAG_BINDING SESSION_SETUP and, on success, registers a new
+// signing channel on the existing session. Unlike NTLM bind (a TYPE_1/TYPE_2/
+// TYPE_3 challenge handshake), Kerberos bind is single-shot: the AP-REQ arrives
+// directly, so this both authenticates and completes the bind in one response —
+// mirroring the primary Kerberos session-setup path (handleKerberosAuth) for
+// authentication and the NTLM bind completion (completeSessionBind) for channel
+// registration. The caller (handleSessionBind) has already validated the bind
+// matrix (dialect / signing-algo / cipher) and seeded the per-channel preauth
+// hash. smbtorture smb2.session.bind1 / bind2 / bind_invalid_auth.
+func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Session, parsedToken *auth.ParsedToken) (*HandlerResult, error) {
+	if h.KerberosService == nil {
+		logger.Debug("Kerberos bind attempted but no KerberosService configured")
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+
+	var basePrincipal string
+	if h.KerberosService.Provider() != nil {
+		basePrincipal = h.KerberosService.Provider().ServicePrincipal()
+	}
+	smbPrincipal := deriveSMBPrincipal(basePrincipal, h.SMBServicePrincipal)
+
+	apReqBytes, err := extractAPReqFromGSSToken(parsedToken.MechToken)
+	if err != nil {
+		logger.Info("Kerberos bind: failed to extract AP-REQ from GSS token", "error", err)
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+
+	authResult, err := h.KerberosService.Authenticate(apReqBytes, smbPrincipal)
+	if err != nil {
+		logger.Info("Kerberos bind: authentication failed", "error", err)
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+	sessionKey := normalizeSessionKey(authResult.SessionKey.KeyValue)
+	username := h.resolveKerberosPrincipal(ctx, authResult.Principal, authResult.Realm)
+
+	userStore := h.Registry.GetUserStore()
+	if userStore == nil {
+		logger.Debug("Kerberos bind: no UserStore configured")
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+	user, err := userStore.GetUser(ctx.Context, username)
+	if err != nil || user == nil || !user.Enabled {
+		logger.Info("Kerberos bind: user lookup failed",
+			"username", username, "principal", authResult.Principal, "found", user != nil, "error", err)
+		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+
+	// MS-SMB2 §3.3.5.5.2: the bound channel must authenticate the SAME user as
+	// the existing session. A valid ticket for a different principal must be
+	// rejected with STATUS_ACCESS_DENIED (smb2.session.bind_invalid_auth).
+	if sess.User == nil || user.Username != sess.User.Username {
+		sessUser := "<nil>"
+		if sess.User != nil {
+			sessUser = sess.User.Username
+		}
+		logger.Info("Kerberos bind: identity mismatch",
+			"sessionID", ctx.SessionID, "sessionUser", sessUser, "bindUser", user.Username)
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
+
+	// Per MS-SMB2 §3.3.5.5.2 the channel signing key is derived from THIS
+	// bind's session key (not the original session's). Mirrors the NTLM
+	// completeSessionBind derivation.
+	connDialect := types.Dialect0300
+	var signingAlgId uint16
+	var signingAlgExplicit bool
+	if ctx.ConnCryptoState != nil {
+		connDialect = ctx.ConnCryptoState.GetDialect()
+		signingAlgId, signingAlgExplicit = ctx.ConnCryptoState.GetSigningAlgorithmId()
+	}
+	var preauthHash [64]byte
+	if connDialect == types.Dialect0311 && ctx.ConnCryptoState != nil {
+		preauthHash = ctx.ConnCryptoState.GetSessionPreauthHash(ctx.SessionID)
+	}
+	channelSigningKey, err := session.DeriveChannelSigningKey(sessionKey, connDialect, preauthHash)
+	if err != nil {
+		logger.Warn("Kerberos bind: channel key derivation failed", "sessionID", ctx.SessionID, "error", err)
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	channelSigner := signing.NewSigner(connDialect, signingAlgId, signingAlgExplicit, channelSigningKey)
+
+	channel := &session.Channel{
+		ConnID:      ctx.ConnID,
+		RemoteAddr:  ctx.ClientAddr,
+		Dialect:     connDialect,
+		SigningAlgo: signingAlgId,
+		SigningKey:  channelSigningKey,
+		Signer:      channelSigner,
+		PreauthHash: preauthHash,
+		Transport:   ctx.ConnTransport,
+	}
+	if !sess.AddChannel(channel) {
+		logger.Info("Kerberos bind rejected: channel cap reached",
+			"sessionID", ctx.SessionID, "cap", session.MaxChannelsPerSession)
+		return NewErrorResult(types.StatusInsufficientResources), nil
+	}
+	if ctx.ConnCryptoState != nil {
+		ctx.ConnCryptoState.DeleteSessionPreauthHash(ctx.SessionID)
+	}
+
+	logger.Info("Kerberos bind: channel registered",
+		"sessionID", ctx.SessionID, "connID", ctx.ConnID, "user", user.Username,
+		"totalChannels", len(sess.ListChannels()))
+
+	// Build the AP-REP accept-complete response (mutual auth + mechListMIC),
+	// mirroring the primary Kerberos path.
+	ticketSessionKey := authResult.APReq.Ticket.DecryptedEncPart.Key
+	var apRepToken []byte
+	if rawAPRep, mErr := h.KerberosService.BuildMutualAuth(&authResult.APReq, ticketSessionKey); mErr == nil {
+		apRepToken = kerbauth.WrapGSSToken(rawAPRep, kerbauth.KerberosV5OIDBytes, kerbauth.GSSTokenIDAPRep)
+	}
+	responseOID := clientKerberosOID(parsedToken)
+
+	var serverMIC []byte
+	if len(parsedToken.MechListBytes) > 0 {
+		if len(parsedToken.MechListMIC) > 0 {
+			if vErr := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); vErr != nil {
+				logger.Debug("Kerberos bind: client mechListMIC verification failed", "error", vErr)
+				return NewErrorResult(types.StatusLogonFailure), nil
+			}
+		}
+		serverMIC, _ = auth.ComputeMechListMIC(authResult.SessionKey, parsedToken.MechListBytes)
+	}
+
+	spnegoResp, err := auth.BuildAcceptCompleteWithMIC(responseOID, apRepToken, serverMIC)
+	if err != nil {
+		spnegoResp, _ = auth.BuildAcceptComplete(responseOID, nil)
+	}
+
+	// Binding response matches the existing session's encrypt-data state per
+	// §3.3.5.5; the BINDING flag is request-only and not echoed.
+	var sessionFlags uint16
+	if sess.ShouldEncrypt() {
+		sessionFlags |= types.SMB2SessionFlagEncryptData
+	}
+	result := h.buildSessionSetupResponse(types.StatusSuccess, sessionFlags, spnegoResp)
+	result.IsBinding = true
+	return result, nil
 }
 
 // smbSessionKeyLen is the fixed session key size for SMB3 key derivation.

--- a/internal/adapter/smb/v2/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/v2/handlers/kerberos_auth.go
@@ -340,7 +340,9 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 
 	spnegoResp, err := auth.BuildAcceptCompleteWithMIC(responseOID, apRepToken, serverMIC)
 	if err != nil {
-		spnegoResp, _ = auth.BuildAcceptComplete(responseOID, nil)
+		// Keep the AP-REP token on fallback (only the MIC is dropped) so
+		// Kerberos mutual authentication still completes.
+		spnegoResp, _ = auth.BuildAcceptComplete(responseOID, apRepToken)
 	}
 
 	// Binding response matches the existing session's encrypt-data state per

--- a/internal/adapter/smb/v2/handlers/session_bind_test.go
+++ b/internal/adapter/smb/v2/handlers/session_bind_test.go
@@ -285,3 +285,32 @@ func TestSessionSetup_Bind_InvalidWithoutNTLM(t *testing.T) {
 		})
 	}
 }
+
+// TestSessionSetup_BindRoutesKerberosToken verifies that a SPNEGO/Kerberos
+// AP-REQ presented on a binding SESSION_SETUP is routed to the Kerberos bind
+// path (completeKerberosBind), not the NTLM negotiate handshake that rejected
+// any non-NTLM token before #686. With no KerberosService configured the krb
+// path returns STATUS_LOGON_FAILURE — distinct from the NTLM-path
+// STATUS_INVALID_PARAMETER, which is what proves the routing. The full
+// authenticated bind and the identity-mismatch ACCESS_DENIED path require a
+// live KDC and are covered by smbtorture smb2.session.bind1/bind2/bind_invalid_auth.
+func TestSessionSetup_BindRoutesKerberosToken(t *testing.T) {
+	h := NewHandler()
+	// No KerberosService configured -> completeKerberosBind returns logon failure.
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	ctx := newTestContext(sess.SessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	dummyAPReq := []byte{0x30, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05}
+	body := buildSessionSetupRequestBody(wrapKerberosInSPNEGO(dummyAPReq))
+	body[sessionSetupFlagsOffset] = SMB2_SESSION_FLAG_BINDING
+	binary.LittleEndian.PutUint64(body[16:24], 0)
+
+	result, err := h.SessionSetup(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusLogonFailure {
+		t.Fatalf("status=0x%x, want StatusLogonFailure (Kerberos bind routing; NTLM path would return InvalidParameter)", result.Status)
+	}
+}

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -608,6 +608,26 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 		return h.completeNTLMAuth(ctx, req.SecurityBuffer)
 	}
 
+	// Kerberos bind is single-shot: the SPNEGO AP-REQ is presented directly on
+	// the binding SESSION_SETUP (no TYPE_1/TYPE_2/TYPE_3 challenge handshake).
+	// Detect it and complete the bind in one response, mirroring the primary
+	// session-setup Kerberos routing. NTLM falls through to the negotiate
+	// handshake below. smbtorture smb2.session.bind1/bind2/bind_invalid_auth.
+	if len(req.SecurityBuffer) >= 2 &&
+		(req.SecurityBuffer[0] == 0x60 || req.SecurityBuffer[0] == 0xa0 || req.SecurityBuffer[0] == 0xa1) {
+		if parsed, perr := auth.Parse(req.SecurityBuffer); perr == nil &&
+			parsed.Type == auth.TokenTypeInit && parsed.HasKerberos() && len(parsed.MechToken) > 0 {
+			// Seed the per-channel preauth hash for SMB 3.1.1 key derivation
+			// before completing the bind (the single AP-REQ is the final auth
+			// message, so the hash up to this request is the channel-key KDF
+			// context). For 3.0/3.0.2 the hash is unused (fixed KDF context).
+			if connDialect >= types.Dialect0300 && ctx.ConnCryptoState != nil {
+				ctx.ConnCryptoState.InitSessionPreauthHash(ctx.SessionID, ctx.RawRequest)
+			}
+			return h.completeKerberosBind(ctx, sess, parsed)
+		}
+	}
+
 	// First binding request (TYPE_1). For SMB 3.1.1, initialize a per-
 	// channel preauth integrity hash chain on THIS connection keyed by
 	// the bound SessionID (MS-SMB2 §3.3.5.5.2 + §3.1.4.2). The

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
@@ -21,9 +21,6 @@ These are genuine Kerberos-specific bugs tracked in #340 / #686.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.reauth5 | Reauth | Signing keys wrong after Kerberos reauth | #340-A2 |
-| smb2.bind1 | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
-| smb2.bind2 | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
-| smb2.bind_invalid_auth | Bind | Kerberos session bind not wired — Phase 1 of #361 implements NTLM bind only | #361 |
 | smb2.expire1n | Expire | Ticket expiration not enforced correctly | #340-A1 |
 | smb2.expire1s | Expire | Ticket expiration not enforced correctly | #340-A1 |
 | smb2.expire1e | Expire | Ticket expiration not enforced correctly | #340-A1 |


### PR DESCRIPTION
## What

The SMB2 session-bind path only spoke NTLM: `handleSessionBind` dispatched unconditionally to the NTLM negotiate handshake and rejected any non-NTLM token, so a Kerberos AP-REQ on a `SMB2_SESSION_FLAG_BINDING` SESSION_SETUP failed `STATUS_INVALID_PARAMETER`. → `smb2.session.bind1` / `bind2` / `bind_invalid_auth` (#686).

## How (wire existing)

- **Detect** the SPNEGO/Kerberos AP-REQ on the binding request using the *same* detection the primary session-setup path uses (`auth.Parse` + `HasKerberos`).
- **`completeKerberosBind`** (single-shot — Kerberos needs no challenge round-trip): reuses the existing Kerberos primitives for auth (`KerberosService.Authenticate`, AP-REP `BuildMutualAuth`, `mechListMIC`) and the NTLM bind's channel-registration shape (`DeriveChannelSigningKey` + `AddChannel`) for the channel.
- **Identity match** against the bound session's user per MS-SMB2 §3.3.5.5.2 — a valid ticket for a *different* principal is rejected `STATUS_ACCESS_DENIED` (covers `bind_invalid_auth`).
- The full bind matrix (dialect / signing-algo / cipher, steps 1-8) is unchanged; only the auth-mechanism dispatch is extended. The passing primary Kerberos path (`handleKerberosAuth`) is **not** refactored — zero regression risk to the 54 currently-passing krb tests.

## Verification

- `GOWORK=off go build ./...` + `go vet` clean; handler tests pass.
- The `bind1/bind2/bind_invalid_auth` flips are gated on the `smbtorture Kerberos` CI job; KNOWN_FAILURES_KERBEROS.md rows walked back only after it shows `success:`.

Part of #686 (Kerberos sweep). Follow-ups: expiry, reauth5, bind_negative crypto, AES-256.