### PR TITLE
fix(api): decode RFC 7807 problem+json in apiclient + operator (revives typed errors)

### DIFF
--- a/cmd/dfsctl/commands/netgroup/delete.go
+++ b/cmd/dfsctl/commands/netgroup/delete.go
@@ -48,9 +48,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		if err := client.DeleteNetgroup(name); err != nil {
 			// Check for conflict (in-use by shares)
 			if apiErr, ok := err.(*apiclient.APIError); ok && apiErr.IsConflict() {
-				msg := fmt.Sprintf("failed to delete netgroup: %s", apiErr.Message)
-				if apiErr.Details != "" {
-					msg += fmt.Sprintf("\n  Shares using this netgroup: %s", strings.TrimSpace(apiErr.Details))
+				msg := fmt.Sprintf("failed to delete netgroup: %s", apiErr.Error())
+				if apiErr.Hint != "" {
+					msg += fmt.Sprintf("\n  Shares using this netgroup: %s", strings.TrimSpace(apiErr.Hint))
 				}
 				return fmt.Errorf("%s", msg)
 			}

--- a/cmd/dfsctl/commands/netgroup/delete.go
+++ b/cmd/dfsctl/commands/netgroup/delete.go
@@ -50,7 +50,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			if apiErr, ok := err.(*apiclient.APIError); ok && apiErr.IsConflict() {
 				msg := fmt.Sprintf("failed to delete netgroup: %s", apiErr.Error())
 				if apiErr.Hint != "" {
-					msg += fmt.Sprintf("\n  Shares using this netgroup: %s", strings.TrimSpace(apiErr.Hint))
+					msg += fmt.Sprintf("\n  Hint: %s", strings.TrimSpace(apiErr.Hint))
 				}
 				return fmt.Errorf("%s", msg)
 			}

--- a/cmd/dfsctl/commands/share/snapshot/fake_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/fake_test.go
@@ -53,7 +53,7 @@ func (f *fakeClient) GetSnapshot(share, id string) (*apiclient.Snapshot, error) 
 	if s, ok := f.snapshots[id]; ok {
 		return s, nil
 	}
-	return nil, &apiclient.APIError{Code: "NOT_FOUND", Message: "snapshot not found", StatusCode: 404}
+	return nil, &apiclient.APIError{Title: "Not Found", Detail: "snapshot not found", StatusCode: 404}
 }
 
 func (f *fakeClient) DeleteSnapshot(share, id string) error {

--- a/cmd/dfsctl/commands/share/snapshot/restore_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/restore_test.go
@@ -123,7 +123,7 @@ func TestRestore_PreconditionFailedHint(t *testing.T) {
 	fc := &fakeClient{
 		share:      &apiclient.Share{Name: "/archive", Enabled: false},
 		snapshots:  map[string]*apiclient.Snapshot{"snap-1": {ID: "snap-1"}},
-		restoreErr: &apiclient.APIError{Code: "PRECONDITION_FAILED", Message: "not durable", StatusCode: 412},
+		restoreErr: &apiclient.APIError{Title: "Precondition Failed", Detail: "not durable", StatusCode: 412},
 	}
 	withFakeClient(t, fc)
 

--- a/cmd/dfsctl/commands/store/block/audit_test.go
+++ b/cmd/dfsctl/commands/store/block/audit_test.go
@@ -33,8 +33,9 @@ func newAuditServer(t *testing.T) *auditServer {
 
 		w.Header().Set("Content-Type", "application/json")
 		if s.status >= 400 {
+			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(s.status)
-			_, _ = io.WriteString(w, `{"code":"NOT_FOUND","message":"share not found"}`)
+			_, _ = io.WriteString(w, `{"type":"about:blank","title":"Not Found","status":404,"detail":"share not found"}`)
 			return
 		}
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/audit/refcounts") {

--- a/cmd/dfsctl/commands/store/block/gc_test.go
+++ b/cmd/dfsctl/commands/store/block/gc_test.go
@@ -38,8 +38,9 @@ func newGCServer(t *testing.T) *gcServer {
 
 		w.Header().Set("Content-Type", "application/json")
 		if s.status >= 400 {
+			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(s.status)
-			body := `{"code":"NOT_FOUND","message":"no GC run recorded"}`
+			body := `{"type":"about:blank","title":"Not Found","status":404,"detail":"no GC run recorded"}`
 			_, _ = io.WriteString(w, body)
 			return
 		}

--- a/k8s/dittofs-operator/internal/controller/adapter_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/adapter_reconciler_test.go
@@ -125,8 +125,9 @@ func TestReconcileAdapters_APIError_PreservesState(t *testing.T) {
 	// Mock DittoFS API returning 500
 	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
 		"GET /api/v1/adapters": func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"code":"INTERNAL","message":"Server error"}`))
+			w.Write([]byte(`{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"Server error"}`))
 		},
 	})
 

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -444,12 +444,15 @@ func isTransientError(err error) bool {
 		}
 	}
 
-	// Check for DittoFS API errors that indicate transient issues
+	// Check for DittoFS API errors that indicate transient issues. 5xx means
+	// the server is reachable but failing transiently, so the reconcile may
+	// succeed on retry; 4xx is a terminal client error.
 	var apiErr *DittoFSAPIError
 	if errors.As(err, &apiErr) {
-		// 502, 503, 504 are transient gateway errors
-		// The API error code won't directly have status codes, but the message might
-		return false // API errors mean the server is reachable, not transient
+		return apiErr.StatusCode == 500 ||
+			apiErr.StatusCode == 502 ||
+			apiErr.StatusCode == 503 ||
+			apiErr.StatusCode == 504
 	}
 
 	return false

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -207,8 +207,10 @@ func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 			w.Write(tokenJSON("operator-token", 900))
 		},
 		"POST /api/v1/users": func(w http.ResponseWriter, req *http.Request) {
+			// Real server emits RFC 7807 problem+json with no legacy "code".
+			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusConflict)
-			w.Write([]byte(`{"code":"CONFLICT","message":"User already exists"}`))
+			w.Write([]byte(`{"type":"about:blank","title":"Conflict","status":409,"detail":"User already exists"}`))
 		},
 	})
 
@@ -310,8 +312,9 @@ func TestRefreshOperatorToken_RefreshFails_ReloginSuccess(t *testing.T) {
 	// Mock DittoFS API: refresh fails, but login succeeds
 	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
 		"POST /api/v1/auth/refresh": func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"code":"UNAUTHORIZED","message":"Invalid refresh token"}`))
+			w.Write([]byte(`{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid refresh token"}`))
 		},
 		"POST /api/v1/auth/login": func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/k8s/dittofs-operator/internal/controller/contract_test.go
+++ b/k8s/dittofs-operator/internal/controller/contract_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// canonicalProblemBodies are the exact RFC 7807 problem+json wire bodies the
+// DittoFS server emits. The operator module cannot import the server's
+// internal/controlplane/api/handlers package (separate go.mod), so the
+// canonical shape is hardcoded here. Source of truth:
+//
+//	internal/controlplane/api/handlers/problem.go
+//	  WriteProblem sets {"type":"about:blank","title":<X>,"status":<N>,"detail":<msg>}
+//	  helpers: Conflict / NotFound / Unauthorized / Forbidden / PreconditionFailed / ...
+//
+// If the server's wire shape drifts, this test must be updated in lockstep —
+// that is the contract this guards.
+var canonicalProblemBodies = map[string]struct {
+	status int
+	body   string
+}{
+	"Conflict": {
+		status: http.StatusConflict,
+		body:   `{"type":"about:blank","title":"Conflict","status":409,"detail":"resource already exists"}`,
+	},
+	"NotFound": {
+		status: http.StatusNotFound,
+		body:   `{"type":"about:blank","title":"Not Found","status":404,"detail":"resource not found"}`,
+	},
+	"Unauthorized": {
+		status: http.StatusUnauthorized,
+		body:   `{"type":"about:blank","title":"Unauthorized","status":401,"detail":"invalid credentials"}`,
+	},
+	"Forbidden": {
+		status: http.StatusForbidden,
+		body:   `{"type":"about:blank","title":"Forbidden","status":403,"detail":"forbidden"}`,
+	},
+}
+
+// TestContract_DittoFSAPIErrorDecodesProblemJSON proves the operator's
+// DittoFSAPIError decodes the real server problem+json shape and that
+// errors.As + the Is* helpers classify correctly on HTTP status. This is the
+// regression guard for the bug where the operator decoded legacy
+// {code,message} and silently dropped every typed error — which made the
+// auth reconciler's conflict-tolerance unreachable.
+func TestContract_DittoFSAPIErrorDecodesProblemJSON(t *testing.T) {
+	for name, tc := range canonicalProblemBodies {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			c := NewDittoFSClient(server.URL)
+			err := c.do(context.Background(), http.MethodGet, "/test", nil, nil)
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", name)
+			}
+
+			var apiErr *DittoFSAPIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("%s: expected *DittoFSAPIError via errors.As, got %T (%v)", name, err, err)
+			}
+			if apiErr.StatusCode != tc.status {
+				t.Errorf("%s: StatusCode = %d, want %d", name, apiErr.StatusCode, tc.status)
+			}
+
+			switch name {
+			case "Conflict":
+				if !apiErr.IsConflict() {
+					t.Errorf("Conflict: IsConflict() = false, want true")
+				}
+			case "NotFound":
+				if !apiErr.IsNotFound() {
+					t.Errorf("NotFound: IsNotFound() = false, want true")
+				}
+			case "Unauthorized", "Forbidden":
+				if !apiErr.IsAuthError() {
+					t.Errorf("%s: IsAuthError() = false, want true", name)
+				}
+			}
+		})
+	}
+}
+
+// TestContract_IsTransientError_5xx proves a 5xx problem+json from the server
+// is classified transient (so the reconciler retries) while a 4xx is
+// terminal. This guards the isTransientError fix that previously returned
+// false unconditionally for every *DittoFSAPIError.
+func TestContract_IsTransientError_5xx(t *testing.T) {
+	cases := []struct {
+		status int
+		want   bool
+	}{
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+		{http.StatusConflict, false},
+		{http.StatusNotFound, false},
+		{http.StatusUnauthorized, false},
+	}
+	for _, tc := range cases {
+		err := &DittoFSAPIError{StatusCode: tc.status, Status: tc.status, Title: "x"}
+		if got := isTransientError(err); got != tc.want {
+			t.Errorf("isTransientError(status=%d) = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}

--- a/k8s/dittofs-operator/internal/controller/dittofs_client.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client.go
@@ -90,7 +90,7 @@ func (c *DittoFSClient) do(ctx context.Context, method, path string, body, resul
 	if resp.StatusCode >= 400 {
 		var apiErr DittoFSAPIError
 		if json.Unmarshal(respBody, &apiErr) == nil &&
-			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "") {
+			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "" || apiErr.Detail != "") {
 			apiErr.StatusCode = resp.StatusCode
 			return &apiErr
 		}

--- a/k8s/dittofs-operator/internal/controller/dittofs_client.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client.go
@@ -89,10 +89,14 @@ func (c *DittoFSClient) do(ctx context.Context, method, path string, body, resul
 
 	if resp.StatusCode >= 400 {
 		var apiErr DittoFSAPIError
-		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Message != "" {
+		if json.Unmarshal(respBody, &apiErr) == nil &&
+			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "") {
+			apiErr.StatusCode = resp.StatusCode
 			return &apiErr
 		}
-		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respBody))
+		// Non-JSON or empty body: still return a typed error so callers can
+		// classify on the HTTP status. Never lose the type via fmt.Errorf.
+		return &DittoFSAPIError{StatusCode: resp.StatusCode, Detail: string(respBody)}
 	}
 
 	if result != nil && len(respBody) > 0 {
@@ -104,34 +108,48 @@ func (c *DittoFSClient) do(ctx context.Context, method, path string, body, resul
 	return nil
 }
 
-// DittoFSAPIError represents an error response from the DittoFS API.
+// DittoFSAPIError represents an RFC 7807 problem+json error response from the
+// DittoFS API. The server emits {"type","title","status","detail"} (and
+// optionally "code"/"hint"); StatusCode carries the HTTP status and is
+// authoritative for classification. The operator cannot import
+// pkg/apiclient (separate go.mod), so this mirrors the canonical wire shape
+// defined in internal/controlplane/api/handlers/problem.go.
 type DittoFSAPIError struct {
-	Code    string `json:"code,omitempty"`
-	Message string `json:"message"`
-	Details string `json:"details,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Status int    `json:"status,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	Code   string `json:"code,omitempty"`
+	Hint   string `json:"hint,omitempty"`
+
+	// StatusCode is the HTTP status code, authoritative for classification.
+	StatusCode int `json:"-"`
 }
 
 // Error implements the error interface.
 func (e *DittoFSAPIError) Error() string {
-	if e.Code != "" {
-		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	if e.Detail != "" {
+		return e.Detail
 	}
-	return e.Message
+	if e.Title != "" {
+		return e.Title
+	}
+	return fmt.Sprintf("request failed with status %d", e.StatusCode)
 }
 
 // IsConflict returns true if this is a conflict error (e.g., user already exists).
 func (e *DittoFSAPIError) IsConflict() bool {
-	return e.Code == "CONFLICT"
+	return e.StatusCode == 409
 }
 
 // IsAuthError returns true if this is an authentication/authorization error.
 func (e *DittoFSAPIError) IsAuthError() bool {
-	return e.Code == "UNAUTHORIZED" || e.Code == "FORBIDDEN"
+	return e.StatusCode == 401 || e.StatusCode == 403
 }
 
 // IsNotFound returns true if this is a not-found error.
 func (e *DittoFSAPIError) IsNotFound() bool {
-	return e.Code == "NOT_FOUND"
+	return e.StatusCode == 404
 }
 
 // LoginRequest represents a login request to the DittoFS API.

--- a/pkg/apiclient/auth_test.go
+++ b/pkg/apiclient/auth_test.go
@@ -45,10 +45,13 @@ func TestLogin(t *testing.T) {
 
 func TestLogin_InvalidCredentials(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusUnauthorized)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "UNAUTHORIZED",
-			Message: "Invalid username or password",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Unauthorized",
+			"status": http.StatusUnauthorized,
+			"detail": "Invalid username or password",
 		})
 	}))
 	defer server.Close()
@@ -61,7 +64,7 @@ func TestLogin_InvalidCredentials(t *testing.T) {
 
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
-	assert.Equal(t, "UNAUTHORIZED", apiErr.Code)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
 	assert.True(t, apiErr.IsAuthError())
 }
 
@@ -97,10 +100,13 @@ func TestRefreshToken(t *testing.T) {
 
 func TestRefreshToken_Expired(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusUnauthorized)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "TOKEN_EXPIRED",
-			Message: "Refresh token has expired",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Unauthorized",
+			"status": http.StatusUnauthorized,
+			"detail": "Refresh token has expired",
 		})
 	}))
 	defer server.Close()
@@ -113,7 +119,8 @@ func TestRefreshToken_Expired(t *testing.T) {
 
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
-	assert.Equal(t, "TOKEN_EXPIRED", apiErr.Code)
+	assert.True(t, apiErr.IsAuthError())
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
 }
 
 func TestLogout(t *testing.T) {

--- a/pkg/apiclient/blockstore_gc_test.go
+++ b/pkg/apiclient/blockstore_gc_test.go
@@ -111,11 +111,13 @@ func TestBlockStoreGCStatus_RoundTrip(t *testing.T) {
 // the "no run yet" state without string matching.
 func TestBlockStoreGCStatus_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "NOT_FOUND",
-			Message: "no GC run recorded for share myshare",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Not Found",
+			"status": http.StatusNotFound,
+			"detail": "no GC run recorded for share myshare",
 		})
 	}))
 	defer server.Close()

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -125,11 +125,12 @@ func (c *Client) doVia(ctx context.Context, hc *http.Client, method, path string
 
 	if resp.StatusCode >= 400 {
 		var apiErr APIError
-		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Message != "" {
+		if json.Unmarshal(respBody, &apiErr) == nil &&
+			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "") {
 			apiErr.StatusCode = resp.StatusCode
 			return &apiErr
 		}
-		return &APIError{StatusCode: resp.StatusCode, Message: string(respBody)}
+		return &APIError{StatusCode: resp.StatusCode, Detail: string(respBody)}
 	}
 
 	if result != nil && len(respBody) > 0 {

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -126,7 +126,7 @@ func (c *Client) doVia(ctx context.Context, hc *http.Client, method, path string
 	if resp.StatusCode >= 400 {
 		var apiErr APIError
 		if json.Unmarshal(respBody, &apiErr) == nil &&
-			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "") {
+			(apiErr.Title != "" || apiErr.Status != 0 || apiErr.Code != "" || apiErr.Detail != "") {
 			apiErr.StatusCode = resp.StatusCode
 			return &apiErr
 		}

--- a/pkg/apiclient/client_test.go
+++ b/pkg/apiclient/client_test.go
@@ -69,10 +69,13 @@ func TestDoWithAuthHeader(t *testing.T) {
 
 func TestDoWithAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusUnauthorized)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "UNAUTHORIZED",
-			Message: "Invalid credentials",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Unauthorized",
+			"status": http.StatusUnauthorized,
+			"detail": "Invalid credentials",
 		})
 	}))
 	defer server.Close()
@@ -83,8 +86,8 @@ func TestDoWithAPIError(t *testing.T) {
 
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
-	assert.Equal(t, "UNAUTHORIZED", apiErr.Code)
-	assert.Equal(t, "Invalid credentials", apiErr.Message)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.Equal(t, "Invalid credentials", apiErr.Detail)
 	assert.True(t, apiErr.IsAuthError())
 }
 

--- a/pkg/apiclient/contract_test.go
+++ b/pkg/apiclient/contract_test.go
@@ -83,3 +83,26 @@ func TestContract_DecodesRealServerProblemJSON(t *testing.T) {
 		})
 	}
 }
+
+// TestContract_DetailOnlyBodyIsParsed guards the accept-gate edge case: an error
+// body carrying only "detail" (no title/status) must still be decoded into the
+// typed *APIError with Detail parsed — NOT routed to the raw-body fallback,
+// which would surface the JSON blob verbatim via Error().
+func TestContract_DetailOnlyBodyIsParsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"user is locked"}`))
+	}))
+	defer server.Close()
+
+	err := New(server.URL).get("/test", nil)
+	require.Error(t, err)
+
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+	assert.Equal(t, "user is locked", apiErr.Detail, "detail-only body must be parsed, not left as raw JSON")
+	assert.Equal(t, "user is locked", apiErr.Error(), "Error() must not return the raw JSON blob")
+	assert.True(t, apiErr.IsAuthError(), "403 must classify as auth error")
+}

--- a/pkg/apiclient/contract_test.go
+++ b/pkg/apiclient/contract_test.go
@@ -1,0 +1,85 @@
+package apiclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/internal/controlplane/api/handlers"
+)
+
+// TestContract_DecodesRealServerProblemJSON proves the apiclient decodes the
+// canonical RFC 7807 problem+json shape the server actually emits. The
+// httptest handler calls the SAME helpers the production handlers use
+// (handlers.Conflict / NotFound / Unauthorized / PreconditionFailed), so a
+// drift between the wire shape and APIError's tags fails here. This is the
+// regression guard for the bug where the client decoded legacy
+// {code,message} and silently swallowed every typed error.
+func TestContract_DecodesRealServerProblemJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		emit   func(w http.ResponseWriter, detail string)
+		detail string
+		status int
+		check  func(t *testing.T, e *APIError)
+	}{
+		{
+			name:   "Conflict",
+			emit:   handlers.Conflict,
+			detail: "resource already exists",
+			status: http.StatusConflict,
+			check: func(t *testing.T, e *APIError) {
+				assert.True(t, e.IsConflict(), "IsConflict() must be true for 409")
+			},
+		},
+		{
+			name:   "NotFound",
+			emit:   handlers.NotFound,
+			detail: "resource not found",
+			status: http.StatusNotFound,
+			check: func(t *testing.T, e *APIError) {
+				assert.True(t, e.IsNotFound(), "IsNotFound() must be true for 404")
+			},
+		},
+		{
+			name:   "Unauthorized",
+			emit:   handlers.Unauthorized,
+			detail: "invalid credentials",
+			status: http.StatusUnauthorized,
+			check: func(t *testing.T, e *APIError) {
+				assert.True(t, e.IsAuthError(), "IsAuthError() must be true for 401")
+			},
+		},
+		{
+			name:   "PreconditionFailed",
+			emit:   handlers.PreconditionFailed,
+			detail: "snapshot is not remotely durable",
+			status: http.StatusPreconditionFailed,
+			check: func(t *testing.T, e *APIError) {
+				assert.Equal(t, http.StatusPreconditionFailed, e.StatusCode)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				tc.emit(w, tc.detail)
+			}))
+			defer server.Close()
+
+			client := New(server.URL)
+			err := client.get("/test", nil)
+			require.Error(t, err)
+
+			apiErr, ok := err.(*APIError)
+			require.True(t, ok, "expected *APIError, got %T (%v)", err, err)
+			assert.Equal(t, tc.status, apiErr.StatusCode, "StatusCode must match HTTP status")
+			assert.Equal(t, tc.detail, apiErr.Detail, "Detail must round-trip from problem+json")
+			tc.check(t, apiErr)
+		})
+	}
+}

--- a/pkg/apiclient/errors.go
+++ b/pkg/apiclient/errors.go
@@ -4,38 +4,49 @@ import (
 	"fmt"
 )
 
-// APIError represents an error response from the API.
+// APIError represents an RFC 7807 problem+json error response from the API.
+// The server emits {"type","title","status","detail"} (and optionally
+// "code"/"hint"); StatusCode carries the HTTP status and is authoritative
+// for classification.
 type APIError struct {
-	Code       string `json:"code,omitempty"`
-	Message    string `json:"message"`
-	Details    string `json:"details,omitempty"`
-	StatusCode int    `json:"-"`
+	Type   string `json:"type,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Status int    `json:"status,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	Code   string `json:"code,omitempty"`
+	Hint   string `json:"hint,omitempty"`
+
+	// StatusCode is the HTTP status code, authoritative for classification.
+	StatusCode int `json:"-"`
 }
 
 // Error implements the error interface.
 func (e *APIError) Error() string {
-	if e.Code != "" {
-		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	if e.Detail != "" {
+		return e.Detail
 	}
-	return e.Message
+	if e.Title != "" {
+		return e.Title
+	}
+	return fmt.Sprintf("request failed with status %d", e.StatusCode)
 }
 
-// IsAuthError returns true if this is an authentication error.
+// IsAuthError returns true if this is an authentication/authorization error.
 func (e *APIError) IsAuthError() bool {
-	return e.Code == "UNAUTHORIZED" || e.Code == "FORBIDDEN"
+	return e.StatusCode == 401 || e.StatusCode == 403
 }
 
 // IsNotFound returns true if this is a not found error.
 func (e *APIError) IsNotFound() bool {
-	return e.Code == "NOT_FOUND" || e.StatusCode == 404
+	return e.StatusCode == 404
 }
 
 // IsConflict returns true if this is a conflict error.
 func (e *APIError) IsConflict() bool {
-	return e.Code == "CONFLICT"
+	return e.StatusCode == 409
 }
 
 // IsValidationError returns true if this is a validation error.
 func (e *APIError) IsValidationError() bool {
-	return e.Code == "VALIDATION_ERROR"
+	return e.StatusCode == 400 || e.StatusCode == 422
 }

--- a/pkg/apiclient/snapshots_test.go
+++ b/pkg/apiclient/snapshots_test.go
@@ -129,7 +129,12 @@ func TestGetSnapshot_NotFound(t *testing.T) {
 
 	s.reset()
 	s.status = http.StatusNotFound
-	s.body, _ = json.Marshal(APIError{Code: "NOT_FOUND", Message: "snapshot not found"})
+	s.body, _ = json.Marshal(map[string]any{
+		"type":   "about:blank",
+		"title":  "Not Found",
+		"status": http.StatusNotFound,
+		"detail": "snapshot not found",
+	})
 
 	c := newTestClient(s)
 	snap, err := c.GetSnapshot("/archive", "missing")
@@ -163,7 +168,12 @@ func TestDeleteSnapshot_NotFound(t *testing.T) {
 
 	s.reset()
 	s.status = http.StatusNotFound
-	s.body, _ = json.Marshal(APIError{Code: "NOT_FOUND", Message: "snapshot not found"})
+	s.body, _ = json.Marshal(map[string]any{
+		"type":   "about:blank",
+		"title":  "Not Found",
+		"status": http.StatusNotFound,
+		"detail": "snapshot not found",
+	})
 
 	c := newTestClient(s)
 	err := c.DeleteSnapshot("/archive", "missing")
@@ -242,7 +252,12 @@ func TestRestoreSnapshot_PreconditionFailed(t *testing.T) {
 
 	s.reset()
 	s.status = http.StatusPreconditionFailed
-	s.body, _ = json.Marshal(APIError{Code: "PRECONDITION_FAILED", Message: "snapshot is not remotely durable"})
+	s.body, _ = json.Marshal(map[string]any{
+		"type":   "about:blank",
+		"title":  "Precondition Failed",
+		"status": http.StatusPreconditionFailed,
+		"detail": "snapshot is not remotely durable",
+	})
 
 	c := newTestClient(s)
 	resp, err := c.RestoreSnapshot("/archive", "snap-x", RestoreSnapshotRequest{})

--- a/pkg/apiclient/users_test.go
+++ b/pkg/apiclient/users_test.go
@@ -60,10 +60,13 @@ func TestGetUser(t *testing.T) {
 
 func TestGetUser_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "NOT_FOUND",
-			Message: "User not found",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Not Found",
+			"status": http.StatusNotFound,
+			"detail": "User not found",
 		})
 	}))
 	defer server.Close()
@@ -76,7 +79,7 @@ func TestGetUser_NotFound(t *testing.T) {
 
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
-	assert.Equal(t, "NOT_FOUND", apiErr.Code)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
 	assert.True(t, apiErr.IsNotFound())
 }
 
@@ -119,10 +122,13 @@ func TestCreateUser(t *testing.T) {
 
 func TestCreateUser_Duplicate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusConflict)
-		_ = json.NewEncoder(w).Encode(APIError{
-			Code:    "CONFLICT",
-			Message: "User already exists",
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":   "about:blank",
+			"title":  "Conflict",
+			"status": http.StatusConflict,
+			"detail": "User already exists",
 		})
 	}))
 	defer server.Close()
@@ -138,7 +144,8 @@ func TestCreateUser_Duplicate(t *testing.T) {
 
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
-	assert.Equal(t, "CONFLICT", apiErr.Code)
+	assert.True(t, apiErr.IsConflict())
+	assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
 }
 
 func TestUpdateUser(t *testing.T) {


### PR DESCRIPTION
The server emits RFC 7807 `application/problem+json` (`{type,title,status,detail}`, never `code`/`message`), but both independent clients decoded legacy `{code,message,details}`. The accept-gate never matched, so every typed error was swallowed and `IsConflict/IsAuthError/IsNotFound` were dead. Consequences:

- **operator reconcile never converged** — `provisionOperatorAccount`'s 409-conflict tolerance was unreachable (user-already-exists looked like a hard failure)
- **dfsctl printed raw JSON blobs** instead of friendly messages
- **5xx misclassified as terminal** — `isTransientError` returned false for every API error, so transient gateway failures never retried

## Fix
- Rekeyed both `APIError` (`pkg/apiclient`) and `DittoFSAPIError` (operator, separate go.mod) to the RFC 7807 wire shape; classification now keys on the authoritative HTTP `StatusCode`.
- Both decoders always stamp `StatusCode` for `>=400`, accept a problem body when `title`/`status`/`code` is present, and fall back to a typed error carrying the raw body (operator no longer loses the type via `fmt.Errorf`).
- `isTransientError` now returns true for 500/502/503/504.
- Fixed the `netgroup delete` caller (`.Message`/`.Details` -> `.Error()`/`.Hint`).

## Tests
- Added a **contract test in each module** proving the client decodes the *real* server shape: the main test drives the actual `internal/controlplane/api/handlers` helpers (`Conflict`/`NotFound`/`Unauthorized`/`PreconditionFailed`); the operator test pins the canonical problem+json wire bodies (it cannot import internal/) and round-trips through `errors.As` + `Is*()`.
- Replaced all fabricated `{code,message}` mocks with real problem+json and switched assertions from `.Code==` to `Is*()`/`StatusCode`. The operator conflict mock now emits a real 409 and asserts provisioning succeeds.

Closes the round-2 cross-area RFC 7807 drift (operator H1 + CLI H1 + config-API). Both modules build, test, vet, and `gofmt -s` clean.