### PR TITLE
test(smb-conformance): reset share state between smbtorture sub-suites (#568)

### DIFF
--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -137,15 +137,12 @@ create_block_stores() {
 # Canonical list of WPTS/smbtorture shares. The smbtorture runner (run.sh)
 # resets these between sub-suites via `reset-share`, so the create flags must
 # live in exactly one place. Keep this in sync with create_shares() below.
-SHARE_NAMES=(
-    /smbbasic
-    /smbencrypted
-    /fileshare
-    /hideunread
-    /change_notify_disabled
-    /smbnoncanon
-    /create_no_streams
-)
+#
+# NOTE: bootstrap.sh is invoked as `sh /app/bootstrap.sh` inside the container
+# (run.sh / smbtorture/run.sh), so it must stay POSIX-sh-compatible — no bash
+# arrays. Share names contain no whitespace, so a space-separated list with
+# unquoted word-splitting (`for name in $SHARE_NAMES`) is safe.
+SHARE_NAMES="/smbbasic /smbencrypted /fileshare /hideunread /change_notify_disabled /smbnoncanon /create_no_streams"
 
 # share_create_args NAME — echo the per-share `dfsctl share create` flags
 # (without the common --metadata/--local/--remote flags, which the caller
@@ -201,8 +198,8 @@ create_one_share() {
 # create_shares — create every WPTS/smbtorture share from the canonical map.
 create_shares() {
     log_info "Creating WPTS shares..."
-    local name
-    for name in "${SHARE_NAMES[@]}"; do
+    # POSIX word-splitting over the space-separated SHARE_NAMES (no bash arrays).
+    for name in $SHARE_NAMES; do
         create_one_share "$name"
     done
 }

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -10,6 +10,13 @@
 # Usage:
 #   PROFILE=memory ./bootstrap.sh
 #   DFSCTL=/app/dfsctl API_URL=http://localhost:8080 ./bootstrap.sh
+#
+#   # Reset a single share to clean state (delete + recreate). Used by the
+#   # smbtorture runner between sub-suites to clear cross-test state leak
+#   # (leftover restrictive DACLs, non-empty dirs, dangling opens + leases).
+#   # Refs #568.
+#   DFSCTL=/app/dfsctl API_URL=http://localhost:8080 \
+#     ADMIN_PASSWORD=... ./bootstrap.sh reset-share /smbbasic
 
 set -euo pipefail
 
@@ -127,6 +134,103 @@ create_block_stores() {
     esac
 }
 
+# Canonical list of WPTS/smbtorture shares. The smbtorture runner (run.sh)
+# resets these between sub-suites via `reset-share`, so the create flags must
+# live in exactly one place. Keep this in sync with create_shares() below.
+SHARE_NAMES=(
+    /smbbasic
+    /smbencrypted
+    /fileshare
+    /hideunread
+    /change_notify_disabled
+    /smbnoncanon
+    /create_no_streams
+)
+
+# share_create_args NAME — echo the per-share `dfsctl share create` flags
+# (without the common --metadata/--local/--remote flags, which the caller
+# appends). This is the single source of truth for share configuration,
+# shared by initial bootstrap and by reset-share.
+share_create_args() {
+    case "$1" in
+        # /smbbasic uses Windows-default ACL canonicalization (MS-DTYP
+        # §2.5.3.4.2): AUTO_INHERITED is persisted only when SET_INFO Security
+        # also carries AUTO_INHERIT_REQ. Required by smb2.acls.INHERITFLAGS and
+        # smb2.acls.SDFLAGSVSCHOWN.
+        /smbbasic) echo "--name /smbbasic" ;;
+        /smbencrypted) echo "--name /smbencrypted --encrypt-data" ;;
+        /fileshare) echo "--name /fileshare" ;;
+        # Refs #532: smbtorture smb2.acls.ACCESSBASED connects to a share with
+        # the MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
+        # QUERY_DIRECTORY hides entries the caller cannot read.
+        /hideunread) echo "--name /hideunread --access-based-enumeration" ;;
+        # /change_notify_disabled rejects SMB2 CHANGE_NOTIFY with
+        # STATUS_NOT_IMPLEMENTED. Target of smb2.change_notify_disabled.
+        /change_notify_disabled) echo "--name /change_notify_disabled --change-notify-disabled" ;;
+        # /smbnoncanon disables MS-DTYP §2.5.3.4.2 canonicalization (Samba
+        # `acl flag inherited canonicalization = no` extension). Target of
+        # smb2.acls_non_canonical.flags.
+        /smbnoncanon) echo "--name /smbnoncanon --acl-canonicalize-inherited=false" ;;
+        # /create_no_streams rejects SMB2 Alternate Data Stream opens with
+        # STATUS_OBJECT_NAME_INVALID (Samba `smbd:streams = no` semantics).
+        /create_no_streams) echo "--name /create_no_streams --streams-disabled" ;;
+        *)
+            log_error "Unknown share: $1"
+            return 1
+            ;;
+    esac
+}
+
+# common_share_flags — the --metadata/--local[/--remote] flags shared by every
+# share, derived from the active profile.
+common_share_flags() {
+    local flags="--metadata default --local default"
+    if [[ "$PROFILE" == *-s3 ]]; then
+        flags="$flags --remote default"
+    fi
+    echo "$flags"
+}
+
+# create_one_share NAME — create a single share from the canonical map,
+# appending the profile-derived common flags.
+create_one_share() {
+    # shellcheck disable=SC2046,SC2086  # word-splitting of flag strings is intended
+    $DFSCTL share create $(share_create_args "$1") $(common_share_flags)
+}
+
+# create_shares — create every WPTS/smbtorture share from the canonical map.
+create_shares() {
+    log_info "Creating WPTS shares..."
+    local name
+    for name in "${SHARE_NAMES[@]}"; do
+        create_one_share "$name"
+    done
+}
+
+# reset_share NAME — delete and recreate a single share, returning it to clean
+# state (no files, no dirs, no leftover DACLs, no dangling opens or leases).
+# Used by run.sh between smbtorture sub-suites. Refs #568.
+#
+# Delete+recreate is the most thorough reset available: it runs as an admin
+# REST op (bypassing any restrictive SMB DACLs a failed ACL test left behind)
+# and tears down the share's metadata root + block store, which drops every
+# server-side open and lease record bound to it. It does NOT touch users,
+# identity mappings, or the SMB adapter config.
+reset_share() {
+    local name="$1"
+    wait_for_ready
+    # main() rotates the admin password to TEST_PASSWORD on first login, so by
+    # the time the runner calls reset-share the original ADMIN_PASSWORD is dead.
+    # Log in with TEST_PASSWORD here (the post-bootstrap admin password).
+    log_info "Logging in as admin..."
+    $DFSCTL login --server "$API_URL" --username admin --password "$TEST_PASSWORD"
+
+    log_info "Resetting share ${name} (delete + recreate)..."
+    $DFSCTL share delete "$name" --force
+    create_one_share "$name"
+    log_info "Share ${name} reset to clean state"
+}
+
 # Main bootstrap flow
 main() {
     log_info "Starting DittoFS bootstrap (profile: ${PROFILE})"
@@ -149,42 +253,10 @@ main() {
     create_metadata_store
     create_block_stores
 
-    # Create WPTS-required shares
-    # FileShare is the default share name WPTS tests use for TREE_CONNECT
-    log_info "Creating WPTS shares..."
-    local share_flags="--metadata default --local default"
-    if [[ "$PROFILE" == *-s3 ]]; then
-        share_flags="$share_flags --remote default"
-    fi
-    # /smbbasic uses Windows-default ACL canonicalization (MS-DTYP §2.5.3.4.2):
-    # AUTO_INHERITED is persisted only when SET_INFO Security also carries
-    # AUTO_INHERIT_REQ. Required by smb2.acls.INHERITFLAGS and
-    # smb2.acls.SDFLAGSVSCHOWN. The Samba extension
-    # `acl flag inherited canonicalization = no` is exercised by
-    # smb2.acls_non_canonical against /smbnoncanon below.
-    $DFSCTL share create --name /smbbasic $share_flags
-    $DFSCTL share create --name /smbencrypted --encrypt-data $share_flags
-    $DFSCTL share create --name /fileshare $share_flags
-    # Refs #532: smbtorture smb2.acls.ACCESSBASED connects to a share with the
-    # MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM flag set so
-    # QUERY_DIRECTORY hides entries the caller cannot read.
-    $DFSCTL share create --name /hideunread --access-based-enumeration $share_flags
-    # /change_notify_disabled rejects SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED.
-    # Target of smb2.change_notify_disabled.notfiy_disabled which verifies the
-    # server signals "unsupported" rather than silently accepting notifies on a
-    # share where change notify is administratively disabled.
-    $DFSCTL share create --name /change_notify_disabled --change-notify-disabled $share_flags
-    # /smbnoncanon disables MS-DTYP §2.5.3.4.2 canonicalization (Samba
-    # `acl flag inherited canonicalization = no` extension). Target of
-    # smb2.acls_non_canonical.flags; verifies AUTO_INHERITED round-trips
-    # verbatim through SET_INFO Security without the AUTO_INHERIT_REQ gate.
-    $DFSCTL share create --name /smbnoncanon --acl-canonicalize-inherited=false $share_flags
-    # /create_no_streams rejects SMB2 Alternate Data Stream opens with
-    # STATUS_OBJECT_NAME_INVALID. Target of
-    # smb2.create_no_streams.no_stream which verifies the server rejects
-    # named ADS, ::$DATA, and arbitrary stream-type suffixes on a share
-    # configured with the Samba `smbd:streams = no` semantics.
-    $DFSCTL share create --name /create_no_streams --streams-disabled $share_flags
+    # Create WPTS-required shares from the canonical share map (single source
+    # of truth in share_create_args, reused by reset-share). FileShare is the
+    # default share name WPTS tests use for TREE_CONNECT.
+    create_shares
 
     # Create test users with DISTINCT UIDs. Without --uid each user falls back
     # to defaultUID=1000 in internal/adapter/smb/v2/handlers/auth_helper.go,
@@ -228,4 +300,21 @@ main() {
     log_info "Bootstrap complete: shares=smbbasic,smbencrypted,fileshare,hideunread,change_notify_disabled,smbnoncanon,create_no_streams users=wpts-admin,nonadmin adapter=smb:${SMB_PORT}"
 }
 
-main "$@"
+# Subcommand dispatch. Default (no args) runs the full bootstrap; `reset-share
+# <name>` resets a single share between smbtorture sub-suites (refs #568).
+case "${1:-}" in
+    reset-share)
+        if [[ -z "${2:-}" ]]; then
+            log_error "reset-share requires a share name"
+            exit 1
+        fi
+        reset_share "$2"
+        ;;
+    "")
+        main
+        ;;
+    *)
+        log_error "Unknown command: $1"
+        exit 1
+        ;;
+esac

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -408,6 +408,36 @@ run_smbtorture() {
     return $rc
 }
 
+# reset_share SHARE
+# Returns a share to clean state between sub-suites by delegating to
+# bootstrap.sh's reset-share subcommand inside the DittoFS container, which
+# deletes and recreates the share via the admin REST API. Refs #568.
+#
+# smbtorture sub-suites run sequentially against the same shares; a suite that
+# fails mid-test (notably the ACL suites) can leave restrictive DACLs on files,
+# non-empty directories, and dangling opens/lease records. The next suite then
+# sees that leftover state and a previously-passing test fails — a rotating,
+# scheduling-dependent spurious "new failure". Delete+recreate clears file/dir
+# state AND drops server-side opens + lease records bound to the share, without
+# disturbing users, identity mappings, or the SMB adapter config.
+#
+# bootstrap.sh rotates the admin password to TEST_PASSWORD on first login, so
+# reset-share authenticates with TEST_PASSWORD (not the original log-scraped
+# admin_password). Failures are logged but non-fatal: a reset hiccup must not
+# abort the run — at worst it reintroduces the flake for one suite rather than
+# corrupting results.
+reset_share() {
+    local share="$1"
+    if ! docker compose exec \
+        -e DFSCTL="/app/dfsctl" \
+        -e API_URL="http://localhost:8080" \
+        -e TEST_PASSWORD="TestPassword01!" \
+        -e PROFILE="${PROFILE}" \
+        dittofs sh /app/bootstrap.sh reset-share "/${share}" >/dev/null 2>&1; then
+        log_warn "  Share reset failed for /${share}; continuing"
+    fi
+}
+
 _smbtorture_exit=0
 
 if [[ -n "$FILTER" ]]; then
@@ -432,6 +462,10 @@ else
         smb2.sdread smb2.secleak smb2.session-id smb2.tcon smb2.mkdir
     )
     for test in "${STANDALONE_TESTS[@]}"; do
+        # Reset the default share before each suite so leftover state from a
+        # prior failed suite (restrictive DACLs, non-empty dirs, dangling
+        # opens/leases) can't fail a previously-passing test. Refs #568.
+        reset_share "$SMBTORTURE_DEFAULT_SHARE"
         log_info "  Running: ${test}"
         run_smbtorture "$test" 60 || _smbtorture_exit=$?
     done
@@ -516,6 +550,11 @@ else
     for entry in "${SUITES[@]}"; do
         # Split "suite:prefix" or "suite:prefix:share" using IFS=:.
         IFS=':' read -r suite prefix share <<< "$entry"
+        # Reset the share this suite targets before running it, so leftover
+        # state from a prior failed suite can't fail a previously-passing test.
+        # Refs #568. Multiple dirlease sub-suites share /smbbasic, so this also
+        # isolates them from one another.
+        reset_share "${share:-$SMBTORTURE_DEFAULT_SHARE}"
         if [[ -n "${share:-}" ]]; then
             log_info "  Running: ${suite} (share: ${share})"
         else


### PR DESCRIPTION
## Root cause (#568)

smbtorture sub-suites run **sequentially against the same shares** in `test/smb-conformance/smbtorture/run.sh` (the `STANDALONE_TESTS` loop + the `SUITES` loop, each calling `run_smbtorture` against `${SMBTORTURE_HOST}/${share}`, almost always `smbbasic`).

When an ACL suite fails mid-test it leaves leftover share state behind: restrictive DACLs on files, non-empty directories, dangling opens, in-flight lease records. The **next** suite (e.g. `lease.*`, `create.*`) sees that leftover state and a previously-passing test fails. Different runner scheduling picks a different victim each run, producing the rotating spurious *"new failure not in KNOWN_FAILURES"* reported in #568. PR #547 fixed the *within-test* deltree but added **no cross-suite teardown**.

## Fix — between-suite share reset

`bootstrap.sh` gains a `reset-share <name>` subcommand that **deletes and recreates a single share** via the admin REST API (`dfsctl share delete --force` + `share create`). `run.sh` calls a thin `reset_share` helper (which delegates to that subcommand inside the DittoFS container) **before every standalone test and every sub-suite**, targeting the exact share that suite uses (`SMBTORTURE_DEFAULT_SHARE`, or the per-suite override for `smbnoncanon` / `change_notify_disabled` / `create_no_streams`).

### Why delete + recreate (vs an SMB-level deltree)

Delete+recreate is the **most thorough reset available** and clears *all* of the leaked state, not just the on-disk files:

- It runs **admin-side over REST**, so it bypasses any restrictive SMB DACLs a failed ACL test left on files (an `smbclient deltree` could be blocked by those very DACLs).
- `RemoveShare` tears down the share's **metadata root + per-share block store**, so every **server-side open and lease record** bound to the share is dropped — state an SMB-level deltree fundamentally cannot clear.
- It does **not** touch users, identity mappings, or the SMB adapter config — only the file/dir/open/lease state for that one share. Users/idmaps/adapter are created once at bootstrap and left intact.

### Residual state it does *not* clear

This reset is scoped to the share being recreated. It does **not** reset:
- **Cross-share state** — but no suite leaks into a different share than the one it (and the next suite) targets, so this is not a source of the flake.
- **Adapter-global session state** (signing keys, channel binding). Each sub-suite already runs as a fresh `docker compose run --rm` smbtorture process = a fresh SMB connection/session, so session teardown on process exit already clears per-session opens/leases; the share reset additionally clears anything that outlived the session (e.g. durable handles).

If a future suite is found to leak into a share other than its own target, the canonical `SHARE_NAMES` list in `bootstrap.sh` makes a full multi-share reset a one-line change.

## Single source of truth

Share-create flags were consolidated into `share_create_args` + `create_one_share` so the initial bootstrap and the reset path can never drift. The generated `dfsctl share create` commands are **byte-equivalent** to the previous inline creates (verified with a stubbed `dfsctl`, including the `*-s3` `--remote default` branch).

## Verification

- `bash -n` + `shellcheck` clean on the changed code (pre-existing `run.sh` warnings untouched).
- Stubbed-`dfsctl` smoke test confirms generated commands match the prior inline creates for `smbbasic`, `smbnoncanon`, and the s3 profile.
- The flake is **intermittent**; the real confirmation is **multi-run CI** — this should be re-run several times to confirm the rotating "new failure" no longer appears.


