### PR TITLE
fix(windows): de-flake notify + blockstore log-file tests on Windows runner (#714, #697)

### DIFF
--- a/internal/adapter/smb/v2/handlers/change_notify.go
+++ b/internal/adapter/smb/v2/handlers/change_notify.go
@@ -279,6 +279,15 @@ type NotifyRegistry struct {
 	// (smb2.notify.mask). MarkInterimSent fires the deferred response after
 	// writing interim and clears this map entry. Keyed by (ConnID, MessageID).
 	pendingInterim map[notifyMsgKey]*PendingNotify
+
+	// flushDelay is the per-registry accumulation window for buffered events.
+	// Defaults to notifyFlushDelay (100µs) in production. Tests that drive
+	// delivery synchronously via FlushAll set this to a large value so the
+	// background time.AfterFunc timer never fires before FlushAll stops it —
+	// otherwise the two delivery paths race on slow/contended schedulers
+	// (the Windows CI runner in particular), letting a callback run on the
+	// timer goroutine with no happens-before edge to the test's assertion.
+	flushDelay time.Duration
 }
 
 // cancelTombstoneTTL bounds how long a pre-arrival SMB2_CANCEL is remembered
@@ -336,6 +345,7 @@ func NewNotifyRegistry() *NotifyRegistry {
 		armed:            make(map[string]*armedHandle),
 		cancelTombstones: make(map[notifyMsgKey]time.Time),
 		pendingInterim:   make(map[notifyMsgKey]*PendingNotify),
+		flushDelay:       notifyFlushDelay,
 	}
 }
 
@@ -1157,7 +1167,7 @@ func (r *NotifyRegistry) bufferEventLocked(notify *PendingNotify, change FileNot
 	notify.bufferedChanges = append(notify.bufferedChanges, change)
 	if notify.flushTimer == nil {
 		fileID := notify.FileID
-		notify.flushTimer = time.AfterFunc(notifyFlushDelay, func() {
+		notify.flushTimer = time.AfterFunc(r.flushDelay, func() {
 			r.flushWatcher(fileID)
 		})
 	}

--- a/internal/adapter/smb/v2/handlers/change_notify_test.go
+++ b/internal/adapter/smb/v2/handlers/change_notify_test.go
@@ -19,8 +19,24 @@ func mustRegister(t *testing.T, r *NotifyRegistry, n *PendingNotify) {
 	}
 }
 
+// newTestNotifyRegistry builds a NotifyRegistry whose background flush timer
+// is effectively disabled (flushDelay set far past any test's runtime). These
+// tests deliver buffered events synchronously and deterministically via
+// FlushAll; with the production 100µs timer left armed, the time.AfterFunc
+// goroutine could fire BEFORE FlushAll stops it, delivering the callback on
+// the timer goroutine with no happens-before edge to the test's assertion.
+// On a fast machine FlushAll always wins, so the race is invisible; on the
+// contended Windows CI runner the timer wins often enough to flake (#714,
+// TestNotifyChange_ExactPath). Pushing flushDelay out of reach makes FlushAll
+// the sole, synchronous delivery path on every platform.
+func newTestNotifyRegistry() *NotifyRegistry {
+	reg := NewNotifyRegistry()
+	reg.flushDelay = time.Hour
+	return reg
+}
+
 func TestNotifyRegistry_RegisterAndUnregister(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{1, 2, 3}
 	notify := &PendingNotify{
@@ -69,7 +85,7 @@ func TestNotifyRegistry_RegisterAndUnregister(t *testing.T) {
 // — no final response, CANCEL couldn't find the entry, connection
 // eventually dropped. After the fix, (ConnID, MessageID) is the key.
 func TestNotifyRegistry_Register_CrossConnectionMessageIDNoEvict(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	a := &PendingNotify{
 		FileID:           [16]byte{0xA},
@@ -108,7 +124,7 @@ func TestNotifyRegistry_Register_CrossConnectionMessageIDNoEvict(t *testing.T) {
 // so two pending notifies sharing a MessageID across two TCP connections
 // can each be cancelled independently.
 func TestNotifyRegistry_UnregisterByMessageID_DisambiguatesByConnID(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	a := &PendingNotify{
 		FileID:           [16]byte{0xA},
@@ -144,7 +160,7 @@ func TestNotifyRegistry_UnregisterByMessageID_DisambiguatesByConnID(t *testing.T
 }
 
 func TestNotifyRegistry_UnregisterByMessageID(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notify := &PendingNotify{
 		FileID:           [16]byte{1},
@@ -175,7 +191,7 @@ func TestNotifyRegistry_UnregisterByMessageID(t *testing.T) {
 }
 
 func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notify := &PendingNotify{
 		FileID:           [16]byte{2},
@@ -205,7 +221,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 }
 
 func TestNotifyRegistry_ReplaceExisting(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{5}
 
@@ -248,7 +264,7 @@ func TestNotifyRegistry_ReplaceExisting(t *testing.T) {
 }
 
 func TestNotifyRegistry_MultipleWatchers(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	mustRegister(t, r, &PendingNotify{
 		FileID:           [16]byte{1},
@@ -274,7 +290,7 @@ func TestNotifyRegistry_MultipleWatchers(t *testing.T) {
 }
 
 func TestNotifyChange_ExactPath(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -308,7 +324,7 @@ func TestNotifyChange_ExactPath(t *testing.T) {
 }
 
 func TestNotifyChange_NoMatchDifferentShare(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -336,7 +352,7 @@ func TestNotifyChange_NoMatchDifferentShare(t *testing.T) {
 }
 
 func TestNotifyChange_RecursiveWatchTree(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -365,7 +381,7 @@ func TestNotifyChange_RecursiveWatchTree(t *testing.T) {
 }
 
 func TestNotifyChange_NonRecursiveNoMatch(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -394,7 +410,7 @@ func TestNotifyChange_NonRecursiveNoMatch(t *testing.T) {
 }
 
 func TestNotifyRename_PairedNotification(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -431,7 +447,7 @@ func TestNotifyRename_PairedNotification(t *testing.T) {
 }
 
 func TestNotifyRename_CrossDirectory(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	notified := false
 	mustRegister(t, r, &PendingNotify{
@@ -463,7 +479,7 @@ func TestNotifyRename_CrossDirectory(t *testing.T) {
 }
 
 func TestNotifyChange_MaxOutputLengthExceeded_SendsEnumDir(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var receivedStatus types.Status
 	mustRegister(t, r, &PendingNotify{
@@ -497,7 +513,7 @@ func TestNotifyChange_MaxOutputLengthExceeded_SendsEnumDir(t *testing.T) {
 }
 
 func TestNotifyChange_ConcurrentDoubleFire(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var callbackCount atomic.Int32
 	mustRegister(t, r, &PendingNotify{
@@ -537,7 +553,7 @@ func TestNotifyChange_ConcurrentDoubleFire(t *testing.T) {
 }
 
 func TestNotifyRegistry_MaxWatchesLimit(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	// Fill up to the limit
 	for i := 0; i < MaxPendingWatches; i++ {
@@ -689,7 +705,7 @@ func TestRelativePathFromWatch_CrossPath(t *testing.T) {
 }
 
 func TestNotifyChange_StreamNameOnADSCreate(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var notified bool
 	mustRegister(t, r, &PendingNotify{
@@ -717,7 +733,7 @@ func TestNotifyChange_StreamNameOnADSCreate(t *testing.T) {
 }
 
 func TestNotifyChange_StreamWriteOnADSWrite(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var notified bool
 	mustRegister(t, r, &PendingNotify{
@@ -745,7 +761,7 @@ func TestNotifyChange_StreamWriteOnADSWrite(t *testing.T) {
 }
 
 func TestNotifyChange_StreamSizeOnADSWrite(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var notified bool
 	mustRegister(t, r, &PendingNotify{
@@ -773,7 +789,7 @@ func TestNotifyChange_StreamSizeOnADSWrite(t *testing.T) {
 }
 
 func TestNotifyChange_SecurityDescriptorChange(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var notified bool
 	mustRegister(t, r, &PendingNotify{
@@ -828,7 +844,7 @@ func TestMatchesFilter_StreamFilters(t *testing.T) {
 }
 
 func TestNotifyChange_DoubleWatchers_BothNotified(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var count1, count2 atomic.Int32
 	mustRegister(t, r, &PendingNotify{
@@ -929,7 +945,7 @@ func TestIsValidCompletionFilter(t *testing.T) {
 }
 
 func TestNotifyRmdir_SendsCleanupToWatchersOnRemovedDir(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var receivedStatus types.Status
 	mustRegister(t, r, &PendingNotify{
@@ -958,7 +974,7 @@ func TestNotifyRmdir_SendsCleanupToWatchersOnRemovedDir(t *testing.T) {
 }
 
 func TestNotifyRmdir_NotifiesParentWatcher(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var parentNotified bool
 	mustRegister(t, r, &PendingNotify{
@@ -985,7 +1001,7 @@ func TestNotifyRmdir_NotifiesParentWatcher(t *testing.T) {
 }
 
 func TestUnregisterAllForSession(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	mustRegister(t, r, &PendingNotify{
 		FileID:           [16]byte{1},
@@ -1143,7 +1159,7 @@ func TestIsValidCompletionFilter_AllBits(t *testing.T) {
 func TestNotifyChange_OverflowWithMultipleChanges(t *testing.T) {
 	// Verify that when we manually build a notification that would exceed
 	// MaxOutputLength, the registry sends STATUS_NOTIFY_ENUM_DIR.
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var receivedStatus types.Status
 	mustRegister(t, r, &PendingNotify{
@@ -1174,7 +1190,7 @@ func TestNotifyChange_OverflowWithMultipleChanges(t *testing.T) {
 func TestUnregisterAllForSession_PreservesOtherSessions(t *testing.T) {
 	// Verify that UnregisterAllForSession does NOT affect other sessions.
 	// This is critical for session reconnect/re-auth scenarios.
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	// Session 100: two watches
 	mustRegister(t, r, &PendingNotify{
@@ -1223,7 +1239,7 @@ func TestUnregisterAllForSession_PreservesOtherSessions(t *testing.T) {
 // NOTIFY_ENUM_DIR, all do" sticky property is enforced one layer up at the
 // handler via OpenFile.NotifyMaxBufferSize, not by the registry.
 func TestSendAndUnregister_UndersizedBufferYieldsEnumDir(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var deliveredStatus types.Status
 	fileID := [16]byte{0xAA}
@@ -1256,7 +1272,7 @@ func TestSendAndUnregister_UndersizedBufferYieldsEnumDir(t *testing.T) {
 // so the caller can fire STATUS_NOTIFY_CLEANUP per MS-SMB2 3.3.5.5.2
 // (smb2.notify.invalid-reauth / session-reconnect / .tcon / .dir).
 func TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	var calledWithStatus types.Status
 	mustRegister(t, r, &PendingNotify{
@@ -1299,7 +1315,7 @@ func TestUnregisterAllForSession_ReturnedNotifiesPreserveAsyncCallback(t *testin
 // so events accumulated in the gap were never counted and the handle's
 // sticky overflow was never set.
 func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{0xCC}
 	var overflowFireCount int32
@@ -1368,7 +1384,7 @@ func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
 // the next batch of events accumulates against the freshly advertised
 // MaxOutputLength rather than re-tripping immediately.
 func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{0xDD}
 	var overflowFireCount int32
@@ -1423,7 +1439,7 @@ func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
 // on unrelated shares/paths/filters must not charge against an armed
 // handle. Guards against false-positive overflows on unrelated buckets.
 func TestArmedBuffer_ScopedByShareAndPath(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{0xEE}
 	var overflowFireCount int32
@@ -1473,7 +1489,7 @@ func TestArmedBuffer_ScopedByShareAndPath(t *testing.T) {
 // delivers the event, so the armed accounting must skip handles that just
 // fired (the armed entry will be torn down/replaced on the next Register).
 func TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{0xEF}
 	var overflowFireCount int32
@@ -1513,7 +1529,7 @@ func TestArmedBuffer_NotChargedWhenLiveWatcherServesEvent(t *testing.T) {
 // systematically undercounted recursive watchers and let overflow latch
 // later than a real marshal (or Samba notify_marshall_changes) would.
 func TestArmedBuffer_RecursiveWatcherChargesRelativePath(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	fileID := [16]byte{0xF0}
 	var overflowFireCount int32
@@ -1670,7 +1686,7 @@ func TestReleaseSessionLeasesAndNotifies_FiresCleanupSynchronously(t *testing.T)
 }
 
 func TestUnregisterAllForTree_PreservesOtherTrees(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	// Same session and share, different tree IDs (two tree connects to same share)
 	mustRegister(t, r, &PendingNotify{
@@ -2048,7 +2064,7 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 // tombstone and returns ErrAlreadyCancelled so the handler can answer
 // STATUS_CANCELLED synchronously.
 func TestNotifyRegistry_PreArrivalCancel_TombstoneShortCircuitsRegister(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 
 	const connID, messageID uint64 = 7, 42
 
@@ -2089,7 +2105,7 @@ func TestNotifyRegistry_PreArrivalCancel_TombstoneShortCircuitsRegister(t *testi
 // future CHANGE_NOTIFY with a different MessageID (or different ConnID).
 // Without this guard, the tombstone would be a global blocker.
 func TestNotifyRegistry_CancelTombstoneNoCrossMessageIDLeak(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 	r.MarkPendingCancel(1, 10)
 
 	otherMsg := &PendingNotify{
@@ -2116,7 +2132,7 @@ func TestNotifyRegistry_CancelTombstoneNoCrossMessageIDLeak(t *testing.T) {
 // (ConnID, MessageID). This uses the public surface — direct map-poking
 // would couple the test to the internal layout.
 func TestNotifyRegistry_CancelTombstoneExpires(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 	r.MarkPendingCancel(1, 99)
 
 	// Manually age the tombstone by rewriting it past the TTL. Going through
@@ -2192,7 +2208,7 @@ func TestChangeNotify_PreArrivalCancel_HandlerReturnsCancelledSync(t *testing.T)
 func TestNotifyRegistry_ConcurrentCancelBeforeRegister(t *testing.T) {
 	const iters = 200
 	for i := 0; i < iters; i++ {
-		r := NewNotifyRegistry()
+		r := newTestNotifyRegistry()
 		connID := uint64(i)
 		messageID := uint64(i*2 + 1)
 		fileID := [16]byte{byte(i), byte(i >> 8)}
@@ -2228,7 +2244,7 @@ func TestNotifyRegistry_ConcurrentCancelBeforeRegister(t *testing.T) {
 // re-registered yet. The event must buffer on the armed handle and be
 // replayed on the next Register so the client doesn't miss it.
 func TestArmedBuffer_ReplayDeliversBufferedEventsOnReregister(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 	fileID := [16]byte{0xAA, 0xBB}
 
 	// First Register — arms the handle — then UnregisterByAsyncId to leave
@@ -2291,7 +2307,7 @@ func TestArmedBuffer_ReplayDeliversBufferedEventsOnReregister(t *testing.T) {
 // handle must be discarded so a subsequent register does not replay stale
 // state into a fresh request with a different filter.
 func TestArmedBuffer_CancelClearsBufferedEvents(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 	fileID := [16]byte{0xCD}
 
 	first := &PendingNotify{
@@ -2347,7 +2363,7 @@ func TestArmedBuffer_CancelClearsBufferedEvents(t *testing.T) {
 // buffered events on the armed handle are dropped — the client has been
 // told to re-enumerate, so the stale buffer must not replay.
 func TestArmedBuffer_OverflowClearsBufferedEvents(t *testing.T) {
-	r := NewNotifyRegistry()
+	r := newTestNotifyRegistry()
 	fileID := [16]byte{0xEE}
 
 	first := &PendingNotify{

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -544,7 +545,7 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 			}
 		}
 		if lf.path != "" {
-			if rerr := os.Remove(lf.path); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			if rerr := removeLogFile(lf.path); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
 				// FIX-25: do NOT include the absolute on-disk path in
 				// the error returned to the caller — protocol error
 				// responses (NFS/SMB) propagate this string and would
@@ -580,6 +581,45 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	// in-memory FSStore is left consistent regardless of whether the
 	// on-disk file was successfully removed.
 	return stepFourErr
+}
+
+// removeLogFile unlinks path, tolerating Windows' delayed handle release.
+//
+// On POSIX a file can be unlinked while a handle is still open and Close()
+// synchronously releases the descriptor, so a single os.Remove always
+// succeeds (or fails for a real reason). Windows is different on both counts:
+// it refuses to delete a file that has ANY open handle, and the kernel may
+// not have fully released a handle by the time Close() returns. The result
+// is a transient ERROR_SHARING_VIOLATION ("The process cannot access the
+// file because it is being used by another process") on the os.Remove that
+// immediately follows the log fd's Close() — even though no goroutine is
+// logically using the file anymore. This surfaced as a Windows-CI-only flake
+// in the AppendWrite/DeleteAppendLog delete race (#714) and would equally
+// break real unlink-after-write workflows on a Windows host.
+//
+// On Windows we retry with a short backoff so the unlink lands once the
+// kernel drains the closed handle; on POSIX the first os.Remove is
+// authoritative and the loop never iterates. The retry budget is small and
+// bounded — a handle the OS will never release indicates a genuine error
+// (another live handle, EACCES, EROFS), which we surface after the last
+// attempt for the caller to log and for recovery's boot-time orphan sweep
+// to reconcile.
+func removeLogFile(path string) error {
+	err := os.Remove(path)
+	if runtime.GOOS != "windows" || err == nil || errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Windows-only: back off and retry the unlink while the closed handle
+	// drains. Total worst-case wait ~500ms (10 × 50ms) — long enough for the
+	// kernel's lazy release, short enough not to stall a delete-heavy caller.
+	for i := 0; i < 10; i++ {
+		time.Sleep(50 * time.Millisecond)
+		err = os.Remove(path)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return err
 }
 
 // TruncateAppendLog records a truncation boundary for payloadID.

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -599,14 +600,18 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 //
 // On Windows we retry with a short backoff so the unlink lands once the
 // kernel drains the closed handle; on POSIX the first os.Remove is
-// authoritative and the loop never iterates. The retry budget is small and
-// bounded — a handle the OS will never release indicates a genuine error
-// (another live handle, EACCES, EROFS), which we surface after the last
-// attempt for the caller to log and for recovery's boot-time orphan sweep
-// to reconcile.
+// authoritative and the loop never iterates. The retry is gated on a
+// transient ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33) — a
+// genuine non-transient error (EACCES, EROFS, invalid path) is surfaced
+// immediately rather than stalling the delete path for ~500ms first. After
+// the bounded retry budget a still-held handle is returned for the caller to
+// log and for recovery's boot-time orphan sweep to reconcile.
 func removeLogFile(path string) error {
 	err := os.Remove(path)
 	if runtime.GOOS != "windows" || err == nil || errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if !isTransientUnlinkError(err) {
 		return err
 	}
 	// Windows-only: back off and retry the unlink while the closed handle
@@ -618,8 +623,27 @@ func removeLogFile(path string) error {
 		if err == nil || errors.Is(err, os.ErrNotExist) {
 			return err
 		}
+		if !isTransientUnlinkError(err) {
+			return err
+		}
 	}
 	return err
+}
+
+// isTransientUnlinkError reports whether err is a Windows
+// ERROR_SHARING_VIOLATION (32) or ERROR_LOCK_VIOLATION (33) — the transient
+// "file in use" condition a just-closed handle produces before the kernel
+// drains it. On non-Windows it is always false so the same numeric errnos on
+// Unix are never misread.
+func isTransientUnlinkError(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == 32 || errno == 33
+	}
+	return false
 }
 
 // TruncateAppendLog records a truncation boundary for payloadID.

--- a/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
+++ b/pkg/blockstore/local/fs/rollup_logindex_regression_test.go
@@ -146,28 +146,33 @@ func TestRollup_StalledFence_ChunksStillCommitted(t *testing.T) {
 		}
 	}
 
-	// Wait long enough for the later regions to stabilize and roll
-	// up. The head region keeps getting refreshed during this loop
-	// (via the refresh writes above already issued); after the refresh
-	// loop completes, wait one stabilization window for the later
-	// regions.
-	time.Sleep(200 * time.Millisecond)
-
-	if n := countChunksInBlocks(t, bc.baseDir); n < 3 {
-		t.Fatalf("expected ≥3 chunks for later regions while head stalls, got %d", n)
+	// Wait for the later regions to stabilize and roll up. The three
+	// non-overlapping regions each clear the 50 ms stabilization window
+	// and produce at least one chunk. POLL for the chunk count rather
+	// than sleeping a fixed interval and asserting once: the rollup pool
+	// is driven by a wall-clock ticker plus fsync, and Windows fsync is
+	// markedly slower than POSIX, so a fixed 200 ms sleep raced the
+	// chunk commit on the Windows CI runner (#697). Polling to a generous
+	// deadline keeps the test fast on POSIX while removing the timing
+	// dependency that made it Windows-only flaky.
+	deadline := time.Now().Add(8 * time.Second)
+	var chunks int
+	for time.Now().Before(deadline) {
+		chunks = countChunksInBlocks(t, bc.baseDir)
+		if chunks >= 3 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if chunks < 3 {
+		t.Fatalf("expected ≥3 chunks for later regions while head stalls, got %d", chunks)
 	}
 
-	// Now stop refreshing head and let it stabilize too. Then the
-	// full file should roll up and rollup_offset advance to (or past)
-	// the end of all records we appended.
-	time.Sleep(300 * time.Millisecond)
-	off, err := rs.GetRollupOffset(ctx, "file-stall")
-	if err != nil {
-		t.Fatalf("GetRollupOffset: %v", err)
-	}
-	if off <= uint64(logHeaderSize) {
-		t.Fatalf("rollup_offset did not advance after head stabilization: got %d", off)
-	}
+	// Now stop refreshing head and let it stabilize too. Then the full
+	// file should roll up and rollup_offset advance past the log header.
+	// waitForRollup polls for that advance (same rationale as the chunk
+	// poll above — no fixed sleep) and fails the test if it never lands.
+	waitForRollup(t, rs, "file-stall", 8*time.Second)
 }
 
 // TestRollup_R7_OverwriteReclaimsHeadBytes is the R-7 (#580) acceptance


### PR DESCRIPTION
Fixes three Windows-CI-only flaky tests (#714 and #697). All three pass on macOS/Linux and develop; they reproduce only on the Windows runner, so **Windows CI is the verification** for these fixes. Root causes all sit in the `pkg/blockstore/local/fs` + `internal/adapter/smb/v2/handlers` area, kept in one branch to avoid conflicts.

## #714 — `TestNotifyChange_ExactPath` (smb notify)

**Root cause:** buffered CHANGE_NOTIFY delivery has two paths — a background `time.AfterFunc(100µs)` timer (`bufferEventLocked`) and the synchronous `FlushAll` the tests drive. On a fast machine `FlushAll` always stops the timer before it fires; on the contended Windows runner the timer goroutine can win, running the callback off-goroutine with **no happens-before edge** to the test's plain-`bool` assertion (a genuine data race reading stale `false`).

**Fix:** make the flush window a per-registry field `flushDelay` (default `notifyFlushDelay` = 100µs in `NewNotifyRegistry`, production unchanged). Notify tests construct the registry via a `newTestNotifyRegistry()` helper that pushes `flushDelay` out of reach, so `FlushAll` is the sole synchronous delivery path on every platform. No production behaviour change.

## #714 — `TestAppendWrite_DeleteRace_NoDeadlock` (blockstore fs)

**Root cause (real production bug, not test-only):** `DeleteAppendLog` step 4 closes the log fd then immediately `os.Remove`s the file. POSIX releases the descriptor synchronously on `Close()`, but Windows both refuses to delete a file with any open handle *and* may not have fully released a just-closed handle — so the unlink hits a transient `ERROR_SHARING_VIOLATION` ("the process cannot access the file because it is being used by another process"). This is the exact Windows error in the issue, and it would equally break real unlink-after-write workflows on a Windows host.

**Fix:** route the unlink through a new `removeLogFile` helper that retries with a short bounded backoff (~500ms worst case) on Windows only, so the delete lands once the kernel drains the closed handle. POSIX takes the first-`os.Remove` path with zero added cost.

## #697 — `TestRollup_StalledFence_ChunksStillCommitted` (blockstore fs)

**Root cause:** the test slept a fixed 200ms then asserted ≥3 chunks, and slept another fixed 300ms then asserted `rollup_offset` advanced. The rollup pool is driven by a wall-clock ticker plus fsync; Windows fsync is markedly slower than POSIX, so the fixed sleeps raced the chunk commit and the test flaked Windows-only.

**Fix:** replace both fixed sleeps with poll-until-condition loops against a generous deadline (reusing the existing `waitForRollup` helper for the offset wait). Fast on POSIX, deterministic on Windows, no timing dependency.

## Verification

- `GOWORK=off go test -race ./pkg/blockstore/local/fs/ ./internal/adapter/smb/v2/handlers/` — green (multiple `-count` repetitions)
- `gofmt`, `go vet`, `golangci-lint` — clean
- No `t.Skip` added — all three are fixed at the source per the fix-flaky-tests policy.
- Windows CI on this PR is the platform-specific verification.