### PR TITLE
ci(nix): automate vendorHash updates via GitHub Action

### DIFF
--- a/.github/workflows/nix-update-hash.yml
+++ b/.github/workflows/nix-update-hash.yml
@@ -1,0 +1,52 @@
+name: nix-update-hash
+
+on:
+  push:
+    paths:
+      - go.mod
+      - go.sum
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-hash:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Update nix vendorHash
+        run: go run scripts/update-nix-hash.go
+
+      - name: Check for changes
+        id: git-check
+        run: git diff --exit-code flake.nix || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit -m "chore(nix): update vendorHash for go deps"
+          git push

--- a/scripts/update-nix-hash.go
+++ b/scripts/update-nix-hash.go
@@ -1,0 +1,127 @@
+// Command update-nix-hash automatically updates the vendorHash in flake.nix
+// after Go dependencies have changed.
+//
+// Usage (from the repo root):
+//
+//	go run scripts/update-nix-hash.go
+//
+// It is also run automatically by .github/workflows/nix-update-hash.yml
+// whenever go.mod or go.sum change.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+const (
+	flakeFile = "flake.nix"
+	fakeHash  = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+)
+
+func main() {
+	log.SetFlags(0)
+
+	// Check if flake.nix exists
+	if _, err := os.Stat(flakeFile); err != nil {
+		log.Fatalf("Error: %s not found. Run this from the project root.", flakeFile)
+	}
+
+	// Read the current flake.nix
+	content, err := os.ReadFile(flakeFile)
+	if err != nil {
+		log.Fatalf("Error reading %s: %v", flakeFile, err)
+	}
+
+	// Find current vendorHash
+	hashRe := regexp.MustCompile(`vendorHash = "(sha256-[A-Za-z0-9+/=]+)";`)
+	matches := hashRe.FindSubmatch(content)
+	if matches == nil {
+		log.Fatalf("Error: Could not find vendorHash in %s", flakeFile)
+	}
+	currentHash := string(matches[1])
+
+	log.Printf("Current vendorHash: %s", currentHash)
+	log.Println("Updating vendorHash in flake.nix...")
+
+	// Replace with fake hash to trigger a Nix mismatch error
+	updatedContent := hashRe.ReplaceAll(content, fmt.Appendf(nil, `vendorHash = "%s";`, fakeHash))
+
+	// Write temporary flake.nix
+	if err := os.WriteFile(flakeFile, updatedContent, 0644); err != nil {
+		log.Fatalf("Error writing %s: %v", flakeFile, err)
+	}
+
+	// Run nix build to get the correct hash (expected to fail)
+	log.Println("Running nix build to determine correct hash...")
+	cmd := exec.Command("nix", "build", ".#default")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	_ = cmd.Run()
+
+	// Extract the correct hash from stderr
+	output := stderr.String()
+	correctHash := extractHash(output)
+
+	if correctHash == "" {
+		// Restore original content
+		if err := os.WriteFile(flakeFile, content, 0644); err != nil {
+			log.Printf("Warning: Failed to restore original flake.nix: %v", err)
+		}
+		log.Fatalf("Error: Could not extract hash from nix build output.\n%s", output)
+	}
+
+	log.Printf("Extracted hash: %s", correctHash)
+
+	// If hash hasn't changed, we're done
+	if correctHash == currentHash {
+		// Restore original
+		if err := os.WriteFile(flakeFile, content, 0644); err != nil {
+			log.Fatalf("Error restoring %s: %v", flakeFile, err)
+		}
+		log.Println("✓ vendorHash is already up to date")
+		return
+	}
+
+	// Update with correct hash (reuse the regex so only the vendorHash line is touched)
+	finalContent := hashRe.ReplaceAll(content, fmt.Appendf(nil, `vendorHash = "%s";`, correctHash))
+	if err := os.WriteFile(flakeFile, finalContent, 0644); err != nil {
+		log.Fatalf("Error writing %s: %v", flakeFile, err)
+	}
+
+	log.Printf("Updated vendorHash: %s -> %s", currentHash, correctHash)
+
+	// Verify build works with the new hash
+	log.Println("Verifying build with new hash...")
+	cmd = exec.Command("nix", "build", ".#default")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("Error: Build failed with new hash: %v", err)
+	}
+
+	log.Println("✓ Build successful with new hash")
+}
+
+// extractHash parses the nix build error output to find the correct hash.
+func extractHash(output string) string {
+	// Look for "got:    sha256-..."
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "got:") {
+			// Extract the hash after "got:"
+			parts := strings.Fields(line)
+			if len(parts) >= 2 && strings.HasPrefix(parts[1], "sha256-") {
+				return parts[1]
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #161.

## What
- `scripts/update-nix-hash.go` — forces a `nix build` hash mismatch, parses the correct `vendorHash` from the `got:` line, writes it back, and re-verifies the build. Stdlib-only.
- `.github/workflows/nix-update-hash.yml` — runs the script on `go.mod`/`go.sum` pushes (+ `workflow_dispatch`) and commits `chore(nix): update vendorHash` if it changed.
- `flake.nix` — replaced the manual-update comment with a pointer to the automation, and **refreshed the stale `vendorHash`** (`sha256-IbW…` → `sha256-GlGT…`) so `nix build` works on develop again.

## Why
Manual blank-build-copy-paste loop was easy to forget, breaking `nix build` for everyone pulling latest. Pattern from datum-cloud/datumctl (per the issue).

## Notes
- No trigger loop: workflow commits only `flake.nix`; trigger filters on `go.mod`/`go.sum`.
- `concurrency` group serializes runs; `timeout-minutes: 30` caps a hung build.
- develop is unprotected → direct push works; flake covers `x86_64-linux` so the ubuntu runner can build.

## Verify
Ran `go run scripts/update-nix-hash.go` locally: update path rewrote+verified the hash, no-op path exits clean. `gofmt`/`vet`/`build` green.