### PR TITLE
fix(nix): refresh stale vendorHash dropped from #928

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,8 +381,9 @@
               inherit version;
               src = ./.;
 
-              # To update: set to "", run `nix build`, copy hash from error
-              vendorHash = "sha256-IbW/a0aI3/qnTT44eX3mIAnLfQmyFcHs3cebiBHrQ38=";
+              # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
+              # Manual: go run scripts/update-nix-hash.go
+              vendorHash = "sha256-GlGTkoYjjie3hh6ViJ7oMLery1Lv+dBXxnbjmqKLXPg=";
 
               ldflags = [
                 "-s"


### PR DESCRIPTION
Follow-up to #928. The flake.nix portion of that PR (vendorHash refresh + automation comment) was unstaged at commit time and never landed, so develop still carries the stale `sha256-IbW…` hash and `nix build` is broken.

This applies both:
- `vendorHash` → `sha256-GlGTkoYjjie3hh6ViJ7oMLery1Lv+dBXxnbjmqKLXPg=` (derived + build-verified via `scripts/update-nix-hash.go` against current develop go.mod/go.sum)
- comment now points at `.github/workflows/nix-update-hash.yml` instead of the manual loop

The auto-update workflow couldn't self-heal this (it only triggers on go.mod/go.sum changes).