### PR TITLE
feat(gc): report objects scanned in GC stats + dfsctl output (#189)

### DIFF
--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -82,6 +82,7 @@ func printGCStatsTable(res *apiclient.BlockStoreGCResult, dryRun bool) error {
 	pairs := [][2]string{
 		{"Run ID", s.RunID},
 		{"Hashes Marked", fmt.Sprintf("%d", s.HashesMarked)},
+		{"Objects Found", fmt.Sprintf("%d", s.ObjectsScanned)},
 		{"Objects Swept", fmt.Sprintf("%d", s.ObjectsSwept)},
 		{"Bytes Freed", formatBytes(s.BytesFreed)},
 		{"Duration", fmt.Sprintf("%dms", s.DurationMs)},

--- a/cmd/dfsctl/commands/store/block/gc_status.go
+++ b/cmd/dfsctl/commands/store/block/gc_status.go
@@ -75,6 +75,7 @@ func runBlockStoreGCStatus(cmd *cobra.Command, args []string) error {
 			{"Completed At", summary.CompletedAt.Format("2006-01-02T15:04:05Z07:00")},
 			{"Duration", fmt.Sprintf("%dms", summary.DurationMs)},
 			{"Hashes Marked", fmt.Sprintf("%d", summary.HashesMarked)},
+			{"Objects Found", fmt.Sprintf("%d", summary.ObjectsScanned)},
 			{"Objects Swept", fmt.Sprintf("%d", summary.ObjectsSwept)},
 			{"Bytes Freed", formatBytes(summary.BytesFreed)},
 			{"Errors", fmt.Sprintf("%d", summary.ErrorCount)},

--- a/cmd/dfsctl/commands/store/block/gc_test.go
+++ b/cmd/dfsctl/commands/store/block/gc_test.go
@@ -104,11 +104,12 @@ func TestGCCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 	s := newGCServer(t)
 	defer s.Close()
 	s.gcStats = &engine.GCStats{
-		RunID:        "run-1",
-		HashesMarked: 11,
-		ObjectsSwept: 3,
-		BytesFreed:   2048,
-		DurationMs:   500,
+		RunID:          "run-1",
+		HashesMarked:   11,
+		ObjectsScanned: 14,
+		ObjectsSwept:   3,
+		BytesFreed:     2048,
+		DurationMs:     500,
 	}
 	withGCTestServer(t, s.URL)
 
@@ -129,7 +130,7 @@ func TestGCCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 	if s.lastDryRun {
 		t.Error("dry_run flag should be false by default")
 	}
-	for _, frag := range []string{"Hashes Marked", "11", "Objects Swept", "3", "Bytes Freed", "Run ID", "run-1"} {
+	for _, frag := range []string{"Hashes Marked", "11", "Objects Found", "14", "Objects Swept", "3", "Bytes Freed", "Run ID", "run-1"} {
 		if !strings.Contains(out, frag) {
 			t.Errorf("stdout missing %q, got %q", frag, out)
 		}
@@ -188,13 +189,14 @@ func TestGCStatusCmd_PrintsSummary(t *testing.T) {
 	s := newGCServer(t)
 	defer s.Close()
 	s.summary = engine.GCRunSummary{
-		RunID:        "run-7",
-		StartedAt:    time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC),
-		CompletedAt:  time.Date(2026, 4, 25, 10, 0, 1, 0, time.UTC),
-		HashesMarked: 99,
-		ObjectsSwept: 5,
-		BytesFreed:   8192,
-		DurationMs:   1100,
+		RunID:          "run-7",
+		StartedAt:      time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC),
+		CompletedAt:    time.Date(2026, 4, 25, 10, 0, 1, 0, time.UTC),
+		HashesMarked:   99,
+		ObjectsScanned: 120,
+		ObjectsSwept:   5,
+		BytesFreed:     8192,
+		DurationMs:     1100,
 	}
 	withGCTestServer(t, s.URL)
 
@@ -210,7 +212,7 @@ func TestGCStatusCmd_PrintsSummary(t *testing.T) {
 	if s.lastPath != "/api/v1/shares/myshare/blockstore/gc-status" {
 		t.Errorf("path = %q, want /api/v1/shares/myshare/blockstore/gc-status", s.lastPath)
 	}
-	for _, frag := range []string{"run-7", "Hashes Marked", "99", "Objects Swept", "5"} {
+	for _, frag := range []string{"run-7", "Hashes Marked", "99", "Objects Found", "120", "Objects Swept", "5"} {
 		if !strings.Contains(out, frag) {
 			t.Errorf("stdout missing %q, got %q", frag, out)
 		}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -269,11 +269,13 @@ dfsctl store block gc /archive --dry-run
 |------|---------|-------------|
 | `--dry-run` | `false` | Skip DELETEs; print up to `gc.dry_run_sample_size` candidate keys (default 1000). Critical for first-time deployment confidence. |
 
-**Output:** A `GCStats` record with `hashes_marked` (live blocks
-referenced), `objects_scanned` (total CAS objects found in the store),
-`objects_swept` (orphans deleted, or would-be-deleted under
-`--dry-run`), `bytes_freed`, `duration_ms`, and `error_count` plus a
-sample of the first errors when `error_count > 0`.
+**Output:** the default table shows `Hashes Marked` (live blocks
+referenced), `Objects Found` (total CAS objects walked), `Objects
+Swept` (orphans deleted, or would-be-deleted under `--dry-run`), `Bytes
+Freed`, `Duration`, and `Errors`, plus a sample of the first errors
+when there are any. With `-o json`/`-o yaml` the raw `GCStats` struct is
+emitted; it carries no json tags, so fields serialize under their Go
+names (e.g. `HashesMarked`, `ObjectsScanned`, `ObjectsSwept`).
 
 **Fail-closed posture:** any mark-phase error aborts the sweep entirely
 (no objects are deleted). Sweep-side per-prefix DELETE errors are
@@ -291,10 +293,10 @@ output.
 dfsctl store block gc-status /archive
 ```
 
-**Output:** the `GCRunSummary` JSON: `run_id`, `started_at`,
-`finished_at`, `hashes_marked`, `objects_scanned`, `objects_swept`,
-`bytes_freed`, `duration_ms`, `error_count`, `error_samples`, plus the
-configuration snapshot (`grace_period`, `dry_run`) used for the run.
+**Output:** the `GCRunSummary` JSON (snake_case tags): `run_id`,
+`started_at`, `completed_at`, `hashes_marked`, `objects_scanned`,
+`objects_swept`, `bytes_freed`, `duration_ms`, `error_count`,
+`first_errors`, `dry_run`, and `dry_run_candidates`.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md#garbage-collection-mark-sweep-v0150-phase-11)
 for the full mark-sweep design and [CONFIGURATION.md](CONFIGURATION.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -269,9 +269,11 @@ dfsctl store block gc /archive --dry-run
 |------|---------|-------------|
 | `--dry-run` | `false` | Skip DELETEs; print up to `gc.dry_run_sample_size` candidate keys (default 1000). Critical for first-time deployment confidence. |
 
-**Output:** A `GCStats` record with `hashes_marked`, `objects_swept`,
-`bytes_freed`, `duration_ms`, and `error_count` plus a sample of the
-first errors when `error_count > 0`.
+**Output:** A `GCStats` record with `hashes_marked` (live blocks
+referenced), `objects_scanned` (total CAS objects found in the store),
+`objects_swept` (orphans deleted, or would-be-deleted under
+`--dry-run`), `bytes_freed`, `duration_ms`, and `error_count` plus a
+sample of the first errors when `error_count > 0`.
 
 **Fail-closed posture:** any mark-phase error aborts the sweep entirely
 (no objects are deleted). Sweep-side per-prefix DELETE errors are
@@ -290,8 +292,8 @@ dfsctl store block gc-status /archive
 ```
 
 **Output:** the `GCRunSummary` JSON: `run_id`, `started_at`,
-`finished_at`, `hashes_marked`, `objects_swept`, `bytes_freed`,
-`duration_ms`, `error_count`, `error_samples`, plus the
+`finished_at`, `hashes_marked`, `objects_scanned`, `objects_swept`,
+`bytes_freed`, `duration_ms`, `error_count`, `error_samples`, plus the
 configuration snapshot (`grace_period`, `dry_run`) used for the run.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md#garbage-collection-mark-sweep-v0150-phase-11)

--- a/pkg/blockstore/engine/gc.go
+++ b/pkg/blockstore/engine/gc.go
@@ -489,17 +489,18 @@ func sweepPhase(
 	// future re-sharding extension belongs at the backend Walk layer
 	// (per-prefix fan-out), not here.
 	runSweep := func() {
+		// Count every object the backend reports — before any grace /
+		// zero-LastModified / live-set filtering — so ObjectsScanned is the
+		// total CAS objects present in the store ("blocks found"). Walk
+		// invokes the callback sequentially, so a local counter folded into
+		// stats once after the walk avoids a mutex round-trip per object.
+		var scanned int64
 		walkErr := remoteStore.Walk(ctx, func(h blockstore.ContentHash, meta blockstore.Meta) error {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
 			casKey := blockstore.FormatCASKey(h)
-			// Count every object the backend reports — before any grace /
-			// zero-LastModified / live-set filtering — so ObjectsScanned is
-			// the total CAS objects present in the store ("blocks found").
-			statsMu.Lock()
-			stats.ObjectsScanned++
-			statsMu.Unlock()
+			scanned++
 			// — fail-closed on missing LastModified.
 			// A zero LastModified means the backend did not report
 			// per-object age; we cannot evaluate the snapshot - grace
@@ -544,6 +545,9 @@ func sweepPhase(
 		if walkErr != nil {
 			addError("walk: " + walkErr.Error())
 		}
+		statsMu.Lock()
+		stats.ObjectsScanned += scanned
+		statsMu.Unlock()
 		if options.ProgressCallback != nil {
 			statsMu.Lock()
 			snap := *stats

--- a/pkg/blockstore/engine/gc.go
+++ b/pkg/blockstore/engine/gc.go
@@ -134,6 +134,7 @@ func releaseGCRootLock(root string, entry *gcRootLock) {
 type GCStats struct {
 	RunID            string
 	HashesMarked     int64
+	ObjectsScanned   int64
 	ObjectsSwept     int64
 	BytesFreed       int64
 	DurationMs       int64
@@ -353,6 +354,7 @@ func CollectGarbage(
 	slog.Info("GC: complete",
 		"run_id", runID,
 		"hashes_marked", stats.HashesMarked,
+		"objects_scanned", stats.ObjectsScanned,
 		"objects_swept", stats.ObjectsSwept,
 		"bytes_freed", stats.BytesFreed,
 		"duration_ms", stats.DurationMs,
@@ -492,6 +494,12 @@ func sweepPhase(
 				return err
 			}
 			casKey := blockstore.FormatCASKey(h)
+			// Count every object the backend reports — before any grace /
+			// zero-LastModified / live-set filtering — so ObjectsScanned is
+			// the total CAS objects present in the store ("blocks found").
+			statsMu.Lock()
+			stats.ObjectsScanned++
+			statsMu.Unlock()
 			// — fail-closed on missing LastModified.
 			// A zero LastModified means the backend did not report
 			// per-object age; we cannot evaluate the snapshot - grace
@@ -630,6 +638,7 @@ func gcRunSummaryFromStats(stats *GCStats, started, completed time.Time) GCRunSu
 		StartedAt:        started,
 		CompletedAt:      completed,
 		HashesMarked:     stats.HashesMarked,
+		ObjectsScanned:   stats.ObjectsScanned,
 		ObjectsSwept:     stats.ObjectsSwept,
 		BytesFreed:       stats.BytesFreed,
 		DurationMs:       stats.DurationMs,

--- a/pkg/blockstore/engine/gc_test.go
+++ b/pkg/blockstore/engine/gc_test.go
@@ -216,6 +216,14 @@ func TestGCMarkSweep_SweepHappyPath(t *testing.T) {
 	if stats.ObjectsSwept != 2 {
 		t.Errorf("ObjectsSwept = %d, want 2", stats.ObjectsSwept)
 	}
+	// ObjectsScanned counts every CAS object the sweep walked: the 3 live
+	// blocks plus the 2 orphans = 5, regardless of how many were deleted.
+	if stats.ObjectsScanned != 5 {
+		t.Errorf("ObjectsScanned = %d, want 5 (3 live + 2 orphans)", stats.ObjectsScanned)
+	}
+	if stats.ObjectsScanned < stats.ObjectsSwept {
+		t.Errorf("ObjectsScanned (%d) must be >= ObjectsSwept (%d)", stats.ObjectsScanned, stats.ObjectsSwept)
+	}
 	wantBytes := int64(len(orphan1Data) + len(orphan2Data))
 	if stats.BytesFreed != wantBytes {
 		t.Errorf("BytesFreed = %d, want %d", stats.BytesFreed, wantBytes)

--- a/pkg/blockstore/engine/gcstate.go
+++ b/pkg/blockstore/engine/gcstate.go
@@ -240,6 +240,7 @@ type GCRunSummary struct {
 	StartedAt        time.Time `json:"started_at"`
 	CompletedAt      time.Time `json:"completed_at"`
 	HashesMarked     int64     `json:"hashes_marked"`
+	ObjectsScanned   int64     `json:"objects_scanned"`
 	ObjectsSwept     int64     `json:"objects_swept"`
 	BytesFreed       int64     `json:"bytes_freed"`
 	DurationMs       int64     `json:"duration_ms"`

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -209,6 +209,7 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 	}
 	s := *stats
 	total.HashesMarked += s.HashesMarked
+	total.ObjectsScanned += s.ObjectsScanned
 	total.ObjectsSwept += s.ObjectsSwept
 	total.BytesFreed += s.BytesFreed
 	total.ErrorCount += s.ErrorCount


### PR DESCRIPTION
Closes #189.

## Background
#189 asked to expose GC via a CLI. That already exists — `dfsctl store block gc <share> [--dry-run] [-o json|yaml|table]` plus `gc-status`, an API client, REST endpoints, 7 unit tests, and docs. The issue is stale (it cites `pkg/payload/transfer/gc.go`, which no longer exists; real GC lives in `pkg/blockstore/engine/gc.go`). `--share-prefix` is dead (mark-sweep is globally scoped) and a live progress bar isn't feasible over a synchronous REST call.

## What this adds
The one genuinely-missing number from the issue's output spec: **blocks found in store**. The engine reported `HashesMarked` (referenced) and `ObjectsSwept` (orphans) but never the total objects walked, so the table couldn't say "N found → M orphaned".

- `ObjectsScanned int64` on `GCStats` + `GCRunSummary` (json `objects_scanned`), incremented once per object in the sweep `Walk` callback **before** grace/live-set filtering = total CAS objects present.
- Summed across remotes in `accumulateGCStats`; persisted in `last-run.json`; added to the complete-log line.
- Surfaced as **Objects Found** in `dfsctl store block gc` and `gc-status` tables (ordered referenced → found → orphaned). JSON/YAML inherit it automatically.

**Purely observational** — touches no mark/sweep deletion decision, fail-closed posture, grace TTL, or dry-run behavior.

## Tests
- Engine `TestGCMarkSweep_SweepHappyPath` pins `ObjectsScanned == 5` (3 live + 2 orphans) and `>= ObjectsSwept`.
- dfsctl gc + gc-status tests assert "Objects Found" renders with the value.
- docs/CLI.md updated.

## Out of scope
No `dfs gc` command, no `--share-prefix`, no progress bar (per discussion).

## Follow-up note
This closes #189. Mapping comment to follow on the issue.