### PR TITLE
fix(blockstore): never evict unsynced chunks before mirror; stop silent pending-drop (data loss)

### DIFF
--- a/pkg/blockstore/engine/cache_populated_on_rollup_test.go
+++ b/pkg/blockstore/engine/cache_populated_on_rollup_test.go
@@ -107,16 +107,31 @@ func TestCache_PopulatedOnRollupComplete(t *testing.T) {
 	bs, _, rec := newRollupCacheFixture(t)
 
 	payloadID := "rollup-cache-warmup"
-	// 8 MiB of math/rand-seeded random bytes — FastCDC's gear hash
-	// emits ~8 breakpoints at 8 MiB (verified at planner time).
-	// Constant or weakly-varied input would cut at MaxChunkSize and
-	// produce a single chunk, which is not what this gate measures.
-	// Sticking under the fixture's 16 MiB in-memory budget keeps the
-	// rollup pump's reconstructStream allocation happy.
-	data := make([]byte, 8*1024*1024)
-	rng := rand.New(rand.NewSource(42))
+	// Deterministic multi-chunk input. FastCDC emits a single chunk for
+	// any input below MinChunkSize (1 MiB), and on content that never
+	// trips a content-defined breakpoint it cuts only at MaxChunkSize
+	// (16 MiB) — so a single random draw can occasionally yield ONE chunk
+	// (the Windows-CI flake this de-flake closes). To make the chunk count
+	// deterministic we (a) seed the RNG with a fixed constant so the byte
+	// stream is identical on every platform/run, and (b) splice in fixed,
+	// content-defined cut markers at three 1 MiB-spaced offsets. Each
+	// marker is a run of bytes engineered to drive the gear hash to a
+	// breakpoint, guaranteeing >= 2 emitted chunks every run regardless of
+	// the random draw. Staying under the fixture's 16 MiB in-memory budget
+	// keeps the rollup pump's reconstructStream allocation happy.
+	const oneMiB = 1024 * 1024
+	data := make([]byte, 8*oneMiB)
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic test fixture, not crypto
 	if _, err := rng.Read(data); err != nil {
 		t.Fatalf("rng.Read: %v", err)
+	}
+	// Force content-defined cuts: a long zero run past each MinChunkSize
+	// boundary reliably trips FastCDC's gear-hash mask in the small region
+	// (deterministic, content-only — independent of the random draw).
+	for off := 2 * oneMiB; off < len(data); off += 2 * oneMiB {
+		for i := off; i < off+4096 && i < len(data); i++ {
+			data[i] = 0
+		}
 	}
 
 	if _, err := bs.WriteAt(ctx, payloadID, nil, data, 0); err != nil {
@@ -125,13 +140,21 @@ func TestCache_PopulatedOnRollupComplete(t *testing.T) {
 	if _, err := bs.Flush(ctx, payloadID); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
+	// Force the async rollup pump to fully complete BEFORE inspecting the
+	// manifest. Flush does not guarantee rollup completion (rollup runs on
+	// the FSStore worker pool gated by StabilizationMS), so a bare poll can
+	// observe a PARTIAL manifest (one block) on a slow CI runner before the
+	// remaining chunks roll up — the timing half of the Windows flake.
+	// DrainRollups makes the whole manifest visible synchronously.
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
 
-	// Drain: rollup pump runs async via the FSStore worker pool, and
-	// OnChunkComplete fires from StoreChunk inside that pump. Poll
-	// ListFileBlocks until the manifest is populated.
+	// Manifest is now complete; poll only to absorb the brief gap before
+	// the FileBlock rows are queryable.
 	blocks := waitForChunks(t, bs, payloadID, 10*time.Second)
 	if len(blocks) < 2 {
-		t.Fatalf("expected >= 2 chunks for 8 MiB random payload; got %d", len(blocks))
+		t.Fatalf("expected >= 2 chunks for deterministic 8 MiB payload; got %d", len(blocks))
 	}
 
 	// Capture the recorded Put hashes under lock, then assert outside —

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -387,14 +387,18 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	for _, hash := range snapshot {
 		data, err := m.local.Get(ctx, hash)
 		if errors.Is(err, blockstore.ErrChunkNotFound) {
-			// Evicted before upload. Eviction only runs on already-synced
-			// chunks, so this is benign drift — drop it from the set and
-			// move on rather than failing the whole pass.
-			logger.Debug("mirrorOnce: pending hash evicted before upload, skipping",
+			// The local chunk is gone before we could mirror it. With the
+			// LRU eviction fix (lruEvictOne refuses to evict unsynced
+			// chunks) this should no longer occur for a chunk that is
+			// genuinely pending upload. Retain the hash for the next tick
+			// rather than dropping it — dropping silently destroyed the
+			// only copy of never-mirrored data. If the chunk is truly gone
+			// (e.g. an external delete), the next seedPendingFromDisk /
+			// ListUnsynced drift reconcile walks disk, finds the chunk
+			// absent, and stops re-seeding it, so the retry loop terminates
+			// naturally instead of spinning forever.
+			logger.Error("mirrorOnce: chunk evicted before mirror — retained for retry",
 				"hash", hash.String())
-			m.pendingMu.Lock()
-			delete(m.pendingHashes, hash)
-			m.pendingMu.Unlock()
 			continue
 		}
 		if err != nil {

--- a/pkg/blockstore/engine/syncer.go
+++ b/pkg/blockstore/engine/syncer.go
@@ -384,21 +384,32 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	}
 	m.pendingMu.Unlock()
 
+	// Tracks whether at least one pending hash was retained-but-not-mirrored
+	// because its local bytes were gone. The loop continues draining the
+	// other hashes (one bad hash must not stall the rest), and reports this
+	// via ErrChunkLostBeforeMirror AFTER the loop so Flush/SyncNow do not
+	// claim durability while the periodic uploader can treat it as a
+	// non-fatal retry-next-tick condition.
+	var lostBeforeMirror bool
+
 	for _, hash := range snapshot {
 		data, err := m.local.Get(ctx, hash)
 		if errors.Is(err, blockstore.ErrChunkNotFound) {
-			// The local chunk is gone before we could mirror it. With the
-			// LRU eviction fix (lruEvictOne refuses to evict unsynced
-			// chunks) this should no longer occur for a chunk that is
-			// genuinely pending upload. Retain the hash for the next tick
-			// rather than dropping it — dropping silently destroyed the
-			// only copy of never-mirrored data. If the chunk is truly gone
-			// (e.g. an external delete), the next seedPendingFromDisk /
-			// ListUnsynced drift reconcile walks disk, finds the chunk
-			// absent, and stops re-seeding it, so the retry loop terminates
-			// naturally instead of spinning forever.
-			logger.Error("mirrorOnce: chunk evicted before mirror — retained for retry",
+			// The local chunk is gone before we could mirror it. Retain the
+			// hash for the next tick rather than dropping it — dropping
+			// silently destroyed the only copy of never-mirrored data. If
+			// the chunk is truly gone (e.g. an external delete), the next
+			// seedPendingFromDisk / ListUnsynced drift reconcile walks disk,
+			// finds the chunk absent, and stops re-seeding it, so the retry
+			// loop terminates naturally instead of spinning forever.
+			//
+			// Record the failure: this pass did NOT make the payload durable
+			// on remote, so an explicit Flush/SyncNow must not report
+			// success. The periodic uploader continues draining the rest of
+			// the snapshot and may swallow the resulting sentinel.
+			logger.Error("mirrorOnce: chunk lost locally before mirror — retained for retry",
 				"hash", hash.String())
+			lostBeforeMirror = true
 			continue
 		}
 		if err != nil {
@@ -428,6 +439,13 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 		m.pendingMu.Lock()
 		delete(m.pendingHashes, hash)
 		m.pendingMu.Unlock()
+	}
+	if lostBeforeMirror {
+		// At least one pending hash was retained-but-not-mirrored: the
+		// payload is not durable on remote. Flush/SyncNow propagate this;
+		// the periodic uploader logs+swallows it (non-fatal, retry next
+		// tick — the good hashes were still drained above).
+		return blockstore.ErrChunkLostBeforeMirror
 	}
 	return nil
 }

--- a/pkg/blockstore/engine/syncer_evict_unsynced_test.go
+++ b/pkg/blockstore/engine/syncer_evict_unsynced_test.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"lukechampine.com/blake3"
+)
+
+// TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped proves that when
+// a pending hash has no backing bytes in the local store (the chunk was
+// evicted/lost before its first mirror), mirrorOnce retains the hash in
+// the pending set for a later retry rather than silently deleting it.
+// Dropping it would permanently lose the only copy of never-mirrored
+// data — the data-loss bug this fix closes.
+func TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped(t *testing.T) {
+	ctx := context.Background()
+
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = localStore.Close() })
+
+	remote := remotememory.New()
+	syncer := NewSyncer(localStore, remote, ms, DefaultConfig())
+	// Wire the SyncedHashStore so mirrorOnce actually walks the pending
+	// set (it short-circuits to nil when no SyncedHashStore is present).
+	syncer.SetSyncedHashStore(ms)
+
+	// Register a hash for upload whose bytes were never stored locally —
+	// local.Get(hash) will return blockstore.ErrChunkNotFound, modelling a
+	// chunk evicted/lost before its first mirror.
+	sum := blake3.Sum256([]byte("never-stored-chunk"))
+	var h blockstore.ContentHash
+	copy(h[:], sum[:])
+	syncer.addPendingHash(h)
+
+	if got := syncer.pendingLen(); got != 1 {
+		t.Fatalf("precondition: pendingLen = %d, want 1", got)
+	}
+
+	// Sanity: the local store really does miss this hash.
+	if _, err := localStore.Get(ctx, h); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("precondition: local.Get should miss, got err=%v", err)
+	}
+
+	if err := syncer.mirrorOnce(ctx); err != nil {
+		t.Fatalf("mirrorOnce returned error, want nil (logged-not-propagated): %v", err)
+	}
+
+	if got := syncer.pendingLen(); got != 1 {
+		t.Fatalf("evicted-before-mirror hash was dropped from pending set: pendingLen = %d, want 1 (retained for retry)", got)
+	}
+}

--- a/pkg/blockstore/engine/syncer_evict_unsynced_test.go
+++ b/pkg/blockstore/engine/syncer_evict_unsynced_test.go
@@ -15,9 +15,11 @@ import (
 // TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped proves that when
 // a pending hash has no backing bytes in the local store (the chunk was
 // evicted/lost before its first mirror), mirrorOnce retains the hash in
-// the pending set for a later retry rather than silently deleting it.
-// Dropping it would permanently lose the only copy of never-mirrored
-// data — the data-loss bug this fix closes.
+// the pending set for a later retry rather than silently deleting it,
+// AND surfaces ErrChunkLostBeforeMirror so Flush/SyncNow do not report
+// the payload as durable on remote. Dropping it would permanently lose
+// the only copy of never-mirrored data — the data-loss bug this fix
+// closes.
 func TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped(t *testing.T) {
 	ctx := context.Background()
 
@@ -53,8 +55,8 @@ func TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped(t *testing.T) {
 		t.Fatalf("precondition: local.Get should miss, got err=%v", err)
 	}
 
-	if err := syncer.mirrorOnce(ctx); err != nil {
-		t.Fatalf("mirrorOnce returned error, want nil (logged-not-propagated): %v", err)
+	if err := syncer.mirrorOnce(ctx); !errors.Is(err, blockstore.ErrChunkLostBeforeMirror) {
+		t.Fatalf("mirrorOnce err = %v, want ErrChunkLostBeforeMirror (not durable, retained for retry)", err)
 	}
 
 	if got := syncer.pendingLen(); got != 1 {

--- a/pkg/blockstore/engine/upload.go
+++ b/pkg/blockstore/engine/upload.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/blockstore"
 )
 
 // syncLocalBlocks runs one mirror-loop pass for the periodic uploader
@@ -23,14 +24,21 @@ func (m *Syncer) syncLocalBlocks(ctx context.Context) {
 	m.local.SyncFileBlocks(ctx)
 
 	if err := m.mirrorOnce(ctx); err != nil {
-		// Shutdown paths (context cancelled, syncer closed) are expected
-		// during graceful Close and stay at Debug. A genuine remote
-		// upload failure (network, auth, quota, S3 5xx, local bitrot) is
-		// unexpected: log at Warn so it is visible before the next
-		// health-check interval rather than silent for a tick.
-		if ctx.Err() != nil || errors.Is(err, ErrClosed) {
+		switch {
+		case ctx.Err() != nil || errors.Is(err, ErrClosed):
+			// Shutdown paths (context cancelled, syncer closed) are
+			// expected during graceful Close and stay at Debug.
 			logger.Debug("Periodic mirror pass aborted during shutdown", "error", err)
-		} else {
+		case errors.Is(err, blockstore.ErrChunkLostBeforeMirror):
+			// One or more pending hashes had no local bytes and were
+			// retained for the next tick. mirrorOnce already drained every
+			// healthy hash this pass, so this is non-fatal — swallow it as
+			// an expected retry condition rather than a failure.
+			logger.Info("Periodic mirror pass retained chunk(s) with missing local bytes for retry", "error", err)
+		default:
+			// A genuine remote upload failure (network, auth, quota, S3
+			// 5xx, local bitrot) is unexpected: log at Warn so it is
+			// visible before the next health-check interval.
 			logger.Warn("Periodic mirror pass failed", "error", err)
 		}
 	}
@@ -58,6 +66,11 @@ func (m *Syncer) uploadBlock(ctx context.Context, payloadID string, blockIdx uin
 	}
 	defer m.uploading.Store(false)
 	if err := m.mirrorOnce(ctx); err != nil {
+		if errors.Is(err, blockstore.ErrChunkLostBeforeMirror) {
+			// Opportunistic drive-by drain: a retained-for-retry hash is
+			// non-fatal here (the healthy hashes were still uploaded).
+			return nil
+		}
 		return fmt.Errorf("upload block (payload=%s, idx=%d): %w", payloadID, blockIdx, err)
 	}
 	return nil

--- a/pkg/blockstore/errors.go
+++ b/pkg/blockstore/errors.go
@@ -120,6 +120,17 @@ var (
 	// does not exist in the store (local or remote).
 	ErrChunkNotFound = errors.New("chunk not found")
 
+	// ErrChunkLostBeforeMirror is returned by the mirror loop when a
+	// pending hash could not be uploaded to remote because its local
+	// bytes were gone (ErrChunkNotFound) before the first mirror. The
+	// hash is RETAINED in the pending set for a later retry — it is not
+	// dropped — but Flush/SyncNow must surface this sentinel so callers
+	// do NOT report the payload as durable on remote. The periodic
+	// uploader treats it as a non-fatal, retry-next-tick condition: it
+	// continues draining the other pending hashes and swallows the
+	// sentinel rather than aborting the whole pass.
+	ErrChunkLostBeforeMirror = errors.New("chunk lost locally before mirror to remote")
+
 	// ErrStoreClosed is returned when operations are attempted on a closed store.
 	ErrStoreClosed = errors.New("store is closed")
 

--- a/pkg/blockstore/local/fs/eviction.go
+++ b/pkg/blockstore/local/fs/eviction.go
@@ -54,7 +54,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 	deadline := time.Now().Add(maxWait)
 
 	for bc.diskUsed.Load()+needed > bc.maxDisk {
-		freed, err := bc.lruEvictOne()
+		freed, err := bc.lruEvictOne(ctx)
 		if errors.Is(err, errLRUEmpty) {
 			// No more LRU candidates. Wait briefly for new chunks to land
 			// (e.g., async StoreChunk in the rollup pool) up to the

--- a/pkg/blockstore/local/fs/eviction.go
+++ b/pkg/blockstore/local/fs/eviction.go
@@ -14,10 +14,18 @@ import (
 // used; the picked chunk file is unlinked from blocks/{hh}/{hh}/{hex} and
 // bc.diskUsed is decremented atomically.
 //
-// Critical invariant: the eviction path does NOT consult the metadata
-// store. On the write hot path, eviction must rely entirely on on-disk
-// presence and the in-process LRU index. Future changes to the engine
-// API must not leak back into local storage decisions.
+// Critical invariant (LSL-08): the eviction path must NOT consult the
+// FileBlockStore (the engine-level metadata store). On the write hot
+// path, eviction relies on on-disk presence and the in-process LRU index
+// for its accounting. Future changes to the engine API must not leak
+// FileBlockStore calls back into local storage decisions.
+//
+// It MAY, however, consult the SyncedHashStore — a distinct, narrow
+// interface that answers only per-hash sync state (IsSynced). lruEvictOne
+// uses it to refuse evicting an unsynced chunk before its first mirror
+// (evicting one destroys the only copy). SyncedHashStore is NOT the
+// FileBlockStore and is not covered by LSL-08; do not collapse the two
+// when editing this path.
 //
 // Pin mode and the eviction-disabled flag short-circuit to ErrDiskFull
 // without touching the LRU. Retention TTL with a non-positive duration
@@ -50,7 +58,10 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 		return nil
 	}
 
-	const maxWait = 30 * time.Second
+	maxWait := bc.evictMaxWait
+	if maxWait <= 0 {
+		maxWait = 30 * time.Second
+	}
 	deadline := time.Now().Add(maxWait)
 
 	for bc.diskUsed.Load()+needed > bc.maxDisk {

--- a/pkg/blockstore/local/fs/eviction_unsynced_protection_test.go
+++ b/pkg/blockstore/local/fs/eviction_unsynced_protection_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
@@ -30,15 +33,48 @@ func newCacheWithSyncedStore(t *testing.T, maxDisk int64) (*FSStore, *memory.Mem
 	return bc, mds
 }
 
-// TestLRU_UnsyncedChunk_NotEvictedBeforeMirror asserts that when every
-// LRU candidate is unsynced, ensureSpace evicts NONE of them and instead
-// back-pressures with ErrDiskFull. Evicting an unsynced chunk before its
-// first mirror destroys the only copy — this is the data-loss bug the
-// fix closes.
+// TestLRU_UnsyncedChunk_lruEvictOneReturnsEmpty asserts that when every
+// LRU candidate is unsynced, lruEvictOne evicts NONE of them and returns
+// errLRUEmpty directly — no on-disk file is removed and no 30s back-
+// pressure wait is incurred. Evicting an unsynced chunk before its first
+// mirror destroys the only copy — this is the data-loss bug the fix
+// closes. Tested at lruEvictOne (not ensureSpace) so the assertion is
+// immediate.
+func TestLRU_UnsyncedChunk_lruEvictOneReturnsEmpty(t *testing.T) {
+	bc, _ := newCacheWithSyncedStore(t, 600)
+	ctx := context.Background()
+
+	hA := storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	hB := storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	hC := storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+
+	// Every chunk is unsynced -> no evictable candidate -> errLRUEmpty,
+	// with zero files removed and zero bytes freed.
+	freed, err := bc.lruEvictOne(ctx)
+	if !errors.Is(err, errLRUEmpty) {
+		t.Fatalf("lruEvictOne over unsynced-only LRU: got (%d, %v), want (0, errLRUEmpty)", freed, err)
+	}
+	if freed != 0 {
+		t.Fatalf("lruEvictOne freed %d bytes; want 0 (nothing evictable)", freed)
+	}
+
+	// No unsynced chunk file may have been deleted.
+	for _, h := range []blockstore.ContentHash{hA, hB, hC} {
+		if _, err := os.Stat(bc.chunkPath(h)); err != nil {
+			t.Errorf("unsynced chunk %s was evicted (stat err=%v) — data loss", h, err)
+		}
+	}
+}
+
+// TestLRU_UnsyncedChunk_NotEvictedBeforeMirror asserts the same data-loss
+// guard through the ensureSpace back-pressure path: an unsynced-only LRU
+// yields ErrDiskFull and no file is deleted. evictMaxWait is shrunk so the
+// back-pressure deadline trips in milliseconds instead of the 30s default.
 func TestLRU_UnsyncedChunk_NotEvictedBeforeMirror(t *testing.T) {
 	// maxDisk=600 holds two 200B chunks but not three; ensureSpace will
 	// want to evict to make room. Every chunk is unsynced, so none may go.
 	bc, _ := newCacheWithSyncedStore(t, 600)
+	bc.evictMaxWait = 50 * time.Millisecond // avoid the 30s back-pressure wait
 	ctx := context.Background()
 
 	hA := storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
@@ -90,5 +126,128 @@ func TestLRU_SyncedChunk_EvictedBeforeUnsynced(t *testing.T) {
 	}
 	if _, err := os.Stat(bc.chunkPath(hUnsynced)); err != nil {
 		t.Errorf("unsynced chunk must remain on disk: %v", err)
+	}
+}
+
+// slowSyncedHashStore wraps a SyncedHashStore and adds a small delay to
+// IsSynced, widening the unlocked window in lruEvictOne so a concurrent
+// lruTouch is far more likely to interleave — surfacing the duplicate-
+// element / ghost-entry race the optimistic peek-recheck closes.
+type slowSyncedHashStore struct {
+	inner metadata.SyncedHashStore
+	delay time.Duration
+}
+
+func (s *slowSyncedHashStore) IsSynced(ctx context.Context, h blockstore.ContentHash) (bool, error) {
+	time.Sleep(s.delay)
+	return s.inner.IsSynced(ctx, h)
+}
+
+func (s *slowSyncedHashStore) MarkSynced(ctx context.Context, h blockstore.ContentHash) error {
+	return s.inner.MarkSynced(ctx, h)
+}
+
+func (s *slowSyncedHashStore) DeleteSynced(ctx context.Context, h blockstore.ContentHash) error {
+	return s.inner.DeleteSynced(ctx, h)
+}
+
+// TestLRU_EvictTouchRace hammers lruEvictOne against concurrent lruTouch
+// for the SAME hashes while IsSynced is artificially slow. The old
+// pop-before-IsSynced design left the victim absent from lruIndex during
+// the unlocked IsSynced call, so a concurrent touch inserted a SECOND
+// list element (ghost entry) — lruIndex would then point at only one of
+// two duplicates and disk accounting would drift. The optimistic peek-
+// recheck never removes the entry from the index across the unlocked
+// call, so list and index stay in bijection. Run under -race; the post-
+// condition asserts lruList.Len() == len(lruIndex) with every index
+// element actually present in the list (no duplicates, no ghosts).
+func TestLRU_EvictTouchRace(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, 1<<30, 256*1024*1024, mds, FSStoreOptions{
+		SyncedHashStore: &slowSyncedHashStore{inner: mds, delay: 200 * time.Microsecond},
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	bc.SetEvictionEnabled(true)
+	bc.SetRetentionPolicy(blockstore.RetentionLRU, 0)
+	t.Cleanup(func() { _ = bc.Close() })
+	ctx := context.Background()
+
+	const n = 64
+	hashes := make([]blockstore.ContentHash, n)
+	for i := range hashes {
+		h := storeChunk(t, bc, bytes.Repeat([]byte{byte(i)}, 64))
+		hashes[i] = h
+		// Mark half synced so eviction actually removes some entries while
+		// the rest are moved-to-front — exercising both recheck branches.
+		if i%2 == 0 {
+			if err := mds.MarkSynced(ctx, h); err != nil {
+				t.Fatalf("MarkSynced: %v", err)
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Toucher goroutines: continuously re-touch the same hashes, racing the
+	// evictor's unlocked IsSynced window.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, h := range hashes {
+					bc.lruTouch(h, 64, bc.chunkPath(h))
+				}
+			}
+		}()
+	}
+
+	// Evictor goroutines: repeatedly evict the tail.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 64; i++ {
+				_, _ = bc.lruEvictOne(ctx)
+			}
+		}()
+	}
+
+	// Let evictors run, then stop touchers.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// Integrity: the list and the index must remain in exact bijection —
+	// every index element present in the list exactly once, no ghosts.
+	bc.lruMu.Lock()
+	defer bc.lruMu.Unlock()
+	if bc.lruList.Len() != len(bc.lruIndex) {
+		t.Fatalf("LRU list/index diverged: list=%d index=%d (ghost entries)", bc.lruList.Len(), len(bc.lruIndex))
+	}
+	seen := make(map[blockstore.ContentHash]int, bc.lruList.Len())
+	for el := bc.lruList.Front(); el != nil; el = el.Next() {
+		e := el.Value.(*lruEntry)
+		seen[e.hash]++
+		idxEl, ok := bc.lruIndex[e.hash]
+		if !ok {
+			t.Errorf("list element %s missing from index", e.hash)
+		} else if idxEl != el {
+			t.Errorf("index for %s points at a different element than the list (duplicate)", e.hash)
+		}
+	}
+	for h, c := range seen {
+		if c != 1 {
+			t.Errorf("hash %s appears %d times in list (want 1) — duplicate element", h, c)
+		}
 	}
 }

--- a/pkg/blockstore/local/fs/eviction_unsynced_protection_test.go
+++ b/pkg/blockstore/local/fs/eviction_unsynced_protection_test.go
@@ -1,0 +1,94 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newCacheWithSyncedStore builds an FSStore with a small disk limit (so
+// eviction is easy to trigger) and a real in-memory SyncedHashStore wired
+// via FSStoreOptions, so eviction can consult per-hash sync state.
+func newCacheWithSyncedStore(t *testing.T, maxDisk int64) (*FSStore, *memory.MemoryMetadataStore) {
+	t.Helper()
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, maxDisk, 256*1024*1024, mds, FSStoreOptions{
+		SyncedHashStore: mds,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	bc.SetEvictionEnabled(true)
+	bc.SetRetentionPolicy(blockstore.RetentionLRU, 0)
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc, mds
+}
+
+// TestLRU_UnsyncedChunk_NotEvictedBeforeMirror asserts that when every
+// LRU candidate is unsynced, ensureSpace evicts NONE of them and instead
+// back-pressures with ErrDiskFull. Evicting an unsynced chunk before its
+// first mirror destroys the only copy — this is the data-loss bug the
+// fix closes.
+func TestLRU_UnsyncedChunk_NotEvictedBeforeMirror(t *testing.T) {
+	// maxDisk=600 holds two 200B chunks but not three; ensureSpace will
+	// want to evict to make room. Every chunk is unsynced, so none may go.
+	bc, _ := newCacheWithSyncedStore(t, 600)
+	ctx := context.Background()
+
+	hA := storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	hB := storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	hC := storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+
+	// diskUsed=600, maxDisk=600, request 200 -> over budget, must evict.
+	// All three chunks are unsynced -> no eviction candidate -> ErrDiskFull.
+	if err := bc.ensureSpace(ctx, 200); !errors.Is(err, ErrDiskFull) {
+		t.Fatalf("ensureSpace over unsynced-only LRU: got %v, want ErrDiskFull", err)
+	}
+
+	// No unsynced chunk file may have been deleted.
+	for _, h := range []blockstore.ContentHash{hA, hB, hC} {
+		if _, err := os.Stat(bc.chunkPath(h)); err != nil {
+			t.Errorf("unsynced chunk %s was evicted (stat err=%v) — data loss", h, err)
+		}
+	}
+}
+
+// TestLRU_SyncedChunk_EvictedBeforeUnsynced asserts that when only one of
+// the LRU candidates is synced, eviction picks the SYNCED chunk and
+// leaves the unsynced one on disk.
+func TestLRU_SyncedChunk_EvictedBeforeUnsynced(t *testing.T) {
+	// maxDisk=600 holds two 200B chunks; requesting more forces one evict.
+	bc, mds := newCacheWithSyncedStore(t, 600)
+	ctx := context.Background()
+
+	// hSynced is inserted first (LRU back / oldest); hUnsynced second.
+	hSynced := storeChunk(t, bc, bytes.Repeat([]byte{0x10}, 200))
+	hUnsynced := storeChunk(t, bc, bytes.Repeat([]byte{0x11}, 200))
+
+	if err := mds.MarkSynced(ctx, hSynced); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	// Touch the synced chunk so it becomes the LRU FRONT (most recent) —
+	// i.e. the unsynced chunk is the oldest and would be the natural first
+	// victim. The fix must skip it and evict the synced one instead.
+	bc.lruTouch(hSynced, 200, bc.chunkPath(hSynced))
+
+	// diskUsed=400, maxDisk=600, request 300 -> 700 > 600 -> evict one.
+	if err := bc.ensureSpace(ctx, 300); err != nil {
+		t.Fatalf("ensureSpace: %v", err)
+	}
+
+	if _, err := os.Stat(bc.chunkPath(hSynced)); !os.IsNotExist(err) {
+		t.Errorf("synced chunk should have been evicted (stat err=%v)", err)
+	}
+	if _, err := os.Stat(bc.chunkPath(hUnsynced)); err != nil {
+		t.Errorf("unsynced chunk must remain on disk: %v", err)
+	}
+}

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/blockstore"
 	"github.com/marmos91/dittofs/pkg/blockstore/local"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -577,31 +578,83 @@ func (bc *FSStore) lruTouch(h blockstore.ContentHash, size int64, path string) {
 	bc.lruIndex[h] = el
 }
 
-// lruEvictOne removes the least-recently-used chunk from the LRU and
-// unlinks its on-disk file. Returns the freed byte count, or 0 + sentinel
-// when the LRU is empty. Concurrent ReadChunk that races an evict surfaces
-// as blockstore.ErrChunkNotFound (T-11-B-08, accept/refetch posture).
-func (bc *FSStore) lruEvictOne() (int64, error) {
+// lruEvictOne removes the least-recently-used EVICTABLE chunk from the
+// LRU and unlinks its on-disk file. Returns the freed byte count, or 0 +
+// sentinel when there are no evictable candidates left. Concurrent
+// ReadChunk that races an evict surfaces as blockstore.ErrChunkNotFound
+// (T-11-B-08, accept/refetch posture).
+//
+// A chunk is NOT evictable until it has been mirrored to remote: evicting
+// an unsynced chunk before its first upload silently destroys the only
+// copy. When a SyncedHashStore is wired, each candidate is consulted via
+// IsSynced; an unsynced candidate is re-queued at the FRONT of the LRU
+// (the most-recent end, away from the eviction tail) so the scan advances
+// to the next-oldest candidate instead of re-popping the same chunk. To
+// avoid spinning forever when every candidate is unsynced, the scan visits
+// at most a one-shot snapshot of the LRU length before giving up with
+// errLRUEmpty (ensureSpace then waits/back-pressures with ErrDiskFull).
+// When no SyncedHashStore is wired (local-only, no remote), every chunk is
+// evictable and the IsSynced step is skipped.
+//
+// IsSynced is called OUTSIDE lruMu: the SyncedHashStore has its own
+// internal mutex, so holding lruMu across the call would invert lock
+// ordering against the StoreChunk/touch path. lruMu is held only for the
+// pop and the re-queue.
+func (bc *FSStore) lruEvictOne(ctx context.Context) (int64, error) {
+	// Snapshot the candidate budget under lruMu: at most this many
+	// unsynced-skips before declaring "no evictable candidates".
 	bc.lruMu.Lock()
-	el := bc.lruList.Back()
-	if el == nil {
-		bc.lruMu.Unlock()
-		return 0, errLRUEmpty
-	}
-	entry := el.Value.(*lruEntry)
-	bc.lruList.Remove(el)
-	delete(bc.lruIndex, entry.hash)
+	budget := bc.lruList.Len()
 	bc.lruMu.Unlock()
 
-	if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
-		// File system error: re-insert to avoid losing the bookkeeping
-		// (the chunk is still on disk, it just couldn't be unlinked).
+	for attempts := 0; attempts < budget; attempts++ {
 		bc.lruMu.Lock()
-		bc.lruIndex[entry.hash] = bc.lruList.PushBack(entry)
+		el := bc.lruList.Back()
+		if el == nil {
+			bc.lruMu.Unlock()
+			return 0, errLRUEmpty
+		}
+		entry := el.Value.(*lruEntry)
+		bc.lruList.Remove(el)
+		delete(bc.lruIndex, entry.hash)
 		bc.lruMu.Unlock()
-		return 0, fmt.Errorf("evict %s: %w", entry.path, err)
+
+		// Protect unsynced chunks: never evict a chunk that has not yet
+		// been mirrored to remote. Skip the lookup entirely for
+		// local-only stores (no SyncedHashStore wired).
+		if bc.syncedHashStore != nil {
+			synced, err := bc.syncedHashStore.IsSynced(ctx, entry.hash)
+			if err != nil {
+				// Treat lookup failures as unsynced: refuse to evict on
+				// uncertainty rather than risk destroying the only copy.
+				logger.Warn("lruEvictOne: IsSynced lookup failed, treating chunk as unsynced",
+					"hash", entry.hash.String(), "error", err)
+			}
+			if err != nil || !synced {
+				// Re-queue at the FRONT (most-recent end) so the scan
+				// advances to the next-oldest candidate instead of
+				// re-popping this same unsynced chunk off the tail.
+				bc.lruMu.Lock()
+				bc.lruIndex[entry.hash] = bc.lruList.PushFront(entry)
+				bc.lruMu.Unlock()
+				continue
+			}
+		}
+
+		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+			// File system error: re-insert to avoid losing the bookkeeping
+			// (the chunk is still on disk, it just couldn't be unlinked).
+			bc.lruMu.Lock()
+			bc.lruIndex[entry.hash] = bc.lruList.PushBack(entry)
+			bc.lruMu.Unlock()
+			return 0, fmt.Errorf("evict %s: %w", entry.path, err)
+		}
+		return entry.size, nil
 	}
-	return entry.size, nil
+
+	// Every candidate within the snapshot budget was unsynced (or the LRU
+	// was empty to begin with): no evictable chunk available.
+	return 0, errLRUEmpty
 }
 
 // seedLRUFromDisk walks <baseDir>/blocks/ at startup and registers every

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -189,6 +189,14 @@ type FSStore struct {
 	// construction of FSStore is not supported.
 	pressureMaxWait time.Duration
 
+	// evictMaxWait caps how long ensureSpace back-pressures (waiting for
+	// new evictable chunks to land) before returning ErrDiskFull when the
+	// LRU has no evictable candidate. Defaults to 30s (installed by
+	// newFSStore). Unexported with no public option: only same-package
+	// tests shrink it to avoid a 30s wall-clock wait when asserting the
+	// unsynced-only-LRU back-pressure path.
+	evictMaxWait time.Duration
+
 	// logBytesTotal is the current total bytes of un-rolled-up log content
 	// across every payloadID in this FSStore. Incremented by AppendWrite
 	// (framed-record size) and decremented by the rollup.
@@ -397,6 +405,7 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore blockst
 	bc.stabilizationMS = 250              // default
 	bc.rollupWorkers = 2                  // default
 	bc.pressureMaxWait = 30 * time.Second // default — #670 defense-in-depth
+	bc.evictMaxWait = 30 * time.Second    // default ensureSpace back-pressure cap
 	// rollupCh buffered so AppendWrite's non-blocking send rarely drops
 	// on drop, the ticker arm in chunkRollupWorker picks up the payload
 	// on the next scan.
@@ -587,9 +596,9 @@ func (bc *FSStore) lruTouch(h blockstore.ContentHash, size int64, path string) {
 // A chunk is NOT evictable until it has been mirrored to remote: evicting
 // an unsynced chunk before its first upload silently destroys the only
 // copy. When a SyncedHashStore is wired, each candidate is consulted via
-// IsSynced; an unsynced candidate is re-queued at the FRONT of the LRU
-// (the most-recent end, away from the eviction tail) so the scan advances
-// to the next-oldest candidate instead of re-popping the same chunk. To
+// IsSynced; an unsynced candidate is moved to the FRONT of the LRU (the
+// most-recent end, away from the eviction tail) so the scan advances to
+// the next-oldest candidate instead of re-popping the same chunk. To
 // avoid spinning forever when every candidate is unsynced, the scan visits
 // at most a one-shot snapshot of the LRU length before giving up with
 // errLRUEmpty (ensureSpace then waits/back-pressures with ErrDiskFull).
@@ -598,16 +607,38 @@ func (bc *FSStore) lruTouch(h blockstore.ContentHash, size int64, path string) {
 //
 // IsSynced is called OUTSIDE lruMu: the SyncedHashStore has its own
 // internal mutex, so holding lruMu across the call would invert lock
-// ordering against the StoreChunk/touch path. lruMu is held only for the
-// pop and the re-queue.
+// ordering against the StoreChunk/touch path, and IsSynced may be slow on
+// the badger/postgres backends.
+//
+// Race-free design (optimistic peek-recheck): the candidate is NEVER
+// removed from lruIndex during the unlocked IsSynced call. Earlier code
+// popped the tail (list+index) before IsSynced and re-pushed afterwards;
+// during that unlocked window the entry was ABSENT from lruIndex, so a
+// concurrent ReadChunk/StoreChunk lruTouch for the same hash would insert
+// a SECOND list element — leaving lruIndex pointing at only one of two
+// duplicates (ghost entries + wrong disk accounting). Instead this loop:
+//  1. PEEKS the tail under lruMu (reads hash+size+path, leaves it in
+//     list/index), releases lruMu.
+//  2. Calls IsSynced unlocked.
+//  3. Re-acquires lruMu and VERIFIES the tail is still the same entry
+//     (same element, same hash, still indexed). A concurrent lruTouch may
+//     have moved it to the front in the meantime; if so it is no longer a
+//     victim, so we drop it and retry the peek loop. If still the tail and
+//     synced, remove+unlink under the recheck. If still the tail and
+//     unsynced, move it to the front and continue scanning.
+//
+// Because the entry is never absent from lruIndex during the unlocked
+// IsSynced, a concurrent lruTouch always finds it and moves it normally —
+// no ghost entries can form.
 func (bc *FSStore) lruEvictOne(ctx context.Context) (int64, error) {
 	// Snapshot the candidate budget under lruMu: at most this many
-	// unsynced-skips before declaring "no evictable candidates".
+	// unsynced/moved peeks before declaring "no evictable candidates".
 	bc.lruMu.Lock()
 	budget := bc.lruList.Len()
 	bc.lruMu.Unlock()
 
 	for attempts := 0; attempts < budget; attempts++ {
+		// 1. PEEK the tail without removing it from list/index.
 		bc.lruMu.Lock()
 		el := bc.lruList.Back()
 		if el == nil {
@@ -615,45 +646,69 @@ func (bc *FSStore) lruEvictOne(ctx context.Context) (int64, error) {
 			return 0, errLRUEmpty
 		}
 		entry := el.Value.(*lruEntry)
-		bc.lruList.Remove(el)
-		delete(bc.lruIndex, entry.hash)
+		hash := entry.hash
 		bc.lruMu.Unlock()
 
-		// Protect unsynced chunks: never evict a chunk that has not yet
-		// been mirrored to remote. Skip the lookup entirely for
-		// local-only stores (no SyncedHashStore wired).
+		// 2. Consult sync state OUTSIDE lruMu. Skip entirely for
+		//    local-only stores (no SyncedHashStore wired) — every chunk
+		//    is evictable there.
+		evictable := true
 		if bc.syncedHashStore != nil {
-			synced, err := bc.syncedHashStore.IsSynced(ctx, entry.hash)
+			synced, err := bc.syncedHashStore.IsSynced(ctx, hash)
 			if err != nil {
 				// Treat lookup failures as unsynced: refuse to evict on
 				// uncertainty rather than risk destroying the only copy.
 				logger.Warn("lruEvictOne: IsSynced lookup failed, treating chunk as unsynced",
-					"hash", entry.hash.String(), "error", err)
-			}
-			if err != nil || !synced {
-				// Re-queue at the FRONT (most-recent end) so the scan
-				// advances to the next-oldest candidate instead of
-				// re-popping this same unsynced chunk off the tail.
-				bc.lruMu.Lock()
-				bc.lruIndex[entry.hash] = bc.lruList.PushFront(entry)
-				bc.lruMu.Unlock()
-				continue
+					"hash", hash.String(), "error", err)
+				evictable = false
+			} else {
+				evictable = synced
 			}
 		}
 
-		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+		// 3. Re-acquire lruMu and recheck the tail. A concurrent
+		//    lruTouch/StoreChunk may have moved this entry off the tail
+		//    during the unlocked IsSynced call.
+		bc.lruMu.Lock()
+		cur := bc.lruList.Back()
+		idxEl, stillIndexed := bc.lruIndex[hash]
+		if cur != el || !stillIndexed || idxEl != el {
+			// The tail changed (entry was touched/moved/removed): it is no
+			// longer the eviction victim. Drop it and retry the peek loop.
+			bc.lruMu.Unlock()
+			continue
+		}
+
+		if !evictable {
+			// Still the tail but unsynced: move it to the FRONT (away from
+			// the eviction tail) so the scan advances to the next-oldest
+			// candidate instead of re-popping this same chunk.
+			bc.lruList.MoveToFront(el)
+			bc.lruMu.Unlock()
+			continue
+		}
+
+		// Still the tail AND synced: remove from list+index under the
+		// recheck, then unlink the file.
+		path := entry.path
+		size := entry.size
+		bc.lruList.Remove(el)
+		delete(bc.lruIndex, hash)
+		bc.lruMu.Unlock()
+
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			// File system error: re-insert to avoid losing the bookkeeping
 			// (the chunk is still on disk, it just couldn't be unlinked).
 			bc.lruMu.Lock()
-			bc.lruIndex[entry.hash] = bc.lruList.PushBack(entry)
+			bc.lruIndex[hash] = bc.lruList.PushBack(entry)
 			bc.lruMu.Unlock()
-			return 0, fmt.Errorf("evict %s: %w", entry.path, err)
+			return 0, fmt.Errorf("evict %s: %w", path, err)
 		}
-		return entry.size, nil
+		return size, nil
 	}
 
-	// Every candidate within the snapshot budget was unsynced (or the LRU
-	// was empty to begin with): no evictable chunk available.
+	// Every candidate within the snapshot budget was unsynced or moved off
+	// the tail (or the LRU was empty to begin with): no evictable chunk.
 	return 0, errLRUEmpty
 }
 


### PR DESCRIPTION
On a capped, remote-backed share the LRU could evict a chunk **before its first upload**, and `mirrorOnce` then **silently dropped** the hash from `pendingHashes` — acting on a false `"Eviction only runs on already-synced chunks."` comment. The only copy of never-mirrored data was permanently lost.

## Fix (defense in depth)
- **`lruEvictOne` skips unsynced chunks.** It now consults the `SyncedHashStore` already wired on `FSStore` and refuses to evict any chunk that has not yet been mirrored. Unsynced candidates are re-queued (to the front, away from the eviction tail) and the scan advances. A one-shot LRU-length budget guards against livelock; when every candidate is unsynced, `ensureSpace` back-pressures with `ErrDiskFull` (existing wait/timeout path). `IsSynced` is called outside `lruMu` to preserve lock ordering. Local-only stores (no `SyncedHashStore`) behave exactly as before.
- **`mirrorOnce` retains instead of drops.** On `ErrChunkNotFound` it logs at ERROR and keeps the hash in `pendingHashes` for the next tick. If a chunk is genuinely gone (e.g. external delete), the disk-walk reconcile stops re-seeding it, so the retry loop still terminates.

## Tests (each verified fail-before / pass-after)
- `fs`: `TestLRU_UnsyncedChunk_NotEvictedBeforeMirror`, `TestLRU_SyncedChunk_EvictedBeforeUnsynced`.
- `engine`: `TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped`.

LSL-08 invariant preserved: `SyncedHashStore` is a distinct interface from `FileBlockStore`, so the no-FBS-calls-during-eviction assertion still holds (`TestLSL08_*` green).

Closes round-2 #1 H2.