### PR TITLE
chore: add Makefile targets for all test suites (#206)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup-hooks check-hooks fmt lint vet build bench-phase12 build-bench bench-blockstore bench-all
+.PHONY: setup-hooks check-hooks fmt lint vet build bench-phase12 build-bench bench-blockstore bench-all test-unit test-e2e test-posix test-smb-conformance test-all
 
 # Configure git to use the project's hooks directory and make hooks
 # executable. Safe to re-run.
@@ -68,3 +68,25 @@ bench-blockstore:
 # Umbrella target — only blockstore is wired today. As gc / snapshots /
 # metadata / adapters / e2e land, append their bench-<area> targets.
 bench-all: bench-blockstore
+
+# Run unit + integration tests with the race detector, matching CI.
+test-unit:
+	go test -race ./...
+
+# E2E suite. Requires sudo + a kernel NFS client. Pass script flags via
+# ARGS, e.g. `make test-e2e ARGS="--verbose --s3"`.
+test-e2e:
+	test/e2e/run-e2e.sh $(ARGS)
+
+# POSIX compliance suite. Requires a mounted DittoFS export (see the
+# script header). Pass flags/patterns via ARGS, e.g. `make test-posix ARGS=chmod`.
+test-posix:
+	test/posix/run-posix.sh $(ARGS)
+
+# SMB conformance suite (WPTS FileServer BVT). Pass flags via ARGS,
+# e.g. `make test-smb-conformance ARGS="--profile badger-fs"`.
+test-smb-conformance:
+	test/smb-conformance/run.sh $(ARGS)
+
+# Run unit tests followed by all three protocol suites.
+test-all: test-unit test-e2e test-posix test-smb-conformance

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ bench-all: bench-blockstore
 test-unit:
 	go test -race ./...
 
-# E2E suite. Requires sudo + a kernel NFS client. Pass script flags via
-# ARGS, e.g. `make test-e2e ARGS="--verbose --s3"`.
+# E2E suite. Requires root + a kernel NFS client, so invoke under sudo:
+# `sudo make test-e2e ARGS="--verbose --s3"`. Flags pass through via ARGS.
 test-e2e:
 	test/e2e/run-e2e.sh $(ARGS)
 
-# POSIX compliance suite. Requires a mounted DittoFS export (see the
-# script header). Pass flags/patterns via ARGS, e.g. `make test-posix ARGS=chmod`.
+# POSIX compliance suite. Requires root (mounts a DittoFS export; see the
+# script header), so invoke under sudo: `sudo make test-posix ARGS=chmod`.
 test-posix:
 	test/posix/run-posix.sh $(ARGS)
 
@@ -88,5 +88,12 @@ test-posix:
 test-smb-conformance:
 	test/smb-conformance/run.sh $(ARGS)
 
-# Run unit tests followed by all three protocol suites.
-test-all: test-unit test-e2e test-posix test-smb-conformance
+# Run unit tests followed by all three protocol suites. Uses a recipe
+# (not prerequisites) with $(MAKE) so the suites run strictly in order
+# even under `make -j` — the protocol suites share ports/mounts and must
+# not run concurrently. Requires root for the e2e/posix stages.
+test-all:
+	$(MAKE) test-unit
+	$(MAKE) test-e2e
+	$(MAKE) test-posix
+	$(MAKE) test-smb-conformance


### PR DESCRIPTION
## Summary

Adds consistent Makefile targets wrapping the existing test scripts, addressing #206.

- `make test-unit` — `go test -race ./...` (matches CI / CONTRIBUTING convention)
- `make test-e2e` — wraps `test/e2e/run-e2e.sh` (requires sudo + kernel NFS client)
- `make test-posix` — wraps `test/posix/run-posix.sh`
- `make test-smb-conformance` — wraps `test/smb-conformance/run.sh`
- `make test-all` — runs unit + the three protocol suites in order

## Passing flags

Each script already exposes its own flags; the targets forward them verbatim via an `ARGS` pass-through rather than inventing new flags:

```bash
make test-e2e ARGS="--verbose --s3"
make test-posix ARGS=chmod
make test-smb-conformance ARGS="--profile badger-fs"
```

(The issue's `VERBOSE=1` example was illustrative — the scripts use their native flags like `--verbose`, surfaced through `ARGS`.)

## Notes

- All five targets added to `.PHONY`.
- Style mirrors the existing `bench-*` / `build` targets (single recipe line + comment).
- Verified with `make -n test-all`; `gofmt`/`go vet`/`golangci-lint` clean.
- GitHub auto-close only fires on merge to the default branch, so this references #206 rather than closing it (base is `develop`).
