### PR TITLE
feat(nsm): dispatch SM_NOTIFY callbacks to local monitors (#218)

### DIFF
--- a/internal/adapter/nfs/nsm/handlers/handler.go
+++ b/internal/adapter/nfs/nsm/handlers/handler.go
@@ -1,11 +1,31 @@
 package handlers
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/callback"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// notifyDispatcher sends a single SM_NOTIFY callback to one local monitor.
+//
+// It is satisfied by *callback.Client. The handler depends on this narrow
+// interface (rather than the concrete client) so the relay can be exercised
+// without real sockets in tests. A nil dispatcher disables relay: the security
+// gates still run, but no callback is sent.
+type notifyDispatcher interface {
+	Send(
+		ctx context.Context,
+		addr string,
+		status *types.Status,
+		proc uint32,
+		prog uint32,
+		vers uint32,
+	) error
+}
 
 // DefaultMaxClients is the default maximum number of monitored clients.
 const DefaultMaxClients = 10000
@@ -45,6 +65,11 @@ type Handler struct {
 	// SM_MON returns STAT_FAIL if this limit is reached.
 	maxClients int
 
+	// dispatcher relays inbound SM_NOTIFY to local monitors. If nil, the
+	// relay is disabled (security gates still run) — useful for tests and for
+	// deployments that do not consume inbound notifications.
+	dispatcher notifyDispatcher
+
 	// peerStateMu guards peerState.
 	peerStateMu sync.Mutex
 
@@ -80,6 +105,11 @@ type HandlerConfig struct {
 	// MaxClients limits monitored clients (default: 10000).
 	// SM_MON returns STAT_FAIL when this limit is exceeded.
 	MaxClients int
+
+	// Dispatcher relays inbound SM_NOTIFY callbacks to local monitors
+	// (optional). If nil, inbound NOTIFY is validated but not relayed.
+	// Normally a *callback.Client.
+	Dispatcher notifyDispatcher
 }
 
 // NewHandler creates a new NSM handler.
@@ -101,12 +131,18 @@ func NewHandler(config HandlerConfig) *Handler {
 	if config.InitialState == 0 {
 		config.InitialState = 1 // Default: odd = up
 	}
+	if config.Dispatcher == nil {
+		// Default to a real callback client so the inbound NOTIFY relay works
+		// out of the box. Tests inject a fake dispatcher via config.
+		config.Dispatcher = callback.NewClient(0)
+	}
 
 	h := &Handler{
 		tracker:     config.Tracker,
 		clientStore: config.ClientStore,
 		serverName:  config.ServerName,
 		maxClients:  config.MaxClients,
+		dispatcher:  config.Dispatcher,
 		peerState:   make(map[string]int32),
 	}
 	h.serverState.Store(config.InitialState)

--- a/internal/adapter/nfs/nsm/handlers/notify.go
+++ b/internal/adapter/nfs/nsm/handlers/notify.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"net"
+	"sync"
+	"sync/atomic"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // Notify handles NSM NOTIFY (X/Open NSM, SM procedure 6).
@@ -80,18 +83,112 @@ func (h *Handler) Notify(ctx *NSMHandlerContext, data []byte) (*HandlerResult, e
 		"mon_name", statChge.MonName,
 		"new_state", statChge.State)
 
-	// Relay / lock-recovery dispatch is intentionally NOT implemented here.
-	//
-	// This PR establishes the security gates (above) so that a future relay is
-	// safe by construction: any relay implementation MUST run only after BOTH
-	// gates have passed. When the relay ships it should, for the validated
-	// mon_name:
-	//   1. find local registrations monitoring this host,
-	//   2. send SM_NOTIFY callbacks to those clients, and
-	//   3. release the rebooted host's stale NLM locks,
-	// all gated by the checks performed above.
+	// Both gates passed: relay the state change to every local monitor that
+	// registered (via SM_MON) for this mon_name. Each callback carries the
+	// monitor's own stored priv data so its lock manager (lockd/NLM) can
+	// reclaim or release the rebooted host's locks. Lock release proper is the
+	// callback recipient's responsibility, not ours.
+	h.dispatchNotify(ctx, statChge.MonName, statChge.State)
 
 	return ack, nil
+}
+
+// dispatchNotify sends an SM_NOTIFY callback to every local registration that
+// monitors monName. It runs ONLY after both H16 and H17 gates have passed.
+//
+// For each matching registration it builds a status carrying:
+//   - mon_name = the rebooted peer (monName), so the recipient knows whose
+//     locks to reclaim;
+//   - state    = the new peer state from the notification;
+//   - priv     = the registration's own 16-byte priv from SM_MON, returned
+//     unchanged so the recipient can correlate recovery context.
+//
+// The callback uses the prog/vers/proc the monitor supplied at SM_MON time.
+// Success and failure are counted and logged for observability; a failed
+// callback never aborts the remaining ones. With no dispatcher configured the
+// relay is a no-op (gates already enforced).
+func (h *Handler) dispatchNotify(ctx *NSMHandlerContext, monName string, state int32) {
+	if h.dispatcher == nil {
+		logger.Debug("NSM NOTIFY relay skipped: no dispatcher configured",
+			"mon_name", monName)
+		return
+	}
+
+	targets := h.monitorsFor(monName)
+	if len(targets) == 0 {
+		// Gate 1 guaranteed at least one registration matched mon_name; a zero
+		// count here means it was unregistered between the gate and now.
+		logger.Debug("NSM NOTIFY relay: no current monitors", "mon_name", monName)
+		return
+	}
+
+	// Fire callbacks in parallel: each Send carries its own (up to 5s) timeout,
+	// so serial dispatch would let one slow monitor stall the rest. This
+	// mirrors Notifier.NotifyAllClients.
+	var (
+		wg           sync.WaitGroup
+		sent, failed atomic.Int64
+		attempted    int
+	)
+	for _, reg := range targets {
+		if reg.CallbackInfo == nil {
+			// No callback target recorded; nothing to send to.
+			continue
+		}
+		attempted++
+		wg.Add(1)
+		go func(reg *lock.ClientRegistration) {
+			defer wg.Done()
+			status := &types.Status{
+				MonName: monName,
+				State:   state,
+				Priv:    reg.Priv,
+			}
+			err := h.dispatcher.Send(
+				ctx.Context,
+				reg.CallbackInfo.Hostname,
+				status,
+				reg.CallbackInfo.Proc,
+				reg.CallbackInfo.Program,
+				reg.CallbackInfo.Version,
+			)
+			if err != nil {
+				failed.Add(1)
+				logger.Warn("NSM NOTIFY callback failed",
+					"mon_name", monName,
+					"client_id", reg.ClientID,
+					"callback_host", reg.CallbackInfo.Hostname,
+					"error", err)
+				return
+			}
+			sent.Add(1)
+			logger.Debug("NSM NOTIFY callback sent",
+				"mon_name", monName,
+				"client_id", reg.ClientID,
+				"callback_host", reg.CallbackInfo.Hostname)
+		}(reg)
+	}
+	wg.Wait()
+
+	logger.Info("NSM NOTIFY relayed",
+		"mon_name", monName,
+		"new_state", state,
+		"monitors", attempted,
+		"sent", sent.Load(),
+		"failed", failed.Load())
+}
+
+// monitorsFor returns all local registrations monitoring monName. It mirrors
+// the membership half of the H16 gate (mon_name match) over the tracker's
+// snapshot of NSM clients.
+func (h *Handler) monitorsFor(monName string) []*lock.ClientRegistration {
+	var matches []*lock.ClientRegistration
+	for _, reg := range h.tracker.GetNSMClients() {
+		if reg.MonName == monName {
+			matches = append(matches, reg)
+		}
+	}
+	return matches
 }
 
 // isMonitoredFromSource enforces the H16 gate. It returns true only when:

--- a/internal/adapter/nfs/nsm/handlers/notify_test.go
+++ b/internal/adapter/nfs/nsm/handlers/notify_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
@@ -11,14 +13,52 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// newTestHandler builds a Handler backed by a real ConnectionTracker.
-func newTestHandler(t *testing.T) *Handler {
+// recordedCall captures one SM_NOTIFY callback fired by the relay.
+type recordedCall struct {
+	addr   string
+	status *types.Status
+	proc   uint32
+	prog   uint32
+	vers   uint32
+}
+
+// fakeDispatcher records every callback the handler relays and can be told to
+// fail, so tests exercise dispatch without real sockets.
+type fakeDispatcher struct {
+	mu    sync.Mutex
+	calls []recordedCall
+	// failAddrs maps a callback hostname to the error Send should return.
+	failAddrs map[string]error
+}
+
+func (f *fakeDispatcher) Send(_ context.Context, addr string, status *types.Status, proc, prog, vers uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, recordedCall{addr: addr, status: status, proc: proc, prog: prog, vers: vers})
+	if err, ok := f.failAddrs[addr]; ok {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeDispatcher) recorded() []recordedCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]recordedCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// newTestHandler builds a Handler backed by a real ConnectionTracker and the
+// given dispatcher (nil disables the relay).
+func newTestHandler(t *testing.T, dispatcher notifyDispatcher) *Handler {
 	t.Helper()
 	tracker := lock.NewConnectionTracker(lock.DefaultConnectionTrackerConfig())
 	t.Cleanup(tracker.Close)
 	return NewHandler(HandlerConfig{
 		Tracker:    tracker,
 		ServerName: "test-server",
+		Dispatcher: dispatcher,
 	})
 }
 
@@ -111,7 +151,7 @@ func TestEncodeStatChge_RoundTrips(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNotify_UnmonitoredHost_Ignored(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	// No SM_MON for "ghost.example".
 	notify(t, h, "10.0.0.9:55000", "ghost.example", 5)
 
@@ -121,7 +161,7 @@ func TestNotify_UnmonitoredHost_Ignored(t *testing.T) {
 }
 
 func TestNotify_SourceAddrMismatch_Rejected(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	// We monitor peer.example as seen from 10.0.0.5.
 	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
 
@@ -134,7 +174,7 @@ func TestNotify_SourceAddrMismatch_Rejected(t *testing.T) {
 }
 
 func TestNotify_MonitoredHostRightAddr_Accepted(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
 
 	// Legitimate NOTIFY: monitored mon_name, matching source IP (ephemeral
@@ -152,7 +192,7 @@ func TestNotify_MonitoredHostRightAddr_Accepted(t *testing.T) {
 
 // isMonitoredFromSource focused unit coverage.
 func TestIsMonitoredFromSource(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	monitor(t, h, "192.168.1.10:700", "host-a", "host-a")
 
 	if !h.isMonitoredFromSource("host-a", "192.168.1.10:40000") {
@@ -174,7 +214,7 @@ func TestIsMonitoredFromSource(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNotify_Monotonicity_OnlyHigherActs(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
 
 	// First NOTIFY at state 5 -> accepted, recorded.
@@ -203,7 +243,7 @@ func TestNotify_Monotonicity_OnlyHigherActs(t *testing.T) {
 }
 
 func TestAdmitPeerState(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 
 	if !h.admitPeerState("p", 1) {
 		t.Error("first state should be admitted")
@@ -227,7 +267,7 @@ func TestAdmitPeerState(t *testing.T) {
 // the monotonicity gate sits AFTER the address gate, so a monitored host
 // replaying an old state still does nothing.
 func TestNotify_MonitoredReplay_NoOp(t *testing.T) {
-	h := newTestHandler(t)
+	h := newTestHandler(t, &fakeDispatcher{})
 	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
 
 	notify(t, h, "10.0.0.5:40001", "peer.example", 9)
@@ -235,5 +275,140 @@ func TestNotify_MonitoredReplay_NoOp(t *testing.T) {
 
 	if got, _ := recordedState(h, "peer.example"); got != 9 {
 		t.Fatalf("monitored replay must be a no-op; got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Relay dispatch (#218)
+// ---------------------------------------------------------------------------
+
+// monitorWithCallback registers a monitor with an explicit callback host and
+// priv, so dispatch targets and payloads can be asserted.
+func monitorWithCallback(t *testing.T, h *Handler, clientAddr, monName, callbackHost string, priv [16]byte) {
+	t.Helper()
+	mon := &types.Mon{
+		MonID: types.MonID{
+			MonName: monName,
+			MyID: types.MyID{
+				MyName: callbackHost,
+				MyProg: 100021,
+				MyVers: 4,
+				MyProc: 23,
+			},
+		},
+		Priv: priv,
+	}
+	data := encodeMon(t, mon)
+	ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: clientAddr}
+	if _, err := h.Mon(ctx, data); err != nil {
+		t.Fatalf("Mon failed: %v", err)
+	}
+}
+
+// A NOTIFY passing both gates relays a callback to every local monitor of that
+// mon_name, each carrying its own priv and the rebooted peer's mon_name/state.
+func TestNotify_DispatchesToAllMonitors(t *testing.T) {
+	fd := &fakeDispatcher{}
+	h := newTestHandler(t, fd)
+
+	privA := [16]byte{1, 2, 3}
+	privB := [16]byte{9, 9, 9}
+	// Two distinct local clients both monitor peer.example from the same host.
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", privA)
+	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", "client-b", privB)
+	// A third client monitors a different host — must NOT be notified.
+	monitorWithCallback(t, h, "10.0.0.5:603", "other.example", "client-c", [16]byte{7})
+
+	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
+
+	calls := fd.recorded()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 callbacks, got %d", len(calls))
+	}
+
+	byAddr := map[string]recordedCall{}
+	for _, c := range calls {
+		byAddr[c.addr] = c
+		if c.status.MonName != "peer.example" {
+			t.Errorf("callback to %s: mon_name = %q, want peer.example", c.addr, c.status.MonName)
+		}
+		if c.status.State != 5 {
+			t.Errorf("callback to %s: state = %d, want 5", c.addr, c.status.State)
+		}
+		if c.proc != 23 || c.prog != 100021 || c.vers != 4 {
+			t.Errorf("callback to %s: prog/vers/proc = %d/%d/%d, want 100021/4/23", c.addr, c.prog, c.vers, c.proc)
+		}
+	}
+	if _, ok := byAddr["client-c"]; ok {
+		t.Fatal("client-c monitors a different host and must not receive a callback")
+	}
+	if got := byAddr["client-a"].status.Priv; got != privA {
+		t.Errorf("client-a priv = %v, want %v", got, privA)
+	}
+	if got := byAddr["client-b"].status.Priv; got != privB {
+		t.Errorf("client-b priv = %v, want %v", got, privB)
+	}
+}
+
+// A NOTIFY that fails the H16 gate must produce zero dispatch (no side effects).
+func TestNotify_GateH16Fail_NoDispatch(t *testing.T) {
+	fd := &fakeDispatcher{}
+	h := newTestHandler(t, fd)
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+
+	// Wrong source IP -> H16 fails.
+	notify(t, h, "10.0.0.66:55000", "peer.example", 5)
+
+	if calls := fd.recorded(); len(calls) != 0 {
+		t.Fatalf("H16 failure must not dispatch; got %d callbacks", len(calls))
+	}
+}
+
+// A NOTIFY that fails the H17 gate (replay/stale) must produce zero new
+// dispatch beyond the first admitted notification.
+func TestNotify_GateH17Fail_NoDispatch(t *testing.T) {
+	fd := &fakeDispatcher{}
+	h := newTestHandler(t, fd)
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+
+	notify(t, h, "10.0.0.5:40001", "peer.example", 5) // admitted -> 1 callback
+	notify(t, h, "10.0.0.5:40002", "peer.example", 5) // replay -> no callback
+	notify(t, h, "10.0.0.5:40003", "peer.example", 3) // stale -> no callback
+
+	if calls := fd.recorded(); len(calls) != 1 {
+		t.Fatalf("only the admitted NOTIFY may dispatch; got %d callbacks", len(calls))
+	}
+}
+
+// A failing callback is accounted for but does not abort the remaining ones.
+func TestNotify_CallbackFailure_DoesNotAbortOthers(t *testing.T) {
+	fd := &fakeDispatcher{failAddrs: map[string]error{"client-a": errors.New("dial timeout")}}
+	h := newTestHandler(t, fd)
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", "client-b", [16]byte{})
+
+	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
+
+	calls := fd.recorded()
+	if len(calls) != 2 {
+		t.Fatalf("both monitors must be attempted despite one failure; got %d", len(calls))
+	}
+	// Gate state must still advance even though one callback failed.
+	if got, ok := recordedState(h, "peer.example"); !ok || got != 5 {
+		t.Fatalf("peer state must advance to 5; got %d (recorded=%v)", got, ok)
+	}
+}
+
+// With no dispatcher configured the relay is a no-op, but the gates still run
+// and state is still recorded.
+func TestNotify_NilDispatcher_NoOpButGatesRun(t *testing.T) {
+	h := newTestHandler(t, &fakeDispatcher{})
+	h.dispatcher = nil // explicitly disable the relay (same-package access)
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+
+	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
+
+	if got, ok := recordedState(h, "peer.example"); !ok || got != 5 {
+		t.Fatalf("gates must still run without a dispatcher; state=%d ok=%v", got, ok)
 	}
 }


### PR DESCRIPTION
## Summary

Implements the inbound SM_NOTIFY relay for NSM, addressing #218. Previously `notify.go` validated each notification through both security gates but then **dropped** it ("Relay / lock-recovery dispatch is intentionally NOT implemented here").

Now, after a NOTIFY passes **both** gates, the handler:

1. **Finds all local registrations** where `MonName` matches the notification's `mon_name` (`monitorsFor`).
2. **Sends an SM_NOTIFY callback to each**, carrying the registration's own stored 16-byte `priv` and the rebooted peer's `mon_name`/`state`, using the `prog`/`vers`/`proc` the client supplied at SM_MON time (matches `rpc.statd`/lockd semantics — the recipient's lock manager reclaims/frees the rebooted host's locks).
3. **Tracks callback success/failure** for observability (structured logs: per-callback `Warn`/`Debug` + a summary `Info` line with `monitors`/`sent`/`failed`).

The outbound-callback RPC infrastructure already existed (`internal/adapter/nfs/nsm/callback` — `Client.Send` builds and frames the RPC over a fresh TCP connection); this is a wiring job, not a new subsystem. Callbacks fire **in parallel** (mirroring `Notifier.NotifyAllClients`) so one slow/unreachable monitor — each `Send` has a 5s timeout — can't stall the others.

## Security gates preserved (no regression)

Dispatch runs **strictly after** both gates pass. A NOTIFY failing H16 (monitored-list + source-address) or H17 (state monotonicity) produces **zero** callbacks and no state mutation — covered by new tests. The relay is injected via a narrow `notifyDispatcher` interface (default: real `callback.Client`; nil disables relay while keeping the gates).

## Tests

New unit tests in `notify_test.go`:
- `TestNotify_DispatchesToAllMonitors` — dispatch to N matching monitors; non-matching mon_name excluded; per-registration priv + correct mon_name/state/prog/vers/proc.
- `TestNotify_GateH16Fail_NoDispatch` / `TestNotify_GateH17Fail_NoDispatch` — failing gates ⇒ zero dispatch.
- `TestNotify_CallbackFailure_DoesNotAbortOthers` — one failed callback is accounted for, others still fire, state still advances.
- `TestNotify_NilDispatcher_NoOpButGatesRun` — relay is a no-op without a dispatcher, gates still run.

`go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), and `go test -race ./internal/adapter/nfs/nsm/...` all green.

## Scope note

DittoFS is documented single-node; this relay primarily matters for multi-server NFS lock recovery. The NSM dispatch path is not yet wired into the live server (`NSMHandlerContext` is constructed only in tests today), so this lands the correct, tested behavior ready for that wiring without speculative infrastructure.

Closes #218