### PR TITLE
feat: per-share NFS adapter config API for netgroup association (#220)

### DIFF
--- a/cmd/dfsctl/commands/share/nfs_config.go
+++ b/cmd/dfsctl/commands/share/nfs_config.go
@@ -1,0 +1,143 @@
+package share
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	nfsCfgNetgroup        string
+	nfsCfgSquash          string
+	nfsCfgAllowAuthSys    string
+	nfsCfgRequireKerberos string
+)
+
+// nfsConfigCmd is the parent for per-share NFS adapter config.
+var nfsConfigCmd = &cobra.Command{
+	Use:   "nfs-config",
+	Short: "Manage per-share NFS adapter configuration",
+	Long: `View and update the NFS adapter configuration for a share.
+
+This controls protocol-specific NFS export settings such as the squash mode,
+auth flavor, and the netgroup that restricts which clients may access the
+export. Netgroup changes take effect immediately; other fields apply on the
+next adapter restart.
+
+Examples:
+  # Show a share's NFS config
+  dfsctl share nfs-config show /export
+
+  # Associate a netgroup with the share's NFS export
+  dfsctl share nfs-config set /export --netgroup office-network
+
+  # Remove the netgroup association (allow all clients)
+  dfsctl share nfs-config set /export --netgroup ""`,
+}
+
+var nfsConfigShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show a share's NFS adapter configuration",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runNFSConfigShow,
+}
+
+var nfsConfigSetCmd = &cobra.Command{
+	Use:   "set <name>",
+	Short: "Update a share's NFS adapter configuration",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runNFSConfigSet,
+}
+
+func init() {
+	nfsConfigSetCmd.Flags().StringVar(&nfsCfgNetgroup, "netgroup", "", "Netgroup name to associate (empty string clears the association)")
+	nfsConfigSetCmd.Flags().StringVar(&nfsCfgSquash, "squash", "", "Squash mode (none|root|all)")
+	nfsConfigSetCmd.Flags().StringVar(&nfsCfgAllowAuthSys, "allow-auth-sys", "", "Allow AUTH_SYS flavor (true|false)")
+	nfsConfigSetCmd.Flags().StringVar(&nfsCfgRequireKerberos, "require-kerberos", "", "Require Kerberos auth (true|false)")
+
+	nfsConfigCmd.AddCommand(nfsConfigShowCmd)
+	nfsConfigCmd.AddCommand(nfsConfigSetCmd)
+}
+
+func runNFSConfigShow(_ *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := client.GetShareNFSConfig(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get NFS config: %w", err)
+	}
+
+	return cmdutil.PrintResource(os.Stdout, cfg, nil)
+}
+
+func runNFSConfigSet(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	req := &apiclient.PatchShareNFSConfigRequest{}
+	hasUpdate := false
+
+	// --netgroup is a pointer-to-string so an explicit empty value clears the
+	// association. Only act when the flag was actually provided.
+	if cmd.Flags().Changed("netgroup") {
+		ng := nfsCfgNetgroup
+		req.Netgroup = &ng
+		hasUpdate = true
+	}
+
+	if nfsCfgSquash != "" {
+		req.Squash = &nfsCfgSquash
+		hasUpdate = true
+	}
+
+	if nfsCfgAllowAuthSys != "" {
+		v, err := parseBoolFlag("allow-auth-sys", nfsCfgAllowAuthSys)
+		if err != nil {
+			return err
+		}
+		req.AllowAuthSys = &v
+		hasUpdate = true
+	}
+
+	if nfsCfgRequireKerberos != "" {
+		v, err := parseBoolFlag("require-kerberos", nfsCfgRequireKerberos)
+		if err != nil {
+			return err
+		}
+		req.RequireKerberos = &v
+		hasUpdate = true
+	}
+
+	if !hasUpdate {
+		return fmt.Errorf("no fields specified. Use --netgroup, --squash, --allow-auth-sys, or --require-kerberos")
+	}
+
+	cfg, err := client.PatchShareNFSConfig(name, req)
+	if err != nil {
+		return fmt.Errorf("failed to update NFS config: %w", err)
+	}
+
+	return cmdutil.PrintResourceWithSuccess(os.Stdout, cfg, fmt.Sprintf("NFS config for share '%s' updated successfully", name))
+}
+
+func parseBoolFlag(flag, value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("--%s: invalid value %q, must be true or false", flag, value)
+	}
+}

--- a/cmd/dfsctl/commands/share/share.go
+++ b/cmd/dfsctl/commands/share/share.go
@@ -63,4 +63,6 @@ func init() {
 
 	Cmd.AddCommand(disableCmd)
 	Cmd.AddCommand(enableCmd)
+
+	Cmd.AddCommand(nfsConfigCmd) // per-share NFS adapter config (squash, netgroup, auth)
 }

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -107,7 +107,7 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		if netgroupName == "" {
 			opts.NetgroupID = nil
 		} else {
-			ng, err := h.store.GetNetgroup(r.Context(), netgroupName)
+			id, err := h.store.GetNetgroupIDByName(r.Context(), netgroupName)
 			if err != nil {
 				if errors.Is(err, models.ErrNetgroupNotFound) {
 					BadRequest(w, "Netgroup not found: "+netgroupName)
@@ -116,7 +116,6 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 				InternalServerError(w, "Failed to resolve netgroup")
 				return
 			}
-			id := ng.ID
 			opts.NetgroupID = &id
 		}
 	}

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// ShareNFSConfigHandlerStore is the composite store interface required by
+// ShareNFSConfigHandler: share lookup, per-share adapter config persistence,
+// and netgroup name/ID resolution.
+type ShareNFSConfigHandlerStore interface {
+	store.ShareStore
+	store.NetgroupStore
+}
+
+// ShareNFSConfigHandler serves the per-share NFS adapter config endpoints
+// (GET/PATCH /api/v1/shares/{name}/adapters/nfs/config). It decouples
+// protocol-specific export settings (squash, netgroup association, auth flavor)
+// from the generic Share resource, persisting them in share_adapter_configs and
+// pushing the live netgroup association into the runtime.
+type ShareNFSConfigHandler struct {
+	store   ShareNFSConfigHandlerStore
+	runtime *runtime.Runtime
+}
+
+// NewShareNFSConfigHandler creates a new ShareNFSConfigHandler.
+func NewShareNFSConfigHandler(s ShareNFSConfigHandlerStore, rt *runtime.Runtime) *ShareNFSConfigHandler {
+	return &ShareNFSConfigHandler{store: s, runtime: rt}
+}
+
+// ShareNFSConfigResponse is the response body for the per-share NFS config
+// endpoints. Netgroup is exposed by name (empty string = no association),
+// keeping IDs internal to the storage layer.
+type ShareNFSConfigResponse struct {
+	Squash             string  `json:"squash"`
+	AnonymousUID       *uint32 `json:"anonymous_uid,omitempty"`
+	AnonymousGID       *uint32 `json:"anonymous_gid,omitempty"`
+	AllowAuthSys       bool    `json:"allow_auth_sys"`
+	RequireKerberos    bool    `json:"require_kerberos"`
+	MinKerberosLevel   string  `json:"min_kerberos_level"`
+	Netgroup           string  `json:"netgroup"`
+	DisableReaddirplus bool    `json:"disable_readdirplus"`
+}
+
+// PatchShareNFSConfigRequest is the request body for PATCH. All fields are
+// pointers so the caller can update only the fields it specifies. Netgroup is a
+// pointer-to-string: a non-nil empty string clears the association, a non-nil
+// name sets it, nil leaves it unchanged.
+type PatchShareNFSConfigRequest struct {
+	Squash             *string `json:"squash,omitempty"`
+	AnonymousUID       *uint32 `json:"anonymous_uid,omitempty"`
+	AnonymousGID       *uint32 `json:"anonymous_gid,omitempty"`
+	AllowAuthSys       *bool   `json:"allow_auth_sys,omitempty"`
+	RequireKerberos    *bool   `json:"require_kerberos,omitempty"`
+	MinKerberosLevel   *string `json:"min_kerberos_level,omitempty"`
+	Netgroup           *string `json:"netgroup,omitempty"`
+	DisableReaddirplus *bool   `json:"disable_readdirplus,omitempty"`
+}
+
+// Get handles GET /api/v1/shares/{name}/adapters/nfs/config.
+func (h *ShareNFSConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
+	share, ok := h.lookupShare(w, r)
+	if !ok {
+		return
+	}
+
+	opts, ok := h.loadOptions(w, r, share.ID)
+	if !ok {
+		return
+	}
+
+	resp, ok := h.optionsToResponse(w, r, opts)
+	if !ok {
+		return
+	}
+	WriteJSONOK(w, resp)
+}
+
+// Patch handles PATCH /api/v1/shares/{name}/adapters/nfs/config.
+func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
+	share, ok := h.lookupShare(w, r)
+	if !ok {
+		return
+	}
+
+	var req PatchShareNFSConfigRequest
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+
+	opts, ok := h.loadOptions(w, r, share.ID)
+	if !ok {
+		return
+	}
+
+	// Resolve netgroup name -> ID before mutating, so an unknown name fails the
+	// request without persisting a partial update.
+	netgroupName := ""
+	if req.Netgroup != nil {
+		netgroupName = *req.Netgroup
+		if netgroupName == "" {
+			opts.NetgroupID = nil
+		} else {
+			ng, err := h.store.GetNetgroup(r.Context(), netgroupName)
+			if err != nil {
+				if errors.Is(err, models.ErrNetgroupNotFound) {
+					BadRequest(w, "Netgroup not found: "+netgroupName)
+					return
+				}
+				InternalServerError(w, "Failed to resolve netgroup")
+				return
+			}
+			id := ng.ID
+			opts.NetgroupID = &id
+		}
+	}
+
+	if req.Squash != nil {
+		opts.Squash = *req.Squash
+	}
+	if req.AnonymousUID != nil {
+		opts.AnonymousUID = req.AnonymousUID
+	}
+	if req.AnonymousGID != nil {
+		opts.AnonymousGID = req.AnonymousGID
+	}
+	if req.AllowAuthSys != nil {
+		opts.AllowAuthSys = *req.AllowAuthSys
+	}
+	if req.RequireKerberos != nil {
+		opts.RequireKerberos = *req.RequireKerberos
+	}
+	if req.MinKerberosLevel != nil {
+		opts.MinKerberosLevel = *req.MinKerberosLevel
+	}
+	if req.DisableReaddirplus != nil {
+		opts.DisableReaddirplus = *req.DisableReaddirplus
+	}
+
+	cfg := &models.ShareAdapterConfig{ShareID: share.ID, AdapterType: "nfs"}
+	if err := cfg.SetConfig(opts); err != nil {
+		InternalServerError(w, "Failed to encode NFS config")
+		return
+	}
+	if err := h.store.SetShareAdapterConfig(r.Context(), cfg); err != nil {
+		InternalServerError(w, "Failed to persist NFS config")
+		return
+	}
+
+	// Push the netgroup association into the running share so it takes effect
+	// immediately (CheckNetgroupAccess reads NetgroupName from the runtime
+	// registry). Other NFS export fields apply on adapter restart.
+	if req.Netgroup != nil && h.runtime != nil {
+		if err := h.runtime.SetShareNetgroup(share.Name, netgroupName); err != nil {
+			logger.Warn("NFS config persisted but failed to update runtime netgroup",
+				"share", share.Name, "netgroup", netgroupName, "error", err)
+		}
+	}
+
+	resp, ok := h.optionsToResponse(w, r, opts)
+	if !ok {
+		return
+	}
+	WriteJSONOK(w, resp)
+}
+
+// lookupShare resolves the {name} path param to a stored share, writing a
+// 404/500 problem and returning ok=false on failure.
+func (h *ShareNFSConfigHandler) lookupShare(w http.ResponseWriter, r *http.Request) (*models.Share, bool) {
+	name := normalizeShareName(chi.URLParam(r, "name"))
+	share, err := h.store.GetShare(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, models.ErrShareNotFound) {
+			NotFound(w, "Share not found")
+			return nil, false
+		}
+		InternalServerError(w, "Failed to get share")
+		return nil, false
+	}
+	return share, true
+}
+
+// loadOptions returns the share's persisted NFS export options, falling back to
+// defaults when no config row exists yet.
+func (h *ShareNFSConfigHandler) loadOptions(w http.ResponseWriter, r *http.Request, shareID string) (models.NFSExportOptions, bool) {
+	opts := models.DefaultNFSExportOptions()
+	cfg, err := h.store.GetShareAdapterConfig(r.Context(), shareID, "nfs")
+	if err != nil {
+		InternalServerError(w, "Failed to get NFS config")
+		return opts, false
+	}
+	if cfg != nil {
+		if err := cfg.ParseConfig(&opts); err != nil {
+			InternalServerError(w, "Failed to parse NFS config")
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+// optionsToResponse resolves the stored netgroup ID back to a name for the
+// response payload.
+func (h *ShareNFSConfigHandler) optionsToResponse(w http.ResponseWriter, r *http.Request, opts models.NFSExportOptions) (ShareNFSConfigResponse, bool) {
+	resp := ShareNFSConfigResponse{
+		Squash:             opts.Squash,
+		AnonymousUID:       opts.AnonymousUID,
+		AnonymousGID:       opts.AnonymousGID,
+		AllowAuthSys:       opts.AllowAuthSys,
+		RequireKerberos:    opts.RequireKerberos,
+		MinKerberosLevel:   opts.MinKerberosLevel,
+		DisableReaddirplus: opts.DisableReaddirplus,
+	}
+	if opts.NetgroupID != nil && *opts.NetgroupID != "" {
+		ng, err := h.store.GetNetgroupByID(r.Context(), *opts.NetgroupID)
+		if err != nil {
+			if errors.Is(err, models.ErrNetgroupNotFound) {
+				// Dangling reference (netgroup deleted out from under the
+				// config) — report empty rather than failing the read.
+				logger.Warn("Share NFS config references unknown netgroup",
+					"netgroup_id", *opts.NetgroupID)
+				return resp, true
+			}
+			InternalServerError(w, "Failed to resolve netgroup")
+			return resp, false
+		}
+		resp.Netgroup = ng.Name
+	}
+	return resp, true
+}

--- a/internal/controlplane/api/handlers/share_adapter_config_test.go
+++ b/internal/controlplane/api/handlers/share_adapter_config_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// setupShareNFSConfigTest builds a GORM sqlite store with one share and returns
+// a handler (runtime nil — the handler tolerates a nil runtime, persistence is
+// still exercised).
+func setupShareNFSConfigTest(t *testing.T) (*store.GORMStore, *ShareNFSConfigHandler, string) {
+	t.Helper()
+
+	cpStore, err := store.New(&store.Config{
+		Type:   "sqlite",
+		SQLite: store.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	ctx := context.Background()
+
+	metaStore := &models.MetadataStoreConfig{ID: uuid.New().String(), Name: "m", Type: "memory"}
+	if _, err := cpStore.CreateMetadataStore(ctx, metaStore); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	localBlockStore := &models.BlockStoreConfig{ID: uuid.New().String(), Name: "l", Kind: models.BlockStoreKindLocal, Type: "fs"}
+	if _, err := cpStore.CreateBlockStore(ctx, localBlockStore); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	share := &models.Share{
+		ID:                uuid.New().String(),
+		Name:              "/export",
+		MetadataStoreID:   metaStore.ID,
+		LocalBlockStoreID: localBlockStore.ID,
+		CreatedAt:         time.Now(),
+	}
+	if _, err := cpStore.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+
+	handler := NewShareNFSConfigHandler(struct {
+		store.ShareStore
+		store.NetgroupStore
+	}{cpStore, cpStore}, nil)
+
+	return cpStore, handler, share.ID
+}
+
+// doRequest runs a request against a handler func and returns the recorder.
+func doRequest(t *testing.T, h func(http.ResponseWriter, *http.Request), method, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, "/api/v1/shares/export/adapters/nfs/config", nil)
+	} else {
+		r = httptest.NewRequest(method, "/api/v1/shares/export/adapters/nfs/config", bytes.NewReader([]byte(body)))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "export")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h(w, r)
+	return w
+}
+
+func TestShareNFSConfig_GetDefaults(t *testing.T) {
+	_, handler, _ := setupShareNFSConfigTest(t)
+
+	w := doRequest(t, handler.Get, http.MethodGet, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("Get() status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp ShareNFSConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Netgroup != "" {
+		t.Errorf("default Netgroup = %q, want empty", resp.Netgroup)
+	}
+	if !resp.AllowAuthSys {
+		t.Errorf("default AllowAuthSys = false, want true")
+	}
+}
+
+func TestShareNFSConfig_GetShareNotFound(t *testing.T) {
+	_, handler, _ := setupShareNFSConfigTest(t)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/shares/missing/adapters/nfs/config", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "missing")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.Get(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Get(missing share) status = %d, want 404", w.Code)
+	}
+}
+
+func TestShareNFSConfig_PatchAssociatesNetgroup(t *testing.T) {
+	cpStore, handler, shareID := setupShareNFSConfigTest(t)
+	ctx := context.Background()
+
+	if _, err := cpStore.CreateNetgroup(ctx, &models.Netgroup{Name: "office"}); err != nil {
+		t.Fatalf("CreateNetgroup: %v", err)
+	}
+
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"netgroup":"office"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Patch() status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp ShareNFSConfigResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Netgroup != "office" {
+		t.Errorf("Netgroup = %q, want office", resp.Netgroup)
+	}
+
+	// Verify persistence: stored config holds the netgroup ID.
+	cfg, err := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	if err != nil || cfg == nil {
+		t.Fatalf("GetShareAdapterConfig: cfg=%v err=%v", cfg, err)
+	}
+	var opts models.NFSExportOptions
+	if err := cfg.ParseConfig(&opts); err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if opts.NetgroupID == nil || *opts.NetgroupID == "" {
+		t.Errorf("persisted NetgroupID = %v, want non-empty", opts.NetgroupID)
+	}
+}
+
+func TestShareNFSConfig_PatchClearsNetgroup(t *testing.T) {
+	cpStore, handler, shareID := setupShareNFSConfigTest(t)
+	ctx := context.Background()
+
+	ngID, _ := cpStore.CreateNetgroup(ctx, &models.Netgroup{Name: "office"})
+	opts := models.DefaultNFSExportOptions()
+	opts.NetgroupID = &ngID
+	cfg := &models.ShareAdapterConfig{ShareID: shareID, AdapterType: "nfs"}
+	cfg.SetConfig(opts)
+	cpStore.SetShareAdapterConfig(ctx, cfg)
+
+	// Clear via explicit empty string.
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"netgroup":""}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Patch(clear) status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp ShareNFSConfigResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Netgroup != "" {
+		t.Errorf("Netgroup = %q, want empty after clear", resp.Netgroup)
+	}
+
+	stored, _ := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	var storedOpts models.NFSExportOptions
+	stored.ParseConfig(&storedOpts)
+	if storedOpts.NetgroupID != nil {
+		t.Errorf("persisted NetgroupID = %v, want nil after clear", storedOpts.NetgroupID)
+	}
+}
+
+func TestShareNFSConfig_PatchUnknownNetgroup(t *testing.T) {
+	_, handler, _ := setupShareNFSConfigTest(t)
+
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"netgroup":"does-not-exist"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Patch(unknown netgroup) status = %d, want 400, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestShareNFSConfig_PatchOtherFields(t *testing.T) {
+	cpStore, handler, shareID := setupShareNFSConfigTest(t)
+	ctx := context.Background()
+
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"squash":"all","allow_auth_sys":false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Patch() status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+
+	cfg, _ := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	var opts models.NFSExportOptions
+	cfg.ParseConfig(&opts)
+	if opts.Squash != "all" {
+		t.Errorf("Squash = %q, want all", opts.Squash)
+	}
+	if opts.AllowAuthSys {
+		t.Errorf("AllowAuthSys = true, want false")
+	}
+}

--- a/internal/controlplane/api/handlers/share_adapter_config_test.go
+++ b/internal/controlplane/api/handlers/share_adapter_config_test.go
@@ -126,7 +126,9 @@ func TestShareNFSConfig_PatchAssociatesNetgroup(t *testing.T) {
 	}
 
 	var resp ShareNFSConfigResponse
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 	if resp.Netgroup != "office" {
 		t.Errorf("Netgroup = %q, want office", resp.Netgroup)
 	}
@@ -149,12 +151,19 @@ func TestShareNFSConfig_PatchClearsNetgroup(t *testing.T) {
 	cpStore, handler, shareID := setupShareNFSConfigTest(t)
 	ctx := context.Background()
 
-	ngID, _ := cpStore.CreateNetgroup(ctx, &models.Netgroup{Name: "office"})
+	ngID, err := cpStore.CreateNetgroup(ctx, &models.Netgroup{Name: "office"})
+	if err != nil {
+		t.Fatalf("CreateNetgroup: %v", err)
+	}
 	opts := models.DefaultNFSExportOptions()
 	opts.NetgroupID = &ngID
 	cfg := &models.ShareAdapterConfig{ShareID: shareID, AdapterType: "nfs"}
-	cfg.SetConfig(opts)
-	cpStore.SetShareAdapterConfig(ctx, cfg)
+	if err := cfg.SetConfig(opts); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := cpStore.SetShareAdapterConfig(ctx, cfg); err != nil {
+		t.Fatalf("SetShareAdapterConfig: %v", err)
+	}
 
 	// Clear via explicit empty string.
 	w := doRequest(t, handler.Patch, http.MethodPatch, `{"netgroup":""}`)
@@ -163,14 +172,21 @@ func TestShareNFSConfig_PatchClearsNetgroup(t *testing.T) {
 	}
 
 	var resp ShareNFSConfigResponse
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 	if resp.Netgroup != "" {
 		t.Errorf("Netgroup = %q, want empty after clear", resp.Netgroup)
 	}
 
-	stored, _ := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	stored, err := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	if err != nil || stored == nil {
+		t.Fatalf("GetShareAdapterConfig: cfg=%v err=%v", stored, err)
+	}
 	var storedOpts models.NFSExportOptions
-	stored.ParseConfig(&storedOpts)
+	if err := stored.ParseConfig(&storedOpts); err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
 	if storedOpts.NetgroupID != nil {
 		t.Errorf("persisted NetgroupID = %v, want nil after clear", storedOpts.NetgroupID)
 	}
@@ -194,9 +210,14 @@ func TestShareNFSConfig_PatchOtherFields(t *testing.T) {
 		t.Fatalf("Patch() status = %d, want 200, body = %s", w.Code, w.Body.String())
 	}
 
-	cfg, _ := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	cfg, err := cpStore.GetShareAdapterConfig(ctx, shareID, "nfs")
+	if err != nil || cfg == nil {
+		t.Fatalf("GetShareAdapterConfig: cfg=%v err=%v", cfg, err)
+	}
 	var opts models.NFSExportOptions
-	cfg.ParseConfig(&opts)
+	if err := cfg.ParseConfig(&opts); err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
 	if opts.Squash != "all" {
 		t.Errorf("Squash = %q, want all", opts.Squash)
 	}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -135,6 +135,33 @@ type UpdateShareRequest struct {
 	TrashExcludePatterns []string `json:"trash_exclude_patterns,omitempty"`
 }
 
+// ShareNFSConfig represents the per-share NFS adapter configuration. Netgroup
+// is exposed by name (empty = no association).
+type ShareNFSConfig struct {
+	Squash             string  `json:"squash"`
+	AnonymousUID       *uint32 `json:"anonymous_uid,omitempty"`
+	AnonymousGID       *uint32 `json:"anonymous_gid,omitempty"`
+	AllowAuthSys       bool    `json:"allow_auth_sys"`
+	RequireKerberos    bool    `json:"require_kerberos"`
+	MinKerberosLevel   string  `json:"min_kerberos_level"`
+	Netgroup           string  `json:"netgroup"`
+	DisableReaddirplus bool    `json:"disable_readdirplus"`
+}
+
+// PatchShareNFSConfigRequest is the request to update a share's NFS adapter
+// config. All fields are optional; nil leaves the field unchanged. Netgroup is
+// a pointer-to-string: a non-nil empty string clears the association.
+type PatchShareNFSConfigRequest struct {
+	Squash             *string `json:"squash,omitempty"`
+	AnonymousUID       *uint32 `json:"anonymous_uid,omitempty"`
+	AnonymousGID       *uint32 `json:"anonymous_gid,omitempty"`
+	AllowAuthSys       *bool   `json:"allow_auth_sys,omitempty"`
+	RequireKerberos    *bool   `json:"require_kerberos,omitempty"`
+	MinKerberosLevel   *string `json:"min_kerberos_level,omitempty"`
+	Netgroup           *string `json:"netgroup,omitempty"`
+	DisableReaddirplus *bool   `json:"disable_readdirplus,omitempty"`
+}
+
 // SharePermission represents a permission on a share.
 type SharePermission struct {
 	Type  string `json:"type"`  // "user" or "group"
@@ -177,6 +204,24 @@ func (c *Client) UpdateShare(name string, req *UpdateShareRequest) (*Share, erro
 // DeleteShare deletes a share.
 func (c *Client) DeleteShare(name string) error {
 	return deleteResource(c, fmt.Sprintf("/api/v1/shares/%s", url.PathEscape(normalizeShareNameForAPI(name))))
+}
+
+// GetShareNFSConfig returns the per-share NFS adapter configuration.
+func (c *Client) GetShareNFSConfig(name string) (*ShareNFSConfig, error) {
+	var cfg ShareNFSConfig
+	if err := c.get(fmt.Sprintf("/api/v1/shares/%s/adapters/nfs/config", url.PathEscape(normalizeShareNameForAPI(name))), &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// PatchShareNFSConfig updates the per-share NFS adapter configuration.
+func (c *Client) PatchShareNFSConfig(name string, req *PatchShareNFSConfigRequest) (*ShareNFSConfig, error) {
+	var cfg ShareNFSConfig
+	if err := c.patch(fmt.Sprintf("/api/v1/shares/%s/adapters/nfs/config", url.PathEscape(normalizeShareNameForAPI(name))), req, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
 }
 
 // ListSharePermissions returns permissions for a share.

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -220,6 +220,20 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 					r.Get("/status", trashHandler.Status)
 				})
 
+				// Per-share NFS adapter config (squash, netgroup association,
+				// auth flavor). Requires NetgroupStore capability for
+				// name<->ID resolution.
+				if ns, ok := cpStore.(store.NetgroupStore); ok {
+					nfsCfgHandler := handlers.NewShareNFSConfigHandler(struct {
+						store.ShareStore
+						store.NetgroupStore
+					}{cpStore, ns}, rt)
+					r.Route("/{name}/adapters/nfs/config", func(r chi.Router) {
+						r.Get("/", nfsCfgHandler.Get)
+						r.Patch("/", nfsCfgHandler.Patch)
+					})
+				}
+
 				// Share permissions
 				r.Get("/{name}/permissions", shareHandler.ListPermissions)
 				r.Put("/{name}/permissions/users/{username}", shareHandler.SetUserPermission)

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -118,7 +118,12 @@ func (c *dnsCache) cleanExpiredLocked(now time.Time) {
 // 5-minute positive TTL and 1-minute negative TTL. Falls back to IP matching
 // if DNS lookup fails (does not block).
 func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, clientIP net.IP) (bool, error) {
-	// 1. Get share from runtime state.
+	// 1. Get the share's netgroup association from runtime state.
+	//
+	// Read NetgroupName via the locked accessor rather than off a *Share
+	// returned by GetShare: GetShare hands back the shared registry pointer
+	// with the lock already dropped, so reading the field there would race
+	// SetShareNetgroup's write under the same lock.
 	//
 	// A lookup miss here (unknown / renamed / partially-loaded share) is NOT a
 	// legitimate netgroup deny: it signals config drift between the requested
@@ -126,15 +131,16 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 	// indistinguishable from "client not in allowlist" and silently invisible.
 	// Surface it as a wrapped ErrShareNotFound so it is diagnosable while still
 	// denying access (the mount handler treats any error as fail-closed).
-	share, err := r.sharesSvc.GetShare(shareName)
-	if err != nil {
+	netgroupName, exists := r.sharesSvc.GetShareNetgroupName(shareName)
+	if !exists {
+		err := fmt.Errorf("%w: %q", shares.ErrShareNotFound, shareName)
 		logger.Warn("Netgroup access denied: share not found in runtime registry",
 			"share", shareName, "error", err)
-		return false, fmt.Errorf("%w: %q: %w", shares.ErrShareNotFound, shareName, err)
+		return false, err
 	}
 
 	// 2. If share has no netgroup -> allow all
-	if share.NetgroupName == "" {
+	if netgroupName == "" {
 		return true, nil
 	}
 
@@ -143,15 +149,15 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 	if !ok {
 		logger.Warn("Store does not implement NetgroupStore, denying access",
 			"share", shareName,
-			"netgroup", share.NetgroupName)
+			"netgroup", netgroupName)
 		return false, fmt.Errorf("store does not support netgroup operations")
 	}
 
-	members, err := ns.GetNetgroupMembers(ctx, share.NetgroupName)
+	members, err := ns.GetNetgroupMembers(ctx, netgroupName)
 	if err != nil {
 		logger.Warn("Failed to get netgroup members, denying access",
 			"share", shareName,
-			"netgroup", share.NetgroupName,
+			"netgroup", netgroupName,
 			"error", err)
 		return false, err
 	}

--- a/pkg/controlplane/runtime/netgroups_test.go
+++ b/pkg/controlplane/runtime/netgroups_test.go
@@ -313,6 +313,47 @@ func TestCheckNetgroupAccess_NetgroupNotFound(t *testing.T) {
 	}
 }
 
+// TestCheckNetgroupAccess_ConcurrentSetShareNetgroup is the Copilot data-race
+// regression. SetShareNetgroup writes share.NetgroupName under the shares
+// service lock, while CheckNetgroupAccess previously read the same field off a
+// pointer returned by GetShare with the lock already dropped. The two ran
+// concurrently on every NFS request that overlapped a PATCH, a genuine
+// read/write race. Run with -race to detect it; the fix routes the read
+// through the locked GetShareNetgroupName accessor.
+func TestCheckNetgroupAccess_ConcurrentSetShareNetgroup(t *testing.T) {
+	rt, _, _ := createTestRuntimeWithStore(t)
+	ctx := context.Background()
+
+	addShareDirect(rt, "/export", "")
+
+	const iterations = 200
+	done := make(chan struct{})
+
+	// Writer: flip the netgroup association back and forth.
+	go func() {
+		defer close(done)
+		for i := 0; i < iterations; i++ {
+			ng := ""
+			if i%2 == 0 {
+				ng = "office"
+			}
+			if err := rt.SetShareNetgroup("/export", ng); err != nil {
+				t.Errorf("SetShareNetgroup: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Reader: hammer CheckNetgroupAccess concurrently. The netgroup name may
+	// or may not resolve to a stored group; we only care that the field read
+	// is race-free, so errors here are expected and ignored.
+	for i := 0; i < iterations; i++ {
+		_, _ = rt.CheckNetgroupAccess(ctx, "/export", net.ParseIP("192.168.1.100"))
+	}
+
+	<-done
+}
+
 // --- matchHostname tests ---
 // matchHostname is now a package-level function that uses the package-level DNS cache.
 // We test it by pre-populating the DNS cache to avoid real DNS lookups.

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -430,6 +430,13 @@ func (r *Runtime) SetShareTrashConfig(name string, cfg shares.TrashSettings) err
 	return r.sharesSvc.SetShareTrashConfig(r.store, name, cfg)
 }
 
+// SetShareNetgroup updates the live netgroup association for a share's NFS
+// export. An empty netgroupName clears the association (allow-all). Takes
+// effect immediately for subsequent CheckNetgroupAccess calls.
+func (r *Runtime) SetShareNetgroup(name, netgroupName string) error {
+	return r.sharesSvc.SetShareNetgroup(name, netgroupName)
+}
+
 // DisableShare sets enabled=false on the share's DB row and runtime
 // registry, then notifies adapters so active sessions drop.
 // Idempotent on already-disabled shares (returns shares.ErrShareAlreadyDisabled

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1097,6 +1097,23 @@ func (s *Service) SetShareNetgroup(name, netgroupName string) error {
 	return nil
 }
 
+// GetShareNetgroupName returns the live netgroup association for a share,
+// read under s.mu. Callers (e.g. CheckNetgroupAccess) must use this rather
+// than reading NetgroupName off a *Share returned by GetShare: GetShare hands
+// back the shared registry pointer with the lock already dropped, so reading
+// the field there races with SetShareNetgroup's write under s.mu. The bool is
+// false when the share is unknown.
+func (s *Service) GetShareNetgroupName(name string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	share, exists := s.registry[name]
+	if !exists {
+		return "", false
+	}
+	return share.NetgroupName, true
+}
+
 // DisableShare sets enabled=false on the share's DB row and runtime Share
 // struct, then invokes notifyShareChange so adapters drop active sessions.
 // DB-first-then-runtime ordering is crash-consistent: if the process dies

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1080,6 +1080,23 @@ func (s *Service) SetShareTrashConfig(store ShareStore, name string, cfg TrashSe
 	return nil
 }
 
+// SetShareNetgroup updates the live netgroup association for a share's NFS
+// export. An empty netgroupName clears the association (allow-all). The change
+// takes effect immediately: CheckNetgroupAccess reads NetgroupName from this
+// runtime registry, so subsequent NFS operations honour the new allowlist
+// without an adapter restart. Returns an error if the share is unknown.
+func (s *Service) SetShareNetgroup(name, netgroupName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	share, exists := s.registry[name]
+	if !exists {
+		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
+	}
+	share.NetgroupName = netgroupName
+	return nil
+}
+
 // DisableShare sets enabled=false on the share's DB row and runtime Share
 // struct, then invokes notifyShareChange so adapters drop active sessions.
 // DB-first-then-runtime ordering is crash-consistent: if the process dies

--- a/pkg/controlplane/runtime/shares/service_test.go
+++ b/pkg/controlplane/runtime/shares/service_test.go
@@ -169,6 +169,43 @@ func TestDisableShare_DBWriteFails_RuntimeUnchanged(t *testing.T) {
 	}
 }
 
+func TestSetShareNetgroup(t *testing.T) {
+	svc, _ := makeService(t, &Share{
+		Name:          "/export",
+		MetadataStore: "meta-a",
+		Enabled:       true,
+	})
+
+	if err := svc.SetShareNetgroup("/export", "office"); err != nil {
+		t.Fatalf("SetShareNetgroup: %v", err)
+	}
+	sh, err := svc.GetShare("/export")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if sh.NetgroupName != "office" {
+		t.Errorf("NetgroupName = %q, want office", sh.NetgroupName)
+	}
+
+	// Empty name clears the association.
+	if err := svc.SetShareNetgroup("/export", ""); err != nil {
+		t.Fatalf("SetShareNetgroup(clear): %v", err)
+	}
+	sh, _ = svc.GetShare("/export")
+	if sh.NetgroupName != "" {
+		t.Errorf("NetgroupName = %q, want empty after clear", sh.NetgroupName)
+	}
+}
+
+func TestSetShareNetgroup_UnknownShare(t *testing.T) {
+	svc, _ := makeService(t)
+
+	err := svc.SetShareNetgroup("/missing", "office")
+	if !errors.Is(err, ErrShareNotFound) {
+		t.Errorf("expected ErrShareNotFound, got %v", err)
+	}
+}
+
 func TestEnableShare_Idempotent(t *testing.T) {
 	svc, store := makeService(t, &Share{
 		Name:          "/export",

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -561,6 +561,12 @@ type NetgroupStore interface {
 	// Returns models.ErrNetgroupNotFound if the netgroup doesn't exist.
 	GetNetgroupByID(ctx context.Context, id string) (*models.Netgroup, error)
 
+	// GetNetgroupIDByName resolves a netgroup name to its ID without preloading
+	// members. Callers that only need the ID (e.g. validating + associating a
+	// netgroup) should prefer this over GetNetgroup to avoid loading members.
+	// Returns models.ErrNetgroupNotFound if the netgroup doesn't exist.
+	GetNetgroupIDByName(ctx context.Context, name string) (string, error)
+
 	// ListNetgroups returns all netgroups with members preloaded.
 	ListNetgroups(ctx context.Context) ([]*models.Netgroup, error)
 

--- a/pkg/controlplane/store/netgroups.go
+++ b/pkg/controlplane/store/netgroups.go
@@ -19,6 +19,21 @@ func (s *GORMStore) GetNetgroupByID(ctx context.Context, id string) (*models.Net
 	return getByField[models.Netgroup](s.db, ctx, "id", id, models.ErrNetgroupNotFound, "Members")
 }
 
+// GetNetgroupIDByName resolves a netgroup name to its ID, selecting only the id
+// column and skipping the Members preload that GetNetgroup performs.
+func (s *GORMStore) GetNetgroupIDByName(ctx context.Context, name string) (string, error) {
+	var id string
+	err := s.db.WithContext(ctx).
+		Model(&models.Netgroup{}).
+		Select("id").
+		Where("name = ?", name).
+		First(&id).Error
+	if err != nil {
+		return "", convertNotFoundError(err, models.ErrNetgroupNotFound)
+	}
+	return id, nil
+}
+
 func (s *GORMStore) ListNetgroups(ctx context.Context) ([]*models.Netgroup, error) {
 	return listAll[models.Netgroup](s.db, ctx, "Members")
 }

--- a/test/e2e/controlplane_v2_test.go
+++ b/test/e2e/controlplane_v2_test.go
@@ -340,9 +340,9 @@ func TestControlPlaneV2_NetgroupInUse(t *testing.T) {
 	assert.Equal(t, shareName, share.Name)
 	t.Log("Step 2: Share created")
 
-	// TODO: Once adapter config API exists, associate netgroup with share's NFS config here.
-	// For now, skip the netgroup-in-use check since we can't set it via the current API.
-	t.Skip("Netgroup-share association requires adapter config API (not yet implemented)")
+	// Associate the netgroup with the share's NFS adapter config so it is in-use.
+	helpers.AssociateNetgroup(t, client, shareName, ngName)
+	t.Log("Step 2b: Netgroup associated with share NFS config")
 
 	// 3. Try delete netgroup -> expect 409 Conflict
 	err = helpers.DeleteNetgroupExpectError(t, client, ngName)

--- a/test/e2e/helpers/controlplane.go
+++ b/test/e2e/helpers/controlplane.go
@@ -155,6 +155,19 @@ func CleanupShare(client *apiclient.Client, name string) {
 	_ = client.DeleteShare(name)
 }
 
+// AssociateNetgroup associates a netgroup with a share's NFS adapter config via
+// the per-share adapter config API. Returns the updated config.
+func AssociateNetgroup(t *testing.T, client *apiclient.Client, shareName, netgroupName string) *apiclient.ShareNFSConfig {
+	t.Helper()
+
+	cfg, err := client.PatchShareNFSConfig(shareName, &apiclient.PatchShareNFSConfigRequest{
+		Netgroup: &netgroupName,
+	})
+	require.NoError(t, err, "Failed to associate netgroup %s with share %s", netgroupName, shareName)
+
+	return cfg
+}
+
 // =============================================================================
 // Wait Helpers
 // =============================================================================

--- a/test/e2e/nfsv4_controlplane_test.go
+++ b/test/e2e/nfsv4_controlplane_test.go
@@ -198,8 +198,10 @@ func TestNFSv4ControlPlaneNetgroup(t *testing.T) {
 			assert.Equal(t, shareName, share.Name)
 			t.Log("Step 2: Share created")
 
-			// TODO: Associate netgroup with share's NFS adapter config when adapter config API exists.
-			t.Skip("Netgroup-share association requires adapter config API (not yet implemented)")
+			// Associate the netgroup with the share's NFS adapter config.
+			cfg := helpers.AssociateNetgroup(t, client, shareName, ngName)
+			assert.Equal(t, ngName, cfg.Netgroup, "NFS config should reflect the associated netgroup")
+			t.Log("Step 2b: Netgroup associated with share NFS config")
 
 			// Enable NFS adapter
 			nfsPort := helpers.FindFreePort(t)


### PR DESCRIPTION
## Summary

Implements the per-share NFS adapter-config API that two e2e tests were blocked on (#220). The storage and model layer for this already existed (`share_adapter_configs` table, `NFSExportOptions.NetgroupID`, `SetShareAdapterConfig`, `GetNetgroupByID`, `CheckNetgroupAccess`); the missing pieces were the REST surface, client, CLI verb, and a runtime hook to make netgroup changes take effect on a live share.

## API shape

New endpoints under the existing admin-only `/shares` group:

- `GET /api/v1/shares/{name}/adapters/nfs/config` — returns the share's NFS export options (squash, anon uid/gid, auth flavor, `netgroup` by **name**, readdirplus). Falls back to defaults when no config row exists.
- `PATCH /api/v1/shares/{name}/adapters/nfs/config` — partial update. All fields optional. `netgroup` is pointer-to-string: a non-nil name associates (resolved name→ID, unknown name → 400 before any write), a non-nil empty string clears the association, nil leaves it unchanged.

Netgroup is exposed by **name** in the API; IDs stay internal to storage.

## Wiring

- `Runtime.SetShareNetgroup` / `shares.Service.SetShareNetgroup` mutate the live `Share.NetgroupName` under lock. `CheckNetgroupAccess` reads `NetgroupName` from the runtime registry, so the new allowlist takes effect immediately (no adapter restart). Other NFS export fields apply on adapter restart, matching existing share-edit semantics.
- The route is gated on the store implementing `NetgroupStore` (capability check, same pattern as the existing `/adapters/nfs/netgroups` routes).

## Surface added

- `pkg/apiclient`: `GetShareNFSConfig` / `PatchShareNFSConfig` + `ShareNFSConfig` / `PatchShareNFSConfigRequest`.
- `dfsctl share nfs-config show|set` (e.g. `dfsctl share nfs-config set /export --netgroup office-network`).
- e2e helper `AssociateNetgroup`.

## Tests

- Unskipped `TestNFSv4ControlPlaneNetgroup` and `TestControlPlaneV2_NetgroupInUse`; they now exercise the real API.
- New handler integration tests (`share_adapter_config_test.go`): defaults, share-not-found, associate, clear, unknown-netgroup→400, other-field update + persistence.
- New runtime tests for `SetShareNetgroup` (set / clear / unknown share).

## Gates

`gofmt -s`, `go vet`, `golangci-lint` (0 issues), `go build ./...`, touched-package unit tests, and `go vet -tags e2e ./test/e2e/...` all pass locally. The two e2e tests require sudo + a kernel NFS client so are not run here, but compile clean.

Refs #220