### PR TITLE
fix(nfs): runtime AddShare must not arm server-wide NFSv4 reboot grace

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -476,6 +476,15 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	// for thread-safe reads. Settings are consumed here at startup and on
 	// each new connection (grandfathering per locked decision).
 	s.applyNFSSettings(rt)
+
+	// Boot/initial-recovery wiring is complete: boot shares already in
+	// lock-manager grace have been caught up above and the durable v4 reclaim
+	// roster (LoadClientRecovery) has been armed. Latch the coordinator into the
+	// serving phase so a subsequent RUNTIME AddShare does not arm server-wide
+	// NFSv4 reboot grace (round-2 #7 H-1): a runtime-added share has no
+	// pre-existing v4 clients to reclaim, and arming grace with the LIVE client
+	// set would freeze every connected client's OPEN/LOCK for the grace window.
+	graceCoord.MarkServing()
 }
 
 // Serve starts the NFS server and blocks until the context is cancelled

--- a/pkg/adapter/nfs/grace_coordinator.go
+++ b/pkg/adapter/nfs/grace_coordinator.go
@@ -2,6 +2,7 @@ package nfs
 
 import (
 	"sync"
+	"sync/atomic"
 
 	v4state "github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -44,8 +45,30 @@ import (
 // grace can never wedge regardless. The coordinator only force-ends v4 grace
 // when IT started it (coupled, no independent roster); then refcount-zero is
 // the correct lockstep lift.
+//
+// Boot-vs-runtime arming gate (round-2 #7 H-1): the GLOBAL NFSv4 reboot-grace
+// machine exists to let PRE-RESTART clients reclaim their state, so it is only
+// legitimate to arm at server boot/recovery. A share ADDED AT RUNTIME, while the
+// server is already serving live clients, has no pre-existing v4 clients to
+// reclaim — yet a fresh share's lock store reports an unclean (zero-value)
+// shutdown marker, so initLockManagerFromStore returns enterGrace=true and fires
+// OnLockGraceStart. Without a gate that drove c.sm.StartGracePeriod with the LIVE
+// confirmed-client set, freezing every connected client's OPEN(CLAIM_NULL)/LOCK
+// with NFS4ERR_GRACE until the hard timer (~90s) — pure self-harm on a routine
+// AddShare. The bootComplete latch is set once boot/initial-recovery finishes
+// (right after the adapter's boot wiring, see adapter.SetRuntime): while serving,
+// OnLockGraceStart still maintains the refcount but does NOT arm v4 grace. The
+// boot path is unaffected — boot shares couple in before the latch is set, and
+// the durable reclaim roster (LoadClientRecovery → StartGraceWithRoster) arms v4
+// grace independently of this coordinator either way.
 type nfsGraceCoordinator struct {
 	sm *v4state.StateManager
+
+	// bootComplete latches true once the server has finished boot/initial
+	// recovery and is serving. While true, OnLockGraceStart will not arm the
+	// global v4 reboot-grace machine for a runtime-added share (it has no
+	// pre-existing v4 clients to reclaim); the refcount is still maintained.
+	bootComplete atomic.Bool
 
 	mu sync.Mutex
 	// active counts open per-share lock-manager grace windows coupled through
@@ -57,6 +80,16 @@ type nfsGraceCoordinator struct {
 	// was boot-seeded with a roster the coordinator defers to the v4 machine's
 	// own timer/reclaim lift.
 	startedByCoordinator bool
+}
+
+// MarkServing latches the coordinator into the serving phase. It must be called
+// once the server has finished boot and initial client recovery (after the
+// adapter has caught up shares already in grace at startup and after
+// LoadClientRecovery has armed any boot reclaim roster). After this point a
+// runtime-added share's OnLockGraceStart will not arm the global v4 reboot-grace
+// machine.
+func (c *nfsGraceCoordinator) MarkServing() {
+	c.bootComplete.Store(true)
 }
 
 // OnLockGraceStart drives the NFSv4 StateManager into its grace period when a
@@ -87,6 +120,18 @@ func (c *nfsGraceCoordinator) OnLockGraceStart(expectedClients []string) {
 		// durable roster, or coupled in by a prior cycle. We do NOT own it, so
 		// at refcount zero we will leave the lift to the v4 machine's own
 		// timer/reclaim governance rather than force-ending.
+		c.startedByCoordinator = false
+		return
+	}
+
+	if c.bootComplete.Load() {
+		// Server is already serving: this is a runtime-added share, which has no
+		// pre-existing v4 clients to reclaim. Arming global v4 reboot grace here
+		// would freeze every live client's OPEN(CLAIM_NULL)/LOCK with
+		// NFS4ERR_GRACE for no benefit. Keep the refcount (so OnLockGraceEnd
+		// stays balanced) but do NOT arm v4 grace and do NOT claim ownership.
+		logger.Info("NFSv4 grace NOT armed for runtime-added share (server already serving)",
+			"lock_clients", len(expectedClients))
 		c.startedByCoordinator = false
 		return
 	}

--- a/pkg/adapter/nfs/grace_coordinator_test.go
+++ b/pkg/adapter/nfs/grace_coordinator_test.go
@@ -125,6 +125,67 @@ func TestGraceCoordinator_EndUnderflowIgnored(t *testing.T) {
 	}
 }
 
+// TestGraceCoordinator_RuntimeAddShareDoesNotArmV4Grace is the round-2 #7 H-1
+// regression. Once the server is serving (MarkServing latched) with a LIVE
+// confirmed v4 client, a routine runtime AddShare drives the new share's
+// lock-manager into grace and fires OnLockGraceStart. This must NOT arm the
+// global v4 reboot-grace machine: a runtime-added share has no pre-existing v4
+// clients to reclaim, and arming grace would freeze every connected client's
+// OPEN(CLAIM_NULL)/LOCK with NFS4ERR_GRACE. On the unfixed code OnLockGraceStart
+// called StartGracePeriod with GetConfirmedClientIDs() (the live set), arming
+// grace; this test fails there.
+func TestGraceCoordinator_RuntimeAddShareDoesNotArmV4Grace(t *testing.T) {
+	sm := newConfirmedSM(t)
+	c := &nfsGraceCoordinator{sm: sm}
+
+	// Server has finished boot/recovery and is serving live clients.
+	c.MarkServing()
+
+	// A routine runtime AddShare: the fresh share's lock-manager enters grace
+	// (unclean zero-value shutdown marker) and couples through the coordinator.
+	c.OnLockGraceStart([]string{"nlm-runtime"})
+
+	if sm.IsInGrace() {
+		t.Fatal("runtime AddShare armed server-wide NFSv4 reboot grace (self-inflicted freeze)")
+	}
+	if err := sm.CheckGraceForNewState(); err != nil {
+		t.Fatalf("OPEN(CLAIM_NULL)/LOCK rejected with NFS4ERR_GRACE after runtime AddShare: %v", err)
+	}
+
+	// The refcount must still be maintained so OnLockGraceEnd stays balanced and
+	// does not underflow.
+	c.OnLockGraceEnd()
+	if sm.IsInGrace() {
+		t.Fatal("v4 grace must remain off after balanced runtime grace-end")
+	}
+}
+
+// TestGraceCoordinator_BootArmsGraceBeforeServing asserts the LEGITIMATE boot
+// case is preserved: before MarkServing (boot/initial-recovery phase), a share
+// entering lock-manager grace DOES arm the global v4 reboot grace so pre-restart
+// clients can reclaim (CLAIM_PREVIOUS). This is the catch-up path the adapter
+// runs at startup for boot shares already in grace.
+func TestGraceCoordinator_BootArmsGraceBeforeServing(t *testing.T) {
+	sm := newConfirmedSM(t)
+	c := &nfsGraceCoordinator{sm: sm}
+
+	// Boot phase: MarkServing has NOT been called yet.
+	c.OnLockGraceStart([]string{"nlm-boot"})
+
+	if !sm.IsInGrace() {
+		t.Fatal("boot-time share grace must arm v4 reboot grace for reclaim")
+	}
+	if err := sm.CheckGraceForNewState(); err == nil {
+		t.Fatal("boot grace must reject new state (NFS4ERR_GRACE) so prior owners reclaim first")
+	}
+
+	// Coordinator owns this window, so the last grace-end lifts v4 grace.
+	c.OnLockGraceEnd()
+	if sm.IsInGrace() {
+		t.Fatal("coordinator-owned boot grace must lift at refcount zero")
+	}
+}
+
 // TestGraceCoordinator_NilStateManagerNoPanic confirms the coordinator is a
 // safe no-op when no StateManager is wired (defensive).
 func TestGraceCoordinator_NilStateManagerNoPanic(t *testing.T) {


### PR DESCRIPTION
A fresh share's lock store reports a zero-value (unclean) shutdown marker, so `RegisterStoreForShare` -> `initLockManagerFromStore` returns `enterGrace=true` even with zero persisted locks and fires `OnLockGraceStart`. While the server is already serving, the coordinator armed the GLOBAL v4 reboot-grace machine with the LIVE confirmed-client set (`GetConfirmedClientIDs`), returning NFS4ERR_GRACE for every connected client's OPEN(CLAIM_NULL)/LOCK until the hard timer (~90s) on a routine `AddShare`. The #919 refcount counted windows but did not gate the arm direction.

**Fix:** only arm v4 grace at boot/recovery, not for runtime-added shares. A `bootComplete` latch (`MarkServing()`) is set once the adapter's boot wiring finishes (after the boot-share catch-up loop and after `LoadClientRecovery` has armed any durable reclaim roster). While serving, `OnLockGraceStart` still maintains the refcount but does not call `StartGracePeriod`.

**Preserved:**
- Boot-time arming + CLAIM_PREVIOUS reclaim (boot shares couple in before the latch).
- The slice-2 durable roster path (`LoadClientRecovery` -> `StartGraceWithRoster`) arms v4 grace independently of the coordinator.
- The #919 refcount semantics (OnLockGraceStart/End counting) unchanged.

**Tests:** `TestGraceCoordinator_RuntimeAddShareDoesNotArmV4Grace` (serving + live v4 client -> AddShare -> IsInGrace stays false, CheckGraceForNewState nil; verified FAIL on temp-revert) and `TestGraceCoordinator_BootArmsGraceBeforeServing` (boot path still arms grace + rejects new state). Existing refcount/roster/underflow tests stay green. `-race` clean.

Closes round-2 #7 H-1.