### PR TITLE
fix(operator): unblock install, deletion, and NetworkPolicy RBAC (v1.0 audit #11)

### DIFF
--- a/k8s/dittofs-operator/chart/templates/deployment.yaml
+++ b/k8s/dittofs-operator/chart/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - /manager
           args:
             {{- toYaml .Values.controllerManager.manager.args | nindent 12 }}
+            # Appended last so the chart-managed default wins over any
+            # --enable-webhooks the user may have set in .args (Go flag last-wins).
             - --enable-webhooks={{ .Values.controllerManager.manager.enableWebhooks | default false }}
           env:
             - name: KUBERNETES_CLUSTER_DOMAIN

--- a/k8s/dittofs-operator/chart/templates/deployment.yaml
+++ b/k8s/dittofs-operator/chart/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - /manager
           args:
             {{- toYaml .Values.controllerManager.manager.args | nindent 12 }}
+            - --enable-webhooks={{ .Values.controllerManager.manager.enableWebhooks | default false }}
           env:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: {{ quote .Values.kubernetesClusterDomain }}

--- a/k8s/dittofs-operator/chart/templates/manager-rbac.yaml
+++ b/k8s/dittofs-operator/chart/templates/manager-rbac.yaml
@@ -89,6 +89,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - pgv2.percona.com
   resources:
   - perconapgclusters

--- a/k8s/dittofs-operator/chart/values.yaml
+++ b/k8s/dittofs-operator/chart/values.yaml
@@ -8,6 +8,10 @@ controllerManager:
       - --metrics-bind-address=:8443
       - --leader-elect
       - --health-probe-bind-address=:8081
+    # Enable admission webhooks. Disabled by default: the chart does not yet
+    # provision a webhook TLS certificate, and enabling webhooks without one
+    # crash-loops the manager. Set to true only once cert wiring is in place.
+    enableWebhooks: false
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/k8s/dittofs-operator/config/manager/manager.yaml
+++ b/k8s/dittofs-operator/config/manager/manager.yaml
@@ -63,6 +63,10 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          # Webhooks are disabled until a TLS cert is provisioned (no
+          # cert-manager Certificate/Issuer is wired in config/default yet).
+          # Enabling them without a cert crash-loops the manager at startup.
+          - --enable-webhooks=false
         image: controller:latest
         name: manager
         ports: []

--- a/k8s/dittofs-operator/docs/INSTALL.md
+++ b/k8s/dittofs-operator/docs/INSTALL.md
@@ -347,7 +347,7 @@ configuration environment variables.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--enable-webhooks` | Enable admission webhooks. Requires a webhook TLS certificate (e.g. cert-manager); the chart does not provision one yet, so this defaults to `false` in the deployed manifests to avoid a startup crash-loop. | `false` (deployed) |
-| `--metrics-bind-address` | Metrics endpoint address | `:8443` |
+| `--metrics-bind-address` | Metrics endpoint address (`0` disables; use `:8443` for HTTPS or `:8080` for HTTP) | `0` (disabled) |
 | `--health-probe-bind-address` | Health probe endpoint | `:8081` |
 | `--leader-elect` | Enable leader election | `false` |
 

--- a/k8s/dittofs-operator/docs/INSTALL.md
+++ b/k8s/dittofs-operator/docs/INSTALL.md
@@ -338,15 +338,26 @@ kubectl apply -f config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Service account name | `""` (auto-generated) |
 
-### Environment Variables
+### Manager Flags
 
-The operator supports the following environment variables:
+The operator is configured via command-line flags on the manager container
+(set through the Deployment `args`, or the chart values below). There are no
+configuration environment variables.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ENABLE_WEBHOOKS` | Enable admission webhooks | `true` |
-| `METRICS_BIND_ADDRESS` | Metrics endpoint address | `:8443` |
-| `HEALTH_PROBE_BIND_ADDRESS` | Health probe endpoint | `:8081` |
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--enable-webhooks` | Enable admission webhooks. Requires a webhook TLS certificate (e.g. cert-manager); the chart does not provision one yet, so this defaults to `false` in the deployed manifests to avoid a startup crash-loop. | `false` (deployed) |
+| `--metrics-bind-address` | Metrics endpoint address | `:8443` |
+| `--health-probe-bind-address` | Health probe endpoint | `:8081` |
+| `--leader-elect` | Enable leader election | `false` |
+
+The Helm chart exposes webhook enablement as a value:
+
+```yaml
+controllerManager:
+  manager:
+    enableWebhooks: false  # set to true only once a webhook cert is wired
+```
 
 ## Troubleshooting
 

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -465,12 +465,17 @@ func (r *DittoServerReconciler) handleDeletion(ctx context.Context, dittoServer 
 
 	logger.Info("Processing DittoServer deletion", "name", dittoServer.Name)
 
-	// Update phase to Deleting
-	dittoServerCopy := dittoServer.DeepCopy()
-	dittoServerCopy.Status.Phase = "Deleting"
-	if err := r.Status().Update(ctx, dittoServerCopy); err != nil {
-		logger.Error(err, "Failed to update phase to Deleting")
-		// Continue with cleanup even if status update fails
+	// Update phase to Deleting (only once - re-writing on every reconcile bumps
+	// resourceVersion needlessly and is wasteful). The status write must not be
+	// allowed to poison the in-memory object used for the finalizer-removal Update
+	// below, so it operates on a copy and any RV refresh is discarded.
+	if dittoServer.Status.Phase != "Deleting" {
+		dittoServerCopy := dittoServer.DeepCopy()
+		dittoServerCopy.Status.Phase = "Deleting"
+		if err := r.Status().Update(ctx, dittoServerCopy); err != nil {
+			logger.Error(err, "Failed to update phase to Deleting")
+			// Continue with cleanup even if status update fails
+		}
 	}
 	r.Recorder.Event(dittoServer, corev1.EventTypeNormal, "Deleting",
 		"DittoServer is being deleted, cleaning up resources")
@@ -485,8 +490,7 @@ func (r *DittoServerReconciler) handleDeletion(ctx context.Context, dittoServer 
 		r.Recorder.Eventf(dittoServer, corev1.EventTypeWarning, "CleanupTimeout",
 			"Cleanup timeout exceeded (%v), forcing finalizer removal", cleanupTimeout)
 		// Force remove finalizer after timeout
-		controllerutil.RemoveFinalizer(dittoServer, finalizerName)
-		if err := r.Update(ctx, dittoServer); err != nil {
+		if err := r.removeFinalizer(ctx, dittoServer); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -501,12 +505,31 @@ func (r *DittoServerReconciler) handleDeletion(ctx context.Context, dittoServer 
 
 	// Cleanup successful, remove finalizer
 	logger.Info("Cleanup complete, removing finalizer")
-	controllerutil.RemoveFinalizer(dittoServer, finalizerName)
-	if err := r.Update(ctx, dittoServer); err != nil {
+	if err := r.removeFinalizer(ctx, dittoServer); err != nil {
 		return false, err
 	}
 
 	return false, nil
+}
+
+// removeFinalizer removes the DittoServer finalizer, re-fetching the object on
+// each attempt so the Update never carries a stale resourceVersion (e.g. one
+// invalidated by the earlier Phase=Deleting status write). Wrapping in
+// retryOnConflict makes it resilient to concurrent writers.
+func (r *DittoServerReconciler) removeFinalizer(ctx context.Context, dittoServer *dittoiov1alpha1.DittoServer) error {
+	key := client.ObjectKeyFromObject(dittoServer)
+	return retryOnConflict(func() error {
+		current := &dittoiov1alpha1.DittoServer{}
+		if err := r.Get(ctx, key, current); err != nil {
+			// Object already gone: finalizer effectively removed.
+			return client.IgnoreNotFound(err)
+		}
+		if !controllerutil.ContainsFinalizer(current, finalizerName) {
+			return nil
+		}
+		controllerutil.RemoveFinalizer(current, finalizerName)
+		return r.Update(ctx, current)
+	})
 }
 
 // performCleanup handles cleanup of resources that need special handling beyond owner references.

--- a/k8s/dittofs-operator/internal/controller/dittoserver_deletion_test.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_deletion_test.go
@@ -93,7 +93,7 @@ var _ = Describe("DittoServer deletion", func() {
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, key, &dittoiov1alpha1.DittoServer{})
 			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
+		}, "10s", "200ms").Should(BeTrue())
 	})
 
 	It("force-removes the finalizer without conflict on the cleanup-timeout path", func() {
@@ -120,7 +120,7 @@ var _ = Describe("DittoServer deletion", func() {
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, key, &dittoiov1alpha1.DittoServer{})
 			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
+		}, "10s", "200ms").Should(BeTrue())
 	})
 
 	It("is idempotent when the finalizer is already absent", func() {

--- a/k8s/dittofs-operator/internal/controller/dittoserver_deletion_test.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_deletion_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	dittoiov1alpha1 "github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
+)
+
+// These tests exercise the deletion/finalizer path against envtest, which has
+// real resourceVersion (optimistic-concurrency) semantics. They guard against
+// the regression where the Phase=Deleting status write bumps the shared RV and
+// the subsequent finalizer-removal Update 409-conflicts forever.
+var _ = Describe("DittoServer deletion", func() {
+	const namespace = "default"
+
+	newReconciler := func() *DittoServerReconciler {
+		return &DittoServerReconciler{
+			Client:   k8sClient,
+			Scheme:   scheme.Scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
+	}
+
+	newDittoServer := func(name string) *dittoiov1alpha1.DittoServer {
+		return &dittoiov1alpha1.DittoServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				Storage: dittoiov1alpha1.StorageSpec{
+					CacheSize:    "1Gi",
+					MetadataSize: "1Gi",
+				},
+			},
+		}
+	}
+
+	It("removes the finalizer and deletes the object after a Phase=Deleting status write", func() {
+		ds := newDittoServer("delete-finalizer-test")
+		Expect(k8sClient.Create(ctx, ds)).To(Succeed())
+
+		key := client.ObjectKeyFromObject(ds)
+
+		// Add the finalizer the way the controller does.
+		Expect(k8sClient.Get(ctx, key, ds)).To(Succeed())
+		controllerutil.AddFinalizer(ds, finalizerName)
+		Expect(k8sClient.Update(ctx, ds)).To(Succeed())
+
+		// Delete the object: with the finalizer present it lingers in
+		// Terminating until the finalizer is removed.
+		Expect(k8sClient.Delete(ctx, ds)).To(Succeed())
+
+		r := newReconciler()
+		req := ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      ds.Name,
+		}}
+
+		// First reconcile: writes Phase=Deleting (bumping RV) AND must still
+		// succeed at removing the finalizer on a freshly-fetched object.
+		res, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		// The object must be fully gone (finalizer removed -> GC completes).
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, key, &dittoiov1alpha1.DittoServer{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("force-removes the finalizer without conflict on the cleanup-timeout path", func() {
+		ds := newDittoServer("delete-force-test")
+		Expect(k8sClient.Create(ctx, ds)).To(Succeed())
+
+		key := client.ObjectKeyFromObject(ds)
+		Expect(k8sClient.Get(ctx, key, ds)).To(Succeed())
+		controllerutil.AddFinalizer(ds, finalizerName)
+		Expect(k8sClient.Update(ctx, ds)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, ds)).To(Succeed())
+
+		// Re-fetch so DeletionTimestamp is populated, then back-date it past the
+		// cleanup timeout to drive the force-removal branch.
+		Expect(k8sClient.Get(ctx, key, ds)).To(Succeed())
+		backdated := metav1.NewTime(metav1.Now().Add(-2 * cleanupTimeout))
+		ds.DeletionTimestamp = &backdated
+
+		r := newReconciler()
+		requeue, err := r.handleDeletion(ctx, ds)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(requeue).To(BeFalse())
+
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, key, &dittoiov1alpha1.DittoServer{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("is idempotent when the finalizer is already absent", func() {
+		// removeFinalizer on a non-existent object must not error.
+		r := newReconciler()
+		ds := newDittoServer("delete-absent-test")
+		Expect(r.removeFinalizer(ctx, ds)).To(Succeed())
+	})
+})


### PR DESCRIPTION
Fixes the three liveness-blocking HIGH findings from the v1.0 operator audit (area #11), plus two folded MEDs. Scoped tightly to making the operator start, be deletable, and reconcile.

## NEW-H2 — install crash-loop (operator never starts on either documented path)
`cmd/main.go` defaults `--enable-webhooks=true`, but neither the Helm chart nor kustomize `config/default` provisions a webhook TLS cert. controller-runtime's certwatcher then hits a missing cert at `mgr.Start` → `os.Exit(1)` → CrashLoopBackOff before any DittoServer reconciles.

Low-risk fix (per "less is more" — no full cert-manager stack): default webhooks **off** in the deployed manifests until cert wiring ships.
- Chart: new `controllerManager.manager.enableWebhooks` value (default `false`), wired into the manager container args.
- Kustomize: `--enable-webhooks=false` added to `config/manager/manager.yaml` args.

Folded **M-CFG-WEBHOOK**: the documented `ENABLE_WEBHOOKS` env var in `docs/INSTALL.md` is bound to nothing (the manager reads no env vars). Rewrote that section to document the actual `--enable-webhooks` flag / chart value. No env binding added.

## NEW-H1 — deletion finalizer always 409-conflicts → CR hangs in Terminating forever
`handleDeletion` wrote `Phase="Deleting"` via `r.Status().Update` on a `DeepCopy`, bumping the shared `resourceVersion` only into the copy. The later `RemoveFinalizer` + `r.Update` (and the 60s force-removal path) then ran on the now-stale original → 409 every reconcile → never escapes.

Fix:
- Extracted `removeFinalizer`, which re-fetches the object inside the existing `retryOnConflict` helper so the Update never carries a stale RV; used at both the normal and force-removal call sites.
- Guarded the `Phase="Deleting"` status write behind `if dittoServer.Status.Phase != "Deleting"` so it stops re-poisoning the RV every reconcile (folds **M-REC2-1**).

Added envtest coverage in `dittoserver_deletion_test.go` (real RV semantics): normal delete → finalizer removed and object gone; cleanup-timeout force path; and idempotent removal when the finalizer is already absent.

## Round-1 H2 — chart manager ClusterRole missing `networkpolicies` RBAC
`chart/templates/manager-rbac.yaml` lacked the `networking.k8s.io/networkpolicies` rule that the kubebuilder source of truth `config/rbac/role.yaml` already grants. Every reconcile 403'd on the baseline NetworkPolicy (security-critical, propagated) → CR never Ready. Added the matching rule (`get;list;watch;create;update;patch;delete`).

## Verification
- `go build ./...` and `go test ./...` (envtest) green in `k8s/dittofs-operator`, including the new deletion tests.
- `gofmt -s`, `go vet`, `golangci-lint` clean (only the ~17 pre-existing `goconst` findings remain; no new findings).
- `helm template` confirms `--enable-webhooks=false` in the manager args and the `networkpolicies` RBAC rule render correctly.