### PR TITLE
fix(config): redact secrets on show/API/CLI and bind env+postgres keys (v1.0 audit #9)

### DIFF
--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -246,7 +246,10 @@ func (h *BlockStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 		bs.Type = *req.Type
 	}
 	if req.Config != nil {
-		bs.Config = *req.Config
+		// Read paths redact secrets to "********"; reconcile any sentinel
+		// the client echoed back so we never overwrite a real credential
+		// with the redaction marker.
+		bs.Config = mergeRedactedSecrets(bs.Config, *req.Config)
 		bs.ParsedConfig = nil
 	}
 
@@ -321,7 +324,7 @@ func blockStoreToResponse(s *models.BlockStoreConfig) BlockStoreResponse {
 		Name:      s.Name,
 		Kind:      s.Kind,
 		Type:      s.Type,
-		Config:    s.Config,
+		Config:    redactSecretJSON(s.Config),
 		CreatedAt: s.CreatedAt,
 	}
 }

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -4,9 +4,140 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
+
+// redactedSecret is the sentinel substituted for secret values in store
+// config blobs returned on read paths.
+const redactedSecret = "********"
+
+// redactSecretJSON parses a stored store-config JSON object and replaces the
+// values of secret-bearing keys with a fixed sentinel, returning the
+// re-serialized blob. It is applied on READ paths only (GET/List/Create/Update
+// responses) so the S3 secret_access_key and postgres password never leave the
+// process; Create/Update still accept plaintext input.
+//
+// A key is considered secret if it is exactly "secret_access_key"/"password"
+// or, by convention, contains "secret"/"password" or ends in "_key" (e.g.
+// "access_key", "api_key"). Matching is case-insensitive. Redaction recurses
+// into nested objects and arrays.
+//
+// If the blob is empty or not valid JSON, it is returned unchanged — the goal
+// is to never WIDEN exposure, and an unparseable blob carries no addressable
+// secret key for us to mask. The caller stores well-formed JSON, so this is a
+// defensive no-op in practice.
+func redactSecretJSON(blob string) string {
+	if strings.TrimSpace(blob) == "" {
+		return blob
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(blob), &decoded); err != nil {
+		return blob
+	}
+
+	redacted := redactSecretValue(decoded)
+
+	out, err := json.Marshal(redacted)
+	if err != nil {
+		return blob
+	}
+	return string(out)
+}
+
+// redactSecretValue walks an arbitrary JSON value, redacting secret-bearing
+// keys in any object it encounters.
+func redactSecretValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		for k, child := range val {
+			if isSecretKey(k) {
+				val[k] = redactedSecret
+				continue
+			}
+			val[k] = redactSecretValue(child)
+		}
+		return val
+	case []any:
+		for i, child := range val {
+			val[i] = redactSecretValue(child)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// isSecretKey reports whether a config key names a secret value.
+func isSecretKey(key string) bool {
+	k := strings.ToLower(key)
+	return strings.Contains(k, "secret") ||
+		strings.Contains(k, "password") ||
+		strings.HasSuffix(k, "_key")
+}
+
+// mergeRedactedSecrets reconciles an incoming store-config blob (newBlob)
+// against the currently stored one (oldBlob): any value in newBlob equal to
+// the redaction sentinel is replaced with the corresponding value from
+// oldBlob. This makes the read-then-write pattern safe — because read paths
+// emit "********" for secrets, a client (CLI, operator UI) that fetches a
+// config, tweaks a non-secret field, and PUTs it back would otherwise persist
+// the sentinel and destroy the real credential. Reconciling here, at the
+// Update handler, fixes the whole class regardless of which client resends a
+// redacted blob.
+//
+// If either blob is empty or not a JSON object, newBlob is returned unchanged
+// (Create-style full replacement still works, and a non-object blob carries no
+// addressable key to reconcile).
+func mergeRedactedSecrets(oldBlob, newBlob string) string {
+	if strings.TrimSpace(newBlob) == "" || strings.TrimSpace(oldBlob) == "" {
+		return newBlob
+	}
+
+	var oldObj, newObj map[string]any
+	if err := json.Unmarshal([]byte(oldBlob), &oldObj); err != nil {
+		return newBlob
+	}
+	if err := json.Unmarshal([]byte(newBlob), &newObj); err != nil {
+		return newBlob
+	}
+
+	if !restoreRedactedValues(oldObj, newObj) {
+		// No sentinel present: nothing to reconcile, avoid re-serializing.
+		return newBlob
+	}
+
+	out, err := json.Marshal(newObj)
+	if err != nil {
+		return newBlob
+	}
+	return string(out)
+}
+
+// restoreRedactedValues walks newObj, replacing any sentinel value with the
+// value at the same key in oldObj. Returns true if any substitution was made.
+func restoreRedactedValues(oldObj, newObj map[string]any) bool {
+	changed := false
+	for k, nv := range newObj {
+		ov, ok := oldObj[k]
+		switch nvt := nv.(type) {
+		case string:
+			if nvt == redactedSecret && ok {
+				newObj[k] = ov
+				changed = true
+			}
+		case map[string]any:
+			if ovm, isMap := ov.(map[string]any); isMap {
+				if restoreRedactedValues(ovm, nvt) {
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
 
 // decodeJSONBody decodes a JSON request body into the provided pointer.
 // Returns true if successful, false if decoding fails (error response is written automatically).

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -117,7 +117,10 @@ func mergeRedactedSecrets(oldBlob, newBlob string) string {
 }
 
 // restoreRedactedValues walks newObj, replacing any sentinel value with the
-// value at the same key in oldObj. Returns true if any substitution was made.
+// value at the same key in oldObj. It descends into both nested objects
+// (map[string]any) and arrays ([]any), so a redacted secret nested inside an
+// array is restored rather than clobbering a real secret. Returns true if any
+// substitution was made.
 func restoreRedactedValues(oldObj, newObj map[string]any) bool {
 	changed := false
 	for k, nv := range newObj {
@@ -131,6 +134,45 @@ func restoreRedactedValues(oldObj, newObj map[string]any) bool {
 		case map[string]any:
 			if ovm, isMap := ov.(map[string]any); isMap {
 				if restoreRedactedValues(ovm, nvt) {
+					changed = true
+				}
+			}
+		case []any:
+			if ova, isArr := ov.([]any); isArr {
+				if restoreRedactedArray(ova, nvt) {
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+// restoreRedactedArray walks newArr positionally against oldArr, restoring
+// sentinel values nested inside array elements. Returns true if any
+// substitution was made.
+func restoreRedactedArray(oldArr, newArr []any) bool {
+	changed := false
+	for i, nv := range newArr {
+		if i >= len(oldArr) {
+			break
+		}
+		ov := oldArr[i]
+		switch nvt := nv.(type) {
+		case string:
+			if nvt == redactedSecret {
+				newArr[i] = ov
+				changed = true
+			}
+		case map[string]any:
+			if ovm, isMap := ov.(map[string]any); isMap {
+				if restoreRedactedValues(ovm, nvt) {
+					changed = true
+				}
+			}
+		case []any:
+			if ova, isArr := ov.([]any); isArr {
+				if restoreRedactedArray(ova, nvt) {
 					changed = true
 				}
 			}

--- a/internal/controlplane/api/handlers/metadata_stores.go
+++ b/internal/controlplane/api/handlers/metadata_stores.go
@@ -236,7 +236,10 @@ func (h *MetadataStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 		store.Type = *req.Type
 	}
 	if req.Config != nil {
-		store.Config = *req.Config
+		// Read paths redact secrets to "********"; reconcile any sentinel
+		// the client echoed back so we never overwrite a real credential
+		// with the redaction marker.
+		store.Config = mergeRedactedSecrets(store.Config, *req.Config)
 	}
 
 	if err := h.store.UpdateMetadataStore(r.Context(), store); err != nil {
@@ -289,7 +292,7 @@ func metadataStoreToResponse(s *models.MetadataStoreConfig) MetadataStoreRespons
 		ID:        s.ID,
 		Name:      s.Name,
 		Type:      s.Type,
-		Config:    s.Config,
+		Config:    redactSecretJSON(s.Config),
 		CreatedAt: s.CreatedAt,
 	}
 }

--- a/internal/controlplane/api/handlers/redact_secrets_test.go
+++ b/internal/controlplane/api/handlers/redact_secrets_test.go
@@ -156,6 +156,20 @@ func TestMergeRedactedSecrets(t *testing.T) {
 			mustHave: []string{"REAL"},
 		},
 		{
+			name:     "array-nested object sentinel preserved",
+			old:      `{"endpoints":[{"password":"REAL1"},{"password":"REAL2"}]}`,
+			new:      `{"endpoints":[{"password":"********"},{"password":"********"}]}`,
+			mustHave: []string{"REAL1", "REAL2"},
+			mustHide: []string{"********"},
+		},
+		{
+			name:     "array-of-strings sentinel preserved",
+			old:      `{"keys":["REALKEY","plain"]}`,
+			new:      `{"keys":["********","plain"]}`,
+			mustHave: []string{"REALKEY", "plain"},
+			mustHide: []string{"********"},
+		},
+		{
 			name:     "empty old returns new",
 			old:      "",
 			new:      `{"password":"********"}`,

--- a/internal/controlplane/api/handlers/redact_secrets_test.go
+++ b/internal/controlplane/api/handlers/redact_secrets_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func TestRedactSecretJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		blob     string
+		mustHide []string // substrings that must NOT appear in output
+		mustKeep []string // substrings that must still appear (non-secret)
+		wantSame bool     // output should equal input unchanged
+	}{
+		{
+			name:     "s3 secret access key",
+			blob:     `{"bucket":"data","access_key_id":"AKIA123","secret_access_key":"s3cr3tVALUE"}`,
+			mustHide: []string{"s3cr3tVALUE"},
+			// access_key_id is an identifier (not a secret), so it is kept.
+			mustKeep: []string{"data", "AKIA123"},
+		},
+		{
+			name:     "postgres password",
+			blob:     `{"host":"db","user":"dfs","password":"pgPASSWORD"}`,
+			mustHide: []string{"pgPASSWORD"},
+			mustKeep: []string{"db", "dfs"},
+		},
+		{
+			name:     "nested object",
+			blob:     `{"outer":{"api_secret":"deep","name":"keep"}}`,
+			mustHide: []string{"deep"},
+			mustKeep: []string{"keep"},
+		},
+		{
+			name:     "array of objects",
+			blob:     `{"endpoints":[{"password":"x1"},{"password":"x2"}]}`,
+			mustHide: []string{"x1", "x2"},
+		},
+		{
+			name:     "empty blob unchanged",
+			blob:     "",
+			wantSame: true,
+		},
+		{
+			name:     "invalid json unchanged",
+			blob:     "not-json",
+			wantSame: true,
+		},
+		{
+			name:     "no secrets unchanged in value",
+			blob:     `{"path":"/var/data","size":100}`,
+			mustKeep: []string{"/var/data", "100"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSecretJSON(tc.blob)
+			if tc.wantSame {
+				if got != tc.blob {
+					t.Fatalf("expected unchanged, got %q", got)
+				}
+				return
+			}
+			for _, h := range tc.mustHide {
+				if strings.Contains(got, h) {
+					t.Errorf("secret %q leaked in %q", h, got)
+				}
+			}
+			for _, k := range tc.mustKeep {
+				if !strings.Contains(got, k) {
+					t.Errorf("non-secret %q dropped from %q", k, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIsSecretKey documents the key-matching convention.
+func TestIsSecretKey(t *testing.T) {
+	secret := []string{"password", "secret_access_key", "Password", "API_SECRET", "access_key", "private_key"}
+	plain := []string{"host", "port", "bucket", "path", "user", "region", "key_id"}
+
+	for _, k := range secret {
+		if !isSecretKey(k) {
+			t.Errorf("expected %q to be treated as secret", k)
+		}
+	}
+	for _, k := range plain {
+		if isSecretKey(k) {
+			t.Errorf("expected %q to be treated as non-secret", k)
+		}
+	}
+}
+
+// TestBlockStoreToResponse_RedactsConfig verifies the READ-path response
+// scrubs secrets from the stored config blob (round-2 §2.1).
+func TestBlockStoreToResponse_RedactsConfig(t *testing.T) {
+	m := &models.BlockStoreConfig{
+		ID:        "id1",
+		Name:      "remote-s3",
+		Kind:      models.BlockStoreKindRemote,
+		Type:      "s3",
+		Config:    `{"bucket":"b","secret_access_key":"LEAKED-S3-SECRET"}`,
+		CreatedAt: time.Now(),
+	}
+	resp := blockStoreToResponse(m)
+	if strings.Contains(resp.Config, "LEAKED-S3-SECRET") {
+		t.Fatalf("block store response leaked secret: %s", resp.Config)
+	}
+	if !strings.Contains(resp.Config, "b") {
+		t.Fatalf("non-secret bucket dropped: %s", resp.Config)
+	}
+}
+
+// TestMergeRedactedSecrets verifies the Update-path reconciliation: a client
+// that fetched a redacted config and echoed the sentinel back must not destroy
+// the stored credential. Non-sentinel values (including a genuinely changed
+// secret) pass through untouched.
+func TestMergeRedactedSecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		mustHave []string // substrings the merged blob must contain
+		mustHide []string // substrings it must NOT contain
+		wantSame bool     // merged should equal new unchanged
+	}{
+		{
+			name:     "sentinel preserves stored secret",
+			old:      `{"bucket":"b","secret_access_key":"REAL-SECRET"}`,
+			new:      `{"bucket":"b2","secret_access_key":"********"}`,
+			mustHave: []string{"REAL-SECRET", "b2"},
+		},
+		{
+			name:     "explicit new secret overrides",
+			old:      `{"password":"old"}`,
+			new:      `{"password":"NEW-REAL"}`,
+			mustHave: []string{"NEW-REAL"},
+			mustHide: []string{"********"},
+		},
+		{
+			name:     "no sentinel returns new unchanged",
+			old:      `{"password":"old"}`,
+			new:      `{"host":"db","password":"keep"}`,
+			wantSame: true,
+		},
+		{
+			name:     "nested sentinel preserved",
+			old:      `{"creds":{"password":"REAL"}}`,
+			new:      `{"creds":{"password":"********"}}`,
+			mustHave: []string{"REAL"},
+		},
+		{
+			name:     "empty old returns new",
+			old:      "",
+			new:      `{"password":"********"}`,
+			wantSame: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeRedactedSecrets(tc.old, tc.new)
+			if tc.wantSame {
+				if got != tc.new {
+					t.Fatalf("expected unchanged %q, got %q", tc.new, got)
+				}
+				return
+			}
+			for _, h := range tc.mustHave {
+				if !strings.Contains(got, h) {
+					t.Errorf("merged blob missing %q: %s", h, got)
+				}
+			}
+			for _, h := range tc.mustHide {
+				if strings.Contains(got, h) {
+					t.Errorf("merged blob unexpectedly contains %q: %s", h, got)
+				}
+			}
+		})
+	}
+}
+
+// TestMetadataStoreToResponse_RedactsConfig verifies the metadata store
+// READ-path response scrubs the postgres password (round-2 §2.1).
+func TestMetadataStoreToResponse_RedactsConfig(t *testing.T) {
+	m := &models.MetadataStoreConfig{
+		ID:        "id1",
+		Name:      "pg",
+		Type:      "postgres",
+		Config:    `{"host":"db","password":"LEAKED-PG-PASSWORD"}`,
+		CreatedAt: time.Now(),
+	}
+	resp := metadataStoreToResponse(m)
+	if strings.Contains(resp.Config, "LEAKED-PG-PASSWORD") {
+		t.Fatalf("metadata store response leaked secret: %s", resp.Config)
+	}
+	if !strings.Contains(resp.Config, "db") {
+		t.Fatalf("non-secret host dropped: %s", resp.Config)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -593,10 +593,15 @@ func setupViper(v *viper.Viper, configPath string) {
 	}
 
 	// DITTOFS_CONTROLPLANE_SECRET is documented as a first-class override
-	// for the JWT signing key (controlplane.jwt.secret). Bind the
-	// documented short form explicitly in addition to the reflected
-	// nested path.
-	_ = v.BindEnv("controlplane.secret")
+	// for the JWT signing key. The struct field is JWTConfig.Secret nested
+	// under controlplane.jwt, i.e. viper key controlplane.jwt.secret — so the
+	// documented short form must bind to THAT key, not controlplane.secret
+	// (which no struct field reads). Pass both the documented short form and
+	// the auto long form explicitly: a second BindEnv overwrites the env-var
+	// list set by the reflective configEnvKeys() walk (which bound the long
+	// form DITTOFS_CONTROLPLANE_JWT_SECRET), so we must re-list it here to
+	// keep both forms working.
+	_ = v.BindEnv("controlplane.jwt.secret", "DITTOFS_CONTROLPLANE_SECRET", "DITTOFS_CONTROLPLANE_JWT_SECRET")
 
 	// Configure config file search
 	if configPath != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -313,6 +314,35 @@ type AdminConfig struct {
 	PasswordHash string `mapstructure:"password_hash" yaml:"password_hash,omitempty"`
 }
 
+// redactedSecret is the sentinel substituted for sensitive fields when the
+// config is serialized for display (e.g. `dfs config show`). It is never
+// parsed back on the load path, which uses mapstructure/viper rather than
+// json/yaml Unmarshal of these types.
+const redactedSecret = "********"
+
+// MarshalYAML redacts the admin password hash when the config is serialized
+// for display. An empty hash stays empty so "unset" is distinguishable from a
+// redacted value.
+func (c AdminConfig) MarshalYAML() (interface{}, error) {
+	type alias AdminConfig // avoid infinite recursion
+	out := alias(c)
+	if out.PasswordHash != "" {
+		out.PasswordHash = redactedSecret
+	}
+	return out, nil
+}
+
+// MarshalJSON redacts the admin password hash when the config is serialized
+// for display. See MarshalYAML.
+func (c AdminConfig) MarshalJSON() ([]byte, error) {
+	type alias AdminConfig // avoid infinite recursion
+	out := alias(c)
+	if out.PasswordHash != "" {
+		out.PasswordHash = redactedSecret
+	}
+	return json.Marshal(out)
+}
+
 // KerberosConfig contains Kerberos/RPCSEC_GSS authentication configuration.
 //
 // When Enabled is true, the NFS server supports Kerberos authentication
@@ -544,17 +574,29 @@ func setupViper(v *viper.Viper, configPath string) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
-	// Explicitly bind env vars for nested struct fields.
-	// Viper's AutomaticEnv + Unmarshal doesn't resolve env vars for nested keys
-	// unless they are explicitly bound or accessed via Get().
-	_ = v.BindEnv("database.postgres.host")
-	_ = v.BindEnv("database.postgres.port")
-	_ = v.BindEnv("database.postgres.database")
-	_ = v.BindEnv("database.postgres.user")
-	_ = v.BindEnv("database.postgres.password")
-	_ = v.BindEnv("database.postgres.sslmode")
+	// Bind every config key for AutomaticEnv resolution.
+	//
+	// Viper's AutomaticEnv + Unmarshal only honours an env var for a key
+	// that is already known to viper (present in the config file, a
+	// SetDefault, or an explicit BindEnv). Any key absent from the file
+	// is otherwise silently dropped from the env — so e.g. a container
+	// setting DITTOFS_DATABASE_TYPE=postgres with `type` omitted from the
+	// file would be ignored and the server would silently boot on SQLite.
+	//
+	// To make env precedence reliable for the whole config surface we
+	// reflect over the default Config struct and BindEnv every nested
+	// mapstructure key path (dot-separated; the key replacer above maps
+	// "." -> "_" so database.postgres.ssl_root_cert binds
+	// DITTOFS_DATABASE_POSTGRES_SSL_ROOT_CERT).
+	for _, key := range configEnvKeys() {
+		_ = v.BindEnv(key)
+	}
+
+	// DITTOFS_CONTROLPLANE_SECRET is documented as a first-class override
+	// for the JWT signing key (controlplane.jwt.secret). Bind the
+	// documented short form explicitly in addition to the reflected
+	// nested path.
 	_ = v.BindEnv("controlplane.secret")
-	_ = v.BindEnv("controlplane.pprof")
 
 	// Configure config file search
 	if configPath != "" {
@@ -567,6 +609,79 @@ func setupViper(v *viper.Viper, configPath string) {
 		v.SetConfigName("config")
 		v.SetConfigType("yaml") // Primary format
 	}
+}
+
+// configEnvKeys returns every dot-separated mapstructure key path in the
+// Config struct, so each can be bound for AutomaticEnv resolution. Nested
+// structs are walked recursively; leaf fields (including maps and slices)
+// contribute their own key. Maps with dynamic keys (e.g. the Kerberos
+// static_map) bind at the container level only — env cannot address
+// arbitrary map entries.
+func configEnvKeys() []string {
+	var keys []string
+	collectMapstructureKeys(reflect.TypeOf(Config{}), "", &keys)
+	return keys
+}
+
+// collectMapstructureKeys recursively appends the mapstructure key paths of t
+// (rooted at prefix) to out.
+func collectMapstructureKeys(t reflect.Type, prefix string, out *[]string) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		tag := field.Tag.Get("mapstructure")
+		// Strip mapstructure options like ",squash"/",omitempty".
+		name := tag
+		if comma := strings.IndexByte(name, ','); comma >= 0 {
+			name = name[:comma]
+		}
+		if name == "" {
+			// Untagged exported field: skip — it has no stable key.
+			continue
+		}
+
+		key := name
+		if prefix != "" {
+			key = prefix + "." + name
+		}
+
+		ft := field.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+
+		// Recurse into nested structs (but not time.Duration, which is a
+		// named int64, nor stdlib structs we treat as leaves). A struct
+		// with mapstructure-tagged fields is a nested namespace.
+		if ft.Kind() == reflect.Struct && ft != reflect.TypeOf(time.Duration(0)) && hasMapstructureFields(ft) {
+			collectMapstructureKeys(ft, key, out)
+			continue
+		}
+
+		*out = append(*out, key)
+	}
+}
+
+// hasMapstructureFields reports whether t has at least one exported field with
+// a mapstructure tag, i.e. it is a config namespace worth recursing into.
+func hasMapstructureFields(t reflect.Type) bool {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.IsExported() && f.Tag.Get("mapstructure") != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // readConfigFile reads the configuration file if it exists.

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// writeConfigFile writes content to a temp config.yaml and returns its path.
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestLoad_EnvOverride_KeyAbsentFromFile verifies that an env var overrides a
+// key that is NOT present in the config file — the round-1 §2.2 / round-2 §2.4
+// env-precedence-drop class. The documented precedence is env > file >
+// defaults, which only holds if every key is bound for AutomaticEnv.
+func TestLoad_EnvOverride_KeyAbsentFromFile(t *testing.T) {
+	// File omits controlplane.port and logging.level entirely.
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_CONTROLPLANE_PORT", "9191")
+	t.Setenv("DITTOFS_LOGGING_LEVEL", "ERROR")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.ControlPlane.Port != 9191 {
+		t.Errorf("controlplane.port: env override dropped, got %d want 9191", cfg.ControlPlane.Port)
+	}
+	if cfg.Logging.Level != "ERROR" {
+		t.Errorf("logging.level: env override dropped, got %q want ERROR", cfg.Logging.Level)
+	}
+}
+
+// TestLoad_DatabaseTypeFromEnv_TypeOmittedFromFile reproduces round-2 §2.2(b):
+// a container supplies postgres connection details in the file but omits
+// database.type, then sets DITTOFS_DATABASE_TYPE=postgres via env. Before the
+// fix the env var was silently dropped and the server booted on SQLite.
+func TestLoad_DatabaseTypeFromEnv_TypeOmittedFromFile(t *testing.T) {
+	// type is intentionally omitted from the file.
+	content := `
+database:
+  postgres:
+    host: db.internal
+    database: dfs
+    user: dfs
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_DATABASE_TYPE", "postgres")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Database.Type != store.DatabaseTypePostgres {
+		t.Fatalf("database.type: env override dropped, got %q want postgres", cfg.Database.Type)
+	}
+}
+
+// TestLoad_PostgresDocumentedKeys verifies the EXACT multi-word postgres keys
+// documented in docs/CONFIGURATION.md parse into the struct from a YAML file —
+// round-2 §2.2(a). Before the struct tags were added these silently decoded to
+// zero values (and ssl_root_cert being unsettable was a silent TLS downgrade).
+func TestLoad_PostgresDocumentedKeys(t *testing.T) {
+	content := `
+database:
+  type: postgres
+  postgres:
+    host: db.internal
+    port: 5433
+    database: dfs
+    user: dfs
+    password: filesecret
+    sslmode: verify-full
+    ssl_root_cert: /etc/ca.pem
+    max_open_conns: 99
+    max_idle_conns: 7
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	pg := cfg.Database.Postgres
+	if pg.SSLRootCert != "/etc/ca.pem" {
+		t.Errorf("ssl_root_cert: got %q want /etc/ca.pem", pg.SSLRootCert)
+	}
+	if pg.SSLMode != "verify-full" {
+		t.Errorf("sslmode: got %q want verify-full", pg.SSLMode)
+	}
+	if pg.MaxOpenConns != 99 {
+		t.Errorf("max_open_conns: got %d want 99", pg.MaxOpenConns)
+	}
+	if pg.MaxIdleConns != 7 {
+		t.Errorf("max_idle_conns: got %d want 7", pg.MaxIdleConns)
+	}
+}
+
+// TestLoad_PostgresKeysFromEnv verifies the documented postgres keys can also
+// be set via env (round-2 §2.2(a) env dimension), now that every key is bound.
+func TestLoad_PostgresKeysFromEnv(t *testing.T) {
+	content := `
+database:
+  type: postgres
+  postgres:
+    host: db.internal
+    database: dfs
+    user: dfs
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_DATABASE_POSTGRES_SSL_ROOT_CERT", "/etc/env-ca.pem")
+	t.Setenv("DITTOFS_DATABASE_POSTGRES_MAX_OPEN_CONNS", "42")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Database.Postgres.SSLRootCert != "/etc/env-ca.pem" {
+		t.Errorf("ssl_root_cert from env: got %q want /etc/env-ca.pem", cfg.Database.Postgres.SSLRootCert)
+	}
+	if cfg.Database.Postgres.MaxOpenConns != 42 {
+		t.Errorf("max_open_conns from env: got %d want 42", cfg.Database.Postgres.MaxOpenConns)
+	}
+}
+
+// TestConfigEnvKeys_CoversKnownKeys asserts the reflective key walk produces
+// the load-bearing nested key paths. Guards against a refactor that drops a
+// nested namespace from the BindEnv walk (which would silently reintroduce the
+// env-drop bug).
+func TestConfigEnvKeys_CoversKnownKeys(t *testing.T) {
+	keys := configEnvKeys()
+	set := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		set[k] = true
+	}
+
+	want := []string{
+		"logging.level",
+		"logging.rotation.max_size",
+		"shutdown_timeout",
+		"database.type",
+		"database.sqlite.path",
+		"database.postgres.host",
+		"database.postgres.ssl_root_cert",
+		"database.postgres.max_open_conns",
+		"database.postgres.max_idle_conns",
+		"controlplane.port",
+		"controlplane.jwt.secret",
+		"controlplane.pprof",
+		"admin.username",
+		"kerberos.enabled",
+		"gc.grace_period",
+		"snapshot.restore_http_timeout",
+	}
+	for _, k := range want {
+		if !set[k] {
+			t.Errorf("configEnvKeys() missing %q (got %v)", k, keys)
+		}
+	}
+}

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -156,6 +156,54 @@ controlplane:
 	}
 }
 
+// TestLoad_JWTSecretFromShortEnv verifies the documented short-form override
+// DITTOFS_CONTROLPLANE_SECRET lands in cfg.ControlPlane.JWT.Secret when the
+// key is omitted from the file. Before the fix this bound to controlplane.secret
+// (a key no struct field reads), so the documented override was dead.
+func TestLoad_JWTSecretFromShortEnv(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+`
+	path := writeConfigFile(t, content)
+
+	const want = "short-form-secret-key-minimum-32-characters!"
+	t.Setenv("DITTOFS_CONTROLPLANE_SECRET", want)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.ControlPlane.JWT.Secret != want {
+		t.Errorf("controlplane.jwt.secret: short-form env override dropped, got %q want %q", cfg.ControlPlane.JWT.Secret, want)
+	}
+}
+
+// TestLoad_JWTSecretFromLongEnv verifies the auto long form
+// DITTOFS_CONTROLPLANE_JWT_SECRET still resolves after the explicit BindEnv for
+// the short form (a second BindEnv overwrites the env-var list, so both forms
+// must be listed).
+func TestLoad_JWTSecretFromLongEnv(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+`
+	path := writeConfigFile(t, content)
+
+	const want = "long-form-secret-key-minimum-32-characters!"
+	t.Setenv("DITTOFS_CONTROLPLANE_JWT_SECRET", want)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.ControlPlane.JWT.Secret != want {
+		t.Errorf("controlplane.jwt.secret: long-form env override dropped, got %q want %q", cfg.ControlPlane.JWT.Secret, want)
+	}
+}
+
 // TestConfigEnvKeys_CoversKnownKeys asserts the reflective key walk produces
 // the load-bearing nested key paths. Guards against a refactor that drops a
 // nested namespace from the BindEnv walk (which would silently reintroduce the

--- a/pkg/config/redaction_test.go
+++ b/pkg/config/redaction_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/api"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"gopkg.in/yaml.v3"
+)
+
+// TestConfigShow_RedactsSecrets asserts that serializing the live *Config for
+// display (the `dfs config show` path, json + yaml) never emits the JWT
+// signing secret, the postgres password, or the admin password hash —
+// round-2 §2.3 / round-1 §2.1.
+func TestConfigShow_RedactsSecrets(t *testing.T) {
+	const (
+		jwtSecret = "super-secret-jwt-signing-key-32-chars-long"
+		pgPass    = "p0stgr3s-pa55word"
+		adminHash = "$2y$10$abcdefghijklmnopqrstuv"
+	)
+
+	cfg := GetDefaultConfig()
+	cfg.ControlPlane.JWT.Secret = jwtSecret
+	cfg.Database.Type = store.DatabaseTypePostgres
+	cfg.Database.Postgres = store.PostgresConfig{
+		Host:     "db",
+		Database: "dfs",
+		User:     "dfs",
+		Password: pgPass,
+	}
+	cfg.Admin.PasswordHash = adminHash
+
+	secrets := []string{jwtSecret, pgPass, adminHash}
+
+	t.Run("yaml", func(t *testing.T) {
+		out, err := yaml.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		assertNoSecrets(t, string(out), secrets)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		out, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		assertNoSecrets(t, string(out), secrets)
+	})
+}
+
+func assertNoSecrets(t *testing.T, out string, secrets []string) {
+	t.Helper()
+	for _, s := range secrets {
+		if strings.Contains(out, s) {
+			t.Errorf("serialized config leaked secret %q:\n%s", s, out)
+		}
+	}
+	if !strings.Contains(out, "********") {
+		t.Errorf("expected redaction sentinel in output:\n%s", out)
+	}
+}
+
+// TestJWTConfig_EmptySecretNotRedacted ensures an unset secret stays empty
+// (distinguishable from a redacted one) rather than being masked.
+func TestJWTConfig_EmptySecretNotRedacted(t *testing.T) {
+	c := api.JWTConfig{}
+	out, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(out), "********") {
+		t.Errorf("empty secret should not be redacted: %s", out)
+	}
+}

--- a/pkg/controlplane/api/config.go
+++ b/pkg/controlplane/api/config.go
@@ -1,11 +1,18 @@
 package api
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// redactedSecret is the sentinel substituted for sensitive fields when a
+// config struct is serialized for display (e.g. `dfs config show`). It is
+// never parsed back on the load path, which uses mapstructure/viper rather
+// than json/yaml Unmarshal of these types.
+const redactedSecret = "********"
 
 // EnvControlPlaneSecret is the name of the environment variable for the control plane's JWT authentication signing secret.
 const EnvControlPlaneSecret = "DITTOFS_CONTROLPLANE_SECRET"
@@ -59,6 +66,29 @@ type JWTConfig struct {
 	// RefreshTokenDuration is the lifetime of refresh tokens.
 	// Default: 168h (7 days)
 	RefreshTokenDuration time.Duration `mapstructure:"refresh_token_duration" yaml:"refresh_token_duration"`
+}
+
+// MarshalYAML redacts the JWT signing secret when the config is serialized
+// for display. Only the secret is masked; an empty secret stays empty so
+// "no secret configured" is distinguishable from a redacted one.
+func (c JWTConfig) MarshalYAML() (interface{}, error) {
+	type alias JWTConfig // avoid infinite recursion
+	out := alias(c)
+	if out.Secret != "" {
+		out.Secret = redactedSecret
+	}
+	return out, nil
+}
+
+// MarshalJSON redacts the JWT signing secret when the config is serialized
+// for display. See MarshalYAML.
+func (c JWTConfig) MarshalJSON() ([]byte, error) {
+	type alias JWTConfig // avoid infinite recursion
+	out := alias(c)
+	if out.Secret != "" {
+		out.Secret = redactedSecret
+	}
+	return json.Marshal(out)
 }
 
 // applyDefaults fills in zero values with sensible defaults.

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -35,20 +36,49 @@ const (
 type SQLiteConfig struct {
 	// Path is the path to the SQLite database file.
 	// Default: $XDG_CONFIG_HOME/dittofs/controlplane.db
-	Path string
+	Path string `mapstructure:"path" yaml:"path"`
 }
 
 // PostgresConfig contains PostgreSQL-specific configuration.
 type PostgresConfig struct {
-	Host         string
-	Port         int
-	Database     string
-	User         string
-	Password     string
-	SSLMode      string // disable, require, verify-ca, verify-full
-	SSLRootCert  string
-	MaxOpenConns int
-	MaxIdleConns int
+	Host         string `mapstructure:"host" yaml:"host"`
+	Port         int    `mapstructure:"port" yaml:"port"`
+	Database     string `mapstructure:"database" yaml:"database"`
+	User         string `mapstructure:"user" yaml:"user"`
+	Password     string `mapstructure:"password" yaml:"password"`
+	SSLMode      string `mapstructure:"sslmode" yaml:"sslmode"` // disable, require, verify-ca, verify-full
+	SSLRootCert  string `mapstructure:"ssl_root_cert" yaml:"ssl_root_cert"`
+	MaxOpenConns int    `mapstructure:"max_open_conns" yaml:"max_open_conns"`
+	MaxIdleConns int    `mapstructure:"max_idle_conns" yaml:"max_idle_conns"`
+}
+
+// redactedSecret is the sentinel substituted for the postgres password when
+// the config is serialized for display (e.g. `dfs config show`). It is never
+// parsed back on the load path, which uses mapstructure/viper rather than
+// json/yaml Unmarshal of this type.
+const redactedSecret = "********"
+
+// MarshalYAML redacts the postgres password when the config is serialized for
+// display. An empty password stays empty so "unset" is distinguishable from a
+// redacted value.
+func (c PostgresConfig) MarshalYAML() (interface{}, error) {
+	type alias PostgresConfig // avoid infinite recursion
+	out := alias(c)
+	if out.Password != "" {
+		out.Password = redactedSecret
+	}
+	return out, nil
+}
+
+// MarshalJSON redacts the postgres password when the config is serialized for
+// display. See MarshalYAML.
+func (c PostgresConfig) MarshalJSON() ([]byte, error) {
+	type alias PostgresConfig // avoid infinite recursion
+	out := alias(c)
+	if out.Password != "" {
+		out.Password = redactedSecret
+	}
+	return json.Marshal(out)
 }
 
 // DSN returns the PostgreSQL connection string.
@@ -68,9 +98,9 @@ func (c *PostgresConfig) DSN() string {
 
 // Config contains database configuration.
 type Config struct {
-	Type     DatabaseType
-	SQLite   SQLiteConfig
-	Postgres PostgresConfig
+	Type     DatabaseType   `mapstructure:"type" yaml:"type"`
+	SQLite   SQLiteConfig   `mapstructure:"sqlite" yaml:"sqlite"`
+	Postgres PostgresConfig `mapstructure:"postgres" yaml:"postgres"`
 }
 
 // ApplyDefaults fills in missing configuration with default values.


### PR DESCRIPTION
Fixes the four HIGH findings from the v1.0 config-area audit (`.planning/v1.0-audit/9-config/REVIEW2.md`). All are secret-disclosure or silent-misconfiguration; none is an architectural change.

## Secret redaction (two independent code paths — both needed)

**`dfs config show` typed-field leak (§2.3 / round-1 §2.1):** `config show` serialized the live `*config.Config` with zero redaction, exposing `JWTConfig.Secret`, `AdminConfig.PasswordHash`, and `PostgresConfig.Password`. Added `MarshalYAML`/`MarshalJSON` sentinel redaction (`********`) on `JWTConfig` and `PostgresConfig`, and redact `AdminConfig.PasswordHash`. The marshalers are display-only — the config load path uses mapstructure/viper, not json/yaml `Unmarshal` of these types, so loading is unaffected. Empty secrets stay empty (distinguishable from redacted).

**Store-config API + `dfsctl` opaque-blob leak (§2.1, cross-area):** `BlockStoreResponse.Config` / `MetadataStoreResponse.Config` returned the stored JSON config blob unredacted in GET/List/Create/Update responses, leaking the S3 `secret_access_key` and postgres `password` (also rendered by `dfsctl ... list` table and `-o json`). Added `redactSecretJSON` in `blockStoreToResponse`/`metadataStoreToResponse` that parses the blob and masks `secret_access_key`/`password` and any `*secret*`/`*password*`/`*_key` key (case-insensitive, recursing into nested objects/arrays). Read paths only — Create/Update still accept plaintext input. Redacting at the handler covers both the CLI table and `-o json`, which consume the API response.

**Update reconciliation:** because read paths now emit `********`, a read-then-write client (CLI `store edit`, operator UI) would otherwise PUT the sentinel back and destroy the real credential. Added `mergeRedactedSecrets` on both Update handlers: any incoming value equal to the sentinel is reconciled against the stored value. Fixes the whole class at the server, regardless of which client resends a redacted blob.

## Env precedence + postgres key binding

**Full-key env binding (§2.4 / §2.2b):** viper `AutomaticEnv` only honors env vars for keys already known to viper, so any key absent from the config file was silently dropped from env — including `DITTOFS_DATABASE_TYPE=postgres` when `database.type` is omitted (server silently booted SQLite). Replaced the ~8 hand-written `BindEnv` calls with a reflective walk over the default `Config` struct that `BindEnv`s every nested `mapstructure` key path (the `.`→`_` replacer maps them to `DITTOFS_*`). Guarded by a test that asserts the load-bearing nested key paths are produced.

**Postgres struct tags (§2.2a):** `store.Config`/`PostgresConfig`/`SQLiteConfig` carried no `mapstructure`/`yaml` tags, so documented multi-word keys (`ssl_root_cert`, `max_open_conns`, `max_idle_conns`) silently dropped from file and env — `ssl_root_cert` being unsettable was a silent TLS-posture downgrade. Added explicit `mapstructure`/`yaml` tags matching `docs/CONFIGURATION.md`; these are now covered by the BindEnv walk too.

## Tests
- Stored secrets never appear in `config show` output (json + yaml) or in any block/metadata store GET/List/Create/Update response body.
- Sentinel-echo on Update preserves the stored secret; an explicit new secret still overrides.
- `redactSecretJSON` masks the right keys, keeps identifiers (e.g. `access_key_id`), and leaves empty/invalid blobs unchanged.
- Env override lands for a key omitted from the file; `DITTOFS_DATABASE_TYPE=postgres` with `type` omitted yields `Type==postgres`; the exact documented postgres keys parse from YAML and from env.

Out of scope (deferred per the audit): all MED/LOW — `Database.Validate` fan-out, negative pool-size validation, json-tag/schema round-trip, Kerberos validate, dead `LockConfig`/`SyncerConfig` deletion, `SnapshotDefaults` no-op.