### PR TITLE
fix(smb): zero-fill copychunk sparse destination gap (#750)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -57,16 +57,13 @@ not advertised — they consume no failure slots and are not listed below.
 The compress_notsup_get/set tests correctly SKIP because FILE_FILE_COMPRESSION
 is advertised.
 
-Most IOCTL sparse-family entries walked back under #718. The remaining residual
-failure is a real feature gap: SRV_COPYCHUNK on a sparse destination must surface
-zeros for the unwritten hole between the old EOF and the chunk's target offset
-(see Samba `test_ioctl_copy_chunk_sparse_dest`). DittoFS's copychunk path grows
-the destination file via `WriteAt` at the target offset but does not advertise
-or materialize the [old EOF, target offset) hole as zero-reading bytes.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.ioctl.copy_chunk_sparse_dest | IOCTL | SRV_COPYCHUNK to a 0-byte destination at offset 4096 must surface the [0, 4096) gap as zeros on subsequent reads. The block-store sparse-hole zero-fill path does not run for copychunk-extended files. | #750 |
+Most IOCTL sparse-family entries walked back under #718. The last residual
+sparse failure, `smb2.ioctl.copy_chunk_sparse_dest` (#750), now PASSES:
+SRV_COPYCHUNK into a 0-byte destination at offset 4096 leaves the
+[0, 4096) hole readable as zeros, because the destination `WriteAt` past
+EOF grows the block store's append log with zero-valued leading bytes and
+the read path serves that gap as zeros. Pinned by the engine and handler
+integration tests under #855.
 
 Note: the standalone `smb2.set-sparse-ioctl` and `smb2.zero-data-ioctl` driver
 tests require `--option=torture:filename=` / `--option=torture:offset=` runtime


### PR DESCRIPTION
## Summary

`smb2.ioctl.copy_chunk_sparse_dest` (#750) was the last residual sparse smbtorture failure. Investigation against a freshly-built `origin/develop` shows the destination write path **already** materializes the sparse hole correctly — the failure is stale.

## Root cause (of the original failure)

SRV_COPYCHUNK to a 0-byte destination with a chunk at `target_off = 4096` must surface `[0, 4096)` as zeros on a subsequent read (MS-SMB2 §3.3.5.15.1 / sparse semantics; Samba `source4/torture/smb2/ioctl.c::test_ioctl_copy_chunk_sparse_dest`). Earlier the block-store sparse-hole zero-fill was not exercised for copychunk-extended files.

## Where the zero-fill runs now

`executeCopyChunks` writes the copied extent at `TargetOffset` via the same `engine.Store.WriteAt` path a normal SMB WRITE uses. That `WriteAt` past EOF grows the block store's local append log, and the gap `[oldEOF, TargetOffset)` is served as zeros by the read path (`memory.ReadPayloadAt` / engine `readAtInternal`) — exactly the existing sparse/zero-fill mechanism, lazily (no whole-gap buffering). `PrepareWrite(newSize = TargetOffset + Length)` extends the file size so the subsequent READ passes the EOF gate and returns the zero-filled hole. No new mechanism was introduced and no production code change was required.

The invariant is already pinned by integration tests added under #855:
- `pkg/blockstore/engine/copychunk_sparse_dest_test.go` — engine `WriteAt`/`ReadAt` + memory `ReadPayloadAt` contracts.
- `internal/adapter/smb/v2/handlers/ioctl_copychunk_sparse_integration_test.go` — drives the real `executeCopyChunks` write path + the real `Read` handler against the memory block store (the backend every smb-conformance profile uses).

## Verification

- Local smbtorture, memory profile: `smb2.ioctl.copy_chunk_sparse_dest` → **PASS** (Passed: 1, Failed: 0, New failures: 0).
- `GOWORK=off go build ./...`, `go vet ./internal/adapter/smb/...`, `gofmt -s` — clean.
- `GOWORK=off go test -race ./internal/adapter/smb/...` and the engine `Sparse` tests — green.

## Change

Removes the stale `smb2.ioctl.copy_chunk_sparse_dest` row from `KNOWN_FAILURES.md` (local smbtorture proves the flip) and updates the surrounding prose to document why the hole reads back as zeros.

MS reference: MS-SMB2 §3.3.5.15.1 (FSCTL_SRV_COPYCHUNK), sparse-file read semantics.