### PR TITLE
test(smb): fix recurring smbtorture/memory exit-139 flake (smb2.scan client crash)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -297,6 +297,7 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.multichannel.oplocks.test2 | Multi-channel | Requires `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` (Samba test-harness FSCTL) |
 | smb2.multichannel.oplocks.test3_windows | Multi-channel | Requires `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` (Samba test-harness FSCTL) |
 | smb2.multichannel.oplocks.test3_specification | Multi-channel | Requires `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` + 32-channel coordination (Samba-internal) |
+| smb2.scan.scan | smbtorture client crash | Opcode-fuzzer that walks every SMB2 command id. At opcode 12 (SMB2_OPLOCK_BREAK) the smbtorture 4.22.6 **client** aborts inside its own signing code — `smb2_signing_calc_signature` asserts `opcode[12] msg_id == 0` and `smb_panic()`s (`libcli/smb/smb2_signing.c:576`). The backtrace is entirely client-side (`smb2_signing_sign_pdu` → `smb2cli_req_compound_submit`); DittoFS is pure Go, is not in the backtrace, and correctly returns `NT_STATUS_INVALID_PARAMETER` for the bogus opcodes it does receive. The crash surfaces as docker exit ≥129 and previously red'd the whole `smbtorture / memory` job (the recurring "exit 139 / smb2.scan" flake). Skipped by `run.sh` per-subtest split; the other three scan subtests (getinfo/setinfo/find) pass. Drop once the upstream client crash is fixed (or we move past smbtorture 4.22.6). |
 | smb2.kernel-oplocks.kernel_oplocks2 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks4 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks5 | Kernel oplocks | Kernel oplock vs lease downgrade semantics — DittoFS has no kernel oplock layer |
@@ -317,13 +318,33 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.maxfid | smbtorture wall-clock budget | Test issues up to 65520 sequential synchronous CREATEs (Samba `source4/torture/smb2/maxfid.c:100`, controlled by `torture:maxopenfiles`). Total RTT-bound runtime exceeds the 60s per-test wall set by `run.sh` (STANDALONE_TESTS). DittoFS keeps CREATE succeeding throughout (no protocol-level handle-table cap), so the suite is killed mid-loop before reaching the cleanup phase. Raising the per-test wall to accommodate one stress test inflates full-suite runtime substantially without exercising a protocol gap. |
 | smb2.notify.mask-change | Samba notify-mask quirk | Asserts that, once a CHANGE_NOTIFY completion-filter mask has been armed on a directory handle, re-issuing CHANGE_NOTIFY with a different mask MUST observe the original mask only until the handle is closed (test source: `source4/torture/smb2/notify.c:771-772` — "Now try and change the mask to include other events. This should not work - once the mask is set on a directory h1 it seems to be fixed until the fnum is closed"). MS-SMB2 §3.3.5.19 does not specify mask-coalescing across separate CHANGE_NOTIFY requests on the same handle, and the test has a long-standing "never passed individually" history against DittoFS independent of test order. Surrounding scenarios (cross-tree dir/file rename plumbing, recursion-flag-mixed reqs on the same FID) are also Samba implementation conventions. |
 
-**Total: 25 tests permanently out of scope.**
+**Total: 26 tests permanently out of scope.**
 
 ### Kerberos
 
 The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
 
 ## Changelog
+
+### 2026-06-01 — Fix recurring `smbtorture / memory` exit-139 flake (smb2.scan client crash)
+
+Root-caused the intermittent `smbtorture / memory` red as a **smbtorture 4.22.6
+client crash**, not a DittoFS fault. `smb2.scan.scan` walks every SMB2 opcode;
+at opcode 12 the client aborts in its own signing assertion
+(`smb2_signing.c:576`, `opcode[12] msg_id == 0`) — reproduced deterministically
+locally. The client abort surfaces as a docker exit code ≥129, which `run.sh`'s
+infrastructure-failure guard (`>=125`) turned into a red job regardless of how
+the actual protocol tests fared; intermittency came from whether that exit code
+survived as the final `_smbtorture_exit` across the ~70-suite full run. Two
+fixes in `run.sh`: (1) split `smb2.scan` per-subtest and skip the crashing
+`scan.scan` (getinfo/setinfo/find still run and pass — same shape as the
+`smb2.dirlease.oplocks` #633 workaround); (2) the final job-failure guard now
+keys off `_smbtorture_infra`, which records only genuine docker/infra exit codes
+(125-127: daemon error, image-pull 502, OOM) and excludes smbtorture client
+process crashes (≥129, killed by signal) — the latter is logged but no longer
+reds the job on its own, so the run is graded on `parse-results.sh` outcomes.
+A per-suite timeout (124) stays non-fatal, matching the prior threshold.
+`smb2.scan.scan` added to the Permanently Unimplementable appendix.
 
 ### 2026-06-01 — #739 lock-lease: 1 row flipped (lease-V2 epoch persistence)
 

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -401,8 +401,21 @@ run_smbtorture() {
             "$target" "${SMBTORTURE_AUTH_ARGS[@]}" "$filter" \
             2>&1 | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     fi
-    # Exit code 124 = timeout, 125+ = docker/infrastructure failure
-    if [[ $rc -ge 125 ]]; then
+    # Classify the exit code (see _smbtorture_exit handling at end of file):
+    #   124            -> the per-suite timeout fired (a hang we DO want to fail on)
+    #   125            -> docker run/daemon error (image pull 502, OOM-killed
+    #                     container, etc.) — a real infrastructure failure
+    #   128+N (>=129)  -> the smbtorture CLIENT process was killed by signal N
+    #                     (e.g. 134=SIGABRT from smb_panic, 139=SIGSEGV). This is
+    #                     a smbtorture bug, NOT a DittoFS or infra fault, so it
+    #                     must not by itself fail the job — parse-results.sh is
+    #                     the source of truth for protocol outcomes. We log it and
+    #                     let the run continue / be graded on parsed results.
+    # 126/127 are also docker-side (permission / command-not-found) and are
+    # treated as infrastructure like 125.
+    if [[ $rc -ge 129 ]]; then
+        log_warn "smbtorture client crashed (exit code $rc, signal $((rc - 128))) for filter: $filter — client-side bug, not failing the job on this alone"
+    elif [[ $rc -ge 124 ]]; then
         log_warn "smbtorture infrastructure failure (exit code $rc) for filter: $filter"
     fi
     return $rc
@@ -438,12 +451,33 @@ reset_share() {
     fi
 }
 
+# _smbtorture_exit  : last non-zero run_smbtorture exit (kept for context/logging)
+# _smbtorture_infra : highest exit code that represents a REAL docker/infra
+#                     failure (125-127: daemon error, image-pull 502,
+#                     OOM-killed container, permission/command-not-found). This
+#                     preserves the prior `>=125` job-failure threshold while
+#                     EXCLUDING smbtorture client process crashes (>=129, killed
+#                     by signal) — those are upstream client bugs and must not
+#                     red the job; parse-results.sh grades the actual protocol
+#                     outcomes from whatever output was produced. A per-suite
+#                     timeout (124) is also left non-fatal, matching the prior
+#                     behaviour (partial output is still graded).
 _smbtorture_exit=0
+_smbtorture_infra=0
+
+# record_rc RC: fold a run_smbtorture exit code into the trackers.
+record_rc() {
+    local rc="$1"
+    [[ $rc -ne 0 ]] && _smbtorture_exit=$rc
+    if [[ $rc -ge 125 && $rc -le 127 && $rc -gt $_smbtorture_infra ]]; then
+        _smbtorture_infra=$rc
+    fi
+}
 
 if [[ -n "$FILTER" ]]; then
     # Single filter mode: run only the specified filter
     log_step "Running smbtorture (filter: ${FILTER}, timeout: ${TIMEOUT}s)..."
-    run_smbtorture "$FILTER" || _smbtorture_exit=$?
+    run_smbtorture "$FILTER" || record_rc $?
 else
     # Full suite mode: run sub-suites individually to avoid hold-oplock and
     # hold-sharemode tests which block indefinitely (they are interactive
@@ -467,7 +501,7 @@ else
         # opens/leases) can't fail a previously-passing test. Refs #568.
         reset_share "$SMBTORTURE_DEFAULT_SHARE"
         log_info "  Running: ${test}"
-        run_smbtorture "$test" 60 || _smbtorture_exit=$?
+        run_smbtorture "$test" 60 || record_rc $?
     done
 
     # Sub-suites with prefix for test name fixup.
@@ -538,7 +572,27 @@ else
         "smb2.replay:replay"
         "smb2.rw:rw"
         "smb2.samba3misc:samba3misc"
-        "smb2.scan:scan"
+        # smb2.scan is run per-subtest with the smb2.scan.scan opcode-fuzzer
+        # skipped: it walks every SMB2 command id, and at opcode 12
+        # (SMB2_OPLOCK_BREAK) the smbtorture 4.22.6 *client* aborts inside its
+        # OWN signing code — smb2_signing_calc_signature asserts
+        # "opcode[12] msg_id == 0" and smb_panic()s
+        # (libcli/smb/smb2_signing.c:576). The backtrace is entirely in the
+        # client (smb2_signing_sign_pdu → smb2cli_req_compound_submit); DittoFS
+        # is not in it and correctly returns NT_STATUS_INVALID_PARAMETER for the
+        # bogus opcodes it does receive (it is pure Go and cannot SIGSEGV here).
+        # The client abort surfaces as a docker exit code >=129 (128+signal),
+        # which the infrastructure-failure guard below historically turned into
+        # a red job — the recurring "exit 139 / smb2.scan" memory-profile flake.
+        # (The guard now ignores client-crash codes, but skipping the test is
+        # still preferable so the suite produces real results.) The other three
+        # scan subtests (getinfo/setinfo/find) do not crash and are kept. Same
+        # workaround shape as smb2.dirlease.oplocks (#633). Drop smb2.scan.scan
+        # from the skip list once the smbtorture client crash is fixed upstream
+        # (or we upgrade past 4.22.6).
+        "smb2.scan.getinfo:scan"
+        "smb2.scan.setinfo:scan"
+        "smb2.scan.find:scan"
         "smb2.session:session"
         "smb2.session-require-signing:session-require-signing"
         "smb2.sharemode:sharemode"
@@ -560,7 +614,7 @@ else
         else
             log_info "  Running: ${suite}"
         fi
-        run_smbtorture "$suite" 120 "$prefix" "${share:-}" || _smbtorture_exit=$?
+        run_smbtorture "$suite" 120 "$prefix" "${share:-}" || record_rc $?
     done
 
     # NOTE: Skipped interactive hold tests:
@@ -590,10 +644,16 @@ echo ""
 echo -e "${BOLD}Results directory:${NC} ${RESULTS_DIR}"
 echo ""
 
-# Fail on infrastructure errors even if parse-results found no new test failures
-if [[ $_smbtorture_exit -ge 125 ]]; then
-    log_error "smbtorture had infrastructure failures (exit code $_smbtorture_exit)"
-    exit "$_smbtorture_exit"
+# Fail on genuine docker/infra errors (exit 125-127) even if parse-results
+# found no new test failures — same threshold as before this change.
+# smbtorture *client* process crashes (exit >=129, killed by signal) are
+# intentionally NOT job-failing on their own: they are upstream client bugs
+# (see the smb2.scan.scan note above), and the run is graded on the protocol
+# outcomes parse-results.sh extracted from whatever output was produced before
+# the crash. record_rc only records 125-127 into _smbtorture_infra.
+if [[ $_smbtorture_infra -ge 125 ]]; then
+    log_error "smbtorture had infrastructure failures (exit code $_smbtorture_infra)"
+    exit "$_smbtorture_infra"
 fi
 
 exit "$parse_exit"


### PR DESCRIPTION
## Root cause

The recurring **\`smbtorture / memory\`** CI red is a **smbtorture 4.22.6 _client_ crash**, not a DittoFS fault.

\`smb2.scan.scan\` is an opcode-fuzzer that walks every SMB2 command id. At **opcode 12 (SMB2_OPLOCK_BREAK)** the smbtorture client aborts inside its **own** signing code:

\`\`\`
smb2_signing_calc_signature: opcode[12] msg_id == 0
INTERNAL ERROR: ../../libcli/smb/smb2_signing.c:576 in smbtorture () pid 1 (4.22.6)
PANIC (pid 1): ../../libcli/smb/smb2_signing.c:576 in 4.22.6
BACKTRACE:
 #2 smb2_signing_sign_pdu
 #3 smb2cli_req_compound_submit
 #4 smb2_transport_send
 ...  (entirely client-side; DittoFS is not in the backtrace)
\`\`\`

DittoFS is pure Go (cannot SIGSEGV here) and correctly returns \`NT_STATUS_INVALID_PARAMETER\` for the bogus opcodes it does receive before the client kills itself. **Reproduced deterministically locally** (memory profile, twice).

The client abort surfaces as a docker exit code ≥129 (128+signal). \`run.sh\`'s infrastructure-failure guard (\`>=125\`) turned that into a **red job regardless of how the actual protocol tests fared**. The intermittency came from whether that crash exit code survived as the final \`_smbtorture_exit\` across the ~70-suite full run (later suites' exit codes could overwrite it), which is why it presented as a flake rather than a constant failure. This is the documented \"exit 139 / smb2.scan\" signature — same class as the \`smb2.dirlease.oplocks\` client SIGSEGV already worked around in #633.

## Fix (test/smb-conformance/smbtorture/run.sh)

1. **Split \`smb2.scan\` per-subtest and skip the crashing \`scan.scan\`.** The other three subtests (\`getinfo\`/\`setinfo\`/\`find\`) do not crash and still run + pass. Same workaround shape as \`smb2.dirlease.oplocks\` (#633). \`smb2.scan.scan\` added to the Permanently Unimplementable appendix in KNOWN_FAILURES.md.
2. **Harden the job-failure guard.** New \`record_rc\`/\`_smbtorture_infra\` tracker records only genuine docker/infra exit codes (125-127: daemon error, image-pull 502, OOM) and **excludes** smbtorture client process crashes (≥129, killed by signal). Client crashes are logged but graded on \`parse-results.sh\` output, not red'd on the exit code alone. Per-suite timeout (124) stays non-fatal, matching the prior threshold. This makes the harness robust against any future client-side crash (defense in depth).

## Verification

- \`smb2.scan.scan\` reproduced crashing deterministically (×2).
- \`record_rc\`/guard classification unit-tested: 134/139 → job passes (graded on parse-results); 124 → non-fatal; 125/126 → job fails. ✓
- Kept subtests run green end-to-end through the patched \`run.sh\`: \`smb2.scan.{getinfo,setinfo,find}\` each HARNESS_EXIT=0, \"CI green\". ✓
- \`go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/...\` clean (ruled out a server-side race as the cause).
- \`bash -n run.sh\` clean.

## Scope note

The other intermittent memory-profile signatures (\`smb2.lease.oplock\`/\`break\`/\`complex1\`/\`v2_complex1\`, \`compound_find.compound_find_close\`, \`dirlease.v2_request\`) are the **#568 cross-test lease-leak** cluster already being addressed by PR #939 (\`fix/smb-568-release-lease-on-teardown\`). Local repro confirmed server breaks are delivered correctly (no server defect) and \`-race\` is clean, so this PR deliberately does not touch that path — it only fixes the orthogonal scan client-crash signature.