### PR TITLE
fix(runtime/snapshot): close GC-vs-delete race in hold provider (flaky stress test)

### DIFF
--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -207,7 +207,17 @@ func New(config *Config) (*GORMStore, error) {
 		// SQLite pragmas for better concurrent access:
 		// - journal_mode(WAL): Write-Ahead Logging for concurrent readers/single writer
 		// - busy_timeout(5000): Wait up to 5 seconds when database is locked
-		dsn := config.SQLite.Path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+		// - synchronous(NORMAL): the canonical WAL pairing. With WAL, NORMAL is
+		//   crash-safe for application/process failures (a checkpoint still
+		//   fsyncs); only an OS crash or power loss in the window between a
+		//   commit and the next checkpoint can lose the most recent
+		//   transactions. That tradeoff is acceptable for this single-node
+		//   metadata store and removes a per-commit fsync, which is the
+		//   dominant cost under write-heavy churn (e.g. concurrent snapshot
+		//   create/delete) — without it, that churn serializes on fsync long
+		//   enough to starve readers and blow test/operation timeouts.
+		dsn := config.SQLite.Path +
+			"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)"
 		dialector = sqlite.Open(dsn)
 
 	case DatabaseTypePostgres:
@@ -228,14 +238,42 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	// Configure connection pool for PostgreSQL
-	if config.Type == DatabaseTypePostgres {
+	// Configure the connection pool.
+	switch config.Type {
+	case DatabaseTypePostgres:
 		sqlDB, err := db.DB()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get underlying database: %w", err)
 		}
 		sqlDB.SetMaxOpenConns(config.Postgres.MaxOpenConns)
 		sqlDB.SetMaxIdleConns(config.Postgres.MaxIdleConns)
+
+	case DatabaseTypeSQLite:
+		// Pin SQLite to a single database/sql connection.
+		//
+		// SQLite is a single-writer store. With the default unbounded pool
+		// each concurrent goroutine opens its own connection, and N writers
+		// then fight over the WAL write lock through SQLite's busy-handler
+		// retry loop. Under sustained churn (e.g. many concurrent snapshot
+		// create/delete operations) that degenerates into writer starvation
+		// and busy-loop thrash: a writer can repeatedly lose the race, hold
+		// its higher-level lock far longer than expected, and eventually
+		// exhaust busy_timeout and surface SQLITE_BUSY ("database is
+		// locked"). Both the latency spikes and the spurious lock errors are
+		// observed as intermittent failures on slow/loaded CI runners.
+		//
+		// One connection makes Go's connection pool the single, FIFO point
+		// of serialization, so writes queue in order instead of thrashing
+		// the SQLite lock. Transactions all use the closure form
+		// (db.Transaction(func(tx)...)), which never needs a second
+		// connection, so a single connection cannot self-deadlock. No
+		// behavior change for the single-node SQLite deployment — just
+		// orderly serialization instead of contention.
+		sqlDB, err := db.DB()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get underlying database: %w", err)
+		}
+		sqlDB.SetMaxOpenConns(1)
 	}
 
 	// --- Pre-AutoMigrate migrations ---


### PR DESCRIPTION
## Summary

`TestSnapshotHoldProvider_StressGCvsDeleteUnderChurn` flaked intermittently on the Windows `-short -race` CI job (`windows-build.yml` runs `go test -short -race ./...`). This fixes the underlying cause.

## Root cause — not a race, a SQLite write-contention stall

I first verified the suspected lock/ordering bug is **not** present:

- `snapshotDeleteLock(share)` returns a single shared `*sync.RWMutex` per share (allocated once, reused), so every `SnapshotHoldProvider` instance borrows the **same pointer**. `DeleteSnapshot` `Lock`s it; `HeldHashes` `RLock`s it. Mark-vs-delete serialize correctly across provider instances (`TestSnapshotHoldProvider_DeleteLockSerializesAcrossInstances` passes).
- `DeleteSnapshot` holds that lock across both the row delete and `os.RemoveAll`, so GC mark never observes a half-deleted snapshot. No TOCTOU, no missing-pinned-hash path.

Forcing a goroutine dump mid-run showed **no deadlock and no lock cycle** — just forward-progressing contention:

- 4 mark goroutines all blocked on `RLock` of the *same* per-share mutex (proving the shared-pointer design works).
- 4 churn goroutines inside `DeleteSnapshot`, stuck in the SQLite driver write (`database/sql.withLock`) / `os.RemoveAll`.

The real cost is **SQLite write contention**. The store opens SQLite with the default unbounded `database/sql` pool, so every concurrent goroutine gets its own connection. SQLite is single-writer: N connections then fight over the WAL write lock through SQLite's busy-handler retry loop. Under sustained snapshot create/delete churn this degenerates into writer starvation and busy-loop thrash — a writer repeatedly loses the race, holds its higher-level RWMutex far longer than expected (blocking every GC-mark reader behind Go's writer-priority RWMutex), and can exhaust `busy_timeout` and surface `SQLITE_BUSY`. On a slow/loaded runner the resulting latency spikes blow the test timeout. The dumps from the failing runs were stuck in exactly these spots (`CreateSnapshot`/`DeleteSnapshot` writes and `HeldHashes` RLock).

## The fix

`pkg/controlplane/store/gorm.go`, SQLite only:

1. **`SetMaxOpenConns(1)`** — pin SQLite to one connection so Go's pool is the single FIFO serialization point. Writes queue in order instead of thrashing the WAL lock; no writer starvation, no spurious `SQLITE_BUSY`. All store transactions use the closure form (`db.Transaction(func(tx)...)`), which never needs a second connection, so one connection cannot self-deadlock.
2. **`synchronous=NORMAL`** — the canonical WAL pairing, dropping the per-commit fsync (crash-safe for app/process failures under WAL).

Behavior-preserving: single-node SQLite already serializes at the write-lock level; this just makes the serialization orderly instead of contended. Postgres path unchanged.

Measured (single full stress run, `-race`, loaded laptop):

| config | time |
|---|---|
| baseline (default pool) | ~25s |
| `synchronous=NORMAL` only (default pool) | ~30s (worse — multi-conn thrash dominates) |
| `SetMaxOpenConns(1)` + `synchronous=NORMAL` | ~15s, starvation tail gone |

The pool change is the load-bearing one.

## Verification

- `GOWORK=off go test -race -run TestSnapshotHoldProvider_StressGCvsDeleteUnderChurn ./pkg/controlplane/runtime/ -count=200` → **`ok 3041.004s`, 200/200 green, race-clean**.
- `GOWORK=off go test -race ./pkg/controlplane/runtime/` (full package incl. stress) → green.
- All `./pkg/controlplane/...` packages → green.
- `go vet` / `gofmt -s` clean.
