### PR TITLE
fix(dfsctl): return non-zero exit on -o json command failures (v1.0 audit #10)

### DIFF
--- a/cmd/dfsctl/commands/share/snapshot/create.go
+++ b/cmd/dfsctl/commands/share/snapshot/create.go
@@ -119,26 +119,37 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("wait for snapshot: %w", err)
 	}
 
+	// Emit the result body first so observability is identical across
+	// formats, then inspect snap.State independently of the output format.
+	// A server-reported `failed` snapshot must exit non-zero in EVERY
+	// format (including -o json/-o yaml) so scripts/CI can gate on the
+	// exit code — not only the table branch.
 	switch format {
 	case output.FormatJSON:
-		return output.PrintJSON(os.Stdout, snap)
+		if err := output.PrintJSON(os.Stdout, snap); err != nil {
+			return err
+		}
 	case output.FormatYAML:
-		return output.PrintYAML(os.Stdout, snap)
+		if err := output.PrintYAML(os.Stdout, snap); err != nil {
+			return err
+		}
 	default:
 		switch snap.State {
 		case "ready":
 			fmt.Printf("Snapshot %s -> ready\n", snap.ID)
-			return nil
 		case "failed":
-			msg := snap.Error
-			if msg == "" {
-				msg = "(no error message)"
-			}
-			fmt.Fprintf(os.Stderr, "Snapshot %s failed: %s\n", snap.ID, msg)
-			return fmt.Errorf("snapshot failed")
+			// The returned error below is printed to stderr by main.go.
 		default:
 			fmt.Printf("Snapshot %s in state %q\n", snap.ID, snap.State)
-			return nil
 		}
 	}
+
+	if snap.State == "failed" {
+		msg := snap.Error
+		if msg == "" {
+			msg = "(no error message)"
+		}
+		return fmt.Errorf("snapshot %s failed: %s", snap.ID, msg)
+	}
+	return nil
 }

--- a/cmd/dfsctl/commands/share/snapshot/create_test.go
+++ b/cmd/dfsctl/commands/share/snapshot/create_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
@@ -49,5 +50,47 @@ func TestCreate_NoWaitJSONHasIDField(t *testing.T) {
 	}
 	if obj["state"] != "creating" {
 		t.Fatalf("json state = %v, want creating", obj["state"])
+	}
+}
+
+// TestCreate_FailedStateExitsNonZeroAcrossFormats asserts that a blocking
+// create whose snapshot reaches the `failed` terminal state returns a
+// non-nil error in EVERY output format — json/yaml/table. This is the
+// exit-0-on-failure class fix: previously the json/yaml branches returned
+// nil unconditionally, so `snapshot create -o json` reported a failed
+// backup as success and CI could not detect it. The body is still emitted.
+func TestCreate_FailedStateExitsNonZeroAcrossFormats(t *testing.T) {
+	for _, format := range []string{"json", "yaml", "table"} {
+		t.Run(format, func(t *testing.T) {
+			resetCreateFlags()
+			cmdutil.Flags.Output = format
+			t.Cleanup(func() { cmdutil.Flags.Output = "" })
+
+			fc := &fakeClient{
+				createResp: &apiclient.CreateSnapshotResponse{SnapshotID: "snap-fail", Share: "/archive"},
+				snapshots: map[string]*apiclient.Snapshot{
+					"snap-fail": {ID: "snap-fail", Share: "/archive", State: "creating"},
+				},
+				waitFinalState: "failed",
+			}
+			withFakeClient(t, fc)
+
+			prev := osStdout()
+			r, w := setStdout()
+			defer restoreStdout(prev)
+
+			err := runCreate(createCmd, []string{"/archive"})
+
+			_ = w.Close()
+			var buf bytes.Buffer
+			_, _ = buf.ReadFrom(r)
+
+			if err == nil {
+				t.Fatalf("%s: failed snapshot must return a non-nil error (non-zero exit)", format)
+			}
+			if !strings.Contains(err.Error(), "snap-fail") {
+				t.Errorf("%s: error should reference the snapshot id; got %v", format, err)
+			}
+		})
 	}
 }

--- a/cmd/dfsctl/commands/store/block/audit.go
+++ b/cmd/dfsctl/commands/store/block/audit.go
@@ -54,14 +54,30 @@ func runAuditRefcounts(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Emit the audit body first so observability is identical across
+	// formats, then surface a detected refcount drift as a non-zero exit
+	// independently of the output format. A non-zero Delta is a real
+	// INV-02 violation (leaked block / dedup bug) — `audit-refcounts || alert`
+	// must fire in -o json/-o yaml too, not only the table branch.
 	switch format {
 	case output.FormatJSON:
-		return output.PrintJSON(os.Stdout, res)
+		if err := output.PrintJSON(os.Stdout, res); err != nil {
+			return err
+		}
 	case output.FormatYAML:
-		return output.PrintYAML(os.Stdout, res)
+		if err := output.PrintYAML(os.Stdout, res); err != nil {
+			return err
+		}
 	default:
-		return printAuditTable(res)
+		if err := printAuditTable(res); err != nil {
+			return err
+		}
 	}
+
+	if res.Result.Delta != 0 {
+		return fmt.Errorf("INV-02 violation: refcount delta=%d", res.Result.Delta)
+	}
+	return nil
 }
 
 // printAuditTable renders the audit summary as a key/value table mirroring

--- a/cmd/dfsctl/commands/store/block/audit_test.go
+++ b/cmd/dfsctl/commands/store/block/audit_test.go
@@ -124,7 +124,8 @@ func TestAuditCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 }
 
 // TestAuditCmd_DriftSurfacesViolation asserts a non-zero delta appends
-// the violation banner to the table output.
+// the violation banner to the table output AND returns a non-nil error so
+// cobra exits non-zero (scripts can gate on `audit-refcounts || alert`).
 func TestAuditCmd_DriftSurfacesViolation(t *testing.T) {
 	s := newAuditServer(t)
 	defer s.Close()
@@ -140,17 +141,59 @@ func TestAuditCmd_DriftSurfacesViolation(t *testing.T) {
 	}
 	withAuditTestServer(t, s.URL)
 
+	var runErr error
 	out := captureStdoutAudit(t, func() {
-		if err := runAuditRefcounts(auditRefcountsCmd, []string{"myshare"}); err != nil {
-			t.Fatalf("runAuditRefcounts: %v", err)
-		}
+		runErr = runAuditRefcounts(auditRefcountsCmd, []string{"myshare"})
 	})
 
+	if runErr == nil {
+		t.Fatal("non-zero delta must return a non-nil error (non-zero exit)")
+	}
+	if !strings.Contains(runErr.Error(), "delta=-5") {
+		t.Errorf("error must include the delta value; got %v", runErr)
+	}
 	if !strings.Contains(out, "INV-02 violation") {
 		t.Errorf("non-zero delta must surface INV-02 violation banner; got %q", out)
 	}
 	if !strings.Contains(out, "delta=-5") {
 		t.Errorf("violation banner must include delta value; got %q", out)
+	}
+}
+
+// TestAuditCmd_DriftExitsNonZeroAcrossFormats asserts a non-zero delta
+// returns a non-nil error in EVERY output format — the exit-0-on-failure
+// class fix. Without it, `audit-refcounts -o json || alert` never fires on
+// detected corruption. The JSON/YAML body is still emitted for observability.
+func TestAuditCmd_DriftExitsNonZeroAcrossFormats(t *testing.T) {
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			s := newAuditServer(t)
+			defer s.Close()
+			s.result = &engine.AuditRefcountsResult{
+				Share:         "myshare",
+				TotalRefs:     10,
+				TotalRefCount: 7,
+				Delta:         3,
+			}
+			withAuditTestServer(t, s.URL)
+			cmdutil.Flags.Output = format
+
+			var runErr error
+			out := captureStdoutAudit(t, func() {
+				runErr = runAuditRefcounts(auditRefcountsCmd, []string{"myshare"})
+			})
+
+			if runErr == nil {
+				t.Fatalf("%s: non-zero delta must return a non-nil error", format)
+			}
+			if !strings.Contains(runErr.Error(), "delta=3") {
+				t.Errorf("%s: error must include the delta value; got %v", format, runErr)
+			}
+			// Body is still emitted so machine consumers get the full result.
+			if !strings.Contains(out, "myshare") {
+				t.Errorf("%s: result body must still be emitted; got %q", format, out)
+			}
+		})
 	}
 }
 

--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -65,14 +65,30 @@ func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Emit the stats body first so observability is identical across
+	// formats, then surface sweep errors as a non-zero exit independently
+	// of the output format. A GC run that hit Delete/list errors left
+	// orphan objects unreclaimed (storage/cost leak) — scripts gating on
+	// the exit code must see that in -o json/-o yaml too, not only table.
 	switch format {
 	case output.FormatJSON:
-		return output.PrintJSON(os.Stdout, res)
+		if err := output.PrintJSON(os.Stdout, res); err != nil {
+			return err
+		}
 	case output.FormatYAML:
-		return output.PrintYAML(os.Stdout, res)
+		if err := output.PrintYAML(os.Stdout, res); err != nil {
+			return err
+		}
 	default:
-		return printGCStatsTable(res, dryRun)
+		if err := printGCStatsTable(res, dryRun); err != nil {
+			return err
+		}
 	}
+
+	if res.Stats.ErrorCount > 0 {
+		return fmt.Errorf("GC completed with %d sweep error(s)", res.Stats.ErrorCount)
+	}
+	return nil
 }
 
 // printGCStatsTable renders the GC summary as a key/value table plus an

--- a/cmd/dfsctl/commands/store/block/gc_test.go
+++ b/cmd/dfsctl/commands/store/block/gc_test.go
@@ -171,6 +171,43 @@ func TestGCCmd_DryRunFlag(t *testing.T) {
 	}
 }
 
+// TestGCCmd_SweepErrorsExitNonZeroAcrossFormats asserts a GC run that hit
+// sweep errors (ErrorCount > 0 — orphan objects left unreclaimed) returns a
+// non-nil error in EVERY output format, so `gc -o json || alert` fires. The
+// stats body is still emitted for observability. Exit-0-on-failure class fix.
+func TestGCCmd_SweepErrorsExitNonZeroAcrossFormats(t *testing.T) {
+	for _, format := range []string{"json", "yaml", "table"} {
+		t.Run(format, func(t *testing.T) {
+			s := newGCServer(t)
+			defer s.Close()
+			s.gcStats = &engine.GCStats{
+				RunID:       "run-err",
+				ErrorCount:  2,
+				FirstErrors: []string{"delete cas/aa/bb: timeout"},
+			}
+			withGCTestServer(t, s.URL)
+			cmdutil.Flags.Output = format
+			t.Cleanup(func() { cmdutil.Flags.Output = "table" })
+
+			var runErr error
+			out := captureStdoutBlock(t, func() {
+				_ = gcCmd.Flags().Set("dry-run", "false")
+				runErr = runBlockStoreGC(gcCmd, []string{"myshare"})
+			})
+
+			if runErr == nil {
+				t.Fatalf("%s: ErrorCount>0 must return a non-nil error", format)
+			}
+			if !strings.Contains(runErr.Error(), "2 sweep error") {
+				t.Errorf("%s: error must report the sweep error count; got %v", format, runErr)
+			}
+			if !strings.Contains(out, "run-err") {
+				t.Errorf("%s: stats body must still be emitted; got %q", format, out)
+			}
+		})
+	}
+}
+
 // TestGCCmd_NoArg_Errors confirms cobra.ExactArgs(1) rejects bare
 // invocations before RunE runs.
 func TestGCCmd_NoArg_Errors(t *testing.T) {


### PR DESCRIPTION
## Problem

Three `dfsctl` commands emitted their result body under `-o json`/`-o yaml` and then returned `nil` even when the underlying operation had **failed** — so scripts and CI gating on the process exit code saw a failure as a success. The error was only surfaced (non-zero exit) in the human-readable table branch.

This is the exit-0-on-failure class identified in the v1.0 CLI audit (round-1 H1, broadened in round-2 §4).

## Affected commands

- **`share snapshot create`** — a server-reported `failed` snapshot exited 0 under `-o json`/`-o yaml` (only the table branch checked `snap.State`). A failed backup looked like a successful one to automation.
- **`store block gc`** — a GC run that hit sweep Delete/list errors (`Stats.ErrorCount > 0`, orphan objects left unreclaimed) exited 0 in every format.
- **`store block audit-refcounts`** — a detected INV-02 refcount drift (`Result.Delta != 0`, a real corruption/leak indicator) exited 0 in every format; `audit-refcounts || alert` never fired.

## Fix

For each command, inspect the failure field **after** the output-format switch and return a non-nil error in **every** format, while still emitting the structured body first for observability. This mirrors the existing correct reference pattern in `store/block/health.go` (emit body, then check status, return error in all formats).

- `create.go`: check `snap.State == "failed"` after the switch; return a richer error referencing the snapshot id (also removed the duplicate stderr print — `main.go` already prints the returned error to stderr).
- `gc.go`: return error when `Stats.ErrorCount > 0`.
- `audit.go`: return error when `Result.Delta != 0`.

## Tests

Added table-driven exit-code tests across `json`/`yaml`/`table` for each command asserting a non-nil error (non-zero exit) on the failure path while the body is still emitted. Updated the existing `TestAuditCmd_DriftSurfacesViolation` to assert the new non-zero exit.

`go build ./...`, `go vet`, `golangci-lint` (0 issues), and `go test ./cmd/dfsctl/... -count=1` all green.