### PR TITLE
fix(nfs/nlm): validate SETATTR stateid, gate crash-cleanup on grace, drain NLM waiters on SMB unlock (v1.0 audit #4/#5)

### DIFF
--- a/internal/adapter/nfs/nsm/notifier.go
+++ b/internal/adapter/nfs/nsm/notifier.go
@@ -162,13 +162,20 @@ func (n *Notifier) NotifyAllClients(ctx context.Context) []NotifyResult {
 		allResults = append(allResults, result)
 
 		if result.Error != nil {
-			// Per CONTEXT.md: Failed notification = client crashed, cleanup locks
-			logger.Warn("NSM: SM_NOTIFY failed, treating client as crashed",
+			// A failed OUTBOUND SM_NOTIFY on server restart means the
+			// notification did not reach the client (client temporarily down,
+			// network blip, firewall, changed ephemeral port) — it does NOT
+			// mean the client crashed. Canonical rpc.statd / Linux fs/lockd
+			// treat restart-notify as best-effort and release a host's locks
+			// only on INBOUND crash evidence (a peer SM_NOTIFY / FREE_ALL from
+			// the rebooted client). Releasing here would wipe a momentarily
+			// unreachable client's locks DURING the reclaim grace window,
+			// defeating grace for exactly the clients it protects. Leave the
+			// locks intact: the per-share grace timer and its onGraceEnd sweep
+			// age out genuinely-unreclaimed locks once grace expires.
+			logger.Warn("NSM: SM_NOTIFY delivery failed; leaving locks intact for grace/reclaim",
 				"client", result.ClientID,
 				"error", result.Error)
-
-			// Trigger crash handling (lock cleanup)
-			n.handleClientCrash(ctx, result.ClientID)
 		} else {
 			logger.Debug("NSM: SM_NOTIFY succeeded", "client", result.ClientID)
 		}

--- a/internal/adapter/nfs/nsm/notifier_test.go
+++ b/internal/adapter/nfs/nsm/notifier_test.go
@@ -23,9 +23,11 @@ func TestNotifyAllClients_OutboundFailure_DoesNotReleaseLocks(t *testing.T) {
 	tracker := lock.NewConnectionTracker(lock.ConnectionTrackerConfig{})
 	require.NoError(t, tracker.RegisterClient("clientA", "nlm", "10.0.0.1:0", 0))
 	// Mark the client as NSM-monitored with a callback target that cannot be
-	// reached, so SendNotify fails.
+	// reached, so SendNotify fails. Use a localhost port with no listener so the
+	// dial is refused immediately rather than blocking the full CallbackTimeout
+	// against an unroutable host (which made the test slow/flaky in CI).
 	tracker.UpdateNSMInfo("clientA", "clientA", [16]byte{}, &lock.NSMCallback{
-		Hostname: "192.0.2.1:0", // TEST-NET-1, guaranteed unroutable
+		Hostname: "127.0.0.1:1", // no listener — connection refused immediately
 		Program:  100021,
 		Version:  4,
 		Proc:     1,

--- a/internal/adapter/nfs/nsm/notifier_test.go
+++ b/internal/adapter/nfs/nsm/notifier_test.go
@@ -1,0 +1,85 @@
+package nsm
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/handlers"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifyAllClients_OutboundFailure_DoesNotReleaseLocks proves that a failed
+// OUTBOUND SM_NOTIFY on server restart does NOT trigger crash cleanup. A notify
+// failure means the notification did not reach the client (down, network blip,
+// changed ephemeral port) — it is not crash evidence. Releasing the client's
+// locks here would defeat the reclaim grace window for the very clients it
+// protects (NFS H-D / NSM grace regression). Locks must be left intact for the
+// grace timer + onGraceEnd sweep to age out.
+func TestNotifyAllClients_OutboundFailure_DoesNotReleaseLocks(t *testing.T) {
+	t.Parallel()
+
+	tracker := lock.NewConnectionTracker(lock.ConnectionTrackerConfig{})
+	require.NoError(t, tracker.RegisterClient("clientA", "nlm", "10.0.0.1:0", 0))
+	// Mark the client as NSM-monitored with a callback target that cannot be
+	// reached, so SendNotify fails.
+	tracker.UpdateNSMInfo("clientA", "clientA", [16]byte{}, &lock.NSMCallback{
+		Hostname: "192.0.2.1:0", // TEST-NET-1, guaranteed unroutable
+		Program:  100021,
+		Version:  4,
+		Proc:     1,
+	})
+
+	h := handlers.NewHandler(handlers.HandlerConfig{
+		Tracker:    tracker,
+		ServerName: "testserver",
+	})
+
+	var crashCalls int32
+	n := NewNotifier(NotifierConfig{
+		Handler:    h,
+		ServerName: "testserver",
+		OnClientCrash: func(_ context.Context, _ string) error {
+			atomic.AddInt32(&crashCalls, 1)
+			return nil
+		},
+	})
+
+	results := n.NotifyAllClients(context.Background())
+
+	require.Len(t, results, 1, "exactly one client should be notified")
+	require.Error(t, results[0].Error, "outbound notify to unroutable host must fail")
+	require.Equal(t, int32(0), atomic.LoadInt32(&crashCalls),
+		"a failed outbound SM_NOTIFY must NOT trigger crash cleanup")
+}
+
+// TestDetectCrash_StillReleasesLocks proves the INBOUND crash-evidence path
+// (DetectCrash) still releases locks — the fix only removes the outbound-notify
+// path, not legitimate crash handling.
+func TestDetectCrash_StillReleasesLocks(t *testing.T) {
+	t.Parallel()
+
+	tracker := lock.NewConnectionTracker(lock.ConnectionTrackerConfig{})
+	require.NoError(t, tracker.RegisterClient("clientA", "nlm", "10.0.0.1:0", 0))
+
+	h := handlers.NewHandler(handlers.HandlerConfig{
+		Tracker:    tracker,
+		ServerName: "testserver",
+	})
+
+	var crashCalls int32
+	n := NewNotifier(NotifierConfig{
+		Handler:    h,
+		ServerName: "testserver",
+		OnClientCrash: func(_ context.Context, _ string) error {
+			atomic.AddInt32(&crashCalls, 1)
+			return nil
+		},
+	})
+
+	n.DetectCrash(context.Background(), "clientA")
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&crashCalls),
+		"inbound crash evidence must still trigger crash cleanup")
+}

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -51,9 +51,6 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
-	// Log stateid at debug level (full open-mode/lease validation is handled by
-	// the dedicated stateid slice; this slice enforces only the special-stateid
-	// rule below).
 	logger.Debug("NFSv4 SETATTR stateid",
 		"seqid", stateid.Seqid,
 		"special", stateid.IsSpecialStateid(),
@@ -82,12 +79,54 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
-	// 4b. A SETATTR that changes the file size is a write-family operation:
-	// reject the READ-bypass (all-ones) special stateid with NFS4ERR_BAD_STATEID
-	// (RFC 7530 Section 9.1.4.3). Without this, a client could truncate/extend a
-	// file using the READ-only special stateid, bypassing share-mode and lock
-	// enforcement.
-	if setAttrs.Size != nil && stateid.IsReadBypassStateid() {
+	// 4b. Validate the stateid via StateManager (RFC 7530 Section 16.32). A
+	// SETATTR that changes the file size is a write-family operation and is
+	// validated as such; any other SETATTR is read-family (the stateid is only
+	// meaningful for size, per RFC 7530 Section 5.11). This mirrors the
+	// WRITE/READ handlers so a bogus/expired/revoked/wrong-filehandle stateid is
+	// rejected, the READ-bypass (all-ones) special stateid cannot truncate, and
+	// a real open stateid renews its lease.
+	//
+	// StateManager may be nil in unit fixtures that exercise only the metadata
+	// path; in that case fall back to the special-stateid guard so a READ-bypass
+	// stateid still cannot drive a size change.
+	sizeChange := setAttrs.Size != nil
+	if h.StateManager != nil {
+		op := state.StateidOpRead
+		if sizeChange {
+			op = state.StateidOpWrite
+		}
+		openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, op)
+		if stateErr != nil {
+			nfsStatus := mapStateError(stateErr)
+			logger.Debug("NFSv4 SETATTR stateid validation failed",
+				"error", stateErr,
+				"nfs_status", nfsStatus,
+				"size_change", sizeChange,
+				"handle", string(ctx.CurrentFH),
+				"client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: nfsStatus,
+				OpCode: types.OP_SETATTR,
+				Data:   encodeSetAttrError(nfsStatus),
+			}
+		}
+		// A size change requires the open to carry WRITE access. Special
+		// stateids (openState == nil) bypass this check; the READ-bypass
+		// stateid was already rejected by ValidateStateid for the write op.
+		if sizeChange && openState != nil &&
+			openState.ShareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+			logger.Debug("NFSv4 SETATTR rejected: size change on read-only open",
+				"share_access", openState.ShareAccess,
+				"handle", string(ctx.CurrentFH),
+				"client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_OPENMODE,
+				OpCode: types.OP_SETATTR,
+				Data:   encodeSetAttrError(types.NFS4ERR_OPENMODE),
+			}
+		}
+	} else if sizeChange && stateid.IsReadBypassStateid() {
 		logger.Debug("NFSv4 SETATTR rejected: READ-bypass stateid on size change",
 			"handle", string(ctx.CurrentFH),
 			"client", ctx.ClientAddr)

--- a/internal/adapter/nfs/v4/handlers/shareres_test.go
+++ b/internal/adapter/nfs/v4/handlers/shareres_test.go
@@ -119,6 +119,84 @@ func TestSetAttr_ReadBypassStateid_OnSizeChange_ReturnsBadStateid(t *testing.T) 
 	}
 }
 
+// encodeSetAttrSizeArgs builds SETATTR4args with a FATTR4_SIZE change to the
+// given size using the supplied stateid.
+func encodeSetAttrSizeArgs(t *testing.T, stateid *types.Stateid4, size uint64) []byte {
+	t.Helper()
+	var attrVals bytes.Buffer
+	_ = xdr.WriteUint64(&attrVals, size)
+	var bitmap []uint32
+	attrs.SetBit(&bitmap, attrs.FATTR4_SIZE)
+	return encodeSetAttrArgs(t, stateid, bitmap, attrVals.Bytes())
+}
+
+// TestSetAttr_BogusStateid_OnSizeChange_ReturnsBadStateid verifies a SETATTR
+// that changes size with an unknown (never-OPENed) real stateid is rejected by
+// ValidateStateid (RFC 7530 Section 16.32), mirroring WRITE.
+func TestSetAttr_BogusStateid_OnSizeChange_ReturnsBadStateid(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "bogus.txt", 0o644, 0, 0)
+	fx.writeContent(t, fileHandle, []byte("0123456789"))
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	// A non-special stateid that was never issued by the server.
+	bogus := &types.Stateid4{Seqid: 1}
+	bogus.Other[0] = 0xDE
+	bogus.Other[1] = 0xAD
+
+	args := encodeSetAttrSizeArgs(t, bogus, 0)
+	result := fx.handler.handleSetAttr(ctx, bytes.NewReader(args))
+	// A never-issued stateid is rejected as BAD_STATEID (current epoch) or
+	// STALE_STATEID (prior-epoch byte pattern) — either is a valid rejection;
+	// the point is the size change is NOT silently accepted.
+	if result.Status != types.NFS4ERR_BAD_STATEID && result.Status != types.NFS4ERR_STALE_STATEID {
+		t.Errorf("SETATTR(size) with bogus stateid status = %d, want NFS4ERR_BAD_STATEID (%d) or NFS4ERR_STALE_STATEID (%d)",
+			result.Status, types.NFS4ERR_BAD_STATEID, types.NFS4ERR_STALE_STATEID)
+	}
+}
+
+// TestSetAttr_ReadOnlyOpenStateid_OnSizeChange_ReturnsOpenMode verifies a
+// SETATTR truncate using a READ-only open's real stateid is rejected with
+// NFS4ERR_OPENMODE — the open-mode gate WRITE enforces must also apply to a
+// size-changing SETATTR (round-1 H18).
+func TestSetAttr_ReadOnlyOpenStateid_OnSizeChange_ReturnsOpenMode(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdonly", types.OPEN4_SHARE_ACCESS_READ)
+	fx.writeContent(t, fileHandle, []byte("content"))
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeSetAttrSizeArgs(t, stateid, 0)
+	result := fx.handler.handleSetAttr(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_OPENMODE {
+		t.Errorf("SETATTR(size) with read-only open stateid status = %d, want NFS4ERR_OPENMODE (%d)",
+			result.Status, types.NFS4ERR_OPENMODE)
+	}
+}
+
+// TestSetAttr_WriteOpenStateid_OnSizeChange_Allowed verifies a SETATTR truncate
+// with a valid read-write open stateid succeeds (regression guard for the
+// stateid validation added for H18 not being over-strict).
+func TestSetAttr_WriteOpenStateid_OnSizeChange_Allowed(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdwr", types.OPEN4_SHARE_ACCESS_BOTH)
+	fx.writeContent(t, fileHandle, []byte("content"))
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeSetAttrSizeArgs(t, stateid, 0)
+	result := fx.handler.handleSetAttr(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Errorf("SETATTR(size) with read-write open stateid status = %d, want NFS4_OK", result.Status)
+	}
+}
+
 func TestRead_ReadBypassStateid_Allowed(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	fileHandle := fx.createRegularFile(t, fx.rootHandle, "rbypass.txt", 0o644, 0, 0)

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/config"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -414,6 +415,22 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	metadataService := rt.GetMetadataService()
 	nlmSvc := s.createRoutingNLMService(metadataService)
 	s.nlmHandler = nlm_handlers.NewHandler(nlmSvc, s.blockingQueue)
+
+	// Cross-protocol blocked-waiter wakeup: a byte-range UNLOCK on ANY protocol
+	// (notably an SMB UNLOCK) must re-drive blocked NLM waiters on the freed
+	// range, because NLM uses a server-driven NLM_GRANTED callback rather than
+	// poll-retry. Register the hook on the service for shares added later AND
+	// stamp it onto lock managers already created at boot (shares loaded before
+	// this adapter existed), mirroring the grace-coordinator catch-up below.
+	byteRangeReleaseHook := func(handleKey string) {
+		go s.processNLMWaiters(metadata.FileHandle(handleKey))
+	}
+	metadataService.SetByteRangeReleaseHook(byteRangeReleaseHook)
+	for _, shareName := range rt.ListShares() {
+		if lm := metadataService.GetLockManagerForShare(shareName); lm != nil {
+			lm.SetByteRangeReleaseCallback(byteRangeReleaseHook)
+		}
+	}
 
 	// Couple the NFSv4 StateManager grace machine to the per-share lock-manager
 	// grace machine so both enter/exit the post-restart window together. Shares

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -539,6 +539,20 @@ func releaseCrashedClientLocks(
 			continue
 		}
 
+		// Defense in depth against grace-defeating cleanup: never release a
+		// client's persisted locks while the share is in its reclaim grace
+		// window. During grace a momentarily-unreachable client may still
+		// reconnect and reclaim; the grace timer's onGraceEnd sweep ages out
+		// any locks that genuinely go unreclaimed. Crash cleanup that fired
+		// inside grace would hand a held byte-range to a third party before the
+		// rightful client got its reclaim chance.
+		if lockMgr.IsInGracePeriod() {
+			logger.Info("NSM: skipping crash cleanup during grace; deferring to reclaim/onGraceEnd",
+				"share", shareName,
+				"client", clientID)
+			continue
+		}
+
 		released := lockMgr.ReleaseByOwnerPrefix(clientPrefix)
 		totalReleased += released
 		if released > 0 {

--- a/pkg/adapter/nfs/nlm_crash_test.go
+++ b/pkg/adapter/nfs/nlm_crash_test.go
@@ -2,6 +2,7 @@ package nfs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -97,6 +98,49 @@ func TestReleaseCrashedClientLocks(t *testing.T) {
 		Type:       lock.LockTypeExclusive,
 	})
 	require.NoError(t, err, "B must be able to acquire the freed range after A's crash")
+}
+
+// TestReleaseCrashedClientLocks_SkipsDuringGrace proves crash cleanup does NOT
+// release a client's persisted locks while the share is in its reclaim grace
+// window: a momentarily-unreachable client may still reconnect and reclaim, so
+// wiping its locks inside grace would defeat the grace fix (NFS H-D / NSM
+// grace regression). The grace timer's onGraceEnd sweep is the only path that
+// ages out genuinely-unreclaimed locks.
+func TestReleaseCrashedClientLocks_SkipsDuringGrace(t *testing.T) {
+	t.Parallel()
+
+	// Manager with a grace period manager, placed into its grace window.
+	gpm := lock.NewGracePeriodManager(time.Hour, func() {})
+	lmGrace := lock.NewManagerWithGracePeriod(gpm)
+	lmGrace.EnterGracePeriod([]string{"clientA"})
+	require.True(t, lmGrace.IsInGracePeriod(), "manager must be in grace for this test")
+
+	// A second share NOT in grace, to prove the gate is per-share.
+	lmNormal := lock.NewManager()
+	require.False(t, lmNormal.IsInGracePeriod())
+
+	lockMgrFor := func(share string) *metadata.LockManager {
+		switch share {
+		case "share-grace":
+			return lmGrace
+		case "share-normal":
+			return lmNormal
+		default:
+			return nil
+		}
+	}
+
+	addNLMLock(t, lmGrace, "share-grace:file1", "nlm:clientA:1:aa", 0)
+	addNLMLock(t, lmNormal, "share-normal:file1", "nlm:clientA:2:bb", 0)
+
+	releaseCrashedClientLocks("clientA", []string{"share-grace", "share-normal"}, lockMgrFor, nil)
+
+	// In-grace share keeps the lock (deferred to reclaim/onGraceEnd).
+	require.Len(t, lmGrace.ListUnifiedLocks("share-grace:file1"), 1,
+		"locks on an in-grace share must survive crash cleanup")
+	// Non-grace share is cleaned up normally.
+	require.Empty(t, lmNormal.ListUnifiedLocks("share-normal:file1"),
+		"locks on a non-grace share must still be released")
 }
 
 // TestReleaseCrashedClientLocks_NoLocksHeld proves idempotency / safety when the

--- a/pkg/metadata/cross_protocol_unlock_wakeup_test.go
+++ b/pkg/metadata/cross_protocol_unlock_wakeup_test.go
@@ -1,0 +1,92 @@
+package metadata_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetByteRangeReleaseHook_FiresOnSMBUnlock proves the cross-protocol
+// blocked-waiter wakeup seam end-to-end through the MetadataService: the hook
+// registered via SetByteRangeReleaseHook is stamped onto the per-share lock
+// manager at registration, and an SMB-style byte-range UnlockFile fires it with
+// the correct handle key. In production the NFS adapter wires this hook to
+// processNLMWaiters so an NLM F_SETLKW waiter blocked on the released SMB lock
+// is woken (NLM uses a server-driven NLM_GRANTED callback, not poll-retry).
+//
+// This is the regression guard for the cross-protocol NLM-waiter starvation
+// (area #5 H-1): before the fix the SMB UNLOCK path had no hook into the NLM
+// drain, so an NLM waiter blocked on an SMB lock hung indefinitely.
+func TestSetByteRangeReleaseHook_FiresOnSMBUnlock(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	const shareName = "/xproto"
+
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+	})
+	require.NoError(t, err)
+
+	svc := metadata.New()
+
+	// Register the hook BEFORE the share so it is stamped onto the manager at
+	// creation (no UNLOCK can race past the manager becoming observable without
+	// the hook).
+	var (
+		mu    sync.Mutex
+		fired []string
+	)
+	svc.SetByteRangeReleaseHook(func(handleKey string) {
+		mu.Lock()
+		fired = append(fired, handleKey)
+		mu.Unlock()
+	})
+
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(t, err)
+
+	authCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID: metadata.Uint32Ptr(0),
+			GID: metadata.Uint32Ptr(0),
+		},
+		ClientAddr: "127.0.0.1",
+	}
+
+	file, err := svc.CreateFile(authCtx, rootHandle, "locked.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeFileHandle(file)
+	require.NoError(t, err)
+	handleKey := string(handle)
+
+	// Acquire an SMB-style byte-range lock (OpenID + SessionID set).
+	const sessionID = uint64(7)
+	require.NoError(t, svc.LockFile(authCtx, handle, metadata.FileLock{
+		ID:        1,
+		OpenID:    "smb-open-1",
+		SessionID: sessionID,
+		Offset:    0,
+		Length:    100,
+		Exclusive: true,
+	}))
+
+	// The SMB UNLOCK path must fire the cross-protocol release hook so blocked
+	// NLM waiters on this handle are re-driven.
+	require.NoError(t, svc.UnlockFile(ctx, handle, "smb-open-1", sessionID, 0, 100))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{handleKey}, fired,
+		"SMB UnlockFile must fire the byte-range release hook with the handle key")
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -691,6 +691,16 @@ type Manager struct {
 	// Delegation-related fields
 	breakWaitChans          map[string]chan struct{} // per-handleKey channel for break wait
 	delegationRecallTimeout time.Duration            // default 90s, configurable
+
+	// onByteRangeRelease is a protocol-agnostic notification fired after a
+	// byte-range lock is released on handleKey, so a different protocol's
+	// blocked waiters can be re-driven. It exists because NLM uses a
+	// server-driven GRANTED-callback model (it does not poll): when an SMB
+	// UNLOCK frees a range an NLM waiter is blocked on, that waiter must be
+	// actively woken. The NFS adapter wires this to its processNLMWaiters
+	// drain, mirroring the NLM-side onUnlock callback. May be nil. Fired
+	// outside lm.mu so the subscriber can call back into the Manager.
+	onByteRangeRelease func(handleKey string)
 }
 
 // DefaultDelegationRecallTimeout is the default delegation recall timeout.
@@ -731,6 +741,28 @@ func NewManagerWithGracePeriod(gracePeriod *GracePeriodManager) *Manager {
 	m := newBaseManager(defaultRecentlyBrokenTTL)
 	m.gracePeriod = gracePeriod
 	return m
+}
+
+// SetByteRangeReleaseCallback registers a protocol-agnostic notification that
+// fires after a byte-range lock is released on a handle (see the field doc on
+// onByteRangeRelease). Used by the NFS adapter to re-drive blocked NLM waiters
+// when an SMB UNLOCK frees a contended range. Safe to call once at wiring time.
+func (lm *Manager) SetByteRangeReleaseCallback(fn func(handleKey string)) {
+	lm.mu.Lock()
+	lm.onByteRangeRelease = fn
+	lm.mu.Unlock()
+}
+
+// notifyByteRangeReleased fires the release callback (if registered) for
+// handleKey. MUST be called WITHOUT lm.mu held: the subscriber (e.g. the NLM
+// waiter drain) calls back into the Manager to re-attempt blocked locks.
+func (lm *Manager) notifyByteRangeReleased(handleKey string) {
+	lm.mu.RLock()
+	fn := lm.onByteRangeRelease
+	lm.mu.RUnlock()
+	if fn != nil {
+		fn(handleKey)
+	}
 }
 
 // Lock attempts to acquire a byte-range lock on a file.
@@ -808,12 +840,22 @@ func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 //
 // Returns nil on success, or ErrLockNotFound if the lock wasn't found.
 func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, offset, length uint64) error {
+	released, err := lm.unlockLocked(handleKey, openID, sessionID, offset, length)
+	if released {
+		// A freed byte-range may unblock a cross-protocol waiter (e.g. an NLM
+		// F_SETLKW blocked on this SMB lock). Notify outside lm.mu.
+		lm.notifyByteRangeReleased(handleKey)
+	}
+	return err
+}
+
+func (lm *Manager) unlockLocked(handleKey string, openID string, sessionID uint64, offset, length uint64) (bool, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
-		return NewLockNotFoundError("")
+		return false, NewLockNotFoundError("")
 	}
 
 	// Find and remove the matching lock. For stacked identical SMB shared
@@ -832,11 +874,11 @@ func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, off
 			if len(lm.locks[handleKey]) == 0 {
 				delete(lm.locks, handleKey)
 			}
-			return nil
+			return true, nil
 		}
 	}
 
-	return NewLockNotFoundError("")
+	return false, NewLockNotFoundError("")
 }
 
 // UnlockAllForOpen releases all locks held by a specific open on a file.
@@ -846,6 +888,15 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 	if openID == "" {
 		return 0 // empty openID would match all unset locks — guard against misuse
 	}
+	removed := lm.unlockAllForOpenLocked(handleKey, openID)
+	if removed > 0 {
+		// Freed ranges may unblock cross-protocol waiters; notify outside lm.mu.
+		lm.notifyByteRangeReleased(handleKey)
+	}
+	return removed
+}
+
+func (lm *Manager) unlockAllForOpenLocked(handleKey string, openID string) int {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -880,6 +931,15 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 //
 // Returns the number of locks released.
 func (lm *Manager) UnlockAllForSession(handleKey string, sessionID uint64) int {
+	removed := lm.unlockAllForSessionLocked(handleKey, sessionID)
+	if removed > 0 {
+		// Freed ranges may unblock cross-protocol waiters; notify outside lm.mu.
+		lm.notifyByteRangeReleased(handleKey)
+	}
+	return removed
+}
+
+func (lm *Manager) unlockAllForSessionLocked(handleKey string, sessionID uint64) int {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -840,7 +840,7 @@ func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 //
 // Returns nil on success, or ErrLockNotFound if the lock wasn't found.
 func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, offset, length uint64) error {
-	released, err := lm.unlockLocked(handleKey, openID, sessionID, offset, length)
+	released, err := lm.doUnlock(handleKey, openID, sessionID, offset, length)
 	if released {
 		// A freed byte-range may unblock a cross-protocol waiter (e.g. an NLM
 		// F_SETLKW blocked on this SMB lock). Notify outside lm.mu.
@@ -849,7 +849,7 @@ func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, off
 	return err
 }
 
-func (lm *Manager) unlockLocked(handleKey string, openID string, sessionID uint64, offset, length uint64) (bool, error) {
+func (lm *Manager) doUnlock(handleKey string, openID string, sessionID uint64, offset, length uint64) (bool, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -888,7 +888,7 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 	if openID == "" {
 		return 0 // empty openID would match all unset locks — guard against misuse
 	}
-	removed := lm.unlockAllForOpenLocked(handleKey, openID)
+	removed := lm.doUnlockAllForOpen(handleKey, openID)
 	if removed > 0 {
 		// Freed ranges may unblock cross-protocol waiters; notify outside lm.mu.
 		lm.notifyByteRangeReleased(handleKey)
@@ -896,7 +896,7 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 	return removed
 }
 
-func (lm *Manager) unlockAllForOpenLocked(handleKey string, openID string) int {
+func (lm *Manager) doUnlockAllForOpen(handleKey string, openID string) int {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
@@ -931,7 +931,7 @@ func (lm *Manager) unlockAllForOpenLocked(handleKey string, openID string) int {
 //
 // Returns the number of locks released.
 func (lm *Manager) UnlockAllForSession(handleKey string, sessionID uint64) int {
-	removed := lm.unlockAllForSessionLocked(handleKey, sessionID)
+	removed := lm.doUnlockAllForSession(handleKey, sessionID)
 	if removed > 0 {
 		// Freed ranges may unblock cross-protocol waiters; notify outside lm.mu.
 		lm.notifyByteRangeReleased(handleKey)
@@ -939,7 +939,7 @@ func (lm *Manager) UnlockAllForSession(handleKey string, sessionID uint64) int {
 	return removed
 }
 
-func (lm *Manager) unlockAllForSessionLocked(handleKey string, sessionID uint64) int {
+func (lm *Manager) doUnlockAllForSession(handleKey string, sessionID uint64) int {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // ============================================================================
@@ -17,6 +19,66 @@ func TestManager_ImplementsLockManager(t *testing.T) {
 	// Runtime verification that NewManager returns a usable LockManager:
 	var lm LockManager = NewManager()
 	_ = lm // interface assignment confirms compliance
+}
+
+// ============================================================================
+// Cross-protocol byte-range release callback
+// ============================================================================
+
+// TestManager_ByteRangeReleaseCallback_FiresOnUnlock proves the protocol-
+// agnostic release notification fires once per SMB-style byte-range release path
+// (Unlock / UnlockAllForOpen / UnlockAllForSession) so a blocked cross-protocol
+// waiter (e.g. an NLM F_SETLKW waiter) can be re-driven. A no-op unlock (nothing
+// removed) must NOT fire.
+func TestManager_ByteRangeReleaseCallback_FiresOnUnlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Unlock fires once", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		var fired []string
+		lm.SetByteRangeReleaseCallback(func(h string) { fired = append(fired, h) })
+
+		require.NoError(t, lm.Lock("file1", FileLock{ID: 1, OpenID: "open-a", Offset: 0, Length: 10, Exclusive: true}))
+		require.NoError(t, lm.Unlock("file1", "open-a", 0, 0, 10))
+		require.Equal(t, []string{"file1"}, fired)
+	})
+
+	t.Run("no-op Unlock does not fire", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		var count int
+		lm.SetByteRangeReleaseCallback(func(string) { count++ })
+
+		// Nothing held -> LockNotFound -> no release notification.
+		_ = lm.Unlock("file1", "open-a", 0, 0, 10)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("UnlockAllForOpen fires when locks removed", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		var count int
+		lm.SetByteRangeReleaseCallback(func(string) { count++ })
+
+		require.NoError(t, lm.Lock("file1", FileLock{ID: 1, OpenID: "open-a", Offset: 0, Length: 10, Exclusive: true}))
+		require.Equal(t, 1, lm.UnlockAllForOpen("file1", "open-a"))
+		require.Equal(t, 1, count)
+		// Removing nothing must not fire again.
+		require.Equal(t, 0, lm.UnlockAllForOpen("file1", "open-a"))
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("UnlockAllForSession fires when locks removed", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		var count int
+		lm.SetByteRangeReleaseCallback(func(string) { count++ })
+
+		require.NoError(t, lm.Lock("file1", FileLock{ID: 1, SessionID: 42, Offset: 0, Length: 10, Exclusive: true}))
+		require.Equal(t, 1, lm.UnlockAllForSession("file1", 42))
+		require.Equal(t, 1, count)
+	})
 }
 
 // ============================================================================

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -56,6 +56,16 @@ type MetadataService struct {
 	// StateManager grace machine in lockstep with the lock-manager grace machine
 	// so both enter and exit together. Registered via SetGraceCoordinator.
 	graceCoordinator GraceCoordinator
+
+	// byteRangeReleaseHook, if set, is stamped onto every per-share lock manager
+	// at creation so a byte-range UNLOCK on ANY protocol re-drives blocked
+	// waiters on the OTHER protocol. The NFS adapter wires this to its
+	// processNLMWaiters drain: an NLM F_SETLKW waiter blocked on an SMB lock is
+	// woken when the SMB holder unlocks (NLM uses a server-driven GRANTED
+	// callback, not poll-retry). Registered via SetByteRangeReleaseHook before
+	// RegisterStoreForShare to affect a given share. The hook receives the
+	// handle key (string-encoded FileHandle).
+	byteRangeReleaseHook func(handleKey string)
 }
 
 // GraceCoordinator couples the lock-manager grace period with another grace
@@ -118,6 +128,17 @@ func (s *MetadataService) SetGraceCoordinator(c GraceCoordinator) {
 	s.graceCoordinator = c
 }
 
+// SetByteRangeReleaseHook registers a protocol-agnostic notification that every
+// per-share lock manager fires after a byte-range UNLOCK, so a release on one
+// protocol re-drives blocked waiters on another (e.g. an SMB UNLOCK waking an
+// NLM F_SETLKW waiter). Must be called before RegisterStoreForShare to affect a
+// given share. The hook receives the string-encoded FileHandle (handle key).
+func (s *MetadataService) SetByteRangeReleaseHook(fn func(handleKey string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byteRangeReleaseHook = fn
+}
+
 // RegisterStoreForShare associates a metadata store with a share.
 // Each share must have exactly one store. Calling this again for the same
 // share will replace the previous store.
@@ -149,6 +170,7 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	s.mu.Lock()
 	graceDuration := s.graceDuration
 	graceCoordinator := s.graceCoordinator
+	byteRangeReleaseHook := s.byteRangeReleaseHook
 	s.mu.Unlock()
 	if graceDuration <= 0 {
 		graceDuration = DefaultLockGracePeriod
@@ -186,6 +208,14 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 		}
 	} else {
 		lm = NewLockManager()
+	}
+
+	// Stamp the cross-protocol byte-range release notification so an UNLOCK on
+	// this share wakes blocked waiters on another protocol (e.g. NLM F_SETLKW
+	// blocked on an SMB lock). Set before publishing so no UNLOCK can race past
+	// the manager becoming observable without the hook.
+	if byteRangeReleaseHook != nil {
+		lm.SetByteRangeReleaseCallback(byteRangeReleaseHook)
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
Fixes the NFS + NLM/lock correctness tail from the v1.0 audit (areas #4 and #5). Four self-contained fixes, each with regression tests.

## 1. SETATTR never validated the stateid (audit #4 H18 / H-A)
`handleSetAttr` decoded and logged the stateid but never called `ValidateStateid` (unlike WRITE/READ), so a bogus / expired / revoked-after-CLOSE / wrong-filehandle stateid was silently accepted, no lease renewal occurred, and a READ-only open's stateid could drive a truncate.

SETATTR now validates the stateid via `StateManager` (RFC 7530 §16.32): a size-changing SETATTR is validated as write-family and requires the open to carry `OPEN4_SHARE_ACCESS_WRITE` (`NFS4ERR_OPENMODE` otherwise); any other SETATTR is validated read-family (the stateid is only meaningful for size). Mirrors `write.go`. The pre-existing all-ones READ-bypass guard is preserved (and now enforced by `ValidateStateid` itself).

## 2/3. SM_NOTIFY-failure + crash-cleanup defeated grace (audit #4 NSM-grace / H-D)
On server restart, a failed **outbound** `SM_NOTIFY` was treated as a client crash and immediately wiped the client's in-memory **and persisted** NLM locks — inside the reclaim grace window, for exactly the momentarily-unreachable clients grace exists to protect.

- `NotifyAllClients` no longer treats an outbound notify-delivery failure as crash evidence; locks are left intact for the grace timer + `onGraceEnd` sweep. Crash cleanup is reserved for inbound evidence (`DetectCrash`), matching canonical rpc.statd / Linux `fs/lockd` semantics.
- `releaseCrashedClientLocks` additionally skips any share whose lock manager is currently in its grace window (defense in depth).

## 4. NLM blocking-waiter starvation on SMB unlock (audit #5 H-1)
After #865, an NLM blocking lock (`F_SETLKW`) correctly blocks on a conflicting SMB byte-range lock — but the SMB UNLOCK path had no hook into the NLM blocked-waiter drain, so the NLM waiter never received its server-driven `NLM_GRANTED` callback and hung indefinitely.

The lock `Manager` now exposes a protocol-agnostic release notification, fired outside its mutex by the SMB unlock paths (`Unlock` / `UnlockAllForOpen` / `UnlockAllForSession`). The `MetadataService` stamps the hook onto every per-share lock manager, and the NFS adapter wires it to `processNLMWaiters` (mirroring the existing NLM `onUnlock` callback, with a boot catch-up for shares loaded before the adapter). An SMB release now re-drives blocked NLM waiters on the same handle.

## Tests
- `internal/adapter/nfs/v4/handlers`: bogus-stateid and read-only-open SETATTR truncate rejected; read-write-open truncate allowed.
- `internal/adapter/nfs/nsm`: failed outbound notify does NOT trigger crash cleanup; inbound `DetectCrash` still does.
- `pkg/adapter/nfs`: crash cleanup skips an in-grace share, still cleans a non-grace share.
- `pkg/metadata/lock`: release callback fires once per SMB unlock path, not on no-op unlocks.
- `pkg/metadata`: SMB `UnlockFile` fires the cross-protocol release hook end-to-end.

`go build ./...`, targeted tests, `go test -race` on the lock/waiter changes, `gofmt`/`go vet`/`golangci-lint` all clean.