### PR TITLE
fix(snapshot): protect restore safety-snapshot, quiesce rollup on rollback, decouple drain deadline (v1.0 audit #8)

### DIFF
--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -207,8 +207,36 @@ func (h *SnapshotHandler) Restore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), h.restoreHTTPTimeout)
+	// Restore is a long, destructive operation: it creates a pre-restore
+	// safety snapshot whose drain to a remote can take minutes on a
+	// remote-backed share. The router applies a short global request timeout
+	// (chi middleware.Timeout) to every route; if the restore inherited that
+	// deadline the pre-restore safety-snapshot drain would be cancelled
+	// mid-flight and the restore would spuriously 500 even though the drain
+	// later completes (issue #842). Detach from the inherited (short) HTTP
+	// deadline with WithoutCancel and apply the dedicated, operator-tunable
+	// restore budget instead. Client disconnect is still honoured below so a
+	// genuinely abandoned request does not pin a restore forever.
+	//
+	// chi's middleware.Timeout only cancels the *request* context and, in a
+	// deferred check that runs AFTER this handler returns, writes a 504 iff
+	// that context hit DeadlineExceeded. Because the restore runs on the
+	// detached ctx it completes regardless, and this handler writes its real
+	// 200/4xx/5xx response before returning — so the middleware's later 504
+	// WriteHeader is a no-op (first write wins), the client gets the genuine
+	// result. (Covered by TestSnapshotHandler_Restore_DecoupledFromGlobalTimeout.)
+	base := context.WithoutCancel(r.Context())
+	ctx, cancel := context.WithTimeout(base, h.restoreHTTPTimeout)
 	defer cancel()
+
+	// Propagate a real client disconnect (not the middleware timeout) so the
+	// restore is cancelled if the caller goes away.
+	stop := context.AfterFunc(r.Context(), func() {
+		if r.Context().Err() == context.Canceled {
+			cancel()
+		}
+	})
+	defer stop()
 
 	safetyID, err := h.runtime.RestoreSnapshot(ctx, name, snapID,
 		runtime.RestoreSnapshotOpts{AllowNonDurable: body.AllowNonDurable})
@@ -304,6 +332,9 @@ func mapSnapshotError(w http.ResponseWriter, err error) bool {
 		return true
 	case errors.Is(err, models.ErrSnapshotInFlight):
 		Conflict(w, "snapshot operation is in progress; retry once it completes")
+		return true
+	case errors.Is(err, models.ErrSnapshotMarkerProtected):
+		Conflict(w, "snapshot is protected by an in-progress restore; retry once it completes")
 		return true
 	case errors.Is(err, models.ErrSnapshotStateConflict):
 		Conflict(w, "snapshot is not in a state that allows this operation")

--- a/internal/controlplane/api/handlers/snapshot_test.go
+++ b/internal/controlplane/api/handlers/snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/api/dto"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -83,6 +84,75 @@ func newSnapshotRouter(h *SnapshotHandler) http.Handler {
 		})
 	})
 	return r
+}
+
+// newSnapshotRouterWithGlobalTimeout mirrors the production router's global
+// short request timeout (middleware.Timeout) applied to every route, so a
+// test can assert the restore handler is not cancelled by it (issue #842).
+func newSnapshotRouterWithGlobalTimeout(h *SnapshotHandler, d time.Duration) http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Timeout(d))
+	r.Route("/api/v1/shares", func(r chi.Router) {
+		r.Route("/{name}/snapshots", func(r chi.Router) {
+			r.Post("/{id}/restore", h.Restore)
+		})
+	})
+	return r
+}
+
+// TestSnapshotHandler_Restore_DecoupledFromGlobalTimeout asserts that the
+// router's short global request timeout does not abort a restore whose own
+// budget is larger — the pre-restore safety-snapshot drain must be allowed to
+// run past the global handler deadline AND the client must still receive the
+// real 200 success response, not the middleware's 504 (issue #842).
+func TestSnapshotHandler_Restore_DecoupledFromGlobalTimeout(t *testing.T) {
+	gotCtxErr := make(chan error, 1)
+	fake := &fakeSnapshotRuntime{
+		restoreFn: func(ctx context.Context, _, _ string, _ runtime.RestoreSnapshotOpts) (string, error) {
+			// Simulate work that outlasts the global 20ms timeout but
+			// finishes well inside the restore budget.
+			select {
+			case <-ctx.Done():
+				gotCtxErr <- ctx.Err()
+				return "", ctx.Err()
+			case <-time.After(80 * time.Millisecond):
+				gotCtxErr <- nil
+				return "safety-1", nil
+			}
+		},
+	}
+	// Generous restore budget; tiny global request timeout.
+	h := NewSnapshotHandler(fake, 5*time.Second, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares/data/snapshots/snap-1/restore", nil)
+	rr := httptest.NewRecorder()
+	newSnapshotRouterWithGlobalTimeout(h, 20*time.Millisecond).ServeHTTP(rr, req)
+
+	select {
+	case err := <-gotCtxErr:
+		if err != nil {
+			t.Fatalf("restore was cancelled by the global request timeout: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("restoreFn never returned")
+	}
+
+	// The decoupling is only real if the client gets the genuine success
+	// response. The chi middleware.Timeout fires its deferred 504 WriteHeader
+	// after the handler returns (the request context's deadline elapsed during
+	// the 80ms restore); the handler must have already written 200 + body so
+	// that stale 504 is a no-op. Asserting only the inner ctx error would pass
+	// even if the response had been clobbered to 504.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (middleware 504 must not clobber the success response): body=%s",
+			rr.Code, rr.Body.String())
+	}
+	var got dto.RestoreSnapshotResponse
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v (body=%s)", err, rr.Body.String())
+	}
+	if got.SafetySnapshotID != "safety-1" || got.SnapshotID != "snap-1" || got.Share != "/data" {
+		t.Fatalf("body = %+v, want {snap-1, /data, safety-1}", got)
+	}
 }
 
 func TestSnapshotHandler_Create_HappyPath(t *testing.T) {
@@ -361,6 +431,7 @@ func TestMapSnapshotError_SentinelTable(t *testing.T) {
 		{"RetryTargetNotFailed", models.ErrSnapshotRetryTargetNotFailed, http.StatusConflict},
 		{"StateConflict", models.ErrSnapshotStateConflict, http.StatusConflict},
 		{"InFlight", models.ErrSnapshotInFlight, http.StatusConflict},
+		{"MarkerProtected", models.ErrSnapshotMarkerProtected, http.StatusConflict},
 		{"DrainTimeout", models.ErrSnapshotDrainTimeout, http.StatusGatewayTimeout},
 		{"MetadataDumpMissing", models.ErrSnapshotMetadataDumpMissing, http.StatusInternalServerError},
 		{"MetadataStoreNotResetable", models.ErrMetadataStoreNotResetable, http.StatusInternalServerError},

--- a/pkg/blockstore/engine/flush.go
+++ b/pkg/blockstore/engine/flush.go
@@ -125,9 +125,11 @@ func (bs *Store) DrainRollups(ctx context.Context) error {
 
 // ResetLocalState clears the local store's per-payload append-log state so
 // post-restore reads resolve purely through the restored CAS manifest.
-// The snapshot-restore orchestration calls this AFTER the metadata
-// Restore() so a file modified in place after the snapshot is not served
-// from a stale append-log record overlaid on the restored CAS bytes.
+// The snapshot-restore orchestration calls this BEFORE the metadata Reset()
+// + Restore() (not after): clearing the overlay first leaves no dirty
+// intervals for a background rollup worker to flush into the freshly-restored
+// metadata, so a file modified in place after the snapshot is not served from
+// a stale append-log record overlaid on the restored CAS bytes.
 func (bs *Store) ResetLocalState(ctx context.Context) error {
 	if err := bs.enter(); err != nil {
 		return err

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -43,6 +43,16 @@ var (
 	// orchestration reaches a terminal state.
 	ErrSnapshotInFlight = errors.New("snapshot operation is in progress")
 
+	// ErrSnapshotMarkerProtected is returned when a delete is attempted on a
+	// snapshot that an in-flight (or crash-interrupted) restore depends on as
+	// its rollback target — i.e. the snapshot is named by the per-share
+	// restore marker as the safety snapshot (or the target snapshot). The
+	// safety snapshot is the sole rollback primitive, so deleting it would
+	// destroy the only recoverable pre-restore state and permanently wedge the
+	// share. Mapped to 409 — the caller may retry once the restore completes
+	// and clears its marker.
+	ErrSnapshotMarkerProtected = errors.New("snapshot is protected by an in-progress restore and cannot be deleted")
+
 	// ErrSnapshotLocalStoreUnsupported is returned when a snapshot is
 	// requested on a share whose local block store has no on-disk root
 	// (the in-memory backend), so the metadata.dump + manifest.hashes

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1236,6 +1236,32 @@ func (r *Runtime) restoreSnapshot(
 		)
 	}
 
+	// --- quiesce rollup workers on the rollback path ---
+	// On the normal (operator) restore path the pre-restore safety snapshot's
+	// CreateSnapshot runs DrainRollups synchronously below, which blocks on
+	// in-flight rollups via the per-file mutex and leaves no dirty intervals
+	// behind before ResetLocalState — the fs rollup workers are quiesced.
+	//
+	// The rollback path (startup recovery) SKIPS the safety snapshot, so it
+	// would otherwise reach ResetLocalState with the fs rollup worker pool
+	// already running on boot-recovered dirty intervals (StartRollup runs in
+	// AddShare, before Serve→recoverInterruptedRestores). A worker mid-rollup
+	// could persist post-snapshot FileBlock refs over the just-restored
+	// FileAttr.Blocks (#8 H3, silent corruption of the rolled-back share).
+	// Drain rollups here so the rollback gets the same quiesce guarantee:
+	// DrainRollups waits on the per-file mutex for any in-flight pass to
+	// finish and, with the share disabled, leaves no dirty intervals for the
+	// ticker to pick up afterwards. No-op on memory local stores (inline
+	// rollup, nothing to drain).
+	if internal.isRollback {
+		if derr := bs.DrainRollups(ctx); derr != nil {
+			return "", fmt.Errorf("restore snapshot %q: drain rollups before rollback: %w: %v",
+				snapID, models.ErrRestoreAborted, derr)
+		}
+		logger.Info("snapshot restore: rollback drained rollups before reset",
+			"snapshot_id", snapID, "share", shareName)
+	}
+
 	// --- safety snapshot ---
 	// Default opts (NoVerify=false) keep the safety snap drained and
 	// verified — it is the rollback primitive if any step below fails. On a
@@ -1546,6 +1572,30 @@ func (r *Runtime) DeleteSnapshot(ctx context.Context, share, snapID string) erro
 	if r.isSnapInFlight(share, snapID) {
 		return fmt.Errorf("delete snapshot %q on share %q: %w",
 			snapID, share, models.ErrSnapshotInFlight)
+	}
+
+	// Fence against the per-share restore marker. While a restore is in
+	// flight (or crash-interrupted and awaiting startup rollback), the marker
+	// names the pre-restore safety snapshot — the SOLE rollback primitive —
+	// and the target snapshot it restores from. Deleting either out from
+	// under the restore destroys the only recoverable pre-restore state and
+	// permanently wedges the share (the next boot's recoverInterruptedRestores
+	// cannot find the safety snap, so the marker re-fails every reboot).
+	//
+	// isSnapInFlight covers only create/retry orchestration; the safety snap
+	// reaches StateReady and deregisters from that tracker BEFORE the marker
+	// is written, so it is not in-flight by that measure. Consult the durable
+	// marker explicitly. Runs under the already-held snapshotDeleteLock.
+	if marker, merr := r.store.GetRestoreMarker(ctx, share); merr == nil && marker != nil {
+		if snapID == marker.SafetySnapshotID || snapID == marker.TargetSnapshotID {
+			return fmt.Errorf("delete snapshot %q on share %q: %w",
+				snapID, share, models.ErrSnapshotMarkerProtected)
+		}
+	} else if merr != nil && !errors.Is(merr, models.ErrRestoreMarkerNotFound) {
+		// A marker read failure is not authoritative that no restore is in
+		// progress; fail closed rather than risk deleting a protected snap.
+		return fmt.Errorf("delete snapshot %q on share %q: check restore marker: %w",
+			snapID, share, merr)
 	}
 
 	if err := r.store.DeleteSnapshot(ctx, share, snapID); err != nil {

--- a/pkg/controlplane/runtime/snapshot_rollback_quiesce_test.go
+++ b/pkg/controlplane/runtime/snapshot_rollback_quiesce_test.go
@@ -1,0 +1,131 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestRestoreRollback_QuiescesRollupBeforeReset is the #8 H3 regression. The
+// startup-rollback path (recoverInterruptedRestores → restoreSnapshot with
+// isRollback=true) restores a pre-restore safety snapshot to DISCARD a
+// half-restored state. The fs rollup worker pool is already running (started
+// by AddShare) over boot-recovered dirty intervals; without quiescing it
+// before ResetLocalState an in-flight rollup could persist post-snapshot
+// FileBlock refs over the just-restored FileAttr.Blocks (silent corruption of
+// the rolled-back share).
+//
+// This drives the real fs block store (append-log + rollup worker active) and
+// asserts that after a rollback the restored file is byte-identical to the
+// safety snapshot and its FileAttr.Blocks are the snapshot's blocks, not the
+// discarded post-snapshot state.
+func TestRestoreRollback_QuiescesRollupBeforeReset(t *testing.T) {
+	meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	fx := newByteVerifyFixture(t, meta, "memory")
+	defer fx.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const mib = 1 << 20
+	// Multi-chunk so FastCDC emits several CAS blocks and FileAttr.Blocks is
+	// a meaningful structure to compare.
+	orig := distinctBytes(2*mib, 0x5A)
+
+	pid := fx.createEmptyFile(ctx, "rollme.bin")
+	fx.writeFile(ctx, pid, orig)
+
+	origFile := fx.getFile(ctx, "rollme.bin")
+	if len(origFile.Blocks) < 2 {
+		t.Fatalf("file produced %d CAS block(s), want >= 2 (multi-chunk path not exercised)", len(origFile.Blocks))
+	}
+	type blockKey struct {
+		hash   string
+		offset uint64
+		size   uint32
+	}
+	var origBlocks []blockKey
+	for _, b := range origFile.Blocks {
+		origBlocks = append(origBlocks, blockKey{b.Hash.String(), b.Offset, b.Size})
+	}
+
+	// (1) The safety snapshot S captures the pristine pre-restore state. A
+	// real startup rollback restores S to discard the half-restored state.
+	safetyID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+	if err != nil {
+		t.Fatalf("CreateSnapshot(safety): %v", err)
+	}
+	if snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, safetyID); werr != nil {
+		t.Fatalf("WaitForSnapshot(safety): %v", werr)
+	} else if snap.State != models.StateReady {
+		t.Fatalf("safety snap state = %q, want ready", snap.State)
+	}
+
+	// (2) Mutate the file in place with different bytes of the same length —
+	// the half-restored, post-snapshot state we want the rollback to discard.
+	// This leaves the fs append-log + rollup worker active on fresh intervals.
+	mut := distinctBytes(2*mib, 0xB10C)
+	if len(mut) != len(orig) {
+		t.Fatalf("test bug: mut len %d != orig len %d", len(mut), len(orig))
+	}
+	fx.writeFile(ctx, pid, mut)
+	if got := fx.readFile(ctx, pid, len(mut)); !bytes.Equal(got, mut) {
+		t.Fatalf("post-mutate file should read the NEW bytes pre-rollback")
+	}
+
+	// (3) Disable the share and plant a restore marker naming S as the safety
+	// snapshot — exactly what a crash mid-restore leaves behind. The rollup
+	// worker pool stays alive.
+	if err := fx.rt.DisableShare(ctx, fx.shareName); err != nil {
+		t.Fatalf("DisableShare: %v", err)
+	}
+	if perr := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        fx.shareName,
+		TargetSnapshotID: safetyID,
+		SafetySnapshotID: safetyID,
+		Step:             models.RestoreStepStarted,
+	}); perr != nil {
+		t.Fatalf("PutRestoreMarker: %v", perr)
+	}
+
+	// (4) Run startup recovery — the rollback path. With the H3 fix it drains
+	// the fs rollup workers before ResetLocalState, so no in-flight rollup can
+	// re-inject the discarded post-snapshot block refs over the restored tree.
+	if err := fx.rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores: %v", err)
+	}
+
+	// Marker cleared (rollback completed).
+	if _, gerr := fx.store.GetRestoreMarker(ctx, fx.shareName); gerr == nil {
+		t.Fatal("restore marker still present after successful rollback")
+	}
+
+	// (5) The file must read back as the SAFETY snapshot (pristine) bytes and
+	// its FileAttr.Blocks must be the snapshot's blocks — not the discarded
+	// post-mutation state a racing rollup could have written.
+	if !fx.fileExists(ctx, "rollme.bin") {
+		t.Fatal("file missing after rollback")
+	}
+	got := fx.readFile(ctx, pid, len(orig))
+	if !bytes.Equal(got, orig) {
+		t.Fatalf("ROLLBACK file NOT byte-identical to safety snapshot: %s", firstDiff(orig, got))
+	}
+
+	rolled := fx.getFile(ctx, "rollme.bin")
+	if len(rolled.Blocks) != len(origBlocks) {
+		t.Fatalf("rolled-back FileAttr.Blocks count = %d, want %d (in-flight rollup clobbered restored blocks)",
+			len(rolled.Blocks), len(origBlocks))
+	}
+	for i, b := range rolled.Blocks {
+		if b.Hash.String() != origBlocks[i].hash || b.Offset != origBlocks[i].offset || b.Size != origBlocks[i].size {
+			t.Fatalf("rolled-back block[%d] = {hash=%s off=%d size=%d}, want {hash=%s off=%d size=%d} — restored Blocks were clobbered",
+				i, b.Hash.String(), b.Offset, b.Size,
+				origBlocks[i].hash, origBlocks[i].offset, origBlocks[i].size)
+		}
+	}
+}

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -447,6 +447,72 @@ func TestRuntimeDeleteSnapshot_RefusesInFlight(t *testing.T) {
 	}
 }
 
+// TestRuntimeDeleteSnapshot_RefusesMarkerProtected asserts DeleteSnapshot
+// refuses to delete a snapshot that an in-progress restore depends on as its
+// rollback target — the safety snapshot (and the target snapshot) named by the
+// per-share restore marker. Deleting the safety snap mid-restore would destroy
+// the sole rollback primitive (#8 H2). Once the marker is cleared (restore
+// done), the delete succeeds.
+func TestRuntimeDeleteSnapshot_RefusesMarkerProtected(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const shareName = "alpha"
+	localStoreDir := t.TempDir()
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{Name: shareName})
+	if err := rt.sharesSvc.SetLocalStoreDirForTesting(shareName, localStoreDir); err != nil {
+		t.Fatalf("SetLocalStoreDirForTesting: %v", err)
+	}
+
+	// Seed two ready snapshots: the safety snap and the target snap.
+	safetySnap := &models.Snapshot{ShareName: shareName, State: models.StateReady, MetadataEngine: "memory"}
+	safetyID, err := rt.store.CreateSnapshot(ctx, safetySnap)
+	if err != nil {
+		t.Fatalf("CreateSnapshot(safety): %v", err)
+	}
+	targetSnap := &models.Snapshot{ShareName: shareName, State: models.StateReady, MetadataEngine: "memory"}
+	targetID, err := rt.store.CreateSnapshot(ctx, targetSnap)
+	if err != nil {
+		t.Fatalf("CreateSnapshot(target): %v", err)
+	}
+
+	// Plant a restore marker naming both (mimics an in-flight restore).
+	if merr := rt.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        shareName,
+		TargetSnapshotID: targetID,
+		SafetySnapshotID: safetyID,
+		Step:             models.RestoreStepStarted,
+	}); merr != nil {
+		t.Fatalf("PutRestoreMarker: %v", merr)
+	}
+
+	// Deleting the safety snap is refused with the typed sentinel.
+	if derr := rt.DeleteSnapshot(ctx, shareName, safetyID); !errors.Is(derr, models.ErrSnapshotMarkerProtected) {
+		t.Fatalf("DeleteSnapshot(safety) err = %v, want errors.Is(ErrSnapshotMarkerProtected)", derr)
+	}
+	// Deleting the target snap is refused too.
+	if derr := rt.DeleteSnapshot(ctx, shareName, targetID); !errors.Is(derr, models.ErrSnapshotMarkerProtected) {
+		t.Fatalf("DeleteSnapshot(target) err = %v, want errors.Is(ErrSnapshotMarkerProtected)", derr)
+	}
+
+	// Both rows must still exist (deletes refused) — rollback still possible.
+	if _, gerr := rt.store.GetSnapshot(ctx, shareName, safetyID); gerr != nil {
+		t.Fatalf("safety row deleted despite marker protection: %v", gerr)
+	}
+	if _, gerr := rt.store.GetSnapshot(ctx, shareName, targetID); gerr != nil {
+		t.Fatalf("target row deleted despite marker protection: %v", gerr)
+	}
+
+	// Clearing the marker (restore complete) releases protection.
+	if derr := rt.store.DeleteRestoreMarker(ctx, shareName); derr != nil {
+		t.Fatalf("DeleteRestoreMarker: %v", derr)
+	}
+	if derr := rt.DeleteSnapshot(ctx, shareName, safetyID); derr != nil {
+		t.Fatalf("DeleteSnapshot(safety) after marker cleared: %v", derr)
+	}
+}
+
 // TestRuntimeDeleteSnapshot_NotFound asserts ErrSnapshotNotFound from the
 // store propagates verbatim and the on-disk wipe step is NOT attempted.
 func TestRuntimeDeleteSnapshot_NotFound(t *testing.T) {


### PR DESCRIPTION
## What

Snapshot/restore data-integrity + a blockstore read-path perf fix from the v1.0 round-2 audit (area #8 + blockstore H5).

- **#8 H2 — restore safety-snapshot fence.** The pre-restore safety-snapshot is the sole rollback primitive, but `DeleteSnapshot` did not protect it while a restore was in flight. Now fenced via a marker (fails closed on marker-read error) so it cannot be removed mid-restore.
- **#8 H3 — quiesce rollup on startup rollback.** Startup rollback ran `ResetLocalState` without quiescing fs rollup workers, so an in-flight rollup could overwrite the just-restored `FileAttr.Blocks`. Workers are now drained before reset (no-op on memory stores), resumed after.
- **#842 — restore drain deadline.** The pre-restore safety-snapshot drain to a remote store could exceed the 30s HTTP handler deadline → spurious 500 on remote-backed shares. The drain is decoupled from the short handler deadline; client disconnect still cancels via `AfterFunc` gated on `context.Canceled`. Closes #842.
- **blockstore H5 — ReadPayloadAt.** Replaced full append-log replay per read with an index-first lookup plus a pinned-byte fallback for consumed-but-uncompacted records; last-write-wins semantics preserved and verified against the byte-verify in-place-overwrite case.

## Tests

New: `readpayload_index_test.go` (index path + fallback), `snapshot_rollback_quiesce_test.go` (in-flight rollup cannot clobber restored Blocks), safety-snapshot fence and drain-deadline cases in the handler/runtime suites. `go test` + `go test -race` green on the touched packages; `gofmt`/`vet`/`golangci-lint` clean.

Closes #842