### PR TITLE
fix(operator): harden managed dfs pod (disable SA-token automount, secure default SecurityContext) (v1.0 audit #11)

### DIFF
--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -59,6 +59,9 @@ const (
 	defaultAPIPort = 8080
 	// defaultFSGroup is the default fsGroup for pod security context (nonroot user)
 	defaultFSGroup = 65532
+	// capabilityAll is the special capability value that drops all Linux
+	// capabilities from the managed dfs container.
+	capabilityAll corev1.Capability = "ALL"
 )
 
 // retryOnConflict wraps an operation with retry logic for optimistic locking conflicts.
@@ -994,6 +997,11 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 						},
 					},
 					Spec: corev1.PodSpec{
+						// dfs imports no client-go and never calls the K8s API,
+						// so it has no legitimate consumer for a ServiceAccount
+						// token. Disabling automount keeps the unused namespace
+						// default SA token off the network-exposed container.
+						AutomountServiceAccountToken:  ptr.To(false),
 						SecurityContext:               getPodSecurityContext(dittoServer),
 						TerminationGracePeriodSeconds: ptr.To(getTerminationGracePeriodSeconds(dittoServer)),
 						InitContainers:                initContainers,
@@ -1005,7 +1013,7 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								Args:            []string{"start", "--foreground", "--config", "/config/config.yaml"},
 								VolumeMounts:    volumeMounts,
 								Resources:       dittoServer.Spec.Resources,
-								SecurityContext: dittoServer.Spec.SecurityContext,
+								SecurityContext: getContainerSecurityContext(dittoServer),
 								Ports:           buildContainerPorts(dittoServer, existingAdapterPorts(statefulSet)),
 								Env:             envVars,
 								LivenessProbe: &corev1.Probe{
@@ -1096,6 +1104,47 @@ func getPodSecurityContext(dittoServer *dittoiov1alpha1.DittoServer) *corev1.Pod
 	return &corev1.PodSecurityContext{
 		FSGroup: &fsGroup,
 	}
+}
+
+// getContainerSecurityContext returns the SecurityContext for the managed dfs
+// container. It applies a secure-by-default posture (drop ALL capabilities, no
+// privilege escalation, run as non-root, RuntimeDefault seccomp) so the
+// operator-generated StatefulSet is admitted by Pod-Security-Standards
+// "restricted" namespaces and matches the hardened operator pod. The dfs image
+// already ships USER 65532, so non-root is consistent.
+//
+// readOnlyRootFilesystem is intentionally NOT set: dfs writes to os.TempDir()
+// (the block-store GC engine and config default-dir fallback) outside its
+// mounted volumes, which a read-only root filesystem would break.
+//
+// When the user supplies Spec.SecurityContext, those fields override the
+// secure defaults (user wins on conflicts).
+func getContainerSecurityContext(dittoServer *dittoiov1alpha1.DittoServer) *corev1.SecurityContext {
+	// Start from the user's context (if any) so all user-set fields — including
+	// any added in future API versions — are preserved, then backfill the
+	// secure defaults only where the user left a field unset (user wins).
+	sc := dittoServer.Spec.SecurityContext.DeepCopy()
+	if sc == nil {
+		sc = &corev1.SecurityContext{}
+	}
+
+	if sc.AllowPrivilegeEscalation == nil {
+		sc.AllowPrivilegeEscalation = ptr.To(false)
+	}
+	if sc.RunAsNonRoot == nil {
+		sc.RunAsNonRoot = ptr.To(true)
+	}
+	if sc.Capabilities == nil {
+		sc.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{capabilityAll}}
+	}
+	if sc.SeccompProfile == nil {
+		sc.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+	}
+	// readOnlyRootFilesystem is intentionally left as the user set it (default
+	// unset): dfs writes to os.TempDir() outside its mounted volumes, which a
+	// read-only root filesystem would break.
+
+	return sc
 }
 
 // existingAdapterPorts extracts existing container ports from the StatefulSet.

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -1136,6 +1136,11 @@ func getContainerSecurityContext(dittoServer *dittoiov1alpha1.DittoServer) *core
 	}
 	if sc.Capabilities == nil {
 		sc.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{capabilityAll}}
+	} else if len(sc.Capabilities.Drop) == 0 {
+		// User set Capabilities (e.g. to Add one) but left Drop unset; backfill
+		// the drop-ALL baseline so the pod still satisfies the restricted
+		// Pod-Security-Standard while preserving the user's Add list.
+		sc.Capabilities.Drop = []corev1.Capability{capabilityAll}
 	}
 	if sc.SeccompProfile == nil {
 		sc.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}

--- a/k8s/dittofs-operator/internal/controller/pod_hardening_test.go
+++ b/k8s/dittofs-operator/internal/controller/pod_hardening_test.go
@@ -95,6 +95,33 @@ func TestGetContainerSecurityContext_UserOverrideMerge(t *testing.T) {
 	}
 }
 
+// TestGetContainerSecurityContext_UserAddsCapabilityKeepsDropBaseline asserts
+// that when the user sets Capabilities only to Add a capability (leaving Drop
+// unset), the operator still backfills Drop=[ALL] so the pod satisfies the
+// restricted Pod-Security-Standard, while preserving the user's Add list.
+func TestGetContainerSecurityContext_UserAddsCapabilityKeepsDropBaseline(t *testing.T) {
+	ds := &v1alpha1.DittoServer{
+		Spec: v1alpha1.DittoServerSpec{
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_BIND_SERVICE"},
+				},
+			},
+		},
+	}
+
+	sc := getContainerSecurityContext(ds)
+	if sc == nil || sc.Capabilities == nil {
+		t.Fatalf("expected a non-nil SecurityContext with Capabilities")
+	}
+	if len(sc.Capabilities.Add) != 1 || sc.Capabilities.Add[0] != "NET_BIND_SERVICE" {
+		t.Errorf("expected user Capabilities.Add=[NET_BIND_SERVICE] to be preserved, got %+v", sc.Capabilities.Add)
+	}
+	if len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != capabilityAll {
+		t.Errorf("expected backfilled Capabilities.Drop=[ALL], got %+v", sc.Capabilities.Drop)
+	}
+}
+
 // TestGetContainerSecurityContext_UserDisablesHardening asserts the merge does
 // not clobber a user that explicitly relaxes a default (e.g. allows privilege
 // escalation) — user always wins, even when relaxing.

--- a/k8s/dittofs-operator/internal/controller/pod_hardening_test.go
+++ b/k8s/dittofs-operator/internal/controller/pod_hardening_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+// TestGetContainerSecurityContext_SecureDefault asserts that when the user does
+// not supply a container SecurityContext, the operator applies a secure default
+// (drop ALL caps, no privilege escalation, run as non-root, RuntimeDefault
+// seccomp) so the StatefulSet is admitted under a "restricted" Pod-Security
+// namespace. readOnlyRootFilesystem must stay unset because dfs writes to
+// os.TempDir outside its mounted volumes.
+func TestGetContainerSecurityContext_SecureDefault(t *testing.T) {
+	ds := &v1alpha1.DittoServer{}
+
+	sc := getContainerSecurityContext(ds)
+	if sc == nil {
+		t.Fatalf("expected a non-nil SecurityContext when Spec.SecurityContext is nil")
+	}
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Errorf("expected AllowPrivilegeEscalation=false, got %v", sc.AllowPrivilegeEscalation)
+	}
+	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Errorf("expected RunAsNonRoot=true, got %v", sc.RunAsNonRoot)
+	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != capabilityAll {
+		t.Errorf("expected Capabilities.Drop=[ALL], got %+v", sc.Capabilities)
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("expected SeccompProfile=RuntimeDefault, got %+v", sc.SeccompProfile)
+	}
+	if sc.ReadOnlyRootFilesystem != nil {
+		t.Errorf("expected ReadOnlyRootFilesystem unset (dfs writes to /tmp), got %v", *sc.ReadOnlyRootFilesystem)
+	}
+}
+
+// TestGetContainerSecurityContext_UserOverrideMerge asserts that user-supplied
+// fields win over the secure defaults while unset fields retain the defaults.
+func TestGetContainerSecurityContext_UserOverrideMerge(t *testing.T) {
+	ds := &v1alpha1.DittoServer{
+		Spec: v1alpha1.DittoServerSpec{
+			SecurityContext: &corev1.SecurityContext{
+				// User opts into a read-only root filesystem and a specific UID,
+				// but leaves the rest to the operator defaults.
+				ReadOnlyRootFilesystem: ptr.To(true),
+				RunAsUser:              ptr.To(int64(1234)),
+			},
+		},
+	}
+
+	sc := getContainerSecurityContext(ds)
+	if sc == nil {
+		t.Fatalf("expected a non-nil SecurityContext")
+	}
+	// User overrides win.
+	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Errorf("expected user ReadOnlyRootFilesystem=true to win, got %v", sc.ReadOnlyRootFilesystem)
+	}
+	if sc.RunAsUser == nil || *sc.RunAsUser != 1234 {
+		t.Errorf("expected user RunAsUser=1234 to win, got %v", sc.RunAsUser)
+	}
+	// Unset user fields keep the secure defaults.
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Errorf("expected default AllowPrivilegeEscalation=false to persist, got %v", sc.AllowPrivilegeEscalation)
+	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != capabilityAll {
+		t.Errorf("expected default Capabilities.Drop=[ALL] to persist, got %+v", sc.Capabilities)
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("expected default SeccompProfile=RuntimeDefault to persist, got %+v", sc.SeccompProfile)
+	}
+}
+
+// TestGetContainerSecurityContext_UserDisablesHardening asserts the merge does
+// not clobber a user that explicitly relaxes a default (e.g. allows privilege
+// escalation) — user always wins, even when relaxing.
+func TestGetContainerSecurityContext_UserDisablesHardening(t *testing.T) {
+	ds := &v1alpha1.DittoServer{
+		Spec: v1alpha1.DittoServerSpec{
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(true),
+			},
+		},
+	}
+
+	sc := getContainerSecurityContext(ds)
+	if sc.AllowPrivilegeEscalation == nil || !*sc.AllowPrivilegeEscalation {
+		t.Errorf("expected user AllowPrivilegeEscalation=true to win, got %v", sc.AllowPrivilegeEscalation)
+	}
+}
+
+// TestReconcileStatefulSet_PodHardening reconciles a StatefulSet through the
+// fake client and asserts the managed PodSpec disables ServiceAccount-token
+// automount (M-SEC-2) and carries the secure default container SecurityContext
+// (M-SEC-3).
+func TestReconcileStatefulSet_PodHardening(t *testing.T) {
+	ctx := context.Background()
+
+	ds := newHardeningDittoServer()
+	r := setupDittoServerReconciler(t, fields{dittoServer: ds})
+
+	if _, err := r.reconcileStatefulSet(ctx, ds, 1); err != nil {
+		t.Fatalf("reconcileStatefulSet failed: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, sts); err != nil {
+		t.Fatalf("failed to get StatefulSet: %v", err)
+	}
+
+	spec := sts.Spec.Template.Spec
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		t.Errorf("expected AutomountServiceAccountToken=false, got %v", spec.AutomountServiceAccountToken)
+	}
+
+	if len(spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(spec.Containers))
+	}
+	sc := spec.Containers[0].SecurityContext
+	if sc == nil {
+		t.Fatalf("expected a container SecurityContext on the managed pod")
+	}
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Errorf("expected AllowPrivilegeEscalation=false, got %v", sc.AllowPrivilegeEscalation)
+	}
+	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Errorf("expected RunAsNonRoot=true, got %v", sc.RunAsNonRoot)
+	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != capabilityAll {
+		t.Errorf("expected Capabilities.Drop=[ALL], got %+v", sc.Capabilities)
+	}
+}
+
+func newHardeningDittoServer() *v1alpha1.DittoServer {
+	return &v1alpha1.DittoServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "harden-test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DittoServerSpec{
+			Image: "marmos91c/dittofs:test",
+			Storage: v1alpha1.StorageSpec{
+				MetadataSize: "1Gi",
+				CacheSize:    "1Gi",
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What

Hardens the operator-managed `dfs` StatefulSet PodSpec (built in `k8s/dittofs-operator/internal/controller/dittoserver_controller.go`). Addresses two findings from the v1.0 audit area #11 (operator) REVIEW2.md §4.

### M-SEC-2 — disable ServiceAccount-token automount
The managed pod previously set neither `ServiceAccountName` nor `AutomountServiceAccountToken`, so Kubernetes mounted the namespace `default` SA API token onto the most network-exposed container (NFS/SMB/REST). `dfs` imports no client-go and never calls the Kubernetes API, so that token has zero legitimate consumer. Now sets `AutomountServiceAccountToken: false` on the PodSpec.

### M-SEC-3 — secure-default container SecurityContext
The managed container previously used `SecurityContext: Spec.SecurityContext` with no operator default (only `FSGroup` was set at the pod level). With no default, `allowPrivilegeEscalation` defaults true and no capabilities are dropped — asymmetric with the hardened operator pod, and a Pod-Security-Standards "restricted" namespace would **reject** the operator-generated StatefulSet, breaking install on hardened clusters.

A new `getContainerSecurityContext` helper applies a secure default when `Spec.SecurityContext` is nil:
- `allowPrivilegeEscalation: false`
- `runAsNonRoot: true` (the dfs image already ships `USER 65532`)
- `capabilities.drop: [ALL]`
- `seccompProfile: RuntimeDefault`

When the user **does** supply `Spec.SecurityContext`, the secure defaults are backfilled only where the user left a field unset (user wins on conflicts), starting from a deep copy so all user-set fields — including any added in future API versions — are preserved.

### readOnlyRootFilesystem — NOT enabled
Left unset. `dfs` writes to `os.TempDir()` (`/tmp` on the container root fs) outside its mounted volumes — the block-store GC engine (`pkg/blockstore/engine/gc.go` uses `os.MkdirTemp("", …)`) and the config default-dir fallback (`pkg/config/config.go`). A read-only root filesystem would break those paths, so it is left off (user may opt in via `Spec.SecurityContext.readOnlyRootFilesystem`).

## Tests
Added `pod_hardening_test.go`:
- `AutomountServiceAccountToken == false` on the reconciled StatefulSet
- secure default container SecurityContext applied when `Spec.SecurityContext` is nil
- user-override merge: user-set fields win, unset fields keep the secure defaults
- user-relaxed override (allowPrivilegeEscalation=true) is honored

Full operator module suite (incl. envtest) green; `go vet` clean; golangci-lint adds no new findings (the module's ~16 pre-existing goconst findings are unchanged).