### PR TITLE
fix(smb/dirlease): release dir lease after open-file removal on CLOSE

### DIFF
--- a/internal/adapter/smb/v2/handlers/close.go
+++ b/internal/adapter/smb/v2/handlers/close.go
@@ -557,26 +557,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	}
 
 	// ========================================================================
-	// Step 9: Release oplock/lease if held
-	// ========================================================================
-
-	// Release any lease/oplock record associated with this open. The gate
-	// previously checked openFile.OplockLevel != None, but an oplock that was
-	// broken-to-None has its OplockLevel updated to None on ACK (see
-	// handleOplockBreakAck) — gating on the demoted level would leave the
-	// synthetic-key lease record alive past CLOSE. Per Samba ack-to-None
-	// semantics the record IS kept alive at LeaseState=None until CLOSE
-	// removes it (Samba `share_mode_cleanup_disconnected`); CLOSE is the
-	// release point. Gate on LeaseKey instead so the same release runs for
-	// real leases (OplockLevelLease) and for traditional oplocks (LEVEL_II
-	// / Exclusive / Batch and their broken-to-None descendants). Required by
-	// smbtorture smb2.oplock.exclusive9 (multi-iter EXCLUSIVE+SUPERSEDE loop
-	// where each iter's tree1 ack-to-None must clean up before the next
-	// iter's tree1 EXCLUSIVE request).
-	h.releaseHandleLeaseRecord(ctx.Context, openFile, "CLOSE")
-
-	// ========================================================================
-	// Step 10: Unregister any pending CHANGE_NOTIFY watches
+	// Step 9: Unregister any pending CHANGE_NOTIFY watches
 	// ========================================================================
 	//
 	// If this is a directory with pending CHANGE_NOTIFY requests, unregister them.
@@ -628,7 +609,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	}
 
 	// ========================================================================
-	// Step 11: Remove the open file handle
+	// Step 10: Remove the open file handle
 	// ========================================================================
 
 	// WaitAndDeleteOpenFile drains in-flight operations (e.g., a concurrent
@@ -637,6 +618,38 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// goroutine on the same connection and causing a spurious FILE_CLOSED
 	// (smbtorture compound_find.compound_find_close).
 	h.WaitAndDeleteOpenFile(req.FileID)
+
+	// ========================================================================
+	// Step 11: Release oplock/lease if held
+	// ========================================================================
+
+	// Release any lease/oplock record associated with this open. The gate
+	// previously checked openFile.OplockLevel != None, but an oplock that was
+	// broken-to-None has its OplockLevel updated to None on ACK (see
+	// handleOplockBreakAck) — gating on the demoted level would leave the
+	// synthetic-key lease record alive past CLOSE. Per Samba ack-to-None
+	// semantics the record IS kept alive at LeaseState=None until CLOSE
+	// removes it (Samba `share_mode_cleanup_disconnected`); CLOSE is the
+	// release point. Gate on LeaseKey instead so the same release runs for
+	// real leases (OplockLevelLease) and for traditional oplocks (LEVEL_II
+	// / Exclusive / Batch and their broken-to-None descendants). Required by
+	// smbtorture smb2.oplock.exclusive9 (multi-iter EXCLUSIVE+SUPERSEDE loop
+	// where each iter's tree1 ack-to-None must clean up before the next
+	// iter's tree1 EXCLUSIVE request).
+	//
+	// MUST run AFTER WaitAndDeleteOpenFile (step 10), not before: when this
+	// holder closes its conflicting directory handle in response to a dir-lease
+	// break, ReleaseLeaseForHandle signals WaitForBreakCompletion waiters (the
+	// SET_INFO-rename dst-parent Handle-break wait). That waiter wakes and
+	// re-runs checkParentDirRenameConflict against h.files. If the lease
+	// release (and its signal) fired while this OpenFile were still in h.files,
+	// the woken rename would observe the stale holder and return a spurious
+	// STATUS_SHARING_VIOLATION instead of STATUS_OK — the intermittent
+	// smbtorture smb2.dirlease.rename_dst_parent phase-2 failure. Removing the
+	// OpenFile first makes the post-wait recheck see the shrunk table. This
+	// mirrors the SignalParkedCreates ordering below, which was already moved
+	// after the open-file removal for the dir-CREATE park path (v2_request).
+	h.releaseHandleLeaseRecord(ctx.Context, openFile, "CLOSE")
 
 	// Wake any parked dir-CREATE on this handle so it can re-evaluate
 	// share-mode against the now-shrunk open-file table. The signal MUST

--- a/internal/adapter/smb/v2/handlers/close_dirlease_break_order_test.go
+++ b/internal/adapter/smb/v2/handlers/close_dirlease_break_order_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// orderRecordingLockManager wraps a real lock.LockManager and, on each
+// ReleaseLeaseForHandle call, invokes a probe so the test can observe handler
+// state (the open-file table) at the exact moment the lease record is dropped.
+//
+// ReleaseLeaseForHandle is the no-ACK break-completion path: when a directory
+// lease holder closes its conflicting handle in response to a dir-lease break,
+// the release signals any WaitForBreakCompletion waiter (the SET_INFO-rename
+// dst-parent Handle-break wait) via signalBreakWaitLocked. The waiter then
+// re-runs checkParentDirRenameConflict against h.files. For that recheck to be
+// correct, the closing holder's OpenFile MUST already be gone from h.files when
+// the release fires — otherwise the woken rename observes a stale holder and
+// returns a spurious STATUS_SHARING_VIOLATION (the intermittent
+// smb2.dirlease.rename_dst_parent phase-2 flake).
+type orderRecordingLockManager struct {
+	lock.LockManager
+	onRelease func(handleKey string, leaseKey [16]byte)
+}
+
+func (m *orderRecordingLockManager) ReleaseLeaseForHandle(ctx context.Context, handleKey string, leaseKey [16]byte) error {
+	if m.onRelease != nil {
+		m.onRelease(handleKey, leaseKey)
+	}
+	return m.LockManager.ReleaseLeaseForHandle(ctx, handleKey, leaseKey)
+}
+
+// TestClose_DirLeaseRelease_AfterOpenFileRemoval is a regression test for the
+// intermittent smbtorture smb2.dirlease.rename_dst_parent phase-2 failure
+// ("waiting for a lease break timed out" + STATUS_SHARING_VIOLATION).
+//
+// Root cause: the CLOSE handler released the per-handle directory lease record
+// (which signals WaitForBreakCompletion waiters via the no-ACK break-completion
+// path) BEFORE it removed the OpenFile from h.files. A SET_INFO rename parked in
+// breakDstParentDirHandleLeasesForRename -> WaitForBreakCompletion would wake on
+// that early signal, re-run checkParentDirRenameConflict while the closing
+// holder's OpenFile was still in the table, observe the stale holder, and return
+// STATUS_SHARING_VIOLATION instead of STATUS_OK. The race was scheduler-timed
+// (the rename goroutine usually lost to WaitAndDeleteOpenFile), hence the
+// intermittency.
+//
+// The fix reorders CLOSE so WaitAndDeleteOpenFile (open-file removal) runs
+// BEFORE releaseHandleLeaseRecord (lease release + waiter signal). This test
+// asserts that invariant directly: at the instant ReleaseLeaseForHandle fires,
+// GetOpenFile for the closing handle must already report "not found".
+func TestClose_DirLeaseRelease_AfterOpenFileRemoval(t *testing.T) {
+	h := NewHandler()
+
+	var openFilePresentAtRelease bool
+	var releaseObserved bool
+
+	var fileID [16]byte
+	copy(fileID[:], []byte{0xde, 0xad, 0xbe, 0xef})
+
+	probeMgr := &orderRecordingLockManager{
+		LockManager: lock.NewManager(),
+		onRelease: func(_ string, _ [16]byte) {
+			releaseObserved = true
+			// Observe the handler's open-file table AT THE MOMENT of release.
+			// With the fix, the OpenFile is already gone; with the bug it is
+			// still present (release ran before WaitAndDeleteOpenFile).
+			if _, ok := h.GetOpenFile(fileID); ok {
+				openFilePresentAtRelease = true
+			}
+		},
+	}
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: probeMgr}, nil)
+
+	const shareName = "share"
+	dirMetaHandle := metadata.FileHandle("dst-parent-dir-handle")
+	leaseKey := [16]byte{0x01}
+
+	// Grant a real RH directory lease on the dst-parent handle so the release
+	// path takes the IsDirectory break-completion-signal branch.
+	if _, _, err := h.LeaseManager.RequestLease(
+		context.Background(),
+		lock.FileHandle(dirMetaHandle),
+		leaseKey,
+		[16]byte{}, // parentLeaseKey
+		1,          // sessionID
+		[16]byte{}, // clientGUID
+		"owner-1",  // ownerID
+		"client-1", // clientID
+		shareName,
+		lock.LeaseStateRead|lock.LeaseStateHandle,
+		true, // isDirectory
+	); err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+
+	// Put the dir lease into the Breaking state, mirroring the rename path's
+	// dst-parent dir-lease break. Without a Breaking lease the release path's
+	// signal branch (gated on lock.Lease.Breaking) is inert. Use the async
+	// (no-ACK, no-wait) dispatch so the lease lands in Breaking=true without
+	// blocking the test on a holder ack that never arrives.
+	if err := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+		lock.FileHandle(dirMetaHandle),
+		shareName,
+		"",
+		[16]byte{},
+		false,
+	); err != nil {
+		t.Fatalf("BreakParentDirLeasesOnContentChangeAsync: %v", err)
+	}
+
+	// Register the holder's OpenFile (the conflicting dst-parent dir handle).
+	openFile := &OpenFile{
+		FileID:         fileID,
+		FileName:       "dst-parent",
+		Path:           "/share/dst-parent",
+		IsDirectory:    true,
+		ShareName:      shareName,
+		OplockLevel:    OplockLevelLease,
+		LeaseKey:       leaseKey,
+		MetadataHandle: dirMetaHandle,
+	}
+	h.StoreOpenFile(openFile)
+
+	ctx := &SMBHandlerContext{
+		Context:   context.Background(),
+		SessionID: 1,
+		ShareName: shareName,
+	}
+
+	resp, err := h.Close(ctx, &CloseRequest{FileID: fileID, Flags: 0})
+	if err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Close returned nil response")
+	}
+
+	if !releaseObserved {
+		t.Fatal("ReleaseLeaseForHandle was never called during CLOSE; " +
+			"test cannot validate the ordering invariant")
+	}
+	if openFilePresentAtRelease {
+		t.Fatal("CLOSE released the directory lease (and signaled break-completion " +
+			"waiters) while the closing holder's OpenFile was STILL in h.files. " +
+			"A SET_INFO-rename waiting in WaitForBreakCompletion would wake and " +
+			"observe the stale holder, returning a spurious STATUS_SHARING_VIOLATION " +
+			"(smb2.dirlease.rename_dst_parent phase-2 flake). The open-file removal " +
+			"must precede the lease release.")
+	}
+
+	// Sanity: the OpenFile must be gone after CLOSE.
+	if _, ok := h.GetOpenFile(fileID); ok {
+		t.Fatal("OpenFile still present after CLOSE")
+	}
+}


### PR DESCRIPTION
## Problem

Intermittent smbtorture flake `smb2.dirlease.rename_dst_parent` (memory backend, smbtorture 4.22.6):

```
test: dirlease.rename_dst_parent
... waiting for a lease break timed out   (x2)
failure: dirlease.rename_dst_parent [
  lease.c:6879: status was NT_STATUS_SHARING_VIOLATION, expected NT_STATUS_OK
]
```

Passes most runs, fails some — a real race, not a timing artifact.

## Root cause

The test (lease.c `test_rename_dst_parent`, phase 2) holds an **RH directory lease** on the destination parent dir, arms its break handler to **close that handle on break**, then renames a file into the dir. The server must break the dst-parent dir lease, let the holder close its conflicting handle, then complete the rename with `STATUS_OK`.

The rename path (`set_info.go`) does this correctly: on a dst-parent share-mode conflict it pre-breaks the dir's Handle lease (`breakDstParentDirHandleLeasesForRename` → `BreakParentHandleLeasesOnCreate` → `WaitForBreakCompletion`), then re-runs `checkParentDirRenameConflict` against `h.files` once the wait drains.

The bug was in the **CLOSE handler ordering**. CLOSE released the per-handle directory lease record (step 9) *before* removing the OpenFile from `h.files` (step 11). `ReleaseLeaseForHandle` is the no-ACK break-completion path — releasing a *breaking* directory lease calls `signalBreakWaitLocked`, waking the parked rename. Because that signal fired before `WaitAndDeleteOpenFile`, the woken rename could re-run `checkParentDirRenameConflict` while the closing holder's OpenFile was **still in the table**, observe the stale holder, and return a spurious `STATUS_SHARING_VIOLATION` instead of `STATUS_OK`.

The race is scheduler-timed (the rename goroutine usually loses to `WaitAndDeleteOpenFile`), which is exactly why it was intermittent.

This is the same race the code already guarded against for the dir-CREATE park path: `SignalParkedCreates` was deliberately placed *after* the open-file removal (comment: "The signal MUST follow the open-file removal … so the parked CREATE's share-mode recheck does not still observe the closing holder"). The rename waiter, signaled from inside `ReleaseLeaseForHandle`, was missing that same guarantee.

## Fix

Reorder CLOSE so `WaitAndDeleteOpenFile` (open-file removal) runs **before** `releaseHandleLeaseRecord` (lease release + waiter signal). The lease is still released before the CLOSE response returns, so no other ordering guarantee changes (`oplock.exclusive9` ack-to-None-before-next-CREATE still holds). `releaseHandleLeaseRecord` reads only immutable OpenFile fields, and `WaitAndDeleteOpenFile` waits only on in-flight ops of the *closing* handle, so the move introduces no deadlock.

## Test

Adds `TestClose_DirLeaseRelease_AfterOpenFileRemoval`, a deterministic, single-goroutine regression test that wraps the real lock manager and asserts the invariant directly: at the instant the directory lease is released, the closing handle's OpenFile must already be absent from `h.files`.

- Passes on the fix.
- Fails fast (0.00s) on the pre-fix ordering (verified by stashing the close.go change): "CLOSE released the directory lease … while the closing holder's OpenFile was STILL in h.files."

No sleeps/timeouts; the break is driven into the Breaking state via the existing async (no-ACK) dispatch.

## Gates

- `GOWORK=off go build ./...` ✅
- `GOWORK=off go vet ./internal/adapter/smb/v2/handlers/` ✅
- `GOWORK=off go test -race ./internal/adapter/smb/...` ✅
- `GOWORK=off go test -race ./pkg/metadata/lock/... ./pkg/adapter/smb/...` ✅

KNOWN_FAILURES untouched (this test is not KF-listed).