### PR TITLE
perf(blockstore): index-seek ReadPayloadAt instead of full-log replay (v1.0 audit #1 H5)

### DIFF
--- a/pkg/blockstore/local/fs/readpayload.go
+++ b/pkg/blockstore/local/fs/readpayload.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sort"
 
@@ -93,27 +92,65 @@ func allCovered(covered []bool) bool {
 	return true
 }
 
-// replayLogIntoDest opens the payload's append log (if any) and replays
-// every record, copying the portions that intersect [reqStart, reqEnd)
-// into dest. Records are applied in log order so later writes at the
-// same offset overwrite earlier ones.
+// replayLogIntoDest fills the portions of dest that intersect
+// [reqStart, reqEnd) from the payload's in-flight append-log records.
 //
-// Returns nil when no log exists for payloadID (treated as "nothing to
-// fill from the log") OR after a successful replay. Returns a non-nil
-// error only for genuine I/O failures.
+// Instead of replaying the FULL on-disk log (O(log-size) per read), it
+// consults the per-payload logIndex to translate the requested file-offset
+// window into the exact set of record frames that intersect it, then preads
+// each one directly via readRecordAt. The index is trimmed at the
+// compaction fence (logindex.go), so it holds only records NOT yet rolled
+// into CAS — exactly the records that live ONLY in the log. Bytes whose
+// records have already been consumed by the rollup are served from the CAS
+// manifest in step 2 of ReadPayloadAt.
+//
+// Last-write-wins is preserved: EntriesForInterval returns entries in
+// logPos (== arrival) order, and we copy each intersecting record into dest
+// unconditionally in that order, so a later overwrite at the same offset
+// supersedes an earlier record exactly as the previous full-log replay did.
+//
+// Concurrency: the logIndex entries carry ABSOLUTE log-byte positions
+// (logPos). A concurrent rollup compaction (compaction.go) atomically
+// rewrites the on-disk log AND rebases idx.entries[].logPos under the
+// per-file mutex. To read a logPos and pread at it safely we therefore hold
+// the SAME per-file mutex across both the index lookup and the preads — a
+// snapshot taken without the lock could pread a stale (pre-rebase) logPos
+// and decode a garbage frame. readRecordAt cross-checks the frame's
+// declared payload_len and file_offset against the index entry, so any
+// residual divergence surfaces as a hard error rather than wrong bytes.
+//
+// Returns nil when no log/index exists for payloadID (treated as "nothing
+// to fill from the log") OR after a successful fill. Returns a non-nil
+// error only for genuine I/O failures or log/index divergence.
 func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest []byte, reqStart, reqEnd uint64, covered []bool) error {
 	bc.logsMu.RLock()
 	lf := bc.logFDs[payloadID]
 	mu := bc.logLocks[payloadID]
+	idx := bc.logIndices[payloadID]
 	bc.logsMu.RUnlock()
-	if lf == nil || mu == nil {
+	if lf == nil || mu == nil || idx == nil {
+		return nil
+	}
+
+	// Hold the per-file mutex across the index lookup AND every pread so a
+	// concurrent rollup compaction cannot rebase idx.entries[].logPos (and
+	// rewrite the on-disk log) underneath us. AppendWrite also holds this
+	// mutex, so we observe a consistent log/index pair.
+	mu.Lock()
+	defer mu.Unlock()
+
+	if reqEnd <= reqStart {
+		return nil
+	}
+	entries := idx.EntriesForInterval(reqStart, reqEnd-reqStart, nil)
+	if len(entries) == 0 {
 		return nil
 	}
 
 	// Open a separate read-only fd so we don't disturb the append fd's
-	// EOF position (writers seek to EOF on getOrCreateLog and we must
-	// not race the append cursor). The path is captured at logFile
-	// construction time and stable across reopens.
+	// EOF position. The path is captured at logFile construction time and
+	// stable across reopens; compaction renames a fresh file into place
+	// under the mutex we hold, so the path still resolves.
 	rf, err := os.Open(lf.path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -124,36 +161,41 @@ func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest [
 	}
 	defer func() { _ = rf.Close() }()
 
-	// We do NOT take the per-file mutex here. Writers append at EOF and
-	// fsync each record before returning; the on-disk log is monotonic
-	// (records only grow upward) so a concurrent reader sees either a
-	// committed record or hits EOF/short-read mid-frame. readRecord
-	// returns (_, _, false, nil) on torn-tail / EOF, terminating the
-	// loop cleanly. The post-record CRC catches torn writes that
-	// reached the platter but were not yet fsynced — those are skipped
-	// as if the record did not exist (consistent with what the writer
-	// thinks: a fsync that has not returned has not yet acknowledged
-	// the write).
-
-	// Seek past the 64-byte header.
-	if _, err := rf.Seek(int64(logHeaderSize), io.SeekStart); err != nil {
-		return fmt.Errorf("ReadPayloadAt: seek past header: %w", err)
-	}
-
-	for {
-		recOff, payload, ok, rerr := readRecord(rf)
-		if rerr != nil {
-			return fmt.Errorf("ReadPayloadAt: readRecord: %w", rerr)
+	for _, e := range entries {
+		// A single AppendWrite may legitimately exceed maxRecordPayload (the
+		// writer's only ceiling is uint32; the engine appends whole writes —
+		// e.g. a 32 MiB seed write lands as one frame). readRecordAt and the
+		// sequential readRecord both REJECT frames above maxRecordPayload as a
+		// torn/hostile-length DoS guard, so neither can decode such a record.
+		// The pre-index full-log replay used readRecord, which skipped these
+		// frames and let the byte coverage fall through to the CAS manifest /
+		// remote-fetch miss path. We preserve that EXACT behavior: skip the
+		// over-cap record rather than erroring. The bytes stay uncovered and
+		// the caller resolves them downstream — byte-identical to the prior
+		// replay. This is the case whose mishandling (a hard error) broke the
+		// previous attempt's mixed-rw read of the 32 MiB seed at logPos=64.
+		if e.payloadLen > maxRecordPayload {
+			continue
 		}
-		if !ok {
-			break
+		recOff, payload, rerr := readRecordAt(rf, e.logPos, e.payloadLen)
+		if rerr != nil {
+			// A CRC mismatch or pread failure at a record the logIndex
+			// claims is valid implies log-fd corruption or a logIndex/log
+			// divergence bug. Surface it rather than silently serving wrong
+			// bytes — a wrong read is data corruption.
+			return fmt.Errorf("ReadPayloadAt: readRecordAt(logPos=%d): %w", e.logPos, rerr)
+		}
+		if recOff != e.fileOff {
+			return fmt.Errorf("ReadPayloadAt: logIndex fileOff divergence at logPos=%d (indexed=%d frame=%d)",
+				e.logPos, e.fileOff, recOff)
 		}
 		recEnd := recOff + uint64(len(payload))
-		// Skip records that do not intersect the requested window.
+		// EntriesForInterval already filtered to intersecting records, but
+		// clamp defensively in case a record's tail extends past reqEnd or
+		// its head sits below reqStart.
 		if recEnd <= reqStart || recOff >= reqEnd {
 			continue
 		}
-		// Compute intersection [hi, lo) and copy into dest.
 		copyStart := recOff
 		if copyStart < reqStart {
 			copyStart = reqStart
@@ -257,9 +299,21 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 		destIdx := copyStart - reqStart
 		srcIdx := copyStart - chunkStart
 		n := copyEnd - copyStart
-		copy(dest[destIdx:destIdx+n], data[srcIdx:srcIdx+n])
-		for i := destIdx; i < destIdx+n; i++ {
-			covered[i] = true
+		// Fill ONLY bytes the append-log step (step 1) did not already
+		// cover. The log holds the freshest, not-yet-rolled-up overwrites;
+		// a CAS chunk may still span a file region whose latest bytes live
+		// only in the log (a partial in-place overwrite of a rolled-up
+		// extent). Stamping the chunk over a log-covered byte would discard
+		// that overwrite — the data-loss class the partial-overwrite
+		// regression test guards. Per-byte gating preserves last-write-wins
+		// regardless of how the read window straddles the chunk boundary.
+		for k := uint64(0); k < n; k++ {
+			di := destIdx + k
+			if covered[di] {
+				continue
+			}
+			dest[di] = data[srcIdx+k]
+			covered[di] = true
 		}
 		if allCovered(covered) {
 			return nil

--- a/pkg/blockstore/local/fs/readpayload_indexseek_test.go
+++ b/pkg/blockstore/local/fs/readpayload_indexseek_test.go
@@ -1,0 +1,282 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestReadPayloadAt_IndexSeek_LastWriteWins exercises the index-seek read
+// path directly: multiple records covering the SAME file offset must resolve
+// to the LATEST record's bytes (last-write-wins), exactly as the previous
+// full-log replay did. The records are NOT rolled up, so they live only in
+// the append log and the read is served entirely from the logIndex seek.
+func TestReadPayloadAt_IndexSeek_LastWriteWins(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	const pid = "lww"
+
+	// Three writes at offset 0, same length: A then B then C. Last wins.
+	for _, b := range []byte{'A', 'B', 'C'} {
+		if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{b}, 1024), 0); err != nil {
+			t.Fatalf("AppendWrite %c: %v", b, err)
+		}
+	}
+
+	got := make([]byte, 1024)
+	n, err := bc.ReadPayloadAt(ctx, pid, got, 0)
+	if err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if n != len(got) {
+		t.Fatalf("short read: got %d want %d", n, len(got))
+	}
+	if want := bytes.Repeat([]byte{'C'}, 1024); !bytes.Equal(got, want) {
+		t.Fatalf("last-write-wins violated: got[:4]=%q want C*", got[:4])
+	}
+}
+
+// TestReadPayloadAt_IndexSeek_OutOfOrderArrival mirrors the parallel-write
+// case the index was designed for: records arrive in an order that is NOT
+// file-offset order, with a later overwrite partially superseding an earlier
+// record. The read must reflect arrival-order (logPos) last-write-wins on the
+// overlapping bytes and the earlier record's bytes elsewhere.
+func TestReadPayloadAt_IndexSeek_OutOfOrderArrival(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	const pid = "ooo"
+
+	// Arrival 1: offset 4096, 'Z' x 4096  (higher file offset arrives first).
+	if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{'Z'}, 4096), 4096); err != nil {
+		t.Fatalf("AppendWrite hi: %v", err)
+	}
+	// Arrival 2: offset 0, 'X' x 4096  (lower file offset arrives second).
+	if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{'X'}, 4096), 0); err != nil {
+		t.Fatalf("AppendWrite lo: %v", err)
+	}
+	// Arrival 3: offset 2048, 'Y' x 4096 — straddles both, arrives LAST so it
+	// wins on [2048, 6144).
+	if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{'Y'}, 4096), 2048); err != nil {
+		t.Fatalf("AppendWrite straddle: %v", err)
+	}
+
+	// Expected logical content over [0, 8192):
+	//   [0, 2048)    -> 'X' (arrival 2)
+	//   [2048, 6144) -> 'Y' (arrival 3, last writer)
+	//   [6144, 8192) -> 'Z' (arrival 1)
+	want := make([]byte, 8192)
+	for i := 0; i < 2048; i++ {
+		want[i] = 'X'
+	}
+	for i := 2048; i < 6144; i++ {
+		want[i] = 'Y'
+	}
+	for i := 6144; i < 8192; i++ {
+		want[i] = 'Z'
+	}
+
+	got := make([]byte, 8192)
+	if _, err := bc.ReadPayloadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		// Report the first divergence for diagnosis.
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("byte %d: got %q want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestReadPayloadAt_IndexSeek_PartialWindow asserts a sub-window read (offset
+// inside a record, length shorter than the record) lands the correct bytes
+// via the seek path — the destIdx/srcIdx clamping must be exact.
+func TestReadPayloadAt_IndexSeek_PartialWindow(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	const pid = "partial"
+
+	// One 8 KiB record of incrementing bytes at offset 0.
+	rec := make([]byte, 8192)
+	for i := range rec {
+		rec[i] = byte(i)
+	}
+	if err := bc.AppendWrite(ctx, pid, rec, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Read [3000, 5000).
+	got := make([]byte, 2000)
+	if _, err := bc.ReadPayloadAt(ctx, pid, got, 3000); err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if !bytes.Equal(got, rec[3000:5000]) {
+		t.Fatalf("partial window mismatch: got[:4]=%v want %v", got[:4], rec[3000:5000][:4])
+	}
+}
+
+// TestReadPayloadAt_ConsumedThenOverwritten is the regression for the mixed
+// read/write/overwrite workload that broke the previous attempt. A record is
+// written and ROLLED UP (consumed → dropped from the logIndex, but its frame
+// remains physically in the on-disk log). A later in-place overwrite of the
+// SAME region lands ONLY in the append log (unconsumed). A read of the region
+// must return:
+//   - the overwrite bytes where the unconsumed log record covers them
+//     (served from the index seek), and
+//   - the rolled-up CAS bytes elsewhere (served from the manifest),
+//
+// never decoding the stale physical frame of the consumed record (the
+// previous attempt's "payloadLen ... exceeds ... cap" bug came from seeking a
+// wrong/stale logPos into such a frame).
+func TestReadPayloadAt_ConsumedThenOverwritten(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	fbs := newMemFileBlockStore()
+	persister := func(ctx context.Context, payloadID string, blocks []blockstore.BlockRef, _ blockstore.ObjectID) error {
+		return fbs.persist(ctx, payloadID, blocks)
+	}
+
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+	ctx := context.Background()
+	const pid = "consumed-overwrite"
+
+	// Write 16 KiB of 'A' at offset 0 and roll it up into CAS.
+	base := bytes.Repeat([]byte{'A'}, 16*1024)
+	if err := bc.AppendWrite(ctx, pid, base, 0); err != nil {
+		t.Fatalf("AppendWrite base: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	// The base record is now consumed: the index must have been trimmed at
+	// the fence so its entry is gone, even though the physical frame remains
+	// on disk.
+	bc.logsMu.RLock()
+	idx := bc.logIndices[pid]
+	bc.logsMu.RUnlock()
+	if idx == nil {
+		t.Fatal("logIndex missing for payload")
+	}
+	if got := idx.Len(); got != 0 {
+		t.Fatalf("expected 0 unconsumed index entries after drain, got %d", got)
+	}
+
+	// In-place overwrite of [4096, 8192) with 'B' — lands ONLY in the log.
+	over := bytes.Repeat([]byte{'B'}, 4096)
+	if err := bc.AppendWrite(ctx, pid, over, 4096); err != nil {
+		t.Fatalf("AppendWrite overwrite: %v", err)
+	}
+
+	// Read [0, 16384): 'A' from CAS everywhere except [4096,8192) which is
+	// the unconsumed 'B' overwrite served via the index seek.
+	want := bytes.Repeat([]byte{'A'}, 16*1024)
+	for i := 4096; i < 8192; i++ {
+		want[i] = 'B'
+	}
+	got := make([]byte, 16*1024)
+	n, err := bc.ReadPayloadAt(ctx, pid, got, 0)
+	if err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if n != len(got) {
+		t.Fatalf("short read: got %d want %d", n, len(got))
+	}
+	if !bytes.Equal(got, want) {
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("byte %d: got %q want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestReadPayloadAt_OverCapRecordSkipped is the exact regression for the
+// previous attempt's failure: a single AppendWrite larger than
+// maxRecordPayload (e.g. the bench's 32 MiB mixed-rw seed) lands as ONE log
+// frame at logPos=64. readRecordAt cannot decode a frame above the cap, so
+// the seek path must SKIP it — matching the pre-index full-log replay, which
+// likewise skipped over-cap frames and let coverage fall through to a miss —
+// rather than returning the hard "payloadLen ... exceeds ... cap" error that
+// broke mixed-rw. A read of the unrolled large record therefore reports a
+// local miss (ErrFileBlockNotFound), never wrong bytes and never an error.
+func TestReadPayloadAt_OverCapRecordSkipped(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	const pid = "overcap"
+
+	big := make([]byte, maxRecordPayload+4096) // exceeds the read-path cap
+	if err := bc.AppendWrite(ctx, pid, big, 0); err != nil {
+		t.Fatalf("AppendWrite big: %v", err)
+	}
+
+	// Sanity: the index has the over-cap entry (the WRITE path accepts it).
+	bc.logsMu.RLock()
+	idx := bc.logIndices[pid]
+	bc.logsMu.RUnlock()
+	if idx == nil || idx.Len() != 1 {
+		t.Fatalf("expected 1 index entry for the over-cap write")
+	}
+
+	// Read must not error and must not partially fill; it reports a local
+	// miss so the engine falls back (exactly as the old full-log replay did).
+	got := make([]byte, 4096)
+	_, err := bc.ReadPayloadAt(ctx, pid, got, 0)
+	if !errors.Is(err, blockstore.ErrFileBlockNotFound) {
+		t.Fatalf("ReadPayloadAt over-cap: err = %v, want ErrFileBlockNotFound (skip, not hard error)", err)
+	}
+}
+
+// TestReadPayloadAt_IndexSeek_NoLogPosScaling proves the per-read cost no
+// longer scales with the on-disk log size. We write many DISTINCT records at
+// increasing offsets, then read only the FIRST record. The index-seek path
+// must touch exactly one frame regardless of how many records precede or
+// follow it on disk — verified by asserting the index returns a single entry
+// for the queried window even though the log holds many.
+func TestReadPayloadAt_IndexSeek_NoLogPosScaling(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	const pid = "noscale"
+	const recLen = 4096
+	const nRecs = 256
+
+	for i := 0; i < nRecs; i++ {
+		if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{byte(i)}, recLen), uint64(i)*recLen); err != nil {
+			t.Fatalf("AppendWrite %d: %v", i, err)
+		}
+	}
+
+	bc.logsMu.RLock()
+	idx := bc.logIndices[pid]
+	bc.logsMu.RUnlock()
+	if idx == nil {
+		t.Fatal("logIndex missing")
+	}
+	if total := idx.Len(); total != nRecs {
+		t.Fatalf("index entry count: got %d want %d", total, nRecs)
+	}
+	// A read of the first record's window must map to exactly ONE index
+	// entry — the lookup does not depend on the total record count.
+	hits := idx.EntriesForInterval(0, recLen, nil)
+	if len(hits) != 1 {
+		t.Fatalf("EntriesForInterval(first record) returned %d entries, want 1 (read cost must not scale with log size)", len(hits))
+	}
+
+	got := make([]byte, recLen)
+	if _, err := bc.ReadPayloadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if want := bytes.Repeat([]byte{0}, recLen); !bytes.Equal(got, want) {
+		t.Fatalf("first record read mismatch: got[:4]=%v", got[:4])
+	}
+}


### PR DESCRIPTION
## What

`ReadPayloadAt` (`pkg/blockstore/local/fs/readpayload.go`) previously **replayed the entire per-payload append log on every read** — opening the log, seeking past the header, and sequentially decoding + CRC-checking every framed record (O(log-size) per read). This pass uses the per-payload `logIndex` (already maintained for the rollup) to translate the requested file-offset window into the exact set of intersecting record frames and `pread` each one directly.

The index is trimmed at the compaction fence, so it only holds records **not yet rolled into CAS** — exactly the records that live only in the log. Bytes whose records were already consumed by the rollup are served from the CAS manifest in step 2, unchanged. Read semantics (last-write-wins, exact bytes) are byte-identical.

## Why this is correct (and why the prior attempt was reverted)

A previous refactor was reverted because it broke both reads and rollup with `readRecordAt(logPos=64): append log: payloadLen 33554432 exceeds 17825792 cap at logPos=64`. Root causes addressed here:

1. **Stale `logPos`.** `logIndex` entries carry absolute log-byte positions; a rollup *compaction* atomically rewrites the on-disk log **and** rebases `idx.entries[].logPos` under the per-file mutex. Reading a `logPos` without that mutex can `pread` a stale (pre-rebase) position and decode a garbage frame. This pass holds the **same per-file mutex** across the index lookup *and* all preads, so the log/index pair is always consistent. `readRecordAt` additionally cross-checks the frame's declared `payload_len` and `file_offset` against the index entry.

2. **Legitimately large records.** A single `AppendWrite` may exceed `maxRecordPayload` (the engine appends whole writes — e.g. the bench's 32 MiB `mixed-rw` seed lands as one frame). `readRecordAt`/`readRecord` both reject frames above the cap as a torn/hostile-length DoS guard. The pre-index replay used `readRecord`, which **skipped** such frames and let coverage fall through to the CAS/remote-miss path. We preserve that exact behavior (skip, not error) — this is the case whose mishandling (a hard error) broke `mixed-rw`.

3. **Partial-overwrite data loss.** `fillFromCASManifest` now fills only the bytes the log step did not already cover, so a partial in-place overwrite of a rolled-up extent (latest bytes in the log, older bytes in CAS) is not clobbered by the CAS chunk.

## Performance

Reading the first record while the log holds 256× more records grows only ~3× (18.9µs → 58.9µs), versus the previous ~linear-in-log-bytes replay. The residual is the in-memory index scan + fd open, not per-byte log replay.

## Tests

New `readpayload_indexseek_test.go`: index-seek last-write-wins, out-of-order arrival (parallel-write), partial window, **consumed-then-overwritten** (log overlay over CAS), **over-cap record skipped** (the 32 MiB-seed regression), and a no-log-size-scaling assertion.

Verification gate (the integration tag is how the prior bug escaped):
- `go build ./...` — clean
- `go test ./pkg/blockstore/... -count=1` — pass
- `go test -tags=integration -p 1 -timeout=20m ./bench/blockstore/... ./pkg/blockstore/... -count=1` — pass; **`TestRunWorkload_AllWorkloads/mixed-rw` PASSES**, no `payloadLen ... exceeds ... cap` or `rollupFile ... readRecordAt` errors
- `go test -race ./pkg/blockstore/local/fs/... ./pkg/blockstore/engine/... -count=1` — clean
- `gofmt -s`, `go vet ./...`, `golangci-lint run` — 0 issues