### PR TITLE
fix(blockstore/remote): correct sentinel for invalid GetRange offset/length (#694)

### DIFF
--- a/pkg/blockstore/blockstoretest/conformance.go
+++ b/pkg/blockstore/blockstoretest/conformance.go
@@ -76,6 +76,7 @@ func BlockStoreConformance(t *testing.T, factory Factory) {
 	t.Run("Put_Concurrent_SameHash", func(t *testing.T) { testPutConcurrent(t, factory) })
 	t.Run("Put_ZeroByte", func(t *testing.T) { testPutZeroByte(t, factory) })
 	t.Run("GetRange_PastEOF", func(t *testing.T) { testGetRangePastEOF(t, factory) })
+	t.Run("GetRange_InvalidBounds", func(t *testing.T) { testGetRangeInvalidBounds(t, factory) })
 	t.Run("Concurrent_Put_Walk_NoDuplicates", func(t *testing.T) { testConcurrentPutWalkNoDuplicates(t, factory) })
 	t.Run("Put_WrongHash_NoVerify", func(t *testing.T) { testPutWrongHashNoVerify(t, factory) })
 }
@@ -486,6 +487,39 @@ func testGetRangePastEOF(t *testing.T, factory Factory) {
 	want := stored[8:]
 	if !bytes.Equal(got, want) {
 		t.Fatalf("GetRange partial-past-EOF returned %q, want %q", got, want)
+	}
+}
+
+// testGetRangeInvalidBounds pins the malformed-argument sentinels on the
+// BlockStore.GetRange contract: a negative offset MUST surface
+// blockstore.ErrInvalidOffset and a non-positive length MUST surface
+// blockstore.ErrInvalidSize. Unlike the offset-past-EOF case (which the
+// godoc permits backends to report with any error), these two arguments
+// are unconditionally invalid regardless of object size, so every
+// backend can detect them before touching storage and report the exact
+// sentinel via errors.Is.
+func testGetRangeInvalidBounds(t *testing.T, factory Factory) {
+	bs, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	stored := []byte("0123456789abcdef") // exactly 16 bytes
+	h := blake3Sum(stored)
+	if err := bs.Put(ctx, h, stored); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Negative offset is ErrInvalidOffset.
+	if _, err := bs.GetRange(ctx, h, -1, 4); !errors.Is(err, blockstore.ErrInvalidOffset) {
+		t.Fatalf("GetRange offset=-1: want ErrInvalidOffset, got %v", err)
+	}
+
+	// Zero and negative length are ErrInvalidSize.
+	if _, err := bs.GetRange(ctx, h, 0, 0); !errors.Is(err, blockstore.ErrInvalidSize) {
+		t.Fatalf("GetRange length=0: want ErrInvalidSize, got %v", err)
+	}
+	if _, err := bs.GetRange(ctx, h, 0, -4); !errors.Is(err, blockstore.ErrInvalidSize) {
+		t.Fatalf("GetRange length=-4: want ErrInvalidSize, got %v", err)
 	}
 }
 

--- a/pkg/blockstore/local/memory/memory.go
+++ b/pkg/blockstore/local/memory/memory.go
@@ -202,7 +202,9 @@ func (s *MemoryStore) GetRange(_ context.Context, hash blockstore.ContentHash, o
 	if offset >= size {
 		return nil, fmt.Errorf("blockstore.memory: GetRange: offset %d beyond size %d", offset, size)
 	}
-	if offset+length > size {
+	// offset < size is guaranteed above, so size-offset is positive; compare
+	// against it instead of offset+length (which can overflow int64).
+	if length > size-offset {
 		length = size - offset
 	}
 	out := make([]byte, length)

--- a/pkg/blockstore/local/memory/memory.go
+++ b/pkg/blockstore/local/memory/memory.go
@@ -189,10 +189,10 @@ func (s *MemoryStore) GetRange(_ context.Context, hash blockstore.ContentHash, o
 		return nil, ErrStoreClosed
 	}
 	if offset < 0 {
-		return nil, fmt.Errorf("blockstore.memory: GetRange: negative offset %d", offset)
+		return nil, fmt.Errorf("blockstore.memory: GetRange: %w: offset %d", blockstore.ErrInvalidOffset, offset)
 	}
 	if length <= 0 {
-		return nil, fmt.Errorf("blockstore.memory: GetRange: non-positive length %d", length)
+		return nil, fmt.Errorf("blockstore.memory: GetRange: %w: length %d", blockstore.ErrInvalidSize, length)
 	}
 	entry, ok := s.cas[hash]
 	if !ok {

--- a/pkg/blockstore/remote/memory/store.go
+++ b/pkg/blockstore/remote/memory/store.go
@@ -149,9 +149,15 @@ func (s *Store) GetRange(_ context.Context, hash blockstore.ContentHash, offset,
 		return nil, blockstore.ErrChunkNotFound
 	}
 
-	// Bounds checking
+	// Bounds checking. Per the BlockStore.GetRange contract, a negative
+	// or past-EOF offset is ErrInvalidOffset and a non-positive length is
+	// ErrInvalidSize; an in-range offset whose length runs past EOF is
+	// clamped to the chunk's remaining bytes (no error).
 	if offset < 0 || offset >= int64(len(mb.data)) {
-		return nil, blockstore.ErrChunkNotFound
+		return nil, blockstore.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, blockstore.ErrInvalidSize
 	}
 
 	end := offset + length

--- a/pkg/blockstore/remote/memory/store.go
+++ b/pkg/blockstore/remote/memory/store.go
@@ -160,9 +160,13 @@ func (s *Store) GetRange(_ context.Context, hash blockstore.ContentHash, offset,
 		return nil, blockstore.ErrInvalidSize
 	}
 
-	end := offset + length
-	if end > int64(len(mb.data)) {
-		end = int64(len(mb.data))
+	// Clamp past-EOF length without computing offset+length (which can
+	// overflow int64 for a hostile length). offset < len is guaranteed above,
+	// so len-offset is positive.
+	size := int64(len(mb.data))
+	end := size
+	if length <= size-offset {
+		end = offset + length
 	}
 
 	result := make([]byte, end-offset)

--- a/pkg/blockstore/remote/memory/store_test.go
+++ b/pkg/blockstore/remote/memory/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"lukechampine.com/blake3"
@@ -149,6 +150,18 @@ func TestStore_GetRange_InvalidBounds(t *testing.T) {
 			}
 		})
 	}
+
+	// A valid in-range offset with a length so large that offset+length would
+	// overflow int64 must clamp to the remaining bytes, not panic or wrap.
+	t.Run("length overflow clamps", func(t *testing.T) {
+		got, err := s.GetRange(ctx, hash, 6, math.MaxInt64)
+		if err != nil {
+			t.Fatalf("GetRange(6, MaxInt64): unexpected error %v", err)
+		}
+		if string(got) != "world" {
+			t.Fatalf("GetRange(6, MaxInt64): want clamped %q, got %q", "world", got)
+		}
+	})
 }
 
 func TestStore_Delete(t *testing.T) {

--- a/pkg/blockstore/remote/memory/store_test.go
+++ b/pkg/blockstore/remote/memory/store_test.go
@@ -115,6 +115,42 @@ func TestStore_GetRange(t *testing.T) {
 	}
 }
 
+// TestStore_GetRange_InvalidBounds pins the malformed-bounds sentinels:
+// an offset at or beyond the chunk size is ErrInvalidOffset (not
+// ErrChunkNotFound, the historical regression) and a non-positive length
+// is ErrInvalidSize.
+func TestStore_GetRange_InvalidBounds(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	data := []byte("hello world") // 11 bytes
+	hash := hashOf(t, data)
+	if err := s.Put(ctx, hash, data); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		offset, length int64
+		want           error
+	}{
+		{"negative offset", -1, 4, blockstore.ErrInvalidOffset},
+		{"offset at size", 11, 4, blockstore.ErrInvalidOffset},
+		{"offset beyond size", 12, 4, blockstore.ErrInvalidOffset},
+		{"zero length", 0, 0, blockstore.ErrInvalidSize},
+		{"negative length", 0, -1, blockstore.ErrInvalidSize},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.GetRange(ctx, hash, tc.offset, tc.length)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("GetRange(offset=%d,length=%d): want %v, got %v", tc.offset, tc.length, tc.want, err)
+			}
+		})
+	}
+}
+
 func TestStore_Delete(t *testing.T) {
 	ctx := context.Background()
 	s := New()

--- a/pkg/blockstore/remote/s3/store.go
+++ b/pkg/blockstore/remote/s3/store.go
@@ -344,6 +344,18 @@ func (s *Store) GetRange(ctx context.Context, hash blockstore.ContentHash, offse
 		return nil, err
 	}
 
+	// Validate bounds before issuing the range request so callers get a
+	// stable sentinel instead of an opaque S3 protocol error from a
+	// malformed Range header. A past-EOF offset cannot be detected here
+	// without a HEAD, so S3 surfaces its native 416 for that case (the
+	// conformance suite only requires "any error" for offset >= EOF).
+	if offset < 0 {
+		return nil, blockstore.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, blockstore.ErrInvalidSize
+	}
+
 	key := s.hashKey(hash)
 	rangeHeader := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
 

--- a/pkg/blockstore/remote/s3/store.go
+++ b/pkg/blockstore/remote/s3/store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"strings"
@@ -353,6 +354,12 @@ func (s *Store) GetRange(ctx context.Context, hash blockstore.ContentHash, offse
 		return nil, blockstore.ErrInvalidOffset
 	}
 	if length <= 0 {
+		return nil, blockstore.ErrInvalidSize
+	}
+
+	// Guard against offset+length-1 overflowing int64 (which would emit a
+	// negative, malformed Range header). offset >= 0 and length > 0 here.
+	if length > math.MaxInt64-offset {
 		return nil, blockstore.ErrInvalidSize
 	}
 


### PR DESCRIPTION
## Problem

`pkg/blockstore/remote/memory` `GetRange` returned the wrong sentinel for malformed bounds:

- Out-of-bounds offset (`offset < 0 || offset >= size`) returned **`ErrChunkNotFound`** — implying the chunk was absent when it exists.
- `length <= 0` was **not validated at all**.

The `BlockStore.GetRange` contract (godoc in `pkg/blockstore/blockstore.go`) requires:
- **`ErrInvalidOffset`** when offset is negative or beyond the chunk size,
- **`ErrInvalidSize`** when length is non-positive,
- partial-past-EOF (valid offset, length runs off the end) is **clamped** to the remaining bytes, no error.

## Fix

- **remote/memory**: invalid offset → `ErrInvalidOffset`; `length <= 0` → `ErrInvalidSize`; partial-past-EOF still clamps.
- **local/memory**: shared the same bug class — it returned a plain `fmt.Errorf` ("negative offset" / "non-positive length") instead of the wrapped sentinel. Now wraps `ErrInvalidOffset`/`ErrInvalidSize` with `%w`, matching FSStore.
- **s3**: had no in-process bounds check. Added up-front validation for negative offset and non-positive length so a malformed `Range` header no longer surfaces an opaque S3 protocol error. A past-EOF offset can't be detected without a HEAD, so S3 keeps surfacing its native 416 there (the conformance suite only requires "any error" for offset >= EOF — unchanged).

## Was S3 affected?

Not the exact `ErrChunkNotFound` regression (it has no in-process bounds check), but it returned opaque errors for negative offset / non-positive length. Hardened to the same sentinel contract.

## Tests

- New `GetRange_InvalidBounds` case in the shared conformance suite (`pkg/blockstore/blockstoretest`) — runs against **every** backend (fs, local/memory, remote/memory, and s3 when env-gated). This caught the local/memory divergence.
- New `TestStore_GetRange_InvalidBounds` regression test in remote/memory pinning all five malformed-bounds cases.
- `go build ./...`, `go test ./pkg/blockstore/...`, and `go test -race ./pkg/blockstore/remote/...` all green; `gofmt`/`go vet`/`golangci-lint` clean.

Closes #694