### PR TITLE
fix(smb/acl): expand GENERIC_* before MAXIMUM_ALLOWED subset check

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -671,8 +671,9 @@ const (
 // parent's FILE_DELETE_CHILD can override a DELETE denial on the file's own
 // DACL — see that function's documentation for the spec citation.
 //
-// GENERIC_*, OWNER_RIGHTS, and ACCESSBASED enumeration are intentionally
-// out of scope here — those are tracked separately under #530/#531/#532.
+// GENERIC_* bits in desiredAccess are expanded to their file-object-specific
+// rights before evaluation (see CheckFileAccessWithParent). OWNER_RIGHTS and
+// ACCESSBASED enumeration remain out of scope here — tracked under #531/#532.
 func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
 	return s.CheckFileAccessWithParent(file, nil, authCtx, desiredAccess)
 }
@@ -701,7 +702,16 @@ func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desi
 // When parent is nil, behavior is identical to CheckFileAccess.
 func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
 	maximumAllowed := desiredAccess&accessMaskMaximumAllowed != 0
-	explicit := desiredAccess &^ accessMaskMaximumAllowed
+	// Expand MS-DTYP §2.4.3 GENERIC_* bits to their file-object-specific
+	// rights before the subset checks below (MS-DTYP §2.5.3 / MS-FSA
+	// §2.1.5.1.2.1). Without this, a request such as MAXIMUM_ALLOWED |
+	// GENERIC_READ leaves the raw GENERIC_READ bit (0x80000000) in `explicit`
+	// while the DACL evaluation produces only the specific READ rights — the
+	// `effective&explicit == explicit` / `granted&explicit == explicit`
+	// subset checks could then never be satisfied, denying an open the DACL
+	// actually permits (smb2.maximum_allowed). ExpandGenericMask strips the
+	// generic bits and leaves MAXIMUM_ALLOWED untouched.
+	explicit := acl.ExpandGenericMask(desiredAccess &^ accessMaskMaximumAllowed)
 
 	// Root bypass: identical semantics to computeMaximalAccess and
 	// evaluateACLPermissions. UID 0 gets everything; MAXIMUM_ALLOWED resolves

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -32,6 +32,11 @@ const (
 	rightReadControl uint32 = 0x00020000
 	rightSynchronize uint32 = 0x00100000
 	rightMaxAllowed  uint32 = 0x02000000
+
+	// MS-DTYP §2.4.3 GENERIC_* bits (pre-expansion form a client may send).
+	rightGenericRead    uint32 = 0x80000000
+	rightGenericWrite   uint32 = 0x40000000
+	rightGenericExecute uint32 = 0x20000000
 )
 
 // TestCheckFileAccess_DenyACEOnOwnerDeniesWrite covers smbtorture acls.OWNER /
@@ -697,4 +702,143 @@ func TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent(t *testing.T) {
 	var storeErr *metadata.StoreError
 	require.ErrorAs(t, err, &storeErr)
 	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// createSpecificRightsFile is a helper for the GENERIC_* expansion tests: it
+// creates a file whose DACL grants exactly `mask` to `sid` and nothing else,
+// owned by an unrelated UID so only the DACL (not the POSIX owner fallback)
+// governs access.
+func createSpecificRightsFile(t *testing.T, f *testFixture, name, sid string, mask uint32) *metadata.File {
+	t.Helper()
+	a := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        "sid:" + sid,
+				AccessMask: mask,
+			},
+		},
+	}
+	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, name,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  9999, // not the requester
+			GID:  9999,
+			ACL:  a,
+		})
+	require.NoError(t, err)
+	return created
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusGenericReadGranted covers smbtorture
+// smb2.maximum_allowed (max_allowed.c:162). A request of
+// MAXIMUM_ALLOWED | GENERIC_READ against a DACL that grants only the specific
+// READ rights (FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES |
+// READ_CONTROL | SYNCHRONIZE) must be GRANTED with STATUS_OK.
+//
+// Regression guard: before expanding GENERIC_* in `explicit`, the raw
+// GENERIC_READ bit (0x80000000) survived into the subset check while the DACL
+// evaluation produced only specific rights, so effective&explicit could never
+// equal explicit and the open was wrongly denied STATUS_ACCESS_DENIED.
+func TestCheckFileAccess_MaximumAllowedPlusGenericReadGranted(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// FILE_GENERIC_READ specific-rights set (MS-DTYP §2.4.3 file mapping).
+	readMask := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_NAMED_ATTRS |
+		acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+	created := createSpecificRightsFile(t, f, "max_generic_read.txt", requesterSID, readMask)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericRead)
+	require.NoError(t, err, "MAXIMUM_ALLOWED|GENERIC_READ against a READ-granting DACL must succeed")
+	require.NotZero(t, granted&acl.ACE4_READ_DATA, "expected READ_DATA in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&uint32(0xF0000000), "granted mask must not retain raw GENERIC_* bits, got 0x%x", granted)
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusGenericWriteGranted is the WRITE
+// symmetric case of the smb2.maximum_allowed fix.
+func TestCheckFileAccess_MaximumAllowedPlusGenericWriteGranted(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// FILE_GENERIC_WRITE specific-rights set.
+	writeMask := uint32(acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA |
+		acl.ACE4_WRITE_NAMED_ATTRS | acl.ACE4_WRITE_ATTRIBUTES |
+		acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+	created := createSpecificRightsFile(t, f, "max_generic_write.txt", requesterSID, writeMask)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericWrite)
+	require.NoError(t, err, "MAXIMUM_ALLOWED|GENERIC_WRITE against a WRITE-granting DACL must succeed")
+	require.NotZero(t, granted&acl.ACE4_WRITE_DATA, "expected WRITE_DATA in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&uint32(0xF0000000), "granted mask must not retain raw GENERIC_* bits, got 0x%x", granted)
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusGenericExecuteGranted is the EXECUTE
+// symmetric case of the smb2.maximum_allowed fix.
+func TestCheckFileAccess_MaximumAllowedPlusGenericExecuteGranted(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// FILE_GENERIC_EXECUTE specific-rights set.
+	execMask := uint32(acl.ACE4_READ_ATTRIBUTES | acl.ACE4_EXECUTE |
+		acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+	created := createSpecificRightsFile(t, f, "max_generic_exec.txt", requesterSID, execMask)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericExecute)
+	require.NoError(t, err, "MAXIMUM_ALLOWED|GENERIC_EXECUTE against an EXECUTE-granting DACL must succeed")
+	require.NotZero(t, granted&acl.ACE4_EXECUTE, "expected EXECUTE in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&uint32(0xF0000000), "granted mask must not retain raw GENERIC_* bits, got 0x%x", granted)
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusGenericReadDeniedTrueControl is the
+// true-deny control for the GENERIC_* expansion fix: GENERIC_READ expands to a
+// set that includes specific READ rights, but the DACL here grants only
+// WRITE_DATA. The expanded explicit READ bits are not in the DACL, so the open
+// MUST still be denied — proving the expansion does not blanket-grant.
+func TestCheckFileAccess_MaximumAllowedPlusGenericReadDeniedTrueControl(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// DACL grants ONLY WRITE_DATA — none of the GENERIC_READ specific rights
+	// (other than the always-granted READ_ATTRIBUTES from the parent).
+	created := createSpecificRightsFile(t, f, "max_generic_read_deny.txt", requesterSID, acl.ACE4_WRITE_DATA)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	_, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericRead)
+	require.Error(t, err, "MAXIMUM_ALLOWED|GENERIC_READ against a WRITE-only DACL must deny")
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// TestCheckFileAccess_StrictGenericReadGranted exercises the strict (non-MAX)
+// branch: a bare GENERIC_READ request (no MAXIMUM_ALLOWED) against a
+// READ-granting DACL must succeed once the generic bit is expanded.
+func TestCheckFileAccess_StrictGenericReadGranted(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	readMask := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_NAMED_ATTRS |
+		acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+	created := createSpecificRightsFile(t, f, "strict_generic_read.txt", requesterSID, readMask)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightGenericRead)
+	require.NoError(t, err, "GENERIC_READ against a READ-granting DACL must succeed in strict mode")
+	require.NotZero(t, granted&acl.ACE4_READ_DATA, "expected READ_DATA in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&uint32(0xF0000000), "granted mask must not retain raw GENERIC_* bits, got 0x%x", granted)
 }


### PR DESCRIPTION
## Summary

Fixes smbtorture `smb2.maximum_allowed` (#750).

`MetadataService.CheckFileAccessWithParent` computed the explicit-bit set as `desiredAccess &^ MAXIMUM_ALLOWED`, which left raw MS-DTYP §2.4.3 GENERIC_* bits (`GENERIC_READ`/`WRITE`/`EXECUTE`/`ALL`) in `explicit`. The two subset checks then compared expanded specific rights from the DACL evaluation against an un-expanded generic bit:

- MAXIMUM_ALLOWED branch: `effective & explicit == explicit`
- strict branch: `granted & explicit == explicit`

Because `effective`/`granted` only ever hold specific rights while `explicit` still held e.g. `GENERIC_READ` (0x80000000), the equality could never hold, so a request such as `MAXIMUM_ALLOWED | GENERIC_READ` against a DACL granting specific READ rights was wrongly denied with STATUS_ACCESS_DENIED (max_allowed.c:162 expects STATUS_OK).

## Fix

Expand GENERIC_* to file-object-specific rights via the existing `acl.ExpandGenericMask` before the subset checks (MS-DTYP §2.4.3 / §2.5.3, MS-FSA §2.1.5.1.2.1). One derivation point feeds both branches, so the fix covers both. `MAXIMUM_ALLOWED` and unrelated bits (incl. ACCESS_SYSTEM_SECURITY) pass through unchanged.

## Tests

Added to `pkg/metadata/auth_permissions_file_access_test.go`:
- `MAXIMUM_ALLOWED | GENERIC_READ/WRITE/EXECUTE` against a DACL granting the matching specific rights → GRANTED
- strict (non-MAX) `GENERIC_READ` → GRANTED
- true-deny control: `MAXIMUM_ALLOWED | GENERIC_READ` against a WRITE-only DACL → DENIED

Reverting the one-line fix makes the new tests fail with AccessDenied; with the fix all pass. `go test -race ./pkg/metadata/...` green.