### PR TITLE
perf(nfs): presize compound reply buffer, bound connections, drop dead code (v1.0 audit #4)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -799,7 +799,7 @@ adapters:
   nfs:
     enabled: true
     port: 2049
-    max_connections: 0           # 0 = unlimited
+    max_connections: 0           # 0 falls back to 1024 (default cap)
 
     # Grouped timeout configuration
     timeouts:

--- a/internal/adapter/nfs/doc.go
+++ b/internal/adapter/nfs/doc.go
@@ -100,7 +100,7 @@
 // # Configuration Recommendations
 //
 // Development:
-//   - MaxConnections: 0 (unlimited)
+//   - MaxConnections: 1024 (default; 0 in config falls back to this)
 //   - Timeouts: 30s-60s
 //
 // Production (moderate load):

--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -716,8 +716,8 @@ func resolveOwnerString(uid uint32) string {
 // This is compatible with the Linux kernel NFS client's default
 // nfs4_disable_idmapping=Y mode. See resolveOwnerString for details.
 func resolveGroupString(gid uint32) string {
-	// Note: Identity mapper does not currently support group reverse resolution.
-	// This can be extended when GroupResolver implements reverse lookup.
+	// Note: the identity mapper does not currently support group reverse
+	// resolution. This can be extended when reverse group lookup is added.
 	return fmt.Sprintf("%d", gid)
 }
 

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -608,6 +608,17 @@ func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, fir
 func encodeCompoundResponse(status uint32, tag []byte, results []types.CompoundResult) ([]byte, error) {
 	var buf bytes.Buffer
 
+	// Presize the buffer to the exact encoded length so the hot COMPOUND reply
+	// path performs a single allocation instead of repeated grow-and-copy. The
+	// wire output is byte-identical; this only reserves capacity up front.
+	//   status(4) + tag opaque(4 + len + pad) + numresults(4)
+	//   + per result: opcode(4) + len(Data)
+	size := 4 + 4 + len(tag) + ((4 - (len(tag) % 4)) % 4) + 4
+	for i := range results {
+		size += 4 + len(results[i].Data)
+	}
+	buf.Grow(size)
+
 	// Write overall status
 	if err := xdr.WriteUint32(&buf, status); err != nil {
 		return nil, fmt.Errorf("encode COMPOUND status: %w", err)

--- a/internal/adapter/nfs/v4/handlers/compound_bench_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_bench_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// BenchmarkEncodeCompoundResponse measures allocations of the COMPOUND reply
+// encoder. The buffer is presized to the exact wire length so a typical reply
+// allocates once instead of growing repeatedly.
+func BenchmarkEncodeCompoundResponse(b *testing.B) {
+	tag := []byte("compound-tag")
+	// A representative compound reply: SEQUENCE + PUTFH + a few ops each
+	// carrying a small result payload (status + op-specific data).
+	results := make([]types.CompoundResult, 8)
+	for i := range results {
+		data := make([]byte, 64)
+		results[i] = types.CompoundResult{
+			Status: types.NFS4_OK,
+			OpCode: uint32(i + 1),
+			Data:   data,
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := encodeCompoundResponse(types.NFS4_OK, tag, results)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) == 0 {
+			b.Fatal("empty encode")
+		}
+	}
+}

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -29,6 +29,12 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
+// DefaultMaxConnections is the connection cap applied when MaxConnections is
+// left at its zero value. A non-zero default ensures the accept-loop semaphore
+// is always built, preventing unauthenticated connection-exhaustion DoS.
+// Operators can raise it for high-load deployments.
+const DefaultMaxConnections = 1024
+
 // NFSAdapter implements the adapter.Adapter interface for NFS protocol.
 //
 // This adapter provides a production-ready NFS server supporting both
@@ -160,7 +166,7 @@ type NFSTimeoutsConfig struct {
 //
 // Default values (applied by New if zero):
 //   - Port: 2049 (standard NFS port)
-//   - MaxConnections: 0 (unlimited)
+//   - MaxConnections: 1024 (DefaultMaxConnections)
 //   - Timeouts.Read: 5m
 //   - Timeouts.Write: 30s
 //   - Timeouts.Idle: 5m
@@ -184,8 +190,8 @@ type NFSConfig struct {
 
 	// MaxConnections limits the number of concurrent client connections.
 	// When reached, new connections are rejected until existing ones close.
-	// 0 means unlimited (not recommended for production).
-	// Recommended: 1000-5000 for production servers.
+	// If 0, defaults to DefaultMaxConnections (1024) so the accept loop is
+	// always bounded. Raise to 1000-5000 for busy production servers.
 	MaxConnections int `mapstructure:"max_connections" validate:"min=0"`
 
 	// MaxRequestsPerConnection limits the number of concurrent RPC requests
@@ -236,6 +242,12 @@ func (c *NFSConfig) applyDefaults() {
 	}
 	if c.MaxRequestsPerConnection == 0 {
 		c.MaxRequestsPerConnection = 100
+	}
+	if c.MaxConnections == 0 {
+		// A sane default cap so the accept loop's connSemaphore is always
+		// built. Leaving this at 0 (unlimited) lets unauthenticated clients
+		// exhaust memory/goroutines. Operators can raise it for busy servers.
+		c.MaxConnections = DefaultMaxConnections
 	}
 	if c.Timeouts.Read == 0 {
 		c.Timeouts.Read = 5 * time.Minute

--- a/pkg/adapter/nfs/identity/mapper.go
+++ b/pkg/adapter/nfs/identity/mapper.go
@@ -10,9 +10,6 @@
 //   - TableMapper: Resolves explicit mappings from a MappingStore
 //   - StaticMapper: Maps from a static config map (migrated from pkg/auth/kerberos)
 //   - CachedMapper: TTL-based caching wrapper for any IdentityMapper
-//
-// GroupResolver is a separate interface for group membership queries, used during
-// ACL evaluation of group@domain principals.
 package identity
 
 import (
@@ -66,18 +63,6 @@ type ResolvedIdentity struct {
 	// Found indicates whether the principal was successfully resolved.
 	// false means the mapper could not resolve this principal (not an error).
 	Found bool
-}
-
-// GroupResolver provides group membership queries for ACL evaluation.
-//
-// When evaluating group@domain ACE principals, the ACL engine needs to check
-// whether the requesting user is a member of the specified group.
-type GroupResolver interface {
-	// GetGroupMembers returns all usernames that are members of the given group.
-	GetGroupMembers(ctx context.Context, groupName string) ([]string, error)
-
-	// IsGroupMember checks whether a username is a member of the given group.
-	IsGroupMember(ctx context.Context, username string, groupName string) (bool, error)
 }
 
 // ParsePrincipal splits an NFSv4 principal string into name and domain parts.


### PR DESCRIPTION
Residual MED-tier fixes from the v1.0 NFS area #4 audit (REVIEW.md §9 perf + REVIEW2.md H-C + interface audit). The HIGHs were already shipped via #844/#885/#911/#919; this is the conservatively-scoped quick-win remainder. No architectural changes.

## Fixes

### 1. Presize the COMPOUND reply buffer (perf)
`encodeCompoundResponse` (`v4/handlers/compound.go`) used an unsized `bytes.Buffer` that grew via repeated realloc-and-copy on every NFSv4 COMPOUND reply — the audit measured this as the top allocation hotspot (~27% / 2.9 GB of v4 reply allocation). The buffer is now presized to the exact encoded wire length (`status + tag opaque + numresults + per-result opcode/data`) before writing, so the hot path allocates once.

Wire output is byte-identical — this only reserves capacity up front; existing `TestCompound*` tests pass unchanged. A new `BenchmarkEncodeCompoundResponse` documents the delta.

**Benchmark (M1 Max, representative 8-op reply):**

| | B/op | allocs/op |
|---|---|---|
| before | 2076 | 17 |
| after | 668 | 13 |

−68% bytes, −4 allocs. (The residual 13 allocs come from per-call XDR `WriteUint32` temporaries in the codec — out of scope for this PR; the grow-and-copy churn is eliminated.)

### 2. Bound NFS connections by default (DoS)
`NFSConfig.MaxConnections` defaulted to `0` = unlimited (`pkg/adapter/nfs/adapter.go`). The accept-loop `connSemaphore` is only built when `MaxConnections > 0`, so the default left the server accepting unbounded connections — each costs a goroutine plus up to 100 in-flight pooled buffers — an unauthenticated memory/goroutine-exhaustion surface.

`applyDefaults` now sets `MaxConnections = DefaultMaxConnections` (1024) when unset, so the semaphore is always built. Explicit non-zero config values are preserved; operators can raise it for busy servers. Docs updated (`doc.go`, `CONFIGURATION.md` NFS block only — SMB has no such default and is left as `0 = unlimited`).

### 3. Drop dead `GroupResolver` interface
`pkg/adapter/nfs/identity.GroupResolver` had zero implementations and zero callers (verified by grep across the whole repo incl. tests + build tags — the only `GetGroupMembers`/`IsGroupMember` hits are an unrelated `controlplane/store` method with a different signature). Removed the interface and its stale doc references.

## Deliberately left in place
- **`BumpBootVerifier`** — flagged as zero-production-caller, but REVIEW2 §2 H-B classifies it as a HIGH (silent data-loss on snapshot restore) whose fix is to **wire it into the restore path**, not delete it. Left intact for the separate `v1.0/nfs-restore-verifier` PR.
- **The larger bloat targets** (codec-file folding, `v4/types` collapse, auth-builder merge, `manager.go` split) and the auth-unify / dual-dispatch-collapse — these are separate design efforts, out of scope.

## Verification
- `go build ./...` clean
- `go test ./internal/adapter/nfs/... ./pkg/adapter/nfs/... -count=1` green
- `go vet ./...` clean
- `golangci-lint run` 0 issues