### PR TITLE
test(perf): proactive pprof capture under seeded workloads (#680)

### DIFF
--- a/bench/blockstore/README.md
+++ b/bench/blockstore/README.md
@@ -75,12 +75,35 @@ caller wraps it for pprof or `b.N` timing as needed.
 
 ## Profile output
 
+Every CLI run writes a seeded-workload profile set under a timestamped
+directory. `cpu`, `heap`, and `goroutine` are always captured. Add
+`--full-profiles` to also enable the runtime mutex + block profilers and
+emit `mutex.pprof` + `block.pprof` — without that flag those two
+profiles would be empty, since `runtime.SetMutexProfileFraction` /
+`SetBlockProfileRate` default to off (see #671). The flag is opt-in
+because the extra per-event accounting skews throughput.
+
+`seed.txt` records the exact parameters (workload, ops, block size,
+working set, seed, remote) for deterministic replay.
+
 ```
 _profiles/blockstore/<workload>-<UTC-timestamp>/
   cpu.pprof
   heap.pprof
+  goroutine.pprof
+  mutex.pprof        # only with --full-profiles
+  block.pprof        # only with --full-profiles
+  seed.txt
 ```
 
 ```sh
-go tool pprof -http :8080 _profiles/blockstore/random-write-*/cpu.pprof
+# Full set under the seeded sequential-write workload:
+./dfsbench blockstore --workload sequential-write --ops 2000 \
+    --block-size 65536 --working-set 4 --full-profiles
+
+go tool pprof -http :8080 _profiles/blockstore/sequential-write-*/cpu.pprof
+go tool pprof -top         _profiles/blockstore/sequential-write-*/mutex.pprof
 ```
+
+These captures are run on demand only — the `go test` suite never
+constructs a profile session, so normal CI is unaffected.

--- a/cmd/bench/blockstore.go
+++ b/cmd/bench/blockstore.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
-	"runtime/pprof"
-	"time"
 
 	bsbench "github.com/marmos91/dittofs/bench/blockstore"
 	"github.com/spf13/cobra"
@@ -21,6 +17,7 @@ var (
 	bsSeed           uint64
 	bsRemote         string
 	bsGCGarbageRatio float64
+	bsFullProfiles   bool
 )
 
 var blockstoreCmd = &cobra.Command{
@@ -31,8 +28,10 @@ Syncer and drives one of:
   sequential-write | random-write | dedup-heavy | mixed-rw | flush-churn
   walk | delete | gc | raw-s3-put
 
-Captures wall-clock, throughput, and CPU + heap pprof to
-<profile-dir>/blockstore/<workload>-<timestamp>/.`,
+Captures wall-clock, throughput, and CPU + heap + goroutine pprof to
+<profile-dir>/blockstore/<workload>-<timestamp>/. Add --full-profiles to
+also enable the runtime mutex + block profilers and emit mutex.pprof +
+block.pprof (off by default — they add per-event accounting overhead).`,
 	RunE: runBlockstore,
 }
 
@@ -45,6 +44,7 @@ func init() {
 	flags.Uint64Var(&bsSeed, "seed", 1, "PRNG seed for randomized workloads")
 	flags.StringVar(&bsRemote, "remote", bsbench.RemoteMemory, "remote backend: memory | s3")
 	flags.Float64Var(&bsGCGarbageRatio, "gc-garbage-ratio", bsbench.DefaultGCGarbage, "fraction of seeded chunks left unreferenced for the gc workload")
+	flags.BoolVar(&bsFullProfiles, "full-profiles", false, "also capture mutex + block profiles (enables runtime mutex/block profilers; adds overhead)")
 	_ = blockstoreCmd.MarkFlagRequired("workload")
 }
 
@@ -101,27 +101,23 @@ func runEngineWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opt
 	}
 	defer engineClose()
 
-	profDir, cpuStop, err := startProfiles(opts.ProfileDir, opts.Workload)
+	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
-	cpuStopped := false
-	defer func() {
-		if !cpuStopped {
-			cpuStop()
-		}
-	}()
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
 
 	res, err := bsbench.RunWorkload(ctx, bs, opts)
-	cpuStop()
-	cpuStopped = true
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
 	if err != nil {
 		return err
 	}
-	if err := writeHeapProfile(profDir); err != nil {
-		return err
-	}
-	printResult(cmd, opts, res, profDir, true)
+	printResult(cmd, opts, res, sess.dir, true)
 	return nil
 }
 
@@ -132,16 +128,14 @@ func runLocalWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer closeFn()
 
-	profDir, cpuStop, err := startProfiles(opts.ProfileDir, opts.Workload)
+	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
-	cpuStopped := false
-	defer func() {
-		if !cpuStopped {
-			cpuStop()
-		}
-	}()
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
 
 	var res bsbench.Result
 	switch opts.Workload {
@@ -150,15 +144,13 @@ func runLocalWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	case bsbench.WorkloadDelete:
 		res, err = bsbench.RunDelete(ctx, local, opts)
 	}
-	cpuStop()
-	cpuStopped = true
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
 	if err != nil {
 		return err
 	}
-	if err := writeHeapProfile(profDir); err != nil {
-		return err
-	}
-	printResult(cmd, opts, res, profDir, false)
+	printResult(cmd, opts, res, sess.dir, false)
 	return nil
 }
 
@@ -169,27 +161,23 @@ func runGCWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts) e
 	}
 	defer remoteClose()
 
-	profDir, cpuStop, err := startProfiles(opts.ProfileDir, opts.Workload)
+	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
-	cpuStopped := false
-	defer func() {
-		if !cpuStopped {
-			cpuStop()
-		}
-	}()
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
 
 	res, err := bsbench.RunGC(ctx, remoteStore, opts, bsGCGarbageRatio)
-	cpuStop()
-	cpuStopped = true
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
 	if err != nil {
 		return err
 	}
-	if err := writeHeapProfile(profDir); err != nil {
-		return err
-	}
-	printResult(cmd, opts, res, profDir, false)
+	printResult(cmd, opts, res, sess.dir, false)
 	return nil
 }
 
@@ -200,27 +188,23 @@ func runRawS3Workload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer remoteClose()
 
-	profDir, cpuStop, err := startProfiles(opts.ProfileDir, opts.Workload)
+	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
-	cpuStopped := false
-	defer func() {
-		if !cpuStopped {
-			cpuStop()
-		}
-	}()
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
 
 	res, err := bsbench.RunRawS3Put(ctx, remoteStore, opts)
-	cpuStop()
-	cpuStopped = true
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
 	if err != nil {
 		return err
 	}
-	if err := writeHeapProfile(profDir); err != nil {
-		return err
-	}
-	printResult(cmd, opts, res, profDir, false)
+	printResult(cmd, opts, res, sess.dir, false)
 	return nil
 }
 
@@ -237,39 +221,6 @@ func resolveBlockSize(workload string, requested int) int {
 	default:
 		return bsbench.DefaultRandomBlockSize
 	}
-}
-
-// startProfiles creates <root>/blockstore/<workload>-<ts>/ and begins
-// CPU profiling. The returned closure stops the profile and closes
-// the file; safe to call exactly once.
-func startProfiles(rootDir, workload string) (string, func(), error) {
-	ts := time.Now().UTC().Format("20060102T150405Z")
-	dir := filepath.Join(rootDir, "blockstore", fmt.Sprintf("%s-%s", workload, ts))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", func() {}, fmt.Errorf("mkdir profiles: %w", err)
-	}
-	f, err := os.Create(filepath.Join(dir, "cpu.pprof"))
-	if err != nil {
-		return "", func() {}, fmt.Errorf("create cpu.pprof: %w", err)
-	}
-	if err := pprof.StartCPUProfile(f); err != nil {
-		_ = f.Close()
-		return "", func() {}, fmt.Errorf("StartCPUProfile: %w", err)
-	}
-	return dir, func() { pprof.StopCPUProfile(); _ = f.Close() }, nil
-}
-
-func writeHeapProfile(dir string) error {
-	runtime.GC()
-	f, err := os.Create(filepath.Join(dir, "heap.pprof"))
-	if err != nil {
-		return fmt.Errorf("create heap.pprof: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	if err := pprof.WriteHeapProfile(f); err != nil {
-		return fmt.Errorf("WriteHeapProfile: %w", err)
-	}
-	return nil
 }
 
 // printResult emits the canonical one-line summary, optionally

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	bsbench "github.com/marmos91/dittofs/bench/blockstore"
+)
+
+// profileSession is the shared pprof capture envelope wrapped around a
+// workload's timed region. It always captures cpu, heap, and goroutine.
+// When full=true it also enables the runtime mutex/block profilers
+// before the timed region and emits mutex.pprof + block.pprof on stop.
+//
+// mutex/block profiling is opt-in because it adds per-contention-event
+// runtime accounting overhead that would skew throughput numbers and is
+// not wanted for routine macro runs. The normal `go test` suite never
+// constructs a session, so capture has zero effect on it.
+//
+// Without runtime.SetMutexProfileFraction / SetBlockProfileRate the
+// mutex and block profiles are silently empty (see #671) — enabling
+// them here is what makes those two profiles meaningful.
+type profileSession struct {
+	dir     string
+	cpuFile *os.File
+	full    bool
+	stopped bool
+}
+
+const (
+	// mutexProfileFraction reports 1/N mutex contention events. 1 = report
+	// every event; the most detailed setting, fine for a bounded bench run.
+	mutexProfileFraction = 1
+	// blockProfileRate samples one blocking event per N nanoseconds of
+	// blocking. 1 = sample every blocking event.
+	blockProfileRate = 1
+)
+
+// startProfileSession creates <root>/blockstore/<workload>-<UTC-ts>/ and
+// begins CPU profiling. When full is set it also turns on the mutex and
+// block profilers. The caller must invoke stop() exactly once, after the
+// timed region, to flush every profile and restore runtime profiler
+// state. On error the partially-started session is rolled back.
+func startProfileSession(rootDir, workload string, full bool) (*profileSession, error) {
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	dir := filepath.Join(rootDir, "blockstore", fmt.Sprintf("%s-%s", workload, ts))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir profiles: %w", err)
+	}
+
+	f, err := os.Create(filepath.Join(dir, "cpu.pprof"))
+	if err != nil {
+		return nil, fmt.Errorf("create cpu.pprof: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("StartCPUProfile: %w", err)
+	}
+
+	if full {
+		runtime.SetMutexProfileFraction(mutexProfileFraction)
+		runtime.SetBlockProfileRate(blockProfileRate)
+	}
+
+	return &profileSession{dir: dir, cpuFile: f, full: full}, nil
+}
+
+// stop finalizes the session: stops CPU profiling and writes heap and
+// goroutine profiles (plus mutex/block when full). It is idempotent —
+// the deferred safety call after an early error is a no-op once the
+// happy path has already stopped. The first encountered error is
+// returned; later profiles are still attempted so a single failure does
+// not silently drop the rest.
+func (s *profileSession) stop() error {
+	if s == nil || s.stopped {
+		return nil
+	}
+	s.stopped = true
+
+	pprof.StopCPUProfile()
+	err := s.cpuFile.Close()
+
+	// Heap reflects live allocations after a forced GC so the profile is
+	// not dominated by not-yet-collected garbage from the timed region.
+	runtime.GC()
+	err = firstErr(err, writeNamedProfile(s.dir, "heap", "heap"))
+	err = firstErr(err, writeNamedProfile(s.dir, "goroutine", "goroutine"))
+
+	if s.full {
+		err = firstErr(err, writeNamedProfile(s.dir, "mutex", "mutex"))
+		err = firstErr(err, writeNamedProfile(s.dir, "block", "block"))
+		// Restore default profiler state so a subsequent run in the same
+		// process is not influenced by this session.
+		runtime.SetMutexProfileFraction(0)
+		runtime.SetBlockProfileRate(0)
+	}
+	return err
+}
+
+// writeSeed records the exact replay parameters next to the profiles as
+// seed.txt — workload, ops, block size, working set, seed, remote. Re-run
+// with the same values to reproduce the captured profile set.
+func (s *profileSession) writeSeed(opts bsbench.Opts) error {
+	if s == nil {
+		return nil
+	}
+	body := fmt.Sprintf(
+		"workload=%s\nops=%d\nblock_size=%d\nworking_set=%d\nseed=%d\nremote=%s\nfull_profiles=%t\n",
+		opts.Workload, opts.Ops, opts.BlockSize, opts.WorkingSet, opts.Seed, opts.Remote, s.full,
+	)
+	if err := os.WriteFile(filepath.Join(s.dir, "seed.txt"), []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write seed.txt: %w", err)
+	}
+	return nil
+}
+
+// writeNamedProfile writes the named runtime profile to <dir>/<file>.pprof.
+func writeNamedProfile(dir, file, profile string) error {
+	p := pprof.Lookup(profile)
+	if p == nil {
+		return fmt.Errorf("unknown profile %q", profile)
+	}
+	f, err := os.Create(filepath.Join(dir, file+".pprof"))
+	if err != nil {
+		return fmt.Errorf("create %s.pprof: %w", file, err)
+	}
+	defer func() { _ = f.Close() }()
+	// debug=0 emits the binary protobuf form consumable by `go tool pprof`.
+	if err := p.WriteTo(f, 0); err != nil {
+		return fmt.Errorf("write %s profile: %w", profile, err)
+	}
+	return nil
+}
+
+func firstErr(prev, next error) error {
+	if prev != nil {
+		return prev
+	}
+	return next
+}

--- a/cmd/bench/profiles_test.go
+++ b/cmd/bench/profiles_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	bsbench "github.com/marmos91/dittofs/bench/blockstore"
+)
+
+// TestProfileSession_BasicProfilesNonEmpty verifies the default capture
+// (no --full-profiles) writes non-empty cpu/heap/goroutine profiles and
+// does NOT write mutex/block.
+func TestProfileSession_BasicProfilesNonEmpty(t *testing.T) {
+	root := t.TempDir()
+	sess, err := startProfileSession(root, "unit", false)
+	if err != nil {
+		t.Fatalf("startProfileSession: %v", err)
+	}
+	if err := sess.writeSeed(bsbench.Opts{Workload: "unit", Ops: 1, BlockSize: 4096, Seed: 7}); err != nil {
+		t.Fatalf("writeSeed: %v", err)
+	}
+	burnCPUAndAlloc()
+	if err := sess.stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	for _, name := range []string{"cpu", "heap", "goroutine"} {
+		requireNonEmpty(t, sess.dir, name)
+	}
+	seed, err := os.ReadFile(filepath.Join(sess.dir, "seed.txt"))
+	if err != nil {
+		t.Fatalf("read seed.txt: %v", err)
+	}
+	if !strings.Contains(string(seed), "seed=7") {
+		t.Errorf("seed.txt missing seed param: %q", seed)
+	}
+	for _, name := range []string{"mutex", "block"} {
+		if _, err := os.Stat(filepath.Join(sess.dir, name+".pprof")); !os.IsNotExist(err) {
+			t.Errorf("%s.pprof should not exist without --full-profiles (err=%v)", name, err)
+		}
+	}
+}
+
+// TestProfileSession_FullProfilesNonEmpty verifies --full-profiles adds
+// non-empty mutex + block profiles. Mutex/block are empty unless the
+// runtime profilers are enabled (the #671 wiring) — exercising real
+// contention here proves the session enables them.
+func TestProfileSession_FullProfilesNonEmpty(t *testing.T) {
+	root := t.TempDir()
+	sess, err := startProfileSession(root, "unit-full", true)
+	if err != nil {
+		t.Fatalf("startProfileSession: %v", err)
+	}
+	burnCPUAndAlloc()
+	contendMutexAndBlock()
+	if err := sess.stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	for _, name := range []string{"cpu", "heap", "goroutine", "mutex", "block"} {
+		requireNonEmpty(t, sess.dir, name)
+	}
+}
+
+// TestProfileSession_StopIdempotent confirms the deferred safety stop is
+// a no-op once the happy-path stop has run.
+func TestProfileSession_StopIdempotent(t *testing.T) {
+	sess, err := startProfileSession(t.TempDir(), "unit-idem", false)
+	if err != nil {
+		t.Fatalf("startProfileSession: %v", err)
+	}
+	if err := sess.stop(); err != nil {
+		t.Fatalf("first stop: %v", err)
+	}
+	if err := sess.stop(); err != nil {
+		t.Fatalf("second stop should be no-op: %v", err)
+	}
+}
+
+func requireNonEmpty(t *testing.T, dir, name string) {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dir, name+".pprof"))
+	if err != nil {
+		t.Fatalf("stat %s.pprof: %v", name, err)
+	}
+	if info.Size() == 0 {
+		t.Errorf("%s.pprof is empty", name)
+	}
+}
+
+// cpuSink keeps burnCPUAndAlloc's results live so the compiler cannot
+// elide the work, and so the heap profile has retained allocations.
+var cpuSink [][]byte
+
+func burnCPUAndAlloc() {
+	sink := make([][]byte, 0, 64)
+	var acc uint64
+	for i := 0; i < 1<<16; i++ {
+		acc += uint64(i * i)
+		if i%1024 == 0 {
+			sink = append(sink, make([]byte, 4096))
+		}
+	}
+	if acc != 0 {
+		cpuSink = sink
+	}
+}
+
+// contendMutexAndBlock generates real lock contention and channel
+// blocking so the mutex/block profiles have samples to record.
+func contendMutexAndBlock() {
+	var mu sync.Mutex
+	ch := make(chan int)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				mu.Lock()
+				mu.Unlock() //nolint:staticcheck // intentional tight contention
+			}
+			ch <- 1
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-ch
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

Extends the `bench/blockstore` profile-capture envelope so the existing seeded `RunWorkload` matrix produces the full pprof set, giving us a repeatable way to capture profiles under deterministic workloads and proactively triage perf regressions.

Per timestamped run directory:
- `cpu.pprof`, `heap.pprof`, `goroutine.pprof` — always captured
- `mutex.pprof`, `block.pprof` — only with `--full-profiles`
- `seed.txt` — workload / ops / block-size / working-set / seed / remote, for exact replay

The four `run*Workload` functions in `cmd/bench/blockstore.go` now share a single `profileSession` (`cmd/bench/profiles.go`) instead of each duplicating the cpu+heap boilerplate, so adding the new profiles touched one place.

## #671 wiring (mutex/block non-empty)

`mutex`/`block` profiles are empty unless the runtime profilers are enabled. `--full-profiles` sets `runtime.SetMutexProfileFraction` + `runtime.SetBlockProfileRate` around the timed region and restores them on stop. It is off by default because the per-event accounting skews throughput numbers.

## How to run

```sh
go build -o dfsbench ./cmd/bench
./dfsbench blockstore --workload sequential-write --ops 2000 \
    --block-size 65536 --working-set 4 --full-profiles

go tool pprof -top _profiles/blockstore/sequential-write-*/mutex.pprof
```

## Sample output (verified locally)

```
workload=sequential-write ops=500 dur=14400.033ms ops_per_sec=34.72 ...
```
```
cpu.pprof = 6413 bytes    heap.pprof = 4453 bytes    goroutine.pprof = 2042 bytes
mutex.pprof = 3525 bytes  block.pprof = 2383 bytes    seed.txt
```
All five parse with `go tool pprof`; mutex/block carry real engine samples (e.g. `sync.(*Mutex).Lock`, `runtime.selectgo`), confirming the runtime registration works.

## Why it's CI-safe

Capture is on-demand only. The `go test` suite never constructs a `profileSession`, so default test timing is unchanged. New unit tests (`cmd/bench/profiles_test.go`) assert the basic set is non-empty, that `--full-profiles` adds non-empty mutex/block, that mutex/block are absent without the flag, and that `stop()` is idempotent.

Closes #680