### PR TITLE
fix(blockstore): delete superseded FileBlock rows on in-place overwrite (manifest authoritative) (#953)

### DIFF
--- a/pkg/blockstore/engine/cold_read_overwrite_test.go
+++ b/pkg/blockstore/engine/cold_read_overwrite_test.go
@@ -237,6 +237,10 @@ func TestBadgerColdRead_CrossFileDedupKeepAlive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
 	}
+	// Close badger before the function returns so its value-log file is
+	// released before t.TempDir's RemoveAll cleanup runs — Windows cannot
+	// unlink a file that is still open.
+	defer func() { _ = ms.Close() }()
 	runCrossFileDedupKeepAlive(t, ms, "badger")
 }
 
@@ -245,5 +249,9 @@ func TestBadgerColdRead_InPlaceOverwrite_ReturnsNewestBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
 	}
+	// Close badger before the function returns so its value-log file is
+	// released before t.TempDir's RemoveAll cleanup runs — Windows cannot
+	// unlink a file that is still open.
+	defer func() { _ = ms.Close() }()
 	runColdReadInPlaceOverwrite(t, ms, "badger")
 }

--- a/pkg/blockstore/engine/cold_read_overwrite_test.go
+++ b/pkg/blockstore/engine/cold_read_overwrite_test.go
@@ -1,0 +1,249 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// runColdReadInPlaceOverwrite is the #953 cold-read repro. It exercises
+// the data-correctness risk described in the issue:
+//
+//  1. Write a multi-MiB file that rolls up into several FastCDC chunks.
+//  2. Overwrite a middle sub-range in place with DIFFERENT content so the
+//     re-chunked region lands on DIFFERENT FastCDC boundaries than the
+//     original write.
+//  3. Drain the rollup again. The per-file FileBlock manifest
+//     (ListFileBlocks) accumulates overlapping rows from BOTH generations
+//     if the persister never deletes the superseded rows.
+//  4. Force the COLD read path via ResetLocalState — the append log is
+//     gone, so reads MUST resolve through the CAS manifest
+//     (readLocalByHash / findRowCoveringOffset), not the warm append-log
+//     replay that masks the bug.
+//  5. Cold-read the whole file and assert it byte-matches the NEWEST
+//     content. A stale-generation chunk surfacing here is silent data
+//     corruption.
+func runColdReadInPlaceOverwrite(t *testing.T, ms metadata.MetadataStore, sharePrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shareName := sharePrefix + "-cold-ow"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	pid, h := createRealFile(t, ms, shareName, "overwrite.bin", rootHandle)
+
+	// 8 MiB original content: with AvgChunkSize=4 MiB / Min=1 MiB this
+	// reliably rolls up into multiple chunks. Deterministic seed so the
+	// boundaries are reproducible across runs.
+	const fileSize = 8 * 1024 * 1024
+	orig := make([]byte, fileSize)
+	rng := rand.New(rand.NewSource(0xC01D)) //nolint:gosec // deterministic test fixture
+	rng.Read(orig)
+
+	if _, err := bs.WriteAt(ctx, pid, nil, orig, 0); err != nil {
+		t.Fatalf("initial WriteAt: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (gen1): %v", err)
+	}
+	logManifest(t, ms, pid, "gen1")
+
+	// Build the post-overwrite "want" image. Overwrite a middle window
+	// with fresh random bytes so the re-chunk produces different
+	// boundaries from gen1. The window straddles interior chunk
+	// boundaries to maximize re-chunking.
+	want := make([]byte, fileSize)
+	copy(want, orig)
+	const owOff = 2 * 1024 * 1024
+	const owLen = 3 * 1024 * 1024
+	owData := make([]byte, owLen)
+	rng2 := rand.New(rand.NewSource(0xBEEF)) //nolint:gosec // deterministic test fixture
+	rng2.Read(owData)
+	copy(want[owOff:owOff+owLen], owData)
+
+	if _, err := bs.WriteAt(ctx, pid, nil, owData, owOff); err != nil {
+		t.Fatalf("overwrite WriteAt: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (gen2): %v", err)
+	}
+	overlaps := logManifest(t, ms, pid, "gen2")
+	t.Logf("gen2 overlapping manifest row pairs: %d", overlaps)
+
+	// Force the cold read path: drop the append log so reads resolve via
+	// the CAS manifest only. The CAS chunks themselves remain on disk.
+	if err := bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	got := make([]byte, fileSize)
+	if _, err := bs.ReadAt(ctx, pid, nil, got, 0); err != nil {
+		t.Fatalf("cold ReadAt: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("cold read returned STALE bytes: first mismatch at off=%d got=0x%02x want=0x%02x (overlapping manifest rows=%d) — #953 confirmed",
+					i, got[i], want[i], overlaps)
+			}
+		}
+		t.Fatalf("cold read length/content mismatch (len got=%d want=%d)", len(got), len(want))
+	}
+	_ = h
+}
+
+// logManifest dumps the per-file FileBlock manifest rows and returns the
+// count of overlapping (stale-superseded) row pairs.
+func logManifest(t *testing.T, ms metadata.MetadataStore, pid, label string) int {
+	t.Helper()
+	fbl, ok := ms.(interface {
+		ListFileBlocks(context.Context, string) ([]*metadata.FileBlock, error)
+	})
+	if !ok {
+		return 0
+	}
+	rows, err := fbl.ListFileBlocks(context.Background(), pid)
+	if err != nil {
+		t.Fatalf("ListFileBlocks: %v", err)
+	}
+	type rng struct{ start, end uint64 }
+	ranges := make([]rng, 0, len(rows))
+	for _, r := range rows {
+		abs, ok := blockstore.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		ranges = append(ranges, rng{start: abs, end: abs + uint64(r.DataSize)})
+		t.Logf("  %s off=%d size=%d", label, abs, r.DataSize)
+	}
+	overlaps := 0
+	for i := 0; i < len(ranges); i++ {
+		for j := i + 1; j < len(ranges); j++ {
+			if ranges[i].start < ranges[j].end && ranges[j].start < ranges[i].end {
+				overlaps++
+			}
+		}
+	}
+	t.Logf("%s manifest rows: %d", label, len(rows))
+	return overlaps
+}
+
+// runCrossFileDedupKeepAlive is the #953 over-reap negative control. Two
+// files A and B are written with BYTE-IDENTICAL content, so FastCDC
+// produces identical chunk hashes and the CAS index dedups them (both
+// files' FileBlock rows point at the same hashes). File A is then
+// overwritten in place with different content, which reaps A's superseded
+// rows. The superseded chunk hashes are still referenced by file B's rows,
+// so they MUST NOT be reclaimed: a cold read of file B must still return
+// B's original content. A naive by-hash reap (instead of by-exact-ID)
+// would strand B's data here.
+func runCrossFileDedupKeepAlive(t *testing.T, ms metadata.MetadataStore, sharePrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shareName := sharePrefix + "-dedup-keepalive"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	const fileSize = 8 * 1024 * 1024
+	shared := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x5117)).Read(shared) //nolint:gosec // deterministic test fixture
+
+	pidA, _ := createRealFile(t, ms, shareName, "a.bin", rootHandle)
+	pidB, _ := createRealFile(t, ms, shareName, "b.bin", rootHandle)
+
+	// Both files get byte-identical content → identical FastCDC chunks →
+	// shared hashes via CAS dedup.
+	for _, pid := range []string{pidA, pidB} {
+		if _, err := bs.WriteAt(ctx, pid, nil, shared, 0); err != nil {
+			t.Fatalf("WriteAt %s: %v", pid, err)
+		}
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (shared): %v", err)
+	}
+
+	// Overwrite a middle window of file A only → re-chunks → reaps A's
+	// superseded rows whose hashes file B still references.
+	const owOff = 2 * 1024 * 1024
+	const owLen = 3 * 1024 * 1024
+	owData := make([]byte, owLen)
+	rand.New(rand.NewSource(0x0FFF)).Read(owData) //nolint:gosec // deterministic test fixture
+	if _, err := bs.WriteAt(ctx, pidA, nil, owData, owOff); err != nil {
+		t.Fatalf("overwrite A: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups (overwrite A): %v", err)
+	}
+
+	// Force the cold path for both files.
+	if err := bs.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// File B must STILL cold-read its original (shared) content — its
+	// chunks were not reaped by file A's overwrite.
+	gotB := make([]byte, fileSize)
+	if _, err := bs.ReadAt(ctx, pidB, nil, gotB, 0); err != nil {
+		t.Fatalf("cold ReadAt B: %v", err)
+	}
+	if !bytes.Equal(gotB, shared) {
+		for i := range shared {
+			if gotB[i] != shared[i] {
+				t.Fatalf("over-reap: file B lost data at off=%d got=0x%02x want=0x%02x — A's reap reclaimed a chunk B still referenced",
+					i, gotB[i], shared[i])
+			}
+		}
+		t.Fatalf("file B content/length mismatch (len got=%d want=%d)", len(gotB), len(shared))
+	}
+
+	// File A must read the overwritten image.
+	wantA := make([]byte, fileSize)
+	copy(wantA, shared)
+	copy(wantA[owOff:owOff+owLen], owData)
+	gotA := make([]byte, fileSize)
+	if _, err := bs.ReadAt(ctx, pidA, nil, gotA, 0); err != nil {
+		t.Fatalf("cold ReadAt A: %v", err)
+	}
+	if !bytes.Equal(gotA, wantA) {
+		for i := range wantA {
+			if gotA[i] != wantA[i] {
+				t.Fatalf("file A stale at off=%d got=0x%02x want=0x%02x", i, gotA[i], wantA[i])
+			}
+		}
+	}
+}
+
+func TestMemoryColdRead_InPlaceOverwrite_ReturnsNewestBytes(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	runColdReadInPlaceOverwrite(t, ms, "mem")
+}
+
+func TestMemoryColdRead_CrossFileDedupKeepAlive(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	runCrossFileDedupKeepAlive(t, ms, "mem")
+}
+
+func TestBadgerColdRead_CrossFileDedupKeepAlive(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	runCrossFileDedupKeepAlive(t, ms, "badger")
+}
+
+func TestBadgerColdRead_InPlaceOverwrite_ReturnsNewestBytes(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	runColdReadInPlaceOverwrite(t, ms, "badger")
+}

--- a/pkg/blockstore/engine/engine.go
+++ b/pkg/blockstore/engine/engine.go
@@ -187,6 +187,34 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 			//     locate which chunk covers a given byte range under
 			//     FastCDC's variable chunk geometry. The trailing
 			//     numeric component is the chunk Offset in bytes.
+			// #953: snapshot the per-file FileBlock row offsets that exist
+			// BEFORE this pass writes its new rows. After the new rows are
+			// durable we reap any prior row that this pass's re-chunk
+			// SUPERSEDED — a row whose offset falls inside the byte region
+			// this pass rewrote but is NOT one of the new chunk offsets.
+			// Without this the per-file CAS manifest accumulates stale,
+			// overlapping rows from multiple write generations; the cold
+			// read path (fillFromCASManifest / readLocalByHash) then mixes
+			// generations and a stale row clobbers freshly-written bytes
+			// (silent corruption after log compaction / local-state
+			// eviction). Snapshot now, reap after PersistFileBlocks below.
+			var priorOffsets []uint64
+			if bs.fileBlockStore != nil {
+				priorRows, lerr := bs.fileBlockStore.ListFileBlocks(ctx, payloadID)
+				if lerr != nil {
+					return fmt.Errorf("ObjectIDPersister: list prior blocks for %s: %w", payloadID, lerr)
+				}
+				priorOffsets = make([]uint64, 0, len(priorRows))
+				for _, pr := range priorRows {
+					if pr == nil {
+						continue
+					}
+					if off, ok := blockstore.ParseChunkOffset(pr.ID); ok {
+						priorOffsets = append(priorOffsets, off)
+					}
+				}
+			}
+
 			if fbs != nil {
 				for _, b := range blocks {
 					if b.Hash.IsZero() {
@@ -269,11 +297,11 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, zeroObjectID); rerr != nil {
 						return fmt.Errorf("rollup persist: retry without object_id after dedup conflict: %w", rerr)
 					}
-					return nil
+					return bs.reapSupersededFileBlocks(ctx, payloadID, priorOffsets, blocks)
 				}
 				return err
 			}
-			return nil
+			return bs.reapSupersededFileBlocks(ctx, payloadID, priorOffsets, blocks)
 		})
 
 		// (2) Install the chunk-completion callback (production

--- a/pkg/blockstore/engine/readwrite.go
+++ b/pkg/blockstore/engine/readwrite.go
@@ -383,3 +383,64 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 
 	return dst, nil
 }
+
+// reapSupersededFileBlocks deletes the per-file FileBlock rows that a
+// rollup pass's re-chunk superseded (#953). A row is superseded when its
+// chunk offset falls inside the byte region this pass rewrote
+// (newBlocks span) but is NOT one of the new chunk offsets — i.e. an
+// old-generation chunk that an in-place overwrite re-chunked onto
+// different FastCDC boundaries. Left behind, such rows accumulate in the
+// CAS manifest (ListFileBlocks) and the cold read path mixes generations,
+// returning stale bytes after log compaction or local-state eviction.
+//
+// Region-scoped + by-exact-ID, mirroring the engine Delete/Truncate reap
+// contract:
+//   - Only rows whose offset is in [regionStart, regionEnd) are eligible —
+//     a row strictly before the region (a straddling predecessor the FS
+//     rollup could not boundary-align because its chunk was not locally
+//     readable) is KEPT so its non-overwritten head still serves bytes.
+//   - Rows whose offset is reused by a new chunk (overwritten in place by
+//     FileBlock.Put above) are skipped — they are the current generation.
+//   - Reap by EXACT ID "{payloadID}/{offset}" via DecrementRefCountAndReap.
+//     Each {payloadID}/offset row is independent; reaping this file's own
+//     row never touches another file's row. Cross-file dedup keep-alive is
+//     by-hash in the GC live set (EnumerateFileBlocks): the chunk is
+//     reclaimed only when no row anywhere references the hash, so a hash a
+//     sibling file still uses stays alive even after this row is reaped.
+//
+// No-ops when the coordinator is unwired (tests/fixtures) or when nothing
+// was superseded (pure append, first write).
+func (bs *Store) reapSupersededFileBlocks(ctx context.Context, payloadID string, priorOffsets []uint64, newBlocks []blockstore.BlockRef) error {
+	if bs.coordinator == nil || len(priorOffsets) == 0 || len(newBlocks) == 0 {
+		return nil
+	}
+	regionStart := newBlocks[0].Offset
+	var regionEnd uint64
+	newOffsets := make(map[uint64]struct{}, len(newBlocks))
+	for _, b := range newBlocks {
+		if b.Offset < regionStart {
+			regionStart = b.Offset
+		}
+		if end := b.Offset + uint64(b.Size); end > regionEnd {
+			regionEnd = end
+		}
+		newOffsets[b.Offset] = struct{}{}
+	}
+	reaped := make(map[uint64]struct{}, len(priorOffsets))
+	for _, off := range priorOffsets {
+		if off < regionStart || off >= regionEnd {
+			continue // outside the rewritten region — untouched, keep.
+		}
+		if _, isNew := newOffsets[off]; isNew {
+			continue // reused offset — current generation (overwritten in place).
+		}
+		if _, done := reaped[off]; done {
+			continue
+		}
+		reaped[off] = struct{}{}
+		if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, off); err != nil {
+			return fmt.Errorf("reap superseded block %s/%d: %w", payloadID, off, err)
+		}
+	}
+	return nil
+}

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -357,6 +357,36 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		return nil
 	}
 
+	// #953: align the reconstruction window to existing CAS chunk
+	// boundaries. An in-place overwrite whose dirty interval starts/ends
+	// INSIDE a previously-rolled-up chunk would otherwise re-chunk only
+	// [baseOff, maxEnd) and emit new FileBlock rows that OVERLAP the old
+	// straddling chunks. The CAS read path (fillFromCASManifest /
+	// readLocalByHash) then mixes generations: a stale row sorted after a
+	// new row clobbers the freshly-written bytes (silent corruption on the
+	// cold read), and naively reaping the straddling chunk instead would
+	// leave its non-overwritten head/tail uncovered (zero-fill data loss).
+	//
+	// Expand the window to whole straddling-chunk boundaries by prepending
+	// synthetic records carrying the straddling neighbors' CAS bytes, so
+	// the re-chunk produces boundary-aligned chunks and every superseded
+	// row is FULLY contained in the new region (cleanly reapable by the
+	// ObjectIDPersister). The straddling bytes that the overwrite did not
+	// touch are preserved because the overwrite records, applied later in
+	// reconstructStream's "last record wins" order, overlay only the bytes
+	// the client actually rewrote.
+	//
+	// Best-effort: a straddling neighbor whose chunk is not locally
+	// readable (post-eviction) cannot be spliced; we skip expansion on
+	// that side and the persister's reap stays conservative (it only
+	// reaps rows fully inside the unexpanded region), leaving the existing
+	// behaviour on that edge rather than risking a gap.
+	//
+	// trunc/hasTrunc are threaded through so a straddling neighbor is
+	// never spliced past the truncation boundary — re-emitting bytes the
+	// truncate just removed would resurrect truncated tail data.
+	recs = bc.alignRecsToChunkBoundaries(ctx, payloadID, recs, trunc, hasTrunc)
+
 	// Reconstruct contiguous byte stream ("later record wins") + chunk
 	// + store. Chunker is stateless across calls; we feed it the whole
 	// reconstructed buffer and slice out chunks by the returned boundaries.
@@ -669,6 +699,99 @@ func reconstructStream(recs []rec) ([]byte, uint64, error) {
 		copy(buf[r.off-baseOff:], r.payload)
 	}
 	return buf, baseOff, nil
+}
+
+// alignRecsToChunkBoundaries expands the record set so the reconstructed
+// window covers WHOLE existing CAS chunks at its edges (#953). It finds
+// the existing FileBlock rows that straddle the dirty window's start or
+// end — i.e. a chunk [off, off+size) with off < windowStart < off+size or
+// off < windowEnd < off+size — reads those chunks from the local CAS, and
+// prepends them as synthetic records at their original offset. Prepending
+// (rather than appending) keeps the real overwrite records LAST so
+// reconstructStream's "last record wins" rule still lets the overwrite
+// overlay the bytes the client actually rewrote, while the straddling
+// chunk supplies its non-overwritten head/tail.
+//
+// Returns recs unchanged when there is no FileBlock store, no rows, or no
+// straddling chunk is locally readable. The function never returns an
+// error: an unreadable straddling chunk is a benign best-effort miss (the
+// caller's reap stays conservative on that edge).
+func (bc *FSStore) alignRecsToChunkBoundaries(ctx context.Context, payloadID string, recs []rec, trunc uint64, hasTrunc bool) []rec {
+	if bc.blockStore == nil || len(recs) == 0 {
+		return recs
+	}
+	var windowStart, windowEnd uint64
+	windowStart = recs[0].off
+	for _, r := range recs {
+		if r.off < windowStart {
+			windowStart = r.off
+		}
+		end := r.off + uint64(len(r.payload))
+		if end > windowEnd {
+			windowEnd = end
+		}
+	}
+
+	rows, err := bc.blockStore.ListFileBlocks(ctx, payloadID)
+	if err != nil || len(rows) == 0 {
+		return recs
+	}
+
+	var prepend []rec
+	for _, fb := range rows {
+		if fb == nil || fb.Hash.IsZero() || fb.DataSize == 0 {
+			continue
+		}
+		off, ok := blockstore.ParseChunkOffset(fb.ID)
+		if !ok {
+			continue
+		}
+		// A pending truncation already removed bytes at/after trunc this
+		// pass. A neighbor chunk starting at/after trunc is gone; one that
+		// straddles trunc must only contribute its surviving head [off,
+		// trunc). Splicing past trunc would re-emit truncated tail data.
+		dataSize := uint64(fb.DataSize)
+		if hasTrunc {
+			if off >= trunc {
+				continue
+			}
+			if off+dataSize > trunc {
+				dataSize = trunc - off
+			}
+		}
+		end := off + dataSize
+		// Only chunks that STRADDLE an edge of the window need splicing.
+		// A chunk fully inside the window is superseded (reaped later); a
+		// chunk fully outside is untouched and must NOT be rewritten.
+		straddlesStart := off < windowStart && windowStart < end
+		straddlesEnd := off < windowEnd && windowEnd < end
+		if !straddlesStart && !straddlesEnd {
+			continue
+		}
+		data, gerr := bc.Get(ctx, fb.Hash)
+		if gerr != nil {
+			// Not locally readable (evicted) — skip; reap stays
+			// conservative on this edge.
+			continue
+		}
+		// Clamp to the surviving byte count so a padded on-disk surface
+		// (or a truncation boundary) never injects bytes past it.
+		if dataSize < uint64(len(data)) {
+			data = data[:dataSize]
+		}
+		// Copy: bc.Get may return an LRU-owned/shared buffer; the
+		// reconstruction buffer must not alias it.
+		buf := make([]byte, len(data))
+		copy(buf, data)
+		prepend = append(prepend, rec{off: off, payload: buf})
+	}
+	if len(prepend) == 0 {
+		return recs
+	}
+	// Synthetic straddling-chunk records FIRST, real overwrite records
+	// LAST — preserves "last record wins" so the overwrite overlays only
+	// the bytes it actually rewrote.
+	return append(prepend, recs...)
 }
 
 // blake3ContentHash returns the 32-byte BLAKE3 hash of data as a


### PR DESCRIPTION
## Repro (cold-read, confirmed on develop)

`pkg/blockstore/engine/cold_read_overwrite_test.go` (memory + badger):

1. Write an 8 MiB file → rolls up into multiple FastCDC chunks.
2. Overwrite a middle 3 MiB sub-range in place; the re-chunk lands on **different** FastCDC boundaries. Drain again.
3. `ResetLocalState` drops the append log → reads MUST resolve through the CAS manifest (cold path).
4. Cold-read the whole file.

On unmodified develop this **FAILS**: gen2 manifest had 11 rows with 6 overlapping pairs, and the cold read returned stale bytes at off=2286952 (`got=0x54 want=0x1e`). Reproduced identically on memory and badger.

## Root cause

On an in-place overwrite that re-chunks an extent, the rollup persister wrote new `FileBlock` rows keyed `{payloadID}/{offset}` but never deleted the superseded prior-generation rows. `ListFileBlocks` then returned overlapping rows spanning multiple write generations. The warm read path (`replayLogIntoDest` full-log scan) masked it; the cold path (`fillFromCASManifest` / `readLocalByHash`) consults the manifest directly, and a stale row sorted after a new row clobbered freshly-written bytes after log compaction or local-state eviction → silent corruption.

A naive "delete overlapping rows" would have created a second bug: a straddling-neighbor chunk (start before / end after the overwrite) supplies non-overwritten head/tail bytes, so deleting it leaves an uncovered gap → zero-fill data loss.

## Fix — make the manifest authoritative (two coordinated changes)

- **FS rollup boundary alignment** (`local/fs/rollup.go`): `alignRecsToChunkBoundaries` expands the reconstruction window to whole existing CAS chunk boundaries by prepending synthetic records carrying the straddling neighbors' CAS bytes. The re-chunk then produces boundary-aligned chunks, every superseded row is fully contained in the new region, and no gap is created. Best-effort: skips splice when a neighbor chunk is not locally readable (post-eviction); never splices past a pending truncation boundary.
- **Persister reap** (`engine/engine.go` + `engine/readwrite.go`): `reapSupersededFileBlocks` reaps superseded per-file rows by **exact ID** `{payloadID}/{offset}` via `DecrementRefCountAndReap`, region-scoped, skipping offsets reused by a new chunk. Runs after `PersistFileBlocks` succeeds (including the dedup-conflict retry path) so a crash leaves stale-but-not-lost rows that the idempotent next pass cleans up.

## Refcount / GC safety (cf #832 / #929)

Reap is **by exact ID, not by hash**. Each `{payloadID}/{offset}` row is independent; reaping this file's own row never touches another file's row. Cross-file dedup keep-alive is by-hash in the GC live set (`EnumerateFileBlocks`) — a chunk is reclaimed only when no row anywhere references the hash. Deleting a row that is still live = data loss; leaving a stale row = the bug — the region+offset scoping reaps exactly the superseded rows.

## Tests

- Cold-read repro (memory + badger): proven to **fail before** the fix, **pass after** (gen2 manifest: 9 rows, 0 overlaps, gap-free `[0, 8 MiB)`, newest bytes returned).
- **Cross-file dedup keep-alive negative control** (memory + badger): two files written with byte-identical content (shared chunk hashes); file A overwritten in place reaps its superseded rows; file B still cold-reads its original content byte-for-byte — the reap did not strand a chunk B references.
- Full `./pkg/blockstore/...` + `./pkg/controlplane/runtime/...` (incl. `TestSnapshotByteVerify_Matrix`, `TestRestoreRollback_QuiescesRollupBeforeReset`), `-race`, and `-tags=integration -p 1` all green. Postgres unverified locally (no DSN); CI covers pg. `gofmt`/`go vet`/`golangci-lint` clean.

Closes #953