### PR TITLE
test(blockstore): fill area #1 coverage gaps (#679)

### DIFF
--- a/pkg/blockstore/encryption/keyprovider/kmip_fake_test.go
+++ b/pkg/blockstore/encryption/keyprovider/kmip_fake_test.go
@@ -1,0 +1,464 @@
+package keyprovider
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gemalto/kmip-go"
+	"github.com/gemalto/kmip-go/kmip14"
+	"github.com/gemalto/kmip-go/ttlv"
+)
+
+// genSelfSigned writes a self-signed ECDSA cert + key PEM pair to dir and
+// returns their paths plus the PEM-encoded certificate (usable as a CA).
+// Deterministic shape; the only randomness is the key material, which does
+// not affect any assertion.
+func genSelfSigned(t *testing.T, dir, name string) (certPath, keyPath string, certPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certPath = filepath.Join(dir, name+"-cert.pem")
+	keyPath = filepath.Join(dir, name+"-key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath, certPEM
+}
+
+// fakeKMIPServer is a single-shot TLS listener that answers exactly one
+// KMIP Get request with a server-provided ResponseMessage. It speaks the
+// minimal subset of the protocol the provider drives: read one framed TTLV
+// request, write one framed TTLV response.
+type fakeKMIPServer struct {
+	ln   net.Listener
+	resp ttlv.TTLV // pre-marshalled response to send back
+	wg   sync.WaitGroup
+}
+
+// kmipSuccessResponse marshals a Get ResponseMessage carrying a symmetric
+// key with the given raw material as a ByteString KeyMaterial.
+func kmipSuccessResponse(t *testing.T, keyUID string, material []byte) ttlv.TTLV {
+	t.Helper()
+	resp := kmip.ResponseMessage{
+		ResponseHeader: kmip.ResponseHeader{
+			ProtocolVersion: kmip.ProtocolVersion{ProtocolVersionMajor: 1, ProtocolVersionMinor: 4},
+			TimeStamp:       time.Now(),
+			BatchCount:      1,
+		},
+		BatchItem: []kmip.ResponseBatchItem{{
+			Operation:    kmip14.OperationGet,
+			ResultStatus: kmip14.ResultStatusSuccess,
+			ResponsePayload: kmip.GetResponsePayload{
+				ObjectType:       kmip14.ObjectTypeSymmetricKey,
+				UniqueIdentifier: keyUID,
+				SymmetricKey: &kmip.SymmetricKey{
+					KeyBlock: kmip.KeyBlock{
+						KeyFormatType: kmip14.KeyFormatTypeRaw,
+						KeyValue: &kmip.KeyValue{
+							KeyMaterial: material,
+						},
+						CryptographicAlgorithm: kmip14.CryptographicAlgorithmAES,
+						CryptographicLength:    len(material) * 8,
+					},
+				},
+			},
+		}},
+	}
+	raw, err := ttlv.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal kmip response: %v", err)
+	}
+	return raw
+}
+
+// kmipFailureResponse marshals a Get ResponseMessage carrying a
+// non-success result status.
+func kmipFailureResponse(t *testing.T) ttlv.TTLV {
+	t.Helper()
+	resp := kmip.ResponseMessage{
+		ResponseHeader: kmip.ResponseHeader{
+			ProtocolVersion: kmip.ProtocolVersion{ProtocolVersionMajor: 1, ProtocolVersionMinor: 4},
+			TimeStamp:       time.Now(),
+			BatchCount:      1,
+		},
+		BatchItem: []kmip.ResponseBatchItem{{
+			Operation:     kmip14.OperationGet,
+			ResultStatus:  kmip14.ResultStatusOperationFailed,
+			ResultReason:  kmip14.ResultReasonItemNotFound,
+			ResultMessage: "no such object",
+		}},
+	}
+	raw, err := ttlv.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal kmip failure response: %v", err)
+	}
+	return raw
+}
+
+// startFakeKMIP runs a TLS listener that answers one connection with resp.
+func startFakeKMIP(t *testing.T, tlsCfg *tls.Config, resp ttlv.TTLV) *fakeKMIPServer {
+	t.Helper()
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	s := &fakeKMIPServer{ln: ln, resp: resp}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		// Drain the request: read one framed TTLV so we don't reply before
+		// the client finishes writing (avoids a RST on some platforms).
+		if _, err := readOneFrame(conn); err != nil {
+			return
+		}
+		_, _ = conn.Write(s.resp)
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		s.wg.Wait()
+	})
+	return s
+}
+
+func (s *fakeKMIPServer) addr() string { return s.ln.Addr().String() }
+
+// readOneFrame mirrors the framing in readKMIPMessage so the fake server
+// consumes exactly one request before replying.
+func readOneFrame(r io.Reader) ([]byte, error) {
+	const headerLen = 8
+	header := make([]byte, headerLen)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, err
+	}
+	bodyLen := binary.BigEndian.Uint32(header[4:8])
+	pad := (8 - int(bodyLen%8)) % 8
+	body := make([]byte, headerLen+int(bodyLen)+pad)
+	copy(body, header)
+	if _, err := io.ReadFull(r, body[headerLen:]); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// serverTLSConfig builds the server-side TLS config from the given cert.
+func serverTLSConfig(t *testing.T, certPath, keyPath string) *tls.Config {
+	t.Helper()
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("server LoadX509KeyPair: %v", err)
+	}
+	return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+}
+
+// TestKMIP_FetchSymmetricKey_HappyPath drives newKMIPProvider end-to-end
+// against a fake KMIP server: dial, marshal Get, read framed response,
+// decode the symmetric key, and confirm Wrap/Unwrap round-trips with it.
+func TestKMIP_FetchSymmetricKey_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	// One self-signed cert used for both server identity and as the CA the
+	// client trusts, and (separately) as the client cert.
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	material := bytes.Repeat([]byte{0xA7}, 32)
+	resp := kmipSuccessResponse(t, "key-uid-1", material)
+	srv := startFakeKMIP(t, serverTLSConfig(t, srvCert, srvKey), resp)
+
+	cfg := Config{
+		Kind:       KindKMIP,
+		Endpoint:   srv.addr(),
+		ClientCert: cliCert,
+		ClientKey:  cliKey,
+		ServerCA:   caPath,
+		KeyUID:     "key-uid-1",
+		TimeoutMS:  5000,
+	}
+	p, err := newKMIPProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	if !bytes.Equal(p.masterKey, material) {
+		t.Fatalf("fetched master key mismatch: got %x want %x", p.masterKey, material)
+	}
+
+	blockKey := bytes.Repeat([]byte{0x33}, 32)
+	wrapped, id, err := p.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	got, err := p.Unwrap(context.Background(), wrapped, id)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !bytes.Equal(got, blockKey) {
+		t.Fatalf("Unwrap roundtrip mismatch")
+	}
+}
+
+// TestKMIP_FetchSymmetricKey_WrongLength verifies a non-32-byte key from
+// the server is rejected by newKMIPProvider.
+func TestKMIP_FetchSymmetricKey_WrongLength(t *testing.T) {
+	dir := t.TempDir()
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	resp := kmipSuccessResponse(t, "k", bytes.Repeat([]byte{0x01}, 16)) // AES-128, wrong for us
+	srv := startFakeKMIP(t, serverTLSConfig(t, srvCert, srvKey), resp)
+
+	cfg := Config{
+		Kind: KindKMIP, Endpoint: srv.addr(),
+		ClientCert: cliCert, ClientKey: cliKey, ServerCA: caPath, KeyUID: "k",
+	}
+	_, err := newKMIPProvider(context.Background(), cfg)
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("want ErrInvalidConfig for wrong-length key, got %v", err)
+	}
+}
+
+// TestKMIP_FetchSymmetricKey_ServerFailure verifies a non-success KMIP
+// result status surfaces as an error.
+func TestKMIP_FetchSymmetricKey_ServerFailure(t *testing.T) {
+	dir := t.TempDir()
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	srv := startFakeKMIP(t, serverTLSConfig(t, srvCert, srvKey), kmipFailureResponse(t))
+
+	cfg := Config{
+		Kind: KindKMIP, Endpoint: srv.addr(),
+		ClientCert: cliCert, ClientKey: cliKey, ServerCA: caPath, KeyUID: "k",
+	}
+	_, err := newKMIPProvider(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("want error on KMIP failure status, got nil")
+	}
+	if !strings.Contains(err.Error(), "kmip Get failed") {
+		t.Errorf("error should mention Get failure, got %q", err.Error())
+	}
+}
+
+// TestKMIP_DialError verifies a connection to a dead endpoint surfaces a
+// dial error rather than hanging.
+func TestKMIP_DialError(t *testing.T) {
+	dir := t.TempDir()
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+
+	cfg := Config{
+		Kind: KindKMIP,
+		// Reserved TEST-NET-1 address; connection will fail fast under the
+		// short timeout below.
+		Endpoint:   "192.0.2.1:5696",
+		ClientCert: cliCert, ClientKey: cliKey, KeyUID: "k",
+		TimeoutMS: 200,
+	}
+	start := time.Now()
+	_, err := newKMIPProvider(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("want dial error, got nil")
+	}
+	if !strings.Contains(err.Error(), "kmip dial") {
+		t.Errorf("error should mention dial, got %q", err.Error())
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("dial took %s; timeout not honored", elapsed)
+	}
+}
+
+// TestBuildKMIPTLSConfig covers the cert-load and server-CA branches.
+func TestBuildKMIPTLSConfig(t *testing.T) {
+	dir := t.TempDir()
+	cliCert, cliKey, cliPEM := genSelfSigned(t, dir, "client")
+
+	t.Run("valid_no_ca", func(t *testing.T) {
+		cfg, err := buildKMIPTLSConfig(Config{ClientCert: cliCert, ClientKey: cliKey})
+		if err != nil {
+			t.Fatalf("buildKMIPTLSConfig: %v", err)
+		}
+		if len(cfg.Certificates) != 1 {
+			t.Errorf("want 1 client cert, got %d", len(cfg.Certificates))
+		}
+		if cfg.RootCAs != nil {
+			t.Error("RootCAs should be nil when no ServerCA configured")
+		}
+	})
+
+	t.Run("valid_with_ca", func(t *testing.T) {
+		caPath := filepath.Join(dir, "ca.pem")
+		if err := os.WriteFile(caPath, cliPEM, 0o600); err != nil {
+			t.Fatalf("write ca: %v", err)
+		}
+		cfg, err := buildKMIPTLSConfig(Config{ClientCert: cliCert, ClientKey: cliKey, ServerCA: caPath})
+		if err != nil {
+			t.Fatalf("buildKMIPTLSConfig with CA: %v", err)
+		}
+		if cfg.RootCAs == nil {
+			t.Error("RootCAs should be set when ServerCA configured")
+		}
+	})
+
+	t.Run("bad_client_cert", func(t *testing.T) {
+		if _, err := buildKMIPTLSConfig(Config{ClientCert: "/nonexistent", ClientKey: "/nonexistent"}); err == nil {
+			t.Error("want error for missing client cert, got nil")
+		}
+	})
+
+	t.Run("missing_server_ca_file", func(t *testing.T) {
+		if _, err := buildKMIPTLSConfig(Config{ClientCert: cliCert, ClientKey: cliKey, ServerCA: "/nonexistent-ca"}); err == nil {
+			t.Error("want error for missing CA file, got nil")
+		}
+	})
+
+	t.Run("server_ca_not_pem", func(t *testing.T) {
+		badCA := filepath.Join(dir, "bad-ca.pem")
+		if err := os.WriteFile(badCA, []byte("not a pem certificate"), 0o600); err != nil {
+			t.Fatalf("write bad ca: %v", err)
+		}
+		_, err := buildKMIPTLSConfig(Config{ClientCert: cliCert, ClientKey: cliKey, ServerCA: badCA})
+		if err == nil {
+			t.Error("want error for non-PEM CA, got nil")
+		}
+	})
+}
+
+// TestExtractSymmetricKeyMaterial covers every branch of the KeyValue
+// type-switch.
+func TestExtractSymmetricKeyMaterial(t *testing.T) {
+	t.Run("nil_keyvalue", func(t *testing.T) {
+		if _, err := extractSymmetricKeyMaterial(nil); err == nil {
+			t.Error("want error for nil KeyValue")
+		}
+	})
+
+	t.Run("byte_slice", func(t *testing.T) {
+		material := []byte{1, 2, 3, 4}
+		out, err := extractSymmetricKeyMaterial(&kmip.KeyValue{KeyMaterial: material})
+		if err != nil {
+			t.Fatalf("extract []byte: %v", err)
+		}
+		if !bytes.Equal(out, material) {
+			t.Errorf("got %x want %x", out, material)
+		}
+		// Defensive-copy: mutating the returned slice must not affect input.
+		out[0] = 0xFF
+		if material[0] == 0xFF {
+			t.Error("extractSymmetricKeyMaterial aliased the input slice")
+		}
+	})
+
+	t.Run("unexpected_go_type", func(t *testing.T) {
+		if _, err := extractSymmetricKeyMaterial(&kmip.KeyValue{KeyMaterial: 12345}); err == nil {
+			t.Error("want error for unexpected go type")
+		}
+	})
+}
+
+// TestReadKMIPMessage covers the framing, padding, oversize-cap, and
+// short-read paths.
+func TestReadKMIPMessage(t *testing.T) {
+	t.Run("oversize_cap", func(t *testing.T) {
+		// Header with a body length far above the cap.
+		hdr := make([]byte, 8)
+		binary.BigEndian.PutUint32(hdr[4:8], maxKMIPMessageSize+1)
+		_, err := readKMIPMessage(bytes.NewReader(hdr))
+		if err == nil || !strings.Contains(err.Error(), "exceeds cap") {
+			t.Fatalf("want oversize-cap error, got %v", err)
+		}
+	})
+
+	t.Run("short_header", func(t *testing.T) {
+		if _, err := readKMIPMessage(bytes.NewReader([]byte{0x01, 0x02})); err == nil {
+			t.Error("want error on short header")
+		}
+	})
+
+	t.Run("short_body", func(t *testing.T) {
+		hdr := make([]byte, 8)
+		binary.BigEndian.PutUint32(hdr[4:8], 16) // promise 16 body bytes
+		// Provide only 4 body bytes -> io.ErrUnexpectedEOF.
+		buf := append(append([]byte{}, hdr...), 1, 2, 3, 4)
+		if _, err := readKMIPMessage(bytes.NewReader(buf)); err == nil {
+			t.Error("want error on truncated body")
+		}
+	})
+
+	t.Run("exact_frame_with_padding", func(t *testing.T) {
+		// bodyLen=3 -> pad to 8-byte boundary = 5 padding bytes.
+		hdr := make([]byte, 8)
+		binary.BigEndian.PutUint32(hdr[4:8], 3)
+		body := []byte{0xAA, 0xBB, 0xCC, 0, 0, 0, 0, 0} // 3 + 5 pad
+		full := append(append([]byte{}, hdr...), body...)
+		out, err := readKMIPMessage(bytes.NewReader(full))
+		if err != nil {
+			t.Fatalf("readKMIPMessage: %v", err)
+		}
+		if len(out) != len(full) {
+			t.Errorf("frame length = %d, want %d", len(out), len(full))
+		}
+	})
+}

--- a/pkg/blockstore/encryption/keyprovider/local_corrupt_test.go
+++ b/pkg/blockstore/encryption/keyprovider/local_corrupt_test.go
@@ -1,0 +1,131 @@
+package keyprovider
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadKeyFile parses a freshly-generated key file back into its struct so
+// tests can mutate individual fields and re-encode a corrupted variant.
+func loadKeyFile(t *testing.T, passphrase string) localKeyFile {
+	t.Helper()
+	raw, err := GenerateKeyFile(passphrase)
+	if err != nil {
+		t.Fatalf("GenerateKeyFile: %v", err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("decode generated key file: nil block")
+	}
+	var kf localKeyFile
+	if err := json.Unmarshal(block.Bytes, &kf); err != nil {
+		t.Fatalf("unmarshal generated key file: %v", err)
+	}
+	return kf
+}
+
+// writeMutatedKeyFile re-encodes kf into a PEM key file on disk and returns
+// the path.
+func writeMutatedKeyFile(t *testing.T, kf localKeyFile) string {
+	t.Helper()
+	body, err := json.Marshal(kf)
+	if err != nil {
+		t.Fatalf("marshal mutated key file: %v", err)
+	}
+	out := pem.EncodeToMemory(&pem.Block{Type: localPEMType, Bytes: body})
+	path := filepath.Join(t.TempDir(), "mutated.key")
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("write mutated key file: %v", err)
+	}
+	return path
+}
+
+// TestLocal_DecodeKeyFile_CorruptFields exercises every guard in
+// decodeKeyFile that rejects a structurally-valid-but-unsupported key
+// file. Each case mutates exactly one field of an otherwise-valid file.
+func TestLocal_DecodeKeyFile_CorruptFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(kf *localKeyFile)
+	}{
+		{"unsupported_version", func(kf *localKeyFile) { kf.Version = 99 }},
+		{"unsupported_kdf", func(kf *localKeyFile) { kf.KDF.Algo = "scrypt" }},
+		{"unsupported_wrap", func(kf *localKeyFile) { kf.Wrap = "chacha20" }},
+		{"empty_master_key_id", func(kf *localKeyFile) { kf.MasterKeyID = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kf := loadKeyFile(t, testPassphrase)
+			tc.mutate(&kf)
+			path := writeMutatedKeyFile(t, kf)
+			t.Setenv(localPassphraseEnv, testPassphrase)
+			_, err := newLocalProvider(Config{Kind: KindLocal, File: path})
+			if !errors.Is(err, ErrKeyFileCorrupt) {
+				t.Fatalf("%s: want ErrKeyFileCorrupt, got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestLocal_UnwrapMasterKey_BadBase64 covers the base64-decode guards in
+// unwrapMasterKey for the salt, nonce, and wrapped-key fields.
+func TestLocal_UnwrapMasterKey_BadBase64(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(kf *localKeyFile)
+	}{
+		{"bad_salt", func(kf *localKeyFile) { kf.KDF.Salt = "!!!not-base64!!!" }},
+		{"bad_nonce", func(kf *localKeyFile) { kf.Nonce = "!!!not-base64!!!" }},
+		{"bad_wrapped", func(kf *localKeyFile) { kf.WrappedMasterKey = "!!!not-base64!!!" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kf := loadKeyFile(t, testPassphrase)
+			tc.mutate(&kf)
+			path := writeMutatedKeyFile(t, kf)
+			t.Setenv(localPassphraseEnv, testPassphrase)
+			_, err := newLocalProvider(Config{Kind: KindLocal, File: path})
+			if !errors.Is(err, ErrKeyFileCorrupt) {
+				t.Fatalf("%s: want ErrKeyFileCorrupt, got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestLocal_MissingFileConfig covers the empty-File and missing-file
+// guards in newLocalProvider.
+func TestLocal_MissingFileConfig(t *testing.T) {
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	if _, err := newLocalProvider(Config{Kind: KindLocal, File: ""}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("empty File: want ErrInvalidConfig, got %v", err)
+	}
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.key")
+	_, err := newLocalProvider(Config{Kind: KindLocal, File: missing})
+	if err == nil {
+		t.Fatal("missing file: want error, got nil")
+	}
+}
+
+// TestLocal_EmptyBlockKey verifies Wrap rejects a zero-length block key.
+func TestLocal_EmptyBlockKey(t *testing.T) {
+	p := newLocalForTest(t)
+	if _, _, err := p.Wrap(context.Background(), nil); err == nil {
+		t.Fatal("Wrap with empty block key: want error, got nil")
+	}
+}
+
+// TestLocal_Unwrap_ShortPayload verifies a too-short wrapped payload is
+// rejected before AEAD.Open.
+func TestLocal_Unwrap_ShortPayload(t *testing.T) {
+	p := newLocalForTest(t)
+	if _, err := p.Unwrap(context.Background(), []byte{0x01, 0x02}, p.CurrentMasterKeyID()); !errors.Is(err, ErrUnwrapFailed) {
+		t.Fatalf("Unwrap short payload: want ErrUnwrapFailed, got %v", err)
+	}
+}

--- a/pkg/blockstore/engine/api_accessors_test.go
+++ b/pkg/blockstore/engine/api_accessors_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// TestStore_GetSize_Exists drives the public GetSize/Exists accessors for
+// both a present and an absent payload. The local-only engine (no remote)
+// resolves entirely from the local store.
+func TestStore_GetSize_Exists(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+	const payloadID = "share/sized-file"
+
+	// Absent payload.
+	if ok, err := bs.Exists(ctx, payloadID); err != nil || ok {
+		t.Fatalf("Exists(absent) = (%v, %v), want (false, nil)", ok, err)
+	}
+
+	data := []byte("size-and-exists payload bytes")
+	if _, err := bs.WriteAt(ctx, payloadID, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	sz, err := bs.GetSize(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("GetSize: %v", err)
+	}
+	if sz != uint64(len(data)) {
+		t.Errorf("GetSize = %d, want %d", sz, len(data))
+	}
+	if ok, err := bs.Exists(ctx, payloadID); err != nil || !ok {
+		t.Fatalf("Exists(present) = (%v, %v), want (true, nil)", ok, err)
+	}
+}
+
+// TestStore_Accessors covers the cheap public accessor surface that the
+// runtime and snapshot layers depend on: HasRemoteStore, RemoteStore,
+// RemoteForTesting, LocalForTest, ListFiles, and LocalStats.
+func TestStore_Accessors(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+
+	if bs.HasRemoteStore() {
+		t.Error("HasRemoteStore: local-only engine should report false")
+	}
+	if bs.RemoteStore() != nil {
+		t.Error("RemoteStore: want nil for local-only engine")
+	}
+	if bs.RemoteForTesting() != nil {
+		t.Error("RemoteForTesting: want nil for local-only engine")
+	}
+	if bs.LocalForTest() == nil {
+		t.Error("LocalForTest: want non-nil local store")
+	}
+
+	const payloadID = "share/listed-file"
+	if _, err := bs.WriteAt(ctx, payloadID, nil, []byte("listed"), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	files := bs.ListFiles()
+	found := false
+	for _, f := range files {
+		if f == payloadID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ListFiles = %v, want to contain %q", files, payloadID)
+	}
+
+	// LocalStats must not panic and reflects a non-negative file count.
+	_ = bs.LocalStats()
+}
+
+// TestStore_RetentionAndEvictionSetters exercises the delegating setters
+// (they must not panic and must accept valid policies).
+func TestStore_RetentionAndEvictionSetters(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+
+	bs.SetRetentionPolicy(blockstore.RetentionLRU, time.Hour)
+	bs.SetRetentionPolicy(blockstore.RetentionPin, 0)
+	bs.SetEvictionEnabled(true)
+	bs.SetEvictionEnabled(false)
+}
+
+// TestStore_HealthCheck covers both the legacy error probe and the
+// structured Healthcheck for a healthy local-only engine.
+func TestStore_HealthCheck(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+
+	if err := bs.HealthCheck(ctx); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	rep := bs.Healthcheck(ctx)
+	if rep.Status != health.StatusHealthy {
+		t.Errorf("Healthcheck = %+v, want healthy", rep)
+	}
+}
+
+// TestStore_EvictLocal drops a file's local state and confirms a
+// subsequent Exists reports it gone (no remote to fall back to).
+func TestStore_EvictLocal(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+	const payloadID = "share/evict-me"
+
+	if _, err := bs.WriteAt(ctx, payloadID, nil, []byte("evictable bytes"), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if ok, _ := bs.Exists(ctx, payloadID); !ok {
+		t.Fatal("Exists before evict: want true")
+	}
+
+	if err := bs.EvictLocal(ctx, payloadID); err != nil {
+		t.Fatalf("EvictLocal: %v", err)
+	}
+	if ok, _ := bs.Exists(ctx, payloadID); ok {
+		t.Error("Exists after evict: want false for local-only engine")
+	}
+}
+
+// TestStore_ClosedGuards verifies the public accessors that pin against
+// Close fail closed with ErrStoreClosed after the store is closed.
+func TestStore_ClosedGuards(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+
+	if err := bs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := bs.GetSize(ctx, "x"); err == nil {
+		t.Error("GetSize after Close: want error")
+	}
+	if _, err := bs.Exists(ctx, "x"); err == nil {
+		t.Error("Exists after Close: want error")
+	}
+	if err := bs.EvictLocal(ctx, "x"); err == nil {
+		t.Error("EvictLocal after Close: want error")
+	}
+	if err := bs.HealthCheck(ctx); err == nil {
+		t.Error("HealthCheck after Close: want error")
+	}
+	if rep := bs.Healthcheck(ctx); rep.Status == health.StatusHealthy {
+		t.Error("Healthcheck after Close: want non-healthy")
+	}
+	// LocalStats returns a zero-value Stats on a closed store rather than
+	// erroring — assert it does not panic.
+	_ = bs.LocalStats()
+}

--- a/pkg/blockstore/remote/s3/mock_store_test.go
+++ b/pkg/blockstore/remote/s3/mock_store_test.go
@@ -1,0 +1,843 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/blockstore"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// mockS3 is an in-process, deterministic S3 wire emulator sufficient to
+// exercise the Store wire path (Put/Get/GetRange/Head/Has/Delete/Walk)
+// without a Localstack/MinIO container. It implements only the subset of
+// the S3 REST API the Store uses and is intentionally minimal — it is a
+// test fixture, not a general S3 implementation.
+//
+// It uses path-style addressing (/{bucket}/{key}); the test client is
+// constructed with UsePathStyle=true to match.
+type mockS3 struct {
+	mu      sync.Mutex
+	objects map[string]mockObject // key -> object (key excludes the bucket segment)
+	bucket  string
+
+	// listPageSize, when >0, caps ListObjectsV2 results per page so the
+	// paginator multi-page path is exercised deterministically.
+	listPageSize int
+
+	// failNext, when set, causes the next matching request to return the
+	// given HTTP status instead of servicing it. It is consumed (reset to
+	// 0) after firing once so retries can succeed. method is matched
+	// case-insensitively; an empty method matches any.
+	failNextStatus int
+	failNextMethod string
+
+	// omitContentLength, when true, suppresses the Content-Length header on
+	// GET responses (chunked transfer) so the Store's no-content-length
+	// readResponseBody fallback is exercised.
+	omitContentLength bool
+}
+
+type mockObject struct {
+	data         []byte
+	metadata     map[string]string
+	lastModified time.Time
+}
+
+func newMockS3(bucket string) *mockS3 {
+	return &mockS3{
+		objects: make(map[string]mockObject),
+		bucket:  bucket,
+	}
+}
+
+// listObjectsV2Result mirrors the XML the AWS SDK unmarshals for a
+// ListObjectsV2 response. Only the fields the Store reads are populated.
+type listObjectsV2Result struct {
+	XMLName               xml.Name       `xml:"ListBucketResult"`
+	IsTruncated           bool           `xml:"IsTruncated"`
+	NextContinuationToken string         `xml:"NextContinuationToken,omitempty"`
+	Contents              []listObjEntry `xml:"Contents"`
+}
+
+type listObjEntry struct {
+	Key          string    `xml:"Key"`
+	Size         int64     `xml:"Size"`
+	LastModified time.Time `xml:"LastModified"`
+}
+
+func (m *mockS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	if m.failNextStatus != 0 &&
+		(m.failNextMethod == "" || strings.EqualFold(m.failNextMethod, r.Method)) {
+		status := m.failNextStatus
+		m.failNextStatus = 0
+		m.failNextMethod = ""
+		m.mu.Unlock()
+		http.Error(w, "<Error><Code>InternalError</Code></Error>", status)
+		return
+	}
+	m.mu.Unlock()
+
+	// Path-style: /{bucket}/{key...}. The leading slash + bucket are
+	// stripped to recover the object key.
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	key := ""
+	if len(parts) == 2 {
+		key = parts[1]
+	}
+
+	// ListObjectsV2 is a GET on the bucket root with ?list-type=2.
+	if r.Method == http.MethodGet && r.URL.Query().Get("list-type") == "2" {
+		m.handleList(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		m.handlePut(w, r, key)
+	case http.MethodGet:
+		m.handleGet(w, r, key)
+	case http.MethodHead:
+		// HeadBucket is a HEAD on the bucket root (empty key); the Store
+		// uses it for HealthCheck. Always reachable in the mock.
+		if key == "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		m.handleHead(w, key)
+	case http.MethodDelete:
+		m.handleDelete(w, key)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *mockS3) handlePut(w http.ResponseWriter, r *http.Request, key string) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	meta := make(map[string]string)
+	for h, vals := range r.Header {
+		const prefix = "X-Amz-Meta-"
+		if strings.HasPrefix(h, prefix) && len(vals) > 0 {
+			meta[strings.ToLower(strings.TrimPrefix(h, prefix))] = vals[0]
+		}
+	}
+	m.mu.Lock()
+	m.objects[key] = mockObject{data: body, metadata: meta, lastModified: time.Now().UTC()}
+	m.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (m *mockS3) handleGet(w http.ResponseWriter, r *http.Request, key string) {
+	m.mu.Lock()
+	obj, ok := m.objects[key]
+	m.mu.Unlock()
+	if !ok {
+		writeNoSuchKey(w)
+		return
+	}
+
+	for k, v := range obj.metadata {
+		w.Header().Set("X-Amz-Meta-"+k, v)
+	}
+	w.Header().Set("Last-Modified", obj.lastModified.Format(http.TimeFormat))
+
+	data := obj.data
+	status := http.StatusOK
+	if rangeHdr := r.Header.Get("Range"); rangeHdr != "" {
+		start, end, ok := parseByteRange(rangeHdr, int64(len(data)))
+		if !ok {
+			// Unsatisfiable range -> 416, matching real S3 for offset>=EOF.
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		data = data[start : end+1]
+		status = http.StatusPartialContent
+	}
+
+	m.mu.Lock()
+	omit := m.omitContentLength
+	m.mu.Unlock()
+	if !omit {
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+
+func (m *mockS3) handleHead(w http.ResponseWriter, key string) {
+	m.mu.Lock()
+	obj, ok := m.objects[key]
+	m.mu.Unlock()
+	if !ok {
+		// HEAD has no body; the SDK maps a 404 with no NoSuchKey body to a
+		// NotFound, which isNotFoundError catches via the "404"/"NotFound"
+		// string fallback.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	for k, v := range obj.metadata {
+		w.Header().Set("X-Amz-Meta-"+k, v)
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(obj.data)))
+	w.Header().Set("Last-Modified", obj.lastModified.Format(http.TimeFormat))
+	w.WriteHeader(http.StatusOK)
+}
+
+func (m *mockS3) handleDelete(w http.ResponseWriter, key string) {
+	m.mu.Lock()
+	delete(m.objects, key)
+	m.mu.Unlock()
+	// S3 DeleteObject returns 204 even when the key was absent.
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (m *mockS3) handleList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	prefix := q.Get("prefix")
+	token := q.Get("continuation-token")
+
+	m.mu.Lock()
+	keys := make([]string, 0, len(m.objects))
+	for k := range m.objects {
+		if prefix == "" || strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	objs := make(map[string]mockObject, len(m.objects))
+	for k, v := range m.objects {
+		objs[k] = v
+	}
+	pageSize := m.listPageSize
+	m.mu.Unlock()
+
+	sort.Strings(keys)
+
+	// Continuation token is simply the index to resume from (encoded as a
+	// decimal string). Deterministic and sufficient for the paginator.
+	startIdx := 0
+	if token != "" {
+		if i, err := strconv.Atoi(token); err == nil {
+			startIdx = i
+		}
+	}
+
+	res := listObjectsV2Result{}
+	end := len(keys)
+	if pageSize > 0 && startIdx+pageSize < end {
+		end = startIdx + pageSize
+		res.IsTruncated = true
+		res.NextContinuationToken = strconv.Itoa(end)
+	}
+	for _, k := range keys[startIdx:end] {
+		obj := objs[k]
+		res.Contents = append(res.Contents, listObjEntry{
+			Key:          k,
+			Size:         int64(len(obj.data)),
+			LastModified: obj.lastModified,
+		})
+	}
+
+	out, err := xml.Marshal(res)
+	if err != nil {
+		http.Error(w, "marshal", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_, _ = w.Write(out)
+}
+
+func writeNoSuchKey(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+		`<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>`))
+}
+
+// parseByteRange parses a single "bytes=start-end" header against a known
+// object size and returns the inclusive [start,end] indices. Returns
+// ok=false for an unsatisfiable range (start beyond EOF), mirroring S3's
+// 416 behavior. end is clamped to size-1 so a partial-past-EOF request
+// returns the available tail.
+func parseByteRange(hdr string, size int64) (start, end int64, ok bool) {
+	const p = "bytes="
+	if !strings.HasPrefix(hdr, p) {
+		return 0, 0, false
+	}
+	spec := strings.TrimPrefix(hdr, p)
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(spec[:dash], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(spec[dash+1:], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if start < 0 || start >= size {
+		return 0, 0, false // unsatisfiable
+	}
+	if end >= size {
+		end = size - 1
+	}
+	if end < start {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// newTestStore spins up a mockS3 behind an httptest.Server and returns a
+// Store wired to it plus the mock for fault injection. The store and
+// server are torn down via t.Cleanup.
+//
+// The client disables request/response checksums so PutObject sends a
+// plain (non-aws-chunked) body the mock can read directly.
+func newTestStore(t *testing.T) (*Store, *mockS3) {
+	t.Helper()
+	const bucket = "test-bucket"
+	mock := newMockS3(bucket)
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+
+	client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(srv.URL),
+		UsePathStyle: true,
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"test", "test", ""),
+		HTTPClient:                 awshttp.NewBuildableClient(),
+		RequestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		ResponseChecksumValidation: aws.ResponseChecksumValidationWhenRequired,
+	})
+
+	store := New(client, Config{Bucket: bucket})
+	t.Cleanup(func() { _ = store.Close() })
+	return store, mock
+}
+
+// mustHash returns the BLAKE3-256 content hash of b. Unlike the
+// *testing.T-bound hashOf in verifier_test.go, this is usable from
+// helpers that do not hold a t.
+func mustHash(b []byte) blockstore.ContentHash {
+	return blockstore.ContentHash(blake3.Sum256(b))
+}
+
+// TestStore_Put_Get_RoundTrip drives the full PUT then GET wire path.
+func TestStore_Put_Get_RoundTrip(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("mock-s3 round-trip payload — deterministic bytes")
+	h := mustHash(data)
+
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := store.Get(ctx, h)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("Get returned %q, want %q", got, data)
+	}
+}
+
+// TestStore_Get_NotFound pins the NoSuchKey -> ErrChunkNotFound mapping.
+func TestStore_Get_NotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := store.Get(ctx, mustHash([]byte("absent"))); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("Get on missing key: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_Has covers both the present and absent HEAD outcomes.
+func TestStore_Has(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("has-probe payload")
+	h := mustHash(data)
+
+	has, err := store.Has(ctx, h)
+	if err != nil {
+		t.Fatalf("Has (absent): %v", err)
+	}
+	if has {
+		t.Fatal("Has on absent key: want false")
+	}
+
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	has, err = store.Has(ctx, h)
+	if err != nil {
+		t.Fatalf("Has (present): %v", err)
+	}
+	if !has {
+		t.Fatal("Has on present key: want true")
+	}
+}
+
+// TestStore_Head verifies Meta.Size and a non-zero LastModified, plus the
+// NotFound mapping.
+func TestStore_Head(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := make([]byte, 4096)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	m, err := store.Head(ctx, h)
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if m.Size != int64(len(data)) {
+		t.Errorf("Head Size = %d, want %d", m.Size, len(data))
+	}
+	if m.LastModified.IsZero() {
+		t.Error("Head LastModified is zero")
+	}
+
+	if _, err := store.Head(ctx, mustHash([]byte("nope"))); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("Head on missing key: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_GetRange exercises mid-block, tail, partial-past-EOF, and the
+// argument-validation sentinels.
+func TestStore_GetRange(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef") // 16 bytes
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Mid-block.
+	got, err := store.GetRange(ctx, h, 4, 8)
+	if err != nil {
+		t.Fatalf("GetRange mid: %v", err)
+	}
+	if string(got) != "456789ab" {
+		t.Fatalf("GetRange mid = %q, want %q", got, "456789ab")
+	}
+
+	// Partial past EOF: returns the available tail without error.
+	got, err = store.GetRange(ctx, h, 8, 20)
+	if err != nil {
+		t.Fatalf("GetRange partial-past-EOF: %v", err)
+	}
+	if string(got) != "89abcdef" {
+		t.Fatalf("GetRange partial-past-EOF = %q, want %q", got, "89abcdef")
+	}
+
+	// Offset strictly past EOF: the mock returns 416, surfaced as an error.
+	if _, err := store.GetRange(ctx, h, 100, 4); err == nil {
+		t.Fatal("GetRange offset past EOF: want error, got nil")
+	}
+
+	// Argument validation sentinels (checked before any wire call).
+	if _, err := store.GetRange(ctx, h, -1, 4); !errors.Is(err, blockstore.ErrInvalidOffset) {
+		t.Fatalf("GetRange offset=-1: want ErrInvalidOffset, got %v", err)
+	}
+	if _, err := store.GetRange(ctx, h, 0, 0); !errors.Is(err, blockstore.ErrInvalidSize) {
+		t.Fatalf("GetRange length=0: want ErrInvalidSize, got %v", err)
+	}
+	if _, err := store.GetRange(ctx, h, 0, -4); !errors.Is(err, blockstore.ErrInvalidSize) {
+		t.Fatalf("GetRange length=-4: want ErrInvalidSize, got %v", err)
+	}
+
+	// Range on a missing key maps to ErrChunkNotFound.
+	if _, err := store.GetRange(ctx, mustHash([]byte("missing")), 0, 4); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("GetRange on missing key: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_Delete_Idempotent confirms Delete succeeds whether or not the
+// object exists and that a subsequent Get misses.
+func TestStore_Delete_Idempotent(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("to be deleted")
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete(ctx, h); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, h); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("Get after Delete: want ErrChunkNotFound, got %v", err)
+	}
+	// Idempotent: deleting an absent key still succeeds.
+	if err := store.Delete(ctx, h); err != nil {
+		t.Fatalf("Delete (idempotent): %v", err)
+	}
+}
+
+// TestStore_ReadBlockVerified covers the happy path, the streaming-hash
+// mismatch path, and the header pre-check fast-fail path.
+func TestStore_ReadBlockVerified(t *testing.T) {
+	store, mock := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("verified read payload — must hash to the stored key")
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Happy path: body hashes to expected.
+	got, err := store.ReadBlockVerified(ctx, h, h)
+	if err != nil {
+		t.Fatalf("ReadBlockVerified happy: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("ReadBlockVerified bytes mismatch")
+	}
+
+	// Header pre-check: the stored object carries content-hash == h, so
+	// asking the verifier to expect a different hash trips the header
+	// fast-fail before the body is read.
+	wrongExpected := mustHash([]byte("different"))
+	if _, err := store.ReadBlockVerified(ctx, h, wrongExpected); !errors.Is(err, blockstore.ErrCASContentMismatch) {
+		t.Fatalf("ReadBlockVerified header pre-check: want ErrCASContentMismatch, got %v", err)
+	}
+
+	// Streaming mismatch: store an object whose stamped header matches the
+	// expected hash but whose body does NOT, so the header pre-check passes
+	// and the streaming recompute catches the corruption.
+	key := store.hashKey(h)
+	mock.mu.Lock()
+	mock.objects[key] = mockObject{
+		data:         []byte("corrupted body that does not hash to h"),
+		metadata:     map[string]string{"content-hash": h.CASKey()},
+		lastModified: time.Now().UTC(),
+	}
+	mock.mu.Unlock()
+	if _, err := store.ReadBlockVerified(ctx, h, h); !errors.Is(err, blockstore.ErrCASContentMismatch) {
+		t.Fatalf("ReadBlockVerified streaming mismatch: want ErrCASContentMismatch, got %v", err)
+	}
+
+	// Missing key maps to ErrChunkNotFound.
+	if _, err := store.ReadBlockVerified(ctx, mustHash([]byte("gone")), mustHash([]byte("gone"))); !errors.Is(err, blockstore.ErrChunkNotFound) {
+		t.Fatalf("ReadBlockVerified missing: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_Walk_Enumerate verifies Walk visits every CAS object exactly
+// once with a non-zero LastModified, skips non-CAS keys, and spans
+// multiple paginator pages.
+func TestStore_Walk_Enumerate(t *testing.T) {
+	store, mock := newTestStore(t)
+	mock.mu.Lock()
+	mock.listPageSize = 2 // force multi-page pagination
+	mock.mu.Unlock()
+	ctx := context.Background()
+
+	want := make(map[blockstore.ContentHash]int64)
+	for i := 0; i < 5; i++ {
+		p := []byte(fmt.Sprintf("walk-object-%d-payload", i))
+		h := mustHash(p)
+		want[h] = int64(len(p))
+		if err := store.Put(ctx, h, p); err != nil {
+			t.Fatalf("Put %d: %v", i, err)
+		}
+	}
+
+	// A non-CAS key under the bucket must be skipped by Walk.
+	mock.mu.Lock()
+	mock.objects["cas/zz/zz/not-a-valid-cas-key"] = mockObject{
+		data: []byte("junk"), lastModified: time.Now().UTC(),
+	}
+	mock.mu.Unlock()
+
+	seen := make(map[blockstore.ContentHash]int)
+	err := store.Walk(ctx, func(h blockstore.ContentHash, m blockstore.Meta) error {
+		seen[h]++
+		if m.LastModified.IsZero() {
+			t.Errorf("Walk Meta.LastModified zero for %s", h)
+		}
+		if w, ok := want[h]; ok && m.Size != w {
+			t.Errorf("Walk Size for %s = %d, want %d", h, m.Size, w)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("Walk visited %d objects, want %d", len(seen), len(want))
+	}
+	for h, n := range seen {
+		if n != 1 {
+			t.Errorf("Walk visited %s %d times, want 1", h, n)
+		}
+	}
+}
+
+// TestStore_Walk_StopSentinel pins the ErrStopWalk clean-exit contract.
+func TestStore_Walk_StopSentinel(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		p := []byte(fmt.Sprintf("stop-%d", i))
+		if err := store.Put(ctx, mustHash(p), p); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	seen := 0
+	err := store.Walk(ctx, func(blockstore.ContentHash, blockstore.Meta) error {
+		seen++
+		return blockstore.ErrStopWalk
+	})
+	if err != nil {
+		t.Fatalf("Walk ErrStopWalk: want nil, got %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("Walk should stop after first ErrStopWalk; saw %d", seen)
+	}
+}
+
+// TestStore_Walk_ErrorWrap pins the "walk halted at %s: %w" wrapping
+// contract for a non-sentinel callback error.
+func TestStore_Walk_ErrorWrap(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	p := []byte("wrap-target")
+	if err := store.Put(ctx, mustHash(p), p); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	custom := errors.New("custom walk callback error")
+	err := store.Walk(ctx, func(blockstore.ContentHash, blockstore.Meta) error {
+		return custom
+	})
+	if !errors.Is(err, custom) {
+		t.Fatalf("Walk error does not wrap custom: got %v", err)
+	}
+	if !strings.Contains(err.Error(), "walk halted at") {
+		t.Errorf("Walk error missing 'walk halted at' prefix: %q", err.Error())
+	}
+}
+
+// TestStore_Walk_ContextCancel verifies a cancelled context aborts Walk.
+func TestStore_Walk_ContextCancel(t *testing.T) {
+	store, mock := newTestStore(t)
+	mock.mu.Lock()
+	mock.listPageSize = 1
+	mock.mu.Unlock()
+
+	for i := 0; i < 4; i++ {
+		p := []byte(fmt.Sprintf("cancel-%d", i))
+		if err := store.Put(context.Background(), mustHash(p), p); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Walk starts
+	err := store.Walk(ctx, func(blockstore.ContentHash, blockstore.Meta) error {
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Walk on cancelled ctx: want context.Canceled, got %v", err)
+	}
+}
+
+// TestStore_ClosedGuards confirms every public method fails closed with
+// ErrStoreClosed after Close.
+func TestStore_ClosedGuards(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	h := mustHash([]byte("x"))
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := store.Put(ctx, h, []byte("x")); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("Put after Close: want ErrStoreClosed, got %v", err)
+	}
+	if _, err := store.Get(ctx, h); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("Get after Close: want ErrStoreClosed, got %v", err)
+	}
+	if _, err := store.GetRange(ctx, h, 0, 4); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("GetRange after Close: want ErrStoreClosed, got %v", err)
+	}
+	if _, err := store.Has(ctx, h); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("Has after Close: want ErrStoreClosed, got %v", err)
+	}
+	if _, err := store.Head(ctx, h); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("Head after Close: want ErrStoreClosed, got %v", err)
+	}
+	if err := store.Delete(ctx, h); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("Delete after Close: want ErrStoreClosed, got %v", err)
+	}
+	if _, err := store.ReadBlockVerified(ctx, h, h); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("ReadBlockVerified after Close: want ErrStoreClosed, got %v", err)
+	}
+	walkErr := store.Walk(ctx, func(blockstore.ContentHash, blockstore.Meta) error { return nil })
+	if !errors.Is(walkErr, blockstore.ErrStoreClosed) {
+		t.Errorf("Walk after Close: want ErrStoreClosed, got %v", walkErr)
+	}
+	if err := store.HealthCheck(ctx); !errors.Is(err, blockstore.ErrStoreClosed) {
+		t.Errorf("HealthCheck after Close: want ErrStoreClosed, got %v", err)
+	}
+}
+
+// TestStore_RetryOn5xx verifies the SDK retryer recovers from a single
+// transient 5xx on Put (failNext fires once, then the retry succeeds).
+func TestStore_RetryOn5xx(t *testing.T) {
+	store, mock := newTestStore(t)
+	ctx := context.Background()
+
+	mock.mu.Lock()
+	mock.failNextStatus = http.StatusServiceUnavailable
+	mock.failNextMethod = http.MethodPut
+	mock.mu.Unlock()
+
+	data := []byte("retry payload")
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put should recover after one 5xx: %v", err)
+	}
+	got, err := store.Get(ctx, h)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("Get bytes mismatch after retry")
+	}
+}
+
+// TestStore_HealthCheck covers the HeadBucket success path and the
+// structured Healthcheck wrapper.
+func TestStore_HealthCheck(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.HealthCheck(ctx); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	rep := store.Healthcheck(ctx)
+	if rep.Status != health.StatusHealthy {
+		t.Errorf("Healthcheck reported non-healthy status: %+v", rep)
+	}
+}
+
+// TestStore_PutContextCancel verifies a cancelled context propagates as an
+// error from a wire call rather than hanging.
+func TestStore_PutContextCancel(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.Put(ctx, mustHash([]byte("x")), []byte("x"))
+	if err == nil {
+		t.Fatal("Put on cancelled ctx: want error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Logf("Put on cancelled ctx returned %v (non-context.Canceled is acceptable if it is a wrapped transport error)", err)
+	}
+}
+
+// TestStore_Get_NoContentLength exercises the readResponseBody fallback
+// path where the response omits Content-Length (chunked transfer).
+func TestStore_Get_NoContentLength(t *testing.T) {
+	store, mock := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("chunked-transfer payload without content-length")
+	h := mustHash(data)
+	if err := store.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	mock.mu.Lock()
+	mock.omitContentLength = true
+	mock.mu.Unlock()
+
+	got, err := store.Get(ctx, h)
+	if err != nil {
+		t.Fatalf("Get (no content-length): %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("Get bytes mismatch on no-content-length path")
+	}
+}
+
+// TestNewFromConfig_Validation pins the required-field validation and a
+// successful construction (which does not perform any network I/O).
+func TestNewFromConfig_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	if _, err := NewFromConfig(ctx, Config{}); err == nil {
+		t.Error("NewFromConfig with empty bucket: want error, got nil")
+	}
+	if _, err := NewFromConfig(ctx, Config{Bucket: "b"}); err == nil {
+		t.Error("NewFromConfig without credentials: want error, got nil")
+	}
+	if _, err := NewFromConfig(ctx, Config{Bucket: "b", AccessKey: "a"}); err == nil {
+		t.Error("NewFromConfig with access key but no secret: want error, got nil")
+	}
+
+	store, err := NewFromConfig(ctx, Config{
+		Bucket:         "b",
+		Region:         "us-east-1",
+		Endpoint:       "localhost:4566",
+		AccessKey:      "a",
+		SecretKey:      "s",
+		KeyPrefix:      "prefix/",
+		MaxRetries:     3,
+		ForcePathStyle: true,
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig valid: %v", err)
+	}
+	if store == nil {
+		t.Fatal("NewFromConfig valid: want non-nil store")
+	}
+	_ = store.Close()
+}


### PR DESCRIPTION
## Summary

Fills the test-coverage gaps surfaced by the area #1 blockstore PR-A audit (#677), prioritizing the highest-risk under-tested packages. All new tests are deterministic and run with plain `go test` — no Localstack/MinIO/KMIP container required.

## Gaps covered

### `remote/s3` — 21% → 88% (P0, CRITICAL; target 75%)
New in-process `httptest`-backed S3 wire emulator (`mockS3`) drives the full store wire path without a container:
- Put/Get round-trip, `NoSuchKey` → `ErrChunkNotFound` mapping, `Has`, `Head` (size + non-zero LastModified)
- `GetRange`: mid-block, partial-past-EOF tail, offset-past-EOF (416), and the `ErrInvalidOffset`/`ErrInvalidSize` arg-validation sentinels
- `ReadBlockVerified`: happy path, header pre-check fast-fail, streaming BLAKE3 mismatch, not-found
- `Walk`: multi-page pagination, non-CAS-key skip, `ErrStopWalk` clean-exit, `walk halted at %s: %w` error-wrap, context cancellation
- `Delete` idempotency, closed-store guards on every method, retry-on-5xx recovery, no-content-length fallback, `HealthCheck`/`Healthcheck`, `NewFromConfig` validation

### `encryption/keyprovider` — 45% → 85% (P1; target 75%)
The gap was entirely the KMIP path. Added:
- A fake TLS KMIP server (self-signed certs generated in-test) that drives `newKMIPProvider`/`fetchKMIPSymmetricKey` end-to-end: dial → marshal Get → framed read → decode → Wrap/Unwrap round-trip
- KMIP error paths: wrong key length, server failure status, dial error (timeout honored)
- Pure-function coverage: `buildKMIPTLSConfig` (cert load, server-CA, bad-PEM), `readKMIPMessage` (framing, padding, oversize cap, short reads), `extractSymmetricKeyMaterial` (all type-switch branches + defensive-copy)
- Local-provider corrupt-on-disk cases: unsupported version/kdf/wrap, empty master-key-id, bad-base64 salt/nonce/wrapped, missing file, empty block key, short payload

### `engine` — 65.8% → 67.2%
Public-accessor + closed-store-guard coverage: `GetSize`/`Exists` round-trip, `EvictLocal`, `HealthCheck`/`Healthcheck`, `ListFiles`, `RemoteStore`/`RemoteForTesting`/`LocalForTest`, retention/eviction setters, `LocalStats`. The deeper remote-download read path (`fetch.go` `EnsureAvailable*`, `sync_queue.go` download workers) needs a started-syncer-with-remote harness and is left for a follow-up — it is the bulk of the remaining engine gap toward 80%.

## Bug exposed

None — adding the coverage exposed no production-code bug. No production code changed.

## Testing

- `go build ./...`
- `go test ./pkg/blockstore/... -count=1`
- `go test -tags=integration -p 1 ./pkg/blockstore/... ./bench/blockstore/... -count=1`
- `go test -race ./pkg/blockstore/...` — race-clean
- New tests run 3–5× each: non-flaky
- `gofmt -s`, `go vet`, `golangci-lint run` — 0 issues

Closes #679