### PR TITLE
fix(bench): size log budget so random-write/mixed-rw workloads complete (#964)

### DIFF
--- a/bench/blockstore/workloads.go
+++ b/bench/blockstore/workloads.go
@@ -36,6 +36,14 @@ const (
 	MixedRWFileSize     = 32 * 1024 * 1024
 )
 
+// seedChunkSize bounds each seed WriteAt so a single record never
+// exceeds the local store's per-record cap (maxRecordPayload, 17 MiB,
+// just above the chunker's 16 MiB hard ceiling). Production protocol
+// callers (NFS WRITE, SMB write) already arrive in sub-MiB segments;
+// only the bench seed would otherwise emit one multi-MiB record. 8 MiB
+// keeps the seed fast while staying well under the cap.
+const seedChunkSize = 8 * 1024 * 1024
+
 // Opts is the unified workload configuration. Shared by cmd/bench
 // blockstore (CLI flags), Go Benchmark* tests, and any future caller.
 // Zero values are valid only for fields explicitly documented as
@@ -221,11 +229,29 @@ func seedAndOffsetCap(ctx context.Context, bs *engine.Store, files int, prefix s
 	data := seededBytes(opts.Seed^0x9E3779B97F4A7C15, size)
 	for i := 0; i < files; i++ {
 		pid := fmt.Sprintf("%s/%d", prefix, i)
-		if _, err := bs.WriteAt(ctx, pid, nil, data, 0); err != nil {
-			return 0, fmt.Errorf("seed %s: %w", pid, err)
+		if err := seedPayload(ctx, bs, pid, data); err != nil {
+			return 0, err
 		}
 	}
 	return uint64(size - opts.BlockSize), nil
+}
+
+// seedPayload writes data into payloadID at offset 0 in segments of at
+// most seedChunkSize bytes. A single WriteAt becomes one append-log
+// record, so seeding a multi-MiB working-set file in one call would
+// exceed the local store's per-record cap; splitting mirrors the
+// bounded segments real protocol callers emit.
+func seedPayload(ctx context.Context, bs *engine.Store, payloadID string, data []byte) error {
+	for off := 0; off < len(data); off += seedChunkSize {
+		end := off + seedChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		if _, err := bs.WriteAt(ctx, payloadID, nil, data[off:end], uint64(off)); err != nil {
+			return fmt.Errorf("seed %s: %w", payloadID, err)
+		}
+	}
+	return nil
 }
 
 // seededBytes returns `size` deterministic PRNG bytes for the given seed.

--- a/bench/blockstore/workloads_test.go
+++ b/bench/blockstore/workloads_test.go
@@ -37,8 +37,8 @@ func newBenchEngine(tb testing.TB) *engine.Store {
 func seedFile(tb testing.TB, bs *engine.Store, payloadID string, size int) {
 	tb.Helper()
 	data := seededBytes(0x9E3779B97F4A7C15, size)
-	if _, err := bs.WriteAt(context.Background(), payloadID, nil, data, 0); err != nil {
-		tb.Fatalf("seed %s: %v", payloadID, err)
+	if err := seedPayload(context.Background(), bs, payloadID, data); err != nil {
+		tb.Fatalf("%v", err)
 	}
 }
 


### PR DESCRIPTION
## Root cause

The `random-write` and `mixed-rw` workloads in `bench/blockstore` seed their working-set file (64 MiB / 32 MiB) with a **single** `bs.WriteAt(ctx, pid, data, 0)`. `engine.WriteAt` emits **one append-log record per call** (`local.AppendWrite`), so the seed produced one 64 MiB record. The local store's append log enforces a per-record `maxRecordPayload` cap of **17 MiB** (an intentional DoS guard, set just above the FastCDC chunker's 16 MiB hard ceiling). The oversized record wedged the rollup with:

```
rollup: readRecordAt: append log: payloadLen 67108864 exceeds 17825792 cap
```

so only `sequential-write` (which never seeds a large single write) ran end-to-end. This blocked #680's pprof + §Bottlenecks capture for two of three workloads.

**This is a bench-harness usage mismatch, not an engine bug.** Production protocol callers (NFS WRITE wsize, SMB write) always arrive in bounded sub-MiB segments and never emit a multi-MiB single record; the per-record cap is correct and intentional. The bench seed was the only caller violating that contract.

## Fix

Seed the working-set file in `<= 8 MiB` segments via a shared `seedPayload` helper, mirroring the bounded segments real callers emit. The resulting file content is byte-identical to the old single write. Both the library seed (`seedAndOffsetCap`) and the Go benchmark helper (`seedFile`) now route through it. Engine code and the per-record cap are untouched.

## Verification (all run to completion, zero `payloadLen exceeds cap`)

```
sequential-write --ops 2000 --block-size 65536 --working-set 4   exit 0  (regression: still passes)
random-write     --ops 2000 --block-size 4096  --working-set 1   exit 0  (previously failed)
mixed-rw         --ops 2000 --block-size 4096  --working-set 1   exit 0  (previously failed)
```

`--full-profiles` on random-write and mixed-rw now captures all five non-empty, pprof-parseable profiles (cpu/heap/block/mutex/goroutine + seed.txt) — ties back to #680.

`go build ./...`, `go test ./cmd/bench/... ./bench/... -count=1`, `go vet ./...`, `golangci-lint run` all green. No engine code touched (diff scoped to `bench/blockstore/`).

> Note: the residual `rollup: StoreChunk: local store: closed` log on random-write is a pre-existing benign rollup-ticker-during-shutdown artifact (logged AFTER the workload result line), unrelated to this fix.

Closes #964