### PR TITLE
fix(smb): collapse typed-nil LockManager so missing-share guards work

### DIFF
--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -623,13 +623,30 @@ type metadataServiceResolver struct {
 	metaSvc *metadata.MetadataService
 }
 
-// GetLockManagerForShare returns the LockManager for the given share.
-// Returns nil if no LockManager exists for the share.
-func (r *metadataServiceResolver) GetLockManagerForShare(shareName string) lock.LockManager {
+// lockManagerForShare resolves the per-share LockManager and returns it as a
+// true nil interface when the share has no manager.
+//
+// metaSvc.GetLockManagerForShare returns a concrete *metadata.LockManager that
+// is nil when the share has been removed (e.g. a CREATE races a DeleteShare in
+// the conformance battery). Returning that nil pointer directly through the
+// lock.LockManager interface would box it into a non-nil interface (a typed
+// nil), so every downstream `lockMgr == nil` guard would evaluate false and the
+// first method call would nil-deref the receiver. Collapse the typed nil to a
+// real nil interface here, at the single boxing boundary.
+func (r *metadataServiceResolver) lockManagerForShare(shareName string) lock.LockManager {
 	if r.metaSvc == nil {
 		return nil
 	}
-	return r.metaSvc.GetLockManagerForShare(shareName)
+	if lm := r.metaSvc.GetLockManagerForShare(shareName); lm != nil {
+		return lm
+	}
+	return nil
+}
+
+// GetLockManagerForShare returns the LockManager for the given share.
+// Returns nil if no LockManager exists for the share.
+func (r *metadataServiceResolver) GetLockManagerForShare(shareName string) lock.LockManager {
+	return r.lockManagerForShare(shareName)
 }
 
 // GetLockManagerForHandle attempts to resolve the LockManager from a file handle.
@@ -647,5 +664,5 @@ func (r *metadataServiceResolver) GetLockManagerForHandle(handleKey string) lock
 	if err != nil || shareName == "" {
 		return nil
 	}
-	return r.metaSvc.GetLockManagerForShare(shareName)
+	return r.lockManagerForShare(shareName)
 }

--- a/pkg/adapter/smb/resolver_nil_test.go
+++ b/pkg/adapter/smb/resolver_nil_test.go
@@ -1,0 +1,67 @@
+package smb
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestResolver_GetLockManagerForShare_MissingShareReturnsNilInterface guards
+// against a typed-nil regression: metadata.MetadataService.GetLockManagerForShare
+// returns a concrete *metadata.LockManager that is nil for an unknown/removed
+// share. If the resolver returns that nil pointer through its lock.LockManager
+// interface return value, the interface is non-nil (it carries a type) and every
+// downstream `lockMgr == nil` guard evaluates false — the first method call then
+// nil-derefs the receiver and crashes the SMB server mid-battery.
+//
+// Reproduces the panic seen in CI:
+//
+//	lock.(*Manager).breakOpLocks(0x0, ...)            manager.go
+//	lock.(*Manager).BreakLeasesOnOpenConflict(0x0, ...)
+//	lease.(*LeaseManager).BreakParentDirLeasesOnDestructiveCreate(0x0, ...)
+//
+// triggered when a CREATE raced a DeleteShare.
+func TestResolver_GetLockManagerForShare_MissingShareReturnsNilInterface(t *testing.T) {
+	// Fresh service has no registered shares, so the underlying lookup returns
+	// a nil *metadata.LockManager.
+	resolver := &metadataServiceResolver{metaSvc: metadata.New()}
+
+	lm := resolver.GetLockManagerForShare("/does-not-exist")
+	if lm != nil {
+		t.Fatalf("GetLockManagerForShare for a missing share must return a nil "+
+			"interface, got non-nil interface %#v (typed-nil regression)", lm)
+	}
+}
+
+// TestResolver_GetLockManagerForHandle_MissingShareReturnsNilInterface is the
+// handle-keyed twin of the test above. The handle encodes a share that has no
+// registered LockManager, so the resolver must surface a true nil interface.
+func TestResolver_GetLockManagerForHandle_MissingShareReturnsNilInterface(t *testing.T) {
+	resolver := &metadataServiceResolver{metaSvc: metadata.New()}
+
+	// "shareName:uuid" is the on-the-wire handle format the resolver decodes.
+	handle, err := metadata.EncodeShareHandle("/does-not-exist", uuid.New())
+	if err != nil {
+		t.Fatalf("EncodeShareHandle: %v", err)
+	}
+
+	lm := resolver.GetLockManagerForHandle(string(handle))
+	if lm != nil {
+		t.Fatalf("GetLockManagerForHandle for a missing share must return a nil "+
+			"interface, got non-nil interface %#v (typed-nil regression)", lm)
+	}
+}
+
+// TestResolver_NilMetaSvc_ReturnsNil exercises the metaSvc==nil short-circuits.
+func TestResolver_NilMetaSvc_ReturnsNil(t *testing.T) {
+	resolver := &metadataServiceResolver{metaSvc: nil}
+
+	if lm := resolver.GetLockManagerForShare("/x"); lm != nil {
+		t.Fatalf("nil metaSvc must yield nil interface, got %#v", lm)
+	}
+	if lm := resolver.GetLockManagerForHandle("/x:00000000-0000-0000-0000-000000000001"); lm != nil {
+		t.Fatalf("nil metaSvc must yield nil interface, got %#v", lm)
+	}
+}


### PR DESCRIPTION
## Problem

Cross-run diff of the last ~8 `smbtorture` CI runs on develop showed the **memory** profile is clean (New Failures = 0 every run; all variance traced to the 4 already-fixed flakes + bench noise + the #739 lock-lease KNOWN_FAILURES addition + transient Docker registry 502s). But several **memory-fs** and **badger-fs** runs failed with large clusters of "new failures" (e.g. one memory-fs run reported 10).

Those clusters are not independent test failures. The DittoFS server **crashed with a SIGSEGV nil-pointer dereference mid-battery**, after which every subsequent `TREE_CONNECT` returned `STATUS_BAD_NETWORK_NAME` and the rest of the smbtorture suite could not connect (`Establishing SMB2 connection failed`) — so hundreds of tests "failed" as collateral.

Recovered stack traces (same signature across runs):

```
lock.(*Manager).breakOpLocks(0x0, ...)                         <- nil receiver
lock.(*Manager).BreakLeasesOnOpenConflict(0x0, ...)
lease.(*LeaseManager).BreakParentDirLeasesOnDestructiveCreate(0x0, ...)
handlers.(*Handler).completeCreateAfterBreak
```
and the close-path twin:
```
lock.(*Manager).signalBreakWait(0x0, ...)
lock.(*Manager).SignalParkedCreates(0x0, ...)
lease.(*LeaseManager).SignalParkedCreates
handlers.(*Handler).Close
```

## Root cause

`metadataServiceResolver.GetLockManagerForShare` / `GetLockManagerForHandle` (pkg/adapter/smb/adapter.go) returned `metaSvc.GetLockManagerForShare(shareName)` directly. That inner method returns a **concrete `*metadata.LockManager`** which is `nil` for a removed share. Returned through the `lock.LockManager` **interface** return type, a nil concrete pointer boxes into a **non-nil interface (typed nil)**.

Every lease path guards with `if lockMgr == nil { return nil }` — but a typed nil is `!= nil`, so the guard passes and the first method call nil-derefs the receiver.

The race window: the conformance battery (and `bench.*` in particular) deletes and recreates shares via the REST API mid-run. A CREATE/CLOSE that resolves the LockManager for a share being torn down gets the nil-pointer LockManager, slips past the guard, and panics.

This single boxing bug defeats **every** `lockMgr == nil` guard in `internal/adapter/smb/lease/manager.go` at once.

## Fix

Collapse the typed nil to a true nil interface at the single boxing boundary — a new private `lockManagerForShare` helper that both public resolver methods delegate to. The existing nil guards then fire as intended.

The NFS twin (`pkg/adapter/nfs/nlm.go`) is unaffected: it returns the concrete `*lock.Manager` (not the interface) and its caller nil-checks the concrete pointer, which works correctly.

## Test

`pkg/adapter/smb/resolver_nil_test.go` — asserts both resolver methods return a true nil interface for a missing share/handle (and the `metaSvc==nil` short-circuits). Verified to **fail without the fix** (`got non-nil interface (*lock.Manager)(nil)`) and pass with it.

## Gates

- `GOWORK=off go build ./...` green
- `GOWORK=off go test -race ./internal/adapter/smb/... ./pkg/adapter/smb/... ./pkg/metadata/...` green
- code-simplifier + code-reviewer run; simplifier collapsed the duplicated conversion into one helper, reviewer found no issues

## Not in scope (follow-up)

`smb2.multichannel.leases.test1` is a separate, lower-frequency flake (12 pass / 2 fail across the downloaded runs; one of the 2 was collateral from this crash). Its assertion is `lease_response.lease_version got 0x0 - should be 0x1` — an intermittent lease-V2 version edge on a multichannel cross-session open, not the nil-deref. It needs the smbtorture multichannel harness to reproduce deterministically and is **not** added to KNOWN_FAILURES (policy: fix flakes, don't silence). Worth a dedicated issue.