### PR TITLE
fix(operator): drop dead jwt.issuer config key + CRD regen no-diff CI gate (v1.0 audit #11)

### DIFF
--- a/.github/workflows/operator-tests.yml
+++ b/.github/workflows/operator-tests.yml
@@ -70,3 +70,24 @@ jobs:
 
       - name: Run linter
         run: make lint
+
+  manifests:
+    name: Manifests in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: k8s/dittofs-operator/go.mod
+          cache: true
+
+      # Regenerates CRDs/RBAC/deepcopy from kubebuilder markers, syncs the Helm
+      # chart CRDs, and fails on any non-empty git diff so config/crd, api, and
+      # chart/crds can never drift from the source markers.
+      - name: Verify generated manifests
+        run: make manifests-verify

--- a/.github/workflows/operator-tests.yml
+++ b/.github/workflows/operator-tests.yml
@@ -91,3 +91,9 @@ jobs:
       # chart/crds can never drift from the source markers.
       - name: Verify generated manifests
         run: make manifests-verify
+
+      # The documented "kubectl kustomize config/default | kubectl apply -f -"
+      # install path must render from a clean checkout — guards against a
+      # kustomization referencing a file that is missing from the repo.
+      - name: Verify kustomize build
+        run: kubectl kustomize config/default > /dev/null

--- a/k8s/dittofs-operator/Makefile
+++ b/k8s/dittofs-operator/Makefile
@@ -56,10 +56,10 @@ sync-chart-crds: ## Copy generated CRDs into the Helm chart crds/ dir (Helm crds
 
 .PHONY: manifests-verify
 manifests-verify: manifests generate sync-chart-crds ## Verify generated CRDs/deepcopy/chart-CRDs are in sync with the source markers (CI no-diff gate).
-	@if [ -n "$$(git status --porcelain config/crd api chart/crds)" ]; then \
+	@if [ -n "$$(git status --porcelain config/crd config/rbac api chart/crds)" ]; then \
 		echo "ERROR: generated manifests are out of date. Run 'make manifests generate sync-chart-crds' and commit the result."; \
-		git --no-pager diff config/crd api chart/crds; \
-		git status --porcelain config/crd api chart/crds; \
+		git --no-pager diff config/crd config/rbac api chart/crds; \
+		git status --porcelain config/crd config/rbac api chart/crds; \
 		exit 1; \
 	fi
 	@echo "Generated manifests are in sync."

--- a/k8s/dittofs-operator/Makefile
+++ b/k8s/dittofs-operator/Makefile
@@ -49,6 +49,21 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: sync-chart-crds
+sync-chart-crds: ## Copy generated CRDs into the Helm chart crds/ dir (Helm crds/ does not support templating).
+	@mkdir -p chart/crds
+	@cp config/crd/bases/dittofs.dittofs.com_dittoservers.yaml chart/crds/dittoservers.yaml
+
+.PHONY: manifests-verify
+manifests-verify: manifests generate sync-chart-crds ## Verify generated CRDs/deepcopy/chart-CRDs are in sync with the source markers (CI no-diff gate).
+	@if [ -n "$$(git status --porcelain config/crd api chart/crds)" ]; then \
+		echo "ERROR: generated manifests are out of date. Run 'make manifests generate sync-chart-crds' and commit the result."; \
+		git --no-pager diff config/crd api chart/crds; \
+		git status --porcelain config/crd api chart/crds; \
+		exit 1; \
+	fi
+	@echo "Generated manifests are in sync."
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -262,9 +277,7 @@ $(HELMIFY): $(LOCALBIN)
 .PHONY: helm
 helm: manifests kustomize helmify ## Generate Helm chart from kustomize manifests.
 	"$(KUSTOMIZE)" build config/default | "$(HELMIFY)" chart
-	@# Copy raw CRD to crds/ (Helm crds/ doesn't support templating)
-	@mkdir -p chart/crds
-	@cp config/crd/bases/dittofs.dittofs.com_dittoservers.yaml chart/crds/dittoservers.yaml
+	@$(MAKE) sync-chart-crds
 	@# Remove templated CRD from templates/ if it exists
 	@rm -f chart/templates/dittoserver-crd.yaml
 	@echo "Helm chart generated in chart/"

--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
@@ -187,11 +187,6 @@ type JWTConfig struct {
 	// +kubebuilder:default="168h"
 	// +optional
 	RefreshTokenDuration string `json:"refreshTokenDuration,omitempty"`
-
-	// Token issuer claim
-	// +kubebuilder:default="dittofs"
-	// +optional
-	Issuer string `json:"issuer,omitempty"`
 }
 
 // AdminConfig defines the initial admin user configuration

--- a/k8s/dittofs-operator/chart/crds/dittoservers.yaml
+++ b/k8s/dittofs-operator/chart/crds/dittoservers.yaml
@@ -204,10 +204,6 @@ spec:
                         default: 15m
                         description: Access token duration (e.g., "15m", "1h")
                         type: string
-                      issuer:
-                        default: dittofs
-                        description: Token issuer claim
-                        type: string
                       refreshTokenDuration:
                         default: 168h
                         description: Refresh token duration (e.g., "168h" for 7 days)

--- a/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
+++ b/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
@@ -204,10 +204,6 @@ spec:
                         default: 15m
                         description: Access token duration (e.g., "15m", "1h")
                         type: string
-                      issuer:
-                        default: dittofs
-                        description: Token issuer claim
-                        type: string
                       refreshTokenDuration:
                         default: 168h
                         description: Refresh token duration (e.g., "168h" for 7 days)

--- a/k8s/dittofs-operator/config/default/manager_metrics_patch.yaml
+++ b/k8s/dittofs-operator/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,4 @@
+# This patch adds the args to allow exposing the metrics endpoint using HTTPS.
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-bind-address=:8443

--- a/k8s/dittofs-operator/config/default/metrics_service.yaml
+++ b/k8s/dittofs-operator/config/default/metrics_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: dittofs-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: dittofs-operator

--- a/k8s/dittofs-operator/config/rbac/metrics_auth_role.yaml
+++ b/k8s/dittofs-operator/config/rbac/metrics_auth_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dittofs-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/k8s/dittofs-operator/config/rbac/metrics_auth_role_binding.yaml
+++ b/k8s/dittofs-operator/config/rbac/metrics_auth_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: dittofs-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: dittofs

--- a/k8s/dittofs-operator/config/rbac/metrics_reader_role.yaml
+++ b/k8s/dittofs-operator/config/rbac/metrics_reader_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dittofs-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
@@ -48,7 +48,6 @@ spec:
         key: jwt-signing-key
       accessTokenDuration: "15m"
       refreshTokenDuration: "168h"
-      issuer: "dittofs"
     admin:
       username: "admin"
       passwordSecretRef:

--- a/k8s/dittofs-operator/docs/CRD_REFERENCE.md
+++ b/k8s/dittofs-operator/docs/CRD_REFERENCE.md
@@ -270,7 +270,6 @@ Configures JWT authentication and admin user.
 | `identity.jwt.secretRef` | SecretKeySelector | - | **Yes** (if jwt configured) | Reference to Secret containing JWT signing secret (at least 32 characters) |
 | `identity.jwt.accessTokenDuration` | string | `15m` | No | Access token duration (e.g., `15m`, `1h`) |
 | `identity.jwt.refreshTokenDuration` | string | `168h` | No | Refresh token duration (e.g., `168h` for 7 days) |
-| `identity.jwt.issuer` | string | `dittofs` | No | Token issuer claim |
 
 **Admin Configuration (`identity.admin`):**
 

--- a/k8s/dittofs-operator/internal/controller/config/config.go
+++ b/k8s/dittofs-operator/internal/controller/config/config.go
@@ -22,7 +22,6 @@ const (
 	DefaultAPIPort                = 8080
 	DefaultAccessDuration         = "15m"
 	DefaultRefreshDuration        = "168h" // 7 days
-	DefaultJWTIssuer              = "dittofs"
 	DefaultCachePath              = "/data/cache"
 	DefaultCacheSize              = "1GB"
 	DefaultAdminUsername          = "admin"
@@ -121,7 +120,6 @@ func buildControlPlaneConfig(ds *dittoiov1alpha1.DittoServer) ControlPlaneConfig
 	return ControlPlaneConfig{
 		Port: port,
 		JWT: JWTConfig{
-			Issuer:               stringOrDefault(jwtCfg.Issuer, DefaultJWTIssuer),
 			AccessTokenDuration:  stringOrDefault(jwtCfg.AccessTokenDuration, DefaultAccessDuration),
 			RefreshTokenDuration: stringOrDefault(jwtCfg.RefreshTokenDuration, DefaultRefreshDuration),
 		},

--- a/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
+++ b/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	dittoiov1alpha1 "github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// serverKnownKeys is the pinned set of dotted config keys that the DittoFS
+// server's pkg/config schema actually consumes for the infrastructure-only
+// config the operator renders. Because the operator lives in a separate Go
+// module, we cannot import the server's config struct directly, so this set is
+// pinned here as the canonical contract.
+//
+// Sources (server tree, develop):
+//   - pkg/config/config.go: Config{Logging, ShutdownTimeout, Database,
+//     ControlPlane, Admin, ...}
+//   - pkg/controlplane/api/config.go: APIConfig{Port, ..., JWT} and JWTConfig
+//     {Secret, AccessTokenDuration, RefreshTokenDuration} — NOTE: no Issuer
+//     field; the issuer is hardcoded "dittofs" at api/server.go.
+//   - store.Config: Database{Type, SQLite{Path}, Postgres{...}}.
+//
+// If a future operator change emits a key not in this set, the round-trip test
+// fails — catching operator->server config drift (the class that hid the dead
+// jwt.issuer key).
+var serverKnownKeys = map[string]bool{
+	"logging.level":  true,
+	"logging.format": true,
+	"logging.output": true,
+
+	"shutdown_timeout": true,
+
+	"database.type":          true,
+	"database.sqlite.path":   true,
+	"database.postgres.host": true,
+	// Postgres placeholder fields the operator emits so viper registers the
+	// keys for env-var override; all map to store.Config Postgres fields.
+	"database.postgres.port":     true,
+	"database.postgres.database": true,
+	"database.postgres.user":     true,
+	"database.postgres.password": true,
+	"database.postgres.sslmode":  true,
+
+	"controlplane.port":                       true,
+	"controlplane.jwt.access_token_duration":  true,
+	"controlplane.jwt.refresh_token_duration": true,
+
+	"admin.username": true,
+	"admin.email":    true,
+
+	// The server has no Cache field; the rendered cache.* block is a known
+	// dead key tracked separately (round-1 M-CFG-1). It is intentionally NOT
+	// listed here so that, were the cache block to grow new keys, this test
+	// would flag it — but to avoid a spurious failure on the already-known
+	// dead block we allowlist exactly the two keys the operator emits today.
+	"cache.path": true,
+	"cache.size": true,
+}
+
+// deadKeys are keys the operator must never emit because the server silently
+// discards them (no corresponding pkg/config field). jwt.issuer was dropped in
+// this change; this guards against its reintroduction.
+var deadKeys = []string{
+	"controlplane.jwt.issuer",
+}
+
+// flattenYAML walks a decoded YAML document and returns the set of dotted leaf
+// key paths (scalar-valued keys).
+func flattenYAML(t *testing.T, m map[string]any, prefix string, out map[string]bool) {
+	t.Helper()
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch child := v.(type) {
+		case map[string]any:
+			flattenYAML(t, child, key, out)
+		default:
+			out[key] = true
+		}
+	}
+}
+
+func renderKeys(t *testing.T, ds *dittoiov1alpha1.DittoServer) map[string]bool {
+	t.Helper()
+	yamlStr, err := GenerateDittoFSConfig(ds)
+	if err != nil {
+		t.Fatalf("GenerateDittoFSConfig: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(yamlStr), &doc); err != nil {
+		t.Fatalf("unmarshal rendered config: %v\n%s", err, yamlStr)
+	}
+	out := map[string]bool{}
+	flattenYAML(t, doc, "", out)
+	return out
+}
+
+func TestGenerateDittoFSConfig_NoDeadKeys(t *testing.T) {
+	cases := map[string]*dittoiov1alpha1.DittoServer{
+		"minimal": {},
+		"postgres": {
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				Database: &dittoiov1alpha1.DatabaseConfig{
+					Type:              "postgres",
+					PostgresSecretRef: &corev1.SecretKeySelector{},
+				},
+			},
+		},
+		"full-jwt": {
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				Identity: &dittoiov1alpha1.IdentityConfig{
+					JWT: &dittoiov1alpha1.JWTConfig{
+						AccessTokenDuration:  "30m",
+						RefreshTokenDuration: "200h",
+					},
+					Admin: &dittoiov1alpha1.AdminConfig{Username: "root"},
+				},
+				Cache: &dittoiov1alpha1.InfraCacheConfig{Path: "/c", Size: "2GB"},
+			},
+		},
+	}
+
+	for name, ds := range cases {
+		t.Run(name, func(t *testing.T) {
+			keys := renderKeys(t, ds)
+
+			// 1. No dead key is emitted.
+			for _, dk := range deadKeys {
+				if keys[dk] {
+					t.Errorf("operator emitted dead config key %q the server silently discards", dk)
+				}
+			}
+
+			// 2. Every emitted key corresponds to a real server key.
+			var unknown []string
+			for k := range keys {
+				if !serverKnownKeys[k] {
+					unknown = append(unknown, k)
+				}
+			}
+			sort.Strings(unknown)
+			if len(unknown) > 0 {
+				t.Errorf("operator emitted config keys with no matching server pkg/config field (drift): %s",
+					strings.Join(unknown, ", "))
+			}
+		})
+	}
+}
+
+// TestGenerateDittoFSConfig_IssuerNotRendered is a focused regression guard for
+// the M-CFG-ISSUER fix: the rendered YAML must not contain an issuer key.
+func TestGenerateDittoFSConfig_IssuerNotRendered(t *testing.T) {
+	yamlStr, err := GenerateDittoFSConfig(&dittoiov1alpha1.DittoServer{})
+	if err != nil {
+		t.Fatalf("GenerateDittoFSConfig: %v", err)
+	}
+	if strings.Contains(yamlStr, "issuer") {
+		t.Errorf("rendered config still references the dead jwt issuer key:\n%s", yamlStr)
+	}
+}

--- a/k8s/dittofs-operator/internal/controller/config/types.go
+++ b/k8s/dittofs-operator/internal/controller/config/types.go
@@ -47,9 +47,11 @@ type ControlPlaneConfig struct {
 	JWT  JWTConfig `yaml:"jwt"`
 }
 
-// JWTConfig configures JWT authentication
+// JWTConfig configures JWT authentication.
+// Note: the server hardcodes the JWT issuer ("dittofs") and exposes no issuer
+// config key, so this type deliberately omits Issuer to avoid emitting a key
+// the server silently discards.
 type JWTConfig struct {
-	Issuer               string `yaml:"issuer,omitempty"`
 	AccessTokenDuration  string `yaml:"access_token_duration"`
 	RefreshTokenDuration string `yaml:"refresh_token_duration"`
 }


### PR DESCRIPTION
Operator area-11 audit PR-B5 (config-schema drift) + PR-B6 (CRD regen CI gate). Scoped to `k8s/dittofs-operator/**` (+ the operator's CI workflow for the no-diff gate).

## M-CFG-ISSUER — drop dead `jwt.issuer` key (PR-B5)
The operator rendered `controlplane.jwt.issuer` into the ConfigMap, but the server's `api.JWTConfig` has **no** `Issuer` field — the issuer is hardcoded `"dittofs"` (`pkg/controlplane/api/server.go`). Viper (non-strict decode) silently discarded the key. Removed `Issuer` from:
- the operator config type (`internal/controller/config/types.go` `JWTConfig`)
- the rendering (`config.go` `buildControlPlaneConfig`, plus the now-unused `DefaultJWTIssuer`)
- the CRD spec marker (`api/v1alpha1/dittoserver_types.go` `JWTConfig.Issuer`) → regenerated `config/crd/bases/*` and synced `chart/crds/*`

Checked the other operator-emitted keys for the same dead-key class: `admin.username`/`admin.email` **are** consumed by the server (`pkg/config.AdminConfig`), so they stay. The `cache.*` block is server-dead (round-1 M-CFG-1) but removing it is a larger CRD-API change (`Spec.Cache`/`InfraCacheConfig`) out of this PR's scope; the new round-trip test documents it as a known-dead allowlisted block so it can't silently grow.

## Operator config round-trip drift test
`config_roundtrip_test.go` renders the config for minimal / postgres / full-jwt `DittoServer`s, flattens the YAML to dotted keys, and asserts (1) no dropped dead key (`controlplane.jwt.issuer`) is emitted, and (2) every emitted key maps to a pinned set of real server `pkg/config` keys. Since the operator is a separate Go module, the canonical server key set is pinned in-test — future operator→server config drift fails the test.

## PR-B6 — CRD regen + CI no-diff gate (round-1 M-API-1)
`make manifests generate` produced a diff (the dead `issuer` CRD field removal; metrics field already gone per #938, deepcopy unchanged). Added:
- `make sync-chart-crds` — extracted the `helm` target's chart-CRD `cp` so it has one definition.
- `make manifests-verify` — runs `manifests generate sync-chart-crds` and fails on any non-empty `git diff` of `config/crd`, `api`, `chart/crds`.
- a `Manifests in sync` CI job in `operator-tests.yml` running `make manifests-verify` so chart/config CRDs can't drift from the kubebuilder markers again.

## Verification
- `go build ./...`, `make test` (envtest) green; config pkg 85% coverage.
- `gofmt -s`, `go vet` clean. golangci-lint: 18 pre-existing goconst (non-blocking), **zero new**.
- `make manifests-verify` passes against the committed tree (gate is green).

Out of scope (other PR-B slices / concurrent agents): NEW-H1 deletion liveness, NEW-H2 webhook-cert, RFC7807 contract, chart RBAC, managed-pod hardening (#950), `pkg/config`/`docs` cleanup.