### PR TITLE
test(smb): cover AES-256 encryption derivation, AEAD round-trip, and cipher selection (#686 / #340)

### DIFF
--- a/internal/adapter/smb/session/crypto_state_aead_test.go
+++ b/internal/adapter/smb/session/crypto_state_aead_test.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/encryption"
+	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// TestDeriveAllKeys_EncryptKeyLength asserts that the negotiated cipher ID
+// drives the encryption/decryption key length: 32 bytes for the AES-256
+// ciphers and 16 bytes for AES-128. This is the load-bearing switch for
+// AES-256 support — if the cipher ID does not select a 256-bit KDF output,
+// the server derives a 16-byte key but builds a 256-bit AEAD, which silently
+// produces ciphertext the client cannot decrypt (the IO_TIMEOUT failure mode).
+func TestDeriveAllKeys_EncryptKeyLength(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0xAB}, 16)
+	var preauth [64]byte
+	for i := range preauth {
+		preauth[i] = byte(i)
+	}
+
+	tests := []struct {
+		name       string
+		cipherID   uint16
+		wantKeyLen int
+	}{
+		{"AES-128-CCM", types.CipherAES128CCM, 16},
+		{"AES-128-GCM", types.CipherAES128GCM, 16},
+		{"AES-256-CCM", types.CipherAES256CCM, 32},
+		{"AES-256-GCM", types.CipherAES256GCM, 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := DeriveAllKeys(sessionKey, types.Dialect0311, preauth, tt.cipherID, signing.SigningAlgAESGMAC, true)
+
+			if got := len(cs.EncryptionKey); got != tt.wantKeyLen {
+				t.Errorf("EncryptionKey length = %d, want %d", got, tt.wantKeyLen)
+			}
+			if got := len(cs.DecryptionKey); got != tt.wantKeyLen {
+				t.Errorf("DecryptionKey length = %d, want %d", got, tt.wantKeyLen)
+			}
+			// Signing and application keys are always 128-bit regardless of cipher.
+			if got := len(cs.SigningKey); got != 16 {
+				t.Errorf("SigningKey length = %d, want 16", got)
+			}
+			if got := len(cs.ApplicationKey); got != 16 {
+				t.Errorf("ApplicationKey length = %d, want 16", got)
+			}
+		})
+	}
+}
+
+// TestDeriveAllKeys_AEADRoundTrip drives the full server path that smbtorture's
+// encryption-aes-* suites exercise: negotiated cipher ID -> SP800-108 KDF with
+// the correct L parameter -> AEAD construction with the derived key. It then
+// confirms a client encrypting with the client-to-server key produces ciphertext
+// the server's Decryptor (keyed on the same EncryptionKey) can open, for every
+// supported cipher. This catches a mismatch between the KDF key length and the
+// AEAD key length — the class of bug that makes AES-256 hang while AES-128 works.
+func TestDeriveAllKeys_AEADRoundTrip(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x5C}, 16)
+	var preauth [64]byte
+	for i := range preauth {
+		preauth[i] = byte(0xF0 ^ i)
+	}
+
+	ciphers := []struct {
+		name     string
+		cipherID uint16
+	}{
+		{"AES-128-CCM", types.CipherAES128CCM},
+		{"AES-128-GCM", types.CipherAES128GCM},
+		{"AES-256-CCM", types.CipherAES256CCM},
+		{"AES-256-GCM", types.CipherAES256GCM},
+	}
+
+	plaintext := []byte("smbtorture AES round-trip payload \x00\x01\x02 with binary bytes")
+
+	for _, tc := range ciphers {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := DeriveAllKeys(sessionKey, types.Dialect0311, preauth, tc.cipherID, signing.SigningAlgAESGMAC, true)
+			if err := cs.CreateEncryptors(tc.cipherID); err != nil {
+				t.Fatalf("CreateEncryptors: %v", err)
+			}
+
+			// The server's Decryptor opens client-to-server traffic and is keyed
+			// on EncryptionKey ("ServerIn"). Build a matching client-side encryptor
+			// from the same EncryptionKey to model the client encrypting a request.
+			clientEnc, err := encryption.NewEncryptor(tc.cipherID, cs.EncryptionKey)
+			if err != nil {
+				t.Fatalf("client NewEncryptor: %v", err)
+			}
+
+			aad := []byte("transform-header-AAD")
+			nonce, ciphertext, err := clientEnc.Encrypt(plaintext, aad)
+			if err != nil {
+				t.Fatalf("client Encrypt: %v", err)
+			}
+
+			got, err := cs.Decryptor.Decrypt(nonce, ciphertext, aad)
+			if err != nil {
+				t.Fatalf("server Decryptor.Decrypt: %v", err)
+			}
+			if !bytes.Equal(got, plaintext) {
+				t.Fatalf("decrypted payload mismatch:\n got = %q\nwant = %q", got, plaintext)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/v2/handlers/select_cipher_test.go
+++ b/internal/adapter/smb/v2/handlers/select_cipher_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// TestSelectCipher covers the NEGOTIATE cipher-selection path that decides
+// whether the server accepts AES-256. selectCipher honours the client's
+// preference order against the server's allowed set, so a client that lists
+// AES-256 first (and the server allows it) must end up on AES-256.
+func TestSelectCipher(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowedConfig []uint16 // nil = use built-in default (all four, AES-256 first)
+		clientCiphers []uint16
+		want          uint16
+	}{
+		{
+			name:          "default allowed, client prefers AES-256-GCM",
+			allowedConfig: nil,
+			clientCiphers: []uint16{types.CipherAES256GCM, types.CipherAES256CCM, types.CipherAES128GCM, types.CipherAES128CCM},
+			want:          types.CipherAES256GCM,
+		},
+		{
+			name:          "default allowed, client prefers AES-256-CCM",
+			allowedConfig: nil,
+			clientCiphers: []uint16{types.CipherAES256CCM, types.CipherAES128GCM},
+			want:          types.CipherAES256CCM,
+		},
+		{
+			name:          "default allowed, client prefers AES-128 first",
+			allowedConfig: nil,
+			clientCiphers: []uint16{types.CipherAES128GCM, types.CipherAES256GCM},
+			want:          types.CipherAES128GCM,
+		},
+		{
+			name:          "default allowed, client offers only AES-256-GCM",
+			allowedConfig: nil,
+			clientCiphers: []uint16{types.CipherAES256GCM},
+			want:          types.CipherAES256GCM,
+		},
+		{
+			name:          "server restricted to AES-128, client offers AES-256 first",
+			allowedConfig: []uint16{types.CipherAES128GCM, types.CipherAES128CCM},
+			clientCiphers: []uint16{types.CipherAES256GCM, types.CipherAES128GCM},
+			want:          types.CipherAES128GCM,
+		},
+		{
+			name:          "no mutual cipher",
+			allowedConfig: []uint16{types.CipherAES128CCM},
+			clientCiphers: []uint16{types.CipherAES256GCM, types.CipherAES256CCM},
+			want:          0,
+		},
+		{
+			name:          "empty client list",
+			allowedConfig: nil,
+			clientCiphers: nil,
+			want:          0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandler()
+			h.EncryptionConfig.AllowedCiphers = tt.allowedConfig
+
+			got := h.selectCipher(tt.clientCiphers)
+			if got != tt.want {
+				t.Errorf("selectCipher(%v) = 0x%04x, want 0x%04x", tt.clientCiphers, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the test-coverage gap behind the last two SMB3 encryption KNOWN_FAILURES rows, `smb2.encryption-aes-256-ccm` and `smb2.encryption-aes-256-gcm` (#686 / #340).

**Finding:** AES-256-CCM/GCM is already fully implemented on `develop`. There is no feature gap:

- NEGOTIATE advertises and prefers AES-256 (`defaultCipherPreference` and `DefaultAllowedCiphers` list `0x0003`/`0x0004` first), and `selectCipher` honours client preference order.
- The SP800-108 KDF derives 32-byte encryption/decryption keys for the AES-256 ciphers (`encKeyBits = 256` switch in `DeriveAllKeys`, `kdf.DeriveKey` with `L = 256`).
- The AEAD is built from the 32-byte derived key (`aes.NewCipher` selects AES-256 automatically); the transform-header and middleware paths are cipher-agnostic.

What was missing was an **end-to-end Go test** proving the negotiated cipher ID drives both the 256-bit KDF output and the matching AEAD — the exact class of bug (key-length / AEAD mismatch) that would have produced the reported IO_TIMEOUT hang. That absence is why the KNOWN_FAILURES rows persisted without verification.

## Tests added

- `TestDeriveAllKeys_EncryptKeyLength` — asserts 32-byte enc/dec keys for AES-256, 16-byte for AES-128; signing/application keys fixed at 128-bit.
- `TestDeriveAllKeys_AEADRoundTrip` — full `DeriveAllKeys -> CreateEncryptors -> AEAD encrypt/decrypt` round-trip for all four ciphers, modelling a client encrypting with the client-to-server key and the server decrypting with the derived key.
- `TestSelectCipher` — `selectCipher` selects AES-256 when the client prefers it, respects a server-restricted allowed set, and returns 0 when there is no mutual cipher.

AES-128 coverage is untouched and still passes. `go build ./...` and `go test -race ./internal/adapter/smb/...` are green.

The smbtorture `encryption-aes-256-*` suites require Linux/Docker and are the CI arbiter for clearing the KNOWN_FAILURES rows; the KF entries are intentionally left in place for the orchestrator to remove after CI confirms green.