### PR TITLE
fix(smb): correct AppInstanceId create-context name (flip durable-v2-open.app-instance)

### DIFF
--- a/internal/adapter/smb/v2/handlers/durable_context.go
+++ b/internal/adapter/smb/v2/handlers/durable_context.go
@@ -15,12 +15,20 @@ import (
 
 // Durable Handle Create Context tag constants [MS-SMB2] 2.2.13.2.
 const (
-	DurableHandleV1RequestTag          = "DHnQ"             // SMB2_CREATE_DURABLE_HANDLE_REQUEST
-	DurableHandleV1ReconnectTag        = "DHnC"             // SMB2_CREATE_DURABLE_HANDLE_RECONNECT (also V1 response tag)
-	DurableHandleV2RequestTag          = "DH2Q"             // SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2 (also V2 response tag)
-	DurableHandleV2ReconnectTag        = "DH2C"             // SMB2_CREATE_DURABLE_HANDLE_RECONNECT_V2
-	AppInstanceIdTag                   = "\x45\x17\xb6\x11" // SMB2_CREATE_APP_INSTANCE_ID
-	DH2FlagPersistent           uint32 = 0x00000002         // Persistent handle (not supported)
+	DurableHandleV1RequestTag          = "DHnQ"     // SMB2_CREATE_DURABLE_HANDLE_REQUEST
+	DurableHandleV1ReconnectTag        = "DHnC"     // SMB2_CREATE_DURABLE_HANDLE_RECONNECT (also V1 response tag)
+	DurableHandleV2RequestTag          = "DH2Q"     // SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2 (also V2 response tag)
+	DurableHandleV2ReconnectTag        = "DH2C"     // SMB2_CREATE_DURABLE_HANDLE_RECONNECT_V2
+	DH2FlagPersistent           uint32 = 0x00000002 // Persistent handle (not supported)
+
+	// AppInstanceIdTag is the 16-byte SMB2_CREATE_APP_INSTANCE_ID create-context
+	// name (MS-SMB2 2.2.13.2.8). Unlike DH2Q/RqLs, this name is a GUID, not a
+	// 4-byte ASCII tag; the value matches Samba SMB2_CREATE_TAG_APP_INSTANCE_ID.
+	// A prior 4-byte value never matched the on-wire name, so the AppInstanceId
+	// failover never fired: a same-AppInstanceId second open conflicted via an
+	// oplock break instead of silently displacing the first open
+	// (smb2.durable-v2-open.app-instance asserts break_info.count == 0).
+	AppInstanceIdTag = "\x45\xBC\xA6\x6A\xEF\xA7\xF7\x4A\x90\x08\xFA\x46\x2E\x14\x4D\x74" // SMB2_CREATE_APP_INSTANCE_ID
 )
 
 // DecodeDHnQRequest validates a V1 durable handle request (DHnQ).

--- a/internal/adapter/smb/v2/handlers/durable_context_test.go
+++ b/internal/adapter/smb/v2/handlers/durable_context_test.go
@@ -1014,6 +1014,27 @@ func TestOpenFile_DurableFields(t *testing.T) {
 	}
 }
 
+// TestAppInstanceIdTag_MatchesWireName pins AppInstanceIdTag to the exact
+// 16-byte SMB2_CREATE_APP_INSTANCE_ID create-context name (MS-SMB2 2.2.13.2.8,
+// Samba SMB2_CREATE_TAG_APP_INSTANCE_ID). This is a GUID, not a 4-byte ASCII
+// tag. A prior truncated value never matched the on-wire name, so the
+// AppInstanceId failover never fired and smb2.durable-v2-open.app-instance
+// failed (break_info.count == 1, expected 0). The other ProcessAppInstanceId
+// tests build their context from AppInstanceIdTag itself, so they cannot catch
+// a wrong constant — this guard asserts the literal wire bytes directly.
+func TestAppInstanceIdTag_MatchesWireName(t *testing.T) {
+	want := []byte{
+		0x45, 0xBC, 0xA6, 0x6A, 0xEF, 0xA7, 0xF7, 0x4A,
+		0x90, 0x08, 0xFA, 0x46, 0x2E, 0x14, 0x4D, 0x74,
+	}
+	if AppInstanceIdTag != string(want) {
+		t.Errorf("AppInstanceIdTag = %x, want %x", AppInstanceIdTag, want)
+	}
+	if len(AppInstanceIdTag) != 16 {
+		t.Errorf("AppInstanceIdTag length = %d, want 16 (GUID name)", len(AppInstanceIdTag))
+	}
+}
+
 func TestProcessAppInstanceId_NotPresent(t *testing.T) {
 	store := newMockDurableStore()
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -190,7 +190,6 @@ still fail due to incomplete reconnect, lease coordination, and persistence.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-v2-open.app-instance | Durable handles V2 | App instance ID not fully working | #739 |
 | smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
 | smb2.durable-v2-open.persistent-open-lease | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
 


### PR DESCRIPTION
## Summary

`smb2.durable-v2-open.app-instance` failed with `break_info.count was 1, expected 0` (durable_v2_open.c:4764).

**Root cause:** the `AppInstanceIdTag` create-context name constant was a wrong, truncated 4-byte value (`\x45\x17\xb6\x11`). SMB2_CREATE_APP_INSTANCE_ID (MS-SMB2 §2.2.13.2.8) is a **16-byte GUID** name, not a 4-byte ASCII tag like DH2Q/RqLs. With the wrong tag, `FindCreateContext` never matched the on-wire name, so the already-implemented AppInstanceId silent force-close in `ProcessAppInstanceId` never fired — a same-AppInstanceId second open conflicted via an oplock break instead of silently displacing the first open.

**Fix:** correct the constant to the canonical value (matches Samba `SMB2_CREATE_TAG_APP_INSTANCE_ID`). The force-close machinery already existed; only the tag was wrong.

## Verification

Confirmed via local docker smbtorture (`smbtorture/run.sh --filter smb2.durable-v2-open.app-instance`):
- before: `failure: app-instance` (break_info.count == 1)
- after: `success: app-instance`, New Failures 0, server log shows `ProcessAppInstanceId: force-closed live opens count=1`

## Tests

Added `TestAppInstanceIdTag_MatchesWireName` pinning the literal 16-byte wire value. The existing `ProcessAppInstanceId` tests build their context from the constant itself, so they could not catch a self-consistent wrong value.

## KF

Removed the now-passing `smb2.durable-v2-open.app-instance` row. CI smbtorture-memory self-verifies (New Failures must stay 0 with the row gone).

Closes part of #739.