### PR TITLE
fix(nfs/v4): never emit fileid 0 — fixes macOS NFSv4.1 mount kernel panic (#841)

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -260,6 +260,20 @@ func EncodePseudoFSAttrs(buf *bytes.Buffer, requested []uint32, node PseudoFSAtt
 	return nil
 }
 
+// nonZeroFileID guards against ever emitting a fileid of 0 on the wire.
+//
+// A fileid of 0 is illegal per RFC 7530: clients treat it as a "no such entry"
+// sentinel. The Linux client merely logs a buggy-server warning, but the macOS
+// NFS client builds its vnode keyed on the fileid and dereferences a NULL vnode
+// for fileid 0, kernel-panicking the machine. This is a cheap belt-and-suspenders
+// clamp covering any source (pseudo-fs root, HandleToINode edge) that yields 0.
+func nonZeroFileID(id uint64) uint64 {
+	if id == 0 {
+		return 1
+	}
+	return id
+}
+
 // encodeSingleAttr encodes a single attribute value into the buffer.
 func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) error {
 	switch bit {
@@ -328,8 +342,8 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 		return xdr.WriteXDROpaque(buf, node.GetHandle())
 
 	case FATTR4_FILEID:
-		// uint64: unique file identifier
-		return xdr.WriteUint64(buf, node.GetFileID())
+		// uint64: unique file identifier (never 0; see nonZeroFileID)
+		return xdr.WriteUint64(buf, nonZeroFileID(node.GetFileID()))
 
 	case FATTR4_MAXFILESIZE:
 		// uint64: maximum file size in bytes
@@ -404,8 +418,8 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 		return xdr.WriteUint32(buf, 0)
 
 	case FATTR4_MOUNTED_ON_FILEID:
-		// uint64: same as fileid for pseudo-fs nodes
-		return xdr.WriteUint64(buf, node.GetFileID())
+		// uint64: same as fileid for pseudo-fs nodes (never 0; see nonZeroFileID)
+		return xdr.WriteUint64(buf, nonZeroFileID(node.GetFileID()))
 
 	case FATTR4_SUPPATTR_EXCLCREAT:
 		// bitmap4: attributes that can be set atomically during EXCLUSIVE4_1 create.
@@ -554,7 +568,7 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, file *metadata.File, hand
 		return xdr.WriteXDROpaque(buf, []byte(handle))
 
 	case FATTR4_FILEID:
-		return xdr.WriteUint64(buf, metadata.HandleToINode(handle))
+		return xdr.WriteUint64(buf, nonZeroFileID(metadata.HandleToINode(handle)))
 
 	case FATTR4_MAXFILESIZE:
 		return xdr.WriteUint64(buf, fsMaxFileSize.Load())
@@ -635,7 +649,7 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, file *metadata.File, hand
 		return xdr.WriteUint32(buf, uint32(file.Mtime.Nanosecond()))
 
 	case FATTR4_MOUNTED_ON_FILEID:
-		return xdr.WriteUint64(buf, metadata.HandleToINode(handle))
+		return xdr.WriteUint64(buf, nonZeroFileID(metadata.HandleToINode(handle)))
 
 	case FATTR4_SUPPATTR_EXCLCREAT:
 		return EncodeBitmap4(buf, exclcreatAttrs())

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -368,3 +368,71 @@ func TestEncodePseudoFSAttrsMultipleAttributes(t *testing.T) {
 		t.Errorf("size = %d, want 0", size)
 	}
 }
+
+// TestNonZeroFileID verifies the wire-level guard that no fileid of 0 is ever
+// emitted. A fileid of 0 is illegal per RFC 7530 and kernel-panics the macOS
+// NFSv4.1 client (regression test for the pseudo-fs root fileid=0 crash).
+func TestNonZeroFileID(t *testing.T) {
+	if got := nonZeroFileID(0); got != 1 {
+		t.Errorf("nonZeroFileID(0) = %d, want 1", got)
+	}
+	for _, id := range []uint64{1, 2, 42, 1 << 40, ^uint64(0)} {
+		if got := nonZeroFileID(id); got != id {
+			t.Errorf("nonZeroFileID(%d) = %d, want %d (must pass through non-zero)", id, got, id)
+		}
+	}
+}
+
+// TestEncodePseudoFSAttrsFileIDNeverZero ensures a node whose GetFileID() yields
+// 0 is still encoded with a non-zero FATTR4_FILEID on the wire, so a buggy or
+// uninitialized source can never trigger the macOS fileid-0 panic.
+func TestEncodePseudoFSAttrsFileIDNeverZero(t *testing.T) {
+	var buf bytes.Buffer
+	node := &mockPseudoNode{
+		handle:   []byte("pseudofs:/"),
+		fsidMaj:  0,
+		fsidMin:  1,
+		fileID:   0, // deliberately zero
+		changeID: 1,
+		fileType: v4types.NF4DIR,
+	}
+
+	var requested []uint32
+	SetBit(&requested, FATTR4_FILEID)
+	SetBit(&requested, FATTR4_MOUNTED_ON_FILEID)
+
+	if err := EncodePseudoFSAttrs(&buf, requested, node); err != nil {
+		t.Fatalf("EncodePseudoFSAttrs failed: %v", err)
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+	responseBitmap, err := DecodeBitmap4(reader)
+	if err != nil {
+		t.Fatalf("decode response bitmap: %v", err)
+	}
+	if !IsBitSet(responseBitmap, FATTR4_FILEID) {
+		t.Fatal("FATTR4_FILEID not set in response bitmap")
+	}
+	if !IsBitSet(responseBitmap, FATTR4_MOUNTED_ON_FILEID) {
+		t.Fatal("FATTR4_MOUNTED_ON_FILEID not set in response bitmap")
+	}
+
+	var opaqueLen uint32
+	if err := binary.Read(reader, binary.BigEndian, &opaqueLen); err != nil {
+		t.Fatalf("read opaqueLen: %v", err)
+	}
+	// FILEID + MOUNTED_ON_FILEID = two uint64s, encoded in ascending bit order.
+	var fileID, mountedOnFileID uint64
+	if err := binary.Read(reader, binary.BigEndian, &fileID); err != nil {
+		t.Fatalf("read fileid: %v", err)
+	}
+	if err := binary.Read(reader, binary.BigEndian, &mountedOnFileID); err != nil {
+		t.Fatalf("read mounted_on_fileid: %v", err)
+	}
+	if fileID == 0 {
+		t.Error("FATTR4_FILEID encoded as 0 (illegal; crashes macOS client)")
+	}
+	if mountedOnFileID == 0 {
+		t.Error("FATTR4_MOUNTED_ON_FILEID encoded as 0 (illegal; crashes macOS client)")
+	}
+}

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -422,6 +422,9 @@ func TestEncodePseudoFSAttrsFileIDNeverZero(t *testing.T) {
 		t.Fatalf("read opaqueLen: %v", err)
 	}
 	// FILEID + MOUNTED_ON_FILEID = two uint64s, encoded in ascending bit order.
+	if opaqueLen != 16 {
+		t.Fatalf("attr data length = %d, want 16 (two uint64s)", opaqueLen)
+	}
 	var fileID, mountedOnFileID uint64
 	if err := binary.Read(reader, binary.BigEndian, &fileID); err != nil {
 		t.Fatalf("read fileid: %v", err)

--- a/internal/adapter/nfs/v4/pseudofs/pseudofs.go
+++ b/internal/adapter/nfs/v4/pseudofs/pseudofs.go
@@ -115,14 +115,22 @@ func New() *PseudoFS {
 		nextID:   1, // Start at 1, reserve 0
 	}
 
-	// Create root node
+	// Create root node.
+	//
+	// FileID MUST be non-zero. A fileid of 0 is illegal per RFC 7530: clients
+	// use it as a "no such entry" sentinel. The Linux client tolerates it (logs
+	// a buggy-server warning and continues), but the macOS NFSv4.1 client builds
+	// its vnode keyed on the fileid and dereferences a NULL vnode for fileid 0,
+	// kernel-panicking the whole machine on the very first GETATTR at mount.
+	// nextID starts at 1 and children take atomic.AddUint64 (>= 2), so 1 is
+	// reserved exclusively for the root and never collides with a child.
 	rootHandle := makeHandle("/")
 	pfs.root = &PseudoNode{
 		Name:     "",
 		Path:     "/",
 		Handle:   rootHandle,
 		Children: make(map[string]*PseudoNode),
-		FileID:   0, // Root gets FileID 0
+		FileID:   1, // see comment above: must be non-zero, 1 reserved for root
 	}
 	// Root's parent is itself per NFSv4 spec
 	pfs.root.Parent = pfs.root

--- a/internal/adapter/nfs/v4/pseudofs/pseudofs_test.go
+++ b/internal/adapter/nfs/v4/pseudofs/pseudofs_test.go
@@ -482,3 +482,37 @@ func TestFileIDStability(t *testing.T) {
 		t.Errorf("FileID changed after rebuild: %d -> %d", originalFileID, exportNode2.GetFileID())
 	}
 }
+
+// TestNodeFileIDsNonZeroAndUnique guards the macOS NFSv4.1 mount crash: a
+// fileid of 0 is illegal per RFC 7530 and null-derefs the macOS NFS client
+// (kernel panic on the first GETATTR at mount). The root must use fileid 1, and
+// every node across the tree must have a unique, non-zero fileid.
+func TestNodeFileIDsNonZeroAndUnique(t *testing.T) {
+	pfs := New()
+
+	// Fresh root, before any shares.
+	root, ok := pfs.LookupByHandle(pfs.GetRootHandle())
+	if !ok {
+		t.Fatal("root node not found")
+	}
+	if root.FileID == 0 {
+		t.Fatal("root FileID is 0 (illegal; kernel-panics macOS NFSv4.1 client at mount)")
+	}
+	if root.FileID != 1 {
+		t.Errorf("root FileID = %d, want 1", root.FileID)
+	}
+
+	// Build a tree with nested shares and assert non-zero + unique across all nodes.
+	pfs.Rebuild([]string{"/share", "/data/archive", "/data/cold"})
+
+	seen := make(map[uint64]string)
+	for _, node := range pfs.byHandle {
+		if node.FileID == 0 {
+			t.Errorf("node %q has FileID 0 (illegal; crashes macOS client)", node.Path)
+		}
+		if other, dup := seen[node.FileID]; dup {
+			t.Errorf("FileID %d reused by %q and %q (must be unique)", node.FileID, other, node.Path)
+		}
+		seen[node.FileID] = node.Path
+	}
+}

--- a/internal/adapter/nfs/v4/pseudofs/pseudofs_test.go
+++ b/internal/adapter/nfs/v4/pseudofs/pseudofs_test.go
@@ -506,6 +506,7 @@ func TestNodeFileIDsNonZeroAndUnique(t *testing.T) {
 	pfs.Rebuild([]string{"/share", "/data/archive", "/data/cold"})
 
 	seen := make(map[uint64]string)
+	pfs.mu.RLock()
 	for _, node := range pfs.byHandle {
 		if node.FileID == 0 {
 			t.Errorf("node %q has FileID 0 (illegal; crashes macOS client)", node.Path)
@@ -515,4 +516,5 @@ func TestNodeFileIDsNonZeroAndUnique(t *testing.T) {
 		}
 		seen[node.FileID] = node.Path
 	}
+	pfs.mu.RUnlock()
 }


### PR DESCRIPTION
## Summary

Mounting a DittoFS share over **NFSv4.1 from a macOS client kernel-panics the machine** (null-deref in `com.apple.filesystems.nfs`, reproduced deterministically). Root cause found via a **Linux NFSv4.1 wire capture** (safe — never reproduced on macOS): the pseudo-fs **root** node's GETATTR returns `FATTR4_FILEID = 0` (and `FATTR4_MOUNTED_ON_FILEID = 0`).

A fileid of `0` is illegal per RFC 7530 — clients use it as a "no such entry" sentinel. The Linux client tolerates it (logs a buggy-server warning and continues); the **macOS** client builds its vnode keyed on the fileid and dereferences a NULL vnode for fileid 0. `PUTROOTFH`+`GETATTR` is the very first thing macOS does at mount → "immediate panic on mount."

## Evidence (Linux v4.1 pcap, before fix)

```
Opcode: GETATTR (9)   # FH = pseudofs:/  (root)
    reco_attr: FileId (20)
        fileid: 0                       <-- illegal
    reco_attr: Mounted_on_FileId (55)
        fileid: 0x0000000000000000      <-- illegal
```

## Fix

- **`pseudofs.go`** — root node `FileID` `0 → 1`. `nextID` starts at 1 and children take `atomic.AddUint64` (≥ 2), so `1` is reserved exclusively for the root and never collides.
- **`encode.go`** — added `nonZeroFileID()` and applied it at `FATTR4_FILEID` and `FATTR4_MOUNTED_ON_FILEID` in **both** the pseudo-fs and real-fs encode paths (defensive belt-and-suspenders; also covers a theoretical `metadata.HandleToINode(handle) == 0` edge).
- Regression tests: `TestNonZeroFileID`, `TestEncodePseudoFSAttrsFileIDNeverZero`, `TestNodeFileIDsNonZeroAndUnique`.

## Validation

Re-captured a fresh Linux v4.1 mount **after** the fix — root now reports `fileid: 1`, `mounted_on_fileid: 1`; `mount` + `ls` + `mkdir` + `read`/`write` all succeed.

```
go build ./...                                  # ok
go test ./internal/adapter/nfs/...              # ok
golangci-lint run ./internal/adapter/nfs/v4/... # 0 issues
```

Diagnosis was source + wire only; **no macOS mount was ever performed** (it hard-crashes the host).

Fixes #841