### PR TITLE
fix(smb/acls): best-effort GENERIC_READ/EXECUTE under MAXIMUM_ALLOWED

### DIFF
--- a/internal/adapter/smb/v2/handlers/create.go
+++ b/internal/adapter/smb/v2/handlers/create.go
@@ -58,6 +58,13 @@ type CreateRequest struct {
 	//   - 0x120116: Generic write
 	DesiredAccess uint32
 
+	// GenericDerivedAccess holds the file-specific bits that DesiredAccess
+	// gained purely from GENERIC_* expansion at decode time (see
+	// acl.GenericDerivedBits). Under SEC_FLAG_MAXIMUM_ALLOWED these bits are
+	// best-effort and excluded from the strict explicit-bit enforcement gate,
+	// matching Samba (smb2.maximum_allowed vs smb2.acls.MXAC-NOT-GRANTED).
+	GenericDerivedAccess uint32
+
 	// FileAttributes specifies initial file attributes for new files.
 	// Common values:
 	//   - FileAttributeNormal (0x80): Normal file
@@ -209,6 +216,11 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 	// evaluation. Do it at decode time so every downstream consumer
 	// (permission checks, share-mode conflict, MxAc, OpenFile bookkeeping)
 	// observes resolved bits.
+	//
+	// Capture the bits introduced by GENERIC_* expansion BEFORE stripping the
+	// generic flags, so the MAXIMUM_ALLOWED access-check can treat them as
+	// best-effort (excluded from strict explicit-bit enforcement) per Samba.
+	genericDerivedAccess := acl.GenericDerivedBits(desiredAccess)
 	desiredAccess = acl.ExpandGenericMask(desiredAccess)
 	fileAttributes := types.FileAttributes(r.ReadUint32())       // FileAttributes (4)
 	shareAccess := r.ReadUint32()                                // ShareAccess (4)
@@ -221,13 +233,14 @@ func DecodeCreateRequest(body []byte) (*CreateRequest, error) {
 	}
 
 	req := &CreateRequest{
-		OplockLevel:        oplockLevel,
-		ImpersonationLevel: impersonationLevel,
-		DesiredAccess:      desiredAccess,
-		FileAttributes:     fileAttributes,
-		ShareAccess:        shareAccess,
-		CreateDisposition:  createDisposition,
-		CreateOptions:      createOptions,
+		OplockLevel:          oplockLevel,
+		ImpersonationLevel:   impersonationLevel,
+		DesiredAccess:        desiredAccess,
+		GenericDerivedAccess: genericDerivedAccess,
+		FileAttributes:       fileAttributes,
+		ShareAccess:          shareAccess,
+		CreateDisposition:    createDisposition,
+		CreateOptions:        createOptions,
 	}
 
 	// Extract filename (UTF-16LE encoded)

--- a/internal/adapter/smb/v2/handlers/create_post_break.go
+++ b/internal/adapter/smb/v2/handlers/create_post_break.go
@@ -474,7 +474,7 @@ func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint3
 		// receives, so a DACL that grants only READ_DATA fails OVERWRITE /
 		// OVERWRITE_IF / SUPERSEDE with STATUS_ACCESS_DENIED. Covers
 		// smb2.acls.OVERWRITE_READ_ONLY_FILE fs_tcases arm (#565).
-		granted, err := metaSvc.CheckFileAccessWithParent(existingFile, parentFile, authCtx, effectiveAccess)
+		granted, err := metaSvc.CheckFileAccessWithParentGeneric(existingFile, parentFile, authCtx, effectiveAccess, req.GenericDerivedAccess)
 		if err != nil {
 			logger.Debug("CREATE: DesiredAccess denied by DACL",
 				"path", filename,

--- a/pkg/metadata/acl/generic.go
+++ b/pkg/metadata/acl/generic.go
@@ -116,3 +116,34 @@ func ExpandGenericMask(mask uint32) uint32 {
 
 	return expanded
 }
+
+// GenericDerivedBits returns the file-specific rights introduced by the
+// best-effort GENERIC_* bits in mask — GENERIC_READ and GENERIC_EXECUTE only.
+//
+// This matters under SEC_FLAG_MAXIMUM_ALLOWED. Samba's max_allowed.c ok_mask is
+//
+//	SEC_RIGHTS_FILE_READ | SEC_GENERIC_READ | SEC_GENERIC_EXECUTE |
+//	SEC_STD_DELETE | SEC_STD_WRITE_DAC
+//
+// so a MAX open naming GENERIC_READ or GENERIC_EXECUTE succeeds even when the
+// DACL does not grant every mapped specific right (e.g. GENERIC_EXECUTE maps to
+// FILE_EXECUTE, which a read-only DACL lacks, yet the open is OK —
+// smb2.maximum_allowed.maximum_allowed). GENERIC_WRITE and GENERIC_ALL are NOT
+// in ok_mask: a MAX open naming them must still be DENIED when their mapped
+// specific rights aren't granted, so their expansion is left under the strict
+// gate and is NOT reported here.
+//
+// Directly-named specific rights are likewise never reported — those remain
+// strictly enforced (smb2.acls.MXAC-NOT-GRANTED, #564). Callers subtract this
+// set from the explicit mask before the MAX strict-enforcement check.
+func GenericDerivedBits(mask uint32) uint32 {
+	bestEffortGeneric := mask & (genericRead | genericExecute)
+	if bestEffortGeneric == 0 {
+		return 0
+	}
+	named := mask &^ (genericRead | genericWrite | genericExecute | genericAll)
+	// Only the rights that the best-effort generics introduce beyond what was
+	// named directly (and beyond what GENERIC_WRITE/ALL would contribute, which
+	// stay enforced).
+	return ExpandGenericMask(bestEffortGeneric) &^ named
+}

--- a/pkg/metadata/acl/generic_test.go
+++ b/pkg/metadata/acl/generic_test.go
@@ -111,3 +111,37 @@ func TestExpandGenericMask_Idempotent(t *testing.T) {
 		}
 	}
 }
+
+// TestGenericDerivedBits verifies the best-effort set used to relax the
+// MAXIMUM_ALLOWED strict explicit-bit gate: only bits introduced by GENERIC_*
+// expansion are reported, never bits the caller named as specific rights.
+func TestGenericDerivedBits(t *testing.T) {
+	const (
+		genReadExpanded    = uint32(0x00120089)
+		genExecuteExpanded = uint32(0x001200A0)
+	)
+	tests := []struct {
+		name string
+		in   uint32
+		want uint32
+	}{
+		{"no generic, specific only", 0x00000001, 0},
+		{"GENERIC_READ only -> full read set", 0x80000000, genReadExpanded},
+		{"GENERIC_EXECUTE only -> full execute set", 0x20000000, genExecuteExpanded},
+		// GENERIC_WRITE and GENERIC_ALL are NOT best-effort (not in Samba's
+		// ok_mask): their mapped bits stay under the strict gate.
+		{"GENERIC_WRITE only -> nothing derived", 0x40000000, 0},
+		{"GENERIC_ALL only -> nothing derived", 0x10000000, 0},
+		// A directly-named specific bit combined with a generic bit: the named
+		// bit is NOT generic-derived even though expansion also yields it.
+		{"GENERIC_READ | named READ_DATA -> READ_DATA excluded", 0x80000000 | 0x00000001, genReadExpanded &^ 0x00000001},
+		{"named WRITE_DATA only -> nothing derived", 0x00000002, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenericDerivedBits(tt.in); got != tt.want {
+				t.Errorf("GenericDerivedBits(0x%08x) = 0x%08x, want 0x%08x", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -701,6 +701,21 @@ func (s *MetadataService) CheckFileAccess(file *File, authCtx *AuthContext, desi
 //
 // When parent is nil, behavior is identical to CheckFileAccess.
 func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error) {
+	return s.CheckFileAccessWithParentGeneric(file, parent, authCtx, desiredAccess, 0)
+}
+
+// CheckFileAccessWithParentGeneric is CheckFileAccessWithParent with explicit
+// knowledge of which specific bits in desiredAccess were introduced by GENERIC_*
+// expansion (genericDerived). Under SEC_FLAG_MAXIMUM_ALLOWED those bits are
+// best-effort: the strict explicit-bit enforcement gate (which fails the open
+// when a DIRECTLY-named specific right is denied — smb2.acls.MXAC-NOT-GRANTED)
+// excludes them. This matches Samba, where MAX|GENERIC_EXECUTE against a
+// read-only DACL succeeds (smb2.maximum_allowed.maximum_allowed) but
+// MAX|FILE_WRITE_DATA against the same DACL is denied.
+//
+// genericDerived is expected to already be in file-object-specific terms (see
+// acl.GenericDerivedBits). Pass 0 when the caller has no generic bits to expand.
+func (s *MetadataService) CheckFileAccessWithParentGeneric(file *File, parent *File, authCtx *AuthContext, desiredAccess, genericDerived uint32) (uint32, error) {
 	maximumAllowed := desiredAccess&accessMaskMaximumAllowed != 0
 	// Expand MS-DTYP §2.4.3 GENERIC_* bits to their file-object-specific
 	// rights before the subset checks below (MS-DTYP §2.5.3 / MS-FSA
@@ -712,6 +727,13 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 	// actually permits (smb2.maximum_allowed). ExpandGenericMask strips the
 	// generic bits and leaves MAXIMUM_ALLOWED untouched.
 	explicit := acl.ExpandGenericMask(desiredAccess &^ accessMaskMaximumAllowed)
+
+	// Fold any GENERIC_* bits still present in the raw request into the
+	// best-effort set. Production callers pre-expand generics and pass the
+	// derived bits explicitly (effectiveAccess no longer carries the raw
+	// generic flags); direct callers that pass an un-expanded mask are handled
+	// here. Either way the MAX strict-enforcement gate below excludes these.
+	genericDerived |= acl.GenericDerivedBits(desiredAccess &^ accessMaskMaximumAllowed)
 
 	// Root bypass: identical semantics to computeMaximalAccess and
 	// evaluateACLPermissions. UID 0 gets everything; MAXIMUM_ALLOWED resolves
@@ -833,7 +855,16 @@ func (s *MetadataService) CheckFileAccessWithParent(file *File, parent *File, au
 		// MAXIMUM_ALLOWED suppresses denial only for the bits IMPLICITLY
 		// requested via the MAX flag itself, not for bits the caller named
 		// outright. Covers smb2.acls.MXAC-NOT-GRANTED.
-		if explicit != 0 && effective&explicit != explicit {
+		//
+		// Bits introduced by GENERIC_* expansion are NOT directly-named rights:
+		// Samba maps generic→specific only for the best-effort maximal set and
+		// never strict-enforces the mapped bits under MAXIMUM_ALLOWED. So
+		// MAX|GENERIC_EXECUTE (expands to FILE_EXECUTE|... which a read-only DACL
+		// lacks) still succeeds — smb2.maximum_allowed.maximum_allowed — while
+		// MAX|FILE_WRITE_DATA (a directly-named specific bit) is denied. Exclude
+		// the generic-derived bits from the strict gate to honor both.
+		named := explicit &^ genericDerived
+		if named != 0 && effective&named != named {
 			return effective, &StoreError{
 				Code:    ErrAccessDenied,
 				Message: "explicit non-MAXIMUM_ALLOWED bit denied by file DACL",

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -37,6 +37,7 @@ const (
 	rightGenericRead    uint32 = 0x80000000
 	rightGenericWrite   uint32 = 0x40000000
 	rightGenericExecute uint32 = 0x20000000
+	rightGenericAll     uint32 = 0x10000000
 )
 
 // TestCheckFileAccess_DenyACEOnOwnerDeniesWrite covers smbtorture acls.OWNER /
@@ -800,24 +801,76 @@ func TestCheckFileAccess_MaximumAllowedPlusGenericExecuteGranted(t *testing.T) {
 	require.Zero(t, granted&uint32(0xF0000000), "granted mask must not retain raw GENERIC_* bits, got 0x%x", granted)
 }
 
-// TestCheckFileAccess_MaximumAllowedPlusGenericReadDeniedTrueControl is the
-// true-deny control for the GENERIC_* expansion fix: GENERIC_READ expands to a
-// set that includes specific READ rights, but the DACL here grants only
-// WRITE_DATA. The expanded explicit READ bits are not in the DACL, so the open
-// MUST still be denied — proving the expansion does not blanket-grant.
-func TestCheckFileAccess_MaximumAllowedPlusGenericReadDeniedTrueControl(t *testing.T) {
+// TestCheckFileAccess_MaximumAllowedPlusGenericReadBestEffort proves that
+// GENERIC_* bits are best-effort under MAXIMUM_ALLOWED: MAX|GENERIC_READ against
+// a DACL that grants only WRITE_DATA must SUCCEED, granting only what the DACL
+// allows rather than failing because the GENERIC_READ-expanded READ rights are
+// absent. This matches Samba's se_access_check, where the MAXIMUM_ALLOWED branch
+// computes the maximal grantable set and never strict-enforces generic-derived
+// bits (smb2.maximum_allowed.maximum_allowed grants MAX|GENERIC_EXECUTE on a
+// read-only DACL). The strict explicit-bit gate (smb2.acls.MXAC-NOT-GRANTED)
+// applies only to DIRECTLY-named specific rights — see
+// TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies.
+func TestCheckFileAccess_MaximumAllowedPlusGenericReadBestEffort(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterSID := "S-1-5-21-1-2-3-2001"
-	// DACL grants ONLY WRITE_DATA — none of the GENERIC_READ specific rights
-	// (other than the always-granted READ_ATTRIBUTES from the parent).
-	created := createSpecificRightsFile(t, f, "max_generic_read_deny.txt", requesterSID, acl.ACE4_WRITE_DATA)
+	// DACL grants ONLY WRITE_DATA — none of the GENERIC_READ specific rights.
+	created := createSpecificRightsFile(t, f, "max_generic_read_best_effort.txt", requesterSID, acl.ACE4_WRITE_DATA)
 
 	authCtx := f.authContext(1001, 1001)
 	authCtx.Identity.SID = strPtr(requesterSID)
 
-	_, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericRead)
-	require.Error(t, err, "MAXIMUM_ALLOWED|GENERIC_READ against a WRITE-only DACL must deny")
+	granted, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericRead)
+	require.NoError(t, err, "MAXIMUM_ALLOWED|GENERIC_READ is best-effort: generic-derived bits never force a denial")
+	require.NotZero(t, granted&acl.ACE4_WRITE_DATA, "expected the DACL-granted WRITE_DATA in granted mask, got 0x%x", granted)
+	require.Zero(t, granted&acl.ACE4_READ_DATA, "READ_DATA is not granted by the DACL and must not appear, got 0x%x", granted)
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusGenericAllStrictlyEnforced proves the
+// best-effort relaxation is scoped to GENERIC_READ / GENERIC_EXECUTE only.
+// GENERIC_ALL (and GENERIC_WRITE) are NOT in Samba's max_allowed.c ok_mask, so a
+// MAX open naming GENERIC_ALL against a read-only DACL must DENY when the mapped
+// write/all-access rights aren't granted. Without this, the GENERIC_ALL open in
+// smb2.maximum_allowed.maximum_allowed (i=28) would wrongly succeed, leave a
+// share-conflicting handle open, and break the subsequent set_sd WRITE_DAC open
+// with STATUS_SHARING_VIOLATION (max_allowed.c:197).
+func TestCheckFileAccess_MaximumAllowedPlusGenericAllStrictlyEnforced(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// FILE_GENERIC_READ specific-rights set only — no WRITE/EXECUTE/owner rights.
+	readMask := uint32(acl.ACE4_READ_DATA | acl.ACE4_READ_NAMED_ATTRS |
+		acl.ACE4_READ_ATTRIBUTES | acl.ACE4_READ_ACL | acl.ACE4_SYNCHRONIZE)
+	created := createSpecificRightsFile(t, f, "max_generic_all_deny.txt", requesterSID, readMask)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	_, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|rightGenericAll)
+	require.Error(t, err, "MAXIMUM_ALLOWED|GENERIC_ALL against a READ-only DACL must deny — GENERIC_ALL is not best-effort")
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+}
+
+// TestCheckFileAccess_MaximumAllowedPlusExplicitWriteDeniedStillDenies is the
+// companion true-deny control: a DIRECTLY-named specific right (FILE_WRITE_DATA,
+// no generic expansion involved) that the DACL denies must still fail under
+// MAXIMUM_ALLOWED. Guards against the best-effort relaxation leaking into the
+// strict explicit-bit gate (smb2.acls.MXAC-NOT-GRANTED, #564).
+func TestCheckFileAccess_MaximumAllowedPlusExplicitWriteDeniedStillDenies(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterSID := "S-1-5-21-1-2-3-2001"
+	// DACL grants ONLY READ_DATA; the request names WRITE_DATA explicitly.
+	created := createSpecificRightsFile(t, f, "max_explicit_write_deny.txt", requesterSID, acl.ACE4_READ_DATA)
+
+	authCtx := f.authContext(1001, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+
+	_, err := f.service.CheckFileAccess(created, authCtx, rightMaxAllowed|uint32(acl.ACE4_WRITE_DATA))
+	require.Error(t, err, "MAXIMUM_ALLOWED|FILE_WRITE_DATA against a READ-only DACL must deny the directly-named bit")
 	var storeErr *metadata.StoreError
 	require.ErrorAs(t, err, &storeErr)
 	require.Equal(t, metadata.ErrAccessDenied, storeErr.Code)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -132,15 +132,6 @@ Advanced share mode enforcement and deny mode scenarios.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 
-### Maximum Allowed Access (Partial)
-
-Maximum allowed access computation is partially implemented. Read-only
-maximum_allowed works but full computation does not.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.maximum_allowed.maximum_allowed | Access checks | Full maximum allowed computation not implemented | #750 |
-
 ### Character Set (Edge Cases)
 
 Unicode and character set edge cases (partial surrogates, wide-A collision) are


### PR DESCRIPTION
## Problem

`smb2.maximum_allowed.maximum_allowed` failed against DittoFS. The test opens the file with `MAXIMUM_ALLOWED | (1<<i)` for each access bit and expects `NT_STATUS_OK` whenever the named bit is in Samba's `ok_mask`:

```
SEC_RIGHTS_FILE_READ | SEC_GENERIC_READ | SEC_GENERIC_EXECUTE | SEC_STD_DELETE | SEC_STD_WRITE_DAC
```

DittoFS strict-enforced *every* specific bit under `MAXIMUM_ALLOWED`. A `MAX | GENERIC_EXECUTE` open against a read-only DACL was therefore denied: generic expansion adds `FILE_EXECUTE`, which a read-only DACL lacks, and the open-time gate required the whole expanded set to be granted. The test (and Samba) expect this open to succeed.

Root cause confirmed via local docker smbtorture + byte-level trace: the computed maximal set (`0x170089`) already matched Samba exactly (owner-implied `WRITE_DAC`/`READ_CONTROL` + parent `FILE_DELETE_CHILD`); the only defect was the strict gate denying generic-expanded bits.

## Fix

Per Samba's `smbd_calculate_access_mask_fsp`, generic bits are mapped to specific rights only for the best-effort maximal set and are never strict-enforced under `MAXIMUM_ALLOWED`. This change treats the bits introduced by `GENERIC_READ` / `GENERIC_EXECUTE` expansion as best-effort and excludes them from the MAX strict-enforcement gate, while:

- keeping **directly-named specific rights** strictly enforced — `MAX | FILE_WRITE_DATA` against a read-only DACL still denies (`smb2.acls.MXAC-NOT-GRANTED`, #564);
- keeping **GENERIC_WRITE / GENERIC_ALL** enforced — they are *not* in Samba's `ok_mask`, so `MAX | GENERIC_ALL` against a read-only DACL still denies (without this, a leaked handle broke the subsequent `set_sd` open with `STATUS_SHARING_VIOLATION` at `max_allowed.c:197`).

The SMB CREATE decode records the generic-derived bits before stripping the generic flags and threads them to a new `CheckFileAccessWithParentGeneric`. The metadata layer also recomputes the best-effort set from any raw generic bits still present, so direct/2-arg callers stay correct.

## Validation

Docker smbtorture (the authoritative harness), both green, no new failures:

- `smb2.maximum_allowed` → `success: maximum_allowed`, `success: read_only`, New failures: 0
- `smb2.acls` → 14 passed, New failures: 0 (incl. `MXAC-NOT-GRANTED`, `GENERIC`, `OWNER`, `CREATOR`)

Unit tests added/updated in `pkg/metadata/acl` and `pkg/metadata` covering best-effort `GENERIC_READ`/`EXECUTE`, enforced `GENERIC_WRITE`/`GENERIC_ALL`, and directly-named `WRITE_DATA` denial.

Removes the `smb2.maximum_allowed.maximum_allowed` row from `KNOWN_FAILURES.md`.