### PR TITLE
test(smb): walk back smb2.ioctl.copy_chunk_sparse_dest (now passing)

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-05-29 (#743 follow-up — walk back the 6 `smb2.dirlease.*` residuals now PASSing post PR #784: hardlink, rename, unlink_{same,different}_{initial,set}_and_close, v2_request)
+Last updated: 2026-06-02 (walk back `smb2.ioctl.copy_chunk_sparse_dest` — now PASSing on develop; copychunk to a 0-byte dest at offset 4096 surfaces the [0,4096) hole as zeros via the block store's implicit zero-grow. Covered by Go test `TestCopyChunk_SparseDest_LeadingGapReadsZeros`)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -57,16 +57,12 @@ not advertised — they consume no failure slots and are not listed below.
 The compress_notsup_get/set tests correctly SKIP because FILE_FILE_COMPRESSION
 is advertised.
 
-Most IOCTL sparse-family entries walked back under #718. The remaining residual
-failure is a real feature gap: SRV_COPYCHUNK on a sparse destination must surface
-zeros for the unwritten hole between the old EOF and the chunk's target offset
-(see Samba `test_ioctl_copy_chunk_sparse_dest`). DittoFS's copychunk path grows
-the destination file via `WriteAt` at the target offset but does not advertise
-or materialize the [old EOF, target offset) hole as zero-reading bytes.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.ioctl.copy_chunk_sparse_dest | IOCTL | SRV_COPYCHUNK to a 0-byte destination at offset 4096 must surface the [0, 4096) gap as zeros on subsequent reads. The block-store sparse-hole zero-fill path does not run for copychunk-extended files. | #750 |
+Most IOCTL sparse-family entries walked back under #718. `smb2.ioctl.copy_chunk_sparse_dest`
+walked back as well: SRV_COPYCHUNK to a 0-byte destination at offset 4096 grows the
+destination via `WriteAt`, and the block store's implicitly-sparse zero-grow surfaces
+the unwritten [old EOF, target offset) hole as zero-reading bytes on subsequent reads,
+exactly as Samba `test_ioctl_copy_chunk_sparse_dest` requires. Covered by the Go
+regression test `TestCopyChunk_SparseDest_LeadingGapReadsZeros`.
 
 Note: the standalone `smb2.set-sparse-ioctl` and `smb2.zero-data-ioctl` driver
 tests require `--option=torture:filename=` / `--option=torture:offset=` runtime


### PR DESCRIPTION
## Summary

Walks back `smb2.ioctl.copy_chunk_sparse_dest` from the smbtorture `KNOWN_FAILURES.md` — it now passes deterministically on develop.

## Root cause / why it passes

The test (`source4/torture/smb2/ioctl.c::test_ioctl_copy_chunk_sparse_dest`):
1. src filled with 4096 bytes of a non-zero pattern, dest created 0-byte
2. `FSCTL_SRV_COPYCHUNK` copies src [0,4096) → dest [4096,8192)
3. READ dest [0,4096) must return 4096 **zero** bytes (the hole between old EOF=0 and target offset 4096)
4. READ dest [4096,8192) must equal the source pattern

DittoFS's copychunk path grows the destination via `WriteAt` at the target offset, and the block store is **implicitly sparse**: the zero-grow surfaces the unwritten [old EOF, target offset) hole as zero-reading bytes on subsequent reads — exactly what the test requires. No code change is needed; the row in KNOWN_FAILURES.md was stale.

## Regression coverage

Already guarded by the existing Go test `TestCopyChunk_SparseDest_LeadingGapReadsZeros` (`internal/adapter/smb/v2/handlers/ioctl_copychunk_sparse_integration_test.go`), which drives the real `executeCopyChunks` write path and the real READ handler against a memory block store and asserts zeros in the [0,4096) hole + pattern match in [4096,8192).

## Verification

Local docker smbtorture harness, run against `origin/develop` worktree:

```
success: copy_chunk_sparse_dest
| Metric | Count |
|--------|-------|
| Total | 1 |
| Passed | 1 |
| Failed | 0 |
| New Failures | 0 |
```

Confirmed passing across three independent runs. Go test: `ok internal/adapter/smb/v2/handlers`.

## Changes

- Remove the `smb2.ioctl.copy_chunk_sparse_dest` row from the IOCTL/FSCTL section of `test/smb-conformance/smbtorture/KNOWN_FAILURES.md`; update the surrounding prose to document the walk-back and point at the existing regression test.