### PR TITLE
fix(controlplane): wire mutex/block pprof sampling (#671)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -198,10 +198,13 @@ controlplane:
   write_timeout: 10s         # Max time to write response
   idle_timeout: 60s          # Max idle time for keep-alive
 
-  # Profiling (disabled by default; for benchmarks/diagnostics only)
+  # Profiling (disabled by default; for benchmarks/diagnostics only).
+  # The rate keys only take effect when pprof is true; with pprof off all
+  # sampling stays off regardless of their values. When pprof is on and a rate
+  # is unset/0 it falls back to the default shown below.
   pprof: false                 # Expose /debug/pprof/* endpoints
-  pprof_mutex_rate: 100        # runtime.SetMutexProfileFraction; 0 disables mutex profile
-  pprof_block_rate_ns: 1000000 # runtime.SetBlockProfileRate (ns); 0 disables block profile
+  # pprof_mutex_rate: 100        # runtime.SetMutexProfileFraction (default 100 when pprof on)
+  # pprof_block_rate_ns: 1000000 # runtime.SetBlockProfileRate ns (default 1000000 when pprof on)
 
   # JWT authentication configuration
   jwt:
@@ -222,8 +225,8 @@ controlplane:
 | `write_timeout` | `10s` | Maximum duration to write response |
 | `idle_timeout` | `60s` | Maximum idle time for keep-alive |
 | `pprof` | `false` | Expose Go `/debug/pprof/*` profiling endpoints |
-| `pprof_mutex_rate` | `100` | Mutex contention sampling (1 per N events); `0` disables. Only applied when `pprof: true`. Without it, `/debug/pprof/mutex` is header-only |
-| `pprof_block_rate_ns` | `1000000` | Block profiling rate in ns (1 sample per N ns blocked); `0` disables. Only applied when `pprof: true`. Without it, `/debug/pprof/block` is header-only |
+| `pprof_mutex_rate` | `100` (when `pprof: true`; else `0`) | Mutex contention sampling, 1 per N events. Applied only when `pprof: true`; unset/`0` then falls back to `100`. Without it `/debug/pprof/mutex` is header-only. Disable profiling via `pprof: false`, not by zeroing this |
+| `pprof_block_rate_ns` | `1000000` (when `pprof: true`; else `0`) | Block profiling rate in ns, 1 sample per N ns blocked. Applied only when `pprof: true`; unset/`0` then falls back to `1000000`. Without it `/debug/pprof/block` is header-only. Disable profiling via `pprof: false`, not by zeroing this |
 
 **JWT Configuration Options:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -198,6 +198,11 @@ controlplane:
   write_timeout: 10s         # Max time to write response
   idle_timeout: 60s          # Max idle time for keep-alive
 
+  # Profiling (disabled by default; for benchmarks/diagnostics only)
+  pprof: false                 # Expose /debug/pprof/* endpoints
+  pprof_mutex_rate: 100        # runtime.SetMutexProfileFraction; 0 disables mutex profile
+  pprof_block_rate_ns: 1000000 # runtime.SetBlockProfileRate (ns); 0 disables block profile
+
   # JWT authentication configuration
   jwt:
     # HMAC signing key for JWT tokens (min 32 characters)
@@ -216,6 +221,9 @@ controlplane:
 | `read_timeout` | `10s` | Maximum duration to read request |
 | `write_timeout` | `10s` | Maximum duration to write response |
 | `idle_timeout` | `60s` | Maximum idle time for keep-alive |
+| `pprof` | `false` | Expose Go `/debug/pprof/*` profiling endpoints |
+| `pprof_mutex_rate` | `100` | Mutex contention sampling (1 per N events); `0` disables. Only applied when `pprof: true`. Without it, `/debug/pprof/mutex` is header-only |
+| `pprof_block_rate_ns` | `1000000` | Block profiling rate in ns (1 sample per N ns blocked); `0` disables. Only applied when `pprof: true`. Without it, `/debug/pprof/block` is header-only |
 
 **JWT Configuration Options:**
 
@@ -1306,6 +1314,9 @@ export DITTOFS_DATABASE_POSTGRES_SSLMODE=require
 # Control Plane API Server
 export DITTOFS_CONTROLPLANE_PORT=8080
 export DITTOFS_CONTROLPLANE_SECRET=your-secret-key-at-least-32-characters
+export DITTOFS_CONTROLPLANE_PPROF=false
+export DITTOFS_CONTROLPLANE_PPROF_MUTEX_RATE=100
+export DITTOFS_CONTROLPLANE_PPROF_BLOCK_RATE_NS=1000000
 # Server-level configuration
 export DITTOFS_SERVER_SHUTDOWN_TIMEOUT=60s
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -67,19 +67,10 @@ func applyDatabaseDefaults(cfg *store.Config) {
 
 // applyControlPlaneDefaults sets control plane API server defaults.
 // API is always enabled (mandatory for managing shares and users).
+// Delegates to APIConfig.ApplyDefaults so this path and NewServer share one
+// source of truth and cannot drift as fields are added.
 func applyControlPlaneDefaults(cfg *api.APIConfig) {
-	if cfg.Port == 0 {
-		cfg.Port = 8080
-	}
-	if cfg.ReadTimeout == 0 {
-		cfg.ReadTimeout = 10 * time.Second
-	}
-	if cfg.WriteTimeout == 0 {
-		cfg.WriteTimeout = 10 * time.Second
-	}
-	if cfg.IdleTimeout == 0 {
-		cfg.IdleTimeout = 60 * time.Second
-	}
+	cfg.ApplyDefaults()
 }
 
 // applyAdminDefaults sets admin user defaults.

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -45,6 +45,26 @@ func TestApplyDefaults_ControlPlane(t *testing.T) {
 	if cfg.ControlPlane.IdleTimeout != 60*time.Second {
 		t.Errorf("Expected default idle timeout 60s, got %v", cfg.ControlPlane.IdleTimeout)
 	}
+	// pprof off by default → sampling rates stay disabled (0). The global Load
+	// path must reach APIConfig.ApplyDefaults; a regression that bypasses it
+	// would silently drop pprof rate defaults.
+	if cfg.ControlPlane.PprofMutexRate != 0 || cfg.ControlPlane.PprofBlockRateNs != 0 {
+		t.Errorf("Expected pprof rates 0 when pprof off, got mutex=%d block=%d",
+			cfg.ControlPlane.PprofMutexRate, cfg.ControlPlane.PprofBlockRateNs)
+	}
+}
+
+func TestApplyDefaults_ControlPlanePprofRates(t *testing.T) {
+	cfg := &Config{}
+	cfg.ControlPlane.Pprof = true
+	ApplyDefaults(cfg)
+
+	if cfg.ControlPlane.PprofMutexRate != 100 {
+		t.Errorf("Expected default pprof mutex rate 100 when pprof on, got %d", cfg.ControlPlane.PprofMutexRate)
+	}
+	if cfg.ControlPlane.PprofBlockRateNs != 1_000_000 {
+		t.Errorf("Expected default pprof block rate 1_000_000ns when pprof on, got %d", cfg.ControlPlane.PprofBlockRateNs)
+	}
 }
 
 func TestApplyDefaults_Admin(t *testing.T) {

--- a/pkg/controlplane/api/config.go
+++ b/pkg/controlplane/api/config.go
@@ -49,6 +49,20 @@ type APIConfig struct {
 	// Useful for CPU, memory, and goroutine profiling during benchmarks.
 	// Default: false
 	Pprof bool `mapstructure:"pprof" yaml:"pprof"`
+
+	// PprofMutexRate is the sampling fraction passed to
+	// runtime.SetMutexProfileFraction. One mutex contention event is sampled
+	// per N events; 0 disables mutex profiling. Without this, /debug/pprof/mutex
+	// returns an empty (header-only) profile even when Pprof is enabled.
+	// Only applied when Pprof is true. Default when Pprof on: 100.
+	PprofMutexRate int `mapstructure:"pprof_mutex_rate" validate:"omitempty,min=0" yaml:"pprof_mutex_rate"`
+
+	// PprofBlockRateNs is the rate (in nanoseconds) passed to
+	// runtime.SetBlockProfileRate. One blocking event is sampled per N
+	// nanoseconds blocked; 0 disables block profiling. Without this,
+	// /debug/pprof/block returns an empty (header-only) profile even when
+	// Pprof is enabled. Only applied when Pprof is true. Default when Pprof on: 1_000_000.
+	PprofBlockRateNs int `mapstructure:"pprof_block_rate_ns" validate:"omitempty,min=0" yaml:"pprof_block_rate_ns"`
 }
 
 // JWTConfig configures JWT token generation and validation.
@@ -91,8 +105,11 @@ func (c JWTConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// applyDefaults fills in zero values with sensible defaults.
-func (c *APIConfig) applyDefaults() {
+// ApplyDefaults fills in zero values with sensible defaults. It is the single
+// source of truth for API config defaults — both NewServer and the global
+// config.ApplyDefaults path call it, so a new field defaulted here cannot drift
+// between the two entry points.
+func (c *APIConfig) ApplyDefaults() {
 	if c.Port == 0 {
 		c.Port = 8080
 	}
@@ -104,6 +121,17 @@ func (c *APIConfig) applyDefaults() {
 	}
 	if c.IdleTimeout == 0 {
 		c.IdleTimeout = 60 * time.Second
+	}
+	// When pprof is on but the sampling rates are left unset, fall back to
+	// sensible defaults so /debug/pprof/{mutex,block} return non-empty profiles
+	// out of the box. Left at zero (disabled) when pprof is off.
+	if c.Pprof {
+		if c.PprofMutexRate == 0 {
+			c.PprofMutexRate = 100
+		}
+		if c.PprofBlockRateNs == 0 {
+			c.PprofBlockRateNs = 1_000_000
+		}
 	}
 	// JWT defaults
 	if c.JWT.AccessTokenDuration == 0 {

--- a/pkg/controlplane/api/config.go
+++ b/pkg/controlplane/api/config.go
@@ -51,17 +51,21 @@ type APIConfig struct {
 	Pprof bool `mapstructure:"pprof" yaml:"pprof"`
 
 	// PprofMutexRate is the sampling fraction passed to
-	// runtime.SetMutexProfileFraction. One mutex contention event is sampled
-	// per N events; 0 disables mutex profiling. Without this, /debug/pprof/mutex
-	// returns an empty (header-only) profile even when Pprof is enabled.
-	// Only applied when Pprof is true. Default when Pprof on: 100.
+	// runtime.SetMutexProfileFraction (one mutex contention event sampled per N
+	// events). Without it, /debug/pprof/mutex is an empty (header-only) profile
+	// even when Pprof is enabled. Only applied when Pprof is true; when Pprof is
+	// false it is forced to 0 (sampling off). A zero/unset value with Pprof on
+	// falls back to the default 100 — to turn profiling off entirely, set Pprof
+	// to false rather than zeroing this.
 	PprofMutexRate int `mapstructure:"pprof_mutex_rate" validate:"omitempty,min=0" yaml:"pprof_mutex_rate"`
 
 	// PprofBlockRateNs is the rate (in nanoseconds) passed to
-	// runtime.SetBlockProfileRate. One blocking event is sampled per N
-	// nanoseconds blocked; 0 disables block profiling. Without this,
-	// /debug/pprof/block returns an empty (header-only) profile even when
-	// Pprof is enabled. Only applied when Pprof is true. Default when Pprof on: 1_000_000.
+	// runtime.SetBlockProfileRate (one blocking event sampled per N ns blocked).
+	// Without it, /debug/pprof/block is an empty (header-only) profile even when
+	// Pprof is enabled. Only applied when Pprof is true; when Pprof is false it
+	// is forced to 0 (sampling off). A zero/unset value with Pprof on falls back
+	// to the default 1_000_000 — to turn profiling off entirely, set Pprof to
+	// false rather than zeroing this.
 	PprofBlockRateNs int `mapstructure:"pprof_block_rate_ns" validate:"omitempty,min=0" yaml:"pprof_block_rate_ns"`
 }
 

--- a/pkg/controlplane/api/server.go
+++ b/pkg/controlplane/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	goruntime "runtime"
 	"sync"
 	"time"
 
@@ -55,7 +56,7 @@ type Server struct {
 //
 // Returns a configured but not yet started Server, or an error if JWT configuration is invalid.
 func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, restoreHTTPTimeout time.Duration) (*Server, error) {
-	config.applyDefaults()
+	config.ApplyDefaults()
 
 	// Get JWT secret from config (prefers env var)
 	jwtSecret := config.GetJWTSecret()
@@ -73,6 +74,17 @@ func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, resto
 	jwtService, err := auth.NewJWTService(jwtConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JWT service: %w", err)
+	}
+
+	// Enable mutex/block sampling so /debug/pprof/{mutex,block} return
+	// non-empty profiles. The HTTP handlers only read the runtime's sampled
+	// data; without these calls the sampling rate stays 0 and the profiles are
+	// header-only. Gated on Pprof so there is no sampling overhead by default.
+	if config.Pprof {
+		goruntime.SetMutexProfileFraction(config.PprofMutexRate)
+		goruntime.SetBlockProfileRate(config.PprofBlockRateNs)
+		logger.Info("pprof mutex/block sampling enabled",
+			"mutex_rate", config.PprofMutexRate, "block_rate_ns", config.PprofBlockRateNs)
 	}
 
 	// cpStore implements both IdentityStore and Store

--- a/pkg/controlplane/api/server.go
+++ b/pkg/controlplane/api/server.go
@@ -76,15 +76,21 @@ func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, resto
 		return nil, fmt.Errorf("failed to create JWT service: %w", err)
 	}
 
-	// Enable mutex/block sampling so /debug/pprof/{mutex,block} return
-	// non-empty profiles. The HTTP handlers only read the runtime's sampled
-	// data; without these calls the sampling rate stays 0 and the profiles are
-	// header-only. Gated on Pprof so there is no sampling overhead by default.
+	// Set mutex/block sampling so /debug/pprof/{mutex,block} return non-empty
+	// profiles. The HTTP handlers only read the runtime's sampled data; without
+	// these calls the sampling rate stays 0 and the profiles are header-only.
+	// These are process-global runtime knobs, so NewServer is authoritative in
+	// both directions: when Pprof is off we reset them to 0 rather than leaving
+	// whatever a prior caller (another server, bench tooling) set — that keeps
+	// "no sampling overhead when pprof is off" true regardless of call order.
 	if config.Pprof {
 		goruntime.SetMutexProfileFraction(config.PprofMutexRate)
 		goruntime.SetBlockProfileRate(config.PprofBlockRateNs)
 		logger.Info("pprof mutex/block sampling enabled",
 			"mutex_rate", config.PprofMutexRate, "block_rate_ns", config.PprofBlockRateNs)
+	} else {
+		goruntime.SetMutexProfileFraction(0)
+		goruntime.SetBlockProfileRate(0)
 	}
 
 	// cpStore implements both IdentityStore and Store

--- a/pkg/controlplane/api/server_test.go
+++ b/pkg/controlplane/api/server_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -255,5 +256,69 @@ func TestAPIServer_InvalidJWTSecret(t *testing.T) {
 	_, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
 	if err == nil {
 		t.Fatal("Expected error for invalid JWT secret, got nil")
+	}
+}
+
+func TestAPIConfig_PprofRateDefaults(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            APIConfig
+		wantMutexRate int
+		wantBlockRate int
+	}{
+		{
+			name:          "pprof off leaves rates at zero",
+			in:            APIConfig{Pprof: false},
+			wantMutexRate: 0,
+			wantBlockRate: 0,
+		},
+		{
+			name:          "pprof on fills sensible defaults",
+			in:            APIConfig{Pprof: true},
+			wantMutexRate: 100,
+			wantBlockRate: 1_000_000,
+		},
+		{
+			name:          "explicit rates preserved when pprof on",
+			in:            APIConfig{Pprof: true, PprofMutexRate: 5, PprofBlockRateNs: 250},
+			wantMutexRate: 5,
+			wantBlockRate: 250,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.in
+			cfg.ApplyDefaults()
+			if cfg.PprofMutexRate != tt.wantMutexRate {
+				t.Errorf("PprofMutexRate = %d, want %d", cfg.PprofMutexRate, tt.wantMutexRate)
+			}
+			if cfg.PprofBlockRateNs != tt.wantBlockRate {
+				t.Errorf("PprofBlockRateNs = %d, want %d", cfg.PprofBlockRateNs, tt.wantBlockRate)
+			}
+		})
+	}
+}
+
+// TestNewServer_PprofSamplingWired verifies NewServer actually applies the
+// mutex sampling fraction to the Go runtime when Pprof is enabled — the gap
+// that left /debug/pprof/mutex header-only. SetMutexProfileFraction(-1) leaves
+// the rate unchanged and returns the value currently in effect, so we read the
+// prior value, restore it on cleanup, and never write a transient 0 that a
+// concurrent test could observe. Mutates global runtime state — do not add
+// t.Parallel().
+func TestNewServer_PprofSamplingWired(t *testing.T) {
+	prev := goruntime.SetMutexProfileFraction(-1) // read without changing
+	t.Cleanup(func() { goruntime.SetMutexProfileFraction(prev) })
+
+	cpStore, cfg := testSetup(t, 18099)
+	cfg.Pprof = true
+	cfg.PprofMutexRate = 137 // distinctive, non-default value
+
+	if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	if got := goruntime.SetMutexProfileFraction(-1); got != 137 {
+		t.Errorf("mutex profile fraction = %d, want 137", got)
 	}
 }

--- a/pkg/controlplane/api/server_test.go
+++ b/pkg/controlplane/api/server_test.go
@@ -304,11 +304,16 @@ func TestAPIConfig_PprofRateDefaults(t *testing.T) {
 // that left /debug/pprof/mutex header-only. SetMutexProfileFraction(-1) leaves
 // the rate unchanged and returns the value currently in effect, so we read the
 // prior value, restore it on cleanup, and never write a transient 0 that a
-// concurrent test could observe. Mutates global runtime state — do not add
-// t.Parallel().
+// concurrent test could observe. NewServer also sets the block profile rate;
+// there is no runtime getter for it, so we cannot read/assert it, but cleanup
+// resets it to 0 so this test cannot leak block sampling into later tests.
+// Mutates global runtime state — do not add t.Parallel().
 func TestNewServer_PprofSamplingWired(t *testing.T) {
 	prev := goruntime.SetMutexProfileFraction(-1) // read without changing
-	t.Cleanup(func() { goruntime.SetMutexProfileFraction(prev) })
+	t.Cleanup(func() {
+		goruntime.SetMutexProfileFraction(prev)
+		goruntime.SetBlockProfileRate(0)
+	})
 
 	cpStore, cfg := testSetup(t, 18099)
 	cfg.Pprof = true
@@ -320,5 +325,31 @@ func TestNewServer_PprofSamplingWired(t *testing.T) {
 
 	if got := goruntime.SetMutexProfileFraction(-1); got != 137 {
 		t.Errorf("mutex profile fraction = %d, want 137", got)
+	}
+}
+
+// TestNewServer_PprofOffResetsSampling verifies NewServer is authoritative when
+// Pprof is off: it resets the global mutex fraction to 0 even if a prior caller
+// (another server, bench tooling) had enabled sampling, so "no overhead when
+// pprof is off" holds regardless of call order. Mutates global runtime state —
+// do not add t.Parallel().
+func TestNewServer_PprofOffResetsSampling(t *testing.T) {
+	prev := goruntime.SetMutexProfileFraction(-1)
+	t.Cleanup(func() {
+		goruntime.SetMutexProfileFraction(prev)
+		goruntime.SetBlockProfileRate(0)
+	})
+
+	goruntime.SetMutexProfileFraction(50) // simulate sampling left on by a prior caller
+
+	cpStore, cfg := testSetup(t, 18100)
+	cfg.Pprof = false
+
+	if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	if got := goruntime.SetMutexProfileFraction(-1); got != 0 {
+		t.Errorf("mutex profile fraction = %d, want 0 (reset when pprof off)", got)
 	}
 }


### PR DESCRIPTION
Closes #671.

## Problem

`runtime.SetMutexProfileFraction` and `runtime.SetBlockProfileRate` are never called in `dfs`. With `controlplane.pprof: true`, `/debug/pprof/mutex` and `/debug/pprof/block` return 200 with ~235-byte header-only bodies — no samples. This blocks #680 (proactive pprof capture), which needs mutex/block profiles across the Wave-1 areas.

## Fix

- Two new config keys, gated entirely on `controlplane.pprof`:
  - `controlplane.pprof_mutex_rate` (default `100` when pprof on, `0`/off otherwise) → `runtime.SetMutexProfileFraction`
  - `controlplane.pprof_block_rate_ns` (default `1_000_000` when pprof on) → `runtime.SetBlockProfileRate`
- Applied to the runtime in `NewServer`. No sampling overhead when pprof is off.
- Env override works automatically via the reflective `configEnvKeys()` walk on `develop` (`DITTOFS_CONTROLPLANE_PPROF_MUTEX_RATE`, `..._BLOCK_RATE_NS`).

## Drift cleanup

`APIConfig` had two independent default sites — `applyDefaults()` (called by `NewServer`) and a hand-duplicated copy in `pkg/config/defaults.go`. The new rate defaults would have silently dropped on the global `Load` path (same class of bug as the area-9 config-show drift). Exported `APIConfig.ApplyDefaults` as the single source of truth; `applyControlPlaneDefaults` now delegates to it. `TestApplyDefaults_ControlPlane*` pins the global path.

## Tests

- `TestAPIConfig_PprofRateDefaults` — off → rates stay 0; on → 100 / 1e6; explicit preserved.
- `TestNewServer_PprofSamplingWired` — asserts the runtime fraction is actually set (read-and-restore, no transient global write).
- `TestApplyDefaults_ControlPlanePprofRates` — global `Load` path defaults the rates.

`go build ./...`, `go vet`, `go test -race ./pkg/controlplane/api/ ./pkg/config/` all green.