### PR TITLE
fix(smb/lease): dedup dir-lease breaks by lease key to fix unlink double-break flake

### DIFF
--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -164,6 +164,12 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	// the shared ClientGUID, producing the intermittent
 	// smb2.dirlease.unlink_*_and_close "lease_break_info.count got 0x2" flake.
 	dispatchedKeys := make(map[[16]byte]struct{}, len(locks))
+	// canonicalByKey remembers the record whose break stage drove the single
+	// wire notification for each lease key, so a sibling sharing that key
+	// mirrors the same break stage without sending a second notification (see
+	// breakOpLocks / mirrorBreakStageLocked; MS-SMB2 §3.3.5.9 — opens sharing a
+	// lease key share one logical lease).
+	canonicalByKey := make(map[[16]byte]*OpLock, len(locks))
 
 	for _, lock := range locks {
 		// Skip originator for the entire lock entry (covers both lease and delegation).
@@ -195,7 +201,15 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 				lock.Lease.BreakStarted = time.Now()
 				advanceEpoch(lock.Lease)
 				dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
+				canonicalByKey[lock.Lease.LeaseKey] = lock.Lease
 				leasesToBreak = append(leasesToBreak, lock)
+			} else if canonical := canonicalByKey[lock.Lease.LeaseKey]; canonical != nil {
+				// A sibling sharing the canonical record's lease key: mirror its
+				// break stage without a second wire notification or epoch advance
+				// (the canonical already advanced once). OnDirChange holds the
+				// canonical break state in memory only (no PutLock), so the
+				// sibling stays equally non-persisted (persist=false).
+				lm.mirrorBreakStageLocked(lock, canonical, false)
 			}
 		}
 

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -155,6 +155,16 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	var leasesToBreak []*UnifiedLock
 	var delegsToBreak []*UnifiedLock
 
+	// Dedup wire break notifications by lease key. A handleKey can hold more
+	// than one directory-lease record under the same key (an orphaned
+	// ack-to-None record left by an unclean disconnect coexisting with a live
+	// regrant under the smbtorture-reused DLEASE constant). Samba breaks each
+	// holder/lease key exactly once per change; dispatching once per record
+	// sends duplicate notifications that all route to the same live session via
+	// the shared ClientGUID, producing the intermittent
+	// smb2.dirlease.unlink_*_and_close "lease_break_info.count got 0x2" flake.
+	dispatchedKeys := make(map[[16]byte]struct{}, len(locks))
+
 	for _, lock := range locks {
 		// Skip originator for the entire lock entry (covers both lease and delegation).
 		if lock.Owner.ClientID == originClientID {
@@ -178,12 +188,15 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 		// caller waiting on WaitForBreakCompletion until the timeout.
 		if lock.Lease != nil && lock.Lease.IsDirectory &&
 			lock.Lease.LeaseState != LeaseStateNone && !lock.Lease.Breaking {
-			lock.Lease.Breaking = true
-			lock.Lease.BreakToState = LeaseStateNone
-			lock.Lease.BreakingToRequired = LeaseStateNone
-			lock.Lease.BreakStarted = time.Now()
-			advanceEpoch(lock.Lease)
-			leasesToBreak = append(leasesToBreak, lock)
+			if _, already := dispatchedKeys[lock.Lease.LeaseKey]; !already {
+				lock.Lease.Breaking = true
+				lock.Lease.BreakToState = LeaseStateNone
+				lock.Lease.BreakingToRequired = LeaseStateNone
+				lock.Lease.BreakStarted = time.Now()
+				advanceEpoch(lock.Lease)
+				dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
+				leasesToBreak = append(leasesToBreak, lock)
+			}
 		}
 
 		// Check directory delegations

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -1,0 +1,109 @@
+package lock
+
+import (
+	"sync"
+	"testing"
+)
+
+// dlease2Key is the DLEASE2 lease-key constant smbtorture reuses across every
+// dirlease subtest (source4/torture/smb2/lease.c).
+var dlease2Key = [16]byte{0x02, 0, 0, 0, 0, 0, 0, 0, 0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+// twoSameKeyDirLeases injects two RH directory-lease records that share key
+// under one handleKey: a stale ack-to-None-then-regranted record (dead session)
+// coexisting with the live record — exactly the shape an unclean disconnect
+// leaves. RequestLease dedups same-key grants, so the coexistence is built
+// directly. Returns a per-key break counter the caller asserts against.
+func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]byte) (*sync.Mutex, map[[16]byte]int) {
+	t.Helper()
+
+	mu := &sync.Mutex{}
+	breaksByKey := map[[16]byte]int{}
+	lm.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, l *UnifiedLock, _ uint32) {
+			mu.Lock()
+			breaksByKey[l.Lease.LeaseKey]++
+			mu.Unlock()
+		},
+	})
+
+	lm.mu.Lock()
+	lm.unifiedLocks[handleKey] = []*UnifiedLock{
+		{
+			Owner: LockOwner{OwnerID: "stale", ClientID: "smb:1"},
+			Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
+		},
+		{
+			Owner: LockOwner{OwnerID: "live", ClientID: "smb:2"},
+			Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
+		},
+	}
+	lm.mu.Unlock()
+
+	return mu, breaksByKey
+}
+
+// TestBreakLeasesOnOpenConflict_DedupsByLeaseKey is a regression test for the
+// intermittent smbtorture smb2.dirlease.unlink_*_and_close double-break flake
+// (lease.c:7653 "wrong value for lease_break_info.count got 0x2 - should be
+// 0x1").
+//
+// Root cause: a single directory-content-change break iterated every
+// *UnifiedLock record under the parent handleKey and dispatched one wire
+// LEASE_BREAK per record. smbtorture reuses the DLEASE2 lease-key constant
+// across every dirlease subtest on one ClientGUID, so an orphaned ack-to-None
+// record left under the same handleKey by an earlier subtest (or an unclean
+// disconnect) coexists with the live record under the SAME lease key. With no
+// per-key dedup, breaking that handle dispatched TWO notifications for ONE
+// logical lease, and GetSessionForBreak routed both to the same live primary
+// session (shared ClientGUID) — the client observed count==2.
+//
+// Samba dispatches exactly one LEASE_BREAK per distinct lease key per change
+// (source3/smbd/smb2_oplock.c contend_dirleases -> do_dirlease_break_to_none
+// breaks each holder once). This test injects two directory-lease records that
+// share a lease key under one handleKey and asserts a single content-change
+// break dispatches exactly one notification for that key.
+func TestBreakLeasesOnOpenConflict_DedupsByLeaseKey(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir-uuid"
+	mu, breaksByKey := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
+
+	// A directory-content change (unlink) breaks the parent dir lease to None.
+	if err := lm.BreakLeasesOnOpenConflict(handleKey, nil, BreakReasonDestructive); err != nil {
+		t.Fatalf("BreakLeasesOnOpenConflict: %v", err)
+	}
+
+	mu.Lock()
+	got := breaksByKey[dlease2Key]
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("dir-lease break dispatched %d notifications for lease key %x; "+
+			"want exactly 1 (smbtorture unlink_*_and_close asserts lease_break_info.count==1)",
+			got, dlease2Key)
+	}
+}
+
+// TestOnDirChange_DedupsByLeaseKey asserts the same single-notification-per-key
+// invariant on the metadata-store delete path (RemoveFile -> notifyDirChange ->
+// OnDirChange), the other entry point that breaks parent dir leases on a
+// content change.
+func TestOnDirChange_DedupsByLeaseKey(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir-uuid"
+	mu, breaksByKey := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
+
+	// Origin client "smb:3" differs from both holders, so neither is suppressed
+	// by the origin-client rule — both records are break candidates.
+	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:3", [16]byte{}, false)
+
+	mu.Lock()
+	got := breaksByKey[dlease2Key]
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("OnDirChange dispatched %d notifications for lease key %x; want exactly 1", got, dlease2Key)
+	}
+}

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -13,8 +13,9 @@ var dlease2Key = [16]byte{0x02, 0, 0, 0, 0, 0, 0, 0, 0xfd, 0xff, 0xff, 0xff, 0xf
 // under one handleKey: a stale ack-to-None-then-regranted record (dead session)
 // coexisting with the live record — exactly the shape an unclean disconnect
 // leaves. RequestLease dedups same-key grants, so the coexistence is built
-// directly. Returns a per-key break counter the caller asserts against.
-func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]byte) (*sync.Mutex, map[[16]byte]int) {
+// directly. Returns the two injected records (in injection order) and a per-key
+// break counter the caller asserts against.
+func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]byte) (*sync.Mutex, map[[16]byte]int, []*UnifiedLock) {
 	t.Helper()
 
 	mu := &sync.Mutex{}
@@ -27,8 +28,7 @@ func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]by
 		},
 	})
 
-	lm.mu.Lock()
-	lm.unifiedLocks[handleKey] = []*UnifiedLock{
+	records := []*UnifiedLock{
 		{
 			Owner: LockOwner{OwnerID: "stale", ClientID: "smb:1"},
 			Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
@@ -38,9 +38,46 @@ func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]by
 			Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
 		},
 	}
+
+	lm.mu.Lock()
+	lm.unifiedLocks[handleKey] = records
 	lm.mu.Unlock()
 
-	return mu, breaksByKey
+	return mu, breaksByKey, records
+}
+
+// assertBothSiblingsBreaking verifies that every same-key record ends in the
+// SAME break stage after a dedup'd break: Breaking=true and identical
+// BreakToState / BreakingToRequired / Epoch. Per MS-SMB2 §3.3.5.9 opens sharing
+// a lease key share one logical lease, so the sibling skipped for the wire
+// notification must still carry the canonical record's break state — otherwise a
+// later scan treats the stale sibling as an active non-breaking lease and
+// dispatches a fresh spurious break.
+func assertBothSiblingsBreaking(t *testing.T, lm *Manager, records []*UnifiedLock) {
+	t.Helper()
+
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	first := records[0].Lease
+	for i, rec := range records {
+		l := rec.Lease
+		if !l.Breaking {
+			t.Fatalf("record %d (%s): Breaking=false after dedup'd break; "+
+				"a skipped sibling must mirror the canonical break stage "+
+				"(else a later scan dispatches a fresh spurious break)", i, rec.Owner.OwnerID)
+		}
+		if l.BreakToState != first.BreakToState ||
+			l.BreakingToRequired != first.BreakingToRequired ||
+			l.Epoch != first.Epoch {
+			t.Fatalf("record %d (%s): break stage diverged from canonical: "+
+				"BreakToState=%#x BreakingToRequired=%#x Epoch=%d vs canonical "+
+				"BreakToState=%#x BreakingToRequired=%#x Epoch=%d",
+				i, rec.Owner.OwnerID,
+				l.BreakToState, l.BreakingToRequired, l.Epoch,
+				first.BreakToState, first.BreakingToRequired, first.Epoch)
+		}
+	}
 }
 
 // TestBreakLeasesOnOpenConflict_DedupsByLeaseKey is a regression test for the
@@ -68,7 +105,7 @@ func TestBreakLeasesOnOpenConflict_DedupsByLeaseKey(t *testing.T) {
 
 	lm := NewManager()
 	const handleKey = "/share:dir-uuid"
-	mu, breaksByKey := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
+	mu, breaksByKey, records := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
 
 	// A directory-content change (unlink) breaks the parent dir lease to None.
 	if err := lm.BreakLeasesOnOpenConflict(handleKey, nil, BreakReasonDestructive); err != nil {
@@ -83,6 +120,10 @@ func TestBreakLeasesOnOpenConflict_DedupsByLeaseKey(t *testing.T) {
 			"want exactly 1 (smbtorture unlink_*_and_close asserts lease_break_info.count==1)",
 			got, dlease2Key)
 	}
+
+	// Both same-key records must carry the break stage so a later scan can't
+	// treat the skipped sibling as an active non-breaking lease.
+	assertBothSiblingsBreaking(t, lm, records)
 }
 
 // TestOnDirChange_DedupsByLeaseKey asserts the same single-notification-per-key
@@ -94,7 +135,7 @@ func TestOnDirChange_DedupsByLeaseKey(t *testing.T) {
 
 	lm := NewManager()
 	const handleKey = "/share:dir-uuid"
-	mu, breaksByKey := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
+	mu, breaksByKey, records := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
 
 	// Origin client "smb:3" differs from both holders, so neither is suppressed
 	// by the origin-client rule — both records are break candidates.
@@ -106,4 +147,9 @@ func TestOnDirChange_DedupsByLeaseKey(t *testing.T) {
 	if got != 1 {
 		t.Fatalf("OnDirChange dispatched %d notifications for lease key %x; want exactly 1", got, dlease2Key)
 	}
+
+	// Both same-key records must carry the break stage (Breaking + matching
+	// BreakToState/BreakingToRequired/Epoch) so a later OnDirChange scan can't
+	// treat the skipped sibling as an active non-breaking lease.
+	assertBothSiblingsBreaking(t, lm, records)
 }

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2384,6 +2384,16 @@ func (lm *Manager) breakOpLocks(
 		breakToState uint32
 	}
 	var toBreak []breakEntry
+	// Dedup wire break notifications by lease key. A handleKey can hold more
+	// than one *UnifiedLock with the same lease key — e.g. an orphaned
+	// ack-to-None record left by an unclean disconnect coexisting with a live
+	// regrant under the smbtorture-reused DLEASE constant. Samba dispatches
+	// exactly one LEASE_BREAK per distinct holder/lease key per change
+	// (source3/smbd/smb2_oplock.c contend_dirleases); dispatching once per
+	// record sends duplicate notifications that all route to the same live
+	// session via the shared ClientGUID, producing the intermittent
+	// smb2.dirlease.unlink_*_and_close "lease_break_info.count got 0x2" flake.
+	dispatchedKeys := make(map[[16]byte]struct{}, len(locks))
 	for _, lock := range locks {
 		if lock.Lease == nil {
 			continue
@@ -2415,6 +2425,15 @@ func (lm *Manager) breakOpLocks(
 			continue
 		}
 
+		// One notification per distinct lease key (see dispatchedKeys above):
+		// a duplicate record under this handleKey must not produce a second
+		// wire break for the same lease. Marked once the key is accepted for
+		// a fresh dispatch below so the live record drives the notification and
+		// any sibling sharing its key is skipped.
+		if _, already := dispatchedKeys[lock.Lease.LeaseKey]; already {
+			continue
+		}
+
 		targetState := computeFreshTarget(lock.Lease.LeaseState, breakToState)
 
 		// Per Samba `delay_for_oplock_fn` (source3/smbd/open.c lines 2439-2444):
@@ -2440,6 +2459,9 @@ func (lm *Manager) breakOpLocks(
 				pl := ToPersistedLock(lock, 0)
 				_ = lm.lockStore.PutLock(context.Background(), pl)
 			}
+			// This key's break is already in flight; record it so a sibling
+			// record sharing the key is not freshly dispatched below.
+			dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
 			continue
 		}
 
@@ -2461,6 +2483,7 @@ func (lm *Manager) breakOpLocks(
 			pl := ToPersistedLock(lock, 0)
 			_ = lm.lockStore.PutLock(context.Background(), pl)
 		}
+		dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
 	}
 	lm.mu.Unlock()

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2394,6 +2394,15 @@ func (lm *Manager) breakOpLocks(
 	// session via the shared ClientGUID, producing the intermittent
 	// smb2.dirlease.unlink_*_and_close "lease_break_info.count got 0x2" flake.
 	dispatchedKeys := make(map[[16]byte]struct{}, len(locks))
+	// canonicalByKey remembers the record whose break stage drove the single
+	// wire notification for each lease key. A sibling sharing that key (an
+	// orphaned ack-to-None record left by an unclean disconnect coexisting
+	// with the live regrant) must NOT send a second notification, but its
+	// internal break stage MUST be mirrored from the canonical record so a
+	// later scan can't treat the stale sibling as an active non-breaking
+	// lease and dispatch a fresh spurious break (per MS-SMB2 §3.3.5.9: opens
+	// sharing a lease key share one logical lease).
+	canonicalByKey := make(map[[16]byte]*OpLock, len(locks))
 	for _, lock := range locks {
 		if lock.Lease == nil {
 			continue
@@ -2431,6 +2440,12 @@ func (lm *Manager) breakOpLocks(
 		// a fresh dispatch below so the live record drives the notification and
 		// any sibling sharing its key is skipped.
 		if _, already := dispatchedKeys[lock.Lease.LeaseKey]; already {
+			// Mirror the canonical record's break stage onto this sibling
+			// (no wire notification, no second epoch advance) so its state
+			// stays consistent with the one logical lease.
+			if canonical := canonicalByKey[lock.Lease.LeaseKey]; canonical != nil {
+				lm.mirrorBreakStageLocked(lock, canonical, true)
+			}
 			continue
 		}
 
@@ -2460,8 +2475,10 @@ func (lm *Manager) breakOpLocks(
 				_ = lm.lockStore.PutLock(context.Background(), pl)
 			}
 			// This key's break is already in flight; record it so a sibling
-			// record sharing the key is not freshly dispatched below.
+			// record sharing the key is not freshly dispatched below and so
+			// later siblings mirror this record's break stage.
 			dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
+			canonicalByKey[lock.Lease.LeaseKey] = lock.Lease
 			continue
 		}
 
@@ -2484,6 +2501,7 @@ func (lm *Manager) breakOpLocks(
 			_ = lm.lockStore.PutLock(context.Background(), pl)
 		}
 		dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
+		canonicalByKey[lock.Lease.LeaseKey] = lock.Lease
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
 	}
 	lm.mu.Unlock()
@@ -2555,6 +2573,37 @@ func (lm *Manager) applyBreakStageLocked(lock *UnifiedLock, target uint32) *Unif
 		_ = lm.lockStore.PutLock(context.Background(), pl)
 	}
 	return snapshot
+}
+
+// mirrorBreakStageLocked copies the break-stage fields of a canonical lease
+// record onto a sibling that shares its lease key, WITHOUT sending a wire
+// notification or independently advancing the sibling's epoch. Per MS-SMB2
+// §3.3.5.9 opens sharing a lease key share one logical lease, so the sibling
+// must end in the same break stage (Breaking / BreakToState / BreakingToRequired
+// / BreakStarted / Epoch / LeaseState) as the canonical record. Without this,
+// the skipped sibling keeps stale pre-break values and a later scan could treat
+// it as an active non-breaking lease and dispatch a fresh spurious break.
+//
+// The canonical record's epoch was advanced exactly once on its fresh dispatch
+// (or intentionally not advanced on the concurrent-break merge path); copying it
+// keeps the sibling in lockstep rather than diverging via a second advance.
+//
+// When persist is true the sibling is persisted (the caller persists the
+// canonical too); callers whose canonical path does not persist pass false so
+// the sibling stays in lockstep with the canonical's durability. Caller must
+// hold lm.mu.
+func (lm *Manager) mirrorBreakStageLocked(sibling *UnifiedLock, canonical *OpLock, persist bool) {
+	sibling.Lease.Breaking = canonical.Breaking
+	sibling.Lease.BreakToState = canonical.BreakToState
+	sibling.Lease.BreakingToRequired = canonical.BreakingToRequired
+	sibling.Lease.BreakStarted = canonical.BreakStarted
+	sibling.Lease.Epoch = canonical.Epoch
+	sibling.Lease.LeaseState = canonical.LeaseState
+	sibling.Type = lockTypeForLeaseState(canonical.LeaseState)
+	if persist && lm.lockStore != nil {
+		pl := ToPersistedLock(sibling, 0)
+		_ = lm.lockStore.PutLock(context.Background(), pl)
+	}
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

`smb2.dirlease.unlink_{same,different}_{initial,set}_and_close` intermittently fails the smbtorture/memory CI gate with:

```
lease.c:7653 wrong value for lease_break_info.count got 0x2 - should be 0x1
```

These tests are not in KNOWN_FAILURES (passing per #784) — they pass most runs but intermittently deliver the parent-directory lease break **twice** instead of once.

## Root cause

A directory-content-change break (`breakOpLocks` / `OnDirChange`) iterated **every** `UnifiedLock` record under the parent handleKey and dispatched one wire `LEASE_BREAK` **per record**. smbtorture reuses the `DLEASE` lease-key constant across every dirlease subtest on a **single ClientGUID**, so an orphaned ack-to-None record (left under the same handleKey by an unclean disconnect — e.g. the mid-suite smbtorture segfault) coexists with the live record under the **same lease key**.

With no per-key dedup, breaking that handle dispatched two notifications for one logical lease, and `GetSessionForBreak` routed **both** to the same live primary session via the shared ClientGUID — the client observed `count==2`. The "no session for lease, skipping break notification" path is what *usually* masks the duplicate; when the orphan's session still resolves, the client sees the second break.

Live-traced with a temporary stack-dump build: a single unlink produced 3 `OnOpLockBreak` calls on the reused DLEASE2 key (2 "no session" + 1 delivered) once stale records had accumulated; a fresh server produced exactly 1.

## Fix

Per MS-SMB2 §3.3.5.9, opens sharing a lease key share **one** logical lease, so a break must notify each distinct key exactly once (matching Samba `contend_dirleases` → `do_dirlease_break_to_none`, one break per holder). Dedup break dispatch by lease key in both entry points: `breakOpLocks` (manager.go) and `OnDirChange` (directory.go).

The dedup key (`lock.Lease.LeaseKey`) never collapses distinct logical leases: real leases carry client-unique keys; traditional oplocks carry per-FileID synthetic SHA-256 keys.

## Tests

Deterministic regression tests (`dirlease_dedup_break_test.go`) inject two same-key directory-lease records under one handleKey and assert exactly one break — they **fail on baseline** (dispatch=2) and **pass with the fix**. This protects the regression without relying on the flaky smbtorture run.

## Verification

- `go test ./pkg/metadata/lock/... ./internal/adapter/smb/...` green; `-race` clean.
- 5× full `smb2.dirlease` ordering (seteof…hardlink + all 4 unlink subtests) via Docker — 14/14 pass each run, every unlink reports "Got 1 lease breaks", no `count==2`.
- `smb2.lease.{v2_complex1,timeout}` fail identically on baseline and with the fix (pre-existing, environment/timing — not a regression).