### PR TITLE
fix(smb/session): reject re-bind on already-bound channel — flip Kerberos bind_negative CMAC↔HMAC (#686)

### DIFF
--- a/internal/adapter/smb/v2/handlers/session_reauth_signature_test.go
+++ b/internal/adapter/smb/v2/handlers/session_reauth_signature_test.go
@@ -143,3 +143,71 @@ func TestSessionSetup_ReauthOnOriginConnection_NoChannel_NotGated(t *testing.T) 
 		t.Fatalf("status=StatusAccessDenied, origin-connection re-auth must not be signature-gated")
 	}
 }
+
+// buildBindingRequest builds the raw wire bytes of a SESSION_SETUP request with
+// the SMB2_SESSION_FLAG_BINDING flag set, carrying a Kerberos AP-REQ so it would
+// route to completeKerberosBind if it passed the bind gates.
+func buildBindingRequest(t *testing.T, sessionID uint64) []byte {
+	t.Helper()
+	dummyAPReq := []byte{0x30, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05}
+	body := buildSessionSetupRequestBody(wrapKerberosInSPNEGO(dummyAPReq))
+	body[sessionSetupFlagsOffset] = SMB2_SESSION_FLAG_BINDING
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2SessionSetup,
+		MessageID: 5,
+		SessionID: sessionID,
+	}
+	return append(hdr.Encode(), body...)
+}
+
+// TestSessionSetup_RebindOnBoundConnection_AccessDenied verifies that a second
+// SESSION_SETUP_BINDING on a connection that already owns a bound channel is
+// rejected with STATUS_ACCESS_DENIED — the smbtorture re-bind at session.c:2839
+// (the final rejection in test_session_bind_negative_smb3sign{CtoH,HtoC}{s,d}).
+// Without the gate, AddChannel silently replaces the live channel and answers
+// STATUS_SUCCESS.
+func TestSessionSetup_RebindOnBoundConnection_AccessDenied(t *testing.T) {
+	channelKey := make([]byte, 16)
+	for i := range channelKey {
+		channelKey[i] = 0x66
+	}
+
+	h := NewHandler()
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1
+	addSignedChannel(sess, 2, channelKey) // connection 2 already bound
+
+	raw := buildBindingRequest(t, sess.SessionID)
+	ctx := newReauthContext(sess.SessionID, 2, raw)
+
+	result, err := h.SessionSetup(ctx, raw[64:])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Fatalf("status=0x%x, want StatusAccessDenied (0x%x)", result.Status, types.StatusAccessDenied)
+	}
+}
+
+// TestSessionSetup_FirstBindOnUnboundConnection_NotRejectedByRebindGate verifies
+// the re-bind gate is scoped to connections that ALREADY have a channel: the
+// normal first bind (no channel yet on the connection) must not be rejected by
+// this gate. With no KerberosService configured the bind proceeds and fails
+// later with LOGON_FAILURE — the point is only that it is NOT ACCESS_DENIED from
+// the re-bind gate.
+func TestSessionSetup_FirstBindOnUnboundConnection_NotRejectedByRebindGate(t *testing.T) {
+	h := NewHandler() // no KerberosService
+	sess := h.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = 1 // no channel registered on connection 2
+
+	raw := buildBindingRequest(t, sess.SessionID)
+	ctx := newReauthContext(sess.SessionID, 2, raw)
+
+	result, err := h.SessionSetup(ctx, raw[64:])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status == types.StatusAccessDenied {
+		t.Fatalf("status=StatusAccessDenied, a first bind on an unbound connection must not be rejected by the re-bind gate")
+	}
+}

--- a/internal/adapter/smb/v2/handlers/session_setup.go
+++ b/internal/adapter/smb/v2/handlers/session_setup.go
@@ -423,6 +423,34 @@ func (h *Handler) verifyReauthChannelSignature(ctx *SMBHandlerContext, sess *ses
 	return NewErrorResult(types.StatusAccessDenied)
 }
 
+// rejectRebindOnBoundChannel rejects a SESSION_SETUP_BINDING that arrives on a
+// connection which ALREADY owns a bound channel for the session (MS-SMB2
+// §3.3.5.5.2; Samba source3/smbd/smb2_sesssetup.c:785-794 where
+// smbXsrv_session_find_channel returns OK with a valid signing key). It returns
+// a non-nil ACCESS_DENIED result for that re-bind and nil when the gate does not
+// apply (no channel yet — the normal first bind).
+//
+// Distinct from the in-flight bind handshake: that path carries a binding
+// PendingAuth and is routed to completeNTLMAuth before reaching here, and the
+// channel is only registered (AddChannel) once the bind completes. So a channel
+// with a valid signer on this connection means a previous bind already finished
+// — a second bind on the same transport is the smbtorture re-bind
+// (session.c:2839) that must be denied unconditionally, whether the request was
+// signed (its fresh per-bind key cannot match the live channel key anyway) or
+// encrypted (no SMB2 signature, but still not a valid re-bind).
+func (h *Handler) rejectRebindOnBoundChannel(ctx *SMBHandlerContext, sess *session.Session) *HandlerResult {
+	ch := sess.GetChannel(ctx.ConnID)
+	if ch == nil || ch.Signer == nil {
+		return nil
+	}
+
+	logger.Warn("SESSION_SETUP bind rejected: connection already bound to session",
+		"sessionID", ctx.SessionID,
+		"connID", ctx.ConnID,
+		"channelSigningAlgo", fmt.Sprintf("0x%04x", ch.SigningAlgo))
+	return NewErrorResult(types.StatusAccessDenied)
+}
+
 // recordSessionBindIdentity captures the negotiated dialect, signing
 // algorithm, cipher, and client GUID of the origin connection onto the
 // session so subsequent SESSION_SETUP bind requests can validate that a new
@@ -608,6 +636,25 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 	// branches on pending.IsBinding and calls completeSessionBind.
 	if pending, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID); ok && pending.IsBinding {
 		return h.completeNTLMAuth(ctx, req.SecurityBuffer)
+	}
+
+	// Re-bind on an already-bound connection (MS-SMB2 §3.3.5.5.2; Samba
+	// source3/smbd/smb2_sesssetup.c:785-794, smbXsrv_session_find_channel == OK
+	// with a valid signing key). Once a connection holds a bound channel with a
+	// valid signer, a second SESSION_SETUP_BINDING on that same connection — with
+	// no in-flight bind PendingAuth (handled above) — must be rejected rather
+	// than silently replacing the live channel.
+	//
+	// This is the final rejection point in smbtorture's
+	// test_session_bind_negative_smbXtoX (session.c:2839-2842): after the
+	// CMAC<->HMAC bind was accepted, the harness re-binds the same transport and
+	// expects ACCESS_DENIED. The framing verifier skips signature checks for
+	// SESSION_SETUP (keys-not-yet-established), so without this gate the re-bind
+	// reaches completeKerberosBind / completeSessionBind and AddChannel silently
+	// REPLACES the live channel, answering STATUS_SUCCESS
+	// (bind_negative_smb3sign{CtoH,HtoC}{s,d}).
+	if rebindRejected := h.rejectRebindOnBoundChannel(ctx, sess); rebindRejected != nil {
+		return rebindRejected, nil
 	}
 
 	// Kerberos bind is single-shot: the SPNEGO AP-REQ is presented directly on

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures — Kerberos (smb2.session)
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 Tests listed here are expected to fail when running `smb2.session` with
 `--use-kerberos=required`. Only NEW failures (not in this list) will cause
@@ -11,8 +11,11 @@ History: this list once carried 65 rows. After multi-channel session bind
 shipped (#361) the bulk of them began passing under Kerberos; 36 stale rows
 were harvested on 2026-06-01 (reconnect1/2, reauth1-4, the anonymous and
 AES-128 signing/encryption tests, ntlmssp_bug14932, and 18 multi-channel
-`bind_negative_*` rows). The remaining rows are the genuine Kerberos-path
-bugs under #686 (v1.0 Kerberos sweep).
+`bind_negative_*` rows). On 2026-06-02 the four CMAC↔HMAC
+`bind_negative_smb3sign{CtoH,HtoC}{s,d}` rows were fixed (#686): a re-bind on a
+connection that already owns a bound channel is now rejected with ACCESS_DENIED
+instead of silently replacing the channel. The remaining row is the genuine
+Kerberos-path expectation under #686 (v1.0 Kerberos sweep).
 
 ## Kerberos Session Bugs (Fix In Progress)
 
@@ -21,24 +24,3 @@ These are genuine Kerberos-specific bugs tracked in #340 / #686.
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.reauth5 | Reauth | Upstream Samba selftest known-fail (selftest/knownfail.d/ line 213): the test asserts `smb2_util_unlink` of a nonexistent file returns OK, but a correct server returns OBJECT_NAME_NOT_FOUND. Not a DittoFS bug — reauth1-4 (key retention across reauth) pass. | #340-A2 |
-
-## Session-Bind Crypto Negotiation (Fix In Progress)
-
-Multi-channel session bind is implemented (#361). These `bind_negative_*`
-tests assert that a *second* channel bind which changes the signing or
-encryption algorithm relative to the first channel is rejected (MS-SMB2
-§3.3.5.5.2). The cross-algorithm transition matrix (GMAC↔CMAC↔HMAC, GCM↔CCM)
-is already enforced correctly on the Kerberos path — all of those variants
-pass. The four rows below are the CMAC↔HMAC case, where the bind itself is
-accepted (correct) and the follow-up *unsigned re-auth* on the bound channel
-must be rejected. The server now returns ACCESS_DENIED for that re-auth, but the
-signed error reply is mis-decoded as STATUS_OK by the smbtorture client under an
-encrypt-required/keyless fresh-init — a wire-level response-encoding follow-up
-that needs a byte-level pcap diff.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.bind_negative_smb3signCtoHs | Session bind | CMAC→HMAC re-auth: server rejects (ACCESS_DENIED) but signed error reply mis-decoded as OK by client (wire-encoding follow-up) | #686 |
-| smb2.bind_negative_smb3signCtoHd | Session bind | CMAC→HMAC re-auth: server rejects (ACCESS_DENIED) but signed error reply mis-decoded as OK by client (wire-encoding follow-up) | #686 |
-| smb2.bind_negative_smb3signHtoCs | Session bind | HMAC→CMAC re-auth: server rejects (ACCESS_DENIED) but signed error reply mis-decoded as OK by client (wire-encoding follow-up) | #686 |
-| smb2.bind_negative_smb3signHtoCd | Session bind | HMAC→CMAC re-auth: server rejects (ACCESS_DENIED) but signed error reply mis-decoded as OK by client (wire-encoding follow-up) | #686 |


### PR DESCRIPTION
## Summary

Flips the four smbtorture Kerberos tests `smb2.bind_negative_smb3sign{CtoH,HtoC}{s,d}` — the last real failures in the #686 Kerberos sweep (only `reauth5` remains, an upstream Samba selftest known-fail).

## Root cause

These tests bind a second channel that changes the signing algorithm CMAC↔HMAC (neither side GMAC). Per MS-SMB2 §3.3.5.5.2 that bind is correctly **accepted**, then `test_session_bind_negative_smbXtoX` (Samba `source4/torture/smb2/session.c`) exercises three rejection points on the bound transport, all of which must return `ACCESS_DENIED`:

1. `session.c:2796` — signed non-binding re-auth on the bound channel → already rejected by `verifyReauthChannelSignature`.
2. `session.c:2815` — unsigned keyless re-auth → already rejected (#963).
3. `session.c:2839` — a **second `SESSION_SETUP_BINDING` on the same connection** → **was NOT rejected**.

The framing verifier skips signature checks for `SESSION_SETUP` (keys not yet established), so the re-bind reached `completeKerberosBind` / `completeSessionBind` and `AddChannel` **silently REPLACED** the live channel, answering `STATUS_SUCCESS`.

## Fix

Add a gate in `handleSessionBind`, after the in-flight-bind `PendingAuth` check, that rejects a bind arriving on a connection which already owns a bound channel with a valid signer — mirroring Samba `source3/smbd/smb2_sesssetup.c:785-794` (`smbXsrv_session_find_channel` returning OK with a valid signing key is rejected). A legitimate multichannel setup binds **distinct** connections, so a second bind on the same `ConnID` is never valid.

## Verification (docker smbtorture `--kerberos`)

All four targets report `success:`:

```
success: bind_negative_smb3signCtoHs
success: bind_negative_smb3signCtoHd
success: bind_negative_smb3signHtoCs
success: bind_negative_smb3signHtoCd
```

Full `smb2.session` suite under Kerberos (the kerberos CI gate): **Passed 68/71, New failures: 0**. `bind1`, `bind2`, `bind_invalid_auth`, every same-algo / GMAC / cipher `bind_negative` variant, and `reauth1-4` all still `success:` — normal binds are not over-rejected. Only `reauth5` fails (the retained upstream Samba known-fail).

`smb2.multichannel` is unaffected — the new gate fires **zero times** there; its pre-existing oplock/lease-count failures are unrelated and outside the kerberos CI scope (`./run.sh --kerberos --filter smb2.session`).

## Changes

- `internal/adapter/smb/v2/handlers/session_setup.go` — `rejectRebindOnBoundChannel` gate + call site.
- `internal/adapter/smb/v2/handlers/session_reauth_signature_test.go` — unit tests for the gate (re-bind on bound connection → `ACCESS_DENIED`; first bind on unbound connection → not gated).
- `test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md` — remove the four now-passing rows.

Part of #686.