### PR TITLE
feat(bench): concurrent mixed-ops-storm workload + phase/replay capture (#680)

### DIFF
--- a/bench/blockstore/README.md
+++ b/bench/blockstore/README.md
@@ -13,9 +13,37 @@ power both the `dfsbench blockstore` CLI subcommand and the Go
 | `dedup-heavy`      | 8 MiB      | N distinct payloadIDs  | same bytes across files; flush per op so rollup → CAS runs             |
 | `mixed-rw`         | 4 KiB      | seeded 32 MiB file/N   | 50/50 read/write at random offsets                                     |
 | `flush-churn`      | 4 KiB      | monotonic offset       | write→flush→write tight loop                                           |
+| `mixed-ops-storm`  | 4 KiB      | 1 MiB files, ≥4/worker | concurrent WRITE/READ/LIST/DELETE (50/30/15/5); `--workers N`           |
 
 Defaults match the legacy `cmd/blockstore-perf` shape so historical
 results stay comparable. Override per-op size with `--block-size`.
+
+`mixed-ops-storm` is the only concurrent workload. It partitions its
+keyspace — a fixed stable set (pre-seeded, never deleted) backs READs and
+WRITE-overwrites, while WRITE-create/DELETE churn a separate pool — so no
+op ever races a concurrent delete of its own file. Each worker uses a PRNG
+seeded from `(--seed, worker)`, so a given `(seed, workers)` reproduces the
+same *multiset* of ops; goroutine interleaving (and thus the exact per-type
+tally) is not deterministic at `--workers > 1`.
+
+## Profiles & replay
+
+Each run writes `cpu/heap/goroutine.pprof` + `seed.txt` to
+`<profile-dir>/blockstore/[<phase>/]<workload>-<UTC-ts>/`. Add
+`--full-profiles` to also enable the runtime mutex/block profilers and emit
+`mutex.pprof` + `block.pprof` (full-fidelity sampling; off by default — it
+adds per-event accounting overhead). `--phase baseline|post-fix` inserts a
+parent dir so before/after captures sit side by side. `--replay <dir>`
+reloads a recorded run's `seed.txt` (workload, ops, sizes, workers, seed,
+remote, full-profiles) so a regression can be re-captured without retyping
+flags; `--phase`/`--profile-dir` still pick the fresh output location.
+
+```sh
+./dfsbench blockstore --workload mixed-ops-storm --ops 50000 --workers 8 \
+    --full-profiles --phase baseline --profile-dir .planning/v1.0-audit/blockstore/_profiles
+./dfsbench blockstore --replay <baseline-run-dir> --phase post-fix \
+    --profile-dir .planning/v1.0-audit/blockstore/_profiles
+```
 
 ## Running
 
@@ -84,7 +112,8 @@ profiles would be empty, since `runtime.SetMutexProfileFraction` /
 because the extra per-event accounting skews throughput.
 
 `seed.txt` records the exact parameters (workload, ops, block size,
-working set, seed, remote) for deterministic replay.
+working set, workers, seed, remote, full-profiles) for deterministic
+replay via `--replay <dir>`.
 
 ```
 _profiles/blockstore/<workload>-<UTC-timestamp>/

--- a/bench/blockstore/doc.go
+++ b/bench/blockstore/doc.go
@@ -13,6 +13,13 @@
 // gc, raw-s3-put); those expose their own exported Run* helpers in
 // workloads_extra.go and follow the same Opts / Result contract.
 //
+// The mixed-ops-storm is engine-backed but concurrent, so it has its
+// own entry point — RunStorm(ctx, *engine.Store, Opts) — rather than
+// the serial RunWorkload loop. It fans Opts.Ops across Opts.Workers
+// goroutines issuing WRITE/READ/LIST/DELETE and returns the same
+// Result, with Result.Storm carrying the per-op-type tallies. See
+// storm.go for the keyspace partitioning that keeps the ops race-free.
+//
 // The package is intentionally backend-agnostic at the type level:
 // SetupRemote selects memory vs S3 at runtime based on Opts.Remote,
 // and NewEngine wires the standard FSStore + remote + Syncer stack.

--- a/bench/blockstore/storm.go
+++ b/bench/blockstore/storm.go
@@ -1,0 +1,255 @@
+package blockstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+)
+
+// Mixed-ops-storm tuning. The storm targets many small files to exercise
+// metadata churn, dedup, and the local/remote sync path under concurrency
+// rather than raw sequential throughput.
+const (
+	// StormFileSize is the fixed size every storm file is seeded to. Writes
+	// overwrite a block-sized region at a random offset within this size;
+	// reads draw a random offset within it. Fixed size keeps every read/write
+	// offset in range so no op fails on a short file.
+	StormFileSize = 1 * 1024 * 1024
+	// stormCreateOdds is the 1-in-N chance a WRITE creates a brand-new churn
+	// file (seeded to StormFileSize) instead of overwriting a stable one. Low
+	// so most writes are cheap block overwrites.
+	stormCreateOdds = 16
+)
+
+// Op-type weights (out of stormWeightTotal). WRITE/READ dominate; LIST and
+// DELETE are rarer, matching a read-mostly mutating workload.
+const (
+	stormWeightWrite  = 50
+	stormWeightRead   = 30
+	stormWeightList   = 15
+	stormWeightDelete = 5
+	stormWeightTotal  = stormWeightWrite + stormWeightRead + stormWeightList + stormWeightDelete
+)
+
+// churnPool is the storm's concurrency-safe pool of deletable payload IDs.
+//
+// The storm partitions its keyspace to keep ops race-free: a fixed "stable" set
+// (pre-seeded, never deleted) backs all READs and WRITE-overwrites, while this
+// pool holds only files created by WRITE-create and removed by DELETE. Because
+// no payload is ever both a read/write target and a delete target, a worker can
+// never write to a file another worker is concurrently deleting. popRandom is
+// exclusive, so a churn file is deleted at most once.
+//
+// Only payload IDs are tracked, not block refs: the engine resolves a payload's
+// blocks from its ID internally (WriteAt/ReadAt/Delete all accept nil refs).
+type churnPool struct {
+	mu  sync.Mutex
+	ids []string
+	seq atomic.Int64
+}
+
+// nextName returns a unique, not-yet-registered churn payload ID.
+func (p *churnPool) nextName() string {
+	return fmt.Sprintf("perf/storm/c%d", p.seq.Add(1))
+}
+
+// add registers a fully-seeded churn payload as deletable.
+func (p *churnPool) add(pid string) {
+	p.mu.Lock()
+	p.ids = append(p.ids, pid)
+	p.mu.Unlock()
+}
+
+// popRandom removes and returns a random churn payload. ok is false when empty.
+func (p *churnPool) popRandom(rng *rand.Rand) (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.ids) == 0 {
+		return "", false
+	}
+	i := rng.IntN(len(p.ids))
+	pid := p.ids[i]
+	p.ids[i] = p.ids[len(p.ids)-1]
+	p.ids = p.ids[:len(p.ids)-1]
+	return pid, true
+}
+
+// RunStorm drives the concurrent mixed-ops-storm: Opts.Workers goroutines each
+// execute a share of Opts.Ops drawn from WRITE/READ/LIST/DELETE by the weights
+// above. The stable working set is pre-seeded outside the timed region.
+//
+// Determinism: each worker owns a private PRNG seeded from (Opts.Seed, worker)
+// so a given (seed, workers) pair reproduces the same multiset of operations.
+// Goroutine interleaving is not deterministic — two runs with the same inputs
+// issue the same ops but the engine may observe them in a different order. The
+// seed reproduces the workload shape, which is what drives the captured
+// contention profiles; it does not reproduce a byte-exact execution.
+func RunStorm(ctx context.Context, bs *engine.Store, opts Opts) (Result, error) {
+	if bs == nil {
+		return Result{}, fmt.Errorf("RunStorm: bs is nil")
+	}
+	if opts.Ops <= 0 {
+		return Result{}, fmt.Errorf("RunStorm: ops must be > 0")
+	}
+	if opts.BlockSize <= 0 || opts.BlockSize > StormFileSize {
+		return Result{}, fmt.Errorf("RunStorm: block size must be in (0, %d]", StormFileSize)
+	}
+	workers := opts.Workers
+	if workers < 1 {
+		workers = 1
+	}
+
+	// Stable set: at least four files per worker, so readers always have live
+	// targets even at high concurrency.
+	nFiles := max(opts.WorkingSet, workers*4)
+	stable, err := seedStableFiles(ctx, bs, opts, nFiles)
+	if err != nil {
+		return Result{}, err
+	}
+	churn := &churnPool{}
+
+	var counts StormCounts
+	statsBefore := bs.GetStats()
+	start := time.Now()
+
+	gctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var (
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		firstErr error
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			if err := runStormWorker(gctx, bs, opts, stable, churn, worker, workers, &counts); err != nil {
+				errOnce.Do(func() {
+					firstErr = err
+					cancel()
+				})
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return Result{}, firstErr
+	}
+
+	dur := time.Since(start)
+	statsAfter := bs.GetStats()
+	// Approximate throughput: every write/read moves one block. Churn-create
+	// writes actually move StormFileSize, but at 1-in-stormCreateOdds they are
+	// rare enough (<0.5% of bytes) that folding them in isn't worth a separate
+	// counter — this drives the displayed bytes/sec, not any invariant.
+	bytes := (counts.Writes + counts.Reads) * int64(opts.BlockSize)
+	return Result{
+		Duration:    dur,
+		Ops:         opts.Ops,
+		Bytes:       bytes,
+		StatsBefore: statsBefore,
+		StatsAfter:  statsAfter,
+		Storm:       &counts,
+	}, nil
+}
+
+// runStormWorker executes this worker's share of the op stream: global op
+// indices i where i%workers == worker. The worker owns a private PRNG and
+// scratch buffers; only the stable set, churn pool, and atomic counters are
+// shared.
+func runStormWorker(ctx context.Context, bs *engine.Store, opts Opts, stable []string, churn *churnPool, worker, workers int, counts *StormCounts) error {
+	rng := rand.New(rand.NewPCG(opts.Seed, uint64(worker)+1))
+	wbuf := make([]byte, opts.BlockSize)
+	rbuf := make([]byte, opts.BlockSize)
+	maxOff := uint64(StormFileSize - opts.BlockSize)
+
+	for i := worker; i < opts.Ops; i += workers {
+		if ctx.Err() != nil {
+			return nil // another worker failed; stop quietly
+		}
+		switch pickStormOp(rng) {
+		case opWrite:
+			if rng.IntN(stormCreateOdds) == 0 {
+				// Create a new churn file: seed it fully, then publish it as
+				// deletable. Registering only after seeding means DELETE never
+				// races a half-written file.
+				pid := churn.nextName()
+				if err := seedPayload(ctx, bs, pid, seededBytes(rng.Uint64(), StormFileSize)); err != nil {
+					return err
+				}
+				churn.add(pid)
+			} else {
+				pid := stable[rng.IntN(len(stable))]
+				fillRandom(rng, wbuf)
+				if _, err := bs.WriteAt(ctx, pid, nil, wbuf, rng.Uint64N(maxOff+1)); err != nil {
+					return fmt.Errorf("storm write %s: %w", pid, err)
+				}
+			}
+			atomic.AddInt64(&counts.Writes, 1)
+		case opRead:
+			pid := stable[rng.IntN(len(stable))]
+			if _, err := bs.ReadAt(ctx, pid, nil, rbuf, rng.Uint64N(maxOff+1)); err != nil {
+				return fmt.Errorf("storm read %s: %w", pid, err)
+			}
+			atomic.AddInt64(&counts.Reads, 1)
+		case opList:
+			_ = bs.ListFiles()
+			atomic.AddInt64(&counts.Lists, 1)
+		case opDelete:
+			pid, ok := churn.popRandom(rng)
+			if !ok {
+				continue // nothing to delete yet
+			}
+			if err := bs.Delete(ctx, pid, nil); err != nil {
+				return fmt.Errorf("storm delete %s: %w", pid, err)
+			}
+			atomic.AddInt64(&counts.Deletes, 1)
+		}
+	}
+	return nil
+}
+
+// seedStableFiles seeds nFiles distinct StormFileSize payloads (outside the
+// timed region) and returns their fixed payload-ID set.
+func seedStableFiles(ctx context.Context, bs *engine.Store, opts Opts, nFiles int) ([]string, error) {
+	ids := make([]string, nFiles)
+	for i := 0; i < nFiles; i++ {
+		pid := fmt.Sprintf("perf/storm/%d", i)
+		// Distinct bytes per file so the seed isn't one giant dedup class.
+		if err := seedPayload(ctx, bs, pid, seededBytes(opts.Seed^uint64(i+1), StormFileSize)); err != nil {
+			return nil, err
+		}
+		ids[i] = pid
+	}
+	return ids, nil
+}
+
+type stormOp int
+
+const (
+	opWrite stormOp = iota
+	opRead
+	opList
+	opDelete
+)
+
+// pickStormOp draws an op type by the configured weights.
+func pickStormOp(rng *rand.Rand) stormOp {
+	r := rng.IntN(stormWeightTotal)
+	switch {
+	case r < stormWeightWrite:
+		return opWrite
+	case r < stormWeightWrite+stormWeightRead:
+		return opRead
+	case r < stormWeightWrite+stormWeightRead+stormWeightList:
+		return opList
+	default:
+		return opDelete
+	}
+}

--- a/bench/blockstore/storm_test.go
+++ b/bench/blockstore/storm_test.go
@@ -1,0 +1,106 @@
+package blockstore
+
+import (
+	"context"
+	"testing"
+
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+)
+
+// TestRunStorm_Concurrent exercises the storm at single- and multi-worker
+// concurrency with a tiny op count, asserting it completes, issues at least one
+// of each common op type, and never tallies more ops than requested.
+func TestRunStorm_Concurrent(t *testing.T) {
+	cases := []struct {
+		name    string
+		workers int
+	}{
+		{"serial", 1},
+		{"parallel", 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			defer closeFn()
+
+			const ops = 400
+			res, err := RunStorm(context.Background(), bs, Opts{
+				Workload:   WorkloadMixedOpStorm,
+				Ops:        ops,
+				BlockSize:  4 * 1024,
+				WorkingSet: 4,
+				Workers:    tc.workers,
+				Seed:       7,
+			})
+			if err != nil {
+				t.Fatalf("RunStorm: %v", err)
+			}
+			if res.Storm == nil {
+				t.Fatal("Storm counts are nil")
+			}
+			sum := res.Storm.Writes + res.Storm.Reads + res.Storm.Lists + res.Storm.Deletes
+			// Reads/deletes can be skipped (empty set / delete floor), so the
+			// executed total may be <= ops, but never more.
+			if sum <= 0 || sum > ops {
+				t.Errorf("executed op sum = %d, want in (0, %d]", sum, ops)
+			}
+			if res.Storm.Writes == 0 {
+				t.Error("expected at least one write")
+			}
+			if res.Duration <= 0 {
+				t.Errorf("Duration = %v, want > 0", res.Duration)
+			}
+		})
+	}
+}
+
+// TestRunStorm_DeterministicAtSingleWorker verifies that with a fixed seed and
+// one worker the op multiset is reproducible: op types and skip decisions are
+// driven by a single PRNG, so two runs tally identically. (At workers>1
+// goroutine interleaving makes only the shape, not the exact counts, stable.)
+func TestRunStorm_DeterministicAtSingleWorker(t *testing.T) {
+	run := func() StormCounts {
+		bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		defer closeFn()
+		res, err := RunStorm(context.Background(), bs, Opts{
+			Workload:   WorkloadMixedOpStorm,
+			Ops:        300,
+			BlockSize:  4 * 1024,
+			WorkingSet: 4,
+			Workers:    1,
+			Seed:       42,
+		})
+		if err != nil {
+			t.Fatalf("RunStorm: %v", err)
+		}
+		return *res.Storm
+	}
+	a, b := run(), run()
+	if a != b {
+		t.Errorf("non-deterministic counts at workers=1: %+v vs %+v", a, b)
+	}
+}
+
+// TestRunStorm_RejectsBadBlockSize guards the offset-range invariant: a block
+// larger than a storm file would make every write/read offset illegal.
+func TestRunStorm_RejectsBadBlockSize(t *testing.T) {
+	bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer closeFn()
+	if _, err := RunStorm(context.Background(), bs, Opts{
+		Workload:  WorkloadMixedOpStorm,
+		Ops:       1,
+		BlockSize: StormFileSize + 1,
+		Workers:   1,
+	}); err == nil {
+		t.Fatal("expected error for block size > StormFileSize")
+	}
+}

--- a/bench/blockstore/workloads.go
+++ b/bench/blockstore/workloads.go
@@ -20,6 +20,10 @@ const (
 	WorkloadDedupHeavy      = "dedup-heavy"
 	WorkloadMixedRW         = "mixed-rw"
 	WorkloadFlushChurn      = "flush-churn"
+	// WorkloadMixedOpStorm is the concurrent WRITE/READ/LIST/DELETE storm.
+	// Unlike the workloads above it runs across Opts.Workers goroutines and
+	// dispatches through RunStorm (storm.go), not the serial RunWorkload loop.
+	WorkloadMixedOpStorm = "mixed-ops-storm"
 )
 
 // Default block sizes — match the legacy cmd/blockstore-perf shape so
@@ -65,6 +69,11 @@ type Opts struct {
 	// Seed is the PRNG seed for offsets and payload fill. 0 is valid.
 	Seed uint64
 
+	// Workers is the goroutine count for concurrent workloads
+	// (mixed-ops-storm). Values < 1 are treated as 1. Ignored by the
+	// serial workloads, which always run single-threaded.
+	Workers int
+
 	// Remote selects the upload backend: "memory" (default) or "s3".
 	Remote string
 
@@ -90,6 +99,18 @@ type Result struct {
 	// before / after the timed region.
 	StatsBefore engine.BlockStoreStats
 	StatsAfter  engine.BlockStoreStats
+
+	// Storm holds the per-op-type tallies for the mixed-ops-storm
+	// workload; nil for every other workload.
+	Storm *StormCounts
+}
+
+// StormCounts tallies executed operations by type for the mixed-ops-storm.
+type StormCounts struct {
+	Writes  int64
+	Reads   int64
+	Lists   int64
+	Deletes int64
 }
 
 // RunWorkload is the single dispatcher used by the cmd/bench CLI. It

--- a/cmd/bench/blockstore.go
+++ b/cmd/bench/blockstore.go
@@ -14,10 +14,13 @@ var (
 	bsOps            int
 	bsBlockSize      int
 	bsWorkingSet     int
+	bsWorkers        int
 	bsSeed           uint64
 	bsRemote         string
 	bsGCGarbageRatio float64
 	bsFullProfiles   bool
+	bsPhase          string
+	bsReplay         string
 )
 
 var blockstoreCmd = &cobra.Command{
@@ -26,12 +29,16 @@ var blockstoreCmd = &cobra.Command{
 	Long: `Composes FSStore local + remote (memory or s3) + in-memory metadata +
 Syncer and drives one of:
   sequential-write | random-write | dedup-heavy | mixed-rw | flush-churn
+  mixed-ops-storm (concurrent WRITE/READ/LIST/DELETE; use --workers)
   walk | delete | gc | raw-s3-put
 
 Captures wall-clock, throughput, and CPU + heap + goroutine pprof to
-<profile-dir>/blockstore/<workload>-<timestamp>/. Add --full-profiles to
-also enable the runtime mutex + block profilers and emit mutex.pprof +
-block.pprof (off by default — they add per-event accounting overhead).`,
+<profile-dir>/blockstore/[<phase>/]<workload>-<timestamp>/. Add
+--full-profiles to also enable the runtime mutex + block profilers and emit
+mutex.pprof + block.pprof (off by default — they add per-event accounting
+overhead). --phase baseline|post-fix nests the capture so before/after runs
+sit side by side. --replay <dir> reproduces a recorded run from its
+seed.txt.`,
 	RunE: runBlockstore,
 }
 
@@ -42,22 +49,41 @@ func init() {
 	flags.IntVar(&bsBlockSize, "block-size", 0, "per-op block size in bytes (default: 8 MiB for sequential/dedup, 4 KiB otherwise)")
 	flags.IntVar(&bsWorkingSet, "working-set", 1, "number of files in the working set")
 	flags.Uint64Var(&bsSeed, "seed", 1, "PRNG seed for randomized workloads")
+	flags.IntVar(&bsWorkers, "workers", 1, "concurrent worker goroutines (mixed-ops-storm only)")
 	flags.StringVar(&bsRemote, "remote", bsbench.RemoteMemory, "remote backend: memory | s3")
 	flags.Float64Var(&bsGCGarbageRatio, "gc-garbage-ratio", bsbench.DefaultGCGarbage, "fraction of seeded chunks left unreferenced for the gc workload")
 	flags.BoolVar(&bsFullProfiles, "full-profiles", false, "also capture mutex + block profiles (enables runtime mutex/block profilers; adds overhead)")
-	_ = blockstoreCmd.MarkFlagRequired("workload")
+	flags.StringVar(&bsPhase, "phase", "", "optional capture phase subdir under <profile-dir>/blockstore/ (e.g. baseline | post-fix)")
+	flags.StringVar(&bsReplay, "replay", "", "replay a recorded run: load workload params from <dir>/seed.txt (overrides other flags except --phase/--profile-dir)")
+	// --workload is required unless replaying, where it comes from seed.txt.
 }
 
 func runBlockstore(cmd *cobra.Command, _ []string) error {
-	blockSize := resolveBlockSize(bsWorkload, bsBlockSize)
-	opts := bsbench.Opts{
-		Workload:   bsWorkload,
-		Ops:        bsOps,
-		BlockSize:  blockSize,
-		WorkingSet: bsWorkingSet,
-		Seed:       bsSeed,
-		Remote:     bsRemote,
-		ProfileDir: flagProfileDir,
+	var opts bsbench.Opts
+	if bsReplay != "" {
+		// Reproduce a recorded run from its seed.txt. --profile-dir and --phase
+		// still apply so the replay lands in a fresh capture dir.
+		loaded, full, err := loadSeed(bsReplay)
+		if err != nil {
+			return fmt.Errorf("replay: %w", err)
+		}
+		opts = loaded
+		opts.ProfileDir = flagProfileDir
+		bsFullProfiles = full
+	} else {
+		if bsWorkload == "" {
+			return fmt.Errorf("--workload is required (or use --replay <dir>)")
+		}
+		opts = bsbench.Opts{
+			Workload:   bsWorkload,
+			Ops:        bsOps,
+			BlockSize:  resolveBlockSize(bsWorkload, bsBlockSize),
+			WorkingSet: bsWorkingSet,
+			Workers:    bsWorkers,
+			Seed:       bsSeed,
+			Remote:     bsRemote,
+			ProfileDir: flagProfileDir,
+		}
 	}
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -80,10 +106,51 @@ func runBlockstore(cmd *cobra.Command, _ []string) error {
 		return runGCWorkload(ctx, cmd, opts)
 	case bsbench.WorkloadRawS3Put:
 		return runRawS3Workload(ctx, cmd, opts)
+	case bsbench.WorkloadMixedOpStorm:
+		return runStormWorkload(ctx, cmd, opts, tmpDir)
 	default:
 		// Engine-backed workloads (sequential-write, random-write, ...).
 		return runEngineWorkload(ctx, cmd, opts, tmpDir)
 	}
+}
+
+// runStormWorkload wires the engine like runEngineWorkload but drives the
+// concurrent mixed-ops-storm via RunStorm and prints the per-op-type tallies.
+func runStormWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts, tmpDir string) error {
+	remoteStore, remoteClose, err := bsbench.SetupRemote(ctx, opts)
+	if err != nil {
+		return err
+	}
+	bs, engineClose, err := bsbench.NewEngine(tmpDir, remoteStore)
+	if err != nil {
+		remoteClose()
+		return err
+	}
+	defer engineClose()
+
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
+
+	res, err := bsbench.RunStorm(ctx, bs, opts)
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
+	if err != nil {
+		return err
+	}
+	printResult(cmd, opts, res, sess.dir, true)
+	if res.Storm != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"storm ops: workers=%d writes=%d reads=%d lists=%d deletes=%d\n",
+			opts.Workers, res.Storm.Writes, res.Storm.Reads, res.Storm.Lists, res.Storm.Deletes)
+	}
+	return nil
 }
 
 func runEngineWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts, tmpDir string) error {
@@ -101,7 +168,7 @@ func runEngineWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opt
 	}
 	defer engineClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -128,7 +195,7 @@ func runLocalWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer closeFn()
 
-	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -161,7 +228,7 @@ func runGCWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts) e
 	}
 	defer remoteClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -188,7 +255,7 @@ func runRawS3Workload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer remoteClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
+	"strings"
 	"time"
 
 	bsbench "github.com/marmos91/dittofs/bench/blockstore"
@@ -40,14 +42,21 @@ const (
 	blockProfileRate = 1
 )
 
-// startProfileSession creates <root>/blockstore/<workload>-<UTC-ts>/ and
-// begins CPU profiling. When full is set it also turns on the mutex and
-// block profilers. The caller must invoke stop() exactly once, after the
-// timed region, to flush every profile and restore runtime profiler
-// state. On error the partially-started session is rolled back.
-func startProfileSession(rootDir, workload string, full bool) (*profileSession, error) {
+// startProfileSession creates <root>/blockstore/[<phase>/]<workload>-<UTC-ts>/
+// and begins CPU profiling. When phase is non-empty (e.g. "baseline" or
+// "post-fix") it is inserted as a parent directory so before/after captures
+// sit side by side. When full is set it also turns on the mutex and block
+// profilers. The caller must invoke stop() exactly once, after the timed
+// region, to flush every profile and restore runtime profiler state. On error
+// the partially-started session is rolled back.
+func startProfileSession(rootDir, phase, workload string, full bool) (*profileSession, error) {
 	ts := time.Now().UTC().Format("20060102T150405Z")
-	dir := filepath.Join(rootDir, "blockstore", fmt.Sprintf("%s-%s", workload, ts))
+	parts := []string{rootDir, "blockstore"}
+	if phase != "" {
+		parts = append(parts, phase)
+	}
+	parts = append(parts, fmt.Sprintf("%s-%s", workload, ts))
+	dir := filepath.Join(parts...)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir profiles: %w", err)
 	}
@@ -102,20 +111,70 @@ func (s *profileSession) stop() error {
 }
 
 // writeSeed records the exact replay parameters next to the profiles as
-// seed.txt — workload, ops, block size, working set, seed, remote. Re-run
-// with the same values to reproduce the captured profile set.
+// seed.txt — workload, ops, block size, working set, workers, seed, remote,
+// full-profiles. Re-run via --replay to reproduce the captured profile set.
 func (s *profileSession) writeSeed(opts bsbench.Opts) error {
 	if s == nil {
 		return nil
 	}
 	body := fmt.Sprintf(
-		"workload=%s\nops=%d\nblock_size=%d\nworking_set=%d\nseed=%d\nremote=%s\nfull_profiles=%t\n",
-		opts.Workload, opts.Ops, opts.BlockSize, opts.WorkingSet, opts.Seed, opts.Remote, s.full,
+		"workload=%s\nops=%d\nblock_size=%d\nworking_set=%d\nworkers=%d\nseed=%d\nremote=%s\nfull_profiles=%t\n",
+		opts.Workload, opts.Ops, opts.BlockSize, opts.WorkingSet, opts.Workers, opts.Seed, opts.Remote, s.full,
 	)
 	if err := os.WriteFile(filepath.Join(s.dir, "seed.txt"), []byte(body), 0o644); err != nil {
 		return fmt.Errorf("write seed.txt: %w", err)
 	}
 	return nil
+}
+
+// loadSeed reads a seed.txt written by writeSeed and reconstructs the workload
+// Opts plus the full-profiles flag, so `--replay <dir>` reproduces a recorded
+// run exactly. ProfileDir is left to the caller (the replay writes a fresh
+// capture dir). Unknown keys are ignored so older/newer seed files still load.
+func loadSeed(dir string) (bsbench.Opts, bool, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, "seed.txt"))
+	if err != nil {
+		return bsbench.Opts{}, false, fmt.Errorf("read seed.txt: %w", err)
+	}
+	kv := map[string]string{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok {
+			kv[k] = v
+		}
+	}
+	opts := bsbench.Opts{
+		Workload:   kv["workload"],
+		Ops:        atoiDefault(kv["ops"], 0),
+		BlockSize:  atoiDefault(kv["block_size"], 0),
+		WorkingSet: atoiDefault(kv["working_set"], 1),
+		Workers:    atoiDefault(kv["workers"], 1),
+		// Seed is a uint64 — parse the full range, not via Atoi (which is
+		// signed and would silently drop any seed > math.MaxInt64 to 0,
+		// reproducing the wrong PRNG stream on replay).
+		Seed:   parseUintDefault(kv["seed"], 0),
+		Remote: kv["remote"],
+	}
+	if opts.Workload == "" || opts.Ops <= 0 {
+		return bsbench.Opts{}, false, fmt.Errorf("seed.txt missing required workload/ops")
+	}
+	return opts, kv["full_profiles"] == "true", nil
+}
+
+// atoiDefault parses s as an int, returning def on any parse failure.
+func atoiDefault(s string, def int) int {
+	if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil {
+		return n
+	}
+	return def
+}
+
+// parseUintDefault parses s as a uint64, returning def on any parse failure.
+func parseUintDefault(s string, def uint64) uint64 {
+	if n, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64); err == nil {
+		return n
+	}
+	return def
 }
 
 // writeNamedProfile writes the named runtime profile to <dir>/<file>.pprof.

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -50,6 +50,11 @@ const (
 // region, to flush every profile and restore runtime profiler state. On error
 // the partially-started session is rolled back.
 func startProfileSession(rootDir, phase, workload string, full bool) (*profileSession, error) {
+	// phase is a single directory name, not a path: reject separators / "."/".."
+	// so a stray --phase can't escape <rootDir>/blockstore via filepath.Join.
+	if phase != "" && (phase != filepath.Base(phase) || phase == "." || phase == "..") {
+		return nil, fmt.Errorf("invalid phase %q: must be a single path element", phase)
+	}
 	ts := time.Now().UTC().Format("20060102T150405Z")
 	parts := []string{rootDir, "blockstore"}
 	if phase != "" {

--- a/cmd/bench/profiles_test.go
+++ b/cmd/bench/profiles_test.go
@@ -206,6 +206,16 @@ func TestLoadSeed_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestStartProfileSession_RejectsBadPhase guards against a --phase that would
+// escape <profile-dir>/blockstore via filepath.Join.
+func TestStartProfileSession_RejectsBadPhase(t *testing.T) {
+	for _, phase := range []string{"..", ".", "../evil", "a/b", "/abs"} {
+		if _, err := startProfileSession(t.TempDir(), phase, "wl", false); err == nil {
+			t.Errorf("phase %q: expected error, got nil", phase)
+		}
+	}
+}
+
 // TestLoadSeed_Missing surfaces a clear error when the dir has no seed.txt.
 func TestLoadSeed_Missing(t *testing.T) {
 	if _, _, err := loadSeed(t.TempDir()); err == nil {

--- a/cmd/bench/profiles_test.go
+++ b/cmd/bench/profiles_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +16,7 @@ import (
 // does NOT write mutex/block.
 func TestProfileSession_BasicProfilesNonEmpty(t *testing.T) {
 	root := t.TempDir()
-	sess, err := startProfileSession(root, "unit", false)
+	sess, err := startProfileSession(root, "", "unit", false)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestProfileSession_BasicProfilesNonEmpty(t *testing.T) {
 // contention here proves the session enables them.
 func TestProfileSession_FullProfilesNonEmpty(t *testing.T) {
 	root := t.TempDir()
-	sess, err := startProfileSession(root, "unit-full", true)
+	sess, err := startProfileSession(root, "", "unit-full", true)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestProfileSession_FullProfilesNonEmpty(t *testing.T) {
 // TestProfileSession_StopIdempotent confirms the deferred safety stop is
 // a no-op once the happy-path stop has run.
 func TestProfileSession_StopIdempotent(t *testing.T) {
-	sess, err := startProfileSession(t.TempDir(), "unit-idem", false)
+	sess, err := startProfileSession(t.TempDir(), "", "unit-idem", false)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -130,4 +131,84 @@ func contendMutexAndBlock() {
 		<-ch
 	}
 	wg.Wait()
+}
+
+// TestStartProfileSession_PhaseSubdir verifies a non-empty phase is inserted
+// as a parent dir so baseline/post-fix captures sit side by side, and that an
+// empty phase preserves the original flat layout.
+func TestStartProfileSession_PhaseSubdir(t *testing.T) {
+	root := t.TempDir()
+	// Only one CPU profile can be active per process, so each session is
+	// stopped before the next starts.
+	sess, err := startProfileSession(root, "baseline", "wl", false)
+	if err != nil {
+		t.Fatalf("startProfileSession: %v", err)
+	}
+	sessDir := sess.dir
+	_ = sess.stop()
+	if !strings.Contains(sessDir, filepath.Join("blockstore", "baseline")+string(filepath.Separator)+"wl-") {
+		t.Errorf("phase not in path: %s", sessDir)
+	}
+
+	flat, err := startProfileSession(root, "", "wl", false)
+	if err != nil {
+		t.Fatalf("startProfileSession (flat): %v", err)
+	}
+	flatDir := flat.dir
+	_ = flat.stop()
+	if !strings.Contains(flatDir, filepath.Join("blockstore", "wl-")) || strings.Contains(flatDir, "baseline") {
+		t.Errorf("empty phase should keep flat layout: %s", flatDir)
+	}
+}
+
+// TestLoadSeed_RoundTrip writes a seed.txt via the session and reloads it,
+// asserting every replay-relevant field (including workers) round-trips so
+// --replay reproduces a recorded run.
+func TestLoadSeed_RoundTrip(t *testing.T) {
+	// The large-seed case guards the uint64 parse: a seed above math.MaxInt64
+	// must survive the round-trip (signed Atoi would silently drop it to 0).
+	cases := []struct {
+		name string
+		want bsbench.Opts
+	}{
+		{"small-seed", bsbench.Opts{
+			Workload: "mixed-ops-storm", Ops: 1234, BlockSize: 8192,
+			WorkingSet: 16, Workers: 8, Seed: 99, Remote: "memory",
+		}},
+		{"max-uint64-seed", bsbench.Opts{
+			Workload: "mixed-ops-storm", Ops: 10, BlockSize: 4096,
+			WorkingSet: 1, Workers: 2, Seed: math.MaxUint64, Remote: "memory",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sess, err := startProfileSession(t.TempDir(), "", "mixed-ops-storm", true)
+			if err != nil {
+				t.Fatalf("startProfileSession: %v", err)
+			}
+			defer func() { _ = sess.stop() }()
+			if err := sess.writeSeed(tc.want); err != nil {
+				t.Fatalf("writeSeed: %v", err)
+			}
+			got, full, err := loadSeed(sess.dir)
+			if err != nil {
+				t.Fatalf("loadSeed: %v", err)
+			}
+			if !full {
+				t.Error("full_profiles should round-trip as true")
+			}
+			if got.Workload != tc.want.Workload || got.Ops != tc.want.Ops || got.BlockSize != tc.want.BlockSize ||
+				got.WorkingSet != tc.want.WorkingSet || got.Workers != tc.want.Workers || got.Seed != tc.want.Seed ||
+				got.Remote != tc.want.Remote {
+				t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadSeed_Missing surfaces a clear error when the dir has no seed.txt.
+func TestLoadSeed_Missing(t *testing.T) {
+	if _, _, err := loadSeed(t.TempDir()); err == nil {
+		t.Fatal("expected error for missing seed.txt")
+	}
 }


### PR DESCRIPTION
First slice of #680 (proactive pprof capture). Branch `v1.0/perf-pass`. Builds on the 5-profile envelope that landed with #671.

## What

The block-store/engine capture path: a concurrent **mixed-ops-storm** workload plus the harness flags needed to drive before/after captures.

### `mixed-ops-storm` workload
- `--workers N` goroutines issue a weighted **WRITE/READ/LIST/DELETE** stream (50/30/15/5) — surfaces lock/block contention the existing serial workloads can't.
- **Keyspace partitioned to stay race-free:** a fixed `stable` set (pre-seeded, never deleted) backs READs and WRITE-overwrites; a separate `churn` pool is the only create/delete target. No op ever races a concurrent delete of its own file — verified under `go test -race`.
- Tracks only payload IDs, not block refs: the engine resolves a payload's blocks from its ID internally (`WriteAt`/`ReadAt`/`Delete` accept `nil` refs).
- **Determinism:** each worker's PRNG is seeded from `(seed, worker)`, so `(seed, workers)` reproduces the op *multiset*; goroutine interleaving (and thus the exact per-type tally) is not deterministic at `workers>1` — documented.

### Harness flags
- `--workers` — storm concurrency.
- `--phase baseline|post-fix` — nests the capture dir (`<profile-dir>/blockstore/<phase>/<workload>-<ts>/`) so before/after runs sit side by side. Empty phase preserves the existing flat layout.
- `--replay <dir>` — reloads a recorded run's `seed.txt` (workload, ops, sizes, **workers**, seed, remote, full-profiles) and re-captures without retyping flags; `--phase`/`--profile-dir` still pick the fresh output location. `seed.txt` now records `workers`.

## Verification
- `go build ./...`, `go vet`, `gofmt -l` clean; `go test -race ./bench/blockstore/ ./cmd/bench/` green.
- Live smoke: `--full-profiles --workers 4` emits non-empty cpu/heap/goroutine/mutex/block.pprof + seed.txt; `mutex.pprof` shows real contention samples (76% `sync.Mutex.Unlock`). `--replay` reproduces from `seed.txt`.
- Reviewer-caught bug fixed: `loadSeed` parsed the uint64 seed via signed `Atoi` (seeds > MaxInt64 silently → 0, breaking replay) → now `ParseUint`, with a `math.MaxUint64` round-trip test.

## Scope / follow-ups
This is the blockstore slice only (per the locked decision in `.planning/v1.0-audit/680-perf-capture-SCOPE.md`). Per-area SMB/NFS/lock/runtime capture wrappers reuse this envelope and are follow-ups. #680 stays open until those land. Pure concurrent (a)-(d) read/write variants can also reuse the `--workers` primitive later.