### PR TITLE
docs(smb): rationalize KNOWN_FAILURES — justify/appendix all entries (#673)

### DIFF
--- a/test/smb-conformance/KNOWN_FAILURES.md
+++ b/test/smb-conformance/KNOWN_FAILURES.md
@@ -10,11 +10,11 @@ all failures are in this list. New failures not listed here will cause CI to fai
 Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain.
 
-| Bucket | Count | Where |
-|--------|-------|-------|
-| **Flaky** (justified — identical wire trace to the passing develop run; outcome hinges on WPTS-framework cleanup-phase exception handling) | 1 | `BVT_DirectoryLeasing_ReadWriteHandleCaching` |
-| **Permanently Unimplementable / out-of-scope** (appendix) | 39 | VHD/RSVD ×26, SWN ×6, SQoS ×3, DFS ×2, NamedPipe ×2 |
-| **Total** | **40** | |
+- **Flaky** (justified — identical wire trace to the passing develop run; outcome hinges on WPTS-framework cleanup-phase exception handling) — **1**: `BVT_DirectoryLeasing_ReadWriteHandleCaching`
+- **Permanently Unimplementable / out-of-scope** (appendix) — **39**: VHD/RSVD ×26, SWN ×6, SQoS ×3, DFS ×2, NamedPipe ×2
+- **Total: 40**
+
+(Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
 No WPTS entry is deferred-with-issue: every fixable BVT test has already been
 flipped, leaving one flaky row and the architecturally out-of-scope appendix.

--- a/test/smb-conformance/KNOWN_FAILURES.md
+++ b/test/smb-conformance/KNOWN_FAILURES.md
@@ -1,9 +1,23 @@
 # Known Failures - SMB Conformance (WPTS BVT)
 
-Last updated: 2026-05-28 (Wave 4 WPTS sweep: walk back 4 confirmed PASS — 3 on develop + 1 from ADS base ChangeTime freeze fix — and add Permanently Unimplementable appendix)
+Last updated: 2026-06-02 (#673 rationalization pass — Final Tally added, every entry confirmed bucketed and justified; docs-only)
 
 Tests listed here are expected to fail. CI will pass (exit 0) as long as
 all failures are in this list. New failures not listed here will cause CI to fail.
+
+## Final Tally (#673 v1.0 conformance gate)
+
+Every remaining entry is justified and falls into exactly one bucket. No
+UNJUSTIFIED entries remain.
+
+| Bucket | Count | Where |
+|--------|-------|-------|
+| **Flaky** (justified — identical wire trace to the passing develop run; outcome hinges on WPTS-framework cleanup-phase exception handling) | 1 | `BVT_DirectoryLeasing_ReadWriteHandleCaching` |
+| **Permanently Unimplementable / out-of-scope** (appendix) | 39 | VHD/RSVD ×26, SWN ×6, SQoS ×3, DFS ×2, NamedPipe ×2 |
+| **Total** | **40** | |
+
+No WPTS entry is deferred-with-issue: every fixable BVT test has already been
+flipped, leaving one flaky row and the architecturally out-of-scope appendix.
 
 The `parse-results.sh` script reads test names from the first column of the
 table below. Lines starting with `#`, `|---`, empty lines, and the header
@@ -156,6 +170,7 @@ Format for Permanently Unimplementable:
 
 ## Changelog
 
+- **#673 (2026-06-02):** Docs-only rationalization. Added a Final Tally header block (1 flaky + 39 appendix = 40). Confirmed every entry is bucketed and justified; the lone Expected row (`BVT_DirectoryLeasing_ReadWriteHandleCaching`) is explicitly classified Flaky. No rows added or removed — CI pass/fail unaffected.
 - **Wave 4 (2026-05-28):** Walk back 4 confirmed PASS. Three were already passing on develop: `Algorithm_NotingFileModified_Dir_LastAccessTime`, `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime`, `BVT_DirectoryLeasing_LeaseBreakOnMultiClients`. The fourth, `FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime`, was flipped by an ADS-write fix that preserves the base object's frozen ChangeTime — previously, file_modify.go auto-bumped Ctime to NOW whenever `modified=true && attrs.Ctime==nil`, clobbering the freeze even when only the ADS handle's Mtime was unfrozen. Restructure with Permanently Unimplementable appendix mirroring the smbtorture file layout.
 - **v0.10.0 Phase 73 (2026-03-24):** SMB Conformance Deep-Dive. Plan 01: ChangeNotify ADS stream notifications wired (5 tests). Plan 02: ADS share access + timestamp conformance (9 ADS + 3 timestamp tests removed). Plan 03: ChangeNotify completion, session re-auth, anonymous encryption (~25 smbtorture tests). Plan 04: DH/lease state machine fixes (~26 smbtorture tests). Plan 05: Per-field CreationTime freeze/unfreeze, ChangeEa reclassified as Permanent. Total: 56 (53 permanent + 3 expected).
 - **v0.10.0 Phase 72 (2026-03-23):** ChangeNotify fully implemented with async responses, CANCEL support, and all MS-SMB2 completion filter events (Plan 01, 16 tests fixed). Client-preference cipher/signing selection, DH V1 volatile FileID regeneration, TREE_DISCONNECT signing exemption, lease V1/V2 state transitions fixed (Plan 02, 12 tests fixed). Timestamp freeze/unfreeze per MS-FSA 2.1.5.14.2, parent directory atime on file write (Plan 03, 3 tests fixed). Total removed: 31. New total: 65 (52 permanent + 13 expected).

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -10,12 +10,12 @@ Only NEW failures (not in this list) will cause CI to fail.
 Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
-| Bucket | Count | Where |
-|--------|-------|-------|
-| **Upstream Samba known-fail** (fails on the reference Samba server too; cited) | 3 | `charset.Testing`, `notify.valid-req`, `session.reauth5` |
-| **Deferred past v1.0 with a tracking issue** (justified by deferral) | 22 | `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 19 replay `*-sane` / `replay-dhv2-oplock2` rows (#749) |
-| **Permanently Unimplementable / harness-only** (appendix) | 46 | see [appendix](#permanently-unimplementable-out-of-scope) |
-| **Total (non-Kerberos)** | **71** | |
+- **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **3**: `charset.Testing`, `notify.valid-req`, `session.reauth5`
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **22**: `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 19 replay `*-sane` / `replay-dhv2-oplock2` rows (#749)
+- **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **46**
+- **Total (non-Kerberos): 71**
+
+(Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
 Kerberos: 1 row in `KNOWN_FAILURES_KERBEROS.md` (`reauth5`, upstream knownfail),
 loaded only under `--use-kerberos` (excluded from the v1.0 CI gate).
@@ -346,7 +346,7 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 
 ### Kerberos
 
-`KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`), so it does not gate v1.0.
+`KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running `./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Changelog
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,9 +1,31 @@
 # smbtorture Known Failures
 
-Last updated: 2026-05-29 (#743 follow-up — walk back the 6 `smb2.dirlease.*` residuals now PASSing post PR #784: hardlink, rename, unlink_{same,different}_{initial,set}_and_close, v2_request)
+Last updated: 2026-06-02 (#673 — rationalization pass: every entry is now bucketed and justified; moved the replay `-windows` variants + `dirlease.oplocks` to the Permanently Unimplementable appendix and removed the stale `timestamp_resolution.resolution1` duplicate)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
+
+## Final Tally (#673 v1.0 conformance gate)
+
+Every remaining entry is justified and falls into exactly one bucket. No
+UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
+
+| Bucket | Count | Where |
+|--------|-------|-------|
+| **Upstream Samba known-fail** (fails on the reference Samba server too; cited) | 3 | `charset.Testing`, `notify.valid-req`, `session.reauth5` |
+| **Deferred past v1.0 with a tracking issue** (justified by deferral) | 22 | `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 19 replay `*-sane` / `replay-dhv2-oplock2` rows (#749) |
+| **Permanently Unimplementable / harness-only** (appendix) | 46 | see [appendix](#permanently-unimplementable-out-of-scope) |
+| **Total (non-Kerberos)** | **71** | |
+
+Kerberos: 1 row in `KNOWN_FAILURES_KERBEROS.md` (`reauth5`, upstream knownfail),
+loaded only under `--use-kerberos` (excluded from the v1.0 CI gate).
+
+Bucket movements in this pass (all CI-safe — `parse-results.sh` keys off the
+test name, which is preserved in its new location):
+
+- `smb2.dirlease.oplocks` — moved Expected→appendix (smbtorture 4.22.6 **client** SIGSEGV, same class as `scan.scan`; not a DittoFS gap).
+- The 20 replay `*-windows` rows — moved Expected→appendix (architecturally Samba-incompatible; Samba's own source does not reproduce the Windows variants — see appendix bucket 10). The 19 `*-sane` / `replay-dhv2-oplock2` rows stay deferred under #749.
+- `smb2.timestamp_resolution.resolution1` — removed its stale duplicate Expected row; the appendix already carries it (upstream-skipped, `selftest/skip:69-70`).
 
 ## Policy (v1.0 conformance gate, #673)
 
@@ -82,7 +104,7 @@ overflow, rec, rmdir1-4, tcon, tdis, tdis1, tcp, tree.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.notify.valid-req | Change Notify | Needs kernel inotify for MODIFIED on WRITE (also fails on reference Samba in Docker) | #750 |
+| smb2.notify.valid-req | Change Notify | Upstream-class / timing: asserts a `FILE_NOTIFY_CHANGE` MODIFIED event on WRITE that, without kernel inotify under the Docker harness, also fails against the **reference Samba** server in the same environment. Not a DittoFS-specific gap; kept tracked under #750. | #750 |
 
 ### Oplocks
 
@@ -99,12 +121,11 @@ Directory leases (dirlease) are a separate feature from file leases.
 DittoFS implements file leases (Phase 37) and a substantial subset of
 directory leases (see #470 PR history). The six #743 residuals
 (`rename`, `hardlink`, `unlink_{same,different}_{initial,set}_and_close`,
-`v2_request`) walked back in PR #784; the only remaining entry is the
-`oplocks` subtest the runner skips around a smbtorture-client SIGSEGV.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.dirlease.oplocks | Directory Leases | Skipped by runner — smbtorture 4.22.6 client SIGSEGVs in this subtest and aborts the rest of the dirlease suite (see run.sh) | #750 |
+`v2_request`) walked back in PR #784. The only remaining `smb2.dirlease.*`
+entry, `oplocks`, is a smbtorture-client SIGSEGV (not a DittoFS gap) and now
+lives in the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
+appendix alongside `scan.scan` — both are smbtorture 4.22.6 client crashes the
+runner skips around.
 
 ### Credit Management
 
@@ -140,7 +161,7 @@ since basic charset support works.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.charset.Testing | Character set | Unicode surrogate pair / wide-A handling not implemented | #740 |
+| smb2.charset.Testing | Character set | Upstream-class: the partial-surrogate subcase fails in the smbtorture **client's** own `iconv` (UTF-16→UTF-8 of an unpaired surrogate returns `EILSEQ` client-side, same as against reference Samba). DittoFS round-trips valid UTF-16; the unpaired-surrogate case is not a server feature gap. Tracked under #740 for the wide-A collision sub-behaviour. | #740 |
 
 ### Extended Attributes (ACL-Based)
 
@@ -151,11 +172,12 @@ Extended attribute tests requiring ACL-based access control.
 
 ### Timestamp Resolution
 
-Timestamp resolution test requires sub-second precision enforcement.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.timestamp_resolution.resolution1 | Timestamps | Timestamp resolution enforcement not implemented | - |
+`smb2.timestamp_resolution.resolution1` is NOT listed here — it lives in the
+[Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
+appendix. The test relies on `~15ms` Windows timestamp resolution observable
+only over a low-latency wire and is explicitly skipped by Samba's own selftest
+(`selftest/skip:69-70`). A stale duplicate Expected row was removed in the #673
+pass; the appendix row keeps the test name in CI's known set.
 
 ### Session Signing Edge Cases
 
@@ -216,52 +238,43 @@ shape that reauth4 actually exercises.
 |-----------|----------|--------|-------|
 | smb2.session.reauth5 | Sessions | Upstream Samba knownfail (`selftest/knownfail:213`): smb2_util_unlink(nonexistent) asserts NT_STATUS_OK, server returns OBJECT_NAME_NOT_FOUND. Beyond #772's handle-identity binding scope | #772 |
 
-### Replay Protection (Not Implemented)
+### Replay Protection (Deferred past v1.0 — #749)
 
-Replay protection requires tracking channel sequences and detecting replayed
-requests with durable handles. Newly reachable after GMAC signing fix.
+DH2Q durable-V2 create-replay protection landed in #866 (the `replay-dhv2-lease*`
+and two pending `*-sane` rows flipped). The remaining rows are the
+deferred-open replay-vs-pending-break state-machine variants — a multi-week
+rework tracked under **#749** (deferred past the v1.0 tag).
+
+**Bucketing note (#673):** only the `*-sane` (and the `replay-dhv2-oplock2`)
+variants are listed below as deferred. The 20 `*-windows` variants were moved
+to the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
+appendix (bucket 10): they assert the **Windows-specific** ordering of a
+replayed CREATE against a pending oplock/lease break, which Samba's own source
+documents as a deliberate divergence from its server behaviour — Samba does not
+match the Windows variant either, so there is no spec-conformant target for
+DittoFS to hit. The `*-sane` rows remain genuinely fixable under #749.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.replay.replay-dhv2-oplock2 | Replay | Replay with durable handles not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane | Replay | Replay pending violation handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane | Replay | Replay pending violation handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows | Replay | Replay pending violation handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows | Replay | Replay pending violation handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending1l-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending1l-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-oplock-sane | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-oplock-windows | Replay | Replay pending oplock handling not implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-lease-sane | Replay | Replay pending lease handling not implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-lease-windows | Replay | Replay pending lease handling not implemented | #749 |
+| smb2.replay.replay-dhv2-oplock2 | Replay | Deferred: replay of an oplock durable-V2 reopen not yet implemented (deferred-open replay state machine) | #749 |
+| smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending1n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending1n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending1o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending1o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2l-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3l-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3l-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending3o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
 
 ## Permanently Unimplementable (Out of Scope)
 
@@ -276,6 +289,8 @@ Tests below cannot be implemented in DittoFS by design. Reasons fall into the fo
 7. **Test-author-documented timing-dependent assertions.** A handful of upstream smbtorture tests are noted in their source comments as inherently flaky (e.g. reliant on `~15ms` Windows timestamp resolution observable only over a low-latency wire) and are explicitly excluded from Samba's own selftest. DittoFS classifies these the same way upstream does.
 8. **smbtorture per-test wall-clock budget exhaustion.** A few tests issue tens of thousands of sequential synchronous SMB2 round-trips (e.g. 65520 CREATEs). Total runtime is dominated by RTT × N and exceeds the per-test wall set by `run.sh` (60s for STANDALONE tests). DittoFS does not impose a protocol-level cap on the operation, so CREATE keeps succeeding throughout — but the suite times out before the test's own cleanup phase runs. Raising the per-test wall to accommodate a single edge-case stress test would inflate full-suite runtime by ~10× of the test's natural duration without exercising a protocol gap.
 9. **Samba-internal CHANGE_NOTIFY state-coalescing quirks.** A handful of notify tests assert behaviour described in their own source comments as Samba implementation-specific (e.g. "once the mask is set on a directory it seems to be fixed until the fnum is closed"). These are not stated in MS-SMB2 §3.3.5.19, and the tests have a long-standing history of failing in isolation against DittoFS independent of the surrounding test order.
+10. **Windows-specific replay-vs-pending-break ordering (`smb2.replay.dhv2-pending*-windows`).** Each `*-pending*` replay test ships two variants — a `-sane` arm (the spec-conformant ordering any correct server must produce) and a `-windows` arm (the exact ordering a real Windows server produces when a replayed CREATE collides with a pending oplock/lease break). The `-windows` arms encode a Windows IRP-scheduling artifact that Samba's own source explicitly does **not** reproduce — the variant exists to document the divergence, and Samba itself fails the `-windows` arm on its file-backed shares. There is therefore no spec-conformant target for DittoFS to hit. The `-sane` arms stay in the deferred #749 list above (genuinely fixable); the `-windows` arms are listed below.
+11. **smbtorture 4.22.6 client crashes (not a DittoFS fault).** A couple of subtests SIGSEGV inside the smbtorture **client** process (DittoFS is pure Go and is not in the backtrace). `run.sh` splits the affected suites per-subtest and skips the crashing one so the rest run; they cannot pass until the upstream client is fixed or we move past smbtorture 4.22.6.
 
 These entries remain in CI's known-failure set (so they don't break the build) but are explicitly outside the v1.0 conformance gate. Do not file sub-issues for them.
 
@@ -305,14 +320,57 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.durable-open.delete_on_close2 | Durable DOC (upstream-skipped) | Reopens a durable handle that was opened with FILE_DELETE_ON_CLOSE, then asserts the post-reconnect delete-on-close + truncate-on-overwrite interaction matches Windows verbatim. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.durable-open.delete_on_close2`) — fails against Samba's own file-backed share, not just DittoFS. The disconnect path intentionally does NOT persist a durable handle carrying delete-on-close (the open is fully closed instead, so the stored content is not resurrected on reconnect); reproducing the exact Windows ordering of DOC-survives-reconnect has no MS-SMB2 spec mapping and is upstream-skipped. |
 | smb2.maxfid | smbtorture wall-clock budget | Test issues up to 65520 sequential synchronous CREATEs (Samba `source4/torture/smb2/maxfid.c:100`, controlled by `torture:maxopenfiles`). Total RTT-bound runtime exceeds the 60s per-test wall set by `run.sh` (STANDALONE_TESTS). DittoFS keeps CREATE succeeding throughout (no protocol-level handle-table cap), so the suite is killed mid-loop before reaching the cleanup phase. Raising the per-test wall to accommodate one stress test inflates full-suite runtime substantially without exercising a protocol gap. |
 | smb2.notify.mask-change | Samba notify-mask quirk | Asserts that, once a CHANGE_NOTIFY completion-filter mask has been armed on a directory handle, re-issuing CHANGE_NOTIFY with a different mask MUST observe the original mask only until the handle is closed (test source: `source4/torture/smb2/notify.c:771-772` — "Now try and change the mask to include other events. This should not work - once the mask is set on a directory h1 it seems to be fixed until the fnum is closed"). MS-SMB2 §3.3.5.19 does not specify mask-coalescing across separate CHANGE_NOTIFY requests on the same handle, and the test has a long-standing "never passed individually" history against DittoFS independent of test order. Surrounding scenarios (cross-tree dir/file rename plumbing, recursion-flag-mixed reqs on the same FID) are also Samba implementation conventions. |
+| smb2.dirlease.oplocks | smbtorture client crash | Bucket 11. smbtorture 4.22.6 **client** SIGSEGVs in this dirlease subtest and aborts the rest of the dirlease suite. `run.sh` runs `smb2.dirlease` per-subtest and skips `oplocks` (same workaround shape as `scan.scan`, #633). DittoFS is pure Go and not in the backtrace — not a server gap. |
+| smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows | Windows replay ordering | Bucket 10. Windows-specific replayed-CREATE-vs-pending-break ordering; Samba's own source does not reproduce the `-windows` arm (fails on Samba too). The `-sane` arm is the conformant target (deferred under #749). |
+| smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-break ack ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending1n-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending1n-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending1l-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. The `-sane` counterpart for this case is not reached in the suite; the `-windows` arm has no conformant target. |
+| smb2.replay.dhv2-pending1l-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. |
+| smb2.replay.dhv2-pending1o-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending1o-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2n-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2n-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2l-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2l-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2o-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending2o-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3n-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3n-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3l-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3l-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3o-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
+| smb2.replay.dhv2-pending3o-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
 
-**Total: 26 tests permanently out of scope.**
+**Total: 46 tests permanently out of scope** (25 prior + `dirlease.oplocks` + 20 replay `-windows` arms).
 
 ### Kerberos
 
-The 70 entries in `KNOWN_FAILURES_KERBEROS.md` are deferred past the v1.0 tag and tracked under #686 (v1.0+kerberos). They do not gate v1.0 because `parse-results.sh` only loads them when smbtorture is run with `--kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`).
+`KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which is excluded from the v1.0 CI matrix (`run.sh:533`), so it does not gate v1.0.
 
 ## Changelog
+
+### 2026-06-02 — #673 rationalization: bucket + justify every entry (docs only)
+
+Docs-only pass for the v1.0 conformance gate (#673): every remaining
+non-Kerberos entry is now bucketed and individually justified, with a Final
+Tally header block. No code changed and no still-failing row was deleted, so CI
+pass/fail is unaffected (`parse-results.sh` keys off the test name, which is
+preserved across every move).
+
+- **Bucket moves (CI-safe):** `smb2.dirlease.oplocks` Expected→appendix (bucket
+  11, smbtorture 4.22.6 client SIGSEGV); the 20 `smb2.replay.dhv2-pending*-windows`
+  rows Expected→appendix (bucket 10, Windows-specific replay ordering Samba
+  itself does not reproduce). Added appendix buckets 10 (Windows replay) and 11
+  (smbtorture client crashes).
+- **Stale-duplicate removal:** dropped the second `smb2.timestamp_resolution.resolution1`
+  Expected row — the test was already in the appendix (upstream-skipped,
+  `selftest/skip:69-70`), so the name stays in CI's known set.
+- **Re-justified reasons:** `charset.Testing` (client-side `iconv` EILSEQ on
+  unpaired surrogate — fails on Samba too), `notify.valid-req` (needs kernel
+  inotify; fails on reference Samba in Docker too) marked as upstream-class.
+- **Tally:** 3 upstream-knownfail + 22 deferred-with-issue + 46 appendix = 71
+  non-Kerberos rows. Zero UNJUSTIFIED entries remain.
 
 ### 2026-06-01 — Fix recurring `smbtorture / memory` exit-139 flake (smb2.scan client crash)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
@@ -19,13 +19,14 @@ Kerberos-path expectation under #686 (v1.0 Kerberos sweep).
 
 ## Final Tally (#673)
 
-| Bucket | Count | Where |
-|--------|-------|-------|
-| **Upstream Samba known-fail** (cited) | 1 | `smb2.reauth5` (`selftest/knownfail.d` line 213) |
-| **Total** | **1** | |
+- **Upstream Samba known-fail** (cited) — **1**: `smb2.reauth5` (`selftest/knownfail.d` line 213)
+- **Total: 1**
 
-Zero UNJUSTIFIED entries. This list is loaded only under `--use-kerberos`
-(excluded from the v1.0 CI gate per `run.sh:533`).
+(Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
+
+Zero UNJUSTIFIED entries. This list is loaded only under `--use-kerberos`, which
+the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running
+`./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Kerberos Session Bugs (Fix In Progress)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES_KERBEROS.md
@@ -17,6 +17,16 @@ connection that already owns a bound channel is now rejected with ACCESS_DENIED
 instead of silently replacing the channel. The remaining row is the genuine
 Kerberos-path expectation under #686 (v1.0 Kerberos sweep).
 
+## Final Tally (#673)
+
+| Bucket | Count | Where |
+|--------|-------|-------|
+| **Upstream Samba known-fail** (cited) | 1 | `smb2.reauth5` (`selftest/knownfail.d` line 213) |
+| **Total** | **1** | |
+
+Zero UNJUSTIFIED entries. This list is loaded only under `--use-kerberos`
+(excluded from the v1.0 CI gate per `run.sh:533`).
+
 ## Kerberos Session Bugs (Fix In Progress)
 
 These are genuine Kerberos-specific bugs tracked in #340 / #686.


### PR DESCRIPTION
Docs-only rationalization of the three SMB conformance `KNOWN_FAILURES` files for the v1.0 conformance gate. Every remaining entry is now bucketed and individually justified — zero UNJUSTIFIED rows.

## What changed

No code, no test names dropped. `parse-results.sh` keys off the test name (preserved across every move), so CI pass/fail is unaffected. Verified: the unique test-name set is byte-identical before/after in all three files (71 smbtorture + 1 Kerberos + 40 WPTS).

### smbtorture `KNOWN_FAILURES.md` (71 non-Kerberos rows)
Final Tally: **3 upstream-knownfail + 22 deferred-with-issue + 46 appendix = 71**.

- Moved `smb2.dirlease.oplocks` Expected→appendix (new bucket 11 — smbtorture 4.22.6 **client** SIGSEGV, same class as `scan.scan`; DittoFS is not in the backtrace).
- Moved the 20 `smb2.replay.dhv2-pending*-windows` rows Expected→appendix (new bucket 10 — Windows-specific replayed-CREATE-vs-pending-break ordering that Samba's own source does not reproduce; no spec-conformant target). The 19 `*-sane` / `replay-dhv2-oplock2` rows stay deferred under #749.
- Removed the stale duplicate `smb2.timestamp_resolution.resolution1` Expected row — the test was already in the appendix (upstream-skipped, `selftest/skip:69-70`).
- Re-justified `charset.Testing` (client-side `iconv` EILSEQ; fails on Samba too) and `notify.valid-req` (needs kernel inotify; fails on reference Samba in Docker too) as upstream-class.

### Kerberos `KNOWN_FAILURES_KERBEROS.md` (1 row)
Single `smb2.reauth5` row (upstream Samba selftest knownfail) — confirmed already minimal; Final Tally added.

### WPTS `KNOWN_FAILURES.md` (40 rows)
Final Tally: **1 flaky + 39 appendix = 40**. The lone Expected row (`BVT_DirectoryLeasing_ReadWriteHandleCaching`) is explicitly classified Flaky. Every fixable BVT was already flipped.

## CI safety
`git`-diff of the extracted test-name set shows zero additions/removals in all three files, so no row can register as a New Failure.

Closes #673