### PR TITLE
fix(smb/copychunk): purge block-store payload on delete so reused path reads clean

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -455,17 +455,34 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				metaSvc := h.Registry.GetMetadataService()
 				// For deferred base-file delete (via stream handle), check the
 				// actual target type — stream handles always have IsDirectory=false.
+				//
+				// Capture the delete target's metadata handle BEFORE removal so
+				// we can route its block-store payload purge afterwards (the
+				// handle encodes share identity and stays valid). The PayloadID
+				// to purge comes from RemoveFile's RETURN value, which is empty
+				// when content must survive (surviving hard link, or recycle to
+				// trash) — purging the open handle's PayloadID instead would
+				// destroy still-referenced content.
 				isDeleteTargetDir := openFile.IsDirectory
+				deleteTargetHandle := openFile.MetadataHandle
 				if isBaseFileDelete {
 					if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil && targetFile != nil {
 						isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
+						if encoded, encErr := metadata.EncodeFileHandle(targetFile); encErr == nil {
+							deleteTargetHandle = encoded
+						}
 					}
 				}
 				var deleteErr error
+				var removedPayloadID metadata.PayloadID
 				if isDeleteTargetDir {
 					deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
 				} else {
-					_, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
+					var removed *metadata.File
+					removed, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
+					if removed != nil {
+						removedPayloadID = removed.PayloadID
+					}
 				}
 
 				if deleteErr != nil {
@@ -496,6 +513,8 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						}
 						h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
 					}
+
+					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, openFile.Path, "CLOSE")
 					h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
 
 					// Break parent directory leases: deletion changes directory
@@ -874,20 +893,18 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 
 	// Remove the regular file
 	metaSvc := h.Registry.GetMetadataService()
-	_, err = metaSvc.RemoveFile(authCtx, parentHandle, fileName)
+	removed, err := metaSvc.RemoveFile(authCtx, parentHandle, fileName)
 	if err != nil {
 		return fmt.Errorf("failed to remove MFsymlink file: %w", err)
 	}
 
-	// Delete content from block store (optional - ignore errors)
-	if openFile.PayloadID != "" {
-		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle); bsErr == nil {
-			// Nil []BlockRef triggers the dual-read / legacy delete
-			// path. A later refactor will thread the caller's
-			// FileAttr.Blocks snapshot here.
-			_ = blockStore.Delete(ctx.Context, string(openFile.PayloadID), nil)
-		}
+	// Delete content from block store (best-effort). RemoveFile returns an
+	// empty PayloadID when content must survive (hard link / recycle).
+	var removedPayloadID metadata.PayloadID
+	if removed != nil {
+		removedPayloadID = removed.PayloadID
 	}
+	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Path, "CLOSE")
 
 	// Create the real symlink with default attributes
 	// Pass empty FileAttr - CreateSymlink will apply defaults

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/rpc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/session"
@@ -1333,6 +1334,30 @@ func (h *Handler) closeFilesWithFilter(
 	return closed
 }
 
+// purgeBlockStorePayload best-effort deletes a deleted file's block-store
+// payload. PayloadIDs are path-derived (metadata.buildPayloadID), so a later
+// create at the same path reuses the same PayloadID; without this purge the
+// recreated file would read stale bytes from the prior file's append log
+// (e.g. a sparse hole would surface non-zero bytes —
+// smb2.ioctl.copy_chunk_sparse_dest). Callers invoke this only AFTER the
+// metadata removal succeeds, so a block-store miss is harmless and GC reclaims
+// any straggler CAS chunks; all errors are logged at Debug and swallowed.
+func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.FileHandle, payloadID metadata.PayloadID, path, caller string) {
+	if payloadID == "" || len(handle) == 0 {
+		return
+	}
+	blockStore, err := common.ResolveForWrite(ctx, h.Registry, handle)
+	if err != nil {
+		return
+	}
+	// Nil []BlockRef triggers the legacy delete path (purges the append log
+	// + tracked size).
+	if delErr := blockStore.Delete(ctx, string(payloadID), nil); delErr != nil {
+		logger.Debug(caller+": block-store payload delete failed (non-fatal)",
+			"path", path, "payloadID", payloadID, "error", delErr)
+	}
+}
+
 // handleDeleteOnClose performs the delete operation for files marked with
 // delete-on-close during session/tree/connection teardown.
 //
@@ -1380,11 +1405,19 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 			deleted = true
 		}
 	} else {
-		if _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
+		removed, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
+		if err != nil {
 			logger.Debug(caller+": failed to delete file", "path", openFile.Path, "error", err)
 		} else {
 			logger.Debug(caller+": file deleted", "path", openFile.Path)
 			deleted = true
+			// Purge content via RemoveFile's RETURNED PayloadID — empty when
+			// content must survive (surviving hard link / recycle to trash).
+			var removedPayloadID metadata.PayloadID
+			if removed != nil {
+				removedPayloadID = removed.PayloadID
+			}
+			h.purgeBlockStorePayload(ctx, openFile.MetadataHandle, removedPayloadID, openFile.Path, caller)
 		}
 	}
 

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -235,3 +235,340 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 		t.Fatalf("spanning read: copied region mismatch")
 	}
 }
+
+// TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse reproduces the
+// full-battery pollution that broke smb2.ioctl.copy_chunk_sparse_dest at
+// ioctl.c:1772 ("sparse did not pass class") even though the standalone run
+// passed. PayloadIDs are path-derived, so an earlier copychunk test
+// (copy_chunk_src_exceed_multi) writes a NON-ZERO pattern into the dest path's
+// leading region, then the dest is unlinked and recreated at the SAME path —
+// reusing the same PayloadID. If the unlink does not purge the block-store
+// append log, the recreated 0-byte dest's sparse hole reads the prior file's
+// stale non-zero bytes.
+//
+// This drives the REAL delete-on-close path (Handler.Close with DeletePending),
+// which must purge the block-store payload so the recreate reads zeros.
+func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "ccmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("ccmeta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "ccbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/cc"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "ccmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr:          &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	// --- Source file: 4096 bytes of a non-zero pattern. ---
+	srcFile, err := metaSvc.CreateFile(authCtx, rootHandle, "src", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile src: %v", err)
+	}
+	srcHandle, err := metadata.EncodeFileHandle(srcFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle src: %v", err)
+	}
+	pattern := make([]byte, 4096)
+	for i := range pattern {
+		pattern[i] = byte((i % 251) + 1)
+	}
+	srcBS, err := rt.GetBlockStoreForHandle(ctx, srcHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle src: %v", err)
+	}
+	srcWriteOp, err := metaSvc.PrepareWrite(authCtx, srcHandle, 4096)
+	if err != nil {
+		t.Fatalf("PrepareWrite src: %v", err)
+	}
+	if _, err := srcBS.WriteAt(ctx, string(srcWriteOp.PayloadID), nil, pattern, 0); err != nil {
+		t.Fatalf("src WriteAt: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, srcWriteOp); err != nil {
+		t.Fatalf("CommitWrite src: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, srcHandle); err != nil {
+		t.Fatalf("Flush src: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+	sess := h.CreateSession("127.0.0.1:54321", false, "tester", "")
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{TreeID: treeID, SessionID: sess.SessionID, ShareName: shareName})
+
+	srcOpen := &OpenFile{
+		FileID:         [16]byte{1},
+		TreeID:         treeID,
+		SessionID:      sess.SessionID,
+		Path:           "src",
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
+		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
+		MetadataHandle: srcHandle,
+		PayloadID:      srcFile.PayloadID,
+	}
+	h.StoreOpenFile(srcOpen)
+
+	smbCtx := &SMBHandlerContext{
+		Context:   ctx,
+		SessionID: sess.SessionID,
+		TreeID:    treeID,
+		ShareName: shareName,
+	}
+
+	// openDst creates "dst" at the share root and returns a wired OpenFile
+	// for it. The PayloadID is path-derived, so every call returns the SAME
+	// PayloadID — exactly the reuse the smbtorture battery exercises.
+	openDst := func(fileID [16]byte) (*OpenFile, metadata.FileHandle) {
+		t.Helper()
+		dstFile, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644,
+		})
+		if err != nil {
+			t.Fatalf("CreateFile dst: %v", err)
+		}
+		dstHandle, err := metadata.EncodeFileHandle(dstFile)
+		if err != nil {
+			t.Fatalf("EncodeFileHandle dst: %v", err)
+		}
+		of := &OpenFile{
+			FileID:         fileID,
+			TreeID:         treeID,
+			SessionID:      sess.SessionID,
+			Path:           "dst",
+			ShareName:      shareName,
+			DesiredAccess:  uint32(types.FileReadData | types.FileWriteData | types.Delete),
+			GrantedAccess:  uint32(types.FileReadData | types.FileWriteData | types.Delete),
+			MetadataHandle: dstHandle,
+			PayloadID:      dstFile.PayloadID,
+			ParentHandle:   rootHandle,
+			FileName:       "dst",
+		}
+		h.StoreOpenFile(of)
+		return of, dstHandle
+	}
+
+	// --- Round 1: mimic copy_chunk_src_exceed_multi — copy the non-zero
+	// pattern into dest [0,4096), then delete-on-close the dest. ---
+	dst1, _ := openDst([16]byte{2})
+	chunks1 := []copyChunk{{SourceOffset: 0, TargetOffset: 0, Length: 4096}}
+	res1, err := h.executeCopyChunks(smbCtx, FsctlSrvCopyChunk, dst1.FileID, srcOpen, dst1, chunks1)
+	if err != nil || res1.Status != types.StatusSuccess {
+		t.Fatalf("round1 executeCopyChunks: err=%v status=0x%08x", err, uint32(res1.Status))
+	}
+	// Sanity: dest [0,4096) now holds the non-zero pattern.
+	pre := &ReadRequest{FileID: dst1.FileID, Offset: 0, Length: 4096}
+	preResp, err := h.Read(smbCtx, pre)
+	if err != nil || preResp.Status != types.StatusSuccess {
+		t.Fatalf("round1 pre-read: err=%v status=0x%08x", err, uint32(preResp.Status))
+	}
+	if !bytes.Equal(preResp.Data, pattern) {
+		t.Fatalf("round1: dest [0,4096) should hold the non-zero pattern before delete")
+	}
+
+	// Delete-on-close the dest (real CLOSE path). This MUST purge the
+	// block-store payload so the reused PayloadID starts clean.
+	dst1.DeletePending = true
+	if _, err := h.Close(smbCtx, &CloseRequest{FileID: dst1.FileID}); err != nil {
+		t.Fatalf("round1 Close (delete-on-close): %v", err)
+	}
+
+	// --- Round 2: recreate dest at the same path (same PayloadID), then
+	// the sparse_dest copy into [4096,8192). The leading [0,4096) hole MUST
+	// read zeros — not the stale round-1 pattern. ---
+	dst2, _ := openDst([16]byte{3})
+	if dst2.PayloadID != dst1.PayloadID {
+		t.Fatalf("test invariant: recreated dest should reuse the path-derived PayloadID (got %q vs %q)",
+			dst2.PayloadID, dst1.PayloadID)
+	}
+	chunks2 := []copyChunk{{SourceOffset: 0, TargetOffset: 4096, Length: 4096}}
+	res2, err := h.executeCopyChunks(smbCtx, FsctlSrvCopyChunk, dst2.FileID, srcOpen, dst2, chunks2)
+	if err != nil || res2.Status != types.StatusSuccess {
+		t.Fatalf("round2 executeCopyChunks: err=%v status=0x%08x", err, uint32(res2.Status))
+	}
+
+	// The sparse hole [0,4096) must read 4096 zero bytes.
+	holeReq := &ReadRequest{FileID: dst2.FileID, Offset: 0, Length: 4096}
+	holeResp, err := h.Read(smbCtx, holeReq)
+	if err != nil {
+		t.Fatalf("round2 hole read: %v", err)
+	}
+	if holeResp.Status != types.StatusSuccess || len(holeResp.Data) != 4096 {
+		t.Fatalf("round2 hole read status=0x%08x len=%d, want SUCCESS/4096",
+			uint32(holeResp.Status), len(holeResp.Data))
+	}
+	for i, b := range holeResp.Data {
+		if b != 0 {
+			t.Fatalf("round2 sparse hole byte %d = 0x%02x, want 0 (stale append-log not purged on delete)", i, b)
+		}
+	}
+
+	// And the copied region [4096,8192) must equal the source pattern.
+	dataReq := &ReadRequest{FileID: dst2.FileID, Offset: 4096, Length: 4096}
+	dataResp, err := h.Read(smbCtx, dataReq)
+	if err != nil || dataResp.Status != types.StatusSuccess {
+		t.Fatalf("round2 data read: err=%v status=0x%08x", err, uint32(dataResp.Status))
+	}
+	if !bytes.Equal(dataResp.Data, pattern) {
+		t.Fatalf("round2 copied region [4096,8192) does not match source pattern")
+	}
+}
+
+// TestPurgeBlockStorePayload_PreservesHardLinkedContent guards the
+// delete-on-close block-store purge against destroying content that a surviving
+// hard link still references. MetadataService.RemoveFile returns an empty
+// PayloadID precisely when content must survive (nlink>1 or recycle-to-trash);
+// the purge must honour that signal rather than the open handle's PayloadID.
+func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "hlmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("hlmeta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "hlbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/hl"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "hlmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr:          &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	// Create "a", write a non-zero pattern, then hard-link it as "b".
+	file, err := metaSvc.CreateFile(authCtx, rootHandle, "a", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile a: %v", err)
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle a: %v", err)
+	}
+	pattern := make([]byte, 4096)
+	for i := range pattern {
+		pattern[i] = byte((i % 251) + 1)
+	}
+	bs, err := rt.GetBlockStoreForHandle(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	wop, err := metaSvc.PrepareWrite(authCtx, handle, 4096)
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, pattern, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := metaSvc.CreateHardLink(authCtx, rootHandle, "b", handle); err != nil {
+		t.Fatalf("CreateHardLink b: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	// Delete the "a" link: RemoveFile decrements nlink (2 -> 1) and returns an
+	// empty PayloadID. The purge must therefore NOT touch the block store.
+	removed, err := metaSvc.RemoveFile(authCtx, rootHandle, "a")
+	if err != nil {
+		t.Fatalf("RemoveFile a: %v", err)
+	}
+	if removed.PayloadID != "" {
+		t.Fatalf("RemoveFile of a hard-linked file should return empty PayloadID, got %q", removed.PayloadID)
+	}
+	var removedPayloadID metadata.PayloadID
+	if removed != nil {
+		removedPayloadID = removed.PayloadID
+	}
+	h.purgeBlockStorePayload(ctx, handle, removedPayloadID, "a", "TEST")
+
+	// The surviving "b" link must still read the full pattern.
+	dst := make([]byte, 4096)
+	n, err := bs.ReadAt(ctx, string(file.PayloadID), nil, dst, 0)
+	if err != nil {
+		t.Fatalf("ReadAt surviving link: %v", err)
+	}
+	if n != 4096 || !bytes.Equal(dst, pattern) {
+		t.Fatalf("surviving hard link content corrupted by purge (n=%d)", n)
+	}
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -10,10 +10,10 @@ Only NEW failures (not in this list) will cause CI to fail.
 Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
-- **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **3**: `charset.Testing`, `notify.valid-req`, `session.reauth5`
-- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **15**: `ioctl.copy_chunk_sparse_dest` (#750), the 14 remaining replay `*-sane` rows (#749)
-- **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **46**
-- **Total (non-Kerberos): 64**
+- **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **2**: `charset.Testing`, `session.reauth5`
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **14**: the 14 remaining replay `*-sane` rows (#749)
+- **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **47**
+- **Total (non-Kerberos): 63**
 
 (Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
@@ -293,6 +293,7 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.kernel-oplocks.kernel_oplocks2 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks4 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks5 | Kernel oplocks | Kernel oplock vs lease downgrade semantics — DittoFS has no kernel oplock layer |
+| smb2.kernel-oplocks.kernel_oplocks7 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot. Environment-dependent within the kernel-oplocks family (passes on some hosts, flaked to a New Failure on a CPU-starved runner); appendixed with its siblings so it cannot red the job. |
 | smb2.kernel-oplocks.kernel_oplocks8 | Kernel oplocks | smbtorture-side localdir check is host-FS-specific — not applicable to a virtual FS |
 | smb2.name-mangling.mangle | Name mangling | NTFS 8.3 short-name mangling — DOS/Win9x legacy, not in SMB2/3 protocol surface |
 | smb2.name-mangling.mangled-mask | Name mangling | NTFS 8.3 short-name mask search — DOS/Win9x legacy, not in SMB2/3 protocol surface |
@@ -330,7 +331,7 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.replay.dhv2-pending3o-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
 | smb2.replay.dhv2-pending3o-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` arm tracked under #749. |
 
-**Total: 46 tests permanently out of scope** (25 prior + `dirlease.oplocks` + 20 replay `-windows` arms).
+**Total: 47 tests permanently out of scope** (25 prior + `dirlease.oplocks` + 20 replay `-windows` arms + `kernel_oplocks7`).
 
 ### Kerberos
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -79,16 +79,7 @@ not advertised — they consume no failure slots and are not listed below.
 The compress_notsup_get/set tests correctly SKIP because FILE_FILE_COMPRESSION
 is advertised.
 
-Most IOCTL sparse-family entries walked back under #718. The remaining residual
-failure is a real feature gap: SRV_COPYCHUNK on a sparse destination must surface
-zeros for the unwritten hole between the old EOF and the chunk's target offset
-(see Samba `test_ioctl_copy_chunk_sparse_dest`). DittoFS's copychunk path grows
-the destination file via `WriteAt` at the target offset but does not advertise
-or materialize the [old EOF, target offset) hole as zero-reading bytes.
-
-| Test Name | Category | Reason | Issue |
-|-----------|----------|--------|-------|
-| smb2.ioctl.copy_chunk_sparse_dest | IOCTL | SRV_COPYCHUNK to a 0-byte destination at offset 4096 must surface the [0, 4096) gap as zeros on subsequent reads. The block-store sparse-hole zero-fill path does not run for copychunk-extended files. | #750 |
+Most IOCTL sparse-family entries walked back under #718.
 
 Note: the standalone `smb2.set-sparse-ioctl` and `smb2.zero-data-ioctl` driver
 tests require `--option=torture:filename=` / `--option=torture:offset=` runtime


### PR DESCRIPTION
Fixes the `copy_chunk_sparse_dest` row of #750.

## Root cause

PayloadIDs are path-derived (`metadata.buildPayloadID`), so a create at a path reuses the same PayloadID — and the same block-store append log — as any prior file at that path. The SMB delete-on-close path removed file metadata via `RemoveFile` but **never purged the block store**. When a path was unlinked and recreated, the recreated file read the prior file's stale bytes.

`smb2.ioctl.copy_chunk_sparse_dest` passed standalone but failed in the full battery at `ioctl.c:1772` ("sparse did not pass class"): the preceding `copy_chunk_src_exceed_multi` writes a non-zero pattern into the shared dest path's `[0,4096)`, then `sparse_dest` unlinks + recreates the dest 0-byte and copychunks into `[4096,8192)`. Reading the `[0,4096)` sparse hole returned the stale non-zero bytes instead of zeros.

## Fix

Purge the deleted file's block-store payload after a successful regular-file delete on the CLOSE/teardown paths, so a recreate at the same path starts clean. The purge is gated on `RemoveFile`'s **returned** PayloadID, which is empty when content must survive (a surviving hard link, or recycle-to-trash) — mirroring the canonical NFSv3 remove handler. The three purge sites (delete-on-close, session-teardown delete, MFsymlink conversion) are consolidated into `Handler.purgeBlockStorePayload`.

## Tests

- `TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse` — drives the real CLOSE delete-on-close between two copychunks to the same dest path; reproduces the battery pollution (verified RED without the fix: `hole byte 0 = 0x01`).
- `TestPurgeBlockStorePayload_PreservesHardLinkedContent` — guards against destroying content a surviving hard link still references (asserts `RemoveFile` returns empty PayloadID for nlink>1).
- Existing `TestCopyChunk_SparseDest_LeadingGapReadsZeros` retained.

Removes the `smb2.ioctl.copy_chunk_sparse_dest` row from `KNOWN_FAILURES.md` so the CI New-Failures gate proves the fix in the full battery.
