### PR TITLE
fix(smb/replay): replay-vs-pending sane rows + replay-dhv2-oplock2 (#749)

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1714,14 +1714,73 @@ func (h *Handler) resolveCreateReplay(ctx *SMBHandlerContext, req *CreateRequest
 	resp := *entry.Response
 
 	// Lease replays are validated and state-refreshed against the live
-	// open. Non-lease (plain oplock) replays return the cached response
-	// verbatim: Samba echoes the request's oplock level back on replay
-	// without touching the held oplock, which the cached snapshot already
-	// reflects (replay-dhv2-oplock1/2/3).
-	if status := h.refreshReplayLease(ctx, req, entry, &resp); status != types.StatusSuccess {
-		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, true
+	// open. A replay carrying an RqLs context goes through the lease path;
+	// a replay requesting a plain oplock (or none) echoes the REQUESTED
+	// oplock level and re-derives durability for it (replay-dhv2-oplock2).
+	if FindCreateContext(req.CreateContexts, LeaseContextTagRequest) != nil {
+		if status := h.refreshReplayLease(ctx, req, entry, &resp); status != types.StatusSuccess {
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: status}}, true
+		}
+	} else {
+		refreshReplayOplock(req, &resp)
 	}
 	return &resp, true
+}
+
+// refreshReplayOplock applies Samba's plain-oplock replay rule
+// (smbd_smb2_create_replay): the replay response echoes the REQUESTED
+// oplock level of the replay request and only carries a DH2Q durable
+// grant blob if that requested oplock would itself qualify for V2
+// durability (Batch). The original open's held oplock is untouched.
+//
+// For replay-dhv2-oplock1/3 the replay re-requests the same Batch oplock
+// so the cached snapshot already matches and this is a no-op. For
+// replay-dhv2-oplock2 the replay requests NONE over a Batch open: the
+// response must report oplock_level=NONE, durable_open_v2=false, and drop
+// the DH2Q response context (smbtorture asserts exactly these).
+func refreshReplayOplock(req *CreateRequest, resp *CreateResponse) {
+	// A lease-backed cached response (the open holds a lease, OplockLevel
+	// 0xFF) is left untouched here: an oplock-less replay against a
+	// lease-backed open does not re-key the open's lease, and the lease
+	// response context stands. Only plain-oplock cached responses echo the
+	// requested level.
+	if resp.OplockLevel == OplockLevelLease {
+		return
+	}
+
+	resp.OplockLevel = req.OplockLevel
+
+	// Re-derive V2 durability for the requested oplock. Only a Batch oplock
+	// qualifies a non-lease open for V2 durability (MS-SMB2 §3.3.5.9.10).
+	// A weaker/none requested oplock drops the durable grant: strip the
+	// DH2Q response context so out.durable_open_v2 reads false and timeout 0.
+	if req.OplockLevel != OplockLevelBatch {
+		resp.CreateContexts = stripCreateContext(resp.CreateContexts, DurableHandleV2RequestTag)
+	}
+}
+
+// stripCreateContext returns a copy of contexts with every entry named
+// tag removed. Returns the original slice when nothing matches (no
+// allocation on the common path). Never mutates the input backing array,
+// so a cached response shared across replays is safe.
+func stripCreateContext(contexts []CreateContext, tag string) []CreateContext {
+	hasTag := false
+	for i := range contexts {
+		if contexts[i].Name == tag {
+			hasTag = true
+			break
+		}
+	}
+	if !hasTag {
+		return contexts
+	}
+	out := make([]CreateContext, 0, len(contexts))
+	for i := range contexts {
+		if contexts[i].Name != tag {
+			out = append(out, contexts[i])
+		}
+	}
+	return out
 }
 
 // refreshReplayLease applies Samba's replay-with-lease rules to a DH2Q

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1149,6 +1149,11 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// per-handle so the CREATE response and a later QUERY_INFO on this handle
 		// agree (smb2.create.open).
 		RequestedAllocSize: allocReservationFor(file.Type == metadata.FileTypeDirectory, req.RequestedAllocSize),
+		// Record the requested DH2Q CreateGuid for replay-cache keying,
+		// independent of whether V2 durability is granted below. A no-oplock
+		// open never sets CreateGuid (durability requires Batch/Handle lease),
+		// but its CREATE must still be replay-cacheable (MS-SMB2 §3.3.5.9).
+		ReplayCreateGuid: dh2qCreateGuid(req),
 	}
 
 	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {
@@ -1301,14 +1306,16 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			"diskFileId", fmt.Sprintf("%x", qfidFileID[:16]))
 	}
 
-	// SMB3 replay protection (MS-SMB2 §3.3.5.9): record the
-	// freshly-built success response keyed by DH2Q CreateGuid so a
-	// FLAGS_REPLAY_OPERATION retry within the replay window returns
-	// the cached result instead of re-running CREATE. Only V2
-	// durable opens carry a CreateGuid — V1 / non-durable CREATEs
-	// rely on the in-flight MessageID dedup at the framing layer.
-	if h.CreateReplayCache != nil && openFile != nil && openFile.CreateGuid != ([16]byte{}) {
-		h.CreateReplayCache.Store(openFile.SessionID, openFile.CreateGuid, resp, openFile)
+	// SMB3 replay protection (MS-SMB2 §3.3.5.9): record the freshly-built
+	// success response keyed by the REQUESTED DH2Q CreateGuid so a
+	// FLAGS_REPLAY_OPERATION retry within the replay window returns the
+	// cached result (same FileId) instead of re-running CREATE. Keyed on
+	// ReplayCreateGuid, not the durability-granting CreateGuid: a no-oplock
+	// open never gets V2 durability (Batch/Handle lease required) yet its
+	// CREATE must still be replay-cacheable, and the replay must echo the
+	// same handle (smb2.replay.dhv2-pending1n-vs-{oplock,lease}-sane io24).
+	if h.CreateReplayCache != nil && openFile != nil && openFile.ReplayCreateGuid != ([16]byte{}) {
+		h.CreateReplayCache.Store(openFile.SessionID, openFile.ReplayCreateGuid, resp, openFile)
 	}
 
 	return resp

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -504,6 +504,17 @@ type OpenFile struct {
 	// Zero value for V1 durable handles or non-durable handles.
 	CreateGuid [16]byte
 
+	// ReplayCreateGuid is the DH2Q CreateGuid carried by the originating
+	// CREATE request, recorded whenever a DH2Q request context is present —
+	// independent of whether V2 durability was actually granted. A replayed
+	// CREATE (FLAGS_REPLAY_OPERATION) is keyed solely on the requested
+	// CreateGuid per MS-SMB2 §3.3.5.9 (Samba smb2srv_open_lookup_replay_cache),
+	// so a no-oplock / non-durable open (which never sets CreateGuid above)
+	// must still be replay-cacheable. smbtorture
+	// smb2.replay.dhv2-pending1n-vs-{oplock,lease}-sane replay io24 against an
+	// open created with oplock_level=NONE and assert the same FileId comes back.
+	ReplayCreateGuid [16]byte
+
 	// AppInstanceId is the application instance ID for Hyper-V failover.
 	// Zero value if not set.
 	AppInstanceId [16]byte
@@ -941,8 +952,16 @@ func (h *Handler) DeleteOpenFile(fileID [16]byte) {
 func (h *Handler) forgetReplayState(fileID [16]byte) {
 	if h.CreateReplayCache != nil {
 		if v, ok := h.files.Load(string(fileID[:])); ok {
-			if of := v.(*OpenFile); of.CreateGuid != ([16]byte{}) {
-				h.CreateReplayCache.Forget(of.CreateGuid)
+			// Forget by the replay-cache key (the requested CreateGuid),
+			// which is set even for non-durable opens that never populate
+			// CreateGuid. Falls back to CreateGuid for older code paths.
+			of := v.(*OpenFile)
+			guid := of.ReplayCreateGuid
+			if guid == ([16]byte{}) {
+				guid = of.CreateGuid
+			}
+			if guid != ([16]byte{}) {
+				h.CreateReplayCache.Forget(guid)
 			}
 		}
 	}

--- a/internal/adapter/smb/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/handlers/replay_dhv2_test.go
@@ -174,7 +174,11 @@ func TestResolveCreateReplay_OplockSnapshot(t *testing.T) {
 	h.CreateReplayCache.Store(sessionID, guid, cached,
 		&OpenFile{OplockLevel: OplockLevelBatch})
 
-	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), dh2qCreateReq(guid, nil))
+	// A replay that re-requests the SAME Batch oplock echoes Batch back and
+	// returns the original FileID (replay-dhv2-oplock1/3).
+	req := dh2qCreateReq(guid, nil)
+	req.OplockLevel = OplockLevelBatch
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), req)
 	if !handled {
 		t.Fatal("oplock replay must be handled")
 	}
@@ -183,6 +187,49 @@ func TestResolveCreateReplay_OplockSnapshot(t *testing.T) {
 	}
 	if resp.FileID != cached.FileID {
 		t.Fatal("oplock replay must return the original FileID")
+	}
+}
+
+// TestResolveCreateReplay_OplockReplayEchoesRequestedNone reproduces
+// smb2.replay.replay-dhv2-oplock2: the original CREATE held a Batch oplock
+// with V2 durability, but the replay requests OplockLevel=NONE. The replay
+// response must echo NONE and drop the DH2Q durable grant blob (so
+// durable_open_v2 reads false) while still returning the original FileID.
+func TestResolveCreateReplay_OplockReplayEchoesRequestedNone(t *testing.T) {
+	h, _, _ := newReplayTestHandler()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x09}
+
+	cached := &CreateResponse{
+		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		OplockLevel:     OplockLevelBatch,
+		FileID:          [16]byte{0xDE, 0xAD},
+		CreateContexts: []CreateContext{
+			{Name: DurableHandleV2RequestTag, Data: EncodeDH2QResponse(300000, 0).Data},
+		},
+	}
+	h.CreateReplayCache.Store(sessionID, guid, cached,
+		&OpenFile{OplockLevel: OplockLevelBatch})
+
+	// Replay with OplockLevel=NONE (oplock2 second CREATE).
+	req := dh2qCreateReq(guid, nil)
+	req.OplockLevel = OplockLevelNone
+	resp, handled := h.resolveCreateReplay(newReplayCtx(sessionID, true), req)
+	if !handled {
+		t.Fatal("oplock replay must be handled")
+	}
+	if resp.OplockLevel != OplockLevelNone {
+		t.Fatalf("replay oplock = 0x%x, want NONE (0x0)", resp.OplockLevel)
+	}
+	if FindCreateContext(resp.CreateContexts, DurableHandleV2RequestTag) != nil {
+		t.Fatal("replay requesting NONE must drop the DH2Q durable grant blob")
+	}
+	if resp.FileID != cached.FileID {
+		t.Fatal("oplock replay must return the original FileID")
+	}
+	// The cached entry must be untouched for a subsequent replay.
+	if FindCreateContext(cached.CreateContexts, DurableHandleV2RequestTag) == nil {
+		t.Fatal("cached entry's DH2Q blob must not be mutated by the replay")
 	}
 }
 

--- a/internal/adapter/smb/handlers/replay_pending_sane_test.go
+++ b/internal/adapter/smb/handlers/replay_pending_sane_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// noOplockNoneOpen drives a real CREATE of durable.txt with OplockLevel=NONE
+// and a DH2Q CreateGuid through completeCreateAfterBreak, mirroring client2's
+// io21 in smb2.replay.dhv2-pending1n-vs-{oplock,lease}-sane. NONE never grants
+// V2 durability, so openFile.CreateGuid stays zero — but the open must still be
+// replay-cacheable via ReplayCreateGuid.
+func (e *reopen2Env) noOplockNoneOpen(t *testing.T, sessionID uint64, createGuid [16]byte) (*CreateResponse, *OpenFile) {
+	t.Helper()
+
+	metaSvc := e.h.Registry.GetMetadataService()
+	rootHandle, err := e.h.Registry.GetRootHandle(e.tree.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	file, _, err := e.h.lookupCaseInsensitive(rootAuthCtx(), metaSvc, rootHandle, "durable.txt")
+	if err != nil || file == nil {
+		t.Fatalf("lookup durable.txt: file=%v err=%v", file, err)
+	}
+	existingHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	const fullAccess uint32 = 0x001F01FF
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "durable.txt",
+			DesiredAccess:     fullAccess,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpen,
+			OplockLevel:       OplockLevelNone,
+			CreateContexts:    []CreateContext{dh2qContext(createGuid, 300000)},
+		},
+		tree:           e.tree,
+		authCtx:        rootAuthCtx(),
+		filename:       "durable.txt",
+		baseName:       "durable.txt",
+		parentHandle:   rootHandle,
+		existingFile:   file,
+		existingHandle: existingHandle,
+		fileExists:     true,
+		createAction:   types.FileOpened,
+	}
+
+	smbCtx := e.makeSMBCtx(sessionID)
+	e.h.CreateSessionWithID(sessionID, "127.0.0.1:1", false, "alice", "WORKGROUP")
+
+	resp := e.h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("none-oplock open: status=0x%08x, want SUCCESS", uint32(resp.Status))
+	}
+	openFile, ok := e.h.GetOpenFile(resp.FileID)
+	if !ok {
+		t.Fatal("none-oplock open: OpenFile not registered")
+	}
+	return resp, openFile
+}
+
+// TestReplay_NoOplockOpenIsReplayCacheable is the live regression for
+// smb2.replay.dhv2-pending1n-vs-{oplock,lease}-sane. The original prior fix
+// (#966) only exercised the resolveCreateReplay unit, which passed while the
+// wire failed because a NONE-oplock open never set CreateGuid and was therefore
+// never stored in the replay cache — so the replayed io24 created a fresh open
+// with a new FileID (off-by-one) instead of replaying the original handle.
+//
+// This drives the real CREATE path: a NONE-oplock DH2Q open must be cached by
+// the requested CreateGuid (ReplayCreateGuid), and a subsequent replayed CREATE
+// (FLAGS_REPLAY_OPERATION) must return the SAME FileID via the replay cache,
+// not allocate a new open.
+func TestReplay_NoOplockOpenIsReplayCacheable(t *testing.T) {
+	e := setupReopen2Env(t)
+	const sessionID = uint64(31)
+	createGuid := [16]byte{0xAB, 0xCD, 0xEF, 0x01}
+
+	resp, openFile := e.noOplockNoneOpen(t, sessionID, createGuid)
+
+	// NONE oplock must NOT have granted V2 durability...
+	if openFile.CreateGuid != ([16]byte{}) {
+		t.Fatalf("NONE oplock unexpectedly granted V2 durability (CreateGuid=%x)", openFile.CreateGuid)
+	}
+	// ...but it MUST still be replay-cache-keyed on the requested guid.
+	if openFile.ReplayCreateGuid != createGuid {
+		t.Fatalf("ReplayCreateGuid=%x, want %x", openFile.ReplayCreateGuid, createGuid)
+	}
+	if e.h.CreateReplayCache.Lookup(sessionID, createGuid) == nil {
+		t.Fatal("NONE-oplock DH2Q open was not stored in the replay cache")
+	}
+
+	origFileID := resp.FileID
+
+	// Replay the CREATE (same guid, FLAGS_REPLAY_OPERATION). It must resolve via
+	// the replay cache and return the SAME FileID, not a freshly allocated open.
+	replayCtx := e.makeSMBCtx(sessionID)
+	replayCtx.IsReplay = true
+	replayResp, err := e.h.Create(replayCtx, &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		OplockLevel:       OplockLevelNone,
+		CreateContexts:    []CreateContext{dh2qContext(createGuid, 300000)},
+	})
+	if err != nil {
+		t.Fatalf("replay Create: %v", err)
+	}
+	if replayResp.Status != types.StatusSuccess {
+		t.Fatalf("replay status=0x%08x, want SUCCESS", uint32(replayResp.Status))
+	}
+	if replayResp.FileID != origFileID {
+		t.Fatalf("replay FileID=%x, want original %x (replay missed the cache → fresh open)",
+			replayResp.FileID, origFileID)
+	}
+}
+
+// TestReplay_PendingReservationFileNotAvailable is the live regression for the
+// pending-vs-break window: while the original NONE-oplock CREATE is still parked
+// (reserved), a replayed CREATE for the same guid must fail fast with
+// STATUS_FILE_NOT_AVAILABLE rather than running a fresh conflict resolution that
+// would yield SHARING_VIOLATION (the #966 wire symptom).
+func TestReplay_PendingReservationFileNotAvailable(t *testing.T) {
+	e := setupReopen2Env(t)
+	const sessionID = uint64(32)
+	createGuid := [16]byte{0x11, 0x22, 0x33, 0x44}
+
+	// Simulate the parked original: reserve the guid (as Create does before it
+	// parks on a pending break) without yet storing a completed entry.
+	e.h.CreateReplayCache.Reserve(sessionID, createGuid)
+
+	replayCtx := e.makeSMBCtx(sessionID)
+	replayCtx.IsReplay = true
+	resp, handled := e.h.resolveCreateReplay(replayCtx, &CreateRequest{
+		FileName:          "durable.txt",
+		DesiredAccess:     0x001F01FF,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpen,
+		OplockLevel:       OplockLevelNone,
+		CreateContexts:    []CreateContext{dh2qContext(createGuid, 300000)},
+	})
+	if !handled {
+		t.Fatal("replay against a reserved (parked) guid must be handled")
+	}
+	if resp.Status != types.StatusFileNotAvailable {
+		t.Fatalf("replay-vs-pending status=0x%08x, want FILE_NOT_AVAILABLE", uint32(resp.Status))
+	}
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -11,7 +11,7 @@ Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
 - **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **3**: `charset.Testing`, `notify.valid-req`, `session.reauth5`
-- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **22**: `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 19 replay `*-sane` / `replay-dhv2-oplock2` rows (#749)
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **22**: `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 14 remaining replay `*-sane` rows (#749)
 - **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **46**
 - **Total (non-Kerberos): 71**
 
@@ -24,7 +24,7 @@ Bucket movements in this pass (all CI-safe — `parse-results.sh` keys off the
 test name, which is preserved in its new location):
 
 - `smb2.dirlease.oplocks` — moved Expected→appendix (smbtorture 4.22.6 **client** SIGSEGV, same class as `scan.scan`; not a DittoFS gap).
-- The 20 replay `*-windows` rows — moved Expected→appendix (architecturally Samba-incompatible; Samba's own source does not reproduce the Windows variants — see appendix bucket 10). The 19 `*-sane` / `replay-dhv2-oplock2` rows stay deferred under #749.
+- The 20 replay `*-windows` rows — moved Expected→appendix (architecturally Samba-incompatible; Samba's own source does not reproduce the Windows variants — see appendix bucket 10). The 14 remaining `*-sane` rows stay deferred under #749.
 - `smb2.timestamp_resolution.resolution1` — removed its stale duplicate Expected row; the appendix already carries it (upstream-skipped, `selftest/skip:69-70`).
 
 ## Policy (v1.0 conformance gate, #673)
@@ -241,12 +241,17 @@ shape that reauth4 actually exercises.
 ### Replay Protection (Deferred past v1.0 — #749)
 
 DH2Q durable-V2 create-replay protection landed in #866 (the `replay-dhv2-lease*`
-and two pending `*-sane` rows flipped). The remaining rows are the
-deferred-open replay-vs-pending-break state-machine variants — a multi-week
-rework tracked under **#749** (deferred past the v1.0 tag).
+and `pending1l-*-sane` rows flipped); #749 then keyed the replay cache on the
+requested CreateGuid and echoed the requested oplock level on replay, flipping
+`replay-dhv2-oplock2` and the `pending1{n,o}-vs-{oplock,lease}-sane` rows. The
+remaining rows are the deferred-open replay-vs-pending-break variants — the
+`pending1n-vs-violation-*-sane` pair (parked share-violation CREATE must wait
+for the holder to release; plus a lease-break-ack state-match bug) and the
+`pending2*/3*-sane` multichannel cases (require session survival across the
+originating-channel disconnect) — tracked under **#749**.
 
-**Bucketing note (#673):** only the `*-sane` (and the `replay-dhv2-oplock2`)
-variants are listed below as deferred. The 20 `*-windows` variants were moved
+**Bucketing note (#673):** only the `*-sane` variants are listed below as
+deferred. The 20 `*-windows` variants were moved
 to the [Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
 appendix (bucket 10): they assert the **Windows-specific** ordering of a
 replayed CREATE against a pending oplock/lease break, which Samba's own source
@@ -256,13 +261,8 @@ DittoFS to hit. The `*-sane` rows remain genuinely fixable under #749.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.replay.replay-dhv2-oplock2 | Replay | Deferred: replay of an oplock durable-V2 reopen not yet implemented (deferred-open replay state machine) | #749 |
 | smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending1o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |


### PR DESCRIPTION
Fixes the `-sane` replay-vs-pending rows + `replay-dhv2-oplock2` of #749; `*-windows` rows stay (upstream knownfail.d/smb2.replay, bug 14449).

## Root cause

A replayed DH2Q CREATE (`FLAGS_REPLAY_OPERATION`) must return the original open's FileId. The CREATE replay cache was keyed on `openFile.CreateGuid`, which is only set when V2 durability is granted (Batch oplock or Handle lease). A no-oplock open (`client2_level = NONE`) never gets durability, so its CreateGuid stayed zero and the CREATE was **never cached** — the replayed `io24` then allocated a fresh open with a new FileId (the smbtorture `wrong value for h24->data[0]` off-by-one). #966's unit tests passed because they used Batch/lease opens that do set CreateGuid; the wire failed on the no-oplock path.

## Fix

- Key the replay cache on the **requested** CreateGuid via a new `OpenFile.ReplayCreateGuid`, recorded whenever a DH2Q request context is present — independent of durability grant (matches Samba `smb2srv_open_lookup_replay_cache`).
- On a plain-oplock replay, echo the replay request's **requested** oplock level and drop the DH2Q grant blob when the requested oplock would not qualify for V2 durability (Samba `smbd_smb2_create_replay`) — fixes `replay-dhv2-oplock2` (replay requests NONE over a Batch open).

## Tests

- Live create-replay regression (`TestReplay_NoOplockOpenIsReplayCacheable`) drives the real `h.Create()` path: a NONE-oplock DH2Q open must be replay-cacheable and the replay must return the SAME FileId — the gap #966's unit-only tests missed.
- `TestReplay_PendingReservationFileNotAvailable`, `TestResolveCreateReplay_OplockReplayEchoesRequestedNone`.

## Rows flipped (removed from KNOWN_FAILURES)

- `smb2.replay.replay-dhv2-oplock2`
- `smb2.replay.dhv2-pending1n-vs-oplock-sane`, `dhv2-pending1n-vs-lease-sane`
- `smb2.replay.dhv2-pending1o-vs-oplock-sane`, `dhv2-pending1o-vs-lease-sane`

## Rows kept in KNOWN_FAILURES (accurate reasons)

- All `*-windows` rows — assert the broken Windows ACCESS_DENIED behavior (upstream knownfail.d/smb2.replay, bug 14449); won't pass against a spec-correct server.
- `dhv2-pending1n-vs-violation-{close,ack}-sane` — parked share-violation CREATE must wait for the holder to release (resume currently rechecks while client1 still holds → SHARING_VIOLATION) + a lease-break-ack state-match bug. Out of scope (break-wait/ack changes, regression risk).
- `dhv2-pending2*/3*-sane` — multichannel: require session survival across the originating-channel disconnect (4-channel bind); current connection-close path tears down the whole session including the parked CREATE.