### PR TITLE
feat(smb): SMB3 persistent durable handles on continuous-availability shares

### DIFF
--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -28,6 +28,7 @@ var (
 	createAccessBasedEnum   bool
 	createChangeNotifyOff   bool
 	createStreamsDisabled   bool
+	createContinuousAvail   bool
 	createEnableTrash       bool
 	createTrashRetention    int
 	createTrashRestrictAdm  bool
@@ -91,6 +92,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createAccessBasedEnum, "access-based-enumeration", false, "Enable Windows access-based enumeration (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM). When true, SMB clients only see directory entries they can read.")
 	createCmd.Flags().BoolVar(&createChangeNotifyOff, "change-notify-disabled", false, "Reject SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED on this share (mirrors Samba 'kernel change notify = no').")
 	createCmd.Flags().BoolVar(&createStreamsDisabled, "streams-disabled", false, "Reject SMB2 Alternate Data Stream opens with STATUS_OBJECT_NAME_INVALID on this share (mirrors Samba 'smbd:streams = no').")
+	createCmd.Flags().BoolVar(&createContinuousAvail, "continuous-availability", false, "Advertise SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY and allow SMB3 persistent durable handles on this share.")
 	createCmd.Flags().BoolVar(&createEnableTrash, "enable-trash", false, "Enable the per-share recycle bin so deletes move to #recycle instead of being permanent.")
 	createCmd.Flags().IntVar(&createTrashRetention, "trash-retention-days", 0, "Days to retain recycled items before the reaper purges them (0 = keep forever).")
 	createCmd.Flags().BoolVar(&createTrashRestrictAdm, "trash-restrict-empty-to-admin", false, "Restrict emptying the recycle bin to admins.")
@@ -194,6 +196,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("streams-disabled") {
 		v := createStreamsDisabled
 		req.StreamsDisabled = &v
+	}
+	if cmd.Flags().Changed("continuous-availability") {
+		v := createContinuousAvail
+		req.ContinuousAvailability = &v
 	}
 	// Per-share recycle-bin policy (#190): only forward flags the operator
 	// set so the server applies its own defaults (trash disabled, zero

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -73,6 +73,7 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Access-Based Enumeration", fmt.Sprintf("%v", s.AccessBasedEnumeration)},
 		{"Change Notify Disabled", fmt.Sprintf("%v", s.ChangeNotifyDisabled)},
 		{"Streams Disabled", fmt.Sprintf("%v", s.StreamsDisabled)},
+		{"Continuous Availability", fmt.Sprintf("%v", s.ContinuousAvailability)},
 		{"Retention", retPolicy},
 	}
 

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1191,7 +1191,11 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	if h.DurableStore != nil {
 		hasHandleLease := leaseResponse != nil && leaseResponse.LeaseState&lock.LeaseStateHandle != 0
 		if respCtx := ProcessDurableHandleContext(
-			req.CreateContexts, openFile, h.DurableTimeoutMs, hasHandleLease,
+			req.CreateContexts, openFile, DurableGrantOptions{
+				ConfiguredTimeoutMs:    h.DurableTimeoutMs,
+				LeaseIncludesHandle:    hasHandleLease,
+				ContinuousAvailability: tree.ContinuousAvailability,
+			},
 		); respCtx != nil {
 			durableResponseCtx = respCtx
 		}

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -568,16 +568,16 @@ func processV2Reconnect(
 	filename string,
 	connClientGUID [16]byte,
 ) (*OpenFile, uint32, uint16, [16]byte, types.Status, error) {
-	// Parse V2 reconnect context
-	fileID, createGuid, flags, err := DecodeDH2CReconnect(dh2cCtx.Data)
+	// Parse V2 reconnect context. The DH2C Flags field
+	// (SMB2_DHANDLE_FLAG_PERSISTENT, MS-SMB2 §2.2.13.2.12) is intentionally
+	// NOT validated here: a client reconnecting a persistent handle sets the
+	// flag, and Samba's `smbd_smb2_create_before_exec` reads only the
+	// persistent_id and create_guid from DH2C, ignoring Flags. Whether the
+	// re-established open is persistent is restored from the persisted record
+	// (handle.IsPersistent), not re-derived from the reconnect request.
+	fileID, createGuid, _, err := DecodeDH2CReconnect(dh2cCtx.Data)
 	if err != nil {
 		logger.Debug("processV2Reconnect: invalid DH2C data", "error", err)
-		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
-	}
-
-	// Reject persistent flag
-	if flags&DH2FlagPersistent != 0 {
-		logger.Debug("processV2Reconnect: persistent flag rejected")
 		return nil, 0, 0, [16]byte{}, types.StatusInvalidParameter, nil
 	}
 

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -19,7 +19,7 @@ const (
 	DurableHandleV1ReconnectTag        = "DHnC"     // SMB2_CREATE_DURABLE_HANDLE_RECONNECT (also V1 response tag)
 	DurableHandleV2RequestTag          = "DH2Q"     // SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2 (also V2 response tag)
 	DurableHandleV2ReconnectTag        = "DH2C"     // SMB2_CREATE_DURABLE_HANDLE_RECONNECT_V2
-	DH2FlagPersistent           uint32 = 0x00000002 // Persistent handle (not supported)
+	DH2FlagPersistent           uint32 = 0x00000002 // SMB2_DHANDLE_FLAG_PERSISTENT — persistent handle (CA shares only)
 
 	// AppInstanceIdTag is the 16-byte SMB2_CREATE_APP_INSTANCE_ID create-context
 	// name (MS-SMB2 2.2.13.2.8). Unlike DH2Q/RqLs, this name is a GUID, not a
@@ -189,20 +189,36 @@ func EncodeDH2QResponse(timeoutMs uint32, flags uint32) CreateContext {
 	}
 }
 
+// DurableGrantOptions carries the per-CREATE inputs that gate a durable or
+// persistent handle grant in ProcessDurableHandleContext.
+type DurableGrantOptions struct {
+	// ConfiguredTimeoutMs is the server's configured durable-handle timeout.
+	ConfiguredTimeoutMs uint32
+	// LeaseIncludesHandle is true when the granted lease includes
+	// SMB2_LEASE_HANDLE_CACHING (H). Per MS-SMB2 §3.3.5.9.10 V2 durability is
+	// grantable on a Batch oplock OR a Handle lease.
+	LeaseIncludesHandle bool
+	// ContinuousAvailability is true when the tree's share advertises
+	// SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY. A persistent-handle request
+	// (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT) is only granted as persistent on a
+	// CA share, and on a CA share the grant is unconditional (no Batch/Handle
+	// gate); on a non-CA share the persistent flag is ignored and the request
+	// degrades to a plain durable grant (MS-SMB2 §3.3.5.9.10).
+	ContinuousAvailability bool
+}
+
 // ProcessDurableHandleContext processes DHnQ or DH2Q create contexts from a CREATE request.
 // V2 (DH2Q) takes precedence over V1 (DHnQ) when both are present.
 // Returns a response CreateContext to include in the CREATE response, or nil if
-// durability was not granted. Mutates openFile (IsDurable, CreateGuid, DurableTimeoutMs).
-//
-// leaseIncludesHandle indicates whether the granted lease includes Handle (H) caching.
-// Per MS-SMB2 3.3.5.9.8, V1 durability can be granted when OplockLevel is Batch OR
-// when the lease includes SMB2_LEASE_HANDLE_CACHING.
+// durability was not granted. Mutates openFile (IsDurable, IsPersistent,
+// CreateGuid, DurableTimeoutMs).
 func ProcessDurableHandleContext(
 	contexts []CreateContext,
 	openFile *OpenFile,
-	configuredTimeoutMs uint32,
-	leaseIncludesHandle ...bool,
+	opts DurableGrantOptions,
 ) *CreateContext {
+	configuredTimeoutMs := opts.ConfiguredTimeoutMs
+	hasHandle := opts.LeaseIncludesHandle
 	// Check for DH2Q first (V2 takes precedence over V1)
 	if dh2qCtx := FindCreateContext(contexts, DurableHandleV2RequestTag); dh2qCtx != nil {
 		timeout, flags, createGuid, err := DecodeDH2QRequest(dh2qCtx.Data)
@@ -222,22 +238,23 @@ func ProcessDurableHandleContext(
 			return nil
 		}
 
-		// Reject persistent flag (not supported)
-		if flags&DH2FlagPersistent != 0 {
-			logger.Debug("ProcessDurableHandleContext: persistent flag rejected (not supported)")
-			return nil
-		}
+		// SMB2_DHANDLE_FLAG_PERSISTENT (MS-SMB2 §2.2.13.2.11): a persistent
+		// handle is grantable ONLY on a continuous-availability share
+		// (§3.3.5.9.10). On a CA share the persistent grant is UNCONDITIONAL —
+		// it bypasses the Batch-oplock / Handle-lease gate that applies to
+		// plain durable V2, so every oplock/lease/share-mode combination
+		// succeeds (smbtorture persistent-open-{oplock,lease} CA tables assert
+		// durable==true && persistent==true for all rows). On a non-CA share
+		// the flag is ignored: the request degrades to a plain durable V2
+		// grant (still Batch/Handle gated) with persistent_open==false, which
+		// is exactly what the non-CA durable_open_vs_{oplock,lease}_table rows
+		// expect when smbtorture sets request_persistent on a non-CA share.
+		persistentRequested := flags&DH2FlagPersistent != 0
+		grantPersistent := persistentRequested && opts.ContinuousAvailability
 
-		// Per MS-SMB2 §3.3.5.9.10: V2 durability MUST NOT be granted unless
-		// either OplockLevel is Batch (legacy oplock-backed durable) or the
-		// granted lease includes SMB2_LEASE_HANDLE_CACHING. Matches Samba
-		// `smbd_smb2_create_durable_lease_check`. smbtorture
-		// smb2.durable-v2-open.open-oplock iterates 8 share-mode × 4 oplock-
-		// level combinations and expects `out.durable_open_v2 == false` for
-		// every non-Batch row — granting V2 unconditionally trips those
-		// assertions (line 293 / 455).
-		hasHandle := len(leaseIncludesHandle) > 0 && leaseIncludesHandle[0]
-		if openFile.OplockLevel != OplockLevelBatch && !hasHandle {
+		// MS-SMB2 §3.3.5.9.10: plain durable V2 requires Batch oplock or a
+		// Handle lease. A persistent grant on a CA share bypasses this gate.
+		if !grantPersistent && openFile.OplockLevel != OplockLevelBatch && !hasHandle {
 			logger.Debug("ProcessDurableHandleContext: V2 rejected (no Batch oplock or Handle lease)",
 				"oplockLevel", openFile.OplockLevel,
 				"hasHandleLease", hasHandle)
@@ -250,17 +267,24 @@ func ProcessDurableHandleContext(
 			grantedTimeout = timeout
 		}
 
-		// Grant V2 durability
+		// Grant V2 durability (persistent handles are durable + persistent).
 		openFile.IsDurable = true
+		openFile.IsPersistent = grantPersistent
 		openFile.CreateGuid = createGuid
 		openFile.DurableTimeoutMs = grantedTimeout
+
+		var respFlags uint32
+		if grantPersistent {
+			respFlags = DH2FlagPersistent
+		}
 
 		logger.Debug("ProcessDurableHandleContext: V2 durable handle granted",
 			"createGuid", fmt.Sprintf("%x", createGuid),
 			"requestedTimeout", timeout,
-			"grantedTimeout", grantedTimeout)
+			"grantedTimeout", grantedTimeout,
+			"persistent", grantPersistent)
 
-		resp := EncodeDH2QResponse(grantedTimeout, 0)
+		resp := EncodeDH2QResponse(grantedTimeout, respFlags)
 		return &resp
 	}
 
@@ -274,7 +298,6 @@ func ProcessDurableHandleContext(
 		// grant durability. Per MS-SMB2 3.3.5.9.8: "If the open supports
 		// leasing, the server SHOULD grant a durable handle if
 		// Open.Lease.LeaseState includes SMB2_LEASE_HANDLE_CACHING."
-		hasHandle := len(leaseIncludesHandle) > 0 && leaseIncludesHandle[0]
 		if openFile.OplockLevel != OplockLevelBatch && !hasHandle {
 			logger.Debug("ProcessDurableHandleContext: V1 rejected (no Batch oplock or Handle lease)",
 				"oplockLevel", openFile.OplockLevel,
@@ -833,7 +856,11 @@ func validateAndRestore(
 		// GetDurableHandleByCreateGuid lookup fails — breaking the multi-cycle
 		// reconnect that smbtorture durable-v2-open.reopen2* exercises. V1
 		// handles persist CreateGuid == 0, so this is a no-op for them.
-		CreateGuid:    handle.CreateGuid,
+		CreateGuid: handle.CreateGuid,
+		// Restore the persistent flag so a reconnect of a persistent handle
+		// re-reports persistent_open (the open stays persistent across the
+		// disconnect). Pre-#739 rows decode false → plain durable handle.
+		IsPersistent:  handle.IsPersistent,
 		OpenTime:      handle.CreatedAt,
 		DeletePending: handle.DeletePending,
 		ParentHandle:  handle.ParentHandle,
@@ -1058,6 +1085,7 @@ func buildPersistedDurableHandle(
 		LeaseEpoch:      leaseEpoch,
 		CreateGuid:      openFile.CreateGuid,
 		AppInstanceId:   openFile.AppInstanceId,
+		IsPersistent:    openFile.IsPersistent,
 		Username:        username,
 		SessionKeyHash:  sessionKeyHash,
 		IsV2:            openFile.CreateGuid != [16]byte{},

--- a/internal/adapter/smb/handlers/durable_context_test.go
+++ b/internal/adapter/smb/handlers/durable_context_test.go
@@ -298,7 +298,7 @@ func TestProcessDurableHandleContext_V1GrantWithBatchOplock(t *testing.T) {
 		{Name: DurableHandleV1RequestTag, Data: make([]byte, 16)},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp == nil {
 		t.Fatal("Expected V1 grant response, got nil")
 	}
@@ -323,7 +323,7 @@ func TestProcessDurableHandleContext_V1RejectWithoutBatchOplock(t *testing.T) {
 		{Name: DurableHandleV1RequestTag, Data: make([]byte, 16)},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp != nil {
 		t.Error("Expected nil response for non-batch oplock V1 request")
 	}
@@ -350,7 +350,7 @@ func TestProcessDurableHandleContext_V2GrantWithCreateGuid(t *testing.T) {
 		{Name: DurableHandleV2RequestTag, Data: dh2qData},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp == nil {
 		t.Fatal("Expected V2 grant response, got nil")
 	}
@@ -385,7 +385,7 @@ func TestProcessDurableHandleContext_V2ZeroTimeoutUsesServerDefault(t *testing.T
 		{Name: DurableHandleV2RequestTag, Data: dh2qData},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp == nil {
 		t.Fatal("Expected V2 grant response, got nil")
 	}
@@ -394,27 +394,89 @@ func TestProcessDurableHandleContext_V2ZeroTimeoutUsesServerDefault(t *testing.T
 	}
 }
 
-func TestProcessDurableHandleContext_V2RejectPersistentFlag(t *testing.T) {
-	openFile := &OpenFile{
-		FileID:      [16]byte{1, 2, 3},
-		OplockLevel: OplockLevelNone,
-	}
-
+// persistentDH2QData builds a 32-byte DH2Q request blob with the persistent
+// flag set and the given CreateGuid.
+func persistentDH2QData(createGuid [16]byte) []byte {
 	dh2qData := make([]byte, 32)
 	binary.LittleEndian.PutUint32(dh2qData[0:4], 60000)
-	binary.LittleEndian.PutUint32(dh2qData[4:8], DH2FlagPersistent) // Persistent flag
-	copy(dh2qData[16:32], []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	binary.LittleEndian.PutUint32(dh2qData[4:8], DH2FlagPersistent)
+	copy(dh2qData[16:32], createGuid[:])
+	return dh2qData
+}
 
-	contexts := []CreateContext{
-		{Name: DurableHandleV2RequestTag, Data: dh2qData},
-	}
+// TestProcessDurableHandleContext_PersistentNonCADegradesToDurable pins
+// MS-SMB2 §3.3.5.9.10: a persistent request on a NON-CA share is not rejected —
+// the persistent flag is ignored and the request degrades to a plain durable
+// V2 grant (still Batch/Handle gated, persistent_open=false). This is what
+// smbtorture persistent-open-{oplock,lease} expect on a non-CA share (the
+// non-CA durable_open_vs_* tables: persistent=false, durable gated on
+// Batch/Handle). On OplockLevelNone the degraded durable grant fails the gate
+// and yields nil; on Batch it grants durable but NOT persistent.
+func TestProcessDurableHandleContext_PersistentNonCADegradesToDurable(t *testing.T) {
+	createGuid := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
-	if resp != nil {
-		t.Error("Expected nil response when persistent flag is set (not supported)")
-	}
-	if openFile.IsDurable {
-		t.Error("Expected openFile.IsDurable to be false")
+	// Non-CA + no Batch/Handle: degraded durable fails the gate → nil.
+	t.Run("no batch, no handle, no CA -> nil", func(t *testing.T) {
+		openFile := &OpenFile{FileID: [16]byte{1}, OplockLevel: OplockLevelNone}
+		contexts := []CreateContext{{Name: DurableHandleV2RequestTag, Data: persistentDH2QData(createGuid)}}
+		resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
+		if resp != nil {
+			t.Error("expected nil: persistent on non-CA share with no Batch/Handle must not grant")
+		}
+		if openFile.IsDurable || openFile.IsPersistent {
+			t.Errorf("IsDurable=%v IsPersistent=%v, want both false", openFile.IsDurable, openFile.IsPersistent)
+		}
+	})
+
+	// Non-CA + Batch: degrades to a plain durable grant, persistent_open=false.
+	t.Run("batch oplock, no CA -> durable but not persistent", func(t *testing.T) {
+		openFile := &OpenFile{FileID: [16]byte{1}, OplockLevel: OplockLevelBatch}
+		contexts := []CreateContext{{Name: DurableHandleV2RequestTag, Data: persistentDH2QData(createGuid)}}
+		resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
+		if resp == nil {
+			t.Fatal("expected durable grant (degraded from persistent) on Batch oplock")
+		}
+		if !openFile.IsDurable {
+			t.Error("expected IsDurable=true")
+		}
+		if openFile.IsPersistent {
+			t.Error("expected IsPersistent=false on a non-CA share")
+		}
+		// The DH2Q response flags must NOT echo PERSISTENT.
+		flags := binary.LittleEndian.Uint32(resp.Data[4:8])
+		if flags&DH2FlagPersistent != 0 {
+			t.Errorf("response flags=%#x, must not set PERSISTENT on non-CA share", flags)
+		}
+	})
+}
+
+// TestProcessDurableHandleContext_PersistentCAGrant pins MS-SMB2 §3.3.5.9.10:
+// on a continuous-availability share, a persistent request is granted
+// UNCONDITIONALLY (no Batch/Handle gate) and the DH2Q response echoes the
+// PERSISTENT flag. smbtorture persistent-open-{oplock,lease} CA tables assert
+// durable==true && persistent==true for every oplock/lease/share-mode row,
+// including the no-oplock / no-lease rows.
+func TestProcessDurableHandleContext_PersistentCAGrant(t *testing.T) {
+	createGuid := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+
+	// Every oplock level — including None — must grant persistent on a CA share.
+	for _, oplock := range []uint8{OplockLevelNone, OplockLevelII, OplockLevelExclusive, OplockLevelBatch, OplockLevelLease} {
+		openFile := &OpenFile{FileID: [16]byte{1}, OplockLevel: oplock}
+		contexts := []CreateContext{{Name: DurableHandleV2RequestTag, Data: persistentDH2QData(createGuid)}}
+		resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{
+			ConfiguredTimeoutMs:    60000,
+			ContinuousAvailability: true,
+		})
+		if resp == nil {
+			t.Fatalf("oplock=%d: expected persistent grant on CA share, got nil", oplock)
+		}
+		if !openFile.IsDurable || !openFile.IsPersistent {
+			t.Errorf("oplock=%d: IsDurable=%v IsPersistent=%v, want both true", oplock, openFile.IsDurable, openFile.IsPersistent)
+		}
+		flags := binary.LittleEndian.Uint32(resp.Data[4:8])
+		if flags&DH2FlagPersistent == 0 {
+			t.Errorf("oplock=%d: response flags=%#x, want PERSISTENT set", oplock, flags)
+		}
 	}
 }
 
@@ -434,7 +496,7 @@ func TestProcessDurableHandleContext_V2PrecedenceOverV1(t *testing.T) {
 		{Name: DurableHandleV2RequestTag, Data: dh2qData},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp == nil {
 		t.Fatal("Expected V2 response when both V1 and V2 present")
 	}
@@ -457,7 +519,7 @@ func TestProcessDurableHandleContext_NeitherPresent(t *testing.T) {
 		{Name: "MxAc", Data: make([]byte, 8)},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp != nil {
 		t.Error("Expected nil when no durable contexts present")
 	}
@@ -1481,7 +1543,10 @@ func TestProcessDurableHandleContext_V2RequiresBatchOrHandleLease(t *testing.T) 
 			contexts := []CreateContext{
 				{Name: DurableHandleV2RequestTag, Data: dh2qData},
 			}
-			resp := ProcessDurableHandleContext(contexts, openFile, 60000, c.handleLease)
+			resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{
+				ConfiguredTimeoutMs: 60000,
+				LeaseIncludesHandle: c.handleLease,
+			})
 			granted := resp != nil
 			if granted != c.expectGranted {
 				t.Errorf("granted=%v want %v (oplock=%d handleLease=%v)",
@@ -1513,7 +1578,7 @@ func TestProcessDurableHandleContext_V2RejectZeroCreateGuid(t *testing.T) {
 		{Name: DurableHandleV2RequestTag, Data: dh2qData},
 	}
 
-	resp := ProcessDurableHandleContext(contexts, openFile, 60000)
+	resp := ProcessDurableHandleContext(contexts, openFile, DurableGrantOptions{ConfiguredTimeoutMs: 60000})
 	if resp != nil {
 		t.Error("Expected nil response for zero CreateGuid (V2 not granted)")
 	}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -300,6 +300,12 @@ type TreeConnection struct {
 	// STATUS_OBJECT_NAME_INVALID — matches Samba `smbd:streams = no`
 	// and the smb2.create_no_streams.no_stream torture test.
 	StreamsDisabled bool
+	// ContinuousAvailability mirrors the share-level toggle. When true, the
+	// TREE_CONNECT response advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+	// (MS-SMB2 §2.2.10) and a DH2Q SMB2_DHANDLE_FLAG_PERSISTENT request is
+	// granted as a persistent durable handle (#739, smbtorture
+	// smb2.durable-v2-open.persistent-open-{oplock,lease}).
+	ContinuousAvailability bool
 }
 
 // OpenFile represents an open file handle created by the CREATE command.
@@ -514,6 +520,16 @@ type OpenFile struct {
 	// smb2.replay.dhv2-pending1n-vs-{oplock,lease}-sane replay io24 against an
 	// open created with oplock_level=NONE and assert the same FileId comes back.
 	ReplayCreateGuid [16]byte
+
+	// IsPersistent indicates the handle was granted as a persistent durable
+	// handle (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT) on a continuous-availability
+	// share. Persistent handles are a strict superset of durable handles
+	// (IsDurable is also set); the distinction is that the DH2Q response
+	// echoes the PERSISTENT flag and the grant is unconditional regardless of
+	// oplock/lease level (MS-SMB2 §3.3.5.9.10). Only grantable on a CA share;
+	// on a non-CA share a persistent request degrades to a plain durable grant
+	// with this flag clear.
+	IsPersistent bool
 
 	// AppInstanceId is the application instance ID for Hyper-V failover.
 	// Zero value if not set.

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -31,6 +31,15 @@ const SMB2ShareFlagEncryptData uint32 = 0x00008000
 // SMB2_SHARE_CAP_ASYMMETRIC, an unrelated dialect-3.0.2 feature.
 const SMB2ShareFlagAccessBasedDirectoryEnum uint32 = 0x00000800
 
+// SMB2ShareCapContinuousAvailability advertises continuous-availability on
+// the share. Set in the Capabilities field (NOT ShareFlags) of the
+// TREE_CONNECT response when the share is CA-enabled, it tells SMB3 clients
+// the share supports persistent handles (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT).
+// [MS-SMB2] Section 2.2.10. smbtorture
+// smb2.durable-v2-open.persistent-open-{oplock,lease} gate their persistent
+// matrix on smb2cli_tcon_capabilities() & this bit (#739).
+const SMB2ShareCapContinuousAvailability uint32 = 0x00000010
+
 // ipcMaximalAccess defines the access rights for the IPC$ virtual share.
 // [MS-SMB2] Section 2.2.10 - MaximalAccess is a bitmask of allowed operations.
 // Value 0x1F grants the following SMB2 access rights for named pipe operations:
@@ -162,6 +171,7 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		AccessBasedEnumeration: share.AccessBasedEnumeration,
 		ChangeNotifyDisabled:   share.ChangeNotifyDisabled,
 		StreamsDisabled:        share.StreamsDisabled,
+		ContinuousAvailability: share.ContinuousAvailability,
 	}
 	h.StoreTree(tree)
 
@@ -185,8 +195,13 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		shareFlags |= SMB2ShareFlagAccessBasedDirectoryEnum
 	}
 
-	// Capabilities — no per-share caps currently emitted.
+	// Capabilities — advertise continuous-availability when the share is
+	// CA-enabled so SMB3 clients know persistent handles are supported
+	// (MS-SMB2 §2.2.10; #739).
 	var capabilities uint32
+	if share.ContinuousAvailability {
+		capabilities |= SMB2ShareCapContinuousAvailability
+	}
 
 	// Build response (16 bytes)
 	w := smbenc.NewWriter(16)

--- a/internal/adapter/smb/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_test.go
@@ -558,6 +558,114 @@ func TestTreeConnect_AccessBasedEnumerationShareFlag(t *testing.T) {
 	})
 }
 
+// Refs #739: SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY must be 0x00000010 in the
+// Capabilities field per MS-SMB2 §2.2.10 (NOT ShareFlags). smbtorture
+// persistent-open-{oplock,lease} reads it via smb2cli_tcon_capabilities.
+func TestTreeConnect_ShareCapContinuousAvailabilityConstant(t *testing.T) {
+	if SMB2ShareCapContinuousAvailability != 0x00000010 {
+		t.Errorf("SMB2ShareCapContinuousAvailability = 0x%08x, expected 0x00000010", SMB2ShareCapContinuousAvailability)
+	}
+}
+
+// newTreeConnectCAHandler builds an SMB handler with a single share whose
+// ContinuousAvailability flag is configurable.
+func newTreeConnectCAHandler(t *testing.T, shareName string, ca bool) (*Handler, uint64) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	metaStore := memorymeta.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("test-meta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	cfg := &runtime.ShareConfig{
+		Name:                   shareName,
+		MetadataStore:          "test-meta",
+		Enabled:                true,
+		ContinuousAvailability: ca,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}
+	if err := rt.AddShare(context.Background(), cfg); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	sess := h.CreateSession("127.0.0.1:12345", false, "testuser", "")
+	return h, sess.SessionID
+}
+
+// TestTreeConnect_ContinuousAvailabilityCapability verifies the wire-level
+// TREE_CONNECT response advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+// (0x10) in the Capabilities field (offset 8) when the share is CA-enabled,
+// and the tree's ContinuousAvailability flag is set so persistent handle
+// grants can gate on it (refs #739).
+func TestTreeConnect_ContinuousAvailabilityCapability(t *testing.T) {
+	t.Run("CASharesetsCapabilityBit", func(t *testing.T) {
+		h, sessionID := newTreeConnectCAHandler(t, "/ca", true)
+		ctx := newTreeConnectTestContext(sessionID)
+
+		body := buildTreeConnectRequestBody("\\\\server\\ca")
+		result, err := h.TreeConnect(ctx, body)
+		if err != nil {
+			t.Fatalf("TreeConnect returned unexpected error: %v", err)
+		}
+		if result.Status != types.StatusSuccess {
+			t.Fatalf("Status = 0x%x, want StatusSuccess", result.Status)
+		}
+		if len(result.Data) != 16 {
+			t.Fatalf("Response should be 16 bytes, got %d", len(result.Data))
+		}
+
+		// Capabilities at offset 8..12 must carry the CA bit (0x10).
+		capabilities := binary.LittleEndian.Uint32(result.Data[8:12])
+		if capabilities&SMB2ShareCapContinuousAvailability == 0 {
+			t.Errorf("Capabilities = 0x%08x, expected SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY (0x10) set", capabilities)
+		}
+
+		// The tree stored for this connection must carry the flag so the CREATE
+		// persistent-handle path can gate on it.
+		tree, ok := h.GetTree(ctx.TreeID)
+		if !ok || tree == nil {
+			t.Fatal("expected a stored tree connection after TREE_CONNECT")
+		}
+		if !tree.ContinuousAvailability {
+			t.Error("stored TreeConnection.ContinuousAvailability = false, want true")
+		}
+	})
+
+	t.Run("NonCAShareDoesNotSetCapabilityBit", func(t *testing.T) {
+		h, sessionID := newTreeConnectCAHandler(t, "/no-ca", false)
+		ctx := newTreeConnectTestContext(sessionID)
+
+		body := buildTreeConnectRequestBody("\\\\server\\no-ca")
+		result, err := h.TreeConnect(ctx, body)
+		if err != nil {
+			t.Fatalf("TreeConnect returned unexpected error: %v", err)
+		}
+		if result.Status != types.StatusSuccess {
+			t.Fatalf("Status = 0x%x, want StatusSuccess", result.Status)
+		}
+
+		capabilities := binary.LittleEndian.Uint32(result.Data[8:12])
+		if capabilities&SMB2ShareCapContinuousAvailability != 0 {
+			t.Errorf("Capabilities = 0x%08x, should NOT have CA bit when share is not CA-enabled", capabilities)
+		}
+
+		tree, ok := h.GetTree(ctx.TreeID)
+		if !ok || tree == nil {
+			t.Fatal("expected a stored tree connection after TREE_CONNECT")
+		}
+		if tree.ContinuousAvailability {
+			t.Error("stored TreeConnection.ContinuousAvailability = true, want false")
+		}
+	})
+}
+
 func TestTreeConnect_EncryptedShareFlagsInResponse(t *testing.T) {
 	// Test that building a tree connect response with share flags at offset 4
 	// correctly encodes the ENCRYPT_DATA flag.

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -91,6 +91,9 @@ type CreateShareRequest struct {
 	// StreamsDisabled — pointer so nil keeps default false (streams
 	// supported).
 	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
+	// ContinuousAvailability — Refs #739. Pointer so nil keeps default false
+	// (no CA / persistent handles); a non-nil pointer is an explicit set.
+	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
 	// Per-share recycle-bin policy (#190). Pointers so nil keeps the
 	// server default (trash disabled, zero limits).
 	TrashEnabled         *bool    `json:"trash_enabled,omitempty"`
@@ -128,6 +131,9 @@ type UpdateShareRequest struct {
 	// StreamsDisabled — nil = no change; non-nil = explicit set.
 	// Persisted on UpdateShare; takes effect on adapter restart.
 	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
+	// ContinuousAvailability — Refs #739. nil = no change; non-nil = explicit
+	// set. Persisted on UpdateShare; takes effect on adapter restart.
+	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
 	// Per-share recycle-bin policy (#190). nil = no change; non-nil =
 	// explicit set. Unlike the adapter-restart fields above, these apply
 	// LIVE via the runtime (SetShareTrashConfig); turning trash off also
@@ -174,6 +180,9 @@ type ShareResponse struct {
 	ChangeNotifyDisabled bool `json:"change_notify_disabled"`
 	// StreamsDisabled mirrors models.Share. No omitempty for the same reason.
 	StreamsDisabled bool `json:"streams_disabled"`
+	// ContinuousAvailability mirrors models.Share — Refs #739. No omitempty:
+	// operators render the explicit CA state.
+	ContinuousAvailability bool `json:"continuous_availability"`
 	// Per-share recycle-bin policy (#190). No omitempty: these are
 	// operator-meaningful state that consumers (dfsctl share show) render
 	// explicitly.
@@ -340,6 +349,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		streamsDisabled = *req.StreamsDisabled
 	}
 
+	// Continuous availability defaults off (no persistent handles). Refs #739.
+	continuousAvailability := false
+	if req.ContinuousAvailability != nil {
+		continuousAvailability = *req.ContinuousAvailability
+	}
+
 	// Per-share recycle bin (#190). All knobs default to the disabled/zero
 	// state; non-nil pointers are explicit sets.
 	trashEnabled := false
@@ -387,6 +402,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AccessBasedEnumeration:           abe,
 		ChangeNotifyDisabled:             cnDisabled,
 		StreamsDisabled:                  streamsDisabled,
+		ContinuousAvailability:           continuousAvailability,
 		TrashEnabled:                     trashEnabled,
 		TrashRetentionDays:               trashRetentionDays,
 		TrashRestrictToAdmin:             trashRestrictToAdmin,
@@ -439,6 +455,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			StreamsDisabled:                  share.StreamsDisabled,
+			ContinuousAvailability:           share.ContinuousAvailability,
 			TrashEnabled:                     share.TrashEnabled,
 			TrashRetentionDays:               share.TrashRetentionDays,
 			TrashRestrictToAdmin:             share.TrashRestrictToAdmin,
@@ -582,6 +599,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.StreamsDisabled != nil {
 		// Persisted to DB; takes effect on adapter restart.
 		share.StreamsDisabled = *req.StreamsDisabled
+	}
+	if req.ContinuousAvailability != nil {
+		// Refs #739. Persisted to DB; takes effect on adapter restart.
+		share.ContinuousAvailability = *req.ContinuousAvailability
 	}
 	// Per-share recycle bin (#190). Persisted here, then applied LIVE via the
 	// runtime below (with auto-empty on disable).
@@ -1135,6 +1156,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 		AccessBasedEnumeration:           s.AccessBasedEnumeration,
 		ChangeNotifyDisabled:             s.ChangeNotifyDisabled,
 		StreamsDisabled:                  s.StreamsDisabled,
+		ContinuousAvailability:           s.ContinuousAvailability,
 		TrashEnabled:                     s.TrashEnabled,
 		TrashRetentionDays:               s.TrashRetentionDays,
 		TrashRestrictToAdmin:             s.TrashRestrictToAdmin,

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -51,6 +51,9 @@ type Share struct {
 	// StreamsDisabled mirrors models.Share. No omitempty for the same
 	// reason as ChangeNotifyDisabled.
 	StreamsDisabled bool `json:"streams_disabled"`
+	// ContinuousAvailability mirrors models.Share — Refs #739. No omitempty:
+	// operators need to render the explicit CA state.
+	ContinuousAvailability bool `json:"continuous_availability"`
 	// Per-share recycle-bin policy (#190). Mirrors the server
 	// ShareResponse so dfsctl share show can render the trash config.
 	TrashEnabled         bool      `json:"trash_enabled"`
@@ -90,6 +93,9 @@ type CreateShareRequest struct {
 	// StreamsDisabled — pointer so callers can distinguish "unset →
 	// server default (false)" from "explicit true".
 	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
+	// ContinuousAvailability — Refs #739. Pointer so callers can distinguish
+	// "unset → server default (false)" from "explicit true".
+	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
 	// Per-share recycle-bin policy (#190). Pointers so nil keeps the
 	// server default (trash disabled, zero limits).
 	TrashEnabled         *bool    `json:"trash_enabled,omitempty"`
@@ -125,6 +131,9 @@ type UpdateShareRequest struct {
 	// StreamsDisabled — nil = no change; non-nil = explicit set. Takes
 	// effect on adapter restart.
 	StreamsDisabled *bool `json:"streams_disabled,omitempty"`
+	// ContinuousAvailability — Refs #739. nil = no change; non-nil = explicit
+	// set. Takes effect on adapter restart.
+	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
 	// Per-share recycle-bin policy (#190). nil = no change; non-nil =
 	// explicit set. Applied live by the server; turning trash off
 	// auto-empties the bin.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -51,6 +51,12 @@ type Share struct {
 	// smb2.create_no_streams.no_stream torture test. Default false leaves
 	// stream support enabled.
 	StreamsDisabled bool `gorm:"default:false;not null" json:"streams_disabled"`
+	// ContinuousAvailability advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+	// in the TREE_CONNECT response (MS-SMB2 §2.2.10) and allows SMB3 persistent
+	// durable handles (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT) on this share. When
+	// false, a persistent-handle request degrades to a plain durable handle.
+	// Default false (refs #739).
+	ContinuousAvailability bool `gorm:"default:false;not null" json:"continuous_availability"`
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	TrashEnabled bool `gorm:"default:false;not null" json:"trash_enabled"`
 	// TrashRetentionDays auto-empties bin entries older than N days (0 = keep forever).

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -198,6 +198,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			AccessBasedEnumeration:           share.AccessBasedEnumeration,
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			StreamsDisabled:                  share.StreamsDisabled,
+			ContinuousAvailability:           share.ContinuousAvailability,
 			TrashEnabled:                     share.TrashEnabled,
 			TrashRetentionDays:               share.TrashRetentionDays,
 			TrashRestrictToAdmin:             share.TrashRestrictToAdmin,

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -78,6 +78,12 @@ type Share struct {
 	// smb2.create_no_streams.no_stream torture test.
 	StreamsDisabled bool
 
+	// ContinuousAvailability advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+	// in TREE_CONNECT and allows SMB3 persistent durable handles (DH2Q
+	// SMB2_DHANDLE_FLAG_PERSISTENT) on this share. See the models.Share field
+	// for semantics (refs #739).
+	ContinuousAvailability bool
+
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	// Read per-delete via the locked TrashSettingsForShare accessor (NOT off a
 	// shared *Share pointer) so it is concurrency-safe and takes effect live.
@@ -170,6 +176,11 @@ type ShareConfig struct {
 	// FileFsAttributeInformation FileSystemAttributes mask so the
 	// filesystem advertises no ADS support.
 	StreamsDisabled bool
+
+	// ContinuousAvailability mirrors models.Share's per-share toggle that
+	// advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY and enables SMB3
+	// persistent durable handles (refs #739).
+	ContinuousAvailability bool
 
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	// Read per-delete via the locked TrashSettingsForShare accessor (NOT off a
@@ -570,6 +581,7 @@ func (s *Service) prepareShare(
 		AccessBasedEnumeration:           config.AccessBasedEnumeration,
 		ChangeNotifyDisabled:             config.ChangeNotifyDisabled,
 		StreamsDisabled:                  config.StreamsDisabled,
+		ContinuousAvailability:           config.ContinuousAvailability,
 		TrashEnabled:                     config.TrashEnabled,
 		TrashRetentionDays:               config.TrashRetentionDays,
 		TrashRestrictToAdmin:             config.TrashRestrictToAdmin,

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -373,6 +373,15 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to backfill shares.streams_disabled: %w", err)
 	}
 
+	// Backfill shares.continuous_availability for rows that predate the column
+	// (refs #739) — same SQLite ALTER TABLE NULL quirk as the toggles above.
+	if err := db.Exec(
+		"UPDATE shares SET continuous_availability = ? WHERE continuous_availability IS NULL",
+		false,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to backfill shares.continuous_availability: %w", err)
+	}
+
 	// --- Post-AutoMigrate migrations ---
 	// Step 2: Migrate legacy Share payload_store_id column to local/remote block store IDs.
 	postMigrator := db.Migrator()

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -90,6 +90,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"access_based_enumeration":            share.AccessBasedEnumeration,
 		"change_notify_disabled":              share.ChangeNotifyDisabled,
 		"streams_disabled":                    share.StreamsDisabled,
+		"continuous_availability":             share.ContinuousAvailability,
 		"trash_enabled":                       share.TrashEnabled,
 		"trash_retention_days":                share.TrashRetentionDays,
 		"trash_restrict_to_admin":             share.TrashRestrictToAdmin,

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -42,9 +42,9 @@ type PersistedDurableHandle struct {
 	// (smb2.durable-v2-open.lock-lease asserts lease_epoch==1 on reconnect).
 	// Pre-existing rows carry 0, which the reconnect handler treats as
 	// "no persisted epoch" and falls back to the re-granted value.
-	LeaseEpoch      uint16
-	CreateGuid      [16]byte // V2 only; zero for V1
-	AppInstanceId   [16]byte // Zero if not set
+	LeaseEpoch    uint16
+	CreateGuid    [16]byte // V2 only; zero for V1
+	AppInstanceId [16]byte // Zero if not set
 	// IsPersistent records whether the durable open was granted as a
 	// persistent handle (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT) on a
 	// continuous-availability share. Persisted so a reconnect re-echoes the
@@ -53,7 +53,7 @@ type PersistedDurableHandle struct {
 	// handler treats as a plain durable handle. The memory backend round-trips
 	// this via struct copy and badger via JSON; postgres needs an explicit
 	// column.
-	IsPersistent bool
+	IsPersistent    bool
 	Username        string
 	SessionKeyHash  [32]byte // SHA-256 hash, not raw key
 	IsV2            bool

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -45,6 +45,15 @@ type PersistedDurableHandle struct {
 	LeaseEpoch      uint16
 	CreateGuid      [16]byte // V2 only; zero for V1
 	AppInstanceId   [16]byte // Zero if not set
+	// IsPersistent records whether the durable open was granted as a
+	// persistent handle (DH2Q SMB2_DHANDLE_FLAG_PERSISTENT) on a
+	// continuous-availability share. Persisted so a reconnect re-echoes the
+	// PERSISTENT flag in the DH2Q response (the open remains persistent across
+	// the disconnect). Pre-existing rows decode false, which the reconnect
+	// handler treats as a plain durable handle. The memory backend round-trips
+	// this via struct copy and badger via JSON; postgres needs an explicit
+	// column.
+	IsPersistent bool
 	Username        string
 	SessionKeyHash  [32]byte // SHA-256 hash, not raw key
 	IsV2            bool

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -268,6 +268,7 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 		LeaseEpoch:         h.LeaseEpoch,
 		CreateGuid:         h.CreateGuid,
 		AppInstanceId:      h.AppInstanceId,
+		IsPersistent:       h.IsPersistent,
 		Username:           h.Username,
 		SessionKeyHash:     h.SessionKeyHash,
 		IsV2:               h.IsV2,

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -27,7 +27,7 @@ const durableHandleColumns = `
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
-	position_info, original_file_id, requested_alloc_size
+	position_info, original_file_id, requested_alloc_size, is_persistent
 `
 
 func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
@@ -67,6 +67,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&positionInfoSigned,
 		&originalFileIDBytes,
 		&requestedAllocSizeSigned,
+		&h.IsPersistent,
 	)
 
 	if err == pgx.ErrNoRows {
@@ -128,6 +129,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&positionInfoSigned,
 			&originalFileIDBytes,
 			&requestedAllocSizeSigned,
+			&h.IsPersistent,
 		)
 		if err != nil {
 			return nil, err
@@ -187,9 +189,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
 			position_info, original_file_id, requested_alloc_size,
-			lease_epoch
+			lease_epoch, is_persistent
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -219,7 +221,8 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			position_info = EXCLUDED.position_info,
 			original_file_id = EXCLUDED.original_file_id,
 			requested_alloc_size = EXCLUDED.requested_alloc_size,
-			lease_epoch = EXCLUDED.lease_epoch
+			lease_epoch = EXCLUDED.lease_epoch,
+			is_persistent = EXCLUDED.is_persistent
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -263,6 +266,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		// LeaseEpoch is the SMB3 lease-V2 epoch (uint16) stored as INTEGER.
 		// The scan path mirrors this with uint16(int32) on read.
 		int32(handle.LeaseEpoch),
+		// IsPersistent marks a persistent durable handle granted on a CA share
+		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
+		handle.IsPersistent,
 	)
 	return err
 }

--- a/pkg/metadata/store/postgres/migrations/000029_durable_handle_is_persistent.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000029_durable_handle_is_persistent.down.sql
@@ -1,0 +1,4 @@
+-- Revert: drop the durable-handle is_persistent column (#739 persistent-open).
+
+ALTER TABLE durable_handles
+    DROP COLUMN IF EXISTS is_persistent;

--- a/pkg/metadata/store/postgres/migrations/000029_durable_handle_is_persistent.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000029_durable_handle_is_persistent.up.sql
@@ -1,0 +1,17 @@
+-- Persist IsPersistent on durable handles (#739 persistent-open).
+--
+-- An SMB3 persistent durable handle is granted when a DH2Q create context
+-- carries SMB2_DHANDLE_FLAG_PERSISTENT on a continuous-availability share
+-- ([MS-SMB2] 2.2.13.2.11 / 3.3.5.9.10). It is durable + persistent: the
+-- distinction from a plain durable handle is that the DH2Q response echoes
+-- the PERSISTENT flag. On a durable disconnect this must be persisted so the
+-- reconnect re-reports persistent_open (the open stays persistent across the
+-- disconnect).
+--
+-- The memory backend round-trips this field via struct copy and badger picks
+-- it up automatically via JSON; only the postgres profile needs an explicit
+-- column. Stored as BOOLEAN. Pre-existing rows default to false, which the
+-- reconnect handler treats as a plain durable handle.
+
+ALTER TABLE durable_handles
+    ADD COLUMN IF NOT EXISTS is_persistent BOOLEAN NOT NULL DEFAULT FALSE;

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -155,6 +155,7 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 		PositionInfo:       0xDEADBEEFCAFE,
 		OriginalFileID:     originalFileID,
 		RequestedAllocSize: 0x1000,
+		IsPersistent:       true,
 	}
 }
 
@@ -242,6 +243,9 @@ func assertDurableHandleEqual(t *testing.T, expected, actual *lock.PersistedDura
 	}
 	if expected.RequestedAllocSize != actual.RequestedAllocSize {
 		t.Errorf("RequestedAllocSize: got %d, want %d", actual.RequestedAllocSize, expected.RequestedAllocSize)
+	}
+	if expected.IsPersistent != actual.IsPersistent {
+		t.Errorf("IsPersistent: got %v, want %v", actual.IsPersistent, expected.IsPersistent)
 	}
 }
 

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -142,7 +142,7 @@ create_block_stores() {
 # (run.sh / smbtorture/run.sh), so it must stay POSIX-sh-compatible — no bash
 # arrays. Share names contain no whitespace, so a space-separated list with
 # unquoted word-splitting (`for name in $SHARE_NAMES`) is safe.
-SHARE_NAMES="/smbbasic /smbencrypted /fileshare /hideunread /change_notify_disabled /smbnoncanon /create_no_streams"
+SHARE_NAMES="/smbbasic /smbencrypted /fileshare /hideunread /change_notify_disabled /smbnoncanon /create_no_streams /smbpersistent"
 
 # share_create_args NAME — echo the per-share `dfsctl share create` flags
 # (without the common --metadata/--local/--remote flags, which the caller
@@ -171,6 +171,10 @@ share_create_args() {
         # /create_no_streams rejects SMB2 Alternate Data Stream opens with
         # STATUS_OBJECT_NAME_INVALID (Samba `smbd:streams = no` semantics).
         /create_no_streams) echo "--name /create_no_streams --streams-disabled" ;;
+        # Refs #739: /smbpersistent advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+        # so smbtorture smb2.durable-v2-open.persistent-open-{oplock,lease} take
+        # their CA path (durable==true && persistent==true for every row).
+        /smbpersistent) echo "--name /smbpersistent --continuous-availability" ;;
         *)
             log_error "Unknown share: $1"
             return 1

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -198,13 +198,11 @@ to the DH state machine — tracked under #792 / #793.
 
 ### Durable Handles V2 (Fix Candidate)
 
-Durable handle V2 open/reopen operations partially implemented but tests
-still fail due to incomplete reconnect, lease coordination, and persistence.
+Durable handle V2 open/reopen and persistent-handle operations pass; no
+outstanding known failures in this category.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.durable-v2-open.persistent-open-oplock | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
-| smb2.durable-v2-open.persistent-open-lease | Durable handles V2 | Deferred past v1.0: needs continuous-availability share (SMB2_SHARE_CAP_CA) + per-share CA config + a CA-share CI harness — disproportionate plumbing for 2 tests; persisted-handle storage already exists, only the CA-share surface is missing | #739 |
 
 ### Leases (Fix Candidate)
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1,6 +1,6 @@
 # smbtorture Known Failures
 
-Last updated: 2026-06-02 (#673 — rationalization pass: every entry is now bucketed and justified; moved the replay `-windows` variants + `dirlease.oplocks` to the Permanently Unimplementable appendix and removed the stale `timestamp_resolution.resolution1` duplicate)
+Last updated: 2026-06-02 (#739 — implemented SMB3 persistent durable handles on continuous-availability shares; removed the two `durable-v2-open.persistent-open-{oplock,lease}` rows now that they pass against the CA share `/smbpersistent`)
 
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
@@ -11,9 +11,9 @@ Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
 - **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **3**: `charset.Testing`, `notify.valid-req`, `session.reauth5`
-- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **22**: `ioctl.copy_chunk_sparse_dest` (#750), `durable-v2-open.persistent-open-{oplock,lease}` (#739), the 14 remaining replay `*-sane` rows (#749)
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **15**: `ioctl.copy_chunk_sparse_dest` (#750), the 14 remaining replay `*-sane` rows (#749)
 - **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **46**
-- **Total (non-Kerberos): 71**
+- **Total (non-Kerberos): 64**
 
 (Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
@@ -404,7 +404,20 @@ the SMB adapter restores it on reconnect and pushes it back via the existing
 
 #739 stays open: `app-instance`; persistent-open rows stay deferred.
 
-### 2026-05-31 — #739 persistent-open: deferred past v1.0 (CA-share infra)
+### 2026-06-02 — #739 persistent-open: implemented (CA shares)
+
+The 2 `persistent-open-{oplock,lease}` rows are removed — persistent durable
+handles are now implemented. A per-share `ContinuousAvailability` flag is
+threaded through the full share stack (CLI → API → models → store → runtime →
+bootstrap) and TREE_CONNECT advertises `SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY`.
+On a CA share a DH2Q `SMB2_DHANDLE_FLAG_PERSISTENT` request is granted
+unconditionally as a persistent durable handle (reusing the existing
+persisted-handle storage) and the response echoes the PERSISTENT flag; on a
+non-CA share the flag degrades to a plain durable grant. The conformance harness
+runs `smb2.durable-v2-open` against a CA share `/smbpersistent`. This supersedes
+the 2026-05-31 deferral note below.
+
+### 2026-05-31 — #739 persistent-open: deferred past v1.0 (CA-share infra) [SUPERSEDED]
 
 The 2 `persistent-open-{oplock,lease}` rows are deferred. Persistent handles
 require the share to advertise `SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY`, a

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -551,7 +551,13 @@ else
         "smb2.dirlease.unlink_different_set_and_close:dirlease"
         "smb2.durable-open:durable-open"
         "smb2.durable-open-disconnect:durable-open-disconnect"
-        "smb2.durable-v2-open:durable-v2-open"
+        # Refs #739: run durable-v2-open against the CA share /smbpersistent so
+        # the persistent-open-{oplock,lease} subtests take their CA path
+        # (SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY → durable==true &&
+        # persistent==true for every row). The non-persistent durable subtests
+        # use their own CA-independent tables (they gate on SCALEOUT, which the
+        # share does not advertise), so the CA share does not affect them.
+        "smb2.durable-v2-open:durable-v2-open:smbpersistent"
         "smb2.durable-v2-delay:durable-v2-delay"
         "smb2.durable-v2-regressions:durable-v2-regressions"
         "smb2.ea:ea"


### PR DESCRIPTION
Implements SMB3 persistent durable handles, fixes `smb2.durable-v2-open.persistent-open-oplock` and `persistent-open-lease`, part of #739.

## What this plumbs

**Per-share `ContinuousAvailability` flag**, threaded end-to-end following the existing `StreamsDisabled`/`AccessBasedEnumeration` pattern:
- CLI (`dfsctl share create --continuous-availability`, `share show`)
- apiclient + REST API (create/update/response, pointer-in-request for unset vs explicit)
- `models.Share` + controlplane store column + GORM backfill
- runtime `Share`/`ShareConfig` + bootstrap (`init.go`, `AddShare`)
- SMB `TreeConnection` → TREE_CONNECT response advertises `SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY` (0x10) in the Capabilities field (MS-SMB2 §2.2.10)

**Persistent-flag handling** in `ProcessDurableHandleContext` (refactored to a `DurableGrantOptions` struct):
- CA share + `SMB2_DHANDLE_FLAG_PERSISTENT`: grant durable **+ persistent unconditionally** (bypasses the Batch-oplock/Handle-lease gate per MS-SMB2 §3.3.5.9.10) and echo the PERSISTENT flag in the DH2Q response.
- Non-CA share: the persistent flag is **ignored** (degrades to a plain durable grant, `persistent_open=false`) rather than rejecting the whole durable request — matches the non-CA `durable_open_vs_*` tables smbtorture asserts.
- `IsPersistent` persisted on the durable handle (memory/badger/postgres + migration 000029) and restored on reconnect.
- DH2C reconnect no longer rejects the persistent flag (matches Samba, which never inspects the DH2C Flags field) — required for a persistent handle to reconnect.

## Harness
Adds a CA share `/smbpersistent` to the conformance bootstrap and runs the `smb2.durable-v2-open` suite against it so the persistent-open subtests take their CA path. The non-persistent durable subtests gate on SCALEOUT (not advertised), so the CA share doesn't affect them. Removes the two persistent-open rows from `KNOWN_FAILURES.md`.

## Tests
- `ProcessDurableHandleContext`: CA grant across every oplock level (durable+persistent, PERSISTENT echoed); non-CA degradation (durable-only on Batch, nil on no-gate).
- TREE_CONNECT: CA capability bit set/clear + stored `TreeConnection.ContinuousAvailability`.
- Durable store conformance: `IsPersistent` round-trips across memory/badger/postgres.
- Existing durable-V2 matrix kept green.