### PR TITLE
fix(smb/notify): complete CHANGE_NOTIFY on WRITE-modified — flips notify.valid-req (#750)

### DIFF
--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -2523,3 +2523,111 @@ func TestExpireSessionNotifies_CompletesPendingNotify(t *testing.T) {
 		t.Errorf("ExpireSessionNotifies must be idempotent, got %d calls", calls)
 	}
 }
+
+// TestNotifyChange_ValidReq_RemovedAddedModifiedSequence locks in the
+// smb2.notify.valid-req scenario (#750). A directory watcher armed with
+// FILE_NOTIFY_CHANGE_ALL must, when a pre-existing file is unlinked, re-created,
+// and written, observe exactly three buffered changes in order:
+// REMOVED, ADDED, MODIFIED — all naming the same file. The MODIFIED event is the
+// one a userspace VFS must synthesize from its WRITE handler (Samba gets it from
+// kernel inotify); without it the registered CHANGE_NOTIFY only ever sees two
+// changes and the test's CHECK_VAL(num_changes, 3) fails.
+func TestNotifyChange_ValidReq_RemovedAddedModifiedSequence(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	var got []FileNotifyInformation
+	mustRegister(t, r, &PendingNotify{
+		FileID:           [16]byte{1},
+		SessionID:        1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/",
+		ShareName:        "share1",
+		CompletionFilter: AllValidCompletionFilterFlags,
+		MaxOutputLength:  4096,
+		AsyncCallback: func(_, _, _ uint64, resp *ChangeNotifyResponse) error {
+			if resp.GetStatus() != types.StatusSuccess {
+				t.Errorf("expected STATUS_SUCCESS, got 0x%08X", uint32(resp.GetStatus()))
+			}
+			got = decodeFileNotifyInfos(resp.Buffer)
+			return nil
+		},
+	})
+
+	// unlink(FNAME) -> create(FNAME) -> write(FNAME), as torture_setup_simple_file
+	// does when FNAME already exists. These three events accumulate in the
+	// flush window and are delivered as one response.
+	r.NotifyChange("share1", "/", "fname", FileActionRemoved, NameChangeFilterFor("fname", false))
+	r.NotifyChange("share1", "/", "fname", FileActionAdded, NameChangeFilterFor("fname", false))
+	// The WRITE-synthesized MODIFIED event (mirrors write.go).
+	r.NotifyChange("share1", "/", "fname", FileActionModified,
+		FileNotifyChangeSize|FileNotifyChangeLastWrite|FileNotifyChangeAttributes)
+	r.FlushAll()
+
+	want := []FileNotifyInformation{
+		{Action: FileActionRemoved, FileName: "fname"},
+		{Action: FileActionAdded, FileName: "fname"},
+		{Action: FileActionModified, FileName: "fname"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d changes, got %d: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i].Action != want[i].Action || got[i].FileName != want[i].FileName {
+			t.Errorf("change[%d] = {action=0x%X name=%q}, want {action=0x%X name=%q}",
+				i, got[i].Action, got[i].FileName, want[i].Action, want[i].FileName)
+		}
+	}
+}
+
+// TestNotifyChange_WriteModified_RespectsNarrowFilter verifies the WRITE-path
+// MODIFIED event reaches a watcher that requested only FILE_NOTIFY_CHANGE_LAST_WRITE
+// (a strict subset of the WRITE event's size|last-write|attributes mask), and
+// does NOT reach a watcher requesting only FILE_NOTIFY_CHANGE_FILE_NAME.
+func TestNotifyChange_WriteModified_RespectsNarrowFilter(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	lastWriteFired := false
+	mustRegister(t, r, &PendingNotify{
+		FileID:           [16]byte{1},
+		SessionID:        1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeLastWrite,
+		MaxOutputLength:  4096,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			lastWriteFired = true
+			return nil
+		},
+	})
+
+	nameOnlyFired := false
+	mustRegister(t, r, &PendingNotify{
+		FileID:           [16]byte{2},
+		SessionID:        1,
+		MessageID:        11,
+		AsyncId:          101,
+		WatchPath:        "/dir",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  4096,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			nameOnlyFired = true
+			return nil
+		},
+	})
+
+	// Same mask the WRITE handler emits.
+	r.NotifyChange("share1", "/dir", "file.txt", FileActionModified,
+		FileNotifyChangeSize|FileNotifyChangeLastWrite|FileNotifyChangeAttributes)
+	r.FlushAll()
+
+	if !lastWriteFired {
+		t.Error("LAST_WRITE watcher should be notified of a WRITE MODIFIED event")
+	}
+	if nameOnlyFired {
+		t.Error("FILE_NAME-only watcher must NOT be notified of a WRITE MODIFIED event")
+	}
+}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -574,19 +574,37 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		effectiveFilter = stored
 	}
 
-	// Per Samba: buffer_size=0 means the client cannot receive any events.
-	// Return NOTIFY_ENUM_DIR immediately without setting the sticky overflow
-	// flag and without registering a watcher. This is distinct from a real
-	// overflow (buffer>0 but too small) which latches sticky overflow.
-	// Disarm the handle so events fired between this response and the next
-	// CHANGE_NOTIFY register are dropped: ENUM_DIR tells the client to
-	// re-enumerate, so any pre-register events would diverge from the
-	// directory snapshot the client is about to take (smb2.notify.valid-req:
-	// after buffer_size=0 → ENUM_DIR, the next notify must reflect only
-	// events that occur after that next CHANGE_NOTIFY is registered). The
-	// next CHANGE_NOTIFY's Register re-arms the handle from a clean state.
+	// Per Samba: buffer_size=0 means no buffered event can be marshalled into
+	// the (zero-length) reply, so the request completes immediately with
+	// STATUS_NOTIFY_ENUM_DIR and the notify buffer is cleared
+	// (change_notify_reply → notify_marshall_changes fails → num_changes=0).
+	// This is distinct from a real overflow (buffer>0 but too small) which
+	// also latches the sticky-overflow flag.
+	//
+	// Crucially, the handle stays ARMED: Samba's notify_buffer is per-fsp and
+	// outlives individual CHANGE_NOTIFY requests, so filesystem events that
+	// occur after this ENUM_DIR but before the next CHANGE_NOTIFY accumulate
+	// and are replayed on the next request. smb2.notify.valid-req depends on
+	// this — after the buffer_size=0 → ENUM_DIR step it runs unlink→create→write
+	// on an existing file (REMOVED+ADDED+MODIFIED) with no live watcher, then
+	// the following max-sized CHANGE_NOTIFY must report all three. Disarming
+	// here would drop them. We clear the currently-buffered events (the
+	// ENUM_DIR consumed them, matching notify_marshall_changes resetting
+	// num_changes=0) and reset the overflow byte accounting against the new
+	// (zero) buffer size, but leave the armed entry in place.
 	if effectiveMax == 0 {
-		h.NotifyRegistry.Disarm(req.FileID)
+		// Reset overflow accounting against the handle's sticky captured buffer
+		// size (set by the FIRST CHANGE_NOTIFY), not against the transient
+		// zero. The zero only prevents marshalling THIS reply; the handle's
+		// buffering capacity for events that arrive before the next request is
+		// still the sticky max. Using zero here would mark the very next event
+		// as an overflow and drop it, defeating the replay that valid-req needs.
+		stickyMax, set := openFile.NotifyMaxBufferSizeValue()
+		if !set {
+			stickyMax = effectiveMax
+		}
+		h.NotifyRegistry.ClearBufferedEvents(req.FileID)
+		h.NotifyRegistry.ResetArmedOverflow(req.FileID, stickyMax)
 		respBytes, encErr := (&ChangeNotifyResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
 		}).Encode()

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -104,7 +104,6 @@ overflow, rec, rmdir1-4, tcon, tdis, tdis1, tcp, tree.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.notify.valid-req | Change Notify | Upstream-class / timing: asserts a `FILE_NOTIFY_CHANGE` MODIFIED event on WRITE that, without kernel inotify under the Docker harness, also fails against the **reference Samba** server in the same environment. Not a DittoFS-specific gap; kept tracked under #750. | #750 |
 
 ### Oplocks
 


### PR DESCRIPTION
Fixes the `smb2.notify.valid-req` row of #750.

## Root cause

`smb2.notify.valid-req` (source4/torture/smb2/notify.c:82) drives `unlink → create → write` on a file in a watched directory and asserts the registered CHANGE_NOTIFY reports the exact sequence `REMOVED + ADDED + MODIFIED` (num_changes == 3). A userspace VFS must synthesize the MODIFIED event from its own WRITE handler — Samba gets it from kernel inotify. That WRITE hook already existed in `write.go` (FILE_ACTION_MODIFIED with size|last-write|attributes), so the test had been left masked as "needs kernel inotify". It does not.

The actual remaining gap was in the `buffer_size=0` fast path of the CHANGE_NOTIFY handler. valid-req registers a notify with `buffer_size=0` which correctly returns `STATUS_NOTIFY_ENUM_DIR` — but the handler then **disarmed** the directory handle, tearing down the per-handle event buffer. Samba's `notify_buffer` is per-fsp and outlives individual CHANGE_NOTIFY requests: events that occur after the ENUM_DIR but before the next request must accumulate and replay on the next notify. valid-req relies on exactly that — the three events from the *previous* `torture_setup_simple_file` must surface on the *next* max-sized CHANGE_NOTIFY. Disarming dropped them, so the watcher only ever saw a single live event and the test asserted `num_changes 0x1 should be 0x3`.

## Fix

On the `buffer_size=0` path, clear the consumed event buffer but **keep the handle armed**, resetting overflow accounting against the handle's sticky captured buffer size (set by the first CHANGE_NOTIFY) rather than the transient zero — so subsequent events buffer instead of tripping a spurious overflow. The "first notify returns ENUM_DIR → all do" invariant is preserved (a first request with buffer_size=0 captures sticky max 0, which still latches overflow). Reuses the existing `ClearBufferedEvents` / `ResetArmedOverflow` / `NotifyMaxBufferSizeValue` infrastructure — no new state.

## Tests

- New registry-level Go tests assert (a) the full REMOVED+ADDED+MODIFIED sequence coalesces into one response and (b) a WRITE MODIFIED reaches a LAST_WRITE-only watcher but not a FILE_NAME-only watcher.
- `go test -race ./internal/adapter/smb/v2/handlers/` green.

## Local conformance proof-of-flip

Ran the smbtorture battery locally (docker, linux/amd64):
- `smb2.notify.valid-req` → **success** (was: `num_changes 0x1 should be 0x3`)
- `smb2.notify.overflow`, `.tcon`, `.dir` → unregressed (pass)

`smb2.notify.mask` fails in isolation, but it **also fails on clean develop** (CONNECTION_DISCONNECTED, line varies run-to-run) — a pre-existing flake unrelated to this change, which never touches the buffer_size>0 path mask exercises.

Removes only the `smb2.notify.valid-req` row from KNOWN_FAILURES.