### PR TITLE
feat(smb): multichannel session survival on channel disconnect

### DIFF
--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -143,6 +143,14 @@ type SessionTracker interface {
 	TrackSession(sessionID uint64)
 	UntrackSession(sessionID uint64)
 
+	// BindSession records that a channel of sessionID was bound on this
+	// connection (MS-SMB2 §3.3.5.5.2). The session's lifecycle is owned by its
+	// originating connection, not this one; recording the bind lets this
+	// connection's close remove only its channel from the session rather than
+	// tearing the whole session down — the session survives as long as any
+	// channel remains live (multichannel session survival, §3.3.7.1).
+	BindSession(sessionID uint64)
+
 	// AnyTrackedSession returns one of the session IDs currently tracked on
 	// this connection (zero if none). Used by SendErrorResponse for the
 	// wrong-SessionId path so a STATUS_USER_SESSION_DELETED reply can still

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -1273,11 +1273,12 @@ func HandleSMB1Negotiate(connInfo *ConnInfo, message []byte) error {
 // TrackSessionLifecycle tracks session creation/deletion for connection cleanup.
 // This ensures proper cleanup when connections close ungracefully.
 //
-// Channel-bind responses (isBinding==true) are explicitly skipped: a
-// successful bind does not create a session on this connection — the
-// session lives on a different connection, and tracking it here would
-// cause this connection's close to delete the original session via
-// cleanupSessions() (MS-SMB2 §3.3.5.5.2).
+// Channel-bind responses (isBinding==true) are recorded via BindSession rather
+// than TrackSession: a successful bind does not create a session on this
+// connection — the session lives on its originating connection. The bound
+// channel is tracked so this connection's close removes only THIS channel; the
+// session is fully torn down only once its last channel is gone (MS-SMB2
+// §3.3.7.1, multichannel session survival). See cleanupSessions().
 func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uint64, status types.Status, isBinding bool, tracker SessionTracker) {
 	if tracker == nil {
 		return
@@ -1285,16 +1286,27 @@ func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uin
 
 	switch command {
 	case types.SMB2SessionSetup:
-		if status != types.StatusSuccess || isBinding {
+		if status != types.StatusSuccess {
 			return
 		}
 		sessionIDToTrack := ctxSessionID
 		if sessionIDToTrack == 0 {
 			sessionIDToTrack = reqSessionID
 		}
-		if sessionIDToTrack != 0 {
-			tracker.TrackSession(sessionIDToTrack)
+		if sessionIDToTrack == 0 {
+			return
 		}
+		if isBinding {
+			// A successful channel bind does not create a session on this
+			// connection — the session lives on its originating connection.
+			// Record it as a bound channel so this connection's close removes
+			// just THIS channel; the session itself is torn down only when its
+			// last channel is gone (MS-SMB2 §3.3.7.1, multichannel session
+			// survival). See cleanupSessions().
+			tracker.BindSession(sessionIDToTrack)
+			return
+		}
+		tracker.TrackSession(sessionIDToTrack)
 	case types.SMB2Logoff:
 		if status == types.StatusSuccess && reqSessionID != 0 {
 			tracker.UntrackSession(reqSessionID)

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -41,8 +41,14 @@ type Connection struct {
 	writeMu    smb.LockedWriter // Protects connection writes (replies must be serialized)
 
 	// Session tracking for cleanup on disconnect
-	sessionsMu sync.Mutex          // Protects sessions map
+	sessionsMu sync.Mutex          // Protects sessions and boundSessions
 	sessions   map[uint64]struct{} // Sessions created on this connection
+
+	// boundSessions are sessions whose channel was bound on this connection
+	// (MS-SMB2 §3.3.5.5.2) but whose lifecycle is owned by another connection.
+	// On close, this connection removes only its channel from each such session;
+	// the session survives until its last channel closes (§3.3.7.1).
+	boundSessions map[uint64]struct{}
 
 	// CryptoState holds per-connection cryptographic negotiation state
 	// including the preauth integrity hash chain for SMB 3.1.1.
@@ -55,12 +61,13 @@ type Connection struct {
 // preauth integrity hash computation from the very first message.
 func NewConnection(server *Adapter, conn net.Conn) *Connection {
 	return &Connection{
-		ID:          nextConnID.Add(1),
-		server:      server,
-		conn:        conn,
-		requestSem:  make(chan struct{}, server.config.MaxRequestsPerConnection),
-		sessions:    make(map[uint64]struct{}),
-		CryptoState: smb.NewConnectionCryptoState(),
+		ID:            nextConnID.Add(1),
+		server:        server,
+		conn:          conn,
+		requestSem:    make(chan struct{}, server.config.MaxRequestsPerConnection),
+		sessions:      make(map[uint64]struct{}),
+		boundSessions: make(map[uint64]struct{}),
+		CryptoState:   smb.NewConnectionCryptoState(),
 	}
 }
 
@@ -88,6 +95,25 @@ func (c *Connection) TrackSession(sessionID uint64) {
 			SMB:      &clients.SmbDetails{SessionID: sessionID},
 		})
 	}
+}
+
+// BindSession records that a channel of sessionID was bound on this connection
+// (MS-SMB2 §3.3.5.5.2). Unlike TrackSession, this connection does not own the
+// session's lifecycle — it merely carries one of its channels. On connection
+// close, cleanupSessions removes this connection's channel from the session and
+// only tears the session down once its last channel is gone (§3.3.7.1).
+func (c *Connection) BindSession(sessionID uint64) {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	// A session created here (TrackSession) already owns its lifecycle on this
+	// connection; don't downgrade it to a mere bound channel.
+	if _, owned := c.sessions[sessionID]; owned {
+		return
+	}
+	c.boundSessions[sessionID] = struct{}{}
+	logger.Debug("Binding session channel on connection",
+		"sessionID", sessionID,
+		"address", c.conn.RemoteAddr().String())
 }
 
 // UntrackSession removes a session from this connection's tracking.
@@ -399,32 +425,55 @@ func (c *Connection) handleConnectionClose() {
 		"cleanupDuration", cleanupDur)
 }
 
-// cleanupSessions cleans up all sessions that were created on this connection.
+// cleanupSessions cleans up the sessions this connection participated in when
+// the connection closes.
+//
+// Multichannel session survival (MS-SMB2 §3.3.7.1): a session may span several
+// connections (its originating connection plus channels bound via
+// SMB2_SESSION_FLAG_BINDING, §3.3.5.5.2). Closing ONE connection removes only
+// that connection's channel from each session it touched. The session — and any
+// operation parked on it, such as a pending durable-handle reservation — is
+// fully torn down only once its LAST channel is gone. This mirrors Samba's
+// smbXsrv_session_remove_channel, which destroys the session only when
+// num_channels reaches 0.
+//
+// Single-channel sessions (the common case) always reach a zero channel count
+// on close and tear down exactly as before.
 func (c *Connection) cleanupSessions() {
 	clientAddr := c.conn.RemoteAddr().String()
 
 	c.sessionsMu.Lock()
-	sessions := make([]uint64, 0, len(c.sessions))
+	touched := make([]uint64, 0, len(c.sessions)+len(c.boundSessions))
 	for sessionID := range c.sessions {
-		sessions = append(sessions, sessionID)
+		touched = append(touched, sessionID)
+	}
+	for sessionID := range c.boundSessions {
+		if _, owned := c.sessions[sessionID]; !owned {
+			touched = append(touched, sessionID)
+		}
 	}
 	c.sessions = make(map[uint64]struct{})
+	c.boundSessions = make(map[uint64]struct{})
 	c.sessionsMu.Unlock()
 
-	if len(sessions) == 0 {
+	if len(touched) == 0 {
+		return
+	}
+
+	// Remove this connection's channel from each session, then keep only the
+	// sessions whose last channel just closed — those are the ones to tear down.
+	dying := c.removeChannelsAndPartition(touched, clientAddr)
+	if len(dying) == 0 {
 		return
 	}
 
 	logger.Debug("Cleaning up sessions on connection close",
 		"address", clientAddr,
-		"sessionCount", len(sessions))
+		"sessionCount", len(dying))
 
-	// Clean up session→ConnInfo mapping so lease break notifications
-	// are no longer routed to this (now-closed) connection.
-	// Also deregister from the client registry.
+	// Deregister fully-closed sessions from the client registry.
 	rt := c.server.Registry
-	for _, sessionID := range sessions {
-		c.server.sessionConns.Delete(sessionID)
+	for _, sessionID := range dying {
 		if rt != nil {
 			rt.Clients().Deregister(smbClientID(sessionID))
 		}
@@ -439,7 +488,7 @@ func (c *Connection) cleanupSessions() {
 	// enter CleanupSession. Without this pre-increment, there is a race window
 	// where cleanupWg is 0 (Add hasn't been called yet) and WaitForCleanup
 	// returns immediately, allowing the new session to access stale state.
-	c.server.handler.SignalPendingCleanup(len(sessions))
+	c.server.handler.SignalPendingCleanup(len(dying))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -450,7 +499,7 @@ func (c *Connection) cleanupSessions() {
 	cleaned := 0
 	defer func() {
 		if r := recover(); r != nil {
-			remaining := len(sessions) - cleaned
+			remaining := len(dying) - cleaned
 			for i := 0; i < remaining; i++ {
 				c.server.handler.SignalCleanupDone()
 			}
@@ -458,7 +507,7 @@ func (c *Connection) cleanupSessions() {
 		}
 	}()
 
-	for _, sessionID := range sessions {
+	for _, sessionID := range dying {
 		c.server.handler.CleanupSession(ctx, sessionID, true /* transport disconnect */)
 		cleaned++
 	}
@@ -468,7 +517,60 @@ func (c *Connection) cleanupSessions() {
 
 	logger.Debug("Session cleanup complete",
 		"address", clientAddr,
-		"sessionCount", len(sessions))
+		"sessionCount", len(dying))
+}
+
+// removeChannelsAndPartition unbinds this connection's channel from each of the
+// given sessions and returns the subset whose LAST channel just closed (and so
+// must be fully torn down). Sessions that still have a live channel survive
+// (MS-SMB2 §3.3.7.1) — only their break-routing entry is cleaned up when it
+// pointed at this connection. This is the pure channel-survival decision,
+// separated from the runtime-backed teardown so it can be tested in isolation.
+func (c *Connection) removeChannelsAndPartition(sessions []uint64, clientAddr string) []uint64 {
+	var dying []uint64
+	for _, sessionID := range sessions {
+		sess, ok := c.server.handler.GetSession(sessionID)
+		if !ok {
+			// Session already gone (e.g. concurrent LOGOFF / supersession).
+			// Drop any stale break-routing entry pointing at this connection
+			// and move on; there is nothing left to tear down.
+			c.deleteOwnSessionConn(sessionID)
+			continue
+		}
+		sess.RemoveChannel(c.ID)
+		// Reap any half-finished bind auth state for THIS connection. Pending
+		// auth is keyed by (SessionID, ConnID), so this drops only this
+		// channel's entry and leaves other channels' binds intact. For dying
+		// sessions, CleanupSession's DeleteAllPendingAuthForSession is a
+		// superset, so doing it here too is harmless.
+		c.server.handler.DeletePendingAuth(sessionID, c.ID)
+		// Drop the break-routing entry only if it still points at THIS
+		// (now-closed) connection — otherwise it belongs to a surviving
+		// channel and break fan-out must keep using it.
+		c.deleteOwnSessionConn(sessionID)
+		if sess.ChannelCount() > 0 {
+			logger.Debug("Connection close: session survives on remaining channels",
+				"address", clientAddr,
+				"sessionID", sessionID,
+				"remainingChannels", sess.ChannelCount())
+			continue
+		}
+		dying = append(dying, sessionID)
+	}
+	return dying
+}
+
+// deleteOwnSessionConn removes the session→ConnInfo break-routing entry for
+// sessionID only when it currently points at THIS connection. When a surviving
+// channel on another connection owns the entry, it is left intact so break
+// fan-out continues to reach the client (MS-SMB2 §3.3.4.7).
+func (c *Connection) deleteOwnSessionConn(sessionID uint64) {
+	if v, ok := c.server.sessionConns.Load(sessionID); ok {
+		if ci, ok := v.(*smb.ConnInfo); ok && ci != nil && ci.ConnID != c.ID {
+			return
+		}
+	}
+	c.server.sessionConns.Delete(sessionID)
 }
 
 // handleRequestPanic handles cleanup and panic recovery for individual requests.

--- a/pkg/adapter/smb/connection_test.go
+++ b/pkg/adapter/smb/connection_test.go
@@ -567,11 +567,15 @@ func TestTrackSessionLifecycle(t *testing.T) {
 		smb.TrackSessionLifecycle(types.SMB2SessionSetup, 55, 55, types.StatusSuccess, true, c)
 
 		c.sessionsMu.Lock()
-		_, exists := c.sessions[55]
+		_, owned := c.sessions[55]
+		_, bound := c.boundSessions[55]
 		c.sessionsMu.Unlock()
 
-		if exists {
-			t.Error("Channel bind must not track bound session on this connection")
+		if owned {
+			t.Error("Channel bind must not own the session lifecycle on this connection")
+		}
+		if !bound {
+			t.Error("Channel bind must record the bound session for channel accounting")
 		}
 	})
 

--- a/pkg/adapter/smb/lease_notifier.go
+++ b/pkg/adapter/smb/lease_notifier.go
@@ -254,6 +254,15 @@ func (t *connRegistryTracker) TrackSession(sessionID uint64) {
 	}
 }
 
+// BindSession records a bound channel on the connection. The channel itself is
+// registered on the session by the SESSION_SETUP bind path (AddChannel); this
+// only records the bind for connection-close accounting so the session survives
+// until its last channel closes. No sessionConns entry is created — break
+// fan-out reaches bound channels via the session's channel registry.
+func (t *connRegistryTracker) BindSession(sessionID uint64) {
+	t.inner.BindSession(sessionID)
+}
+
 // UntrackSession removes a session from the connection, deregisters its
 // ConnInfo from the break fallback, and unbinds the channel from the
 // session registry.

--- a/pkg/adapter/smb/multichannel_survival_test.go
+++ b/pkg/adapter/smb/multichannel_survival_test.go
@@ -1,0 +1,198 @@
+package smb
+
+import (
+	"net"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// newConnWithID builds a test Connection bound to the same Adapter (so they
+// share the handler / session manager) with a caller-chosen ConnID, modelling
+// two TCP connections of the same multichannel session.
+func newConnWithID(adapter *Adapter, conn net.Conn, id uint64) *Connection {
+	c := NewConnection(adapter, conn)
+	c.ID = id
+	return c
+}
+
+// addChannel registers a Channel for connID on the session.
+func addChannel(t *testing.T, sess *session.Session, connID uint64) {
+	t.Helper()
+	if !sess.AddChannel(&session.Channel{ConnID: connID, RemoteAddr: "127.0.0.1:0"}) {
+		t.Fatalf("AddChannel(%d) failed", connID)
+	}
+}
+
+// parkCreate registers a pending CREATE for sessionID.
+func parkCreate(h *handlers.Handler, sessionID, connID, asyncID uint64) {
+	_ = h.PendingCreateRegistry.Register(&handlers.PendingCreate{
+		ConnID:    connID,
+		SessionID: sessionID,
+		MessageID: 1,
+		AsyncId:   asyncID,
+		Cancel:    func() {},
+		Callback:  func(_, _, _ uint64, _ types.Status, _ []byte) error { return nil },
+	})
+}
+
+// snapshotTouched mirrors the snapshot-and-clear that cleanupSessions performs
+// up front, returning the set of sessions this connection participates in.
+func snapshotTouched(c *Connection) []uint64 {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	out := make([]uint64, 0, len(c.sessions)+len(c.boundSessions))
+	for id := range c.sessions {
+		out = append(out, id)
+	}
+	for id := range c.boundSessions {
+		if _, owned := c.sessions[id]; !owned {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// TestMultichannelSessionSurvival verifies MS-SMB2 §3.3.7.1 multichannel session
+// survival: closing one connection of a multichannel session removes only that
+// connection's channel; the session and any parked operation survive while other
+// channels remain live, and only the last channel's close marks the session for
+// teardown. This is the fix for the smb2.replay.dhv2-pending2*/3*-sane rows of
+// #749.
+//
+// The runtime-backed final teardown (Handler.CleanupSession) is exercised
+// elsewhere (handler-package replay tests); here we assert the pure channel
+// survival/partition decision.
+func TestMultichannelSessionSurvival(t *testing.T) {
+	srvA, cliA := net.Pipe()
+	defer func() { _ = srvA.Close() }()
+	defer func() { _ = cliA.Close() }()
+	srvB, cliB := net.Pipe()
+	defer func() { _ = srvB.Close() }()
+	defer func() { _ = cliB.Close() }()
+
+	adapter := New(Config{})
+
+	origin := newConnWithID(adapter, srvA, 1)
+	secondary := newConnWithID(adapter, srvB, 2)
+
+	sess := adapter.handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sessionID := sess.SessionID
+
+	addChannel(t, sess, origin.ID)
+	addChannel(t, sess, secondary.ID)
+
+	// Origin owns the lifecycle; secondary merely carries a bound channel.
+	origin.TrackSession(sessionID)
+	secondary.BindSession(sessionID)
+
+	parkCreate(adapter.handler, sessionID, origin.ID, 0xAA)
+
+	// --- Drop the ORIGIN connection (the test disconnects the originating
+	// channel mid-test). The session must SURVIVE because the secondary
+	// channel remains live: it is NOT in the dying set, the channel is removed,
+	// and the parked CREATE stays registered. ---
+	dying := origin.removeChannelsAndPartition(snapshotTouched(origin), "origin")
+	if len(dying) != 0 {
+		t.Fatalf("origin close: dying=%v, want empty (session survives on secondary)", dying)
+	}
+	if _, ok := adapter.handler.GetSession(sessionID); !ok {
+		t.Fatal("session must survive origin-channel close while another channel is live")
+	}
+	if got := sess.ChannelCount(); got != 1 {
+		t.Fatalf("after origin close: channel count = %d, want 1 (secondary only)", got)
+	}
+	if sess.GetChannel(origin.ID) != nil {
+		t.Fatal("origin channel must be removed from the session on its connection close")
+	}
+	if n := adapter.handler.PendingCreateRegistry.Len(); n != 1 {
+		t.Fatalf("parked CREATE registry len = %d, want 1 (survives)", n)
+	}
+
+	// --- Drop the SECONDARY connection (the last channel). Now the session is
+	// the last-channel case and must be marked dying. ---
+	dying = secondary.removeChannelsAndPartition(snapshotTouched(secondary), "secondary")
+	if len(dying) != 1 || dying[0] != sessionID {
+		t.Fatalf("secondary close: dying=%v, want [%d] (last channel)", dying, sessionID)
+	}
+	if got := sess.ChannelCount(); got != 0 {
+		t.Fatalf("after secondary close: channel count = %d, want 0", got)
+	}
+}
+
+// TestSingleChannelSessionMarkedDyingOnClose pins the common case: a session
+// with exactly one channel is marked for teardown on connection close, exactly
+// as before the survival change. Guards against the survival gate accidentally
+// leaking single-channel sessions.
+func TestSingleChannelSessionMarkedDyingOnClose(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer func() { _ = srv.Close() }()
+	defer func() { _ = cli.Close() }()
+
+	adapter := New(Config{})
+	c := newConnWithID(adapter, srv, 1)
+
+	sess := adapter.handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sessionID := sess.SessionID
+	addChannel(t, sess, c.ID)
+	c.TrackSession(sessionID)
+
+	dying := c.removeChannelsAndPartition(snapshotTouched(c), "single")
+	if len(dying) != 1 || dying[0] != sessionID {
+		t.Fatalf("single-channel close: dying=%v, want [%d]", dying, sessionID)
+	}
+}
+
+// TestBoundChannelCloseKeepsSessionAndRouting verifies the inverse drop order:
+// when a non-origin (bound) channel closes first, the session survives on the
+// origin channel and the break-routing entry (sessionConns), which points at the
+// still-live origin, is left intact. Dropping the origin afterwards both marks
+// the session dying and clears the routing entry.
+func TestBoundChannelCloseKeepsSessionAndRouting(t *testing.T) {
+	srvA, cliA := net.Pipe()
+	defer func() { _ = srvA.Close() }()
+	defer func() { _ = cliA.Close() }()
+	srvB, cliB := net.Pipe()
+	defer func() { _ = srvB.Close() }()
+	defer func() { _ = cliB.Close() }()
+
+	adapter := New(Config{})
+	origin := newConnWithID(adapter, srvA, 1)
+	secondary := newConnWithID(adapter, srvB, 2)
+
+	sess := adapter.handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sessionID := sess.SessionID
+	addChannel(t, sess, origin.ID)
+	addChannel(t, sess, secondary.ID)
+	origin.TrackSession(sessionID)
+	secondary.BindSession(sessionID)
+
+	// Record a break-routing entry pointing at the origin connection.
+	adapter.sessionConns.Store(sessionID, origin.connInfo())
+
+	// Drop the bound secondary first.
+	dying := secondary.removeChannelsAndPartition(snapshotTouched(secondary), "secondary")
+	if len(dying) != 0 {
+		t.Fatalf("secondary close: dying=%v, want empty (origin still live)", dying)
+	}
+	if _, ok := adapter.handler.GetSession(sessionID); !ok {
+		t.Fatal("session must survive bound-channel close while origin is live")
+	}
+	if got := sess.ChannelCount(); got != 1 {
+		t.Fatalf("after secondary close: channel count = %d, want 1 (origin only)", got)
+	}
+	if _, ok := adapter.sessionConns.Load(sessionID); !ok {
+		t.Fatal("break-routing entry pointing at the live origin must be preserved")
+	}
+
+	// Now drop the origin (last channel).
+	dying = origin.removeChannelsAndPartition(snapshotTouched(origin), "origin")
+	if len(dying) != 1 || dying[0] != sessionID {
+		t.Fatalf("origin close: dying=%v, want [%d] (last channel)", dying, sessionID)
+	}
+	if _, ok := adapter.sessionConns.Load(sessionID); ok {
+		t.Fatal("break-routing entry must be deleted when the origin closes")
+	}
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -11,9 +11,9 @@ Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
 - **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **2**: `charset.Testing`, `session.reauth5`
-- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **14**: the 14 remaining replay `*-sane` rows (#749)
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **8**: the 6 `dhv2-pending2*-sane` replay rows (#749, parked-CREATE finalize-on-holder-release) and the 2 `dhv2-pending1n-vs-violation-*-sane` replay rows (#749, deferred-open dependency)
 - **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **47**
-- **Total (non-Kerberos): 63**
+- **Total (non-Kerberos): 57**
 
 (Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
@@ -232,11 +232,18 @@ DH2Q durable-V2 create-replay protection landed in #866 (the `replay-dhv2-lease*
 and `pending1l-*-sane` rows flipped); #749 then keyed the replay cache on the
 requested CreateGuid and echoed the requested oplock level on replay, flipping
 `replay-dhv2-oplock2` and the `pending1{n,o}-vs-{oplock,lease}-sane` rows. The
-remaining rows are the deferred-open replay-vs-pending-break variants — the
-`pending1n-vs-violation-*-sane` pair (parked share-violation CREATE must wait
-for the holder to release; plus a lease-break-ack state-match bug) and the
-`pending2*/3*-sane` multichannel cases (require session survival across the
-originating-channel disconnect) — tracked under **#749**.
+6 `pending3*-sane` multichannel cases then flipped via multichannel session
+survival (MS-SMB2 §3.3.7.1): closing a channel of a multichannel session now
+removes only that channel and the session — with its parked CREATE and durable
+reservation — survives until its last channel closes, so the replayed CREATE on
+a surviving channel still finds the reservation. The remaining rows are:
+(a) the 6 `pending2*-sane` cases, which additionally disconnect the parked
+CREATE's *originating* channel and then race to the replay before the parked
+CREATE's break-wait timer fires — these need the parked CREATE to finalize and
+clear its reservation the moment the holder *releases* its oplock/lease, not
+only on timeout; and (b) the deferred-open `pending1n-vs-violation-*-sane` pair
+(parked share-violation CREATE must wait for the holder to release; plus a
+lease-break-ack state-match bug). All tracked under **#749**.
 
 **Bucketing note (#673):** only the `*-sane` variants are listed below as
 deferred. The 20 `*-windows` variants were moved
@@ -251,18 +258,12 @@ DittoFS to hit. The `*-sane` rows remain genuinely fixable under #749.
 |-----------|----------|--------|-------|
 | smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2l-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending2o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3n-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3l-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-oplock-sane | Replay | Deferred: replay-vs-pending-oplock (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending3o-vs-lease-sane | Replay | Deferred: replay-vs-pending-lease (sane variant) state machine not yet implemented | #749 |
+| smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Deferred: parked CREATE must finalize + clear its replay reservation when the holder *releases* the conflicting oplock/lease, not only on the break-wait timeout — its originating channel is dropped so the test races to the replay before the timer fires (the surviving-channel half is done; needs break-wake finalization) | #749 |
+| smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
+| smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
+| smb2.replay.dhv2-pending2l-vs-lease-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
+| smb2.replay.dhv2-pending2o-vs-oplock-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
+| smb2.replay.dhv2-pending2o-vs-lease-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
 
 ## Permanently Unimplementable (Out of Scope)
 
@@ -338,6 +339,32 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 `KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running `./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Changelog
+
+### 2026-06-02 — #749 multichannel session survival: 6 rows flipped
+
+Implemented multichannel session survival (MS-SMB2 §3.3.7.1, part of #361):
+closing one connection of a multichannel session now removes only that
+connection's channel from the session rather than tearing the whole session
+down. The session — and any operation parked on it, including a pending
+durable-handle break reservation — survives until its LAST channel closes,
+mirroring Samba's `smbXsrv_session_remove_channel` (destroy only when
+`num_channels == 0`). Single-channel sessions (the common case) reach a zero
+channel count on close and tear down exactly as before.
+
+This flips the 6 `dhv2-pending3*-sane` rows (verified `success:` on the local
+docker smbtorture battery, `samba-toolbox:v0.8`):
+
+- `smb2.replay.dhv2-pending3n-vs-oplock-sane` / `dhv2-pending3n-vs-lease-sane`
+- `smb2.replay.dhv2-pending3l-vs-oplock-sane` / `dhv2-pending3l-vs-lease-sane`
+- `smb2.replay.dhv2-pending3o-vs-oplock-sane` / `dhv2-pending3o-vs-lease-sane`
+
+The 6 `dhv2-pending2*-sane` rows stay deferred: they additionally disconnect the
+parked CREATE's *originating* channel and then race to the replay before the
+5 s break-wait timer fires (replay.c:3119 returns FILE_NOT_AVAILABLE, should be
+OK). They need the parked CREATE to finalize and clear its reservation the
+moment the holder *releases* its oplock/lease — a deeper break-completion change
+on top of session survival. The 2 `dhv2-pending1n-vs-violation-*-sane` rows
+remain deferred (separate deferred-open dependency). All under #749.
 
 ### 2026-06-02 — #673 rationalization: bucket + justify every entry (docs only)
 


### PR DESCRIPTION
Implements SMB3 multichannel session survival (MS-SMB2 §3.3.7.1, part of #361).

When one connection of a multichannel session closes, DittoFS previously tore the whole session down on any tracked-connection close, dropping any operation parked on it. Closing one connection now removes only that connection's channel from the session; the session — and any parked CREATE with its durable-handle break reservation — survives until its LAST channel closes, mirroring Samba's `smbXsrv_session_remove_channel` (destroy only when `num_channels == 0`). Single-channel sessions reach a zero channel count on close and tear down exactly as before.

Flips the 6 `smb2.replay.dhv2-pending3*-{oplock,lease}-sane` rows of #749 — verified `success:` on the local docker smbtorture battery (`samba-toolbox:v0.8`). These disconnect a session channel mid-test while a durable-V2 CREATE is parked on a pending break; the replayed CREATE on a surviving channel still finds the session-scoped reservation.

The 6 `dhv2-pending2*-sane` rows stay deferred under #749: they additionally disconnect the parked CREATE's *originating* channel and race to the replay before the 5 s break-wait timer fires (replay.c:3119 → FILE_NOT_AVAILABLE, should be OK). They need the parked CREATE to finalize and clear its reservation the moment the holder releases its oplock/lease — a deeper break-completion change layered on top of session survival, kept out of this PR for regression safety. KNOWN_FAILURES.md is updated to flip only the 6 verified rows with accurate per-row reasons for the rest.