### PR TITLE
fix(smb/replay): deferred-open wait-for-conflict-clear for pending-break sane rows (#749)

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -330,7 +330,7 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		if !h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
 			return 0
 		}
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout); asyncId != 0 {
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout, false); asyncId != 0 {
 			return asyncId
 		}
 		// Park failed (no slots / registry full): fall through to sync
@@ -369,6 +369,20 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		breakWaitTimeout = lease.TraditionalOplockBreakWaitTimeout
 	}
 
+	// Deferred-open resume for the share-violation case: the parked CREATE
+	// waits for the live share-mode conflict to clear (holder CLOSE) rather
+	// than force-completing the holder's lease on timeout. The holder may
+	// release at any time within the deferred-open window, so the ceiling is
+	// the longer ~35 s grace (Samba defer_open retry window); ack-sane exits
+	// early when the holder's break drains without the conflict clearing, so
+	// it does not actually wait the full ceiling. The non-violation paths
+	// (default / destructive break-to-Write, smbtorture breaking3 /
+	// timeout-disconnect / batch22) keep the existing force-complete wait.
+	shareConflictWait := reason == lock.BreakReasonSharingViolation
+	if shareConflictWait {
+		breakWaitTimeout = lease.TraditionalOplockBreakWaitTimeout
+	}
+
 	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
 	// When a compound CREATE needs to wait for a lease break, it MUST go async
 	// (STATUS_PENDING) even if it is not the last command in the compound.
@@ -378,7 +392,7 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// the test (and real clients) cannot ACK the lease break until they
 	// receive the STATUS_PENDING interim response.
 	if h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout); asyncId != 0 {
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout, shareConflictWait); asyncId != 0 {
 			return asyncId
 		}
 	}
@@ -1335,12 +1349,23 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 // auto-downgrade on expiry). Callers pass TraditionalOplockBreakWaitTimeout
 // (~35 s, MS-SMB2 §3.3.4.6) when the holder is a traditional oplock and
 // AsyncCreateBreakWaitTimeout (~5 s) otherwise.
+//
+// shareConflictWait selects the deferred-open resume semantics for the
+// share-violation case (reason == BreakReasonSharingViolation): instead of
+// force-completing the holder's lease on timeout and rechecking once, the
+// resume goroutine waits for the live share-mode conflict to clear — the holder
+// CLOSEs (conflict gone → CREATE proceeds) or only ACKs the break (open kept →
+// SHARING_VIOLATION on the final recheck), and the holder's deferred ACK still
+// succeeds because the lease is never tombstoned here (smbtorture replay
+// dhv2-pending1n-vs-violation-lease-{close,ack}-sane, MS-SMB2 §3.3.5.9 /
+// Samba defer_open→retry_open).
 func (h *Handler) parkCreateOnLeaseBreak(
 	ctx *SMBHandlerContext,
 	d *createDraft,
 	lockFileHandle lock.FileHandle,
 	waitExceptKey [16]byte,
 	breakWaitTimeout time.Duration,
+	shareConflictWait bool,
 ) uint64 {
 	if h.PendingCreateRegistry == nil || ctx.AsyncCreateCompleteCallback == nil ||
 		ctx.TryReserveAsync == nil || ctx.ReleaseAsync == nil {
@@ -1410,15 +1435,35 @@ func (h *Handler) parkCreateOnLeaseBreak(
 			}
 		}()
 
-		// Wait for the other-key break to drain (or timeout auto-downgrade).
-		// Errors here are logged but not propagated: on timeout the lease
-		// manager has auto-downgraded other-key leases, so the CREATE can
-		// still proceed (same semantics as the sync wait path).
-		if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
-			logger.Debug("CREATE async: break wait completed",
-				"messageID", messageID,
-				"asyncId", asyncId,
-				"error", err)
+		if shareConflictWait {
+			// Deferred-open resume: wait for the live share-mode conflict to
+			// clear (holder CLOSE) rather than force-completing the holder's
+			// lease. On timeout the conflict is still live (holder only ACKed,
+			// keeping its open) and completeCreateAfterBreak's recheck returns
+			// SHARING_VIOLATION — but the holder's lease is left intact so its
+			// deferred ACK still succeeds. See parkCreateOnLeaseBreak doc.
+			effectiveAccess := effectiveAccessForOpen(d.req.DesiredAccess, d.req.CreateDisposition)
+			conflictPresent := func() bool {
+				return d.existingHandle != nil &&
+					h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.filename)
+			}
+			if err := h.LeaseManager.WaitForShareConflictClear(waitCtx, lockFileHandle, shareName, conflictPresent); err != nil {
+				logger.Debug("CREATE async: share-conflict wait completed",
+					"messageID", messageID,
+					"asyncId", asyncId,
+					"error", err)
+			}
+		} else {
+			// Wait for the other-key break to drain (or timeout auto-downgrade).
+			// Errors here are logged but not propagated: on timeout the lease
+			// manager has auto-downgraded other-key leases, so the CREATE can
+			// still proceed (same semantics as the sync wait path).
+			if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
+				logger.Debug("CREATE async: break wait completed",
+					"messageID", messageID,
+					"asyncId", asyncId,
+					"error", err)
+			}
 		}
 
 		// Wait for the dispatcher to finalize the callback assignment before

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -397,11 +397,25 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		}
 	}
 
-	// Sync fallback: bounded wait. On timeout forceCompleteBreaks auto-downgrades
-	// other-key leases so the post-break recheck runs against deterministic state.
+	// Sync fallback (async park unavailable — no slots / registry full): bounded
+	// wait, then let the caller's post-break recheck run. The share-violation
+	// case uses the same deferred-open wait-for-conflict-clear as the async
+	// resume so a CLOSE wakes it promptly and the holder's lease is never
+	// force-completed (otherwise its ACK would fail STATUS_UNSUCCESSFUL). The
+	// non-violation case keeps WaitForOtherKeyBreaks, whose timeout
+	// auto-downgrades other-key leases for a deterministic post-break recheck.
 	waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, breakWaitTimeout)
 	defer cancelWait()
-	if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
+	if shareConflictWait {
+		effectiveAccess := effectiveAccessForOpen(d.req.DesiredAccess, d.req.CreateDisposition)
+		conflictPresent := func() bool {
+			return d.existingHandle != nil &&
+				h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.filename)
+		}
+		if err := h.LeaseManager.WaitForShareConflictClear(waitCtx, lockFileHandle, shareName, conflictPresent); err != nil {
+			logger.Debug("CREATE: sync share-conflict wait completed", "error", err)
+		}
+	} else if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
 		logger.Debug("CREATE: sync break wait completed", "error", err)
 	}
 	return 0

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -823,15 +823,14 @@ func (lm *LeaseManager) WaitForOtherKeyBreaks(ctx context.Context, fileHandle lo
 	return lockMgr.WaitForBreakCompletionExceptKey(ctx, string(fileHandle), excludeKey)
 }
 
-// WaitForShareConflictClear waits on ctx until conflictPresent() reports false,
-// re-evaluating it on every break-wait signal for fileHandle. Used by the SMB
-// CREATE share-violation park path: the parked opener resumes when the
-// conflicting holder CLOSEs (conflict clears → CREATE proceeds) and otherwise
-// waits out the deadline so a holder that only ACKs the break (keeping its
-// open) yields a deterministic SHARING_VIOLATION on the caller's final
-// re-check. Unlike WaitForOtherKeyBreaks this never force-completes the
-// holder's lease on timeout, so the holder's deferred ACK still succeeds
-// (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane).
+// WaitForShareConflictClear waits for the SMB CREATE share-violation park to be
+// ready to recheck the share mode: it returns when the conflicting holder CLOSEs
+// (conflictPresent() goes false → CREATE proceeds), when the holder ACKs the
+// break but keeps its open (break drains with the conflict live → deterministic
+// SHARING_VIOLATION on the caller's recheck), or on ctx timeout. A nil return
+// means "recheck", not "conflict cleared". Unlike WaitForOtherKeyBreaks this
+// never force-completes the holder's lease, so the holder's deferred ACK still
+// succeeds (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane).
 func (lm *LeaseManager) WaitForShareConflictClear(ctx context.Context, fileHandle lock.FileHandle, shareName string, conflictPresent func() bool) error {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -823,6 +823,23 @@ func (lm *LeaseManager) WaitForOtherKeyBreaks(ctx context.Context, fileHandle lo
 	return lockMgr.WaitForBreakCompletionExceptKey(ctx, string(fileHandle), excludeKey)
 }
 
+// WaitForShareConflictClear waits on ctx until conflictPresent() reports false,
+// re-evaluating it on every break-wait signal for fileHandle. Used by the SMB
+// CREATE share-violation park path: the parked opener resumes when the
+// conflicting holder CLOSEs (conflict clears → CREATE proceeds) and otherwise
+// waits out the deadline so a holder that only ACKs the break (keeping its
+// open) yields a deterministic SHARING_VIOLATION on the caller's final
+// re-check. Unlike WaitForOtherKeyBreaks this never force-completes the
+// holder's lease on timeout, so the holder's deferred ACK still succeeds
+// (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane).
+func (lm *LeaseManager) WaitForShareConflictClear(ctx context.Context, fileHandle lock.FileHandle, shareName string, conflictPresent func() bool) error {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return nil
+	}
+	return lockMgr.WaitForShareConflictClear(ctx, string(fileHandle), conflictPresent)
+}
+
 // AsyncCreateBreakWaitTimeout bounds the server-side wait for a parked CREATE.
 // Matches handleLeaseBreakWaitTimeout so sync and async paths have identical
 // auto-downgrade timing — the difference is that async emits an interim

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -264,6 +264,18 @@ type LockManager interface {
 	// even when no waiter exists.
 	SignalParkedCreates(handleKey string)
 
+	// WaitForShareConflictClear blocks until conflictPresent() reports false or
+	// ctx is cancelled, re-evaluating conflictPresent on every break-wait
+	// signal (a holder CLOSE removes its open-table entry; a LEASE_BREAK_ACK
+	// downgrades but keeps it). Unlike WaitForBreakCompletion it does NOT
+	// force-complete breaking leases on ctx timeout: the holder is expected to
+	// release on its own schedule and its later ACK must still succeed
+	// (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane,
+	// MS-SMB2 §3.3.5.9 deferred open / Samba defer_open→retry_open). On timeout
+	// returns ctx.Err() with the lease left intact so the caller does a final
+	// share-mode re-check against the still-live holder.
+	WaitForShareConflictClear(ctx context.Context, handleKey string, conflictPresent func() bool) error
+
 	// ========================================================================
 	// Break Callbacks
 	// ========================================================================
@@ -2266,6 +2278,87 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 			continue
 		}
 	}
+}
+
+// WaitForShareConflictClear blocks until conflictPresent() reports false or ctx
+// is cancelled. It re-evaluates conflictPresent on every break-wait signal so a
+// parked CREATE wakes when the conflicting holder either CLOSEs (open-table
+// entry removed → conflict clears → proceed) or ACKs the lease break (holder
+// kept, share conflict persists → keep waiting until the deadline → caller
+// re-checks and returns SHARING_VIOLATION).
+//
+// Crucially, unlike WaitForBreakCompletion, the ctx-timeout path here does NOT
+// force-complete (tombstone) the holder's breaking lease: the deferred-open
+// contract (MS-SMB2 §3.3.5.9, Samba defer_open→retry_open) lets the holder ack
+// on its own schedule, and forcing the lease to None here would make that later
+// ACK fail STATUS_UNSUCCESSFUL (smbtorture
+// dhv2-pending1n-vs-violation-lease-ack-sane). The lease is left intact and the
+// caller does a final share-mode recheck against the still-live holder.
+func (lm *Manager) WaitForShareConflictClear(ctx context.Context, handleKey string, conflictPresent func() bool) error {
+	// Poll interval. A holder CLOSE that resolves the conflict does NOT signal
+	// the breakWaitChans channel for file leases (that signal is scoped to
+	// directory leases so a file-lease holder closing without ACKing cannot
+	// prematurely wake a regular parked CREATE — smbtorture
+	// smb2.kernel-oplocks.kernel_oplocks7). The deferred-open resume instead
+	// re-evaluates the live share-mode predicate on a short poll, plus on every
+	// break-wait signal, so it wakes promptly on either a CLOSE or an ACK
+	// without disturbing the regular break-completion wait path.
+	const pollInterval = 100 * time.Millisecond
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		if !conflictPresent() {
+			return nil
+		}
+
+		lm.mu.Lock()
+		// Early deterministic exit: the conflict is still present but no break
+		// is in flight any more. The holder resolved its break by ACKing
+		// (keeping its open, e.g. RWH→RW) rather than CLOSEing, so the share
+		// conflict will never clear on its own. Return now so the caller's
+		// final recheck yields SHARING_VIOLATION promptly instead of stalling
+		// until the deadline (smbtorture dhv2-pending1n-vs-violation-lease-ack-sane).
+		if !lm.hasBreakingLeaseLocked(handleKey) {
+			lm.mu.Unlock()
+			return nil
+		}
+		ch, ok := lm.breakWaitChans[handleKey]
+		if !ok {
+			ch = make(chan struct{})
+			lm.breakWaitChans[handleKey] = ch
+		}
+		lm.mu.Unlock()
+
+		// Re-check after subscribing so a signal racing between the predicate
+		// evaluation above and channel registration is not missed.
+		if !conflictPresent() {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ch:
+			continue
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+// hasBreakingLeaseLocked reports whether any lease or delegation on handleKey is
+// currently in the Breaking state. Caller holds lm.mu.
+func (lm *Manager) hasBreakingLeaseLocked(handleKey string) bool {
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.Breaking {
+			return true
+		}
+		if l.Delegation != nil && l.Delegation.Breaking {
+			return true
+		}
+	}
+	return false
 }
 
 // forceCompleteBreaks force-revokes all breaking leases on a file to None when

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -264,16 +264,16 @@ type LockManager interface {
 	// even when no waiter exists.
 	SignalParkedCreates(handleKey string)
 
-	// WaitForShareConflictClear blocks until conflictPresent() reports false or
-	// ctx is cancelled, re-evaluating conflictPresent on every break-wait
-	// signal (a holder CLOSE removes its open-table entry; a LEASE_BREAK_ACK
-	// downgrades but keeps it). Unlike WaitForBreakCompletion it does NOT
-	// force-complete breaking leases on ctx timeout: the holder is expected to
-	// release on its own schedule and its later ACK must still succeed
-	// (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane,
-	// MS-SMB2 §3.3.5.9 deferred open / Samba defer_open→retry_open). On timeout
-	// returns ctx.Err() with the lease left intact so the caller does a final
-	// share-mode re-check against the still-live holder.
+	// WaitForShareConflictClear blocks until the parked CREATE should stop
+	// waiting and recheck the share mode, returning when ANY of: conflictPresent()
+	// reports false (holder CLOSEd → conflict cleared), the holder's break drained
+	// while the conflict persists (holder ACKed but kept its open), or ctx is
+	// cancelled. It re-evaluates conflictPresent on every break-wait signal and on
+	// a short poll. A nil return means "recheck", NOT "conflict cleared" — the
+	// caller MUST re-run the share-mode check. Unlike WaitForBreakCompletion it
+	// NEVER force-completes breaking leases, so the holder's deferred ACK still
+	// succeeds (smbtorture replay dhv2-pending1n-vs-violation-lease-{close,ack}-sane,
+	// MS-SMB2 §3.3.5.9 deferred open / Samba defer_open→retry_open).
 	WaitForShareConflictClear(ctx context.Context, handleKey string, conflictPresent func() bool) error
 
 	// ========================================================================
@@ -2280,20 +2280,27 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 	}
 }
 
-// WaitForShareConflictClear blocks until conflictPresent() reports false or ctx
-// is cancelled. It re-evaluates conflictPresent on every break-wait signal so a
-// parked CREATE wakes when the conflicting holder either CLOSEs (open-table
-// entry removed → conflict clears → proceed) or ACKs the lease break (holder
-// kept, share conflict persists → keep waiting until the deadline → caller
-// re-checks and returns SHARING_VIOLATION).
+// WaitForShareConflictClear blocks until one of three conditions, whichever
+// comes first, then returns. It re-evaluates conflictPresent on every break-wait
+// signal AND on a short poll:
 //
-// Crucially, unlike WaitForBreakCompletion, the ctx-timeout path here does NOT
-// force-complete (tombstone) the holder's breaking lease: the deferred-open
-// contract (MS-SMB2 §3.3.5.9, Samba defer_open→retry_open) lets the holder ack
-// on its own schedule, and forcing the lease to None here would make that later
-// ACK fail STATUS_UNSUCCESSFUL (smbtorture
-// dhv2-pending1n-vs-violation-lease-ack-sane). The lease is left intact and the
-// caller does a final share-mode recheck against the still-live holder.
+//   - conflictPresent() reports false → the holder CLOSEd (its open-table entry
+//     is gone), the conflict cleared → returns nil; the caller's CREATE proceeds.
+//   - the holder's break drained but the conflict is still present → the holder
+//     ACKed the break while keeping its open (e.g. RWH→RW) → returns nil; the
+//     caller's final recheck then yields SHARING_VIOLATION. This early exit is
+//     deterministic, so ack-sane does not stall to the deadline.
+//   - ctx is cancelled (genuine never-released conflict) → returns ctx.Err();
+//     the caller's recheck yields SHARING_VIOLATION against the still-live holder.
+//
+// A nil return therefore means "stop waiting and recheck", NOT "conflict
+// cleared" — the caller MUST re-run the share-mode check to decide the outcome.
+//
+// Crucially, unlike WaitForBreakCompletion, NONE of these paths force-complete
+// (tombstone) the holder's breaking lease: the deferred-open contract
+// (MS-SMB2 §3.3.5.9, Samba defer_open→retry_open) lets the holder ack on its own
+// schedule, and forcing the lease to None here would make a later ACK fail
+// STATUS_UNSUCCESSFUL (smbtorture dhv2-pending1n-vs-violation-lease-ack-sane).
 func (lm *Manager) WaitForShareConflictClear(ctx context.Context, handleKey string, conflictPresent func() bool) error {
 	// Poll interval. A holder CLOSE that resolves the conflict does NOT signal
 	// the breakWaitChans channel for file leases (that signal is scoped to

--- a/pkg/metadata/lock/wait_share_conflict_test.go
+++ b/pkg/metadata/lock/wait_share_conflict_test.go
@@ -1,0 +1,142 @@
+package lock
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// WaitForShareConflictClear backs the SMB CREATE deferred-open resume for the
+// share-violation case (smbtorture replay
+// dhv2-pending1n-vs-violation-lease-{close,ack}-sane). It differs from
+// WaitForBreakCompletion in two ways these tests pin:
+//
+//  1. It returns as soon as the caller's live share-mode predicate clears
+//     (modelling the conflicting holder CLOSEing its open) — without any
+//     break-wait signal, since file-lease CLOSEs do not signal the channel.
+//  2. On ctx timeout it does NOT force-complete (tombstone) the holder's
+//     breaking lease, so the holder's later ACK still succeeds.
+
+// TestWaitForShareConflictClear_ClearsOnConflictDrop proves the wait returns nil
+// promptly once the predicate reports the conflict gone, even with the holder's
+// lease still breaking and no break-wait signal fired (the file-CLOSE path).
+func TestWaitForShareConflictClear_ClearsOnConflictDrop(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	ctx := context.Background()
+	holderKey := [16]byte{1, 0, 0, 0}
+
+	// Holder takes an RWH lease and is broken (Handle strip) by a conflicting open.
+	_, _, err := lm.RequestLease(ctx, FileHandle("file1"), holderKey, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.NoError(t, lm.BreakLeasesOnOpenConflict("file1", nil, BreakReasonSharingViolation))
+
+	var conflict atomic.Bool
+	conflict.Store(true)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- lm.WaitForShareConflictClear(waitCtx, "file1", func() bool { return conflict.Load() })
+	}()
+
+	// Simulate the holder CLOSEing (its conflicting open is removed) without any
+	// break-wait signal — the poll must catch the cleared predicate.
+	time.Sleep(150 * time.Millisecond)
+	conflict.Store(false)
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "wait must return nil once the conflict clears")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForShareConflictClear did not return after the conflict cleared")
+	}
+}
+
+// TestWaitForShareConflictClear_ReturnsWhenBreakDrainsButConflictPersists proves
+// the deterministic ack-sane exit: once the holder ACKs its break (Breaking
+// cleared) but keeps its open (predicate still true), the wait returns promptly
+// so the caller's final recheck yields SHARING_VIOLATION — without stalling to
+// the deadline.
+func TestWaitForShareConflictClear_ReturnsWhenBreakDrainsButConflictPersists(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	ctx := context.Background()
+	holderKey := [16]byte{2, 0, 0, 0}
+
+	_, _, err := lm.RequestLease(ctx, FileHandle("file2"), holderKey, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.NoError(t, lm.BreakLeasesOnOpenConflict("file2", nil, BreakReasonSharingViolation))
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// Conflict persists forever (holder keeps its open after ACK).
+		done <- lm.WaitForShareConflictClear(waitCtx, "file2", func() bool { return true })
+	}()
+
+	// Holder ACKs the break to RW (Handle stripped), keeping its open. This
+	// clears Breaking; the wait must then exit on the no-breaking-lease branch.
+	time.Sleep(150 * time.Millisecond)
+	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, holderKey, LeaseStateRead|LeaseStateWrite, 0))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "wait must return nil (no err) once the break drains, even with the conflict live")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForShareConflictClear did not return after the break drained")
+	}
+
+	// The holder's lease must NOT have been force-completed to None: the ACK
+	// already moved it to RW and the wait left it intact.
+	state, _, found := lm.GetLeaseState(ctx, holderKey)
+	require.True(t, found, "holder lease must still exist (not tombstoned)")
+	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state, "ACKed RW must survive — the wait must not force-complete it")
+}
+
+// TestWaitForShareConflictClear_TimeoutDoesNotForceComplete proves that a
+// genuine never-released conflict times out (ctx error) AND leaves the holder's
+// breaking lease intact — so a holder that ACKs after the deadline still
+// succeeds (the ack-sane UNSUCCESSFUL bug is gone).
+func TestWaitForShareConflictClear_TimeoutDoesNotForceComplete(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	ctx := context.Background()
+	holderKey := [16]byte{3, 0, 0, 0}
+
+	_, _, err := lm.RequestLease(ctx, FileHandle("file3"), holderKey, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.NoError(t, lm.BreakLeasesOnOpenConflict("file3", nil, BreakReasonSharingViolation))
+
+	// Pin the break Breaking across the wait: a callback is required so the
+	// break does not auto-resolve. With no registered callback the break stays
+	// pending (Breaking=true) until ACK or force-complete; assert that the wait
+	// times out WITHOUT force-completing.
+	waitCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	// Conflict persists AND the break never drains (no ACK, no callback).
+	err = lm.WaitForShareConflictClear(waitCtx, "file3", func() bool { return true })
+	require.Error(t, err, "a never-released conflict must time out")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// The lease must NOT be a timeout tombstone — it is still breaking, so a
+	// late ACK succeeds (contrast WaitForBreakCompletion, which would have
+	// force-revoked it to None and made the ACK fail STATUS_UNSUCCESSFUL).
+	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, holderKey, LeaseStateRead|LeaseStateWrite, 0),
+		"holder ACK after the deferred-open timeout must still succeed (lease not tombstoned)")
+}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -24,7 +24,7 @@ Bucket movements in this pass (all CI-safe — `parse-results.sh` keys off the
 test name, which is preserved in its new location):
 
 - `smb2.dirlease.oplocks` — moved Expected→appendix (smbtorture 4.22.6 **client** SIGSEGV, same class as `scan.scan`; not a DittoFS gap).
-- The 20 replay `*-windows` rows — moved Expected→appendix (architecturally Samba-incompatible; Samba's own source does not reproduce the Windows variants — see appendix bucket 10). The 14 remaining `*-sane` rows stay deferred under #749.
+- The 20 replay `*-windows` rows — moved Expected→appendix (architecturally Samba-incompatible; Samba's own source does not reproduce the Windows variants — see appendix bucket 10). The `*-sane` rows stay deferred under #749 (12 remaining after the 2026-06-02 #749 deferred-open flip, below).
 - `smb2.timestamp_resolution.resolution1` — removed its stale duplicate Expected row; the appendix already carries it (upstream-skipped, `selftest/skip:69-70`).
 
 ## Policy (v1.0 conformance gate, #673)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -11,9 +11,9 @@ Every remaining entry is justified and falls into exactly one bucket. No
 UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
 - **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **2**: `charset.Testing`, `session.reauth5`
-- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **8**: the 6 `dhv2-pending2*-sane` replay rows (#749, parked-CREATE finalize-on-holder-release) and the 2 `dhv2-pending1n-vs-violation-*-sane` replay rows (#749, deferred-open dependency)
+- **Deferred past v1.0 with a tracking issue** (justified by deferral) — **6**: the 6 `dhv2-pending2*-sane` replay rows (#749, parked-CREATE finalize-on-holder-release)
 - **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **47**
-- **Total (non-Kerberos): 57**
+- **Total (non-Kerberos): 55**
 
 (Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
@@ -236,14 +236,15 @@ requested CreateGuid and echoed the requested oplock level on replay, flipping
 survival (MS-SMB2 §3.3.7.1): closing a channel of a multichannel session now
 removes only that channel and the session — with its parked CREATE and durable
 reservation — survives until its last channel closes, so the replayed CREATE on
-a surviving channel still finds the reservation. The remaining rows are:
-(a) the 6 `pending2*-sane` cases, which additionally disconnect the parked
-CREATE's *originating* channel and then race to the replay before the parked
-CREATE's break-wait timer fires — these need the parked CREATE to finalize and
-clear its reservation the moment the holder *releases* its oplock/lease, not
-only on timeout; and (b) the deferred-open `pending1n-vs-violation-*-sane` pair
-(parked share-violation CREATE must wait for the holder to release; plus a
-lease-break-ack state-match bug). All tracked under **#749**.
+a surviving channel still finds the reservation. The deferred-open
+`pending1n-vs-violation-*-sane` pair then flipped via a wait-for-conflict-clear
+retry (the parked share-violation CREATE waits for the holder to CLOSE/ACK
+instead of force-completing the lease, which also fixed the lease-break-ack
+STATUS_UNSUCCESSFUL bug). The remaining rows are the 6 `pending2*-sane` cases,
+which additionally disconnect the parked CREATE's *originating* channel and then
+race to the replay before the parked CREATE's break-wait timer fires — these
+need the parked CREATE to finalize and clear its reservation the moment the
+holder *releases* its oplock/lease, not only on timeout. All tracked under **#749**.
 
 **Bucketing note (#673):** only the `*-sane` variants are listed below as
 deferred. The 20 `*-windows` variants were moved
@@ -256,8 +257,6 @@ DittoFS to hit. The `*-sane` rows remain genuinely fixable under #749.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
-| smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane | Replay | Deferred: replay-vs-pending-break (sane variant) state machine not yet implemented | #749 |
 | smb2.replay.dhv2-pending2n-vs-oplock-sane | Replay | Deferred: parked CREATE must finalize + clear its replay reservation when the holder *releases* the conflicting oplock/lease, not only on the break-wait timeout — its originating channel is dropped so the test races to the replay before the timer fires (the surviving-channel half is done; needs break-wake finalization) | #749 |
 | smb2.replay.dhv2-pending2n-vs-lease-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
 | smb2.replay.dhv2-pending2l-vs-oplock-sane | Replay | Deferred: parked CREATE must finalize on holder release, not break-wait timeout (originating channel dropped); see pending2n-vs-oplock-sane | #749 |
@@ -363,8 +362,25 @@ parked CREATE's *originating* channel and then race to the replay before the
 5 s break-wait timer fires (replay.c:3119 returns FILE_NOT_AVAILABLE, should be
 OK). They need the parked CREATE to finalize and clear its reservation the
 moment the holder *releases* its oplock/lease — a deeper break-completion change
-on top of session survival. The 2 `dhv2-pending1n-vs-violation-*-sane` rows
-remain deferred (separate deferred-open dependency). All under #749.
+on top of session survival. (The 2 `dhv2-pending1n-vs-violation-*-sane` rows
+flipped separately — see the next entry.) All under #749.
+
+### 2026-06-02 — #749 replay-vs-pending-break: 2 rows flipped (deferred-open retry)
+
+Flipped `smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane` and
+`smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane`. Root cause: the parked
+share-violation CREATE force-completed (tombstoned) the conflicting holder's
+lease on its 5 s break-wait timeout, then rechecked once — racing the holder's
+~5 s release. For close-sane that produced a spurious SHARING_VIOLATION; for
+ack-sane the tombstoned lease made the holder's deferred LEASE_BREAK_ACK fail
+STATUS_UNSUCCESSFUL. Fix: a deferred-open `WaitForShareConflictClear` retry
+(MS-SMB2 §3.3.5.9, Samba `defer_open`→`retry_open`) — the parked CREATE waits
+for the live share-mode conflict to clear (holder CLOSE → CREATE OK) or for the
+break to drain with the conflict intact (holder ACK → SHARING_VIOLATION), and
+never force-completes the holder's lease, so its ACK succeeds. Scoped to the
+share-violation lease park; the non-violation paths (breaking3 /
+timeout-disconnect / batch22) keep the existing force-complete wait. Deferred
+tally 8→6; total 57→55 (relative to the post-#992 baseline).
 
 ### 2026-06-02 — #673 rationalization: bucket + justify every entry (docs only)
 


### PR DESCRIPTION
fixes the 2 `dhv2-pending1n-vs-violation-lease-{close,ack}-sane` replay rows of #749 via deferred-open wait-for-conflict-clear retry.

## Root cause

The parked share-violation CREATE force-completed (tombstoned) the conflicting holder's lease on its 5 s break-wait timeout, then rechecked the share mode once — racing the holder's ~5 s release:

- **close-sane**: the timeout fired before the holder's CLOSE landed, so the recheck still saw the holder's open and returned a spurious `SHARING_VIOLATION` (expected `OK`).
- **ack-sane**: the timeout tombstoned the lease, so the holder's deferred `LEASE_BREAK_ACK` failed `STATUS_UNSUCCESSFUL` (expected `OK`).

## Fix

A deferred-open `WaitForShareConflictClear` retry (MS-SMB2 §3.3.5.9, Samba `defer_open`→`retry_open`):

- The parked CREATE waits for the **live share-mode conflict** to clear — holder CLOSE → conflict gone → CREATE `OK`; holder ACK (keeps its open) → break drains with the conflict intact → `SHARING_VIOLATION` on the final recheck.
- It **never force-completes** the holder's lease, so the holder's deferred ACK still succeeds (fixes the `UNSUCCESSFUL` bug).
- A 100 ms poll catches the file-CLOSE (file-lease CLOSEs don't signal the break-wait channel, by design for `kernel_oplocks7`); an early-exit returns as soon as the break drains without the conflict clearing (deterministic ack-sane `SHARING_VIOLATION`).
- Scoped to the share-violation lease park (`reason == BreakReasonSharingViolation`). Non-violation paths (breaking3 / timeout-disconnect / batch22) keep the existing force-complete wait unchanged.

## Verification

- New `WaitForShareConflictClear` unit tests (lock pkg): conflict-clears-on-CLOSE, returns-on-break-drain-with-conflict, timeout-does-not-tombstone (late ACK still succeeds). `go test -race` green.
- Local smbtorture (docker linux/amd64): both target rows `success:`.
- Regression sweep — every observed failure reproduces identically on clean develop (host-load timing/epoch flakes, not regressions): `smb2.durable-v2-open` 32/0; `smb2.oplock` only `batch22b` (`te=36` 35 s-boundary flake, fails on develop too); `smb2.lease` only `timeout`/`v2_complex1` (run-isolated flakes, fail on develop too); `smb2.durable-open` only `delete_on_close2` (fails on develop too).

Removes the 2 rows from `KNOWN_FAILURES.md` and decrements Deferred 15→13 / Total 64→62.