### PR TITLE
perf(blockstore): stat-sized chunk read to drop io.ReadAll doubling (C4, #680)

### DIFF
--- a/pkg/blockstore/local/fs/chunkstore.go
+++ b/pkg/blockstore/local/fs/chunkstore.go
@@ -145,9 +145,31 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h blockstore.ContentHash) ([]b
 		return nil, fmt.Errorf("chunkstore: open: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	data, err := io.ReadAll(f)
+	// .blk chunk files are immutable content-addressed blobs: StoreChunk
+	// writes the full slice then atomically renames into place, so the
+	// on-disk size equals the content size and never changes afterward.
+	// Stat the open fd (not the path) so a concurrent lruEvictOne unlink
+	// can't change the size out from under us — the open fd still reads on
+	// POSIX. A single stat-sized allocation + io.ReadFull avoids the
+	// repeated doubling+copy that io.ReadAll incurs on the big-read path.
+	var data []byte
+	fi, err := f.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("chunkstore: read: %w", err)
+	}
+	if size := fi.Size(); size > 0 {
+		buf := make([]byte, size)
+		if _, err := io.ReadFull(f, buf); err != nil {
+			return nil, fmt.Errorf("chunkstore: read: %w", err)
+		}
+		data = buf
+	} else {
+		// Zero-byte stat (or an unexpected non-regular file): fall back to
+		// io.ReadAll, which correctly handles a size we can't trust.
+		data, err = io.ReadAll(f)
+		if err != nil {
+			return nil, fmt.Errorf("chunkstore: read: %w", err)
+		}
 	}
 	// promote on cache hit so frequently-read chunks survive
 	// eviction. A concurrent lruEvictOne may have unlinked the file

--- a/pkg/blockstore/local/fs/chunkstore_test.go
+++ b/pkg/blockstore/local/fs/chunkstore_test.go
@@ -49,6 +49,45 @@ func TestChunkStore_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestChunkStore_RoundTrip_OddSize exercises the stat-sized read path with a
+// chunk whose length is odd and not a power of two (so a single make()+ReadFull
+// must size the buffer exactly from the on-disk stat). The in-RAM LRU index is
+// cleared before the read to force a cold disk read and exercise the
+// re-stat-after-read LRU promote. Bytes must be returned byte-identical.
+func TestChunkStore_RoundTrip_OddSize(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{})
+	h := hashFromHex(t, strings.Repeat("3e", 32))
+	// 7919 is prime: odd, not a power of two, larger than any round buffer.
+	data := make([]byte, 7919)
+	for i := range data {
+		data[i] = byte(i*31 + 7)
+	}
+	ctx := context.Background()
+
+	if err := bc.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	// Drop the LRU index so the read can't be served from a warm entry and
+	// the stat-sized cold-read path is exercised end to end.
+	bc.lruMu.Lock()
+	bc.lruList.Init()
+	for k := range bc.lruIndex {
+		delete(bc.lruIndex, k)
+	}
+	bc.lruMu.Unlock()
+
+	got, err := bc.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if len(got) != len(data) {
+		t.Fatalf("odd-size read length: got %d want %d", len(got), len(data))
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("odd-size round-trip data mismatch")
+	}
+}
+
 func TestChunkStore_Idempotent(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{})
 	h := hashFromHex(t, strings.Repeat("cd", 32))


### PR DESCRIPTION
## C4 — stat-sized chunk read (drop io.ReadAll doubling)

`FSStore.ReadChunk` (`pkg/blockstore/local/fs/chunkstore.go`) read each `.blk`
chunk with `io.ReadAll`, which grows its working buffer by repeated
doubling+copy. The #680 re-profile (REVIEW.md §5.1, finding **C4**) measured
this `io.ReadAll` growth as **~49% of alloc_space** on the sequential/big-read
path: every read of an N-byte chunk allocates roughly 2N (the doubling
overshoot) and copies the data ~log2(N/512) times.

### The change
Replace the `io.ReadAll(f)` with a single stat-sized allocation + `io.ReadFull`:
- `fi := f.Stat()` (stat the **open fd**, not the path), then
  `buf := make([]byte, fi.Size())`, then `io.ReadFull(f, buf)`.
- A 0-byte / untrustworthy stat falls back to `io.ReadAll`.

This collapses the read to **one exact-sized allocation + one copy**, removing
the doubling overshoot and the intermediate copies.

### Safety / immutability argument
`.blk` files are immutable content-addressed blobs. `StoreChunk` writes the
**full** slice in one `f.Write(data)`, fsyncs, then **atomically renames** the
temp file into place; the file is never appended, truncated, or rewritten
afterward. So the on-disk size returned by `f.Stat()` exactly equals the
content size — `io.ReadFull` reads the whole chunk and the result is
byte-identical to the old `io.ReadAll` path.

Stat is taken from the **open fd** (not the path) so a concurrent `lruEvictOne`
unlink between `os.Open` and the read cannot change the size out from under us —
the open fd still reads on POSIX. The existing error wrapping
(`blockstore.ErrChunkNotFound` on ENOENT, `chunkstore: open/read: %w`) and the
re-stat-after-read LRU-promote logic are preserved exactly.

### Tests
Added `TestChunkStore_RoundTrip_OddSize`: writes a prime-length (7919-byte,
odd/non-power-of-two) chunk via the normal store path, clears the in-RAM LRU
index, reads it back cold, and asserts byte-identical — covering the stat-sized
read path with a size no doubling buffer would land on exactly.

Addresses REVIEW.md §5.1 **C4** under #680.
