### PR TITLE
perf(blockstore): shard per-payload append-log state to cut create-path contention (C2, #680)

### DIFF
--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -33,7 +33,7 @@ type logFile struct {
 	// pooled, not rotated); there is no file-rotation path that would
 	// stale-capture lf.f. On error-recovery close (the writeRecord-error
 	// branch in AppendWrite), the entire *logFile is dropped from
-	// bc.logFDs and a fresh one is constructed on next touch — the
+	// the shard's logFDs and a fresh one is constructed on next touch — the
 	// coordinator goes with it.
 	//
 	// Teardown: no explicit Stop is required. The design has no
@@ -61,8 +61,8 @@ func (bc *FSStore) logPath(payloadID string) string {
 
 // getOrCreateLog returns the open log file, per-file append mutex,
 // interval tree, and logIndex for payloadID, creating them on first
-// touch. Uses the standard double-checked-locking idiom against
-// bc.logsMu (mirrors getOrCreateMemBlock in fs.go).
+// touch. Uses the standard double-checked-locking idiom against the
+// payload's shard lock (mirrors getOrCreateMemBlock in fs.go).
 //
 // On first touch it initializes a fresh log via initLogFile; if the log
 // already exists on disk it is reopened O_RDWR and seeked to EOF for
@@ -75,8 +75,8 @@ func (bc *FSStore) logPath(payloadID string) string {
 // a pessimization.
 //
 // Returning the logIndex alongside the tree lets AppendWrite use the
-// snapshot that getOrCreateLog produced under bc.logsMu rather than
-// re-reading bc.logIndices on a second RLock cycle. That second lookup
+// snapshot that getOrCreateLog produced under the shard lock rather than
+// re-reading the shard's logIndices on a second RLock cycle. That second lookup
 // could observe a nil idx if the map had been cleared between AppendWrite's
 // tree.Insert and the logIndex re-read, producing a tree/logIndex
 // divergence that wedged rollup (#668).
@@ -87,30 +87,35 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 	// otherwise place a log file outside <baseDir>/logs. Recovery already
 	// validates filenames read from disk (recovery.go ~line 254); this
 	// guard closes the symmetric write-path gap. The check is intentionally
-	// upstream of bc.logsMu so a malicious id can't take the global RLock
+	// upstream of the shard lock so a malicious id can't take a shard RLock
 	// either.
 	if !isValidPayloadID(payloadID) {
 		return nil, nil, nil, nil, fmt.Errorf("%w: %q", ErrInvalidPayloadID, payloadID)
 	}
 
+	// C2: per-payload state lives in the shard for this payloadID, so the
+	// create-path write lock below contends only with other payloads in the
+	// same shard, not the whole store.
+	sh := bc.shardFor(payloadID)
+
 	// Fast path: all four already present.
-	bc.logsMu.RLock()
-	lf, lfOk := bc.logFDs[payloadID]
-	mu, muOk := bc.logLocks[payloadID]
-	tree, treeOk := bc.dirtyIntervals[payloadID]
-	idx, idxOk := bc.logIndices[payloadID]
-	bc.logsMu.RUnlock()
+	sh.mu.RLock()
+	lf, lfOk := sh.logFDs[payloadID]
+	mu, muOk := sh.logLocks[payloadID]
+	tree, treeOk := sh.dirtyIntervals[payloadID]
+	idx, idxOk := sh.logIndices[payloadID]
+	sh.mu.RUnlock()
 	if lfOk && muOk && treeOk && idxOk {
 		return lf, mu, tree, idx, nil
 	}
 
 	// Slow path: upgrade to write lock, double-check, create missing entries.
-	bc.logsMu.Lock()
-	defer bc.logsMu.Unlock()
-	lf, lfOk = bc.logFDs[payloadID]
-	mu, muOk = bc.logLocks[payloadID]
-	tree, treeOk = bc.dirtyIntervals[payloadID]
-	idx, idxOk = bc.logIndices[payloadID]
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	lf, lfOk = sh.logFDs[payloadID]
+	mu, muOk = sh.logLocks[payloadID]
+	tree, treeOk = sh.dirtyIntervals[payloadID]
+	idx, idxOk = sh.logIndices[payloadID]
 	if !lfOk {
 		path := bc.logPath(payloadID)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -150,35 +155,36 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 		// Bound method value captures lf.f at construction; lf.f is not
 		// rotated for the FSStore lifetime, so the binding stays valid.
 		lf.groupCommit = newGroupCommit(lf.f.Sync)
-		bc.logFDs[payloadID] = lf
+		sh.logFDs[payloadID] = lf
 	}
 	if !muOk {
 		mu = &sync.Mutex{}
-		bc.logLocks[payloadID] = mu
+		sh.logLocks[payloadID] = mu
 	}
 	// C1: pair every payload's append mutex with a rollup mutex, allocated
-	// under the same bc.logsMu write lock so rollupFile always observes a
+	// under the same shard write lock so rollupFile always observes a
 	// non-nil rollup lock whenever the append mutex exists.
-	if _, rmuOk := bc.rollupLocks[payloadID]; !rmuOk {
-		bc.rollupLocks[payloadID] = &sync.Mutex{}
+	if _, rmuOk := sh.rollupLocks[payloadID]; !rmuOk {
+		sh.rollupLocks[payloadID] = &sync.Mutex{}
 	}
 	if !treeOk {
 		tree = newIntervalTree()
-		bc.dirtyIntervals[payloadID] = tree
+		sh.dirtyIntervals[payloadID] = tree
 	}
 	// Direction-1 rollup redesign: pair every payload's interval tree
 	// with a logIndex. The logIndex is allocated on first touch (here)
-	// and from recovery's install path. Both sites run under bc.logsMu.
+	// and from recovery's install path. Both sites run under the shard's
+	// write lock.
 	//
 	// #668: the tree and logIndex MUST be allocated under the same
-	// bc.logsMu write lock so any caller that observes a non-nil tree on
+	// shard write lock so any caller that observes a non-nil tree on
 	// the fast path also observes a non-nil logIndex. A prior version
-	// re-read bc.logIndices on a second RLock cycle inside AppendWrite,
+	// re-read the shard's logIndices on a second RLock cycle inside AppendWrite,
 	// which could see nil and skip Append while tree.Insert had already
 	// landed — wedging the rollup on the next stabilization tick.
 	if !idxOk {
 		idx = newLogIndex()
-		bc.logIndices[payloadID] = idx
+		sh.logIndices[payloadID] = idx
 	}
 	return lf, mu, tree, idx, nil
 }
@@ -234,9 +240,10 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// DeleteAppendLog tombstones the id (DeleteAppendLog acquires the
 	// per-file mutex after tombstoning, and any pressure-blocked writer
 	// re-checks this flag each loop iteration below).
-	bc.logsMu.RLock()
-	_, isDeleted := bc.tombstones[payloadID]
-	bc.logsMu.RUnlock()
+	tsh := bc.shardFor(payloadID)
+	tsh.mu.RLock()
+	_, isDeleted := tsh.tombstones[payloadID]
+	tsh.mu.RUnlock()
 	if isDeleted {
 		return ErrDeleted
 	}
@@ -288,7 +295,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 
 	mu.Lock()
 	// Guarded unlock so the error path can release `mu` BEFORE acquiring
-	// bc.logsMu.Lock() (FIX-2 lock-order discipline) without risking a
+	// the shard lock (FIX-2 lock-order discipline) without risking a
 	// double-unlock panic from this deferred call.
 	muUnlocked := false
 	defer func() {
@@ -311,7 +318,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// a wasted log append; DeleteAppendLog itself acquires the same mutex
 	// immediately after tombstoning so this check is race-free.
 	//
-	// Also re-validate `lf` against the current bc.logFDs entry: if
+	// Also re-validate `lf` against the current shard's logFDs entry: if
 	// DeleteAppendLog ran fully (including step 5's logFDs+tombstones
 	// clear) BETWEEN the writer's pre-mutex tombstone check and the
 	// mutex hand-off, our snapshotted `lf` references a closed/unlinked
@@ -323,10 +330,10 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// the client. The recreate path is intentionally NOT followed by
 	// the same in-flight writer — it belongs to a different file
 	// lifecycle.
-	bc.logsMu.RLock()
-	_, isDeleted = bc.tombstones[payloadID]
-	curLf, curLfOk := bc.logFDs[payloadID]
-	bc.logsMu.RUnlock()
+	tsh.mu.RLock()
+	_, isDeleted = tsh.tombstones[payloadID]
+	curLf, curLfOk := tsh.logFDs[payloadID]
+	tsh.mu.RUnlock()
 	if isDeleted {
 		return ErrDeleted
 	}
@@ -343,21 +350,21 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 		// LOCK ORDERING (FIX-2 / FIX-20 extension)
 		//   per-file `mu` (held by caller across this region)
 		//     → groupCommit.mu (acquired inside lf.groupCommit.Sync below)
-		// → bc.logsMu (NEVER held while waiting on groupCommit.mu
-		//                    the coordinator NEVER references logsMu
+		// → the shard lock (NEVER held while waiting on groupCommit.mu
+		//                    the coordinator NEVER references a shard lock
 		//                    directly — enforced by the
 		//                    TestGroupCommit_NoLogsMuTouch grep gate).
 		// The pre-Phase-19 rule still holds: release per-file mu BEFORE
-		// acquiring bc.logsMu.Lock() (any path that holds logsMu and
+		// acquiring the shard lock (any path that holds the shard lock and
 		// waits on mu would otherwise deadlock against us; the global
-		// rule is "always acquire mu before logsMu" — here we guarantee
-		// it by releasing mu first).
+		// rule is "always acquire mu before the shard lock" — here we
+		// guarantee it by releasing mu first).
 		//
-		// FIX-20: remove the lf entry from bc.logFDs BEFORE closing the
+		// FIX-20: remove the lf entry from the shard's logFDs BEFORE closing the
 		// fd. The previous order (close, then unlock-and-delete) opened
 		// a use-after-close window: any concurrent reader (another
 		// AppendWrite or rollupFile) that snapshotted `lf` from
-		// bc.logFDs while we held the per-file mutex could still hold
+		// the shard's logFDs while we held the per-file mutex could still hold
 		// the same `*logFile` pointer, and once we Close()d the fd they
 		// would read/write a closed descriptor. Removing the map entry
 		// first guarantees no NEW caller can retrieve this lf, and the
@@ -367,9 +374,9 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 		// hold, Close() is safe.
 		mu.Unlock()
 		muUnlocked = true
-		bc.logsMu.Lock()
-		delete(bc.logFDs, payloadID)
-		bc.logsMu.Unlock()
+		tsh.mu.Lock()
+		delete(tsh.logFDs, payloadID)
+		tsh.mu.Unlock()
 		_ = lf.f.Close()
 		return fmt.Errorf("append log: %w", err)
 	}
@@ -406,7 +413,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// when records arrived out of file-offset order.
 	//
 	// #668: idx is the snapshot getOrCreateLog returned under
-	// bc.logsMu, paired with tree under the same lock. Append BEFORE
+	// the shard lock, paired with tree under the same lock. Append BEFORE
 	// tree.Insert so a future rollup pass that observes the dirty
 	// interval is guaranteed to also see the matching logIndex entry,
 	// closing the divergence window that wedged rollupFile permanently.
@@ -445,8 +452,8 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 // because
 //
 //   - Step 2's Lock/Unlock barrier waits for any goroutine that
-//     snapshotted bc.logFDs / bc.logLocks BEFORE step 1's
-//     bc.tombstones[payloadID] = struct{}{} to complete. By the time
+//     snapshotted the shard's logFDs / logLocks BEFORE step 1's
+//     tombstones[payloadID] = struct{}{} to complete. By the time
 //     step 5 runs, no in-flight AppendWrite or rollup can still be
 //     racing against the tombstone clear.
 //   - Steps 4 and 5 happen AFTER the drain — when we clear the
@@ -469,7 +476,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 // open/00.t).
 //
 // Ordering (Blocker 3 fix)
-//  1. Set tombstone under bc.logsMu so new AppendWrites and new rollupFile
+//  1. Set tombstone under the shard lock so new AppendWrites and new rollupFile
 //     entries short-circuit immediately.
 //  2. Acquire the per-file mutex. Because rollupFile holds the
 //     same mutex through reconstructStream → chunker → StoreChunk →
@@ -498,19 +505,17 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 		return ErrStoreClosed
 	}
 
-	// Step 1: tombstone + snapshot mutex/fd under the shared lock. We
-	// release logsMu before acquiring the per-file mutex so a concurrent
-	// rollup that already holds the per-file mutex can still RLock logsMu
-	// (e.g., inside isTombstoned) without deadlocking.
-	bc.logsMu.Lock()
-	if bc.tombstones == nil {
-		bc.tombstones = make(map[string]struct{})
-	}
-	bc.tombstones[payloadID] = struct{}{}
-	mu := bc.logLocks[payloadID]
-	rmu := bc.rollupLocks[payloadID]
-	lf := bc.logFDs[payloadID]
-	bc.logsMu.Unlock()
+	// Step 1: tombstone + snapshot mutex/fd under the shard lock. We
+	// release the shard lock before acquiring the per-file mutex so a
+	// concurrent rollup that already holds the per-file mutex can still
+	// RLock the shard (e.g., inside isTombstoned) without deadlocking.
+	sh := bc.shardFor(payloadID)
+	sh.mu.Lock()
+	sh.tombstones[payloadID] = struct{}{}
+	mu := sh.logLocks[payloadID]
+	rmu := sh.rollupLocks[payloadID]
+	lf := sh.logFDs[payloadID]
+	sh.mu.Unlock()
 
 	// Step 2: wait for any in-flight AppendWrite / rollupFile to drain.
 	// When mu is nil the payload never had a log — no race to wait for.
@@ -534,7 +539,7 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 		// as `mu.Lock(); mu.Unlock()`. The pattern is intentional: we wait
 		// for any goroutine currently holding `mu` (an AppendWrite or
 		// rollupFile pass) to complete before clearing per-payload state.
-		// Subsequent state mutation is guarded by bc.logsMu.
+		// Subsequent state mutation is guarded by the shard lock.
 		//nolint:staticcheck // SA2001: intentional in-flight drain barrier
 		mu.Lock()
 		mu.Unlock() //nolint:staticcheck // SA2001: see above
@@ -590,15 +595,15 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	// derived from the file's path (metadata/file_helpers.go
 	// buildPayloadID), so 'unlink + create at same path' must reuse
 	// the PayloadID and must therefore succeed.
-	bc.logsMu.Lock()
-	delete(bc.logFDs, payloadID)
-	delete(bc.logLocks, payloadID)
-	delete(bc.rollupLocks, payloadID)
-	delete(bc.dirtyIntervals, payloadID)
-	delete(bc.logIndices, payloadID)
-	delete(bc.truncations, payloadID)
-	delete(bc.tombstones, payloadID)
-	bc.logsMu.Unlock()
+	sh.mu.Lock()
+	delete(sh.logFDs, payloadID)
+	delete(sh.logLocks, payloadID)
+	delete(sh.rollupLocks, payloadID)
+	delete(sh.dirtyIntervals, payloadID)
+	delete(sh.logIndices, payloadID)
+	delete(sh.truncations, payloadID)
+	delete(sh.tombstones, payloadID)
+	sh.mu.Unlock()
 
 	// FIX-17: surface any step-4 unlink error after step 5 cleanup so the
 	// in-memory FSStore is left consistent regardless of whether the
@@ -672,7 +677,7 @@ func isTransientUnlinkError(err error) bool {
 // Subsequent behavior
 //   - The per-file interval tree drops entries whose Offset >= newSize and
 //     clips entries that straddle (intervalTree.DropAbove).
-//   - rollupFile consults bc.truncations and filters / clips records
+//   - rollupFile consults the shard's truncations and filters / clips records
 //     whose file_offset + len(payload) crosses newSize so the emitted
 //     chunk stream never contains data past the truncation point.
 //   - AppendWrite is NOT blocked — writes past newSize are still accepted
@@ -692,10 +697,11 @@ func (bc *FSStore) TruncateAppendLog(_ context.Context, payloadID string, newSiz
 		return ErrStoreClosed
 	}
 
-	bc.logsMu.RLock()
-	mu := bc.logLocks[payloadID]
-	tree := bc.dirtyIntervals[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	mu := sh.logLocks[payloadID]
+	tree := sh.dirtyIntervals[payloadID]
+	sh.mu.RUnlock()
 
 	// Drop / clip dirty intervals under the per-file mutex so a
 	// concurrent AppendWrite cannot observe a half-updated tree.
@@ -710,12 +716,9 @@ func (bc *FSStore) TruncateAppendLog(_ context.Context, payloadID string, newSiz
 	// by a later AppendWrite + rollup still honors the boundary for the
 	// records that existed at truncate time. (Records appended AFTER the
 	// truncate are still accepted — see method doc.)
-	bc.logsMu.Lock()
-	if bc.truncations == nil {
-		bc.truncations = make(map[string]uint64)
-	}
-	bc.truncations[payloadID] = newSize
-	bc.logsMu.Unlock()
+	sh.mu.Lock()
+	sh.truncations[payloadID] = newSize
+	sh.mu.Unlock()
 
 	return nil
 }

--- a/pkg/blockstore/local/fs/appendwrite_group_commit_bench_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_group_commit_bench_test.go
@@ -54,9 +54,10 @@ func BenchmarkAppendWrite_GroupCommit(b *testing.B) {
 	if err := bc.AppendWrite(ctx, payloadID, []byte("seed"), 0); err != nil {
 		b.Fatalf("seed AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs[payloadID]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.RLock()
+	lf := bcSh.logFDs[payloadID]
+	bcSh.mu.RUnlock()
 	if lf == nil || lf.groupCommit == nil {
 		b.Fatal("logFile/coordinator missing after seed AppendWrite")
 	}

--- a/pkg/blockstore/local/fs/appendwrite_test.go
+++ b/pkg/blockstore/local/fs/appendwrite_test.go
@@ -38,9 +38,10 @@ func TestAppendWrite_Enabled_HappyPath(t *testing.T) {
 	if got := bc.logBytesTotal.Load(); got != wantBytes {
 		t.Fatalf("logBytesTotal: got %d want %d", got, wantBytes)
 	}
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	tree := sh.dirtyIntervals["file1"]
+	sh.mu.RUnlock()
 	if tree == nil || tree.Len() != 3 {
 		t.Fatalf("interval tree: %+v want len=3", tree)
 	}
@@ -95,9 +96,10 @@ func TestAppendWrite_PerFileSerial(t *testing.T) {
 	}
 	// All 50 inserts must live in the tree — each goroutine used a
 	// distinct offset so there are no collisions.
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	tree := sh.dirtyIntervals["file1"]
+	sh.mu.RUnlock()
 	if tree == nil || tree.Len() != goroutines {
 		t.Fatalf("interval tree: len=%v want %d", tree, goroutines)
 	}
@@ -150,9 +152,10 @@ func TestLogFile_GroupCommit_NonNilAfterConstruction(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file1", []byte("hi"), 0); err != nil {
 		t.Fatalf("AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	lf := sh.logFDs["file1"]
+	sh.mu.RUnlock()
 	if lf == nil {
 		t.Fatal("logFile not present after AppendWrite")
 	}
@@ -173,9 +176,10 @@ func TestLogFile_GroupCommit_FsyncFn_BoundToLfFile(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file1", payload, 0); err != nil {
 		t.Fatalf("AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	lf := sh.logFDs["file1"]
+	sh.mu.RUnlock()
 	if lf == nil || lf.groupCommit == nil {
 		t.Fatal("logFile or coordinator missing after AppendWrite")
 	}
@@ -231,9 +235,10 @@ func TestAppendWrite_CoordinatorOnHotPath_BurstCounts(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file1", []byte("seed"), 0); err != nil {
 		t.Fatalf("seed AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	lf := sh.logFDs["file1"]
+	sh.mu.RUnlock()
 	if lf == nil || lf.groupCommit == nil {
 		t.Fatal("logFile/coordinator missing")
 	}
@@ -305,9 +310,10 @@ func TestAppendWrite_FsyncError_PropagatesToCaller(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file1", []byte("seed"), 0); err != nil {
 		t.Fatalf("seed AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	lf := sh.logFDs["file1"]
+	sh.mu.RUnlock()
 	if lf == nil || lf.groupCommit == nil {
 		t.Fatal("logFile/coordinator missing")
 	}
@@ -335,9 +341,10 @@ func TestAppendWrite_CtxCancel_StillFsyncs(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file1", []byte("seed"), 0); err != nil {
 		t.Fatalf("seed AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file1"]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor("file1")
+	sh.mu.RLock()
+	lf := sh.logFDs["file1"]
+	sh.mu.RUnlock()
 	if lf == nil || lf.groupCommit == nil {
 		t.Fatal("logFile/coordinator missing")
 	}
@@ -461,12 +468,13 @@ func TestAppendWrite_InvalidPayloadID_RejectedBeforeFS(t *testing.T) {
 			}
 
 			// No FSStore map entries for the invalid payloadID.
-			bc.logsMu.RLock()
-			_, lfOk := bc.logFDs[tc.payloadID]
-			_, muOk := bc.logLocks[tc.payloadID]
-			_, treeOk := bc.dirtyIntervals[tc.payloadID]
-			_, idxOk := bc.logIndices[tc.payloadID]
-			bc.logsMu.RUnlock()
+			sh := bc.shardFor(tc.payloadID)
+			sh.mu.RLock()
+			_, lfOk := sh.logFDs[tc.payloadID]
+			_, muOk := sh.logLocks[tc.payloadID]
+			_, treeOk := sh.dirtyIntervals[tc.payloadID]
+			_, idxOk := sh.logIndices[tc.payloadID]
+			sh.mu.RUnlock()
 			if lfOk || muOk || treeOk || idxOk {
 				t.Fatalf("FSStore created map entries for invalid payloadID %q: lf=%v mu=%v tree=%v idx=%v",
 					tc.payloadID, lfOk, muOk, treeOk, idxOk)

--- a/pkg/blockstore/local/fs/compaction.go
+++ b/pkg/blockstore/local/fs/compaction.go
@@ -362,9 +362,10 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 		if oldFd != nil {
 			_ = oldFd.Close()
 		}
-		bc.logsMu.Lock()
-		delete(bc.logFDs, payloadID)
-		bc.logsMu.Unlock()
+		sh := bc.shardFor(payloadID)
+		sh.mu.Lock()
+		delete(sh.logFDs, payloadID)
+		sh.mu.Unlock()
 		return fmt.Errorf("compaction: reopen after rename: %w", err)
 	}
 	eof, err := newFd.Seek(0, io.SeekEnd)
@@ -373,9 +374,10 @@ func (bc *FSStore) compactLogLocked(ctx context.Context, payloadID string, lf *l
 		if oldFd != nil {
 			_ = oldFd.Close()
 		}
-		bc.logsMu.Lock()
-		delete(bc.logFDs, payloadID)
-		bc.logsMu.Unlock()
+		sh := bc.shardFor(payloadID)
+		sh.mu.Lock()
+		delete(sh.logFDs, payloadID)
+		sh.mu.Unlock()
 		return fmt.Errorf("compaction: seek end after rename: %w", err)
 	}
 

--- a/pkg/blockstore/local/fs/delete_truncate_test.go
+++ b/pkg/blockstore/local/fs/delete_truncate_test.go
@@ -44,13 +44,14 @@ func TestDelete_FreshPayload_UnlinksLog(t *testing.T) {
 	// fresh log (DittoFS's path-based PayloadID lifecycle — see the
 	// BlockStoreAppend.DeleteLog godoc and FSStore.DeleteAppendLog
 	// tombstone-lifecycle comment for why FIX-8 was reverted).
-	bc.logsMu.RLock()
-	_, hasFD := bc.logFDs["file1"]
-	_, hasLock := bc.logLocks["file1"]
-	_, hasTree := bc.dirtyIntervals["file1"]
-	_, hasTomb := bc.tombstones["file1"]
-	_, hasTrunc := bc.truncations["file1"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("file1")
+	bcSh.mu.RLock()
+	_, hasFD := bcSh.logFDs["file1"]
+	_, hasLock := bcSh.logLocks["file1"]
+	_, hasTree := bcSh.dirtyIntervals["file1"]
+	_, hasTomb := bcSh.tombstones["file1"]
+	_, hasTrunc := bcSh.truncations["file1"]
+	bcSh.mu.RUnlock()
 	if hasFD || hasLock || hasTree || hasTrunc {
 		t.Fatalf("per-file state not cleared: fd=%v lock=%v tree=%v trunc=%v",
 			hasFD, hasLock, hasTree, hasTrunc)
@@ -371,9 +372,10 @@ func TestTruncate_DropsIntervalsAbove(t *testing.T) {
 		t.Fatalf("TruncateAppendLog: %v", err)
 	}
 
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals["f1"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("f1")
+	bcSh.mu.RLock()
+	tree := bcSh.dirtyIntervals["f1"]
+	bcSh.mu.RUnlock()
 	if tree == nil {
 		t.Fatal("interval tree missing after truncate")
 	}
@@ -411,9 +413,10 @@ func TestTruncate_ClipsStraddling(t *testing.T) {
 		t.Fatalf("TruncateAppendLog: %v", err)
 	}
 
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals["f1"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("f1")
+	bcSh.mu.RLock()
+	tree := bcSh.dirtyIntervals["f1"]
+	bcSh.mu.RUnlock()
 
 	var entries []interval
 	tree.t.Ascend(func(iv *interval) bool {

--- a/pkg/blockstore/local/fs/drain_reset.go
+++ b/pkg/blockstore/local/fs/drain_reset.go
@@ -49,12 +49,14 @@ func (bc *FSStore) DrainRollups(ctx context.Context) error {
 		// re-reads it so newly-dirtied payloads are picked up. Per-payload
 		// emptiness is rechecked under the per-file mutex by dirtyLen
 		// below — the btree is not safe to read here without that mutex.
-		bc.logsMu.RLock()
-		pending := make([]string, 0, len(bc.dirtyIntervals))
-		for pid := range bc.dirtyIntervals {
-			pending = append(pending, pid)
+		var pending []string
+		for _, sh := range bc.logShards {
+			sh.mu.RLock()
+			for pid := range sh.dirtyIntervals {
+				pending = append(pending, pid)
+			}
+			sh.mu.RUnlock()
 		}
-		bc.logsMu.RUnlock()
 
 		progressed := false
 		anyDirty := false
@@ -114,19 +116,20 @@ func (bc *FSStore) DrainRollups(ctx context.Context) error {
 // Len() read is serialized against AppendWrite / rollupFile via the
 // per-file mutex.
 func (bc *FSStore) dirtyLen(payloadID string) int {
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	tree := sh.dirtyIntervals[payloadID]
+	mu := sh.logLocks[payloadID]
+	sh.mu.RUnlock()
 	if tree == nil {
 		return 0
 	}
 	if mu == nil {
 		// No per-file mutex established yet (payload registered but never
 		// written through getOrCreateLog). Guard the btree read against a
-		// racing tree mutation under the shared logsMu instead.
-		bc.logsMu.RLock()
-		defer bc.logsMu.RUnlock()
+		// racing tree mutation under the shard lock instead.
+		sh.mu.RLock()
+		defer sh.mu.RUnlock()
 		return tree.Len()
 	}
 	mu.Lock()
@@ -148,11 +151,12 @@ func (bc *FSStore) dirtyLen(payloadID string) int {
 func (bc *FSStore) payloadsWithRealResidual(candidates []string) []string {
 	var out []string
 	for _, pid := range candidates {
-		bc.logsMu.RLock()
-		tree := bc.dirtyIntervals[pid]
-		mu := bc.logLocks[pid]
-		idx := bc.logIndices[pid]
-		bc.logsMu.RUnlock()
+		sh := bc.shardFor(pid)
+		sh.mu.RLock()
+		tree := sh.dirtyIntervals[pid]
+		mu := sh.logLocks[pid]
+		idx := sh.logIndices[pid]
+		sh.mu.RUnlock()
 		if tree == nil || idx == nil {
 			continue
 		}
@@ -178,9 +182,9 @@ func (bc *FSStore) payloadsWithRealResidual(candidates []string) []string {
 			walk()
 			mu.Unlock()
 		} else {
-			bc.logsMu.RLock()
+			sh.mu.RLock()
 			walk()
-			bc.logsMu.RUnlock()
+			sh.mu.RUnlock()
 		}
 		if hasReal {
 			out = append(out, pid)
@@ -212,49 +216,53 @@ func (bc *FSStore) payloadsWithRealResidual(candidates []string) []string {
 // writes the operator is deliberately discarding.
 //
 // Concurrency: the caller MUST have quiesced writes (the share is disabled
-// during restore). ResetLocalState takes bc.logsMu for the whole teardown
-// so it does not race getOrCreateLog; it does not, however, defend against
-// a concurrent in-flight AppendWrite mid-record — that is the caller's
-// share-disabled barrier to provide.
+// during restore). ResetLocalState takes each shard lock (one at a time)
+// for that shard's teardown so it does not race getOrCreateLog; it does
+// not, however, defend against a concurrent in-flight AppendWrite
+// mid-record — that is the caller's share-disabled barrier to provide.
 func (bc *FSStore) ResetLocalState(_ context.Context) error {
 	if bc.isClosed() {
 		return ErrStoreClosed
 	}
 
-	bc.logsMu.Lock()
-	defer bc.logsMu.Unlock()
-
+	// Tear down every shard under its own lock (the caller has quiesced
+	// writes, so a one-shard-at-a-time sweep is safe and avoids holding all
+	// shard locks at once). Each shard's close+unlink+clear is atomic under
+	// its lock so no getOrCreateLog can resurrect a half-cleared payload.
 	var firstErr error
-	for pid, lf := range bc.logFDs {
-		if lf == nil {
-			continue
-		}
-		if lf.f != nil {
-			if cerr := lf.f.Close(); cerr != nil {
-				logger.Warn("ResetLocalState: log file close failed",
-					"payloadID", pid, "path", lf.path, "error", cerr)
+	for _, sh := range bc.logShards {
+		sh.mu.Lock()
+		for pid, lf := range sh.logFDs {
+			if lf == nil {
+				continue
 			}
-		}
-		if lf.path != "" {
-			if rerr := os.Remove(lf.path); rerr != nil && !os.IsNotExist(rerr) {
-				logger.Error("ResetLocalState: log file unlink failed",
-					"payloadID", pid, "path", lf.path, "error", rerr)
-				if firstErr == nil {
-					firstErr = fmt.Errorf("ResetLocalState: unlink log for payload %q: %w", pid, rerr)
+			if lf.f != nil {
+				if cerr := lf.f.Close(); cerr != nil {
+					logger.Warn("ResetLocalState: log file close failed",
+						"payloadID", pid, "path", lf.path, "error", cerr)
+				}
+			}
+			if lf.path != "" {
+				if rerr := os.Remove(lf.path); rerr != nil && !os.IsNotExist(rerr) {
+					logger.Error("ResetLocalState: log file unlink failed",
+						"payloadID", pid, "path", lf.path, "error", rerr)
+					if firstErr == nil {
+						firstErr = fmt.Errorf("ResetLocalState: unlink log for payload %q: %w", pid, rerr)
+					}
 				}
 			}
 		}
+		// Wipe this shard's per-payload maps so a subsequent AppendWrite
+		// starts from a fresh log and ReadPayloadAt finds no log to replay.
+		clear(sh.logFDs)
+		clear(sh.logLocks)
+		clear(sh.rollupLocks) // C1: keep rollupLocks 1:1 with logLocks across reset
+		clear(sh.dirtyIntervals)
+		clear(sh.logIndices)
+		clear(sh.truncations)
+		clear(sh.tombstones)
+		sh.mu.Unlock()
 	}
-
-	// Wipe every per-payload map so a subsequent AppendWrite starts from a
-	// fresh log and a subsequent ReadPayloadAt finds no log to replay.
-	clear(bc.logFDs)
-	clear(bc.logLocks)
-	clear(bc.rollupLocks) // C1: keep rollupLocks 1:1 with logLocks across reset
-	clear(bc.dirtyIntervals)
-	clear(bc.logIndices)
-	clear(bc.truncations)
-	clear(bc.tombstones)
 	bc.logBytesTotal.Store(0)
 
 	// Best-effort: remove any residual .log files left under the logs dir

--- a/pkg/blockstore/local/fs/drain_reset_test.go
+++ b/pkg/blockstore/local/fs/drain_reset_test.go
@@ -146,12 +146,10 @@ func TestDrainRollups_TombstonedResidualSucceeds(t *testing.T) {
 
 	// Tombstone the payload directly (mirrors a concurrent DeleteAppendLog
 	// having set the tombstone). The classifier must now exclude it.
-	bc.logsMu.Lock()
-	if bc.tombstones == nil {
-		bc.tombstones = make(map[string]struct{})
-	}
-	bc.tombstones[payloadID] = struct{}{}
-	bc.logsMu.Unlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.Lock()
+	bcSh.tombstones[payloadID] = struct{}{}
+	bcSh.mu.Unlock()
 
 	if got := bc.payloadsWithRealResidual([]string{payloadID}); len(got) != 0 {
 		t.Fatalf("payloadsWithRealResidual on tombstoned payload = %v, want empty", got)

--- a/pkg/blockstore/local/fs/eofpos_test.go
+++ b/pkg/blockstore/local/fs/eofpos_test.go
@@ -48,10 +48,11 @@ func TestLogFile_EofPos_MatchesDiskSizeSequential(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat: %v", err)
 		}
-		bc.logsMu.RLock()
-		lf := bc.logFDs["file-seq"]
-		mu := bc.logLocks["file-seq"]
-		bc.logsMu.RUnlock()
+		bcSh := bc.shardFor("file-seq")
+		bcSh.mu.RLock()
+		lf := bcSh.logFDs["file-seq"]
+		mu := bcSh.logLocks["file-seq"]
+		bcSh.mu.RUnlock()
 		mu.Lock()
 		got := lf.eofPos
 		mu.Unlock()
@@ -92,10 +93,11 @@ func TestLogFile_EofPos_MatchesDiskSizeConcurrent(t *testing.T) {
 	if st.Size() != wantDisk {
 		t.Fatalf("disk size: got %d want %d", st.Size(), wantDisk)
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file-conc"]
-	mu := bc.logLocks["file-conc"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("file-conc")
+	bcSh.mu.RLock()
+	lf := bcSh.logFDs["file-conc"]
+	mu := bcSh.logLocks["file-conc"]
+	bcSh.mu.RUnlock()
 	mu.Lock()
 	got := lf.eofPos
 	mu.Unlock()
@@ -124,10 +126,11 @@ func TestLogFile_EofPos_RestoredAfterRecover(t *testing.T) {
 	preCloseSize := st.Size()
 
 	bc2 := reopenFSStore(t, bc, rs)
-	bc2.logsMu.RLock()
-	lf := bc2.logFDs["file-rec"]
-	mu := bc2.logLocks["file-rec"]
-	bc2.logsMu.RUnlock()
+	bc2Sh := bc2.shardFor("file-rec")
+	bc2Sh.mu.RLock()
+	lf := bc2Sh.logFDs["file-rec"]
+	mu := bc2Sh.logLocks["file-rec"]
+	bc2Sh.mu.RUnlock()
 	if lf == nil {
 		t.Fatalf("logFile not restored after recover")
 	}

--- a/pkg/blockstore/local/fs/fs.go
+++ b/pkg/blockstore/local/fs/fs.go
@@ -208,49 +208,24 @@ type FSStore struct {
 	// along with ctx.Done() and bc.done.
 	pressureCh chan struct{}
 
-	// logsMu guards logFDs, logLocks, dirtyIntervals, logIndices, and
-	// tombstones. Double-checked locking idiom matches blocksMu /
-	// memBlocks in getOrCreateMemBlock.
-	logsMu   sync.RWMutex
-	logFDs   map[string]*logFile    // payloadID -> open log fd wrapper (one fd per file, bypasses fdPool)
-	logLocks map[string]*sync.Mutex // payloadID -> per-file append mutex
-	// rollupLocks is the per-payload ROLLUP mutex (C1 contention fix). It is
-	// held by rollupFile across its entire pass (read -> store -> commit),
-	// serializing concurrent rollups on the same payload and giving
-	// DeleteAppendLog a barrier to wait on. It is DISTINCT from logLocks
-	// (the append mutex): rollupFile releases the append mutex during its
-	// CAS-store / persister phase so a concurrent AppendWrite is not blocked
-	// on rollup I/O, but keeps rollupLocks held throughout. Lock order is
-	// rollupLocks (outer) -> logLocks (inner), matching the existing
-	// "always mu before logsMu" discipline at the next level down.
-	rollupLocks    map[string]*sync.Mutex   // payloadID -> per-file rollup mutex
-	dirtyIntervals map[string]*intervalTree // payloadID -> dirty-region tree
-	// logIndices is the per-payload log-position oracle (Direction-1
-	// rollup redesign). One entry per appended record carries the
-	// frame's log byte offset, its file_offset, and its payload length.
-	// Populated under the per-file `mu` from AppendWrite (P3) and from
-	// the recovery scan (P4). Consumed by the rollup (P5) to translate
-	// a stable file-offset interval into the set of records to pread.
-	logIndices map[string]*logIndex
-	// tombstones marks payloadIDs whose append log has been (or is being)
-	// deleted by DeleteAppendLog. rollupFile consults
-	// this BEFORE and AFTER the per-file mutex hand-off to ensure no
-	// rollup_offset gets persisted for a dead payload. Initialized in New
-	// alongside the other logs-* maps. Cleared at the end of
-	// DeleteAppendLog so subsequent AppendWrites can resurrect the
-	// payloadID (DittoFS's metadata layer derives PayloadID from
-	// shareName + path, so 'unlink + create at same path' reuses the
-	// PayloadID and must succeed).
-	tombstones map[string]struct{}
-
-	// truncations records per-payload truncation boundaries set by
-	// TruncateAppendLog. rollupFile consults this after
-	// reading the record batch and filters / clips records whose
-	// file_offset >= boundary so the emitted chunk stream never includes
-	// bytes past the truncation point. Entries are cleared when the
-	// payload is deleted; they persist otherwise so subsequent rollup
-	// passes keep honoring the boundary.
-	truncations map[string]uint64
+	// logShards stripes all per-payload append-log state across
+	// numLogShards independent RWMutex-guarded maps, keyed by payloadID
+	// hash (shardFor). Before C2 a single RWMutex (logsMu) guarded every
+	// map; getOrCreateLog's write-lock on the create path then serialized
+	// every new-payload acquisition across the WHOLE store, which the #680
+	// re-profile measured as ~60% of mutex-wait under a concurrent
+	// create/delete storm (REVIEW.md §5.1 C2). Sharding confines that
+	// write-lock to 1/numLogShards of the keyspace.
+	//
+	// Lock order is unchanged by sharding: the per-file rollup mutex (rmu)
+	// and append mutex (mu) are still acquired BEFORE a shard lock (the
+	// FIX-2 "mu before the map lock" discipline), and a shard lock is never
+	// held while acquiring a different shard's lock — cross-payload sweeps
+	// lock exactly one shard at a time. Each payloadID maps to exactly one
+	// shard, so all of a payload's state (fd, mutexes, tree, index,
+	// tombstone, truncation) lives under that single shard lock, preserving
+	// the #668 "tree and logIndex created under the same lock" invariant.
+	logShards []*logShard
 
 	// --- -06 rollup pool. ---
 	//
@@ -405,13 +380,10 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore blockst
 	// initialized; the opt-out flag was deleted with the legacy
 	// path-keyed writer.
 	bc.pressureCh = make(chan struct{}, 1)
-	bc.logFDs = make(map[string]*logFile)
-	bc.logLocks = make(map[string]*sync.Mutex)
-	bc.rollupLocks = make(map[string]*sync.Mutex)
-	bc.dirtyIntervals = make(map[string]*intervalTree)
-	bc.logIndices = make(map[string]*logIndex)
-	bc.tombstones = make(map[string]struct{})
-	bc.truncations = make(map[string]uint64)
+	bc.logShards = make([]*logShard, numLogShards)
+	for i := range bc.logShards {
+		bc.logShards[i] = newLogShard()
+	}
 	bc.maxLogBytes = 1 << 30              // 1 GiB default
 	bc.stabilizationMS = 250              // default
 	bc.rollupWorkers = 2                  // default
@@ -971,14 +943,16 @@ func (bc *FSStore) Close() error {
 	// Close append-log fds. Safe after closedFlag.Store(true) +
 	// wg.Wait above: no new AppendWrite can acquire an fd (isClosed guard)
 	// and any rollup worker (06) has already joined via wg.
-	bc.logsMu.Lock()
-	for pid, lf := range bc.logFDs {
-		if lf != nil && lf.f != nil {
-			_ = lf.f.Close()
+	for _, sh := range bc.logShards {
+		sh.mu.Lock()
+		for pid, lf := range sh.logFDs {
+			if lf != nil && lf.f != nil {
+				_ = lf.f.Close()
+			}
+			delete(sh.logFDs, pid)
 		}
-		delete(bc.logFDs, pid)
+		sh.mu.Unlock()
 	}
-	bc.logsMu.Unlock()
 	return nil
 }
 

--- a/pkg/blockstore/local/fs/groupcommit_test.go
+++ b/pkg/blockstore/local/fs/groupcommit_test.go
@@ -192,16 +192,20 @@ func TestGroupCommit_CtxCancel_MidWait_ReturnsCtxErr_ButFsyncStillRuns(t *testin
 	}
 }
 
-// TestGroupCommit_NoLogsMuTouch enforces the lock-order
-// invariant by grepping the source file: the coordinator must never
-// reference bc.logsMu.
+// TestGroupCommit_NoLogsMuTouch enforces the lock-order invariant by grepping
+// the source file: the coordinator must never reach the per-store map lock.
+// Pre-C2 that lock was bc.logsMu; post-C2 it is the per-payload shard lock
+// reachable only via bc.logShards / shardFor. The gate checks for any of those
+// names so a reintroduced violation under the new name is still caught.
 func TestGroupCommit_NoLogsMuTouch(t *testing.T) {
 	body, err := os.ReadFile("groupcommit.go")
 	if err != nil {
 		t.Fatalf("read groupcommit.go: %v", err)
 	}
-	if bytes.Contains(body, []byte("logsMu")) {
-		t.Fatalf("groupcommit.go must not reference logsMu (D-09 lock-order invariant)")
+	for _, banned := range []string{"logsMu", "logShards", "shardFor"} {
+		if bytes.Contains(body, []byte(banned)) {
+			t.Fatalf("groupcommit.go must not reference %q (D-09 lock-order invariant)", banned)
+		}
 	}
 }
 

--- a/pkg/blockstore/local/fs/lockorder_test.go
+++ b/pkg/blockstore/local/fs/lockorder_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 // TestAppendWrite_DeleteRace_NoDeadlock is a regression guard for FIX-2
-// the AppendWrite error-recovery path used to acquire bc.logsMu.Lock()
-// while still holding the per-file mutex. Combined with any path that
-// holds logsMu and then waits on the per-file mutex, the result was an
-// AB/BA deadlock. The fix releases the per-file mutex BEFORE acquiring
-// logsMu in the error path, so the global discipline "always mu before
-// logsMu" is preserved.
+// the AppendWrite error-recovery path used to acquire the per-store map lock
+// while still holding the per-file mutex. Combined with any path that holds
+// the map lock and then waits on the per-file mutex, the result was an AB/BA
+// deadlock. The fix releases the per-file mutex BEFORE acquiring the map lock
+// in the error path, so the discipline "always mu before the map lock" is
+// preserved. (Post-C2 the map lock is the per-payload shard lock, shardFor;
+// pre-C2 it was the single bc.logsMu — the ordering rule is identical.)
 //
 // This test exercises the AppendWrite ↔ DeleteAppendLog hot path under a
 // hard wall-clock deadline: if the lock order regresses, the test hangs

--- a/pkg/blockstore/local/fs/logindex_appendwrite_test.go
+++ b/pkg/blockstore/local/fs/logindex_appendwrite_test.go
@@ -15,10 +15,11 @@ import (
 // with concurrent AppendWriters. Test-only helper.
 func snapshotLogIndex(t *testing.T, bc *FSStore, payloadID string) []logEntry {
 	t.Helper()
-	bc.logsMu.RLock()
-	idx := bc.logIndices[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.RLock()
+	idx := bcSh.logIndices[payloadID]
+	mu := bcSh.logLocks[payloadID]
+	bcSh.mu.RUnlock()
 	if idx == nil || mu == nil {
 		return nil
 	}
@@ -128,10 +129,11 @@ func TestLogIndex_OutOfOrderArrivals_RecoverableByLookup(t *testing.T) {
 		}
 	}
 
-	bc.logsMu.RLock()
-	idx := bc.logIndices["file-ooo"]
-	mu := bc.logLocks["file-ooo"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("file-ooo")
+	bcSh.mu.RLock()
+	idx := bcSh.logIndices["file-ooo"]
+	mu := bcSh.logLocks["file-ooo"]
+	bcSh.mu.RUnlock()
 	mu.Lock()
 	// Query [0, 65536) — must find both fileOff=32768 (rec#0) and
 	// fileOff=0 (rec#2), the latter buried after a higher-offset record
@@ -160,9 +162,10 @@ func TestLogIndex_ClearedByDeleteAppendLog(t *testing.T) {
 	if err := bc.AppendWrite(context.Background(), "file-del", []byte("hello"), 0); err != nil {
 		t.Fatalf("AppendWrite: %v", err)
 	}
-	bc.logsMu.RLock()
-	_, exists := bc.logIndices["file-del"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("file-del")
+	bcSh.mu.RLock()
+	_, exists := bcSh.logIndices["file-del"]
+	bcSh.mu.RUnlock()
 	if !exists {
 		t.Fatalf("logIndex not populated before delete")
 	}
@@ -170,9 +173,10 @@ func TestLogIndex_ClearedByDeleteAppendLog(t *testing.T) {
 	if err := bc.DeleteAppendLog(context.Background(), "file-del"); err != nil {
 		t.Fatalf("DeleteAppendLog: %v", err)
 	}
-	bc.logsMu.RLock()
-	_, exists = bc.logIndices["file-del"]
-	bc.logsMu.RUnlock()
+	bcSh = bc.shardFor("file-del")
+	bcSh.mu.RLock()
+	_, exists = bcSh.logIndices["file-del"]
+	bcSh.mu.RUnlock()
 	if exists {
 		t.Fatalf("logIndex still present after DeleteAppendLog")
 	}
@@ -190,11 +194,12 @@ func TestLogIndex_LogPosMatchesEofPosProgress(t *testing.T) {
 			t.Fatalf("AppendWrite: %v", err)
 		}
 	}
-	bc.logsMu.RLock()
-	lf := bc.logFDs["file-pos"]
-	idx := bc.logIndices["file-pos"]
-	mu := bc.logLocks["file-pos"]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor("file-pos")
+	bcSh.mu.RLock()
+	lf := bcSh.logFDs["file-pos"]
+	idx := bcSh.logIndices["file-pos"]
+	mu := bcSh.logLocks["file-pos"]
+	bcSh.mu.RUnlock()
 	mu.Lock()
 	defer mu.Unlock()
 	last := idx.entries[len(idx.entries)-1]
@@ -221,10 +226,11 @@ func TestLogIndex_SeededByRecovery(t *testing.T) {
 	}
 
 	bc2 := reopenFSStore(t, bc, rs)
-	bc2.logsMu.RLock()
-	idx := bc2.logIndices["file-rec-idx"]
-	mu := bc2.logLocks["file-rec-idx"]
-	bc2.logsMu.RUnlock()
+	bc2Sh := bc2.shardFor("file-rec-idx")
+	bc2Sh.mu.RLock()
+	idx := bc2Sh.logIndices["file-rec-idx"]
+	mu := bc2Sh.logLocks["file-rec-idx"]
+	bc2Sh.mu.RUnlock()
 	if idx == nil || mu == nil {
 		t.Fatalf("logIndex / mu missing after recovery")
 	}

--- a/pkg/blockstore/local/fs/logshard.go
+++ b/pkg/blockstore/local/fs/logshard.go
@@ -1,0 +1,56 @@
+package fs
+
+import "sync"
+
+// numLogShards is the stripe count for per-payload append-log state. A power
+// of two so shardFor can mask instead of modulo. 16 cuts the create-path
+// write-lock contention (#680 §5.1 C2) by ~16x while keeping the per-shard
+// map overhead negligible.
+const numLogShards = 16
+
+// logShard holds the per-payload append-log maps for one stripe of the
+// payloadID keyspace, guarded by its own RWMutex. Every map is keyed by
+// payloadID, and a payloadID maps to exactly one shard (FSStore.shardFor), so
+// all of a payload's state lives under a single shard lock. This preserves the
+// #668 invariant that a payload's interval tree and logIndex are always
+// created — and observed — under the same lock.
+type logShard struct {
+	mu             sync.RWMutex
+	logFDs         map[string]*logFile      // open log fd wrapper (one fd per file, bypasses fdPool)
+	logLocks       map[string]*sync.Mutex   // per-file append mutex
+	rollupLocks    map[string]*sync.Mutex   // per-file rollup mutex (C1)
+	dirtyIntervals map[string]*intervalTree // dirty-region tree
+	logIndices     map[string]*logIndex     // log-position oracle (Direction-1)
+	tombstones     map[string]struct{}      // payloads being deleted by DeleteAppendLog
+	truncations    map[string]uint64        // truncation boundaries set by TruncateAppendLog
+}
+
+// newLogShard allocates an empty shard with all maps initialized.
+func newLogShard() *logShard {
+	return &logShard{
+		logFDs:         make(map[string]*logFile),
+		logLocks:       make(map[string]*sync.Mutex),
+		rollupLocks:    make(map[string]*sync.Mutex),
+		dirtyIntervals: make(map[string]*intervalTree),
+		logIndices:     make(map[string]*logIndex),
+		tombstones:     make(map[string]struct{}),
+		truncations:    make(map[string]uint64),
+	}
+}
+
+// shardFor returns the logShard that owns payloadID. FNV-1a over the
+// payloadID bytes, masked to numLogShards (a power of two). The hash is
+// deterministic, so a payloadID always resolves to the same shard for the
+// FSStore's lifetime.
+func (bc *FSStore) shardFor(payloadID string) *logShard {
+	const (
+		fnvOffset64 = 14695981039346656037
+		fnvPrime64  = 1099511628211
+	)
+	h := uint64(fnvOffset64)
+	for i := 0; i < len(payloadID); i++ {
+		h ^= uint64(payloadID[i])
+		h *= fnvPrime64
+	}
+	return bc.logShards[h&(numLogShards-1)]
+}

--- a/pkg/blockstore/local/fs/logshard_test.go
+++ b/pkg/blockstore/local/fs/logshard_test.go
@@ -1,0 +1,106 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestShardFor_Deterministic verifies shardFor is stable per payloadID and
+// distributes a realistic key set across more than one shard (a degenerate
+// hash that mapped every payload to one shard would silently re-serialize the
+// create path and defeat C2).
+func TestShardFor_Deterministic(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+
+	// Stability: same id always resolves to the same shard pointer. Capture
+	// into locals so staticcheck doesn't flag the two calls as an identical
+	// expression (SA4000) — exercising determinism is the point here.
+	for _, id := range []string{"a", "share/dir/file.txt", "perf/storm/42", ""} {
+		first := bc.shardFor(id)
+		second := bc.shardFor(id)
+		if first != second {
+			t.Fatalf("shardFor(%q) not stable", id)
+		}
+	}
+
+	// Distribution: a path-like key set must touch several shards.
+	seen := make(map[*logShard]int)
+	for i := 0; i < 1000; i++ {
+		seen[bc.shardFor(fmt.Sprintf("share/dir%d/file%d", i%37, i))]++
+	}
+	if len(seen) < numLogShards/2 {
+		t.Fatalf("payload keys hit only %d/%d shards — distribution too skewed", len(seen), numLogShards)
+	}
+}
+
+// TestLogShards_ConcurrentCreateDelete hammers create (AppendWrite) and delete
+// (DeleteAppendLog) across many distinct payloads — and therefore many shards —
+// concurrently. It is the C2 regression guard: the create path now takes a
+// per-shard write lock and DeleteAppendLog drains per-shard, so a lock-order or
+// cross-shard mistake would deadlock (caught by the test timeout) or trip the
+// race detector. It asserts every payload ends fully torn down.
+func TestLogShards_ConcurrentCreateDelete(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		RollupWorkers:   3,
+		StabilizationMS: 2,
+		RollupStore:     rs,
+	})
+	if err := bc.StartRollup(context.Background()); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+	ctx := context.Background()
+
+	const workers = 8
+	const perWorker = 80
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			buf := make([]byte, 4096)
+			for i := 0; i < perWorker; i++ {
+				pid := fmt.Sprintf("perf/c2/w%d/f%d", w, i)
+				if err := bc.AppendWrite(ctx, pid, buf, 0); err != nil {
+					t.Errorf("AppendWrite %s: %v", pid, err)
+					return
+				}
+				// Half the payloads are deleted immediately, racing their own
+				// in-flight rollup; the other half are left to drain.
+				if i%2 == 0 {
+					if err := bc.DeleteAppendLog(ctx, pid); err != nil {
+						t.Errorf("DeleteAppendLog %s: %v", pid, err)
+						return
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Every deleted payload must be fully cleared from its shard; every
+	// surviving payload drains to a quiescent tree.
+	for w := 0; w < workers; w++ {
+		for i := 0; i < perWorker; i++ {
+			pid := fmt.Sprintf("perf/c2/w%d/f%d", w, i)
+			if i%2 == 0 {
+				sh := bc.shardFor(pid)
+				sh.mu.RLock()
+				_, hasFD := sh.logFDs[pid]
+				_, hasTomb := sh.tombstones[pid]
+				sh.mu.RUnlock()
+				if hasFD || hasTomb {
+					t.Fatalf("deleted payload %s left residual state (fd=%v tomb=%v)", pid, hasFD, hasTomb)
+				}
+				continue
+			}
+			// Surviving payload: force a drain pass and confirm it quiesces.
+			_ = bc.ForceRollupForTest(ctx, pid)
+		}
+	}
+}

--- a/pkg/blockstore/local/fs/readpayload.go
+++ b/pkg/blockstore/local/fs/readpayload.go
@@ -102,10 +102,11 @@ func allCovered(covered []bool) bool {
 // fill from the log") OR after a successful replay. Returns a non-nil
 // error only for genuine I/O failures.
 func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest []byte, reqStart, reqEnd uint64, covered []bool) error {
-	bc.logsMu.RLock()
-	lf := bc.logFDs[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	lf := sh.logFDs[payloadID]
+	mu := sh.logLocks[payloadID]
+	sh.mu.RUnlock()
 	if lf == nil || mu == nil {
 		return nil
 	}

--- a/pkg/blockstore/local/fs/recovery.go
+++ b/pkg/blockstore/local/fs/recovery.go
@@ -456,21 +456,22 @@ func (bc *FSStore) recoverAppendLogs(ctx context.Context) (int, int, int, int, i
 			_ = f.Close()
 			return nil
 		}
-		bc.logsMu.Lock()
+		sh := bc.shardFor(payloadID)
+		sh.mu.Lock()
 		lf := &logFile{f: f, path: path, eofPos: uint64(eof)}
 		// Opt 2: per-file fsync coordinator
 		// matching the getOrCreateLog construction site in appendwrite.go.
 		lf.groupCommit = newGroupCommit(lf.f.Sync)
-		bc.logFDs[payloadID] = lf
-		bc.logLocks[payloadID] = &sync.Mutex{}
-		bc.rollupLocks[payloadID] = &sync.Mutex{} // C1: per-file rollup mutex
-		bc.dirtyIntervals[payloadID] = tree
+		sh.logFDs[payloadID] = lf
+		sh.logLocks[payloadID] = &sync.Mutex{}
+		sh.rollupLocks[payloadID] = &sync.Mutex{} // C1: per-file rollup mutex
+		sh.dirtyIntervals[payloadID] = tree
 		// Direction-1 redesign: publish the recovery-built logIndex.
 		// The scan above populated one entry per unconsumed record and
 		// pinned the compaction fence at effectiveOff so post-boot
 		// AdvanceFence walks start from the persisted rollup_offset.
-		bc.logIndices[payloadID] = idx
-		bc.logsMu.Unlock()
+		sh.logIndices[payloadID] = idx
+		sh.mu.Unlock()
 		// Reflect the resident (un-rolled-up) log bytes in logBytesTotal
 		// so the pressure loop sees accurate state after boot.
 		if st, serr := f.Stat(); serr == nil {

--- a/pkg/blockstore/local/fs/recovery_test.go
+++ b/pkg/blockstore/local/fs/recovery_test.go
@@ -107,9 +107,10 @@ func TestRecovery_HappyPath_NoOp(t *testing.T) {
 		t.Fatalf("AppendWrite: %v", err)
 	}
 	bc2 := reopenFSStore(t, bc, rs)
-	bc2.logsMu.RLock()
-	tree := bc2.dirtyIntervals["file1"]
-	bc2.logsMu.RUnlock()
+	bc2Sh := bc2.shardFor("file1")
+	bc2Sh.mu.RLock()
+	tree := bc2Sh.dirtyIntervals["file1"]
+	bc2Sh.mu.RUnlock()
 	if tree == nil || tree.Len() == 0 {
 		t.Fatalf("expected 1 interval rebuilt, got %v", tree)
 	}
@@ -152,9 +153,10 @@ func TestRecovery_TornRecord_TruncatesAtFirstBadCRC(t *testing.T) {
 	if st.Size() != want {
 		t.Fatalf("truncated size: got %d want %d", st.Size(), want)
 	}
-	bc2.logsMu.RLock()
-	tree := bc2.dirtyIntervals["file1"]
-	bc2.logsMu.RUnlock()
+	bc2Sh := bc2.shardFor("file1")
+	bc2Sh.mu.RLock()
+	tree := bc2Sh.dirtyIntervals["file1"]
+	bc2Sh.mu.RUnlock()
 	if tree == nil || tree.Len() != 3 {
 		t.Fatalf("interval tree: len=%d want 3", func() int {
 			if tree == nil {
@@ -399,12 +401,13 @@ func TestRecovery_RejectsLongPayloadIDFromDisk(t *testing.T) {
 	}
 
 	// No FSStore state must have been created under the over-long payloadID.
-	bc2.logsMu.RLock()
-	defer bc2.logsMu.RUnlock()
-	if _, ok := bc2.logFDs[stem]; ok {
+	bc2Sh := bc2.shardFor(stem)
+	bc2Sh.mu.RLock()
+	defer bc2Sh.mu.RUnlock()
+	if _, ok := bc2Sh.logFDs[stem]; ok {
 		t.Fatalf("FSStore created logFDs entry for over-long payloadID")
 	}
-	if _, ok := bc2.dirtyIntervals[stem]; ok {
+	if _, ok := bc2Sh.dirtyIntervals[stem]; ok {
 		t.Fatalf("FSStore created dirtyIntervals entry for over-long payloadID")
 	}
 }
@@ -440,11 +443,12 @@ func TestRecovery_PathKeyedPayloadID_RoundTrip(t *testing.T) {
 	}
 
 	bc2 := reopenFSStore(t, bc, rs)
-	bc2.logsMu.RLock()
-	_, lfOk := bc2.logFDs[payloadID]
-	_, treeOk := bc2.dirtyIntervals[payloadID]
-	_, idxOk := bc2.logIndices[payloadID]
-	bc2.logsMu.RUnlock()
+	bc2Sh := bc2.shardFor(payloadID)
+	bc2Sh.mu.RLock()
+	_, lfOk := bc2Sh.logFDs[payloadID]
+	_, treeOk := bc2Sh.dirtyIntervals[payloadID]
+	_, idxOk := bc2Sh.logIndices[payloadID]
+	bc2Sh.mu.RUnlock()
 	if !lfOk {
 		t.Fatalf("FSStore did not restore logFile for path-keyed payloadID %q", payloadID)
 	}

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -110,12 +110,14 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 // dispatches rollupFile on each. Used by the ticker arm so payloads that
 // missed a rollupCh signal (buffer full) still get rolled up.
 func (bc *FSStore) scanAllFiles(ctx context.Context) {
-	bc.logsMu.RLock()
-	ids := make([]string, 0, len(bc.dirtyIntervals))
-	for pid := range bc.dirtyIntervals {
-		ids = append(ids, pid)
+	var ids []string
+	for _, sh := range bc.logShards {
+		sh.mu.RLock()
+		for pid := range sh.dirtyIntervals {
+			ids = append(ids, pid)
+		}
+		sh.mu.RUnlock()
 	}
-	bc.logsMu.RUnlock()
 	for _, pid := range ids {
 		if err := ctx.Err(); err != nil {
 			return
@@ -178,13 +180,14 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		return nil
 	}
 
-	bc.logsMu.RLock()
-	lf := bc.logFDs[payloadID]
-	tree := bc.dirtyIntervals[payloadID]
-	mu := bc.logLocks[payloadID]
-	rmu := bc.rollupLocks[payloadID]
-	idx := bc.logIndices[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	lf := sh.logFDs[payloadID]
+	tree := sh.dirtyIntervals[payloadID]
+	mu := sh.logLocks[payloadID]
+	rmu := sh.rollupLocks[payloadID]
+	idx := sh.logIndices[payloadID]
+	sh.mu.RUnlock()
 	if lf == nil || tree == nil || mu == nil || rmu == nil || idx == nil {
 		// Nothing to do — payload never had an AppendWrite (or was
 		// cleared by Close/DeleteAppendLog).
@@ -237,9 +240,9 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// (or replaced with a fresh lf on a subsequent getOrCreateLog). A
 		// stale rollup pass is benign — chunks will be retried on the next
 		// pass once the new lf is established.
-		bc.logsMu.RLock()
-		curLf := bc.logFDs[payloadID]
-		bc.logsMu.RUnlock()
+		sh.mu.RLock()
+		curLf := sh.logFDs[payloadID]
+		sh.mu.RUnlock()
 		if curLf == nil || curLf != lf {
 			return false, nil
 		}
@@ -378,9 +381,9 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// have their consumedExtent.payloadLen shortened to match the bytes
 		// that actually made it into a chunk — coverage MUST match the bytes
 		// chunked, not the original record size.
-		bc.logsMu.RLock()
-		trunc, hasTrunc = bc.truncations[payloadID]
-		bc.logsMu.RUnlock()
+		sh.mu.RLock()
+		trunc, hasTrunc = sh.truncations[payloadID]
+		sh.mu.RUnlock()
 		if hasTrunc {
 			filtered := recs[:0]
 			filteredExt := consumedExtents[:0]
@@ -618,9 +621,9 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// rows we wrote are reaped by GC / DeleteAppendLog cleanup. (The
 		// DeleteAppendLog rmu drain blocks delete's metadata clear until this
 		// pass returns, so it observes a consistent state afterwards.)
-		bc.logsMu.RLock()
-		curLf := bc.logFDs[payloadID]
-		bc.logsMu.RUnlock()
+		sh.mu.RLock()
+		curLf := sh.logFDs[payloadID]
+		sh.mu.RUnlock()
 		if curLf == nil || curLf != lf {
 			return nil
 		}
@@ -912,15 +915,13 @@ func blake3ContentHash(data []byte) blockstore.ContentHash {
 }
 
 // isTombstoned reports whether payloadID has been marked for deletion by
-// DeleteAppendLog. Through plans up to 09, bc.tombstones
-// is nil and this always returns false — which is correct, because no
-// deletion path exists yet.
+// DeleteAppendLog (which writes the entry in step 1). The read is taken under
+// the payload's shard lock; the shard's tombstones map is always allocated by
+// newLogShard, so an unknown payloadID simply returns false.
 func (bc *FSStore) isTombstoned(payloadID string) bool {
-	bc.logsMu.RLock()
-	defer bc.logsMu.RUnlock()
-	if bc.tombstones == nil {
-		return false
-	}
-	_, ok := bc.tombstones[payloadID]
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	_, ok := sh.tombstones[payloadID]
 	return ok
 }

--- a/pkg/blockstore/local/fs/rollup_divergence_test.go
+++ b/pkg/blockstore/local/fs/rollup_divergence_test.go
@@ -44,10 +44,11 @@ func TestRollup_DivergentInterval_DroppedNoLoop(t *testing.T) {
 	// returns this interval (it is the earliest UNCONSUMED stable one
 	// after the real append rolls up, OR can be reached on the first
 	// pass if it sorts ahead of the real append's Touched).
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.RLock()
+	tree := bcSh.dirtyIntervals[payloadID]
+	mu := bcSh.logLocks[payloadID]
+	bcSh.mu.RUnlock()
 	if tree == nil || mu == nil {
 		t.Fatalf("expected tree+mu to exist after AppendWrite")
 	}
@@ -70,9 +71,10 @@ func TestRollup_DivergentInterval_DroppedNoLoop(t *testing.T) {
 		if err := bc.rollupFile(ctx, payloadID, false); err != nil {
 			t.Fatalf("rollupFile returned error (divergence wedge regression): %v", err)
 		}
-		bc.logsMu.RLock()
-		tr := bc.dirtyIntervals[payloadID]
-		bc.logsMu.RUnlock()
+		bcSh := bc.shardFor(payloadID)
+		bcSh.mu.RLock()
+		tr := bcSh.dirtyIntervals[payloadID]
+		bcSh.mu.RUnlock()
 		mu.Lock()
 		_, hasStable := tr.EarliestStable(time.Now(), time.Duration(bc.stabilizationMS)*time.Millisecond)
 		mu.Unlock()
@@ -170,11 +172,12 @@ func TestAppendWrite_TreeAndLogIndexAtomicity(t *testing.T) {
 
 	// Walk every tree interval; assert each has a matching logIndex
 	// entry at the same fileOff with the same payloadLen.
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals[payloadID]
-	idx := bc.logIndices[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.RLock()
+	tree := bcSh.dirtyIntervals[payloadID]
+	idx := bcSh.logIndices[payloadID]
+	mu := bcSh.logLocks[payloadID]
+	bcSh.mu.RUnlock()
 	if tree == nil || idx == nil || mu == nil {
 		t.Fatalf("per-payload state missing after concurrent AppendWrite")
 	}
@@ -242,11 +245,12 @@ func TestAppendWrite_RollupConcurrent_NoDivergence(t *testing.T) {
 	// idx lookup race would leave the tree carrying an interval the
 	// logIndex cannot back. Production-path verification: every tree
 	// interval has a matching logIndex hit.
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals[payloadID]
-	idx := bc.logIndices[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	bcSh := bc.shardFor(payloadID)
+	bcSh.mu.RLock()
+	tree := bcSh.dirtyIntervals[payloadID]
+	idx := bcSh.logIndices[payloadID]
+	mu := bcSh.logLocks[payloadID]
+	bcSh.mu.RUnlock()
 	if tree != nil && idx != nil && mu != nil {
 		mu.Lock()
 		tree.t.Ascend(func(iv *interval) bool {

--- a/pkg/blockstore/local/fs/test_hooks.go
+++ b/pkg/blockstore/local/fs/test_hooks.go
@@ -61,14 +61,15 @@ func (bc *FSStore) RollupStoreForTest() metadata.RollupStore { return bc.rollupS
 // tracked for payloadID, or 0 when the payload has no interval tree.
 //
 // Acquires the per-file mutex to serialize against rollupFile's
-// ConsumeUpTo (which mutates the btree under mu). logsMu alone is
-// insufficient because rollupFile snapshots the tree pointer under
-// logsMu.RLock and then mutates the btree later under the per-file mu.
+// ConsumeUpTo (which mutates the btree under mu). The shard lock alone is
+// insufficient because rollupFile snapshots the tree pointer under the
+// shard RLock and then mutates the btree later under the per-file mu.
 func (bc *FSStore) IntervalsLenForTest(payloadID string) int {
-	bc.logsMu.RLock()
-	t := bc.dirtyIntervals[payloadID]
-	mu := bc.logLocks[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	t := sh.dirtyIntervals[payloadID]
+	mu := sh.logLocks[payloadID]
+	sh.mu.RUnlock()
 	if t == nil {
 		return 0
 	}
@@ -85,9 +86,10 @@ func (bc *FSStore) IntervalsLenForTest(payloadID string) int {
 // rollupFile would observe a stable interval — replacing brittle
 // time.Sleep calls (FIX-10).
 func (bc *FSStore) EarliestStableForTest(payloadID string) bool {
-	bc.logsMu.RLock()
-	tree := bc.dirtyIntervals[payloadID]
-	bc.logsMu.RUnlock()
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	tree := sh.dirtyIntervals[payloadID]
+	sh.mu.RUnlock()
 	if tree == nil {
 		return false
 	}


### PR DESCRIPTION
Fixes the **C2** contention from the #680 re-profile (REVIEW.md §5.1), now the #1 mutex cost after C1 landed.

### Problem
A single `logsMu sync.RWMutex` guarded all **seven** per-payload append-log maps. `getOrCreateLog`'s create-path write-lock serialized *every* new-payload acquisition across the whole store — **~60% of mutex-wait** under a concurrent create/delete storm, scaling super-linearly with workers.

### Change
Shard into `numLogShards` (16) independent `*logShard`, each with its own `RWMutex` + its own seven maps. `shardFor(payloadID)` (FNV-1a, masked) routes each payload to exactly one shard, so all of a payload's state lives under one shard lock — preserving the #668 "tree + logIndex under the same lock" invariant and `getOrCreateLog`'s atomic create.

- Single-payload sites lock the one shard.
- Cross-payload sweeps (`scanAllFiles`, `DrainRollups`, `ResetLocalState`, `Close`) iterate shards **one lock at a time** (no two shard locks held at once → no cross-shard deadlock).
- Lock order unchanged: per-file `rmu`/`mu` before the shard lock (FIX-2 discipline intact).

### Result (storm, 8 workers)
| | total mutex-wait | create-path RWMutex share |
|---|---|---|
| pre-C2 | 54.7s | 60.7% |
| **post-C2** | **19.5s (−64%)** | **13.6%** |

Residual is the intrinsic per-file append mutex (one writer per file), not a global bottleneck.

### Tests
- `TestShardFor_Deterministic` — stability + distribution across shards.
- `TestLogShards_ConcurrentCreateDelete` — concurrent create/delete across many payloads/shards under `-race`.
- Updated `TestGroupCommit_NoLogsMuTouch` lock-order grep gate to also catch the shard lock by its new names.

Full `pkg/blockstore/local/fs` green under `-race`; golangci-lint 0 issues. Reviewed by code-reviewer (6 concurrency invariants traced; 0 CRITICAL/HIGH; 2 IMPORTANT doc/test-gate items fixed) + code-simplifier (stale-comment cleanup).