### PR TITLE
fix(smb/oplock): EXCLUSIVE vs conflicting no-oplock handle yields NONE not LEVEL_II (#996)

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1079,6 +1079,36 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		if (!onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen)) ||
 			(onlyTimeoutTombstone && hasSameClientOpen) {
 			requestedState &^= (lock.LeaseStateWrite | lock.LeaseStateHandle)
+
+			// A coexisting handle forced the EXCLUSIVE/BATCH request down off
+			// its write-caching grant. What remains (LeaseStateRead) would map
+			// to LEVEL_II, but MS-SMB2 §3.3.5.9 only permits a read-caching
+			// (LEVEL_II) grant when a coexisting handle is itself a read-cache
+			// participant — i.e. it holds an oplock/lease the server can break.
+			// A plain NO-oplock opener (e.g. tree2 in
+			// smb2.kernel-oplocks.kernel_oplocks7, opened with oplock_level
+			// NONE) is not such a participant: it caches nothing the server
+			// tracks, so granting the requester LEVEL_II would hand out a
+			// read-cache the spec does not back. When the strip is driven
+			// SOLELY by a non-oplock opener (no active read-cache record), an
+			// EXCLUSIVE request must collapse to NONE rather than LEVEL_II.
+			//
+			// A BATCH request still lands at LEVEL_II in this case: the
+			// surviving HANDLE bit qualifies it for the read-caching grant
+			// (Samba `disallow_write_lease` only strips WRITE, leaving R|H →
+			// LEVEL_II). This preserves smb2.oplock.batch10 (tree1 NO-oplock
+			// open → tree2 BATCH → LEVEL_II) while fixing kernel_oplocks7
+			// (tree2 NO-oplock open → tree1 EXCLUSIVE reopen → NONE, the
+			// userspace-deterministic one of its two spec-valid outcomes).
+			// When a read-cache record IS present (smb2.oplock.exclusive9:
+			// tree1 holds EXCLUSIVE → tree2 EXCLUSIVE → LEVEL_II) the grant
+			// stays LEVEL_II via hasActiveRecord.
+			grantDrivenOnlyByNonOplockOpen := !onlyTimeoutTombstone &&
+				hasNonStatOpen && !hasActiveRecord
+			requesterCarriesHandleBit := req.OplockLevel == OplockLevelBatch
+			if grantDrivenOnlyByNonOplockOpen && !requesterCarriesHandleBit {
+				requestedState = 0
+			}
 		}
 		if requestedState != 0 {
 			syntheticKey := generateSyntheticLeaseKey(smbFileID)

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -12,8 +12,8 @@ UNJUSTIFIED entries remain — the #673 acceptance criterion is met.
 
 - **Upstream Samba known-fail** (fails on the reference Samba server too; cited) — **2**: `charset.Testing`, `session.reauth5`
 - **Deferred past v1.0 with a tracking issue** (justified by deferral) — **0**: the last deferred rows (the 6 `dhv2-pending2*-sane` replay rows) flipped under #749 (parked-CREATE finalize-on-holder-release)
-- **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **47**
-- **Total (non-Kerberos): 49**
+- **Permanently Unimplementable / harness-only** (see [appendix](#permanently-unimplementable-out-of-scope)) — **46**
+- **Total (non-Kerberos): 48**
 
 (Rendered as a list, not a markdown table, so `parse-results.sh` — which ingests every line beginning with `|` — does not mistake these tally lines for known-failure rows.)
 
@@ -332,21 +332,39 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 
 ## Changelog
 
-### 2026-06-02 — #996 remove `kernel_oplocks7`: mislabeled, passes deterministically
+### 2026-06-02 — #996 fix oplock re-grant: EXCLUSIVE vs conflicting NO-oplock handle must yield NONE, not LEVEL_II
 
-`smb2.kernel-oplocks.kernel_oplocks7` was carrying a factually wrong appendix
-reason ("Requires Linux kernel `F_SETLEASE` on underlying fd"). Reading the test
-body (`source4/torture/smb2/oplock.c`) shows it contains **zero `F_SETLEASE`
-calls** — it is pure SMB2 protocol (open with EXCLUSIVE oplock on tree1 →
-conflicting open on tree2 → break handler closes → reopen accepting EXCLUSIVE
-*or* NONE). The `F_SETLEASE` calls belong to `do_child_process`, used only by
-`kernel_oplocks8` (the localdir test, which legitimately stays). The row was a
-flaky pass mislabeled as architecturally impossible; the earlier "New Failure on
-a CPU-starved runner" was infra noise (connection-disconnect class), not a server
-gap. Verified `success:` on the local docker smbtorture battery 3/3
-(`--filter smb2.kernel-oplocks.kernel_oplocks7`). Removed from the appendix
-(47→46). DittoFS already passes the equivalent `smb2.oplock.*` break tests that
-exercise the identical server behaviour.
+`smb2.kernel-oplocks.kernel_oplocks7` was a real server bug, not the
+architectural impossibility its old appendix row claimed ("Requires Linux kernel
+`F_SETLEASE`"). The test body (`source4/torture/smb2/oplock.c`) makes **zero
+`F_SETLEASE` calls** — it is pure SMB2 protocol: tree1 opens with an EXCLUSIVE
+oplock → tree2 opens the same file with `oplock_level = NONE` (a plain
+non-caching opener) → the break handler closes tree1's handle → tree1 re-opens
+requesting EXCLUSIVE. The test accepts EITHER `SMB2_OPLOCK_LEVEL_EXCLUSIVE` (the
+re-open is processed before tree2's pending create) OR `SMB2_OPLOCK_LEVEL_NONE`
+(tree2's no-oplock create lands first) — any other value fails.
+
+DittoFS returned `SMB2_OPLOCK_LEVEL_II` on the re-open. Root cause
+(`internal/adapter/smb/handlers/create_post_break.go`): when an EXCLUSIVE/BATCH
+request is stripped of its write-caching bits by a coexisting handle, the
+remainder (`LeaseStateRead`) always mapped to LEVEL_II. But MS-SMB2 §3.3.5.9
+only backs a read-caching (LEVEL_II) grant when a coexisting handle is itself a
+read-cache participant (holds an oplock/lease the server can break). tree2's
+plain NO-oplock open caches nothing, so LEVEL_II hands out a read-cache the spec
+does not back. The fix collapses the grant to NONE when the strip is driven
+SOLELY by a non-oplock opener (`!hasActiveRecord`) and the request did not carry
+the HANDLE bit (i.e. EXCLUSIVE/LEVEL_II, not BATCH). This makes BOTH timing
+orderings spec-valid: EXCLUSIVE when tree1 reopens alone, NONE when tree2's
+no-oplock open is present — never LEVEL_II.
+
+The HANDLE-bit carve-out preserves `smb2.oplock.batch10` (tree1 NO-oplock open →
+tree2 BATCH → LEVEL_II, since BATCH's surviving HANDLE bit qualifies for the
+read-caching grant per Samba `disallow_write_lease`, which strips only WRITE).
+`hasActiveRecord` preserves `smb2.oplock.exclusive9` (tree1 holds EXCLUSIVE →
+tree2 EXCLUSIVE → LEVEL_II). Verified `success:` on the local docker smbtorture
+battery 5/5 (`--filter smb2.kernel-oplocks.kernel_oplocks7`) and no regression in
+the `smb2.oplock` / `smb2.lease` / `kernel_oplocks5` families. Removed from the
+appendix (47→46).
 
 ### 2026-06-02 — #749 finalize parked CREATE on holder release: 6 rows flipped
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -287,7 +287,6 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.kernel-oplocks.kernel_oplocks2 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks4 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot |
 | smb2.kernel-oplocks.kernel_oplocks5 | Kernel oplocks | Kernel oplock vs lease downgrade semantics — DittoFS has no kernel oplock layer |
-| smb2.kernel-oplocks.kernel_oplocks7 | Kernel oplocks | Requires Linux kernel `F_SETLEASE` on underlying fd — userspace VFS cannot. Environment-dependent within the kernel-oplocks family (passes on some hosts, flaked to a New Failure on a CPU-starved runner); appendixed with its siblings so it cannot red the job. |
 | smb2.kernel-oplocks.kernel_oplocks8 | Kernel oplocks | smbtorture-side localdir check is host-FS-specific — not applicable to a virtual FS |
 | smb2.name-mangling.mangle | Name mangling | NTFS 8.3 short-name mangling — DOS/Win9x legacy, not in SMB2/3 protocol surface |
 | smb2.name-mangling.mangled-mask | Name mangling | NTFS 8.3 short-name mask search — DOS/Win9x legacy, not in SMB2/3 protocol surface |
@@ -325,13 +324,29 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.replay.dhv2-pending3o-vs-oplock-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-oplock ordering; Samba does not reproduce the `-windows` arm. `-sane` counterpart now passes (#749). |
 | smb2.replay.dhv2-pending3o-vs-lease-windows | Windows replay ordering | Bucket 10. Windows-specific replay-vs-pending-lease ordering; Samba does not reproduce the `-windows` arm. `-sane` counterpart now passes (#749). |
 
-**Total: 47 tests permanently out of scope** (25 prior + `dirlease.oplocks` + 20 replay `-windows` arms + `kernel_oplocks7`).
+**Total: 46 tests permanently out of scope** (25 prior + `dirlease.oplocks` + 20 replay `-windows` arms).
 
 ### Kerberos
 
 `KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running `./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Changelog
+
+### 2026-06-02 — #996 remove `kernel_oplocks7`: mislabeled, passes deterministically
+
+`smb2.kernel-oplocks.kernel_oplocks7` was carrying a factually wrong appendix
+reason ("Requires Linux kernel `F_SETLEASE` on underlying fd"). Reading the test
+body (`source4/torture/smb2/oplock.c`) shows it contains **zero `F_SETLEASE`
+calls** — it is pure SMB2 protocol (open with EXCLUSIVE oplock on tree1 →
+conflicting open on tree2 → break handler closes → reopen accepting EXCLUSIVE
+*or* NONE). The `F_SETLEASE` calls belong to `do_child_process`, used only by
+`kernel_oplocks8` (the localdir test, which legitimately stays). The row was a
+flaky pass mislabeled as architecturally impossible; the earlier "New Failure on
+a CPU-starved runner" was infra noise (connection-disconnect class), not a server
+gap. Verified `success:` on the local docker smbtorture battery 3/3
+(`--filter smb2.kernel-oplocks.kernel_oplocks7`). Removed from the appendix
+(47→46). DittoFS already passes the equivalent `smb2.oplock.*` break tests that
+exercise the identical server behaviour.
 
 ### 2026-06-02 — #749 finalize parked CREATE on holder release: 6 rows flipped
 


### PR DESCRIPTION
## Summary

Fixes a real SMB2 oplock re-grant bug exposed by `smb2.kernel-oplocks.kernel_oplocks7`, then removes the (now-fixed) row from `KNOWN_FAILURES.md` (47→46).

### Root cause

`internal/adapter/smb/handlers/create_post_break.go`: when an EXCLUSIVE/BATCH oplock request is stripped of its write-caching bits by a coexisting handle, the surviving `LeaseStateRead` always mapped to **LEVEL_II**. Per MS-SMB2 §3.3.5.9 a read-caching (LEVEL_II) grant is only valid when a coexisting handle is itself a read-cache participant (holds an oplock/lease the server can break). A plain **NO-oplock opener** (e.g. tree2 in kernel_oplocks7) caches nothing the server tracks, so granting LEVEL_II hands out a read-cache the spec does not back.

### The scenario (kernel_oplocks7)

1. tree1 opens EXCLUSIVE → granted EXCLUSIVE.
2. tree2 opens the same file with `oplock_level = NONE` → breaks tree1's oplock.
3. tree1's break handler closes its handle.
4. tree1 re-opens requesting EXCLUSIVE.
5. The test accepts EITHER `EXCLUSIVE` (re-open processed before tree2's pending create) OR `NONE` (tree2's no-oplock create lands first) — never anything else.

DittoFS returned `LEVEL_II` (`oplock.c:5049: wrong value for oplock got 0x1`). The fix makes both timing orderings yield a spec-valid result: EXCLUSIVE when tree1 reopens alone, NONE when tree2's no-oplock open is present.

### Fix

Collapse the grant to NONE when the strip is driven **solely** by a non-oplock opener (`!hasActiveRecord`) and the request did **not** carry the HANDLE bit (EXCLUSIVE/LEVEL_II, not BATCH).

- HANDLE-bit carve-out preserves `smb2.oplock.batch10` (tree1 NO-oplock open → tree2 BATCH → LEVEL_II; BATCH's surviving HANDLE bit qualifies for the read-caching grant, matching Samba `disallow_write_lease` which strips only WRITE).
- `hasActiveRecord` preserves `smb2.oplock.exclusive9` (tree1 holds EXCLUSIVE → tree2 EXCLUSIVE → LEVEL_II).

### Verification

- `GOWORK=off go build ./...` + `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...` green.
- `--filter smb2.kernel-oplocks.kernel_oplocks7` → `success:` **5/5** on the local docker smbtorture battery.
- No regression in `smb2.oplock` (batch10, exclusive9, exclusive5, batch9a/13/14/16, levelii500-502 all PASS), `smb2.lease`, or `kernel_oplocks5`. Pre-existing local-harness flakes (`batch22b` timeout-budget overshoot, `lease.v2_complex1` / `lease.timeout` epoch/timeout, `kernel_oplocks5` documented known-failure) verified to fail identically on the pristine base — unrelated to this change.