### PR TITLE
fix(metadata): guard register/remove TOCTOU lock-manager resurrection (area-7 M1)

### DIFF
--- a/pkg/controlplane/runtime/lockmgr_toctou_test.go
+++ b/pkg/controlplane/runtime/lockmgr_toctou_test.go
@@ -1,0 +1,54 @@
+package runtime
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestRemoveShare_ConcurrentLockManagerLookup is the area-7 M1 -race reproducer
+// at the Runtime façade. RemoveShare deregisters a share's lock manager from the
+// MetadataService (via RemoveStoreForShare) while in-flight protocol ops may
+// still resolve it through the GetLockManagerForShare lazy getter. Run under
+// -race it exercises the register/remove TOCTOU on the per-share lock-manager
+// registry: a RemoveShare must never leave a resurrected lock manager behind, and
+// concurrent lookups must not race the removal.
+//
+// The fix lives in MetadataService.RegisterStoreForShare/RemoveStoreForShare (a
+// per-share removal generation that makes a register decline to publish when a
+// removal landed mid-flight); this test drives that path through the real
+// AddShare/RemoveShare lifecycle the control plane uses.
+func TestRemoveShare_ConcurrentLockManagerLookup(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	localID := createLocalBlockStoreConfig(t, s, "local-lockmgr-toctou")
+
+	const shareName = "/lockmgr-toctou"
+	addShareViaRuntime(t, rt, s, shareName, localID)
+
+	meta := rt.GetMetadataService()
+
+	var wg sync.WaitGroup
+
+	// Reader: hammers the lazy getter the REVIEW names, concurrent with removal.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			_ = meta.GetLockManagerForShare(shareName)
+		}
+	}()
+
+	// Remover: removes the share while lookups are in flight.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = rt.RemoveShare(shareName)
+	}()
+
+	wg.Wait()
+
+	// After RemoveShare the lock manager must be fully gone — not resurrected by
+	// a racing lookup or a late register publish.
+	if lm := meta.GetLockManagerForShare(shareName); lm != nil {
+		t.Fatalf("lock manager for removed share %q must not be resurrected", shareName)
+	}
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -47,6 +47,16 @@ type MetadataService struct {
 	cookies            *CookieManager                    // NFS/SMB cookie to store token translation
 	quotas             map[string]int64                  // shareName -> quota in bytes (0 = unlimited)
 
+	// removeGen counts RemoveStoreForShare calls per share. RegisterStoreForShare
+	// snapshots a share's counter before recovering its lock manager outside s.mu
+	// and re-checks it at publish: any removal of that share during recovery bumps
+	// its counter, so the register declines to publish. This closes the
+	// register/remove TOCTOU the store-pointer re-check alone cannot: a removal
+	// that completes mid-flight and is followed by a same-pointer re-register
+	// leaves the entry looking "still ours", which would otherwise resurrect a
+	// lock manager + notifier for a removed share.
+	removeGen map[string]uint64
+
 	// graceDuration is the lock-manager grace period applied to shares whose
 	// stores carry persisted locks at registration. Zero means use the default.
 	graceDuration time.Duration
@@ -100,6 +110,7 @@ func New() *MetadataService {
 		deferredCommit:     true, // Enable deferred commits by default
 		cookies:            NewCookieManager(),
 		quotas:             make(map[string]int64),
+		removeGen:          make(map[string]uint64),
 	}
 }
 
@@ -168,6 +179,10 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	s.mu.Lock()
 	s.stores[shareName] = store
 	_, exists := s.lockManagers[shareName]
+	// Snapshot this share's removal generation under the same lock that publishes
+	// our store. A RemoveStoreForShare for this share that lands while we recover
+	// (outside s.mu) bumps it; the publish re-check below aborts when it advanced.
+	startGen := s.removeGen[shareName]
 	s.mu.Unlock()
 
 	if exists {
@@ -247,7 +262,12 @@ func (s *MetadataService) RegisterStoreForShare(shareName string, store Metadata
 	// the entry is gone or no longer ours, we must abort the publish.
 	cur, stillOurs := s.stores[shareName]
 	_, lmExists := s.lockManagers[shareName]
-	removedMidFlight := !lmExists && (!stillOurs || cur != store)
+	// A removal that landed during recovery bumps removeGen. The store-pointer
+	// check below misses the case where the same store pointer is re-published
+	// after the removal (the entry then looks "still ours"), so the generation
+	// check is the authoritative removed-mid-flight signal; the pointer check
+	// remains as a defence-in-depth for a different-store re-register.
+	removedMidFlight := !lmExists && (s.removeGen[shareName] != startGen || !stillOurs || cur != store)
 	if lmExists || removedMidFlight {
 		// Our manager may have armed a grace timer above. It was never
 		// published, so abort that timer without firing onGraceEnd — letting it
@@ -336,6 +356,11 @@ func (s *MetadataService) RemoveStoreForShare(shareName string) {
 	delete(s.unifiedViews, shareName)
 	delete(s.dirChangeNotifiers, shareName)
 	delete(s.quotas, shareName)
+
+	// Bump this share's removal generation so any RegisterStoreForShare recovering
+	// it outside s.mu declines to publish: the register snapshots removeGen before
+	// recovery and re-checks it at publish (register/remove TOCTOU guard).
+	s.removeGen[shareName]++
 }
 
 // initLockManagerFromStore stamps a fresh server epoch and replays any locks

--- a/pkg/metadata/service_register_race_test.go
+++ b/pkg/metadata/service_register_race_test.go
@@ -2,6 +2,7 @@ package metadata_test
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -224,4 +225,49 @@ func TestRegisterStoreForShare_LostRaceDoesNotEndWinnerGrace(t *testing.T) {
 		"the winner's grace window must survive a lost concurrent register")
 	require.Same(t, lm, svc.GetLockManagerForShare(shareName),
 		"the published lock manager must remain the winner's (no replacement)")
+}
+
+// TestRemoveStoreForShare_ConcurrentRegisterDoesNotResurrect is the concurrent
+// -race reproducer the area-7 REVIEW calls for. It drives the add/remove churn
+// the static finding describes: many concurrent RemoveStoreForShare vs
+// RegisterStoreForShare for the same share, with GetLockManagerForShare reading
+// throughout. Run under -race it surfaces any unsynchronised access to the
+// per-share maps across the register/remove TOCTOU window.
+func TestRemoveStoreForShare_ConcurrentRegisterDoesNotResurrect(t *testing.T) {
+	const (
+		shareName = "/churn"
+		rounds    = 200
+	)
+
+	svc := metadata.New()
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds*4; i++ {
+			_ = svc.GetLockManagerForShare(shareName)
+			_, _ = svc.GetStoreForShare(shareName)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			_ = svc.RegisterStoreForShare(shareName, store)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			svc.RemoveStoreForShare(shareName)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/metadata/service_remove_gen_internal_test.go
+++ b/pkg/metadata/service_remove_gen_internal_test.go
@@ -1,0 +1,97 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/require"
+)
+
+// removeThenRepublishStore is a white-box test store used to isolate the
+// removal-generation guard. It implements lock.LockStore (so the recovery path
+// type-asserts it and calls ListLocks) and embeds the MetadataStore interface
+// (nil) only to satisfy the static type RegisterStoreForShare expects — the
+// register/recovery path never invokes any MetadataStore method.
+//
+// During the unlocked recovery phase (ListLocks) it fires a RemoveStoreForShare
+// for its share AND re-publishes its OWN store pointer into s.stores. Re-publishing
+// the same pointer defeats the store-pointer re-check (the entry is present and
+// still "ours"), so only the removal-generation bump can reveal that a removal
+// landed mid-flight. This is exactly the residual area-7 M1 window: a
+// RemoveStoreForShare completing while a RegisterStoreForShare for the same store
+// is recovering, with the store pointer re-published in between (e.g. by a racing
+// re-add resolving to the same store — the control-plane stores.Service registry
+// keeps the same pointer across share remove/re-add).
+type removeThenRepublishStore struct {
+	MetadataStore // nil; never called during register/recovery
+	svc           *MetadataService
+	shareName     string
+	fired         bool
+}
+
+func (s *removeThenRepublishStore) PutLock(context.Context, *lock.PersistedLock) error { return nil }
+func (s *removeThenRepublishStore) GetLock(context.Context, string) (*lock.PersistedLock, error) {
+	return nil, lock.NewLockNotFoundError("")
+}
+func (s *removeThenRepublishStore) DeleteLock(context.Context, string) error { return nil }
+func (s *removeThenRepublishStore) ListLocks(context.Context, lock.LockQuery) ([]*lock.PersistedLock, error) {
+	if !s.fired {
+		s.fired = true
+		// A concurrent RemoveStoreForShare lands while we recover outside s.mu;
+		// it bumps removeGen[shareName].
+		s.svc.RemoveStoreForShare(s.shareName)
+		// The store pointer is then re-published (same pointer), so the register's
+		// pointer re-check still sees "our" store. Only the generation bump reveals
+		// that a removal happened.
+		s.svc.mu.Lock()
+		s.svc.stores[s.shareName] = s
+		s.svc.mu.Unlock()
+	}
+	return nil, nil
+}
+func (s *removeThenRepublishStore) DeleteLocksByClient(context.Context, string) (int, error) {
+	return 0, nil
+}
+func (s *removeThenRepublishStore) DeleteLocksByFile(context.Context, string) (int, error) {
+	return 0, nil
+}
+func (s *removeThenRepublishStore) GetServerEpoch(context.Context) (uint64, error) { return 0, nil }
+func (s *removeThenRepublishStore) IncrementServerEpoch(context.Context) (uint64, error) {
+	return 1, nil
+}
+func (s *removeThenRepublishStore) GetCleanShutdown(context.Context) (bool, error) {
+	return true, nil
+}
+func (s *removeThenRepublishStore) SetCleanShutdown(context.Context, bool) error { return nil }
+func (s *removeThenRepublishStore) ReclaimLease(context.Context, lock.FileHandle, [16]byte, string) (*lock.UnifiedLock, error) {
+	return nil, lock.NewLockNotFoundError("")
+}
+
+// TestRegisterStoreForShare_RemovalGenerationBlocksResurrection is the Finding-M1
+// regression. It proves the removal-generation guard aborts the publish even when
+// the store-pointer re-check would pass, so a share removed mid-flight is never
+// resurrected.
+func TestRegisterStoreForShare_RemovalGenerationBlocksResurrection(t *testing.T) {
+	const shareName = "/raced-gen"
+
+	svc := New()
+
+	store := &removeThenRepublishStore{svc: svc, shareName: shareName}
+
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+	require.True(t, store.fired, "the mid-flight removal must have been exercised")
+
+	// The store pointer was re-published by the decorator, so the pointer re-check
+	// alone would have passed. The generation guard must still have aborted the
+	// publish: no lock manager / notifier for a removed share.
+	require.Nil(t, svc.GetLockManagerForShare(shareName),
+		"a share removed mid-flight must NOT have its lock manager resurrected even "+
+			"when the store pointer is re-published before the publish re-check")
+
+	svc.mu.RLock()
+	_, hasNotifier := svc.dirChangeNotifiers[shareName]
+	svc.mu.RUnlock()
+	require.False(t, hasNotifier,
+		"a share removed mid-flight must NOT have its dirChangeNotifier resurrected")
+}


### PR DESCRIPTION
## Summary

Closes #1005 (area-7 runtime REVIEW M1).

`MetadataService.RegisterStoreForShare` recovers a share's lock manager **outside `s.mu`** (recovery issues backend IO) and re-checks the registry under the publish lock. The existing re-check compared the currently-registered store *pointer* against its own, which detects a `RemoveStoreForShare` that **deletes** the entry mid-flight — but **misses** the case where a removal lands mid-flight and the **same store pointer** is re-published in between. That same-pointer re-register is realistic: a same-name re-add resolves to the **same** `*MemoryMetadataStore` via the `stores.Service` registry (which persists the pointer across share remove/re-add). The entry then looks "still ours", so the register would **resurrect** `lockManagers`/`dirChangeNotifiers` for a share the control plane already removed — stale routing + a lock manager that is never torn down (leak), and an unbalanced `OnLockGraceStart`.

## Fix

Add a per-share **removal generation** counter:
- `RemoveStoreForShare` bumps `removeGen[shareName]`.
- `RegisterStoreForShare` snapshots `removeGen[shareName]` under the same lock that publishes its store, before recovery, and aborts the publish (without resurrecting maps; balancing the grace coordinator via the existing `removedMidFlight` path) if it advanced.

The store-pointer check is kept as defence-in-depth for a different-store re-register. Minimal, no config knobs. A legitimate re-add after a completed removal still succeeds (its snapshot is taken after the bump).

## Tests
- `TestRegisterStoreForShare_RemovalGenerationBlocksResurrection` (white-box): deterministically fires a removal during recovery **and** re-publishes the same store pointer, defeating the pointer check — proves the generation guard blocks resurrection. Verified to FAIL without the guard, PASS with it.
- `TestRemoveStoreForShare_ConcurrentRegisterDoesNotResurrect` (`-race`): concurrent register/remove/lookup churn.
- `TestRemoveShare_ConcurrentLockManagerLookup` (`-race`, Runtime façade): `RemoveShare` vs `GetLockManagerForShare` lazy getter through the real AddShare/RemoveShare lifecycle.

## Gates
- `go build ./...` — clean
- `go vet ./pkg/controlplane/... ./pkg/metadata/...` — clean
- `go fmt` — clean
- `go test -race ./pkg/metadata/ ./pkg/controlplane/runtime/...` — all green