### PR TITLE
fix(nfs/v3): v3-interop HIGHs — atomic WCC pre-op attrs, WRITE wtmax short-write, READDIRPLUS maxcount budget (#1002)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -194,6 +194,10 @@ func (h *Handler) Create(
 
 	var fileHandle metadata.FileHandle
 	var fileAttr *metadata.FileAttr
+	// createDirWcc holds the parent-directory WCC captured atomically when a new
+	// file is created (H9). Nil for the truncate-existing path (parent dir
+	// unchanged) and for early returns.
+	var createDirWcc *metadata.DirWcc
 
 	switch req.Mode {
 	case types.CreateGuarded:
@@ -212,7 +216,7 @@ func (h *Handler) Create(
 		}
 
 		// Create new file
-		fileHandle, fileAttr, err = createNewFile(authCtx, metaSvc, parentHandle, req)
+		fileHandle, fileAttr, createDirWcc, err = createNewFile(authCtx, metaSvc, parentHandle, req)
 
 	case types.CreateExclusive:
 		// EXCLUSIVE: Check idempotency token if file exists
@@ -264,7 +268,7 @@ func (h *Handler) Create(
 		}
 
 		// Create new file with idempotency token
-		fileHandle, fileAttr, err = createNewFile(authCtx, metaSvc, parentHandle, req)
+		fileHandle, fileAttr, createDirWcc, err = createNewFile(authCtx, metaSvc, parentHandle, req)
 
 	case types.CreateUnchecked:
 		// UNCHECKED: Create or truncate existing
@@ -275,7 +279,7 @@ func (h *Handler) Create(
 			fileAttr, err = truncateExistingFile(authCtx, blockStore, metaSvc, existingFile, req)
 		} else {
 			// Create new file
-			fileHandle, fileAttr, err = createNewFile(authCtx, metaSvc, parentHandle, req)
+			fileHandle, fileAttr, createDirWcc, err = createNewFile(authCtx, metaSvc, parentHandle, req)
 		}
 
 	default:
@@ -350,9 +354,10 @@ func (h *Handler) Create(
 	// Convert metadata to NFS attributes
 	nfsFileAttr := h.convertFileAttrToNFS(fileHandle, fileAttr)
 
-	// Get updated parent directory attributes
-	updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-	nfsDirAttr := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+	// H9: prefer the parent-directory WCC captured atomically with the create.
+	// For the truncate-existing path (createDirWcc nil) the parent dir is
+	// unchanged, so dirWccPair falls back to a fresh read.
+	dirWccBefore, nfsDirAttr := h.dirWccPair(ctx, metaSvc, parentHandle, createDirWcc, dirWccBefore)
 
 	logger.InfoCtx(ctx.Context, "CREATE successful", "file", req.Filename, "handle", fmt.Sprintf("0x%x", fileHandle), "mode", fmt.Sprintf("0%o", fileAttr.Mode), "size", fileAttr.Size, "client", clientIP)
 
@@ -395,7 +400,7 @@ func createNewFile(
 	metaSvc *metadata.MetadataService,
 	parentHandle metadata.FileHandle,
 	req *CreateRequest,
-) (metadata.FileHandle, *metadata.FileAttr, error) {
+) (metadata.FileHandle, *metadata.FileAttr, *metadata.DirWcc, error) {
 	// Build file attributes for the new file
 	// The repository will complete these with timestamps and PayloadID
 	fileAttr := &metadata.FileAttr{
@@ -458,9 +463,9 @@ func createNewFile(
 
 	// Call metaSvc's atomic Create operation
 	// This handles file creation, parent linking, and permission checking
-	createdFile, err := metaSvc.CreateFile(authCtx, parentHandle, req.Filename, fileAttr)
+	createdFile, dirWcc, err := metaSvc.CreateFile(authCtx, parentHandle, req.Filename, fileAttr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create file: %w", err)
+		return nil, nil, nil, fmt.Errorf("create file: %w", err)
 	}
 
 	// Debug logging to trace file creation
@@ -474,10 +479,10 @@ func createNewFile(
 	// Encode the file handle for return
 	fileHandle, err := metadata.EncodeFileHandle(createdFile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("encode file handle: %w", err)
+		return nil, nil, nil, fmt.Errorf("encode file handle: %w", err)
 	}
 
-	return fileHandle, &createdFile.FileAttr, nil
+	return fileHandle, &createdFile.FileAttr, dirWcc, nil
 }
 
 // truncateExistingFile truncates an existing file and updates attributes.
@@ -534,8 +539,10 @@ func truncateExistingFile(
 	}
 
 	// Update file metadata using metaSvc
-	// This includes permission checking
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs); err != nil {
+	// This includes permission checking. The returned WCC describes the file
+	// being truncated; the CREATE response's directory WCC is unaffected because
+	// truncating an existing entry does not modify the parent directory.
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs); err != nil {
 		return nil, fmt.Errorf("update file metadata: %w", err)
 	}
 

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -78,6 +78,35 @@ func (h *Handler) convertFileAttrToNFS(fileHandle metadata.FileHandle, fileAttr 
 	return xdr.MetadataToNFS(fileAttr, fileid)
 }
 
+// dirWccPair derives the WCC before/after attributes for a directory (or, for
+// SETATTR, a file) from the atomic *metadata.DirWcc a mutation returned (H9).
+//
+// When the store captured the pre/post attributes atomically with the mutation,
+// they are used directly — these are guaranteed to bracket the operation. The
+// fallbackBefore (a pre-op snapshot the handler read at entry) is used only when
+// the atomic Before is absent, and a fresh GetFile supplies the After only when
+// the atomic After is absent. handle identifies the WCC subject.
+func (h *Handler) dirWccPair(
+	ctx *NFSHandlerContext,
+	metaSvc *metadata.MetadataService,
+	handle metadata.FileHandle,
+	wcc *metadata.DirWcc,
+	fallbackBefore *types.WccAttr,
+) (before *types.WccAttr, after *types.NFSFileAttr) {
+	before = fallbackBefore
+	if wcc != nil && wcc.Before != nil {
+		before = xdr.CaptureWccAttr(wcc.Before)
+	}
+	if wcc != nil && wcc.After != nil {
+		after = h.convertFileAttrToNFS(handle, wcc.After)
+		return before, after
+	}
+	if file, err := metaSvc.GetFile(ctx.Context, handle); err == nil {
+		after = h.convertFileAttrToNFS(handle, &file.FileAttr)
+	}
+	return before, after
+}
+
 // getFileOrError retrieves a file from the metadata store with error handling.
 // Checks for context cancellation and returns appropriate NFS status codes.
 //

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -257,7 +257,7 @@ func (h *Handler) Link(
 	// - Incrementing the link count (nlink) on the file
 	// - Updating directory timestamps
 
-	err = metaSvc.CreateHardLink(authCtx, dirHandle, req.Name, fileHandle)
+	dirWcc, err := metaSvc.CreateHardLink(authCtx, dirHandle, req.Name, fileHandle)
 	if err != nil {
 		logError(ctx.Context, err, "LINK failed: store error", "name", req.Name, "client", clientIP)
 
@@ -290,9 +290,8 @@ func (h *Handler) Link(
 
 	nfsFileAttr := h.convertFileAttrToNFS(fileHandle, &updatedFile.FileAttr)
 
-	// Get updated directory attributes
-	updatedDirFile, _ := metaSvc.GetFile(ctx.Context, dirHandle)
-	nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
+	// H9: use the directory attributes captured atomically with the link.
+	dirWccBefore, nfsDirAttr := h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, dirWccBefore)
 
 	logger.InfoCtx(ctx.Context, "LINK successful", "name", req.Name, "file_handle", fmt.Sprintf("%x", req.FileHandle), "nlink", nfsFileAttr.Nlink, "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -285,7 +285,7 @@ func (h *Handler) Mkdir(
 
 	// Call store.Create() with Type = FileTypeDirectory
 	// The store will complete the attributes with timestamps, size, etc.
-	newDirFile, err := metaSvc.CreateDirectory(authCtx, parentHandle, req.Name, dirAttr)
+	newDirFile, dirWcc, err := metaSvc.CreateDirectory(authCtx, parentHandle, req.Name, dirAttr)
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {
@@ -332,9 +332,8 @@ func (h *Handler) Mkdir(
 	// Generate file ID from handle for NFS attributes
 	nfsAttr := h.convertFileAttrToNFS(newHandle, &newDirFile.FileAttr)
 
-	// Get updated parent attributes for WCC data
-	updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-	wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+	// H9: use the parent attributes captured atomically with the create.
+	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "MKDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newDirFile.Mode), "size", newDirFile.Size, "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -286,7 +286,7 @@ func (h *Handler) Mknod(
 	}
 
 	// Create the special file
-	newFile, err := metaSvc.CreateSpecialFile(
+	newFile, dirWcc, err := metaSvc.CreateSpecialFile(
 		authCtx,
 		parentHandle,
 		req.Name,
@@ -332,9 +332,8 @@ func (h *Handler) Mknod(
 	// Generate file ID from handle for NFS attributes
 	nfsAttr := h.convertFileAttrToNFS(newHandle, &newFile.FileAttr)
 
-	// Get updated parent attributes for WCC data
-	updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-	wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+	// H9: use the parent attributes captured atomically with the create.
+	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "MKNOD successful", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newFile.Mode), "major", req.Spec.SpecData1, "minor", req.Spec.SpecData2, "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -11,6 +11,40 @@ import (
 )
 
 // ============================================================================
+// XDR size accounting (RFC 1813 Section 3.3.17 maxcount / dircount budgets)
+// ============================================================================
+
+// readDirPlusFattr3Size is the fixed XDR-encoded size of an fattr3 structure
+// (RFC 1813 Section 2.3.1): 5×uint32 + 2×uint64 + specdata3(2×uint32) +
+// 2×uint64 + 3×nfstime3(2×uint32) = 84 bytes.
+const readDirPlusFattr3Size = 84
+
+// xdrOpaqueLen returns the XDR-encoded length of an opaque/string payload of
+// n bytes: a 4-byte length prefix followed by the data padded up to a 4-byte
+// boundary.
+func xdrOpaqueLen(n int) uint32 {
+	return uint32(4 + (n+3)&^3)
+}
+
+// readDirPlusEntryDirSize returns the "directory information" cost of an entry
+// (the fields a plain READDIR3 entry would carry): fileid(8) + name(opaque) +
+// cookie(8), plus the leading value_follows flag(4). This is what dircount
+// bounds.
+func readDirPlusEntryDirSize(name string) uint32 {
+	return 4 + 8 + xdrOpaqueLen(len(name)) + 8
+}
+
+// readDirPlusEntryExtraSize returns the per-entry cost beyond the directory
+// information: the optional post-op attributes (present flag + fattr3) and the
+// optional file handle (present flag + opaque). This counts only against
+// maxcount.
+func readDirPlusEntryExtraSize(handleLen int) uint32 {
+	// name_attributes: present flag(4) + fattr3(84) — we always include attrs.
+	// name_handle: present flag(4) + opaque handle.
+	return 4 + readDirPlusFattr3Size + 4 + xdrOpaqueLen(handleLen)
+}
+
+// ============================================================================
 // Request and Response Structures
 // ============================================================================
 
@@ -301,6 +335,25 @@ func (h *Handler) ReadDirPlus(
 	// Build entries list - look up each entry to get handle and full attributes
 	entries := make([]*DirPlusEntry, 0, len(page.Entries))
 
+	// ========================================================================
+	// Byte-budget accounting (RFC 1813 Section 3.3.17)
+	// ========================================================================
+	// maxcount bounds the total READDIRPLUS3resok reply size; dircount bounds
+	// the "directory information" portion (the fields READDIR would have
+	// returned: fileid + name + cookie), excluding the per-entry attributes and
+	// file handle. We track both as we append entries and stop before either
+	// budget is exceeded, setting eof=false so the client resumes from the last
+	// emitted cookie. Without this, a large directory produces an oversized
+	// reply the client truncates or rejects.
+	//
+	// Fixed reply overhead consumed before any entry:
+	//   status(4) + post-op dir attr (present flag 4 + fattr3 84) +
+	//   cookieverf(8) + trailing value_follows=FALSE(4) + eof(4).
+	const replyFixedOverhead = 4 + (4 + readDirPlusFattr3Size) + 8 + 4 + 4
+	totalBudget := uint32(replyFixedOverhead)
+	dirBudget := uint32(0)
+	budgetExhausted := false
+
 	for i, entry := range page.Entries {
 		// Check context periodically (every 50 entries) for large directories
 		if i%50 == 0 {
@@ -350,6 +403,27 @@ func (h *Handler) ReadDirPlus(
 		// Convert attributes to NFS format
 		nfsEntryAttr := h.convertFileAttrToNFS(entryHandle, entryAttr)
 
+		// Enforce the maxcount/dircount budgets before committing this entry.
+		// entryDirSize is the directory-info cost (counts against dircount and
+		// maxcount); entryExtraSize is the per-entry attributes + handle cost
+		// (counts only against maxcount).
+		entryDirSize := readDirPlusEntryDirSize(entry.Name)
+		entryTotalSize := entryDirSize + readDirPlusEntryExtraSize(len(entryHandle))
+
+		// Always emit at least one entry to guarantee forward progress, even if
+		// a single entry exceeds the client's budget (the client will then have
+		// to raise maxcount, but never deadlocks).
+		if len(entries) > 0 {
+			if totalBudget+entryTotalSize > req.MaxCount ||
+				dirBudget+entryDirSize > req.DirCount {
+				budgetExhausted = true
+				break
+			}
+		}
+
+		totalBudget += entryTotalSize
+		dirBudget += entryDirSize
+
 		// Use cookie from entry (set by MetadataService.ReadDirectory)
 		plusEntry := &DirPlusEntry{
 			Fileid:     entry.ID,
@@ -368,8 +442,11 @@ func (h *Handler) ReadDirPlus(
 	// Step 7: Build success response
 	// ========================================================================
 
-	// EOF is true when there are no more pages
-	eof := !page.HasMore
+	// EOF is true only when there are no more pages AND we did not stop early
+	// due to the maxcount/dircount budget. If the budget was exhausted (or we
+	// emitted fewer entries than the page contained), eof MUST be false so the
+	// client resumes from the last emitted cookie (RFC 1813 Section 3.3.17).
+	eof := !page.HasMore && !budgetExhausted && len(entries) == len(page.Entries)
 
 	logger.InfoCtx(ctx.Context, "READDIRPLUS successful", "handle", fmt.Sprintf("%x", req.DirHandle), "entries", len(entries), "eof", eof, "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/readdirplus_test.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
@@ -135,4 +136,88 @@ func TestReadDirPlus_StaleVerifierContinues(t *testing.T) {
 	assert.Contains(t, names, "file3.txt", "second page should include newly created file")
 	assert.NotContains(t, names, "file1.txt", "second page should not repeat earlier entries")
 	assert.NotContains(t, names, "file2.txt", "second page should not repeat earlier entries")
+}
+
+// TestReadDirPlus_MaxCountTruncation verifies H11: when the client's maxcount
+// byte budget is smaller than the encoded reply for all entries, READDIRPLUS
+// returns a partial list with eof=false so the client resumes from the last
+// emitted cookie (RFC 1813 Section 3.3.17).
+func TestReadDirPlus_MaxCountTruncation(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	const numFiles = 40
+	for i := 0; i < numFiles; i++ {
+		fx.CreateFile(fmt.Sprintf("budgetdir/file%02d.txt", i), []byte("x"))
+	}
+	dirHandle := fx.MustGetHandle("budgetdir")
+
+	// Each READDIRPLUS entry costs ~140+ bytes (value_follows + fileid + name +
+	// cookie + fattr3 + handle). A tiny maxcount must force truncation. DirCount
+	// is kept large so only the maxcount (total reply) budget bites.
+	// maxcount must be >= dircount per RFC 1813 / request validation. Keep both
+	// small and equal so the total-reply (maxcount) budget bites first: each
+	// entry's total cost (~140 B incl. fattr3+handle) far exceeds its dir-info
+	// cost (~32 B), so maxcount truncates before dircount does.
+	req := &handlers.ReadDirPlusRequest{
+		DirHandle:  dirHandle,
+		Cookie:     0,
+		CookieVerf: 0,
+		DirCount:   512,
+		MaxCount:   512, // far smaller than the full reply
+	}
+	resp, err := fx.Handler.ReadDirPlus(fx.Context(), req)
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+
+	// Must be a partial reply.
+	assert.Greater(t, len(resp.Entries), 0, "should emit at least one entry")
+	assert.Less(t, len(resp.Entries), numFiles, "should not emit all entries under a tiny maxcount")
+	assert.False(t, resp.Eof, "eof must be false when the reply was truncated by maxcount")
+
+	// The encoded reply must actually fit within the advertised maxcount.
+	encoded, err := resp.Encode()
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(encoded), int(req.MaxCount),
+		"encoded reply (%d bytes) must not exceed maxcount (%d)", len(encoded), req.MaxCount)
+
+	// Resuming from the last cookie must make forward progress (no infinite loop).
+	lastCookie := resp.Entries[len(resp.Entries)-1].Cookie
+	resp2, err := fx.Handler.ReadDirPlus(fx.Context(), &handlers.ReadDirPlusRequest{
+		DirHandle:  dirHandle,
+		Cookie:     lastCookie,
+		CookieVerf: resp.CookieVerf,
+		DirCount:   512,
+		MaxCount:   512,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp2.Status)
+	assert.Greater(t, len(resp2.Entries), 0, "second page should make progress")
+}
+
+// TestReadDirPlus_DirCountTruncation verifies the dircount (directory-info)
+// budget is honored independently of maxcount.
+func TestReadDirPlus_DirCountTruncation(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	const numFiles = 40
+	for i := 0; i < numFiles; i++ {
+		fx.CreateFile(fmt.Sprintf("dircountdir/file%02d.txt", i), []byte("x"))
+	}
+	dirHandle := fx.MustGetHandle("dircountdir")
+
+	// Large maxcount but tiny dircount: each entry's dir-info (~32 bytes) must
+	// bound the result.
+	req := &handlers.ReadDirPlusRequest{
+		DirHandle:  dirHandle,
+		Cookie:     0,
+		CookieVerf: 0,
+		DirCount:   128,
+		MaxCount:   1 << 20,
+	}
+	resp, err := fx.Handler.ReadDirPlus(fx.Context(), req)
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.Greater(t, len(resp.Entries), 0, "should emit at least one entry")
+	assert.Less(t, len(resp.Entries), numFiles, "dircount should bound the entry count")
+	assert.False(t, resp.Eof, "eof must be false when truncated by dircount")
 }

--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -177,7 +177,7 @@ func (h *Handler) Remove(
 	// We don't check for cancellation inside RemoveFile to maintain atomicity.
 	// The store should respect context internally for its operations.
 
-	removedFileAttr, err := metaSvc.RemoveFile(authCtx, dirHandle, req.Filename)
+	removedFileAttr, dirWcc, err := metaSvc.RemoveFile(authCtx, dirHandle, req.Filename)
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {
@@ -242,15 +242,9 @@ func (h *Handler) Remove(
 	// Step 6: Build success response with updated directory attributes
 	// ========================================================================
 
-	// Get updated directory attributes for WCC data
-	dirFile, err = metaSvc.GetFile(ctx.Context, dirHandle)
-	if err != nil {
-		logger.WarnCtx(ctx.Context, "REMOVE: file removed but cannot get updated directory attributes", "handle", fmt.Sprintf("%x", req.DirHandle), "error", err)
-		// Continue with nil WccAfter rather than failing the entire operation
-		wccAfter = nil
-	} else {
-		wccAfter = h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
-	}
+	// H9: use the parent attributes captured atomically with the removal,
+	// falling back to a fresh read only if the store did not return them.
+	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "REMOVE successful", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -285,7 +285,7 @@ func (h *Handler) Rename(
 	// We don't check for cancellation inside RenameFile to maintain atomicity.
 	// The store should respect context internally for its operations.
 
-	err = metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
+	renameWcc, err := metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
 	if err == nil {
 		// ====================================================================
 		// NFS-specific: Handle silly rename (.nfs* pattern)
@@ -362,22 +362,16 @@ func (h *Handler) Rename(
 	// Step 6: Build success response with updated WCC data
 	// ========================================================================
 
-	// Get updated source directory attributes
-	if updatedFromDirFile, getErr := metaSvc.GetFile(ctx.Context, fromDirHandle); getErr != nil {
-		logger.WarnCtx(ctx.Context, "RENAME: successful but cannot get updated source directory attributes", "dir", fmt.Sprintf("0x%x", req.FromDirHandle), "error", getErr)
-		fromDirWccAfter = nil
-	} else {
-		fromDirWccAfter = h.convertFileAttrToNFS(fromDirHandle, &updatedFromDirFile.FileAttr)
+	// H9: use the source/destination directory attributes captured atomically
+	// inside the Move transaction. The pre-op snapshots read at handler entry
+	// can race a concurrent mutation in the window; the in-transaction captures
+	// are guaranteed to bracket the rename.
+	var fromWcc, toWcc *metadata.DirWcc
+	if renameWcc != nil {
+		fromWcc, toWcc = renameWcc.FromDir, renameWcc.ToDir
 	}
-
-	// Get updated destination directory attributes
-	var toDirWccAfter *types.NFSFileAttr
-	if updatedToDirFile, getErr := metaSvc.GetFile(ctx.Context, toDirHandle); getErr != nil {
-		logger.WarnCtx(ctx.Context, "RENAME: successful but cannot get updated destination directory attributes", "dir", fmt.Sprintf("0x%x", req.ToDirHandle), "error", getErr)
-		// toDirWccAfter will be nil
-	} else {
-		toDirWccAfter = h.convertFileAttrToNFS(toDirHandle, &updatedToDirFile.FileAttr)
-	}
+	fromDirWccBefore, fromDirWccAfter = h.dirWccPair(ctx, metaSvc, fromDirHandle, fromWcc, fromDirWccBefore)
+	toDirWccBefore, toDirWccAfter := h.dirWccPair(ctx, metaSvc, toDirHandle, toWcc, toDirWccBefore)
 
 	logger.InfoCtx(ctx.Context, "RENAME successful", "from", req.FromName, "to", req.ToName, "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -186,7 +186,7 @@ func (h *Handler) Rmdir(
 	}
 
 	// Delegate to metaSvc for directory removal
-	err = metaSvc.RemoveDirectory(authCtx, parentHandle, req.Name)
+	dirWcc, err := metaSvc.RemoveDirectory(authCtx, parentHandle, req.Name)
 	if err != nil {
 		logger.DebugCtx(ctx.Context, "RMDIR failed: store error", "name", req.Name, "client", clientIP, "error", err)
 
@@ -208,9 +208,8 @@ func (h *Handler) Rmdir(
 	// Step 5: Build success response with updated parent attributes
 	// ========================================================================
 
-	// Get updated parent directory attributes
-	parentFile, _ = metaSvc.GetFile(ctx.Context, parentHandle)
-	wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+	// H9: use the parent attributes captured atomically with the removal.
+	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "RMDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -263,10 +263,15 @@ func (h *Handler) SetAttr(
 	hasOtherAttrs := req.NewAttr.Mode != nil || req.NewAttr.UID != nil ||
 		req.NewAttr.GID != nil || req.NewAttr.Atime != nil || req.NewAttr.Mtime != nil
 
+	// setWcc accumulates the file's own pre/post attributes captured atomically
+	// with the SetFileAttributes mutation(s) (H9). For the two-phase size+other
+	// case, Before comes from the first (size) call and After from the second.
+	var setWcc *metadata.DirWcc
 	if hasSize && hasOtherAttrs {
 		// Apply size change first (separate call per RFC 5661)
 		sizeOnlyAttrs := metadata.SetAttrs{Size: req.NewAttr.Size}
-		err = metaSvc.SetFileAttributes(authCtx, fileHandle, &sizeOnlyAttrs)
+		var sizeWcc *metadata.DirWcc
+		sizeWcc, err = metaSvc.SetFileAttributes(authCtx, fileHandle, &sizeOnlyAttrs)
 		if err != nil {
 			// Handle size change error
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -301,10 +306,19 @@ func (h *Handler) SetAttr(
 			Atime: req.NewAttr.Atime,
 			Mtime: req.NewAttr.Mtime,
 		}
-		err = metaSvc.SetFileAttributes(authCtx, fileHandle, &otherAttrs)
+		var otherWcc *metadata.DirWcc
+		otherWcc, err = metaSvc.SetFileAttributes(authCtx, fileHandle, &otherAttrs)
+		// Before from the size call (true pre-op), After from the latest call.
+		setWcc = &metadata.DirWcc{}
+		if sizeWcc != nil {
+			setWcc.Before = sizeWcc.Before
+		}
+		if otherWcc != nil {
+			setWcc.After = otherWcc.After
+		}
 	} else {
 		// Only size or only other attributes - single call is fine
-		err = metaSvc.SetFileAttributes(authCtx, fileHandle, &req.NewAttr)
+		setWcc, err = metaSvc.SetFileAttributes(authCtx, fileHandle, &req.NewAttr)
 	}
 	if err != nil {
 		// Check if error is due to context cancellation
@@ -362,31 +376,22 @@ func (h *Handler) SetAttr(
 	// Step 6: Build success response with updated attributes
 	// ========================================================================
 
-	// Get updated file attributes for WCC data
-	updatedFile, _, err := h.getFileOrError(ctx, fileHandle, "SETATTR", req.Handle)
-	if updatedFile == nil && err != nil {
-		// Context cancelled
-		return nil, err
-	}
-	if updatedFile == nil {
-		logger.WarnCtx(ctx.Context, "SETATTR: attributes updated but cannot get new attributes",
-			"handle", fmt.Sprintf("%x", req.Handle))
-		// Continue with nil WccAfter rather than failing the entire operation
-		wccAfter = nil
-	} else {
-		wccAfter = h.convertFileAttrToNFS(fileHandle, &updatedFile.FileAttr)
-	}
+	// H9: prefer the file's pre/post attributes captured atomically with the
+	// SetFileAttributes mutation. The wccBefore read at handler entry can race a
+	// concurrent mutation in the window; setWcc.Before is the state the op
+	// actually transitioned from. The WCC subject for SETATTR is the file itself.
+	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, fileHandle, setWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "SETATTR successful",
 		"handle", fmt.Sprintf("%x", req.Handle),
 		"client", clientIP)
 
-	if updatedFile != nil {
+	if setWcc != nil && setWcc.After != nil {
 		logger.DebugCtx(ctx.Context, "SETATTR details",
 			"old_size", currentFile.Size,
-			"new_size", updatedFile.Size,
+			"new_size", setWcc.After.Size,
 			"old_mode", fmt.Sprintf("%o", currentFile.Mode),
-			"new_mode", fmt.Sprintf("%o", updatedFile.Mode))
+			"new_mode", fmt.Sprintf("%o", setWcc.After.Mode))
 	} else {
 		logger.DebugCtx(ctx.Context, "SETATTR details",
 			"old_size", currentFile.Size,

--- a/internal/adapter/nfs/v3/handlers/symlink.go
+++ b/internal/adapter/nfs/v3/handlers/symlink.go
@@ -215,7 +215,7 @@ func (h *Handler) Symlink(
 	// - Updating parent directory timestamps
 	// - Respecting context cancellation internally
 
-	createdSymlink, err := metaSvc.CreateSymlink(authCtx, dirHandle, req.Name, req.Target, symlinkAttr)
+	createdSymlink, dirWcc, err := metaSvc.CreateSymlink(authCtx, dirHandle, req.Name, req.Target, symlinkAttr)
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {
@@ -266,17 +266,8 @@ func (h *Handler) Symlink(
 	// Generate symlink attributes for response
 	nfsSymlinkAttr := h.convertFileAttrToNFS(symlinkHandle, &createdSymlink.FileAttr)
 
-	// Get updated directory attributes for WCC data
-	updatedDirFile, err := metaSvc.GetFile(ctx.Context, dirHandle)
-	if err != nil {
-		logger.WarnCtx(ctx.Context, "SYMLINK: successful but cannot get updated directory attributes", "dir", fmt.Sprintf("0x%x", req.DirHandle), "error", err)
-		// Continue with nil WccAfter rather than failing
-	}
-
-	var wccAfter *types.NFSFileAttr
-	if updatedDirFile != nil {
-		wccAfter = h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
-	}
+	// H9: use the directory attributes captured atomically with the create.
+	wccBefore, wccAfter := h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, wccBefore)
 
 	logger.InfoCtx(ctx.Context, "SYMLINK successful", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "handle", fmt.Sprintf("0x%x", symlinkHandle), "client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -48,6 +48,10 @@ type HandlerTestFixture struct {
 	// It owns the memory-backed metadata store.
 	MetadataService *metadata.MetadataService
 
+	// MetaStore is the underlying memory-backed metadata store. Exposed so
+	// tests can adjust static capabilities (e.g. MaxWriteSize) directly.
+	MetaStore *metadatamemory.MemoryMetadataStore
+
 	// BlockStore provides block storage for content operations.
 	BlockStore *engine.Store
 
@@ -130,6 +134,7 @@ func NewHandlerFixture(t *testing.T) *HandlerTestFixture {
 		Handler:         handler,
 		Registry:        reg,
 		MetadataService: reg.GetMetadataService(),
+		MetaStore:       metaStore,
 		BlockStore:      blockSvc,
 		ShareName:       DefaultShareName,
 		RootHandle:      share.RootHandle,
@@ -220,7 +225,7 @@ func (f *HandlerTestFixture) CreateDirectory(path string) metadata.FileHandle {
 		}
 
 		// Create directory
-		dir, err := f.MetadataService.CreateDirectory(authCtx, parentHandle, name, &metadata.FileAttr{
+		dir, _, err := f.MetadataService.CreateDirectory(authCtx, parentHandle, name, &metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0755,
 			UID:  DefaultUID,
@@ -263,7 +268,7 @@ func (f *HandlerTestFixture) CreateFile(path string, content []byte) metadata.Fi
 
 	// Create the file
 	name := filepath.Base(path)
-	file, err := f.MetadataService.CreateFile(authCtx, parentHandle, name, &metadata.FileAttr{
+	file, _, err := f.MetadataService.CreateFile(authCtx, parentHandle, name, &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0644,
 		UID:  DefaultUID,
@@ -282,7 +287,7 @@ func (f *HandlerTestFixture) CreateFile(path string, content []byte) metadata.Fi
 
 		// Update file size in metadata
 		newSize := uint64(len(content))
-		err := f.MetadataService.SetFileAttributes(authCtx, mustEncodeHandle(f.t, file), &metadata.SetAttrs{
+		_, err := f.MetadataService.SetFileAttributes(authCtx, mustEncodeHandle(f.t, file), &metadata.SetAttrs{
 			Size: &newSize,
 		})
 		if err != nil {
@@ -312,7 +317,7 @@ func (f *HandlerTestFixture) CreateSymlink(path, target string) metadata.FileHan
 
 	// Create the symlink
 	name := filepath.Base(path)
-	symlink, err := f.MetadataService.CreateSymlink(authCtx, parentHandle, name, target, &metadata.FileAttr{
+	symlink, _, err := f.MetadataService.CreateSymlink(authCtx, parentHandle, name, target, &metadata.FileAttr{
 		Mode: 0777,
 		UID:  DefaultUID,
 		GID:  DefaultGID,

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -145,12 +145,10 @@ func (h *Handler) Write(
 	// ========================================================================
 	// Step 2: Validate request parameters
 	// ========================================================================
-	// Note: We use a fixed max write size (1MB) to avoid a metadata lookup.
-	// GetFilesystemCapabilities is expensive and the value rarely changes.
-	// The actual capabilities are still enforced by the metadata store.
+	// Structural validation only (handle, overflow, stability). The size cap
+	// is applied as a short-write below, derived from the advertised wtmax.
 
-	const maxWriteSize uint32 = 1 << 20 // 1MB - matches default config
-	if err := validateWriteRequest(req, maxWriteSize); err != nil {
+	if err := validateWriteRequest(req); err != nil {
 		logWarn(ctx.Context, err, "WRITE validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
@@ -168,6 +166,25 @@ func (h *Handler) Write(
 	}
 
 	logger.DebugCtx(ctx.Context, "WRITE", "share", ctx.Share)
+
+	// ========================================================================
+	// Step 3b: Short-write to the advertised wtmax (RFC 1813 Section 3.3.7)
+	// ========================================================================
+	// Derive the per-request cap from the same value advertised by FSINFO
+	// (GetFilesystemCapabilities().MaxWriteSize / wtmax) so the WRITE limit can
+	// never drift from what the client was told. RFC 1813 permits the server to
+	// write fewer bytes than requested; an over-large request is short-written
+	// (data truncated, reply Count reflects the actual bytes) rather than
+	// rejected with NFS3ERR_FBIG. This mirrors Linux nfsd, which clamps to
+	// svc_max_payload. A genuine "file too large" (offset overflow / OffsetMax)
+	// still returns NFS3ERR_FBIG below.
+	if caps, capErr := metaSvc.GetFilesystemCapabilities(ctx.Context, fileHandle); capErr == nil &&
+		caps.MaxWriteSize > 0 && uint32(len(req.Data)) > caps.MaxWriteSize {
+		logger.DebugCtx(ctx.Context, "WRITE: short-write to advertised wtmax",
+			"requested", len(req.Data), "wtmax", caps.MaxWriteSize, "client", clientIP)
+		req.Data = req.Data[:caps.MaxWriteSize]
+		req.Count = caps.MaxWriteSize
+	}
 
 	// ========================================================================
 	// Step 4: Calculate new file size

--- a/internal/adapter/nfs/v3/handlers/write_test.go
+++ b/internal/adapter/nfs/v3/handlers/write_test.go
@@ -566,3 +566,78 @@ func TestWrite_CountMismatch(t *testing.T) {
 		assert.EqualValues(t, 5, resp.Count)
 	}
 }
+
+// TestWrite_ShortWriteToAdvertisedWtmax verifies H10: a request larger than the
+// advertised wtmax (FSINFO MaxWriteSize) is short-written rather than rejected
+// with NFS3ERR_FBIG. Per RFC 1813 Section 3.3.7 the server may write fewer bytes
+// than requested; the reply Count must reflect the actual (capped) bytes written.
+func TestWrite_ShortWriteToAdvertisedWtmax(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	// Shrink the advertised write cap to a small value. The WRITE handler must
+	// derive its cap from this same value (not a hardcoded 1MB).
+	caps, err := fx.MetaStore.GetFilesystemCapabilities(fx.Context().Context, fx.RootHandle)
+	require.NoError(t, err)
+	const wtmax = uint32(16)
+	caps.MaxWriteSize = wtmax
+	fx.MetaStore.SetFilesystemCapabilities(*caps)
+
+	fileHandle := fx.CreateFile("short.txt", []byte{})
+
+	// Request 64 bytes — 4x the advertised cap.
+	data := make([]byte, 64)
+	for i := range data {
+		data[i] = byte('A' + (i % 26))
+	}
+	req := &handlers.WriteRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  uint32(len(data)),
+		Stable: 2,
+		Data:   data,
+	}
+	resp, err := fx.Handler.Write(fx.ContextWithUID(0, 0), req)
+	require.NoError(t, err)
+
+	// Must NOT be NFS3ERR_FBIG — that is the wrong code for an over-large request.
+	assert.NotEqualValues(t, types.NFS3ErrFBig, resp.Status, "over-large WRITE must not return FBIG")
+	require.EqualValues(t, types.NFS3OK, resp.Status, "over-large WRITE should short-write, not error")
+
+	// Reply Count must equal the advertised cap (short write).
+	assert.EqualValues(t, wtmax, resp.Count, "Count must reflect the short-written byte total")
+
+	// Exactly wtmax bytes must be persisted.
+	readResp, err := fx.Handler.Read(fx.Context(), &handlers.ReadRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  100,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, data[:wtmax], readResp.Data, "only the capped prefix should be written")
+}
+
+// TestWrite_WithinWtmaxNotTruncated verifies a request at exactly the advertised
+// wtmax is written in full (boundary case for H10).
+func TestWrite_WithinWtmaxNotTruncated(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	caps, err := fx.MetaStore.GetFilesystemCapabilities(fx.Context().Context, fx.RootHandle)
+	require.NoError(t, err)
+	const wtmax = uint32(32)
+	caps.MaxWriteSize = wtmax
+	fx.MetaStore.SetFilesystemCapabilities(*caps)
+
+	fileHandle := fx.CreateFile("exact.txt", []byte{})
+	data := make([]byte, wtmax)
+	req := &handlers.WriteRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  wtmax,
+		Stable: 2,
+		Data:   data,
+	}
+	resp, err := fx.Handler.Write(fx.ContextWithUID(0, 0), req)
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.EqualValues(t, wtmax, resp.Count, "exact-wtmax WRITE must not be truncated")
+}

--- a/internal/adapter/nfs/v3/handlers/write_validation.go
+++ b/internal/adapter/nfs/v3/handlers/write_validation.go
@@ -17,18 +17,19 @@ import (
 //   - File handle is not empty and within limits
 //   - File handle is long enough for file ID extraction
 //   - Count matches actual data length
-//   - Count doesn't exceed server's maximum write size
 //   - Offset + Count doesn't overflow uint64
 //   - Stability level is valid
 //
-// Parameters:
-//   - req: The write request to validate
-//   - maxWriteSize: Maximum write size from store configuration
+// An over-large request (data exceeding the advertised wtmax) is NOT rejected
+// here. Per RFC 1813 Section 3.3.7 the server may write fewer bytes than
+// requested; the WRITE handler short-writes by capping the data to the value
+// advertised in FSINFO (GetFilesystemCapabilities().MaxWriteSize), mirroring
+// Linux nfsd which clamps to svc_max_payload rather than returning NFS3ERR_FBIG.
 //
 // Returns:
 //   - nil if valid
 //   - *validationError with NFS status if invalid
-func validateWriteRequest(req *WriteRequest, maxWriteSize uint32) *validationError {
+func validateWriteRequest(req *WriteRequest) *validationError {
 	// Validate file handle
 	if len(req.Handle) == 0 {
 		return &validationError{
@@ -59,16 +60,6 @@ func validateWriteRequest(req *WriteRequest, maxWriteSize uint32) *validationErr
 	if dataLen != req.Count {
 		logger.Warn("WRITE: count mismatch (proceeding with actual data length)", "count", req.Count, "data_len", dataLen)
 		// Not fatal - we'll use actual data length
-	}
-
-	// Validate count doesn't exceed maximum write size configured by store
-	// The store can configure this based on its constraints and the
-	// wtmax value advertised in FSINFO.
-	if dataLen > maxWriteSize {
-		return &validationError{
-			message:   fmt.Sprintf("write data too large: %d bytes (max %d)", dataLen, maxWriteSize),
-			nfsStatus: types.NFS3ErrFBig,
-		}
 	}
 
 	// Validate offset + count doesn't overflow

--- a/internal/adapter/nfs/v4/handlers/create.go
+++ b/internal/adapter/nfs/v4/handlers/create.go
@@ -216,7 +216,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			dirAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateDirectory(authCtx, parentHandle, objName, dirAttr)
+		newFile, _, createErr = metaSvc.CreateDirectory(authCtx, parentHandle, objName, dirAttr)
 
 	case types.NF4LNK:
 		symlinkAttr := &metadata.FileAttr{
@@ -234,7 +234,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			symlinkAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateSymlink(authCtx, parentHandle, objName, linkTarget, symlinkAttr)
+		newFile, _, createErr = metaSvc.CreateSymlink(authCtx, parentHandle, objName, linkTarget, symlinkAttr)
 
 	case types.NF4BLK:
 		blkAttr := &metadata.FileAttr{
@@ -252,7 +252,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			blkAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
+		newFile, _, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
 			metadata.FileTypeBlockDevice, blkAttr, specMajor, specMinor)
 
 	case types.NF4CHR:
@@ -271,7 +271,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			chrAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
+		newFile, _, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
 			metadata.FileTypeCharDevice, chrAttr, specMajor, specMinor)
 
 	case types.NF4SOCK:
@@ -290,7 +290,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			sockAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
+		newFile, _, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
 			metadata.FileTypeSocket, sockAttr, 0, 0)
 
 	case types.NF4FIFO:
@@ -309,7 +309,7 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		if setAttrs.GID != nil {
 			fifoAttr.GID = *setAttrs.GID
 		}
-		newFile, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
+		newFile, _, createErr = metaSvc.CreateSpecialFile(authCtx, parentHandle, objName,
 			metadata.FileTypeFIFO, fifoAttr, 0, 0)
 	}
 

--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -478,7 +478,7 @@ func TestRemove_Directory_Success(t *testing.T) {
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	}
-	_, err := fx.metaSvc.CreateDirectory(dirAuthCtx, fx.rootHandle, "emptydir", dirAttr)
+	_, _, err := fx.metaSvc.CreateDirectory(dirAuthCtx, fx.rootHandle, "emptydir", dirAttr)
 	if err != nil {
 		t.Fatalf("create test directory: %v", err)
 	}

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -117,7 +117,7 @@ func (fx *ioTestFixture) createRegularFile(t *testing.T, parentHandle metadata.F
 		},
 	}
 
-	file, err := fx.metaSvc.CreateFile(authCtx, parentHandle, name, &metadata.FileAttr{
+	file, _, err := fx.metaSvc.CreateFile(authCtx, parentHandle, name, &metadata.FileAttr{
 		Mode: mode,
 		UID:  uid,
 		GID:  gid,
@@ -165,7 +165,7 @@ func (fx *ioTestFixture) writeContent(t *testing.T, fileHandle metadata.FileHand
 		},
 	}
 	newSize := uint64(len(data))
-	if err := fx.metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
+	if _, err := fx.metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
 		Size: &newSize,
 	}); err != nil {
 		t.Fatalf("update file size: %v", err)

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -120,7 +120,7 @@ func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *type
 	beforeCtime := uint64(dirFile.Ctime.UnixNano())
 
 	// Create the hard link: dirHandle (target dir) + newName + sourceHandle (source file)
-	linkErr := metaSvc.CreateHardLink(authCtx, dirHandle, newName, sourceHandle)
+	_, linkErr := metaSvc.CreateHardLink(authCtx, dirHandle, newName, sourceHandle)
 	if linkErr != nil {
 		status := common.MapToNFS4(linkErr)
 		logger.Debug("NFSv4 LINK failed",

--- a/internal/adapter/nfs/v4/handlers/link_rename_test.go
+++ b/internal/adapter/nfs/v4/handlers/link_rename_test.go
@@ -543,7 +543,7 @@ func TestHandleLink_CompoundSequence(t *testing.T) {
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	}
-	createdFile, err := fx.metaSvc.CreateFile(authCtx, fx.rootHandle, "source.txt", fileAttr)
+	createdFile, _, err := fx.metaSvc.CreateFile(authCtx, fx.rootHandle, "source.txt", fileAttr)
 	if err != nil {
 		t.Fatalf("create test file: %v", err)
 	}
@@ -581,21 +581,21 @@ func TestHandleRename_CompoundSequence(t *testing.T) {
 	// Create source dir, target dir, and a file in source dir
 	authCtx := newTestAuthCtx(0, 0)
 	srcDirAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}
-	srcDir, err := fx.metaSvc.CreateDirectory(authCtx, fx.rootHandle, "srcdir", srcDirAttr)
+	srcDir, _, err := fx.metaSvc.CreateDirectory(authCtx, fx.rootHandle, "srcdir", srcDirAttr)
 	if err != nil {
 		t.Fatalf("create src dir: %v", err)
 	}
 	srcDirHandle, _ := metadata.EncodeFileHandle(srcDir)
 
 	tgtDirAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}
-	tgtDir, err := fx.metaSvc.CreateDirectory(authCtx, fx.rootHandle, "tgtdir", tgtDirAttr)
+	tgtDir, _, err := fx.metaSvc.CreateDirectory(authCtx, fx.rootHandle, "tgtdir", tgtDirAttr)
 	if err != nil {
 		t.Fatalf("create tgt dir: %v", err)
 	}
 	tgtDirHandle, _ := metadata.EncodeFileHandle(tgtDir)
 
 	fileAttr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}
-	_, err = fx.metaSvc.CreateFile(authCtx, metadata.FileHandle(srcDirHandle), "myfile.txt", fileAttr)
+	_, _, err = fx.metaSvc.CreateFile(authCtx, metadata.FileHandle(srcDirHandle), "myfile.txt", fileAttr)
 	if err != nil {
 		t.Fatalf("create file in src dir: %v", err)
 	}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -298,7 +298,7 @@ func (h *Handler) handleOpenClaimNull(
 			if createAttrs != nil && createAttrs.Mode != nil {
 				fileMode = *createAttrs.Mode
 			}
-			newFile, createErr := metaSvc.CreateFile(authCtx, parentHandle, filename, &metadata.FileAttr{
+			newFile, _, createErr := metaSvc.CreateFile(authCtx, parentHandle, filename, &metadata.FileAttr{
 				Mode: fileMode,
 				UID:  uid,
 				GID:  gid,

--- a/internal/adapter/nfs/v4/handlers/remove.go
+++ b/internal/adapter/nfs/v4/handlers/remove.go
@@ -108,13 +108,13 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 	}
 
 	// Try RemoveFile first (works for regular files, symlinks, etc.)
-	_, removeErr := metaSvc.RemoveFile(authCtx, parentHandle, target)
+	_, _, removeErr := metaSvc.RemoveFile(authCtx, parentHandle, target)
 	if removeErr != nil {
 		// Check if the error indicates this is a directory (ErrIsDirectory)
 		var storeErr *metaerrors.StoreError
 		if goerrors.As(removeErr, &storeErr) && storeErr.Code == metaerrors.ErrIsDirectory {
 			// It's a directory -- try RemoveDirectory instead
-			removeErr = metaSvc.RemoveDirectory(authCtx, parentHandle, target)
+			_, removeErr = metaSvc.RemoveDirectory(authCtx, parentHandle, target)
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -148,7 +148,7 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 	tgtBeforeCtime := uint64(tgtDirFile.Ctime.UnixNano())
 
 	// Perform the rename: Move(fromDir, fromName, toDir, toName)
-	renameErr := metaSvc.Move(authCtx, srcDirHandle, oldName, tgtDirHandle, newName)
+	_, renameErr := metaSvc.Move(authCtx, srcDirHandle, oldName, tgtDirHandle, newName)
 	if renameErr != nil {
 		status := common.MapToNFS4(renameErr)
 		logger.Debug("NFSv4 RENAME failed",

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -189,7 +189,7 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 	}
 
 	// 7. Apply attributes via MetadataService (all-or-nothing semantics)
-	if err := metaSvc.SetFileAttributes(authCtx, metadata.FileHandle(ctx.CurrentFH), setAttrs); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, metadata.FileHandle(ctx.CurrentFH), setAttrs); err != nil {
 		nfsStatus := common.MapToNFS4(err)
 		logger.Debug("NFSv4 SETATTR failed",
 			"error", err,

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -476,10 +476,10 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				var deleteErr error
 				var removedPayloadID metadata.PayloadID
 				if isDeleteTargetDir {
-					deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
+					_, deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
 				} else {
 					var removed *metadata.File
-					removed, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
+					removed, _, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
 					if removed != nil {
 						removedPayloadID = removed.PayloadID
 					}
@@ -893,7 +893,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 
 	// Remove the regular file
 	metaSvc := h.Registry.GetMetadataService()
-	removed, err := metaSvc.RemoveFile(authCtx, parentHandle, fileName)
+	removed, _, err := metaSvc.RemoveFile(authCtx, parentHandle, fileName)
 	if err != nil {
 		return fmt.Errorf("failed to remove MFsymlink file: %w", err)
 	}
@@ -909,7 +909,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	// Create the real symlink with default attributes
 	// Pass empty FileAttr - CreateSymlink will apply defaults
 	symlinkAttr := &metadata.FileAttr{}
-	_, err = metaSvc.CreateSymlink(authCtx, parentHandle, fileName, target, symlinkAttr)
+	_, _, err = metaSvc.CreateSymlink(authCtx, parentHandle, fileName, target, symlinkAttr)
 	if err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
@@ -962,7 +962,7 @@ func (h *Handler) cascadeDeleteADSStreams(authCtx *metadata.AuthContext, metaSvc
 
 	for _, entry := range page.Entries {
 		if len(entry.Name) > len(prefix) && strings.EqualFold(entry.Name[:len(prefix)], prefix) {
-			_, deleteErr := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, entry.Name)
+			_, _, deleteErr := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, entry.Name)
 			if deleteErr != nil {
 				logger.Debug("CLOSE: cascade ADS delete: failed to remove stream",
 					"stream", entry.Name,

--- a/internal/adapter/smb/handlers/converters_test.go
+++ b/internal/adapter/smb/handlers/converters_test.go
@@ -492,7 +492,7 @@ func TestLoneSurrogateNames_CreateQueryRoundTrip(t *testing.T) {
 		return &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0644}
 	}
 	for _, name := range []string{hiName, loName, pairName} {
-		if _, err := metaSvc.CreateFile(authCtx, rootHandle, name, fileAttr()); err != nil {
+		if _, _, err := metaSvc.CreateFile(authCtx, rootHandle, name, fileAttr()); err != nil {
 			t.Fatalf("CreateFile(% x) failed (spurious collision?): %v", name, err)
 		}
 	}

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1277,7 +1277,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 			if authCtx.Identity.GID != nil {
 				baseAttr.GID = *authCtx.Identity.GID
 			}
-			if _, createBaseErr := metaSvc.CreateFile(authCtx, parentHandle, adsBaseFileName, baseAttr); createBaseErr != nil {
+			if _, _, createBaseErr := metaSvc.CreateFile(authCtx, parentHandle, adsBaseFileName, baseAttr); createBaseErr != nil {
 				// Concurrent stream CREATE may race on base-file creation.
 				// ErrAlreadyExists means another goroutine won — proceed.
 				var storeErr *metadata.StoreError
@@ -2140,9 +2140,9 @@ func (h *Handler) createNewFile(
 	var file *metadata.File
 	var err error
 	if isDirectory {
-		file, err = metaSvc.CreateDirectory(authCtx, parentHandle, name, fileAttr)
+		file, _, err = metaSvc.CreateDirectory(authCtx, parentHandle, name, fileAttr)
 	} else {
-		file, err = metaSvc.CreateFile(authCtx, parentHandle, name, fileAttr)
+		file, _, err = metaSvc.CreateFile(authCtx, parentHandle, name, fileAttr)
 	}
 
 	if err != nil {
@@ -2186,7 +2186,7 @@ func (h *Handler) overwriteFile(
 	setAttrs.Hidden = &hiddenVal
 
 	metaSvc := h.Registry.GetMetadataService()
-	err = metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs)
+	_, err = metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2218,7 +2218,7 @@ func (h *Handler) updateBaseObjectCtime(
 		return
 	}
 	now := time.Now()
-	if updateErr := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{Ctime: &now}); updateErr != nil {
+	if _, updateErr := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{Ctime: &now}); updateErr != nil {
 		logger.Debug("updateBaseObjectCtime: failed",
 			"baseObject", baseObjectName, "error", updateErr)
 	}
@@ -2272,7 +2272,7 @@ func (h *Handler) updateBaseObjectTimestampsForADSWrite(
 		baseCtime := baseFile.Ctime
 		setAttrs.Ctime = &baseCtime
 	}
-	_ = metaSvc.SetFileAttributes(authCtx, baseHandle, setAttrs)
+	_, _ = metaSvc.SetFileAttributes(authCtx, baseHandle, setAttrs)
 }
 
 // isStatOnlyOpen returns true when DesiredAccess contains only stat-open bits:

--- a/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
@@ -137,7 +137,7 @@ func TestCreate_DaclEnforcement_DeniesWhenBitNotGranted(t *testing.T) {
 			},
 		},
 	}
-	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "deny.txt",
+	existingFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "deny.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -192,7 +192,7 @@ func TestCreate_DaclEnforcement_AllowsWhenBitGranted(t *testing.T) {
 			},
 		},
 	}
-	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "allow.txt",
+	existingFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "allow.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -249,7 +249,7 @@ func TestCreate_DaclEnforcement_MaximumAllowedNeverDenies(t *testing.T) {
 			},
 		},
 	}
-	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "max.txt",
+	existingFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "max.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -295,7 +295,7 @@ func TestCreate_DaclEnforcement_NilACLPermissive(t *testing.T) {
 
 	metaSvc := rt.GetMetadataService()
 
-	existingFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "no_dacl.txt",
+	existingFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "no_dacl.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o600, // owner rw — but no DACL stored
@@ -394,7 +394,7 @@ func restrictedDACLFile(
 			},
 		},
 	}
-	f, err := metaSvc.CreateFile(rootAuth, rootHandle, name,
+	f, _, err := metaSvc.CreateFile(rootAuth, rootHandle, name,
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -640,7 +640,7 @@ func runDestructiveShareViolationCase(t *testing.T, fname string, disposition ty
 			},
 		},
 	}
-	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, fname,
+	existingFile, _, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, fname,
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -735,7 +735,7 @@ func TestCreate_OpenWithReadShareDoesNotConflictExistingHolder(t *testing.T) {
 			},
 		},
 	}
-	existingFile, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, "open_share.txt",
+	existingFile, _, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, "open_share.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,

--- a/internal/adapter/smb/handlers/create_doc_perms_test.go
+++ b/internal/adapter/smb/handlers/create_doc_perms_test.go
@@ -139,7 +139,7 @@ func TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete(t *testing.T) {
 
 	// Persist a regular file with the mode bits CREATE+FILE_ATTRIBUTE_READONLY
 	// would leave after the store round-trip (owner-write cleared, no DACL).
-	readonlyFile, err := metaSvc.CreateFile(rootAuth, rootHandle, "ro.txt",
+	readonlyFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "ro.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o444,

--- a/internal/adapter/smb/handlers/create_filecreated_grant_test.go
+++ b/internal/adapter/smb/handlers/create_filecreated_grant_test.go
@@ -58,7 +58,7 @@ func TestCreate_FileCreated_GrantsResolvedDesiredAccess(t *testing.T) {
 			},
 		},
 	}
-	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "testdir",
+	parentDir, _, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "testdir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -135,7 +135,7 @@ func TestCreate_FileCreated_ExpandsGenericAll(t *testing.T) {
 	creatorUID := uint32(1000)
 	creatorGID := uint32(1000)
 
-	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "gendir",
+	parentDir, _, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "gendir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -762,7 +762,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				}
 				if apply {
 					metaSvc := h.Registry.GetMetadataService()
-					if setErr := metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs); setErr != nil {
+					if _, setErr := metaSvc.SetFileAttributes(authCtx, fileHandle, setAttrs); setErr != nil {
 						logger.Debug("CREATE: failed to apply SD_BUFFER", "path", baseName, "error", setErr)
 					} else {
 						if updated, getErr := metaSvc.GetFile(authCtx.Context, fileHandle); getErr == nil {
@@ -801,7 +801,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			}
 			if muts := eaMutationsFromEntries(entries); len(muts) > 0 {
 				metaSvc := h.Registry.GetMetadataService()
-				if setErr := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{EAMutations: muts}); setErr != nil {
+				if _, setErr := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{EAMutations: muts}); setErr != nil {
 					logger.Debug("CREATE: failed to apply EA_BUFFER", "path", baseName, "error", setErr)
 				} else if updated, getErr := metaSvc.GetFile(authCtx.Context, fileHandle); getErr == nil {
 					file = updated
@@ -961,7 +961,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 					//   - FileOpened: nothing destructive happened, fail safely.
 					switch createAction {
 					case types.FileCreated:
-						if _, delErr := metaSvc.RemoveFile(authCtx, parentHandle, baseName); delErr != nil {
+						if _, _, delErr := metaSvc.RemoveFile(authCtx, parentHandle, baseName); delErr != nil {
 							logger.Warn("CREATE: failed to roll back orphaned file after lease rejection",
 								"name", baseName, "error", delErr)
 						}

--- a/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
+++ b/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
@@ -36,7 +36,7 @@ func raceParentDir(
 	name string,
 ) (metadata.FileHandle, *metadata.File) {
 	t.Helper()
-	dir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, name,
+	dir, _, err := metaSvc.CreateDirectory(rootAuth, rootHandle, name,
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -128,7 +128,7 @@ func TestCreate_RaceRecovery_SupersedeDeniedByWinnerDACL(t *testing.T) {
 			},
 		},
 	}
-	winner, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
+	winner, _, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o700,
@@ -146,7 +146,7 @@ func TestCreate_RaceRecovery_SupersedeDeniedByWinnerDACL(t *testing.T) {
 	// CreateFile forces Size=0 (ApplyCreateDefaults); set a non-zero size as
 	// root so a successful supersede would be observable as truncation to zero.
 	winnerSize := uint64(4096)
-	if err := metaSvc.SetFileAttributes(rootAuth, winnerHandle, &metadata.SetAttrs{Size: &winnerSize}); err != nil {
+	if _, err := metaSvc.SetFileAttributes(rootAuth, winnerHandle, &metadata.SetAttrs{Size: &winnerSize}); err != nil {
 		t.Fatalf("seed winner size: %v", err)
 	}
 
@@ -199,7 +199,7 @@ func TestCreate_RaceRecovery_OverwriteIfDeniedByShareMode(t *testing.T) {
 
 	// Pre-seed a permissive winner (nil DACL → no DACL denial) so the rejection
 	// is unambiguously from the share-mode gate, not the DACL gate.
-	winner, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
+	winner, _, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -265,7 +265,7 @@ func TestCreate_RaceRecovery_OpenIfMkdirDupStillSucceeds(t *testing.T) {
 	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "race-mkdir")
 
 	// Pre-seed the winning directory (the "other" parallel OPEN_IF that won).
-	if _, err := metaSvc.CreateDirectory(rootAuth, parentHandle, "dup-dir",
+	if _, _, err := metaSvc.CreateDirectory(rootAuth, parentHandle, "dup-dir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -331,7 +331,7 @@ func TestCreate_RaceRecovery_OpenIfNonRootInheritedACLSucceeds(t *testing.T) {
 			},
 		},
 	}
-	parentDir, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "race-inherit",
+	parentDir, _, err := metaSvc.CreateDirectory(rootAuth, rootHandle, "race-inherit",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -362,7 +362,7 @@ func TestCreate_RaceRecovery_OpenIfNonRootInheritedACLSucceeds(t *testing.T) {
 
 	// Pre-seed the winning directory as the requester so it inherits the
 	// parent's ACL granting the requester full access.
-	if _, err := metaSvc.CreateDirectory(requesterAuth, parentHandle, "dup-dir",
+	if _, _, err := metaSvc.CreateDirectory(requesterAuth, parentHandle, "dup-dir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o755,

--- a/internal/adapter/smb/handlers/create_test.go
+++ b/internal/adapter/smb/handlers/create_test.go
@@ -443,7 +443,7 @@ func setupWalkPathTest(t *testing.T) (*Handler, *metadata.AuthContext, metadata.
 	dirAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0755}
 
 	// Create /a
-	dirA, err := metaSvc.CreateDirectory(authCtx, rootHandle, "a", dirAttr)
+	dirA, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "a", dirAttr)
 	if err != nil {
 		t.Fatalf("Failed to create dir 'a': %v", err)
 	}
@@ -453,13 +453,13 @@ func setupWalkPathTest(t *testing.T) (*Handler, *metadata.AuthContext, metadata.
 	if err != nil {
 		t.Fatalf("Failed to encode handle for dir 'a': %v", err)
 	}
-	_, err = metaSvc.CreateDirectory(authCtx, handleA, "b", dirAttr)
+	_, _, err = metaSvc.CreateDirectory(authCtx, handleA, "b", dirAttr)
 	if err != nil {
 		t.Fatalf("Failed to create dir 'b': %v", err)
 	}
 
 	// Create /c
-	_, err = metaSvc.CreateDirectory(authCtx, rootHandle, "c", dirAttr)
+	_, _, err = metaSvc.CreateDirectory(authCtx, rootHandle, "c", dirAttr)
 	if err != nil {
 		t.Fatalf("Failed to create dir 'c': %v", err)
 	}

--- a/internal/adapter/smb/handlers/durable_scavenger.go
+++ b/internal/adapter/smb/handlers/durable_scavenger.go
@@ -166,9 +166,9 @@ func (s *DurableHandleScavenger) cleanupAndDelete(ctx context.Context, h *lock.P
 			systemCtx := metadata.NewSystemAuthContext(ctx)
 			var deleteErr error
 			if h.IsDirectory {
-				deleteErr = metaSvc.RemoveDirectory(systemCtx, h.ParentHandle, h.FileName)
+				_, deleteErr = metaSvc.RemoveDirectory(systemCtx, h.ParentHandle, h.FileName)
 			} else {
-				_, deleteErr = metaSvc.RemoveFile(systemCtx, h.ParentHandle, h.FileName)
+				_, _, deleteErr = metaSvc.RemoveFile(systemCtx, h.ParentHandle, h.FileName)
 			}
 			if deleteErr != nil {
 				logger.Debug("DurableHandleScavenger: delete-on-close failed",

--- a/internal/adapter/smb/handlers/fileid_test.go
+++ b/internal/adapter/smb/handlers/fileid_test.go
@@ -28,7 +28,7 @@ func TestFileID_StableAcrossViews(t *testing.T) {
 	h, authCtx, rootHandle := setupFileIDTest(t)
 	metaSvc := h.Registry.GetMetadataService()
 
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "foo", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "foo", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -115,7 +115,7 @@ func TestFileID_StreamMatchesBase(t *testing.T) {
 	h, authCtx, rootHandle := setupFileIDTest(t)
 	metaSvc := h.Registry.GetMetadataService()
 
-	base, err := metaSvc.CreateFile(authCtx, rootHandle, "foo", &metadata.FileAttr{
+	base, _, err := metaSvc.CreateFile(authCtx, rootHandle, "foo", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -126,7 +126,7 @@ func TestFileID_StreamMatchesBase(t *testing.T) {
 
 	// ADS streams are stored as siblings in the parent directory under names
 	// containing a colon (see internal/adapter/smb/handlers/close.go).
-	stream, err := metaSvc.CreateFile(authCtx, rootHandle, "foo:bar", &metadata.FileAttr{
+	stream, _, err := metaSvc.CreateFile(authCtx, rootHandle, "foo:bar", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -189,12 +189,12 @@ func TestFileID_UniqueAcrossSiblings(t *testing.T) {
 				err error
 			)
 			if kind == metadata.FileTypeDirectory {
-				f, err = metaSvc.CreateDirectory(authCtx, rootHandle, name, &metadata.FileAttr{
+				f, _, err = metaSvc.CreateDirectory(authCtx, rootHandle, name, &metadata.FileAttr{
 					Type: metadata.FileTypeDirectory,
 					Mode: 0o755,
 				})
 			} else {
-				f, err = metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
+				f, _, err = metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
 					Type: metadata.FileTypeRegular,
 					Mode: 0o644,
 				})

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1398,14 +1398,14 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 
 	var deleted bool
 	if openFile.IsDirectory {
-		if err := metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
+		if _, err := metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
 			logger.Debug(caller+": failed to delete directory", "path", openFile.Path, "error", err)
 		} else {
 			logger.Debug(caller+": directory deleted", "path", openFile.Path)
 			deleted = true
 		}
 	} else {
-		removed, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
+		removed, _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
 		if err != nil {
 			logger.Debug(caller+": failed to delete file", "path", openFile.Path, "error", err)
 		} else {

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -533,13 +533,13 @@ func (h *Handler) executeCopyChunks(
 	now := time.Now()
 	// IsAtimeFrozen takes the per-OpenFile read lock; see #606.
 	if !srcOpen.IsAtimeFrozen() {
-		_ = metaSvc.SetFileAttributes(authCtx, srcOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, srcOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 	if !dstOpen.IsAtimeFrozen() {
-		_ = metaSvc.SetFileAttributes(authCtx, dstOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, dstOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 	if len(dstOpen.ParentHandle) > 0 {
-		_ = metaSvc.SetFileAttributes(authCtx, dstOpen.ParentHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, dstOpen.ParentHandle, &metadata.SetAttrs{Atime: &now})
 		h.restoreParentDirFrozenTimestamps(authCtx, dstOpen.ParentHandle)
 	}
 

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -86,7 +86,7 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 	metaSvc := rt.GetMetadataService()
 
 	// --- Source file: create + write 4096 bytes of a non-zero pattern. ---
-	srcFile, err := metaSvc.CreateFile(authCtx, rootHandle, "src", &metadata.FileAttr{
+	srcFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "src", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	})
 	if err != nil {
@@ -121,7 +121,7 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 	}
 
 	// --- Destination file: create 0-byte. ---
-	dstFile, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
+	dstFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	})
 	if err != nil {
@@ -298,7 +298,7 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	metaSvc := rt.GetMetadataService()
 
 	// --- Source file: 4096 bytes of a non-zero pattern. ---
-	srcFile, err := metaSvc.CreateFile(authCtx, rootHandle, "src", &metadata.FileAttr{
+	srcFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "src", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	})
 	if err != nil {
@@ -361,7 +361,7 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	// PayloadID — exactly the reuse the smbtorture battery exercises.
 	openDst := func(fileID [16]byte) (*OpenFile, metadata.FileHandle) {
 		t.Helper()
-		dstFile, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
+		dstFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
 			Type: metadata.FileTypeRegular, Mode: 0o644,
 		})
 		if err != nil {
@@ -509,7 +509,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 	metaSvc := rt.GetMetadataService()
 
 	// Create "a", write a non-zero pattern, then hard-link it as "b".
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "a", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "a", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	})
 	if err != nil {
@@ -540,7 +540,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
-	if err := metaSvc.CreateHardLink(authCtx, rootHandle, "b", handle); err != nil {
+	if _, err := metaSvc.CreateHardLink(authCtx, rootHandle, "b", handle); err != nil {
 		t.Fatalf("CreateHardLink b: %v", err)
 	}
 
@@ -549,7 +549,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 
 	// Delete the "a" link: RemoveFile decrements nlink (2 -> 1) and returns an
 	// empty PayloadID. The purge must therefore NOT touch the block store.
-	removed, err := metaSvc.RemoveFile(authCtx, rootHandle, "a")
+	removed, _, err := metaSvc.RemoveFile(authCtx, rootHandle, "a")
 	if err != nil {
 		t.Fatalf("RemoveFile a: %v", err)
 	}

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -123,7 +123,7 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
 			logger.Warn("FSCTL_SET_COMPRESSION: failed to build auth context", "error", authErr)
-		} else if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+		} else if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
 			Mode: &newMode,
 		}); err != nil {
 			logger.Warn("FSCTL_SET_COMPRESSION: failed to persist mode", "error", err)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -109,7 +109,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		newMode &^= modeDOSSparse
 	}
 	if newMode != file.Mode {
-		if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
 			Mode: &newMode,
 		}); err != nil {
 			logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",

--- a/internal/adapter/smb/handlers/openfile_concurrency_test.go
+++ b/internal/adapter/smb/handlers/openfile_concurrency_test.go
@@ -57,7 +57,7 @@ func setupConcurrentDirTest(t *testing.T, nChildren int) (*Handler, *OpenFile, *
 	}
 	metaSvc := rt.GetMetadataService()
 	for i := 0; i < nChildren; i++ {
-		if _, err := metaSvc.CreateFile(authCtx, rootHandle, fmt.Sprintf("f%03d", i), &metadata.FileAttr{
+		if _, _, err := metaSvc.CreateFile(authCtx, rootHandle, fmt.Sprintf("f%03d", i), &metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o644,
 		}); err != nil {

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -558,7 +558,7 @@ doneLoop:
 	// LastAccessTime to the current system time, unless frozen via SET_INFO -1.
 	if !openFile.AtimeFrozen {
 		now := time.Now()
-		_ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 
 	logger.Debug("QUERY_DIRECTORY successful",

--- a/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
+++ b/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
@@ -201,7 +201,7 @@ func TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask(t *testin
 			// subdirectory, `testfile` is the regular file inside it whose
 			// SD we will set. Enumeration is then on the BASEDIR.
 			metaSvc := rt.GetMetadataService()
-			baseDir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "smb2-testsd",
+			baseDir, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "smb2-testsd",
 				&metadata.FileAttr{
 					Mode: 0o755,
 				})
@@ -213,7 +213,7 @@ func TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask(t *testin
 				t.Fatalf("EncodeFileHandle (BASEDIR): %v", err)
 			}
 
-			child, err := metaSvc.CreateFile(authCtx, baseDirHandle, "testfile",
+			child, _, err := metaSvc.CreateFile(authCtx, baseDirHandle, "testfile",
 				&metadata.FileAttr{
 					Type: metadata.FileTypeRegular,
 					Mode: 0o644,

--- a/internal/adapter/smb/handlers/query_directory_test.go
+++ b/internal/adapter/smb/handlers/query_directory_test.go
@@ -95,7 +95,7 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 	}
 	metaSvc := rt.GetMetadataService()
 	for _, c := range children {
-		childFile, err := metaSvc.CreateFile(rootAuth, rootHandle, c.name, &metadata.FileAttr{
+		childFile, _, err := metaSvc.CreateFile(rootAuth, rootHandle, c.name, &metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: c.mode,
 			UID:  c.uid,
@@ -115,7 +115,7 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 		if err != nil {
 			t.Fatalf("EncodeFileHandle(%q): %v", c.name, err)
 		}
-		if err := metaSvc.SetFileAttributes(rootAuth, childHandle, &metadata.SetAttrs{ACL: c.acl}); err != nil {
+		if _, err := metaSvc.SetFileAttributes(rootAuth, childHandle, &metadata.SetAttrs{ACL: c.acl}); err != nil {
 			t.Fatalf("SetFileAttributes ACL(%q): %v", c.name, err)
 		}
 	}
@@ -314,7 +314,7 @@ func setupQueryDirTest(t *testing.T, names []string) (*Handler, *OpenFile, *meta
 
 	metaSvc := rt.GetMetadataService()
 	for _, name := range names {
-		_, err := metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
+		_, _, err := metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o644,
 		})
@@ -499,10 +499,10 @@ func TestQueryDirectory_ConcurrentModify_NoPanic(t *testing.T) {
 	}
 
 	// Delete "c", add "z".
-	if _, err := metaSvc.RemoveFile(authCtx, open.MetadataHandle, "c"); err != nil {
+	if _, _, err := metaSvc.RemoveFile(authCtx, open.MetadataHandle, "c"); err != nil {
 		t.Fatalf("RemoveFile c: %v", err)
 	}
-	if _, err := metaSvc.CreateFile(authCtx, open.MetadataHandle, "z",
+	if _, _, err := metaSvc.CreateFile(authCtx, open.MetadataHandle, "z",
 		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}); err != nil {
 		t.Fatalf("CreateFile z: %v", err)
 	}

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -411,7 +411,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// against a concurrent SET_INFO freeze/thaw on the same handle (#606).
 	if !openFile.IsAtimeFrozen() {
 		now := time.Now()
-		_ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 
 	// ========================================================================

--- a/internal/adapter/smb/handlers/reopen2_e2e_test.go
+++ b/internal/adapter/smb/handlers/reopen2_e2e_test.go
@@ -61,7 +61,7 @@ func setupReopen2Env(t *testing.T) *reopen2Env {
 	metaSvc := rt.GetMetadataService()
 
 	// Create the file that the durable handle will reference.
-	_, err := metaSvc.CreateFile(rootAuth, rootHandle, "durable.txt", &metadata.FileAttr{
+	_, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "durable.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})

--- a/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
+++ b/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
@@ -96,7 +96,7 @@ func setupTeardownLeakEnv(t *testing.T) *teardownLeakEnv {
 // makeFile creates a regular file in the share root and returns its handle.
 func (e *teardownLeakEnv) makeFile(t *testing.T, name string) ([]byte, *metadata.File) {
 	t.Helper()
-	if _, err := e.metaSvc.CreateFile(e.rootAuth, e.root, name, &metadata.FileAttr{
+	if _, _, err := e.metaSvc.CreateFile(e.rootAuth, e.root, name, &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	}); err != nil {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -472,7 +472,7 @@ func (h *Handler) setFileInfoFromStore(
 			setAttrs.Mtime = &now
 		}
 
-		if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
+		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			openFile.mu.Unlock() // release before returning; refs #606.
 			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
@@ -533,7 +533,7 @@ func (h *Handler) setFileInfoFromStore(
 					basePropagate.Atime != nil || basePropagate.CreationTime != nil ||
 					basePropagate.Mode != nil || basePropagate.Hidden != nil {
 					if baseHandle, encErr := metadata.EncodeFileHandle(baseFile); encErr == nil {
-						_ = metaSvc.SetFileAttributes(authCtx, baseHandle, basePropagate)
+						_, _ = metaSvc.SetFileAttributes(authCtx, baseHandle, basePropagate)
 					}
 				}
 			}
@@ -729,7 +729,7 @@ func (h *Handler) setFileInfoFromStore(
 
 			// Perform the rename
 			metaSvc := h.Registry.GetMetadataService()
-			err = metaSvc.Move(authCtx, toDir, openFile.FileName, toDir, toName)
+			_, err = metaSvc.Move(authCtx, toDir, openFile.FileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
 					"from", openFile.FileName,
@@ -1052,7 +1052,7 @@ func (h *Handler) setFileInfoFromStore(
 		// sibling entry. Remove the matched-case destination upfront so Move
 		// inserts the source under the client-requested casing.
 		if isOverwrite && dstMatchedName != "" && dstMatchedName != toName {
-			if _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName); rmErr != nil {
+			if _, _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName); rmErr != nil {
 				logger.Debug("SET_INFO: rename overwrite pre-remove failed",
 					"name", dstMatchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
@@ -1060,7 +1060,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Perform the rename/move
-		err = metaSvc.Move(authCtx, openFile.ParentHandle, openFile.FileName, toDir, toName)
+		_, err = metaSvc.Move(authCtx, openFile.ParentHandle, openFile.FileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
 				"from", openFile.Path,
@@ -1299,7 +1299,7 @@ func (h *Handler) setFileInfoFromStore(
 			Size: &newSize,
 		}
 
-		err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
+		_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 		if err != nil {
 			logger.Debug("SET_INFO: failed to set EOF", "path", openFile.Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
@@ -1378,7 +1378,7 @@ func (h *Handler) setFileInfoFromStore(
 				metaSvc := h.Registry.GetMetadataService()
 				if curFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil &&
 					requested < curFile.Size {
-					if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+					if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
 						Size: &requested,
 					}); err != nil {
 						logger.Debug("SET_INFO: allocation-driven truncate failed",
@@ -1462,7 +1462,7 @@ func (h *Handler) setFileInfoFromStore(
 		// layer resolves them so casing round-trips.
 		metaSvc := h.Registry.GetMetadataService()
 		setAttrs := &metadata.SetAttrs{EAMutations: eaMutationsFromEntries(entries)}
-		if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
+		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			logger.Debug("SET_INFO: FileFullEaInformation persist failed",
 				"path", openFile.Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
@@ -1519,7 +1519,7 @@ func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.
 	mtime := file.Mtime
 	ctime := file.Ctime
 	return func() {
-		_ = metaSvc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{
+		_, _ = metaSvc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{
 			Mtime: &mtime,
 			Ctime: &ctime,
 		})
@@ -1571,7 +1571,7 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 		"frozenAtime", frozenAtime)
 
 	metaSvc := h.Registry.GetMetadataService()
-	if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
 		logger.Debug("restoreFrozenTimestamps: failed", "path", openFile.Path, "error", err)
 		return
 	}
@@ -1615,7 +1615,7 @@ func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext
 		}
 
 		metaSvc := h.Registry.GetMetadataService()
-		if err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
+		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
 			logger.Debug("restoreParentDirFrozenTimestamps: failed",
 				"path", openFile.Path, "error", err)
 		} else {
@@ -1779,7 +1779,7 @@ func (h *Handler) setSecurityInfo(
 	}
 
 	metaSvc := h.Registry.GetMetadataService()
-	err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
+	_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 	if err != nil {
 		logger.Debug("SET_INFO: failed to set security info", "path", openFile.Path, "error", err)
 		return setInfoStatus(common.MapToSMB(err)), nil
@@ -2074,7 +2074,7 @@ func (h *Handler) handleFileLinkInformation(
 	metaSvc := h.Registry.GetMetadataService()
 	if linkInfo.ReplaceIfExists {
 		if existing, matchedName, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
-			if _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName); rmErr != nil {
+			if _, _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName); rmErr != nil {
 				logger.Debug("SET_INFO: hardlink replace failed to remove existing",
 					"name", matchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
@@ -2088,7 +2088,7 @@ func (h *Handler) handleFileLinkInformation(
 	// matching parent dir lease (same-key holder does not get broken).
 	PropagateOpenFileParentLeaseKey(authCtx, openFile)
 
-	if err := metaSvc.CreateHardLink(authCtx, dstDir, linkName, openFile.MetadataHandle); err != nil {
+	if _, err := metaSvc.CreateHardLink(authCtx, dstDir, linkName, openFile.MetadataHandle); err != nil {
 		logger.Debug("SET_INFO: CreateHardLink failed",
 			"src", openFile.Path, "dst", newPath, "error", err)
 		return setInfoStatus(common.MapToSMB(err)), nil

--- a/internal/adapter/smb/handlers/set_info_ads_attrs_test.go
+++ b/internal/adapter/smb/handlers/set_info_ads_attrs_test.go
@@ -70,7 +70,7 @@ func setupADSAttrPropagationTest(t *testing.T, basePOSIXMode uint32) (
 
 	// Base file with the requested POSIX mode plus modeDOSCompressed set so
 	// the test can also assert that bit survives the SET_INFO propagation.
-	baseFile, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt", &metadata.FileAttr{
+	baseFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: basePOSIXMode | modeDOSCompressed,
 	})
@@ -85,7 +85,7 @@ func setupADSAttrPropagationTest(t *testing.T, basePOSIXMode uint32) (
 	// Stream as a sibling entry under the parent directory, mirroring how
 	// the CREATE handler stores ADS — name carries the colon, no special
 	// metadata flag (the colon in the name is the marker).
-	streamFile, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt:s", &metadata.FileAttr{
+	streamFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "base.txt:s", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -200,7 +200,7 @@ func TestSetInfo_ADS_PreservesBaseCompressedBitWithExistingDosBits(t *testing.T)
 	}
 	const extraDOS = modeDOSExplicit | modeDOSSystem
 	seedMode := preBase.Mode | extraDOS
-	if err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{Mode: &seedMode}); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{Mode: &seedMode}); err != nil {
 		t.Fatalf("SetFileAttributes(base seed): %v", err)
 	}
 

--- a/internal/adapter/smb/handlers/set_info_ea_persist_test.go
+++ b/internal/adapter/smb/handlers/set_info_ea_persist_test.go
@@ -46,7 +46,7 @@ func setupEATest(t *testing.T) (*Handler, *metadata.AuthContext, *OpenFile) {
 	}
 
 	metaSvc := rt.GetMetadataService()
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "ea.txt", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "ea.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -122,7 +122,7 @@ func TestSetInfo_EA_SetGetDelete(t *testing.T) {
 
 	// Seed a pre-existing EA the way the CREATE EA buffer context would.
 	metaSvc := h.Registry.GetMetadataService()
-	if err := metaSvc.SetFileAttributes(authCtx, open.MetadataHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, open.MetadataHandle, &metadata.SetAttrs{
 		EAMutations: []metadata.EAMutation{{Name: "EAONE", Value: []byte("one")}},
 	}); err != nil {
 		t.Fatalf("seed EAONE: %v", err)

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -56,7 +56,7 @@ func setupSecurityAuthzTest(t *testing.T) (*Handler, *OpenFile, *metadata.AuthCo
 	}
 
 	metaSvc := rt.GetMetadataService()
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "g.dat", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "g.dat", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})

--- a/internal/adapter/smb/handlers/set_info_security_toggle_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_toggle_test.go
@@ -53,7 +53,7 @@ func setupACLToggleTest(t *testing.T, shareName string, canonicalize bool) (*Han
 	}
 
 	metaSvc := rt.GetMetadataService()
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "f.dat", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "f.dat", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})

--- a/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
@@ -61,7 +61,7 @@ func setupBasicInfoTimestampTest(t *testing.T) (
 	}
 
 	metaSvc := rt.GetMetadataService()
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "ts.txt", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "ts.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})

--- a/internal/adapter/smb/handlers/timestamps_test.go
+++ b/internal/adapter/smb/handlers/timestamps_test.go
@@ -43,7 +43,7 @@ func setupTimestampTest(t *testing.T) (*Handler, *metadata.AuthContext, metadata
 	}
 
 	metaSvc := rt.GetMetadataService()
-	file, err := metaSvc.CreateFile(authCtx, rootHandle, "f.dat", &metadata.FileAttr{
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "f.dat", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -95,7 +95,7 @@ func TestSetFileInfo_FreezeThaw(t *testing.T) {
 
 	// Step 1: explicit set of CreationTime + Mtime to nttime.
 	pinned := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
 		CreationTime: &pinned,
 		Mtime:        &pinned,
 	}); err != nil {
@@ -162,7 +162,7 @@ func TestSetFileInfo_FreezeThaw_AllFields(t *testing.T) {
 	metaSvc := h.Registry.GetMetadataService()
 
 	pinned := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
 		CreationTime: &pinned,
 		Atime:        &pinned,
 		Mtime:        &pinned,
@@ -318,7 +318,7 @@ func TestDelayedWrite_VsSetEOF(t *testing.T) {
 	}
 	preMtime := pre.Mtime
 	time.Sleep(20 * time.Millisecond)
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Size: &zero}); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Size: &zero}); err != nil {
 		t.Fatalf("SetEOF #1: %v", err)
 	}
 	post, err := metaSvc.GetFile(authCtx.Context, fileHandle)
@@ -347,7 +347,7 @@ func TestDelayedWrite_VsSetEOF(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	one := uint64(1)
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Size: &one}); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Size: &one}); err != nil {
 		t.Fatalf("SetEOF #2: %v", err)
 	}
 	postWrite2, err := metaSvc.GetFile(authCtx.Context, fileHandle)
@@ -362,7 +362,7 @@ func TestDelayedWrite_VsSetEOF(t *testing.T) {
 	// SetBasic with explicit future write_time. SetFileAttributes pins
 	// file.Mtime to the explicit value regardless of which handle issues it.
 	setTime := time.Now().UTC().Add(86400 * time.Second).Truncate(time.Microsecond)
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Mtime: &setTime}); err != nil {
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Mtime: &setTime}); err != nil {
 		t.Fatalf("SetBasic h2: %v", err)
 	}
 
@@ -395,7 +395,7 @@ func TestSetFileInfo_DelayedWriteVsSetbasic(t *testing.T) {
 
 	// Simulate a WRITE: drive mtime to a known recent value.
 	writeTime := time.Now().Add(-time.Hour).UTC()
-	if err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{
 		Mtime: &writeTime,
 	}); err != nil {
 		t.Fatalf("seed Mtime: %v", err)
@@ -485,7 +485,7 @@ func TestDirFreezeTimestamps_ChildCreate_AllFrozen(t *testing.T) {
 	metaSvc := rt.GetMetadataService()
 
 	// Step 1: Create a subdirectory.
-	dir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
+	dir, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	})
@@ -499,7 +499,7 @@ func TestDirFreezeTimestamps_ChildCreate_AllFrozen(t *testing.T) {
 
 	// Pin timestamps to a well-known value so assertions are deterministic.
 	pinned := time.Date(2026, 1, 2, 13, 40, 49, 0, time.UTC)
-	if err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
 		CreationTime: &pinned,
 		Mtime:        &pinned,
 		Atime:        &pinned,
@@ -547,7 +547,7 @@ func TestDirFreezeTimestamps_ChildCreate_AllFrozen(t *testing.T) {
 
 	// Step 4: Create a child file -- this updates the directory's
 	// Mtime/Ctime/Atime in the metadata store.
-	if _, createErr := metaSvc.CreateFile(authCtx, dirHandle, "child.dat", &metadata.FileAttr{
+	if _, _, createErr := metaSvc.CreateFile(authCtx, dirHandle, "child.dat", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	}); createErr != nil {
@@ -635,7 +635,7 @@ func TestDirFreezeTimestamps_ChildCreate_WalkPath(t *testing.T) {
 	metaSvc := rt.GetMetadataService()
 
 	// Create subdirectory.
-	dir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
+	dir, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	})
@@ -649,7 +649,7 @@ func TestDirFreezeTimestamps_ChildCreate_WalkPath(t *testing.T) {
 
 	// Pin and freeze all timestamps.
 	pinned := time.Date(2026, 1, 2, 13, 40, 49, 0, time.UTC)
-	if err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
 		CreationTime: &pinned, Mtime: &pinned, Atime: &pinned, Ctime: &pinned,
 	}); err != nil {
 		t.Fatalf("pin: %v", err)
@@ -688,7 +688,7 @@ func TestDirFreezeTimestamps_ChildCreate_WalkPath(t *testing.T) {
 	}
 
 	// Create child and restore (using walked handle as the CREATE handler would).
-	if _, createErr := metaSvc.CreateFile(authCtx, walkedHandle, "child.dat", &metadata.FileAttr{
+	if _, _, createErr := metaSvc.CreateFile(authCtx, walkedHandle, "child.dat", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	}); createErr != nil {
 		t.Fatalf("CreateFile: %v", createErr)
@@ -792,7 +792,7 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 			metaSvc := rt.GetMetadataService()
 
 			// Create subdirectory and pin all timestamps.
-			dir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
+			dir, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "testdir", &metadata.FileAttr{
 				Type: metadata.FileTypeDirectory,
 				Mode: 0o755,
 			})
@@ -804,7 +804,7 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 				t.Fatalf("EncodeFileHandle: %v", err)
 			}
 			pinned := time.Date(2026, 1, 2, 13, 40, 49, 0, time.UTC)
-			if err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
+			if _, err := metaSvc.SetFileAttributes(authCtx, dirHandle, &metadata.SetAttrs{
 				CreationTime: &pinned,
 				Mtime:        &pinned,
 				Atime:        &pinned,
@@ -834,7 +834,7 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 			}
 
 			// Create child file (updates dir Mtime/Ctime/Atime).
-			if _, createErr := metaSvc.CreateFile(authCtx, dirHandle, "child.dat", &metadata.FileAttr{
+			if _, _, createErr := metaSvc.CreateFile(authCtx, dirHandle, "child.dat", &metadata.FileAttr{
 				Type: metadata.FileTypeRegular,
 				Mode: 0o644,
 			}); createErr != nil {
@@ -898,7 +898,7 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 	metaSvc := rt.GetMetadataService()
 
 	// Create the base directory (mirrors WPTS test: directory hosts the ADS).
-	baseDir, err := metaSvc.CreateDirectory(authCtx, rootHandle, "basedir", &metadata.FileAttr{
+	baseDir, _, err := metaSvc.CreateDirectory(authCtx, rootHandle, "basedir", &metadata.FileAttr{
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	})
@@ -912,7 +912,7 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 
 	// Create the ADS as a sibling entry under root (matches CREATE handler's
 	// stream-entry layout: stream `basedir:streamname` is a root child).
-	streamFile, err := metaSvc.CreateFile(authCtx, rootHandle, "basedir:streamname", &metadata.FileAttr{
+	streamFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "basedir:streamname", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 	})
@@ -926,7 +926,7 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 
 	// Pin the base directory's Ctime to a known value.
 	pinned := time.Date(2026, 1, 2, 13, 40, 49, 0, time.UTC)
-	if err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{
+	if _, err := metaSvc.SetFileAttributes(authCtx, baseHandle, &metadata.SetAttrs{
 		Ctime: &pinned, Mtime: &pinned, CreationTime: &pinned, Atime: &pinned,
 	}); err != nil {
 		t.Fatalf("pin base: %v", err)

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -454,10 +454,10 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	now := time.Now()
 	// IsAtimeFrozen takes openFile.mu (read); see #606.
 	if !openFile.IsAtimeFrozen() {
-		_ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
 	if len(openFile.ParentHandle) > 0 {
-		_ = metaSvc.SetFileAttributes(authCtx, openFile.ParentHandle, &metadata.SetAttrs{Atime: &now})
+		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.ParentHandle, &metadata.SetAttrs{Atime: &now})
 		// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on the parent directory
 		// if any open handle has them frozen. The SetFileAttributes call above
 		// unconditionally updates atime; if a handle has atime frozen, restore it.

--- a/pkg/controlplane/runtime/trash/reaper_test.go
+++ b/pkg/controlplane/runtime/trash/reaper_test.go
@@ -20,7 +20,7 @@ import (
 // eviction test can assert on it deterministically.
 func (tt *trashTest) recycleSized(name string, size uint64) {
 	tt.t.Helper()
-	_, err := tt.deps.svc.CreateFile(tt.ctx, tt.deps.rootHandle, name, &metadata.FileAttr{Mode: 0o644})
+	_, _, err := tt.deps.svc.CreateFile(tt.ctx, tt.deps.rootHandle, name, &metadata.FileAttr{Mode: 0o644})
 	require.NoError(tt.t, err)
 
 	store, err := tt.deps.svc.GetStoreForShare(tt.deps.shareName)
@@ -32,7 +32,7 @@ func (tt *trashTest) recycleSized(name string, size uint64) {
 	file.Size = size
 	require.NoError(tt.t, store.PutFile(tt.ctx.Context, file))
 
-	_, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, name)
+	_, _, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, name)
 	require.NoError(tt.t, err)
 }
 

--- a/pkg/controlplane/runtime/trash/service.go
+++ b/pkg/controlplane/runtime/trash/service.go
@@ -320,7 +320,7 @@ func (s *Service) Restore(ctx *metadata.AuthContext, shareName, binPath, dest st
 	}
 
 	// Move the entry out of the bin, then clear its deletion stamp in place.
-	if err := svc.Move(ctx, binSrcParent, binSrcName, destParent, destName); err != nil {
+	if _, err := svc.Move(ctx, binSrcParent, binSrcName, destParent, destName); err != nil {
 		return err
 	}
 	return clearStamp(ctx, svc, shareName, destParent, destName)
@@ -426,7 +426,8 @@ func (s *Service) OnDisable(ctx *metadata.AuthContext, shareName string) error {
 
 	// Empty left the bin logically empty; remove the now-empty #recycle root.
 	// A surviving non-empty / other error is surfaced, not swallowed.
-	return svc.RemoveDirectory(ctx, root, metadata.RecycleDirName)
+	_, err = svc.RemoveDirectory(ctx, root, metadata.RecycleDirName)
+	return err
 }
 
 // pruneEmptyDirs removes now-empty intermediary directories under dirHandle
@@ -461,7 +462,7 @@ func (s *Service) pruneEmptyDirs(ctx *metadata.AuthContext, svc *metadata.Metada
 			return err
 		}
 		// Attempt removal; a non-empty or already-gone directory is fine.
-		if err := svc.RemoveDirectory(ctx, dirHandle, e.Name); err != nil &&
+		if _, err := svc.RemoveDirectory(ctx, dirHandle, e.Name); err != nil &&
 			!metadata.IsNotFoundError(err) && !isNotEmpty(err) {
 			return err
 		}
@@ -495,10 +496,11 @@ func (s *Service) purgeEntry(ctx *metadata.AuthContext, svc *metadata.MetadataSe
 		if err := s.purgeChildren(ctx, svc, shareName, root, handle); err != nil {
 			return err
 		}
-		return svc.RemoveDirectory(ctx, parent, name)
+		_, err := svc.RemoveDirectory(ctx, parent, name)
+		return err
 	}
 
-	removed, err := svc.RemoveFile(ctx, parent, name)
+	removed, _, err := svc.RemoveFile(ctx, parent, name)
 	if err != nil {
 		return err
 	}
@@ -569,7 +571,7 @@ func ensureParent(ctx *metadata.AuthContext, svc *metadata.MetadataService, root
 			if !metadata.IsNotFoundError(err) {
 				return nil, "", err
 			}
-			created, cErr := svc.CreateDirectory(ctx, parent, dir, &metadata.FileAttr{
+			created, _, cErr := svc.CreateDirectory(ctx, parent, dir, &metadata.FileAttr{
 				Type: metadata.FileTypeDirectory,
 				Mode: 0o755,
 			})

--- a/pkg/controlplane/runtime/trash/service_test.go
+++ b/pkg/controlplane/runtime/trash/service_test.go
@@ -137,7 +137,7 @@ func rootAuthContext() *metadata.AuthContext {
 // createFile creates a regular file under parent.
 func (tt *trashTest) createFile(parent metadata.FileHandle, name string) metadata.FileHandle {
 	tt.t.Helper()
-	_, err := tt.deps.svc.CreateFile(tt.ctx, parent, name, &metadata.FileAttr{Mode: 0o644})
+	_, _, err := tt.deps.svc.CreateFile(tt.ctx, parent, name, &metadata.FileAttr{Mode: 0o644})
 	require.NoError(tt.t, err)
 	h, err := tt.deps.svc.GetChild(tt.ctx.Context, parent, name)
 	require.NoError(tt.t, err)
@@ -147,7 +147,7 @@ func (tt *trashTest) createFile(parent metadata.FileHandle, name string) metadat
 // mkdir creates a directory under parent and returns its handle.
 func (tt *trashTest) mkdir(parent metadata.FileHandle, name string) metadata.FileHandle {
 	tt.t.Helper()
-	dir, err := tt.deps.svc.CreateDirectory(tt.ctx, parent, name, &metadata.FileAttr{Mode: 0o755})
+	dir, _, err := tt.deps.svc.CreateDirectory(tt.ctx, parent, name, &metadata.FileAttr{Mode: 0o755})
 	require.NoError(tt.t, err)
 	h, err := metadata.EncodeFileHandle(dir)
 	require.NoError(tt.t, err)
@@ -159,7 +159,7 @@ func (tt *trashTest) mkdir(parent metadata.FileHandle, name string) metadata.Fil
 func (tt *trashTest) recycle(name string) {
 	tt.t.Helper()
 	tt.createFile(tt.deps.rootHandle, name)
-	_, err := tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, name)
+	_, _, err := tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, name)
 	require.NoError(tt.t, err)
 }
 
@@ -177,7 +177,7 @@ func (tt *trashTest) recycleAt(dir, name string) {
 		}
 	}
 	tt.createFile(parent, name)
-	_, err := tt.deps.svc.RemoveFile(tt.ctx, parent, name)
+	_, _, err := tt.deps.svc.RemoveFile(tt.ctx, parent, name)
 	require.NoError(tt.t, err)
 }
 
@@ -249,7 +249,8 @@ func TestListReturnsRecycledRoots(t *testing.T) {
 	// A non-empty directory subtree recycles as ONE entry.
 	dir := tt.mkdir(tt.deps.rootHandle, "docs")
 	tt.createFile(dir, "inner.txt")
-	require.NoError(t, tt.deps.svc.RemoveDirectory(tt.ctx, tt.deps.rootHandle, "docs"))
+	_, rmErr := tt.deps.svc.RemoveDirectory(tt.ctx, tt.deps.rootHandle, "docs")
+	require.NoError(t, rmErr)
 
 	entries, err := tt.svc.List(tt.ctx, tt.deps.shareName)
 	require.NoError(t, err)
@@ -318,7 +319,7 @@ func TestEmptyThreadsBlocksToFreeBlocks(t *testing.T) {
 	require.NoError(t, store.PutFile(tt.ctx.Context, file))
 
 	// Recycle it, then empty the bin.
-	_, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, "withblocks.txt")
+	_, _, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, "withblocks.txt")
 	require.NoError(t, err)
 	n, err := tt.svc.Empty(tt.ctx, tt.deps.shareName, false)
 	require.NoError(t, err)

--- a/pkg/controlplane/runtime/trash_integration_test.go
+++ b/pkg/controlplane/runtime/trash_integration_test.go
@@ -63,7 +63,7 @@ func TestRuntimeTrash_RecycleListEmpty_EndToEnd(t *testing.T) {
 	// RemoveFile through the metadata service: the installed TrashPolicy must
 	// RECYCLE (not destroy). The returned File carries an empty PayloadID
 	// because the content was moved, not deleted.
-	removed, err := svc.RemoveFile(actx, root, fileName)
+	removed, _, err := svc.RemoveFile(actx, root, fileName)
 	if err != nil {
 		t.Fatalf("RemoveFile (recycle): %v", err)
 	}

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -36,7 +36,7 @@ func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -87,7 +87,7 @@ func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "allow_only.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "allow_only.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o755,

--- a/pkg/metadata/auth_permissions_bypass_traverse_test.go
+++ b/pkg/metadata/auth_permissions_bypass_traverse_test.go
@@ -33,7 +33,7 @@ func TestLookup_BypassTraverseChecking_GrantsAccess(t *testing.T) {
 	// restrict the parent's DACL so callers without bypass cannot traverse.
 	rootCtx := fx.rootContext()
 	rootCtx.BypassTraverseChecking = true
-	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "restricted", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "restricted", &metadata.FileAttr{
 		Mode: 0700,
 		UID:  1000,
 		GID:  1000,
@@ -43,7 +43,7 @@ func TestLookup_BypassTraverseChecking_GrantsAccess(t *testing.T) {
 	subHandle, err := fx.store.GetChild(ctx, fx.rootHandle, "restricted")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateFile(rootCtx, subHandle, "child.txt", &metadata.FileAttr{
+	_, _, err = fx.service.CreateFile(rootCtx, subHandle, "child.txt", &metadata.FileAttr{
 		Mode: 0644,
 		UID:  1000,
 		GID:  1000,
@@ -62,7 +62,7 @@ func TestLookup_BypassTraverseChecking_GrantsAccess(t *testing.T) {
 			},
 		},
 	}
-	err = fx.service.SetFileAttributes(rootCtx, subHandle, &metadata.SetAttrs{
+	_, err = fx.service.SetFileAttributes(rootCtx, subHandle, &metadata.SetAttrs{
 		ACL: restrictedACL,
 	})
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestLookup_BypassTraverseChecking_NFSStrict(t *testing.T) {
 
 	rootCtx := fx.rootContext()
 	rootCtx.BypassTraverseChecking = true
-	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "nfs-dir", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "nfs-dir", &metadata.FileAttr{
 		Mode: 0700,
 		UID:  1000,
 		GID:  1000,
@@ -110,7 +110,7 @@ func TestLookup_BypassTraverseChecking_NFSStrict(t *testing.T) {
 	subHandle, err := fx.store.GetChild(ctx, fx.rootHandle, "nfs-dir")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateFile(rootCtx, subHandle, "file", &metadata.FileAttr{
+	_, _, err = fx.service.CreateFile(rootCtx, subHandle, "file", &metadata.FileAttr{
 		Mode: 0644,
 		UID:  1000,
 		GID:  1000,

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -63,7 +63,7 @@ func TestCheckFileAccess_DenyACEOnOwnerDeniesWrite(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "owner_denied.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "owner_denied.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -102,7 +102,7 @@ func TestCheckFileAccess_AllowOnlyReadGrantsReadDeniesWrite(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -151,7 +151,7 @@ func TestCheckFileAccess_MaximumAllowedAloneNeverDenies(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -199,7 +199,7 @@ func TestCheckFileAccess_MaximumAllowedPlusExplicitDeniedBitDenies(t *testing.T)
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "mxac.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "mxac.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -235,7 +235,7 @@ func TestCheckFileAccess_RootBypassGetsEverything(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "root_only.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "root_only.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o000,
@@ -261,7 +261,7 @@ func TestCheckFileAccess_NilACLOwnerGrantsRequested(t *testing.T) {
 	f := newTestFixture(t)
 
 	ownerUID := uint32(1001)
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o600,
@@ -288,7 +288,7 @@ func TestCheckFileAccess_NilACLOwnerGrantsRequested(t *testing.T) {
 func TestCheckFileAccess_NilACLNonOwnerGrantsRequested(t *testing.T) {
 	f := newTestFixture(t)
 
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix_owner_only.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "posix_owner_only.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o600,
@@ -322,7 +322,7 @@ func TestCheckFileAccess_NilACLMaxAllowedReturnsGenericAll(t *testing.T) {
 	f := newTestFixture(t)
 
 	ownerUID := uint32(1001)
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max_nil_acl.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "max_nil_acl.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o600,
@@ -344,7 +344,7 @@ func TestCheckFileAccess_NilACLMaxAllowedReturnsGenericAll(t *testing.T) {
 // shape (e.g., probing existence or paired solely with MAXIMUM_ALLOWED).
 func TestCheckFileAccess_ZeroDesiredAccessIsNoop(t *testing.T) {
 	f := newTestFixture(t)
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "empty.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "empty.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o644,
@@ -373,7 +373,7 @@ func TestCheckFileAccess_DenyErrorIsStoreError(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "denied.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,
@@ -420,7 +420,7 @@ func TestCheckFileAccessWithParent_DeleteOverrideViaParentDeleteChild(t *testing
 			},
 		},
 	}
-	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deldir",
+	parentCreated, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deldir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o755,
@@ -488,7 +488,7 @@ func TestCheckFileAccessWithParent_OverrideDoesNotApplyToNonDeleteBits(t *testin
 			},
 		},
 	}
-	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "broadparent",
+	parentCreated, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "broadparent",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o755,
@@ -543,7 +543,7 @@ func TestCheckFileAccessWithParent_NullParentDACLGrantsDelete(t *testing.T) {
 	requesterSID := "S-1-5-21-1-2-3-2001"
 
 	// Parent: created with no explicit ACL → parent.ACL is nil.
-	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "nullacldir",
+	parentCreated, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "nullacldir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o755,
@@ -601,7 +601,7 @@ func TestCheckFileAccessWithParent_NoOverrideWhenParentLacksDeleteChild(t *testi
 			},
 		},
 	}
-	parentCreated, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "lockedparent",
+	parentCreated, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "lockedparent",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o755,
@@ -669,7 +669,7 @@ func TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent(t *testing.T) {
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "raa.txt",
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "raa.txt",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o644,
@@ -720,7 +720,7 @@ func createSpecificRightsFile(t *testing.T, f *testFixture, name, sid string, ma
 			},
 		},
 	}
-	created, err := f.service.CreateFile(f.rootContext(), f.rootHandle, name,
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, name,
 		&metadata.FileAttr{
 			Type: metadata.FileTypeRegular,
 			Mode: 0o777,

--- a/pkg/metadata/auth_permissions_parent_check_test.go
+++ b/pkg/metadata/auth_permissions_parent_check_test.go
@@ -36,7 +36,7 @@ func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
 			},
 		},
 	}
-	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "denied-dir",
+	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "denied-dir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -102,7 +102,7 @@ func TestCheckParentCreateAccess_DenyAddFileBlocksFileAllowsDir(t *testing.T) {
 			},
 		},
 	}
-	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-file",
+	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-file",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,
@@ -160,7 +160,7 @@ func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) 
 			},
 		},
 	}
-	dir, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-subdir",
+	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "deny-add-subdir",
 		&metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,

--- a/pkg/metadata/cross_protocol_unlock_wakeup_test.go
+++ b/pkg/metadata/cross_protocol_unlock_wakeup_test.go
@@ -64,7 +64,7 @@ func TestSetByteRangeReleaseHook_FiresOnSMBUnlock(t *testing.T) {
 		ClientAddr: "127.0.0.1",
 	}
 
-	file, err := svc.CreateFile(authCtx, rootHandle, "locked.bin", &metadata.FileAttr{Mode: 0o644})
+	file, _, err := svc.CreateFile(authCtx, rootHandle, "locked.bin", &metadata.FileAttr{Mode: 0o644})
 	require.NoError(t, err)
 	handle, err := metadata.EncodeFileHandle(file)
 	require.NoError(t, err)

--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -112,27 +112,29 @@ func (s *MetadataService) ReadDirectory(ctx *AuthContext, dirHandle FileHandle, 
 	}, nil
 }
 
-// RemoveDirectory removes an empty directory from its parent.
-func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, name string) error {
+// RemoveDirectory removes an empty directory from its parent. The returned
+// DirWcc carries the parent directory's pre/post attributes captured atomically
+// with the mutation for protocol weak-cache-consistency data (H9).
+func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, name string) (*DirWcc, error) {
 	store, err := s.storeForHandle(parentHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Validate name
 	if err := ValidateName(name); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get parent entry
 	parent, err := store.GetFile(ctx.Context, parentHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Verify parent is a directory
 	if parent.Type != FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "parent is not a directory",
 			Path:    parent.Path,
@@ -142,18 +144,18 @@ func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHan
 	// Get child handle
 	dirHandle, err := store.GetChild(ctx.Context, parentHandle, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get directory entry
 	dir, err := store.GetFile(ctx.Context, dirHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Verify it's a directory
 	if dir.Type != FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "not a directory",
 			Path:    name,
@@ -162,12 +164,12 @@ func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHan
 
 	// Check delete permission: WRITE on parent (POSIX) or owner-of-dir (Windows DELETE).
 	if err := s.checkDeletePermission(ctx, parentHandle, dir); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check sticky bit restriction
 	if err := CheckStickyBitRestriction(ctx, &parent.FileAttr, &dir.FileAttr); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Recycle instead of destroying when the share has trash enabled. A
@@ -179,11 +181,17 @@ func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHan
 		if cfg, ok := s.trashPolicy.TrashConfigForShare(shareName); ok && cfg.Enabled {
 			origRel := strings.TrimPrefix(buildPath(parent.Path, name), "/")
 			if !inRecycle(origRel) && !cfg.Excluded(name) {
+				// Best-effort pre/post WCC around the recycle Move (rare path).
+				wccBefore := CopyFileAttr(&parent.FileAttr)
 				if _, rErr := s.recycleNode(ctx, shareName, parentHandle, name, origRel); rErr != nil {
-					return rErr
+					return nil, rErr
+				}
+				wcc := &DirWcc{Before: wccBefore}
+				if after, aErr := store.GetFile(ctx.Context, parentHandle); aErr == nil {
+					wcc.After = CopyFileAttr(&after.FileAttr)
 				}
 				s.notifyDirChange(shareName, parentHandle, lock.DirChangeRemoveEntry, ctx)
-				return nil
+				return wcc, nil
 			}
 		}
 	}
@@ -191,15 +199,26 @@ func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHan
 	// Check if directory is empty
 	entries, _, err := store.ListChildren(ctx.Context, dirHandle, "", 1)
 	if err == nil && len(entries) > 0 {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotEmpty,
 			Message: "directory not empty",
 			Path:    name,
 		}
 	}
 
+	// wcc brackets the parent attributes around the mutation, captured inside
+	// the transaction below (H9).
+	wcc := &DirWcc{}
+
 	// Execute all write operations in a single transaction for better performance.
 	txErr := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-read the parent inside the transaction so the pre-op snapshot and
+		// the timestamp mutation derive from the same committed state.
+		if txParent, pErr := tx.GetFile(ctx.Context, parentHandle); pErr == nil && txParent != nil {
+			parent = txParent
+		}
+		wcc.Before = CopyFileAttr(&parent.FileAttr)
+
 		// Remove directory entry
 		if err := tx.DeleteFile(ctx.Context, dirHandle); err != nil {
 			return err
@@ -223,23 +242,25 @@ func (s *MetadataService) RemoveDirectory(ctx *AuthContext, parentHandle FileHan
 		parent.Mtime = now
 		parent.Ctime = now
 		parent.Atime = now
+		wcc.After = CopyFileAttr(&parent.FileAttr)
 		return tx.PutFile(ctx.Context, parent)
 	})
 
 	if txErr != nil {
-		return txErr
+		return nil, txErr
 	}
 
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeRemoveEntry, ctx)
-	return nil
+	return wcc, nil
 }
 
-// CreateDirectory creates a new directory in a parent directory.
-func (s *MetadataService) CreateDirectory(ctx *AuthContext, parentHandle FileHandle, name string, attr *FileAttr) (*File, error) {
-	file, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeDirectory, "", 0, 0)
+// CreateDirectory creates a new directory in a parent directory. The returned
+// DirWcc carries the parent's pre/post attributes captured atomically (H9).
+func (s *MetadataService) CreateDirectory(ctx *AuthContext, parentHandle FileHandle, name string, attr *FileAttr) (*File, *DirWcc, error) {
+	file, wcc, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeDirectory, "", 0, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeAddEntry, ctx)
-	return file, nil
+	return file, wcc, nil
 }

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -7,72 +7,79 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// CreateFile creates a new regular file in a directory.
-func (s *MetadataService) CreateFile(ctx *AuthContext, parentHandle FileHandle, name string, attr *FileAttr) (*File, error) {
-	file, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeRegular, "", 0, 0)
+// CreateFile creates a new regular file in a directory. The returned DirWcc
+// carries the parent's pre/post attributes captured atomically with the create
+// (H9).
+func (s *MetadataService) CreateFile(ctx *AuthContext, parentHandle FileHandle, name string, attr *FileAttr) (*File, *DirWcc, error) {
+	file, wcc, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeRegular, "", 0, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeAddEntry, ctx)
-	return file, nil
+	return file, wcc, nil
 }
 
-// CreateSymlink creates a new symbolic link in a directory.
-func (s *MetadataService) CreateSymlink(ctx *AuthContext, parentHandle FileHandle, name string, target string, attr *FileAttr) (*File, error) {
+// CreateSymlink creates a new symbolic link in a directory. The returned DirWcc
+// carries the parent's pre/post attributes captured atomically (H9).
+func (s *MetadataService) CreateSymlink(ctx *AuthContext, parentHandle FileHandle, name string, target string, attr *FileAttr) (*File, *DirWcc, error) {
 	// Validate symlink target
 	if err := ValidateSymlinkTarget(target); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	file, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeSymlink, target, 0, 0)
+	file, wcc, err := s.createEntry(ctx, parentHandle, name, attr, FileTypeSymlink, target, 0, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeAddEntry, ctx)
-	return file, nil
+	return file, wcc, nil
 }
 
-// CreateSpecialFile creates a special file (device, socket, or FIFO).
-func (s *MetadataService) CreateSpecialFile(ctx *AuthContext, parentHandle FileHandle, name string, fileType FileType, attr *FileAttr, deviceMajor, deviceMinor uint32) (*File, error) {
+// CreateSpecialFile creates a special file (device, socket, or FIFO). The
+// returned DirWcc carries the parent's pre/post attributes captured
+// atomically (H9).
+func (s *MetadataService) CreateSpecialFile(ctx *AuthContext, parentHandle FileHandle, name string, fileType FileType, attr *FileAttr, deviceMajor, deviceMinor uint32) (*File, *DirWcc, error) {
 	// Validate special file type
 	if err := ValidateSpecialFileType(fileType); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check if user is root (required for device files)
 	if fileType == FileTypeBlockDevice || fileType == FileTypeCharDevice {
 		if err := RequiresRoot(ctx); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	file, err := s.createEntry(ctx, parentHandle, name, attr, fileType, "", deviceMajor, deviceMinor)
+	file, wcc, err := s.createEntry(ctx, parentHandle, name, attr, fileType, "", deviceMajor, deviceMinor)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeAddEntry, ctx)
-	return file, nil
+	return file, wcc, nil
 }
 
-// CreateHardLink creates a hard link to an existing file.
-func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name string, targetHandle FileHandle) error {
+// CreateHardLink creates a hard link to an existing file. The returned DirWcc
+// carries the link directory's pre/post attributes captured atomically with the
+// mutation (H9).
+func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name string, targetHandle FileHandle) (*DirWcc, error) {
 	store, err := s.storeForHandle(dirHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Validate name
 	if err := ValidateName(name); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get directory entry
 	dir, err := store.GetFile(ctx.Context, dirHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if dir.Type != FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "not a directory",
 		}
@@ -81,23 +88,23 @@ func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle,
 	// Validate full path length (POSIX PATH_MAX compliance)
 	fullPath := buildPath(dir.Path, name)
 	if err := ValidatePath(fullPath); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check write permission on directory
 	if err := s.checkWritePermission(ctx, dirHandle); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get target file
 	target, err := store.GetFile(ctx.Context, targetHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Cannot hard link directories
 	if target.Type == FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrIsDirectory,
 			Message: "cannot create hard link to directory",
 		}
@@ -106,18 +113,29 @@ func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle,
 	// Check if name already exists
 	_, err = store.GetChild(ctx.Context, dirHandle, name)
 	if err == nil {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrAlreadyExists,
 			Message: "file already exists",
 			Path:    name,
 		}
 	}
 	if !IsNotFoundError(err) {
-		return err
+		return nil, err
 	}
+
+	// wcc brackets the link directory attributes around the mutation, both
+	// captured inside the transaction below (H9).
+	wcc := &DirWcc{}
 
 	// Execute all write operations in a single transaction for better performance.
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-read the directory inside the transaction so the pre-op snapshot and
+		// the timestamp mutation derive from the same committed state.
+		if txDir, dErr := tx.GetFile(ctx.Context, dirHandle); dErr == nil && txDir != nil {
+			dir = txDir
+		}
+		wcc.Before = CopyFileAttr(&dir.FileAttr)
+
 		// Re-check existence inside the transaction to close the TOCTOU race
 		// between the outer GetChild and this SetChild (same pattern as
 		// createEntry).
@@ -149,14 +167,15 @@ func (s *MetadataService) CreateHardLink(ctx *AuthContext, dirHandle FileHandle,
 
 		dir.Mtime = now
 		dir.Ctime = now
+		wcc.After = CopyFileAttr(&dir.FileAttr)
 		return tx.PutFile(ctx.Context, dir)
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.notifyDirChange(shareNameForHandle(dirHandle), dirHandle, lock.DirChangeAddEntry, ctx)
-	return nil
+	return wcc, nil
 }
 
 // createEntry is the internal implementation for creating files, directories, symlinks, and special files.
@@ -168,26 +187,26 @@ func (s *MetadataService) createEntry(
 	fileType FileType,
 	linkTarget string,
 	deviceMajor, deviceMinor uint32,
-) (*File, error) {
+) (*File, *DirWcc, error) {
 	store, err := s.storeForHandle(parentHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate name
 	if err := ValidateName(name); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Get parent entry
 	parent, err := store.GetFile(ctx.Context, parentHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Verify parent is a directory
 	if parent.Type != FileTypeDirectory {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "parent is not a directory",
 			Path:    parent.Path,
@@ -197,7 +216,7 @@ func (s *MetadataService) createEntry(
 	// Validate full path length (POSIX PATH_MAX compliance)
 	fullPath := buildPath(parent.Path, name)
 	if err := ValidatePath(fullPath); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check create permission on parent. Use the precise NFSv4 mask for the
@@ -205,13 +224,13 @@ func (s *MetadataService) createEntry(
 	// denies only one variant does not also block the other — required by
 	// MS-FSA 2.1.5.1.1 and smbtorture smb2.create.mkdir-visible.
 	if err := s.CheckParentCreateAccess(ctx, parentHandle, fileType == FileTypeDirectory); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check if name already exists
 	_, err = store.GetChild(ctx.Context, parentHandle, name)
 	if err == nil {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrAlreadyExists,
 			Message: "file already exists",
 			Path:    name,
@@ -219,19 +238,19 @@ func (s *MetadataService) createEntry(
 	}
 	// If error is not ErrNotFound, it's a real error
 	if !IsNotFoundError(err) {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Generate new handle
 	newHandle, err := store.GenerateHandle(ctx.Context, parent.ShareName, fullPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Decode handle to get ID
 	_, id, err := DecodeFileHandle(newHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Prepare attributes
@@ -318,9 +337,22 @@ func (s *MetadataService) createEntry(
 		newFile.ACL = inherited
 	}
 
+	// wcc brackets the parent directory attributes around the mutation, both
+	// captured inside the transaction below so they atomically describe the
+	// state immediately before and after the create (H9).
+	wcc := &DirWcc{}
+
 	// Execute all write operations in a single transaction for better performance.
 	// This reduces PostgreSQL round-trips from 6+ to 2 (BEGIN + COMMIT).
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-read the parent inside the transaction so the pre-op snapshot and
+		// the timestamp mutation derive from the same committed state (After is
+		// then guaranteed monotonic w.r.t. Before).
+		if txParent, pErr := tx.GetFile(ctx.Context, parentHandle); pErr == nil && txParent != nil {
+			parent = txParent
+		}
+		wcc.Before = CopyFileAttr(&parent.FileAttr)
+
 		// TOCTOU guard: re-check inside transaction.
 		if _, innerErr := tx.GetChild(ctx.Context, parentHandle, name); innerErr == nil {
 			return &StoreError{
@@ -367,12 +399,13 @@ func (s *MetadataService) createEntry(
 		parent.Mtime = now
 		parent.Ctime = now
 		parent.Atime = now
+		wcc.After = CopyFileAttr(&parent.FileAttr)
 		return tx.PutFile(ctx.Context, parent)
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return newFile, nil
+	return newFile, wcc, nil
 }

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -186,18 +186,27 @@ func (s *MetadataService) ReadSymlink(ctx *AuthContext, handle FileHandle) (stri
 
 // SetFileAttributes updates file attributes with validation and access control.
 //
-// Only attributes with non-nil pointers in attrs are modified.
-func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *SetAttrs) error {
+// Only attributes with non-nil pointers in attrs are modified. The returned
+// DirWcc carries the target file's own pre/post attributes for protocol WCC
+// data: Before is the state the operation transitioned from (the attributes the
+// mutation observed), After is the resulting state (H9). For SETATTR the WCC
+// subject is the file itself, not a parent directory.
+func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *SetAttrs) (*DirWcc, error) {
 	store, err := s.storeForHandle(handle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get file entry
 	file, err := store.GetFile(ctx.Context, handle)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	// Capture pre-op attributes: a copy of the file as observed by this
+	// operation, before any mutation is applied below. This is exactly the
+	// state WCC "before" must describe.
+	wcc := &DirWcc{Before: CopyFileAttr(&file.FileAttr)}
 
 	// Check permissions based on what's being changed
 	identity := ctx.Identity
@@ -233,10 +242,10 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 
 	if writePermSufficient && !isOwner && !isRoot {
 		if err := s.checkWritePermission(ctx, handle); err != nil {
-			return err
+			return nil, err
 		}
 	} else if !isOwner && !isRoot {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrPermissionDenied,
 			Message: "operation not permitted",
 			Path:    file.Path,
@@ -285,7 +294,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		// Only root can change owner to a different UID
 		// Owner can set UID to their own UID (no-op for chown(file, same_uid, new_gid))
 		if *attrs.UID != file.UID && !isRoot {
-			return &StoreError{
+			return nil, &StoreError{
 				Code:    ErrPermissionDenied,
 				Message: "only root can change owner",
 				Path:    file.Path,
@@ -308,7 +317,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		if !isRoot {
 			isPrimaryGroup := identity.GID != nil && *identity.GID == *attrs.GID
 			if !isPrimaryGroup && !identity.HasGID(*attrs.GID) {
-				return &StoreError{
+				return nil, &StoreError{
 					Code:    ErrPermissionDenied,
 					Message: "not a member of target group",
 					Path:    file.Path,
@@ -336,7 +345,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 	if attrs.Size != nil {
 		// Size change requires write permission
 		if err := s.checkWritePermission(ctx, handle); err != nil {
-			return err
+			return nil, err
 		}
 		// A size-down truncate must trim the content-addressed block list to
 		// the new size, otherwise stale-tail refs past EOF survive in
@@ -398,7 +407,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 	// Handle ACL setting
 	if attrs.ACL != nil {
 		if err := acl.ValidateACL(attrs.ACL); err != nil {
-			return &StoreError{
+			return nil, &StoreError{
 				Code:    ErrInvalidArgument,
 				Message: fmt.Sprintf("invalid ACL: %v", err),
 				Path:    file.Path,
@@ -420,7 +429,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 	if len(attrs.EAMutations) > 0 {
 		if !isOwner && !isRoot {
 			if err := s.checkWritePermission(ctx, handle); err != nil {
-				return err
+				return nil, err
 			}
 		}
 		file.ApplyEAMutations(attrs.EAMutations)
@@ -433,7 +442,7 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 			file.Ctime = now
 		}
 		if err := store.PutFile(ctx.Context, file); err != nil {
-			return err
+			return nil, err
 		}
 
 		// Invalidate cached file in pending writes to ensure subsequent
@@ -441,36 +450,39 @@ func (s *MetadataService) SetFileAttributes(ctx *AuthContext, handle FileHandle,
 		s.pendingWrites.InvalidateCache(handle)
 	}
 
-	return nil
+	// Post-op attributes reflect the resulting file state (mutated in place
+	// above; equals Before when nothing changed).
+	wcc.After = CopyFileAttr(&file.FileAttr)
+	return wcc, nil
 }
 
 // Move moves or renames a file or directory atomically.
-func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) error {
+func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) (*RenameWcc, error) {
 	store, err := s.storeForHandle(fromDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Validate names
 	if err := ValidateName(fromName); err != nil {
-		return err
+		return nil, err
 	}
 	if err := ValidateName(toName); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Same directory and same name - no-op (POSIX rename semantics)
 	if string(fromDir) == string(toDir) && fromName == toName {
-		return nil
+		return nil, nil
 	}
 
 	// Get source directory
 	srcDir, err := store.GetFile(ctx.Context, fromDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if srcDir.Type != FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "source parent is not a directory",
 		}
@@ -479,10 +491,10 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 	// Get destination directory
 	dstDir, err := store.GetFile(ctx.Context, toDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if dstDir.Type != FileTypeDirectory {
-		return &StoreError{
+		return nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "destination parent is not a directory",
 		}
@@ -491,30 +503,30 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 	// Validate destination path length (POSIX PATH_MAX compliance)
 	destPath := buildPath(dstDir.Path, toName)
 	if err := ValidatePath(destPath); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check write permission on both directories
 	if err := s.checkWritePermission(ctx, fromDir); err != nil {
-		return err
+		return nil, err
 	}
 	if err := s.checkWritePermission(ctx, toDir); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get source file
 	srcHandle, err := store.GetChild(ctx.Context, fromDir, fromName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	srcFile, err := store.GetFile(ctx.Context, srcHandle)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check sticky bit on source directory
 	if err := CheckStickyBitRestriction(ctx, &srcDir.FileAttr, &srcFile.FileAttr); err != nil {
-		return err
+		return nil, err
 	}
 
 	// POSIX: When moving a directory to a different parent from a sticky directory,
@@ -535,7 +547,7 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 				"reason", "caller does not own directory being moved",
 				"src_file_uid", srcFile.UID,
 				"caller_uid", callerUID)
-			return &StoreError{
+			return nil, &StoreError{
 				Code:    ErrAccessDenied,
 				Message: "sticky bit set: cannot move directory you don't own to different parent",
 			}
@@ -550,18 +562,18 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 		// Destination exists - check compatibility
 		dstFile, err = store.GetFile(ctx.Context, dstHandle)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Check sticky bit on destination directory
 		if err := CheckStickyBitRestriction(ctx, &dstDir.FileAttr, &dstFile.FileAttr); err != nil {
-			return err
+			return nil, err
 		}
 
 		// Type compatibility checks
 		if srcFile.Type == FileTypeDirectory {
 			if dstFile.Type != FileTypeDirectory {
-				return &StoreError{
+				return nil, &StoreError{
 					Code:    ErrNotDirectory,
 					Message: "cannot overwrite non-directory with directory",
 				}
@@ -569,14 +581,14 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 			// Check if destination directory is empty
 			entries, _, err := store.ListChildren(ctx.Context, dstHandle, "", 1)
 			if err == nil && len(entries) > 0 {
-				return &StoreError{
+				return nil, &StoreError{
 					Code:    ErrNotEmpty,
 					Message: "destination directory not empty",
 				}
 			}
 		} else {
 			if dstFile.Type == FileTypeDirectory {
-				return &StoreError{
+				return nil, &StoreError{
 					Code:    ErrIsDirectory,
 					Message: "cannot overwrite directory with non-directory",
 				}
@@ -604,7 +616,7 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 						// into #recycle (the reaper frees its blocks later), so we
 						// have no blocks to release here.
 						if _, err := s.recycleNode(ctx, shareName, toDir, toName, victimRel); err != nil {
-							return err // never silently clobber
+							return nil, err // never silently clobber
 						}
 						// The victim has moved into #recycle, so the destination
 						// name is now free. Drop the cached dest-exists state so
@@ -617,11 +629,36 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 			}
 		}
 	} else if !IsNotFoundError(err) {
-		return err
+		return nil, err
+	}
+
+	// rename carries the source/destination directory pre/post attributes for
+	// WCC, captured inside the transaction below (H9). For an intra-directory
+	// move FromDir and ToDir reference the same DirWcc.
+	sameDir := string(fromDir) == string(toDir)
+	rename := &RenameWcc{FromDir: &DirWcc{}}
+	if sameDir {
+		rename.ToDir = rename.FromDir
+	} else {
+		rename.ToDir = &DirWcc{}
 	}
 
 	// Execute all write operations in a single transaction for better performance.
 	txErr := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Re-read the source/destination directories inside the transaction so
+		// the pre-op snapshots and the timestamp mutations derive from the same
+		// committed state (After then monotonic w.r.t. Before).
+		if txSrc, sErr := tx.GetFile(ctx.Context, fromDir); sErr == nil && txSrc != nil {
+			srcDir = txSrc
+		}
+		rename.FromDir.Before = CopyFileAttr(&srcDir.FileAttr)
+		if !sameDir {
+			if txDst, dErr := tx.GetFile(ctx.Context, toDir); dErr == nil && txDst != nil {
+				dstDir = txDst
+			}
+			rename.ToDir.Before = CopyFileAttr(&dstDir.FileAttr)
+		}
+
 		// Handle destination removal if it exists
 		if dstFile != nil {
 			// Remove destination
@@ -730,13 +767,15 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 
 		srcDir.Mtime = now
 		srcDir.Ctime = now
+		rename.FromDir.After = CopyFileAttr(&srcDir.FileAttr)
 		if err := tx.PutFile(ctx.Context, srcDir); err != nil {
 			return err
 		}
 
-		if string(fromDir) != string(toDir) {
+		if !sameDir {
 			dstDir.Mtime = now
 			dstDir.Ctime = now
+			rename.ToDir.After = CopyFileAttr(&dstDir.FileAttr)
 			if err := tx.PutFile(ctx.Context, dstDir); err != nil {
 				return err
 			}
@@ -746,7 +785,7 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 	})
 
 	if txErr != nil {
-		return txErr
+		return nil, txErr
 	}
 
 	// Notify directory change after successful move
@@ -756,7 +795,7 @@ func (s *MetadataService) Move(ctx *AuthContext, fromDir FileHandle, fromName st
 		s.notifyDirChange(shareNameForHandle(toDir), toDir, lock.DirChangeAddEntry, ctx)
 	}
 
-	return nil
+	return rename, nil
 }
 
 // updateDescendantPaths recursively updates the Path field of all descendants

--- a/pkg/metadata/file_modify_test.go
+++ b/pkg/metadata/file_modify_test.go
@@ -19,13 +19,13 @@ func TestMove_UpdatesFilePath(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a file in root
-	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "myfile.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "myfile.txt", &metadata.FileAttr{
 		Mode: 0644,
 	})
 	require.NoError(t, err)
 
 	// Create destination directory
-	_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest", &metadata.FileAttr{
+	_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestMove_UpdatesFilePath(t *testing.T) {
 	assert.Equal(t, "/myfile.txt", file.Path)
 
 	// Move file to dest directory
-	err = fx.service.Move(fx.rootContext(), fx.rootHandle, "myfile.txt", destHandle, "moved.txt")
+	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "myfile.txt", destHandle, "moved.txt")
 	require.NoError(t, err)
 
 	// Verify path updated in store
@@ -58,7 +58,7 @@ func TestMove_UpdatesDirectoryPath(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a directory
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "olddir", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "olddir", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestMove_UpdatesDirectoryPath(t *testing.T) {
 	assert.Equal(t, "/olddir", dir.Path)
 
 	// Rename directory
-	err = fx.service.Move(fx.rootContext(), fx.rootHandle, "olddir", fx.rootHandle, "newdir")
+	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "olddir", fx.rootHandle, "newdir")
 	require.NoError(t, err)
 
 	// Verify path updated in store
@@ -87,7 +87,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	ctx := context.Background()
 
 	// Build tree: /a/b/c/file.txt
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "a", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "a", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	aHandle, err := fx.store.GetChild(ctx, fx.rootHandle, "a")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateDirectory(fx.rootContext(), aHandle, "b", &metadata.FileAttr{
+	_, _, err = fx.service.CreateDirectory(fx.rootContext(), aHandle, "b", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	bHandle, err := fx.store.GetChild(ctx, aHandle, "b")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateDirectory(fx.rootContext(), bHandle, "c", &metadata.FileAttr{
+	_, _, err = fx.service.CreateDirectory(fx.rootContext(), bHandle, "c", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	cHandle, err := fx.store.GetChild(ctx, bHandle, "c")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateFile(fx.rootContext(), cHandle, "file.txt", &metadata.FileAttr{
+	_, _, err = fx.service.CreateFile(fx.rootContext(), cHandle, "file.txt", &metadata.FileAttr{
 		Mode: 0644,
 	})
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	assert.Equal(t, "/a/b/c/file.txt", leafFile.Path)
 
 	// Rename /a to /x
-	err = fx.service.Move(fx.rootContext(), fx.rootHandle, "a", fx.rootHandle, "x")
+	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "a", fx.rootHandle, "x")
 	require.NoError(t, err)
 
 	// Verify all paths updated recursively
@@ -164,7 +164,7 @@ func TestMove_SameDirectoryRename(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a file
-	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "old.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "old.txt", &metadata.FileAttr{
 		Mode: 0644,
 	})
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestMove_SameDirectoryRename(t *testing.T) {
 	assert.Equal(t, "/old.txt", file.Path)
 
 	// Rename within same directory
-	err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
+	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
 	require.NoError(t, err)
 
 	// Verify path updated
@@ -193,7 +193,7 @@ func TestMove_EmptyDirectoryRename(t *testing.T) {
 	ctx := context.Background()
 
 	// Create an empty directory
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "empty", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "empty", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestMove_EmptyDirectoryRename(t *testing.T) {
 	assert.Equal(t, "/empty", dir.Path)
 
 	// Rename empty directory
-	err = fx.service.Move(fx.rootContext(), fx.rootHandle, "empty", fx.rootHandle, "renamed")
+	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "empty", fx.rootHandle, "renamed")
 	require.NoError(t, err)
 
 	// Verify path updated (no children to traverse)

--- a/pkg/metadata/file_recycle.go
+++ b/pkg/metadata/file_recycle.go
@@ -103,7 +103,7 @@ func (s *MetadataService) recycleNode(ctx *AuthContext, shareName string, parent
 	//    a directory moves its whole subtree as one entry). If this fails, the
 	//    source is still live but marked-deleted: clear the stamp best-effort so
 	//    a live file is not left looking recycled, then surface the move error.
-	if err := s.Move(ctx, parentHandle, name, destParent, destName); err != nil {
+	if _, err := s.Move(ctx, parentHandle, name, destParent, destName); err != nil {
 		if clearErr := s.clearRecycleStamp(ctx, victimHandle); clearErr != nil {
 			return nil, &StoreError{
 				Code:    ErrIOError,
@@ -152,7 +152,7 @@ func (s *MetadataService) ensureChildDir(ctx *AuthContext, parentHandle FileHand
 		return h, nil
 	}
 	attr := &FileAttr{Type: FileTypeDirectory, Mode: perm}
-	if _, err := s.CreateDirectory(ctx, parentHandle, name, attr); err != nil {
+	if _, _, err := s.CreateDirectory(ctx, parentHandle, name, attr); err != nil {
 		var storeErr *StoreError
 		if !stderrors.As(err, &storeErr) || storeErr.Code != ErrAlreadyExists {
 			return nil, err

--- a/pkg/metadata/file_recycle_test.go
+++ b/pkg/metadata/file_recycle_test.go
@@ -58,10 +58,10 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		fx := newRecycleFixture(t)
 		fx.service.SetTrashPolicy(stubTrashPolicy{cfg: metadata.TrashConfig{Enabled: true}})
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "report.pdf", &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "report.pdf", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
 
-		removed, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "report.pdf")
+		removed, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "report.pdf")
 		require.NoError(t, err)
 		require.NotNil(t, removed)
 		// Cleared PayloadID makes adapters skip block deletion (deferred reaping).
@@ -86,9 +86,9 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		fx.service.SetTrashPolicy(stubTrashPolicy{cfg: metadata.TrashConfig{Enabled: true}})
 
 		// Recycle once so #recycle exists with an entry.
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
-		_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "a.txt")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "a.txt")
 		require.NoError(t, err)
 
 		binHandle, err := fx.service.GetChild(fx.rootContext().Context, fx.rootHandle, metadata.RecycleDirName)
@@ -96,7 +96,7 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 
 		// Deleting the file already in the bin must be permanent: it does not
 		// get re-recycled into a nested #recycle, it is removed.
-		_, err = fx.service.RemoveFile(fx.rootContext(), binHandle, "a.txt")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), binHandle, "a.txt")
 		require.NoError(t, err)
 		_, err = fx.service.Lookup(fx.rootContext(), binHandle, "a.txt")
 		assert.True(t, metadata.IsNotFoundError(err))
@@ -113,9 +113,9 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 			ExcludePatterns: []string{"*.tmp"},
 		}})
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "scratch.tmp", &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "scratch.tmp", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
-		_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "scratch.tmp")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "scratch.tmp")
 		require.NoError(t, err)
 
 		// No bin created, file permanently gone.
@@ -132,9 +132,9 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		// land in the same wall-clock second. The collision must NOT overwrite
 		// the first recycled copy.
 		for i := 0; i < 2; i++ {
-			_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "dup.txt", &metadata.FileAttr{Mode: 0644})
+			_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "dup.txt", &metadata.FileAttr{Mode: 0644})
 			require.NoError(t, err)
-			_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "dup.txt")
+			_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "dup.txt")
 			require.NoError(t, err)
 		}
 
@@ -170,13 +170,14 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		// so the surviving file's Mode tells us whose identity won.
 		const modeA = uint32(0640)
 		const modeB = uint32(0600)
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a", &metadata.FileAttr{Mode: modeA})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a", &metadata.FileAttr{Mode: modeA})
 		require.NoError(t, err)
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "b", &metadata.FileAttr{Mode: modeB})
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "b", &metadata.FileAttr{Mode: modeB})
 		require.NoError(t, err)
 
 		// Rename "b" onto "a" — an overwrite. The old "a" must be recycled.
-		require.NoError(t, fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "a"))
+		_, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "a")
+		require.NoError(t, mvErr)
 
 		// Source "b" is gone.
 		_, err = fx.service.Lookup(fx.rootContext(), fx.rootHandle, "b")
@@ -203,11 +204,12 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		fx := newRecycleFixture(t)
 		fx.service.SetTrashPolicy(stubTrashPolicy{cfg: metadata.TrashConfig{Enabled: true}})
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "b", &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "b", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
 
 		// "c" does not exist: a plain rename must not touch the bin.
-		require.NoError(t, fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "c"))
+		_, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "c")
+		require.NoError(t, mvErr)
 
 		_, err = fx.service.Lookup(fx.rootContext(), fx.rootHandle, "c")
 		require.NoError(t, err)
@@ -224,15 +226,15 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		fx := newRecycleFixture(t)
 		fx.service.SetTrashPolicy(stubTrashPolicy{cfg: metadata.TrashConfig{Enabled: true}})
 
-		dir, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "docs", &metadata.FileAttr{Mode: 0755})
+		dir, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "docs", &metadata.FileAttr{Mode: 0755})
 		require.NoError(t, err)
 		dirHandle, err := metadata.EncodeFileHandle(dir)
 		require.NoError(t, err)
-		_, err = fx.service.CreateFile(fx.rootContext(), dirHandle, "inner.txt", &metadata.FileAttr{Mode: 0644})
+		_, _, err = fx.service.CreateFile(fx.rootContext(), dirHandle, "inner.txt", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
 
 		// RemoveDirectory on a non-empty dir succeeds (recycled, not ErrNotEmpty).
-		err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "docs")
+		_, err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "docs")
 		require.NoError(t, err)
 
 		_, err = fx.service.Lookup(fx.rootContext(), fx.rootHandle, "docs")

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -25,26 +25,26 @@ import (
 // POSIX Compliance:
 //   - When last link is removed, nlink is set to 0 (not deleted)
 //   - This allows fstat() on open file descriptors to return nlink=0
-func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name string) (*File, error) {
+func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name string) (*File, *DirWcc, error) {
 	store, err := s.storeForHandle(parentHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate name
 	if err := ValidateName(name); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Get parent entry
 	parent, err := store.GetFile(ctx.Context, parentHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Verify parent is a directory
 	if parent.Type != FileTypeDirectory {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "parent is not a directory",
 			Path:    parent.Path,
@@ -54,18 +54,18 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 	// Get child handle
 	fileHandle, err := store.GetChild(ctx.Context, parentHandle, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Get file entry
 	file, err := store.GetFile(ctx.Context, fileHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Verify it's not a directory
 	if file.Type == FileTypeDirectory {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrIsDirectory,
 			Message: "cannot remove directory with RemoveFile, use RemoveDirectory",
 			Path:    name,
@@ -74,12 +74,12 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 
 	// Check delete permission: WRITE on parent (POSIX) or owner-of-file (Windows DELETE).
 	if err := s.checkDeletePermission(ctx, parentHandle, file); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check sticky bit restriction
 	if err := CheckStickyBitRestriction(ctx, &parent.FileAttr, &file.FileAttr); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Recycle instead of destroying when the share has trash enabled. Deletes
@@ -90,12 +90,22 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 		if cfg, ok := s.trashPolicy.TrashConfigForShare(shareName); ok && cfg.Enabled {
 			origRel := strings.TrimPrefix(buildPath(parent.Path, name), "/")
 			if !inRecycle(origRel) && !cfg.Excluded(name) {
-				return s.recycleNode(ctx, shareName, parentHandle, name, origRel)
+				// Recycle relocates via Move (a separate metadata op). Bracket
+				// it with best-effort pre/post parent reads for WCC; this path
+				// is rare and not perf-critical.
+				wccBefore := CopyFileAttr(&parent.FileAttr)
+				recycled, rErr := s.recycleNode(ctx, shareName, parentHandle, name, origRel)
+				if rErr != nil {
+					return nil, nil, rErr
+				}
+				wcc := &DirWcc{Before: wccBefore}
+				if after, aErr := store.GetFile(ctx.Context, parentHandle); aErr == nil {
+					wcc.After = CopyFileAttr(&after.FileAttr)
+				}
+				return recycled, wcc, nil
 			}
 		}
 	}
-
-	now := time.Now()
 
 	// Prepare return value
 	returnFile := &File{
@@ -105,8 +115,26 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 		FileAttr:  file.FileAttr,
 	}
 
+	// wcc captures the parent directory attributes immediately before and after
+	// the mutation, both inside the transaction below so they atomically bracket
+	// the operation (H9: closes the WCC pre-op TOCTOU window).
+	wcc := &DirWcc{}
+
 	// Execute all write operations in a single transaction for better performance.
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+		// Sample the mutation timestamp inside the transaction (after the pre-op
+		// snapshot) so the post-op directory mtime is monotonic w.r.t. Before.
+		now := time.Now()
+		// Re-read the parent INSIDE the transaction so the pre-op WCC snapshot,
+		// the timestamp mutation, and the post-op snapshot all derive from the
+		// same committed state. The in-tx read registers the key for conflict
+		// detection so a racing mutation triggers a retry, and basing the
+		// mutation on the in-tx copy guarantees After is never older than Before.
+		if txParent, pErr := tx.GetFile(ctx.Context, parentHandle); pErr == nil && txParent != nil {
+			parent = txParent
+		}
+		wcc.Before = CopyFileAttr(&parent.FileAttr)
+
 		// Read the link count INSIDE the transaction so the read, the
 		// branch decision, and the write are atomic. Reading it outside the
 		// tx is a TOCTOU race with CreateHardLink: a concurrent link bump in
@@ -166,13 +194,14 @@ func (s *MetadataService) RemoveFile(ctx *AuthContext, parentHandle FileHandle, 
 		parent.Mtime = now
 		parent.Ctime = now
 		parent.Atime = now
+		wcc.After = CopyFileAttr(&parent.FileAttr)
 		return tx.PutFile(ctx.Context, parent)
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	s.notifyDirChange(shareNameForHandle(parentHandle), parentHandle, lock.DirChangeRemoveEntry, ctx)
-	return returnFile, nil
+	return returnFile, wcc, nil
 }

--- a/pkg/metadata/hardlink_parent_key_test.go
+++ b/pkg/metadata/hardlink_parent_key_test.go
@@ -55,7 +55,7 @@ func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
 			rootCtx := fx.rootContext()
 
 			// Source dir + file (always linked from "srcdir").
-			_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "srcdir", &metadata.FileAttr{
+			_, _, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "srcdir", &metadata.FileAttr{
 				Type: metadata.FileTypeDirectory, Mode: 0o777,
 			})
 			if err != nil {
@@ -65,7 +65,7 @@ func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetChild(srcdir): %v", err)
 			}
-			srcFile, err := fx.service.CreateFile(rootCtx, srcDirHandle, "src.txt", &metadata.FileAttr{
+			srcFile, _, err := fx.service.CreateFile(rootCtx, srcDirHandle, "src.txt", &metadata.FileAttr{
 				Type: metadata.FileTypeRegular, Mode: 0o644,
 			})
 			if err != nil {
@@ -80,7 +80,7 @@ func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
 			dstDirHandle := srcDirHandle
 			if tc.differentDir {
 				dstDirName := "dstdir"
-				_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, dstDirName, &metadata.FileAttr{
+				_, _, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, dstDirName, &metadata.FileAttr{
 					Type: metadata.FileTypeDirectory, Mode: 0o777,
 				})
 				if err != nil {
@@ -109,7 +109,7 @@ func TestCreateHardLink_NotifyDirChangeMatrix(t *testing.T) {
 				HasParentLeaseKey: true,
 			}
 
-			if err := fx.service.CreateHardLink(linkCtx, dstDirHandle, "link.txt", srcHandle); err != nil {
+			if _, err := fx.service.CreateHardLink(linkCtx, dstDirHandle, "link.txt", srcHandle); err != nil {
 				t.Fatalf("CreateHardLink: %v", err)
 			}
 
@@ -150,7 +150,7 @@ func TestCreateHardLink_NFSCallerHasNoParentKey(t *testing.T) {
 
 	rootCtx := fx.rootContext()
 
-	_, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "d", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(rootCtx, fx.rootHandle, "d", &metadata.FileAttr{
 		Type: metadata.FileTypeDirectory, Mode: 0o777,
 	})
 	if err != nil {
@@ -160,7 +160,7 @@ func TestCreateHardLink_NFSCallerHasNoParentKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetChild: %v", err)
 	}
-	srcFile, err := fx.service.CreateFile(rootCtx, dirHandle, "src.txt", &metadata.FileAttr{
+	srcFile, _, err := fx.service.CreateFile(rootCtx, dirHandle, "src.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0o644,
 	})
 	if err != nil {
@@ -183,7 +183,7 @@ func TestCreateHardLink_NFSCallerHasNoParentKey(t *testing.T) {
 		ParentLeaseKey:    bogus,
 		HasParentLeaseKey: false,
 	}
-	if err := fx.service.CreateHardLink(nfsCtx, dirHandle, "link.txt", srcHandle); err != nil {
+	if _, err := fx.service.CreateHardLink(nfsCtx, dirHandle, "link.txt", srcHandle); err != nil {
 		t.Fatalf("CreateHardLink: %v", err)
 	}
 

--- a/pkg/metadata/lookup_case_insensitive_test.go
+++ b/pkg/metadata/lookup_case_insensitive_test.go
@@ -15,7 +15,7 @@ func TestLookupCaseInsensitive_ExactMatch(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)
 
-	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "ExactCase.txt", &metadata.FileAttr{Mode: 0644})
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "ExactCase.txt", &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
 
 	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "ExactCase.txt")
@@ -32,7 +32,7 @@ func TestLookupCaseInsensitive_FallbackMatch(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)
 
-	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "TestFile.TXT", &metadata.FileAttr{Mode: 0644})
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "TestFile.TXT", &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
 
 	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "TESTFILE.TXT")
@@ -60,7 +60,7 @@ func TestLookupCaseInsensitive_DirectoryEntry(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)
 
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "MyDir", &metadata.FileAttr{Mode: 0755})
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "MyDir", &metadata.FileAttr{Mode: 0755})
 	require.NoError(t, err)
 
 	file, matched, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, "MYDIR")
@@ -77,7 +77,7 @@ func TestLookupCaseInsensitive_NotADirectory(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)
 
-	fileEntry, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "regular.txt", &metadata.FileAttr{Mode: 0644})
+	fileEntry, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "regular.txt", &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
 
 	fileHandle, err := metadata.EncodeFileHandle(fileEntry)
@@ -144,7 +144,7 @@ func TestLookupCaseInsensitive_LoneSurrogatesDoNotFold(t *testing.T) {
 
 	// Create only the high surrogate. An exact Lookup of {U+D800} succeeds,
 	// but a Lookup of {U+DC00} misses and drops into the EqualFold scan.
-	hiFile, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, hi, &metadata.FileAttr{Mode: 0644})
+	hiFile, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, hi, &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
 
 	// The fallback scan must NOT fold {U+DC00} onto the stored {U+D800}.
@@ -153,7 +153,7 @@ func TestLookupCaseInsensitive_LoneSurrogatesDoNotFold(t *testing.T) {
 	assert.Nil(t, loFound, "lone low surrogate must not fold onto the stored lone high surrogate")
 
 	// Now create the low surrogate too; both must resolve to distinct files.
-	loFile, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, lo, &metadata.FileAttr{Mode: 0644})
+	loFile, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, lo, &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err, "second CREATE must not collide with the first")
 
 	hiResolved, _, err := fx.service.LookupCaseInsensitive(fx.rootContext(), fx.rootHandle, hi)
@@ -176,7 +176,7 @@ func TestLookupCaseInsensitive_PreservesCaseAcrossMultipleEntries(t *testing.T) 
 	fx := newTestFixture(t)
 
 	for _, name := range []string{"alpha.txt", "Beta.TXT", "gamma.txt"} {
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, name, &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, name, &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
 	}
 

--- a/pkg/metadata/notify_dir_change_parent_key_test.go
+++ b/pkg/metadata/notify_dir_change_parent_key_test.go
@@ -60,7 +60,7 @@ func TestNotifyDirChange_ThreadsParentLeaseKey(t *testing.T) {
 	}
 
 	// CreateFile triggers notifyDirChange(DirChangeAddEntry, ctx).
-	_, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0644,
 		UID:  0,
@@ -99,7 +99,7 @@ func TestRemoveFile_UnlinkSameSetAndClose(t *testing.T) {
 
 	// Pre-create the victim file under root so RemoveFile has something to unlink.
 	rootCtx := fx.rootContext()
-	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
 	})
 	if err != nil {
@@ -118,7 +118,7 @@ func TestRemoveFile_UnlinkSameSetAndClose(t *testing.T) {
 		HasParentLeaseKey: true,
 		HasDeleteAccess:   true,
 	}
-	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+	if _, _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
 		t.Fatalf("RemoveFile failed: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestRemoveFile_UnlinkDifferentSetAndClose(t *testing.T) {
 	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
 
 	rootCtx := fx.rootContext()
-	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestRemoveFile_UnlinkDifferentSetAndClose(t *testing.T) {
 		HasParentLeaseKey: false,
 		HasDeleteAccess:   true,
 	}
-	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+	if _, _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
 		t.Fatalf("RemoveFile failed: %v", err)
 	}
 
@@ -211,7 +211,7 @@ func TestRemoveFile_UnlinkSameInitialAndClose(t *testing.T) {
 	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
 
 	rootCtx := fx.rootContext()
-	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
 	})
 	if err != nil {
@@ -230,7 +230,7 @@ func TestRemoveFile_UnlinkSameInitialAndClose(t *testing.T) {
 		HasParentLeaseKey: true,
 		HasDeleteAccess:   true,
 	}
-	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+	if _, _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
 		t.Fatalf("RemoveFile failed: %v", err)
 	}
 
@@ -266,7 +266,7 @@ func TestRemoveFile_UnlinkDifferentInitialAndClose(t *testing.T) {
 	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
 
 	rootCtx := fx.rootContext()
-	_, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(rootCtx, fx.rootHandle, "victim.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular, Mode: 0644, UID: 0, GID: 0,
 	})
 	if err != nil {
@@ -280,7 +280,7 @@ func TestRemoveFile_UnlinkDifferentInitialAndClose(t *testing.T) {
 		HasParentLeaseKey: false,
 		HasDeleteAccess:   true,
 	}
-	if _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
+	if _, _, err := fx.service.RemoveFile(closeCtx, fx.rootHandle, "victim.txt"); err != nil {
 		t.Fatalf("RemoveFile failed: %v", err)
 	}
 
@@ -325,7 +325,7 @@ func TestNotifyDirChange_NFSCallerHasNoParentKey(t *testing.T) {
 		HasParentLeaseKey: false,
 	}
 
-	_, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
+	_, _, err := fx.service.CreateFile(ctx, fx.rootHandle, "foo.txt", &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0644,
 		UID:  0,

--- a/pkg/metadata/service_extended_test.go
+++ b/pkg/metadata/service_extended_test.go
@@ -21,7 +21,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateSpecialFile(
+		file, _, err := fx.service.CreateSpecialFile(
 			fx.rootContext(),
 			fx.rootHandle,
 			"sda1",
@@ -40,7 +40,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateSpecialFile(
+		file, _, err := fx.service.CreateSpecialFile(
 			fx.rootContext(),
 			fx.rootHandle,
 			"tty0",
@@ -58,7 +58,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateSpecialFile(
+		file, _, err := fx.service.CreateSpecialFile(
 			fx.rootContext(),
 			fx.rootHandle,
 			"app.sock",
@@ -76,7 +76,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateSpecialFile(
+		file, _, err := fx.service.CreateSpecialFile(
 			fx.rootContext(),
 			fx.rootHandle,
 			"pipe",
@@ -94,7 +94,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.CreateSpecialFile(
+		_, _, err := fx.service.CreateSpecialFile(
 			fx.userContext(),
 			fx.rootHandle,
 			"sda1",
@@ -113,7 +113,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.CreateSpecialFile(
+		_, _, err := fx.service.CreateSpecialFile(
 			fx.userContext(),
 			fx.rootHandle,
 			"tty0",
@@ -130,7 +130,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Regular file is not a valid special file type
-		_, err := fx.service.CreateSpecialFile(
+		_, _, err := fx.service.CreateSpecialFile(
 			fx.rootContext(),
 			fx.rootHandle,
 			"file",
@@ -147,7 +147,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Socket
-		_, err := fx.service.CreateSpecialFile(
+		_, _, err := fx.service.CreateSpecialFile(
 			fx.userContext(),
 			fx.rootHandle,
 			"user.sock",
@@ -158,7 +158,7 @@ func TestMetadataService_CreateSpecialFile(t *testing.T) {
 		require.NoError(t, err)
 
 		// FIFO
-		_, err = fx.service.CreateSpecialFile(
+		_, _, err = fx.service.CreateSpecialFile(
 			fx.userContext(),
 			fx.rootHandle,
 			"user.fifo",
@@ -182,7 +182,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "truncate.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "truncate.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 
 		// Truncate to 1024 bytes
 		newSize := uint64(1024)
-		err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 			Size: &newSize,
 		})
 		require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "chmod.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "chmod.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 
 		// Change mode
 		newMode := uint32(0755)
-		err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 			Mode: &newMode,
 		})
 		require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "touch.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "touch.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 
 		// Change timestamps
 		newTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
-		err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 			Atime: &newTime,
 			Mtime: &newTime,
 		})
@@ -262,7 +262,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file as root
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "chown.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "chown.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		// Change owner
 		newUID := uint32(1000)
 		newGID := uint32(1000)
-		err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 			UID: &newUID,
 			GID: &newGID,
 		})
@@ -291,7 +291,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file as root
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "nochange.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "nochange.txt", &metadata.FileAttr{
 			Mode: 0666,
 			UID:  0,
 			GID:  0,
@@ -303,7 +303,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 
 		// Try to change owner as non-root
 		newUID := uint32(1000)
-		err = fx.service.SetFileAttributes(fx.userContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.userContext(), fileHandle, &metadata.SetAttrs{
 			UID: &newUID,
 		})
 
@@ -315,7 +315,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "multi.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "multi.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -326,7 +326,7 @@ func TestMetadataService_SetFileAttributes_Extended(t *testing.T) {
 		// Set multiple attributes at once
 		newMode := uint32(0755)
 		newSize := uint64(512)
-		err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 			Mode: &newMode,
 			Size: &newSize,
 		})
@@ -352,7 +352,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "original.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "original.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Rename it
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "original.txt", fx.rootHandle, "renamed.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "original.txt", fx.rootHandle, "renamed.txt")
 
 		require.NoError(t, err)
 
@@ -380,13 +380,13 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create source file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "moveme.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "moveme.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Create destination directory
-		_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "destdir", &metadata.FileAttr{
+		_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "destdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -395,7 +395,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move file
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "moveme.txt", destHandle, "moved.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "moveme.txt", destHandle, "moved.txt")
 
 		require.NoError(t, err)
 
@@ -413,13 +413,13 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create source file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "source.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "source.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Create destination file (will be overwritten)
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "dest.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "dest.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move (overwrite)
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "source.txt", fx.rootHandle, "dest.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "source.txt", fx.rootHandle, "dest.txt")
 
 		require.NoError(t, err)
 
@@ -447,13 +447,13 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create source directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "srcdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "srcdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Rename directory
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "newdir")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "newdir")
 
 		require.NoError(t, err)
 
@@ -471,13 +471,13 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "same.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "same.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Move to same location
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "same.txt", fx.rootHandle, "same.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "same.txt", fx.rootHandle, "same.txt")
 
 		require.NoError(t, err)
 
@@ -491,19 +491,19 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Create a directory
-		_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
+		_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Try to move file over directory
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "file.txt", fx.rootHandle, "dir")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "file.txt", fx.rootHandle, "dir")
 
 		require.Error(t, err)
 	})
@@ -513,19 +513,19 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "srcdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "srcdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Create a file
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "destfile.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "destfile.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to move directory over file
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "destfile.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "destfile.txt")
 
 		require.Error(t, err)
 	})
@@ -543,13 +543,13 @@ func TestMetadataService_RemoveFile_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "delete.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "delete.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Remove it
-		_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "delete.txt")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "delete.txt")
 
 		require.NoError(t, err)
 
@@ -563,13 +563,13 @@ func TestMetadataService_RemoveFile_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "mydir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "mydir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Try to remove it with RemoveFile (should fail)
-		_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "mydir")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "mydir")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -581,7 +581,7 @@ func TestMetadataService_RemoveFile_Extended(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "nonexistent.txt")
+		_, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "nonexistent.txt")
 
 		require.Error(t, err)
 		assert.True(t, metadata.IsNotFoundError(err))
@@ -600,7 +600,7 @@ func TestMetadataService_ReadDirectory_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create empty directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "empty", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "empty", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -620,7 +620,7 @@ func TestMetadataService_ReadDirectory_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "withfiles", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "withfiles", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -630,7 +630,7 @@ func TestMetadataService_ReadDirectory_Extended(t *testing.T) {
 
 		// Create some files
 		for i := 0; i < 5; i++ {
-			_, err := fx.service.CreateFile(fx.rootContext(), dirHandle, "file"+string(rune('a'+i))+".txt", &metadata.FileAttr{
+			_, _, err := fx.service.CreateFile(fx.rootContext(), dirHandle, "file"+string(rune('a'+i))+".txt", &metadata.FileAttr{
 				Mode: 0644,
 			})
 			require.NoError(t, err)
@@ -648,7 +648,7 @@ func TestMetadataService_ReadDirectory_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "pagedir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "pagedir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -658,7 +658,7 @@ func TestMetadataService_ReadDirectory_Extended(t *testing.T) {
 
 		// Create 10 files
 		for i := 0; i < 10; i++ {
-			_, err := fx.service.CreateFile(fx.rootContext(), dirHandle, "file"+string(rune('0'+i))+".txt", &metadata.FileAttr{
+			_, _, err := fx.service.CreateFile(fx.rootContext(), dirHandle, "file"+string(rune('0'+i))+".txt", &metadata.FileAttr{
 				Mode: 0644,
 			})
 			require.NoError(t, err)
@@ -683,7 +683,7 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create target file
-		targetFile, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
+		targetFile, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -693,7 +693,7 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create hard link
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link.txt", targetHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link.txt", targetHandle)
 		require.NoError(t, err)
 
 		// Verify link count increased
@@ -707,7 +707,7 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "targetdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "targetdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -716,7 +716,7 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create hard link to directory
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "dirlink", dirHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "dirlink", dirHandle)
 
 		require.Error(t, err)
 	})
@@ -726,7 +726,7 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create target file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "original.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "original.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -735,13 +735,13 @@ func TestMetadataService_CreateHardLink_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create another file with the name we want to use for the link
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "linkname.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "linkname.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to create hard link with existing name
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "linkname.txt", targetHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "linkname.txt", targetHandle)
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -764,7 +764,7 @@ func TestMetadataService_Symlink_Extended(t *testing.T) {
 		targetPath := "/path/to/target"
 
 		// Create symlink
-		file, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "mylink", targetPath, &metadata.FileAttr{})
+		file, _, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "mylink", targetPath, &metadata.FileAttr{})
 		require.NoError(t, err)
 		assert.Equal(t, metadata.FileTypeSymlink, file.Type)
 
@@ -782,7 +782,7 @@ func TestMetadataService_Symlink_Extended(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create regular file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "notlink.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "notlink.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -809,7 +809,7 @@ func TestMetadataService_GetFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		created, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "getme.txt", &metadata.FileAttr{
+		created, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "getme.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -834,7 +834,7 @@ func TestMetadataService_GetChild(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "child.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "child.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)

--- a/pkg/metadata/service_quota_test.go
+++ b/pkg/metadata/service_quota_test.go
@@ -73,7 +73,7 @@ func (f *quotaFixture) createFileWithSize(name string, size uint64) metadata.Fil
 	f.t.Helper()
 	ctx := f.rootContext()
 
-	file, err := f.service.CreateFile(ctx, f.rootHandle, name, &metadata.FileAttr{
+	file, _, err := f.service.CreateFile(ctx, f.rootHandle, name, &metadata.FileAttr{
 		Type: metadata.FileTypeRegular,
 		Mode: 0o644,
 		UID:  0,

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -216,7 +216,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		file, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -231,7 +231,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		file, err := fx.service.CreateFile(fx.userContext(), fx.rootHandle, "userfile.txt", &metadata.FileAttr{
+		file, _, err := fx.service.CreateFile(fx.userContext(), fx.rootHandle, "userfile.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -244,7 +244,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "..", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "..", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -255,7 +255,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -267,13 +267,13 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create first file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to create again
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -297,7 +297,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 
 			for i := 0; i < numWorkers; i++ {
 				go func() {
-					_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "race.txt", &metadata.FileAttr{
+					_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "race.txt", &metadata.FileAttr{
 						Mode: 0644,
 					})
 					results <- result{err: err}
@@ -327,7 +327,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a subdirectory owned by root with mode 0755
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "restricted", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "restricted", &metadata.FileAttr{
 			Mode: 0755,
 			UID:  0,
 			GID:  0,
@@ -339,7 +339,7 @@ func TestMetadataService_CreateFile(t *testing.T) {
 		require.NoError(t, err)
 
 		// User should be denied (write permission not available to others on 0755 dir)
-		_, err = fx.service.CreateFile(fx.userContext(), restrictedHandle, "test.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.userContext(), restrictedHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 
@@ -359,7 +359,7 @@ func TestMetadataService_Lookup(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -417,7 +417,7 @@ func TestMetadataService_CreateDirectory(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		dir, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
+		dir, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 
@@ -433,7 +433,7 @@ func TestMetadataService_CreateDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create parent
-		parent, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
+		parent, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -443,7 +443,7 @@ func TestMetadataService_CreateDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create child
-		child, err := fx.service.CreateDirectory(fx.rootContext(), parentHandle, "child", &metadata.FileAttr{
+		child, _, err := fx.service.CreateDirectory(fx.rootContext(), parentHandle, "child", &metadata.FileAttr{
 			Mode: 0755,
 		})
 
@@ -471,13 +471,13 @@ func TestMetadataService_RemoveFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Remove it
-		removed, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "test.txt")
+		removed, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "test.txt")
 
 		require.NoError(t, err)
 		assert.NotNil(t, removed)
@@ -493,13 +493,13 @@ func TestMetadataService_RemoveFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Try to remove with RemoveFile
-		_, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "subdir")
+		_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "subdir")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -511,7 +511,7 @@ func TestMetadataService_RemoveFile(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "nonexistent.txt")
+		_, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "nonexistent.txt")
 
 		require.Error(t, err)
 	})
@@ -529,13 +529,13 @@ func TestMetadataService_RemoveDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Remove it
-		err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "subdir")
+		_, err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "subdir")
 
 		require.NoError(t, err)
 
@@ -549,7 +549,7 @@ func TestMetadataService_RemoveDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -559,13 +559,13 @@ func TestMetadataService_RemoveDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a file inside
-		_, err = fx.service.CreateFile(fx.rootContext(), dirHandle, "file.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), dirHandle, "file.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to remove directory
-		err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "subdir")
+		_, err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "subdir")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -578,13 +578,13 @@ func TestMetadataService_RemoveDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to remove with RemoveDirectory
-		err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "test.txt")
+		_, err = fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "test.txt")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -612,7 +612,7 @@ func prepareDeletePermTest(t *testing.T, fx *testFixture, dirMode uint32, dirOwn
 
 	// 1) Create parent as root with mode 0777 so we can then create children in
 	//    it regardless of the final dirOwner/dirMode we're configuring.
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
 		Mode: 0777,
 	})
 	require.NoError(t, err)
@@ -621,7 +621,7 @@ func prepareDeletePermTest(t *testing.T, fx *testFixture, dirMode uint32, dirOwn
 	require.NoError(t, err)
 
 	// 2) Create the file as root so we don't need write on parent for fileOwner.
-	_, err = fx.service.CreateFile(fx.rootContext(), parentHandle, "target.txt", &metadata.FileAttr{
+	_, _, err = fx.service.CreateFile(fx.rootContext(), parentHandle, "target.txt", &metadata.FileAttr{
 		Mode: 0644,
 	})
 	require.NoError(t, err)
@@ -630,7 +630,7 @@ func prepareDeletePermTest(t *testing.T, fx *testFixture, dirMode uint32, dirOwn
 	require.NoError(t, err)
 
 	// 3) Chown the file to its intended owner.
-	err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), fileHandle, &metadata.SetAttrs{
 		UID: metadata.Uint32Ptr(fileOwner),
 		GID: metadata.Uint32Ptr(fileOwner),
 	})
@@ -638,7 +638,7 @@ func prepareDeletePermTest(t *testing.T, fx *testFixture, dirMode uint32, dirOwn
 
 	// 4) Apply the desired parent ownership/mode last so the mode isn't masked
 	//    by earlier operations.
-	err = fx.service.SetFileAttributes(fx.rootContext(), parentHandle, &metadata.SetAttrs{
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), parentHandle, &metadata.SetAttrs{
 		Mode: metadata.Uint32Ptr(dirMode),
 		UID:  metadata.Uint32Ptr(dirOwner),
 		GID:  metadata.Uint32Ptr(dirOwner),
@@ -660,7 +660,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		parentHandle, name := prepareDeletePermTest(t, fx, 0777, 1000, 2000)
 
 		// Caller 3000 has neither ownership nor anything special — only world WRITE.
-		_, err := fx.service.RemoveFile(fx.authContext(3000, 3000), parentHandle, name)
+		_, _, err := fx.service.RemoveFile(fx.authContext(3000, 3000), parentHandle, name)
 		require.NoError(t, err)
 	})
 
@@ -677,7 +677,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		// Caller 3000 is neither owner nor has parent-WRITE. The SMB CREATE
 		// handler already verified DELETE access at open, so HasDeleteAccess
 		// is sufficient — this is the reauth5 scenario.
-		_, err := fx.service.RemoveFile(fx.smbDeleteContext(3000, 3000), parentHandle, name)
+		_, _, err := fx.service.RemoveFile(fx.smbDeleteContext(3000, 3000), parentHandle, name)
 		require.NoError(t, err)
 	})
 
@@ -690,7 +690,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		parentHandle, name := prepareDeletePermTest(t, fx, 0755, 1000, 2000)
 
 		// Caller 2000 owns the file but HasDeleteAccess is not set (NFS path).
-		_, err := fx.service.RemoveFile(fx.authContext(2000, 2000), parentHandle, name)
+		_, _, err := fx.service.RemoveFile(fx.authContext(2000, 2000), parentHandle, name)
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
@@ -707,7 +707,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		ctx := fx.smbDeleteContext(2000, 2000)
 		ctx.ShareReadOnly = true
 
-		_, err := fx.service.RemoveFile(ctx, parentHandle, name)
+		_, _, err := fx.service.RemoveFile(ctx, parentHandle, name)
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
@@ -725,7 +725,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 
 		// Caller 3000 has WRITE via world bit, but sticky restricts to
 		// root / file-owner / dir-owner.
-		_, err := fx.service.RemoveFile(fx.authContext(3000, 3000), parentHandle, name)
+		_, _, err := fx.service.RemoveFile(fx.authContext(3000, 3000), parentHandle, name)
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
@@ -742,7 +742,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		parentHandle, name := prepareDeletePermTest(t, fx, 01777, 1000, 2000)
 
 		// Caller owns the file; sticky rule explicitly permits this.
-		_, err := fx.service.RemoveFile(fx.authContext(2000, 2000), parentHandle, name)
+		_, _, err := fx.service.RemoveFile(fx.authContext(2000, 2000), parentHandle, name)
 		require.NoError(t, err)
 	})
 }
@@ -753,7 +753,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 func prepareDeletePermDirTest(t *testing.T, fx *testFixture, parentMode uint32, parentOwner, dirTargetOwner uint32) (metadata.FileHandle, string) {
 	t.Helper()
 
-	_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "parent", &metadata.FileAttr{
 		Mode: 0777,
 	})
 	require.NoError(t, err)
@@ -761,7 +761,7 @@ func prepareDeletePermDirTest(t *testing.T, fx *testFixture, parentMode uint32, 
 	parentHandle, err := fx.store.GetChild(t.Context(), fx.rootHandle, "parent")
 	require.NoError(t, err)
 
-	_, err = fx.service.CreateDirectory(fx.rootContext(), parentHandle, "target", &metadata.FileAttr{
+	_, _, err = fx.service.CreateDirectory(fx.rootContext(), parentHandle, "target", &metadata.FileAttr{
 		Mode: 0755,
 	})
 	require.NoError(t, err)
@@ -769,13 +769,13 @@ func prepareDeletePermDirTest(t *testing.T, fx *testFixture, parentMode uint32, 
 	targetHandle, err := fx.store.GetChild(t.Context(), parentHandle, "target")
 	require.NoError(t, err)
 
-	err = fx.service.SetFileAttributes(fx.rootContext(), targetHandle, &metadata.SetAttrs{
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), targetHandle, &metadata.SetAttrs{
 		UID: metadata.Uint32Ptr(dirTargetOwner),
 		GID: metadata.Uint32Ptr(dirTargetOwner),
 	})
 	require.NoError(t, err)
 
-	err = fx.service.SetFileAttributes(fx.rootContext(), parentHandle, &metadata.SetAttrs{
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), parentHandle, &metadata.SetAttrs{
 		Mode: metadata.Uint32Ptr(parentMode),
 		UID:  metadata.Uint32Ptr(parentOwner),
 		GID:  metadata.Uint32Ptr(parentOwner),
@@ -795,7 +795,7 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 
 		parentHandle, name := prepareDeletePermDirTest(t, fx, 0777, 1000, 2000)
 
-		err := fx.service.RemoveDirectory(fx.authContext(3000, 3000), parentHandle, name)
+		_, err := fx.service.RemoveDirectory(fx.authContext(3000, 3000), parentHandle, name)
 		require.NoError(t, err)
 	})
 
@@ -806,7 +806,7 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 
 		parentHandle, name := prepareDeletePermDirTest(t, fx, 0755, 1000, 2000)
 
-		err := fx.service.RemoveDirectory(fx.smbDeleteContext(3000, 3000), parentHandle, name)
+		_, err := fx.service.RemoveDirectory(fx.smbDeleteContext(3000, 3000), parentHandle, name)
 		require.NoError(t, err)
 	})
 
@@ -817,7 +817,7 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 
 		parentHandle, name := prepareDeletePermDirTest(t, fx, 0755, 1000, 2000)
 
-		err := fx.service.RemoveDirectory(fx.authContext(2000, 2000), parentHandle, name)
+		_, err := fx.service.RemoveDirectory(fx.authContext(2000, 2000), parentHandle, name)
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
@@ -834,7 +834,7 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 		ctx := fx.smbDeleteContext(2000, 2000)
 		ctx.ShareReadOnly = true
 
-		err := fx.service.RemoveDirectory(ctx, parentHandle, name)
+		_, err := fx.service.RemoveDirectory(ctx, parentHandle, name)
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
@@ -854,13 +854,13 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "old.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "old.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Rename it
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
 
 		require.NoError(t, err)
 
@@ -878,13 +878,13 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		original, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		original, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Move to same name
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "test.txt", fx.rootHandle, "test.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "test.txt", fx.rootHandle, "test.txt")
 
 		require.NoError(t, err)
 
@@ -899,27 +899,27 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create source directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "src", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "src", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 		srcDir, _ := fx.store.GetChild(context.Background(), fx.rootHandle, "src")
 
 		// Create destination directory
-		_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dst", &metadata.FileAttr{
+		_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dst", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 		dstDir, _ := fx.store.GetChild(context.Background(), fx.rootHandle, "dst")
 
 		// Create a file in source
-		_, err = fx.service.CreateFile(fx.rootContext(), srcDir, "test.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), srcDir, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Move to destination
-		err = fx.service.Move(fx.rootContext(), srcDir, "test.txt", dstDir, "test.txt")
+		_, err = fx.service.Move(fx.rootContext(), srcDir, "test.txt", dstDir, "test.txt")
 
 		require.NoError(t, err)
 
@@ -936,19 +936,19 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
 
 		// Create a file
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
 		// Try to move directory over file
-		err = fx.service.Move(fx.rootContext(), fx.rootHandle, "dir", fx.rootHandle, "file.txt")
+		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "dir", fx.rootHandle, "file.txt")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -961,7 +961,7 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a directory with sticky bit (mode 01777), owned by root
-		stickyDir, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "sticky", &metadata.FileAttr{
+		stickyDir, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "sticky", &metadata.FileAttr{
 			Mode: 0o1777, // Sticky bit + rwxrwxrwx
 			UID:  0,      // Owned by root
 			GID:  0,
@@ -974,7 +974,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.Equal(t, uint32(0o1777), stickyDir.Mode, "sticky bit should be set")
 
 		// Create destination directory (no sticky bit), owned by root, world-writable
-		_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest", &metadata.FileAttr{
+		_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest", &metadata.FileAttr{
 			Mode: 0o0777, // World-writable so user 65534 can write to it
 			UID:  0,
 			GID:  0,
@@ -983,7 +983,7 @@ func TestMetadataService_Move(t *testing.T) {
 		destDirHandle, _ := fx.store.GetChild(context.Background(), fx.rootHandle, "dest")
 
 		// Create a file in sticky dir, owned by root
-		file, err := fx.service.CreateFile(fx.rootContext(), stickyDirHandle, "rootfile.txt", &metadata.FileAttr{
+		file, _, err := fx.service.CreateFile(fx.rootContext(), stickyDirHandle, "rootfile.txt", &metadata.FileAttr{
 			Mode: 0o0644,
 			UID:  0, // Owned by root
 			GID:  0,
@@ -997,7 +997,7 @@ func TestMetadataService_Move(t *testing.T) {
 		// - User 65534 does not own the file (file owned by UID 0)
 		// - User 65534 does not own the directory (dir owned by UID 0)
 		nobodyCtx := fx.authContext(65534, 65534)
-		err = fx.service.Move(nobodyCtx, stickyDirHandle, "rootfile.txt", destDirHandle, "renamed.txt")
+		_, err = fx.service.Move(nobodyCtx, stickyDirHandle, "rootfile.txt", destDirHandle, "renamed.txt")
 
 		// Should return ErrAccessDenied
 		require.Error(t, err, "rename should fail due to sticky bit restriction")
@@ -1020,7 +1020,7 @@ func TestMetadataService_Move(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a sticky directory owned by root
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "sticky2", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "sticky2", &metadata.FileAttr{
 			Mode: 0o1777,
 			UID:  0,
 			GID:  0,
@@ -1029,7 +1029,7 @@ func TestMetadataService_Move(t *testing.T) {
 		stickyDirHandle, _ := fx.store.GetChild(context.Background(), fx.rootHandle, "sticky2")
 
 		// Create destination directory (world-writable)
-		_, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest2", &metadata.FileAttr{
+		_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dest2", &metadata.FileAttr{
 			Mode: 0o0777,
 		})
 		require.NoError(t, err)
@@ -1037,7 +1037,7 @@ func TestMetadataService_Move(t *testing.T) {
 
 		// Create a file in sticky dir, owned by user 65534
 		userCtx := fx.authContext(65534, 65534)
-		_, err = fx.service.CreateFile(userCtx, stickyDirHandle, "myfile.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(userCtx, stickyDirHandle, "myfile.txt", &metadata.FileAttr{
 			Mode: 0o0644,
 			UID:  65534, // Owned by user 65534
 			GID:  65534,
@@ -1045,7 +1045,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// User 65534 should be able to rename their own file
-		err = fx.service.Move(userCtx, stickyDirHandle, "myfile.txt", destDirHandle, "renamed.txt")
+		_, err = fx.service.Move(userCtx, stickyDirHandle, "myfile.txt", destDirHandle, "renamed.txt")
 		require.NoError(t, err, "owner should be able to rename their own file despite sticky bit")
 	})
 }
@@ -1061,7 +1061,7 @@ func TestMetadataService_CreateSymlink(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		symlink, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "/target/path", &metadata.FileAttr{})
+		symlink, _, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "/target/path", &metadata.FileAttr{})
 
 		require.NoError(t, err)
 		assert.Equal(t, metadata.FileTypeSymlink, symlink.Type)
@@ -1073,7 +1073,7 @@ func TestMetadataService_CreateSymlink(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)
 
-		_, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "", &metadata.FileAttr{})
+		_, _, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "", &metadata.FileAttr{})
 
 		require.Error(t, err)
 	})
@@ -1087,7 +1087,7 @@ func TestMetadataService_ReadSymlink(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create symlink
-		_, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "/target/path", &metadata.FileAttr{})
+		_, _, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "link", "/target/path", &metadata.FileAttr{})
 		require.NoError(t, err)
 
 		// Get handle
@@ -1107,7 +1107,7 @@ func TestMetadataService_ReadSymlink(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create regular file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1135,7 +1135,7 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create target file
-		target, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
+		target, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1146,7 +1146,7 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create hard link
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link.txt", targetHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link.txt", targetHandle)
 
 		require.NoError(t, err)
 
@@ -1161,7 +1161,7 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create directory
-		_, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
+		_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dir", &metadata.FileAttr{
 			Mode: 0755,
 		})
 		require.NoError(t, err)
@@ -1171,7 +1171,7 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create hard link to directory
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link", dirHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link", dirHandle)
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -1184,12 +1184,12 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create two files
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "target.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
 
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "existing.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "existing.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1199,7 +1199,7 @@ func TestMetadataService_CreateHardLink(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create link with existing name
-		err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "existing.txt", targetHandle)
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "existing.txt", targetHandle)
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -1220,7 +1220,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file as root
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 			UID:  1000,
 			GID:  1000,
@@ -1233,7 +1233,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 
 		// Change mode as owner
 		newMode := uint32(0600)
-		err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
 			Mode: &newMode,
 		})
 
@@ -1250,7 +1250,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 			UID:  1000,
 			GID:  1000,
@@ -1263,7 +1263,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 
 		// Try to change owner as non-root
 		newUID := uint32(2000)
-		err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
 			UID: &newUID,
 		})
 
@@ -1278,7 +1278,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1289,7 +1289,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 
 		// Change owner as root
 		newUID := uint32(2000)
-		err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{
 			UID: &newUID,
 		})
 
@@ -1306,7 +1306,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file owned by different user
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 			UID:  2000,
 			GID:  2000,
@@ -1319,7 +1319,7 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 
 		// Try to change mode as different user
 		newMode := uint32(0600)
-		err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
+		_, err = fx.service.SetFileAttributes(fx.userContext(), handle, &metadata.SetAttrs{
 			Mode: &newMode,
 		})
 
@@ -1339,7 +1339,7 @@ func TestMetadataService_PrepareWrite(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1379,7 +1379,7 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1403,7 +1403,7 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create setuid file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0o4755, // setuid
 			UID:  1000,
 			GID:  1000,
@@ -1429,7 +1429,7 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "frozen.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "frozen.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1488,7 +1488,7 @@ func TestMetadataService_PrepareRead(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1542,9 +1542,9 @@ func TestMetadataService_ReadDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create some files
-		_, _ = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file1.txt", &metadata.FileAttr{Mode: 0644})
-		_, _ = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file2.txt", &metadata.FileAttr{Mode: 0644})
-		_, _ = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{Mode: 0755})
+		_, _, _ = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file1.txt", &metadata.FileAttr{Mode: 0644})
+		_, _, _ = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file2.txt", &metadata.FileAttr{Mode: 0644})
+		_, _, _ = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "subdir", &metadata.FileAttr{Mode: 0755})
 
 		page, err := fx.service.ReadDirectory(fx.rootContext(), fx.rootHandle, 0, 0)
 
@@ -1557,7 +1557,7 @@ func TestMetadataService_ReadDirectory(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create a file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1588,7 +1588,7 @@ func TestMetadataService_LockFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1629,7 +1629,7 @@ func TestMetadataService_LockFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1669,7 +1669,7 @@ func TestMetadataService_UnlockFile(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1702,7 +1702,7 @@ func TestMetadataService_TestLock(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1724,7 +1724,7 @@ func TestMetadataService_TestLock(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1760,7 +1760,7 @@ func TestMetadataService_CheckLockForIO(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1780,7 +1780,7 @@ func TestMetadataService_CheckLockForIO(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1818,7 +1818,7 @@ func TestMetadataService_ContextCancellation(t *testing.T) {
 		fx := newTestFixture(t)
 
 		// Create file
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)
@@ -1949,7 +1949,7 @@ func TestTimestampUpdates(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 
 		// Create file
-		_, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
+		_, _, err = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "test.txt", &metadata.FileAttr{
 			Mode: 0644,
 		})
 		require.NoError(t, err)

--- a/pkg/metadata/storetest/trash_conformance.go
+++ b/pkg/metadata/storetest/trash_conformance.go
@@ -109,7 +109,7 @@ func runTrashConformanceTests(t *testing.T, factory StoreFactory) {
 // trashCreateFile creates a regular file with the given mode under parent.
 func (fx *trashFixture) trashCreateFile(t *testing.T, parent metadata.FileHandle, name string, mode uint32) {
 	t.Helper()
-	if _, err := fx.svc.CreateFile(fx.ctx, parent, name, &metadata.FileAttr{Mode: mode}); err != nil {
+	if _, _, err := fx.svc.CreateFile(fx.ctx, parent, name, &metadata.FileAttr{Mode: mode}); err != nil {
 		t.Fatalf("CreateFile(%q) failed: %v", name, err)
 	}
 }
@@ -117,7 +117,7 @@ func (fx *trashFixture) trashCreateFile(t *testing.T, parent metadata.FileHandle
 // trashMkdir creates a directory under parent and returns its handle.
 func (fx *trashFixture) trashMkdir(t *testing.T, parent metadata.FileHandle, name string, mode uint32) metadata.FileHandle {
 	t.Helper()
-	dir, err := fx.svc.CreateDirectory(fx.ctx, parent, name, &metadata.FileAttr{Mode: mode})
+	dir, _, err := fx.svc.CreateDirectory(fx.ctx, parent, name, &metadata.FileAttr{Mode: mode})
 	if err != nil {
 		t.Fatalf("CreateDirectory(%q) failed: %v", name, err)
 	}
@@ -161,7 +161,7 @@ func testUnlinkRecyclesIntoBin(t *testing.T, factory StoreFactory) {
 	fx := newTrashService(t, factory, nil)
 	fx.trashCreateFile(t, fx.rootHandle, "doc.txt", 0644)
 
-	removed, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "doc.txt")
+	removed, _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "doc.txt")
 	if err != nil {
 		t.Fatalf("RemoveFile(doc.txt) failed: %v", err)
 	}
@@ -195,14 +195,14 @@ func testDeleteInsideBinIsPermanent(t *testing.T, factory StoreFactory) {
 	fx := newTrashService(t, factory, nil)
 	fx.trashCreateFile(t, fx.rootHandle, "doc.txt", 0644)
 
-	if _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "doc.txt"); err != nil {
+	if _, _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "doc.txt"); err != nil {
 		t.Fatalf("RemoveFile(doc.txt) failed: %v", err)
 	}
 	bin := fx.trashBinHandle(t)
 
 	// Deleting the entry already inside #recycle must be permanent: a real
 	// PayloadID is returned (so blocks are reaped) and no nested bin is made.
-	removed, err := fx.svc.RemoveFile(fx.ctx, bin, "doc.txt")
+	removed, _, err := fx.svc.RemoveFile(fx.ctx, bin, "doc.txt")
 	if err != nil {
 		t.Fatalf("RemoveFile(#recycle/doc.txt) failed: %v", err)
 	}
@@ -226,7 +226,7 @@ func testExcludePatternBypassesBin(t *testing.T, factory StoreFactory) {
 	fx := newTrashService(t, factory, []string{"*.tmp"})
 	fx.trashCreateFile(t, fx.rootHandle, "scratch.tmp", 0644)
 
-	removed, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "scratch.tmp")
+	removed, _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "scratch.tmp")
 	if err != nil {
 		t.Fatalf("RemoveFile(scratch.tmp) failed: %v", err)
 	}
@@ -249,7 +249,7 @@ func testCollisionGetsUniqueName(t *testing.T, factory StoreFactory) {
 	// the same name. The second must NOT overwrite the first.
 	for i := 0; i < 2; i++ {
 		fx.trashCreateFile(t, fx.rootHandle, "a.txt", 0644)
-		if _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "a.txt"); err != nil {
+		if _, _, err := fx.svc.RemoveFile(fx.ctx, fx.rootHandle, "a.txt"); err != nil {
 			t.Fatalf("RemoveFile(a.txt) iteration %d failed: %v", i, err)
 		}
 	}
@@ -294,7 +294,7 @@ func testSubtreeRecycledAsOneEntry(t *testing.T, factory StoreFactory) {
 
 	// RemoveDirectory on a non-empty dir recycles the whole subtree (no
 	// ErrNotEmpty).
-	if err := fx.svc.RemoveDirectory(fx.ctx, fx.rootHandle, "project"); err != nil {
+	if _, err := fx.svc.RemoveDirectory(fx.ctx, fx.rootHandle, "project"); err != nil {
 		t.Fatalf("RemoveDirectory(project) failed: %v", err)
 	}
 	fx.trashLookupMissing(t, fx.rootHandle, "project")
@@ -329,7 +329,7 @@ func testOverwriteRecyclesVictim(t *testing.T, factory StoreFactory) {
 	fx.trashCreateFile(t, fx.rootHandle, "b", modeB)
 
 	// Rename "b" onto "a" — an overwrite that recycles the old "a".
-	if err := fx.svc.Move(fx.ctx, fx.rootHandle, "b", fx.rootHandle, "a"); err != nil {
+	if _, err := fx.svc.Move(fx.ctx, fx.rootHandle, "b", fx.rootHandle, "a"); err != nil {
 		t.Fatalf("Move(b -> a) failed: %v", err)
 	}
 

--- a/pkg/metadata/storetest/truncate_block_refs.go
+++ b/pkg/metadata/storetest/truncate_block_refs.go
@@ -75,7 +75,7 @@ func testTruncateDownPrunesBlockRefs(t *testing.T, factory StoreFactory) {
 		Identity: &metadata.Identity{UID: &rootUID, GID: &rootUID},
 	}
 	newSize := mib
-	if err := svc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Size: &newSize}); err != nil {
+	if _, err := svc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Size: &newSize}); err != nil {
 		t.Fatalf("SetFileAttributes(size=1MiB) failed: %v", err)
 	}
 

--- a/pkg/metadata/suid_clearing_test.go
+++ b/pkg/metadata/suid_clearing_test.go
@@ -57,7 +57,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	}
 
 	// 1. Root creates file with mode 04777 (SUID + world-writable)
-	_, err = svc.CreateFile(rootCtx, rootHandle, "suidfile", &metadata.FileAttr{
+	_, _, err = svc.CreateFile(rootCtx, rootHandle, "suidfile", &metadata.FileAttr{
 		Mode: 0o4777,
 		UID:  0,
 		GID:  0,
@@ -76,7 +76,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	// 2. Simulate Linux NFS client file_remove_privs(): SETATTR(mode = 0777)
 	// This is what the client sends before WRITE when SUID bits are set
 	clearedMode := uint32(0o0777)
-	err = svc.SetFileAttributes(nobodyCtx, handle, &metadata.SetAttrs{
+	_, err = svc.SetFileAttributes(nobodyCtx, handle, &metadata.SetAttrs{
 		Mode: &clearedMode,
 	})
 	t.Logf("SetFileAttributes error: %v", err)
@@ -91,7 +91,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	assert.Equal(t, uint32(0o0777), file.Mode, "SUID bits should be cleared")
 
 	// 4. Also test SGID (02777 -> 0777)
-	_, err = svc.CreateFile(rootCtx, rootHandle, "sgidfile", &metadata.FileAttr{
+	_, _, err = svc.CreateFile(rootCtx, rootHandle, "sgidfile", &metadata.FileAttr{
 		Mode: 0o2777,
 		UID:  0,
 		GID:  0,
@@ -106,7 +106,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	t.Logf("SGID file mode after creation: %04o", file2.Mode)
 
 	sgidCleared := uint32(0o0777)
-	err = svc.SetFileAttributes(nobodyCtx, handle2, &metadata.SetAttrs{
+	_, err = svc.SetFileAttributes(nobodyCtx, handle2, &metadata.SetAttrs{
 		Mode: &sgidCleared,
 	})
 	t.Logf("SGID SetFileAttributes error: %v", err)
@@ -118,7 +118,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	assert.Equal(t, uint32(0o0777), file2.Mode, "SGID bits should be cleared")
 
 	// 5. Test SUID+SGID combo (06777 -> 0777)
-	_, err = svc.CreateFile(rootCtx, rootHandle, "susgidfile", &metadata.FileAttr{
+	_, _, err = svc.CreateFile(rootCtx, rootHandle, "susgidfile", &metadata.FileAttr{
 		Mode: 0o6777,
 		UID:  0,
 		GID:  0,
@@ -129,7 +129,7 @@ func TestSUIDClearingViaSetAttr(t *testing.T) {
 	require.NoError(t, err)
 
 	bothCleared := uint32(0o0777)
-	err = svc.SetFileAttributes(nobodyCtx, handle3, &metadata.SetAttrs{
+	_, err = svc.SetFileAttributes(nobodyCtx, handle3, &metadata.SetAttrs{
 		Mode: &bothCleared,
 	})
 	require.NoError(t, err, "non-owner should be allowed to clear both SUID+SGID bits")

--- a/pkg/metadata/suid_write_test.go
+++ b/pkg/metadata/suid_write_test.go
@@ -57,7 +57,7 @@ func TestSUIDClearingOnWrite(t *testing.T) {
 
 	t.Run("SUID cleared on non-root write via deferred commit", func(t *testing.T) {
 		// 1. Root creates file with SUID + world-writable
-		_, err := svc.CreateFile(rootCtx, rootHandle, "suidfile", &metadata.FileAttr{
+		_, _, err := svc.CreateFile(rootCtx, rootHandle, "suidfile", &metadata.FileAttr{
 			Mode: 0o4777,
 			UID:  0,
 			GID:  0,
@@ -98,7 +98,7 @@ func TestSUIDClearingOnWrite(t *testing.T) {
 	})
 
 	t.Run("SGID cleared on non-root write via deferred commit", func(t *testing.T) {
-		_, err := svc.CreateFile(rootCtx, rootHandle, "sgidfile", &metadata.FileAttr{
+		_, _, err := svc.CreateFile(rootCtx, rootHandle, "sgidfile", &metadata.FileAttr{
 			Mode: 0o2777,
 			UID:  0,
 			GID:  0,
@@ -121,7 +121,7 @@ func TestSUIDClearingOnWrite(t *testing.T) {
 	})
 
 	t.Run("SUID+SGID cleared on non-root write via deferred commit", func(t *testing.T) {
-		_, err := svc.CreateFile(rootCtx, rootHandle, "bothfile", &metadata.FileAttr{
+		_, _, err := svc.CreateFile(rootCtx, rootHandle, "bothfile", &metadata.FileAttr{
 			Mode: 0o6777,
 			UID:  0,
 			GID:  0,
@@ -144,7 +144,7 @@ func TestSUIDClearingOnWrite(t *testing.T) {
 	})
 
 	t.Run("Root write does NOT clear SUID", func(t *testing.T) {
-		_, err := svc.CreateFile(rootCtx, rootHandle, "rootwrite", &metadata.FileAttr{
+		_, _, err := svc.CreateFile(rootCtx, rootHandle, "rootwrite", &metadata.FileAttr{
 			Mode: 0o4777,
 			UID:  0,
 			GID:  0,

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -24,17 +24,18 @@ func TestRemoveFile_HardLinkSurvives(t *testing.T) {
 	fx := newTestFixture(t)
 	ctx := context.Background()
 
-	_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
 
 	target, err := fx.store.GetChild(ctx, fx.rootHandle, "a.txt")
 	require.NoError(t, err)
 
 	// Add a second link → nlink=2.
-	require.NoError(t, fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "b.txt", target))
+	_, hlErr := fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "b.txt", target)
+	require.NoError(t, hlErr)
 
 	// Removing one link drops nlink to 1, content stays referenced.
-	removed, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "a.txt")
+	removed, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "a.txt")
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), removed.Nlink, "one surviving link expected")
 	assert.Empty(t, removed.PayloadID, "content must not be eligible for deletion while a link remains")
@@ -62,25 +63,26 @@ func TestRemoveFile_ConcurrentCreateHardLink(t *testing.T) {
 		fx := newTestFixture(t)
 		ctx := context.Background()
 
-		_, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "orig.txt", &metadata.FileAttr{Mode: 0644})
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "orig.txt", &metadata.FileAttr{Mode: 0644})
 		require.NoError(t, err)
 		target, err := fx.store.GetChild(ctx, fx.rootHandle, "orig.txt")
 		require.NoError(t, err)
 
 		// Pre-create a second link so the file starts at nlink=2.
-		require.NoError(t, fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link1.txt", target))
+		_, hlErr := fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link1.txt", target)
+		require.NoError(t, hlErr)
 
 		var wg sync.WaitGroup
 		wg.Add(2)
 		// Goroutine A: add a third link concurrently.
 		go func() {
 			defer wg.Done()
-			_ = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link2.txt", target)
+			_, _ = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link2.txt", target)
 		}()
 		// Goroutine B: remove the original link concurrently.
 		go func() {
 			defer wg.Done()
-			_, _ = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "orig.txt")
+			_, _, _ = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "orig.txt")
 		}()
 		wg.Wait()
 
@@ -174,9 +176,9 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 		ClientAddr: "127.0.0.1",
 	}
 
-	_, err = svc.CreateFile(rootCtx, rootHandle, "myfile.txt", &metadata.FileAttr{Mode: 0644})
+	_, _, err = svc.CreateFile(rootCtx, rootHandle, "myfile.txt", &metadata.FileAttr{Mode: 0644})
 	require.NoError(t, err)
-	_, err = svc.CreateDirectory(rootCtx, rootHandle, "dest", &metadata.FileAttr{Mode: 0755})
+	_, _, err = svc.CreateDirectory(rootCtx, rootHandle, "dest", &metadata.FileAttr{Mode: 0755})
 	require.NoError(t, err)
 	destHandle, err := store.GetChild(ctx, rootHandle, "dest")
 	require.NoError(t, err)
@@ -185,7 +187,7 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// The move must fail with the injected error.
-	err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")
+	_, err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")
 	require.Error(t, err, "Move must surface the injected PutFile failure, not swallow it")
 	require.ErrorIs(t, err, errPutFileInjected)
 

--- a/pkg/metadata/wcc.go
+++ b/pkg/metadata/wcc.go
@@ -1,0 +1,33 @@
+package metadata
+
+// DirWcc carries the parent-directory attributes captured atomically with a
+// mutating metadata operation, for protocol weak-cache-consistency (WCC) data.
+//
+// Before holds the directory attributes as they were immediately before the
+// mutation; After holds them immediately after. Both are captured inside the
+// same store transaction that performs the mutation, so the pair is guaranteed
+// to bracket the operation with no intervening modification — closing the
+// time-of-check/time-of-use window that exists when a handler reads the
+// directory separately (a stale Before could otherwise describe a state that
+// never preceded the operation, corrupting the client's cached view).
+//
+// Either field may be nil if the directory attributes could not be captured
+// (e.g. an early error); callers must tolerate nil.
+type DirWcc struct {
+	// Before is a copy of the parent directory attributes prior to the mutation.
+	Before *FileAttr
+
+	// After is a copy of the parent directory attributes after the mutation.
+	After *FileAttr
+}
+
+// RenameWcc carries the source- and destination-directory attributes captured
+// atomically with a Move/rename, for protocol WCC data on both directories (H9).
+// FromDir and ToDir are the same DirWcc instance when the move is intra-directory.
+type RenameWcc struct {
+	// FromDir holds the source parent directory's pre/post attributes.
+	FromDir *DirWcc
+
+	// ToDir holds the destination parent directory's pre/post attributes.
+	ToDir *DirWcc
+}

--- a/pkg/metadata/wcc_contract_test.go
+++ b/pkg/metadata/wcc_contract_test.go
@@ -1,0 +1,202 @@
+package metadata_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests assert the H9 contract: every mutating MetadataService method
+// returns the affected directory's pre- and post-operation attributes, captured
+// atomically with the mutation (inside the same store transaction). Protocol
+// handlers consume these for WCC data instead of doing a separate GetFile that
+// could race a concurrent mutation in the window.
+
+func childHandle(t *testing.T, fx *testFixture, parent metadata.FileHandle, name string) metadata.FileHandle {
+	t.Helper()
+	h, err := fx.service.GetChild(fx.rootContext().Context, parent, name)
+	require.NoError(t, err)
+	return h
+}
+
+// assertBracketsMutation verifies a DirWcc looks like a real before/after pair:
+// both halves present and the post-op mtime is not before the pre-op mtime.
+func assertBracketsMutation(t *testing.T, wcc *metadata.DirWcc) {
+	t.Helper()
+	require.NotNil(t, wcc, "mutation must return DirWcc")
+	require.NotNil(t, wcc.Before, "DirWcc.Before must be captured")
+	require.NotNil(t, wcc.After, "DirWcc.After must be captured")
+	assert.False(t, wcc.After.Mtime.Before(wcc.Before.Mtime),
+		"post-op mtime must not precede pre-op mtime")
+}
+
+func TestWCC_CreateFile_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	pre, err := fx.store.GetFile(fx.rootContext().Context, fx.rootHandle)
+	require.NoError(t, err)
+
+	_, wcc, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "f.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+	// Before must equal the directory state observed immediately prior.
+	assert.Equal(t, pre.Mtime.UnixNano(), wcc.Before.Mtime.UnixNano(),
+		"DirWcc.Before must equal the pre-op directory mtime")
+}
+
+func TestWCC_CreateDirectory_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	_, wcc, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "d", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+}
+
+func TestWCC_CreateSymlink_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	_, wcc, err := fx.service.CreateSymlink(fx.rootContext(), fx.rootHandle, "l", "/target", &metadata.FileAttr{
+		Type: metadata.FileTypeSymlink, Mode: 0o777,
+	})
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+}
+
+func TestWCC_RemoveFile_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "f.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+
+	_, wcc, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "f.txt")
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+}
+
+func TestWCC_RemoveDirectory_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "d", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+
+	wcc, err := fx.service.RemoveDirectory(fx.rootContext(), fx.rootHandle, "d")
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+}
+
+func TestWCC_CreateHardLink_ReturnsDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "orig.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+	target := childHandle(t, fx, fx.rootHandle, "orig.txt")
+
+	wcc, err := fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link.txt", target)
+	require.NoError(t, err)
+	assertBracketsMutation(t, wcc)
+}
+
+func TestWCC_SetFileAttributes_ReturnsFileAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	f, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "f.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+	fh, err := metadata.EncodeFileHandle(f)
+	require.NoError(t, err)
+
+	newMode := uint32(0o600)
+	wcc, err := fx.service.SetFileAttributes(fx.rootContext(), fh, &metadata.SetAttrs{Mode: &newMode})
+	require.NoError(t, err)
+	require.NotNil(t, wcc)
+	require.NotNil(t, wcc.Before)
+	require.NotNil(t, wcc.After)
+	// For SETATTR the WCC subject is the file itself.
+	assert.EqualValues(t, 0o644, wcc.Before.Mode, "Before must reflect the pre-op file mode")
+	assert.EqualValues(t, 0o600, wcc.After.Mode, "After must reflect the post-op file mode")
+}
+
+func TestWCC_Move_ReturnsBothDirAttrs(t *testing.T) {
+	fx := newTestFixture(t)
+	// Source and destination directories.
+	_, _, err := fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "src", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	_, _, err = fx.service.CreateDirectory(fx.rootContext(), fx.rootHandle, "dst", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	srcDir := childHandle(t, fx, fx.rootHandle, "src")
+	dstDir := childHandle(t, fx, fx.rootHandle, "dst")
+	_, _, err = fx.service.CreateFile(fx.rootContext(), srcDir, "f.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+
+	rw, err := fx.service.Move(fx.rootContext(), srcDir, "f.txt", dstDir, "f.txt")
+	require.NoError(t, err)
+	require.NotNil(t, rw)
+	assertBracketsMutation(t, rw.FromDir)
+	assertBracketsMutation(t, rw.ToDir)
+	assert.NotSame(t, rw.FromDir, rw.ToDir, "cross-directory move must report distinct DirWcc")
+}
+
+func TestWCC_Move_SameDirectorySharesDirWcc(t *testing.T) {
+	fx := newTestFixture(t)
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "a.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+
+	rw, err := fx.service.Move(fx.rootContext(), fx.rootHandle, "a.txt", fx.rootHandle, "b.txt")
+	require.NoError(t, err)
+	require.NotNil(t, rw)
+	assert.Same(t, rw.FromDir, rw.ToDir, "intra-directory move must share one DirWcc")
+	assertBracketsMutation(t, rw.FromDir)
+}
+
+// TestWCC_RemoveFile_PreOpAttrsAreAtomic is the core H9 regression guard. It
+// runs many concurrent RemoveFile + CreateFile cycles and asserts the pre-op
+// directory mtime returned by each RemoveFile never exceeds its post-op mtime —
+// i.e. the Before snapshot genuinely precedes the mutation rather than being a
+// separately-read value that a concurrent mutation could have advanced past.
+func TestWCC_RemoveFile_PreOpAttrsAreAtomic(t *testing.T) {
+	fx := newTestFixture(t)
+	const workers = 8
+	const iters = 50
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			name := "concurrent.txt"
+			for i := 0; i < iters; i++ {
+				// Create then remove; ignore ErrAlreadyExists / ErrNoEntity from
+				// the inherent races between workers — we only assert the WCC
+				// invariant on successful removals.
+				_, _, _ = fx.service.CreateFile(fx.rootContext(), fx.rootHandle, name, &metadata.FileAttr{
+					Type: metadata.FileTypeRegular, Mode: 0o644,
+				})
+				_, wcc, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, name)
+				if err != nil {
+					continue
+				}
+				require.NotNil(t, wcc)
+				if wcc.Before != nil && wcc.After != nil {
+					assert.False(t, wcc.After.Mtime.Before(wcc.Before.Mtime),
+						"pre-op mtime must not be after post-op mtime (TOCTOU)")
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Ships the three HIGH NFSv3-interop correctness findings from the area-#4 audit (`.planning/v1.0-audit/nfs/REVIEW.md` H9/H10/H11). Closes #1002.

## H9 — WCC pre-op attrs captured non-atomically (TOCTOU)
Every mutating v3 handler read the parent directory with a separate `GetFile` to build `wccBefore`, then mutated — a concurrent mutation in that window produced a pre-op snapshot that never preceded the operation, silently corrupting the client's weak-cache-consistency view (RFC 1813 §2.6).

Fix mirrors the WRITE model (`PrepareWrite` → `PreWriteAttr`): each `MetadataService` mutation method now returns the affected directory's pre/post attrs captured **inside the same store transaction** as the mutation. The parent is re-read inside the txn and the timestamp mutation is based on that in-txn snapshot, so `Before`/`After` atomically bracket the op (After monotonic w.r.t. Before) and the in-txn read registers the key for the backend's read/write conflict detection.

**Contract change (`MetadataService` only — backends unaffected, they already expose `tx.GetFile`):**
- `RemoveFile`, `CreateFile`, `CreateDirectory`, `CreateSymlink`, `CreateSpecialFile`, `CreateHardLink`, `RemoveDirectory`, `SetFileAttributes` → now return `*metadata.DirWcc`
- `Move` → returns `*metadata.RenameWcc` (source + destination dirs; shared instance for intra-dir moves)

v3 handlers consume it via a shared `dirWccPair` helper; v4/SMB/trash call sites discard it. SETATTR's WCC subject is the file itself. `storetest`/badger/postgres/memory conformance suites stay green. Added service-level WCC contract tests + a concurrent RemoveFile+CreateFile storm that fails if the pre-op snapshot is not atomic.

## H10 — WRITE hardcoded 1 MB cap → wrong NFS3ERR_FBIG
`write.go` used `const maxWriteSize = 1<<20` decoupled from the advertised FSINFO `wtmax`, and returned `NFS3ERR_FBIG` for an over-large request. Now the cap derives from `GetFilesystemCapabilities().MaxWriteSize` (the same value FSINFO advertises), and an over-large request is **short-written** (data truncated to the cap, reply `Count` reflects the actual bytes) per RFC 1813 §3.3.7 — matching Linux nfsd's clamp to `svc_max_payload`. FBIG is now reserved for genuine offset/OffsetMax overflow.

## H11 — READDIRPLUS ignored client maxcount byte budget
Entries were appended with no running tally vs `MaxCount` → oversized replies the client truncates/rejects. Now tracks the XDR-encoded reply size and stops before exceeding `maxcount` (total reply) or `dircount` (directory-info) per RFC 1813 §3.3.17, setting `eof=false` on truncation so the client resumes from the last cookie. Always emits ≥1 entry for forward progress. Added maxcount/dircount truncation tests (with an encoded-size assertion + resume check).

## Gates
`go build ./...`, `go vet`, `go fmt`, `go test -race ./internal/adapter/nfs/... ./pkg/metadata/...` (incl. conformance), and `go test -race -tags=integration ./pkg/metadata/store/badger/...` all green. SMB/runtime/trash suites green (no behavior change — they discard the new WCC return).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
