### PR TITLE
fix(nfs/v3): duplicate-request cache for non-idempotent procedures (#1003)

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -128,6 +128,12 @@ type NFSAdapter struct {
 	// shareUnsubscribers holds unsubscribe functions returned by rt.OnShareChange.
 	// Called during Stop to prevent stale callbacks from accumulating across restarts.
 	shareUnsubscribers []func()
+
+	// drc is the server-wide duplicate-request cache for non-idempotent NFSv3
+	// procedures. It replays the recorded reply of a completed op when a client
+	// retransmits the same request (RPC-timeout retry on a hard mount), so the
+	// retry does not re-execute and return a spurious EEXIST/ENOENT/NOT_SYNC.
+	drc *duplicateRequestCache
 }
 
 // NFSTimeoutsConfig groups all timeout-related configuration.
@@ -334,6 +340,7 @@ func New(
 		config:       nfsConfig,
 		nfsHandler:   &v3.Handler{},
 		mountHandler: &mount.Handler{},
+		drc:          newDuplicateRequestCache(),
 	}
 }
 

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -23,6 +23,13 @@ import (
 // incoming message is a backchannel REPLY (msg_type=1) rather than a CALL.
 var errBackchannelReply = errors.New("backchannel reply routed")
 
+// errDropReply is a sentinel error signalling that no reply must be written for
+// this request: it is a duplicate of an op still in flight (DRC in-progress).
+// The original request owns the XID and will send the single authoritative
+// reply, mirroring nfsd's RC_DROPIT. handleRPCCall recognises it and returns
+// without emitting any RPC reply.
+var errDropReply = errors.New("duplicate request dropped")
+
 // NFSConnection handles a single NFS client TCP connection.
 // Requests are read sequentially from the wire but dispatched concurrently
 // via goroutines, bounded by requestSem. Replies are serialized by writeMu.

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -211,6 +211,13 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 	}
 
 	if err != nil {
+		// Duplicate of an in-flight request (DRC): write nothing. The original
+		// request owns the XID and will send the single authoritative reply.
+		if errors.Is(err, errDropReply) {
+			logger.Debug("Dropping duplicate request without reply", "program", call.Program, "procedure", call.Procedure, "xid", fmt.Sprintf("0x%x", call.XID), "client", clientAddr)
+			return nil
+		}
+
 		// Check if error was due to context cancellation
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			logger.Debug("Handler cancelled", "program", call.Program, "procedure", call.Procedure, "xid", fmt.Sprintf("0x%x", call.XID), "client", clientAddr, "error", err)

--- a/pkg/adapter/nfs/drc.go
+++ b/pkg/adapter/nfs/drc.go
@@ -1,0 +1,240 @@
+package nfs
+
+import (
+	"hash/crc32"
+	"sync"
+	"time"
+
+	nfs_types "github.com/marmos91/dittofs/internal/adapter/nfs/types"
+)
+
+// ============================================================================
+// NFSv3 Duplicate-Request Cache (DRC)
+// ============================================================================
+//
+// On a hard NFS mount a client that times out an RPC retransmits the *same*
+// request (same XID). For idempotent procedures (GETATTR, LOOKUP, READ, WRITE,
+// READDIR, ...) re-executing is harmless. For non-idempotent procedures
+// (REMOVE, RMDIR, RENAME, non-exclusive CREATE, MKDIR, LINK, SYMLINK, MKNOD,
+// SETATTR-with-guard) re-execution produces a spurious error: the second
+// REMOVE returns NFS3ERR_NOENT, the second MKDIR/CREATE returns NFS3ERR_EXIST,
+// a guarded SETATTR returns NFS3ERR_NOT_SYNC, etc. The client surfaces that as
+// a real failure even though its original op succeeded.
+//
+// This cache mirrors the Linux server reply cache (fs/nfsd/nfscache.c): it
+// records the encoded reply of a completed non-idempotent op keyed by
+// (source address, XID, request-body checksum) and, on a confirmed duplicate,
+// replays the recorded bytes instead of re-invoking the handler.
+//
+// Why all three key fields: the data path is TCP, but an RPC-timeout retransmit
+// on a hard mount can arrive on a *reconnected* connection with a fresh source
+// port, and a client is free to reuse an XID for a brand-new request once the
+// old one is believed complete. XID alone is therefore not collision-safe. The
+// request-body checksum (as in nfscache.c) disambiguates an XID reused for a
+// genuinely different request from a true retransmit of the same bytes.
+//
+// Idempotent procedures bypass this cache entirely and are never recorded —
+// caching their (often large) replies would waste memory for no correctness
+// benefit. CREATE-exclusive is already idempotent via its create verifier
+// (the metadata store stores an IdempotencyToken), so a retransmit re-resolves
+// to the same file; it flows through the non-idempotent CREATE path here
+// harmlessly (recording its reply is correct and cheap).
+
+const (
+	// drcMaxEntries bounds the cache. The Linux reply cache scales its hash
+	// table with RAM but caps the working set in the low thousands; 4096 covers
+	// the in-flight + recently-completed non-idempotent ops of many concurrent
+	// clients while bounding memory to a few MB of small reply blobs.
+	drcMaxEntries = 4096
+
+	// drcTTL is how long a completed reply is retained for replay. NFS client
+	// retransmit timeouts are on the order of seconds and back off; a few
+	// seconds of retention catches the retransmit window without holding stale
+	// replies. Mirrors the short lifetime of nfsd reply-cache DONE entries.
+	drcTTL = 8 * time.Second
+)
+
+// drcState is the lifecycle of a cache entry, mirroring nfsd's RC_INPROG /
+// RC_REPLY distinction.
+type drcState uint8
+
+const (
+	// drcInProgress: the original request is still executing. A duplicate that
+	// arrives in this window is dropped (no reply written) — the in-flight
+	// original will produce the single authoritative reply.
+	drcInProgress drcState = iota
+
+	// drcDone: the original completed and its reply bytes are cached for replay.
+	drcDone
+)
+
+// drcKey identifies a request. Two requests are "the same" iff all three match.
+type drcKey struct {
+	srcAddr  string // client source address (host:port)
+	xid      uint32 // RPC transaction id
+	checksum uint32 // CRC-32 of the request body (disambiguates XID reuse)
+}
+
+// drcEntry is a cached request slot.
+type drcEntry struct {
+	state    drcState
+	reply    []byte    // encoded reply bytes (valid only when state == drcDone)
+	inserted time.Time // for TTL eviction
+}
+
+// drcLookupResult tells the dispatch path what to do for an incoming request.
+type drcLookupResult uint8
+
+const (
+	// drcMiss: not seen before; the caller registered an in-progress entry and
+	// MUST run the handler, then call Record with the reply.
+	drcMiss drcLookupResult = iota
+
+	// drcReplay: a completed duplicate; the caller MUST return the cached reply
+	// and MUST NOT run the handler.
+	drcReplay
+
+	// drcInProgressDup: a duplicate of a still-executing request; the caller
+	// MUST drop the request (write nothing) and let the original reply.
+	drcInProgressDup
+)
+
+// duplicateRequestCache is a server-wide bounded reply cache for non-idempotent
+// NFSv3 procedures. Safe for concurrent use.
+type duplicateRequestCache struct {
+	mu         sync.Mutex
+	entries    map[drcKey]*drcEntry
+	maxEntries int
+	ttl        time.Duration
+	now        func() time.Time // injectable clock for tests
+}
+
+func newDuplicateRequestCache() *duplicateRequestCache {
+	return &duplicateRequestCache{
+		entries:    make(map[drcKey]*drcEntry),
+		maxEntries: drcMaxEntries,
+		ttl:        drcTTL,
+		now:        time.Now,
+	}
+}
+
+// drcCachedProcs is the set of non-idempotent NFSv3 procedures whose replies
+// are cached. Every other procedure bypasses the cache.
+var drcCachedProcs = map[uint32]struct{}{
+	nfs_types.NFSProcSetAttr: {}, // guarded SETATTR is non-idempotent (NFS3ERR_NOT_SYNC on replay)
+	nfs_types.NFSProcCreate:  {},
+	nfs_types.NFSProcMkdir:   {},
+	nfs_types.NFSProcSymlink: {},
+	nfs_types.NFSProcMknod:   {},
+	nfs_types.NFSProcRemove:  {},
+	nfs_types.NFSProcRmdir:   {},
+	nfs_types.NFSProcRename:  {},
+	nfs_types.NFSProcLink:    {},
+}
+
+// isCacheable reports whether a procedure's reply should flow through the DRC.
+// Idempotent procedures (GETATTR, LOOKUP, READ, WRITE, READDIR, ...) return false
+// and never touch the cache.
+func isCacheable(procedure uint32) bool {
+	_, ok := drcCachedProcs[procedure]
+	return ok
+}
+
+// lookup classifies an incoming request and, on a miss, atomically reserves an
+// in-progress slot so concurrent duplicates are detected. The key is built from
+// the source address, XID and a checksum of the request body.
+//
+// Callers must only invoke lookup for cacheable procedures (see isCacheable).
+func (d *duplicateRequestCache) lookup(srcAddr string, xid uint32, body []byte) (drcLookupResult, []byte) {
+	key := drcKey{srcAddr: srcAddr, xid: xid, checksum: crc32.ChecksumIEEE(body)}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if e, ok := d.entries[key]; ok {
+		switch {
+		case e.state == drcInProgress:
+			return drcInProgressDup, nil
+		case d.now().Sub(e.inserted) < d.ttl:
+			return drcReplay, e.reply
+		default:
+			// DONE but past TTL: expire lazily and fall through so a long-after
+			// XID reuse is treated as a fresh request, not a false replay.
+			delete(d.entries, key)
+		}
+	}
+
+	d.evictIfNeeded()
+	d.entries[key] = &drcEntry{state: drcInProgress, inserted: d.now()}
+	return drcMiss, nil
+}
+
+// record promotes the in-progress slot for (srcAddr, xid, body) to DONE with the
+// encoded reply. It is a no-op if the slot was evicted in the meantime. The
+// reply is copied so the caller may reuse the backing buffer.
+func (d *duplicateRequestCache) record(srcAddr string, xid uint32, body []byte, reply []byte) {
+	key := drcKey{srcAddr: srcAddr, xid: xid, checksum: crc32.ChecksumIEEE(body)}
+
+	cp := make([]byte, len(reply))
+	copy(cp, reply)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	e, ok := d.entries[key]
+	if !ok {
+		// Slot evicted under cap pressure while the handler ran; re-insert as
+		// DONE so a retransmit still replays.
+		d.evictIfNeeded()
+		d.entries[key] = &drcEntry{state: drcDone, reply: cp, inserted: d.now()}
+		return
+	}
+	e.state = drcDone
+	e.reply = cp
+	e.inserted = d.now()
+}
+
+// abort drops the in-progress slot for a request whose handler did not produce
+// a cacheable reply (e.g. decode failure). Without this an errored op would
+// leave a permanent in-progress slot that swallows later legitimate retries.
+func (d *duplicateRequestCache) abort(srcAddr string, xid uint32, body []byte) {
+	key := drcKey{srcAddr: srcAddr, xid: xid, checksum: crc32.ChecksumIEEE(body)}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if e, ok := d.entries[key]; ok && e.state == drcInProgress {
+		delete(d.entries, key)
+	}
+}
+
+// evictIfNeeded enforces the entry cap. It first drops TTL-expired entries; if
+// still at capacity it evicts the oldest entry (approximate LRU by insertion/
+// completion time). Caller must hold d.mu.
+func (d *duplicateRequestCache) evictIfNeeded() {
+	if len(d.entries) < d.maxEntries {
+		return
+	}
+
+	now := d.now()
+	for k, e := range d.entries {
+		if now.Sub(e.inserted) >= d.ttl {
+			delete(d.entries, k)
+		}
+	}
+	if len(d.entries) < d.maxEntries {
+		return
+	}
+
+	// Still full: evict the single oldest entry to make room.
+	var oldestKey drcKey
+	var oldest time.Time
+	first := true
+	for k, e := range d.entries {
+		if first || e.inserted.Before(oldest) {
+			oldestKey, oldest, first = k, e.inserted, false
+		}
+	}
+	if !first {
+		delete(d.entries, oldestKey)
+	}
+}

--- a/pkg/adapter/nfs/drc_test.go
+++ b/pkg/adapter/nfs/drc_test.go
@@ -1,0 +1,274 @@
+package nfs
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	nfs_types "github.com/marmos91/dittofs/internal/adapter/nfs/types"
+)
+
+// dispatchThroughDRC models the dispatch wiring: a cacheable request flows
+// through the DRC (replay/in-progress/miss), and on a miss the handler runs and
+// its reply is recorded. handler reports (reply, cacheable). This mirrors
+// handleNFSProcedure so the tests prove the wiring contract, not just the map.
+func dispatchThroughDRC(d *duplicateRequestCache, srcAddr string, xid uint32, body []byte, handler func() (reply []byte, cacheable bool)) (reply []byte, dropped bool) {
+	switch res, cached := d.lookup(srcAddr, xid, body); res {
+	case drcReplay:
+		return cached, false
+	case drcInProgressDup:
+		return nil, true
+	}
+	r, cacheable := handler()
+	if !cacheable {
+		d.abort(srcAddr, xid, body)
+		return nil, false
+	}
+	d.record(srcAddr, xid, body, r)
+	return r, false
+}
+
+// TestDRC_ReplaysNonIdempotentReply proves a retransmitted REMOVE replays the
+// original success reply instead of re-executing into NFS3ERR_NOENT.
+//
+// This is the TDD anchor: the handler returns the success reply on the FIRST
+// call and a NOENT reply on any SUBSEQUENT call. Without the DRC the second
+// dispatch would surface NOENT; with it the cached success reply is replayed.
+func TestDRC_ReplaysNonIdempotentReply(t *testing.T) {
+	d := newDuplicateRequestCache()
+
+	const srcAddr = "10.0.0.1:1010"
+	const xid = uint32(0xAABBCCDD)
+	body := []byte("remove(dir-fh, \"file\")")
+
+	successReply := []byte{0, 0, 0, 0} // NFS3OK
+	noentReply := []byte{0, 0, 0, 2}   // NFS3ERR_NOENT
+
+	calls := 0
+	handler := func() ([]byte, bool) {
+		calls++
+		if calls == 1 {
+			return successReply, true
+		}
+		return noentReply, true // re-execution: file already gone
+	}
+
+	// Original request.
+	got, dropped := dispatchThroughDRC(d, srcAddr, xid, body, handler)
+	if dropped {
+		t.Fatal("original request unexpectedly dropped")
+	}
+	if string(got) != string(successReply) {
+		t.Fatalf("original reply = %v, want success %v", got, successReply)
+	}
+
+	// Retransmit (same srcAddr+xid+body).
+	got, dropped = dispatchThroughDRC(d, srcAddr, xid, body, handler)
+	if dropped {
+		t.Fatal("retransmit unexpectedly dropped")
+	}
+	if string(got) != string(successReply) {
+		t.Fatalf("retransmit reply = %v, want replayed success %v (re-executed into NOENT?)", got, successReply)
+	}
+	if calls != 1 {
+		t.Fatalf("handler invoked %d times, want 1 (DRC must not re-execute)", calls)
+	}
+}
+
+// TestDRC_ReplaysAcrossProcedures covers RENAME/MKDIR/LINK with the same
+// "succeed then fail on replay" shape, ensuring each non-idempotent op replays.
+func TestDRC_ReplaysAcrossProcedures(t *testing.T) {
+	for _, proc := range []uint32{
+		nfs_types.NFSProcRename,
+		nfs_types.NFSProcMkdir,
+		nfs_types.NFSProcLink,
+	} {
+		if !isCacheable(proc) {
+			t.Fatalf("proc %d expected cacheable", proc)
+		}
+		d := newDuplicateRequestCache()
+		body := []byte{byte(proc), 1, 2, 3}
+		ok := []byte{0, 0, 0, 0}
+		errReply := []byte{0, 0, 0, 17} // e.g. NFS3ERR_EXIST
+
+		calls := 0
+		h := func() ([]byte, bool) {
+			calls++
+			if calls == 1 {
+				return ok, true
+			}
+			return errReply, true
+		}
+		_, _ = dispatchThroughDRC(d, "c:1", 7, body, h)
+		got, _ := dispatchThroughDRC(d, "c:1", 7, body, h)
+		if string(got) != string(ok) {
+			t.Fatalf("proc %d: replay = %v, want %v", proc, got, ok)
+		}
+		if calls != 1 {
+			t.Fatalf("proc %d: handler called %d times, want 1", proc, calls)
+		}
+	}
+}
+
+// TestDRC_IdempotentOpsBypass proves GETATTR/READ/LOOKUP/WRITE/READDIR are not
+// cacheable and so never enter the cache.
+func TestDRC_IdempotentOpsBypass(t *testing.T) {
+	idempotent := []uint32{
+		nfs_types.NFSProcGetAttr,
+		nfs_types.NFSProcRead,
+		nfs_types.NFSProcLookup,
+		nfs_types.NFSProcWrite,
+		nfs_types.NFSProcReadDir,
+		nfs_types.NFSProcReadDirPlus,
+		nfs_types.NFSProcAccess,
+		nfs_types.NFSProcFsStat,
+		nfs_types.NFSProcCommit,
+	}
+	for _, p := range idempotent {
+		if isCacheable(p) {
+			t.Fatalf("idempotent proc %d must not be cacheable", p)
+		}
+	}
+
+	// And the cacheable set is exactly the non-idempotent procedures.
+	for _, p := range []uint32{
+		nfs_types.NFSProcSetAttr,
+		nfs_types.NFSProcCreate,
+		nfs_types.NFSProcMkdir,
+		nfs_types.NFSProcSymlink,
+		nfs_types.NFSProcMknod,
+		nfs_types.NFSProcRemove,
+		nfs_types.NFSProcRmdir,
+		nfs_types.NFSProcRename,
+		nfs_types.NFSProcLink,
+	} {
+		if !isCacheable(p) {
+			t.Fatalf("non-idempotent proc %d must be cacheable", p)
+		}
+	}
+}
+
+// TestDRC_DifferentChecksumIsNewRequest proves a same-srcAddr+same-XID request
+// with a different body is treated as a fresh request (no false replay). This
+// is the reconnect/XID-reuse disambiguation that XID alone cannot provide.
+func TestDRC_DifferentChecksumIsNewRequest(t *testing.T) {
+	d := newDuplicateRequestCache()
+	const srcAddr = "10.0.0.2:2020"
+	const xid = uint32(42)
+
+	replyA := []byte{0, 0, 0, 0}
+	replyB := []byte{0, 0, 0, 13}
+
+	calls := 0
+	mk := func(r []byte) func() ([]byte, bool) {
+		return func() ([]byte, bool) { calls++; return r, true }
+	}
+
+	got, _ := dispatchThroughDRC(d, srcAddr, xid, []byte("remove A"), mk(replyA))
+	if string(got) != string(replyA) {
+		t.Fatalf("first reply = %v, want %v", got, replyA)
+	}
+	// Same xid, different body -> must run the handler, not replay replyA.
+	got, _ = dispatchThroughDRC(d, srcAddr, xid, []byte("remove B"), mk(replyB))
+	if string(got) != string(replyB) {
+		t.Fatalf("different-checksum reply = %v, want fresh %v (false replay?)", got, replyB)
+	}
+	if calls != 2 {
+		t.Fatalf("handler called %d times, want 2 (both are distinct requests)", calls)
+	}
+}
+
+// TestDRC_InProgressDuplicateDropped proves a duplicate arriving while the
+// original is still executing is dropped (no double reply / double execution).
+func TestDRC_InProgressDuplicateDropped(t *testing.T) {
+	d := newDuplicateRequestCache()
+	const srcAddr = "10.0.0.3:3030"
+	const xid = uint32(99)
+	body := []byte("rmdir(...)")
+
+	// Reserve the in-progress slot (simulates original mid-flight).
+	res, _ := d.lookup(srcAddr, xid, body)
+	if res != drcMiss {
+		t.Fatalf("first lookup = %v, want drcMiss", res)
+	}
+	// Duplicate while in progress.
+	res, _ = d.lookup(srcAddr, xid, body)
+	if res != drcInProgressDup {
+		t.Fatalf("concurrent duplicate lookup = %v, want drcInProgressDup", res)
+	}
+	// After completion it replays.
+	d.record(srcAddr, xid, body, []byte{1, 2, 3, 4})
+	res, reply := d.lookup(srcAddr, xid, body)
+	if res != drcReplay || string(reply) != string([]byte{1, 2, 3, 4}) {
+		t.Fatalf("post-completion lookup = (%v,%v), want replay of recorded reply", res, reply)
+	}
+}
+
+// TestDRC_TTLEviction proves a DONE entry past the TTL is treated as a fresh
+// request (no replay), using an injected clock.
+func TestDRC_TTLEviction(t *testing.T) {
+	d := newDuplicateRequestCache()
+	now := time.Unix(1000, 0)
+	d.now = func() time.Time { return now }
+
+	const srcAddr = "10.0.0.4:4040"
+	const xid = uint32(7)
+	body := []byte("remove(...)")
+
+	d.lookup(srcAddr, xid, body)
+	d.record(srcAddr, xid, body, []byte{0, 0, 0, 0})
+
+	// Within TTL: replays.
+	now = now.Add(d.ttl - time.Nanosecond)
+	if res, _ := d.lookup(srcAddr, xid, body); res != drcReplay {
+		t.Fatalf("within TTL lookup = %v, want drcReplay", res)
+	}
+	// Past TTL: fresh request (miss).
+	now = now.Add(2 * d.ttl)
+	if res, _ := d.lookup(srcAddr, xid, body); res != drcMiss {
+		t.Fatalf("past-TTL lookup = %v, want drcMiss", res)
+	}
+}
+
+// TestDRC_CapEviction proves the entry cap is enforced (no unbounded growth).
+func TestDRC_CapEviction(t *testing.T) {
+	d := newDuplicateRequestCache()
+	d.maxEntries = 8
+	now := time.Unix(2000, 0)
+	d.now = func() time.Time { return now }
+
+	for i := 0; i < 100; i++ {
+		now = now.Add(time.Millisecond) // distinct ages for oldest-eviction
+		body := []byte{byte(i), byte(i >> 8)}
+		d.lookup("c:1", uint32(i), body)
+		d.record("c:1", uint32(i), body, []byte{0})
+	}
+
+	d.mu.Lock()
+	n := len(d.entries)
+	d.mu.Unlock()
+	if n > d.maxEntries {
+		t.Fatalf("cache holds %d entries, exceeds cap %d", n, d.maxEntries)
+	}
+}
+
+// TestDRC_ConcurrentAccess exercises the cache under -race with many goroutines
+// hitting overlapping and distinct keys.
+func TestDRC_ConcurrentAccess(t *testing.T) {
+	d := newDuplicateRequestCache()
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				xid := uint32((g*500 + i) % 64) // forces key collisions
+				body := []byte{byte(i), byte(g)}
+				if res, _ := d.lookup("c:1", xid, body); res == drcMiss {
+					d.record("c:1", xid, body, []byte{byte(i)})
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -84,6 +84,37 @@ func (c *NFSConnection) handleNFSProcedure(ctx context.Context, call *rpc.RPCCal
 		return result.Data, nil
 	}
 
+	// Duplicate-request cache (DRC) for non-idempotent procedures.
+	//
+	// On an RPC-timeout retransmit a client re-sends the same request; for
+	// non-idempotent ops (REMOVE/RMDIR/RENAME/CREATE/MKDIR/LINK/SYMLINK/MKNOD/
+	// guarded SETATTR) re-executing yields a spurious EEXIST/ENOENT/NOT_SYNC.
+	// We replay the recorded reply instead. Idempotent ops bypass the cache.
+	useDRC := c.server.drc != nil && isCacheable(call.Procedure)
+	if useDRC {
+		switch res, reply := c.server.drc.lookup(clientAddr, call.XID, data); res {
+		case drcReplay:
+			logger.DebugCtx(ctx, "NFS duplicate request replayed from DRC",
+				"procedure", procedure.Name,
+				"client", clientAddr,
+				"xid", fmt.Sprintf("0x%x", call.XID))
+			return reply, nil
+		case drcInProgressDup:
+			// Original is still executing; drop this duplicate and let the
+			// in-flight request produce the single authoritative reply. Signal
+			// "write nothing" via errDropReply so the dispatcher does not emit a
+			// truncated success reply (or a second reply for this XID).
+			logger.DebugCtx(ctx, "NFS duplicate of in-flight request dropped",
+				"procedure", procedure.Name,
+				"client", clientAddr,
+				"xid", fmt.Sprintf("0x%x", call.XID))
+			return nil, errDropReply
+		default:
+			// drcMiss: an in-progress slot is now reserved; fall through to run
+			// the handler and record the reply below.
+		}
+	}
+
 	// Dispatch to handler
 	result, err := procedure.Handler(
 		handlerCtx,
@@ -93,7 +124,15 @@ func (c *NFSConnection) handleNFSProcedure(ctx context.Context, call *rpc.RPCCal
 	)
 
 	if result == nil {
+		if useDRC {
+			// No reply to cache (e.g. decode failure); release the slot so a
+			// later legitimate retry is not swallowed.
+			c.server.drc.abort(clientAddr, call.XID, data)
+		}
 		return nil, err
+	}
+	if useDRC {
+		c.server.drc.record(clientAddr, call.XID, data, result.Data)
 	}
 	return result.Data, err
 }


### PR DESCRIPTION
## Summary

Closes #1003 (NFS area-#4 audit finding **H12**). Adds a server-wide
**duplicate-request cache (DRC)** for non-idempotent NFSv3 procedures.

On a hard NFS mount, a client that times out an RPC retransmits the same
request (same XID). For idempotent ops re-execution is harmless, but for
non-idempotent ops re-execution returns a spurious error even though the
client's original op succeeded:

- second `REMOVE`/`RMDIR` → `NFS3ERR_NOENT`
- second `CREATE`/`MKDIR`/`SYMLINK`/`MKNOD`/`LINK` → `NFS3ERR_EXIST`
- replayed guarded `SETATTR` → `NFS3ERR_NOT_SYNC`

The data path is TCP-only, but an RPC-timeout retransmit can arrive on a
*reconnected* connection with a fresh source port, so there was no retry
protection anywhere in dispatch.

## Design

Mirrors the Linux server reply cache (`fs/nfsd/nfscache.c` + `cache.h`;
RFC 1813 idempotency semantics):

- **Key:** source address + RPC XID + CRC-32 of the request body. XID alone
  is not collision-safe across reconnects / XID reuse; the body checksum
  disambiguates a reused XID for a genuinely different request from a true
  retransmit (as nfsd does).
- **Value:** the fully-encoded reply bytes (copied on record).
- **States:** in-progress vs done (mirrors nfsd `RC_INPROG` / `RC_REPLY`).
  - *done* duplicate → replay the recorded reply, skip the handler.
  - *in-progress* duplicate → drop silently (nfsd `RC_DROPIT`) so only the
    original request emits the authoritative reply for that XID.
- **Bounds:** 4096 entries, 8s TTL. Lazy TTL expiry on lookup +
  TTL-sweep/oldest-entry eviction on insert. No config knob (less-is-more).

### Procedures cached vs bypass

- **Cached (non-idempotent):** SETATTR, CREATE, MKDIR, SYMLINK, MKNOD,
  REMOVE, RMDIR, RENAME, LINK.
- **Bypass (idempotent, never cached):** GETATTR, LOOKUP, ACCESS, READLINK,
  READ, WRITE, READDIR, READDIRPLUS, FSSTAT, FSINFO, PATHCONF, COMMIT, NULL.
- CREATE-exclusive is already idempotent via its create verifier; it flows
  through the CREATE path harmlessly (recording its reply is correct/cheap).

### Hook point

Single chokepoint in `(*NFSConnection).handleNFSProcedure`
(`pkg/adapter/nfs/handlers.go`): gate on `isCacheable(proc)`, `lookup` before
dispatch (replay / drop / miss), `record` after the handler runs, `abort` the
reserved slot if the handler produced no reply. The in-flight-drop signal uses
a new `errDropReply` sentinel handled in `handleRPCCall` so the dispatcher
writes nothing (no truncated/duplicate reply for the XID).

## Tests

`pkg/adapter/nfs/drc_test.go`:
- replayed REMOVE returns the cached success reply, **not** a re-executed
  `NFS3ERR_NOENT` (handler invoked exactly once) — same for RENAME/MKDIR/LINK
- idempotent ops are never cacheable (and the cacheable set is exactly the
  non-idempotent procs)
- same srcaddr+XID with a **different body checksum** is a fresh request (no
  false replay)
- in-progress duplicate is dropped, then replays after completion
- TTL eviction and entry-cap eviction (injected clock)
- concurrent access under `-race`

TDD: the replay test fails (returns NOENT) with replay disabled, passes with
the DRC wired.

## Gates

- `go build ./...`, `go vet`, `go fmt` clean
- `go test -race ./internal/adapter/nfs/... ./pkg/adapter/nfs/...` — all green
