### PR TITLE
fix(controlplane): log swallowed errors on persist paths + discarded-error audit (#1009)

### DIFF
--- a/.planning/v1.0-audit/err-discard-audit.md
+++ b/.planning/v1.0-audit/err-discard-audit.md
@@ -1,0 +1,99 @@
+# Discarded-error (`_ =`) sampling audit — issue #1009
+
+**Scope.** The tree has ~2360 `_ =` discarded-error sites. This was a *sampling*
+audit (not a full sweep) over the non-reserved control-plane / CLI / config /
+snapshot packages: `cmd/`, `pkg/config/`, `internal/controlplane/`,
+`pkg/controlplane/` (excluding the runtime lock-manager files), `pkg/snapshot/`,
+`pkg/api/`. NFS/SMB/blockstore/metadata/auth/e2e were reserved for other agents
+and not touched.
+
+**Sample size.** ~55 sites enumerated and individually reviewed (the full
+population of discards in the allowed dirs is ~118; every suspicious-looking
+call — Marshal/Encode/persist/Write/state-flip — was read, plus a representative
+slice of the obviously-benign ones).
+
+## Result
+
+| Outcome | Count (sites) |
+|---|---|
+| Benign — left untouched | ~50 |
+| Genuine swallow — fixed | 5 sites across 3 files / 3 bug classes |
+
+### Fixes
+
+1. **`internal/controlplane/api/handlers/shares.go:437,443`** — share-create
+   handler swallowed `store.SetShareAdapterConfig` for the default NFS and SMB
+   adapter configs. A persist failure there leaves a newly-created share with no
+   default adapter config and *zero diagnostic trail*. Now logged at `Warn`,
+   matching the existing "Share created but failed to add to runtime" precedent
+   in the same handler. Behavior (request still succeeds) is unchanged.
+
+2. **`pkg/controlplane/runtime/adapters/service.go:97`** — `CreateAdapter`
+   rollback (`store.DeleteAdapter`) was discarded. If the rollback delete fails
+   after a failed adapter start, the store keeps a config row for an adapter
+   that will not start — a silent orphan. Now logged at `Warn`. (The sibling
+   `_ = s.stopAdapter(...)` discards at `:123`/`:157` were reviewed and left:
+   `stopAdapter` already logs its own stop errors/timeouts internally, and its
+   only swallowed signal otherwise is the expected "adapter not running".)
+
+3. **`pkg/controlplane/runtime/trash/reaper.go:54,57`** — the background trash
+   reaper swallowed per-share `reapShareAt` / `evictToCap` errors. Swallowing is
+   intentional for loop resilience (one bad share must not stall the others),
+   but neither callee logs internally, so a share that *persistently* fails to
+   reap would grow its trash bin forever with no operator signal. Now logs each
+   per-share failure at `Warn` while keeping the loop resilient; doc comment
+   updated.
+
+## Benign classes observed (left untouched, by design)
+
+- **Deferred `Close()` on read-only handles / after the real error surfaced** —
+  e.g. `defer func() { _ = f.Close() }()`, `_ = resp.Body.Close()`,
+  `_ = j.Close()`, `_ = bs.Close()`. The meaningful error already surfaced on
+  the read/write path; the close is best-effort.
+- **`fmt.Fprintf`/`Fprintln` to stdout/stderr/`cmd.Out`** — write-to-terminal,
+  no actionable error.
+- **Cobra `MarkFlagRequired("literal")`** — only errors on an unknown flag name,
+  which is a compile-time-stable literal; cannot fail at runtime.
+- **Cobra `cmd.Flags().GetString/GetBool` in PersistentPreRun** — the flags are
+  declared on the same command; lookup cannot fail.
+- **`json.NewEncoder(w).Encode(...)` into an `http.ResponseWriter`** — headers
+  and status are already written (e.g. RFC 7807 `WriteProblem`); a body-encode
+  failure (client disconnect) is unrecoverable. Standard idiom.
+- **Best-effort cleanup `os.Remove(tmpPath)` / `os.RemoveAll(dir)`** — atomic-
+  write temp-file cleanup and bench/probe scratch dirs.
+- **Documented idempotent best-effort ops** — `AddUserToGroup` (duplicate-add
+  expected), GORM `DropIndex/DropColumn` migration drops (IF-EXISTS semantics).
+- **`viper.BindEnv(key)`** — only errors on an empty key; keys are literal or
+  reflected struct paths.
+- **Error-path state-flip cleanup** — e.g. snapshot `UpdateSnapshotState(...,
+  StateFailed)` where the function already returns a wrapped primary error.
+- **CLI interactive `json.Unmarshal(current.Config, &cfg)`** — failure leaves a
+  nil map; downstream prompts already guard `if cfg != nil` and just show empty
+  defaults. UX degradation only, no state corruption; left as-is to avoid churn.
+
+## Candidate noted, not changed
+
+- **`internal/controlplane/api/handlers/shares.go:799`** — `_ =
+  h.runtime.RemoveShare(name)` in the share-delete handler. The discard is
+  documented ("Ignore error if not found in runtime") and the common case is
+  not-found, but a non-not-found failure (e.g. block-store close error) leaks
+  runtime resources while the DB row is deleted. Left unchanged for this
+  sampling pass; flagged for a future targeted fix if runtime teardown errors
+  become a concern.
+
+## Recommendation on a full sweep for v1.0
+
+**A full mechanical sweep is NOT warranted for v1.0.** The discard population is
+overwhelmingly benign and falls into the well-known idiomatic classes above; a
+2360-site sweep would be almost entirely churn with a poor signal-to-noise ratio
+and a real regression risk. The genuine bugs cluster narrowly around
+**persist/rollback/background-loop error paths** — three found here, all in the
+control plane.
+
+Targeted, higher-yield follow-ups instead:
+- A focused grep for `_ = .*\.(Set|Update|Delete|Create|Save|Put|Write|Persist)`
+  across the persist layers (this is where the real swallows live) is a small,
+  high-value pass worth doing per-area as those areas are audited.
+- Consider an `errcheck` lint gate with an exclude-list for the benign idioms
+  (Fprintf-to-terminal, deferred Close, MarkFlagRequired) so *new* swallows on
+  persist/state-flip paths are caught at CI time rather than by future audits.

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -434,13 +434,19 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 	nfsOpts := models.DefaultNFSExportOptions()
 	nfsCfg := &models.ShareAdapterConfig{ShareID: share.ID, AdapterType: "nfs"}
 	if err := nfsCfg.SetConfig(nfsOpts); err == nil {
-		_ = h.store.SetShareAdapterConfig(r.Context(), nfsCfg)
+		if err := h.store.SetShareAdapterConfig(r.Context(), nfsCfg); err != nil {
+			logger.Warn("Failed to persist default NFS adapter config for new share",
+				"share", req.Name, "error", err)
+		}
 	}
 
 	smbOpts := models.DefaultSMBShareOptions()
 	smbCfg := &models.ShareAdapterConfig{ShareID: share.ID, AdapterType: "smb"}
 	if err := smbCfg.SetConfig(smbOpts); err == nil {
-		_ = h.store.SetShareAdapterConfig(r.Context(), smbCfg)
+		if err := h.store.SetShareAdapterConfig(r.Context(), smbCfg); err != nil {
+			logger.Warn("Failed to persist default SMB adapter config for new share",
+				"share", req.Name, "error", err)
+		}
 	}
 
 	// Add share to runtime if runtime is available

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -94,7 +94,13 @@ func (s *Service) CreateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 	}
 
 	if err := s.startAdapter(cfg); err != nil {
-		_ = s.store.DeleteAdapter(ctx, cfg.Type) // rollback
+		// Roll back the persisted config so a non-startable adapter does not
+		// linger in the store. A rollback failure leaves an orphan row, so
+		// surface it rather than swallowing it silently.
+		if delErr := s.store.DeleteAdapter(ctx, cfg.Type); delErr != nil {
+			logger.Warn("Failed to roll back adapter config after start failure",
+				"type", cfg.Type, "error", delErr)
+		}
 		return fmt.Errorf("failed to start adapter: %w", err)
 	}
 

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -95,9 +95,13 @@ func (s *Service) CreateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 
 	if err := s.startAdapter(cfg); err != nil {
 		// Roll back the persisted config so a non-startable adapter does not
-		// linger in the store. A rollback failure leaves an orphan row, so
-		// surface it rather than swallowing it silently.
-		if delErr := s.store.DeleteAdapter(ctx, cfg.Type); delErr != nil {
+		// linger in the store. Use a fresh bounded context, not the caller's:
+		// the request may already be canceled (client disconnect/timeout),
+		// and that must not abort the cleanup. A rollback failure leaves an
+		// orphan row, so surface it rather than swallowing it silently.
+		rbCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+		if delErr := s.store.DeleteAdapter(rbCtx, cfg.Type); delErr != nil {
 			logger.Warn("Failed to roll back adapter config after start failure",
 				"type", cfg.Type, "error", delErr)
 		}

--- a/pkg/controlplane/runtime/trash/reaper.go
+++ b/pkg/controlplane/runtime/trash/reaper.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -40,8 +41,9 @@ func (s *Service) Stop() {
 }
 
 // reapAll runs one reap pass over every trash-enabled share, applying retention
-// (RetentionDays) then max-size (MaxBytes) eviction. Per-share errors are
-// swallowed so one bad share cannot stall the others; the next tick retries.
+// (RetentionDays) then max-size (MaxBytes) eviction. Per-share errors are logged
+// but not propagated so one bad share cannot stall the others; the next tick
+// retries.
 func (s *Service) reapAll(ctx context.Context) {
 	now := time.Now().UTC()
 	for _, share := range s.deps.EnabledTrashShares() {
@@ -51,10 +53,14 @@ func (s *Service) reapAll(ctx context.Context) {
 		}
 		actx := metadata.NewSystemAuthContext(ctx)
 		if cfg.RetentionDays > 0 {
-			_, _ = s.reapShareAt(actx, share, cfg, now)
+			if _, err := s.reapShareAt(actx, share, cfg, now); err != nil {
+				logger.Warn("Trash retention reap failed", "share", share, "error", err)
+			}
 		}
 		if cfg.MaxBytes > 0 {
-			_, _ = s.evictToCap(actx, share, cfg.MaxBytes)
+			if _, err := s.evictToCap(actx, share, cfg.MaxBytes); err != nil {
+				logger.Warn("Trash max-size eviction failed", "share", share, "error", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #1009.

## Discarded-error (`_ =`) sampling audit

This is the Wave-2 **sampling** audit of discarded-error sites (the tree has ~2360; a full mechanical sweep is not warranted — see the doc). Scope was the non-reserved control-plane / CLI / config / snapshot packages (`cmd/`, `pkg/config/`, `internal/controlplane/`, `pkg/controlplane/` excluding lock-manager, `pkg/snapshot/`, `pkg/api/`).

### Counts
- **~55 sites** enumerated and individually reviewed (full population in the allowed dirs is ~118; every persist/Marshal/Encode/state-flip candidate was read).
- **5 sites fixed** across 3 files / 3 genuine bug classes.
- **~50 left untouched** as benign idioms (no churn).

### Fixes (all log at `Warn`, no behavior change on the success path)
1. `internal/controlplane/api/handlers/shares.go` — share-create swallowed `SetShareAdapterConfig` for the default NFS/SMB adapter configs (share created with no adapter config and zero diagnostic trail).
2. `pkg/controlplane/runtime/adapters/service.go` — `CreateAdapter` rollback `DeleteAdapter` discarded (rollback failure leaves an orphan store row).
3. `pkg/controlplane/runtime/trash/reaper.go` — background reaper swallowed per-share `reapShareAt`/`evictToCap` errors with no internal logging (a persistently failing share would grow its trash bin forever, silently). Loop stays resilient; failures now logged.

### Benign classes left alone
Deferred/read-only `Close()`, `fmt.Fprintf` to terminals, Cobra `MarkFlagRequired(literal)` / flag getters, `json.Encode` into an already-written ResponseWriter, best-effort `os.Remove` cleanup, documented idempotent ops, `viper.BindEnv`, error-path state-flip cleanup, CLI interactive `json.Unmarshal` (nil-guarded downstream).

### Audit doc
`.planning/v1.0-audit/err-discard-audit.md` — sample, benign classes, one noted-but-unchanged candidate (`shares.Delete` runtime RemoveShare), and the recommendation: **no full sweep for v1.0**; instead a focused `_ = .*\.(Set|Update|Delete|Create|Save|Put|Write)` grep per-area plus an `errcheck` lint gate with a benign-idiom exclude-list.

### Gates
`go build ./...`, `go vet`, `gofmt`, and `go test -race` on the touched packages all green.