### PR TITLE
fix(blockstore): C3 append-log pressure-budget leak under storm churn (#1007)

### DIFF
--- a/.planning/v1.0-audit/blockstore/REVIEW.md
+++ b/.planning/v1.0-audit/blockstore/REVIEW.md
@@ -254,6 +254,65 @@ Re-run with the #680 harness (PR #983): five-profile envelope (`--full-profiles`
 
 ---
 
+## 5.2 B1 + C3 resolution (#1007 — 2026-06-02)
+
+The two remaining structural perf items from §5/§5.1 — **B1** (full-tree CAS
+walk per Flush) and **C3** (append-log backpressure ceiling) — were re-profiled
+on develop and resolved as follows.
+
+- **B1 — already RESOLVED on develop (no code change needed).** §6 of REVIEW2.md
+  already verified the per-Flush full CAS walk was replaced: the syncer now
+  maintains an in-memory `pendingHashes` set populated O(1) via `addPendingHash`
+  (fired from `StoreChunk`) and drained in `mirrorOnce` after `MarkSynced`
+  (`engine/syncer.go:91-130,362-440`). `ListUnsynced` (the full `bc.Walk` of the
+  CAS `blocks/` tree) now runs ONLY at startup (`seedPendingFromDisk`) and as a
+  ~10-minute drift reconciler — not per Flush. The flush-churn CPU profile no
+  longer shows the structural O(total-chunks) directory walk on the hot path.
+  Confirmed against current develop; no further work in #1007.
+
+- **C3 — FIXED (this PR).** Root cause was NOT a missing backpressure mechanism
+  (the `pressureCh` + `pressureMaxWait → ErrPressureTimeout` ceiling already
+  exists). It was a **budget-accounting leak** that made the existing
+  backpressure a permanent deadlock. The pressure budget `logBytesTotal` was
+  released by the *compaction-fence position delta* (`targetPos - priorFence`),
+  a CONTIGUOUS high-water mark from the log head. Two paths leaked:
+  1. **Out-of-order overwrites** (the storm's random mid-file WRITEs): a consumed
+     record can sit behind an unconsumed lower-logPos record, so
+     `AdvanceFenceUpTo` stalls and the position delta under-counts the bytes
+     actually rolled up. Stranded bytes never leave `logBytesTotal`.
+  2. **Create/delete churn** (dominant): `DeleteAppendLog` discards a payload's
+     `logIndex` for files deleted mid-write WITHOUT reclaiming the budget their
+     un-rolled-up records reserved.
+  Either way `logBytesTotal` ratcheted to `maxLogBytes` and pinned there;
+  every writer then blocked on `pressureCh` and timed out. Repro: the 20 000-op
+  / 8-worker / ws=64 `mixed-ops-storm` aborts on develop with `append log:
+  pressure wait timed out` at ~50 s; the budget flatlines at exactly the ceiling
+  with `dirtyIntervals=0 liveEntries=0` (all records rolled up, budget still
+  full = pure accounting leak).
+  **Fix:** make `logBytesTotal` an exact running total of un-rolled-up framed
+  record bytes, decoupled from fence contiguity. The rollup releases
+  `retiredBytes` — the summed frame size of every entry the fence actually
+  retired this pass (`logIndex.advanceFenceUpTo`, covers both directly-consumed
+  and R-7 "released-by-overwrite-coverage" records). `DeleteAppendLog` releases
+  `logIndex.LiveBytes()` for the discarded payload. Both go through
+  `FSStore.releaseLogBytes` which floors the total at zero (defends against
+  recovery's resident-bytes seed drifting by a torn-tail record). Result: the
+  20 000-op storm now completes (~477 ops/s, was a hard stall). The
+  compaction fence (`targetPos`) is unchanged and remains authoritative for
+  physical log compaction — only the backpressure budget accounting changed; no
+  CAS content / dedup / rollup-correctness change. Regression tests:
+  `TestC3_DeleteMidWrite_ReclaimsBudget` + `TestC3_OverwriteSameRegion_BudgetDrains`
+  (fs unit) and `TestRunStorm_BackpressureCeiling` (engine `-race` storm).
+
+The `rollup: dropping divergent stable interval` warnings (the §5.1 "new gap")
+are benign under this fix — those records' budget is reclaimed by the fence
+retirement of the overlapping consume that trimmed their index entries, so the
+drops no longer leak budget. Reducing the warning volume (overwrite-into-stable
+reconciliation, akin to #668) remains a separate, non-blocking observability
+follow-up.
+
+---
+
 ## 6. Pre-existing Tracker Mapping
 
 | Issue | Root cause | Severity | PR-B slot |

--- a/bench/blockstore/storm_test.go
+++ b/bench/blockstore/storm_test.go
@@ -104,3 +104,39 @@ func TestRunStorm_RejectsBadBlockSize(t *testing.T) {
 		t.Fatal("expected error for block size > StormFileSize")
 	}
 }
+
+// TestRunStorm_BackpressureCeiling is the C3 regression guard: a high-op,
+// multi-worker storm with create/delete churn and random mid-file overwrites
+// must complete WITHOUT ErrPressureTimeout. Before the C3 fix the append-log
+// pressure budget (logBytesTotal) leaked — DeleteAppendLog discarded the
+// logIndex of churn files mid-write without reclaiming their reserved bytes,
+// and the rollup released budget by a compaction-fence position delta that
+// under-counted out-of-order overwrites — so the global budget ratcheted to
+// maxLogBytes and pinned there, wedging every writer on ErrPressureTimeout
+// (the storm aborted at ~50s). The fix makes logBytesTotal an exact running
+// total of un-rolled-up record bytes (reclaimed by per-record frame size on
+// both the rollup-retire and delete paths), so the budget drains and the storm
+// runs to completion. ~40s; skipped under -short.
+func TestRunStorm_BackpressureCeiling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("storm backpressure regression is long-running; skipped under -short")
+	}
+	bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer closeFn()
+
+	// 20k ops / 8 workers / 64-file working set is the configuration the
+	// blockstore perf audit (REVIEW2.md §5.1) recorded as STALLED on develop.
+	if _, err := RunStorm(context.Background(), bs, Opts{
+		Workload:   WorkloadMixedOpStorm,
+		Ops:        20000,
+		BlockSize:  4 * 1024,
+		WorkingSet: 64,
+		Workers:    8,
+		Seed:       7,
+	}); err != nil {
+		t.Fatalf("storm did not complete (C3 backpressure ceiling regression): %v", err)
+	}
+}

--- a/pkg/blockstore/local/fs/appendlog_budget_c3_test.go
+++ b/pkg/blockstore/local/fs/appendlog_budget_c3_test.go
@@ -1,0 +1,104 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newC3BudgetStore builds an FSStore wired with a real rollup coordinator so
+// rollup passes complete end-to-end, exercising the logBytesTotal accounting.
+// It is an in-package (package fs) helper so the C3 tests can read the
+// unexported logBytesTotal counter directly without the *ForTest seams.
+func newC3BudgetStore(t *testing.T, maxLogBytes int64) *FSStore {
+	t.Helper()
+	mem := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(t.TempDir(), 1<<30, 1<<30, mem, FSStoreOptions{
+		MaxLogBytes:     maxLogBytes,
+		RollupWorkers:   1,
+		StabilizationMS: 1,
+		RollupStore:     mem,
+		SyncedHashStore: mem,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc
+}
+
+// TestC3_OverwriteSameRegion_BudgetDrains pins the C3 budget-leak fix: writing
+// and rolling up the SAME file region repeatedly must keep logBytesTotal an
+// exact running total of un-rolled-up record bytes — it must NOT ratchet
+// upward. Before the fix the budget was released by the compaction-fence
+// position delta, which under repeated same-offset overwrites under-counted
+// the bytes actually retired, leaking ~one record's worth of budget per pass
+// until the global pressure ceiling pinned and every writer timed out.
+func TestC3_OverwriteSameRegion_BudgetDrains(t *testing.T) {
+	bc := newC3BudgetStore(t, 1<<30)
+	ctx := context.Background()
+	const pid = "c3-overwrite"
+	const sz = 64 * 1024
+	payload := bytes.Repeat([]byte{0xAB}, sz)
+
+	for pass := 0; pass < 30; pass++ {
+		if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+			t.Fatalf("pass %d AppendWrite: %v", pass, err)
+		}
+		// ForceRollup bypasses the stabilization window so the just-written
+		// record is consumed deterministically this pass.
+		if err := bc.rollupFile(ctx, pid, true); err != nil {
+			t.Fatalf("pass %d rollup: %v", pass, err)
+		}
+	}
+
+	// After 30 force-rolled-up overwrites of one region the budget must be
+	// near zero — at most a single straggling record. A leak shows up as
+	// ~30x the record size.
+	const frame = recordFrameOverhead + sz
+	if got := bc.logBytesTotal.Load(); got > int64(frame) {
+		t.Fatalf("budget leaked across overwrite passes: logBytesTotal=%d, want <= one record (%d)", got, frame)
+	}
+}
+
+// TestC3_DeleteMidWrite_ReclaimsBudget pins the dominant storm leak: deleting a
+// payload that still has un-rolled-up records must release their reserved
+// pressure budget. Before the fix DeleteAppendLog dropped the logIndex without
+// reclaiming logBytesTotal, so create/delete churn ratcheted the global budget
+// to maxLogBytes and wedged every writer on ErrPressureTimeout.
+func TestC3_DeleteMidWrite_ReclaimsBudget(t *testing.T) {
+	bc := newC3BudgetStore(t, 1<<30)
+	ctx := context.Background()
+	const sz = 128 * 1024
+	payload := bytes.Repeat([]byte{0xCD}, sz)
+
+	const files = 50
+	for i := 0; i < files; i++ {
+		pid := pidN(i)
+		if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+			t.Fatalf("file %d AppendWrite: %v", i, err)
+		}
+	}
+	// Each write reserved frame bytes; nothing has rolled up yet.
+	const frame = recordFrameOverhead + sz
+	if got, want := bc.logBytesTotal.Load(), int64(files*frame); got != want {
+		t.Fatalf("pre-delete budget = %d, want %d", got, want)
+	}
+
+	// Delete every payload mid-write (no rollup ran). All reserved budget
+	// must be reclaimed.
+	for i := 0; i < files; i++ {
+		if err := bc.DeleteAppendLog(ctx, pidN(i)); err != nil {
+			t.Fatalf("file %d DeleteAppendLog: %v", i, err)
+		}
+	}
+	if got := bc.logBytesTotal.Load(); got != 0 {
+		t.Fatalf("budget leaked after deleting un-rolled-up payloads: logBytesTotal=%d, want 0", got)
+	}
+}
+
+func pidN(i int) string {
+	return "c3-del/" + string(rune('a'+i/26)) + string(rune('a'+i%26))
+}

--- a/pkg/blockstore/local/fs/appendwrite.go
+++ b/pkg/blockstore/local/fs/appendwrite.go
@@ -189,6 +189,34 @@ func (bc *FSStore) getOrCreateLog(payloadID string) (*logFile, *sync.Mutex, *int
 	return lf, mu, tree, idx, nil
 }
 
+// signalPressure wakes any AppendWrite blocked in the pressure loop after log
+// budget has been freed (rollup retirement or payload delete). pressureCh is a
+// size-1 buffered channel, so the send is non-blocking and a missed pulse is
+// harmless — a blocked writer also re-checks the budget on the rollup ticker.
+func (bc *FSStore) signalPressure() {
+	select {
+	case bc.pressureCh <- struct{}{}:
+	default:
+	}
+}
+
+// releaseLogBytes subtracts n from the pressure budget and pulses pressureCh,
+// flooring the running total at zero. The exact callers (the rollup fence
+// retirement and the DeleteAppendLog mid-write reclaim) never over-release in
+// steady state, but recovery seeds logBytesTotal from the on-disk resident
+// estimate (file size - rollup_offset) which can drift by a torn-tail record
+// from the per-record frame sum; the floor keeps a benign drift from turning
+// the budget negative and defeating backpressure. n <= 0 is a no-op.
+func (bc *FSStore) releaseLogBytes(n int64) {
+	if n <= 0 {
+		return
+	}
+	if bc.logBytesTotal.Add(-n) < 0 {
+		bc.logBytesTotal.Store(0)
+	}
+	bc.signalPressure()
+}
+
 // AppendWrite writes exactly one framed record to the payload's append
 // log. The append is serialized by a per-file mutex to
 // guarantee crash-safe log ordering — a lock-free log would risk torn
@@ -596,6 +624,19 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	// buildPayloadID), so 'unlink + create at same path' must reuse
 	// the PayloadID and must therefore succeed.
 	sh.mu.Lock()
+	// C3: release the pressure budget for any record still live in this
+	// payload's logIndex. AppendWrite reserved recordFrameOverhead+payloadLen
+	// per record in logBytesTotal; a rollup pass releases it via the fence
+	// retirement, but a payload deleted mid-write (storm create/delete churn)
+	// discards its logIndex here before those records ever roll up. Without
+	// this reclaim their reserved bytes leak permanently and the global budget
+	// ratchets to maxLogBytes, eventually wedging every writer on
+	// ErrPressureTimeout. LiveBytes counts exactly the un-retired records, so
+	// the reclaim never double-counts against the rollup's own release.
+	var reclaim int64
+	if idx := sh.logIndices[payloadID]; idx != nil {
+		reclaim = idx.LiveBytes()
+	}
 	delete(sh.logFDs, payloadID)
 	delete(sh.logLocks, payloadID)
 	delete(sh.rollupLocks, payloadID)
@@ -604,6 +645,10 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	delete(sh.truncations, payloadID)
 	delete(sh.tombstones, payloadID)
 	sh.mu.Unlock()
+	// Release the discarded payload's reserved budget and pulse pressure so any
+	// writer blocked on the budget re-checks immediately rather than waiting
+	// for the next rollup tick.
+	bc.releaseLogBytes(reclaim)
 
 	// FIX-17: surface any step-4 unlink error after step 5 cleanup so the
 	// in-memory FSStore is left consistent regardless of whether the

--- a/pkg/blockstore/local/fs/logindex.go
+++ b/pkg/blockstore/local/fs/logindex.go
@@ -76,6 +76,15 @@ func (e logEntry) fileEnd() uint64 {
 	return end
 }
 
+// frameBytes returns the on-disk framed size of this record
+// (recordFrameOverhead + payloadLen) — the exact number of bytes AppendWrite
+// reserved in logBytesTotal for it. The single source of truth for the
+// pressure-budget accounting in advanceFenceUpTo / LiveBytes and the rollup's
+// consumed-record tally.
+func (e logEntry) frameBytes() int64 {
+	return int64(recordFrameOverhead) + int64(e.payloadLen)
+}
+
 // logIndex maintains per-file log-position bookkeeping. Entries are
 // appended in arrival order (== logPos order, since AppendWrite advances
 // lf.eofPos monotonically under per-file mu). consumedCoverage is the
@@ -269,6 +278,22 @@ func (idx *logIndex) AdvanceFence() uint64 {
 // entry and is rolled up by a later pass. AdvanceFence (no ceiling) preserves
 // the original behavior for every other caller.
 func (idx *logIndex) AdvanceFenceUpTo(maxLogPos uint64) uint64 {
+	fence, _ := idx.advanceFenceUpTo(maxLogPos)
+	return fence
+}
+
+// advanceFenceUpTo is AdvanceFenceUpTo plus the sum of on-disk framed-record
+// bytes (recordFrameOverhead + payloadLen) for every entry the fence walked
+// past in this call — i.e. every record that leaves the live log this pass.
+// This is the authoritative quantity to release from the pressure budget
+// (logBytesTotal): it covers BOTH records consumed directly this pass AND
+// records the fence retires only because a later overwrite's MarkConsumed
+// fully covered their file region (the R-7 "released without being consumed"
+// case). A per-consumed-record tally misses the latter and leaks budget under
+// out-of-order overwrites (C3). The returned byte count is exactly what
+// trimBelowFenceLocked is about to drop, so it never double-counts across
+// successive passes.
+func (idx *logIndex) advanceFenceUpTo(maxLogPos uint64) (fence uint64, retiredBytes int64) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	for idx.fenceCursor < len(idx.entries) {
@@ -281,10 +306,11 @@ func (idx *logIndex) AdvanceFenceUpTo(maxLogPos uint64) uint64 {
 		}
 		// Fence advances past the dead entry's full record extent.
 		idx.compactionFence = e.logPos + uint64(recordFrameOverhead) + uint64(e.payloadLen)
+		retiredBytes += e.frameBytes()
 		idx.fenceCursor++
 	}
 	idx.trimBelowFenceLocked()
-	return idx.compactionFence
+	return idx.compactionFence, retiredBytes
 }
 
 // trimBelowFenceLocked drops the [0:fenceCursor) prefix of `entries`
@@ -334,6 +360,23 @@ func (idx *logIndex) Fence() uint64 {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	return idx.compactionFence
+}
+
+// LiveBytes returns the sum of on-disk framed-record bytes
+// (recordFrameOverhead + payloadLen) for every entry still in the index —
+// i.e. every record that AppendWrite reserved budget for and that no rollup
+// pass has yet retired. DeleteAppendLog uses this to release the pressure
+// budget for a payload being discarded mid-rollup; without it the un-rolled-up
+// records' reserved bytes leak from logBytesTotal forever, ratcheting the
+// global pressure budget to maxLogBytes under create/delete churn (C3).
+func (idx *logIndex) LiveBytes() int64 {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	var total int64
+	for _, e := range idx.entries {
+		total += e.frameBytes()
+	}
+	return total
 }
 
 // SetFence overrides the compaction fence. Intended for recovery, which

--- a/pkg/blockstore/local/fs/rollup.go
+++ b/pkg/blockstore/local/fs/rollup.go
@@ -643,14 +643,6 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// landed during Phase B has its own logIndex entry, NOT in
 		// consumedExtents, so the fence does not advance past it and it is
 		// rolled up by a later pass.
-		//
-		// priorFence is captured BEFORE MarkConsumed/AdvanceFence so the
-		// budget-release math below uses the in-memory fence delta (truth)
-		// rather than (targetPos - hdr.RollupOffset). The log header is
-		// derived state that can lag if a prior advanceRollupOffset failed —
-		// using it to compute reclaimed would double-decrement logBytesTotal
-		// on the recovery-from-stale-header path.
-		priorFence := idx.Fence()
 		for _, ext := range consumedExtents {
 			idx.MarkConsumed(ext.fileOff, ext.payloadLen)
 		}
@@ -659,7 +651,10 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// file extent we just consumed (its logPos exceeds everything we read
 		// in Phase A). Such a record's bytes were not chunked this pass; it
 		// stays in the index + dirty tree and is rolled up by a later pass.
-		targetPos := idx.AdvanceFenceUpTo(maxReadLogPos)
+		//
+		// retiredBytes is the exact framed-record total the fence retired this
+		// pass — the quantity to release from logBytesTotal below (C3).
+		targetPos, retiredBytes := idx.advanceFenceUpTo(maxReadLogPos)
 
 		// SetRollupOffset is atomic-monotone at the RollupStore layer: on
 		// attempted regression it returns ErrRollupOffsetRegression and the
@@ -709,21 +704,28 @@ func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool)
 		// the corresponding log budget. C1: ConsumeUpToStable (not plain
 		// ConsumeUpTo) preserves any interval a write created during Phase B
 		// (Touched > phaseStart), so its bytes are rolled up by a later pass
-		// rather than silently dropped. Reclaimed bytes are measured against
-		// the in-memory priorFence, NOT hdr.RollupOffset — the log header is
-		// derived state that may lag the metadata-authoritative fence after a
-		// prior advanceRollupOffset failure, and basing reclaimed on the stale
-		// header would double-decrement budget on the next pass.
+		// rather than silently dropped.
+		//
+		// C3 budget-leak fix: release exactly the framed-record bytes the
+		// fence retired this pass (retiredBytes), NOT the compaction-fence
+		// position delta (targetPos - priorFence). The previous delta was a
+		// CONTIGUOUS high-water mark from the log head; under out-of-order
+		// overwrites a consumed record can sit behind an unconsumed
+		// lower-logPos record, so AdvanceFenceUpTo stalls and the position
+		// delta systematically under-counts the bytes actually retired. The
+		// stranded bytes then never leave logBytesTotal, the pressure budget
+		// ratchets to maxLogBytes and pins there, and every writer blocks
+		// until ErrPressureTimeout — the storm-stall reported as C3.
+		// retiredBytes sums the frame size of every entry the fence walked
+		// past — both records consumed this pass AND records released only
+		// because an overwrite's MarkConsumed covered their region (R-7) —
+		// so logBytesTotal becomes an exact running total of un-rolled-up
+		// record bytes, decoupled from fence contiguity. targetPos remains
+		// authoritative for physical log compaction below.
 		tree.ConsumeUpToStable(stableEnd, phaseStart)
-		if targetPos > priorFence {
-			bc.logBytesTotal.Add(-int64(targetPos - priorFence))
-		}
-
-		// Non-blocking signal to unblock any AppendWrite waiting on pressure.
-		select {
-		case bc.pressureCh <- struct{}{}:
-		default:
-		}
+		// releaseLogBytes also pulses pressureCh to unblock any AppendWrite
+		// waiting on the budget.
+		bc.releaseLogBytes(retiredBytes)
 
 		// #579: physical log compaction. Runs under the append mutex (mu) we
 		// hold here in Phase C. The threshold check is internal to


### PR DESCRIPTION
## Summary

Closes #1007 — the last blockstore perf item. Covers both tracked items:

- **C3 (append-log backpressure ceiling) — FIXED here.**
- **B1 (per-Flush full CAS walk) — already resolved on develop** via the syncer's in-memory `pendingHashes` set (the full `ListUnsynced`/`bc.Walk` of the CAS tree now runs only at startup + a ~10-min drift reconcile, not per Flush). Confirmed by re-profiling; no code change needed. Documented in `REVIEW.md §5.2`.

## C3 root cause

The append-log already has a backpressure mechanism (`pressureCh` + `pressureMaxWait → ErrPressureTimeout`). The bug was **not** a missing mechanism — it was a **budget-accounting leak** that turned the existing backpressure into a permanent deadlock.

`logBytesTotal` (the pressure budget) was released by the **compaction-fence position delta** (`targetPos - priorFence`), a *contiguous* high-water mark from the log head. Two paths leaked:

1. **Out-of-order overwrites** (the storm's random mid-file WRITEs): a consumed record can sit behind an unconsumed lower-logPos record, so `AdvanceFenceUpTo` stalls and the position delta under-counts the bytes actually rolled up.
2. **Create/delete churn** (dominant under the storm): `DeleteAppendLog` discards a payload's `logIndex` for files deleted mid-write **without** reclaiming the budget their un-rolled-up records reserved.

Either way `logBytesTotal` ratcheted to `maxLogBytes` and pinned there; every writer then blocked on `pressureCh` and timed out.

Repro signature on develop: the 20k-op / 8-worker / ws=64 `mixed-ops-storm` aborts with `append log: pressure wait timed out` at ~50s. Instrumented, the budget flatlines at exactly the ceiling with `dirtyIntervals=0 liveEntries=0` — every record had rolled up yet the budget was still full = pure accounting leak.

## Fix

Make `logBytesTotal` an exact running total of un-rolled-up framed-record bytes, decoupled from fence contiguity:

- Rollup releases `retiredBytes` — the summed frame size of every entry the fence actually retired this pass (`logIndex.advanceFenceUpTo`; covers both directly-consumed records and R-7 "released-by-overwrite-coverage" records).
- `DeleteAppendLog` releases `logIndex.LiveBytes()` for the discarded payload.
- Both go through `FSStore.releaseLogBytes`, which floors the total at zero (defends against recovery's resident-bytes seed drifting by a torn-tail record).

The compaction fence (`targetPos`) is unchanged and remains authoritative for physical log compaction — **only the backpressure accounting changed**; no CAS content / dedup / rollup-correctness change.

## Before / after

`cmd/bench blockstore --workload mixed-ops-storm --ops 20000 --workers 8 --working-set 64` (dev laptop, `--remote=memory`):

| | develop (before) | this PR (after) |
|---|---|---|
| 20 000-op storm | **STALLS → `append log: pressure wait timed out`** (~50s abort) | **completes, ~477 ops/s** (41.9s) |
| budget at steady state | flatlines at `maxLogBytes` (256 MiB), never drains | oscillates ~5–12 MiB, drains cleanly |
| 4 000-op storm (develop survives) | 545 ops/s | 477 ops/s (within run-to-run noise) |

## Tests

- `TestC3_DeleteMidWrite_ReclaimsBudget` (fs unit) — fails on develop (leaks ~6.5 MiB), passes here.
- `TestC3_OverwriteSameRegion_BudgetDrains` (fs unit) — budget must not ratchet across repeated same-region rollups.
- `TestRunStorm_BackpressureCeiling` (engine storm, `-race`, skipped under `-short`) — the 20k/8-worker storm must complete without `ErrPressureTimeout`.

## Gates

- `go build ./...`, `go vet ./pkg/blockstore/...`, `go fmt` — clean.
- `go test -race ./pkg/blockstore/...` — all green incl. `localtest`/`remotetest` conformance suites.
- `go test -race ./bench/blockstore/` storm — green, no data race on the new backpressure path.
- code-simplifier + code-reviewer run; no correctness change to CAS/dedup, bounds floored at zero, no data race (all budget mutations atomic; `LiveBytes` read under `idx.mu`).

> Note: SMB-conformance / smbtorture CI failures are unrelated known flakes for this blockstore change.
