### PR TITLE
feat(bench): concurrent (a)-(d) blockstore workloads + storm --mix (#680)

### DIFF
--- a/bench/blockstore/README.md
+++ b/bench/blockstore/README.md
@@ -13,18 +13,39 @@ power both the `dfsbench blockstore` CLI subcommand and the Go
 | `dedup-heavy`      | 8 MiB      | N distinct payloadIDs  | same bytes across files; flush per op so rollup → CAS runs             |
 | `mixed-rw`         | 4 KiB      | seeded 32 MiB file/N   | 50/50 read/write at random offsets                                     |
 | `flush-churn`      | 4 KiB      | monotonic offset       | write→flush→write tight loop                                           |
-| `mixed-ops-storm`  | 4 KiB      | 1 MiB files, ≥4/worker | concurrent WRITE/READ/LIST/DELETE (50/30/15/5); `--workers N`           |
+| `mixed-ops-storm`  | 4 KiB      | 1 MiB files, ≥4/worker | concurrent WRITE/READ/LIST/DELETE (50/30/15/5); `--workers N`, `--mix`   |
+| `concurrent-small-write` | 4–64 KiB | files/worker     | (a) N workers, disjoint files; size drawn per op from seed; `--workers` |
+| `concurrent-small-read`  | 4–64 KiB | pre-seeded/worker | (b) reads the (a) fileset; seed phase excluded from timing             |
+| `concurrent-big-write`   | 64–256 MiB | files/worker   | (c) big disjoint writes; `--workers`                                   |
+| `concurrent-big-read`    | 64–256 MiB | pre-seeded/worker | (d) big reads; seed phase excluded from timing                        |
 
 Defaults match the legacy `cmd/blockstore-perf` shape so historical
 results stay comparable. Override per-op size with `--block-size`.
 
-`mixed-ops-storm` is the only concurrent workload. It partitions its
-keyspace — a fixed stable set (pre-seeded, never deleted) backs READs and
-WRITE-overwrites, while WRITE-create/DELETE churn a separate pool — so no
-op ever races a concurrent delete of its own file. Each worker uses a PRNG
-seeded from `(--seed, worker)`, so a given `(seed, workers)` reproduces the
-same *multiset* of ops; goroutine interleaving (and thus the exact per-type
-tally) is not deterministic at `--workers > 1`.
+### Concurrent workloads
+
+Five concurrent workloads fan ops across `--workers N` goroutines:
+
+- **`mixed-ops-storm`** — the (e) storm. Partitions its keyspace: a fixed
+  stable set (pre-seeded, never deleted) backs READs and WRITE-overwrites,
+  while WRITE-create/DELETE churn a separate pool — so no op ever races a
+  concurrent delete of its own file. Op weights default to 50/30/15/5
+  (WRITE/READ/LIST/DELETE); override with `--mix W,R,L,D` (e.g.
+  `--mix 70,20,5,5` for a write-heavy storm).
+- **`concurrent-small-write` / `concurrent-big-write`** — (a) / (c). Each
+  worker writes its own disjoint payloadID space (`w<worker>/<op>`), so there
+  is no shared blockref state or cross-worker lock — the scaling/contention
+  picture comes purely from the engine internals. Per-op size is drawn from
+  the worker PRNG (4–64 KiB small, 64–256 MiB big).
+- **`concurrent-small-read` / `concurrent-big-read`** — (b) / (d). One file
+  per op is pre-seeded outside the timed region (so timing is pure read
+  latency), then every worker reads back its own files.
+
+Every concurrent worker uses a PRNG seeded from `(--seed, worker)`, so a
+given `(seed, workers)` reproduces the same *multiset* of ops; goroutine
+interleaving (and thus the exact per-type storm tally) is not deterministic
+at `--workers > 1`. The seed reproduces the workload shape that drives the
+contention profiles, not a byte-exact execution.
 
 ## Profiles & replay
 
@@ -35,12 +56,17 @@ Each run writes `cpu/heap/goroutine.pprof` + `seed.txt` to
 adds per-event accounting overhead). `--phase baseline|post-fix` inserts a
 parent dir so before/after captures sit side by side. `--replay <dir>`
 reloads a recorded run's `seed.txt` (workload, ops, sizes, workers, seed,
-remote, full-profiles) so a regression can be re-captured without retyping
-flags; `--phase`/`--profile-dir` still pick the fresh output location.
+remote, mix, full-profiles) so a regression can be re-captured without
+retyping flags; `--phase`/`--profile-dir` still pick the fresh output
+location.
 
 ```sh
 ./dfsbench blockstore --workload mixed-ops-storm --ops 50000 --workers 8 \
-    --full-profiles --phase baseline --profile-dir .planning/v1.0-audit/blockstore/_profiles
+    --mix 70,20,5,5 --full-profiles --phase baseline \
+    --profile-dir .planning/v1.0-audit/blockstore/_profiles
+./dfsbench blockstore --workload concurrent-small-write --ops 20000 --workers 8 \
+    --full-profiles --phase baseline \
+    --profile-dir .planning/v1.0-audit/blockstore/_profiles
 ./dfsbench blockstore --replay <baseline-run-dir> --phase post-fix \
     --profile-dir .planning/v1.0-audit/blockstore/_profiles
 ```
@@ -112,7 +138,7 @@ profiles would be empty, since `runtime.SetMutexProfileFraction` /
 because the extra per-event accounting skews throughput.
 
 `seed.txt` records the exact parameters (workload, ops, block size,
-working set, workers, seed, remote, full-profiles) for deterministic
+working set, workers, seed, remote, mix, full-profiles) for deterministic
 replay via `--replay <dir>`.
 
 ```

--- a/bench/blockstore/concurrent.go
+++ b/bench/blockstore/concurrent.go
@@ -1,0 +1,146 @@
+package blockstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/blockstore/engine"
+)
+
+// Concurrent (a)–(d) workloads. Unlike the serial RunWorkload family these
+// fan a disjoint slice of the working set across Opts.Workers goroutines via
+// runWorkerPool, so a given (Seed, Workers) reproduces the same op multiset.
+// Each worker owns its own files (payloadID = "<prefix>/w<worker>/<n>"), so
+// there is no shared blockref state and no cross-worker lock — the pure
+// scaling/contention picture comes from the engine's own internals, not from
+// the harness serializing on a shared map.
+const (
+	WorkloadConcurrentSmallWrite = "concurrent-small-write"
+	WorkloadConcurrentSmallRead  = "concurrent-small-read"
+	WorkloadConcurrentBigWrite   = "concurrent-big-write"
+	WorkloadConcurrentBigRead    = "concurrent-big-read"
+)
+
+// Concurrent workload sizing (per PLAN §Performance). Small ops are 4–64 KiB;
+// big ops are 64–256 MiB. The per-op size is drawn from the worker PRNG so a
+// seed reproduces the exact size sequence. Read workloads pre-seed a file per
+// op outside the timed region.
+const (
+	concSmallMin = 4 * 1024
+	concSmallMax = 64 * 1024
+	concBigMin   = 64 * 1024 * 1024
+	concBigMax   = 256 * 1024 * 1024
+)
+
+// IsConcurrentWorkload reports whether name routes through RunConcurrent.
+func IsConcurrentWorkload(name string) bool {
+	switch name {
+	case WorkloadConcurrentSmallWrite, WorkloadConcurrentSmallRead,
+		WorkloadConcurrentBigWrite, WorkloadConcurrentBigRead:
+		return true
+	default:
+		return false
+	}
+}
+
+// RunConcurrent drives one of the concurrent (a)–(d) workloads across
+// Opts.Workers goroutines. Each worker writes (or reads) Opts.Ops/Workers ops
+// against its own disjoint payloadID space. Read workloads seed one file per
+// op before the timed region (seeding is excluded from Duration). Returns the
+// fan-out wall-clock plus before/after engine stats.
+func RunConcurrent(ctx context.Context, bs *engine.Store, opts Opts) (Result, error) {
+	if bs == nil {
+		return Result{}, fmt.Errorf("RunConcurrent: bs is nil")
+	}
+	if opts.Ops <= 0 {
+		return Result{}, fmt.Errorf("RunConcurrent: ops must be > 0")
+	}
+	workers := opts.Workers
+	if workers < 1 {
+		workers = 1
+	}
+
+	var (
+		sizeMin, sizeMax int
+		prefix           string
+		isRead           bool
+	)
+	switch opts.Workload {
+	case WorkloadConcurrentSmallWrite:
+		sizeMin, sizeMax, prefix = concSmallMin, concSmallMax, "perf/conc/sw"
+	case WorkloadConcurrentSmallRead:
+		sizeMin, sizeMax, prefix, isRead = concSmallMin, concSmallMax, "perf/conc/sr", true
+	case WorkloadConcurrentBigWrite:
+		sizeMin, sizeMax, prefix = concBigMin, concBigMax, "perf/conc/bw"
+	case WorkloadConcurrentBigRead:
+		sizeMin, sizeMax, prefix, isRead = concBigMin, concBigMax, "perf/conc/br", true
+	default:
+		return Result{}, fmt.Errorf("RunConcurrent: not a concurrent workload %q", opts.Workload)
+	}
+
+	pid := func(worker, op int) string { return fmt.Sprintf("%s/w%d/%d", prefix, worker, op) }
+	// opSize draws this op's size deterministically from the worker PRNG, so a
+	// seed reproduces the exact size sequence per worker.
+	opSize := func(rng *rand.Rand) int { return sizeMin + rng.IntN(sizeMax-sizeMin+1) }
+
+	// Read workloads pre-seed one file per op (sized like its write would be)
+	// outside the timed region so the timed fan-out is pure read latency.
+	if isRead {
+		if err := seedConcurrentReads(ctx, bs, opts, workers, pid, opSize); err != nil {
+			return Result{}, err
+		}
+	}
+
+	var moved atomic.Int64
+	statsBefore := bs.GetStats()
+	start := time.Now()
+	err := runWorkerPool(ctx, workers, opts.Ops, opts.Seed, func(worker int, rng *rand.Rand, op int) error {
+		size := opSize(rng)
+		p := pid(worker, op)
+		buf := make([]byte, size)
+		if isRead {
+			if _, err := bs.ReadAt(ctx, p, nil, buf, 0); err != nil {
+				return fmt.Errorf("%s read %s: %w", opts.Workload, p, err)
+			}
+		} else {
+			fillRandom(rng, buf)
+			if _, err := bs.WriteAt(ctx, p, nil, buf, 0); err != nil {
+				return fmt.Errorf("%s write %s: %w", opts.Workload, p, err)
+			}
+		}
+		moved.Add(int64(size))
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	dur := time.Since(start)
+	statsAfter := bs.GetStats()
+
+	return Result{
+		Duration:    dur,
+		Ops:         opts.Ops,
+		Bytes:       moved.Load(),
+		StatsBefore: statsBefore,
+		StatsAfter:  statsAfter,
+	}, nil
+}
+
+// seedConcurrentReads writes one file per op (same payloadID and size the read
+// pass will request) so every read hits a live file. The size draw replays the
+// worker PRNG used in the timed loop, keeping payload IDs and sizes aligned.
+func seedConcurrentReads(ctx context.Context, bs *engine.Store, opts Opts, workers int, pid func(int, int) string, opSize func(*rand.Rand) int) error {
+	for worker := 0; worker < workers; worker++ {
+		rng := workerRNG(opts.Seed, worker)
+		for op := worker; op < opts.Ops; op += workers {
+			size := opSize(rng)
+			if err := seedPayload(ctx, bs, pid(worker, op), seededBytes(opts.Seed^uint64(op+1), size)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/bench/blockstore/concurrent_test.go
+++ b/bench/blockstore/concurrent_test.go
@@ -1,0 +1,149 @@
+package blockstore
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync"
+	"testing"
+
+	remotememory "github.com/marmos91/dittofs/pkg/blockstore/remote/memory"
+)
+
+// TestRunWorkerPool_CoversEveryOpOnce asserts the fan-out hands every op index
+// in [0,ops) to exactly one worker regardless of worker count, so the op set
+// is a pure function of (ops, workers) — the determinism guarantee the storm
+// and concurrent workloads rely on.
+func TestRunWorkerPool_CoversEveryOpOnce(t *testing.T) {
+	const ops = 1000
+	for _, workers := range []int{1, 3, 8, 16} {
+		var (
+			mu   sync.Mutex
+			seen = make([]int, ops)
+		)
+		err := runWorkerPool(context.Background(), workers, ops, 5, func(_ int, _ *rand.Rand, op int) error {
+			mu.Lock()
+			seen[op]++
+			mu.Unlock()
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("workers=%d: %v", workers, err)
+		}
+		for i, c := range seen {
+			if c != 1 {
+				t.Fatalf("workers=%d: op %d ran %d times, want 1", workers, i, c)
+			}
+		}
+	}
+}
+
+// TestWorkerRNG_DeterministicAndDistinct verifies per-worker streams reproduce
+// across runs (same seed → same draws) but differ between workers (no two
+// workers draw the same sequence), which is what keeps a concurrent run both
+// replayable and free of accidental cross-worker dedup.
+func TestWorkerRNG_DeterministicAndDistinct(t *testing.T) {
+	draw := func(seed uint64, worker int) [8]uint64 {
+		rng := workerRNG(seed, worker)
+		var out [8]uint64
+		for i := range out {
+			out[i] = rng.Uint64()
+		}
+		return out
+	}
+	if draw(42, 0) != draw(42, 0) {
+		t.Error("same (seed, worker) must reproduce the same stream")
+	}
+	if draw(42, 0) == draw(42, 1) {
+		t.Error("distinct workers must draw distinct streams")
+	}
+}
+
+// TestRunConcurrent_WriteAndRead drives each (a)–(d) concurrent workload at a
+// small op count and asserts it completes, moves bytes, and tallies ops.
+func TestRunConcurrent_WriteAndRead(t *testing.T) {
+	for _, wl := range []string{
+		WorkloadConcurrentSmallWrite, WorkloadConcurrentSmallRead,
+	} {
+		t.Run(wl, func(t *testing.T) {
+			bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			defer closeFn()
+
+			res, err := RunConcurrent(context.Background(), bs, Opts{
+				Workload: wl,
+				Ops:      120,
+				Workers:  4,
+				Seed:     3,
+			})
+			if err != nil {
+				t.Fatalf("RunConcurrent: %v", err)
+			}
+			if res.Ops != 120 {
+				t.Errorf("Ops = %d, want 120", res.Ops)
+			}
+			if res.Bytes <= 0 {
+				t.Errorf("Bytes = %d, want > 0", res.Bytes)
+			}
+			if res.Duration <= 0 {
+				t.Errorf("Duration = %v, want > 0", res.Duration)
+			}
+		})
+	}
+}
+
+// TestRunConcurrent_RejectsNonConcurrent guards the dispatcher: a serial
+// workload name must not be accepted by RunConcurrent.
+func TestRunConcurrent_RejectsNonConcurrent(t *testing.T) {
+	bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer closeFn()
+	if _, err := RunConcurrent(context.Background(), bs, Opts{
+		Workload: WorkloadSequentialWrite, Ops: 1, Workers: 1,
+	}); err == nil {
+		t.Fatal("expected error for non-concurrent workload")
+	}
+}
+
+// TestParseStormMix covers the default, a valid override, and the malformed
+// cases (wrong arity, negative, non-numeric, all-zero).
+func TestParseStormMix(t *testing.T) {
+	if got, err := parseStormMix(""); err != nil || got != defaultStormWeights() {
+		t.Fatalf("empty mix = %+v, %v; want default", got, err)
+	}
+	if got, err := parseStormMix("70,20,5,5"); err != nil ||
+		got != (stormWeights{write: 70, read: 20, list: 5, delete: 5}) {
+		t.Fatalf("valid mix = %+v, %v", got, err)
+	}
+	for _, bad := range []string{"1,2,3", "1,2,3,4,5", "1,-2,3,4", "a,b,c,d", "0,0,0,0"} {
+		if _, err := parseStormMix(bad); err == nil {
+			t.Errorf("mix %q: expected error", bad)
+		}
+	}
+}
+
+// TestRunStorm_MixHonored runs an all-writes mix and asserts no reads/lists/
+// deletes are tallied, proving --mix flows through to op selection.
+func TestRunStorm_MixHonored(t *testing.T) {
+	bs, closeFn, err := NewEngine(t.TempDir(), remotememory.New())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer closeFn()
+	res, err := RunStorm(context.Background(), bs, Opts{
+		Workload: WorkloadMixedOpStorm, Ops: 200, BlockSize: 4096,
+		WorkingSet: 4, Workers: 2, Seed: 11, Mix: "100,0,0,0",
+	})
+	if err != nil {
+		t.Fatalf("RunStorm: %v", err)
+	}
+	if res.Storm.Reads != 0 || res.Storm.Lists != 0 || res.Storm.Deletes != 0 {
+		t.Errorf("all-write mix tallied non-writes: %+v", *res.Storm)
+	}
+	if res.Storm.Writes == 0 {
+		t.Error("all-write mix tallied zero writes")
+	}
+}

--- a/bench/blockstore/concurrent_test.go
+++ b/bench/blockstore/concurrent_test.go
@@ -50,10 +50,11 @@ func TestWorkerRNG_DeterministicAndDistinct(t *testing.T) {
 		}
 		return out
 	}
-	if draw(42, 0) != draw(42, 0) {
+	w0a, w0b, w1 := draw(42, 0), draw(42, 0), draw(42, 1)
+	if w0a != w0b {
 		t.Error("same (seed, worker) must reproduce the same stream")
 	}
-	if draw(42, 0) == draw(42, 1) {
+	if w0a == w1 {
 		t.Error("distinct workers must draw distinct streams")
 	}
 }

--- a/bench/blockstore/fixture.go
+++ b/bench/blockstore/fixture.go
@@ -3,6 +3,9 @@ package blockstore
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/marmos91/dittofs/pkg/blockstore/engine"
 	"github.com/marmos91/dittofs/pkg/blockstore/local/fs"
@@ -54,4 +57,47 @@ func NewEngine(baseDir string, remoteStore remote.RemoteStore) (*engine.Store, f
 	}
 	// engine.Store.Close also closes the remote — no double close here.
 	return bs, func() { _ = bs.Close() }, nil
+}
+
+// workerRNG returns the per-worker PRNG for the concurrent workloads. Seeding
+// the stream component with worker+1 (so worker 0 differs from the serial
+// seed) gives each worker a deterministic-yet-distinct sequence: re-running
+// with the same (Seed, Workers) reproduces every worker's stream exactly,
+// while no two workers draw the same offsets/payload bytes.
+func workerRNG(seed uint64, worker int) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, uint64(worker)+1))
+}
+
+// runWorkerPool fans an op stream of `ops` ops across `workers` errgroup
+// goroutines and returns the wall-clock duration of the fan-out (the timed
+// region). Op index i is owned by worker i%workers, so the set of ops is a
+// pure function of (ops, workers) regardless of concurrency. fn receives the
+// worker index, that worker's private PRNG (workerRNG), and the global op
+// index; it must touch only worker-private or concurrency-safe state. The
+// first non-nil error cancels the group and is returned. workers < 1 is
+// treated as 1.
+//
+// Setup that must stay out of the timed region (seeding files, etc.) belongs
+// before the call — runWorkerPool times only the fan-out.
+func runWorkerPool(ctx context.Context, workers, ops int, seed uint64, fn func(worker int, rng *rand.Rand, op int) error) error {
+	if workers < 1 {
+		workers = 1
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	for w := 0; w < workers; w++ {
+		worker := w
+		g.Go(func() error {
+			rng := workerRNG(seed, worker)
+			for i := worker; i < ops; i += workers {
+				if gctx.Err() != nil {
+					return nil // another worker failed; stop quietly
+				}
+				if err := fn(worker, rng, i); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	return g.Wait()
 }

--- a/bench/blockstore/storm.go
+++ b/bench/blockstore/storm.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,15 +28,52 @@ const (
 	stormCreateOdds = 16
 )
 
-// Op-type weights (out of stormWeightTotal). WRITE/READ dominate; LIST and
-// DELETE are rarer, matching a read-mostly mutating workload.
+// Default op-type weights. WRITE/READ dominate; LIST and DELETE are rarer,
+// matching a read-mostly mutating workload. Override via Opts.Mix.
 const (
 	stormWeightWrite  = 50
 	stormWeightRead   = 30
 	stormWeightList   = 15
 	stormWeightDelete = 5
-	stormWeightTotal  = stormWeightWrite + stormWeightRead + stormWeightList + stormWeightDelete
 )
+
+// stormWeights is the resolved WRITE/READ/LIST/DELETE op-type mix for a storm
+// run. Total is their sum (the modulus for pickStormOp).
+type stormWeights struct {
+	write, read, list, delete int
+}
+
+func (w stormWeights) total() int { return w.write + w.read + w.list + w.delete }
+
+func defaultStormWeights() stormWeights {
+	return stormWeights{write: stormWeightWrite, read: stormWeightRead, list: stormWeightList, delete: stormWeightDelete}
+}
+
+// parseStormMix parses a "W,R,L,D" weight string (e.g. "50,30,15,5"). An empty
+// string yields the default mix. All four weights are required, must be
+// non-negative, and must not all be zero.
+func parseStormMix(mix string) (stormWeights, error) {
+	if strings.TrimSpace(mix) == "" {
+		return defaultStormWeights(), nil
+	}
+	parts := strings.Split(mix, ",")
+	if len(parts) != 4 {
+		return stormWeights{}, fmt.Errorf("mix %q: want four comma-separated weights W,R,L,D", mix)
+	}
+	vals := make([]int, 4)
+	for i, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 0 {
+			return stormWeights{}, fmt.Errorf("mix %q: weight %d (%q) must be a non-negative integer", mix, i, p)
+		}
+		vals[i] = n
+	}
+	w := stormWeights{write: vals[0], read: vals[1], list: vals[2], delete: vals[3]}
+	if w.total() == 0 {
+		return stormWeights{}, fmt.Errorf("mix %q: weights must not all be zero", mix)
+	}
+	return w, nil
+}
 
 // churnPool is the storm's concurrency-safe pool of deletable payload IDs.
 //
@@ -103,6 +142,10 @@ func RunStorm(ctx context.Context, bs *engine.Store, opts Opts) (Result, error) 
 	if workers < 1 {
 		workers = 1
 	}
+	weights, err := parseStormMix(opts.Mix)
+	if err != nil {
+		return Result{}, err
+	}
 
 	// Stable set: at least four files per worker, so readers always have live
 	// targets even at high concurrency.
@@ -128,7 +171,7 @@ func RunStorm(ctx context.Context, bs *engine.Store, opts Opts) (Result, error) 
 		wg.Add(1)
 		go func(worker int) {
 			defer wg.Done()
-			if err := runStormWorker(gctx, bs, opts, stable, churn, worker, workers, &counts); err != nil {
+			if err := runStormWorker(gctx, bs, opts, weights, stable, churn, worker, workers, &counts); err != nil {
 				errOnce.Do(func() {
 					firstErr = err
 					cancel()
@@ -163,8 +206,8 @@ func RunStorm(ctx context.Context, bs *engine.Store, opts Opts) (Result, error) 
 // indices i where i%workers == worker. The worker owns a private PRNG and
 // scratch buffers; only the stable set, churn pool, and atomic counters are
 // shared.
-func runStormWorker(ctx context.Context, bs *engine.Store, opts Opts, stable []string, churn *churnPool, worker, workers int, counts *StormCounts) error {
-	rng := rand.New(rand.NewPCG(opts.Seed, uint64(worker)+1))
+func runStormWorker(ctx context.Context, bs *engine.Store, opts Opts, weights stormWeights, stable []string, churn *churnPool, worker, workers int, counts *StormCounts) error {
+	rng := workerRNG(opts.Seed, worker)
 	wbuf := make([]byte, opts.BlockSize)
 	rbuf := make([]byte, opts.BlockSize)
 	maxOff := uint64(StormFileSize - opts.BlockSize)
@@ -173,7 +216,7 @@ func runStormWorker(ctx context.Context, bs *engine.Store, opts Opts, stable []s
 		if ctx.Err() != nil {
 			return nil // another worker failed; stop quietly
 		}
-		switch pickStormOp(rng) {
+		switch pickStormOp(rng, weights) {
 		case opWrite:
 			if rng.IntN(stormCreateOdds) == 0 {
 				// Create a new churn file: seed it fully, then publish it as
@@ -240,14 +283,14 @@ const (
 )
 
 // pickStormOp draws an op type by the configured weights.
-func pickStormOp(rng *rand.Rand) stormOp {
-	r := rng.IntN(stormWeightTotal)
+func pickStormOp(rng *rand.Rand, w stormWeights) stormOp {
+	r := rng.IntN(w.total())
 	switch {
-	case r < stormWeightWrite:
+	case r < w.write:
 		return opWrite
-	case r < stormWeightWrite+stormWeightRead:
+	case r < w.write+w.read:
 		return opRead
-	case r < stormWeightWrite+stormWeightRead+stormWeightList:
+	case r < w.write+w.read+w.list:
 		return opList
 	default:
 		return opDelete

--- a/bench/blockstore/workloads.go
+++ b/bench/blockstore/workloads.go
@@ -77,6 +77,11 @@ type Opts struct {
 	// Remote selects the upload backend: "memory" (default) or "s3".
 	Remote string
 
+	// Mix overrides the mixed-ops-storm op weights as "W,R,L,D" (e.g.
+	// "50,30,15,5"). Empty uses the default 50/30/15/5. Ignored by every
+	// other workload.
+	Mix string
+
 	// ProfileDir is the parent dir for per-run pprof output. Optional
 	// at the library level (only the cmd layer captures profiles).
 	ProfileDir string

--- a/cmd/bench/blockstore.go
+++ b/cmd/bench/blockstore.go
@@ -21,6 +21,7 @@ var (
 	bsFullProfiles   bool
 	bsPhase          string
 	bsReplay         string
+	bsMix            string
 )
 
 var blockstoreCmd = &cobra.Command{
@@ -29,7 +30,9 @@ var blockstoreCmd = &cobra.Command{
 	Long: `Composes FSStore local + remote (memory or s3) + in-memory metadata +
 Syncer and drives one of:
   sequential-write | random-write | dedup-heavy | mixed-rw | flush-churn
-  mixed-ops-storm (concurrent WRITE/READ/LIST/DELETE; use --workers)
+  mixed-ops-storm (concurrent WRITE/READ/LIST/DELETE; use --workers, --mix)
+  concurrent-small-write | concurrent-small-read (4-64 KiB, --workers)
+  concurrent-big-write   | concurrent-big-read   (64-256 MiB, --workers)
   walk | delete | gc | raw-s3-put
 
 Captures wall-clock, throughput, and CPU + heap + goroutine pprof to
@@ -55,6 +58,7 @@ func init() {
 	flags.BoolVar(&bsFullProfiles, "full-profiles", false, "also capture mutex + block profiles (enables runtime mutex/block profilers; adds overhead)")
 	flags.StringVar(&bsPhase, "phase", "", "optional capture phase subdir under <profile-dir>/blockstore/ (e.g. baseline | post-fix)")
 	flags.StringVar(&bsReplay, "replay", "", "replay a recorded run: load workload params from <dir>/seed.txt (overrides other flags except --phase/--profile-dir)")
+	flags.StringVar(&bsMix, "mix", "", "mixed-ops-storm op weights as W,R,L,D (e.g. 50,30,15,5); default 50/30/15/5")
 	// --workload is required unless replaying, where it comes from seed.txt.
 }
 
@@ -82,6 +86,7 @@ func runBlockstore(cmd *cobra.Command, _ []string) error {
 			Workers:    bsWorkers,
 			Seed:       bsSeed,
 			Remote:     bsRemote,
+			Mix:        bsMix,
 			ProfileDir: flagProfileDir,
 		}
 	}
@@ -109,6 +114,9 @@ func runBlockstore(cmd *cobra.Command, _ []string) error {
 	case bsbench.WorkloadMixedOpStorm:
 		return runStormWorkload(ctx, cmd, opts, tmpDir)
 	default:
+		if bsbench.IsConcurrentWorkload(opts.Workload) {
+			return runConcurrentWorkload(ctx, cmd, opts, tmpDir)
+		}
 		// Engine-backed workloads (sequential-write, random-write, ...).
 		return runEngineWorkload(ctx, cmd, opts, tmpDir)
 	}
@@ -150,6 +158,40 @@ func runStormWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 			"storm ops: workers=%d writes=%d reads=%d lists=%d deletes=%d\n",
 			opts.Workers, res.Storm.Writes, res.Storm.Reads, res.Storm.Lists, res.Storm.Deletes)
 	}
+	return nil
+}
+
+// runConcurrentWorkload wires the engine like runEngineWorkload but drives one
+// of the concurrent (a)–(d) workloads via RunConcurrent across opts.Workers.
+func runConcurrentWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts, tmpDir string) error {
+	remoteStore, remoteClose, err := bsbench.SetupRemote(ctx, opts)
+	if err != nil {
+		return err
+	}
+	bs, engineClose, err := bsbench.NewEngine(tmpDir, remoteStore)
+	if err != nil {
+		remoteClose()
+		return err
+	}
+	defer engineClose()
+
+	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return err
+	}
+
+	res, err := bsbench.RunConcurrent(ctx, bs, opts)
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
+	if err != nil {
+		return err
+	}
+	printResult(cmd, opts, res, sess.dir, true)
 	return nil
 }
 

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -123,8 +123,8 @@ func (s *profileSession) writeSeed(opts bsbench.Opts) error {
 		return nil
 	}
 	body := fmt.Sprintf(
-		"workload=%s\nops=%d\nblock_size=%d\nworking_set=%d\nworkers=%d\nseed=%d\nremote=%s\nfull_profiles=%t\n",
-		opts.Workload, opts.Ops, opts.BlockSize, opts.WorkingSet, opts.Workers, opts.Seed, opts.Remote, s.full,
+		"workload=%s\nops=%d\nblock_size=%d\nworking_set=%d\nworkers=%d\nseed=%d\nremote=%s\nmix=%s\nfull_profiles=%t\n",
+		opts.Workload, opts.Ops, opts.BlockSize, opts.WorkingSet, opts.Workers, opts.Seed, opts.Remote, opts.Mix, s.full,
 	)
 	if err := os.WriteFile(filepath.Join(s.dir, "seed.txt"), []byte(body), 0o644); err != nil {
 		return fmt.Errorf("write seed.txt: %w", err)
@@ -159,6 +159,7 @@ func loadSeed(dir string) (bsbench.Opts, bool, error) {
 		// reproducing the wrong PRNG stream on replay).
 		Seed:   parseUintDefault(kv["seed"], 0),
 		Remote: kv["remote"],
+		Mix:    kv["mix"],
 	}
 	if opts.Workload == "" || opts.Ops <= 0 {
 		return bsbench.Opts{}, false, fmt.Errorf("seed.txt missing required workload/ops")

--- a/cmd/bench/profiles_test.go
+++ b/cmd/bench/profiles_test.go
@@ -173,7 +173,7 @@ func TestLoadSeed_RoundTrip(t *testing.T) {
 	}{
 		{"small-seed", bsbench.Opts{
 			Workload: "mixed-ops-storm", Ops: 1234, BlockSize: 8192,
-			WorkingSet: 16, Workers: 8, Seed: 99, Remote: "memory",
+			WorkingSet: 16, Workers: 8, Seed: 99, Remote: "memory", Mix: "70,20,5,5",
 		}},
 		{"max-uint64-seed", bsbench.Opts{
 			Workload: "mixed-ops-storm", Ops: 10, BlockSize: 4096,
@@ -199,7 +199,7 @@ func TestLoadSeed_RoundTrip(t *testing.T) {
 			}
 			if got.Workload != tc.want.Workload || got.Ops != tc.want.Ops || got.BlockSize != tc.want.BlockSize ||
 				got.WorkingSet != tc.want.WorkingSet || got.Workers != tc.want.Workers || got.Seed != tc.want.Seed ||
-				got.Remote != tc.want.Remote {
+				got.Remote != tc.want.Remote || got.Mix != tc.want.Mix {
 				t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, tc.want)
 			}
 		})


### PR DESCRIPTION
Completes the #680 blockstore pprof-capture harness on top of the storm/replay slice from #983.

## What this adds (per the locked SCOPE, `.planning/v1.0-audit/680-perf-capture-SCOPE.md`)

- **Worker-pool primitive** (`bench/blockstore/fixture.go`): `runWorkerPool` (errgroup) fans an op stream round-robin (`i%workers`) across goroutines; `workerRNG(seed, worker)` gives each worker a deterministic-yet-distinct PRNG. The mixed-ops-storm worker now reuses `workerRNG` (dedup of its inline seeding).
- **Concurrent (a)–(d) workloads** (`bench/blockstore/concurrent.go`): `concurrent-small-write`, `concurrent-small-read`, `concurrent-big-write`, `concurrent-big-read`. Each worker owns a disjoint payloadID space (`w<worker>/<op>`) — no shared blockref state, no cross-worker lock — so the scaling/contention picture comes purely from engine internals. Per-op size is drawn from the worker PRNG (4–64 KiB small / 64–256 MiB big). Read variants pre-seed one file per op **outside** the timed region so timing is pure read latency.
- **`--mix W,R,L,D` flag** for the mixed-ops-storm op weights (default 50/30/15/5). Threaded through `Opts.Mix`, `seed.txt`, and `--replay`. `parseStormMix` validates arity / non-negative / not-all-zero.
- **README**: documents (a)–(e), `--mix`, and the per-worker determinism caveat (a seed reproduces the op *multiset*/shape; goroutine interleaving stays nondeterministic at `--workers>1` per locked decision #3).

The 5-profile envelope (cpu/heap/block/mutex/goroutine), `--workers`, `--phase`, `--replay`, and the storm + `fileRegistry` already shipped in #983; this PR closes the remaining in-scope items (concurrent variants + `--mix`).

## Verification

- `go build ./...`, `go vet ./cmd/bench/... ./bench/...`, `gofmt` — clean.
- `go test -race ./bench/blockstore/... ./cmd/bench/...` — green (incl. the long C3 storm backpressure regression guard). New tests: worker-pool op-coverage (every index once), `workerRNG` deterministic-and-distinct, concurrent write/read end-to-end, `parseStormMix` cases, storm `--mix` honored, seed.txt `mix` round-trip.
- Live: ran each new concurrent workload + a `--mix 70,20,5,5` storm; confirmed all 5 profiles written under `--full-profiles`, `mix=` recorded in `seed.txt`, and `--replay` reloads params (workers/seed/mix) and reproduces the op shape (writes count identical; LIST/DELETE counts shift slightly at workers>1 exactly as the documented interleaving caveat predicts).

## Scope

Blockstore harness only (`cmd/bench/` + `bench/blockstore/`). Per-area SMB/NFS/lock/runtime wrappers remain explicit follow-ups (locked decision #4).

Closes #680.