### PR TITLE
fix(nfs): MED/LOW hardening from area audit

### DIFF
--- a/internal/adapter/nfs/connection.go
+++ b/internal/adapter/nfs/connection.go
@@ -83,6 +83,68 @@ func ReadRPCMessage(r io.Reader, length uint32) ([]byte, error) {
 	return message, nil
 }
 
+// ReadRPCRecord reads a complete RPC record from the reader, reassembling
+// multiple record-marking fragments (RFC 5531 §11) until the last-fragment
+// flag is set.
+//
+// firstHeader is the already-read header of the first fragment (whose size the
+// caller has validated). Subsequent fragment headers are read and validated
+// here, with the running total bounded by MaxFragmentSize so a stream of
+// not-last fragments cannot exhaust memory.
+//
+// The common case — a single last fragment — returns a single pooled buffer
+// with no extra copy. The returned buffer is from the pool; the caller must
+// return it via pool.Put() after processing.
+func ReadRPCRecord(r io.Reader, firstHeader *FragmentHeader, clientAddr string) ([]byte, error) {
+	// Fast path: a single, final fragment (the overwhelmingly common case).
+	if firstHeader.IsLast {
+		return ReadRPCMessage(r, firstHeader.Length)
+	}
+
+	// Slow path: accumulate fragments until the last-fragment flag is seen.
+	// The first fragment's buffer is pooled; subsequent fragments are read into
+	// scratch buffers and appended.
+	message, err := ReadRPCMessage(r, firstHeader.Length)
+	if err != nil {
+		return nil, err
+	}
+
+	total := uint32(len(message))
+	for {
+		header, herr := ReadFragmentHeader(r)
+		if herr != nil {
+			pool.Put(message)
+			return nil, fmt.Errorf("read continuation fragment header: %w", herr)
+		}
+
+		// Bound the cumulative record size, not just each fragment, so a flood
+		// of not-last fragments cannot drive unbounded growth.
+		if header.Length > MaxFragmentSize-total {
+			pool.Put(message)
+			logger.Warn("RPC record exceeds maximum after reassembly",
+				"accumulated", bytesize.ByteSize(total),
+				"fragment", bytesize.ByteSize(header.Length),
+				"max", bytesize.ByteSize(MaxFragmentSize),
+				"address", clientAddr)
+			return nil, fmt.Errorf("reassembled RPC record too large: %d + %d bytes", total, header.Length)
+		}
+
+		if header.Length > 0 {
+			frag := make([]byte, header.Length)
+			if _, rerr := io.ReadFull(r, frag); rerr != nil {
+				pool.Put(message)
+				return nil, fmt.Errorf("read continuation fragment: %w", rerr)
+			}
+			message = append(message, frag...)
+			total += header.Length
+		}
+
+		if header.IsLast {
+			return message, nil
+		}
+	}
+}
+
 // DemuxBackchannelReply checks if an RPC message is a backchannel REPLY (msg_type=1)
 // rather than a CALL, and routes it to the pending callback replies handler.
 //

--- a/internal/adapter/nfs/connection_test.go
+++ b/internal/adapter/nfs/connection_test.go
@@ -1,0 +1,95 @@
+package nfs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// frame builds a record-marking fragment: 4-byte header (last flag + length)
+// followed by payload.
+func frame(last bool, payload []byte) []byte {
+	var hdr [4]byte
+	v := uint32(len(payload)) & 0x7FFFFFFF
+	if last {
+		v |= 0x80000000
+	}
+	binary.BigEndian.PutUint32(hdr[:], v)
+	return append(hdr[:], payload...)
+}
+
+func TestReadRPCRecord_SingleFragment(t *testing.T) {
+	payload := []byte("hello world")
+	stream := bytes.NewReader(frame(true, payload))
+
+	hdr, err := ReadFragmentHeader(stream)
+	require.NoError(t, err)
+	require.True(t, hdr.IsLast)
+
+	msg, err := ReadRPCRecord(stream, hdr, "test")
+	require.NoError(t, err)
+	assert.Equal(t, payload, msg)
+}
+
+func TestReadRPCRecord_MultiFragmentReassembly(t *testing.T) {
+	// Three fragments, only the last marked final.
+	var stream bytes.Buffer
+	stream.Write(frame(false, []byte("part-one-")))
+	stream.Write(frame(false, []byte("part-two-")))
+	stream.Write(frame(true, []byte("part-three")))
+
+	r := bytes.NewReader(stream.Bytes())
+	hdr, err := ReadFragmentHeader(r)
+	require.NoError(t, err)
+	require.False(t, hdr.IsLast)
+
+	msg, err := ReadRPCRecord(r, hdr, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "part-one-part-two-part-three", string(msg))
+}
+
+func TestReadRPCRecord_EmptyContinuationFragment(t *testing.T) {
+	// A zero-length non-final fragment followed by a final fragment.
+	var stream bytes.Buffer
+	stream.Write(frame(false, []byte("data")))
+	stream.Write(frame(false, nil))
+	stream.Write(frame(true, []byte("end")))
+
+	r := bytes.NewReader(stream.Bytes())
+	hdr, err := ReadFragmentHeader(r)
+	require.NoError(t, err)
+
+	msg, err := ReadRPCRecord(r, hdr, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "dataend", string(msg))
+}
+
+func TestReadRPCRecord_ExceedsMaxAfterReassembly(t *testing.T) {
+	// First fragment near the cap, a continuation that pushes the cumulative
+	// record over MaxFragmentSize must be rejected.
+	first := make([]byte, MaxFragmentSize-10)
+	var stream bytes.Buffer
+	stream.Write(frame(false, first))
+	stream.Write(frame(true, make([]byte, 100)))
+
+	r := bytes.NewReader(stream.Bytes())
+	hdr, err := ReadFragmentHeader(r)
+	require.NoError(t, err)
+
+	_, err = ReadRPCRecord(r, hdr, "test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestReadRPCRecord_TruncatedContinuation(t *testing.T) {
+	// Non-final first fragment, then EOF before the continuation header.
+	r := bytes.NewReader(frame(false, []byte("partial")))
+	hdr, err := ReadFragmentHeader(r)
+	require.NoError(t, err)
+
+	_, err = ReadRPCRecord(r, hdr, "test")
+	require.Error(t, err)
+}

--- a/internal/adapter/nfs/v3/handlers/fsstat.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat.go
@@ -184,10 +184,14 @@ func (h *Handler) FsStat(
 
 	logger.InfoCtx(ctx.Context, "FSSTAT successful", "client", ctx.ClientAddr, "total", bytesize.ByteSize(stats.TotalBytes), "used", bytesize.ByteSize(stats.UsedBytes), "avail", bytesize.ByteSize(stats.AvailableBytes), "tfiles", stats.TotalFiles, "ffiles", stats.UsedFiles, "afiles", stats.AvailableFiles)
 
-	// Build response with data from store
-	// Note: NFS uses "free bytes" while the interface tracks "used bytes"
-	// Calculate free bytes as: total - used
-	freeBytes := stats.TotalBytes - stats.UsedBytes
+	// Build response with data from store.
+	// Note: NFS uses "free bytes" while the interface tracks "used bytes".
+	// Clamp the subtractions at zero: if a store ever reports used > total
+	// (e.g. over-quota or a transient accounting skew) an unsigned underflow
+	// would otherwise wrap to a near-2^64 value and the client would believe
+	// the filesystem has effectively unlimited free space.
+	freeBytes := satSub(stats.TotalBytes, stats.UsedBytes)
+	freeFiles := satSub(stats.TotalFiles, stats.UsedFiles)
 
 	return &FsStatResponse{
 		NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
@@ -196,8 +200,16 @@ func (h *Handler) FsStat(
 		Fbytes:          freeBytes,
 		Abytes:          stats.AvailableBytes,
 		Tfiles:          stats.TotalFiles,
-		Ffiles:          stats.TotalFiles - stats.UsedFiles, // Free = Total - Used
+		Ffiles:          freeFiles, // Free = Total - Used (clamped at 0)
 		Afiles:          stats.AvailableFiles,
 		Invarsec:        invarsec,
 	}, nil
+}
+
+// satSub returns a - b, saturating at 0 instead of wrapping on underflow.
+func satSub(a, b uint64) uint64 {
+	if b > a {
+		return 0
+	}
+	return a - b
 }

--- a/internal/adapter/nfs/v3/handlers/utils_test.go
+++ b/internal/adapter/nfs/v3/handlers/utils_test.go
@@ -275,3 +275,21 @@ func TestSafeAddPatterns(t *testing.T) {
 		assert.Equal(t, uint64(1<<32), sum)
 	})
 }
+
+// TestSatSub verifies the saturating subtraction used by FSSTAT so an
+// over-quota store (used > total) cannot wrap to a near-2^64 free-space value.
+func TestSatSub(t *testing.T) {
+	t.Run("NormalSubtraction", func(t *testing.T) {
+		assert.Equal(t, uint64(40), satSub(100, 60))
+	})
+	t.Run("EqualOperandsYieldsZero", func(t *testing.T) {
+		assert.Equal(t, uint64(0), satSub(100, 100))
+	})
+	t.Run("UnderflowSaturatesAtZero", func(t *testing.T) {
+		// Without saturation this would wrap to 2^64-1.
+		assert.Equal(t, uint64(0), satSub(60, 100))
+	})
+	t.Run("MaxUsedZeroTotalSaturates", func(t *testing.T) {
+		assert.Equal(t, uint64(0), satSub(0, math.MaxUint64))
+	})
+}

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -56,15 +56,20 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		}, shareName, nil
 	}
 
-	// Apply share-level identity mapping (all_squash, root_squash)
+	// Apply share-level identity mapping (all_squash, root_squash).
+	//
+	// Fail closed on mapping failure (parity with the v3 path,
+	// BuildAuthContextWithMapping). A mapping failure means the share could
+	// not be resolved (e.g. a stale handle for a deleted/renamed share); the
+	// previous behaviour of falling back to the original, UNMAPPED identity
+	// silently bypassed squash rules (a root client would have stayed root).
 	effectiveIdentity, err := h.Registry.ApplyIdentityMapping(shareName, originalIdentity)
 	if err != nil {
 		logger.Debug("NFSv4 identity mapping failed",
 			"share", shareName,
 			"error", err,
 			"client", ctx.ClientAddr)
-		// Fall back to original identity if mapping fails (share may not exist yet)
-		effectiveIdentity = originalIdentity
+		return nil, "", fmt.Errorf("apply identity mapping: %w", err)
 	}
 
 	// Get share for read-only flag

--- a/internal/adapter/nfs/v4/handlers/helpers_test.go
+++ b/internal/adapter/nfs/v4/handlers/helpers_test.go
@@ -112,6 +112,40 @@ func TestBuildV4AuthContext_NilRegistry(t *testing.T) {
 	}
 }
 
+// TestBuildV4AuthContext_FailsClosedOnMappingFailure verifies the G1 security
+// fix: when a registry is present but identity mapping fails (e.g. the handle
+// decodes to a share that is not registered), buildV4AuthContext must fail
+// closed with an error rather than silently falling back to the original,
+// UNMAPPED identity. This mirrors the v3 BuildAuthContextWithMapping behaviour
+// and prevents a stale handle for a deleted/renamed share from bypassing
+// squash rules (a root client must not remain root).
+func TestBuildV4AuthContext_FailsClosedOnMappingFailure(t *testing.T) {
+	// The fixture registers share "/export". We hand the handler a valid-format
+	// handle for a DIFFERENT share that is NOT registered (e.g. a stale handle
+	// for a deleted/renamed share), so ApplyIdentityMapping fails for it.
+	fixture := newRealFSTestFixture(t, "/export")
+
+	staleHandle := []byte("/deleted-share:00000000-0000-0000-0000-000000000001")
+
+	uid := uint32(0) // root -- squash is meant to map this away
+	gid := uint32(0)
+	ctx := &types.CompoundContext{
+		Context:    context.Background(),
+		ClientAddr: "192.168.1.100:9999",
+		AuthFlavor: 1, // AUTH_UNIX
+		UID:        &uid,
+		GID:        &gid,
+	}
+
+	authCtx, _, err := fixture.handler.buildV4AuthContext(ctx, staleHandle)
+	if err == nil {
+		t.Fatal("expected fail-closed error on identity mapping failure, got nil")
+	}
+	if authCtx != nil {
+		t.Errorf("expected nil authCtx on mapping failure, got %+v", authCtx)
+	}
+}
+
 func TestEncodeChangeInfo4(t *testing.T) {
 	t.Run("atomic true", func(t *testing.T) {
 		var buf bytes.Buffer

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -50,6 +50,12 @@ func newRealFSTestFixture(t *testing.T, shareName string) *realFSTestFixture {
 		t.Fatalf("register store: %v", err)
 	}
 
+	// Also register the share in the share service so identity mapping and
+	// permission lookups resolve (production invariant: every share with a
+	// metadata store is a registered share). Without this, buildV4AuthContext
+	// now fails closed on the identity-mapping step (G1).
+	rt.RegisterShareForTesting(shareName)
+
 	// Create root directory handle
 	rootID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	rootHandle, err := metadata.EncodeShareHandle(shareName, rootID)

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -210,7 +210,10 @@ func (c *NFSConnection) readRequest(ctx context.Context) (*rpc.RPCCallMessage, [
 	default:
 	}
 
-	message, err := nfs_internal.ReadRPCMessage(c.conn, header.Length)
+	// Reassemble all record-marking fragments (RFC 5531 §11) until the
+	// last-fragment flag is set. The common single-fragment case is a direct
+	// pooled read with no extra copy.
+	message, err := nfs_internal.ReadRPCRecord(c.conn, header, c.conn.RemoteAddr().String())
 	if err != nil {
 		return nil, nil, fmt.Errorf("read RPC message: %w", err)
 	}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -387,6 +387,14 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	return nil
 }
 
+// RegisterShareForTesting registers a minimal enabled share in the share
+// service, bypassing the full AddShare store-composition path. Test-only:
+// used by protocol handler unit tests that register a metadata store directly
+// and need the share to resolve in identity mapping / permission lookups.
+func (r *Runtime) RegisterShareForTesting(name string) {
+	r.sharesSvc.RegisterShareForTesting(name)
+}
+
 // RemoveShare removes a share. Snapshot orchestration goroutines for the
 // share are cancelled and drained BEFORE the per-share snapshots/ tree is
 // wiped (Phase 22 D-15 hook inside sharesSvc.RemoveShare) — without this

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1285,6 +1285,27 @@ func (s *Service) LocalStoreDir(name string) (string, error) {
 	return share.localStoreDir, nil
 }
 
+// RegisterShareForTesting inserts a minimal enabled Share into the registry
+// without the full AddShare composition (no block/remote stores, no DB row).
+// Test-only — used by handler unit tests that register a metadata store via
+// MetadataService.RegisterStoreForShare and need the share to also resolve in
+// identity mapping and permission lookups (the production invariant: every
+// share with a metadata store is a registered share). If the share already
+// exists it is left untouched.
+func (s *Service) RegisterShareForTesting(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.registry[name]; exists {
+		return
+	}
+	s.registry[name] = &Share{
+		Name:              name,
+		Enabled:           true,
+		DefaultPermission: "read-write",
+		Squash:            models.SquashNone,
+	}
+}
+
 // SetLocalStoreDirForTesting overrides the per-share localStoreDir field.
 // Test-only — used by handler unit tests that bypass the full
 // AddShare composition path (which requires a DB-backed


### PR DESCRIPTION
Part of #1014 (NFS MED/LOW backlog from the area-4 audit). Does **not** close the umbrella.

Scope: `internal/adapter/nfs/` + `pkg/adapter/nfs/` only.

## Fixed

- **G1 (SECURITY) — v4 identity-mapping now fails closed.** `buildV4AuthContext` (`internal/adapter/nfs/v4/handlers/helpers.go`) previously fell back to the original, **unmapped** identity when `ApplyIdentityMapping` failed, while v3 (`BuildAuthContextWithMapping`) fails closed. A stale handle for a deleted/renamed share could therefore run with the unmapped (e.g. root) identity, bypassing squash. v4 now returns the error — all callers already map auth-context errors to `NFS4ERR_SERVERFAULT`. PUTFH validates the share before a handle becomes the current FH, so the only failure paths are a genuine remove-mid-compound race or misconfiguration, both of which should fail closed.
- **FSSTAT free-bytes/free-files underflow** (`v3/handlers/fsstat.go`): `total - used` used saturating subtraction (`satSub`) so an over-quota store (`used > total`) can no longer wrap to a near-2^64 free-space value the client would read as unlimited.
- **RPC multi-fragment reassembly** (`internal/adapter/nfs/connection.go`, `pkg/adapter/nfs/connection.go`): record-marking fragments (RFC 5531 §11) are now reassembled until the last-fragment flag, with the cumulative record bounded by `MaxFragmentSize`. Previously `IsLast` was read and logged but never consulted, so a multi-fragment RPC record was mis-parsed. The common single-fragment case stays a single pooled read with no extra copy.

Adds a test-only `RegisterShareForTesting` hook (shares service + Runtime passthrough) so handler unit tests register the share — now required by the fail-closed auth path, and reflecting the production invariant that every share with a metadata store is a registered share.

## Tests added
- `TestBuildV4AuthContext_FailsClosedOnMappingFailure` (G1)
- `TestSatSub` (saturation)
- `TestReadRPCRecord_*` (single/multi-fragment, empty continuation, over-cap reject, truncated)

## Skipped (with reasons)
- **CREATE EXCLUSIVE verf==0 idempotency edge** — storing token 0 cannot be distinguished from "no token" without a new field; treating verf==0 as "no idempotency, conflict on existing" is the safe current behaviour. REVIEW2 §3 also confirms EXCLUSIVE idempotency is otherwise correct. Not worth a new field pre-1.0.
- **CREATE non-atomic Lookup-then-create** — the Lookup is only an early-exit probe for GUARDED/EXCLUSIVE; the atomic `CreateFile` is the real guard and returns EEXIST on the race. Cosmetic.
- **ReadData length-validation panic** (C-MED) — already fixed via the bounds-checked `HeaderMICPreimage` refactor (REVIEW2 §6 confirms).
- **portmap PMAP_DUMP / UDP DUMP info-disclosure** (LOW) — matches canonical rpcbind behaviour; SET/UNSET are already localhost-gated. Not a security gap.
- **XDR padding-not-validated, Y2038 time truncation, Fsid=0 aliasing, duplicate AUTH_UNIX parsers, trivial helper files** — cosmetic LOWs, noted only.

## Not gating for this change
SMB-conformance / smbtorture / WPTS failures are unrelated to this NFS change.

## Gates
`go build ./...`, `go vet`, `gofmt` clean; `go test -race ./internal/adapter/nfs/... ./pkg/adapter/nfs/...` and `./pkg/controlplane/runtime/...` all green.