### PR TITLE
fix(operator): MED/LOW hardening + TLS for operator->API credentials

### DIFF
--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
@@ -152,6 +152,18 @@ type ControlPlaneAPIConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
+
+	// TLS controls the URL scheme the operator uses to reach the control plane
+	// API. When true the operator connects over https:// so the admin and
+	// operator service-account credentials it sends are not transmitted in
+	// cleartext over the pod network. This requires the dfs control plane API to
+	// be served over TLS (terminated at the server or by an in-cluster mesh/
+	// sidecar that exposes the API service on https). Defaults to false (http://)
+	// for backward compatibility; in-cluster credentialed deployments should
+	// enable it once TLS termination is in place.
+	// +kubebuilder:default=false
+	// +optional
+	TLS bool `json:"tls,omitempty"`
 }
 
 // IdentityConfig defines identity store and JWT authentication configuration

--- a/k8s/dittofs-operator/api/v1alpha1/helpers.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers.go
@@ -20,29 +20,37 @@ const (
 	OperatorServiceAccountUsername = "k8s-operator"
 )
 
-// GetEffectiveJWTSecretRef returns the JWT secret reference to use for a DittoServer.
-// If the user provided a secretRef, returns that. Otherwise, returns the managed secret reference.
-// This avoids mutating the DittoServer spec while providing consistent access to the JWT secret.
-func (ds *DittoServer) GetEffectiveJWTSecretRef() corev1.SecretKeySelector {
-	// If user has explicitly provided a JWT secret reference, use that
-	if ds.Spec.Identity != nil && ds.Spec.Identity.JWT != nil &&
-		ds.Spec.Identity.JWT.SecretRef.Name != "" {
-		return ds.Spec.Identity.JWT.SecretRef
-	}
-
-	// Return the managed secret reference
-	return corev1.SecretKeySelector{
-		LocalObjectReference: corev1.LocalObjectReference{
-			Name: ds.Name + "-jwt-secret",
-		},
-		Key: ManagedJWTSecretKey,
-	}
+// GetManagedJWTSecretName returns the name of the JWT signing-secret the
+// operator manages for a DittoServer. It is the single source of truth for the
+// managed-secret name shared by GetEffectiveJWTSecretRef and the controller's
+// secret reconciliation, so the name cannot drift between the two and silently
+// break authentication.
+func (ds *DittoServer) GetManagedJWTSecretName() string {
+	return ds.Name + "-jwt-secret"
 }
 
 // HasUserProvidedJWTSecret returns true if the user explicitly provided a JWT secret reference.
 func (ds *DittoServer) HasUserProvidedJWTSecret() bool {
 	return ds.Spec.Identity != nil && ds.Spec.Identity.JWT != nil &&
 		ds.Spec.Identity.JWT.SecretRef.Name != ""
+}
+
+// GetEffectiveJWTSecretRef returns the JWT secret reference to use for a DittoServer.
+// If the user provided a secretRef, returns that. Otherwise, returns the managed secret reference.
+// This avoids mutating the DittoServer spec while providing consistent access to the JWT secret.
+func (ds *DittoServer) GetEffectiveJWTSecretRef() corev1.SecretKeySelector {
+	// If user has explicitly provided a JWT secret reference, use that
+	if ds.HasUserProvidedJWTSecret() {
+		return ds.Spec.Identity.JWT.SecretRef
+	}
+
+	// Return the managed secret reference
+	return corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: ds.GetManagedJWTSecretName(),
+		},
+		Key: ManagedJWTSecretKey,
+	}
 }
 
 // GetOperatorCredentialsSecretName returns the name of the operator credentials Secret.
@@ -56,10 +64,22 @@ func (ds *DittoServer) GetAdminCredentialsSecretName() string {
 }
 
 // GetAPIServiceURL returns the in-cluster URL for the DittoFS API service.
+//
+// The scheme is https:// when spec.controlPlane.tls is set, so the credentials
+// the operator sends (admin bootstrap password, operator service-account
+// password, bearer tokens) are not transmitted in cleartext over the pod
+// network. It defaults to http:// for backward compatibility with control
+// planes that do not yet terminate TLS.
 func (ds *DittoServer) GetAPIServiceURL() string {
 	apiPort := defaultAPIPort
-	if ds.Spec.ControlPlane != nil && ds.Spec.ControlPlane.Port > 0 {
-		apiPort = int(ds.Spec.ControlPlane.Port)
+	scheme := "http"
+	if ds.Spec.ControlPlane != nil {
+		if ds.Spec.ControlPlane.Port > 0 {
+			apiPort = int(ds.Spec.ControlPlane.Port)
+		}
+		if ds.Spec.ControlPlane.TLS {
+			scheme = "https"
+		}
 	}
-	return fmt.Sprintf("http://%s-api.%s.svc.cluster.local:%d", ds.Name, ds.Namespace, apiPort)
+	return fmt.Sprintf("%s://%s-api.%s.svc.cluster.local:%d", scheme, ds.Name, ds.Namespace, apiPort)
 }

--- a/k8s/dittofs-operator/api/v1alpha1/helpers_test.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newDittoServer(name, namespace string, cp *ControlPlaneAPIConfig) *DittoServer {
+	return &DittoServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       DittoServerSpec{ControlPlane: cp},
+	}
+}
+
+func TestGetAPIServiceURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cp   *ControlPlaneAPIConfig
+		want string
+	}{
+		{
+			name: "nil control plane defaults to http on default port",
+			cp:   nil,
+			want: "http://srv-api.ns.svc.cluster.local:8080",
+		},
+		{
+			name: "tls disabled stays http",
+			cp:   &ControlPlaneAPIConfig{TLS: false},
+			want: "http://srv-api.ns.svc.cluster.local:8080",
+		},
+		{
+			name: "tls enabled uses https so credentials are not plaintext",
+			cp:   &ControlPlaneAPIConfig{TLS: true},
+			want: "https://srv-api.ns.svc.cluster.local:8080",
+		},
+		{
+			name: "custom port is honored",
+			cp:   &ControlPlaneAPIConfig{Port: 9443},
+			want: "http://srv-api.ns.svc.cluster.local:9443",
+		},
+		{
+			name: "tls enabled with custom port",
+			cp:   &ControlPlaneAPIConfig{Port: 9443, TLS: true},
+			want: "https://srv-api.ns.svc.cluster.local:9443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newDittoServer("srv", "ns", tt.cp).GetAPIServiceURL()
+			if got != tt.want {
+				t.Fatalf("GetAPIServiceURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetAPIServiceURL_CredentialedPathNotPlaintextByOptIn asserts the
+// credentialed operator->API path can be moved off plaintext via the spec knob
+// without requiring any code change in the client.
+func TestGetAPIServiceURL_TLSOptIn(t *testing.T) {
+	ds := newDittoServer("srv", "ns", &ControlPlaneAPIConfig{TLS: true})
+	if !strings.HasPrefix(ds.GetAPIServiceURL(), "https://") {
+		t.Fatalf("expected https:// scheme when TLS is enabled, got %q", ds.GetAPIServiceURL())
+	}
+}
+
+func TestGetManagedJWTSecretName(t *testing.T) {
+	ds := newDittoServer("srv", "ns", nil)
+	if got, want := ds.GetManagedJWTSecretName(), "srv-jwt-secret"; got != want {
+		t.Fatalf("GetManagedJWTSecretName() = %q, want %q", got, want)
+	}
+}
+
+func TestGetEffectiveJWTSecretRef(t *testing.T) {
+	t.Run("managed secret when user provides none", func(t *testing.T) {
+		ds := newDittoServer("srv", "ns", nil)
+		ref := ds.GetEffectiveJWTSecretRef()
+		if ref.Name != ds.GetManagedJWTSecretName() {
+			t.Fatalf("ref.Name = %q, want managed name %q", ref.Name, ds.GetManagedJWTSecretName())
+		}
+		if ref.Key != ManagedJWTSecretKey {
+			t.Fatalf("ref.Key = %q, want %q", ref.Key, ManagedJWTSecretKey)
+		}
+	})
+
+	t.Run("user-provided secret takes precedence", func(t *testing.T) {
+		ds := newDittoServer("srv", "ns", nil)
+		ds.Spec.Identity = &IdentityConfig{JWT: &JWTConfig{}}
+		ds.Spec.Identity.JWT.SecretRef.Name = "my-secret"
+		ds.Spec.Identity.JWT.SecretRef.Key = "my-key"
+		if !ds.HasUserProvidedJWTSecret() {
+			t.Fatal("HasUserProvidedJWTSecret() = false, want true")
+		}
+		ref := ds.GetEffectiveJWTSecretRef()
+		if ref.Name != "my-secret" || ref.Key != "my-key" {
+			t.Fatalf("GetEffectiveJWTSecretRef() = %+v, want user-provided secret", ref)
+		}
+	})
+}

--- a/k8s/dittofs-operator/chart/crds/dittoservers.yaml
+++ b/k8s/dittofs-operator/chart/crds/dittoservers.yaml
@@ -113,6 +113,18 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  tls:
+                    default: false
+                    description: |-
+                      TLS controls the URL scheme the operator uses to reach the control plane
+                      API. When true the operator connects over https:// so the admin and
+                      operator service-account credentials it sends are not transmitted in
+                      cleartext over the pod network. This requires the dfs control plane API to
+                      be served over TLS (terminated at the server or by an in-cluster mesh/
+                      sidecar that exposes the API service on https). Defaults to false (http://)
+                      for backward compatibility; in-cluster credentialed deployments should
+                      enable it once TLS termination is in place.
+                    type: boolean
                 type: object
               database:
                 description: Database configures the control plane database

--- a/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
+++ b/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
@@ -113,6 +113,18 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  tls:
+                    default: false
+                    description: |-
+                      TLS controls the URL scheme the operator uses to reach the control plane
+                      API. When true the operator connects over https:// so the admin and
+                      operator service-account credentials it sends are not transmitted in
+                      cleartext over the pod network. This requires the dfs control plane API to
+                      be served over TLS (terminated at the server or by an in-cluster mesh/
+                      sidecar that exposes the API service on https). Defaults to false (http://)
+                      for backward compatibility; in-cluster credentialed deployments should
+                      enable it once TLS termination is in place.
+                    type: boolean
                 type: object
               database:
                 description: Database configures the control plane database

--- a/k8s/dittofs-operator/docs/CRD_REFERENCE.md
+++ b/k8s/dittofs-operator/docs/CRD_REFERENCE.md
@@ -251,9 +251,20 @@ Configures the REST API server.
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
 | `controlPlane.port` | int32 | `8080` | No | API server port |
+| `controlPlane.tls` | bool | `false` | No | Connect to the control plane API over `https://` instead of `http://` |
 
 **Validation Rules:**
 - `port` must be between 1 and 65535
+
+**Credential transport:** the operator authenticates to the control plane API
+with the admin bootstrap password and the operator service-account password,
+and carries bearer tokens on every subsequent call. By default (`tls: false`)
+these travel over `http://` on the in-cluster pod network. Set
+`controlPlane.tls: true` to use `https://` so the credentials are not sent in
+cleartext. This requires the `dfs` control plane API to be served over TLS —
+either terminated by the server itself or by an in-cluster mesh/sidecar that
+exposes the `*-api` Service on HTTPS. Enable it for any deployment where the pod
+network is not trusted.
 
 ### Identity Configuration (`identity`)
 

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -658,12 +658,11 @@ func (r *DittoServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // in a managed Kubernetes Secret.
 func (r *DittoServerReconciler) reconcileJWTSecret(ctx context.Context, dittoServer *dittoiov1alpha1.DittoServer) error {
 	// If user has explicitly provided a JWT secret reference, use that
-	if dittoServer.Spec.Identity != nil && dittoServer.Spec.Identity.JWT != nil &&
-		dittoServer.Spec.Identity.JWT.SecretRef.Name != "" {
+	if dittoServer.HasUserProvidedJWTSecret() {
 		return nil
 	}
 
-	secretName := dittoServer.Name + "-jwt-secret"
+	secretName := dittoServer.GetManagedJWTSecretName()
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,


### PR DESCRIPTION
Part of #1014. Operator-area MED/LOW backlog from `.planning/v1.0-audit/11-operator/` REVIEW.md + REVIEW2.md. Scope is operator code only (`api/v1alpha1/`, controller, Helm chart) — nfs/smb/blockstore/metadata/runtime/cli untouched.

Many HIGH/MED items from the reviews already shipped (#940 install/deletion/NP-RBAC, #950 managed-pod hardening, #971/#972 jwt.issuer + CRD regen CI gate, #924 RFC7807 error decode). This sweeps the residual security/correctness items, led by the G2/M-SEC-1 plaintext-credentials finding.

## Fixed

- **G2 / M-SEC-1 — operator→`dfs` API credentials no longer forced over plaintext `http://`.** `GetAPIServiceURL` (`api/v1alpha1/helpers.go`) hardcoded `http://`, so the admin bootstrap password, the operator service-account password, and every bearer token traversed the pod network in cleartext. Added a `controlPlane.tls` CRD field; when set, the operator connects over `https://` (Go's default transport verifies the server cert — no `InsecureSkipVerify`). Both `auth_reconciler` call sites inherit the scheme for free via the single URL builder.

  **Design note / scheme default:** the `dfs` control-plane REST API is HTTP-only today — there is no TLS server in `pkg/controlplane/api` (server-side TLS is the runtime area, out of this PR's scope). Defaulting the operator to `https://` would therefore brick *every* install against the current server. So the knob defaults to `false` (preserves current behavior) and is opt-in once TLS termination is in place (server-side or via an in-cluster mesh/sidecar exposing the `*-api` Service on HTTPS). This matches the audit's own M-SEC-1 recommendation ("emit `https://` (configurable scheme), or at minimum document the exposure"). The credentialed path is now movable off plaintext without any code change, and the exposure is documented. Flipping the default to TLS-on is blocked on a server-side TLS-termination feature (separate area).

- **L-API-3 — single source of truth for the managed JWT-secret name.** The literal `<name>-jwt-secret` was duplicated in `helpers.go` and `dittoserver_controller.go`; a rename of one would silently break auth. Collapsed into `GetManagedJWTSecretName()`, used by both.

- **L-API-2 — reuse the dead `HasUserProvidedJWTSecret` predicate** in `GetEffectiveJWTSecretRef` and the controller instead of re-inlining the three-part nil check.

- Regenerated CRD bases + chart CRDs for the new field (controller-gen v0.19.0); `make manifests-verify` no-diff gate passes.
- Documented credential transport + the `tls` knob in `docs/CRD_REFERENCE.md`.

## Tests

- `api/v1alpha1/helpers_test.go` (new): `GetAPIServiceURL` scheme/port matrix (http default, https opt-in, custom port), `GetManagedJWTSecretName`, `GetEffectiveJWTSecretRef` (managed vs user-provided).
- Full controller envtest suite re-run green with the refactor.

## Skipped (cosmetic / out of operator-code scope / already shipped)

- L-SIMP-1 (55 MB committed `manager-linux-amd64`), L-SIMP-4 (`Dockerfile.cross`), L-SIMP-7 (sample sprawl), L-SIMP-9 (`PROJECT` scaffold version) — repo-hygiene, no runtime effect; bundle separately if desired.
- L-SIMP-3 (replace `utils/conditions` with `apimachinery/meta`), L-API-1 (test-only builder in public package) — larger refactors, no correctness/security impact.
- L-REC-1/2/3, L-SEC-1, L-CFG-1, M-CFG-1/2/3, M-REC-1/2, M-CDF-1 — config-schema drift + reconcile-edge items; several touch the `dfs` server config/router contract (cross-area) and belong with the config-schema round-trip work, not this operator-security pass.
- All NEW-H1/NEW-H2 + M-SEC-2/3 + M-CFG-ISSUER + CRD-regen items — already shipped (#940/#950/#971/#972/#924).

## Gates

`go build ./...`, `go vet`, `gofmt`, `helm lint chart/`, `make manifests-verify` (no regen drift), `go test -race ./api/...` and `./internal/controller/...` (envtest) — all green.