### PR TITLE
fix(lock/acl): MED hardening from area audit

### DIFF
--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -271,27 +271,20 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	return (allowedBits & requestedMask) == requestedMask
 }
 
-// aceMatchesWho checks if an ACE applies to the given evaluation context,
-// with OWNER_RIGHTS treated as an ordinary owner-matching arm. Callers that
-// need MS-DTYP §2.5.3 OWNER_RIGHTS-vs-OWNER@ arbitration should use
-// aceMatchesWhoWithOwnerRights instead.
+// aceMatchesWhoWithOwnerRights checks if an ACE applies to the given
+// evaluation context. When ownerRightsPresent is true AND the requester is the
+// file owner, OWNER@ ACEs are made to not-match and OWNER_RIGHTS ACEs are
+// made to match — implementing MS-DTYP §2.5.3 / §2.4.10 (S-1-3-4): an
+// explicit OWNER_RIGHTS entry supersedes the implicit owner grants and
+// becomes the sole authority for the owner's effective rights. Pass false to
+// treat OWNER_RIGHTS as an ordinary owner-matching arm.
 //
-// Resolution rules for special identifiers (Pitfall 3 - dynamic resolution):
+// Resolution rules for special identifiers (dynamic resolution):
 //   - "OWNER@": matches when requestor UID == file owner UID
 //   - "GROUP@": matches when requestor primary GID == file group GID,
 //     or file group GID is in requestor's supplementary GIDs
 //   - "EVERYONE@": always matches
 //   - Otherwise: exact string match on named principal
-func aceMatchesWho(ace *ACE, evalCtx *EvaluateContext) bool {
-	return aceMatchesWhoWithOwnerRights(ace, evalCtx, false)
-}
-
-// aceMatchesWhoWithOwnerRights is the OWNER_RIGHTS-aware variant of
-// aceMatchesWho. When ownerRightsPresent is true AND the requester is the
-// file owner, OWNER@ ACEs are made to not-match and OWNER_RIGHTS ACEs are
-// made to match — implementing MS-DTYP §2.5.3 / §2.4.10 (S-1-3-4): an
-// explicit OWNER_RIGHTS entry supersedes the implicit owner grants and
-// becomes the sole authority for the owner's effective rights.
 //
 // Mirrors Samba `libcli/security/access_check.c::se_access_check` handling
 // of `SID_OWNER_RIGHTS` / `SEC_RIGHTS_OWNER_RIGHTS`.

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -388,7 +388,7 @@ func TestAceMatchesWho_SIDForm(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ace := &ACE{Who: tc.aceWho, Type: ACE4_ACCESS_ALLOWED_ACE_TYPE}
 			ctx := &EvaluateContext{SID: tc.ctxSID, GroupSIDs: tc.ctxGSIDs}
-			got := aceMatchesWho(ace, ctx)
+			got := aceMatchesWhoWithOwnerRights(ace, ctx, false)
 			if got != tc.want {
 				t.Errorf("aceMatchesWho(%q, SID=%q, GroupSIDs=%v) = %v, want %v",
 					tc.aceWho, tc.ctxSID, tc.ctxGSIDs, got, tc.want)
@@ -451,7 +451,7 @@ func TestAceMatchesWho_LocalDomain(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ace := &ACE{Who: tc.aceWho, Type: ACE4_ACCESS_ALLOWED_ACE_TYPE}
 			ctx := &EvaluateContext{UID: tc.ctxUID, GID: tc.ctxGID, GIDs: tc.ctxGIDs}
-			got := aceMatchesWho(ace, ctx)
+			got := aceMatchesWhoWithOwnerRights(ace, ctx, false)
 			if got != tc.want {
 				t.Errorf("aceMatchesWho(%q, UID=%d, GID=%d, GIDs=%v) = %v, want %v",
 					tc.aceWho, tc.ctxUID, tc.ctxGID, tc.ctxGIDs, got, tc.want)
@@ -542,7 +542,7 @@ func TestAceMatchesWho_OwnerRights(t *testing.T) {
 				UID:          tc.requesterUID,
 				FileOwnerUID: tc.fileOwnerUID,
 			}
-			if got := aceMatchesWho(ace, ctx); got != tc.want {
+			if got := aceMatchesWhoWithOwnerRights(ace, ctx, false); got != tc.want {
 				t.Errorf("aceMatchesWho(OwnerRights@, requester=%d, owner=%d) = %v, want %v",
 					tc.requesterUID, tc.fileOwnerUID, got, tc.want)
 			}

--- a/pkg/metadata/acl/validate.go
+++ b/pkg/metadata/acl/validate.go
@@ -28,10 +28,15 @@ var (
 
 // aceWireOverhead is the fixed per-ACE NFSv4 wire footprint preceding the
 // variable-length Who string: type(4) + flag(4) + access_mask(4) +
-// who-length(4). The Who string itself is added on top. This is a lower-bound
-// estimate (it ignores 4-byte Who padding), which is the safe direction for a
-// DoS bound: a real serialization is never smaller.
+// who-length(4). The Who string itself (4-byte aligned) is added on top.
 const aceWireOverhead = 16
+
+// xdrPad rounds n up to the next 4-byte XDR boundary. NFSv4 opaque/string
+// fields are zero-padded to a multiple of 4, so the on-wire footprint of a
+// Who string is len rounded up — accounting for it makes the size estimate an
+// accurate upper bound rather than an undershoot that could let a >64KB ACL
+// pass (per Copilot review).
+func xdrPad(n int) int { return (n + 3) &^ 3 }
 
 // ValidateACL validates an entire ACL, checking:
 //  1. ACE count does not exceed MaxACECount (128)
@@ -58,10 +63,12 @@ func ValidateACL(a *ACL) error {
 
 	// Enforce MaxDACLSize. ACE.Who is an unbounded Go string, so the 128-ACE
 	// count cap alone does not bound the serialized size — large Who strings
-	// can blow past 64KB. Estimate the serialized footprint and reject early.
-	size := 0
+	// can blow past 64KB. The per-ACE footprint is the fixed header plus the
+	// 4-byte-aligned Who string; the leading 4 bytes account for the ACE-array
+	// length prefix so the estimate is an upper bound on the wire size.
+	size := 4
 	for i := range a.ACEs {
-		size += aceWireOverhead + len(a.ACEs[i].Who)
+		size += aceWireOverhead + xdrPad(len(a.ACEs[i].Who))
 		if size > MaxDACLSize {
 			return fmt.Errorf("%w: exceeds %d bytes", ErrACLTooLarge, MaxDACLSize)
 		}

--- a/pkg/metadata/acl/validate.go
+++ b/pkg/metadata/acl/validate.go
@@ -15,6 +15,10 @@ var (
 	// ErrACEEmptyWho is returned when an ACE has an empty Who field.
 	ErrACEEmptyWho = errors.New("ACE has empty Who field")
 
+	// ErrACLTooLarge is returned when an ACL's serialized size exceeds
+	// MaxDACLSize.
+	ErrACLTooLarge = errors.New("ACL exceeds maximum serialized size")
+
 	// ErrACLNotCanonical is the documented sentinel for "ACL is not in
 	// canonical (Windows-presentation) order". ValidateACL no longer
 	// returns this error — it is retained for callers that wish to
@@ -22,9 +26,17 @@ var (
 	ErrACLNotCanonical = errors.New("ACL is not in canonical order")
 )
 
+// aceWireOverhead is the fixed per-ACE NFSv4 wire footprint preceding the
+// variable-length Who string: type(4) + flag(4) + access_mask(4) +
+// who-length(4). The Who string itself is added on top. This is a lower-bound
+// estimate (it ignores 4-byte Who padding), which is the safe direction for a
+// DoS bound: a real serialization is never smaller.
+const aceWireOverhead = 16
+
 // ValidateACL validates an entire ACL, checking:
 //  1. ACE count does not exceed MaxACECount (128)
-//  2. Each individual ACE is valid (type, who)
+//  2. Estimated serialized size does not exceed MaxDACLSize (64KB)
+//  3. Each individual ACE is valid (type, who)
 //
 // ACE ordering is NOT validated. Per MS-DTYP §2.4.5 the ACL layout is
 // an unordered array of ACEs; canonical order (explicit DENY before
@@ -42,6 +54,17 @@ func ValidateACL(a *ACL) error {
 
 	if len(a.ACEs) > MaxACECount {
 		return fmt.Errorf("%w: %d ACEs (maximum %d)", ErrACETooMany, len(a.ACEs), MaxACECount)
+	}
+
+	// Enforce MaxDACLSize. ACE.Who is an unbounded Go string, so the 128-ACE
+	// count cap alone does not bound the serialized size — large Who strings
+	// can blow past 64KB. Estimate the serialized footprint and reject early.
+	size := 0
+	for i := range a.ACEs {
+		size += aceWireOverhead + len(a.ACEs[i].Who)
+		if size > MaxDACLSize {
+			return fmt.Errorf("%w: exceeds %d bytes", ErrACLTooLarge, MaxDACLSize)
+		}
 	}
 
 	for i := range a.ACEs {

--- a/pkg/metadata/acl/validate_test.go
+++ b/pkg/metadata/acl/validate_test.go
@@ -93,6 +93,34 @@ func TestValidateACL_MaxACECount(t *testing.T) {
 	}
 }
 
+func TestValidateACL_MaxDACLSize(t *testing.T) {
+	// A handful of ACEs with very large Who strings stays under the 128-ACE
+	// count cap but blows past the 64KB serialized-size bound. The size check
+	// must reject it (the count check alone would not).
+	bigWho := make([]byte, MaxDACLSize) // 64KB single Who string
+	for i := range bigWho {
+		bigWho[i] = 'a'
+	}
+	a := &ACL{ACEs: []ACE{
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: string(bigWho)},
+	}}
+	err := ValidateACL(a)
+	if err == nil {
+		t.Fatal("expected ErrACLTooLarge for an oversized DACL")
+	}
+	if !errors.Is(err, ErrACLTooLarge) {
+		t.Errorf("expected ErrACLTooLarge, got: %v", err)
+	}
+
+	// A small ACL is well under the bound.
+	small := &ACL{ACEs: []ACE{
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+	}}
+	if err := ValidateACL(small); err != nil {
+		t.Errorf("expected small ACL to be valid, got: %v", err)
+	}
+}
+
 func TestValidateACL_EmptyACL(t *testing.T) {
 	a := &ACL{ACEs: []ACE{}}
 	if err := ValidateACL(a); err != nil {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -462,12 +462,7 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 				"epoch", locks[i].Lease.Epoch)
 
 			// Persist if store available
-			if lm.lockStore != nil {
-				pl := ToPersistedLock(locks[i], 0)
-				if err := lm.lockStore.PutLock(ctx, pl); err != nil {
-					logger.Error("RequestLease: failed to persist lease upgrade", "fileHandle", handleKey, "error", err)
-				}
-			}
+			lm.persistUnifiedLockLocked(locks[i])
 
 			epoch := locks[i].Lease.Epoch
 			lm.mu.Unlock()
@@ -579,13 +574,7 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 			// re-Lock below must be skipped to avoid self-deadlock.
 			if lock.Lease.Breaking {
 				lock.Lease.BreakingToRequired &= breakTo
-				if lm.lockStore != nil {
-					pl := ToPersistedLock(lock, 0)
-					if err := lm.lockStore.PutLock(ctx, pl); err != nil {
-						logger.Error("RequestLease: failed to persist tightened break target",
-							"fileHandle", handleKey, "error", err)
-					}
-				}
+				lm.persistUnifiedLockLocked(lock)
 				logger.Debug("RequestLease: cross-key conflict on already-breaking lease, suppressed duplicate break",
 					"fileHandle", handleKey,
 					"existingKey", fmt.Sprintf("%x", lock.Lease.LeaseKey),
@@ -611,12 +600,7 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 			advanceEpoch(lock.Lease)
 
 			// Persist the breaking state
-			if lm.lockStore != nil {
-				pl := ToPersistedLock(lock, 0)
-				if err := lm.lockStore.PutLock(ctx, pl); err != nil {
-					logger.Error("RequestLease: failed to persist breaking state", "fileHandle", handleKey, "error", err)
-				}
-			}
+			lm.persistUnifiedLockLocked(lock)
 
 			// Clone the lock before releasing mu so that dispatchOpLockBreak
 			// receives a snapshot. Without this, concurrent AcknowledgeLeaseBreak
@@ -875,12 +859,7 @@ func (lm *Manager) createAndGrantLease(
 
 	lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], newLock)
 
-	if lm.lockStore != nil {
-		pl := ToPersistedLock(newLock, 0)
-		if err := lm.lockStore.PutLock(ctx, pl); err != nil {
-			logger.Error("RequestLease: failed to persist new lease", "fileHandle", handleKey, "error", err)
-		}
-	}
+	lm.persistUnifiedLockLocked(newLock)
 
 	return requestedState, 1
 }
@@ -965,10 +944,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		lock.Lease.BreakStarted = time.Time{}
 		lock.Type = lockTypeForLeaseState(LeaseStateNone)
 
-		if lm.lockStore != nil {
-			pl := ToPersistedLock(lock, 0)
-			_ = lm.lockStore.PutLock(ctx, pl)
-		}
+		lm.persistUnifiedLockLocked(lock)
 
 		logger.Debug("AcknowledgeLeaseBreak: lease released to None (record kept until CLOSE)",
 			"leaseKey", fmt.Sprintf("%x", leaseKey))
@@ -1007,11 +983,9 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		// store reflects Breaking=true / BreakToState=nextTarget. Otherwise a
 		// crash between the ACK-clear (Breaking=false written above) and the
 		// next-stage-set would lose the second progressive stage on restart,
-		// leaving parked CREATEs to wait until the scanner timeout.
-		if lm.lockStore != nil {
-			pl := ToPersistedLock(lock, 0)
-			_ = lm.lockStore.PutLock(ctx, pl)
-		}
+		// leaving parked CREATEs to wait until the scanner timeout. The persist
+		// MUST land, so errors are logged (not swallowed) by the helper.
+		lm.persistUnifiedLockLocked(lock)
 
 		logger.Debug("AcknowledgeLeaseBreak: progressive break next stage",
 			"leaseKey", fmt.Sprintf("%x", leaseKey),
@@ -1057,10 +1031,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 	lock.Lease.BreakingToRequired = acknowledgedState
 
 	// Persist updated state
-	if lm.lockStore != nil {
-		pl := ToPersistedLock(lock, 0)
-		_ = lm.lockStore.PutLock(ctx, pl)
-	}
+	lm.persistUnifiedLockLocked(lock)
 
 	logger.Debug("AcknowledgeLeaseBreak: break acknowledged",
 		"leaseKey", fmt.Sprintf("%x", leaseKey),
@@ -1082,9 +1053,7 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 		for _, lock := range locks {
 			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
 				// Remove from persistent store
-				if lm.lockStore != nil {
-					_ = lm.lockStore.DeleteLock(ctx, lock.ID)
-				}
+				lm.deleteUnifiedLockLocked(lock)
 				continue // Skip (remove) this lock
 			}
 			remaining = append(remaining, lock)

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1426,19 +1426,37 @@ func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
 	// client carries the higher requested epoch. Subsequent break
 	// notifications then dispatch with Epoch=2 instead of requestedEpoch+2,
 	// regressing smbtorture V2 tests (break_twice, breaking*, v2_breaking3).
-	found := false
+	// Two passes so all matching records converge to the SAME epoch. A
+	// per-record `if epoch >= lock.Lease.Epoch` guard lets sibling records that
+	// start at different epochs diverge (e.g. one at 5 stays 5 while another at
+	// 1 moves to 4), and GetLeaseState / break dispatch then read whichever
+	// map-order surfaces first — a non-deterministic NewEpoch in break
+	// notifications (the break_twice / v2_breaking3 regression class). Compute
+	// the max of the requested epoch and every matching record's current epoch,
+	// then assign that single max to all of them so the lease has one epoch.
+	target := epoch
+	var matches []*UnifiedLock
 	for _, locks := range lm.unifiedLocks {
 		for _, lock := range locks {
 			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
 				continue
 			}
-			if epoch >= lock.Lease.Epoch {
-				lock.Lease.Epoch = epoch
+			if lock.Lease.Epoch > target {
+				target = lock.Lease.Epoch
 			}
-			found = true
+			matches = append(matches, lock)
 		}
 	}
-	return found
+	for _, lock := range matches {
+		lock.Lease.Epoch = target
+		// Persist the new epoch like every other lease state-change path.
+		// Without this, RestoreLocks rebuilds the lease at the stale grant-time
+		// epoch after a restart and a later break dispatches a NewEpoch below
+		// the client's last-seen value, violating MS-SMB2 §2.2.14.2.11 /
+		// §3.3.4.7 epoch monotonicity.
+		lm.persistUnifiedLockLocked(lock)
+	}
+	return len(matches) > 0
 }
 
 // ============================================================================
@@ -1472,17 +1490,19 @@ func SplitLock(existing *UnifiedLock, unlockOffset, unlockLength uint64) []*Unif
 		return []*UnifiedLock{existing.Clone()}
 	}
 
-	// Calculate lock end
+	// Calculate lock end. End() returns maxUint64 for unbounded (Length==0)
+	// locks, which is exactly the "treat as very large" value the coverage
+	// arithmetic below needs.
 	lockEnd := existing.End()
-	if existing.Length == 0 {
-		// Unbounded lock - treat as very large for calculation purposes
-		lockEnd = ^uint64(0) // Max uint64
-	}
 
-	// Calculate unlock end
+	// Calculate unlock end. unlockOffset/unlockLength are wire-controlled, so
+	// the sum can wrap uint64 (e.g. offset near 2^64 + a large length); a wrap
+	// would corrupt the coverage checks below (fabricate or drop a fragment).
+	// Clamp to maxUint64 on overflow — a range that reaches past 2^64 covers to
+	// EOF for our purposes, same as an unbounded unlock.
 	unlockEnd := unlockOffset + unlockLength
-	if unlockLength == 0 {
-		// Unbounded unlock - goes to EOF
+	if unlockLength == 0 || unlockEnd < unlockOffset {
+		// Unbounded unlock (length 0 = to EOF) or arithmetic overflow.
 		unlockEnd = ^uint64(0)
 	}
 
@@ -2417,10 +2437,7 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 		l.Lease.BrokenViaTimeout = true
 		l.Type = lockTypeForLeaseState(l.Lease.LeaseState)
 
-		if lm.lockStore != nil {
-			pl := ToPersistedLock(l, 0)
-			_ = lm.lockStore.PutLock(context.Background(), pl)
-		}
+		lm.persistUnifiedLockLocked(l)
 		logger.Debug("forceCompleteBreaks: auto-downgraded lease",
 			"handleKey", handleKey,
 			"leaseKey", fmt.Sprintf("%x", l.Lease.LeaseKey),
@@ -2570,10 +2587,7 @@ func (lm *Manager) breakOpLocks(
 			// (Samba intentionally skips the bump per its inline comment).
 			// The next progressive stage will be dispatched on ACK.
 			lock.Lease.BreakingToRequired &= targetState
-			if lm.lockStore != nil {
-				pl := ToPersistedLock(lock, 0)
-				_ = lm.lockStore.PutLock(context.Background(), pl)
-			}
+			lm.persistUnifiedLockLocked(lock)
 			// This key's break is already in flight; record it so a sibling
 			// record sharing the key is not freshly dispatched below and so
 			// later siblings mirror this record's break stage.
@@ -2596,10 +2610,7 @@ func (lm *Manager) breakOpLocks(
 		// applyBreakStageLocked only persists the fire-and-forget downgrade
 		// path; the ack-required path (which is the common case) is
 		// persisted here.
-		if lm.lockStore != nil {
-			pl := ToPersistedLock(lock, 0)
-			_ = lm.lockStore.PutLock(context.Background(), pl)
-		}
+		lm.persistUnifiedLockLocked(lock)
 		dispatchedKeys[lock.Lease.LeaseKey] = struct{}{}
 		canonicalByKey[lock.Lease.LeaseKey] = lock.Lease
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
@@ -2668,10 +2679,7 @@ func (lm *Manager) applyBreakStageLocked(lock *UnifiedLock, target uint32) *Unif
 	lock.Lease.LeaseState = target
 	lock.Lease.BreakingToRequired = target
 	lock.Type = lockTypeForLeaseState(target)
-	if lm.lockStore != nil {
-		pl := ToPersistedLock(lock, 0)
-		_ = lm.lockStore.PutLock(context.Background(), pl)
-	}
+	lm.persistUnifiedLockLocked(lock)
 	return snapshot
 }
 
@@ -2700,9 +2708,8 @@ func (lm *Manager) mirrorBreakStageLocked(sibling *UnifiedLock, canonical *OpLoc
 	sibling.Lease.Epoch = canonical.Epoch
 	sibling.Lease.LeaseState = canonical.LeaseState
 	sibling.Type = lockTypeForLeaseState(canonical.LeaseState)
-	if persist && lm.lockStore != nil {
-		pl := ToPersistedLock(sibling, 0)
-		_ = lm.lockStore.PutLock(context.Background(), pl)
+	if persist {
+		lm.persistUnifiedLockLocked(sibling)
 	}
 }
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1,6 +1,7 @@
 package lock
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -1171,6 +1172,49 @@ func TestSplitLock_UnlockMiddle(t *testing.T) {
 	}
 }
 
+// TestSplitLock_UnlockOverflow guards the partial-unlock arithmetic against a
+// uint64 wrap: unlockOffset + unlockLength is wire-controlled and can overflow.
+// A wrap must be treated as "covers to EOF", not silently fabricate a fragment
+// at a wrapped-around offset or drop a lock.
+func TestSplitLock_UnlockOverflow(t *testing.T) {
+	t.Parallel()
+
+	// Unbounded lock starting at offset 10. An unlock from offset 20 with a
+	// length that overflows when added (maxUint64) must fully cover the tail,
+	// leaving only the [10,20) head fragment.
+	lock := &UnifiedLock{
+		ID:     "lock1",
+		Offset: 10,
+		Length: 0, // unbounded (to EOF)
+		Type:   LockTypeExclusive,
+	}
+
+	// unlockOffset=20, unlockLength=maxUint64 → 20 + maxUint64 wraps to 19.
+	result := SplitLock(lock, 20, ^uint64(0))
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 lock (head fragment) after overflowing unlock, got %d", len(result))
+	}
+	if result[0].Offset != 10 || result[0].Length != 10 {
+		t.Fatalf("Expected head fragment [10-20], got [%d, len %d]", result[0].Offset, result[0].Length)
+	}
+}
+
+// TestUnifiedLock_EndUnbounded asserts End() reports maxUint64 (not 0) for an
+// unbounded lock so byte-range math never treats it as ending before offset 0.
+func TestUnifiedLock_EndUnbounded(t *testing.T) {
+	t.Parallel()
+
+	unbounded := &UnifiedLock{Offset: 100, Length: 0}
+	if got := unbounded.End(); got != ^uint64(0) {
+		t.Fatalf("End() for unbounded lock = %d, want maxUint64", got)
+	}
+
+	bounded := &UnifiedLock{Offset: 100, Length: 50}
+	if got := bounded.End(); got != 150 {
+		t.Fatalf("End() for bounded lock = %d, want 150", got)
+	}
+}
+
 // ============================================================================
 // Merge Lock Tests
 // ============================================================================
@@ -1268,6 +1312,68 @@ func TestSetLeaseEpoch_ReturnsFalseForUnknownKey(t *testing.T) {
 	if lm.SetLeaseEpoch([16]byte{0xff, 0xee}, 5) {
 		t.Fatalf("SetLeaseEpoch returned true for unknown key")
 	}
+}
+
+// TestSetLeaseEpoch_ConvergesDivergentRecords asserts that sibling records
+// sharing a lease key but starting at DIFFERENT epochs all converge to a
+// single epoch — the max of the requested epoch and every record's current
+// epoch. A per-record `if requested >= current` guard would leave the higher
+// record untouched while raising the lower one, so break dispatch could read a
+// non-deterministic NewEpoch depending on map-iteration order.
+func TestSetLeaseEpoch_ConvergesDivergentRecords(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	leaseKey := [16]byte{0x11, 0x22, 0x33}
+
+	lm.mu.Lock()
+	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 5}},
+	}
+	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
+	}
+	lm.mu.Unlock()
+
+	// Request a lower epoch (4) than the highest existing record (5). All
+	// records must converge to 5 (the max), not split into 5 and 4.
+	if !lm.SetLeaseEpoch(leaseKey, 4) {
+		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
+	}
+
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	for _, handle := range []string{"/share:fileA", "/share:fileB"} {
+		if got := lm.unifiedLocks[handle][0].Lease.Epoch; got != 5 {
+			t.Errorf("%s: Epoch = %d, want 5 (all records converge to the max)", handle, got)
+		}
+	}
+}
+
+// TestSetLeaseEpoch_Persists asserts the client-derived epoch is written
+// through to the lock store so RestoreLocks rebuilds the lease at the higher
+// epoch after a restart (MS-SMB2 epoch monotonicity).
+func TestSetLeaseEpoch_Persists(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	lm := NewManager()
+	lm.SetLockStore(store)
+	leaseKey := [16]byte{0x44, 0x55, 0x66}
+
+	lm.mu.Lock()
+	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
+		{ID: "lease-1", Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
+	}
+	lm.mu.Unlock()
+
+	if !lm.SetLeaseEpoch(leaseKey, 9) {
+		t.Fatalf("SetLeaseEpoch returned false, expected true")
+	}
+
+	pl, err := store.GetLock(ctx, "lease-1")
+	require.NoError(t, err)
+	require.Equal(t, uint16(9), pl.LeaseEpoch, "epoch must be persisted for restart monotonicity")
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -221,10 +221,14 @@ func (ul *UnifiedLock) IsShared() bool {
 }
 
 // End returns the end offset of the lock (exclusive).
-// Returns 0 for unbounded locks (Length=0 means to EOF).
+//
+// For unbounded locks (Length==0 means to EOF) it returns maxUint64, matching
+// rangeLast/rangeEnd's inclusive-end arithmetic. Returning 0 here (the old
+// behavior) was a byte-range-math footgun: callers comparing End() against a
+// real offset would treat an unbounded lock as ending before offset 0.
 func (ul *UnifiedLock) End() uint64 {
 	if ul.Length == 0 {
-		return 0 // Unbounded
+		return ^uint64(0) // Unbounded: to EOF.
 	}
 	return ul.Offset + ul.Length
 }


### PR DESCRIPTION
Part of #1014. Sweeps the actionable lock/ACL MED + correctness-LOW backlog from the area-5 audit (`.planning/v1.0-audit/5-lock-acl/REVIEW.md` + `REVIEW2.md`). All 3 area-5 HIGH already shipped (#852/#856/#860/#865); this is the MED/LOW cleanup. Scoped strictly to `pkg/metadata/lock/` + `pkg/metadata/acl/` — no adapter/runtime changes.

## Fixed

**Lock layer (`pkg/metadata/lock`)**
- **`SetLeaseEpoch` divergent epoch + no-persist (R1 MED + R2 MED).** Now converges every record sharing a lease key to a single epoch (max of requested and all existing), instead of a per-record `>=` raise that let siblings diverge and produce a non-deterministic `NewEpoch` in break notifications (break_twice / v2_breaking3 class). Also persists the epoch so `RestoreLocks` rebuilds at the client-aligned epoch after restart (MS-SMB2 §2.2.14.2.11 / §3.3.4.7 monotonicity).
- **Lease + break persist sites use cancellable request ctx / swallow errors (R2 MED + R1 LOW).** Routed all lease and lease-break persist/delete calls through the shared `persistUnifiedLockLocked` / `deleteUnifiedLockLocked` helpers. This bounds the persist with `withPersistTimeout` (a client disconnect mid-op no longer skips the durable write the progressive-break path depends on), logs errors instead of `_ = PutLock(...)`, replaces five `context.Background()` break-path calls, and stamps the share name so lease records survive per-share recovery.
- **`SplitLock` uint64 overflow (R1 MED).** Clamp `unlockOffset + unlockLength` on wrap so a wire-controlled overflow can't drop a lock or fabricate a fragment at a wrapped offset.
- **`UnifiedLock.End()` returns 0 for unbounded (R1 LOW).** Now returns maxUint64, consistent with `rangeLast`/`rangeEnd`; removed `SplitLock`'s now-redundant clamp.

**ACL (`pkg/metadata/acl`)**
- **`MaxDACLSize` declared but never enforced (R1 LOW).** `ValidateACL` now rejects an ACL whose estimated serialized size exceeds 64KB; the 128-ACE count cap alone did not bound unbounded `Who` strings.
- **`aceMatchesWho` dead wrapper (R1 LOW).** Removed; tests now call `aceMatchesWhoWithOwnerRights(ace, ctx, false)` directly.

## Skipped (noted, not in this PR)
- **48-method `LockManager` interface split (R1 MED)** — architectural refactor, out of scope for a conservative MED sweep.
- **ALARM-ACE advertise-vs-drop (R1 MED)** — the honest fix touches `internal/adapter/{nfs,smb}` encoders, outside this PR's lock/acl scope.
- **NFSv4 delegation persistence asymmetry / `UpgradeLock` cross-scan (R2 MED)** — both behind dead production code (delegations re-OPEN under grace; `UpgradeLock` has no callers); decision-issues, deferred.
- **`ToPersistedLock` double-log/truncation (R1 LOW)** — the double-log is already collapsed to a single Error on `develop`; the signature-changing error-return variant is invasive and the path is defensive.
- **H-1 (R2): NLM blocking-lock waiter starvation when holder is SMB** — confirmed HIGH but the fix wires the SMB UNLOCK path (`pkg/adapter/nfs/nlm.go` + SMB handlers), outside this PR's scope. Flagged for a separate cross-protocol PR.

## Gates
`go build ./...`, `go vet ./pkg/metadata/...`, `gofmt` clean. `go test -race ./pkg/metadata/...` green (incl. lock + acl + badger/memory/postgres conformance). Adapter NFS/SMB suites green. Tests added: SplitLock overflow, End() unbounded, SetLeaseEpoch convergence + persistence, MaxDACLSize rejection.


