### PR TITLE
fix(smb): resolve smb2.bench.oplock1 (#1036)

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -161,14 +161,6 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 				)
 				return nil
 			})
-			// Release the resume goroutine NOW that the callback has been
-			// swapped. The goroutine was parked on PendingCreate.started
-			// (initialized in parkCreateOnLeaseBreak) precisely so this
-			// ReplaceCallback could land before the original standalone
-			// callback fired. Skipping the release would deadlock the CREATE
-			// after the wait drains (smbtorture compound.compound-break
-			// IO_TIMEOUT race).
-			connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
 		}
 
 		// Send interim STATUS_PENDING as a standalone async response.
@@ -179,17 +171,30 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		if err := SendMessage(interimHeader, MakeErrorBody(), connInfo); err != nil {
 			logger.Debug("Error sending compound async interim response", "error", err)
 		}
+
+		// Release the resume goroutine only AFTER the interim STATUS_PENDING is
+		// on the wire. The callback was swapped above (ReplaceCallback) so the
+		// goroutine picks up the continue-compound wrapper, and MarkStarted runs
+		// post-interim so the final compound response can never overtake the
+		// interim (MS-SMB2 §3.3.4.4 ordering; same class as the standalone path
+		// in response.go that smb2.bench.oplock1 trips). Skipping the release
+		// would deadlock the CREATE after the wait drains (smbtorture
+		// compound.compound-break IO_TIMEOUT race).
+		if connInfo.Handler.PendingCreateRegistry != nil {
+			connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
+		}
 		return
 	}
 
 	// Fall-through path: the first command returned STATUS_PENDING + AsyncId
-	// AND there were no more commands in the compound. The interim is sent
-	// as part of the compound response below; the resume goroutine fires the
-	// original (standalone-completion) callback with the final response, so
-	// release its started gate now.
+	// AND there were no more commands in the compound. The interim is buffered
+	// into the compound response below; the resume goroutine fires the original
+	// (standalone-completion) callback with the final response. Defer releasing
+	// its started gate until AFTER the compound frame is on the wire so the
+	// final response can never overtake the interim.
 	if result != nil && result.Status == types.StatusPending && result.AsyncId != 0 &&
 		connInfo.Handler.PendingCreateRegistry != nil {
-		connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
+		state.markStartedAsyncIDs = append(state.markStartedAsyncIDs, result.AsyncId)
 	}
 
 	if fileID != [16]byte{} {
@@ -242,6 +247,10 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 	if sendErr != nil {
 		logger.Debug("Error sending compound responses", "error", sendErr)
 	}
+
+	// Release any parked-CREATE resume goroutines now that the interim
+	// STATUS_PENDING is on the wire (see compoundLoopState.markStartedAsyncIDs).
+	state.releaseStartedGates(connInfo.Handler.PendingCreateRegistry)
 
 	// Per MS-SMB2 3.3.4.1: run deferred post-send hooks (e.g.
 	// STATUS_NOTIFY_CLEANUP after CLOSE) only after the compound response
@@ -731,6 +740,27 @@ type compoundLoopState struct {
 	// Accumulated responses + deferred post-send hooks.
 	responses     []compoundResponse
 	postSendHooks []func()
+
+	// AsyncIds of parked CREATEs whose interim STATUS_PENDING is buffered into
+	// responses (not yet on the wire). MarkStarted MUST fire only after the
+	// compound frame is written, so the resume goroutine's final response can
+	// never overtake the interim (MS-SMB2 §3.3.4.4; same ordering class as the
+	// standalone path that smb2.bench.oplock1 trips).
+	markStartedAsyncIDs []uint64
+}
+
+// releaseStartedGates unblocks the resume goroutines for every parked CREATE
+// whose interim STATUS_PENDING was buffered into this compound frame. It MUST
+// be called only after the frame is on the wire so the final responses cannot
+// overtake the interims. Fired unconditionally (even on a write error) so a
+// resume goroutine is never left blocked on PendingCreate.started.
+func (s *compoundLoopState) releaseStartedGates(reg *handlers.PendingCreateRegistry) {
+	if reg == nil {
+		return
+	}
+	for _, asyncID := range s.markStartedAsyncIDs {
+		reg.MarkStarted(asyncID)
+	}
 }
 
 // processRemaining processes every command after the first in a compound,
@@ -922,14 +952,14 @@ func (s *compoundLoopState) processRemaining(
 		// A tail-of-chain compound subcommand that returns STATUS_PENDING + AsyncId
 		// (parked CREATE) inherits the original standalone-completion callback —
 		// no ReplaceCallback redirect happens here, since the subcommand is
-		// already the tail of the chain. Release its resume-goroutine gate so
-		// the deferred completion is not blocked waiting for a swap that will
-		// never arrive. Non-tail parked CREATEs MUST NOT be released here:
-		// trailing related commands still need to defer behind the CREATE
-		// completion, so the chain is not split.
+		// already the tail of the chain. Defer releasing its resume-goroutine gate
+		// until AFTER the compound frame is written (markStartedAsyncIDs) so the
+		// final response cannot overtake the buffered interim. Non-tail parked
+		// CREATEs MUST NOT be released here: trailing related commands still need
+		// to defer behind the CREATE completion, so the chain is not split.
 		if isLastCommand && cmdResult != nil && cmdResult.Status == types.StatusPending && cmdResult.AsyncId != 0 &&
 			connInfo.Handler.PendingCreateRegistry != nil {
-			connInfo.Handler.PendingCreateRegistry.MarkStarted(cmdResult.AsyncId)
+			s.markStartedAsyncIDs = append(s.markStartedAsyncIDs, cmdResult.AsyncId)
 		}
 
 		rh, rb := buildResponseHeaderAndBody(hdr, cmdCtx, cmdResult, connInfo)
@@ -1018,6 +1048,10 @@ func completeCompoundAfterAsyncCreate(
 	if sendErr != nil {
 		logger.Debug("Error sending compound async completion responses", "error", sendErr)
 	}
+
+	// Release any parked-CREATE resume goroutines whose interim was buffered
+	// into this completion frame, only after it is on the wire.
+	state.releaseStartedGates(connInfo.Handler.PendingCreateRegistry)
 
 	if sendErr == nil {
 		for _, hook := range state.postSendHooks {

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -221,18 +221,6 @@ func ProcessSingleRequest(
 	// Track session lifecycle for connection cleanup
 	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, result.IsBinding, connInfo.SessionTracker)
 
-	// Release any parked-CREATE resume goroutine now that the standalone
-	// callback assignment is final. Non-compound CREATEs use the original
-	// callback installed in prepareDispatch — there is no ReplaceCallback
-	// to wait on, so the started gate can fire immediately. Without this,
-	// the resume goroutine deadlocks on PendingCreate.started after the
-	// break drains (smbtorture compound.compound-break IO_TIMEOUT race).
-	if reqHeader.Command == types.SMB2Create &&
-		result.Status == types.StatusPending && result.AsyncId != 0 &&
-		connInfo.Handler.PendingCreateRegistry != nil {
-		connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
-	}
-
 	// Send response and run after-hooks with the response bytes. If the
 	// write fails, return early — any registered PostSend hook is
 	// intentionally dropped because the connection is likely dead and the
@@ -240,6 +228,24 @@ func ProcessSingleRequest(
 	// session. (Same contract as the compound dispatch path.)
 	if err := SendResponseWithHooks(reqHeader, handlerCtx, result, connInfo); err != nil {
 		return err
+	}
+
+	// Release any parked-CREATE resume goroutine now that the interim
+	// STATUS_PENDING has been written to the wire. Non-compound CREATEs use
+	// the original callback installed in prepareDispatch — there is no
+	// ReplaceCallback to wait on, so the started gate can fire as soon as the
+	// interim is sent. This MUST run strictly AFTER SendResponseWithHooks:
+	// MarkStarted unblocks the resume goroutine, which sends the final
+	// response on its own write-lock acquisition. If MarkStarted ran before
+	// the interim write, a fast break-drain (e.g. the holder closing rather
+	// than ACKing, as in smb2.bench.oplock1) could let the resume goroutine
+	// win the write lock and emit the final STATUS_SUCCESS before the interim
+	// STATUS_PENDING — a §3.3.4.4 ordering violation the client answers with a
+	// TCP RST (NT_STATUS_CONNECTION_DISCONNECTED).
+	if reqHeader.Command == types.SMB2Create &&
+		result.Status == types.StatusPending && result.AsyncId != 0 &&
+		connInfo.Handler.PendingCreateRegistry != nil {
+		connInfo.Handler.PendingCreateRegistry.MarkStarted(result.AsyncId)
 	}
 
 	// Per MS-SMB2 3.3.4.1: some handlers (currently CLOSE with a pending


### PR DESCRIPTION
## Diagnosis (path A — real correctness bug)

`smb2.bench.oplock1` failed **deterministically** on the `smbtorture / memory` job with:

```
../../source4/torture/smb2/oplock.c:4332: status was NT_STATUS_CONNECTION_DISCONNECTED, expected NT_STATUS_OK
```

This is **not** a perf/timing threshold — the benchmark ran healthy at ~1500–1900 ops/sec for its full 10s window, then a connection died. Reproduced locally via the smbtorture harness and captured a byte-level pcap.

The benchmark opens 4 connections, installs an oplock-break handler that responds to a BATCH break by **closing** the handle (not sending an oplock-break ACK), and round-robins `smb2_create(... SHARE_ACCESS_NONE, OPLOCK_LEVEL_BATCH)` so each open breaks the previous holder.

DittoFS parks each conflicting CREATE on the lease break: it sends an interim `STATUS_PENDING` (assigning an AsyncId) and a resume goroutine delivers the final response once the break drains. The pcap showed, on the connection that died, two responses for the **same AsyncId**:

| frame | status | note |
|------|--------|------|
| 2141 | STATUS_SUCCESS | final completion — sent **first** |
| 2142 | STATUS_PENDING | interim — sent **second** |
| 2147 | TCP **RST** | client aborts the connection |

The final response overtook the interim — an MS-SMB2 §3.3.4.4 ordering violation. The client RSTs, and the next `smb2_create` returns `NT_STATUS_CONNECTION_DISCONNECTED`.

### Root cause
`ProcessSingleRequest` called `PendingCreateRegistry.MarkStarted` **before** `SendResponseWithHooks` wrote the interim. `MarkStarted` unblocks the resume goroutine, which writes the final response on its own `WriteMu` acquisition. Each frame takes `WriteMu` independently, so the lock only serializes individual writes — it does not enforce interim-before-final ordering. When the break drained fast (the oplock1 holder closes its handle, immediately completing the break-wait), the resume goroutine could win the write lock and emit the final response ahead of the interim.

### Fix
Move `MarkStarted` to **strictly after** the interim is on the wire:
- **response.go** (the standalone-CREATE path oplock1 trips): `MarkStarted` now runs after `SendResponseWithHooks`.
- **compound.go**: the compound paths had the same latent race (interim buffered into the compound frame, gate released before the frame was written). Deferred via `compoundLoopState.markStartedAsyncIDs` + `releaseStartedGates(...)`, fired after `sendCompoundResponses` — unconditionally (even on a write error) so a resume goroutine is never left blocked on `PendingCreate.started`.

Scope is limited to the parked-CREATE gate; byte-range LOCK uses a separate `PendingLockRegistry` and is untouched (owned by the in-flight NLM/lock PR).

## Verification
- `go build ./...`, `go vet`, `go fmt` — clean
- `go test -race ./internal/adapter/smb/...` — pass
- smbtorture harness `smb2.bench.oplock1` — passes / stable with the fix (0 unjustified new failures)

Closes #1036.