### PR TITLE
feat(bench): orchestrator + versioned result schema (#1011)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -62,6 +62,20 @@ Micro runs via `go test -bench` against the library directly:
 go test -bench=. -benchmem -run=^$ ./bench/blockstore/
 ```
 
+### Orchestrated runs (versioned result JSON)
+
+`dfsbench orchestrate` runs a manifest of workloads and emits a versioned,
+machine-readable result document (schema_version 1) — run metadata, host/CPU
+info, and per-workload ns/op / throughput / pprof paths — plus a compare mode
+that flags ns/op regressions between two runs. See
+[`bench/orchestrator/README.md`](orchestrator/README.md) for the manifest
+format, schema, and version contract.
+
+```sh
+./dfsbench orchestrate --out result.json --summary
+./dfsbench orchestrate --compare-baseline base.json --compare-candidate new.json
+```
+
 Use `benchstat` to A/B compare two commits:
 
 ```sh

--- a/bench/orchestrator/README.md
+++ b/bench/orchestrator/README.md
@@ -1,0 +1,140 @@
+# bench/orchestrator
+
+Runs a manifest of DittoFS benchmark workloads and emits a **versioned,
+machine-readable result document** so performance can be tracked over time and
+gated in CI.
+
+This is an orchestration layer on top of the existing `bench/blockstore`
+primitives — it does **not** implement workloads. It runs the blockstore
+workloads (`sequential-write`, `random-write`, `dedup-heavy`, `mixed-rw`,
+`mixed-ops-storm`, the concurrent (a)–(d) workloads, `walk`/`delete`/`gc`),
+captures the shared pprof envelope per workload, and collects the numbers into
+one JSON document.
+
+The package is deliberately free of engine/pprof/runtime dependencies: the
+caller injects a `WorkloadRunner`. `cmd/bench orchestrate` wires the real
+engine-backed runner; tests inject a fast fake. Run metadata (timestamp, run
+ID, git SHA) is injected too — the run loop never calls `time.Now()` or reads
+the environment, so runs are reproducible and tests are deterministic.
+
+## Run
+
+```bash
+go build -o dfsbench ./cmd/bench
+
+# Default manifest (fast, in-process, memory remote — no S3/network):
+dfsbench orchestrate --out result.json --summary
+
+# Pin the timestamp/run-id and git SHA for a reproducible capture:
+dfsbench orchestrate --out result.json \
+  --timestamp 2026-06-02T12:00:00Z --run-id baseline-1 --git-sha "$(git rev-parse HEAD)"
+
+# Custom manifest + baseline/post-fix profile nesting:
+dfsbench orchestrate --manifest my.json --phase baseline --profile-dir _profiles
+dfsbench orchestrate --manifest my.json --phase post-fix --profile-dir _profiles
+
+# Compare two result documents (exits non-zero on a regression — CI-gateable):
+dfsbench orchestrate \
+  --compare-baseline baseline.json --compare-candidate post-fix.json \
+  --compare-threshold 10
+```
+
+Flags: `--out` (write JSON to a path; default stdout), `--summary` (human table
+to stderr), `--full-profiles` (also capture mutex+block per workload),
+`--profile-dir`/`--phase` (where pprof lands — same layout as the `blockstore`
+subcommand, so before/after captures sit side by side).
+
+### Manifest format
+
+A manifest is a JSON list of workload entries. Names must be unique (they key
+the result document). Omitted numeric fields fall back to the workload's
+defaults (e.g. block size resolves to 8 MiB for sequential/dedup, 4 KiB
+otherwise).
+
+```json
+{
+  "workloads": [
+    { "name": "seq-write",    "workload": "sequential-write", "ops": 2000, "block_size": 65536, "working_set": 4, "seed": 1, "remote": "memory" },
+    { "name": "storm-4w",     "workload": "mixed-ops-storm",  "ops": 4000, "workers": 4, "mix": "50,30,15,5", "seed": 1, "remote": "memory" }
+  ]
+}
+```
+
+Omit `--manifest` to use the built-in default set (a quick five-workload
+memory-remote snapshot suitable for a CI gate).
+
+## Result schema
+
+The document is versioned via the top-level `schema_version` field.
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "baseline-1",
+  "timestamp": "2026-06-02T12:00:00Z",
+  "git_sha": "459ebbae...",
+  "system": { "os": "darwin", "arch": "arm64", "num_cpu": 10, "go_version": "go1.26.3", "hostname": "amaterasu" },
+  "outcome": "completed",
+  "workloads": {
+    "seq-write": {
+      "outcome": "completed",
+      "params": { "name": "seq-write", "workload": "sequential-write", "ops": 2000, "block_size": 65536, "working_set": 4, "seed": 1, "remote": "memory" },
+      "metrics": {
+        "duration_ns": 28311948292,
+        "ops": 2000,
+        "ns_per_op": 14155974.146,
+        "ops_per_sec": 70.64,
+        "bytes": 131072000,
+        "bytes_per_sec": 4629564.83
+      },
+      "profile_paths": [
+        ".../seq-write-.../cpu.pprof",
+        ".../seq-write-.../heap.pprof",
+        ".../seq-write-.../goroutine.pprof"
+      ]
+    }
+  }
+}
+```
+
+Fields:
+
+- `schema_version` (int) — read this first; see the version contract below.
+- `run_id`, `timestamp` (RFC3339 UTC), `git_sha` — injected run metadata.
+- `system` — host/runtime the run executed on (so results from different
+  machines are not silently compared).
+- `outcome` — one of `completed` (every workload succeeded), `partial` (some
+  workload failed; surviving results are still present), `aborted` (the run was
+  halted before finishing — e.g. an invalid manifest; `abort_reason` carries
+  the cause).
+- `workloads` — map keyed by manifest entry name. Each entry carries its own
+  `outcome`, the echoed `params`, `metrics` (omitted when the workload did not
+  complete), and `profile_paths` (the captured pprof files; empty when
+  profiling is disabled, e.g. under test).
+
+A CI gate asserts `outcome == "completed"` and that every workload completed.
+
+## Version contract
+
+- `schema_version` is the **first and only** field a consumer must read before
+  interpreting anything else. It is an integer and is always present.
+- **Additive (minor) changes** — new optional fields — do **not** bump
+  `schema_version`. Consumers must ignore unknown fields (Go's `encoding/json`
+  does this by default) so they keep working across additive changes.
+- A **bump** signals a **breaking** change (a field removed, renamed, or its
+  meaning/units changed). A consumer that does not recognize a document's
+  `schema_version` must **refuse** to interpret the numbers rather than
+  silently mis-read them.
+- Use `orchestrator.DecodeDocument` (or `CheckVersion`) to read a document — it
+  verifies `schema_version` before handing the document back. Compare mode and
+  any CI gate go through it.
+
+## Follow-ups (not built here)
+
+- **Per-area wrappers** — NFS / SMB / lock / runtime / metadata workload
+  runners that plug into the same manifest + schema. The `WorkloadRunner`
+  injection point and the per-workload `params`/`metrics`/`profile_paths` shape
+  are designed to accept them without a schema bump.
+- **Latency percentiles** — `metrics` currently reports duration/ops/throughput;
+  p50/p95/p99 are an additive field (no version bump) once a runner records
+  per-op timings.

--- a/bench/orchestrator/compare.go
+++ b/bench/orchestrator/compare.go
@@ -1,0 +1,129 @@
+package orchestrator
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+)
+
+// Comparison is the per-workload delta between a baseline and a candidate run.
+type Comparison struct {
+	Name string
+	// BaseNsPerOp / NewNsPerOp are the ns/op for each side. A workload missing
+	// from one side has its corresponding value left at 0 and Missing set.
+	BaseNsPerOp float64
+	NewNsPerOp  float64
+	// DeltaPct is the percentage change in ns/op from baseline to candidate
+	// (positive = slower = regression). 0 when baseline ns/op is 0.
+	DeltaPct float64
+	// Regression is true when DeltaPct exceeds the caller's threshold.
+	Regression bool
+	// Missing names a side that lacked this workload ("baseline" or
+	// "candidate"); empty when both have it.
+	Missing string
+}
+
+// Compare diffs two result documents by workload, flagging any workload whose
+// ns/op regressed by more than thresholdPct percent. Workloads present in only
+// one document are reported with Missing set and never flagged as regressions
+// (there is nothing to compare). The result is sorted by name for stable output.
+func Compare(baseline, candidate *Document, thresholdPct float64) []Comparison {
+	names := map[string]struct{}{}
+	for n := range baseline.Workloads {
+		names[n] = struct{}{}
+	}
+	for n := range candidate.Workloads {
+		names[n] = struct{}{}
+	}
+	sorted := make([]string, 0, len(names))
+	for n := range names {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	out := make([]Comparison, 0, len(sorted))
+	for _, n := range sorted {
+		b, hasB := baseline.Workloads[n]
+		c, hasC := candidate.Workloads[n]
+		cmp := Comparison{Name: n}
+		switch {
+		case !hasB:
+			cmp.Missing = "baseline"
+		case !hasC:
+			cmp.Missing = "candidate"
+		default:
+			if b.Metrics != nil {
+				cmp.BaseNsPerOp = b.Metrics.NsPerOp
+			}
+			if c.Metrics != nil {
+				cmp.NewNsPerOp = c.Metrics.NsPerOp
+			}
+			if cmp.BaseNsPerOp > 0 {
+				cmp.DeltaPct = (cmp.NewNsPerOp - cmp.BaseNsPerOp) / cmp.BaseNsPerOp * 100
+				cmp.Regression = cmp.DeltaPct > thresholdPct
+			}
+		}
+		out = append(out, cmp)
+	}
+	return out
+}
+
+// HasRegression reports whether any comparison flagged a regression.
+func HasRegression(cmps []Comparison) bool {
+	for _, c := range cmps {
+		if c.Regression {
+			return true
+		}
+	}
+	return false
+}
+
+// WriteComparison renders the comparisons as an aligned table.
+func WriteComparison(w io.Writer, cmps []Comparison) {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "WORKLOAD\tBASE_NS/OP\tNEW_NS/OP\tDELTA%\tFLAG")
+	for _, c := range cmps {
+		flag := ""
+		switch {
+		case c.Missing != "":
+			flag = "missing-in-" + c.Missing
+		case c.Regression:
+			flag = "REGRESSION"
+		}
+		fmt.Fprintf(tw, "%s\t%.1f\t%.1f\t%+.1f\t%s\n", c.Name, c.BaseNsPerOp, c.NewNsPerOp, c.DeltaPct, flag)
+	}
+	_ = tw.Flush()
+}
+
+// WriteSummary renders a document's per-workload metrics as an aligned table —
+// a quick human-readable companion to the JSON output.
+func WriteSummary(w io.Writer, doc *Document) {
+	fmt.Fprintf(w, "run_id=%s schema_version=%d outcome=%s git_sha=%s\n",
+		doc.RunID, doc.SchemaVersion, doc.Outcome, doc.GitSHA)
+	if doc.AbortReason != "" {
+		fmt.Fprintf(w, "abort_reason=%s\n", doc.AbortReason)
+	}
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "WORKLOAD\tOUTCOME\tOPS\tNS/OP\tOPS/SEC\tMB/SEC")
+	for _, name := range sortedKeys(doc.Workloads) {
+		r := doc.Workloads[name]
+		if r.Metrics == nil {
+			fmt.Fprintf(tw, "%s\t%s\t-\t-\t-\t-\n", name, r.Outcome)
+			continue
+		}
+		mbps := r.Metrics.BytesPerSec / (1024 * 1024)
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%.1f\t%.1f\t%.2f\n",
+			name, r.Outcome, r.Metrics.Ops, r.Metrics.NsPerOp, r.Metrics.OpsPerSec, mbps)
+	}
+	_ = tw.Flush()
+}
+
+func sortedKeys(m map[string]WorkloadResult) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/bench/orchestrator/compare.go
+++ b/bench/orchestrator/compare.go
@@ -82,7 +82,7 @@ func HasRegression(cmps []Comparison) bool {
 // WriteComparison renders the comparisons as an aligned table.
 func WriteComparison(w io.Writer, cmps []Comparison) {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "WORKLOAD\tBASE_NS/OP\tNEW_NS/OP\tDELTA%\tFLAG")
+	_, _ = fmt.Fprintln(tw, "WORKLOAD\tBASE_NS/OP\tNEW_NS/OP\tDELTA%\tFLAG")
 	for _, c := range cmps {
 		flag := ""
 		switch {
@@ -91,7 +91,7 @@ func WriteComparison(w io.Writer, cmps []Comparison) {
 		case c.Regression:
 			flag = "REGRESSION"
 		}
-		fmt.Fprintf(tw, "%s\t%.1f\t%.1f\t%+.1f\t%s\n", c.Name, c.BaseNsPerOp, c.NewNsPerOp, c.DeltaPct, flag)
+		_, _ = fmt.Fprintf(tw, "%s\t%.1f\t%.1f\t%+.1f\t%s\n", c.Name, c.BaseNsPerOp, c.NewNsPerOp, c.DeltaPct, flag)
 	}
 	_ = tw.Flush()
 }
@@ -99,21 +99,21 @@ func WriteComparison(w io.Writer, cmps []Comparison) {
 // WriteSummary renders a document's per-workload metrics as an aligned table —
 // a quick human-readable companion to the JSON output.
 func WriteSummary(w io.Writer, doc *Document) {
-	fmt.Fprintf(w, "run_id=%s schema_version=%d outcome=%s git_sha=%s\n",
+	_, _ = fmt.Fprintf(w, "run_id=%s schema_version=%d outcome=%s git_sha=%s\n",
 		doc.RunID, doc.SchemaVersion, doc.Outcome, doc.GitSHA)
 	if doc.AbortReason != "" {
-		fmt.Fprintf(w, "abort_reason=%s\n", doc.AbortReason)
+		_, _ = fmt.Fprintf(w, "abort_reason=%s\n", doc.AbortReason)
 	}
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "WORKLOAD\tOUTCOME\tOPS\tNS/OP\tOPS/SEC\tMB/SEC")
+	_, _ = fmt.Fprintln(tw, "WORKLOAD\tOUTCOME\tOPS\tNS/OP\tOPS/SEC\tMB/SEC")
 	for _, name := range sortedKeys(doc.Workloads) {
 		r := doc.Workloads[name]
 		if r.Metrics == nil {
-			fmt.Fprintf(tw, "%s\t%s\t-\t-\t-\t-\n", name, r.Outcome)
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t-\t-\t-\t-\n", name, r.Outcome)
 			continue
 		}
 		mbps := r.Metrics.BytesPerSec / (1024 * 1024)
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%.1f\t%.1f\t%.2f\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%d\t%.1f\t%.1f\t%.2f\n",
 			name, r.Outcome, r.Metrics.Ops, r.Metrics.NsPerOp, r.Metrics.OpsPerSec, mbps)
 	}
 	_ = tw.Flush()

--- a/bench/orchestrator/compare_test.go
+++ b/bench/orchestrator/compare_test.go
@@ -1,0 +1,78 @@
+package orchestrator
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func docWith(name string, nsPerOp float64) *Document {
+	d := NewDocument("r", "2026-01-02T15:04:05Z", "sha", System{})
+	m := Metrics{NsPerOp: nsPerOp, Ops: 100}
+	d.Workloads[name] = WorkloadResult{Outcome: OutcomeCompleted, Metrics: &m}
+	return d
+}
+
+func TestCompareRegression(t *testing.T) {
+	base := docWith("w", 100)
+	cand := docWith("w", 130) // +30%
+	cmps := Compare(base, cand, 10)
+	if len(cmps) != 1 {
+		t.Fatalf("want 1 comparison, got %d", len(cmps))
+	}
+	if !cmps[0].Regression {
+		t.Errorf("expected regression flagged: %+v", cmps[0])
+	}
+	if cmps[0].DeltaPct < 29 || cmps[0].DeltaPct > 31 {
+		t.Errorf("delta = %v, want ~30", cmps[0].DeltaPct)
+	}
+	if !HasRegression(cmps) {
+		t.Error("HasRegression should be true")
+	}
+}
+
+func TestCompareWithinThreshold(t *testing.T) {
+	cmps := Compare(docWith("w", 100), docWith("w", 105), 10) // +5% < 10%
+	if cmps[0].Regression || HasRegression(cmps) {
+		t.Errorf("5%% should not flag under 10%% threshold: %+v", cmps[0])
+	}
+}
+
+func TestCompareMissingWorkload(t *testing.T) {
+	base := docWith("a", 100)
+	cand := docWith("b", 100)
+	cmps := Compare(base, cand, 10)
+	if len(cmps) != 2 {
+		t.Fatalf("want 2 comparisons (union), got %d", len(cmps))
+	}
+	var sawMissingCand, sawMissingBase bool
+	for _, c := range cmps {
+		if c.Name == "a" && c.Missing == "candidate" {
+			sawMissingCand = true
+		}
+		if c.Name == "b" && c.Missing == "baseline" {
+			sawMissingBase = true
+		}
+		if c.Regression {
+			t.Errorf("missing workload must not be a regression: %+v", c)
+		}
+	}
+	if !sawMissingCand || !sawMissingBase {
+		t.Errorf("missing-side detection failed: %+v", cmps)
+	}
+}
+
+func TestWriteComparisonAndSummary(t *testing.T) {
+	var buf bytes.Buffer
+	WriteComparison(&buf, Compare(docWith("w", 100), docWith("w", 200), 10))
+	if !strings.Contains(buf.String(), "REGRESSION") {
+		t.Errorf("comparison table missing REGRESSION flag:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	WriteSummary(&buf, docWith("w", 100))
+	out := buf.String()
+	if !strings.Contains(out, "schema_version=1") || !strings.Contains(out, "WORKLOAD") {
+		t.Errorf("summary missing header/version:\n%s", out)
+	}
+}

--- a/bench/orchestrator/env.go
+++ b/bench/orchestrator/env.go
@@ -1,0 +1,38 @@
+package orchestrator
+
+import (
+	"os"
+	"runtime"
+	"runtime/debug"
+)
+
+// LocalSystem captures the host/runtime environment of the current process.
+// Producers call this once and pass the result into Run.
+func LocalSystem() System {
+	host, _ := os.Hostname()
+	return System{
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		NumCPU:    runtime.NumCPU(),
+		GoVersion: runtime.Version(),
+		Hostname:  host,
+	}
+}
+
+// BuildGitSHA returns the VCS revision embedded by the Go toolchain at build
+// time (runtime/debug.BuildInfo), or "" when unavailable (e.g. `go run`, or a
+// build with -buildvcs=false). Callers may override it with an explicit flag;
+// this is the zero-config fallback so a normal `go build` artifact self-stamps
+// its commit without a hardcoded time.Now()-style value.
+func BuildGitSHA() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value
+		}
+	}
+	return ""
+}

--- a/bench/orchestrator/manifest.go
+++ b/bench/orchestrator/manifest.go
@@ -1,0 +1,102 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// WorkloadParams is one manifest entry: a named workload plus the knobs the
+// bench/blockstore primitives accept. It mirrors the subset of
+// blockstore.Opts that a manifest needs to express — kept as a plain struct so
+// this package has no dependency on bench/blockstore (the WorkloadRunner the
+// caller injects owns that translation).
+type WorkloadParams struct {
+	// Name is the unique manifest key AND the result key. Required.
+	Name string `json:"name"`
+	// Workload is the bench/blockstore workload identifier (e.g.
+	// "sequential-write", "mixed-ops-storm"). Required.
+	Workload string `json:"workload"`
+
+	Ops        int    `json:"ops"`
+	BlockSize  int    `json:"block_size,omitempty"`
+	WorkingSet int    `json:"working_set,omitempty"`
+	Workers    int    `json:"workers,omitempty"`
+	Seed       uint64 `json:"seed"`
+	Remote     string `json:"remote,omitempty"`
+	Mix        string `json:"mix,omitempty"`
+}
+
+// Manifest is an ordered set of workloads to run. Names must be unique; the
+// document keys results by name.
+type Manifest struct {
+	Workloads []WorkloadParams `json:"workloads"`
+}
+
+// DefaultManifest is a small, fast, dependency-free set of in-process
+// blockstore workloads suitable for a quick perf snapshot or a CI gate. It
+// uses the memory remote so it needs no S3/network, and keeps block sizes
+// modest so the whole set runs in a few seconds. For a heavy capture run pass
+// --manifest with larger ops/block sizes (e.g. the 8 MiB sequential default
+// that the standalone `blockstore` subcommand uses).
+func DefaultManifest() Manifest {
+	const smallBlock = 64 * 1024 // 64 KiB keeps the default set quick.
+	return Manifest{
+		Workloads: []WorkloadParams{
+			{Name: "seq-write", Workload: "sequential-write", Ops: 2000, BlockSize: smallBlock, WorkingSet: 4, Seed: 1, Remote: "memory"},
+			{Name: "random-write", Workload: "random-write", Ops: 5000, BlockSize: 4096, WorkingSet: 4, Seed: 1, Remote: "memory"},
+			{Name: "dedup-heavy", Workload: "dedup-heavy", Ops: 2000, BlockSize: smallBlock, Seed: 1, Remote: "memory"},
+			{Name: "mixed-rw", Workload: "mixed-rw", Ops: 5000, BlockSize: 4096, WorkingSet: 4, Seed: 1, Remote: "memory"},
+			{Name: "storm-4w", Workload: "mixed-ops-storm", Ops: 4000, BlockSize: 4096, Workers: 4, Seed: 1, Remote: "memory"},
+		},
+	}
+}
+
+// LoadManifest decodes a JSON manifest from r and validates it.
+func LoadManifest(r io.Reader) (Manifest, error) {
+	var m Manifest
+	if err := json.NewDecoder(r).Decode(&m); err != nil {
+		return Manifest{}, fmt.Errorf("decode manifest: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	return m, nil
+}
+
+// Validate checks that the manifest is non-empty, every entry names a workload,
+// op counts are positive, and names are unique.
+func (m Manifest) Validate() error {
+	if len(m.Workloads) == 0 {
+		return fmt.Errorf("manifest has no workloads")
+	}
+	seen := map[string]struct{}{}
+	for i, w := range m.Workloads {
+		if w.Name == "" {
+			return fmt.Errorf("workload[%d]: name is required", i)
+		}
+		if w.Workload == "" {
+			return fmt.Errorf("workload %q: workload identifier is required", w.Name)
+		}
+		if w.Ops <= 0 {
+			return fmt.Errorf("workload %q: ops must be > 0", w.Name)
+		}
+		if _, dup := seen[w.Name]; dup {
+			return fmt.Errorf("duplicate workload name %q", w.Name)
+		}
+		seen[w.Name] = struct{}{}
+	}
+	return nil
+}
+
+// Names returns the manifest workload names in sorted order — handy for a
+// stable human summary independent of run order.
+func (m Manifest) Names() []string {
+	out := make([]string, 0, len(m.Workloads))
+	for _, w := range m.Workloads {
+		out = append(out, w.Name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/bench/orchestrator/manifest_test.go
+++ b/bench/orchestrator/manifest_test.go
@@ -1,0 +1,50 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultManifestValid(t *testing.T) {
+	if err := DefaultManifest().Validate(); err != nil {
+		t.Fatalf("default manifest invalid: %v", err)
+	}
+}
+
+func TestLoadManifest(t *testing.T) {
+	in := `{"workloads":[
+		{"name":"w1","workload":"sequential-write","ops":100,"seed":1},
+		{"name":"w2","workload":"mixed-ops-storm","ops":200,"workers":4,"mix":"50,30,15,5","seed":2}
+	]}`
+	m, err := LoadManifest(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(m.Workloads) != 2 {
+		t.Fatalf("want 2 workloads, got %d", len(m.Workloads))
+	}
+	if m.Workloads[1].Workers != 4 || m.Workloads[1].Mix != "50,30,15,5" {
+		t.Errorf("params not decoded: %+v", m.Workloads[1])
+	}
+}
+
+func TestManifestValidateErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		m    Manifest
+	}{
+		{"empty", Manifest{}},
+		{"no-name", Manifest{Workloads: []WorkloadParams{{Workload: "x", Ops: 1}}}},
+		{"no-workload", Manifest{Workloads: []WorkloadParams{{Name: "a", Ops: 1}}}},
+		{"zero-ops", Manifest{Workloads: []WorkloadParams{{Name: "a", Workload: "x", Ops: 0}}}},
+		{"dup-name", Manifest{Workloads: []WorkloadParams{
+			{Name: "a", Workload: "x", Ops: 1}, {Name: "a", Workload: "y", Ops: 1}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.m.Validate(); err == nil {
+				t.Errorf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/bench/orchestrator/orchestrator.go
+++ b/bench/orchestrator/orchestrator.go
@@ -1,0 +1,98 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunOutput is what a WorkloadRunner returns for one workload: the measured
+// numbers and any pprof files it captured. Errors are returned out-of-band.
+type RunOutput struct {
+	Metrics      Metrics
+	ProfilePaths []string
+}
+
+// WorkloadRunner executes a single workload and returns its measured output.
+// The orchestrator injects this so it stays free of the engine/pprof/runtime
+// machinery: cmd/bench wires a runner that composes the bench/blockstore
+// engine and the pprof envelope; tests inject a fast in-memory fake. A non-nil
+// error marks the workload as failed (Outcome != completed) without aborting
+// the rest of the manifest.
+type WorkloadRunner func(ctx context.Context, p WorkloadParams) (RunOutput, error)
+
+// Run executes every workload in the manifest in order, recording per-workload
+// results into a freshly stamped Document. Run metadata (run ID, timestamp, git
+// SHA, system) is supplied by the caller — Run never calls time.Now() or reads
+// the environment itself, which keeps it deterministic under test.
+//
+// A workload runner error is recorded as a per-workload failure and the run
+// continues; the document outcome becomes "partial". If the manifest itself is
+// invalid the run is "aborted" before any workload executes.
+func Run(ctx context.Context, m Manifest, runID, timestamp, gitSHA string, sys System, run WorkloadRunner) (*Document, error) {
+	doc := NewDocument(runID, timestamp, gitSHA, sys)
+
+	if err := m.Validate(); err != nil {
+		doc.Outcome = OutcomeAborted
+		doc.AbortReason = err.Error()
+		return doc, err
+	}
+	if run == nil {
+		doc.Outcome = OutcomeAborted
+		doc.AbortReason = "no workload runner provided"
+		return doc, fmt.Errorf("orchestrator.Run: runner is nil")
+	}
+
+	anyFailed := false
+	for _, p := range m.Workloads {
+		// Honor cancellation between workloads so a budget/timeout halts the
+		// run cleanly with the results gathered so far.
+		if err := ctx.Err(); err != nil {
+			doc.Outcome = OutcomeAborted
+			doc.AbortReason = err.Error()
+			return doc, err
+		}
+
+		out, err := run(ctx, p)
+		if err != nil {
+			anyFailed = true
+			doc.Workloads[p.Name] = WorkloadResult{
+				Outcome: OutcomePartial,
+				Error:   err.Error(),
+				Params:  p,
+			}
+			continue
+		}
+		metrics := out.Metrics
+		doc.Workloads[p.Name] = WorkloadResult{
+			Outcome:      OutcomeCompleted,
+			Params:       p,
+			Metrics:      &metrics,
+			ProfilePaths: out.ProfilePaths,
+		}
+	}
+
+	if anyFailed {
+		doc.Outcome = OutcomePartial
+	}
+	return doc, nil
+}
+
+// MetricsFromRun derives the schema Metrics from a raw duration/ops/bytes
+// triple. Shared by the real runner so the ns/op and throughput math lives in
+// one place. durationNs must be > 0.
+func MetricsFromRun(durationNs, ops, bytes int64) Metrics {
+	m := Metrics{
+		DurationNs: durationNs,
+		Ops:        ops,
+		Bytes:      bytes,
+	}
+	if durationNs > 0 {
+		secs := float64(durationNs) / 1e9
+		m.OpsPerSec = float64(ops) / secs
+		m.BytesPerSec = float64(bytes) / secs
+	}
+	if ops > 0 {
+		m.NsPerOp = float64(durationNs) / float64(ops)
+	}
+	return m
+}

--- a/bench/orchestrator/orchestrator_test.go
+++ b/bench/orchestrator/orchestrator_test.go
@@ -1,0 +1,120 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeRunner returns deterministic metrics derived from the params, with no
+// engine/pprof — so the run loop is tested in isolation and fast.
+func fakeRunner(_ context.Context, p WorkloadParams) (RunOutput, error) {
+	return RunOutput{
+		Metrics:      MetricsFromRun(int64(p.Ops)*1000, int64(p.Ops), int64(p.Ops)*int64(p.BlockSize)),
+		ProfilePaths: []string{p.Name + "/cpu.pprof"},
+	}, nil
+}
+
+func twoWorkloadManifest() Manifest {
+	return Manifest{Workloads: []WorkloadParams{
+		{Name: "a", Workload: "sequential-write", Ops: 100, BlockSize: 4096, Seed: 1},
+		{Name: "b", Workload: "random-write", Ops: 200, BlockSize: 4096, Seed: 2},
+	}}
+}
+
+func TestRunHappyPath(t *testing.T) {
+	doc, err := Run(context.Background(), twoWorkloadManifest(), "rid", "2026-01-02T15:04:05Z", "sha", System{}, fakeRunner)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if doc.Outcome != OutcomeCompleted {
+		t.Errorf("outcome = %s, want completed", doc.Outcome)
+	}
+	if len(doc.Workloads) != 2 {
+		t.Fatalf("want 2 workloads, got %d", len(doc.Workloads))
+	}
+	a := doc.Workloads["a"]
+	if a.Outcome != OutcomeCompleted || a.Metrics == nil || a.Metrics.Ops != 100 {
+		t.Errorf("workload a wrong: %+v", a)
+	}
+	if a.Params.Workload != "sequential-write" {
+		t.Errorf("params not echoed: %+v", a.Params)
+	}
+	if len(a.ProfilePaths) != 1 {
+		t.Errorf("profile paths not captured: %+v", a.ProfilePaths)
+	}
+}
+
+func TestRunRecordsFailureAsPartial(t *testing.T) {
+	var calls atomic.Int32
+	runner := func(_ context.Context, p WorkloadParams) (RunOutput, error) {
+		calls.Add(1)
+		if p.Name == "a" {
+			return RunOutput{}, fmt.Errorf("boom")
+		}
+		return fakeRunner(context.Background(), p)
+	}
+	doc, err := Run(context.Background(), twoWorkloadManifest(), "rid", "2026-01-02T15:04:05Z", "sha", System{}, runner)
+	if err != nil {
+		t.Fatalf("Run should not error on workload failure: %v", err)
+	}
+	if doc.Outcome != OutcomePartial {
+		t.Errorf("outcome = %s, want partial", doc.Outcome)
+	}
+	// b still ran after a failed.
+	if calls.Load() != 2 {
+		t.Errorf("expected both workloads attempted, got %d calls", calls.Load())
+	}
+	if doc.Workloads["a"].Outcome != OutcomePartial || doc.Workloads["a"].Error == "" {
+		t.Errorf("failed workload not recorded: %+v", doc.Workloads["a"])
+	}
+	if doc.Workloads["b"].Outcome != OutcomeCompleted {
+		t.Errorf("surviving workload wrong: %+v", doc.Workloads["b"])
+	}
+}
+
+func TestRunInvalidManifestAborts(t *testing.T) {
+	doc, err := Run(context.Background(), Manifest{}, "rid", "2026-01-02T15:04:05Z", "sha", System{}, fakeRunner)
+	if err == nil {
+		t.Fatal("expected error for empty manifest")
+	}
+	if doc.Outcome != OutcomeAborted || doc.AbortReason == "" {
+		t.Errorf("expected aborted with reason, got %+v", doc)
+	}
+}
+
+func TestRunNilRunnerAborts(t *testing.T) {
+	doc, err := Run(context.Background(), twoWorkloadManifest(), "rid", "ts", "sha", System{}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil runner")
+	}
+	if doc.Outcome != OutcomeAborted {
+		t.Errorf("outcome = %s, want aborted", doc.Outcome)
+	}
+}
+
+func TestRunCanceledContextAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	doc, err := Run(ctx, twoWorkloadManifest(), "rid", "ts", "sha", System{}, fakeRunner)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if doc.Outcome != OutcomeAborted {
+		t.Errorf("outcome = %s, want aborted", doc.Outcome)
+	}
+}
+
+func TestRunDeterministic(t *testing.T) {
+	// Same inputs (including injected timestamp/seed) produce byte-identical
+	// documents — no hidden time.Now()/rand.
+	m := twoWorkloadManifest()
+	d1, _ := Run(context.Background(), m, "rid", "2026-01-02T15:04:05Z", "sha", System{OS: "x"}, fakeRunner)
+	d2, _ := Run(context.Background(), m, "rid", "2026-01-02T15:04:05Z", "sha", System{OS: "x"}, fakeRunner)
+	b1, _ := d1.Marshal()
+	b2, _ := d2.Marshal()
+	if string(b1) != string(b2) {
+		t.Errorf("non-deterministic output:\n%s\nvs\n%s", b1, b2)
+	}
+}

--- a/bench/orchestrator/schema.go
+++ b/bench/orchestrator/schema.go
@@ -1,0 +1,182 @@
+// Package orchestrator runs a manifest of DittoFS benchmark workloads and
+// emits a versioned, machine-readable result document so performance can be
+// tracked over time and gated in CI.
+//
+// It is an orchestration layer on top of the existing bench/blockstore
+// primitives — it does not implement workloads itself. A WorkloadRunner is
+// injected (cmd/bench wires the real engine-backed runner; tests inject a
+// fast fake), which keeps this package free of pprof/engine/runtime deps and
+// trivially testable.
+//
+// The emitted document is versioned via SchemaVersion. See the "Version
+// contract" comment on that constant for how consumers detect and handle
+// version bumps.
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// SchemaVersion is the version of the Document JSON schema. It starts at 1 and
+// is bumped on every breaking change to the document shape.
+//
+// Version contract:
+//
+//   - The top-level "schema_version" field is the FIRST and ONLY field a
+//     consumer must read before interpreting anything else. It is an integer
+//     and is always present.
+//   - MINOR, backward-compatible additions (new optional fields) do NOT bump
+//     SchemaVersion. Consumers MUST ignore unknown fields (encoding/json does
+//     this by default) so they keep working across additive changes.
+//   - A bump signals a BREAKING change (a field removed, renamed, or its
+//     meaning/units changed). A consumer reading a document whose
+//     schema_version it does not recognize MUST refuse to interpret the
+//     per-workload numbers rather than silently mis-reading them. Use
+//     CheckVersion / DecodeDocument to enforce this.
+//   - Producers always stamp the current SchemaVersion via NewDocument.
+const SchemaVersion = 1
+
+// Outcome is the run/workload status. The set is closed and mirrors the
+// versioned-result-schema contract: a CI gate asserts Outcome == OutcomeCompleted
+// across the run and every workload.
+type Outcome string
+
+const (
+	// OutcomeCompleted means every workload ran to completion with no errors.
+	OutcomeCompleted Outcome = "completed"
+	// OutcomePartial means at least one workload failed but others completed;
+	// the document still carries the results that did run.
+	OutcomePartial Outcome = "partial"
+	// OutcomeAborted means the run was halted before finishing the manifest
+	// (e.g. a fatal setup error). AbortReason carries the cause.
+	OutcomeAborted Outcome = "aborted"
+)
+
+// Document is the top-level versioned result. SchemaVersion is first so a
+// consumer can branch on it before reading anything else.
+type Document struct {
+	SchemaVersion int    `json:"schema_version"`
+	RunID         string `json:"run_id"`
+	// Timestamp is the run start time in RFC3339 (UTC). It is injected by the
+	// caller (flag or build info), never read from time.Now() inside the run
+	// loop, so runs are reproducible and tests are deterministic.
+	Timestamp string `json:"timestamp"`
+	GitSHA    string `json:"git_sha"`
+	System    System `json:"system"`
+
+	Outcome     Outcome `json:"outcome"`
+	AbortReason string  `json:"abort_reason,omitempty"`
+
+	// Workloads is keyed by workload entry name (manifest is name-unique).
+	Workloads map[string]WorkloadResult `json:"workloads"`
+}
+
+// System captures the host/runtime environment the run executed on so results
+// from different machines are not silently compared.
+type System struct {
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+	NumCPU    int    `json:"num_cpu"`
+	GoVersion string `json:"go_version"`
+	Hostname  string `json:"hostname,omitempty"`
+}
+
+// WorkloadResult is the per-workload outcome plus the measured numbers and the
+// pprof profile files captured for it (paths relative to the run, or absolute —
+// the producer decides; consumers treat them as opaque locators).
+type WorkloadResult struct {
+	Outcome Outcome `json:"outcome"`
+	// Error is the failure message when Outcome != completed; empty otherwise.
+	Error string `json:"error,omitempty"`
+
+	// Params echoes the manifest entry that produced this result so a document
+	// is self-describing without the manifest.
+	Params WorkloadParams `json:"params"`
+
+	// Metrics is omitted when the workload did not complete.
+	Metrics *Metrics `json:"metrics,omitempty"`
+
+	// ProfilePaths are the pprof files captured for this workload (cpu, heap,
+	// goroutine, and — when full profiling is on — mutex/block). May be empty
+	// when profiling is disabled (e.g. under test).
+	ProfilePaths []string `json:"profile_paths,omitempty"`
+}
+
+// Metrics holds the measured numbers for one workload run.
+type Metrics struct {
+	DurationNs int64   `json:"duration_ns"`
+	Ops        int64   `json:"ops"`
+	NsPerOp    float64 `json:"ns_per_op"`
+	OpsPerSec  float64 `json:"ops_per_sec"`
+	// Bytes is total bytes moved; BytesPerSec is throughput. Both 0 for
+	// workloads that do not move payload (walk/delete/gc).
+	Bytes       int64   `json:"bytes"`
+	BytesPerSec float64 `json:"bytes_per_sec"`
+}
+
+// NewDocument builds a Document stamped with the current SchemaVersion and the
+// injected run metadata. Workloads starts empty and is filled by the run loop.
+func NewDocument(runID, timestamp, gitSHA string, sys System) *Document {
+	return &Document{
+		SchemaVersion: SchemaVersion,
+		RunID:         runID,
+		Timestamp:     timestamp,
+		GitSHA:        gitSHA,
+		System:        sys,
+		Outcome:       OutcomeCompleted,
+		Workloads:     map[string]WorkloadResult{},
+	}
+}
+
+// Marshal renders the document as indented JSON with a trailing newline.
+func (d *Document) Marshal() ([]byte, error) {
+	b, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal result document: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+// CheckVersion enforces the version contract: it accepts a document whose
+// schema_version equals the SchemaVersion this binary was built with, and
+// rejects anything else with an actionable error. Callers that want to read an
+// older document must add explicit migration code — silent reinterpretation is
+// the failure mode this guards against.
+func CheckVersion(got int) error {
+	if got != SchemaVersion {
+		return fmt.Errorf("unsupported schema_version %d (this build understands %d): "+
+			"refusing to interpret results — upgrade the tool or migrate the document", got, SchemaVersion)
+	}
+	return nil
+}
+
+// DecodeDocument reads a result document from r and verifies its schema_version
+// before returning it. It is the safe entry point for consumers (compare mode,
+// CI gates) — it never hands back a document it cannot correctly interpret.
+func DecodeDocument(r io.Reader) (*Document, error) {
+	var d Document
+	if err := json.NewDecoder(r).Decode(&d); err != nil {
+		return nil, fmt.Errorf("decode result document: %w", err)
+	}
+	if err := CheckVersion(d.SchemaVersion); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// ParseTimestamp validates an RFC3339 timestamp string, returning it normalized
+// to UTC RFC3339. An empty string is rejected — the caller must supply one
+// (flag or build info) so documents are never stamped with a hidden time.Now().
+func ParseTimestamp(s string) (string, error) {
+	if s == "" {
+		return "", fmt.Errorf("timestamp is required (pass --timestamp RFC3339)")
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "", fmt.Errorf("invalid timestamp %q (want RFC3339, e.g. 2026-01-02T15:04:05Z): %w", s, err)
+	}
+	return t.UTC().Format(time.RFC3339), nil
+}

--- a/bench/orchestrator/schema_test.go
+++ b/bench/orchestrator/schema_test.go
@@ -1,0 +1,130 @@
+package orchestrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func sampleDoc() *Document {
+	doc := NewDocument("run-1", "2026-01-02T15:04:05Z", "abc123", System{
+		OS: "linux", Arch: "arm64", NumCPU: 8, GoVersion: "go1.24",
+	})
+	m := MetricsFromRun(2_000_000_000, 1000, 8_000_000)
+	doc.Workloads["seq-write"] = WorkloadResult{
+		Outcome:      OutcomeCompleted,
+		Params:       WorkloadParams{Name: "seq-write", Workload: "sequential-write", Ops: 1000, Seed: 1},
+		Metrics:      &m,
+		ProfilePaths: []string{"p/cpu.pprof"},
+	}
+	return doc
+}
+
+func TestDocumentRoundTrip(t *testing.T) {
+	doc := sampleDoc()
+	b, err := doc.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got, err := DecodeDocument(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", got.SchemaVersion, SchemaVersion)
+	}
+	if got.RunID != "run-1" || got.GitSHA != "abc123" {
+		t.Errorf("metadata not round-tripped: %+v", got)
+	}
+	w, ok := got.Workloads["seq-write"]
+	if !ok {
+		t.Fatal("seq-write workload missing after round-trip")
+	}
+	if w.Metrics == nil || w.Metrics.Ops != 1000 {
+		t.Errorf("metrics not round-tripped: %+v", w.Metrics)
+	}
+	if w.Metrics.NsPerOp != 2_000_000 {
+		t.Errorf("ns_per_op = %v, want 2000000", w.Metrics.NsPerOp)
+	}
+}
+
+func TestSchemaVersionAlwaysPresent(t *testing.T) {
+	b, err := sampleDoc().Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["schema_version"]; !ok {
+		t.Fatal("schema_version field absent from emitted JSON")
+	}
+}
+
+func TestVersionMismatchRejected(t *testing.T) {
+	// A document stamped with a future schema_version must be refused so a
+	// consumer never silently mis-reads renamed/reinterpreted fields.
+	doc := sampleDoc()
+	doc.SchemaVersion = SchemaVersion + 1
+	b, err := doc.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := DecodeDocument(bytes.NewReader(b)); err == nil {
+		t.Fatal("expected version-mismatch error, got nil")
+	}
+
+	if err := CheckVersion(SchemaVersion); err != nil {
+		t.Errorf("CheckVersion(current) = %v, want nil", err)
+	}
+	if err := CheckVersion(0); err == nil {
+		t.Error("CheckVersion(0) = nil, want error")
+	}
+}
+
+func TestUnknownFieldsIgnored(t *testing.T) {
+	// Additive (minor) schema changes must not break older consumers: an
+	// extra field is silently ignored.
+	in := `{"schema_version":1,"run_id":"r","future_field":42,"workloads":{}}`
+	got, err := DecodeDocument(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("decode with unknown field: %v", err)
+	}
+	if got.RunID != "r" {
+		t.Errorf("run_id = %q, want r", got.RunID)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	got, err := ParseTimestamp("2026-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != "2026-01-02T15:04:05Z" {
+		t.Errorf("got %q", got)
+	}
+	if _, err := ParseTimestamp(""); err == nil {
+		t.Error("empty timestamp accepted")
+	}
+	if _, err := ParseTimestamp("not-a-time"); err == nil {
+		t.Error("garbage timestamp accepted")
+	}
+	// Non-UTC input is normalized to UTC.
+	utc, err := ParseTimestamp("2026-01-02T15:04:05+02:00")
+	if err != nil {
+		t.Fatalf("parse offset: %v", err)
+	}
+	if utc != "2026-01-02T13:04:05Z" {
+		t.Errorf("UTC normalization failed: %q", utc)
+	}
+}
+
+func TestMetricsFromRunZeroDuration(t *testing.T) {
+	m := MetricsFromRun(0, 100, 200)
+	if m.OpsPerSec != 0 || m.BytesPerSec != 0 || m.NsPerOp != 0 {
+		t.Errorf("zero duration must not divide: %+v", m)
+	}
+}

--- a/cmd/bench/orchestrate.go
+++ b/cmd/bench/orchestrate.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	bsbench "github.com/marmos91/dittofs/bench/blockstore"
+	"github.com/marmos91/dittofs/bench/orchestrator"
+	"github.com/spf13/cobra"
+)
+
+var (
+	orchManifest      string
+	orchOut           string
+	orchSummary       bool
+	orchTimestamp     string
+	orchRunID         string
+	orchGitSHA        string
+	orchPhase         string
+	orchFullProfiles  bool
+	orchCompareBase   string
+	orchCompareCand   string
+	orchCompareThresh float64
+)
+
+var orchestrateCmd = &cobra.Command{
+	Use:   "orchestrate",
+	Short: "Run a manifest of blockstore workloads and emit a versioned result JSON",
+	Long: `Runs each workload in a manifest (default: a fast in-process memory-remote
+set; override with --manifest <file.json>) through the same bench/blockstore
+primitives the 'blockstore' subcommand uses, capturing the pprof envelope per
+workload, and emits a versioned result document (schema_version 1).
+
+Run metadata is injected for reproducibility: --timestamp defaults to now in
+RFC3339 but can be pinned; --git-sha defaults to the build's embedded VCS
+revision. --phase nests profile capture under <profile-dir>/blockstore/<phase>/
+so baseline vs post-fix runs sit side by side.
+
+Compare mode diffs two result JSONs by workload and flags ns/op regressions:
+  dfsbench orchestrate --compare-baseline base.json --compare-candidate new.json`,
+	RunE: runOrchestrate,
+}
+
+func init() {
+	flags := orchestrateCmd.Flags()
+	flags.StringVar(&orchManifest, "manifest", "", "JSON manifest file (default: built-in fast manifest)")
+	flags.StringVar(&orchOut, "out", "", "write result JSON to this path (default: stdout)")
+	flags.BoolVar(&orchSummary, "summary", false, "also print a human-readable summary table to stderr")
+	flags.StringVar(&orchTimestamp, "timestamp", "", "run timestamp in RFC3339 (default: now, UTC)")
+	flags.StringVar(&orchRunID, "run-id", "", "run identifier (default: derived from the timestamp)")
+	flags.StringVar(&orchGitSHA, "git-sha", "", "git SHA to stamp (default: build VCS revision)")
+	flags.StringVar(&orchPhase, "phase", "", "profile capture phase subdir (e.g. baseline | post-fix)")
+	flags.BoolVar(&orchFullProfiles, "full-profiles", false, "also capture mutex + block profiles per workload")
+	flags.StringVar(&orchCompareBase, "compare-baseline", "", "compare mode: baseline result JSON")
+	flags.StringVar(&orchCompareCand, "compare-candidate", "", "compare mode: candidate result JSON")
+	flags.Float64Var(&orchCompareThresh, "compare-threshold", 10, "compare mode: ns/op regression threshold in percent")
+
+	rootCmd.AddCommand(orchestrateCmd)
+}
+
+func runOrchestrate(cmd *cobra.Command, _ []string) error {
+	if orchCompareBase != "" || orchCompareCand != "" {
+		return runCompare(cmd)
+	}
+
+	manifest := orchestrator.DefaultManifest()
+	if orchManifest != "" {
+		f, err := os.Open(orchManifest)
+		if err != nil {
+			return fmt.Errorf("open manifest: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		if manifest, err = orchestrator.LoadManifest(f); err != nil {
+			return err
+		}
+	}
+
+	ts := orchTimestamp
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
+	ts, err := orchestrator.ParseTimestamp(ts)
+	if err != nil {
+		return err
+	}
+	runID := orchRunID
+	if runID == "" {
+		runID = "run-" + ts
+	}
+	gitSHA := orchGitSHA
+	if gitSHA == "" {
+		gitSHA = orchestrator.BuildGitSHA()
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	doc, err := orchestrator.Run(ctx, manifest, runID, ts, gitSHA, orchestrator.LocalSystem(), engineRunner)
+	if err != nil {
+		// A partial/aborted run still produced a document worth emitting; write
+		// it before surfacing the error so failures are not silently lost.
+		_ = emitDocument(cmd, doc)
+		return err
+	}
+
+	if err := emitDocument(cmd, doc); err != nil {
+		return err
+	}
+	if orchSummary {
+		orchestrator.WriteSummary(cmd.ErrOrStderr(), doc)
+	}
+	if doc.Outcome != orchestrator.OutcomeCompleted {
+		return fmt.Errorf("run outcome %s", doc.Outcome)
+	}
+	return nil
+}
+
+// emitDocument marshals the document and writes it to --out (and/or stdout).
+func emitDocument(cmd *cobra.Command, doc *orchestrator.Document) error {
+	b, err := doc.Marshal()
+	if err != nil {
+		return err
+	}
+	if orchOut != "" {
+		if err := os.WriteFile(orchOut, b, 0o644); err != nil {
+			return fmt.Errorf("write --out: %w", err)
+		}
+		return nil
+	}
+	_, err = cmd.OutOrStdout().Write(b)
+	return err
+}
+
+// engineRunner is the real WorkloadRunner: it maps a manifest entry to
+// blockstore.Opts, wires the matching backend, wraps the timed region in the
+// shared pprof envelope, and returns the measured metrics plus profile paths.
+func engineRunner(ctx context.Context, p orchestrator.WorkloadParams) (orchestrator.RunOutput, error) {
+	opts := bsbench.Opts{
+		Workload:   p.Workload,
+		Ops:        p.Ops,
+		BlockSize:  resolveBlockSize(p.Workload, p.BlockSize),
+		WorkingSet: p.WorkingSet,
+		Workers:    p.Workers,
+		Seed:       p.Seed,
+		Remote:     p.Remote,
+		Mix:        p.Mix,
+		ProfileDir: flagProfileDir,
+	}
+
+	tmpDir, err := os.MkdirTemp("", "bench-orch-")
+	if err != nil {
+		return orchestrator.RunOutput{}, fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	res, profDir, err := runOneWorkload(ctx, opts, tmpDir)
+	if err != nil {
+		return orchestrator.RunOutput{}, err
+	}
+
+	out := orchestrator.RunOutput{
+		Metrics: orchestrator.MetricsFromRun(res.Duration.Nanoseconds(), int64(res.Ops), res.Bytes),
+	}
+	if profDir != "" {
+		out.ProfilePaths = profileFiles(profDir, orchFullProfiles)
+	}
+	return out, nil
+}
+
+// runOneWorkload wires the backend for opts.Workload, captures the pprof
+// envelope around the timed region, and returns the Result plus the profile
+// directory. It mirrors runBlockstore's dispatch but returns metrics instead of
+// printing them so the orchestrator can collect across many workloads.
+func runOneWorkload(ctx context.Context, opts bsbench.Opts, tmpDir string) (bsbench.Result, string, error) {
+	switch opts.Workload {
+	case bsbench.WorkloadWalk, bsbench.WorkloadDelete:
+		local, closeFn, err := bsbench.NewLocalStore(tmpDir)
+		if err != nil {
+			return bsbench.Result{}, "", err
+		}
+		defer closeFn()
+		return capture(opts, func() (bsbench.Result, error) {
+			if opts.Workload == bsbench.WorkloadWalk {
+				return bsbench.RunWalk(ctx, local, opts)
+			}
+			return bsbench.RunDelete(ctx, local, opts)
+		})
+	case bsbench.WorkloadGC:
+		remoteStore, remoteClose, err := bsbench.SetupRemote(ctx, opts)
+		if err != nil {
+			return bsbench.Result{}, "", err
+		}
+		defer remoteClose()
+		return capture(opts, func() (bsbench.Result, error) {
+			return bsbench.RunGC(ctx, remoteStore, opts, bsbench.DefaultGCGarbage)
+		})
+	case bsbench.WorkloadRawS3Put:
+		remoteStore, remoteClose, err := bsbench.SetupRemote(ctx, opts)
+		if err != nil {
+			return bsbench.Result{}, "", err
+		}
+		defer remoteClose()
+		return capture(opts, func() (bsbench.Result, error) {
+			return bsbench.RunRawS3Put(ctx, remoteStore, opts)
+		})
+	default:
+		remoteStore, remoteClose, err := bsbench.SetupRemote(ctx, opts)
+		if err != nil {
+			return bsbench.Result{}, "", err
+		}
+		bs, engineClose, err := bsbench.NewEngine(tmpDir, remoteStore)
+		if err != nil {
+			remoteClose()
+			return bsbench.Result{}, "", err
+		}
+		defer engineClose()
+		return capture(opts, func() (bsbench.Result, error) {
+			switch {
+			case opts.Workload == bsbench.WorkloadMixedOpStorm:
+				return bsbench.RunStorm(ctx, bs, opts)
+			case bsbench.IsConcurrentWorkload(opts.Workload):
+				return bsbench.RunConcurrent(ctx, bs, opts)
+			default:
+				return bsbench.RunWorkload(ctx, bs, opts)
+			}
+		})
+	}
+}
+
+// capture wraps fn in a profile session and returns the result + profile dir.
+func capture(opts bsbench.Opts, fn func() (bsbench.Result, error)) (bsbench.Result, string, error) {
+	sess, err := startProfileSession(opts.ProfileDir, orchPhase, opts.Workload, orchFullProfiles)
+	if err != nil {
+		return bsbench.Result{}, "", err
+	}
+	defer func() { _ = sess.stop() }()
+	if err := sess.writeSeed(opts); err != nil {
+		return bsbench.Result{}, "", err
+	}
+	res, err := fn()
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
+	if err != nil {
+		return bsbench.Result{}, "", err
+	}
+	return res, sess.dir, nil
+}
+
+// profileFiles lists the pprof files a session writes into dir.
+func profileFiles(dir string, full bool) []string {
+	names := []string{"cpu.pprof", "heap.pprof", "goroutine.pprof"}
+	if full {
+		names = append(names, "mutex.pprof", "block.pprof")
+	}
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = filepath.Join(dir, n)
+	}
+	return out
+}
+
+func runCompare(cmd *cobra.Command) error {
+	if orchCompareBase == "" || orchCompareCand == "" {
+		return fmt.Errorf("compare mode needs both --compare-baseline and --compare-candidate")
+	}
+	base, err := decodeResultFile(orchCompareBase)
+	if err != nil {
+		return fmt.Errorf("baseline: %w", err)
+	}
+	cand, err := decodeResultFile(orchCompareCand)
+	if err != nil {
+		return fmt.Errorf("candidate: %w", err)
+	}
+	cmps := orchestrator.Compare(base, cand, orchCompareThresh)
+	orchestrator.WriteComparison(cmd.OutOrStdout(), cmps)
+	if orchestrator.HasRegression(cmps) {
+		return fmt.Errorf("regression detected beyond %.1f%% threshold", orchCompareThresh)
+	}
+	return nil
+}
+
+func decodeResultFile(path string) (*orchestrator.Document, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return orchestrator.DecodeDocument(f)
+}


### PR DESCRIPTION
## What

Adds `bench/orchestrator`: an orchestration layer on top of the existing `cmd/bench` + `bench/blockstore` harness (#680/#983/#1029). It runs a **manifest of workloads** through the existing blockstore primitives (it does **not** re-implement workloads) and emits a **versioned, machine-readable result document** so performance can be tracked over time and gated in CI.

Wired as the `orchestrate` subcommand of `cmd/bench`.

Closes #1011.

## Design

- **No new deps.** The `orchestrator` package is free of engine/pprof/runtime imports — the caller injects a `WorkloadRunner`. `cmd/bench` wires the real engine-backed runner (composes the blockstore engine + the shared pprof envelope); tests inject a fast in-memory fake.
- **Deterministic.** Run metadata (timestamp, run-id, git-sha) is injected, never read from `time.Now()`/env inside the run loop. `--git-sha` defaults to the build's embedded VCS revision (`runtime/debug.BuildInfo`); `--timestamp` defaults to now but can be pinned. Same inputs → byte-identical document.
- **Composable with `--phase`.** Profiles land in the same `<profile-dir>/blockstore/<phase>/` layout as the `blockstore` subcommand, so baseline vs post-fix captures sit side by side.

## Orchestrator surface

Entry point: `dfsbench orchestrate`.

```bash
# Default manifest (fast, in-process, memory remote — no S3/network):
dfsbench orchestrate --out result.json --summary

# Reproducible capture:
dfsbench orchestrate --out result.json \
  --timestamp 2026-06-02T12:00:00Z --run-id baseline-1 --git-sha "$(git rev-parse HEAD)"

# baseline / post-fix nesting:
dfsbench orchestrate --manifest my.json --phase baseline --profile-dir _profiles
dfsbench orchestrate --manifest my.json --phase post-fix --profile-dir _profiles

# compare two result JSONs (exits non-zero on a regression — CI-gateable):
dfsbench orchestrate --compare-baseline base.json --compare-candidate new.json --compare-threshold 10
```

### Manifest format

JSON list of workload entries (name-unique; the name keys the result). Omitted numeric fields fall back to the workload's defaults.

```json
{
  "workloads": [
    { "name": "seq-write", "workload": "sequential-write", "ops": 2000, "block_size": 65536, "working_set": 4, "seed": 1, "remote": "memory" },
    { "name": "storm-4w",  "workload": "mixed-ops-storm",  "ops": 4000, "workers": 4, "mix": "50,30,15,5", "seed": 1, "remote": "memory" }
  ]
}
```

Omit `--manifest` to use the built-in five-workload memory-remote snapshot.

## Result schema (schema_version 1)

```json
{
  "schema_version": 1,
  "run_id": "smoke-1",
  "timestamp": "2026-06-02T12:00:00Z",
  "git_sha": "459ebbae...",
  "system": { "os": "darwin", "arch": "arm64", "num_cpu": 10, "go_version": "go1.26.3", "hostname": "amaterasu" },
  "outcome": "completed",
  "workloads": {
    "seq-write": {
      "outcome": "completed",
      "params": { "name": "seq-write", "workload": "sequential-write", "ops": 2000, "block_size": 65536, "working_set": 4, "seed": 1, "remote": "memory" },
      "metrics": { "duration_ns": 28311948292, "ops": 2000, "ns_per_op": 14155974.146, "ops_per_sec": 70.64, "bytes": 131072000, "bytes_per_sec": 4629564.83 },
      "profile_paths": [".../seq-write-.../cpu.pprof", ".../heap.pprof", ".../goroutine.pprof"]
    }
  }
}
```

- `schema_version` (int) — read first; see version contract.
- `run_id`, `timestamp` (RFC3339 UTC), `git_sha` — injected metadata.
- `system` — host/runtime (so cross-machine results aren't silently compared).
- `outcome` ∈ `completed` | `partial` (some workload failed; survivors still present) | `aborted` (`abort_reason` carries cause).
- `workloads` — map keyed by entry name; each carries `outcome`, echoed `params`, `metrics` (omitted when not completed), `profile_paths`.

### Version contract

- `schema_version` is the first and only field a consumer must read before interpreting anything else; always present.
- Additive (minor) changes — new optional fields — do **not** bump it; consumers ignore unknown fields (Go `encoding/json` default).
- A **bump** = breaking change (field removed/renamed/units changed). A consumer that doesn't recognize the version must **refuse** to interpret numbers, not silently mis-read them.
- `orchestrator.DecodeDocument` / `CheckVersion` enforce this — compare mode and CI gates go through them.

## Verification

Real end-to-end run of the default 5-workload manifest produced valid versioned JSON (`outcome: completed`, all 5 workloads, cpu/heap/goroutine profiles each, auto-stamped git SHA + system info). Compare mode flagged a synthetic +50% seq-write regression and exited non-zero.

## Tests added (`go test -race ./bench/orchestrator/...`)

- Schema: round-trip marshal/unmarshal, `schema_version` always present, version-mismatch rejected, unknown-field tolerance, timestamp parse/UTC-normalize, zero-duration guard.
- Run loop (fake fast runner): happy path, failure→`partial` (continues), invalid manifest→`aborted`, nil runner, canceled context, determinism (byte-identical output).
- Manifest: default valid, JSON load, validation errors (empty/no-name/no-workload/zero-ops/dup-name).
- Compare: regression flag, within-threshold, missing-workload (union, never flagged), table rendering.

## Gates

`go build ./...`, `go vet ./bench/... ./cmd/bench/...`, `gofmt -l` clean, `go test -race ./bench/orchestrator/...` green.

## Follow-ups (explicit, not built here)

- **Per-area wrappers** — NFS / SMB / lock / runtime / metadata workload runners plug into the same manifest + `WorkloadRunner` + schema without a version bump.
- **Latency percentiles** — p50/p95/p99 are an additive `metrics` field (no bump) once a runner records per-op timings.
