### PR TITLE
test: coverage gap-fill for pkg/metadata/errors + pkg/controlplane

### DIFF
--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -1,0 +1,119 @@
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/api"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+func memConfig() *store.Config {
+	return &store.Config{
+		Type:   store.DatabaseTypeSQLite,
+		SQLite: store.SQLiteConfig{Path: ":memory:"},
+	}
+}
+
+func TestNew_ValidationErrors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil options", func(t *testing.T) {
+		if _, err := New(ctx, nil); err == nil {
+			t.Error("expected error for nil options")
+		}
+	})
+
+	t.Run("nil database config", func(t *testing.T) {
+		if _, err := New(ctx, &Options{}); err == nil {
+			t.Error("expected error for nil database config")
+		}
+	})
+
+	t.Run("invalid database type", func(t *testing.T) {
+		_, err := New(ctx, &Options{Database: &store.Config{Type: "bogus"}})
+		if err == nil {
+			t.Error("expected error for invalid database type")
+		}
+	})
+}
+
+// Happy path without the API server: store + runtime wired, API nil.
+func TestNew_NoAPIServer(t *testing.T) {
+	cp, err := New(context.Background(), &Options{Database: memConfig()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer cp.Close()
+
+	if cp.Store() == nil {
+		t.Error("Store() is nil")
+	}
+	if cp.Runtime() == nil {
+		t.Error("Runtime() is nil")
+	}
+	if cp.APIServer() != nil {
+		t.Error("APIServer() should be nil when API not configured")
+	}
+	if cp.IdentityStore() == nil {
+		t.Error("IdentityStore() is nil")
+	}
+}
+
+// With an API config present, New constructs the API server and applies the
+// default restore timeout when RestoreHTTPTimeout is zero.
+func TestNew_WithAPIServer(t *testing.T) {
+	apiCfg := &api.APIConfig{}
+	apiCfg.ApplyDefaults()
+	apiCfg.Port = 0 // ephemeral / unbound — New does not Start the server
+	apiCfg.JWT.Secret = "test-secret-at-least-32-characters-long"
+
+	cp, err := New(context.Background(), &Options{
+		Database: memConfig(),
+		API:      apiCfg,
+		// RestoreHTTPTimeout left zero -> DefaultRestoreHTTPTimeout applied
+	})
+	if err != nil {
+		t.Fatalf("New with API: %v", err)
+	}
+	defer cp.Close()
+
+	if cp.APIServer() == nil {
+		t.Error("APIServer() should be non-nil when API is configured")
+	}
+}
+
+func TestEnsureAdminUser(t *testing.T) {
+	cp, err := New(context.Background(), &Options{Database: memConfig()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer cp.Close()
+
+	ctx := context.Background()
+	pw, err := cp.EnsureAdminUser(ctx)
+	if err != nil {
+		t.Fatalf("EnsureAdminUser: %v", err)
+	}
+	if pw == "" {
+		t.Error("expected a generated password on first creation")
+	}
+	// Idempotent: second call returns empty password (user already exists).
+	pw2, err := cp.EnsureAdminUser(ctx)
+	if err != nil {
+		t.Fatalf("EnsureAdminUser (2nd): %v", err)
+	}
+	if pw2 != "" {
+		t.Errorf("second EnsureAdminUser returned password %q, want empty", pw2)
+	}
+}
+
+func TestClose(t *testing.T) {
+	cp, err := New(context.Background(), &Options{Database: memConfig()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := cp.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -44,7 +44,11 @@ func TestNew_NoAPIServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer cp.Close()
+	t.Cleanup(func() {
+		if err := cp.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
 
 	if cp.Store() == nil {
 		t.Error("Store() is nil")
@@ -76,7 +80,11 @@ func TestNew_WithAPIServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New with API: %v", err)
 	}
-	defer cp.Close()
+	t.Cleanup(func() {
+		if err := cp.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
 
 	if cp.APIServer() == nil {
 		t.Error("APIServer() should be non-nil when API is configured")
@@ -88,7 +96,11 @@ func TestEnsureAdminUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer cp.Close()
+	t.Cleanup(func() {
+		if err := cp.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
 
 	ctx := context.Background()
 	pw, err := cp.EnsureAdminUser(ctx)

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -2,11 +2,28 @@ package controlplane
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/api"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
+
+// guardPprofGlobals snapshots the process-global pprof sampling knobs and
+// restores them after the test. api.NewServer (invoked by New when an API
+// config is present) calls runtime.SetMutexProfileFraction /
+// runtime.SetBlockProfileRate unconditionally; without this guard, constructing
+// the server here would leak that mutation into other packages' tests when
+// `go test ./...` runs them in the same process.
+func guardPprofGlobals(t *testing.T) {
+	t.Helper()
+	prevMutex := runtime.SetMutexProfileFraction(-1) // -1 reads without changing
+	runtime.SetMutexProfileFraction(prevMutex)       // restore the read-back value
+	t.Cleanup(func() {
+		runtime.SetMutexProfileFraction(prevMutex)
+		runtime.SetBlockProfileRate(0)
+	})
+}
 
 func memConfig() *store.Config {
 	return &store.Config{
@@ -67,6 +84,8 @@ func TestNew_NoAPIServer(t *testing.T) {
 // With an API config present, New constructs the API server and applies the
 // default restore timeout when RestoreHTTPTimeout is zero.
 func TestNew_WithAPIServer(t *testing.T) {
+	guardPprofGlobals(t)
+
 	apiCfg := &api.APIConfig{}
 	apiCfg.ApplyDefaults()
 	apiCfg.Port = 0 // ephemeral / unbound — New does not Start the server

--- a/pkg/controlplane/runtime/identity/service_test.go
+++ b/pkg/controlplane/runtime/identity/service_test.go
@@ -1,0 +1,157 @@
+package identity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// fakeProvider serves a single canned ShareInfo (or an error) for the share
+// named in want. Any other share name yields a not-found error so the
+// "share missing" branch can be exercised.
+type fakeProvider struct {
+	want string
+	info *ShareInfo
+	err  error
+}
+
+func (f fakeProvider) GetShareIdentityInfo(shareName string) (*ShareInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if shareName != f.want {
+		return nil, errors.New("no such share")
+	}
+	return f.info, nil
+}
+
+func u32(v uint32) *uint32 { return &v }
+
+const (
+	anonUID = uint32(65534)
+	anonGID = uint32(65533)
+)
+
+func anonInfo(mode models.SquashMode) *ShareInfo {
+	return &ShareInfo{Squash: mode, AnonymousUID: anonUID, AnonymousGID: anonGID}
+}
+
+func TestApplyIdentityMapping_ShareNotFound(t *testing.T) {
+	svc := New()
+	prov := fakeProvider{want: "exists", info: anonInfo(models.SquashNone)}
+	_, err := svc.ApplyIdentityMapping("missing", &metadata.Identity{UID: u32(1000)}, prov)
+	if err == nil {
+		t.Fatal("expected error for missing share")
+	}
+}
+
+// AUTH_NULL (nil UID) is always squashed to anonymous regardless of mode.
+func TestApplyIdentityMapping_NilUIDAlwaysAnonymous(t *testing.T) {
+	svc := New()
+	for _, mode := range []models.SquashMode{
+		models.SquashNone, models.SquashRootToAdmin, models.SquashRootToGuest,
+		models.SquashAllToAdmin, models.SquashAllToGuest, "",
+	} {
+		in := &metadata.Identity{UID: nil, GID: nil, Username: "orig"}
+		out, err := svc.ApplyIdentityMapping("s", in, fakeProvider{want: "s", info: anonInfo(mode)})
+		if err != nil {
+			t.Fatalf("mode %q: unexpected error: %v", mode, err)
+		}
+		if out.UID == nil || *out.UID != anonUID || out.GID == nil || *out.GID != anonGID {
+			t.Errorf("mode %q: nil UID not squashed to anonymous: %+v", mode, out)
+		}
+		if out.Username != "anonymous(65534)" {
+			t.Errorf("mode %q: username = %q", mode, out.Username)
+		}
+	}
+}
+
+func TestApplyIdentityMapping_SquashModes(t *testing.T) {
+	svc := New()
+
+	cases := []struct {
+		name     string
+		mode     models.SquashMode
+		inUID    uint32
+		wantUID  uint32
+		wantUser string
+	}{
+		// No-mapping modes leave non-root identities untouched.
+		{"none/nonroot", models.SquashNone, 1000, 1000, "user"},
+		{"empty/nonroot", "", 1000, 1000, "user"},
+		{"root_to_admin/nonroot", models.SquashRootToAdmin, 1000, 1000, "user"},
+		{"root_to_admin/root", models.SquashRootToAdmin, 0, 0, "user"},
+		// root_to_guest only squashes UID 0.
+		{"root_to_guest/root", models.SquashRootToGuest, 0, anonUID, "anonymous(65534)"},
+		{"root_to_guest/nonroot", models.SquashRootToGuest, 1000, 1000, "user"},
+		// all_to_admin maps every UID to root.
+		{"all_to_admin/nonroot", models.SquashAllToAdmin, 1000, 0, "root"},
+		{"all_to_admin/root", models.SquashAllToAdmin, 0, 0, "root"},
+		// all_to_guest maps every UID to anonymous.
+		{"all_to_guest/nonroot", models.SquashAllToGuest, 1000, anonUID, "anonymous(65534)"},
+		{"all_to_guest/root", models.SquashAllToGuest, 0, anonUID, "anonymous(65534)"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := &metadata.Identity{UID: u32(c.inUID), GID: u32(c.inUID), Username: "user"}
+			out, err := svc.ApplyIdentityMapping("s", in, fakeProvider{want: "s", info: anonInfo(c.mode)})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out.UID == nil || *out.UID != c.wantUID {
+				t.Errorf("UID = %v, want %d", out.UID, c.wantUID)
+			}
+			if out.Username != c.wantUser {
+				t.Errorf("Username = %q, want %q", out.Username, c.wantUser)
+			}
+		})
+	}
+}
+
+// The returned identity must be a distinct copy; mutating it must not touch the
+// caller's input (the mapping builds a fresh effective identity).
+func TestApplyIdentityMapping_DoesNotMutateInput(t *testing.T) {
+	svc := New()
+	in := &metadata.Identity{UID: u32(0), GID: u32(0), Username: "root-user"}
+	out, err := svc.ApplyIdentityMapping("s", in, fakeProvider{want: "s", info: anonInfo(models.SquashAllToGuest)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.UID == nil || *in.UID != 0 || in.Username != "root-user" {
+		t.Errorf("input identity was mutated: %+v", in)
+	}
+	if out.UID == nil || *out.UID != anonUID {
+		t.Errorf("output not squashed: %+v", out)
+	}
+}
+
+func TestApplyAnonymousIdentity(t *testing.T) {
+	id := &metadata.Identity{UID: u32(5), GID: u32(5), GIDs: []uint32{5, 6}, Username: "x"}
+	ApplyAnonymousIdentity(id, 1001, 1002)
+	if *id.UID != 1001 || *id.GID != 1002 {
+		t.Errorf("uid/gid = %d/%d, want 1001/1002", *id.UID, *id.GID)
+	}
+	if len(id.GIDs) != 1 || id.GIDs[0] != 1002 {
+		t.Errorf("GIDs = %v, want [1002]", id.GIDs)
+	}
+	if id.Username != "anonymous(1001)" {
+		t.Errorf("Username = %q", id.Username)
+	}
+}
+
+func TestApplyRootIdentity(t *testing.T) {
+	id := &metadata.Identity{UID: u32(5), GID: u32(5), GIDs: []uint32{5, 6}, Username: "x"}
+	ApplyRootIdentity(id)
+	if *id.UID != 0 || *id.GID != 0 {
+		t.Errorf("uid/gid = %d/%d, want 0/0", *id.UID, *id.GID)
+	}
+	if len(id.GIDs) != 1 || id.GIDs[0] != 0 {
+		t.Errorf("GIDs = %v, want [0]", id.GIDs)
+	}
+	if id.Username != "root" {
+		t.Errorf("Username = %q, want root", id.Username)
+	}
+}

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -1,0 +1,300 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---- fakes -----------------------------------------------------------------
+
+type fakeSettings struct {
+	loadErr                  error
+	loaded, started, stopped bool
+}
+
+func (f *fakeSettings) LoadInitial(ctx context.Context) error { f.loaded = true; return f.loadErr }
+func (f *fakeSettings) Start(ctx context.Context)             { f.started = true }
+func (f *fakeSettings) Stop()                                 { f.stopped = true }
+
+type fakeAdapters struct {
+	loadErr         error
+	loaded, stopped bool
+	stopErr         error
+}
+
+func (f *fakeAdapters) LoadAdaptersFromStore(ctx context.Context) error {
+	f.loaded = true
+	return f.loadErr
+}
+
+func (f *fakeAdapters) StopAllAdapters() error { f.stopped = true; return f.stopErr }
+
+type fakeFlusher struct {
+	called bool
+	n      int
+	err    error
+}
+
+func (f *fakeFlusher) FlushAllPendingWritesForShutdown(timeout time.Duration) (int, error) {
+	f.called = true
+	return f.n, f.err
+}
+
+type fakeStoreCloser struct{ closed bool }
+
+func (f *fakeStoreCloser) CloseMetadataStores() { f.closed = true }
+
+type fakeSIDStore struct {
+	mu     sync.Mutex
+	vals   map[string]string
+	getErr error
+	setHit bool
+}
+
+func (f *fakeSIDStore) GetSetting(ctx context.Context, key string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.vals[key], nil
+}
+
+func (f *fakeSIDStore) SetSetting(ctx context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setHit = true
+	if f.vals == nil {
+		f.vals = map[string]string{}
+	}
+	f.vals[key] = value
+	return nil
+}
+
+type fakeDrainer struct{ drained bool }
+
+func (f *fakeDrainer) ShutdownSnapshots(ctx context.Context) { f.drained = true }
+
+type fakeAPIServer struct {
+	port     int
+	stopped  bool
+	startErr error
+}
+
+func (f *fakeAPIServer) Start(ctx context.Context) error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	// Block until shutdown, mirroring a real HTTP server's Start.
+	<-ctx.Done()
+	return nil
+}
+
+func (f *fakeAPIServer) Stop(ctx context.Context) error { f.stopped = true; return nil }
+func (f *fakeAPIServer) Port() int                      { return f.port }
+
+// ---- tests -----------------------------------------------------------------
+
+func TestNewDefaultsTimeout(t *testing.T) {
+	if got := New(0).shutdownTimeout; got != DefaultShutdownTimeout {
+		t.Errorf("zero timeout = %v, want default %v", got, DefaultShutdownTimeout)
+	}
+	if got := New(5 * time.Second).shutdownTimeout; got != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", got)
+	}
+}
+
+func TestSetShutdownTimeout(t *testing.T) {
+	s := New(time.Second)
+	s.SetShutdownTimeout(2 * time.Second)
+	if s.shutdownTimeout != 2*time.Second {
+		t.Errorf("got %v, want 2s", s.shutdownTimeout)
+	}
+	s.SetShutdownTimeout(0)
+	if s.shutdownTimeout != DefaultShutdownTimeout {
+		t.Errorf("zero should reset to default, got %v", s.shutdownTimeout)
+	}
+}
+
+func TestSIDMapperNilBeforeServe(t *testing.T) {
+	if New(0).SIDMapper() != nil {
+		t.Error("SIDMapper should be nil before Serve")
+	}
+}
+
+func TestSetAPIServerPanicsAfterServe(t *testing.T) {
+	s := New(time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Serve returns immediately on cancelled ctx
+	_ = s.Serve(ctx, nil, &fakeAdapters{}, nil, nil, nil, nil)
+
+	defer func() {
+		if recover() == nil {
+			t.Error("SetAPIServer after Serve should panic")
+		}
+	}()
+	s.SetAPIServer(&fakeAPIServer{})
+}
+
+// Serve must run shutdown in order and propagate ctx.Err() when the context is
+// cancelled. With a nil SID store, an ephemeral SID is generated.
+func TestServeGracefulShutdownOnCancel(t *testing.T) {
+	s := New(time.Second)
+	settings := &fakeSettings{}
+	adapters := &fakeAdapters{}
+	flusher := &fakeFlusher{n: 3}
+	closer := &fakeStoreCloser{}
+	drainer := &fakeDrainer{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.Serve(ctx, settings, adapters, flusher, closer, nil, drainer)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if s.SIDMapper() == nil {
+		t.Error("ephemeral SID mapper not generated for nil store")
+	}
+	if !settings.loaded || !settings.started || !settings.stopped {
+		t.Errorf("settings lifecycle incomplete: %+v", settings)
+	}
+	if !adapters.loaded || !adapters.stopped {
+		t.Errorf("adapters lifecycle incomplete: %+v", adapters)
+	}
+	if !drainer.drained {
+		t.Error("snapshot drainer not invoked")
+	}
+	if !flusher.called {
+		t.Error("flusher not invoked")
+	}
+	if !closer.closed {
+		t.Error("metadata stores not closed")
+	}
+}
+
+// A failure loading adapters aborts Serve before entering the select loop and
+// is returned wrapped.
+func TestServeAdapterLoadFailure(t *testing.T) {
+	s := New(time.Second)
+	adapters := &fakeAdapters{loadErr: errors.New("boom")}
+	closer := &fakeStoreCloser{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.Serve(ctx, nil, adapters, nil, closer, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from adapter load failure")
+	}
+	// shutdown() is NOT reached on early adapter-load return.
+	if closer.closed {
+		t.Error("metadata stores should not be closed on early adapter-load failure")
+	}
+}
+
+// When the API server's Start fails, Serve shuts down and returns the wrapped
+// API error rather than ctx.Err().
+func TestServeAPIServerFailureTriggersShutdown(t *testing.T) {
+	s := New(time.Second)
+	api := &fakeAPIServer{port: 8080, startErr: errors.New("bind failed")}
+	s.SetAPIServer(api)
+
+	closer := &fakeStoreCloser{}
+	// Long-lived ctx so the only way out is the API error path.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := s.Serve(ctx, nil, &fakeAdapters{}, nil, closer, nil, nil)
+	if err == nil || !errors.Is(err, api.startErr) {
+		t.Errorf("err = %v, want wrapped %v", err, api.startErr)
+	}
+	if !closer.closed {
+		t.Error("shutdown should have closed metadata stores")
+	}
+	if !api.stopped {
+		t.Error("API server Stop not called during shutdown")
+	}
+}
+
+// Serve uses sync.Once: a second call is a no-op and returns nil.
+func TestServeOnlyRunsOnce(t *testing.T) {
+	s := New(time.Second)
+	adapters := &fakeAdapters{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = s.Serve(ctx, nil, adapters, nil, nil, nil, nil)
+
+	second := &fakeAdapters{}
+	if err := s.Serve(ctx, nil, second, nil, nil, nil, nil); err != nil {
+		t.Errorf("second Serve = %v, want nil", err)
+	}
+	if second.loaded {
+		t.Error("second Serve should not have loaded adapters")
+	}
+}
+
+// initMachineSID loads a previously persisted SID rather than generating a new
+// one when a valid value is stored.
+func TestInitMachineSIDLoadsStored(t *testing.T) {
+	gen := New(0)
+	gen.initMachineSID(context.Background(), nil)
+	stored := gen.SIDMapper().MachineSIDString()
+
+	s := New(0)
+	store := &fakeSIDStore{vals: map[string]string{"machine_sid": stored}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Fatal("SID mapper nil after load")
+	}
+	if got := s.SIDMapper().MachineSIDString(); got != stored {
+		t.Errorf("loaded SID = %q, want %q", got, stored)
+	}
+	if store.setHit {
+		t.Error("SetSetting should not be called when a valid SID is already stored")
+	}
+}
+
+// On first boot (empty store) a SID is generated and persisted.
+func TestInitMachineSIDFirstBootPersists(t *testing.T) {
+	s := New(0)
+	store := &fakeSIDStore{vals: map[string]string{}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Fatal("SID mapper nil")
+	}
+	if !store.setHit {
+		t.Error("first boot should persist generated SID")
+	}
+	if store.vals["machine_sid"] != s.SIDMapper().MachineSIDString() {
+		t.Error("persisted SID does not match generated mapper")
+	}
+}
+
+// A corrupt stored SID is discarded and a fresh one generated + persisted.
+func TestInitMachineSIDInvalidStoredRegenerates(t *testing.T) {
+	s := New(0)
+	store := &fakeSIDStore{vals: map[string]string{"machine_sid": "not-a-valid-sid"}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Fatal("SID mapper nil after invalid stored value")
+	}
+	if !store.setHit {
+		t.Error("invalid stored SID should trigger regenerate + persist")
+	}
+	if store.vals["machine_sid"] == "not-a-valid-sid" {
+		t.Error("invalid SID was not replaced")
+	}
+}
+
+// A read error from the store is tolerated: a SID is still generated.
+func TestInitMachineSIDReadErrorGenerates(t *testing.T) {
+	s := New(0)
+	store := &fakeSIDStore{getErr: errors.New("db down")}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Error("SID mapper should still be generated despite read error")
+	}
+}

--- a/pkg/controlplane/runtime/mounts/service_test.go
+++ b/pkg/controlplane/runtime/mounts/service_test.go
@@ -1,0 +1,154 @@
+package mounts
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRecordAndCount(t *testing.T) {
+	mt := NewTracker()
+	if mt.Count() != 0 {
+		t.Fatalf("new tracker count = %d, want 0", mt.Count())
+	}
+	mt.Record("10.0.0.1", "nfs", "share1", "path-data")
+	mt.Record("10.0.0.2", "smb", "share1", nil)
+	if mt.Count() != 2 {
+		t.Errorf("count = %d, want 2", mt.Count())
+	}
+}
+
+// Re-recording the same protocol:client:share key overwrites rather than
+// duplicating, so the count stays at one.
+func TestRecordSameKeyOverwrites(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("10.0.0.1", "nfs", "share1", "v1")
+	mt.Record("10.0.0.1", "nfs", "share1", "v2")
+	if mt.Count() != 1 {
+		t.Errorf("count = %d, want 1 (overwrite)", mt.Count())
+	}
+	got := mt.List()
+	if len(got) != 1 || got[0].AdapterData != "v2" {
+		t.Errorf("AdapterData = %v, want overwritten v2", got)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("10.0.0.1", "nfs", "share1", nil)
+
+	if !mt.Remove("10.0.0.1", "nfs", "share1") {
+		t.Error("Remove of existing mount returned false")
+	}
+	if mt.Count() != 0 {
+		t.Errorf("count after remove = %d, want 0", mt.Count())
+	}
+	// Removing again (or a non-existent key) returns false.
+	if mt.Remove("10.0.0.1", "nfs", "share1") {
+		t.Error("Remove of missing mount returned true")
+	}
+}
+
+func TestRemoveByClient(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("10.0.0.1", "nfs", "share1", nil)
+	mt.Record("10.0.0.1", "smb", "share2", nil)
+	mt.Record("10.0.0.2", "nfs", "share1", nil)
+
+	if !mt.RemoveByClient("10.0.0.1") {
+		t.Error("RemoveByClient returned false for present client")
+	}
+	if mt.Count() != 1 {
+		t.Errorf("count = %d, want 1 (only 10.0.0.2 remains)", mt.Count())
+	}
+	if mt.RemoveByClient("10.0.0.99") {
+		t.Error("RemoveByClient returned true for absent client")
+	}
+}
+
+func TestRemoveAllByProtocol(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("a", "nfs", "s1", nil)
+	mt.Record("b", "nfs", "s2", nil)
+	mt.Record("c", "smb", "s1", nil)
+
+	if n := mt.RemoveAllByProtocol("nfs"); n != 2 {
+		t.Errorf("RemoveAllByProtocol(nfs) = %d, want 2", n)
+	}
+	if mt.Count() != 1 {
+		t.Errorf("count = %d, want 1", mt.Count())
+	}
+	if n := mt.RemoveAllByProtocol("nfs"); n != 0 {
+		t.Errorf("second RemoveAllByProtocol(nfs) = %d, want 0", n)
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("a", "nfs", "s1", nil)
+	mt.Record("b", "smb", "s2", nil)
+	if n := mt.RemoveAll(); n != 2 {
+		t.Errorf("RemoveAll = %d, want 2", n)
+	}
+	if mt.Count() != 0 {
+		t.Errorf("count = %d, want 0", mt.Count())
+	}
+}
+
+func TestListAndListByProtocol(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("a", "nfs", "s1", nil)
+	mt.Record("b", "smb", "s2", nil)
+	mt.Record("c", "nfs", "s3", nil)
+
+	if got := mt.List(); len(got) != 3 {
+		t.Errorf("List len = %d, want 3", len(got))
+	}
+	nfs := mt.ListByProtocol("nfs")
+	if len(nfs) != 2 {
+		t.Errorf("ListByProtocol(nfs) len = %d, want 2", len(nfs))
+	}
+	for _, m := range nfs {
+		if m.Protocol != "nfs" {
+			t.Errorf("ListByProtocol(nfs) returned %q", m.Protocol)
+		}
+	}
+	if got := mt.ListByProtocol("none"); len(got) != 0 {
+		t.Errorf("ListByProtocol(none) len = %d, want 0", len(got))
+	}
+}
+
+// List must return copies: mutating a returned record must not affect the
+// tracker's internal state.
+func TestListReturnsCopies(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("a", "nfs", "s1", "orig")
+
+	got := mt.List()
+	got[0].ShareName = "tampered"
+	got[0].AdapterData = "tampered"
+
+	fresh := mt.List()
+	if fresh[0].ShareName != "s1" || fresh[0].AdapterData != "orig" {
+		t.Errorf("internal state mutated via returned copy: %+v", fresh[0])
+	}
+}
+
+// The tracker is documented thread-safe; run it under -race with concurrent
+// writers, removers, and readers to validate the locking.
+func TestTrackerConcurrent(t *testing.T) {
+	mt := NewTracker()
+	var wg sync.WaitGroup
+	const n = 50
+
+	for i := 0; i < n; i++ {
+		wg.Add(3)
+		client := string(rune('A' + (i % 26)))
+		go func() { defer wg.Done(); mt.Record(client, "nfs", "s", nil) }()
+		go func() { defer wg.Done(); _ = mt.List() }()
+		go func() { defer wg.Done(); mt.Remove(client, "nfs", "s") }()
+	}
+	wg.Wait()
+	// No assertion on final count (racy by construction); the point is the
+	// race detector finding no data races.
+	_ = mt.Count()
+}

--- a/pkg/controlplane/store/helpers_test.go
+++ b/pkg/controlplane/store/helpers_test.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// widget is a throwaway model used to exercise the generic GORM helpers without
+// coupling the test to the real schema / migrations.
+type widget struct {
+	ID   string `gorm:"primaryKey"`
+	Name string `gorm:"uniqueIndex"`
+	Kind string
+}
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&widget{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestDedup(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"no dups", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"dups preserve order", []string{"b", "a", "b", "c", "a"}, []string{"b", "a", "c"}},
+		{"all same", []string{"x", "x", "x"}, []string{"x"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := dedup(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(c.want), got)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("at %d: %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConvertNotFoundError(t *testing.T) {
+	sentinel := errors.New("widget not found")
+
+	if got := convertNotFoundError(gorm.ErrRecordNotFound, sentinel); !errors.Is(got, sentinel) {
+		t.Errorf("gorm.ErrRecordNotFound not converted to sentinel: %v", got)
+	}
+	// Wrapped gorm.ErrRecordNotFound must still convert (errors.Is unwraps).
+	wrapped := errors.Join(errors.New("ctx"), gorm.ErrRecordNotFound)
+	if got := convertNotFoundError(wrapped, sentinel); !errors.Is(got, sentinel) {
+		t.Errorf("wrapped ErrRecordNotFound not converted: %v", got)
+	}
+	// Any other error passes through unchanged.
+	other := errors.New("disk error")
+	if got := convertNotFoundError(other, sentinel); got != other {
+		t.Errorf("non-notfound error mutated: %v", got)
+	}
+}
+
+func TestIsUniqueConstraintError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sqlite", errors.New("UNIQUE constraint failed: widgets.name"), true},
+		{"postgres", errors.New(`duplicate key value violates unique constraint "widgets_name_key"`), true},
+		{"unrelated", errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isUniqueConstraintError(c.err); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestGetByField(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	db.Create(&widget{ID: "1", Name: "alpha", Kind: "k"})
+
+	notFound := errors.New("nope")
+
+	got, err := getByField[widget](db, ctx, "name", "alpha", notFound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "1" {
+		t.Errorf("ID = %q, want 1", got.ID)
+	}
+
+	// Missing row maps to the supplied sentinel.
+	_, err = getByField[widget](db, ctx, "name", "missing", notFound)
+	if !errors.Is(err, notFound) {
+		t.Errorf("missing row err = %v, want sentinel", err)
+	}
+}
+
+func TestListAll(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Empty table returns a non-nil empty slice.
+	got, err := listAll[widget](db, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Error("listAll returned nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+
+	db.Create(&widget{ID: "1", Name: "a"})
+	db.Create(&widget{ID: "2", Name: "b"})
+	got, err = listAll[widget](db, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}
+
+func TestCreateWithID(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	dupErr := errors.New("dup widget")
+	setID := func(w *widget, id string) { w.ID = id }
+
+	t.Run("generates id when empty", func(t *testing.T) {
+		w := &widget{Name: "gen"}
+		id, err := createWithID[widget](db, ctx, w, setID, "", dupErr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == "" {
+			t.Error("expected generated id")
+		}
+		if w.ID != id {
+			t.Errorf("idSetter not applied: w.ID=%q id=%q", w.ID, id)
+		}
+	})
+
+	t.Run("honors provided id", func(t *testing.T) {
+		w := &widget{Name: "fixed"}
+		id, err := createWithID[widget](db, ctx, w, setID, "fixed-id", dupErr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != "fixed-id" {
+			t.Errorf("id = %q, want fixed-id", id)
+		}
+	})
+
+	t.Run("unique violation maps to dupErr", func(t *testing.T) {
+		// Fresh DB so prior subtests' rows can't interfere with the
+		// uniqueness assertion.
+		db := newTestDB(t)
+		_, err := createWithID[widget](db, ctx, &widget{Name: "clash"}, setID, "a", dupErr)
+		if err != nil {
+			t.Fatalf("first create failed: %v", err)
+		}
+		// Same unique Name -> constraint violation -> dupErr.
+		_, err = createWithID[widget](db, ctx, &widget{Name: "clash"}, setID, "b", dupErr)
+		if !errors.Is(err, dupErr) {
+			t.Errorf("err = %v, want dupErr", err)
+		}
+	})
+}
+
+func TestDeleteByField(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	notFound := errors.New("nope")
+
+	db.Create(&widget{ID: "1", Name: "a", Kind: "x"})
+	db.Create(&widget{ID: "2", Name: "b", Kind: "x"})
+	db.Create(&widget{ID: "3", Name: "c", Kind: "y"})
+
+	// Deletes both kind=x rows.
+	if err := deleteByField[widget](db, ctx, "kind", "x", notFound); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	var remaining []widget
+	db.Find(&remaining)
+	if len(remaining) != 1 || remaining[0].Kind != "y" {
+		t.Errorf("after delete, remaining = %+v", remaining)
+	}
+
+	// No matching rows -> notFound.
+	if err := deleteByField[widget](db, ctx, "kind", "z", notFound); !errors.Is(err, notFound) {
+		t.Errorf("delete of absent rows = %v, want notFound", err)
+	}
+}

--- a/pkg/controlplane/store/helpers_test.go
+++ b/pkg/controlplane/store/helpers_test.go
@@ -32,6 +32,16 @@ func newTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
+// mustCreate inserts a setup row and fails fast on error so a broken
+// fixture surfaces at its source rather than as a confusing downstream
+// assertion failure.
+func mustCreate(t *testing.T, db *gorm.DB, w *widget) {
+	t.Helper()
+	if err := db.Create(w).Error; err != nil {
+		t.Fatalf("setup create %+v: %v", w, err)
+	}
+}
+
 func TestDedup(t *testing.T) {
 	cases := []struct {
 		name string
@@ -99,7 +109,7 @@ func TestIsUniqueConstraintError(t *testing.T) {
 func TestGetByField(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
-	db.Create(&widget{ID: "1", Name: "alpha", Kind: "k"})
+	mustCreate(t, db, &widget{ID: "1", Name: "alpha", Kind: "k"})
 
 	notFound := errors.New("nope")
 
@@ -134,8 +144,8 @@ func TestListAll(t *testing.T) {
 		t.Errorf("len = %d, want 0", len(got))
 	}
 
-	db.Create(&widget{ID: "1", Name: "a"})
-	db.Create(&widget{ID: "2", Name: "b"})
+	mustCreate(t, db, &widget{ID: "1", Name: "a"})
+	mustCreate(t, db, &widget{ID: "2", Name: "b"})
 	got, err = listAll[widget](db, ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -166,13 +176,19 @@ func TestCreateWithID(t *testing.T) {
 	})
 
 	t.Run("honors provided id", func(t *testing.T) {
-		w := &widget{Name: "fixed"}
+		// Mirror real callers: when currentID is supplied, the entity already
+		// carries that ID, so createWithID must not overwrite it nor insert an
+		// empty primary key.
+		w := &widget{ID: "fixed-id", Name: "fixed"}
 		id, err := createWithID[widget](db, ctx, w, setID, "fixed-id", dupErr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if id != "fixed-id" {
 			t.Errorf("id = %q, want fixed-id", id)
+		}
+		if w.ID != "fixed-id" {
+			t.Errorf("entity ID overwritten to %q, want fixed-id", w.ID)
 		}
 	})
 
@@ -197,16 +213,18 @@ func TestDeleteByField(t *testing.T) {
 	ctx := context.Background()
 	notFound := errors.New("nope")
 
-	db.Create(&widget{ID: "1", Name: "a", Kind: "x"})
-	db.Create(&widget{ID: "2", Name: "b", Kind: "x"})
-	db.Create(&widget{ID: "3", Name: "c", Kind: "y"})
+	mustCreate(t, db, &widget{ID: "1", Name: "a", Kind: "x"})
+	mustCreate(t, db, &widget{ID: "2", Name: "b", Kind: "x"})
+	mustCreate(t, db, &widget{ID: "3", Name: "c", Kind: "y"})
 
 	// Deletes both kind=x rows.
 	if err := deleteByField[widget](db, ctx, "kind", "x", notFound); err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
 	var remaining []widget
-	db.Find(&remaining)
+	if err := db.Find(&remaining).Error; err != nil {
+		t.Fatalf("find remaining: %v", err)
+	}
 	if len(remaining) != 1 || remaining[0].Kind != "y" {
 		t.Errorf("after delete, remaining = %+v", remaining)
 	}

--- a/pkg/metadata/errors/errors_test.go
+++ b/pkg/metadata/errors/errors_test.go
@@ -1,0 +1,227 @@
+package errors
+
+import (
+	goerrors "errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorCodeString(t *testing.T) {
+	cases := []struct {
+		code ErrorCode
+		want string
+	}{
+		{ErrNotFound, "NotFound"},
+		{ErrAccessDenied, "AccessDenied"},
+		{ErrAuthRequired, "AuthRequired"},
+		{ErrPermissionDenied, "PermissionDenied"},
+		{ErrAlreadyExists, "AlreadyExists"},
+		{ErrNotEmpty, "NotEmpty"},
+		{ErrIsDirectory, "IsDirectory"},
+		{ErrNotDirectory, "NotDirectory"},
+		{ErrInvalidArgument, "InvalidArgument"},
+		{ErrIOError, "IOError"},
+		{ErrNoSpace, "NoSpace"},
+		{ErrQuotaExceeded, "QuotaExceeded"},
+		{ErrReadOnly, "ReadOnly"},
+		{ErrNotSupported, "NotSupported"},
+		{ErrInvalidHandle, "InvalidHandle"},
+		{ErrStaleHandle, "StaleHandle"},
+		{ErrLocked, "Locked"},
+		{ErrLockNotFound, "LockNotFound"},
+		{ErrPrivilegeRequired, "PrivilegeRequired"},
+		{ErrNameTooLong, "NameTooLong"},
+		{ErrDeadlock, "Deadlock"},
+		{ErrGracePeriod, "GracePeriod"},
+		{ErrLockLimitExceeded, "LockLimitExceeded"},
+		{ErrLockConflict, "LockConflict"},
+		{ErrConnectionLimitReached, "ConnectionLimitReached"},
+		{ErrConflict, "Conflict"},
+	}
+	for _, c := range cases {
+		if got := c.code.String(); got != c.want {
+			t.Errorf("ErrorCode(%d).String() = %q, want %q", c.code, got, c.want)
+		}
+	}
+}
+
+func TestErrorCodeStringUnknown(t *testing.T) {
+	// Zero value and an out-of-range code should both render as Unknown(N).
+	if got := ErrorCode(0).String(); got != "Unknown(0)" {
+		t.Errorf("ErrorCode(0).String() = %q, want %q", got, "Unknown(0)")
+	}
+	if got := ErrorCode(999).String(); got != "Unknown(999)" {
+		t.Errorf("ErrorCode(999).String() = %q, want %q", got, "Unknown(999)")
+	}
+}
+
+// Every named code must have a non-Unknown String mapping. This guards against
+// adding a new code constant without a corresponding switch arm.
+func TestEveryCodeHasName(t *testing.T) {
+	for c := ErrNotFound; c <= ErrConflict; c++ {
+		if s := c.String(); len(s) >= 7 && s[:7] == "Unknown" {
+			t.Errorf("code %d has no String() name (got %q)", c, s)
+		}
+	}
+}
+
+func TestStoreErrorError(t *testing.T) {
+	t.Run("with path", func(t *testing.T) {
+		e := &StoreError{Code: ErrNotFound, Message: "file not found", Path: "/a/b"}
+		want := "NotFound: file not found (path: /a/b)"
+		if got := e.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+	t.Run("without path", func(t *testing.T) {
+		e := &StoreError{Code: ErrInvalidArgument, Message: "bad arg"}
+		want := "InvalidArgument: bad arg"
+		if got := e.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestFactoryFunctions(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      *StoreError
+		wantCode ErrorCode
+		wantPath string
+		wantMsg  string
+	}{
+		{"NotFound", NewNotFoundError("/x", "file"), ErrNotFound, "/x", "file not found"},
+		{"PermissionDenied", NewPermissionDeniedError("/x"), ErrPermissionDenied, "/x", "permission denied"},
+		{"IsDirectory", NewIsDirectoryError("/x"), ErrIsDirectory, "/x", "is a directory"},
+		{"NotDirectory", NewNotDirectoryError("/x"), ErrNotDirectory, "/x", "not a directory"},
+		{"InvalidHandle", NewInvalidHandleError(), ErrInvalidHandle, "", "invalid file handle"},
+		{"StaleHandle", NewStaleHandleError("myshare"), ErrStaleHandle, "", `no store configured for share "myshare"`},
+		{"NotEmpty", NewNotEmptyError("/x"), ErrNotEmpty, "/x", "directory not empty"},
+		{"AlreadyExists", NewAlreadyExistsError("/x"), ErrAlreadyExists, "/x", "already exists"},
+		{"Conflict", NewConflictError("memory PutFile", "dup"), ErrConflict, "", "memory PutFile: dup"},
+		{"InvalidArgument", NewInvalidArgumentError("nope"), ErrInvalidArgument, "", "nope"},
+		{"AccessDenied", NewAccessDeniedError("no read bit"), ErrAccessDenied, "", "no read bit"},
+		{"QuotaExceeded", NewQuotaExceededError("/x"), ErrQuotaExceeded, "/x", "disk quota exceeded"},
+		{"PrivilegeRequired", NewPrivilegeRequiredError("chown"), ErrPrivilegeRequired, "", "operation requires root privileges: chown"},
+		{"NameTooLong", NewNameTooLongError("/x"), ErrNameTooLong, "/x", "name too long"},
+		{"ConnectionLimit", NewConnectionLimitError("nfs", 5), ErrConnectionLimitReached, "", "connection limit reached for nfs adapter (max: 5)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.err.Code != c.wantCode {
+				t.Errorf("Code = %v, want %v", c.err.Code, c.wantCode)
+			}
+			if c.err.Path != c.wantPath {
+				t.Errorf("Path = %q, want %q", c.err.Path, c.wantPath)
+			}
+			if c.err.Message != c.wantMsg {
+				t.Errorf("Message = %q, want %q", c.err.Message, c.wantMsg)
+			}
+		})
+	}
+}
+
+// classifier captures one Is*Error predicate together with its name for
+// table-driven assertions.
+type classifier struct {
+	name string
+	fn   func(error) bool
+}
+
+var classifiers = []classifier{
+	{"IsNotFoundError", IsNotFoundError},
+	{"IsLockConflictError", IsLockConflictError},
+	{"IsDeadlockError", IsDeadlockError},
+	{"IsGracePeriodError", IsGracePeriodError},
+	{"IsLockLimitError", IsLockLimitError},
+	{"IsConflictError", IsConflictError},
+	{"IsInvalidHandleError", IsInvalidHandleError},
+	{"IsStaleHandleError", IsStaleHandleError},
+}
+
+// For each code, exactly the expected set of classifiers must return true.
+// This pins the code->predicate mapping, including the two arms that match
+// more than one code (NotFound also matches LockNotFound; LockConflict also
+// matches Locked).
+func TestClassifiers(t *testing.T) {
+	// code -> set of classifier names expected to return true
+	expect := map[ErrorCode]map[string]bool{
+		ErrNotFound:          {"IsNotFoundError": true},
+		ErrLockNotFound:      {"IsNotFoundError": true},
+		ErrLocked:            {"IsLockConflictError": true},
+		ErrLockConflict:      {"IsLockConflictError": true},
+		ErrDeadlock:          {"IsDeadlockError": true},
+		ErrGracePeriod:       {"IsGracePeriodError": true},
+		ErrLockLimitExceeded: {"IsLockLimitError": true},
+		ErrConflict:          {"IsConflictError": true},
+		ErrInvalidHandle:     {"IsInvalidHandleError": true},
+		ErrStaleHandle:       {"IsStaleHandleError": true},
+	}
+
+	for c := ErrNotFound; c <= ErrConflict; c++ {
+		err := &StoreError{Code: c, Message: "x"}
+		want := expect[c]
+		for _, cl := range classifiers {
+			got := cl.fn(err)
+			wantTrue := want[cl.name]
+			if got != wantTrue {
+				t.Errorf("code %s: %s = %v, want %v", c, cl.name, got, wantTrue)
+			}
+		}
+	}
+}
+
+// Classifiers must unwrap wrapped StoreErrors via errors.As, so a
+// fmt.Errorf("...: %w", storeErr) chain still classifies correctly.
+func TestClassifiersUnwrapWrapped(t *testing.T) {
+	base := NewNotFoundError("/p", "file")
+	wrapped := fmt.Errorf("read failed: %w", base)
+	if !IsNotFoundError(wrapped) {
+		t.Error("IsNotFoundError should unwrap a wrapped StoreError")
+	}
+
+	deep := fmt.Errorf("layer2: %w", fmt.Errorf("layer1: %w", NewConflictError("op", "msg")))
+	if !IsConflictError(deep) {
+		t.Error("IsConflictError should unwrap a doubly-wrapped StoreError")
+	}
+}
+
+// Non-StoreError values (nil, plain errors) must classify as false everywhere.
+func TestClassifiersNonStoreError(t *testing.T) {
+	for _, in := range []error{nil, goerrors.New("plain"), fmt.Errorf("wrapped: %w", goerrors.New("plain"))} {
+		for _, cl := range classifiers {
+			if cl.fn(in) {
+				t.Errorf("%s(%v) = true, want false", cl.name, in)
+			}
+		}
+	}
+}
+
+// errors.As must be able to extract a *StoreError from the concrete type.
+func TestErrorsAsExtraction(t *testing.T) {
+	orig := NewConflictError("badger PutFile", "object_id already mapped")
+	var got *StoreError
+	if !goerrors.As(orig, &got) {
+		t.Fatal("errors.As failed to extract *StoreError")
+	}
+	if got.Code != ErrConflict {
+		t.Errorf("extracted Code = %v, want ErrConflict", got.Code)
+	}
+}
+
+// ConflictOwnerID is a free-form field on StoreError used by the SMB lock
+// path; it must round-trip through errors.As untouched.
+func TestConflictOwnerIDRoundTrips(t *testing.T) {
+	e := &StoreError{Code: ErrLocked, Message: "locked", ConflictOwnerID: "owner-42"}
+	wrapped := fmt.Errorf("lock op: %w", e)
+	var got *StoreError
+	if !goerrors.As(wrapped, &got) {
+		t.Fatal("errors.As failed")
+	}
+	if got.ConflictOwnerID != "owner-42" {
+		t.Errorf("ConflictOwnerID = %q, want %q", got.ConflictOwnerID, "owner-42")
+	}
+	if !IsLockConflictError(wrapped) {
+		t.Error("ErrLocked should classify as lock conflict")
+	}
+}


### PR DESCRIPTION
Part of #1014 (Wave-2 test-coverage stream).

Adds honest unit tests for previously zero-/low-coverage units flagged by the v1.0 roadmap. Test-only — no production code touched. All green under `go test -race`.

## Packages + before/after coverage

| Package | Before | After |
|---|---|---|
| `pkg/metadata/errors` | 0.0% | 100.0% |
| `pkg/controlplane` (top-level) | 0.0% | 96.0% |
| `pkg/controlplane/runtime/identity` | 0.0% | 100.0% |
| `pkg/controlplane/runtime/lifecycle` | 0.0% | 94.0% |
| `pkg/controlplane/runtime/mounts` | 0.0% | 100.0% |
| `pkg/controlplane/store` (helpers) | 2.0% | 6.1%* |

\* Most of `store` is `//go:build integration`-gated (real DB CRUD). This PR covers the non-gated generic GORM helpers (`getByField`, `listAll`, `createWithID`, `deleteByField`), `dedup`, `isUniqueConstraintError`, and `convertNotFoundError` to 100% via an in-memory pure-Go SQLite DB; the package-level number stays low because the integration-gated surface dominates statement count.

## What's covered (real branches, not getters)

- **errors**: every `ErrorCode.String()` arm + Unknown fallback, `StoreError.Error()` with/without path, all 15 factory funcs, all 8 `Is*Error` classifiers including the multi-code arms (NotFound↔LockNotFound, LockConflict↔Locked) and `errors.As` unwrapping of wrapped `StoreError` chains.
- **identity**: full squash-mode matrix (none / root_to_admin / root_to_guest / all_to_admin / all_to_guest), AUTH_NULL→anonymous regardless of mode, input-not-mutated, share-not-found error path.
- **lifecycle**: Serve graceful-shutdown ordering, `serveOnce` no-op on re-entry, adapter-load early-return (shutdown not reached), API-server-failure-triggers-shutdown, `SetAPIServer`-after-Serve panic, and all four `initMachineSID` branches (nil store ephemeral / load stored / first-boot persist / invalid-stored regenerate / read-error tolerate).
- **mounts**: Record/overwrite, Remove(+absent), RemoveByClient, RemoveAllByProtocol, RemoveAll, List/ListByProtocol returns copies, plus a `-race` concurrency exerciser.
- **controlplane**: `New` validation + happy path with/without API server, `EnsureAdminUser` idempotence, `Close`.

## Scope

Did not touch `pkg/controlplane/api/`, `runtime/snapshot.go`, `internal/adapter/`, or `bench/` (reserved for sibling agents).

Gates: `go build ./...`, `go vet`, `go fmt`, `go test -race` all green.
