### PR TITLE
feat(operator/runtime): pod-level TLS cert-Secret + cleartext WARN + snapshot rollback boot-enabled fix

### DIFF
--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
@@ -157,13 +157,35 @@ type ControlPlaneAPIConfig struct {
 	// API. When true the operator connects over https:// so the admin and
 	// operator service-account credentials it sends are not transmitted in
 	// cleartext over the pod network. This requires the dfs control plane API to
-	// be served over TLS (terminated at the server or by an in-cluster mesh/
-	// sidecar that exposes the API service on https). Defaults to false (http://)
-	// for backward compatibility; in-cluster credentialed deployments should
-	// enable it once TLS termination is in place.
+	// be served over TLS — either natively (see CertSecretName, which makes the
+	// pod serve HTTPS end-to-end) or terminated by an in-cluster mesh/sidecar
+	// that exposes the API service on https. Defaults to false (http://) for
+	// backward compatibility; in-cluster credentialed deployments should enable
+	// it once TLS termination is in place.
 	// +kubebuilder:default=false
 	// +optional
 	TLS bool `json:"tls,omitempty"`
+
+	// CertSecretName names a Kubernetes Secret containing the server
+	// certificate and private key the dfs pod uses to serve native TLS
+	// (HTTPS) on the control plane API. When set, the operator mounts the
+	// Secret read-only into the dfs container and renders
+	// controlplane.tls.cert_file / key_file so the API is served over TLS
+	// end-to-end inside the cluster, rather than relying only on edge
+	// termination.
+	//
+	// The Secret must use the standard kubernetes.io/tls keys "tls.crt" and
+	// "tls.key" (e.g. a cert-manager-issued Certificate Secret). Setting this
+	// implies TLS=true (https scheme) for the operator's own API calls.
+	// +optional
+	CertSecretName string `json:"certSecretName,omitempty"`
+
+	// ClientCASecretName optionally names a Secret containing a CA bundle used
+	// to require and verify client certificates (mutual TLS) on the control
+	// plane API. The CA bundle must be stored under the key "ca.crt". Only
+	// honored when CertSecretName is also set (mTLS needs a server cert).
+	// +optional
+	ClientCASecretName string `json:"clientCASecretName,omitempty"`
 }
 
 // IdentityConfig defines identity store and JWT authentication configuration

--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_webhook.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_webhook.go
@@ -86,6 +86,19 @@ func (r *DittoServer) validateDittoServer() (admission.Warnings, error) {
 		}
 	}
 
+	// Native TLS validation: a client-CA Secret (mTLS) needs a server cert.
+	if r.Spec.ControlPlane != nil {
+		if r.Spec.ControlPlane.ClientCASecretName != "" && r.Spec.ControlPlane.CertSecretName == "" {
+			return warnings, fmt.Errorf("controlPlane.clientCASecretName requires controlPlane.certSecretName (mTLS needs a server certificate)")
+		}
+		// A cert Secret implies the API is served over https; tls=false would
+		// make the operator dial http:// and fail. GetAPIServiceURL already
+		// upgrades the scheme, so this is a heads-up, not an error.
+		if r.Spec.ControlPlane.CertSecretName != "" && !r.Spec.ControlPlane.TLS {
+			warnings = append(warnings, "controlPlane.certSecretName is set, so the API serves native TLS; the operator will connect over https regardless of controlPlane.tls")
+		}
+	}
+
 	// Validate port uniqueness and warn about privileged ports
 	portWarnings, err := r.validatePorts()
 	if err != nil {

--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_webhook_tls_test.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_webhook_tls_test.go
@@ -1,0 +1,62 @@
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateDittoServer_TLS covers the native-TLS validation rules:
+//   - a client-CA Secret without a server-cert Secret is rejected (mTLS needs a
+//     server certificate);
+//   - a server-cert Secret with tls=false emits a heads-up warning (the
+//     operator will still dial https).
+func TestValidateDittoServer_TLS(t *testing.T) {
+	mk := func(cp *ControlPlaneAPIConfig) *DittoServer {
+		return &DittoServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "ds", Namespace: "default"},
+			Spec: DittoServerSpec{
+				// Storage is required earlier in validation; provide it so the
+				// TLS rules under test are actually reached.
+				Storage:      StorageSpec{MetadataSize: "1Gi", CacheSize: "1Gi"},
+				ControlPlane: cp,
+			},
+		}
+	}
+
+	t.Run("client-ca without cert secret is rejected", func(t *testing.T) {
+		_, err := mk(&ControlPlaneAPIConfig{ClientCASecretName: "ca"}).validateDittoServer()
+		if err == nil || !strings.Contains(err.Error(), "clientCASecretName requires") {
+			t.Fatalf("expected clientCASecretName-requires-certSecretName error, got %v", err)
+		}
+	})
+
+	t.Run("cert secret with tls=false warns", func(t *testing.T) {
+		warnings, err := mk(&ControlPlaneAPIConfig{CertSecretName: "tls", TLS: false}).validateDittoServer()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "serves native TLS") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected a native-TLS heads-up warning, got %v", warnings)
+		}
+	})
+
+	t.Run("cert + client-ca + tls=true is clean", func(t *testing.T) {
+		warnings, err := mk(&ControlPlaneAPIConfig{CertSecretName: "tls", ClientCASecretName: "ca", TLS: true}).validateDittoServer()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, w := range warnings {
+			if strings.Contains(w, "serves native TLS") {
+				t.Fatalf("did not expect the tls=false warning when tls=true: %v", warnings)
+			}
+		}
+	})
+}

--- a/k8s/dittofs-operator/api/v1alpha1/helpers.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers.go
@@ -10,6 +10,40 @@ import (
 const ManagedJWTSecretKey = "jwt-secret"
 
 const (
+	// TLSCertMountPath is where the control-plane server certificate Secret is
+	// mounted (read-only) inside the dfs container when native TLS is enabled.
+	TLSCertMountPath = "/tls"
+
+	// TLSClientCAMountPath is where the optional client-CA bundle Secret is
+	// mounted (read-only) for mutual TLS.
+	TLSClientCAMountPath = "/tls-client-ca"
+
+	// Standard kubernetes.io/tls Secret keys (cert-manager defaults).
+	TLSCertKey     = "tls.crt"
+	TLSKeyKey      = "tls.key"
+	TLSClientCAKey = "ca.crt"
+)
+
+// NativeTLSEnabled reports whether the operator should make the dfs pod serve
+// native (in-pod) TLS — i.e. a server-certificate Secret was named.
+func (ds *DittoServer) NativeTLSEnabled() bool {
+	return ds.Spec.ControlPlane != nil && ds.Spec.ControlPlane.CertSecretName != ""
+}
+
+// MutualTLSEnabled reports whether client-certificate verification (mTLS) is
+// requested. A client-CA Secret is only honored alongside a server cert.
+func (ds *DittoServer) MutualTLSEnabled() bool {
+	return ds.NativeTLSEnabled() && ds.Spec.ControlPlane.ClientCASecretName != ""
+}
+
+// TLSCertFilePath / TLSKeyFilePath / TLSClientCAFilePath return the in-container
+// paths the rendered config points controlplane.tls.{cert_file,key_file,client_ca}
+// at, matching where the Secrets are mounted.
+func TLSCertFilePath() string     { return TLSCertMountPath + "/" + TLSCertKey }
+func TLSKeyFilePath() string      { return TLSCertMountPath + "/" + TLSKeyKey }
+func TLSClientCAFilePath() string { return TLSClientCAMountPath + "/" + TLSClientCAKey }
+
+const (
 	// OperatorCredentialsSecretSuffix is the naming convention for the operator credentials Secret.
 	OperatorCredentialsSecretSuffix = "-operator-credentials"
 
@@ -77,7 +111,9 @@ func (ds *DittoServer) GetAPIServiceURL() string {
 		if ds.Spec.ControlPlane.Port > 0 {
 			apiPort = int(ds.Spec.ControlPlane.Port)
 		}
-		if ds.Spec.ControlPlane.TLS {
+		// Either the explicit scheme opt-in (edge termination) or a native
+		// server-cert Secret (in-pod TLS) means the API speaks https.
+		if ds.Spec.ControlPlane.TLS || ds.NativeTLSEnabled() {
 			scheme = "https"
 		}
 	}

--- a/k8s/dittofs-operator/api/v1alpha1/helpers_test.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers_test.go
@@ -61,6 +61,11 @@ func TestGetAPIServiceURL(t *testing.T) {
 			cp:   &ControlPlaneAPIConfig{Port: 9443, TLS: true},
 			want: "https://srv-api.ns.svc.cluster.local:9443",
 		},
+		{
+			name: "native cert secret upgrades scheme to https even without tls flag",
+			cp:   &ControlPlaneAPIConfig{CertSecretName: "dfs-tls"},
+			want: "https://srv-api.ns.svc.cluster.local:8080",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -79,6 +84,33 @@ func TestGetAPIServiceURL_TLSOptIn(t *testing.T) {
 	ds := newDittoServer("srv", "ns", &ControlPlaneAPIConfig{TLS: true})
 	if !strings.HasPrefix(ds.GetAPIServiceURL(), "https://") {
 		t.Fatalf("expected https:// scheme when TLS is enabled, got %q", ds.GetAPIServiceURL())
+	}
+}
+
+func TestNativeAndMutualTLSEnabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		cp         *ControlPlaneAPIConfig
+		wantNative bool
+		wantMutual bool
+	}{
+		{"nil control plane", nil, false, false},
+		{"no cert secret", &ControlPlaneAPIConfig{}, false, false},
+		{"cert secret only", &ControlPlaneAPIConfig{CertSecretName: "c"}, true, false},
+		{"cert + client-ca", &ControlPlaneAPIConfig{CertSecretName: "c", ClientCASecretName: "ca"}, true, true},
+		// A client-CA without a server cert is not honored (webhook rejects it).
+		{"client-ca only", &ControlPlaneAPIConfig{ClientCASecretName: "ca"}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := newDittoServer("srv", "ns", tc.cp)
+			if got := ds.NativeTLSEnabled(); got != tc.wantNative {
+				t.Errorf("NativeTLSEnabled() = %v, want %v", got, tc.wantNative)
+			}
+			if got := ds.MutualTLSEnabled(); got != tc.wantMutual {
+				t.Errorf("MutualTLSEnabled() = %v, want %v", got, tc.wantMutual)
+			}
+		})
 	}
 }
 

--- a/k8s/dittofs-operator/chart/crds/dittoservers.yaml
+++ b/k8s/dittofs-operator/chart/crds/dittoservers.yaml
@@ -106,6 +106,27 @@ spec:
               controlPlane:
                 description: ControlPlane configures the REST API server
                 properties:
+                  certSecretName:
+                    description: |-
+                      CertSecretName names a Kubernetes Secret containing the server
+                      certificate and private key the dfs pod uses to serve native TLS
+                      (HTTPS) on the control plane API. When set, the operator mounts the
+                      Secret read-only into the dfs container and renders
+                      controlplane.tls.cert_file / key_file so the API is served over TLS
+                      end-to-end inside the cluster, rather than relying only on edge
+                      termination.
+
+                      The Secret must use the standard kubernetes.io/tls keys "tls.crt" and
+                      "tls.key" (e.g. a cert-manager-issued Certificate Secret). Setting this
+                      implies TLS=true (https scheme) for the operator's own API calls.
+                    type: string
+                  clientCASecretName:
+                    description: |-
+                      ClientCASecretName optionally names a Secret containing a CA bundle used
+                      to require and verify client certificates (mutual TLS) on the control
+                      plane API. The CA bundle must be stored under the key "ca.crt". Only
+                      honored when CertSecretName is also set (mTLS needs a server cert).
+                    type: string
                   port:
                     default: 8080
                     description: Port is the API server port
@@ -120,10 +141,11 @@ spec:
                       API. When true the operator connects over https:// so the admin and
                       operator service-account credentials it sends are not transmitted in
                       cleartext over the pod network. This requires the dfs control plane API to
-                      be served over TLS (terminated at the server or by an in-cluster mesh/
-                      sidecar that exposes the API service on https). Defaults to false (http://)
-                      for backward compatibility; in-cluster credentialed deployments should
-                      enable it once TLS termination is in place.
+                      be served over TLS — either natively (see CertSecretName, which makes the
+                      pod serve HTTPS end-to-end) or terminated by an in-cluster mesh/sidecar
+                      that exposes the API service on https. Defaults to false (http://) for
+                      backward compatibility; in-cluster credentialed deployments should enable
+                      it once TLS termination is in place.
                     type: boolean
                 type: object
               database:

--- a/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
+++ b/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
@@ -106,6 +106,27 @@ spec:
               controlPlane:
                 description: ControlPlane configures the REST API server
                 properties:
+                  certSecretName:
+                    description: |-
+                      CertSecretName names a Kubernetes Secret containing the server
+                      certificate and private key the dfs pod uses to serve native TLS
+                      (HTTPS) on the control plane API. When set, the operator mounts the
+                      Secret read-only into the dfs container and renders
+                      controlplane.tls.cert_file / key_file so the API is served over TLS
+                      end-to-end inside the cluster, rather than relying only on edge
+                      termination.
+
+                      The Secret must use the standard kubernetes.io/tls keys "tls.crt" and
+                      "tls.key" (e.g. a cert-manager-issued Certificate Secret). Setting this
+                      implies TLS=true (https scheme) for the operator's own API calls.
+                    type: string
+                  clientCASecretName:
+                    description: |-
+                      ClientCASecretName optionally names a Secret containing a CA bundle used
+                      to require and verify client certificates (mutual TLS) on the control
+                      plane API. The CA bundle must be stored under the key "ca.crt". Only
+                      honored when CertSecretName is also set (mTLS needs a server cert).
+                    type: string
                   port:
                     default: 8080
                     description: Port is the API server port
@@ -120,10 +141,11 @@ spec:
                       API. When true the operator connects over https:// so the admin and
                       operator service-account credentials it sends are not transmitted in
                       cleartext over the pod network. This requires the dfs control plane API to
-                      be served over TLS (terminated at the server or by an in-cluster mesh/
-                      sidecar that exposes the API service on https). Defaults to false (http://)
-                      for backward compatibility; in-cluster credentialed deployments should
-                      enable it once TLS termination is in place.
+                      be served over TLS — either natively (see CertSecretName, which makes the
+                      pod serve HTTPS end-to-end) or terminated by an in-cluster mesh/sidecar
+                      that exposes the API service on https. Defaults to false (http://) for
+                      backward compatibility; in-cluster credentialed deployments should enable
+                      it once TLS termination is in place.
                     type: boolean
                 type: object
               database:

--- a/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittoserver_tls.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittoserver_tls.yaml
@@ -1,0 +1,60 @@
+# DittoFS with pod-level native TLS on the control plane API.
+#
+# When controlPlane.certSecretName is set, the operator mounts the named TLS
+# Secret into the dfs pod and renders controlplane.tls.{cert_file,key_file} so
+# the API is served over HTTPS end-to-end inside the cluster (not just at an
+# edge terminator). The operator's own API calls then use https and verify the
+# pod certificate against the Secret's ca.crt — no InsecureSkipVerify.
+#
+# The cert Secret must be a standard kubernetes.io/tls Secret (keys tls.crt /
+# tls.key), e.g. one issued by cert-manager. For mutual TLS, also set
+# clientCASecretName to a Secret carrying the client CA bundle under ca.crt.
+apiVersion: dittofs.dittofs.com/v1alpha1
+kind: DittoServer
+metadata:
+  labels:
+    app.kubernetes.io/name: dittofs-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: dittoserver-tls-sample
+  namespace: dittofs
+spec:
+  image: marmos91c/dittofs:latest
+  replicas: 1
+
+  storage:
+    metadataSize: "10Gi"
+    contentSize: "50Gi"
+
+  identity:
+    jwt:
+      secretRef:
+        name: dittofs-jwt-secret
+        key: secret
+    admin:
+      username: admin
+      passwordSecretRef:
+        name: dittofs-admin-secret
+        key: password-hash
+
+  database:
+    type: sqlite
+    sqlite:
+      path: "/data/controlplane/controlplane.db"
+
+  cache:
+    path: "/data/cache"
+    size: "1GB"
+
+  # Control plane REST API: native TLS.
+  controlPlane:
+    port: 8080
+    tls: true
+    # A kubernetes.io/tls Secret (e.g. cert-manager-issued) with tls.crt/tls.key.
+    certSecretName: dittofs-controlplane-tls
+    # Optional: enable mutual TLS by trusting a client CA bundle (ca.crt).
+    # clientCASecretName: dittofs-client-ca
+
+  nfsPort: 12049
+
+  service:
+    type: "ClusterIP"

--- a/k8s/dittofs-operator/internal/controller/adapter_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/adapter_reconciler.go
@@ -63,7 +63,10 @@ func (r *DittoServerReconciler) getAuthenticatedClient(ctx context.Context, ds *
 		return nil, fmt.Errorf("operator credentials secret is missing server-url or access-token")
 	}
 
-	apiClient := NewDittoFSClient(serverURL)
+	apiClient, err := r.newAPIClient(ctx, ds, serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build API client: %w", err)
+	}
 	apiClient.SetToken(accessToken)
 
 	return apiClient, nil

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -304,7 +304,7 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 }
 
 // refreshOperatorToken refreshes the operator's JWT token using the stored credentials.
-func (r *DittoServerReconciler) refreshOperatorToken(ctx context.Context, ds *dittoiov1alpha1.DittoServer, secret *corev1.Secret, apiURL string) (ctrl.Result, error) { //nolint:unparam // ds used for future per-CR token management
+func (r *DittoServerReconciler) refreshOperatorToken(ctx context.Context, ds *dittoiov1alpha1.DittoServer, secret *corev1.Secret, apiURL string) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 
 	refreshToken := string(secret.Data["refresh-token"])

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -94,6 +94,31 @@ func (r *DittoServerReconciler) reconcileAdminCredentials(ctx context.Context, d
 	return nil
 }
 
+// newAPIClient builds a DittoFSClient for the given base URL, wiring TLS trust
+// when the pod serves native TLS. With native TLS the operator reaches the API
+// over https and must verify the pod-served certificate; the cert-manager-style
+// cert Secret carries the issuing CA under "ca.crt", which we load into the
+// client's RootCAs so verification succeeds WITHOUT InsecureSkipVerify. When
+// native TLS is off, or the CA key is absent, the client falls back to system
+// roots (unchanged behavior for edge-terminated / plain-http deployments).
+func (r *DittoServerReconciler) newAPIClient(ctx context.Context, ds *dittoiov1alpha1.DittoServer, baseURL string) (*DittoFSClient, error) {
+	if !ds.NativeTLSEnabled() {
+		return NewDittoFSClient(baseURL), nil
+	}
+	certSecret := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: ds.Namespace,
+		Name:      ds.Spec.ControlPlane.CertSecretName,
+	}, certSecret); err != nil {
+		return nil, fmt.Errorf("failed to get control plane cert secret %q for CA trust: %w",
+			ds.Spec.ControlPlane.CertSecretName, err)
+	}
+	// ca.crt is optional in a TLS Secret; when absent fall back to system roots
+	// (e.g. a publicly-trusted certificate needs no private CA).
+	caPEM := certSecret.Data[dittoiov1alpha1.TLSClientCAKey]
+	return NewDittoFSClientWithCA(baseURL, caPEM)
+}
+
 // reconcileAuth is the main auth reconciliation entry point.
 // It provisions or refreshes the operator service account credentials.
 func (r *DittoServerReconciler) reconcileAuth(ctx context.Context, dittoServer *dittoiov1alpha1.DittoServer) (ctrl.Result, error) {
@@ -193,7 +218,10 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 	}
 
 	// Login as admin
-	apiClient := NewDittoFSClient(apiURL)
+	apiClient, err := r.newAPIClient(ctx, ds, apiURL)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to build API client: %w", err)
+	}
 	tokenResp, err := apiClient.Login(ctx, adminUsername, adminPassword)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to login as admin: %w", err)
@@ -282,7 +310,10 @@ func (r *DittoServerReconciler) refreshOperatorToken(ctx context.Context, ds *di
 	refreshToken := string(secret.Data["refresh-token"])
 	storedPassword := string(secret.Data["password"])
 
-	apiClient := NewDittoFSClient(apiURL)
+	apiClient, err := r.newAPIClient(ctx, ds, apiURL)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to build API client: %w", err)
+	}
 
 	// Try refresh first (cheapest operation)
 	tokenResp, err := apiClient.RefreshToken(ctx, refreshToken)
@@ -355,7 +386,11 @@ func (r *DittoServerReconciler) cleanupOperatorServiceAccount(ctx context.Contex
 	}
 
 	apiURL := ds.GetAPIServiceURL()
-	apiClient := NewDittoFSClient(apiURL)
+	apiClient, err := r.newAPIClient(ctx, ds, apiURL)
+	if err != nil {
+		logger.Info("Failed to build API client for cleanup, skipping", "error", err.Error())
+		return nil
+	}
 
 	// Login as admin
 	tokenResp, err := apiClient.Login(ctx, adminUsername, adminPassword)

--- a/k8s/dittofs-operator/internal/controller/config/config.go
+++ b/k8s/dittofs-operator/internal/controller/config/config.go
@@ -117,7 +117,7 @@ func buildControlPlaneConfig(ds *dittoiov1alpha1.DittoServer) ControlPlaneConfig
 
 	jwtCfg := getJWTConfig(ds)
 
-	return ControlPlaneConfig{
+	cp := ControlPlaneConfig{
 		// Bind all interfaces: the server's 127.0.0.1 default is unreachable
 		// from the API Service, so in-cluster we always listen on 0.0.0.0.
 		Host: "0.0.0.0",
@@ -127,6 +127,22 @@ func buildControlPlaneConfig(ds *dittoiov1alpha1.DittoServer) ControlPlaneConfig
 			RefreshTokenDuration: stringOrDefault(jwtCfg.RefreshTokenDuration, DefaultRefreshDuration),
 		},
 	}
+
+	// Native TLS: when a server-certificate Secret is named, point the server
+	// at the mounted cert/key (and optional client-CA) so the pod serves HTTPS
+	// end-to-end. The controller mounts the matching Secret(s) at these paths.
+	if ds.NativeTLSEnabled() {
+		tls := &TLSConfig{
+			CertFile: dittoiov1alpha1.TLSCertFilePath(),
+			KeyFile:  dittoiov1alpha1.TLSKeyFilePath(),
+		}
+		if ds.MutualTLSEnabled() {
+			tls.ClientCA = dittoiov1alpha1.TLSClientCAFilePath()
+		}
+		cp.TLS = tls
+	}
+
+	return cp
 }
 
 // getJWTConfig returns the JWT config from the spec, or an empty struct if not configured.

--- a/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
+++ b/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
@@ -49,6 +49,10 @@ var serverKnownKeys = map[string]bool{
 	"controlplane.port":                       true,
 	"controlplane.jwt.access_token_duration":  true,
 	"controlplane.jwt.refresh_token_duration": true,
+	// Native TLS keys consumed by pkg/controlplane/api TLSConfig.
+	"controlplane.tls.cert_file": true,
+	"controlplane.tls.key_file":  true,
+	"controlplane.tls.client_ca": true,
 
 	"admin.username": true,
 	"admin.email":    true,

--- a/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
+++ b/k8s/dittofs-operator/internal/controller/config/config_roundtrip_test.go
@@ -129,6 +129,15 @@ func TestGenerateDittoFSConfig_NoDeadKeys(t *testing.T) {
 				Cache: &dittoiov1alpha1.InfraCacheConfig{Path: "/c", Size: "2GB"},
 			},
 		},
+		"native-mtls": {
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				ControlPlane: &dittoiov1alpha1.ControlPlaneAPIConfig{
+					TLS:                true,
+					CertSecretName:     "tls",
+					ClientCASecretName: "ca",
+				},
+			},
+		},
 	}
 
 	for name, ds := range cases {

--- a/k8s/dittofs-operator/internal/controller/config/config_tls_test.go
+++ b/k8s/dittofs-operator/internal/controller/config/config_tls_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	dittoiov1alpha1 "github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
+	"gopkg.in/yaml.v3"
+)
+
+// TestGenerateDittoFSConfig_NativeTLS verifies the rendered controlplane.tls.*
+// block tracks the CertSecretName / ClientCASecretName CRD fields.
+func TestGenerateDittoFSConfig_NativeTLS(t *testing.T) {
+	t.Run("no cert secret -> no tls block", func(t *testing.T) {
+		ds := &dittoiov1alpha1.DittoServer{
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				ControlPlane: &dittoiov1alpha1.ControlPlaneAPIConfig{},
+			},
+		}
+		cp := buildControlPlaneConfig(ds)
+		if cp.TLS != nil {
+			t.Fatalf("expected no TLS block without a cert secret, got %+v", cp.TLS)
+		}
+		yamlStr, err := GenerateDittoFSConfig(ds)
+		if err != nil {
+			t.Fatalf("GenerateDittoFSConfig: %v", err)
+		}
+		if strings.Contains(yamlStr, "tls:") {
+			t.Fatalf("rendered config should omit the tls block:\n%s", yamlStr)
+		}
+	})
+
+	t.Run("cert secret -> cert_file + key_file, no client_ca", func(t *testing.T) {
+		ds := &dittoiov1alpha1.DittoServer{
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				ControlPlane: &dittoiov1alpha1.ControlPlaneAPIConfig{
+					CertSecretName: "dfs-tls",
+				},
+			},
+		}
+		cp := buildControlPlaneConfig(ds)
+		if cp.TLS == nil {
+			t.Fatal("expected a TLS block when a cert secret is named")
+		}
+		if cp.TLS.CertFile != dittoiov1alpha1.TLSCertFilePath() {
+			t.Errorf("cert_file = %q, want %q", cp.TLS.CertFile, dittoiov1alpha1.TLSCertFilePath())
+		}
+		if cp.TLS.KeyFile != dittoiov1alpha1.TLSKeyFilePath() {
+			t.Errorf("key_file = %q, want %q", cp.TLS.KeyFile, dittoiov1alpha1.TLSKeyFilePath())
+		}
+		if cp.TLS.ClientCA != "" {
+			t.Errorf("client_ca should be empty without a client-CA secret, got %q", cp.TLS.ClientCA)
+		}
+		// The cert/key files live under the mount path; the rendered YAML must
+		// reference them so the server loads them.
+		assertRenderedTLS(t, ds, dittoiov1alpha1.TLSCertFilePath(), dittoiov1alpha1.TLSKeyFilePath())
+	})
+
+	t.Run("cert + client-CA secret -> client_ca rendered", func(t *testing.T) {
+		ds := &dittoiov1alpha1.DittoServer{
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				ControlPlane: &dittoiov1alpha1.ControlPlaneAPIConfig{
+					CertSecretName:     "dfs-tls",
+					ClientCASecretName: "dfs-client-ca",
+				},
+			},
+		}
+		cp := buildControlPlaneConfig(ds)
+		if cp.TLS == nil || cp.TLS.ClientCA != dittoiov1alpha1.TLSClientCAFilePath() {
+			t.Fatalf("client_ca = %q, want %q", cp.TLS.ClientCA, dittoiov1alpha1.TLSClientCAFilePath())
+		}
+	})
+
+	t.Run("client-CA without cert secret -> no tls block (guarded by webhook)", func(t *testing.T) {
+		// NativeTLSEnabled keys off the cert secret only, so a stray
+		// ClientCASecretName alone renders nothing (the webhook rejects it).
+		ds := &dittoiov1alpha1.DittoServer{
+			Spec: dittoiov1alpha1.DittoServerSpec{
+				ControlPlane: &dittoiov1alpha1.ControlPlaneAPIConfig{
+					ClientCASecretName: "dfs-client-ca",
+				},
+			},
+		}
+		if cp := buildControlPlaneConfig(ds); cp.TLS != nil {
+			t.Fatalf("expected no TLS block without a cert secret, got %+v", cp.TLS)
+		}
+	})
+}
+
+func assertRenderedTLS(t *testing.T, ds *dittoiov1alpha1.DittoServer, certPath, keyPath string) {
+	t.Helper()
+	yamlStr, err := GenerateDittoFSConfig(ds)
+	if err != nil {
+		t.Fatalf("GenerateDittoFSConfig: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(yamlStr), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cp, _ := doc["controlplane"].(map[string]any)
+	tlsBlock, ok := cp["tls"].(map[string]any)
+	if !ok {
+		t.Fatalf("rendered controlplane has no tls block:\n%s", yamlStr)
+	}
+	if tlsBlock["cert_file"] != certPath {
+		t.Errorf("rendered cert_file = %v, want %q", tlsBlock["cert_file"], certPath)
+	}
+	if tlsBlock["key_file"] != keyPath {
+		t.Errorf("rendered key_file = %v, want %q", tlsBlock["key_file"], keyPath)
+	}
+}

--- a/k8s/dittofs-operator/internal/controller/config/types.go
+++ b/k8s/dittofs-operator/internal/controller/config/types.go
@@ -50,6 +50,19 @@ type ControlPlaneConfig struct {
 	Host string    `yaml:"host"`
 	Port int       `yaml:"port"`
 	JWT  JWTConfig `yaml:"jwt"`
+	// TLS renders controlplane.tls.* so the pod serves native (in-pod) HTTPS.
+	// Omitted entirely (omitempty on the pointer) unless a cert Secret was
+	// named, preserving the plain-http / edge-terminated default.
+	TLS *TLSConfig `yaml:"tls,omitempty"`
+}
+
+// TLSConfig points the server at the cert/key (and optional client-CA) files
+// mounted from the operator-provided Secret(s). It mirrors the dfs
+// controlplane.tls config keys.
+type TLSConfig struct {
+	CertFile string `yaml:"cert_file"`
+	KeyFile  string `yaml:"key_file"`
+	ClientCA string `yaml:"client_ca,omitempty"`
 }
 
 // JWTConfig configures JWT authentication.

--- a/k8s/dittofs-operator/internal/controller/dittofs_client.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -46,6 +48,36 @@ func NewDittoFSClient(baseURL string) *DittoFSClient {
 			Timeout: 10 * time.Second,
 		},
 	}
+}
+
+// NewDittoFSClientWithCA is NewDittoFSClient that additionally trusts the given
+// PEM CA bundle when reaching an https base URL. This lets the operator verify
+// a pod-served native-TLS certificate signed by a private CA (e.g. the ca.crt
+// in a cert-manager-issued Secret) WITHOUT disabling certificate verification.
+// When caPEM is empty the client behaves exactly like NewDittoFSClient (system
+// roots only). An empty/invalid bundle is reported as an error rather than
+// silently falling back, so a misconfigured CA cannot mask an unverified
+// connection.
+func NewDittoFSClientWithCA(baseURL string, caPEM []byte) (*DittoFSClient, error) {
+	if len(caPEM) == 0 {
+		return NewDittoFSClient(baseURL), nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("control plane CA bundle contains no valid PEM certificate")
+	}
+	return &DittoFSClient{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					RootCAs:    pool,
+				},
+			},
+		},
+	}, nil
 }
 
 // SetToken sets the authentication token for subsequent requests.

--- a/k8s/dittofs-operator/internal/controller/dittofs_client.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client.go
@@ -58,24 +58,40 @@ func NewDittoFSClient(baseURL string) *DittoFSClient {
 // roots only). An empty/invalid bundle is reported as an error rather than
 // silently falling back, so a misconfigured CA cannot mask an unverified
 // connection.
+//
+// The CA is ADDED to the system trust pool (not a replacement), so a publicly
+// trusted server cert keeps verifying and a bundle carrying only an
+// intermediate still chains to a system root. The transport is cloned from
+// http.DefaultTransport so proxy support and the standard dial/idle timeouts
+// are preserved.
 func NewDittoFSClientWithCA(baseURL string, caPEM []byte) (*DittoFSClient, error) {
 	if len(caPEM) == 0 {
 		return NewDittoFSClient(baseURL), nil
 	}
-	pool := x509.NewCertPool()
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		// No system pool available (rare; e.g. some scratch images): start fresh
+		// so the operator-provided CA still establishes trust.
+		pool = x509.NewCertPool()
+	}
 	if !pool.AppendCertsFromPEM(caPEM) {
 		return nil, fmt.Errorf("control plane CA bundle contains no valid PEM certificate")
 	}
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unexpected default HTTP transport type %T", http.DefaultTransport)
+	}
+	transport = transport.Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	transport.TLSClientConfig.RootCAs = pool
 	return &DittoFSClient{
 		baseURL: baseURL,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					MinVersion: tls.VersionTLS12,
-					RootCAs:    pool,
-				},
-			},
+			Timeout:   10 * time.Second,
+			Transport: transport,
 		},
 	}, nil
 }

--- a/k8s/dittofs-operator/internal/controller/dittofs_client_test.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// selfSignedCAPEM returns a minimal self-signed CA certificate in PEM form for
+// exercising the client's RootCAs wiring (the cert is never used to serve).
+func selfSignedCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestNewDittoFSClientWithCA verifies the CA-trust wiring: an empty bundle keeps
+// the default transport (system roots), a valid PEM CA installs a RootCAs pool
+// WITHOUT disabling verification, and an invalid bundle is rejected rather than
+// silently ignored.
+func TestNewDittoFSClientWithCA(t *testing.T) {
+	t.Run("empty CA falls back to default client", func(t *testing.T) {
+		c, err := NewDittoFSClientWithCA("https://example.svc:8080", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Default client uses the default transport (nil) -> system roots.
+		if c.httpClient.Transport != nil {
+			t.Errorf("expected default (nil) transport for empty CA, got %T", c.httpClient.Transport)
+		}
+	})
+
+	t.Run("valid CA installs RootCAs without skipping verification", func(t *testing.T) {
+		// Generate a throwaway CA cert PEM via the api package test helper is in
+		// another module; instead reuse a minimal self-signed PEM produced here.
+		caPEM := selfSignedCAPEM(t)
+		c, err := NewDittoFSClientWithCA("https://example.svc:8080", caPEM)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tr, ok := c.httpClient.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", c.httpClient.Transport)
+		}
+		if tr.TLSClientConfig == nil || tr.TLSClientConfig.RootCAs == nil {
+			t.Fatal("expected RootCAs to be set from the CA bundle")
+		}
+		if tr.TLSClientConfig.InsecureSkipVerify {
+			t.Fatal("must never set InsecureSkipVerify")
+		}
+		if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+			t.Errorf("expected MinVersion >= TLS 1.2, got %x", tr.TLSClientConfig.MinVersion)
+		}
+	})
+
+	t.Run("invalid CA is rejected", func(t *testing.T) {
+		if _, err := NewDittoFSClientWithCA("https://example.svc:8080", []byte("not a pem")); err == nil {
+			t.Fatal("expected an error for an invalid CA bundle")
+		}
+	})
+}

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -758,6 +758,17 @@ func getAPIPort(dittoServer *dittoiov1alpha1.DittoServer) int32 {
 	return defaultAPIPort
 }
 
+// probeScheme returns the URI scheme the health probes must use. When the pod
+// serves native TLS the API speaks HTTPS only, so the probes must too;
+// otherwise plain HTTP. The kubelet skips certificate verification for HTTPS
+// probes, so a private CA needs no extra trust here.
+func probeScheme(dittoServer *dittoiov1alpha1.DittoServer) corev1.URIScheme {
+	if dittoServer.NativeTLSEnabled() {
+		return corev1.URISchemeHTTPS
+	}
+	return corev1.URISchemeHTTP
+}
+
 // PreStop hook delay (seconds) applied to the dfs container before SIGTERM.
 const preStopSleepSeconds = 5
 
@@ -898,6 +909,24 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 				})
 			}
 
+			// Native TLS: mount the server cert/key Secret (and optional
+			// client-CA Secret) read-only so the rendered controlplane.tls.*
+			// paths resolve and the pod serves HTTPS end-to-end.
+			if dittoServer.NativeTLSEnabled() {
+				volumeMounts = append(volumeMounts, corev1.VolumeMount{
+					Name:      "tls-cert",
+					MountPath: dittoiov1alpha1.TLSCertMountPath,
+					ReadOnly:  true,
+				})
+				if dittoServer.MutualTLSEnabled() {
+					volumeMounts = append(volumeMounts, corev1.VolumeMount{
+						Name:      "tls-client-ca",
+						MountPath: dittoiov1alpha1.TLSClientCAMountPath,
+						ReadOnly:  true,
+					})
+				}
+			}
+
 			metadataSize, err := resource.ParseQuantity(dittoServer.Spec.Storage.MetadataSize)
 			if err != nil {
 				return fmt.Errorf("invalid metadata size: %w", err)
@@ -982,6 +1011,41 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 				envVars = append(envVars, buildPostgresEnvVars(dittoServer.Name)...)
 			}
 
+			// Pod volumes: the config ConfigMap, plus the native-TLS cert
+			// (and optional client-CA) Secret(s) when TLS is enabled.
+			podVolumes := []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: dittoServer.Name + "-config",
+							},
+						},
+					},
+				},
+			}
+			if dittoServer.NativeTLSEnabled() {
+				podVolumes = append(podVolumes, corev1.Volume{
+					Name: "tls-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: dittoServer.Spec.ControlPlane.CertSecretName,
+						},
+					},
+				})
+				if dittoServer.MutualTLSEnabled() {
+					podVolumes = append(podVolumes, corev1.Volume{
+						Name: "tls-client-ca",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: dittoServer.Spec.ControlPlane.ClientCASecretName,
+							},
+						},
+					})
+				}
+			}
+
 			statefulSet.Spec = appsv1.StatefulSetSpec{
 				Replicas:    &replicas,
 				ServiceName: dittoServer.Name + "-headless",
@@ -1018,8 +1082,9 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								LivenessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/health",
-											Port: intstr.FromInt32(getAPIPort(dittoServer)),
+											Path:   "/health",
+											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
+											Scheme: probeScheme(dittoServer),
 										},
 									},
 									InitialDelaySeconds: 15,
@@ -1031,8 +1096,9 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								ReadinessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/health/ready",
-											Port: intstr.FromInt32(getAPIPort(dittoServer)),
+											Path:   "/health/ready",
+											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
+											Scheme: probeScheme(dittoServer),
 										},
 									},
 									InitialDelaySeconds: 10,
@@ -1044,8 +1110,9 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								StartupProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/health",
-											Port: intstr.FromInt32(getAPIPort(dittoServer)),
+											Path:   "/health",
+											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
+											Scheme: probeScheme(dittoServer),
 										},
 									},
 									InitialDelaySeconds: 0,
@@ -1063,18 +1130,7 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								},
 							},
 						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "config",
-								VolumeSource: corev1.VolumeSource{
-									ConfigMap: &corev1.ConfigMapVolumeSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: dittoServer.Name + "-config",
-										},
-									},
-								},
-							},
-						},
+						Volumes: podVolumes,
 					},
 				},
 				VolumeClaimTemplates: volumeClaimTemplates,

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -758,15 +758,28 @@ func getAPIPort(dittoServer *dittoiov1alpha1.DittoServer) int32 {
 	return defaultAPIPort
 }
 
-// probeScheme returns the URI scheme the health probes must use. When the pod
-// serves native TLS the API speaks HTTPS only, so the probes must too;
-// otherwise plain HTTP. The kubelet skips certificate verification for HTTPS
-// probes, so a private CA needs no extra trust here.
-func probeScheme(dittoServer *dittoiov1alpha1.DittoServer) corev1.URIScheme {
-	if dittoServer.NativeTLSEnabled() {
-		return corev1.URISchemeHTTPS
+// probeHandler builds the kubelet probe handler for a health path.
+//
+//   - Plain / native-TLS (no mTLS): an HTTPGet probe. The kubelet skips
+//     certificate verification for HTTPS probes, so a private server CA needs
+//     no extra trust here; only the scheme must match the listener.
+//   - Mutual TLS (client_ca set): the listener requires a verified client
+//     certificate, which the kubelet cannot present — an HTTPS HTTPGet probe
+//     would fail the handshake and the pod would never become ready. Fall back
+//     to a TCPSocket probe (port-accepting liveness) so mTLS does not wedge the
+//     rollout. The deeper /health semantics are traded for schedulability.
+func probeHandler(dittoServer *dittoiov1alpha1.DittoServer, path string) corev1.ProbeHandler {
+	port := intstr.FromInt32(getAPIPort(dittoServer))
+	if dittoServer.MutualTLSEnabled() {
+		return corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: port}}
 	}
-	return corev1.URISchemeHTTP
+	scheme := corev1.URISchemeHTTP
+	if dittoServer.NativeTLSEnabled() {
+		scheme = corev1.URISchemeHTTPS
+	}
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{Path: path, Port: port, Scheme: scheme},
+	}
 }
 
 // PreStop hook delay (seconds) applied to the dfs container before SIGTERM.
@@ -1080,13 +1093,7 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 								Ports:           buildContainerPorts(dittoServer, existingAdapterPorts(statefulSet)),
 								Env:             envVars,
 								LivenessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path:   "/health",
-											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
-											Scheme: probeScheme(dittoServer),
-										},
-									},
+									ProbeHandler:        probeHandler(dittoServer, "/health"),
 									InitialDelaySeconds: 15,
 									PeriodSeconds:       10,
 									TimeoutSeconds:      5,
@@ -1094,13 +1101,7 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 									FailureThreshold:    3,
 								},
 								ReadinessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path:   "/health/ready",
-											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
-											Scheme: probeScheme(dittoServer),
-										},
-									},
+									ProbeHandler:        probeHandler(dittoServer, "/health/ready"),
 									InitialDelaySeconds: 10,
 									PeriodSeconds:       5,
 									TimeoutSeconds:      5,
@@ -1108,13 +1109,7 @@ func (r *DittoServerReconciler) reconcileStatefulSet(ctx context.Context, dittoS
 									FailureThreshold:    3,
 								},
 								StartupProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path:   "/health",
-											Port:   intstr.FromInt32(getAPIPort(dittoServer)),
-											Scheme: probeScheme(dittoServer),
-										},
-									},
+									ProbeHandler:        probeHandler(dittoServer, "/health"),
 									InitialDelaySeconds: 0,
 									PeriodSeconds:       5,
 									TimeoutSeconds:      5,

--- a/k8s/dittofs-operator/internal/controller/tls_mount_test.go
+++ b/k8s/dittofs-operator/internal/controller/tls_mount_test.go
@@ -147,6 +147,18 @@ func TestReconcileStatefulSet_MutualTLSClientCAMount(t *testing.T) {
 	if mount == nil || !mount.ReadOnly || mount.MountPath != v1alpha1.TLSClientCAMountPath {
 		t.Errorf("tls-client-ca mount = %+v, want read-only at %q", mount, v1alpha1.TLSClientCAMountPath)
 	}
+
+	// Under mTLS the kubelet cannot present a client cert, so HTTPS HTTPGet
+	// probes would fail the handshake. The probes must fall back to TCPSocket.
+	c := spec.Containers[0]
+	for _, p := range []*corev1.Probe{c.LivenessProbe, c.ReadinessProbe, c.StartupProbe} {
+		if p == nil || p.TCPSocket == nil {
+			t.Errorf("expected a TCPSocket probe under mTLS, got %+v", p)
+		}
+		if p != nil && p.HTTPGet != nil {
+			t.Error("mTLS probe must not be HTTPGet (handshake needs a client cert)")
+		}
+	}
 }
 
 // TestReconcileStatefulSet_NoTLSNoCertMount asserts the default (no cert Secret)

--- a/k8s/dittofs-operator/internal/controller/tls_mount_test.go
+++ b/k8s/dittofs-operator/internal/controller/tls_mount_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newTLSDittoServer(certSecret, clientCASecret string) *v1alpha1.DittoServer {
+	cp := &v1alpha1.ControlPlaneAPIConfig{CertSecretName: certSecret}
+	if clientCASecret != "" {
+		cp.ClientCASecretName = clientCASecret
+	}
+	return &v1alpha1.DittoServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-test", Namespace: "default"},
+		Spec: v1alpha1.DittoServerSpec{
+			Image:        "marmos91c/dittofs:test",
+			ControlPlane: cp,
+			Storage: v1alpha1.StorageSpec{
+				MetadataSize: "1Gi",
+				CacheSize:    "1Gi",
+			},
+		},
+	}
+}
+
+func findVolume(vols []corev1.Volume, name string) *corev1.Volume {
+	for i := range vols {
+		if vols[i].Name == name {
+			return &vols[i]
+		}
+	}
+	return nil
+}
+
+func findMount(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+// TestReconcileStatefulSet_NativeTLSCertMount asserts that naming a cert Secret
+// makes the operator mount it read-only into the dfs container, switch the
+// health probes to HTTPS, and (with no client-CA) NOT mount a client-CA volume.
+func TestReconcileStatefulSet_NativeTLSCertMount(t *testing.T) {
+	ctx := context.Background()
+	ds := newTLSDittoServer("dfs-server-tls", "")
+	r := setupDittoServerReconciler(t, fields{dittoServer: ds})
+
+	if _, err := r.reconcileStatefulSet(ctx, ds, 1); err != nil {
+		t.Fatalf("reconcileStatefulSet failed: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, sts); err != nil {
+		t.Fatalf("failed to get StatefulSet: %v", err)
+	}
+	spec := sts.Spec.Template.Spec
+
+	// Cert Secret volume present and backed by the named Secret.
+	vol := findVolume(spec.Volumes, "tls-cert")
+	if vol == nil {
+		t.Fatal("expected a tls-cert volume")
+	}
+	if vol.Secret == nil || vol.Secret.SecretName != "dfs-server-tls" {
+		t.Errorf("tls-cert volume = %+v, want Secret source dfs-server-tls", vol.VolumeSource)
+	}
+
+	// Read-only mount at the expected path.
+	mount := findMount(spec.Containers[0].VolumeMounts, "tls-cert")
+	if mount == nil {
+		t.Fatal("expected a tls-cert volumeMount on the dfs container")
+	}
+	if !mount.ReadOnly {
+		t.Error("tls-cert mount must be read-only")
+	}
+	if mount.MountPath != v1alpha1.TLSCertMountPath {
+		t.Errorf("tls-cert mountPath = %q, want %q", mount.MountPath, v1alpha1.TLSCertMountPath)
+	}
+
+	// No client-CA volume/mount without a client-CA Secret.
+	if findVolume(spec.Volumes, "tls-client-ca") != nil {
+		t.Error("did not expect a tls-client-ca volume without a client-CA secret")
+	}
+
+	// Probes must switch to HTTPS since the pod now serves TLS only.
+	c := spec.Containers[0]
+	for _, p := range []*corev1.Probe{c.LivenessProbe, c.ReadinessProbe, c.StartupProbe} {
+		if p == nil || p.HTTPGet == nil {
+			t.Fatal("expected HTTPGet probes")
+		}
+		if p.HTTPGet.Scheme != corev1.URISchemeHTTPS {
+			t.Errorf("probe %s scheme = %q, want HTTPS", p.HTTPGet.Path, p.HTTPGet.Scheme)
+		}
+	}
+}
+
+// TestReconcileStatefulSet_MutualTLSClientCAMount asserts that adding a
+// client-CA Secret mounts a second read-only volume for the CA bundle.
+func TestReconcileStatefulSet_MutualTLSClientCAMount(t *testing.T) {
+	ctx := context.Background()
+	ds := newTLSDittoServer("dfs-server-tls", "dfs-client-ca")
+	r := setupDittoServerReconciler(t, fields{dittoServer: ds})
+
+	if _, err := r.reconcileStatefulSet(ctx, ds, 1); err != nil {
+		t.Fatalf("reconcileStatefulSet failed: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, sts); err != nil {
+		t.Fatalf("failed to get StatefulSet: %v", err)
+	}
+	spec := sts.Spec.Template.Spec
+
+	vol := findVolume(spec.Volumes, "tls-client-ca")
+	if vol == nil {
+		t.Fatal("expected a tls-client-ca volume for mTLS")
+	}
+	if vol.Secret == nil || vol.Secret.SecretName != "dfs-client-ca" {
+		t.Errorf("tls-client-ca volume = %+v, want Secret source dfs-client-ca", vol.VolumeSource)
+	}
+	mount := findMount(spec.Containers[0].VolumeMounts, "tls-client-ca")
+	if mount == nil || !mount.ReadOnly || mount.MountPath != v1alpha1.TLSClientCAMountPath {
+		t.Errorf("tls-client-ca mount = %+v, want read-only at %q", mount, v1alpha1.TLSClientCAMountPath)
+	}
+}
+
+// TestReconcileStatefulSet_NoTLSNoCertMount asserts the default (no cert Secret)
+// path mounts neither TLS volume and keeps HTTP probes — preserving back-compat.
+func TestReconcileStatefulSet_NoTLSNoCertMount(t *testing.T) {
+	ctx := context.Background()
+	ds := newHardeningDittoServer() // no ControlPlane TLS
+	r := setupDittoServerReconciler(t, fields{dittoServer: ds})
+
+	if _, err := r.reconcileStatefulSet(ctx, ds, 1); err != nil {
+		t.Fatalf("reconcileStatefulSet failed: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, sts); err != nil {
+		t.Fatalf("failed to get StatefulSet: %v", err)
+	}
+	spec := sts.Spec.Template.Spec
+
+	if findVolume(spec.Volumes, "tls-cert") != nil || findVolume(spec.Volumes, "tls-client-ca") != nil {
+		t.Error("expected no TLS volumes when no cert secret is configured")
+	}
+	if p := spec.Containers[0].LivenessProbe; p == nil || p.HTTPGet == nil || p.HTTPGet.Scheme != corev1.URISchemeHTTP {
+		t.Errorf("expected HTTP liveness probe by default, got %+v", p)
+	}
+}

--- a/pkg/controlplane/api/cleartext_warn_test.go
+++ b/pkg/controlplane/api/cleartext_warn_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// TestIsNonLoopbackHost is a table test for the host classifier that gates the
+// cleartext-credentials warning.
+func TestIsNonLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"", false},          // empty defaults to loopback (127.0.0.1)
+		{"127.0.0.1", false}, // explicit loopback
+		{"127.0.0.5", false}, // anything in 127.0.0.0/8 is loopback
+		{"::1", false},
+		{"[::1]", false},
+		{"localhost", false},
+		{"0.0.0.0", true}, // wildcard reaches off-host
+		{"::", true},
+		{"[::]", true},
+		{"10.0.0.5", true},        // private but off-host
+		{"192.168.1.20", true},    // off-host
+		{"api.example.com", true}, // hostname → assume off-host
+	}
+	for _, c := range cases {
+		if got := isNonLoopbackHost(c.host); got != c.want {
+			t.Errorf("isNonLoopbackHost(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+// captureWarn redirects the global logger to a buffer at WARN level for the
+// duration of the test. The logger output is process-global, so the tests that
+// use this run serially (no t.Parallel).
+var logCaptureMu sync.Mutex
+
+func captureWarn(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	logCaptureMu.Lock()
+	buf := &bytes.Buffer{}
+	logger.InitWithWriter(buf, "WARN", "text", false)
+	t.Cleanup(func() {
+		// Restore a quiet default so later tests are unaffected.
+		logger.InitWithWriter(&bytes.Buffer{}, "ERROR", "text", false)
+		logCaptureMu.Unlock()
+	})
+	return buf
+}
+
+// TestNewServer_CleartextWarnOnNonLoopbackNoTLS asserts that binding the API to
+// a non-loopback host with TLS disabled emits the cleartext-credentials WARN,
+// and that a loopback bind (or a TLS-enabled non-loopback bind) does not.
+func TestNewServer_CleartextWarnOnNonLoopbackNoTLS(t *testing.T) {
+	const warnNeedle = "CLEARTEXT"
+
+	t.Run("non-loopback, no TLS -> warns", func(t *testing.T) {
+		buf := captureWarn(t)
+		cpStore, cfg := testSetup(t, 0)
+		t.Cleanup(func() { _ = cpStore.Close() })
+		cfg.Host = "0.0.0.0"
+		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+			t.Fatalf("NewServer: %v", err)
+		}
+		if !strings.Contains(buf.String(), warnNeedle) {
+			t.Fatalf("expected cleartext WARN for non-loopback no-TLS bind; log was:\n%s", buf.String())
+		}
+	})
+
+	t.Run("loopback, no TLS -> no warn", func(t *testing.T) {
+		buf := captureWarn(t)
+		cpStore, cfg := testSetup(t, 0)
+		t.Cleanup(func() { _ = cpStore.Close() })
+		cfg.Host = "127.0.0.1"
+		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+			t.Fatalf("NewServer: %v", err)
+		}
+		if strings.Contains(buf.String(), warnNeedle) {
+			t.Fatalf("did NOT expect cleartext WARN for loopback bind; log was:\n%s", buf.String())
+		}
+	})
+
+	t.Run("non-loopback, TLS enabled -> no warn", func(t *testing.T) {
+		buf := captureWarn(t)
+		cpStore, cfg := testSetup(t, 0)
+		t.Cleanup(func() { _ = cpStore.Close() })
+		cfg.Host = "0.0.0.0"
+		serverCert := generateCert(t, "localhost", []string{"localhost"}, false, nil)
+		certPath, keyPath := writeCertFiles(t, t.TempDir(), serverCert)
+		cfg.TLS = TLSConfig{CertFile: certPath, KeyFile: keyPath}
+		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+			t.Fatalf("NewServer: %v", err)
+		}
+		if strings.Contains(buf.String(), warnNeedle) {
+			t.Fatalf("did NOT expect cleartext WARN when TLS is enabled; log was:\n%s", buf.String())
+		}
+	})
+}

--- a/pkg/controlplane/api/server.go
+++ b/pkg/controlplane/api/server.go
@@ -75,6 +75,20 @@ func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, resto
 		return nil, fmt.Errorf("failed to configure TLS: %w", err)
 	}
 
+	// Default-posture nudge: a non-loopback bind with no native TLS means
+	// login credentials and JWTs cross the network in cleartext unless an edge
+	// terminator (ingress / mesh / reverse proxy) wraps them. We do NOT
+	// hard-require TLS (back-compat: many deployments terminate at the edge),
+	// so this is a startup WARN pointing at the TLS / external-termination docs
+	// rather than a fatal error.
+	if tlsConfig == nil && isNonLoopbackHost(config.Host) {
+		logger.Warn("control plane API is bound to a non-loopback address with TLS disabled; "+
+			"login credentials and tokens will traverse the network in CLEARTEXT. "+
+			"Configure controlplane.tls.{cert_file,key_file} for native TLS, or terminate TLS at an ingress/mesh. "+
+			"See docs/SECURITY.md.",
+			"host", config.Host)
+	}
+
 	// Get JWT secret from config (prefers env var)
 	jwtSecret := config.GetJWTSecret()
 	if len(jwtSecret) < 32 {
@@ -245,6 +259,29 @@ func (s *Server) TLSEnabled() bool {
 // mTLSEnabled reports whether the server requires verified client certificates.
 func (s *Server) mTLSEnabled() bool {
 	return s.tlsConfig != nil && s.tlsConfig.ClientAuth == tls.RequireAndVerifyClientCert
+}
+
+// isNonLoopbackHost reports whether host binds the API to something other than
+// loopback. An empty host defaults to 127.0.0.1 (loopback) elsewhere, so it is
+// treated as loopback here. A wildcard bind (0.0.0.0 / ::) reaches off-host and
+// counts as non-loopback. A named host that does not parse as an IP (e.g. a
+// hostname) is conservatively treated as non-loopback so the cleartext warning
+// is not silently skipped.
+func isNonLoopbackHost(host string) bool {
+	switch host {
+	case "", "127.0.0.1", "::1", "[::1]", "localhost":
+		return false
+	}
+	// Strip brackets from an IPv6 literal like "[::]".
+	h := host
+	if len(h) >= 2 && h[0] == '[' && h[len(h)-1] == ']' {
+		h = h[1 : len(h)-1]
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return !ip.IsLoopback()
+	}
+	// Non-IP host (hostname): assume it resolves off-host.
+	return true
 }
 
 // displayAddr returns a host:port that is routable for example/log URLs. A

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1163,19 +1163,23 @@ func (r *Runtime) restoreSnapshot(
 				snapID, shareName, models.ErrShareEnabled)
 		}
 	} else {
-		// Force-disable the share for the rollback. The destructive
-		// Reset+replay below must run under a quiesced share; a share that
-		// loaded Enabled at boot would otherwise corrupt mid-rollback. The
-		// share STAYS disabled afterwards, matching the operator-restore
-		// contract (restore leaves the share disabled for inspection). An
-		// already-disabled share is a benign no-op.
-		derr := r.DisableShare(ctx, shareName)
-		if derr != nil && !errors.Is(derr, shares.ErrShareAlreadyDisabled) {
-			return "", fmt.Errorf("restore snapshot %q on share %q: force-disable for rollback: %w: %v",
-				snapID, shareName, models.ErrRestoreAborted, derr)
+		// Force-disable the share for the rollback so the destructive
+		// Reset+replay runs under a quiesced share, and so it stays disabled
+		// afterwards (matching the operator-restore contract). Recovery runs
+		// BEFORE adapters serve, so this is belt-and-suspenders rather than a
+		// concurrency barrier — hence best-effort: an already-disabled share is
+		// a benign no-op, and a share whose control-plane DB row is absent
+		// (e.g. removed out from under a stranded marker) must not wedge boot.
+		switch derr := r.DisableShare(ctx, shareName); {
+		case derr == nil:
+			logger.Info("snapshot restore: rollback force-disabled share before reset",
+				"snapshot_id", snapID, "share", shareName)
+		case errors.Is(derr, shares.ErrShareAlreadyDisabled):
+			// Already quiesced; nothing to do.
+		default:
+			logger.Warn("snapshot restore: rollback could not force-disable share, proceeding (recovery precedes adapter serving)",
+				"snapshot_id", snapID, "share", shareName, "error", derr)
 		}
-		logger.Info("snapshot restore: rollback force-disabled share before reset",
-			"snapshot_id", snapID, "share", shareName)
 	}
 
 	snap, err := r.store.GetSnapshot(ctx, shareName, snapID)

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1145,13 +1145,37 @@ func (r *Runtime) restoreSnapshot(
 	defer rlock.Unlock()
 
 	// --- precheck ---
-	enabled, err := r.sharesSvc.IsShareEnabled(shareName)
-	if err != nil {
-		return "", err
-	}
-	if enabled {
-		return "", fmt.Errorf("restore snapshot %q on share %q: %w",
-			snapID, shareName, models.ErrShareEnabled)
+	// The Enabled precheck guards operator-initiated restores: a destructive
+	// Reset+replay must never run under a live share. The startup rollback
+	// path (recoverInterruptedRestores → isRollback=true) is exempt: the share
+	// may legitimately have loaded Enabled at boot, and refusing here would
+	// wedge the rollback on every subsequent boot, leaving the share stuck
+	// half-restored. Mirror the isRollback exemptions on the safety-snap and
+	// marker blocks below — force-disable the share for the rollback's
+	// duration so the destructive steps still run under a quiesced share.
+	if !internal.isRollback {
+		enabled, err := r.sharesSvc.IsShareEnabled(shareName)
+		if err != nil {
+			return "", err
+		}
+		if enabled {
+			return "", fmt.Errorf("restore snapshot %q on share %q: %w",
+				snapID, shareName, models.ErrShareEnabled)
+		}
+	} else {
+		// Force-disable the share for the rollback. The destructive
+		// Reset+replay below must run under a quiesced share; a share that
+		// loaded Enabled at boot would otherwise corrupt mid-rollback. The
+		// share STAYS disabled afterwards, matching the operator-restore
+		// contract (restore leaves the share disabled for inspection). An
+		// already-disabled share is a benign no-op.
+		derr := r.DisableShare(ctx, shareName)
+		if derr != nil && !errors.Is(derr, shares.ErrShareAlreadyDisabled) {
+			return "", fmt.Errorf("restore snapshot %q on share %q: force-disable for rollback: %w: %v",
+				snapID, shareName, models.ErrRestoreAborted, derr)
+		}
+		logger.Info("snapshot restore: rollback force-disabled share before reset",
+			"snapshot_id", snapID, "share", shareName)
 	}
 
 	snap, err := r.store.GetSnapshot(ctx, shareName, snapID)

--- a/pkg/controlplane/runtime/snapshot_rollback_enabled_test.go
+++ b/pkg/controlplane/runtime/snapshot_rollback_enabled_test.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestRestoreRollback_ProceedsWhenShareEnabledAtBoot is the #8 R-L1 regression.
+//
+// The startup-rollback path (recoverInterruptedRestores → restoreSnapshot with
+// isRollback=true) must NOT be blocked by the operator-restore Enabled
+// precheck. A share that loaded Enabled at boot with a stranded restore marker
+// would, without the isRollback exemption, fail the Enabled precheck
+// (models.ErrShareEnabled) on every boot, wedging the share half-restored
+// forever. The fix force-disables the share for the rollback duration instead.
+//
+// This plants a marker with the share STILL ENABLED, runs startup recovery, and
+// asserts the rollback proceeds: the marker is cleared, the share ends up
+// disabled (matching the operator-restore contract), and the file is restored
+// to the safety-snapshot bytes.
+func TestRestoreRollback_ProceedsWhenShareEnabledAtBoot(t *testing.T) {
+	meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	fx := newByteVerifyFixture(t, meta, "memory")
+	defer fx.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const mib = 1 << 20
+	orig := distinctBytes(mib, 0x11)
+
+	pid := fx.createEmptyFile(ctx, "enabled-rollback.bin")
+	fx.writeFile(ctx, pid, orig)
+
+	// Safety snapshot S: the pristine pre-restore state the rollback restores.
+	safetyID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{NoVerify: true})
+	if err != nil {
+		t.Fatalf("CreateSnapshot(safety): %v", err)
+	}
+	if snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, safetyID); werr != nil {
+		t.Fatalf("WaitForSnapshot(safety): %v", werr)
+	} else if snap.State != models.StateReady {
+		t.Fatalf("safety snap state = %q, want ready", snap.State)
+	}
+
+	// Mutate in place: the half-restored, post-snapshot state to discard.
+	mut := distinctBytes(mib, 0x22)
+	fx.writeFile(ctx, pid, mut)
+
+	// Confirm the share is ENABLED at this point — the whole point of the test.
+	// We deliberately do NOT call DisableShare, modeling a share that loaded
+	// Enabled at boot with a stranded marker.
+	if enabled, eerr := fx.rt.sharesSvc.IsShareEnabled(fx.shareName); eerr != nil {
+		t.Fatalf("IsShareEnabled: %v", eerr)
+	} else if !enabled {
+		t.Fatal("test precondition: share must be ENABLED before recovery")
+	}
+
+	// Plant the restore marker naming S as the safety snapshot — exactly what a
+	// crash mid-restore leaves behind, except the share is still Enabled.
+	if perr := fx.store.PutRestoreMarker(ctx, &models.RestoreMarker{
+		ShareName:        fx.shareName,
+		TargetSnapshotID: safetyID,
+		SafetySnapshotID: safetyID,
+		Step:             models.RestoreStepStarted,
+	}); perr != nil {
+		t.Fatalf("PutRestoreMarker: %v", perr)
+	}
+
+	// Run startup recovery. With the R-L1 fix the rollback force-disables the
+	// share and proceeds; without it this returns models.ErrShareEnabled and
+	// the marker is retained (wedged share).
+	if err := fx.rt.recoverInterruptedRestores(ctx); err != nil {
+		t.Fatalf("recoverInterruptedRestores returned error (rollback wedged on Enabled share): %v", err)
+	}
+
+	// Marker cleared → rollback completed (not retained-on-failure).
+	if _, gerr := fx.store.GetRestoreMarker(ctx, fx.shareName); gerr == nil {
+		t.Fatal("restore marker still present after recovery — rollback did not proceed (R-L1 regression)")
+	}
+
+	// Share force-disabled and STAYS disabled (operator-restore contract).
+	if enabled, eerr := fx.rt.sharesSvc.IsShareEnabled(fx.shareName); eerr != nil {
+		t.Fatalf("IsShareEnabled after rollback: %v", eerr)
+	} else if enabled {
+		t.Fatal("share should be DISABLED after rollback (force-disabled for rollback duration)")
+	}
+
+	// File restored to the safety-snapshot bytes, not the discarded mutation.
+	if !fx.fileExists(ctx, "enabled-rollback.bin") {
+		t.Fatal("file missing after rollback")
+	}
+	got := fx.readFile(ctx, pid, len(orig))
+	if !bytes.Equal(got, orig) {
+		t.Fatalf("rolled-back file NOT byte-identical to safety snapshot: %s", firstDiff(orig, got))
+	}
+}


### PR DESCRIPTION
Part of #1014.

Three tracked v1.0 follow-ups, all default-off / back-compat.

## 1a — Operator: pod-level native TLS via cert-Secret mount
Builds on the native control-plane TLS shipped in #1038. A `DittoServer` can now serve native TLS end-to-end inside the cluster instead of relying only on edge termination.

- **CRD**: new `controlPlane.certSecretName` (server cert/key Secret, standard `tls.crt`/`tls.key` keys) and optional `controlPlane.clientCASecretName` (CA bundle under `ca.crt`, for mTLS). CRD manifests regenerated and synced to the chart.
- **Pod**: when a cert Secret is named, the operator mounts it (and the optional client-CA Secret) read-only into the `dfs` container and renders `controlplane.tls.{cert_file,key_file,client_ca}`. Health probes switch to the HTTPS scheme; under mTLS they fall back to `TCPSocket` (the kubelet can't present a client cert).
- **Operator client**: a cert Secret implies `https`; the Secret's `ca.crt` is loaded into the API client's `RootCAs` so the operator verifies the pod certificate **without** `InsecureSkipVerify` (falls back to system roots when no CA is present).
- **Webhook**: rejects `clientCASecretName` without `certSecretName`; warns when a cert Secret is set with `tls: false`.

Keeps the #1032 `controlPlane.tls` opt-in semantics (default off → plain http / edge-terminated unchanged).

## 1b — Cleartext-posture WARN
When `controlplane.host` is non-loopback (e.g. `0.0.0.0`) **and** TLS is unset, `NewServer` logs a startup WARN that credentials will cross the network in cleartext, pointing at the TLS / external-termination docs. Not a hard requirement (back-compat).

## 2 — Snapshot R-L1 (LOW liveness fix)
`restoreSnapshot`'s share-enabled precheck returned `ErrShareEnabled` unconditionally, so a share that loaded Enabled at boot with a stranded restore marker would fail the startup rollback (`recoverInterruptedRestores` → `isRollback=true`) on **every** boot, wedging the share half-restored. Now the precheck is exempted on `isRollback`, force-disabling the share for the rollback's duration (best-effort: recovery runs before adapters serve). Mirrors the existing `isRollback` exemptions on the safety-snap and marker blocks.

## Tests
- R-L1: rollback proceeds when the share is Enabled at boot (fails without the fix; verified).
- Cleartext WARN: warn / no-warn (loopback, TLS-enabled) + `isNonLoopbackHost` table.
- Operator: cert/client-CA mount rendering (envtest), HTTPS/TCPSocket probe selection, config `tls` block rendering + drift guard, scheme upgrade + native/mutual TLS helpers, CA-trust client wiring (no `InsecureSkipVerify`), webhook rules.

## Gates
`go build ./...`, `go vet` (both modules), `go fmt`, `helm lint`, `go test -race ./pkg/controlplane/... ./pkg/config/...`, operator `api` + `controller` (envtest) — all green.