### PR TITLE
fix(nfs/v4): encode partial reply on COMPOUND cancel

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -517,21 +517,27 @@ func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, fir
 		if i == 0 {
 			opCode = firstOpCode
 		} else {
-			// Check context cancellation between operations
-			select {
-			case <-compCtx.Context.Done():
+			// Check context cancellation between operations. Mirror the
+			// SEQUENCE-bearing path (dispatchV41): instead of returning a bare
+			// error (which makes the RPC layer drop the reply and reset the
+			// connection), encode a partial response with NFS4ERR_DELAY so the
+			// client receives a well-formed reply and can retry.
+			if compCtx.Context.Err() != nil {
 				logger.Debug("NFSv4.1 COMPOUND cancelled between ops",
 					"op_index", i,
 					"total_ops", numOps,
 					"client", compCtx.ClientAddr)
-				return nil, compCtx.Context.Err()
-			default:
+				lastStatus = types.NFS4ERR_DELAY
+				break
 			}
 
+			// Read operation code. On decode error, encode the partial response
+			// gathered so far rather than dropping the reply.
 			var err error
 			opCode, err = xdr.DecodeUint32(reader)
 			if err != nil {
-				return nil, fmt.Errorf("decode v4.1 op %d opcode: %w", i, err)
+				lastStatus = types.NFS4ERR_BADXDR
+				break
 			}
 		}
 

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2388,3 +2388,73 @@ func encodeReleaseLockOwnerArgsForTest() []byte {
 	_ = xdr.WriteXDROpaque(&buf, []byte("test-lock-owner"))
 	return buf.Bytes()
 }
+
+// TestCompound_V41ExemptOps_CancelledContext_EncodesPartialReply verifies that
+// when a v4.1 exempt-op COMPOUND (dispatched via dispatchV41Ops with no session
+// context) is cancelled between operations, the handler encodes a well-formed
+// partial reply with NFS4ERR_DELAY instead of returning a bare error that would
+// make the RPC layer drop the reply and reset the connection. This mirrors the
+// SEQUENCE-bearing path (dispatchV41), so both behave identically on cancel.
+func TestCompound_V41ExemptOps_CancelledContext_EncodesPartialReply(t *testing.T) {
+	h := newTestHandler()
+
+	// Cancel the context before dispatch. EXCHANGE_ID (op0) is session-exempt
+	// and executes first; the cancellation is observed at the next op boundary.
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx := &types.CompoundContext{
+		Context:    cancelCtx,
+		ClientAddr: "127.0.0.1:12345",
+	}
+
+	ownerID := []byte("cancel-test-client")
+	var verifier [8]byte
+	copy(verifier[:], "cancelvf")
+	eidArgs := encodeExchangeIdArgs(ownerID, verifier, 0, types.SP4_NONE, nil)
+
+	// Two ops: EXCHANGE_ID (exempt, op0) then GETATTR. The cancel check fires at
+	// op index 1, before GETATTR is dispatched.
+	ops := []compoundOp{
+		{opCode: types.OP_EXCHANGE_ID, data: eidArgs},
+		{opCode: types.OP_GETATTR, data: encodeGetAttrArgsForCancel()},
+	}
+	data := buildCompoundArgsWithOps([]byte("cxl"), 1, ops)
+
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound returned error (reply dropped, connection would reset): %v", err)
+	}
+	if len(resp) == 0 {
+		t.Fatal("ProcessCompound returned empty reply on cancel; expected encoded partial response")
+	}
+
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+
+	// Overall status must be DELAY so the client retries.
+	if decoded.Status != types.NFS4ERR_DELAY {
+		t.Errorf("overall status = %d, want NFS4ERR_DELAY (%d)", decoded.Status, types.NFS4ERR_DELAY)
+	}
+	// The partial reply must include the op0 (EXCHANGE_ID) result, which
+	// dispatched before the cancellation was observed; op1 (GETATTR) was skipped
+	// at the next op boundary.
+	if decoded.NumResults != 1 {
+		t.Errorf("numResults = %d, want 1 (EXCHANGE_ID completed, GETATTR cancelled)", decoded.NumResults)
+	}
+	if decoded.NumResults >= 1 && decoded.Results[0].OpCode != types.OP_EXCHANGE_ID {
+		t.Errorf("first result opcode = %d, want OP_EXCHANGE_ID (%d)",
+			decoded.Results[0].OpCode, types.OP_EXCHANGE_ID)
+	}
+	if string(decoded.Tag) != "cxl" {
+		t.Errorf("tag = %q, want %q (tag must be echoed in partial reply)", string(decoded.Tag), "cxl")
+	}
+}
+
+// encodeGetAttrArgsForCancel encodes a minimal GETATTR bitmap4 (empty request).
+func encodeGetAttrArgsForCancel() []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, 0) // bitmap length = 0
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Problem

`dispatchV41Ops` (the v4.1 exempt-op COMPOUND dispatch path) returned a bare error on context cancellation between operations:

```go
return nil, compCtx.Context.Err()
```

This propagates an error to the TCP/RPC layer, which **drops the reply entirely** — the client sees a connection reset with no encoded response.

The sibling SEQUENCE-bearing path (`dispatchV41`) already handles the same cancellation correctly: it sets `lastStatus = NFS4ERR_DELAY` and breaks the loop, letting the partial response be encoded and returned so the client can retry.

## Fix

Align `dispatchV41Ops` with `dispatchV41`:

- On cancellation: set `NFS4ERR_DELAY` and `break` so the partial response (containing any ops that already completed) is encoded and returned.
- On decode error: set `NFS4ERR_BADXDR` and `break` instead of returning a bare error, matching the sibling path.

Both v4.1 dispatch loops now behave identically on cancellation and malformed input.

## Scope

`dispatchV41Ops` has exactly one caller — the exempt-op path (`v41ctx=nil`, no session). Exempt ops carry no slot/replay state, so there is no replay-cache interaction to preserve here.

## Test

Adds `TestCompound_V41ExemptOps_CancelledContext_EncodesPartialReply`: builds a v4.1 COMPOUND `[EXCHANGE_ID, GETATTR]` under an already-cancelled context, and asserts `ProcessCompound` returns a well-formed reply (err == nil) with overall status `NFS4ERR_DELAY` and the completed `EXCHANGE_ID` result present — proving the reply is no longer dropped.

Gates: `go build ./...`, `go vet`, `gofmt -l` clean, `go test -race ./internal/adapter/nfs/...` green.