### PR TITLE
refactor(smb/durable): push reconnect identity validation into lock.DurableHandleStore domain

### DIFF
--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -705,9 +706,9 @@ func processV2Reconnect(
 // place that mutates the durable store on reconnect, which is what makes the
 // path safe against the V1/V2 reconnect TOCTOU window.
 //
-// TODO: per CLAUDE.md invariant 1 the identity check (username) belongs in
-// pkg/metadata/lock — e.g. inside the Consume* call returning a typed mismatch
-// error. Left in the handler for this iteration to keep the scope small.
+// The share/path/identity matching itself lives in the lock domain
+// (PersistedDurableHandle.ValidateReconnect, pkg/metadata/lock) per CLAUDE.md
+// invariant 1; the handler only maps the typed mismatch back to an SMB status.
 func validateAndRestore(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -721,33 +722,40 @@ func validateAndRestore(
 	checkPath bool,
 	consume func(ctx context.Context) (*lock.PersistedDurableHandle, error),
 ) (*OpenFile, types.Status, error) {
-	if handle.ShareName != shareName {
-		logger.Debug("validateAndRestore: share name mismatch",
-			"expected", handle.ShareName,
-			"actual", shareName)
-		return nil, types.StatusObjectNameNotFound, nil
-	}
-
-	// V1 oplock-backed reconnect ignores the filename per MS-SMB2 §3.3.5.9.7
-	// (mirrors Samba `smbd_smb2_create_durable_lease_check` which only path-
-	// checks lease-backed reopens). Caller passes checkPath=false in that case.
-	if checkPath && handle.Path != filename {
-		logger.Debug("validateAndRestore: path mismatch",
-			"expected", handle.Path,
-			"actual", filename)
-		return nil, types.StatusInvalidParameter, nil
-	}
-
-	if handle.Username != username {
-		logger.Debug("validateAndRestore: username mismatch",
-			"expected", handle.Username,
-			"actual", username)
-		return nil, types.StatusAccessDenied, nil
+	// Identity/path/share matching is owned by the lock domain. Map the typed
+	// mismatch back to the SMB status the reconnect ladder expects (share →
+	// OBJECT_NAME_NOT_FOUND, path → INVALID_PARAMETER, user → ACCESS_DENIED).
+	// V1/V2 oplock-backed reconnect ignores the filename per MS-SMB2 §3.3.5.9.7/12
+	// (mirrors Samba `smbd_smb2_create_durable_lease_check`, which only path-checks
+	// lease-backed reopens), so checkPath is false in that case.
+	if err := handle.ValidateReconnect(lock.ReconnectIdentity{
+		ShareName: shareName,
+		Username:  username,
+		Filename:  filename,
+		CheckPath: checkPath,
+	}); err != nil {
+		var mismatch *lock.DurableHandleMismatchError
+		if errors.As(err, &mismatch) {
+			logger.Debug("validateAndRestore: reconnect identity mismatch",
+				"kind", mismatch.Kind,
+				"expected", mismatch.Expected,
+				"actual", mismatch.Actual)
+			switch mismatch.Kind {
+			case lock.MismatchPath:
+				return nil, types.StatusInvalidParameter, nil
+			case lock.MismatchUser:
+				return nil, types.StatusAccessDenied, nil
+			default: // MismatchShare and any future kinds
+				return nil, types.StatusObjectNameNotFound, nil
+			}
+		}
+		logger.Warn("validateAndRestore: reconnect validation error", "error", err)
+		return nil, types.StatusInternalError, err
 	}
 
 	// NOTE: We intentionally do NOT compare session key hashes here.
 	// Per MS-SMB2 3.3.5.9.7/12, the server validates the user identity
-	// (username check above), not the session key. With NTLM KEY_EXCH,
+	// (ValidateReconnect above), not the session key. With NTLM KEY_EXCH,
 	// each session generates a random ExportedSessionKey, so the session
 	// key hash will differ between the original and reconnect sessions
 	// even for the same user with the same credentials.

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -2,8 +2,88 @@ package lock
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
+
+// DurableMismatchKind classifies why a durable-handle reconnect identity check
+// failed. Each kind maps to a distinct SMB2 status at the protocol boundary
+// (the adapter is responsible for that translation), keeping the matching rules
+// themselves in the lock domain.
+type DurableMismatchKind int
+
+const (
+	// MismatchShare — the reconnecting tree connect is for a different share
+	// than the one that owned the persisted handle (MS-SMB2 §3.3.5.9.7/12).
+	MismatchShare DurableMismatchKind = iota
+	// MismatchPath — the reconnect CREATE names a different path than the
+	// persisted open (lease/path-checked reopens only).
+	MismatchPath
+	// MismatchUser — the reconnecting session belongs to a different user than
+	// the one that established the durable open.
+	MismatchUser
+)
+
+// DurableHandleMismatchError is returned by ValidateReconnect when a persisted
+// durable handle does not match the reconnect request's identity/path/share.
+// It is a sentinel-style typed error: callers inspect Kind to decide how to
+// surface the failure, while the persisted handle is left intact (a transient
+// mismatched retry must not destroy a still-reclaimable open).
+type DurableHandleMismatchError struct {
+	Kind     DurableMismatchKind
+	Expected string
+	Actual   string
+}
+
+func (e *DurableHandleMismatchError) Error() string {
+	var field string
+	switch e.Kind {
+	case MismatchShare:
+		field = "share name"
+	case MismatchPath:
+		field = "path"
+	case MismatchUser:
+		field = "username"
+	default:
+		field = "field"
+	}
+	return fmt.Sprintf("durable handle reconnect %s mismatch: expected %q, got %q", field, e.Expected, e.Actual)
+}
+
+// ReconnectIdentity carries the identity/path/share the reconnect CREATE
+// presents, to be matched against a persisted durable handle.
+type ReconnectIdentity struct {
+	ShareName string
+	Username  string
+	// Filename is compared against the persisted Path only when CheckPath is
+	// set. A V1/V2 oplock-backed (non-lease) reconnect ignores the filename
+	// per MS-SMB2 §3.3.5.9.7/12 (mirrors Samba smbd_smb2_create_durable_lease_check,
+	// which only path-checks lease-backed reopens), so the caller passes
+	// CheckPath=false in that case.
+	Filename  string
+	CheckPath bool
+}
+
+// ValidateReconnect checks that a persisted durable handle matches the identity
+// presented by a reconnect CREATE. It returns a *DurableHandleMismatchError (so
+// callers can switch on Kind) when share name, path, or user identity does not
+// match, and nil when the handle is reclaimable by this request. Session-key
+// hashes are intentionally NOT compared: per MS-SMB2 §3.3.5.9.7/12 the server
+// validates the user identity, not the session key, and NTLM KEY_EXCH gives
+// each session a fresh ExportedSessionKey so the hash differs across reconnect
+// even for the same credentials.
+func (h *PersistedDurableHandle) ValidateReconnect(req ReconnectIdentity) error {
+	if h.ShareName != req.ShareName {
+		return &DurableHandleMismatchError{Kind: MismatchShare, Expected: h.ShareName, Actual: req.ShareName}
+	}
+	if req.CheckPath && h.Path != req.Filename {
+		return &DurableHandleMismatchError{Kind: MismatchPath, Expected: h.Path, Actual: req.Filename}
+	}
+	if h.Username != req.Username {
+		return &DurableHandleMismatchError{Kind: MismatchUser, Expected: h.Username, Actual: req.Username}
+	}
+	return nil
+}
 
 // PersistedDurableHandle is the storage representation of a durable open.
 // When a client disconnects, the open file state is serialized into this struct

--- a/pkg/metadata/lock/durable_store_test.go
+++ b/pkg/metadata/lock/durable_store_test.go
@@ -1,0 +1,90 @@
+package lock
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateReconnect_Matches(t *testing.T) {
+	h := &PersistedDurableHandle{
+		ShareName: "share",
+		Username:  "alice",
+		Path:      "dir/file.txt",
+	}
+
+	// Path check off: filename is ignored (oplock-backed reconnect).
+	err := h.ValidateReconnect(ReconnectIdentity{
+		ShareName: "share",
+		Username:  "alice",
+		Filename:  "junk-name",
+		CheckPath: false,
+	})
+	assert.NoError(t, err)
+
+	// Path check on: filename must match the persisted path.
+	err = h.ValidateReconnect(ReconnectIdentity{
+		ShareName: "share",
+		Username:  "alice",
+		Filename:  "dir/file.txt",
+		CheckPath: true,
+	})
+	assert.NoError(t, err)
+}
+
+func TestValidateReconnect_Mismatch(t *testing.T) {
+	h := &PersistedDurableHandle{
+		ShareName: "share",
+		Username:  "alice",
+		Path:      "dir/file.txt",
+	}
+
+	cases := []struct {
+		name string
+		req  ReconnectIdentity
+		kind DurableMismatchKind
+	}{
+		{
+			name: "share",
+			req:  ReconnectIdentity{ShareName: "other", Username: "alice"},
+			kind: MismatchShare,
+		},
+		{
+			name: "path",
+			req:  ReconnectIdentity{ShareName: "share", Username: "alice", Filename: "wrong", CheckPath: true},
+			kind: MismatchPath,
+		},
+		{
+			name: "user",
+			req:  ReconnectIdentity{ShareName: "share", Username: "bob"},
+			kind: MismatchUser,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := h.ValidateReconnect(tc.req)
+			require.Error(t, err)
+			var mismatch *DurableHandleMismatchError
+			require.True(t, errors.As(err, &mismatch))
+			assert.Equal(t, tc.kind, mismatch.Kind)
+		})
+	}
+}
+
+// Share mismatch takes precedence over a path mismatch, mirroring the order the
+// reconnect ladder checks fields in.
+func TestValidateReconnect_ShareBeforePath(t *testing.T) {
+	h := &PersistedDurableHandle{ShareName: "share", Username: "alice", Path: "p"}
+	err := h.ValidateReconnect(ReconnectIdentity{
+		ShareName: "other",
+		Username:  "alice",
+		Filename:  "q",
+		CheckPath: true,
+	})
+	var mismatch *DurableHandleMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	assert.Equal(t, MismatchShare, mismatch.Kind)
+}


### PR DESCRIPTION
## Summary

Resolves the CLAUDE.md invariant-1 TODO in `validateAndRestore`: durable-handle reconnect identity/path/share matching no longer lives inside the SMB handler.

- Adds `PersistedDurableHandle.ValidateReconnect(ReconnectIdentity)` in `pkg/metadata/lock`, which performs the share-name / path / username matching and returns a typed `*DurableHandleMismatchError` (with a `Kind`: `MismatchShare` / `MismatchPath` / `MismatchUser`).
- The SMB handler (`durable_context.go`) now only maps that typed error to the SMB status: share → `OBJECT_NAME_NOT_FOUND`, path → `INVALID_PARAMETER`, user → `ACCESS_DENIED`.
- Exact reconnect semantics preserved: same checks, same order (share → path → user), path check still gated on `checkPath` (oplock-backed V1/V2 reconnect ignores the filename per MS-SMB2 §3.3.5.9.7/12), session-key hash still intentionally not compared. The non-destructive-lookup-then-`consume` TOCTOU pattern is untouched.

## Tests

- New `pkg/metadata/lock/durable_store_test.go` covering match, each mismatch kind, path-check-off, and share-before-path precedence.
- `go test -race ./internal/adapter/smb/... ./pkg/metadata/...` green (metadata conformance included).

Closes #1056