### PR TITLE
refactor(smb): collapse 3 pending registries into one generic

### DIFF
--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -50,28 +50,22 @@ type PendingCreate struct {
 	startedOnce sync.Once
 }
 
-// PendingCreateRegistry indexes pending CREATEs by three keys: per-connection
-// MessageID (for synchronous CANCEL), AsyncId (for async-flagged CANCEL), and
-// SessionID (for session teardown). Thread-safe.
-//
-// An entry is removed exactly once: either by the resume goroutine after it
-// delivers the final response (via Unregister) or by CANCEL / teardown (via
-// UnregisterByMessageID / UnregisterByAsyncId / UnregisterAllForSession).
-// The resume goroutine must check whether its entry is still registered before
-// sending, so a concurrent CANCEL does not produce a duplicate response for
-// the same MessageID.
-type PendingCreateRegistry struct {
-	mu        sync.Mutex
-	byMsgKey  map[createMsgKey]*PendingCreate
-	byAsyncId map[uint64]*PendingCreate
-	bySession map[uint64]map[uint64]*PendingCreate // sessionID -> asyncId -> entry
-	maxOps    int
-}
-
+// createMsgKey scopes a MessageID to its connection, since SMB2 MessageIDs are
+// per-connection.
 type createMsgKey struct {
 	ConnID    uint64
 	MessageID uint64
 }
+
+// Secondary-index slots for PendingCreateRegistry, in configured order.
+const (
+	createIdxMsgKey = iota
+)
+
+// Bucket-index slots for PendingCreateRegistry, in configured order.
+const (
+	createBucketSession = iota
+)
 
 // MaxPendingCreates caps concurrent parked CREATEs per server to protect the
 // process from runaway clients. Picked to match MaxPendingWatches.
@@ -95,13 +89,35 @@ var ErrDuplicateAsyncId = fmt.Errorf("duplicate AsyncId in PendingCreateRegistry
 // the new registration rather than silently evicting the prior entry.
 var ErrDuplicateMessageID = fmt.Errorf("duplicate (ConnID, MessageID) in PendingCreateRegistry")
 
+// PendingCreateRegistry indexes pending CREATEs by three keys: per-connection
+// MessageID (for synchronous CANCEL), AsyncId (for async-flagged CANCEL), and
+// SessionID (for session teardown). Thread-safe.
+//
+// An entry is removed exactly once: either by the resume goroutine after it
+// delivers the final response (via Unregister) or by CANCEL / teardown (via
+// UnregisterByMessageID / UnregisterByAsyncId / UnregisterAllForSession).
+// The resume goroutine must check whether its entry is still registered before
+// sending, so a concurrent CANCEL does not produce a duplicate response for
+// the same MessageID.
+type PendingCreateRegistry struct {
+	reg *pendingRegistry[PendingCreate]
+}
+
 // NewPendingCreateRegistry builds an empty registry.
 func NewPendingCreateRegistry() *PendingCreateRegistry {
 	return &PendingCreateRegistry{
-		byMsgKey:  make(map[createMsgKey]*PendingCreate),
-		byAsyncId: make(map[uint64]*PendingCreate),
-		bySession: make(map[uint64]map[uint64]*PendingCreate),
-		maxOps:    MaxPendingCreates,
+		reg: newPendingRegistry(registryConfig[PendingCreate]{
+			asyncID: func(p *PendingCreate) uint64 { return p.AsyncId },
+			indexes: []keyFunc[PendingCreate]{
+				func(p *PendingCreate) any {
+					return createMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
+				},
+			},
+			buckets: []keyFunc[PendingCreate]{
+				func(p *PendingCreate) any { return p.SessionID },
+			},
+			maxOps: MaxPendingCreates,
+		}),
 	}
 }
 
@@ -110,37 +126,27 @@ func NewPendingCreateRegistry() *PendingCreateRegistry {
 // failure cases the registry is left untouched and the caller owns releasing
 // its reserved async slot.
 func (r *PendingCreateRegistry) Register(p *PendingCreate) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.reg.mu.Lock()
+	defer r.reg.mu.Unlock()
 
-	if len(r.byAsyncId) >= r.maxOps {
+	if len(r.reg.byAsyncID) >= r.reg.maxOps {
 		return ErrTooManyPendingCreates
 	}
-
-	key := createMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
-	if _, dup := r.byMsgKey[key]; dup {
+	if r.reg.lookupLocked(createIdxMsgKey, createMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}) != nil {
 		return ErrDuplicateMessageID
 	}
-	if _, dup := r.byAsyncId[p.AsyncId]; dup {
+	if _, dup := r.reg.byAsyncID[p.AsyncId]; dup {
 		return ErrDuplicateAsyncId
 	}
 
-	r.byMsgKey[key] = p
-	r.byAsyncId[p.AsyncId] = p
-
-	bucket, ok := r.bySession[p.SessionID]
-	if !ok {
-		bucket = make(map[uint64]*PendingCreate)
-		r.bySession[p.SessionID] = bucket
-	}
-	bucket[p.AsyncId] = p
+	r.reg.insertLocked(p)
 
 	logger.Debug("PendingCreateRegistry: registered",
 		"connID", p.ConnID,
 		"sessionID", p.SessionID,
 		"messageID", p.MessageID,
 		"asyncId", p.AsyncId,
-		"total", len(r.byAsyncId))
+		"total", len(r.reg.byAsyncID))
 	return nil
 }
 
@@ -149,23 +155,17 @@ func (r *PendingCreateRegistry) Register(p *PendingCreate) error {
 // response. Returns the removed entry, or nil if it was already unregistered
 // (e.g. by a concurrent CANCEL).
 func (r *PendingCreateRegistry) Unregister(asyncId uint64) *PendingCreate {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.removeLocked(asyncId)
+	return r.reg.unregisterByAsyncID(asyncId)
 }
 
 // UnregisterByMessageID removes a pending CREATE matching (connID, messageID)
 // and invokes its Cancel closure to unblock the resume goroutine. Returns the
 // removed entry, or nil if none matched. Used by synchronous SMB2_CANCEL.
 func (r *PendingCreateRegistry) UnregisterByMessageID(connID, messageID uint64) *PendingCreate {
-	r.mu.Lock()
-	p, ok := r.byMsgKey[createMsgKey{ConnID: connID, MessageID: messageID}]
-	if !ok {
-		r.mu.Unlock()
+	p := r.reg.unregisterByIndex(createIdxMsgKey, createMsgKey{ConnID: connID, MessageID: messageID})
+	if p == nil {
 		return nil
 	}
-	r.removeLocked(p.AsyncId)
-	r.mu.Unlock()
 	// Release the started gate so any resume goroutine racing the cancel
 	// path past its Unregister check will not deadlock waiting on dispatch
 	// to MarkStarted (CANCEL/teardown bypass the dispatcher).
@@ -179,9 +179,7 @@ func (r *PendingCreateRegistry) UnregisterByMessageID(connID, messageID uint64) 
 // UnregisterByAsyncId removes a pending CREATE matching asyncId and invokes
 // its Cancel closure. Used by async-flagged SMB2_CANCEL.
 func (r *PendingCreateRegistry) UnregisterByAsyncId(asyncId uint64) *PendingCreate {
-	r.mu.Lock()
-	p := r.removeLocked(asyncId)
-	r.mu.Unlock()
+	p := r.reg.unregisterByAsyncID(asyncId)
 	if p != nil {
 		markStarted(p)
 		if p.Cancel != nil {
@@ -195,19 +193,7 @@ func (r *PendingCreateRegistry) UnregisterByAsyncId(asyncId uint64) *PendingCrea
 // with sessionID, invoking Cancel on each. Used by session teardown to unblock
 // goroutines before the session state they depend on is freed.
 func (r *PendingCreateRegistry) UnregisterAllForSession(sessionID uint64) []*PendingCreate {
-	r.mu.Lock()
-	bucket, ok := r.bySession[sessionID]
-	if !ok {
-		r.mu.Unlock()
-		return nil
-	}
-	removed := make([]*PendingCreate, 0, len(bucket))
-	for asyncId := range bucket {
-		if p := r.removeLocked(asyncId); p != nil {
-			removed = append(removed, p)
-		}
-	}
-	r.mu.Unlock()
+	removed := r.reg.unregisterBucket(createBucketSession, sessionID)
 	for _, p := range removed {
 		markStarted(p)
 		if p.Cancel != nil {
@@ -217,23 +203,6 @@ func (r *PendingCreateRegistry) UnregisterAllForSession(sessionID uint64) []*Pen
 	return removed
 }
 
-// removeLocked drops entries keyed on asyncId from all maps. Caller holds mu.
-func (r *PendingCreateRegistry) removeLocked(asyncId uint64) *PendingCreate {
-	p, ok := r.byAsyncId[asyncId]
-	if !ok {
-		return nil
-	}
-	delete(r.byAsyncId, asyncId)
-	delete(r.byMsgKey, createMsgKey{ConnID: p.ConnID, MessageID: p.MessageID})
-	if bucket, ok := r.bySession[p.SessionID]; ok {
-		delete(bucket, asyncId)
-		if len(bucket) == 0 {
-			delete(r.bySession, p.SessionID)
-		}
-	}
-	return p
-}
-
 // ReplaceCallback atomically replaces the Callback of a pending CREATE
 // identified by asyncId. Used by the compound processor to redirect the
 // CREATE's completion from sending a standalone response to continuing
@@ -241,9 +210,9 @@ func (r *PendingCreateRegistry) removeLocked(asyncId uint64) *PendingCreate {
 // true if the entry was found and updated, false if it was already gone
 // (e.g. concurrently cancelled).
 func (r *PendingCreateRegistry) ReplaceCallback(asyncId uint64, cb AsyncCreateCompleteCallback) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p, ok := r.byAsyncId[asyncId]
+	r.reg.mu.Lock()
+	defer r.reg.mu.Unlock()
+	p, ok := r.reg.byAsyncID[asyncId]
 	if !ok {
 		return false
 	}
@@ -261,9 +230,9 @@ func (r *PendingCreateRegistry) ReplaceCallback(asyncId uint64, cb AsyncCreateCo
 // was no longer in the registry. The latter is not an error — CANCEL /
 // teardown already drove the callback synchronously and the gate is moot.
 func (r *PendingCreateRegistry) MarkStarted(asyncId uint64) bool {
-	r.mu.Lock()
-	p, ok := r.byAsyncId[asyncId]
-	r.mu.Unlock()
+	r.reg.mu.Lock()
+	p, ok := r.reg.byAsyncID[asyncId]
+	r.reg.mu.Unlock()
 	if !ok {
 		return false
 	}
@@ -285,7 +254,5 @@ func markStarted(p *PendingCreate) {
 
 // Len returns the number of pending CREATEs.
 func (r *PendingCreateRegistry) Len() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return len(r.byAsyncId)
+	return r.reg.Len()
 }

--- a/internal/adapter/smb/handlers/pending_create_registry_test.go
+++ b/internal/adapter/smb/handlers/pending_create_registry_test.go
@@ -163,7 +163,7 @@ func TestPendingCreateRegistry_RegisterRejectsDuplicateAsyncId(t *testing.T) {
 
 func TestPendingCreateRegistry_RegisterOverflow(t *testing.T) {
 	r := NewPendingCreateRegistry()
-	r.maxOps = 2 // shrink for test speed
+	r.reg.maxOps = 2 // shrink for test speed
 	var calls atomic.Int32
 
 	if err := r.Register(newTestPendingCreate(1, 1, 1, 1, &calls)); err != nil {

--- a/internal/adapter/smb/handlers/pending_lock_registry.go
+++ b/internal/adapter/smb/handlers/pending_lock_registry.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -69,30 +68,23 @@ type PendingLock struct {
 	LockSeqNumber  uint8
 }
 
-// PendingLockRegistry indexes pending blocking LOCKs by four keys:
-// per-connection MessageID (synchronous CANCEL), AsyncId (async-flagged
-// CANCEL), SessionID (LOGOFF / connection cleanup), and TreeID (TREE_DISCONNECT
-// — smb2.lock.cancel-tdis). Thread-safe.
-//
-// An entry is removed exactly once: either by the resume goroutine after it
-// delivers the final response (via Unregister) or by a cancellation path
-// (UnregisterByMessageID / UnregisterByAsyncId / UnregisterAllForSession /
-// UnregisterAllForTree). The resume goroutine must check whether its entry is
-// still registered before sending, so a concurrent CANCEL does not produce a
-// duplicate response for the same MessageID.
-type PendingLockRegistry struct {
-	mu        sync.Mutex
-	byMsgKey  map[lockMsgKey]*PendingLock
-	byAsyncId map[uint64]*PendingLock
-	bySession map[uint64]map[uint64]*PendingLock // sessionID -> asyncId -> entry
-	byTree    map[uint32]map[uint64]*PendingLock // treeID -> asyncId -> entry
-	maxOps    int
-}
-
+// lockMsgKey scopes a MessageID to its connection (SMB2 MessageIDs are
+// per-connection).
 type lockMsgKey struct {
 	ConnID    uint64
 	MessageID uint64
 }
+
+// Secondary-index slots for PendingLockRegistry, in configured order.
+const (
+	lockIdxMsgKey = iota
+)
+
+// Bucket-index slots for PendingLockRegistry, in configured order.
+const (
+	lockBucketSession = iota
+	lockBucketTree
+)
 
 // MaxPendingLocks caps concurrent parked blocking LOCKs per server. Picked to
 // match MaxPendingCreates.
@@ -110,14 +102,37 @@ var ErrDuplicateLockAsyncId = fmt.Errorf("duplicate AsyncId in PendingLockRegist
 // (ConnID, MessageID) pair that is already in the registry.
 var ErrDuplicateLockMessageID = fmt.Errorf("duplicate (ConnID, MessageID) in PendingLockRegistry")
 
+// PendingLockRegistry indexes pending blocking LOCKs by four keys:
+// per-connection MessageID (synchronous CANCEL), AsyncId (async-flagged
+// CANCEL), SessionID (LOGOFF / connection cleanup), and TreeID (TREE_DISCONNECT
+// — smb2.lock.cancel-tdis). Thread-safe.
+//
+// An entry is removed exactly once: either by the resume goroutine after it
+// delivers the final response (via Unregister) or by a cancellation path
+// (UnregisterByMessageID / UnregisterByAsyncId / UnregisterAllForSession /
+// UnregisterAllForTree). The resume goroutine must check whether its entry is
+// still registered before sending, so a concurrent CANCEL does not produce a
+// duplicate response for the same MessageID.
+type PendingLockRegistry struct {
+	reg *pendingRegistry[PendingLock]
+}
+
 // NewPendingLockRegistry builds an empty registry.
 func NewPendingLockRegistry() *PendingLockRegistry {
 	return &PendingLockRegistry{
-		byMsgKey:  make(map[lockMsgKey]*PendingLock),
-		byAsyncId: make(map[uint64]*PendingLock),
-		bySession: make(map[uint64]map[uint64]*PendingLock),
-		byTree:    make(map[uint32]map[uint64]*PendingLock),
-		maxOps:    MaxPendingLocks,
+		reg: newPendingRegistry(registryConfig[PendingLock]{
+			asyncID: func(p *PendingLock) uint64 { return p.AsyncId },
+			indexes: []keyFunc[PendingLock]{
+				func(p *PendingLock) any {
+					return lockMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
+				},
+			},
+			buckets: []keyFunc[PendingLock]{
+				func(p *PendingLock) any { return p.SessionID },
+				func(p *PendingLock) any { return p.TreeID },
+			},
+			maxOps: MaxPendingLocks,
+		}),
 	}
 }
 
@@ -126,37 +141,20 @@ func NewPendingLockRegistry() *PendingLockRegistry {
 // failure cases the registry is left untouched and the caller owns releasing
 // its reserved async slot.
 func (r *PendingLockRegistry) Register(p *PendingLock) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.reg.mu.Lock()
+	defer r.reg.mu.Unlock()
 
-	if len(r.byAsyncId) >= r.maxOps {
+	if len(r.reg.byAsyncID) >= r.reg.maxOps {
 		return ErrTooManyPendingLocks
 	}
-
-	key := lockMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
-	if _, dup := r.byMsgKey[key]; dup {
+	if r.reg.lookupLocked(lockIdxMsgKey, lockMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}) != nil {
 		return ErrDuplicateLockMessageID
 	}
-	if _, dup := r.byAsyncId[p.AsyncId]; dup {
+	if _, dup := r.reg.byAsyncID[p.AsyncId]; dup {
 		return ErrDuplicateLockAsyncId
 	}
 
-	r.byMsgKey[key] = p
-	r.byAsyncId[p.AsyncId] = p
-
-	sessBucket, ok := r.bySession[p.SessionID]
-	if !ok {
-		sessBucket = make(map[uint64]*PendingLock)
-		r.bySession[p.SessionID] = sessBucket
-	}
-	sessBucket[p.AsyncId] = p
-
-	treeBucket, ok := r.byTree[p.TreeID]
-	if !ok {
-		treeBucket = make(map[uint64]*PendingLock)
-		r.byTree[p.TreeID] = treeBucket
-	}
-	treeBucket[p.AsyncId] = p
+	r.reg.insertLocked(p)
 
 	logger.Debug("PendingLockRegistry: registered",
 		"connID", p.ConnID,
@@ -164,7 +162,7 @@ func (r *PendingLockRegistry) Register(p *PendingLock) error {
 		"treeID", p.TreeID,
 		"messageID", p.MessageID,
 		"asyncId", p.AsyncId,
-		"total", len(r.byAsyncId))
+		"total", len(r.reg.byAsyncID))
 	return nil
 }
 
@@ -173,24 +171,15 @@ func (r *PendingLockRegistry) Register(p *PendingLock) error {
 // response. Returns the removed entry, or nil if it was already unregistered
 // (e.g. by a concurrent CANCEL / TDIS / LOGOFF).
 func (r *PendingLockRegistry) Unregister(asyncId uint64) *PendingLock {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.removeLocked(asyncId)
+	return r.reg.unregisterByAsyncID(asyncId)
 }
 
 // UnregisterByMessageID removes a pending LOCK matching (connID, messageID)
 // and invokes its Cancel closure to unblock the resume goroutine. Returns the
 // removed entry, or nil if none matched. Used by synchronous SMB2_CANCEL.
 func (r *PendingLockRegistry) UnregisterByMessageID(connID, messageID uint64) *PendingLock {
-	r.mu.Lock()
-	p, ok := r.byMsgKey[lockMsgKey{ConnID: connID, MessageID: messageID}]
-	if !ok {
-		r.mu.Unlock()
-		return nil
-	}
-	r.removeLocked(p.AsyncId)
-	r.mu.Unlock()
-	if p.Cancel != nil {
+	p := r.reg.unregisterByIndex(lockIdxMsgKey, lockMsgKey{ConnID: connID, MessageID: messageID})
+	if p != nil && p.Cancel != nil {
 		p.Cancel()
 	}
 	return p
@@ -199,9 +188,7 @@ func (r *PendingLockRegistry) UnregisterByMessageID(connID, messageID uint64) *P
 // UnregisterByAsyncId removes a pending LOCK matching asyncId and invokes its
 // Cancel closure. Used by async-flagged SMB2_CANCEL.
 func (r *PendingLockRegistry) UnregisterByAsyncId(asyncId uint64) *PendingLock {
-	r.mu.Lock()
-	p := r.removeLocked(asyncId)
-	r.mu.Unlock()
+	p := r.reg.unregisterByAsyncID(asyncId)
 	if p != nil && p.Cancel != nil {
 		p.Cancel()
 	}
@@ -213,24 +200,8 @@ func (r *PendingLockRegistry) UnregisterByAsyncId(asyncId uint64) *PendingLock {
 // connection drop) to unblock goroutines before the session state they
 // depend on is freed.
 func (r *PendingLockRegistry) UnregisterAllForSession(sessionID uint64) []*PendingLock {
-	r.mu.Lock()
-	bucket, ok := r.bySession[sessionID]
-	if !ok {
-		r.mu.Unlock()
-		return nil
-	}
-	removed := make([]*PendingLock, 0, len(bucket))
-	for asyncId := range bucket {
-		if p := r.removeLocked(asyncId); p != nil {
-			removed = append(removed, p)
-		}
-	}
-	r.mu.Unlock()
-	for _, p := range removed {
-		if p.Cancel != nil {
-			p.Cancel()
-		}
-	}
+	removed := r.reg.unregisterBucket(lockBucketSession, sessionID)
+	cancelAll(removed)
 	return removed
 }
 
@@ -238,48 +209,9 @@ func (r *PendingLockRegistry) UnregisterAllForSession(sessionID uint64) []*Pendi
 // treeID, invoking Cancel on each. Used by TREE_DISCONNECT to unblock
 // goroutines holding state that the tree owns (smb2.lock.cancel-tdis).
 func (r *PendingLockRegistry) UnregisterAllForTree(treeID uint32) []*PendingLock {
-	r.mu.Lock()
-	bucket, ok := r.byTree[treeID]
-	if !ok {
-		r.mu.Unlock()
-		return nil
-	}
-	removed := make([]*PendingLock, 0, len(bucket))
-	for asyncId := range bucket {
-		if p := r.removeLocked(asyncId); p != nil {
-			removed = append(removed, p)
-		}
-	}
-	r.mu.Unlock()
-	for _, p := range removed {
-		if p.Cancel != nil {
-			p.Cancel()
-		}
-	}
+	removed := r.reg.unregisterBucket(lockBucketTree, treeID)
+	cancelAll(removed)
 	return removed
-}
-
-// removeLocked drops entries keyed on asyncId from all maps. Caller holds mu.
-func (r *PendingLockRegistry) removeLocked(asyncId uint64) *PendingLock {
-	p, ok := r.byAsyncId[asyncId]
-	if !ok {
-		return nil
-	}
-	delete(r.byAsyncId, asyncId)
-	delete(r.byMsgKey, lockMsgKey{ConnID: p.ConnID, MessageID: p.MessageID})
-	if bucket, ok := r.bySession[p.SessionID]; ok {
-		delete(bucket, asyncId)
-		if len(bucket) == 0 {
-			delete(r.bySession, p.SessionID)
-		}
-	}
-	if bucket, ok := r.byTree[p.TreeID]; ok {
-		delete(bucket, asyncId)
-		if len(bucket) == 0 {
-			delete(r.byTree, p.TreeID)
-		}
-	}
-	return p
 }
 
 // UnregisterAllForOwner removes and returns every pending LOCK whose OwnerID
@@ -287,31 +219,23 @@ func (r *PendingLockRegistry) removeLocked(asyncId uint64) *PendingLock {
 // unblock the resume goroutine before the handle state is freed (file-close
 // cancellation per Samba brl_close_fnum).
 func (r *PendingLockRegistry) UnregisterAllForOwner(ownerID string) []*PendingLock {
-	r.mu.Lock()
-	var toRemove []uint64
-	for asyncId, p := range r.byAsyncId {
-		if p.OwnerID == ownerID {
-			toRemove = append(toRemove, asyncId)
-		}
-	}
-	removed := make([]*PendingLock, 0, len(toRemove))
-	for _, asyncId := range toRemove {
-		if rp := r.removeLocked(asyncId); rp != nil {
-			removed = append(removed, rp)
-		}
-	}
-	r.mu.Unlock()
+	removed := r.reg.unregisterMatching(func(p *PendingLock) bool {
+		return p.OwnerID == ownerID
+	})
+	cancelAll(removed)
+	return removed
+}
+
+// cancelAll invokes Cancel on each removed pending LOCK.
+func cancelAll(removed []*PendingLock) {
 	for _, p := range removed {
 		if p.Cancel != nil {
 			p.Cancel()
 		}
 	}
-	return removed
 }
 
 // Len returns the number of pending LOCKs.
 func (r *PendingLockRegistry) Len() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return len(r.byAsyncId)
+	return r.reg.Len()
 }

--- a/internal/adapter/smb/handlers/pending_lock_registry_test.go
+++ b/internal/adapter/smb/handlers/pending_lock_registry_test.go
@@ -128,7 +128,7 @@ func TestPendingLockRegistry_UnregisterAllForSession(t *testing.T) {
 
 func TestPendingLockRegistry_OverflowRejected(t *testing.T) {
 	r := NewPendingLockRegistry()
-	r.maxOps = 2
+	r.reg.maxOps = 2
 	_ = r.Register(newTestPendingLock(1, 10, 100, 1000, 50, nil))
 	_ = r.Register(newTestPendingLock(1, 10, 101, 1001, 50, nil))
 	overflow := newTestPendingLock(1, 10, 102, 1002, 50, nil)

--- a/internal/adapter/smb/handlers/pending_registry.go
+++ b/internal/adapter/smb/handlers/pending_registry.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"sync"
+)
+
+// pendingRegistry is a thread-safe, multi-index store for async-parked SMB2
+// operations (parked CREATEs, blocking LOCKs, pending pipe READs). All three
+// concrete registries are the same shape — a primary AsyncId index plus a set
+// of secondary lookup indexes and 1:many bucket indexes — so they share this
+// generic core and differ only in the indexes they configure and a handful of
+// per-entry hooks.
+//
+// V is the parked-entry value type (PendingCreate, PendingLock,
+// PendingPipeRead). Entries are addressed and removed via the primary AsyncId
+// returned by the asyncID extractor; every index is kept in lock-step with
+// that primary map.
+//
+// Index kinds:
+//
+//   - Unique secondary index (index): a 1:1 map from a comparable key to an
+//     entry, e.g. (ConnID, MessageID) or FileID. Keys are derived from the
+//     entry via a keyFn.
+//   - Bucket index (bucketIndex): a 1:many map from a comparable key to the
+//     set of entries sharing it, e.g. SessionID or TreeID. Used for bulk
+//     teardown.
+//
+// Concurrency: a single mutex guards all maps. Per-entry side effects (Cancel,
+// gate release, displaced-callback fan-out) are invoked by callers AFTER the
+// lock is dropped, mirroring the original hand-written registries.
+type pendingRegistry[V any] struct {
+	mu        sync.Mutex
+	byAsyncID map[uint64]*V
+
+	asyncID func(*V) uint64
+
+	indexes []*uniqueIndex[V]
+	buckets []*bucketIndex[V]
+
+	// maxOps caps the number of live entries. Zero means unlimited.
+	maxOps int
+}
+
+// uniqueIndex is a 1:1 secondary index mapping a derived key to one entry.
+type uniqueIndex[V any] struct {
+	keyFn keyFunc[V]
+	m     map[any]*V
+}
+
+// bucketIndex is a 1:many index mapping a derived key to all entries that
+// share it, keyed internally by AsyncId for O(1) per-entry removal.
+type bucketIndex[V any] struct {
+	keyFn keyFunc[V]
+	m     map[any]map[uint64]*V
+}
+
+// keyFunc derives an index key from an entry. Keys are opaque comparables
+// wrapped in `any` so one registry can mix key types (e.g. a struct msg-key
+// and a [16]byte FileID).
+type keyFunc[V any] func(*V) any
+
+// registryConfig configures a pendingRegistry at construction time. indexes
+// are 1:1 unique secondary indexes; buckets are 1:many teardown indexes. Each
+// is configured by a key extractor and addressed by its ordinal position.
+type registryConfig[V any] struct {
+	asyncID func(*V) uint64
+	indexes []keyFunc[V]
+	buckets []keyFunc[V]
+	maxOps  int
+}
+
+func newPendingRegistry[V any](cfg registryConfig[V]) *pendingRegistry[V] {
+	r := &pendingRegistry[V]{
+		byAsyncID: make(map[uint64]*V),
+		asyncID:   cfg.asyncID,
+		maxOps:    cfg.maxOps,
+	}
+	for _, keyFn := range cfg.indexes {
+		r.indexes = append(r.indexes, &uniqueIndex[V]{keyFn: keyFn, m: make(map[any]*V)})
+	}
+	for _, keyFn := range cfg.buckets {
+		r.buckets = append(r.buckets, &bucketIndex[V]{keyFn: keyFn, m: make(map[any]map[uint64]*V)})
+	}
+	return r
+}
+
+// insertLocked adds p to the primary map and every index. Caller holds mu and
+// has already validated capacity / duplicates.
+func (r *pendingRegistry[V]) insertLocked(p *V) {
+	asyncID := r.asyncID(p)
+	r.byAsyncID[asyncID] = p
+	for _, idx := range r.indexes {
+		idx.m[idx.keyFn(p)] = p
+	}
+	for _, b := range r.buckets {
+		key := b.keyFn(p)
+		bucket, ok := b.m[key]
+		if !ok {
+			bucket = make(map[uint64]*V)
+			b.m[key] = bucket
+		}
+		bucket[asyncID] = p
+	}
+}
+
+// removeLocked drops the entry identified by asyncID from the primary map and
+// every index. Returns the removed entry, or nil if absent. Caller holds mu.
+func (r *pendingRegistry[V]) removeLocked(asyncID uint64) *V {
+	p, ok := r.byAsyncID[asyncID]
+	if !ok {
+		return nil
+	}
+	delete(r.byAsyncID, asyncID)
+	for _, idx := range r.indexes {
+		delete(idx.m, idx.keyFn(p))
+	}
+	for _, b := range r.buckets {
+		key := b.keyFn(p)
+		if bucket, ok := b.m[key]; ok {
+			delete(bucket, asyncID)
+			if len(bucket) == 0 {
+				delete(b.m, key)
+			}
+		}
+	}
+	return p
+}
+
+// lookupLocked returns the entry held by index i under key, or nil. Caller
+// holds mu.
+func (r *pendingRegistry[V]) lookupLocked(i int, key any) *V {
+	return r.indexes[i].m[key]
+}
+
+// Len returns the number of live entries.
+func (r *pendingRegistry[V]) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.byAsyncID)
+}
+
+// unregisterByAsyncID removes the entry keyed by asyncID, returning it (or nil).
+func (r *pendingRegistry[V]) unregisterByAsyncID(asyncID uint64) *V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.removeLocked(asyncID)
+}
+
+// unregisterByIndex removes and returns the entry held by index i under key.
+func (r *pendingRegistry[V]) unregisterByIndex(i int, key any) *V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.indexes[i].m[key]
+	if !ok {
+		return nil
+	}
+	return r.removeLocked(r.asyncID(p))
+}
+
+// unregisterBucket removes and returns every entry held by bucket index i under
+// key. Returns nil when the bucket is empty/absent.
+func (r *pendingRegistry[V]) unregisterBucket(i int, key any) []*V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	bucket, ok := r.buckets[i].m[key]
+	if !ok {
+		return nil
+	}
+	removed := make([]*V, 0, len(bucket))
+	for asyncID := range bucket {
+		if p := r.removeLocked(asyncID); p != nil {
+			removed = append(removed, p)
+		}
+	}
+	return removed
+}
+
+// unregisterMatching removes and returns every live entry for which pred
+// reports true. Used by predicate-based teardown (owner-id, session scan)
+// that no dedicated index covers.
+func (r *pendingRegistry[V]) unregisterMatching(pred func(*V) bool) []*V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var toRemove []uint64
+	for asyncID, p := range r.byAsyncID {
+		if pred(p) {
+			toRemove = append(toRemove, asyncID)
+		}
+	}
+	removed := make([]*V, 0, len(toRemove))
+	for _, asyncID := range toRemove {
+		if p := r.removeLocked(asyncID); p != nil {
+			removed = append(removed, p)
+		}
+	}
+	return removed
+}

--- a/internal/adapter/smb/handlers/pending_registry_test.go
+++ b/internal/adapter/smb/handlers/pending_registry_test.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"testing"
+)
+
+// genEntry is a minimal value type used to exercise the generic
+// pendingRegistry core directly, independent of the concrete CREATE/LOCK/PIPE
+// wrappers.
+type genEntry struct {
+	AsyncID   uint64
+	ConnID    uint64
+	MessageID uint64
+	SessionID uint64
+	TreeID    uint32
+	Owner     string
+}
+
+// newGenRegistry builds a registry with one (ConnID, MessageID) unique index
+// and two bucket indexes (Session, Tree), mirroring the lock registry's shape.
+func newGenRegistry(maxOps int) *pendingRegistry[genEntry] {
+	return newPendingRegistry(registryConfig[genEntry]{
+		asyncID: func(e *genEntry) uint64 { return e.AsyncID },
+		indexes: []keyFunc[genEntry]{
+			func(e *genEntry) any {
+				return [2]uint64{e.ConnID, e.MessageID}
+			},
+		},
+		buckets: []keyFunc[genEntry]{
+			func(e *genEntry) any { return e.SessionID },
+			func(e *genEntry) any { return e.TreeID },
+		},
+		maxOps: maxOps,
+	})
+}
+
+func insertGen(t *testing.T, r *pendingRegistry[genEntry], e *genEntry) {
+	t.Helper()
+	r.mu.Lock()
+	r.insertLocked(e)
+	r.mu.Unlock()
+}
+
+func TestPendingRegistry_InsertRemoveAndLen(t *testing.T) {
+	r := newGenRegistry(0)
+	e := &genEntry{AsyncID: 7, ConnID: 1, MessageID: 42, SessionID: 100, TreeID: 5}
+	insertGen(t, r, e)
+
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", r.Len())
+	}
+	if got := r.unregisterByAsyncID(7); got != e {
+		t.Fatalf("unregisterByAsyncID = %v, want %v", got, e)
+	}
+	if r.Len() != 0 {
+		t.Fatalf("Len after remove = %d, want 0", r.Len())
+	}
+	// Idempotent second removal.
+	if got := r.unregisterByAsyncID(7); got != nil {
+		t.Fatalf("second unregisterByAsyncID = %v, want nil", got)
+	}
+}
+
+func TestPendingRegistry_UnregisterByIndex(t *testing.T) {
+	r := newGenRegistry(0)
+	e := &genEntry{AsyncID: 7, ConnID: 1, MessageID: 42, SessionID: 100, TreeID: 5}
+	insertGen(t, r, e)
+
+	// Wrong ConnID does not match (key is the (ConnID, MessageID) pair).
+	if got := r.unregisterByIndex(0, [2]uint64{2, 42}); got != nil {
+		t.Fatalf("unregisterByIndex(wrong conn) = %v, want nil", got)
+	}
+	if got := r.unregisterByIndex(0, [2]uint64{1, 42}); got != e {
+		t.Fatalf("unregisterByIndex = %v, want %v", got, e)
+	}
+	if r.Len() != 0 {
+		t.Fatalf("Len after index removal = %d, want 0", r.Len())
+	}
+}
+
+func TestPendingRegistry_UnregisterBucket(t *testing.T) {
+	r := newGenRegistry(0)
+	a := &genEntry{AsyncID: 1, ConnID: 1, MessageID: 1, SessionID: 100, TreeID: 5}
+	b := &genEntry{AsyncID: 2, ConnID: 1, MessageID: 2, SessionID: 100, TreeID: 6}
+	c := &genEntry{AsyncID: 3, ConnID: 1, MessageID: 3, SessionID: 200, TreeID: 5}
+	for _, e := range []*genEntry{a, b, c} {
+		insertGen(t, r, e)
+	}
+
+	// Session bucket (index 0): session 100 has a+b.
+	gotSess := r.unregisterBucket(0, uint64(100))
+	if len(gotSess) != 2 {
+		t.Fatalf("unregisterBucket(session 100) = %d, want 2", len(gotSess))
+	}
+	if r.Len() != 1 {
+		t.Fatalf("Len after session teardown = %d, want 1", r.Len())
+	}
+
+	// Tree bucket (index 1): only c remains, on tree 5.
+	gotTree := r.unregisterBucket(1, uint32(5))
+	if len(gotTree) != 1 || gotTree[0] != c {
+		t.Fatalf("unregisterBucket(tree 5) = %v, want [c]", gotTree)
+	}
+	if r.Len() != 0 {
+		t.Fatalf("Len after tree teardown = %d, want 0", r.Len())
+	}
+
+	// Absent bucket key yields nil.
+	if got := r.unregisterBucket(0, uint64(999)); got != nil {
+		t.Fatalf("unregisterBucket(absent) = %v, want nil", got)
+	}
+}
+
+func TestPendingRegistry_UnregisterMatching(t *testing.T) {
+	r := newGenRegistry(0)
+	a := &genEntry{AsyncID: 1, ConnID: 1, MessageID: 1, Owner: "x"}
+	b := &genEntry{AsyncID: 2, ConnID: 1, MessageID: 2, Owner: "y"}
+	c := &genEntry{AsyncID: 3, ConnID: 1, MessageID: 3, Owner: "x"}
+	for _, e := range []*genEntry{a, b, c} {
+		insertGen(t, r, e)
+	}
+
+	got := r.unregisterMatching(func(e *genEntry) bool { return e.Owner == "x" })
+	if len(got) != 2 {
+		t.Fatalf("unregisterMatching(owner=x) = %d, want 2", len(got))
+	}
+	if r.Len() != 1 {
+		t.Fatalf("Len after = %d, want 1 (owner=y remains)", r.Len())
+	}
+}
+
+// TestPendingRegistry_RemoveDropsAllIndexes asserts removal purges every index,
+// so a stale secondary lookup never resurrects a removed entry.
+func TestPendingRegistry_RemoveDropsAllIndexes(t *testing.T) {
+	r := newGenRegistry(0)
+	e := &genEntry{AsyncID: 7, ConnID: 1, MessageID: 42, SessionID: 100, TreeID: 5}
+	insertGen(t, r, e)
+	r.unregisterByAsyncID(7)
+
+	if got := r.unregisterByIndex(0, [2]uint64{1, 42}); got != nil {
+		t.Errorf("msg index not purged: got %v", got)
+	}
+	if got := r.unregisterBucket(0, uint64(100)); got != nil {
+		t.Errorf("session bucket not purged: got %v", got)
+	}
+	if got := r.unregisterBucket(1, uint32(5)); got != nil {
+		t.Errorf("tree bucket not purged: got %v", got)
+	}
+}

--- a/internal/adapter/smb/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"sync"
-
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 )
@@ -22,22 +20,29 @@ type PendingPipeRead struct {
 	Callback  AsyncPipeReadCallback
 }
 
+// Secondary-index slots for PipeReadRegistry, in configured order.
+const (
+	pipeIdxFileID = iota
+	pipeIdxMessageID
+)
+
 // PipeReadRegistry tracks outstanding async pipe READ operations.
 // Each named-pipe handle can have at most one pending read at a time.
 // Thread-safe; all methods acquire the mutex.
 type PipeReadRegistry struct {
-	mu          sync.Mutex
-	byFileID    map[[16]byte]*PendingPipeRead
-	byMessageID map[uint64]*PendingPipeRead
-	byAsyncId   map[uint64]*PendingPipeRead
+	reg *pendingRegistry[PendingPipeRead]
 }
 
 // NewPipeReadRegistry creates an empty registry.
 func NewPipeReadRegistry() *PipeReadRegistry {
 	return &PipeReadRegistry{
-		byFileID:    make(map[[16]byte]*PendingPipeRead),
-		byMessageID: make(map[uint64]*PendingPipeRead),
-		byAsyncId:   make(map[uint64]*PendingPipeRead),
+		reg: newPendingRegistry(registryConfig[PendingPipeRead]{
+			asyncID: func(p *PendingPipeRead) uint64 { return p.AsyncId },
+			indexes: []keyFunc[PendingPipeRead]{
+				func(p *PendingPipeRead) any { return p.FileID },
+				func(p *PendingPipeRead) any { return p.MessageID },
+			},
+		}),
 	}
 }
 
@@ -45,20 +50,17 @@ func NewPipeReadRegistry() *PipeReadRegistry {
 // for the same FileID, it is replaced (the old entry is completed first via
 // its callback with STATUS_CANCELLED to avoid leaking async slots).
 func (r *PipeReadRegistry) Register(p *PendingPipeRead) {
-	r.mu.Lock()
+	r.reg.mu.Lock()
 	var displaced *PendingPipeRead
-	if old, ok := r.byFileID[p.FileID]; ok {
+	if old := r.reg.lookupLocked(pipeIdxFileID, p.FileID); old != nil {
 		displaced = old
-		delete(r.byMessageID, old.MessageID)
-		delete(r.byAsyncId, old.AsyncId)
+		r.reg.removeLocked(old.AsyncId)
 		logger.Warn("PipeReadRegistry: replacing existing pending read",
 			"fileID", p.FileID,
 			"oldAsyncId", old.AsyncId)
 	}
-	r.byFileID[p.FileID] = p
-	r.byMessageID[p.MessageID] = p
-	r.byAsyncId[p.AsyncId] = p
-	r.mu.Unlock()
+	r.reg.insertLocked(p)
+	r.reg.mu.Unlock()
 
 	if displaced != nil && displaced.Callback != nil {
 		go func(pr *PendingPipeRead) {
@@ -69,63 +71,27 @@ func (r *PipeReadRegistry) Register(p *PendingPipeRead) {
 	}
 }
 
-// removeLocked deletes p from all three indexes. Caller must hold r.mu.
-func (r *PipeReadRegistry) removeLocked(p *PendingPipeRead) {
-	delete(r.byFileID, p.FileID)
-	delete(r.byMessageID, p.MessageID)
-	delete(r.byAsyncId, p.AsyncId)
-}
-
 // UnregisterByFileID removes and returns the pending read for the given FileID.
 // Returns nil if none is registered.
 func (r *PipeReadRegistry) UnregisterByFileID(fileID [16]byte) *PendingPipeRead {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p, ok := r.byFileID[fileID]
-	if !ok {
-		return nil
-	}
-	r.removeLocked(p)
-	return p
+	return r.reg.unregisterByIndex(pipeIdxFileID, fileID)
 }
 
 // UnregisterByMessageID removes and returns the pending read with the given MessageID.
 // Returns nil if none is registered.
 func (r *PipeReadRegistry) UnregisterByMessageID(messageID uint64) *PendingPipeRead {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p, ok := r.byMessageID[messageID]
-	if !ok {
-		return nil
-	}
-	r.removeLocked(p)
-	return p
+	return r.reg.unregisterByIndex(pipeIdxMessageID, messageID)
 }
 
 // UnregisterByAsyncId removes and returns the pending read with the given AsyncId.
 // Returns nil if none is registered.
 func (r *PipeReadRegistry) UnregisterByAsyncId(asyncId uint64) *PendingPipeRead {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p, ok := r.byAsyncId[asyncId]
-	if !ok {
-		return nil
-	}
-	r.removeLocked(p)
-	return p
+	return r.reg.unregisterByAsyncID(asyncId)
 }
 
 // UnregisterAllForSession removes and returns all pending reads for the given session.
 func (r *PipeReadRegistry) UnregisterAllForSession(sessionID uint64) []*PendingPipeRead {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	var result []*PendingPipeRead
-	for _, p := range r.byFileID {
-		if p.SessionID != sessionID {
-			continue
-		}
-		r.removeLocked(p)
-		result = append(result, p)
-	}
-	return result
+	return r.reg.unregisterMatching(func(p *PendingPipeRead) bool {
+		return p.SessionID == sessionID
+	})
 }

--- a/internal/adapter/smb/handlers/pipe_read_registry_test.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// newTestPipeRead builds a PendingPipeRead. If done is non-nil it receives the
+// callback status exactly once, letting tests wait deterministically for an
+// async displaced-callback completion.
+func newTestPipeRead(fileID byte, sessionID, messageID, asyncId uint64, done chan<- types.Status) *PendingPipeRead {
+	var fid [16]byte
+	fid[0] = fileID
+	return &PendingPipeRead{
+		FileID:    fid,
+		SessionID: sessionID,
+		MessageID: messageID,
+		AsyncId:   asyncId,
+		Callback: func(_, _, _ uint64, st types.Status, _ []byte) error {
+			if done != nil {
+				done <- st
+			}
+			return nil
+		},
+	}
+}
+
+func TestPipeReadRegistry_RegisterAndUnregisterByFileID(t *testing.T) {
+	r := NewPipeReadRegistry()
+	p := newTestPipeRead(1, 10, 100, 1000, nil)
+	r.Register(p)
+
+	if got := r.UnregisterByMessageID(100); got != p {
+		t.Fatalf("UnregisterByMessageID = %v, want p", got)
+	}
+	// Now gone from all indexes.
+	if got := r.UnregisterByFileID(p.FileID); got != nil {
+		t.Fatalf("UnregisterByFileID after removal = %v, want nil", got)
+	}
+	if got := r.UnregisterByAsyncId(1000); got != nil {
+		t.Fatalf("UnregisterByAsyncId after removal = %v, want nil", got)
+	}
+}
+
+// TestPipeReadRegistry_RegisterDisplacesSameFileID verifies that registering a
+// second read for the same FileID cancels the prior one (STATUS_CANCELLED) so
+// async slots are not leaked, matching the one-pending-read-per-handle rule.
+func TestPipeReadRegistry_RegisterDisplacesSameFileID(t *testing.T) {
+	r := NewPipeReadRegistry()
+	done := make(chan types.Status, 1)
+	old := newTestPipeRead(1, 10, 100, 1000, done)
+	r.Register(old)
+
+	newer := newTestPipeRead(1, 10, 101, 1001, nil) // same FileID
+	r.Register(newer)
+
+	// The displaced entry's callback fires asynchronously with STATUS_CANCELLED.
+	select {
+	case st := <-done:
+		if st != types.StatusCancelled {
+			t.Fatalf("displaced callback status = %d, want StatusCancelled", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("displaced callback did not fire within 1s")
+	}
+
+	// Only the newer entry remains; old indexes are gone.
+	if got := r.UnregisterByAsyncId(1000); got != nil {
+		t.Errorf("old entry still present: %v", got)
+	}
+	if got := r.UnregisterByFileID(newer.FileID); got != newer {
+		t.Errorf("UnregisterByFileID = %v, want newer", got)
+	}
+}
+
+func TestPipeReadRegistry_UnregisterAllForSession(t *testing.T) {
+	r := NewPipeReadRegistry()
+	r.Register(newTestPipeRead(1, 10, 100, 1000, nil))
+	r.Register(newTestPipeRead(2, 10, 101, 1001, nil))
+	r.Register(newTestPipeRead(3, 11, 102, 1002, nil)) // different session
+
+	got := r.UnregisterAllForSession(10)
+	if len(got) != 2 {
+		t.Fatalf("UnregisterAllForSession(10) = %d, want 2", len(got))
+	}
+	// Session 11 entry survives.
+	if got := r.UnregisterByAsyncId(1002); got == nil {
+		t.Errorf("session 11 entry should survive teardown of session 10")
+	}
+}


### PR DESCRIPTION
## Summary

The pending **CREATE**, blocking **LOCK**, and **pipe READ** registries each re-implemented the same multi-index store: a primary `byAsyncId` map plus secondary indexes (`byMsgKey` / `byFileID` / `bySession` / `byTree`), guarded by one mutex, with an optional cap. ~739 LOC of near-identical bookkeeping.

This extracts a generic `pendingRegistry[V any]` core (`pending_registry.go`) with:

- a primary AsyncId index,
- pluggable **1:1 unique secondary indexes** (configured by a key extractor, addressed by ordinal),
- pluggable **1:many bucket indexes** for bulk teardown (session / tree),
- an optional `maxOps` cap,
- predicate-based teardown (`unregisterMatching`) for the owner-scan / session-scan paths that have no dedicated index.

Per-entry side effects (Cancel, started-gate release, displaced-callback fan-out) stay in the concrete wrappers and run **after** the lock is dropped, exactly as before.

## Semantics preserved (byte-for-byte behavior)

- **CREATE**: `maxOps` cap, `(ConnID, MessageID)` + AsyncId duplicate rejection, the `started` gate (`MarkStarted` / `markStarted` on CANCEL & teardown), and `ReplaceCallback`.
- **LOCK**: adds the `byTree` bucket (`UnregisterAllForTree`) and `UnregisterAllForOwner` predicate scan; `maxOps`; Cancel fan-out.
- **Pipe READ**: no cap, no duplicate rejection — same-FileID **displacement** that cancels the prior read with `STATUS_CANCELLED` in a goroutine; session teardown via FileID scan.

Public method signatures are unchanged, so all call sites (compound.go, close.go, lock_async.go, stub_handlers.go, handler.go, etc.) are untouched.

## Tests

- Kept and adapted all existing CREATE / LOCK registry tests.
- Added generic-core tests (`pending_registry_test.go`): insert/remove, unique-index lookup, bucket teardown, predicate teardown, all-index-purge-on-remove.
- Added pipe-read tests (`pipe_read_registry_test.go`) that previously did **not** exist — including the displacement-cancels-prior-read path.

`go build ./...`, `go vet`, `gofmt -l` (empty), and `go test -race ./internal/adapter/smb/...` all pass.

Closes #1052