### PR TITLE
refactor(nfs): finish error-mapper consolidation

### DIFF
--- a/internal/adapter/common/content_errmap.go
+++ b/internal/adapter/common/content_errmap.go
@@ -13,11 +13,10 @@ import (
 // Content-error mapping.
 //
 // Block-store content errors (failed reads from remote/cache, transient
-// backend failures) map to I/O-class codes in every protocol. Today the
-// only typed signal is block.ErrRemoteUnavailable; a string-match
-// heuristic for "cache full" is intentionally kept OUT of common/ and
-// stays at the NFSv3 call site (see internal/adapter/nfs/xdr/errors.go:
-// MapContentErrorToNFSStatus) — the typed-error path lives here.
+// backend failures) map to I/O-class codes in every protocol. The typed
+// sentinels (engine.ErrStoreClosed and the block.Err* family) are matched
+// here via errors.Is; every protocol arm (NFSv3/4, SMB) calls the matching
+// MapContentTo* accessor so the mapping lives in exactly one place.
 //
 // Per-protocol fallback when the specific error is unknown:
 //   - NFSv3 → NFS3ErrIO (EIO)

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -285,7 +285,7 @@ func (h *Handler) Write(
 	err = common.WriteToBlockStore(ctx.Context, blockStore, writeIntent.PayloadID, req.Data, req.Offset)
 	if err != nil {
 		logError(ctx.Context, err, "WRITE failed: BlockStore write error", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", len(req.Data), "payload_id", writeIntent.PayloadID, "client", clientIP)
-		status := xdr.MapContentErrorToNFSStatus(err)
+		status := common.MapContentToNFS3(err)
 		return h.buildWriteErrorResponse(status, fileHandle, writeIntent.PreWriteAttr, writeIntent.PreWriteAttr), nil
 	}
 	logger.DebugCtx(ctx.Context, "WRITE: cached successfully", "payload_id", writeIntent.PayloadID)

--- a/internal/adapter/nfs/xdr/errors.go
+++ b/internal/adapter/nfs/xdr/errors.go
@@ -6,7 +6,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -73,71 +72,4 @@ func MapStoreErrorToNFSStatus(err error, clientIP string, operation string) uint
 		logger.Warn("Operation failed", "operation", operation, "code", storeErr.Code, "message", storeErr.Message, "path", storeErr.Path, "client", clientIP)
 	}
 	return nfsCode
-}
-
-// MapContentErrorToNFSStatus maps content repository errors to appropriate
-// NFS status codes.
-//
-// Analyzes error messages and types to determine the most
-// appropriate NFS error code. In the future, the content repository should
-// return typed errors for more precise mapping.
-//
-// Common mappings:
-//   - "no space" / "disk full" → NFS3ErrNoSpc
-//   - "read-only" / "permission denied" → NFS3ErrRofs
-//   - "not found" / "does not exist" → NFS3ErrNoEnt
-//   - Other errors → NFS3ErrIO (generic I/O error)
-//
-// Parameters:
-//   - err: Error returned from content repository
-//
-// Returns:
-//   - uint32: Appropriate NFS status code
-func MapContentErrorToNFSStatus(err error) uint32 {
-	if err == nil {
-		return types.NFS3OK
-	}
-
-	// Check if it's a typed StoreError first (using errors.As to handle wrapped errors)
-	var storeErr *metadata.StoreError
-	if errors.As(err, &storeErr) {
-		// Use the more specific error mapping
-		return MapStoreErrorToNFSStatus(err, "", "content operation")
-	}
-
-	// Check for blockstore sentinel errors
-	if errors.Is(err, block.ErrRemoteUnavailable) {
-		return types.NFS3ErrIO
-	}
-
-	// Analyze error message for common patterns
-	// This is a best-effort approach until content repository returns typed errors
-	errMsg := err.Error()
-
-	// Check for specific error patterns (case-insensitive substring matching)
-	switch {
-	case containsIgnoreCase(errMsg, "no space") || containsIgnoreCase(errMsg, "disk full"):
-		return types.NFS3ErrNoSpc
-
-	case containsIgnoreCase(errMsg, "read-only") || containsIgnoreCase(errMsg, "read only"):
-		return types.NFS3ErrRofs
-
-	case containsIgnoreCase(errMsg, "not found") || containsIgnoreCase(errMsg, "does not exist"):
-		return types.NFS3ErrNoEnt
-
-	case containsIgnoreCase(errMsg, "permission denied") || containsIgnoreCase(errMsg, "access denied"):
-		return types.NFS3ErrAccess
-
-	case containsIgnoreCase(errMsg, "stale") || containsIgnoreCase(errMsg, "invalid handle"):
-		return types.NFS3ErrStale
-
-	case containsIgnoreCase(errMsg, "cache full"):
-		// Cache full - return JUKEBOX to tell client to retry after flushing
-		// This provides backpressure to prevent OOM conditions
-		return types.NFS3ErrJukebox
-
-	default:
-		// Generic I/O error for unrecognized errors
-		return types.NFS3ErrIO
-	}
 }

--- a/internal/adapter/nfs/xdr/utils.go
+++ b/internal/adapter/nfs/xdr/utils.go
@@ -1,8 +1,0 @@
-package xdr
-
-import "strings"
-
-// containsIgnoreCase checks if a string contains a substring (case-insensitive).
-func containsIgnoreCase(s, substr string) bool {
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
-}


### PR DESCRIPTION
Closes #1049

The NFSv3 WRITE block-store error path (`v3/handlers/write.go`) was the last caller of the legacy `xdr.MapContentErrorToNFSStatus`, while the rest of the same file already used the consolidated `common.*` mappers. Repoint it to **`common.MapContentToNFS3`** — the single content-error mapper shared across protocols (NFSv4 and SMB already route the identical `common.WriteToBlockStore` error through `common.MapContentToNFS4` / `common.MapContentToSMB`).

`common.MapToNFS3` (suggested in the issue) is the *store-error* mapper; the correct consolidated target for a block-store **content** error is `common.MapContentToNFS3`, which is exactly what the parallel SMB write path uses.

Then deleted the dead mapper and its only helper:
- `MapContentErrorToNFSStatus` — its string-match heuristics (`no space` / `read-only` / `not found` / `cache full`→Jukebox) matched error *text* that no production code emits; the block layer returns typed sentinels (`engine.ErrStoreClosed`, `block.Err*`) which `MapContentToNFS3` matches via `errors.Is`. Its `metadata.StoreError` arm was also dead at this call site — `engine.WriteAt` returns block-layer errors, never a `StoreError`.
- `containsIgnoreCase` (sole user was that function) — removed the whole `xdr/utils.go`.
- Dropped the now-unused `pkg/block` import from `xdr/errors.go` and refreshed the stale doc comment in `common/content_errmap.go`.

No behavior change for any error the block store actually produces; if anything, `ErrStoreClosed` now maps to STALE (via the shared mapper) instead of the old generic IO.

`go build`, `go vet`, `gofmt -l`, and `go test -race ./internal/adapter/nfs/... ./internal/adapter/common/...` all pass.