### PR TITLE
refactor(smb/security): use smbenc.Writer instead of local helpers

### DIFF
--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -17,7 +17,6 @@
 package handlers
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
@@ -161,16 +160,16 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 	isNullDACL := includeDACL && file.ACL != nil && file.ACL.NullDACL
 
 	// Build DACL
-	var daclBuf bytes.Buffer
+	daclBuf := smbenc.NewWriter(64)
 	var fileACL *acl.ACL
 	if includeDACL && !isNullDACL {
-		fileACL = buildDACL(&daclBuf, file)
+		fileACL = buildDACL(daclBuf, file)
 	}
 
 	// Build SACL (empty stub if requested)
-	var saclBuf bytes.Buffer
+	saclBuf := smbenc.NewWriter(aclHeaderSize)
 	if includeSACL {
-		buildEmptySACL(&saclBuf)
+		buildEmptySACL(saclBuf)
 	}
 
 	// Compute SD control flags dynamically
@@ -220,7 +219,7 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 	if includeOwner {
 		ownerOffset = currentOffset
 		currentOffset += uint32(sid.SIDSize(ownerSID))
-		currentOffset = alignTo4(currentOffset)
+		currentOffset = (currentOffset + 3) &^ 3 // align to 4-byte boundary
 	}
 
 	if includeGroup {
@@ -228,39 +227,39 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 	}
 
 	// Build the complete Security Descriptor
-	var buf bytes.Buffer
+	buf := smbenc.NewWriter(int(currentOffset))
 
 	// Header (20 bytes)
-	buf.WriteByte(1) // Revision
-	buf.WriteByte(0) // Sbz1
-	writeUint16ToBuf(&buf, control)
-	writeUint32ToBuf(&buf, ownerOffset)
-	writeUint32ToBuf(&buf, groupOffset)
-	writeUint32ToBuf(&buf, saclOffset)
-	writeUint32ToBuf(&buf, daclOffset)
+	buf.WriteUint8(1) // Revision
+	buf.WriteUint8(0) // Sbz1
+	buf.WriteUint16(control)
+	buf.WriteUint32(ownerOffset)
+	buf.WriteUint32(groupOffset)
+	buf.WriteUint32(saclOffset)
+	buf.WriteUint32(daclOffset)
 
 	// Body in Windows convention order: SACL, DACL, Owner, Group
 
 	// SACL
 	if includeSACL {
-		buf.Write(saclBuf.Bytes())
+		buf.WriteBytes(saclBuf.Bytes())
 	}
 
 	// DACL
 	if includeDACL {
-		buf.Write(daclBuf.Bytes())
+		buf.WriteBytes(daclBuf.Bytes())
 	}
 
 	// Owner SID
 	if includeOwner {
-		sid.EncodeSID(&buf, ownerSID)
-		padTo4(&buf)
+		encodeSID(buf, ownerSID)
+		buf.Pad(4)
 	}
 
 	// Group SID
 	if includeGroup {
-		sid.EncodeSID(&buf, groupSID)
-		padTo4(&buf)
+		encodeSID(buf, groupSID)
+		buf.Pad(4)
 	}
 
 	return buf.Bytes(), nil
@@ -317,7 +316,7 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 // POSIX semantics so Unix mode bits stay authoritative on the server.
 //
 // Returns the source ACL used for SD control flag computation.
-func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
+func buildDACL(buf *smbenc.Writer, file *metadata.File) *acl.ACL {
 	var aces []windowsACE
 	var fileACL *acl.ACL
 
@@ -349,22 +348,22 @@ func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
 	}
 
 	// Write ACL header (8 bytes) per MS-DTYP Section 2.4.5
-	buf.WriteByte(2) // AclRevision (2 = standard)
-	buf.WriteByte(0) // Sbz1
-	writeUint16ToBuf(buf, uint16(totalACLSize))
-	writeUint16ToBuf(buf, uint16(len(aces)))
-	writeUint16ToBuf(buf, 0) // Sbz2
+	buf.WriteUint8(2) // AclRevision (2 = standard)
+	buf.WriteUint8(0) // Sbz1
+	buf.WriteUint16(uint16(totalACLSize))
+	buf.WriteUint16(uint16(len(aces)))
+	buf.WriteUint16(0) // Sbz2
 
 	// Write each ACE per MS-DTYP Section 2.4.4.2
 	for i := range aces {
 		ace := &aces[i]
 		aceSize := uint16(aceHeaderSize + sid.SIDSize(ace.sid))
 
-		buf.WriteByte(ace.aceType)  // AceType
-		buf.WriteByte(ace.aceFlags) // AceFlags
-		writeUint16ToBuf(buf, aceSize)
-		writeUint32ToBuf(buf, ace.accessMask)
-		sid.EncodeSID(buf, ace.sid)
+		buf.WriteUint8(ace.aceType)  // AceType
+		buf.WriteUint8(ace.aceFlags) // AceFlags
+		buf.WriteUint16(aceSize)
+		buf.WriteUint32(ace.accessMask)
+		encodeSID(buf, ace.sid)
 	}
 
 	return fileACL
@@ -372,12 +371,12 @@ func buildDACL(buf *bytes.Buffer, file *metadata.File) *acl.ACL {
 
 // buildEmptySACL writes a valid empty SACL to buf.
 // The SACL has revision=2, count=0, and total size=8 bytes.
-func buildEmptySACL(buf *bytes.Buffer) {
-	buf.WriteByte(2)                     // AclRevision
-	buf.WriteByte(0)                     // Sbz1
-	writeUint16ToBuf(buf, aclHeaderSize) // AclSize = 8
-	writeUint16ToBuf(buf, 0)             // AceCount = 0
-	writeUint16ToBuf(buf, 0)             // Sbz2
+func buildEmptySACL(buf *smbenc.Writer) {
+	buf.WriteUint8(2)              // AclRevision
+	buf.WriteUint8(0)              // Sbz1
+	buf.WriteUint16(aclHeaderSize) // AclSize = 8
+	buf.WriteUint16(0)             // AceCount = 0
+	buf.WriteUint16(0)             // Sbz2
 }
 
 // ============================================================================
@@ -577,39 +576,17 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 }
 
 // ============================================================================
-// Alignment Helpers
+// Encoding Helpers
 // ============================================================================
 
-// writeUint16ToBuf writes a little-endian uint16 to a bytes.Buffer.
-func writeUint16ToBuf(buf *bytes.Buffer, v uint16) {
-	var tmp [2]byte
-	tmp[0] = byte(v)
-	tmp[1] = byte(v >> 8)
-	buf.Write(tmp[:])
-}
-
-// writeUint32ToBuf writes a little-endian uint32 to a bytes.Buffer.
-func writeUint32ToBuf(buf *bytes.Buffer, v uint32) {
-	var tmp [4]byte
-	tmp[0] = byte(v)
-	tmp[1] = byte(v >> 8)
-	tmp[2] = byte(v >> 16)
-	tmp[3] = byte(v >> 24)
-	buf.Write(tmp[:])
-}
-
-// alignTo4 rounds up a value to the next 4-byte boundary.
-func alignTo4(n uint32) uint32 {
-	return (n + 3) &^ 3
-}
-
-// padTo4 pads a buffer to a 4-byte boundary with zeros.
-func padTo4(buf *bytes.Buffer) {
-	rem := buf.Len() % 4
-	if rem != 0 {
-		padding := 4 - rem
-		for range padding {
-			buf.WriteByte(0)
-		}
+// encodeSID writes a binary SID to w per MS-DTYP Section 2.4.2. It mirrors
+// sid.EncodeSID, which targets *bytes.Buffer, for the smbenc.Writer-based SD
+// builders here.
+func encodeSID(w *smbenc.Writer, s *sid.SID) {
+	w.WriteUint8(s.Revision)
+	w.WriteUint8(s.SubAuthorityCount)
+	w.WriteBytes(s.IdentifierAuthority[:])
+	for _, sa := range s.SubAuthorities {
+		w.WriteUint32(sa)
 	}
 }

--- a/internal/adapter/smb/handlers/security_setinfo_regression_test.go
+++ b/internal/adapter/smb/handlers/security_setinfo_regression_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
@@ -37,27 +38,27 @@ func buildSID(t *testing.T, sidStr string) []byte {
 
 // buildACE builds a single ACE (type + flags + size + mask + sid).
 func buildACE(aceType, aceFlags uint8, accessMask uint32, sidBytes []byte) []byte {
-	var buf bytes.Buffer
+	w := smbenc.NewWriter(8 + len(sidBytes))
 	aceSize := uint16(8 + len(sidBytes))
-	buf.WriteByte(aceType)
-	buf.WriteByte(aceFlags)
-	writeUint16ToBuf(&buf, aceSize)
-	writeUint32ToBuf(&buf, accessMask)
-	buf.Write(sidBytes)
-	return buf.Bytes()
+	w.WriteUint8(aceType)
+	w.WriteUint8(aceFlags)
+	w.WriteUint16(aceSize)
+	w.WriteUint32(accessMask)
+	w.WriteBytes(sidBytes)
+	return w.Bytes()
 }
 
 // buildRawDACL builds a DACL: AclRev(1) + Sbz1(1) + AclSize(2) + AceCount(2) + Sbz2(2) + ACEs.
 func buildRawDACL(aceCount uint16, aces []byte) []byte {
-	var buf bytes.Buffer
+	w := smbenc.NewWriter(8 + len(aces))
 	aclSize := uint16(8 + len(aces))
-	buf.WriteByte(2) // AclRevision = ACL_REVISION (2)
-	buf.WriteByte(0) // Sbz1
-	writeUint16ToBuf(&buf, aclSize)
-	writeUint16ToBuf(&buf, aceCount)
-	writeUint16ToBuf(&buf, 0) // Sbz2
-	buf.Write(aces)
-	return buf.Bytes()
+	w.WriteUint8(2) // AclRevision = ACL_REVISION (2)
+	w.WriteUint8(0) // Sbz1
+	w.WriteUint16(aclSize)
+	w.WriteUint16(aceCount)
+	w.WriteUint16(0) // Sbz2
+	w.WriteBytes(aces)
+	return w.Bytes()
 }
 
 // buildSelfRelativeSD assembles a self-relative SD per MS-DTYP §2.4.6.
@@ -67,12 +68,12 @@ func buildRawDACL(aceCount uint16, aces []byte) []byte {
 // Pass nil for dacl to indicate no DACL.
 func buildSelfRelativeSD(t *testing.T, control uint16, ownerSID, groupSID, daclBytes []byte) []byte {
 	t.Helper()
-	var buf bytes.Buffer
+	w := smbenc.NewWriter(20 + len(daclBytes) + len(ownerSID) + len(groupSID))
 
 	// Header
-	buf.WriteByte(1) // Revision
-	buf.WriteByte(0) // Sbz1
-	writeUint16ToBuf(&buf, control|0x8000)
+	w.WriteUint8(1) // Revision
+	w.WriteUint8(0) // Sbz1
+	w.WriteUint16(control | 0x8000)
 
 	// Offsets — fill in after we know layout
 	// Order on wire: DACL after header, Owner after DACL, Group after Owner.
@@ -94,21 +95,21 @@ func buildSelfRelativeSD(t *testing.T, control uint16, ownerSID, groupSID, daclB
 		offsetGroup = cursor
 	}
 
-	writeUint32ToBuf(&buf, offsetOwner)
-	writeUint32ToBuf(&buf, offsetGroup)
-	writeUint32ToBuf(&buf, offsetSACL)
-	writeUint32ToBuf(&buf, offsetDACL)
+	w.WriteUint32(offsetOwner)
+	w.WriteUint32(offsetGroup)
+	w.WriteUint32(offsetSACL)
+	w.WriteUint32(offsetDACL)
 
 	if daclBytes != nil {
-		buf.Write(daclBytes)
+		w.WriteBytes(daclBytes)
 	}
 	if ownerSID != nil {
-		buf.Write(ownerSID)
+		w.WriteBytes(ownerSID)
 	}
 	if groupSID != nil {
-		buf.Write(groupSID)
+		w.WriteBytes(groupSID)
 	}
-	return buf.Bytes()
+	return w.Bytes()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -1412,3 +1412,65 @@ func TestParseSD_ExpandsGenericMaskInACE(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildSD_GoldenBytes pins the exact wire encoding of a self-relative
+// Security Descriptor (owner + group + DACL + empty SACL) byte-for-byte. It
+// guards the smbenc.Writer-based encoder (and the encodeSID bridge) against
+// any drift in field order, little-endian packing, or 4-byte padding. Uses the
+// deterministic (0,0,0) SIDMapper installed by TestMain.
+func TestBuildSD_GoldenBytes(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{
+					{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: 0, AccessMask: 0x001F01FF, Who: "OWNER@"},
+				},
+			},
+		},
+	}
+
+	secInfo := uint32(OwnerSecurityInformation | GroupSecurityInformation | DACLSecurityInformation | SACLSecurityInformation)
+	got, err := BuildSecurityDescriptor(file, secInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	want := []byte{
+		0x01, 0x00, 0x14, 0x80, 0x48, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00,
+		0x14, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x2c, 0x00, 0x01, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x24, 0x00, 0xff, 0x01, 0x1f, 0x00, 0x01, 0x05, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x05, 0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb8, 0x0b, 0x00, 0x00,
+		0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x15, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xb8, 0x0b, 0x00, 0x00, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05,
+		0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0xb9, 0x0b, 0x00, 0x00,
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("SD wire encoding drifted:\n got (%d bytes) = % x\nwant (%d bytes) = % x", len(got), got, len(want), want)
+	}
+
+	// Round-trip: the golden bytes must parse back to the same owner/group.
+	ownerUID, ownerGID, parsedACL, err := ParseSecurityDescriptor(got)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor(golden): %v", err)
+	}
+	if ownerUID == nil || *ownerUID != 1000 {
+		t.Errorf("round-trip owner UID = %v, want 1000", ownerUID)
+	}
+	if ownerGID == nil || *ownerGID != 1000 {
+		t.Errorf("round-trip owner GID = %v, want 1000", ownerGID)
+	}
+	if parsedACL == nil || len(parsedACL.ACEs) != 1 {
+		t.Fatalf("round-trip ACL = %+v, want 1 ACE", parsedACL)
+	}
+	if parsedACL.ACEs[0].AccessMask != 0x001F01FF {
+		t.Errorf("round-trip ACE mask = 0x%08x, want 0x001F01FF", parsedACL.ACEs[0].AccessMask)
+	}
+}


### PR DESCRIPTION
## Summary

`internal/adapter/smb/handlers/security.go` defined four local helpers —
`writeUint16ToBuf`, `writeUint32ToBuf`, `alignTo4`, `padTo4` — that duplicated
`smbenc.Writer` (and `binary.LittleEndian`). This replaces them with the
shared writer:

- The self-relative Security Descriptor builders (`BuildSecurityDescriptor`,
  `buildDACL`, `buildEmptySACL`) now accumulate into `*smbenc.Writer`
  (`WriteUint8` / `WriteUint16` / `WriteUint32` / `WriteBytes`).
- `padTo4(&buf)` → `buf.Pad(4)`.
- `alignTo4(currentOffset)` was pure offset arithmetic on a `uint32`, not a
  buffer op — inlined as `(currentOffset + 3) &^ 3`.
- Added a small `encodeSID(w *smbenc.Writer, s *sid.SID)` bridge mirroring
  `sid.EncodeSID` (which is coupled to `*bytes.Buffer` and is shared with the
  NFS adapter, so its signature is left untouched).
- Deleted the four locals and the now-unused `bytes` import.
- Converted the regression-test SD builders (`buildACE`, `buildRawDACL`,
  `buildSelfRelativeSD`) to `smbenc.Writer` as well.

The pre-sized writer capacities also avoid the old zero-cap `bytes.Buffer`
re-grows.

## Byte-identical guarantee

`WriteUint16/32` use `binary.LittleEndian.PutUint16/32` — identical bytes to
the hand-rolled shifts; `Pad(4)` matches `padTo4`; `encodeSID` emits the same
field order and little-endian sub-authorities as `sid.EncodeSID`.

Added **`TestBuildSD_GoldenBytes`** that pins the full 128-byte wire encoding
of an owner+group+DACL+empty-SACL descriptor byte-for-byte and parses it back
(round-trip). The existing suite (`TestBuildSD_FieldOrder`,
`TestFourByteAlignment`, `TestParseSD_RoundTrip`, `TestSDRoundTripWithMapper`,
`TestBuildSD_SpecialSIDs`, the SET_INFO regression tests, …) all pass unchanged.

`go build ./...`, `go vet`, `gofmt -l` (empty), and
`go test -race ./internal/adapter/smb/...` all pass.

Closes #1053