### PR TITLE
fix(smb-conformance): bind API to 0.0.0.0 in test configs (unblocks smbtorture/WPTS)

### DIFF
--- a/test/smb-conformance/configs/badger-fs.yaml
+++ b/test/smb-conformance/configs/badger-fs.yaml
@@ -19,6 +19,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"

--- a/test/smb-conformance/configs/badger-s3.yaml
+++ b/test/smb-conformance/configs/badger-s3.yaml
@@ -20,6 +20,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"

--- a/test/smb-conformance/configs/memory-fs.yaml
+++ b/test/smb-conformance/configs/memory-fs.yaml
@@ -19,6 +19,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"

--- a/test/smb-conformance/configs/memory-kerberos.yaml
+++ b/test/smb-conformance/configs/memory-kerberos.yaml
@@ -22,6 +22,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"

--- a/test/smb-conformance/configs/memory.yaml
+++ b/test/smb-conformance/configs/memory.yaml
@@ -19,6 +19,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"

--- a/test/smb-conformance/configs/postgres-s3.yaml
+++ b/test/smb-conformance/configs/postgres-s3.yaml
@@ -20,6 +20,7 @@ database:
 
 # Control plane API server
 controlplane:
+  host: "0.0.0.0"
   port: 8080
   jwt:
     secret: "smb-conformance-test-secret-key-32ch"


### PR DESCRIPTION
All SMB-conformance legs have been failing at 'DittoFS not ready after 60s' since the control plane gained a configurable bind address (host defaults to 127.0.0.1, secure-by-default). The 6 test configs set no override → dittofs binds loopback inside the container → docker port-publish (0.0.0.0:8080->8080) forwards to eth0 where nothing listens → host-side readiness probe `curl localhost:8080/health/ready` (run.sh:457) is refused → no torture test ever runs.

Verified locally: with `host: 0.0.0.0` the harness reaches 'DittoFS is ready', extracts the admin password, and runs the suite. Production default (init.go: host 127.0.0.1) is untouched — this only affects the test containers, which require a wildcard bind for docker port-publish.

Closes #1067