### PR TITLE
refactor(nfs/v3): delete buildWccAttr dup of xdr.CaptureWccAttr

### DIFF
--- a/internal/adapter/nfs/v3/handlers/utils.go
+++ b/internal/adapter/nfs/v3/handlers/utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
-	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/mfsymlink"
 	"github.com/marmos91/dittofs/pkg/block/engine"
@@ -60,25 +59,6 @@ func safeAdd(a, b uint64) (uint64, bool) {
 	sum := a + b
 	overflow := sum < a // If sum wrapped around, it will be less than a
 	return sum, overflow
-}
-
-// buildWccAttr builds WCC (Weak Cache Consistency) attributes from FileAttr.
-// Used in WRITE, COMMIT, and other procedures to help clients detect concurrent modifications.
-//
-// WCC data consists of file attributes before and after an operation, allowing clients
-// to invalidate their caches if the file changed unexpectedly.
-func buildWccAttr(attr *metadata.FileAttr) *types.WccAttr {
-	return &types.WccAttr{
-		Size: attr.Size,
-		Mtime: types.TimeVal{
-			Seconds:  uint32(attr.Mtime.Unix()),
-			Nseconds: uint32(attr.Mtime.Nanosecond()),
-		},
-		Ctime: types.TimeVal{
-			Seconds:  uint32(attr.Ctime.Unix()),
-			Nseconds: uint32(attr.Ctime.Nanosecond()),
-		},
-	}
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -267,7 +267,7 @@ func (h *Handler) Write(
 	}
 
 	// Build WCC attributes from pre-write state
-	nfsWccAttr := buildWccAttr(writeIntent.PreWriteAttr)
+	nfsWccAttr := xdr.CaptureWccAttr(writeIntent.PreWriteAttr)
 
 	// ========================================================================
 	// Step 7: Write data to BlockStore (uses local cache internally)
@@ -369,10 +369,7 @@ func (h *Handler) buildWriteErrorResponse(
 	preWriteAttr *metadata.FileAttr,
 	currentAttr *metadata.FileAttr,
 ) *WriteResponse {
-	var wccBefore *types.WccAttr
-	if preWriteAttr != nil {
-		wccBefore = buildWccAttr(preWriteAttr)
-	}
+	wccBefore := xdr.CaptureWccAttr(preWriteAttr)
 
 	var wccAfter *types.NFSFileAttr
 	if currentAttr != nil {

--- a/internal/adapter/nfs/xdr/attributes_test.go
+++ b/internal/adapter/nfs/xdr/attributes_test.go
@@ -1,0 +1,40 @@
+package xdr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+func TestCaptureWccAttr_NilReturnsNil(t *testing.T) {
+	if got := CaptureWccAttr(nil); got != nil {
+		t.Fatalf("CaptureWccAttr(nil) = %+v, want nil", got)
+	}
+}
+
+func TestCaptureWccAttr_CopiesSizeAndTimes(t *testing.T) {
+	mtime := time.Unix(1_700_000_000, 123).UTC()
+	ctime := time.Unix(1_700_000_500, 456).UTC()
+
+	attr := &metadata.FileAttr{
+		Size:  4096,
+		Mtime: mtime,
+		Ctime: ctime,
+	}
+
+	got := CaptureWccAttr(attr)
+	if got == nil {
+		t.Fatal("CaptureWccAttr(attr) = nil, want non-nil")
+	}
+
+	if got.Size != attr.Size {
+		t.Errorf("Size = %d, want %d", got.Size, attr.Size)
+	}
+	if got.Mtime.Seconds != uint32(mtime.Unix()) || got.Mtime.Nseconds != uint32(mtime.Nanosecond()) {
+		t.Errorf("Mtime = %+v, want secs=%d nsecs=%d", got.Mtime, uint32(mtime.Unix()), uint32(mtime.Nanosecond()))
+	}
+	if got.Ctime.Seconds != uint32(ctime.Unix()) || got.Ctime.Nseconds != uint32(ctime.Nanosecond()) {
+		t.Errorf("Ctime = %+v, want secs=%d nsecs=%d", got.Ctime, uint32(ctime.Unix()), uint32(ctime.Nanosecond()))
+	}
+}


### PR DESCRIPTION
Closes #1050

`buildWccAttr` in `v3/handlers/utils.go` duplicated `xdr.CaptureWccAttr` but **lacked its nil-guard** — a nil `*FileAttr` would nil-deref in `buildWccAttr` instead of returning a nil `WccAttr`.

Repoint both NFSv3 WRITE call sites (`write.go`) to the nil-safe `xdr.CaptureWccAttr` and delete the dup (plus the now-unused `types` import in `utils.go`).

The `buildWriteErrorResponse` call site dropped its now-redundant `if preWriteAttr != nil` guard: `CaptureWccAttr` returns nil for nil input, so `wccBefore` ends up nil in exactly the same cases as before — no behavior change.

Added `xdr/attributes_test.go` covering the nil-guard (`CaptureWccAttr(nil) == nil`) and the size/mtime/ctime copy, since the package had no test for `CaptureWccAttr`.

`go build`, `go vet`, `gofmt -l`, and `go test -race ./internal/adapter/nfs/...` all pass.