### PR TITLE
fix(nfs/v4): apply export-squash policy in buildV4AuthContext

### DIFF
--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -1,0 +1,114 @@
+package auth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// ErrShareAccessDenied is returned when a UID does not have permission to
+// access a share (default permission is "none" for an unknown UID, or the
+// resolved permission for a known user is "none").
+var ErrShareAccessDenied = errors.New("share access denied")
+
+// SharePermissionResult is the outcome of export-squash permission resolution.
+type SharePermissionResult struct {
+	// ReadOnly is true when the effective access is read-only — either the
+	// share itself is read-only, or the resolved permission is "read".
+	ReadOnly bool
+
+	// Username is the resolved DittoFS username (or "root"), for logging and
+	// auditing. Empty when no user could be resolved.
+	Username string
+}
+
+// ResolveSharePermission applies the export-squash permission policy for an NFS
+// request, independent of protocol version. It is the single source of truth
+// shared by the NFSv3 and NFSv4 auth-context builders.
+//
+// The policy:
+//   - No identity store, share, or UID → allow with share defaults (read-write,
+//     honouring share.ReadOnly).
+//   - Root (UID 0) under a squash mode that keeps root privileged (none,
+//     root_to_admin, all_to_admin, or empty/default) → admin, username "root".
+//   - Unknown UID → guest: denied when default_permission is "none", otherwise
+//     granted with read-only coerced when the default permission is "read".
+//   - Known user → their resolved share permission (falling back to the share
+//     default on resolution error); denied when "none", read-only coerced when
+//     "read".
+//
+// Returns ErrShareAccessDenied when access must be denied.
+func ResolveSharePermission(
+	ctx context.Context,
+	identityStore models.IdentityStore,
+	share *runtime.Share,
+	shareName string,
+	clientAddr string,
+	uid *uint32,
+) (SharePermissionResult, error) {
+	var result SharePermissionResult
+
+	// No identity store or UID - allow with share defaults.
+	if identityStore == nil || share == nil || uid == nil {
+		return result, nil
+	}
+
+	defaultPerm := models.ParseSharePermission(share.DefaultPermission)
+
+	// Check if caller is root (UID 0) and squash mode doesn't map root away.
+	// Root has full admin access when squash mode is: none, root_to_admin,
+	// all_to_admin, or empty string (default behavior = root_to_admin).
+	isCallerRoot := *uid == 0
+	rootHasAdmin := share.Squash == "" || // Empty string = default (root_to_admin)
+		share.Squash == models.SquashNone ||
+		share.Squash == models.SquashRootToAdmin ||
+		share.Squash == models.SquashAllToAdmin
+	if isCallerRoot && rootHasAdmin {
+		result.ReadOnly = share.ReadOnly
+		result.Username = "root"
+		return result, nil
+	}
+
+	// Try reverse lookup: find user by UID.
+	user, err := identityStore.GetUserByUID(ctx, *uid)
+	if err != nil || user == nil {
+		logger.DebugCtx(ctx, "NFS UID reverse lookup failed, treating as guest",
+			"share", shareName, "uid", *uid, "client", clientAddr, "error", err)
+
+		// Guest access - check default permission.
+		if defaultPerm == models.PermissionNone {
+			logger.DebugCtx(ctx, "Share access denied (unknown UID, default permission is none)",
+				"share", shareName, "uid", *uid)
+			return SharePermissionResult{}, ErrShareAccessDenied
+		}
+
+		result.ReadOnly = share.ReadOnly || defaultPerm == models.PermissionRead
+		logger.DebugCtx(ctx, "Guest access granted", "share", shareName, "permission", defaultPerm, "readOnly", result.ReadOnly)
+		return result, nil
+	}
+
+	// User found - resolve their permission.
+	logger.DebugCtx(ctx, "NFS UID reverse lookup succeeded",
+		"share", shareName, "uid", *uid, "username", user.Username, "client", clientAddr)
+
+	perm, permErr := identityStore.ResolveSharePermission(ctx, user, shareName)
+	if permErr != nil {
+		logger.DebugCtx(ctx, "Permission resolution failed, using default",
+			"share", shareName, "user", user.Username, "error", permErr, "default", defaultPerm)
+		perm = defaultPerm
+	}
+
+	if perm == models.PermissionNone {
+		logger.DebugCtx(ctx, "Share access denied", "share", shareName, "user", user.Username)
+		return SharePermissionResult{}, ErrShareAccessDenied
+	}
+
+	result.ReadOnly = share.ReadOnly || perm == models.PermissionRead
+	result.Username = user.Username
+	logger.DebugCtx(ctx, "User permission resolved", "share", shareName, "user", user.Username, "permission", perm, "readOnly", result.ReadOnly)
+
+	return result, nil
+}

--- a/internal/adapter/nfs/auth/share_permission_test.go
+++ b/internal/adapter/nfs/auth/share_permission_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// permMockStore is a configurable IdentityStore for ResolveSharePermission
+// tests: it maps UIDs to users and users to a fixed resolved permission.
+type permMockStore struct {
+	usersByUID map[uint32]*models.User
+	perm       models.SharePermission
+	permErr    error
+}
+
+func newPermMockStore() *permMockStore {
+	return &permMockStore{usersByUID: make(map[uint32]*models.User)}
+}
+
+func (m *permMockStore) GetUser(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (m *permMockStore) ValidateCredentials(context.Context, string, string) (*models.User, error) {
+	return nil, models.ErrInvalidCredentials
+}
+func (m *permMockStore) ListUsers(context.Context) ([]*models.User, error) { return nil, nil }
+func (m *permMockStore) GetGuestUser(context.Context, string) (*models.User, error) {
+	return nil, errors.New("guest disabled")
+}
+func (m *permMockStore) GetGroup(context.Context, string) (*models.Group, error) {
+	return nil, models.ErrGroupNotFound
+}
+func (m *permMockStore) ListGroups(context.Context) ([]*models.Group, error) { return nil, nil }
+func (m *permMockStore) GetUserGroups(context.Context, string) ([]*models.Group, error) {
+	return nil, nil
+}
+func (m *permMockStore) GetUserByID(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (m *permMockStore) IsGuestEnabled(context.Context, string) bool { return false }
+
+func (m *permMockStore) ResolveSharePermission(context.Context, *models.User, string) (models.SharePermission, error) {
+	return m.perm, m.permErr
+}
+
+func (m *permMockStore) GetUserByUID(_ context.Context, uid uint32) (*models.User, error) {
+	user, ok := m.usersByUID[uid]
+	if !ok {
+		return nil, models.ErrUserNotFound
+	}
+	return user, nil
+}
+
+func ptrUID(v uint32) *uint32 { return &v }
+
+// Behavior 1: default_permission=none denies an unknown UID. This is the v4
+// regression the fix closes — v4 previously never applied this policy.
+func TestResolveSharePermission_DefaultPermissionNoneDeniesUnknownUID(t *testing.T) {
+	store := newPermMockStore() // no user registered for the UID
+	share := &runtime.Share{
+		Name:              "/export",
+		DefaultPermission: "none",
+		Squash:            models.SquashNone,
+	}
+
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234))
+	if !errors.Is(err, ErrShareAccessDenied) {
+		t.Fatalf("expected ErrShareAccessDenied for unknown UID under default_permission=none, got %v", err)
+	}
+}
+
+func TestResolveSharePermission_DefaultPermissionReadWriteAllowsUnknownUID(t *testing.T) {
+	store := newPermMockStore()
+	share := &runtime.Share{
+		Name:              "/export",
+		DefaultPermission: "read-write",
+		Squash:            models.SquashNone,
+	}
+
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ReadOnly {
+		t.Errorf("ReadOnly = true, want false for read-write default")
+	}
+}
+
+// Behavior 2: SquashRootToAdmin (and the default empty squash) promote root
+// (UID 0) to admin with username "root".
+func TestResolveSharePermission_RootPromotedToAdmin(t *testing.T) {
+	for _, sq := range []models.SquashMode{"", models.SquashNone, models.SquashRootToAdmin, models.SquashAllToAdmin} {
+		store := newPermMockStore() // no user mapping; root path must not need one
+		share := &runtime.Share{
+			Name:              "/export",
+			DefaultPermission: "none", // would deny a non-root unknown UID
+			Squash:            sq,
+		}
+
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0))
+		if err != nil {
+			t.Fatalf("squash=%q: unexpected error: %v", sq, err)
+		}
+		if res.Username != "root" {
+			t.Errorf("squash=%q: Username = %q, want \"root\"", sq, res.Username)
+		}
+		if res.ReadOnly {
+			t.Errorf("squash=%q: ReadOnly = true, want false (admin)", sq)
+		}
+	}
+}
+
+// Behavior 3: a known user resolved to permission "read" is coerced read-only.
+func TestResolveSharePermission_ReadPermissionCoercesReadOnly(t *testing.T) {
+	store := newPermMockStore()
+	store.usersByUID[1000] = &models.User{ID: "u1", Username: "alice", UID: ptrUID(1000)}
+	store.perm = models.PermissionRead
+
+	share := &runtime.Share{
+		Name:              "/export",
+		DefaultPermission: "read-write",
+		Squash:            models.SquashNone,
+	}
+
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ReadOnly {
+		t.Errorf("ReadOnly = false, want true for permission=read")
+	}
+	if res.Username != "alice" {
+		t.Errorf("Username = %q, want \"alice\"", res.Username)
+	}
+}
+
+func TestResolveSharePermission_KnownUserPermissionNoneDenied(t *testing.T) {
+	store := newPermMockStore()
+	store.usersByUID[1000] = &models.User{ID: "u1", Username: "alice", UID: ptrUID(1000)}
+	store.perm = models.PermissionNone
+
+	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", Squash: models.SquashNone}
+
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	if !errors.Is(err, ErrShareAccessDenied) {
+		t.Fatalf("expected ErrShareAccessDenied for known user with permission=none, got %v", err)
+	}
+}
+
+// Guard rails: a nil identity store, share, or UID must allow with defaults
+// (never deny) — this is the "no policy info" degrade path both v3 and v4 rely
+// on (e.g. nil registry / AUTH_NULL).
+func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
+	cases := []struct {
+		name  string
+		store models.IdentityStore
+		share *runtime.Share
+		uid   *uint32
+	}{
+		{"nil store", nil, &runtime.Share{}, ptrUID(0)},
+		{"nil share", newPermMockStore(), nil, ptrUID(0)},
+		{"nil uid", newPermMockStore(), &runtime.Share{DefaultPermission: "none"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := ResolveSharePermission(context.Background(), tc.store, tc.share, "/export", "127.0.0.1:1", tc.uid)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.ReadOnly || res.Username != "" {
+				t.Errorf("expected zero result, got %+v", res)
+			}
+		})
+	}
+}
+
+// share.ReadOnly forces read-only even when the resolved permission would allow
+// writes — verifies the share-level flag is ORed in.
+func TestResolveSharePermission_ShareReadOnlyForcesReadOnly(t *testing.T) {
+	store := newPermMockStore()
+	store.usersByUID[1000] = &models.User{ID: "u1", Username: "alice", UID: ptrUID(1000)}
+	store.perm = models.PermissionReadWrite
+
+	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", Squash: models.SquashNone, ReadOnly: true}
+
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ReadOnly {
+		t.Errorf("ReadOnly = false, want true (share.ReadOnly forces it)")
+	}
+}

--- a/internal/adapter/nfs/v3/handlers/auth_helper.go
+++ b/internal/adapter/nfs/v3/handlers/auth_helper.go
@@ -1,19 +1,19 @@
 package handlers
 
 import (
-	"context"
-	"errors"
 	"fmt"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ErrShareAccessDenied is returned when a user doesn't have permission to access a share.
-var ErrShareAccessDenied = errors.New("share access denied")
+// ErrShareAccessDenied is returned when a user doesn't have permission to
+// access a share. It aliases the shared auth sentinel so existing v3 callers
+// (and errors.Is checks) keep working.
+var ErrShareAccessDenied = auth.ErrShareAccessDenied
 
 // formatUID formats an optional UID for logging.
 // Returns "nil" if the pointer is nil, otherwise the numeric value as string.
@@ -22,12 +22,6 @@ func formatUID(uid *uint32) string {
 		return "nil"
 	}
 	return fmt.Sprintf("%d", *uid)
-}
-
-// permissionResult holds the result of permission resolution.
-type permissionResult struct {
-	readOnly bool
-	username string
 }
 
 // BuildAuthContextWithMapping creates an AuthContext with share-level identity mapping applied.
@@ -81,14 +75,14 @@ func BuildAuthContextWithMapping(
 		return nil, fmt.Errorf("failed to get share: %w", shareErr)
 	}
 
-	// Resolve permissions
+	// Resolve permissions (export-squash policy, shared with NFSv4).
 	identityStore := reg.GetIdentityStore()
-	permResult, err := resolveNFSSharePermission(ctx, nfsCtx, identityStore, share, shareName, clientAddr)
+	permResult, err := auth.ResolveSharePermission(ctx, identityStore, share, shareName, clientAddr, nfsCtx.UID)
 	if err != nil {
 		return nil, err
 	}
-	if permResult.username != "" {
-		originalIdentity.Username = permResult.username
+	if permResult.Username != "" {
+		originalIdentity.Username = permResult.Username
 	}
 
 	// Apply share-level identity mapping (all_squash, root_squash)
@@ -103,7 +97,7 @@ func BuildAuthContextWithMapping(
 		ClientAddr:    clientAddr,
 		AuthMethod:    authMethod,
 		Identity:      effectiveIdentity,
-		ShareReadOnly: permResult.readOnly,
+		ShareReadOnly: permResult.ReadOnly,
 	}
 
 	// Log identity mapping
@@ -117,78 +111,4 @@ func BuildAuthContextWithMapping(
 	}
 
 	return effectiveAuthCtx, nil
-}
-
-// resolveNFSSharePermission resolves the share permission for an NFS request.
-// Returns the permission result or an error if access is denied.
-func resolveNFSSharePermission(
-	ctx context.Context,
-	nfsCtx *NFSHandlerContext,
-	identityStore models.IdentityStore,
-	share *runtime.Share,
-	shareName string,
-	clientAddr string,
-) (*permissionResult, error) {
-	result := &permissionResult{}
-
-	// No identity store or UID - allow with share defaults
-	if identityStore == nil || share == nil || nfsCtx.UID == nil {
-		return result, nil
-	}
-
-	defaultPerm := models.ParseSharePermission(share.DefaultPermission)
-
-	// Check if caller is root (UID 0) and squash mode doesn't map root away
-	// Root has full admin access when squash mode is: none, root_to_admin, all_to_admin,
-	// or empty string (default behavior = root_to_admin)
-	isCallerRoot := *nfsCtx.UID == 0
-	rootHasAdmin := share.Squash == "" || // Empty string = default (root_to_admin)
-		share.Squash == models.SquashNone ||
-		share.Squash == models.SquashRootToAdmin ||
-		share.Squash == models.SquashAllToAdmin
-	if isCallerRoot && rootHasAdmin {
-		result.readOnly = share.ReadOnly
-		result.username = "root"
-		return result, nil
-	}
-
-	// Try reverse lookup: find user by UID
-	user, err := identityStore.GetUserByUID(ctx, *nfsCtx.UID)
-	if err != nil || user == nil {
-		logger.DebugCtx(ctx, "NFS UID reverse lookup failed, treating as guest",
-			"share", shareName, "uid", *nfsCtx.UID, "client", clientAddr, "error", err)
-
-		// Guest access - check default permission
-		if defaultPerm == models.PermissionNone {
-			logger.DebugCtx(ctx, "Share access denied (unknown UID, default permission is none)",
-				"share", shareName, "uid", nfsCtx.UID)
-			return nil, ErrShareAccessDenied
-		}
-
-		result.readOnly = share.ReadOnly || defaultPerm == models.PermissionRead
-		logger.DebugCtx(ctx, "Guest access granted", "share", shareName, "permission", defaultPerm, "readOnly", result.readOnly)
-		return result, nil
-	}
-
-	// User found - resolve their permission
-	logger.DebugCtx(ctx, "NFS UID reverse lookup succeeded",
-		"share", shareName, "uid", *nfsCtx.UID, "username", user.Username, "client", clientAddr)
-
-	perm, permErr := identityStore.ResolveSharePermission(ctx, user, shareName)
-	if permErr != nil {
-		logger.DebugCtx(ctx, "Permission resolution failed, using default",
-			"share", shareName, "user", user.Username, "error", permErr, "default", defaultPerm)
-		perm = defaultPerm
-	}
-
-	if perm == models.PermissionNone {
-		logger.DebugCtx(ctx, "Share access denied", "share", shareName, "user", user.Username)
-		return nil, ErrShareAccessDenied
-	}
-
-	result.readOnly = share.ReadOnly || perm == models.PermissionRead
-	result.username = user.Username
-	logger.DebugCtx(ctx, "User permission resolved", "share", shareName, "user", user.Username, "permission", perm, "readOnly", result.readOnly)
-
-	return result, nil
 }

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
@@ -56,6 +57,26 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		}, shareName, nil
 	}
 
+	// Get share for the export-squash permission policy. On error GetShare
+	// returns a nil share; ResolveSharePermission treats a nil share as "no
+	// policy info" (allow with defaults) and the ApplyIdentityMapping step
+	// below still fails closed if the share is genuinely gone.
+	share, _ := h.Registry.GetShare(shareName)
+
+	// Apply the export-squash permission policy (default_permission=none denial,
+	// root→admin promotion, guest/known-user read-only coercion). This is the
+	// SAME policy the v3 path applies via auth.ResolveSharePermission; v4
+	// previously skipped it, so default_permission=none did not deny unknown
+	// UIDs and read-only coercion never fired.
+	permResult, err := auth.ResolveSharePermission(
+		ctx.Context, h.Registry.GetIdentityStore(), share, shareName, ctx.ClientAddr, ctx.UID)
+	if err != nil {
+		return nil, "", err
+	}
+	if permResult.Username != "" {
+		originalIdentity.Username = permResult.Username
+	}
+
 	// Apply share-level identity mapping (all_squash, root_squash).
 	//
 	// Fail closed on mapping failure (parity with the v3 path,
@@ -72,20 +93,13 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		return nil, "", fmt.Errorf("apply identity mapping: %w", err)
 	}
 
-	// Get share for read-only flag
-	shareReadOnly := false
-	share, shareErr := h.Registry.GetShare(shareName)
-	if shareErr == nil && share != nil {
-		shareReadOnly = share.ReadOnly
-	}
-
 	// Create auth context with the effective (mapped) identity
 	authCtx := &metadata.AuthContext{
 		Context:       ctx.Context,
 		ClientAddr:    ctx.ClientAddr,
 		AuthMethod:    authMethod,
 		Identity:      effectiveIdentity,
-		ShareReadOnly: shareReadOnly,
+		ShareReadOnly: permResult.ReadOnly,
 	}
 
 	return authCtx, shareName, nil

--- a/internal/adapter/nfs/v4/handlers/helpers_test.go
+++ b/internal/adapter/nfs/v4/handlers/helpers_test.go
@@ -3,11 +3,14 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
 func TestBuildV4AuthContext_ValidHandle(t *testing.T) {
@@ -144,6 +147,120 @@ func TestBuildV4AuthContext_FailsClosedOnMappingFailure(t *testing.T) {
 	if authCtx != nil {
 		t.Errorf("expected nil authCtx on mapping failure, got %+v", authCtx)
 	}
+}
+
+// v4PermIdentityStore is a minimal IdentityStore for the buildV4AuthContext
+// export-squash policy tests. It resolves a single UID→user and a fixed
+// permission for that user.
+type v4PermIdentityStore struct {
+	knownUID uint32
+	user     *models.User
+	perm     models.SharePermission
+}
+
+func (s *v4PermIdentityStore) GetUser(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (s *v4PermIdentityStore) ValidateCredentials(context.Context, string, string) (*models.User, error) {
+	return nil, models.ErrInvalidCredentials
+}
+func (s *v4PermIdentityStore) ListUsers(context.Context) ([]*models.User, error) { return nil, nil }
+func (s *v4PermIdentityStore) GetGuestUser(context.Context, string) (*models.User, error) {
+	return nil, errors.New("guest disabled")
+}
+func (s *v4PermIdentityStore) GetGroup(context.Context, string) (*models.Group, error) {
+	return nil, models.ErrGroupNotFound
+}
+func (s *v4PermIdentityStore) ListGroups(context.Context) ([]*models.Group, error) { return nil, nil }
+func (s *v4PermIdentityStore) GetUserGroups(context.Context, string) ([]*models.Group, error) {
+	return nil, nil
+}
+func (s *v4PermIdentityStore) GetUserByID(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (s *v4PermIdentityStore) IsGuestEnabled(context.Context, string) bool { return false }
+func (s *v4PermIdentityStore) ResolveSharePermission(context.Context, *models.User, string) (models.SharePermission, error) {
+	return s.perm, nil
+}
+func (s *v4PermIdentityStore) GetUserByUID(_ context.Context, uid uint32) (*models.User, error) {
+	if s.user != nil && uid == s.knownUID {
+		return s.user, nil
+	}
+	return nil, models.ErrUserNotFound
+}
+
+func v4PolicyCtx(uid uint32) *types.CompoundContext {
+	u, g := uid, uid
+	return &types.CompoundContext{
+		Context:    context.Background(),
+		ClientAddr: "192.168.1.100:9999",
+		AuthFlavor: 1, // AUTH_UNIX
+		UID:        &u,
+		GID:        &g,
+	}
+}
+
+// TestBuildV4AuthContext_AppliesExportSquashPolicy verifies the #1047 fix: the
+// NFSv4 auth-context builder applies the SAME export-squash permission policy as
+// NFSv3, via the shared auth.ResolveSharePermission. Three behaviors that v4
+// previously skipped:
+//   - default_permission=none denies an unknown UID
+//   - SquashRootToAdmin promotes root (UID 0) — no denial under none-default
+//   - permission=read coerces ShareReadOnly=true
+func TestBuildV4AuthContext_AppliesExportSquashPolicy(t *testing.T) {
+	handle := []byte("/export:00000000-0000-0000-0000-000000000001")
+
+	t.Run("default_permission=none denies unknown UID", func(t *testing.T) {
+		fx := newRealFSTestFixture(t, "/export")
+		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{})
+		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "none", models.SquashNone); err != nil {
+			t.Fatalf("set policy: %v", err)
+		}
+
+		_, _, err := fx.handler.buildV4AuthContext(v4PolicyCtx(1234), handle)
+		if !errors.Is(err, auth.ErrShareAccessDenied) {
+			t.Fatalf("expected ErrShareAccessDenied for unknown UID under default_permission=none, got %v", err)
+		}
+	})
+
+	t.Run("SquashRootToAdmin promotes root", func(t *testing.T) {
+		fx := newRealFSTestFixture(t, "/export")
+		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{})
+		// default_permission=none would deny a non-root unknown UID, but root
+		// must be promoted, not denied.
+		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "none", models.SquashRootToAdmin); err != nil {
+			t.Fatalf("set policy: %v", err)
+		}
+
+		authCtx, _, err := fx.handler.buildV4AuthContext(v4PolicyCtx(0), handle)
+		if err != nil {
+			t.Fatalf("root must not be denied under root_to_admin: %v", err)
+		}
+		if authCtx == nil {
+			t.Fatal("authCtx is nil for promoted root")
+		}
+	})
+
+	t.Run("permission=read coerces read-only", func(t *testing.T) {
+		fx := newRealFSTestFixture(t, "/export")
+		uid := uint32(1000)
+		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{
+			knownUID: uid,
+			user:     &models.User{ID: "u1", Username: "alice", UID: &uid},
+			perm:     models.PermissionRead,
+		})
+		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "read-write", models.SquashNone); err != nil {
+			t.Fatalf("set policy: %v", err)
+		}
+
+		authCtx, _, err := fx.handler.buildV4AuthContext(v4PolicyCtx(uid), handle)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !authCtx.ShareReadOnly {
+			t.Errorf("ShareReadOnly = false, want true for permission=read")
+		}
+	})
 }
 
 func TestEncodeChangeInfo4(t *testing.T) {

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -55,6 +55,12 @@ type Runtime struct {
 	mu    sync.RWMutex
 	store store.Store
 
+	// identityStoreOverride, when non-nil, is returned by GetIdentityStore in
+	// place of store. Test-only (set via SetIdentityStoreForTesting) so NFS
+	// auth tests can inject a lightweight IdentityStore without a full
+	// store.Store implementation.
+	identityStoreOverride models.IdentityStore
+
 	metadataService *metadata.Service
 
 	adaptersSvc    *adapters.Service
@@ -723,8 +729,26 @@ func (r *Runtime) EvictBlockStore(ctx context.Context, shareName string, opts sh
 	return r.sharesSvc.EvictBlockStore(ctx, shareName, opts)
 }
 
-func (r *Runtime) GetUserStore() models.UserStore         { return r.store }
-func (r *Runtime) GetIdentityStore() models.IdentityStore { return r.store }
+func (r *Runtime) GetUserStore() models.UserStore { return r.store }
+
+func (r *Runtime) GetIdentityStore() models.IdentityStore {
+	if r.identityStoreOverride != nil {
+		return r.identityStoreOverride
+	}
+	return r.store
+}
+
+// SetIdentityStoreForTesting overrides the identity store returned by
+// GetIdentityStore. Test-only.
+func (r *Runtime) SetIdentityStoreForTesting(s models.IdentityStore) {
+	r.identityStoreOverride = s
+}
+
+// SetSharePolicyForTesting overrides a registered share's DefaultPermission and
+// Squash mode. Test-only.
+func (r *Runtime) SetSharePolicyForTesting(name, defaultPermission string, squash models.SquashMode) error {
+	return r.sharesSvc.SetSharePolicyForTesting(name, defaultPermission, squash)
+}
 
 // GetIdentityMappingStore returns the identity mapping store if supported.
 // Returns nil if the underlying store does not implement IdentityMappingStore.

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1366,6 +1366,21 @@ func (s *Service) SetEnabledForTesting(name string, enabled bool) error {
 	return nil
 }
 
+// SetSharePolicyForTesting overrides a share's DefaultPermission and Squash mode
+// in the registry under lock. Test-only — lets NFS auth tests exercise the
+// export-squash permission policy without a full AddShare flow.
+func (s *Service) SetSharePolicyForTesting(name, defaultPermission string, squash models.SquashMode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	share, ok := s.registry[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
+	}
+	share.DefaultPermission = defaultPermission
+	share.Squash = squash
+	return nil
+}
+
 func (s *Service) GetRootHandle(shareName string) (metadata.FileHandle, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
Closes #1047

**Bug:** NFSv4's `buildV4AuthContext` (`v4/handlers/helpers.go`) applied identity mapping and read `share.ReadOnly`, but never applied the export-squash **permission** policy that NFSv3 applies via `resolveNFSSharePermission` (`v3/handlers/auth_helper.go`). On NFSv4 this meant:

- `default_permission=none` did **not** deny unknown UIDs
- `SquashRootToAdmin` root→admin promotion did **not** fire
- guest / known-user read-only coercion (`perm == read`) was **skipped**

**Fix:** Extracted the v3 policy into a protocol-neutral `auth.ResolveSharePermission` (`internal/adapter/nfs/auth/share_permission.go`) — **one source of truth, no second copy**. Both v3 `BuildAuthContextWithMapping` and v4 `buildV4AuthContext` now call it, using the **original (pre-mapping) UID**, exactly as v3 does. The v3 `ErrShareAccessDenied` sentinel is now an alias of the shared one so `errors.Is` keeps working.

v4 now surfaces `ErrShareAccessDenied` on denial; its callers map it to a failing status the same way v3 does — the operation is **denied** rather than silently allowed. (Both v3 and v4 currently surface a generic fault code for this, not a dedicated ACCESS code; matching v3 is the goal here, and that imprecision is pre-existing/out of scope.) A missing or stale share still **fails closed** via the subsequent `ApplyIdentityMapping` step.

**Verification against v3:** the policy is now literally the same function. Tests:
- `auth/share_permission_test.go` — exhaustive coverage of all three behaviors (none-denies-unknown-UID, root→admin under each squash mode, read→read-only) plus nil-input degrade and `share.ReadOnly` forcing.
- `v4/handlers/helpers_test.go::TestBuildV4AuthContext_AppliesExportSquashPolicy` — end-to-end through `buildV4AuthContext` proving each of the three behaviors fires on v4.

Adds test-only `Runtime.SetIdentityStoreForTesting` / `Runtime.SetSharePolicyForTesting` (+ shares-service backing), following the existing `*ForTesting` convention.

`go build`, `go vet`, `gofmt -l`, and `go test -race ./internal/adapter/nfs/...` all pass.