### PR TITLE
refactor(nfs/v4): unify COMPOUND dispatch to one driver

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -108,6 +107,152 @@ func rejectV40OnlyOp(opCode uint32, reader io.Reader, clientAddr string) *types.
 	return notSuppHandler(opCode)
 }
 
+// dispatchOne resolves and runs a single COMPOUND operation, returning its
+// result. It is the single op-dispatch decision shared by the v4.0 and v4.1
+// loops (mirroring the single op-table + loop structure of the Linux nfsd
+// COMPOUND processor).
+//
+// isV41 selects v4.1 dispatch semantics, which differ from v4.0 in three ways:
+//   - v4.0-only operations (SETCLIENTID, RENEW, …) are rejected with NOTSUPP
+//     after consuming their args (v4.0 has no such concept).
+//   - the v4.1 dispatch table is consulted before the shared v4.0 table.
+//   - the "valid but unimplemented" opcode range extends through
+//     OP_RECLAIM_COMPLETE (v4.1) instead of OP_RELEASE_LOCKOWNER (v4.0).
+//
+// v41ctx carries the per-request v4.1 session context and is nil for the
+// exempt-op path (e.g. EXCHANGE_ID before any SEQUENCE); it is only passed to
+// v4.1 handlers, which tolerate a nil context for exempt ops.
+//
+// The returned result always has OpCode set (defaulting to the dispatched
+// opCode when a handler left it zero).
+func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41RequestContext, opCode uint32, reader io.Reader, isV41 bool) *types.CompoundResult {
+	// Adapter-level operation blocklist: blocked ops return NOTSUPP.
+	if h.IsOperationBlocked(opCode) {
+		logger.Debug("NFSv4 COMPOUND op blocked by adapter settings",
+			"opcode", opCode, "op_name", types.OpName(opCode), "client", compCtx.ClientAddr)
+		result := notSuppHandler(opCode)
+		result.OpCode = opCode
+		return result
+	}
+
+	var result *types.CompoundResult
+	switch {
+	case isV41 && v40OnlyOps[opCode]:
+		result = rejectV40OnlyOp(opCode, reader, compCtx.ClientAddr)
+
+	case isV41 && h.v41DispatchTable[opCode] != nil:
+		result = h.v41DispatchTable[opCode](compCtx, v41ctx, reader)
+
+	case h.opDispatchTable[opCode] != nil:
+		result = h.opDispatchTable[opCode](compCtx, reader)
+
+	case opCode >= 3 && opCode <= h.maxValidOpCode(isV41):
+		// Valid operation number for this minor version but not implemented.
+		result = notSuppHandler(opCode)
+
+	default:
+		// Truly illegal operation number.
+		result = &types.CompoundResult{
+			Status: types.NFS4ERR_OP_ILLEGAL,
+			OpCode: types.OP_ILLEGAL,
+			Data:   encodeStatusOnly(types.NFS4ERR_OP_ILLEGAL),
+		}
+	}
+
+	if result.OpCode == 0 && opCode != 0 {
+		result.OpCode = opCode
+	}
+	return result
+}
+
+// maxValidOpCode returns the highest opcode that is a valid operation number
+// for the active minor version (used to distinguish "valid but unimplemented"
+// from "illegal opcode").
+func (h *Handler) maxValidOpCode(isV41 bool) uint32 {
+	if isV41 {
+		return types.OP_RECLAIM_COMPLETE
+	}
+	return types.OP_RELEASE_LOCKOWNER
+}
+
+// compoundLoopParams configures runCompoundOps for a specific COMPOUND variant.
+type compoundLoopParams struct {
+	// isV41 selects v4.1 dispatch semantics in dispatchOne.
+	isV41 bool
+	// v41ctx is the per-request v4.1 session context (nil for v4.0 and for the
+	// v4.1 exempt-op path).
+	v41ctx *types.V41RequestContext
+	// firstOpCode, when hasFirstOpCode is set, is an opcode already read from
+	// the reader and dispatched as the first iteration (the exempt-op path
+	// peeks the first opcode before deciding how to dispatch).
+	firstOpCode    uint32
+	hasFirstOpCode bool
+	// startIndex is the op index the loop starts at (1 for the SEQUENCE-bearing
+	// v4.1 path, which has already produced the SEQUENCE result).
+	startIndex uint32
+	// hardErrOnDecodeError controls opcode-decode failure handling: v4.0 returns
+	// the error (the RPC layer faults the call); the v4.1 paths instead encode a
+	// partial NFS4ERR_BADXDR reply so completed-op results are preserved and the
+	// slot is cached (the merged cancel/partial-reply fix).
+	hardErrOnDecodeError bool
+}
+
+// runCompoundOps is the single COMPOUND operation loop shared by the v4.0 and
+// v4.1 dispatchers. It appends each op's result to results, stops on the first
+// non-OK status (RFC 7530 §16.2) or on cancellation (encoding NFS4ERR_DELAY),
+// and returns the accumulated results, the last status, and a fatal error
+// (non-nil only when hardErrOnDecodeError is set and an opcode fails to decode).
+func (h *Handler) runCompoundOps(compCtx *types.CompoundContext, numOps uint32, reader io.Reader, p compoundLoopParams) ([]types.CompoundResult, uint32, error) {
+	results := make([]types.CompoundResult, 0, int(numOps))
+	lastStatus := uint32(types.NFS4_OK)
+
+	for i := p.startIndex; i < numOps; i++ {
+		var opCode uint32
+		if p.hasFirstOpCode && i == p.startIndex {
+			opCode = p.firstOpCode
+		} else {
+			// Check context cancellation between operations. Encode a partial
+			// response with NFS4ERR_DELAY (rather than returning a bare error,
+			// which would make the RPC layer drop the reply and reset the
+			// connection) so the client receives a well-formed reply and can
+			// retry — and, on the v4.1 path, so the slot reply is cached.
+			if compCtx.Context.Err() != nil {
+				logger.Debug("NFSv4 COMPOUND cancelled between ops",
+					"op_index", i, "total_ops", numOps, "client", compCtx.ClientAddr)
+				lastStatus = types.NFS4ERR_DELAY
+				break
+			}
+
+			var err error
+			opCode, err = xdr.DecodeUint32(reader)
+			if err != nil {
+				if p.hardErrOnDecodeError {
+					return nil, 0, fmt.Errorf("decode op %d opcode: %w", i, err)
+				}
+				lastStatus = types.NFS4ERR_BADXDR
+				break
+			}
+		}
+
+		result := h.dispatchOne(compCtx, p.v41ctx, opCode, reader, p.isV41)
+		results = append(results, *result)
+		lastStatus = result.Status
+
+		logger.Debug("NFSv4 COMPOUND op dispatched",
+			"op_index", i, "opcode", opCode, "op_name", types.OpName(opCode),
+			"status", result.Status, "client", compCtx.ClientAddr)
+
+		if result.Status != types.NFS4_OK {
+			logger.Debug("NFSv4 COMPOUND op failed, stopping",
+				"op_index", i, "opcode", opCode, "op_name", types.OpName(opCode),
+				"status", result.Status, "client", compCtx.ClientAddr)
+			break
+		}
+	}
+
+	return results, lastStatus, nil
+}
+
 // ProcessCompound is the main NFSv4 COMPOUND dispatcher.
 //
 // Per RFC 7530 Section 16.2, COMPOUND bundles multiple operations into a single
@@ -204,92 +349,15 @@ func (h *Handler) dispatchV40(compCtx *types.CompoundContext, tag []byte, numOps
 		return encodeCompoundResponse(types.NFS4ERR_RESOURCE, tag, nil)
 	}
 
-	// Sequential dispatch loop
-	results := make([]types.CompoundResult, 0, int(numOps))
-	var lastStatus uint32 = types.NFS4_OK
-
-	for i := uint32(0); i < numOps; i++ {
-		// Check context cancellation between operations.
-		// Instead of returning an error (which would cause the RPC layer to
-		// silently drop the reply, hanging the client), encode a partial
-		// response with NFS4ERR_DELAY so the client can retry.
-		if compCtx.Context.Err() != nil {
-			logger.Debug("NFSv4 COMPOUND cancelled between ops",
-				"op_index", i,
-				"total_ops", numOps,
-				"client", compCtx.ClientAddr)
-			lastStatus = types.NFS4ERR_DELAY
-			break
-		}
-
-		// Read operation code
-		opCode, err := xdr.DecodeUint32(reader)
-		if err != nil {
-			return nil, fmt.Errorf("decode op %d opcode: %w", i, err)
-		}
-
-		// Check adapter-level operation blocklist before dispatch.
-		// Blocked operations return NFS4ERR_NOTSUPP per locked decision.
-		if h.IsOperationBlocked(opCode) {
-			logger.Debug("NFSv4 COMPOUND op blocked by adapter settings",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"client", compCtx.ClientAddr)
-
-			result := notSuppHandler(opCode)
-			result.OpCode = opCode
-			results = append(results, *result)
-			lastStatus = result.Status
-			break
-		}
-
-		// Dispatch to v4.0 handler
-		var result *types.CompoundResult
-		handler, ok := h.opDispatchTable[opCode]
-		if ok {
-			result = handler(compCtx, reader)
-		} else {
-			// Unknown opcode: check if it's in the valid v4.0 range (3-39)
-			// or truly illegal/unknown
-			if opCode < 3 || opCode > types.OP_RELEASE_LOCKOWNER {
-				// Truly illegal operation number
-				result = &types.CompoundResult{
-					Status: types.NFS4ERR_OP_ILLEGAL,
-					OpCode: types.OP_ILLEGAL,
-					Data:   encodeStatusOnly(types.NFS4ERR_OP_ILLEGAL),
-				}
-			} else {
-				// Valid v4.0 operation number but not yet implemented
-				result = notSuppHandler(opCode)
-			}
-		}
-
-		// Set the opcode on the result (in case handler didn't set it)
-		if result.OpCode == 0 && opCode != 0 {
-			result.OpCode = opCode
-		}
-
-		results = append(results, *result)
-		lastStatus = result.Status
-
-		// Log every operation for debugging
-		logger.Debug("NFSv4 COMPOUND op dispatched",
-			"op_index", i,
-			"opcode", opCode,
-			"op_name", types.OpName(opCode),
-			"status", result.Status,
-			"client", compCtx.ClientAddr)
-
-		if result.Status != types.NFS4_OK {
-			logger.Debug("NFSv4 COMPOUND op failed, stopping",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"status", result.Status,
-				"client", compCtx.ClientAddr)
-			break
-		}
+	// v4.0 has no SEQUENCE/replay cache, so an opcode that fails to decode is a
+	// fatal protocol error (hardErrOnDecodeError) rather than a cached partial
+	// reply.
+	results, lastStatus, err := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
+		isV41:                false,
+		hardErrOnDecodeError: true,
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return encodeCompoundResponse(lastStatus, tag, results)
@@ -405,93 +473,21 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 		return encoded, nil
 	}
 
-	// Build results starting with SEQUENCE result
-	results := make([]types.CompoundResult, 0, int(numOps))
+	// Dispatch the remaining ops (the SEQUENCE result is prepended below).
+	// startIndex=1 because op 0 was SEQUENCE. Decode errors encode a partial
+	// reply (hardErrOnDecodeError=false) so the defer still caches the slot
+	// response, preserving replay semantics for the ops that did complete.
+	opResults, lastStatus, _ := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
+		isV41:                true,
+		v41ctx:               v41ctx,
+		startIndex:           1,
+		hardErrOnDecodeError: false,
+	})
+
+	// Build results starting with the SEQUENCE result.
+	results := make([]types.CompoundResult, 0, len(opResults)+1)
 	results = append(results, *seqResult)
-	var lastStatus uint32 = types.NFS4_OK
-
-	// Dispatch remaining ops (numOps - 1)
-	for i := uint32(1); i < numOps; i++ {
-		// Check context cancellation between operations.
-		// Instead of returning an error (which would skip slot caching and break
-		// replay semantics), encode the partial response so the defer caches it.
-		if compCtx.Context.Err() != nil {
-			logger.Debug("NFSv4.1 COMPOUND cancelled between ops",
-				"op_index", i,
-				"total_ops", numOps,
-				"client", compCtx.ClientAddr)
-			lastStatus = types.NFS4ERR_DELAY
-			break
-		}
-
-		// Read operation code. On decode error, encode partial response so the
-		// defer caches it (preserving replay semantics for completed ops).
-		opCode, err := xdr.DecodeUint32(reader)
-		if err != nil {
-			lastStatus = types.NFS4ERR_BADXDR
-			break
-		}
-
-		// Check adapter-level operation blocklist before dispatch.
-		if h.IsOperationBlocked(opCode) {
-			logger.Debug("NFSv4.1 COMPOUND op blocked by adapter settings",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"client", compCtx.ClientAddr)
-
-			result := notSuppHandler(opCode)
-			result.OpCode = opCode
-			results = append(results, *result)
-			lastStatus = result.Status
-			break
-		}
-
-		// Dispatch: reject v4.0-only, then v4.1 table, then v4.0 fallback.
-		var result *types.CompoundResult
-
-		if v40OnlyOps[opCode] {
-			result = rejectV40OnlyOp(opCode, reader, compCtx.ClientAddr)
-		} else if v41Handler, ok := h.v41DispatchTable[opCode]; ok {
-			result = v41Handler(compCtx, v41ctx, reader)
-		} else if v40Handler, ok := h.opDispatchTable[opCode]; ok {
-			result = v40Handler(compCtx, reader)
-		} else if opCode >= 3 && opCode <= types.OP_RECLAIM_COMPLETE {
-			result = notSuppHandler(opCode)
-		} else {
-			result = &types.CompoundResult{
-				Status: types.NFS4ERR_OP_ILLEGAL,
-				OpCode: types.OP_ILLEGAL,
-				Data:   encodeStatusOnly(types.NFS4ERR_OP_ILLEGAL),
-			}
-		}
-
-		if result.OpCode == 0 && opCode != 0 {
-			result.OpCode = opCode
-		}
-
-		results = append(results, *result)
-		lastStatus = result.Status
-
-		logger.Debug("NFSv4.1 COMPOUND op dispatched",
-			"op_index", i,
-			"opcode", opCode,
-			"op_name", types.OpName(opCode),
-			"status", result.Status,
-			"session_id", hex.EncodeToString(v41ctx.SessionID[:]),
-			"slot", v41ctx.SlotID,
-			"client", compCtx.ClientAddr)
-
-		if result.Status != types.NFS4_OK {
-			logger.Debug("NFSv4.1 COMPOUND op failed, stopping",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"status", result.Status,
-				"client", compCtx.ClientAddr)
-			break
-		}
-	}
+	results = append(results, opResults...)
 
 	encoded, encErr := encodeCompoundResponse(lastStatus, tag, results)
 	if encErr != nil {
@@ -504,101 +500,18 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 	return encoded, nil
 }
 
-// dispatchV41Ops dispatches a v4.1 COMPOUND starting from firstOpCode.
-// Used for both exempt ops (v41ctx=nil) and could be used after SEQUENCE.
-// The firstOpCode has already been read from the reader.
+// dispatchV41Ops dispatches a v4.1 COMPOUND starting from firstOpCode (already
+// read from the reader). Used for the exempt-op path, where the first op is not
+// SEQUENCE (e.g. EXCHANGE_ID) and so v41ctx is nil. Decode errors encode a
+// partial reply rather than dropping it (matching the SEQUENCE-bearing path).
 func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, firstOpCode uint32, numOps uint32, v41ctx *types.V41RequestContext, reader io.Reader) ([]byte, error) {
-	results := make([]types.CompoundResult, 0, int(numOps))
-	var lastStatus uint32 = types.NFS4_OK
-
-	// Process all ops, starting with firstOpCode already read
-	for i := uint32(0); i < numOps; i++ {
-		var opCode uint32
-		if i == 0 {
-			opCode = firstOpCode
-		} else {
-			// Check context cancellation between operations. Mirror the
-			// SEQUENCE-bearing path (dispatchV41): instead of returning a bare
-			// error (which makes the RPC layer drop the reply and reset the
-			// connection), encode a partial response with NFS4ERR_DELAY so the
-			// client receives a well-formed reply and can retry.
-			if compCtx.Context.Err() != nil {
-				logger.Debug("NFSv4.1 COMPOUND cancelled between ops",
-					"op_index", i,
-					"total_ops", numOps,
-					"client", compCtx.ClientAddr)
-				lastStatus = types.NFS4ERR_DELAY
-				break
-			}
-
-			// Read operation code. On decode error, encode the partial response
-			// gathered so far rather than dropping the reply.
-			var err error
-			opCode, err = xdr.DecodeUint32(reader)
-			if err != nil {
-				lastStatus = types.NFS4ERR_BADXDR
-				break
-			}
-		}
-
-		// Check adapter-level operation blocklist before dispatch.
-		if h.IsOperationBlocked(opCode) {
-			logger.Debug("NFSv4.1 COMPOUND op blocked by adapter settings",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"client", compCtx.ClientAddr)
-
-			result := notSuppHandler(opCode)
-			result.OpCode = opCode
-			results = append(results, *result)
-			lastStatus = result.Status
-			break
-		}
-
-		// Dispatch: reject v4.0-only, then v4.1 table, then v4.0 fallback.
-		var result *types.CompoundResult
-
-		if v40OnlyOps[opCode] {
-			result = rejectV40OnlyOp(opCode, reader, compCtx.ClientAddr)
-		} else if v41Handler, ok := h.v41DispatchTable[opCode]; ok {
-			result = v41Handler(compCtx, v41ctx, reader)
-		} else if v40Handler, ok := h.opDispatchTable[opCode]; ok {
-			result = v40Handler(compCtx, reader)
-		} else if opCode >= 3 && opCode <= types.OP_RECLAIM_COMPLETE {
-			result = notSuppHandler(opCode)
-		} else {
-			result = &types.CompoundResult{
-				Status: types.NFS4ERR_OP_ILLEGAL,
-				OpCode: types.OP_ILLEGAL,
-				Data:   encodeStatusOnly(types.NFS4ERR_OP_ILLEGAL),
-			}
-		}
-
-		if result.OpCode == 0 && opCode != 0 {
-			result.OpCode = opCode
-		}
-
-		results = append(results, *result)
-		lastStatus = result.Status
-
-		logger.Debug("NFSv4.1 COMPOUND op dispatched",
-			"op_index", i,
-			"opcode", opCode,
-			"op_name", types.OpName(opCode),
-			"status", result.Status,
-			"client", compCtx.ClientAddr)
-
-		if result.Status != types.NFS4_OK {
-			logger.Debug("NFSv4.1 COMPOUND op failed, stopping",
-				"op_index", i,
-				"opcode", opCode,
-				"op_name", types.OpName(opCode),
-				"status", result.Status,
-				"client", compCtx.ClientAddr)
-			break
-		}
-	}
+	results, lastStatus, _ := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
+		isV41:                true,
+		v41ctx:               v41ctx,
+		firstOpCode:          firstOpCode,
+		hasFirstOpCode:       true,
+		hardErrOnDecodeError: false,
+	})
 
 	return encodeCompoundResponse(lastStatus, tag, results)
 }

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2458,3 +2458,131 @@ func encodeGetAttrArgsForCancel() []byte {
 	_ = xdr.WriteUint32(&buf, 0) // bitmap length = 0
 	return buf.Bytes()
 }
+
+// ============================================================================
+// Unified COMPOUND dispatch (dispatchOne / runCompoundOps)
+// ============================================================================
+
+// TestCompound_V40_CancelledContext_EncodesPartialReply verifies the v4.0 loop
+// (which has no SEQUENCE/slot cache) still encodes a partial NFS4ERR_DELAY reply
+// on cancellation between ops, rather than dropping the reply. This mirrors the
+// v4.1 cancel behavior now that both share runCompoundOps.
+func TestCompound_V40_CancelledContext_EncodesPartialReply(t *testing.T) {
+	h := newTestHandler()
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	// op0 succeeds and cancels the context; the cancel is then observed at the
+	// op1 boundary (before GETATTR dispatches), so op0's result is preserved.
+	h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		cancel()
+		return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_PUTROOTFH, Data: encodeStatusOnly(types.NFS4_OK)}
+	}
+
+	ctx := &types.CompoundContext{Context: cancelCtx, ClientAddr: "127.0.0.1:12345"}
+
+	data := buildCompoundArgs([]byte("v40-cxl"), 0, []uint32{types.OP_PUTROOTFH, types.OP_GETATTR})
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound returned error (reply would be dropped): %v", err)
+	}
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+	if decoded.Status != types.NFS4ERR_DELAY {
+		t.Errorf("status = %d, want NFS4ERR_DELAY (%d)", decoded.Status, types.NFS4ERR_DELAY)
+	}
+	if decoded.NumResults != 1 {
+		t.Errorf("numResults = %d, want 1 (only op0 dispatched before cancel)", decoded.NumResults)
+	}
+}
+
+// TestCompound_V40_IllegalVsNotSupp verifies dispatchOne's v4.0 opcode-range
+// classification: an opcode just past the v4.0 range (OP_RELEASE_LOCKOWNER) is
+// illegal, while a valid-but-unhandled v4.0 opcode is NOTSUPP.
+func TestCompound_V40_IllegalVsNotSupp(t *testing.T) {
+	h := newTestHandler()
+	ctx := newTestCompoundContext()
+
+	// OP_BIND_CONN_TO_SESSION (41) is > OP_RELEASE_LOCKOWNER (39) → illegal in v4.0.
+	data := buildCompoundArgs([]byte("v40-illegal"), 0, []uint32{types.OP_BIND_CONN_TO_SESSION})
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if decoded.Status != types.NFS4ERR_OP_ILLEGAL {
+		t.Errorf("opcode > v4.0 range: status = %d, want NFS4ERR_OP_ILLEGAL (%d)", decoded.Status, types.NFS4ERR_OP_ILLEGAL)
+	}
+	if decoded.NumResults != 1 || decoded.Results[0].OpCode != types.OP_ILLEGAL {
+		t.Errorf("illegal result opcode = %v, want OP_ILLEGAL", decoded.Results)
+	}
+}
+
+// TestCompound_DispatchOne_MinorVersionRouting verifies the unified dispatchOne
+// applies the right per-minor-version semantics: a v4.0-only op (SETCLIENTID)
+// is dispatched normally under v4.0 but rejected with NOTSUPP under v4.1; and a
+// handler registered only in the v4.1 table is reached only when isV41=true.
+func TestCompound_DispatchOne_MinorVersionRouting(t *testing.T) {
+	t.Run("v4.0-only op rejected under v4.1", func(t *testing.T) {
+		h := newTestHandler()
+		// Register a v4.0 SETCLIENTID handler that, if reached, would succeed.
+		h.opDispatchTable[types.OP_SETCLIENTID] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+			return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_SETCLIENTID, Data: encodeStatusOnly(types.NFS4_OK)}
+		}
+		ctx := newTestCompoundContext()
+
+		// Under v4.0 the op dispatches to the registered handler.
+		args := encodeSetClientIDArgsForReject()
+		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), false); res.Status != types.NFS4_OK {
+			t.Errorf("v4.0 SETCLIENTID status = %d, want NFS4_OK", res.Status)
+		}
+
+		// Under v4.1 the same op is rejected with NOTSUPP (args consumed).
+		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), true); res.Status != types.NFS4ERR_NOTSUPP {
+			t.Errorf("v4.1 SETCLIENTID status = %d, want NFS4ERR_NOTSUPP (%d)", res.Status, types.NFS4ERR_NOTSUPP)
+		}
+	})
+
+	t.Run("v4.1-only handler reached only under v4.1", func(t *testing.T) {
+		h := newTestHandler()
+		const probeOp = types.OP_RECLAIM_COMPLETE
+		var reached bool
+		h.v41DispatchTable[probeOp] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+			reached = true
+			return &types.CompoundResult{Status: types.NFS4_OK, OpCode: probeOp, Data: encodeStatusOnly(types.NFS4_OK)}
+		}
+		// Ensure no v4.0 table entry shadows it.
+		delete(h.opDispatchTable, probeOp)
+		ctx := newTestCompoundContext()
+
+		// Under v4.0 the v4.1 table is not consulted → handler not reached.
+		reached = false
+		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), false); reached {
+			t.Errorf("v4.0 must not reach v4.1 handler (status=%d)", res.Status)
+		}
+
+		// Under v4.1 the handler is reached.
+		reached = false
+		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), true); !reached || res.Status != types.NFS4_OK {
+			t.Errorf("v4.1 must reach v4.1 handler: reached=%v status=%d", reached, res.Status)
+		}
+	})
+}
+
+// encodeSetClientIDArgsForReject builds minimal valid SETCLIENTID args so the
+// v4.0-only rejection path can consume them without a stream-desync error.
+func encodeSetClientIDArgsForReject() []byte {
+	var buf bytes.Buffer
+	var verifier [8]byte
+	_, _ = buf.Write(verifier[:])               // verifier (8 bytes)
+	_ = xdr.WriteXDROpaque(&buf, []byte("cid")) // client id string
+	_ = xdr.WriteUint32(&buf, 0)                // cb_program
+	_ = xdr.WriteXDROpaque(&buf, []byte("tcp")) // netid
+	_ = xdr.WriteXDROpaque(&buf, []byte("a"))   // addr
+	_ = xdr.WriteUint32(&buf, 0)                // callback_ident
+	return buf.Bytes()
+}


### PR DESCRIPTION
Closes #1054

`compound.go` triplicated the per-op dispatch decision and loop across `dispatchV40`, the `dispatchV41` inner loop, and `dispatchV41Ops`. This collapses them into **one `dispatchOne`** (opcode → result) plus **one `runCompoundOps`** loop — mirroring the single op-table + loop structure of the Linux nfsd COMPOUND processor.

**`dispatchOne(compCtx, v41ctx, opCode, reader, isV41)`** captures the only per-minor-version differences:
- v4.0-only-op rejection (`SETCLIENTID`, `RENEW`, … → consume args + NOTSUPP) — v4.1 only
- the v4.1 dispatch table (tried before the shared v4.0 table) — v4.1 only
- the wider valid-opcode range (`OP_RECLAIM_COMPLETE` for v4.1 vs `OP_RELEASE_LOCKOWNER` for v4.0) used to distinguish "valid but unimplemented" (NOTSUPP) from "illegal opcode" (OP_ILLEGAL)

**`runCompoundOps`** is parameterized by:
- `startIndex` (1 after SEQUENCE, which already produced its result)
- an already-read first opcode (the exempt-op path peeks it before deciding how to dispatch)
- `hardErrOnDecodeError` — v4.0 **returns** the decode error (the RPC layer faults the call); the v4.1 paths instead encode a **partial `NFS4ERR_BADXDR`** reply so completed-op results are preserved and the slot is cached (**the merged #1060 cancel/partial-reply fix**)

The SEQUENCE result prepend, slot-caching `defer`, draining check, and replay-cache wiring stay in `dispatchV41` unchanged. The three dispatch-function signatures are unchanged, so `ProcessCompound` calls them exactly as before.

**Behavior preservation:** the full existing `compound_test.go` battery passes (v4.0/v4.1 dispatch, v4.0-only rejection, illegal/NOTSUPP, exempt ops, the cancel partial-reply test, draining), plus `go test -race ./internal/adapter/nfs/...`. Added tests for **v4.0 cancel-between-ops** (partial `NFS4ERR_DELAY` reply), the **v4.0 illegal-vs-NOTSUPP** opcode boundary, and **`dispatchOne` minor-version routing** (v4.0-only op rejected under v4.1; v4.1-only handler reached only under v4.1).

Net **−87 lines** in `compound.go` (658 → 571).

`go build`, `go vet`, `gofmt -l` all clean.