### PR TITLE
chore(adapters): strip banner/step/planning-ID comments; demote hot-path logs

### DIFF
--- a/internal/adapter/common/content_errmap.go
+++ b/internal/adapter/common/content_errmap.go
@@ -29,7 +29,7 @@ func MapContentToNFS3(err error) uint32 {
 		return nfs3types.NFS3OK
 	}
 	// The block store was Closed under the in-flight op — the share was
-	// removed/hot-reloaded mid-transfer (area-7 H-A). STALE tells the
+	// removed/hot-reloaded mid-transfer. STALE tells the
 	// client the handle no longer refers to a live object.
 	if goerrors.Is(err, engine.ErrStoreClosed) {
 		return nfs3types.NFS3ErrStale
@@ -64,7 +64,7 @@ func MapContentToNFS4(err error) uint32 {
 	if err == nil {
 		return nfs4types.NFS4_OK
 	}
-	// Closed store under an in-flight op (area-7 H-A) → STALE.
+	// Closed store under an in-flight op → STALE.
 	if goerrors.Is(err, engine.ErrStoreClosed) {
 		return nfs4types.NFS4ERR_STALE
 	}
@@ -89,7 +89,7 @@ func MapContentToSMB(err error) smbtypes.Status {
 	if err == nil {
 		return smbtypes.StatusSuccess
 	}
-	// Closed store under an in-flight op (area-7 H-A): the share went away
+	// Closed store under an in-flight op: the share went away
 	// mid-transfer. STATUS_FILE_CLOSED is the closest SMB stale-handle
 	// signal (matches the merrs.ErrStaleHandle row in errmap.go).
 	if goerrors.Is(err, engine.ErrStoreClosed) {

--- a/internal/adapter/common/doc.go
+++ b/internal/adapter/common/doc.go
@@ -1,84 +1,35 @@
 // Package common provides shared helpers used by every protocol adapter
-// (NFSv3, NFSv4, SMB2/3) so that block-store resolution, pooled read
-// buffers, and metadata→protocol error mapping live in exactly one place.
+// (NFSv3, NFSv4, SMB2/3) so that block-store resolution, pooled read buffers,
+// and metadata→protocol error mapping live in exactly one place.
 //
 // # Narrow interfaces, not *runtime.Runtime
 //
 // Helpers accept BlockStoreRegistry (and a narrow MetadataService interface)
 // instead of *runtime.Runtime. This keeps common/ testable with trivial mocks
-// and avoids a circular import with pkg/controlplane/runtime. The concrete
-// *runtime.Runtime satisfies these interfaces implicitly — no runtime change
-// is required.
+// and avoids a circular import with pkg/controlplane/runtime; the concrete
+// *runtime.Runtime satisfies these interfaces implicitly.
 //
-// # Pool over-cap fallback
+// # Block-store helpers
 //
-// ReadFromBlockStore allocates its response buffer via internal/adapter/pool.
-// The pool has 4 KB / 64 KB / 1 MB tiers and falls through to a direct
-// make([]byte, size) allocation when size exceeds LargeSize (pool.Get at
-// bufpool.go:157-162). pool.Put silently ignores oversized/undersized
-// buffers. As a result:
+// ReadFromBlockStore, WriteToBlockStore, CommitBlockStore, and CopyPayload are
+// the single fan-in points for block-store I/O. Every adapter routes its
+// READ/WRITE/COMMIT data path through them so the engine contract is exercised
+// in exactly one place. ReadFromBlockStore allocates its response buffer from
+// internal/adapter/pool (4 KB / 64 KB / 1 MB tiers, with a direct make() fallback
+// for sizes above the largest tier).
 //
-//   - Today every DittoFS read fits the 1 MB LargeSize tier (MaxReadSize
-//     is 1 MB on both NFS and SMB), so over-cap fallback is dormant.
-//   - If a future change raises MaxReadSize toward the SMB 3.1.1 ceiling
-//     (8 MB), the pool continues to work correctly via the direct-alloc
-//     fallback; no handler code change is required.
-//   - We deliberately do NOT bump LargeSize speculatively — sync.Pool is
-//     per-P and bumping to 8 MB would pin ~128 MB of idle pool memory on a
-//     16-core host for an optimization that does not fire at the current
-//     negotiated cap. Revisit when a perf profile shows large reads
-//     dominating.
+// # Error mapping
 //
-// # []BlockRef plumbing
+// errmap.go is the single source of truth mapping metadata store errors to
+// per-protocol status codes (NFS3 / NFS4 / SMB) for the general path;
+// lock_errmap.go and content_errmap.go cover the lock and content paths.
 //
-// The helpers ReadFromBlockStore, WriteToBlockStore, and CommitBlockStore are
-// the canonical fan-in points for []BlockRef plumbing. The engine wires
-// engine.Store.ReadAt / WriteAt with `[]BlockRef` parameter on ReadAt
-// and `[]BlockRef` returned from WriteAt, plus a post-transaction
-// CacheInvalidator interface and the CopyPayload helper.
+// # Cache invalidation
 //
-// Caller-snapshot []BlockRef threading from FileAttr.Blocks into
-// engine.ReadAt / WriteAt is deferred: common.ReadFromBlockStore and
-// common.WriteToBlockStore continue passing nil []BlockRef so the engine
-// routes through the dual-read shim. The actual snapshot threading lands
-// when the engine's cache rewrite exposes a coordinator-side
-// GetBlocksForPayload accessor (which avoids re-introducing a metadata
-// dependency at the adapter call sites).
-//
-// Wiring of common.CopyPayload into NFS/SMB CREATE-file copy paths is also
-// deferred: file-level dedup will route copy operations through this helper.
-// The helper exists with full test coverage and is consumed only by tests.
-//
-// # Caller-snapshot wins
-//
-// Once threading lands, the engine trusts the []BlockRef the adapter handed
-// it. If the snapshot is stale (a concurrent WriteAt updated FileAttr.Blocks
-// after the snapshot was taken), the read returns bytes per the snapshot
-// (or zero-fills past the snapshot's last offset). Snapshot freshness is
-// the caller's responsibility via metadata transaction isolation. This
-// avoids a per-read metadata round-trip on the hot path.
-//
-// # Post-transaction cache invalidation
-//
-// Cache invalidation is post-transaction by design: caller commits the
-// metadata transaction first (new BlockRefs persisted), then invokes
-// CacheInvalidator.InvalidateFile with the diff between the old and new
-// BlockRef hashes. If invalidation ran pre-commit and the transaction
-// later rolled back, warm cache entries would be dropped unnecessarily.
-// Post-txn ordering ensures the cache reflects metadata truth.
-//
-// The CacheInvalidator interface (cache_invalidator.go) is defined in this
-// package, not imported from pkg/blockstore/engine, so common helpers stay
-// decoupled from the concrete cache type. The engine.Cache implements this
-// interface implicitly via its InvalidateFile method.
-//
-// # Engine contract consumed by these helpers
-//
-//	ReadAt(ctx, payloadID, []BlockRef, dest, offset) (int, error)
-//	WriteAt(ctx, payloadID, currentBlocks []BlockRef, data, offset) ([]BlockRef, error)
-//	CopyPayload(ctx, srcPayloadID, dstPayloadID, srcBlocks []BlockRef) ([]BlockRef, error)
-//	Flush(ctx, payloadID) (*block.FlushResult, error)
-//
-// Empty / nil []BlockRef on Read/Write triggers the dual-read shim.
-// Non-empty triggers the CAS path with BLAKE3 verification (engine-internal).
+// Cache invalidation is post-transaction by design: the caller commits the
+// metadata transaction first, then invokes CacheInvalidator.InvalidateFile so
+// the cache reflects committed metadata even if the transaction rolls back.
+// The CacheInvalidator interface (cache_invalidator.go) is defined here rather
+// than imported from the engine so common helpers stay decoupled from the
+// concrete cache type; engine.Cache satisfies it implicitly.
 package common

--- a/internal/adapter/common/errmap.go
+++ b/internal/adapter/common/errmap.go
@@ -13,7 +13,7 @@ import (
 // protoCodes carries the per-protocol status code for a single
 // merrs.ErrorCode row. Every row in errorMap populates all three columns —
 // Go's struct literal rules guarantee that adding a new ErrorCode populates
-// NFS3/NFS4/SMB at once (ADAPT-03 "one edit, not two" contract).
+// NFS3/NFS4/SMB at once, so a new code is mapped for every protocol in one edit.
 type protoCodes struct {
 	NFS3 uint32
 	NFS4 uint32
@@ -32,23 +32,22 @@ var defaultCodes = protoCodes{
 // errorMap is the single source of truth for merrs.ErrorCode -> protocol
 // status code (general/non-lock context).
 //
-// Authority per column (consolidated during ADAPT-03):
+// Authority per column:
 //   - NFS3 column: internal/adapter/nfs/xdr/errors.go (MapStoreErrorToNFSStatus
 //     is the audit-logging wrapper and is more complete than
-//     internal/adapter/nfs/v3/handlers/create.go's mapMetadataErrorToNFS —
-//     per PATTERNS.md gotcha #2 / #6). xdr/errors.go includes ErrLocked,
-//     ErrPrivilegeRequired, ErrNameTooLong rows that create.go partially
-//     omitted.
-//   - NFS4 column: internal/adapter/nfs/v4/types/errors.go:11-70. Includes
+//     internal/adapter/nfs/v3/handlers/create.go's mapMetadataErrorToNFS).
+//     xdr/errors.go includes ErrLocked, ErrPrivilegeRequired, ErrNameTooLong
+//     rows that create.go partially omitted.
+//   - NFS4 column: internal/adapter/nfs/v4/types/errors.go. Includes
 //     lock codes (ErrLocked → NFS4ERR_LOCKED, ErrDeadlock → NFS4ERR_DEADLOCK,
 //     ErrGracePeriod → NFS4ERR_GRACE) that NFSv3 had to fall back on
 //     NFS3ErrJukebox for.
-//   - SMB column: internal/adapter/smb/handlers/converters.go:354-395 for
+//   - SMB column: internal/adapter/smb/handlers/converters.go for
 //     general (non-lock) context. Lock-context deltas go in lock_errmap.go.
 //
-// Three-way drift surfaced during consolidation (see PATTERNS.md
-// gotcha #7). Each row with a drift item is annotated inline with the
-// authority source and the fallback chosen for the omitting protocol:
+// The three protocols drifted historically. Each row with a drift item is
+// annotated inline with the authority source and the fallback chosen for the
+// omitting protocol:
 //
 //   - NFSv3 omitted ErrDeadlock, ErrGracePeriod, ErrLockLimitExceeded,
 //     ErrLockConflict, ErrQuotaExceeded, ErrLockNotFound,
@@ -261,7 +260,7 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 func lookupErrorRow(err error) protoCodes {
 	// engine.ErrStoreClosed is a block-store-lifecycle sentinel (not a
 	// merrs.StoreError) returned when a data op hits a Store that an admin
-	// removed/hot-reloaded mid-transfer (area-7 H-A). Map it to the same
+	// removed/hot-reloaded mid-transfer. Map it to the same
 	// stale-handle row as merrs.ErrStaleHandle so the client observes the
 	// share going away (NFS *_STALE / SMB STATUS_FILE_CLOSED) rather than a
 	// generic I/O / server fault.

--- a/internal/adapter/common/lock_errmap.go
+++ b/internal/adapter/common/lock_errmap.go
@@ -20,8 +20,8 @@ import (
 //   - merrs.ErrLocked in general (READ/WRITE) context  →
 //     STATUS_FILE_LOCK_CONFLICT (SMB) — see errorMap in errmap.go.
 //
-// Sources (consolidated during ADAPT-03):
-//   - SMB column: internal/adapter/smb/handlers/lock.go:532-549
+// Sources:
+//   - SMB column: internal/adapter/smb/handlers/lock.go
 //     (lockErrorToStatus — authoritative).
 //   - NFS3 column: internal/adapter/nfs/xdr/errors.go:140-146 (ErrLocked
 //     only; other lock-context codes did not have NFSv3 entries and fall

--- a/internal/adapter/nfs/v3/handlers/access.go
+++ b/internal/adapter/nfs/v3/handlers/access.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // AccessRequest represents an ACCESS request from an NFS client.
 // The client wants to verify if it has specific permissions on a file or directory.
@@ -60,9 +58,7 @@ type AccessResponse struct {
 	Access uint32
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Access handles NFS ACCESS (RFC 1813 Section 3.3.4).
 // Checks whether the client has specific permissions on a file or directory.
@@ -92,10 +88,6 @@ func (h *Handler) Access(
 		"client", clientIP,
 		"auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateAccessRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "ACCESS validation failed",
 			"handle", fmt.Sprintf("%x", req.Handle),
@@ -103,10 +95,6 @@ func (h *Handler) Access(
 			"error", err)
 		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata service
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -117,10 +105,6 @@ func (h *Handler) Access(
 	fileHandle := metadata.FileHandle(req.Handle)
 
 	logger.DebugCtx(ctx.Context, "ACCESS", "share", ctx.Share)
-
-	// ========================================================================
-	// Step 3: Verify file handle exists and is valid
-	// ========================================================================
 
 	file, err := metaSvc.GetFile(ctx.Context, fileHandle)
 	if err != nil {
@@ -150,10 +134,6 @@ func (h *Handler) Access(
 		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 3: Build AuthContext with share-level identity mapping
-	// ========================================================================
-
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
 		// Check if the error is due to context cancellation
@@ -171,20 +151,12 @@ func (h *Handler) Access(
 		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 4: Translate NFS access bits to generic permissions
-	// ========================================================================
-
 	requestedPerms := nfsAccessToPermissions(req.Access, file.Type)
 
 	logger.DebugCtx(ctx.Context, "ACCESS translation",
 		"nfs_access", fmt.Sprintf("0x%x", req.Access),
 		"generic_perms", fmt.Sprintf("0x%x", requestedPerms),
 		"type", file.Type)
-
-	// ========================================================================
-	// Step 5: Check permissions via store
-	// ========================================================================
 
 	grantedPerms, err := metaSvc.CheckPermissions(authCtx, fileHandle, requestedPerms)
 	if err != nil {
@@ -203,19 +175,11 @@ func (h *Handler) Access(
 		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Translate granted permissions back to NFS access bits
-	// ========================================================================
-
 	grantedAccess := permissionsToNFSAccess(grantedPerms, file.Type)
 
 	logger.DebugCtx(ctx.Context, "ACCESS translation",
 		"generic_perms", fmt.Sprintf("0x%x", grantedPerms),
 		"nfs_access", fmt.Sprintf("0x%x", grantedAccess))
-
-	// ========================================================================
-	// Step 7: Build response with granted permissions and attributes
-	// ========================================================================
 
 	// Generate file ID from handle for NFS attributes
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
@@ -241,9 +205,7 @@ func (h *Handler) Access(
 	}, nil
 }
 
-// ============================================================================
 // Helper Functions
-// ============================================================================
 
 // nfsAccessToPermissions translates NFS ACCESS bits to generic Permission flags.
 //
@@ -349,9 +311,7 @@ func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileTyp
 	return nfsAccess
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateAccessRequest validates ACCESS request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/access_codec.go
+++ b/internal/adapter/nfs/v3/handlers/access_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeAccessRequest decodes an ACCESS request from XDR-encoded bytes.
 //
@@ -66,9 +64,7 @@ func DecodeAccessRequest(data []byte) (*AccessRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the AccessResponse into XDR-encoded bytes suitable for
 // transmission over the network.

--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // CommitRequest represents a COMMIT request from an NFS client.
 // The client requests that the server flush any cached writes for a specified
@@ -74,9 +72,7 @@ type CommitResponse struct {
 	WriteVerifier uint64
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Commit handles NFS COMMIT (RFC 1813 Section 3.3.21).
 // Flushes cached unstable writes to stable storage for a file byte range.
@@ -92,27 +88,15 @@ func (h *Handler) Commit(
 
 	logger.InfoCtx(ctx.Context, "COMMIT", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "COMMIT cancelled", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
-
 	if err := validateCommitRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "COMMIT validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", err)
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Get metadata service
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -121,10 +105,6 @@ func (h *Handler) Commit(
 	}
 
 	handle := metadata.FileHandle(req.Handle)
-
-	// ========================================================================
-	// Step 4: Verify file exists and capture pre-operation state
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -153,10 +133,6 @@ func (h *Handler) Commit(
 			AttrAfter:       wccAfter,
 		}, nil
 	}
-
-	// ========================================================================
-	// Step 4b: Perform commit operation - flush block store to stable storage
-	// ========================================================================
 
 	// Check context before potentially long flush operation
 	if ctx.isContextCancelled() {
@@ -189,10 +165,6 @@ func (h *Handler) Commit(
 			WriteVerifier:   serverBootTime,
 		}, nil
 	}
-
-	// ========================================================================
-	// Step 5: Flush data to BlockStore (uses local cache internally)
-	// ========================================================================
 
 	logger.InfoCtx(ctx.Context, "COMMIT: flushing data", "share", ctx.Share)
 
@@ -235,10 +207,6 @@ func (h *Handler) Commit(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Flush pending metadata writes (deferred commit optimization)
-	// ========================================================================
-
 	// Build auth context for metadata flush
 	authCtx, authErr := h.GetCachedAuthContext(ctx)
 	if authErr == nil {
@@ -265,9 +233,7 @@ func (h *Handler) Commit(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateCommitRequest validates COMMIT request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/commit_codec.go
+++ b/internal/adapter/nfs/v3/handlers/commit_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeCommitRequest decodes a COMMIT request from XDR-encoded bytes.
 //
@@ -78,9 +76,7 @@ func DecodeCommitRequest(data []byte) (*CommitRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the CommitResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -116,17 +112,13 @@ func DecodeCommitRequest(data []byte) (*CommitRequest, error) {
 func (resp *CommitResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write file WCC data (both success and failure cases)
-	// ========================================================================
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the file.
 
@@ -134,9 +126,7 @@ func (resp *CommitResponse) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode file wcc data: %w", err)
 	}
 
-	// ========================================================================
 	// Write write verifier (only on success)
-	// ========================================================================
 
 	if resp.Status == types.NFS3OK {
 		if err := binary.Write(&buf, binary.BigEndian, resp.WriteVerifier); err != nil {

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -12,9 +12,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // CreateRequest represents an NFS CREATE request (RFC 1813 Section 3.3.8).
 //
@@ -73,9 +71,7 @@ type CreateResponse struct {
 	DirAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Create handles NFS CREATE (RFC 1813 Section 3.3.8).
 // Creates a new regular file in UNCHECKED, GUARDED, or EXCLUSIVE mode.
@@ -98,18 +94,10 @@ func (h *Handler) Create(
 
 	logger.InfoCtx(ctx.Context, "CREATE", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "mode", createModeName(req.Mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateCreateRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "CREATE validation failed", "file", req.Filename, "client", clientIP, "error", err)
 		return &CreateResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Resolve per-share services from directory handle
-	// ========================================================================
 
 	parentHandle := metadata.FileHandle(req.DirHandle)
 
@@ -119,10 +107,6 @@ func (h *Handler) Create(
 		return &CreateResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrStale}}, nil
 	}
 	logger.DebugCtx(ctx.Context, "CREATE", "share", ctx.Share, "file", req.Filename)
-
-	// ========================================================================
-	// Step 3: Verify parent directory exists and is valid
-	// ========================================================================
 
 	parentFile, status, err := h.getFileOrError(ctx, parentHandle, "CREATE", req.DirHandle)
 	if parentFile == nil {
@@ -146,10 +130,6 @@ func (h *Handler) Create(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 3b: Build AuthContext with share-level identity mapping
-	// ========================================================================
-
 	authCtx, dirWccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "CREATE", req.Filename, req.DirHandle)
 	if authCtx == nil {
 		return &CreateResponse{
@@ -165,10 +145,6 @@ func (h *Handler) Create(
 		logger.DebugCtx(ctx.Context, "CREATE cancelled before existence check", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 		return &CreateResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 4: Check if file already exists using Lookup
-	// ========================================================================
 
 	var existingFile *metadata.File
 	existingFile, err = metaSvc.Lookup(authCtx, parentHandle, req.Filename)
@@ -187,10 +163,6 @@ func (h *Handler) Create(
 		logger.DebugCtx(ctx.Context, "CREATE cancelled before file operation", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "exists", fileExists, "client", clientIP, "error", ctx.Context.Err())
 		return &CreateResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 5: Handle creation based on mode
-	// ========================================================================
 
 	var fileHandle metadata.FileHandle
 	var fileAttr *metadata.FileAttr
@@ -294,10 +266,6 @@ func (h *Handler) Create(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Handle errors from file creation/truncation
-	// ========================================================================
-
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {
@@ -326,9 +294,6 @@ func (h *Handler) Create(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 7: Pre-warm caches for subsequent WRITE operations
-	// ========================================================================
 	// This eliminates cold-start penalty on the first WRITE to this file.
 	// We already have the file metadata and auth context, so caching is free.
 
@@ -346,10 +311,6 @@ func (h *Handler) Create(
 		}
 		metaSvc.PrewarmWriteCache(fileHandle, cachedFile)
 	}
-
-	// ========================================================================
-	// Step 8: Build success response
-	// ========================================================================
 
 	// Convert metadata to NFS attributes
 	nfsFileAttr := h.convertFileAttrToNFS(fileHandle, fileAttr)
@@ -370,9 +331,7 @@ func (h *Handler) Create(
 	}, nil
 }
 
-// ============================================================================
 // Helper Functions for File Operations
-// ============================================================================
 
 // createNewFile creates a new file using the metadata store's Create method.
 //
@@ -423,7 +382,6 @@ func createNewFile(
 	// This enables clients to safely retry file creation after network failures.
 	//
 	// DESIGN NOTE: Intentional deviation from Linux kernel implementation
-	// ====================================================================
 	// Linux's fs/nfsd stores the verifier in atime/mtime fields:
 	//   attrs->ia_atime.tv_sec = verf[0];
 	//   attrs->ia_mtime.tv_sec = verf[1];
@@ -588,9 +546,7 @@ func applySetAttrsToFileAttr(fileAttr *metadata.FileAttr, setAttrs *metadata.Set
 	// Atime/Mtime will be set by repository to current time
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateCreateRequest validates CREATE request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/create_codec.go
+++ b/internal/adapter/nfs/v3/handlers/create_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeCreateRequest decodes a CREATE request from XDR-encoded bytes.
 //
@@ -95,9 +93,7 @@ func DecodeCreateRequest(data []byte) (*CreateRequest, error) {
 	return req, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the CreateResponse into XDR-encoded bytes.
 //

--- a/internal/adapter/nfs/v3/handlers/fsinfo.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo.go
@@ -126,9 +126,7 @@ func (h *Handler) FsInfo(
 		return &FsInfoResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrBadHandle}}, nil
 	}
 
-	// ========================================================================
 	// Get metadata from registry
-	// ========================================================================
 
 	metaSvc, svcErr := getMetadataService(h.Registry)
 	if svcErr != nil {
@@ -199,9 +197,7 @@ func (h *Handler) FsInfo(
 	}, nil
 }
 
-// ============================================================================
 // Helper Functions
-// ============================================================================
 
 // buildNFSProperties builds the NFS properties bitmask from FilesystemCapabilities.
 //
@@ -239,9 +235,7 @@ func durationToTimeVal(d time.Duration) types.TimeVal {
 	}
 }
 
-// ============================================================================
 // Utility Functions
-// ============================================================================
 
 // validateFileHandle performs basic validation on a file handle.
 // This includes checking for nil, empty, and excessively long handles.

--- a/internal/adapter/nfs/v3/handlers/fsinfo_codec.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeFsInfoRequest decodes an FSINFO request from XDR-encoded bytes.
 //
@@ -55,9 +53,7 @@ func DecodeFsInfoRequest(data []byte) (*FsInfoRequest, error) {
 	return &FsInfoRequest{Handle: handle}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the FsInfoResponse into XDR-encoded bytes suitable for
 // transmission over the network.

--- a/internal/adapter/nfs/v3/handlers/fsstat.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // FsStatRequest represents an FSSTAT request from an NFS client.
 // The client provides a file handle to query filesystem statistics for.
@@ -75,9 +73,7 @@ type FsStatResponse struct {
 	Invarsec uint32
 }
 
-// ============================================================================
 // Handler Implementation
-// ============================================================================
 
 // FsStat handles NFS FSSTAT (RFC 1813 Section 3.3.18).
 // Returns volatile filesystem statistics: total/free/available bytes and file slots.
@@ -90,18 +86,10 @@ func (h *Handler) FsStat(
 ) (*FsStatResponse, error) {
 	logger.DebugCtx(ctx.Context, "FSSTAT request", "handle", fmt.Sprintf("%x", req.Handle), "client", ctx.ClientAddr)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "FSSTAT cancelled", "handle", fmt.Sprintf("%x", req.Handle), "client", ctx.ClientAddr, "error", ctx.Context.Err())
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Validate file handle
-	// ========================================================================
 
 	// Validate file handle
 	if len(req.Handle) == 0 {
@@ -121,19 +109,13 @@ func (h *Handler) FsStat(
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrBadHandle}}, nil
 	}
 
-	// ========================================================================
-	// Step 3: Verify the file handle exists
-	// ========================================================================
-
 	// Check context before store call
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "FSSTAT cancelled before GetFile", "handle", fmt.Sprintf("%x", req.Handle), "client", ctx.ClientAddr, "error", ctx.Context.Err())
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
 	// Get metadata from registry
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -149,10 +131,6 @@ func (h *Handler) FsStat(
 	}
 
 	logger.DebugCtx(ctx.Context, "FSSTAT", "share", ctx.Share, "path", file.Path)
-
-	// ========================================================================
-	// Step 4: Retrieve filesystem statistics from the store
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -171,10 +149,6 @@ func (h *Handler) FsStat(
 		logError(ctx.Context, fmt.Errorf("store returned nil statistics"), "FSSTAT failed: store returned nil statistics", "client", ctx.ClientAddr)
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
-
-	// ========================================================================
-	// Step 5: Build success response with file attributes and stats
-	// ========================================================================
 
 	// Generate file ID from handle for attributes
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)

--- a/internal/adapter/nfs/v3/handlers/fsstat_codec.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Encoding and Decoding
-// ============================================================================
 
 // DecodeFsStatRequest decodes an FSSTAT request from XDR-encoded bytes.
 //

--- a/internal/adapter/nfs/v3/handlers/getattr.go
+++ b/internal/adapter/nfs/v3/handlers/getattr.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // GetAttrRequest represents a GETATTR request from an NFS client.
 // The client provides a file handle to retrieve attributes for.
@@ -44,9 +42,7 @@ type GetAttrResponse struct {
 	Attr *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // GetAttr handles NFS GETATTR (RFC 1813 Section 3.3.1).
 // Returns file attributes (type, mode, size, timestamps, ownership) for a file handle.
@@ -77,10 +73,6 @@ func (h *Handler) GetAttr(
 		"client", clientIP,
 		"auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateGetAttrRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "GETATTR validation failed",
 			"handle", fmt.Sprintf("%x", req.Handle),
@@ -89,18 +81,10 @@ func (h *Handler) GetAttr(
 		return &GetAttrResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Get metadata from registry
-	// ========================================================================
-
 	if _, err := getMetadataService(h.Registry); err != nil {
 		logger.ErrorCtx(ctx.Context, "GETATTR failed: metadata service not initialized", "client", clientIP, "error", err)
 		return &GetAttrResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Verify file handle exists and retrieve attributes
-	// ========================================================================
 
 	fileHandle := metadata.FileHandle(req.Handle)
 
@@ -113,9 +97,6 @@ func (h *Handler) GetAttr(
 		"share", ctx.Share,
 		"path", file.Path)
 
-	// ========================================================================
-	// Step 4: Generate file attributes with proper file ID
-	// ========================================================================
 	// The file ID is extracted from the handle for NFS protocol purposes.
 	// This is a protocol-layer concern for creating the wire format.
 	// No cancellation check here - this operation is extremely fast (pure computation)
@@ -142,9 +123,7 @@ func (h *Handler) GetAttr(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateGetAttrRequest validates GETATTR request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/getattr_codec.go
+++ b/internal/adapter/nfs/v3/handlers/getattr_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeGetAttrRequest decodes a GETATTR request from XDR-encoded bytes.
 //
@@ -60,9 +58,7 @@ func DecodeGetAttrRequest(data []byte) (*GetAttrRequest, error) {
 	return &GetAttrRequest{Handle: handle}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the GetAttrResponse into XDR-encoded bytes suitable for
 // transmission over the network.

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // LinkRequest represents a LINK request from an NFS client.
 // The LINK procedure creates a hard link to an existing file.
@@ -66,9 +64,7 @@ type LinkResponse struct {
 	DirWccAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Link handles NFS LINK (RFC 1813 Section 3.3.15).
 // Creates a hard link to an existing file in a target directory.
@@ -84,9 +80,6 @@ func (h *Handler) Link(
 
 	logger.InfoCtx(ctx.Context, "LINK", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "dir_handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation early
-	// ========================================================================
 	// LINK involves multiple operations, so respect cancellation to avoid
 	// wasting resources on abandoned requests
 
@@ -95,18 +88,10 @@ func (h *Handler) Link(
 		return nil, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
-
 	if err := validateLinkRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "LINK validation failed", "name", req.Name, "client", clientIP, "error", err)
 		return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Get metadata store from context and verify cross-share restriction
-	// ========================================================================
 
 	// Decode file handle to verify it's from the same share
 	fileHandle := metadata.FileHandle(req.FileHandle)
@@ -131,10 +116,6 @@ func (h *Handler) Link(
 	dirHandle := metadata.FileHandle(req.DirHandle)
 	logger.DebugCtx(ctx.Context, "LINK", "share", ctx.Share, "name", req.Name)
 
-	// ========================================================================
-	// Step 4: Build AuthContext for permission checking
-	// ========================================================================
-
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
 		// Check if error is due to context cancellation
@@ -147,18 +128,10 @@ func (h *Handler) Link(
 		return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 4: Check cancellation before first store operation
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "LINK cancelled before GetFile", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "client", clientIP, "error", ctx.Context.Err())
 		return nil, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 5: Verify source file exists and is a regular file
-	// ========================================================================
 
 	fileAttr, err := metaSvc.GetFile(ctx.Context, fileHandle)
 	if err != nil {
@@ -172,18 +145,10 @@ func (h *Handler) Link(
 		return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIsDir}}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Check cancellation before target directory lookup
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "LINK cancelled before directory lookup", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "client", clientIP, "error", ctx.Context.Err())
 		return nil, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 7: Verify target directory exists and is a directory
-	// ========================================================================
 
 	dirFile, err := metaSvc.GetFile(ctx.Context, dirHandle)
 	if err != nil {
@@ -208,18 +173,10 @@ func (h *Handler) Link(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 8: Check cancellation before name conflict check
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "LINK cancelled before name check", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "client", clientIP, "error", ctx.Context.Err())
 		return nil, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 9: Check if name already exists in target directory using Lookup
-	// ========================================================================
 
 	_, err = metaSvc.Lookup(authCtx, dirHandle, req.Name)
 	if err == nil {
@@ -238,9 +195,6 @@ func (h *Handler) Link(
 	}
 	// If error, file doesn't exist (good) - continue with link creation
 
-	// ========================================================================
-	// Step 10: Check cancellation before write operation
-	// ========================================================================
 	// This is the most critical check as CreateHardLink modifies filesystem state
 
 	if ctx.isContextCancelled() {
@@ -248,9 +202,6 @@ func (h *Handler) Link(
 		return nil, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 11: Create the hard link via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Verifying write access to the target directory
 	// - Adding the new directory entry
@@ -275,9 +226,6 @@ func (h *Handler) Link(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 12: Build success response with updated attributes
-	// ========================================================================
 	// No cancellation check here - operation succeeded, fetching attributes
 	// is best-effort for cache consistency
 
@@ -303,13 +251,9 @@ func (h *Handler) Link(
 	}, nil
 }
 
-// ============================================================================
 // Helper Functions
-// ============================================================================
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateLinkRequest validates LINK request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/link_codec.go
+++ b/internal/adapter/nfs/v3/handlers/link_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeLinkRequest decodes a LINK request from XDR-encoded bytes.
 //
@@ -52,9 +50,7 @@ func DecodeLinkRequest(data []byte) (*LinkRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode source file handle
-	// ========================================================================
 
 	fileHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -64,9 +60,7 @@ func DecodeLinkRequest(data []byte) (*LinkRequest, error) {
 		return nil, fmt.Errorf("invalid file handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode target directory handle
-	// ========================================================================
 
 	dirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -76,9 +70,7 @@ func DecodeLinkRequest(data []byte) (*LinkRequest, error) {
 		return nil, fmt.Errorf("invalid directory handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode link name
-	// ========================================================================
 
 	name, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -94,9 +86,7 @@ func DecodeLinkRequest(data []byte) (*LinkRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the LinkResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -130,17 +120,13 @@ func DecodeLinkRequest(data []byte) (*LinkRequest, error) {
 func (resp *LinkResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op file attributes (optional)
-	// ========================================================================
 	// Present for both success and failure cases to help clients
 	// maintain cache consistency
 
@@ -148,9 +134,7 @@ func (resp *LinkResponse) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("encode file attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Write directory WCC data (always present)
-	// ========================================================================
 	// Weak cache consistency data helps clients detect if the directory
 	// changed during the operation
 

--- a/internal/adapter/nfs/v3/handlers/lookup.go
+++ b/internal/adapter/nfs/v3/handlers/lookup.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // LookupRequest represents a LOOKUP request from an NFS client.
 // The client provides a directory handle and a filename to search for.
@@ -67,9 +65,7 @@ type LookupResponse struct {
 	DirAttr *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Lookup handles NFS LOOKUP (RFC 1813 Section 3.3.3).
 // Resolves a filename in a directory to a file handle and attributes.
@@ -89,10 +85,6 @@ func (h *Handler) Lookup(
 		"client", clientIP,
 		"auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "LOOKUP cancelled",
 			"name", req.Filename,
@@ -102,10 +94,6 @@ func (h *Handler) Lookup(
 		return &LookupResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
-
 	if err := validateLookupRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "LOOKUP validation failed",
 			"name", req.Filename,
@@ -113,10 +101,6 @@ func (h *Handler) Lookup(
 			"error", err)
 		return &LookupResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Get metadata from registry
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -128,10 +112,6 @@ func (h *Handler) Lookup(
 	logger.DebugCtx(ctx.Context, "LOOKUP",
 		"share", ctx.Share,
 		"name", req.Filename)
-
-	// ========================================================================
-	// Step 4: Verify directory handle exists and is valid
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -168,10 +148,6 @@ func (h *Handler) Lookup(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 4: Build AuthContext with share-level identity mapping
-	// ========================================================================
-
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
 		// Check if the error is due to context cancellation
@@ -197,9 +173,6 @@ func (h *Handler) Lookup(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Look up the child via store
-	// ========================================================================
 	// The store.Lookup() method atomically:
 	// - Checks search/execute permission on the directory
 	// - Finds the child by name (including "." and "..")
@@ -243,9 +216,6 @@ func (h *Handler) Lookup(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Build success response with file handle and attributes
-	// ========================================================================
 	// store.Lookup() already returned the File object with attributes,
 	// so we don't need a separate GetFile() call!
 
@@ -289,9 +259,7 @@ func (h *Handler) Lookup(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateLookupRequest validates LOOKUP request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/lookup_codec.go
+++ b/internal/adapter/nfs/v3/handlers/lookup_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeLookupRequest decodes a LOOKUP request from XDR-encoded bytes.
 //
@@ -80,9 +78,7 @@ func DecodeLookupRequest(data []byte) (*LookupRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the LookupResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -120,17 +116,13 @@ func DecodeLookupRequest(data []byte) (*LookupRequest, error) {
 func (resp *LookupResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Error case: Return status + optional directory attributes
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding LOOKUP error response",
@@ -144,9 +136,7 @@ func (resp *LookupResponse) Encode() ([]byte, error) {
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Success case: Write file handle, file attributes, dir attributes
-	// ========================================================================
 
 	// Write file handle (opaque data: length + data + padding)
 	if err := xdr.WriteXDROpaque(&buf, resp.FileHandle); err != nil {

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // MkdirRequest represents a MKDIR request from an NFS client.
 // The client provides the parent directory handle, the name for the new directory,
@@ -83,9 +81,7 @@ type MkdirResponse struct {
 	WccAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Mkdir handles NFS MKDIR (RFC 1813 Section 3.3.9).
 // Creates a new subdirectory within a parent directory with specified attributes.
@@ -113,18 +109,10 @@ func (h *Handler) Mkdir(
 
 	logger.InfoCtx(ctx.Context, "MKDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateMkdirRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "MKDIR validation failed", "name", req.Name, "client", clientIP, "error", err)
 		return &MkdirResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -135,10 +123,6 @@ func (h *Handler) Mkdir(
 	parentHandle := metadata.FileHandle(req.DirHandle)
 	logger.DebugCtx(ctx.Context, "MKDIR", "share", ctx.Share, "name", req.Name)
 
-	// ========================================================================
-	// Step 3: Verify parent directory exists and is valid
-	// ========================================================================
-
 	parentFile, status, err := h.getFileOrError(ctx, parentHandle, "MKDIR", req.DirHandle)
 	if parentFile == nil {
 		return &MkdirResponse{NFSResponseBase: NFSResponseBase{Status: status}}, err
@@ -146,10 +130,6 @@ func (h *Handler) Mkdir(
 
 	// Capture pre-operation attributes for WCC data
 	wccBefore := xdr.CaptureWccAttr(&parentFile.FileAttr)
-
-	// ========================================================================
-	// Step 3: Build AuthContext with share-level identity mapping
-	// ========================================================================
 
 	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKDIR", req.Name, req.DirHandle)
 	if authCtx == nil {
@@ -187,10 +167,6 @@ func (h *Handler) Mkdir(
 			WccAfter:        wccAfter,
 		}, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 4: Check if directory name already exists using Lookup
-	// ========================================================================
 
 	_, err = metaSvc.Lookup(authCtx, parentHandle, req.Name)
 	if err != nil && ctx.Context.Err() != nil {
@@ -241,9 +217,6 @@ func (h *Handler) Mkdir(
 		}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 5: Create directory via store.Create()
-	// ========================================================================
 	// The store.Create() method handles both regular files and directories
 	// based on the Type field in FileAttr.
 	//
@@ -318,10 +291,6 @@ func (h *Handler) Mkdir(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Build success response with new directory attributes
-	// ========================================================================
-
 	// Encode the file handle for the new directory
 	newHandle, err := metadata.EncodeFileHandle(newDirFile)
 	if err != nil {
@@ -348,9 +317,7 @@ func (h *Handler) Mkdir(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateMkdirRequest validates MKDIR request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/mkdir_codec.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeMkdirRequest decodes a MKDIR request from XDR-encoded bytes.
 //
@@ -76,9 +74,7 @@ func DecodeMkdirRequest(data []byte) (*MkdirRequest, error) {
 	return req, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the MkdirResponse into XDR-encoded bytes suitable for
 // transmission over the network.

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // MknodRequest represents a MKNOD request from an NFS client.
 // The MKNOD procedure creates a special file (device, socket, or FIFO).
@@ -116,9 +114,7 @@ type MknodResponse struct {
 	DirAttrAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Mknod handles NFS MKNOD (RFC 1813 Section 3.3.11).
 // Creates a special file: character/block device, socket, or FIFO.
@@ -129,9 +125,7 @@ func (h *Handler) Mknod(
 	ctx *NFSHandlerContext,
 	req *MknodRequest,
 ) (*MknodResponse, error) {
-	// ========================================================================
 	// Context Cancellation Check - Entry Point
-	// ========================================================================
 	// Check if the client has disconnected or the request has timed out
 	// before we start processing. While MKNOD is typically fast (metadata only),
 	// we should still respect cancellation to avoid wasted work.
@@ -150,18 +144,10 @@ func (h *Handler) Mknod(
 
 	logger.InfoCtx(ctx.Context, "MKNOD", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateMknodRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "MKNOD validation failed", "name", req.Name, "type", req.Type, "client", clientIP, "error", err)
 		return &MknodResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Decode share name from directory file handle
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -172,10 +158,6 @@ func (h *Handler) Mknod(
 	parentHandle := metadata.FileHandle(req.DirHandle)
 
 	logger.DebugCtx(ctx.Context, "MKNOD", "share", ctx.Share, "name", req.Name, "type", req.Type)
-
-	// ========================================================================
-	// Step 3: Verify parent directory exists and is valid
-	// ========================================================================
 
 	parentFile, status, err := h.getFileOrError(ctx, parentHandle, "MKNOD", req.DirHandle)
 	if parentFile == nil {
@@ -199,10 +181,6 @@ func (h *Handler) Mknod(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 3: Build AuthContext for permission checking
-	// ========================================================================
-
 	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKNOD", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &MknodResponse{
@@ -212,18 +190,12 @@ func (h *Handler) Mknod(
 		}, err
 	}
 
-	// ========================================================================
 	// Context Cancellation Check - After Parent Lookup
-	// ========================================================================
 	// Check again after parent verification, before child operations
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "MKNOD: request cancelled after parent lookup", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 		return nil, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 4: Check if special file name already exists using Lookup
-	// ========================================================================
 
 	_, err = metaSvc.Lookup(authCtx, parentHandle, req.Name)
 	if err == nil {
@@ -242,9 +214,6 @@ func (h *Handler) Mknod(
 	}
 	// If error from Lookup, file doesn't exist (good) - continue
 
-	// ========================================================================
-	// Step 5: Create special file via store.CreateSpecialFile()
-	// ========================================================================
 	// The store is responsible for:
 	// - Converting NFS file type to metadata file type
 	// - Building complete file attributes with defaults
@@ -318,10 +287,6 @@ func (h *Handler) Mknod(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Build success response with new file attributes
-	// ========================================================================
-
 	// Encode the file handle for the new special file
 	newHandle, err := metadata.EncodeFileHandle(newFile)
 	if err != nil {
@@ -348,9 +313,7 @@ func (h *Handler) Mknod(
 	}, nil
 }
 
-// ============================================================================
 // Helper Functions
-// ============================================================================
 
 // nfsTypeToMetadataType converts NFS file type to metadata file type.
 //
@@ -395,9 +358,7 @@ func specialFileTypeName(fileType uint32) string {
 	}
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateMknodRequest validates MKNOD request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/mknod_codec.go
+++ b/internal/adapter/nfs/v3/handlers/mknod_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeMknodRequest decodes a MKNOD request from XDR-encoded bytes.
 //
@@ -52,9 +50,7 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 	reader := bytes.NewReader(data)
 	req := &MknodRequest{}
 
-	// ========================================================================
 	// Decode parent directory handle
-	// ========================================================================
 
 	handle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -65,9 +61,7 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 	}
 	req.DirHandle = handle
 
-	// ========================================================================
 	// Decode special file name
-	// ========================================================================
 
 	name, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -75,9 +69,7 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 	}
 	req.Name = name
 
-	// ========================================================================
 	// Decode file type (discriminated union)
-	// ========================================================================
 
 	var fileType uint32
 	if err := binary.Read(reader, binary.BigEndian, &fileType); err != nil {
@@ -85,9 +77,7 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 	}
 	req.Type = fileType
 
-	// ========================================================================
 	// Decode type-specific data based on discriminated union
-	// ========================================================================
 
 	switch fileType {
 	case types.NF3CHR, types.NF3BLK:
@@ -133,9 +123,7 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 	return req, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the MknodResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -167,17 +155,13 @@ func DecodeMknodRequest(data []byte) (*MknodRequest, error) {
 func (resp *MknodResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Success case: Write handle and attributes
-	// ========================================================================
 
 	if resp.Status == types.NFS3OK {
 		// Write new file handle (post_op_fh3 - optional)
@@ -191,9 +175,7 @@ func (resp *MknodResponse) Encode() ([]byte, error) {
 		}
 	}
 
-	// ========================================================================
 	// Write WCC data for parent directory (both success and failure)
-	// ========================================================================
 
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the parent directory.

--- a/internal/adapter/nfs/v3/handlers/null.go
+++ b/internal/adapter/nfs/v3/handlers/null.go
@@ -5,9 +5,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // NullRequest represents a NULL request from an NFS client.
 // The NULL procedure takes no arguments per RFC 1813.
@@ -36,9 +34,7 @@ type NullResponse struct {
 	NFSResponseBase // Embeds Status field and GetStatus() method
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Null handles NFS NULL (RFC 1813 Appendix I, procedure 0).
 // No-op ping/health check verifying the NFSv3 service is running and reachable.
@@ -49,9 +45,7 @@ func (h *Handler) Null(
 	ctx *NFSHandlerContext,
 	req *NullRequest,
 ) (*NullResponse, error) {
-	// ========================================================================
 	// Context Cancellation Check
-	// ========================================================================
 	// Check if the client has disconnected or the request has timed out.
 	// While NULL is extremely fast, we should still respect cancellation to
 	// avoid wasting resources on abandoned requests (e.g., during server shutdown,
@@ -75,9 +69,7 @@ func (h *Handler) Null(
 
 	logger.DebugCtx(ctx.Context, "NULL", "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
 	// Optional: store health check
-	// ========================================================================
 	// NOTE: Health check removed as NULL doesn't have a file handle to decode
 	// and shouldn't depend on any particular share. NULL must always succeed
 	// per RFC 1813 regardless of backend state.

--- a/internal/adapter/nfs/v3/handlers/null_codec.go
+++ b/internal/adapter/nfs/v3/handlers/null_codec.go
@@ -6,9 +6,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeNullRequest decodes a NULL request from XDR-encoded bytes.
 //
@@ -46,9 +44,7 @@ func DecodeNullRequest(data []byte) (*NullRequest, error) {
 	return &NullRequest{}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the NullResponse into XDR-encoded bytes suitable for
 // transmission over the network.

--- a/internal/adapter/nfs/v3/handlers/pathconf.go
+++ b/internal/adapter/nfs/v3/handlers/pathconf.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // PathConfRequest represents a PATHCONF request from an NFS client.
 // The client provides a file handle to query POSIX-compatible information
@@ -88,9 +86,7 @@ type PathConfResponse struct {
 	CasePreserving bool
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // PathConf handles NFS PATHCONF (RFC 1813 Section 3.3.20).
 // Returns POSIX filesystem properties: max links, name length, case sensitivity, chown restrictions.
@@ -106,27 +102,15 @@ func (h *Handler) PathConf(
 
 	logger.InfoCtx(ctx.Context, "PATHCONF", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "PATHCONF cancelled", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "error", ctx.Context.Err())
 		return &PathConfResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate file handle
-	// ========================================================================
-
 	if err := validatePathConfHandle(req.Handle); err != nil {
 		logger.WarnCtx(ctx.Context, "PATHCONF validation failed", "client", clientIP, "error", err)
 		return &PathConfResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Verify the file handle exists and is valid in the store
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -149,9 +133,6 @@ func (h *Handler) PathConf(
 		return &PathConfResponse{NFSResponseBase: NFSResponseBase{Status: status}}, err
 	}
 
-	// ========================================================================
-	// Step 4: Retrieve filesystem capabilities from the store
-	// ========================================================================
 	// FilesystemCapabilities contains POSIX-compatible properties
 	// that map directly to PATHCONF response fields
 
@@ -167,18 +148,11 @@ func (h *Handler) PathConf(
 		return &PathConfResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Generate file attributes for cache consistency
-	// ========================================================================
-
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
 	logger.InfoCtx(ctx.Context, "PATHCONF successful", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP)
 	logger.DebugCtx(ctx.Context, "PATHCONF properties", "linkmax", caps.MaxHardLinkCount, "namemax", caps.MaxFilenameLen, "no_trunc", !caps.TruncatesLongNames, "chown_restricted", caps.ChownRestricted, "case_insensitive", !caps.CaseSensitive, "case_preserving", caps.CasePreserving)
 
-	// ========================================================================
-	// Step 6: Build response with filesystem capabilities
-	// ========================================================================
 	// Map FilesystemCapabilities fields to PATHCONF response fields
 
 	return &PathConfResponse{
@@ -193,9 +167,7 @@ func (h *Handler) PathConf(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validatePathConfHandle validates a PATHCONF file handle.
 //

--- a/internal/adapter/nfs/v3/handlers/pathconf_codec.go
+++ b/internal/adapter/nfs/v3/handlers/pathconf_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodePathConfRequest decodes a PATHCONF request from XDR-encoded bytes.
 //
@@ -47,9 +45,7 @@ func DecodePathConfRequest(data []byte) (*PathConfRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode file handle
-	// ========================================================================
 
 	handle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -64,9 +60,7 @@ func DecodePathConfRequest(data []byte) (*PathConfRequest, error) {
 	return &PathConfRequest{Handle: handle}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the PathConfResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -112,34 +106,26 @@ func DecodePathConfRequest(data []byte) (*PathConfRequest, error) {
 func (resp *PathConfResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op attributes (both success and error cases)
-	// ========================================================================
 
 	if err := xdr.EncodeOptionalFileAttr(&buf, resp.Attr); err != nil {
 		return nil, fmt.Errorf("encode attributes: %w", err)
 	}
 
-	// ========================================================================
 	// If status is not OK, return early (no PATHCONF data on error)
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoded PATHCONF error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Write PATHCONF properties in RFC-specified order
-	// ========================================================================
 
 	// Write linkmax
 	if err := binary.Write(&buf, binary.BigEndian, resp.Linkmax); err != nil {

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -15,9 +15,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // ReadRequest represents a READ request from an NFS client.
 // The client specifies a file handle, offset, and number of bytes to read.
@@ -93,9 +91,7 @@ func (r *ReadResponse) Release() {
 	}
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Read handles NFS READ (RFC 1813 Section 3.3.6).
 // Reads data from a regular file at a given offset, returning bytes and EOF flag.
@@ -106,9 +102,7 @@ func (h *Handler) Read(
 	ctx *NFSHandlerContext,
 	req *ReadRequest,
 ) (*ReadResponse, error) {
-	// ========================================================================
 	// Context Cancellation Check - Entry Point
-	// ========================================================================
 	// Check if the client has disconnected or the request has timed out
 	// before we start any expensive operations.
 	if ctx.isContextCancelled() {
@@ -121,10 +115,6 @@ func (h *Handler) Read(
 
 	logger.DebugCtx(ctx.Context, "READ", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateReadRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READ validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP, "error", err)
 		return &ReadResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
@@ -136,10 +126,6 @@ func (h *Handler) Read(
 		req.Offset = uint64(types.OffsetMax)
 	}
 
-	// ========================================================================
-	// Step 2: Resolve per-share block store from file handle
-	// ========================================================================
-
 	fileHandle := metadata.FileHandle(req.Handle)
 
 	blockStore, err := common.ResolveForRead(ctx.Context, h.Registry, fileHandle)
@@ -149,10 +135,6 @@ func (h *Handler) Read(
 	}
 
 	logger.DebugCtx(ctx.Context, "READ: share", "share", ctx.Share)
-
-	// ========================================================================
-	// Step 3: Verify file exists and is a regular file
-	// ========================================================================
 
 	file, status, err := h.getFileOrError(ctx, fileHandle, "READ", req.Handle)
 	if file == nil {
@@ -172,18 +154,13 @@ func (h *Handler) Read(
 		}, nil
 	}
 
-	// ========================================================================
 	// Context Cancellation Check - After Metadata Lookup
-	// ========================================================================
 	// Check again before opening content (which may be expensive)
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "READ: request cancelled after metadata lookup", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
 		return nil, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 3b: Cross-protocol oplock break
-	// ========================================================================
 	// Fire-and-forget: NFS proceeds even if break is pending (per Samba behavior).
 	if breaker := h.getOplockBreaker(); breaker != nil {
 		if err := breaker.CheckAndBreakForRead(ctx.Context, lock.FileHandle(string(fileHandle))); err != nil {
@@ -191,10 +168,6 @@ func (h *Handler) Read(
 				"handle", fileHandle, "result", err)
 		}
 	}
-
-	// ========================================================================
-	// Step 3c: Check for empty file or offset beyond EOF
-	// ========================================================================
 
 	// If file has no content, return empty data with EOF
 	if file.PayloadID == "" || file.Size == 0 {
@@ -230,9 +203,6 @@ func (h *Handler) Read(
 	readEnd := min(req.Offset+uint64(req.Count), file.Size)
 	actualLength := uint32(readEnd - req.Offset)
 
-	// ========================================================================
-	// Step 4: Read data from BlockStore
-	// ========================================================================
 	// All reads go through BlockStore.ReadAt which reads from block store.
 
 	logger.DebugCtx(ctx.Context, "READ: reading from BlockStore", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", actualLength, "payload_id", file.PayloadID)
@@ -261,10 +231,6 @@ func (h *Handler) Read(
 	if req.Offset+uint64(n) >= file.Size {
 		eof = true
 	}
-
-	// ========================================================================
-	// Step 5: Build success response
-	// ========================================================================
 
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 

--- a/internal/adapter/nfs/v3/handlers/read_codec.go
+++ b/internal/adapter/nfs/v3/handlers/read_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeReadRequest decodes a READ request from XDR-encoded bytes.
 //
@@ -78,9 +76,7 @@ func DecodeReadRequest(data []byte) (*ReadRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the ReadResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -133,34 +129,26 @@ func (resp *ReadResponse) Encode() ([]byte, error) {
 	estimatedSize := 110 + int(resp.Count) + 3
 	buf := bytes.NewBuffer(make([]byte, 0, estimatedSize))
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op attributes (both success and error cases)
-	// ========================================================================
 
 	if err := xdr.EncodeOptionalFileAttr(buf, resp.Attr); err != nil {
 		return nil, fmt.Errorf("failed to encode attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Error case: Return early if status is not OK
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding READ error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Success case: Write count, EOF flag, and data
-	// ========================================================================
 
 	// Write count (number of bytes read)
 	if err := binary.Write(buf, binary.BigEndian, resp.Count); err != nil {

--- a/internal/adapter/nfs/v3/handlers/read_validation.go
+++ b/internal/adapter/nfs/v3/handlers/read_validation.go
@@ -7,9 +7,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // Read Request Validation
-// ============================================================================
 
 // validateReadRequest validates READ request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/readdir.go
+++ b/internal/adapter/nfs/v3/handlers/readdir.go
@@ -18,9 +18,7 @@ func directoryMtimeVerifier(mtime time.Time) uint64 {
 	return uint64(mtime.UnixNano())
 }
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // ReadDirRequest represents a READDIR request from an NFS client.
 // The client requests a list of directory entries, optionally resuming
@@ -87,9 +85,7 @@ type ReadDirResponse struct {
 	Eof bool
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // ReadDir handles NFS READDIR (RFC 1813 Section 3.3.16).
 // Lists directory entries (fileid, name, cookie) with cookie-based pagination.
@@ -112,18 +108,10 @@ func (h *Handler) ReadDir(
 
 	logger.InfoCtx(ctx.Context, "READDIR", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateReadDirRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READDIR validation failed", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", err)
 		return &ReadDirResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -134,10 +122,6 @@ func (h *Handler) ReadDir(
 	dirHandle := metadata.FileHandle(req.DirHandle)
 
 	logger.DebugCtx(ctx.Context, "READDIR", "share", ctx.Share)
-
-	// ========================================================================
-	// Step 3: Verify directory handle exists and is valid
-	// ========================================================================
 
 	dirFile, status, err := h.getFileOrError(ctx, dirHandle, "READDIR", req.DirHandle)
 	if dirFile == nil {
@@ -157,9 +141,7 @@ func (h *Handler) ReadDir(
 		}, nil
 	}
 
-	// ========================================================================
 	// Cookie Verifier Validation (RFC 1813 Section 3.3.16)
-	// ========================================================================
 	// Generate verifier from directory mtime - changes when directory is modified
 	currentVerifier := directoryMtimeVerifier(dirFile.Mtime)
 
@@ -177,10 +159,6 @@ func (h *Handler) ReadDir(
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", clientIP)
 	}
-
-	// ========================================================================
-	// Step 3: Build authentication context for store
-	// ========================================================================
 
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
@@ -223,9 +201,6 @@ func (h *Handler) ReadDir(
 		}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 4: Read directory entries via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Checking read/execute permission on the directory
 	// - Building "." and ".." entries
@@ -263,9 +238,6 @@ func (h *Handler) ReadDir(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Convert metadata entries to NFS wire format
-	// ========================================================================
 	// No cancellation check here - this is fast pure computation
 
 	nfsEntries := make([]*types.DirEntry, 0, len(page.Entries))
@@ -276,10 +248,6 @@ func (h *Handler) ReadDir(
 			Cookie: entry.Cookie, // Cookie from MetadataService
 		})
 	}
-
-	// ========================================================================
-	// Step 6: Build success response
-	// ========================================================================
 
 	// Generate directory attributes for response
 	nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
@@ -300,9 +268,7 @@ func (h *Handler) ReadDir(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateReadDirRequest validates READDIR request parameters.
 //
@@ -358,9 +324,7 @@ func validateReadDirRequest(req *ReadDirRequest) *validationError {
 	return nil
 }
 
-// ============================================================================
 // Utility Functions
-// ============================================================================
 
 // getLastCookie returns the cookie of the last entry in the list.
 // Returns 0 if the list is empty.

--- a/internal/adapter/nfs/v3/handlers/readdir_codec.go
+++ b/internal/adapter/nfs/v3/handlers/readdir_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeReadDirRequest decodes a READDIR request from XDR-encoded bytes.
 //
@@ -64,18 +62,14 @@ func DecodeReadDirRequest(data []byte) (*ReadDirRequest, error) {
 		return nil, fmt.Errorf("read cookie: %w", err)
 	}
 
-	// ========================================================================
 	// Decode cookie verifier
-	// ========================================================================
 
 	var cookieVerf uint64
 	if err := binary.Read(reader, binary.BigEndian, &cookieVerf); err != nil {
 		return nil, fmt.Errorf("read cookieverf: %w", err)
 	}
 
-	// ========================================================================
 	// Decode count
-	// ========================================================================
 
 	var count uint32
 	if err := binary.Read(reader, binary.BigEndian, &count); err != nil {
@@ -92,9 +86,7 @@ func DecodeReadDirRequest(data []byte) (*ReadDirRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the ReadDirResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -142,42 +134,32 @@ func DecodeReadDirRequest(data []byte) (*ReadDirRequest, error) {
 func (resp *ReadDirResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op directory attributes (always, even on error)
-	// ========================================================================
 
 	if err := xdr.EncodeOptionalFileAttr(&buf, resp.DirAttr); err != nil {
 		return nil, fmt.Errorf("encode directory attributes: %w", err)
 	}
 
-	// ========================================================================
 	// If status is not OK, return early (no entries on error)
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding READDIR error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Write cookie verifier
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.CookieVerf); err != nil {
 		return nil, fmt.Errorf("write cookieverf: %w", err)
 	}
 
-	// ========================================================================
 	// Write directory entries
-	// ========================================================================
 
 	for _, entry := range resp.Entries {
 		// value_follows = TRUE (1) - indicates another entry follows
@@ -201,18 +183,14 @@ func (resp *ReadDirResponse) Encode() ([]byte, error) {
 		}
 	}
 
-	// ========================================================================
 	// Write end of entries marker
-	// ========================================================================
 
 	// value_follows = FALSE (0) - indicates no more entries in this response
 	if err := binary.Write(&buf, binary.BigEndian, uint32(0)); err != nil {
 		return nil, fmt.Errorf("write end marker: %w", err)
 	}
 
-	// ========================================================================
 	// Write EOF flag
-	// ========================================================================
 
 	// EOF flag: 1 = all entries returned, 0 = more entries available
 	eofVal := uint32(0)

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // XDR size accounting (RFC 1813 Section 3.3.17 maxcount / dircount budgets)
-// ============================================================================
 
 // readDirPlusFattr3Size is the fixed XDR-encoded size of an fattr3 structure
 // (RFC 1813 Section 2.3.1): 5×uint32 + 2×uint64 + specdata3(2×uint32) +
@@ -44,9 +42,7 @@ func readDirPlusEntryExtraSize(handleLen int) uint32 {
 	return 4 + readDirPlusFattr3Size + 4 + xdrOpaqueLen(handleLen)
 }
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // ReadDirPlusRequest represents a READDIRPLUS request from an NFS client.
 // The client provides a directory handle and parameters to retrieve directory
@@ -150,9 +146,7 @@ type DirPlusEntry struct {
 	FileHandle []byte
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // ReadDirPlus handles NFS READDIRPLUS (RFC 1813 Section 3.3.17).
 // Lists directory entries with full attributes and file handles, eliminating LOOKUP+GETATTR round trips.
@@ -168,27 +162,15 @@ func (h *Handler) ReadDirPlus(
 
 	logger.InfoCtx(ctx.Context, "READDIRPLUS", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "dircount", req.DirCount, "maxcount", req.MaxCount, "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "READDIRPLUS cancelled", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 		return &ReadDirPlusResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
-
 	if err := validateReadDirPlusRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READDIRPLUS validation failed", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", err)
 		return &ReadDirPlusResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Verify directory handle exists and is valid
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -196,9 +178,7 @@ func (h *Handler) ReadDirPlus(
 		return &ReadDirPlusResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
 	// Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -206,9 +186,7 @@ func (h *Handler) ReadDirPlus(
 		return &ReadDirPlusResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
 	// Check if READDIRPLUS is disabled for this share
-	// ========================================================================
 	// Per RFC 1813, servers may refuse READDIRPLUS for operational reasons.
 	// This matches Linux kernel's NFSEXP_NOREADDIRPLUS flag behavior.
 
@@ -241,9 +219,7 @@ func (h *Handler) ReadDirPlus(
 		}, nil
 	}
 
-	// ========================================================================
 	// Cookie Verifier Validation (RFC 1813 Section 3.3.17)
-	// ========================================================================
 	// Generate verifier from directory mtime - changes when directory is modified
 	currentVerifier := directoryMtimeVerifier(dirFile.Mtime)
 
@@ -261,10 +237,6 @@ func (h *Handler) ReadDirPlus(
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", clientIP)
 	}
-
-	// ========================================================================
-	// Step 4: Build authentication context for store
-	// ========================================================================
 
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
@@ -290,9 +262,6 @@ func (h *Handler) ReadDirPlus(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Get directory entries from store
-	// ========================================================================
 	// The store retrieves the directory entries via ReadDirectory.
 	// We need to use Lookup for each entry to get handles and full attributes.
 
@@ -325,19 +294,13 @@ func (h *Handler) ReadDirPlus(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Build response with directory entries
-	// ========================================================================
-
 	// Generate directory file ID for attributes
 	nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
 
 	// Build entries list - look up each entry to get handle and full attributes
 	entries := make([]*DirPlusEntry, 0, len(page.Entries))
 
-	// ========================================================================
 	// Byte-budget accounting (RFC 1813 Section 3.3.17)
-	// ========================================================================
 	// maxcount bounds the total READDIRPLUS3resok reply size; dircount bounds
 	// the "directory information" portion (the fields READDIR would have
 	// returned: fileid + name + cookie), excluding the per-entry attributes and
@@ -438,10 +401,6 @@ func (h *Handler) ReadDirPlus(
 		logger.DebugCtx(ctx.Context, "READDIRPLUS: added entry", "name", entry.Name, "cookie", entry.Cookie, "fileid", entry.ID)
 	}
 
-	// ========================================================================
-	// Step 7: Build success response
-	// ========================================================================
-
 	// EOF is true only when there are no more pages AND we did not stop early
 	// due to the maxcount/dircount budget. If the budget was exhausted (or we
 	// emitted fewer entries than the page contained), eof MUST be false so the
@@ -461,9 +420,7 @@ func (h *Handler) ReadDirPlus(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateReadDirPlusRequest validates READDIRPLUS request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/readdirplus_codec.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeReadDirPlusRequest decodes a READDIRPLUS request from XDR-encoded bytes.
 //
@@ -46,9 +44,7 @@ func DecodeReadDirPlusRequest(data []byte) (*ReadDirPlusRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode directory handle
-	// ========================================================================
 
 	dirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -58,36 +54,28 @@ func DecodeReadDirPlusRequest(data []byte) (*ReadDirPlusRequest, error) {
 		return nil, fmt.Errorf("invalid handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode cookie (8 bytes, big-endian)
-	// ========================================================================
 
 	var cookie uint64
 	if err := binary.Read(reader, binary.BigEndian, &cookie); err != nil {
 		return nil, fmt.Errorf("failed to read cookie: %w", err)
 	}
 
-	// ========================================================================
 	// Decode cookieverf (8 bytes, big-endian)
-	// ========================================================================
 
 	var cookieVerf uint64
 	if err := binary.Read(reader, binary.BigEndian, &cookieVerf); err != nil {
 		return nil, fmt.Errorf("failed to read cookieverf: %w", err)
 	}
 
-	// ========================================================================
 	// Decode dircount (4 bytes, big-endian)
-	// ========================================================================
 
 	var dirCount uint32
 	if err := binary.Read(reader, binary.BigEndian, &dirCount); err != nil {
 		return nil, fmt.Errorf("failed to read dircount: %w", err)
 	}
 
-	// ========================================================================
 	// Decode maxcount (4 bytes, big-endian)
-	// ========================================================================
 
 	var maxCount uint32
 	if err := binary.Read(reader, binary.BigEndian, &maxCount); err != nil {
@@ -105,9 +93,7 @@ func DecodeReadDirPlusRequest(data []byte) (*ReadDirPlusRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the ReadDirPlusResponse into XDR-encoded bytes suitable
 // for transmission over the network.
@@ -155,42 +141,32 @@ func DecodeReadDirPlusRequest(data []byte) (*ReadDirPlusRequest, error) {
 func (resp *ReadDirPlusResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op directory attributes (both success and failure cases)
-	// ========================================================================
 
 	if err := xdr.EncodeOptionalFileAttr(&buf, resp.DirAttr); err != nil {
 		return nil, fmt.Errorf("failed to encode directory attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Error case: Return early (no entries)
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding READDIRPLUS error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Success case: Write cookie verifier
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.CookieVerf); err != nil {
 		return nil, fmt.Errorf("failed to write cookieverf: %w", err)
 	}
 
-	// ========================================================================
 	// Write directory entries
-	// ========================================================================
 
 	for _, entry := range resp.Entries {
 		// value_follows = TRUE (1) - indicates an entry follows
@@ -224,18 +200,14 @@ func (resp *ReadDirPlusResponse) Encode() ([]byte, error) {
 		}
 	}
 
-	// ========================================================================
 	// Write end-of-list marker
-	// ========================================================================
 
 	// value_follows = FALSE (0) - indicates no more entries
 	if err := binary.Write(&buf, binary.BigEndian, uint32(0)); err != nil {
 		return nil, fmt.Errorf("failed to write end-of-list marker: %w", err)
 	}
 
-	// ========================================================================
 	// Write EOF flag
-	// ========================================================================
 
 	eofVal := uint32(0)
 	if resp.Eof {

--- a/internal/adapter/nfs/v3/handlers/readlink.go
+++ b/internal/adapter/nfs/v3/handlers/readlink.go
@@ -12,9 +12,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // ReadLinkRequest represents a READLINK request from an NFS client.
 // The client provides a file handle for a symbolic link and requests
@@ -58,9 +56,7 @@ type ReadLinkResponse struct {
 	Target string
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // ReadLink handles NFS READLINK (RFC 1813 Section 3.3.5).
 // Reads the target pathname stored in a symbolic link for client-side path resolution.
@@ -71,9 +67,7 @@ func (h *Handler) ReadLink(
 	ctx *NFSHandlerContext,
 	req *ReadLinkRequest,
 ) (*ReadLinkResponse, error) {
-	// ========================================================================
 	// Context Cancellation Check - Entry Point
-	// ========================================================================
 	// Check if the client has disconnected or the request has timed out
 	// before we start processing. While READLINK is fast, we should still
 	// respect cancellation to avoid wasted work on abandoned requests.
@@ -87,10 +81,6 @@ func (h *Handler) ReadLink(
 
 	logger.InfoCtx(ctx.Context, "READLINK", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateReadLinkRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READLINK validation failed", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "error", err)
 		return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
@@ -100,9 +90,6 @@ func (h *Handler) ReadLink(
 
 	// Symlink file resolved in store
 
-	// ========================================================================
-	// Step 3: Build authentication context for store
-	// ========================================================================
 	// The store needs authentication details to enforce access control
 	// on the symbolic link (read permission checking)
 
@@ -118,9 +105,6 @@ func (h *Handler) ReadLink(
 		return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 3: Read symlink target via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Verifying the handle is a valid symlink
 	// - Checking read permission on the symlink
@@ -167,10 +151,6 @@ func (h *Handler) ReadLink(
 		return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: status}}, nil
 	}
 
-	// ========================================================================
-	// Step 4: Generate file attributes for cache consistency
-	// ========================================================================
-
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
 	logger.InfoCtx(ctx.Context, "READLINK successful", "handle", fmt.Sprintf("%x", req.Handle), "target", target, "target_len", len(target), "client", clientIP)
@@ -184,9 +164,7 @@ func (h *Handler) ReadLink(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateReadLinkRequest validates READLINK request parameters.
 //
@@ -226,9 +204,7 @@ func validateReadLinkRequest(req *ReadLinkRequest) *validationError {
 	return nil
 }
 
-// ============================================================================
 // Error Mapping
-// ============================================================================
 
 // mapReadLinkErrorToNFSStatus maps store errors to NFS status codes.
 // This provides consistent error handling across the READLINK operation.

--- a/internal/adapter/nfs/v3/handlers/readlink_codec.go
+++ b/internal/adapter/nfs/v3/handlers/readlink_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeReadLinkRequest decodes a READLINK request from XDR-encoded bytes.
 //
@@ -59,9 +57,7 @@ func DecodeReadLinkRequest(data []byte) (*ReadLinkRequest, error) {
 	return &ReadLinkRequest{Handle: handle}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the ReadLinkResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -98,17 +94,13 @@ func DecodeReadLinkRequest(data []byte) (*ReadLinkRequest, error) {
 func (resp *ReadLinkResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write post-op symlink attributes (both success and error cases)
-	// ========================================================================
 	// Including attributes on error helps clients maintain cache consistency
 	// for the symlink itself, even when reading the target fails
 
@@ -116,18 +108,14 @@ func (resp *ReadLinkResponse) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Error case: Return without target path
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding READLINK error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Success case: Write target path
-	// ========================================================================
 
 	// Write target path as XDR string (length + data + padding)
 	if err := xdr.WriteXDRString(&buf, resp.Target); err != nil {

--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // RemoveRequest represents a REMOVE request from an NFS client.
 // The client provides a directory handle and filename to delete.
@@ -60,9 +58,7 @@ type RemoveResponse struct {
 	DirWccAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Remove handles NFS REMOVE (RFC 1813 Section 3.3.12).
 // Deletes a non-directory file from a parent directory (symlinks and special files included).
@@ -85,18 +81,10 @@ func (h *Handler) Remove(
 
 	logger.InfoCtx(ctx.Context, "REMOVE", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateRemoveRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "REMOVE validation failed", "name", req.Filename, "client", clientIP, "error", err)
 		return &RemoveResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Resolve per-share metadata service and block store from directory handle
-	// ========================================================================
 
 	dirHandle := metadata.FileHandle(req.DirHandle)
 
@@ -107,10 +95,6 @@ func (h *Handler) Remove(
 	}
 
 	logger.DebugCtx(ctx.Context, "REMOVE", "share", ctx.Share, "name", req.Filename)
-
-	// ========================================================================
-	// Step 3: Capture pre-operation directory attributes for WCC
-	// ========================================================================
 
 	dirFile, status, err := h.getFileOrError(ctx, dirHandle, "REMOVE", req.DirHandle)
 	if dirFile == nil {
@@ -135,10 +119,6 @@ func (h *Handler) Remove(
 		}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 4: Build authentication context with share-level identity mapping
-	// ========================================================================
-
 	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "REMOVE", req.Filename, req.DirHandle)
 	if authCtx == nil {
 		return &RemoveResponse{
@@ -148,9 +128,6 @@ func (h *Handler) Remove(
 		}, err
 	}
 
-	// ========================================================================
-	// Step 4.5: Cross-protocol oplock break before deletion
-	// ========================================================================
 	// Resolve child handle for oplock break. Best-effort: if lookup fails,
 	// proceed with the removal (the store will report the actual error).
 	if breaker := h.getOplockBreaker(); breaker != nil {
@@ -162,9 +139,6 @@ func (h *Handler) Remove(
 		}
 	}
 
-	// ========================================================================
-	// Step 5: Remove file via store
-	// ========================================================================
 	// The store handles:
 	// - Verifying parent is a directory
 	// - Verifying the file exists
@@ -212,9 +186,6 @@ func (h *Handler) Remove(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5.5: Delete content if file has content
-	// ========================================================================
 	// After successfully removing the metadata, attempt to delete the actual
 	// file content. This is done after metadata removal to ensure consistency:
 	// if metadata is removed but content deletion fails, the content becomes
@@ -238,10 +209,6 @@ func (h *Handler) Remove(
 		}
 	}
 
-	// ========================================================================
-	// Step 6: Build success response with updated directory attributes
-	// ========================================================================
-
 	// H9: use the parent attributes captured atomically with the removal,
 	// falling back to a fresh read only if the store did not return them.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, wccBefore)
@@ -259,9 +226,7 @@ func (h *Handler) Remove(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateRemoveRequest validates REMOVE request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/remove_codec.go
+++ b/internal/adapter/nfs/v3/handlers/remove_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeRemoveRequest decodes a REMOVE request from XDR-encoded bytes.
 //
@@ -49,9 +47,7 @@ func DecodeRemoveRequest(data []byte) (*RemoveRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode directory handle
-	// ========================================================================
 
 	dirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -61,9 +57,7 @@ func DecodeRemoveRequest(data []byte) (*RemoveRequest, error) {
 		return nil, fmt.Errorf("invalid handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode filename
-	// ========================================================================
 
 	filename, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -84,9 +78,7 @@ func DecodeRemoveRequest(data []byte) (*RemoveRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the RemoveResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -120,17 +112,13 @@ func DecodeRemoveRequest(data []byte) (*RemoveRequest, error) {
 func (resp *RemoveResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write directory WCC data (both success and failure cases)
-	// ========================================================================
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the parent directory.
 

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -12,9 +12,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // RenameRequest represents a RENAME request from an NFS client.
 // The client provides source and destination directory handles and names
@@ -76,9 +74,7 @@ type RenameResponse struct {
 	ToDirWccAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Rename handles NFS RENAME (RFC 1813 Section 3.3.14).
 // Moves/renames a file or directory between directories, atomically replacing target if it exists.
@@ -101,18 +97,10 @@ func (h *Handler) Rename(
 
 	logger.InfoCtx(ctx.Context, "RENAME", "from", req.FromName, "from_dir", fmt.Sprintf("0x%x", req.FromDirHandle), "to", req.ToName, "to_dir", fmt.Sprintf("0x%x", req.ToDirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateRenameRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "RENAME validation failed", "from", req.FromName, "to", req.ToName, "client", clientIP, "error", err)
 		return &RenameResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata store from context and validate handles
-	// ========================================================================
 
 	metaSvc, svcErr := getMetadataService(h.Registry)
 	if svcErr != nil {
@@ -138,10 +126,6 @@ func (h *Handler) Rename(
 	}
 
 	logger.DebugCtx(ctx.Context, "RENAME", "share", ctx.Share, "from", req.FromName, "to", req.ToName)
-
-	// ========================================================================
-	// Step 3: Verify source directory exists and is valid
-	// ========================================================================
 
 	fromDirFile, status, err := h.getFileOrError(ctx, fromDirHandle, "RENAME", req.FromDirHandle)
 	if fromDirFile == nil {
@@ -176,10 +160,6 @@ func (h *Handler) Rename(
 			FromDirWccAfter:  fromDirWccAfter,
 		}, ctx.Context.Err()
 	}
-
-	// ========================================================================
-	// Step 3: Verify destination directory exists and is valid
-	// ========================================================================
 
 	toDirFile, status, err := h.getFileOrError(ctx, toDirHandle, "RENAME", req.ToDirHandle)
 	if toDirFile == nil {
@@ -232,10 +212,6 @@ func (h *Handler) Rename(
 		}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 4: Build authentication context for store
-	// ========================================================================
-
 	authCtx, fromDirWccAfter, err := h.buildAuthContextWithWCCError(ctx, fromDirHandle, &fromDirFile.FileAttr, "RENAME", req.FromName, req.FromDirHandle)
 	if authCtx == nil {
 		toDirWccAfter := h.convertFileAttrToNFS(toDirHandle, &toDirFile.FileAttr)
@@ -249,9 +225,6 @@ func (h *Handler) Rename(
 		}, err
 	}
 
-	// ========================================================================
-	// Step 4.5: Cross-protocol oplock break on source and destination
-	// ========================================================================
 	// Break oplocks on source file and (if it exists) destination file.
 	// Best-effort: lookup failures don't block the rename operation.
 	if breaker := h.getOplockBreaker(); breaker != nil {
@@ -270,9 +243,6 @@ func (h *Handler) Rename(
 		}
 	}
 
-	// ========================================================================
-	// Step 5: Perform rename via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Verifying source file exists
 	// - Checking write permissions on both directories
@@ -287,9 +257,7 @@ func (h *Handler) Rename(
 
 	renameWcc, err := metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
 	if err == nil {
-		// ====================================================================
 		// NFS-specific: Handle silly rename (.nfs* pattern)
-		// ====================================================================
 		// When an NFS client deletes a file that's still open, it renames the
 		// file to a temporary name starting with ".nfs". We mark such files as
 		// orphaned (nlink=0) so that fstat() returns the correct link count.
@@ -358,10 +326,6 @@ func (h *Handler) Rename(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Build success response with updated WCC data
-	// ========================================================================
-
 	// H9: use the source/destination directory attributes captured atomically
 	// inside the Move transaction. The pre-op snapshots read at handler entry
 	// can race a concurrent mutation in the window; the in-transaction captures
@@ -389,9 +353,7 @@ func (h *Handler) Rename(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateRenameRequest validates RENAME request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/rename_codec.go
+++ b/internal/adapter/nfs/v3/handlers/rename_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeRenameRequest decodes a RENAME request from XDR-encoded bytes.
 //
@@ -55,9 +53,7 @@ func DecodeRenameRequest(data []byte) (*RenameRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode source directory handle
-	// ========================================================================
 
 	fromDirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -67,18 +63,14 @@ func DecodeRenameRequest(data []byte) (*RenameRequest, error) {
 		return nil, fmt.Errorf("invalid source directory handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode source name
-	// ========================================================================
 
 	fromName, err := xdr.DecodeString(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decode source name: %w", err)
 	}
 
-	// ========================================================================
 	// Decode destination directory handle
-	// ========================================================================
 
 	toDirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -88,9 +80,7 @@ func DecodeRenameRequest(data []byte) (*RenameRequest, error) {
 		return nil, fmt.Errorf("invalid destination directory handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode destination name
-	// ========================================================================
 
 	toName, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -107,9 +97,7 @@ func DecodeRenameRequest(data []byte) (*RenameRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the RenameResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -147,25 +135,19 @@ func DecodeRenameRequest(data []byte) (*RenameRequest, error) {
 func (resp *RenameResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write WCC data for source directory (both success and failure)
-	// ========================================================================
 
 	if err := xdr.EncodeWccData(&buf, resp.FromDirWccBefore, resp.FromDirWccAfter); err != nil {
 		return nil, fmt.Errorf("encode source directory wcc data: %w", err)
 	}
 
-	// ========================================================================
 	// Write WCC data for destination directory (both success and failure)
-	// ========================================================================
 
 	if err := xdr.EncodeWccData(&buf, resp.ToDirWccBefore, resp.ToDirWccAfter); err != nil {
 		return nil, fmt.Errorf("encode destination directory wcc data: %w", err)

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // RmdirRequest represents a RMDIR request from an NFS client.
 // The client provides a parent directory handle and the name of the
@@ -62,9 +60,7 @@ type RmdirResponse struct {
 	DirWccAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Rmdir handles NFS RMDIR (RFC 1813 Section 3.3.13).
 // Removes an empty directory from a parent directory (must contain only "." and "..").
@@ -80,27 +76,15 @@ func (h *Handler) Rmdir(
 
 	logger.InfoCtx(ctx.Context, "RMDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "RMDIR cancelled", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 		return &RmdirResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
-
 	if err := validateRmdirRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "RMDIR validation failed", "name", req.Name, "client", clientIP, "error", err)
 		return &RmdirResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -111,10 +95,6 @@ func (h *Handler) Rmdir(
 	parentHandle := metadata.FileHandle(req.DirHandle)
 
 	logger.DebugCtx(ctx.Context, "RMDIR", "share", ctx.Share, "name", req.Name)
-
-	// ========================================================================
-	// Step 4: Verify parent directory exists and is valid
-	// ========================================================================
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
@@ -145,10 +125,6 @@ func (h *Handler) Rmdir(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 4: Build authentication context with share-level identity mapping
-	// ========================================================================
-
 	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "RMDIR", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &RmdirResponse{
@@ -158,9 +134,6 @@ func (h *Handler) Rmdir(
 		}, err
 	}
 
-	// ========================================================================
-	// Step 5: Remove directory via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Verifying the directory exists
 	// - Verifying it's actually a directory
@@ -204,10 +177,6 @@ func (h *Handler) Rmdir(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Build success response with updated parent attributes
-	// ========================================================================
-
 	// H9: use the parent attributes captured atomically with the removal.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
@@ -222,9 +191,7 @@ func (h *Handler) Rmdir(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateRmdirRequest validates RMDIR request parameters.
 //
@@ -313,9 +280,7 @@ func validateRmdirRequest(req *RmdirRequest) *validationError {
 	return nil
 }
 
-// ============================================================================
 // Error Mapping
-// ============================================================================
 
 // mapRmdirErrorToNFSStatus maps store errors to NFS status codes.
 // This provides consistent error mapping for RMDIR operations.

--- a/internal/adapter/nfs/v3/handlers/rmdir_codec.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir_codec.go
@@ -9,9 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeRmdirRequest decodes a RMDIR request from XDR-encoded bytes.
 //
@@ -53,9 +51,7 @@ func DecodeRmdirRequest(data []byte) (*RmdirRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode parent directory handle
-	// ========================================================================
 
 	handle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -65,9 +61,7 @@ func DecodeRmdirRequest(data []byte) (*RmdirRequest, error) {
 		return nil, fmt.Errorf("invalid handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode directory name
-	// ========================================================================
 
 	name, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -82,9 +76,7 @@ func DecodeRmdirRequest(data []byte) (*RmdirRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the RmdirResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -128,17 +120,13 @@ func DecodeRmdirRequest(data []byte) (*RmdirRequest, error) {
 func (resp *RmdirResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write WCC data for parent directory (both success and failure)
-	// ========================================================================
 
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the parent directory.

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // SetAttrRequest represents a SETATTR request from an NFS client.
 // The client provides a file handle and a set of attributes to modify.
@@ -72,9 +70,7 @@ type SetAttrResponse struct {
 	AttrAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // SetAttr handles NFS SETATTR (RFC 1813 Section 3.3.2).
 // Modifies file attributes (mode, uid, gid, size, atime, mtime) with optional ctime guard.
@@ -85,9 +81,7 @@ func (h *Handler) SetAttr(
 	ctx *NFSHandlerContext,
 	req *SetAttrRequest,
 ) (*SetAttrResponse, error) {
-	// ========================================================================
 	// Context Cancellation Check - Entry Point
-	// ========================================================================
 	// Check if the client has disconnected or the request has timed out
 	// before we start any operations. This is especially important for
 	// SETATTR operations that may involve expensive content truncation.
@@ -108,10 +102,6 @@ func (h *Handler) SetAttr(
 		"client", clientIP,
 		"auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateSetAttrRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "SETATTR validation failed",
 			"handle", fmt.Sprintf("%x", req.Handle),
@@ -119,10 +109,6 @@ func (h *Handler) SetAttr(
 			"error", err)
 		return &SetAttrResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -135,10 +121,6 @@ func (h *Handler) SetAttr(
 	logger.DebugCtx(ctx.Context, "SETATTR",
 		"share", ctx.Share)
 
-	// ========================================================================
-	// Step 3: Get current file attributes for WCC and guard check
-	// ========================================================================
-
 	currentFile, status, err := h.getFileOrError(ctx, fileHandle, "SETATTR", req.Handle)
 	if currentFile == nil {
 		return &SetAttrResponse{NFSResponseBase: NFSResponseBase{Status: status}}, err
@@ -147,9 +129,7 @@ func (h *Handler) SetAttr(
 	// Capture pre-operation attributes for WCC data
 	wccBefore := xdr.CaptureWccAttr(&currentFile.FileAttr)
 
-	// ========================================================================
 	// Handle Empty SETATTR (No-Op)
-	// ========================================================================
 	// If no attributes are specified, return success immediately with current
 	// attributes. This is valid NFS behavior - macOS Finder and other clients
 	// sometimes send empty SETATTR requests (possibly for access verification).
@@ -172,9 +152,7 @@ func (h *Handler) SetAttr(
 		}, nil
 	}
 
-	// ========================================================================
 	// Context Cancellation Check - After Metadata Lookup
-	// ========================================================================
 	// Check again after metadata lookup, before guard check and attribute update
 	if ctx.isContextCancelled() {
 		logger.DebugCtx(ctx.Context, "SETATTR: request cancelled after metadata lookup",
@@ -183,9 +161,6 @@ func (h *Handler) SetAttr(
 		return nil, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 3: Check guard condition if specified
-	// ========================================================================
 	// The guard implements optimistic concurrency control by checking if
 	// the file's ctime has changed since the client last read it.
 	// If it has changed, another client has modified the file and this
@@ -221,10 +196,6 @@ func (h *Handler) SetAttr(
 			"ctime", fmt.Sprintf("%d.%d", currentCtime.Seconds, currentCtime.Nseconds))
 	}
 
-	// ========================================================================
-	// Step 4: Build authentication context with share-level identity mapping
-	// ========================================================================
-
 	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, fileHandle, &currentFile.FileAttr, "SETATTR", "", req.Handle)
 	if authCtx == nil {
 		return &SetAttrResponse{
@@ -234,9 +205,6 @@ func (h *Handler) SetAttr(
 		}, err
 	}
 
-	// ========================================================================
-	// Step 5: Apply attribute updates via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Checking ownership (for chown/chmod)
 	// - Checking write permission (for size/time changes)
@@ -349,9 +317,6 @@ func (h *Handler) SetAttr(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5b: Reclaim block-store space on size-down truncation
-	// ========================================================================
 	// SetFileAttributes prunes FileAttr.Blocks past the new size, but the
 	// per-share block store still holds the dropped CAS chunks. Mirror the
 	// CREATE-with-truncate path (truncateExistingFile): drive
@@ -371,10 +336,6 @@ func (h *Handler) SetAttr(
 				"handle", fmt.Sprintf("%x", req.Handle), "size", *req.NewAttr.Size, "error", tErr)
 		}
 	}
-
-	// ========================================================================
-	// Step 6: Build success response with updated attributes
-	// ========================================================================
 
 	// H9: prefer the file's pre/post attributes captured atomically with the
 	// SetFileAttributes mutation. The wccBefore read at handler entry can race a
@@ -405,9 +366,7 @@ func (h *Handler) SetAttr(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateSetAttrRequest validates SETATTR request parameters.
 //
@@ -470,9 +429,7 @@ func validateSetAttrRequest(req *SetAttrRequest) *validationError {
 	return nil
 }
 
-// ============================================================================
 // Utility Functions
-// ============================================================================
 
 // logSetAttrRequest logs which attributes are being set in a SETATTR request.
 // This provides detailed debugging information about the operation.

--- a/internal/adapter/nfs/v3/handlers/setattr_codec.go
+++ b/internal/adapter/nfs/v3/handlers/setattr_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeSetAttrRequest decodes a SETATTR request from XDR-encoded bytes.
 //
@@ -42,9 +40,7 @@ func DecodeSetAttrRequest(data []byte) (*SetAttrRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode file handle
-	// ========================================================================
 
 	handle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -54,18 +50,14 @@ func DecodeSetAttrRequest(data []byte) (*SetAttrRequest, error) {
 		return nil, fmt.Errorf("invalid handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode new attributes (sattr3)
-	// ========================================================================
 
 	newAttr, err := xdr.DecodeSetAttrs(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decode attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Decode guard (sattrguard3)
-	// ========================================================================
 
 	guard := types.TimeGuard{}
 
@@ -108,9 +100,7 @@ func DecodeSetAttrRequest(data []byte) (*SetAttrRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the SetAttrResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -147,17 +137,13 @@ func DecodeSetAttrRequest(data []byte) (*SetAttrRequest, error) {
 func (resp *SetAttrResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write WCC data (both success and failure cases)
-	// ========================================================================
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the file.
 

--- a/internal/adapter/nfs/v3/handlers/symlink.go
+++ b/internal/adapter/nfs/v3/handlers/symlink.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // SymlinkRequest represents a SYMLINK request from an NFS client.
 // The client provides a parent directory handle, a name for the new symlink,
@@ -83,9 +81,7 @@ type SymlinkResponse struct {
 	DirAttrAfter *types.NFSFileAttr
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Symlink handles NFS SYMLINK (RFC 1813 Section 3.3.10).
 // Creates a symbolic link in a directory pointing to a target pathname (absolute or relative).
@@ -108,18 +104,10 @@ func (h *Handler) Symlink(
 
 	logger.InfoCtx(ctx.Context, "SYMLINK", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Validate request parameters
-	// ========================================================================
-
 	if err := validateSymlinkRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "SYMLINK validation failed", "name", req.Name, "target", req.Target, "client", clientIP, "error", err)
 		return &SymlinkResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 2: Get metadata store from context
-	// ========================================================================
 
 	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
@@ -130,10 +118,6 @@ func (h *Handler) Symlink(
 	dirHandle := metadata.FileHandle(req.DirHandle)
 
 	logger.DebugCtx(ctx.Context, "SYMLINK", "share", ctx.Share, "name", req.Name, "target", req.Target)
-
-	// ========================================================================
-	// Step 3: Verify parent directory exists and capture pre-op attributes
-	// ========================================================================
 
 	dirFile, status, err := h.getFileOrError(ctx, dirHandle, "SYMLINK", req.DirHandle)
 	if dirFile == nil {
@@ -171,10 +155,6 @@ func (h *Handler) Symlink(
 		}, ctx.Context.Err()
 	}
 
-	// ========================================================================
-	// Step 3: Build authentication context for store
-	// ========================================================================
-
 	authCtx, nfsDirAttr, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "SYMLINK", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &SymlinkResponse{
@@ -184,9 +164,6 @@ func (h *Handler) Symlink(
 		}, err
 	}
 
-	// ========================================================================
-	// Step 4: Convert client attributes to metadata format
-	// ========================================================================
 	// Use convertSetAttrsToMetadata to ensure consistent attribute handling
 	// across all file creation operations (MKDIR, MKNOD, SYMLINK, CREATE).
 	// This properly applies:
@@ -203,9 +180,6 @@ func (h *Handler) Symlink(
 
 	symlinkAttr := xdr.ConvertSetAttrsToMetadata(metadata.FileTypeSymlink, &req.Attr, authCtx)
 
-	// ========================================================================
-	// Step 5: Create symlink via store
-	// ========================================================================
 	// The store is responsible for:
 	// - Checking write permission on parent directory
 	// - Verifying name doesn't already exist
@@ -252,10 +226,6 @@ func (h *Handler) Symlink(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 6: Encode file handle and prepare response
-	// ========================================================================
-
 	// Encode the file handle for the symlink
 	symlinkHandle, err := metadata.EncodeFileHandle(createdSymlink)
 	if err != nil {
@@ -282,9 +252,7 @@ func (h *Handler) Symlink(
 	}, nil
 }
 
-// ============================================================================
 // Request Validation
-// ============================================================================
 
 // validateSymlinkRequest validates SYMLINK request parameters.
 //

--- a/internal/adapter/nfs/v3/handlers/symlink_codec.go
+++ b/internal/adapter/nfs/v3/handlers/symlink_codec.go
@@ -10,9 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeSymlinkRequest decodes a SYMLINK request from XDR-encoded bytes.
 //
@@ -54,9 +52,7 @@ func DecodeSymlinkRequest(data []byte) (*SymlinkRequest, error) {
 
 	reader := bytes.NewReader(data)
 
-	// ========================================================================
 	// Decode directory handle
-	// ========================================================================
 
 	dirHandle, err := xdr.DecodeFileHandleFromReader(reader)
 	if err != nil {
@@ -66,27 +62,21 @@ func DecodeSymlinkRequest(data []byte) (*SymlinkRequest, error) {
 		return nil, fmt.Errorf("invalid handle length: 0 (must be > 0)")
 	}
 
-	// ========================================================================
 	// Decode symlink name
-	// ========================================================================
 
 	name, err := xdr.DecodeString(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decode symlink name: %w", err)
 	}
 
-	// ========================================================================
 	// Decode symlink attributes
-	// ========================================================================
 
 	attr, err := xdr.DecodeSetAttrs(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decode attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Decode target path
-	// ========================================================================
 
 	target, err := xdr.DecodeString(reader)
 	if err != nil {
@@ -103,9 +93,7 @@ func DecodeSymlinkRequest(data []byte) (*SymlinkRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the SymlinkResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -144,17 +132,13 @@ func DecodeSymlinkRequest(data []byte) (*SymlinkRequest, error) {
 func (resp *SymlinkResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("write status: %w", err)
 	}
 
-	// ========================================================================
 	// Success case: Write symlink handle and attributes
-	// ========================================================================
 
 	if resp.Status == types.NFS3OK {
 		// Write post-op file handle (optional)
@@ -168,9 +152,7 @@ func (resp *SymlinkResponse) Encode() ([]byte, error) {
 		}
 	}
 
-	// ========================================================================
 	// Write directory WCC data (both success and failure cases)
-	// ========================================================================
 	// WCC (Weak Cache Consistency) data helps clients maintain cache coherency
 	// by providing before-and-after snapshots of the parent directory.
 

--- a/internal/adapter/nfs/v3/handlers/utils.go
+++ b/internal/adapter/nfs/v3/handlers/utils.go
@@ -61,9 +61,7 @@ func safeAdd(a, b uint64) (uint64, bool) {
 	return sum, overflow
 }
 
-// ============================================================================
 // Error Logging Helpers
-// ============================================================================
 
 // logError logs an error.
 // Use this for actual errors that indicate something went wrong.
@@ -83,9 +81,7 @@ func logWarn(ctx context.Context, err error, msg string, args ...any) {
 	logger.WarnCtx(ctx, msg, args...)
 }
 
-// ============================================================================
 // MFsymlink Detection for NFS/SMB Interoperability
-// ============================================================================
 //
 // MFsymlinks are 1067-byte files with "XSym\n" header used by macOS/Windows
 // SMB clients for symlink creation. When accessed via NFS, these files should

--- a/internal/adapter/nfs/v3/handlers/verf.go
+++ b/internal/adapter/nfs/v3/handlers/verf.go
@@ -2,9 +2,7 @@ package handlers
 
 import "time"
 
-// ============================================================================
 // Server Instance Tracking
-// ============================================================================
 
 // serverBootTime stores the time when the NFS server started.
 // This is used as the write verifier to help clients detect server restarts.

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -12,9 +12,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// ============================================================================
 // Write Stability Levels (RFC 1813 Section 3.3.7)
-// ============================================================================
 
 // Write stability levels control how the server handles data persistence.
 // These constants define when data must be committed to stable storage.
@@ -35,9 +33,7 @@ const (
 	FileSyncWrite = 2
 )
 
-// ============================================================================
 // Flush Reasons
-// ============================================================================
 
 // FlushReason indicates why a block store flush was triggered.
 type FlushReason string
@@ -56,9 +52,7 @@ const (
 	FlushReasonTimeout FlushReason = "timeout"
 )
 
-// ============================================================================
 // Request and Response Structures
-// ============================================================================
 
 // WriteRequest represents a WRITE request from an NFS client.
 // The client specifies a file handle, offset, data to write, and
@@ -115,9 +109,7 @@ type WriteResponse struct {
 	Verf            uint64             // Write verifier
 }
 
-// ============================================================================
 // Protocol Handler
-// ============================================================================
 
 // Write handles NFS WRITE (RFC 1813 Section 3.3.7).
 // Writes data to a regular file at a given offset using two-phase PrepareWrite/CommitWrite pattern.
@@ -133,18 +125,11 @@ func (h *Handler) Write(
 
 	logger.DebugCtx(ctx.Context, "WRITE", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "stable", req.Stable, "client", clientIP, "auth", ctx.AuthFlavor)
 
-	// ========================================================================
-	// Step 1: Check for context cancellation before starting work
-	// ========================================================================
-
 	if ctx.isContextCancelled() {
 		logWarn(ctx.Context, ctx.Context.Err(), "WRITE cancelled", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// ========================================================================
-	// Step 2: Validate request parameters
-	// ========================================================================
 	// Structural validation only (handle, overflow, stability). The size cap
 	// is applied as a short-write below, derived from the advertised wtmax.
 
@@ -152,10 +137,6 @@ func (h *Handler) Write(
 		logWarn(ctx.Context, err, "WRITE validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
-
-	// ========================================================================
-	// Step 3: Resolve per-share metadata service and block store from file handle
-	// ========================================================================
 
 	fileHandle := metadata.FileHandle(req.Handle)
 
@@ -167,9 +148,6 @@ func (h *Handler) Write(
 
 	logger.DebugCtx(ctx.Context, "WRITE", "share", ctx.Share)
 
-	// ========================================================================
-	// Step 3b: Short-write to the advertised wtmax (RFC 1813 Section 3.3.7)
-	// ========================================================================
 	// Derive the per-request cap from the same value advertised by FSINFO
 	// (GetFilesystemCapabilities().MaxWriteSize / wtmax) so the WRITE limit can
 	// never drift from what the client was told. RFC 1813 permits the server to
@@ -186,9 +164,6 @@ func (h *Handler) Write(
 		req.Count = caps.MaxWriteSize
 	}
 
-	// ========================================================================
-	// Step 4: Calculate new file size
-	// ========================================================================
 	// Note: File existence and type validation is done by PrepareWrite.
 	// This eliminates a redundant GetFile call.
 
@@ -207,10 +182,6 @@ func (h *Handler) Write(
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrFBig}}, nil
 	}
 
-	// ========================================================================
-	// Step 5: Build AuthContext with share-level identity mapping (cached)
-	// ========================================================================
-
 	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
 		// Check if the error is due to context cancellation
@@ -227,9 +198,6 @@ func (h *Handler) Write(
 		}, nil
 	}
 
-	// ========================================================================
-	// Step 5b: Cross-protocol oplock break
-	// ========================================================================
 	// Fire-and-forget: per Samba behavior, NFS proceeds even if break is pending.
 	// The break notification is sent to the SMB client asynchronously.
 	if breaker := h.getOplockBreaker(); breaker != nil {
@@ -239,9 +207,6 @@ func (h *Handler) Write(
 		}
 	}
 
-	// ========================================================================
-	// Step 6: Prepare write operation (validate permissions)
-	// ========================================================================
 	// PrepareWrite validates permissions but does NOT modify metadata yet.
 	// Metadata is updated by CommitWrite after BlockStore write succeeds.
 
@@ -269,10 +234,6 @@ func (h *Handler) Write(
 	// Build WCC attributes from pre-write state
 	nfsWccAttr := xdr.CaptureWccAttr(writeIntent.PreWriteAttr)
 
-	// ========================================================================
-	// Step 7: Write data to BlockStore (uses local cache internally)
-	// ========================================================================
-
 	// Check context before write operation
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "WRITE cancelled before write", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
@@ -290,10 +251,6 @@ func (h *Handler) Write(
 	}
 	logger.DebugCtx(ctx.Context, "WRITE: cached successfully", "payload_id", writeIntent.PayloadID)
 
-	// ========================================================================
-	// Step 8: Commit metadata changes after successful BlockStore write
-	// ========================================================================
-
 	updatedFile, err := metaSvc.CommitWrite(authCtx, writeIntent)
 	if err != nil {
 		logError(ctx.Context, err, "WRITE failed: CommitWrite error (content written but metadata not updated)", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", len(req.Data), "client", clientIP)
@@ -305,17 +262,11 @@ func (h *Handler) Write(
 		return h.buildWriteErrorResponse(status, fileHandle, writeIntent.PreWriteAttr, writeIntent.PreWriteAttr), nil
 	}
 
-	// ========================================================================
-	// Step 9: Build success response
-	// ========================================================================
-
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &updatedFile.FileAttr)
 
 	logger.DebugCtx(ctx.Context, "WRITE successful", "file", updatedFile.PayloadID, "offset", bytesize.ByteSize(req.Offset), "requested", bytesize.ByteSize(req.Count), "written", bytesize.ByteSize(len(req.Data)), "new_size", bytesize.ByteSize(updatedFile.Size), "client", clientIP)
 
-	// ========================================================================
 	// Stability Level Design Decision (RFC 1813 Section 3.3.7)
-	// ========================================================================
 	//
 	// We always return UNSTABLE because Cache is always enabled.
 	// This is RFC-compliant because:
@@ -357,9 +308,7 @@ func (h *Handler) Write(
 	}, nil
 }
 
-// ============================================================================
 // Write Helper Functions
-// ============================================================================
 
 // buildWriteErrorResponse creates a consistent error response with WCC data.
 // This centralizes error response creation to reduce duplication.

--- a/internal/adapter/nfs/v3/handlers/write_codec.go
+++ b/internal/adapter/nfs/v3/handlers/write_codec.go
@@ -11,9 +11,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // XDR Decoding
-// ============================================================================
 
 // DecodeWriteRequest decodes a WRITE request from XDR-encoded bytes.
 //
@@ -68,27 +66,21 @@ func DecodeWriteRequest(data []byte) (*WriteRequest, error) {
 		return nil, fmt.Errorf("failed to read offset: %w", err)
 	}
 
-	// ========================================================================
 	// Decode count
-	// ========================================================================
 
 	var count uint32
 	if err := binary.Read(reader, binary.BigEndian, &count); err != nil {
 		return nil, fmt.Errorf("failed to read count: %w", err)
 	}
 
-	// ========================================================================
 	// Decode stability level
-	// ========================================================================
 
 	var stable uint32
 	if err := binary.Read(reader, binary.BigEndian, &stable); err != nil {
 		return nil, fmt.Errorf("failed to read stable: %w", err)
 	}
 
-	// ========================================================================
 	// Decode data
-	// ========================================================================
 
 	// Read data length
 	var dataLen uint32
@@ -150,9 +142,7 @@ func DecodeWriteRequest(data []byte) (*WriteRequest, error) {
 	}, nil
 }
 
-// ============================================================================
 // XDR Encoding
-// ============================================================================
 
 // Encode serializes the WriteResponse into XDR-encoded bytes suitable for
 // transmission over the network.
@@ -193,17 +183,13 @@ func DecodeWriteRequest(data []byte) (*WriteRequest, error) {
 func (resp *WriteResponse) Encode() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// ========================================================================
 	// Write status code
-	// ========================================================================
 
 	if err := binary.Write(&buf, binary.BigEndian, resp.Status); err != nil {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// ========================================================================
 	// Write WCC data (Weak Cache Consistency)
-	// ========================================================================
 	// WCC data is included in both success and error cases to help
 	// clients maintain cache consistency.
 
@@ -246,18 +232,14 @@ func (resp *WriteResponse) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode post-op attributes: %w", err)
 	}
 
-	// ========================================================================
 	// Error case: Return early if status is not OK
-	// ========================================================================
 
 	if resp.Status != types.NFS3OK {
 		logger.Debug("Encoding WRITE error response", "status", resp.Status)
 		return buf.Bytes(), nil
 	}
 
-	// ========================================================================
 	// Success case: Write count, committed, and verifier
-	// ========================================================================
 
 	// Write count (number of bytes actually written)
 	if err := binary.Write(&buf, binary.BigEndian, resp.Count); err != nil {

--- a/internal/adapter/nfs/v3/handlers/write_validation.go
+++ b/internal/adapter/nfs/v3/handlers/write_validation.go
@@ -7,9 +7,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// ============================================================================
 // Write Request Validation
-// ============================================================================
 
 // validateWriteRequest validates WRITE request parameters.
 //

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -425,7 +425,7 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 
 	// Replay: return cached COMPOUND response bytes directly
 	if cachedReply != nil {
-		logger.Info("NFSv4.1 COMPOUND replay cache hit",
+		logger.Debug("NFSv4.1 COMPOUND replay cache hit",
 			"client", compCtx.ClientAddr)
 		return cachedReply, nil
 	}

--- a/internal/adapter/nfs/v4/handlers/handler.go
+++ b/internal/adapter/nfs/v4/handlers/handler.go
@@ -185,12 +185,10 @@ func NewHandler(registry *runtime.Runtime, pfs *pseudofs.PseudoFS, stateManager 
 	//   // serialize snapshots to disk
 	//   handler.StateManager.Shutdown()
 
-	// ============================================================================
 	// NFSv4.1 dispatch table (stub handlers for all 19 v4.1 operations)
-	// ============================================================================
 	//
 	// Each stub decodes its operation's XDR args (to prevent stream desync)
-	// and returns NFS4ERR_NOTSUPP. Real handlers replace stubs in Phases 17-24.
+	// and returns NFS4ERR_NOTSUPP.
 
 	// BACKCHANNEL_CTL: update callback program and security params (RFC 8881 Section 18.33)
 	h.v41DispatchTable[types.OP_BACKCHANNEL_CTL] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -49,9 +49,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 		return openError(types.NFS4ERR_ROFS)
 	}
 
-	// ========================================================================
 	// Decode OPEN4args
-	// ========================================================================
 
 	// 1. seqid (uint32) - open-owner sequence number
 	seqid, err := xdr.DecodeUint32(reader)
@@ -167,9 +165,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 		return openError(types.NFS4ERR_BADXDR)
 	}
 
-	// ========================================================================
 	// Dispatch by claim type
-	// ========================================================================
 
 	switch claimType {
 	case types.CLAIM_NULL:
@@ -225,9 +221,7 @@ func (h *Handler) handleOpenClaimNull(
 		return openError(status)
 	}
 
-	// ========================================================================
 	// Build auth context and get services
-	// ========================================================================
 
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
@@ -251,9 +245,7 @@ func (h *Handler) handleOpenClaimNull(
 	}
 	beforeCtime := uint64(parentFile.Ctime.UnixNano())
 
-	// ========================================================================
 	// Execute OPEN logic
-	// ========================================================================
 
 	var fileHandle metadata.FileHandle
 	var created bool
@@ -327,9 +319,7 @@ func (h *Handler) handleOpenClaimNull(
 		}
 	}
 
-	// ========================================================================
 	// Check delegation conflicts BEFORE creating state
-	// ========================================================================
 	// If another client holds a conflicting delegation, trigger async CB_RECALL
 	// and return NFS4ERR_DELAY so the client retries the entire OPEN.
 
@@ -342,9 +332,7 @@ func (h *Handler) handleOpenClaimNull(
 		return openError(types.NFS4ERR_DELAY)
 	}
 
-	// ========================================================================
 	// Create tracked state via StateManager
-	// ========================================================================
 
 	openResult, stateErr := h.StateManager.OpenFile(
 		clientID, ownerData, seqid,
@@ -374,9 +362,7 @@ func (h *Handler) handleOpenClaimNull(
 		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
 	}
 
-	// ========================================================================
 	// Try to grant a delegation
-	// ========================================================================
 
 	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, []byte(fileHandle), shareAccess)
 	var deleg *state.DelegationState
@@ -397,9 +383,7 @@ func (h *Handler) handleOpenClaimNull(
 		"delegation", delegType,
 		"client", ctx.ClientAddr)
 
-	// ========================================================================
 	// Encode OPEN4resok
-	// ========================================================================
 
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
 		beforeCtime, afterCtime, deleg)

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -218,7 +218,6 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 
 	fileHandle := metadata.FileHandle(ctx.CurrentFH)
 
-	// Step 1: PrepareWrite -- validates permissions, returns intent
 	intent, err := metaSvc.PrepareWrite(authCtx, fileHandle, newSize)
 	if err != nil {
 		status := common.MapToNFS4(err)
@@ -247,7 +246,6 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"client", ctx.ClientAddr)
 	}
 
-	// Step 2: Write actual data via BlockStore.
 	// Routed through common.WriteToBlockStore so any future []BlockRef
 	// plumbing lands in one place (see common/doc.go).
 	err = common.WriteToBlockStore(ctx.Context, blockStore, intent.PayloadID, data, offset)
@@ -263,7 +261,6 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
-	// Step 3: CommitWrite -- updates metadata (size, timestamps)
 	_, err = metaSvc.CommitWrite(authCtx, intent)
 	if err != nil {
 		status := common.MapToNFS4(err)

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -124,8 +124,8 @@ func (sm *StateManager) recordReclaimCompleteLocked(clientIDString string) {
 }
 
 // validateReclaimVerifier rejects a CLAIM_PREVIOUS reclaim whose boot verifier
-// does not match the PRE-RESTART durable verifier (RFC 7530 §9.1.4, area-4 H8
-// §3.4): a changed verifier means the client rebooted and must NOT reclaim prior
+// does not match the PRE-RESTART durable verifier (RFC 7530 §9.1.4):
+// a changed verifier means the client rebooted and must NOT reclaim prior
 // state.
 //
 // It compares against the boot-load snapshot (bootRecoveryVerifiers), not the
@@ -155,8 +155,8 @@ func (sm *StateManager) validateReclaimVerifier(clientIDString string, bootVerif
 }
 
 // LoadClientRecovery reads the durable recovery records on boot and starts the
-// v4 grace period seeded with the prior clients' stable identity strings (the
-// area-4 H8 core: today the v4 roster is empty on a fresh process so v4 grace
+// v4 grace period seeded with the prior clients' stable identity strings:
+// today the v4 roster is empty on a fresh process so v4 grace
 // is a no-op; now it is the durable prior-client set).
 //
 // Records whose ReclaimComplete is already true are NOT waited on (a second

--- a/internal/adapter/nfs/v4/state/grace.go
+++ b/internal/adapter/nfs/v4/state/grace.go
@@ -110,7 +110,7 @@ func (g *GracePeriodState) StartGrace(expectedClientIDs []uint64) {
 }
 
 // StartGraceWithRoster begins the grace period with a durable boot-loaded
-// reclaim roster keyed by stable client identity string (the area-4 H8 path),
+// reclaim roster keyed by stable client identity string,
 // optionally alongside any same-epoch numeric client IDs.
 //
 // The string roster is authoritative for early-exit after an ungraceful restart:

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -126,7 +126,7 @@ type StateManager struct {
 	graceDuration time.Duration
 
 	// recoveryStore provides server-global durable persistence of confirmed
-	// client identities for reboot/grace recovery (area-4 H8). Optional: when
+	// client identities for reboot/grace recovery. Optional: when
 	// nil the StateManager behaves exactly as before (no durable recovery),
 	// which keeps bare test constructions working. Set via
 	// SetClientRecoveryStore, wired by the NFS adapter to the first share's
@@ -601,7 +601,7 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 		"client_addr", record.ClientAddr)
 
 	// Persist a durable client-recovery record so this client can reclaim its
-	// state after an ungraceful server restart (area-4 H8). Best-effort under
+	// state after an ungraceful server restart. Best-effort under
 	// sm.mu: a persist failure logs a durability alarm but the confirm STILL
 	// succeeds (the in-memory record is authoritative for this process). No-op
 	// when no recovery store is wired.
@@ -697,7 +697,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 		"client_addr", record.ClientAddr)
 
 	// The client's lease lapsed without renewal: it no longer holds reclaimable
-	// state, so drop its durable recovery record (area-4 H8). Best-effort; no-op
+	// state, so drop its durable recovery record. Best-effort; no-op
 	// when no recovery store is wired.
 	sm.deleteClientRecoveryLocked(record.ClientIDString)
 
@@ -1042,7 +1042,7 @@ func (sm *StateManager) OpenFile(
 		if !sm.IsInGrace() {
 			return nil, ErrNoGrace
 		}
-		// Verifier-gated reclaim (RFC 7530 §9.1.4, area-4 H8 §3.4): a reclaiming
+		// Verifier-gated reclaim (RFC 7530 §9.1.4): a reclaiming
 		// client whose ClientIDString matches a pre-restart record but whose
 		// BootVerifier changed rebooted and must NOT reclaim prior state.
 		// validateReclaimVerifier self-gates on the boot-load snapshot, so it is
@@ -1067,7 +1067,7 @@ func (sm *StateManager) OpenFile(
 			}
 		}
 		// v4.0 has no RECLAIM_COMPLETE; the first successful CLAIM_PREVIOUS is
-		// the analog reclaim marker (area-4 H8 §3.3). Persist it so a second
+		// the analog reclaim marker. Persist it so a second
 		// restart inside one grace window does not wait on this client again.
 		if rec != nil {
 			sm.mu.Lock()
@@ -2459,7 +2459,7 @@ func (sm *StateManager) CreateSession(
 		record.Lease = NewLeaseState(record.ClientID, sm.leaseDuration, nil)
 		record.LastRenewal = time.Now()
 
-		// Persist a durable client-recovery record (area-4 H8). v4.1 has no
+		// Persist a durable client-recovery record. v4.1 has no
 		// nfs_client_id4 string; the stable identity is co_ownerid, so the
 		// record is keyed by its string form. Best-effort under sm.mu.
 		sm.persistClientRecoveryLocked(record.ClientID, v41RecoveryKey(record.OwnerID), record.Verifier, record.Principal)

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -338,7 +338,7 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 // PropagateOpenFileParentLeaseKey copies the OpenFile's RqLs parent-lease-key
 // linkage (if any) onto an AuthContext. This is the hand-off that lets
 // MetadataService.notifyDirChange and the dir-lease parent-key suppression
-// rule (MS-SMB2 §3.3.4.20, #470 C2/C3/C5/C6/C7) skip the matching parent dir
+// rule (MS-SMB2 §3.3.4.20) skip the matching parent dir
 // lease when the originating handle's CREATE carried
 // LEASE_FLAG_PARENT_LEASE_KEY_SET. Safe to call with a nil OpenFile (no-op).
 //
@@ -347,7 +347,7 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 // does not depend on AuthContext — this helper is therefore not required on
 // that path. C3+ (rename, hardlink, overwrite, unlink) route through
 // MetadataService rename/remove/link/create, which calls notifyDirChange and
-// reads `ctx.ParentLeaseKey` / `ctx.HasParentLeaseKey`. Wave 3 PRs should
+// reads `ctx.ParentLeaseKey` / `ctx.HasParentLeaseKey`. Callers should
 // invoke this helper before issuing those metadata operations.
 func PropagateOpenFileParentLeaseKey(authCtx *metadata.AuthContext, openFile *OpenFile) {
 	if authCtx == nil || openFile == nil || !openFile.HasParentLeaseKey {

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -439,7 +439,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			} else {
 				authCtx.HasDeleteAccess = true
 
-				// Dir-lease parent-key suppression (#470 C6/C7): when the closer's
+				// Dir-lease parent-key suppression: when the closer's
 				// parent key matches the DOC-setter's parent key, use the closer's
 				// key for suppression (test_unlink_same_*). When they differ, no
 				// suppression — ALL parent dir leases break (test_unlink_different_*).
@@ -553,7 +553,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// that modified the file (WRITE occurred) breaks parent-dir leases. The
 	// WRITE itself does NOT break — only the CLOSE triggers the break so
 	// directory caching is only invalidated once the mutation is committed.
-	// Parent-key suppression (MS-SMB2 §3.3.4.20, #470 C2) applies: if the
+	// Parent-key suppression (MS-SMB2 §3.3.4.20) applies: if the
 	// closing handle carried a ParentLeaseKey matching the parent's dir lease,
 	// that lease is suppressed. Covers smb2.dirlease.v2_request: write without
 	// parent key -> close breaks dir lease; write with parent key -> close

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -603,8 +603,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// rearm (test_rearm_dirlease). Mirrors Samba's delay_for_oplock_fn
 	// running before the actual create.
 	//
-	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break,
-	// #470 C2): if this CREATE carried an RqLs with
+	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break):
+	// if this CREATE carried an RqLs with
 	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
 	// incoming request so the matching dir-lease is NOT broken.
 	//
@@ -1233,7 +1233,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// lease itself was denied (response leaseState=None) — the linkage
 	// applies regardless of the per-file grant outcome. Gated on HasParent
 	// so a zero-key request without LEASE_FLAG_PARENT_LEASE_KEY_SET is
-	// treated as "no linkage" (#470 C2).
+	// treated as "no linkage".
 	if leaseResponse != nil && leaseResponse.HasParent {
 		openFile.ParentLeaseKey = leaseResponse.ParentLeaseKey
 		openFile.HasParentLeaseKey = true

--- a/internal/adapter/smb/handlers/doc.go
+++ b/internal/adapter/smb/handlers/doc.go
@@ -1,148 +1,36 @@
-// Package handlers provides SMB2 command handlers for DittoFS.
+// Package handlers implements the SMB2/3 command handlers for DittoFS.
 //
-// # Overview
+// Each handler corresponds to an SMB2 command as defined in [MS-SMB2] and
+// translates wire-level requests into operations against the per-share
+// metadata service and block store, reached through the share registry.
 //
-// This package implements SMB2 protocol handlers for file operations,
-// session management, and tree (share) connections. Each handler corresponds
-// to an SMB2 command as defined in [MS-SMB2].
+// # Handler
 //
-// # Production Features
+// The Handler type is the central coordinator for a server's SMB2 operations.
+// Its mutable state uses sync.Map and atomic counters for lock-free concurrent
+// access across connections:
 //
-// Connection Management:
-//   - Configurable timeouts for read, write, and idle connections
-//   - Graceful shutdown with configurable timeout for draining
-//   - Automatic cleanup on connection errors or panics
+//   - SessionManager: authenticated sessions and credit tracking.
+//   - pendingAuth (sync.Map): sessions mid-NTLM-handshake.
+//   - trees (sync.Map) + nextTreeID: tree connections (mounted shares).
+//   - files (sync.Map) + nextFileID: open file handles, keyed by 16-byte FileID.
 //
-// Performance Optimization:
-//   - Per-connection parallel request handling via semaphore
-//   - Lock-free session and tree state via sync.Map
-//   - Atomic ID generation with no contention
-//   - Cache integration for read/write operations
+// # Session lifecycle
 //
-// Security:
-//   - NTLM authentication with SPNEGO wrapping
-//   - Per-share permission validation
-//   - Guest authentication fallback
-//   - Session isolation between clients
+// A client connects over TCP, negotiates a dialect (NEGOTIATE), authenticates
+// over one or two SESSION_SETUP rounds (NTLM wrapped in SPNEGO; Kerberos when
+// configured), connects to a share (TREE_CONNECT), issues file operations, and
+// finally tears down with TREE_DISCONNECT and LOGOFF. Pending authentications
+// are tracked in pendingAuth until the handshake completes or times out.
 //
-// # Handler Architecture
+// # Error handling
 //
-// The Handler type is the central coordinator for all SMB2 operations.
-// It maintains state across connections:
-//
-//	Handler
-//	├── sessions     (sync.Map)   Active authenticated sessions
-//	├── pendingAuth  (sync.Map)   Sessions mid-authentication
-//	├── trees        (sync.Map)   Tree connections (mounted shares)
-//	└── files        (sync.Map)   Open file handles
-//
-// Each SMB2 command is handled by a method on Handler:
-//
-//	Command          Handler Method       Purpose
-//	---------------  ------------------   ---------------------------
-//	NEGOTIATE        Negotiate()          Protocol negotiation
-//	SESSION_SETUP    SessionSetup()       Authentication (NTLM)
-//	LOGOFF           Logoff()             Session termination
-//	TREE_CONNECT     TreeConnect()        Mount a share
-//	TREE_DISCONNECT  TreeDisconnect()     Unmount a share
-//	CREATE           Create()             Open/create file
-//	CLOSE            Close()              Close file handle
-//	READ             Read()               Read file data
-//	WRITE            Write()              Write file data
-//	QUERY_INFO       QueryInfo()          Get file attributes
-//	QUERY_DIRECTORY  QueryDirectory()     List directory contents
-//
-// # Session Lifecycle
-//
-// Sessions track authenticated connections from clients:
-//
-//  1. Client connects (TCP)
-//  2. NEGOTIATE: Protocol version agreed
-//  3. SESSION_SETUP Round 1: Client sends NTLM NEGOTIATE
-//     → Server stores PendingAuth, returns CHALLENGE
-//  4. SESSION_SETUP Round 2: Client sends NTLM AUTHENTICATE
-//     → Server creates Session, removes PendingAuth
-//  5. TREE_CONNECT: Client mounts shares
-//  6. File operations: CREATE, READ, WRITE, etc.
-//  7. TREE_DISCONNECT: Client unmounts shares
-//  8. LOGOFF: Session terminated
-//
-// The Session struct tracks:
-//   - SessionID:  Unique identifier for the session
-//   - IsGuest:    True for guest/anonymous authentication
-//   - Username:   Authenticated username ("guest" for guest auth)
-//   - ClientAddr: Client's network address
-//   - CreatedAt:  Session creation timestamp
-//
-// # Thread Safety
-//
-// All state management uses sync.Map for lock-free concurrent access.
-// This is critical because:
-//   - Multiple goroutines handle concurrent client connections
-//   - Sessions may be accessed from different TCP connections
-//   - ID generation must be atomic across all handlers
-//
-// Atomic operations are used for ID generation:
-//   - nextSessionID: atomic.Uint64
-//   - nextTreeID:    atomic.Uint32
-//   - nextFileID:    atomic.Uint64
-//
-// # Pending Authentication
-//
-// The PendingAuth struct tracks sessions in the middle of NTLM handshake:
-//
-//	Round 1: Type 1 NEGOTIATE → Create PendingAuth → Return Type 2 CHALLENGE
-//	Round 2: Type 3 AUTHENTICATE → Validate PendingAuth → Create Session
-//
-// PendingAuth contains:
-//   - SessionID:  Temporary ID assigned during handshake
-//   - ClientAddr: Client address for validation
-//   - CreatedAt:  Timestamp for timeout purposes
-//
-// Pending authentications should be cleaned up on timeout (not currently
-// implemented) to prevent resource leaks from abandoned handshakes.
-//
-// # Tree Connections
-//
-// Tree connections represent mounted shares (similar to NFS exports):
-//
-//	Client: TREE_CONNECT \\server\sharename
-//	Server: Validates share exists, returns TreeID
-//
-// The TreeConnection struct tracks:
-//   - TreeID:    Unique identifier for this mount
-//   - SessionID: Owning session (for access control)
-//   - ShareName: Name of the mounted share
-//   - ShareType: Share type (disk, printer, IPC, etc.)
-//
-// # Open Files
-//
-// Open files track file handles created by CREATE operations:
-//
-// The OpenFile struct tracks:
-//   - FileID:       SMB2 file identifier (16 bytes)
-//   - TreeID:       Associated tree connection
-//   - SessionID:    Owning session
-//   - Path:         File path within share
-//   - ShareName:    Share name for registry lookup
-//   - IsDirectory:  True if handle is for a directory
-//
-// # Error Handling
-//
-// Handlers return NT_STATUS codes via the HandlerResult type:
-//
-//	STATUS_SUCCESS                    Operation completed
-//	STATUS_MORE_PROCESSING_REQUIRED   Continue NTLM handshake
-//	STATUS_INVALID_PARAMETER          Malformed request
-//	STATUS_USER_SESSION_DELETED       Invalid session ID
-//	STATUS_NETWORK_NAME_DELETED       Invalid tree connection
-//	STATUS_FILE_CLOSED                Invalid file handle
+// Handlers return NT_STATUS codes via HandlerResult. Store errors are mapped to
+// NT_STATUS through internal/adapter/common (errmap.go and friends) so the
+// mapping stays consistent with the NFS adapters.
 //
 // # References
 //
-//   - [MS-SMB2] Server Message Block Protocol Versions 2 and 3
-//     https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2
-//   - [MS-SMB2] Section 2.2.5 - SESSION_SETUP Request
-//   - [MS-SMB2] Section 2.2.6 - SESSION_SETUP Response
-//   - [MS-SMB2] Section 3.3.5.5 - Receiving an SMB2 SESSION_SETUP Request
+//   - [MS-SMB2] Server Message Block Protocol Versions 2 and 3:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2
 package handlers

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -239,7 +239,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 		logger.Warn("FLUSH: failed", "path", openFile.Path, "error", flushErr)
 		// FLUSH is a content-path op (same as NFS COMMIT): MapContentToSMB
 		// maps a closed-store error (the share was removed/hot-reloaded
-		// mid-flush, area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+		// mid-flush) to STATUS_FILE_CLOSED and preserves the
 		// CAS-corruption / remote-unavailable mappings, defaulting to the
 		// I/O-class status for opaque failures.
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: common.MapContentToSMB(flushErr)}}, nil

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -477,7 +477,7 @@ type OpenFile struct {
 	// Used by the dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20):
 	// SET_INFO / WRITE / CLOSE-on-delete on this handle MUST NOT break the
 	// parent dir lease whose LeaseKey matches this value. The field is
-	// meaningful only when HasParentLeaseKey is true (#470 C2).
+	// meaningful only when HasParentLeaseKey is true.
 	ParentLeaseKey    [16]byte
 	HasParentLeaseKey bool
 
@@ -1380,7 +1380,7 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
 	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
-	// suppression rule on the parent dir lease (#470 C6/C7).
+	// suppression rule on the parent dir lease.
 	PropagateOpenFileParentLeaseKey(authCtx, openFile)
 	metaSvc := h.Registry.GetMetadataService()
 

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -457,8 +457,8 @@ func (h *Handler) executeCopyChunks(
 			logger.Warn("COPYCHUNK: source read failed",
 				"chunk", i, "srcPath", srcOpen.Path, "error", err)
 			// COPYCHUNK source read is a content-path op: MapContentToSMB
-			// maps a closed-store error (source share removed mid-copy,
-			// area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+			// maps a closed-store error (source share removed
+			// mid-copy) to STATUS_FILE_CLOSED and preserves the
 			// CAS-corruption / remote-unavailable mappings, defaulting to
 			// the I/O-class status for opaque failures.
 			return copyChunkPartialResponse(ctlCode, dstFileID,
@@ -495,7 +495,7 @@ func (h *Handler) executeCopyChunks(
 				"chunk", i, "dstPath", dstOpen.Path, "error", err)
 			// COPYCHUNK destination write is a content-path op:
 			// MapContentToSMB maps a closed-store error (dest share removed
-			// mid-copy, area-7 H-A) to STATUS_FILE_CLOSED and preserves the
+			// mid-copy) to STATUS_FILE_CLOSED and preserves the
 			// CAS-corruption / remote-unavailable mappings, defaulting to
 			// the I/O-class status for opaque failures.
 			return copyChunkPartialResponse(ctlCode, dstFileID,

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -535,7 +535,7 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
-		logger.Warn("READ: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("READ: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -842,7 +842,7 @@ func (h *Handler) setFileInfoFromStore(
 		// conflicts. Stream renames don't traverse the directory layer and
 		// returned earlier above; we're past that branch here.
 		//
-		// Conflict-gated dst-parent dir-lease pre-break (#470 C3 / smbtorture
+		// Conflict-gated dst-parent dir-lease pre-break (smbtorture
 		// smb2.dirlease.rename_dst_parent, lease.c:7331): when an existing
 		// holder on dst-parent denies the implicit destructive open with
 		// SHARING_VIOLATION, the dst-parent's RH dir-lease holder must observe
@@ -1132,7 +1132,7 @@ func (h *Handler) setFileInfoFromStore(
 		openFile.ParentHandle = toDir
 		h.StoreOpenFile(openFile)
 
-		// Per MS-FSA 2.1.5.14.10 + #470 C3 (smbtorture smb2.dirlease.rename):
+		// Per MS-FSA 2.1.5.14.10 (smbtorture smb2.dirlease.rename):
 		// rename changes directory contents on BOTH source and destination
 		// parents. Break Handle + Read dir leases on each (RH → ""), honoring
 		// the renamer's ParentLeaseKey suppression from C2. Skip the dst
@@ -1228,7 +1228,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Mark file for deletion on close and record the DOC setter's
-		// parent key for unlink parent-key suppression (#470 C6/C7).
+		// parent key for unlink parent-key suppression.
 		openFile.DeletePending = deletePending
 		if deletePending {
 			openFile.DeleteOnCloseParentKey = openFile.ParentLeaseKey
@@ -1848,7 +1848,7 @@ func (h *Handler) breakParentDirLeasesForContentChange(ctx *SMBHandlerContext, a
 }
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
-// the rename branch (#470 C3): break parent directory leases to None on an
+// the rename branch: break parent directory leases to None on an
 // arbitrary directory handle (src-parent or dst-parent), honoring the
 // originating handle's ParentLeaseKey suppression from C2.
 //
@@ -1876,7 +1876,7 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 
 	parentLockHandle := lock.FileHandle(parentHandle)
 
-	// Apply parent-key suppression only (MS-SMB2 §3.3.4.20, #470 C2): if
+	// Apply parent-key suppression only (MS-SMB2 §3.3.4.20): if
 	// the originating handle's CREATE carried an RqLs with ParentLeaseKey
 	// set, the matching parent dir lease MUST NOT be broken. No ClientID
 	// exclusion — same-client breaks fire when the key doesn't match.
@@ -1990,7 +1990,7 @@ func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
 // ReplaceIfExists is FALSE; STATUS_FILE_IS_A_DIRECTORY if the open file is a
 // directory (hard-linking directories is forbidden, MS-FSA 2.1.5.14.5).
 //
-// Directory-lease coordination (#470 C5 — smb2.dirlease.hardlink): a hardlink
+// Directory-lease coordination (smb2.dirlease.hardlink): a hardlink
 // is an add-entry in the destination parent. We thread the open file's RqLs
 // ParentLeaseKey into the auth context so:
 //   - MetadataService.notifyDirChange forwards it to OnDirChange, which
@@ -2082,7 +2082,7 @@ func (h *Handler) handleFileLinkInformation(
 		}
 	}
 
-	// #470 C5: thread the open file's ParentLeaseKey into the auth context so
+	// Thread the open file's ParentLeaseKey into the auth context so
 	// MetadataService.notifyDirChange forwards it to OnDirChange and the
 	// dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20) skips the
 	// matching parent dir lease (same-key holder does not get broken).

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -519,7 +519,7 @@ func (h *Handler) handlePipeWrite(ctx *SMBHandlerContext, req *WriteRequest, ope
 	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
-		logger.Warn("WRITE: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("WRITE: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -964,7 +964,7 @@ func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
 //
 // excludeParentLeaseKey + hasExcludeKey carry the originating handle's
 // ParentLeaseKey (when set on its RqLs) so the dir-lease parent-key
-// suppression rule (MS-SMB2 §3.3.4.20, #470 C2) is applied in breakOpLocks.
+// suppression rule (MS-SMB2 §3.3.4.20) is applied in breakOpLocks.
 func (lm *LeaseManager) resolveParentBreakArgs(
 	parentHandle lock.FileHandle,
 	shareName string,
@@ -1005,7 +1005,7 @@ func (lm *LeaseManager) resolveParentBreakArgs(
 //
 // excludeParentLeaseKey + hasExcludeKey carry the originating handle's RqLs
 // ParentLeaseKey for the dir-lease parent-key suppression rule (MS-SMB2
-// §3.3.4.20, #470 C2). Pass the zero key + false when there is no parent-key
+// §3.3.4.20). Pass the zero key + false when there is no parent-key
 // linkage to honor.
 func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	ctx context.Context,
@@ -1042,7 +1042,7 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 // mask atomically — i.e. an RH parent lease must transition RH → "" via ONE
 // LEASE_BREAK_NOTIFICATION, not via the two-step (strip-H then strip-R) pattern
 // used by the non-destructive CREATE path (BreakParentHandleLeasesOnCreate +
-// BreakParentReadLeasesOnModify). smb2.dirlease.overwrite (#470 C4) asserts
+// BreakParentReadLeasesOnModify). smb2.dirlease.overwrite asserts
 // exactly two break notifications for the test scenario — one on the file
 // lease, one on the dir lease — so the two-step pattern produces three and
 // fails the test.
@@ -1050,7 +1050,7 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 // Waits for LEASE_BREAK_ACK with parentLeaseBreakWaitTimeout (same ack-wait
 // guarantee as BreakParentHandleLeasesOnCreate). excludeClientID +
 // excludeParentLeaseKey + hasExcludeKey carry the suppression rules from
-// MS-SMB2 §3.3.4.20 (#470 C2) so a same-client or parent-key-linked dir
+// MS-SMB2 §3.3.4.20 so a same-client or parent-key-linked dir
 // lease is not broken.
 func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
 	ctx context.Context,

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -44,7 +44,7 @@ type StoreCloser interface {
 // control-plane DB during graceful shutdown — without this hook the
 // normal server path (signal -> ctx cancel -> lifecycle.shutdown) would
 // call StopAllAdapters + CloseMetadataStores directly while snapshot
-// goroutines still hold references to the closing stores. D-23-17.
+// goroutines still hold references to the closing stores.
 type SnapshotDrainer interface {
 	ShutdownSnapshots(ctx context.Context)
 }
@@ -157,7 +157,7 @@ func (s *Service) SetAPIServer(server AuxiliaryServer) {
 // BEFORE StopAllAdapters + CloseMetadataStores — otherwise those
 // goroutines would race a closing metadata store / control-plane DB.
 // Pass nil to skip snapshot draining (tests that do not exercise the
-// snapshot pipeline). D-23-17 #R3-1.
+// snapshot pipeline).
 func (s *Service) Serve(
 	ctx context.Context,
 	settings SettingsInitializer,
@@ -246,7 +246,7 @@ func (s *Service) shutdown(
 	// per-snap ctx derives from it) and waits, bounded by the shutdown
 	// timeout. Orphans after the timeout will still exit on their own
 	// since runtimeCtx is already cancelled; we just may proceed before
-	// every wg.Done fires. D-23-17 #R3-1.
+	// every wg.Done fires.
 	if snapshotDrainer != nil {
 		drainCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
 		snapshotDrainer.ShutdownSnapshots(drainCtx)

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -85,9 +85,9 @@ type Runtime struct {
 	adapterProvidersMu sync.RWMutex
 
 	// snapInFlight tracks per-share in-flight snapshot orchestration
-	// goroutines so RemoveShare (plan 23-05) and Runtime.Shutdown can
+	// goroutines so RemoveShare and Runtime.Shutdown can
 	// cancel + wait before tearing down state. Keyed by share name.
-	// See pkg/controlplane/runtime/snapshot.go (Phase 23, D-23-17).
+	// See pkg/controlplane/runtime/snapshot.go.
 	snapInFlight   map[string]*snapInFlight
 	snapInFlightMu sync.Mutex
 
@@ -98,7 +98,7 @@ type Runtime struct {
 	// for that share — across multiple GC runs and the delete path —
 	// looks up the SAME mutex pointer here, so a per-instance mutex on
 	// the provider can never collude with a delete on a different
-	// provider instance. D-23-04.
+	// provider instance.
 	snapDeleteLocks   map[string]*sync.RWMutex
 	snapDeleteLocksMu sync.Mutex
 
@@ -113,10 +113,10 @@ type Runtime struct {
 	restoreLocks   map[string]*sync.Mutex
 	restoreLocksMu sync.Mutex
 
-	// runtimeCtx is a long-lived ctx cancelled by Runtime.Shutdown
-	// (plan 23-05). Snapshot orchestration goroutines derive their
+	// runtimeCtx is a long-lived ctx cancelled by Runtime.Shutdown.
+	// Snapshot orchestration goroutines derive their
 	// child ctx from this so they outlive any caller request ctx
-	// but die promptly on Runtime shutdown. D-23-17.
+	// but die promptly on Runtime shutdown.
 	runtimeCtx    context.Context
 	runtimeCancel context.CancelFunc
 
@@ -146,8 +146,8 @@ func New(s store.Store) *Runtime {
 		statusCheckers:   newCheckerCache(StatusCacheTTL),
 	}
 
-	// Long-lived ctx for snapshot orchestration goroutines (D-23-17).
-	// Cancelled by Runtime shutdown in plan 23-05.
+	// Long-lived ctx for snapshot orchestration goroutines.
+	// Cancelled by Runtime shutdown.
 	rt.runtimeCtx, rt.runtimeCancel = context.WithCancel(context.Background())
 
 	// Install the recycle-bin policy on the shared metadata service. The
@@ -186,7 +186,7 @@ func (r *Runtime) SetShutdownTimeout(d time.Duration) {
 // Shutdown drains in-flight snapshot goroutines, stops all protocol
 // adapters, and closes metadata stores in that order.
 //
-// ORDER IS LOAD-BEARING (D-23-17):
+// ORDER IS LOAD-BEARING:
 //
 //  1. shutdownSnapshots — cancel in-flight snapshot goroutines and wait.
 //     These goroutines call into Backupable.Backup (on metadata stores)
@@ -403,18 +403,18 @@ func (r *Runtime) RegisterShareForTesting(name string) {
 
 // RemoveShare removes a share. Snapshot orchestration goroutines for the
 // share are cancelled and drained BEFORE the per-share snapshots/ tree is
-// wiped (Phase 22 D-15 hook inside sharesSvc.RemoveShare) — without this
+// wiped (hook inside sharesSvc.RemoveShare) — without this
 // ordering a still-running snap goroutine could write into the
 // about-to-be-deleted directory.
 //
-// Per Phase 22 invariant (shares/service.go:776 "DB row is the source of
+// Per the invariant in shares/service.go ("DB row is the source of
 // truth"), snapshot DB rows are NOT cascade-deleted: the cancelled
-// goroutine has already flipped its row to state=failed per D-23-09 (or the
-// startup-recovery sweep in plan 23-05 / D-23-18 will), and that orphan row
+// goroutine has already flipped its row to state=failed (or the
+// startup-recovery sweep will), and that orphan row
 // is harmless because the on-disk manifest is wiped and the hold filter
-// (D-23-02) returns false once the snapshots/ tree is gone. D-23-17.
+// returns false once the snapshots/ tree is gone.
 func (r *Runtime) RemoveShare(name string) error {
-	r.cancelAndWaitInFlightSnaps(name) // D-23-17: drain BEFORE tree wipe
+	r.cancelAndWaitInFlightSnaps(name) // drain BEFORE tree wipe
 	// sharesSvc.RemoveShare now performs ordered best-effort teardown and may
 	// return an aggregated error (REVIEW M4). We must NOT early-return on it:
 	// the metadata deregistration below is what prevents the unbounded
@@ -550,11 +550,11 @@ func (r *Runtime) Serve(ctx context.Context) error {
 	// an explicit Trash().Stop() from Runtime.Shutdown.
 	r.Trash().Start(ctx)
 
-	// D-23-18: Reconcile snapshot rows abandoned by a prior crash BEFORE
+	// Reconcile snapshot rows abandoned by a prior crash BEFORE
 	// adapters start serving. Metadata stores and shares are already
 	// registered by the cmd/dfs boot sequence at this point; running
 	// recovery here means by the time the first CreateSnapshot RPC
-	// arrives, the Phase 22 D-08 partial unique index slot for any
+	// arrives, the partial unique index slot for any
 	// previously-crashed share is already released. Failure is logged
 	// but non-fatal: the operator can still serve, and DeleteSnapshot
 	// reconciles whatever rows we could not flip.
@@ -581,7 +581,7 @@ func (r *Runtime) Serve(ctx context.Context) error {
 // StopAllAdapters / CloseMetadataStores. Direct callers should prefer
 // Runtime.Shutdown which orchestrates the full sequence; this method
 // exists to satisfy lifecycle.SnapshotDrainer without exporting
-// internal lifecycle details. D-23-17 #R3-1.
+// internal lifecycle details.
 func (r *Runtime) ShutdownSnapshots(ctx context.Context) {
 	r.shutdownSnapshots(ctx)
 }
@@ -833,8 +833,8 @@ func (r *Runtime) NFSClientProvider() any { return r.GetAdapterProvider("nfs") }
 //
 // The done map keys are snapshot IDs; each chan is buffered (cap 1) and
 // receives exactly one snapResult before the goroutine closes it, so
-// WaitForSnapshot (plan 23-06) can surface the orchestration error via
-// errors.Is without consulting the DB. D-23-17.
+// WaitForSnapshot can surface the orchestration error via
+// errors.Is without consulting the DB.
 type snapInFlight struct {
 	wg sync.WaitGroup
 	// cancels is keyed by snapshot ID so completed snapshots can release
@@ -855,7 +855,7 @@ type snapInFlight struct {
 }
 
 // snapResult is sent exactly once on a snap's done channel, immediately
-// before close. nil err == success; non-nil err is wrapped per D-23-12.
+// before close. nil err == success; non-nil err is wrapped.
 type snapResult struct {
 	err error
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -912,7 +912,7 @@ func (s *Service) releaseRemoteStore(configID string) {
 // first (under the lock) so the share disappears from routing immediately;
 // the remaining steps are pure resource teardown.
 //
-// bs.Close() is now drain-safe (area-7 H-A): it takes the engine's lifecycle
+// bs.Close() is now drain-safe: it takes the engine's lifecycle
 // write lock, which blocks until all in-flight WriteAt/ReadAt/Flush ops on the
 // store have completed, so calling it here outside s.mu can no longer race a
 // client mid-transfer into a torn op or panic.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -744,8 +744,7 @@ func (r *Runtime) failSnap(shareName, snapID string, cause error) {
 //
 // Lock discipline: snapInFlightMu is held only long enough to snapshot the
 // cancel funcs + take a reference to the WaitGroup, then released BEFORE the
-// wg.Wait. Per PATTERNS.md shared-pattern §lock-protected registry: never
-// block under the registry mutex.
+// wg.Wait, so the registry mutex is never held across a blocking wait.
 func (r *Runtime) cancelAndWaitInFlightSnaps(shareName string) {
 	r.snapInFlightMu.Lock()
 	entry, ok := r.snapInFlight[shareName]

--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -22,9 +22,9 @@ import (
 // manifest hashes into the block-GC mark phase, scoped to a fixed share
 // list captured at construction time.
 //
-// D-23-02 filter: a snapshot contributes its hashes iff its on-disk
+// Filter: a snapshot contributes its hashes iff its on-disk
 // manifest.hashes file exists, regardless of state. The on-disk manifest
-// is the ground truth (Phase 22 D-04); its existence is the only fact
+// is the ground truth; its existence is the only fact
 // GC needs. This covers three windows the prior state='ready' filter
 // missed: (1) creating-post-manifest-pre-flip, (2) failed-retained-for-retry,
 // (3) failed → creating retry (same id, same dir, atomic overwrite).
@@ -40,7 +40,7 @@ import (
 // AcquireDeleteLock(shareName) Lock-s the SAME shared mutex. Because
 // every provider built for a share borrows the SAME pointer, a delete
 // arriving on a different provider instance still blocks (or is blocked
-// by) any concurrent mark. D-23-04.
+// by) any concurrent mark.
 type SnapshotHoldProvider struct {
 	rt     *Runtime
 	shares []string
@@ -55,7 +55,7 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 		return nil
 	}
 
-	// D-23-04: RLock every borrowed per-share mutex to block concurrent
+	// RLock every borrowed per-share mutex to block concurrent
 	// snapshot-delete writers from removing rows + dirs mid-stream.
 	// Locks are acquired in the construction order baked into p.locks;
 	// the delete path acquires a single share's lock at a time, so
@@ -93,7 +93,7 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 			manifestPath := snap.ManifestPath(localStoreDir)
 			if _, err := os.Stat(manifestPath); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
-					// D-23-02: no manifest = no hold. Covers
+					// No manifest = no hold. Covers
 					// pre-manifest-write creating rows and
 					// operator-deleted ready/failed manifests.
 					continue
@@ -189,12 +189,12 @@ func isTransientSharingViolation(err error) bool {
 }
 
 // AcquireDeleteLock is the write-side counterpart used by the snapshot
-// orchestration layer (Phase 23 plans 23-04/05) before invoking
+// orchestration layer before invoking
 // store.DeleteSnapshot + os.RemoveAll of the snapshot dir. Holding the
 // lock blocks new HeldHashes callers (across ALL provider instances
 // scoped to the same share) until release is invoked, so a concurrent
 // GC mark phase never observes a snapshot whose row has been removed
-// but whose manifest is still being read (or vice versa). D-23-04.
+// but whose manifest is still being read (or vice versa).
 //
 // The looked-up mutex is the SAME pointer that any concurrently-built
 // SnapshotHoldProvider would have borrowed for shareName via
@@ -235,7 +235,7 @@ func (r *Runtime) snapshotHoldForRemote(shareNames []string) engine.HoldProvider
 // thereafter so every caller for the same share name sees the SAME
 // pointer — required for AcquireDeleteLock(shareName) to actually
 // block any concurrent HeldHashes that has the corresponding RLock,
-// regardless of which provider instance constructed each. D-23-04.
+// regardless of which provider instance constructed each.
 func (r *Runtime) snapshotDeleteLock(shareName string) *sync.RWMutex {
 	r.snapDeleteLocksMu.Lock()
 	defer r.snapDeleteLocksMu.Unlock()


### PR DESCRIPTION
Cosmetic comment/log sweep across the protocol adapters and runtime. Comment- and log-level-only — no behavioral change.

## What

- **Banner/step noise (NFS v3/v4 handlers):** removed the `// ====` banner-line dividers and `// Step N:` running-narration comments. Banner-wrapped section headers collapse to a single comment; genuine WHY explanations are preserved.
- **Planning-artifact IDs (adapter + runtime):** stripped GSD/decision IDs baked into source comments — `D-23-*`, `D-04/08/15`, `ADAPT-03`, `area-4 H8`, `area-7 H-A`, `#470 C*`, `PATTERNS.md gotcha #N`, `Phases 17-24`, `plan 23-0x`, `Wave 3 PRs`. The surrounding explanation is kept; only the artifact ID is dropped. Heaviest in `runtime.go`, `common/errmap.go`, `lock_errmap.go`, `content_errmap.go`, the v4 state recovery code, and the SMB dir-lease handlers.
- **Stale docs:** rewrote `smb/handlers/doc.go` (the `Handler ├── sessions (sync.Map)` diagram referenced fields that no longer exist; sessions live in `SessionManager` now) and trimmed the prospective-design essay in `common/doc.go` down to what is actually implemented.
- **Log levels:** demoted expected hot-path lines to Debug — NFSv4.1 COMPOUND replay cache hit, and SMB READ/WRITE pipe-not-found (both return normal client-error statuses). Left `block store not available` / `failed to build auth context` at Warn (server-side / auth-failure, not clearly expected).

## Verification

- Diff is comment text plus three logger level-name changes only; every executable statement, signature, type, and control-flow line is byte-identical (the single touched code line changed only its trailing comment).
- `go build ./...`, `go vet ./internal/adapter/... ./pkg/controlplane/...`, `gofmt -l` clean.
- `go test -race ./internal/adapter/... ./pkg/controlplane/...` green.

75 files changed, 135 insertions(+), 1327 deletions(-).

Closes #1057