### PR TITLE
refactor(adapters): consumer-defined Runtime role interfaces at handler seam

### DIFF
--- a/internal/adapter/nfs/mount/handlers/mount.go
+++ b/internal/adapter/nfs/mount/handlers/mount.go
@@ -11,7 +11,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	internalxdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	xdr "github.com/rasky/go-xdr/xdr2"
 )
 
@@ -21,7 +20,7 @@ import (
 type Handler struct {
 	// Registry provides access to all stores and shares
 	// Exported to allow injection by the NFS adapter
-	Registry *runtime.Runtime
+	Registry mountRuntime
 }
 
 // MountRequest represents a MOUNT (MNT) request from an NFS client.

--- a/internal/adapter/nfs/mount/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/mount/handlers/runtime_iface.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"context"
+	"net"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// mountRuntime is the consumer-defined role interface for the MOUNT protocol
+// handlers. It lists exactly the Runtime methods this package depends on — no
+// more — so the handlers couple to the behaviour they use rather than to the
+// concrete *runtime.Runtime god-object. *runtime.Runtime satisfies it
+// implicitly (compile-time assertion below).
+type mountRuntime interface {
+	// Share + export resolution.
+	GetShare(name string) (*runtime.Share, error)
+	GetRootHandle(shareName string) (metadata.FileHandle, error)
+	ListShares() []string
+	ShareExists(name string) bool
+
+	// Per-client export access control.
+	CheckNetgroupAccess(ctx context.Context, shareName string, clientIP net.IP) (bool, error)
+
+	// Mount tracking (DUMP / UMNT / UMNTALL).
+	RecordMount(clientAddr, shareName string, mountTime int64)
+	RemoveMount(clientAddr string) bool
+	RemoveAllMounts() int
+	ListMounts() []*runtime.LegacyMountInfo
+}
+
+var _ mountRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/nfs/v3/handlers/auth_helper.go
+++ b/internal/adapter/nfs/v3/handlers/auth_helper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -44,7 +43,7 @@ func formatUID(uid *uint32) string {
 //   - error: If identity mapping fails, access is denied, or context is cancelled
 func BuildAuthContextWithMapping(
 	nfsCtx *NFSHandlerContext,
-	reg *runtime.Runtime,
+	reg nfsRuntime,
 	shareName string,
 ) (*metadata.AuthContext, error) {
 	ctx := nfsCtx.Context

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -20,7 +19,7 @@ import (
 type Handler struct {
 	// Registry provides access to all stores and shares
 	// Exported to allow injection by the NFS adapter
-	Registry *runtime.Runtime
+	Registry nfsRuntime
 
 	// authCache caches auth contexts per (share, UID, GID) to avoid
 	// repeated registry lookups on every WRITE request.

--- a/internal/adapter/nfs/v3/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v3/handlers/runtime_iface.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// nfsRuntime is the consumer-defined role interface for the NFSv3 handlers.
+// It lists exactly the Runtime methods this package depends on — no more —
+// so the handlers couple to the behaviour they use rather than to the
+// concrete *runtime.Runtime god-object. *runtime.Runtime satisfies it
+// implicitly (compile-time assertion below).
+type nfsRuntime interface {
+	// Per-share block-store resolution (used via common.ResolveFor*).
+	common.BlockStoreRegistry
+
+	// Metadata service access.
+	GetMetadataService() *metadata.Service
+
+	// Share resolution.
+	GetShare(name string) (*runtime.Share, error)
+
+	// Identity / auth.
+	GetIdentityStore() models.IdentityStore
+	ApplyIdentityMapping(shareName string, ident *metadata.Identity) (*metadata.Identity, error)
+
+	// Adapter-provided extensions (e.g. GSS processor) keyed by name.
+	GetAdapterProvider(key string) any
+}
+
+var _ nfsRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/nfs/v3/handlers/utils.go
+++ b/internal/adapter/nfs/v3/handlers/utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/mfsymlink"
 	"github.com/marmos91/dittofs/pkg/block/engine"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -29,7 +28,7 @@ var ErrMetadataServiceNotInitialized = errors.New("metadata service not initiali
 // getServicesForHandle returns both the metadata service and the per-share block store
 // resolved from the given file handle.
 // Returns an error if either service is not initialized or handle resolution fails.
-func getServicesForHandle(reg *runtime.Runtime, ctx context.Context, handle metadata.FileHandle) (*metadata.Service, *engine.Store, error) {
+func getServicesForHandle(reg nfsRuntime, ctx context.Context, handle metadata.FileHandle) (*metadata.Service, *engine.Store, error) {
 	metaSvc := reg.GetMetadataService()
 	if metaSvc == nil {
 		return nil, nil, ErrMetadataServiceNotInitialized
@@ -45,7 +44,7 @@ func getServicesForHandle(reg *runtime.Runtime, ctx context.Context, handle meta
 
 // getMetadataService returns the metadata service from the runtime.
 // Returns an error if the service is not initialized.
-func getMetadataService(reg *runtime.Runtime) (*metadata.Service, error) {
+func getMetadataService(reg nfsRuntime) (*metadata.Service, error) {
 	metaSvc := reg.GetMetadataService()
 	if metaSvc == nil {
 		return nil, ErrMetadataServiceNotInitialized
@@ -110,7 +109,7 @@ type MFsymlinkResult struct {
 // symlinks before they are converted on CLOSE.
 func checkMFsymlink(
 	ctx context.Context,
-	reg *runtime.Runtime,
+	reg nfsRuntime,
 	handle metadata.FileHandle,
 	file *metadata.File,
 ) MFsymlinkResult {
@@ -165,7 +164,7 @@ func checkMFsymlink(
 // readMFsymlinkContentForNFS reads content from the block store (uses local cache internally).
 func readMFsymlinkContentForNFS(
 	ctx context.Context,
-	reg *runtime.Runtime,
+	reg nfsRuntime,
 	handle metadata.FileHandle,
 	payloadID metadata.PayloadID,
 ) ([]byte, error) {

--- a/internal/adapter/nfs/v4/handlers/handler.go
+++ b/internal/adapter/nfs/v4/handlers/handler.go
@@ -13,7 +13,6 @@ import (
 	v41handlers "github.com/marmos91/dittofs/internal/adapter/nfs/v4/v41/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 )
 
 // OpHandler is the type signature for individual NFSv4 operation handlers.
@@ -32,7 +31,7 @@ type V41OpHandler func(ctx *types.CompoundContext, v41ctx *types.V41RequestConte
 // the opDispatchTable (v4.0) and v41DispatchTable (v4.1).
 type Handler struct {
 	// Registry provides access to all stores and shares.
-	Registry *runtime.Runtime
+	Registry nfsRuntime
 
 	// PseudoFS is the pseudo-filesystem for virtual namespace navigation.
 	PseudoFS *pseudofs.PseudoFS
@@ -85,7 +84,7 @@ type Handler struct {
 //
 // All operation handlers are initialized to return NFS4ERR_NOTSUPP except
 // for OP_ILLEGAL which returns NFS4ERR_OP_ILLEGAL.
-func NewHandler(registry *runtime.Runtime, pfs *pseudofs.PseudoFS, stateManager ...*state.StateManager) *Handler {
+func NewHandler(registry nfsRuntime, pfs *pseudofs.PseudoFS, stateManager ...*state.StateManager) *Handler {
 	var sm *state.StateManager
 	if len(stateManager) > 0 && stateManager[0] != nil {
 		sm = stateManager[0]

--- a/internal/adapter/nfs/v4/handlers/helpers_test.go
+++ b/internal/adapter/nfs/v4/handlers/helpers_test.go
@@ -212,8 +212,8 @@ func TestBuildV4AuthContext_AppliesExportSquashPolicy(t *testing.T) {
 
 	t.Run("default_permission=none denies unknown UID", func(t *testing.T) {
 		fx := newRealFSTestFixture(t, "/export")
-		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{})
-		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "none", models.SquashNone); err != nil {
+		fx.rt.SetIdentityStoreForTesting(&v4PermIdentityStore{})
+		if err := fx.rt.SetSharePolicyForTesting("/export", "none", models.SquashNone); err != nil {
 			t.Fatalf("set policy: %v", err)
 		}
 
@@ -225,10 +225,10 @@ func TestBuildV4AuthContext_AppliesExportSquashPolicy(t *testing.T) {
 
 	t.Run("SquashRootToAdmin promotes root", func(t *testing.T) {
 		fx := newRealFSTestFixture(t, "/export")
-		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{})
+		fx.rt.SetIdentityStoreForTesting(&v4PermIdentityStore{})
 		// default_permission=none would deny a non-root unknown UID, but root
 		// must be promoted, not denied.
-		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "none", models.SquashRootToAdmin); err != nil {
+		if err := fx.rt.SetSharePolicyForTesting("/export", "none", models.SquashRootToAdmin); err != nil {
 			t.Fatalf("set policy: %v", err)
 		}
 
@@ -244,12 +244,12 @@ func TestBuildV4AuthContext_AppliesExportSquashPolicy(t *testing.T) {
 	t.Run("permission=read coerces read-only", func(t *testing.T) {
 		fx := newRealFSTestFixture(t, "/export")
 		uid := uint32(1000)
-		fx.handler.Registry.SetIdentityStoreForTesting(&v4PermIdentityStore{
+		fx.rt.SetIdentityStoreForTesting(&v4PermIdentityStore{
 			knownUID: uid,
 			user:     &models.User{ID: "u1", Username: "alice", UID: &uid},
 			perm:     models.PermissionRead,
 		})
-		if err := fx.handler.Registry.SetSharePolicyForTesting("/export", "read-write", models.SquashNone); err != nil {
+		if err := fx.rt.SetSharePolicyForTesting("/export", "read-write", models.SquashNone); err != nil {
 			t.Fatalf("set policy: %v", err)
 		}
 

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -25,6 +25,7 @@ import (
 // realFSTestFixture holds state for real-FS handler tests.
 type realFSTestFixture struct {
 	handler    *Handler
+	rt         *runtime.Runtime
 	metaSvc    *metadata.Service
 	store      metadata.Store
 	rootHandle metadata.FileHandle
@@ -95,6 +96,7 @@ func newRealFSTestFixture(t *testing.T, shareName string) *realFSTestFixture {
 
 	return &realFSTestFixture{
 		handler:    handler,
+		rt:         rt,
 		metaSvc:    metaSvc,
 		store:      store,
 		rootHandle: rootHandle,

--- a/internal/adapter/nfs/v4/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v4/handlers/runtime_iface.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// nfsRuntime is the consumer-defined role interface for the NFSv4 handlers.
+// It lists exactly the Runtime methods this package depends on — no more —
+// so the handlers couple to the behaviour they use rather than to the
+// concrete *runtime.Runtime god-object. *runtime.Runtime satisfies it
+// implicitly (compile-time assertion below).
+//
+// It is kept separate from the NFSv3 interface because the two protocols use
+// overlapping but distinct method sets (v4 needs root-handle resolution,
+// handle→share routing and live settings; v3 needs the adapter-provider hook).
+type nfsRuntime interface {
+	// Per-share block-store resolution (used via common.ResolveFor*).
+	common.BlockStoreRegistry
+
+	// Metadata service access.
+	GetMetadataService() *metadata.Service
+
+	// Share + handle resolution.
+	GetShare(name string) (*runtime.Share, error)
+	GetRootHandle(shareName string) (metadata.FileHandle, error)
+	GetShareNameForHandle(ctx context.Context, handle metadata.FileHandle) (string, error)
+
+	// Identity / auth.
+	GetIdentityStore() models.IdentityStore
+	ApplyIdentityMapping(shareName string, ident *metadata.Identity) (*metadata.Identity, error)
+
+	// Live NFS adapter settings (blocked-operation gating).
+	GetNFSSettings() *models.NFSAdapterSettings
+}
+
+var _ nfsRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -32,7 +31,7 @@ import (
 // and uses SessionManager for unified session/credit tracking.
 // Thread-safe: all mutable state uses sync.Map or atomic operations.
 type Handler struct {
-	Registry  *runtime.Runtime
+	Registry  smbRuntime
 	StartTime time.Time
 
 	// Server identity

--- a/internal/adapter/smb/handlers/runtime_iface.go
+++ b/internal/adapter/smb/handlers/runtime_iface.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// smbRuntime is the consumer-defined role interface for the SMB handlers.
+// It lists exactly the Runtime methods this package depends on — no more —
+// so the handlers couple to the behaviour they use rather than to the
+// concrete *runtime.Runtime god-object. *runtime.Runtime satisfies it
+// implicitly (compile-time assertion below).
+type smbRuntime interface {
+	// Per-share block-store resolution (used via common.ResolveFor* and
+	// directly for FLUSH / copychunk / scavenger paths).
+	common.BlockStoreRegistry
+
+	// Metadata service access.
+	GetMetadataService() *metadata.Service
+
+	// Share + handle resolution.
+	GetShare(name string) (*runtime.Share, error)
+	GetRootHandle(shareName string) (metadata.FileHandle, error)
+	ListShares() []string
+
+	// Share-change notification (tree-connect cache invalidation).
+	OnShareChange(callback func(shares []string)) func()
+
+	// Identity / auth backends.
+	GetUserStore() models.UserStore
+	GetIdentityMappingStore() store.IdentityMappingStore
+}
+
+var _ smbRuntime = (*runtime.Runtime)(nil)

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -479,7 +479,10 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 
 	// Wire identity resolver if runtime is already injected (SetRuntime may
 	// have been called before SetKerberosProvider depending on init order).
-	s.wireIdentityResolver(s.handler.Registry)
+	// Use the adapter's concrete runtime (same object set on handler.Registry)
+	// since identity-resolver wiring is an adapter-layer concern that needs
+	// methods outside the handler's narrow smbRuntime role interface.
+	s.wireIdentityResolver(s.Registry)
 
 	logger.Debug("SMB adapter Kerberos provider configured",
 		"principal", provider.ServicePrincipal(),


### PR DESCRIPTION
## Phase-5 of the handler refactor: introduce a consumer-defined interface seam at the adapter↔Runtime boundary.

Partially addresses #1059 (role-interface seam done; moving the 3 *ForTesting methods off the prod Runtime type tracked as remaining follow-up)

### Problem
`pkg/controlplane/runtime/runtime.go` defines `Runtime` as a concrete ~114-method struct, and every NFS + SMB handler couples directly to `*runtime.Runtime` (struct fields, constructor params, helper signatures). There was no interface seam — handlers saw the entire god-object.

### Change (accept interfaces, consumer-defined)
One narrow **role interface per protocol-handler package**, each containing *exactly* the Runtime methods that package calls:

| package | interface | methods |
|---|---|---|
| `internal/adapter/nfs/v3/handlers` | `nfsRuntime` | 6 (incl. embedded `common.BlockStoreRegistry`) |
| `internal/adapter/nfs/v4/handlers` | `nfsRuntime` | 8 (incl. embedded `common.BlockStoreRegistry`) |
| `internal/adapter/smb/handlers` | `smbRuntime` | 9 (incl. embedded `common.BlockStoreRegistry`) |
| `internal/adapter/nfs/mount/handlers` | `mountRuntime` | 9 |

Each lives in a `runtime_iface.go` in the consumer package with a compile-time assertion `var _ <iface> = (*runtime.Runtime)(nil)`. Handler dependency types now point at the interface; `*runtime.Runtime` satisfies each implicitly. This extends the pre-existing `common.BlockStoreRegistry` seam, which the NFS/SMB interfaces embed.

v3 and v4 are kept **separate** (overlapping but distinct method sets — v3 needs `GetAdapterProvider`; v4 needs root-handle/handle-routing/live-settings), per the issue's guidance.

### Out of scope, by design
- **v4.1 handlers** call zero Runtime methods → no interface added.
- **NLM dispatch** only threads an *unused* `reg` parameter (calls nothing) → left untouched; inventing an empty interface would be speculative-seam debt.

### `*ForTesting` methods
The 5 `*ForTesting` methods on `*Runtime` stay on the concrete type: they access unexported runtime state and are invoked from **cross-package adapter tests**, so they cannot be relocated to a build-tagged/`_test.go` helper. They appear in **no** role interface, so handlers cannot reach test-only mutators through the seam — the load-bearing requirement.

### Scope discipline
Pure interface-extraction + dependency-type-swap. **Zero behavioural change**; no method bodies touched. One adapter-layer call site (`pkg/adapter/smb/adapter.go`) was repointed to pass the adapter's concrete `s.Registry` to `wireIdentityResolver` (which needs methods outside the handler's narrow role).

### Gates
- `go build ./...` ✅  `go vet ./...` ✅  `gofmt -l` empty ✅
- `go test -race ./internal/adapter/... ./pkg/controlplane/...` ✅
- `go test ./pkg/adapter/...` ✅