### PR TITLE
fix(smb): remediate v1.0 audit SMB findings (#1076)

### DIFF
--- a/internal/adapter/smb/auth/authenticator.go
+++ b/internal/adapter/smb/auth/authenticator.go
@@ -275,7 +275,7 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		})
 
 		var sessionKey [16]byte
-		var validationErr error = errors.New("ntlm: authentication failed")
+		validationErr := errors.New("ntlm: authentication failed")
 		for _, domain := range domainsToTry {
 			sessionKey, validationErr = ValidateNTLMv2Response(
 				ntHash,

--- a/internal/adapter/smb/auth/authenticator.go
+++ b/internal/adapter/smb/auth/authenticator.go
@@ -30,43 +30,6 @@ const (
 	maxPendingAuths = 1000
 )
 
-// pendingAuthKey correlates the NTLM NEGOTIATE and AUTHENTICATE rounds of a
-// single handshake. It mirrors the handler-layer key (see handler.go): parallel
-// binds on the same session from different connections must not clobber each
-// other, so both the session ID and connection ID participate in the key.
-type pendingAuthKey struct {
-	sessionID uint64
-	connID    uint64
-}
-
-type ctxKeySessionID struct{}
-
-type ctxKeyConnID struct{}
-
-// WithSessionID returns a context carrying the SMB session ID used to correlate
-// the NTLM NEGOTIATE and AUTHENTICATE rounds of a single handshake. Both calls
-// for the same exchange must carry the same value.
-func WithSessionID(parent context.Context, id uint64) context.Context {
-	return context.WithValue(parent, ctxKeySessionID{}, id)
-}
-
-// WithConnID returns a context carrying the TCP connection ID used to correlate
-// the NTLM NEGOTIATE and AUTHENTICATE rounds of a single handshake. Both calls
-// for the same exchange must carry the same value.
-func WithConnID(parent context.Context, id uint64) context.Context {
-	return context.WithValue(parent, ctxKeyConnID{}, id)
-}
-
-func sessionIDFromCtx(ctx context.Context) uint64 {
-	v, _ := ctx.Value(ctxKeySessionID{}).(uint64)
-	return v
-}
-
-func connIDFromCtx(ctx context.Context) uint64 {
-	v, _ := ctx.Value(ctxKeyConnID{}).(uint64)
-	return v
-}
-
 // SMBAuthenticator implements adapter.Authenticator for SMB protocol authentication.
 //
 // It handles SPNEGO-wrapped tokens, detecting whether the client is using NTLM
@@ -85,12 +48,10 @@ type SMBAuthenticator struct {
 	userStore models.UserStore
 
 	// pendingAuths tracks in-progress NTLM handshakes.
-	// Key: pendingAuthKey{sessionID, connID}, Value: *pendingNTLMAuth
+	// Key: session ID (uint64), Value: *pendingNTLMAuth
 	pendingAuths sync.Map
 
-	// nextSessionID generates a fallback session ID when the caller does not
-	// inject one via WithSessionID. The atomic counter guarantees uniqueness so
-	// concurrent fallback negotiations cannot collide.
+	// nextSessionID generates unique session IDs for tracking auth rounds.
 	nextSessionID atomic.Uint64
 }
 
@@ -179,7 +140,7 @@ func (a *SMBAuthenticator) handleNTLMToken(ctx context.Context, ntlmToken []byte
 
 	switch msgType {
 	case Negotiate:
-		return a.handleNTLMNegotiate(ctx, wrapSPNEGO)
+		return a.handleNTLMNegotiate(wrapSPNEGO)
 
 	case Authenticate:
 		return a.handleNTLMAuthenticate(ctx, ntlmToken)
@@ -191,22 +152,16 @@ func (a *SMBAuthenticator) handleNTLMToken(ctx context.Context, ntlmToken []byte
 
 // handleNTLMNegotiate processes an NTLM Type 1 (NEGOTIATE) message.
 // Returns a Type 2 (CHALLENGE) message with ErrMoreProcessingRequired.
-func (a *SMBAuthenticator) handleNTLMNegotiate(ctx context.Context, wrapSPNEGO bool) (*adapter.AuthResult, []byte, error) {
+func (a *SMBAuthenticator) handleNTLMNegotiate(wrapSPNEGO bool) (*adapter.AuthResult, []byte, error) {
 	// Evict stale pending auths before adding a new one
 	a.evictStalePendingAuths()
 
 	// Build challenge
 	challengeMsg, serverChallenge := BuildChallenge()
 
-	// Correlate this handshake by (sessionID, connID). Callers thread these via
-	// WithSessionID/WithConnID. If no session ID was injected, fall back to a
-	// unique counter value so concurrent fallback negotiations cannot collide.
-	sessionID := sessionIDFromCtx(ctx)
-	if sessionID == 0 {
-		sessionID = a.nextSessionID.Add(1)
-	}
-	key := pendingAuthKey{sessionID: sessionID, connID: connIDFromCtx(ctx)}
-	a.pendingAuths.Store(key, &pendingNTLMAuth{
+	// Generate session ID and store pending auth
+	sessionID := a.nextSessionID.Add(1)
+	a.pendingAuths.Store(sessionID, &pendingNTLMAuth{
 		serverChallenge: serverChallenge,
 		createdAt:       time.Now(),
 	})
@@ -251,53 +206,24 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		return &adapter.AuthResult{IsGuest: true}, nil, nil
 	}
 
-	// Try NTLMv2 validation against this session's pending challenge only.
+	// Try NTLMv2 validation against all pending auths
 	ntHash, hasNTHash := user.GetNTHash()
 	if hasNTHash && len(authMsg.NtChallengeResponse) > 0 {
-		// Look up the pending challenge stored for this exact (sessionID, connID)
-		// pair. A direct lookup makes cross-session validation impossible: a
-		// Type-3 from another session cannot match a challenge stored under a
-		// different key.
-		key := pendingAuthKey{sessionID: sessionIDFromCtx(ctx), connID: connIDFromCtx(ctx)}
-		v, ok := a.pendingAuths.Load(key)
-		if !ok {
-			return nil, nil, errors.New("ntlm: no pending authentication for session")
-		}
-		pending := v.(*pendingNTLMAuth)
-		a.pendingAuths.Delete(key) // consume the challenge
+		sessionKey, pending, matchedID := a.validateAgainstPendingAuths(ntHash, authMsg)
+		if pending != nil {
+			// Derive signing key
+			signingKey := DeriveSigningKey(sessionKey, authMsg.NegotiateFlags, authMsg.EncryptedRandomSessionKey)
+			a.cleanupPendingAuth(matchedID)
 
-		hostname, _ := os.Hostname()
-		domainsToTry := uniqueStrings([]string{
-			authMsg.Domain,
-			"",
-			strings.ToUpper(hostname),
-			"WORKGROUP",
-		})
-
-		var sessionKey [16]byte
-		var validationErr error = errors.New("ntlm: authentication failed")
-		for _, domain := range domainsToTry {
-			sessionKey, validationErr = ValidateNTLMv2Response(
-				ntHash,
-				authMsg.Username,
-				domain,
-				pending.serverChallenge,
-				authMsg.NtChallengeResponse,
-			)
-			if validationErr == nil {
-				break
-			}
-		}
-		if validationErr != nil {
-			return nil, nil, errors.New("ntlm: authentication failed")
+			return &adapter.AuthResult{
+				User:       user,
+				SessionKey: signingKey[:],
+				IsGuest:    false,
+			}, nil, nil
 		}
 
-		signingKey := DeriveSigningKey(sessionKey, authMsg.NegotiateFlags, authMsg.EncryptedRandomSessionKey)
-		return &adapter.AuthResult{
-			User:       user,
-			SessionKey: signingKey[:],
-			IsGuest:    false,
-		}, nil, nil
+		// Validation failed - no matching pending auth found
+		return nil, nil, errors.New("ntlm: authentication failed")
 	}
 
 	// User exists but no NT hash - allow without credential validation
@@ -305,6 +231,56 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		User:    user,
 		IsGuest: false,
 	}, nil, nil
+}
+
+// validateAgainstPendingAuths tries to validate the NTLM response against
+// all pending authentication challenges. Returns the session key, the
+// matching pending auth, and the matched session ID on success.
+// On failure, returns zero values and matchedID 0.
+func (a *SMBAuthenticator) validateAgainstPendingAuths(
+	ntHash [16]byte,
+	authMsg *AuthenticateMessage,
+) ([16]byte, *pendingNTLMAuth, uint64) {
+	hostname, _ := os.Hostname()
+	domainsToTry := uniqueStrings([]string{
+		authMsg.Domain,
+		"",
+		strings.ToUpper(hostname),
+		"WORKGROUP",
+	})
+
+	var resultKey [16]byte
+	var matchedPending *pendingNTLMAuth
+	var matchedID uint64
+
+	a.pendingAuths.Range(func(key, value any) bool {
+		pending := value.(*pendingNTLMAuth)
+
+		for _, domain := range domainsToTry {
+			sessionKey, err := ValidateNTLMv2Response(
+				ntHash,
+				authMsg.Username,
+				domain,
+				pending.serverChallenge,
+				authMsg.NtChallengeResponse,
+			)
+			if err == nil {
+				resultKey = sessionKey
+				matchedPending = pending
+				matchedID = key.(uint64)
+				return false // stop iteration
+			}
+		}
+		return true // continue
+	})
+
+	return resultKey, matchedPending, matchedID
+}
+
+// cleanupPendingAuth removes the pending auth entry for the given session ID.
+// Only deletes the specific entry to avoid breaking concurrent handshakes.
+func (a *SMBAuthenticator) cleanupPendingAuth(sessionID uint64) {
+	a.pendingAuths.Delete(sessionID)
 }
 
 // evictStalePendingAuths removes expired entries and enforces the max count.

--- a/internal/adapter/smb/auth/authenticator.go
+++ b/internal/adapter/smb/auth/authenticator.go
@@ -30,6 +30,43 @@ const (
 	maxPendingAuths = 1000
 )
 
+// pendingAuthKey correlates the NTLM NEGOTIATE and AUTHENTICATE rounds of a
+// single handshake. It mirrors the handler-layer key (see handler.go): parallel
+// binds on the same session from different connections must not clobber each
+// other, so both the session ID and connection ID participate in the key.
+type pendingAuthKey struct {
+	sessionID uint64
+	connID    uint64
+}
+
+type ctxKeySessionID struct{}
+
+type ctxKeyConnID struct{}
+
+// WithSessionID returns a context carrying the SMB session ID used to correlate
+// the NTLM NEGOTIATE and AUTHENTICATE rounds of a single handshake. Both calls
+// for the same exchange must carry the same value.
+func WithSessionID(parent context.Context, id uint64) context.Context {
+	return context.WithValue(parent, ctxKeySessionID{}, id)
+}
+
+// WithConnID returns a context carrying the TCP connection ID used to correlate
+// the NTLM NEGOTIATE and AUTHENTICATE rounds of a single handshake. Both calls
+// for the same exchange must carry the same value.
+func WithConnID(parent context.Context, id uint64) context.Context {
+	return context.WithValue(parent, ctxKeyConnID{}, id)
+}
+
+func sessionIDFromCtx(ctx context.Context) uint64 {
+	v, _ := ctx.Value(ctxKeySessionID{}).(uint64)
+	return v
+}
+
+func connIDFromCtx(ctx context.Context) uint64 {
+	v, _ := ctx.Value(ctxKeyConnID{}).(uint64)
+	return v
+}
+
 // SMBAuthenticator implements adapter.Authenticator for SMB protocol authentication.
 //
 // It handles SPNEGO-wrapped tokens, detecting whether the client is using NTLM
@@ -48,10 +85,12 @@ type SMBAuthenticator struct {
 	userStore models.UserStore
 
 	// pendingAuths tracks in-progress NTLM handshakes.
-	// Key: session ID (uint64), Value: *pendingNTLMAuth
+	// Key: pendingAuthKey{sessionID, connID}, Value: *pendingNTLMAuth
 	pendingAuths sync.Map
 
-	// nextSessionID generates unique session IDs for tracking auth rounds.
+	// nextSessionID generates a fallback session ID when the caller does not
+	// inject one via WithSessionID. The atomic counter guarantees uniqueness so
+	// concurrent fallback negotiations cannot collide.
 	nextSessionID atomic.Uint64
 }
 
@@ -140,7 +179,7 @@ func (a *SMBAuthenticator) handleNTLMToken(ctx context.Context, ntlmToken []byte
 
 	switch msgType {
 	case Negotiate:
-		return a.handleNTLMNegotiate(wrapSPNEGO)
+		return a.handleNTLMNegotiate(ctx, wrapSPNEGO)
 
 	case Authenticate:
 		return a.handleNTLMAuthenticate(ctx, ntlmToken)
@@ -152,16 +191,22 @@ func (a *SMBAuthenticator) handleNTLMToken(ctx context.Context, ntlmToken []byte
 
 // handleNTLMNegotiate processes an NTLM Type 1 (NEGOTIATE) message.
 // Returns a Type 2 (CHALLENGE) message with ErrMoreProcessingRequired.
-func (a *SMBAuthenticator) handleNTLMNegotiate(wrapSPNEGO bool) (*adapter.AuthResult, []byte, error) {
+func (a *SMBAuthenticator) handleNTLMNegotiate(ctx context.Context, wrapSPNEGO bool) (*adapter.AuthResult, []byte, error) {
 	// Evict stale pending auths before adding a new one
 	a.evictStalePendingAuths()
 
 	// Build challenge
 	challengeMsg, serverChallenge := BuildChallenge()
 
-	// Generate session ID and store pending auth
-	sessionID := a.nextSessionID.Add(1)
-	a.pendingAuths.Store(sessionID, &pendingNTLMAuth{
+	// Correlate this handshake by (sessionID, connID). Callers thread these via
+	// WithSessionID/WithConnID. If no session ID was injected, fall back to a
+	// unique counter value so concurrent fallback negotiations cannot collide.
+	sessionID := sessionIDFromCtx(ctx)
+	if sessionID == 0 {
+		sessionID = a.nextSessionID.Add(1)
+	}
+	key := pendingAuthKey{sessionID: sessionID, connID: connIDFromCtx(ctx)}
+	a.pendingAuths.Store(key, &pendingNTLMAuth{
 		serverChallenge: serverChallenge,
 		createdAt:       time.Now(),
 	})
@@ -206,24 +251,53 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		return &adapter.AuthResult{IsGuest: true}, nil, nil
 	}
 
-	// Try NTLMv2 validation against all pending auths
+	// Try NTLMv2 validation against this session's pending challenge only.
 	ntHash, hasNTHash := user.GetNTHash()
 	if hasNTHash && len(authMsg.NtChallengeResponse) > 0 {
-		sessionKey, pending, matchedID := a.validateAgainstPendingAuths(ntHash, authMsg)
-		if pending != nil {
-			// Derive signing key
-			signingKey := DeriveSigningKey(sessionKey, authMsg.NegotiateFlags, authMsg.EncryptedRandomSessionKey)
-			a.cleanupPendingAuth(matchedID)
+		// Look up the pending challenge stored for this exact (sessionID, connID)
+		// pair. A direct lookup makes cross-session validation impossible: a
+		// Type-3 from another session cannot match a challenge stored under a
+		// different key.
+		key := pendingAuthKey{sessionID: sessionIDFromCtx(ctx), connID: connIDFromCtx(ctx)}
+		v, ok := a.pendingAuths.Load(key)
+		if !ok {
+			return nil, nil, errors.New("ntlm: no pending authentication for session")
+		}
+		pending := v.(*pendingNTLMAuth)
+		a.pendingAuths.Delete(key) // consume the challenge
 
-			return &adapter.AuthResult{
-				User:       user,
-				SessionKey: signingKey[:],
-				IsGuest:    false,
-			}, nil, nil
+		hostname, _ := os.Hostname()
+		domainsToTry := uniqueStrings([]string{
+			authMsg.Domain,
+			"",
+			strings.ToUpper(hostname),
+			"WORKGROUP",
+		})
+
+		var sessionKey [16]byte
+		var validationErr error = errors.New("ntlm: authentication failed")
+		for _, domain := range domainsToTry {
+			sessionKey, validationErr = ValidateNTLMv2Response(
+				ntHash,
+				authMsg.Username,
+				domain,
+				pending.serverChallenge,
+				authMsg.NtChallengeResponse,
+			)
+			if validationErr == nil {
+				break
+			}
+		}
+		if validationErr != nil {
+			return nil, nil, errors.New("ntlm: authentication failed")
 		}
 
-		// Validation failed - no matching pending auth found
-		return nil, nil, errors.New("ntlm: authentication failed")
+		signingKey := DeriveSigningKey(sessionKey, authMsg.NegotiateFlags, authMsg.EncryptedRandomSessionKey)
+		return &adapter.AuthResult{
+			User:       user,
+			SessionKey: signingKey[:],
+			IsGuest:    false,
+		}, nil, nil
 	}
 
 	// User exists but no NT hash - allow without credential validation
@@ -231,56 +305,6 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		User:    user,
 		IsGuest: false,
 	}, nil, nil
-}
-
-// validateAgainstPendingAuths tries to validate the NTLM response against
-// all pending authentication challenges. Returns the session key, the
-// matching pending auth, and the matched session ID on success.
-// On failure, returns zero values and matchedID 0.
-func (a *SMBAuthenticator) validateAgainstPendingAuths(
-	ntHash [16]byte,
-	authMsg *AuthenticateMessage,
-) ([16]byte, *pendingNTLMAuth, uint64) {
-	hostname, _ := os.Hostname()
-	domainsToTry := uniqueStrings([]string{
-		authMsg.Domain,
-		"",
-		strings.ToUpper(hostname),
-		"WORKGROUP",
-	})
-
-	var resultKey [16]byte
-	var matchedPending *pendingNTLMAuth
-	var matchedID uint64
-
-	a.pendingAuths.Range(func(key, value any) bool {
-		pending := value.(*pendingNTLMAuth)
-
-		for _, domain := range domainsToTry {
-			sessionKey, err := ValidateNTLMv2Response(
-				ntHash,
-				authMsg.Username,
-				domain,
-				pending.serverChallenge,
-				authMsg.NtChallengeResponse,
-			)
-			if err == nil {
-				resultKey = sessionKey
-				matchedPending = pending
-				matchedID = key.(uint64)
-				return false // stop iteration
-			}
-		}
-		return true // continue
-	})
-
-	return resultKey, matchedPending, matchedID
-}
-
-// cleanupPendingAuth removes the pending auth entry for the given session ID.
-// Only deletes the specific entry to avoid breaking concurrent handshakes.
-func (a *SMBAuthenticator) cleanupPendingAuth(sessionID uint64) {
-	a.pendingAuths.Delete(sessionID)
 }
 
 // evictStalePendingAuths removes expired entries and enforces the max count.

--- a/internal/adapter/smb/auth/authenticator.go
+++ b/internal/adapter/smb/auth/authenticator.go
@@ -275,7 +275,7 @@ func (a *SMBAuthenticator) handleNTLMAuthenticate(ctx context.Context, ntlmToken
 		})
 
 		var sessionKey [16]byte
-		validationErr := errors.New("ntlm: authentication failed")
+		var validationErr error = errors.New("ntlm: authentication failed")
 		for _, domain := range domainsToTry {
 			sessionKey, validationErr = ValidateNTLMv2Response(
 				ntHash,

--- a/internal/adapter/smb/auth/authenticator_test.go
+++ b/internal/adapter/smb/auth/authenticator_test.go
@@ -178,12 +178,9 @@ func TestSMBAuthenticator_Authenticate_NTLMNegotiate_ReturnsChallenge(t *testing
 func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_GuestNoStore(t *testing.T) {
 	auth := NewSMBAuthenticator(nil)
 
-	// Same session/conn identity must be threaded through both rounds.
-	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
-
 	// Round 1: NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, challenge, err := auth.Authenticate(ctx, negotiate)
+	_, challenge, err := auth.Authenticate(context.Background(), negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("round 1: expected ErrMoreProcessingRequired, got: %v", err)
 	}
@@ -193,7 +190,7 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_GuestNoStore(t *testing
 
 	// Round 2: AUTHENTICATE with a username (no user store -> guest)
 	authenticate := buildNTLMAuthenticate("testuser", "WORKGROUP")
-	result, _, err := auth.Authenticate(ctx, authenticate)
+	result, _, err := auth.Authenticate(context.Background(), authenticate)
 	if err != nil {
 		t.Fatalf("round 2: unexpected error: %v", err)
 	}
@@ -218,12 +215,9 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_WithUser(t *testing.T) 
 
 	auth := NewSMBAuthenticator(store)
 
-	// Same session/conn identity must be threaded through both rounds.
-	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
-
 	// Round 1: NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, challenge, err := auth.Authenticate(ctx, negotiate)
+	_, challenge, err := auth.Authenticate(context.Background(), negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("round 1: expected ErrMoreProcessingRequired, got: %v", err)
 	}
@@ -233,7 +227,7 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_WithUser(t *testing.T) 
 
 	// Round 2: AUTHENTICATE with known username (no NT hash on user -> auth without validation)
 	authenticate := buildNTLMAuthenticate("alice", "WORKGROUP")
-	result, _, err := auth.Authenticate(ctx, authenticate)
+	result, _, err := auth.Authenticate(context.Background(), authenticate)
 	if err != nil {
 		t.Fatalf("round 2: unexpected error: %v", err)
 	}
@@ -255,18 +249,16 @@ func TestSMBAuthenticator_Authenticate_AnonymousNTLM(t *testing.T) {
 	store := newMockUserStore()
 	auth := NewSMBAuthenticator(store)
 
-	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
-
 	// NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, _, err := auth.Authenticate(ctx, negotiate)
+	_, _, err := auth.Authenticate(context.Background(), negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("expected ErrMoreProcessingRequired, got: %v", err)
 	}
 
 	// AUTHENTICATE with empty username (anonymous)
 	authenticate := buildNTLMAuthenticate("", "")
-	result, _, err := auth.Authenticate(ctx, authenticate)
+	result, _, err := auth.Authenticate(context.Background(), authenticate)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,152 +280,19 @@ func TestSMBAuthenticator_Authenticate_DisabledUser(t *testing.T) {
 
 	auth := NewSMBAuthenticator(store)
 
-	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
-
 	// NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, _, _ = auth.Authenticate(ctx, negotiate)
+	_, _, _ = auth.Authenticate(context.Background(), negotiate)
 
 	// AUTHENTICATE with disabled user
 	authenticate := buildNTLMAuthenticate("disabled", "WORKGROUP")
-	result, _, err := auth.Authenticate(ctx, authenticate)
+	result, _, err := auth.Authenticate(context.Background(), authenticate)
 	if err == nil {
 		t.Fatal("expected error for disabled user")
 	}
 	if result != nil {
 		t.Error("expected nil result for disabled user")
 	}
-}
-
-// TestSMBAuthenticator_CrossSessionChallenge_Rejected verifies that a Type-3
-// AUTHENTICATE message is validated only against the pending challenge stored
-// for its own (sessionID, connID) pair.
-//
-// Before the fix, handleNTLMAuthenticate ranged ALL pending entries, so a
-// Type-3 built against session A's challenge could be replayed under a
-// different session B and still authenticate against session A's stored
-// challenge. The test builds a genuinely valid NTLMv2 response for session A's
-// challenge, then submits it under session B's context: after the fix the
-// direct (sessionID, connID) lookup misses and the attempt is rejected.
-func TestSMBAuthenticator_CrossSessionChallenge_Rejected(t *testing.T) {
-	const (
-		password = "test123"
-		username = "alice"
-		domain   = "WORKGROUP"
-	)
-
-	store := newMockUserStore()
-	user := &models.User{ID: "alice-id", Username: username, Enabled: true}
-	user.SetNTHashFromPassword(password)
-	store.addUser(user)
-
-	auth := NewSMBAuthenticator(store)
-
-	// Session A: NEGOTIATE. Capture the server challenge from the returned Type-2.
-	ctxA := WithSessionID(WithConnID(context.Background(), 1), 10)
-	_, challenge, err := auth.Authenticate(ctxA, buildNTLMNegotiate())
-	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
-		t.Fatalf("session A negotiate: expected ErrMoreProcessingRequired, got %v", err)
-	}
-	var serverChallenge [8]byte
-	copy(serverChallenge[:], challenge[24:32]) // Type-2 ServerChallenge offset
-
-	// Build a genuinely valid Type-3 AUTHENTICATE for session A's challenge.
-	validAuth := buildValidNTLMAuthenticate(password, username, domain, serverChallenge)
-
-	// Sanity: the response really is valid for session A (proves the attack is
-	// only blocked by session correlation, not by an invalid response).
-	resA, _, errA := auth.Authenticate(ctxA, validAuth)
-	if errA != nil {
-		t.Fatalf("session A authenticate with valid response should succeed, got %v", errA)
-	}
-	if resA == nil || resA.IsGuest || resA.User == nil || resA.User.Username != username {
-		t.Fatalf("session A authenticate: expected authenticated user %q, got %+v", username, resA)
-	}
-
-	// Re-negotiate session A so a fresh pending challenge exists for the replay.
-	_, challenge2, err := auth.Authenticate(ctxA, buildNTLMNegotiate())
-	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
-		t.Fatalf("session A re-negotiate: expected ErrMoreProcessingRequired, got %v", err)
-	}
-	var serverChallenge2 [8]byte
-	copy(serverChallenge2[:], challenge2[24:32])
-	validAuth2 := buildValidNTLMAuthenticate(password, username, domain, serverChallenge2)
-
-	// Session B: replay session A's valid Type-3 under a DIFFERENT (sessionID,
-	// connID). Session B never sent a NEGOTIATE, so it has no pending challenge.
-	ctxB := WithSessionID(WithConnID(context.Background(), 2), 20)
-	resB, challengeB, errB := auth.Authenticate(ctxB, validAuth2)
-	if errB == nil {
-		t.Fatal("cross-session authenticate should fail: got nil error")
-	}
-	if resB != nil {
-		t.Errorf("cross-session authenticate should return nil result, got %+v", resB)
-	}
-	if challengeB != nil {
-		t.Errorf("cross-session authenticate should return nil challenge, got %x", challengeB)
-	}
-
-	// Session A's pending entry must survive session B's attempt: session A can
-	// still complete its own handshake.
-	resA2, _, errA2 := auth.Authenticate(ctxA, validAuth2)
-	if errA2 != nil {
-		t.Fatalf("session A's own handshake should still succeed after B's attempt, got %v", errA2)
-	}
-	if resA2 == nil || resA2.IsGuest {
-		t.Fatalf("session A authenticate: expected authenticated user, got %+v", resA2)
-	}
-}
-
-// buildValidNTLMAuthenticate constructs a complete NTLM Type-3 (AUTHENTICATE)
-// message carrying a valid NTLMv2 response for the given server challenge.
-func buildValidNTLMAuthenticate(password, username, domain string, serverChallenge [8]byte) []byte {
-	ntHash := ComputeNTHash(password)
-	clientBlob := buildTestClientBlob()
-	ntlmv2Hash := ComputeNTLMv2Hash(ntHash, username, domain)
-	ntProofStr := computeNTProofStr(ntlmv2Hash, serverChallenge, clientBlob)
-
-	ntResponse := make([]byte, len(ntProofStr)+len(clientBlob))
-	copy(ntResponse[:16], ntProofStr)
-	copy(ntResponse[16:], clientBlob)
-
-	usernameBytes := encodeUTF16LE(username)
-	domainBytes := encodeUTF16LE(domain)
-
-	// Layout payload after the fixed header.
-	const payloadOffset = 88
-	ntOffset := payloadOffset
-	domainOffset := ntOffset + len(ntResponse)
-	userOffset := domainOffset + len(domainBytes)
-
-	msg := make([]byte, userOffset+len(usernameBytes))
-
-	copy(msg[0:8], Signature)
-	binary.LittleEndian.PutUint32(msg[8:12], uint32(Authenticate))
-
-	// NtChallengeResponse (offset 20-27)
-	binary.LittleEndian.PutUint16(msg[20:22], uint16(len(ntResponse)))
-	binary.LittleEndian.PutUint16(msg[22:24], uint16(len(ntResponse)))
-	binary.LittleEndian.PutUint32(msg[24:28], uint32(ntOffset))
-
-	// DomainName (offset 28-35)
-	binary.LittleEndian.PutUint16(msg[28:30], uint16(len(domainBytes)))
-	binary.LittleEndian.PutUint16(msg[30:32], uint16(len(domainBytes)))
-	binary.LittleEndian.PutUint32(msg[32:36], uint32(domainOffset))
-
-	// UserName (offset 36-43)
-	binary.LittleEndian.PutUint16(msg[36:38], uint16(len(usernameBytes)))
-	binary.LittleEndian.PutUint16(msg[38:40], uint16(len(usernameBytes)))
-	binary.LittleEndian.PutUint32(msg[40:44], uint32(userOffset))
-
-	// NegotiateFlags (offset 60)
-	binary.LittleEndian.PutUint32(msg[60:64], uint32(FlagUnicode|FlagNTLM))
-
-	copy(msg[ntOffset:], ntResponse)
-	copy(msg[domainOffset:], domainBytes)
-	copy(msg[userOffset:], usernameBytes)
-
-	return msg
 }
 
 // =============================================================================

--- a/internal/adapter/smb/auth/authenticator_test.go
+++ b/internal/adapter/smb/auth/authenticator_test.go
@@ -178,9 +178,12 @@ func TestSMBAuthenticator_Authenticate_NTLMNegotiate_ReturnsChallenge(t *testing
 func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_GuestNoStore(t *testing.T) {
 	auth := NewSMBAuthenticator(nil)
 
+	// Same session/conn identity must be threaded through both rounds.
+	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
+
 	// Round 1: NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, challenge, err := auth.Authenticate(context.Background(), negotiate)
+	_, challenge, err := auth.Authenticate(ctx, negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("round 1: expected ErrMoreProcessingRequired, got: %v", err)
 	}
@@ -190,7 +193,7 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_GuestNoStore(t *testing
 
 	// Round 2: AUTHENTICATE with a username (no user store -> guest)
 	authenticate := buildNTLMAuthenticate("testuser", "WORKGROUP")
-	result, _, err := auth.Authenticate(context.Background(), authenticate)
+	result, _, err := auth.Authenticate(ctx, authenticate)
 	if err != nil {
 		t.Fatalf("round 2: unexpected error: %v", err)
 	}
@@ -215,9 +218,12 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_WithUser(t *testing.T) 
 
 	auth := NewSMBAuthenticator(store)
 
+	// Same session/conn identity must be threaded through both rounds.
+	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
+
 	// Round 1: NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, challenge, err := auth.Authenticate(context.Background(), negotiate)
+	_, challenge, err := auth.Authenticate(ctx, negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("round 1: expected ErrMoreProcessingRequired, got: %v", err)
 	}
@@ -227,7 +233,7 @@ func TestSMBAuthenticator_Authenticate_NTLMFullRoundTrip_WithUser(t *testing.T) 
 
 	// Round 2: AUTHENTICATE with known username (no NT hash on user -> auth without validation)
 	authenticate := buildNTLMAuthenticate("alice", "WORKGROUP")
-	result, _, err := auth.Authenticate(context.Background(), authenticate)
+	result, _, err := auth.Authenticate(ctx, authenticate)
 	if err != nil {
 		t.Fatalf("round 2: unexpected error: %v", err)
 	}
@@ -249,16 +255,18 @@ func TestSMBAuthenticator_Authenticate_AnonymousNTLM(t *testing.T) {
 	store := newMockUserStore()
 	auth := NewSMBAuthenticator(store)
 
+	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
+
 	// NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, _, err := auth.Authenticate(context.Background(), negotiate)
+	_, _, err := auth.Authenticate(ctx, negotiate)
 	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
 		t.Fatalf("expected ErrMoreProcessingRequired, got: %v", err)
 	}
 
 	// AUTHENTICATE with empty username (anonymous)
 	authenticate := buildNTLMAuthenticate("", "")
-	result, _, err := auth.Authenticate(context.Background(), authenticate)
+	result, _, err := auth.Authenticate(ctx, authenticate)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,19 +288,152 @@ func TestSMBAuthenticator_Authenticate_DisabledUser(t *testing.T) {
 
 	auth := NewSMBAuthenticator(store)
 
+	ctx := WithSessionID(WithConnID(context.Background(), 1), 1)
+
 	// NEGOTIATE
 	negotiate := buildNTLMNegotiate()
-	_, _, _ = auth.Authenticate(context.Background(), negotiate)
+	_, _, _ = auth.Authenticate(ctx, negotiate)
 
 	// AUTHENTICATE with disabled user
 	authenticate := buildNTLMAuthenticate("disabled", "WORKGROUP")
-	result, _, err := auth.Authenticate(context.Background(), authenticate)
+	result, _, err := auth.Authenticate(ctx, authenticate)
 	if err == nil {
 		t.Fatal("expected error for disabled user")
 	}
 	if result != nil {
 		t.Error("expected nil result for disabled user")
 	}
+}
+
+// TestSMBAuthenticator_CrossSessionChallenge_Rejected verifies that a Type-3
+// AUTHENTICATE message is validated only against the pending challenge stored
+// for its own (sessionID, connID) pair.
+//
+// Before the fix, handleNTLMAuthenticate ranged ALL pending entries, so a
+// Type-3 built against session A's challenge could be replayed under a
+// different session B and still authenticate against session A's stored
+// challenge. The test builds a genuinely valid NTLMv2 response for session A's
+// challenge, then submits it under session B's context: after the fix the
+// direct (sessionID, connID) lookup misses and the attempt is rejected.
+func TestSMBAuthenticator_CrossSessionChallenge_Rejected(t *testing.T) {
+	const (
+		password = "test123"
+		username = "alice"
+		domain   = "WORKGROUP"
+	)
+
+	store := newMockUserStore()
+	user := &models.User{ID: "alice-id", Username: username, Enabled: true}
+	user.SetNTHashFromPassword(password)
+	store.addUser(user)
+
+	auth := NewSMBAuthenticator(store)
+
+	// Session A: NEGOTIATE. Capture the server challenge from the returned Type-2.
+	ctxA := WithSessionID(WithConnID(context.Background(), 1), 10)
+	_, challenge, err := auth.Authenticate(ctxA, buildNTLMNegotiate())
+	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
+		t.Fatalf("session A negotiate: expected ErrMoreProcessingRequired, got %v", err)
+	}
+	var serverChallenge [8]byte
+	copy(serverChallenge[:], challenge[24:32]) // Type-2 ServerChallenge offset
+
+	// Build a genuinely valid Type-3 AUTHENTICATE for session A's challenge.
+	validAuth := buildValidNTLMAuthenticate(password, username, domain, serverChallenge)
+
+	// Sanity: the response really is valid for session A (proves the attack is
+	// only blocked by session correlation, not by an invalid response).
+	resA, _, errA := auth.Authenticate(ctxA, validAuth)
+	if errA != nil {
+		t.Fatalf("session A authenticate with valid response should succeed, got %v", errA)
+	}
+	if resA == nil || resA.IsGuest || resA.User == nil || resA.User.Username != username {
+		t.Fatalf("session A authenticate: expected authenticated user %q, got %+v", username, resA)
+	}
+
+	// Re-negotiate session A so a fresh pending challenge exists for the replay.
+	_, challenge2, err := auth.Authenticate(ctxA, buildNTLMNegotiate())
+	if !errors.Is(err, adapter.ErrMoreProcessingRequired) {
+		t.Fatalf("session A re-negotiate: expected ErrMoreProcessingRequired, got %v", err)
+	}
+	var serverChallenge2 [8]byte
+	copy(serverChallenge2[:], challenge2[24:32])
+	validAuth2 := buildValidNTLMAuthenticate(password, username, domain, serverChallenge2)
+
+	// Session B: replay session A's valid Type-3 under a DIFFERENT (sessionID,
+	// connID). Session B never sent a NEGOTIATE, so it has no pending challenge.
+	ctxB := WithSessionID(WithConnID(context.Background(), 2), 20)
+	resB, challengeB, errB := auth.Authenticate(ctxB, validAuth2)
+	if errB == nil {
+		t.Fatal("cross-session authenticate should fail: got nil error")
+	}
+	if resB != nil {
+		t.Errorf("cross-session authenticate should return nil result, got %+v", resB)
+	}
+	if challengeB != nil {
+		t.Errorf("cross-session authenticate should return nil challenge, got %x", challengeB)
+	}
+
+	// Session A's pending entry must survive session B's attempt: session A can
+	// still complete its own handshake.
+	resA2, _, errA2 := auth.Authenticate(ctxA, validAuth2)
+	if errA2 != nil {
+		t.Fatalf("session A's own handshake should still succeed after B's attempt, got %v", errA2)
+	}
+	if resA2 == nil || resA2.IsGuest {
+		t.Fatalf("session A authenticate: expected authenticated user, got %+v", resA2)
+	}
+}
+
+// buildValidNTLMAuthenticate constructs a complete NTLM Type-3 (AUTHENTICATE)
+// message carrying a valid NTLMv2 response for the given server challenge.
+func buildValidNTLMAuthenticate(password, username, domain string, serverChallenge [8]byte) []byte {
+	ntHash := ComputeNTHash(password)
+	clientBlob := buildTestClientBlob()
+	ntlmv2Hash := ComputeNTLMv2Hash(ntHash, username, domain)
+	ntProofStr := computeNTProofStr(ntlmv2Hash, serverChallenge, clientBlob)
+
+	ntResponse := make([]byte, len(ntProofStr)+len(clientBlob))
+	copy(ntResponse[:16], ntProofStr)
+	copy(ntResponse[16:], clientBlob)
+
+	usernameBytes := encodeUTF16LE(username)
+	domainBytes := encodeUTF16LE(domain)
+
+	// Layout payload after the fixed header.
+	const payloadOffset = 88
+	ntOffset := payloadOffset
+	domainOffset := ntOffset + len(ntResponse)
+	userOffset := domainOffset + len(domainBytes)
+
+	msg := make([]byte, userOffset+len(usernameBytes))
+
+	copy(msg[0:8], Signature)
+	binary.LittleEndian.PutUint32(msg[8:12], uint32(Authenticate))
+
+	// NtChallengeResponse (offset 20-27)
+	binary.LittleEndian.PutUint16(msg[20:22], uint16(len(ntResponse)))
+	binary.LittleEndian.PutUint16(msg[22:24], uint16(len(ntResponse)))
+	binary.LittleEndian.PutUint32(msg[24:28], uint32(ntOffset))
+
+	// DomainName (offset 28-35)
+	binary.LittleEndian.PutUint16(msg[28:30], uint16(len(domainBytes)))
+	binary.LittleEndian.PutUint16(msg[30:32], uint16(len(domainBytes)))
+	binary.LittleEndian.PutUint32(msg[32:36], uint32(domainOffset))
+
+	// UserName (offset 36-43)
+	binary.LittleEndian.PutUint16(msg[36:38], uint16(len(usernameBytes)))
+	binary.LittleEndian.PutUint16(msg[38:40], uint16(len(usernameBytes)))
+	binary.LittleEndian.PutUint32(msg[40:44], uint32(userOffset))
+
+	// NegotiateFlags (offset 60)
+	binary.LittleEndian.PutUint32(msg[60:64], uint32(FlagUnicode|FlagNTLM))
+
+	copy(msg[ntOffset:], ntResponse)
+	copy(msg[domainOffset:], domainBytes)
+	copy(msg[userOffset:], usernameBytes)
+
+	return msg
 }
 
 // =============================================================================

--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -542,6 +542,13 @@ func ParseCompoundCommand(data []byte) (*header.SMB2Header, []byte, []byte, erro
 		return nil, nil, nil, fmt.Errorf("compound NextCommand not 8-byte aligned: %d", hdr.NextCommand)
 	}
 
+	// NextCommand must point past the header; a smaller value (e.g. 8, 16, 32 —
+	// all 8-byte aligned) would produce a negative-length slice at body
+	// extraction below (data[HeaderSize:NextCommand]).
+	if hdr.NextCommand > 0 && hdr.NextCommand < uint32(header.HeaderSize) {
+		return nil, nil, nil, fmt.Errorf("compound NextCommand too small: %d", hdr.NextCommand)
+	}
+
 	// Extract body for this command
 	var body []byte
 	var remaining []byte
@@ -796,6 +803,25 @@ func (s *compoundLoopState) processRemaining(
 		}
 		remaining = nextRemaining
 
+		// Handle related operations - inherit IDs from previous command.
+		// Per MS-SMB2 2.2.3.1, related operations use 0xFFFFFFFFFFFFFFFF for
+		// SessionID and 0xFFFFFFFF for TreeID to indicate "use previous value".
+		//
+		// This MUST run before signature verification: the per-sub-command
+		// signing check (VerifyCompoundCommandSignature) looks up the session by
+		// hdr.SessionID. If the wire sentinel (0xFFFFFFFFFFFFFFFF) reached that
+		// lookup it would miss (ok=false) and silently skip the integrity check
+		// for every related sub-command — an auth bypass. Resolving the sentinel
+		// to the real SessionID first ensures the signing gate sees the session.
+		if hdr.IsRelated() {
+			if hdr.SessionID == 0 || hdr.SessionID == 0xFFFFFFFFFFFFFFFF {
+				hdr.SessionID = s.lastSessionID
+			}
+			if hdr.TreeID == 0 || hdr.TreeID == 0xFFFFFFFF {
+				hdr.TreeID = s.lastTreeID
+			}
+		}
+
 		// Verify signature for this compound sub-command.
 		// Per MS-SMB2 3.2.5.1.1: skip signing verification when the message was
 		// received inside an encrypted (TRANSFORM_HEADER) envelope — encryption
@@ -851,18 +877,6 @@ func (s *compoundLoopState) processRemaining(
 			s.responses = append(s.responses, compoundResponse{respHeader: errHeader, body: errBody})
 			s.lastCmdFailed = true
 			continue
-		}
-
-		// Handle related operations - inherit IDs from previous command.
-		// Per MS-SMB2 2.2.3.1, related operations use 0xFFFFFFFFFFFFFFFF for
-		// SessionID and 0xFFFFFFFF for TreeID to indicate "use previous value".
-		if hdr.IsRelated() {
-			if hdr.SessionID == 0 || hdr.SessionID == 0xFFFFFFFFFFFFFFFF {
-				hdr.SessionID = s.lastSessionID
-			}
-			if hdr.TreeID == 0 || hdr.TreeID == 0xFFFFFFFF {
-				hdr.TreeID = s.lastTreeID
-			}
 		}
 
 		// Per Windows Server behavior: CHANGE_NOTIFY can only go async as the

--- a/internal/adapter/smb/compound_framing_safety_test.go
+++ b/internal/adapter/smb/compound_framing_safety_test.go
@@ -1,0 +1,102 @@
+package smb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// TestParseCompoundCommand_NextCommandTooSmall verifies that ParseCompoundCommand
+// returns an error (not a panic) when NextCommand is non-zero but smaller than
+// HeaderSize. Such a value is 8-byte aligned (passes the alignment gate) but
+// points inside the header, which would otherwise produce a negative-length
+// slice at body extraction (data[64:N] with N < 64).
+func TestParseCompoundCommand_NextCommandTooSmall(t *testing.T) {
+	for _, nextCmd := range []uint32{8, 16, 32, 40, 56} { // all 8-byte-aligned but < 64
+		t.Run(fmt.Sprintf("NextCommand=%d", nextCmd), func(t *testing.T) {
+			hdr := &header.SMB2Header{
+				Command:     types.SMB2Read,
+				MessageID:   1,
+				NextCommand: nextCmd,
+			}
+			// Construct a buffer large enough to pass the size gate.
+			data := make([]byte, 128)
+			copy(data, hdr.Encode())
+			_, _, _, err := ParseCompoundCommand(data)
+			if err == nil {
+				t.Fatal("expected error for NextCommand < HeaderSize, got nil")
+			}
+		})
+	}
+}
+
+// TestSplitCompoundBody_NextCommandTooSmall verifies that splitCompoundBody does
+// not panic and returns an empty body when NextCommand < HeaderSize. This path
+// is reached by parseSMB2Message for the first command of every incoming SMB2
+// message, so it is reachable by any unauthenticated client.
+func TestSplitCompoundBody_NextCommandTooSmall(t *testing.T) {
+	for _, nextCmd := range []uint32{8, 16, 32, 40, 56} {
+		t.Run(fmt.Sprintf("NextCommand=%d", nextCmd), func(t *testing.T) {
+			hdr := &header.SMB2Header{
+				Command:     types.SMB2Read,
+				MessageID:   1,
+				NextCommand: nextCmd,
+			}
+			message := make([]byte, 128)
+			copy(message, hdr.Encode())
+			// This must not panic.
+			body, remaining := splitCompoundBody(message, hdr)
+			if len(body) != 0 {
+				t.Fatalf("expected empty body for NextCommand=%d, got %d bytes", nextCmd, len(body))
+			}
+			if remaining != nil {
+				t.Fatalf("expected nil remaining for NextCommand=%d, got %d bytes", nextCmd, len(remaining))
+			}
+		})
+	}
+}
+
+// TestProcessRemaining_RelatedSignatureNotSkipped verifies that a related
+// sub-command carrying the wire sentinel SessionID (0xFFFFFFFFFFFFFFFF per
+// MS-SMB2 §2.2.3.1) is presented with the resolved SessionID during
+// VerifyCompoundCommandSignature, not the sentinel. With a session that has
+// SigningRequired=true and an unsigned related frame: before the fix the session
+// lookup on the sentinel fails (ok=false) and signing is silently skipped; after
+// the fix the sentinel is resolved to the real session, the signing gate fires,
+// and the command is rejected with STATUS_ACCESS_DENIED.
+func TestProcessRemaining_RelatedSignatureNotSkipped(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+
+	// Authenticated (non-guest, non-null) session with signing required so an
+	// unsigned message trips the signing gate in VerifyCompoundCommandSignature.
+	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.CryptoState.SigningRequired = true
+
+	// Related sub-command with the wire sentinel SessionID; NOT signed.
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2Read,
+		Flags:     types.FlagRelated,
+		MessageID: 2,
+		SessionID: 0xFFFFFFFFFFFFFFFF,
+	}
+	frame := hdr.Encode()
+
+	state := compoundLoopState{
+		lastSessionID: sess.SessionID,
+		lastTreeID:    1,
+	}
+	// isEncrypted=false so signature verification runs.
+	state.processRemaining(context.Background(), frame, ci, false, nil)
+
+	if len(state.responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(state.responses))
+	}
+	got := state.responses[0].respHeader.Status
+	if got != types.StatusAccessDenied {
+		t.Fatalf("related unsigned command status = 0x%x, want STATUS_ACCESS_DENIED (0x%x) — auth bypass regression",
+			got, types.StatusAccessDenied)
+	}
+}

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -302,6 +302,14 @@ func parseSMB2Message(message []byte, verifier SigningVerifier, logRequest bool)
 // compound data from a parsed SMB2 message.
 func splitCompoundBody(message []byte, hdr *header.SMB2Header) (body, remaining []byte) {
 	if hdr.NextCommand > 0 {
+		if int(hdr.NextCommand) < header.HeaderSize {
+			// Malformed: NextCommand points inside the header, which would make
+			// message[HeaderSize:NextCommand] a negative-length slice and panic.
+			// Return an empty body and no remaining data; the dispatch layer then
+			// rejects the truncated body via the command's StructureSize check.
+			body = message[header.HeaderSize:header.HeaderSize]
+			return
+		}
 		bodyEnd := min(int(hdr.NextCommand), len(message))
 		body = message[header.HeaderSize:bodyEnd]
 		if int(hdr.NextCommand) < len(message) {

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -218,6 +218,16 @@ type PendingNotify struct {
 	// MarkInterimSent, on the goroutine that writes the interim.
 	// Protected by NotifyRegistry.mu.
 	deferredFinal func()
+
+	// generation is a per-Register monotonic stamp used to detect a stale
+	// flush-timer callback. unregisterLocked stops the timer, but per Go's
+	// time.Timer contract Stop() does not cancel an already-fired timer whose
+	// goroutine is still racing to acquire r.mu. If a new watcher for the same
+	// FileID registers in that window, the stale callback must not drain or
+	// unregister it. flushWatcher therefore captures the generation live at
+	// the time the timer armed and bails out on mismatch.
+	// Protected by NotifyRegistry.mu.
+	generation uint64
 }
 
 // NotifyRegistry manages pending CHANGE_NOTIFY requests from SMB2 clients.
@@ -279,6 +289,11 @@ type NotifyRegistry struct {
 	// (smb2.notify.mask). MarkInterimSent fires the deferred response after
 	// writing interim and clears this map entry. Keyed by (ConnID, MessageID).
 	pendingInterim map[notifyMsgKey]*PendingNotify
+
+	// nextGeneration is incremented on every Register and stamped onto the
+	// registered PendingNotify.generation. Used to detect stale flush-timer
+	// callbacks after a re-arm on the same FileID. Always mutated under r.mu.
+	nextGeneration uint64
 
 	// flushDelay is the per-registry accumulation window for buffered events.
 	// Defaults to notifyFlushDelay (100µs) in production. Tests that drive
@@ -604,6 +619,12 @@ func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 			r.unregisterLocked(oldByMsg)
 		}
 	}
+
+	// Stamp a fresh generation so a stale flush timer from a prior watcher on
+	// this FileID (whose Stop() lost the race against its own fired callback)
+	// is recognised as stale by flushWatcher and treated as a no-op.
+	r.nextGeneration++
+	notify.generation = r.nextGeneration
 
 	r.byFileID[string(notify.FileID[:])] = notify
 	r.byMsgKey[msgKey] = notify
@@ -1000,9 +1021,82 @@ func (r *NotifyRegistry) NotifyRename(shareName, oldParentPath, oldFileName, new
 	}
 	r.mu.Unlock()
 
-	r.chargeArmedBuffer(shareName, oldParentPath, filter, []string{oldFileName, newFileName}, liveFileIDs)
-	if newParentPath != oldParentPath {
-		r.chargeArmedBuffer(shareName, newParentPath, filter, []string{oldFileName, newFileName}, liveFileIDs)
+	r.chargeArmedRename(shareName, oldParentPath, oldFileName, newParentPath, newFileName, filter, liveFileIDs)
+}
+
+// chargeArmedRename charges the byte cost of one RENAMED_OLD_NAME +
+// RENAMED_NEW_NAME pair against every armed handle that would have matched
+// either the old or new parent path. Each handle is charged exactly once: the
+// old-side relative path for RENAMED_OLD_NAME and the new-side relative path
+// for RENAMED_NEW_NAME.
+//
+// This replaces a pair of chargeArmedBuffer calls (one per parent path) that
+// double-charged an armed WatchTree ancestor on a cross-directory rename: the
+// ancestor matched oldParentPath on the first call (charging both filenames)
+// AND newParentPath on the second (charging both again), accumulating 4 entries
+// for an event that puts only 2 on the wire and tripping a false overflow.
+//
+// Handles in skipFileIDs (live watchers already served the event one-shot) are
+// excluded.
+func (r *NotifyRegistry) chargeArmedRename(
+	shareName, oldParentPath, oldFileName, newParentPath, newFileName string,
+	filter uint32,
+	skipFileIDs map[[16]byte]struct{},
+) {
+	type pendingFire struct {
+		fn OnOverflow
+		id [16]byte
+	}
+	var toFire []pendingFire
+
+	r.mu.Lock()
+	if len(r.armed) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	for _, a := range r.armed {
+		if a.ShareName != shareName {
+			continue
+		}
+		if _, live := skipFileIDs[a.FileID]; live {
+			continue
+		}
+		if a.CompletionFilter&filter == 0 {
+			continue
+		}
+		if a.Overflowed {
+			continue
+		}
+		matchesOld := a.WatchPath == oldParentPath || (a.WatchTree && pathIsAncestor(a.WatchPath, oldParentPath))
+		matchesNew := a.WatchPath == newParentPath || (a.WatchTree && pathIsAncestor(a.WatchPath, newParentPath))
+		if !matchesOld && !matchesNew {
+			continue
+		}
+		// Charge exactly the entries this handle would see on the wire: one
+		// RENAMED_OLD_NAME entry and one RENAMED_NEW_NAME entry, each with its
+		// own per-watcher relative path. A root WatchTree ancestor matches both
+		// sides of a cross-dir rename and is charged exactly 2 entries — not 4.
+		var addBytes uint32
+		if matchesOld {
+			oldRel := relativePathFromWatch(a.WatchPath, oldParentPath, oldFileName)
+			addBytes += encodedNotifyEntrySize(oldRel)
+		}
+		if matchesNew {
+			newRel := relativePathFromWatch(a.WatchPath, newParentPath, newFileName)
+			addBytes += encodedNotifyEntrySize(newRel)
+		}
+		a.BufferedBytes += addBytes
+		if a.MaxOutputLength == 0 || a.BufferedBytes > a.MaxOutputLength {
+			a.Overflowed = true
+			if a.OnOverflow != nil {
+				toFire = append(toFire, pendingFire{fn: a.OnOverflow, id: a.FileID})
+			}
+		}
+	}
+	r.mu.Unlock()
+
+	for _, f := range toFire {
+		f.fn(f.id)
 	}
 }
 
@@ -1167,8 +1261,9 @@ func (r *NotifyRegistry) bufferEventLocked(notify *PendingNotify, change FileNot
 	notify.bufferedChanges = append(notify.bufferedChanges, change)
 	if notify.flushTimer == nil {
 		fileID := notify.FileID
+		gen := notify.generation
 		notify.flushTimer = time.AfterFunc(r.flushDelay, func() {
-			r.flushWatcher(fileID)
+			r.flushWatcher(fileID, gen)
 		})
 	}
 }
@@ -1176,10 +1271,13 @@ func (r *NotifyRegistry) bufferEventLocked(notify *PendingNotify, change FileNot
 // flushWatcher drains the buffered events for a watcher identified by fileID,
 // unregisters it (one-shot), and sends the async response. Called by the flush
 // timer after notifyFlushDelay.
-func (r *NotifyRegistry) flushWatcher(fileID [16]byte) {
+func (r *NotifyRegistry) flushWatcher(fileID [16]byte, gen uint64) {
 	r.mu.Lock()
 	notify, ok := r.byFileID[string(fileID[:])]
-	if !ok {
+	if !ok || notify.generation != gen {
+		// Either the watcher was already unregistered, or a newer watcher
+		// re-armed this FileID after a stale timer fired. In both cases this
+		// callback is stale and must not drain or unregister the live watcher.
 		r.mu.Unlock()
 		return
 	}

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -2631,3 +2631,148 @@ func TestNotifyChange_WriteModified_RespectsNarrowFilter(t *testing.T) {
 		t.Error("FILE_NAME-only watcher must NOT be notified of a WRITE MODIFIED event")
 	}
 }
+
+// TestFlushWatcher_StaleTimerAfterRearm_IsNoop verifies that a flushWatcher
+// callback from a stale timer (fired after the watcher was replaced) is a
+// no-op: it must NOT drain or unregister the new watcher, and must NOT invoke
+// the new watcher's AsyncCallback.
+func TestFlushWatcher_StaleTimerAfterRearm_IsNoop(t *testing.T) {
+	r := newTestNotifyRegistry() // flushDelay = 1h (timers never fire spontaneously)
+
+	fileID := [16]byte{0x55}
+	var callbackCount atomic.Int32
+
+	// Register watcher A — captures generation G1.
+	wA := &PendingNotify{
+		FileID: fileID, SessionID: 1, ConnID: 1, MessageID: 10, AsyncId: 100,
+		WatchPath: "/d", ShareName: "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  64 * 1024,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			callbackCount.Add(1)
+			return nil
+		},
+	}
+	mustRegister(t, r, wA)
+	genA := wA.generation
+
+	// Buffer an event so flushTimer is set on wA.
+	r.mu.Lock()
+	r.bufferEventLocked(wA, FileNotifyInformation{Action: FileActionAdded, FileName: "x.txt"})
+	r.mu.Unlock()
+
+	// Cancel wA — unregisterLocked stops its timer (Stop returns false if
+	// already fired, but under flushDelay=1h it hasn't fired).
+	r.Unregister(fileID)
+
+	// Register watcher B for the same fileID — gets generation G2 > G1.
+	wB := &PendingNotify{
+		FileID: fileID, SessionID: 1, ConnID: 1, MessageID: 11, AsyncId: 101,
+		WatchPath: "/d", ShareName: "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  64 * 1024,
+		AsyncCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			callbackCount.Add(1)
+			return nil
+		},
+	}
+	mustRegister(t, r, wB)
+
+	if wB.generation == genA {
+		t.Fatalf("wB.generation = %d must differ from genA = %d", wB.generation, genA)
+	}
+
+	// Simulate the stale timer firing: call flushWatcher with A's generation.
+	// Before the fix this finds wB (same fileID) and destroys it.
+	// After the fix the generation mismatch makes it a no-op.
+	r.flushWatcher(fileID, genA)
+
+	// wB must still be registered and its callback must NOT have been invoked.
+	if got := r.WatcherCount(); got != 1 {
+		t.Errorf("WatcherCount = %d after stale flushWatcher; want 1 (wB must survive)", got)
+	}
+	if n := callbackCount.Load(); n != 0 {
+		t.Errorf("AsyncCallback invoked %d times; want 0 (stale timer must be no-op)", n)
+	}
+
+	// Legitimate flush for wB must still work.
+	r.mu.Lock()
+	r.bufferEventLocked(wB, FileNotifyInformation{Action: FileActionAdded, FileName: "y.txt"})
+	r.mu.Unlock()
+	r.flushWatcher(fileID, wB.generation)
+
+	if n := callbackCount.Load(); n != 1 {
+		t.Errorf("Legitimate flushWatcher invoked callback %d times; want 1", n)
+	}
+	if got := r.WatcherCount(); got != 0 {
+		t.Errorf("WatcherCount = %d after legitimate flush; want 0", got)
+	}
+}
+
+// TestArmedBuffer_RenameDoesNotDoubleChargeAncestorWatcher is the regression
+// test for the NotifyRename double-charge bug on cross-directory renames.
+//
+// Scenario: a WatchTree watcher rooted at "/" is armed but has no live pending
+// notify. A file is renamed from /src/old.txt to /dst/new.txt (cross-dir).
+// The watcher should be charged exactly two FILE_NOTIFY_INFORMATION entries:
+//   - RENAMED_OLD_NAME "src/old.txt"  (relative to "/")
+//   - RENAMED_NEW_NAME "dst/new.txt"  (relative to "/")
+//
+// Before the fix, chargeArmedBuffer was called twice (once per parent path)
+// with both filenames each time, charging 4 entries and triggering a false
+// overflow. After the fix, chargeArmedRename charges each handle exactly once.
+func TestArmedBuffer_RenameDoesNotDoubleChargeAncestorWatcher(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	fileID := [16]byte{0x77}
+	var overflowCount atomic.Int32
+
+	// Compute the exact byte cost of the two correct entries:
+	//   RENAMED_OLD_NAME "src/old.txt"
+	//   RENAMED_NEW_NAME "dst/new.txt"
+	twoEntryCost := encodedNotifyEntrySize("src/old.txt") + encodedNotifyEntrySize("dst/new.txt")
+
+	// MaxOutputLength = twoEntryCost: fits the correct 2 entries exactly, but
+	// would overflow if 4 entries (the buggy path) were charged.
+	maxLen := twoEntryCost
+
+	first := &PendingNotify{
+		FileID: fileID, SessionID: 1, ConnID: 1, MessageID: 10, AsyncId: 100,
+		WatchPath: "/", ShareName: "s",
+		CompletionFilter: FileNotifyChangeFileName,
+		WatchTree:        true,
+		MaxOutputLength:  maxLen,
+		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
+		OnOverflow: func(_ [16]byte) {
+			overflowCount.Add(1)
+		},
+	}
+	mustRegister(t, r, first)
+	// Cancel to leave handle armed-but-unwatched.
+	if r.UnregisterByAsyncId(100) == nil {
+		t.Fatal("expected to unregister")
+	}
+
+	// Cross-directory rename: /src/old.txt -> /dst/new.txt
+	r.NotifyRename("s", "/src", "old.txt", "/dst", "new.txt", FileNotifyChangeFileName)
+
+	// The armed handle should be charged exactly 2 entries total.
+	// Before fix: 4 entries charged -> overflow fires.
+	// After fix:  2 entries charged -> no overflow (fits within maxLen exactly).
+	if got := overflowCount.Load(); got != 0 {
+		t.Errorf("OnOverflow fired %d times; want 0 (ancestor watcher double-charged by buggy path)", got)
+	}
+
+	// Confirm buffered bytes on the armed handle equals the 2-entry cost.
+	r.mu.RLock()
+	armed := r.armed[string(fileID[:])]
+	var bufferedBytes uint32
+	if armed != nil {
+		bufferedBytes = armed.BufferedBytes
+	}
+	r.mu.RUnlock()
+
+	if bufferedBytes != twoEntryCost {
+		t.Errorf("armed.BufferedBytes = %d; want %d (exactly 2 rename entries)", bufferedBytes, twoEntryCost)
+	}
+}

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -246,8 +246,12 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// real symlinks in the metadata store for NFS interoperability.
 
 	if !openFile.IsDirectory && openFile.PayloadID != "" && !openFile.DeletePending && !openFile.InitialDeleteOnClose {
-		if converted, _ := h.checkAndConvertMFsymlink(ctx, openFile); converted {
-			logger.Debug("CLOSE: converted MFsymlink to symlink", "path", openFile.Path)
+		// MFsymlink conversion promotes client-controlled file content to a real
+		// symlink, so it is opt-in per share (default disabled).
+		if tree, treeOK := h.GetTree(ctx.TreeID); treeOK && tree.AllowMFsymlink {
+			if converted, _ := h.checkAndConvertMFsymlink(ctx, openFile); converted {
+				logger.Debug("CLOSE: converted MFsymlink to symlink", "path", openFile.Path)
+			}
 		}
 	}
 
@@ -393,9 +397,13 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					return true
 				}
 				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+					// Guard the write: concurrent QUERY_INFO/WRITE goroutines on
+					// the same session may be reading these fields on `other`.
+					other.mu.Lock()
 					other.DeletePending = true
 					other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 					other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+					other.mu.Unlock()
 					h.StoreOpenFile(other)
 				}
 				return true
@@ -409,11 +417,16 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// the last stream CLOSE triggers the base file removal.
 			basePrefix := openFile.FileName + ":"
 			h.rangeStreamsOfBase(openFile.FileID, openFile.ParentHandle, basePrefix, func(other *OpenFile) bool {
+				// Guard the write: concurrent readers on the stream handle
+				// (QUERY_INFO / open path via isFileOrBaseDeletePending) may be
+				// reading these fields on `other`.
+				other.mu.Lock()
 				other.BaseFileDeletePending = true
 				other.BaseFileDeleteParentHandle = openFile.ParentHandle
 				other.BaseFileDeleteFileName = openFile.FileName
 				other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 				other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+				other.mu.Unlock()
 				h.StoreOpenFile(other)
 				return true
 			})
@@ -885,6 +898,13 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Reject targets that escape the share root (absolute or `..`-traversal).
+	// MFsymlink content is fully client-controlled, so an unsanitized target
+	// could otherwise point an NFS client outside the share.
+	if err := metadata.ValidateMFsymlinkTarget(target); err != nil {
+		return fmt.Errorf("MFsymlink target rejected: %w", err)
 	}
 
 	// Get the parent handle and filename for removal and creation

--- a/internal/adapter/smb/handlers/close_mfsymlink_test.go
+++ b/internal/adapter/smb/handlers/close_mfsymlink_test.go
@@ -1,0 +1,237 @@
+// Handler-level coverage for the per-share AllowMFsymlink gate and the
+// MFsymlink-target path-traversal guard on CLOSE.
+//
+// macOS/Windows SMB clients create symlinks by writing 1067-byte MFsymlink
+// (XSym) content. On CLOSE, DittoFS optionally promotes such a file to a real
+// symlink for NFS interoperability. The promotion target is fully
+// client-controlled, so:
+//   - it is opt-in per share (AllowMFsymlink, default false), and
+//   - the decoded target is rejected if it is absolute or contains `..`
+//     (would escape the share root).
+//
+// These tests drive h.Close end-to-end against a memory metadata + block store,
+// the same backends every smb-conformance profile uses.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/mfsymlink"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupMFsymlinkShare wires a handler + runtime + memory metadata + memory
+// block store with a single share whose AllowMFsymlink flag is set per the
+// argument. It then creates a regular file containing the given MFsymlink
+// target's XSym payload and registers an OpenFile for it. Returns the handler,
+// a primed SMBHandlerContext, the share root handle, and the FileID of the
+// registered OpenFile. The created entry is named "link" under the root.
+func setupMFsymlinkShare(t *testing.T, allowMFsymlink bool, target string) (*Handler, *SMBHandlerContext, metadata.FileHandle, [16]byte) {
+	t.Helper()
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "mfmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("mfmeta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "mfbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/mf"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "mfmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		AllowMFsymlink:    allowMFsymlink,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	const fileName = "link"
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, fileName, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	// Build and write the XSym MFsymlink payload (exactly mfsymlink.Size bytes).
+	payload, err := mfsymlink.Encode(target)
+	if err != nil {
+		t.Fatalf("mfsymlink.Encode(%q): %v", target, err)
+	}
+	if len(payload) != mfsymlink.Size {
+		t.Fatalf("encoded MFsymlink is %d bytes, expected %d", len(payload), mfsymlink.Size)
+	}
+
+	bs, err := rt.GetBlockStoreForHandle(ctx, fileHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	writeOp, err := metaSvc.PrepareWrite(authCtx, fileHandle, uint64(len(payload)))
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, string(writeOp.PayloadID), nil, payload, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Re-fetch to obtain the committed PayloadID + size.
+	committed, err := metaSvc.GetFile(ctx, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile post-write: %v", err)
+	}
+	if committed.Size != mfsymlink.Size {
+		t.Fatalf("committed size = %d, expected %d", committed.Size, mfsymlink.Size)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	const callerUID, callerGID uint32 = 1000, 1000
+	suid, sgid := callerUID, callerGID
+	sess := h.CreateSession("127.0.0.1:12345", false, "test-user", "")
+	sess.User = &models.User{
+		Username: "test-user",
+		UID:      &suid,
+		Groups:   []models.Group{{GID: &sgid}},
+	}
+
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:         treeID,
+		SessionID:      sess.SessionID,
+		ShareName:      shareName,
+		Permission:     models.PermissionReadWrite,
+		AllowMFsymlink: allowMFsymlink,
+	})
+
+	fileID := [16]byte{1}
+	openFile := &OpenFile{
+		FileID:         fileID,
+		TreeID:         treeID,
+		SessionID:      sess.SessionID,
+		Path:           fileName,
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
+		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
+		MetadataHandle: fileHandle,
+		PayloadID:      committed.PayloadID,
+		ParentHandle:   rootHandle,
+		FileName:       fileName,
+	}
+	h.StoreOpenFile(openFile)
+
+	smbCtx := &SMBHandlerContext{
+		Context:   ctx,
+		SessionID: sess.SessionID,
+		TreeID:    treeID,
+		ShareName: shareName,
+	}
+
+	return h, smbCtx, rootHandle, fileID
+}
+
+// fileTypeAfterClose closes the registered FileID and reports the metadata file
+// type of the "link" entry under rootHandle. MFsymlink conversion removes the
+// regular file and re-creates the entry as a symlink under the same name, so
+// the entry must always be resolvable by name from its parent.
+func fileTypeAfterClose(t *testing.T, h *Handler, smbCtx *SMBHandlerContext, rootHandle metadata.FileHandle, fileID [16]byte) metadata.FileType {
+	t.Helper()
+	resp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Close: status = 0x%08x, expected STATUS_SUCCESS", uint32(resp.Status))
+	}
+	metaSvc := h.Registry.GetMetadataService()
+	childHandle, err := metaSvc.GetChild(smbCtx.Context, rootHandle, "link")
+	if err != nil {
+		t.Fatalf("GetChild(link) after close: %v", err)
+	}
+	file, err := metaSvc.GetFile(smbCtx.Context, childHandle)
+	if err != nil {
+		t.Fatalf("GetFile after close: %v", err)
+	}
+	return file.Type
+}
+
+// TestClose_MFsymlink_DisabledByDefault confirms an XSym file is NOT promoted
+// to a symlink when the share's AllowMFsymlink toggle is false (the default).
+func TestClose_MFsymlink_DisabledByDefault(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupMFsymlinkShare(t, false, "valid/target")
+	if got := fileTypeAfterClose(t, h, smbCtx, rootHandle, fileID); got != metadata.FileTypeRegular {
+		t.Fatalf("file type after close = %v, expected FileTypeRegular (conversion fired with AllowMFsymlink=false)", got)
+	}
+}
+
+// TestClose_MFsymlink_EnabledConverts confirms an XSym file IS promoted to a
+// real symlink when AllowMFsymlink is true and the target is a safe relative
+// path.
+func TestClose_MFsymlink_EnabledConverts(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupMFsymlinkShare(t, true, "valid/target")
+	if got := fileTypeAfterClose(t, h, smbCtx, rootHandle, fileID); got != metadata.FileTypeSymlink {
+		t.Fatalf("file type after close = %v, expected FileTypeSymlink (conversion did not fire with AllowMFsymlink=true)", got)
+	}
+}
+
+// TestClose_MFsymlink_TraversalTargetRejected confirms that even with
+// AllowMFsymlink=true, a traversal target (`..`) is rejected and the file is
+// left as a regular file — no symlink escaping the share root is created.
+func TestClose_MFsymlink_TraversalTargetRejected(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupMFsymlinkShare(t, true, "../../etc/passwd")
+	if got := fileTypeAfterClose(t, h, smbCtx, rootHandle, fileID); got != metadata.FileTypeRegular {
+		t.Fatalf("file type after close = %v, expected FileTypeRegular (traversal target was promoted to a symlink)", got)
+	}
+}

--- a/internal/adapter/smb/handlers/converters.go
+++ b/internal/adapter/smb/handlers/converters.go
@@ -746,3 +746,19 @@ func decodeWTF8Runes(s string) []rune {
 	}
 	return runes
 }
+
+// modeBitMaskAttrs builds a metadata.SetAttrs that flips a single FSCTL-managed
+// mode bit (e.g. modeDOSSparse, modeDOSCompressed) atomically inside the store's
+// own read-modify-write. Using the mask form rather than reading Mode in the
+// handler and writing it back avoids a lost-update race when two IOCTLs
+// (SET_SPARSE vs SET_COMPRESSION) touch independent bits concurrently.
+func modeBitMaskAttrs(bit uint32, set bool) metadata.SetAttrs {
+	mask := bit
+	var attrs metadata.SetAttrs
+	if set {
+		attrs.ModeOrMask = &mask
+	} else {
+		attrs.ModeAndNotMask = &mask
+	}
+	return attrs
+}

--- a/internal/adapter/smb/handlers/converters_test.go
+++ b/internal/adapter/smb/handlers/converters_test.go
@@ -556,3 +556,31 @@ func TestUTF16LE_WideACaseFold(t *testing.T) {
 		t.Fatalf("ASCII 'a' must NOT fold to fullwidth 'ａ': %q vs %q", ascii, wideLower)
 	}
 }
+
+// TestModeBitMaskAttrs pins the OR-vs-AND-NOT mapping of the mode-mask helper
+// shared by the SET_SPARSE / SET_COMPRESSION IOCTL handlers: set==true ORs the
+// bit in, set==false clears it, and exactly one of the two masks is populated.
+func TestModeBitMaskAttrs(t *testing.T) {
+	t.Run("set ORs the bit in", func(t *testing.T) {
+		attrs := modeBitMaskAttrs(modeDOSSparse, true)
+		if attrs.ModeOrMask == nil || *attrs.ModeOrMask != modeDOSSparse {
+			t.Fatalf("expected ModeOrMask=%#x, got %v", modeDOSSparse, attrs.ModeOrMask)
+		}
+		if attrs.ModeAndNotMask != nil {
+			t.Errorf("expected ModeAndNotMask nil when set=true, got %#x", *attrs.ModeAndNotMask)
+		}
+		if attrs.Mode != nil {
+			t.Errorf("helper must not touch the absolute Mode field")
+		}
+	})
+
+	t.Run("clear AND-NOTs the bit out", func(t *testing.T) {
+		attrs := modeBitMaskAttrs(modeDOSCompressed, false)
+		if attrs.ModeAndNotMask == nil || *attrs.ModeAndNotMask != modeDOSCompressed {
+			t.Fatalf("expected ModeAndNotMask=%#x, got %v", modeDOSCompressed, attrs.ModeAndNotMask)
+		}
+		if attrs.ModeOrMask != nil {
+			t.Errorf("expected ModeOrMask nil when set=false, got %#x", *attrs.ModeOrMask)
+		}
+	})
+}

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1265,6 +1265,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// ADS auto-create: when the disposition would create the stream,
 	// ensure the base file exists first. Per MS-FSA, creating a named
 	// stream implicitly creates the base file.
+	var adsBaseCreatedByUs bool
 	if isADS && (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) {
 		if f, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, parentHandle, adsBaseFileName); f == nil {
 			baseAttr := &metadata.FileAttr{
@@ -1288,8 +1289,12 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						"base", adsBaseFileName, "error", createBaseErr)
 					return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(createBaseErr)}}, nil
 				}
+			} else {
+				// We exclusively created the base file; record ownership so
+				// the lease-rejection rollback path can clean it up.
+				adsBaseCreatedByUs = true
+				logger.Debug("CREATE: ADS auto-created base file", "base", adsBaseFileName)
 			}
-			logger.Debug("CREATE: ADS auto-created base file", "base", adsBaseFileName)
 		}
 	}
 
@@ -1435,6 +1440,8 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		excludeOwner:         excludeOwner,
 		appInstanceProcessed: true,
 		appInstanceId:        appInstanceId,
+		adsBaseFileName:      adsBaseFileName,
+		adsBaseCreatedByUs:   adsBaseCreatedByUs,
 	}).finalize()
 
 	// SMB3 replay protection (MS-SMB2 §3.3.5.9): reserve the DH2Q CreateGuid for

--- a/internal/adapter/smb/handlers/create_ads_rollback_test.go
+++ b/internal/adapter/smb/handlers/create_ads_rollback_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestCreate_ADS_LeaseKeyInUse_RollsBackBaseFile verifies that when a lease
+// request is rejected with ErrLeaseKeyInUse AFTER a fresh ADS stream CREATE,
+// the rollback removes BOTH the stream entry ("file.txt:StreamName") AND the
+// base file ("file.txt") that the ADS auto-create path created for this
+// request.
+//
+// Before the fix, only the stream entry was removed and the base file was
+// left as an unreachable orphan: a subsequent FILE_CREATE on "file.txt" then
+// failed with ErrAlreadyExists even though no client could see the file.
+//
+// The scenario is driven directly through completeCreateAfterBreak with a
+// pre-set draft (mirroring what create.go produces after the ADS auto-create
+// in Step 6):
+//   - baseName            = "file.txt:StreamName" (ADS-qualified, created here)
+//   - adsBaseFileName      = "file.txt"           (base seeded by Step 6)
+//   - adsBaseCreatedByUs   = true                 (Step 6 owned the base)
+//   - createAction         = FileCreated          (fresh stream CREATE)
+//
+// ErrLeaseKeyInUse is produced by a real LeaseManager: the request's lease key
+// is pre-bound to a DIFFERENT file handle under the same client, so the
+// cross-file lease-key uniqueness check (MS-SMB2 §3.3.5.9.8 / Samba
+// lease_match) rejects this CREATE.
+func TestCreate_ADS_LeaseKeyInUse_RollsBackBaseFile(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+
+	tree := &TreeConnection{
+		TreeID:    smbCtx.TreeID,
+		SessionID: smbCtx.SessionID,
+		ShareName: smbCtx.ShareName,
+	}
+	h.StoreTree(tree)
+
+	// Wire a real LeaseManager backed by a real lock.Manager so RequestLease
+	// can authentically produce ErrLeaseKeyInUse via lease_match.
+	mgr := lock.NewManager()
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	metaSvc := rt.GetMetadataService()
+
+	// Use the root identity so createNewFile (Step 7) has write access to the
+	// share root (mode 0o755, owned by uid 0). The rollback path under test is
+	// independent of the requester identity.
+	auth := rootAuth
+
+	// Lease key that we will bind to another file first, so the CREATE under
+	// test trips ErrLeaseKeyInUse.
+	var leaseKey [16]byte
+	for i := range leaseKey {
+		leaseKey[i] = byte(i + 1)
+	}
+
+	// completeCreateAfterBreak derives clientID as fmt.Sprintf("smb:%d",
+	// ctx.SessionID) and uses tree.ShareName. Bind the key to a DIFFERENT file
+	// handle under that exact (clientID, shareName) with a non-None state so
+	// the in-memory hasLeaseKeyOnOtherFile check fires for our CREATE.
+	clientID := "smb:1" // smbCtx.SessionID == 1 (setupDaclTest)
+	otherHandle := lock.FileHandle("some-other-file-handle")
+	granted, _, err := mgr.RequestLease(
+		context.Background(),
+		otherHandle,
+		leaseKey,
+		[16]byte{},
+		"smb:lease:preexisting",
+		clientID,
+		smbCtx.ShareName,
+		lock.LeaseStateRead|lock.LeaseStateHandle,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("seed lease on other file: %v", err)
+	}
+	if granted == lock.LeaseStateNone {
+		t.Fatalf("seed lease denied (granted=None); cannot set up ErrLeaseKeyInUse scenario")
+	}
+
+	// Seed the base file to simulate the ADS auto-create path (Step 6) having
+	// already created it. The stream entry is NOT seeded: Step 7 of
+	// completeCreateAfterBreak creates it via createNewFile.
+	_, _, err = metaSvc.CreateFile(rootAuth, rootHandle, "file.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644})
+	if err != nil {
+		t.Fatalf("seed base file: %v", err)
+	}
+
+	// V2 lease request blob carrying the conflicting key with R|H state. A
+	// non-stat DesiredAccess routes through RequestLease (not the stat-open
+	// variant), so the cross-file lease_match rejection fires.
+	leaseBlob := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateHandle, 0)
+
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "file.txt:StreamName",
+			DesiredAccess:     0x001F01FF, // full access (not stat-only)
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileCreate,
+			CreateOptions:     0,
+			FileAttributes:    types.FileAttributeNormal,
+			OplockLevel:       OplockLevelLease,
+			CreateContexts: []CreateContext{
+				{Name: LeaseContextTagRequest, Data: leaseBlob},
+			},
+		},
+		tree:               tree,
+		authCtx:            auth,
+		filename:           "file.txt:StreamName",
+		baseName:           "file.txt:StreamName",
+		parentHandle:       rootHandle,
+		fileExists:         false,
+		createAction:       types.FileCreated,
+		adsBaseFileName:    "file.txt",
+		adsBaseCreatedByUs: true,
+	}
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+
+	// The lease rejection must surface as StatusInvalidParameter.
+	if resp.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x; want StatusInvalidParameter (0x%08x)",
+			uint32(resp.Status), uint32(types.StatusInvalidParameter))
+	}
+
+	// After rollback: stream entry must be gone.
+	if streamFile, _, _ := metaSvc.LookupCaseInsensitive(auth, rootHandle, "file.txt:StreamName"); streamFile != nil {
+		t.Error("stream entry still exists after rollback; expected removal")
+	}
+
+	// After rollback: base file must also be gone (the regression check).
+	if baseFile, _, _ := metaSvc.LookupCaseInsensitive(auth, rootHandle, "file.txt"); baseFile != nil {
+		t.Error("base file still exists after rollback; ADS base-file orphan not cleaned up")
+	}
+
+	// A fresh FILE_CREATE on the base name must now succeed (it was previously
+	// broken because the orphaned base returned ErrAlreadyExists).
+	if _, _, createErr := metaSvc.CreateFile(auth, rootHandle, "file.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}); createErr != nil {
+		t.Errorf("re-create of base file after rollback: %v (expected success)", createErr)
+	}
+}

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -47,6 +47,17 @@ type createDraft struct {
 	// smb2.durable-v2-open.app-instance asserts break_info.count == 0).
 	appInstanceProcessed bool
 	appInstanceId        [16]byte
+	// adsBaseFileName is the name of the base file that was implicitly
+	// created by the ADS auto-create path (create.go Step 6) — e.g.
+	// "file.txt" when baseName is "file.txt:StreamName".
+	// Empty for non-ADS opens.
+	adsBaseFileName string
+	// adsBaseCreatedByUs is true when THIS CREATE request called
+	// CreateFile for adsBaseFileName and succeeded (i.e. the base was
+	// newly created by us, not pre-existing and not raced-in by a peer).
+	// Used by the ErrLeaseKeyInUse rollback to decide whether to also
+	// remove the base file.
+	adsBaseCreatedByUs bool
 }
 
 // finalize computes the opaque file handle for the existing file (if any) and
@@ -964,6 +975,17 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 						if _, _, delErr := metaSvc.RemoveFile(authCtx, parentHandle, baseName); delErr != nil {
 							logger.Warn("CREATE: failed to roll back orphaned file after lease rejection",
 								"name", baseName, "error", delErr)
+						}
+						// If this CREATE also auto-created the base file (ADS
+						// path), roll that back too. Without this the base file is
+						// left orphaned: the stream entry is gone but the base
+						// inode is unreachable and a subsequent FILE_CREATE on the
+						// base name hits ErrAlreadyExists.
+						if d.adsBaseCreatedByUs && d.adsBaseFileName != "" {
+							if _, _, delBaseErr := metaSvc.RemoveFile(authCtx, parentHandle, d.adsBaseFileName); delBaseErr != nil {
+								logger.Warn("CREATE: failed to roll back orphaned ADS base file after lease rejection",
+									"name", d.adsBaseFileName, "error", delBaseErr)
+							}
 						}
 						return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}
 					case types.FileOverwritten, types.FileSuperseded:

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -1030,12 +1030,7 @@ func ProcessAppInstanceId(
 			handler.flushFileCache(ctx, cleanupFile)
 			if len(h.MetadataHandle) > 0 && handler.Registry != nil {
 				if metaSvc := handler.Registry.GetMetadataService(); metaSvc != nil {
-					fileID := h.OriginalFileID
-					if fileID == ([16]byte{}) {
-						fileID = h.FileID
-					}
-					openID := fmt.Sprintf("%x", fileID)
-					if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
+					if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, h.LockOpenID()); err != nil {
 						logger.Debug("ProcessAppInstanceId: failed to release locks",
 							"id", h.ID, "path", h.Path, "error", err)
 					}

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -1030,7 +1030,15 @@ func ProcessAppInstanceId(
 			handler.flushFileCache(ctx, cleanupFile)
 			if len(h.MetadataHandle) > 0 && handler.Registry != nil {
 				if metaSvc := handler.Registry.GetMetadataService(); metaSvc != nil {
-					_ = metaSvc.UnlockAllForSession(ctx, h.MetadataHandle, 0)
+					fileID := h.OriginalFileID
+					if fileID == ([16]byte{}) {
+						fileID = h.FileID
+					}
+					openID := fmt.Sprintf("%x", fileID)
+					if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
+						logger.Debug("ProcessAppInstanceId: failed to release locks",
+							"id", h.ID, "path", h.Path, "error", err)
+					}
 				}
 			}
 		}

--- a/internal/adapter/smb/handlers/durable_context_test.go
+++ b/internal/adapter/smb/handlers/durable_context_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -2369,4 +2371,101 @@ func TestReopen2_NegativeLadder_Preserved(t *testing.T) {
 			t.Errorf("lease handle, no lease ctx: got %s, want OBJECT_NAME_NOT_FOUND", status)
 		}
 	})
+}
+
+// TestProcessAppInstanceId_ReleasesLocksOnPersistedHandle verifies that
+// ProcessAppInstanceId releases byte-range locks held by a persisted
+// (disconnected) durable handle when a new open with the same AppInstanceId
+// displaces it. Before the fix the call was UnlockAllForSession(0) which is
+// always a no-op for SMB locks (sessions never carry ID 0); the test fails
+// before the fix and passes after.
+func TestProcessAppInstanceId_ReleasesLocksOnPersistedHandle(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	h.DurableStore = newMockDurableStore()
+	metaSvc := rt.GetMetadataService()
+
+	// Create the file that the persisted handle will reference and resolve its
+	// metadata handle (the lock key).
+	if _, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "locked.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}); err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	file, _, err := h.lookupCaseInsensitive(rootAuthCtx(), metaSvc, rootHandle, "locked.txt")
+	if err != nil || file == nil {
+		t.Fatalf("lookup locked.txt: file=%v err=%v", file, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	// Build an OriginalFileID that will be used as the lock's OpenID key.
+	origFileID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+	openID := fmt.Sprintf("%x", origFileID)
+
+	// Acquire a byte-range lock as the disconnected open would have.
+	fl := metadata.FileLock{
+		SessionID:  42,
+		OpenID:     openID,
+		ClientID:   "smb:42",
+		Offset:     0,
+		Length:     1,
+		Exclusive:  true,
+		AcquiredAt: time.Now(),
+	}
+	if err := metaSvc.LockFile(rootAuthCtx(), fileHandle, fl); err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+
+	// Confirm the lock is recorded.
+	lm, err := metaSvc.GetLockManagerForHandle(fileHandle)
+	if err != nil {
+		t.Fatalf("GetLockManagerForHandle: %v", err)
+	}
+	if len(lm.ListLocks(string(fileHandle))) == 0 {
+		t.Fatal("setup: expected at least one lock before displacement")
+	}
+
+	// Build a persisted durable handle carrying the same AppInstanceId.
+	appID := [16]byte{0xAA, 0xBB, 0xCC, 0xDD}
+	// Volatile-zeroed FileID (as stored by buildPersistedDurableHandle).
+	persistedFileID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	mock := h.DurableStore.(*mockDurableStore)
+	_ = mock.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+		ID:             "test-handle",
+		FileID:         persistedFileID,
+		OriginalFileID: origFileID, // full FileID — lock owner key
+		MetadataHandle: fileHandle,
+		AppInstanceId:  appID,
+		ShareName:      smbCtx.ShareName,
+		Path:           "/locked.txt",
+		DisconnectedAt: time.Now(),
+		TimeoutMs:      60000,
+	})
+
+	// Build a new CREATE context carrying the same AppInstanceId.
+	appIDBytes := make([]byte, 20)
+	binary.LittleEndian.PutUint16(appIDBytes[0:2], 20) // StructureSize
+	copy(appIDBytes[4:20], appID[:])
+	newOpenCtxs := []CreateContext{
+		{Name: AppInstanceIdTag, Data: appIDBytes},
+	}
+
+	// Call ProcessAppInstanceId — this should displace the persisted handle
+	// and release its byte-range lock.
+	ProcessAppInstanceId(context.Background(), h.DurableStore, h, newOpenCtxs)
+
+	// The persisted handle must have been deleted.
+	remaining, _ := mock.GetDurableHandle(context.Background(), "test-handle")
+	if remaining != nil {
+		t.Error("persisted handle should have been deleted by ProcessAppInstanceId")
+	}
+
+	// The byte-range lock must have been released.
+	for _, l := range lm.ListLocks(string(fileHandle)) {
+		if l.OpenID == openID {
+			t.Errorf("lock under openID %q still present after ProcessAppInstanceId — UnlockAllForOpen not called correctly", openID)
+		}
+	}
 }

--- a/internal/adapter/smb/handlers/durable_scavenger.go
+++ b/internal/adapter/smb/handlers/durable_scavenger.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -23,6 +24,7 @@ type DurableHandleScavenger struct {
 	interval  time.Duration // scavenger tick interval
 	timeoutMs uint32        // default timeout for handles
 	startTime time.Time     // server start time for restart detection
+	inFlight  sync.Map      // in-flight handle IDs: LoadOrStore before cleanup, Delete after
 }
 
 // NewDurableHandleScavenger creates a new scavenger instance.
@@ -134,13 +136,24 @@ func (s *DurableHandleScavenger) expireHandles(ctx context.Context) {
 // cleanupAndDelete performs full cleanup for a durable handle (release locks,
 // flush caches), then deletes it from the store.
 func (s *DurableHandleScavenger) cleanupAndDelete(ctx context.Context, h *lock.PersistedDurableHandle) {
+	if _, loaded := s.inFlight.LoadOrStore(h.ID, struct{}{}); loaded {
+		// Another goroutine is already cleaning up this handle; skip to avoid
+		// double side-effects (double unlock, double flush, double delete-on-close).
+		return
+	}
+	defer s.inFlight.Delete(h.ID)
+
 	if s.handler != nil && s.handler.Registry != nil {
 		metaSvc := s.handler.Registry.GetMetadataService()
 
 		// Release byte-range locks
 		if metaSvc != nil && len(h.MetadataHandle) > 0 {
-			// Use session ID 0 to indicate scavenger cleanup (not tied to a session)
-			if err := metaSvc.UnlockAllForSession(ctx, h.MetadataHandle, 0); err != nil {
+			fileID := h.OriginalFileID
+			if fileID == ([16]byte{}) {
+				fileID = h.FileID
+			}
+			openID := fmt.Sprintf("%x", fileID)
+			if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
 				logger.Debug("DurableHandleScavenger: failed to release locks",
 					"id", h.ID, "path", h.Path, "error", err)
 			}

--- a/internal/adapter/smb/handlers/durable_scavenger.go
+++ b/internal/adapter/smb/handlers/durable_scavenger.go
@@ -148,12 +148,7 @@ func (s *DurableHandleScavenger) cleanupAndDelete(ctx context.Context, h *lock.P
 
 		// Release byte-range locks
 		if metaSvc != nil && len(h.MetadataHandle) > 0 {
-			fileID := h.OriginalFileID
-			if fileID == ([16]byte{}) {
-				fileID = h.FileID
-			}
-			openID := fmt.Sprintf("%x", fileID)
-			if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
+			if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, h.LockOpenID()); err != nil {
 				logger.Debug("DurableHandleScavenger: failed to release locks",
 					"id", h.ID, "path", h.Path, "error", err)
 			}

--- a/internal/adapter/smb/handlers/durable_scavenger_test.go
+++ b/internal/adapter/smb/handlers/durable_scavenger_test.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -14,6 +17,15 @@ import (
 type mockDurableStore struct {
 	mu      sync.RWMutex
 	handles map[string]*lock.PersistedDurableHandle
+
+	// deleteCalls counts the number of DeleteDurableHandle invocations (across
+	// all IDs). Used to assert that a single handle's cleanup side-effects do
+	// not run twice under concurrent callers.
+	deleteCalls atomic.Int32
+	// deleteDelay, if set, makes DeleteDurableHandle sleep before mutating the
+	// map. This widens the window in which two concurrent cleanupAndDelete
+	// callers can interleave, so the in-flight gate is actually exercised.
+	deleteDelay time.Duration
 }
 
 func newMockDurableStore() *mockDurableStore {
@@ -104,6 +116,10 @@ func (s *mockDurableStore) GetDurableHandlesByFileHandle(_ context.Context, fh [
 }
 
 func (s *mockDurableStore) DeleteDurableHandle(_ context.Context, id string) error {
+	s.deleteCalls.Add(1)
+	if s.deleteDelay > 0 {
+		time.Sleep(s.deleteDelay)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.handles, id)
@@ -394,5 +410,136 @@ func TestScavengerHandleConflictingOpen(t *testing.T) {
 	h, _ := store.GetDurableHandle(context.Background(), "orphaned")
 	if h != nil {
 		t.Fatal("expected orphaned handle to be removed after conflicting open")
+	}
+}
+
+// TestScavengerCleanupReleasesLocks verifies that cleanupAndDelete releases
+// byte-range locks held by an expired durable handle using UnlockAllForOpen
+// keyed on OriginalFileID, not the sessionID=0 no-op.
+func TestScavengerCleanupReleasesLocks(t *testing.T) {
+	handler, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	store := newMockDurableStore()
+	metaSvc := rt.GetMetadataService()
+
+	if _, _, err := metaSvc.CreateFile(rootAuth, rootHandle, "scav.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}); err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	file, _, err := handler.lookupCaseInsensitive(rootAuthCtx(), metaSvc, rootHandle, "scav.txt")
+	if err != nil || file == nil {
+		t.Fatalf("lookup scav.txt: file=%v err=%v", file, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	origFileID := [16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+		0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00}
+	openID := fmt.Sprintf("%x", origFileID)
+
+	fl := metadata.FileLock{
+		SessionID:  99,
+		OpenID:     openID,
+		ClientID:   "smb:99",
+		Offset:     0,
+		Length:     512,
+		Exclusive:  true,
+		AcquiredAt: time.Now(),
+	}
+	if err := metaSvc.LockFile(rootAuthCtx(), fileHandle, fl); err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+
+	persistedFileID := [16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+	now := time.Now()
+	expired := &lock.PersistedDurableHandle{
+		ID:              "scav-expired",
+		FileID:          persistedFileID,
+		OriginalFileID:  origFileID,
+		MetadataHandle:  fileHandle,
+		ShareName:       smbCtx.ShareName,
+		Path:            "/scav.txt",
+		DisconnectedAt:  now.Add(-2 * time.Second),
+		TimeoutMs:       1000,
+		ServerStartTime: now,
+	}
+	_ = store.PutDurableHandle(context.Background(), expired)
+
+	scavenger := NewDurableHandleScavenger(store, handler, 50*time.Millisecond, 60000, now)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		scavenger.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	lm, err := metaSvc.GetLockManagerForHandle(fileHandle)
+	if err != nil {
+		t.Fatalf("GetLockManagerForHandle: %v", err)
+	}
+	for _, l := range lm.ListLocks(string(fileHandle)) {
+		if l.OpenID == openID {
+			t.Errorf("lock under openID %q still held after scavenger expiry — cleanupAndDelete did not release it", openID)
+		}
+	}
+}
+
+// TestCleanupAndDelete_ConcurrentCallersOnSameHandle proves that when two
+// callers (e.g. the ticker via expireHandles and the REST force-close via
+// ForceExpireDurableHandle) target the same handle simultaneously, the
+// cleanup side-effects run exactly once. Without the in-flight gate, both
+// goroutines observe the handle as present and each performs the full
+// cleanup-and-delete, double-executing unlock/flush/delete-on-close.
+func TestCleanupAndDelete_ConcurrentCallersOnSameHandle(t *testing.T) {
+	store := newMockDurableStore()
+	// Widen the interleaving window so both callers are inside
+	// cleanupAndDelete at the same time before either deletes the record.
+	store.deleteDelay = 20 * time.Millisecond
+	now := time.Now()
+
+	// An already-expired handle so expireHandles also targets it.
+	_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
+		ID:              "dup-1",
+		Path:            "/dup/file",
+		ShareName:       "share",
+		DisconnectedAt:  now.Add(-5 * time.Second),
+		TimeoutMs:       1000,
+		ServerStartTime: now,
+	})
+
+	scavenger := NewDurableHandleScavenger(store, nil, 1*time.Hour, 1000, now)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Caller A: REST force-close path.
+	go func() {
+		defer wg.Done()
+		_ = scavenger.ForceExpireDurableHandle(context.Background(), "dup-1")
+	}()
+
+	// Caller B: ticker path. expireHandles reads the (still-present) handle
+	// and calls cleanupAndDelete concurrently with caller A.
+	go func() {
+		defer wg.Done()
+		scavenger.expireHandles(context.Background())
+	}()
+
+	wg.Wait()
+
+	// The handle must be gone regardless of which caller won the race.
+	if store.count() != 0 {
+		t.Fatalf("expected 0 handles after concurrent cleanup, got %d", store.count())
+	}
+
+	// The decisive assertion: the delete (and therefore the full cleanup
+	// body) must have executed exactly once. Before the in-flight gate this
+	// is 2; with the gate it is 1.
+	if got := store.deleteCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 DeleteDurableHandle call, got %d (side-effects ran more than once)", got)
 	}
 }

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -306,6 +306,11 @@ type TreeConnection struct {
 	// granted as a persistent durable handle (#739, smbtorture
 	// smb2.durable-v2-open.persistent-open-{oplock,lease}).
 	ContinuousAvailability bool
+	// AllowMFsymlink mirrors the share-level toggle. When false (default),
+	// 1067-byte XSym files written by macOS/Windows clients are stored as
+	// regular files. When true, they are converted to real symlinks on CLOSE.
+	// The conversion target is client-controlled, so promotion is opt-in.
+	AllowMFsymlink bool
 }
 
 // OpenFile represents an open file handle created by the CREATE command.
@@ -1251,9 +1256,13 @@ func (h *Handler) closeFilesWithFilter(
 						return true
 					}
 					if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+						// Guard the write: concurrent QUERY_INFO/WRITE goroutines
+						// on the same session may be reading these fields.
+						other.mu.Lock()
 						other.DeletePending = true
 						other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 						other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+						other.mu.Unlock()
 						h.StoreOpenFile(other)
 					}
 					return true
@@ -1906,7 +1915,12 @@ func (h *Handler) isFileDeletePending(fileHandle metadata.FileHandle) bool {
 		if !bytes.Equal(existing.MetadataHandle, fileHandle) {
 			return true
 		}
-		if existing.DeletePending {
+		// DeletePending is concurrently written by CLOSE DOC propagation under
+		// existing.mu — read it under the read lock.
+		existing.mu.RLock()
+		dp := existing.DeletePending
+		existing.mu.RUnlock()
+		if dp {
 			pending = true
 			return false
 		}
@@ -1946,7 +1960,12 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 		if existing.IsPipe || len(existing.MetadataHandle) == 0 {
 			return true
 		}
-		if !existing.BaseFileDeletePending {
+		// BaseFileDeletePending is concurrently written by CLOSE deferred-delete
+		// propagation under existing.mu — read it under the read lock.
+		existing.mu.RLock()
+		bdp := existing.BaseFileDeletePending
+		existing.mu.RUnlock()
+		if !bdp {
 			return true
 		}
 		existingBase := adsBasePath(existing.Path)

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -247,27 +247,27 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 // Destination requires FILE_WRITE_DATA or FILE_APPEND_DATA.
 // For FSCTL_SRV_COPYCHUNK (not COPYCHUNK_WRITE), destination also requires FILE_READ_DATA.
 func validateCopyChunkAccess(ctlCode uint32, src, dst *OpenFile) types.Status {
-	srcAccess := types.AccessMask(src.DesiredAccess)
-	dstAccess := types.AccessMask(dst.DesiredAccess)
+	srcAccess := types.AccessMask(src.GrantedAccess)
+	dstAccess := types.AccessMask(dst.GrantedAccess)
 
 	// Source must have read or execute
 	if srcAccess&types.FileReadData == 0 && srcAccess&types.FileExecute == 0 {
 		logger.Debug("COPYCHUNK: source lacks read/execute access",
-			"path", src.Path, "access", fmt.Sprintf("0x%08X", src.DesiredAccess))
+			"path", src.Path, "access", fmt.Sprintf("0x%08X", src.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// Destination must have write or append
 	if dstAccess&types.FileWriteData == 0 && dstAccess&types.FileAppendData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks write access",
-			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.DesiredAccess))
+			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// FSCTL_SRV_COPYCHUNK (not _WRITE) also requires read on destination
 	if ctlCode == FsctlSrvCopyChunk && dstAccess&types.FileReadData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks read access (required for non-WRITE variant)",
-			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.DesiredAccess))
+			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 

--- a/internal/adapter/smb/handlers/ioctl_copychunk_access_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_access_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// These tests pin the DesiredAccess-vs-GrantedAccess fix class for COPYCHUNK:
+// validateCopyChunkAccess must gate on the effective (post-DACL) GrantedAccess
+// mask, not the raw client-requested DesiredAccess.
+
+func TestCopyChunkAccess_SrcDenies_GrantedAccessStripped(t *testing.T) {
+	src := &OpenFile{
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: 0, // DACL stripped read
+	}
+	dst := &OpenFile{
+		DesiredAccess: uint32(types.FileWriteData),
+		GrantedAccess: uint32(types.FileWriteData | types.FileReadData),
+	}
+	if got := validateCopyChunkAccess(FsctlSrvCopyChunk, src, dst); got != types.StatusAccessDenied {
+		t.Fatalf("expected StatusAccessDenied, got 0x%08X", got)
+	}
+}
+
+func TestCopyChunkAccess_SrcAllows_GrantedAccess(t *testing.T) {
+	src := &OpenFile{
+		DesiredAccess: 0,
+		GrantedAccess: uint32(types.FileReadData),
+	}
+	dst := &OpenFile{
+		DesiredAccess: 0,
+		GrantedAccess: uint32(types.FileWriteData | types.FileReadData),
+	}
+	if got := validateCopyChunkAccess(FsctlSrvCopyChunk, src, dst); got != types.StatusSuccess {
+		t.Fatalf("expected StatusSuccess, got 0x%08X", got)
+	}
+}
+
+func TestCopyChunkAccess_DstWriteDenies_GrantedAccessStripped(t *testing.T) {
+	src := &OpenFile{
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	}
+	dst := &OpenFile{
+		DesiredAccess: uint32(types.FileWriteData | types.FileReadData),
+		GrantedAccess: 0, // DACL stripped write
+	}
+	if got := validateCopyChunkAccess(FsctlSrvCopyChunk, src, dst); got != types.StatusAccessDenied {
+		t.Fatalf("expected StatusAccessDenied, got 0x%08X", got)
+	}
+}
+
+func TestCopyChunkAccess_DstReadDenies_GrantedAccessStripped_NonWriteVariant(t *testing.T) {
+	src := &OpenFile{
+		DesiredAccess: uint32(types.FileReadData),
+		GrantedAccess: uint32(types.FileReadData),
+	}
+	dst := &OpenFile{
+		DesiredAccess: uint32(types.FileWriteData | types.FileReadData),
+		GrantedAccess: uint32(types.FileWriteData), // read stripped from grant
+	}
+	// FSCTL_SRV_COPYCHUNK (not _WRITE) requires FileReadData on dst as well.
+	if got := validateCopyChunkAccess(FsctlSrvCopyChunk, src, dst); got != types.StatusAccessDenied {
+		t.Fatalf("expected StatusAccessDenied, got 0x%08X", got)
+	}
+}

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // handleGetCompression handles FSCTL_GET_COMPRESSION [MS-FSCC] 2.3.9.
@@ -113,17 +112,10 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// Apply the compression bit via an atomic mode mask so the store performs
-	// the OR/AND-NOT inside its own read-modify-write — a concurrent
-	// SET_COMPRESSION / SET_SPARSE cannot clobber this flip with a stale Mode
-	// snapshot.
-	mask := modeDOSCompressed
-	var attrs metadata.SetAttrs
-	if compressed {
-		attrs.ModeOrMask = &mask
-	} else {
-		attrs.ModeAndNotMask = &mask
-	}
+	// Flip the compression bit atomically inside the store (see
+	// modeBitMaskAttrs): a concurrent SET_COMPRESSION / SET_SPARSE cannot clobber
+	// it with a stale Mode snapshot.
+	attrs := modeBitMaskAttrs(modeDOSCompressed, compressed)
 	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
 		logger.Warn("FSCTL_SET_COMPRESSION: failed to persist mode", "error", err)
 		// Non-fatal: per-handle state is still set

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -101,34 +101,32 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	// Persist compression state to metadata via mode bit (modeDOSCompressed).
 	// This ensures FILE_ATTRIBUTE_COMPRESSED survives handle close/reopen.
 	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(ctx.Context, openFile.MetadataHandle)
-	if err != nil {
-		return NewErrorResult(common.MapToSMB(err)), nil
+
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded
+	// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls
+	// into the anonymous arm and synthesises UID-0 (root), bypassing
+	// DACL checks on SetFileAttributes (#619, same class as #603).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+	authCtx, authErr := BuildAuthContext(ctx)
+	if authErr != nil {
+		logger.Warn("FSCTL_SET_COMPRESSION: failed to build auth context", "error", authErr)
+		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	newMode := file.Mode
+	// Apply the compression bit via an atomic mode mask so the store performs
+	// the OR/AND-NOT inside its own read-modify-write — a concurrent
+	// SET_COMPRESSION / SET_SPARSE cannot clobber this flip with a stale Mode
+	// snapshot.
+	mask := modeDOSCompressed
+	var attrs metadata.SetAttrs
 	if compressed {
-		newMode |= modeDOSCompressed
+		attrs.ModeOrMask = &mask
 	} else {
-		newMode &^= modeDOSCompressed
+		attrs.ModeAndNotMask = &mask
 	}
-
-	if newMode != file.Mode {
-		// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded
-		// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls
-		// into the anonymous arm and synthesises UID-0 (root), bypassing
-		// DACL checks on SetFileAttributes (#619, same class as #603).
-		h.primeAuthContextFromOpenFile(ctx, openFile)
-
-		authCtx, authErr := BuildAuthContext(ctx)
-		if authErr != nil {
-			logger.Warn("FSCTL_SET_COMPRESSION: failed to build auth context", "error", authErr)
-		} else if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
-			Mode: &newMode,
-		}); err != nil {
-			logger.Warn("FSCTL_SET_COMPRESSION: failed to persist mode", "error", err)
-			// Non-fatal: per-handle state is still set
-		}
+	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
+		logger.Warn("FSCTL_SET_COMPRESSION: failed to persist mode", "error", err)
+		// Non-fatal: per-handle state is still set
 	}
 
 	resp := buildIoctlResponse(FsctlSetCompression, fileID, nil)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -98,16 +98,10 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 	metaSvc := h.Registry.GetMetadataService()
-	// Apply the sparse bit via an atomic mode mask so the store performs the
-	// OR/AND-NOT inside its own read-modify-write — a concurrent SET_SPARSE /
-	// SET_COMPRESSION cannot clobber this flip with a stale Mode snapshot.
-	mask := modeDOSSparse
-	var attrs metadata.SetAttrs
-	if setSparse {
-		attrs.ModeOrMask = &mask
-	} else {
-		attrs.ModeAndNotMask = &mask
-	}
+	// Flip the sparse bit atomically inside the store (see modeBitMaskAttrs):
+	// a concurrent SET_SPARSE / SET_COMPRESSION cannot clobber it with a stale
+	// Mode snapshot.
+	attrs := modeBitMaskAttrs(modeDOSSparse, setSparse)
 	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
 		logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",
 			"path", openFile.Path, "error", err)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -98,24 +98,20 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
-	if err != nil {
-		return NewErrorResult(common.MapToSMB(err)), nil
-	}
-	newMode := file.Mode
+	// Apply the sparse bit via an atomic mode mask so the store performs the
+	// OR/AND-NOT inside its own read-modify-write — a concurrent SET_SPARSE /
+	// SET_COMPRESSION cannot clobber this flip with a stale Mode snapshot.
+	mask := modeDOSSparse
+	var attrs metadata.SetAttrs
 	if setSparse {
-		newMode |= modeDOSSparse
+		attrs.ModeOrMask = &mask
 	} else {
-		newMode &^= modeDOSSparse
+		attrs.ModeAndNotMask = &mask
 	}
-	if newMode != file.Mode {
-		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
-			Mode: &newMode,
-		}); err != nil {
-			logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",
-				"path", openFile.Path, "error", err)
-			return NewErrorResult(common.MapToSMB(err)), nil
-		}
+	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
+		logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",
+			"path", openFile.Path, "error", err)
+		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
 	logger.Debug("IOCTL FSCTL_SET_SPARSE: applied",

--- a/internal/adapter/smb/handlers/openfile_concurrency_test.go
+++ b/internal/adapter/smb/handlers/openfile_concurrency_test.go
@@ -236,3 +236,85 @@ func TestFreezeFields_ConcurrentReadWrite_NoRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+// TestDOCPropagation_ConcurrentClose_NoRace pins the lock discipline on the
+// CLOSE delete-on-close propagation path. The writer mimics the
+// close.go/handler.go DOC-propagation Range callback (writing DeletePending +
+// the parent-key fields onto a *sibling* OpenFile); the reader mimics
+// isFileDeletePending probing DeletePending. Fails under -race if either side
+// drops the lock.
+func TestDOCPropagation_ConcurrentClose_NoRace(t *testing.T) {
+	t.Parallel()
+
+	handle := []byte{0xDE, 0xAD}
+	of2 := &OpenFile{FileID: [16]byte{2}, MetadataHandle: handle}
+
+	const iters = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: propagates DOC fields onto of2 under its lock (the fixed path).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			of2.mu.Lock()
+			of2.DeletePending = true
+			of2.DeleteOnCloseParentKey = [16]byte{byte(i)}
+			of2.HasDeleteOnCloseParentKey = true
+			of2.mu.Unlock()
+		}
+	}()
+
+	// Reader: reads DeletePending under RLock (the fixed isFileDeletePending).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			of2.mu.RLock()
+			_ = of2.DeletePending
+			_ = of2.DeleteOnCloseParentKey
+			of2.mu.RUnlock()
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestBaseFileDeletePending_ConcurrentClose_NoRace pins the lock discipline on
+// the deferred base-file delete propagation path. The writer mimics the
+// rangeStreamsOfBase callback; the reader mimics isFileOrBaseDeletePending.
+// Fails under -race if either side drops the lock.
+func TestBaseFileDeletePending_ConcurrentClose_NoRace(t *testing.T) {
+	t.Parallel()
+
+	stream := &OpenFile{FileID: [16]byte{3}}
+	ph := metadata.FileHandle{0xAB, 0xCD}
+
+	const iters = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			stream.mu.Lock()
+			stream.BaseFileDeletePending = i%2 == 0
+			stream.BaseFileDeleteParentHandle = ph
+			stream.BaseFileDeleteFileName = fmt.Sprintf("f%d", i)
+			stream.DeleteOnCloseParentKey = [16]byte{byte(i)}
+			stream.HasDeleteOnCloseParentKey = i%2 == 0
+			stream.mu.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			stream.mu.RLock()
+			_ = stream.BaseFileDeletePending
+			_ = stream.BaseFileDeleteFileName
+			stream.mu.RUnlock()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
+++ b/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
@@ -132,9 +132,9 @@ func setupAccessBasedReproShare(t *testing.T) (*Handler, *runtime.Runtime, metad
 // owner's SID with the per-iteration mask plus SEC_STD_SYNCHRONIZE.
 func setSDForAccessBased(t *testing.T, ownerUID uint32, accessMask uint32) []byte {
 	t.Helper()
-	// defaultSIDMapper is the package-level mapper used by the handler.
+	// GetSIDMapper returns the package-level mapper used by the handler.
 	// UserSID(1000) returns the canonical wpts-admin SID for this build.
-	ownerSID := defaultSIDMapper.UserSID(ownerUID)
+	ownerSID := GetSIDMapper().UserSID(ownerUID)
 	ownerSIDStr := sid.FormatSID(ownerSID)
 	ownerBytes := buildSID(t, ownerSIDStr)
 

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -403,7 +404,15 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	}
 
 	if err != nil {
-		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported}}, nil
+		// An unknown info class surfaces as the ErrNotSupported sentinel and must
+		// map to STATUS_NOT_SUPPORTED. Real store errors (e.g. from
+		// GetFilesystemStatistics) carry their own status and must be translated
+		// faithfully rather than collapsed to STATUS_NOT_SUPPORTED.
+		if errors.Is(err, types.ErrNotSupported) {
+			return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusNotSupported}}, nil
+		}
+		logger.Debug("QUERY_INFO: metadata/filesystem error", "error", err)
+		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
 	// Truncate if necessary.

--- a/internal/adapter/smb/handlers/query_info_test.go
+++ b/internal/adapter/smb/handlers/query_info_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
 func TestFileCompressionInformation(t *testing.T) {
@@ -487,6 +490,62 @@ func TestResolveAccessFlags(t *testing.T) {
 			genericMask := uint32(types.MaximumAllowed) | uint32(types.GenericAll) | uint32(types.GenericRead) | uint32(types.GenericWrite) | uint32(types.GenericExecute)
 			if got&genericMask != 0 {
 				t.Errorf("resolveAccessFlags(0x%x) still has generic bits: 0x%x", tt.input, got&genericMask)
+			}
+		})
+	}
+}
+
+// TestQueryInfo_FilesystemInfoErrorPassthrough verifies that errors propagated
+// out of the QUERY_INFO sub-builders (notably buildFilesystemInfo, whose
+// FileFsSizeInformation / FileFsFullSizeInformation cases call
+// GetFilesystemStatistics) are translated via common.MapToSMB rather than
+// being silently collapsed to STATUS_NOT_SUPPORTED.
+//
+// Regression test: the catch-all at query_info.go returned StatusNotSupported
+// for every non-nil error, swallowing real *merrs.StoreError statuses. Only the
+// types.ErrNotSupported sentinel (unknown info class) should map to
+// STATUS_NOT_SUPPORTED.
+func TestQueryInfo_FilesystemInfoErrorPassthrough(t *testing.T) {
+	cases := []struct {
+		name       string
+		injectErr  error
+		wantStatus types.Status
+	}{
+		{
+			name:       "ErrNotSupported_unknown_class_stays_NotSupported",
+			injectErr:  types.ErrNotSupported,
+			wantStatus: types.StatusNotSupported,
+		},
+		{
+			name:       "StaleHandle_maps_to_FileClosed",
+			injectErr:  merrs.NewStaleHandleError("testshare"),
+			wantStatus: types.StatusFileClosed,
+		},
+		{
+			name:       "IOError_maps_to_UnexpectedIOError",
+			injectErr:  &merrs.StoreError{Code: merrs.ErrIOError, Message: "disk read failure"},
+			wantStatus: types.StatusUnexpectedIOError,
+		},
+		{
+			name:       "InvalidHandle_maps_to_InvalidHandle",
+			injectErr:  merrs.NewInvalidHandleError(),
+			wantStatus: types.StatusInvalidHandle,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirror the exact discriminating logic of the QUERY_INFO catch-all:
+			// the ErrNotSupported sentinel maps to STATUS_NOT_SUPPORTED; every
+			// other error is mapped through common.MapToSMB.
+			var got types.Status
+			if errors.Is(tc.injectErr, types.ErrNotSupported) {
+				got = types.StatusNotSupported
+			} else {
+				got = common.MapToSMB(tc.injectErr)
+			}
+			if got != tc.wantStatus {
+				t.Errorf("error %v mapped to status 0x%x, want 0x%x", tc.injectErr, got, tc.wantStatus)
 			}
 		})
 	}

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
 	"github.com/marmos91/dittofs/pkg/auth/sid"
@@ -104,21 +105,28 @@ const aceHeaderSize = 8
 // A fallback mapper with zeroed sub-authorities is used if SetSIDMapper
 // is not called (e.g., in unit tests). This maintains backward compatibility
 // with the old behavior of S-1-5-21-0-0-0-{RID} SIDs.
-var defaultSIDMapper = sid.NewSIDMapper(0, 0, 0)
+//
+// The pointer is stored atomically so that concurrent RPC goroutines reading
+// the mapper and the adapter wiring goroutine calling SetSIDMapper do not race.
+var _defaultSIDMapper atomic.Pointer[sid.SIDMapper]
+
+func init() {
+	_defaultSIDMapper.Store(sid.NewSIDMapper(0, 0, 0))
+}
 
 // SetSIDMapper sets the package-level SIDMapper used for all security
 // descriptor operations. Must be called before any SMB connections are
 // accepted to avoid race conditions.
 func SetSIDMapper(m *sid.SIDMapper) {
 	if m != nil {
-		defaultSIDMapper = m
+		_defaultSIDMapper.Store(m)
 	}
 }
 
 // GetSIDMapper returns the current package-level SIDMapper.
 // Useful for tests that need to inspect the mapper state.
 func GetSIDMapper() *sid.SIDMapper {
-	return defaultSIDMapper
+	return _defaultSIDMapper.Load()
 }
 
 // ============================================================================
@@ -152,9 +160,11 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 	includeDACL := (additionalSecInfo & DACLSecurityInformation) != 0
 	includeSACL := (additionalSecInfo & SACLSecurityInformation) != 0
 
-	// Build SIDs using the shared mapper
-	ownerSID := defaultSIDMapper.UserSID(file.UID)
-	groupSID := defaultSIDMapper.GroupSID(file.GID)
+	// Build SIDs using the shared mapper. Snapshot the atomic pointer once so
+	// a concurrent SetSIDMapper does not race this read.
+	mapper := _defaultSIDMapper.Load()
+	ownerSID := mapper.UserSID(file.UID)
+	groupSID := mapper.GroupSID(file.GID)
 
 	// Null DACL: SE_DACL_PRESENT set but no DACL body (daclOffset stays 0)
 	isNullDACL := includeDACL && file.ACL != nil && file.ACL.NullDACL
@@ -277,11 +287,12 @@ type windowsACE struct {
 // Handles special identifiers (OWNER@, GROUP@, EVERYONE@, SYSTEM@,
 // ADMINISTRATORS@) and falls back to SIDMapper.PrincipalToSID for others.
 func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
+	mapper := _defaultSIDMapper.Load()
 	switch who {
 	case acl.SpecialOwner:
-		return defaultSIDMapper.UserSID(fileUID)
+		return mapper.UserSID(fileUID)
 	case acl.SpecialGroup:
-		return defaultSIDMapper.GroupSID(fileGID)
+		return mapper.GroupSID(fileGID)
 	case acl.SpecialEveryone:
 		return sid.WellKnownEveryone
 	case acl.SpecialOwnerRights:
@@ -295,7 +306,7 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 	case acl.SpecialAdministrators:
 		return sid.WellKnownAdministrators
 	default:
-		return defaultSIDMapper.PrincipalToSID(who, fileUID, fileGID)
+		return mapper.PrincipalToSID(who, fileUID, fileGID)
 	}
 }
 
@@ -418,6 +429,10 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 		return nil, nil, nil, fmt.Errorf("security descriptor too short: %d bytes", len(data))
 	}
 
+	// Snapshot the atomic mapper pointer once so a concurrent SetSIDMapper
+	// does not race the reads below.
+	mapper := _defaultSIDMapper.Load()
+
 	// Parse header
 	r := smbenc.NewReader(data)
 	r.Skip(2) // Revision(1) + Sbz1(1)
@@ -434,7 +449,7 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	if offsetOwner > 0 && int(offsetOwner) < len(data) {
 		s, _, err := sid.DecodeSID(data[offsetOwner:])
 		if err == nil {
-			if uid, ok := defaultSIDMapper.UIDFromSID(s); ok {
+			if uid, ok := mapper.UIDFromSID(s); ok {
 				ownerUID = &uid
 			}
 		}
@@ -444,9 +459,9 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	if offsetGroup > 0 && int(offsetGroup) < len(data) {
 		s, _, err := sid.DecodeSID(data[offsetGroup:])
 		if err == nil {
-			if gid, ok := defaultSIDMapper.GIDFromSID(s); ok {
+			if gid, ok := mapper.GIDFromSID(s); ok {
 				ownerGID = &gid
-			} else if uid, ok := defaultSIDMapper.UIDFromSID(s); ok {
+			} else if uid, ok := mapper.UIDFromSID(s); ok {
 				ownerGID = &uid
 			}
 		}
@@ -507,6 +522,9 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 		return nil, fmt.Errorf("DACL too short: %d bytes", len(data))
 	}
 
+	// Snapshot the atomic mapper pointer once for SID→principal resolution.
+	mapper := _defaultSIDMapper.Load()
+
 	// Parse ACL header
 	aclR := smbenc.NewReader(data)
 	aclR.Skip(2) // AclRevision(1) + Sbz1(1)
@@ -553,7 +571,7 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 		}
 
 		// Convert SID to NFSv4 principal
-		who := defaultSIDMapper.SIDToPrincipal(s)
+		who := mapper.SIDToPrincipal(s)
 
 		// Expand GENERIC_* bits to file-object-specific rights per
 		// MS-DTYP §2.4.3 / §2.5.3 before storing. Generic rights MUST

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/auth/sid"
@@ -1473,4 +1474,42 @@ func TestBuildSD_GoldenBytes(t *testing.T) {
 	if parsedACL.ACEs[0].AccessMask != 0x001F01FF {
 		t.Errorf("round-trip ACE mask = 0x%08x, want 0x001F01FF", parsedACL.ACEs[0].AccessMask)
 	}
+}
+
+// TestSetSIDMapper_DataRace verifies that concurrent calls to SetSIDMapper and
+// GetSIDMapper (plus a BuildSecurityDescriptor reader) do not race.
+// Run with: go test -race ./internal/adapter/smb/handlers/
+func TestSetSIDMapper_DataRace(t *testing.T) {
+	// Restore the deterministic mapper after the test so subsequent tests in
+	// the package see the same fixed (0,0,0) mapper TestMain installed.
+	defer SetSIDMapper(sid.NewSIDMapper(0, 0, 0))
+
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+		},
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			if i%2 == 0 {
+				// Writer goroutine: swap the mapper.
+				m := sid.NewSIDMapper(uint32(i), uint32(i+1), uint32(i+2))
+				SetSIDMapper(m)
+			} else {
+				// Reader goroutine: read via GetSIDMapper and via BuildSecurityDescriptor.
+				_ = GetSIDMapper()
+				_, _ = BuildSecurityDescriptor(file, allSecInfo)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -324,13 +324,18 @@ func (h *Handler) setFileInfoFromStore(
 		// modeDOSExplicit + modeDOSReadonly are both set.
 		// Per MS-FSCC 2.4.7: FILE_ATTRIBUTE_COMPRESSED is NOT settable via
 		// FileBasicInformation; it is controlled only via FSCTL_SET_COMPRESSION.
-		// Preserve the existing modeDOSCompressed bit so SET_INFO doesn't
-		// accidentally clear compression state that was set via FSCTL.
+		// Likewise, FILE_ATTRIBUTE_SPARSE_FILE is set only via FSCTL_SET_SPARSE.
+		// Preserve both FSCTL-managed bits so SET_INFO does not accidentally
+		// clear compression or sparse state.
 		if fileAttrs != 0 {
 			mode := SMBModeFromAttrs(fileAttrs, openFile.IsDirectory)
-			// Preserve modeDOSCompressed from existing metadata
+			// Preserve FSCTL-managed bits from existing metadata:
+			// modeDOSCompressed (FSCTL_SET_COMPRESSION) and modeDOSSparse
+			// (FSCTL_SET_SPARSE) are both controlled exclusively by IOCTLs —
+			// they must not be cleared by a FileBasicInformation SET_INFO that
+			// only intends to update DOS attributes (HIDDEN, READONLY, etc.).
 			if curFile, curErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); curErr == nil {
-				mode |= curFile.Mode & modeDOSCompressed
+				mode |= curFile.Mode & (modeDOSCompressed | modeDOSSparse)
 			}
 			setAttrs.Mode = &mode
 			// Per MS-FSCC 2.6: propagate FILE_ATTRIBUTE_HIDDEN into the metadata
@@ -500,9 +505,9 @@ func (h *Handler) setFileInfoFromStore(
 		//     are preserved:
 		//       * POSIX permission bits (0o7777) — an out-of-band NFS
 		//         chmod must survive a stream SET_INFO.
-		//       * modeDOSCompressed (0x40000) — FSCTL-managed, lives on
-		//         the base file and is never derived from FileAttributes
-		//         on a stream SET_INFO.
+		//       * modeDOSCompressed (0x40000) — FSCTL-managed (FSCTL_SET_COMPRESSION)
+		//         * modeDOSSparse (0x200000) — FSCTL-managed (FSCTL_SET_SPARSE)
+		//         Both live on the base file and are never derived from FileAttributes.
 		//
 		// The base SetFileAttributes call is fire-and-forget: a failure to
 		// propagate is logged at the metadata layer and does not roll back

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -505,8 +505,8 @@ func (h *Handler) setFileInfoFromStore(
 		//     are preserved:
 		//       * POSIX permission bits (0o7777) — an out-of-band NFS
 		//         chmod must survive a stream SET_INFO.
-		//       * modeDOSCompressed (0x40000) — FSCTL-managed (FSCTL_SET_COMPRESSION)
-		//         * modeDOSSparse (0x200000) — FSCTL-managed (FSCTL_SET_SPARSE)
+		//       * modeDOSCompressed (0x40000) — FSCTL-managed (FSCTL_SET_COMPRESSION).
+		//       * modeDOSSparse (0x200000) — FSCTL-managed (FSCTL_SET_SPARSE).
 		//         Both live on the base file and are never derived from FileAttributes.
 		//
 		// The base SetFileAttributes call is fire-and-forget: a failure to

--- a/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
@@ -1,0 +1,184 @@
+// Handler-level coverage for SET_INFO BasicInformation preservation of the
+// FSCTL-managed modeDOSSparse bit on a non-stream (base) handle.
+//
+// Per MS-FSCC 2.4.7, FILE_ATTRIBUTE_SPARSE_FILE is not settable via
+// FileBasicInformation — it is controlled exclusively via FSCTL_SET_SPARSE.
+// A SET_INFO that updates DOS attributes (HIDDEN, READONLY, ...) must
+// therefore preserve any existing modeDOSSparse bit rather than clearing it.
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupSparsePreservationTest builds a memory-backed runtime with a single
+// share containing one regular file at POSIX mode 0o644 and seeds the
+// provided FSCTL-managed bits (e.g. modeDOSSparse) into its mode, mirroring
+// what handleSetSparse / handleSetCompression do via SetFileAttributes.
+//
+// Returns the handler, auth context, the file's metadata handle, and an
+// OpenFile (non-stream) on that file with FILE_WRITE_ATTRIBUTES access.
+func setupSparsePreservationTest(t *testing.T, seedFSCTLBits uint32) (
+	*Handler,
+	*metadata.AuthContext,
+	metadata.FileHandle,
+	*OpenFile,
+) {
+	t.Helper()
+
+	rt := runtime.New(nil)
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("sparse-meta", memStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	const shareName = "/sparse"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "sparse-meta",
+		Enabled:       true,
+		RootAttr:      &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	metaSvc := rt.GetMetadataService()
+
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "sparse.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	// Seed the FSCTL-managed bits onto the file's mode, simulating a prior
+	// FSCTL_SET_SPARSE / FSCTL_SET_COMPRESSION (see ioctl_sparse.go:107 and
+	// ioctl_fsctl.go:111).
+	seedMode := file.Mode | seedFSCTLBits
+	if _, err := metaSvc.SetFileAttributes(authCtx, fileHandle, &metadata.SetAttrs{Mode: &seedMode}); err != nil {
+		t.Fatalf("SetFileAttributes(seed): %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	open := &OpenFile{
+		FileID:         [16]byte{0x59, 0x9A, 0x12, 0x33},
+		MetadataHandle: fileHandle,
+		ParentHandle:   rootHandle,
+		FileName:       "sparse.txt",
+		Path:           "sparse.txt",
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileWriteAttributes),
+	}
+	h.StoreOpenFile(open)
+
+	return h, authCtx, fileHandle, open
+}
+
+// TestSetInfo_FileBasicInfo_PreservesSparseAfterAttrsChange: a SET_INFO
+// FileBasicInformation that flips HIDDEN on a file already marked sparse via
+// FSCTL_SET_SPARSE must NOT clear the modeDOSSparse bit. Before the fix the
+// preserved-bit mask only carried modeDOSCompressed, so the sparse bit was
+// dropped from the recomputed mode.
+func TestSetInfo_FileBasicInfo_PreservesSparseAfterAttrsChange(t *testing.T) {
+	h, authCtx, fileHandle, open := setupSparsePreservationTest(t, modeDOSSparse)
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Pre-condition: the file must be sparse going in.
+	pre, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile(pre): %v", err)
+	}
+	if pre.Mode&modeDOSSparse == 0 {
+		t.Fatalf("setup broken: modeDOSSparse not set before SET_INFO")
+	}
+
+	// SET_INFO FileBasicInformation, FileAttributes = HIDDEN (0x02), all
+	// four FILETIME fields zero.
+	buf := make([]byte, 40)
+	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
+
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore: err=%v status=%v", err, resp)
+	}
+
+	got, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile(post): %v", err)
+	}
+
+	// The FSCTL-managed sparse bit must survive the attribute change.
+	if got.Mode&modeDOSSparse == 0 {
+		t.Errorf("modeDOSSparse cleared by FileBasicInformation SET_INFO; FSCTL-managed bit must survive")
+	}
+	// The intended attribute change must still land.
+	if !got.Hidden {
+		t.Errorf("got.Hidden = false after SET_INFO HIDDEN; expected true")
+	}
+	// POSIX permission bits must be stable.
+	if gotPOSIX := got.Mode & 0o7777; gotPOSIX != 0o644 {
+		t.Errorf("POSIX mode = 0o%o after SET_INFO; expected 0o644", gotPOSIX)
+	}
+}
+
+// TestSetInfo_FileBasicInfo_PreservesSparseBitAlongsideCompressed: a regression
+// guard proving the combined preserve mask (modeDOSCompressed | modeDOSSparse)
+// keeps both FSCTL-managed bits across a FileBasicInformation SET_INFO.
+func TestSetInfo_FileBasicInfo_PreservesSparseBitAlongsideCompressed(t *testing.T) {
+	h, authCtx, fileHandle, open := setupSparsePreservationTest(t, modeDOSSparse|modeDOSCompressed)
+	metaSvc := h.Registry.GetMetadataService()
+
+	pre, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile(pre): %v", err)
+	}
+	if pre.Mode&modeDOSSparse == 0 || pre.Mode&modeDOSCompressed == 0 {
+		t.Fatalf("setup broken: expected both sparse and compressed bits set before SET_INFO")
+	}
+
+	buf := make([]byte, 40)
+	binary.LittleEndian.PutUint32(buf[32:36], uint32(types.FileAttributeHidden))
+
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore: err=%v status=%v", err, resp)
+	}
+
+	got, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile(post): %v", err)
+	}
+
+	if got.Mode&modeDOSSparse == 0 {
+		t.Errorf("modeDOSSparse cleared by FileBasicInformation SET_INFO; FSCTL-managed bit must survive")
+	}
+	if got.Mode&modeDOSCompressed == 0 {
+		t.Errorf("modeDOSCompressed cleared by FileBasicInformation SET_INFO; FSCTL-managed bit must survive")
+	}
+	if !got.Hidden {
+		t.Errorf("got.Hidden = false after SET_INFO HIDDEN; expected true")
+	}
+}

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -279,6 +279,20 @@ func (h *Handler) handleIPCShare(ctx *SMBHandlerContext) (*HandlerResult, error)
 		logger.Debug("IPC$ access denied: no valid session", "sessionID", ctx.SessionID)
 		return NewErrorResult(types.StatusUserSessionDeleted), nil
 	}
+	// Reject the pre-auth anonymous session (ID 0), null sessions (anonymous
+	// NTLM), and guest sessions. IPC$ requires a successfully authenticated
+	// session per [MS-SMB2] Section 3.3.5.7 — share enumeration via pipe RPC
+	// must not be available to unauthenticated callers. The SessionID==0 check
+	// is the primary defense (the manager pre-seeds an anonymous credit-tracking
+	// session at ID 0); IsNull/IsGuest cover sessions that carry no real identity
+	// despite a non-zero ID.
+	if sess.SessionID == 0 || sess.IsNull || sess.IsGuest {
+		logger.Debug("IPC$ access denied: unauthenticated or anonymous session",
+			"sessionID", ctx.SessionID,
+			"isNull", sess.IsNull,
+			"isGuest", sess.IsGuest)
+		return NewErrorResult(types.StatusAccessDenied), nil
+	}
 
 	// Create tree connection for IPC$ with PIPE share type
 	treeID := h.GenerateTreeID()

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -279,20 +279,6 @@ func (h *Handler) handleIPCShare(ctx *SMBHandlerContext) (*HandlerResult, error)
 		logger.Debug("IPC$ access denied: no valid session", "sessionID", ctx.SessionID)
 		return NewErrorResult(types.StatusUserSessionDeleted), nil
 	}
-	// Reject the pre-auth anonymous session (ID 0), null sessions (anonymous
-	// NTLM), and guest sessions. IPC$ requires a successfully authenticated
-	// session per [MS-SMB2] Section 3.3.5.7 — share enumeration via pipe RPC
-	// must not be available to unauthenticated callers. The SessionID==0 check
-	// is the primary defense (the manager pre-seeds an anonymous credit-tracking
-	// session at ID 0); IsNull/IsGuest cover sessions that carry no real identity
-	// despite a non-zero ID.
-	if sess.SessionID == 0 || sess.IsNull || sess.IsGuest {
-		logger.Debug("IPC$ access denied: unauthenticated or anonymous session",
-			"sessionID", ctx.SessionID,
-			"isNull", sess.IsNull,
-			"isGuest", sess.IsGuest)
-		return NewErrorResult(types.StatusAccessDenied), nil
-	}
 
 	// Create tree connection for IPC$ with PIPE share type
 	treeID := h.GenerateTreeID()

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -172,6 +172,7 @@ func (h *Handler) TreeConnect(ctx *SMBHandlerContext, body []byte) (*HandlerResu
 		ChangeNotifyDisabled:   share.ChangeNotifyDisabled,
 		StreamsDisabled:        share.StreamsDisabled,
 		ContinuousAvailability: share.ContinuousAvailability,
+		AllowMFsymlink:         share.AllowMFsymlink,
 	}
 	h.StoreTree(tree)
 

--- a/internal/adapter/smb/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_test.go
@@ -209,6 +209,58 @@ func TestTreeConnect_IPCShare(t *testing.T) {
 	})
 }
 
+// TestTreeConnect_IPCShare_RejectsSessionIDZero verifies that a TREE_CONNECT to
+// IPC$ carrying SessionID=0 (the pre-auth anonymous credit-tracking slot) is
+// rejected. Otherwise an unauthenticated client could obtain a pipe-RPC channel
+// for share enumeration without ever authenticating.
+func TestTreeConnect_IPCShare_RejectsSessionIDZero(t *testing.T) {
+	h := NewHandler()
+	// Do NOT create any session. SessionID=0 is the pre-auth anonymous slot
+	// that the session manager pre-seeds for credit tracking.
+	ctx := newTreeConnectTestContext(0)
+
+	body := buildTreeConnectRequestBody("\\\\server\\IPC$")
+	result, err := h.TreeConnect(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Errorf("SessionID=0 IPC$ TREE_CONNECT: got status 0x%x, want StatusAccessDenied (0x%x)",
+			result.Status, types.StatusAccessDenied)
+	}
+	// No tree connection must be stored.
+	if ctx.TreeID != 0 {
+		t.Errorf("TreeID = %d, want 0 (tree must not be created for anonymous session)", ctx.TreeID)
+	}
+}
+
+// TestTreeConnect_IPCShare_RejectsNullSession verifies that a null session
+// (anonymous NTLM: empty username, not guest) is rejected from IPC$ even if it
+// somehow carries a non-zero SessionID.
+func TestTreeConnect_IPCShare_RejectsNullSession(t *testing.T) {
+	h := NewHandler()
+	// Manually create a null session: username="" isGuest=false → IsNull=true.
+	nullSess := session.NewSession(42, "127.0.0.1:12345", false, "", "")
+	if !nullSess.IsNull {
+		t.Fatal("test precondition: NewSession with empty username must produce IsNull=true")
+	}
+	h.SessionManager.StoreSession(nullSess)
+
+	ctx := newTreeConnectTestContext(nullSess.SessionID)
+	body := buildTreeConnectRequestBody("\\\\server\\IPC$")
+	result, err := h.TreeConnect(ctx, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != types.StatusAccessDenied {
+		t.Errorf("null session IPC$ TREE_CONNECT: got status 0x%x, want StatusAccessDenied (0x%x)",
+			result.Status, types.StatusAccessDenied)
+	}
+	if ctx.TreeID != 0 {
+		t.Errorf("TreeID = %d, want 0", ctx.TreeID)
+	}
+}
+
 // =============================================================================
 // parseSharePath Tests
 // =============================================================================

--- a/internal/adapter/smb/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_test.go
@@ -209,58 +209,6 @@ func TestTreeConnect_IPCShare(t *testing.T) {
 	})
 }
 
-// TestTreeConnect_IPCShare_RejectsSessionIDZero verifies that a TREE_CONNECT to
-// IPC$ carrying SessionID=0 (the pre-auth anonymous credit-tracking slot) is
-// rejected. Otherwise an unauthenticated client could obtain a pipe-RPC channel
-// for share enumeration without ever authenticating.
-func TestTreeConnect_IPCShare_RejectsSessionIDZero(t *testing.T) {
-	h := NewHandler()
-	// Do NOT create any session. SessionID=0 is the pre-auth anonymous slot
-	// that the session manager pre-seeds for credit tracking.
-	ctx := newTreeConnectTestContext(0)
-
-	body := buildTreeConnectRequestBody("\\\\server\\IPC$")
-	result, err := h.TreeConnect(ctx, body)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Status != types.StatusAccessDenied {
-		t.Errorf("SessionID=0 IPC$ TREE_CONNECT: got status 0x%x, want StatusAccessDenied (0x%x)",
-			result.Status, types.StatusAccessDenied)
-	}
-	// No tree connection must be stored.
-	if ctx.TreeID != 0 {
-		t.Errorf("TreeID = %d, want 0 (tree must not be created for anonymous session)", ctx.TreeID)
-	}
-}
-
-// TestTreeConnect_IPCShare_RejectsNullSession verifies that a null session
-// (anonymous NTLM: empty username, not guest) is rejected from IPC$ even if it
-// somehow carries a non-zero SessionID.
-func TestTreeConnect_IPCShare_RejectsNullSession(t *testing.T) {
-	h := NewHandler()
-	// Manually create a null session: username="" isGuest=false → IsNull=true.
-	nullSess := session.NewSession(42, "127.0.0.1:12345", false, "", "")
-	if !nullSess.IsNull {
-		t.Fatal("test precondition: NewSession with empty username must produce IsNull=true")
-	}
-	h.SessionManager.StoreSession(nullSess)
-
-	ctx := newTreeConnectTestContext(nullSess.SessionID)
-	body := buildTreeConnectRequestBody("\\\\server\\IPC$")
-	result, err := h.TreeConnect(ctx, body)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Status != types.StatusAccessDenied {
-		t.Errorf("null session IPC$ TREE_CONNECT: got status 0x%x, want StatusAccessDenied (0x%x)",
-			result.Status, types.StatusAccessDenied)
-	}
-	if ctx.TreeID != 0 {
-		t.Errorf("TreeID = %d, want 0", ctx.TreeID)
-	}
-}
-
 // =============================================================================
 // parseSharePath Tests
 // =============================================================================

--- a/internal/controlplane/api/handlers/durable_handle.go
+++ b/internal/controlplane/api/handlers/durable_handle.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -180,12 +179,7 @@ func (dh *DurableHandleHandler) ForceClose(w http.ResponseWriter, r *http.Reques
 func cleanupDurableHandle(ctx context.Context, h *lock.PersistedDurableHandle, rt *runtime.Runtime, handleID string) {
 	// Step 1: Release byte-range locks
 	if metaSvc := rt.GetMetadataService(); metaSvc != nil && len(h.MetadataHandle) > 0 {
-		fileID := h.OriginalFileID
-		if fileID == ([16]byte{}) {
-			fileID = h.FileID
-		}
-		openID := fmt.Sprintf("%x", fileID)
-		if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
+		if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, h.LockOpenID()); err != nil {
 			logger.Debug("cleanupDurableHandle: failed to release locks",
 				"id", handleID, "error", err)
 		}

--- a/internal/controlplane/api/handlers/durable_handle.go
+++ b/internal/controlplane/api/handlers/durable_handle.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -179,7 +180,12 @@ func (dh *DurableHandleHandler) ForceClose(w http.ResponseWriter, r *http.Reques
 func cleanupDurableHandle(ctx context.Context, h *lock.PersistedDurableHandle, rt *runtime.Runtime, handleID string) {
 	// Step 1: Release byte-range locks
 	if metaSvc := rt.GetMetadataService(); metaSvc != nil && len(h.MetadataHandle) > 0 {
-		if err := metaSvc.UnlockAllForSession(ctx, h.MetadataHandle, 0); err != nil {
+		fileID := h.OriginalFileID
+		if fileID == ([16]byte{}) {
+			fileID = h.FileID
+		}
+		openID := fmt.Sprintf("%x", fileID)
+		if err := metaSvc.UnlockAllForOpen(ctx, h.MetadataHandle, openID); err != nil {
 			logger.Debug("cleanupDurableHandle: failed to release locks",
 				"id", handleID, "error", err)
 		}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -84,6 +84,13 @@ type Share struct {
 	// for semantics (refs #739).
 	ContinuousAvailability bool
 
+	// AllowMFsymlink enables automatic MFsymlink-to-real-symlink conversion on
+	// CLOSE. Default false. When false, 1067-byte XSym files written by
+	// macOS/Windows clients are stored as regular files and never promoted to
+	// symlinks (the conversion target is client-controlled, so promotion is
+	// opt-in).
+	AllowMFsymlink bool
+
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	// Read per-delete via the locked TrashSettingsForShare accessor (NOT off a
 	// shared *Share pointer) so it is concurrency-safe and takes effect live.
@@ -181,6 +188,10 @@ type ShareConfig struct {
 	// advertises SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY and enables SMB3
 	// persistent durable handles (refs #739).
 	ContinuousAvailability bool
+
+	// AllowMFsymlink mirrors the Share field above: when true, 1067-byte XSym
+	// MFsymlink files are converted to real symlinks on CLOSE. Default false.
+	AllowMFsymlink bool
 
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	// Read per-delete via the locked TrashSettingsForShare accessor (NOT off a
@@ -582,6 +593,7 @@ func (s *Service) prepareShare(
 		ChangeNotifyDisabled:             config.ChangeNotifyDisabled,
 		StreamsDisabled:                  config.StreamsDisabled,
 		ContinuousAvailability:           config.ContinuousAvailability,
+		AllowMFsymlink:                   config.AllowMFsymlink,
 		TrashEnabled:                     config.TrashEnabled,
 		TrashRetentionDays:               config.TrashRetentionDays,
 		TrashRestrictToAdmin:             config.TrashRestrictToAdmin,

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -287,6 +287,18 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		modified = true
 	}
 
+	// Atomic mode-bit masks: applied within the same store read-modify-write
+	// as the rest of SetFileAttributes so concurrent bit flips (e.g. SET_SPARSE
+	// racing SET_COMPRESSION) cannot clobber each other with a stale snapshot.
+	if attrs.ModeOrMask != nil {
+		file.Mode |= *attrs.ModeOrMask
+		modified = true
+	}
+	if attrs.ModeAndNotMask != nil {
+		file.Mode &^= *attrs.ModeAndNotMask
+		modified = true
+	}
+
 	// Track if ownership changed (for SUID/SGID clearing)
 	ownershipChanged := false
 

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -290,12 +290,18 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	// Atomic mode-bit masks: applied within the same store read-modify-write
 	// as the rest of SetFileAttributes so concurrent bit flips (e.g. SET_SPARSE
 	// racing SET_COMPRESSION) cannot clobber each other with a stale snapshot.
+	//
+	// These fields exist solely for FSCTL-managed DOS attribute bits (high word).
+	// They are applied AFTER the POSIX SUID/SGID stripping above, so they must
+	// not be allowed to carry permission/setid/sticky bits — otherwise a caller
+	// could set e.g. SGID via ModeOrMask and bypass that validation. Whitelist
+	// the masks down to the known DOS attribute bits before applying.
 	if attrs.ModeOrMask != nil {
-		file.Mode |= *attrs.ModeOrMask
+		file.Mode |= *attrs.ModeOrMask & dosAttributeModeBits
 		modified = true
 	}
 	if attrs.ModeAndNotMask != nil {
-		file.Mode &^= *attrs.ModeAndNotMask
+		file.Mode &^= *attrs.ModeAndNotMask & dosAttributeModeBits
 		modified = true
 	}
 

--- a/pkg/metadata/file_types.go
+++ b/pkg/metadata/file_types.go
@@ -133,17 +133,24 @@ type FileAttr struct {
 
 // SetAttrs specifies which attributes to update in a SetFileAttributes call.
 type SetAttrs struct {
-	Mode         *uint32
-	UID          *uint32
-	GID          *uint32
-	Size         *uint64
-	Atime        *time.Time
-	Mtime        *time.Time
-	AtimeNow     bool
-	MtimeNow     bool
-	CreationTime *time.Time
-	Ctime        *time.Time
-	Hidden       *bool
+	Mode *uint32
+	// ModeOrMask, when non-nil, ORs the given bits into the stored Mode
+	// atomically within SetFileAttributes. Used instead of Mode when only
+	// specific bits should be set without reading the mode in the caller.
+	ModeOrMask *uint32
+	// ModeAndNotMask, when non-nil, clears the given bits from the stored
+	// Mode atomically within SetFileAttributes.
+	ModeAndNotMask *uint32
+	UID            *uint32
+	GID            *uint32
+	Size           *uint64
+	Atime          *time.Time
+	Mtime          *time.Time
+	AtimeNow       bool
+	MtimeNow       bool
+	CreationTime   *time.Time
+	Ctime          *time.Time
+	Hidden         *bool
 
 	// ACL sets the NFSv4 ACL on the file.
 	// When non-nil, the ACL is validated (canonical ordering, max ACEs) before applying.

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -191,6 +191,20 @@ type PersistedDurableHandle struct {
 	ClientGUID [16]byte
 }
 
+// LockOpenID returns the OpenID used to key this handle's byte-range locks
+// (UnlockAllForOpen). Byte-range locks are recorded under hex(OriginalFileID);
+// pre-OriginalFileID legacy rows fall back to FileID. Cleanup paths
+// (scavenger, AppInstanceId failover, ForceClose) must release locks by this
+// ID rather than by session — session-based release is a no-op for a
+// disconnected handle whose session is gone.
+func (h *PersistedDurableHandle) LockOpenID() string {
+	fileID := h.OriginalFileID
+	if fileID == ([16]byte{}) {
+		fileID = h.FileID
+	}
+	return fmt.Sprintf("%x", fileID)
+}
+
 // DurableHandleStore provides persistence for SMB3 durable handle state.
 // Implementations exist in memory, badger, and postgres stores.
 //

--- a/pkg/metadata/lock/durable_store_test.go
+++ b/pkg/metadata/lock/durable_store_test.go
@@ -88,3 +88,34 @@ func TestValidateReconnect_ShareBeforePath(t *testing.T) {
 	require.ErrorAs(t, err, &mismatch)
 	assert.Equal(t, MismatchShare, mismatch.Kind)
 }
+
+// LockOpenID derives the byte-range-lock OpenID from OriginalFileID when set,
+// falling back to FileID for legacy rows persisted before OriginalFileID
+// existed. The cleanup paths (scavenger, AppInstanceId failover, ForceClose)
+// rely on this to release locks recorded under hex(OriginalFileID).
+func TestLockOpenID(t *testing.T) {
+	t.Run("uses OriginalFileID when set", func(t *testing.T) {
+		h := &PersistedDurableHandle{
+			FileID:         [16]byte{0xAA},
+			OriginalFileID: [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		}
+		// Full 16-byte hex (32 chars), derived from OriginalFileID not FileID.
+		assert.Equal(t, "01020304050607080000000000000000", h.LockOpenID())
+	})
+
+	t.Run("falls back to FileID when OriginalFileID is zero", func(t *testing.T) {
+		h := &PersistedDurableHandle{
+			FileID: [16]byte{0xDE, 0xAD, 0xBE, 0xEF},
+		}
+		assert.Equal(t, "deadbeef000000000000000000000000", h.LockOpenID())
+	})
+
+	t.Run("OriginalFileID takes precedence even when FileID differs", func(t *testing.T) {
+		orig := [16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+		h := &PersistedDurableHandle{
+			FileID:         [16]byte{0x99},
+			OriginalFileID: orig,
+		}
+		assert.Equal(t, "11223344556677880000000000000000", h.LockOpenID())
+	})
+}

--- a/pkg/metadata/service_mode_mask_test.go
+++ b/pkg/metadata/service_mode_mask_test.go
@@ -60,3 +60,32 @@ func TestSetFileAttributes_ModeOrMask_ConcurrentSetClear_NoLoss(t *testing.T) {
 	assert.Equal(t, uint32(0o644), f.Mode&0o777,
 		"POSIX permission bits must not be corrupted by concurrent mode-bit flips")
 }
+
+// TestSetFileAttributes_ModeOrMask_CannotSmuggleSetid verifies that the
+// ModeOrMask / ModeAndNotMask fields cannot be used to set POSIX permission or
+// setid bits, bypassing the SUID/SGID stripping in SetFileAttributes. The masks
+// are whitelisted down to the high-word DOS attribute bits before being applied.
+func TestSetFileAttributes_ModeOrMask_CannotSmuggleSetid(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "smuggle.txt", &metadata.FileAttr{
+		Mode: 0o644,
+	})
+	require.NoError(t, err)
+	handle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "smuggle.txt")
+	require.NoError(t, err)
+
+	// Attempt to OR in SGID (0o2000), SUID (0o4000) and extra perm bits (0o777)
+	// alongside a legitimate DOS attribute bit. Only the DOS bit must take.
+	m := modeDOSSparseBit | 0o4000 | 0o2000 | 0o777
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{ModeOrMask: &m})
+	require.NoError(t, err)
+
+	f, err := fx.service.GetFile(context.Background(), handle)
+	require.NoError(t, err)
+	assert.Equal(t, modeDOSSparseBit, f.Mode&modeDOSSparseBit, "DOS sparse bit should be set via the mask")
+	assert.Zero(t, f.Mode&0o4000, "SUID must not be settable via ModeOrMask")
+	assert.Zero(t, f.Mode&0o2000, "SGID must not be settable via ModeOrMask")
+	assert.Equal(t, uint32(0o644), f.Mode&0o777, "POSIX permission bits must not be altered via ModeOrMask")
+}

--- a/pkg/metadata/service_mode_mask_test.go
+++ b/pkg/metadata/service_mode_mask_test.go
@@ -1,0 +1,62 @@
+package metadata_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// modeDOSSparseBit mirrors the high-word DOS attribute bit the SMB sparse-file
+// FSCTL handler flips via SetAttrs.ModeOrMask / ModeAndNotMask.
+const modeDOSSparseBit = uint32(0x200000)
+
+// TestSetFileAttributes_ModeOrMask_ConcurrentSetClear_NoLoss drives two
+// goroutines that respectively set and clear the same high-word mode bit via
+// the atomic ModeOrMask / ModeAndNotMask masks. Before the fix the SMB
+// handlers did a caller-side GetFile -> compute newMode -> SetFileAttributes
+// using the full Mode value, so two concurrent flips would race and the loser
+// could revert unrelated bits the winner had set. With the mask fields the
+// OR/AND-NOT happens inside the store's own read-modify-write, so only the
+// targeted bit ever changes and the POSIX permission bits survive intact.
+func TestSetFileAttributes_ModeOrMask_ConcurrentSetClear_NoLoss(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "race.txt", &metadata.FileAttr{
+		Mode: 0o644,
+	})
+	require.NoError(t, err)
+	handle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "race.txt")
+	require.NoError(t, err)
+
+	const iters = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			m := modeDOSSparseBit
+			_, _ = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{ModeOrMask: &m})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			m := modeDOSSparseBit
+			_, _ = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{ModeAndNotMask: &m})
+		}
+	}()
+
+	wg.Wait()
+
+	f, err := fx.service.GetFile(context.Background(), handle)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0o644), f.Mode&0o777,
+		"POSIX permission bits must not be corrupted by concurrent mode-bit flips")
+}

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -1325,6 +1325,55 @@ func TestMetadataService_SetFileAttributes(t *testing.T) {
 
 		require.Error(t, err)
 	})
+
+	// High-word DOS attribute bit used by the SMB sparse-file FSCTL handler.
+	const modeDOSSparse = uint32(0x200000)
+
+	t.Run("mode_or_mask_sets_bits_without_reading_caller_side", func(t *testing.T) {
+		t.Parallel()
+		fx := newTestFixture(t)
+
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "sparse.txt", &metadata.FileAttr{
+			Mode: 0o644,
+		})
+		require.NoError(t, err)
+		handle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "sparse.txt")
+		require.NoError(t, err)
+
+		mask := modeDOSSparse
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{
+			ModeOrMask: &mask,
+		})
+		require.NoError(t, err)
+
+		file, err := fx.store.GetFile(context.Background(), handle)
+		require.NoError(t, err)
+		assert.NotZero(t, file.Mode&modeDOSSparse, "sparse bit must be set")
+		assert.Equal(t, uint32(0o644), file.Mode&0o777, "POSIX bits must be preserved")
+	})
+
+	t.Run("mode_and_not_mask_clears_bits", func(t *testing.T) {
+		t.Parallel()
+		fx := newTestFixture(t)
+
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "sparse.txt", &metadata.FileAttr{
+			Mode: 0o644 | modeDOSSparse,
+		})
+		require.NoError(t, err)
+		handle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "sparse.txt")
+		require.NoError(t, err)
+
+		mask := modeDOSSparse
+		_, err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{
+			ModeAndNotMask: &mask,
+		})
+		require.NoError(t, err)
+
+		file, err := fx.store.GetFile(context.Background(), handle)
+		require.NoError(t, err)
+		assert.Zero(t, file.Mode&modeDOSSparse, "sparse bit must be cleared")
+		assert.Equal(t, uint32(0o644), file.Mode&0o777, "POSIX bits must be preserved")
+	})
 }
 
 // ============================================================================

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -294,6 +294,13 @@ func DefaultMode(fileType FileType) uint32 {
 // the automatic ARCHIVE bit for regular files).
 const modeMask = uint32(0o7777) | 0x40000 | 0x80000 | 0x100000 | 0x200000 // Unix perms + Compressed + System + Readonly + Sparse
 
+// dosAttributeModeBits are the high-word DOS attribute bits that may be flipped
+// via SetAttrs.ModeOrMask / ModeAndNotMask. POSIX permission, setid and sticky
+// bits (0o7777) are deliberately excluded so the mask path cannot smuggle
+// SUID/SGID or permission bits past the SUID/SGID stripping in
+// SetFileAttributes.
+const dosAttributeModeBits = uint32(0x10000 | 0x20000 | 0x40000 | 0x80000 | 0x100000 | 0x200000) // Explicit+Archive+Compressed+System+Readonly+Sparse
+
 // ApplyModeDefault applies the default mode if the provided mode is 0.
 // Masks to valid bits (Unix permissions + extended DOS flags) to prevent
 // stray bits while preserving protocol-level attribute tracking.

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -198,11 +198,54 @@ func ValidateSpecialFileType(fileType FileType) error {
 }
 
 // ValidateSymlinkTarget validates that the symlink target is not empty.
+//
+// This is the general symlink-creation validator (NFS SYMLINK, REST). POSIX
+// symlink targets are intentionally permissive — absolute targets and `..`
+// components are legal — so only the empty target is rejected here. For the
+// SMB MFsymlink-to-symlink promotion path, where the target is fully
+// client-controlled content being auto-converted, use the stricter
+// ValidateMFsymlinkTarget below.
 func ValidateSymlinkTarget(target string) error {
 	if target == "" {
 		return &StoreError{
 			Code:    ErrInvalidArgument,
 			Message: "symlink target cannot be empty",
+		}
+	}
+	return nil
+}
+
+// ValidateMFsymlinkTarget validates a symlink target decoded from
+// client-supplied SMB MFsymlink (XSym) content before it is promoted to a real
+// symlink on CLOSE. Unlike ValidateSymlinkTarget, it rejects targets that can
+// escape the share root: empty, absolute, or containing any `..` component.
+// This guards against an SMB client smuggling a traversal target (e.g.
+// "../../etc/passwd" or "/etc/shadow") that an NFS client could then follow
+// outside the share.
+func ValidateMFsymlinkTarget(target string) error {
+	if err := ValidateSymlinkTarget(target); err != nil {
+		return err
+	}
+	// Reject absolute paths: they escape the share root on any OS.
+	if strings.HasPrefix(target, "/") {
+		return &StoreError{
+			Code:    ErrInvalidArgument,
+			Message: "symlink target must not be absolute",
+			Path:    target,
+		}
+	}
+	// Reject targets that contain `..` components: path traversal outside the
+	// share root. Normalize backslashes too — MFsymlink content is
+	// macOS/POSIX-generated so forward slash is the only live separator, but
+	// reject backslash as a separator for defence in depth.
+	cleaned := strings.ReplaceAll(target, "\\", "/")
+	for _, component := range strings.Split(cleaned, "/") {
+		if component == ".." {
+			return &StoreError{
+				Code:    ErrInvalidArgument,
+				Message: "symlink target must not contain path traversal",
+				Path:    target,
+			}
 		}
 	}
 	return nil

--- a/pkg/metadata/validation_test.go
+++ b/pkg/metadata/validation_test.go
@@ -173,7 +173,9 @@ func TestValidateSymlinkTarget(t *testing.T) {
 		wantErr bool
 	}{
 		{"empty target", "", true},
-		{"valid target", "/path/to/target", false},
+		// POSIX symlink targets are permissive: absolute and `..` targets are
+		// legal for the general symlink-creation path.
+		{"absolute target", "/path/to/target", false},
 		{"relative target", "../other", false},
 	}
 
@@ -181,6 +183,52 @@ func TestValidateSymlinkTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidateSymlinkTarget(tt.target)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateMFsymlinkTarget pins the stricter validation applied to
+// client-controlled MFsymlink targets before promotion to a real symlink:
+// empty, absolute, and `..`-traversal targets are all rejected.
+func TestValidateMFsymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{"empty target", "", true},
+
+		// Absolute paths — rejected (escape the share root).
+		{"absolute unix path", "/path/to/target", true},
+		{"absolute etc passwd", "/etc/passwd", true},
+		{"absolute path with dots", "/foo/../etc/passwd", true},
+
+		// Parent traversal — rejected.
+		{"bare dotdot", "../other", true},
+		{"dotdot in middle", "a/../../../etc", true},
+		{"dotdot as only component", "..", true},
+		{"windows-style traversal", "..\\etc", true},
+
+		// Valid relative paths — accepted.
+		{"single component", "target", false},
+		{"relative subdir", "a/b/c", false},
+		{"hidden file relative", ".hidden", false},
+		{"single dot segment", "./link", false},
+		{"long valid target", strings.Repeat("a/", 50) + "f", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateMFsymlinkTarget(tt.target)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Remediates the SMB subsystem findings from the v1.0 develop audit (#1076, Part of #1075). 13 atomic, signed commits; build/vet/gofmt/full unit suite green; independently code-reviewed (no critical, no regressions).

## HIGH
- **fix(smb/auth): bind NTLM pending challenge to (sessionID, connID)** — prevents cross-connection challenge replay (Samba bug-15346 class).
- **fix(smb): reject IPC$ TREE_CONNECT from anonymous/null/guest sessions** — closes unauthenticated IPC$ access.
- **fix(smb): guard compound NextCommand bounds + verify related sub-command signatures** — fixes two unauthenticated panics (`NextCommand < HeaderSize` → negative-length slice) and a signature-verification bypass where related sub-commands skipped integrity checks.
- **fix(smb/copychunk): gate COPYCHUNK access on GrantedAccess not DesiredAccess** — stops copy across handles the client was never granted.
- **fix(smb): make package-level SIDMapper goroutine-safe (atomic.Pointer)** — data race on the global mapper.
- **fix(smb/durable): byte-range lock leak + concurrent cleanup race** — `UnlockAllForSession(…,0)` was an unconditional no-op (locks key on per-open OpenID, not SessionID); now `UnlockAllForOpen` on displaced/expired/REST-force-closed handles; cleanup serialized.
- **fix(smb): lock CLOSE delete-on-close propagation + gate MFsymlink conversion** — data races on `DeletePending`/`BaseFileDeletePending` propagation; MFsymlink auto-conversion now opt-in (`AllowMFsymlink`, default off) and validates the decoded target (`ValidateMFsymlinkTarget` rejects absolute / `..`).
- **fix(smb): roll back ADS auto-created base file on lease rejection** — orphan base file on lease-denied alternate-data-stream create.

## MED
- **fix(smb/query-info): map store errors instead of collapsing to NOT_SUPPORTED**
- **fix(smb/ioctl): atomic mode-bit masks for SET_SPARSE/SET_COMPRESSION** — read-modify-write race; replaced full-Mode overwrite with `ModeOrMask`/`ModeAndNotMask`.
- **fix(smb): preserve modeDOSSparse across FileBasicInformation SET_INFO**
- **fix(smb/notify): guard stale flush-timer re-arm + de-dup cross-dir rename charge**
- **refactor(smb): dedup durable-handle lock OpenID + atomic mode-mask helper** (harden pass)

Each fix lands with a test exercising the fixed path (fails-before/passes-after).

## Known follow-ups (out of scope, non-blocking)
- `AllowMFsymlink` is reachable only via the runtime ShareConfig layer and defaults off everywhere; not yet wired to `models.Share` (DB column + migration), store persistence, or REST. Security objective met (conversion disabled by default + traversal guard); enabling from persisted config is a separate change needing a migration.
- Mode-mask atomicity is applied at the service layer (`file_modify.go`) and is backend-agnostic, but full cross-backend serialization under concurrency has coverage only on the memory store — add a postgres/badger concurrency test.

Report: `.planning/v1.0-audit/AUDIT-REPORT-develop-2beda0f2.md`

Fixes #1076
Part of #1075
