### PR TITLE
fix(nfs/v4): remediate v1.0 audit NFSv4/v4.1 findings (#1077)

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -79,17 +79,24 @@ const DefaultLeaseTime = 90
 
 // leaseTimeSeconds holds the configured lease time for FATTR4_LEASE_TIME.
 // Updated by SetLeaseTime() from the handler when StateManager is available.
-var leaseTimeSeconds uint32 = DefaultLeaseTime
+// Uses atomic.Uint32 to avoid data races with concurrent GETATTR encoding.
+var leaseTimeSeconds atomic.Uint32
+
+func init() {
+	leaseTimeSeconds.Store(DefaultLeaseTime)
+}
 
 // SetLeaseTime configures the lease time returned by FATTR4_LEASE_TIME.
 // Called by the handler layer when StateManager provides the lease duration.
+// Thread-safe: uses atomic store.
 func SetLeaseTime(seconds uint32) {
-	leaseTimeSeconds = seconds
+	leaseTimeSeconds.Store(seconds)
 }
 
 // GetLeaseTime returns the currently configured lease time in seconds.
+// Thread-safe: uses atomic load.
 func GetLeaseTime() uint32 {
-	return leaseTimeSeconds
+	return leaseTimeSeconds.Load()
 }
 
 // Filesystem capability defaults (matching metadata store defaults).
@@ -118,19 +125,29 @@ func SetFilesystemCapabilities(maxFileSize uint64, maxReadSize, maxWriteSize uin
 }
 
 // identityMapper holds the configured identity mapper for FATTR4_OWNER/OWNER_GROUP encoding.
-// When nil, the numeric UID/GID format is used as fallback.
-var identityMapper identity.IdentityMapper
+// When nil (zero Pointer), the numeric UID/GID format is used as fallback.
+// Uses atomic.Pointer to avoid data races with concurrent GETATTR encoding.
+var identityMapper atomic.Pointer[identity.IdentityMapper]
 
 // SetIdentityMapper configures the identity mapper used for FATTR4_OWNER
 // and FATTR4_OWNER_GROUP encoding. When set, UIDs/GIDs are reverse-resolved
 // to user@domain/group@domain format. When nil, numeric format is used.
+// Thread-safe: uses atomic store.
 func SetIdentityMapper(mapper identity.IdentityMapper) {
-	identityMapper = mapper
+	if mapper == nil {
+		identityMapper.Store(nil)
+		return
+	}
+	identityMapper.Store(&mapper)
 }
 
 // GetIdentityMapper returns the currently configured identity mapper, or nil.
+// Thread-safe: uses atomic load.
 func GetIdentityMapper() identity.IdentityMapper {
-	return identityMapper
+	if p := identityMapper.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // ============================================================================
@@ -323,7 +340,7 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 
 	case FATTR4_LEASE_TIME:
 		// uint32: lease duration in seconds (configured via SetLeaseTime)
-		return xdr.WriteUint32(buf, leaseTimeSeconds)
+		return xdr.WriteUint32(buf, leaseTimeSeconds.Load())
 
 	case FATTR4_RDATTR_ERROR:
 		// nfsstat4: NFS4_OK (no error)
@@ -551,7 +568,7 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, file *metadata.File, hand
 
 	case FATTR4_LEASE_TIME:
 		// uint32: lease duration in seconds (configured via SetLeaseTime)
-		return xdr.WriteUint32(buf, leaseTimeSeconds)
+		return xdr.WriteUint32(buf, leaseTimeSeconds.Load())
 
 	case FATTR4_RDATTR_ERROR:
 		return xdr.WriteUint32(buf, v4types.NFS4_OK)
@@ -707,10 +724,11 @@ func NeedsFilesystemStats(requested []uint32) bool {
 // matching idmapd configuration would cause the client to map all owners to
 // nobody (65534).
 func resolveOwnerString(uid uint32) string {
-	if identityMapper != nil {
+	if p := identityMapper.Load(); p != nil {
+		mapper := *p
 		// Try numeric UID format as the principal for reverse lookup
 		principal := fmt.Sprintf("%d@localdomain", uid)
-		resolved, err := identityMapper.Resolve(context.Background(), principal)
+		resolved, err := mapper.Resolve(context.Background(), principal)
 		if err == nil && resolved != nil && resolved.Found && resolved.Username != "" {
 			domain := resolved.Domain
 			if domain == "" {

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -3,6 +3,7 @@ package attrs
 import (
 	"bytes"
 	"encoding/binary"
+	"sync"
 	"testing"
 
 	v4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -438,4 +439,82 @@ func TestEncodePseudoFSAttrsFileIDNeverZero(t *testing.T) {
 	if mountedOnFileID == 0 {
 		t.Error("FATTR4_MOUNTED_ON_FILEID encoded as 0 (illegal; crashes macOS client)")
 	}
+}
+
+// TestSetLeaseTime_NoDataRace exercises concurrent SetLeaseTime writes against
+// FATTR4_LEASE_TIME encode reads. Run with -race to detect the data race that
+// existed before leaseTimeSeconds was made atomic.
+func TestSetLeaseTime_NoDataRace(t *testing.T) {
+	// Restore original value after test.
+	orig := GetLeaseTime()
+	t.Cleanup(func() { SetLeaseTime(orig) })
+
+	const goroutines = 8
+	ready := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Half goroutines write.
+	for i := 0; i < goroutines; i++ {
+		go func(v uint32) {
+			defer wg.Done()
+			<-ready
+			SetLeaseTime(v)
+		}(uint32(30 + i))
+	}
+
+	// Half goroutines read via the encode path (exercises a read site).
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-ready
+			node := newMockNode()
+			var buf bytes.Buffer
+			var req []uint32
+			SetBit(&req, FATTR4_LEASE_TIME)
+			_ = EncodePseudoFSAttrs(&buf, req, node)
+		}()
+	}
+
+	close(ready)
+	wg.Wait()
+}
+
+// TestSetIdentityMapper_NoDataRace exercises concurrent SetIdentityMapper writes
+// against FATTR4_OWNER encode reads (resolveOwnerString). Run with -race to detect
+// the data race that existed before identityMapper became an atomic.Pointer.
+func TestSetIdentityMapper_NoDataRace(t *testing.T) {
+	// Restore nil after test.
+	t.Cleanup(func() { SetIdentityMapper(nil) })
+
+	const goroutines = 8
+	ready := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Half goroutines swap the mapper.
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-ready
+			SetIdentityMapper(nil)
+		}()
+	}
+
+	// Half goroutines read via OWNER encoding (calls resolveOwnerString).
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-ready
+			node := newMockNode()
+			var buf bytes.Buffer
+			var req []uint32
+			SetBit(&req, FATTR4_OWNER)
+			SetBit(&req, FATTR4_OWNER_GROUP)
+			_ = EncodePseudoFSAttrs(&buf, req, node)
+		}()
+	}
+
+	close(ready)
+	wg.Wait()
 }

--- a/internal/adapter/nfs/v4/handlers/backchannel_ctl_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/backchannel_ctl_handler_test.go
@@ -222,6 +222,72 @@ func TestBackchannelCtl_BadXDR(t *testing.T) {
 	}
 }
 
+// TestBackchannelCtl_NoSession verifies NFS4ERR_OP_NOT_IN_SESSION when
+// BACKCHANNEL_CTL is dispatched without a SEQUENCE-established session context
+// (v41ctx == nil). A compound that starts with a session-exempt op
+// (EXCHANGE_ID) reaches the handler with v41ctx == nil, exercising the
+// handler-level nil guard directly.
+func TestBackchannelCtl_NoSession(t *testing.T) {
+	h := newTestHandler()
+	ctx := newTestCompoundContext()
+
+	var verifier [8]byte
+	copy(verifier[:], "testverf")
+	eidArgs := encodeExchangeIdArgs([]byte("bctl-no-session-client"), verifier, 0, types.SP4_NONE, nil)
+	bctlArgs := encodeBackchannelCtlArgs(0x50000000, []types.CallbackSecParms4{
+		{CbSecFlavor: 0}, // AUTH_NONE
+	})
+
+	ops := []compoundOp{
+		{opCode: types.OP_EXCHANGE_ID, data: eidArgs},
+		{opCode: types.OP_BACKCHANNEL_CTL, data: bctlArgs},
+	}
+	data := buildCompoundArgsWithOps([]byte("bctl-no-session"), 1, ops)
+
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	// EXCHANGE_ID returns a full result body, so decode the response manually
+	// (the shared decodeCompoundResponse helper only handles status-only ops).
+	reader := bytes.NewReader(resp)
+	status, _ := xdr.DecodeUint32(reader) // overall status
+	if status != types.NFS4ERR_OP_NOT_IN_SESSION {
+		t.Errorf("overall status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
+			status, types.NFS4ERR_OP_NOT_IN_SESSION)
+	}
+	_, _ = xdr.DecodeOpaque(reader) // tag
+	numResults, _ := xdr.DecodeUint32(reader)
+	if numResults != 2 {
+		t.Fatalf("numResults = %d, want 2", numResults)
+	}
+
+	// EXCHANGE_ID result (succeeds with v41ctx == nil, since it is exempt).
+	eidOp, _ := xdr.DecodeUint32(reader)
+	if eidOp != types.OP_EXCHANGE_ID {
+		t.Errorf("result[0] opcode = %d, want OP_EXCHANGE_ID (%d)", eidOp, types.OP_EXCHANGE_ID)
+	}
+	var eidRes types.ExchangeIdRes
+	if err := eidRes.Decode(reader); err != nil {
+		t.Fatalf("decode ExchangeIdRes: %v", err)
+	}
+	if eidRes.Status != types.NFS4_OK {
+		t.Errorf("EXCHANGE_ID status = %d, want NFS4_OK", eidRes.Status)
+	}
+
+	// BACKCHANNEL_CTL result: rejected with NFS4ERR_OP_NOT_IN_SESSION.
+	bctlOp, _ := xdr.DecodeUint32(reader)
+	if bctlOp != types.OP_BACKCHANNEL_CTL {
+		t.Errorf("result[1] opcode = %d, want OP_BACKCHANNEL_CTL (%d)", bctlOp, types.OP_BACKCHANNEL_CTL)
+	}
+	bctlStatus, _ := xdr.DecodeUint32(reader)
+	if bctlStatus != types.NFS4ERR_OP_NOT_IN_SESSION {
+		t.Errorf("BACKCHANNEL_CTL status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
+			bctlStatus, types.NFS4ERR_OP_NOT_IN_SESSION)
+	}
+}
+
 // TestBackchannelCtl_NoAcceptableSecurity verifies NFS4ERR_INVAL when only
 // RPCSEC_GSS is offered (no AUTH_NONE or AUTH_SYS).
 func TestBackchannelCtl_NoAcceptableSecurity(t *testing.T) {

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -516,6 +516,14 @@ func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, fir
 	return encodeCompoundResponse(lastStatus, tag, results)
 }
 
+// EncodeAbortCompound encodes a COMPOUND4res with the given status, an empty
+// tag, and zero results. It is used to reject a COMPOUND before the request
+// body is decoded (e.g. a pre-flight auth failure where the request tag is not
+// yet known). RFC 7530 §15.1 permits replying with an empty tag and zero results.
+func EncodeAbortCompound(status uint32) ([]byte, error) {
+	return encodeCompoundResponse(status, []byte{}, nil)
+}
+
 // encodeCompoundResponse encodes a COMPOUND4res response.
 //
 // Wire format:

--- a/internal/adapter/nfs/v4/handlers/context.go
+++ b/internal/adapter/nfs/v4/handlers/context.go
@@ -9,6 +9,15 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
+// authCall is the minimal view of an RPC call message needed to extract
+// authentication credentials. *rpc.RPCCallMessage satisfies it. Keeping the
+// surface narrow lets this protocol-concern helper stay decoupled from the
+// full concrete message type (and makes it testable with a lightweight stub).
+type authCall interface {
+	GetAuthFlavor() uint32
+	GetAuthBody() []byte
+}
+
 // ExtractV4HandlerContext creates a CompoundContext from an RPC call message.
 //
 // This extracts AUTH_UNIX credentials (UID, GID, supplementary GIDs) from the
@@ -20,12 +29,17 @@ import (
 //   - call: The RPC call message containing authentication data
 //   - clientAddr: The remote address of the client connection
 //
-// Returns a CompoundContext with extracted authentication information.
+// Returns a CompoundContext with extracted authentication information and an
+// NFSv4 status. The status is NFS4_OK on success. When the call claims the
+// RPCSEC_GSS auth flavor but no verified GSS identity is present in the context
+// (i.e. the GSS unwrap path never resolved an identity), the context is rejected
+// with (nil, NFS4ERR_WRONGSEC) so the COMPOUND is not executed as an
+// unauthenticated/anonymous request.
 func ExtractV4HandlerContext(
 	ctx context.Context,
-	call *rpc.RPCCallMessage,
+	call authCall,
 	clientAddr string,
-) *types.CompoundContext {
+) (*types.CompoundContext, uint32) {
 	compCtx := &types.CompoundContext{
 		Context:    ctx,
 		ClientAddr: clientAddr,
@@ -45,23 +59,24 @@ func ExtractV4HandlerContext(
 				"gid", gssIdentity.GID,
 				"ngids", len(gssIdentity.GIDs))
 
-			return compCtx
+			return compCtx, types.NFS4_OK
 		}
-		// GSS auth flavor but no identity in context
-		logger.Warn("NFSv4 RPCSEC_GSS auth flavor but no GSS identity in context",
+		// GSS auth flavor claimed but no verified identity in context: reject the
+		// COMPOUND rather than letting it proceed with a nil-UID (anonymous) context.
+		logger.Warn("NFSv4 RPCSEC_GSS auth flavor but no GSS identity in context — rejecting with NFS4ERR_WRONGSEC",
 			"client", clientAddr)
-		return compCtx
+		return nil, types.NFS4ERR_WRONGSEC
 	}
 
 	// Only attempt to parse Unix credentials if AUTH_UNIX is specified
 	if compCtx.AuthFlavor != rpc.AuthUnix {
-		return compCtx
+		return compCtx, types.NFS4_OK
 	}
 
 	authBody := call.GetAuthBody()
 	if len(authBody) == 0 {
 		logger.Warn("NFSv4 AUTH_UNIX specified but auth body is empty", "client", clientAddr)
-		return compCtx
+		return compCtx, types.NFS4_OK
 	}
 
 	unixAuth, err := rpc.ParseUnixAuth(authBody)
@@ -69,7 +84,7 @@ func ExtractV4HandlerContext(
 		logger.Warn("NFSv4 failed to parse AUTH_UNIX credentials",
 			"client", clientAddr,
 			"error", err)
-		return compCtx
+		return compCtx, types.NFS4_OK
 	}
 
 	logger.Debug("NFSv4 parsed Unix auth",
@@ -82,5 +97,5 @@ func ExtractV4HandlerContext(
 	compCtx.GID = &unixAuth.GID
 	compCtx.GIDs = unixAuth.GIDs
 
-	return compCtx
+	return compCtx, types.NFS4_OK
 }

--- a/internal/adapter/nfs/v4/handlers/context_test.go
+++ b/internal/adapter/nfs/v4/handlers/context_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// fakeCall implements the authCall interface consumed by ExtractV4HandlerContext.
+type fakeCall struct {
+	flavor   uint32
+	authBody []byte
+}
+
+func (f *fakeCall) GetAuthFlavor() uint32 { return f.flavor }
+func (f *fakeCall) GetAuthBody() []byte   { return f.authBody }
+
+// TestExtractV4HandlerContext_GSSNoIdentityReturnsWRONGSEC verifies that when
+// AuthFlavor==AuthRPCSECGSS but no GSS identity is present in the context,
+// ExtractV4HandlerContext returns (nil, NFS4ERR_WRONGSEC) instead of a context
+// with nil UID/GID that would let the COMPOUND proceed as anonymous.
+func TestExtractV4HandlerContext_GSSNoIdentityReturnsWRONGSEC(t *testing.T) {
+	ctx := context.Background() // no gss.ContextWithIdentity call — identity is nil
+
+	call := &fakeCall{flavor: rpc.AuthRPCSECGSS}
+	compCtx, status := ExtractV4HandlerContext(ctx, call, "127.0.0.1:1234")
+
+	if status != types.NFS4ERR_WRONGSEC {
+		t.Errorf("status = %d, want NFS4ERR_WRONGSEC (%d)", status, types.NFS4ERR_WRONGSEC)
+	}
+	if compCtx != nil {
+		t.Errorf("compCtx = %+v, want nil on WRONGSEC rejection", compCtx)
+	}
+}
+
+// TestExtractV4HandlerContext_GSSWithIdentitySucceeds verifies that when a
+// verified GSS identity IS present in the context, ExtractV4HandlerContext
+// propagates it and returns NFS4_OK.
+func TestExtractV4HandlerContext_GSSWithIdentitySucceeds(t *testing.T) {
+	uid := uint32(1000)
+	gid := uint32(1000)
+	identity := &metadata.Identity{UID: &uid, GID: &gid, GIDs: []uint32{1000, 2000}}
+	ctx := gss.ContextWithIdentity(context.Background(), identity)
+
+	call := &fakeCall{flavor: rpc.AuthRPCSECGSS}
+	compCtx, status := ExtractV4HandlerContext(ctx, call, "127.0.0.1:1234")
+
+	if status != types.NFS4_OK {
+		t.Errorf("status = %d, want NFS4_OK (%d)", status, types.NFS4_OK)
+	}
+	if compCtx == nil {
+		t.Fatal("compCtx = nil, want non-nil context on successful GSS auth")
+	}
+	if compCtx.UID == nil || *compCtx.UID != 1000 {
+		t.Errorf("UID = %v, want 1000", compCtx.UID)
+	}
+	if compCtx.GID == nil || *compCtx.GID != 1000 {
+		t.Errorf("GID = %v, want 1000", compCtx.GID)
+	}
+	if len(compCtx.GIDs) != 2 {
+		t.Errorf("len(GIDs) = %d, want 2", len(compCtx.GIDs))
+	}
+}
+
+// TestExtractV4HandlerContext_AuthUnixSucceeds is a regression guard to confirm
+// that AUTH_UNIX paths are not disturbed by this change.
+func TestExtractV4HandlerContext_AuthUnixSucceeds(t *testing.T) {
+	call := &fakeCall{flavor: rpc.AuthUnix} // no body → warns but returns OK
+	compCtx, status := ExtractV4HandlerContext(context.Background(), call, "127.0.0.1:1234")
+	if status != types.NFS4_OK {
+		t.Errorf("AUTH_UNIX empty-body status = %d, want NFS4_OK", status)
+	}
+	if compCtx == nil {
+		t.Error("compCtx = nil for AUTH_UNIX, want non-nil")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/create.go
+++ b/internal/adapter/nfs/v4/handlers/create.go
@@ -89,19 +89,17 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		// Directory: no type-specific data
 
 	case types.NF4REG:
-		// Regular files must be created via OPEN, not CREATE
-		// Consume remaining args before returning error
-		_, _ = xdr.DecodeString(reader)
-		skipFattr4(reader)
-
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADTYPE,
-			OpCode: types.OP_CREATE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADTYPE),
-		}
+		// Regular files must be created via OPEN, not CREATE. Fall through to the
+		// BADTYPE handling below, which also consumes the remaining args.
+		fallthrough
 
 	default:
-		// Unknown type
+		// Unsupported/unknown objtype (NF4REG or anything we don't recognize).
+		// Consume the remaining args (objname + createattrs) before returning so
+		// the XDR stream stays aligned for any following COMPOUND ops.
+		_, _ = xdr.DecodeString(reader) // objname
+		skipFattr4(reader)              // createattrs
+
 		return &types.CompoundResult{
 			Status: types.NFS4ERR_BADTYPE,
 			OpCode: types.OP_CREATE,

--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -101,6 +101,20 @@ func encodeCreateRegularFileArgs(name string) []byte {
 	return buf.Bytes()
 }
 
+// encodeCreateUnknownTypeArgs encodes CREATE4args with an unrecognized objtype.
+// objname and createattrs are fully encoded so that the default-case consume test
+// can verify the reader is left clean for the following op.
+func encodeCreateUnknownTypeArgs(name string) []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, 255) // objtype = 255, unrecognized by the server
+	// objname (XDR string)
+	_ = xdr.WriteXDRString(&buf, name)
+	// createattrs: empty bitmap + empty opaque
+	_ = xdr.WriteUint32(&buf, 0) // bitmap length = 0
+	_ = xdr.WriteUint32(&buf, 0) // attr data length = 0
+	return buf.Bytes()
+}
+
 // encodeRemoveArgs encodes REMOVE4args.
 func encodeRemoveArgs(target string) []byte {
 	var buf bytes.Buffer
@@ -372,6 +386,116 @@ func TestCreate_RegularFile_ReturnsBadType(t *testing.T) {
 	if result.Status != types.NFS4ERR_BADTYPE {
 		t.Errorf("CREATE regular file status = %d, want NFS4ERR_BADTYPE (%d)",
 			result.Status, types.NFS4ERR_BADTYPE)
+	}
+}
+
+// TestCreate_UnknownType_ReturnsBadType verifies that CREATE with an unrecognized
+// objtype returns NFS4ERR_BADTYPE.
+func TestCreate_UnknownType_ReturnsBadType(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeCreateUnknownTypeArgs("ghost")
+	result := fx.handler.handleCreate(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_BADTYPE {
+		t.Errorf("CREATE unknown type status = %d, want NFS4ERR_BADTYPE (%d)",
+			result.Status, types.NFS4ERR_BADTYPE)
+	}
+}
+
+// TestCreate_UnknownType_ConsumesArgs is the regression test for the default-case
+// XDR stream desync bug. The CREATE handler shares its reader with the COMPOUND
+// dispatcher, so on every exit path it must consume exactly its own arguments
+// (objtype + objname + createattrs) and leave the reader positioned at the next
+// operation's opcode. Before the fix the default case returned after reading only
+// objtype, leaving objname (8 XDR-padded bytes for "ghost") + createattrs (8 bytes
+// of empty fattr4) on the reader — desyncing every following operation.
+//
+// We assert on the reader directly: a sentinel opcode is appended after the CREATE
+// args; after handleCreate returns, exactly that 4-byte sentinel must remain. Before
+// the fix 20 bytes remain (16 unconsumed CREATE args + the 4-byte sentinel) and the
+// next DecodeUint32 returns the leading bytes of the unconsumed "ghost" string, not
+// the sentinel opcode.
+func TestCreate_UnknownType_ConsumesArgs(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	var buf bytes.Buffer
+	buf.Write(encodeCreateUnknownTypeArgs("ghost"))
+	// Sentinel: the opcode the COMPOUND dispatcher would read next.
+	_ = xdr.WriteUint32(&buf, types.OP_GETFH)
+
+	reader := bytes.NewReader(buf.Bytes())
+	result := fx.handler.handleCreate(ctx, reader)
+
+	if result.Status != types.NFS4ERR_BADTYPE {
+		t.Fatalf("CREATE unknown type status = %d, want NFS4ERR_BADTYPE (%d)",
+			result.Status, types.NFS4ERR_BADTYPE)
+	}
+
+	// Only the 4-byte sentinel opcode must remain on the reader.
+	if remaining := reader.Len(); remaining != 4 {
+		t.Fatalf("reader has %d bytes left after CREATE, want 4 (only the next opcode); "+
+			"handler did not consume objname+createattrs (XDR stream desync)", remaining)
+	}
+
+	// And that remaining opcode must decode as the sentinel, proving the reader is
+	// aligned on the next operation boundary.
+	nextOp, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode next opcode: %v", err)
+	}
+	if nextOp != types.OP_GETFH {
+		t.Errorf("next opcode = %d, want OP_GETFH (%d) — reader is desynced",
+			nextOp, types.OP_GETFH)
+	}
+}
+
+// TestCreate_RegularFile_ConsumesArgs is the NF4REG counterpart to
+// TestCreate_UnknownType_ConsumesArgs. NF4REG now falls through to the same
+// arg-consuming BADTYPE path as unknown objtypes, so it must likewise leave the
+// shared reader positioned exactly at the next operation's opcode. A sentinel
+// opcode is appended after the CREATE args; after handleCreate returns, only
+// that 4-byte sentinel must remain.
+func TestCreate_RegularFile_ConsumesArgs(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	var buf bytes.Buffer
+	buf.Write(encodeCreateRegularFileArgs("myfile.txt"))
+	// Sentinel: the opcode the COMPOUND dispatcher would read next.
+	_ = xdr.WriteUint32(&buf, types.OP_GETFH)
+
+	reader := bytes.NewReader(buf.Bytes())
+	result := fx.handler.handleCreate(ctx, reader)
+
+	if result.Status != types.NFS4ERR_BADTYPE {
+		t.Fatalf("CREATE regular file status = %d, want NFS4ERR_BADTYPE (%d)",
+			result.Status, types.NFS4ERR_BADTYPE)
+	}
+
+	if remaining := reader.Len(); remaining != 4 {
+		t.Fatalf("reader has %d bytes left after CREATE NF4REG, want 4 (only the next opcode); "+
+			"handler did not consume objname+createattrs (XDR stream desync)", remaining)
+	}
+
+	nextOp, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode next opcode: %v", err)
+	}
+	if nextOp != types.OP_GETFH {
+		t.Errorf("next opcode = %d, want OP_GETFH (%d) — reader is desynced",
+			nextOp, types.OP_GETFH)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/create_session_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_session_handler_test.go
@@ -336,6 +336,9 @@ func TestHandleCreateSession_RoundTripWithDestroy(t *testing.T) {
 	clientID, seqID := registerExchangeID(t, h, "cs-roundtrip-client")
 
 	ctx := newTestCompoundContext()
+	// A real client's connection is bound to the session at CREATE_SESSION time;
+	// the subsequent standalone DESTROY_SESSION is authorized via that binding.
+	ctx.ConnectionID = 7700
 	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}}
 	csArgs := encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)
 

--- a/internal/adapter/nfs/v4/handlers/destroy_session_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/destroy_session_handler_test.go
@@ -178,10 +178,10 @@ func TestHandleDestroySession_OwnerStandalone_OverDifferentConnection(t *testing
 			t.Fatalf("CREATE_SESSION %s error: %v", tag, err)
 		}
 		reader := bytes.NewReader(resp)
-		xdr.DecodeUint32(reader) // overall status
-		xdr.DecodeOpaque(reader) // tag
-		xdr.DecodeUint32(reader) // numResults
-		xdr.DecodeUint32(reader) // opcode
+		_, _ = xdr.DecodeUint32(reader) // overall status
+		_, _ = xdr.DecodeOpaque(reader) // tag
+		_, _ = xdr.DecodeUint32(reader) // numResults
+		_, _ = xdr.DecodeUint32(reader) // opcode
 		var csRes types.CreateSessionRes
 		if err := csRes.Decode(reader); err != nil {
 			t.Fatalf("decode CreateSessionRes %s: %v", tag, err)
@@ -241,10 +241,10 @@ func TestHandleDestroySession_OwnershipCheck_NFS4ERR_NOT_SAME(t *testing.T) {
 		t.Fatalf("CREATE_SESSION A error: %v", err)
 	}
 	readerA := bytes.NewReader(csRespA)
-	xdr.DecodeUint32(readerA) // overall status
-	xdr.DecodeOpaque(readerA) // tag
-	xdr.DecodeUint32(readerA) // numResults
-	xdr.DecodeUint32(readerA) // opcode
+	_, _ = xdr.DecodeUint32(readerA) // overall status
+	_, _ = xdr.DecodeOpaque(readerA) // tag
+	_, _ = xdr.DecodeUint32(readerA) // numResults
+	_, _ = xdr.DecodeUint32(readerA) // opcode
 	var csResA types.CreateSessionRes
 	if err := csResA.Decode(readerA); err != nil {
 		t.Fatalf("decode CreateSessionRes A: %v", err)
@@ -261,10 +261,10 @@ func TestHandleDestroySession_OwnershipCheck_NFS4ERR_NOT_SAME(t *testing.T) {
 		t.Fatalf("CREATE_SESSION B error: %v", err)
 	}
 	readerB := bytes.NewReader(csRespB)
-	xdr.DecodeUint32(readerB)
-	xdr.DecodeOpaque(readerB)
-	xdr.DecodeUint32(readerB)
-	xdr.DecodeUint32(readerB)
+	_, _ = xdr.DecodeUint32(readerB)
+	_, _ = xdr.DecodeOpaque(readerB)
+	_, _ = xdr.DecodeUint32(readerB)
+	_, _ = xdr.DecodeUint32(readerB)
 	var csResB types.CreateSessionRes
 	if err := csResB.Decode(readerB); err != nil {
 		t.Fatalf("decode CreateSessionRes B: %v", err)
@@ -292,13 +292,13 @@ func TestHandleDestroySession_OwnershipCheck_NFS4ERR_NOT_SAME(t *testing.T) {
 	if overallStatus == types.NFS4_OK {
 		t.Fatal("overall status should be non-OK (DESTROY_SESSION must fail)")
 	}
-	xdr.DecodeOpaque(reader) // tag
+	_, _ = xdr.DecodeOpaque(reader) // tag
 	numResults, _ := xdr.DecodeUint32(reader)
 	if numResults < 2 {
 		t.Fatalf("numResults = %d, want >= 2 (SEQUENCE + DESTROY_SESSION)", numResults)
 	}
 	// Skip SEQUENCE result
-	xdr.DecodeUint32(reader) // opcode
+	_, _ = xdr.DecodeUint32(reader) // opcode
 	var seqRes types.SequenceRes
 	if err := seqRes.Decode(reader); err != nil {
 		t.Fatalf("decode SequenceRes: %v", err)
@@ -342,14 +342,14 @@ func TestHandleDestroySession_OwnerCanDestroy_WithSequence(t *testing.T) {
 	}
 
 	reader := bytes.NewReader(resp)
-	xdr.DecodeUint32(reader) // overall status
-	xdr.DecodeOpaque(reader) // tag
+	_, _ = xdr.DecodeUint32(reader) // overall status
+	_, _ = xdr.DecodeOpaque(reader) // tag
 	numResults, _ := xdr.DecodeUint32(reader)
 	if numResults < 2 {
 		t.Fatalf("numResults = %d, want 2 (SEQUENCE + DESTROY_SESSION)", numResults)
 	}
 	// Skip SEQUENCE
-	xdr.DecodeUint32(reader)
+	_, _ = xdr.DecodeUint32(reader)
 	var seqRes types.SequenceRes
 	_ = seqRes.Decode(reader)
 	// Read DESTROY_SESSION

--- a/internal/adapter/nfs/v4/handlers/destroy_session_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/destroy_session_handler_test.go
@@ -70,47 +70,72 @@ func TestHandleDestroySession_NonExistent(t *testing.T) {
 	}
 }
 
-func TestHandleDestroySession_ValidSession(t *testing.T) {
-	h := newTestHandler()
-	clientID, seqID := registerExchangeID(t, h, "ds-valid-client")
+// TestHandleDestroySession_AnonymousStandalone_Rejected is the security
+// regression guard for the audit attack: an anonymous client sends a bare
+// (no SEQUENCE) DESTROY_SESSION targeting a victim's session over a connection
+// that is not bound to any session and carries no v4.0 client state. The server
+// MUST refuse, otherwise the victim's session is destroyed by an unrelated
+// caller (RFC 8881 Section 18.37.3 -- the requester must own the target).
+//
+// Before the ownership fix this asserted NFS4_OK (the vulnerable behavior);
+// it now asserts the destroy is rejected and the session survives.
+func TestHandleDestroySession_AnonymousStandalone_Rejected(t *testing.T) {
+	// Victim creates a session over connection 9100 (auto-bound at CREATE_SESSION).
+	h, victimSession := createTestSessionWithConnectionID(t, 9100)
 
-	ctx := newTestCompoundContext()
+	// Attacker: standalone DESTROY_SESSION(victimSession) over an unbound
+	// connection with no client state -- a fully anonymous caller.
+	attackerCtx := newTestCompoundContext()
+	attackerCtx.ConnectionID = 0 // not bound to any session
+	attackerCtx.ClientState = nil
 
-	// Create session first
-	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}} // AUTH_NONE
-	csArgs := encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)
-	csOps := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgs}}
-	csData := buildCompoundArgsWithOps([]byte("create"), 1, csOps)
-	csResp, err := h.ProcessCompound(ctx, csData)
-	if err != nil {
-		t.Fatalf("CREATE_SESSION error: %v", err)
-	}
-
-	// Extract session ID
-	reader := bytes.NewReader(csResp)
-	st, _ := xdr.DecodeUint32(reader)
-	if st != types.NFS4_OK {
-		t.Fatalf("CREATE_SESSION overall status = %d", st)
-	}
-	_, _ = xdr.DecodeOpaque(reader) // tag
-	_, _ = xdr.DecodeUint32(reader) // numResults
-	_, _ = xdr.DecodeUint32(reader) // opcode
-
-	var csRes types.CreateSessionRes
-	if err := csRes.Decode(reader); err != nil {
-		t.Fatalf("decode CreateSessionRes: %v", err)
-	}
-	if csRes.Status != types.NFS4_OK {
-		t.Fatalf("CREATE_SESSION res status = %d", csRes.Status)
-	}
-
-	// Destroy the session
 	var dsBuf bytes.Buffer
-	dsArgs := types.DestroySessionArgs{SessionID: csRes.SessionID}
+	dsArgs := types.DestroySessionArgs{SessionID: victimSession}
 	_ = dsArgs.Encode(&dsBuf)
-
 	dsOps := []compoundOp{{opCode: types.OP_DESTROY_SESSION, data: dsBuf.Bytes()}}
-	dsData := buildCompoundArgsWithOps([]byte("destroy"), 1, dsOps)
+	dsData := buildCompoundArgsWithOps([]byte("attack"), 1, dsOps)
+	dsResp, err := h.ProcessCompound(attackerCtx, dsData)
+	if err != nil {
+		t.Fatalf("DESTROY_SESSION error: %v", err)
+	}
+
+	decoded, err := decodeCompoundResponse(dsResp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+
+	if decoded.Status == types.NFS4_OK {
+		t.Fatalf("anonymous standalone DESTROY_SESSION was accepted (status NFS4_OK): victim session destroyed -- vulnerability present")
+	}
+	if decoded.Results[0].Status != types.NFS4ERR_OP_NOT_IN_SESSION {
+		t.Errorf("DESTROY_SESSION status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
+			decoded.Results[0].Status, types.NFS4ERR_OP_NOT_IN_SESSION)
+	}
+
+	// The victim's session must still exist and still be destroyable by its owner.
+	if h.StateManager.GetSession(victimSession) == nil {
+		t.Fatal("victim session was destroyed by the anonymous caller")
+	}
+}
+
+// TestHandleDestroySession_OwnerStandalone_OverBoundConnection covers the
+// legitimate session-exempt path: the owner sends a standalone (no SEQUENCE)
+// DESTROY_SESSION for its own session over a connection that is bound to that
+// session. The server authorizes via the connection binding and destroys it.
+func TestHandleDestroySession_OwnerStandalone_OverBoundConnection(t *testing.T) {
+	// Owner creates a session over connection 9200; CREATE_SESSION auto-binds it.
+	h, ownerSession := createTestSessionWithConnectionID(t, 9200)
+
+	// Standalone DESTROY_SESSION(ownerSession) over the same bound connection,
+	// no SEQUENCE op. Authorization comes from the connection->session binding.
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9200
+
+	var dsBuf bytes.Buffer
+	dsArgs := types.DestroySessionArgs{SessionID: ownerSession}
+	_ = dsArgs.Encode(&dsBuf)
+	dsOps := []compoundOp{{opCode: types.OP_DESTROY_SESSION, data: dsBuf.Bytes()}}
+	dsData := buildCompoundArgsWithOps([]byte("self"), 1, dsOps)
 	dsResp, err := h.ProcessCompound(ctx, dsData)
 	if err != nil {
 		t.Fatalf("DESTROY_SESSION error: %v", err)
@@ -122,13 +147,220 @@ func TestHandleDestroySession_ValidSession(t *testing.T) {
 	}
 
 	if decoded.Status != types.NFS4_OK {
-		t.Errorf("DESTROY_SESSION status = %d, want NFS4_OK", decoded.Status)
-	}
-	if decoded.NumResults != 1 {
-		t.Fatalf("numResults = %d, want 1", decoded.NumResults)
+		t.Errorf("owner standalone DESTROY_SESSION status = %d, want NFS4_OK", decoded.Status)
 	}
 	if decoded.Results[0].OpCode != types.OP_DESTROY_SESSION {
 		t.Errorf("result opcode = %d, want OP_DESTROY_SESSION", decoded.Results[0].OpCode)
+	}
+	if h.StateManager.GetSession(ownerSession) != nil {
+		t.Error("session still exists after the owner destroyed it")
+	}
+}
+
+// TestHandleDestroySession_OwnerStandalone_OverDifferentConnection covers the
+// cross-connection legitimate case: the owner has two sessions; it destroys
+// session A over a connection bound to session B. Both sessions belong to the
+// same client, so the connection binding authorizes the destroy.
+func TestHandleDestroySession_OwnerStandalone_OverDifferentConnection(t *testing.T) {
+	h := newTestHandler()
+
+	clientID, seqID := registerExchangeID(t, h, "ds-multi-session-owner")
+	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}}
+
+	createSession := func(connID uint64, seq uint32, tag string) types.SessionId4 {
+		ctx := newTestCompoundContext()
+		ctx.ConnectionID = connID
+		csArgs := encodeCreateSessionArgsWithSec(clientID, seq, 0, secParms)
+		ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgs}}
+		data := buildCompoundArgsWithOps([]byte(tag), 1, ops)
+		resp, err := h.ProcessCompound(ctx, data)
+		if err != nil {
+			t.Fatalf("CREATE_SESSION %s error: %v", tag, err)
+		}
+		reader := bytes.NewReader(resp)
+		xdr.DecodeUint32(reader) // overall status
+		xdr.DecodeOpaque(reader) // tag
+		xdr.DecodeUint32(reader) // numResults
+		xdr.DecodeUint32(reader) // opcode
+		var csRes types.CreateSessionRes
+		if err := csRes.Decode(reader); err != nil {
+			t.Fatalf("decode CreateSessionRes %s: %v", tag, err)
+		}
+		if csRes.Status != types.NFS4_OK {
+			t.Fatalf("CREATE_SESSION %s status = %d", tag, csRes.Status)
+		}
+		return csRes.SessionID
+	}
+
+	// Same client, two sessions on two connections. CREATE_SESSION increments
+	// the EXCHANGE_ID sequence, so the second uses seqID+1.
+	sessionA := createSession(9300, seqID, "csa")
+	sessionB := createSession(9301, seqID+1, "csb")
+
+	// Standalone DESTROY_SESSION(sessionA) over connection 9301 (bound to B).
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9301
+
+	var dsBuf bytes.Buffer
+	dsArgs := types.DestroySessionArgs{SessionID: sessionA}
+	_ = dsArgs.Encode(&dsBuf)
+	dsOps := []compoundOp{{opCode: types.OP_DESTROY_SESSION, data: dsBuf.Bytes()}}
+	dsData := buildCompoundArgsWithOps([]byte("cross-own"), 1, dsOps)
+	dsResp, err := h.ProcessCompound(ctx, dsData)
+	if err != nil {
+		t.Fatalf("DESTROY_SESSION error: %v", err)
+	}
+
+	decoded, err := decodeCompoundResponse(dsResp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+	if decoded.Status != types.NFS4_OK {
+		t.Errorf("owner cross-connection DESTROY_SESSION status = %d, want NFS4_OK", decoded.Status)
+	}
+	if h.StateManager.GetSession(sessionA) != nil {
+		t.Error("session A still exists after owner destroyed it over a sibling connection")
+	}
+	if h.StateManager.GetSession(sessionB) == nil {
+		t.Error("session B should be unaffected")
+	}
+}
+
+func TestHandleDestroySession_OwnershipCheck_NFS4ERR_NOT_SAME(t *testing.T) {
+	h := newTestHandler()
+	ctx := newTestCompoundContext()
+
+	// Client A: register + create session
+	clientAID, seqA := registerExchangeID(t, h, "ds-owner-a")
+	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}}
+	csArgsA := encodeCreateSessionArgsWithSec(clientAID, seqA, 0, secParms)
+	csOpsA := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgsA}}
+	csDataA := buildCompoundArgsWithOps([]byte("cs-a"), 1, csOpsA)
+	csRespA, err := h.ProcessCompound(ctx, csDataA)
+	if err != nil {
+		t.Fatalf("CREATE_SESSION A error: %v", err)
+	}
+	readerA := bytes.NewReader(csRespA)
+	xdr.DecodeUint32(readerA) // overall status
+	xdr.DecodeOpaque(readerA) // tag
+	xdr.DecodeUint32(readerA) // numResults
+	xdr.DecodeUint32(readerA) // opcode
+	var csResA types.CreateSessionRes
+	if err := csResA.Decode(readerA); err != nil {
+		t.Fatalf("decode CreateSessionRes A: %v", err)
+	}
+	sessionA := csResA.SessionID
+
+	// Client B: register + create session
+	clientBID, seqB := registerExchangeID(t, h, "ds-attacker-b")
+	csArgsB := encodeCreateSessionArgsWithSec(clientBID, seqB, 0, secParms)
+	csOpsB := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgsB}}
+	csDataB := buildCompoundArgsWithOps([]byte("cs-b"), 1, csOpsB)
+	csRespB, err := h.ProcessCompound(ctx, csDataB)
+	if err != nil {
+		t.Fatalf("CREATE_SESSION B error: %v", err)
+	}
+	readerB := bytes.NewReader(csRespB)
+	xdr.DecodeUint32(readerB)
+	xdr.DecodeOpaque(readerB)
+	xdr.DecodeUint32(readerB)
+	xdr.DecodeUint32(readerB)
+	var csResB types.CreateSessionRes
+	if err := csResB.Decode(readerB); err != nil {
+		t.Fatalf("decode CreateSessionRes B: %v", err)
+	}
+	sessionB := csResB.SessionID
+
+	// Client B issues: SEQUENCE(sessionB) + DESTROY_SESSION(sessionA)
+	seqArgs := encodeSequenceArgs(sessionB, 0, 1, 0, true)
+	var dsBuf bytes.Buffer
+	dsArgs := types.DestroySessionArgs{SessionID: sessionA}
+	_ = dsArgs.Encode(&dsBuf)
+	ops := []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: seqArgs},
+		{opCode: types.OP_DESTROY_SESSION, data: dsBuf.Bytes()},
+	}
+	data := buildCompoundArgsWithOps([]byte("cross-destroy"), 1, ops)
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	// Decode: skip overall status + SEQUENCE result, examine DESTROY_SESSION result
+	reader := bytes.NewReader(resp)
+	overallStatus, _ := xdr.DecodeUint32(reader)
+	if overallStatus == types.NFS4_OK {
+		t.Fatal("overall status should be non-OK (DESTROY_SESSION must fail)")
+	}
+	xdr.DecodeOpaque(reader) // tag
+	numResults, _ := xdr.DecodeUint32(reader)
+	if numResults < 2 {
+		t.Fatalf("numResults = %d, want >= 2 (SEQUENCE + DESTROY_SESSION)", numResults)
+	}
+	// Skip SEQUENCE result
+	xdr.DecodeUint32(reader) // opcode
+	var seqRes types.SequenceRes
+	if err := seqRes.Decode(reader); err != nil {
+		t.Fatalf("decode SequenceRes: %v", err)
+	}
+	if seqRes.Status != types.NFS4_OK {
+		t.Fatalf("SEQUENCE status = %d, want NFS4_OK", seqRes.Status)
+	}
+	// Read DESTROY_SESSION result
+	opCode, _ := xdr.DecodeUint32(reader)
+	if opCode != types.OP_DESTROY_SESSION {
+		t.Errorf("result opcode = %d, want OP_DESTROY_SESSION (%d)", opCode, types.OP_DESTROY_SESSION)
+	}
+	dsStatus, _ := xdr.DecodeUint32(reader)
+	if dsStatus != types.NFS4ERR_NOT_SAME {
+		t.Errorf("DESTROY_SESSION status = %d, want NFS4ERR_NOT_SAME (%d)", dsStatus, types.NFS4ERR_NOT_SAME)
+	}
+}
+
+func TestHandleDestroySession_OwnerCanDestroy_WithSequence(t *testing.T) {
+	// Owner destroys their own session via a SEQUENCE-prefixed compound. The
+	// ownership check must NOT fire (requesting client == owning client), so the
+	// result must not be NFS4ERR_NOT_SAME. Destroying a session from within a
+	// SEQUENCE on that same session legitimately returns NFS4ERR_DELAY because the
+	// SEQUENCE itself holds an in-flight slot; this guards that the ownership
+	// check doesn't reject the legitimate owner path.
+	h, sessionID := createTestSession(t)
+	ctx := newTestCompoundContext()
+
+	seqArgs := encodeSequenceArgs(sessionID, 0, 1, 0, true)
+	var dsBuf bytes.Buffer
+	dsArgs := types.DestroySessionArgs{SessionID: sessionID}
+	_ = dsArgs.Encode(&dsBuf)
+	ops := []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: seqArgs},
+		{opCode: types.OP_DESTROY_SESSION, data: dsBuf.Bytes()},
+	}
+	data := buildCompoundArgsWithOps([]byte("self-destroy"), 1, ops)
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	reader := bytes.NewReader(resp)
+	xdr.DecodeUint32(reader) // overall status
+	xdr.DecodeOpaque(reader) // tag
+	numResults, _ := xdr.DecodeUint32(reader)
+	if numResults < 2 {
+		t.Fatalf("numResults = %d, want 2 (SEQUENCE + DESTROY_SESSION)", numResults)
+	}
+	// Skip SEQUENCE
+	xdr.DecodeUint32(reader)
+	var seqRes types.SequenceRes
+	_ = seqRes.Decode(reader)
+	// Read DESTROY_SESSION
+	opCode, _ := xdr.DecodeUint32(reader)
+	if opCode != types.OP_DESTROY_SESSION {
+		t.Errorf("result opcode = %d, want OP_DESTROY_SESSION", opCode)
+	}
+	dsStatus, _ := xdr.DecodeUint32(reader)
+	if dsStatus == types.NFS4ERR_NOT_SAME {
+		t.Errorf("DESTROY_SESSION status = NFS4ERR_NOT_SAME (%d): ownership check wrongly rejected the owning client",
+			types.NFS4ERR_NOT_SAME)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -245,6 +245,23 @@ func (h *Handler) handleOpenClaimNull(
 	}
 	beforeCtime := uint64(parentFile.Ctime.UnixNano())
 
+	// For OPEN4_CREATE where the file may not yet exist, check the delegation
+	// conflict against the parent directory — the file handle is not yet known.
+	// This prevents orphaning a newly-created file if NFS4ERR_DELAY must be
+	// returned. If another client holds a conflicting delegation, trigger async
+	// CB_RECALL and return NFS4ERR_DELAY so the client retries the entire OPEN.
+	// For OPEN4_NOCREATE the file exists; the conflict is checked after lookup.
+	if openType == types.OPEN4_CREATE {
+		conflict, _ := h.StateManager.CheckDelegationConflict([]byte(parentHandle), clientID, shareAccess)
+		if conflict {
+			logger.Debug("NFSv4 OPEN CLAIM_NULL CREATE delegation conflict, returning NFS4ERR_DELAY",
+				"file", filename,
+				"client_id", clientID,
+				"client", ctx.ClientAddr)
+			return openError(types.NFS4ERR_DELAY)
+		}
+	}
+
 	// Execute OPEN logic
 
 	var fileHandle metadata.FileHandle
@@ -265,6 +282,18 @@ func (h *Handler) handleOpenClaimNull(
 			return openError(common.MapToNFS4(accessErr))
 		}
 		fileHandle = fh
+
+		// The file exists; check the delegation conflict against its own handle.
+		// If another client holds a conflicting delegation, trigger async
+		// CB_RECALL and return NFS4ERR_DELAY so the client retries the OPEN.
+		conflict, _ := h.StateManager.CheckDelegationConflict([]byte(fileHandle), clientID, shareAccess)
+		if conflict {
+			logger.Debug("NFSv4 OPEN CLAIM_NULL NOCREATE delegation conflict, returning NFS4ERR_DELAY",
+				"file", filename,
+				"client_id", clientID,
+				"client", ctx.ClientAddr)
+			return openError(types.NFS4ERR_DELAY)
+		}
 	} else {
 		// OPEN4_CREATE: create or open existing
 		child, lookupErr := metaSvc.Lookup(authCtx, parentHandle, filename)
@@ -283,6 +312,19 @@ func (h *Handler) handleOpenClaimNull(
 				return openError(common.MapToNFS4(accessErr))
 			}
 			fileHandle = fh
+
+			// The file already exists; opening it via UNCHECKED4 is an open of
+			// an existing file. Check the delegation conflict against its own
+			// handle. If another client holds a conflicting delegation, trigger
+			// async CB_RECALL and return NFS4ERR_DELAY so the client retries.
+			conflict, _ := h.StateManager.CheckDelegationConflict([]byte(fileHandle), clientID, shareAccess)
+			if conflict {
+				logger.Debug("NFSv4 OPEN CLAIM_NULL CREATE/UNCHECKED4 existing-file delegation conflict, returning NFS4ERR_DELAY",
+					"file", filename,
+					"client_id", clientID,
+					"client", ctx.ClientAddr)
+				return openError(types.NFS4ERR_DELAY)
+			}
 		} else {
 			// File doesn't exist: create it
 			uid, gid := effectiveUIDGID(authCtx)
@@ -317,19 +359,6 @@ func (h *Handler) handleOpenClaimNull(
 		if getErr == nil {
 			afterCtime = uint64(parentFileAfter.Ctime.UnixNano())
 		}
-	}
-
-	// Check delegation conflicts BEFORE creating state
-	// If another client holds a conflicting delegation, trigger async CB_RECALL
-	// and return NFS4ERR_DELAY so the client retries the entire OPEN.
-
-	conflict, _ := h.StateManager.CheckDelegationConflict([]byte(fileHandle), clientID, shareAccess)
-	if conflict {
-		logger.Debug("NFSv4 OPEN delegation conflict, returning NFS4ERR_DELAY",
-			"file", filename,
-			"client_id", clientID,
-			"client", ctx.ClientAddr)
-		return openError(types.NFS4ERR_DELAY)
 	}
 
 	// Create tracked state via StateManager
@@ -669,6 +698,12 @@ func (h *Handler) handleOpenClaimDelegateCur(
 			OpCode: types.OP_OPEN,
 			Data:   openResult.CachedData,
 		}
+	}
+
+	// In NFSv4.1, OPEN_CONFIRM was removed; auto-confirm if needed.
+	if ctx.SkipOwnerSeqid && openResult.RFlags&types.OPEN4_RESULT_CONFIRM != 0 {
+		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
 	}
 
 	logger.Debug("NFSv4 OPEN CLAIM_DELEGATE_CUR successful",

--- a/internal/adapter/nfs/v4/handlers/open_delegation_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_delegation_test.go
@@ -1,0 +1,342 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// encodeOpenArgsDelegateCur encodes OPEN args for CLAIM_DELEGATE_CUR.
+// Wire: seqid shareAccess shareDeny clientID owner openType claimType delegStateid filename
+// CLAIM_DELEGATE_CUR always opens an existing file, so openType is OPEN4_NOCREATE
+// and there is no createhow4 block.
+func encodeOpenArgsDelegateCur(
+	seqid, shareAccess, shareDeny uint32,
+	clientID uint64, owner []byte,
+	openType uint32,
+	delegStateid *types.Stateid4,
+	filename string,
+) []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, seqid)
+	_ = xdr.WriteUint32(&buf, shareAccess)
+	_ = xdr.WriteUint32(&buf, shareDeny)
+	_ = xdr.WriteUint64(&buf, clientID)
+	_ = xdr.WriteXDROpaque(&buf, owner)
+	_ = xdr.WriteUint32(&buf, openType)
+	// open_claim4: claim_type
+	_ = xdr.WriteUint32(&buf, types.CLAIM_DELEGATE_CUR)
+	// delegate_stateid
+	types.EncodeStateid4(&buf, delegStateid)
+	// filename
+	_ = xdr.WriteXDRString(&buf, filename)
+	return buf.Bytes()
+}
+
+// rflagsFromOpenResult parses the rflags field out of an encoded OPEN4resok.
+// Layout: status, stateid4 (seqid + other[12]), change_info4 (atomic + before + after), rflags...
+func rflagsFromOpenResult(t *testing.T, data []byte) uint32 {
+	t.Helper()
+	reader := bytes.NewReader(data)
+	_, _ = xdr.DecodeUint32(reader) // status
+	if _, err := types.DecodeStateid4(reader); err != nil {
+		t.Fatalf("decode stateid: %v", err)
+	}
+	_, _ = xdr.DecodeUint32(reader) // atomic
+	_, _ = xdr.DecodeUint64(reader) // before
+	_, _ = xdr.DecodeUint64(reader) // after
+	rflags, _ := xdr.DecodeUint32(reader)
+	return rflags
+}
+
+// ============================================================================
+// Bug 1 — CLAIM_NULL delegation-conflict must not orphan a created file
+// ============================================================================
+
+// TestOpen_ClaimNull_CreateNew_DelegationConflict_NoOrphan verifies that an
+// OPEN4_CREATE that hits a conflicting delegation returns NFS4ERR_DELAY WITHOUT
+// creating the file. Before the fix, the file was created first and the conflict
+// check ran against the new file's handle, leaving an orphan that turned every
+// GUARDED4 retry into NFS4ERR_EXIST.
+func TestOpen_ClaimNull_CreateNew_DelegationConflict_NoOrphan(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	// Client A holds a WRITE delegation on an existing file under the same parent.
+	const clientA = uint64(0xAAAA)
+	const clientB = uint64(0xBBBB)
+	existing := fx.createRegularFile(t, fx.rootHandle, "existing.txt", 0o644, 0, 0)
+	if d := fx.handler.StateManager.GrantDelegation(clientA, []byte(existing), types.OPEN_DELEGATE_WRITE); d == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+	// Also hold a WRITE delegation registered against the parent directory handle,
+	// so a CREATE in this directory observes a conflict for a different client.
+	if d := fx.handler.StateManager.GrantDelegation(clientA, []byte(fx.rootHandle), types.OPEN_DELEGATE_WRITE); d == nil {
+		t.Fatalf("GrantDelegation (parent) returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgs(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientB,
+		[]byte("owner-b"),
+		types.OPEN4_CREATE,
+		types.GUARDED4,
+		types.CLAIM_NULL,
+		"newfile.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_DELAY {
+		t.Fatalf("first OPEN status = %d, want NFS4ERR_DELAY (%d)", result.Status, types.NFS4ERR_DELAY)
+	}
+
+	// The file must NOT exist after the conflict — no orphan.
+	authCtx := newTestAuthCtx(0, 0)
+	if _, lookupErr := fx.metaSvc.Lookup(authCtx, fx.rootHandle, "newfile.txt"); lookupErr == nil {
+		t.Fatalf("newfile.txt was orphaned: it exists after a conflicting OPEN4_CREATE")
+	}
+
+	// A retry must still return NFS4ERR_DELAY, not NFS4ERR_EXIST.
+	ctx2 := newRealFSContext(0, 0)
+	ctx2.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx2.CurrentFH, fx.rootHandle)
+	retry := fx.handler.handleOpen(ctx2, bytes.NewReader(args))
+	if retry.Status != types.NFS4ERR_DELAY {
+		t.Fatalf("retry OPEN status = %d, want NFS4ERR_DELAY (%d)", retry.Status, types.NFS4ERR_DELAY)
+	}
+}
+
+// TestOpen_ClaimNull_OpenExisting_DelegationConflict_ReturnsDelay guards the
+// NOCREATE sub-path: opening an existing file under a conflicting delegation
+// must still return NFS4ERR_DELAY after the refactor.
+func TestOpen_ClaimNull_OpenExisting_DelegationConflict_ReturnsDelay(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xAAAA)
+	const clientB = uint64(0xBBBB)
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "existing.txt", 0o644, 0, 0)
+	if d := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE); d == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgs(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientB,
+		[]byte("owner-b"),
+		types.OPEN4_NOCREATE,
+		0,
+		types.CLAIM_NULL,
+		"existing.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_DELAY {
+		t.Fatalf("OPEN NOCREATE conflict status = %d, want NFS4ERR_DELAY (%d)", result.Status, types.NFS4ERR_DELAY)
+	}
+}
+
+// TestOpen_ClaimNull_CreateUnchecked_ExistingFile_DelegationConflict_ReturnsDelay
+// guards the OPEN4_CREATE + UNCHECKED4 "open existing file" sub-path. When the
+// target already exists, UNCHECKED4 degenerates to an open of the existing file
+// (lookupErr == nil), so a conflicting delegation held by another client MUST
+// trigger a recall and return NFS4ERR_DELAY. The pre-creation conflict check
+// only runs against the parent directory and does not cover this case; without
+// the per-file check on the existing-file branch, this OPEN would silently
+// succeed and bypass the held delegation.
+func TestOpen_ClaimNull_CreateUnchecked_ExistingFile_DelegationConflict_ReturnsDelay(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xAAAA)
+	const clientB = uint64(0xBBBB)
+
+	// Client A holds a WRITE delegation on the existing file itself. Note that
+	// NO delegation is registered against the parent directory handle, so the
+	// pre-creation parent-handle check cannot fire — the conflict can only be
+	// detected on the existing-file branch.
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "existing.txt", 0o644, 0, 0)
+	if d := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE); d == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	// OPEN4_CREATE + UNCHECKED4 against the name that already exists: the handler
+	// takes the lookupErr == nil branch (open existing), not the create branch.
+	args := encodeOpenArgs(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientB,
+		[]byte("owner-b"),
+		types.OPEN4_CREATE,
+		types.UNCHECKED4,
+		types.CLAIM_NULL,
+		"existing.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_DELAY {
+		t.Fatalf("OPEN CREATE/UNCHECKED4 existing-file conflict status = %d, want NFS4ERR_DELAY (%d)",
+			result.Status, types.NFS4ERR_DELAY)
+	}
+}
+
+// TestOpen_ClaimNull_CreateNew_NoDelegationConflict_Succeeds is a regression
+// guard ensuring the pre-creation conflict check is a no-op when no conflicting
+// delegation exists.
+func TestOpen_ClaimNull_CreateNew_NoDelegationConflict_Succeeds(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgs(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		0xCCCC,
+		[]byte("owner-c"),
+		types.OPEN4_CREATE,
+		types.UNCHECKED4,
+		types.CLAIM_NULL,
+		"created.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN CREATE status = %d, want NFS4_OK", result.Status)
+	}
+
+	authCtx := newTestAuthCtx(0, 0)
+	if _, lookupErr := fx.metaSvc.Lookup(authCtx, fx.rootHandle, "created.txt"); lookupErr != nil {
+		t.Fatalf("created.txt should exist after a successful OPEN CREATE: %v", lookupErr)
+	}
+}
+
+// ============================================================================
+// Bug 2 — CLAIM_DELEGATE_CUR v4.1 auto-confirm
+// ============================================================================
+
+// TestOpenClaimDelegateCur_V41_AutoConfirm verifies that on a v4.1 session
+// (SkipOwnerSeqid=true) the CLAIM_DELEGATE_CUR path strips OPEN4_RESULT_CONFIRM
+// from the reply and auto-confirms the open-owner. A v4.1 client cannot issue
+// OPEN_CONFIRM, so without the guard the owner would stay unconfirmed forever.
+func TestOpenClaimDelegateCur_V41_AutoConfirm(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xA11CE)
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "deleg.txt", 0o644, 0, 0)
+	deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+	if deleg == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.SkipOwnerSeqid = true // v4.1 session
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	owner := []byte("owner-deleg")
+	args := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientA,
+		owner,
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"deleg.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR status = %d, want NFS4_OK", result.Status)
+	}
+
+	// The CONFIRM flag must NOT be set in a reply to a v4.1 client.
+	rflags := rflagsFromOpenResult(t, result.Data)
+	if rflags&types.OPEN4_RESULT_CONFIRM != 0 {
+		t.Fatalf("rflags = %#x, OPEN4_RESULT_CONFIRM must not be set for a v4.1 client", rflags)
+	}
+
+	// Prove the owner is confirmed: a second OPEN by the same owner must not
+	// request confirmation again. An unconfirmed owner would re-set the flag.
+	ctx2 := newRealFSContext(0, 0)
+	ctx2.SkipOwnerSeqid = true
+	ctx2.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx2.CurrentFH, fx.rootHandle)
+	args2 := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientA,
+		owner,
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"deleg.txt",
+	)
+	result2 := fx.handler.handleOpen(ctx2, bytes.NewReader(args2))
+	if result2.Status != types.NFS4_OK {
+		t.Fatalf("second OPEN status = %d, want NFS4_OK", result2.Status)
+	}
+	rflags2 := rflagsFromOpenResult(t, result2.Data)
+	if rflags2&types.OPEN4_RESULT_CONFIRM != 0 {
+		t.Fatalf("second OPEN rflags = %#x: owner was not confirmed by the first CLAIM_DELEGATE_CUR", rflags2)
+	}
+}
+
+// TestOpenClaimDelegateCur_V40_ConfirmFlagPreserved is a regression guard: on a
+// v4.0 session the CONFIRM flag must still be set for a new owner so the client
+// performs OPEN_CONFIRM.
+func TestOpenClaimDelegateCur_V40_ConfirmFlagPreserved(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xB0B)
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "deleg40.txt", 0o644, 0, 0)
+	deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+	if deleg == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.SkipOwnerSeqid = false // v4.0 session
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientA,
+		[]byte("owner-deleg40"),
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"deleg40.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR (v4.0) status = %d, want NFS4_OK", result.Status)
+	}
+
+	rflags := rflagsFromOpenResult(t, result.Data)
+	if rflags&types.OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatalf("rflags = %#x, OPEN4_RESULT_CONFIRM must be set for a new v4.0 owner", rflags)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/readdir.go
+++ b/internal/adapter/nfs/v4/handlers/readdir.go
@@ -133,16 +133,24 @@ func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cooki
 	// avoiding a duplicate store lookup.
 	currentVerifier := directoryMtimeVerifier(page.DirMtime)
 
-	// Validate incoming cookie verifier for non-initial requests (advisory only).
-	// cookie=0 means initial request; cookieVerf all-zeros means client doesn't use verifiers.
-	// On mismatch, log at debug level but continue serving entries (matches NFSv3 behavior).
+	// Validate incoming cookie verifier for non-initial requests.
+	// cookie=0 means initial request, so the verifier is ignored; an all-zeros
+	// cookieVerf likewise means the client does not use verifiers.
+	// On a non-zero-cookie verifier mismatch, return NFS4ERR_BAD_COOKIE per
+	// RFC 7530 Section 16.24.5: the directory changed since the cookie was
+	// issued, so the cookie is no longer valid and the client must restart.
 	incomingVerf := binary.BigEndian.Uint64(cookieVerf[:])
 	if cookie != 0 && incomingVerf != 0 && incomingVerf != currentVerifier {
-		logger.Debug("NFSv4 READDIR: directory modified since last read, continuing with current entries",
+		logger.Debug("NFSv4 READDIR: cookieverf mismatch, returning NFS4ERR_BAD_COOKIE",
 			"handle", fmt.Sprintf("%x", ctx.CurrentFH),
 			"incoming_verf", fmt.Sprintf("0x%016x", incomingVerf),
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_BAD_COOKIE,
+			OpCode: types.OP_READDIR,
+			Data:   encodeStatusOnly(types.NFS4ERR_BAD_COOKIE),
+		}
 	}
 
 	// Debug logging for READDIR

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -589,19 +589,54 @@ func TestReadDir_RealFS_VerifierMismatch(t *testing.T) {
 	binary.BigEndian.PutUint64(staleVerf[:], initial.verifier^0xFF)
 
 	// Second READDIR with a real cookie from the first page and stale verifier.
-	// Advisory-only mismatch: should return NFS4_OK, not an error.
+	// RFC 7530 §16.24.5 requires NFS4ERR_BAD_COOKIE on stale verifier.
 	ctx2 := newRealFSContext(0, 0)
 	ctx2.CurrentFH = make([]byte, len(fx.rootHandle))
 	copy(ctx2.CurrentFH, fx.rootHandle)
 
 	result2 := fx.handler.readDirRealFS(ctx2, initial.lastCookie, staleVerf, 8192, attrRequest)
-	if result2.Status != types.NFS4_OK {
-		t.Fatalf("READDIR with stale verifier status = %d, want NFS4_OK (advisory only)", result2.Status)
+	if result2.Status != types.NFS4ERR_BAD_COOKIE {
+		t.Fatalf("READDIR with stale verifier status = %d, want NFS4ERR_BAD_COOKIE (%d)",
+			result2.Status, types.NFS4ERR_BAD_COOKIE)
+	}
+}
+
+func TestReadDir_RealFS_ZeroCookieIgnoresVerifierMismatch(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	fx.createTestFile(t, fx.rootHandle, "aaa.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	var attrRequest []uint32
+	attrs.SetBit(&attrRequest, attrs.FATTR4_TYPE)
+
+	// Garbage verifier with cookie=0 must be silently ignored (initial READDIR).
+	var junkVerf [8]byte
+	binary.BigEndian.PutUint64(junkVerf[:], 0xDEADBEEFCAFEBABE)
+
+	result := fx.handler.readDirRealFS(ctx, 0, junkVerf, 8192, attrRequest)
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("initial READDIR (cookie=0) must ignore verifier mismatch, got status %d", result.Status)
 	}
 
-	stale := parseReadDirResponse(t, result2)
-	if len(stale.entryNames) == 0 {
-		t.Error("expected entries to be served despite verifier mismatch, got none")
+	// All-zero verifier with cookie!=0 must also be silently ignored (client
+	// does not use verifiers).
+	resp := parseReadDirResponse(t, result)
+	if resp.lastCookie == 0 {
+		t.Fatal("expected at least one entry")
+	}
+
+	var zeroVerf [8]byte
+	ctx2 := newRealFSContext(0, 0)
+	ctx2.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx2.CurrentFH, fx.rootHandle)
+
+	result2 := fx.handler.readDirRealFS(ctx2, resp.lastCookie, zeroVerf, 8192, attrRequest)
+	if result2.Status != types.NFS4_OK {
+		t.Fatalf("READDIR with zero verifier must ignore mismatch, got status %d", result2.Status)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/backchannel.go
+++ b/internal/adapter/nfs/v4/state/backchannel.go
@@ -146,6 +146,12 @@ type BackchannelSender struct {
 
 	nextXID atomic.Uint32
 
+	// nextCBSeqID is the per-slot CB_SEQUENCE seqID counter (RFC 8881
+	// §2.10.6.1). It is independent of nextXID: the backchannel uses a single
+	// slot, so a single monotonic counter incrementing by exactly 1 per send
+	// is correct. Zero-value starts at 0, giving first seqID=1 on first Add(1).
+	nextCBSeqID atomic.Uint32
+
 	callbackTimeout time.Duration
 }
 
@@ -267,7 +273,7 @@ func (bs *BackchannelSender) sendCallbackWithRetry(ctx context.Context, req Call
 // sendCallback is the core send logic for a single callback attempt.
 func (bs *BackchannelSender) sendCallback(ctx context.Context, req CallbackRequest) error {
 	// 1. Allocate slot 0 with monotonic seqid (simplified EOS)
-	seqID := bs.nextXID.Add(1)
+	seqID := bs.nextCBSeqID.Add(1)
 	slotID := uint32(0)
 	highestSlotID := uint32(0)
 	if bs.slotTable != nil {

--- a/internal/adapter/nfs/v4/state/backchannel_test.go
+++ b/internal/adapter/nfs/v4/state/backchannel_test.go
@@ -385,12 +385,88 @@ func TestBackchannelSender_SequenceIDIncrement(t *testing.T) {
 	}()
 	seqID2 := readAndReply()
 
-	// The seqID should be different and increasing between calls
-	if seqID1 == seqID2 {
-		t.Errorf("seqID should increment between callbacks: seqID1=%d, seqID2=%d", seqID1, seqID2)
+	// RFC 8881 §2.10.6.1: CB_SEQUENCE seqID must increment by exactly 1 per send.
+	if seqID2 != seqID1+1 {
+		t.Errorf("CB_SEQUENCE seqID must increment by exactly 1: seqID1=%d seqID2=%d (want %d)", seqID1, seqID2, seqID1+1)
 	}
-	if seqID2 <= seqID1 {
-		t.Errorf("seqID should increase: seqID1=%d, seqID2=%d", seqID1, seqID2)
+}
+
+// TestBackchannelSender_SeqIDAndXIDAreIndependent proves the CB_SEQUENCE seqID
+// counter and the RPC XID counter are fully decoupled. A shared counter (the
+// prior bug) made CB_SEQUENCE seqIDs skip by 2, violating RFC 8881 §2.10.6.1.
+func TestBackchannelSender_SeqIDAndXIDAreIndependent(t *testing.T) {
+	sender, sm, sessionID := createTestBackchannelSender(t)
+
+	// Pre-skew the XID counter to prove the two counters diverge and do not
+	// share state: after this, XIDs start at 6 while CB seqIDs still start at 1.
+	sender.nextXID.Add(5)
+
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = serverConn.Close() }()
+
+	connID := uint64(4100)
+	pending := sm.RegisterConnWriter(connID, func(data []byte) error {
+		_, err := serverConn.Write(data)
+		return err
+	})
+	if _, err := sm.BindConnToSession(connID, sessionID, types.CDFC4_FORE_OR_BOTH); err != nil {
+		t.Fatalf("BindConnToSession: %v", err)
+	}
+
+	// Helper to read one CB_COMPOUND frame and extract both the RPC XID and the
+	// CB_SEQUENCE seqID, then deliver a mock reply.
+	readAndReply := func() (xid, seqID uint32) {
+		var headerBuf [4]byte
+		if _, err := io.ReadFull(clientConn, headerBuf[:]); err != nil {
+			t.Fatalf("read header: %v", err)
+		}
+		header := binary.BigEndian.Uint32(headerBuf[:])
+		fragLen := header & 0x7FFFFFFF
+		body := make([]byte, fragLen)
+		if _, err := io.ReadFull(clientConn, body); err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if len(body) < 60+16+4 {
+			t.Fatalf("body too short: %d bytes", len(body))
+		}
+		xid = binary.BigEndian.Uint32(body[0:4])
+		seqID = binary.BigEndian.Uint32(body[60+16 : 60+16+4])
+
+		pending.Deliver(xid, buildMockCBCompoundReplyBody(xid))
+		return xid, seqID
+	}
+
+	go func() {
+		recallOp := EncodeCBRecallOp(&types.Stateid4{Seqid: 1}, false, []byte{0x01})
+		_ = sender.sendCallback(context.Background(), CallbackRequest{
+			OpCode:  types.OP_CB_RECALL,
+			Payload: recallOp,
+		})
+	}()
+	xid1, seqID1 := readAndReply()
+
+	go func() {
+		recallOp := EncodeCBRecallOp(&types.Stateid4{Seqid: 2}, false, []byte{0x02})
+		_ = sender.sendCallback(context.Background(), CallbackRequest{
+			OpCode:  types.OP_CB_RECALL,
+			Payload: recallOp,
+		})
+	}()
+	xid2, seqID2 := readAndReply()
+
+	// CB_SEQUENCE seqID increments by exactly 1, independent of XID activity.
+	if seqID2 != seqID1+1 {
+		t.Errorf("CB_SEQUENCE seqID must increment by exactly 1: seqID1=%d seqID2=%d (want %d)", seqID1, seqID2, seqID1+1)
+	}
+	// RPC XID increments by exactly 1, independently.
+	if xid2 != xid1+1 {
+		t.Errorf("RPC XID must increment by exactly 1: xid1=%d xid2=%d (want %d)", xid1, xid2, xid1+1)
+	}
+	// The two counters are genuinely independent: with the XID pre-skewed, the
+	// first XID and first seqID must not coincide.
+	if xid1 == seqID1 {
+		t.Errorf("seqID and XID counters must be independent: xid1=%d seqID1=%d", xid1, seqID1)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -1,0 +1,383 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// Finding 1 — LockNew must not leak lock-owner / lock-state on bad seqid
+// ============================================================================
+
+// TestLockNew_BadLockSeqidDoesNotLeakState verifies that a LOCK with an
+// invalid lock seqid is rejected BEFORE the lock-owner is registered, so no
+// orphaned lock-owner is left in sm.lockOwners.
+func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	ownerData := []byte("new-owner")
+
+	// Bad lock seqid for a brand-new lock-owner: only nextSeqID(0)==1 is valid.
+	_, err := sm.LockNew(
+		clientID, ownerData, 99,
+		openStateid, openSeqid+1,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err == nil {
+		t.Fatal("expected ErrBadSeqid for bad lock seqid on brand-new owner")
+	}
+
+	// The lock-owner must NOT have been registered.
+	loKey := makeLockOwnerKey(clientID, ownerData)
+	if _, exists := sm.lockOwners[loKey]; exists {
+		t.Error("lock owner must not be registered after bad seqid rejection")
+	}
+}
+
+// TestLockNew_BadLockSeqidDoesNotLeakLockState verifies that no LockState is
+// appended to the open-state when a bad lock seqid is rejected. A subsequent
+// valid LOCK must therefore allocate a fresh lock state (seqid starts at 1)
+// rather than reuse a leaked one.
+func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	openState := sm.openStateByOther[openStateid.Other]
+	if openState == nil {
+		t.Fatal("open state not found")
+	}
+
+	ownerData := []byte("new-owner")
+
+	// Bad seqid rejection.
+	if _, err := sm.LockNew(
+		clientID, ownerData, 99,
+		openStateid, openSeqid+1,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	); err == nil {
+		t.Fatal("expected ErrBadSeqid for bad lock seqid")
+	}
+
+	if len(openState.LockStates) != 0 {
+		t.Fatalf("open state must have no lock states after bad seqid, got %d", len(openState.LockStates))
+	}
+
+	// A valid follow-up LOCK (seqid=1) must now succeed cleanly.
+	res, err := sm.LockNew(
+		clientID, ownerData, 1,
+		openStateid, openSeqid+1,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("valid LockNew after rejection failed: %v", err)
+	}
+	if res.Denied != nil {
+		t.Fatal("expected no conflict for valid LOCK after rejection")
+	}
+	// First successful lock state advances seqid 1 -> 2; a leaked-then-reused
+	// state would have shown a higher value.
+	if res.Stateid.Seqid != 2 {
+		t.Errorf("lock stateid seqid = %d, want 2 (fresh state)", res.Stateid.Seqid)
+	}
+}
+
+// ============================================================================
+// Finding 2 — lease-expiry reap must stop each session's backchannel sender
+// ============================================================================
+
+// TestReapExpiredSessions_StopsBackchannelSender verifies that when a v4.1
+// client's lease expires, the session reaper stops the backchannel sender
+// (closing its stopCh) instead of leaking the goroutine.
+func TestReapExpiredSessions_StopsBackchannelSender(t *testing.T) {
+	// Very short lease so it expires almost immediately.
+	sm := NewStateManager(1 * time.Millisecond)
+	clientID, seqID := registerV41Client(t, sm)
+
+	csResult, _, err := sm.CreateSession(
+		clientID, seqID, types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN,
+		defaultForeAttrs(), defaultBackAttrs(), 0x40000000, nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateSession error: %v", err)
+	}
+
+	// Plant a backchannel sender on the session whose Stop() we can observe.
+	session := sm.GetSession(csResult.SessionID)
+	if session == nil {
+		t.Fatal("GetSession returned nil")
+	}
+	sender := NewBackchannelSender(csResult.SessionID, clientID, 0x40000000, session.BackChannelSlots, sm)
+	sm.mu.Lock()
+	session.backchannelSender = sender
+	sm.mu.Unlock()
+	go sender.Run(context.Background())
+
+	// Let the lease expire, then run the reaper.
+	time.Sleep(10 * time.Millisecond)
+	sm.reapExpiredSessions()
+
+	// The sender's stopCh must be closed (Stop was called by purgeV41Client).
+	select {
+	case <-sender.stopCh:
+		// pass
+	case <-time.After(1 * time.Second):
+		t.Error("BackchannelSender.Stop not called after lease-expiry reap")
+	}
+
+	// And the session/client must be fully purged.
+	if sm.GetSession(csResult.SessionID) != nil {
+		t.Error("session should be destroyed after lease-expiry reap")
+	}
+}
+
+// ============================================================================
+// Finding 5 — acquireLock LOCK4denied must contain decoded owner bytes
+// ============================================================================
+
+// setupClientAndOpenStateForClient is a variant of setupClientAndOpenState
+// that accepts a client name + file handle, so two distinct clients can open
+// the same file in one test.
+func setupClientAndOpenStateForClient(t *testing.T, sm *StateManager, clientName string, fileHandle []byte, verifier [8]byte) (clientID uint64, openStateid *types.Stateid4, openSeqid uint32) {
+	t.Helper()
+
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+
+	result, err := sm.SetClientID(clientName, verifier, callback, "10.0.0.9:1234")
+	if err != nil {
+		t.Fatalf("SetClientID(%s) failed: %v", clientName, err)
+	}
+	clientID = result.ClientID
+
+	if err := sm.ConfirmClientID(clientID, result.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID(%s) failed: %v", clientName, err)
+	}
+
+	openSeqid = 1
+	openResult, err := sm.OpenFile(
+		clientID,
+		[]byte("open-owner-"+clientName),
+		openSeqid,
+		fileHandle,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		types.CLAIM_NULL,
+	)
+	if err != nil {
+		t.Fatalf("OpenFile(%s) failed: %v", clientName, err)
+	}
+
+	confirmSeqid := openSeqid + 1
+	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid)
+	if err != nil {
+		t.Fatalf("ConfirmOpen(%s) failed: %v", clientName, err)
+	}
+
+	return clientID, &confirmRes.Stateid, confirmSeqid
+}
+
+// TestAcquireLock_DeniedOwnerDataIsDecodedBytes verifies the LOCK4denied
+// returned to a conflicting client carries the decoded opaque owner bytes and
+// the conflicting client's ID, not the raw "nfs4:{id}:{hex}" format string.
+func TestAcquireLock_DeniedOwnerDataIsDecodedBytes(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	fh := []byte("/export:denied-owner-file")
+	verifierA := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	verifierB := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}
+
+	clientA, stateidA, seqA := setupClientAndOpenStateForClient(t, sm, "client-a", fh, verifierA)
+	clientB, stateidB, seqB := setupClientAndOpenStateForClient(t, sm, "client-b", fh, verifierB)
+
+	// Client A acquires an exclusive lock on [0, 100).
+	ownerA := []byte("owner-a")
+	if _, err := sm.LockNew(
+		clientA, ownerA, 1,
+		stateidA, seqA+1,
+		fh, types.WRITE_LT, 0, 100, false,
+	); err != nil {
+		t.Fatalf("LockNew for A failed: %v", err)
+	}
+
+	// Client B requests an overlapping exclusive lock -> DENIED.
+	resB, err := sm.LockNew(
+		clientB, []byte("owner-b"), 1,
+		stateidB, seqB+1,
+		fh, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew for B error: %v", err)
+	}
+	if resB.Denied == nil {
+		t.Fatal("expected LOCK4denied for overlapping exclusive lock")
+	}
+
+	if !bytes.Equal(resB.Denied.Owner.OwnerData, ownerA) {
+		t.Errorf("Denied.Owner.OwnerData = %q, want %q (decoded bytes)", resB.Denied.Owner.OwnerData, ownerA)
+	}
+	if resB.Denied.Owner.ClientID != clientA {
+		t.Errorf("Denied.Owner.ClientID = %d, want %d", resB.Denied.Owner.ClientID, clientA)
+	}
+}
+
+// ============================================================================
+// Finding 3 — SETCLIENTID principal-mismatch must return CLID_INUSE
+// ============================================================================
+
+func TestSetClientID_PrincipalMismatchReturnsClientIDInUse(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+
+	r1, err := sm.SetClientID("hijack-target", verifier, cb, "10.0.0.1:1234", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID failed: %v", err)
+	}
+	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID failed: %v", err)
+	}
+
+	// Case 5 (same verifier) from a DIFFERENT principal -> CLID_INUSE.
+	_, err = sm.SetClientID("hijack-target", verifier, cb, "10.0.0.2:5678", "uid:9999")
+	if !errors.Is(err, ErrClientIDInUse) {
+		t.Errorf("expected ErrClientIDInUse, got %v", err)
+	}
+}
+
+func TestSetClientID_RebootPrincipalMismatchReturnsClientIDInUse(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+
+	r1, err := sm.SetClientID("hijack-target", verifier, cb, "10.0.0.1:1234", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID failed: %v", err)
+	}
+	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID failed: %v", err)
+	}
+
+	// Case 3 (different verifier = reboot) from a DIFFERENT principal -> CLID_INUSE.
+	verifier2 := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}
+	_, err = sm.SetClientID("hijack-target", verifier2, cb, "10.0.0.2:5678", "uid:9999")
+	if !errors.Is(err, ErrClientIDInUse) {
+		t.Errorf("expected ErrClientIDInUse for reboot from different principal, got %v", err)
+	}
+}
+
+func TestSetClientID_SamePrincipalAllowed(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+
+	r1, err := sm.SetClientID("same-principal", verifier, cb, "10.0.0.1:1234", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID failed: %v", err)
+	}
+	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID failed: %v", err)
+	}
+
+	// Re-SETCLIENTID from the SAME principal (Case 5) must still succeed.
+	if _, err := sm.SetClientID("same-principal", verifier, cb, "10.0.0.1:1234", "uid:1000"); err != nil {
+		t.Errorf("re-SETCLIENTID from same principal should succeed, got %v", err)
+	}
+
+	// Reboot (Case 3) from the SAME principal must also succeed.
+	verifier2 := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}
+	if _, err := sm.SetClientID("same-principal", verifier2, cb, "10.0.0.1:1234", "uid:1000"); err != nil {
+		t.Errorf("reboot from same principal should succeed, got %v", err)
+	}
+}
+
+// ============================================================================
+// Finding 4 — CB_NULL goroutine must not corrupt a replaced record
+// ============================================================================
+
+// TestConfirmClientID_CBNullDoesNotUpdateReplacedRecord verifies the CB_NULL
+// goroutine launched by SETCLIENTID_CONFIRM compares record pointer identity
+// before writing CBPathUp. If the map entry for the client ID was swapped to a
+// different record generation while CB_NULL was in flight, the stale goroutine
+// must NOT touch the replacement.
+//
+// Determinism: the sendCBNull hook blocks until the test swaps
+// clientsByID[clientID] to a fresh record generation, then returns err==nil
+// (a "successful" CB path). Absent the pointer-identity guard, the stale
+// goroutine reads the swapped-in record from the map and writes CBPathUp=true
+// onto it -- the WRONG generation. The replacement's sentinel starts false, so
+// such a write is detectable. With the guard, the goroutine sees the map slot
+// no longer holds its captured pointer and returns without writing.
+func TestConfirmClientID_CBNullDoesNotUpdateReplacedRecord(t *testing.T) {
+	released := make(chan struct{})
+	entered := make(chan struct{})
+	done := make(chan struct{})
+
+	sm := NewStateManager(90 * time.Second)
+	// Override the per-manager CB_NULL hook (set before any goroutine runs).
+	sm.cbNullFunc = func(_ context.Context, _ CallbackInfo) error {
+		close(entered)
+		<-released
+		return nil // "success" -- buggy path would set CBPathUp=true
+	}
+
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.0.1"}
+
+	r1, err := sm.SetClientID("cb-stale", verifier, cb, "10.0.0.1:1234", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID failed: %v", err)
+	}
+	// CONFIRM launches the CB_NULL goroutine capturing this record's pointer.
+	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID failed: %v", err)
+	}
+
+	// Wait until the goroutine entered the hook (pointer already captured).
+	<-entered
+
+	oldRec := sm.GetClient(r1.ClientID)
+	if oldRec == nil {
+		t.Fatal("confirmed record not found")
+	}
+
+	// Swap the map slot to a fresh record generation at the SAME client ID.
+	// Sentinel CBPathUp=false: the stale goroutine must NOT flip it to true.
+	replacement := &ClientRecord{
+		ClientID:       r1.ClientID,
+		ClientIDString: oldRec.ClientIDString,
+		Confirmed:      true,
+		CBPathUp:       false,
+	}
+	sm.mu.Lock()
+	sm.clientsByID[r1.ClientID] = replacement
+	sm.mu.Unlock()
+
+	// Release the hook; signal completion from a watcher so we can join.
+	go func() {
+		close(released)
+		// Best-effort: give the goroutine time to run its critical section.
+		time.Sleep(200 * time.Millisecond)
+		close(done)
+	}()
+	<-done
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if replacement.CBPathUp {
+		t.Error("stale CB_NULL goroutine wrote CBPathUp onto the replacement (wrong) record generation")
+	}
+}

--- a/internal/adapter/nfs/v4/state/callback.go
+++ b/internal/adapter/nfs/v4/state/callback.go
@@ -118,6 +118,35 @@ func encodeCBCompound(callbackIdent uint32, ops []byte) []byte {
 // Connection Helpers
 // ============================================================================
 
+// allowLoopbackCallback permits dialling loopback callback addresses. It is
+// false in production (loopback callbacks are an SSRF vector) and is only set
+// to true by tests that drive the dial-out path against a 127.0.0.1 mock
+// listener.
+var allowLoopbackCallback = false
+
+// validateCallbackHost rejects callback addresses that must not be dialled
+// from the server: loopback (127.x, ::1) and link-local unicast
+// (169.254.0.0/16 — which covers the cloud-instance metadata endpoint
+// 169.254.169.254 — and fe80::/10). Dialling such addresses turns the NFS
+// callback path into an SSRF relay into the server's own network context.
+//
+// ParseUniversalAddr always returns an IP literal, so net.ParseIP must succeed
+// for any address that passed address parsing; a nil result here means the host
+// string is malformed and must be rejected.
+func validateCallbackHost(host string) error {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("callback host %q is not a valid IP address", host)
+	}
+	if ip.IsLoopback() && !allowLoopbackCallback {
+		return fmt.Errorf("callback host %q is a loopback address", host)
+	}
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("callback host %q is a link-local address", host)
+	}
+	return nil
+}
+
 // dialCallback establishes a TCP connection to a client's callback address.
 // It parses the universal address, dials with the context deadline, and sets
 // I/O deadlines on the connection. The caller must close the returned connection.
@@ -125,6 +154,10 @@ func dialCallback(ctx context.Context, callback CallbackInfo) (net.Conn, error) 
 	host, port, err := ParseUniversalAddr(callback.NetID, callback.Addr)
 	if err != nil {
 		return nil, fmt.Errorf("parse callback address: %w", err)
+	}
+
+	if err := validateCallbackHost(host); err != nil {
+		return nil, fmt.Errorf("callback address rejected: %w", err)
 	}
 
 	addr := net.JoinHostPort(host, strconv.Itoa(port))

--- a/internal/adapter/nfs/v4/state/callback_common.go
+++ b/internal/adapter/nfs/v4/state/callback_common.go
@@ -295,6 +295,9 @@ func ValidateCBReply(replyBuf []byte) error {
 		return fmt.Errorf("read verf length: %w", err)
 	}
 	if verfLen > 0 {
+		if verfLen > MaxFragmentSize {
+			return fmt.Errorf("verifier length %d exceeds maximum %d", verfLen, MaxFragmentSize)
+		}
 		// XDR opaque fields are padded to 4-byte boundaries
 		paddedLen := int64((verfLen + 3) &^ 3)
 		if _, err := reader.Seek(paddedLen, io.SeekCurrent); err != nil {

--- a/internal/adapter/nfs/v4/state/callback_test.go
+++ b/internal/adapter/nfs/v4/state/callback_test.go
@@ -488,6 +488,16 @@ func extractXIDFromRequest(conn net.Conn) (uint32, error) {
 	return xid, nil
 }
 
+// enableLoopbackCallback flips the loopback SSRF guard off for the duration of
+// a test that drives the dial-out path against a 127.0.0.1 mock listener, then
+// restores the production default.
+func enableLoopbackCallback(t *testing.T) {
+	t.Helper()
+	prev := allowLoopbackCallback
+	allowLoopbackCallback = true
+	t.Cleanup(func() { allowLoopbackCallback = prev })
+}
+
 func makeCallbackInfoFromListener(l net.Listener) CallbackInfo {
 	addr := l.Addr().(*net.TCPAddr)
 	ip := addr.IP.To4()
@@ -507,6 +517,7 @@ func makeCallbackInfoFromListener(l net.Listener) CallbackInfo {
 }
 
 func TestSendCBRecall_Success(t *testing.T) {
+	enableLoopbackCallback(t)
 	// Start a mock TCP server
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -555,6 +566,7 @@ func TestSendCBRecall_Success(t *testing.T) {
 }
 
 func TestSendCBRecall_ConnectionRefused(t *testing.T) {
+	enableLoopbackCallback(t)
 	// Use a callback address with a port that's not listening
 	callback := CallbackInfo{
 		Program: 0x40000000,
@@ -572,6 +584,7 @@ func TestSendCBRecall_ConnectionRefused(t *testing.T) {
 }
 
 func TestSendCBRecall_Timeout(t *testing.T) {
+	enableLoopbackCallback(t)
 	// Start a listener that accepts but never responds
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -610,6 +623,7 @@ func TestSendCBRecall_Timeout(t *testing.T) {
 }
 
 func TestSendCBNull_Success(t *testing.T) {
+	enableLoopbackCallback(t)
 	// Start a mock TCP server
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -655,6 +669,7 @@ func TestSendCBNull_Success(t *testing.T) {
 }
 
 func TestSendCBNull_ConnectionRefused(t *testing.T) {
+	enableLoopbackCallback(t)
 	callback := CallbackInfo{
 		Program: 0x40000000,
 		NetID:   "tcp",
@@ -668,6 +683,7 @@ func TestSendCBNull_ConnectionRefused(t *testing.T) {
 }
 
 func TestSendCBNull_Timeout(t *testing.T) {
+	enableLoopbackCallback(t)
 	// Start a listener that accepts but never responds
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -798,6 +814,7 @@ func TestReadAndValidateCBReply_NFS4Error(t *testing.T) {
 // ============================================================================
 
 func TestSendCBRecall_VerifyWireFormat(t *testing.T) {
+	enableLoopbackCallback(t)
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -875,7 +892,151 @@ func TestSendCBRecall_VerifyWireFormat(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// validateCallbackHost Tests (SSRF guard)
+// ============================================================================
+
+func TestValidateCallbackHost_Loopback_IPv4(t *testing.T) {
+	if err := validateCallbackHost("127.0.0.1"); err == nil {
+		t.Fatal("expected error for loopback IPv4, got nil")
+	}
+}
+
+func TestValidateCallbackHost_Loopback_IPv6(t *testing.T) {
+	if err := validateCallbackHost("::1"); err == nil {
+		t.Fatal("expected error for loopback IPv6, got nil")
+	}
+}
+
+func TestValidateCallbackHost_LinkLocal_IPv4(t *testing.T) {
+	if err := validateCallbackHost("169.254.169.254"); err == nil {
+		t.Fatal("expected error for link-local IPv4, got nil")
+	}
+}
+
+func TestValidateCallbackHost_LinkLocal_IPv6(t *testing.T) {
+	if err := validateCallbackHost("fe80::1"); err == nil {
+		t.Fatal("expected error for link-local IPv6, got nil")
+	}
+}
+
+func TestValidateCallbackHost_Normal_IPv4(t *testing.T) {
+	if err := validateCallbackHost("10.1.2.3"); err != nil {
+		t.Fatalf("unexpected error for routable IPv4: %v", err)
+	}
+}
+
+func TestValidateCallbackHost_Normal_IPv6(t *testing.T) {
+	if err := validateCallbackHost("2001:db8::1"); err != nil {
+		t.Fatalf("unexpected error for routable IPv6: %v", err)
+	}
+}
+
+func TestValidateCallbackHost_Invalid(t *testing.T) {
+	if err := validateCallbackHost("not-an-ip"); err == nil {
+		t.Fatal("expected error for non-IP string, got nil")
+	}
+}
+
+// TestSendCBRecall_LoopbackRejected verifies that a callback to a loopback
+// address is rejected at address validation, not at dial time.
+func TestSendCBRecall_LoopbackRejected(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	addr := l.Addr().(*net.TCPAddr)
+	p1 := addr.Port / 256
+	p2 := addr.Port % 256
+	uaddr := fmt.Sprintf("127.0.0.1.%d.%d", p1, p2)
+
+	callback := CallbackInfo{
+		Program: 0x40000000,
+		NetID:   "tcp",
+		Addr:    uaddr,
+	}
+	stateid := &types.Stateid4{Seqid: 1}
+	fh := []byte{0x01}
+
+	if err := SendCBRecall(context.Background(), callback, stateid, false, fh); err == nil {
+		t.Fatal("expected error: loopback callback address must be rejected")
+	}
+}
+
+// TestSendCBNull_LinkLocalRejected verifies that a link-local callback
+// address is rejected at address validation.
+func TestSendCBNull_LinkLocalRejected(t *testing.T) {
+	callback := CallbackInfo{
+		Program: 0x40000000,
+		NetID:   "tcp",
+		// 169.254.169.254 encoded: p1=0, p2=80 -> port 80
+		Addr: "169.254.169.254.0.80",
+	}
+	if err := SendCBNull(context.Background(), callback); err == nil {
+		t.Fatal("expected error: link-local callback address must be rejected")
+	}
+}
+
+// ============================================================================
+// ValidateCBReply verifier-length overflow Tests
+// ============================================================================
+
+// buildReplyWithVerfLen builds a raw (unframed) RPC reply buffer with the
+// given verifier body length field and no verifier body bytes.
+func buildReplyWithVerfLen(verfLen uint32) []byte {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(1234))               // XID
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.RPCReply))       // MsgType
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.RPCMsgAccepted)) // reply_stat
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.AuthNull))       // verf_flavor
+	_ = binary.Write(&buf, binary.BigEndian, verfLen)                    // verf_len
+	return buf.Bytes()
+}
+
+func TestValidateCBReply_VerfLen_Overflow_FFFFFFFF(t *testing.T) {
+	if err := ValidateCBReply(buildReplyWithVerfLen(0xFFFFFFFF)); err == nil {
+		t.Fatal("expected error for verfLen=0xFFFFFFFF, got nil")
+	}
+}
+
+func TestValidateCBReply_VerfLen_Overflow_FFFFFFFD(t *testing.T) {
+	if err := ValidateCBReply(buildReplyWithVerfLen(0xFFFFFFFD)); err == nil {
+		t.Fatal("expected error for verfLen=0xFFFFFFFD, got nil")
+	}
+}
+
+func TestValidateCBReply_VerfLen_ExceedsMaxFragment(t *testing.T) {
+	if err := ValidateCBReply(buildReplyWithVerfLen(MaxFragmentSize + 1)); err == nil {
+		t.Fatalf("expected error for verfLen=%d (MaxFragmentSize+1), got nil", MaxFragmentSize+1)
+	}
+}
+
+func TestValidateCBReply_VerfLen_AtMaxFragment(t *testing.T) {
+	if err := ValidateCBReply(buildReplyWithVerfLen(MaxFragmentSize)); err == nil {
+		t.Fatal("expected error for verfLen=MaxFragmentSize, got nil")
+	}
+}
+
+func TestValidateCBReply_VerfLen_SmallNonZero(t *testing.T) {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(1234))               // XID
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.RPCReply))       // MsgType
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.RPCMsgAccepted)) // reply_stat
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.AuthNull))       // verf_flavor
+	_ = binary.Write(&buf, binary.BigEndian, uint32(8))                  // verf_len = 8
+	buf.Write(make([]byte, 8))                                           // 8-byte verifier body
+	_ = binary.Write(&buf, binary.BigEndian, uint32(rpc.RPCSuccess))     // accept_stat
+	_ = binary.Write(&buf, binary.BigEndian, uint32(types.NFS4_OK))      // nfsstat4
+
+	if err := ValidateCBReply(buf.Bytes()); err != nil {
+		t.Fatalf("unexpected error for small valid verfLen: %v", err)
+	}
+}
+
 func TestSendCBNull_VerifyProcedure(t *testing.T) {
+	enableLoopbackCallback(t)
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -471,7 +471,8 @@ func (sm *StateManager) CheckDelegationConflict(fileHandle []byte, clientID uint
 	// Recall every conflicting delegation, not just the first one. With multiple
 	// READ holders on a file, recalling only the first leaves the others active,
 	// so a conflicting WRITE open would spin on NFS4ERR_DELAY indefinitely.
-	var conflicting []*DelegationState
+	var conflicting bool
+	var toRecall []*DelegationState
 	for _, deleg := range sm.delegByFile[string(fileHandle)] {
 		if deleg.ClientID == clientID || deleg.Revoked {
 			continue
@@ -481,17 +482,26 @@ func (sm *StateManager) CheckDelegationConflict(fileHandle []byte, clientID uint
 			(deleg.DelegType == types.OPEN_DELEGATE_READ && shareAccess&types.OPEN4_SHARE_ACCESS_WRITE != 0)
 
 		if isConflict {
-			deleg.RecallSent = true
-			deleg.RecallTime = time.Now()
-			conflicting = append(conflicting, deleg)
+			conflicting = true
+			// Recall every conflicting delegation, but only the FIRST time each
+			// is observed. A retried OPEN (which keeps seeing NFS4ERR_DELAY) must
+			// not spawn a second concurrent recall goroutine for the same
+			// delegation — that races on its recall timer/state. The in-flight
+			// recall stays pending until the delegation is returned; meanwhile we
+			// still report a conflict so the caller keeps returning NFS4ERR_DELAY.
+			if !deleg.RecallSent {
+				deleg.RecallSent = true
+				deleg.RecallTime = time.Now()
+				toRecall = append(toRecall, deleg)
+			}
 		}
 	}
 
-	for _, deleg := range conflicting {
+	for _, deleg := range toRecall {
 		go sm.sendRecall(deleg)
 	}
 
-	return len(conflicting) > 0, nil
+	return conflicting, nil
 }
 
 // startRevocationTimer starts a recall timer on the delegation that will revoke it

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -206,6 +206,10 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
+	// Prune expired recently-recalled entries while we hold the write lock so the
+	// map stays bounded (isRecentlyRecalled is read-only under RLock).
+	sm.pruneStaleRecentlyRecalledLocked()
+
 	// Check total active delegation count against limit
 	if sm.maxDelegations > 0 && sm.countActiveDelegations() >= sm.maxDelegations {
 		return nil
@@ -291,6 +295,13 @@ func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
 
 	deleg.StopRecallTimer()
 
+	// Remove the delegation from both maps eagerly, while we still hold sm.mu.
+	// For directory delegations we drop sm.mu below to flush notifications; if we
+	// deferred the delete until after re-acquiring the lock, a concurrent
+	// RevokeDelegation could observe the still-present entry and corrupt state.
+	delete(sm.delegByOther, stateid.Other)
+	sm.removeDelegFromFile(deleg)
+
 	// For directory delegations: flush pending notifications before removal.
 	// Must release sm.mu because flushDirNotifications needs RLock for backchannel.
 	if deleg.IsDirectory {
@@ -307,9 +318,6 @@ func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
 		sm.flushDirNotifications(deleg)
 		sm.mu.Lock()
 	}
-
-	delete(sm.delegByOther, stateid.Other)
-	sm.removeDelegFromFile(deleg)
 
 	lmDelegID := deleg.LockManagerDelegID
 	fhKey := string(deleg.FileHandle)
@@ -460,6 +468,10 @@ func (sm *StateManager) CheckDelegationConflict(fileHandle []byte, clientID uint
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
+	// Recall every conflicting delegation, not just the first one. With multiple
+	// READ holders on a file, recalling only the first leaves the others active,
+	// so a conflicting WRITE open would spin on NFS4ERR_DELAY indefinitely.
+	var conflicting []*DelegationState
 	for _, deleg := range sm.delegByFile[string(fileHandle)] {
 		if deleg.ClientID == clientID || deleg.Revoked {
 			continue
@@ -471,14 +483,15 @@ func (sm *StateManager) CheckDelegationConflict(fileHandle []byte, clientID uint
 		if isConflict {
 			deleg.RecallSent = true
 			deleg.RecallTime = time.Now()
-
-			go sm.sendRecall(deleg)
-
-			return true, nil
+			conflicting = append(conflicting, deleg)
 		}
 	}
 
-	return false, nil
+	for _, deleg := range conflicting {
+		go sm.sendRecall(deleg)
+	}
+
+	return len(conflicting) > 0, nil
 }
 
 // startRevocationTimer starts a recall timer on the delegation that will revoke it
@@ -537,6 +550,14 @@ func (sm *StateManager) sendRecallV41(deleg *DelegationState, sender *Backchanne
 		logger.Debug("CB_RECALL (v4.1) sent successfully",
 			"client_id", deleg.ClientID,
 			"deleg_type", deleg.DelegType)
+
+	case <-sender.stopCh:
+		// Backchannel sender stopped (session destroy or server shutdown).
+		// Abort the wait immediately instead of leaking this goroutine for up
+		// to 30 seconds on the timer below.
+		logger.Debug("CB_RECALL (v4.1) aborted: backchannel sender stopped",
+			"client_id", deleg.ClientID)
+		sm.startRevocationTimer(deleg, 5*time.Second)
 
 	case <-time.After(30 * time.Second):
 		logger.Warn("CB_RECALL (v4.1) result timeout",
@@ -682,18 +703,31 @@ func (sm *StateManager) addRecentlyRecalled(fileHandle []byte) {
 }
 
 // isRecentlyRecalled returns true if the file handle was recently recalled
-// within the TTL window. Also lazily cleans up expired entries.
+// within the TTL window.
+//
+// This method is read-only: it never mutates sm.recentlyRecalled, so it is
+// safe to call while holding only an RLock. Stale entries are pruned by the
+// write-lock holders via pruneStaleRecentlyRecalledLocked.
 //
 // Caller must hold sm.mu (RLock or Lock).
 func (sm *StateManager) isRecentlyRecalled(fileHandle []byte) bool {
-	fhKey := string(fileHandle)
-	recallTime, exists := sm.recentlyRecalled[fhKey]
+	recallTime, exists := sm.recentlyRecalled[string(fileHandle)]
 	if !exists {
 		return false
 	}
-	if time.Since(recallTime) > sm.recentlyRecalledTTL {
-		delete(sm.recentlyRecalled, fhKey)
-		return false
+	return time.Since(recallTime) <= sm.recentlyRecalledTTL
+}
+
+// pruneStaleRecentlyRecalledLocked removes entries whose TTL has expired,
+// keeping the recently-recalled cache bounded. Called from write-lock paths
+// (e.g. GrantDelegation) so the read-only isRecentlyRecalled never has to
+// mutate the map under an RLock.
+//
+// Caller must hold sm.mu.Lock (write lock).
+func (sm *StateManager) pruneStaleRecentlyRecalledLocked() {
+	for fhKey, recallTime := range sm.recentlyRecalled {
+		if time.Since(recallTime) > sm.recentlyRecalledTTL {
+			delete(sm.recentlyRecalled, fhKey)
+		}
 	}
-	return true
 }

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -1383,5 +1384,188 @@ func TestShutdown_StopsRecallTimers(t *testing.T) {
 	// Delegation should NOT be revoked (timer was cancelled by shutdown)
 	if deleg.Revoked {
 		t.Error("delegation should NOT be revoked -- timer was stopped by Shutdown")
+	}
+}
+
+// ============================================================================
+// Concurrency / lifecycle regression tests
+// ============================================================================
+
+// TestReturnDelegation_ConcurrentRevoke verifies that a concurrent RevokeDelegation
+// racing the sm.mu drop inside ReturnDelegation (directory delegation path) does not
+// corrupt state: the delegation must be fully cleaned up and the Revoked flag preserved.
+func TestReturnDelegation_ConcurrentRevoke(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	fh := []byte("fh-concurrent-revoke")
+	deleg := sm.GrantDelegation(100, fh, types.OPEN_DELEGATE_READ)
+
+	// Mark as directory delegation so ReturnDelegation drops sm.mu mid-function.
+	sm.mu.Lock()
+	deleg.IsDirectory = true
+	sm.mu.Unlock()
+
+	// Launch ReturnDelegation and RevokeDelegation concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_ = sm.ReturnDelegation(&deleg.Stateid)
+	}()
+
+	go func() {
+		defer wg.Done()
+		sm.RevokeDelegation(deleg.Stateid.Other)
+	}()
+
+	wg.Wait()
+
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	// delegByFile must not contain the delegation after either path completes.
+	for _, d := range sm.delegByFile[string(fh)] {
+		if d == deleg {
+			t.Error("delegation must be removed from delegByFile")
+		}
+	}
+
+	// The delegation must not appear as an active (non-revoked) entry in delegByOther.
+	// If it remains (kept for stale detection by RevokeDelegation), it must be Revoked.
+	if d, ok := sm.delegByOther[deleg.Stateid.Other]; ok && !d.Revoked {
+		t.Error("if delegation remains in delegByOther it must be marked Revoked")
+	}
+}
+
+// TestCheckDelegationConflict_RecallsAllReadDelegations verifies that when a WRITE
+// open conflicts with multiple READ delegations, ALL holders are recalled -- not just
+// the first one encountered.
+func TestCheckDelegationConflict_RecallsAllReadDelegations(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	fh := []byte("fh-multi-read-deleg-conflict")
+
+	// Grant READ delegations to three different clients.
+	d1 := sm.GrantDelegation(101, fh, types.OPEN_DELEGATE_READ)
+	d2 := sm.GrantDelegation(102, fh, types.OPEN_DELEGATE_READ)
+	d3 := sm.GrantDelegation(103, fh, types.OPEN_DELEGATE_READ)
+
+	// Client 200 opens for WRITE: conflicts with all three READ delegations.
+	conflict, err := sm.CheckDelegationConflict(fh, 200, types.OPEN4_SHARE_ACCESS_WRITE)
+	if err != nil {
+		t.Fatalf("CheckDelegationConflict: %v", err)
+	}
+	if !conflict {
+		t.Fatal("expected conflict=true with three READ delegations and WRITE access")
+	}
+
+	// The flags must be set synchronously before any goroutines launch.
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for i, d := range []*DelegationState{d1, d2, d3} {
+		if !d.RecallSent {
+			t.Errorf("delegation[%d] (clientID=%d): RecallSent should be true", i, d.ClientID)
+		}
+		if d.RecallTime.IsZero() {
+			t.Errorf("delegation[%d] (clientID=%d): RecallTime should be set", i, d.ClientID)
+		}
+	}
+}
+
+// TestRecentlyRecalled_NoRaceOnExpiry verifies that concurrent calls to
+// ShouldGrantDelegation (which takes RLock and calls isRecentlyRecalled) do not
+// race when the TTL has just expired.
+func TestRecentlyRecalled_NoRaceOnExpiry(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.recentlyRecalledTTL = 10 * time.Millisecond
+
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	result, err := sm.SetClientID("client-race-recalled", verifier, callback, "10.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err = sm.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	setCBPathUp(sm, result.ClientID)
+
+	fh := []byte("fh-race-recalled")
+	sm.mu.Lock()
+	sm.addRecentlyRecalled(fh)
+	sm.mu.Unlock()
+
+	// Wait for the TTL to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Hammer ShouldGrantDelegation from multiple goroutines concurrently.
+	// Before the fix: go test -race detects a concurrent write (delete) and read
+	// on sm.recentlyRecalled.  After the fix: no race.
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sm.ShouldGrantDelegation(result.ClientID, fh, types.OPEN4_SHARE_ACCESS_READ)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestSendRecallV41_StopCh verifies that the goroutine spawned by sendRecallV41
+// exits promptly when the BackchannelSender is stopped, rather than blocking
+// for the full 30-second time.After timeout.
+func TestSendRecallV41_StopCh(t *testing.T) {
+	sender, sm, sessionID := createTestBackchannelSender(t)
+
+	// Register a connection that accepts bytes but never delivers a reply,
+	// simulating a client that sent CB_RECALL but disappeared.
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = serverConn.Close() }()
+
+	connID := uint64(9001)
+	sm.RegisterConnWriter(connID, func(data []byte) error {
+		_, err := serverConn.Write(data)
+		return err
+	})
+	if _, err := sm.BindConnToSession(connID, sessionID, types.CDFC4_FORE_OR_BOTH); err != nil {
+		t.Fatalf("BindConnToSession: %v", err)
+	}
+
+	// Drain the server side without replying.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	fh := []byte("fh-stop-recall")
+	deleg := sm.GrantDelegation(sender.clientID, fh, types.OPEN_DELEGATE_READ)
+	deleg.RecallSent = true
+	deleg.RecallTime = time.Now()
+
+	recallDone := make(chan struct{})
+	go func() {
+		sm.sendRecallV41(deleg, sender)
+		close(recallDone)
+	}()
+
+	// Give the goroutine a moment to reach the select.
+	time.Sleep(30 * time.Millisecond)
+
+	// Stop the sender -- the goroutine must exit well before 30 seconds.
+	sender.Stop()
+
+	select {
+	case <-recallDone:
+		// OK -- exited promptly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendRecallV41 goroutine did not exit within 2s after sender.Stop()")
 	}
 }

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -1092,6 +1092,7 @@ func TestRevokedDelegation_ReturnSucceeds(t *testing.T) {
 // ============================================================================
 
 func TestCBPathUp_VerifiedOnConfirm(t *testing.T) {
+	enableLoopbackCallback(t)
 	sm := NewStateManager(90 * time.Second)
 
 	// Start a mock TCP listener that accepts CB_NULL

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -210,6 +210,11 @@ type StateManager struct {
 	// backchannelFaults tracks per-client backchannel fault state. Set when a
 	// callback send fails, cleared on success. Protected by connMu.
 	backchannelFaults map[uint64]bool
+
+	// cbNullFunc verifies the callback path during SETCLIENTID_CONFIRM. It
+	// defaults to SendCBNull and is only overridden by tests (set once at
+	// construction, before any goroutine reads it).
+	cbNullFunc func(context.Context, CallbackInfo) error
 }
 
 // NewStateManager creates a new StateManager with the given lease duration.
@@ -262,6 +267,7 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		connWriters:       make(map[uint64]ConnWriter),
 		cbRepliesByConn:   make(map[uint64]*PendingCBReplies),
 		backchannelFaults: make(map[uint64]bool),
+		cbNullFunc:        SendCBNull,
 	}
 }
 
@@ -403,6 +409,14 @@ func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, ca
 // unconfirmed record that will replace the confirmed one when confirmed.
 // Caller must hold sm.mu.
 func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
+	// RFC 7530 Section 9.1.1: if the confirmed record was established by a
+	// principal and this request carries a different non-empty principal,
+	// reject with NFS4ERR_CLID_INUSE. Prevents a third party that knows the
+	// client ID string + verifier from hijacking the client's lease/state.
+	if confirmed.Principal != "" && principal != "" && confirmed.Principal != principal {
+		return nil, ErrClientIDInUse
+	}
+
 	// Remove any existing unconfirmed record for this name
 	if old := sm.unconfirmedByName[clientIDStr]; old != nil {
 		// Only delete from clientsByID if it's a different ID than the confirmed client.
@@ -451,6 +465,15 @@ func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDSt
 // the new one is confirmed in SETCLIENTID_CONFIRM.
 // Caller must hold sm.mu.
 func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
+	// RFC 7530 Section 9.1.1: a reboot (different verifier) from a different
+	// non-empty principal than the confirmed record is a hijack attempt, not a
+	// real reboot. Reject with NFS4ERR_CLID_INUSE.
+	if confirmed := sm.clientsByName[clientIDStr]; confirmed != nil {
+		if confirmed.Principal != "" && principal != "" && confirmed.Principal != principal {
+			return nil, ErrClientIDInUse
+		}
+	}
+
 	// Remove any existing unconfirmed record for this name
 	if old := sm.unconfirmedByName[clientIDStr]; old != nil {
 		delete(sm.clientsByID, old.ClientID)
@@ -611,13 +634,17 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 	// This runs in a goroutine so SETCLIENTID_CONFIRM returns immediately.
 	if record.Callback.Addr != "" {
 		cbInfo := record.Callback
+		recordPtr := record // capture this record generation's pointer identity
 		go func() {
-			err := SendCBNull(context.Background(), cbInfo)
+			err := sm.cbNullFunc(context.Background(), cbInfo)
 			sm.mu.Lock()
 			defer sm.mu.Unlock()
 			rec, ok := sm.clientsByID[clientID]
-			if !ok {
-				return // Client was removed while CB_NULL was in flight
+			if !ok || rec != recordPtr {
+				// Client was removed, or this client ID now points at a
+				// different record generation (reboot / re-SETCLIENTID) while
+				// CB_NULL was in flight. Do not touch the replacement.
+				return
 			}
 			rec.CBPathUp = (err == nil)
 			if err != nil {
@@ -1746,9 +1773,52 @@ func (sm *StateManager) LockNew(
 		return nil, err
 	}
 
-	// 4. Find or create lock-owner
+	// 4. Probe the lock-owner WITHOUT allocating. Seqid validation (step 6)
+	// must run before any state is inserted into the maps; otherwise a bad
+	// lock seqid would strand a freshly-allocated lock-owner / lock-state
+	// (they would be reused by a later valid LOCK with a wrong LastSeqID=0
+	// baseline).
 	loKey := makeLockOwnerKey(lockClientID, lockOwnerData)
 	lockOwner, ownerExists := sm.lockOwners[loKey]
+
+	// 6. Validate lock seqid on lock-owner BEFORE any allocation.
+	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
+	if lockSeqid != 0 {
+		if ownerExists {
+			lockValidation := lockOwner.ValidateSeqID(lockSeqid)
+			switch lockValidation {
+			case SeqIDBad:
+				return nil, ErrBadSeqid
+			case SeqIDReplay:
+				// Replay the exact cached LOCK reply. Returning NFS4ERR_BAD_SEQID
+				// here (the previous behavior) is treated as fatal by the Linux
+				// client and drops the lock-owner -> silent lock loss.
+				if lockOwner.LastResult != nil {
+					return nil, &ReplayError{Status: lockOwner.LastResult.Status, Data: lockOwner.LastResult.Data}
+				}
+				return nil, ErrBadSeqid
+			case SeqIDOK:
+				// A fresh lock seqid alongside a replayed open seqid is an
+				// inconsistent retransmit; treat as bad seqid.
+				if openSeqIsReplay {
+					return nil, ErrBadSeqid
+				}
+			}
+		} else {
+			// Brand-new lock-owner: the only valid lock seqid is nextSeqID(0)
+			// (== 1) per RFC 7530 Section 9.1.4. Reject anything else before
+			// allocating, so a bad seqid leaves no orphaned state behind.
+			if lockSeqid != nextSeqID(0) {
+				return nil, ErrBadSeqid
+			}
+		}
+	} else if openSeqIsReplay {
+		// Open seqid replayed but the lock-owner is brand new / not yet
+		// seqid-tracked: nothing consistent to replay.
+		return nil, ErrBadSeqid
+	}
+
+	// 4b. Find or create lock-owner -- only after seqid validation passes.
 	if !ownerExists {
 		clientRecord := sm.clientsByID[lockClientID]
 		lockOwner = &LockOwner{
@@ -1787,34 +1857,6 @@ func (sm *StateManager) LockNew(
 		// Register in maps
 		openState.LockStates = append(openState.LockStates, lockState)
 		sm.lockStateByOther[other] = lockState
-	}
-
-	// 6. Validate lock seqid on lock-owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if ownerExists && lockSeqid != 0 {
-		lockValidation := lockOwner.ValidateSeqID(lockSeqid)
-		switch lockValidation {
-		case SeqIDBad:
-			return nil, ErrBadSeqid
-		case SeqIDReplay:
-			// Replay the exact cached LOCK reply. Returning NFS4ERR_BAD_SEQID
-			// here (the previous behavior) is treated as fatal by the Linux
-			// client and drops the lock-owner -> silent lock loss.
-			if lockOwner.LastResult != nil {
-				return nil, &ReplayError{Status: lockOwner.LastResult.Status, Data: lockOwner.LastResult.Data}
-			}
-			return nil, ErrBadSeqid
-		case SeqIDOK:
-			// A fresh lock seqid alongside a replayed open seqid is an
-			// inconsistent retransmit; treat as bad seqid.
-			if openSeqIsReplay {
-				return nil, ErrBadSeqid
-			}
-		}
-	} else if openSeqIsReplay {
-		// Open seqid replayed but the lock-owner is brand new / not yet
-		// seqid-tracked: nothing consistent to replay.
-		return nil, ErrBadSeqid
 	}
 
 	// 7. Acquire the lock via unified lock manager
@@ -1993,10 +2035,13 @@ func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offse
 					Length:   el.Length,
 					LockType: conflictType,
 				}
-				// Parse OwnerID to extract clientID and ownerData
-				// Format: "nfs4:{clientid}:{owner_hex}"
-				denied.Owner.ClientID = 0 // Default if parsing fails
-				denied.Owner.OwnerData = []byte(el.Owner.OwnerID)
+				// Parse OwnerID to extract clientID and ownerData.
+				// Format: "nfs4:{clientid}:{owner_hex}". Use the shared helper
+				// so OwnerData is the decoded opaque bytes, not the raw format
+				// string (LOCKT uses the same path).
+				denied.Owner.ClientID = 0    // default; parseConflictOwner overwrites on success
+				denied.Owner.OwnerData = nil // default
+				parseConflictOwner(el.Owner.OwnerID, denied)
 				return denied, nil
 			}
 		}
@@ -2641,12 +2686,9 @@ func (sm *StateManager) reapExpiredSessions() {
 				"client_id", fmt.Sprintf("0x%x", record.ClientID),
 				"client_addr", record.ClientAddr)
 
-			// Destroy all sessions for this client with "lease_expired" reason
-			for _, session := range sm.sessionsByClientID[record.ClientID] {
-				delete(sm.sessionsByID, session.SessionID)
-			}
-			delete(sm.sessionsByClientID, record.ClientID)
-
+			// Defer all session teardown to purgeV41Client, which stops each
+			// session's backchannel sender before deleting it. Deleting the
+			// sessions here would empty sessionsByClientID and leak the senders.
 			toPurge = append(toPurge, record)
 			continue
 		}

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -386,10 +386,23 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 		}
 	}
 
-	// Remove lock-owner from lockOwners map
+	// Remove lock-owner from lockOwners map only when no other LockState
+	// still references this owner (reference-count to zero). A LockOwner can
+	// be shared across multiple LockState entries (one per open-state/file),
+	// so deleting it on the first free would blind replay-detection and the
+	// owner caches for the still-live lock states.
 	if lockState.LockOwner != nil {
 		lockKey := makeLockOwnerKey(lockState.LockOwner.ClientID, lockState.LockOwner.OwnerData)
-		delete(sm.lockOwners, lockKey)
+		ownerStillReferenced := false
+		for _, ls := range sm.lockStateByOther {
+			if ls.LockOwner == lockState.LockOwner {
+				ownerStillReferenced = true
+				break
+			}
+		}
+		if !ownerStillReferenced {
+			delete(sm.lockOwners, lockKey)
+		}
 	}
 
 	// Remove from parent open state's LockStates slice

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -1160,6 +1160,135 @@ func TestFreeStateid(t *testing.T) {
 		}
 	})
 
+	t.Run("free_one_lock_stateid_does_not_delete_shared_owner", func(t *testing.T) {
+		lm := lock.NewManager()
+		sm := NewStateManager(90 * time.Second)
+		sm.SetLockManager(lm)
+		defer sm.Shutdown()
+
+		// Two separate open states on two different files, same lock owner.
+		fh1 := []byte("fh-shared-owner-file1")
+		fh2 := []byte("fh-shared-owner-file2")
+		lockOwnerData := []byte("shared-lock-owner")
+		clientID := uint64(0)
+
+		open1, err := sm.OpenFile(clientID, []byte("open-owner"), 1, fh1,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+		if err != nil {
+			t.Fatalf("OpenFile 1: %v", err)
+		}
+		conf1, err := sm.ConfirmOpen(&open1.Stateid, 2)
+		if err != nil {
+			t.Fatalf("ConfirmOpen 1: %v", err)
+		}
+
+		open2, err := sm.OpenFile(clientID, []byte("open-owner"), 3, fh2,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+		if err != nil {
+			t.Fatalf("OpenFile 2: %v", err)
+		}
+		// open2 uses a confirmed owner; no OPEN_CONFIRM needed.
+
+		// Acquire a lock on file1 with the shared lock owner.
+		lock1, err := sm.LockNew(
+			clientID, lockOwnerData, 1,
+			&conf1.Stateid, 4,
+			fh1, types.WRITE_LT, 0, 100, false,
+		)
+		if err != nil {
+			t.Fatalf("LockNew on fh1: %v", err)
+		}
+		if lock1.Denied != nil {
+			t.Fatal("unexpected conflict for lock on fh1")
+		}
+
+		// LOCKU to release the actual byte-range lock before FREE_STATEID.
+		_, err = sm.UnlockFile(&lock1.Stateid, 2, types.WRITE_LT, 0, 100)
+		if err != nil {
+			t.Fatalf("UnlockFile on fh1: %v", err)
+		}
+
+		// Acquire a lock on file2 with the SAME lock owner — this reuses the
+		// existing LockOwner entry in sm.lockOwners and creates a second LockState.
+		lock2, err := sm.LockNew(
+			clientID, lockOwnerData, 3,
+			&open2.Stateid, 5,
+			fh2, types.WRITE_LT, 0, 50, false,
+		)
+		if err != nil {
+			t.Fatalf("LockNew on fh2: %v", err)
+		}
+		if lock2.Denied != nil {
+			t.Fatal("unexpected conflict for lock on fh2")
+		}
+
+		// Confirm there are two LockState entries in lockStateByOther.
+		sm.mu.RLock()
+		lockStateCount := 0
+		loKey := makeLockOwnerKey(clientID, lockOwnerData)
+		owner, ownerExists := sm.lockOwners[loKey]
+		for _, ls := range sm.lockStateByOther {
+			if ls.LockOwner == owner {
+				lockStateCount++
+			}
+		}
+		sm.mu.RUnlock()
+		if !ownerExists {
+			t.Fatal("lock owner should exist before FREE_STATEID")
+		}
+		if lockStateCount != 2 {
+			t.Fatalf("expected 2 lock states for shared owner, got %d", lockStateCount)
+		}
+
+		// FREE_STATEID on the first lock stateid (already unlocked).
+		if err := sm.FreeStateid(clientID, &lock1.Stateid); err != nil {
+			t.Fatalf("FreeStateid lock1: %v", err)
+		}
+
+		// The lock owner MUST still be present — lock2's LockState still references it.
+		sm.mu.RLock()
+		_, ownerStillExists := sm.lockOwners[loKey]
+		sm.mu.RUnlock()
+		if !ownerStillExists {
+			t.Error("BUG: freeing one lock stateid must not delete the shared LockOwner " +
+				"while another LockState still references it")
+		}
+
+		// CacheLockOwnerResult must still work for the surviving owner.
+		sm.CacheLockOwnerResult(clientID, lockOwnerData, types.NFS4_OK, []byte("cached"))
+
+		sm.mu.RLock()
+		loKey2 := makeLockOwnerKey(clientID, lockOwnerData)
+		lo2, exists2 := sm.lockOwners[loKey2]
+		var cachedData []byte
+		if exists2 && lo2.LastResult != nil {
+			cachedData = lo2.LastResult.Data
+		}
+		sm.mu.RUnlock()
+		if !exists2 {
+			t.Fatal("lock owner not found after CacheLockOwnerResult")
+		}
+		if string(cachedData) != "cached" {
+			t.Errorf("cache not written: got %q, want %q", cachedData, "cached")
+		}
+
+		// Now LOCKU and FREE_STATEID the second stateid; owner should be deleted then.
+		_, err = sm.UnlockFile(&lock2.Stateid, 4, types.WRITE_LT, 0, 50)
+		if err != nil {
+			t.Fatalf("UnlockFile on fh2: %v", err)
+		}
+		if err := sm.FreeStateid(clientID, &lock2.Stateid); err != nil {
+			t.Fatalf("FreeStateid lock2: %v", err)
+		}
+
+		sm.mu.RLock()
+		_, ownerGone := sm.lockOwners[loKey]
+		sm.mu.RUnlock()
+		if ownerGone {
+			t.Error("lock owner should be deleted after its last LockState is freed")
+		}
+	})
+
 	t.Run("free_open_stateid", func(t *testing.T) {
 		sm := NewStateManager(90 * time.Second)
 		defer sm.Shutdown()

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -318,8 +318,11 @@ func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
 		sm.removeDelegFromFile(deleg)
 	}
 
-	// Destroy all sessions for this client
+	// Destroy all sessions for this client. Stop each session's backchannel
+	// sender BEFORE removing it from sessionsByID -- stopBackchannelSender
+	// looks the session up there, so deleting first would leak the goroutine.
 	for _, session := range sm.sessionsByClientID[record.ClientID] {
+		sm.stopBackchannelSender(session.SessionID)
 		delete(sm.sessionsByID, session.SessionID)
 	}
 	delete(sm.sessionsByClientID, record.ClientID)

--- a/internal/adapter/nfs/v4/v41/handlers/backchannel_ctl.go
+++ b/internal/adapter/nfs/v4/v41/handlers/backchannel_ctl.go
@@ -35,6 +35,16 @@ func HandleBackchannelCtl(
 		}
 	}
 
+	// BACKCHANNEL_CTL requires SEQUENCE context; reject if sent outside a session.
+	if v41ctx == nil {
+		logger.Debug("BACKCHANNEL_CTL: no session context", "client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_OP_NOT_IN_SESSION,
+			OpCode: types.OP_BACKCHANNEL_CTL,
+			Data:   EncodeStatusOnly(types.NFS4ERR_OP_NOT_IN_SESSION),
+		}
+	}
+
 	// Look up the session from the V41RequestContext session ID
 	session := d.StateManager.GetSession(v41ctx.SessionID)
 	if session == nil {

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_session.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_session.go
@@ -2,6 +2,7 @@ package v41handlers
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -13,7 +14,7 @@ import (
 // Delegates to StateManager.DestroySession; returns NFS4ERR_DELAY for in-flight requests.
 // Removes session from tracking maps; stops backchannel sender; frees all slot resources.
 // Errors: NFS4ERR_BADSESSION, NFS4ERR_DELAY (in-flight requests), NFS4ERR_BADXDR.
-func HandleDestroySession(d *Deps, ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+func HandleDestroySession(d *Deps, ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
 	var args types.DestroySessionArgs
 	if err := args.Decode(reader); err != nil {
 		logger.Debug("DESTROY_SESSION: decode error", "error", err, "client", ctx.ClientAddr)
@@ -21,6 +22,45 @@ func HandleDestroySession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reque
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_DESTROY_SESSION,
 			Data:   EncodeStatusOnly(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	// Verify the requesting client owns the target session (RFC 8881 Section 18.37.3).
+	// GetSession uses a read lock; we look up before the write-locking DestroySession.
+	//
+	// DESTROY_SESSION is session-exempt: it may be sent standalone (without a
+	// preceding SEQUENCE) so an owner can tear down a session over a different
+	// connection. The server MUST still confirm the requester owns the target
+	// session, otherwise an anonymous caller could destroy a victim's session.
+	targetSess := d.StateManager.GetSession(args.SessionID)
+	if targetSess != nil {
+		requestingClientID, identified := resolveRequestingClientID(d, v41ctx, ctx)
+		if !identified {
+			// The caller has no resolvable association with any session/client
+			// (no SEQUENCE, the connection is not bound to a session, and no
+			// v4.0 client state). Refuse rather than fall through to destroy.
+			logger.Debug("DESTROY_SESSION: requester identity unknown -- refusing destroy",
+				"target_session", args.SessionID.String(),
+				"target_client_id", fmt.Sprintf("0x%016x", targetSess.ClientID),
+				"connection_id", ctx.ConnectionID,
+				"client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_OP_NOT_IN_SESSION,
+				OpCode: types.OP_DESTROY_SESSION,
+				Data:   EncodeStatusOnly(types.NFS4ERR_OP_NOT_IN_SESSION),
+			}
+		}
+		if requestingClientID != targetSess.ClientID {
+			logger.Debug("DESTROY_SESSION: ownership mismatch -- not same client",
+				"target_session", args.SessionID.String(),
+				"target_client_id", fmt.Sprintf("0x%016x", targetSess.ClientID),
+				"requesting_client_id", fmt.Sprintf("0x%016x", requestingClientID),
+				"client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_NOT_SAME,
+				OpCode: types.OP_DESTROY_SESSION,
+				Data:   EncodeStatusOnly(types.NFS4ERR_NOT_SAME),
+			}
 		}
 	}
 
@@ -61,4 +101,42 @@ func HandleDestroySession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reque
 		OpCode: types.OP_DESTROY_SESSION,
 		Data:   buf.Bytes(),
 	}
+}
+
+// resolveRequestingClientID returns the client ID of the entity that sent this
+// DESTROY_SESSION and whether that identity could be established at all, using
+// the most authoritative source available (RFC 8881 Section 18.37.3):
+//
+//  1. v41ctx != nil: a preceding SEQUENCE identified the requesting session, so
+//     the requester is that session's owning client.
+//  2. The connection this request arrived on is bound to a session (the common
+//     standalone case: an owner destroys a session over a connection that is
+//     itself bound to one of its sessions). The requester is the client that
+//     owns the bound session.
+//  3. ctx.ClientState != nil: the v4.0 connection layer set a client ID.
+//
+// The second return value is false when none of the above can associate the
+// caller with a client. In that case the caller is anonymous with respect to
+// session state and MUST NOT be allowed to destroy an existing session.
+func resolveRequestingClientID(d *Deps, v41ctx *types.V41RequestContext, ctx *types.CompoundContext) (uint64, bool) {
+	if v41ctx != nil {
+		if reqSess := d.StateManager.GetSession(v41ctx.SessionID); reqSess != nil {
+			return reqSess.ClientID, true
+		}
+		return 0, false
+	}
+	// Standalone DESTROY_SESSION (no SEQUENCE): authorize via the connection
+	// the request arrived on. If that connection is bound to a session, the
+	// owner of that session is the requester.
+	if ctx.ConnectionID != 0 {
+		if binding := d.StateManager.GetConnectionBinding(ctx.ConnectionID); binding != nil {
+			if boundSess := d.StateManager.GetSession(binding.SessionID); boundSess != nil {
+				return boundSess.ClientID, true
+			}
+		}
+	}
+	if ctx.ClientState != nil {
+		return ctx.ClientState.ClientID, true
+	}
+	return 0, false
 }

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -335,7 +335,20 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 
 	case v4types.NFSPROC4_COMPOUND:
 		// Extract CompoundContext with auth credentials
-		compCtx := v4handlers.ExtractV4HandlerContext(ctx, call, clientAddr)
+		compCtx, authStatus := v4handlers.ExtractV4HandlerContext(ctx, call, clientAddr)
+		if authStatus != v4types.NFS4_OK {
+			// GSS auth flavor claimed but no verified identity — abort before
+			// decoding any ops. We cannot echo the COMPOUND tag here because the
+			// request body has not been decoded; RFC 7530 §15.1 permits replying
+			// with NFS4ERR_WRONGSEC, an empty tag, and zero results.
+			logger.Warn("NFSv4 COMPOUND rejected: unauthenticated GSS flavor",
+				"status", authStatus, "client", clientAddr)
+			reply, encErr := v4handlers.EncodeAbortCompound(authStatus)
+			if encErr != nil {
+				return nil, fmt.Errorf("encode GSS auth error reply: %w", encErr)
+			}
+			return reply, nil
+		}
 		compCtx.ConnectionID = c.connectionID
 
 		result, err := c.server.v4Handler.ProcessCompound(compCtx, data)


### PR DESCRIPTION
Remediates the NFSv4.0/4.1 audit findings (#1077, Part of #1075). 12 atomic, signed commits; build/vet/gofmt + full NFS test suite + `-race` on the state package all green; independently reviewed.

## HIGH
- **fix(nfs/v4): reject RPCSEC_GSS COMPOUND with no verified identity** — a COMPOUND claiming `AUTH_RPCSEC_GSS` but carrying no verified GSS identity was silently given an anonymous (nil-UID) context and allowed to proceed; now returns `NFS4ERR_WRONGSEC`.
- **fix(nfs/v4): block SSRF + verifier-length overflow in callback path** — client-supplied callback uaddr (SETCLIENTID) was dialed without host validation (loopback/link-local/169.254 metadata SSRF); added `validateCallbackHost`. Also fixed a `uint32` wraparound in `ValidateCBReply` verifier-length skip that let a malicious callback server bypass the RPC `acceptStat` check.
- **fix(nfs/v4.1): enforce session ownership in DESTROY_SESSION** — an anonymous standalone `DESTROY_SESSION(victim)` (no SEQUENCE) bypassed the ownership check and destroyed any session; now authorizes via the connection→session binding and rejects unidentified cross-session destroys (`NFS4ERR_OP_NOT_IN_SESSION`), while still permitting the RFC 8881 §18.37 session-exempt owner case. (Replaced a fabricated test that asserted the vulnerable behavior.)
- **fix(nfs/v4): delegation concurrency + recall lifecycle** — `ReturnDelegation`/`RevokeDelegation` mid-function `sm.mu` drop race; `CheckDelegationConflict` recalled only the first of multiple holders (others spun on `NFS4ERR_DELAY` forever) — now recalls all conflicting delegations with a retry-dedup guard (no duplicate recall goroutines); map-write-under-RLock race; `sendRecallV41` goroutine leak on session destroy.
- **fix(nfs/v4): recall conflicting delegation on OPEN4_CREATE+UNCHECKED4 of existing file** — the existing-file open sub-path had lost its delegation-conflict check.
- **fix(nfs/v4): harden state manager** — LockNew bad-seqid orphaned lock state; `reapExpiredSessions` backchannel-sender goroutine leak; CLID_INUSE principal-mismatch guard; CB_NULL stale-record update; LOCK4denied owner decoding.
- **fix(nfs/v4): ref-count lock-owner on FREE_STATEID**
- **fix(nfs/v4): consume CREATE args on unknown objtype** — prevents XDR stream desync.
- **fix(nfs/v4.1): dedicated CB_SEQUENCE seqID counter on backchannel** — seqIDs were skipping by 2 (shared with RPC XID) → client `NFS4ERR_SEQ_MISORDERED` killed the session.

## MED
- **fix(nfs/v4.1): reject BACKCHANNEL_CTL outside a session**
- **fix(nfs/v4): atomic leaseTime/identityMapper in attrs encode**
- **fix(nfs/v4): return NFS4ERR_BAD_COOKIE on READDIR cookieverf mismatch** (RFC 7530 §16.24.5)

Each fix lands with a test exercising the fixed path (fail-before/pass-after). Note: during finalization, two workflow-excluded batches were completed (OPEN existing-file delegation check; DESTROY_SESSION ownership — the latter's auto-generated test had codified the vulnerability and was replaced), and two were salvaged (state-manager test repair; READDIR comment).

Report: `.planning/v1.0-audit/report-nfsv4-1077.md`

Fixes #1077
Part of #1075
