### PR TITLE
fix(nfs/v3): remediate v1.0 audit NFSv3 + NLM/NSM/RPC findings (#1078)

### DIFF
--- a/internal/adapter/nfs/nsm/callback/client.go
+++ b/internal/adapter/nfs/nsm/callback/client.go
@@ -34,6 +34,30 @@ const (
 	rpcVersion = 2
 )
 
+// allowNSMLoopbackCallback permits dialling loopback addresses from the NSM
+// callback client. False in production; set true only by tests that bind a
+// listener on 127.0.0.1.
+var allowNSMLoopbackCallback = false
+
+// validateNSMCallbackHost rejects callback addresses that must not be dialled:
+// loopback (127.x, ::1) and link-local unicast (169.254.0.0/16, fe80::/10).
+// host must be an IP literal; hostnames are rejected (NSM callbacks are
+// internal and should never require DNS resolution). This mirrors the v4
+// callback SSRF guard in v4/state/callback.go.
+func validateNSMCallbackHost(host string) error {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("NSM callback host %q is not a valid IP literal", host)
+	}
+	if ip.IsLoopback() && !allowNSMLoopbackCallback {
+		return fmt.Errorf("NSM callback host %q is a loopback address", host)
+	}
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("NSM callback host %q is a link-local address", host)
+	}
+	return nil
+}
+
 // Client sends SM_NOTIFY callbacks to registered monitors.
 //
 // Client is stateless and thread-safe. Each callback creates a fresh TCP
@@ -90,6 +114,9 @@ func (c *Client) Send(
 		// No port specified, use default
 		host = addr
 		port = fmt.Sprintf("%d", DefaultNSMPort)
+	}
+	if err := validateNSMCallbackHost(host); err != nil {
+		return fmt.Errorf("callback address rejected: %w", err)
 	}
 	addr = net.JoinHostPort(host, port)
 

--- a/internal/adapter/nfs/nsm/callback/client_test.go
+++ b/internal/adapter/nfs/nsm/callback/client_test.go
@@ -1,0 +1,51 @@
+package callback
+
+import "testing"
+
+// TestValidateNSMCallbackHost verifies the dial-time SSRF guard: only IP
+// literals that are neither loopback nor link-local may be dialled. The cloud
+// IMDS address 169.254.169.254 falls under link-local and must be rejected.
+func TestValidateNSMCallbackHost(t *testing.T) {
+	cases := []struct {
+		host    string
+		wantErr bool
+		desc    string
+	}{
+		{"10.0.0.1", false, "RFC-1918 private — allowed"},
+		{"192.168.1.100", false, "RFC-1918 private — allowed"},
+		{"203.0.113.5", false, "public IP — allowed"},
+		{"::1", true, "IPv6 loopback — rejected"},
+		{"127.0.0.1", true, "loopback — rejected"},
+		{"127.1.2.3", true, "loopback subnet — rejected"},
+		{"169.254.169.254", true, "cloud IMDS — rejected (link-local)"},
+		{"169.254.0.1", true, "link-local — rejected"},
+		{"fe80::1", true, "IPv6 link-local — rejected"},
+		{"hostname.local", true, "hostname (not IP literal) — rejected"},
+		{"", true, "empty — rejected"},
+	}
+	for _, tc := range cases {
+		err := validateNSMCallbackHost(tc.host)
+		if tc.wantErr && err == nil {
+			t.Errorf("[%s] host=%q: expected error, got nil", tc.desc, tc.host)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("[%s] host=%q: unexpected error: %v", tc.desc, tc.host, err)
+		}
+	}
+}
+
+// TestValidateNSMCallbackHost_LoopbackEscapeHatch verifies the test-only
+// override permits loopback so tests can bind a listener on 127.0.0.1.
+func TestValidateNSMCallbackHost_LoopbackEscapeHatch(t *testing.T) {
+	prev := allowNSMLoopbackCallback
+	allowNSMLoopbackCallback = true
+	defer func() { allowNSMLoopbackCallback = prev }()
+
+	if err := validateNSMCallbackHost("127.0.0.1"); err != nil {
+		t.Errorf("loopback should be allowed when allowNSMLoopbackCallback=true: %v", err)
+	}
+	// Link-local must still be rejected even with the loopback escape hatch.
+	if err := validateNSMCallbackHost("169.254.169.254"); err == nil {
+		t.Error("link-local must remain rejected regardless of loopback override")
+	}
+}

--- a/internal/adapter/nfs/nsm/handlers/handler.go
+++ b/internal/adapter/nfs/nsm/handlers/handler.go
@@ -200,18 +200,30 @@ func (h *Handler) GetServerName() string {
 
 // admitPeerState enforces SM_NOTIFY state-number monotonicity for a monitored
 // host (H17). It returns true and records incoming as the new last-seen state
-// only when incoming strictly exceeds the previously stored state for monName.
-// An equal-or-lower state is a replay/stale notification and returns false
-// without mutating stored state.
+// only when incoming is a forward advance over the previously stored state for
+// monName, using RFC 1982 serial-number arithmetic (the state is conceptually a
+// uint32 that wraps). A replay (equal) or retrograde state returns false without
+// mutating stored state.
 //
-// The first NOTIFY ever seen for a monName is admitted (any positive state is
-// greater than the zero-value default), then recorded.
+// The first NOTIFY ever seen for a monName is admitted (its difference from the
+// zero-value default is a small positive forward advance), then recorded.
 func (h *Handler) admitPeerState(monName string, incoming int32) bool {
 	h.peerStateMu.Lock()
 	defer h.peerStateMu.Unlock()
 
-	if incoming <= h.peerState[monName] {
-		return false
+	// Serial-number arithmetic per RFC 1982: NSM state numbers are conceptually
+	// uint32 and increment monotonically, so they wrap from MaxInt32 to MinInt32
+	// without going backwards. Admit if (incoming - stored) mod 2^32 is in
+	// (0, 2^31): the values differ AND the high bit of the wrapped difference is
+	// clear ("went forwards"). A signed comparison would wrongly reject a
+	// legitimate reboot once the counter wraps past math.MaxInt32.
+	stored := h.peerState[monName]
+	if incoming == stored {
+		return false // exact replay
+	}
+	diff := uint32(incoming) - uint32(stored)
+	if diff >= 0x80000000 {
+		return false // stale / retrograde (high bit set means "went backwards")
 	}
 	h.peerState[monName] = incoming
 	return true

--- a/internal/adapter/nfs/nsm/handlers/mon.go
+++ b/internal/adapter/nfs/nsm/handlers/mon.go
@@ -2,13 +2,33 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"net"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// validateCallbackName enforces that the SM_MON my_name callback address is a
+// safe IP literal. NSM callback addresses must be IP literals (no DNS names),
+// must not be loopback, and must not be link-local (which covers the cloud
+// instance metadata address 169.254.169.254). Violations return STAT_FAIL.
+func validateCallbackName(name string) error {
+	ip := net.ParseIP(name)
+	if ip == nil {
+		return fmt.Errorf("callback my_name %q is not an IP literal", name)
+	}
+	if ip.IsLoopback() {
+		return fmt.Errorf("callback my_name %q is a loopback address", name)
+	}
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("callback my_name %q is a link-local address", name)
+	}
+	return nil
+}
 
 // Mon handles NSM MON (RFC 1813, SM procedure 2).
 // Registers caller for SM_NOTIFY callbacks when a monitored host's state changes.
@@ -35,6 +55,16 @@ func (h *Handler) Mon(ctx *NSMHandlerContext, data []byte) (*HandlerResult, erro
 		"callback_prog", mon.MonID.MyID.MyProg,
 		"callback_vers", mon.MonID.MyID.MyVers,
 		"callback_proc", mon.MonID.MyID.MyProc)
+
+	// Reject unsafe callback addresses (SSRF guard): the my_name is fully
+	// client-controlled and is later dialled verbatim by the callback client.
+	if err := validateCallbackName(mon.MonID.MyID.MyName); err != nil {
+		logger.Warn("NSM MON rejected: unsafe callback address",
+			"client", ctx.ClientAddr,
+			"callback_host", mon.MonID.MyID.MyName,
+			"error", err)
+		return encodeStatFailure(state)
+	}
 
 	// Generate client ID from client address and callback info
 	// This ensures uniqueness per client/callback combination

--- a/internal/adapter/nfs/nsm/handlers/mon_test.go
+++ b/internal/adapter/nfs/nsm/handlers/mon_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
+)
+
+// TestValidateCallbackName exercises the SM_MON callback-address SSRF guard
+// directly: only safe IP literals are accepted; loopback, link-local (including
+// the cloud IMDS address 169.254.169.254), and non-IP hostnames are rejected.
+func TestValidateCallbackName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+		desc    string
+	}{
+		{"10.0.0.1", false, "RFC-1918 private — allowed"},
+		{"192.168.1.100", false, "RFC-1918 private — allowed"},
+		{"203.0.113.5", false, "public IP — allowed"},
+		{"::1", true, "IPv6 loopback — rejected"},
+		{"127.0.0.1", true, "loopback — rejected"},
+		{"127.1.2.3", true, "loopback subnet — rejected"},
+		{"169.254.169.254", true, "cloud IMDS — rejected (link-local)"},
+		{"169.254.0.1", true, "link-local — rejected"},
+		{"fe80::1", true, "IPv6 link-local — rejected"},
+		{"hostname.local", true, "hostname (not IP literal) — rejected"},
+		{"", true, "empty — rejected"},
+	}
+	for _, tc := range cases {
+		err := validateCallbackName(tc.name)
+		if tc.wantErr && err == nil {
+			t.Errorf("[%s] name=%q: expected error, got nil", tc.desc, tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("[%s] name=%q: unexpected error: %v", tc.desc, tc.name, err)
+		}
+	}
+}
+
+// TestMon_CallbackNameSSRF_Rejected verifies the SM_MON handler rejects unsafe
+// callback addresses with STAT_FAIL (no Go error) and accepts safe IP literals.
+func TestMon_CallbackNameSSRF_Rejected(t *testing.T) {
+	cases := []struct {
+		name         string
+		callbackHost string
+		wantFail     bool
+	}{
+		{"loopback rejected", "127.0.0.1", true},
+		{"link-local IMDS", "169.254.169.254", true},
+		{"IPv6 loopback", "::1", true},
+		{"fe80 link-local", "fe80::1", true},
+		{"hostname rejected", "callback.example", true},
+		{"valid IP accepted", "10.0.0.5", false},
+		{"valid public IP", "203.0.113.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, &fakeDispatcher{})
+			mon := &types.Mon{
+				MonID: types.MonID{
+					MonName: "peer.example",
+					MyID: types.MyID{
+						MyName: tc.callbackHost,
+						MyProg: 100021, MyVers: 4, MyProc: 23,
+					},
+				},
+			}
+			data := encodeMon(t, mon)
+			ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.1:600"}
+			result, err := h.Mon(ctx, data)
+			if err != nil {
+				t.Fatalf("Mon must not return a Go error: %v", err)
+			}
+			gotFail := result.NSMStatus == types.StatFail
+			if tc.wantFail && !gotFail {
+				t.Errorf("callback host %q should have been rejected (STAT_FAIL), got STAT_SUCC", tc.callbackHost)
+			}
+			if !tc.wantFail && gotFail {
+				t.Errorf("callback host %q should have been accepted (STAT_SUCC), got STAT_FAIL", tc.callbackHost)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/nsm/handlers/notify_test.go
+++ b/internal/adapter/nfs/nsm/handlers/notify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"testing"
 
@@ -163,7 +164,7 @@ func TestNotify_UnmonitoredHost_Ignored(t *testing.T) {
 func TestNotify_SourceAddrMismatch_Rejected(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
 	// We monitor peer.example as seen from 10.0.0.5.
-	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+	monitor(t, h, "10.0.0.5:601", "peer.example", "203.0.113.5")
 
 	// NOTIFY for peer.example arrives from a DIFFERENT source IP.
 	notify(t, h, "10.0.0.66:55000", "peer.example", 5)
@@ -175,7 +176,7 @@ func TestNotify_SourceAddrMismatch_Rejected(t *testing.T) {
 
 func TestNotify_MonitoredHostRightAddr_Accepted(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
-	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+	monitor(t, h, "10.0.0.5:601", "peer.example", "203.0.113.5")
 
 	// Legitimate NOTIFY: monitored mon_name, matching source IP (ephemeral
 	// NOTIFY port differs from the SM_MON port — only the IP must match).
@@ -193,7 +194,7 @@ func TestNotify_MonitoredHostRightAddr_Accepted(t *testing.T) {
 // isMonitoredFromSource focused unit coverage.
 func TestIsMonitoredFromSource(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
-	monitor(t, h, "192.168.1.10:700", "host-a", "host-a")
+	monitor(t, h, "192.168.1.10:700", "host-a", "203.0.113.6")
 
 	if !h.isMonitoredFromSource("host-a", "192.168.1.10:40000") {
 		t.Error("monitored host + matching IP should pass")
@@ -215,7 +216,7 @@ func TestIsMonitoredFromSource(t *testing.T) {
 
 func TestNotify_Monotonicity_OnlyHigherActs(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
-	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+	monitor(t, h, "10.0.0.5:601", "peer.example", "203.0.113.5")
 
 	// First NOTIFY at state 5 -> accepted, recorded.
 	notify(t, h, "10.0.0.5:40001", "peer.example", 5)
@@ -263,12 +264,73 @@ func TestAdmitPeerState(t *testing.T) {
 	}
 }
 
+// TestAdmitPeerState_Wraparound exercises RFC 1982 serial-number arithmetic.
+// A state counter wrapping past MaxInt32 must be admitted (it is a legitimate
+// forward advance), not rejected by the old signed-int32 comparison.
+func TestAdmitPeerState_Wraparound(t *testing.T) {
+	h := newTestHandler(t, &fakeDispatcher{})
+
+	// Seed the stored state at math.MaxInt32 (0x7FFFFFFF).
+	maxI32 := int32(math.MaxInt32)
+	h.peerStateMu.Lock()
+	h.peerState["wrap"] = maxI32
+	h.peerStateMu.Unlock()
+
+	// The next legitimate state is MaxInt32 + 1 = MinInt32 (0x80000000 as uint32).
+	// Signed comparison: MinInt32 < MaxInt32 → old code wrongly rejects.
+	// RFC 1982: diff = uint32(MinInt32) - uint32(MaxInt32) = 1 → admitted.
+	// Compute via uint32 wrap to avoid an int32 constant-overflow at compile time.
+	next := int32(uint32(maxI32) + 1) // = math.MinInt32
+	if !h.admitPeerState("wrap", next) {
+		t.Fatal("state wrap MaxInt32 → MinInt32 must be admitted (RFC 1982); old signed comparison would reject it")
+	}
+	if got, _ := recordedState(h, "wrap"); got != next {
+		t.Fatalf("stored state after wrap: want %d, got %d", next, got)
+	}
+
+	// A state that is 2^31 ahead or more (half the uint32 space) is "backwards":
+	// diff = uint32(MaxInt32) - uint32(MinInt32) = 0xFFFFFFFF → high bit set → stale.
+	if h.admitPeerState("wrap", maxI32) {
+		t.Fatal("MaxInt32 after MinInt32 is retrograde; must be rejected")
+	}
+
+	// Exact replay of next must be rejected.
+	if h.admitPeerState("wrap", next) {
+		t.Fatal("exact replay must be rejected")
+	}
+}
+
+// TestAdmitPeerState_Wraparound_NegativeStored covers the scenario where the
+// stored value is already negative (i.e. we are past the wrap point) and a
+// further legitimate increment arrives.
+func TestAdmitPeerState_Wraparound_NegativeStored(t *testing.T) {
+	h := newTestHandler(t, &fakeDispatcher{})
+
+	// Stored = MinInt32 + 1 (one past the wrap point).
+	stored := int32(math.MinInt32 + 1)
+	h.peerStateMu.Lock()
+	h.peerState["neg"] = stored
+	h.peerStateMu.Unlock()
+
+	// Next = MinInt32 + 2: RFC 1982 diff = 1 → admitted.
+	next := stored + 1
+	if !h.admitPeerState("neg", next) {
+		t.Fatalf("state advance from %d to %d must be admitted", stored, next)
+	}
+
+	// Previous = MinInt32: RFC 1982 diff = 0xFFFFFFFF → stale → rejected.
+	prev := int32(math.MinInt32)
+	if h.admitPeerState("neg", prev) {
+		t.Fatalf("retrograde state %d after %d must be rejected", prev, stored)
+	}
+}
+
 // Replay that passes H16 but fails H17 must remain a no-op (defence in depth):
 // the monotonicity gate sits AFTER the address gate, so a monitored host
 // replaying an old state still does nothing.
 func TestNotify_MonitoredReplay_NoOp(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
-	monitor(t, h, "10.0.0.5:601", "peer.example", "peer.example")
+	monitor(t, h, "10.0.0.5:601", "peer.example", "203.0.113.5")
 
 	notify(t, h, "10.0.0.5:40001", "peer.example", 9)
 	notify(t, h, "10.0.0.5:40002", "peer.example", 9) // duplicate
@@ -313,11 +375,16 @@ func TestNotify_DispatchesToAllMonitors(t *testing.T) {
 
 	privA := [16]byte{1, 2, 3}
 	privB := [16]byte{9, 9, 9}
+	// Callback hosts must be valid (non-loopback, non-link-local) IP literals
+	// per the SSRF guard.
+	const clientA = "203.0.113.10"
+	const clientB = "203.0.113.11"
+	const clientC = "203.0.113.12"
 	// Two distinct local clients both monitor peer.example from the same host.
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", privA)
-	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", "client-b", privB)
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", clientA, privA)
+	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", clientB, privB)
 	// A third client monitors a different host — must NOT be notified.
-	monitorWithCallback(t, h, "10.0.0.5:603", "other.example", "client-c", [16]byte{7})
+	monitorWithCallback(t, h, "10.0.0.5:603", "other.example", clientC, [16]byte{7})
 
 	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
 
@@ -339,13 +406,13 @@ func TestNotify_DispatchesToAllMonitors(t *testing.T) {
 			t.Errorf("callback to %s: prog/vers/proc = %d/%d/%d, want 100021/4/23", c.addr, c.prog, c.vers, c.proc)
 		}
 	}
-	if _, ok := byAddr["client-c"]; ok {
+	if _, ok := byAddr[clientC]; ok {
 		t.Fatal("client-c monitors a different host and must not receive a callback")
 	}
-	if got := byAddr["client-a"].status.Priv; got != privA {
+	if got := byAddr[clientA].status.Priv; got != privA {
 		t.Errorf("client-a priv = %v, want %v", got, privA)
 	}
-	if got := byAddr["client-b"].status.Priv; got != privB {
+	if got := byAddr[clientB].status.Priv; got != privB {
 		t.Errorf("client-b priv = %v, want %v", got, privB)
 	}
 }
@@ -354,7 +421,7 @@ func TestNotify_DispatchesToAllMonitors(t *testing.T) {
 func TestNotify_GateH16Fail_NoDispatch(t *testing.T) {
 	fd := &fakeDispatcher{}
 	h := newTestHandler(t, fd)
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "203.0.113.10", [16]byte{})
 
 	// Wrong source IP -> H16 fails.
 	notify(t, h, "10.0.0.66:55000", "peer.example", 5)
@@ -369,7 +436,7 @@ func TestNotify_GateH16Fail_NoDispatch(t *testing.T) {
 func TestNotify_GateH17Fail_NoDispatch(t *testing.T) {
 	fd := &fakeDispatcher{}
 	h := newTestHandler(t, fd)
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "203.0.113.10", [16]byte{})
 
 	notify(t, h, "10.0.0.5:40001", "peer.example", 5) // admitted -> 1 callback
 	notify(t, h, "10.0.0.5:40002", "peer.example", 5) // replay -> no callback
@@ -382,10 +449,10 @@ func TestNotify_GateH17Fail_NoDispatch(t *testing.T) {
 
 // A failing callback is accounted for but does not abort the remaining ones.
 func TestNotify_CallbackFailure_DoesNotAbortOthers(t *testing.T) {
-	fd := &fakeDispatcher{failAddrs: map[string]error{"client-a": errors.New("dial timeout")}}
+	fd := &fakeDispatcher{failAddrs: map[string]error{"203.0.113.10": errors.New("dial timeout")}}
 	h := newTestHandler(t, fd)
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
-	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", "client-b", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "203.0.113.10", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", "203.0.113.11", [16]byte{})
 
 	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
 
@@ -404,7 +471,7 @@ func TestNotify_CallbackFailure_DoesNotAbortOthers(t *testing.T) {
 func TestNotify_NilDispatcher_NoOpButGatesRun(t *testing.T) {
 	h := newTestHandler(t, &fakeDispatcher{})
 	h.dispatcher = nil // explicitly disable the relay (same-package access)
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "client-a", [16]byte{})
+	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", "203.0.113.10", [16]byte{})
 
 	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
 

--- a/internal/adapter/nfs/rpc/gss/context.go
+++ b/internal/adapter/nfs/rpc/gss/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -165,6 +166,8 @@ type ContextStore struct {
 	contextTTL    time.Duration
 	cleanupTicker *time.Ticker
 	stopCh        chan struct{}
+	stopOnce      sync.Once
+	count         atomic.Int64
 }
 
 // cleanupInterval is the time between TTL cleanup sweeps.
@@ -206,12 +209,23 @@ func NewContextStore(maxContexts int, contextTTL time.Duration) *ContextStore {
 //   - ctx: The context to store (must have a non-nil Handle)
 func (cs *ContextStore) Store(ctx *GSSContext) {
 	if cs.maxContexts > 0 {
-		count := cs.Count()
-		if count >= cs.maxContexts {
+		// Atomically claim a slot. If over capacity, evict first.
+		// Loop until the slot is secured so concurrent INITs cannot both bypass the cap.
+		for {
+			n := cs.count.Load()
+			if n < int64(cs.maxContexts) {
+				// Try to claim the slot with a CAS; retry if another goroutine won the race.
+				if cs.count.CompareAndSwap(n, n+1) {
+					break
+				}
+				continue
+			}
+			// At or over cap: evict oldest (which decrements count) then retry claiming.
 			cs.evictOldest()
 		}
+	} else {
+		cs.count.Add(1)
 	}
-
 	cs.contexts.Store(string(ctx.Handle), ctx)
 }
 
@@ -245,20 +259,17 @@ func (cs *ContextStore) Lookup(handle []byte) (*GSSContext, bool) {
 // Parameters:
 //   - handle: The context handle to remove
 func (cs *ContextStore) Delete(handle []byte) {
-	cs.contexts.Delete(string(handle))
+	_, loaded := cs.contexts.LoadAndDelete(string(handle))
+	if loaded {
+		cs.count.Add(-1)
+	}
 }
 
 // Count returns the number of active contexts in the store.
 //
-// This iterates the sync.Map, so it is O(n). Use for metrics and
-// capacity checks, not in hot paths.
+// This is an O(1) atomic read of the maintained counter.
 func (cs *ContextStore) Count() int {
-	count := 0
-	cs.contexts.Range(func(_, _ interface{}) bool {
-		count++
-		return true
-	})
-	return count
+	return int(cs.count.Load())
 }
 
 // Stop stops the background cleanup goroutine and ticker.
@@ -266,8 +277,10 @@ func (cs *ContextStore) Count() int {
 // Must be called when the GSS processor is shut down to prevent
 // goroutine leaks.
 func (cs *ContextStore) Stop() {
-	close(cs.stopCh)
-	cs.cleanupTicker.Stop()
+	cs.stopOnce.Do(func() {
+		close(cs.stopCh)
+		cs.cleanupTicker.Stop()
+	})
 }
 
 // cleanupLoop runs the periodic TTL cleanup.
@@ -294,7 +307,7 @@ func (cs *ContextStore) cleanup() {
 				"realm", ctx.Realm,
 				"idle", now.Sub(lastUsed).String(),
 			)
-			cs.contexts.Delete(key)
+			cs.Delete([]byte(key.(string)))
 		}
 		return true
 	})
@@ -325,6 +338,6 @@ func (cs *ContextStore) evictOldest() {
 				"realm", ctx.Realm,
 			)
 		}
-		cs.contexts.Delete(oldestKey)
+		cs.Delete([]byte(oldestKey.(string)))
 	}
 }

--- a/internal/adapter/nfs/rpc/gss/context_test.go
+++ b/internal/adapter/nfs/rpc/gss/context_test.go
@@ -178,6 +178,28 @@ func TestContextMaxContextsEviction(t *testing.T) {
 	}
 }
 
+func TestContextMaxContextsRaceNoBurst(t *testing.T) {
+	const maxCtx = 5
+	store := NewContextStore(maxCtx, time.Minute)
+	defer store.Stop()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			store.Store(newTestContext("race", "EXAMPLE.COM"))
+		}()
+	}
+	wg.Wait()
+
+	got := store.Count()
+	if got > maxCtx {
+		t.Fatalf("maxContexts=%d exceeded under concurrency: got %d contexts", maxCtx, got)
+	}
+}
+
 func TestContextConcurrentAccess(t *testing.T) {
 	store := NewContextStore(1000, 10*time.Minute)
 	defer store.Stop()
@@ -309,4 +331,17 @@ func TestContextUnlimitedMaxContexts(t *testing.T) {
 	if store.Count() != 100 {
 		t.Fatalf("expected 100 contexts with unlimited max, got %d", store.Count())
 	}
+}
+
+func TestContextStoreStopIdempotent(t *testing.T) {
+	// Before the fix, the second Stop() panics with "close of closed channel".
+	store := NewContextStore(10, time.Minute)
+	store.Stop()
+	// Must not panic:
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop() panicked on second call: %v", r)
+		}
+	}()
+	store.Stop()
 }

--- a/internal/adapter/nfs/rpc/gss/context_test.go
+++ b/internal/adapter/nfs/rpc/gss/context_test.go
@@ -92,6 +92,49 @@ func TestContextDeleteNonexistent(t *testing.T) {
 	store.Delete([]byte("does-not-exist"))
 }
 
+// Deleting a handle that is not present must not decrement the maintained
+// counter; otherwise the cap accounting drifts and the store would silently
+// accept contexts beyond maxContexts.
+func TestContextDeleteNonexistentDoesNotDecrementCount(t *testing.T) {
+	store := NewContextStore(100, 10*time.Minute)
+	defer store.Stop()
+
+	ctx := newTestContext("alice", "EXAMPLE.COM")
+	store.Store(ctx)
+	if store.Count() != 1 {
+		t.Fatalf("expected 1 context after store, got %d", store.Count())
+	}
+
+	store.Delete([]byte("never-stored"))
+	if store.Count() != 1 {
+		t.Fatalf("delete of absent handle changed count: want 1, got %d", store.Count())
+	}
+}
+
+// Deleting the same handle twice must decrement the counter exactly once. A
+// double-decrement would push Count negative and corrupt the capacity check in
+// Store, letting the store grow without bound.
+func TestContextDoubleDeleteDecrementsOnce(t *testing.T) {
+	store := NewContextStore(2, 10*time.Minute)
+	defer store.Stop()
+
+	ctx := newTestContext("bob", "EXAMPLE.COM")
+	store.Store(ctx)
+
+	store.Delete(ctx.Handle)
+	store.Delete(ctx.Handle) // second delete is a no-op for the counter
+	if store.Count() != 0 {
+		t.Fatalf("double delete drove count off zero: got %d", store.Count())
+	}
+
+	// The cap must still admit exactly maxContexts contexts after the no-op delete.
+	store.Store(newTestContext("c1", "EXAMPLE.COM"))
+	store.Store(newTestContext("c2", "EXAMPLE.COM"))
+	if store.Count() != 2 {
+		t.Fatalf("expected count to cap at 2, got %d", store.Count())
+	}
+}
+
 func TestContextTTLCleanup(t *testing.T) {
 	// Use a very short TTL so we can test cleanup
 	store := NewContextStore(100, 10*time.Millisecond)

--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -410,7 +410,7 @@ func (p *GSSProcessor) Process(ctx context.Context, credBody []byte, verifBody [
 	case RPCGSSData:
 		return p.handleData(ctx, cred, verifBody, headerPreimage, requestBody)
 	case RPCGSSDestroy:
-		return p.handleDestroy(cred)
+		return p.handleDestroy(cred, verifBody, headerPreimage)
 	default:
 		return &GSSProcessResult{
 			Err: fmt.Errorf("unknown RPCSEC_GSS procedure: %d", cred.GSSProc),
@@ -848,11 +848,34 @@ func (p *GSSProcessor) resolveIdentity(ctx context.Context, principal, realm str
 // 1. Look up context by handle
 // 2. Delete context from store (if found)
 // 3. Return empty reply with IsControl=true
-func (p *GSSProcessor) handleDestroy(cred *RPCGSSCredV1) *GSSProcessResult {
+func (p *GSSProcessor) handleDestroy(cred *RPCGSSCredV1, verifBody []byte, headerPreimage []byte) *GSSProcessResult {
 	// Lookup context (may not exist if already expired)
-	_, found := p.contexts.Lookup(cred.Handle)
+	gssCtx, found := p.contexts.Lookup(cred.Handle)
 	if !found {
 		logger.Debug("GSS DESTROY for unknown context (may have expired)")
+	}
+
+	// Verify call-header MIC on DESTROY, same as for DATA (RFC 2203 Section 5.3.3.2).
+	// An unauthenticated DESTROY lets any peer that learns a 16-byte context handle
+	// tear down the security context without possessing the session key.
+	if found {
+		if err := verifyHeaderMIC(gssCtx.SessionKey, headerPreimage, verifBody); err != nil {
+			logger.Debug("GSS DESTROY: call-header MIC verification failed",
+				"principal", gssCtx.Principal,
+				"error", err,
+			)
+			return &GSSProcessResult{
+				Err:      fmt.Errorf("RPCSEC_GSS_CREDPROBLEM: DESTROY MIC verification failed: %w", err),
+				AuthStat: AuthStatCredProblem,
+			}
+		}
+		if !gssCtx.SeqWindow.Accept(cred.SeqNum) {
+			logger.Debug("GSS DESTROY: sequence number rejected (duplicate or out of window)",
+				"seq_num", cred.SeqNum,
+				"principal", gssCtx.Principal,
+			)
+			return &GSSProcessResult{SilentDiscard: true}
+		}
 	}
 
 	// Delete the context

--- a/internal/adapter/nfs/rpc/gss/framework_test.go
+++ b/internal/adapter/nfs/rpc/gss/framework_test.go
@@ -300,9 +300,10 @@ func TestProcessDESTROYRemovesContext(t *testing.T) {
 	// Find the context handle
 	handle := extractContextHandle(t, proc)
 
-	// Send DESTROY
+	// Send DESTROY with a valid call-header MIC (required after the MIC-verification fix).
 	destroyCredBody := buildDESTROYCredBody(t, handle, 1)
-	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil, nil)
+	destroyMIC := signHeaderMIC(t, mockVerifierSessionKey, destroyCredBody)
+	destroyResult := proc.Process(context.Background(), destroyCredBody, destroyMIC, destroyCredBody, nil)
 
 	if destroyResult.Err != nil {
 		t.Fatalf("DESTROY failed: %v", destroyResult.Err)
@@ -336,6 +337,68 @@ func TestProcessDESTROYUnknownContext(t *testing.T) {
 	if !result.IsControl {
 		t.Fatal("expected IsControl=true for DESTROY")
 	}
+}
+
+func TestProcessDESTROYRequiresMIC(t *testing.T) {
+	verifier := newMockVerifier("alice", "EXAMPLE.COM")
+	proc := NewGSSProcessor(verifier, newTestMapper(), 100, 10*time.Minute)
+	defer proc.Stop()
+
+	// Establish a context.
+	initCred := &RPCGSSCredV1{GSSProc: RPCGSSInit, SeqNum: 0, Service: RPCGSSSvcNone}
+	initCredBody, _ := EncodeGSSCred(initCred)
+	initRes := proc.Process(context.Background(), initCredBody, nil, nil,
+		encodeOpaqueToken([]byte("mock-token")))
+	if initRes.Err != nil {
+		t.Fatalf("INIT failed: %v", initRes.Err)
+	}
+	handle := extractContextHandle(t, proc)
+
+	destroyCred := &RPCGSSCredV1{
+		GSSProc: RPCGSSDestroy,
+		SeqNum:  1,
+		Service: RPCGSSSvcNone,
+		Handle:  handle,
+	}
+	destroyCredBody, _ := EncodeGSSCred(destroyCred)
+
+	t.Run("no MIC rejects DESTROY", func(t *testing.T) {
+		// No verifBody supplied — must be rejected before Delete.
+		res := proc.Process(context.Background(), destroyCredBody, nil, destroyCredBody, nil)
+		if res.Err == nil {
+			t.Fatal("expected rejection for DESTROY without MIC")
+		}
+		if res.AuthStat != AuthStatCredProblem {
+			t.Fatalf("expected AuthStatCredProblem, got %d", res.AuthStat)
+		}
+		// Context must still exist — DESTROY was rejected.
+		if proc.ContextCount() != 1 {
+			t.Fatalf("expected context to survive rejected DESTROY, got %d", proc.ContextCount())
+		}
+	})
+
+	t.Run("MIC under wrong key rejects DESTROY", func(t *testing.T) {
+		wrongKey := types.EncryptionKey{KeyType: 17, KeyValue: []byte("WRONG-session-ky")}
+		mic := signHeaderMIC(t, wrongKey, destroyCredBody)
+		res := proc.Process(context.Background(), destroyCredBody, mic, destroyCredBody, nil)
+		if res.Err == nil {
+			t.Fatal("expected rejection for DESTROY with wrong-key MIC")
+		}
+		if proc.ContextCount() != 1 {
+			t.Fatalf("context must survive rejected DESTROY, got %d", proc.ContextCount())
+		}
+	})
+
+	t.Run("valid MIC accepts DESTROY", func(t *testing.T) {
+		mic := signHeaderMIC(t, mockVerifierSessionKey, destroyCredBody)
+		res := proc.Process(context.Background(), destroyCredBody, mic, destroyCredBody, nil)
+		if res.Err != nil {
+			t.Fatalf("DESTROY with valid MIC failed: %v", res.Err)
+		}
+		if proc.ContextCount() != 0 {
+			t.Fatalf("expected context deleted after valid DESTROY, got %d", proc.ContextCount())
+		}
+	})
 }
 
 func TestProcessDATAWithValidContext(t *testing.T) {
@@ -1108,7 +1171,8 @@ func TestGSSLifecycle_Full(t *testing.T) {
 		Handle:  handle,
 	}
 	destroyCredBody, _ := EncodeGSSCred(destroyCred)
-	destroyResult := proc.Process(context.Background(), destroyCredBody, nil, nil, nil)
+	destroyMIC := signHeaderMIC(t, mockVerifierSessionKey, destroyCredBody)
+	destroyResult := proc.Process(context.Background(), destroyCredBody, destroyMIC, destroyCredBody, nil)
 
 	if destroyResult.Err != nil {
 		t.Fatalf("Step 5: DESTROY failed: %v", destroyResult.Err)

--- a/internal/adapter/nfs/rpc/gss/integrity.go
+++ b/internal/adapter/nfs/rpc/gss/integrity.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 
 	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -152,7 +153,7 @@ func readXDROpaque(reader *bytes.Reader) ([]byte, error) {
 	}
 
 	data := make([]byte, length)
-	if _, err := reader.Read(data); err != nil {
+	if _, err := io.ReadFull(reader, data); err != nil {
 		return nil, fmt.Errorf("read opaque data: %w", err)
 	}
 

--- a/internal/adapter/nfs/rpc/gss/integrity_test.go
+++ b/internal/adapter/nfs/rpc/gss/integrity_test.go
@@ -186,6 +186,22 @@ func TestUnwrapIntegrityRejectsTruncatedData(t *testing.T) {
 	}
 }
 
+func TestReadXDROpaqueShortRead(t *testing.T) {
+	// Build an XDR opaque header claiming 8 bytes of data, but supply only 4.
+	// With reader.Read this would succeed and return zero-filled data[4:8].
+	// With io.ReadFull this must return io.ErrUnexpectedEOF wrapped in an error.
+	buf := make([]byte, 4+4) // length(4) = 8, then only 4 data bytes
+	binary.BigEndian.PutUint32(buf[0:4], 8)
+	copy(buf[4:], []byte{0x01, 0x02, 0x03, 0x04})
+	// NOTE: no padding bytes beyond the 4 supplied data bytes
+
+	reader := bytes.NewReader(buf)
+	_, err := readXDROpaque(reader)
+	if err == nil {
+		t.Fatal("expected error on short-read; reader.Read would silently succeed with zero-fill")
+	}
+}
+
 // ============================================================================
 // WrapIntegrity Format Tests (server wraps reply for client)
 // ============================================================================

--- a/internal/adapter/nfs/rpc/gss/privacy.go
+++ b/internal/adapter/nfs/rpc/gss/privacy.go
@@ -10,7 +10,7 @@
 // The Wrap token is a GSS-API WrapToken per RFC 4121 Section 4.2.6.2.
 // For krb5p, the token provides both confidentiality and integrity.
 // For client->server: KeyUsageInitiatorSeal (24)
-// For server->client: KeyUsageAcceptorSeal (26)
+// For server->client: KeyUsageAcceptorSeal (22)
 //
 // RFC 4121 Section 4.2.4 defines the encrypted Wrap token format:
 //   - Wire format: header (16 bytes) | encrypt(plaintext | filler | header_copy)
@@ -253,7 +253,7 @@ func rotateLeft(data []byte, n int) []byte {
 // Per RFC 2203 Section 5.3.3.4.3 and RFC 4121 Section 4.2.4:
 // 1. Build plaintext: XDR(seq_num) + replyBody
 // 2. Build to-be-encrypted: plaintext | filler | header_copy (with EC=0, RRC=0)
-// 3. Encrypt using acceptor seal key usage (26)
+// 3. Encrypt using acceptor seal key usage (22)
 // 4. Build wire format: header (16 bytes) | ciphertext
 // 5. Encode as rpc_gss_priv_data: XDR opaque(wrap_token_bytes)
 //
@@ -308,7 +308,7 @@ func WrapPrivacy(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte
 	copy(toEncrypt, plaintext)
 	copy(toEncrypt[len(plaintext):], headerCopy)
 
-	// 6. Encrypt using acceptor seal key usage (26)
+	// 6. Encrypt using acceptor seal key usage (22)
 	_, ciphertext, err := encType.EncryptMessage(sessionKey.KeyValue, toEncrypt, KeyUsageAcceptorSeal)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt Wrap token: %w", err)

--- a/internal/adapter/nfs/rpc/gss/privacy_test.go
+++ b/internal/adapter/nfs/rpc/gss/privacy_test.go
@@ -337,7 +337,7 @@ func TestWrapPrivacyVerifiableByClient(t *testing.T) {
 		ciphertext = rotateLeft(ciphertext, int(rrc))
 	}
 
-	// Decrypt using acceptor seal key usage (26)
+	// Decrypt using acceptor seal key usage (22)
 	decrypted, err := crypto.DecryptMessage(ciphertext, key, KeyUsageAcceptorSeal)
 	if err != nil {
 		t.Fatalf("decrypt failed: %v", err)

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -196,7 +196,14 @@ func (h *Handler) Create(
 		// with the client's token. If they match, this is a retry - return success.
 		if fileExists {
 			// Check if idempotency token matches - this indicates a retry
-			if existingFile.IdempotencyToken == req.Verf && req.Verf != 0 {
+			// RFC 1813 §3.3.8: a CREATE EXCLUSIVE retry is detected by comparing
+			// the stored idempotency token with the supplied verifier. They match
+			// on a genuine retransmission; a mismatch is a real conflict. Note we
+			// do NOT special-case a zero verifier here: createNewFile stores the
+			// verifier unconditionally for EXCLUSIVE creates, so a legitimate
+			// zero-verifier retry (stored 0 == req 0) is correctly recognised
+			// rather than being mis-flagged as a conflict.
+			if existingFile.IdempotencyToken == req.Verf {
 				// Token matches - this is a retry of a successful create
 				logger.InfoCtx(ctx.Context, "CREATE EXCLUSIVE retry detected",
 					"file", req.Filename, "token", fmt.Sprintf("0x%016x", req.Verf), "client", clientIP)
@@ -410,7 +417,10 @@ func createNewFile(
 	// Per RFC 1813, the verifier comparison is opaque - how it's stored
 	// is implementation-defined as long as the same verifier can be
 	// retrieved on CREATE retry to detect duplicate requests.
-	if req.Mode == types.CreateExclusive && req.Verf != 0 {
+	// Store the verifier unconditionally for EXCLUSIVE creates (including a zero
+	// verifier). This lets a subsequent EXCLUSIVE retry with the same verifier —
+	// zero or not — be recognised as a retry instead of a false conflict.
+	if req.Mode == types.CreateExclusive {
 		fileAttr.IdempotencyToken = req.Verf
 	}
 

--- a/internal/adapter/nfs/v3/handlers/create_test.go
+++ b/internal/adapter/nfs/v3/handlers/create_test.go
@@ -422,3 +422,70 @@ func TestCreate_InvalidMode(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, types.NFS3ErrInval, resp.Status, "Invalid mode should return NFS3ErrInval")
 }
+
+// TestCreate_ExclusiveZeroVerifierRetry verifies that a zero verifier is not
+// falsely classified as a conflict when the file was created with Verf=0.
+func TestCreate_ExclusiveZeroVerifierRetry(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	req := &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "zero-verf.txt",
+		Mode:      types.CreateExclusive,
+		Verf:      0, // zero verifier
+	}
+	// First create must succeed
+	resp1, err := fx.Handler.Create(fx.ContextWithUID(0, 0), req)
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp1.Status, "initial zero-verifier EXCLUSIVE create must succeed")
+
+	// Retry with same (zero) verifier: must be recognised as a retry (NFS3OK).
+	resp2, err := fx.Handler.Create(fx.ContextWithUID(0, 0), req)
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp2.Status,
+		"zero-verifier retry must return NFS3OK, not NFS3ErrExist")
+	assert.NotNil(t, resp2.FileHandle, "retry must return the existing file handle")
+}
+
+// TestCreate_ExclusiveZeroVerifierNewFile verifies a first create with Verf=0 succeeds.
+func TestCreate_ExclusiveZeroVerifierNewFile(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	req := &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "zero-new.txt",
+		Mode:      types.CreateExclusive,
+		Verf:      0,
+	}
+	resp, err := fx.Handler.Create(fx.ContextWithUID(0, 0), req)
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.NotNil(t, resp.FileHandle)
+}
+
+// TestCreate_ExclusiveZeroVsNonZeroVerifierConflict tests that Verf=0 sent
+// against a file created with Verf!=0 is still a conflict.
+func TestCreate_ExclusiveZeroVsNonZeroVerifierConflict(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	req1 := &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "nonzero.txt",
+		Mode:      types.CreateExclusive,
+		Verf:      42,
+	}
+	resp1, err := fx.Handler.Create(fx.ContextWithUID(0, 0), req1)
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp1.Status)
+
+	req2 := &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "nonzero.txt",
+		Mode:      types.CreateExclusive,
+		Verf:      0, // different verifier
+	}
+	resp2, err := fx.Handler.Create(fx.ContextWithUID(0, 0), req2)
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrExist, resp2.Status,
+		"zero verifier vs stored non-zero verifier must conflict")
+}

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -108,6 +108,23 @@ func (h *Handler) convertFileAttrToNFS(fileHandle metadata.FileHandle, fileAttr 
 	return xdr.MetadataToNFS(fileAttr, fileid)
 }
 
+// wccAfterOrFallback returns the post-op WCC attributes for handle by fetching
+// the current file from the store, falling back to the supplied pre-op
+// attributes when the fetch fails or returns nil. This guards against
+// dereferencing a nil *metadata.File on the WCC error paths (a best-effort
+// GetFile is intentionally ignored for its error).
+func (h *Handler) wccAfterOrFallback(
+	ctx *NFSHandlerContext,
+	metaSvc *metadata.Service,
+	handle metadata.FileHandle,
+	fallback *metadata.FileAttr,
+) *types.NFSFileAttr {
+	if updated, err := metaSvc.GetFile(ctx.Context, handle); err == nil && updated != nil {
+		return h.convertFileAttrToNFS(handle, &updated.FileAttr)
+	}
+	return h.convertFileAttrToNFS(handle, fallback)
+}
+
 // dirWccPair derives the WCC before/after attributes for a directory (or, for
 // SETATTR, a file) from the atomic *metadata.DirWcc a mutation returned (H9).
 //

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -184,13 +184,7 @@ func (h *Handler) Link(
 		logger.DebugCtx(ctx.Context, "LINK failed: name already exists", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 		// Get updated directory attributes for WCC
-		updatedDirFile, _ := metaSvc.GetFile(ctx.Context, dirHandle)
-		var dirWccAfter *types.NFSFileAttr
-		if updatedDirFile != nil {
-			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
-		} else {
-			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
-		}
+		dirWccAfter := h.wccAfterOrFallback(ctx, metaSvc, dirHandle, &dirFile.FileAttr)
 
 		return &LinkResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -218,13 +212,7 @@ func (h *Handler) Link(
 		logError(ctx.Context, err, "LINK failed: store error", "name", req.Name, "client", clientIP)
 
 		// Get updated directory attributes for WCC
-		updatedDirFile, _ := metaSvc.GetFile(ctx.Context, dirHandle)
-		var dirWccAfter *types.NFSFileAttr
-		if updatedDirFile != nil {
-			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
-		} else {
-			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
-		}
+		dirWccAfter := h.wccAfterOrFallback(ctx, metaSvc, dirHandle, &dirFile.FileAttr)
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -185,7 +185,12 @@ func (h *Handler) Link(
 
 		// Get updated directory attributes for WCC
 		updatedDirFile, _ := metaSvc.GetFile(ctx.Context, dirHandle)
-		dirWccAfter := h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
+		var dirWccAfter *types.NFSFileAttr
+		if updatedDirFile != nil {
+			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
+		} else {
+			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
+		}
 
 		return &LinkResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -214,7 +219,12 @@ func (h *Handler) Link(
 
 		// Get updated directory attributes for WCC
 		updatedDirFile, _ := metaSvc.GetFile(ctx.Context, dirHandle)
-		dirWccAfter := h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
+		var dirWccAfter *types.NFSFileAttr
+		if updatedDirFile != nil {
+			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &updatedDirFile.FileAttr)
+		} else {
+			dirWccAfter = h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
+		}
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)
@@ -236,7 +246,14 @@ func (h *Handler) Link(
 		// Continue with cached attributes - this shouldn't happen but handle gracefully
 	}
 
-	nfsFileAttr := h.convertFileAttrToNFS(fileHandle, &updatedFile.FileAttr)
+	var nfsFileAttr *types.NFSFileAttr
+	if updatedFile != nil {
+		nfsFileAttr = h.convertFileAttrToNFS(fileHandle, &updatedFile.FileAttr)
+	} else {
+		// fileAttr was fetched earlier (and succeeded) before the link; fall
+		// back to it so we never dereference a nil GetFile result.
+		nfsFileAttr = h.convertFileAttrToNFS(fileHandle, &fileAttr.FileAttr)
+	}
 
 	// H9: use the directory attributes captured atomically with the link.
 	dirWccBefore, nfsDirAttr := h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, dirWccBefore)

--- a/internal/adapter/nfs/v3/handlers/link_test.go
+++ b/internal/adapter/nfs/v3/handlers/link_test.go
@@ -79,3 +79,27 @@ func TestLink_InvalidHandle(t *testing.T) {
 	assert.NotEqualValues(t, types.NFS3OK, resp.Status,
 		"Invalid handle should not return NFS3OK")
 }
+
+// TestLink_NameExistsReturnsWCC drives the "name already exists" branch and
+// verifies it returns NFS3ErrExist with non-nil WCC fields without a nil-pointer
+// dereference (regression guard for the discarded-error GetFile paths).
+func TestLink_NameExistsReturnsWCC(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	// Create source file
+	fileHandle := fx.CreateFile("src.txt", []byte("hello"))
+	// Create an existing entry at the target name
+	fx.CreateFile("existing-link.txt", []byte("other"))
+
+	req := &handlers.LinkRequest{
+		FileHandle: fileHandle,
+		DirHandle:  fx.RootHandle,
+		Name:       "existing-link.txt", // already exists -> drives name-exists path
+	}
+	resp, err := fx.Handler.Link(fx.Context(), req)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrExist, resp.Status)
+	assert.NotNil(t, resp.DirWccBefore, "WCC before must be set even on error")
+	assert.NotNil(t, resp.DirWccAfter, "WCC after must be set even on error")
+}

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -175,7 +175,12 @@ func (h *Handler) Mkdir(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -190,7 +195,12 @@ func (h *Handler) Mkdir(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -208,7 +218,12 @@ func (h *Handler) Mkdir(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -266,7 +281,12 @@ func (h *Handler) Mkdir(
 
 			// Get updated parent attributes for WCC data
 			updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-			wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+			var wccAfter *types.NFSFileAttr
+			if updatedParentFile != nil {
+				wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+			} else {
+				wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+			}
 
 			return &MkdirResponse{
 				NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -279,7 +299,12 @@ func (h *Handler) Mkdir(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -174,13 +174,7 @@ func (h *Handler) Mkdir(
 		logger.DebugCtx(ctx.Context, "MKDIR cancelled during existence check", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -194,13 +188,7 @@ func (h *Handler) Mkdir(
 		logger.DebugCtx(ctx.Context, "MKDIR failed: directory already exists", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -217,13 +205,7 @@ func (h *Handler) Mkdir(
 		logger.DebugCtx(ctx.Context, "MKDIR cancelled before create operation", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		return &MkdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -280,13 +262,7 @@ func (h *Handler) Mkdir(
 			logger.DebugCtx(ctx.Context, "MKDIR cancelled during create operation", "name", req.Name, "client", clientIP, "error", ctx.Context.Err())
 
 			// Get updated parent attributes for WCC data
-			updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-			var wccAfter *types.NFSFileAttr
-			if updatedParentFile != nil {
-				wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-			} else {
-				wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-			}
+			wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 			return &MkdirResponse{
 				NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -298,13 +274,7 @@ func (h *Handler) Mkdir(
 		logError(ctx.Context, err, "MKDIR failed: store error", "name", req.Name, "client", clientIP)
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)

--- a/internal/adapter/nfs/v3/handlers/mkdir_test.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir_test.go
@@ -363,3 +363,22 @@ func TestMkdir_NilAttr(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, types.NFS3OK, resp.Status)
 }
+
+// TestMkdir_ExistingDirectoryReturnsWCC drives the "already exists" error path
+// and verifies it returns non-nil WCC data without a nil-pointer dereference.
+func TestMkdir_ExistingDirectoryReturnsWCC(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fx.CreateDirectory("existing")
+
+	req := &handlers.MkdirRequest{
+		DirHandle: fx.RootHandle,
+		Name:      "existing",
+	}
+	resp, err := fx.Handler.Mkdir(fx.ContextWithUID(0, 0), req)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrExist, resp.Status)
+	assert.NotNil(t, resp.WccBefore, "WCC before must be present on NFS3ErrExist")
+	assert.NotNil(t, resp.WccAfter, "WCC after must be present on NFS3ErrExist")
+}

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -203,13 +203,7 @@ func (h *Handler) Mknod(
 		logger.DebugCtx(ctx.Context, "MKNOD failed: file already exists", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		return &MknodResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -279,13 +273,7 @@ func (h *Handler) Mknod(
 		logError(ctx.Context, err, "MKNOD failed: store error", "name", req.Name, "type", req.Type, "client", clientIP)
 
 		// Get updated parent attributes for WCC data
-		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		var wccAfter *types.NFSFileAttr
-		if updatedParentFile != nil {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
-		} else {
-			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
-		}
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -204,7 +204,12 @@ func (h *Handler) Mknod(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		return &MknodResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrExist},
@@ -275,7 +280,12 @@ func (h *Handler) Mknod(
 
 		// Get updated parent attributes for WCC data
 		updatedParentFile, _ := metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		var wccAfter *types.NFSFileAttr
+		if updatedParentFile != nil {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &updatedParentFile.FileAttr)
+		} else {
+			wccAfter = h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		}
 
 		// Map store errors to NFS status codes
 		status := common.MapToNFS3(err)

--- a/internal/adapter/nfs/v3/handlers/mknod_test.go
+++ b/internal/adapter/nfs/v3/handlers/mknod_test.go
@@ -48,3 +48,23 @@ func TestMknod_InvalidHandle(t *testing.T) {
 	assert.NotEqualValues(t, types.NFS3OK, resp.Status,
 		"Invalid handle should not return NFS3OK")
 }
+
+// TestMknod_ExistingFileReturnsWCC drives the "already exists" path and verifies
+// WCC data is returned without a nil-pointer dereference.
+func TestMknod_ExistingFileReturnsWCC(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fx.CreateFile("existing-sock", nil)
+
+	req := &handlers.MknodRequest{
+		DirHandle: fx.RootHandle,
+		Name:      "existing-sock",
+		Type:      types.NF3SOCK,
+	}
+	resp, err := fx.Handler.Mknod(fx.ContextWithUID(0, 0), req)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrExist, resp.Status)
+	assert.NotNil(t, resp.DirAttrBefore, "DirAttrBefore must be present on error")
+	assert.NotNil(t, resp.DirAttrAfter, "DirAttrAfter must be present on error")
+}

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -178,7 +178,7 @@ func (h *Handler) Read(
 		}, nil
 	}
 
-	metaSvc, _, err := getServicesForHandle(h.Registry, ctx.Context, fileHandle)
+	metaSvc, err := getMetadataService(h.Registry)
 	if err != nil {
 		logger.ErrorCtx(ctx.Context, "READ failed: metadata service not available", "client", clientIP, "error", err)
 		return &ReadResponse{

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -161,6 +161,44 @@ func (h *Handler) Read(
 		return nil, ctx.Context.Err()
 	}
 
+	// Enforce read permission before returning any file content. Without this
+	// any client holding a valid handle could read arbitrary file bytes,
+	// bypassing the file's mode/owner/group checks (WRITE already gates on
+	// PrepareWrite; READ must gate on PrepareRead symmetrically).
+	authCtx, err := h.GetCachedAuthContext(ctx)
+	if err != nil {
+		if ctx.Context.Err() != nil {
+			return nil, ctx.Context.Err()
+		}
+		logError(ctx.Context, err, "READ failed: failed to build auth context",
+			"handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		return &ReadResponse{
+			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
+		}, nil
+	}
+
+	metaSvc, _, err := getServicesForHandle(h.Registry, ctx.Context, fileHandle)
+	if err != nil {
+		logger.ErrorCtx(ctx.Context, "READ failed: metadata service not available", "client", clientIP, "error", err)
+		return &ReadResponse{
+			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
+		}, nil
+	}
+
+	if _, err := metaSvc.PrepareRead(authCtx, fileHandle); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		status := common.MapToNFS3(err)
+		logger.DebugCtx(ctx.Context, "READ denied", "handle", fmt.Sprintf("0x%x", req.Handle), "status", status, "client", clientIP, "error", err)
+		return &ReadResponse{
+			NFSResponseBase: NFSResponseBase{Status: status},
+			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
+		}, nil
+	}
+
 	// Fire-and-forget: NFS proceeds even if break is pending (per Samba behavior).
 	if breaker := h.getOplockBreaker(); breaker != nil {
 		if err := breaker.CheckAndBreakForRead(ctx.Context, lock.FileHandle(string(fileHandle))); err != nil {

--- a/internal/adapter/nfs/v3/handlers/read_test.go
+++ b/internal/adapter/nfs/v3/handlers/read_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
 	handlertesting "github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers/testing"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -389,4 +390,65 @@ func TestRead_LargeFile(t *testing.T) {
 	assert.EqualValues(t, count, resp.Count)
 	assert.Equal(t, content[offset:offset+uint64(count)], resp.Data)
 	assert.False(t, resp.Eof)
+}
+
+// TestRead_PermissionDenied verifies that READ on a mode-000 file owned by root
+// returns NFS3ErrAccess when the caller is a non-root user, proving the
+// PrepareRead permission gate is active.
+func TestRead_PermissionDenied(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	rootCtx := fx.ContextWithUID(0, 0)
+
+	// Create a file as root (UID 0).
+	createResp, err := fx.Handler.Create(rootCtx, &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "secret.txt",
+		Mode:      types.CreateUnchecked,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, createResp.Status)
+	fileHandle := createResp.FileHandle
+
+	// chmod 000 via SETATTR so no one but root may read.
+	mode := uint32(0000)
+	setattrResp, err := fx.Handler.SetAttr(rootCtx, &handlers.SetAttrRequest{
+		Handle:  fileHandle,
+		NewAttr: metadata.SetAttrs{Mode: &mode},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, setattrResp.Status)
+
+	// Read as non-root user (uid=1000) -> must be denied.
+	req := &handlers.ReadRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  100,
+	}
+	resp, err := fx.Handler.Read(fx.Context(), req) // fx.Context() uses uid=1000
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrAccess, resp.Status,
+		"READ on mode-000 root-owned file by non-root must return NFS3ErrAccess")
+}
+
+// TestRead_PermissionGranted verifies that a readable file (mode 0644 owned by
+// the caller) is still readable after the PrepareRead gate is added.
+func TestRead_PermissionGranted(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	// CreateFile makes the file mode 0644 owned by DefaultUID (1000).
+	content := []byte("readable content")
+	fileHandle := fx.CreateFile("readable.txt", content)
+
+	req := &handlers.ReadRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  uint32(len(content)),
+	}
+	resp, err := fx.Handler.Read(fx.Context(), req) // uid=1000, file owned by 1000, mode 0644
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.Equal(t, content, resp.Data)
 }

--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -499,6 +499,7 @@ func TestCreate_RegularFile_ConsumesArgs(t *testing.T) {
 	}
 }
 
+
 func TestCreate_NoCurrentFH(t *testing.T) {
 	pfs := pseudofs.New()
 	h := NewHandler(nil, pfs)

--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -499,7 +499,6 @@ func TestCreate_RegularFile_ConsumesArgs(t *testing.T) {
 	}
 }
 
-
 func TestCreate_NoCurrentFH(t *testing.T) {
 	pfs := pseudofs.New()
 	h := NewHandler(nil, pfs)

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -202,8 +202,8 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 
 	default:
 		logger.Debug("Unknown program", "program", call.Program)
-		// Send PROC_UNAVAIL error reply for unknown programs
-		errorReply, err := rpc.MakeErrorReply(call.XID, rpc.RPCProcUnavail)
+		// Send PROG_UNAVAIL error reply for unknown programs (RFC 5531 §9)
+		errorReply, err := rpc.MakeErrorReply(call.XID, rpc.RPCProgUnavail)
 		if err != nil {
 			return fmt.Errorf("make error reply: %w", err)
 		}

--- a/pkg/adapter/nfs/dispatch_unknown_prog_test.go
+++ b/pkg/adapter/nfs/dispatch_unknown_prog_test.go
@@ -1,0 +1,92 @@
+package nfs
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+)
+
+// TestHandleRPCCall_UnknownProgram_ReturnsProgUnavail verifies that an RPC
+// call for an unrecognised program number receives accept_stat=1 (PROG_UNAVAIL,
+// RFC 5531 §9) and NOT accept_stat=3 (PROC_UNAVAIL).
+//
+// Fails before the fix because RPCProcUnavail (3) is returned instead.
+// Passes after the fix because RPCProgUnavail (1) is returned.
+func TestHandleRPCCall_UnknownProgram_ReturnsProgUnavail(t *testing.T) {
+	const testXID = uint32(0xDEADBEEF)
+	const unknownProg = uint32(999999)
+
+	// Build a minimal NFSAdapter (no runtime wired — the default branch fires
+	// before any handler is reached).
+	adapter := New(NFSConfig{
+		Enabled: true,
+		Port:    12049,
+	}, nil)
+
+	// net.Pipe gives a synchronous, in-process full-duplex connection.
+	client, server := net.Pipe()
+	t.Cleanup(func() { client.Close(); server.Close() })
+
+	conn := NewNFSConnection(adapter, server, 1)
+
+	// Build an RPC CALL for an unknown program with AUTH_NULL credentials.
+	call := &rpc.RPCCallMessage{
+		XID:       testXID,
+		Program:   unknownProg,
+		Version:   1,
+		Procedure: 0,
+		Cred:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+		Verf:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+	}
+
+	// Drive handleRPCCall in a goroutine; it writes to server end of the pipe.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.handleRPCCall(context.Background(), call, nil, nil)
+	}()
+
+	// Read the reply from the client end.
+	// RPC-over-TCP: 4-byte fragment header then the XDR body.
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(client, header); err != nil {
+		t.Fatalf("reading fragment header: %v", err)
+	}
+	// Top bit marks last fragment; lower 31 bits = body length.
+	bodyLen := binary.BigEndian.Uint32(header) &^ 0x80000000
+	body := make([]byte, bodyLen)
+	if _, err := io.ReadFull(client, body); err != nil {
+		t.Fatalf("reading reply body: %v", err)
+	}
+
+	// Verify the goroutine completed without error.
+	if err := <-errCh; err != nil {
+		t.Fatalf("handleRPCCall returned error: %v", err)
+	}
+
+	// Parse the XDR reply:
+	//   body[0:4]   = XID
+	//   body[4:8]   = MsgType (1 = REPLY)
+	//   body[8:12]  = ReplyState (0 = MSG_ACCEPTED)
+	//   body[12:16] = Verf Flavor
+	//   body[16:20] = Verf Body Length
+	//   body[20:24] = AcceptStat  <-- what we check
+	const minLen = 24
+	if len(body) < minLen {
+		t.Fatalf("reply body too short: got %d bytes, want >= %d", len(body), minLen)
+	}
+
+	xid := binary.BigEndian.Uint32(body[0:4])
+	if xid != testXID {
+		t.Errorf("XID echo: got 0x%x, want 0x%x", xid, testXID)
+	}
+
+	acceptStat := binary.BigEndian.Uint32(body[20:24])
+	if acceptStat != rpc.RPCProgUnavail {
+		t.Errorf("accept_stat: got %d, want %d (PROG_UNAVAIL); got PROC_UNAVAIL(3)=%v",
+			acceptStat, rpc.RPCProgUnavail, acceptStat == rpc.RPCProcUnavail)
+	}
+}

--- a/pkg/adapter/nfs/dispatch_unknown_prog_test.go
+++ b/pkg/adapter/nfs/dispatch_unknown_prog_test.go
@@ -29,7 +29,7 @@ func TestHandleRPCCall_UnknownProgram_ReturnsProgUnavail(t *testing.T) {
 
 	// net.Pipe gives a synchronous, in-process full-duplex connection.
 	client, server := net.Pipe()
-	t.Cleanup(func() { client.Close(); server.Close() })
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
 
 	conn := NewNFSConnection(adapter, server, 1)
 


### PR DESCRIPTION
Remediates NFSv3 + NLM/NSM/RPC/GSS audit findings (#1078, Part of #1075). Signed commits; build/vet/gofmt + full NFS suite + `-race` on gss/nsm green.

## HIGH
- **fix(nfs/nsm): SSRF guard on SM_MON callback host** — client-supplied `my_name` used for outbound dial; reject non-IP-literal/loopback/link-local (169.254 IMDS). Two-layer (handler + callback client).
- **fix(nfs/nsm): RFC 1982 serial-number monotonicity** — int32 signed comparison rejected legitimate reboots on wrap; now serial arithmetic.
- **fix(nfs/gss): authenticate RPCSEC_GSS DESTROY** — DESTROY skipped call-header MIC verification (unauthenticated context teardown via leaked handle); now verifies MIC + seq window (RFC 2203 §5.3.3.2).
- **fix(nfs/gss): atomic context-cap, ReadFull, idempotent Stop** — non-atomic maxContexts (burst past cap under concurrent INIT); `readXDROpaque` silent short-read → `io.ReadFull`; `ContextStore.Stop` double-call panic → `sync.Once`.
- **fix(nfs/v3): harden CREATE EXCLUSIVE verifier** — zero-verifier retransmit false-flagged as conflict.
- **fix(nfs/v3): guard nil GetFile in WCC** — discarded-error `GetFile` deref'd unconditionally for WCC across LINK/MKDIR/MKNOD (nil-deref).
- **fix(nfs/v3): enforce READ permission** — READ never permission-checked; any valid handle could read arbitrary content. Added `PrepareRead` gate mirroring WRITE.
- **fix(nfs): PROG_UNAVAIL not PROC_UNAVAIL for unknown RPC programs.**

Each fix lands with a test (fail-before/pass-after).

Fixes #1078
Part of #1075