### PR TITLE
fix(block): remediate v1.0 audit block/CAS store findings (#1081)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -499,6 +499,7 @@ func TestCreate_RegularFile_ConsumesArgs(t *testing.T) {
 	}
 }
 
+
 func TestCreate_NoCurrentFH(t *testing.T) {
 	pfs := pseudofs.New()
 	h := NewHandler(nil, pfs)

--- a/internal/adapter/nfs/v4/handlers/create_remove_test.go
+++ b/internal/adapter/nfs/v4/handlers/create_remove_test.go
@@ -499,7 +499,6 @@ func TestCreate_RegularFile_ConsumesArgs(t *testing.T) {
 	}
 }
 
-
 func TestCreate_NoCurrentFH(t *testing.T) {
 	pfs := pseudofs.New()
 	h := NewHandler(nil, pfs)

--- a/pkg/block/compression/codec.go
+++ b/pkg/block/compression/codec.go
@@ -38,7 +38,7 @@ var zstdCodec codec = &zstdImpl{}
 
 type zstdImpl struct{}
 
-var zstdEncoderPool = sync.Pool{
+var zstdEncoderPool = &sync.Pool{
 	New: func() any {
 		// Discard the bound writer here; callers Reset() before use.
 		enc, err := zstd.NewWriter(io.Discard,
@@ -54,7 +54,7 @@ var zstdEncoderPool = sync.Pool{
 	},
 }
 
-var zstdDecoderPool = sync.Pool{
+var zstdDecoderPool = &sync.Pool{
 	New: func() any {
 		dec, err := zstd.NewReader(nil,
 			zstd.WithDecoderConcurrency(1),
@@ -90,10 +90,14 @@ func (h *zstdEncoderHandle) Close() error {
 		return nil
 	}
 	h.closed = true
-	err := h.enc.Close()
-	zstdEncoderPool.Put(h.enc)
+	enc := h.enc
 	h.enc = nil
-	return err
+	if err := enc.Close(); err != nil {
+		// enc is in an undefined state; let the GC reclaim it.
+		return err
+	}
+	zstdEncoderPool.Put(enc)
+	return nil
 }
 
 func (zstdImpl) DecodeStream(r io.Reader) (io.ReadCloser, error) {
@@ -136,13 +140,13 @@ var lz4Codec codec = &lz4Impl{}
 
 type lz4Impl struct{}
 
-var lz4WriterPool = sync.Pool{
+var lz4WriterPool = &sync.Pool{
 	New: func() any {
 		return lz4.NewWriter(io.Discard)
 	},
 }
 
-var lz4ReaderPool = sync.Pool{
+var lz4ReaderPool = &sync.Pool{
 	New: func() any {
 		return lz4.NewReader(nil)
 	},
@@ -168,10 +172,14 @@ func (h *lz4EncoderHandle) Close() error {
 		return nil
 	}
 	h.closed = true
-	err := h.w.Close()
-	lz4WriterPool.Put(h.w)
+	w := h.w
 	h.w = nil
-	return err
+	if err := w.Close(); err != nil {
+		// w is in an undefined state; let the GC reclaim it.
+		return err
+	}
+	lz4WriterPool.Put(w)
+	return nil
 }
 
 func (lz4Impl) DecodeStream(r io.Reader) (io.ReadCloser, error) {

--- a/pkg/block/compression/codec_test.go
+++ b/pkg/block/compression/codec_test.go
@@ -3,9 +3,14 @@ package compression
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
 )
 
 func codecRoundTrip(t *testing.T, c codec, plaintext []byte) []byte {
@@ -91,6 +96,116 @@ func TestNewCodec_UnknownAlgo(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown algo")
 	}
+}
+
+// failWriter is an io.Writer that accepts up to n bytes, then returns err
+// on the Write call that exhausts the budget. It simulates a downstream
+// flush failure during encoder Close.
+type failWriter struct {
+	n   int
+	err error
+}
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	if f.n <= 0 {
+		return 0, f.err
+	}
+	take := len(p)
+	if take > f.n {
+		take = f.n
+	}
+	f.n -= take
+	if f.n == 0 {
+		return take, f.err
+	}
+	return take, nil
+}
+
+// TestZstdEncoderHandle_CloseError_DoesNotPoisonPool deterministically
+// asserts that an encoder whose Close fails (downstream write error) is NOT
+// returned to the shared pool. It swaps the package pool for an empty one,
+// captures the single encoder handed out by EncodeStream, forces a Close
+// failure, then Gets from the same pool and confirms the broken encoder
+// pointer is not recycled.
+//
+// Before the fix the Close path called Put unconditionally, so the swapped
+// pool would hand the very same (poisoned) *zstd.Encoder back on the next
+// Get and the test fails. After the fix the broken encoder is dropped and a
+// fresh one is constructed by New.
+func TestZstdEncoderHandle_CloseError_DoesNotPoisonPool(t *testing.T) {
+	// Swap in an empty pool whose New always builds a fresh encoder. Save
+	// only the New func (copying the whole sync.Pool by value is illegal).
+	savedNew := zstdEncoderPool.New
+	t.Cleanup(func() { zstdEncoderPool = &sync.Pool{New: savedNew} })
+	zstdEncoderPool = &sync.Pool{New: savedNew}
+
+	c, err := newCodec(AlgoZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Accept only a few bytes, then reject. A 1 MiB payload guarantees the
+	// encoder must write past the budget during compression and/or the
+	// Close-emitted frame trailer, so Close reports the downstream error.
+	fw := &failWriter{n: 8, err: errors.New("simulated write failure")}
+	wc, err := c.EncodeStream(fw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := wc.(*zstdEncoderHandle).enc
+	if _, err := wc.Write(bytes.Repeat([]byte("x"), 1<<20)); err != nil {
+		// A buffered write failure here is acceptable; Close drives the guard.
+		_ = err
+	}
+	if closeErr := wc.Close(); closeErr == nil {
+		t.Fatal("expected Close to surface the downstream write failure, got nil")
+	}
+
+	// The poisoned encoder must not be in the pool. Drain a few times to be
+	// robust against sync.Pool's per-P local/shared placement.
+	for i := 0; i < 8; i++ {
+		got := zstdEncoderPool.Get().(*zstd.Encoder)
+		if got == broken {
+			t.Fatalf("poisoned zstd encoder was returned to the pool (iter %d)", i)
+		}
+	}
+
+	// Sanity: the codec still round-trips correctly afterwards.
+	codecRoundTrip(t, c, []byte("post-error round-trip payload"))
+}
+
+// TestLZ4EncoderHandle_CloseError_DoesNotPoisonPool is the lz4 counterpart.
+func TestLZ4EncoderHandle_CloseError_DoesNotPoisonPool(t *testing.T) {
+	savedNew := lz4WriterPool.New
+	t.Cleanup(func() { lz4WriterPool = &sync.Pool{New: savedNew} })
+	lz4WriterPool = &sync.Pool{New: savedNew}
+
+	c, err := newCodec(AlgoLZ4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fw := &failWriter{n: 8, err: errors.New("simulated write failure")}
+	wc, err := c.EncodeStream(fw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := wc.(*lz4EncoderHandle).w
+	if _, err := wc.Write(bytes.Repeat([]byte("y"), 1<<20)); err != nil {
+		_ = err
+	}
+	if closeErr := wc.Close(); closeErr == nil {
+		t.Fatal("expected Close to surface the downstream write failure, got nil")
+	}
+
+	for i := 0; i < 8; i++ {
+		got := lz4WriterPool.Get().(*lz4.Writer)
+		if got == broken {
+			t.Fatalf("poisoned lz4 writer was returned to the pool (iter %d)", i)
+		}
+	}
+
+	codecRoundTrip(t, c, []byte("post-error round-trip payload lz4"))
 }
 
 func TestCodec_CompressibleShrinks(t *testing.T) {

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -142,7 +142,11 @@ func fetchKMIPSymmetricKey(ctx context.Context, endpoint string, tlsCfg *tls.Con
 			item.ResultStatus, item.ResultReason, item.ResultMessage)
 	}
 	var payload kmip.GetResponsePayload
-	if err := ttlv.Unmarshal(item.ResponsePayload.(ttlv.TTLV), &payload); err != nil {
+	raw, ok := item.ResponsePayload.(ttlv.TTLV)
+	if !ok {
+		return nil, fmt.Errorf("keyprovider: kmip Get payload is not TTLV (got %T)", item.ResponsePayload)
+	}
+	if err := ttlv.Unmarshal(raw, &payload); err != nil {
 		return nil, fmt.Errorf("keyprovider: kmip decode Get payload: %w", err)
 	}
 	if payload.ObjectType != kmip14.ObjectTypeSymmetricKey {

--- a/pkg/block/encryption/keyprovider/kmip_fake_test.go
+++ b/pkg/block/encryption/keyprovider/kmip_fake_test.go
@@ -303,6 +303,61 @@ func TestKMIP_FetchSymmetricKey_ServerFailure(t *testing.T) {
 	}
 }
 
+// kmipNilPayloadResponse returns a success-status ResponseMessage with no
+// ResponsePayload field. The library leaves ResponsePayload as nil after
+// decode, so a bare type assertion in fetchKMIPSymmetricKey would panic.
+func kmipNilPayloadResponse(t *testing.T) ttlv.TTLV {
+	t.Helper()
+	resp := kmip.ResponseMessage{
+		ResponseHeader: kmip.ResponseHeader{
+			ProtocolVersion: kmip.ProtocolVersion{ProtocolVersionMajor: 1, ProtocolVersionMinor: 4},
+			TimeStamp:       time.Now(),
+			BatchCount:      1,
+		},
+		BatchItem: []kmip.ResponseBatchItem{{
+			Operation:    kmip14.OperationGet,
+			ResultStatus: kmip14.ResultStatusSuccess,
+			// ResponsePayload intentionally omitted (nil interface{}).
+		}},
+	}
+	raw, err := ttlv.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal nil-payload kmip response: %v", err)
+	}
+	return raw
+}
+
+// TestKMIP_FetchSymmetricKey_NilPayload verifies that a success-status KMIP
+// response with a missing ResponsePayload does not panic but returns a
+// descriptive error.
+func TestKMIP_FetchSymmetricKey_NilPayload(t *testing.T) {
+	dir := t.TempDir()
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	srv := startFakeKMIP(t, serverTLSConfig(t, srvCert, srvKey), kmipNilPayloadResponse(t))
+
+	cfg := Config{
+		Kind:       KindKMIP,
+		Endpoint:   srv.addr(),
+		ClientCert: cliCert,
+		ClientKey:  cliKey,
+		ServerCA:   caPath,
+		KeyUID:     "k",
+	}
+	_, err := newKMIPProvider(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("want error for nil ResponsePayload, got nil")
+	}
+	if !strings.Contains(err.Error(), "payload is not TTLV") {
+		t.Errorf("error should mention payload type, got %q", err.Error())
+	}
+}
+
 // TestKMIP_DialError verifies a connection to a dead endpoint surfaces a
 // dial error rather than hanging.
 func TestKMIP_DialError(t *testing.T) {

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -408,10 +408,27 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 //     reclaimed only when no row anywhere references the hash, so a hash a
 //     sibling file still uses stays alive even after this row is reaped.
 //
-// No-ops when the coordinator is unwired (tests/fixtures) or when nothing
-// was superseded (pure append, first write).
+// No-ops when the coordinator is unwired or when priorOffsets is empty
+// (first write). When newBlocks is empty all prior rows are reaped
+// unconditionally (file truncated to zero bytes this pass).
 func (bs *Store) reapSupersededFileBlocks(ctx context.Context, payloadID string, priorOffsets []uint64, newBlocks []block.BlockRef) error {
-	if bs.coordinator == nil || len(priorOffsets) == 0 || len(newBlocks) == 0 {
+	if bs.coordinator == nil || len(priorOffsets) == 0 {
+		return nil
+	}
+	// Fast path: no new chunks were produced (file truncated to zero bytes
+	// or the reconstructed stream was entirely clipped by the truncation
+	// fence). Every prior row is unconditionally superseded — reap all.
+	if len(newBlocks) == 0 {
+		reaped := make(map[uint64]struct{}, len(priorOffsets))
+		for _, off := range priorOffsets {
+			if _, done := reaped[off]; done {
+				continue
+			}
+			reaped[off] = struct{}{}
+			if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, off); err != nil {
+				return fmt.Errorf("reap superseded block %s/%d: %w", payloadID, off, err)
+			}
+		}
 		return nil
 	}
 	regionStart := newBlocks[0].Offset

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -415,41 +415,45 @@ func (bs *Store) reapSupersededFileBlocks(ctx context.Context, payloadID string,
 	if bs.coordinator == nil || len(priorOffsets) == 0 {
 		return nil
 	}
-	// Fast path: no new chunks were produced (file truncated to zero bytes
-	// or the reconstructed stream was entirely clipped by the truncation
-	// fence). Every prior row is unconditionally superseded — reap all.
+
+	// superseded decides whether a prior offset is reaped this pass.
+	//
+	// When newBlocks is empty no chunks were produced (file truncated to zero
+	// bytes, or the reconstructed stream was entirely clipped by the
+	// truncation fence): every prior row is unconditionally superseded.
+	// Otherwise a prior offset is superseded only when it falls inside the
+	// rewritten region [regionStart, regionEnd) and is not itself a reused
+	// offset (those rows were overwritten in place by FileBlock.Put and are
+	// the current generation).
+	var superseded func(off uint64) bool
 	if len(newBlocks) == 0 {
-		reaped := make(map[uint64]struct{}, len(priorOffsets))
-		for _, off := range priorOffsets {
-			if _, done := reaped[off]; done {
-				continue
+		superseded = func(uint64) bool { return true }
+	} else {
+		regionStart := newBlocks[0].Offset
+		var regionEnd uint64
+		newOffsets := make(map[uint64]struct{}, len(newBlocks))
+		for _, b := range newBlocks {
+			if b.Offset < regionStart {
+				regionStart = b.Offset
 			}
-			reaped[off] = struct{}{}
-			if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, off); err != nil {
-				return fmt.Errorf("reap superseded block %s/%d: %w", payloadID, off, err)
+			if end := b.Offset + uint64(b.Size); end > regionEnd {
+				regionEnd = end
 			}
+			newOffsets[b.Offset] = struct{}{}
 		}
-		return nil
+		superseded = func(off uint64) bool {
+			if off < regionStart || off >= regionEnd {
+				return false // outside the rewritten region — untouched, keep.
+			}
+			_, isNew := newOffsets[off]
+			return !isNew // reused offset is the current generation — keep.
+		}
 	}
-	regionStart := newBlocks[0].Offset
-	var regionEnd uint64
-	newOffsets := make(map[uint64]struct{}, len(newBlocks))
-	for _, b := range newBlocks {
-		if b.Offset < regionStart {
-			regionStart = b.Offset
-		}
-		if end := b.Offset + uint64(b.Size); end > regionEnd {
-			regionEnd = end
-		}
-		newOffsets[b.Offset] = struct{}{}
-	}
+
 	reaped := make(map[uint64]struct{}, len(priorOffsets))
 	for _, off := range priorOffsets {
-		if off < regionStart || off >= regionEnd {
-			continue // outside the rewritten region — untouched, keep.
-		}
-		if _, isNew := newOffsets[off]; isNew {
-			continue // reused offset — current generation (overwritten in place).
+		if !superseded(off) {
+			continue
 		}
 		if _, done := reaped[off]; done {
 			continue

--- a/pkg/block/engine/reap_zero_blocks_test.go
+++ b/pkg/block/engine/reap_zero_blocks_test.go
@@ -1,0 +1,81 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestReapSupersededFileBlocks_ZeroNewBlocks_ReapsAllPrior asserts that when a
+// rollup pass produces zero chunks (file truncated to zero bytes), every prior
+// FileBlock row is unconditionally reaped. Before the fix the outer guard
+// short-circuited on len(newBlocks) == 0, leaving the prior rows (and their
+// CAS chunks) orphaned forever.
+func TestReapSupersededFileBlocks_ZeroNewBlocks_ReapsAllPrior(t *testing.T) {
+	ctx := context.Background()
+	coord := newRefcountCoordinator()
+	var h0, h1 block.ContentHash
+	h0[0] = 0xA0
+	h1[0] = 0xA1
+	coord.seedBlock("pid-trunc", 0, h0, 1)
+	coord.seedBlock("pid-trunc", 4096, h1, 1)
+
+	bs := buildCascadeFixture(t, coord, nil)
+
+	priorOffsets := []uint64{0, 4096}
+	var newBlocks []block.BlockRef // empty — truncated to zero
+
+	if err := bs.reapSupersededFileBlocks(ctx, "pid-trunc", priorOffsets, newBlocks); err != nil {
+		t.Fatalf("reapSupersededFileBlocks: %v", err)
+	}
+
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	for _, h := range []block.ContentHash{h0, h1} {
+		if c := coord.counts[h]; c != 0 {
+			t.Errorf("hash %x refcount=%d after reap; want 0 (block not reaped)", h[:2], c)
+		}
+	}
+}
+
+// TestReapSupersededFileBlocks_EmptyPrior_IsNoOp guards that removing the
+// len(newBlocks) == 0 short-circuit from the outer guard did not break the
+// len(priorOffsets) == 0 no-op path. With no prior rows there is nothing to
+// reap regardless of newBlocks.
+func TestReapSupersededFileBlocks_EmptyPrior_IsNoOp(t *testing.T) {
+	ctx := context.Background()
+	coord := newRefcountCoordinator()
+	var h0 block.ContentHash
+	h0[0] = 0xB0
+	coord.seedBlock("pid-empty-prior", 0, h0, 1)
+
+	bs := buildCascadeFixture(t, coord, nil)
+
+	newBlocks := []block.BlockRef{{Hash: h0, Offset: 0, Size: 4096}}
+
+	if err := bs.reapSupersededFileBlocks(ctx, "pid-empty-prior", nil, newBlocks); err != nil {
+		t.Fatalf("reapSupersededFileBlocks: %v", err)
+	}
+
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	if c := coord.counts[h0]; c != 1 {
+		t.Errorf("hash %x refcount=%d after no-op; want 1 (DecrementRefCountAndReap must not fire)", h0[:2], c)
+	}
+}
+
+// TestReapSupersededFileBlocks_NilCoordinator_IsNoOp asserts the unwired
+// coordinator guard still short-circuits even on the zero-blocks path (no
+// panic, nil error).
+func TestReapSupersededFileBlocks_NilCoordinator_IsNoOp(t *testing.T) {
+	ctx := context.Background()
+	bs := buildCascadeFixture(t, nil, nil)
+
+	priorOffsets := []uint64{0, 4096}
+	var newBlocks []block.BlockRef // empty — truncated to zero
+
+	if err := bs.reapSupersededFileBlocks(ctx, "pid-nil-coord", priorOffsets, newBlocks); err != nil {
+		t.Fatalf("reapSupersededFileBlocks with nil coordinator: %v", err)
+	}
+}

--- a/pkg/block/engine/reap_zero_blocks_test.go
+++ b/pkg/block/engine/reap_zero_blocks_test.go
@@ -79,3 +79,62 @@ func TestReapSupersededFileBlocks_NilCoordinator_IsNoOp(t *testing.T) {
 		t.Fatalf("reapSupersededFileBlocks with nil coordinator: %v", err)
 	}
 }
+
+// TestReapSupersededFileBlocks_RegionFilter exercises the general (non-empty
+// newBlocks) reap path: only prior offsets that fall inside the rewritten
+// region [regionStart, regionEnd) and are NOT reused by a new chunk are
+// reaped. Prior offsets outside the region are kept, and reused offsets are
+// kept (overwritten in place — current generation). It also covers a
+// duplicate prior offset to confirm the dedup guard fires DecrementRefCount
+// at most once per offset.
+func TestReapSupersededFileBlocks_RegionFilter(t *testing.T) {
+	ctx := context.Background()
+	coord := newRefcountCoordinator()
+
+	const payloadID = "pid-region"
+
+	// Three distinct prior rows at offsets 0, 8192, 16384.
+	var hKept, hReaped, hOutside block.ContentHash
+	hKept[0] = 0x10    // offset 0 — reused by a new chunk -> kept
+	hReaped[0] = 0x12  // offset 8192 — inside region, not reused -> reaped
+	hOutside[0] = 0x13 // offset 16384 — outside the rewritten region -> kept
+
+	coord.seedBlock(payloadID, 0, hKept, 1)
+	coord.seedBlock(payloadID, 8192, hReaped, 1)
+	coord.seedBlock(payloadID, 16384, hOutside, 1)
+
+	bs := buildCascadeFixture(t, coord, nil)
+
+	// New chunks: one reuses offset 0, two fresh chunks extend regionEnd past
+	// offset 8192. With chunks at 0, 4096, 6144 (each size 4096) the rewritten
+	// region is [0, 10240). Prior offset 0 is reused (kept); prior offset 8192
+	// is inside [0, 10240) and not reused (reaped); prior offset 16384 is
+	// outside (kept).
+	var nh0, nh1 block.ContentHash
+	nh0[0] = 0x20
+	nh1[0] = 0x21
+	newBlocks := []block.BlockRef{
+		{Hash: hKept, Offset: 0, Size: 4096},  // reuses prior offset 0
+		{Hash: nh0, Offset: 4096, Size: 4096}, // fresh
+		{Hash: nh1, Offset: 6144, Size: 4096}, // fresh, extends regionEnd to 10240
+	}
+
+	// Duplicate the reaped offset in priorOffsets to exercise the dedup guard.
+	priorOffsets := []uint64{0, 8192, 8192, 16384}
+
+	if err := bs.reapSupersededFileBlocks(ctx, payloadID, priorOffsets, newBlocks); err != nil {
+		t.Fatalf("reapSupersededFileBlocks: %v", err)
+	}
+
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	if c := coord.counts[hKept]; c != 1 {
+		t.Errorf("reused offset 0 hash refcount=%d; want 1 (must not be reaped)", c)
+	}
+	if c := coord.counts[hOutside]; c != 1 {
+		t.Errorf("out-of-region offset 16384 hash refcount=%d; want 1 (must not be reaped)", c)
+	}
+	if _, present := coord.counts[hReaped]; present {
+		t.Errorf("superseded offset 8192 hash still present; want reaped to 0 (deleted)")
+	}
+}

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -130,10 +130,11 @@ func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
 			stats.BlocksTotal++
 			switch b.State {
 			case block.BlockStatePending:
-				// Pending now covers both legacy Dirty (no LocalPath / no key)
-				// and Local (complete, awaiting sync). Distinguish by data
-				// state to keep the existing introspection counters meaningful.
-				if b.LocalPath != "" || b.BlockStoreKey != "" {
+				// A CAS-pending block with a non-zero hash is locally present in the
+				// CAS store; a zero hash means the block is truly dirty/in-flight
+				// (rollup not yet complete). LocalPath and BlockStoreKey are legacy
+				// signals irrelevant on the CAS path.
+				if !b.Hash.IsZero() {
 					stats.BlocksLocal++
 				} else {
 					stats.BlocksDirty++

--- a/pkg/block/engine/stats_test.go
+++ b/pkg/block/engine/stats_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"context"
 	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
 )
 
 // TestStats_EmptyStore verifies Stats() returns UsedSize==0 for an empty store.
@@ -108,4 +110,76 @@ func TestStats_AverageSize(t *testing.T) {
 	}
 
 	// When ContentCount == 0, AverageSize should be 0 (tested by empty store test).
+}
+
+// TestGetStats_PopulateBlockCounts_CASPendingCountedAsLocal verifies that a
+// CAS-path Pending FileBlock (non-zero Hash, no LocalPath / BlockStoreKey) is
+// classified as locally present rather than dirty. Before the fix the
+// discriminator keyed on LocalPath/BlockStoreKey, which are never set on the
+// CAS path, so every rolled-up chunk was mis-counted as dirty.
+func TestGetStats_PopulateBlockCounts_CASPendingCountedAsLocal(t *testing.T) {
+	bs := newTestEngine(t, 0, 0)
+	ctx := context.Background()
+
+	fbs := bs.fileBlockStore.(*stubFileBlockStore)
+
+	// Block A: CAS-path Pending — non-zero hash, no LocalPath, no BlockStoreKey.
+	// Before fix -> BlocksDirty (wrong). After fix -> BlocksLocal (correct).
+	var hashA block.ContentHash
+	hashA[0] = 0xAB
+	blockA := &block.FileBlock{
+		ID:    "payload-test/0",
+		Hash:  hashA,
+		State: block.BlockStatePending,
+	}
+
+	// Block B: truly dirty/in-flight — zero hash.
+	// Both before and after fix -> BlocksDirty (correct).
+	blockB := &block.FileBlock{
+		ID:    "payload-test/8388608",
+		Hash:  block.ContentHash{}, // zero
+		State: block.BlockStatePending,
+	}
+
+	// Block C: Remote — must go to BlocksRemote.
+	var hashC block.ContentHash
+	hashC[0] = 0xCD
+	blockC := &block.FileBlock{
+		ID:            "payload-test/16777216",
+		Hash:          hashC,
+		BlockStoreKey: "cas/cd/00/cd00",
+		State:         block.BlockStateRemote,
+	}
+
+	if err := fbs.Put(ctx, blockA); err != nil {
+		t.Fatalf("Put blockA: %v", err)
+	}
+	if err := fbs.Put(ctx, blockB); err != nil {
+		t.Fatalf("Put blockB: %v", err)
+	}
+	if err := fbs.Put(ctx, blockC); err != nil {
+		t.Fatalf("Put blockC: %v", err)
+	}
+
+	// Register the payload so ListFiles returns it and ListFileBlocks is called.
+	if _, err := bs.WriteAt(ctx, "payload-test", nil, []byte("x"), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	stats := bs.GetStats()
+
+	if stats.BlocksTotal != 3 {
+		t.Errorf("BlocksTotal: got %d, want 3", stats.BlocksTotal)
+	}
+	if stats.BlocksLocal != 1 {
+		// Before fix this is 0 (block A goes to BlocksDirty).
+		t.Errorf("BlocksLocal: got %d, want 1 (block A — CAS Pending with non-zero hash)", stats.BlocksLocal)
+	}
+	if stats.BlocksDirty != 1 {
+		// Before fix this is 2 (block A is misclassified here).
+		t.Errorf("BlocksDirty: got %d, want 1 (block B — truly dirty, zero hash)", stats.BlocksDirty)
+	}
+	if stats.BlocksRemote != 1 {
+		t.Errorf("BlocksRemote: got %d, want 1 (block C)", stats.BlocksRemote)
+	}
 }

--- a/pkg/block/local/fs/drain_reset.go
+++ b/pkg/block/local/fs/drain_reset.go
@@ -265,20 +265,20 @@ func (bc *FSStore) ResetLocalState(_ context.Context) error {
 	}
 	bc.logBytesTotal.Store(0)
 
-	// Best-effort: remove any residual .log files left under the logs dir
-	// that had no live fd (e.g. orphaned by an interrupted DeleteAppendLog).
-	// A missing logs dir is fine — nothing was ever written.
+	// Best-effort: remove any residual .log files (including nested subdirs
+	// created by slash-bearing payloadIDs) that had no live fd — e.g.,
+	// orphaned by an interrupted DeleteAppendLog. Use RemoveAll + MkdirAll
+	// to clear the entire tree atomically rather than a flat ReadDir that
+	// misses nested layouts. A missing logs dir is fine — MkdirAll is
+	// skipped so we don't create an empty directory that never existed.
 	logsDir := filepath.Join(bc.baseDir, "logs")
-	if entries, derr := os.ReadDir(logsDir); derr == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			full := filepath.Join(logsDir, e.Name())
-			if rerr := os.Remove(full); rerr != nil && !os.IsNotExist(rerr) {
-				logger.Warn("ResetLocalState: residual log unlink failed",
-					"path", full, "error", rerr)
-			}
+	if _, serr := os.Stat(logsDir); serr == nil {
+		if rerr := os.RemoveAll(logsDir); rerr != nil {
+			logger.Warn("ResetLocalState: failed to remove logs dir",
+				"path", logsDir, "error", rerr)
+		} else if merr := os.MkdirAll(logsDir, 0755); merr != nil {
+			logger.Warn("ResetLocalState: failed to recreate logs dir after removal",
+				"path", logsDir, "error", merr)
 		}
 	}
 

--- a/pkg/block/local/fs/drain_reset_test.go
+++ b/pkg/block/local/fs/drain_reset_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -273,5 +276,103 @@ func TestResetLocalState_DropsStaleLog(t *testing.T) {
 	}
 	if !bytes.Equal(got, snapBytes) {
 		t.Fatalf("ResetLocalState did not drop stale log: read returned mutated bytes (C2 corruption)\n got[:8]=%q want[:8]=%q", got[:8], snapBytes[:8])
+	}
+}
+
+// TestResetLocalState_DropsNestedLog reproduces the residual-log bug for
+// slash-bearing payloadIDs. logPath produces a nested file
+// ({baseDir}/logs/{share}/{path}.log); the old flat os.ReadDir sweep
+// only saw top-level entries and skipped subdirectories, leaving stale
+// log files in place after a restore. After ResetLocalState, no .log
+// files must exist anywhere under the logs/ directory tree.
+func TestResetLocalState_DropsNestedLog(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	fbs := newMemFileBlockStore()
+	persister := func(ctx context.Context, payloadID string, blocks []block.BlockRef, _ block.ObjectID) error {
+		return fbs.persist(ctx, payloadID, blocks)
+	}
+
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+
+	ctx := context.Background()
+	// Slash-bearing payloadID: log lands at logs/myshare/subdir/fileA.log
+	const payloadID = "myshare/subdir/fileA"
+
+	// Snapshot state: write and drain to CAS.
+	snapBytes := bytes.Repeat([]byte{'A'}, 4096)
+	if err := bc.AppendWrite(ctx, payloadID, snapBytes, 0); err != nil {
+		t.Fatalf("AppendWrite snapshot: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	// Post-snapshot mutation: log-only, not rolled up.
+	mutBytes := bytes.Repeat([]byte{'B'}, 4096)
+	if err := bc.AppendWrite(ctx, payloadID, mutBytes, 0); err != nil {
+		t.Fatalf("AppendWrite mutation: %v", err)
+	}
+
+	// Confirm the nested log file actually exists on disk before reset.
+	logFile := filepath.Join(bc.baseDir, "logs", "myshare", "subdir", "fileA.log")
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("expected nested log file at %s before reset: %v", logFile, err)
+	}
+
+	// Orphan the log fd: close it and drop the logFDs entry while leaving
+	// the .log file on disk. This models the production residual case the
+	// sweep is meant to catch — an interrupted DeleteAppendLog or a restart
+	// where the file survived but no live fd references it. The per-shard
+	// teardown loop in ResetLocalState only unlinks paths it finds via live
+	// fds, so an orphaned nested log can ONLY be removed by the residual
+	// sweep. The old flat os.ReadDir sweep skipped subdirectories and thus
+	// left this nested file in place after reset.
+	sh := bc.shardFor(payloadID)
+	sh.mu.Lock()
+	if lf := sh.logFDs[payloadID]; lf != nil && lf.f != nil {
+		_ = lf.f.Close()
+	}
+	delete(sh.logFDs, payloadID)
+	sh.mu.Unlock()
+
+	// The orphaned nested log must still be on disk.
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("expected orphaned nested log at %s to survive fd eviction: %v", logFile, err)
+	}
+
+	if err := bc.ResetLocalState(ctx); err != nil {
+		t.Fatalf("ResetLocalState: %v", err)
+	}
+
+	// PRIMARY ASSERTION: no .log files anywhere under logs/ after reset.
+	logsDir := filepath.Join(bc.baseDir, "logs")
+	var residual []string
+	_ = filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".log") {
+			residual = append(residual, path)
+		}
+		return nil
+	})
+	if len(residual) > 0 {
+		t.Fatalf("ResetLocalState left %d residual .log file(s) in nested subdirs (bug reproduced):\n%v",
+			len(residual), residual)
+	}
+
+	// SECONDARY ASSERTION: read resolves through CAS (snapshot bytes), not stale log.
+	got := make([]byte, 4096)
+	if _, err := bc.ReadPayloadAt(ctx, payloadID, got, 0); err != nil {
+		t.Fatalf("ReadPayloadAt after reset: %v", err)
+	}
+	if !bytes.Equal(got, snapBytes) {
+		t.Fatalf("stale log overlay after reset: got[:8]=%q want[:8]=%q", got[:8], snapBytes[:8])
 	}
 }


### PR DESCRIPTION
Remediates block/CAS store audit findings (#1081, Part of #1075). Signed commits; build/vet/gofmt + `-race ./pkg/block/...` green.

## HIGH
- **fix(block/fs): ResetLocalState drops nested append-logs** — flat `os.ReadDir` skipped subdirectories, so slash-bearing payloadIDs (`<share>/<path>`) left orphaned `logs/<share>/<path>.log` that replayed stale records over restored CAS content. Now `RemoveAll(logsDir)` + recreate.
- **fix(block/compression): codec pool poisoning** — zstd/lz4 encoders returned to the shared `sync.Pool` even when `Close` failed flushing → later consumer gets a poisoned encoder emitting corrupt output. Now only `Put` on success; nil handle to make double-Close a no-op.

## MED
- **fix(block/engine): reapSupersededFileBlocks zero-blocks** — `|| len(newBlocks)==0` short-circuit left prior FileBlock rows + CAS chunks orphaned on truncate-to-zero; added explicit fast-reap.
- **fix(block/engine): CAS-pending blocks mis-counted** — `populateBlockCounts` classified by LocalPath/BlockStoreKey (never set on CAS path) → CAS chunks counted Dirty not Local; now `!Hash.IsZero()`.
- block encryption keyprovider (kmip) hardening.

Each fix lands with a test (fail-before/pass-after).

Fixes #1081
Part of #1075