### PR TITLE
fix(test/e2e): remediate v1.0 audit conformance/e2e findings (#1083)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -383,7 +383,7 @@
 
               # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
               # Manual: go run scripts/update-nix-hash.go
-              vendorHash = "sha256-GlGTkoYjjie3hh6ViJ7oMLery1Lv+dBXxnbjmqKLXPg=";
+              vendorHash = "sha256-QFZio1k/Dn+QLdYikMpoiziA61FYtt/5DdW3mXRCgpA=";
 
               ldflags = [
                 "-s"

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.2 // indirect
-	github.com/aws/smithy-go v1.23.2 // indirect
+	github.com/aws/smithy-go v1.23.2
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/test/e2e/cross_protocol_lock_test.go
+++ b/test/e2e/cross_protocol_lock_test.go
@@ -318,7 +318,14 @@ func testCrossProtocolConflict(t *testing.T, nfsMount, smbMount *framework.Mount
 		t.Logf("XPRO-03: SMB shared lock blocked (platform-specific): %v", err)
 	} else {
 		t.Log("XPRO-03: SMB shared lock acquired (multiple readers)")
-		defer framework.UnlockFileRange(t, smbSharedLock)
+		// Safety-net release for early bail-outs. Step 4 releases the lock
+		// explicitly and nils smbSharedLock, making this deferred call a no-op
+		// on the happy path (avoids a double unlock of the same handle).
+		defer func() {
+			if smbSharedLock != nil {
+				framework.UnlockFileRange(t, smbSharedLock)
+			}
+		}()
 	}
 
 	// Step 3: Attempt exclusive lock via NFS (should fail - SMB shared exists if acquired)

--- a/test/e2e/cross_protocol_lock_test.go
+++ b/test/e2e/cross_protocol_lock_test.go
@@ -171,16 +171,15 @@ func testNFSLockBlocksSMBLease(t *testing.T, nfsMount, smbMount *framework.Mount
 	// Step 4: Try to acquire lock via SMB using flock
 	// This should either fail (if SMB translates to byte-range lock) or succeed
 	// (if SMB uses only leases for caching). Platform behavior varies.
+	// SMB exclusive lock MUST be blocked: DittoFS routes both NFS (NLM) and SMB byte-range
+	// locks through the same unified lock manager, so overlapping exclusive locks across
+	// protocols must conflict regardless of the kernel's own lock-namespace separation.
 	smbLock, err := framework.TryLockFileRange(t, smbPath, 0, 0, true)
-	if err != nil {
-		t.Logf("XPRO-01: SMB exclusive lock blocked as expected (cross-protocol conflict): %v", err)
-		// This is the expected behavior - NFS lock should block SMB lock
-	} else {
-		// On some platforms, SMB locks may not conflict with NFS locks
-		// at the kernel level (independent lock namespaces)
-		t.Logf("XPRO-01: SMB lock acquired (platform-specific behavior - independent lock namespaces)")
+	if smbLock != nil {
 		framework.UnlockFileRange(t, smbLock)
 	}
+	assert.ErrorIs(t, err, framework.ErrLockWouldBlock,
+		"XPRO-01: SMB exclusive lock must be blocked by DittoFS unified lock manager while NFS exclusive lock is held")
 
 	// Step 5: Release NFS lock
 	framework.UnlockFileRange(t, nfsLock)
@@ -324,12 +323,22 @@ func testCrossProtocolConflict(t *testing.T, nfsMount, smbMount *framework.Mount
 
 	// Step 3: Attempt exclusive lock via NFS (should fail - SMB shared exists if acquired)
 	nfsExclusiveLock, err := framework.TryLockFileRange(t, nfsPath, 0, 0, true)
-	if err != nil {
-		t.Logf("XPRO-03: NFS exclusive lock correctly blocked while shared locks exist: %v", err)
+	if smbSharedLock != nil {
+		// SMB shared lock is held — NFS exclusive MUST be blocked by the unified lock manager.
+		if nfsExclusiveLock != nil {
+			framework.UnlockFileRange(t, nfsExclusiveLock)
+		}
+		assert.ErrorIs(t, err, framework.ErrLockWouldBlock,
+			"XPRO-03: NFS exclusive lock must be blocked while cross-protocol SMB shared lock is held")
 	} else {
-		// This might happen if SMB shared lock wasn't acquired
-		t.Log("XPRO-03: NFS exclusive lock acquired (no conflicting locks)")
-		framework.UnlockFileRange(t, nfsExclusiveLock)
+		// SMB shared lock was not acquired (conservative platform behaviour); NFS exclusive
+		// is uncontested by SMB and may legitimately succeed.
+		if nfsExclusiveLock != nil {
+			t.Log("XPRO-03: NFS exclusive lock acquired (no active SMB shared lock to conflict)")
+			framework.UnlockFileRange(t, nfsExclusiveLock)
+		} else {
+			t.Logf("XPRO-03: NFS exclusive lock blocked by own NFS shared lock (expected): %v", err)
+		}
 	}
 
 	// Step 4: Release SMB lock (if acquired)
@@ -596,13 +605,14 @@ func testOverlappingByteRangeLockConflict(t *testing.T, nfsMount, smbMount *fram
 	t.Log("NFS locked bytes [256:768]")
 
 	// SMB attempts lock on [0:512] - overlaps with NFS [256:768]
+	// Overlapping byte-range locks across protocols MUST conflict via DittoFS's unified
+	// lock manager. NFS holds [256:768]; SMB [0:512] overlaps in [256:512] — must block.
 	smbLock, err := framework.TryLockFileRange(t, smbPath, 0, 512, true)
-	if err != nil {
-		t.Logf("SMB lock on [0:512] correctly blocked due to overlap with NFS [256:768]: %v", err)
-	} else {
-		t.Log("SMB lock on [0:512] unexpectedly acquired (platform-specific lock namespaces)")
+	if smbLock != nil {
 		framework.UnlockFileRange(t, smbLock)
 	}
+	assert.ErrorIs(t, err, framework.ErrLockWouldBlock,
+		"overlapping cross-protocol byte-range lock [0:512] must be blocked by NFS lock [256:768]")
 
 	framework.UnlockFileRange(t, nfsLock)
 	nfsLock = nil

--- a/test/e2e/framework/containers.go
+++ b/test/e2e/framework/containers.go
@@ -168,18 +168,12 @@ type S3ObjectInfo struct {
 	Size int64
 }
 
-// ListS3PrefixWithSizes lists all objects under the given prefix in
-// the given bucket, returning their key + size. DEDUP-02 + DEDUP-03
-// use this for byte-summation assertions; mirrors the CleanupBucket
-// enumeration pattern.
-func (lh *LocalstackHelper) ListS3PrefixWithSizes(t *testing.T, bucket, prefix string) []S3ObjectInfo {
-	t.Helper()
-	if lh.Client == nil {
-		t.Fatalf("ListS3PrefixWithSizes: S3 client not initialized")
-	}
-	var out []S3ObjectInfo
+// listAllObjects paginates ListObjectsV2 (max 1000 entries/page) and returns
+// every object under prefix in bucket. It is the single enumeration primitive
+// behind both ListS3PrefixWithSizes and CleanupBucket.
+func (lh *LocalstackHelper) listAllObjects(ctx context.Context, bucket, prefix string) ([]types.Object, error) {
+	var out []types.Object
 	var continuation *string
-	ctx := context.Background()
 	for {
 		resp, err := lh.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(bucket),
@@ -187,23 +181,40 @@ func (lh *LocalstackHelper) ListS3PrefixWithSizes(t *testing.T, bucket, prefix s
 			ContinuationToken: continuation,
 		})
 		if err != nil {
-			t.Fatalf("ListS3PrefixWithSizes: list %s/%s: %v", bucket, prefix, err)
+			return nil, err
 		}
-		for _, obj := range resp.Contents {
-			var size int64
-			if obj.Size != nil {
-				size = *obj.Size
-			}
-			key := ""
-			if obj.Key != nil {
-				key = *obj.Key
-			}
-			out = append(out, S3ObjectInfo{Key: key, Size: size})
-		}
+		out = append(out, resp.Contents...)
 		if resp.IsTruncated == nil || !*resp.IsTruncated {
 			break
 		}
 		continuation = resp.NextContinuationToken
+	}
+	return out, nil
+}
+
+// ListS3PrefixWithSizes lists all objects under the given prefix in
+// the given bucket, returning their key + size. DEDUP-02 + DEDUP-03
+// use this for byte-summation assertions.
+func (lh *LocalstackHelper) ListS3PrefixWithSizes(t *testing.T, bucket, prefix string) []S3ObjectInfo {
+	t.Helper()
+	if lh.Client == nil {
+		t.Fatalf("ListS3PrefixWithSizes: S3 client not initialized")
+	}
+	objs, err := lh.listAllObjects(context.Background(), bucket, prefix)
+	if err != nil {
+		t.Fatalf("ListS3PrefixWithSizes: list %s/%s: %v", bucket, prefix, err)
+	}
+	out := make([]S3ObjectInfo, 0, len(objs))
+	for _, obj := range objs {
+		var size int64
+		if obj.Size != nil {
+			size = *obj.Size
+		}
+		key := ""
+		if obj.Key != nil {
+			key = *obj.Key
+		}
+		out = append(out, S3ObjectInfo{Key: key, Size: size})
 	}
 	return out
 }
@@ -222,24 +233,13 @@ func (lh *LocalstackHelper) ListS3Prefix(t *testing.T, bucket, prefix string) []
 
 // CleanupBucket removes a bucket and all its contents if it exists.
 func (lh *LocalstackHelper) CleanupBucket(ctx context.Context, bucketName string) {
-	// Paginate through all objects — ListObjectsV2 returns at most 1000 per page.
-	var toDelete []types.ObjectIdentifier
-	var continuation *string
-	for {
-		resp, err := lh.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(bucketName),
-			ContinuationToken: continuation,
-		})
-		if err != nil {
-			return // Bucket does not exist or is inaccessible; nothing to do.
-		}
-		for _, obj := range resp.Contents {
-			toDelete = append(toDelete, types.ObjectIdentifier{Key: obj.Key})
-		}
-		if resp.IsTruncated == nil || !*resp.IsTruncated {
-			break
-		}
-		continuation = resp.NextContinuationToken
+	objs, err := lh.listAllObjects(ctx, bucketName, "")
+	if err != nil {
+		return // Bucket does not exist or is inaccessible; nothing to do.
+	}
+	toDelete := make([]types.ObjectIdentifier, len(objs))
+	for i, obj := range objs {
+		toDelete[i] = types.ObjectIdentifier{Key: obj.Key}
 	}
 
 	// Delete in batches of up to 1000 (S3 DeleteObjects limit).
@@ -249,10 +249,9 @@ func (lh *LocalstackHelper) CleanupBucket(ctx context.Context, bucketName string
 		if end > len(toDelete) {
 			end = len(toDelete)
 		}
-		batch := toDelete[i:end]
 		_, err := lh.Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 			Bucket: aws.String(bucketName),
-			Delete: &types.Delete{Objects: batch},
+			Delete: &types.Delete{Objects: toDelete[i:end]},
 		})
 		if err != nil {
 			lh.T.Logf("CleanupBucket: failed to delete objects from %s: %v", bucketName, err)

--- a/test/e2e/framework/containers.go
+++ b/test/e2e/framework/containers.go
@@ -13,6 +13,7 @@ import (
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -221,25 +222,48 @@ func (lh *LocalstackHelper) ListS3Prefix(t *testing.T, bucket, prefix string) []
 
 // CleanupBucket removes a bucket and all its contents if it exists.
 func (lh *LocalstackHelper) CleanupBucket(ctx context.Context, bucketName string) {
-	listResp, err := lh.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(bucketName),
-	})
-	if err != nil {
-		return // Bucket doesn't exist
+	// Paginate through all objects — ListObjectsV2 returns at most 1000 per page.
+	var toDelete []types.ObjectIdentifier
+	var continuation *string
+	for {
+		resp, err := lh.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucketName),
+			ContinuationToken: continuation,
+		})
+		if err != nil {
+			return // Bucket does not exist or is inaccessible; nothing to do.
+		}
+		for _, obj := range resp.Contents {
+			toDelete = append(toDelete, types.ObjectIdentifier{Key: obj.Key})
+		}
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		continuation = resp.NextContinuationToken
 	}
 
-	if listResp != nil {
-		for _, obj := range listResp.Contents {
-			_, _ = lh.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-				Bucket: aws.String(bucketName),
-				Key:    obj.Key,
-			})
+	// Delete in batches of up to 1000 (S3 DeleteObjects limit).
+	const batchSize = 1000
+	for i := 0; i < len(toDelete); i += batchSize {
+		end := i + batchSize
+		if end > len(toDelete) {
+			end = len(toDelete)
+		}
+		batch := toDelete[i:end]
+		_, err := lh.Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucketName),
+			Delete: &types.Delete{Objects: batch},
+		})
+		if err != nil {
+			lh.T.Logf("CleanupBucket: failed to delete objects from %s: %v", bucketName, err)
 		}
 	}
 
-	_, _ = lh.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+	if _, err := lh.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(bucketName),
-	})
+	}); err != nil {
+		lh.T.Logf("CleanupBucket: failed to delete bucket %s: %v", bucketName, err)
+	}
 }
 
 // Cleanup removes all created buckets and their contents.

--- a/test/e2e/framework/containers_cleanup_test.go
+++ b/test/e2e/framework/containers_cleanup_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestCleanupBucket_PaginatesAndDeletesAll verifies that CleanupBucket
+// paginates past the 1000-object ListObjectsV2 page boundary and removes
+// every object before deleting the bucket. With the pre-fix implementation
+// (single un-paginated list) the trailing 500 objects survive and DeleteBucket
+// fails with BucketNotEmpty, leaving the bucket present.
+func TestCleanupBucket_PaginatesAndDeletesAll(t *testing.T) {
+	if !CheckLocalstackAvailable(t) {
+		t.Skip("Localstack not available")
+	}
+
+	lh := NewLocalstackHelper(t)
+	ctx := context.Background()
+
+	bucketName := fmt.Sprintf("cleanup-pagination-%d", rand.Int63())
+	if err := lh.CreateBucket(ctx, bucketName); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	// Upload 1500 zero-byte objects — one page boundary above 1000.
+	const objectCount = 1500
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(50)
+	for i := 0; i < objectCount; i++ {
+		key := fmt.Sprintf("obj-%05d", i)
+		g.Go(func() error {
+			_, err := lh.Client.PutObject(gctx, &s3.PutObjectInput{
+				Bucket: aws.String(bucketName),
+				Key:    aws.String(key),
+				Body:   strings.NewReader(""),
+			})
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("uploading objects: %v", err)
+	}
+
+	// Sanity: confirm all objects are present before cleanup.
+	if got := len(lh.ListS3Prefix(t, bucketName, "")); got != objectCount {
+		t.Fatalf("setup: expected %d objects, got %d", objectCount, got)
+	}
+
+	lh.CleanupBucket(ctx, bucketName)
+
+	// The bucket must no longer exist.
+	_, err := lh.Client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err == nil {
+		// Secondary guard: surface how many objects remained.
+		remaining := lh.ListS3Prefix(t, bucketName, "")
+		t.Fatalf("bucket %s still exists after CleanupBucket; %d objects remain", bucketName, len(remaining))
+	}
+
+	// Confirm the error is a not-found (404 / NoSuchBucket), not some other
+	// transport failure that would mask a real bug.
+	var notFound *types.NotFound
+	var noSuchBucket *types.NoSuchBucket
+	var respErr *smithyhttp.ResponseError
+	switch {
+	case errors.As(err, &notFound):
+	case errors.As(err, &noSuchBucket):
+	case errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404:
+	default:
+		t.Fatalf("HeadBucket returned unexpected error (want 404/NoSuchBucket): %v", err)
+	}
+}

--- a/test/e2e/helpers/cli.go
+++ b/test/e2e/helpers/cli.go
@@ -190,6 +190,14 @@ func UniqueTestName(prefix string) string {
 func LoginAsAdmin(t *testing.T, serverURL string) *CLIRunner {
 	t.Helper()
 
+	// Isolate credential storage to a per-test temp dir so dfsctl login never
+	// reads or writes the developer's real ~/.config/dfsctl/config.json.
+	// dfsctl login writes XDG_CONFIG_HOME/dfsctl/config.json; the child process
+	// inherits this env, and extractTokenFromLogin reads from the same path.
+	// t.Setenv restores the original value and t.TempDir removes the directory
+	// when the test ends.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	runner := NewCLIRunner(serverURL, "")
 
 	// Try to login as admin

--- a/test/e2e/helpers/cli.go
+++ b/test/e2e/helpers/cli.go
@@ -20,6 +20,15 @@ type CLIRunner struct {
 	serverURL string
 	token     string
 	binary    string
+
+	// xdgConfigHome, when non-empty, isolates this runner's dfsctl credential
+	// storage. Every dfsctl invocation runs with XDG_CONFIG_HOME set to this
+	// directory (set per-exec, not via a process-global env mutation), and the
+	// runner's token extraction reads config.json from this same directory.
+	// This keeps credential I/O confined to a per-test temp dir regardless of
+	// call order. When empty, dfsctl inherits the ambient environment and
+	// token extraction falls back to XDG_CONFIG_HOME / ~/.config.
+	xdgConfigHome string
 }
 
 // NewCLIRunner creates a new CLI runner for the given server URL and auth token.
@@ -91,6 +100,7 @@ func (r *CLIRunner) ServerURL() string {
 func (r *CLIRunner) execDfsctl(args ...string) ([]byte, error) {
 	binary := r.getBinary()
 	cmd := exec.Command(binary, args...)
+	cmd.Env = r.commandEnv()
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -110,6 +120,7 @@ func (r *CLIRunner) execDfsctl(args ...string) ([]byte, error) {
 func (r *CLIRunner) execDfsctlWithInput(input string, args ...string) ([]byte, error) {
 	binary := r.getBinary()
 	cmd := exec.Command(binary, args...)
+	cmd.Env = r.commandEnv()
 
 	cmd.Stdin = strings.NewReader(input)
 
@@ -124,6 +135,35 @@ func (r *CLIRunner) execDfsctlWithInput(input string, args ...string) ([]byte, e
 	}
 
 	return stdout.Bytes(), nil
+}
+
+// commandEnv returns the environment for a dfsctl child process. When the
+// runner is isolated, XDG_CONFIG_HOME is overridden per-exec so credential I/O
+// stays confined to the runner's temp dir; otherwise the ambient environment
+// is inherited unchanged.
+func (r *CLIRunner) commandEnv() []string {
+	if r.xdgConfigHome == "" {
+		return nil // nil means inherit the parent's environment
+	}
+	return append(os.Environ(), "XDG_CONFIG_HOME="+r.xdgConfigHome)
+}
+
+// configHomeDir returns the directory dfsctl uses to resolve
+// <configHome>/dfsctl/config.json for this runner. It mirrors dfsctl's own
+// resolution: the runner's isolated dir when set, else XDG_CONFIG_HOME, else
+// ~/.config.
+func (r *CLIRunner) configHomeDir() (string, error) {
+	if r.xdgConfigHome != "" {
+		return r.xdgConfigHome, nil
+	}
+	if env := os.Getenv("XDG_CONFIG_HOME"); env != "" {
+		return env, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home dir: %w", err)
+	}
+	return filepath.Join(home, ".config"), nil
 }
 
 // getBinary returns the path to the dfsctl binary.
@@ -190,15 +230,16 @@ func UniqueTestName(prefix string) string {
 func LoginAsAdmin(t *testing.T, serverURL string) *CLIRunner {
 	t.Helper()
 
-	// Isolate credential storage to a per-test temp dir so dfsctl login never
-	// reads or writes the developer's real ~/.config/dfsctl/config.json.
-	// dfsctl login writes XDG_CONFIG_HOME/dfsctl/config.json; the child process
-	// inherits this env, and extractTokenFromLogin reads from the same path.
-	// t.Setenv restores the original value and t.TempDir removes the directory
-	// when the test ends.
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
 	runner := NewCLIRunner(serverURL, "")
+
+	// Isolate credential storage to a per-test temp dir so dfsctl login never
+	// reads or writes the developer's real ~/.config/dfsctl/config.json. The
+	// runner carries this dir and applies it as XDG_CONFIG_HOME on every dfsctl
+	// invocation (per-exec, not via a process-global env mutation), and reads
+	// the resulting config.json back from the same dir. t.TempDir is removed
+	// when the test ends. Any runner derived from this one (e.g. via
+	// LoginAsUser) inherits the same isolation.
+	runner.xdgConfigHome = t.TempDir()
 
 	// Try to login as admin
 	// The login command doesn't support --output json, so we use RunRaw
@@ -212,8 +253,11 @@ func LoginAsAdmin(t *testing.T, serverURL string) *CLIRunner {
 		t.Fatalf("Failed to login as admin: %v\nOutput: %s", err, string(output))
 	}
 
-	// Extract token from the login response or credentials file
-	token := extractTokenFromLogin(t, serverURL)
+	// Extract token from the credentials file in the runner's isolated dir.
+	token, err := runner.extractToken(serverURL)
+	if err != nil {
+		t.Fatalf("Failed to extract token after login: %v", err)
+	}
 	runner.SetToken(token)
 
 	return runner
@@ -234,56 +278,15 @@ func GetAdminPassword() string {
 	return "adminpassword"
 }
 
-// extractTokenFromLogin extracts the auth token after login.
-// This reads from the credentials file that dfsctl creates.
-func extractTokenFromLogin(t *testing.T, serverURL string) string {
-	t.Helper()
-
-	// Get credentials file path (matches internal/cli/credentials/store.go)
-	// Uses XDG_CONFIG_HOME or ~/.config
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			t.Fatalf("Failed to get home dir: %v", err)
-		}
-		configHome = filepath.Join(home, ".config")
-	}
-
-	credFile := filepath.Join(configHome, "dfsctl", "config.json")
-	data, err := os.ReadFile(credFile)
+// extractToken reads the auth token for serverURL from the dfsctl credentials
+// file in this runner's config dir. For an isolated runner that is the per-test
+// temp dir, so token extraction stays paired with the dir the login wrote to.
+func (r *CLIRunner) extractToken(serverURL string) (string, error) {
+	configHome, err := r.configHomeDir()
 	if err != nil {
-		t.Fatalf("Failed to read credentials file: %v", err)
+		return "", err
 	}
-
-	// Parse the credentials file
-	var creds map[string]interface{}
-	if err := json.Unmarshal(data, &creds); err != nil {
-		t.Fatalf("Failed to parse credentials file: %v", err)
-	}
-
-	// The credentials file stores contexts with server URLs
-	// Find the matching context
-	contexts, ok := creds["contexts"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("No contexts found in credentials file")
-	}
-
-	for _, ctx := range contexts {
-		ctxMap, ok := ctx.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		// Field name is "server_url" in JSON (snake_case)
-		if ctxMap["server_url"] == serverURL {
-			if token, ok := ctxMap["access_token"].(string); ok {
-				return token
-			}
-		}
-	}
-
-	t.Fatalf("No token found for server %s in credentials file", serverURL)
-	return ""
+	return parseTokenFromCredentialsFile(configHome, serverURL)
 }
 
 // ParseJSONResponse parses a JSON response into the given struct.

--- a/test/e2e/helpers/users.go
+++ b/test/e2e/helpers/users.go
@@ -271,8 +271,9 @@ func (r *CLIRunner) Login(serverURL, username, password string) (string, error) 
 		return "", fmt.Errorf("login failed: %w\noutput: %s", err, string(output))
 	}
 
-	// Extract token from credentials file
-	token, err := extractTokenFromCredentialsFile(serverURL)
+	// Extract token from the credentials file in this runner's config dir
+	// (the isolated temp dir when the runner was created via LoginAsAdmin).
+	token, err := r.extractToken(serverURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract token after login: %w", err)
 	}
@@ -281,9 +282,13 @@ func (r *CLIRunner) Login(serverURL, username, password string) (string, error) 
 }
 
 // LoginAsUser creates a new CLIRunner logged in as the specified user.
+// The derived runner inherits the receiver's credential isolation, so a user
+// login performed through an isolated admin runner stays confined to the same
+// per-test temp dir.
 func (r *CLIRunner) LoginAsUser(serverURL, username, password string) (*CLIRunner, error) {
-	// Create a new runner for this user
+	// Create a new runner for this user, inheriting the isolated config dir.
 	newRunner := NewCLIRunner(serverURL, "")
+	newRunner.xdgConfigHome = r.xdgConfigHome
 
 	token, err := newRunner.Login(serverURL, username, password)
 	if err != nil {
@@ -294,14 +299,10 @@ func (r *CLIRunner) LoginAsUser(serverURL, username, password string) (*CLIRunne
 	return newRunner, nil
 }
 
-// extractTokenFromCredentialsFile reads the token from the credentials file.
-// This is the internal version used by other helpers.
-func extractTokenFromCredentialsFile(serverURL string) (string, error) {
-	return ExtractTokenFromCredentialsFile(serverURL)
-}
-
-// ExtractTokenFromCredentialsFile reads the token from the credentials file.
-// Exported version for use in tests that need direct token extraction.
+// ExtractTokenFromCredentialsFile reads the token from the credentials file in
+// the ambient config location (XDG_CONFIG_HOME or ~/.config). Exported for
+// tests that drive dfsctl through a non-isolated runner and need to read the
+// token directly. Isolated runners should use extractToken instead.
 func ExtractTokenFromCredentialsFile(serverURL string) (string, error) {
 	// Get credentials file path (matches internal/cli/credentials/store.go)
 	// Uses XDG_CONFIG_HOME or ~/.config
@@ -314,6 +315,13 @@ func ExtractTokenFromCredentialsFile(serverURL string) (string, error) {
 		configHome = filepath.Join(home, ".config")
 	}
 
+	return parseTokenFromCredentialsFile(configHome, serverURL)
+}
+
+// parseTokenFromCredentialsFile reads <configHome>/dfsctl/config.json and
+// returns the access token for serverURL. Shared by the runner-scoped and
+// ambient token extractors so both honor the same on-disk format.
+func parseTokenFromCredentialsFile(configHome, serverURL string) (string, error) {
 	credFile := filepath.Join(configHome, "dfsctl", "config.json")
 	data, err := os.ReadFile(credFile)
 	if err != nil {

--- a/test/e2e/login_isolation_test.go
+++ b/test/e2e/login_isolation_test.go
@@ -12,36 +12,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLoginAsAdmin_XDGIsolation verifies that LoginAsAdmin does not read or
-// write the developer's real ~/.config/dfsctl/config.json.
+// TestLoginAsAdmin_XDGIsolation proves that LoginAsAdmin confines all dfsctl
+// credential I/O to its own per-test temp dir and never reads or writes the
+// developer's ambient ~/.config/dfsctl/config.json (or the XDG_CONFIG_HOME
+// location).
 //
-// Fail-before: with XDG_CONFIG_HOME unset, LoginAsAdmin lets dfsctl login fall
-// back to ~/.config/dfsctl/config.json, creating or overwriting real
-// credentials on disk.
+// The test points the ambient XDG_CONFIG_HOME at a controlled directory that it
+// owns, then asserts that after LoginAsAdmin:
+//   - no dfsctl/config.json was created under that ambient directory, and
+//   - the token LoginAsAdmin returned is the one written into the isolated dir,
+//     proving the credential lives in the temp tree rather than the ambient one.
 //
-// Pass-after: LoginAsAdmin sets XDG_CONFIG_HOME to a fresh t.TempDir() before
-// invoking dfsctl login, so all credential I/O is confined to a temp tree that
-// is removed when the test ends and the real ~/.config is never touched.
+// This fails if the isolation is removed: a non-isolating LoginAsAdmin would let
+// dfsctl write config.json into the ambient XDG_CONFIG_HOME, tripping the
+// "ambient location untouched" assertion.
 func TestLoginAsAdmin_XDGIsolation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping login isolation test in short mode")
 	}
 
-	// Force the unprotected fallback path: with XDG_CONFIG_HOME empty, a
-	// non-isolating LoginAsAdmin would write the real ~/.config/dfsctl/config.json.
-	// t.Setenv restores any prior value when the test ends.
-	t.Setenv("XDG_CONFIG_HOME", "")
-	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+	// Point the ambient config location at a directory this test owns. A
+	// non-isolating LoginAsAdmin would write its credentials here; an isolating
+	// one must leave it empty. t.Setenv restores the prior value at test end,
+	// and using a fresh temp dir means we never touch the real ~/.config.
+	ambientConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", ambientConfigHome)
+	ambientCredFile := filepath.Join(ambientConfigHome, "dfsctl", "config.json")
 
-	// Capture the real home config file so we can assert it is not touched.
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-	realCredFile := filepath.Join(home, ".config", "dfsctl", "config.json")
-
-	// Snapshot the real cred file's existence + contents before the test so we
-	// can detect both creation and overwrite of a pre-existing file.
-	beforeData, beforeErr := os.ReadFile(realCredFile)
-	realCredExistedBefore := beforeErr == nil
+	// Sanity check: the ambient credentials file does not exist yet.
+	_, statErr := os.Stat(ambientCredFile)
+	require.True(t, os.IsNotExist(statErr),
+		"precondition: ambient cred file must not exist before login")
 
 	sp := helpers.StartServerProcess(t, "")
 	t.Cleanup(sp.ForceKill)
@@ -51,17 +52,19 @@ func TestLoginAsAdmin_XDGIsolation(t *testing.T) {
 	// LoginAsAdmin must return a runner with a non-empty token.
 	require.NotEmpty(t, runner.Token(), "LoginAsAdmin must return a non-empty token")
 
-	// The real ~/.config/dfsctl/config.json must not have been created or
-	// modified by this test run. A self-isolating LoginAsAdmin points dfsctl at
-	// a per-test temp dir, so the real file is never created and, if it already
-	// existed, its contents are left byte-for-byte unchanged.
-	afterData, afterErr := os.ReadFile(realCredFile)
-	if realCredExistedBefore {
-		require.NoError(t, afterErr, "real cred file disappeared during test")
-		assert.Equal(t, beforeData, afterData,
-			"LoginAsAdmin must not modify the real ~/.config/dfsctl/config.json")
-	} else {
-		assert.True(t, os.IsNotExist(afterErr),
-			"LoginAsAdmin must not create the real ~/.config/dfsctl/config.json; stat err: %v", afterErr)
-	}
+	// The ambient XDG_CONFIG_HOME must be untouched: a self-isolating
+	// LoginAsAdmin points dfsctl at its own temp dir, so no config.json appears
+	// under the ambient location.
+	_, afterErr := os.Stat(ambientCredFile)
+	assert.True(t, os.IsNotExist(afterErr),
+		"LoginAsAdmin must not write credentials into the ambient XDG_CONFIG_HOME; stat err: %v", afterErr)
+
+	// The token must NOT be resolvable from the ambient location either: reading
+	// the ambient credentials file should fail because it was never created.
+	// This proves the token came from the isolated dir, not the ambient one.
+	ambientToken, ambientTokenErr := helpers.ExtractTokenFromCredentialsFile(sp.APIURL())
+	assert.Error(t, ambientTokenErr,
+		"no token should be resolvable from the ambient config location")
+	assert.Empty(t, ambientToken,
+		"ambient config location must not yield a token")
 }

--- a/test/e2e/login_isolation_test.go
+++ b/test/e2e/login_isolation_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/test/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoginAsAdmin_XDGIsolation verifies that LoginAsAdmin does not read or
+// write the developer's real ~/.config/dfsctl/config.json.
+//
+// Fail-before: with XDG_CONFIG_HOME unset, LoginAsAdmin lets dfsctl login fall
+// back to ~/.config/dfsctl/config.json, creating or overwriting real
+// credentials on disk.
+//
+// Pass-after: LoginAsAdmin sets XDG_CONFIG_HOME to a fresh t.TempDir() before
+// invoking dfsctl login, so all credential I/O is confined to a temp tree that
+// is removed when the test ends and the real ~/.config is never touched.
+func TestLoginAsAdmin_XDGIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping login isolation test in short mode")
+	}
+
+	// Force the unprotected fallback path: with XDG_CONFIG_HOME empty, a
+	// non-isolating LoginAsAdmin would write the real ~/.config/dfsctl/config.json.
+	// t.Setenv restores any prior value when the test ends.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+
+	// Capture the real home config file so we can assert it is not touched.
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	realCredFile := filepath.Join(home, ".config", "dfsctl", "config.json")
+
+	// Snapshot the real cred file's existence + contents before the test so we
+	// can detect both creation and overwrite of a pre-existing file.
+	beforeData, beforeErr := os.ReadFile(realCredFile)
+	realCredExistedBefore := beforeErr == nil
+
+	sp := helpers.StartServerProcess(t, "")
+	t.Cleanup(sp.ForceKill)
+
+	runner := helpers.LoginAsAdmin(t, sp.APIURL())
+
+	// LoginAsAdmin must return a runner with a non-empty token.
+	require.NotEmpty(t, runner.Token(), "LoginAsAdmin must return a non-empty token")
+
+	// The real ~/.config/dfsctl/config.json must not have been created or
+	// modified by this test run. A self-isolating LoginAsAdmin points dfsctl at
+	// a per-test temp dir, so the real file is never created and, if it already
+	// existed, its contents are left byte-for-byte unchanged.
+	afterData, afterErr := os.ReadFile(realCredFile)
+	if realCredExistedBefore {
+		require.NoError(t, afterErr, "real cred file disappeared during test")
+		assert.Equal(t, beforeData, afterData,
+			"LoginAsAdmin must not modify the real ~/.config/dfsctl/config.json")
+	} else {
+		assert.True(t, os.IsNotExist(afterErr),
+			"LoginAsAdmin must not create the real ~/.config/dfsctl/config.json; stat err: %v", afterErr)
+	}
+}


### PR DESCRIPTION
Remediates conformance/e2e test-framework audit findings (#1083, Part of #1075). All changes under `test/e2e/` (no production code). Signed commits; `go build ./...` + `go build/vet -tags e2e ./test/e2e/...` + gofmt clean. (e2e runtime suite needs sudo + kernel NFS/SMB clients — not run in CI.)

## Fixes
- **fix(e2e): isolate dfsctl credentials** — e2e `dfsctl login` wrote to the developer's real `~/.config/dfsctl/config.json`. Now self-contained per-`CLIRunner` `XDG_CONFIG_HOME` set per-exec (`cmd.Env`), covering `LoginAsAdmin`/`Login`/`LoginAsUser` regardless of call order. Regression test rewritten to genuinely prove the real config is untouched (fails if isolation removed).
- **fix(test/e2e): CleanupBucket pagination** — single un-paginated `ListObjectsV2` (max 1000) left overflow → `DeleteBucket` failed `BucketNotEmpty` (error discarded) → leaked buckets. Now paginates + batch-`DeleteObjects`.
- **test(e2e): harden cross-protocol lock assertions** — XPRO-01/03 + overlapping byte-range tests accepted both outcomes (log-only); now hard-assert `ErrLockWouldBlock` so they actually catch unenforced cross-protocol lock conflicts.

Fixes #1083
Part of #1075