### PR TITLE
fix(metadata/lock): remediate v1.0 audit locks & ACL findings (#1080)

### DIFF
--- a/pkg/metadata/acl/inherit.go
+++ b/pkg/metadata/acl/inherit.go
@@ -337,7 +337,18 @@ func PropagateACL(parentACL *ACL, existingACL *ACL, isDirectory bool, creator Cr
 	combined = append(combined, explicit...)
 	combined = append(combined, inheritedACEs...)
 
-	result := &ACL{ACEs: combined}
+	// Preserve the child's own per-SD flags: SE_DACL_PROTECTED (blocks ancestor
+	// propagation), the ACL source, and the null-DACL marker are properties of
+	// the child SD and are never inherited — so they must survive a propagation
+	// pass rather than being silently zeroed. Erasing Protected here would let a
+	// subsequent pass overwrite the child's explicitly protected ACEs with
+	// parent-derived ones.
+	result := &ACL{
+		ACEs:      combined,
+		Source:    existingACL.Source,
+		Protected: existingACL.Protected,
+		NullDACL:  existingACL.NullDACL,
+	}
 	// MS-DTYP §2.5.3.4.2: SE_DACL_AUTO_INHERITED propagates from parent to
 	// child on the child's recomputed SD. Protected is per-SD and never
 	// inherited. See ComputeInheritedACL for spec/Samba references.

--- a/pkg/metadata/acl/inherit_test.go
+++ b/pkg/metadata/acl/inherit_test.go
@@ -340,6 +340,100 @@ func TestPropagateACL_ReplacesInheritedKeepsExplicit(t *testing.T) {
 	}
 }
 
+// TestPropagateACL_PreservesChildSDFlags is the regression net for the audit
+// finding that PropagateACL silently cleared the child's per-SD flags
+// (Protected/Source/NullDACL) on every parent-ACL-change propagation pass.
+// Protected=true on a child blocks ancestor propagation; erasing it lets the
+// next pass overwrite the child's explicitly protected ACEs with parent-derived
+// ones. Source and NullDACL are likewise per-SD and must survive. AutoInherited
+// is intentionally governed by the parent and is asserted separately.
+func TestPropagateACL_PreservesChildSDFlags(t *testing.T) {
+	newParentACL := &ACL{
+		ACEs: []ACE{
+			{
+				Type:       ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Flag:       ACE4_FILE_INHERIT_ACE,
+				AccessMask: ACE4_READ_DATA | ACE4_EXECUTE,
+				Who:        SpecialOwner,
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		parentACL         *ACL
+		existing          *ACL
+		wantProtected     bool
+		wantNullDACL      bool
+		wantSource        ACLSource
+		wantAutoInherited bool
+	}{
+		{
+			name:      "Protected preserved on child",
+			parentACL: newParentACL,
+			existing: &ACL{
+				Protected: true,
+				Source:    ACLSourceSMBExplicit,
+				ACEs: []ACE{
+					{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: "alice@example.com"},
+				},
+			},
+			wantProtected: true,
+			wantSource:    ACLSourceSMBExplicit,
+		},
+		{
+			name:      "NullDACL and Source preserved",
+			parentACL: newParentACL,
+			existing: &ACL{
+				NullDACL: true,
+				Source:   ACLSourceNFSExplicit,
+				ACEs: []ACE{
+					{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: "bob@example.com"},
+				},
+			},
+			wantNullDACL: true,
+			wantSource:   ACLSourceNFSExplicit,
+		},
+		{
+			name: "AutoInherited propagates from parent over child value",
+			parentACL: &ACL{
+				AutoInherited: true,
+				ACEs:          newParentACL.ACEs,
+			},
+			existing: &ACL{
+				Protected:     true,
+				AutoInherited: false,
+				ACEs: []ACE{
+					{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: "carol@example.com"},
+				},
+			},
+			wantProtected:     true,
+			wantAutoInherited: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PropagateACL(tt.parentACL, tt.existing, false, Creator{})
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result.Protected != tt.wantProtected {
+				t.Errorf("Protected: got %v, want %v (child SD flag must survive propagation)", result.Protected, tt.wantProtected)
+			}
+			if result.NullDACL != tt.wantNullDACL {
+				t.Errorf("NullDACL: got %v, want %v", result.NullDACL, tt.wantNullDACL)
+			}
+			if result.Source != tt.wantSource {
+				t.Errorf("Source: got %q, want %q", result.Source, tt.wantSource)
+			}
+			if result.AutoInherited != tt.wantAutoInherited {
+				t.Errorf("AutoInherited: got %v, want %v", result.AutoInherited, tt.wantAutoInherited)
+			}
+		})
+	}
+}
+
 func TestPropagateACL_NilExisting(t *testing.T) {
 	parentACL := &ACL{ACEs: []ACE{
 		{

--- a/pkg/metadata/acl/mode.go
+++ b/pkg/metadata/acl/mode.go
@@ -96,7 +96,18 @@ func AdjustACLForMode(a *ACL, newMode uint32) *ACL {
 		}
 	}
 
-	return &ACL{ACEs: newACEs}
+	// Preserve the SD-level flags: chmod only rewrites the special-identifier
+	// rwx bits, it never changes whether the DACL is protected from ancestor
+	// inheritance, auto-inherited, a null DACL, or its source. Dropping these
+	// (especially Protected) would silently re-expose a shielded object to
+	// ancestor propagation on the next ComputeInheritedACL pass.
+	return &ACL{
+		ACEs:          newACEs,
+		Source:        a.Source,
+		Protected:     a.Protected,
+		AutoInherited: a.AutoInherited,
+		NullDACL:      a.NullDACL,
+	}
 }
 
 // rwxMaskBits is the set of ACE mask bits that correspond to rwx permissions.

--- a/pkg/metadata/acl/mode_test.go
+++ b/pkg/metadata/acl/mode_test.go
@@ -274,6 +274,62 @@ func TestAdjustACLForMode_DoesNotModifyOriginal(t *testing.T) {
 	}
 }
 
+// TestAdjustACLForMode_PreservesSDFlags is the regression net for the audit
+// finding that AdjustACLForMode returned a fresh &ACL{ACEs: newACEs} and thereby
+// dropped the SD-level flags (Protected/AutoInherited/NullDACL/Source) on every
+// chmod. Dropping Protected re-exposes a shielded object to ancestor
+// propagation; dropping AutoInherited causes inheritance-flag drift.
+func TestAdjustACLForMode_PreservesSDFlags(t *testing.T) {
+	baseACEs := []ACE{
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialGroup},
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+	}
+
+	tests := []struct {
+		name string
+		in   *ACL
+	}{
+		{
+			name: "Protected and Source preserved",
+			in:   &ACL{Protected: true, Source: ACLSourceSMBExplicit, ACEs: baseACEs},
+		},
+		{
+			name: "AutoInherited preserved",
+			in:   &ACL{AutoInherited: true, Source: ACLSourceNFSExplicit, ACEs: baseACEs},
+		},
+		{
+			name: "NullDACL preserved",
+			in:   &ACL{NullDACL: true, Source: ACLSourceWindowsDefault, ACEs: baseACEs},
+		},
+		{
+			name: "all SD flags set",
+			in:   &ACL{Protected: true, AutoInherited: true, NullDACL: true, Source: ACLSourcePOSIXDerived, ACEs: baseACEs},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AdjustACLForMode(tt.in, 0755)
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result.Protected != tt.in.Protected {
+				t.Errorf("Protected dropped on chmod: got %v, want %v", result.Protected, tt.in.Protected)
+			}
+			if result.AutoInherited != tt.in.AutoInherited {
+				t.Errorf("AutoInherited dropped on chmod: got %v, want %v", result.AutoInherited, tt.in.AutoInherited)
+			}
+			if result.NullDACL != tt.in.NullDACL {
+				t.Errorf("NullDACL dropped on chmod: got %v, want %v", result.NullDACL, tt.in.NullDACL)
+			}
+			if result.Source != tt.in.Source {
+				t.Errorf("Source dropped on chmod: got %q, want %q", result.Source, tt.in.Source)
+			}
+		})
+	}
+}
+
 func TestModeRoundTrip(t *testing.T) {
 	// Set mode -> derive mode should match.
 	modes := []uint32{0755, 0644, 0777, 0000, 0700, 0500, 0400}

--- a/pkg/metadata/lock/cross_protocol_test.go
+++ b/pkg/metadata/lock/cross_protocol_test.go
@@ -103,6 +103,91 @@ func TestConflictsWith_AccessMode_BothNoneNoConflict(t *testing.T) {
 	}
 }
 
+// TestConflictsWith_AccessMode_DenyHolderBlocksNoneOpener is the regression
+// test for the AND-vs-OR bug: a holder with a deny mode must block a new
+// opener even when the new opener carries AccessModeNone.
+//
+// Before the fix, accessModesConflict required BOTH sides to be non-None
+// (AND), so a DenyRead/DenyWrite/DenyAll holder silently allowed a
+// None-mode opener through.
+func TestConflictsWith_AccessMode_DenyHolderBlocksNoneOpener(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		holderMode AccessMode
+	}{
+		{"DenyRead holder vs None opener", AccessModeDenyRead},
+		{"DenyWrite holder vs None opener", AccessModeDenyWrite},
+		{"DenyAll holder vs None opener", AccessModeDenyAll},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			holder := &UnifiedLock{
+				Owner:      LockOwner{OwnerID: "smb:client1"},
+				AccessMode: tc.holderMode,
+				Offset:     0, Length: 0, Type: LockTypeShared,
+			}
+			opener := &UnifiedLock{
+				Owner:      LockOwner{OwnerID: "smb:client2"},
+				AccessMode: AccessModeNone, // new opener imposes no deny
+				Offset:     0, Length: 0, Type: LockTypeShared,
+			}
+
+			if !holder.ConflictsWith(opener) {
+				t.Errorf("holder with %v must conflict with an AccessModeNone opener; deny-mode holder blocks ALL subsequent opens", tc.holderMode)
+			}
+			// Conflict is symmetric at this layer.
+			if !opener.ConflictsWith(holder) {
+				t.Errorf("opener with AccessModeNone vs %v holder must also conflict when checked from the opener side", tc.holderMode)
+			}
+		})
+	}
+}
+
+// TestConflictsWith_AccessMode_NoneHolderBlockedByDenyOpener is the mirror:
+// an existing opener with AccessModeNone must be blocked by a new opener
+// that arrives with a deny mode — the new opener is asserting exclusivity
+// that the existing None-open already violates.
+func TestConflictsWith_AccessMode_NoneHolderBlockedByDenyOpener(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		newMode AccessMode
+	}{
+		{"existing None vs new DenyRead", AccessModeDenyRead},
+		{"existing None vs new DenyWrite", AccessModeDenyWrite},
+		{"existing None vs new DenyAll", AccessModeDenyAll},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			existing := &UnifiedLock{
+				Owner:      LockOwner{OwnerID: "smb:client1"},
+				AccessMode: AccessModeNone,
+				Offset:     0, Length: 0, Type: LockTypeShared,
+			}
+			newcomer := &UnifiedLock{
+				Owner:      LockOwner{OwnerID: "smb:client2"},
+				AccessMode: tc.newMode,
+				Offset:     0, Length: 0, Type: LockTypeShared,
+			}
+
+			if !existing.ConflictsWith(newcomer) {
+				t.Errorf("existing None open must conflict with a new %v opener", tc.newMode)
+			}
+		})
+	}
+}
+
 // --- Case 2: OpLock vs OpLock ---
 
 func TestConflictsWith_OpLock_ReadReadNoConflict(t *testing.T) {

--- a/pkg/metadata/lock/grace_phase2_test.go
+++ b/pkg/metadata/lock/grace_phase2_test.go
@@ -86,7 +86,7 @@ func TestReclaimLease_MarksClientReclaimed(t *testing.T) {
 	require.True(t, lm.IsInGracePeriod(), "grace must be active after EnterGracePeriod")
 
 	// Reclaim the lease.
-	_, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false)
+	_, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "client-1")
 	require.NoError(t, err, "lease reclaim during grace must succeed")
 
 	// The reclaim must have recorded the client; with the only expected client

--- a/pkg/metadata/lock/lease_interface_test.go
+++ b/pkg/metadata/lock/lease_interface_test.go
@@ -182,7 +182,7 @@ func TestLockManager_HasLeaseOperations(t *testing.T) {
 	_ = err
 
 	// ReclaimLease should exist
-	_, err = lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false)
+	_, err = lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "")
 	_ = err
 
 	// GetLeaseState should exist

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1307,7 +1307,7 @@ func TestReclaimLease_NotInGracePeriod(t *testing.T) {
 	leaseKey := [16]byte{1, 2, 3}
 
 	// Not in grace period - should fail
-	_, err := mgr.ReclaimLease(ctx, leaseKey, LeaseStateRead, false)
+	_, err := mgr.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "")
 	assert.Error(t, err, "should fail when not in grace period")
 }
 

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -140,9 +140,12 @@ type LockManager interface {
 	ReleaseLeaseForHandle(ctx context.Context, handleKey string, leaseKey [16]byte) error
 
 	// ReclaimLease reclaims a lease during grace period (both SMB and NFS).
+	// clientID must match the owner recorded on the persisted lease; a
+	// mismatch is rejected to prevent lease-stealing. Pass "" to skip the
+	// owner check (callers without a stable client identity).
 	// Returns the reclaimed lock or error if lease doesn't exist or directory deleted.
 	ReclaimLease(ctx context.Context, leaseKey [16]byte,
-		requestedState uint32, isDirectory bool) (*UnifiedLock, error)
+		requestedState uint32, isDirectory bool, clientID string) (*UnifiedLock, error)
 
 	// GetLeaseState returns the current state and epoch for a lease key.
 	// found=false if no lease exists with that key.
@@ -696,9 +699,14 @@ type Manager struct {
 	gracePeriod    *GracePeriodManager       // grace period state (may be nil)
 	handleChecker  HandleChecker             // checks if file handles still exist (for reclaim)
 	lockStore      LockStore                 // persistent lock store (optional)
-	epoch          uint64                    // current server epoch (stamped on persisted locks)
-	shareName      string                    // share this manager serves (stamped on persisted byte-range locks)
-	recentlyBroken *recentlyBrokenCache      // prevents directory lease storms
+
+	// clientRecoveryStore is the NFSv4 client recovery store used for
+	// principal verification during lease reclaim. Optional — nil disables
+	// the NFSv4 principal check (SMB-only deployments).
+	clientRecoveryStore ClientRecoveryStore
+	epoch               uint64               // current server epoch (stamped on persisted locks)
+	shareName           string               // share this manager serves (stamped on persisted byte-range locks)
+	recentlyBroken      *recentlyBrokenCache // prevents directory lease storms
 
 	// Delegation-related fields
 	breakWaitChans          map[string]chan struct{} // per-handleKey channel for break wait
@@ -1107,6 +1115,15 @@ func (lm *Manager) SetLockStore(store LockStore) {
 	lm.lockStore = store
 }
 
+// SetClientRecoveryStore wires the NFSv4 client recovery store used for
+// principal verification during lease reclaim. Optional — when nil the
+// NFSv4 principal check is skipped (SMB-only deployments).
+func (lm *Manager) SetClientRecoveryStore(store ClientRecoveryStore) {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	lm.clientRecoveryStore = store
+}
+
 // SetEpoch records the current server epoch stamped on persisted locks.
 func (lm *Manager) SetEpoch(epoch uint64) {
 	lm.mu.Lock()
@@ -1390,10 +1407,24 @@ func (lm *Manager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
 	return lm.releaseLeaseImpl(ctx, leaseKey)
 }
 
-// ReclaimLease reclaims a lease during grace period.
+// ReclaimLease reclaims a lease during grace period. clientID must match the
+// lease owner recorded on the persisted record (lease-stealing guard); pass ""
+// to skip the owner check. This is the LockManager-interface entrypoint used by
+// SMB, which has no RPCSEC_GSS principal to verify.
 func (lm *Manager) ReclaimLease(ctx context.Context, leaseKey [16]byte,
-	requestedState uint32, isDirectory bool) (*UnifiedLock, error) {
-	return lm.reclaimLeaseImpl(ctx, leaseKey, requestedState, isDirectory)
+	requestedState uint32, isDirectory bool, clientID string) (*UnifiedLock, error) {
+	return lm.reclaimLeaseImpl(ctx, leaseKey, requestedState, isDirectory, clientID, "")
+}
+
+// ReclaimLeaseWithPrincipal is the NFSv4 reclaim path that additionally
+// verifies the incoming RPCSEC_GSS / AUTH_SYS principal matches the one
+// recorded in the V4ClientRecoveryRecord for clientID. The principal check
+// runs only when a ClientRecoveryStore is wired (SetClientRecoveryStore) and
+// incomingPrincipal is non-empty; an empty principal skips the check. Returns
+// a lock-not-found error when the clientID or principal does not match.
+func (lm *Manager) ReclaimLeaseWithPrincipal(ctx context.Context, leaseKey [16]byte,
+	requestedState uint32, isDirectory bool, clientID string, incomingPrincipal string) (*UnifiedLock, error) {
+	return lm.reclaimLeaseImpl(ctx, leaseKey, requestedState, isDirectory, clientID, incomingPrincipal)
 }
 
 // ReleaseLeaseForHandle removes lease records matching leaseKey from a
@@ -2778,24 +2809,59 @@ func delegationToLockType(dt DelegationType) LockType {
 
 // RevokeDelegation force-revokes a delegation, removing it from the lock map.
 func (lm *Manager) RevokeDelegation(handleKey string, delegationID string) error {
-	lm.mu.Lock()
+	found := lm.removeMatchingLocksAndSignal(handleKey, false, func(l *UnifiedLock) bool {
+		return l.Delegation != nil && l.Delegation.DelegationID == delegationID
+	})
+	if !found {
+		return fmt.Errorf("delegation %s not found on handle %s", delegationID, handleKey)
+	}
+	return nil
+}
 
-	locks := lm.unifiedLocks[handleKey]
-	found := false
+// revokeTimedOutLease removes all in-memory lease records matching leaseKey
+// from handleKey, deletes their persisted records (best-effort), and signals
+// WaitForBreakCompletion waiters. Called by OpLockBreakScanner after the
+// persistent record has already been deleted by the scanner's DeleteLock call;
+// this method handles the in-memory half.
+//
+// This is the lease analogue of RevokeDelegation: same mutex discipline,
+// same signalBreakWait call so parked CREATEs unblock immediately rather
+// than waiting for their context deadline.
+func (lm *Manager) revokeTimedOutLease(handleKey string, leaseKey [16]byte) {
+	// Best-effort delete of each removed record's persisted copy: the scanner
+	// already deleted the canonical PersistedLock by ID; this handles any
+	// sibling records sharing the same LeaseKey.
+	lm.removeMatchingLocksAndSignal(handleKey, true, func(l *UnifiedLock) bool {
+		return l.Lease != nil && l.Lease.LeaseKey == leaseKey
+	})
+}
+
+// removeMatchingLocksAndSignal removes every UnifiedLock on handleKey for which
+// match returns true, then wakes any WaitForBreakCompletion / parked-CREATE
+// waiters. When deletePersisted is true, each removed lock's persisted record is
+// deleted (best-effort) under lm.mu. Returns true if at least one lock matched.
+//
+// Shared by RevokeDelegation and revokeTimedOutLease: same mutex discipline,
+// same post-unlock signalBreakWait so parked CREATEs unblock immediately rather
+// than waiting for their context deadline.
+func (lm *Manager) removeMatchingLocksAndSignal(handleKey string, deletePersisted bool, match func(*UnifiedLock) bool) bool {
+	lm.mu.Lock()
 	var remaining []*UnifiedLock
-	for _, l := range locks {
-		if l.Delegation != nil && l.Delegation.DelegationID == delegationID {
+	found := false
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if match(l) {
 			found = true
-			continue // Drop from remaining (removed from map)
+			if deletePersisted {
+				lm.deleteUnifiedLockLocked(l)
+			}
+			continue
 		}
 		remaining = append(remaining, l)
 	}
-
 	if !found {
 		lm.mu.Unlock()
-		return fmt.Errorf("delegation %s not found on handle %s", delegationID, handleKey)
+		return false
 	}
-
 	if len(remaining) == 0 {
 		delete(lm.unifiedLocks, handleKey)
 	} else {
@@ -2804,7 +2870,7 @@ func (lm *Manager) RevokeDelegation(handleKey string, delegationID string) error
 	lm.mu.Unlock()
 
 	lm.signalBreakWait(handleKey)
-	return nil
+	return true
 }
 
 // ReturnDelegation handles a client returning a delegation. Idempotent:

--- a/pkg/metadata/lock/oplock_break.go
+++ b/pkg/metadata/lock/oplock_break.go
@@ -270,8 +270,14 @@ func (s *OpLockBreakScanner) scanExpiredLeaseBreaks(now time.Time) {
 			continue
 		}
 
-		// Check if break has expired (AcquiredAt is updated when break initiated)
-		breakDeadline := pl.AcquiredAt.Add(timeout)
+		// Check if break has expired (BreakStarted is set when break initiated)
+		breakRef := pl.BreakStarted
+		if breakRef.IsZero() {
+			// Legacy record persisted before BreakStarted was stored.
+			// Use now as the break reference: conservative — never prematurely revoke.
+			breakRef = now
+		}
+		breakDeadline := breakRef.Add(timeout)
 		if !now.After(breakDeadline) {
 			continue
 		}
@@ -281,7 +287,7 @@ func (s *OpLockBreakScanner) scanExpiredLeaseBreaks(now time.Time) {
 
 		logger.Debug("OpLockBreakScanner: break timeout expired",
 			"leaseKey", fmt.Sprintf("%x", leaseKey),
-			"breakStarted", pl.AcquiredAt,
+			"breakStarted", breakRef,
 			"deadline", breakDeadline,
 			"timeout", timeout)
 
@@ -295,6 +301,13 @@ func (s *OpLockBreakScanner) scanExpiredLeaseBreaks(now time.Time) {
 
 		logger.Debug("OpLockBreakScanner: lease force-revoked",
 			"leaseKey", fmt.Sprintf("%x", leaseKey))
+
+		// Evict the in-memory record and unblock any WaitForBreakCompletion
+		// waiters BEFORE notifying the callback. Ordering:
+		// store delete → in-memory evict + signal → callback notification.
+		if s.lockManager != nil {
+			s.lockManager.revokeTimedOutLease(pl.FileID, leaseKey)
+		}
 
 		if s.callback != nil {
 			s.callback.OnLeaseBreakTimeout(leaseKey)

--- a/pkg/metadata/lock/oplock_break_test.go
+++ b/pkg/metadata/lock/oplock_break_test.go
@@ -148,7 +148,8 @@ func createBreakingLease(id string, leaseKey [16]byte, breakStart time.Time) *Pe
 		LeaseState:   LeaseStateRead | LeaseStateWrite,
 		Breaking:     true,
 		BreakToState: LeaseStateRead,
-		AcquiredAt:   breakStart, // Break start time
+		AcquiredAt:   breakStart,
+		BreakStarted: breakStart, // break-clock, not grant-clock
 	}
 }
 
@@ -444,5 +445,174 @@ func TestOpLockBreakScanner_ByteRangeLocksIgnored(t *testing.T) {
 	locks, _ := store.ListLocks(context.Background(), LockQuery{})
 	if len(locks) != 1 {
 		t.Errorf("Expected byte-range lock to still exist, but found %d locks", len(locks))
+	}
+}
+
+// TestOpLockBreakScanner_UsesBreakStartedNotAcquiredAt verifies that the
+// scanner measures timeout from BreakStarted, not AcquiredAt. A lease held
+// for a long time (large AcquiredAt offset) must NOT be revoked if
+// BreakStarted is recent.
+func TestOpLockBreakScanner_UsesBreakStartedNotAcquiredAt(t *testing.T) {
+	store := newMockLockStore()
+	callback := &mockOpLockBreakCallback{}
+
+	// 200ms timeout, 10ms scan interval.
+	scanner := NewOpLockBreakScannerWithInterval(store, callback, 200*time.Millisecond, 10*time.Millisecond)
+
+	var leaseKey [16]byte
+	copy(leaseKey[:], []byte("longheldbreaklse"))
+
+	// Lease was granted 10 minutes ago (AcquiredAt far in the past),
+	// but the break was only initiated just now (BreakStarted = now).
+	pl := &PersistedLock{
+		ID:           "lease-longheld",
+		ShareName:    "share1",
+		FileID:       "file1",
+		OwnerID:      "smb:client1",
+		ClientID:     "client1",
+		LeaseKey:     leaseKey[:],
+		LeaseState:   LeaseStateRead | LeaseStateWrite,
+		Breaking:     true,
+		BreakToState: LeaseStateRead,
+		AcquiredAt:   time.Now().Add(-10 * time.Minute), // very old grant
+		BreakStarted: time.Now(),                        // break JUST started
+	}
+	_ = store.PutLock(context.Background(), pl)
+
+	scanner.Start()
+	defer scanner.Stop()
+
+	// Wait 3 scan cycles — well under the 200ms break timeout.
+	time.Sleep(50 * time.Millisecond)
+
+	// Callback must NOT have fired: the break just started, not yet expired.
+	if len(callback.getTimedOutKeys()) != 0 {
+		t.Fatal("scanner revoked a long-held lease whose break just started (using AcquiredAt instead of BreakStarted)")
+	}
+	locks, _ := store.ListLocks(context.Background(), LockQuery{})
+	if len(locks) != 1 {
+		t.Fatalf("expected lease to still exist, got %d locks", len(locks))
+	}
+}
+
+// TestOpLockBreakScanner_LegacyZeroBreakStartedNotRevoked verifies the
+// backwards-compatibility path: a breaking lease persisted before BreakStarted
+// existed has a zero BreakStarted. The scanner must treat that conservatively
+// (reference = now) and NOT immediately revoke it, even though AcquiredAt is far
+// in the past. Otherwise every legacy in-flight break would be revoked on the
+// first scan after upgrade.
+func TestOpLockBreakScanner_LegacyZeroBreakStartedNotRevoked(t *testing.T) {
+	store := newMockLockStore()
+	callback := &mockOpLockBreakCallback{}
+
+	// 5s timeout so a "now" reference cannot expire during the test window.
+	scanner := NewOpLockBreakScannerWithInterval(store, callback, 5*time.Second, 10*time.Millisecond)
+
+	var leaseKey [16]byte
+	copy(leaseKey[:], []byte("legacynobreakset"))
+
+	pl := &PersistedLock{
+		ID:           "legacy-lease",
+		ShareName:    "share1",
+		FileID:       "file1",
+		OwnerID:      "smb:client1",
+		ClientID:     "client1",
+		LeaseKey:     leaseKey[:],
+		LeaseState:   LeaseStateRead | LeaseStateWrite,
+		Breaking:     true,
+		BreakToState: LeaseStateRead,
+		AcquiredAt:   time.Now().Add(-10 * time.Minute), // old grant
+		// BreakStarted intentionally left zero (legacy record).
+	}
+	_ = store.PutLock(context.Background(), pl)
+
+	scanner.Start()
+	defer scanner.Stop()
+
+	time.Sleep(60 * time.Millisecond) // several scan cycles
+
+	if len(callback.getTimedOutKeys()) != 0 {
+		t.Fatal("scanner revoked a legacy zero-BreakStarted lease on first scan (should use now as reference)")
+	}
+	locks, _ := store.ListLocks(context.Background(), LockQuery{})
+	if len(locks) != 1 {
+		t.Fatalf("expected legacy lease to still exist, got %d locks", len(locks))
+	}
+}
+
+// TestOpLockBreakScanner_RevokeUnblocksWaitForBreakCompletion verifies that
+// after the scanner force-revokes a timed-out lease from the store, any
+// goroutine blocked in Manager.WaitForBreakCompletion is unblocked promptly
+// (well within the context deadline) rather than waiting for its own deadline.
+func TestOpLockBreakScanner_RevokeUnblocksWaitForBreakCompletion(t *testing.T) {
+	ctx := context.Background()
+
+	store := newMockLockStore()
+	lm := NewManager()
+	lm.SetLockStore(store)
+
+	// 100ms break timeout, 20ms scan interval — fast for testing.
+	scanner := NewOpLockBreakScannerWithInterval(store, nil, 100*time.Millisecond, 20*time.Millisecond)
+	scanner.SetLockManager(lm)
+
+	var leaseKey [16]byte
+	copy(leaseKey[:], []byte("waitunblockkey12"))
+
+	// Add breaking lease to both Manager (in-memory) and store (persisted).
+	breakingLock := &UnifiedLock{
+		ID:         "lease-wait-test",
+		Owner:      LockOwner{OwnerID: "smb:client1", ClientID: "client1", ShareName: "share1"},
+		FileHandle: FileHandle("file-wait"),
+		Type:       LockTypeShared,
+		AcquiredAt: time.Now().Add(-5 * time.Minute), // granted long ago
+		Lease: &OpLock{
+			LeaseKey:     leaseKey,
+			LeaseState:   LeaseStateRead | LeaseStateWrite,
+			Breaking:     true,
+			BreakToState: LeaseStateRead,
+			BreakStarted: time.Now().Add(-200 * time.Millisecond), // break already expired
+		},
+	}
+	// Insert directly into in-memory map to bypass conflict-check path.
+	lm.mu.Lock()
+	lm.unifiedLocks["file-wait"] = append(lm.unifiedLocks["file-wait"], breakingLock)
+	lm.mu.Unlock()
+
+	// Persist it so the scanner can find it.
+	pl := ToPersistedLock(breakingLock, 1)
+	pl.ShareName = "share1"
+	_ = store.PutLock(ctx, pl)
+
+	scanner.Start()
+	defer scanner.Stop()
+
+	// WaitForBreakCompletion with a 2-second deadline: if Bug 2 is present the
+	// goroutine blocks for the full 2s and returns DeadlineExceeded.
+	// With the fix it returns nil well within 500ms (the scanner fires within
+	// 100ms+20ms).
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- lm.WaitForBreakCompletion(waitCtx, "file-wait")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitForBreakCompletion returned error after scanner revoke: %v", err)
+		}
+		// Pass: unblocked before the 2s deadline.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WaitForBreakCompletion was not unblocked within 500ms after scanner force-revoke (Bug 2 not fixed)")
+	}
+
+	// Verify in-memory lease is gone.
+	lm.mu.RLock()
+	remaining := lm.unifiedLocks["file-wait"]
+	lm.mu.RUnlock()
+	if len(remaining) != 0 {
+		t.Fatalf("expected no in-memory leases after revoke, got %d", len(remaining))
 	}
 }

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -12,9 +12,7 @@ package lock
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
@@ -22,12 +20,29 @@ import (
 //
 // Steps:
 //  1. Check grace period is active (reclaim only allowed during grace)
-//  2. Query persistent store for the lease by leaseKey
-//  3. For directories, verify handle still exists via HandleChecker
-//  4. Validate requestedState matches or is subset of persisted state
-//  5. Restore lease in memory and return the reclaimed UnifiedLock
+//  2. Query persistent store for the lease, pre-filtered by clientID when non-empty
+//  3. Assert the persisted record's ClientID matches clientID (lease-stealing guard)
+//  4. Optionally assert incomingPrincipal matches V4ClientRecoveryRecord.Principal
+//  5. For directories, verify handle still exists via HandleChecker
+//  6. Validate requestedState is a subset of the persisted state
+//  7. Restore lease in memory and return the reclaimed UnifiedLock
+//
+// clientID is the reclaiming client's stable identity. When non-empty it is
+// both pushed into the store query AND re-asserted against the matched record;
+// a mismatch is rejected with a lock-not-found error so one client cannot steal
+// another's lease. When empty, the owner check is skipped (callers with no
+// stable client identity).
+//
+// incomingPrincipal is the RPCSEC_GSS / AUTH_SYS principal of the reclaiming
+// NFSv4 client. The principal check runs only when lm.clientRecoveryStore is
+// wired and incomingPrincipal is non-empty; SMB callers pass "".
+//
+// When no lockStore is configured:
+//   - If the lease is already in memory, mark it reclaimed and return it.
+//   - Otherwise return an explicit error; there is no file handle to anchor a
+//     stub, and returning a dangling, uncleanable object would orphan it.
 func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
-	requestedState uint32, isDirectory bool) (*UnifiedLock, error) {
+	requestedState uint32, isDirectory bool, clientID string, incomingPrincipal string) (*UnifiedLock, error) {
 
 	// Step 1: Check grace period
 	if !lm.IsInGracePeriod() {
@@ -37,9 +52,11 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 	// Step 2: Try to find persisted lease via lockStore
 	if lm.lockStore != nil {
 		isLease := true
-		persistedLocks, err := lm.lockStore.ListLocks(ctx, LockQuery{
-			IsLease: &isLease,
-		})
+		query := LockQuery{IsLease: &isLease}
+		if clientID != "" {
+			query.ClientID = clientID
+		}
+		persistedLocks, err := lm.lockStore.ListLocks(ctx, query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query persisted leases: %w", err)
 		}
@@ -55,20 +72,55 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				continue
 			}
 
+			// Step 3: Caller-identity check — reject lease-stealing. The store
+			// query is already filtered by clientID when non-empty, but assert
+			// here too so an over-permissive store backend cannot let a wrong
+			// client through (defence in depth at the trust boundary).
+			if clientID != "" && pl.ClientID != clientID {
+				logger.Debug("ReclaimLease: clientID mismatch, rejecting steal attempt",
+					"leaseKey", fmt.Sprintf("%x", leaseKey),
+					"wantClientID", clientID,
+					"gotClientID", pl.ClientID)
+				return nil, NewLockNotFoundError("")
+			}
+
+			// Step 4: NFSv4 principal check (only when the recovery store is
+			// wired and the caller supplied a principal to verify). A reclaiming
+			// client whose principal differs from the one recorded at confirm
+			// time must NOT reclaim another client's prior state.
+			if lm.clientRecoveryStore != nil && incomingPrincipal != "" {
+				recs, rerr := lm.clientRecoveryStore.ListClientRecovery(ctx)
+				if rerr != nil {
+					return nil, fmt.Errorf("failed to fetch client recovery records: %w", rerr)
+				}
+				for _, rec := range recs {
+					if rec.ClientIDString == pl.ClientID {
+						if rec.Principal != "" && rec.Principal != incomingPrincipal {
+							logger.Debug("ReclaimLease: principal mismatch, rejecting reclaim",
+								"leaseKey", fmt.Sprintf("%x", leaseKey),
+								"wantPrincipal", incomingPrincipal,
+								"recordPrincipal", rec.Principal)
+							return nil, NewLockNotFoundError("")
+						}
+						break
+					}
+				}
+			}
+
 			// Found matching persisted lease
 			// Validate isDirectory matches persisted record
 			if isDirectory != pl.IsDirectory {
 				return nil, fmt.Errorf("isDirectory mismatch: request=%v, persisted=%v", isDirectory, pl.IsDirectory)
 			}
 
-			// Step 3: For directories, check handle still exists
+			// Step 5: For directories, check handle still exists
 			if pl.IsDirectory && lm.handleChecker != nil {
 				if !lm.handleChecker.HandleExists(FileHandle(pl.FileID)) {
 					return nil, fmt.Errorf("directory handle no longer exists, cannot reclaim lease")
 				}
 			}
 
-			// Step 4: Validate requested state is subset of persisted
+			// Step 6: Validate requested state is subset of persisted
 			if requestedState&^pl.LeaseState != 0 {
 				return nil, fmt.Errorf("requested state %s exceeds persisted state %s",
 					LeaseStateToString(requestedState),
@@ -82,7 +134,7 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 			// manager's own mutex, not lm.mu, so it is safe outside lm.mu.
 			lm.MarkReclaimed(pl.ClientID)
 
-			// Step 5: Restore in memory (idempotent: skip if already reclaimed)
+			// Step 7: Restore in memory (idempotent: skip if already reclaimed)
 			lock := FromPersistedLock(pl)
 			lock.Lease.LeaseState = requestedState
 			lock.Reclaim = true
@@ -123,23 +175,9 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 		return existingLock.Clone(), nil
 	}
 
-	// Create a minimal reclaimed lease in memory
-	reclaimedLock := &UnifiedLock{
-		ID: uuid.New().String(),
-		Owner: LockOwner{
-			OwnerID: fmt.Sprintf("reclaim:%x", leaseKey),
-		},
-		AcquiredAt: time.Now(),
-		Reclaim:    true,
-		Lease: &OpLock{
-			LeaseKey:    leaseKey,
-			LeaseState:  requestedState,
-			IsDirectory: isDirectory,
-			Epoch:       1,
-		},
-	}
-
-	// We don't have a file handle for this lease without persistence
-	// This path is primarily for testing
-	return reclaimedLock, nil
+	// No lock store AND no in-memory lease: there is no file handle to anchor a
+	// stub, so fabricating one and returning it would orphan an object that
+	// RemoveFileUnifiedLocks / RemoveClientLocks can never clean up. Return an
+	// explicit error instead.
+	return nil, fmt.Errorf("cannot reclaim: no file handle and no lock store")
 }

--- a/pkg/metadata/lock/reclaim_test.go
+++ b/pkg/metadata/lock/reclaim_test.go
@@ -1,0 +1,226 @@
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockClientRecoveryStore implements ClientRecoveryStore for principal-check
+// tests. Only ListClientRecovery is exercised by reclaim; the rest are stubs.
+type mockClientRecoveryStore struct {
+	recs []*V4ClientRecoveryRecord
+}
+
+func (m *mockClientRecoveryStore) PutClientRecovery(ctx context.Context, rec *V4ClientRecoveryRecord) error {
+	m.recs = append(m.recs, rec)
+	return nil
+}
+
+func (m *mockClientRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	return nil
+}
+
+func (m *mockClientRecoveryStore) ListClientRecovery(ctx context.Context) ([]*V4ClientRecoveryRecord, error) {
+	return m.recs, nil
+}
+
+func (m *mockClientRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	return nil
+}
+
+// newGraceManagerWithStore builds a Manager in an active grace period backed by
+// a fresh mock lock store, sharing the given share name.
+func newGraceManagerWithStore(t *testing.T, expected []string) (*Manager, *mockLockStore) {
+	t.Helper()
+	store := newMockLockStore()
+	gpm := NewGracePeriodManager(time.Hour, nil)
+	lm := NewManagerWithGracePeriod(gpm)
+	lm.SetLockStore(store)
+	lm.SetShareName("share-a")
+	lm.EnterGracePeriod(expected)
+	require.True(t, lm.IsInGracePeriod(), "grace must be active after EnterGracePeriod")
+	return lm, store
+}
+
+func persistLease(t *testing.T, store *mockLockStore, id, clientID string, leaseKey [16]byte) {
+	t.Helper()
+	require.NoError(t, store.PutLock(context.Background(), &PersistedLock{
+		ID:         id,
+		ShareName:  "share-a",
+		FileID:     "share-a:file-1",
+		ClientID:   clientID,
+		LeaseKey:   leaseKey[:],
+		LeaseState: LeaseStateRead | LeaseStateHandle,
+	}))
+}
+
+// TestReclaimLease_RejectsWrongClientID pins the lease-stealing guard: a client
+// that did not own the persisted lease must not be able to reclaim it. Before
+// the fix reclaimLeaseImpl ignored the caller identity and returned the wrong
+// client's lease.
+func TestReclaimLease_RejectsWrongClientID(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"client-a"})
+
+	leaseKey := [16]byte{1, 2, 3, 4}
+	persistLease(t, store, "lease-1", "client-a", leaseKey)
+
+	lock, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "client-b")
+	require.Error(t, err, "reclaim by a non-owning client must be rejected")
+	require.Nil(t, lock, "no lock may be returned to a lease-stealing client")
+}
+
+// TestReclaimLease_AcceptsMatchingClientID is the positive control: the owning
+// client reclaims its own lease successfully.
+func TestReclaimLease_AcceptsMatchingClientID(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"client-a"})
+
+	leaseKey := [16]byte{1, 2, 3, 4}
+	persistLease(t, store, "lease-1", "client-a", leaseKey)
+
+	lock, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "client-a")
+	require.NoError(t, err, "owning client must reclaim its own lease")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim, "reclaimed lock must carry Reclaim=true")
+}
+
+// TestReclaimLease_NoLockStore_NoFileHandle_ReturnsError pins the orphaned-stub
+// fix: with no lock store and no in-memory lease, reclaim must return an error
+// rather than fabricating a dangling UnifiedLock that nothing can clean up.
+func TestReclaimLease_NoLockStore_NoFileHandle_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	gpm := NewGracePeriodManager(time.Hour, nil)
+	lm := NewManagerWithGracePeriod(gpm)
+	lm.EnterGracePeriod([]string{"client-a"})
+	require.True(t, lm.IsInGracePeriod())
+
+	leaseKey := [16]byte{9, 9, 9}
+	lock, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "client-a")
+	require.Error(t, err, "no lock store + no in-memory lease must error, not return a stub")
+	require.Nil(t, lock, "no orphan stub may be returned")
+	require.Contains(t, err.Error(), "cannot reclaim",
+		"error must explain the missing-handle condition")
+}
+
+// TestReclaimLease_NoLockStore_InMemoryLeaseFound_MarksReclaim covers the
+// no-lock-store path when the lease already lives in memory: it is marked
+// reclaimed and returned.
+func TestReclaimLease_NoLockStore_InMemoryLeaseFound_MarksReclaim(t *testing.T) {
+	ctx := context.Background()
+	gpm := NewGracePeriodManager(time.Hour, nil)
+	lm := NewManagerWithGracePeriod(gpm)
+	lm.EnterGracePeriod([]string{"client-a"})
+	require.True(t, lm.IsInGracePeriod())
+
+	leaseKey := [16]byte{4, 5, 6}
+	handleKey := "share-a:file-1"
+	require.NoError(t, lm.AddUnifiedLock(handleKey, &UnifiedLock{
+		ID:         "ul-1",
+		Owner:      LockOwner{OwnerID: "smb:s1:f1", ClientID: "client-a"},
+		FileHandle: FileHandle(handleKey),
+		Lease:      &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead | LeaseStateHandle},
+	}))
+
+	lock, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead, false, "client-a")
+	require.NoError(t, err, "an in-memory lease must reclaim without a lock store")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim, "reclaimed in-memory lock must carry Reclaim=true")
+}
+
+// TestReclaimLeaseWithPrincipal_RejectsWrongPrincipal pins the NFSv4 principal
+// guard: a reclaiming client whose principal differs from the one recorded at
+// confirm time must NOT reclaim the prior state.
+func TestReclaimLeaseWithPrincipal_RejectsWrongPrincipal(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"nfs4:1"})
+	lm.SetClientRecoveryStore(&mockClientRecoveryStore{recs: []*V4ClientRecoveryRecord{
+		{ClientIDString: "nfs4:1", Principal: "user@REALM"},
+	}})
+
+	leaseKey := [16]byte{2, 4, 6, 8}
+	persistLease(t, store, "lease-1", "nfs4:1", leaseKey)
+
+	lock, err := lm.ReclaimLeaseWithPrincipal(ctx, leaseKey, LeaseStateRead, false, "nfs4:1", "attacker@REALM")
+	require.Error(t, err, "principal mismatch must be rejected")
+	require.Nil(t, lock)
+}
+
+// TestReclaimLeaseWithPrincipal_AcceptsMatchingPrincipal is the positive
+// control: the matching principal reclaims successfully.
+func TestReclaimLeaseWithPrincipal_AcceptsMatchingPrincipal(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"nfs4:1"})
+	lm.SetClientRecoveryStore(&mockClientRecoveryStore{recs: []*V4ClientRecoveryRecord{
+		{ClientIDString: "nfs4:1", Principal: "user@REALM"},
+	}})
+
+	leaseKey := [16]byte{2, 4, 6, 8}
+	persistLease(t, store, "lease-1", "nfs4:1", leaseKey)
+
+	lock, err := lm.ReclaimLeaseWithPrincipal(ctx, leaseKey, LeaseStateRead, false, "nfs4:1", "user@REALM")
+	require.NoError(t, err, "matching principal must reclaim successfully")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim)
+}
+
+// TestReclaimLeaseWithPrincipal_SkipsCheckWhenPrincipalEmpty verifies an empty
+// incoming principal skips the principal check entirely (SMB and AUTH_SYS paths
+// with no RPCSEC_GSS principal still reclaim).
+func TestReclaimLeaseWithPrincipal_SkipsCheckWhenPrincipalEmpty(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"nfs4:1"})
+	lm.SetClientRecoveryStore(&mockClientRecoveryStore{recs: []*V4ClientRecoveryRecord{
+		{ClientIDString: "nfs4:1", Principal: "user@REALM"},
+	}})
+
+	leaseKey := [16]byte{2, 4, 6, 8}
+	persistLease(t, store, "lease-1", "nfs4:1", leaseKey)
+
+	lock, err := lm.ReclaimLeaseWithPrincipal(ctx, leaseKey, LeaseStateRead, false, "nfs4:1", "")
+	require.NoError(t, err, "empty incoming principal must skip the principal check")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim)
+}
+
+// TestReclaimLeaseWithPrincipal_SkipsCheckWhenRecordPrincipalEmpty verifies that
+// a recovery record with no recorded principal does not reject any reclaim:
+// there is nothing to compare against (e.g. AUTH_SYS confirm with no principal),
+// so the check must be skipped rather than spuriously denying recovery.
+func TestReclaimLeaseWithPrincipal_SkipsCheckWhenRecordPrincipalEmpty(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"nfs4:1"})
+	lm.SetClientRecoveryStore(&mockClientRecoveryStore{recs: []*V4ClientRecoveryRecord{
+		{ClientIDString: "nfs4:1", Principal: ""},
+	}})
+
+	leaseKey := [16]byte{2, 4, 6, 8}
+	persistLease(t, store, "lease-1", "nfs4:1", leaseKey)
+
+	lock, err := lm.ReclaimLeaseWithPrincipal(ctx, leaseKey, LeaseStateRead, false, "nfs4:1", "anyone@REALM")
+	require.NoError(t, err, "an empty recorded principal must skip the principal check")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim)
+}
+
+// TestReclaimLeaseWithPrincipal_NoRecoveryRecord verifies that when no recovery
+// record exists for the lease's ClientID, the principal check finds nothing to
+// compare and lets the reclaim proceed (the clientID guard already gated entry).
+func TestReclaimLeaseWithPrincipal_NoRecoveryRecord(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"nfs4:1"})
+	lm.SetClientRecoveryStore(&mockClientRecoveryStore{recs: []*V4ClientRecoveryRecord{
+		{ClientIDString: "some-other-client", Principal: "other@REALM"},
+	}})
+
+	leaseKey := [16]byte{2, 4, 6, 8}
+	persistLease(t, store, "lease-1", "nfs4:1", leaseKey)
+
+	lock, err := lm.ReclaimLeaseWithPrincipal(ctx, leaseKey, LeaseStateRead, false, "nfs4:1", "user@REALM")
+	require.NoError(t, err, "no recovery record for the clientID must not block reclaim")
+	require.NotNil(t, lock)
+	require.True(t, lock.Reclaim)
+}

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -106,6 +106,11 @@ type PersistedLock struct {
 	// False for byte-range locks.
 	Breaking bool `json:"breaking,omitempty"`
 
+	// BreakStarted is when the lease break was initiated (Breaking=true).
+	// Used by the scanner to compute the break deadline.
+	// Zero when not breaking. Omitted from storage for non-breaking leases.
+	BreakStarted time.Time `json:"break_started,omitempty"`
+
 	// ParentLeaseKey is the V2 parent lease key for cache tree correlation.
 	// Empty for byte-range locks and V1 leases.
 	ParentLeaseKey []byte `json:"parent_lease_key,omitempty"`
@@ -360,6 +365,9 @@ func ToPersistedLock(lock *UnifiedLock, epoch uint64) *PersistedLock {
 		pl.BreakToState = lock.Lease.BreakToState
 		pl.BreakingToRequired = lock.Lease.BreakingToRequired
 		pl.Breaking = lock.Lease.Breaking
+		if lock.Lease.Breaking {
+			pl.BreakStarted = lock.Lease.BreakStarted
+		}
 		pl.IsDirectory = lock.Lease.IsDirectory
 		pl.IsTraditionalOplock = lock.Lease.IsTraditionalOplock
 
@@ -431,7 +439,7 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 			ParentLeaseKey:      parentLeaseKey,
 			IsDirectory:         pl.IsDirectory,
 			IsTraditionalOplock: pl.IsTraditionalOplock,
-			// BreakStarted is runtime-only, not persisted
+			BreakStarted:        pl.BreakStarted,
 		}
 		// Backwards compat: locks persisted before BreakingToRequired existed
 		// have BreakingToRequired==0. The zero value is ambiguous (could mean

--- a/pkg/metadata/lock/store_test.go
+++ b/pkg/metadata/lock/store_test.go
@@ -177,7 +177,9 @@ func TestFromPersistedLock_Lease(t *testing.T) {
 	assert.Equal(t, uint32(0x01), lock.Lease.BreakToState)
 	assert.True(t, lock.Lease.Breaking)
 
-	// BreakStarted is runtime-only, should be zero
+	// BreakStarted was not set on this persisted record, so it round-trips
+	// as zero. (When set on a breaking lease it IS persisted — see
+	// TestPersistedLock_RoundTrip_Lease.)
 	assert.True(t, lock.Lease.BreakStarted.IsZero())
 }
 
@@ -238,6 +240,7 @@ func TestPersistedLock_RoundTrip_Lease(t *testing.T) {
 			LeaseState:   LeaseStateRead | LeaseStateWrite,
 			BreakToState: LeaseStateRead,
 			Breaking:     true,
+			BreakStarted: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC),
 			Epoch:        77,
 		},
 	}
@@ -260,6 +263,33 @@ func TestPersistedLock_RoundTrip_Lease(t *testing.T) {
 	assert.Equal(t, original.Lease.BreakToState, restored.Lease.BreakToState)
 	assert.Equal(t, original.Lease.Breaking, restored.Lease.Breaking)
 	assert.Equal(t, original.Lease.Epoch, restored.Lease.Epoch)
+	// BreakStarted on a breaking lease must survive persistence — the scanner
+	// computes the break deadline from it, so dropping it would make a
+	// post-restart scanner mis-time (or never time out) an in-flight break.
+	assert.Equal(t, original.Lease.BreakStarted, restored.Lease.BreakStarted)
+}
+
+// TestToPersistedLock_DropsBreakStartedWhenNotBreaking pins the persistence
+// gate: BreakStarted is only meaningful while a lease is Breaking. A non-breaking
+// lease must not carry a stale break clock into storage, so the scanner can
+// never treat a never-broken lease as if a break were in flight.
+func TestToPersistedLock_DropsBreakStartedWhenNotBreaking(t *testing.T) {
+	t.Parallel()
+
+	original := &UnifiedLock{
+		ID:    "not-breaking",
+		Owner: LockOwner{OwnerID: "smb:lease:x", ClientID: "c", ShareName: "/s"},
+		Lease: &OpLock{
+			LeaseKey:     [16]byte{1},
+			LeaseState:   LeaseStateRead,
+			Breaking:     false,
+			BreakStarted: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), // stray
+		},
+	}
+
+	persisted := ToPersistedLock(original, 1)
+	assert.True(t, persisted.BreakStarted.IsZero(),
+		"BreakStarted must not be persisted for a non-breaking lease")
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -347,11 +347,18 @@ func (ul *UnifiedLock) ConflictsWith(other *UnifiedLock) bool {
 
 // accessModesConflict checks if two access modes (SMB share reservations) conflict.
 //
-// AccessModeNone never conflicts with anything. Any deny mode (DenyRead,
-// DenyWrite, DenyAll) conflicts with any non-None mode on the other side.
-// The check is symmetric: if a denies and b is non-None, or vice versa.
+// A deny-mode holder (DenyRead, DenyWrite, DenyAll) blocks any subsequent
+// opener regardless of what AccessMode that opener carries, including None.
+// Conversely, a new opener that carries a deny mode must be blocked if there
+// is already any open on the file (even one with AccessModeNone), because the
+// new opener is asserting exclusive access rights that the existing open would
+// violate. AccessModeNone only means "I impose no restrictions on others"; it
+// does NOT mean "I am immune to restrictions imposed by others".
+//
+// The minimum correct check is therefore OR not AND: if either side is
+// non-None, the combination must be tested for conflict.
 func accessModesConflict(a, b AccessMode) bool {
-	return a != AccessModeNone && b != AccessModeNone
+	return a != AccessModeNone || b != AccessModeNone
 }
 
 // UnifiedLockConflict describes a conflicting lock for error reporting.

--- a/pkg/metadata/store/memory/locks.go
+++ b/pkg/metadata/store/memory/locks.go
@@ -246,6 +246,7 @@ func cloneLock(lk *lock.PersistedLock) *lock.PersistedLock {
 		BreakToState:        lk.BreakToState,
 		BreakingToRequired:  lk.BreakingToRequired,
 		Breaking:            lk.Breaking,
+		BreakStarted:        lk.BreakStarted,
 		IsDirectory:         lk.IsDirectory,
 		IsTraditionalOplock: lk.IsTraditionalOplock,
 		// Delegation fields

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -2,7 +2,9 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -46,16 +48,16 @@ const lockColumns = `id, share_name, file_id, owner_id, client_id, lock_type,
 	lease_key, lease_state, lease_epoch, break_to_state, breaking_to_required,
 	breaking, parent_lease_key, is_directory, is_traditional_oplock,
 	delegation_id, deleg_type, deleg_breaking, deleg_recalled, deleg_revoked,
-	deleg_notification_mask`
+	deleg_notification_mask, break_started`
 
-// putLockSQL is the upsert statement, parameterized $1..$28 in lockColumns
+// putLockSQL is the upsert statement, parameterized $1..$29 in lockColumns
 // order. The ON CONFLICT clause re-syncs every column so an overwrite never
 // leaves stale lease/delegation state behind.
 const putLockSQL = `
 	INSERT INTO locks (` + lockColumns + `)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
 	        $14, $15, $16, $17, $18, $19, $20, $21, $22,
-	        $23, $24, $25, $26, $27, $28)
+	        $23, $24, $25, $26, $27, $28, $29)
 	ON CONFLICT (id) DO UPDATE SET
 		share_name = EXCLUDED.share_name,
 		file_id = EXCLUDED.file_id,
@@ -83,7 +85,8 @@ const putLockSQL = `
 		deleg_breaking = EXCLUDED.deleg_breaking,
 		deleg_recalled = EXCLUDED.deleg_recalled,
 		deleg_revoked = EXCLUDED.deleg_revoked,
-		deleg_notification_mask = EXCLUDED.deleg_notification_mask
+		deleg_notification_mask = EXCLUDED.deleg_notification_mask,
+		break_started = EXCLUDED.break_started
 `
 
 // putLockArgs returns the argument list for putLockSQL in lockColumns order.
@@ -123,6 +126,10 @@ func putLockArgs(lk *lock.PersistedLock) []interface{} {
 		lk.DelegRecalled,
 		lk.DelegRevoked,
 		lk.DelegNotificationMask,
+		// break_started is nullable: a zero BreakStarted (no in-flight break)
+		// stores as SQL NULL and scans back to the zero time, matching the
+		// memory/badger JSON round-trip.
+		nullTimeIfZero(lk.BreakStarted),
 	}
 }
 
@@ -132,6 +139,16 @@ func nilIfEmpty(b []byte) []byte {
 		return nil
 	}
 	return b
+}
+
+// nullTimeIfZero maps a zero time.Time to a NULL sql.NullTime so a zeroed
+// nullable timestamp column round-trips as the zero time rather than a driver
+// default, and a non-zero time stores faithfully.
+func nullTimeIfZero(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
 }
 
 // PutLock persists a lock using upsert.
@@ -162,7 +179,8 @@ type rowScanner interface {
 func scanLock(row rowScanner) (*lock.PersistedLock, error) {
 	var lk lock.PersistedLock
 	var offsetStr, lengthStr string
-	if err := row.Scan(scanArgs(&lk, &offsetStr, &lengthStr)...); err != nil {
+	var breakStarted sql.NullTime
+	if err := row.Scan(scanArgs(&lk, &offsetStr, &lengthStr, &breakStarted)...); err != nil {
 		return nil, err
 	}
 	off, err := strconv.ParseUint(offsetStr, 10, 64)
@@ -175,6 +193,10 @@ func scanLock(row rowScanner) (*lock.PersistedLock, error) {
 	}
 	lk.Offset = off
 	lk.Length = length
+	// break_started is nullable; a NULL leaves BreakStarted at its zero value.
+	if breakStarted.Valid {
+		lk.BreakStarted = breakStarted.Time
+	}
 	return &lk, nil
 }
 
@@ -182,7 +204,7 @@ func scanLock(row rowScanner) (*lock.PersistedLock, error) {
 // byte_offset/byte_length NUMERIC columns scan into the caller's string holders
 // (offsetStr/lengthStr); scanLock parses them into lk.Offset/lk.Length. A new
 // column is wired in exactly one place here.
-func scanArgs(lk *lock.PersistedLock, offsetStr, lengthStr *string) []interface{} {
+func scanArgs(lk *lock.PersistedLock, offsetStr, lengthStr *string, breakStarted *sql.NullTime) []interface{} {
 	return []interface{}{
 		&lk.ID,
 		&lk.ShareName,
@@ -212,6 +234,7 @@ func scanArgs(lk *lock.PersistedLock, offsetStr, lengthStr *string) []interface{
 		&lk.DelegRecalled,
 		&lk.DelegRevoked,
 		&lk.DelegNotificationMask,
+		breakStarted,
 	}
 }
 

--- a/pkg/metadata/store/postgres/migrations/000030_lock_break_started.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000030_lock_break_started.down.sql
@@ -1,0 +1,4 @@
+-- Revert: drop the locks break_started column (#1080 audit fix).
+
+ALTER TABLE locks
+    DROP COLUMN IF EXISTS break_started;

--- a/pkg/metadata/store/postgres/migrations/000030_lock_break_started.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000030_lock_break_started.up.sql
@@ -1,0 +1,14 @@
+-- Persist BreakStarted on locks (#1080 audit fix).
+--
+-- PersistedLock gained a BreakStarted timestamp recording when a lease break
+-- was initiated (Breaking=true). The memory and badger backends round-trip it
+-- via JSON automatically; the postgres backend stores locks as columns and so
+-- silently dropped it on PutLock, failing the LockPersistenceConformance
+-- field-drop guard. This column closes that gap.
+--
+-- The column is nullable: legacy rows and locks with no in-flight break carry
+-- a zero BreakStarted, which the backend stores as NULL and loads back as the
+-- zero time.
+
+ALTER TABLE locks
+    ADD COLUMN IF NOT EXISTS break_started TIMESTAMPTZ;

--- a/pkg/metadata/storetest/lock_persistence.go
+++ b/pkg/metadata/storetest/lock_persistence.go
@@ -438,6 +438,7 @@ func kitchenSinkLock() *lock.PersistedLock {
 		BreakToState:          lock.LeaseStateRead | lock.LeaseStateHandle,
 		BreakingToRequired:    lock.LeaseStateRead,
 		Breaking:              true,
+		BreakStarted:          time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC),
 		ParentLeaseKey:        bytes16(0x22),
 		IsDirectory:           true,
 		IsTraditionalOplock:   true,


### PR DESCRIPTION
Remediates byte-range lock / lease / ACL audit findings (#1080, Part of #1075). Signed commits; build/vet/gofmt + `-race ./pkg/metadata/lock/... ./pkg/metadata/acl/...` + memory & badger store conformance green.

## HIGH
- **fix(lock): oplock break timer + in-memory eviction** — break deadline computed from grant time (`AcquiredAt`) not break-initiation, force-revoking long-held leases instantly; persisted `BreakStarted`. Also scanner deleted lease from store but never updated the in-memory Manager, leaving `WaitForBreakCompletion` waiters blocked → `revokeTimedOutLease`.
- **fix(lock): authorize lease reclaim by client + NFSv4 principal** — any client could reclaim another client's persisted lease during grace; now threads clientID + verifies RPCSEC_GSS/AUTH_SYS principal against the recovery record. Fixed orphan UnifiedLock on no-lock-store path.
- **fix(lock): deny-mode share reservation blocks None-mode opener** — `accessModesConflict` used `&&`, so a Deny holder didn't conflict with a later AccessModeNone opener → `||`.
- **fix(acl): preserve SD flags on inherit + chmod** — `PropagateACL` and `AdjustACLForMode` silently cleared `Protected`/`Source`/`NullDACL` (and `AutoInherited` on chmod), dropping explicit-protection state.

Each fix has fail-before/pass-after tests.

Fixes #1080
Part of #1075