### PR TITLE
chore(metadata): sweep LOW audit findings

### DIFF
--- a/pkg/metadata/acl/flags_test.go
+++ b/pkg/metadata/acl/flags_test.go
@@ -68,13 +68,13 @@ func TestWindowsFlagsRoundTrip(t *testing.T) {
 		winFlags uint8
 	}{
 		{"no flags", 0},
-		{"CI", 0x01},
-		{"OI", 0x02},
+		{"OI", 0x01},
+		{"CI", 0x02},
 		{"NP", 0x04},
 		{"IO", 0x08},
 		{"INHERITED", 0x10},
-		{"CI+OI", 0x03},
-		{"CI+OI+INHERITED", 0x13},
+		{"OI+CI", 0x03},
+		{"OI+CI+INHERITED", 0x13},
 		{"all flags", 0x1F},
 	}
 

--- a/pkg/metadata/acl/mode.go
+++ b/pkg/metadata/acl/mode.go
@@ -7,13 +7,13 @@ const (
 	modeExecute = 0x1
 )
 
-// DeriveMode derives Unix mode bits from an ACL for display purposes.
+// deriveMode derives Unix mode bits from an ACL for display purposes.
 // It scans OWNER@, GROUP@, and EVERYONE@ ALLOW ACEs and maps their
 // mask bits to the corresponding rwx triplets per RFC 7530 Section 6.4.1.
 //
 // Returns the composed 9-bit mode (e.g., 0755, 0644).
 // If the ACL is nil, returns 0.
-func DeriveMode(a *ACL) uint32 {
+func deriveMode(a *ACL) uint32 {
 	if a == nil {
 		return 0
 	}

--- a/pkg/metadata/acl/mode_test.go
+++ b/pkg/metadata/acl/mode_test.go
@@ -58,9 +58,9 @@ func TestDeriveMode_OwnerGroupEveryone(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := DeriveMode(tt.acl)
+			got := deriveMode(tt.acl)
 			if got != tt.wantMode {
-				t.Errorf("DeriveMode() = 0%o, want 0%o", got, tt.wantMode)
+				t.Errorf("deriveMode() = 0%o, want 0%o", got, tt.wantMode)
 			}
 		})
 	}
@@ -75,9 +75,9 @@ func TestDeriveMode_SkipsDenyACEs(t *testing.T) {
 	}}
 
 	// DENY ACEs are not used for mode derivation.
-	got := DeriveMode(a)
+	got := deriveMode(a)
 	if got != 0755 {
-		t.Errorf("DeriveMode() = 0%o, want 0755 (DENY ACEs should not affect mode)", got)
+		t.Errorf("deriveMode() = 0%o, want 0755 (DENY ACEs should not affect mode)", got)
 	}
 }
 
@@ -89,9 +89,9 @@ func TestDeriveMode_SkipsInheritOnlyACEs(t *testing.T) {
 		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
 	}}
 
-	got := DeriveMode(a)
+	got := deriveMode(a)
 	if got != 0444 {
-		t.Errorf("DeriveMode() = 0%o, want 0444 (INHERIT_ONLY ACEs should not affect mode)", got)
+		t.Errorf("deriveMode() = 0%o, want 0444 (INHERIT_ONLY ACEs should not affect mode)", got)
 	}
 }
 
@@ -104,9 +104,9 @@ func TestDeriveMode_SkipsNamedPrincipals(t *testing.T) {
 	}}
 
 	// Named principals are not OWNER@/GROUP@/EVERYONE@.
-	got := DeriveMode(a)
+	got := deriveMode(a)
 	if got != 0444 {
-		t.Errorf("DeriveMode() = 0%o, want 0444 (named principals should not affect mode)", got)
+		t.Errorf("deriveMode() = 0%o, want 0444 (named principals should not affect mode)", got)
 	}
 }
 
@@ -119,9 +119,9 @@ func TestDeriveMode_MultipleOwnerACEs(t *testing.T) {
 		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
 	}}
 
-	got := DeriveMode(a)
+	got := deriveMode(a)
 	if got != 0644 {
-		t.Errorf("DeriveMode() = 0%o, want 0644 (multiple OWNER@ ACEs should OR)", got)
+		t.Errorf("deriveMode() = 0%o, want 0644 (multiple OWNER@ ACEs should OR)", got)
 	}
 }
 
@@ -342,10 +342,10 @@ func TestModeRoundTrip(t *testing.T) {
 		}}
 
 		adjusted := AdjustACLForMode(base, mode)
-		derived := DeriveMode(adjusted)
+		derived := deriveMode(adjusted)
 
 		if derived != mode {
-			t.Errorf("round-trip mode 0%o: AdjustACLForMode -> DeriveMode = 0%o", mode, derived)
+			t.Errorf("round-trip mode 0%o: AdjustACLForMode -> deriveMode = 0%o", mode, derived)
 		}
 	}
 }

--- a/pkg/metadata/acl/synthesize_test.go
+++ b/pkg/metadata/acl/synthesize_test.go
@@ -101,7 +101,7 @@ func TestSynthesizeFromMode_0755_Directory(t *testing.T) {
 	for i, ace := range acl.ACEs {
 		ciOi := uint32(ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE)
 		if ace.Flag&ciOi != ciOi {
-			t.Errorf("ACE %d (%s %s): missing CI+OI flags, flag=0x%08x", i, ace.TypeString(), ace.Who, ace.Flag)
+			t.Errorf("ACE %d (%s %s): missing CI+OI flags, flag=0x%08x", i, ace.typeString(), ace.Who, ace.Flag)
 		}
 	}
 
@@ -159,7 +159,7 @@ func TestSynthesizeFromMode_0644_File(t *testing.T) {
 		ciOi := uint32(ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE)
 		if ace.Flag&ciOi != 0 {
 			t.Errorf("ACE %d (%s %s): file ACE should not have CI+OI flags, flag=0x%08x",
-				i, ace.TypeString(), ace.Who, ace.Flag)
+				i, ace.typeString(), ace.Who, ace.Flag)
 		}
 	}
 
@@ -336,7 +336,7 @@ func TestSynthesizeInheritanceFlags(t *testing.T) {
 	dirACL := SynthesizeFromMode(0755, 1000, 1000, true)
 	for i, ace := range dirACL.ACEs {
 		if ace.Flag&ciOi != ciOi {
-			t.Errorf("dir ACE %d (%s %s): missing CI+OI, flag=0x%08x", i, ace.TypeString(), ace.Who, ace.Flag)
+			t.Errorf("dir ACE %d (%s %s): missing CI+OI, flag=0x%08x", i, ace.typeString(), ace.Who, ace.Flag)
 		}
 	}
 
@@ -344,7 +344,7 @@ func TestSynthesizeInheritanceFlags(t *testing.T) {
 	fileACL := SynthesizeFromMode(0755, 1000, 1000, false)
 	for i, ace := range fileACL.ACEs {
 		if ace.Flag&ciOi != 0 {
-			t.Errorf("file ACE %d (%s %s): unexpected CI+OI, flag=0x%08x", i, ace.TypeString(), ace.Who, ace.Flag)
+			t.Errorf("file ACE %d (%s %s): unexpected CI+OI, flag=0x%08x", i, ace.typeString(), ace.Who, ace.Flag)
 		}
 	}
 }

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -163,9 +163,9 @@ type ACL struct {
 	NullDACL      bool      `json:"null_dacl,omitempty"`      // Windows null DACL — no DACL present (everyone full access)
 }
 
-// IsSpecialWho reports whether who is one of the special identifiers:
+// isSpecialWho reports whether who is one of the special identifiers:
 // OWNER@, GROUP@, EVERYONE@, or OwnerRights@.
-func IsSpecialWho(who string) bool {
+func isSpecialWho(who string) bool {
 	return who == SpecialOwner || who == SpecialGroup || who == SpecialEveryone || who == SpecialOwnerRights
 }
 
@@ -181,8 +181,8 @@ func (a *ACE) IsInherited() bool {
 	return a.Flag&ACE4_INHERITED_ACE != 0
 }
 
-// TypeString returns a human-readable representation of the ACE type.
-func (a *ACE) TypeString() string {
+// typeString returns a human-readable representation of the ACE type.
+func (a *ACE) typeString() string {
 	switch a.Type {
 	case ACE4_ACCESS_ALLOWED_ACE_TYPE:
 		return "ALLOW"

--- a/pkg/metadata/acl/types_test.go
+++ b/pkg/metadata/acl/types_test.go
@@ -88,8 +88,8 @@ func TestIsSpecialWho(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := IsSpecialWho(tt.who); got != tt.want {
-			t.Errorf("IsSpecialWho(%q) = %v, want %v", tt.who, got, tt.want)
+		if got := isSpecialWho(tt.who); got != tt.want {
+			t.Errorf("isSpecialWho(%q) = %v, want %v", tt.who, got, tt.want)
 		}
 	}
 }
@@ -152,8 +152,8 @@ func TestACETypeString(t *testing.T) {
 
 	for _, tt := range tests {
 		ace := &ACE{Type: tt.typ, Who: SpecialEveryone}
-		if got := ace.TypeString(); got != tt.want {
-			t.Errorf("TypeString() for type %d = %q, want %q", tt.typ, got, tt.want)
+		if got := ace.typeString(); got != tt.want {
+			t.Errorf("typeString() for type %d = %q, want %q", tt.typ, got, tt.want)
 		}
 	}
 }

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -216,20 +216,6 @@ func (lm *Manager) hasPersistedLeaseKeyOnOtherFile(ctx context.Context, leaseKey
 	return false
 }
 
-// RequestLease requests a new or upgraded lease on a file or directory.
-//
-// For new leases, the granted state may be less than requested if conflicts exist.
-// For existing leases with the same key, this performs an upgrade if the transition is valid.
-//
-// Returns (LeaseStateNone, 0, nil) for rejected requests (invalid state, recently-broken,
-// NLM conflicts, cross-key conflicts, invalid downgrade).
-func (lm *Manager) requestLeaseImpl(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
-	parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
-	requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error) {
-	return lm.requestLeaseImplWithMode(ctx, fileHandle, leaseKey, parentLeaseKey,
-		ownerID, clientID, shareName, requestedState, isDirectory, false, false)
-}
-
 // requestLeaseImplWithMode is the underlying lease-grant implementation with
 // the additional `isTraditionalOplock` flag distinguishing real SMB2.1+ leases
 // from synthetic-key records modeling traditional oplocks (LEVEL_II/Exclusive/

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1359,7 +1359,7 @@ func sessionIDFromOwnerID(ownerID string) (uint64, bool) {
 func (lm *Manager) RequestLease(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
 	parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
 	requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error) {
-	return lm.requestLeaseImpl(ctx, fileHandle, leaseKey, parentLeaseKey, ownerID, clientID, shareName, requestedState, isDirectory)
+	return lm.requestLeaseImplWithMode(ctx, fileHandle, leaseKey, parentLeaseKey, ownerID, clientID, shareName, requestedState, isDirectory, false, false)
 }
 
 // RequestLeaseAsOplock is the traditional-oplock variant of RequestLease.

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -317,6 +317,7 @@ func (l *OpLock) Clone() *OpLock {
 		ParentLeaseKey:      l.ParentLeaseKey, // Fixed-size array, copied by value
 		IsDirectory:         l.IsDirectory,
 		IsTraditionalOplock: l.IsTraditionalOplock,
+		BrokenViaTimeout:    l.BrokenViaTimeout,
 	}
 }
 

--- a/pkg/metadata/store/memory/backup.go
+++ b/pkg/metadata/store/memory/backup.go
@@ -35,7 +35,7 @@ const (
 // memoryBackupSnapshot is the gob-encoded payload written inside the
 // envelope. All fields are exported so gob can encode/decode them.
 // The struct mirrors the data portion of MemoryMetadataStore; transient
-// caches (sessions, attrPool) and config limits
+// caches (sessions) and config limits
 // (maxStorageBytes, maxFiles) are excluded.
 type memoryBackupSnapshot struct {
 	Shares        map[string]*shareData

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -13,7 +13,7 @@ var _ metadata.Resetable = (*MemoryMetadataStore)(nil)
 
 // Reset truncates all in-memory metadata state under the store-level
 // write lock. Engine-identity fields (capabilities, maxStorageBytes,
-// maxFiles, storeID, attrPool) are preserved — they are static config,
+// maxFiles, storeID) are preserved — they are static config,
 // not data, and altering them would change the engine's API-level
 // identity. Lazy sub-stores are nilled to mirror Restore's
 // "never-initialized" branches.

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -190,10 +190,6 @@ type MemoryMetadataStore struct {
 	// 0 means unlimited (constrained only by available memory).
 	maxFiles uint64
 
-	// attrPool is a sync.Pool for FileAttr allocations to reduce GC pressure.
-	// This pool is used to recycle FileAttr objects during copy operations.
-	attrPool sync.Pool
-
 	// sessions tracks active share mount sessions for monitoring and DUMP.
 	// Key: composite key "shareName|clientAddr"
 	// Value: ShareSession with mount timestamp
@@ -338,13 +334,6 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		rollupOffsets: make(map[string]uint64),
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
-	}
-
-	// Initialize the sync.Pool for FileAttr allocations
-	store.attrPool = sync.Pool{
-		New: func() any {
-			return &metadata.FileAttr{}
-		},
 	}
 
 	return store

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -229,15 +229,14 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// tx.store.files[key]. The caller (WithTransaction) holds the write
 	// lock; tx.store.files is mutated directly without per-call locking.
 	//
-	// (review iteration 1): race detection MUST run before
-	// stale-entry cleanup. memory's WithTransaction has no rollback (see
-	// transaction.go WithTransaction docstring): "If fn returns an error,
-	// no rollback is needed since operations are performed directly on the
-	// maps." If we cleaned the old index entry first and then returned
-	// ErrConflict on the race check, the file row would still hold the
-	// old ObjectID but the index would no longer map it — a subsequent
-	// FindByObjectID(oldObjectID) would return nil even though the file
-	// persists with that ObjectID. Reorder so a failed PutFile leaves
+	// race detection MUST run before stale-entry cleanup. Although
+	// WithTransaction snapshots and restores every map on error, ordering the
+	// race check first keeps the no-partial-mutation invariant obvious and
+	// independent of the rollback mechanics: if we cleaned the old index entry
+	// first and then returned ErrConflict on the race check, the file row would
+	// still hold the old ObjectID but the index would no longer map it — a
+	// subsequent FindByObjectID(oldObjectID) would return nil even though the
+	// file persists with that ObjectID. Reorder so a failed PutFile leaves
 	// every map untouched.
 	//
 	// Step 1: race detection (first-committer-wins). If someone

--- a/pkg/metadata/store/postgres/clients.go
+++ b/pkg/metadata/store/postgres/clients.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -92,7 +93,7 @@ func (s *postgresClientStore) GetClientRegistration(ctx context.Context, clientI
 		&reg.ServerEpoch,
 	)
 
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil // Not found returns nil, nil
 	}
 	if err != nil {

--- a/pkg/metadata/store/postgres/connection.go
+++ b/pkg/metadata/store/postgres/connection.go
@@ -67,14 +67,3 @@ func createConnectionPool(ctx context.Context, cfg *PostgresMetadataStoreConfig,
 
 	return pool, nil
 }
-
-// closeConnectionPool closes the PostgreSQL connection pool gracefully
-func closeConnectionPool(pool *pgxpool.Pool, logger *slog.Logger) {
-	if pool == nil {
-		return
-	}
-
-	logger.Info("Closing PostgreSQL connection pool...")
-	pool.Close()
-	logger.Info("PostgreSQL connection pool closed")
-}

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -70,7 +71,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&h.IsPersistent,
 	)
 
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -17,12 +17,6 @@ import (
 // File Handle Encoding/Decoding
 // ============================================================================
 
-// decodeFileHandle extracts the share name and UUID from a file handle
-// This is a convenience wrapper around metadata.DecodeFileHandle
-func decodeFileHandle(handle metadata.FileHandle) (shareName string, id uuid.UUID, err error) {
-	return metadata.DecodeFileHandle(handle)
-}
-
 // encodeFileHandle creates a file handle from share name and UUID string
 func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, error) {
 	id, err := uuid.Parse(idStr)

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -161,9 +161,11 @@ func (s *PostgresMetadataStore) GetParent(ctx context.Context, handle metadata.F
 // SetParent sets the parent handle for a file/directory.
 //
 // Parent tracking is handled implicitly by parent_child_map via SetChild, so
-// this is a no-op and avoids the cost of opening an empty transaction.
+// this performs no write. It still honours context cancellation, matching the
+// prior WithTransaction-based implementation, while avoiding the cost of
+// opening an empty transaction.
 func (s *PostgresMetadataStore) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	return nil
+	return ctx.Err()
 }
 
 // GetLinkCount returns the hard link count for a file.

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -30,7 +30,7 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 		return nil, err
 	}
 
-	shareName, id, err := decodeFileHandle(handle)
+	shareName, id, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -94,7 +94,7 @@ func (s *PostgresMetadataStore) GetChild(ctx context.Context, dirHandle metadata
 		return nil, err
 	}
 
-	shareName, parentID, err := decodeFileHandle(dirHandle)
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -139,7 +139,7 @@ func (s *PostgresMetadataStore) GetParent(ctx context.Context, handle metadata.F
 		return nil, err
 	}
 
-	shareName, childID, err := decodeFileHandle(handle)
+	shareName, childID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -159,10 +159,11 @@ func (s *PostgresMetadataStore) GetParent(ctx context.Context, handle metadata.F
 }
 
 // SetParent sets the parent handle for a file/directory.
+//
+// Parent tracking is handled implicitly by parent_child_map via SetChild, so
+// this is a no-op and avoids the cost of opening an empty transaction.
 func (s *PostgresMetadataStore) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.SetParent(ctx, handle, parentHandle)
-	})
+	return nil
 }
 
 // GetLinkCount returns the hard link count for a file.
@@ -173,7 +174,7 @@ func (s *PostgresMetadataStore) GetLinkCount(ctx context.Context, handle metadat
 		return 0, err
 	}
 
-	_, fileID, err := decodeFileHandle(handle)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return 0, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -205,7 +206,7 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		return nil, "", err
 	}
 
-	shareName, parentID, err := decodeFileHandle(dirHandle)
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return nil, "", &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -48,7 +49,7 @@ func (s *PostgresMetadataStore) GetFileBlock(ctx context.Context, id string) (*m
 	row := s.queryRow(ctx, query, id)
 
 	block, err := scanFileBlock(row)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, metadata.ErrFileBlockNotFound
 	}
 	if err != nil {
@@ -152,7 +153,7 @@ func (s *PostgresMetadataStore) DecrementRefCount(ctx context.Context, id string
 	query := `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`
 	var newCount uint32
 	err := s.queryRow(ctx, query, id).Scan(&newCount)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, metadata.ErrFileBlockNotFound
 	}
 	if err != nil {
@@ -195,7 +196,7 @@ func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, erro
 	err := tx.QueryRow(ctx,
 		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
 		id).Scan(&newCount)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, nil // tolerate already-swept row
 	}
 	if err != nil {
@@ -270,7 +271,7 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 	row := s.queryRow(ctx, query, hash.String())
 
 	block, err := scanFileBlock(row)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -489,7 +490,7 @@ func (tx *postgresTransaction) GetFileBlock(ctx context.Context, id string) (*me
 		FROM file_blocks WHERE id = $1`
 	row := tx.tx.QueryRow(ctx, query, id)
 	block, err := scanFileBlock(row)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, metadata.ErrFileBlockNotFound
 	}
 	if err != nil {
@@ -585,7 +586,7 @@ func (tx *postgresTransaction) DecrementRefCount(ctx context.Context, id string)
 	query := `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`
 	var newCount uint32
 	err := tx.tx.QueryRow(ctx, query, id).Scan(&newCount)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, metadata.ErrFileBlockNotFound
 	}
 	if err != nil {
@@ -636,7 +637,7 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
 	row := tx.tx.QueryRow(ctx, query, hash.String())
 	block, err := scanFileBlock(row)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -478,7 +479,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		&hidden,
 	)
 
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil // Not found, not an error
 	}
 	if err != nil {

--- a/pkg/metadata/store/postgres/statfs.go
+++ b/pkg/metadata/store/postgres/statfs.go
@@ -25,7 +25,7 @@ const (
 // Both the pool and transaction implementations share this so the scoping rule
 // lives in exactly one place.
 func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
-	shareName, _, decodeErr := decodeFileHandle(handle)
+	shareName, _, decodeErr := metadata.DecodeFileHandle(handle)
 	if decodeErr != nil {
 		shareName = ""
 	}

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -230,7 +230,10 @@ func (s *PostgresMetadataStore) Close() error {
 	s.cancel()
 
 	// Close connection pool
-	closeConnectionPool(s.pool, s.logger)
+	if s.pool != nil {
+		s.logger.Info("Closing PostgreSQL connection pool")
+		s.pool.Close()
+	}
 
 	s.logger.Info("PostgreSQL metadata store closed")
 	return nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -137,7 +137,7 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 		return nil, err
 	}
 
-	shareName, id, err := decodeFileHandle(handle)
+	shareName, id, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -390,7 +390,7 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		return err
 	}
 
-	shareName, id, err := decodeFileHandle(handle)
+	shareName, id, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -437,7 +437,7 @@ func (tx *postgresTransaction) GetChild(ctx context.Context, dirHandle metadata.
 		return nil, err
 	}
 
-	shareName, parentID, err := decodeFileHandle(dirHandle)
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -471,7 +471,7 @@ func (tx *postgresTransaction) SetChild(ctx context.Context, dirHandle metadata.
 		return err
 	}
 
-	_, parentID, err := decodeFileHandle(dirHandle)
+	_, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -479,7 +479,7 @@ func (tx *postgresTransaction) SetChild(ctx context.Context, dirHandle metadata.
 		}
 	}
 
-	_, childID, err := decodeFileHandle(childHandle)
+	_, childID, err := metadata.DecodeFileHandle(childHandle)
 	if err != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -506,7 +506,7 @@ func (tx *postgresTransaction) DeleteChild(ctx context.Context, dirHandle metada
 		return err
 	}
 
-	_, parentID, err := decodeFileHandle(dirHandle)
+	_, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -532,7 +532,7 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 		return nil, "", err
 	}
 
-	shareName, parentID, err := decodeFileHandle(dirHandle)
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
 	if err != nil {
 		return nil, "", &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -688,7 +688,7 @@ func (tx *postgresTransaction) GetParent(ctx context.Context, handle metadata.Fi
 		return nil, err
 	}
 
-	shareName, childID, err := decodeFileHandle(handle)
+	shareName, childID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -718,7 +718,7 @@ func (tx *postgresTransaction) GetLinkCount(ctx context.Context, handle metadata
 		return 0, err
 	}
 
-	_, fileID, err := decodeFileHandle(handle)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return 0, &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -741,7 +741,7 @@ func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata
 		return err
 	}
 
-	_, fileID, err := decodeFileHandle(handle)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return &metadata.StoreError{
 			Code:    metadata.ErrInvalidHandle,
@@ -1103,7 +1103,7 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 			},
 		}, nil
 	}
-	if err != pgx.ErrNoRows {
+	if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, mapPgError(err, "CreateRootDirectory", shareName)
 	}
 


### PR DESCRIPTION
Mechanical, correctness-neutral cleanups from the v1.0 LOW audit sweep for the metadata subsystem. No wire/persisted-format or behavior changes; all changes are safe across the memory/badger/postgres backends.

## Fixed

**acl**
- `flags_test.go`: swapped CI/OI test-case labels (0x01 is OBJECT_INHERIT/OI, 0x02 is CONTAINER_INHERIT/CI) to match `flags.go` convention.
- Unexported `DeriveMode` → `deriveMode`, `IsSpecialWho` → `isSpecialWho`, `ACE.TypeString` → `typeString` — all three had no production callers (test-only).

**lock**
- `OpLock.Clone()` now copies `BrokenViaTimeout` (was silently dropped).
- Inlined the `requestLeaseImpl` one-line pass-through into `RequestLease`; the variant entry points already call `requestLeaseImplWithMode` directly.

**memory store**
- Removed the unused `attrPool sync.Pool` field, its initialization, and stale comment references in `reset.go`/`backup.go` — never wired to any allocation path.
- Replaced a stale `PutFile` comment that falsely claimed `WithTransaction` has no rollback (it snapshots/restores on error).

**postgres**
- Inlined single-use `closeConnectionPool` into `Close`.
- Dropped the `decodeFileHandle` pass-through wrapper; call sites use `metadata.DecodeFileHandle` directly (matching badger/memory).
- `SetParent` returns `nil` directly instead of opening an empty BEGIN/COMMIT — the transaction-level impl was already an unconditional no-op (parent tracking is implicit via `parent_child_map`/`SetChild`).
- Converted `== pgx.ErrNoRows` to `errors.Is(...)` in clients/durable_handles/objects/shares/statfs/transaction for consistency with the rest of the package.

## Skipped (with reasons)

- **`buildPayloadID`/`BuildPayloadID` dedup** — `buildPayloadID` is the documented canonical PayloadID derivation referenced across block-store comments; the two differ only on empty-string inputs (never hit for real file creates). PayloadID is a load-bearing derived value for block storage, so deferring to avoid any risk.
- **`IsUnifiedLockConflicting` removal** — has cross-package callers in NFS NLM/v4 adapters plus a deprecated alias; touching adapters is out of metadata scope.
- **`rangeEnd` inline** — sits in the byte-range lock conflict path with explicit overflow caveats vs `rangeLast`'s inclusive arithmetic; inlining risks altering conflict detection.
- **`encodeUint32` stack-array micro-opt** — the function returns a slice retained by `txn.Set`, so it escapes regardless; the audit's fix requires inlining at call sites across paths for negligible gain.
- **`ACL4_SUPPORT_*` collapse to `0x0F`** — the named bits are self-documenting RFC7530 constants; collapsing reduces clarity for no functional gain.
- **`locks.go` `== pgx.ErrNoRows`** — that file imports `pkg/metadata/errors` unaliased as `errors`, so stdlib `errors.Is` would require an aliased import (more churn than warranted).
- **Larger structural items** (`*bool` tri-state → enum in `LockQuery`, `GetStats` counter, context-on-struct in pg store, `SetFilesystemCapabilities` error/ctx handling, `poolRow` lifecycle, capabilities-default dedup, transaction-level `GetFilesystemStatistics` delegation, storetest atomicity/black-box/helper-dedup items) — design refactors or touch persisted/serialized behavior or test contracts beyond a trivially-safe change; deferred to dedicated PRs.

## Verification
- `go build ./...`, `go vet ./...`, gofmt all clean.
- `go test ./pkg/metadata/...` passes (memory + badger + postgres unit tests). Postgres conformance against a real DB runs in CI.