### PR TITLE
chore(misc): sweep LOW audit findings

### DIFF
--- a/bench/blockstore/workloads_extra.go
+++ b/bench/blockstore/workloads_extra.go
@@ -29,18 +29,6 @@ const (
 	DefaultGCGarbage = 0.3
 )
 
-// IsEngineWorkload reports whether name routes through RunWorkload
-// (i.e. needs a wired engine.Store). Extra workloads (walk/delete/
-// gc/raw-s3-put) take their own dispatchers.
-func IsEngineWorkload(name string) bool {
-	switch name {
-	case WorkloadSequentialWrite, WorkloadRandomWrite, WorkloadDedupHeavy, WorkloadMixedRW, WorkloadFlushChurn:
-		return true
-	default:
-		return false
-	}
-}
-
 // NewLocalStore wires a bare FSStore (no engine, no syncer) for the
 // walk + delete workloads, which exercise local CAS enumeration and
 // chunk removal without engine overhead.

--- a/bench/infra/systems.go
+++ b/bench/infra/systems.go
@@ -101,11 +101,6 @@ var systemsByName = func() map[string]*System {
 	return m
 }()
 
-// AllSystems returns the full list of competitors to benchmark.
-func AllSystems() []System {
-	return allSystems
-}
-
 // FindSystem returns the system with the given name, or nil if not found.
 func FindSystem(name string) *System {
 	return systemsByName[name]

--- a/bench/orchestrator/compare.go
+++ b/bench/orchestrator/compare.go
@@ -3,7 +3,7 @@ package orchestrator
 import (
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"text/tabwriter"
 )
 
@@ -40,7 +40,7 @@ func Compare(baseline, candidate *Document, thresholdPct float64) []Comparison {
 	for n := range names {
 		sorted = append(sorted, n)
 	}
-	sort.Strings(sorted)
+	slices.Sort(sorted)
 
 	out := make([]Comparison, 0, len(sorted))
 	for _, n := range sorted {
@@ -139,6 +139,6 @@ func sortedKeys(m map[string]WorkloadResult) []string {
 	for k := range m {
 		out = append(out, k)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }

--- a/bench/orchestrator/latency.go
+++ b/bench/orchestrator/latency.go
@@ -1,6 +1,6 @@
 package orchestrator
 
-import "sort"
+import "slices"
 
 // LatencyFromSamples computes p50/p95/p99 from a set of per-op nanosecond
 // latencies. It returns nil for an empty input (no per-op timings → no latency
@@ -20,7 +20,7 @@ func LatencyFromSamples(samplesNs []int64) *Latency {
 	}
 	s := make([]int64, len(samplesNs))
 	copy(s, samplesNs)
-	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	slices.Sort(s)
 	return &Latency{
 		P50Ns: percentile(s, 50),
 		P95Ns: percentile(s, 95),

--- a/bench/orchestrator/manifest.go
+++ b/bench/orchestrator/manifest.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 )
 
 // WorkloadParams is one manifest entry: a named workload plus the knobs the
@@ -97,6 +97,6 @@ func (m Manifest) Names() []string {
 	for _, w := range m.Workloads {
 		out = append(out, w.Name)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }

--- a/cmd/dfs/commands/config/config.go
+++ b/cmd/dfs/commands/config/config.go
@@ -11,7 +11,7 @@ var Cmd = &cobra.Command{
 	Short: "Configuration management",
 	Long: `Manage DittoFS configuration files.
 
-Use 'dittofs init' to create a new configuration file.
+Use 'dfs init' to create a new configuration file.
 
 Subcommands:
   edit      Open configuration in editor

--- a/cmd/dfs/commands/config/edit.go
+++ b/cmd/dfs/commands/config/edit.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,10 +34,10 @@ func runConfigEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if file exists
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("configuration file not found: %s\n\n"+
 			"Create it first with:\n"+
-			"  dfs config init --config %s",
+			"  dfs init --config %s",
 			configPath, configPath)
 	}
 

--- a/cmd/dfs/commands/daemon_windows.go
+++ b/cmd/dfs/commands/daemon_windows.go
@@ -87,13 +87,13 @@ func startDaemon() error {
 	cmd.Stderr = lf
 
 	if err := cmd.Start(); err != nil {
-		lf.Close()
+		_ = lf.Close()
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
 
 	// Close the log file handle in the parent process.
 	// The child process inherits its own file descriptor, so this is safe.
-	lf.Close()
+	_ = lf.Close()
 
 	// Write PID file
 	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {

--- a/cmd/dfs/commands/init.go
+++ b/cmd/dfs/commands/init.go
@@ -20,13 +20,13 @@ Use --config to specify a custom path.
 
 Examples:
   # Initialize with default location
-  dittofs init
+  dfs init
 
   # Initialize with custom path
-  dittofs init --config /etc/dittofs/config.yaml
+  dfs init --config /etc/dittofs/config.yaml
 
   # Force overwrite existing config
-  dittofs init --force`,
+  dfs init --force`,
 	RunE: runInit,
 }
 

--- a/cmd/dfs/commands/logs.go
+++ b/cmd/dfs/commands/logs.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -57,7 +58,7 @@ func init() {
 
 func runLogs(cmd *cobra.Command, args []string) error {
 	// Load configuration to find log file
-	cfg, err := config.Load(cfgFile)
+	cfg, err := config.Load(GetConfigFile())
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -70,7 +71,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if log file exists
-	if _, err := os.Stat(logOutput); os.IsNotExist(err) {
+	if _, err := os.Stat(logOutput); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("log file not found: %s\nThe server may not have started yet or is logging elsewhere", logOutput)
 	}
 

--- a/cmd/dfs/commands/root.go
+++ b/cmd/dfs/commands/root.go
@@ -2,8 +2,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/marmos91/dittofs/cmd/dfs/commands/config"
 	"github.com/spf13/cobra"
 )
@@ -65,15 +63,4 @@ func init() {
 // GetConfigFile returns the config file path from the global flag.
 func GetConfigFile() string {
 	return cfgFile
-}
-
-// PrintErr prints an error message to stderr.
-func PrintErr(format string, args ...any) {
-	rootCmd.PrintErrf(format+"\n", args...)
-}
-
-// Exit prints an error and exits with code 1.
-func Exit(format string, args ...any) {
-	PrintErr(format, args...)
-	os.Exit(1)
 }

--- a/cmd/dfs/commands/stop.go
+++ b/cmd/dfs/commands/stop.go
@@ -53,7 +53,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	// Read PID file
 	pidData, err := os.ReadFile(pidPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("PID file not found: %s\n\nIs the server running?", pidPath)
 		}
 		return fmt.Errorf("failed to read PID file: %w", err)

--- a/cmd/dfsctl/cmdutil/util.go
+++ b/cmd/dfsctl/cmdutil/util.go
@@ -120,11 +120,6 @@ func GetAuthenticatedClient() (*apiclient.Client, error) {
 	return apiclient.New(url).WithToken(tok), nil
 }
 
-// GetOutputFormat returns the output format string.
-func GetOutputFormat() string {
-	return Flags.Output
-}
-
 // GetOutputFormatParsed returns the parsed output format.
 func GetOutputFormatParsed() (output.Format, error) {
 	return output.ParseFormat(Flags.Output)

--- a/cmd/dfsctl/commands/bench/compare.go
+++ b/cmd/dfsctl/commands/bench/compare.go
@@ -29,18 +29,28 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	results := make([]*bench.Result, 0, len(args))
 
 	for _, path := range args {
-		data, err := os.ReadFile(path)
+		r, err := loadResult(path)
 		if err != nil {
-			return fmt.Errorf("read %s: %w", path, err)
+			return err
 		}
-
-		var r bench.Result
-		if err := json.Unmarshal(data, &r); err != nil {
-			return fmt.Errorf("parse %s: %w", path, err)
-		}
-
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return cmdutil.PrintResource(os.Stdout, results, CompareTable{Results: results})
+}
+
+// loadResult streams and decodes a single benchmark result file, avoiding
+// buffering the raw JSON bytes alongside the decoded struct.
+func loadResult(path string) (*bench.Result, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var r bench.Result
+	if err := json.NewDecoder(f).Decode(&r); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &r, nil
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,7 +97,7 @@ Configuration management
 
 Manage DittoFS configuration files.
 
-Use 'dittofs init' to create a new configuration file.
+Use 'dfs init' to create a new configuration file.
 
 Subcommands:
   edit      Open configuration in editor
@@ -245,13 +245,13 @@ Use --config to specify a custom path.
 
 Examples:
   # Initialize with default location
-  dittofs init
+  dfs init
 
   # Initialize with custom path
-  dittofs init --config /etc/dittofs/config.yaml
+  dfs init --config /etc/dittofs/config.yaml
 
   # Force overwrite existing config
-  dittofs init --force
+  dfs init --force
 
 ```
 dfs init [flags]

--- a/infra/systems.go
+++ b/infra/systems.go
@@ -110,11 +110,6 @@ var systemsByName = func() map[string]*System {
 	return m
 }()
 
-// AllSystems returns the full list of deployable systems.
-func AllSystems() []System {
-	return allSystems
-}
-
 // FindSystem returns the system with the given name, or nil if not found.
 func FindSystem(name string) *System {
 	return systemsByName[name]

--- a/pkg/apiclient/clients.go
+++ b/pkg/apiclient/clients.go
@@ -86,11 +86,6 @@ func (c *Client) DisconnectClient(clientID string) error {
 // Kept for backward compatibility with existing CLI code.
 type ClientInfo = ClientRecord
 
-// EvictClient is deprecated: use DisconnectClient instead.
-func (c *Client) EvictClient(clientID string) error {
-	return c.DisconnectClient(clientID)
-}
-
 // --- Legacy NFS-specific session types (kept for NFS session endpoints) ---
 
 // ConnectionInfo represents a single bound connection in a session.

--- a/test/e2e/helpers/cli.go
+++ b/test/e2e/helpers/cli.go
@@ -61,21 +61,6 @@ func (r *CLIRunner) RunRaw(args ...string) ([]byte, error) {
 	return r.execDfsctl(args...)
 }
 
-// RunWithInput executes dfsctl and provides stdin input.
-func (r *CLIRunner) RunWithInput(input string, args ...string) ([]byte, error) {
-	// Prepend standard args
-	fullArgs := []string{"--output", "json"}
-	if r.serverURL != "" {
-		fullArgs = append(fullArgs, "--server", r.serverURL)
-	}
-	if r.token != "" {
-		fullArgs = append(fullArgs, "--token", r.token)
-	}
-	fullArgs = append(fullArgs, args...)
-
-	return r.execDfsctlWithInput(input, fullArgs...)
-}
-
 // SetToken updates the authentication token.
 func (r *CLIRunner) SetToken(token string) {
 	r.token = token
@@ -109,27 +94,6 @@ func (r *CLIRunner) execDfsctl(args ...string) ([]byte, error) {
 	err := cmd.Run()
 	if err != nil {
 		// Include stderr in error for better debugging
-		return stdout.Bytes(), fmt.Errorf("dfsctl %s failed: %w\nstderr: %s",
-			strings.Join(args, " "), err, stderr.String())
-	}
-
-	return stdout.Bytes(), nil
-}
-
-// execDfsctlWithInput runs the dfsctl binary with stdin input.
-func (r *CLIRunner) execDfsctlWithInput(input string, args ...string) ([]byte, error) {
-	binary := r.getBinary()
-	cmd := exec.Command(binary, args...)
-	cmd.Env = r.commandEnv()
-
-	cmd.Stdin = strings.NewReader(input)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if err != nil {
 		return stdout.Bytes(), fmt.Errorf("dfsctl %s failed: %w\nstderr: %s",
 			strings.Join(args, " "), err, stderr.String())
 	}

--- a/test/e2e/helpers/controlplane.go
+++ b/test/e2e/helpers/controlplane.go
@@ -180,22 +180,3 @@ func WaitForSettingsReload(t *testing.T) {
 	t.Log("Waiting for settings watcher reload (12s)...")
 	time.Sleep(12 * time.Second)
 }
-
-// =============================================================================
-// Pointer Helpers
-// =============================================================================
-
-// BoolPtr returns a pointer to a bool value.
-func BoolPtr(v bool) *bool {
-	return &v
-}
-
-// IntPtr returns a pointer to an int value.
-func IntPtr(v int) *int {
-	return &v
-}
-
-// StringPtr returns a pointer to a string value.
-func StringPtr(v string) *string {
-	return &v
-}

--- a/test/e2e/helpers/server.go
+++ b/test/e2e/helpers/server.go
@@ -367,25 +367,16 @@ func findDfsBinary(t *testing.T) string {
 	return localBinary
 }
 
-// findProjectRoot locates the project root by looking for go.mod.
+// findProjectRoot locates the project root by looking for go.mod, failing the
+// test if it cannot be found.
 func findProjectRoot(t *testing.T) string {
 	t.Helper()
 
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get working directory: %v", err)
+	root := findProjectRootForCLI()
+	if root == "." {
+		t.Fatalf("Could not find project root (go.mod not found)")
 	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("Could not find project root (go.mod not found)")
-		}
-		dir = parent
-	}
+	return root
 }
 
 // StartServerProcessWithConfig starts a DittoFS server using a pre-created config file.


### PR DESCRIPTION
Sweep of LOW-severity audit findings in the **misc** group (cmd/dfs, cmd/dfsctl, pkg/apiclient, pkg/identity, bench, test/e2e helpers). All changes are correctness-neutral cleanups or verified dead-code removals.

## Fixed

**Dead code removal (grep-verified zero callers)**
- `bench/blockstore`: `IsEngineWorkload`
- `bench/infra` + `infra`: `AllSystems()` (exported in `package main` — unimportable, no internal caller)
- `cmd/dfs/commands/root.go`: `PrintErr` / `Exit`
- `cmd/dfsctl/cmdutil`: `GetOutputFormat` (callers use `GetOutputFormatParsed`)
- `pkg/apiclient`: `EvictClient` deprecated alias
- `test/e2e/helpers`: `RunWithInput` + `execDfsctlWithInput`; `BoolPtr`/`IntPtr`/`StringPtr`

**Cleanups**
- Help text: `dittofs init` → `dfs init` (init.go, config.go); `dfs config init` → `dfs init` (edit.go) — non-existent command name
- `errors.Is(err, os.ErrNotExist)` over deprecated `os.IsNotExist` (stop.go, logs.go, config/edit.go)
- `logs.go`: route through `GetConfigFile()` instead of reading the unexported `cfgFile` directly
- `daemon_windows.go`: explicit `_ = lf.Close()` (matches daemon_unix.go, silences errcheck)
- `bench/orchestrator`: `slices.Sort` over `sort.Slice` closure / `sort.Strings`
- `dfsctl bench compare`: streaming `json.NewDecoder` over `os.ReadFile`+`Unmarshal`
- Dedup `findProjectRoot` (server.go now delegates to the helper in cli.go)
- Regenerated `docs/CLI.md` (help-text change only)

## Skipped (with reasons)
- **AllSystems/FindSystem lowercasing** (near-dup finding): only removed the genuinely-dead `AllSystems`; `FindSystem` has a real caller and lowercasing it is cosmetic.
- **formatBytes dedup → bytesize.ByteSize**: the two formatters produce different output (`1.5 KB` vs `1.50KiB`, `0` vs `0B`); replacing changes user-facing table output — out of scope per output-contract rule.
- **util.go InitLogger/GetDefaultStateDir wrapper deletion**: 3+ internal callers across build-tagged daemon files; pure indirection removal with wide blast radius and zero behavior change.
- **apiclient `do`/`doCtx` and `resourcePath` inlining**: subjective indirection-preference refactors touching many call sites; not a clear safe win.
- **SettingsOption *string → url.Values**, **list_mounts output abstraction**, **PrintSuccess io.Writer param**, **FuncLinkStore restructure**, **NobodyIdentity / ResolvedIdentity consolidation**, **ListNetgroups []*T → []T**, **gc table extraction**: subjective design refactors or wire/API-shape changes — out of scope.
- **trashServer stub error body**, **WaitReady ctx cancellation**, **WriteManifest sort caching**, **makeProgressFn alloc**: behavior changes / non-mechanical perf work needing judgment, not <5-min safe wins.

## Verification
- `go build ./...`, `GOOS=windows go build ./cmd/dfs/...`, `go build -tags e2e ./test/...` — clean
- `go vet ./...` and `go vet -tags e2e ./test/e2e/helpers/` — clean
- `go test ./cmd/... ./pkg/apiclient/... ./pkg/identity/... ./pkg/snapshot/...` — all pass
- gofmt clean