### PR TITLE
test(smb): drop flaky smb2.bench from smbtorture battery

### DIFF
--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -515,7 +515,16 @@ else
         "smb2.acls:acls"
         "smb2.acls_non_canonical:acls_non_canonical:smbnoncanon"
         "smb2.aio_delay:aio_delay"
-        "smb2.bench:bench"
+        # smb2.bench is intentionally NOT run: it is a throughput benchmark
+        # family (echo, oplock1, path-contention-shared, read, session-setup),
+        # not a conformance suite. The tests measure round-trip timing and
+        # complete-or-time-out under load, so under CI contention (linux/amd64
+        # via QEMU) they flake to failure — and because they normally pass,
+        # none are recorded in KNOWN_FAILURES.md, so a flaked run surfaces as a
+        # spurious "new failure" and reds the whole job. Benchmarks exercise no
+        # protocol behaviour the functional suites don't already cover, so we
+        # drop them from the gate entirely (kills the recurring flake, saves the
+        # emulated runtime). Run them ad hoc with `--filter smb2.bench`.
         "smb2.change_notify_disabled:change_notify_disabled:change_notify_disabled"
         "smb2.charset:charset"
         "smb2.compound:compound"
@@ -626,7 +635,9 @@ else
     # NOTE: Skipped interactive hold tests:
     #   smb2.hold-oplock    - waits 5 min for oplock events (no real test)
     #   smb2.hold-sharemode - blocks indefinitely waiting for SIGINT
-    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests)"
+    # Also skipped: smb2.bench (throughput benchmarks — flaky under load, no
+    # conformance signal; see the SUITES list above).
+    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests), smb2.bench (benchmarks)"
 fi
 
 # Collect DittoFS logs


### PR DESCRIPTION
## Problem
`smbtorture / memory` intermittently reds CI with a single "new failure" — almost always `smb2.bench.oplock1` (sometimes `bench.session-setup`) — on PRs that touch **no SMB code** (e.g. metadata/block LOW sweeps #1095/#1097).

## Root cause
`smb2.bench` is a **throughput benchmark** family (echo, oplock1, path-contention-shared, read, session-setup), not a conformance suite. The tests measure round-trip timing and complete-or-time-out. Under CI contention (linux/amd64 via QEMU emulation) they flake to failure. Because they *normally* pass, none are recorded as table-row entries in `KNOWN_FAILURES.md` (which `parse-results.sh` reads) — so a flaked benchmark surfaces as a spurious **new failure** and reds the whole job.

## Fix
Drop `smb2.bench` from the conformance battery in `run.sh`. Benchmarks exercise no protocol behaviour the functional suites don't already cover; they only add flake noise and emulated runtime. Still runnable ad hoc with `--filter smb2.bench`.

This unblocks the in-flight LOW-sweep PRs (they fail only on this flake) and stops the recurring red across the repo.