### PR TITLE
feat(shares): expose AllowMFsymlink toggle via REST + dfsctl

### DIFF
--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -29,6 +29,7 @@ var (
 	createChangeNotifyOff   bool
 	createStreamsDisabled   bool
 	createContinuousAvail   bool
+	createAllowMFsymlink    bool
 	createEnableTrash       bool
 	createTrashRetention    int
 	createTrashRestrictAdm  bool
@@ -93,6 +94,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createChangeNotifyOff, "change-notify-disabled", false, "Reject SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED on this share (mirrors Samba 'kernel change notify = no').")
 	createCmd.Flags().BoolVar(&createStreamsDisabled, "streams-disabled", false, "Reject SMB2 Alternate Data Stream opens with STATUS_OBJECT_NAME_INVALID on this share (mirrors Samba 'smbd:streams = no').")
 	createCmd.Flags().BoolVar(&createContinuousAvail, "continuous-availability", false, "Advertise SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY and allow SMB3 persistent durable handles on this share.")
+	createCmd.Flags().BoolVar(&createAllowMFsymlink, "allow-mfsymlink", false, "Convert 1067-byte XSym (Minshall+French) symlink files written by macOS/Windows SMB clients into real symlinks on CLOSE. Off by default (XSym files are stored as regular files).")
 	createCmd.Flags().BoolVar(&createEnableTrash, "enable-trash", false, "Enable the per-share recycle bin so deletes move to #recycle instead of being permanent.")
 	createCmd.Flags().IntVar(&createTrashRetention, "trash-retention-days", 0, "Days to retain recycled items before the reaper purges them (0 = keep forever).")
 	createCmd.Flags().BoolVar(&createTrashRestrictAdm, "trash-restrict-empty-to-admin", false, "Restrict emptying the recycle bin to admins.")
@@ -200,6 +202,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("continuous-availability") {
 		v := createContinuousAvail
 		req.ContinuousAvailability = &v
+	}
+	if cmd.Flags().Changed("allow-mfsymlink") {
+		v := createAllowMFsymlink
+		req.AllowMFsymlink = &v
 	}
 	// Per-share recycle-bin policy (#190): only forward flags the operator
 	// set so the server applies its own defaults (trash disabled, zero

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -74,6 +74,7 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Change Notify Disabled", fmt.Sprintf("%v", s.ChangeNotifyDisabled)},
 		{"Streams Disabled", fmt.Sprintf("%v", s.StreamsDisabled)},
 		{"Continuous Availability", fmt.Sprintf("%v", s.ContinuousAvailability)},
+		{"Allow MFsymlink", fmt.Sprintf("%v", s.AllowMFsymlink)},
 		{"Retention", retPolicy},
 	}
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2770,6 +2770,7 @@ Flags:
 ```
       --access-based-enumeration        Enable Windows access-based enumeration (SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM). When true, SMB clients only see directory entries they can read.
       --acl-canonicalize-inherited      When false, preserves the SE_DACL_AUTO_INHERITED control bit verbatim on SET_INFO Security instead of applying MS-DTYP §2.5.3.4.2 canonicalization (Samba "acl flag inherited canonicalization = no"). Default true matches Windows. (default true)
+      --allow-mfsymlink                 Convert 1067-byte XSym (Minshall+French) symlink files written by macOS/Windows SMB clients into real symlinks on CLOSE. Off by default (XSym files are stored as regular files).
       --change-notify-disabled          Reject SMB2 CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED on this share (mirrors Samba 'kernel change notify = no').
       --continuous-availability         Advertise SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY and allow SMB3 persistent durable handles on this share.
       --default-permission string       Default permission (none|read|read-write|admin) (default "read-write")

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -94,6 +94,9 @@ type CreateShareRequest struct {
 	// ContinuousAvailability — Refs #739. Pointer so nil keeps default false
 	// (no CA / persistent handles); a non-nil pointer is an explicit set.
 	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
+	// AllowMFsymlink — pointer so nil keeps default false (XSym files stored
+	// as regular files); a non-nil pointer is an explicit set.
+	AllowMFsymlink *bool `json:"allow_mfsymlink,omitempty"`
 	// Per-share recycle-bin policy (#190). Pointers so nil keeps the
 	// server default (trash disabled, zero limits).
 	TrashEnabled         *bool    `json:"trash_enabled,omitempty"`
@@ -134,6 +137,9 @@ type UpdateShareRequest struct {
 	// ContinuousAvailability — Refs #739. nil = no change; non-nil = explicit
 	// set. Persisted on UpdateShare; takes effect on adapter restart.
 	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
+	// AllowMFsymlink — nil = no change; non-nil = explicit set. Persisted on
+	// UpdateShare; takes effect on adapter restart.
+	AllowMFsymlink *bool `json:"allow_mfsymlink,omitempty"`
 	// Per-share recycle-bin policy (#190). nil = no change; non-nil =
 	// explicit set. Unlike the adapter-restart fields above, these apply
 	// LIVE via the runtime (SetShareTrashConfig); turning trash off also
@@ -183,6 +189,9 @@ type ShareResponse struct {
 	// ContinuousAvailability mirrors models.Share — Refs #739. No omitempty:
 	// operators render the explicit CA state.
 	ContinuousAvailability bool `json:"continuous_availability"`
+	// AllowMFsymlink mirrors models.Share. No omitempty: operators render the
+	// explicit MFsymlink-conversion state.
+	AllowMFsymlink bool `json:"allow_mfsymlink"`
 	// Per-share recycle-bin policy (#190). No omitempty: these are
 	// operator-meaningful state that consumers (dfsctl share show) render
 	// explicitly.
@@ -355,6 +364,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		continuousAvailability = *req.ContinuousAvailability
 	}
 
+	// MFsymlink conversion defaults off (XSym files stored as regular files).
+	allowMFsymlink := false
+	if req.AllowMFsymlink != nil {
+		allowMFsymlink = *req.AllowMFsymlink
+	}
+
 	// Per-share recycle bin (#190). All knobs default to the disabled/zero
 	// state; non-nil pointers are explicit sets.
 	trashEnabled := false
@@ -403,6 +418,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ChangeNotifyDisabled:             cnDisabled,
 		StreamsDisabled:                  streamsDisabled,
 		ContinuousAvailability:           continuousAvailability,
+		AllowMFsymlink:                   allowMFsymlink,
 		TrashEnabled:                     trashEnabled,
 		TrashRetentionDays:               trashRetentionDays,
 		TrashRestrictToAdmin:             trashRestrictToAdmin,
@@ -462,6 +478,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			StreamsDisabled:                  share.StreamsDisabled,
 			ContinuousAvailability:           share.ContinuousAvailability,
+			AllowMFsymlink:                   share.AllowMFsymlink,
 			TrashEnabled:                     share.TrashEnabled,
 			TrashRetentionDays:               share.TrashRetentionDays,
 			TrashRestrictToAdmin:             share.TrashRestrictToAdmin,
@@ -609,6 +626,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.ContinuousAvailability != nil {
 		// Refs #739. Persisted to DB; takes effect on adapter restart.
 		share.ContinuousAvailability = *req.ContinuousAvailability
+	}
+	if req.AllowMFsymlink != nil {
+		// Persisted to DB; takes effect on adapter restart.
+		share.AllowMFsymlink = *req.AllowMFsymlink
 	}
 	// Per-share recycle bin (#190). Persisted here, then applied LIVE via the
 	// runtime below (with auto-empty on disable).
@@ -1163,6 +1184,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 		ChangeNotifyDisabled:             s.ChangeNotifyDisabled,
 		StreamsDisabled:                  s.StreamsDisabled,
 		ContinuousAvailability:           s.ContinuousAvailability,
+		AllowMFsymlink:                   s.AllowMFsymlink,
 		TrashEnabled:                     s.TrashEnabled,
 		TrashRetentionDays:               s.TrashRetentionDays,
 		TrashRestrictToAdmin:             s.TrashRestrictToAdmin,

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -54,6 +54,9 @@ type Share struct {
 	// ContinuousAvailability mirrors models.Share — Refs #739. No omitempty:
 	// operators need to render the explicit CA state.
 	ContinuousAvailability bool `json:"continuous_availability"`
+	// AllowMFsymlink mirrors models.Share. No omitempty: operators need to
+	// render the explicit MFsymlink-conversion state.
+	AllowMFsymlink bool `json:"allow_mfsymlink"`
 	// Per-share recycle-bin policy (#190). Mirrors the server
 	// ShareResponse so dfsctl share show can render the trash config.
 	TrashEnabled         bool      `json:"trash_enabled"`
@@ -96,6 +99,9 @@ type CreateShareRequest struct {
 	// ContinuousAvailability — Refs #739. Pointer so callers can distinguish
 	// "unset → server default (false)" from "explicit true".
 	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
+	// AllowMFsymlink — pointer so callers can distinguish "unset → server
+	// default (false)" from "explicit true".
+	AllowMFsymlink *bool `json:"allow_mfsymlink,omitempty"`
 	// Per-share recycle-bin policy (#190). Pointers so nil keeps the
 	// server default (trash disabled, zero limits).
 	TrashEnabled         *bool    `json:"trash_enabled,omitempty"`
@@ -134,6 +140,9 @@ type UpdateShareRequest struct {
 	// ContinuousAvailability — Refs #739. nil = no change; non-nil = explicit
 	// set. Takes effect on adapter restart.
 	ContinuousAvailability *bool `json:"continuous_availability,omitempty"`
+	// AllowMFsymlink — nil = no change; non-nil = explicit set. Takes effect
+	// on adapter restart.
+	AllowMFsymlink *bool `json:"allow_mfsymlink,omitempty"`
 	// Per-share recycle-bin policy (#190). nil = no change; non-nil =
 	// explicit set. Applied live by the server; turning trash off
 	// auto-empties the bin.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -57,6 +57,15 @@ type Share struct {
 	// false, a persistent-handle request degrades to a plain durable handle.
 	// Default false (refs #739).
 	ContinuousAvailability bool `gorm:"default:false;not null" json:"continuous_availability"`
+	// AllowMFsymlink enables automatic conversion of 1067-byte XSym
+	// (Minshall+French) symlink files written by macOS/Windows SMB clients into
+	// real symlinks on CLOSE. The conversion target is client-controlled, so
+	// promotion is opt-in. Default false (XSym files are stored as regular
+	// files and never promoted).
+	// Column pinned explicitly: GORM's default naming would mangle the
+	// "MFsymlink" initialism into a different snake_case column than the
+	// "allow_mfsymlink" the store field-map and backfill use.
+	AllowMFsymlink bool `gorm:"column:allow_mfsymlink;default:false;not null" json:"allow_mfsymlink"`
 	// TrashEnabled turns on the per-share recycle bin (#190). Default false.
 	TrashEnabled bool `gorm:"default:false;not null" json:"trash_enabled"`
 	// TrashRetentionDays auto-empties bin entries older than N days (0 = keep forever).

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -199,6 +199,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
 			StreamsDisabled:                  share.StreamsDisabled,
 			ContinuousAvailability:           share.ContinuousAvailability,
+			AllowMFsymlink:                   share.AllowMFsymlink,
 			TrashEnabled:                     share.TrashEnabled,
 			TrashRetentionDays:               share.TrashRetentionDays,
 			TrashRestrictToAdmin:             share.TrashRestrictToAdmin,

--- a/pkg/controlplane/store/gorm.go
+++ b/pkg/controlplane/store/gorm.go
@@ -394,6 +394,15 @@ func New(config *Config) (*GORMStore, error) {
 		return nil, fmt.Errorf("failed to backfill shares.continuous_availability: %w", err)
 	}
 
+	// Backfill shares.allow_mfsymlink for rows that predate the column — same
+	// SQLite ALTER TABLE NULL quirk as the toggles above.
+	if err := db.Exec(
+		"UPDATE shares SET allow_mfsymlink = ? WHERE allow_mfsymlink IS NULL",
+		false,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to backfill shares.allow_mfsymlink: %w", err)
+	}
+
 	// --- Post-AutoMigrate migrations ---
 	// Step 2: Migrate legacy Share payload_store_id column to local/remote block store IDs.
 	postMigrator := db.Migrator()

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -91,6 +91,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"change_notify_disabled":              share.ChangeNotifyDisabled,
 		"streams_disabled":                    share.StreamsDisabled,
 		"continuous_availability":             share.ContinuousAvailability,
+		"allow_mfsymlink":                     share.AllowMFsymlink,
 		"trash_enabled":                       share.TrashEnabled,
 		"trash_retention_days":                share.TrashRetentionDays,
 		"trash_restrict_to_admin":             share.TrashRestrictToAdmin,

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -705,6 +705,40 @@ func TestShareOperations(t *testing.T) {
 		}
 	})
 
+	t.Run("allow_mfsymlink round-trips through create and update", func(t *testing.T) {
+		// Guards the explicit column:allow_mfsymlink pin — GORM's default
+		// naming would mangle the "MFsymlink" initialism, so the field-map and
+		// backfill literal would target a column AutoMigrate never created.
+		share := &models.Share{
+			Name:              "/export-mfsymlink",
+			MetadataStoreID:   metaStoreID,
+			LocalBlockStoreID: localBlockStoreID,
+			AllowMFsymlink:    true,
+		}
+		if _, err := store.CreateShare(ctx, share); err != nil {
+			t.Fatalf("failed to create share: %v", err)
+		}
+		got, err := store.GetShare(ctx, "/export-mfsymlink")
+		if err != nil {
+			t.Fatalf("failed to get share: %v", err)
+		}
+		if !got.AllowMFsymlink {
+			t.Error("expected CreateShare with AllowMFsymlink=true to persist true")
+		}
+
+		got.AllowMFsymlink = false
+		if err := store.UpdateShare(ctx, got); err != nil {
+			t.Fatalf("failed to update share: %v", err)
+		}
+		updated, err := store.GetShare(ctx, "/export-mfsymlink")
+		if err != nil {
+			t.Fatalf("failed to get share: %v", err)
+		}
+		if updated.AllowMFsymlink {
+			t.Error("expected UpdateShare to persist AllowMFsymlink=false")
+		}
+	})
+
 	t.Run("create share persists acl_flag_inherited_canonicalization=false (#514 GORM default override)", func(t *testing.T) {
 		// Refs #514: GORM substitutes the SQL `default:true` for the
 		// Go zero-value `false`, silently coercing operator intent.


### PR DESCRIPTION
## What
The per-share `AllowMFsymlink` flag — auto-convert 1067-byte XSym (Minshall+French) symlink files written by macOS/Windows SMB clients into real symlinks on CLOSE — existed end-to-end in the SMB adapter (`close.go` gate, tree wiring, runtime `Share`/`ShareConfig`) but had **no way to be set**: it was never persisted or surfaced over any API, so it was permanently stuck at its `false` default.

This wires it through the full stack, mirroring `ContinuousAvailability` (#739).

## Changes
- **Persistence:** `models.Share.AllowMFsymlink` (GORM column **pinned** to `allow_mfsymlink` — GORM's default naming mangles the "MFsymlink" initialism into a different column than the store field-map/backfill use), store field-map, and an AutoMigrate backfill for rows predating the column.
- **REST:** `CreateShareRequest` / `UpdateShareRequest` (`*bool`, nil = no change) + `ShareResponse`.
- **Client/CLI:** apiclient share DTOs; `dfsctl share create --allow-mfsymlink`; `dfsctl share show` row.
- **Runtime:** `init.go` maps the persisted flag into `ShareConfig`.
- **Test:** store round-trip (create=true persists, update→false persists) guarding the column-name pin.
- Regenerated `docs/CLI.md`.

## Behavior
Default stays **false** — the conversion target is client-controlled, so promotion is opt-in. Takes effect on adapter restart (same as the other share toggles).

Local: `go build ./...`, `go vet`, `go test` (controlplane/api/apiclient/dfsctl + `-tags integration` store round-trip), `golangci-lint` (0 issues) all green.