### PR TITLE
fix(blockstore): wire remote-health callback before syncer start (data-loss race)

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -396,10 +396,14 @@ func (bs *Store) Start(ctx context.Context) error {
 	// Use background context so these outlive the calling request context.
 	bs.local.Start(context.Background())
 
-	// Start syncer background goroutines (periodic uploader, transfer queue).
-	bs.syncer.Start(context.Background())
-
-	// Wire health callback to toggle eviction on remote health changes.
+	// Wire the health callback BEFORE starting the syncer. The health monitor
+	// captures the callback at Start time (startHealthMonitor reads
+	// m.onHealthChanged once); registering it afterwards means an initial
+	// "unhealthy" transition fired by the syncer's eager startup probe is
+	// delivered to a nil callback and lost — leaving eviction enabled while the
+	// remote is down, which can evict local CAS chunks before they are mirrored
+	// (silent data loss on read).
+	//
 	// When remote goes unhealthy, suspend eviction to prevent evicting blocks
 	// that cannot be re-downloaded. When healthy again, re-enable eviction.
 	bs.syncer.SetHealthCallback(func(healthy bool) {
@@ -410,6 +414,15 @@ func (bs *Store) Start(ctx context.Context) error {
 			logger.Warn("Remote store unhealthy: eviction suspended")
 		}
 	})
+
+	// Start syncer background goroutines (periodic uploader, transfer queue).
+	bs.syncer.Start(context.Background())
+
+	// Reconcile eviction with the post-start health state, covering the case
+	// where the initial probe settled health without driving a transition
+	// callback (e.g. it started unhealthy with no prior state to transition
+	// from).
+	bs.local.SetEvictionEnabled(bs.syncer.IsRemoteHealthy())
 
 	// Wire the Cache in Start so the loadByHash closure captures bs and
 	// NewCache spawns workers immediately. A single Cache type replaces

--- a/pkg/block/engine/engine_health_test.go
+++ b/pkg/block/engine/engine_health_test.go
@@ -58,7 +58,7 @@ func (f *fakeRemoteStore) SetHealthy(h bool) { f.healthy.Store(h) }
 // RollupStore + a tight stabilization window so the
 // AppendWrite → rollup → CAS chunk → FileBlock-row pipeline runs
 // promptly inside the test.
-func newHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
+func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -105,13 +105,57 @@ func newHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 		t.Fatalf("engine.New() error = %v", err)
 	}
 
+	return bs, fakeRemote
+}
+
+// newHealthTestEngine builds and starts a health test engine with the remote
+// initially healthy.
+func newHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
+	t.Helper()
+	bs, fakeRemote := buildHealthTestEngine(t)
 	if err := bs.Start(context.Background()); err != nil {
 		t.Fatalf("engine.Start() error = %v", err)
 	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, fakeRemote
+}
 
+// TestEngineHealthEvictionSuspended_RemoteUnhealthyAtStart is a regression test
+// for the health-callback ordering bug: the callback must be wired BEFORE the
+// syncer starts, otherwise the initial "unhealthy" transition fired by the
+// startup probe is lost and eviction stays enabled while the remote is down —
+// risking eviction of not-yet-mirrored local CAS chunks. With the remote
+// unhealthy from the outset there is no later transition to recover the lost
+// signal, so the only thing keeping eviction suspended is correct startup
+// wiring + reconciliation.
+func TestEngineHealthEvictionSuspended_RemoteUnhealthyAtStart(t *testing.T) {
+	bs, fakeRemote := buildHealthTestEngine(t)
+	// Remote is unhealthy BEFORE Start, so the initial transition fires during
+	// startup (the window the old code dropped).
+	fakeRemote.SetHealthy(false)
+
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start() error = %v", err)
+	}
 	t.Cleanup(func() { _ = bs.Close() })
 
-	return bs, fakeRemote
+	// Allow the startup probe + threshold to settle, then assert eviction is
+	// suspended. No further health transition occurs (remote stays down), so a
+	// pass here proves the startup signal was not dropped.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if bs.GetStats().EvictionSuspended {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	stats := bs.GetStats()
+	if stats.RemoteHealthy {
+		t.Fatal("expected remote unhealthy at start")
+	}
+	if !stats.EvictionSuspended {
+		t.Fatal("expected eviction suspended when remote is unhealthy at start (health callback wired before syncer start)")
+	}
 }
 
 // TestEngineHealthEvictionSuspension verifies that when remote goes unhealthy


### PR DESCRIPTION
## Issue (v1.0 re-audit deepwaves, verified HIGH)
`Store.Start` registered the eviction-toggle health callback **after** `syncer.Start()`. The syncer's health monitor captures the callback once at start time, and the startup probe can fire an initial *unhealthy* transition synchronously during `Start`. If the remote is already down at startup, that transition is delivered to a **nil** callback and lost — eviction stays enabled while the remote is unhealthy, allowing local CAS chunks to be evicted before they are mirrored remotely → **silent data loss on read**. Because the remote stays down, no later transition recovers the lost signal.

## Fix
- Wire the health callback **before** `syncer.Start()` so `startHealthMonitor` captures a non-nil callback.
- After Start, **reconcile** eviction with the post-start health state (`SetEvictionEnabled(syncer.IsRemoteHealthy())`) to cover a settled-without-transition initial state.
- Regression test `TestEngineHealthEvictionSuspended_RemoteUnhealthyAtStart`: remote unhealthy from the outset → eviction suspended (fails on the old ordering — lost initial transition, no recovery transition).

Local: build, vet, `go test ./pkg/block/engine/`, `golangci-lint` (0 issues) green.

This is the cross-file finding the lens passes missed and the deepwaves re-hunt caught (engine.go ↔ syncer.go ↔ sync_health.go ordering).