### PR TITLE
perf(nfs): single-alloc RPC reply; reader-free AUTH_UNIX; direct-write fattr encode

### DIFF
--- a/internal/adapter/nfs/rpc/auth.go
+++ b/internal/adapter/nfs/rpc/auth.go
@@ -1,9 +1,9 @@
 package rpc
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 )
 
 // Authentication Flavors
@@ -120,18 +120,35 @@ func ParseUnixAuth(body []byte) (*UnixAuth, error) {
 	}
 
 	auth := &UnixAuth{}
-	reader := bytes.NewReader(body)
+
+	// PERFORMANCE OPTIMIZATION: Decode directly from the body slice with a
+	// manual offset instead of wrapping it in a bytes.Reader and using
+	// reflection-based binary.Read. off tracks the current read position.
+	off := 0
+
+	// readUint32 consumes the next big-endian uint32, returning an error if
+	// fewer than 4 bytes remain (equivalent to binary.Read's truncation error).
+	readUint32 := func(field string) (uint32, error) {
+		if off+4 > len(body) {
+			return 0, fmt.Errorf("read %s: %w", field, io.ErrUnexpectedEOF)
+		}
+		v := binary.BigEndian.Uint32(body[off : off+4])
+		off += 4
+		return v, nil
+	}
 
 	// Read stamp (4 bytes, big-endian)
 	// This is an arbitrary client-generated identifier
-	if err := binary.Read(reader, binary.BigEndian, &auth.Stamp); err != nil {
-		return nil, fmt.Errorf("read stamp: %w", err)
+	stamp, err := readUint32("stamp")
+	if err != nil {
+		return nil, err
 	}
+	auth.Stamp = stamp
 
 	// Read machine name length (4 bytes, big-endian)
-	var nameLen uint32
-	if err := binary.Read(reader, binary.BigEndian, &nameLen); err != nil {
-		return nil, fmt.Errorf("read machine name length: %w", err)
+	nameLen, err := readUint32("machine name length")
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate machine name length to prevent excessive memory allocation
@@ -141,35 +158,43 @@ func ParseUnixAuth(body []byte) (*UnixAuth, error) {
 	}
 
 	// Read machine name bytes
-	nameBytes := make([]byte, nameLen)
-	if err := binary.Read(reader, binary.BigEndian, &nameBytes); err != nil {
-		return nil, fmt.Errorf("read machine name: %w", err)
+	if off+int(nameLen) > len(body) {
+		return nil, fmt.Errorf("read machine name: %w", io.ErrUnexpectedEOF)
 	}
-	auth.MachineName = string(nameBytes)
+	auth.MachineName = string(body[off : off+int(nameLen)])
+	off += int(nameLen)
 
 	// Skip XDR padding to align to 4-byte boundary
-	// XDR strings are padded to ensure the next field starts at a 4-byte boundary
-	padding := (4 - (nameLen % 4)) % 4
-	for i := uint32(0); i < padding; i++ {
-		_, _ = reader.ReadByte()
+	// XDR strings are padded to ensure the next field starts at a 4-byte
+	// boundary. Matching the previous behaviour, padding bytes past the end of
+	// the body are tolerated rather than treated as an error.
+	padding := int((4 - (nameLen % 4)) % 4)
+	if off+padding > len(body) {
+		off = len(body)
+	} else {
+		off += padding
 	}
 
 	// Read UID (4 bytes, big-endian)
 	// This is the effective user ID on the client
-	if err := binary.Read(reader, binary.BigEndian, &auth.UID); err != nil {
-		return nil, fmt.Errorf("read uid: %w", err)
+	uid, err := readUint32("uid")
+	if err != nil {
+		return nil, err
 	}
+	auth.UID = uid
 
 	// Read GID (4 bytes, big-endian)
 	// This is the effective primary group ID on the client
-	if err := binary.Read(reader, binary.BigEndian, &auth.GID); err != nil {
-		return nil, fmt.Errorf("read gid: %w", err)
+	gid, err := readUint32("gid")
+	if err != nil {
+		return nil, err
 	}
+	auth.GID = gid
 
 	// Read supplementary GIDs count (4 bytes, big-endian)
-	var gidsLen uint32
-	if err := binary.Read(reader, binary.BigEndian, &gidsLen); err != nil {
-		return nil, fmt.Errorf("read gids length: %w", err)
+	gidsLen, err := readUint32("gids length")
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate GID count to prevent excessive memory allocation
@@ -182,9 +207,11 @@ func ParseUnixAuth(body []byte) (*UnixAuth, error) {
 	// These represent additional group memberships beyond the primary GID
 	auth.GIDs = make([]uint32, gidsLen)
 	for i := uint32(0); i < gidsLen; i++ {
-		if err := binary.Read(reader, binary.BigEndian, &auth.GIDs[i]); err != nil {
-			return nil, fmt.Errorf("read gid[%d]: %w", i, err)
+		g, err := readUint32(fmt.Sprintf("gid[%d]", i))
+		if err != nil {
+			return nil, err
 		}
+		auth.GIDs[i] = g
 	}
 
 	return auth, nil

--- a/internal/adapter/nfs/rpc/auth.go
+++ b/internal/adapter/nfs/rpc/auth.go
@@ -204,14 +204,16 @@ func ParseUnixAuth(body []byte) (*UnixAuth, error) {
 	}
 
 	// Read each supplementary GID (4 bytes each, big-endian)
-	// These represent additional group memberships beyond the primary GID
+	// These represent additional group memberships beyond the primary GID.
+	// Inlined (rather than via readUint32) so the success path performs no
+	// fmt.Sprintf allocation per element; the index is only formatted on error.
 	auth.GIDs = make([]uint32, gidsLen)
 	for i := uint32(0); i < gidsLen; i++ {
-		g, err := readUint32(fmt.Sprintf("gid[%d]", i))
-		if err != nil {
-			return nil, err
+		if off+4 > len(body) {
+			return nil, fmt.Errorf("read gid[%d]: %w", i, io.ErrUnexpectedEOF)
 		}
-		auth.GIDs[i] = g
+		auth.GIDs[i] = binary.BigEndian.Uint32(body[off : off+4])
+		off += 4
 	}
 
 	return auth, nil

--- a/internal/adapter/nfs/rpc/parser.go
+++ b/internal/adapter/nfs/rpc/parser.go
@@ -277,11 +277,19 @@ func MakeSuccessReply(xid uint32, data []byte) ([]byte, error) {
 		AcceptStat: RPCSuccess, // 0 = SUCCESS (procedure executed successfully)
 	}
 
-	// PERFORMANCE OPTIMIZATION: Pre-allocate buffer for reply header
-	// Size: RPC reply header (~28 bytes) + procedure data
-	replyHeaderSize := 28
-	estimatedSize := replyHeaderSize + len(data)
+	// PERFORMANCE OPTIMIZATION: Marshal the entire reply into a single buffer,
+	// reserving 4 leading placeholder bytes for the record-marking fragment
+	// header. This avoids a second allocation for the fragment header and the
+	// full-payload copy that prepending it would otherwise require.
+	// Size: 4 (fragment header) + RPC reply header (~28 bytes) + procedure data
+	const replyHeaderSize = 28
+	estimatedSize := 4 + replyHeaderSize + len(data)
 	buf := bytes.NewBuffer(make([]byte, 0, estimatedSize))
+
+	// Reserve 4 placeholder bytes for the fragment header; patched in below
+	// once the total record length is known. WriteString avoids allocating a
+	// throwaway byte slice for the placeholder.
+	buf.WriteString("\x00\x00\x00\x00")
 
 	// Marshal the reply header using XDR encoding
 	// This converts the struct to network byte order
@@ -294,20 +302,12 @@ func MakeSuccessReply(xid uint32, data []byte) ([]byte, error) {
 	// This data should already be XDR-encoded by the caller
 	buf.Write(data)
 
-	// Prepend RPC fragment header (4 bytes)
+	// Patch the RPC fragment header (first 4 bytes) in place.
 	// Format: [last_fragment_bit (1 bit)][fragment_length (31 bits)]
-	replyData := buf.Bytes()
-	fragmentHeader := make([]byte, 4)
-
-	// Set high bit (0x80000000) to indicate last fragment
-	// OR with length to combine both fields
-	// 0x80000000 = binary 10000000_00000000_00000000_00000000
-	binary.BigEndian.PutUint32(fragmentHeader, 0x80000000|uint32(len(replyData)))
-
-	// PERFORMANCE OPTIMIZATION: Pre-allocate final buffer to avoid append reallocation
-	result := make([]byte, 0, 4+len(replyData))
-	result = append(result, fragmentHeader...)
-	result = append(result, replyData...)
+	// The fragment length covers everything after the 4-byte header. The high
+	// bit (0x80000000) marks this as the last (and only) fragment.
+	result := buf.Bytes()
+	binary.BigEndian.PutUint32(result[:4], 0x80000000|uint32(len(result)-4))
 	return result, nil
 }
 

--- a/internal/adapter/nfs/rpc/rpc_test.go
+++ b/internal/adapter/nfs/rpc/rpc_test.go
@@ -415,3 +415,57 @@ func TestHeaderMICPreimage(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// ============================================================================
+// MakeSuccessReply Tests
+// ============================================================================
+
+func TestMakeSuccessReply(t *testing.T) {
+	t.Run("WireFormatAndRecordMarker", func(t *testing.T) {
+		xid := uint32(0xABCD1234)
+		data := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04}
+
+		reply, err := MakeSuccessReply(xid, data)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(reply), 4)
+
+		// Fragment header: last-fragment bit set, length = everything after it.
+		fragHeader := binary.BigEndian.Uint32(reply[0:4])
+		assert.NotZero(t, fragHeader&0x80000000, "last fragment bit must be set")
+		assert.Equal(t, uint32(len(reply)-4), fragHeader&0x7FFFFFFF,
+			"fragment length must equal record body length")
+
+		// The XDR-decoded reply body must round-trip the original fields, and
+		// the trailing bytes must equal the supplied procedure data verbatim.
+		var decoded RPCReplyMessage
+		n, err := xdr.Unmarshal(bytes.NewReader(reply[4:]), &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, xid, decoded.XID)
+		assert.Equal(t, uint32(RPCReply), decoded.MsgType)
+		assert.Equal(t, uint32(RPCMsgAccepted), decoded.ReplyState)
+		assert.Equal(t, uint32(RPCSuccess), decoded.AcceptStat)
+		assert.Equal(t, data, reply[4+n:], "procedure data must be appended verbatim")
+	})
+
+	t.Run("HandlesEmptyData", func(t *testing.T) {
+		reply, err := MakeSuccessReply(1, nil)
+		require.NoError(t, err)
+		fragHeader := binary.BigEndian.Uint32(reply[0:4])
+		assert.NotZero(t, fragHeader&0x80000000)
+		assert.Equal(t, uint32(len(reply)-4), fragHeader&0x7FFFFFFF)
+	})
+}
+
+func TestParseUnixAuth_Truncated(t *testing.T) {
+	full := encodeAuthUnix(validAuthUnixCredentials())
+
+	// Every strict prefix shorter than the full body is malformed and must
+	// produce an error rather than a partial/garbage credential.
+	for n := 1; n < len(full); n++ {
+		_, err := ParseUnixAuth(full[:n])
+		// A prefix is only valid if it happens to land exactly on the end of
+		// the GID array; otherwise it must error. The full body's final field
+		// is the last GID, so any strict prefix is short.
+		require.Error(t, err, "prefix length %d should be rejected", n)
+	}
+}

--- a/internal/adapter/nfs/xdr/encode.go
+++ b/internal/adapter/nfs/xdr/encode.go
@@ -215,60 +215,35 @@ func EncodeFileAttr(buf *bytes.Buffer, attr *types.NFSFileAttr) error {
 		return fmt.Errorf("file attributes are nil")
 	}
 
-	// Write all fields in order per RFC 1813
-	if err := binary.Write(buf, binary.BigEndian, attr.Type); err != nil {
-		return fmt.Errorf("write type: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Mode); err != nil {
-		return fmt.Errorf("write mode: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Nlink); err != nil {
-		return fmt.Errorf("write nlink: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.UID); err != nil {
-		return fmt.Errorf("write uid: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.GID); err != nil {
-		return fmt.Errorf("write gid: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Size); err != nil {
-		return fmt.Errorf("write size: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Used); err != nil {
-		return fmt.Errorf("write used: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Rdev); err != nil {
-		return fmt.Errorf("write rdev: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Fsid); err != nil {
-		return fmt.Errorf("write fsid: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Fileid); err != nil {
-		return fmt.Errorf("write fileid: %w", err)
-	}
+	// fattr3 is a fixed-size structure: 5 uint32 + 2 uint64 + specdata3 (2
+	// uint32) + 2 uint64 + 3 nfstime3 (each 2 uint32) = 84 bytes. Encode all
+	// fields directly into a stack-allocated array via binary.BigEndian to
+	// avoid the per-field reflection overhead of binary.Write.
+	var b [84]byte
+	binary.BigEndian.PutUint32(b[0:4], attr.Type)
+	binary.BigEndian.PutUint32(b[4:8], attr.Mode)
+	binary.BigEndian.PutUint32(b[8:12], attr.Nlink)
+	binary.BigEndian.PutUint32(b[12:16], attr.UID)
+	binary.BigEndian.PutUint32(b[16:20], attr.GID)
+	binary.BigEndian.PutUint64(b[20:28], attr.Size)
+	binary.BigEndian.PutUint64(b[28:36], attr.Used)
+	// rdev (specdata3): major then minor
+	binary.BigEndian.PutUint32(b[36:40], attr.Rdev.Major)
+	binary.BigEndian.PutUint32(b[40:44], attr.Rdev.Minor)
+	binary.BigEndian.PutUint64(b[44:52], attr.Fsid)
+	binary.BigEndian.PutUint64(b[52:60], attr.Fileid)
+	// atime (nfstime3): seconds then nseconds
+	binary.BigEndian.PutUint32(b[60:64], attr.Atime.Seconds)
+	binary.BigEndian.PutUint32(b[64:68], attr.Atime.Nseconds)
+	// mtime (nfstime3)
+	binary.BigEndian.PutUint32(b[68:72], attr.Mtime.Seconds)
+	binary.BigEndian.PutUint32(b[72:76], attr.Mtime.Nseconds)
+	// ctime (nfstime3)
+	binary.BigEndian.PutUint32(b[76:80], attr.Ctime.Seconds)
+	binary.BigEndian.PutUint32(b[80:84], attr.Ctime.Nseconds)
 
-	// Write atime (nfstime3)
-	if err := binary.Write(buf, binary.BigEndian, attr.Atime.Seconds); err != nil {
-		return fmt.Errorf("write atime seconds: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Atime.Nseconds); err != nil {
-		return fmt.Errorf("write atime nseconds: %w", err)
-	}
-
-	// Write mtime (nfstime3)
-	if err := binary.Write(buf, binary.BigEndian, attr.Mtime.Seconds); err != nil {
-		return fmt.Errorf("write mtime seconds: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Mtime.Nseconds); err != nil {
-		return fmt.Errorf("write mtime nseconds: %w", err)
-	}
-
-	// Write ctime (nfstime3)
-	if err := binary.Write(buf, binary.BigEndian, attr.Ctime.Seconds); err != nil {
-		return fmt.Errorf("write ctime seconds: %w", err)
-	}
-	if err := binary.Write(buf, binary.BigEndian, attr.Ctime.Nseconds); err != nil {
-		return fmt.Errorf("write ctime nseconds: %w", err)
+	if _, err := buf.Write(b[:]); err != nil {
+		return fmt.Errorf("write fattr3: %w", err)
 	}
 
 	return nil

--- a/internal/adapter/nfs/xdr/encode_fattr_test.go
+++ b/internal/adapter/nfs/xdr/encode_fattr_test.go
@@ -1,0 +1,65 @@
+package xdr
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
+)
+
+// goldenFileAttr is a fully-populated fattr3 with distinct, non-trivial values
+// in every field so that any byte-offset or endianness regression in
+// EncodeFileAttr is detected.
+func goldenFileAttr() *types.NFSFileAttr {
+	return &types.NFSFileAttr{
+		Type:   1,
+		Mode:   0o644,
+		Nlink:  2,
+		UID:    1000,
+		GID:    1001,
+		Size:   123456789,
+		Used:   0xdeadbeefcafe,
+		Rdev:   types.SpecData{Major: 7, Minor: 13},
+		Fsid:   0x1122334455667788,
+		Fileid: 0x99aabbccddeeff00,
+		Atime:  types.TimeVal{Seconds: 0x01020304, Nseconds: 0x05060708},
+		Mtime:  types.TimeVal{Seconds: 0x11121314, Nseconds: 0x15161718},
+		Ctime:  types.TimeVal{Seconds: 0x21222324, Nseconds: 0x25262728},
+	}
+}
+
+// TestEncodeFileAttr_GoldenBytes asserts byte-for-byte equality against the
+// exact wire output captured from the previous reflection-based encoder. The
+// fattr3 wire format must never drift, so this golden vector is load-bearing.
+func TestEncodeFileAttr_GoldenBytes(t *testing.T) {
+	// Captured from the previous reflection-based EncodeFileAttr implementation.
+	const golden = "00000001000001a400000002000003e8000003e900000000075bcd150000deadbeefcafe000000070000000d112233445566778899aabbccddeeff00010203040506070811121314151617182122232425262728"
+
+	want, err := hex.DecodeString(golden)
+	if err != nil {
+		t.Fatalf("decode golden hex: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := EncodeFileAttr(&buf, goldenFileAttr()); err != nil {
+		t.Fatalf("EncodeFileAttr: %v", err)
+	}
+
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("EncodeFileAttr wire mismatch:\n got=%x\nwant=%x", got, want)
+	}
+
+	// fattr3 is fixed-size: 5 uint32 + 2 uint64 + specdata3 + 2 uint64 + 3
+	// nfstime3 = 84 bytes.
+	if buf.Len() != 84 {
+		t.Fatalf("EncodeFileAttr length = %d, want 84", buf.Len())
+	}
+}
+
+func TestEncodeFileAttr_NilReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EncodeFileAttr(&buf, nil); err == nil {
+		t.Fatal("EncodeFileAttr(nil) = nil error, want error")
+	}
+}


### PR DESCRIPTION
Fixes three verified allocation findings in the NFS RPC/XDR layer. All changes preserve the exact wire output.

## Findings & fixes

1. **`rpc/parser.go` `MakeSuccessReply`** — previously did two heap allocations (header buffer + final result buffer) plus a full-payload copy per reply. Now marshals the header and payload into a single buffer that reserves 4 leading placeholder bytes for the record-marking fragment header, then patches those bytes in place via `binary.BigEndian.PutUint32`. Eliminates the second allocation and the full-payload copy. Last-fragment bit (`0x80000000`) and fragment length (record bytes minus the 4-byte marker) are unchanged.

2. **`rpc/auth.go` `ParseUnixAuth`** (LOW) — dropped the per-request `bytes.NewReader` + reflection-based `binary.Read`. Now decodes directly from the `[]byte` body with a manual offset and `binary.BigEndian.Uint32`, with explicit bounds checks. Error handling is equivalent: truncated/short input returns an error (`io.ErrUnexpectedEOF`-wrapped), and trailing padding past the end of the body is tolerated exactly as before.

3. **`xdr/encode.go` `EncodeFileAttr`** (LOW) — replaced 16 reflection-based `binary.Write` calls (and the `SpecData` reflect path) with direct `binary.BigEndian.PutUint32/64` writes into a fixed 84-byte stack array, followed by a single `buf.Write`. **Byte-for-byte identical output is required** — a golden-byte vector captured from the previous implementation is asserted in the new test.

## Tests
- `xdr/encode_fattr_test.go`: golden-byte assertion (84-byte fattr3) + nil-error case.
- `rpc/rpc_test.go`: `MakeSuccessReply` wire-format + record-marker + XDR round-trip + verbatim payload tail; `ParseUnixAuth` truncation sweep (every strict prefix rejected). Existing `ParseUnixAuth` round-trip coverage retained.

`go build ./...`, `go vet ./internal/adapter/nfs/...`, and `go test [-race] ./internal/adapter/nfs/...` all green.