### PR TITLE
perf(smb): dedup CREATE conflict scans; arithmetic EA size; pre-fold QUERY_DIRECTORY sort

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -122,32 +122,22 @@ func effectiveAccessForOpen(desiredAccess uint32, disposition types.CreateDispos
 	return desiredAccess | uint32(types.FileWriteData)
 }
 
-// hasOtherNonStatOpenForFile reports whether any open in h.files refers to
-// the same metadata handle as fileHandle (excluding the open identified by
-// selfFileID) AND has a non-stat-only access mask. Stat-only opens are
-// excluded because Samba's `disallow_write_lease` predicate
-// (source3/smbd/open.c lines 2397-2403) ignores them — they do not invalidate
-// the exclusive caching premise of a Batch/Exclusive grant on a subsequent
-// opener.
-//
-// Used by the traditional-oplock grant path to coerce Batch/Exclusive to
-// LEVEL_II when a previously-existing raw (non-oplocked) open is present.
-// Callers must additionally verify that no lease/oplock record exists for the
-// file via LeaseManager.HasAnyLeaseRecord — when a record exists (even at
-// LeaseStateNone post-break-timeout), bestGrantableState already handles the
-// grant correctly and the coarse OpenFile coercion would incorrectly demote
-// a grant that the lease layer would otherwise allow (smbtorture batch22b
-// post-timeout re-grant).
-func (h *Handler) hasOtherNonStatOpenForFile(fileHandle metadata.FileHandle, selfFileID [16]byte) bool {
-	hasNonStat, _ := h.scanNonStatOpensForFile(fileHandle, selfFileID, [16]byte{}, false)
-	return hasNonStat
-}
-
 // scanNonStatOpensForFile walks h.files once and reports two predicates used by
 // the post-break traditional-oplock grant path:
 //
 //   - hasNonStat: any non-stat-only OpenFile on the same metadata handle
-//     (excluding selfFileID) exists. Equivalent to hasOtherNonStatOpenForFile.
+//     (excluding the open identified by selfFileID) exists. Stat-only opens
+//     are excluded because Samba's `disallow_write_lease` predicate
+//     (source3/smbd/open.c lines 2397-2403) ignores them — they do not
+//     invalidate the exclusive caching premise of a Batch/Exclusive grant on a
+//     subsequent opener. Used to coerce Batch/Exclusive to LEVEL_II when a
+//     previously-existing raw (non-oplocked) open is present. Callers must
+//     additionally verify that no lease/oplock record exists for the file via
+//     LeaseManager.HasAnyLeaseRecord — when a record exists (even at
+//     LeaseStateNone post-break-timeout) bestGrantableState already handles the
+//     grant correctly and the coarse OpenFile coercion would incorrectly demote
+//     a grant the lease layer would otherwise allow (smbtorture batch22b
+//     post-timeout re-grant).
 //   - hasSameClient: any such open is also owned by clientGUID (the
 //     ClientGUID-scoped variant). Only computed when checkSameClient is true —
 //     callers that don't yet have a connection identity skip it.

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -139,10 +139,50 @@ func effectiveAccessForOpen(desiredAccess uint32, disposition types.CreateDispos
 // a grant that the lease layer would otherwise allow (smbtorture batch22b
 // post-timeout re-grant).
 func (h *Handler) hasOtherNonStatOpenForFile(fileHandle metadata.FileHandle, selfFileID [16]byte) bool {
+	hasNonStat, _ := h.scanNonStatOpensForFile(fileHandle, selfFileID, [16]byte{}, false)
+	return hasNonStat
+}
+
+// scanNonStatOpensForFile walks h.files once and reports two predicates used by
+// the post-break traditional-oplock grant path:
+//
+//   - hasNonStat: any non-stat-only OpenFile on the same metadata handle
+//     (excluding selfFileID) exists. Equivalent to hasOtherNonStatOpenForFile.
+//   - hasSameClient: any such open is also owned by clientGUID (the
+//     ClientGUID-scoped variant). Only computed when checkSameClient is true —
+//     callers that don't yet have a connection identity skip it.
+//
+// The same-client carve-out distinguishes the two arms of smbtorture
+// smb2.oplock.batch22{a,b}:
+//
+//   - batch22b (different ClientGUID, tree2 opens after tree1's batch break
+//     times out): tree2 must receive a fresh BATCH grant — the abandoned
+//     holder is on a different client, so its still-alive OpenFile does not
+//     invalidate batch caching semantics for the new client.
+//   - batch22a (same ClientGUID, h2 opens on tree1 after h1's batch break
+//     times out): h2 must receive LEVEL_II — h1 is still alive on this
+//     client and may hold dirty cached data, so exclusive batch caching
+//     cannot be granted again to the same client.
+//
+// The all-tombstones gate (OnlyTimeoutTombstoneRecords) handles the
+// different-client side by skipping the strip when only timeout tombstones
+// remain; hasSameClient carves out the same-client exception: even after
+// timeout, a same-ClientGUID non-stat open constrains the new grant. Mirrors
+// Samba's `disallow_write_lease` predicate (source3/smbd/open.c lines
+// 2397-2403), which gates on whether the existing entry's connection matches
+// the requestor's client; we approximate via ClientGUID equality.
+//
+// Folding both predicates into one Range pass avoids a redundant O(F) scan per
+// CREATE on the traditional-oplock grant path.
+func (h *Handler) scanNonStatOpensForFile(
+	fileHandle metadata.FileHandle,
+	selfFileID [16]byte,
+	clientGUID [16]byte,
+	checkSameClient bool,
+) (hasNonStat, hasSameClient bool) {
 	if len(fileHandle) == 0 {
-		return false
+		return false, false
 	}
-	found := false
 	h.files.Range(func(_, value any) bool {
 		other := value.(*OpenFile)
 		if other.FileID == selfFileID {
@@ -159,68 +199,19 @@ func (h *Handler) hasOtherNonStatOpenForFile(fileHandle metadata.FileHandle, sel
 		if isOplockStatOpen(other.DesiredAccess) {
 			return true
 		}
-		found = true
-		return false
+		hasNonStat = true
+		if checkSameClient && other.ClientGUID == clientGUID {
+			hasSameClient = true
+		}
+		// Stop early once both flags are settled (hasSameClient implies
+		// hasNonStat; when same-client is not requested, the first non-stat
+		// open is conclusive).
+		if !checkSameClient || hasSameClient {
+			return false
+		}
+		return true
 	})
-	return found
-}
-
-// hasSameClientNonStatOpenForFile is the ClientGUID-scoped variant of
-// hasOtherNonStatOpenForFile. It reports whether any open in h.files on the
-// same metadata handle (excluding selfFileID) is owned by the SAME SMB
-// ClientGUID AND has a non-stat-only access mask.
-//
-// Used by the post-break trad-oplock grant path to distinguish the two arms
-// of smbtorture smb2.oplock.batch22{a,b}:
-//
-//   - batch22b (different ClientGUID, tree2 opens after tree1's batch break
-//     times out): tree2 must receive a fresh BATCH grant — the abandoned
-//     holder is on a different client, so its still-alive OpenFile does not
-//     invalidate batch caching semantics for the new client.
-//   - batch22a (same ClientGUID, h2 opens on tree1 after h1's batch break
-//     times out): h2 must receive LEVEL_II — h1 is still alive on this
-//     client and may hold dirty cached data, so exclusive batch caching
-//     cannot be granted again to the same client.
-//
-// The all-tombstones gate (OnlyTimeoutTombstoneRecords) handles the
-// different-client side by skipping the strip when only timeout tombstones
-// remain. This helper carves out the same-client exception: even after
-// timeout, a same-ClientGUID non-stat open constrains the new grant.
-//
-// Mirrors Samba's `disallow_write_lease` predicate (source3/smbd/open.c
-// lines 2397-2403) which gates on whether the existing entry's connection
-// matches the requestor's client — Samba's share entries carry the open's
-// connection identity directly; we approximate via ClientGUID equality.
-func (h *Handler) hasSameClientNonStatOpenForFile(
-	fileHandle metadata.FileHandle,
-	selfFileID [16]byte,
-	clientGUID [16]byte,
-) bool {
-	if len(fileHandle) == 0 {
-		return false
-	}
-	found := false
-	h.files.Range(func(_, value any) bool {
-		other := value.(*OpenFile)
-		if other.FileID == selfFileID {
-			return true
-		}
-		if len(other.MetadataHandle) == 0 {
-			return true
-		}
-		if !bytes.Equal(other.MetadataHandle, fileHandle) {
-			return true
-		}
-		if other.ClientGUID != clientGUID {
-			return true
-		}
-		if isOplockStatOpen(other.DesiredAccess) {
-			return true
-		}
-		found = true
-		return false
-	})
-	return found
+	return hasNonStat, hasSameClient
 }
 
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
@@ -280,13 +271,32 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// break to None; share-mode violation or DELETE_ON_CLOSE → strip
 	// Handle so other holders drop cached handles ahead of the delete;
 	// otherwise → strip Write.
+	//
+	// Compute the share-mode conflict once for the break-reason decision and
+	// reuse it as the FIRST poll of the share-conflict-wait closure below.
+	// Whenever we reach the conflict scan the disposition is non-destructive
+	// (destructive is handled by the prior switch case), so
+	// effectiveAccessForOpen(req) == req.DesiredAccess here and the wait
+	// closure's effectiveAccess matches this scan's input — the cached result
+	// is exact. The scan only runs when delete-on-close is unset (otherwise the
+	// reason is already SharingViolation and no scan is needed).
+	//
+	// initialConflict is consumed at most once by the wait closure; every
+	// subsequent poll must re-scan because a holder CLOSE/ACK can clear the
+	// conflict. conflictComputed records whether the scan actually ran.
+	var initialConflict, conflictComputed bool
 	reason := lock.BreakReasonDefault
 	switch {
 	case isDestructiveDisposition(d.req.CreateDisposition):
 		reason = lock.BreakReasonDestructive
-	case d.req.CreateOptions&types.FileDeleteOnClose != 0,
-		h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename):
+	case d.req.CreateOptions&types.FileDeleteOnClose != 0:
 		reason = lock.BreakReasonSharingViolation
+	default:
+		initialConflict = h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename)
+		conflictComputed = true
+		if initialConflict {
+			reason = lock.BreakReasonSharingViolation
+		}
 	}
 
 	var waitExceptKey [16]byte
@@ -419,7 +429,18 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	defer cancelWait()
 	if shareConflictWait {
 		effectiveAccess := effectiveAccessForOpen(d.req.DesiredAccess, d.req.CreateDisposition)
+		// Reuse the conflict scan already performed for the break-reason
+		// decision on the FIRST poll, then re-scan on every subsequent poll
+		// (a holder CLOSE/ACK can clear the conflict). The cached result is
+		// only valid when the reason was driven by initialConflict
+		// (conflictComputed); the delete-on-close path set the reason without
+		// scanning, so it falls straight through to a live scan.
+		firstPoll := conflictComputed
 		conflictPresent := func() bool {
+			if firstPoll {
+				firstPoll = false
+				return initialConflict
+			}
 			return d.existingHandle != nil &&
 				h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.filename)
 		}
@@ -1088,16 +1109,20 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		lockFileHandle := lock.FileHandle(fileHandle)
 		onlyTimeoutTombstone := h.LeaseManager.OnlyTimeoutTombstoneRecords(lockFileHandle, tree.ShareName)
 		hasActiveRecord := h.LeaseManager.HasActiveLeaseRecord(lockFileHandle, tree.ShareName, [16]byte{})
-		hasNonStatOpen := h.hasOtherNonStatOpenForFile(fileHandle, smbFileID)
-		// Only consult the same-client carve-out once NEGOTIATE has
-		// established a connection identity. Without CryptoState the
-		// requestor's identity is unknown — falling through would zero-
-		// vs-zero match unrelated pre-NEGOTIATE opens (regressed
+		// Single O(F) pass over h.files yields both the non-stat-open flag and
+		// the same-client carve-out. The same-client check is only consulted
+		// once NEGOTIATE has established a connection identity — without
+		// CryptoState the requestor's identity is unknown and a zero-vs-zero
+		// match would catch unrelated pre-NEGOTIATE opens (regressed
 		// smb2.compound.interim2 when the early gate was removed).
-		hasSameClientOpen := false
-		if ctx != nil && ctx.ConnCryptoState != nil {
-			hasSameClientOpen = h.hasSameClientNonStatOpenForFile(fileHandle, smbFileID, connClientGUID(ctx))
+		checkSameClient := ctx != nil && ctx.ConnCryptoState != nil
+		var sameClientGUID [16]byte
+		if checkSameClient {
+			sameClientGUID = connClientGUID(ctx)
 		}
+		hasNonStatOpen, hasSameClientOpen := h.scanNonStatOpensForFile(
+			fileHandle, smbFileID, sameClientGUID, checkSameClient,
+		)
 		if (!onlyTimeoutTombstone && (hasActiveRecord || hasNonStatOpen)) ||
 			(onlyTimeoutTombstone && hasSameClientOpen) {
 			requestedState &^= (lock.LeaseStateWrite | lock.LeaseStateHandle)

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -443,7 +443,7 @@ func shouldPersistDurableOnDisconnect(
 //     downgrading its own lease (smb2.lease.upgrade3, smb2.lease.break). Samba
 //     keys conflict on the share entry's connection identity; we approximate via
 //     ClientGuid equality, the same approximation used by
-//     hasSameClientNonStatOpenForFile.
+//     scanNonStatOpensForFile's same-client carve-out.
 //
 // Pipes, directories, and the requestor's own opens (same SMB FileID) never
 // contribute. The decision only strips W — it never blocks the grant or sends a

--- a/internal/adapter/smb/handlers/ea.go
+++ b/internal/adapter/smb/handlers/ea.go
@@ -173,6 +173,48 @@ func encodeFullEaInformation(eas map[string][]byte) []byte {
 // FILE_ALL_INFORMATION / FILE_EA_INFORMATION. Matches encodeFullEaInformation's
 // layout exactly (including inter-entry 4-byte padding).
 func fullEaInformationSize(eas map[string][]byte) uint32 {
-	encoded := encodeFullEaInformation(eas)
-	return uint32(len(encoded))
+	// Accumulate the chain length arithmetically, avoiding the allocation of
+	// the full encoded chain just to measure it. The filter rules MUST match
+	// encodeFullEaInformation exactly: the reserved ACL-xattr slot is never
+	// enumerated, and entries whose name/value exceed the wire field widths
+	// (EaNameLength uint8 / EaValueLength uint16) are skipped. Each entry is
+	// fixed-header(8) + name + NUL(1) + value; every entry except the LAST is
+	// padded up to a 4-byte boundary.
+	//
+	// Which entry is "last" matters because per-entry padding depends on the
+	// entry's own length, so the names are sorted with the same comparator as
+	// the encoder to identify the unpadded final entry. Sorting the name slice
+	// is far cheaper than materialising the whole byte chain.
+	names := make([]string, 0, len(eas))
+	for name := range eas {
+		if isReservedACLXattrName(name) {
+			continue
+		}
+		if len(name) > 0xFF || len(eas[name]) > 0xFFFF {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return 0
+	}
+	sort.Slice(names, func(i, j int) bool {
+		li, lj := strings.ToUpper(names[i]), strings.ToUpper(names[j])
+		if li == lj {
+			return names[i] < names[j]
+		}
+		return li < lj
+	})
+
+	var total int
+	for idx, name := range names {
+		entry := 8 + len(name) + 1 + len(eas[name])
+		if idx < len(names)-1 {
+			if pad := entry % 4; pad != 0 {
+				entry += 4 - pad
+			}
+		}
+		total += entry
+	}
+	return uint32(total)
 }

--- a/internal/adapter/smb/handlers/ea_test.go
+++ b/internal/adapter/smb/handlers/ea_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -171,5 +172,58 @@ func TestFileAttrEAHelpers_CaseInsensitiveAndPreserveCase(t *testing.T) {
 	a.ApplyEAMutations([]metadata.EAMutation{{Name: "mixedea", Delete: true}})
 	if a.EAs != nil {
 		t.Fatalf("deleting the last EA must nil the map, got %v", a.EAs)
+	}
+}
+
+// TestFullEaInformationSize_MatchesEncodedLength asserts the arithmetic size
+// helper returns exactly len(encodeFullEaInformation(...)) across empty,
+// single, and multi-EA inputs with varying name/value lengths (including
+// entries that need 4-byte padding and entries that are already aligned), plus
+// the reserved ACL-xattr and oversized-field skips.
+func TestFullEaInformationSize_MatchesEncodedLength(t *testing.T) {
+	cases := []struct {
+		name string
+		eas  map[string][]byte
+	}{
+		{"empty", nil},
+		{"empty-map", map[string][]byte{}},
+		{"single-aligned", map[string][]byte{"AB": []byte("xy")}},
+		{"single-needs-pad", map[string][]byte{"NAME": []byte("v")}},
+		{"single-zero-value", map[string][]byte{"FLAG": nil}},
+		{
+			"multi-varied",
+			map[string][]byte{
+				"a":          []byte("1"),
+				"BB":         []byte("value-two"),
+				"ccc":        []byte(""),
+				"LongerName": bytes.Repeat([]byte("x"), 37),
+				"zEnd":       []byte("last"),
+			},
+		},
+		{
+			"reserved-skipped",
+			map[string][]byte{
+				reservedACLXattrName: bytes.Repeat([]byte("z"), 100),
+				"keepme":             []byte("data"),
+			},
+		},
+		{
+			"oversized-skipped",
+			map[string][]byte{
+				strings.Repeat("n", 0x100): []byte("v"),                        // name > 0xFF, skipped
+				"big":                      bytes.Repeat([]byte("v"), 0x10000), // value > 0xFFFF, skipped
+				"ok":                       []byte("fine"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := uint32(len(encodeFullEaInformation(tc.eas)))
+			got := fullEaInformationSize(tc.eas)
+			if got != want {
+				t.Fatalf("fullEaInformationSize = %d, want len(encode) = %d", got, want)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -233,6 +233,24 @@ func EncodeDirectoryEntry(entry *DirectoryEntry, nextOffset uint32) []byte {
 // Protocol Handler
 // ============================================================================
 
+// entriesByFoldedName sorts directory entries by a parallel slice of
+// pre-folded (lower-cased) names, so the QUERY_DIRECTORY case-insensitive sort
+// folds each name once instead of twice per comparison. The two slices are
+// permuted in lockstep; comparison is a plain string compare on the folded key.
+type entriesByFoldedName struct {
+	entries []metadata.DirEntry
+	folded  []string
+}
+
+func (s *entriesByFoldedName) Len() int { return len(s.entries) }
+
+func (s *entriesByFoldedName) Less(i, j int) bool { return s.folded[i] < s.folded[j] }
+
+func (s *entriesByFoldedName) Swap(i, j int) {
+	s.entries[i], s.entries[j] = s.entries[j], s.entries[i]
+	s.folded[i], s.folded[j] = s.folded[j], s.folded[i]
+}
+
 // QueryDirectory handles SMB2 QUERY_DIRECTORY command [MS-SMB2] 2.2.33, 2.2.34.
 //
 // QUERY_DIRECTORY enumerates files and subdirectories in a directory handle,
@@ -407,9 +425,16 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 
 	// Sort entries by name (case-insensitive) for consistent enumeration order.
 	// SMB clients (including smbtorture) expect directory entries in sorted order.
-	sort.Slice(filteredEntries, func(i, j int) bool {
-		return strings.ToLower(filteredEntries[i].Name) < strings.ToLower(filteredEntries[j].Name)
-	})
+	// Pre-fold each name once into a parallel slice and sort against the folded
+	// keys, instead of calling strings.ToLower twice on every comparison
+	// (O(N log N) temporary strings on large directories). The folded slice is
+	// permuted in lockstep with the entries so the comparator stays a plain
+	// string compare; the resulting order is identical to the prior comparator.
+	foldedNames := make([]string, len(filteredEntries))
+	for i := range filteredEntries {
+		foldedNames[i] = strings.ToLower(filteredEntries[i].Name)
+	}
+	sort.Sort(&entriesByFoldedName{entries: filteredEntries, folded: foldedNames})
 
 	isWildcardSearch := req.FileName == "" || req.FileName == "*" || req.FileName == "*.*" || req.FileName == "<"
 


### PR DESCRIPTION
## Summary

Four verified perf findings in `internal/adapter/smb/handlers/`. All behavior-preserving; no protocol semantics change.

### 1. Dedup CREATE share-mode conflict scans (`create_post_break.go`)
`checkShareModeConflict` (a full `h.files` Range scan) ran up to three times per CREATE. The break-reason decision now computes the conflict once and the synchronous share-conflict-wait closure reuses that result for its **first** poll, then re-scans on every subsequent poll (a holder CLOSE/ACK can clear the conflict). Reuse is exact: when the conflict scan runs, the disposition is non-destructive, so `effectiveAccessForOpen == DesiredAccess` and the wait closure's effective access matches the cached scan's input. The delete-on-close path (which sets the reason without scanning) falls straight through to a live scan.

### 2. Single-pass non-stat-open scan (`create_post_break.go`)
`hasOtherNonStatOpenForFile` + `hasSameClientNonStatOpenForFile` did two sequential full `sync.Map` Range scans on the traditional-oplock grant path. Merged into one `scanNonStatOpensForFile` pass that returns both the non-stat-open flag and the same-client carve-out flag (the same-client check stays gated on an established connection identity, as before).

### 3. Arithmetic EA size (`ea.go`)
`fullEaInformationSize` allocated the full encoded FILE_FULL_EA_INFORMATION chain just to take its length. It now computes the byte count arithmetically (`8 + len(name) + 1 + len(value)` per entry, 4-byte padded for all but the sorted-last entry), matching the encoder's filter (reserved ACL xattr + oversized-field skips) and last-entry no-pad rule. A new table test (`TestFullEaInformationSize_MatchesEncodedLength`) asserts the arithmetic size equals `len(encodeFullEaInformation(...))` across 0/1/many EAs with varying name/value lengths, padding-needed vs aligned, and the skip cases.

### 4. Pre-folded QUERY_DIRECTORY sort (`query_directory.go`)
The sort comparator called `strings.ToLower` twice per comparison (O(N log N) temporary strings). Names are now lower-cased once into a parallel slice and sorted in lockstep with the entries via `entriesByFoldedName`; order is identical (unstable→unstable).

## Validation
- `go build ./...` clean
- `go vet ./internal/adapter/smb/...` clean
- `go test -race ./internal/adapter/smb/...` all pass

Addresses the four #1104 SMB-handler perf findings.