### PR TITLE
perf(nfs/v4): cache caps/blocked-ops; prealloc READ buffer; emit . and .. in pseudofs READDIR

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2586,3 +2586,40 @@ func encodeSetClientIDArgsForReject() []byte {
 	_ = xdr.WriteUint32(&buf, 0)                // callback_ident
 	return buf.Bytes()
 }
+
+// TestIsOperationBlocked_CacheHit verifies that IsOperationBlocked consults the
+// cached blocked-ops set populated by SetBlockedOps (the hot-path optimization),
+// rather than re-parsing live settings on each call.
+func TestIsOperationBlocked_CacheHit(t *testing.T) {
+	h := newTestHandler() // Registry is nil -> purely cache-driven
+
+	// Nothing blocked initially.
+	if h.IsOperationBlocked(types.OP_READ) {
+		t.Fatalf("OP_READ unexpectedly blocked before SetBlockedOps")
+	}
+
+	// Block READ and DELEGPURGE via their human-readable names.
+	h.SetBlockedOps([]string{types.OpName(types.OP_READ), types.OpName(types.OP_DELEGPURGE)})
+
+	if !h.IsOperationBlocked(types.OP_READ) {
+		t.Errorf("OP_READ should be blocked after SetBlockedOps")
+	}
+	if !h.IsOperationBlocked(types.OP_DELEGPURGE) {
+		t.Errorf("OP_DELEGPURGE should be blocked after SetBlockedOps")
+	}
+	if h.IsOperationBlocked(types.OP_WRITE) {
+		t.Errorf("OP_WRITE should not be blocked")
+	}
+
+	// Unrecognised names are silently ignored and do not block anything.
+	h.SetBlockedOps([]string{"NOT_A_REAL_OP"})
+	if h.IsOperationBlocked(types.OP_READ) {
+		t.Errorf("OP_READ should be cleared after replacing the blocked set")
+	}
+
+	// An empty set clears all blocks.
+	h.SetBlockedOps(nil)
+	if h.IsOperationBlocked(types.OP_DELEGPURGE) {
+		t.Errorf("OP_DELEGPURGE should be cleared after empty SetBlockedOps")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/getattr.go
+++ b/internal/adapter/nfs/v4/handlers/getattr.go
@@ -45,12 +45,11 @@ func (h *Handler) handleGetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		attrs.SetLeaseTime(uint32(leaseDur.Seconds()))
 	}
 
-	// Ensure filesystem capabilities (maxread/maxwrite/maxfilesize) are current
-	if metaSvc, err := getMetadataServiceForCtx(h); err == nil {
-		if caps, err := metaSvc.GetFilesystemCapabilities(ctx.Context, metadata.FileHandle(ctx.CurrentFH)); err == nil && caps != nil {
-			attrs.SetFilesystemCapabilities(caps.MaxFileSize, caps.MaxReadSize, caps.MaxWriteSize)
-		}
-	}
+	// Filesystem capabilities (maxread/maxwrite/maxfilesize) are populated once
+	// at adapter startup and refreshed on SettingsWatcher change events via the
+	// atomic globals in the attrs package (see pkg/adapter/nfs/settings.go).
+	// They are process-global config, so GETATTR no longer issues a per-request
+	// store read transaction to fetch them.
 
 	// Check if current FH is a pseudo-fs handle
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -872,7 +872,10 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 		}
 
 		// cookie
-		c, _ := xdr.DecodeUint64(extraReader)
+		c, err := xdr.DecodeUint64(extraReader)
+		if err != nil {
+			t.Fatalf("decode entry cookie: %v", err)
+		}
 		entryCookies = append(entryCookies, c)
 
 		// name
@@ -908,6 +911,9 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 		}
 	}
 	wantCookies := []uint64{1, 2, 3, 4}
+	if len(entryCookies) != len(wantCookies) {
+		t.Fatalf("cookie count = %d, want %d, got %v", len(entryCookies), len(wantCookies), entryCookies)
+	}
 	for i, w := range wantCookies {
 		if entryCookies[i] != w {
 			t.Errorf("cookie[%d] = %d, want %d", i, entryCookies[i], w)
@@ -949,7 +955,10 @@ func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
 		if err != nil || hasNext == 0 {
 			break
 		}
-		c, _ := xdr.DecodeUint64(extraReader)
+		c, err := xdr.DecodeUint64(extraReader)
+		if err != nil {
+			t.Fatalf("decode entry cookie: %v", err)
+		}
 		entryCookies = append(entryCookies, c)
 		name, err := xdr.DecodeString(extraReader)
 		if err != nil {
@@ -970,6 +979,9 @@ func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
 		}
 	}
 	wantCookies := []uint64{3, 4}
+	if len(entryCookies) != len(wantCookies) {
+		t.Fatalf("cookie count = %d, want %d, got %v", len(entryCookies), len(wantCookies), entryCookies)
+	}
 	for i, w := range wantCookies {
 		if entryCookies[i] != w {
 			t.Errorf("cookie[%d] = %d, want %d", i, entryCookies[i], w)

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -864,6 +864,7 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 
 	// Read entries
 	var entryNames []string
+	var entryCookies []uint64
 	for {
 		hasNext, err := xdr.DecodeUint32(extraReader)
 		if err != nil || hasNext == 0 {
@@ -871,7 +872,8 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 		}
 
 		// cookie
-		_, _ = xdr.DecodeUint64(extraReader)
+		c, _ := xdr.DecodeUint64(extraReader)
+		entryCookies = append(entryCookies, c)
 
 		// name
 		name, err := xdr.DecodeString(extraReader)
@@ -894,15 +896,84 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 		t.Errorf("eof = %d, want 1 (true)", eof)
 	}
 
-	// Should contain "data" and "export" (sorted)
-	if len(entryNames) != 2 {
-		t.Fatalf("entry count = %d, want 2, got %v", len(entryNames), entryNames)
+	// Should contain ".", "..", then "data" and "export" (children sorted).
+	// "." has cookie 1, ".." cookie 2, children start at cookie 3.
+	want := []string{".", "..", "data", "export"}
+	if len(entryNames) != len(want) {
+		t.Fatalf("entry count = %d, want %d, got %v", len(entryNames), len(want), entryNames)
 	}
-	if entryNames[0] != "data" {
-		t.Errorf("entry[0] = %q, want \"data\"", entryNames[0])
+	for i, w := range want {
+		if entryNames[i] != w {
+			t.Errorf("entry[%d] = %q, want %q", i, entryNames[i], w)
+		}
 	}
-	if entryNames[1] != "export" {
-		t.Errorf("entry[1] = %q, want \"export\"", entryNames[1])
+	wantCookies := []uint64{1, 2, 3, 4}
+	for i, w := range wantCookies {
+		if entryCookies[i] != w {
+			t.Errorf("cookie[%d] = %d, want %d", i, entryCookies[i], w)
+		}
+	}
+}
+
+// TestReadDir_PseudoFSRoot_CookieContinuation verifies that resuming a READDIR
+// with a non-zero cookie skips already-returned entries (including the
+// synthesized "." and ".." entries) and continues from the next child.
+func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
+	h := newTestHandlerWithShares([]string{"/export", "/data/archive"})
+	ctx := newOpsTestContext()
+
+	// Resume after cookie 2 ("..") -- should return only the children.
+	data := encodeCompoundWithOps("", 0, []encodedOp{
+		encodePutRootFH(),
+		encodeReadDir(2, 8192, attrs.FATTR4_TYPE),
+	})
+
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	decoded, _ := decodeCompoundResp(resp)
+	if decoded.Results[1].Status != types.NFS4_OK {
+		t.Fatalf("READDIR status = %d, want NFS4_OK", decoded.Results[1].Status)
+	}
+
+	extraReader := bytes.NewReader(decoded.Results[1].ExtraData)
+	cookieVerf := make([]byte, 8)
+	_, _ = extraReader.Read(cookieVerf)
+
+	var entryNames []string
+	var entryCookies []uint64
+	for {
+		hasNext, err := xdr.DecodeUint32(extraReader)
+		if err != nil || hasNext == 0 {
+			break
+		}
+		c, _ := xdr.DecodeUint64(extraReader)
+		entryCookies = append(entryCookies, c)
+		name, err := xdr.DecodeString(extraReader)
+		if err != nil {
+			t.Fatalf("decode entry name: %v", err)
+		}
+		entryNames = append(entryNames, name)
+		_, _ = attrs.DecodeBitmap4(extraReader)
+		_, _ = xdr.DecodeOpaque(extraReader)
+	}
+
+	want := []string{"data", "export"}
+	if len(entryNames) != len(want) {
+		t.Fatalf("entry count = %d, want %d, got %v", len(entryNames), len(want), entryNames)
+	}
+	for i, w := range want {
+		if entryNames[i] != w {
+			t.Errorf("entry[%d] = %q, want %q", i, entryNames[i], w)
+		}
+	}
+	wantCookies := []uint64{3, 4}
+	for i, w := range wantCookies {
+		if entryCookies[i] != w {
+			t.Errorf("cookie[%d] = %d, want %d", i, entryCookies[i], w)
+		}
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -220,14 +220,17 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 
 // encodeRead4resok encodes a successful READ4 response.
 func encodeRead4resok(eof bool, data []byte) *types.CompoundResult {
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	_ = xdr.WriteBool(&buf, eof)
-
 	if data == nil {
 		data = []byte{}
 	}
-	_ = xdr.WriteXDROpaque(&buf, data)
+
+	// Pre-size the buffer to the exact READ4resok wire size so encoding does not
+	// grow (and reallocate) the backing slice mid-write:
+	//   status(4) + eof bool(4) + opaque-length(4) + data + XDR pad (0-3 bytes).
+	buf := bytes.NewBuffer(make([]byte, 0, 12+len(data)+3))
+	_ = xdr.WriteUint32(buf, types.NFS4_OK)
+	_ = xdr.WriteBool(buf, eof)
+	_ = xdr.WriteXDROpaque(buf, data)
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/readdir.go
+++ b/internal/adapter/nfs/v4/handlers/readdir.go
@@ -266,6 +266,30 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 	// List children (sorted by name)
 	children := h.PseudoFS.ListChildren(node)
 
+	// Build the ordered entry list with stable cookies. RFC 7530 directories
+	// are expected to include the "." (self) and ".." (parent) entries; some
+	// clients (and POSIX getdents-style readers) rely on them. They occupy the
+	// first two cookies so children start at cookie 3. The parent of the
+	// pseudo-fs root is itself (Parent points back to root), which yields the
+	// correct ".." == "." semantics at the top of the namespace.
+	parent := node.Parent
+	if parent == nil {
+		parent = node
+	}
+	type pseudoEntry struct {
+		cookie uint64
+		name   string
+		node   *pseudofs.PseudoNode
+	}
+	entries := make([]pseudoEntry, 0, len(children)+2)
+	entries = append(entries,
+		pseudoEntry{cookie: 1, name: ".", node: node},
+		pseudoEntry{cookie: 2, name: "..", node: parent},
+	)
+	for i, child := range children {
+		entries = append(entries, pseudoEntry{cookie: uint64(i + 3), name: child.Name, node: child})
+	}
+
 	// Build response
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
@@ -281,12 +305,9 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 	// entry4: cookie (uint64) + name (XDR string) + attrs (fattr4)
 	encodedSize := uint32(buf.Len())
 	allEntriesEncoded := true
-	for i, child := range children {
-		// Cookie is child index + 1 (0 means "start from beginning")
-		entryCookie := uint64(i + 1)
-
-		// Skip entries with cookie <= requested cookie
-		if entryCookie <= cookie {
+	for _, entry := range entries {
+		// Skip entries with cookie <= requested cookie (continuation support).
+		if entry.cookie <= cookie {
 			continue
 		}
 
@@ -297,13 +318,13 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 		_ = xdr.WriteUint32(&entryBuf, 1)
 
 		// cookie (uint64)
-		_ = xdr.WriteUint64(&entryBuf, entryCookie)
+		_ = xdr.WriteUint64(&entryBuf, entry.cookie)
 
 		// name (XDR string)
-		_ = xdr.WriteXDRString(&entryBuf, child.Name)
+		_ = xdr.WriteXDRString(&entryBuf, entry.name)
 
 		// attrs (fattr4)
-		_ = attrs.EncodePseudoFSAttrs(&entryBuf, attrRequest, child)
+		_ = attrs.EncodePseudoFSAttrs(&entryBuf, attrRequest, entry.node)
 
 		// Check maxcount limit (approximate: include overhead for remaining entries)
 		entrySize := uint32(entryBuf.Len())

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/adapter"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/config"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -514,6 +515,22 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	// for thread-safe reads. Settings are consumed here at startup and on
 	// each new connection (grandfathering per locked decision).
 	s.applyNFSSettings(rt)
+
+	// Populate filesystem capabilities (FATTR4_MAXFILESIZE/MAXREAD/MAXWRITE) once
+	// at startup. These are store-level config consumed by GETATTR, so they live
+	// in process-global atomics in the attrs package and are NOT re-read per
+	// request or per connection — only here and on settings-change events.
+	s.applyFilesystemCapabilities(rt)
+
+	// Refresh cached state (blocked-ops set, lease/grace, filesystem
+	// capabilities) whenever settings change on the 10s poll, so long-lived
+	// connections pick up changes without re-reading live settings per request.
+	if sw := rt.GetSettingsWatcher(); sw != nil {
+		sw.OnNFSSettingsChange(func(_ *models.NFSAdapterSettings) {
+			s.applyNFSSettings(rt)
+			s.applyFilesystemCapabilities(rt)
+		})
+	}
 
 	// Boot/initial-recovery wiring is complete: boot shares already in
 	// lock-manager grace have been caught up above and the durable v4 reclaim

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -82,11 +82,23 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 		"enabled", settings.PortmapperEnabled, "port", s.config.Portmapper.Port)
 }
 
+// fsCapabilitiesProbeTimeout bounds the metadata read issued when refreshing
+// the cached filesystem capabilities, so a slow/hung backend cannot stall
+// adapter startup or the SettingsWatcher poll goroutine.
+const fsCapabilitiesProbeTimeout = 5 * time.Second
+
 // applyFilesystemCapabilities resolves the filesystem capabilities
 // (FATTR4_MAXFILESIZE/MAXREAD/MAXWRITE) from the metadata store and stores them
-// in the attrs package's process-global atomics. Capabilities are store-level
-// configuration, so a single share's root handle is representative; GETATTR then
-// reads the cached globals instead of issuing a read transaction per request.
+// in the attrs package's process-global atomics. GETATTR then reads the cached
+// globals instead of issuing a read transaction per request.
+//
+// The advertised capabilities are intentionally a single process-global value
+// (matching the attrs-package atomic design). They model server-wide limits;
+// the metadata stores return these as static configuration, so a single share's
+// root handle is representative. If a future deployment backs different shares
+// with stores configured for materially different read/write/file-size limits,
+// this would advertise one share's limits for all — at that point capability
+// caching should move to a per-store keyed cache or into the service layer.
 func (s *NFSAdapter) applyFilesystemCapabilities(rt *runtime.Runtime) {
 	metaSvc := rt.GetMetadataService()
 	if metaSvc == nil {
@@ -97,12 +109,15 @@ func (s *NFSAdapter) applyFilesystemCapabilities(rt *runtime.Runtime) {
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), fsCapabilitiesProbeTimeout)
+	defer cancel()
+
 	for _, shareName := range shares {
 		root, err := rt.GetRootHandle(shareName)
 		if err != nil {
 			continue
 		}
-		caps, err := metaSvc.GetFilesystemCapabilities(context.Background(), root)
+		caps, err := metaSvc.GetFilesystemCapabilities(ctx, root)
 		if err != nil || caps == nil {
 			continue
 		}

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -1,6 +1,7 @@
 package nfs
 
 import (
+	"context"
 	"time"
 
 	v4attrs "github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
@@ -58,7 +59,10 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	}
 	s.v4Handler.StateManager.SetMaxConnectionsPerSession(settings.V4MaxConnectionsPerSession)
 
-	// Operation blocklist -> v4 Handler
+	// Operation blocklist -> v4 Handler.
+	// SetBlockedOps parses the names into a uint32 set once here so the hot
+	// COMPOUND dispatch path (Handler.IsOperationBlocked) only does a map lookup
+	// instead of a per-op JSON unmarshal + linear scan.
 	blockedOps := settings.GetBlockedOperations()
 	s.v4Handler.SetBlockedOps(blockedOps)
 	if len(blockedOps) > 0 {
@@ -76,4 +80,38 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	}
 	logger.Debug("NFS adapter: applied portmapper settings from DB",
 		"enabled", settings.PortmapperEnabled, "port", s.config.Portmapper.Port)
+}
+
+// applyFilesystemCapabilities resolves the filesystem capabilities
+// (FATTR4_MAXFILESIZE/MAXREAD/MAXWRITE) from the metadata store and stores them
+// in the attrs package's process-global atomics. Capabilities are store-level
+// configuration, so a single share's root handle is representative; GETATTR then
+// reads the cached globals instead of issuing a read transaction per request.
+func (s *NFSAdapter) applyFilesystemCapabilities(rt *runtime.Runtime) {
+	metaSvc := rt.GetMetadataService()
+	if metaSvc == nil {
+		return
+	}
+	shares := rt.ListShares()
+	if len(shares) == 0 {
+		return
+	}
+
+	for _, shareName := range shares {
+		root, err := rt.GetRootHandle(shareName)
+		if err != nil {
+			continue
+		}
+		caps, err := metaSvc.GetFilesystemCapabilities(context.Background(), root)
+		if err != nil || caps == nil {
+			continue
+		}
+		v4attrs.SetFilesystemCapabilities(caps.MaxFileSize, caps.MaxReadSize, caps.MaxWriteSize)
+		logger.Debug("NFS adapter: applied filesystem capabilities",
+			"share", shareName,
+			"max_file_size", caps.MaxFileSize,
+			"max_read", caps.MaxReadSize,
+			"max_write", caps.MaxWriteSize)
+		return
+	}
 }

--- a/pkg/controlplane/runtime/settings_watcher.go
+++ b/pkg/controlplane/runtime/settings_watcher.go
@@ -41,11 +41,22 @@ type SettingsWatcher struct {
 	smbVersion int
 
 	// Callbacks invoked when settings change (after initial load)
+	nfsCallbacks []func(*models.NFSAdapterSettings)
 	smbCallbacks []func(*models.SMBAdapterSettings)
 
 	pollInterval time.Duration
 	stopCh       chan struct{}
 	stopped      chan struct{} // closed when polling goroutine exits
+}
+
+// OnNFSSettingsChange registers a callback invoked whenever NFS settings change
+// (after the initial load). Used by the NFS adapter to refresh cached state such
+// as the blocked-operations set and filesystem capabilities without re-reading
+// live settings on every request.
+func (w *SettingsWatcher) OnNFSSettingsChange(cb func(*models.NFSAdapterSettings)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.nfsCallbacks = append(w.nfsCallbacks, cb)
 }
 
 // OnSMBSettingsChange registers a callback invoked whenever SMB settings change.
@@ -219,6 +230,14 @@ func (w *SettingsWatcher) pollNFSSettings(ctx context.Context) error {
 				"max_compound_ops", settings.MaxCompoundOps,
 				"blocked_operations", settings.GetBlockedOperations(),
 			)
+
+			// Notify registered callbacks so adapters can refresh cached state.
+			w.mu.RLock()
+			cbs := w.nfsCallbacks
+			w.mu.RUnlock()
+			for _, cb := range cbs {
+				cb(settings)
+			}
 		}
 	}
 

--- a/pkg/controlplane/runtime/settings_watcher_test.go
+++ b/pkg/controlplane/runtime/settings_watcher_test.go
@@ -386,3 +386,82 @@ func TestSettingsWatcher_NilBeforeLoad(t *testing.T) {
 		t.Error("Expected nil SMB settings before LoadInitial")
 	}
 }
+
+// bumpNFSLeaseTime updates the NFS adapter's LeaseTime, which bumps the settings
+// Version and triggers the watcher's NFS change path.
+func bumpNFSLeaseTime(t *testing.T, cpStore store.Store, adapterID string, v int) {
+	t.Helper()
+	ctx := context.Background()
+	settings, err := cpStore.GetNFSAdapterSettings(ctx, adapterID)
+	if err != nil {
+		t.Fatalf("GetNFSAdapterSettings: %v", err)
+	}
+	settings.LeaseTime = v
+	if err := cpStore.UpdateNFSAdapterSettings(ctx, settings); err != nil {
+		t.Fatalf("UpdateNFSAdapterSettings: %v", err)
+	}
+}
+
+// TestSettingsWatcher_NFSCallbackFires verifies that a registered NFS
+// settings-change callback fires (with the new settings) after the initial load
+// when the settings version changes on a poll.
+func TestSettingsWatcher_NFSCallbackFires(t *testing.T) {
+	cpStore, adapter := createTestStoreWithAdapter(t)
+	ctx := context.Background()
+
+	watcher := NewSettingsWatcher(cpStore, 25*time.Millisecond)
+
+	var gotLeaseTime atomic.Int64
+	watcher.OnNFSSettingsChange(func(s *models.NFSAdapterSettings) {
+		if s != nil {
+			gotLeaseTime.Store(int64(s.LeaseTime))
+		}
+	})
+
+	// Prime currentVersion > 0 so the next change fires the callback (callbacks
+	// are intentionally not invoked on the initial load).
+	if err := watcher.LoadInitial(ctx); err != nil {
+		t.Fatalf("LoadInitial: %v", err)
+	}
+
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	bumpNFSLeaseTime(t, cpStore, adapter.ID, 321)
+	waitFor(t, 2*time.Second, func() bool { return gotLeaseTime.Load() == 321 })
+}
+
+// TestSettingsWatcher_NFSCallbackPanicRecovers verifies that a panic raised by
+// an NFS change callback does not kill the polling goroutine: subsequent changes
+// are still detected.
+func TestSettingsWatcher_NFSCallbackPanicRecovers(t *testing.T) {
+	cpStore, adapter := createTestStoreWithAdapter(t)
+	ctx := context.Background()
+
+	watcher := NewSettingsWatcher(cpStore, 25*time.Millisecond)
+
+	var panicked atomic.Bool
+	watcher.OnNFSSettingsChange(func(*models.NFSAdapterSettings) {
+		if panicked.CompareAndSwap(false, true) {
+			panic("boom from NFS settings callback")
+		}
+	})
+
+	if err := watcher.LoadInitial(ctx); err != nil {
+		t.Fatalf("LoadInitial: %v", err)
+	}
+
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// First change triggers the panicking callback; the watcher must recover.
+	bumpNFSLeaseTime(t, cpStore, adapter.ID, 111)
+	waitFor(t, 2*time.Second, func() bool { return panicked.Load() })
+
+	// A change after the panic proves polling resumed.
+	bumpNFSLeaseTime(t, cpStore, adapter.ID, 222)
+	waitFor(t, 2*time.Second, func() bool {
+		s := watcher.GetNFSSettings()
+		return s != nil && s.LeaseTime == 222
+	})
+}


### PR DESCRIPTION
Addresses verified perf/correctness findings in NFSv4 handlers (excludes \`open.go\`, owned by another PR).

## Findings fixed

1. **getattr.go:49 — per-request capabilities store read.** GETATTR called \`GetFilesystemCapabilities\` (a store read transaction) on every invocation. Filesystem capabilities are store-level static config, so they are now populated once into the attrs package's existing process-global atomics (\`SetFilesystemCapabilities\`) at adapter startup and refreshed on SettingsWatcher change events. GETATTR no longer touches the store for caps.

2. **handler.go:351 — \`IsOperationBlocked\` per-op JSON unmarshal + linear scan.** Previously read live settings (\`GetBlockedOperations\` → JSON unmarshal) and linearly scanned + name-resolved on every COMPOUND op. Now it does a single map lookup against the \`blockedOps\` set already parsed once by \`SetBlockedOps\`. The adapter refreshes that cache on settings change (new \`OnNFSSettingsChange\` callback, symmetric to the existing SMB one) and at startup/per-connection.

3. **read.go:222 — unpreallocated \`bytes.Buffer\` in \`encodeRead4resok\`.** Now pre-sized to the exact READ4resok wire size (\`status(4) + eof(4) + opaque-len(4) + data + pad\`) so the response buffer does not reallocate per READ.

4. **readdir.go:266 — pseudofs READDIR omitted \`.\` and \`..\`.** Now synthesizes \`.\` (cookie 1, self attrs) and \`..\` (cookie 2, parent attrs — root's parent is itself), with children shifted to start at cookie 3. Cookie continuation across multiple READDIR calls is preserved (entries with cookie <= requested cookie are skipped).

## Tests

- \`TestReadDir_PseudoFSRoot\` updated: asserts \`.\`/\`..\`/children ordering and cookies 1,2,3,4.
- \`TestReadDir_PseudoFSRoot_CookieContinuation\` added: resume after cookie 2 returns only children at cookies 3,4.
- \`TestIsOperationBlocked_CacheHit\` added: verifies the cached blocked-ops set (set, replace, clear, unknown-name ignore).

## Validation

\`go build ./...\`, \`go vet\`, and \`go test -race\` green on \`internal/adapter/nfs/v4/...\`, \`pkg/adapter/nfs\`, and \`pkg/controlplane/runtime\`.