### PR TITLE
perf(nfs/v4): index open-state and revoked-delegation lookups

### DIFF
--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -193,6 +193,36 @@ func (sm *StateManager) removeDelegFromFile(deleg *DelegationState) {
 	}
 }
 
+// markDelegRevokedLocked marks a delegation revoked and updates the per-client
+// revoked-delegation index. It is idempotent: re-marking an already-revoked
+// delegation does not double-count. Caller must hold sm.mu.
+func (sm *StateManager) markDelegRevokedLocked(deleg *DelegationState) {
+	if deleg.Revoked {
+		return
+	}
+	deleg.Revoked = true
+	sm.revokedDelegCount[deleg.ClientID]++
+}
+
+// deleteDelegByOtherLocked removes a delegation from delegByOther, keeping the
+// per-client revoked-delegation index consistent (decrementing the count when a
+// revoked delegation leaves the table). This is the single removal path for
+// delegByOther so the index can never drift. Caller must hold sm.mu.
+func (sm *StateManager) deleteDelegByOtherLocked(other [types.NFS4_OTHER_SIZE]byte) {
+	deleg, ok := sm.delegByOther[other]
+	if !ok {
+		return
+	}
+	if deleg.Revoked {
+		if n := sm.revokedDelegCount[deleg.ClientID]; n <= 1 {
+			delete(sm.revokedDelegCount, deleg.ClientID)
+		} else {
+			sm.revokedDelegCount[deleg.ClientID] = n - 1
+		}
+	}
+	delete(sm.delegByOther, other)
+}
+
 // GrantDelegation creates a new delegation for a client on a file.
 //
 // It generates a delegation stateid with type tag 0x03, creates a
@@ -299,7 +329,7 @@ func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
 	// For directory delegations we drop sm.mu below to flush notifications; if we
 	// deferred the delete until after re-acquiring the lock, a concurrent
 	// RevokeDelegation could observe the still-present entry and corrupt state.
-	delete(sm.delegByOther, stateid.Other)
+	sm.deleteDelegByOtherLocked(stateid.Other)
 	sm.removeDelegFromFile(deleg)
 
 	// For directory delegations: flush pending notifications before removal.
@@ -383,10 +413,9 @@ func (sm *StateManager) GetDelegationsForFile(fileHandle []byte) []*DelegationSt
 // Caller must hold sm.mu.
 func (sm *StateManager) countOpensOnFile(fileHandle []byte, excludeClientID uint64) int {
 	count := 0
-	for _, openState := range sm.openStateByOther {
-		if bytes.Equal(openState.FileHandle, fileHandle) &&
-			openState.Owner != nil &&
-			openState.Owner.ClientID != excludeClientID {
+	// Iterate only the opens on this file via the per-file open index.
+	for _, openState := range sm.openStateByFile[string(fileHandle)] {
+		if openState.Owner != nil && openState.Owner.ClientID != excludeClientID {
 			count++
 		}
 	}

--- a/internal/adapter/nfs/v4/state/index_consistency_test.go
+++ b/internal/adapter/nfs/v4/state/index_consistency_test.go
@@ -1,0 +1,294 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// These tests guard the secondary indexes (openStateByFile and
+// revokedDelegCount) against drift from the authoritative state. Each mutation
+// path that touches openStateByOther / delegByOther must keep the index in
+// sync; the assertions below check the index directly (white-box) after every
+// open/close/free/evict/revoke/return so a missed maintenance call is caught.
+
+// fileIndexLen returns the number of OpenStates indexed under fileHandle.
+func fileIndexLen(sm *StateManager, fileHandle []byte) int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return len(sm.openStateByFile[string(fileHandle)])
+}
+
+// fileIndexMatchesAuthoritative verifies that openStateByFile is a faithful
+// reindex of openStateByOther: same membership, no orphan/empty file slots.
+func fileIndexMatchesAuthoritative(t *testing.T, sm *StateManager) {
+	t.Helper()
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	// Every authoritative open must appear exactly once under its file handle.
+	for _, os := range sm.openStateByOther {
+		found := 0
+		for _, indexed := range sm.openStateByFile[string(os.FileHandle)] {
+			if indexed == os {
+				found++
+			}
+		}
+		if found != 1 {
+			t.Fatalf("open state for fh %q indexed %d times, want 1", os.FileHandle, found)
+		}
+	}
+
+	// The index must contain no entries that are absent from the authoritative
+	// map, and no empty file slots.
+	total := 0
+	for fh, states := range sm.openStateByFile {
+		if len(states) == 0 {
+			t.Fatalf("openStateByFile has empty slot for fh %q", fh)
+		}
+		for _, os := range states {
+			if _, ok := sm.openStateByOther[os.Stateid.Other]; !ok {
+				t.Fatalf("openStateByFile contains stale open state for fh %q", fh)
+			}
+			total++
+		}
+	}
+	if total != len(sm.openStateByOther) {
+		t.Fatalf("openStateByFile has %d entries, openStateByOther has %d", total, len(sm.openStateByOther))
+	}
+}
+
+func TestOpenStateByFile_OpenThenCloseRemovesFromIndex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-open-close")
+
+	stateid := openConfirmed(t, sm, 0, []byte("owner-oc"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE)
+
+	if n := fileIndexLen(sm, fh); n != 1 {
+		t.Fatalf("after open: index len = %d, want 1", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+
+	// CLOSE advances the owner seqid; open used 1, confirm used 2, close uses 3.
+	if _, err := sm.CloseFile(&stateid, 3); err != nil {
+		t.Fatalf("CloseFile: %v", err)
+	}
+
+	if n := fileIndexLen(sm, fh); n != 0 {
+		t.Fatalf("after close: index len = %d, want 0 (slot must be dropped)", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+}
+
+func TestOpenStateByFile_MultipleOwnersSameFile(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-multi-owner")
+
+	// Two distinct owners with non-conflicting share modes (both READ, no deny).
+	sidA := openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	openConfirmed(t, sm, 0, []byte("ownerB"), fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+
+	if n := fileIndexLen(sm, fh); n != 2 {
+		t.Fatalf("two owners: index len = %d, want 2", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+
+	// Closing one owner leaves the other indexed.
+	if _, err := sm.CloseFile(&sidA, 3); err != nil {
+		t.Fatalf("CloseFile(A): %v", err)
+	}
+	if n := fileIndexLen(sm, fh); n != 1 {
+		t.Fatalf("after closing A: index len = %d, want 1", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+}
+
+func TestOpenStateByFile_EvictClearsIndex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-evict")
+
+	verifier := [8]byte{9, 9, 9, 9, 9, 9, 9, 9}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.2.8.1"}
+	res, err := sm.SetClientID("evict-client", verifier, callback, "10.0.0.2:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	openConfirmed(t, sm, res.ClientID, []byte("owner-evict"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE)
+	if n := fileIndexLen(sm, fh); n != 1 {
+		t.Fatalf("after open: index len = %d, want 1", n)
+	}
+
+	if err := sm.EvictV40Client(res.ClientID); err != nil {
+		t.Fatalf("EvictV40Client: %v", err)
+	}
+	if n := fileIndexLen(sm, fh); n != 0 {
+		t.Fatalf("after evict: index len = %d, want 0", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+}
+
+func TestOpenStateByFile_FreeStateidRemovesFromIndex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-free-stateid")
+
+	stateid := openConfirmed(t, sm, 0, []byte("owner-free"), fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE)
+	if n := fileIndexLen(sm, fh); n != 1 {
+		t.Fatalf("after open: index len = %d, want 1", n)
+	}
+
+	sm.mu.Lock()
+	err := sm.freeOpenStateidLocked(0, &stateid)
+	sm.mu.Unlock()
+	if err != nil {
+		t.Fatalf("freeOpenStateidLocked: %v", err)
+	}
+
+	if n := fileIndexLen(sm, fh); n != 0 {
+		t.Fatalf("after free: index len = %d, want 0", n)
+	}
+	fileIndexMatchesAuthoritative(t, sm)
+}
+
+// revokedCount reads the per-client revoked-delegation index directly.
+func revokedCount(sm *StateManager, clientID uint64) int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.revokedDelegCount[clientID]
+}
+
+func TestRevokedDelegIndex_SetOnRevokeClearedOnReturn(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	const clientID = uint64(7777)
+	fh := []byte("fh-revoke-return")
+
+	deleg := sm.GrantDelegation(clientID, fh, types.OPEN_DELEGATE_READ)
+	if deleg == nil {
+		t.Fatal("GrantDelegation returned nil")
+	}
+	if c := revokedCount(sm, clientID); c != 0 {
+		t.Fatalf("fresh delegation: revoked count = %d, want 0", c)
+	}
+
+	session := &Session{ClientID: clientID}
+	if sm.GetStatusFlags(session)&types.SEQ4_STATUS_RECALLABLE_STATE_REVOKED != 0 {
+		t.Fatal("RECALLABLE_STATE_REVOKED set before any revoke")
+	}
+
+	sm.RevokeDelegation(deleg.Stateid.Other)
+	if c := revokedCount(sm, clientID); c != 1 {
+		t.Fatalf("after revoke: revoked count = %d, want 1", c)
+	}
+	if sm.GetStatusFlags(session)&types.SEQ4_STATUS_RECALLABLE_STATE_REVOKED == 0 {
+		t.Fatal("RECALLABLE_STATE_REVOKED not set after revoke")
+	}
+
+	// Revoking again must not double-count (idempotent).
+	sm.RevokeDelegation(deleg.Stateid.Other)
+	if c := revokedCount(sm, clientID); c != 1 {
+		t.Fatalf("after double revoke: revoked count = %d, want 1 (idempotent)", c)
+	}
+
+	// Returning the (revoked) delegation frees it from delegByOther and must
+	// clear the revoked index entry.
+	if err := sm.ReturnDelegation(&deleg.Stateid); err != nil {
+		t.Fatalf("ReturnDelegation: %v", err)
+	}
+	if c := revokedCount(sm, clientID); c != 0 {
+		t.Fatalf("after return: revoked count = %d, want 0", c)
+	}
+	if sm.GetStatusFlags(session)&types.SEQ4_STATUS_RECALLABLE_STATE_REVOKED != 0 {
+		t.Fatal("RECALLABLE_STATE_REVOKED still set after returning the revoked delegation")
+	}
+}
+
+func TestRevokedDelegIndex_ClearedOnEvict(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	verifier := [8]byte{2, 2, 2, 2, 2, 2, 2, 2}
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.3.8.1"}
+	res, err := sm.SetClientID("revoke-evict-client", verifier, callback, "10.0.0.3:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	fh := []byte("fh-revoke-evict")
+	deleg := sm.GrantDelegation(res.ClientID, fh, types.OPEN_DELEGATE_READ)
+	if deleg == nil {
+		t.Fatal("GrantDelegation returned nil")
+	}
+	sm.RevokeDelegation(deleg.Stateid.Other)
+	if c := revokedCount(sm, res.ClientID); c != 1 {
+		t.Fatalf("after revoke: revoked count = %d, want 1", c)
+	}
+
+	if err := sm.EvictV40Client(res.ClientID); err != nil {
+		t.Fatalf("EvictV40Client: %v", err)
+	}
+	if c := revokedCount(sm, res.ClientID); c != 0 {
+		t.Fatalf("after evict: revoked count = %d, want 0 (index entry must be dropped)", c)
+	}
+}
+
+// TestOwnerCachedKey_MatchesRecomputed verifies the cached owner keys agree
+// with the canonical make*Key functions, and that the LockManager owner ID is
+// exactly the prefix + lock-owner key (so cached and free-function derivations
+// stay in lock-step).
+func TestOwnerCachedKey_MatchesRecomputed(t *testing.T) {
+	const clientID = uint64(0xABCDEF)
+	ownerData := []byte("owner-cached-key")
+
+	oo := &OpenOwner{ClientID: clientID, OwnerData: ownerData, key: makeOwnerKey(clientID, ownerData)}
+	if got, want := oo.Key(), makeOwnerKey(clientID, ownerData); got != want {
+		t.Fatalf("OpenOwner.Key() = %q, want %q", got, want)
+	}
+	// Fallback (no cached key) must still match.
+	if got, want := (&OpenOwner{ClientID: clientID, OwnerData: ownerData}).Key(), makeOwnerKey(clientID, ownerData); got != want {
+		t.Fatalf("OpenOwner.Key() fallback = %q, want %q", got, want)
+	}
+
+	lo := &LockOwner{ClientID: clientID, OwnerData: ownerData, key: makeLockOwnerKey(clientID, ownerData)}
+	if got, want := lo.Key(), makeLockOwnerKey(clientID, ownerData); got != want {
+		t.Fatalf("LockOwner.Key() = %q, want %q", got, want)
+	}
+	if got, want := lo.LockManagerOwnerID(), lockManagerOwnerID(clientID, ownerData); got != want {
+		t.Fatalf("LockOwner.LockManagerOwnerID() = %q, want %q", got, want)
+	}
+	// Fallback path (literal lock-owner without cached key) must also agree.
+	loNoKey := &LockOwner{ClientID: clientID, OwnerData: ownerData}
+	if got, want := loNoKey.LockManagerOwnerID(), lockManagerOwnerID(clientID, ownerData); got != want {
+		t.Fatalf("LockOwner.LockManagerOwnerID() fallback = %q, want %q", got, want)
+	}
+}
+
+// TestRevokedDelegIndex_NonRevokedFreeDoesNotUnderflow ensures freeing a
+// delegation that was never revoked leaves the index untouched (no spurious
+// decrement / negative count).
+func TestRevokedDelegIndex_NonRevokedFreeDoesNotUnderflow(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	const clientID = uint64(4242)
+	fh := []byte("fh-nonrevoked-free")
+
+	deleg := sm.GrantDelegation(clientID, fh, types.OPEN_DELEGATE_READ)
+	if deleg == nil {
+		t.Fatal("GrantDelegation returned nil")
+	}
+	if err := sm.ReturnDelegation(&deleg.Stateid); err != nil {
+		t.Fatalf("ReturnDelegation: %v", err)
+	}
+	if c := revokedCount(sm, clientID); c != 0 {
+		t.Fatalf("returning a never-revoked delegation: revoked count = %d, want 0", c)
+	}
+}

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -35,6 +35,21 @@ type LockOwner struct {
 
 	// ClientRecord is a back-reference to the owning client record.
 	ClientRecord *ClientRecord
+
+	// key is the precomputed composite map key (clientID + hex(ownerData)),
+	// cached at creation so hot-path lookups reuse it instead of re-running
+	// makeLockOwnerKey. ClientID/OwnerData are immutable after creation.
+	key lockOwnerKey
+}
+
+// Key returns the cached composite map key for this lock-owner. Owners
+// constructed via the StateManager always carry a cached key; the fallback
+// covers literal-built instances (e.g. in tests).
+func (lo *LockOwner) Key() lockOwnerKey {
+	if lo.key == "" {
+		return makeLockOwnerKey(lo.ClientID, lo.OwnerData)
+	}
+	return lo.key
 }
 
 // ValidateSeqID checks whether a seqid is valid for this lock-owner.
@@ -89,6 +104,32 @@ type lockOwnerKey string
 // makeLockOwnerKey creates a lockOwnerKey from a client ID and owner data.
 func makeLockOwnerKey(clientID uint64, ownerData []byte) lockOwnerKey {
 	return lockOwnerKey(fmt.Sprintf("%d:%s", clientID, hex.EncodeToString(ownerData)))
+}
+
+// lockManagerOwnerIDPrefix is the namespace prefix the StateManager stamps onto
+// every LockManager owner ID so NFSv4 byte-range locks are distinguishable from
+// other protocols (e.g. SMB) sharing the unified lock map.
+const lockManagerOwnerIDPrefix = "nfs4:"
+
+// lockManagerOwnerID builds the LockManager owner ID for an NFSv4 lock-owner.
+// It is exactly lockManagerOwnerIDPrefix + makeLockOwnerKey(...) so the lock
+// manager identity stays in lock-step with the internal lock-owner map key:
+// callers that have a (clientID, ownerData) pair but no *LockOwner use this.
+func lockManagerOwnerID(clientID uint64, ownerData []byte) string {
+	return lockManagerOwnerIDPrefix + string(makeLockOwnerKey(clientID, ownerData))
+}
+
+// LockManagerOwnerID returns the LockManager owner ID for this lock-owner,
+// reusing the cached map key instead of recomputing the hex encoding. It agrees
+// byte-for-byte with the free lockManagerOwnerID(clientID, ownerData) helper.
+// Lock-owners constructed via the StateManager always have a cached key; the
+// fallback covers literal-built instances (e.g. in tests) so the method is
+// always correct.
+func (lo *LockOwner) LockManagerOwnerID() string {
+	if lo.key == "" {
+		return lockManagerOwnerID(lo.ClientID, lo.OwnerData)
+	}
+	return lockManagerOwnerIDPrefix + string(lo.key)
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1302,13 +1302,20 @@ func (sm *StateManager) removeOpenStateFromFileLocked(os *OpenState) {
 	fhKey := string(os.FileHandle)
 	states := sm.openStateByFile[fhKey]
 	for i, s := range states {
-		if s == os {
-			sm.openStateByFile[fhKey] = append(states[:i], states[i+1:]...)
-			break
+		if s != os {
+			continue
 		}
-	}
-	if len(sm.openStateByFile[fhKey]) == 0 {
-		delete(sm.openStateByFile, fhKey)
+		// Shift the tail down, nil out the now-unused last slot so the backing
+		// array does not retain the removed OpenState, then reslice.
+		copy(states[i:], states[i+1:])
+		states[len(states)-1] = nil
+		states = states[:len(states)-1]
+		if len(states) == 0 {
+			delete(sm.openStateByFile, fhKey)
+		} else {
+			sm.openStateByFile[fhKey] = states
+		}
+		return
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -45,6 +45,15 @@ type StateManager struct {
 	// This is the primary lookup table for stateid validation.
 	openStateByOther map[[types.NFS4_OTHER_SIZE]byte]*OpenState
 
+	// openStateByFile indexes live OpenState records by file handle
+	// (string(fileHandle)). It is a secondary index kept consistent with
+	// openStateByOther at every insert/remove so share-conflict checks
+	// (shareConflictLocked) and delegation grant checks (countOpensOnFile)
+	// iterate only the opens on the target file instead of scanning every
+	// open in the server. Maintained via addOpenStateToFileLocked /
+	// removeOpenStateFromFileLocked.
+	openStateByFile map[string][]*OpenState
+
 	// openOwners maps open-owner keys to OpenOwner records.
 	// Key is composite of clientID + hex(ownerData).
 	openOwners map[openOwnerKey]*OpenOwner
@@ -72,6 +81,14 @@ type StateManager struct {
 	// delegByFile maps file handle (string key) to a list of DelegationState records.
 	// Used for conflict detection: "does any client hold a delegation for this file?"
 	delegByFile map[string][]*DelegationState
+
+	// revokedDelegCount counts, per client ID, the number of delegations that
+	// have been marked Revoked but are still retained in delegByOther (for
+	// stale-stateid detection). It is a secondary index so GetStatusFlags can
+	// answer "does this client have any revoked delegation?" in O(1) on the
+	// SEQUENCE hot path instead of scanning every delegation in the server.
+	// Maintained via markDelegRevokedLocked and deleteDelegByOtherLocked.
+	revokedDelegCount map[uint64]int
 
 	// delegStateidMap maps LockManager DelegationID (UUID string) to NFS Stateid4.
 	// This enables NFSBreakHandler to look up the NFS wire-format stateid when
@@ -102,7 +119,7 @@ type StateManager struct {
 
 	// lockManager is the unified lock manager for actual byte-range conflict
 	// detection and cross-protocol locking. Set via SetLockManager() or constructor.
-	lockManager *lock.Manager
+	lockManager lock.LockManager
 
 	// bootEpoch is the server boot epoch, used as the high 32 bits of
 	// client IDs to ensure uniqueness across server restarts.
@@ -238,12 +255,14 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		clientsByName:       make(map[string]*ClientRecord),
 		unconfirmedByName:   make(map[string]*ClientRecord),
 		openStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*OpenState),
+		openStateByFile:     make(map[string][]*OpenState),
 		openOwners:          make(map[openOwnerKey]*OpenOwner),
 		closedOwnerByOther:  make(map[[types.NFS4_OTHER_SIZE]byte]*OpenOwner),
 		lockOwners:          make(map[lockOwnerKey]*LockOwner),
 		lockStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*LockState),
 		delegByOther:        make(map[[types.NFS4_OTHER_SIZE]byte]*DelegationState),
 		delegByFile:         make(map[string][]*DelegationState),
+		revokedDelegCount:   make(map[uint64]int),
 		delegStateidMap:     make(map[string]types.Stateid4),
 		recentlyRecalled:    make(map[string]time.Time),
 		recentlyRecalledTTL: RecentlyRecalledTTL,
@@ -738,8 +757,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 
 				// Remove actual locks from unified lock manager
 				if sm.lockManager != nil {
-					ownerID := fmt.Sprintf("nfs4:%d:%s", lockState.LockOwner.ClientID,
-						hex.EncodeToString(lockState.LockOwner.OwnerData))
+					ownerID := lockState.LockOwner.LockManagerOwnerID()
 					handleKey := string(lockState.FileHandle)
 					locks := sm.lockManager.ListUnifiedLocks(handleKey)
 					for _, l := range locks {
@@ -754,16 +772,15 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 
 				// Remove lock-owner from lockOwners map
 				if lockState.LockOwner != nil {
-					lockKey := makeLockOwnerKey(lockState.LockOwner.ClientID, lockState.LockOwner.OwnerData)
-					delete(sm.lockOwners, lockKey)
+					delete(sm.lockOwners, lockState.LockOwner.Key())
 				}
 			}
 
 			delete(sm.openStateByOther, openState.Stateid.Other)
+			sm.removeOpenStateFromFileLocked(openState)
 		}
 		// Remove the owner from the openOwners map
-		ownerKey := makeOwnerKey(owner.ClientID, owner.OwnerData)
-		delete(sm.openOwners, ownerKey)
+		delete(sm.openOwners, owner.Key())
 	}
 
 	// Drop any retained closed-stateid -> owner replay entries for this client.
@@ -778,7 +795,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 		if deleg.ClientID != clientID {
 			continue
 		}
-		delete(sm.delegByOther, other)
+		sm.deleteDelegByOtherLocked(other)
 		sm.removeDelegFromFile(deleg)
 
 		logger.Info("Delegation revoked on lease expiry",
@@ -818,7 +835,7 @@ func (sm *StateManager) RevokeDelegation(delegOther [types.NFS4_OTHER_SIZE]byte)
 		return
 	}
 
-	deleg.Revoked = true
+	sm.markDelegRevokedLocked(deleg)
 	sm.removeDelegFromFile(deleg)
 	sm.addRecentlyRecalled(deleg.FileHandle)
 
@@ -1143,6 +1160,7 @@ func (sm *StateManager) OpenFile(
 			Confirmed:    false,
 			OpenStates:   make([]*OpenState, 0),
 			ClientRecord: clientRecord,
+			key:          ownerKey,
 		}
 		copy(owner.OwnerData, ownerData)
 		sm.openOwners[ownerKey] = owner
@@ -1214,6 +1232,7 @@ func (sm *StateManager) OpenFile(
 
 		owner.OpenStates = append(owner.OpenStates, openState)
 		sm.openStateByOther[other] = openState
+		sm.addOpenStateToFileLocked(openState)
 	}
 
 	// Determine rflags: OPEN4_RESULT_CONFIRM only if owner is not yet confirmed
@@ -1255,12 +1274,11 @@ func (sm *StateManager) shareConflictLocked(
 	fileHandle []byte,
 	reqAccess, reqDeny uint32,
 ) bool {
-	for _, os := range sm.openStateByOther {
-		if !bytes.Equal(os.FileHandle, fileHandle) {
-			continue
-		}
+	// Iterate only the opens on this file via the secondary per-file index
+	// (openStateByFile), not every open in the server.
+	for _, os := range sm.openStateByFile[string(fileHandle)] {
 		// Same owner: bits are OR-merged, never in conflict with themselves.
-		if os.Owner != nil && makeOwnerKey(os.Owner.ClientID, os.Owner.OwnerData) == ownerKey {
+		if os.Owner != nil && os.Owner.Key() == ownerKey {
 			continue
 		}
 		if reqAccess&os.ShareDeny != 0 || reqDeny&os.ShareAccess != 0 {
@@ -1268,6 +1286,30 @@ func (sm *StateManager) shareConflictLocked(
 		}
 	}
 	return false
+}
+
+// addOpenStateToFileLocked inserts an OpenState into the per-file open index.
+// Caller must hold sm.mu.
+func (sm *StateManager) addOpenStateToFileLocked(os *OpenState) {
+	fhKey := string(os.FileHandle)
+	sm.openStateByFile[fhKey] = append(sm.openStateByFile[fhKey], os)
+}
+
+// removeOpenStateFromFileLocked removes an OpenState from the per-file open
+// index, dropping the file's slot entirely when it becomes empty so the map
+// stays bounded. Caller must hold sm.mu.
+func (sm *StateManager) removeOpenStateFromFileLocked(os *OpenState) {
+	fhKey := string(os.FileHandle)
+	states := sm.openStateByFile[fhKey]
+	for i, s := range states {
+		if s == os {
+			sm.openStateByFile[fhKey] = append(states[:i], states[i+1:]...)
+			break
+		}
+	}
+	if len(sm.openStateByFile[fhKey]) == 0 {
+		delete(sm.openStateByFile, fhKey)
+	}
 }
 
 // CacheOpenOwnerResult stores the encoded reply for an open-owner so that a
@@ -1476,8 +1518,9 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 		}
 	}
 
-	// Remove the open state from the "other" map
+	// Remove the open state from the "other" map and per-file index.
 	delete(sm.openStateByOther, stateid.Other)
+	sm.removeOpenStateFromFileLocked(openState)
 
 	// Remember which retained owner this now-closed stateid belonged to so a
 	// retransmitted CLOSE can still resolve the owner's cached reply.
@@ -1504,8 +1547,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 	// replay its cached reply (RFC 7530 §9.1.7); that entry is reaped on lease
 	// expiry.
 	if len(owner.OpenStates) == 0 {
-		ownerKey := makeOwnerKey(owner.ClientID, owner.OwnerData)
-		delete(sm.openOwners, ownerKey)
+		delete(sm.openOwners, owner.Key())
 		if owner.ClientRecord != nil {
 			delete(owner.ClientRecord.OpenOwners, string(owner.OwnerData))
 		}
@@ -1673,7 +1715,7 @@ func (sm *StateManager) RenewLease(clientID uint64) error {
 
 // SetLockManager sets the unified lock manager for byte-range conflict detection.
 // Called by the NFS adapter after construction to inject the lock manager.
-func (sm *StateManager) SetLockManager(lm *lock.Manager) {
+func (sm *StateManager) SetLockManager(lm lock.LockManager) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	sm.lockManager = lm
@@ -1826,6 +1868,7 @@ func (sm *StateManager) LockNew(
 			OwnerData:    make([]byte, len(lockOwnerData)),
 			LastSeqID:    0,
 			ClientRecord: clientRecord,
+			key:          loKey,
 		}
 		copy(lockOwner.OwnerData, lockOwnerData)
 		sm.lockOwners[loKey] = lockOwner
@@ -1993,7 +2036,7 @@ func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offse
 
 	// Build the protocol-agnostic lock owner
 	owner := lock.LockOwner{
-		OwnerID:   fmt.Sprintf("nfs4:%d:%s", lockState.LockOwner.ClientID, hex.EncodeToString(lockState.LockOwner.OwnerData)),
+		OwnerID:   lockState.LockOwner.LockManagerOwnerID(),
 		ClientID:  fmt.Sprintf("nfs4:%d", lockState.LockOwner.ClientID),
 		ShareName: "",
 	}
@@ -2085,7 +2128,7 @@ func (sm *StateManager) TestLock(
 	}
 
 	// Build the owner ID string using the same format as acquireLock
-	ownerID := fmt.Sprintf("nfs4:%d:%s", clientID, hex.EncodeToString(ownerData))
+	ownerID := lockManagerOwnerID(clientID, ownerData)
 
 	// Map lock type to shared/exclusive
 	var mappedType lock.LockType
@@ -2213,7 +2256,7 @@ func (sm *StateManager) UnlockFile(
 	// 4. Release the lock via unified lock manager
 	if sm.lockManager != nil {
 		owner := lock.LockOwner{
-			OwnerID:   fmt.Sprintf("nfs4:%d:%s", lockOwner.ClientID, hex.EncodeToString(lockOwner.OwnerData)),
+			OwnerID:   lockOwner.LockManagerOwnerID(),
 			ClientID:  fmt.Sprintf("nfs4:%d", lockOwner.ClientID),
 			ShareName: "",
 		}
@@ -2271,8 +2314,7 @@ func (sm *StateManager) ReleaseLockOwner(clientID uint64, ownerData []byte) erro
 
 	// Check if this lock-owner has any active locks in the lock manager
 	if sm.lockManager != nil {
-		ownerID := fmt.Sprintf("nfs4:%d:%s", lockOwner.ClientID,
-			hex.EncodeToString(lockOwner.OwnerData))
+		ownerID := lockOwner.LockManagerOwnerID()
 
 		// Find all lock states for this lock-owner by scanning lockStateByOther
 		for _, ls := range sm.lockStateByOther {
@@ -2408,12 +2450,10 @@ func (sm *StateManager) GetStatusFlags(session *Session) uint32 {
 		flags |= types.SEQ4_STATUS_EXPIRED_ALL_STATE_REVOKED
 	}
 
-	// Check for revoked delegations for this client
-	for _, deleg := range sm.delegByOther {
-		if deleg.ClientID == session.ClientID && deleg.Revoked {
-			flags |= types.SEQ4_STATUS_RECALLABLE_STATE_REVOKED
-			break
-		}
+	// Check for revoked delegations for this client via the per-client
+	// revoked-delegation index (O(1)) instead of scanning every delegation.
+	if sm.revokedDelegCount[session.ClientID] > 0 {
+		flags |= types.SEQ4_STATUS_RECALLABLE_STATE_REVOKED
 	}
 
 	return flags

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -61,6 +61,23 @@ type OpenOwner struct {
 
 	// ClientRecord is a back-reference to the owning client record.
 	ClientRecord *ClientRecord
+
+	// key is the precomputed composite map key (clientID + hex(ownerData)).
+	// It is cached at owner creation so hot-path lookups and comparisons reuse
+	// it instead of re-running makeOwnerKey (fmt.Sprintf + hex.EncodeToString)
+	// on every stateful op. OwnerData/ClientID are immutable after creation,
+	// so the cached key never goes stale.
+	key openOwnerKey
+}
+
+// Key returns the cached composite map key for this open-owner. Owners
+// constructed via the StateManager always carry a cached key; the fallback
+// covers literal-built instances (e.g. in tests).
+func (oo *OpenOwner) Key() openOwnerKey {
+	if oo.key == "" {
+		return makeOwnerKey(oo.ClientID, oo.OwnerData)
+	}
+	return oo.key
 }
 
 // ValidateSeqID checks whether a seqid is valid for this open-owner.

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -376,8 +376,7 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 
 	// Remove actual locks from unified lock manager
 	if sm.lockManager != nil && lockState.LockOwner != nil {
-		ownerID := fmt.Sprintf("nfs4:%d:%s", lockState.LockOwner.ClientID,
-			hex.EncodeToString(lockState.LockOwner.OwnerData))
+		ownerID := lockState.LockOwner.LockManagerOwnerID()
 		handleKey := string(lockState.FileHandle)
 		for _, l := range sm.lockManager.ListUnifiedLocks(handleKey) {
 			if l.Owner.OwnerID == ownerID {
@@ -392,7 +391,6 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 	// so deleting it on the first free would blind replay-detection and the
 	// owner caches for the still-live lock states.
 	if lockState.LockOwner != nil {
-		lockKey := makeLockOwnerKey(lockState.LockOwner.ClientID, lockState.LockOwner.OwnerData)
 		ownerStillReferenced := false
 		for _, ls := range sm.lockStateByOther {
 			if ls.LockOwner == lockState.LockOwner {
@@ -401,7 +399,7 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 			}
 		}
 		if !ownerStillReferenced {
-			delete(sm.lockOwners, lockKey)
+			delete(sm.lockOwners, lockState.LockOwner.Key())
 		}
 	}
 
@@ -445,8 +443,9 @@ func (sm *StateManager) freeOpenStateidLocked(clientID uint64, stateid *types.St
 		}
 	}
 
-	// Remove from openStateByOther
+	// Remove from openStateByOther and the per-file index
 	delete(sm.openStateByOther, stateid.Other)
+	sm.removeOpenStateFromFileLocked(openState)
 
 	// Remove from owner's OpenStates slice
 	if openState.Owner != nil {
@@ -462,8 +461,7 @@ func (sm *StateManager) freeOpenStateidLocked(clientID uint64, stateid *types.St
 
 		// If owner has no more open states, clean up the owner
 		if len(openState.Owner.OpenStates) == 0 {
-			ownerKey := makeOwnerKey(openState.Owner.ClientID, openState.Owner.OwnerData)
-			delete(sm.openOwners, ownerKey)
+			delete(sm.openOwners, openState.Owner.Key())
 		}
 	}
 
@@ -488,8 +486,8 @@ func (sm *StateManager) freeDelegStateidLocked(clientID uint64, stateid *types.S
 	// Stop recall timer if running
 	deleg.StopRecallTimer()
 
-	// Remove from delegByOther
-	delete(sm.delegByOther, stateid.Other)
+	// Remove from delegByOther (keeps revoked-delegation index consistent)
+	sm.deleteDelegByOtherLocked(stateid.Other)
 
 	// Remove from delegByFile
 	sm.removeDelegFromFile(deleg)

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/hex"
 	"fmt"
 	"os"
 	"time"
@@ -314,7 +313,7 @@ func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
 		}
 		sm.cleanupDirDelegation(deleg)
 		deleg.StopRecallTimer()
-		delete(sm.delegByOther, other)
+		sm.deleteDelegByOtherLocked(other)
 		sm.removeDelegFromFile(deleg)
 	}
 
@@ -460,8 +459,7 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 
 				// Remove actual locks from unified lock manager (matches onLeaseExpired)
 				if sm.lockManager != nil && lockState.LockOwner != nil {
-					ownerID := fmt.Sprintf("nfs4:%d:%s", lockState.LockOwner.ClientID,
-						hex.EncodeToString(lockState.LockOwner.OwnerData))
+					ownerID := lockState.LockOwner.LockManagerOwnerID()
 					handleKey := string(lockState.FileHandle)
 					for _, l := range sm.lockManager.ListUnifiedLocks(handleKey) {
 						if l.Owner.OwnerID == ownerID {
@@ -471,14 +469,13 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 				}
 
 				if lockState.LockOwner != nil {
-					lockKey := makeLockOwnerKey(lockState.LockOwner.ClientID, lockState.LockOwner.OwnerData)
-					delete(sm.lockOwners, lockKey)
+					delete(sm.lockOwners, lockState.LockOwner.Key())
 				}
 			}
 			delete(sm.openStateByOther, openState.Stateid.Other)
+			sm.removeOpenStateFromFileLocked(openState)
 		}
-		ownerKey := makeOwnerKey(owner.ClientID, owner.OwnerData)
-		delete(sm.openOwners, ownerKey)
+		delete(sm.openOwners, owner.Key())
 	}
 
 	// Clean up delegations for the evicted client
@@ -488,7 +485,7 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 		}
 		deleg.StopRecallTimer()
 		sm.cleanupDirDelegation(deleg)
-		delete(sm.delegByOther, other)
+		sm.deleteDelegByOtherLocked(other)
 		sm.removeDelegFromFile(deleg)
 	}
 


### PR DESCRIPTION
Replaces three O(N) full-table scans and a per-op string-allocation in the NFSv4 state layer (internal/adapter/nfs/v4/state/) with O(1)/O(opens-on-file) indexed lookups. Behavior-preserving; new white-box tests prove the indexes stay in sync across every mutation path.

## Findings addressed

- manager.go:1258 shareConflictLocked — was O(N) scan of all open states + per-entry makeOwnerKey alloc. Now iterates only the per-file slice via new openStateByFile index and compares the cached owner key.
- delegation.go:386 countOpensOnFile — was O(N) scan on every delegation grant check. Now uses the same per-file open index.
- manager.go:2412 GetStatusFlags — was O(N) delegation scan on every SEQUENCE op. Now O(1) via per-client revokedDelegCount index.
- openowner.go:206 makeOwnerKey / makeLockOwnerKey — fmt.Sprintf + hex.EncodeToString on every hot-path op. Now the composite key is cached on OpenOwner/LockOwner at creation and reused via Key(); the LockManager owner ID is unified via LockManagerOwnerID() / lockManagerOwnerID() so it stays in lock-step with the lock-owner map key (collapses 6 duplicated nfs4:%d:%s Sprintf sites).
- manager.go:105 (LOW) — lockManager field + SetLockManager now use the lock.LockManager interface instead of the concrete *lock.Manager.

## Index consistency

Index maintenance is centralized in helpers (addOpenStateToFileLocked / removeOpenStateFromFileLocked, markDelegRevokedLocked / deleteDelegByOtherLocked) and routed through every insert/delete of openStateByOther and delegByOther: OPEN, CLOSE, FREE_STATEID, v4.0/v4.1 client eviction, lease expiry, RevokeDelegation, ReturnDelegation. New tests in index_consistency_test.go assert the indexes match the authoritative maps after open/close/free/evict and revoke/return (idempotent revoke, no underflow on non-revoked free).

Validation: go build ./..., go vet, go test -race ./internal/adapter/nfs/v4/... all green.