### PR TITLE
fix(nfs/v3): BAD_COOKIE on cookieverf mismatch, honor sync WRITE, cache wtmax

### DIFF
--- a/internal/adapter/nfs/v3/handlers/caps_cache.go
+++ b/internal/adapter/nfs/v3/handlers/caps_cache.go
@@ -1,0 +1,50 @@
+package handlers
+
+import "sync/atomic"
+
+// Filesystem capability cache.
+//
+// The advertised maximum WRITE size (wtmax) is a static, store-level limit. The
+// WRITE handler needs it on every RPC to short-write over-large requests to the
+// value the client was told in FSINFO. Calling GetFilesystemCapabilities (a
+// Badger db.View on the BadgerDB backend) on every WRITE is wasteful, so the
+// value is cached here and refreshed whenever it is observed (FSINFO, or the
+// first WRITE on a cold cache).
+//
+// This mirrors the NFSv4 attrs package, which caches the same store
+// capabilities in atomic globals updated via SetFilesystemCapabilities.
+//
+// INVARIANT (process-global is safe): wtmax is a server-wide value, not a
+// per-share one. GetFilesystemCapabilities ignores the file handle and every
+// metadata backend (memory/badger/postgres) returns the same hardcoded
+// MaxWriteSize (1 MiB). FSINFO advertises this same value to every client on
+// every share, so a single global cannot diverge from what any one client was
+// told. If a future change makes wtmax per-share (a per-share override in
+// GetFilesystemCapabilities), this cache MUST become handle-keyed to avoid
+// clamping one share's WRITE with another share's limit.
+//
+// Uses an atomic to stay race-free with concurrent WRITE/FSINFO handlers.
+
+// fsMaxWriteSize holds the cached wtmax. Zero means "not yet observed".
+var fsMaxWriteSize atomic.Uint32
+
+// setMaxWriteSize records the advertised wtmax so subsequent WRITEs can clamp
+// without a per-RPC store lookup. A zero value is ignored (treated as unknown).
+func setMaxWriteSize(maxWriteSize uint32) {
+	if maxWriteSize > 0 {
+		fsMaxWriteSize.Store(maxWriteSize)
+	}
+}
+
+// cachedMaxWriteSize returns the cached wtmax, or 0 if it has not been observed
+// yet. A zero result means the caller must fall back to a one-time store lookup.
+func cachedMaxWriteSize() uint32 {
+	return fsMaxWriteSize.Load()
+}
+
+// ResetCapsCacheForTest clears the process-global capability cache so a test
+// starts from a cold cache. Because the cache is process-wide, tests that set
+// different wtmax values must reset it to avoid bleed-through from earlier runs.
+func ResetCapsCacheForTest() {
+	fsMaxWriteSize.Store(0)
+}

--- a/internal/adapter/nfs/v3/handlers/fsinfo.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo.go
@@ -168,6 +168,10 @@ func (h *Handler) FsInfo(
 		return &FsInfoResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
+	// Cache the advertised wtmax so WRITE can clamp over-large requests without
+	// a per-RPC GetFilesystemCapabilities lookup.
+	setMaxWriteSize(capabilities.MaxWriteSize)
+
 	// Convert metadata attributes to NFS wire format
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 

--- a/internal/adapter/nfs/v3/handlers/readdir.go
+++ b/internal/adapter/nfs/v3/handlers/readdir.go
@@ -145,19 +145,26 @@ func (h *Handler) ReadDir(
 	// Generate verifier from directory mtime - changes when directory is modified
 	currentVerifier := directoryMtimeVerifier(dirFile.Mtime)
 
-	// Validate cookie verifier for non-initial requests
-	// Initial request (cookie=0) or clients that don't use verifiers (verifier=0) bypass this check
-	// Note: We intentionally do NOT return NFS3ErrBadCookie on verifier mismatch.
-	// Our verifier is mtime-based, so it changes on every directory modification.
-	// Returning BAD_COOKIE during concurrent writes (e.g., macOS Finder copy)
-	// causes clients to fail with error -8062. We treat mismatches as advisory
-	// and continue serving entries from the cookie position, matching Linux knfsd.
+	// Validate cookie verifier for non-initial requests.
+	// Initial request (cookie=0) or clients that don't use verifiers (verifier=0)
+	// bypass this check. On a non-zero-cookie verifier mismatch, return
+	// NFS3ErrBadCookie per RFC 1813 Section 3.3.16 — the cookie was issued
+	// against a different directory snapshot and is no longer meaningful.
+	// This mirrors the NFSv4 READDIR behavior (NFS4ERR_BAD_COOKIE).
 	if req.Cookie != 0 && req.CookieVerf != 0 && req.CookieVerf != currentVerifier {
-		logger.DebugCtx(ctx.Context, "READDIR: directory modified since last read, continuing with current entries",
+		logger.DebugCtx(ctx.Context, "READDIR: cookieverf mismatch, returning NFS3ErrBadCookie",
 			"handle", fmt.Sprintf("%x", req.DirHandle),
 			"expected_verf", fmt.Sprintf("0x%016x", req.CookieVerf),
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", clientIP)
+
+		// Include directory attributes even on error for cache consistency
+		nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
+
+		return &ReadDirResponse{
+			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrBadCookie},
+			DirAttr:         nfsDirAttr,
+		}, nil
 	}
 
 	authCtx, err := h.GetCachedAuthContext(ctx)

--- a/internal/adapter/nfs/v3/handlers/readdir_test.go
+++ b/internal/adapter/nfs/v3/handlers/readdir_test.go
@@ -366,7 +366,11 @@ func TestReadDir_NestedDirectory(t *testing.T) {
 // TestReadDir_StaleVerifierContinues tests that READDIR continues serving entries
 // when the cookie verifier is stale (directory modified between paginated reads).
 // This prevents macOS Finder error -8062 during concurrent directory operations.
-func TestReadDir_StaleVerifierContinues(t *testing.T) {
+// TestReadDir_StaleVerifierBadCookie verifies that a non-zero-cookie READDIR
+// carrying a stale cookie verifier returns NFS3ERR_BAD_COOKIE per RFC 1813
+// Section 3.3.16. The cookie was issued against a different directory snapshot
+// and is no longer meaningful. This mirrors the NFSv4 READDIR behavior.
+func TestReadDir_StaleVerifierBadCookie(t *testing.T) {
 	fx := handlertesting.NewHandlerFixture(t)
 
 	// Setup: Create a directory with files
@@ -392,7 +396,7 @@ func TestReadDir_StaleVerifierContinues(t *testing.T) {
 	// Modify the directory (changes mtime, invalidates verifier)
 	fx.CreateFile("stale/file3.txt", []byte("3"))
 
-	// Second read with old verifier and a real non-zero cookie — should succeed, not BAD_COOKIE
+	// Second read with old verifier and a real non-zero cookie — must return BAD_COOKIE.
 	resp2, err := fx.Handler.ReadDir(fx.Context(), &handlers.ReadDirRequest{
 		DirHandle:  dirHandle,
 		Cookie:     resumeCookie,
@@ -400,16 +404,39 @@ func TestReadDir_StaleVerifierContinues(t *testing.T) {
 		Count:      8192,
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, types.NFS3OK, resp2.Status, "Stale verifier should not return BAD_COOKIE")
+	assert.EqualValues(t, types.NFS3ErrBadCookie, resp2.Status, "stale verifier must return NFS3ERR_BAD_COOKIE")
+}
 
-	// Verify that we continue from the cookie position:
-	// - the new file3.txt appears after resuming
-	// - previously returned entries (file1.txt, file2.txt) are not re-returned
-	require.NotEmpty(t, resp2.Entries, "expected entries when resuming directory read after modification")
-	names2 := extractEntryNames(resp2.Entries)
-	assert.Contains(t, names2, "file3.txt", "resumed READDIR should include newly created file3.txt")
-	assert.NotContains(t, names2, "file1.txt", "resumed READDIR should not re-return file1.txt")
-	assert.NotContains(t, names2, "file2.txt", "resumed READDIR should not re-return file2.txt")
+// TestReadDir_ZeroCookieIgnoresVerifierMismatch verifies that the verifier
+// check is bypassed for the initial request (cookie=0) and for clients that do
+// not use verifiers (verifier=0), even when the supplied verifier is garbage.
+func TestReadDir_ZeroCookieIgnoresVerifierMismatch(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fx.CreateFile("zc/aaa.txt", []byte("1"))
+	dirHandle := fx.MustGetHandle("zc")
+
+	// Initial READDIR (cookie=0) must ignore a junk verifier.
+	resp, err := fx.Handler.ReadDir(fx.Context(), &handlers.ReadDirRequest{
+		DirHandle:  dirHandle,
+		Cookie:     0,
+		CookieVerf: 0xDEADBEEFCAFEBABE,
+		Count:      8192,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp.Status, "initial READDIR (cookie=0) must ignore verifier mismatch")
+	require.NotEmpty(t, resp.Entries, "expected entries from initial READDIR")
+	resumeCookie := resp.Entries[len(resp.Entries)-1].Cookie
+
+	// Non-zero cookie but zero verifier (client does not use verifiers) must also be ignored.
+	resp2, err := fx.Handler.ReadDir(fx.Context(), &handlers.ReadDirRequest{
+		DirHandle:  dirHandle,
+		Cookie:     resumeCookie,
+		CookieVerf: 0,
+		Count:      8192,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp2.Status, "zero verifier must bypass the cookie check")
 }
 
 // extractEntryNames extracts the names from directory entries.

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -223,19 +223,26 @@ func (h *Handler) ReadDirPlus(
 	// Generate verifier from directory mtime - changes when directory is modified
 	currentVerifier := directoryMtimeVerifier(dirFile.Mtime)
 
-	// Validate cookie verifier for non-initial requests
-	// Initial request (cookie=0) or clients that don't use verifiers (verifier=0) bypass this check
-	// Note: We intentionally do NOT return NFS3ErrBadCookie on verifier mismatch.
-	// Our verifier is mtime-based, so it changes on every directory modification.
-	// Returning BAD_COOKIE during concurrent writes (e.g., macOS Finder copy)
-	// causes clients to fail with error -8062. We treat mismatches as advisory
-	// and continue serving entries from the cookie position, matching Linux knfsd.
+	// Validate cookie verifier for non-initial requests.
+	// Initial request (cookie=0) or clients that don't use verifiers (verifier=0)
+	// bypass this check. On a non-zero-cookie verifier mismatch, return
+	// NFS3ErrBadCookie per RFC 1813 Section 3.3.17 — the cookie was issued
+	// against a different directory snapshot and is no longer meaningful.
+	// This mirrors the NFSv4 READDIR behavior (NFS4ERR_BAD_COOKIE).
 	if req.Cookie != 0 && req.CookieVerf != 0 && req.CookieVerf != currentVerifier {
-		logger.DebugCtx(ctx.Context, "READDIRPLUS: directory modified since last read, continuing with current entries",
+		logger.DebugCtx(ctx.Context, "READDIRPLUS: cookieverf mismatch, returning NFS3ErrBadCookie",
 			"handle", fmt.Sprintf("%x", req.DirHandle),
 			"expected_verf", fmt.Sprintf("0x%016x", req.CookieVerf),
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", clientIP)
+
+		// Include directory attributes even on error for cache consistency
+		nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
+
+		return &ReadDirPlusResponse{
+			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrBadCookie},
+			DirAttr:         nfsDirAttr,
+		}, nil
 	}
 
 	authCtx, err := h.GetCachedAuthContext(ctx)

--- a/internal/adapter/nfs/v3/handlers/readdirplus_test.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus_test.go
@@ -89,7 +89,10 @@ func TestReadDirPlus_InvalidHandle(t *testing.T) {
 // TestReadDirPlus_StaleVerifierContinues tests that READDIRPLUS continues serving entries
 // when the cookie verifier is stale (directory modified between paginated reads).
 // This prevents macOS Finder error -8062 during concurrent directory operations.
-func TestReadDirPlus_StaleVerifierContinues(t *testing.T) {
+// TestReadDirPlus_StaleVerifierBadCookie verifies that a non-zero-cookie
+// READDIRPLUS carrying a stale cookie verifier returns NFS3ERR_BAD_COOKIE per
+// RFC 1813 Section 3.3.17, mirroring the NFSv4 READDIR behavior.
+func TestReadDirPlus_StaleVerifierBadCookie(t *testing.T) {
 	fx := handlertesting.NewHandlerFixture(t)
 
 	// Setup: Create a directory with files
@@ -116,7 +119,7 @@ func TestReadDirPlus_StaleVerifierContinues(t *testing.T) {
 	// Modify the directory (changes mtime, invalidates verifier)
 	fx.CreateFile("stale/file3.txt", []byte("3"))
 
-	// Second read with old verifier and a real non-zero cookie — should succeed, not BAD_COOKIE
+	// Second read with old verifier and a real non-zero cookie — must return BAD_COOKIE.
 	resp2, err := fx.Handler.ReadDirPlus(fx.Context(), &handlers.ReadDirPlusRequest{
 		DirHandle:  dirHandle,
 		Cookie:     resumeCookie,
@@ -125,17 +128,39 @@ func TestReadDirPlus_StaleVerifierContinues(t *testing.T) {
 		MaxCount:   65536,
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, types.NFS3OK, resp2.Status, "Stale verifier should not return BAD_COOKIE")
+	assert.EqualValues(t, types.NFS3ErrBadCookie, resp2.Status, "stale verifier must return NFS3ERR_BAD_COOKIE")
+}
 
-	// Ensure pagination semantics are preserved: the second page should not repeat earlier entries
-	// and should include the newly created file3.txt.
-	names := make([]string, len(resp2.Entries))
-	for i, entry := range resp2.Entries {
-		names[i] = entry.Name
-	}
-	assert.Contains(t, names, "file3.txt", "second page should include newly created file")
-	assert.NotContains(t, names, "file1.txt", "second page should not repeat earlier entries")
-	assert.NotContains(t, names, "file2.txt", "second page should not repeat earlier entries")
+// TestReadDirPlus_ZeroCookieIgnoresVerifierMismatch verifies the verifier check
+// is bypassed for the initial request (cookie=0) and for verifier-less clients
+// (verifier=0), even when the supplied verifier is garbage.
+func TestReadDirPlus_ZeroCookieIgnoresVerifierMismatch(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fx.CreateFile("zc/aaa.txt", []byte("1"))
+	dirHandle := fx.MustGetHandle("zc")
+
+	resp, err := fx.Handler.ReadDirPlus(fx.Context(), &handlers.ReadDirPlusRequest{
+		DirHandle:  dirHandle,
+		Cookie:     0,
+		CookieVerf: 0xDEADBEEFCAFEBABE,
+		DirCount:   8192,
+		MaxCount:   65536,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp.Status, "initial READDIRPLUS (cookie=0) must ignore verifier mismatch")
+	require.NotEmpty(t, resp.Entries, "expected entries from initial READDIRPLUS")
+	resumeCookie := resp.Entries[len(resp.Entries)-1].Cookie
+
+	resp2, err := fx.Handler.ReadDirPlus(fx.Context(), &handlers.ReadDirPlusRequest{
+		DirHandle:  dirHandle,
+		Cookie:     resumeCookie,
+		CookieVerf: 0,
+		DirCount:   8192,
+		MaxCount:   65536,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp2.Status, "zero verifier must bypass the cookie check")
 }
 
 // TestReadDirPlus_MaxCountTruncation verifies H11: when the client's maxcount

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -74,6 +74,11 @@ type HandlerTestFixture struct {
 func NewHandlerFixture(t testing.TB) *HandlerTestFixture {
 	t.Helper()
 
+	// The wtmax capability cache is process-global; clear it so each fixture
+	// starts cold and tests that set distinct wtmax values do not bleed into
+	// one another.
+	handlers.ResetCapsCacheForTest()
+
 	ctx := context.Background()
 
 	// Create stores

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -8,6 +8,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -156,12 +157,24 @@ func (h *Handler) Write(
 	// rejected with NFS3ERR_FBIG. This mirrors Linux nfsd, which clamps to
 	// svc_max_payload. A genuine "file too large" (offset overflow / OffsetMax)
 	// still returns NFS3ERR_FBIG below.
-	if caps, capErr := metaSvc.GetFilesystemCapabilities(ctx.Context, fileHandle); capErr == nil &&
-		caps.MaxWriteSize > 0 && uint32(len(req.Data)) > caps.MaxWriteSize {
+	//
+	// wtmax is a static store-level limit, so it is read from the process-wide
+	// cache (populated by FSINFO) instead of a per-RPC GetFilesystemCapabilities
+	// lookup. On a cold cache (WRITE before any FSINFO) we fetch once and
+	// populate it; the common mount sequence (FSINFO precedes WRITE) keeps the
+	// store off the hot WRITE path entirely.
+	maxWriteSize := cachedMaxWriteSize()
+	if maxWriteSize == 0 {
+		if caps, capErr := metaSvc.GetFilesystemCapabilities(ctx.Context, fileHandle); capErr == nil && caps != nil {
+			maxWriteSize = caps.MaxWriteSize
+			setMaxWriteSize(maxWriteSize)
+		}
+	}
+	if maxWriteSize > 0 && uint32(len(req.Data)) > maxWriteSize {
 		logger.DebugCtx(ctx.Context, "WRITE: short-write to advertised wtmax",
-			"requested", len(req.Data), "wtmax", caps.MaxWriteSize, "client", clientIP)
-		req.Data = req.Data[:caps.MaxWriteSize]
-		req.Count = caps.MaxWriteSize
+			"requested", len(req.Data), "wtmax", maxWriteSize, "client", clientIP)
+		req.Data = req.Data[:maxWriteSize]
+		req.Count = maxWriteSize
 	}
 
 	// Note: File existence and type validation is done by PrepareWrite.
@@ -266,28 +279,31 @@ func (h *Handler) Write(
 
 	logger.DebugCtx(ctx.Context, "WRITE successful", "file", updatedFile.PayloadID, "offset", bytesize.ByteSize(req.Offset), "requested", bytesize.ByteSize(req.Count), "written", bytesize.ByteSize(len(req.Data)), "new_size", bytesize.ByteSize(updatedFile.Size), "client", clientIP)
 
-	// Stability Level Design Decision (RFC 1813 Section 3.3.7)
+	// Stability Level (RFC 1813 Section 3.3.7)
 	//
-	// We always return UNSTABLE because Cache is always enabled.
-	// This is RFC-compliant because:
+	// The `stable` field is the client's request. The server reports what it
+	// ACTUALLY did via the `committed` field.
 	//
-	// RFC 1813 says: "The server may choose to write the data to stable storage
-	// or may hold it in the server's internal buffers to be written later."
+	// Default: UNSTABLE. Cache is always enabled, so an unstable WRITE leaves the
+	// data in the local cache (crash-safe via the WAL) and the client calls COMMIT
+	// when it needs durability. This is much faster for high-latency backends (S3
+	// writes are 100ms+; batching on COMMIT is 10-100x faster for sequential I/O).
 	//
-	// The `stable` field is the client's PREFERENCE, not a mandate. The server
-	// returns what it ACTUALLY did via the `committed` field. Clients handle
-	// UNSTABLE correctly by calling COMMIT when they need durability.
-	//
-	// Why this design:
-	//   - S3 backends: Synchronous writes to S3 are slow (100ms+ per request).
-	//     Async flush on COMMIT is 10-100x faster for sequential writes.
-	//   - Performance: Buffering writes and flushing in batches is more efficient
-	//     for any remote or high-latency storage backend.
-	//   - Client compatibility: All NFS clients handle UNSTABLE correctly and
-	//     will call COMMIT before closing files or when fsync() is called.
-	//
+	// When the client requests DATA_SYNC or FILE_SYNC, RFC 1813 requires the data
+	// (and, for FILE_SYNC, metadata) to be on stable storage before the reply. We
+	// honor that by flushing this file synchronously and reporting the requested
+	// stability level, mirroring the COMMIT path. On flush failure we fall back to
+	// reporting UNSTABLE rather than failing the WRITE — the bytes are still in the
+	// crash-safe cache and the client can retry COMMIT.
 	committed := uint32(UnstableWrite)
-	logger.DebugCtx(ctx.Context, "WRITE: returning UNSTABLE (flush on COMMIT)")
+	if req.Stable >= DataSyncWrite {
+		if err := h.flushStableWrite(ctx, metaSvc, blockStore, fileHandle, writeIntent.PayloadID, authCtx, req.Stable); err != nil {
+			logError(ctx.Context, err, "WRITE: stable flush failed, downgrading to UNSTABLE",
+				"handle", fmt.Sprintf("0x%x", req.Handle), "stable_requested", req.Stable, "client", clientIP)
+		} else {
+			committed = req.Stable
+		}
+	}
 
 	logger.DebugCtx(ctx.Context, "WRITE details", "stable_requested", req.Stable, "committed", committed, "size", bytesize.ByteSize(updatedFile.Size), "type", updatedFile.Type, "mode", fmt.Sprintf("%o", updatedFile.Mode))
 
@@ -303,12 +319,47 @@ func (h *Handler) Write(
 		// be updated to report the actual number of bytes written instead of
 		// len(req.Data), and the WriteAt contract should document that behavior.
 		Count:     uint32(len(req.Data)),
-		Committed: committed,      // UNSTABLE when using cache, tells client to call COMMIT
+		Committed: committed,      // requested stability if flushed, else UNSTABLE (client calls COMMIT)
 		Verf:      serverBootTime, // Server boot time for restart detection
 	}, nil
 }
 
 // Write Helper Functions
+
+// flushStableWrite forces this file's cached data (and, for FILE_SYNC, metadata)
+// to stable storage so a DATA_SYNC / FILE_SYNC WRITE can be acknowledged as
+// committed, per RFC 1813 Section 3.3.7. It mirrors the COMMIT path: flush the
+// block store, then persist any pending metadata for the file.
+//
+// RFC 1813 distinguishes the two stable levels:
+//   - DATA_SYNC (1): only the file data must be on stable storage. A metadata
+//     flush failure is tolerated — it is reconciled by a later COMMIT — and the
+//     write is still reported at the requested level.
+//   - FILE_SYNC (2): both data AND metadata must be on stable storage before the
+//     reply. A metadata flush failure must therefore propagate so the caller
+//     reports UNSTABLE instead of falsely claiming FILE_SYNC durability.
+func (h *Handler) flushStableWrite(
+	ctx *NFSHandlerContext,
+	metaSvc *metadata.Service,
+	blockStore *engine.Store,
+	handle metadata.FileHandle,
+	payloadID metadata.PayloadID,
+	authCtx *metadata.AuthContext,
+	stable uint32,
+) error {
+	if err := common.CommitBlockStore(ctx.Context, blockStore, payloadID); err != nil {
+		return err
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle); err != nil {
+		if stable >= FileSyncWrite {
+			// FILE_SYNC requires durable metadata; surface the failure.
+			return err
+		}
+		logger.WarnCtx(ctx.Context, "WRITE: DATA_SYNC metadata flush failed (data durable, will reconcile)",
+			"handle", fmt.Sprintf("0x%x", handle), "error", err)
+	}
+	return nil
+}
 
 // buildWriteErrorResponse creates a consistent error response with WCC data.
 // This centralizes error response creation to reduce duplication.

--- a/internal/adapter/nfs/v3/handlers/write_test.go
+++ b/internal/adapter/nfs/v3/handlers/write_test.go
@@ -365,9 +365,11 @@ func TestWrite_FileSyncStability(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, types.NFS3OK, resp.Status)
 	assert.EqualValues(t, uint32(5), resp.Count)
-	// With Cache always enabled, we always return UNSTABLE (0)
-	// Server is allowed to return less stable than requested per RFC 1813
-	assert.EqualValues(t, uint32(0), resp.Committed)
+	// A FILE_SYNC request triggers a synchronous flush; on success the server
+	// reports the requested stability level (FILE_SYNC = 2) per RFC 1813
+	// Section 3.3.7.
+	assert.EqualValues(t, uint32(handlers.FileSyncWrite), resp.Committed,
+		"FILE_SYNC WRITE must report FILE_SYNC when the flush succeeds")
 }
 
 // TestWrite_InvalidStability tests WRITE with invalid stability level.


### PR DESCRIPTION
Addresses the NFSv3-handlers findings from the v1.0 re-audit (#1104).

## Findings fixed

- **`readdir.go` / `readdirplus.go` — cookieverf mismatch silently ignored.** READDIR/READDIRPLUS now return `NFS3ERR_BAD_COOKIE` on a non-zero-cookie verifier mismatch (RFC 1813 §3.3.16/3.3.17), matching the NFSv4 READDIR behavior already shipped (commit `7548192f`). A zero cookie (initial request) or zero verifier (verifier-less client) still bypasses the check. Directory attributes are returned even on the error, consistent with the existing `NFS3ERR_NOTDIR` path.
- **`write.go` — per-RPC `GetFilesystemCapabilities` (Badger `db.View`) on every WRITE.** wtmax is now cached in a process-global atomic (`caps_cache.go`), populated by FSINFO and refreshed on a cold-cache WRITE. This mirrors the existing NFSv4 `attrs/encode.go` `fsMaxWriteSize` cache. The store stays off the hot WRITE path for the common mount sequence (FSINFO precedes WRITE).
- **`write.go` — WRITE always returned UNSTABLE.** A DATA_SYNC / FILE_SYNC request now triggers a synchronous flush (block store + pending metadata, via the shared `common.CommitBlockStore` seam used by COMMIT) and reports the requested stability level. On flush failure it falls back to UNSTABLE — the bytes remain in the crash-safe cache and the client can retry COMMIT.

## Notes

- The process-global wtmax cache is the established pattern in this codebase (NFSv4 `attrs` package); the metadata store exposes a single static wtmax process-wide.
- Tests `TestReadDir/Plus_StaleVerifierContinues` encoded the old advisory-only behavior and were replaced with `*_StaleVerifierBadCookie` + `*_ZeroCookieIgnoresVerifierMismatch` coverage, mirroring the NFSv4 test additions. `TestWrite_FileSyncStability` updated to assert FILE_SYNC is honored.
- The `NewHandlerFixture` constructor resets the process-global caps cache so tests setting distinct wtmax values do not bleed into one another.

Relates to #1104.