### PR TITLE
perf(nfs): cache parsed blocked-operations set off the RPC dispatch path

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -140,6 +140,17 @@ type NFSAdapter struct {
 	// retransmits the same request (RPC-timeout retry on a hard mount), so the
 	// retry does not re-execute and return a spurious EEXIST/ENOENT/NOT_SYNC.
 	drc *duplicateRequestCache
+
+	// blockedOpsMu protects v3BlockedOps from concurrent read/write access.
+	blockedOpsMu sync.RWMutex
+
+	// v3BlockedOps is the parsed set of NFSv3 procedure names blocked at the
+	// adapter level, keyed by procedure name (e.g. "WRITE", "REMOVE"). It is
+	// parsed once from NFSAdapterSettings.BlockedOperations in applyNFSSettings
+	// (at startup and on each settings-change event) so the hot v3 dispatch path
+	// (isOperationBlocked) does a single map lookup instead of a per-RPC JSON
+	// unmarshal + linear scan.
+	v3BlockedOps map[string]bool
 }
 
 // NFSTimeoutsConfig groups all timeout-related configuration.

--- a/pkg/adapter/nfs/blocked_ops_test.go
+++ b/pkg/adapter/nfs/blocked_ops_test.go
@@ -1,0 +1,71 @@
+package nfs
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestIsOperationBlocked_UsesCachedSet verifies that the NFSv3 dispatch path
+// consults the pre-parsed blocked-ops set rather than unmarshalling the stored
+// blocklist on every call. It also confirms blocked vs allowed semantics.
+func TestIsOperationBlocked_UsesCachedSet(t *testing.T) {
+	s := &NFSAdapter{}
+	c := &NFSConnection{server: s}
+
+	// No Registry, no settings, empty cache: nothing is blocked. This also
+	// proves isOperationBlocked does not depend on the SettingsWatcher on the
+	// hot path -- it reads only the cached set.
+	if c.isOperationBlocked("WRITE") {
+		t.Fatal("expected no ops blocked before any settings applied")
+	}
+
+	s.setV3BlockedOps([]string{"WRITE", "REMOVE"})
+
+	if !c.isOperationBlocked("WRITE") {
+		t.Error("expected WRITE to be blocked")
+	}
+	if !c.isOperationBlocked("REMOVE") {
+		t.Error("expected REMOVE to be blocked")
+	}
+	if c.isOperationBlocked("READ") {
+		t.Error("expected READ to be allowed")
+	}
+
+	// Clearing the set unblocks everything (hot-reload to an empty blocklist).
+	s.setV3BlockedOps(nil)
+	if c.isOperationBlocked("WRITE") {
+		t.Error("expected WRITE to be allowed after clearing the blocklist")
+	}
+}
+
+// TestIsOperationBlocked_NoPerCallUnmarshal proves that the blocklist is parsed
+// once (at apply time) and not re-parsed per dispatch: mutating the source
+// settings' serialized blocklist after the cache is populated has no effect on
+// subsequent isOperationBlocked calls.
+func TestIsOperationBlocked_NoPerCallUnmarshal(t *testing.T) {
+	settings := &models.NFSAdapterSettings{}
+	settings.SetBlockedOperations([]string{"WRITE"})
+
+	s := &NFSAdapter{}
+	c := &NFSConnection{server: s}
+
+	// Apply the blocklist once (mirrors applyNFSSettings).
+	s.setV3BlockedOps(settings.GetBlockedOperations())
+
+	if !c.isOperationBlocked("WRITE") {
+		t.Fatal("expected WRITE to be blocked after applying settings")
+	}
+
+	// Mutate the underlying serialized blocklist. If isOperationBlocked were
+	// re-unmarshalling settings.BlockedOperations on every call, this would
+	// change the result. Because the parsed set is cached, it must not.
+	settings.SetBlockedOperations([]string{"READ"})
+
+	if !c.isOperationBlocked("WRITE") {
+		t.Error("WRITE should still be blocked: dispatch must read the cached set, not re-parse settings")
+	}
+	if c.isOperationBlocked("READ") {
+		t.Error("READ must not become blocked from a post-apply settings mutation: dispatch must not re-parse settings")
+	}
+}

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"slices"
 
 	nfs "github.com/marmos91/dittofs/internal/adapter/nfs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/middleware"
@@ -373,20 +372,34 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 	}
 }
 
-// isOperationBlocked checks if the given operation is blocked via adapter
-// settings. Reads from the runtime's settings watcher for hot-reload support.
-// Used for NFSv3 dispatch; NFSv4 has its own blocked ops mechanism via Handler.SetBlockedOps.
+// setV3BlockedOps replaces the cached set of NFSv3 procedure names blocked at
+// the adapter level. Called from applyNFSSettings on startup and on each
+// settings-change event, so the hot RPC dispatch path (isOperationBlocked)
+// consults a pre-parsed name-keyed set instead of unmarshalling the stored
+// blocklist on every request. A nil/empty slice clears the set.
+func (s *NFSAdapter) setV3BlockedOps(opNames []string) {
+	var blocked map[string]bool
+	if len(opNames) > 0 {
+		blocked = make(map[string]bool, len(opNames))
+		for _, name := range opNames {
+			blocked[name] = true
+		}
+	}
+	s.blockedOpsMu.Lock()
+	s.v3BlockedOps = blocked
+	s.blockedOpsMu.Unlock()
+}
+
+// isOperationBlocked checks if the given NFSv3 procedure is blocked via adapter
+// settings. It consults the pre-parsed v3BlockedOps set (populated from the
+// SettingsWatcher in applyNFSSettings, with hot-reload support) so the hot
+// dispatch path does a single map lookup rather than a per-RPC JSON unmarshal.
+// NFSv4 has its own blocked ops mechanism via Handler.SetBlockedOps.
 func (c *NFSConnection) isOperationBlocked(opName string) bool {
-	if c.server.Registry == nil {
-		return false
-	}
-
-	settings := c.server.Registry.GetNFSSettings()
-	if settings == nil {
-		return false
-	}
-
-	return slices.Contains(settings.GetBlockedOperations(), opName)
+	c.server.blockedOpsMu.RLock()
+	blocked := c.server.v3BlockedOps[opName]
+	c.server.blockedOpsMu.RUnlock()
+	return blocked
 }
 
 // maybeRegisterBackchannel checks if this connection has been bound for

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -59,12 +59,18 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	}
 	s.v4Handler.StateManager.SetMaxConnectionsPerSession(settings.V4MaxConnectionsPerSession)
 
-	// Operation blocklist -> v4 Handler.
-	// SetBlockedOps parses the names into a uint32 set once here so the hot
-	// COMPOUND dispatch path (Handler.IsOperationBlocked) only does a map lookup
-	// instead of a per-op JSON unmarshal + linear scan.
+	// Operation blocklist. GetBlockedOperations does a JSON unmarshal of the
+	// stored blocklist, so it is parsed exactly once here (on startup and on
+	// each settings-change event) and cached for both protocol versions:
+	//   - v4: SetBlockedOps parses the names into a uint32 set so the hot
+	//     COMPOUND dispatch path (Handler.IsOperationBlocked) only does a map
+	//     lookup instead of a per-op JSON unmarshal + linear scan.
+	//   - v3: the names are cached in s.v3BlockedOps as a name-keyed set so the
+	//     hot RPC dispatch path (isOperationBlocked) only does a map lookup
+	//     instead of a per-RPC JSON unmarshal + linear scan.
 	blockedOps := settings.GetBlockedOperations()
 	s.v4Handler.SetBlockedOps(blockedOps)
+	s.setV3BlockedOps(blockedOps)
 	if len(blockedOps) > 0 {
 		logger.Info("NFS adapter: operation blocklist active",
 			"blocked_ops", blockedOps)


### PR DESCRIPTION
## Finding

`pkg/adapter/nfs/handlers.go:389` — the NFSv3 `isOperationBlocked` path did a JSON unmarshal of the blocked-operations config (`NFSAdapterSettings.GetBlockedOperations` → `parseStringSlice` → `json.Unmarshal`) followed by a linear scan **on every RPC dispatch** (called from `handleNFSProcedure` for each request).

## Fix

Reuse the same mechanism PR #1108 added for the v4 tree (`SettingsWatcher.OnNFSSettingsChange` + cached blocked-ops set):

- Add a name-keyed `v3BlockedOps map[string]bool` (guarded by an `RWMutex`) to `NFSAdapter`.
- Parse the blocklist **once** in `applyNFSSettings` — alongside the existing `v4Handler.SetBlockedOps` call — which already runs at startup and on every settings-change event (the `OnNFSSettingsChange` callback registered in `adapter.go`).
- `isOperationBlocked` now consults the pre-parsed set via a single map lookup; no per-RPC unmarshal or live `GetNFSSettings` read on the hot path.

This is purely the **v3** path; #1108 addressed only the v4 `internal/adapter/nfs/v4` tree (its `IsOperationBlocked` still read live settings, but v4 is out of scope here). Behavior is preserved: before settings load the set is empty (nothing blocked), matching the old nil-Registry/nil-settings early returns, and the cache is populated synchronously in `SetRuntime` before serving begins.

## Tests

`pkg/adapter/nfs/blocked_ops_test.go`:
- `TestIsOperationBlocked_UsesCachedSet` — blocked vs allowed semantics, empty/cleared set.
- `TestIsOperationBlocked_NoPerCallUnmarshal` — mutating the source settings' serialized blocklist after the cache is populated has no effect on subsequent dispatch calls, proving the set is parsed once and not re-unmarshalled per call.

`go build ./...`, `go vet ./pkg/adapter/nfs/...`, `go test [-race] ./pkg/adapter/nfs/...` all green.