### PR TITLE
perf(blockstore): single ListFileBlocks scan per read; sync.Once SyncQueue.Stop; fix gcstate comment

### DIFF
--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -226,22 +226,6 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 	return offset / uint64(BlockSize), (offset + uint64(length) - 1) / uint64(BlockSize)
 }
 
-// allBlocksLocal returns true if every block in the range is already in the
-// local store. It scans the per-payload FileBlock rows ONCE and reuses that
-// snapshot across the range, replacing the previous N store scans.
-func (m *Syncer) allBlocksLocal(ctx context.Context, payloadID string, startIdx, endIdx uint64) bool {
-	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
-	if err != nil {
-		return false
-	}
-	for blockIdx := startIdx; blockIdx <= endIdx; blockIdx++ {
-		if !m.blockIsLocalFromRows(ctx, rows, blockIdx) {
-			return false
-		}
-	}
-	return true
-}
-
 // EnsureAvailableAndRead downloads blocks and copies data directly to dest, avoiding
 // a second local ReadAt. Demanded blocks are downloaded inline in the caller's goroutine
 // prefetch uses the worker pool. Returns (filled, error).
@@ -261,8 +245,9 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	// Single point-in-time scan of the per-payload FileBlock rows, reused for
 	// the all-local fast path, the per-block locality checks below, and the
 	// inline fetch hash lookups. This replaces the prior 2N store scans (one
-	// per block in allBlocksLocal + one per block in the loop, plus one more
-	// inside each inlineFetchOrWait) with a single O(M) scan per read.
+	// per block in the all-local check + one per block in the download loop,
+	// plus one more inside each inlineFetchOrWait) with a single O(M) scan per
+	// read.
 	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
 	if err != nil {
 		return false, err

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -34,6 +34,23 @@ func inFlightKey(payloadID string, blockIdx uint64) string {
 // zero for any reachable block; the dispatchRemoteFetch helper enforces
 // this.
 func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockIdx uint64) (*block.FileBlock, error) {
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		return nil, err
+	}
+	return resolveFileBlockFromRows(rows, blockIdx), nil
+}
+
+// listFileBlocksSnapshot returns a point-in-time snapshot of the FileBlock rows
+// for payloadID with a single O(M) store scan. A sparse / not-yet-uploaded
+// payload (ErrFileBlockNotFound) yields (nil, nil). Callers that need to test
+// many block indices for one read should fetch the snapshot ONCE and pass it to
+// resolveFileBlockFromRows / blockIsLocalFromRows, collapsing the previous O(N)
+// store scans (one per block index) into a single scan per read. The snapshot
+// is point-in-time: a concurrent writer that mutates the block set after the
+// scan is not reflected for the remainder of that read, which is the acceptable
+// (and arguably more correct) per-read isolation semantics.
+func (m *Syncer) listFileBlocksSnapshot(ctx context.Context, payloadID string) ([]*block.FileBlock, error) {
 	rows, err := m.fileBlockStore.ListFileBlocks(ctx, payloadID)
 	if err != nil {
 		if errors.Is(err, block.ErrFileBlockNotFound) {
@@ -41,8 +58,15 @@ func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockId
 		}
 		return nil, fmt.Errorf("list file blocks for %s: %w", payloadID, err)
 	}
+	return rows, nil
+}
+
+// resolveFileBlockFromRows finds the FileBlock covering blockIdx's byte window
+// within an already-fetched row snapshot. See resolveFileBlock for the offset-
+// covering semantics. Returns nil when no row covers the window.
+func resolveFileBlockFromRows(rows []*block.FileBlock, blockIdx uint64) *block.FileBlock {
 	if len(rows) == 0 {
-		return nil, nil
+		return nil
 	}
 	target := blockIdx * uint64(BlockSize)
 	for _, fb := range rows {
@@ -54,10 +78,10 @@ func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockId
 			continue
 		}
 		if target >= abs && target < abs+uint64(fb.DataSize) {
-			return fb, nil
+			return fb
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 // blockIsLocal reports whether the bytes for (payloadID, blockIdx) are
@@ -70,10 +94,24 @@ func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockId
 // non-true outcome as "must round-trip to remote".
 func (m *Syncer) blockIsLocal(ctx context.Context, payloadID string, blockIdx uint64) bool {
 	fb, err := m.resolveFileBlock(ctx, payloadID, blockIdx)
-	if err != nil || fb == nil {
+	if err != nil {
 		return false
 	}
-	if fb.Hash.IsZero() {
+	return m.blockIsLocalFromRow(ctx, fb)
+}
+
+// blockIsLocalFromRows answers blockIsLocal against an already-fetched row
+// snapshot, avoiding a fresh ListFileBlocks scan per block index.
+func (m *Syncer) blockIsLocalFromRows(ctx context.Context, rows []*block.FileBlock, blockIdx uint64) bool {
+	return m.blockIsLocalFromRow(ctx, resolveFileBlockFromRows(rows, blockIdx))
+}
+
+// blockIsLocalFromRow reports whether the resolved FileBlock's CAS chunk is
+// present in the local store. A nil row, a zero hash (sparse / pre-CAS drift),
+// or a local.Has error all yield false — the caller treats any non-true outcome
+// as "must round-trip to remote".
+func (m *Syncer) blockIsLocalFromRow(ctx context.Context, fb *block.FileBlock) bool {
+	if fb == nil || fb.Hash.IsZero() {
 		return false
 	}
 	has, err := m.local.Has(ctx, fb.Hash)
@@ -188,10 +226,16 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 	return offset / uint64(BlockSize), (offset + uint64(length) - 1) / uint64(BlockSize)
 }
 
-// allBlocksLocal returns true if every block in the range is already in the local store.
+// allBlocksLocal returns true if every block in the range is already in the
+// local store. It scans the per-payload FileBlock rows ONCE and reuses that
+// snapshot across the range, replacing the previous N store scans.
 func (m *Syncer) allBlocksLocal(ctx context.Context, payloadID string, startIdx, endIdx uint64) bool {
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		return false
+	}
 	for blockIdx := startIdx; blockIdx <= endIdx; blockIdx++ {
-		if !m.blockIsLocal(ctx, payloadID, blockIdx) {
+		if !m.blockIsLocalFromRows(ctx, rows, blockIdx) {
 			return false
 		}
 	}
@@ -213,7 +257,25 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	}
 
 	startBlockIdx, endBlockIdx := blockRange(offset, length)
-	if m.allBlocksLocal(ctx, payloadID, startBlockIdx, endBlockIdx) {
+
+	// Single point-in-time scan of the per-payload FileBlock rows, reused for
+	// the all-local fast path, the per-block locality checks below, and the
+	// inline fetch hash lookups. This replaces the prior 2N store scans (one
+	// per block in allBlocksLocal + one per block in the loop, plus one more
+	// inside each inlineFetchOrWait) with a single O(M) scan per read.
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		return false, err
+	}
+
+	allLocal := true
+	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
+		if !m.blockIsLocalFromRows(ctx, rows, blockIdx) {
+			allLocal = false
+			break
+		}
+	}
+	if allLocal {
 		return false, nil
 	}
 
@@ -228,12 +290,12 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	needLocalReadAt := false
 
 	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
-		if m.blockIsLocal(ctx, payloadID, blockIdx) {
+		if m.blockIsLocalFromRows(ctx, rows, blockIdx) {
 			needLocalReadAt = true
 			continue
 		}
 
-		data, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx)
+		data, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, rows)
 		if err != nil {
 			return false, err
 		}
@@ -266,7 +328,10 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 
 // inlineFetchOrWait downloads a block inline or waits for an in-flight download.
 // Returns (data, true, nil) for inline download, (nil, false, nil) if piggybacked on existing.
-func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64) ([]byte, bool, error) {
+//
+// rows is the caller's point-in-time FileBlock snapshot for payloadID; the
+// block is resolved from it instead of re-scanning the store.
+func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, rows []*block.FileBlock) ([]byte, bool, error) {
 	key := inFlightKey(payloadID, blockIdx)
 
 	m.inFlightMu.Lock()
@@ -298,11 +363,7 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 		}
 	}()
 
-	fb, err := m.resolveFileBlock(ctx, payloadID, blockIdx)
-	if err != nil {
-		completionErr = err
-		return nil, false, err
-	}
+	fb := resolveFileBlockFromRows(rows, blockIdx)
 	if fb == nil {
 		return nil, true, nil
 	}

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -42,14 +42,15 @@ func (m *Syncer) resolveFileBlock(ctx context.Context, payloadID string, blockId
 }
 
 // listFileBlocksSnapshot returns a point-in-time snapshot of the FileBlock rows
-// for payloadID with a single O(M) store scan. A sparse / not-yet-uploaded
-// payload (ErrFileBlockNotFound) yields (nil, nil). Callers that need to test
-// many block indices for one read should fetch the snapshot ONCE and pass it to
-// resolveFileBlockFromRows / blockIsLocalFromRows, collapsing the previous O(N)
-// store scans (one per block index) into a single scan per read. The snapshot
-// is point-in-time: a concurrent writer that mutates the block set after the
-// scan is not reflected for the remainder of that read, which is the acceptable
-// (and arguably more correct) per-read isolation semantics.
+// for payloadID with a single ListFileBlocks store scan. A sparse / not-yet-
+// uploaded payload (ErrFileBlockNotFound) yields (nil, nil). Callers that need
+// to test many block indices for one read should fetch the snapshot ONCE and
+// pass it to resolveFileBlockFromRows / blockIsLocalFromRows: each block lookup
+// then walks the in-memory snapshot instead of issuing its own store scan,
+// collapsing the previous N store scans (one per block index) into one. The
+// snapshot is point-in-time: a concurrent writer that mutates the block set
+// after the scan is not reflected for the remainder of that read, which is the
+// acceptable (and arguably more correct) per-read isolation semantics.
 func (m *Syncer) listFileBlocksSnapshot(ctx context.Context, payloadID string) ([]*block.FileBlock, error) {
 	rows, err := m.fileBlockStore.ListFileBlocks(ctx, payloadID)
 	if err != nil {
@@ -242,11 +243,12 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 
 	startBlockIdx, endBlockIdx := blockRange(offset, length)
 
-	// Single point-in-time scan of the per-payload FileBlock rows, reused for
-	// the all-local fast path, the per-block locality checks below, and the
-	// inline fetch hash lookups. This replaces the prior 2N store scans (one
+	// Single point-in-time store scan of the per-payload FileBlock rows,
+	// reused for the all-local fast path, the per-block locality checks below,
+	// and the inline fetch hash lookups (all of which walk this in-memory
+	// snapshot). This replaces the prior 2N+ ListFileBlocks store scans (one
 	// per block in the all-local check + one per block in the download loop,
-	// plus one more inside each inlineFetchOrWait) with a single O(M) scan per
+	// plus one more inside each inlineFetchOrWait) with a single store scan per
 	// read.
 	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
 	if err != nil {

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -112,7 +112,12 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToCaller(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs)
 
-	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0)
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("listFileBlocksSnapshot: %v", err)
+	}
+
+	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
 	if err == nil {
 		t.Fatalf("inlineFetchOrWait returned nil err; want error wrapping %v", errBoomLocalPut)
 	}
@@ -154,6 +159,11 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs)
 
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("listFileBlocksSnapshot: %v", err)
+	}
+
 	// Goroutine A: enters inlineFetchOrWait first, registers the in-flight
 	// entry, and blocks inside local.Put on loc.release.
 	type result struct {
@@ -163,7 +173,7 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 	}
 	chA := make(chan result, 1)
 	go func() {
-		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0)
+		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
 		chA <- result{d, dl, e}
 	}()
 
@@ -179,7 +189,7 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 	// the waiter branch, and blocks on <-existing.done.
 	chB := make(chan result, 1)
 	go func() {
-		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0)
+		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
 		chB <- result{d, dl, e}
 	}()
 

--- a/pkg/block/engine/gcstate.go
+++ b/pkg/block/engine/gcstate.go
@@ -76,8 +76,9 @@ func NewGCState(rootDir, runID string) (*GCState, error) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return nil, fmt.Errorf("gcstate: mkdir %s: %w", runDir, err)
 	}
-	// Drop the incomplete marker. If MarkComplete is never called, the
-	// next CleanStaleGCStateDirs sweep will reclaim this directory.
+	// Create the incomplete marker. MarkComplete removes it on a clean run;
+	// if the run crashes before MarkComplete, the marker survives and the
+	// next CleanStaleGCStateDirs sweep reclaims this directory.
 	if f, err := os.Create(filepath.Join(runDir, gcStateIncompleteFlag)); err != nil {
 		return nil, fmt.Errorf("gcstate: create incomplete flag: %w", err)
 	} else {

--- a/pkg/block/engine/sync_queue.go
+++ b/pkg/block/engine/sync_queue.go
@@ -27,7 +27,8 @@ type SyncQueue struct {
 	wg              gosync.WaitGroup
 	stopCh          chan struct{}
 	stoppedCh       chan struct{}
-	started         bool // tracks whether Start() was called
+	stopOnce        gosync.Once // guards close(stopCh) against concurrent/repeated Stop()
+	started         bool        // tracks whether Start() was called
 
 	// workerCtx is the parent context for per-request contexts created in
 	// processRequest. It is cancelled when stopCh is closed so that in-flight
@@ -113,6 +114,7 @@ func (q *SyncQueue) Start(ctx context.Context) {
 
 // Stop gracefully shuts down the transfer queue.
 // It waits for pending uploads to complete (with timeout).
+// Safe to call multiple times and from concurrent goroutines.
 func (q *SyncQueue) Stop(timeout time.Duration) {
 	q.mu.Lock()
 	if !q.started {
@@ -122,7 +124,11 @@ func (q *SyncQueue) Stop(timeout time.Duration) {
 	q.mu.Unlock()
 
 	logger.Info("Stopping transfer queue", "pending", q.Pending())
-	close(q.stopCh)
+	// sync.Once guards close(stopCh) so concurrent/repeated Stop() calls
+	// cannot double-close the channel (panic). Mirrors HealthMonitor.Stop().
+	q.stopOnce.Do(func() {
+		close(q.stopCh)
+	})
 
 	select {
 	case <-q.stoppedCh:

--- a/pkg/block/engine/sync_queue_test.go
+++ b/pkg/block/engine/sync_queue_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -70,6 +71,32 @@ func TestSyncQueue_DoubleStart(t *testing.T) {
 	q.Start(ctx)
 	q.Start(ctx) // Should be a no-op
 
+	q.Stop(time.Second)
+}
+
+// TestSyncQueue_StopConcurrentAndRepeated asserts that Stop() is safe to call
+// concurrently and more than once: the sync.Once guard around close(stopCh)
+// must prevent a double-close panic. Run under -race.
+func TestSyncQueue_StopConcurrentAndRepeated(t *testing.T) {
+	cfg := DefaultSyncQueueConfig()
+	q := NewSyncQueue(nil, cfg)
+
+	ctx := context.Background()
+	q.Start(ctx)
+
+	const callers = 8
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			q.Stop(time.Second) // must not panic on double-close(stopCh)
+		}()
+	}
+	wg.Wait()
+
+	// A further sequential Stop after all goroutines returned must also be a
+	// no-op rather than panicking.
 	q.Stop(time.Second)
 }
 


### PR DESCRIPTION
Fixes three verified findings in `pkg/block/engine/`.

## Findings & fixes

**1. `fetch.go` — O(N) `ListFileBlocks` scans per read (perf)**
`allBlocksLocal` + `EnsureAvailableAndRead` previously scanned the per-payload
FileBlock rows once per block index (2N O(M) scans for an N-block read, plus
one more inside each `inlineFetchOrWait`). Now a single point-in-time snapshot
is fetched once per read via the new `listFileBlocksSnapshot` and threaded
through `resolveFileBlockFromRows` / `blockIsLocalFromRows` / `inlineFetchOrWait`,
collapsing it to one O(M) scan per read. The snapshot is per-read isolated —
a concurrent writer mutating the block set mid-read is not reflected, which is
acceptable (and arguably more correct) read semantics. Single-block callers
(`fetchBlock`, `enqueuePrefetch`) keep the existing
`resolveFileBlock`/`blockIsLocal` wrappers, which now delegate to the shared
helpers.

**2. `sync_queue.go:116` — `SyncQueue.Stop` double-close panic (concurrency)**
Replaced the `started`-flag-only guard around `close(q.stopCh)` with a
`sync.Once`, matching `HealthMonitor.Stop()`. Concurrent or repeated `Stop()`
can no longer double-close the channel. Added
`TestSyncQueue_StopConcurrentAndRepeated` (8 concurrent + 1 sequential Stop),
green under `-race`.

**3. `gcstate.go:79` — misleading comment (LOW, comment-only)**
The comment said "Drop the incomplete marker" while the code *creates* the
crash-recovery marker. Reworded to describe creating the marker that
`CleanStaleGCStateDirs` reclaims if the run crashes before `MarkComplete`.

## Validation
- `go build ./...` clean
- `go vet ./pkg/block/...` clean
- `go test -race ./pkg/block/engine/...` green
- `go test ./pkg/block/...` green