### PR TITLE
fix: CIFS credentials-file mount (no option injection); single-statement postgres PutFile; skip redundant GetFile in migrate walk

### DIFF
--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -303,31 +303,35 @@ func (a *cliMetadataAdapter) walkDir(ctx context.Context, dirHandle metadata.Fil
 			return fmt.Errorf("list children at %q: %w", prefix, err)
 		}
 		for _, e := range entries {
-			file, err := a.store.GetFile(ctx, e.Handle)
-			if err != nil {
-				return fmt.Errorf("get file %s%s: %w", prefix, e.Name, err)
+			// ListChildren populates e.Attr for performance; use it directly
+			// and fall back to GetFile only when the store left it nil.
+			attr := e.Attr
+			if attr == nil {
+				file, err := a.store.GetFile(ctx, e.Handle)
+				if err != nil {
+					return fmt.Errorf("get file %s%s: %w", prefix, e.Name, err)
+				}
+				attr = &file.FileAttr
 			}
-			if file.Type == metadata.FileTypeDirectory {
+			if attr.Type == metadata.FileTypeDirectory {
 				if err := a.walkDir(ctx, e.Handle, prefix+e.Name+"/", out); err != nil {
 					return err
 				}
 				continue
 			}
-			if file.Type != metadata.FileTypeRegular || file.Size == 0 {
+			if attr.Type != metadata.FileTypeRegular || attr.Size == 0 {
 				continue
 			}
-			if len(file.Blocks) > 0 {
+			if len(attr.Blocks) > 0 {
 				continue
 			}
-			handle, err := metadata.EncodeFileHandle(file)
-			if err != nil {
-				return fmt.Errorf("encode handle for %s%s: %w", prefix, e.Name, err)
-			}
+			// e.Handle is EncodeShareHandle(shareName, id), identical to
+			// EncodeFileHandle(file), so no GetFile/re-encode is needed.
 			*out = append(*out, migrate.LegacyFileInfo{
-				Handle:    handle,
+				Handle:    e.Handle,
 				Path:      prefix + e.Name,
-				PayloadID: file.PayloadID,
-				Size:      int64(file.Size),
+				PayloadID: attr.PayloadID,
+				Size:      int64(attr.Size),
 				BlockSize: block.BlockSize,
 			})
 		}

--- a/cmd/dfsctl/commands/share/mount_unix.go
+++ b/cmd/dfsctl/commands/share/mount_unix.go
@@ -145,6 +145,14 @@ func mountSMBLinux(sharePath, mountPoint string, port int, username, password, s
 	}
 	defer func() { _ = os.Remove(credFile) }()
 
+	// The credentials path itself is interpolated into the comma-delimited -o
+	// string, so a temp dir containing a comma or newline (e.g. an attacker-
+	// controlled TMPDIR) could reintroduce option injection via the filename.
+	// Reject such a path rather than build a corrupt option list.
+	if strings.ContainsAny(credFile, ",\r\n") {
+		return fmt.Errorf("temporary credentials path %q contains a comma or newline; set TMPDIR to a path without those characters", credFile)
+	}
+
 	opts := fmt.Sprintf("vers=2.1,port=%d,credentials=%s", port, credFile)
 
 	// If running as root with SUDO_UID, set uid/gid so files are owned by original user

--- a/cmd/dfsctl/commands/share/mount_unix.go
+++ b/cmd/dfsctl/commands/share/mount_unix.go
@@ -143,7 +143,7 @@ func mountSMBLinux(sharePath, mountPoint string, port int, username, password, s
 	if err != nil {
 		return err
 	}
-	defer os.Remove(credFile)
+	defer func() { _ = os.Remove(credFile) }()
 
 	opts := fmt.Sprintf("vers=2.1,port=%d,credentials=%s", port, credFile)
 
@@ -193,19 +193,19 @@ func writeCIFSCredentials(username, password string) (string, error) {
 	// Restrict to owner read/write before writing any secret. CreateTemp already
 	// uses 0600, but set it explicitly so the guarantee does not depend on umask.
 	if err := f.Chmod(0o600); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+		_ = f.Close()
+		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to secure credentials file: %w", err)
 	}
 
 	contents := fmt.Sprintf("username=%s\npassword=%s\n", username, password)
 	if _, err := f.WriteString(contents); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+		_ = f.Close()
+		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to write credentials file: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
+		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to write credentials file: %w", err)
 	}
 	return f.Name(), nil

--- a/cmd/dfsctl/commands/share/mount_unix.go
+++ b/cmd/dfsctl/commands/share/mount_unix.go
@@ -133,7 +133,19 @@ func mountSMB(sharePath, mountPoint string, adapters []apiclient.Adapter, server
 }
 
 func mountSMBLinux(sharePath, mountPoint string, port int, username, password, serverHost string) error {
-	opts := fmt.Sprintf("vers=2.1,port=%d,username=%s,password=%s", port, username, password)
+	// Credentials are written to a private temp file passed via the documented
+	// CIFS "credentials=" option rather than placed inline in the comma-delimited
+	// -o string. mount.cifs splits -o on commas, so a username or password that
+	// contains a comma, newline, or '=' would otherwise corrupt the option list
+	// or smuggle in arbitrary mount options (credential/option injection). The
+	// credentials file is created 0600 and removed after the mount completes.
+	credFile, err := writeCIFSCredentials(username, password)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(credFile)
+
+	opts := fmt.Sprintf("vers=2.1,port=%d,credentials=%s", port, credFile)
 
 	// If running as root with SUDO_UID, set uid/gid so files are owned by original user
 	if os.Geteuid() == 0 {
@@ -160,6 +172,43 @@ func mountSMBLinux(sharePath, mountPoint string, port int, username, password, s
 	}
 	fmt.Printf("Mounted %s at %s via SMB (port %d)\n", sharePath, mountPoint, port)
 	return nil
+}
+
+// writeCIFSCredentials writes a mount.cifs credentials file (username/password
+// on separate lines) to a securely-created 0600 temp file and returns its path.
+// The caller is responsible for removing the file. A username or password
+// containing a newline is rejected: the credentials file format is line-based,
+// so an embedded newline could inject a "domain=" line or otherwise corrupt the
+// file. Commas and '=' are safe inside the file (only the -o option string
+// splits on them), so they need no escaping here.
+func writeCIFSCredentials(username, password string) (string, error) {
+	if strings.ContainsAny(username, "\r\n") || strings.ContainsAny(password, "\r\n") {
+		return "", fmt.Errorf("SMB username/password must not contain newline characters")
+	}
+
+	f, err := os.CreateTemp("", "dfsctl-cifs-creds-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create credentials file: %w", err)
+	}
+	// Restrict to owner read/write before writing any secret. CreateTemp already
+	// uses 0600, but set it explicitly so the guarantee does not depend on umask.
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to secure credentials file: %w", err)
+	}
+
+	contents := fmt.Sprintf("username=%s\npassword=%s\n", username, password)
+	if _, err := f.WriteString(contents); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to write credentials file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to write credentials file: %w", err)
+	}
+	return f.Name(), nil
 }
 
 func mountSMBDarwin(sharePath, mountPoint string, port int, username, password, serverHost string) error {

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -204,7 +204,22 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// recycle (Move into #recycle) followed by recreating the original name would
 	// then fail "already exists" on postgres only (#190). path_hash is maintained
 	// by the files_path_hash_trigger, so updating path refreshes it.
+	//
+	// The leading CTE reads the pre-update size under FOR UPDATE and the UPDATE
+	// joins against it, so a single round-trip both locks the row and returns
+	// its old size for usedBytes delta tracking. This replaces a separate
+	// SELECT-then-UPDATE that left a serialization window between the two
+	// statements (the read size could be stale by the time the UPDATE ran).
+	// RETURNING old.size yields exactly one row when the file existed and zero
+	// rows when it did not — the same not-found signal the previous
+	// RowsAffected()==0 check relied on.
 	updateQuery := `
+		WITH old AS (
+			SELECT id, share_name, size
+			FROM files
+			WHERE id = $22 AND share_name = $23
+			FOR UPDATE
+		)
 		UPDATE files SET
 			path = $1,
 			file_type = $2,
@@ -227,7 +242,9 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			deleted_at = $19,
 			original_path = $20,
 			deleted_by = $21
-		WHERE id = $22 AND share_name = $23
+		FROM old
+		WHERE files.id = old.id AND files.share_name = old.share_name
+		RETURNING old.size
 	`
 
 	var deviceMajor, deviceMinor *int32
@@ -289,26 +306,14 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		deletedAtArg = &n
 	}
 
-	// Query old size for delta tracking (only for regular files).
-	var oldSize uint64
-	if file.Type == metadata.FileTypeRegular {
-		var oldSizeVal sql.NullInt64
-		// Only ErrNoRows (no prior row -> oldSize stays 0) is benign. A real
-		// error (connection drop, timeout) must abort, otherwise oldSize is
-		// silently treated as 0 and the usedBytes delta is computed wrong.
-		if scanErr := tx.tx.QueryRow(ctx,
-			`SELECT size FROM files WHERE id = $1 AND share_name = $2 AND file_type = $3`,
-			file.ID, file.ShareName, int(metadata.FileTypeRegular),
-		).Scan(&oldSizeVal); scanErr != nil && !errors.Is(scanErr, pgx.ErrNoRows) {
-			return mapPgError(scanErr, "PutFile", "read old size")
-		}
-		if oldSizeVal.Valid {
-			oldSize = uint64(oldSizeVal.Int64)
-		}
-	}
-
-	// Try UPDATE first (most common case for existing files)
-	result, err := tx.tx.Exec(ctx, updateQuery,
+	// Try UPDATE first (most common case for existing files). The CTE locks the
+	// row and RETURNING old.size hands back the pre-update size in the same
+	// round-trip, so there is no separate SELECT and no window between read and
+	// write. A returned row means the file existed (and we have its old size);
+	// pgx.ErrNoRows means it did not, so we fall through to INSERT.
+	var oldSizeVal sql.NullInt64
+	updated := true
+	scanErr := tx.tx.QueryRow(ctx, updateQuery,
 		file.Path,
 		file.Type, file.Mode, file.UID, file.GID, file.Size,
 		timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
@@ -317,22 +322,29 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		file.Hidden, aclJSON, easJSON, objectIDArg,
 		deletedAtArg, file.OriginalPath, file.DeletedBy,
 		file.ID, file.ShareName,
-	)
-	if err != nil {
-		return mapPgError(err, "PutFile", "")
+	).Scan(&oldSizeVal)
+	switch {
+	case scanErr == nil:
+		// Row existed and was updated; oldSizeVal holds the pre-update size.
+	case errors.Is(scanErr, pgx.ErrNoRows):
+		updated = false
+	default:
+		return mapPgError(scanErr, "PutFile", "")
 	}
 
-	// Track size delta for regular files after successful update/insert.
+	// Track size delta for regular files after a successful update.
 	// Accumulated on the tx and applied once after a successful commit so a
 	// serialization/deadlock retry never double-counts.
-	if file.Type == metadata.FileTypeRegular {
-		if result.RowsAffected() > 0 {
-			tx.pendingDelta += int64(file.Size) - int64(oldSize)
+	if updated && file.Type == metadata.FileTypeRegular {
+		var oldSize uint64
+		if oldSizeVal.Valid {
+			oldSize = uint64(oldSizeVal.Int64)
 		}
+		tx.pendingDelta += int64(file.Size) - int64(oldSize)
 	}
 
 	// If no rows were updated, the file doesn't exist - do an INSERT
-	if result.RowsAffected() == 0 {
+	if !updated {
 		insertQuery := `
 			INSERT INTO files (
 				id, share_name, path, file_type, mode, uid, gid, size,
@@ -345,7 +357,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			)
 		`
 
-		_, err = tx.tx.Exec(ctx, insertQuery,
+		if _, err := tx.tx.Exec(ctx, insertQuery,
 			file.ID, file.ShareName, file.Path,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
 			timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
@@ -353,8 +365,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
-		)
-		if err != nil {
+		); err != nil {
 			return mapPgError(err, "PutFile", "")
 		}
 


### PR DESCRIPTION
Fixes three verified audit findings across distinct files.

## 1. SECURITY (MED) — `cmd/dfsctl/commands/share/mount_unix.go`
`mountSMBLinux` inlined the SMB username/password into the comma-delimited `mount.cifs -o` options string. `mount.cifs` splits `-o` on commas, so a credential containing a comma, newline, or `=` could corrupt the option list or inject arbitrary mount options (option/credential injection).

**Fix:** write the credentials to a securely-created `0600` temp file and pass it via the documented `mount.cifs -o credentials=<file>` mechanism. The file is removed after the mount (deferred, so it is cleaned up on failure too). Newline-bearing username/password are rejected since the credentials-file format is line-based; commas and `=` are safe inside the file and need no escaping.

## 2. PERF (MED) — `pkg/metadata/store/postgres/transaction.go`
`PutFile` issued a separate `SELECT size` before every `UPDATE` on the hot WRITE path (an extra round-trip and a serialization window between the read and the write).

**Fix:** fold the read into the UPDATE with a `FOR UPDATE` CTE that returns the old size atomically:
```sql
WITH old AS (SELECT id, share_name, size FROM files WHERE id=$22 AND share_name=$23 FOR UPDATE)
UPDATE files SET ... FROM old WHERE files.id=old.id AND files.share_name=old.share_name RETURNING old.size
```
Return semantics are preserved: a returned row means the file existed (with its old size for the usedBytes delta); `pgx.ErrNoRows` means not-found and falls through to INSERT, exactly as the previous `RowsAffected()==0` check. The usedBytes delta is still applied only for regular files.

## 3. LOW — `cmd/dfs/commands/migrate_to_cas.go`
`walkDir` did an N+1 `GetFile` per directory entry even though `ListChildren` already populates `DirEntry.Attr`.

**Fix:** use `e.Attr` (`Type`/`Size`/`Blocks`/`PayloadID`) directly and the entry handle (`EncodeShareHandle(shareName, id)`, byte-identical to `EncodeFileHandle(file)`); fall back to `GetFile` only when `Attr` is nil.

## Validation
- `go build ./...`, `go vet ./cmd/... ./pkg/metadata/store/postgres/...` — clean
- `go test ./cmd/... ./pkg/metadata/store/postgres/...` — pass
- Postgres integration build (`-tags integration`) compiles; the pg conformance lane (create→grow→truncate→delete usedBytes deltas) validates finding #2 in CI.