### PR TITLE
perf(metadata): single-pass ACL eval; reuse handle in case-insensitive lookup; fix flushLocks leak; decode handle once

### DIFF
--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -271,6 +271,95 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	return (allowedBits & requestedMask) == requestedMask
 }
 
+// EvaluateGranted computes, in a SINGLE pass over the DACL, the subset of
+// probeMask that the requester is granted. It is the multi-bit analog of
+// Evaluate: where Evaluate answers "are ALL bits in mask allowed?" (and must
+// be called once per probed bit to discover a granted subset), EvaluateGranted
+// answers "which of these bits are allowed?" and walks the ACE list only once.
+//
+// The result is bit-identical to probing each set bit of probeMask through
+// Evaluate individually and OR-ing the ones that return true. This holds
+// because Evaluate's allow/deny accumulation is per-bit-independent —
+// first-match-wins applies separately to each bit position via
+// `ace.AccessMask &^ (allowedBits | deniedBits)` — and the OWNER_RIGHTS
+// pre-scan and MS-DTYP §2.5.3.2 owner-implicit grant likewise act per-bit.
+// Early termination in Evaluate only short-circuits once a decision is reached
+// and never alters the final allow/deny outcome for any bit.
+//
+// Returns 0 immediately for an empty probeMask or a nil ACL (matching
+// Evaluate's "nil ACL grants nothing" contract). NullDACL grants every probed
+// bit.
+func EvaluateGranted(a *ACL, evalCtx *EvaluateContext, probeMask uint32) uint32 {
+	// Empty probe or nil ACL grants nothing (matches Evaluate's nil-ACL contract).
+	if probeMask == 0 || a == nil {
+		return 0
+	}
+	if a.NullDACL {
+		return probeMask
+	}
+
+	requesterIsOwner := evalCtx.UID == evalCtx.FileOwnerUID
+	var ownerRightsPresent bool
+	if requesterIsOwner {
+		for i := range a.ACEs {
+			ace := &a.ACEs[i]
+			if ace.IsInheritOnly() {
+				continue
+			}
+			if ace.Who != SpecialOwnerRights {
+				continue
+			}
+			if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE &&
+				ace.Type != ACE4_ACCESS_DENIED_ACE_TYPE {
+				continue
+			}
+			ownerRightsPresent = true
+			break
+		}
+	}
+
+	var allowedBits uint32
+	var deniedBits uint32
+
+	for i := range a.ACEs {
+		ace := &a.ACEs[i]
+
+		if ace.IsInheritOnly() {
+			continue
+		}
+		if !aceMatchesWhoWithOwnerRights(ace, evalCtx, ownerRightsPresent) {
+			continue
+		}
+
+		switch ace.Type {
+		case ACE4_ACCESS_ALLOWED_ACE_TYPE:
+			newBits := ace.AccessMask &^ (allowedBits | deniedBits)
+			allowedBits |= newBits
+
+		case ACE4_ACCESS_DENIED_ACE_TYPE:
+			newBits := ace.AccessMask &^ (allowedBits | deniedBits)
+			deniedBits |= newBits
+
+		case ACE4_SYSTEM_AUDIT_ACE_TYPE, ACE4_SYSTEM_ALARM_ACE_TYPE:
+			continue
+		}
+
+		// Early termination: every probed bit has been decided either way.
+		if (allowedBits|deniedBits)&probeMask == probeMask {
+			break
+		}
+	}
+
+	if requesterIsOwner && !ownerRightsPresent {
+		allowedBits |= ownerImplicitRights &^ deniedBits
+		if evalCtx.RequesterHasTakeOwnership {
+			allowedBits |= takeOwnershipImplicitRight &^ deniedBits
+		}
+	}
+
+	return allowedBits & probeMask
+}
+
 // aceMatchesWhoWithOwnerRights checks if an ACE applies to the given
 // evaluation context. When ownerRightsPresent is true AND the requester is the
 // file owner, OWNER@ ACEs are made to not-match and OWNER_RIGHTS ACEs are

--- a/pkg/metadata/acl/evaluate_granted_test.go
+++ b/pkg/metadata/acl/evaluate_granted_test.go
@@ -1,0 +1,160 @@
+package acl
+
+import "testing"
+
+// evaluateGrantedReference probes each set bit of probeMask through Evaluate
+// individually and ORs the granted bits — the exact behavior EvaluateGranted
+// replaces in a single pass. Used as the oracle for the equivalence tests.
+func evaluateGrantedReference(a *ACL, evalCtx *EvaluateContext, probeMask uint32) uint32 {
+	var granted uint32
+	for bit := uint32(1); bit != 0; bit <<= 1 {
+		if probeMask&bit == 0 {
+			continue
+		}
+		if Evaluate(a, evalCtx, bit) {
+			granted |= bit
+		}
+	}
+	return granted
+}
+
+// TestEvaluateGranted_MatchesPerBitProbe asserts EvaluateGranted is
+// bit-identical to the per-bit Evaluate loop it replaces, across a matrix of
+// ACL shapes and requester contexts. This guards the single-pass MAXIMUM_ALLOWED
+// / MxAc optimization in pkg/metadata/auth_permissions.go.
+func TestEvaluateGranted_MatchesPerBitProbe(t *testing.T) {
+	const fullProbe = ACE4_READ_DATA | ACE4_WRITE_DATA | ACE4_APPEND_DATA |
+		ACE4_READ_NAMED_ATTRS | ACE4_WRITE_NAMED_ATTRS | ACE4_EXECUTE |
+		ACE4_DELETE_CHILD | ACE4_READ_ATTRIBUTES | ACE4_WRITE_ATTRIBUTES |
+		ACE4_DELETE | ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER |
+		ACE4_SYNCHRONIZE
+
+	admin := func(c *EvaluateContext) *EvaluateContext {
+		c.RequesterHasTakeOwnership = true
+		return c
+	}
+
+	acls := []struct {
+		name string
+		acl  *ACL
+	}{
+		{
+			name: "allow-everyone-read-exec",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_EXECUTE, Who: SpecialEveryone},
+			}},
+		},
+		{
+			name: "deny-before-allow",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA, Who: SpecialEveryone},
+			}},
+		},
+		{
+			name: "owner-only",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA, Who: SpecialOwner},
+			}},
+		},
+		{
+			name: "group-allow",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialGroup},
+			}},
+		},
+		{
+			name: "owner-rights-override",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwnerRights},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullProbe, Who: SpecialOwner},
+			}},
+		},
+		{
+			name: "audit-alarm-noise",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+				{Type: ACE4_SYSTEM_ALARM_ACE_TYPE, AccessMask: ACE4_DELETE, Who: SpecialEveryone},
+			}},
+		},
+		{
+			name: "empty-dacl",
+			acl:  &ACL{ACEs: []ACE{}},
+		},
+		{
+			name: "null-dacl",
+			acl:  &ACL{NullDACL: true},
+		},
+		{
+			name: "inherit-only-skipped",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: fullProbe, Who: SpecialEveryone, Flag: ACE4_INHERIT_ONLY_ACE},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+			}},
+		},
+		{
+			name: "complex-mixed",
+			acl: &ACL{ACEs: []ACE{
+				{Type: ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: ACE4_DELETE, Who: SpecialEveryone},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA | ACE4_WRITE_DATA, Who: SpecialOwner},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialGroup},
+				{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_EXECUTE, Who: SpecialEveryone},
+			}},
+		},
+	}
+
+	ctxs := []struct {
+		name string
+		ctx  *EvaluateContext
+	}{
+		{"owner", ownerCtx()},
+		{"owner-admin", admin(ownerCtx())},
+		{"non-owner", nonOwnerCtx()},
+		{"group-member", groupMemberCtx()},
+	}
+
+	masks := []uint32{
+		fullProbe,
+		ACE4_READ_DATA | ACE4_WRITE_DATA,
+		ACE4_READ_ACL | ACE4_WRITE_ACL | ACE4_WRITE_OWNER,
+		ACE4_DELETE,
+		0,
+	}
+
+	for _, ac := range acls {
+		for _, cc := range ctxs {
+			for _, mask := range masks {
+				want := evaluateGrantedReference(ac.acl, cc.ctx, mask)
+				got := EvaluateGranted(ac.acl, cc.ctx, mask)
+				if got != want {
+					t.Errorf("acl=%s ctx=%s mask=%#x: EvaluateGranted=%#x, per-bit oracle=%#x",
+						ac.name, cc.name, mask, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestEvaluateGranted_NilACL(t *testing.T) {
+	if got := EvaluateGranted(nil, ownerCtx(), ACE4_READ_DATA); got != 0 {
+		t.Errorf("nil ACL: want 0, got %#x", got)
+	}
+}
+
+func TestEvaluateGranted_ZeroMask(t *testing.T) {
+	a := &ACL{ACEs: []ACE{
+		{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialEveryone},
+	}}
+	if got := EvaluateGranted(a, ownerCtx(), 0); got != 0 {
+		t.Errorf("zero mask: want 0, got %#x", got)
+	}
+}
+
+func TestEvaluateGranted_NullDACLGrantsProbe(t *testing.T) {
+	a := &ACL{NullDACL: true}
+	mask := uint32(ACE4_READ_DATA | ACE4_WRITE_DATA)
+	if got := EvaluateGranted(a, nonOwnerCtx(), mask); got != mask {
+		t.Errorf("null DACL: want %#x, got %#x", mask, got)
+	}
+}

--- a/pkg/metadata/acl/probe.go
+++ b/pkg/metadata/acl/probe.go
@@ -33,3 +33,14 @@ var ProbeBitsAll = [...]uint32{
 	ACE4_WRITE_OWNER,
 	ACE4_SYNCHRONIZE,
 }
+
+// ProbeMaskAll is the OR of every bit in ProbeBitsAll — the single-call
+// probeMask for EvaluateGranted when computing the full effective-rights set
+// (MAXIMUM_ALLOWED / MxAc). Kept in sync with ProbeBitsAll via package init.
+var ProbeMaskAll = func() uint32 {
+	var m uint32
+	for _, b := range ProbeBitsAll {
+		m |= b
+	}
+	return m
+}()

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -793,22 +793,13 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 		return explicit, nil
 	}
 
-	// DACL-present path: per-bit acl.Evaluate.
+	// DACL-present path: single-pass acl.EvaluateGranted. It accumulates the
+	// per-bit allow/deny decisions across the whole DACL in one walk and
+	// returns the granted subset of `explicit` — bit-identical to probing each
+	// requested bit through acl.Evaluate individually, without conflating
+	// per-bit DENY semantics.
 	evalCtx := buildFileAccessEvalContext(file, authCtx)
-	var granted uint32
-	// Per-bit probe: acl.Evaluate(mask, …) returns true only when ALL bits in
-	// mask are allowed, so we must probe each requested bit individually —
-	// anything else conflates per-bit DENY semantics.
-	probe := explicit
-	for bit := uint32(1); bit != 0 && probe != 0; bit <<= 1 {
-		if probe&bit == 0 {
-			continue
-		}
-		if acl.Evaluate(file.ACL, evalCtx, bit) {
-			granted |= bit
-		}
-		probe &^= bit
-	}
+	granted := acl.EvaluateGranted(file.ACL, evalCtx, explicit)
 
 	// MS-FSA §2.1.4.13 "Algorithm to Check Access to an Existing File":
 	// FILE_READ_ATTRIBUTES is always granted from the containing directory
@@ -845,12 +836,9 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 		// bits the requester is allowed (independent of what they asked for,
 		// minus the MAXIMUM_ALLOWED bit itself). Mirrors computeMaximalAccess
 		// so the handle's effective access matches the MxAc reply.
-		var effective uint32
-		for _, bit := range acl.ProbeBitsAll {
-			if acl.Evaluate(file.ACL, evalCtx, bit) {
-				effective |= bit
-			}
-		}
+		// Single-pass effective-rights computation over the same evalCtx,
+		// equivalent to probing each acl.ProbeBitsAll bit through acl.Evaluate.
+		effective := acl.EvaluateGranted(file.ACL, evalCtx, acl.ProbeMaskAll)
 		// Apply parent FILE_DELETE_CHILD override to the MAXIMUM_ALLOWED
 		// effective-rights set too so the open's GrantedAccess (which the
 		// caller propagates into Open.GrantedAccess and surfaces via MxAc)
@@ -953,19 +941,13 @@ func (s *Service) ComputeMaximalAccess(file *File, authCtx *AuthContext) uint32 
 			return accessMaskPosixGenericAll
 		}
 		evalCtx := buildFileAccessEvalContext(file, authCtx)
-		var granted uint32
-		// acl.ProbeBitsAll is the shared probe set (mirrors the MAXIMUM_ALLOWED
-		// branch of CheckFileAccessWithParentGeneric). ExpandGenericMask is
-		// applied defensively so any future additions carrying GENERIC_* bits
-		// are normalized per MS-DTYP §2.5.3 before evaluation.
-		for _, bit := range acl.ProbeBitsAll {
-			probe := acl.ExpandGenericMask(bit)
-			if acl.Evaluate(file.ACL, evalCtx, probe) {
-				granted |= probe
-			}
-		}
-		// Result also expanded for defense-in-depth: per MS-DTYP §2.5.3 the
-		// MaximalAccess reply must contain only resolved rights.
+		// Single-pass probe over acl.ProbeMaskAll (the OR of acl.ProbeBitsAll),
+		// mirroring the MAXIMUM_ALLOWED branch of
+		// CheckFileAccessWithParentGeneric. ProbeBitsAll contains only specific
+		// rights, so the previous per-bit ExpandGenericMask was a no-op; the
+		// result is still expanded defensively per MS-DTYP §2.5.3 so the
+		// MaximalAccess reply contains only resolved rights.
+		granted := acl.EvaluateGranted(file.ACL, evalCtx, acl.ProbeMaskAll)
 		return acl.ExpandGenericMask(granted)
 	}
 

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -142,6 +142,23 @@ func (s *Service) LookupCaseInsensitive(ctx *AuthContext, dirHandle FileHandle, 
 		}
 		for _, entry := range entries {
 			if equalFoldName(entry.Name, name) {
+				// Fast path: stores populate entry.Handle (DirEntry.Handle is
+				// MUST-populate). The initial exact-case s.Lookup above already
+				// validated the directory and execute/traverse permission, so a
+				// second s.Lookup would redundantly re-run GetFile(dir) + type
+				// check + permission check + GetChild. Fetch the matched file
+				// directly from its handle instead.
+				if len(entry.Handle) != 0 {
+					match, matchErr := store.GetFile(ctx.Context, entry.Handle)
+					if matchErr != nil {
+						if IsNotFoundError(matchErr) {
+							continue
+						}
+						return nil, "", matchErr
+					}
+					return match, entry.Name, nil
+				}
+				// Fallback for stores that leave Handle empty: full Lookup.
 				match, matchErr := s.Lookup(ctx, dirHandle, entry.Name)
 				if matchErr != nil {
 					if IsNotFoundError(matchErr) {

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -75,8 +75,14 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 		return nil, err
 	}
 
-	// Resolve the store once for use throughout this method.
-	store, err := s.storeForHandle(handle)
+	// Decode the handle once and reuse the share name for both the store
+	// lookup and the quota check below (avoids a second UUID parse on this
+	// write hot path).
+	shareName, _, err := DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	store, err := s.GetStoreForShare(shareName)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +128,6 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 	// quota until the next check catches up. Hard atomic enforcement would require
 	// kernel-level integration which is impractical for userspace NFS/SMB servers.
 	// Truncate (shrink) and zero-byte writes are always allowed.
-	shareName := shareNameForHandle(handle)
 	quotaBytes := s.GetQuotaForShare(shareName)
 	if quotaBytes > 0 && newSize > file.Size {
 		currentUsed := store.GetUsedBytes()

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -214,13 +214,25 @@ func (t *PendingWritesTracker) PopAllPending() []PendingEntry {
 	defer t.mu.Unlock()
 
 	result := make([]PendingEntry, 0, len(t.pending))
+	keys := make([]string, 0, len(t.pending))
 	for key, state := range t.pending {
 		result = append(result, PendingEntry{
 			Handle: FileHandle(key),
 			State:  state,
 		})
+		keys = append(keys, key)
 	}
 	t.pending = make(map[string]*PendingWriteState)
+
+	// Clean up the per-file flush locks for the popped entries to prevent
+	// unbounded growth of flushLocks (mirrors PopPending). Lock ordering is
+	// t.mu -> t.flushMu, consistent with PopPending, so no deadlock.
+	t.flushMu.Lock()
+	for _, key := range keys {
+		delete(t.flushLocks, key)
+	}
+	t.flushMu.Unlock()
+
 	return result
 }
 

--- a/pkg/metadata/pending_writes_test.go
+++ b/pkg/metadata/pending_writes_test.go
@@ -1,0 +1,73 @@
+package metadata
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestPopAllPending_CleansFlushLocks asserts PopAllPending removes the per-file
+// flush locks for every popped entry, so flushLocks does not grow unbounded
+// across repeated record/pop cycles (mirrors the cleanup in PopPending).
+func TestPopAllPending_CleansFlushLocks(t *testing.T) {
+	tr := NewPendingWritesTracker()
+
+	const rounds = 50
+	const perRound = 20
+
+	for r := 0; r < rounds; r++ {
+		for i := 0; i < perRound; i++ {
+			h := FileHandle(fmt.Appendf(nil, "share:%d-%d", r, i))
+			// GetFlushLock populates flushLocks (as the real flush path does),
+			// and RecordWrite populates pending.
+			tr.GetFlushLock(h)
+			tr.RecordWrite(h, &WriteOperation{Handle: h, NewSize: uint64(i + 1)}, false)
+		}
+
+		popped := tr.PopAllPending()
+		if len(popped) != perRound {
+			t.Fatalf("round %d: PopAllPending returned %d entries, want %d", r, len(popped), perRound)
+		}
+
+		tr.flushMu.Lock()
+		n := len(tr.flushLocks)
+		tr.flushMu.Unlock()
+		if n != 0 {
+			t.Fatalf("round %d: flushLocks has %d entries after PopAllPending, want 0", r, n)
+		}
+	}
+
+	if c := tr.Count(); c != 0 {
+		t.Fatalf("pending count = %d after all rounds, want 0", c)
+	}
+}
+
+// TestPopAllPending_ReturnsAllEntries asserts the pop still surfaces every
+// recorded entry with its state intact.
+func TestPopAllPending_ReturnsAllEntries(t *testing.T) {
+	tr := NewPendingWritesTracker()
+
+	want := map[string]uint64{}
+	for i := 0; i < 8; i++ {
+		key := fmt.Sprintf("share:f%d", i)
+		h := FileHandle(key)
+		tr.RecordWrite(h, &WriteOperation{Handle: h, NewSize: uint64(100 + i)}, false)
+		want[key] = uint64(100 + i)
+	}
+
+	popped := tr.PopAllPending()
+	if len(popped) != len(want) {
+		t.Fatalf("popped %d entries, want %d", len(popped), len(want))
+	}
+	for _, e := range popped {
+		k := string(e.Handle)
+		if e.State == nil {
+			t.Fatalf("entry %q has nil state", k)
+		}
+		if e.State.MaxSize != want[k] {
+			t.Errorf("entry %q MaxSize=%d, want %d", k, e.State.MaxSize, want[k])
+		}
+	}
+	if c := tr.Count(); c != 0 {
+		t.Fatalf("pending count = %d after pop, want 0", c)
+	}
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -560,7 +560,14 @@ func (s *Service) lockManagerForHandle(handle FileHandle) (*LockManager, error) 
 	if err != nil {
 		return nil, err
 	}
+	return s.lockManagerForShare(shareName)
+}
 
+// lockManagerForShare returns the lock manager for an already-decoded share
+// name. Splitting this out of lockManagerForHandle lets callers that have
+// already decoded the handle (see storeAndLockManagerForHandle) avoid a second
+// UUID parse.
+func (s *Service) lockManagerForShare(shareName string) (*LockManager, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -571,6 +578,29 @@ func (s *Service) lockManagerForHandle(handle FileHandle) (*LockManager, error) 
 	// Decoded handle names a share with no lock manager (removed share):
 	// stale-handle StoreError so callers map to *STALE.
 	return nil, NewStaleHandleError(shareName)
+}
+
+// storeAndLockManagerForHandle resolves both the metadata store and the lock
+// manager for a handle with a SINGLE DecodeFileHandle call. The store and
+// lock-manager handlers (LockFile, UnlockFile, TestLock, …) need both, and
+// calling storeForHandle + lockManagerForHandle separately parsed the same
+// handle's UUID twice per operation. The share name is decoded once here and
+// reused for both share-keyed lookups. Handle opacity is preserved: callers
+// still pass an opaque FileHandle and never see the decoded components.
+func (s *Service) storeAndLockManagerForHandle(handle FileHandle) (Store, *LockManager, error) {
+	shareName, _, err := DecodeFileHandle(handle)
+	if err != nil {
+		return nil, nil, err
+	}
+	store, err := s.GetStoreForShare(shareName)
+	if err != nil {
+		return nil, nil, err
+	}
+	lm, err := s.lockManagerForShare(shareName)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, lm, nil
 }
 
 // GetLockManagerForHandle returns the lock manager for the share that owns
@@ -754,7 +784,12 @@ func (s *Service) GetQuotaForShare(shareName string) int64 {
 // When a quota is configured for the share, the returned TotalBytes and
 // AvailableBytes are overlaid with quota-adjusted values.
 func (s *Service) GetFilesystemStatistics(ctx context.Context, handle FileHandle) (*FilesystemStatistics, error) {
-	store, err := s.storeForHandle(handle)
+	// Decode once: the share name is reused for the quota overlay below.
+	shareName, _, err := DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	store, err := s.GetStoreForShare(shareName)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +799,6 @@ func (s *Service) GetFilesystemStatistics(ctx context.Context, handle FileHandle
 	}
 
 	// Apply quota overlay if configured
-	shareName := shareNameForHandle(handle)
 	quotaBytes := s.GetQuotaForShare(shareName)
 	if quotaBytes > 0 {
 		quota := uint64(quotaBytes)
@@ -822,12 +856,7 @@ func (s *Service) LockFile(ctx *AuthContext, handle FileHandle, lock FileLock) e
 		return err
 	}
 
-	store, err := s.storeForHandle(handle)
-	if err != nil {
-		return err
-	}
-
-	lm, err := s.lockManagerForHandle(handle)
+	store, lm, err := s.storeAndLockManagerForHandle(handle)
 	if err != nil {
 		return err
 	}
@@ -877,12 +906,7 @@ func (s *Service) UnlockFile(ctx context.Context, handle FileHandle, openID stri
 		return err
 	}
 
-	store, err := s.storeForHandle(handle)
-	if err != nil {
-		return err
-	}
-
-	lm, err := s.lockManagerForHandle(handle)
+	store, lm, err := s.storeAndLockManagerForHandle(handle)
 	if err != nil {
 		return err
 	}
@@ -944,12 +968,7 @@ func (s *Service) TestLock(ctx *AuthContext, handle FileHandle, sessionID, offse
 		return false, nil, err
 	}
 
-	store, err := s.storeForHandle(handle)
-	if err != nil {
-		return false, nil, err
-	}
-
-	lm, err := s.lockManagerForHandle(handle)
+	store, lm, err := s.storeAndLockManagerForHandle(handle)
 	if err != nil {
 		return false, nil, err
 	}
@@ -977,12 +996,7 @@ func (s *Service) ListLocks(ctx *AuthContext, handle FileHandle) ([]FileLock, er
 		return nil, err
 	}
 
-	store, err := s.storeForHandle(handle)
-	if err != nil {
-		return nil, err
-	}
-
-	lm, err := s.lockManagerForHandle(handle)
+	store, lm, err := s.storeAndLockManagerForHandle(handle)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Perf/correctness fixes in the metadata core (`pkg/metadata/`, top-level + `acl/`). All changes are behavior-preserving.

## Findings addressed

### 1. Single-pass ACL evaluation (`auth_permissions.go`, `acl/`)
`CheckFileAccessWithParentGeneric` (MAXIMUM_ALLOWED + MxAc path) and `ComputeMaximalAccess` called `acl.Evaluate` once per probed bit — up to 28 full DACL walks per open. Added `acl.EvaluateGranted(a, evalCtx, probeMask)` which accumulates per-bit allow/deny across the whole DACL in **one** walk and returns the granted subset. Both 14-probe loops and the `ComputeMaximalAccess` loop now call it once over a shared `evalCtx`.

- Result is **bit-identical** to per-bit probing: `Evaluate`'s allow/deny accumulation, the OWNER_RIGHTS pre-scan, and the MS-DTYP §2.5.3.2 owner-implicit grant are all per-bit-independent.
- Added `acl.ProbeMaskAll` (OR of `ProbeBitsAll`) for the full-rights single call.
- New `acl/evaluate_granted_test.go` proves equivalence against a per-bit oracle across a matrix of ACL shapes (allow/deny/owner/group/owner-rights/audit/null/inherit-only/mixed) × requester contexts × masks.

### 2. Reuse handle in case-insensitive lookup (`file_modify.go`)
On a case-fold match, `LookupCaseInsensitive` re-ran a full `s.Lookup` (GetFile(dir) + type check + permission check + GetChild) even though `DirEntry.Handle` was already populated. Now fetches the matched file directly via `store.GetFile(entry.Handle)` (saving 2 store round-trips/match); the initial exact-case `s.Lookup` already validated the directory and traverse permission. Falls back to `s.Lookup` when `Handle` is empty.

### 3. flushLocks leak in `PopAllPending` (`pending_writes.go`)
`PopAllPending` cleared `t.pending` but never removed the corresponding `flushLocks` entries → unbounded map growth. Now collects the popped keys and deletes them from `flushLocks` under `t.flushMu`, mirroring `PopPending` and its lock ordering (`t.mu` → `t.flushMu`). New `pending_writes_test.go` asserts `flushLocks` stays at 0 across repeated record/pop rounds.

### 4. Decode file handle once (`service.go`, `io.go`)
The lock ops (`LockFile`/`UnlockFile`/`TestLock`/`ListLocks`) parsed the handle UUID twice (`storeForHandle` + `lockManagerForHandle`). Added `storeAndLockManagerForHandle` (single `DecodeFileHandle`, then share-keyed lookups via the new `lockManagerForShare`). `PrepareWrite` (write hot path) and `GetFilesystemStatistics` decode once and reuse the share name for the quota lookup. Handle opacity is preserved — callers still pass opaque handles.

## Validation
- `go build ./...`, `go vet ./pkg/metadata/...`, `gofmt` clean
- `go test ./pkg/metadata/...` (incl. storetest conformance, memory/badger/postgres) green
- `go test -race` green on the new tests