### PR TITLE
fix(nfs/v4): EXCLUSIVE4 verifier idempotency; apply UNCHECKED4 createAttrs to existing file

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -317,7 +317,16 @@ func (h *Handler) handleOpenClaimNull(
 				// the file's idempotency token at create time. Match -> treat as
 				// a successful (idempotent) open returning a fresh stateid;
 				// mismatch -> NFS4ERR_EXIST.
-				if child.IdempotencyToken != *createVerifier {
+				//
+				// A zero stored token is the default for files NOT created via an
+				// exclusive create (UNCHECKED4 / GUARDED4 / NFSv3 non-exclusive),
+				// so it must never be accepted as an idempotent match — otherwise
+				// a stray verifier==0 exclusive OPEN would silently re-open any
+				// such file instead of returning NFS4ERR_EXIST. Real clients pick
+				// a non-zero (random/clock-based) verifier, so requiring a
+				// non-zero token here loses only the pathological zero-verifier
+				// retry while closing the false-match hole.
+				if *createVerifier == 0 || child.IdempotencyToken != *createVerifier {
 					logger.Debug("NFSv4 OPEN EXCLUSIVE verifier mismatch on existing file",
 						"file", filename,
 						"client", ctx.ClientAddr)
@@ -361,6 +370,18 @@ func (h *Handler) handleOpenClaimNull(
 			// EXCLUSIVE4_1 retry must not re-mutate the existing file, so this
 			// is gated to UNCHECKED4.
 			if createMode == types.UNCHECKED4 && createAttrs != nil {
+				// A size change is a write to the file. Mirror the SETATTR
+				// gating (RFC 7530 §5.11): a size-bearing createattrs on an
+				// open that does not carry WRITE access is rejected with
+				// NFS4ERR_OPENMODE, so a read-only OPEN cannot truncate the
+				// file even when POSIX permissions would otherwise allow it.
+				if createAttrs.Size != nil && shareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+					logger.Debug("NFSv4 OPEN UNCHECKED4 rejected: size change on read-only open",
+						"file", filename,
+						"share_access", shareAccess,
+						"client", ctx.ClientAddr)
+					return openError(types.NFS4ERR_OPENMODE)
+				}
 				// child was fetched via Lookup above and still reflects the full
 				// pre-truncate extent, so it is the pre-op snapshot the reclaim
 				// needs. Shared with the SETATTR path.

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -112,6 +113,10 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 
 	var createMode uint32
 	var createAttrs *metadata.SetAttrs
+	// createVerifier carries the 8-byte EXCLUSIVE4/EXCLUSIVE4_1 createverf4 as a
+	// uint64. Non-nil only for exclusive-create modes; it drives RFC 7530
+	// §16.16.3 idempotent-retry detection in the CLAIM_NULL path.
+	var createVerifier *uint64
 
 	if openType == types.OPEN4_CREATE {
 		// Decode createhow4: createmode (uint32)
@@ -132,17 +137,21 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 			}
 			createAttrs = setAttrs
 		case types.EXCLUSIVE4:
-			// Decode verifier (8 bytes) -- treat as GUARDED4
-			var verifier [8]byte
-			if _, err := io.ReadFull(reader, verifier[:]); err != nil {
+			// EXCLUSIVE4 (RFC 7530 §16.16.3): createverf4 (8 bytes). The
+			// verifier is preserved so a retransmitted exclusive create with
+			// the same verifier is idempotent, while a different verifier on an
+			// existing file yields NFS4ERR_EXIST. Stored via FileAttr's
+			// idempotency token (same mechanism as NFSv3 CREATE EXCLUSIVE).
+			verifier, vErr := decodeVerifier(reader)
+			if vErr != nil {
 				return openError(types.NFS4ERR_BADXDR)
 			}
-			createMode = types.GUARDED4
+			createVerifier = &verifier
 		case types.EXCLUSIVE4_1:
 			// NFSv4.1 exclusive create (RFC 8881 Section 18.16.3):
 			// createverf4 (8 bytes) + cattr (fattr4)
-			var verifier [8]byte
-			if _, err := io.ReadFull(reader, verifier[:]); err != nil {
+			verifier, vErr := decodeVerifier(reader)
+			if vErr != nil {
 				return openError(types.NFS4ERR_BADXDR)
 			}
 			setAttrs, _, fattr4Err := attrs.DecodeFattr4ToSetAttrs(reader)
@@ -153,7 +162,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 				return openError(types.NFS4ERR_BADXDR)
 			}
 			createAttrs = setAttrs
-			createMode = types.GUARDED4
+			createVerifier = &verifier
 		default:
 			return openError(types.NFS4ERR_INVAL)
 		}
@@ -179,7 +188,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 		}
 
 		return h.handleOpenClaimNull(ctx, reader, seqid, shareAccess, shareDeny,
-			clientID, ownerData, openType, createMode, claimType, createAttrs)
+			clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier)
 
 	case types.CLAIM_PREVIOUS:
 		return h.handleOpenClaimPrevious(ctx, reader, seqid, shareAccess, shareDeny,
@@ -210,6 +219,7 @@ func (h *Handler) handleOpenClaimNull(
 	clientID uint64, ownerData []byte,
 	openType, createMode, claimType uint32,
 	createAttrs *metadata.SetAttrs,
+	createVerifier *uint64,
 ) *types.CompoundResult {
 	// CLAIM_NULL: decode filename (component4 = XDR string)
 	filename, err := xdr.DecodeString(reader)
@@ -298,11 +308,26 @@ func (h *Handler) handleOpenClaimNull(
 		// OPEN4_CREATE: create or open existing
 		child, lookupErr := metaSvc.Lookup(authCtx, parentHandle, filename)
 		if lookupErr == nil {
-			// File exists
-			if createMode == types.GUARDED4 {
+			// File exists.
+			switch {
+			case createVerifier != nil:
+				// EXCLUSIVE4 / EXCLUSIVE4_1 (RFC 7530 §16.16.3): a retransmitted
+				// exclusive create is idempotent iff it presents the same
+				// verifier that created the file. The verifier is persisted in
+				// the file's idempotency token at create time. Match -> treat as
+				// a successful (idempotent) open returning a fresh stateid;
+				// mismatch -> NFS4ERR_EXIST.
+				if child.IdempotencyToken != *createVerifier {
+					logger.Debug("NFSv4 OPEN EXCLUSIVE verifier mismatch on existing file",
+						"file", filename,
+						"client", ctx.ClientAddr)
+					return openError(types.NFS4ERR_EXIST)
+				}
+				// Verifier matches: fall through to open the existing file.
+			case createMode == types.GUARDED4:
 				return openError(types.NFS4ERR_EXIST)
 			}
-			// UNCHECKED4: open existing -- no error
+
 			fh, encErr := metadata.EncodeFileHandle(child)
 			if encErr != nil {
 				return openError(types.NFS4ERR_SERVERFAULT)
@@ -325,18 +350,43 @@ func (h *Handler) handleOpenClaimNull(
 					"client", ctx.ClientAddr)
 				return openError(types.NFS4ERR_DELAY)
 			}
+
+			// UNCHECKED4 on an existing file applies the supplied createattrs
+			// (RFC 7530 §16.16: "the existing file is opened ... and the
+			// attributes specified are set"). Only the attributes the client
+			// actually sent are applied (the createAttrs bitmap), so e.g.
+			// size=0 truncates while unset attributes are left untouched.
+			// SetFileAttributes enforces its own permission checks. Exclusive
+			// creates do not carry settable createattrs in EXCLUSIVE4, and an
+			// EXCLUSIVE4_1 retry must not re-mutate the existing file, so this
+			// is gated to UNCHECKED4.
+			if createMode == types.UNCHECKED4 && createAttrs != nil {
+				// child was fetched via Lookup above and still reflects the full
+				// pre-truncate extent, so it is the pre-op snapshot the reclaim
+				// needs. Shared with the SETATTR path.
+				if setErr := h.applySetAttrsWithTruncateReclaim(ctx, metaSvc, authCtx, fileHandle, child, createAttrs); setErr != nil {
+					return openError(common.MapToNFS4(setErr))
+				}
+			}
 		} else {
-			// File doesn't exist: create it
+			// File doesn't exist: create it.
 			uid, gid := effectiveUIDGID(authCtx)
 			fileMode := uint32(0o644) // Default mode
 			if createAttrs != nil && createAttrs.Mode != nil {
 				fileMode = *createAttrs.Mode
 			}
-			newFile, _, createErr := metaSvc.CreateFile(authCtx, parentHandle, filename, &metadata.FileAttr{
+			newAttr := &metadata.FileAttr{
 				Mode: fileMode,
 				UID:  uid,
 				GID:  gid,
-			})
+			}
+			// Persist the exclusive-create verifier so a later retransmission
+			// with the same verifier is recognised as an idempotent retry
+			// (RFC 7530 §16.16.3). Same mechanism as NFSv3 CREATE EXCLUSIVE.
+			if createVerifier != nil {
+				newAttr.IdempotencyToken = *createVerifier
+			}
+			newFile, _, createErr := metaSvc.CreateFile(authCtx, parentHandle, filename, newAttr)
 			if createErr != nil {
 				return openError(common.MapToNFS4(createErr))
 			}
@@ -714,6 +764,19 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	// No delegation grant (client already has one)
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
 		beforeCtime, beforeCtime, nil)
+}
+
+// decodeVerifier reads an 8-byte createverf4 and returns it as a uint64
+// (big-endian), matching the NFSv3 CREATE EXCLUSIVE verifier representation so
+// both protocols store and compare the verifier identically via FileAttr's
+// idempotency token. The verifier is opaque per RFC 7530 §16.16.3; the only
+// requirement is that the same wire bytes round-trip to the same value.
+func decodeVerifier(reader io.Reader) (uint64, error) {
+	var verifier [8]byte
+	if _, err := io.ReadFull(reader, verifier[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(verifier[:]), nil
 }
 
 // openError builds an OPEN error result for the given NFS4 status code.

--- a/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
@@ -130,6 +130,63 @@ func TestOpen_Exclusive4_RetryDifferentVerifier(t *testing.T) {
 	}
 }
 
+// TestOpen_Exclusive4_ZeroVerifierOnExistingFileConflicts verifies that an
+// EXCLUSIVE4 OPEN carrying an all-zero verifier does NOT false-match a
+// pre-existing non-exclusive file (whose idempotency token defaults to 0): it
+// must return NFS4ERR_EXIST rather than being mistaken for an idempotent retry.
+func TestOpen_Exclusive4_ZeroVerifierOnExistingFileConflicts(t *testing.T) {
+	const clientID = uint64(0xABCD)
+	owner := []byte("zero-verf-owner")
+
+	fx := newIOTestFixture(t, "/export")
+	ctx := newRealFSContext(0, 0)
+
+	// Pre-create a file via a normal (non-exclusive) path -> token stays 0.
+	fx.createRegularFile(t, fx.rootHandle, "plain.txt", 0o644, 0, 0)
+
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+	args := encodeOpenExclusiveArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE, clientID, owner, 0, "plain.txt")
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status != types.NFS4ERR_EXIST {
+		t.Fatalf("EXCLUSIVE4 zero-verifier on existing non-exclusive file status = %d, want NFS4ERR_EXIST", r.Status)
+	}
+}
+
+// TestOpen_Unchecked4_SizeOnReadOnlyOpenRejected verifies that an UNCHECKED4
+// OPEN that requests a size change (truncate) but does not carry WRITE access
+// is rejected with NFS4ERR_OPENMODE, mirroring the SETATTR size-change gating.
+func TestOpen_Unchecked4_SizeOnReadOnlyOpenRejected(t *testing.T) {
+	const clientID = uint64(0x5151)
+	owner := []byte("ro-trunc-owner")
+
+	fx := newIOTestFixture(t, "/export")
+	ctx := newRealFSContext(0, 0)
+
+	fh := fx.createRegularFile(t, fx.rootHandle, "ro.txt", 0o644, 0, 0)
+	fx.writeContent(t, fh, []byte("some content"))
+
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+	// READ-only open requesting size=0.
+	args := encodeOpenUncheckedSizeArgs(1, types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE, clientID, owner, 0, "ro.txt")
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status != types.NFS4ERR_OPENMODE {
+		t.Fatalf("UNCHECKED4 size change on read-only open status = %d, want NFS4ERR_OPENMODE", r.Status)
+	}
+
+	// The file must NOT have been truncated.
+	post, err := fx.metaSvc.GetFile(context.Background(), fh)
+	if err != nil {
+		t.Fatalf("get file: %v", err)
+	}
+	if post.Size == 0 {
+		t.Fatalf("file was truncated despite read-only open rejection")
+	}
+}
+
 // TestOpen_Unchecked4_ExistingFileTruncates verifies RFC 7530 §16.16: an
 // UNCHECKED4 OPEN of an existing file applies the supplied createattrs. A
 // requested size=0 must truncate the file's metadata size to zero.

--- a/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// encodeOpenExclusiveArgs builds OPEN4args for an EXCLUSIVE4 create with the
+// given 8-byte verifier (big-endian encoding of verf).
+func encodeOpenExclusiveArgs(
+	seqid, shareAccess, shareDeny uint32,
+	clientID uint64, owner []byte, verf uint64, filename string,
+) []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, seqid)
+	_ = xdr.WriteUint32(&buf, shareAccess)
+	_ = xdr.WriteUint32(&buf, shareDeny)
+	_ = xdr.WriteUint64(&buf, clientID)
+	_ = xdr.WriteXDROpaque(&buf, owner)
+	_ = xdr.WriteUint32(&buf, types.OPEN4_CREATE)
+	_ = xdr.WriteUint32(&buf, types.EXCLUSIVE4)
+	var verifier [8]byte
+	binary.BigEndian.PutUint64(verifier[:], verf)
+	buf.Write(verifier[:])
+	_ = xdr.WriteUint32(&buf, types.CLAIM_NULL)
+	_ = xdr.WriteXDRString(&buf, filename)
+	return buf.Bytes()
+}
+
+// encodeOpenUncheckedSizeArgs builds OPEN4args for an UNCHECKED4 create whose
+// createattrs request the given file size (FATTR4_SIZE).
+func encodeOpenUncheckedSizeArgs(
+	seqid, shareAccess, shareDeny uint32,
+	clientID uint64, owner []byte, size uint64, filename string,
+) []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, seqid)
+	_ = xdr.WriteUint32(&buf, shareAccess)
+	_ = xdr.WriteUint32(&buf, shareDeny)
+	_ = xdr.WriteUint64(&buf, clientID)
+	_ = xdr.WriteXDROpaque(&buf, owner)
+	_ = xdr.WriteUint32(&buf, types.OPEN4_CREATE)
+	_ = xdr.WriteUint32(&buf, types.UNCHECKED4)
+
+	// createattrs (fattr4 = bitmap4 + opaque attr_vals) requesting size.
+	var attrVals bytes.Buffer
+	_ = xdr.WriteUint64(&attrVals, size)
+	var bitmap []uint32
+	attrs.SetBit(&bitmap, attrs.FATTR4_SIZE)
+	_ = attrs.EncodeBitmap4(&buf, bitmap)
+	_ = xdr.WriteXDROpaque(&buf, attrVals.Bytes())
+
+	_ = xdr.WriteUint32(&buf, types.CLAIM_NULL)
+	_ = xdr.WriteXDRString(&buf, filename)
+	return buf.Bytes()
+}
+
+// TestOpen_Exclusive4_RetrySameVerifier verifies RFC 7530 §16.16.3 idempotency:
+// an EXCLUSIVE4 create followed by a retransmission with the SAME verifier must
+// succeed (the create is idempotent), returning a valid stateid rather than
+// NFS4ERR_EXIST.
+func TestOpen_Exclusive4_RetrySameVerifier(t *testing.T) {
+	const clientID = uint64(0xCAFE)
+	owner := []byte("excl-owner")
+	const verf = uint64(0x0123456789abcdef)
+
+	fx := newIOTestFixture(t, "/export")
+	ctx := newRealFSContext(0, 0)
+
+	open := func() *types.CompoundResult {
+		ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+		copy(ctx.CurrentFH, fx.rootHandle)
+		args := encodeOpenExclusiveArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE, clientID, owner, verf, "excl.txt")
+		return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	}
+
+	r1 := open()
+	if r1.Status != types.NFS4_OK {
+		t.Fatalf("first EXCLUSIVE4 OPEN status = %d, want NFS4_OK", r1.Status)
+	}
+
+	// Retransmission with the same verifier: must be idempotent success.
+	r2 := open()
+	if r2.Status != types.NFS4_OK {
+		t.Fatalf("EXCLUSIVE4 retry (same verifier) status = %d, want NFS4_OK", r2.Status)
+	}
+
+	// The reply must carry a decodable stateid.
+	rd := bytes.NewReader(r2.Data)
+	if _, err := xdr.DecodeUint32(rd); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if _, err := types.DecodeStateid4(rd); err != nil {
+		t.Fatalf("EXCLUSIVE4 retry reply missing valid stateid: %v", err)
+	}
+}
+
+// TestOpen_Exclusive4_RetryDifferentVerifier verifies that an EXCLUSIVE4 create
+// retransmitted with a DIFFERENT verifier (i.e. a genuine conflict on an
+// already-existing file) returns NFS4ERR_EXIST.
+func TestOpen_Exclusive4_RetryDifferentVerifier(t *testing.T) {
+	const clientID = uint64(0xBEEF)
+	owner := []byte("excl-owner2")
+
+	fx := newIOTestFixture(t, "/export")
+	ctx := newRealFSContext(0, 0)
+
+	open := func(verf uint64) *types.CompoundResult {
+		ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+		copy(ctx.CurrentFH, fx.rootHandle)
+		args := encodeOpenExclusiveArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE, clientID, owner, verf, "excl2.txt")
+		return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	}
+
+	if r := open(0x1111111111111111); r.Status != types.NFS4_OK {
+		t.Fatalf("first EXCLUSIVE4 OPEN status = %d, want NFS4_OK", r.Status)
+	}
+
+	if r := open(0x2222222222222222); r.Status != types.NFS4ERR_EXIST {
+		t.Fatalf("EXCLUSIVE4 with different verifier status = %d, want NFS4ERR_EXIST", r.Status)
+	}
+}
+
+// TestOpen_Unchecked4_ExistingFileTruncates verifies RFC 7530 §16.16: an
+// UNCHECKED4 OPEN of an existing file applies the supplied createattrs. A
+// requested size=0 must truncate the file's metadata size to zero.
+func TestOpen_Unchecked4_ExistingFileTruncates(t *testing.T) {
+	const clientID = uint64(0xF00D)
+	owner := []byte("unchecked-owner")
+
+	fx := newIOTestFixture(t, "/export")
+	ctx := newRealFSContext(0, 0)
+
+	// Create a file and give it some content/size.
+	fh := fx.createRegularFile(t, fx.rootHandle, "trunc.txt", 0o644, 0, 0)
+	fx.writeContent(t, fh, []byte("hello world contents"))
+
+	pre, err := fx.metaSvc.GetFile(context.Background(), fh)
+	if err != nil {
+		t.Fatalf("get file pre: %v", err)
+	}
+	if pre.Size == 0 {
+		t.Fatalf("setup: expected non-zero size before truncate")
+	}
+
+	// UNCHECKED4 OPEN of the existing file requesting size=0.
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+	args := encodeOpenUncheckedSizeArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE, clientID, owner, 0, "trunc.txt")
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status != types.NFS4_OK {
+		t.Fatalf("UNCHECKED4 OPEN existing status = %d, want NFS4_OK", r.Status)
+	}
+
+	post, err := fx.metaSvc.GetFile(context.Background(), metadata.FileHandle(ctx.CurrentFH))
+	if err != nil {
+		t.Fatalf("get file post: %v", err)
+	}
+	if post.Size != 0 {
+		t.Fatalf("file size after UNCHECKED4 size=0 = %d, want 0 (truncation skipped)", post.Size)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -168,28 +168,16 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
-	// 7a. On a size-down, capture the file's PRE-truncate FileAttr.Blocks so
-	// the block store can reap RefCount on dropped chunks after the metadata
-	// write (#832). Fetched BEFORE SetFileAttributes prunes FileAttr.Blocks.
-	// preTruncateBlocks stays nil unless this is a genuine shrink, so the
-	// reclaim below is skipped for grows / no-ops.
-	var (
-		preTruncateBlocks []block.BlockRef
-		preTruncatePID    metadata.PayloadID
-		newSize           uint64
-	)
+	// 7. Apply attributes via MetadataService (all-or-nothing semantics), then
+	// reclaim block-store space on a size-down truncation (#832). See
+	// applySetAttrsWithTruncateReclaim for the pre-blocks-snapshot ordering.
+	// The pre-op file is only needed when the size changes (the reclaim is a
+	// no-op otherwise), so skip the extra read for mode/owner/time-only SETATTRs.
+	var preFile *metadata.File
 	if setAttrs.Size != nil {
-		if cur, getErr := metaSvc.GetFile(ctx.Context, metadata.FileHandle(ctx.CurrentFH)); getErr == nil && cur != nil {
-			if *setAttrs.Size < cur.Size && cur.PayloadID != "" {
-				preTruncateBlocks = cur.Blocks
-				preTruncatePID = cur.PayloadID
-				newSize = *setAttrs.Size
-			}
-		}
+		preFile, _ = metaSvc.GetFile(ctx.Context, metadata.FileHandle(ctx.CurrentFH))
 	}
-
-	// 7. Apply attributes via MetadataService (all-or-nothing semantics)
-	if _, err := metaSvc.SetFileAttributes(authCtx, metadata.FileHandle(ctx.CurrentFH), setAttrs); err != nil {
+	if err := h.applySetAttrsWithTruncateReclaim(ctx, metaSvc, authCtx, metadata.FileHandle(ctx.CurrentFH), preFile, setAttrs); err != nil {
 		nfsStatus := common.MapToNFS4(err)
 		logger.Debug("NFSv4 SETATTR failed",
 			"error", err,
@@ -202,23 +190,6 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 			Status: nfsStatus,
 			OpCode: types.OP_SETATTR,
 			Data:   encodeSetAttrError(nfsStatus),
-		}
-	}
-
-	// 7b. Reclaim block-store space on size-down truncation. Mirror the v3
-	// SETATTR / CREATE-with-truncate path: drive blockStore.Truncate with the
-	// pre-truncate FileAttr.Blocks snapshot so the engine reaps RefCount on
-	// every dropped block and the GC sweep can reclaim the remote chunks
-	// (#832). Best-effort: a failure is logged but does not fail the
-	// already-committed metadata update. Handler coordinates metaSvc +
-	// blockStore exactly as the WRITE path does (invariants #1/#5).
-	if preTruncateBlocks != nil {
-		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH)); bsErr != nil {
-			logger.Warn("NFSv4 SETATTR: cannot resolve block store for truncate reclaim",
-				"handle", string(ctx.CurrentFH), "error", bsErr)
-		} else if _, tErr := blockStore.Truncate(ctx.Context, string(preTruncatePID), preTruncateBlocks, newSize); tErr != nil {
-			logger.Warn("NFSv4 SETATTR: block store truncate reclaim failed",
-				"handle", string(ctx.CurrentFH), "size", newSize, "error", tErr)
 		}
 	}
 
@@ -247,6 +218,57 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		OpCode: types.OP_SETATTR,
 		Data:   encodeSetAttrSuccess(requestedBitmap),
 	}
+}
+
+// applySetAttrsWithTruncateReclaim applies attrs to the file via
+// MetadataService.SetFileAttributes and, on a size-down truncation, reclaims
+// the block-store space of the dropped tail. preFile is the file as observed
+// BEFORE the metadata write (so its FileAttr.Blocks still describes the full
+// pre-truncate extent); it may be nil when unavailable, in which case the
+// reclaim is skipped. The block-store Truncate is best-effort: the metadata
+// write is authoritative and already committed, so a reclaim failure is logged
+// but not surfaced as an error. This mirrors the v3 SETATTR / CREATE-truncate
+// path and keeps the handler coordinating metaSvc + blockStore per CLAUDE.md
+// invariants #1/#5. Used by both SETATTR and OPEN(UNCHECKED4) on an existing
+// file.
+func (h *Handler) applySetAttrsWithTruncateReclaim(
+	ctx *types.CompoundContext,
+	metaSvc *metadata.Service,
+	authCtx *metadata.AuthContext,
+	handle metadata.FileHandle,
+	preFile *metadata.File,
+	attrs *metadata.SetAttrs,
+) error {
+	// Capture the pre-truncate FileAttr.Blocks snapshot BEFORE SetFileAttributes
+	// prunes them, so the engine reaps RefCount on every dropped block (#832).
+	// Stays nil unless this is a genuine shrink, so reclaim is skipped for
+	// grows / no-ops.
+	var (
+		preTruncateBlocks []block.BlockRef
+		preTruncatePID    metadata.PayloadID
+		newSize           uint64
+	)
+	if attrs.Size != nil && preFile != nil &&
+		*attrs.Size < preFile.Size && preFile.PayloadID != "" {
+		preTruncateBlocks = preFile.Blocks
+		preTruncatePID = preFile.PayloadID
+		newSize = *attrs.Size
+	}
+
+	if _, err := metaSvc.SetFileAttributes(authCtx, handle, attrs); err != nil {
+		return err
+	}
+
+	if preTruncateBlocks != nil {
+		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, handle); bsErr != nil {
+			logger.Warn("NFSv4 truncate reclaim: cannot resolve block store",
+				"handle", string(handle), "error", bsErr)
+		} else if _, tErr := blockStore.Truncate(ctx.Context, string(preTruncatePID), preTruncateBlocks, newSize); tErr != nil {
+			logger.Warn("NFSv4 truncate reclaim: block store truncate failed",
+				"handle", string(handle), "size", newSize, "error", tErr)
+		}
+	}
+	return nil
 }
 
 // isSignificantAttrChange returns true if the attribute bitmap contains


### PR DESCRIPTION
## Findings (internal/adapter/nfs/v4/handlers/open.go)

Two HIGH correctness findings in the NFSv4 OPEN handler.

### 1. EXCLUSIVE4 verifier idempotency (HIGH)
`open.go` mapped both `EXCLUSIVE4` and `EXCLUSIVE4_1` create modes to `GUARDED4` and decoded-then-discarded the 8-byte `createverf4`. This breaks RFC 7530 §16.16.3 exclusive-create idempotency: a client retransmitting an EXCLUSIVE OPEN after a network drop got `NFS4ERR_EXIST` instead of success, even when presenting the same verifier.

**Fix:** decode the verifier as a `uint64` (big-endian, matching the NFSv3 representation) and persist it in `FileAttr.IdempotencyToken` at create time — the same durable mechanism NFSv3 `CREATE EXCLUSIVE` already uses, which round-trips across all metadata backends (memory/badger/postgres) with no schema change. On an OPEN4_CREATE where the file already exists:
- verifier matches the stored token → idempotent success (opens the existing file, returns a fresh stateid);
- verifier differs → `NFS4ERR_EXIST`.

EXCLUSIVE4_1 retries do not re-mutate the existing file's attributes.

### 2. UNCHECKED4 ignores createAttrs on existing file (HIGH)
`open.go` UNCHECKED4 on an existing file opened it but ignored the supplied `createattrs`, so a requested `size=0` truncation was silently skipped.

**Fix:** after opening the existing file under UNCHECKED4, apply the decoded `createAttrs` (the bitmap the client actually sent) via `metaSvc.SetFileAttributes` — which enforces its own permission checks — and reclaim block-store space on a size-down. Only attributes present in the createAttrs bitmap are applied; unset attributes are untouched.

## Implementation notes
- Handlers stay protocol-only: storage uses the existing `FileAttr.IdempotencyToken` field and `metadata.SetFileAttributes`; no business logic inlined.
- The truncate+block-reclaim logic (`#832` RefCount reaping) was duplicated from the SETATTR path; extracted into a shared `applySetAttrsWithTruncateReclaim` helper used by both SETATTR and OPEN(UNCHECKED4).
- The SETATTR pre-op `GetFile` is now gated to size-changing requests only (avoids an extra read on mode/owner/time-only SETATTRs).

## Limitation
The verifier lives in `IdempotencyToken` and is **not** cleared by a later normal SETATTR — identical to the existing NFSv3 design. This is intentional and RFC-correct: once a file exists, any subsequent exclusive create with a *different* verifier must yield `NFS4ERR_EXIST` (the file exists), and the same-verifier case stays idempotent. The Linux atime/mtime "create verifier" trick was deliberately not used (it would overload timestamp fields and require clearing); reusing `IdempotencyToken` is durable and cleaner.

## Tests (internal/adapter/nfs/v4/handlers/open_exclusive_test.go)
- `TestOpen_Exclusive4_RetrySameVerifier` — create then retry with same verifier → NFS4_OK with a decodable stateid.
- `TestOpen_Exclusive4_RetryDifferentVerifier` — retry with a different verifier → NFS4ERR_EXIST.
- `TestOpen_Unchecked4_ExistingFileTruncates` — UNCHECKED4 on an existing file with size=0 → metadata size truncated to 0.

All `./internal/adapter/nfs/v4/...` and `./pkg/metadata/...` suites pass.