### PR TITLE
perf(lock,smb/lease): reverse indexes for lease/client-lock lookups; raw lease-key map keys

### DIFF
--- a/internal/adapter/smb/handlers/state_debug.go
+++ b/internal/adapter/smb/handlers/state_debug.go
@@ -139,12 +139,12 @@ func (h *Handler) AuditSessionCleanup(sessionID uint64) int {
 
 	// Check leases
 	if h.LeaseManager != nil {
-		h.LeaseManager.RangeLeases(func(leaseKeyHex string, sid uint64, shareName string) bool {
+		h.LeaseManager.RangeLeases(func(leaseKey [16]byte, sid uint64, shareName string) bool {
 			if sid == sessionID {
 				leaked++
 				logger.Warn("LEAKED lease after session cleanup",
 					"sessionID", sessionID,
-					"leaseKey", leaseKeyHex,
+					"leaseKey", fmt.Sprintf("%x", leaseKey),
 					"shareName", shareName,
 				)
 			}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -10,7 +10,6 @@ package lease
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -58,15 +57,19 @@ const handleLeaseBreakWaitTimeout = 5 * time.Second
 // (timeout-disconnect, breaking3, etc.) rely on the shorter bound.
 const TraditionalOplockBreakWaitTimeout = 35 * time.Second
 
-// clientLeaseKey scopes lease-key bindings by (Owner.ClientID, lease-key
-// hex) because lock.Manager allows two distinct clients to each hold a
-// record under the same numeric LeaseKey on different files (per round-3
+// clientLeaseKey scopes lease-key bindings by (Owner.ClientID, lease key)
+// because lock.Manager allows two distinct clients to each hold a record
+// under the same numeric LeaseKey on different files (per round-3
 // `lease_match` scoping). Without this composite key, client B's lease
 // would overwrite client A's break-routing binding in `leaseClientGUID`,
 // or — sticky-on-first — route B's breaks to A's primary session.
+//
+// Key holds the raw 16-byte lease key (not a hex string): it is the map key
+// for every hot-path lease lookup, so using the array directly keeps those
+// paths allocation-free. Hex is computed only for logging.
 type clientLeaseKey struct {
 	ClientID string
-	KeyHex   string
+	Key      [16]byte
 }
 
 // LockManagerResolver resolves the LockManager for a given share name.
@@ -86,8 +89,8 @@ type LockManagerResolver interface {
 type LeaseManager struct {
 	resolver   LockManagerResolver
 	notifier   LeaseBreakNotifier
-	sessionMap map[string]uint64 // hex(leaseKey) -> sessionID
-	leaseShare map[string]string // hex(leaseKey) -> shareName (for resolution)
+	sessionMap map[[16]byte]uint64 // leaseKey -> sessionID
+	leaseShare map[[16]byte]string // leaseKey -> shareName (for resolution)
 	// leaseV2 records whether each lease was granted from an
 	// SMB2_CREATE_REQUEST_LEASE_V2 context. Per MS-SMB2 §2.2.23.2 the
 	// NewEpoch field of a break notification MUST be zero for V1 leases;
@@ -103,8 +106,8 @@ type LeaseManager struct {
 	// version-not-yet-known (mark absent), we track BOTH versions
 	// explicitly via parallel maps; a single bool can't carry the third
 	// state. leaseV1 is true iff first grant was V1.
-	leaseV2 map[string]bool // hex(leaseKey) -> true iff V2-established
-	leaseV1 map[string]bool // hex(leaseKey) -> true iff V1-established
+	leaseV2 map[[16]byte]bool // leaseKey -> true iff V2-established
+	leaseV1 map[[16]byte]bool // leaseKey -> true iff V1-established
 
 	// leaseClientGUID records the ClientGUID that first granted each
 	// (clientID, leaseKey) pair. Per MS-SMB2 §3.3.5.9.8 a lease is bound to
@@ -115,7 +118,7 @@ type LeaseManager struct {
 	// Sticky on FIRST grant: a same-(clientID,key) reopen does NOT change
 	// the recorded GUID.
 	//
-	// Composite-keyed by (clientID, keyHex) because lock.Manager scopes
+	// Composite-keyed by (clientID, leaseKey) because lock.Manager scopes
 	// lease-key uniqueness per Owner.ClientID — two distinct clients may
 	// each hold a record under the same numeric LeaseKey on different
 	// files, and break routing must not collide between them.
@@ -148,10 +151,10 @@ func NewLeaseManager(resolver LockManagerResolver, notifier LeaseBreakNotifier) 
 	return &LeaseManager{
 		resolver:             resolver,
 		notifier:             notifier,
-		sessionMap:           make(map[string]uint64),
-		leaseShare:           make(map[string]string),
-		leaseV2:              make(map[string]bool),
-		leaseV1:              make(map[string]bool),
+		sessionMap:           make(map[[16]byte]uint64),
+		leaseShare:           make(map[[16]byte]string),
+		leaseV2:              make(map[[16]byte]bool),
+		leaseV1:              make(map[[16]byte]bool),
 		leaseClientGUID:      make(map[clientLeaseKey][16]byte),
 		clientPrimarySession: make(map[[16]byte]uint64),
 	}
@@ -280,10 +283,9 @@ func (lm *LeaseManager) requestLeaseInternal(
 	//
 	// Pre-registering is safe: if the grant fails or returns None, we
 	// remove the entry below.
-	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
-	lm.sessionMap[keyHex] = sessionID
-	lm.leaseShare[keyHex] = shareName
+	lm.sessionMap[leaseKey] = sessionID
+	lm.leaseShare[leaseKey] = shareName
 	// Bind the lease to a ClientGUID on FIRST grant (sticky). Cross-client
 	// key reuse is rejected upstream by lease_match (ErrLeaseKeyInUse), so
 	// the only paths that re-enter here on the same key are same-client
@@ -291,7 +293,7 @@ func (lm *LeaseManager) requestLeaseInternal(
 	// callers (legacy paths) leave the binding unset and fall back to the
 	// per-lease sessionMap for break dispatch.
 	if clientGUID != ([16]byte{}) {
-		clk := clientLeaseKey{ClientID: clientID, KeyHex: keyHex}
+		clk := clientLeaseKey{ClientID: clientID, Key: leaseKey}
 		if _, bound := lm.leaseClientGUID[clk]; !bound {
 			lm.leaseClientGUID[clk] = clientGUID
 		}
@@ -337,7 +339,7 @@ func (lm *LeaseManager) requestLeaseInternal(
 		)
 	}
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
-		lm.removeLeaseMapping(keyHex)
+		lm.removeLeaseMapping(leaseKey)
 		return 0, 0, err
 	}
 
@@ -349,7 +351,7 @@ func (lm *LeaseManager) requestLeaseInternal(
 	//     and surfaces ErrLeaseAckNotBreaking (smbtorture breaking5).
 	if grantedState == lock.LeaseStateNone {
 		if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
-			lm.removeLeaseMapping(keyHex)
+			lm.removeLeaseMapping(leaseKey)
 		}
 	}
 
@@ -378,16 +380,14 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	acknowledgedState uint32,
 	epoch uint16,
 ) error {
-	keyHex := hex.EncodeToString(leaseKey[:])
-
 	lm.mu.RLock()
-	shareName := lm.leaseShare[keyHex]
+	shareName := lm.leaseShare[leaseKey]
 	lm.mu.RUnlock()
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		logger.Debug("AcknowledgeLeaseBreak: no lock manager for lease (CLOSE-beat-ack), treating as success",
-			"leaseKey", keyHex)
+			"leaseKey", fmt.Sprintf("%x", leaseKey))
 		return nil
 	}
 
@@ -395,8 +395,8 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	if err != nil {
 		if errors.Is(err, lock.ErrLeaseAckNotFound) {
 			logger.Debug("AcknowledgeLeaseBreak: lease record absent (CLOSE-beat-ack), treating as success",
-				"leaseKey", keyHex)
-			lm.removeLeaseMapping(keyHex)
+				"leaseKey", fmt.Sprintf("%x", leaseKey))
+			lm.removeLeaseMapping(leaseKey)
 			return nil
 		}
 		return err
@@ -412,17 +412,15 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 
 // ReleaseLease delegates to the shared LockManager and removes the session mapping.
 func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
-	keyHex := hex.EncodeToString(leaseKey[:])
-
 	// Resolve the LockManager for this lease's share
 	lm.mu.RLock()
-	shareName := lm.leaseShare[keyHex]
+	shareName := lm.leaseShare[leaseKey]
 	lm.mu.RUnlock()
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		// Already released or no manager
-		lm.removeLeaseMapping(keyHex)
+		lm.removeLeaseMapping(leaseKey)
 		return nil
 	}
 
@@ -431,7 +429,7 @@ func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) err
 		return err
 	}
 
-	lm.removeLeaseMapping(keyHex)
+	lm.removeLeaseMapping(leaseKey)
 	return nil
 }
 
@@ -454,7 +452,7 @@ func (lm *LeaseManager) ReleaseLeaseForHandle(ctx context.Context, fileHandle lo
 	// this key — otherwise a concurrent open on a different file would lose
 	// break-dispatch routing.
 	if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
-		lm.removeLeaseMapping(hex.EncodeToString(leaseKey[:]))
+		lm.removeLeaseMapping(leaseKey)
 	}
 	return nil
 }
@@ -465,15 +463,8 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 	lm.mu.RLock()
 	// Collect all lease keys for this session
 	var keysToRelease [][16]byte
-	for keyHex, sid := range lm.sessionMap {
+	for key, sid := range lm.sessionMap {
 		if sid == sessionID {
-			var key [16]byte
-			if b, err := hex.DecodeString(keyHex); err == nil && len(b) == 16 {
-				copy(key[:], b)
-			} else {
-				logger.Warn("LeaseManager: invalid lease key hex", "keyHex", keyHex, "error", err)
-				continue
-			}
 			keysToRelease = append(keysToRelease, key)
 		}
 	}
@@ -514,7 +505,7 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 			if boundGUID != guid {
 				continue
 			}
-			candidateSID, ok := lm.sessionMap[clk.KeyHex]
+			candidateSID, ok := lm.sessionMap[clk.Key]
 			if !ok || candidateSID == sessionID {
 				continue // skip the released session
 			}
@@ -536,10 +527,8 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 
 // GetLeaseState delegates to the shared LockManager.
 func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	keyHex := hex.EncodeToString(leaseKey[:])
-
 	lm.mu.RLock()
-	shareName := lm.leaseShare[keyHex]
+	shareName := lm.leaseShare[leaseKey]
 	lm.mu.RUnlock()
 
 	lockMgr := lm.resolveLockManager(shareName)
@@ -554,7 +543,7 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	sid, ok := lm.sessionMap[hex.EncodeToString(leaseKey[:])]
+	sid, ok := lm.sessionMap[leaseKey]
 	return sid, ok
 }
 
@@ -581,15 +570,14 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 func (lm *LeaseManager) GetSessionForBreak(leaseKey [16]byte, clientID string) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	keyHex := hex.EncodeToString(leaseKey[:])
 	if clientID != "" {
-		if guid, ok := lm.leaseClientGUID[clientLeaseKey{ClientID: clientID, KeyHex: keyHex}]; ok {
+		if guid, ok := lm.leaseClientGUID[clientLeaseKey{ClientID: clientID, Key: leaseKey}]; ok {
 			if sid, ok := lm.clientPrimarySession[guid]; ok {
 				return sid, true
 			}
 		}
 	}
-	sid, ok := lm.sessionMap[keyHex]
+	sid, ok := lm.sessionMap[leaseKey]
 	return sid, ok
 }
 
@@ -597,10 +585,9 @@ func (lm *LeaseManager) GetSessionForBreak(leaseKey [16]byte, clientID string) (
 // Used during durable handle reconnect to associate the existing lease with
 // the new session for break notification routing.
 func (lm *LeaseManager) UpdateSessionForLease(leaseKey [16]byte, sessionID uint64) {
-	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	lm.sessionMap[keyHex] = sessionID
+	lm.sessionMap[leaseKey] = sessionID
 }
 
 // SetNotifier sets the lease break notifier for sending break notifications.
@@ -1146,10 +1133,8 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 // Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
 // epoch from the RqLs create context.
 func (lm *LeaseManager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) {
-	keyHex := hex.EncodeToString(leaseKey[:])
-
 	lm.mu.RLock()
-	shareName := lm.leaseShare[keyHex]
+	shareName := lm.leaseShare[leaseKey]
 	lm.mu.RUnlock()
 
 	lockMgr := lm.resolveLockManager(shareName)
@@ -1212,14 +1197,15 @@ func (lm *LeaseManager) LeaseCount() int {
 }
 
 // RangeLeases iterates over all tracked leases, calling fn for each.
-// The callback receives (leaseKeyHex, sessionID, shareName).
+// The callback receives (leaseKey, sessionID, shareName); callers that need a
+// hex string for logging format it themselves (fmt.Sprintf("%x", leaseKey)).
 // Return false to stop iteration. Used for state debugging instrumentation.
-func (lm *LeaseManager) RangeLeases(fn func(leaseKeyHex string, sessionID uint64, shareName string) bool) {
+func (lm *LeaseManager) RangeLeases(fn func(leaseKey [16]byte, sessionID uint64, shareName string) bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	for keyHex, sid := range lm.sessionMap {
-		shareName := lm.leaseShare[keyHex]
-		if !fn(keyHex, sid, shareName) {
+	for key, sid := range lm.sessionMap {
+		shareName := lm.leaseShare[key]
+		if !fn(key, sid, shareName) {
 			return
 		}
 	}
@@ -1232,20 +1218,20 @@ func (lm *LeaseManager) RangeLeases(fn func(leaseKeyHex string, sessionID uint64
 // ClientGUID, not by lease key, and other leases of the same client may
 // still need it for break routing. The map is reaped by ReleaseSessionLeases
 // when the corresponding session disappears.
-func (lm *LeaseManager) removeLeaseMapping(keyHex string) {
+func (lm *LeaseManager) removeLeaseMapping(leaseKey [16]byte) {
 	lm.mu.Lock()
-	delete(lm.sessionMap, keyHex)
-	delete(lm.leaseShare, keyHex)
-	delete(lm.leaseV2, keyHex)
-	delete(lm.leaseV1, keyHex)
-	// leaseClientGUID is composite-keyed by (clientID, keyHex). The caller
+	delete(lm.sessionMap, leaseKey)
+	delete(lm.leaseShare, leaseKey)
+	delete(lm.leaseV2, leaseKey)
+	delete(lm.leaseV1, leaseKey)
+	// leaseClientGUID is composite-keyed by (clientID, leaseKey). The caller
 	// of removeLeaseMapping is the cleanup path of RequestLease for a
 	// failed grant; for a bound entry, the matching clientID is whichever
-	// client first bound it. Sweep all entries with this keyHex suffix —
-	// safe because at most one (clientID, keyHex) is ever bound here per
+	// client first bound it. Sweep all entries with this leaseKey —
+	// safe because at most one (clientID, leaseKey) is ever bound here per
 	// client (round-3 same-client cross-file rejection).
 	for clk := range lm.leaseClientGUID {
-		if clk.KeyHex == keyHex {
+		if clk.Key == leaseKey {
 			delete(lm.leaseClientGUID, clk)
 		}
 	}
@@ -1262,16 +1248,15 @@ func (lm *LeaseManager) removeLeaseMapping(keyHex string) {
 // grantedState is non-None, passing isV2 derived from the request's
 // create-context size (V2 = 52 bytes, V1 = 32 bytes).
 func (lm *LeaseManager) MarkLeaseVersionIfUnset(leaseKey [16]byte, isV2 bool) {
-	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	if lm.leaseV1[keyHex] || lm.leaseV2[keyHex] {
+	if lm.leaseV1[leaseKey] || lm.leaseV2[leaseKey] {
 		return
 	}
 	if isV2 {
-		lm.leaseV2[keyHex] = true
+		lm.leaseV2[leaseKey] = true
 	} else {
-		lm.leaseV1[keyHex] = true
+		lm.leaseV1[leaseKey] = true
 	}
 }
 
@@ -1279,10 +1264,9 @@ func (lm *LeaseManager) MarkLeaseVersionIfUnset(leaseKey [16]byte, isV2 bool) {
 // Returns false for V1-established leases AND for unknown keys (safe default:
 // treat as V1 and send NewEpoch = 0 rather than leak a non-zero epoch).
 func (lm *LeaseManager) IsV2(leaseKey [16]byte) bool {
-	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	return lm.leaseV2[keyHex]
+	return lm.leaseV2[leaseKey]
 }
 
 // IsLeaseVersionKnown reports whether the lease's version has been recorded
@@ -1290,10 +1274,9 @@ func (lm *LeaseManager) IsV2(leaseKey [16]byte) bool {
 // fired). Used by the response-encoding path to decide whether to use the
 // established version or fall back to the current request's format.
 func (lm *LeaseManager) IsLeaseVersionKnown(leaseKey [16]byte) bool {
-	keyHex := hex.EncodeToString(leaseKey[:])
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	return lm.leaseV1[keyHex] || lm.leaseV2[keyHex]
+	return lm.leaseV1[leaseKey] || lm.leaseV2[leaseKey]
 }
 
 // resolveLockManager resolves the LockManager for a share name.

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -928,3 +928,74 @@ func TestBreakParentDirLeasesOnDestructiveCreate_PlumbsParentKeySuppression(t *t
 		t.Errorf("ExcludeParentDirLeaseKey = %x, want %x", excludeOwner.ExcludeParentDirLeaseKey, parentKey)
 	}
 }
+
+// TestLeaseKeyRawMapRoundTrip pins the [16]byte map-key change: the session,
+// share, and version maps must round-trip a raw lease key, distinct keys must
+// not collide, and RangeLeases must yield the raw key (not a hex string). This
+// guards the perf change (raw-array keys instead of per-op hex encoding) from
+// regressing lease bookkeeping.
+func TestLeaseKeyRawMapRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+	ctx := context.Background()
+
+	keyA := [16]byte{0x01, 0x02, 0x03}
+	keyB := [16]byte{0x01, 0x02, 0x04} // differs only in last byte
+	const sessA uint64 = 5
+	const sessB uint64 = 6
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("fA"), keyA, [16]byte{},
+		sessA, [16]byte{}, "oA", "cA", "share1", lock.LeaseStateRead, false); err != nil {
+		t.Fatalf("RequestLease A: %v", err)
+	}
+	lm.MarkLeaseVersionIfUnset(keyA, true)
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("fB"), keyB, [16]byte{},
+		sessB, [16]byte{}, "oB", "cB", "share1", lock.LeaseStateRead, false); err != nil {
+		t.Fatalf("RequestLease B: %v", err)
+	}
+	lm.MarkLeaseVersionIfUnset(keyB, false)
+
+	// Distinct keys must not collide across any map.
+	if sid, ok := lm.GetSessionForLease(keyA); !ok || sid != sessA {
+		t.Errorf("session(keyA) = %d ok=%v, want %d", sid, ok, sessA)
+	}
+	if sid, ok := lm.GetSessionForLease(keyB); !ok || sid != sessB {
+		t.Errorf("session(keyB) = %d ok=%v, want %d", sid, ok, sessB)
+	}
+	if !lm.IsV2(keyA) {
+		t.Errorf("keyA should be V2")
+	}
+	if lm.IsV2(keyB) {
+		t.Errorf("keyB should be V1")
+	}
+
+	// RangeLeases yields raw keys; collect and verify both are present.
+	seen := map[[16]byte]uint64{}
+	lm.RangeLeases(func(k [16]byte, sid uint64, _ string) bool {
+		seen[k] = sid
+		return true
+	})
+	if seen[keyA] != sessA {
+		t.Errorf("RangeLeases keyA session = %d, want %d", seen[keyA], sessA)
+	}
+	if seen[keyB] != sessB {
+		t.Errorf("RangeLeases keyB session = %d, want %d", seen[keyB], sessB)
+	}
+
+	// Release A; B must remain intact (no cross-key wipe).
+	if err := lm.ReleaseLease(ctx, keyA); err != nil {
+		t.Fatalf("ReleaseLease A: %v", err)
+	}
+	if _, ok := lm.GetSessionForLease(keyA); ok {
+		t.Errorf("keyA session mapping should be gone after release")
+	}
+	if sid, ok := lm.GetSessionForLease(keyB); !ok || sid != sessB {
+		t.Errorf("keyB session mapping must survive A's release: %d ok=%v", sid, ok)
+	}
+	if !lm.IsLeaseVersionKnown(keyB) {
+		t.Errorf("keyB version mark must survive A's release")
+	}
+}

--- a/pkg/metadata/lock/indexes.go
+++ b/pkg/metadata/lock/indexes.go
@@ -1,0 +1,111 @@
+// Reverse indexes over unifiedLocks for O(1)/bounded lookups on hot paths.
+//
+// Two indexes are maintained:
+//
+//   - leaseKeyIndex: leaseKey [16]byte -> handleKey. Lets findLeaseByKey
+//     resolve a lease in O(1) instead of scanning every (handleKey, lock)
+//     pair in unifiedLocks. A lease key resolves to whichever handleKey bucket
+//     most recently added a record for it; reindexHandleLocked rebinds it from
+//     the live slice on every mutation, so the binding never drifts.
+//
+//   - clientHandleIndex: clientID -> set of handleKeys that hold at least one
+//     lock owned by that client (reference-counted per bucket). Lets
+//     RemoveClientLocks touch only the buckets a client actually appears in
+//     instead of scanning the whole map under the global mutex.
+//
+// Both indexes are DERIVED state: every mutation site updates the live
+// unifiedLocks slice and then calls reindexHandleLocked(handleKey, old) with
+// the pre-mutation slice. reindexHandleLocked removes every old contribution
+// and re-adds every current one, so the index is always reconstructed from the
+// authoritative slice and can never silently drift. All index access requires
+// lm.mu (write for mutation, read or write for lookup).
+package lock
+
+// ensureIndexes lazily initializes the reverse-index maps. The index maps are
+// created on first use so existing constructors (and any test doubles building
+// a Manager literal) keep working without an explicit init.
+//
+// Must be called with lm.mu held for writing.
+func (lm *Manager) ensureIndexes() {
+	if lm.leaseKeyIndex == nil {
+		lm.leaseKeyIndex = make(map[[16]byte]string)
+	}
+	if lm.clientHandleIndex == nil {
+		lm.clientHandleIndex = make(map[string]map[string]int)
+	}
+}
+
+// indexAddLockLocked records a single lock's contributions to the reverse
+// indexes for handleKey. Must hold lm.mu for writing.
+func (lm *Manager) indexAddLockLocked(handleKey string, l *UnifiedLock) {
+	if l == nil {
+		return
+	}
+	lm.ensureIndexes()
+
+	if l.Lease != nil {
+		// Last add for a given key wins the bucket binding. findLeaseByKey
+		// previously returned the first (handleKey, lock) match while scanning
+		// non-deterministic map iteration order; binding to whichever bucket
+		// most recently added the key is equally valid and is reconciled from
+		// the live slice on every reindex.
+		lm.leaseKeyIndex[l.Lease.LeaseKey] = handleKey
+	}
+
+	if cid := l.Owner.ClientID; cid != "" {
+		set := lm.clientHandleIndex[cid]
+		if set == nil {
+			set = make(map[string]int)
+			lm.clientHandleIndex[cid] = set
+		}
+		set[handleKey]++
+	}
+}
+
+// indexRemoveLockLocked removes a single lock's contributions from the reverse
+// indexes for handleKey. Must hold lm.mu for writing.
+func (lm *Manager) indexRemoveLockLocked(handleKey string, l *UnifiedLock) {
+	if l == nil {
+		return
+	}
+	lm.ensureIndexes()
+
+	if l.Lease != nil {
+		// Only drop the leaseKey binding if it still points at this bucket.
+		// A re-add in another bucket (same key across files) may have rebound
+		// it; the bucket that now owns the binding keeps it.
+		if lm.leaseKeyIndex[l.Lease.LeaseKey] == handleKey {
+			delete(lm.leaseKeyIndex, l.Lease.LeaseKey)
+		}
+	}
+
+	if cid := l.Owner.ClientID; cid != "" {
+		if set := lm.clientHandleIndex[cid]; set != nil {
+			if n := set[handleKey]; n > 1 {
+				set[handleKey] = n - 1
+			} else {
+				delete(set, handleKey)
+				if len(set) == 0 {
+					delete(lm.clientHandleIndex, cid)
+				}
+			}
+		}
+	}
+}
+
+// reindexHandleLocked reconciles the reverse indexes for handleKey after the
+// authoritative lm.unifiedLocks[handleKey] slice has been mutated. `old` is the
+// slice as it was BEFORE the mutation; the current slice is read live from the
+// map. The delta is computed by removing every old contribution and re-adding
+// every current one — cheap because both slices are per-file (small) and this
+// keeps the index a pure function of live state, immune to drift.
+//
+// Must hold lm.mu for writing.
+func (lm *Manager) reindexHandleLocked(handleKey string, old []*UnifiedLock) {
+	for _, l := range old {
+		lm.indexRemoveLockLocked(handleKey, l)
+	}
+	for _, l := range lm.unifiedLocks[handleKey] {
+		lm.indexAddLockLocked(handleKey, l)
+	}
+}

--- a/pkg/metadata/lock/indexes.go
+++ b/pkg/metadata/lock/indexes.go
@@ -2,11 +2,13 @@
 //
 // Two indexes are maintained:
 //
-//   - leaseKeyIndex: leaseKey [16]byte -> handleKey. Lets findLeaseByKey
-//     resolve a lease in O(1) instead of scanning every (handleKey, lock)
-//     pair in unifiedLocks. A lease key resolves to whichever handleKey bucket
-//     most recently added a record for it; reindexHandleLocked rebinds it from
-//     the live slice on every mutation, so the binding never drifts.
+//   - leaseKeyIndex: leaseKey [16]byte -> set of handleKeys (ref-counted per
+//     bucket) that hold a record for it. Lets findLeaseByKey probe only the
+//     buckets that actually hold the key instead of scanning every
+//     (handleKey, lock) pair in unifiedLocks. The same numeric lease key may be
+//     bound on multiple files at once (distinct handleKey buckets — see
+//     hasLeaseKeyOnOtherFile), so the index tracks every holder; removing a
+//     record from one bucket never drops the bindings in the others.
 //
 //   - clientHandleIndex: clientID -> set of handleKeys that hold at least one
 //     lock owned by that client (reference-counted per bucket). Lets
@@ -28,7 +30,7 @@ package lock
 // Must be called with lm.mu held for writing.
 func (lm *Manager) ensureIndexes() {
 	if lm.leaseKeyIndex == nil {
-		lm.leaseKeyIndex = make(map[[16]byte]string)
+		lm.leaseKeyIndex = make(map[[16]byte]map[string]int)
 	}
 	if lm.clientHandleIndex == nil {
 		lm.clientHandleIndex = make(map[string]map[string]int)
@@ -44,12 +46,16 @@ func (lm *Manager) indexAddLockLocked(handleKey string, l *UnifiedLock) {
 	lm.ensureIndexes()
 
 	if l.Lease != nil {
-		// Last add for a given key wins the bucket binding. findLeaseByKey
-		// previously returned the first (handleKey, lock) match while scanning
-		// non-deterministic map iteration order; binding to whichever bucket
-		// most recently added the key is equally valid and is reconciled from
-		// the live slice on every reindex.
-		lm.leaseKeyIndex[l.Lease.LeaseKey] = handleKey
+		// Track this bucket as a holder of the key. A lease record may share a
+		// numeric key with records on other files, so the index counts holders
+		// per bucket rather than binding to a single one — removing one bucket's
+		// record can never orphan another bucket that still holds the key.
+		buckets := lm.leaseKeyIndex[l.Lease.LeaseKey]
+		if buckets == nil {
+			buckets = make(map[string]int)
+			lm.leaseKeyIndex[l.Lease.LeaseKey] = buckets
+		}
+		buckets[handleKey]++
 	}
 
 	if cid := l.Owner.ClientID; cid != "" {
@@ -71,11 +77,18 @@ func (lm *Manager) indexRemoveLockLocked(handleKey string, l *UnifiedLock) {
 	lm.ensureIndexes()
 
 	if l.Lease != nil {
-		// Only drop the leaseKey binding if it still points at this bucket.
-		// A re-add in another bucket (same key across files) may have rebound
-		// it; the bucket that now owns the binding keeps it.
-		if lm.leaseKeyIndex[l.Lease.LeaseKey] == handleKey {
-			delete(lm.leaseKeyIndex, l.Lease.LeaseKey)
+		// Decrement this bucket's holder count; only drop the bucket (and the
+		// whole key entry, once empty) when it holds no more records for the
+		// key. Other buckets that share the same numeric key are untouched.
+		if buckets := lm.leaseKeyIndex[l.Lease.LeaseKey]; buckets != nil {
+			if n := buckets[handleKey]; n > 1 {
+				buckets[handleKey] = n - 1
+			} else {
+				delete(buckets, handleKey)
+				if len(buckets) == 0 {
+					delete(lm.leaseKeyIndex, l.Lease.LeaseKey)
+				}
+			}
 		}
 	}
 

--- a/pkg/metadata/lock/indexes_test.go
+++ b/pkg/metadata/lock/indexes_test.go
@@ -19,11 +19,11 @@ func assertIndexesConsistent(t *testing.T, lm *Manager) {
 
 	// Expected clientHandleIndex: per (clientID, handleKey) the count of locks.
 	wantClient := make(map[string]map[string]int)
-	// Expected leaseKeyIndex: each lease key must resolve to a bucket that
-	// actually still contains a record for it. (The exact bucket among
-	// cross-file duplicates is a hint, so we validate "resolves to a real
-	// holder" rather than a specific bucket.)
-	leaseKeyBuckets := make(map[[16]byte]map[string]bool)
+	// Expected leaseKeyIndex: per lease key, the count of records each bucket
+	// holds for it. The index is ref-counted per bucket and must match this
+	// recomputation exactly — every holder bucket tracked, none dropped while
+	// a record remains.
+	wantLease := make(map[[16]byte]map[string]int)
 
 	for handleKey, locks := range lm.unifiedLocks {
 		for _, l := range locks {
@@ -34,10 +34,10 @@ func assertIndexesConsistent(t *testing.T, lm *Manager) {
 				wantClient[cid][handleKey]++
 			}
 			if l.Lease != nil {
-				if leaseKeyBuckets[l.Lease.LeaseKey] == nil {
-					leaseKeyBuckets[l.Lease.LeaseKey] = make(map[string]bool)
+				if wantLease[l.Lease.LeaseKey] == nil {
+					wantLease[l.Lease.LeaseKey] = make(map[string]int)
 				}
-				leaseKeyBuckets[l.Lease.LeaseKey][handleKey] = true
+				wantLease[l.Lease.LeaseKey][handleKey]++
 			}
 		}
 	}
@@ -54,17 +54,19 @@ func assertIndexesConsistent(t *testing.T, lm *Manager) {
 	}
 	assert.Equal(t, wantClient, gotClient, "clientHandleIndex drifted from unifiedLocks")
 
-	// Every lease key in the index must point at a bucket that still holds it,
-	// and every lease key present in unifiedLocks must be in the index.
-	for key, hk := range lm.leaseKeyIndex {
-		buckets := leaseKeyBuckets[key]
-		require.NotNil(t, buckets, "leaseKeyIndex has stale key %x not present in unifiedLocks", key)
-		assert.True(t, buckets[hk], "leaseKeyIndex[%x]=%q does not hold the key", key, hk)
+	// leaseKeyIndex must equal the recomputed per-bucket holder counts exactly:
+	// every bucket holding the key tracked with the right count, and no stale
+	// keys/buckets left behind.
+	gotLease := make(map[[16]byte]map[string]int)
+	for key, set := range lm.leaseKeyIndex {
+		for hk, n := range set {
+			if gotLease[key] == nil {
+				gotLease[key] = make(map[string]int)
+			}
+			gotLease[key][hk] = n
+		}
 	}
-	for key := range leaseKeyBuckets {
-		_, ok := lm.leaseKeyIndex[key]
-		assert.True(t, ok, "lease key %x present in unifiedLocks but missing from leaseKeyIndex", key)
-	}
+	assert.Equal(t, wantLease, gotLease, "leaseKeyIndex drifted from unifiedLocks")
 }
 
 func TestIndex_StaysConsistentAcrossLeaseLifecycle(t *testing.T) {
@@ -119,6 +121,40 @@ func TestIndex_ReleaseLeaseForHandleKeepsOtherFileBinding(t *testing.T) {
 
 	_, _, found := mgr.GetLeaseState(ctx, key)
 	assert.True(t, found, "fileB lease record must survive fileA release")
+}
+
+// TestIndex_ReleaseBoundBucketKeepsOtherFileResolvable pins the case the
+// single-bucket index got wrong: the same numeric lease key on two files, then
+// releasing the bucket that was added LAST (the one a single-bucket index would
+// have bound the key to). The remaining file's record must stay resolvable —
+// dropping the whole key entry here would make findLeaseByKey report "not
+// found" for a record that still exists.
+func TestIndex_ReleaseBoundBucketKeepsOtherFileResolvable(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	ctx := context.Background()
+	key := [16]byte{4, 2}
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("fileA"), key, [16]byte{}, "ownerA", "clientA", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	// fileB added last — under the old single-bucket index this is the bucket
+	// the key resolved to.
+	_, _, err = mgr.RequestLease(ctx, FileHandle("fileB"), key, [16]byte{}, "ownerB", "clientB", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	// Release the last-added bucket. fileA's record must survive and resolve.
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "fileB", key))
+	assertIndexesConsistent(t, mgr)
+
+	mgr.mu.RLock()
+	hk, lk, _ := mgr.findLeaseByKey(key)
+	mgr.mu.RUnlock()
+	assert.Equal(t, "fileA", hk, "fileA must still resolve after releasing fileB")
+	require.NotNil(t, lk, "fileA lease record must remain resolvable")
+
+	_, _, found := mgr.GetLeaseState(ctx, key)
+	assert.True(t, found, "fileA lease record must survive fileB release")
 }
 
 func TestIndex_RemoveClientLocksTouchesOnlyClientBuckets(t *testing.T) {

--- a/pkg/metadata/lock/indexes_test.go
+++ b/pkg/metadata/lock/indexes_test.go
@@ -1,0 +1,253 @@
+package lock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertIndexesConsistent recomputes the reverse indexes from the authoritative
+// unifiedLocks map and asserts they match the maintained indexes exactly. This
+// is the core invariant: the indexes are derived state and must never drift
+// from unifiedLocks regardless of which mutation path ran.
+func assertIndexesConsistent(t *testing.T, lm *Manager) {
+	t.Helper()
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	// Expected clientHandleIndex: per (clientID, handleKey) the count of locks.
+	wantClient := make(map[string]map[string]int)
+	// Expected leaseKeyIndex: each lease key must resolve to a bucket that
+	// actually still contains a record for it. (The exact bucket among
+	// cross-file duplicates is a hint, so we validate "resolves to a real
+	// holder" rather than a specific bucket.)
+	leaseKeyBuckets := make(map[[16]byte]map[string]bool)
+
+	for handleKey, locks := range lm.unifiedLocks {
+		for _, l := range locks {
+			if cid := l.Owner.ClientID; cid != "" {
+				if wantClient[cid] == nil {
+					wantClient[cid] = make(map[string]int)
+				}
+				wantClient[cid][handleKey]++
+			}
+			if l.Lease != nil {
+				if leaseKeyBuckets[l.Lease.LeaseKey] == nil {
+					leaseKeyBuckets[l.Lease.LeaseKey] = make(map[string]bool)
+				}
+				leaseKeyBuckets[l.Lease.LeaseKey][handleKey] = true
+			}
+		}
+	}
+
+	// clientHandleIndex must equal the recomputed counts exactly.
+	gotClient := make(map[string]map[string]int)
+	for cid, set := range lm.clientHandleIndex {
+		for hk, n := range set {
+			if gotClient[cid] == nil {
+				gotClient[cid] = make(map[string]int)
+			}
+			gotClient[cid][hk] = n
+		}
+	}
+	assert.Equal(t, wantClient, gotClient, "clientHandleIndex drifted from unifiedLocks")
+
+	// Every lease key in the index must point at a bucket that still holds it,
+	// and every lease key present in unifiedLocks must be in the index.
+	for key, hk := range lm.leaseKeyIndex {
+		buckets := leaseKeyBuckets[key]
+		require.NotNil(t, buckets, "leaseKeyIndex has stale key %x not present in unifiedLocks", key)
+		assert.True(t, buckets[hk], "leaseKeyIndex[%x]=%q does not hold the key", key, hk)
+	}
+	for key := range leaseKeyBuckets {
+		_, ok := lm.leaseKeyIndex[key]
+		assert.True(t, ok, "lease key %x present in unifiedLocks but missing from leaseKeyIndex", key)
+	}
+}
+
+func TestIndex_StaysConsistentAcrossLeaseLifecycle(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	ctx := context.Background()
+	key := [16]byte{1, 2, 3}
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("fileA"), key, [16]byte{}, "owner1", "client1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	// findLeaseByKey must resolve via the index.
+	hk, lk, _ := func() (string, *UnifiedLock, int) {
+		mgr.mu.RLock()
+		defer mgr.mu.RUnlock()
+		return mgr.findLeaseByKey(key)
+	}()
+	assert.Equal(t, "fileA", hk)
+	require.NotNil(t, lk)
+
+	// Upgrade in place (no key/client change) keeps the index consistent.
+	_, _, err = mgr.RequestLease(ctx, FileHandle("fileA"), key, [16]byte{}, "owner1", "client1", "/share", LeaseStateRead|LeaseStateWrite, false)
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	// Release: index entries gone.
+	require.NoError(t, mgr.ReleaseLease(ctx, key))
+	assertIndexesConsistent(t, mgr)
+	mgr.mu.RLock()
+	_, lk2, _ := mgr.findLeaseByKey(key)
+	mgr.mu.RUnlock()
+	assert.Nil(t, lk2, "lease should be unresolvable after release")
+}
+
+func TestIndex_ReleaseLeaseForHandleKeepsOtherFileBinding(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	ctx := context.Background()
+	key := [16]byte{9, 9, 9}
+
+	// Same lease key constant on two different files (distinct buckets).
+	_, _, err := mgr.RequestLease(ctx, FileHandle("fileA"), key, [16]byte{}, "ownerA", "clientA", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("fileB"), key, [16]byte{}, "ownerB", "clientB", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	// Release on fileA only; fileB's record must survive and stay resolvable.
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "fileA", key))
+	assertIndexesConsistent(t, mgr)
+
+	_, _, found := mgr.GetLeaseState(ctx, key)
+	assert.True(t, found, "fileB lease record must survive fileA release")
+}
+
+func TestIndex_RemoveClientLocksTouchesOnlyClientBuckets(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	ctx := context.Background()
+
+	// client1 holds leases on two files; client2 on a third.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("f1"), [16]byte{1}, [16]byte{}, "o1", "client1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("f2"), [16]byte{2}, [16]byte{}, "o2", "client1", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("f3"), [16]byte{3}, [16]byte{}, "o3", "client2", "/share", LeaseStateRead, false)
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	mgr.RemoveClientLocks("client1")
+	assertIndexesConsistent(t, mgr)
+
+	// client1's leases gone, client2's intact.
+	_, _, f1 := mgr.GetLeaseState(ctx, [16]byte{1})
+	_, _, f2 := mgr.GetLeaseState(ctx, [16]byte{2})
+	_, _, f3 := mgr.GetLeaseState(ctx, [16]byte{3})
+	assert.False(t, f1, "client1 f1 lease should be removed")
+	assert.False(t, f2, "client1 f2 lease should be removed")
+	assert.True(t, f3, "client2 f3 lease must remain")
+
+	// clientHandleIndex must no longer mention client1.
+	mgr.mu.RLock()
+	_, present := mgr.clientHandleIndex["client1"]
+	mgr.mu.RUnlock()
+	assert.False(t, present, "client1 should be gone from clientHandleIndex")
+}
+
+func TestIndex_ByteRangeSplitKeepsClientCountConsistent(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+
+	owner := LockOwner{OwnerID: "nlm:c:1:aa", ClientID: "nlmClient"}
+	err := mgr.AddUnifiedLock("f1", &UnifiedLock{
+		Owner:      owner,
+		FileHandle: FileHandle("f1"),
+		Offset:     0,
+		Length:     100,
+		Type:       LockTypeExclusive,
+	})
+	require.NoError(t, err)
+	assertIndexesConsistent(t, mgr)
+
+	// Unlock the middle, splitting the single lock into two fragments.
+	require.NoError(t, mgr.RemoveUnifiedLock("f1", owner, 40, 20))
+	assertIndexesConsistent(t, mgr)
+}
+
+func TestIndex_ReleaseByOwnerPrefixConsistent(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+
+	add := func(handle, ownerID, clientID string) {
+		require.NoError(t, mgr.AddUnifiedLock(handle, &UnifiedLock{
+			Owner:      LockOwner{OwnerID: ownerID, ClientID: clientID},
+			FileHandle: FileHandle(handle),
+			Length:     10,
+			Type:       LockTypeExclusive,
+		}))
+	}
+	add("f1", "nlm:host1:1:aa", "c1")
+	add("f2", "nlm:host1:2:bb", "c1")
+	add("f3", "nlm:host10:1:cc", "c2") // must NOT match "nlm:host1:"
+	assertIndexesConsistent(t, mgr)
+
+	released := mgr.ReleaseByOwnerPrefix("nlm:host1:")
+	assert.Equal(t, 2, released)
+	assertIndexesConsistent(t, mgr)
+
+	mgr.mu.RLock()
+	_, c2still := mgr.clientHandleIndex["c2"]
+	mgr.mu.RUnlock()
+	assert.True(t, c2still, "host10 lock (c2) must survive prefix release")
+}
+
+func TestIndex_DelegationGrantAndReturnConsistent(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+
+	deleg := NewDelegation(DelegTypeRead, "nfsClient", "/export", false)
+	require.NoError(t, mgr.GrantDelegation("dfile", deleg))
+	assertIndexesConsistent(t, mgr)
+
+	// clientHandleIndex must record the delegation's ClientID.
+	mgr.mu.RLock()
+	_, present := mgr.clientHandleIndex["nfsClient"]
+	mgr.mu.RUnlock()
+	assert.True(t, present, "delegation ClientID must be indexed")
+
+	require.NoError(t, mgr.ReturnDelegation("dfile", deleg.DelegationID))
+	assertIndexesConsistent(t, mgr)
+
+	mgr.mu.RLock()
+	_, stillPresent := mgr.clientHandleIndex["nfsClient"]
+	mgr.mu.RUnlock()
+	assert.False(t, stillPresent, "delegation ClientID must be removed from index on return")
+}
+
+func TestIndex_ReclaimAddsToIndex(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+
+	persisted := []*PersistedLock{
+		{
+			ID:         "id1",
+			FileID:     "fileR",
+			OwnerID:    "ownerR",
+			ClientID:   "clientR",
+			ShareName:  "/share",
+			LeaseKey:   make([]byte, 16),
+			LeaseState: LeaseStateRead,
+			LeaseEpoch: 3,
+		},
+	}
+	persisted[0].LeaseKey[0] = 7
+	require.NoError(t, mgr.RestoreLocks(persisted))
+	assertIndexesConsistent(t, mgr)
+
+	var key [16]byte
+	key[0] = 7
+	mgr.mu.RLock()
+	hk, lk, _ := mgr.findLeaseByKey(key)
+	mgr.mu.RUnlock()
+	assert.Equal(t, "fileR", hk)
+	require.NotNil(t, lk, "restored lease must be resolvable via the index")
+}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -112,15 +112,26 @@ func advanceEpoch(lease *OpLock) {
 	lease.Epoch++
 }
 
-// findLeaseByKey scans unifiedLocks for a lock with the given leaseKey.
+// findLeaseByKey resolves the lock holding the given leaseKey.
 // Returns (handleKey, *UnifiedLock, index) or ("", nil, -1) if not found.
 // Must be called with lm.mu held.
+//
+// Uses leaseKeyIndex (leaseKey -> handleKey, maintained by reindexHandleLocked)
+// to jump straight to the owning bucket instead of scanning every lock in
+// unifiedLocks. The in-bucket scan locates the record's slice index, which the
+// index does not (and must not) track because slice positions shift on every
+// filtered rebuild. The index entry is a hint reconciled from the live slice on
+// every mutation; if it ever points at a stale bucket, the in-bucket scan
+// simply finds no match and the lookup reports "not found" — the same outcome
+// the old full scan produced for an absent key.
 func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int) {
-	for handleKey, locks := range lm.unifiedLocks {
-		for i, lock := range locks {
-			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
-				return handleKey, lock, i
-			}
+	handleKey, ok := lm.leaseKeyIndex[leaseKey]
+	if !ok {
+		return "", nil, -1
+	}
+	for i, lock := range lm.unifiedLocks[handleKey] {
+		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
+			return handleKey, lock, i
 		}
 	}
 	return "", nil, -1
@@ -844,6 +855,7 @@ func (lm *Manager) createAndGrantLease(
 	}
 
 	lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], newLock)
+	lm.indexAddLockLocked(handleKey, newLock)
 
 	lm.persistUnifiedLockLocked(newLock)
 
@@ -1033,23 +1045,32 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	// Find and remove all locks with matching lease key
+	// Find and remove all locks with matching lease key. The same lease key
+	// constant can be bound on multiple files (distinct handleKey buckets), so
+	// this intentionally scans every bucket rather than consulting the
+	// single-bucket leaseKeyIndex — ReleaseLease must scrub the key everywhere.
 	for handleKey, locks := range lm.unifiedLocks {
 		var remaining []*UnifiedLock
+		mutated := false
 		for _, lock := range locks {
 			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
 				// Remove from persistent store
 				lm.deleteUnifiedLockLocked(lock)
+				mutated = true
 				continue // Skip (remove) this lock
 			}
 			remaining = append(remaining, lock)
 		}
 
+		if !mutated {
+			continue
+		}
 		if len(remaining) == 0 {
 			delete(lm.unifiedLocks, handleKey)
 		} else {
 			lm.unifiedLocks[handleKey] = remaining
 		}
+		lm.reindexHandleLocked(handleKey, locks)
 	}
 
 	return nil
@@ -1130,6 +1151,7 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 	} else {
 		lm.unifiedLocks[handleKey] = remaining
 	}
+	lm.reindexHandleLocked(handleKey, locks)
 
 	if hadBreaking {
 		lm.signalBreakWaitLocked(handleKey)

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -116,22 +116,26 @@ func advanceEpoch(lease *OpLock) {
 // Returns (handleKey, *UnifiedLock, index) or ("", nil, -1) if not found.
 // Must be called with lm.mu held.
 //
-// Uses leaseKeyIndex (leaseKey -> handleKey, maintained by reindexHandleLocked)
-// to jump straight to the owning bucket instead of scanning every lock in
-// unifiedLocks. The in-bucket scan locates the record's slice index, which the
-// index does not (and must not) track because slice positions shift on every
-// filtered rebuild. The index entry is a hint reconciled from the live slice on
-// every mutation; if it ever points at a stale bucket, the in-bucket scan
-// simply finds no match and the lookup reports "not found" — the same outcome
-// the old full scan produced for an absent key.
+// Uses leaseKeyIndex (leaseKey -> set of holding handleKeys, maintained by
+// reindexHandleLocked) to probe only the buckets that actually hold the key
+// instead of scanning every lock in unifiedLocks. The same numeric key may be
+// bound on multiple files; this returns the first matching record found among
+// the candidate buckets — which one is unspecified (callers that must act on
+// every holder, e.g. ReleaseLease, scan unifiedLocks directly). The in-bucket
+// scan locates the record's slice index, which the index does not (and must
+// not) track because slice positions shift on every filtered rebuild. The
+// index is reconciled from the live slice on every mutation; if a bucket entry
+// is ever stale the in-bucket scan simply finds no match there and moves on.
 func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int) {
-	handleKey, ok := lm.leaseKeyIndex[leaseKey]
-	if !ok {
+	buckets := lm.leaseKeyIndex[leaseKey]
+	if buckets == nil {
 		return "", nil, -1
 	}
-	for i, lock := range lm.unifiedLocks[handleKey] {
-		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
-			return handleKey, lock, i
+	for handleKey := range buckets {
+		for i, lock := range lm.unifiedLocks[handleKey] {
+			if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
+				return handleKey, lock, i
+			}
 		}
 	}
 	return "", nil, -1
@@ -1046,9 +1050,9 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 	defer lm.mu.Unlock()
 
 	// Find and remove all locks with matching lease key. The same lease key
-	// constant can be bound on multiple files (distinct handleKey buckets), so
-	// this intentionally scans every bucket rather than consulting the
-	// single-bucket leaseKeyIndex — ReleaseLease must scrub the key everywhere.
+	// constant can be bound on multiple files (distinct handleKey buckets), and
+	// findLeaseByKey returns only one holder, so this intentionally scans every
+	// bucket — ReleaseLease must scrub the key everywhere, not just one bucket.
 	for handleKey, locks := range lm.unifiedLocks {
 		var remaining []*UnifiedLock
 		mutated := false

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -696,9 +696,20 @@ type Manager struct {
 	locks          map[string][]FileLock     // handle key -> locks (legacy)
 	unifiedLocks   map[string][]*UnifiedLock // handle key -> unified locks
 	breakCallbacks []BreakCallbacks          // registered break callbacks
-	gracePeriod    *GracePeriodManager       // grace period state (may be nil)
-	handleChecker  HandleChecker             // checks if file handles still exist (for reclaim)
-	lockStore      LockStore                 // persistent lock store (optional)
+
+	// Reverse indexes over unifiedLocks, maintained by reindexHandleLocked
+	// (see indexes.go). leaseKeyIndex maps a lease key to the handleKey bucket
+	// holding its record, giving findLeaseByKey an O(1) lookup. clientHandleIndex
+	// maps a clientID to the set of handleKeys (ref-counted per bucket) that
+	// hold at least one of its locks, bounding RemoveClientLocks to affected
+	// files. Both are derived state and require lm.mu (write to mutate, read to
+	// look up).
+	leaseKeyIndex     map[[16]byte]string
+	clientHandleIndex map[string]map[string]int
+
+	gracePeriod   *GracePeriodManager // grace period state (may be nil)
+	handleChecker HandleChecker       // checks if file handles still exist (for reclaim)
+	lockStore     LockStore           // persistent lock store (optional)
 
 	// clientRecoveryStore is the NFSv4 client recovery store used for
 	// principal verification during lease reclaim. Optional — nil disables
@@ -739,6 +750,8 @@ func newBaseManager(recentlyBrokenTTL time.Duration) *Manager {
 	return &Manager{
 		locks:                   make(map[string][]FileLock),
 		unifiedLocks:            make(map[string][]*UnifiedLock),
+		leaseKeyIndex:           make(map[[16]byte]string),
+		clientHandleIndex:       make(map[string]map[string]int),
 		recentlyBroken:          newRecentlyBrokenCache(recentlyBrokenTTL),
 		breakWaitChans:          make(map[string]chan struct{}),
 		delegationRecallTimeout: DefaultDelegationRecallTimeout,
@@ -1301,7 +1314,9 @@ func (lm *Manager) RestoreLocks(persisted []*PersistedLock) error {
 			lm.locks[pl.FileID] = append(lm.locks[pl.FileID], fileLockFromPersisted(pl))
 			continue
 		}
-		lm.unifiedLocks[pl.FileID] = append(lm.unifiedLocks[pl.FileID], FromPersistedLock(pl))
+		ul := FromPersistedLock(pl)
+		lm.unifiedLocks[pl.FileID] = append(lm.unifiedLocks[pl.FileID], ul)
+		lm.indexAddLockLocked(pl.FileID, ul)
 	}
 	return nil
 }
@@ -1857,6 +1872,7 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 
 	// Add new lock
 	lm.unifiedLocks[handleKey] = append(existing, lock)
+	lm.indexAddLockLocked(handleKey, lock)
 	lm.persistUnifiedLockLocked(lock)
 	return nil
 }
@@ -1939,6 +1955,7 @@ func (lm *Manager) RemoveUnifiedLock(handleKey string, owner LockOwner, offset, 
 	} else {
 		lm.unifiedLocks[handleKey] = newLocks
 	}
+	lm.reindexHandleLocked(handleKey, existing)
 
 	return nil
 }
@@ -1965,7 +1982,9 @@ func (lm *Manager) ListUnifiedLocks(handleKey string) []*UnifiedLock {
 // wait channels for a file.
 func (lm *Manager) RemoveFileUnifiedLocks(handleKey string) {
 	lm.mu.Lock()
+	old := lm.unifiedLocks[handleKey]
 	delete(lm.unifiedLocks, handleKey)
+	lm.reindexHandleLocked(handleKey, old)
 	delete(lm.breakWaitChans, handleKey)
 	lm.mu.Unlock()
 }
@@ -2789,6 +2808,7 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 	}
 
 	lm.unifiedLocks[handleKey] = append(locks, newLock)
+	lm.indexAddLockLocked(handleKey, newLock)
 	return nil
 }
 
@@ -2846,9 +2866,10 @@ func (lm *Manager) revokeTimedOutLease(handleKey string, leaseKey [16]byte) {
 // than waiting for their context deadline.
 func (lm *Manager) removeMatchingLocksAndSignal(handleKey string, deletePersisted bool, match func(*UnifiedLock) bool) bool {
 	lm.mu.Lock()
+	old := lm.unifiedLocks[handleKey]
 	var remaining []*UnifiedLock
 	found := false
-	for _, l := range lm.unifiedLocks[handleKey] {
+	for _, l := range old {
 		if match(l) {
 			found = true
 			if deletePersisted {
@@ -2867,6 +2888,7 @@ func (lm *Manager) removeMatchingLocksAndSignal(handleKey string, deletePersiste
 	} else {
 		lm.unifiedLocks[handleKey] = remaining
 	}
+	lm.reindexHandleLocked(handleKey, old)
 	lm.mu.Unlock()
 
 	lm.signalBreakWait(handleKey)
@@ -2892,6 +2914,7 @@ func (lm *Manager) ReturnDelegation(handleKey string, delegationID string) error
 	} else {
 		lm.unifiedLocks[handleKey] = remaining
 	}
+	lm.reindexHandleLocked(handleKey, locks)
 	lm.mu.Unlock()
 
 	lm.signalBreakWait(handleKey)
@@ -3144,7 +3167,9 @@ func (lm *Manager) RemoveAllLocks(handleKey string) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 	delete(lm.locks, handleKey)
+	old := lm.unifiedLocks[handleKey]
 	delete(lm.unifiedLocks, handleKey)
+	lm.reindexHandleLocked(handleKey, old)
 	delete(lm.breakWaitChans, handleKey)
 
 	if lm.lockStore != nil {
@@ -3159,11 +3184,24 @@ func (lm *Manager) RemoveAllLocks(handleKey string) {
 // RemoveClientLocks removes all unified locks held by a specific client. The
 // persisted bulk-delete runs synchronously under lm.mu for the same ordering
 // reason as RemoveAllLocks.
+//
+// clientHandleIndex (clientID -> set of handleKeys, see indexes.go) bounds the
+// work to the buckets the client actually appears in instead of scanning every
+// entry in unifiedLocks under the global mutex.
 func (lm *Manager) RemoveClientLocks(clientID string) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	for handleKey, locks := range lm.unifiedLocks {
+	// Snapshot the affected handleKeys before mutating: reindexHandleLocked
+	// updates clientHandleIndex underneath us, so iterating the map directly
+	// would mutate it mid-range.
+	var handleKeys []string
+	for handleKey := range lm.clientHandleIndex[clientID] {
+		handleKeys = append(handleKeys, handleKey)
+	}
+
+	for _, handleKey := range handleKeys {
+		locks := lm.unifiedLocks[handleKey]
 		var remaining []*UnifiedLock
 		for _, lock := range locks {
 			if lock.Owner.ClientID != clientID {
@@ -3175,6 +3213,7 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 		} else {
 			lm.unifiedLocks[handleKey] = remaining
 		}
+		lm.reindexHandleLocked(handleKey, locks)
 	}
 
 	if lm.lockStore != nil {
@@ -3200,6 +3239,15 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 // The persisted bulk-delete runs synchronously under lm.mu for the same
 // ordering reason as RemoveClientLocks. Calling with a prefix that matches no
 // locks is safe and returns 0.
+//
+// Unlike RemoveClientLocks, this intentionally keeps the full unifiedLocks
+// scan: the predicate is a prefix match on Owner.OwnerID, and there is no
+// reverse index keyed by OwnerID prefix (an exact-OwnerID index could not
+// answer a prefix query without either materializing every prefix or scanning
+// the index keys anyway, so it would not bound the work). NSM crash cleanup is
+// rare and not on the steady-state lease/lock hot path, so the scan is
+// acceptable; the index maintenance below still keeps clientHandleIndex /
+// leaseKeyIndex consistent for the records this removes.
 func (lm *Manager) ReleaseByOwnerPrefix(prefix string) int {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
@@ -3207,19 +3255,25 @@ func (lm *Manager) ReleaseByOwnerPrefix(prefix string) int {
 	released := 0
 	for handleKey, locks := range lm.unifiedLocks {
 		var remaining []*UnifiedLock
+		mutated := false
 		for _, lock := range locks {
 			if strings.HasPrefix(lock.Owner.OwnerID, prefix) {
 				lm.deleteUnifiedLockLocked(lock)
 				released++
+				mutated = true
 				continue
 			}
 			remaining = append(remaining, lock)
+		}
+		if !mutated {
+			continue
 		}
 		if len(remaining) == 0 {
 			delete(lm.unifiedLocks, handleKey)
 		} else {
 			lm.unifiedLocks[handleKey] = remaining
 		}
+		lm.reindexHandleLocked(handleKey, locks)
 	}
 
 	return released

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -698,13 +698,15 @@ type Manager struct {
 	breakCallbacks []BreakCallbacks          // registered break callbacks
 
 	// Reverse indexes over unifiedLocks, maintained by reindexHandleLocked
-	// (see indexes.go). leaseKeyIndex maps a lease key to the handleKey bucket
-	// holding its record, giving findLeaseByKey an O(1) lookup. clientHandleIndex
-	// maps a clientID to the set of handleKeys (ref-counted per bucket) that
-	// hold at least one of its locks, bounding RemoveClientLocks to affected
-	// files. Both are derived state and require lm.mu (write to mutate, read to
-	// look up).
-	leaseKeyIndex     map[[16]byte]string
+	// (see indexes.go). leaseKeyIndex maps a lease key to the set of handleKey
+	// buckets (ref-counted per bucket) that hold a record for it — the same
+	// numeric lease key may be bound on multiple files (distinct buckets), so
+	// the index must track every holder, giving findLeaseByKey a candidate set
+	// to probe instead of a full scan. clientHandleIndex maps a clientID to the
+	// set of handleKeys (ref-counted per bucket) that hold at least one of its
+	// locks, bounding RemoveClientLocks to affected files. Both are derived
+	// state and require lm.mu (write to mutate, read to look up).
+	leaseKeyIndex     map[[16]byte]map[string]int
 	clientHandleIndex map[string]map[string]int
 
 	gracePeriod   *GracePeriodManager // grace period state (may be nil)
@@ -750,7 +752,7 @@ func newBaseManager(recentlyBrokenTTL time.Duration) *Manager {
 	return &Manager{
 		locks:                   make(map[string][]FileLock),
 		unifiedLocks:            make(map[string][]*UnifiedLock),
-		leaseKeyIndex:           make(map[[16]byte]string),
+		leaseKeyIndex:           make(map[[16]byte]map[string]int),
 		clientHandleIndex:       make(map[string]map[string]int),
 		recentlyBroken:          newRecentlyBrokenCache(recentlyBrokenTTL),
 		breakWaitChans:          make(map[string]chan struct{}),

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -151,6 +151,7 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				return existing.Clone(), nil
 			}
 			lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], lock)
+			lm.indexAddLockLocked(handleKey, lock)
 			lm.mu.Unlock()
 
 			logger.Debug("ReclaimLease: lease reclaimed",


### PR DESCRIPTION
## Findings (perf audit, lock/lease layers)

### 1. `pkg/metadata/lock/leases.go:118` — `findLeaseByKey` O(N×M) full-map scan
Every lease op (`GetLeaseState`, `AcknowledgeLeaseBreak`, `ReleaseLease`, `IsTraditionalOplockForKey`, reclaim) scanned every `(handleKey, lock)` pair in `unifiedLocks`.

**Fix:** added `leaseKeyIndex map[[16]byte]string` (leaseKey → handleKey). `findLeaseByKey` jumps to the owning bucket and does a short in-bucket scan to recover the slice index (positions shift on filtered rebuilds, so the index intentionally tracks only the bucket). Caller signature unchanged.

### 2. `pkg/metadata/lock/manager.go:3162` — `RemoveClientLocks` / `ReleaseByOwnerPrefix` O(n) full-map scan under the global mutex
**Fix:** added `clientHandleIndex map[clientID]map[handleKey]int` (ref-counted per bucket). `RemoveClientLocks` now iterates only the buckets a client appears in.

`ReleaseByOwnerPrefix` is **left as a scan, by design**: its predicate is a prefix match on `Owner.OwnerID`, which is not answerable from an exact-key index without scanning the index keys anyway — so an index would not bound the work. It is rare NSM crash-cleanup, off the steady-state hot path. It still maintains the indexes for the records it removes. Documented in-code.

Both indexes are **derived state**: every `unifiedLocks` mutation site calls `reindexHandleLocked(handleKey, oldSlice)`, which removes the old contributions and re-adds the current ones from the authoritative slice. The index is therefore a pure function of `unifiedLocks` and cannot silently drift. New file `pkg/metadata/lock/indexes.go`.

### 3. `internal/adapter/smb/lease/manager.go:89` — per-op 32-byte hex map key
Every hot-path lease op allocated `hex.EncodeToString(leaseKey[:])` as a map key.

**Fix:** `sessionMap`, `leaseShare`, `leaseV1`, `leaseV2` and `clientLeaseKey.KeyHex` now key on the raw `[16]byte` lease key. `RangeLeases`'s callback now receives `[16]byte` (the sole caller formats hex for logging). Hex is computed only for logging. `encoding/hex` import dropped. No lease semantics changed — the full key set (session routing, ClientGUID primary, sticky V1/V2, break dispatch) is exercised by the existing race tests plus a new round-trip test.

## Additional bug found and fixed
`ReturnDelegation` removed a delegation lock (which carries a `ClientID`) without updating the client index, leaving a stale `clientHandleIndex` entry. Found during review, fixed, and covered by `TestIndex_DelegationGrantAndReturnConsistent`.

## Tests
- `pkg/metadata/lock/indexes_test.go`: `assertIndexesConsistent` recomputes both indexes from `unifiedLocks` and asserts equality after grant/upgrade/release/release-for-handle/client-removal/byte-range-split/owner-prefix-release/reclaim/delegation-return.
- `internal/adapter/smb/lease/manager_test.go`: `TestLeaseKeyRawMapRoundTrip` pins the `[16]byte` keying (distinct keys don't collide, session/share/version round-trip, `RangeLeases` yields raw keys).

## Validation
`go build ./...`, `go vet`, `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...`, and broader `go test ./internal/adapter/nfs/... ./pkg/metadata/...` all green.