### PR TITLE
fix(operator): repair admin auth, control-plane durability, sample CRs, and image build

### DIFF
--- a/k8s/dittofs-operator/.dockerignore
+++ b/k8s/dittofs-operator/.dockerignore
@@ -2,6 +2,12 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include directories first — without this, `**` excludes the directory
+# entries themselves and Docker never descends into them, so the `!**/*.go`
+# negation below can't reach nested source (e.g. cmd/main.go) and the
+# from-source build fails with "stat /workspace/cmd: directory not found".
+!**/
+
 # Re-include Go source files (but not *_test.go)
 !**/*.go
 **/*_test.go

--- a/k8s/dittofs-operator/Dockerfile
+++ b/k8s/dittofs-operator/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary.
 # Base tracks the go.mod toolchain (go 1.25.x); keep in sync to avoid a
 # GOTOOLCHAIN=auto re-download on every build.
-FROM golang:1.25 AS builder
+FROM golang:1.25.1 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/k8s/dittofs-operator/Dockerfile
+++ b/k8s/dittofs-operator/Dockerfile
@@ -1,5 +1,7 @@
-# Build the manager binary
-FROM golang:1.24.3 AS builder
+# Build the manager binary.
+# Base tracks the go.mod toolchain (go 1.25.x); keep in sync to avoid a
+# GOTOOLCHAIN=auto re-download on every build.
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -20,7 +22,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOTOOLCHAIN=auto CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN GOTOOLCHAIN=auto CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager ./cmd
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
+++ b/k8s/dittofs-operator/api/v1alpha1/dittoserver_types.go
@@ -129,8 +129,11 @@ type DatabaseConfig struct {
 
 // SQLiteConfig configures SQLite database
 type SQLiteConfig struct {
-	// Path is the database file path inside the container
-	// +kubebuilder:default="/data/controlplane/controlplane.db"
+	// Path is the database file path inside the container. It MUST live under a
+	// persistent volume (the operator mounts the "metadata" PVC at /data/metadata)
+	// — a path on the ephemeral container overlay is wiped on every pod restart,
+	// silently dropping all metadata-store and share definitions.
+	// +kubebuilder:default="/data/metadata/controlplane/controlplane.db"
 	Path string `json:"path,omitempty"`
 }
 

--- a/k8s/dittofs-operator/chart/crds/dittoservers.yaml
+++ b/k8s/dittofs-operator/chart/crds/dittoservers.yaml
@@ -182,8 +182,12 @@ spec:
                     description: SQLite configuration (used when Type=sqlite)
                     properties:
                       path:
-                        default: /data/controlplane/controlplane.db
-                        description: Path is the database file path inside the container
+                        default: /data/metadata/controlplane/controlplane.db
+                        description: |-
+                          Path is the database file path inside the container. It MUST live under a
+                          persistent volume (the operator mounts the "metadata" PVC at /data/metadata)
+                          — a path on the ephemeral container overlay is wiped on every pod restart,
+                          silently dropping all metadata-store and share definitions.
                         type: string
                     type: object
                   type:

--- a/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
+++ b/k8s/dittofs-operator/config/crd/bases/dittofs.dittofs.com_dittoservers.yaml
@@ -182,8 +182,12 @@ spec:
                     description: SQLite configuration (used when Type=sqlite)
                     properties:
                       path:
-                        default: /data/controlplane/controlplane.db
-                        description: Path is the database file path inside the container
+                        default: /data/metadata/controlplane/controlplane.db
+                        description: |-
+                          Path is the database file path inside the container. It MUST live under a
+                          persistent volume (the operator mounts the "metadata" PVC at /data/metadata)
+                          — a path on the ephemeral container overlay is wiped on every pod restart,
+                          silently dropping all metadata-store and share definitions.
                         type: string
                     type: object
                   type:

--- a/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver.yaml
+++ b/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver.yaml
@@ -27,13 +27,13 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   # Control plane database - defaults to SQLite
   database:
     type: sqlite
     sqlite:
-      path: "/data/controlplane/controlplane.db"
+      path: "/data/metadata/controlplane/controlplane.db"
 
   # WAL-backed cache configuration
   cache:
@@ -45,7 +45,6 @@ spec:
     port: 8080
 
   # NFS server port
-  nfsPort: 12049
 
   # Service configuration
   service:

--- a/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver_aws_s3.yaml
+++ b/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver_aws_s3.yaml
@@ -38,13 +38,13 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   # Control plane database
   database:
     type: sqlite
     sqlite:
-      path: "/data/controlplane/controlplane.db"
+      path: "/data/metadata/controlplane/controlplane.db"
 
   # WAL-backed cache - larger for S3 workloads
   cache:
@@ -56,7 +56,6 @@ spec:
     port: 8080
 
   # NFS server port
-  nfsPort: 12049
 
   # Service configuration
   service:

--- a/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver_with_cache.yaml
+++ b/k8s/dittofs-operator/config/samples/ditto.io_v1alpha1_dittoserver_with_cache.yaml
@@ -34,13 +34,13 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   # Control plane database
   database:
     type: sqlite
     sqlite:
-      path: "/data/controlplane/controlplane.db"
+      path: "/data/metadata/controlplane/controlplane.db"
 
   # Large WAL-backed cache for performance
   cache:
@@ -52,7 +52,6 @@ spec:
     port: 8080
 
   # NFS server port (non-privileged default)
-  nfsPort: 12049
 
   # Service configuration
   service:

--- a/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
@@ -52,10 +52,9 @@ spec:
       username: "admin"
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   # NFS server port (non-privileged default)
-  nfsPort: 12049
 
   # SMB configuration
   smb:
@@ -130,7 +129,5 @@ metadata:
     app.kubernetes.io/name: dittofs-operator
 type: Opaque
 data:
-  # Base64 encoded bcrypt password hash
-  # Generate hash: htpasswd -bnBC 10 "" adminpassword | tr -d ':\n'
   # Then encode: echo -n '$2y$10$...' | base64
-  password-hash: JDJ5JDEwJHh5ei4uLg==
+  password: Y2hhbmdlLW1lLXRvLWEtc3Ryb25nLWFkbWluLXBhc3N3b3Jk

--- a/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server-with-secrets.yaml
@@ -129,5 +129,6 @@ metadata:
     app.kubernetes.io/name: dittofs-operator
 type: Opaque
 data:
-  # Then encode: echo -n '$2y$10$...' | base64
+  # CLEARTEXT admin password, base64-encoded: echo -n 'your-strong-password' | base64
+  # (the server bootstraps the admin user from this and hashes it internally)
   password: Y2hhbmdlLW1lLXRvLWEtc3Ryb25nLWFkbWluLXBhc3N3b3Jk

--- a/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs-s3-smb-server.yaml
@@ -36,13 +36,13 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   # Control plane database
   database:
     type: sqlite
     sqlite:
-      path: "/data/controlplane/controlplane.db"
+      path: "/data/metadata/controlplane/controlplane.db"
 
   # WAL-backed cache - larger for S3 workloads
   cache:
@@ -54,7 +54,6 @@ spec:
     port: 8080
 
   # NFS server port (non-privileged default)
-  nfsPort: 12049
 
   # SMB configuration
   smb:

--- a/k8s/dittofs-operator/config/samples/dittofs_secrets.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs_secrets.yaml
@@ -19,6 +19,4 @@ metadata:
   namespace: dittofs
 type: Opaque
 stringData:
-  # Generate bcrypt hash with: htpasswd -bnBC 10 "" yourpassword | tr -d ':'
-  # Or use: python3 -c "import bcrypt; print(bcrypt.hashpw(b'admin', bcrypt.gensalt()).decode())"
-  password-hash: "$2a$10$N9qo8uLOickgx2ZMRZoMy.Mrq4H1D/REPLACEWITHREALHASH"
+  password: "change-me-to-a-strong-admin-password"

--- a/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittofs_memory.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittofs_memory.yaml
@@ -22,7 +22,7 @@ spec:
   database:
     type: sqlite
     sqlite:
-      path: /data/controlplane/controlplane.db
+      path: /data/metadata/controlplane/controlplane.db
 
   # Cache configuration (WAL-backed for crash recovery)
   cache:
@@ -44,18 +44,27 @@ spec:
       refreshTokenDuration: "168h"
     admin:
       username: admin
+      # The referenced key must hold the admin password in CLEARTEXT — the
+      # server bootstraps the admin user from it (and hashes it itself). A
+      # bcrypt hash here does NOT work (the server has no hash-bootstrap path).
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
-  # Kubernetes Service configuration
+  # Kubernetes Service configuration for the REST API service.
   service:
     type: ClusterIP
     # annotations:
     #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
 
-  # NFS port (default 12049, non-privileged)
-  nfsPort: 12049
+  # Per-adapter (NFS/SMB) file-serving Services are created automatically once
+  # the server is Ready. They are SEPARATE from `service` above (which only
+  # governs the REST API) and default to type LoadBalancer. On clusters WITHOUT
+  # a LoadBalancer controller (bare-metal, kind, k3s without an LB) the external
+  # IP stays <pending> and the file endpoint is only reachable via NodePort —
+  # set type: NodePort (or ClusterIP) here to make it reachable everywhere.
+  # adapterServices:
+  #   type: NodePort
 
   # SMB (optional, disabled by default)
   # smb:
@@ -72,8 +81,8 @@ type: Opaque
 stringData:
   jwt-signing-key: "your-jwt-signing-secret-at-least-32-chars-long"
 ---
-# Admin password hash secret (required)
-# Generate hash with: htpasswd -nbB "" "yourpassword" | cut -d: -f2
+# Admin password secret (required) — CLEARTEXT password, not a hash.
+# The server bootstraps the admin user from this value and hashes it internally.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -81,4 +90,4 @@ metadata:
   namespace: dittofs
 type: Opaque
 stringData:
-  password-hash: "$2y$10$example-bcrypt-hash-here"
+  password: "change-me-to-a-strong-admin-password"

--- a/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittofs_s3.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittofs_s3.yaml
@@ -19,7 +19,7 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 # After this DittoServer is Ready, create S3-backed stores via the REST API:
 #
 #   dfsctl store block remote add --name s3-content --type s3 \

--- a/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittoserver_tls.yaml
+++ b/k8s/dittofs-operator/config/samples/dittofs_v1alpha1_dittoserver_tls.yaml
@@ -34,12 +34,12 @@ spec:
       username: admin
       passwordSecretRef:
         name: dittofs-admin-secret
-        key: password-hash
+        key: password
 
   database:
     type: sqlite
     sqlite:
-      path: "/data/controlplane/controlplane.db"
+      path: "/data/metadata/controlplane/controlplane.db"
 
   cache:
     path: "/data/cache"
@@ -54,7 +54,6 @@ spec:
     # Optional: enable mutual TLS by trusting a client CA bundle (ca.crt).
     # clientCASecretName: dittofs-client-ca
 
-  nfsPort: 12049
 
   service:
     type: "ClusterIP"

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -225,6 +225,14 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 
 	adminUsername := string(adminSecret.Data["username"])
 	adminPassword := string(adminSecret.Data[passwordKey])
+	// Fail fast with an actionable error when the referenced key is absent/empty,
+	// rather than attempting a login with a blank password (which surfaces as a
+	// generic 401 and an indefinitely un-Ready DittoServer).
+	if adminPassword == "" {
+		return ctrl.Result{}, fmt.Errorf(
+			"admin credentials secret %s has no value under key %q (it must hold the cleartext admin password)",
+			adminSecretName, passwordKey)
+	}
 	// Username precedence: Secret "username" key, then spec.identity.admin.username,
 	// then the "admin" default.
 	if adminUsername == "" {

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -197,11 +197,23 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 	adminSecret := &corev1.Secret{}
 	adminSecretName := ds.GetAdminCredentialsSecretName()
 
-	// If user provided admin password via spec, use that Secret
+	// passwordKey is the Secret key holding the admin password (cleartext). For
+	// the operator-managed auto-generated Secret this is always "password"; for a
+	// user-provided PasswordSecretRef it is the caller's chosen key. Reading a
+	// fixed "password" key for the user case was a bug — it ignored ref.Key and
+	// read an empty value, so admin login failed and the server never reached Ready.
+	passwordKey := "password"
+
+	// If user provided admin password via spec, use that Secret + key.
+	var specAdminUsername string
 	if ds.Spec.Identity != nil && ds.Spec.Identity.Admin != nil &&
 		ds.Spec.Identity.Admin.PasswordSecretRef != nil {
 		ref := ds.Spec.Identity.Admin.PasswordSecretRef
 		adminSecretName = ref.Name
+		if ref.Key != "" {
+			passwordKey = ref.Key
+		}
+		specAdminUsername = ds.Spec.Identity.Admin.Username
 	}
 
 	if err := r.Get(ctx, client.ObjectKey{
@@ -212,7 +224,12 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 	}
 
 	adminUsername := string(adminSecret.Data["username"])
-	adminPassword := string(adminSecret.Data["password"])
+	adminPassword := string(adminSecret.Data[passwordKey])
+	// Username precedence: Secret "username" key, then spec.identity.admin.username,
+	// then the "admin" default.
+	if adminUsername == "" {
+		adminUsername = specAdminUsername
+	}
 	if adminUsername == "" {
 		adminUsername = "admin"
 	}
@@ -361,10 +378,17 @@ func (r *DittoServerReconciler) cleanupOperatorServiceAccount(ctx context.Contex
 	// Read admin credentials
 	adminSecret := &corev1.Secret{}
 	adminSecretName := ds.GetAdminCredentialsSecretName()
+	passwordKey := "password"
+	var specAdminUsername string
 
 	if ds.Spec.Identity != nil && ds.Spec.Identity.Admin != nil &&
 		ds.Spec.Identity.Admin.PasswordSecretRef != nil {
-		adminSecretName = ds.Spec.Identity.Admin.PasswordSecretRef.Name
+		ref := ds.Spec.Identity.Admin.PasswordSecretRef
+		adminSecretName = ref.Name
+		if ref.Key != "" {
+			passwordKey = ref.Key
+		}
+		specAdminUsername = ds.Spec.Identity.Admin.Username
 	}
 
 	if err := r.Get(ctx, client.ObjectKey{
@@ -380,7 +404,10 @@ func (r *DittoServerReconciler) cleanupOperatorServiceAccount(ctx context.Contex
 	}
 
 	adminUsername := string(adminSecret.Data["username"])
-	adminPassword := string(adminSecret.Data["password"])
+	adminPassword := string(adminSecret.Data[passwordKey])
+	if adminUsername == "" {
+		adminUsername = specAdminUsername
+	}
 	if adminUsername == "" {
 		adminUsername = "admin"
 	}

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -184,6 +184,67 @@ func TestProvisionOperatorAccount_Success(t *testing.T) {
 	}
 }
 
+// TestProvisionOperatorAccount_UserProvidedPasswordKey is a regression test for
+// the bug where the reconciler read a hardcoded Data["password"] key and ignored
+// the user's passwordSecretRef.Key — yielding an empty password, a failed admin
+// login, and a server that never reached Ready. The referenced Secret here has
+// ONLY the user's chosen key (no "password" key), so the old code would send an
+// empty password and the mock login (which verifies the cleartext) would reject.
+func TestProvisionOperatorAccount_UserProvidedPasswordKey(t *testing.T) {
+	const userKey = "adminpw"
+	const userPass = "user-chosen-cleartext-pass"
+
+	ds := newTestDittoServer("test-server", "default")
+	ds.Spec.Identity = &dittoiov1alpha1.IdentityConfig{
+		Admin: &dittoiov1alpha1.AdminConfig{
+			Username: "admin",
+			PasswordSecretRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "user-admin-secret"},
+				Key:                  userKey,
+			},
+		},
+	}
+
+	// User-provided Secret carries the password ONLY under their chosen key.
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-admin-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{userKey: []byte(userPass)},
+	}
+
+	r := setupAuthReconciler(t, ds, adminSecret)
+
+	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
+		"POST /api/v1/auth/login": func(w http.ResponseWriter, req *http.Request) {
+			var body struct {
+				Username string `json:"username"`
+				Password string `json:"password"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			// The admin login must carry the cleartext read from ref.Key. The
+			// subsequent operator-account login uses a separately generated
+			// password, so only assert on the admin login here.
+			if body.Username == "admin" && body.Password != userPass {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"error":"bad password"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(tokenJSON("test-access-token", 900))
+		},
+		"POST /api/v1/users": func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"1","username":"k8s-operator","role":"operator"}`))
+		},
+	})
+
+	if _, err := r.provisionOperatorAccount(context.Background(), ds, server.URL); err != nil {
+		t.Fatalf("provisionOperatorAccount must read passwordSecretRef.Key and log in with the cleartext: %v", err)
+	}
+}
+
 func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 	ds := newTestDittoServer("test-server", "default")
 

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -223,13 +223,16 @@ func TestProvisionOperatorAccount_UserProvidedPasswordKey(t *testing.T) {
 				Password string `json:"password"`
 			}
 			_ = json.NewDecoder(req.Body).Decode(&body)
-			// The admin login must carry the cleartext read from ref.Key. The
-			// subsequent operator-account login uses a separately generated
-			// password, so only assert on the admin login here.
-			if body.Username == "admin" && body.Password != userPass {
-				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"error":"bad password"}`))
-				return
+			// The operator-account login uses a separately generated password, so
+			// accept it. Every OTHER login is the admin bootstrap and must carry
+			// BOTH the expected admin username AND the cleartext read from ref.Key —
+			// a wrong username or password here means the fix regressed.
+			if body.Username != dittoiov1alpha1.OperatorServiceAccountUsername {
+				if body.Username != "admin" || body.Password != userPass {
+					w.WriteHeader(http.StatusUnauthorized)
+					w.Write([]byte(`{"error":"bad admin credentials"}`))
+					return
+				}
 			}
 			w.WriteHeader(http.StatusOK)
 			w.Write(tokenJSON("test-access-token", 900))

--- a/k8s/dittofs-operator/internal/controller/config/config.go
+++ b/k8s/dittofs-operator/internal/controller/config/config.go
@@ -18,13 +18,18 @@ const (
 	// TerminationGracePeriodSeconds from it so the grace period and the server's
 	// per-stage shutdown budget stay coupled.
 	DefaultShutdownTimeoutSeconds = 30
-	DefaultSQLitePath             = "/data/controlplane/controlplane.db"
-	DefaultAPIPort                = 8080
-	DefaultAccessDuration         = "15m"
-	DefaultRefreshDuration        = "168h" // 7 days
-	DefaultCachePath              = "/data/cache"
-	DefaultCacheSize              = "1GB"
-	DefaultAdminUsername          = "admin"
+	// DefaultSQLitePath lives UNDER the persistent "metadata" PVC (mounted at
+	// /data/metadata) so the control-plane DB — which holds the metadata-store
+	// registry and share definitions — survives pod restart/reschedule. A path
+	// outside a PVC (e.g. /data/controlplane) sits on the ephemeral container
+	// overlay and is wiped on every restart, silently orphaning all on-disk data.
+	DefaultSQLitePath      = "/data/metadata/controlplane/controlplane.db"
+	DefaultAPIPort         = 8080
+	DefaultAccessDuration  = "15m"
+	DefaultRefreshDuration = "168h" // 7 days
+	DefaultCachePath       = "/data/cache"
+	DefaultCacheSize       = "1GB"
+	DefaultAdminUsername   = "admin"
 )
 
 // GenerateDittoFSConfig generates DittoFS configuration YAML from the CRD spec.

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -1295,12 +1295,18 @@ func buildSecretEnvVars(dittoServer *dittoiov1alpha1.DittoServer) []corev1.EnvVa
 		false,
 	))
 
-	// Admin password hash (optional - only if user configured it)
+	// Admin password (optional - only if user configured it). The referenced
+	// Secret key must hold the admin password in CLEARTEXT: the server bootstraps
+	// the admin user from DITTOFS_ADMIN_INITIAL_PASSWORD (hashing it itself) and
+	// has no consumed password-hash bootstrap path. Injecting a bcrypt hash here
+	// was a no-op — the server ignored it and generated a random password that
+	// neither the user nor the operator knew, so admin login (and thus operator
+	// service-account provisioning) failed and the server never reached Ready.
 	if dittoServer.Spec.Identity != nil && dittoServer.Spec.Identity.Admin != nil &&
 		dittoServer.Spec.Identity.Admin.PasswordSecretRef != nil {
 		ref := dittoServer.Spec.Identity.Admin.PasswordSecretRef
 		envVars = append(envVars, secretEnvVar(
-			"DITTOFS_ADMIN_PASSWORD_HASH",
+			"DITTOFS_ADMIN_INITIAL_PASSWORD",
 			ref.Name,
 			ref.Key,
 			false,


### PR DESCRIPTION
Fixes 5 audit findings in the DittoFS Kubernetes operator (`k8s/dittofs-operator/`), all **live-validated end-to-end on a real single-node k3s cluster** (Scaleway VM, all store types).

## Fixes

- **#1118 (HIGH)** — admin `passwordSecretRef` path was broken end-to-end: the reconciler read a hardcoded `Data["password"]` key (ignoring `ref.Key`) and the controller injected `DITTOFS_ADMIN_PASSWORD_HASH`, which the server never consumes (it only honors cleartext `DITTOFS_ADMIN_INITIAL_PASSWORD`). Admin login always failed → operator never provisioned its service account → `DittoServer` never reached `Ready`. Now both the provision and cleanup paths read `ref.Key` + spec admin username, and the controller injects the cleartext as `INITIAL_PASSWORD`. New regression test `TestProvisionOperatorAccount_UserProvidedPasswordKey`.
- **#1122 (HIGH)** — the SQLite control-plane DB defaulted to `/data/controlplane`, which is on the **ephemeral container overlay** (no PVC). Every pod restart/reschedule wiped all metadata-store and share definitions and orphaned the on-disk data. Relocated the default (and the explicit sample paths) under the persistent `metadata` PVC (`/data/metadata/controlplane`).
- **#1119 (HIGH)** — every sample CR set `spec.nfsPort`, which the CRD has no field for → strict-decode rejection on `kubectl apply`. Removed.
- **#1120 (MED)** — documented `spec.adapterServices.type` (defaults `LoadBalancer`; bare clusters like k3s/kind need `NodePort` for a reachable NFS/SMB endpoint).
- **#1121 (LOW)** — from-source image build was broken: bumped builder to `golang:1.25` (matches `go.mod`), dropped `go build -a`, build `./cmd`, and added `!**/` to `.dockerignore` (the `**` + `!**/*.go` allowlist excluded directory entries so the build failed with `stat /workspace/cmd: directory not found`).

Also switched all sample admin secrets from bcrypt-hash to cleartext (the only working bootstrap), per the #1118 contract.

## Live validation on k3s (operator image built from this branch)

- ✅ #1118 — applied a sample CR **with** `passwordSecretRef` (cleartext secret) → `Ready=True`, `Authenticated=True` in ~25s (was stuck `NotAuthenticated` forever).
- ✅ #1119 — all sample CRs apply cleanly (`kubectl apply --dry-run=client` + live apply).
- ✅ #1122 — created badger+fs stores and a share, `kubectl delete pod` → **stores + share survived** (control-plane DB now on the persistent PVC). Previously 0/0 after restart.
- ✅ #1120 — adapter NFS/SMB Services created; NodePort reachable.
- ✅ #1121 — operator image builds from source and runs.

Gates: `go build`/`go vet`/`gofmt` clean; operator unit tests pass; independent code review (2 issues found and fixed: cleanup-path `ref.Key`, remaining samples).
