### PR TITLE
docs: fix stale references (pkg/blockstore→pkg/block, phantom cache.size_mib, store contracts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Block-level compression on remote stores (opt-in).** A new
-  `pkg/blockstore/compression` decorator transparently compresses block
+  `pkg/block/compression` decorator transparently compresses block
   payloads before upload and decompresses on download. Configured per
   remote via the `compression` key in the block-store config JSON
   (`{ "compression": { "algo": "zstd" } }` or `{ "compression": { "algo": "lz4" } }`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,8 @@ composition layer over six sub-services: `adapters/`, `stores/`, `shares/`, `mou
    `ErrAccess`, `ErrExist`, `ErrNotEmpty`, …). Log expected errors at `Debug`, unexpected at `Error`.
 
 7. **Store contracts** live in `pkg/metadata/storetest/` — any new metadata backend must pass
-   that conformance suite. Same for `pkg/block/local/localtest/` and
-   `pkg/block/remote/remotetest/`.
+   that conformance suite. Block stores have a unified suite in `pkg/block/blockstoretest/`
+   (`BlockStoreConformance` + `BlockStoreAppendConformance`).
 
 ## Commits & PRs
 

--- a/bench/blockstore/doc.go
+++ b/bench/blockstore/doc.go
@@ -1,5 +1,5 @@
 // Package blockstore contains exported workload drivers for the
-// pkg/blockstore engine. Engine-backed workloads share one entry
+// pkg/block engine. Engine-backed workloads share one entry
 // point — RunWorkload(ctx, *engine.Store, Opts) Result — which
 // dispatches on Opts.Workload, seeds the working set outside the
 // timed region, runs Opts.Ops iterations, and returns Result

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,8 +197,8 @@ DittoFS uses a three-tier storage model for block data:
 │  - Internal sequential prefetch     │
 │    (3-trigger threshold)            │
 │  - Cross-file dedup                 │
-│  - Configurable budget per share    │
-│    (cache.size_mib, default 256)    │
+│  - RAM budget auto-sized per share  │
+│    from available system memory     │
 │  - Volatile (lost on restart)       │
 └──────────────┬──────────────────────┘
                │ cache miss
@@ -1116,7 +1116,11 @@ exception in `gc.go`.
 
 The `Cache` type (`pkg/block/engine/cache.go`) is keyed solely by
 `ContentHash`. It combines read buffering and prefetch into a single
-per-share type with a single budget (`cache.size_mib`, default 256 MiB).
+per-share type. The cache is **in-memory (RAM-only), CAS-keyed, and
+volatile** — there is no cache-budget config knob. Its byte budget
+(`maxBytes`, passed to `NewCache`) is **auto-deduced from available system
+memory at startup** (`AvailableMemory / 8`, clamped to a floor; see
+`pkg/block/defaults.go`), wired into the engine as `ReadBufferBytes`.
 Two files reading the same chunk hit the same entry (cross-file dedup).
 
 ```go
@@ -1130,10 +1134,11 @@ suppress speculative prefetch on accidental two-block runs in random-IO
 workloads). Bounded concurrency: 4 worker goroutines per cache by default.
 LRU eviction.
 
-Single-copy reads: on Linux/Darwin, `readFromCAS` (`cache_mmap_unix.go`)
-`mmap`s the local CAS chunk and `copy(dest, mapped[offset:])` once. Chunks
-below 64 KiB use `os.ReadFile` (mmap setup overhead dominates tiny reads).
-Windows uses `os.ReadFile` only.
+Cache misses load through `local.Get` — a single content-addressed local
+read that returns a freshly allocated buffer, which the Cache copies into its
+LRU slot. There is no `mmap`/page-cache fast path on any platform (the cache
+is RAM-only); the allocation simply moves earlier in the pipeline than the
+former mmap-then-copy design.
 
 `InvalidateFile` is **surgical**: the caller passes only the hashes that
 disappeared from the file, so other files still referencing those hashes
@@ -1155,9 +1160,10 @@ threading, so changes to the read/write path stay confined to the helpers.
   last-run summary at `<localStore>/audit-state/last-inv02.json`. See
   `docs/CLI.md` for the full reference and `docs/FAQ.md` for operator
   guidance.
-- Cache and prefetch knobs (`cache.size_mib`, `cache.prefetch_threshold`,
-  `cache.prefetch_max_depth`, `cache.prefetch_workers`) are documented
-  in `docs/CONFIGURATION.md`.
+- The cache has no operator-facing config knobs: its RAM budget is
+  auto-deduced from available system memory at startup (see
+  `pkg/block/defaults.go`), the sequential-prefetch trigger (3 consecutive
+  reads) is fixed, and the prefetch worker count defaults to 4 in code.
 
 ## File-Level Dedup: ObjectID + Merkle Root
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -317,7 +317,7 @@ Related glossary terms: [TLS / mTLS](GLOSSARY.md#authentication).
 
 ### 6. Block Store Configuration
 
-Per-share block storage is configured via `dfsctl store` / `dfsctl share` commands (not the server config file). Each share owns an isolated local storage directory plus a reference to a remote store (S3 or filesystem). The block store lives in `pkg/blockstore/engine/` and composes a local tier, a remote tier, the unified CAS-keyed in-memory `Cache`, a syncer (async local-to-remote transfer), and a garbage collector.
+Per-share block storage is configured via `dfsctl store` / `dfsctl share` commands (not the server config file). Each share owns an isolated local storage directory plus a reference to a remote store (S3 or filesystem). The block store lives in `pkg/block/engine/` and composes a local tier, a remote tier, the unified CAS-keyed in-memory `Cache`, a syncer (async local-to-remote transfer), and a garbage collector.
 
 #### Append-log tier
 
@@ -350,35 +350,30 @@ The local `fs` store requires a metadata backend that implements
 `metadata.RollupStore` to persist each log's `rollup_offset`; memory, badger,
 and postgres all qualify.
 
-#### Syncer + GC knobs
+#### GC knobs
 
 The CAS write path uses an async syncer and a fail-closed mark-sweep
-garbage collector. Their knobs live inside the per-share local block store's
-`config` JSON under the `syncer` and `gc` sub-maps:
+garbage collector. The syncer's sizing (upload concurrency, claim timeout,
+etc.) is **not** an operator-facing config section — it is auto-deduced from
+system resources at startup and constructed in code; there is no `syncer:`
+config block (a stale `syncer:` section in a config file is tolerated but
+ignored, logged as an unknown key).
+
+The mark-sweep GC is the one tunable surface, configured via the top-level
+`gc:` server-config section:
 
 ```yaml
-blockstore:
-  syncer:
-    tick: 30s                   # Periodic sync interval. Default 30s.
-    upload_concurrency: 8       # Parallel uploads per share.
-                                # Default 8. Caps S3 connections per
-                                # share; predictable throughput.
-    claim_timeout: 10m          # Janitor at syncer Start requeues any
-                                # Syncing row whose last_sync_attempt_at
-                                # is older than this back to Pending.
-                                # Default 10m. Tune lower for workloads
-                                # with strict RPO; higher for slow links.
-  gc:
-    grace_period: 1h            # Objects whose LastModified is newer than
-                                # (snapshot - grace_period) are NEVER
-                                # deleted. Default 1h. Values in (0, 5m)
-                                # are REJECTED at config load; values in
-                                # [5m, 10m) are accepted but emit a
-                                # warning. The cushion protects in-flight
-                                # uploads whose metadata-txn lands after
-                                # the snapshot.
-    dry_run_sample_size: 1000   # Maximum candidate keys reported in
-                                # --dry-run mode. Default 1000.
+gc:
+  grace_period: 1h            # Objects whose LastModified is newer than
+                              # (snapshot - grace_period) are NEVER
+                              # deleted. Default 1h. Values in (0, 5m)
+                              # are REJECTED at config load; values in
+                              # [5m, 10m) are accepted but emit a
+                              # warning. The cushion protects in-flight
+                              # uploads whose metadata-txn lands after
+                              # the snapshot.
+  dry_run_sample_size: 1000   # Maximum candidate keys reported in
+                              # --dry-run mode. Default 1000.
 ```
 
 **Tuning guidance:**
@@ -389,23 +384,12 @@ blockstore:
   hashes_marked / objects_swept ratio for your workload, then schedule
   the real run via cron at the cadence that matches your delete rate.
   No periodic-GC scheduler ships today; trigger GC on demand or via cron.
-- `syncer.upload_concurrency` × `syncer.tick` × average chunk size
-  (~4 MiB with the default FastCDC) bounds steady-state upload
-  throughput per share.
-- `syncer.claim_timeout` controls how aggressively the restart-recovery
-  janitor requeues stuck `Syncing` rows: shorter values surface stalls
-  faster, longer values tolerate slow remotes. The default 10m fits
-  most S3 workloads.
 - `gc.grace_period` MUST be longer than your worst-case
   metadata-commit latency after a successful PUT. The default 1h is
   comfortable for any commit path that completes in seconds.
 
-Env-var mapping (dot-path convention; viper binds the top-level `syncer`
-and `gc` blocks directly, with no `blockstore.` prefix):
-`DITTOFS_SYNCER_TICK`,
-`DITTOFS_SYNCER_CLAIM_BATCH_SIZE`,
-`DITTOFS_SYNCER_UPLOAD_CONCURRENCY`,
-`DITTOFS_SYNCER_CLAIM_TIMEOUT`,
+Env-var mapping (dot-path convention; the top-level `gc` block binds
+directly):
 `DITTOFS_GC_GRACE_PERIOD`,
 `DITTOFS_GC_DRY_RUN_SAMPLE_SIZE`.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -287,30 +287,40 @@ DittoFS uses a Service-oriented architecture where **stores are simple CRUD inte
 
 **Block Store (Local):**
 
-1. Implement `pkg/blockstore/local.LocalStore` interface (ReadAt, WriteAt, Delete, Exists, Flush, List, Close)
-2. Support random-access reads/writes
+1. Implement `pkg/block/local.LocalStore` interface. It embeds the
+   content-addressed `block.BlockStoreAppend` surface (`Put`, `Get`,
+   `GetRange`, `Has`, `Delete`, `Head`, `Walk`, plus `AppendWrite` /
+   `DeleteAppendLog`) and adds per-payload admin, lifecycle, rollup-drain,
+   and retention methods — see `pkg/block/local/local.go` for the full list.
+2. Storage is content-addressed (keyed by `block.ContentHash`), not by
+   block ID/offset
 3. Each share gets an isolated local storage directory
-4. Test with conformance suite in `pkg/blockstore/local/localtest/`
+4. Test with the conformance suite in `pkg/block/blockstoretest/`
+   (`BlockStoreConformance` for the CAS contract, `BlockStoreAppendConformance`
+   for the append-write absorber)
 
 **Block Store (Remote):**
 
-1. Implement `pkg/blockstore/remote.RemoteStore` interface (ReadBlock, WriteBlock, DeleteBlock, HealthCheck, Close)
+1. Implement `pkg/block/remote.RemoteStore` interface. It embeds the
+   content-addressed `block.Store` surface and adds `ReadBlockVerified`,
+   `HealthCheck`, `Healthcheck`, and `Close` — see
+   `pkg/block/remote/remote.go`.
 2. Remote stores are shared across shares via ref counting
-3. Test with conformance suite in `pkg/blockstore/remote/remotetest/`
+3. Test with the `BlockStoreConformance` suite in `pkg/block/blockstoretest/`
 
 Example:
 ```go
-// pkg/blockstore/local/mybackend/store.go
+// pkg/block/local/mybackend/store.go
 type MyLocalStore struct {
     basePath string
 }
 
-func (s *MyLocalStore) ReadAt(ctx context.Context, blockID string, p []byte, offset int64) (int, error) {
-    // Read block data from your backend
+func (s *MyLocalStore) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
+    // Write the chunk to your backend under the content-hash key
 }
 
-func (s *MyLocalStore) WriteAt(ctx context.Context, blockID string, data []byte, offset int64) (int, error) {
-    // Write block data to your backend
+func (s *MyLocalStore) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
+    // Return the chunk bytes addressed by hash (freshly allocated, no aliasing)
 }
 ```
 

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -81,7 +81,7 @@ dfsctl store block remote add \
 Generate a fresh key file (no dedicated subcommand — call the Go helper directly):
 
 ```go
-import "github.com/marmos91/dittofs/pkg/blockstore/encryption/keyprovider"
+import "github.com/marmos91/dittofs/pkg/block/encryption/keyprovider"
 
 bytes, _ := keyprovider.GenerateKeyFile("your-strong-passphrase")
 os.WriteFile("/etc/dittofs/keys/share.key", bytes, 0o600)
@@ -130,7 +130,7 @@ DITTOFS_TEST_KMIP=1 \
   DITTOFS_TEST_KMIP_KEY=test/fixtures/kmip/client.key \
   DITTOFS_TEST_KMIP_CA=test/fixtures/kmip/ca.pem \
   DITTOFS_TEST_KMIP_KEY_UID=<your-key-uid> \
-  go test ./pkg/blockstore/encryption/keyprovider/...
+  go test ./pkg/block/encryption/keyprovider/...
 ```
 
 ## Prior art

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -84,8 +84,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
 Absolutely! Implement either or both of these interfaces:
 
 - **Metadata Store**: `pkg/metadata/Store` interface
-- **Local Block Store**: `pkg/blockstore/local.LocalStore` interface
-- **Remote Block Store**: `pkg/blockstore/remote.RemoteStore` interface
+- **Local Block Store**: `pkg/block/local.LocalStore` interface
+- **Remote Block Store**: `pkg/block/remote.RemoteStore` interface
 
 See [IMPLEMENTING_STORES.md](IMPLEMENTING_STORES.md) for implementation guidelines.
 
@@ -270,7 +270,7 @@ See [CLI.md](CLI.md) for the full reference.
 ### What's a BlockRef?
 
 A `BlockRef` is the 3-tuple `(Hash ContentHash, Offset uint64, Size
-uint32)` defined in `pkg/blockstore/types.go`. `FileAttr.Blocks
+uint32)` defined in `pkg/block/types.go`. `FileAttr.Blocks
 []BlockRef` is the **authoritative content list** for every file: which
 chunks compose the file, where each chunk sits inside the file, and how
 big it is.
@@ -278,7 +278,7 @@ big it is.
 The list is:
 
 - **Sorted by `Offset`** so the engine can binary-search it
-  (`findBlocksForRange` in `pkg/blockstore/engine/range.go`).
+  (`findBlocksForRange` in `pkg/block/engine/range.go`).
 - **Populated on every sync finalization** — the engine returns the
   new `[]BlockRef` from `WriteAt`/`Truncate`/`Delete`/`CopyPayload`
   and the caller persists it in the same metadata transaction.

--- a/docs/IMPLEMENTING_STORES.md
+++ b/docs/IMPLEMENTING_STORES.md
@@ -52,7 +52,7 @@ Implement a custom local store when you need:
 - **Custom eviction**: Access-pattern-aware eviction beyond simple LRU
 - **Encryption at rest**: Hardware-accelerated encryption for local blocks
 
-**Reference implementation**: `pkg/blockstore/local/fs/` (filesystem-backed local store)
+**Reference implementation**: `pkg/block/local/fs/` (filesystem-backed local store)
 
 ### Remote Store Use Cases
 
@@ -62,7 +62,7 @@ Implement a custom remote store when you need:
 - **Specialized storage**: Tape archives, HSM systems, data lakes
 - **Tiering**: Automatic hot/cold data movement based on access patterns
 
-**Reference implementation**: `pkg/blockstore/remote/s3/` (S3-backed remote store)
+**Reference implementation**: `pkg/block/remote/s3/` (S3-backed remote store)
 
 ## Understanding the Architecture
 
@@ -159,39 +159,46 @@ with batches of 1000 rows.
 
 ### FileBlockStore narrowing
 
-`pkg/blockstore.FileBlockStore` is exactly **6 hash-keyed CRUD methods**.
-Backend implementations are simpler; engine-internal helpers live on a
-separate wider interface.
+`pkg/block.FileBlockStore` is the narrow public FileBlock surface.
+Backend implementations are simpler than the engine-internal helpers, which
+live on a separate wider interface.
 
 ```go
-// pkg/blockstore/store.go
+// pkg/block/fileblock.go
 type FileBlockStore interface {
-    // GetByHash looks up the FileBlock with the given content hash.
-    // Returns ErrFileBlockNotFound when no row matches.
+    // GetByHash returns any FileBlock with the given content hash, or
+    // (nil, nil) when absent (multiple rows may share a hash; best-effort).
     GetByHash(ctx context.Context, hash ContentHash) (*FileBlock, error)
 
-    // Put inserts or updates a FileBlock keyed by hash.
-    Put(ctx context.Context, fb *FileBlock) error
+    // Put creates or replaces a FileBlock by ID (upsert by ID, not hash).
+    Put(ctx context.Context, block *FileBlock) error
 
-    // Delete removes the FileBlock with the given hash. Idempotent —
-    // deleting a non-existent hash is not an error.
-    Delete(ctx context.Context, hash ContentHash) error
+    // Delete removes a FileBlock by ID. Returns ErrFileBlockNotFound if absent.
+    Delete(ctx context.Context, id string) error
 
-    // IncrementRefCount atomically bumps the FileBlock's RefCount by 1.
-    IncrementRefCount(ctx context.Context, hash ContentHash) error
+    // IncrementRefCount atomically bumps RefCount for the given FileBlock id.
+    IncrementRefCount(ctx context.Context, id string) error
 
-    // DecrementRefCount atomically decrements RefCount; returns the new
-    // value. Callers MUST NOT decrement below zero.
-    DecrementRefCount(ctx context.Context, hash ContentHash) (int64, error)
+    // DecrementRefCount atomically decrements; returns the new count.
+    DecrementRefCount(ctx context.Context, id string) (uint32, error)
 
-    // ListPending streams every Pending FileBlock to fn. Used by syncer.
-    ListPending(ctx context.Context, fn func(*FileBlock) error) error
+    // DecrementRefCountAndReap atomically decrements and, if the count hits 0,
+    // deletes the row in the same critical section. Returns the new count.
+    DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error)
+
+    // AddRef atomically increments RefCount on the row indexed by hash
+    // (the dedup LRU hit path). Returns ErrUnknownHash if no row exists.
+    AddRef(ctx context.Context, hash ContentHash, payloadID string, blockRef BlockRef) error
+
+    // ListPending returns up to `limit` Pending FileBlocks older than
+    // `olderThan`, for the syncer claim path.
+    ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*FileBlock, error)
 }
 ```
 
-**Engine-internal companion interface:** `pkg/blockstore.EngineFileBlockStore`
+**Engine-internal companion interface:** `pkg/block.EngineFileBlockStore`
 extends `FileBlockStore` with `GetFileBlock(ctx, id)` and
-`ListFileBlocks(ctx, fn)` for the engine's hot paths. All three built-in
+`ListFileBlocks(ctx, payloadID)` for the engine's hot paths. All three built-in
 backends (memory, badger, postgres) satisfy it without changes — the
 narrow public surface is a documentation concern, not a runtime
 restriction. Custom backends implementing `FileBlockStore` SHOULD also
@@ -206,7 +213,7 @@ per hash for older data; the public `GetByHash` surface hides that detail.
 
 `FileAttr.Blocks []blockstore.BlockRef` is the authoritative content list
 for every file. `BlockRef` is the 3-tuple `(Hash, Offset, Size)` — see
-`pkg/blockstore/types.go`. The list MUST be sorted by `Offset` and is
+`pkg/block/types.go`. The list MUST be sorted by `Offset` and is
 populated on every sync finalization.
 
 Encoding requirements per backend:
@@ -396,68 +403,50 @@ Local stores provide fast, per-share block storage. Each share gets an isolated 
 
 ### The LocalStore Interface
 
-The `pkg/blockstore/local.LocalStore` interface defines the contract:
+The `pkg/block/local.LocalStore` interface defines the contract. Storage is
+**content-addressed** — chunks are keyed by their BLAKE3 `block.ContentHash`,
+not by a block ID + offset. The interface embeds the content-addressed
+`block.BlockStoreAppend` surface and adds lifecycle, per-payload admin,
+rollup-drain, and retention methods. See `pkg/block/local/local.go` for the
+authoritative definition; the embedded CAS contract is:
 
 ```go
-type LocalStore interface {
-    // ReadAt reads block data at the given offset
-    ReadAt(ctx context.Context, blockID string, p []byte, offset int64) (int, error)
+type Store interface { // block.Store, embedded by LocalStore via BlockStoreAppend
+    // Put writes data under the key derived from hash (idempotent for
+    // identical bytes). Returns an error on a zero hash.
+    Put(ctx context.Context, hash ContentHash, data []byte) error
 
-    // WriteAt writes block data at the given offset
-    WriteAt(ctx context.Context, blockID string, data []byte, offset int64) (int, error)
+    // Get returns the chunk bytes addressed by hash (freshly allocated,
+    // never aliasing internal storage). Returns ErrChunkNotFound if absent.
+    Get(ctx context.Context, hash ContentHash) ([]byte, error)
 
-    // Delete removes a block from local storage
-    Delete(ctx context.Context, blockID string) error
+    // GetRange returns the byte sub-range [offset, offset+length).
+    GetRange(ctx context.Context, hash ContentHash, offset, length int64) ([]byte, error)
 
-    // Exists checks if a block exists locally
-    Exists(ctx context.Context, blockID string) (bool, error)
+    // Has reports whether the store holds the object addressed by hash.
+    Has(ctx context.Context, hash ContentHash) (bool, error)
 
-    // Flush ensures all pending writes are persisted
-    Flush(ctx context.Context, blockID string) error
+    // Delete removes the object addressed by hash.
+    Delete(ctx context.Context, hash ContentHash) error
 
-    // List returns all block IDs in local storage
-    List(ctx context.Context) ([]string, error)
+    // Head returns object metadata (size, last-modified) without the body.
+    Head(ctx context.Context, hash ContentHash) (ObjectInfo, error)
 
-    // Close releases resources
-    Close() error
+    // Walk enumerates every stored object. Return ErrStopWalk to exit early.
+    Walk(ctx context.Context, fn func(ObjectInfo) error) error
 }
 ```
 
-### Implementation Pattern
-
-```go
-package mylocal
-
-import (
-    "context"
-)
-
-type MyLocalStore struct {
-    basePath string
-    // Your backend (filesystem, NVMe, etc.)
-}
-
-func New(basePath string) (*MyLocalStore, error) {
-    // Initialize your storage backend
-    return &MyLocalStore{basePath: basePath}, nil
-}
-
-func (s *MyLocalStore) ReadAt(ctx context.Context, blockID string, p []byte, offset int64) (int, error) {
-    // Read block data from your backend
-    // Return bytes read and any error
-}
-
-func (s *MyLocalStore) WriteAt(ctx context.Context, blockID string, data []byte, offset int64) (int, error) {
-    // Write block data to your backend
-    // Return bytes written and any error
-}
-
-// ... implement remaining interface methods
-```
+`BlockStoreAppend` adds `AppendWrite` and `DeleteAppendLog` for the append-log
+write path. `LocalStore` then layers on lifecycle (`Start`, `Close`),
+per-payload admin (`Truncate`, `EvictMemory`, `GetFileSize`, `ListFiles`,
+`ReadPayloadAt`), snapshot drain/reset (`DrainRollups`, `ResetLocalState`),
+and retention policy (`SetRetentionPolicy`, `SetEvictionEnabled`) — consult
+`pkg/block/local/local.go` for the full method set and per-method contract.
 
 ### Reference Implementation
 
-See `pkg/blockstore/local/fs/` for a complete filesystem-backed local store implementation that handles:
+See `pkg/block/local/fs/` for a complete filesystem-backed local store implementation that handles:
 - Per-share isolated directories
 - Atomic writes
 - Block listing for sync operations
@@ -486,13 +475,26 @@ package mylocal_test
 
 import (
     "testing"
-    "github.com/marmos91/dittofs/pkg/blockstore/local/localtest"
+
+    "github.com/marmos91/dittofs/pkg/block"
+    "github.com/marmos91/dittofs/pkg/block/blockstoretest"
 )
 
 func TestMyLocalStore(t *testing.T) {
-    store, cleanup := createTestStore(t)
-    defer cleanup()
-    localtest.RunLocalStoreTests(t, store)
+    // The factory returns a fresh store plus a cleanup closure per subtest.
+    factory := func(t *testing.T) (block.Store, func()) {
+        store, cleanup := createTestStore(t)
+        return store, cleanup
+    }
+    blockstoretest.BlockStoreConformance(t, factory)
+
+    // If your store implements the append-write absorber (block.BlockStoreAppend),
+    // also run the append conformance suite:
+    appendFactory := func(t *testing.T) (block.BlockStoreAppend, func()) {
+        store, cleanup := createTestAppendStore(t)
+        return store, cleanup
+    }
+    blockstoretest.BlockStoreAppendConformance(t, appendFactory)
 }
 ```
 
@@ -502,23 +504,28 @@ Remote stores provide durable block storage shared across shares via ref countin
 
 ### The RemoteStore Interface
 
-The `pkg/blockstore/remote.RemoteStore` interface defines the contract:
+The `pkg/block/remote.RemoteStore` interface defines the contract. Like the
+local store, remote storage is **content-addressed**: the interface embeds the
+CAS `block.Store` surface (`Put`, `Get`, `GetRange`, `Has`, `Delete`, `Head`,
+`Walk` — keyed by `block.ContentHash`) and adds verification + health methods.
+See `pkg/block/remote/remote.go` for the authoritative definition:
 
 ```go
 type RemoteStore interface {
-    // ReadBlock reads an entire block from remote storage
-    ReadBlock(ctx context.Context, blockID string) ([]byte, error)
+    block.Store // CAS Put/Get/GetRange/Has/Delete/Head/Walk
 
-    // WriteBlock writes an entire block to remote storage
-    WriteBlock(ctx context.Context, blockID string, data []byte) error
+    // ReadBlockVerified GETs the object addressed by hash and verifies the
+    // body's BLAKE3 hash matches `expected` before returning bytes. Returns
+    // block.ErrCASContentMismatch on any verification failure.
+    ReadBlockVerified(ctx context.Context, hash block.ContentHash, expected block.ContentHash) ([]byte, error)
 
-    // DeleteBlock removes a block from remote storage
-    DeleteBlock(ctx context.Context, blockID string) error
-
-    // HealthCheck verifies the remote store is accessible
+    // HealthCheck is the legacy error-returning probe used by the syncer.
     HealthCheck(ctx context.Context) error
 
-    // Close releases resources
+    // Healthcheck returns a structured health.Report (satisfies health.Checker).
+    Healthcheck(ctx context.Context) health.Report
+
+    // Close releases resources.
     Close() error
 }
 ```
@@ -530,6 +537,8 @@ package myremote
 
 import (
     "context"
+
+    "github.com/marmos91/dittofs/pkg/block"
 )
 
 type MyRemoteStore struct {
@@ -545,19 +554,25 @@ func New(config Config) (*MyRemoteStore, error) {
     return &MyRemoteStore{client: client, bucket: config.Bucket}, nil
 }
 
-func (s *MyRemoteStore) ReadBlock(ctx context.Context, blockID string) ([]byte, error) {
-    // Fetch block from cloud storage
-    return s.client.GetObject(ctx, s.bucket, blockID)
+// objectKey derives the storage key from the content hash. The CAS key is
+// the hash; backends typically use its hex form, optionally sharded.
+func (s *MyRemoteStore) objectKey(hash block.ContentHash) string {
+    return hash.String()
 }
 
-func (s *MyRemoteStore) WriteBlock(ctx context.Context, blockID string, data []byte) error {
-    // Upload block to cloud storage
-    return s.client.PutObject(ctx, s.bucket, blockID, data)
+func (s *MyRemoteStore) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
+    // Fetch the chunk addressed by hash. Return block.ErrChunkNotFound if absent.
+    return s.client.GetObject(ctx, s.bucket, s.objectKey(hash))
 }
 
-func (s *MyRemoteStore) DeleteBlock(ctx context.Context, blockID string) error {
-    // Remove block from cloud storage (idempotent)
-    err := s.client.DeleteObject(ctx, s.bucket, blockID)
+func (s *MyRemoteStore) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
+    // Upload the chunk under its content-hash key (idempotent for identical bytes).
+    return s.client.PutObject(ctx, s.bucket, s.objectKey(hash), data)
+}
+
+func (s *MyRemoteStore) Delete(ctx context.Context, hash block.ContentHash) error {
+    // Remove the chunk (idempotent).
+    err := s.client.DeleteObject(ctx, s.bucket, s.objectKey(hash))
     if err != nil && !isNotFoundError(err) {
         return err
     }
@@ -572,6 +587,9 @@ func (s *MyRemoteStore) HealthCheck(ctx context.Context) error {
 func (s *MyRemoteStore) Close() error {
     return s.client.Close()
 }
+
+// ... implement the remaining block.Store methods (GetRange, Has, Head, Walk),
+// ReadBlockVerified, and Healthcheck — see pkg/block/remote/s3 for a full example.
 ```
 
 ### Ref Counting
@@ -585,7 +603,7 @@ This means your `Close()` implementation should release all resources (connectio
 
 ### Reference Implementation
 
-See `pkg/blockstore/remote/s3/` for a production S3 remote store implementation with:
+See `pkg/block/remote/s3/` for a production S3 remote store implementation with:
 - Configurable retry with exponential backoff
 - Health check via HEAD bucket
 - Efficient multipart uploads for large blocks
@@ -660,21 +678,27 @@ package myremote_test
 
 import (
     "testing"
-    "github.com/marmos91/dittofs/pkg/blockstore/remote/remotetest"
+
+    "github.com/marmos91/dittofs/pkg/block"
+    "github.com/marmos91/dittofs/pkg/block/blockstoretest"
 )
 
 func TestMyRemoteStore(t *testing.T) {
-    store, cleanup := createTestStore(t)
-    defer cleanup()
-    remotetest.RunRemoteStoreTests(t, store)
+    factory := func(t *testing.T) (block.Store, func()) {
+        store, cleanup := createTestStore(t)
+        return store, cleanup
+    }
+    blockstoretest.BlockStoreConformance(t, factory)
 }
 ```
 
-The conformance suite (`remotetest`) includes scenarios for
-`WriteBlockWithHash` (header is set; key shape matches `cas/...`;
-re-PUT is idempotent) and `ReadBlockVerified` (round-trip succeeds;
-header-mismatch returns `ErrCASContentMismatch`; body-mismatch returns
-`ErrCASContentMismatch`; corrupt bytes never surface upstream).
+The `BlockStoreConformance` suite pins the CAS contract: `Put` + `Get`
+round-trip with no aliasing, idempotent re-`Put` of identical bytes,
+`Get`/`GetRange`/`Has`/`Head`/`Delete` semantics, and `Walk` enumeration.
+The dedicated `ReadBlockVerified` path on `RemoteStore` (round-trip succeeds;
+body-mismatch returns `block.ErrCASContentMismatch`; corrupt bytes never
+surface upstream) is exercised separately — see `pkg/block/remote/s3` for the
+verification tests.
 
 ## Best Practices
 
@@ -708,7 +732,7 @@ func (s *MyStore) ReadBlock(ctx context.Context, blockID string) ([]byte, error)
 
 ## Testing Your Implementation
 
-1. **Conformance tests**: Run the provided test suites (`localtest`/`remotetest`)
+1. **Conformance tests**: Run the provided test suite (`pkg/block/blockstoretest`)
 2. **Concurrency tests**: Verify thread safety with parallel reads/writes
 3. **Error handling tests**: Test behavior with canceled contexts, network failures
 4. **Integration tests**: Test with the full DittoFS stack (create share, mount, read/write)
@@ -753,12 +777,12 @@ Users can then create your store via CLI:
 
 ## Additional Resources
 
-- **Interface Definitions**: `pkg/blockstore/local/local.go`, `pkg/blockstore/remote/remote.go`
+- **Interface Definitions**: `pkg/block/local/local.go`, `pkg/block/remote/remote.go`
 - **Reference Implementations**:
-  - Local: `pkg/blockstore/local/fs/`, `pkg/blockstore/local/memory/`
-  - Remote: `pkg/blockstore/remote/s3/`, `pkg/blockstore/remote/memory/`
+  - Local: `pkg/block/local/fs/`, `pkg/block/local/memory/`
+  - Remote: `pkg/block/remote/s3/`, `pkg/block/remote/memory/`
   - Metadata: `pkg/metadata/store/memory/`, `pkg/metadata/store/badger/`, `pkg/metadata/store/postgres/`
-- **Conformance Tests**: `pkg/blockstore/local/localtest/`, `pkg/blockstore/remote/remotetest/`, `pkg/metadata/storetest/`
+- **Conformance Tests**: `pkg/block/blockstoretest/` (block stores), `pkg/metadata/storetest/` (metadata stores)
 - **Architecture**: `docs/ARCHITECTURE.md`
 - **Configuration**: `docs/CONFIGURATION.md`
 - **Contributing**: `docs/CONTRIBUTING.md`

--- a/internal/adapter/common/cache_invalidator.go
+++ b/internal/adapter/common/cache_invalidator.go
@@ -8,7 +8,7 @@ import (
 // CacheInvalidator is the minimal cache-surface adapter helpers (and the
 // common.CopyPayload helper) depend on for surgical post-transaction
 // invalidation. It is defined here in package common rather than imported
-// from pkg/blockstore/engine so that adapter helpers remain decoupled from
+// from pkg/block/engine so that adapter helpers remain decoupled from
 // the concrete engine.Cache type — the engine's Cache type implements this
 // interface implicitly via its InvalidateFile method.
 //

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -34,7 +34,7 @@ import (
 // caller-supplied context (NOT a txn-bound ctx). The coordinator
 // implementation (per-share runtime wrapper) is responsible for binding
 // its RefCount UPDATEs to whatever txn is currently active for the
-// caller's context — see pkg/blockstore/engine/coordinator.go for the
+// caller's context — see pkg/block/engine/coordinator.go for the
 // contract. The metadata.Transaction passed to fn here is the canonical
 // place where dst's PutFile lands; engine increments piggyback on the
 // same txn through the coordinator's per-impl mechanism.

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -64,7 +64,7 @@ func (f *fakeCoordinator) GetPersistedBlocks(_ context.Context, _ string) ([]blo
 }
 
 // FindByObjectID stub. Adapter-common tests don't exercise short-circuit
-// lookups (those live in pkg/blockstore/engine and pkg/metadata/storetest);
+// lookups (those live in pkg/block/engine and pkg/metadata/storetest);
 // satisfy the interface so the fake satisfies engine.MetadataCoordinator.
 func (f *fakeCoordinator) FindByObjectID(_ context.Context, _ block.ObjectID) ([]block.BlockRef, error) {
 	return nil, nil

--- a/internal/controlplane/api/handlers/migrate_status.go
+++ b/internal/controlplane/api/handlers/migrate_status.go
@@ -62,7 +62,7 @@ type MigrateStatusRuntime interface {
 // and dfsctl share a single contract. Admin-only auth is enforced by
 // the router placing the route inside JWTAuth + RequireAdmin middleware.
 //
-// This file imports `pkg/blockstore/migrate` (the journal type, placed
+// This file imports `pkg/block/migrate` (the journal type, placed
 // in pkg/ from day one for exactly this reason) rather than
 // `cmd/dfsctl/...`, which Go's build system forbids from being imported
 // by internal/.

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -44,9 +44,9 @@ type Meta struct {
 // no opaque "block key" strings appear on this surface.
 //
 // Implementations
-//   - pkg/blockstore/local/fs.FSStore (also implements BlockStoreAppend)
-//   - pkg/blockstore/remote/s3.Store
-//   - pkg/blockstore/remote/memory.Store
+//   - pkg/block/local/fs.FSStore (also implements BlockStoreAppend)
+//   - pkg/block/remote/s3.Store
+//   - pkg/block/remote/memory.Store
 //
 // All methods take ctx context.Context as the first argument and MUST
 // honor cancellation. All hash arguments are the full 32-byte

--- a/pkg/block/blockstoretest/appendlog.go
+++ b/pkg/block/blockstoretest/appendlog.go
@@ -38,7 +38,7 @@ type AppendFactory func(t *testing.T) (block.BlockStoreAppend, func())
 //
 // The three SKIPPED scenarios are exercised by the fs backend via
 // fs-internal `_test.go` files
-// (pkg/blockstore/local/fs/appendlog_internals_test.go) that hold the
+// (pkg/block/local/fs/appendlog_internals_test.go) that hold the
 // scenarios verbatim and call the fs-internal *ForTest probes.
 func BlockStoreAppendConformance(t *testing.T, factory AppendFactory) {
 	t.Helper()
@@ -159,7 +159,7 @@ func testRecreateAfterDeleteAppendLog(t *testing.T, factory AppendFactory) {
 // fs backend continues to exercise this scenario via the legacy
 // fs-internal appendlog_internals_test.go scenarios.
 func testPressureChannelINV05(t *testing.T, factory AppendFactory) {
-	t.Skip("PressureChannel_INV05 is not portable to BlockStoreAppend: requires fs-internal SetMaxLogBytesForTest + LogBytesTotalForTest probes. The fs backend exercises this via pkg/blockstore/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
+	t.Skip("PressureChannel_INV05 is not portable to BlockStoreAppend: requires fs-internal SetMaxLogBytesForTest + LogBytesTotalForTest probes. The fs backend exercises this via pkg/block/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
 }
 
 // testTornWriteRecoveryLSL06 asserts that appending random garbage
@@ -175,9 +175,9 @@ func testPressureChannelINV05(t *testing.T, factory AppendFactory) {
 // on-disk paths or recovery hooks — recovery is a backend-internal
 // concern. The fs backend continues to exercise this scenario via
 // the fs-internal appendlog_internals_test.go scenarios in
-// pkg/blockstore/local/fs/.
+// pkg/block/local/fs/.
 func testTornWriteRecoveryLSL06(t *testing.T, factory AppendFactory) {
-	t.Skip("TornWriteRecovery_LSL06 is not portable to BlockStoreAppend: requires direct on-disk log access + ReopenForTest / IntervalsLenForTest fs-internal probes. The fs backend exercises this via pkg/blockstore/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
+	t.Skip("TornWriteRecovery_LSL06 is not portable to BlockStoreAppend: requires direct on-disk log access + ReopenForTest / IntervalsLenForTest fs-internal probes. The fs backend exercises this via pkg/block/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
 }
 
 // testConcurrentStorm asserts no deadlock and no silent data loss
@@ -202,7 +202,7 @@ func testTornWriteRecoveryLSL06(t *testing.T, factory AppendFactory) {
 // LogBytesTotalForTest / RollupOffsetForTest internal probes for
 // deterministic assertions instead of polling Walk.
 func testConcurrentStorm(t *testing.T, factory AppendFactory) {
-	t.Skip("ConcurrentStorm is not portable to BlockStoreAppend: the only portable rollup-progress hook is polling Walk, which is timing-dependent and flakes on CI runners with slow shared IO. The fs backend exercises this via pkg/blockstore/local/fs/appendlog_internals_test.go using fs-internal probes for deterministic assertions.")
+	t.Skip("ConcurrentStorm is not portable to BlockStoreAppend: the only portable rollup-progress hook is polling Walk, which is timing-dependent and flakes on CI runners with slow shared IO. The fs backend exercises this via pkg/block/local/fs/appendlog_internals_test.go using fs-internal probes for deterministic assertions.")
 }
 
 // testRollupOffsetMonotoneINV03 asserts that if metadata has
@@ -219,5 +219,5 @@ func testConcurrentStorm(t *testing.T, factory AppendFactory) {
 // continues to exercise this scenario via the legacy fs-internal
 // appendlog_internals_test.go scenarios.
 func testRollupOffsetMonotoneINV03(t *testing.T, factory AppendFactory) {
-	t.Skip("RollupOffsetMonotone_INV03 is not portable to BlockStoreAppend: requires header-CRC corruption + ReopenForTest / HeaderRollupOffsetForTest fs-internal probes. The fs backend exercises this via pkg/blockstore/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
+	t.Skip("RollupOffsetMonotone_INV03 is not portable to BlockStoreAppend: requires header-CRC corruption + ReopenForTest / HeaderRollupOffsetForTest fs-internal probes. The fs backend exercises this via pkg/block/local/fs/appendlog_internals_test.go (the scenarios were moved out of the deleted localtest package by Plan 17-06).")
 }

--- a/pkg/block/blockstoretest/conformance.go
+++ b/pkg/block/blockstoretest/conformance.go
@@ -30,7 +30,7 @@ type Factory func(t *testing.T) (block.Store, func())
 // own _test.go files via a backend-specific factory.
 //
 // The scenarios pin the contract documented on the BlockStore interface
-// in pkg/blockstore/blockstore.go
+// in pkg/block/blockstore.go
 //
 //   - Put + Get round-trip with no-aliasing of internal storage.
 //   - Get on an unstored hash returns block.ErrChunkNotFound.
@@ -82,7 +82,7 @@ func BlockStoreConformance(t *testing.T, factory Factory) {
 }
 
 // blake3Sum is the conformance suite's shared hashing helper. It mirrors
-// blake3ContentHash at pkg/blockstore/local/fs/rollup.go:449 — the
+// blake3ContentHash at pkg/block/local/fs/rollup.go:449 — the
 // rollup loop hashes chunk bytes the same way before storing them, so
 // the suite's fixtures share the rollup's content-address contract.
 // Shared with appendlog.go (same package, no import needed).

--- a/pkg/block/blockstoretest/doc.go
+++ b/pkg/block/blockstoretest/doc.go
@@ -1,6 +1,6 @@
 // Package blockstoretest provides a unified conformance suite for the
 // BlockStore and BlockStoreAppend contracts declared in
-// pkg/blockstore/blockstore.go.
+// pkg/block/blockstore.go.
 //
 // Two top-level entrypoints are exposed:
 //
@@ -12,12 +12,12 @@
 //     the fs backend implements BlockStoreAppend and therefore calls
 //     this entrypoint.
 //
-// This package replaces pkg/blockstore/local/localtest and
-// pkg/blockstore/remote/remotetest. The three fs-internal scenarios
+// This package replaces pkg/block/local/localtest and
+// pkg/block/remote/remotetest. The three fs-internal scenarios
 // that cannot be expressed through the interface surface
 // (PressureChannel_INV05, TornWriteRecovery_LSL06,
 // RollupOffsetMonotone_INV03) live in
-// pkg/blockstore/local/fs/appendlog_internals_test.go.
+// pkg/block/local/fs/appendlog_internals_test.go.
 //
 // Each scenario uses a factory that returns a fresh (BlockStore
 // cleanup) pair per subtest, so subtests do not share state and

--- a/pkg/block/chunker/doc.go
+++ b/pkg/block/chunker/doc.go
@@ -5,11 +5,11 @@
 // MaskS biases against short chunks; large-region mask MaskL biases toward
 // the average. Breakpoints are detected via a rolling Gear hash
 // (gear.go). This package is consumed by the local block store's rollup
-// pool (pkg/blockstore/local/fs/rollup.go) and is pure / stateless across
+// pool (pkg/block/local/fs/rollup.go) and is pure / stateless across
 // calls to NewChunker.
 //
 // Boundary-stability guarantee: random 1-4096 byte prefix shifts preserve
 // >=70% of chunk boundaries; enforced by TestChunker_BoundaryStability_70pct.
 //
-// CAS key format: see ContentHash.CASKey() in pkg/blockstore/types.go.
+// CAS key format: see ContentHash.CASKey() in pkg/block/types.go.
 package chunker

--- a/pkg/block/defaults.go
+++ b/pkg/block/defaults.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SystemDetector provides system resource information for deduction.
-// This mirrors sysinfo.Detector but lives in pkg/blockstore to avoid
+// This mirrors sysinfo.Detector but lives in pkg/block to avoid
 // importing internal/ from pkg/. The sysinfo.Detector satisfies this
 // interface structurally (duck typing).
 type SystemDetector interface {

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -15,9 +15,9 @@
 //     (Put / Get / GetRange / Has / Delete / Head / Walk). Idempotent
 //     same-bytes Put, no opaque "block key" strings, every method
 //     takes a context.Context first. Implemented by:
-//     *pkg/blockstore/local/fs.FSStore (local CAS chunks);
-//     *pkg/blockstore/remote/s3.Store (S3-backed CAS);
-//     *pkg/blockstore/remote/memory.Store (in-memory CAS for tests).
+//     *pkg/block/local/fs.FSStore (local CAS chunks);
+//     *pkg/block/remote/s3.Store (S3-backed CAS);
+//     *pkg/block/remote/memory.Store (in-memory CAS for tests).
 //
 //   - BlockStoreAppend — embeds BlockStore and adds AppendWrite +
 //     DeleteAppendLog for the random-write absorber tier (the per-file
@@ -120,7 +120,7 @@
 //
 // The offline one-shot legacy-to-CAS migration ships as the cobra
 // subcommand `dfs migrate-to-cas`, backed by the shared library at
-// pkg/blockstore/migrate/migrate_to_cas.go (MigrateShareToCAS). The
+// pkg/block/migrate/migrate_to_cas.go (MigrateShareToCAS). The
 // command is server-side and offline (refuses to run while the dfs
 // PID lockfile exists), idempotent via a per-share journal
 // (.dittofs-migrate-to-cas.state), and writes the .cas-migrated-v1
@@ -193,12 +193,12 @@
 // them to a specific milestone tag.
 //
 // Apply the markers on the symbol's godoc, not on internal callers
-// the goal is for `grep -rn 'TRANSITIONAL-' ./pkg/blockstore` to
+// the goal is for `grep -rn 'TRANSITIONAL-' ./pkg/block` to
 // enumerate every deferral surface in one pass and for new contributors
 // to recognize the convention without consulting a roadmap.
 //
 // audit: at the close of the write-path RAM-optimization
-// phase, every TRANSITIONAL-NEXT-MILESTONE marker in pkg/blockstore/
+// phase, every TRANSITIONAL-NEXT-MILESTONE marker in pkg/block/
 // points at #519 ("Deferred to v0.17+") — the five v0.17 anchor sites
 // are pinned hot-tail RAM + zstd compression (chunkstore.go), O_DIRECT
 // (appendwrite.go), tmpfs spill (appendlog.go), and cold-cache prefetch

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -32,7 +32,7 @@ import (
 	// entrypoint for reconciliation. It MUST bind
 	// metadata.Store to enumerate FileAttr.Blocks across the share's
 	// directory tree (GetRootHandle, GetFile, ListChildren). Lifting these
-	// helpers into pkg/blockstore would create a circular import.
+	// helpers into pkg/block would create a circular import.
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 

--- a/pkg/block/engine/cache_populated_on_rollup_test.go
+++ b/pkg/block/engine/cache_populated_on_rollup_test.go
@@ -97,7 +97,7 @@ func waitForChunks(t *testing.T, bs *Store, payloadID string, timeout time.Durat
 // . Write data spanning multiple chunks; drive engine.Flush
 // assert every post-rollup chunk hash is reachable in bs.cache.
 //
-// Payload sizing: pkg/blockstore/chunker emits a single chunk for data
+// Payload sizing: pkg/block/chunker emits a single chunk for data
 // up to MinChunkSize (1 MiB) when final=true. To force multiple chunk
 // emissions we write 12 MiB of varied bytes which crosses several
 // FastCDC breakpoints. We then assert all emitted hashes are

--- a/pkg/block/engine/dedup.go
+++ b/pkg/block/engine/dedup.go
@@ -24,7 +24,7 @@ import (
 // finalize machinery so cache invalidation invariants remain identical
 // to the speculative path's hit.
 //
-// ObjectID semantics (verified against pkg/blockstore/objectid.go)
+// ObjectID semantics (verified against pkg/block/objectid.go)
 // ComputeObjectID returns BLAKE3(prefix || h0 || ... || hN-1), so the
 // single-block ObjectID is BLAKE3(prefix || hash(data)) — NOT a bare
 // leaf hash. A previously-quiesced file dedups to this ObjectID only

--- a/pkg/block/engine/doc.go
+++ b/pkg/block/engine/doc.go
@@ -8,12 +8,12 @@
 // package cannot import them back.
 //
 // As of the merge, the previously separate sibling packages
-// pkg/blockstore/{readbuffer,sync,gc} are folded into this package. The merge
+// pkg/block/{readbuffer,sync,gc} are folded into this package. The merge
 // preserves all public behaviour; only the package path, a handful of
 // collision-resolving type/function names, and the package-qualified call
 // sites changed.
 //
-// # Read buffer and prefetch (formerly pkg/blockstore/readbuffer)
+// # Read buffer and prefetch (formerly pkg/block/readbuffer)
 //
 // ReadBuffer is an LRU block buffer that stores full 8MB blocks (matching
 // block.BlockSize) as heap-allocated []byte slices with copy-on-read
@@ -35,7 +35,7 @@
 // Non-blocking submit drops requests when the worker channel is full
 // providing natural backpressure.
 //
-// # Syncer (formerly pkg/blockstore/sync)
+// # Syncer (formerly pkg/block/sync)
 //
 // The syncer is responsible for moving data between the local store and the
 // remote block store (S3 or memory). It handles
@@ -58,7 +58,7 @@
 // The Syncer struct is created via NewSyncer() and requires a LocalStore
 // RemoteStore, and FileBlockStore.
 //
-// # Block garbage collection (formerly pkg/blockstore/gc)
+// # Block garbage collection (formerly pkg/block/gc)
 //
 // Orphan blocks are blocks that exist in the block store but have no
 // corresponding metadata. This can happen when file deletion fails after

--- a/pkg/block/engine/eager_dedup_test.go
+++ b/pkg/block/engine/eager_dedup_test.go
@@ -66,7 +66,7 @@ func (r *recordingPutCache) InvalidateFile(string, []block.ContentHash) {}
 func (r *recordingPutCache) Stats() CacheStats                          { return CacheStats{} }
 func (r *recordingPutCache) Close() error                               { return nil }
 
-// hashContent mirrors blake3ContentHash from pkg/blockstore/local/fs/rollup.go
+// hashContent mirrors blake3ContentHash from pkg/block/local/fs/rollup.go
 // (private to that package). Tests need the same content-address hash
 // so seeded ObjectIDs match what the production eager-dedup path
 // computes from arbitrary test data.

--- a/pkg/block/engine/perf_bench_phase12_test.go
+++ b/pkg/block/engine/perf_bench_phase12_test.go
@@ -14,7 +14,7 @@
 // Or directly
 //
 //	go test -bench BenchmarkPerfGate_Phase12 -benchtime=10s -run=^$ \
-//	    ./pkg/blockstore/engine/...
+//	    ./pkg/block/engine/...
 package engine
 
 import (
@@ -195,7 +195,7 @@ func BenchmarkRandRead_Phase12(b *testing.B) {
 // via
 //
 //	go test -bench BenchmarkPerfGate_Phase12 -benchtime=10s -run=^$ \
-//	    ./pkg/blockstore/engine/...
+//	    ./pkg/block/engine/...
 //
 // Local runs: make bench-phase12.
 //
@@ -250,7 +250,7 @@ func BenchmarkPerfGate_Phase12RandReadRegression(b *testing.B) {
 		b.Fatalf("rand-read perf gate FAILED: %.0f IOPS, floor %.0f (microbench baseline %.0f, tolerance %.0f%%). "+
 			"Likely culprits: findBlocksForRange linearisation, Cache.OnRead lock contention, "+
 			"loadByHash regression. Profile with: go test -bench BenchmarkPerfGate_Phase12 "+
-			"-cpuprofile=cpu.prof ./pkg/blockstore/engine/...",
+			"-cpuprofile=cpu.prof ./pkg/block/engine/...",
 			opsPerSec, floor, microbenchFloorIOPS, tolerance*100)
 	}
 }

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -72,7 +72,7 @@ func (bs *Store) Exists(ctx context.Context, payloadID string) (bool, error) {
 //
 // WriteAt remains a per-write append into the local store — it does
 // NOT chunk or assemble BlockRefs. The FastCDC chunker runs at the
-// local-store rollup layer (pkg/blockstore/local/fs/rollup.go
+// local-store rollup layer (pkg/block/local/fs/rollup.go
 // rollupFile), which produces Pending FileBlocks carrying chunk
 // hashes. Syncer.Flush projects ListFileBlocks(payloadID) into the
 // canonical sorted []BlockRef list at quiesce time and invokes either
@@ -103,7 +103,7 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 	bs.cache.OnRead(payloadID, nil, 0)
 	// the FastCDC chunker output is
 	// produced by the local-store rollup pump
-	// (pkg/blockstore/local/fs/rollup.go:rollupFile) and lands as
+	// (pkg/block/local/fs/rollup.go:rollupFile) and lands as
 	// Pending FileBlocks with chunk-hash populated. The canonical
 	// []BlockRef projection is built at Flush time from
 	// ListFileBlocks(payloadID) — see Syncer.snapshotPendingBlockRefs

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -326,7 +326,7 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	// blocking the explicit caller until the periodic uploader's tick
 	// finishes could span minutes of remote I/O and translate into
 	// protocol-client D-state. Callers MUST NOT spin-retry: see godoc
-	// above and the Flusher.Flush contract in pkg/blockstore.
+	// above and the Flusher.Flush contract in pkg/block.
 	if !m.uploading.CompareAndSwap(false, true) {
 		return &block.FlushResult{Finalized: false}, nil
 	}
@@ -450,7 +450,7 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 // parallel blockStates slice for the trigger
 // evaluation. Projection: ListFileBlocks(payloadID) yields the FastCDC
 // chunker output already produced by the local-store rollup
-// (pkg/blockstore/local/fs/rollup.go:rollupFile populates Pending
+// (pkg/block/local/fs/rollup.go:rollupFile populates Pending
 // FileBlocks at chunk boundaries with the BLAKE3-256 chunk hash as
 // FileBlock.Hash). expects the trigger to fire only when
 // every projected block is Pending; this helper returns the FULL

--- a/pkg/block/engine/syncer_test.go
+++ b/pkg/block/engine/syncer_test.go
@@ -43,8 +43,8 @@ import (
 //
 // Two backend fixtures
 //
-// - memory — pkg/blockstore/remote/memory.New(). Always available.
-// - s3 — pkg/blockstore/remote/s3.NewFromConfig against a
+// - memory — pkg/block/remote/memory.New(). Always available.
+// - s3 — pkg/block/remote/s3.NewFromConfig against a
 //               Localstack/MinIO endpoint. Gated on
 // DITTOFS_TEST_S3_ENDPOINT (with DITTOFS_TEST_S3_ACCESS_KEY
 // DITTOFS_TEST_S3_SECRET_KEY, DITTOFS_TEST_S3_BUCKET

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -142,7 +142,7 @@ var (
 
 	// ErrUnknownHash is returned by FileBlockStore.AddRef when no
 	// FileBlock row exists for the given hash. The LRU hit path
-	// (Opt 1 — see pkg/blockstore/local/fs/rollup.go) MUST
+	// (Opt 1 — see pkg/block/local/fs/rollup.go) MUST
 	// fall back to the full Put path on this sentinel; the LRU may
 	// be ahead of the metadata store after a crash (RAM-only LRU
 	// see), or the hash may not be present yet.

--- a/pkg/block/errors_test.go
+++ b/pkg/block/errors_test.go
@@ -38,7 +38,7 @@ func TestErrLegacyLayoutDetected_DetectsThroughWrap(t *testing.T) {
 }
 
 // TestSentinelMessages_HaveBlockstorePrefix asserts the existing
-// convention from pkg/blockstore/errors.go (every package sentinel
+// convention from pkg/block/errors.go (every package sentinel
 // message starts with "blockstore:").
 func TestSentinelMessages_HaveBlockstorePrefix(t *testing.T) {
 	for _, e := range []error{

--- a/pkg/block/fileblock.go
+++ b/pkg/block/fileblock.go
@@ -101,7 +101,7 @@ type FileBlockStore interface {
 	// an existing block — it never creates one.
 	//
 	// Returns ErrUnknownHash if no FileBlock row exists for the given
-	// hash. Callers (see pkg/blockstore/local/fs/rollup.go LRU hit
+	// hash. Callers (see pkg/block/local/fs/rollup.go LRU hit
 	// path) MUST fall back to the full Put path on this sentinel —
 	// the LRU may be ahead of the metadata store after a crash, or
 	// the hash may not be present yet.
@@ -142,7 +142,7 @@ type FileBlockStore interface {
 // FileBlockStore. The engine + local/fs packages still need by-ID
 // and per-file lookups for the dual-read read path, recovery,
 // dedup-delete and stats fan-out (callers under
-// pkg/blockstore/{engine,local/fs}/).
+// pkg/block/{engine,local/fs}/).
 //
 // All three metadata backends (memory/badger/postgres) satisfy this
 // interface — the methods are concrete on the backend struct, just

--- a/pkg/block/local/fs/appendlog_internals_test.go
+++ b/pkg/block/local/fs/appendlog_internals_test.go
@@ -22,9 +22,9 @@ import (
 //
 // Inlined these three scenarios (PressureChannel_INV05
 // TornWriteRecovery_LSL06, RollupOffsetMonotone_INV03) from
-// pkg/blockstore/local/localtest/appendlog_suite.go (deleted in this
+// pkg/block/local/localtest/appendlog_suite.go (deleted in this
 // plan). The other two scenarios from that suite (AppendLogRoundTrip
-// ConcurrentStorm) now live in pkg/blockstore/blockstoretest as
+// ConcurrentStorm) now live in pkg/block/blockstoretest as
 // BlockStoreAppendConformance subtests; the fs backend invokes them
 // via fs_conformance_test.go.
 //

--- a/pkg/block/local/fs/blockstore_methods_test.go
+++ b/pkg/block/local/fs/blockstore_methods_test.go
@@ -250,7 +250,7 @@ func TestFSStore_Walk_StopWalkSentinel(t *testing.T) {
 
 	t.Run("CleanExitOnWrappedErrStopWalk", func(t *testing.T) {
 		// Callers idiomatically wrap ErrStopWalk via fmt.Errorf("%w", ...)
-		// (see pkg/blockstore/errors.go). errors.Is must detect through
+		// (see pkg/block/errors.go). errors.Is must detect through
 		// the wrap and still trigger clean exit.
 		bc := newFSStoreForTest(t, FSStoreOptions{})
 		_ = seedChunks(t, bc, 3)

--- a/pkg/block/local/fs/chunkstore_test.go
+++ b/pkg/block/local/fs/chunkstore_test.go
@@ -171,7 +171,7 @@ func TestChunkStore_ShardPath_TwoLevel(t *testing.T) {
 }
 
 // TestChunkPathFormat closes the FIX-9 audit gap: TestContentHash_CASKey_Format
-// (in pkg/blockstore) only validates the hex string helper, not the on-disk
+// (in pkg/block) only validates the hex string helper, not the on-disk
 // path layout that StoreChunk actually uses. This test calls StoreChunk with a
 // known-hex hash and asserts the resulting file lives at the documented
 // blocks/{hex[0:2]}/{hex[2:4]}/{hex} layout under baseDir — a regression

--- a/pkg/block/local/fs/eviction_lsl08_conformance_test.go
+++ b/pkg/block/local/fs/eviction_lsl08_conformance_test.go
@@ -21,7 +21,7 @@ import (
 // FileBlockStore (so the no-FBS-call assertion can probe).
 //
 // -06 inlined the scenarios here from
-// pkg/blockstore/local/localtest/eviction_lsl08_suite.go (deleted in
+// pkg/block/local/localtest/eviction_lsl08_suite.go (deleted in
 // this plan). The scenarios remain fs-specific — they exercise CAS
 // chunk paths, LRU eviction policy, and the FBS-call invariant —
 // none of which appear on the unified BlockStore contract.

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -473,7 +473,7 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 
 // sentinelFileName is the per-share boot-guard marker written by
 // `dfs migrate-to-cas` at the successful completion of a share migration.
-// Kept in sync with pkg/blockstore/migrate.SentinelFileName.
+// Kept in sync with pkg/block/migrate.SentinelFileName.
 const sentinelFileName = ".cas-migrated-v1"
 
 // legacyLayoutWalkDepthCap bounds the depth-limited `.blk` probe so a

--- a/pkg/block/local/fs/fs_conformance_test.go
+++ b/pkg/block/local/fs/fs_conformance_test.go
@@ -35,7 +35,7 @@ func newFSStoreForConformance(t *testing.T) *fs.FSStore {
 }
 
 // TestFSStore_BlockStoreConformance runs the unified
-// BlockStoreConformance suite from pkg/blockstore/blockstoretest against
+// BlockStoreConformance suite from pkg/block/blockstoretest against
 // *fs.FSStore. The fs backend satisfies the BlockStore contract by way
 // of its embedded BlockStoreAppend implementation (07 lands the
 // missing Put/Has/Walk/etc. methods that complete the interface).
@@ -50,7 +50,7 @@ func TestFSStore_BlockStoreConformance(t *testing.T) {
 }
 
 // TestFSStore_BlockStoreAppendConformance runs the random-write
-// absorber suite from pkg/blockstore/blockstoretest against
+// absorber suite from pkg/block/blockstoretest against
 // *fs.FSStore. The fs backend implements BlockStoreAppend in full
 // (s3 and memory-remote implement only BlockStore).
 //

--- a/pkg/block/local/fs/fs_test.go
+++ b/pkg/block/local/fs/fs_test.go
@@ -153,7 +153,7 @@ func (c *countingFileBlockStore) TotalCount() int {
 }
 
 // writeSentinelForTest writes a minimal valid `.cas-migrated-v1` marker
-// at the share-dir root. Mirrors pkg/blockstore/migrate.writeSentinel's
+// at the share-dir root. Mirrors pkg/block/migrate.writeSentinel's
 // contract (file content is opaque to the boot guard; presence is what
 // matters).
 func writeSentinelForTest(t *testing.T, shareDir string) {

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -22,7 +22,7 @@ import (
 // These helpers exist only to support the conformance scenarios
 // (10) and the eviction scenarios. They are
 // not part of the production FSStore API. The -06 mega-PR
-// retired the legacy pkg/blockstore/local/localtest/ package that
+// retired the legacy pkg/block/local/localtest/ package that
 // originally consumed these hooks; the scenarios now live inside the
 // fs package as external `_test.go` files.
 

--- a/pkg/block/local/memory/memory_test.go
+++ b/pkg/block/local/memory/memory_test.go
@@ -28,7 +28,7 @@ func TestMemoryStore_BlockStoreConformance(t *testing.T) {
 }
 
 // TestMemoryStore_BlockStoreAppendConformance runs the random-write
-// absorber suite from pkg/blockstore/blockstoretest against the local
+// absorber suite from pkg/block/blockstoretest against the local
 // in-memory backend. Three scenarios `t.Skip` on the interface-only
 // surface (require fs-internal probes); the two portable scenarios
 // (AppendLogRoundTrip, ConcurrentStorm) exercise the public surface

--- a/pkg/block/migrate/migrate_to_cas.go
+++ b/pkg/block/migrate/migrate_to_cas.go
@@ -723,7 +723,7 @@ func contextErr(ctx context.Context, err error) error {
 }
 
 // blake3ContentHash returns the 32-byte BLAKE3 hash of data. Mirrors
-// pkg/blockstore/local/fs/rollup.go:blake3ContentHash (CAS chunk
+// pkg/block/local/fs/rollup.go:blake3ContentHash (CAS chunk
 // hashing contract).
 func blake3ContentHash(data []byte) block.ContentHash {
 	var h block.ContentHash

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -19,8 +19,8 @@ import (
 // RemoteStore is the unified content-addressed remote block storage
 // interface. Implemented by
 //
-//   - pkg/blockstore/remote/s3.Store
-//   - pkg/blockstore/remote/memory.Store
+//   - pkg/block/remote/s3.Store
+//   - pkg/block/remote/memory.Store
 //
 // Every method is keyed by block.ContentHash; no opaque "block key"
 // strings appear on this surface. Backends derive their on-disk / on-wire

--- a/pkg/config/blockstore.go
+++ b/pkg/config/blockstore.go
@@ -15,7 +15,7 @@ type BlockstoreLocalConfig struct {
 	// DedupLRUSize is the slot count for the in-memory hash dedup LRU.
 	// Default 4096 when zero. Surface for the RAM-only per-share hash
 	// LRU consulted between FastCDC.Next() and Put(hash, data) in
-	// pkg/blockstore/local/fs/rollup.go.
+	// pkg/block/local/fs/rollup.go.
 	DedupLRUSize int `mapstructure:"dedup_lru_size" yaml:"dedup_lru_size"`
 }
 

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -20,7 +20,7 @@ import (
 // surface (RefCount mutations, FileAttr.Blocks persistence) to a concrete
 // metadata.Store so the engine package itself can satisfy the
 // strict-grep boundary (zero pkg/metadata imports under
-// pkg/blockstore/engine/*.go).
+// pkg/block/engine/*.go).
 //
 // Transaction ownership rule (BLOCKER-1/2/3 resolution): the engine
 // NEVER opens a metadata txn. The CALLER (per-share runtime wrapper for

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -12,7 +12,7 @@ import (
 const HashSize = block.HashSize
 
 // ContentHash represents a BLAKE3-256 hash of content.
-// Type alias to block.ContentHash -- all definitions live in pkg/blockstore.
+// Type alias to block.ContentHash -- all definitions live in pkg/block.
 type ContentHash = block.ContentHash
 
 // ParseContentHash parses a hex-encoded hash string.
@@ -49,7 +49,7 @@ const (
 // ============================================================================
 
 // FileBlock is the single block entity in DittoFS.
-// Type alias to block.FileBlock -- all definitions live in pkg/blockstore.
+// Type alias to block.FileBlock -- all definitions live in pkg/block.
 type FileBlock = block.FileBlock
 
 // NewFileBlock creates a new pending FileBlock with the given ID and cache path.

--- a/pkg/metadata/rollup_store.go
+++ b/pkg/metadata/rollup_store.go
@@ -1,7 +1,7 @@
 // Package metadata — rollup_store.go.
 //
 // RollupStore persists the per-file append-log rollup_offset for the hybrid
-// local tier. See pkg/blockstore/local/fs/rollup.go for the consumer; see
+// local tier. See pkg/block/local/fs/rollup.go for the consumer; see
 // planning/phases/10-fastcdc-chunker-hybrid-local-store-a1/10-CONTEXT.md
 // for the atomicity contract.
 package metadata

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -213,7 +213,7 @@ type ServerConfig interface {
 // ============================================================================
 
 // FileBlockStore defines operations for content-addressed file block management.
-// Type alias to block.FileBlockStore -- all definitions live in pkg/blockstore.
+// Type alias to block.FileBlockStore -- all definitions live in pkg/block.
 type FileBlockStore = block.FileBlockStore
 
 // ============================================================================


### PR DESCRIPTION
Pure documentation/comment corrections — every change verified against the current source.

## What was stale

- **Moved package path `pkg/blockstore` → `pkg/block`** — 70 references across source godoc comments + `docs/`, `README.md`, `CHANGELOG.md`, `CLAUDE.md`. The package was renamed long ago; all references were in comments/prose (no functional code, build unaffected).
- **Phantom config key `cache.size_mib`** (`ARCHITECTURE.md`) — there is no such key. The in-memory CAS read cache is RAM-only and auto-sized from system memory (`pkg/block/defaults.go` `DeduceDefaults`), not a config knob.
- **`CONFIGURATION.md` syncer/gc** — documented a configurable `syncer:` block + `DITTOFS_SYNCER_*` env vars that don't exist (syncer sizing is auto-deduced; the server logs `syncer:`/`cache:`/`lock:` as ignored unknown keys). Corrected `gc:` to a real top-level section and trimmed env vars to those that exist.
- **mmap read path** — removed claims about `cache_mmap_unix.go` / `readFromCAS` mmap fast path; no mmap fast path exists on any platform (cache loads via `local.Get`).
- **`IMPLEMENTING_STORES.md` store contracts** — rewrote the fabricated `LocalStore`/`RemoteStore` `ReadAt/WriteAt/ReadBlock/...` signatures to the real CAS interfaces (`block.Store` / `block.BlockStoreAppend`, the 8 `FileBlockStore` methods), and pointed conformance at the unified `pkg/block/blockstoretest` suite (replacing the deleted `localtest`/`remotetest`).
- **`CLAUDE.md`** conformance-suite pointer → `pkg/block/blockstoretest`.

## Not changed (verified accurate / out of scope)

- `.planning/**` (historical records) untouched.
- `docs/CLI.md` is generated — not hand-edited.
- Accurate historical comments ("deleted the legacy `localtest` package…") left as-is.
- Real config keys (append-log tier `max_log_bytes`/`rollup_workers`, SMB `lease_break_timeout`) verified present and left.

Documentation-only: `go build` and `go vet` pass (comment-only source edits).
