### PR TITLE
fix(identity/kerberos): validate numeric principal via userLookup

### DIFF
--- a/pkg/identity/kerberos/provider.go
+++ b/pkg/identity/kerberos/provider.go
@@ -8,7 +8,6 @@ package kerberos
 
 import (
 	"context"
-	"strconv"
 	"strings"
 
 	"github.com/marmos91/dittofs/pkg/identity"
@@ -55,9 +54,15 @@ func (p *Provider) CanResolve(cred *identity.Credential) bool {
 //
 // Resolution order:
 //  1. Explicit mapping in LinkStore: ("kerberos", "alice@EXAMPLE.COM") → username
-//  2. Convention: if realm matches, strip realm and look up bare username
-//  3. Numeric UID: "1000@EXAMPLE.COM" → UID=1000 (AUTH_SYS interop)
-//  4. Found=false if unmapped
+//  2. Convention: if realm matches, strip realm and look up bare name as a
+//     DittoFS username via userLookup
+//  3. Found=false if unmapped
+//
+// The bare name is always validated through userLookup before any UID/GID is
+// granted — including names that happen to be decimal integers. A principal
+// such as "0@EXAMPLE.COM" does NOT bypass identity mapping; it only resolves
+// if a DittoFS user named "0" actually exists. This prevents a KDC account
+// with a numeric name from asserting an arbitrary (e.g. privileged) UID.
 func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*identity.ResolvedIdentity, error) {
 	if p.store != nil {
 		username, found, err := p.store.GetLink(ctx, ProviderName, cred.ExternalID)
@@ -80,16 +85,6 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 	name, domain := parsePrincipal(cred.ExternalID)
 	if domain == "" || !strings.EqualFold(domain, p.realm) {
 		return &identity.ResolvedIdentity{Found: false}, nil
-	}
-
-	if uid, err := strconv.ParseUint(name, 10, 32); err == nil {
-		return &identity.ResolvedIdentity{
-			Username: name,
-			UID:      uint32(uid),
-			GID:      uint32(uid),
-			Domain:   domain,
-			Found:    true,
-		}, nil
 	}
 
 	resolved, err := p.userLookup(ctx, name)

--- a/pkg/identity/kerberos/provider_test.go
+++ b/pkg/identity/kerberos/provider_test.go
@@ -124,15 +124,67 @@ func TestProvider_UnknownUser(t *testing.T) {
 	}
 }
 
-func TestProvider_NumericUID(t *testing.T) {
+// TestProvider_NumericPrincipalRequiresLookup ensures a Kerberos principal
+// whose name is a decimal integer cannot assert an arbitrary UID. The numeric
+// name must be validated through userLookup like any other name; if no DittoFS
+// user with that name exists, resolution must fail (Found=false).
+//
+// Without the fix the provider parsed the numeric name straight into UID=N and
+// returned Found=true, so a KDC account named "0" would be granted UID=0 (root)
+// without ever existing in DittoFS — a privilege-escalation hole.
+func TestProvider_NumericPrincipalRequiresLookup(t *testing.T) {
 	p := New("EXAMPLE.COM", nil, aliceLookup)
 
-	result, _ := p.Resolve(context.Background(), &identity.Credential{
+	// "0@EXAMPLE.COM" must NOT be granted UID=0: no DittoFS user named "0".
+	result, err := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "0@EXAMPLE.COM",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Found {
+		t.Fatalf("numeric principal must not bypass userLookup; got privileged %+v", result)
+	}
+
+	// An arbitrary UID that does not correspond to a DittoFS user must
+	// likewise be rejected rather than trusted.
+	result, err = p.Resolve(context.Background(), &identity.Credential{
 		Provider:   "kerberos",
 		ExternalID: "1000@EXAMPLE.COM",
 	})
-	if !result.Found || result.UID != 1000 {
-		t.Fatalf("expected numeric UID 1000, got %+v", result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Found {
+		t.Fatalf("numeric principal 1000 must require a matching DittoFS user; got %+v", result)
+	}
+}
+
+// TestProvider_NumericPrincipalValidUser confirms the legitimate mapping path
+// is preserved: a numeric name that DOES correspond to a configured DittoFS
+// user resolves through userLookup to that user's real UID/GID.
+func TestProvider_NumericPrincipalValidUser(t *testing.T) {
+	lookup := func(_ context.Context, username string) (*identity.ResolvedIdentity, error) {
+		if username == "1000" {
+			return &identity.ResolvedIdentity{Username: "1000", UID: 4242, GID: 4242, Found: true}, nil
+		}
+		return &identity.ResolvedIdentity{Found: false}, nil
+	}
+	p := New("EXAMPLE.COM", nil, lookup)
+
+	result, err := p.Resolve(context.Background(), &identity.Credential{
+		Provider:   "kerberos",
+		ExternalID: "1000@EXAMPLE.COM",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.UID != 4242 || result.GID != 4242 {
+		t.Fatalf("expected validated user 1000 -> UID/GID 4242, got %+v", result)
+	}
+	if result.Domain != "EXAMPLE.COM" {
+		t.Fatalf("expected domain EXAMPLE.COM, got %s", result.Domain)
 	}
 }
 


### PR DESCRIPTION
Fixes #1133

## Problem

The Kerberos identity provider's convention path parsed a principal whose
name component was a decimal integer (e.g. `0@EXAMPLE.COM`) straight into
`UID=N` / `GID=N` and returned `Found=true` — **before** ever calling
`userLookup`. Because the KDC only authenticates that the ticket is valid (not
*which* DittoFS user it maps to), any KDC account whose name is a number could
assert an arbitrary, including privileged, UID. A principal named `0` was
granted `UID=0` (root) without existing as a DittoFS user. The NFS `squash`
export option does not protect SMB, so this was a real privilege-escalation
hole.

## Fix

Remove the unvalidated numeric shortcut. Numeric names now flow through
`userLookup` exactly like every other name: a numeric principal only resolves
if a DittoFS user with that name actually exists, and resolves to **that
user's** real UID/GID — never to the asserted number. Unmapped numeric names
return `Found=false`.

The legitimate configured mapping path is preserved (both the LinkStore
explicit mapping and the convention path remain `userLookup`-gated).

## Test

`TestProvider_NumericPrincipalRequiresLookup` fails without the fix (it
observes `0@EXAMPLE.COM` → `UID:0 Found:true`) and passes with it.
`TestProvider_NumericPrincipalValidUser` proves a numeric name backed by a
real DittoFS user still resolves through validation.

`go test -race ./pkg/identity/...` green. Scope limited to
`pkg/identity/kerberos/` (the rpc/gss SID path is owned by a sibling PR).