### PR TITLE
fix(nfs/v4): NFSv4/4.1 stateid authz & seqid handling (#1128)

### DIFF
--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1991,12 +1991,19 @@ func (sm *StateManager) LockExisting(
 		}
 	}
 
-	// 3. Validate stateid seqid (only for non-replay LOCK)
-	if lockStateid.Seqid < lockState.Stateid.Seqid {
-		return nil, ErrOldStateid
-	}
-	if lockStateid.Seqid > lockState.Stateid.Seqid {
-		return nil, ErrBadStateid
+	// 3. Validate stateid seqid (only for non-replay LOCK).
+	// Per RFC 8881 Section 8.2.2, a v4.1 client may send stateid seqid=0 to
+	// mean "the most recent seqid"; the slot table already provides replay
+	// protection, so the server MUST bypass the seqid comparison in that case.
+	// lockState.Stateid.Seqid starts at 1 after LockNew, so without this bypass
+	// every v4.1 LOCK via LockExisting would return NFS4ERR_OLD_STATEID.
+	if lockStateid.Seqid != 0 {
+		if lockStateid.Seqid < lockState.Stateid.Seqid {
+			return nil, ErrOldStateid
+		}
+		if lockStateid.Seqid > lockState.Stateid.Seqid {
+			return nil, ErrBadStateid
+		}
 	}
 
 	// 4. Validate open mode for lock type
@@ -2252,12 +2259,18 @@ func (sm *StateManager) UnlockFile(
 		}
 	}
 
-	// 3. Validate stateid seqid (only for non-replay LOCKU)
-	if lockStateid.Seqid < lockState.Stateid.Seqid {
-		return nil, ErrOldStateid
-	}
-	if lockStateid.Seqid > lockState.Stateid.Seqid {
-		return nil, ErrBadStateid
+	// 3. Validate stateid seqid (only for non-replay LOCKU).
+	// Per RFC 8881 Section 8.2.2, a v4.1 client may send stateid seqid=0;
+	// bypass the seqid comparison as in LockExisting. lockState.Stateid.Seqid
+	// is >=2 after any prior LOCK, so without this bypass every v4.1 LOCKU
+	// would return NFS4ERR_OLD_STATEID, making unlock impossible.
+	if lockStateid.Seqid != 0 {
+		if lockStateid.Seqid < lockState.Stateid.Seqid {
+			return nil, ErrOldStateid
+		}
+		if lockStateid.Seqid > lockState.Stateid.Seqid {
+			return nil, ErrBadStateid
+		}
 	}
 
 	// 4. Release the lock via unified lock manager

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -354,10 +354,10 @@ func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH [
 
 	openState := lockState.OpenState
 	if openState == nil {
-		// A lock stateid must always derive from an open; a nil parent means
-		// inconsistent state rather than a client error.
+		// A lock stateid must always derive from an open; a nil parent is an
+		// internal invariant violation, not a client error.
 		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
+			Status:  types.NFS4ERR_SERVERFAULT,
 			Message: "lock stateid has no parent open state",
 		}
 	}

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -132,7 +132,8 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 //     on any op; the READ-bypass (all-ones) stateid is accepted ONLY when
 //     op == StateidOpRead and otherwise rejected with NFS4ERR_BAD_STATEID
 //     (RFC 7530 Section 9.1.4.3). Both return (nil, nil) when accepted.
-//  2. Route by type tag: open stateids -> openStateByOther, delegation -> delegByOther
+//  2. Route by type tag: open -> openStateByOther, lock -> lockStateByOther
+//     (returns the parent open state), delegation -> delegByOther
 //  3. If not found -> NFS4ERR_BAD_STATEID (or NFS4ERR_STALE_STATEID for wrong epoch)
 //  4. Compare seqid: < current -> NFS4ERR_OLD_STATEID; > current -> NFS4ERR_BAD_STATEID
 //  5. Verify filehandle matches (if provided and non-nil) -> NFS4ERR_BAD_STATEID
@@ -170,7 +171,15 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 		return sm.validateDelegStateid(stateid, currentFH)
 	}
 
-	// Open stateids (type 0x01) and lock stateids (type 0x02) use openStateByOther
+	// Lock stateids (type 0x02) are stored in lockStateByOther, never in
+	// openStateByOther. RFC 7530 Section 9.1.4.1 permits a lock stateid on
+	// READ/WRITE, so validate it against the lock state and return the parent
+	// open state (whose share-access bits the caller enforces).
+	if stateType == StateTypeLock {
+		return sm.validateLockStateid(stateid, currentFH)
+	}
+
+	// Open stateids (type 0x01) use openStateByOther.
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
 		if !sm.isCurrentEpoch(stateid.Other) {
@@ -296,6 +305,77 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 	return nil, nil
 }
 
+// validateLockStateid validates a lock stateid (type 0x02) presented to an
+// I/O operation (READ/WRITE/SETATTR-size). Lock stateids live in
+// lockStateByOther; on success this returns the parent OpenState so the caller
+// can enforce that open's share-access mode (RFC 7530 Section 9.1.4.1).
+// Caller must hold sm.mu.RLock.
+func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
+	lockState, exists := sm.lockStateByOther[stateid.Other]
+	if !exists {
+		if !sm.isCurrentEpoch(stateid.Other) {
+			return nil, &NFS4StateError{
+				Status:  types.NFS4ERR_STALE_STATEID,
+				Message: "stateid from previous server incarnation",
+			}
+		}
+		return nil, &NFS4StateError{
+			Status:  types.NFS4ERR_BAD_STATEID,
+			Message: "lock stateid not found",
+		}
+	}
+
+	// Compare seqid. Per RFC 8881 Section 8.2.2, seqid=0 in a non-special
+	// stateid bypasses the seqid comparison entirely.
+	if stateid.Seqid != 0 {
+		if stateid.Seqid < lockState.Stateid.Seqid {
+			return nil, &NFS4StateError{
+				Status:  types.NFS4ERR_OLD_STATEID,
+				Message: fmt.Sprintf("lock stateid seqid %d < current %d", stateid.Seqid, lockState.Stateid.Seqid),
+			}
+		}
+		if stateid.Seqid > lockState.Stateid.Seqid {
+			return nil, &NFS4StateError{
+				Status:  types.NFS4ERR_BAD_STATEID,
+				Message: fmt.Sprintf("lock stateid seqid %d > current %d", stateid.Seqid, lockState.Stateid.Seqid),
+			}
+		}
+	}
+
+	// Verify filehandle matches the locked file.
+	if len(currentFH) > 0 && len(lockState.FileHandle) > 0 {
+		if !bytes.Equal(currentFH, lockState.FileHandle) {
+			return nil, &NFS4StateError{
+				Status:  types.NFS4ERR_BAD_STATEID,
+				Message: "lock stateid filehandle mismatch",
+			}
+		}
+	}
+
+	openState := lockState.OpenState
+	if openState == nil {
+		// A lock stateid must always derive from an open; a nil parent means
+		// inconsistent state rather than a client error.
+		return nil, &NFS4StateError{
+			Status:  types.NFS4ERR_BAD_STATEID,
+			Message: "lock stateid has no parent open state",
+		}
+	}
+
+	// Implicit lease renewal for the owning client (RFC 7530 Section 9.6).
+	if openState.Owner != nil && openState.Owner.ClientRecord != nil {
+		lease := openState.Owner.ClientRecord.Lease
+		if lease != nil {
+			if lease.IsExpired() {
+				return nil, ErrExpired
+			}
+			lease.Renew()
+		}
+	}
+
+	return openState, nil
+}
+
 // ============================================================================
 // FreeStateid (RFC 8881 Section 18.38)
 // ============================================================================
@@ -371,6 +451,16 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 		}
 	}
 
+	// RFC 8881 Section 18.38.3: the stateid must belong to the requesting
+	// session's client. Reject cross-client frees so a peer that learns
+	// another client's stateid.Other bytes cannot destroy its locks.
+	if lockState.LockOwner == nil || lockState.LockOwner.ClientID != clientID {
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_BAD_STATEID,
+			Message: "lock stateid does not belong to client",
+		}
+	}
+
 	// Remove from lockStateByOther
 	delete(sm.lockStateByOther, stateid.Other)
 
@@ -435,6 +525,15 @@ func (sm *StateManager) freeOpenStateidLocked(clientID uint64, stateid *types.St
 		}
 	}
 
+	// RFC 8881 Section 18.38.3: the stateid must belong to the requesting
+	// session's client.
+	if openState.Owner == nil || openState.Owner.ClientID != clientID {
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_BAD_STATEID,
+			Message: "open stateid does not belong to client",
+		}
+	}
+
 	// Check if any lock stateids reference this open
 	if len(openState.LockStates) > 0 {
 		return &NFS4StateError{
@@ -480,6 +579,15 @@ func (sm *StateManager) freeDelegStateidLocked(clientID uint64, stateid *types.S
 		return &NFS4StateError{
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "delegation stateid not found",
+		}
+	}
+
+	// RFC 8881 Section 18.38.3: the stateid must belong to the requesting
+	// session's client.
+	if deleg.ClientID != clientID {
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_BAD_STATEID,
+			Message: "delegation stateid does not belong to client",
 		}
 	}
 

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -261,6 +261,7 @@ func TestUnlockFile_V41Seqid0(t *testing.T) {
 // hijack the client.
 func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
 
 	ownerID := []byte("client-owner-principal")
 	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
@@ -291,6 +292,18 @@ func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 	// The legitimate principal can still EXCHANGE_ID idempotently.
 	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345", "alice"); err != nil {
 		t.Fatalf("idempotent EXCHANGE_ID by owning principal: %v", err)
+	}
+
+	// An idempotent call with no principal (e.g. AUTH_NONE) must not clear the
+	// stored principal — otherwise the hijack guard could be reset.
+	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345"); err != nil {
+		t.Fatalf("idempotent EXCHANGE_ID with empty principal: %v", err)
+	}
+	sm.mu.RLock()
+	rec = sm.v41ClientsByOwner[string(ownerID)]
+	sm.mu.RUnlock()
+	if rec == nil || rec.Principal != "alice" {
+		t.Errorf("empty-principal call cleared stored principal: got %q", recPrincipal(rec))
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -1,0 +1,302 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// These tests are negative controls for the NFSv4/4.1 state & stateid audit
+// fixes (issue #1128). Each one fails against the pre-fix code.
+
+// newLockedFile opens, confirms, and acquires a WRITE lock for the given
+// client, returning the lock stateid and the locked file handle. It is the
+// shared setup for the lock-stateid and FREE_STATEID ownership tests.
+func newLockedFile(t *testing.T, sm *StateManager, clientID uint64, fh []byte) types.Stateid4 {
+	t.Helper()
+	openResult, err := sm.OpenFile(clientID, []byte("open-owner"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+	lockResult, err := sm.LockNew(
+		clientID, []byte("lock-owner"), 1,
+		&confirmed.Stateid, 3,
+		fh, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+	if lockResult.Denied != nil {
+		t.Fatalf("LockNew unexpectedly denied")
+	}
+	return lockResult.Stateid
+}
+
+// TestValidateStateid_LockStateid_RoutedToLockMap is the negative control for
+// the lock-stateid routing fix (stateid.go). RFC 7530 Section 9.1.4.1 permits
+// a lock stateid on READ/WRITE; before the fix ValidateStateid looked lock
+// stateids up in openStateByOther and returned NFS4ERR_BAD_STATEID.
+func TestValidateStateid_LockStateid_RoutedToLockMap(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	fh := []byte("fh-lock-stateid-io")
+	lockStateid := newLockedFile(t, sm, 0, fh)
+
+	// A lock stateid presented to WRITE must validate and return the parent
+	// open state (carrying the share-access bits the caller enforces).
+	openState, err := sm.ValidateStateid(&lockStateid, fh, StateidOpWrite)
+	if err != nil {
+		t.Fatalf("ValidateStateid on lock stateid (WRITE): %v", err)
+	}
+	if openState == nil {
+		t.Fatal("lock stateid must return its parent open state, got nil")
+	}
+	if openState.ShareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+		t.Errorf("parent open state ShareAccess = %d, missing WRITE", openState.ShareAccess)
+	}
+
+	// Same lock stateid must also validate on READ.
+	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead); err != nil {
+		t.Fatalf("ValidateStateid on lock stateid (READ): %v", err)
+	}
+}
+
+// TestValidateStateid_LockStateid_Seqid0 confirms the RFC 8881 Section 8.2.2
+// seqid=0 "current stateid" bypass works for lock stateids too.
+func TestValidateStateid_LockStateid_Seqid0(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	fh := []byte("fh-lock-stateid-seqid0")
+	lockStateid := newLockedFile(t, sm, 0, fh)
+	lockStateid.Seqid = 0
+
+	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead); err != nil {
+		t.Fatalf("ValidateStateid on lock stateid with seqid=0: %v", err)
+	}
+}
+
+// TestFreeStateid_CrossClientLock is the negative control for the FREE_STATEID
+// lock ownership fix. RFC 8881 Section 18.38.3 requires the stateid to belong
+// to the requesting client; before the fix any client could free another
+// client's lock stateid.
+func TestFreeStateid_CrossClientLock(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	const victimClientID = uint64(1)
+	const attackerClientID = uint64(2)
+
+	fh := []byte("fh-cross-client-lock")
+	lockStateid := newLockedFile(t, sm, victimClientID, fh)
+
+	// Attacker tries to free the victim's lock stateid.
+	err := sm.FreeStateid(attackerClientID, &lockStateid)
+	if err == nil {
+		t.Fatal("FREE_STATEID by a different client must be rejected")
+	}
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("expected NFS4StateError, got %T", err)
+	}
+	if stateErr.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID", stateErr.Status)
+	}
+
+	// The victim's lock state must still exist.
+	sm.mu.RLock()
+	_, exists := sm.lockStateByOther[lockStateid.Other]
+	sm.mu.RUnlock()
+	if !exists {
+		t.Error("victim's lock stateid was destroyed by another client")
+	}
+
+	// The owning client can still free it.
+	if err := sm.FreeStateid(victimClientID, &lockStateid); err != nil {
+		t.Fatalf("FreeStateid by owning client: %v", err)
+	}
+}
+
+// TestFreeStateid_CrossClientOpen is the negative control for the FREE_STATEID
+// open ownership fix.
+func TestFreeStateid_CrossClientOpen(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	const victimClientID = uint64(1)
+	const attackerClientID = uint64(2)
+
+	fh := []byte("fh-cross-client-open")
+	openResult, err := sm.OpenFile(victimClientID, []byte("owner1"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := sm.ConfirmOpen(&openResult.Stateid, 2); err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+
+	err = sm.FreeStateid(attackerClientID, &openResult.Stateid)
+	if err == nil {
+		t.Fatal("FREE_STATEID of another client's open stateid must be rejected")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("expected NFS4ERR_BAD_STATEID, got %v", err)
+	}
+	if sm.GetOpenState(openResult.Stateid.Other) == nil {
+		t.Error("victim's open stateid was destroyed by another client")
+	}
+
+	// Owning client can still free it.
+	if err := sm.FreeStateid(victimClientID, &openResult.Stateid); err != nil {
+		t.Fatalf("FreeStateid by owning client: %v", err)
+	}
+}
+
+// TestFreeStateid_CrossClientDelegation is the negative control for the
+// FREE_STATEID delegation ownership fix.
+func TestFreeStateid_CrossClientDelegation(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	const victimClientID = uint64(100)
+	const attackerClientID = uint64(200)
+
+	deleg := sm.GrantDelegation(victimClientID, []byte("fh-cross-client-deleg"), types.OPEN_DELEGATE_WRITE)
+
+	err := sm.FreeStateid(attackerClientID, &deleg.Stateid)
+	if err == nil {
+		t.Fatal("FREE_STATEID of another client's delegation must be rejected")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("expected NFS4ERR_BAD_STATEID, got %v", err)
+	}
+
+	sm.mu.RLock()
+	_, exists := sm.delegByOther[deleg.Stateid.Other]
+	sm.mu.RUnlock()
+	if !exists {
+		t.Error("victim's delegation was destroyed by another client")
+	}
+
+	if err := sm.FreeStateid(victimClientID, &deleg.Stateid); err != nil {
+		t.Fatalf("FreeStateid by owning client: %v", err)
+	}
+}
+
+// TestLockExisting_V41Seqid0 is the negative control for the LockExisting
+// stateid seqid=0 bypass (manager.go). A v4.1 client sends stateid seqid=0;
+// before the fix `0 < lockState.Stateid.Seqid` always returned
+// NFS4ERR_OLD_STATEID, making every additional LOCK fail.
+func TestLockExisting_V41Seqid0(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	fh := []byte("fh-lockexisting-seqid0")
+	lockStateid := newLockedFile(t, sm, 0, fh)
+
+	// v4.1 client: stateid seqid=0, owner seqid=0 (slot table provides replay
+	// protection). Extend the lock with a second byte range via LockExisting.
+	v41Stateid := lockStateid
+	v41Stateid.Seqid = 0
+	result, err := sm.LockExisting(&v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false)
+	if err != nil {
+		t.Fatalf("LockExisting with v4.1 stateid seqid=0: %v", err)
+	}
+	if result.Denied != nil {
+		t.Fatalf("LockExisting unexpectedly denied")
+	}
+}
+
+// TestUnlockFile_V41Seqid0 is the negative control for the UnlockFile (LOCKU)
+// stateid seqid=0 bypass. After a prior LOCK incremented lockState.Stateid.Seqid,
+// a v4.1 LOCKU (stateid seqid=0) always returned NFS4ERR_OLD_STATEID before the
+// fix, making unlock impossible.
+func TestUnlockFile_V41Seqid0(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	fh := []byte("fh-locku-seqid0")
+	lockStateid := newLockedFile(t, sm, 0, fh)
+
+	// Advance lockState.Stateid.Seqid to >=2 via a successful LockExisting so
+	// the LOCKU below is unambiguously after a seqid increment.
+	v41Lock := lockStateid
+	v41Lock.Seqid = 0
+	if _, err := sm.LockExisting(&v41Lock, 0, fh, types.WRITE_LT, 200, 100, false); err != nil {
+		t.Fatalf("LockExisting setup: %v", err)
+	}
+
+	// v4.1 LOCKU: stateid seqid=0, owner seqid=0.
+	unlockStateid := lockStateid
+	unlockStateid.Seqid = 0
+	if _, err := sm.UnlockFile(&unlockStateid, 0, types.WRITE_LT, 0, 100); err != nil {
+		t.Fatalf("UnlockFile with v4.1 stateid seqid=0: %v", err)
+	}
+}
+
+// TestExchangeID_Case2_PrincipalMismatch is the negative control for the
+// EXCHANGE_ID Case 2 principal-mismatch fix (v41_client.go). RFC 8881
+// Section 18.35.4 requires NFS4ERR_CLID_INUSE when the existing record's
+// principal differs from the incoming one. Before the fix Case 2 unconditionally
+// overwrote the principal, allowing a peer that knows the owner ID + verifier to
+// hijack the client.
+func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	ownerID := []byte("client-owner-principal")
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+
+	// Establish the record under principal "alice".
+	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345", "alice"); err != nil {
+		t.Fatalf("ExchangeID (alice): %v", err)
+	}
+
+	// A peer that knows the owner ID + verifier replays EXCHANGE_ID under a
+	// different principal -- must be rejected with NFS4ERR_CLID_INUSE.
+	_, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.9:12345", "mallory")
+	if err == nil {
+		t.Fatal("EXCHANGE_ID Case 2 with a different principal must be rejected")
+	}
+	if err != ErrClientIDInUse {
+		t.Errorf("expected ErrClientIDInUse, got %v", err)
+	}
+
+	// The stored principal must remain "alice".
+	sm.mu.RLock()
+	rec := sm.v41ClientsByOwner[string(ownerID)]
+	sm.mu.RUnlock()
+	if rec == nil || rec.Principal != "alice" {
+		t.Errorf("stored principal = %q, want \"alice\" (hijack not prevented)", recPrincipal(rec))
+	}
+
+	// The legitimate principal can still EXCHANGE_ID idempotently.
+	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345", "alice"); err != nil {
+		t.Fatalf("idempotent EXCHANGE_ID by owning principal: %v", err)
+	}
+}
+
+func recPrincipal(rec *V41ClientRecord) string {
+	if rec == nil {
+		return ""
+	}
+	return rec.Principal
+}

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -196,7 +196,16 @@ func (sm *StateManager) ExchangeID(
 			"client_addr", clientAddr)
 
 	case existing.Verifier == verifier:
-		// Case 2: Same owner + same verifier -- idempotent (update impl info)
+		// Case 2: Same owner + same verifier -- idempotent return.
+		// RFC 8881 Section 18.35.4: if the existing record was established by a
+		// principal and this request carries a different non-empty principal,
+		// reject with NFS4ERR_CLID_INUSE (mirrors the v4.0 SETCLIENTID Case 5
+		// guard in reuseConfirmedClient). Without this a third party that knows
+		// a confirmed client's co_ownerid + co_verifier could overwrite the
+		// stored principal and hijack the client's lease/state.
+		if existing.Principal != "" && princ != "" && existing.Principal != princ {
+			return nil, ErrClientIDInUse
+		}
 		existing.ClientAddr = clientAddr
 		existing.Principal = princ
 		existing.LastRenewal = time.Now()

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -207,7 +207,11 @@ func (sm *StateManager) ExchangeID(
 			return nil, ErrClientIDInUse
 		}
 		existing.ClientAddr = clientAddr
-		existing.Principal = princ
+		// Only adopt a non-empty incoming principal; never clear a stored
+		// principal with an empty one (that would weaken the hijack guard).
+		if princ != "" {
+			existing.Principal = princ
+		}
 		existing.LastRenewal = time.Now()
 		applyImplInfo(existing, clientImplId)
 		record = existing


### PR DESCRIPTION
Fixes #1128 (the stateid/state-authz subset of the audit).

## Findings addressed

- **[HIGH] ValidateStateid routes lock stateids to the wrong map** (`stateid.go`)
  Lock stateids (type `0x02`) live in `lockStateByOther`, never in
  `openStateByOther`. The old code looked them up in `openStateByOther`, so any
  RFC 7530 §9.1.4.1-compliant client presenting a lock stateid to READ/WRITE got
  `NFS4ERR_BAD_STATEID`. New `validateLockStateid` validates against the lock
  state (epoch, seqid with the §8.2.2 seqid=0 bypass, filehandle) and returns the
  parent open state so the caller can enforce its share-access bits.

- **[HIGH] FreeStateid: clientID ownership never enforced** (`stateid.go`)
  `freeLockStateidLocked` / `freeOpenStateidLocked` / `freeDelegStateidLocked`
  accepted `clientID` but never checked it. Any session that knew another
  client's `stateid.Other` bytes could destroy that client's locks/opens/
  delegations. Each sub-function now verifies the state's owning clientID and
  returns `NFS4ERR_BAD_STATEID` on mismatch (RFC 8881 §18.38.3). Same-client
  frees are unaffected.

- **[HIGH] LockExisting / UnlockFile: missing v4.1 stateid seqid=0 bypass**
  (`manager.go`) The stateid-seqid comparison was unconditional, so a v4.1 client
  (which sends stateid seqid=0 per RFC 8881 §8.2.2) always got
  `NFS4ERR_OLD_STATEID` on LOCK-via-existing-owner and on every LOCKU. The bypass
  that already existed on the owner-seqid check (and in ValidateStateid) is now
  applied to the stateid-seqid check too.

- **[HIGH] ExchangeID Case 2: missing principal-mismatch rejection**
  (`v41_client.go`) Case 2 (same ownerID + verifier) unconditionally overwrote
  the stored principal. A peer that knows a confirmed client's co_ownerid +
  co_verifier could hijack its principal and lease. Now rejects with
  `NFS4ERR_CLID_INUSE` when the existing principal differs (RFC 8881 §18.35.4),
  mirroring the v4.0 `reuseConfirmedClient` guard.

## Tests

`stateid_authz_test.go` adds 8 negative-control tests (one per finding plus the
lock-stateid seqid=0 case); all fail against the pre-fix tree and pass after.
Same-client free / idempotent EXCHANGE_ID paths are asserted to keep working.

`go build ./...`, `go vet ./internal/adapter/nfs/...`, and
`go test -race ./internal/adapter/nfs/...` are green.