### PR TITLE
fix(nfs/gss): set FLAG_ACCEPTOR_SUBKEY on DATA reply MIC/Wrap tokens

### DIFF
--- a/internal/adapter/nfs/rpc/gss/context.go
+++ b/internal/adapter/nfs/rpc/gss/context.go
@@ -66,6 +66,12 @@ type GSSSessionInfo struct {
 	// Service is the RPCSEC_GSS service level (none/integrity/privacy).
 	// Needed by the reply path to determine which wrapping to apply.
 	Service uint32
+
+	// HasAcceptorSubkey indicates the acceptor produced a subkey in the AP-REP
+	// during context establishment (mutual auth). When true, RFC 4121 §4.2.2
+	// requires FLAG_ACCEPTOR_SUBKEY on every acceptor MIC/Wrap token, including
+	// DATA reply verifiers and krb5i/krb5p reply wrapping.
+	HasAcceptorSubkey bool
 }
 
 // ContextWithSessionInfo returns a new context carrying GSS session info.
@@ -111,6 +117,12 @@ type GSSContext struct {
 	// Service is the protection level negotiated during INIT.
 	// One of RPCGSSSvcNone, RPCGSSSvcIntegrity, or RPCGSSSvcPrivacy.
 	Service uint32
+
+	// HasAcceptorSubkey records whether the acceptor produced a subkey in the
+	// AP-REP during context establishment (mutual auth). When true, RFC 4121
+	// §4.2.2 requires FLAG_ACCEPTOR_SUBKEY on every subsequent acceptor MIC/Wrap
+	// token; the DATA reply path reads this to set the flag correctly.
+	HasAcceptorSubkey bool
 
 	// CreatedAt is the time the context was established.
 	CreatedAt time.Time

--- a/internal/adapter/nfs/rpc/gss/framework.go
+++ b/internal/adapter/nfs/rpc/gss/framework.go
@@ -492,14 +492,15 @@ func (p *GSSProcessor) handleInit(cred *RPCGSSCredV1, requestBody []byte) *GSSPr
 	// Create the GSS context
 	now := time.Now()
 	gssCtx := &GSSContext{
-		Handle:     handle,
-		Principal:  verified.Principal,
-		Realm:      verified.Realm,
-		SessionKey: verified.SessionKey,
-		SeqWindow:  NewSeqWindow(DefaultSeqWindowSize),
-		Service:    cred.Service,
-		CreatedAt:  now,
-		LastUsed:   now,
+		Handle:            handle,
+		Principal:         verified.Principal,
+		Realm:             verified.Realm,
+		SessionKey:        verified.SessionKey,
+		SeqWindow:         NewSeqWindow(DefaultSeqWindowSize),
+		Service:           cred.Service,
+		HasAcceptorSubkey: verified.HasAcceptorSubkey,
+		CreatedAt:         now,
+		LastUsed:          now,
 	}
 
 	// CRITICAL: Store context BEFORE building reply.
@@ -723,12 +724,13 @@ func (p *GSSProcessor) handleData(ctx context.Context, cred *RPCGSSCredV1, verif
 	)
 
 	return &GSSProcessResult{
-		ProcessedData: processedData,
-		Identity:      ident,
-		IsControl:     false,
-		SeqNum:        cred.SeqNum,
-		Service:       cred.Service,
-		SessionKey:    gssCtx.SessionKey,
+		ProcessedData:     processedData,
+		Identity:          ident,
+		IsControl:         false,
+		SeqNum:            cred.SeqNum,
+		Service:           cred.Service,
+		SessionKey:        gssCtx.SessionKey,
+		HasAcceptorSubkey: gssCtx.HasAcceptorSubkey,
 	}
 }
 

--- a/internal/adapter/nfs/rpc/gss/framework_test.go
+++ b/internal/adapter/nfs/rpc/gss/framework_test.go
@@ -16,11 +16,12 @@ import (
 // mockVerifier implements Verifier for testing without a real KDC.
 type mockVerifier struct {
 	// result to return on VerifyToken calls
-	principal  string
-	realm      string
-	sessionKey types.EncryptionKey
-	apRepToken []byte
-	err        error
+	principal         string
+	realm             string
+	sessionKey        types.EncryptionKey
+	apRepToken        []byte
+	hasAcceptorSubkey bool
+	err               error
 }
 
 func newMockVerifier(principal, realm string) *mockVerifier {
@@ -43,10 +44,11 @@ func (v *mockVerifier) VerifyToken(gssToken []byte) (*VerifiedContext, error) {
 		return nil, v.err
 	}
 	return &VerifiedContext{
-		Principal:  v.principal,
-		Realm:      v.realm,
-		SessionKey: v.sessionKey,
-		APRepToken: v.apRepToken,
+		Principal:         v.principal,
+		Realm:             v.realm,
+		SessionKey:        v.sessionKey,
+		APRepToken:        v.apRepToken,
+		HasAcceptorSubkey: v.hasAcceptorSubkey,
 	}, nil
 }
 
@@ -464,6 +466,70 @@ func TestProcessDATAWithValidContext(t *testing.T) {
 	}
 	if result.Service != RPCGSSSvcNone {
 		t.Fatalf("expected Service %d, got %d", RPCGSSSvcNone, result.Service)
+	}
+}
+
+// TestProcessDATAPropagatesAcceptorSubkey proves that an acceptor subkey
+// produced during context establishment (mutual auth) flows from handleInit,
+// through the persisted GSSContext, into the handleData result so the DATA
+// reply path can set FLAG_ACCEPTOR_SUBKEY. Without the plumbing the result's
+// HasAcceptorSubkey is always false and every DATA reply MIC omits the flag,
+// which MIT krb5/libtirpc reject with GSS_S_BAD_SIG (RFC 4121 §4.2.2). This
+// test FAILS unless the field is threaded end-to-end.
+func TestProcessDATAPropagatesAcceptorSubkey(t *testing.T) {
+	verifier := newMockVerifier("alice", "EXAMPLE.COM")
+	// Simulate a mutual-auth INIT that produced an acceptor subkey in the AP-REP.
+	verifier.hasAcceptorSubkey = true
+	mapper := newTestMapper()
+	proc := NewGSSProcessor(verifier, mapper, 100, 10*time.Minute)
+	defer proc.Stop()
+
+	// INIT at svc_none so the svc_none DATA call below is not a downgrade.
+	initCred := &RPCGSSCredV1{GSSProc: RPCGSSInit, SeqNum: 0, Service: RPCGSSSvcNone}
+	initCredBody, err := EncodeGSSCred(initCred)
+	if err != nil {
+		t.Fatalf("encode INIT cred: %v", err)
+	}
+	initResult := proc.Process(context.Background(), initCredBody, nil, nil, encodeOpaqueToken([]byte("mock-ap-req-token")))
+	if initResult.Err != nil {
+		t.Fatalf("INIT failed: %v", initResult.Err)
+	}
+	if !initResult.HasAcceptorSubkey {
+		t.Fatal("INIT result should report HasAcceptorSubkey=true")
+	}
+
+	// The persisted context must record the subkey flag.
+	handle := extractContextHandle(t, proc)
+	gssCtx, ok := proc.contexts.Lookup(handle)
+	if !ok {
+		t.Fatal("context not stored")
+	}
+	if !gssCtx.HasAcceptorSubkey {
+		t.Fatal("persisted GSSContext lost HasAcceptorSubkey")
+	}
+
+	// A subsequent DATA request must carry the subkey flag in its result so the
+	// reply verifier/wrap path can set FLAG_ACCEPTOR_SUBKEY.
+	dataCred := &RPCGSSCredV1{GSSProc: RPCGSSData, SeqNum: 1, Service: RPCGSSSvcNone, Handle: handle}
+	dataCredBody, err := EncodeGSSCred(dataCred)
+	if err != nil {
+		t.Fatalf("encode DATA cred: %v", err)
+	}
+	result := processDATA(t, proc, mockVerifierSessionKey, dataCredBody, []byte("args"))
+	if result.Err != nil {
+		t.Fatalf("DATA failed: %v", result.Err)
+	}
+	if !result.HasAcceptorSubkey {
+		t.Fatal("DATA result must report HasAcceptorSubkey=true (subkey flag not propagated to reply path)")
+	}
+
+	// And the resulting reply MIC must actually carry the flag.
+	mic, err := ComputeReplyVerifier(result.SessionKey, result.SeqNum, result.HasAcceptorSubkey)
+	if err != nil {
+		t.Fatalf("ComputeReplyVerifier failed: %v", err)
+	}
+	if mic[2]&gssapi.MICTokenFlagAcceptorSubkey == 0 {
+		t.Fatalf("DATA reply MIC missing AcceptorSubkey flag, got flags 0x%02x", mic[2])
 	}
 }
 

--- a/internal/adapter/nfs/rpc/gss/integrity.go
+++ b/internal/adapter/nfs/rpc/gss/integrity.go
@@ -102,19 +102,21 @@ func UnwrapIntegrity(sessionKey types.EncryptionKey, credSeqNum uint32, requestB
 //   - sessionKey: The session key from the GSS context
 //   - seqNum: The sequence number for this reply
 //   - replyBody: The XDR-encoded procedure results
+//   - hasAcceptorSubkey: Whether the context used an acceptor subkey (from AP-REP).
+//     When true, RFC 4121 §4.2.2 requires FLAG_ACCEPTOR_SUBKEY on this acceptor MIC.
 //
 // Returns:
 //   - []byte: The encoded rpc_gss_integ_data
 //   - error: If MIC computation fails
-func WrapIntegrity(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte) ([]byte, error) {
+func WrapIntegrity(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte, hasAcceptorSubkey bool) ([]byte, error) {
 	// 1. Build databody_integ: XDR(seq_num) + replyBody
 	databodyInteg := make([]byte, 4+len(replyBody))
 	binary.BigEndian.PutUint32(databodyInteg[0:4], seqNum)
 	copy(databodyInteg[4:], replyBody)
 
-	// 2. Compute MIC over databody_integ using acceptor sign key usage (23)
+	// 2. Compute MIC over databody_integ using acceptor sign key usage (25)
 	micToken := gssapi.MICToken{
-		Flags:     gssapi.MICTokenFlagSentByAcceptor,
+		Flags:     acceptorMICFlags(hasAcceptorSubkey),
 		SndSeqNum: uint64(seqNum),
 		Payload:   databodyInteg,
 	}

--- a/internal/adapter/nfs/rpc/gss/integrity.go
+++ b/internal/adapter/nfs/rpc/gss/integrity.go
@@ -114,7 +114,7 @@ func WrapIntegrity(sessionKey types.EncryptionKey, seqNum uint32, replyBody []by
 	binary.BigEndian.PutUint32(databodyInteg[0:4], seqNum)
 	copy(databodyInteg[4:], replyBody)
 
-	// 2. Compute MIC over databody_integ using acceptor sign key usage (25)
+	// 2. Compute MIC over databody_integ using acceptor sign key usage (23)
 	micToken := gssapi.MICToken{
 		Flags:     acceptorMICFlags(hasAcceptorSubkey),
 		SndSeqNum: uint64(seqNum),

--- a/internal/adapter/nfs/rpc/gss/integrity_test.go
+++ b/internal/adapter/nfs/rpc/gss/integrity_test.go
@@ -211,7 +211,7 @@ func TestWrapIntegrityProducesValidFormat(t *testing.T) {
 	seqNum := uint32(7)
 	args := []byte("hello")
 
-	wrapped, err := WrapIntegrity(key, seqNum, args)
+	wrapped, err := WrapIntegrity(key, seqNum, args, false)
 	if err != nil {
 		t.Fatalf("WrapIntegrity failed: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestWrapIntegrityVerifiableByClient(t *testing.T) {
 	seqNum := uint32(42)
 	replyBody := []byte("nfs-reply-data")
 
-	wrapped, err := WrapIntegrity(key, seqNum, replyBody)
+	wrapped, err := WrapIntegrity(key, seqNum, replyBody, false)
 	if err != nil {
 		t.Fatalf("WrapIntegrity failed: %v", err)
 	}

--- a/internal/adapter/nfs/rpc/gss/integrity_test.go
+++ b/internal/adapter/nfs/rpc/gss/integrity_test.go
@@ -282,6 +282,44 @@ func TestWrapIntegrityProducesValidFormat(t *testing.T) {
 	}
 }
 
+// integMICFlags wraps a reply via WrapIntegrity and returns the flags byte of
+// the embedded checksum MIC token (byte 2 of the second XDR opaque field).
+func integMICFlags(t *testing.T, key krbTypes.EncryptionKey, hasAcceptorSubkey bool) byte {
+	t.Helper()
+	wrapped, err := WrapIntegrity(key, 7, []byte("hello"), hasAcceptorSubkey)
+	if err != nil {
+		t.Fatalf("WrapIntegrity failed: %v", err)
+	}
+	reader := bytes.NewReader(wrapped)
+	databody, err := readXDROpaque(reader)
+	if err != nil {
+		t.Fatalf("read databody_integ: %v", err)
+	}
+	_ = databody
+	checksum, err := readXDROpaque(reader)
+	if err != nil {
+		t.Fatalf("read checksum: %v", err)
+	}
+	if len(checksum) < 16 || checksum[0] != 0x04 || checksum[1] != 0x04 {
+		t.Fatalf("invalid MIC token in checksum: %x", checksum)
+	}
+	return checksum[2]
+}
+
+// TestWrapIntegritySetsAcceptorSubkeyFlag asserts that the krb5i reply MIC
+// carries FLAG_ACCEPTOR_SUBKEY iff the context was established with an acceptor
+// subkey (RFC 4121 §4.2.2).
+func TestWrapIntegritySetsAcceptorSubkeyFlag(t *testing.T) {
+	key := testSessionKey()
+
+	if flags := integMICFlags(t, key, true); flags&gssapi.MICTokenFlagAcceptorSubkey == 0 {
+		t.Fatalf("expected AcceptorSubkey flag set, got flags 0x%02x", flags)
+	}
+	if flags := integMICFlags(t, key, false); flags&gssapi.MICTokenFlagAcceptorSubkey != 0 {
+		t.Fatalf("expected AcceptorSubkey flag clear, got flags 0x%02x", flags)
+	}
+}
+
 func TestWrapIntegrityVerifiableByClient(t *testing.T) {
 	key := testSessionKey()
 	seqNum := uint32(42)

--- a/internal/adapter/nfs/rpc/gss/privacy.go
+++ b/internal/adapter/nfs/rpc/gss/privacy.go
@@ -261,11 +261,13 @@ func rotateLeft(data []byte, n int) []byte {
 //   - sessionKey: The session key from the GSS context
 //   - seqNum: The sequence number for this reply
 //   - replyBody: The XDR-encoded procedure results
+//   - hasAcceptorSubkey: Whether the context used an acceptor subkey (from AP-REP).
+//     When true, RFC 4121 §4.2.2 requires FLAG_ACCEPTOR_SUBKEY on this acceptor Wrap token.
 //
 // Returns:
 //   - []byte: The encoded rpc_gss_priv_data
 //   - error: If encryption/wrapping fails
-func WrapPrivacy(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte) ([]byte, error) {
+func WrapPrivacy(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte, hasAcceptorSubkey bool) ([]byte, error) {
 	// 1. Build plaintext: XDR(seq_num) + replyBody
 	plaintext := make([]byte, 4+len(replyBody))
 	binary.BigEndian.PutUint32(plaintext[0:4], seqNum)
@@ -278,8 +280,12 @@ func WrapPrivacy(sessionKey types.EncryptionKey, seqNum uint32, replyBody []byte
 	}
 
 	// 3. Build the header (to be sent in plaintext)
-	// Flags: SentByAcceptor (0x01) | Sealed (0x02) = 0x03
+	// Flags: SentByAcceptor (0x01) | Sealed (0x02), plus AcceptorSubkey (0x04)
+	// when the acceptor produced a subkey during mutual auth (RFC 4121 §4.2.2).
 	flags := byte(wrapFlagSentByAcceptor | wrapFlagSealed)
+	if hasAcceptorSubkey {
+		flags |= wrapFlagAcceptorSubkey
+	}
 
 	// For sealed tokens, EC = filler size (we use 0 for simplicity)
 	// The encryption provides integrity, so we don't need padding for checksum

--- a/internal/adapter/nfs/rpc/gss/privacy_test.go
+++ b/internal/adapter/nfs/rpc/gss/privacy_test.go
@@ -252,7 +252,7 @@ func TestWrapPrivacyProducesValidFormat(t *testing.T) {
 	seqNum := uint32(7)
 	args := []byte("hello")
 
-	wrapped, err := WrapPrivacy(key, seqNum, args)
+	wrapped, err := WrapPrivacy(key, seqNum, args, false)
 	if err != nil {
 		t.Fatalf("WrapPrivacy failed: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestWrapPrivacyVerifiableByClient(t *testing.T) {
 	seqNum := uint32(42)
 	replyBody := []byte("nfs-reply-data")
 
-	wrapped, err := WrapPrivacy(key, seqNum, replyBody)
+	wrapped, err := WrapPrivacy(key, seqNum, replyBody, false)
 	if err != nil {
 		t.Fatalf("WrapPrivacy failed: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestWrapPrivacyVerifiableByClient(t *testing.T) {
 func TestWrapPrivacySealedFlagSet(t *testing.T) {
 	key := testSessionKey()
 
-	wrapped, err := WrapPrivacy(key, 1, []byte("test"))
+	wrapped, err := WrapPrivacy(key, 1, []byte("test"), false)
 	if err != nil {
 		t.Fatalf("WrapPrivacy failed: %v", err)
 	}

--- a/internal/adapter/nfs/rpc/gss/privacy_test.go
+++ b/internal/adapter/nfs/rpc/gss/privacy_test.go
@@ -399,6 +399,39 @@ func TestWrapPrivacySealedFlagSet(t *testing.T) {
 	}
 }
 
+// privacyWrapFlags wraps a reply via WrapPrivacy and returns the flags byte of
+// the Wrap token header (byte 2 of the XDR opaque databody_priv).
+func privacyWrapFlags(t *testing.T, key krbTypes.EncryptionKey, hasAcceptorSubkey bool) byte {
+	t.Helper()
+	wrapped, err := WrapPrivacy(key, 1, []byte("test"), hasAcceptorSubkey)
+	if err != nil {
+		t.Fatalf("WrapPrivacy failed: %v", err)
+	}
+	reader := bytes.NewReader(wrapped)
+	tokenBytes, err := readXDROpaque(reader)
+	if err != nil {
+		t.Fatalf("read databody_priv: %v", err)
+	}
+	if len(tokenBytes) < wrapTokenHdrLen {
+		t.Fatalf("wrap token too short: %d bytes", len(tokenBytes))
+	}
+	return tokenBytes[2]
+}
+
+// TestWrapPrivacySetsAcceptorSubkeyFlag asserts that the krb5p reply Wrap token
+// carries FLAG_ACCEPTOR_SUBKEY (0x04) iff the context was established with an
+// acceptor subkey (RFC 4121 §4.2.2).
+func TestWrapPrivacySetsAcceptorSubkeyFlag(t *testing.T) {
+	key := testSessionKey()
+
+	if flags := privacyWrapFlags(t, key, true); flags&wrapFlagAcceptorSubkey == 0 {
+		t.Fatalf("expected AcceptorSubkey flag set, got flags 0x%02x", flags)
+	}
+	if flags := privacyWrapFlags(t, key, false); flags&wrapFlagAcceptorSubkey != 0 {
+		t.Fatalf("expected AcceptorSubkey flag clear, got flags 0x%02x", flags)
+	}
+}
+
 // ============================================================================
 // Non-sealed Wrap token tests (backward compatibility)
 // ============================================================================

--- a/internal/adapter/nfs/rpc/gss/verifier.go
+++ b/internal/adapter/nfs/rpc/gss/verifier.go
@@ -26,18 +26,20 @@ import (
 // Parameters:
 //   - sessionKey: The session key from the GSS context (decrypted service ticket)
 //   - seqNum: The sequence number from the RPCSEC_GSS credential
+//   - hasAcceptorSubkey: Whether the context used an acceptor subkey (from AP-REP).
+//     When true, RFC 4121 §4.2.2 requires FLAG_ACCEPTOR_SUBKEY on this acceptor MIC.
 //
 // Returns:
 //   - []byte: The MIC token bytes (reply verifier body)
 //   - error: If MIC computation fails (e.g., unsupported encryption type)
-func ComputeReplyVerifier(sessionKey types.EncryptionKey, seqNum uint32) ([]byte, error) {
+func ComputeReplyVerifier(sessionKey types.EncryptionKey, seqNum uint32, hasAcceptorSubkey bool) ([]byte, error) {
 	// XDR-encode the sequence number as uint32 (4 bytes big-endian)
 	seqBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(seqBytes, seqNum)
 
 	// Create a GSS-API MIC token per RFC 4121
 	micToken := gssapi.MICToken{
-		Flags:     gssapi.MICTokenFlagSentByAcceptor, // Server is the acceptor
+		Flags:     acceptorMICFlags(hasAcceptorSubkey),
 		SndSeqNum: uint64(seqNum),
 		Payload:   seqBytes,
 	}
@@ -95,23 +97,10 @@ func ComputeInitVerifier(sessionKey types.EncryptionKey, seqWindow uint32, hasAc
 	winBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(winBytes, seqWindow)
 
-	// Build flags for the MIC token.
-	// Per RFC 4121 Section 4.2.2:
-	// - Bit 0 (SentByAcceptor): Set because server is the acceptor
-	// - Bit 2 (AcceptorSubkey): Set when acceptor subkey is used for the MIC
-	//
-	// CRITICAL: When we include a subkey in EncAPRepPart, the client sets
-	// ctx->have_acceptor_subkey = 1 and expects FLAG_ACCEPTOR_SUBKEY in MIC tokens.
-	// Without this flag, gss_verify_mic() may fail or use wrong key.
-	var flags byte = gssapi.MICTokenFlagSentByAcceptor
-	if hasAcceptorSubkey {
-		flags |= gssapi.MICTokenFlagAcceptorSubkey
-	}
-
 	// Create a GSS-API MIC token per RFC 4121
 	// For INIT response, we use sequence number 0 since context is being established
 	micToken := gssapi.MICToken{
-		Flags:     flags,
+		Flags:     acceptorMICFlags(hasAcceptorSubkey),
 		SndSeqNum: 0, // Initial sequence
 		Payload:   winBytes,
 	}
@@ -129,4 +118,21 @@ func ComputeInitVerifier(sessionKey types.EncryptionKey, seqWindow uint32, hasAc
 	}
 
 	return micBytes, nil
+}
+
+// acceptorMICFlags returns the RFC 4121 §4.2.2 flag byte for an acceptor
+// (server) MIC token.
+//
+//   - Bit 0 (SentByAcceptor): always set, the server is the context acceptor.
+//   - Bit 2 (AcceptorSubkey): set when the acceptor produced a subkey in the
+//     AP-REP during mutual auth. The client (MIT krb5 / libtirpc) records
+//     have_acceptor_subkey=1 and requires FLAG_ACCEPTOR_SUBKEY on every
+//     subsequent acceptor token; omitting it fails gss_verify_mic with
+//     GSS_S_BAD_SIG.
+func acceptorMICFlags(hasAcceptorSubkey bool) byte {
+	flags := byte(gssapi.MICTokenFlagSentByAcceptor)
+	if hasAcceptorSubkey {
+		flags |= gssapi.MICTokenFlagAcceptorSubkey
+	}
+	return flags
 }

--- a/internal/adapter/nfs/rpc/gss/verifier_test.go
+++ b/internal/adapter/nfs/rpc/gss/verifier_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jcmturner/gokrb5/v8/crypto"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
 	krbTypes "github.com/jcmturner/gokrb5/v8/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 )
@@ -24,7 +25,7 @@ func TestComputeReplyVerifierProducesNonEmptyMIC(t *testing.T) {
 		key.KeyValue[i] = byte(i + 1)
 	}
 
-	mic, err := ComputeReplyVerifier(key, 42)
+	mic, err := ComputeReplyVerifier(key, 42, false)
 	if err != nil {
 		t.Fatalf("ComputeReplyVerifier failed: %v", err)
 	}
@@ -51,12 +52,12 @@ func TestComputeReplyVerifierDifferentSeqNums(t *testing.T) {
 		key.KeyValue[i] = byte(i + 1)
 	}
 
-	mic1, err := ComputeReplyVerifier(key, 1)
+	mic1, err := ComputeReplyVerifier(key, 1, false)
 	if err != nil {
 		t.Fatalf("ComputeReplyVerifier(1) failed: %v", err)
 	}
 
-	mic2, err := ComputeReplyVerifier(key, 2)
+	mic2, err := ComputeReplyVerifier(key, 2, false)
 	if err != nil {
 		t.Fatalf("ComputeReplyVerifier(2) failed: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestComputeReplyVerifierUnsupportedEtype(t *testing.T) {
 		KeyValue: []byte("test-key"),
 	}
 
-	_, err := ComputeReplyVerifier(key, 1)
+	_, err := ComputeReplyVerifier(key, 1, false)
 	if err == nil {
 		t.Fatal("expected error for unsupported encryption type")
 	}
@@ -89,7 +90,7 @@ func TestComputeReplyVerifierMICTokenFormat(t *testing.T) {
 		key.KeyValue[i] = byte(i + 1)
 	}
 
-	mic, err := ComputeReplyVerifier(key, 100)
+	mic, err := ComputeReplyVerifier(key, 100, false)
 	if err != nil {
 		t.Fatalf("ComputeReplyVerifier failed: %v", err)
 	}
@@ -132,7 +133,7 @@ func TestComputeReplyVerifierMatchesManualChecksum(t *testing.T) {
 		t.Skip("unknown checksum size for etype")
 	}
 
-	mic, err := ComputeReplyVerifier(key, seqNum)
+	mic, err := ComputeReplyVerifier(key, seqNum, false)
 	if err != nil {
 		t.Fatalf("ComputeReplyVerifier failed: %v", err)
 	}
@@ -141,6 +142,44 @@ func TestComputeReplyVerifierMatchesManualChecksum(t *testing.T) {
 	expectedSize := 16 + int(checksumSize)
 	if len(mic) != expectedSize {
 		t.Fatalf("expected MIC size %d, got %d", expectedSize, len(mic))
+	}
+}
+
+// TestComputeReplyVerifierSetsAcceptorSubkeyFlag asserts that a DATA reply
+// verifier carries FLAG_ACCEPTOR_SUBKEY (bit 2) when, and only when, the
+// context was established with an acceptor subkey (mutual auth). RFC 4121
+// §4.2.2 requires the flag on every acceptor token once a subkey was included
+// in the AP-REP; without it MIT krb5/libtirpc gss_verify_mic rejects the reply
+// with GSS_S_BAD_SIG, breaking krb5i/krb5p. This test FAILS if the flag is not
+// plumbed into ComputeReplyVerifier.
+func TestComputeReplyVerifierSetsAcceptorSubkeyFlag(t *testing.T) {
+	key := krbTypes.EncryptionKey{
+		KeyType:  17, // aes128-cts-hmac-sha1-96
+		KeyValue: make([]byte, 16),
+	}
+	for i := range key.KeyValue {
+		key.KeyValue[i] = byte(i + 1)
+	}
+
+	// With an acceptor subkey, bit 2 (AcceptorSubkey) must be set.
+	withSubkey, err := ComputeReplyVerifier(key, 7, true)
+	if err != nil {
+		t.Fatalf("ComputeReplyVerifier(hasAcceptorSubkey=true) failed: %v", err)
+	}
+	if withSubkey[2]&gssapi.MICTokenFlagAcceptorSubkey == 0 {
+		t.Fatalf("expected AcceptorSubkey flag set on reply MIC, got flags 0x%02x", withSubkey[2])
+	}
+	if withSubkey[2]&gssapi.MICTokenFlagSentByAcceptor == 0 {
+		t.Fatalf("expected SentByAcceptor flag set on reply MIC, got flags 0x%02x", withSubkey[2])
+	}
+
+	// Without an acceptor subkey, bit 2 must remain clear.
+	noSubkey, err := ComputeReplyVerifier(key, 7, false)
+	if err != nil {
+		t.Fatalf("ComputeReplyVerifier(hasAcceptorSubkey=false) failed: %v", err)
+	}
+	if noSubkey[2]&gssapi.MICTokenFlagAcceptorSubkey != 0 {
+		t.Fatalf("expected AcceptorSubkey flag clear on reply MIC, got flags 0x%02x", noSubkey[2])
 	}
 }
 

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -158,9 +158,10 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 
 		// Store session info for reply verifier computation and body wrapping
 		ctx = gss.ContextWithSessionInfo(ctx, &gss.GSSSessionInfo{
-			SessionKey: gssResult.SessionKey,
-			SeqNum:     gssResult.SeqNum,
-			Service:    gssResult.Service,
+			SessionKey:        gssResult.SessionKey,
+			SeqNum:            gssResult.SeqNum,
+			Service:           gssResult.Service,
+			HasAcceptorSubkey: gssResult.HasAcceptorSubkey,
 		})
 	}
 

--- a/pkg/adapter/nfs/reply.go
+++ b/pkg/adapter/nfs/reply.go
@@ -35,7 +35,7 @@ func (c *NFSConnection) sendGSSReply(xid uint32, data []byte, sessionInfo *gss.G
 	switch sessionInfo.Service {
 	case gss.RPCGSSSvcIntegrity:
 		// krb5i: wrap reply body with MIC
-		wrapped, err := gss.WrapIntegrity(sessionInfo.SessionKey, sessionInfo.SeqNum, data)
+		wrapped, err := gss.WrapIntegrity(sessionInfo.SessionKey, sessionInfo.SeqNum, data, sessionInfo.HasAcceptorSubkey)
 		if err != nil {
 			return fmt.Errorf("wrap GSS integrity reply: %w", err)
 		}
@@ -43,7 +43,7 @@ func (c *NFSConnection) sendGSSReply(xid uint32, data []byte, sessionInfo *gss.G
 
 	case gss.RPCGSSSvcPrivacy:
 		// krb5p: wrap reply body with encryption
-		wrapped, err := gss.WrapPrivacy(sessionInfo.SessionKey, sessionInfo.SeqNum, data)
+		wrapped, err := gss.WrapPrivacy(sessionInfo.SessionKey, sessionInfo.SeqNum, data, sessionInfo.HasAcceptorSubkey)
 		if err != nil {
 			return fmt.Errorf("wrap GSS privacy reply: %w", err)
 		}
@@ -53,8 +53,10 @@ func (c *NFSConnection) sendGSSReply(xid uint32, data []byte, sessionInfo *gss.G
 		// krb5 (svc_none): reply body sent as-is
 	}
 
-	// Compute the reply verifier: MIC of the sequence number
-	mic, err := gss.ComputeReplyVerifier(sessionInfo.SessionKey, sessionInfo.SeqNum)
+	// Compute the reply verifier: MIC of the sequence number.
+	// When the acceptor produced a subkey during mutual auth, the verifier MIC
+	// must carry FLAG_ACCEPTOR_SUBKEY per RFC 4121 §4.2.2.
+	mic, err := gss.ComputeReplyVerifier(sessionInfo.SessionKey, sessionInfo.SeqNum, sessionInfo.HasAcceptorSubkey)
 	if err != nil {
 		return fmt.Errorf("compute GSS reply verifier: %w", err)
 	}


### PR DESCRIPTION
Fixes #1125

## Problem

After a mutual-auth Kerberos session that produced an acceptor subkey, RFC 4121 §4.2.2 requires `FLAG_ACCEPTOR_SUBKEY` (bit 2, 0x04) on every subsequent acceptor MIC/Wrap token. The server set this flag correctly on the **INIT** reply verifier (`ComputeInitVerifier`) but dropped it on **every DATA reply**:

- `GSSContext` had no `HasAcceptorSubkey` field — the value from `VerifyToken`/`handleInit` was stored only in the INIT `GSSProcessResult` and never persisted.
- `handleData` always returned `HasAcceptorSubkey=false`.
- `ComputeReplyVerifier`, `WrapIntegrity`, and `WrapPrivacy` never set the bit.

MIT krb5 / libtirpc `gss_verify_mic()` checks this flag and rejects mismatched replies with `GSS_S_BAD_SIG`. Mutual auth (`MUTUAL-REQUIRED`) is the default for every Linux NFS krb5 mount, so this broke **all** krb5i and krb5p operations after mount.

## Fix

Thread `HasAcceptorSubkey` from `VerifyToken` through the persisted `GSSContext` into the DATA reply path, mirroring how the INIT path already plumbs it:

- Add `HasAcceptorSubkey` to `GSSContext` (set in `handleInit`) and `GSSSessionInfo` (set in `dispatch.go`).
- `handleData` propagates it into `GSSProcessResult`.
- `ComputeReplyVerifier` / `WrapIntegrity` / `WrapPrivacy` accept the flag and set `FLAG_ACCEPTOR_SUBKEY` accordingly; `reply.go` passes it through.
- Factor the acceptor MIC flag computation into a shared `acceptorMICFlags` helper (also adopted by `ComputeInitVerifier`).

The client→server (initiator) unwrap paths are unchanged — only acceptor-emitted tokens carry the flag.

## Tests

- `TestComputeReplyVerifierSetsAcceptorSubkeyFlag` — asserts the DATA reply MIC carries the flag iff a subkey was established. Verified to FAIL without the verifier fix.
- `TestProcessDATAPropagatesAcceptorSubkey` — end-to-end: a subkey-producing INIT propagates through the persisted context into the DATA result and reply MIC. Verified to FAIL without the propagation fix.

`go build ./...`, `go vet`, and `go test -race ./internal/adapter/nfs/rpc/... ./pkg/adapter/nfs/...` all green.