### PR TITLE
fix(nfs): AUTH_NULL share-perm bypass, RMDIR nil-deref, NFSv4 double-reply

### DIFF
--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -30,8 +30,11 @@ type SharePermissionResult struct {
 // shared by the NFSv3 and NFSv4 auth-context builders.
 //
 // The policy:
-//   - No identity store, share, or UID → allow with share defaults (read-write,
-//     honouring share.ReadOnly).
+//   - No identity store or share → no policy information available; allow with
+//     share defaults (read-write, honouring share.ReadOnly).
+//   - No UID (AUTH_NULL / AUTH_NONE anonymous caller) → treated as guest, NOT
+//     bypassed: denied when default_permission is "none", otherwise granted with
+//     read-only coerced when the default permission is "read".
 //   - Root (UID 0) under a squash mode that keeps root privileged (none,
 //     root_to_admin, all_to_admin, or empty/default) → admin, username "root".
 //   - Unknown UID → guest: denied when default_permission is "none", otherwise
@@ -51,12 +54,30 @@ func ResolveSharePermission(
 ) (SharePermissionResult, error) {
 	var result SharePermissionResult
 
-	// No identity store or UID - allow with share defaults.
-	if identityStore == nil || share == nil || uid == nil {
+	// No identity store or share - no policy information available, allow with
+	// share defaults. (A nil UID is NOT treated this way: an anonymous AUTH_NULL
+	// caller must still be gated by the share's default_permission policy below.)
+	if identityStore == nil || share == nil {
 		return result, nil
 	}
 
 	defaultPerm := models.ParseSharePermission(share.DefaultPermission)
+
+	// AUTH_NULL / AUTH_NONE anonymous caller (no UID asserted). This must NOT
+	// bypass the export permission model: gate it through the same guest policy
+	// as an unknown UID so default_permission=none denies it and read-only
+	// exports / default_permission=read coerce it to read-only.
+	if uid == nil {
+		if defaultPerm == models.PermissionNone {
+			logger.DebugCtx(ctx, "Share access denied (anonymous AUTH_NULL caller, default permission is none)",
+				"share", shareName, "client", clientAddr)
+			return SharePermissionResult{}, ErrShareAccessDenied
+		}
+		result.ReadOnly = share.ReadOnly || defaultPerm == models.PermissionRead
+		logger.DebugCtx(ctx, "Anonymous (AUTH_NULL) guest access granted",
+			"share", shareName, "permission", defaultPerm, "readOnly", result.ReadOnly, "client", clientAddr)
+		return result, nil
+	}
 
 	// Check if caller is root (UID 0) and squash mode doesn't map root away.
 	// Root has full admin access when squash mode is: none, root_to_admin,

--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -54,10 +54,15 @@ func ResolveSharePermission(
 ) (SharePermissionResult, error) {
 	var result SharePermissionResult
 
-	// No identity store or share - no policy information available, allow with
-	// share defaults. (A nil UID is NOT treated this way: an anonymous AUTH_NULL
-	// caller must still be gated by the share's default_permission policy below.)
+	// No identity store or share - no per-user policy is resolvable, so allow
+	// with share defaults. Still honour the share-level read-only flag when a
+	// share is present: an unavailable identity store must never silently make a
+	// read-only export writable. (A nil UID is NOT short-circuited here: an
+	// anonymous AUTH_NULL caller is gated by default_permission below.)
 	if identityStore == nil || share == nil {
+		if share != nil {
+			result.ReadOnly = share.ReadOnly
+		}
 		return result, nil
 	}
 

--- a/internal/adapter/nfs/auth/share_permission_test.go
+++ b/internal/adapter/nfs/auth/share_permission_test.go
@@ -178,6 +178,21 @@ func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 	}
 }
 
+// When no identity store is available but the share is read-only, the result
+// must still be read-only — an unavailable/unconfigured identity store must not
+// silently make a read-only export writable.
+func TestResolveSharePermission_NilStoreHonoursShareReadOnly(t *testing.T) {
+	share := &runtime.Share{Name: "/export", ReadOnly: true}
+
+	res, err := ResolveSharePermission(context.Background(), nil, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ReadOnly {
+		t.Errorf("nil identity store with read-only share: ReadOnly = false, want true")
+	}
+}
+
 // Negative control for the AUTH_NULL share-permission bypass: an anonymous
 // caller (nil UID, e.g. AUTH_NULL credentials) must be DENIED on a share with
 // default_permission=none. Before the fix the nil-UID early return granted

--- a/internal/adapter/nfs/auth/share_permission_test.go
+++ b/internal/adapter/nfs/auth/share_permission_test.go
@@ -151,9 +151,10 @@ func TestResolveSharePermission_KnownUserPermissionNoneDenied(t *testing.T) {
 	}
 }
 
-// Guard rails: a nil identity store, share, or UID must allow with defaults
-// (never deny) — this is the "no policy info" degrade path both v3 and v4 rely
-// on (e.g. nil registry / AUTH_NULL).
+// Guard rails: a nil identity store or share means no policy information is
+// available, so resolution must allow with defaults (never deny). A nil UID
+// (AUTH_NULL) is NOT in this set: an anonymous caller is gated by the share's
+// default_permission policy (see the AnonymousAuthNull tests below).
 func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -163,7 +164,6 @@ func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 	}{
 		{"nil store", nil, &runtime.Share{}, ptrUID(0)},
 		{"nil share", newPermMockStore(), nil, ptrUID(0)},
-		{"nil uid", newPermMockStore(), &runtime.Share{DefaultPermission: "none"}, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -175,6 +175,68 @@ func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 				t.Errorf("expected zero result, got %+v", res)
 			}
 		})
+	}
+}
+
+// Negative control for the AUTH_NULL share-permission bypass: an anonymous
+// caller (nil UID, e.g. AUTH_NULL credentials) must be DENIED on a share with
+// default_permission=none. Before the fix the nil-UID early return granted
+// full read-write access, nullifying the export permission model.
+func TestResolveSharePermission_AnonymousAuthNullDeniedWhenDefaultNone(t *testing.T) {
+	store := newPermMockStore()
+	share := &runtime.Share{
+		Name:              "/export",
+		DefaultPermission: "none",
+		Squash:            models.SquashNone,
+	}
+
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+	if !errors.Is(err, ErrShareAccessDenied) {
+		t.Fatalf("anonymous AUTH_NULL caller on default_permission=none: expected ErrShareAccessDenied, got %v", err)
+	}
+}
+
+// An anonymous AUTH_NULL caller on a read-only export must be coerced to
+// read-only, not granted read-write. Before the fix the nil-UID early return
+// returned ReadOnly=false even on read-only exports.
+func TestResolveSharePermission_AnonymousAuthNullCoercedReadOnly(t *testing.T) {
+	store := newPermMockStore()
+
+	t.Run("share read-only flag", func(t *testing.T) {
+		share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", ReadOnly: true}
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.ReadOnly {
+			t.Errorf("AUTH_NULL on read-only export: ReadOnly = false, want true")
+		}
+	})
+
+	t.Run("default_permission=read", func(t *testing.T) {
+		share := &runtime.Share{Name: "/export", DefaultPermission: "read"}
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.ReadOnly {
+			t.Errorf("AUTH_NULL on default_permission=read: ReadOnly = false, want true")
+		}
+	})
+}
+
+// A read-write share with no read-only flag still allows the anonymous caller —
+// the fix must not break legitimate anon-allowed shares.
+func TestResolveSharePermission_AnonymousAuthNullAllowedReadWrite(t *testing.T) {
+	store := newPermMockStore()
+	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write"}
+
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ReadOnly {
+		t.Errorf("AUTH_NULL on read-write export: ReadOnly = true, want false")
 	}
 }
 

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -147,9 +147,10 @@ func (h *Handler) Rmdir(
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "RMDIR cancelled before RemoveDirectory", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
 
-		// Get updated parent attributes for WCC data
-		parentFile, _ = metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		// Post-op WCC: the context is already cancelled here, so a re-fetch
+		// typically returns (nil, err); wccAfterOrFallback guards the nil and
+		// falls back to the pre-op parent attributes.
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		return &RmdirResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -163,9 +164,10 @@ func (h *Handler) Rmdir(
 	if err != nil {
 		logger.DebugCtx(ctx.Context, "RMDIR failed: store error", "name", req.Name, "client", clientIP, "error", err)
 
-		// Get updated parent attributes for WCC data
-		parentFile, _ = metaSvc.GetFile(ctx.Context, parentHandle)
-		wccAfter := h.convertFileAttrToNFS(parentHandle, &parentFile.FileAttr)
+		// Post-op WCC: on RemoveDirectory failure the parent may no longer be
+		// accessible, so a re-fetch can return (nil, err); wccAfterOrFallback
+		// guards the nil and falls back to the pre-op parent attributes.
+		wccAfter := h.wccAfterOrFallback(ctx, metaSvc, parentHandle, &parentFile.FileAttr)
 
 		// Map store errors to NFS status codes
 		status := mapRmdirErrorToNFSStatus(err)

--- a/internal/adapter/nfs/v3/handlers/rmdir_nilfetch_test.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir_nilfetch_test.go
@@ -1,0 +1,91 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
+	handlertesting "github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers/testing"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nilOnNthParentFetchStore wraps a memory store and returns (nil, nil) from
+// GetFile for a specific handle once a configured number of GetFile calls for
+// that handle have occurred. It reproduces the production condition the RMDIR
+// nil-deref finding describes: the post-operation parent re-fetch returning nil
+// after RemoveDirectory has run.
+type nilOnNthParentFetchStore struct {
+	*metadatamemory.MemoryMetadataStore
+
+	targetHandle metadata.FileHandle
+	failAfter    int64 // start returning nil once the call count exceeds this
+	calls        atomic.Int64
+	triggered    atomic.Bool // set true the first time the nil branch fires
+}
+
+func (s *nilOnNthParentFetchStore) GetFile(ctx context.Context, h metadata.FileHandle) (*metadata.File, error) {
+	if bytes.Equal([]byte(h), []byte(s.targetHandle)) {
+		if s.calls.Add(1) > s.failAfter {
+			// Simulate a store that can no longer resolve the parent (e.g. it
+			// was removed/raced, or the context is cancelled): the real store
+			// returns (nil, err); a blank-discarded error then leaves a nil
+			// *File. Return (nil, nil) to make the nil dereference unambiguous.
+			s.triggered.Store(true)
+			return nil, nil
+		}
+	}
+	return s.MemoryMetadataStore.GetFile(ctx, h)
+}
+
+// TestRmdir_StoreErrorReFetchNil_NoPanic is a negative control for the RMDIR
+// nil-dereference finding (rmdir.go:167). When RemoveDirectory fails and the
+// post-op parent re-fetch returns a nil *File, the handler must NOT dereference
+// it. Before the fix the handler did `&parentFile.FileAttr` on a nil pointer
+// and panicked the server goroutine; after the fix it returns a clean status
+// with no post-op WCC attributes.
+func TestRmdir_StoreErrorReFetchNil_NoPanic(t *testing.T) {
+	var wrapped *nilOnNthParentFetchStore
+
+	fx := handlertesting.NewHandlerFixtureWithStore(t, func(inner *metadatamemory.MemoryMetadataStore) metadata.Store {
+		wrapped = &nilOnNthParentFetchStore{
+			MemoryMetadataStore: inner,
+			// The parent handle is fetched several times before the handler's
+			// post-failure re-fetch (handler pre-op fetch, the service's parent
+			// lookup, and the delete-permission check). Only the final re-fetch
+			// at rmdir.go:167 returns nil; the `triggered` assertion below
+			// guards against this count drifting and making the test vacuous.
+			failAfter: 3,
+		}
+		return wrapped
+	})
+
+	// A non-empty directory makes Service.RemoveDirectory fail with NotEmpty,
+	// reaching the post-op re-fetch branch in the handler.
+	fx.CreateFile("notempty/keep.txt", []byte("x"))
+	wrapped.targetHandle = fx.RootHandle
+
+	req := &handlers.RmdirRequest{
+		DirHandle: fx.RootHandle,
+		Name:      "notempty",
+	}
+
+	// Must not panic on the nil re-fetch.
+	resp, err := fx.Handler.Rmdir(fx.ContextWithUID(0, 0), req)
+
+	require.NoError(t, err)
+	require.True(t, wrapped.triggered.Load(),
+		"test did not exercise the nil post-op re-fetch path (call count drifted); adjust failAfter")
+	assert.EqualValues(t, types.NFS3ErrNotEmpty, resp.Status,
+		"RMDIR of a non-empty directory should return NFS3ErrNotEmpty")
+	// The handler must survive the nil re-fetch (the regression was a panic).
+	// Post-op WCC falls back to the pre-op parent attributes via
+	// wccAfterOrFallback, so it is non-nil; the load-bearing assertion is
+	// simply that we got here without a nil-pointer panic.
+	assert.NotNil(t, resp.DirWccAfter, "post-op WCC should fall back to pre-op attrs, not panic on nil")
+}

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -73,6 +73,22 @@ type HandlerTestFixture struct {
 // The fixture automatically cleans up on test completion.
 func NewHandlerFixture(t testing.TB) *HandlerTestFixture {
 	t.Helper()
+	return NewHandlerFixtureWithStore(t, nil)
+}
+
+// NewHandlerFixtureWithStore is like NewHandlerFixture but lets a test wrap the
+// underlying memory metadata store before it is registered with the runtime.
+//
+// The wrap function receives the concrete memory store (already wired to the
+// block store / syncer) and returns the metadata.Store to register. This lets a
+// test inject fault behaviour (e.g. a GetFile that returns nil) to exercise
+// handler error paths that the plain memory store cannot reach. A nil wrap
+// registers the memory store unchanged.
+func NewHandlerFixtureWithStore(
+	t testing.TB,
+	wrap func(*metadatamemory.MemoryMetadataStore) metadata.Store,
+) *HandlerTestFixture {
+	t.Helper()
 
 	// The wtmax capability cache is process-global; clear it so each fixture
 	// starts cold and tests that set distinct wtmax values do not bleed into
@@ -108,7 +124,14 @@ func NewHandlerFixture(t testing.TB) *HandlerTestFixture {
 	// Create registry
 	reg := runtime.New(nil)
 
-	if err := reg.RegisterMetadataStore("test-metaSvc", metaStore); err != nil {
+	// Register the (optionally wrapped) metadata store. The block store/syncer
+	// above always reference the concrete inner store; the wrapper only changes
+	// what the runtime's metadata Service sees.
+	var registerStore metadata.Store = metaStore
+	if wrap != nil {
+		registerStore = wrap(metaStore)
+	}
+	if err := reg.RegisterMetadataStore("test-metaSvc", registerStore); err != nil {
 		t.Fatalf("Failed to register metadata store: %v", err)
 	}
 

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -24,11 +24,16 @@ import (
 // incoming message is a backchannel REPLY (msg_type=1) rather than a CALL.
 var errBackchannelReply = errors.New("backchannel reply routed")
 
-// errDropReply is a sentinel error signalling that no reply must be written for
-// this request: it is a duplicate of an op still in flight (DRC in-progress).
-// The original request owns the XID and will send the single authoritative
-// reply, mirroring nfsd's RC_DROPIT. handleRPCCall recognises it and returns
-// without emitting any RPC reply.
+// errDropReply is a sentinel error signalling that handleRPCCall must NOT write
+// a reply for this request, because the authoritative reply has already been
+// (or will be) sent elsewhere. Two cases use it:
+//   - DRC in-progress: the request is a duplicate of an op still in flight; the
+//     original request owns the XID and sends the single reply (nfsd RC_DROPIT).
+//   - A dispatch branch that already wrote its own reply (e.g. the NFSv4
+//     unknown-procedure PROC_UNAVAIL path) and must prevent the fall-through
+//     sendReply from emitting a second reply on the same XID.
+//
+// handleRPCCall recognises it and returns without emitting any further reply.
 var errDropReply = errors.New("duplicate request dropped")
 
 // NFSConnection handles a single NFS client TCP connection.

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -24,17 +24,19 @@ import (
 // incoming message is a backchannel REPLY (msg_type=1) rather than a CALL.
 var errBackchannelReply = errors.New("backchannel reply routed")
 
-// errDropReply is a sentinel error signalling that handleRPCCall must NOT write
-// a reply for this request, because the authoritative reply has already been
-// (or will be) sent elsewhere. Two cases use it:
-//   - DRC in-progress: the request is a duplicate of an op still in flight; the
-//     original request owns the XID and sends the single reply (nfsd RC_DROPIT).
-//   - A dispatch branch that already wrote its own reply (e.g. the NFSv4
-//     unknown-procedure PROC_UNAVAIL path) and must prevent the fall-through
-//     sendReply from emitting a second reply on the same XID.
-//
-// handleRPCCall recognises it and returns without emitting any further reply.
+// errDropReply is a sentinel error signalling that no reply must be written for
+// this request: it is a duplicate of an op still in flight (DRC in-progress).
+// The original request owns the XID and will send the single authoritative
+// reply, mirroring nfsd's RC_DROPIT. handleRPCCall recognises it and returns
+// without emitting any RPC reply.
 var errDropReply = errors.New("duplicate request dropped")
+
+// errReplyAlreadySent is a sentinel error signalling that a dispatch branch has
+// already written the single authoritative reply for this request (e.g. the
+// NFSv4 unknown-procedure PROC_UNAVAIL path). handleRPCCall recognises it and
+// returns without emitting a second reply on the same XID — unlike errDropReply,
+// it does not imply a duplicate request, so it is logged distinctly.
+var errReplyAlreadySent = errors.New("reply already sent by handler")
 
 // NFSConnection handles a single NFS client TCP connection.
 // Requests are read sequentially from the wire but dispatched concurrently

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -218,6 +218,13 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 			return nil
 		}
 
+		// A dispatch branch already wrote the single authoritative reply (e.g.
+		// the NFSv4 unknown-procedure PROC_UNAVAIL path): write nothing further.
+		if errors.Is(err, errReplyAlreadySent) {
+			logger.Debug("Reply already sent by handler", "program", call.Program, "procedure", call.Procedure, "xid", fmt.Sprintf("0x%x", call.XID), "client", clientAddr)
+			return nil
+		}
+
 		// Check if error was due to context cancellation
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			logger.Debug("Handler cancelled", "program", call.Program, "procedure", call.Procedure, "xid", fmt.Sprintf("0x%x", call.XID), "client", clientAddr, "error", err)

--- a/pkg/adapter/nfs/dispatch_v4_unknown_proc_test.go
+++ b/pkg/adapter/nfs/dispatch_v4_unknown_proc_test.go
@@ -75,7 +75,7 @@ func TestHandleRPCCall_NFSv4UnknownProcedure_SingleReply(t *testing.T) {
 	// The handler must have returned already. With the bug it would still be
 	// blocked writing a SECOND reply to the synchronous pipe (no second reader),
 	// so this select would time out. handleRPCCall recognises the internal
-	// errDropReply signal and returns nil (no further reply, no error).
+	// errReplyAlreadySent signal and returns nil (no further reply, no error).
 	select {
 	case err := <-errCh:
 		if err != nil {

--- a/pkg/adapter/nfs/dispatch_v4_unknown_proc_test.go
+++ b/pkg/adapter/nfs/dispatch_v4_unknown_proc_test.go
@@ -1,0 +1,94 @@
+package nfs
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+)
+
+// TestHandleRPCCall_NFSv4UnknownProcedure_SingleReply verifies that an NFSv4
+// RPC call for an unknown procedure number (not NULL=0 or COMPOUND=1) produces
+// EXACTLY ONE reply (PROC_UNAVAIL) on the connection.
+//
+// Before the fix the v4 default branch returned (nil, nil) after writing its
+// PROC_UNAVAIL reply, so handleRPCCall fell through to sendReply and wrote a
+// SECOND (empty MSG_ACCEPTED) reply on the same XID — corrupting the TCP stream
+// for every subsequent request on the connection.
+//
+// net.Pipe is synchronous and unbuffered: a second write would block until a
+// second read consumed it. The test reads exactly one reply, then asserts the
+// handler goroutine has already returned (it would still be blocked on the
+// second write if the bug were present) and returned errDropReply.
+func TestHandleRPCCall_NFSv4UnknownProcedure_SingleReply(t *testing.T) {
+	const testXID = uint32(0xCAFEF00D)
+	const unknownProc = uint32(7) // NFSv4 only defines NULL(0) and COMPOUND(1)
+
+	adapter := New(NFSConfig{Enabled: true, Port: 12049})
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	conn := NewNFSConnection(adapter, server, 1)
+
+	call := &rpc.RPCCallMessage{
+		XID:       testXID,
+		Program:   rpc.ProgramNFS,
+		Version:   rpc.NFSVersion4,
+		Procedure: unknownProc,
+		Cred:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+		Verf:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.handleRPCCall(context.Background(), call, nil, nil)
+	}()
+
+	// Read exactly one RPC-over-TCP reply (4-byte fragment header + body).
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(client, header); err != nil {
+		t.Fatalf("reading fragment header: %v", err)
+	}
+	bodyLen := binary.BigEndian.Uint32(header) &^ 0x80000000
+	body := make([]byte, bodyLen)
+	if _, err := io.ReadFull(client, body); err != nil {
+		t.Fatalf("reading reply body: %v", err)
+	}
+
+	// First reply must be PROC_UNAVAIL on the request XID.
+	const minLen = 24
+	if len(body) < minLen {
+		t.Fatalf("reply body too short: got %d bytes, want >= %d", len(body), minLen)
+	}
+	if xid := binary.BigEndian.Uint32(body[0:4]); xid != testXID {
+		t.Errorf("XID echo: got 0x%x, want 0x%x", xid, testXID)
+	}
+	if acceptStat := binary.BigEndian.Uint32(body[20:24]); acceptStat != rpc.RPCProcUnavail {
+		t.Errorf("accept_stat: got %d, want %d (PROC_UNAVAIL)", acceptStat, rpc.RPCProcUnavail)
+	}
+
+	// The handler must have returned already. With the bug it would still be
+	// blocked writing a SECOND reply to the synchronous pipe (no second reader),
+	// so this select would time out. handleRPCCall recognises the internal
+	// errDropReply signal and returns nil (no further reply, no error).
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("handleRPCCall returned %v, want nil (single reply already sent)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleRPCCall did not return: it is blocked writing a SECOND reply (double-reply bug)")
+	}
+
+	// Belt-and-braces: confirm no second frame is queued on the pipe.
+	_ = client.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	extra := make([]byte, 4)
+	if n, err := io.ReadFull(client, extra); err == nil {
+		t.Fatalf("unexpected second reply frame on the connection: read %d bytes", n)
+	}
+}

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -360,7 +360,12 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		return result, err
 
 	default:
-		// NFSv4 only has 2 procedures -- anything else is invalid
+		// NFSv4 only has 2 procedures -- anything else is invalid. Write the
+		// single authoritative PROC_UNAVAIL reply here, then signal the
+		// dispatcher to emit nothing further via errDropReply. Returning
+		// (nil, nil) instead would fall through to handleRPCCall's sendReply,
+		// writing a SECOND (empty MSG_ACCEPTED) reply on the same XID and
+		// corrupting the TCP stream for all subsequent requests.
 		logger.Debug("Unknown NFSv4 procedure",
 			"procedure", call.Procedure,
 			"client", clientAddr)
@@ -368,7 +373,10 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		if err != nil {
 			return nil, fmt.Errorf("make NFSv4 proc unavail reply: %w", err)
 		}
-		return nil, c.writeReply(call.XID, errorReply)
+		if writeErr := c.writeReply(call.XID, errorReply); writeErr != nil {
+			return nil, writeErr
+		}
+		return nil, errDropReply
 	}
 }
 

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -362,7 +362,7 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 	default:
 		// NFSv4 only has 2 procedures -- anything else is invalid. Write the
 		// single authoritative PROC_UNAVAIL reply here, then signal the
-		// dispatcher to emit nothing further via errDropReply. Returning
+		// dispatcher to emit nothing further via errReplyAlreadySent. Returning
 		// (nil, nil) instead would fall through to handleRPCCall's sendReply,
 		// writing a SECOND (empty MSG_ACCEPTED) reply on the same XID and
 		// corrupting the TCP stream for all subsequent requests.
@@ -376,7 +376,7 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		if writeErr := c.writeReply(call.XID, errorReply); writeErr != nil {
 			return nil, writeErr
 		}
-		return nil, errDropReply
+		return nil, errReplyAlreadySent
 	}
 }
 


### PR DESCRIPTION
Fixes #1126

Three verified HIGH audit findings (NFSv3 + NFS auth/dispatch).

## Fixes

**1. AUTH_NULL bypassed share permission enforcement** (`internal/adapter/nfs/auth/share_permission.go`)
`ResolveSharePermission` returned early with full read-write whenever `uid == nil`. AUTH_NULL requests carry no UID, so any anonymous client could write/create/delete/rename on any exported share — `default_permission=none` was never evaluated and read-only exports were not coerced. The nil-UID case is now gated through the same guest policy as an unknown UID: denied on `default_permission=none`, coerced read-only on `read` / read-only export, allowed only on `read-write`. A nil identity store or share still degrades to allow-with-defaults (genuine "no policy info"). The fix applies to both the v3 and v4 auth-context builders since both call this shared resolver. AUTH_NULL is not rejected — it is correctly mapped to the share's anonymous/squash identity.

**2. RMDIR nil dereference on post-op WCC re-fetch** (`internal/adapter/nfs/v3/handlers/rmdir.go`)
Both the cancelled-context path and the `RemoveDirectory`-error path re-fetched the parent with `GetFile`, blank-discarded the error, and dereferenced `.FileAttr`. On context cancellation or store error `GetFile` returns `(nil, err)`, panicking the server goroutine. Both paths now route through the existing `wccAfterOrFallback` helper, which guards the nil and falls back to the pre-op parent attributes.

**3. NFSv4 double-reply on unknown procedure** (`pkg/adapter/nfs/handlers.go`)
The v4 dispatch default branch wrote a `PROC_UNAVAIL` reply then returned `(nil, nil)` on `writeReply` success, so `handleRPCCall` fell through to `sendReply` and wrote a second empty `MSG_ACCEPTED` reply on the same XID — corrupting the TCP stream for all subsequent requests on the connection. It now returns `errDropReply` after writing, so the dispatcher emits nothing further (mirrors the PROG_UNAVAIL handling).

## Tests
Each fix has a negative-control test that fails (panics / asserts) without the fix:
- `TestResolveSharePermission_AnonymousAuthNull{DeniedWhenDefaultNone,CoercedReadOnly,AllowedReadWrite}`
- `TestRmdir_StoreErrorReFetchNil_NoPanic` (via a fault-injecting store wrapper, new `NewHandlerFixtureWithStore`)
- `TestHandleRPCCall_NFSv4UnknownProcedure_SingleReply`

`go test -race ./internal/adapter/nfs/... ./pkg/adapter/nfs/...` green; build + vet clean.