### PR TITLE
fix(smb): close auth/session bypasses (anon→root, no-NT-hash, lease-ack, races) (#1132)

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -478,7 +478,7 @@ func compoundShouldEncrypt(connInfo *ConnInfo, hdr *header.SMB2Header, requestEn
 		return false
 	}
 	sess, ok := connInfo.Handler.GetSession(hdr.SessionID)
-	if !ok || sess.CryptoState == nil || sess.CryptoState.Encryptor == nil {
+	if cs := sess.GetCryptoState(); !ok || cs == nil || cs.Encryptor == nil {
 		return false
 	}
 	return sess.ShouldEncrypt() || requestEncrypted
@@ -610,7 +610,8 @@ func VerifyCompoundCommandSignature(data []byte, hdr *header.SMB2Header, connInf
 	}
 
 	isSigned := hdr.Flags.IsSigned()
-	if sess.CryptoState != nil && sess.CryptoState.SigningRequired && !isSigned {
+	sessCrypto := sess.GetCryptoState()
+	if sessCrypto != nil && sessCrypto.SigningRequired && !isSigned {
 		return fmt.Errorf("STATUS_ACCESS_DENIED: compound message not signed")
 	}
 
@@ -618,7 +619,7 @@ func VerifyCompoundCommandSignature(data []byte, hdr *header.SMB2Header, connInf
 	// from authenticated sessions require disconnect.
 	if !isSigned && connInfo.CryptoState != nil && connInfo.CryptoState.GetDialect() == types.Dialect0311 &&
 		!sess.IsGuest && !sess.IsNull &&
-		sess.CryptoState != nil && sess.CryptoState.ShouldVerify() {
+		sessCrypto != nil && sessCrypto.ShouldVerify() {
 		return fmt.Errorf("SMB 3.1.1: unsigned unencrypted compound request requires disconnect")
 	}
 

--- a/internal/adapter/smb/compound_framing_safety_test.go
+++ b/internal/adapter/smb/compound_framing_safety_test.go
@@ -73,7 +73,7 @@ func TestProcessRemaining_RelatedSignatureNotSkipped(t *testing.T) {
 	// Authenticated (non-guest, non-null) session with signing required so an
 	// unsigned message trips the signing gate in VerifyCompoundCommandSignature.
 	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
-	sess.CryptoState.SigningRequired = true
+	sess.GetCryptoState().SigningRequired = true
 
 	// Related sub-command with the wire sentinel SessionID; NOT signed.
 	hdr := &header.SMB2Header{

--- a/internal/adapter/smb/framing.go
+++ b/internal/adapter/smb/framing.go
@@ -431,7 +431,7 @@ func (sv *sessionSigningVerifier) VerifyRequest(hdr *header.SMB2Header, message 
 
 	isSigned := hdr.Flags.IsSigned()
 
-	if sess.CryptoState != nil && sess.CryptoState.SigningRequired && !isSigned {
+	if cs := sess.GetCryptoState(); cs != nil && cs.SigningRequired && !isSigned {
 		logger.Warn("SMB2 message not signed but signing required",
 			"command", hdr.Command.String(),
 			"sessionID", hdr.SessionID,
@@ -451,9 +451,9 @@ func (sv *sessionSigningVerifier) VerifyRequest(hdr *header.SMB2Header, message 
 	// disconnect the connection. This applies regardless of the server's
 	// signing configuration because 3.1.1 implicitly requires message
 	// integrity for all authenticated sessions.
-	if !isSigned && sv.connCrypto != nil && sv.connCrypto.GetDialect() == types.Dialect0311 &&
+	if cs := sess.GetCryptoState(); !isSigned && sv.connCrypto != nil && sv.connCrypto.GetDialect() == types.Dialect0311 &&
 		!sess.IsGuest && !sess.IsNull &&
-		sess.CryptoState != nil && sess.CryptoState.ShouldVerify() {
+		cs != nil && cs.ShouldVerify() {
 		logger.Warn("SMB 3.1.1: unsigned unencrypted request from authenticated session, disconnecting",
 			"command", hdr.Command.String(),
 			"sessionID", hdr.SessionID,

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -31,7 +31,26 @@ var implicitAuthenticatedGroupSIDs = []string{
 const (
 	defaultUID = uint32(1000)
 	defaultGID = uint32(1000)
+
+	// nobodyUID/nobodyGID is the unprivileged identity that guest AND
+	// null/anonymous SMB sessions map to. It MUST never be 0 (root): UID 0
+	// trips the metadata UID==0 root short-circuit (auth_permissions.go) and
+	// bypasses all POSIX bits / ACLs (audit #1132). Per MS-DTYP §2.4.2.4
+	// anonymous and guest logons are excluded from "Authenticated Users", so
+	// neither gets elevated authority.
+	nobodyUID = uint32(65534)
+	nobodyGID = uint32(65534)
 )
+
+// setUnprivilegedIdentity points the AuthContext identity at the nobody/nogroup
+// (65534) UID/GID. Used for guest and null/anonymous sessions so per-file
+// permission checks still apply. Centralised so the two call sites cannot drift
+// back to a privileged mapping.
+func setUnprivilegedIdentity(authCtx *metadata.AuthContext) {
+	uid, gid := nobodyUID, nobodyGID
+	authCtx.Identity.UID = &uid
+	authCtx.Identity.GID = &gid
+}
 
 // BuildAuthContext creates a metadata.AuthContext from SMB handler context.
 //
@@ -59,20 +78,13 @@ func BuildAuthContext(ctx *SMBHandlerContext) (*metadata.AuthContext, error) {
 		BypassTraverseChecking: true,
 	}
 
-	if ctx.IsGuest {
-		// Guest session - use nobody/nogroup
-		guestUID := uint32(65534) // nobody
-		guestGID := uint32(65534) // nogroup
-		authCtx.Identity.UID = &guestUID
-		authCtx.Identity.GID = &guestGID
-	} else {
-		// Anonymous/null session - use root (for now)
-		// This allows basic operations but should be restricted by share permissions
-		rootUID := uint32(0)
-		rootGID := uint32(0)
-		authCtx.Identity.UID = &rootUID
-		authCtx.Identity.GID = &rootGID
-	}
+	// Both guest AND null/anonymous sessions map to the unprivileged
+	// nobody/nogroup identity. An anonymous SMB *connect* is spec-legal
+	// (smb2.anon-signing / anon-encryption rely on it), but the resulting
+	// principal MUST be non-privileged so per-file POSIX bits and NFSv4 ACLs
+	// are still enforced. See nobodyUID for the UID=0 root-bypass rationale
+	// (audit #1132).
+	setUnprivilegedIdentity(authCtx)
 
 	// Set share-level permission flags for guest/anonymous sessions
 	authCtx.ShareWritable = HasWritePermission(ctx)
@@ -183,10 +195,10 @@ func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
 // operations CREATE / READ / WRITE / QUERY_DIRECTORY (the four current
 // callers of this helper) arrive keyed only by FileID — the SMB2 dispatcher
 // has no user state to prefill ctx.User with. Without this hand-off
-// BuildAuthContext takes the ctx.User==nil arm and synthesises a UID-0
-// "anonymous/root" identity, which then trips the UID-0 root-bypass at the
-// top of metadata permission checks (e.g. ABE filterByAccess) and silently
-// grants root.
+// BuildAuthContext takes the ctx.User==nil arm and synthesises an
+// unprivileged nobody (65534) identity instead of the authenticated user's
+// UID, causing follow-up ops to be authorized as nobody rather than the
+// real opener.
 //
 // We also realign ctx.TreeID / ctx.SessionID onto the IDs the open was
 // created against. Downstream gates (notably treeHasAccessBasedEnumeration
@@ -239,8 +251,8 @@ func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessio
 //
 // Guest and null sessions have User=nil but carry IsGuest/IsNull on the
 // session — the snapshot preserves those flags so the rebuilt opener
-// AuthContext maps back to the same nobody/65534 (or root-fallback)
-// identity rather than re-resolving against the current session's user.
+// AuthContext maps back to the same unprivileged nobody/65534 identity
+// rather than re-resolving against the current session's user.
 //
 // smbtorture smb2.session.reauth4 / reauth5 gate on this — the tests open
 // h1 / dh1 as U1, re-auth the session to anonymous, then SET_INFO SD on
@@ -317,19 +329,10 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 		Identity:               &metadata.Identity{},
 		BypassTraverseChecking: true,
 	}
-	if openFile.OpenerIsGuest {
-		guestUID := uint32(65534) // nobody
-		guestGID := uint32(65534) // nogroup
-		authCtx.Identity.UID = &guestUID
-		authCtx.Identity.GID = &guestGID
-	} else {
-		// Anonymous/null opener — fall back to root, matching the
-		// existing BuildAuthContext(ctx.User==nil, IsGuest==false) arm.
-		rootUID := uint32(0)
-		rootGID := uint32(0)
-		authCtx.Identity.UID = &rootUID
-		authCtx.Identity.GID = &rootGID
-	}
+	// Guest AND null/anonymous openers both map to the unprivileged
+	// nobody/nogroup identity, matching the BuildAuthContext User==nil arm.
+	// Never UID=0 — see nobodyUID for the root-bypass rationale.
+	setUnprivilegedIdentity(authCtx)
 	authCtx.ShareWritable = HasWritePermission(ctx)
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 	return authCtx

--- a/internal/adapter/smb/handlers/auth_helper_test.go
+++ b/internal/adapter/smb/handlers/auth_helper_test.go
@@ -178,6 +178,67 @@ func TestPrimeAuthContext_PreservesFixtureUserWhenSessionUserNil(t *testing.T) {
 	}
 }
 
+// TestBuildAuthContext_NullSessionMapsToNobodyNotRoot is the negative control
+// for the anonymous-NTLM-to-UID-0 root-bypass (audit #1132 HIGH). A null /
+// anonymous SMB session has ctx.User==nil and ctx.IsGuest==false. Before the
+// fix BuildAuthContext mapped it to UID=0/GID=0, which trips the UID==0 root
+// short-circuit in pkg/metadata/auth_permissions.go and grants
+// root-equivalent access to every file regardless of POSIX bits or ACLs.
+//
+// The mapping MUST resolve to the unprivileged nobody/nogroup (65534)
+// identity so per-file permission checks still apply. Accepting the anonymous
+// *connection* stays legal (smb2.anon-signing / anon-encryption); only the
+// identity mapping changes.
+func TestBuildAuthContext_NullSessionMapsToNobodyNotRoot(t *testing.T) {
+	ctx := &SMBHandlerContext{
+		Context: context.Background(),
+		User:    nil,   // anonymous / null
+		IsGuest: false, // NOT a guest — this is the null-session arm
+	}
+
+	authCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+	if authCtx.Identity == nil || authCtx.Identity.UID == nil || authCtx.Identity.GID == nil {
+		t.Fatal("null session produced no UID/GID identity")
+	}
+	if *authCtx.Identity.UID == 0 || *authCtx.Identity.GID == 0 {
+		t.Fatalf("null/anonymous session mapped to UID=%d/GID=%d — this hits the metadata UID==0 root bypass and grants root to unauthenticated clients",
+			*authCtx.Identity.UID, *authCtx.Identity.GID)
+	}
+	if *authCtx.Identity.UID != 65534 || *authCtx.Identity.GID != 65534 {
+		t.Errorf("null session UID/GID = %d/%d, want 65534/65534 (nobody/nogroup)",
+			*authCtx.Identity.UID, *authCtx.Identity.GID)
+	}
+}
+
+// TestBuildOpenerAuthContext_NullOpenerMapsToNobodyNotRoot is the negative
+// control for the same root-bypass on the handle-bound opener path
+// (buildOpenerAuthContext). A handle opened by a null session (OpenerUser==nil,
+// OpenerIsGuest==false, OpenerIsNull==true) must rebuild to the unprivileged
+// nobody identity, never UID=0.
+func TestBuildOpenerAuthContext_NullOpenerMapsToNobodyNotRoot(t *testing.T) {
+	h := NewHandler()
+	ctx := &SMBHandlerContext{Context: context.Background()}
+	openFile := &OpenFile{
+		OpenerUser:    nil,
+		OpenerIsGuest: false,
+		OpenerIsNull:  true,
+	}
+
+	authCtx := h.buildOpenerAuthContext(ctx, openFile)
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		t.Fatal("null opener produced no identity")
+	}
+	if *authCtx.Identity.UID == 0 {
+		t.Fatalf("null opener mapped to UID=0 — root bypass on the handle-bound path")
+	}
+	if *authCtx.Identity.UID != 65534 {
+		t.Errorf("null opener UID = %d, want 65534 (nobody)", *authCtx.Identity.UID)
+	}
+}
+
 // TestPropagateOpenFileParentLeaseKey_Set asserts that the helper copies
 // OpenFile.ParentLeaseKey / HasParentLeaseKey onto the AuthContext so the
 // metadata layer can route the value into notifyDirChange (#470 C6/C7).

--- a/internal/adapter/smb/handlers/auth_priming_test.go
+++ b/internal/adapter/smb/handlers/auth_priming_test.go
@@ -142,20 +142,25 @@ func TestFlush_PrimesAuthContextFromOpenFile(t *testing.T) {
 		t.Errorf("ctx.TreeID = %d, want %d", ctx.TreeID, treeID)
 	}
 
-	// Negative: with no prime, BuildAuthContext mints UID-0 root. Confirm
-	// the bug exists in the bare path so the positive prime fix is
-	// actually load-bearing.
+	// Negative: with no prime, BuildAuthContext takes the User==nil arm and
+	// mints the unprivileged nobody (65534) identity — NOT the authenticated
+	// opener (bob). The prime is what restores the real opener's UID; this
+	// asserts the bare path differs (and is non-privileged) so the prime is
+	// load-bearing. Crucially the bare path must NOT be root (UID=0), which
+	// would bypass all metadata permission checks (audit #1132).
 	bareCtx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
 	bareAuth, err := BuildAuthContext(bareCtx)
 	if err != nil {
 		t.Fatalf("BuildAuthContext (bare): %v", err)
 	}
-	if bareAuth.Identity == nil || bareAuth.Identity.UID == nil || *bareAuth.Identity.UID != 0 {
-		gotUID := uint32(0xffffffff)
-		if bareAuth.Identity != nil && bareAuth.Identity.UID != nil {
-			gotUID = *bareAuth.Identity.UID
-		}
-		t.Errorf("bare-ctx BuildAuthContext.UID = %d, want 0 (root) — anonymous arm is what the prime is supposed to bypass; test fixture has drifted", gotUID)
+	if bareAuth.Identity == nil || bareAuth.Identity.UID == nil {
+		t.Fatal("bare-ctx BuildAuthContext produced no UID")
+	}
+	if *bareAuth.Identity.UID == 0 {
+		t.Errorf("bare-ctx BuildAuthContext.UID = 0 (root) — null session must map to unprivileged nobody, not root (audit #1132)")
+	}
+	if *bareAuth.Identity.UID != 65534 {
+		t.Errorf("bare-ctx BuildAuthContext.UID = %d, want 65534 (nobody); the prime restores the real opener UID", *bareAuth.Identity.UID)
 	}
 }
 

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -2183,8 +2183,9 @@ func isOplockStatOpen(desiredAccess uint32) bool {
 // This is used for durable handle security validation during reconnect.
 // Returns zero hash if the session has no crypto state or signing key.
 func computeSessionKeyHash(sess *session.Session) [32]byte {
-	if sess == nil || sess.CryptoState == nil || len(sess.CryptoState.SigningKey) == 0 {
+	cs := sess.GetCryptoState()
+	if cs == nil || len(cs.SigningKey) == 0 {
 		return [32]byte{}
 	}
-	return sha256.Sum256(sess.CryptoState.SigningKey)
+	return sha256.Sum256(cs.SigningKey)
 }

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -136,7 +136,17 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 	h := NewHandler()
 	h.Registry = rt
 
+	// Authenticated session whose identity (UID/GID 0) matches the file
+	// owner created above. A null/anonymous session would map to the
+	// unprivileged nobody (65534) and be denied write on the 0o644 files
+	// (audit #1132 — null sessions no longer get root).
+	sessUID, sessGID := uint32(0), uint32(0)
 	sess := h.CreateSession("127.0.0.1:54321", false, "tester", "")
+	sess.User = &models.User{
+		Username: "tester",
+		UID:      &sessUID,
+		Groups:   []models.Group{{GID: &sessGID}},
+	}
 	const treeID uint32 = 1
 	h.StoreTree(&TreeConnection{TreeID: treeID, SessionID: sess.SessionID, ShareName: shareName})
 
@@ -332,7 +342,15 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 
 	h := NewHandler()
 	h.Registry = rt
+	// Authenticated session whose UID/GID 0 matches the file owner; a null
+	// session would map to nobody (65534) and be denied write (audit #1132).
+	sessUID, sessGID := uint32(0), uint32(0)
 	sess := h.CreateSession("127.0.0.1:54321", false, "tester", "")
+	sess.User = &models.User{
+		Username: "tester",
+		UID:      &sessUID,
+		Groups:   []models.Group{{GID: &sessGID}},
+	}
 	const treeID uint32 = 1
 	h.StoreTree(&TreeConnection{TreeID: treeID, SessionID: sess.SessionID, ShareName: shareName})
 

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1215,41 +1215,25 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				return h.buildAuthenticatedResponse(pending, signingKey[:], authMsg.NegotiateFlags, sess.ShouldEncrypt()), nil
 			}
 
-			// SECURITY: User exists but no valid NT hash configured.
-			// This is a transitional mode that allows authentication without password validation.
-			// Any client knowing the username can authenticate - this bypasses credential checks entirely.
-			// To fix: run 'dittofs user passwd <username>' to set an NT hash for this user.
-			// Client may have presented an NTLM response, but we can't verify it due to missing NT hash.
-			logger.Warn("SECURITY: User authenticated without credential validation (no NT hash configured)",
+			// SECURITY: User exists and is enabled, but either has no NT hash
+			// configured or presented no NTLM response to validate against it.
+			// We CANNOT prove the client controls this account, so we MUST NOT
+			// grant the user's authenticated identity. Doing so previously let
+			// any client that merely knew a valid username authenticate as that
+			// user (missing-authentication / privilege-escalation). Reject the
+			// logon. An account with no password set is unusable for password
+			// auth by design — set one with 'dittofs user passwd <username>'.
+			logger.Warn("SECURITY: rejecting NTLM logon — no credential to validate (no NT hash configured or no NTLM response)",
 				"username", authMsg.Username,
-				"action", "run 'dittofs user passwd' to fix")
+				"hasNTHash", hasNTHash,
+				"action", "run 'dittofs user passwd' to set a password")
 
-			ctx.IsGuest = false
-
-			if pending.IsBinding {
-				// Without a validated signing key we cannot derive a channel
-				// signing key; a bind here would leave the channel unsigned.
-				return NewErrorResult(types.StatusLogonFailure), nil
-			}
-
+			// Re-auth and bind must fail closed without replacing/keeping the
+			// existing session (MS-SMB2 §3.3.5.5.2 / §3.3.5.5.3).
 			if pending.IsReauth {
-				if result := h.tryReauthUpdate(pending, resolvedUsername, authMsg.Domain, user, false); result != nil {
-					return result, nil
-				}
+				h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 			}
-
-			sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
-			sess.OriginConnID = ctx.ConnID
-			recordSessionBindIdentity(sess, ctx)
-
-			// No signing without proper session key derivation
-			logger.Debug("NTLM authentication complete (no credential validation)",
-				"sessionID", sess.SessionID,
-				"username", sess.Username,
-				"domain", sess.Domain,
-				"isGuest", sess.IsGuest)
-
-			return h.buildAuthenticatedResponse(pending, nil, authMsg.NegotiateFlags, false), nil
+			return NewErrorResult(types.StatusLogonFailure), nil
 		}
 
 		// User not found or disabled

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1228,8 +1228,11 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				"hasNTHash", hasNTHash,
 				"action", "run 'dittofs user passwd' to set a password")
 
-			// Re-auth and bind must fail closed without replacing/keeping the
-			// existing session (MS-SMB2 §3.3.5.5.2 / §3.3.5.5.3).
+			// Fail closed. On re-auth the existing authenticated session MUST be
+			// destroyed (MS-SMB2 §3.3.5.5.3) so the prior identity cannot
+			// survive a failed re-auth. On bind the existing session is left
+			// intact (MS-SMB2 §3.3.5.5.2) — only this bind attempt fails. A
+			// fresh SESSION_SETUP simply returns LOGON_FAILURE with no session.
 			if pending.IsReauth {
 				h.destroySessionOnReauthFailure(ctx.Context, pending, authMsg.Username)
 			}

--- a/internal/adapter/smb/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/handlers/session_setup_reauth_test.go
@@ -350,3 +350,67 @@ func TestSessionSetup_FailedReauth_UnparseableType3_DestroysSession(t *testing.T
 
 	f.assertSessionDestroyedAndNotifyCleaned(t, result.Status)
 }
+
+// TestSessionSetup_UserWithoutNTHash_Rejected is the negative control for the
+// no-NT-hash authentication bypass (audit #1132 HIGH). An enabled user that
+// has no NT hash configured (no password ever set) must NOT be granted an
+// authenticated session merely because a client knows the username — that is a
+// missing-authentication / privilege-escalation vulnerability.
+//
+// Before the fix, completeNTLMAuth's "transitional mode" branch created a full
+// Session with IsGuest=false and User=<the real user>, granting the user's
+// identity and all share/file permissions with no credential check. The fix
+// rejects the logon with STATUS_LOGON_FAILURE and creates no authenticated
+// session.
+func TestSessionSetup_UserWithoutNTHash_Rejected(t *testing.T) {
+	cpStore := newInMemoryStoreForTest(t)
+	// Enabled user with NO NT hash (no SetNTHashFromPassword call) -> hasNTHash
+	// is false in completeNTLMAuth.
+	noHash := &models.User{Username: "dave", Enabled: true}
+	if _, err := cpStore.CreateUser(context.Background(), noHash); err != nil {
+		t.Fatalf("CreateUser(no hash): %v", err)
+	}
+	if _, ok := noHash.GetNTHash(); ok {
+		t.Fatal("test precondition: user unexpectedly has an NT hash")
+	}
+
+	h := NewHandler()
+	h.NtlmEnabled = true
+	h.Registry = runtime.New(cpStore)
+
+	// Fresh session: NEGOTIATE (TYPE_1) then AUTHENTICATE (TYPE_3).
+	ctx1 := newTestContext(0)
+	negResult, err := h.SessionSetup(ctx1, buildSessionSetupRequestBody(validNTLMNegotiateMessage()))
+	if err != nil {
+		t.Fatalf("NEGOTIATE error: %v", err)
+	}
+	if negResult.Status != types.StatusMoreProcessingRequired {
+		t.Fatalf("NEGOTIATE status = 0x%x, want MORE_PROCESSING_REQUIRED", negResult.Status)
+	}
+	sessionID := ctx1.SessionID
+
+	// AUTHENTICATE with the username but a present NtChallengeResponse blob.
+	// hasNTHash is false, so the validation block is skipped and execution
+	// reaches the no-credential branch regardless of the response bytes.
+	ntResponse := make([]byte, 16+28+4)
+	ntResponse[16] = 0x01
+	ntResponse[17] = 0x01
+	ctx2 := newTestContext(sessionID)
+	result, err := h.SessionSetup(ctx2, buildSessionSetupRequestBody(
+		buildNTLMAuthenticateForTest("dave", "WORKGROUP", ntResponse),
+	))
+	if err != nil {
+		t.Fatalf("AUTHENTICATE error: %v", err)
+	}
+
+	if result.Status != types.StatusLogonFailure {
+		t.Errorf("AUTHENTICATE status = 0x%x, want STATUS_LOGON_FAILURE — a user with no NT hash must not authenticate",
+			uint32(result.Status))
+	}
+
+	// No authenticated session for this user may exist.
+	if sess, ok := h.GetSession(sessionID); ok && !sess.IsGuest && sess.User != nil {
+		t.Errorf("authenticated session created for credential-less user %q (User=%+v); the no-NT-hash bypass is still open",
+			sess.Username, sess.User)
+	}
+}

--- a/internal/adapter/smb/handlers/session_setup_test.go
+++ b/internal/adapter/smb/handlers/session_setup_test.go
@@ -1036,10 +1036,11 @@ func TestConfigureSessionSigningWithKey_Encryption(t *testing.T) {
 		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
 			t.Fatalf("unexpected error result: %v", errResult.Status)
 		}
-		if sess.CryptoState == nil || sess.CryptoState.Encryptor == nil {
+		cs := sess.GetCryptoState()
+		if cs == nil || cs.Encryptor == nil {
 			t.Error("Encryptor not created in preferred mode (per-share enforcement needs it)")
 		}
-		if sess.CryptoState.Decryptor == nil {
+		if cs.Decryptor == nil {
 			t.Error("Decryptor not created in preferred mode")
 		}
 		if sess.ShouldEncrypt() {
@@ -1109,7 +1110,7 @@ func TestConfigureSessionSigningWithKey_IsNullEncryptionGate(t *testing.T) {
 		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
 			t.Fatalf("unexpected error result: %v", errResult.Status)
 		}
-		if sess.CryptoState != nil && sess.CryptoState.Decryptor != nil {
+		if scs := sess.GetCryptoState(); scs != nil && scs.Decryptor != nil {
 			t.Error("Decryptor derived on IsNull session without prior auth (would break anon-encryption1/3)")
 		}
 	})
@@ -1129,7 +1130,7 @@ func TestConfigureSessionSigningWithKey_IsNullEncryptionGate(t *testing.T) {
 		if errResult := h.configureSessionSigningWithKey(sess, sessionKey, ctx); errResult != nil {
 			t.Fatalf("unexpected error result: %v", errResult.Status)
 		}
-		if sess.CryptoState == nil || sess.CryptoState.Decryptor == nil {
+		if scs := sess.GetCryptoState(); scs == nil || scs.Decryptor == nil {
 			t.Error("Decryptor NOT derived on IsNull session with prior auth (would break anon-encryption2)")
 		}
 	})

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -802,6 +802,17 @@ func (h *Handler) handleLeaseBreakAck(ctx *SMBHandlerContext, body []byte) (*Han
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
+	// MS-SMB2 §3.3.5.22.2 step 1: only the client that owns the lease may
+	// acknowledge its break. Without this gate any authenticated session
+	// could fabricate an ack for an arbitrary 16-byte leaseKey it does not
+	// own and downgrade another client's lease (data-integrity / DoS).
+	if !h.LeaseManager.VerifyLeaseAckOwnership(ack.LeaseKey, ctx.SessionID, connClientGUID(ctx)) {
+		logger.Warn("LEASE_BREAK_ACK: ownership check failed — session does not own lease",
+			"leaseKey", fmt.Sprintf("%x", ack.LeaseKey),
+			"sessionID", ctx.SessionID)
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
 	if err := h.LeaseManager.AcknowledgeLeaseBreak(ctx.Context, ack.LeaseKey, ack.LeaseState, 0); err != nil {
 		logger.Warn("LEASE_BREAK_ACK: acknowledgment failed",
 			"leaseKey", fmt.Sprintf("%x", ack.LeaseKey),

--- a/internal/adapter/smb/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_test.go
@@ -739,8 +739,9 @@ func TestTreeConnect_RequiredModeRejectsUnencryptedSession(t *testing.T) {
 
 		// Create a session WITH encryption
 		sess := h.CreateSession("127.0.0.1:12345", false, "testuser", "DOMAIN")
-		sess.CryptoState.EncryptData = true
-		sess.CryptoState.Encryptor = &mockEncryptor{}
+		sessCrypto := sess.GetCryptoState()
+		sessCrypto.EncryptData = true
+		sessCrypto.Encryptor = &mockEncryptor{}
 
 		share := &runtime.Share{
 			Name:        "/encrypted",

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -547,6 +547,54 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 	return sid, ok
 }
 
+// VerifyLeaseAckOwnership reports whether a session presenting a
+// LEASE_BREAK_ACK for leaseKey is entitled to acknowledge it, per MS-SMB2
+// §3.3.5.22.2 step 1 ("the server MUST locate the lease ... whose LeaseKey
+// matches ... and whose ClientGuid matches the Connection.ClientGuid"). A
+// lease is bound to a (ClientGuid, LeaseKey) pair, so an ack is valid only
+// when it arrives from the owning client.
+//
+// Authorization rule (most-specific first):
+//   - If a ClientGUID was recorded for this leaseKey (the normal lease-V2 /
+//     multi-session path) the ack's connection ClientGUID MUST match it.
+//   - Otherwise (no GUID recorded — traditional oplock-as-lease, durable
+//     reconnect paths, and tests that don't thread a CryptoState) fall back
+//     to the per-lease sessionMap and require the ack's sessionID to match.
+//
+// Returns false when the lease is unknown so a stray ack for a non-existent
+// lease key cannot be used to probe state. A zero connGUID never matches a
+// recorded non-zero GUID, so an attacker who cannot reproduce the victim's
+// ClientGUID is rejected.
+func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) bool {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	// Prefer ClientGUID binding when one was recorded for this key.
+	matchedGUID := false
+	for clk, guid := range lm.leaseClientGUID {
+		if clk.Key != leaseKey {
+			continue
+		}
+		matchedGUID = true
+		if guid == connGUID && connGUID != ([16]byte{}) {
+			return true
+		}
+	}
+	if matchedGUID {
+		// A GUID binding exists but the ack's connection GUID didn't match
+		// any of them (or was zero): reject.
+		return false
+	}
+
+	// Legacy fallback: no ClientGUID binding. Require the per-lease session
+	// to match the acking session.
+	sid, ok := lm.sessionMap[leaseKey]
+	if !ok {
+		return false
+	}
+	return sid == sessionID
+}
+
 // GetSessionForBreak returns the sessionID that should receive a break
 // notification for the given lease. Per MS-SMB2 §3.3.4.7 and Samba
 // `smbXsrv_pending_break_submit` (source3/smbd/smb2_server.c) the break is

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -554,45 +554,51 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 // lease is bound to a (ClientGuid, LeaseKey) pair, so an ack is valid only
 // when it arrives from the owning client.
 //
-// Authorization rule (most-specific first):
-//   - If a ClientGUID was recorded for this leaseKey (the normal lease-V2 /
-//     multi-session path) the ack's connection ClientGUID MUST match it.
-//   - Otherwise (no GUID recorded — traditional oplock-as-lease, durable
-//     reconnect paths, and tests that don't thread a CryptoState) fall back
-//     to the per-lease sessionMap and require the ack's sessionID to match.
+// Authorization rule:
+//   - The lease must exist (sessionMap is the authoritative leaseKey registry).
+//   - The ack is authorized if the acking sessionID is the lease's registering
+//     session (the common case), OR the ack's connection ClientGUID matches the
+//     lease's recorded (ClientGuid, LeaseKey) binding (multichannel / durable
+//     reconnect on a different session of the same client).
 //
 // Returns false when the lease is unknown so a stray ack for a non-existent
 // lease key cannot be used to probe state. A zero connGUID never matches a
 // recorded non-zero GUID, so an attacker who cannot reproduce the victim's
 // ClientGUID is rejected.
+//
+// Cost: O(1) for the legitimate-owner ack (the only ack a well-behaved client
+// sends) via the sessionMap fast path below. The ClientGUID scan runs only for
+// acks whose sessionID does NOT already own the lease — and is bounded by the
+// number of distinct clients holding this EXACT leaseKey (effectively 1 for
+// real clients, which use random 16-byte keys), not the total lease count.
 func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
 
-	// Prefer ClientGUID binding when one was recorded for this key.
-	matchedGUID := false
-	for clk, guid := range lm.leaseClientGUID {
-		if clk.Key != leaseKey {
-			continue
-		}
-		matchedGUID = true
-		if guid == connGUID && connGUID != ([16]byte{}) {
-			return true
-		}
-	}
-	if matchedGUID {
-		// A GUID binding exists but the ack's connection GUID didn't match
-		// any of them (or was zero): reject.
+	// Lease must exist (sessionMap is the authoritative leaseKey registry).
+	sid, known := lm.sessionMap[leaseKey]
+	if !known {
 		return false
 	}
 
-	// Legacy fallback: no ClientGUID binding. Require the per-lease session
-	// to match the acking session.
-	sid, ok := lm.sessionMap[leaseKey]
-	if !ok {
-		return false
+	// Fast path: the registering session is acking its own lease. O(1).
+	if sid == sessionID {
+		return true
 	}
-	return sid == sessionID
+
+	// Otherwise the ack may still be legitimate via the ClientGUID binding
+	// (multichannel / durable reconnect on a different session of the same
+	// client). Match the ack's connection GUID against the lease's recorded
+	// binding. A zero connGUID never matches a recorded non-zero GUID.
+	if connGUID != ([16]byte{}) {
+		for clk, guid := range lm.leaseClientGUID {
+			if clk.Key == leaseKey && guid == connGUID {
+				return true
+			}
+		}
+	}
+	// Neither the owning session nor a matching ClientGUID binding -> reject.
+	return false
 }
 
 // GetSessionForBreak returns the sessionID that should receive a break

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -229,6 +229,83 @@ func TestGetSessionForBreak_FallsBackToSessionMap(t *testing.T) {
 	}
 }
 
+// TestVerifyLeaseAckOwnership is the negative control for the LEASE_BREAK_ACK
+// ownership gate (audit #1132 HIGH). Per MS-SMB2 §3.3.5.22.2 step 1, only the
+// client that owns the lease may acknowledge its break. Before the fix
+// handleLeaseBreakAck trusted the wire-supplied leaseKey with no ownership
+// check, so any authenticated session could downgrade another client's lease.
+func TestVerifyLeaseAckOwnership(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ClientGUIDBound_OwnerAcceptedImposterRejected", func(t *testing.T) {
+		mgr := lock.NewManager()
+		lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+
+		ownerGUID := [16]byte{0xCA, 0xFE, 0xBA, 0xBE}
+		const ownerSession uint64 = 100
+		leaseKey := [16]byte{0x01}
+		fh := lock.FileHandle("file-1")
+
+		if _, _, err := lm.RequestLease(context.Background(), fh,
+			leaseKey, [16]byte{}, ownerSession, ownerGUID,
+			"owner-1", "client-1", "share1",
+			lock.LeaseStateRead|lock.LeaseStateWrite, false); err != nil {
+			t.Fatalf("RequestLease: %v", err)
+		}
+
+		// Owning client's connection GUID is accepted (sessionID irrelevant
+		// when a GUID binding exists — break routing is client-level).
+		if !lm.VerifyLeaseAckOwnership(leaseKey, ownerSession, ownerGUID) {
+			t.Error("owning client's ack rejected — should be accepted")
+		}
+
+		// An attacker session on a DIFFERENT client GUID must be rejected even
+		// though it knows the (fixed, well-known) lease key.
+		attackerGUID := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+		const attackerSession uint64 = 999
+		if lm.VerifyLeaseAckOwnership(leaseKey, attackerSession, attackerGUID) {
+			t.Error("imposter client's ack accepted — lease downgrade by non-owner is possible")
+		}
+
+		// A zero connection GUID must never match a recorded non-zero binding.
+		if lm.VerifyLeaseAckOwnership(leaseKey, attackerSession, [16]byte{}) {
+			t.Error("zero-GUID ack accepted against a GUID-bound lease")
+		}
+	})
+
+	t.Run("LegacyNoGUID_SessionMapEnforced", func(t *testing.T) {
+		mgr := lock.NewManager()
+		lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+
+		const ownerSession uint64 = 42
+		leaseKey := [16]byte{0xAB}
+		fh := lock.FileHandle("file-1")
+
+		// Zero ClientGUID -> falls back to per-lease sessionMap.
+		if _, _, err := lm.RequestLease(context.Background(), fh,
+			leaseKey, [16]byte{}, ownerSession, [16]byte{},
+			"owner-1", "client-1", "share1",
+			lock.LeaseStateRead, false); err != nil {
+			t.Fatalf("RequestLease: %v", err)
+		}
+
+		if !lm.VerifyLeaseAckOwnership(leaseKey, ownerSession, [16]byte{}) {
+			t.Error("owning session's ack rejected in sessionMap fallback")
+		}
+		if lm.VerifyLeaseAckOwnership(leaseKey, ownerSession+1, [16]byte{}) {
+			t.Error("non-owning session's ack accepted in sessionMap fallback — cross-session lease downgrade possible")
+		}
+	})
+
+	t.Run("UnknownLeaseRejected", func(t *testing.T) {
+		mgr := lock.NewManager()
+		lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+		if lm.VerifyLeaseAckOwnership([16]byte{0xFF}, 1, [16]byte{}) {
+			t.Error("ack for a non-existent lease accepted")
+		}
+	})
+}
+
 // TestReleaseSessionLeases_ReapsClientPrimary verifies that when a session
 // is torn down (LOGOFF / disconnect), any clientPrimarySession entry that
 // pointed at it is removed. Without this the next break for a lease bound

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -253,10 +253,18 @@ func TestVerifyLeaseAckOwnership(t *testing.T) {
 			t.Fatalf("RequestLease: %v", err)
 		}
 
-		// Owning client's connection GUID is accepted (sessionID irrelevant
-		// when a GUID binding exists — break routing is client-level).
+		// Owning session acks its own lease.
 		if !lm.VerifyLeaseAckOwnership(leaseKey, ownerSession, ownerGUID) {
-			t.Error("owning client's ack rejected — should be accepted")
+			t.Error("owning session's ack rejected — should be accepted")
+		}
+
+		// Multichannel / durable reconnect: a DIFFERENT session of the SAME
+		// client (same ClientGUID) acks. Break routing is client-level, so
+		// this must be accepted via the GUID binding even though the sessionID
+		// differs from the registering one.
+		const otherOwnerSession uint64 = 101
+		if !lm.VerifyLeaseAckOwnership(leaseKey, otherOwnerSession, ownerGUID) {
+			t.Error("same-client different-session ack rejected — multichannel/durable owner must be accepted via ClientGUID")
 		}
 
 		// An attacker session on a DIFFERENT client GUID must be rejected even

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -792,7 +792,10 @@ func sendDispatchError(reqHeader *header.SMB2Header, status types.Status, connIn
 		return SendErrorResponse(reqHeader, status, connInfo)
 	}
 	sess, ok := connInfo.Handler.GetSession(reqHeader.SessionID)
-	if !ok || sess.CryptoState == nil || sess.CryptoState.Encryptor == nil {
+	if !ok {
+		return SendErrorResponse(reqHeader, status, connInfo)
+	}
+	if cs := sess.GetCryptoState(); cs == nil || cs.Encryptor == nil {
 		return SendErrorResponse(reqHeader, status, connInfo)
 	}
 
@@ -871,7 +874,7 @@ func SendSignatureFailureResponse(reqHeader *header.SMB2Header, status types.Sta
 func sendMessageWithSigner(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, signingSessionID uint64) error {
 	smbPayload := append(hdr.Encode(), body...)
 	sess, ok := connInfo.Handler.GetSession(signingSessionID)
-	if !ok || sess.CryptoState == nil {
+	if !ok || sess.GetCryptoState() == nil {
 		// Falls back to plain unsigned send.
 		return WriteNetBIOSFrame(connInfo.Conn, connInfo.WriteMu, connInfo.WriteTimeout, smbPayload)
 	}
@@ -935,8 +938,8 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, respon
 			isSessionSetup := hdr.Command == types.SMB2SessionSetup
 			isSessionSetupSuccess := isSessionSetup && hdr.Status == types.StatusSuccess
 			isInterim := isSessionSetup && hdr.Status != types.StatusSuccess
-			if isSessionSetupSuccess && sess.NewlyCreated {
-				sess.NewlyCreated = false // Clear so subsequent messages get encrypted
+			if isSessionSetupSuccess && sess.IsNewlyCreated() {
+				sess.ClearNewlyCreated() // Clear so subsequent messages get encrypted
 				suppressSessionSetupEncryption = true
 			}
 			// Encrypt when the session forces it (mode=required), the
@@ -949,8 +952,8 @@ func sendMessage(hdr *header.SMB2Header, body []byte, connInfo *ConnInfo, respon
 			// must still get encrypted responses — pull the tree-level flag
 			// and honour responseEncrypted.
 			shouldEncrypt := sess.ShouldEncrypt() || responseEncrypted
-			if !shouldEncrypt && hdr.TreeID != 0 && sess.CryptoState != nil &&
-				sess.CryptoState.Encryptor != nil {
+			if cs := sess.GetCryptoState(); !shouldEncrypt && hdr.TreeID != 0 && cs != nil &&
+				cs.Encryptor != nil {
 				if tree, ok := connInfo.Handler.GetTree(hdr.TreeID); ok && tree.EncryptData {
 					shouldEncrypt = true
 				}

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -74,18 +74,29 @@ type Session struct {
 	// for permission checking and share access control.
 	User *models.User
 
-	// CryptoState holds per-session cryptographic state (signing keys, signer,
+	// cryptoState holds per-session cryptographic state (signing keys, signer,
 	// encryption/decryption keys). Replaces the old Signing field.
 	// For 2.x: HMAC-SHA256 signer. For 3.x: CMAC/GMAC signer + KDF-derived keys.
-	CryptoState *SessionCryptoState
+	//
+	// Stored as an atomic pointer: SESSION_SETUP re-authentication
+	// (configureSessionSigningWithKey -> SetCryptoState) swaps the whole
+	// SessionCryptoState on an already-published session while in-flight
+	// requests on the same session read it via ShouldSign / ShouldEncrypt /
+	// VerifyMessage / DecryptMessage and the response path. A plain pointer
+	// store/load across goroutines is a data race under the Go memory model
+	// and can observe a torn or partially-initialised state. Access only via
+	// GetCryptoState / SetCryptoState (and the wrapper methods below).
+	cryptoState atomic.Pointer[SessionCryptoState]
 
-	// NewlyCreated is true for sessions just established via SESSION_SETUP.
+	// newlyCreated is true for sessions just established via SESSION_SETUP.
 	// The framing layer uses this to suppress encryption on the initial
 	// SESSION_SETUP SUCCESS response (client hasn't derived keys yet).
 	// For re-authenticated sessions this is false, so the response is encrypted
 	// with existing keys as expected by the client.
-	// Cleared by the framing layer after the first response.
-	NewlyCreated bool
+	// Cleared by the framing layer after the first response. Atomic because the
+	// per-request dispatch goroutines race the clear against subsequent reads
+	// (response.go) — mirrors LoggedOff.
+	newlyCreated atomic.Bool
 
 	// ExpiresAt holds the Kerberos ticket end time for Kerberos-authenticated
 	// sessions. Zero value means no expiration (NTLM or guest sessions).
@@ -200,17 +211,17 @@ type Credits struct {
 // Called internally by SessionManager.CreateSession.
 func NewSession(sessionID uint64, clientAddr string, isGuest bool, username, domain string) *Session {
 	s := &Session{
-		SessionID:    sessionID,
-		IsGuest:      isGuest,
-		IsNull:       username == "" && !isGuest,
-		CreatedAt:    time.Now(),
-		ClientAddr:   clientAddr,
-		Username:     username,
-		Domain:       domain,
-		CryptoState:  &SessionCryptoState{},
-		NewlyCreated: true,
-		channels:     make(map[uint64]*Channel),
+		SessionID:  sessionID,
+		IsGuest:    isGuest,
+		IsNull:     username == "" && !isGuest,
+		CreatedAt:  time.Now(),
+		ClientAddr: clientAddr,
+		Username:   username,
+		Domain:     domain,
+		channels:   make(map[uint64]*Channel),
 	}
+	s.cryptoState.Store(&SessionCryptoState{})
+	s.newlyCreated.Store(true)
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s
 }
@@ -219,18 +230,18 @@ func NewSession(sessionID uint64, clientAddr string, isGuest bool, username, dom
 // Use this when the user has been authenticated against the UserStore.
 func NewSessionWithUser(sessionID uint64, clientAddr string, user *models.User, domain string) *Session {
 	s := &Session{
-		SessionID:    sessionID,
-		IsGuest:      false,
-		IsNull:       false,
-		CreatedAt:    time.Now(),
-		ClientAddr:   clientAddr,
-		Username:     user.Username,
-		Domain:       domain,
-		User:         user,
-		CryptoState:  &SessionCryptoState{},
-		NewlyCreated: true,
-		channels:     make(map[uint64]*Channel),
+		SessionID:  sessionID,
+		IsGuest:    false,
+		IsNull:     false,
+		CreatedAt:  time.Now(),
+		ClientAddr: clientAddr,
+		Username:   user.Username,
+		Domain:     domain,
+		User:       user,
+		channels:   make(map[uint64]*Channel),
 	}
+	s.cryptoState.Store(&SessionCryptoState{})
+	s.newlyCreated.Store(true)
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s
 }
@@ -339,69 +350,107 @@ type SessionStats struct {
 	HighWaterMark       uint32
 }
 
+// GetCryptoState returns the session's current cryptographic state via an
+// atomic load. May return nil before the state is initialised. All readers
+// MUST use this accessor (never the field) so the SESSION_SETUP re-auth swap
+// in SetCryptoState is observed atomically.
+func (s *Session) GetCryptoState() *SessionCryptoState {
+	if s == nil {
+		return nil
+	}
+	return s.cryptoState.Load()
+}
+
+// IsNewlyCreated reports whether this session was just established via
+// SESSION_SETUP and has not yet had its first response sent. The framing
+// layer uses it to suppress encryption on the initial SESSION_SETUP SUCCESS
+// response. Atomic load — the clear (ClearNewlyCreated) races per-request
+// dispatch goroutines.
+func (s *Session) IsNewlyCreated() bool {
+	return s.newlyCreated.Load()
+}
+
+// ClearNewlyCreated marks the session as no longer newly created, so
+// subsequent responses are encrypted with the now-derived keys.
+func (s *Session) ClearNewlyCreated() {
+	s.newlyCreated.Store(false)
+}
+
 // SetSigningKey sets the signing key from the session key.
 // This creates a CryptoState with an HMACSigner for SMB 2.x sessions.
 // For 3.x sessions, use SetCryptoState with DeriveAllKeys instead.
 func (s *Session) SetSigningKey(sessionKey []byte) {
-	s.CryptoState = DeriveAllKeys(sessionKey, types.Dialect0202, [64]byte{}, 0, signing.SigningAlgHMACSHA256, false)
+	s.cryptoState.Store(DeriveAllKeys(sessionKey, types.Dialect0202, [64]byte{}, 0, signing.SigningAlgHMACSHA256, false))
 }
 
 // EnableSigning enables message signing for this session.
+//
+// The current crypto state is copied, the signing flags are set on the copy,
+// and the copy is published atomically. Mutating the published state in place
+// would race in-flight readers that loaded the same pointer.
 func (s *Session) EnableSigning(required bool) {
-	if s.CryptoState == nil {
+	cur := s.cryptoState.Load()
+	if cur == nil {
 		return
 	}
-	s.CryptoState.SigningEnabled = true
-	s.CryptoState.SigningRequired = required
+	updated := *cur
+	updated.SigningEnabled = true
+	updated.SigningRequired = required
+	s.cryptoState.Store(&updated)
 }
 
 // SetCryptoState sets the session's cryptographic state directly.
 // Used by session setup when KDF-derived keys are available (3.x sessions).
 func (s *Session) SetCryptoState(cs *SessionCryptoState) {
-	s.CryptoState = cs
+	s.cryptoState.Store(cs)
 }
 
 // ShouldEncrypt returns true if outgoing messages should be encrypted.
 func (s *Session) ShouldEncrypt() bool {
-	return s.CryptoState.ShouldEncrypt()
+	return s.cryptoState.Load().ShouldEncrypt()
 }
 
 // EncryptWithNonce encrypts plaintext using a pre-generated nonce and AAD.
 // Used by the encryption middleware which needs to control the nonce.
 func (s *Session) EncryptWithNonce(nonce, plaintext, aad []byte) ([]byte, error) {
-	if s.CryptoState == nil || s.CryptoState.Encryptor == nil {
+	cs := s.cryptoState.Load()
+	if cs == nil || cs.Encryptor == nil {
 		return nil, fmt.Errorf("session has no encryptor")
 	}
-	return s.CryptoState.Encryptor.EncryptWithNonce(nonce, plaintext, aad)
+	return cs.Encryptor.EncryptWithNonce(nonce, plaintext, aad)
 }
 
 // DecryptMessage decrypts ciphertext using the given nonce and AAD.
 func (s *Session) DecryptMessage(nonce, ciphertext, aad []byte) ([]byte, error) {
-	if s.CryptoState == nil || s.CryptoState.Decryptor == nil {
+	cs := s.cryptoState.Load()
+	if cs == nil || cs.Decryptor == nil {
 		return nil, fmt.Errorf("session has no decryptor")
 	}
-	return s.CryptoState.Decryptor.Decrypt(nonce, ciphertext, aad)
+	return cs.Decryptor.Decrypt(nonce, ciphertext, aad)
 }
 
 func (s *Session) EncryptorNonceSize() int {
-	if s.CryptoState == nil || s.CryptoState.Encryptor == nil {
+	cs := s.cryptoState.Load()
+	if cs == nil || cs.Encryptor == nil {
 		return 0
 	}
-	return s.CryptoState.Encryptor.NonceSize()
+	return cs.Encryptor.NonceSize()
 }
 
 func (s *Session) DecryptorNonceSize() int {
-	if s.CryptoState == nil || s.CryptoState.Decryptor == nil {
+	cs := s.cryptoState.Load()
+	if cs == nil || cs.Decryptor == nil {
 		return 0
 	}
-	return s.CryptoState.Decryptor.NonceSize()
+	return cs.Decryptor.NonceSize()
 }
 
 func (s *Session) EncryptorOverhead() int {
-	if s.CryptoState == nil || s.CryptoState.Encryptor == nil {
+	cs := s.cryptoState.Load()
+	if cs == nil || cs.Encryptor == nil {
 		return 0
 	}
-	return s.CryptoState.Encryptor.Overhead()
+	return cs.Encryptor.Overhead()
 }
 
 // IsNullSession reports whether this session was created with anonymous
@@ -414,19 +463,20 @@ func (s *Session) IsNullSession() bool {
 
 // ShouldSign returns true if outgoing messages should be signed.
 func (s *Session) ShouldSign() bool {
-	return s.CryptoState.ShouldSign()
+	return s.cryptoState.Load().ShouldSign()
 }
 
 // ShouldVerify returns true if incoming messages should have signatures verified.
 func (s *Session) ShouldVerify() bool {
-	return s.CryptoState.ShouldVerify()
+	return s.cryptoState.Load().ShouldVerify()
 }
 
 // SignMessage signs an SMB2 message in place using the session's signer.
 // This should be called before sending a message if signing is enabled.
 func (s *Session) SignMessage(message []byte) {
-	if s.CryptoState.ShouldSign() {
-		signing.SignMessage(s.CryptoState.Signer, message)
+	cs := s.cryptoState.Load()
+	if cs.ShouldSign() {
+		signing.SignMessage(cs.Signer, message)
 	}
 }
 
@@ -445,10 +495,11 @@ func (s *Session) SignMessageOnChannel(connID uint64, message []byte) {
 // VerifyMessage verifies the signature of an SMB2 message.
 // Returns true if the signature is valid or if signing is not enabled.
 func (s *Session) VerifyMessage(message []byte) bool {
-	if !s.CryptoState.ShouldVerify() {
+	cs := s.cryptoState.Load()
+	if !cs.ShouldVerify() {
 		return true
 	}
-	return s.CryptoState.Signer.Verify(message)
+	return cs.Signer.Verify(message)
 }
 
 // VerifyMessageOnChannel verifies an incoming message's signature against the

--- a/internal/adapter/smb/session/session_race_test.go
+++ b/internal/adapter/smb/session/session_race_test.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSession_CryptoStateConcurrentReauthRace is the negative control for the
+// data race on Session.CryptoState (audit #1132 MED). SESSION_SETUP re-auth
+// swaps the whole SessionCryptoState (SetCryptoState / SetSigningKey /
+// EnableSigning) on an already-published session while in-flight requests on
+// the same session read it through ShouldSign / ShouldVerify / ShouldEncrypt /
+// VerifyMessage / DecryptMessage and the response path.
+//
+// Before the fix CryptoState was a plain pointer field; the concurrent
+// store/load is a data race under the Go memory model and `go test -race`
+// flags it. After the fix it is an atomic.Pointer accessed only via
+// GetCryptoState / SetCryptoState, so this test must run clean under -race.
+//
+// Run: go test -race ./internal/adapter/smb/session/ -run CryptoStateConcurrentReauthRace
+func TestSession_CryptoStateConcurrentReauthRace(t *testing.T) {
+	s := NewSession(1, "127.0.0.1:1", false, "alice", "WORKGROUP")
+
+	const iters = 2000
+	var wg sync.WaitGroup
+
+	// Writer: re-auth swaps the crypto state repeatedly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		key := make([]byte, 16)
+		for i := 0; i < iters; i++ {
+			switch i % 3 {
+			case 0:
+				s.SetCryptoState(&SessionCryptoState{})
+			case 1:
+				s.SetSigningKey(key)
+			case 2:
+				s.EnableSigning(true)
+			}
+		}
+	}()
+
+	// Readers: in-flight requests inspect signing/encryption state.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			msg := make([]byte, 64)
+			for i := 0; i < iters; i++ {
+				_ = s.ShouldSign()
+				_ = s.ShouldVerify()
+				_ = s.ShouldEncrypt()
+				_ = s.VerifyMessage(msg)
+				_ = s.GetCryptoState()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSession_NewlyCreatedConcurrentRace is the negative control for the data
+// race on Session.NewlyCreated (audit #1132 LOW). The framing layer clears the
+// flag (ClearNewlyCreated) on one request goroutine while another reads it
+// (IsNewlyCreated) on a pipelined request during SESSION_SETUP completion.
+//
+// Before the fix NewlyCreated was a plain bool; the concurrent read+write is a
+// data race. After the fix it is an atomic.Bool. Run under -race.
+func TestSession_NewlyCreatedConcurrentRace(t *testing.T) {
+	s := NewSession(1, "127.0.0.1:1", false, "alice", "WORKGROUP")
+	if !s.IsNewlyCreated() {
+		t.Fatal("freshly created session should report IsNewlyCreated()=true")
+	}
+
+	const iters = 5000
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.ClearNewlyCreated()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = s.IsNewlyCreated()
+		}
+	}()
+
+	wg.Wait()
+
+	if s.IsNewlyCreated() {
+		t.Error("NewlyCreated should be cleared after ClearNewlyCreated()")
+	}
+}


### PR DESCRIPTION
Fixes #1132 — verified SMB auth/session findings from the develop `3488526a` re-audit.

## Findings fixed

### [HIGH] Anonymous/null SMB session mapped to UID=0 root (`auth_helper.go`)
A null/anonymous SMB session (`User==nil`, `IsGuest==false`) was assigned UID=0/GID=0, which trips the metadata `UID==0` root short-circuit (`auth_permissions.go`) and grants root-equivalent access to every file, bypassing POSIX bits and ACLs. Any client completing anonymous NTLM logon got root-equivalent read (and write/delete on writable shares).

**Fix:** map null/anonymous sessions to the unprivileged **nobody/nogroup (65534)** identity — same as guest — so per-file permission checks still apply. The anonymous *connection* stays spec-legal (smb2.anon-signing / anon-encryption unaffected); only the identity mapping changes. Applied to both `BuildAuthContext` and the opener-snapshot path `buildOpenerAuthContext`. Centralised into `setUnprivilegedIdentity` + `nobodyUID/nobodyGID` constants so it cannot drift back.

### [HIGH] No-NT-hash → full authenticated session (`session_setup.go`)
An enabled user with no NT hash (no password ever set) — or one presenting no NTLM response — was granted a full authenticated `Session` with `IsGuest=false` and the real `User`, with **no credential validation**. Knowledge of a username alone was sufficient to authenticate as that user.

**Fix:** reject the logon with `STATUS_LOGON_FAILURE`. Re-auth destroys the existing session (MS-SMB2 §3.3.5.5.3); bind fails closed. An account with no password is unusable for password auth by design.

### [HIGH] LEASE_BREAK_ACK accepts any session's ack (`stub_handlers.go` / `lease/manager.go`)
`handleLeaseBreakAck` trusted the wire-supplied 16-byte leaseKey with no ownership check, so any authenticated session could fabricate an ack for a lease it does not own and downgrade another client's lease (data-integrity / DoS).

**Fix:** new `LeaseManager.VerifyLeaseAckOwnership(leaseKey, sessionID, connGUID)` enforces MS-SMB2 §3.3.5.22.2 step 1 — the ack must come from the owning client (ClientGUID binding when recorded; per-lease sessionMap fallback for legacy/no-GUID paths). Multichannel and durable-reconnect (same ClientGUID) still validate.

### [MED] Data race on `Session.CryptoState` pointer during reauth (`session/session.go`)
Plain pointer store (`SetCryptoState`) raced concurrent loads in `ShouldSign`/`ShouldEncrypt`/`VerifyMessage`/`DecryptMessage` and the response path while a re-auth SESSION_SETUP swapped the state on a live session.

**Fix:** `CryptoState` → `atomic.Pointer[SessionCryptoState]`, accessed only via `GetCryptoState`/`SetCryptoState`. `EnableSigning` copies-then-stores instead of mutating the published state. All external readers updated.

### [LOW] Data race on `Session.NewlyCreated` bool (`session/session.go`)
Plain bool read (`response.go`) raced its clear across per-request goroutines during SESSION_SETUP completion.

**Fix:** `NewlyCreated` → `atomic.Bool` with `IsNewlyCreated`/`ClearNewlyCreated`, mirroring `LoggedOff`.

## Tests
Each finding has a negative-control test that fails without the fix:
- `TestBuildAuthContext_NullSessionMapsToNobodyNotRoot`, `TestBuildOpenerAuthContext_NullOpenerMapsToNobodyNotRoot`
- `TestSessionSetup_UserWithoutNTHash_Rejected`
- `TestVerifyLeaseAckOwnership` (owner accepted / imposter & cross-session rejected / unknown rejected)
- `TestSession_CryptoStateConcurrentReauthRace`, `TestSession_NewlyCreatedConcurrentRace` (clean under `-race`)

`go build ./...`, `go vet ./...`, and `go test -race ./internal/adapter/smb/...` all green.
