### PR TITLE
fix(nfs/nlm): GRANTED callback port, FREE_ALL cleanup, lock-theft + SSRF guards

### DIFF
--- a/internal/adapter/nfs/nlm/blocking/waiter.go
+++ b/internal/adapter/nfs/nlm/blocking/waiter.go
@@ -35,8 +35,11 @@ type Waiter struct {
 	// Exclusive is whether the lock is exclusive (write) or shared (read)
 	Exclusive bool
 
-	// CallbackAddr is the client's callback address (IP:port)
-	CallbackAddr string
+	// CallbackHost is the client's transport source host (IP), used to resolve
+	// the NLM_GRANTED callback target at grant time. The callback PORT is not
+	// stored here: it is looked up from the client's portmapper when the grant
+	// is actually delivered, so a stale/guessed port is never dialed.
+	CallbackHost string
 
 	// CallbackProg is the client's callback program number (NLM)
 	CallbackProg uint32

--- a/internal/adapter/nfs/nlm/callback/client.go
+++ b/internal/adapter/nfs/nlm/callback/client.go
@@ -57,6 +57,16 @@ func SendGrantedCallback(
 	vers uint32,
 	args *types.NLM4GrantedArgs,
 ) error {
+	// SSRF guard: never dial an address that did not originate from a validated
+	// client source. The host portion of addr is always derived from the NLM
+	// request's transport source IP (never from client-supplied wire fields), but
+	// we additionally reject addresses that could be used to reach internal
+	// infrastructure or trigger amplification (unspecified, multicast, link-local
+	// multicast). This bounds the dial target to a plausible unicast NLM client.
+	if err := validateCallbackAddr(addr); err != nil {
+		return fmt.Errorf("reject callback address %s: %w", addr, err)
+	}
+
 	// Create a context with 5s total deadline for the entire operation
 	// This is a LOCKED DECISION from CONTEXT.md: 5 second timeout total
 	callbackCtx, cancel := context.WithTimeout(ctx, CallbackTimeout)
@@ -106,6 +116,46 @@ func SendGrantedCallback(
 		return fmt.Errorf("read reply: %w", err)
 	}
 
+	return nil
+}
+
+// validateCallbackAddr rejects callback destinations that are unsafe to dial.
+//
+// The host must be a literal IP (callback addresses are always built from the
+// request's transport source IP, never a client-supplied hostname, so DNS is
+// never involved). Mirroring the v4/NSM callback SSRF guards
+// (v4/state/callback.go, nsm/callback/client.go) we reject:
+//   - the unspecified address and an invalid port (malformed targets),
+//   - multicast (amplification),
+//   - link-local unicast (169.254.0.0/16 / fe80::/10) — this covers the
+//     cloud-instance metadata endpoint 169.254.169.254, the canonical SSRF
+//     pivot, so the NLM callback path can never be coerced into reaching it.
+//
+// Loopback is deliberately allowed: unlike the server-initiated v4/NSM
+// callbacks (which target remotely-registered clients), an NLM_GRANTED callback
+// targets the lock requester's own source IP, which is legitimately loopback for
+// an NFS mount co-located with the server.
+func validateCallbackAddr(addr string) error {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("malformed address: %w", err)
+	}
+	if portStr == "" || portStr == "0" {
+		return fmt.Errorf("invalid port %q", portStr)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("host %q is not a literal IP", host)
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("unspecified host %q", host)
+	}
+	if ip.IsMulticast() {
+		return fmt.Errorf("multicast host %q", host)
+	}
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("link-local host %q", host)
+	}
 	return nil
 }
 

--- a/internal/adapter/nfs/nlm/callback/client_test.go
+++ b/internal/adapter/nfs/nlm/callback/client_test.go
@@ -1,0 +1,57 @@
+package callback
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+)
+
+// TestValidateCallbackAddr_RejectsUnsafe is the negative control for the SSRF
+// guard. The server must refuse to dial unspecified, multicast, port-0, or
+// malformed callback destinations.
+func TestValidateCallbackAddr_RejectsUnsafe(t *testing.T) {
+	bad := []string{
+		"0.0.0.0:111",        // unspecified
+		"[::]:111",           // unspecified v6
+		"224.0.0.1:111",      // multicast v4
+		"[ff02::1]:111",      // multicast v6
+		"169.254.169.254:80", // cloud metadata endpoint (link-local) — SSRF pivot
+		"[fe80::1]:4045",     // link-local v6
+		"10.0.0.7:0",         // invalid port
+		"not-an-ip:111",      // non-literal host
+		"10.0.0.7",           // missing port
+	}
+	for _, addr := range bad {
+		if err := validateCallbackAddr(addr); err == nil {
+			t.Errorf("validateCallbackAddr(%q) = nil, want rejection", addr)
+		}
+	}
+}
+
+// TestValidateCallbackAddr_AllowsUnicast confirms ordinary unicast client
+// addresses are accepted.
+func TestValidateCallbackAddr_AllowsUnicast(t *testing.T) {
+	// Loopback is intentionally allowed for NLM (co-located NFS mounts).
+	ok := []string{"10.0.0.7:54321", "192.168.1.5:1023", "127.0.0.1:1023", "[::1]:4045"}
+	for _, addr := range ok {
+		if err := validateCallbackAddr(addr); err != nil {
+			t.Errorf("validateCallbackAddr(%q) = %v, want nil", addr, err)
+		}
+	}
+}
+
+// TestSendGrantedCallback_RejectsSSRFTarget verifies the SSRF guard fires
+// before any dial: an unsafe address returns a "reject callback address" error
+// rather than attempting a connection.
+func TestSendGrantedCallback_RejectsSSRFTarget(t *testing.T) {
+	err := SendGrantedCallback(context.Background(), "224.0.0.1:111",
+		types.ProgramNLM, types.NLMVersion4, &types.NLM4GrantedArgs{})
+	if err == nil {
+		t.Fatal("SendGrantedCallback to multicast addr = nil, want SSRF rejection")
+	}
+	if !strings.Contains(err.Error(), "reject callback address") {
+		t.Fatalf("error = %q, want SSRF rejection", err.Error())
+	}
+}

--- a/internal/adapter/nfs/nlm/callback/granted.go
+++ b/internal/adapter/nfs/nlm/callback/granted.go
@@ -2,6 +2,8 @@ package callback
 
 import (
 	"context"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
@@ -42,6 +44,24 @@ func ProcessGrantedCallback(
 		return false
 	}
 
+	// Resolve the client's NLM callback address. The host is the transport
+	// source recorded at lock time; the port is looked up NOW from the client's
+	// portmapper so we dial the lockd port the client actually registered rather
+	// than a stale or hardcoded port. If resolution fails the grant cannot be
+	// delivered: release the lock (same as a failed callback) so it is not
+	// orphaned, and re-drive remaining waiters via the normal release hook.
+	addr, err := callbackAddrResolver(ctx, waiter.CallbackHost)
+	if err != nil {
+		logger.Warn("NLM_GRANTED: cannot resolve client callback address, releasing lock",
+			"host", waiter.CallbackHost,
+			"owner", waiter.Lock.Owner.OwnerID,
+			"error", err)
+		handleKey := string(waiter.Lock.FileHandle)
+		_ = lm.RemoveUnifiedLock(handleKey, waiter.Lock.Owner,
+			waiter.Lock.Offset, waiter.Lock.Length)
+		return false
+	}
+
 	// Build NLM_GRANTED args
 	args := &types.NLM4GrantedArgs{
 		Cookie:    waiter.Cookie,
@@ -60,7 +80,7 @@ func ProcessGrantedCallback(
 	start := time.Now()
 
 	// Send callback
-	err := SendGrantedCallback(ctx, waiter.CallbackAddr, waiter.CallbackProg,
+	err = SendGrantedCallback(ctx, addr, waiter.CallbackProg,
 		waiter.CallbackVers, args)
 
 	duration := time.Since(start)
@@ -68,7 +88,7 @@ func ProcessGrantedCallback(
 	if err != nil {
 		logger.Warn("NLM_GRANTED callback failed, releasing lock",
 			"error", err,
-			"addr", waiter.CallbackAddr,
+			"addr", addr,
 			"owner", waiter.Lock.Owner.OwnerID,
 			"duration", duration)
 
@@ -81,9 +101,37 @@ func ProcessGrantedCallback(
 	}
 
 	logger.Debug("NLM_GRANTED callback succeeded",
-		"addr", waiter.CallbackAddr,
+		"addr", addr,
 		"owner", waiter.Lock.Owner.OwnerID,
 		"duration", duration)
 
 	return true
+}
+
+// callbackAddrResolver resolves a client source host to a dialable NLM callback
+// address. It is a package var so tests can stand in a deterministic resolver
+// (the real one performs a portmap network round-trip). Production always uses
+// resolveCallbackAddr.
+var callbackAddrResolver = resolveCallbackAddr
+
+// SetCallbackAddrResolver overrides how a client source host is resolved to a
+// dialable NLM callback address. It returns a restore func. Intended for tests
+// that need a deterministic callback target without a portmap round-trip.
+func SetCallbackAddrResolver(fn func(ctx context.Context, host string) (string, error)) (restore func()) {
+	prev := callbackAddrResolver
+	callbackAddrResolver = fn
+	return func() { callbackAddrResolver = prev }
+}
+
+// resolveCallbackAddr turns a client source host into a dialable NLM callback
+// "host:port" address by querying the client's portmapper for its registered
+// NLM (lockd) port. The host is always the request's transport source, never a
+// client-supplied wire field, so the callback can only ever target the host
+// that issued the lock.
+func resolveCallbackAddr(ctx context.Context, host string) (string, error) {
+	port, err := ResolveNLMCallbackPort(ctx, host, types.ProgramNLM, types.NLMVersion4)
+	if err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(port))), nil
 }

--- a/internal/adapter/nfs/nlm/callback/portmap.go
+++ b/internal/adapter/nfs/nlm/callback/portmap.go
@@ -1,0 +1,168 @@
+package callback
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/portmap/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+)
+
+// PortmapPort is the well-known port for the portmapper (rpcbind) service.
+// NLM clients register their dynamically-assigned NLM callback port with their
+// local portmapper; the server resolves it via a GETPORT query.
+const PortmapPort = 111
+
+// resolveNLMCallbackPort queries the client's portmapper for the TCP port its
+// NLM (lockd) service is listening on, so NLM_GRANTED callbacks reach the right
+// endpoint rather than a hardcoded port.
+//
+// NLM clients listen for GRANTED callbacks on a dynamically-assigned port that
+// they register with their local portmapper under (program=100021, version=4,
+// protocol=TCP). The server discovers that port by sending a portmap GETPORT
+// RPC to the client IP on port 111.
+//
+// Parameters:
+//   - ctx: parent context for cancellation/timeout
+//   - host: the client IP (must already be validated as the request source)
+//   - prog: the NLM program number to look up
+//   - vers: the NLM program version to look up
+//
+// Returns the resolved port, or an error if the query failed or the client's
+// portmapper reported the program as not registered (port 0).
+func ResolveNLMCallbackPort(ctx context.Context, host string, prog, vers uint32) (uint16, error) {
+	return resolveViaPortmapAddr(ctx, host, PortmapPort, prog, vers)
+}
+
+// resolveViaPortmapAddr is the core GETPORT query against an explicit portmapper
+// port. ResolveNLMCallbackPort fixes the port at the well-known 111; tests use a
+// custom port to stand up a fake portmapper on an ephemeral port.
+func resolveViaPortmapAddr(ctx context.Context, host string, portmapPort int, prog, vers uint32) (uint16, error) {
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", portmapPort))
+
+	// SSRF guard on the portmap dial too: an empty/unsafe host would otherwise
+	// dial e.g. ":111" (the server's own portmapper) or a link-local target.
+	// The host is the request's transport source, but validate defensively.
+	if err := validateCallbackAddr(addr); err != nil {
+		return 0, fmt.Errorf("reject portmapper address %s: %w", addr, err)
+	}
+
+	callbackCtx, cancel := context.WithTimeout(ctx, CallbackTimeout)
+	defer cancel()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(callbackCtx, "tcp", addr)
+	if err != nil {
+		return 0, fmt.Errorf("dial portmapper %s: %w", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if deadline, ok := callbackCtx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return 0, fmt.Errorf("set deadline: %w", err)
+		}
+	}
+
+	// GETPORT mapping argument: prog, vers, prot, port(=0, ignored).
+	var argsBuf bytes.Buffer
+	for _, v := range []uint32{prog, vers, types.ProtoTCP, 0} {
+		if err := binary.Write(&argsBuf, binary.BigEndian, v); err != nil {
+			return 0, fmt.Errorf("encode getport args: %w", err)
+		}
+	}
+
+	xid := uint32(time.Now().UnixNano() & 0xFFFFFFFF)
+	callMsg, err := buildRPCCallMessage(xid, types.ProgramPortmap, types.PortmapVersion2,
+		types.ProcGetport, argsBuf.Bytes())
+	if err != nil {
+		return 0, fmt.Errorf("build getport call: %w", err)
+	}
+
+	if _, err := conn.Write(addRecordMark(callMsg, true)); err != nil {
+		return 0, fmt.Errorf("write getport call: %w", err)
+	}
+
+	port, err := readGetportReply(conn)
+	if err != nil {
+		return 0, err
+	}
+	if port == 0 {
+		return 0, fmt.Errorf("portmapper reports NLM (prog=%d vers=%d) not registered", prog, vers)
+	}
+	return uint16(port), nil
+}
+
+// readGetportReply reads the portmap GETPORT reply and returns the port.
+//
+// It validates the RPC reply is MSG_ACCEPTED/SUCCESS and extracts the trailing
+// uint32 port value.
+func readGetportReply(conn net.Conn) (uint32, error) {
+	var headerBuf [4]byte
+	if _, err := io.ReadFull(conn, headerBuf[:]); err != nil {
+		return 0, fmt.Errorf("read getport reply header: %w", err)
+	}
+	fragLen := binary.BigEndian.Uint32(headerBuf[:]) & 0x7FFFFFFF
+	if fragLen < 24 || fragLen > 1*1024*1024 {
+		return 0, fmt.Errorf("getport reply fragment invalid length: %d", fragLen)
+	}
+
+	body := make([]byte, fragLen)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return 0, fmt.Errorf("read getport reply body: %w", err)
+	}
+
+	// RPC reply: xid(4) msg_type(4)=REPLY reply_stat(4)=MSG_ACCEPTED
+	// verf(flavor 4 + len 4 + body) accept_stat(4)=SUCCESS then port(4).
+	r := bytes.NewReader(body)
+	var xid, msgType, replyStat uint32
+	if err := readU32(r, &xid); err != nil {
+		return 0, err
+	}
+	if err := readU32(r, &msgType); err != nil {
+		return 0, err
+	}
+	if msgType != rpc.RPCReply {
+		return 0, fmt.Errorf("getport reply: not a reply (msg_type=%d)", msgType)
+	}
+	if err := readU32(r, &replyStat); err != nil {
+		return 0, err
+	}
+	if replyStat != 0 { // MSG_ACCEPTED
+		return 0, fmt.Errorf("getport reply: rejected (reply_stat=%d)", replyStat)
+	}
+
+	// Verifier: flavor(4) + length(4) + body(length).
+	var verfFlavor, verfLen uint32
+	if err := readU32(r, &verfFlavor); err != nil {
+		return 0, err
+	}
+	if err := readU32(r, &verfLen); err != nil {
+		return 0, err
+	}
+	if verfLen > 0 {
+		if _, err := io.CopyN(io.Discard, r, int64(verfLen)); err != nil {
+			return 0, fmt.Errorf("getport reply: read verifier: %w", err)
+		}
+	}
+
+	var acceptStat, port uint32
+	if err := readU32(r, &acceptStat); err != nil {
+		return 0, err
+	}
+	if acceptStat != 0 { // SUCCESS
+		return 0, fmt.Errorf("getport reply: accept_stat=%d", acceptStat)
+	}
+	if err := readU32(r, &port); err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+func readU32(r io.Reader, v *uint32) error {
+	return binary.Read(r, binary.BigEndian, v)
+}

--- a/internal/adapter/nfs/nlm/callback/portmap.go
+++ b/internal/adapter/nfs/nlm/callback/portmap.go
@@ -144,8 +144,10 @@ func readGetportReply(conn net.Conn) (uint32, error) {
 	if err := readU32(r, &verfLen); err != nil {
 		return 0, err
 	}
-	if verfLen > 0 {
-		if _, err := io.CopyN(io.Discard, r, int64(verfLen)); err != nil {
+	// XDR opaque fields are padded to a 4-byte boundary; skip the padded length
+	// so the trailing accept_stat/port are read from the correct offset.
+	if padded := (verfLen + 3) &^ 3; padded > 0 {
+		if _, err := io.CopyN(io.Discard, r, int64(padded)); err != nil {
 			return 0, fmt.Errorf("getport reply: read verifier: %w", err)
 		}
 	}

--- a/internal/adapter/nfs/nlm/callback/portmap_test.go
+++ b/internal/adapter/nfs/nlm/callback/portmap_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 // fakePortmapper accepts one TCP connection, reads the record-marked GETPORT
-// call, and replies with a successful RPC reply carrying replyPort.
-func fakePortmapper(t *testing.T, ln net.Listener, replyPort uint32) {
+// call, and replies with a successful RPC reply carrying replyPort. verfLen is
+// the verifier opaque length to advertise: the verifier body is XDR-padded to a
+// 4-byte boundary, exercising the reader's padding handling.
+func fakePortmapper(t *testing.T, ln net.Listener, replyPort uint32, verfLen int) {
 	t.Helper()
 	conn, err := ln.Accept()
 	if err != nil {
@@ -34,15 +36,16 @@ func fakePortmapper(t *testing.T, ln net.Listener, replyPort uint32) {
 		return
 	}
 
-	// Extract the XID from the call we just read is not needed; a real client
-	// validates only the port here, so we reply with a fixed XID of 0.
 	var body bytes.Buffer
 	write := func(v uint32) { _ = binary.Write(&body, binary.BigEndian, v) }
-	write(0)         // xid
-	write(1)         // msg_type = REPLY
-	write(0)         // reply_stat = MSG_ACCEPTED
-	write(0)         // verifier flavor = AUTH_NULL
-	write(0)         // verifier length = 0
+	write(0)               // xid
+	write(1)               // msg_type = REPLY
+	write(0)               // reply_stat = MSG_ACCEPTED
+	write(0)               // verifier flavor = AUTH_NULL
+	write(uint32(verfLen)) // verifier length
+	if padded := (verfLen + 3) &^ 3; padded > 0 {
+		body.Write(make([]byte, padded)) // verifier body + XDR padding
+	}
 	write(0)         // accept_stat = SUCCESS
 	write(replyPort) // port
 
@@ -63,20 +66,9 @@ func TestResolveNLMCallbackPort_UsesPortmapNotHardcoded(t *testing.T) {
 	defer func() { _ = ln.Close() }()
 
 	const advertised = 54045
-	go fakePortmapper(t, ln, advertised)
+	go fakePortmapper(t, ln, advertised, 0)
 
-	// Point the resolver at our fake portmapper's actual address by overriding
-	// the host:port through a direct dial: ResolveNLMCallbackPort always dials
-	// host:111, so we run the fake listener on an ephemeral port and verify the
-	// wire logic via a thin wrapper that targets the listener address.
-	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("parse listener port: %v", err)
-	}
-
-	got, err := resolveViaPortmapAddr(context.Background(), host, port,
-		types.ProgramNLM, types.NLMVersion4)
+	got, err := resolveListener(t, ln)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -86,4 +78,39 @@ func TestResolveNLMCallbackPort_UsesPortmapNotHardcoded(t *testing.T) {
 	if got == 12049 {
 		t.Fatalf("resolved port is the old hardcoded 12049; portmap lookup not used")
 	}
+}
+
+// TestResolveNLMCallbackPort_NonAlignedVerifier exercises the XDR padding of the
+// reply verifier: a verifier length that is not a multiple of 4 must still leave
+// the reader aligned so accept_stat/port are read from the right offset. Without
+// rounding the skip up to a 4-byte boundary the port resolves incorrectly.
+func TestResolveNLMCallbackPort_NonAlignedVerifier(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	const advertised = 4045
+	go fakePortmapper(t, ln, advertised, 5) // 5-byte verifier -> 3 bytes padding
+
+	got, err := resolveListener(t, ln)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != advertised {
+		t.Fatalf("resolved port = %d, want %d (verifier padding mishandled)", got, advertised)
+	}
+}
+
+// resolveListener runs the GETPORT query against the fake portmapper bound to ln.
+func resolveListener(t *testing.T, ln net.Listener) (uint16, error) {
+	t.Helper()
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+	return resolveViaPortmapAddr(context.Background(), host, port,
+		types.ProgramNLM, types.NLMVersion4)
 }

--- a/internal/adapter/nfs/nlm/callback/portmap_test.go
+++ b/internal/adapter/nfs/nlm/callback/portmap_test.go
@@ -1,0 +1,89 @@
+package callback
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+)
+
+// fakePortmapper accepts one TCP connection, reads the record-marked GETPORT
+// call, and replies with a successful RPC reply carrying replyPort.
+func fakePortmapper(t *testing.T, ln net.Listener, replyPort uint32) {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		return // listener closed
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	// Read and discard the call (record mark + body).
+	var hdr [4]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return
+	}
+	fragLen := binary.BigEndian.Uint32(hdr[:]) & 0x7FFFFFFF
+	if _, err := io.CopyN(io.Discard, conn, int64(fragLen)); err != nil {
+		return
+	}
+
+	// Extract the XID from the call we just read is not needed; a real client
+	// validates only the port here, so we reply with a fixed XID of 0.
+	var body bytes.Buffer
+	write := func(v uint32) { _ = binary.Write(&body, binary.BigEndian, v) }
+	write(0)         // xid
+	write(1)         // msg_type = REPLY
+	write(0)         // reply_stat = MSG_ACCEPTED
+	write(0)         // verifier flavor = AUTH_NULL
+	write(0)         // verifier length = 0
+	write(0)         // accept_stat = SUCCESS
+	write(replyPort) // port
+
+	out := make([]byte, 4+body.Len())
+	binary.BigEndian.PutUint32(out[:4], uint32(body.Len())|0x80000000)
+	copy(out[4:], body.Bytes())
+	_, _ = conn.Write(out)
+}
+
+// TestResolveNLMCallbackPort_UsesPortmapNotHardcoded is the negative control for
+// the hardcoded-12049 finding. The resolver must return the port the client's
+// portmapper advertises (here 54045), proving it no longer dials a fixed port.
+func TestResolveNLMCallbackPort_UsesPortmapNotHardcoded(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	const advertised = 54045
+	go fakePortmapper(t, ln, advertised)
+
+	// Point the resolver at our fake portmapper's actual address by overriding
+	// the host:port through a direct dial: ResolveNLMCallbackPort always dials
+	// host:111, so we run the fake listener on an ephemeral port and verify the
+	// wire logic via a thin wrapper that targets the listener address.
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+
+	got, err := resolveViaPortmapAddr(context.Background(), host, port,
+		types.ProgramNLM, types.NLMVersion4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != advertised {
+		t.Fatalf("resolved port = %d, want advertised %d (must not be hardcoded)", got, advertised)
+	}
+	if got == 12049 {
+		t.Fatalf("resolved port is the old hardcoded 12049; portmap lookup not used")
+	}
+}

--- a/internal/adapter/nfs/nlm/handlers/caller_binding.go
+++ b/internal/adapter/nfs/nlm/handlers/caller_binding.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 )
 
+// MaxCallerNameLen bounds an NLM caller_name (a client hostname). RFC 1813
+// MAXNAMELEN is 1024; anything larger is rejected as malformed/abusive.
+const MaxCallerNameLen = 1024
+
 // callerBinding maps an NLM caller_name to the transport source host (IP) that
 // first acquired a lock under that name. NLM v4 is advisory and unauthenticated
 // by RFC 1813 design: every field of an UNLOCK/CANCEL request (caller_name,

--- a/internal/adapter/nfs/nlm/handlers/caller_binding.go
+++ b/internal/adapter/nfs/nlm/handlers/caller_binding.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net"
+	"sync"
+)
+
+// callerBinding maps an NLM caller_name to the transport source host (IP) that
+// first acquired a lock under that name. NLM v4 is advisory and unauthenticated
+// by RFC 1813 design: every field of an UNLOCK/CANCEL request (caller_name,
+// svid, owner handle) is client-supplied, so without binding any peer that can
+// reach the NLM port could reconstruct a victim's ownerID and release or cancel
+// that victim's byte-range lock (lock theft / silent data corruption between
+// NFSv3 writers).
+//
+// This binding closes that gap to the extent the transport allows: a caller_name
+// is pinned to the source host that introduced it, and a request from a
+// different source host claiming that caller_name is rejected. It does not (and
+// cannot, without per-RPC authentication) defend against a same-host spoofer.
+type callerBinding struct {
+	mu      sync.RWMutex
+	hostFor map[string]string // caller_name -> source host (IP)
+}
+
+func newCallerBinding() *callerBinding {
+	return &callerBinding{hostFor: make(map[string]string)}
+}
+
+// hostOf extracts the host (IP) portion from a "host:port" transport address.
+// If the address has no port it is returned unchanged.
+func hostOf(clientAddr string) string {
+	host, _, err := net.SplitHostPort(clientAddr)
+	if err != nil {
+		return clientAddr
+	}
+	return host
+}
+
+// bind records that callerName was used from sourceHost. The first source host
+// to use a caller_name owns it; subsequent locks from the same host refresh it.
+// An empty callerName or sourceHost is ignored.
+func (b *callerBinding) bind(callerName, clientAddr string) {
+	if b == nil || callerName == "" {
+		return
+	}
+	host := hostOf(clientAddr)
+	if host == "" {
+		return
+	}
+	b.mu.Lock()
+	b.hostFor[callerName] = host
+	b.mu.Unlock()
+}
+
+// authorized reports whether a request from clientAddr may act on callerName.
+//
+// It is allowed when the caller_name is unbound (first use / lock not seen by
+// this server instance) or when the request's source host matches the bound
+// host. It is denied only when the caller_name is bound to a DIFFERENT host,
+// which is the lock-theft case.
+func (b *callerBinding) authorized(callerName, clientAddr string) bool {
+	if b == nil || callerName == "" {
+		return true
+	}
+	b.mu.RLock()
+	bound, ok := b.hostFor[callerName]
+	b.mu.RUnlock()
+	if !ok {
+		return true
+	}
+	return bound == hostOf(clientAddr)
+}

--- a/internal/adapter/nfs/nlm/handlers/caller_binding_test.go
+++ b/internal/adapter/nfs/nlm/handlers/caller_binding_test.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// recordingLockService records whether UnlockFileNLM was invoked, so a test can
+// assert that a rejected (spoofed) UNLOCK performs no actual release.
+type recordingLockService struct {
+	unlockCalls int
+}
+
+func (r *recordingLockService) LockFileNLM(_ context.Context, _ []byte, _ lock.LockOwner, _, _ uint64, _, _ bool) (*lock.LockResult, error) {
+	return &lock.LockResult{Success: true}, nil
+}
+
+func (r *recordingLockService) TestLockNLM(_ context.Context, _ []byte, _ lock.LockOwner, _, _ uint64, _ bool) (bool, *lock.UnifiedLockConflict, error) {
+	return true, nil, nil
+}
+
+func (r *recordingLockService) UnlockFileNLM(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	r.unlockCalls++
+	return nil
+}
+
+func (r *recordingLockService) CancelBlockingLock(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	return nil
+}
+
+func lockReq(caller string) *LockRequest {
+	return &LockRequest{
+		Exclusive: true,
+		Lock: types.NLM4Lock{
+			CallerName: caller,
+			FH:         []byte("share-a:file-1"),
+			OH:         []byte{0x01},
+			Svid:       42,
+			Offset:     0,
+			Length:     100,
+		},
+	}
+}
+
+func unlockReq(caller string) *UnlockRequest {
+	return &UnlockRequest{
+		Lock: types.NLM4Lock{
+			CallerName: caller,
+			FH:         []byte("share-a:file-1"),
+			OH:         []byte{0x01},
+			Svid:       42,
+			Offset:     0,
+			Length:     100,
+		},
+	}
+}
+
+// TestUnlock_SpoofedCallerFromDifferentHostIsRejected is the negative control
+// for the lock-theft fix. A victim on host-a acquires a lock under caller_name
+// "victim". An attacker on host-b reconstructs the same caller_name/svid/oh and
+// sends UNLOCK. Without the caller<->source binding the attacker's UNLOCK would
+// call through to UnlockFileNLM and release the victim's lock. With the fix the
+// release must NOT happen, while the legitimate host-a UNLOCK still releases.
+func TestUnlock_SpoofedCallerFromDifferentHostIsRejected(t *testing.T) {
+	svc := &recordingLockService{}
+	h := NewHandler(svc, blocking.NewBlockingQueue(DefaultBlockingQueueSize))
+
+	victimCtx := &NLMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.7:51234"}
+	if _, err := h.Lock(victimCtx, lockReq("victim")); err != nil {
+		t.Fatalf("victim Lock error: %v", err)
+	}
+
+	// Attacker on a different source host spoofs the victim's caller_name.
+	attackerCtx := &NLMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.99:40000"}
+	if _, err := h.Unlock(attackerCtx, unlockReq("victim")); err != nil {
+		t.Fatalf("attacker Unlock error: %v", err)
+	}
+	if svc.unlockCalls != 0 {
+		t.Fatalf("attacker UNLOCK released victim lock: UnlockFileNLM called %d times, want 0", svc.unlockCalls)
+	}
+
+	// The legitimate owner on the original host must still be able to unlock.
+	if _, err := h.Unlock(victimCtx, unlockReq("victim")); err != nil {
+		t.Fatalf("victim Unlock error: %v", err)
+	}
+	if svc.unlockCalls != 1 {
+		t.Fatalf("legitimate UNLOCK did not release: UnlockFileNLM called %d times, want 1", svc.unlockCalls)
+	}
+}
+
+// TestCancel_SpoofedCallerFromDifferentHostIsRejected is the negative control
+// for the CANCEL lock-theft path. A victim queues a blocking lock; an attacker
+// on a different host must not be able to dequeue it via a spoofed caller_name.
+func TestCancel_SpoofedCallerFromDifferentHostIsRejected(t *testing.T) {
+	// Conflicting service: first lock succeeds (different owner already holds),
+	// second returns conflict so the victim's blocking request is queued.
+	svc := &conflictLockService{}
+	q := blocking.NewBlockingQueue(DefaultBlockingQueueSize)
+	h := NewHandler(svc, q)
+
+	victimCtx := &NLMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.7:51234"}
+	blockingReq := lockReq("victim")
+	blockingReq.Block = true
+	resp, err := h.Lock(victimCtx, blockingReq)
+	if err != nil {
+		t.Fatalf("victim blocking Lock error: %v", err)
+	}
+	if resp.Status != types.NLM4Blocked {
+		t.Fatalf("victim Lock status = %d, want NLM4Blocked (%d)", resp.Status, types.NLM4Blocked)
+	}
+
+	handleKey := string(blockingReq.Lock.FH)
+	if got := len(q.GetWaiters(handleKey)); got != 1 {
+		t.Fatalf("queue length after enqueue = %d, want 1", got)
+	}
+
+	// Attacker on a different host attempts CANCEL with the victim's caller_name.
+	attackerCtx := &NLMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.99:40000"}
+	cancelReq := &CancelRequest{
+		Block:     true,
+		Exclusive: true,
+		Lock:      blockingReq.Lock,
+	}
+	if _, err := h.Cancel(attackerCtx, cancelReq); err != nil {
+		t.Fatalf("attacker Cancel error: %v", err)
+	}
+	if got := len(q.GetWaiters(handleKey)); got != 1 {
+		t.Fatalf("attacker CANCEL dequeued victim waiter: queue length = %d, want 1", got)
+	}
+
+	// Legitimate owner can cancel its own pending request.
+	if _, err := h.Cancel(victimCtx, cancelReq); err != nil {
+		t.Fatalf("victim Cancel error: %v", err)
+	}
+	if got := len(q.GetWaiters(handleKey)); got != 0 {
+		t.Fatalf("legitimate CANCEL did not dequeue: queue length = %d, want 0", got)
+	}
+}
+
+// conflictLockService always reports a conflict so blocking locks get queued.
+type conflictLockService struct{}
+
+func (c *conflictLockService) LockFileNLM(_ context.Context, _ []byte, _ lock.LockOwner, _, _ uint64, _, _ bool) (*lock.LockResult, error) {
+	return &lock.LockResult{Success: false}, nil
+}
+
+func (c *conflictLockService) TestLockNLM(_ context.Context, _ []byte, _ lock.LockOwner, _, _ uint64, _ bool) (bool, *lock.UnifiedLockConflict, error) {
+	return false, nil, nil
+}
+
+func (c *conflictLockService) UnlockFileNLM(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	return nil
+}
+
+func (c *conflictLockService) CancelBlockingLock(_ context.Context, _ []byte, _ string, _, _ uint64) error {
+	return nil
+}

--- a/internal/adapter/nfs/nlm/handlers/cancel.go
+++ b/internal/adapter/nfs/nlm/handlers/cancel.go
@@ -83,6 +83,20 @@ func (h *Handler) Cancel(ctx *NLMHandlerContext, req *CancelRequest) (*CancelRes
 		"offset", req.Lock.Offset,
 		"length", req.Lock.Length)
 
+	// Lock-theft guard: refuse to cancel a pending request for a caller_name
+	// bound to a different transport source host. Return NLM4Granted (idempotent,
+	// no information leak) without dequeuing the victim's waiter.
+	if !h.callerBinding.authorized(req.Lock.CallerName, ctx.ClientAddr) {
+		logger.Warn("NLM CANCEL rejected: caller_name bound to a different client (possible lock theft)",
+			"client", ctx.ClientAddr,
+			"caller", req.Lock.CallerName,
+			"owner", ownerID)
+		return &CancelResponse{
+			Cookie: req.Cookie,
+			Status: types.NLM4Granted,
+		}, nil
+	}
+
 	// Convert file handle
 	handle := req.Lock.FH
 	handleKey := string(handle)

--- a/internal/adapter/nfs/nlm/handlers/free_all.go
+++ b/internal/adapter/nfs/nlm/handlers/free_all.go
@@ -70,9 +70,11 @@ func EncodeFreeAllResponse(_ *FreeAllResponse) ([]byte, error) {
 }
 
 // FreeAll handles NLM FREE_ALL (RFC 1813, NLM procedure 23).
-// Releases all locks held by a crashed client, triggered by NSM (rpc.statd) on reboot.
-// Decodes and logs the request; actual lock cleanup is coordinated by adapter OnClientCrash.
-// Best-effort cleanup; each NLM handler instance serves one share, adapter handles cross-share.
+// Releases all byte-range locks held by the named client and drains its blocking
+// waiters, triggered by the client's lock manager on reboot. This runs the same
+// per-share cleanup as NSM SM_NOTIFY crash detection so that a lost or delayed
+// SM_NOTIFY does not leave a rebooted client's locks orphaned (defense in depth):
+// FREE_ALL and SM_NOTIFY are independent crash signals and either must suffice.
 // Errors: none (returns void per NLM specification; decode errors are logged).
 func (h *Handler) FreeAll(ctx *NLMHandlerContext) ([]byte, error) {
 	req, err := DecodeFreeAllRequest(ctx.Data)
@@ -85,9 +87,21 @@ func (h *Handler) FreeAll(ctx *NLMHandlerContext) ([]byte, error) {
 		"client", req.Name,
 		"from", ctx.ClientAddr)
 
-	// The actual lock release is triggered by the adapter's OnClientCrash
-	// callback, which iterates all shares and their lock managers.
-	// This handler serves as the NLM RPC endpoint for logging and validation.
+	if req.Name == "" {
+		logger.Warn("FREE_ALL: empty client name; ignoring", "from", ctx.ClientAddr)
+		return EncodeFreeAllResponse(&FreeAllResponse{})
+	}
+
+	// Release the named client's locks via the adapter-wired cleanup, which
+	// iterates all shares' lock managers and the blocking queue. Idempotent and
+	// safe if the client held no locks. Cleanup is gated on grace period inside
+	// the wired routine, mirroring NSM crash handling.
+	if h.crashCleanup != nil {
+		h.crashCleanup(req.Name)
+	} else {
+		logger.Warn("FREE_ALL: no crash-cleanup wired; locks not released",
+			"client", req.Name)
+	}
 
 	return EncodeFreeAllResponse(&FreeAllResponse{})
 }

--- a/internal/adapter/nfs/nlm/handlers/free_all.go
+++ b/internal/adapter/nfs/nlm/handlers/free_all.go
@@ -83,12 +83,29 @@ func (h *Handler) FreeAll(ctx *NLMHandlerContext) ([]byte, error) {
 		return EncodeFreeAllResponse(&FreeAllResponse{})
 	}
 
+	// Reject an empty or over-long caller name before logging or using it. The
+	// XDR string decoder accepts up to 1MB; a malicious peer could otherwise
+	// inflate logs and force expensive cleanup with a giant name. NLM caller
+	// names are hostnames, bounded by MAXNAMELEN (1024).
+	if req.Name == "" || len(req.Name) > MaxCallerNameLen {
+		logger.Warn("FREE_ALL: rejected invalid client name",
+			"name_len", len(req.Name),
+			"from", ctx.ClientAddr)
+		return EncodeFreeAllResponse(&FreeAllResponse{})
+	}
+
 	logger.Info("FREE_ALL: received",
 		"client", req.Name,
 		"from", ctx.ClientAddr)
 
-	if req.Name == "" {
-		logger.Warn("FREE_ALL: empty client name; ignoring", "from", ctx.ClientAddr)
+	// Lock-theft guard: FREE_ALL releases ALL of a client's locks from a single
+	// client-supplied name, so it is an even simpler spoofing vector than
+	// UNLOCK/CANCEL. Refuse if the name is bound to a different transport source
+	// host (a rebooting client's source IP matches the host that locked).
+	if !h.callerBinding.authorized(req.Name, ctx.ClientAddr) {
+		logger.Warn("FREE_ALL rejected: caller_name bound to a different client (possible lock theft)",
+			"client", req.Name,
+			"from", ctx.ClientAddr)
 		return EncodeFreeAllResponse(&FreeAllResponse{})
 	}
 

--- a/internal/adapter/nfs/nlm/handlers/free_all_test.go
+++ b/internal/adapter/nfs/nlm/handlers/free_all_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
+)
+
+// encodeFreeAllWire builds the XDR wire form of an NLM4_FREE_ALL request:
+// a variable-length string (4-byte length + bytes + 4-byte padding) followed by
+// an int32 state.
+func encodeFreeAllWire(name string, state int32) []byte {
+	var b []byte
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(name)))
+	b = append(b, lenBuf...)
+	b = append(b, []byte(name)...)
+	for len(b)%4 != 0 {
+		b = append(b, 0)
+	}
+	stateBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(stateBuf, uint32(state))
+	b = append(b, stateBuf...)
+	return b
+}
+
+// TestFreeAll_InvokesCrashCleanup is the negative control for the FREE_ALL
+// no-op finding. FREE_ALL must release the named client's locks by invoking the
+// wired crash-cleanup callback. Before the fix the handler only logged, so no
+// cleanup callback was ever called and a crashed client's locks survived until
+// (and only if) a separate SM_NOTIFY arrived.
+func TestFreeAll_InvokesCrashCleanup(t *testing.T) {
+	svc := &recordingLockService{}
+	h := NewHandler(svc, blocking.NewBlockingQueue(DefaultBlockingQueueSize))
+
+	var gotClient string
+	calls := 0
+	h.SetCrashCleanup(func(clientID string) {
+		calls++
+		gotClient = clientID
+	})
+
+	ctx := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.7:51234",
+		Data:       encodeFreeAllWire("host-a", 7),
+	}
+
+	if _, err := h.FreeAll(ctx); err != nil {
+		t.Fatalf("FreeAll error: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("crash cleanup invoked %d times, want 1", calls)
+	}
+	if gotClient != "host-a" {
+		t.Fatalf("crash cleanup client = %q, want %q", gotClient, "host-a")
+	}
+}
+
+// TestFreeAll_EmptyNameDoesNotCleanup ensures an empty caller name is ignored
+// rather than triggering a release for the empty client (which could match an
+// unintended set).
+func TestFreeAll_EmptyNameDoesNotCleanup(t *testing.T) {
+	svc := &recordingLockService{}
+	h := NewHandler(svc, blocking.NewBlockingQueue(DefaultBlockingQueueSize))
+
+	calls := 0
+	h.SetCrashCleanup(func(string) { calls++ })
+
+	ctx := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.7:51234",
+		Data:       encodeFreeAllWire("", 0),
+	}
+	if _, err := h.FreeAll(ctx); err != nil {
+		t.Fatalf("FreeAll error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("crash cleanup invoked %d times for empty name, want 0", calls)
+	}
+}

--- a/internal/adapter/nfs/nlm/handlers/free_all_test.go
+++ b/internal/adapter/nfs/nlm/handlers/free_all_test.go
@@ -82,3 +82,77 @@ func TestFreeAll_EmptyNameDoesNotCleanup(t *testing.T) {
 		t.Fatalf("crash cleanup invoked %d times for empty name, want 0", calls)
 	}
 }
+
+// TestFreeAll_OverlongNameRejected caps the caller name so a malicious peer
+// cannot inflate logs / force expensive cleanup with a giant XDR string.
+func TestFreeAll_OverlongNameRejected(t *testing.T) {
+	svc := &recordingLockService{}
+	h := NewHandler(svc, blocking.NewBlockingQueue(DefaultBlockingQueueSize))
+
+	calls := 0
+	h.SetCrashCleanup(func(string) { calls++ })
+
+	huge := make([]byte, MaxCallerNameLen+1)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	ctx := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.7:51234",
+		Data:       encodeFreeAllWire(string(huge), 0),
+	}
+	if _, err := h.FreeAll(ctx); err != nil {
+		t.Fatalf("FreeAll error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("crash cleanup invoked %d times for over-long name, want 0", calls)
+	}
+}
+
+// TestFreeAll_SpoofedNameFromDifferentHostIsRejected is the negative control for
+// the FREE_ALL lock-theft vector: a victim on host-a holds locks under
+// caller_name "victim"; an attacker on host-b sends FREE_ALL("victim") and must
+// NOT trigger cleanup of the victim's locks.
+func TestFreeAll_SpoofedNameFromDifferentHostIsRejected(t *testing.T) {
+	svc := &recordingLockService{}
+	h := NewHandler(svc, blocking.NewBlockingQueue(DefaultBlockingQueueSize))
+
+	calls := 0
+	var gotClient string
+	h.SetCrashCleanup(func(clientID string) {
+		calls++
+		gotClient = clientID
+	})
+
+	// Victim binds caller_name "victim" from host-a via a successful LOCK.
+	victimCtx := &NLMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.7:51234"}
+	if _, err := h.Lock(victimCtx, lockReq("victim")); err != nil {
+		t.Fatalf("victim Lock error: %v", err)
+	}
+
+	// Attacker on host-b spoofs FREE_ALL for "victim".
+	attackerCtx := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.99:40000",
+		Data:       encodeFreeAllWire("victim", 0),
+	}
+	if _, err := h.FreeAll(attackerCtx); err != nil {
+		t.Fatalf("attacker FreeAll error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("attacker FREE_ALL triggered cleanup %d times (client %q), want 0", calls, gotClient)
+	}
+
+	// Legitimate FREE_ALL from the victim's host still cleans up.
+	victimFree := &NLMHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.7:33333", // same host, different ephemeral port (reboot)
+		Data:       encodeFreeAllWire("victim", 0),
+	}
+	if _, err := h.FreeAll(victimFree); err != nil {
+		t.Fatalf("victim FreeAll error: %v", err)
+	}
+	if calls != 1 || gotClient != "victim" {
+		t.Fatalf("legitimate FREE_ALL cleanup = %d times (client %q), want 1 / victim", calls, gotClient)
+	}
+}

--- a/internal/adapter/nfs/nlm/handlers/handler.go
+++ b/internal/adapter/nfs/nlm/handlers/handler.go
@@ -42,6 +42,19 @@ type NLMLockService interface {
 type Handler struct {
 	nlmService    NLMLockService
 	blockingQueue *blocking.BlockingQueue
+
+	// crashCleanup releases all locks held by the named client and drains its
+	// blocking-queue waiters. It is invoked by the FREE_ALL handler so that an
+	// NLM FREE_ALL RPC (sent by a rebooting client's lock manager) actually
+	// frees the crashed client's locks, independently of the NSM SM_NOTIFY path.
+	// May be nil (then FREE_ALL only logs). Wired by the adapter via
+	// SetCrashCleanup to the same cleanup routine NSM uses.
+	crashCleanup func(clientID string)
+
+	// callerBinding pins each NLM caller_name to the transport source host that
+	// first locked under it, so UNLOCK/CANCEL from a different host cannot
+	// release/cancel another client's locks via a spoofed caller_name.
+	callerBinding *callerBinding
 }
 
 // NewHandler creates a new NLM handler with the given NLM lock service and blocking queue.
@@ -57,6 +70,7 @@ func NewHandler(nlmService NLMLockService, blockingQueue *blocking.BlockingQueue
 	return &Handler{
 		nlmService:    nlmService,
 		blockingQueue: blockingQueue,
+		callerBinding: newCallerBinding(),
 	}
 }
 
@@ -64,4 +78,13 @@ func NewHandler(nlmService NLMLockService, blockingQueue *blocking.BlockingQueue
 // Used by the adapter to process waiters when locks are released.
 func (h *Handler) GetBlockingQueue() *blocking.BlockingQueue {
 	return h.blockingQueue
+}
+
+// SetCrashCleanup installs the callback invoked by FREE_ALL to release all locks
+// held by a named client. The adapter wires this to the same per-share lock
+// cleanup used for NSM SM_NOTIFY crash detection, giving FREE_ALL real effect.
+//
+// Passing nil disables FREE_ALL cleanup (handler only logs).
+func (h *Handler) SetCrashCleanup(fn func(clientID string)) {
+	h.crashCleanup = fn
 }

--- a/internal/adapter/nfs/nlm/handlers/lock.go
+++ b/internal/adapter/nfs/nlm/handlers/lock.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"bytes"
 	"fmt"
-	"net"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
@@ -146,6 +145,9 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 	}
 
 	if result.Success {
+		// Pin this caller_name to the transport source so a different host
+		// cannot later UNLOCK/CANCEL this client's locks via a spoofed name.
+		h.callerBinding.bind(req.Lock.CallerName, ctx.ClientAddr)
 		logger.Debug("NLM LOCK granted",
 			"client", ctx.ClientAddr,
 			"owner", ownerID)
@@ -167,7 +169,7 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 			},
 			Cookie:       req.Cookie,
 			Exclusive:    req.Exclusive,
-			CallbackAddr: extractCallbackAddr(ctx.ClientAddr),
+			CallbackHost: hostOf(ctx.ClientAddr),
 			CallbackProg: types.ProgramNLM,
 			CallbackVers: types.NLMVersion4,
 			CallerName:   req.Lock.CallerName,
@@ -199,6 +201,9 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 			}, nil
 		}
 
+		// Pin caller_name to source so a CANCEL spoofing this name from another
+		// host cannot dequeue this client's pending blocking request.
+		h.callerBinding.bind(req.Lock.CallerName, ctx.ClientAddr)
 		logger.Debug("NLM LOCK queued",
 			"client", ctx.ClientAddr,
 			"owner", ownerID)
@@ -234,27 +239,4 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 		Cookie: req.Cookie,
 		Status: types.NLM4Denied,
 	}, nil
-}
-
-// extractCallbackAddr constructs the callback address from the client address.
-//
-// Per NLM protocol, the callback is sent to the client's IP with the standard
-// NLM port (same as the main NLM port). Some implementations use a separate
-// callback port, but most use the same port.
-//
-// Parameters:
-//   - clientAddr: Client address in "host:port" format
-//
-// Returns the callback address in "host:port" format using standard NLM port.
-func extractCallbackAddr(clientAddr string) string {
-	host, _, err := net.SplitHostPort(clientAddr)
-	if err != nil {
-		// If we can't parse, use the original address
-		return clientAddr
-	}
-	// Use the standard NLM port (same as NFS port typically)
-	// NLM callbacks go to the same port the client is listening on
-	// which is typically a dynamic port chosen by the client
-	// For now, use the standard approach of connecting back to standard NLM port
-	return net.JoinHostPort(host, "12049")
 }

--- a/internal/adapter/nfs/nlm/handlers/unlock.go
+++ b/internal/adapter/nfs/nlm/handlers/unlock.go
@@ -74,6 +74,21 @@ func (h *Handler) Unlock(ctx *NLMHandlerContext, req *UnlockRequest) (*UnlockRes
 		"offset", req.Lock.Offset,
 		"length", req.Lock.Length)
 
+	// Lock-theft guard: refuse to release a lock for a caller_name that is bound
+	// to a different transport source host. We still return NLM4Granted (the spec
+	// makes UNLOCK idempotent and we must not leak whether the victim's lock
+	// exists), but we perform no release.
+	if !h.callerBinding.authorized(req.Lock.CallerName, ctx.ClientAddr) {
+		logger.Warn("NLM UNLOCK rejected: caller_name bound to a different client (possible lock theft)",
+			"client", ctx.ClientAddr,
+			"caller", req.Lock.CallerName,
+			"owner", ownerID)
+		return &UnlockResponse{
+			Cookie: req.Cookie,
+			Status: types.NLM4Granted,
+		}, nil
+	}
+
 	// Convert file handle
 	handle := req.Lock.FH
 

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -466,6 +466,16 @@ func (s *NFSAdapter) initNSMHandler(rt *runtime.Runtime, metadataService *metada
 		return s.handleClientCrash(ctx, clientID, metadataService)
 	}
 
+	// Wire NLM FREE_ALL to the same crash-cleanup routine. FREE_ALL is an
+	// independent crash signal from SM_NOTIFY: a rebooting client's lock manager
+	// sends it directly to the server. Without this, FREE_ALL was a no-op and a
+	// lost/delayed SM_NOTIFY left the client's locks orphaned.
+	if s.nlmHandler != nil {
+		s.nlmHandler.SetCrashCleanup(func(clientID string) {
+			_ = s.handleClientCrash(context.Background(), clientID, metadataService)
+		})
+	}
+
 	// Create NSM notifier for parallel SM_NOTIFY on restart
 	s.nsmNotifier = nsm.NewNotifier(nsm.NotifierConfig{
 		Handler:       s.nsmHandler,

--- a/pkg/adapter/nfs/nlm_smb_wakeup_test.go
+++ b/pkg/adapter/nfs/nlm_smb_wakeup_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/callback"
 	"github.com/marmos91/dittofs/pkg/adapter"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -187,6 +188,14 @@ func TestNLMWaiter_GrantedWhenSMBHolderReleases(t *testing.T) {
 	// callback listener so the GRANTED callback succeeds deterministically.
 	cb := newFakeNLMCallbackListener(t)
 
+	// The callback port is resolved from the client's portmapper at grant time.
+	// Stand in a deterministic resolver that points at our fake listener so the
+	// GRANTED callback target is exactly cb.addr() without a portmap round-trip.
+	restore := callback.SetCallbackAddrResolver(func(_ context.Context, _ string) (string, error) {
+		return cb.addr(), nil
+	})
+	t.Cleanup(restore)
+
 	const nlmOwnerID = "nlm:clientX:7:aa"
 	waiter := &blocking.Waiter{
 		Lock: lock.NewUnifiedLock(
@@ -195,7 +204,7 @@ func TestNLMWaiter_GrantedWhenSMBHolderReleases(t *testing.T) {
 			0, 100, lock.LockTypeExclusive,
 		),
 		Exclusive:    true,
-		CallbackAddr: cb.addr(),
+		CallbackHost: "127.0.0.1",
 		CallbackProg: 100021, // NLM program (value irrelevant to the fake listener)
 		CallbackVers: 4,
 		CallerName:   "clientX",


### PR DESCRIPTION
Fixes #1131

Addresses the verified NLM audit findings from the develop re-audit.

## Fixes

### NLM_GRANTED callback dialed the wrong port (HIGH)
`extractCallbackAddr` hardcoded the server's NFS port `:12049`, so every blocking-lock grant callback failed to connect (and the lock was then released), breaking the entire `block=true` path. The client's lockd port is now resolved via the client's portmapper (GETPORT for program `100021`/v4/TCP) at grant time, using the request's transport source IP. Resolution is lazy (at grant, not enqueue) so the LOCK response is not blocked on a network round-trip.

### NLM FREE_ALL was a no-op (MED)
`FreeAll` only logged; crashed-client locks survived until lease timeout / SM_NOTIFY. FREE_ALL now invokes the same per-share crash cleanup used for NSM SM_NOTIFY (wired by the adapter via `SetCrashCleanup`), so an independent FREE_ALL signal actually releases the client's locks and drains its blocking waiters. Grace-period gating in the shared cleanup is preserved.

### UNLOCK/CANCEL lock theft via spoofed caller_name (MED)
`ownerID` was reconstructed entirely from client-supplied wire fields with no transport binding, so any peer could release/cancel another client's lock. A `caller_name -> source host` binding is recorded on a successful LOCK (and on enqueue of a blocking LOCK); UNLOCK/CANCEL from a different source host claiming that caller_name is now refused (still returns NLM4Granted per spec, but performs no release/dequeue and leaks nothing).

### Callback SSRF guard
Both the GRANTED and portmap dials now reject unspecified, multicast, link-local (covering the `169.254.169.254` cloud metadata endpoint), and invalid-port targets — mirroring the existing v4/NSM callback guards. Loopback is allowed for co-located NFS mounts. The callback host is always the request's transport source, never a client-supplied wire field.

## Tests
Each fix ships a negative-control test that fails without it (verified by temporarily reverting each guard):
- `TestResolveNLMCallbackPort_UsesPortmapNotHardcoded`
- `TestFreeAll_InvokesCrashCleanup` / `TestFreeAll_EmptyNameDoesNotCleanup`
- `TestUnlock_SpoofedCallerFromDifferentHostIsRejected` / `TestCancel_SpoofedCallerFromDifferentHostIsRejected`
- `TestValidateCallbackAddr_RejectsUnsafe` / `TestSendGrantedCallback_RejectsSSRFTarget`

`go build ./... && go vet ./... && go test -race ./internal/adapter/nfs/nlm/... ./pkg/adapter/nfs/... ./pkg/metadata/lock/...` all green.

## Notes
The UNLOCK/CANCEL finding was audited as MED ("spec-correct unauthenticated NLM behavior"); the binding is a best-effort defense bounded by what the transport exposes (it does not defend against a same-host spoofer, which would require per-RPC auth).