### PR TITLE
fix(metadata): recompute usedBytes after postgres Restore; harden badger lock index keys (#1123)

### DIFF
--- a/pkg/metadata/store/badger/locks.go
+++ b/pkg/metadata/store/badger/locks.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -15,15 +16,32 @@ import (
 // BadgerDB LockStore Implementation
 // ============================================================================
 
-// Key prefixes for lock storage
+// Key prefixes for lock storage. The indexed segment (fileID/ownerID/clientID)
+// is hex-encoded so an attacker-controlled ':' cannot forge an extra key
+// segment (see lockIndexPrefix).
 const (
 	prefixLock         = "lock:"     // Primary: lock:{lockID}
-	prefixLockByFile   = "lkfile:"   // Index: lkfile:{fileID}:{lockID}
-	prefixLockByOwner  = "lkowner:"  // Index: lkowner:{ownerID}:{lockID}
-	prefixLockByClient = "lkclient:" // Index: lkclient:{clientID}:{lockID}
+	prefixLockByFile   = "lkfile:"   // Index: lkfile:{hex(fileID)}:{lockID}
+	prefixLockByOwner  = "lkowner:"  // Index: lkowner:{hex(ownerID)}:{lockID}
+	prefixLockByClient = "lkclient:" // Index: lkclient:{hex(clientID)}:{lockID}
 	prefixServerEpoch  = "srvepoch"  // Single key for epoch
 	keyCleanShutdown   = "srvclean"  // Single key for clean-shutdown marker
 )
+
+// lockIndexPrefix builds a secondary-index key prefix for one indexed value.
+//
+// fileID, ownerID and clientID all carry raw, unauthenticated, network-supplied
+// strings — and OwnerID/FileID legitimately contain ':' (e.g. NLM OwnerID
+// "nlm:caller:svid:oh", FileID = string(FileHandle)). Embedding them raw in a
+// ':'-separated Badger key lets a crafted value inject extra key segments: an
+// OwnerID "victim-owner:fake-lock-id" would plant a key that a later prefix scan
+// for "victim-owner" matches, letting deleteLocksByIndexPrefixTx remove another
+// owner's locks. Hex-encoding the indexed value makes the ':' separator
+// unambiguous so the segment boundary cannot be forged. Mirrors the MonName fix
+// in clients.go:monNameIndexPrefix.
+func lockIndexPrefix(prefix, value string) string {
+	return prefix + hex.EncodeToString([]byte(value)) + ":"
+}
 
 // badgerLockStore implements lock.LockStore using BadgerDB.
 //
@@ -81,19 +99,19 @@ func (s *badgerLockStore) putLockTx(txn *badgerdb.Txn, lk *lock.PersistedLock) e
 	lockIDBytes := []byte(lk.ID)
 
 	// Index by file
-	fileKey := []byte(prefixLockByFile + lk.FileID + ":" + lk.ID)
+	fileKey := []byte(lockIndexPrefix(prefixLockByFile, lk.FileID) + lk.ID)
 	if err := txn.Set(fileKey, lockIDBytes); err != nil {
 		return err
 	}
 
 	// Index by owner
-	ownerKey := []byte(prefixLockByOwner + lk.OwnerID + ":" + lk.ID)
+	ownerKey := []byte(lockIndexPrefix(prefixLockByOwner, lk.OwnerID) + lk.ID)
 	if err := txn.Set(ownerKey, lockIDBytes); err != nil {
 		return err
 	}
 
 	// Index by client
-	clientKey := []byte(prefixLockByClient + lk.ClientID + ":" + lk.ID)
+	clientKey := []byte(lockIndexPrefix(prefixLockByClient, lk.ClientID) + lk.ID)
 	if err := txn.Set(clientKey, lockIDBytes); err != nil {
 		return err
 	}
@@ -168,17 +186,17 @@ func (s *badgerLockStore) deleteLockTx(txn *badgerdb.Txn, lockID string) error {
 	}
 
 	// Delete secondary indexes
-	fileKey := []byte(prefixLockByFile + lk.FileID + ":" + lockID)
+	fileKey := []byte(lockIndexPrefix(prefixLockByFile, lk.FileID) + lockID)
 	if err := txn.Delete(fileKey); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err
 	}
 
-	ownerKey := []byte(prefixLockByOwner + lk.OwnerID + ":" + lockID)
+	ownerKey := []byte(lockIndexPrefix(prefixLockByOwner, lk.OwnerID) + lockID)
 	if err := txn.Delete(ownerKey); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err
 	}
 
-	clientKey := []byte(prefixLockByClient + lk.ClientID + ":" + lockID)
+	clientKey := []byte(lockIndexPrefix(prefixLockByClient, lk.ClientID) + lockID)
 	if err := txn.Delete(clientKey); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err
 	}
@@ -265,11 +283,11 @@ func (s *badgerLockStore) listLocksTx(txn *badgerdb.Txn, query lock.LockQuery) (
 	// Choose the best index based on query
 	switch {
 	case query.FileID != "":
-		prefix = prefixLockByFile + query.FileID + ":"
+		prefix = lockIndexPrefix(prefixLockByFile, query.FileID)
 	case query.OwnerID != "":
-		prefix = prefixLockByOwner + query.OwnerID + ":"
+		prefix = lockIndexPrefix(prefixLockByOwner, query.OwnerID)
 	case query.ClientID != "":
-		prefix = prefixLockByClient + query.ClientID + ":"
+		prefix = lockIndexPrefix(prefixLockByClient, query.ClientID)
 	default:
 		// No specific filter, scan all locks
 		prefix = prefixLock
@@ -344,7 +362,7 @@ func (s *badgerLockStore) DeleteLocksByClient(ctx context.Context, clientID stri
 	count := 0
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		var derr error
-		count, derr = s.deleteLocksByIndexPrefixTx(txn, []byte(prefixLockByClient+clientID+":"))
+		count, derr = s.deleteLocksByIndexPrefixTx(txn, []byte(lockIndexPrefix(prefixLockByClient, clientID)))
 		return derr
 	})
 	return count, err
@@ -359,7 +377,7 @@ func (s *badgerLockStore) DeleteLocksByFile(ctx context.Context, fileID string) 
 	count := 0
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		var derr error
-		count, derr = s.deleteLocksByIndexPrefixTx(txn, []byte(prefixLockByFile+fileID+":"))
+		count, derr = s.deleteLocksByIndexPrefixTx(txn, []byte(lockIndexPrefix(prefixLockByFile, fileID)))
 		return derr
 	})
 	return count, err
@@ -628,7 +646,7 @@ func (tx *badgerTransaction) DeleteLocksByClient(ctx context.Context, clientID s
 	// the rest of the operation and are discarded if WithTransaction retries on
 	// an OCC conflict (the store-level method would commit out-of-band).
 	tx.store.initLockStore()
-	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(prefixLockByClient+clientID+":"))
+	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(lockIndexPrefix(prefixLockByClient, clientID)))
 }
 
 func (tx *badgerTransaction) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
@@ -636,7 +654,7 @@ func (tx *badgerTransaction) DeleteLocksByFile(ctx context.Context, fileID strin
 		return 0, err
 	}
 	tx.store.initLockStore()
-	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(prefixLockByFile+fileID+":"))
+	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(lockIndexPrefix(prefixLockByFile, fileID)))
 }
 
 func (tx *badgerTransaction) GetServerEpoch(ctx context.Context) (uint64, error) {

--- a/pkg/metadata/store/badger/locks.go
+++ b/pkg/metadata/store/badger/locks.go
@@ -39,6 +39,15 @@ const (
 // owner's locks. Hex-encoding the indexed value makes the ':' separator
 // unambiguous so the segment boundary cannot be forged. Mirrors the MonName fix
 // in clients.go:monNameIndexPrefix.
+//
+// No on-disk migration is needed for the format change: startup lock recovery
+// (service.go) enumerates locks via the primary lock:{lockID} keys
+// (ListLocks with only a ShareName filter takes the default primaryKey scan),
+// which this change does not touch — so every persisted lock is still found and
+// re-graced. Stale legacy index entries left by a pre-upgrade run are
+// unreachable by the new scans and harmless: lock state is ephemeral runtime
+// state, cleared on clean shutdown and rebuilt under a fresh grace period after
+// an unclean one.
 func lockIndexPrefix(prefix, value string) string {
 	return prefix + hex.EncodeToString([]byte(value)) + ":"
 }

--- a/pkg/metadata/store/badger/locks_injection_test.go
+++ b/pkg/metadata/store/badger/locks_injection_test.go
@@ -1,0 +1,142 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestDeleteLocksByOwner_NoKeyInjection asserts that an OwnerID containing the
+// key separator ':' cannot forge an extra index segment that a prefix scan for
+// a different (victim) owner would match. NLM OwnerIDs legitimately contain ':'
+// (e.g. "nlm:caller:svid:oh") and come straight from the wire, so without
+// hex-encoding the indexed value an attacker registering OwnerID
+// "victim:fakeLockID" plants a key under the "victim" prefix that a bulk delete
+// for the victim owner would also reap.
+func TestDeleteLocksByOwner_NoKeyInjection(t *testing.T) {
+	ctx := context.Background()
+	store := newLockTestStore(t)
+
+	// Victim: a legitimate lock owned by "victim".
+	victimLock := &lock.PersistedLock{
+		ID:       "victim-lock",
+		FileID:   "fileV",
+		OwnerID:  "victim",
+		ClientID: "clientV",
+	}
+	if err := store.PutLock(ctx, victimLock); err != nil {
+		t.Fatalf("Put victim lock: %v", err)
+	}
+
+	// Attacker: OwnerID crafted to inject the victim's prefix + a lock ID.
+	attackerLock := &lock.PersistedLock{
+		ID:       "attacker-lock",
+		FileID:   "fileA",
+		OwnerID:  "victim:attacker-lock",
+		ClientID: "clientA",
+	}
+	if err := store.PutLock(ctx, attackerLock); err != nil {
+		t.Fatalf("Put attacker lock: %v", err)
+	}
+
+	// Deleting locks owned by "victim" via the owner index (ListLocks routes
+	// through prefixLockByOwner) must touch exactly the genuine victim lock.
+	locks, err := store.ListLocks(ctx, lock.LockQuery{OwnerID: "victim"})
+	if err != nil {
+		t.Fatalf("ListLocks(owner=victim): %v", err)
+	}
+	if len(locks) != 1 || locks[0].ID != "victim-lock" {
+		t.Fatalf("ListLocks(owner=victim) returned %+v; want exactly [victim-lock] (key-injection regression)", locks)
+	}
+
+	// The attacker lock must remain queryable under its true owner.
+	atk, err := store.ListLocks(ctx, lock.LockQuery{OwnerID: "victim:attacker-lock"})
+	if err != nil {
+		t.Fatalf("ListLocks(owner=attacker): %v", err)
+	}
+	if len(atk) != 1 || atk[0].ID != "attacker-lock" {
+		t.Fatalf("ListLocks for attacker owner returned %+v; want exactly [attacker-lock]", atk)
+	}
+}
+
+// TestDeleteLocksByClient_NoKeyInjection asserts the client index resists the
+// same ':' injection through DeleteLocksByClient, the bulk cleanup path.
+func TestDeleteLocksByClient_NoKeyInjection(t *testing.T) {
+	ctx := context.Background()
+	store := newLockTestStore(t)
+
+	if err := store.PutLock(ctx, &lock.PersistedLock{
+		ID:       "victim-lock",
+		FileID:   "fileV",
+		OwnerID:  "ownerV",
+		ClientID: "victim",
+	}); err != nil {
+		t.Fatalf("Put victim lock: %v", err)
+	}
+	if err := store.PutLock(ctx, &lock.PersistedLock{
+		ID:       "attacker-lock",
+		FileID:   "fileA",
+		OwnerID:  "ownerA",
+		ClientID: "victim:attacker-lock",
+	}); err != nil {
+		t.Fatalf("Put attacker lock: %v", err)
+	}
+
+	count, err := store.DeleteLocksByClient(ctx, "victim")
+	if err != nil {
+		t.Fatalf("DeleteLocksByClient(victim): %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("DeleteLocksByClient(victim) deleted %d locks; want 1 (key-injection regression)", count)
+	}
+
+	// The attacker lock must survive.
+	if _, err := store.GetLock(ctx, "attacker-lock"); err != nil {
+		t.Fatalf("attacker lock was unexpectedly deleted by the victim client scan: %v", err)
+	}
+	// The victim lock must be gone.
+	if _, err := store.GetLock(ctx, "victim-lock"); err == nil {
+		t.Fatalf("victim lock still present after DeleteLocksByClient; want removed")
+	}
+}
+
+// TestLockIndex_ColonRoundTrip is a control: OwnerID/FileID/ClientID values that
+// legitimately contain ':' still index, query, and delete correctly.
+func TestLockIndex_ColonRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newLockTestStore(t)
+
+	lk := &lock.PersistedLock{
+		ID:       "lock-1",
+		FileID:   "fh:00:01",
+		OwnerID:  "nlm:host1:1234:abcd",
+		ClientID: "smb:session456:pid789",
+	}
+	if err := store.PutLock(ctx, lk); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	for _, q := range []lock.LockQuery{
+		{FileID: lk.FileID},
+		{OwnerID: lk.OwnerID},
+		{ClientID: lk.ClientID},
+	} {
+		got, err := store.ListLocks(ctx, q)
+		if err != nil {
+			t.Fatalf("ListLocks(%+v): %v", q, err)
+		}
+		if len(got) != 1 || got[0].ID != "lock-1" {
+			t.Fatalf("ListLocks(%+v) returned %+v; want exactly [lock-1]", q, got)
+		}
+	}
+
+	// Bulk cleanup by file must find and remove the lock.
+	count, err := store.DeleteLocksByFile(ctx, lk.FileID)
+	if err != nil {
+		t.Fatalf("DeleteLocksByFile: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("DeleteLocksByFile deleted %d; want 1", count)
+	}
+}

--- a/pkg/metadata/store/badger/locks_injection_test.go
+++ b/pkg/metadata/store/badger/locks_injection_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// TestDeleteLocksByOwner_NoKeyInjection asserts that an OwnerID containing the
+// TestListLocksByOwner_NoKeyInjection asserts that an OwnerID containing the
 // key separator ':' cannot forge an extra index segment that a prefix scan for
 // a different (victim) owner would match. NLM OwnerIDs legitimately contain ':'
 // (e.g. "nlm:caller:svid:oh") and come straight from the wire, so without
 // hex-encoding the indexed value an attacker registering OwnerID
-// "victim:fakeLockID" plants a key under the "victim" prefix that a bulk delete
-// for the victim owner would also reap.
-func TestDeleteLocksByOwner_NoKeyInjection(t *testing.T) {
+// "victim:fakeLockID" plants a key under the "victim" prefix that an owner-keyed
+// scan for the victim would also match.
+func TestListLocksByOwner_NoKeyInjection(t *testing.T) {
 	ctx := context.Background()
 	store := newLockTestStore(t)
 
@@ -40,7 +40,7 @@ func TestDeleteLocksByOwner_NoKeyInjection(t *testing.T) {
 		t.Fatalf("Put attacker lock: %v", err)
 	}
 
-	// Deleting locks owned by "victim" via the owner index (ListLocks routes
+	// Scanning locks owned by "victim" via the owner index (ListLocks routes
 	// through prefixLockByOwner) must touch exactly the genuine victim lock.
 	locks, err := store.ListLocks(ctx, lock.LockQuery{OwnerID: "victim"})
 	if err != nil {

--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -326,6 +326,16 @@ func (s *PostgresMetadataStore) Restore(ctx context.Context, r io.Reader) error 
 		return fmt.Errorf("restore: commit: %w", err)
 	}
 
+	// The DB has been fully repopulated, but the in-memory usedBytes counter
+	// still holds the pre-restore value (often 0 from the prior Reset truncate).
+	// Recompute it from the committed rows so GetUsedBytes — and the quota guard
+	// in metadata/io.go that reads it — reflect the restored contents without a
+	// process restart. The query runs on the pool, which now sees the committed
+	// data. Badger's restore path does the same at backup.go:291 for parity.
+	if err := s.initUsedBytesCounter(ctx); err != nil {
+		return fmt.Errorf("restore: reinitialize used-bytes counter: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/metadata/storetest/backup_conformance.go
+++ b/pkg/metadata/storetest/backup_conformance.go
@@ -68,6 +68,47 @@ func RunBackupConformanceSuite(t *testing.T, factory BackupableStoreFactory) {
 	t.Run("LiveSetUnionsManifestNegativeControl", func(t *testing.T) {
 		testBackup_LiveSetUnionsManifestNegativeControl(t, factory)
 	})
+
+	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
+		testBackup_UsedBytesAfterRestore(t, factory)
+	})
+}
+
+// testBackup_UsedBytesAfterRestore pins the quota-counter invariant: after
+// Restore the in-memory usedBytes counter MUST reflect the restored regular-file
+// bytes, not the destination's pre-restore value. GetUsedBytes feeds the quota
+// guard in metadata/io.go; a stale 0 (the value a freshly-opened store holds on
+// an empty DB) silently disables quota enforcement until the process restarts.
+// The postgres restore path failed to recompute the counter; memory and badger
+// recompute it. This conformance test catches the divergence for every backend.
+func testBackup_UsedBytesAfterRestore(t *testing.T, factory BackupableStoreFactory) {
+	srcStore := factory(t)
+	srcB := asBackupable(t, srcStore)
+	ctx := t.Context()
+
+	// populateTestData writes two regular files of 8 MiB and 6 MiB.
+	populateTestData(t, srcStore, "ub")
+	const wantBytes = int64((8 << 20) + (6 << 20))
+
+	if got := srcStore.GetUsedBytes(); got != wantBytes {
+		t.Fatalf("source GetUsedBytes() = %d, want %d (fixture sanity)", got, wantBytes)
+	}
+
+	var buf bytes.Buffer
+	if _, err := srcB.Backup(ctx, &buf); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+
+	// Restore into a fresh store, whose usedBytes counter starts at 0.
+	dstStore := factory(t)
+	dstB := asBackupable(t, dstStore)
+	if err := dstB.Restore(ctx, &buf); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if got := dstStore.GetUsedBytes(); got != wantBytes {
+		t.Fatalf("restored GetUsedBytes() = %d, want %d — restore did not recompute the quota counter", got, wantBytes)
+	}
 }
 
 // testBackup_LiveSetSupersetOfBackup pins the GC-vs-snapshot invariant fixed in


### PR DESCRIPTION
Closes #1123.

## HIGH — postgres Restore breaks the quota/used-bytes counter
`Restore()` committed the COPY-loaded data but never reinitialized the in-memory
`usedBytes` atomic counter, leaving it at the pre-restore value (typically 0 from
the prior `Reset` truncate). `GetUsedBytes()` feeds the quota guard in
`pkg/metadata/io.go`, so after a restore every write passed the quota check
regardless of actual DB usage until the process restarted. The badger backend
already recomputes the counter post-restore (backup.go:291); postgres did not.

Fix: call `initUsedBytesCounter(ctx)` after `COMMIT` (the pool now sees the
committed rows), mirroring badger.

## MED — badger lock index keys allow ':' prefix-scan injection
The `lkfile:`/`lkowner:`/`lkclient:` secondary-index keys concatenated raw,
unauthenticated, network-supplied values with `':'` as the segment delimiter.
NLM `OwnerID` (`nlm:caller:svid:oh`) and `FileID` (`string(FileHandle)`)
legitimately contain `':'`, so a crafted value could forge an extra key segment
and let a prefix-scan bulk delete reap another owner's locks — the same flaw
already fixed for `MonName` in `clients.go`.

Fix: hex-encode the indexed value via a shared `lockIndexPrefix` helper across
all put/delete/list/bulk-delete sites, mirroring `monNameIndexPrefix`.

## Tests
- New backend-agnostic `UsedBytesAfterRestore` conformance subtest (runs against
  memory, badger, and postgres) asserts the counter reflects restored bytes.
- New badger key-injection regression tests (`TestDeleteLocksByOwner_NoKeyInjection`,
  `TestDeleteLocksByClient_NoKeyInjection`) plus a `:` round-trip control.

`go build ./...`, `go test ./pkg/metadata/...`, `go test -race` on the badger
lock/backup paths, and `go vet -tags integration ./pkg/metadata/store/postgres/`
all pass locally; the postgres conformance subtest runs in CI's integration job.