### PR TITLE
fix(nfs/v4): CLAIM_DELEGATE_CUR checks + write-only FATTR4 TIME encode (#1127)

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -218,11 +218,12 @@ func SupportedAttrs() []uint32 {
 	SetBit(&bitmap, FATTR4_SPACE_FREE)
 	SetBit(&bitmap, FATTR4_SPACE_AVAIL)
 	SetBit(&bitmap, FATTR4_TIME_ACCESS)
-	SetBit(&bitmap, FATTR4_TIME_ACCESS_SET)
 	SetBit(&bitmap, FATTR4_TIME_METADATA)
 	SetBit(&bitmap, FATTR4_TIME_MODIFY)
-	SetBit(&bitmap, FATTR4_TIME_MODIFY_SET)
 	SetBit(&bitmap, FATTR4_MOUNTED_ON_FILEID)
+	// FATTR4_TIME_ACCESS_SET (48) and FATTR4_TIME_MODIFY_SET (54) are write-only
+	// (RFC 7530 Section 5.7): they are valid only in SETATTR/EXCLUSIVE4_1 create and
+	// must not appear in FATTR4_SUPPORTED_ATTRS. See WritableAttrs/exclcreatAttrs.
 
 	// NFSv4.1 exclusive create attributes (word 2)
 	SetBit(&bitmap, FATTR4_SUPPATTR_EXCLCREAT)

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -518,3 +518,77 @@ func TestSetIdentityMapper_NoDataRace(t *testing.T) {
 	close(ready)
 	wg.Wait()
 }
+
+// ============================================================================
+// Write-only attribute regression (RFC 7530 Section 5.7)
+// ============================================================================
+
+// TestSupportedAttrsExcludesWriteOnlyTimeSet asserts that the write-only
+// SETATTR attributes FATTR4_TIME_ACCESS_SET (48) and FATTR4_TIME_MODIFY_SET
+// (54) are NOT advertised in FATTR4_SUPPORTED_ATTRS. Per RFC 7530 Section 5.7
+// these are write-only (valid only in SETATTR / EXCLUSIVE4_1 create) and must
+// not appear in the supported-attrs bitmap. Advertising them caused GETATTR to
+// fail: Intersect() would include them in the response bitmap, and the encoder
+// has no case for them, hitting the "unsupported attribute bit" error path.
+func TestSupportedAttrsExcludesWriteOnlyTimeSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bit  uint32
+	}{
+		{"FATTR4_TIME_ACCESS_SET", FATTR4_TIME_ACCESS_SET},
+		{"FATTR4_TIME_MODIFY_SET", FATTR4_TIME_MODIFY_SET},
+	} {
+		if IsBitSet(SupportedAttrs(), tc.bit) {
+			t.Errorf("SupportedAttrs() advertises write-only bit %s (%d)", tc.name, tc.bit)
+		}
+		if IsBitSet(SupportedRealAttrs(), tc.bit) {
+			t.Errorf("SupportedRealAttrs() advertises write-only bit %s (%d)", tc.name, tc.bit)
+		}
+	}
+}
+
+// TestGetattrWriteOnlyTimeSetDoesNotFail verifies that a GETATTR requesting the
+// write-only time-set bits does not error: since they are no longer supported,
+// Intersect drops them and they are simply absent from the response bitmap.
+func TestGetattrWriteOnlyTimeSetDoesNotFail(t *testing.T) {
+	node := newMockNode()
+
+	var requested []uint32
+	SetBit(&requested, FATTR4_TIME_ACCESS_SET)
+	SetBit(&requested, FATTR4_TIME_MODIFY_SET)
+	// Mix in a normal attribute to ensure encoding still happens.
+	SetBit(&requested, FATTR4_TYPE)
+
+	var buf bytes.Buffer
+	if err := EncodePseudoFSAttrs(&buf, requested, node); err != nil {
+		t.Fatalf("EncodePseudoFSAttrs failed on write-only bits: %v", err)
+	}
+
+	responseBitmap, err := DecodeBitmap4(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("decode response bitmap: %v", err)
+	}
+	if IsBitSet(responseBitmap, FATTR4_TIME_ACCESS_SET) {
+		t.Error("FATTR4_TIME_ACCESS_SET leaked into GETATTR response bitmap")
+	}
+	if IsBitSet(responseBitmap, FATTR4_TIME_MODIFY_SET) {
+		t.Error("FATTR4_TIME_MODIFY_SET leaked into GETATTR response bitmap")
+	}
+	if !IsBitSet(responseBitmap, FATTR4_TYPE) {
+		t.Error("FATTR4_TYPE missing from response bitmap")
+	}
+}
+
+// TestWritableAndExclcreatStillIncludeTimeSet guards the inverse: the
+// write-only bits must remain valid for SETATTR and EXCLUSIVE4_1 create even
+// though they are excluded from SUPPORTED_ATTRS.
+func TestWritableAndExclcreatStillIncludeTimeSet(t *testing.T) {
+	for _, bit := range []uint32{FATTR4_TIME_ACCESS_SET, FATTR4_TIME_MODIFY_SET} {
+		if !IsBitSet(WritableAttrs(), bit) {
+			t.Errorf("WritableAttrs() missing write-only bit %d", bit)
+		}
+		if !IsBitSet(exclcreatAttrs(), bit) {
+			t.Errorf("exclcreatAttrs() missing write-only bit %d", bit)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -697,8 +697,8 @@ func (h *Handler) handleOpenClaimDelegateCur(
 		return openError(types.NFS4ERR_BADXDR)
 	}
 
-	// Validate the delegation stateid
-	_, delegErr := h.StateManager.ValidateDelegationStateid(delegStateid)
+	// Validate the delegation stateid.
+	deleg, delegErr := h.StateManager.ValidateDelegationStateid(delegStateid)
 	if delegErr != nil {
 		nfsStatus := mapStateError(delegErr)
 		logger.Debug("NFSv4 OPEN CLAIM_DELEGATE_CUR: invalid delegation stateid",
@@ -706,6 +706,19 @@ func (h *Handler) handleOpenClaimDelegateCur(
 			"nfs_status", nfsStatus,
 			"client", ctx.ClientAddr)
 		return openError(nfsStatus)
+	}
+
+	// The delegation stateid only proves it exists; it must also be owned by the
+	// client issuing this OPEN. Without this check, any client presenting a
+	// syntactically valid delegation stateid (e.g. observed on the wire) could
+	// open the delegated file under a foreign delegation. RFC 7530 Section 8.2:
+	// a stateid is scoped to the client that was granted it.
+	if deleg.ClientID != clientID {
+		logger.Debug("NFSv4 OPEN CLAIM_DELEGATE_CUR: delegation owned by another client",
+			"deleg_client_id", deleg.ClientID,
+			"open_client_id", clientID,
+			"client", ctx.ClientAddr)
+		return openError(types.NFS4ERR_BAD_STATEID)
 	}
 
 	if status := types.ValidateUTF8Filename(filename); status != types.NFS4_OK {
@@ -748,16 +761,35 @@ func (h *Handler) handleOpenClaimDelegateCur(
 		return openError(types.NFS4ERR_SERVERFAULT)
 	}
 
+	// The delegation stateid must reference the file being opened. Presenting a
+	// delegation for one file to open a different file is a bad stateid.
+	if !bytes.Equal(deleg.FileHandle, fileHandle) {
+		logger.Debug("NFSv4 OPEN CLAIM_DELEGATE_CUR: delegation file handle mismatch",
+			"file", filename,
+			"client", ctx.ClientAddr)
+		return openError(types.NFS4ERR_BAD_STATEID)
+	}
+
+	// Enforce file permissions for the requested share_access, exactly as the
+	// CLAIM_NULL paths do. A delegation stateid proves the client held a
+	// delegation, not that this RPC caller may read/write the file.
+	if accessErr := checkOpenAccess(metaSvc, authCtx, fileHandle, shareAccess); accessErr != nil {
+		return openError(common.MapToNFS4(accessErr))
+	}
+
 	ctx.CurrentFH = make([]byte, len(fileHandle))
 	copy(ctx.CurrentFH, fileHandle)
 
-	// Create tracked state via StateManager (use CLAIM_NULL for state tracking).
-	// The client already has a delegation, so no conflict check or grant needed.
+	// Create tracked state via StateManager. CLAIM_DELEGATE_CUR is permitted
+	// during the grace period (RFC 7530 Section 8.4.2): the client already holds a
+	// delegation, so this is not a new open that must wait for grace to end.
+	// Passing the real claim type skips the CLAIM_NULL grace gate while still
+	// running the share-reservation conflict scan.
 	openResult, stateErr := h.StateManager.OpenFile(
 		clientID, ownerData, seqid,
 		[]byte(fileHandle),
 		shareAccess, shareDeny,
-		types.CLAIM_NULL,
+		types.CLAIM_DELEGATE_CUR,
 	)
 	if stateErr != nil {
 		return openError(mapStateError(stateErr))

--- a/internal/adapter/nfs/v4/handlers/open_delegation_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_delegation_test.go
@@ -340,3 +340,130 @@ func TestOpenClaimDelegateCur_V40_ConfirmFlagPreserved(t *testing.T) {
 		t.Fatalf("rflags = %#x, OPEN4_RESULT_CONFIRM must be set for a new v4.0 owner", rflags)
 	}
 }
+
+// ============================================================================
+// Bug 3 — CLAIM_DELEGATE_CUR security and grace-period handling (#1127)
+// ============================================================================
+
+// TestOpenClaimDelegateCur_DuringGrace_Succeeds verifies that CLAIM_DELEGATE_CUR
+// is honored during the grace period (RFC 7530 Section 8.4.2): a client that
+// held a delegation before restart must be able to reclaim via this path. Before
+// the fix the handler passed CLAIM_NULL to OpenFile, which the grace gate
+// rejected with NFS4ERR_GRACE.
+func TestOpenClaimDelegateCur_DuringGrace_Succeeds(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xC0FFEE)
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "grace.txt", 0o644, 0, 0)
+	deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+	if deleg == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	// Put the server into grace, as it would be just after a restart.
+	fx.handler.StateManager.StartGracePeriod([]uint64{clientA})
+	if !fx.handler.StateManager.IsInGrace() {
+		t.Fatalf("expected server to be in grace")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.SkipOwnerSeqid = true // v4.1 session
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientA,
+		[]byte("owner-grace"),
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"grace.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR during grace status = %d, want NFS4_OK", result.Status)
+	}
+}
+
+// TestOpenClaimDelegateCur_ForeignDelegation_Rejected verifies that a client
+// cannot use a delegation stateid owned by a different client. Before the fix
+// the delegation's ClientID was discarded and never compared to the OPEN arg's
+// clientID, letting any client open the file under a foreign delegation.
+func TestOpenClaimDelegateCur_ForeignDelegation_Rejected(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const ownerClient = uint64(0xA11CE)
+	const attackerClient = uint64(0xBADBAD)
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "foreign.txt", 0o644, 0, 0)
+	deleg := fx.handler.StateManager.GrantDelegation(ownerClient, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+	if deleg == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.SkipOwnerSeqid = true
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	// Attacker presents the victim's delegation stateid with its OWN clientID.
+	args := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		attackerClient,
+		[]byte("attacker-owner"),
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"foreign.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4ERR_BAD_STATEID {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR with foreign delegation status = %d, want NFS4ERR_BAD_STATEID", result.Status)
+	}
+}
+
+// TestOpenClaimDelegateCur_EnforcesFilePermissions verifies that the path runs
+// the same POSIX permission check as the CLAIM_NULL paths. A non-root client
+// opening a file it has no write access to must be denied even with a valid,
+// self-owned delegation stateid. Before the fix checkOpenAccess was never
+// called on this path.
+func TestOpenClaimDelegateCur_EnforcesFilePermissions(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	const clientA = uint64(0xD00D)
+	// File owned by uid 1000, mode 0600 (rw for owner only).
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "secret.txt", 0o600, 1000, 1000)
+	deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+	if deleg == nil {
+		t.Fatalf("GrantDelegation returned nil")
+	}
+
+	// Requester is uid 2000 — no access to a 0600 file owned by uid 1000.
+	ctx := newRealFSContext(2000, 2000)
+	ctx.SkipOwnerSeqid = true
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+
+	args := encodeOpenArgsDelegateCur(
+		1,
+		types.OPEN4_SHARE_ACCESS_WRITE,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientA,
+		[]byte("owner-noperm"),
+		types.OPEN4_NOCREATE,
+		&deleg.Stateid,
+		"secret.txt",
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status == types.NFS4_OK {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR with no file permission succeeded; want access error")
+	}
+	if result.Status != types.NFS4ERR_ACCESS {
+		t.Fatalf("OPEN CLAIM_DELEGATE_CUR status = %d, want NFS4ERR_ACCESS", result.Status)
+	}
+}


### PR DESCRIPTION
Closes #1127. Addresses all 3 HIGH findings from the develop `3488526a` re-audit.

### 1. FATTR4_TIME_ACCESS_SET / FATTR4_TIME_MODIFY_SET advertised but not encodable (HIGH)
`SupportedAttrs()` set bits 48/54, but the encoder has no case for them — any GETATTR requesting those bits hit `default: unsupported attribute bit` and failed the op. Per RFC 7530 §5.7 these are **write-only** (valid only in SETATTR / EXCLUSIVE4_1 create) and must not appear in `FATTR4_SUPPORTED_ATTRS`. Removed them from `SupportedAttrs`; they remain in `WritableAttrs` (SETATTR decode) and `exclcreatAttrs` (EXCLUSIVE4_1).

### 2. CLAIM_DELEGATE_CUR blocked during grace (HIGH)
The handler hardcoded `CLAIM_NULL` into `OpenFile`, whose grace gate returns `NFS4ERR_GRACE` for `CLAIM_NULL`. RFC 7530 §8.4.2 permits CLAIM_DELEGATE_CUR during grace (delegation holders reclaim via this path). Now passes `CLAIM_DELEGATE_CUR`, which skips the new-open grace gate while still running the share-reservation conflict scan.

### 3. CLAIM_DELEGATE_CUR: no ownership check, no permission check (HIGH)
The validated `DelegationState` was discarded, so the delegation's `ClientID` was never compared to the OPEN arg, and `checkOpenAccess` was never called. Any client presenting a valid (possibly sniffed) delegation stateid could open any file with no permission enforcement. Now:
- rejects a delegation owned by another client (`NFS4ERR_BAD_STATEID`),
- rejects a delegation whose file handle doesn't match the opened file (`NFS4ERR_BAD_STATEID`),
- enforces POSIX permissions via `checkOpenAccess`, exactly as the CLAIM_NULL paths.

### Tests
Each fix has a regression test proven to fail before / pass after:
- `TestSupportedAttrsExcludesWriteOnlyTimeSet`, `TestGetattrWriteOnlyTimeSetDoesNotFail`, `TestWritableAndExclcreatStillIncludeTimeSet`
- `TestOpenClaimDelegateCur_DuringGrace_Succeeds`
- `TestOpenClaimDelegateCur_ForeignDelegation_Rejected`
- `TestOpenClaimDelegateCur_EnforcesFilePermissions`