### PR TITLE
fix(smb): CANCEL compound nil-deref, MAXIMUM_ALLOWED share-mode, EaSize nil-deref (#1129)

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -220,18 +220,18 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		}
 	}
 
-	respHeader, body := buildResponseHeaderAndBody(firstHeader, handlerCtx, result, connInfo)
-	// collect ReleaseData from the sub-result so sendCompoundResponses
-	// can fire it AFTER the composed wire write — not between sub-responses.
-	var firstRelease func()
+	// A nil result signals "no response should be sent" — only CANCEL does this
+	// per MS-SMB2 §3.3.5.16. Compounding CANCEL is prohibited by spec, but a
+	// malicious or buggy client can still send it; building a response from the
+	// nil result would dereference result.Status and panic the connection
+	// goroutine (DoS). Skip emitting a response for this subcommand and continue
+	// processing the rest of the chain, mirroring the standalone path.
 	if result != nil {
-		firstRelease = result.ReleaseData
-	}
-	state.responses = append(state.responses, compoundResponse{respHeader: respHeader, body: body, releaseData: firstRelease})
-	if handlerCtx != nil && handlerCtx.PostSend != nil {
-		state.postSendHooks = append(state.postSendHooks, handlerCtx.PostSend)
-	}
-	if result != nil {
+		respHeader, body := buildResponseHeaderAndBody(firstHeader, handlerCtx, result, connInfo)
+		state.responses = append(state.responses, compoundResponse{respHeader: respHeader, body: body, releaseData: result.ReleaseData})
+		if handlerCtx != nil && handlerCtx.PostSend != nil {
+			state.postSendHooks = append(state.postSendHooks, handlerCtx.PostSend)
+		}
 		state.lastCmdSessionFailed = isSessionLevelError(result.Status)
 		state.lastCmdFailed = result.Status.IsError()
 		if state.lastCmdFailed {
@@ -976,6 +976,15 @@ func (s *compoundLoopState) processRemaining(
 			s.markStartedAsyncIDs = append(s.markStartedAsyncIDs, cmdResult.AsyncId)
 		}
 
+		// A nil result signals "no response should be sent" (CANCEL, per
+		// MS-SMB2 §3.3.5.16). Passing it to buildResponseHeaderAndBody would
+		// dereference cmdResult.Status and panic the connection goroutine.
+		// Compounding CANCEL is prohibited by spec, but the server must not
+		// crash on malformed client input — skip this subcommand's response.
+		if cmdResult == nil {
+			continue
+		}
+
 		rh, rb := buildResponseHeaderAndBody(hdr, cmdCtx, cmdResult, connInfo)
 		// Per MS-SMB2 3.3.5.2.7: if the request had FLAGS_RELATED_OPERATIONS,
 		// the response MUST also have FLAGS_RELATED_OPERATIONS set.
@@ -984,11 +993,7 @@ func (s *compoundLoopState) processRemaining(
 		}
 		// propagate the sub-result's ReleaseData so the composed wire
 		// write can fire it post-write (see compoundResponse doc comment).
-		var subRelease func()
-		if cmdResult != nil {
-			subRelease = cmdResult.ReleaseData
-		}
-		s.responses = append(s.responses, compoundResponse{respHeader: rh, body: rb, releaseData: subRelease})
+		s.responses = append(s.responses, compoundResponse{respHeader: rh, body: rb, releaseData: cmdResult.ReleaseData})
 
 		// Collect any PostSend hook (CLOSE→CHANGE_NOTIFY cleanup) so it can
 		// fire strictly after the compound frame has been written.

--- a/internal/adapter/smb/compound_framing_safety_test.go
+++ b/internal/adapter/smb/compound_framing_safety_test.go
@@ -100,3 +100,94 @@ func TestProcessRemaining_RelatedSignatureNotSkipped(t *testing.T) {
 			got, types.StatusAccessDenied)
 	}
 }
+
+// cancelBody is the 4-byte SMB2 CANCEL request body (StructureSize=4, Reserved=0).
+// A CANCEL handler returns a nil result (MS-SMB2 §3.3.5.16: no response) only
+// when the body is at least 4 bytes; a shorter body yields an error result.
+var cancelBody = []byte{0x04, 0x00, 0x00, 0x00}
+
+// encodeCompoundCommand encodes hdr+body as one compound member. When withNext
+// is true the member is padded to an 8-byte-aligned length and its NextCommand
+// field is set to that length so a following member can be appended.
+func encodeCompoundCommand(hdr *header.SMB2Header, body []byte, withNext bool) []byte {
+	if withNext {
+		// 8-byte align so NextCommand satisfies the alignment + min-size gates.
+		total := (header.HeaderSize + len(body) + 7) &^ 7
+		hdr.NextCommand = uint32(total)
+	}
+	frame := append(hdr.Encode(), body...)
+	if withNext {
+		for len(frame) < int(hdr.NextCommand) {
+			frame = append(frame, 0)
+		}
+	}
+	return frame
+}
+
+// TestProcessRemaining_CancelSubcommandNoPanic verifies that a CANCEL appearing
+// as a subsequent compound command does not panic. ProcessRequestWithFileID...
+// returns a nil result for CANCEL (MS-SMB2 §3.3.5.16 requires no response);
+// before the fix processRemaining passed that nil to buildResponseHeaderAndBody,
+// which dereferenced result.Status and crashed the connection goroutine (DoS).
+// After the fix the nil subcommand is skipped and the chain continues.
+func TestProcessRemaining_CancelSubcommandNoPanic(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+
+	// CANCEL (yields nil result) chained to a trailing CANCEL. Both emit no
+	// response per §3.3.5.16, so the response list must be empty — and the
+	// loop must not panic on the first nil.
+	first := encodeCompoundCommand(&header.SMB2Header{Command: types.SMB2Cancel, MessageID: 2}, cancelBody, true)
+	second := encodeCompoundCommand(&header.SMB2Header{Command: types.SMB2Cancel, MessageID: 3}, cancelBody, false)
+	frame := append(first, second...)
+
+	state := compoundLoopState{lastSessionID: 0, lastTreeID: 0}
+	state.processRemaining(context.Background(), frame, ci, false, nil)
+
+	if len(state.responses) != 0 {
+		t.Fatalf("CANCEL subcommands must emit no response, got %d", len(state.responses))
+	}
+}
+
+// TestProcessRemaining_CancelThenRealCommandContinues verifies that after a nil
+// CANCEL subcommand the loop continues and still emits a response for the next
+// command (a nil result must skip, not abort the chain). The trailing command
+// uses an invalid command code so prepareDispatch returns a non-nil error
+// result (STATUS_INVALID_PARAMETER) — proving the following member was
+// processed despite the preceding nil.
+func TestProcessRemaining_CancelThenRealCommandContinues(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+
+	const invalidCommand = types.Command(0xFFFF)
+	first := encodeCompoundCommand(&header.SMB2Header{Command: types.SMB2Cancel, MessageID: 2}, cancelBody, true)
+	second := encodeCompoundCommand(&header.SMB2Header{Command: invalidCommand, MessageID: 3}, nil, false)
+	frame := append(first, second...)
+
+	state := compoundLoopState{lastSessionID: 0, lastTreeID: 0}
+	state.processRemaining(context.Background(), frame, ci, false, nil)
+
+	if len(state.responses) != 1 {
+		t.Fatalf("expected 1 response (CANCEL skipped, invalid command answered), got %d", len(state.responses))
+	}
+	if got := state.responses[0].respHeader.Status; got != types.StatusInvalidParameter {
+		t.Fatalf("trailing command status = 0x%x, want STATUS_INVALID_PARAMETER (0x%x)", got, types.StatusInvalidParameter)
+	}
+}
+
+// TestProcessCompoundRequest_CancelFirstNoPanic verifies that a CANCEL as the
+// FIRST command of a compound does not panic. The first-command path in
+// ProcessCompoundRequest previously passed the nil CANCEL result straight to
+// buildResponseHeaderAndBody (result.Status nil deref → connection-goroutine
+// crash). After the fix the nil first command is skipped and the remaining
+// chain is processed.
+func TestProcessCompoundRequest_CancelFirstNoPanic(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+
+	const invalidCommand = types.Command(0xFFFF)
+	firstHeader := &header.SMB2Header{Command: types.SMB2Cancel, MessageID: 2}
+	// Trailing member: invalid command → non-nil error response, proving the
+	// chain continued past the nil first command.
+	remaining := encodeCompoundCommand(&header.SMB2Header{Command: invalidCommand, MessageID: 3}, nil, false)
+
+	// This must not panic.
+	ProcessCompoundRequest(context.Background(), firstHeader, cancelBody, firstHeader.Encode(), remaining, ci, false, nil)
+}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2031,12 +2031,20 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 		return access&(fileReadData|fileExecute|genericRead|genericAll|maxAllowed) != 0
 	}
 	// Helper: does access mask imply write?
+	// MAXIMUM_ALLOWED resolves to the maximal granted rights, which include
+	// write+delete on a writable handle. Samba's share_conflict evaluates the
+	// resolved effective mask; DittoFS keeps the raw 0x02000000 bit in
+	// OpenFile.DesiredAccess (ExpandGenericMask strips GENERIC_* but not
+	// MAXIMUM_ALLOWED), so it must be treated as write/delete here too —
+	// otherwise a MAXIMUM_ALLOWED opener is wrongly treated as read-only and
+	// bypasses SHARE_WRITE / SHARE_DELETE enforcement (matches hasRead above and
+	// the module-level hasWriteAccess/hasDeleteAccess).
 	hasWrite := func(access uint32) bool {
-		return access&(fileWriteData|fileAppendData|genericWrite|genericAll) != 0
+		return access&(fileWriteData|fileAppendData|genericWrite|genericAll|maxAllowed) != 0
 	}
 	// Helper: does access mask imply delete?
 	hasDelete := func(access uint32) bool {
-		return access&(deleteAccess|genericAll) != 0
+		return access&(deleteAccess|genericAll|maxAllowed) != 0
 	}
 
 	newBase := adsBasePath(filePath)

--- a/internal/adapter/smb/handlers/handler_test.go
+++ b/internal/adapter/smb/handlers/handler_test.go
@@ -875,6 +875,88 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	})
 }
 
+// TestCheckShareModeConflict_MaximumAllowed verifies that a handle opened with
+// MAXIMUM_ALLOWED (0x02000000) is treated as carrying write+delete rights for
+// share-mode enforcement. MAXIMUM_ALLOWED resolves to the maximal granted
+// rights (write+delete on a writable handle), and the raw bit survives in
+// OpenFile.DesiredAccess (ExpandGenericMask strips GENERIC_* but not
+// MAXIMUM_ALLOWED). Before the fix hasWrite/hasDelete omitted the bit, so a
+// MAXIMUM_ALLOWED opener was treated as read-only and bypassed SHARE_WRITE /
+// SHARE_DELETE enforcement in both directions.
+func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
+	const (
+		fileReadData    = uint32(0x00000001)
+		fileWriteData   = uint32(0x00000002)
+		fileShareRead   = uint32(0x01)
+		fileShareWrite  = uint32(0x02)
+		fileShareDelete = uint32(0x04)
+		maximumAllowed  = uint32(0x02000000)
+	)
+
+	t.Run("ExistingMaxAllowed_NewNoWriteShare_WriteConflict", func(t *testing.T) {
+		h := NewHandler()
+		// Existing MAXIMUM_ALLOWED handle that does NOT share write.
+		h.StoreOpenFile(&OpenFile{
+			FileID:         h.GenerateFileID(),
+			Path:           "file.txt",
+			DesiredAccess:  maximumAllowed,
+			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
+			MetadataHandle: []byte{0x01},
+		})
+		// New writer with full sharing must conflict: the existing
+		// MAXIMUM_ALLOWED handle holds write and does not share it.
+		if !h.checkShareModeConflict([]byte{0x01}, fileWriteData, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+			t.Error("Expected conflict: existing MAXIMUM_ALLOWED holds write but does not share it")
+		}
+	})
+
+	t.Run("ExistingMaxAllowed_NewNoDeleteShare_DeleteConflict", func(t *testing.T) {
+		h := NewHandler()
+		const deleteAccess = uint32(0x00010000)
+		h.StoreOpenFile(&OpenFile{
+			FileID:         h.GenerateFileID(),
+			Path:           "file.txt",
+			DesiredAccess:  maximumAllowed,
+			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
+			MetadataHandle: []byte{0x01},
+		})
+		if !h.checkShareModeConflict([]byte{0x01}, deleteAccess, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+			t.Error("Expected conflict: existing MAXIMUM_ALLOWED holds delete but does not share it")
+		}
+	})
+
+	t.Run("NewMaxAllowed_ExistingNoWriteShare_WriteConflict", func(t *testing.T) {
+		h := NewHandler()
+		// Existing read handle that does NOT share write.
+		h.StoreOpenFile(&OpenFile{
+			FileID:         h.GenerateFileID(),
+			Path:           "file.txt",
+			DesiredAccess:  fileReadData,
+			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
+			MetadataHandle: []byte{0x01},
+		})
+		// New MAXIMUM_ALLOWED opener implies write; the existing handle does
+		// not share write, so this must conflict.
+		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+			t.Error("Expected conflict: new MAXIMUM_ALLOWED implies write, existing handle does not share write")
+		}
+	})
+
+	t.Run("NewMaxAllowed_ExistingNoDeleteShare_DeleteConflict", func(t *testing.T) {
+		h := NewHandler()
+		h.StoreOpenFile(&OpenFile{
+			FileID:         h.GenerateFileID(),
+			Path:           "file.txt",
+			DesiredAccess:  fileReadData,
+			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
+			MetadataHandle: []byte{0x01},
+		})
+		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+			t.Error("Expected conflict: new MAXIMUM_ALLOWED implies delete, existing handle does not share delete")
+		}
+	})
+}
+
 // =============================================================================
 // PendingAuth Struct Tests
 // =============================================================================

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -418,12 +418,30 @@ func (h *Handler) executeCopyChunks(
 	var totalBytesWritten uint64
 	var lastWritePayloadID metadata.PayloadID
 
+	// flushCommitted forces the deferred write metadata for the chunks committed
+	// so far to the store (SMB requires immediate cross-session visibility). It
+	// is invoked once on the success path and on each partial-error return,
+	// rather than per chunk inside the loop: flushing every 1 MiB chunk meant up
+	// to 256 redundant store round-trips even though the next PrepareWrite
+	// immediately reopened a pending transaction. Only the last flush before
+	// returning is observable; a partial copy must still flush what it committed.
+	flushCommitted := func() {
+		if chunksWritten == 0 {
+			return
+		}
+		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle); flushErr != nil {
+			logger.Debug("COPYCHUNK: deferred metadata flush failed (non-fatal)",
+				"dstPath", dstOpen.Path, "error", flushErr)
+		}
+	}
+
 	for i, chunk := range chunks {
 		// Validate source range: SourceOffset + Length must not exceed source file size
 		if chunk.SourceOffset+uint64(chunk.Length) > srcSize {
 			logger.Debug("COPYCHUNK: source range exceeds file size",
 				"chunk", i, "srcOff", chunk.SourceOffset,
 				"len", chunk.Length, "srcSize", srcSize)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				statusInvalidViewSize, chunksWritten, totalBytesWritten), nil
 		}
@@ -434,6 +452,7 @@ func (h *Handler) executeCopyChunks(
 			srcOpen.SessionID, chunk.SourceOffset, uint64(chunk.Length), false,
 		); lockErr != nil {
 			logger.Debug("COPYCHUNK: source locked", "chunk", i, "error", lockErr)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				types.StatusFileLockConflict, chunksWritten, totalBytesWritten), nil
 		}
@@ -444,6 +463,7 @@ func (h *Handler) executeCopyChunks(
 			dstOpen.SessionID, chunk.TargetOffset, uint64(chunk.Length), true,
 		); lockErr != nil {
 			logger.Debug("COPYCHUNK: destination locked", "chunk", i, "error", lockErr)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				types.StatusFileLockConflict, chunksWritten, totalBytesWritten), nil
 		}
@@ -461,6 +481,7 @@ func (h *Handler) executeCopyChunks(
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
 			// CAS-corruption / remote-unavailable mappings, defaulting to
 			// the I/O-class status for opaque failures.
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				common.MapContentToSMB(err), chunksWritten, totalBytesWritten), nil
 		}
@@ -469,6 +490,7 @@ func (h *Handler) executeCopyChunks(
 		if uint32(n) < chunk.Length {
 			logger.Debug("COPYCHUNK: short read from source (possible concurrent truncation)",
 				"chunk", i, "expected", chunk.Length, "got", n)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				statusInvalidViewSize, chunksWritten, totalBytesWritten), nil
 		}
@@ -482,6 +504,7 @@ func (h *Handler) executeCopyChunks(
 		if err != nil {
 			logger.Warn("COPYCHUNK: prepare write failed",
 				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				common.MapToSMB(err), chunksWritten, totalBytesWritten), nil
 		}
@@ -498,6 +521,7 @@ func (h *Handler) executeCopyChunks(
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
 			// CAS-corruption / remote-unavailable mappings, defaulting to
 			// the I/O-class status for opaque failures.
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				common.MapContentToSMB(err), chunksWritten, totalBytesWritten), nil
 		}
@@ -506,20 +530,17 @@ func (h *Handler) executeCopyChunks(
 		if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
 			logger.Warn("COPYCHUNK: commit write failed",
 				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				types.StatusInternalError, chunksWritten, totalBytesWritten), nil
-		}
-
-		// Flush deferred metadata (SMB requires immediate visibility)
-		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle); flushErr != nil {
-			logger.Debug("COPYCHUNK: deferred metadata flush failed (non-fatal)",
-				"dstPath", dstOpen.Path, "error", flushErr)
 		}
 
 		lastWritePayloadID = writeOp.PayloadID
 		chunksWritten++
 		totalBytesWritten += uint64(chunk.Length)
 	}
+
+	flushCommitted()
 
 	// Update cached PayloadID on destination (matches write.go pattern).
 	// This ensures close.go flushes block store data correctly.

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -754,6 +754,13 @@ func isSupportedDirInfoClass(c types.FileInfoClass) bool {
 // FILE_ALL_INFORMATION for the same file — smb2.dir.one asserts
 // id_both_directory_info/ea_size == all_info2/ea_size (dir.c:673).
 func writeDirEntryEaSize(entry []byte, attr *metadata.FileAttr) {
+	// attr is nil for "." / ".." when GetFile fails and per the documented-
+	// optional DirEntry.Attr contract. A nil attr carries no EAs, so EaSize is
+	// 0 — leave the field zero rather than dereferencing attr.EAs and panicking
+	// (mirrors the nil guard in resolveDirEntryFields).
+	if attr == nil {
+		return
+	}
 	eaSize := fullEaInformationSize(attr.EAs)
 	if eaSize == 0 {
 		return

--- a/internal/adapter/smb/handlers/query_directory_test.go
+++ b/internal/adapter/smb/handlers/query_directory_test.go
@@ -669,3 +669,27 @@ func TestDirEntryEaSize_MatchesFullEaInformationSize(t *testing.T) {
 		t.Errorf("no-EA entry: EaSize = %d, want 0", got)
 	}
 }
+
+// TestDirEntryEaSize_NilAttrNoPanic verifies that the EaSize-carrying directory
+// encoders do not panic when attr is nil. attr is nil for "." / ".." when
+// GetFile fails and per the documented-optional DirEntry.Attr contract; before
+// the fix writeDirEntryEaSize dereferenced attr.EAs and panicked on any
+// EaSize-carrying FileInfoClass when the metadata store errored. A nil attr
+// carries no EAs, so EaSize must be 0.
+func TestDirEntryEaSize_NilAttrNoPanic(t *testing.T) {
+	readEaSize := func(entry []byte) uint32 {
+		return uint32(entry[64]) | uint32(entry[65])<<8 | uint32(entry[66])<<16 | uint32(entry[67])<<24
+	}
+
+	cases := map[string][]byte{
+		"both":   encodeBothDirEntry(".", nil, 1),
+		"idboth": encodeIdBothDirEntry(".", nil, 1, 0x1234),
+		"full":   encodeFullDirEntry(".", nil, 1),
+		"idfull": encodeIdFullDirEntry(".", nil, 1, 0x1234),
+	}
+	for name, entry := range cases {
+		if got := readEaSize(entry); got != 0 {
+			t.Errorf("%s: nil-attr EaSize = %d, want 0", name, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1129.

Fixes the verified SMB handler/framing findings from the develop re-audit (`3488526a`).

## HIGH — CANCEL compound nil-deref (DoS)
`ProcessRequestWithFileIDAndCallback` returns a nil result for CANCEL (MS-SMB2 §3.3.5.16 — no response). The compound path passed that nil to `buildResponseHeaderAndBody`, which dereferences `result.Status` → nil-pointer panic crashing the connection goroutine. A client can craft a compound with CANCEL as the first or any subsequent command to trigger it. Compounding CANCEL is prohibited by spec, but the server must reject gracefully. Both sites (first-command path in `ProcessCompoundRequest` and `processRemaining`) now skip nil results and continue the chain, mirroring the standalone path. An all-CANCEL compound correctly emits no response frame.

## HIGH — MAXIMUM_ALLOWED bypasses write/delete share-mode
`checkShareModeConflict`'s local `hasWrite`/`hasDelete` helpers omitted MAXIMUM_ALLOWED (0x02000000), while `hasRead` included it. MAXIMUM_ALLOWED resolves to full write+delete rights and the raw bit survives `ExpandGenericMask` in `OpenFile.DesiredAccess`, so a MAXIMUM_ALLOWED opener was treated as read-only and bypassed SHARE_WRITE/SHARE_DELETE enforcement in both directions. Added the bit to `hasWrite`/`hasDelete`, matching the module-level `hasWriteAccess`/`hasDeleteAccess`.

## HIGH — EaSize nil-deref in writeDirEntryEaSize
`writeDirEntryEaSize` dereferenced `attr.EAs` with no nil guard. `attr` is nil for `.`/`..` when `GetFile` fails and per the documented-optional `DirEntry.Attr` contract, so any EaSize-carrying FileInfoClass panicked on a metadata-store error path. Added a nil guard (a nil attr carries no EAs → EaSize 0), mirroring `resolveDirEntryFields`.

## LOW — COPYCHUNK per-chunk metadata flush
`FlushPendingWriteForFile` ran inside the chunk loop — up to 256 redundant store round-trips per 16 MiB request, each immediately superseded by the next `PrepareWrite`. Hoisted to a single flush per request; partial-error returns still flush committed progress so cross-session visibility of partial copies is preserved.

## Tests
- `TestProcessRemaining_CancelSubcommandNoPanic`, `TestProcessRemaining_CancelThenRealCommandContinues`, `TestProcessCompoundRequest_CancelFirstNoPanic` — panic-before / pass-after; verified the pre-fix panic at `compound.go:979`/`response.go:656`.
- `TestCheckShareModeConflict_MaximumAllowed` (4 subtests, both directions × write/delete) — fail-before / pass-after.
- `TestDirEntryEaSize_NilAttrNoPanic` (all four EaSize encoders) — panic-before / pass-after.

`go build ./...`, `go test ./internal/adapter/smb/...`, and `go test -race` on the touched packages all pass. Existing COPYCHUNK (multi-chunk/sparse) tests still green.