### PR TITLE
fix(nfs/v4.1): CREATE_SESSION replay, cbProgram race, DESTROY_CLIENTID ownership (#1128)

### DIFF
--- a/internal/adapter/nfs/v4/state/backchannel.go
+++ b/internal/adapter/nfs/v4/state/backchannel.go
@@ -135,7 +135,12 @@ func (p *PendingCBReplies) Cancel(xid uint32) {
 type BackchannelSender struct {
 	sessionID types.SessionId4
 	clientID  uint64
-	cbProgram uint32
+
+	// cbProgram is the callback RPC program number. It is read by the Run
+	// goroutine (sendCallback) and updated by BackchannelCtl via
+	// StateManager.UpdateBackchannelParams, so it is accessed atomically to
+	// avoid a data race between the two goroutines.
+	cbProgram atomic.Uint32
 
 	queue chan CallbackRequest
 	sm    *StateManager
@@ -163,16 +168,17 @@ func NewBackchannelSender(
 	slotTable *SlotTable,
 	sm *StateManager,
 ) *BackchannelSender {
-	return &BackchannelSender{
+	bs := &BackchannelSender{
 		sessionID:       sessionID,
 		clientID:        clientID,
-		cbProgram:       cbProgram,
 		queue:           make(chan CallbackRequest, backchannelQueueSize),
 		sm:              sm,
 		slotTable:       slotTable,
 		stopCh:          make(chan struct{}),
 		callbackTimeout: defaultBackchannelTimeout,
 	}
+	bs.cbProgram.Store(cbProgram)
+	return bs
 }
 
 // Run is the main loop for the BackchannelSender goroutine.
@@ -288,7 +294,7 @@ func (bs *BackchannelSender) sendCallback(ctx context.Context, req CallbackReque
 
 	// 4. Build RPC CALL message
 	xid := bs.nextXID.Add(1)
-	callMsg := BuildCBRPCCallMessage(xid, bs.cbProgram, types.NFS4_CALLBACK_VERSION, types.CB_PROC_COMPOUND, compoundArgs)
+	callMsg := BuildCBRPCCallMessage(xid, bs.cbProgram.Load(), types.NFS4_CALLBACK_VERSION, types.CB_PROC_COMPOUND, compoundArgs)
 
 	// 5. Add record marking
 	framedMsg := AddCBRecordMark(callMsg, true)

--- a/internal/adapter/nfs/v4/state/backchannel_test.go
+++ b/internal/adapter/nfs/v4/state/backchannel_test.go
@@ -315,6 +315,51 @@ func TestBackchannelSender_Stop(t *testing.T) {
 	}
 }
 
+// TestBackchannelSender_CbProgramRace exercises the two real call sites that
+// touch BackchannelSender.cbProgram concurrently: UpdateBackchannelParams
+// (BACKCHANNEL_CTL) writes it, while sendCallback (the Run-goroutine read path)
+// reads it on every callback. Before the fix cbProgram was a plain uint32 read
+// without sm.mu, so `go test -race` flagged a data race here. With cbProgram as
+// an atomic.Uint32 this test must pass cleanly under -race.
+func TestBackchannelSender_CbProgramRace(t *testing.T) {
+	sender, sm, sessionID := createTestBackchannelSender(t)
+
+	// Attach the sender to the session so UpdateBackchannelParams targets it.
+	sm.mu.Lock()
+	sm.sessionsByID[sessionID].backchannelSender = sender
+	sm.mu.Unlock()
+
+	const iterations = 500
+	done := make(chan struct{}, 2)
+
+	// Writer: BACKCHANNEL_CTL updating the callback program number.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for i := 0; i < iterations; i++ {
+			if err := sm.UpdateBackchannelParams(sessionID, 0x40000000+uint32(i), nil); err != nil {
+				t.Errorf("UpdateBackchannelParams: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Reader: sendCallback reads cbProgram before failing (no bound connection),
+	// which is the exact unsynchronised read the race covered.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		recallOp := EncodeCBRecallOp(&types.Stateid4{Seqid: 1}, false, []byte{0x01})
+		for i := 0; i < iterations; i++ {
+			_ = sender.sendCallback(context.Background(), CallbackRequest{
+				OpCode:  types.OP_CB_RECALL,
+				Payload: recallOp,
+			})
+		}
+	}()
+
+	<-done
+	<-done
+}
+
 // TestBackchannelSender_SequenceIDIncrement verifies seqID increments between callbacks.
 func TestBackchannelSender_SequenceIDIncrement(t *testing.T) {
 	sender, sm, sessionID := createTestBackchannelSender(t)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2490,7 +2490,12 @@ func (sm *StateManager) GetStatusFlags(session *Session) uint32 {
 //   - sequenceID == record.SequenceID + 1: new request -- create session
 //   - otherwise: misordered -- return error
 //
-// On success, returns the CreateSessionResult and nil cached bytes.
+// On success, returns the CreateSessionResult and nil cached bytes. The encoded
+// XDR response is also cached on the client record under sm.mu in the same
+// critical section as the sequence-ID bump, so a concurrent retransmit that
+// matches record.SequenceID always observes a populated cache (RFC 8881
+// Section 18.36 replay requirement) — there is no window where the seqid has
+// advanced but the cache is still nil.
 // On replay, returns nil result and the cached XDR response bytes.
 // On error, returns an appropriate NFS4StateError.
 //
@@ -2573,22 +2578,53 @@ func (sm *StateManager) CreateSession(
 	// Increment sequence ID
 	record.SequenceID++
 
-	logger.Info("CREATE_SESSION: session created",
-		"client_id", fmt.Sprintf("0x%x", clientID),
-		"session_id", session.SessionID.String(),
-		"fore_slots", negotiatedFore.MaxRequests)
-
-	return &CreateSessionResult{
+	result := &CreateSessionResult{
 		SessionID:        session.SessionID,
 		SequenceID:       record.SequenceID,
 		Flags:            responseFlags,
 		ForeChannelAttrs: negotiatedFore,
 		BackChannelAttrs: negotiatedBack,
-	}, nil, nil
+	}
+
+	// Encode and cache the XDR response under the same sm.mu critical section
+	// as the seqid bump. This guarantees a retransmit matching record.SequenceID
+	// always finds CachedCreateSessionRes populated (RFC 8881 Section 18.36),
+	// closing the replay window that would otherwise return NFS4ERR_SEQ_MISORDERED.
+	res := &types.CreateSessionRes{
+		Status:           types.NFS4_OK,
+		SessionID:        result.SessionID,
+		SequenceID:       result.SequenceID,
+		Flags:            result.Flags,
+		ForeChannelAttrs: result.ForeChannelAttrs,
+		BackChannelAttrs: result.BackChannelAttrs,
+	}
+	var buf bytes.Buffer
+	if err := res.Encode(&buf); err != nil {
+		return nil, nil, &NFS4StateError{
+			Status:  types.NFS4ERR_SERVERFAULT,
+			Message: fmt.Sprintf("failed to encode CREATE_SESSION response: %v", err),
+		}
+	}
+	cached := make([]byte, buf.Len())
+	copy(cached, buf.Bytes())
+	record.CachedCreateSessionRes = cached
+	result.EncodedRes = cached
+
+	logger.Info("CREATE_SESSION: session created",
+		"client_id", fmt.Sprintf("0x%x", clientID),
+		"session_id", session.SessionID.String(),
+		"fore_slots", negotiatedFore.MaxRequests)
+
+	return result, nil, nil
 }
 
-// CacheCreateSessionResponse stores the full XDR-encoded CREATE_SESSION
-// response bytes on the client record for replay detection.
+// CacheCreateSessionResponse stores the full XDR-encoded CREATE_SESSION response
+// bytes on the client record for replay detection.
+//
+// The normal CREATE_SESSION path no longer needs this: CreateSession already
+// encodes and caches the response atomically with the sequence-ID bump (see
+// above), which is what closes the replay window. This method remains as an
+// explicit override for the rare caller that wants to replace the cached bytes.
 // Thread-safe: acquires sm.mu.Lock.
 func (sm *StateManager) CacheCreateSessionResponse(clientID uint64, responseBytes []byte) {
 	sm.mu.Lock()
@@ -2599,7 +2635,6 @@ func (sm *StateManager) CacheCreateSessionResponse(clientID uint64, responseByte
 		return
 	}
 
-	// Copy the bytes to avoid holding references to caller's buffer
 	cached := make([]byte, len(responseBytes))
 	copy(cached, responseBytes)
 	record.CachedCreateSessionRes = cached
@@ -3193,9 +3228,10 @@ func (sm *StateManager) UpdateBackchannelParams(sessionID types.SessionId4, cbPr
 	session.CbProgram = cbProgram
 	session.BackchannelSecParms = secParms
 
-	// Update the sender's program number if it exists
+	// Update the sender's program number if it exists. The sender's Run
+	// goroutine reads cbProgram without sm.mu, so the field is atomic.
 	if session.backchannelSender != nil {
-		session.backchannelSender.cbProgram = cbProgram
+		session.backchannelSender.cbProgram.Store(cbProgram)
 	}
 
 	logger.Info("Backchannel params updated",

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -395,29 +396,57 @@ func TestCreateSession_Replay(t *testing.T) {
 	}
 }
 
-func TestCreateSession_ReplayNoCachedResponse(t *testing.T) {
+// TestCreateSession_ReplayAfterImplicitCache verifies that CreateSession
+// populates the replay cache atomically with the seqid bump (RFC 8881
+// Section 18.36): a retransmit that arrives before the handler does any
+// follow-up work must still observe the cached XDR response, never
+// NFS4ERR_SEQ_MISORDERED.
+//
+// Before the fix the cache was populated in a separate lock acquisition by
+// the handler (CacheCreateSessionResponse), leaving a window where the seqid
+// had advanced but the cache was still nil — a replay in that window returned
+// ErrSeqMisordered and broke Linux mount.
+func TestCreateSession_ReplayAfterImplicitCache(t *testing.T) {
 	sm := NewStateManager(DefaultLeaseDuration)
 	clientID, seqID := registerV41Client(t, sm)
 
-	// First request - but don't cache the response
-	_, _, err := sm.CreateSession(
+	// First request. The handler does NOT call CacheCreateSessionResponse;
+	// CreateSession itself must have populated the cache under sm.mu.
+	first, cached, err := sm.CreateSession(
 		clientID, seqID, 0,
 		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateSession error: %v", err)
 	}
+	if cached != nil {
+		t.Fatal("Expected nil cached bytes for new session")
+	}
+	if len(first.EncodedRes) == 0 {
+		t.Fatal("CreateSession must return the encoded response bytes")
+	}
 
-	// Replay with same seqid (record's SequenceID is now seqID)
-	_, _, err = sm.CreateSession(
+	// Immediate replay with the same seqid -- no intervening cache call.
+	replayResult, replayCached, err := sm.CreateSession(
 		clientID, seqID, 0,
 		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
 	)
-	if err == nil {
-		t.Fatal("Expected error for replay without cached response")
+	if err != nil {
+		t.Fatalf("replay must succeed with cached response, got error: %v", err)
 	}
-	if !errors.Is(err, ErrSeqMisordered) {
-		t.Errorf("Expected ErrSeqMisordered, got: %v", err)
+	if replayResult != nil {
+		t.Error("Replay should return nil result")
+	}
+	if replayCached == nil {
+		t.Fatal("Replay must return the cached XDR response, not ErrSeqMisordered")
+	}
+	if !bytes.Equal(replayCached, first.EncodedRes) {
+		t.Error("Replayed bytes must equal the original encoded response")
+	}
+
+	// The replay must NOT have created a second session.
+	if sessions := sm.ListSessionsForClient(clientID); len(sessions) != 1 {
+		t.Errorf("Expected 1 session after replay, got %d", len(sessions))
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -645,4 +645,10 @@ type CreateSessionResult struct {
 	Flags            uint32
 	ForeChannelAttrs types.ChannelAttrs
 	BackChannelAttrs types.ChannelAttrs
+
+	// EncodedRes holds the full XDR-encoded success response. It is produced and
+	// cached for replay under sm.mu in the same critical section that bumps the
+	// client sequence ID, so the handler can return it directly without a second
+	// encode/cache round-trip (which would reopen the replay window).
+	EncodedRes []byte
 }

--- a/internal/adapter/nfs/v4/v41/handlers/create_session.go
+++ b/internal/adapter/nfs/v4/v41/handlers/create_session.go
@@ -1,7 +1,6 @@
 package v41handlers
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
@@ -75,28 +74,10 @@ func HandleCreateSession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reques
 		}
 	}
 
-	// Encode the success response
-	res := &types.CreateSessionRes{
-		Status:           types.NFS4_OK,
-		SessionID:        result.SessionID,
-		SequenceID:       result.SequenceID,
-		Flags:            result.Flags,
-		ForeChannelAttrs: result.ForeChannelAttrs,
-		BackChannelAttrs: result.BackChannelAttrs,
-	}
-
-	var buf bytes.Buffer
-	if err := res.Encode(&buf); err != nil {
-		logger.Error("CREATE_SESSION: encode response error", "error", err)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_CREATE_SESSION,
-			Data:   EncodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
-	}
-
-	// Cache the encoded response bytes for replay detection
-	d.StateManager.CacheCreateSessionResponse(args.ClientID, buf.Bytes())
+	// The state manager already encoded the success response and cached it for
+	// replay detection atomically with the sequence-ID bump (RFC 8881 Section
+	// 18.36). Reuse those bytes directly; re-encoding here would reopen the
+	// replay window the state manager closed.
 
 	// Auto-bind the connection that created the session as fore-channel.
 	// This is best-effort: CREATE_SESSION already succeeded, so we only
@@ -119,6 +100,6 @@ func HandleCreateSession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reques
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
 		OpCode: types.OP_CREATE_SESSION,
-		Data:   buf.Bytes(),
+		Data:   result.EncodedRes,
 	}
 }

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
@@ -24,7 +24,7 @@ import (
 func HandleDestroyClientID(
 	d *Deps,
 	ctx *types.CompoundContext,
-	_ *types.V41RequestContext,
+	v41ctx *types.V41RequestContext,
 	reader io.Reader,
 ) *types.CompoundResult {
 	var args types.DestroyClientidArgs
@@ -34,6 +34,34 @@ func HandleDestroyClientID(
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_DESTROY_CLIENTID,
 			Data:   EncodeStatusOnly(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	// Verify the requester owns the target client ID (RFC 8881 Section 18.50.3).
+	//
+	// DESTROY_CLIENTID is session-exempt: it may be sent standalone (without a
+	// preceding SEQUENCE) so a client can tear down its own session-less client
+	// ID. The principal attack the audit identified is a client operating inside
+	// its OWN session (or over a connection bound to one of its sessions) that
+	// targets a DIFFERENT client's ID to destroy the victim's state. When the
+	// requester's identity resolves to a different client, reject with
+	// NFS4ERR_NOT_SAME, mirroring DESTROY_SESSION (Section 18.37.3).
+	//
+	// If the requester cannot be associated with any client (no SEQUENCE, no
+	// bound connection, no v4.0 client state) we do NOT reject: that is the
+	// legitimate standalone self-destroy of a session-less client the RFC
+	// permits, and the binding layer offers no stronger identity to check
+	// against in that case. The NFS4ERR_CLIENTID_BUSY guard below still prevents
+	// destroying any client that holds active sessions.
+	if requestingClientID, identified := resolveRequestingClientID(d, v41ctx, ctx); identified && requestingClientID != args.ClientID {
+		logger.Debug("DESTROY_CLIENTID: ownership mismatch -- not same client",
+			"target_client_id", fmt.Sprintf("0x%016x", args.ClientID),
+			"requesting_client_id", fmt.Sprintf("0x%016x", requestingClientID),
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_NOT_SAME,
+			OpCode: types.OP_DESTROY_CLIENTID,
+			Data:   EncodeStatusOnly(types.NFS4ERR_NOT_SAME),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_clientid_test.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_clientid_test.go
@@ -1,0 +1,105 @@
+package v41handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// makeV41Client registers a confirmed v4.1 client with one session and returns
+// its client ID and the session ID (used to identify the requester).
+func makeV41Client(t *testing.T, sm *state.StateManager, ownerSuffix string) (uint64, types.SessionId4) {
+	t.Helper()
+
+	var verifier [8]byte
+	copy(verifier[:], "verify01")
+	eid, err := sm.ExchangeID([]byte("destroy-clientid-test-"+ownerSuffix), verifier, 0, nil, "10.0.0.1:12345")
+	if err != nil {
+		t.Fatalf("ExchangeID(%s): %v", ownerSuffix, err)
+	}
+
+	csRes, _, err := sm.CreateSession(
+		eid.ClientID, eid.SequenceID, 0,
+		types.ChannelAttrs{MaxRequestSize: 1 << 20, MaxResponseSize: 1 << 20, MaxRequests: 16},
+		types.ChannelAttrs{MaxRequestSize: 1 << 16, MaxResponseSize: 1 << 16, MaxRequests: 4},
+		0, nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateSession(%s): %v", ownerSuffix, err)
+	}
+	return eid.ClientID, csRes.SessionID
+}
+
+func v41ClientExists(sm *state.StateManager, clientID uint64) bool {
+	for _, rec := range sm.ListV41Clients() {
+		if rec.ClientID == clientID {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeDestroyClientidArgs(t *testing.T, clientID uint64) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	args := types.DestroyClientidArgs{ClientID: clientID}
+	if err := args.Encode(&buf); err != nil {
+		t.Fatalf("encode args: %v", err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}
+
+// TestHandleDestroyClientID_CrossClientRejected is the core security regression
+// test: a request whose identity resolves to client A must NOT be able to
+// destroy client B's client ID. Before the fix DESTROY_CLIENTID performed no
+// ownership check, so any peer operating its own session could tear down a
+// victim's state by targeting the victim's 64-bit client ID. The server must
+// now return NFS4ERR_NOT_SAME and leave the victim intact.
+func TestHandleDestroyClientID_CrossClientRejected(t *testing.T) {
+	sm := state.NewStateManager(90 * time.Second)
+	d := &Deps{StateManager: sm}
+
+	_, attackerSession := makeV41Client(t, sm, "attacker")
+	victimClientID, _ := makeV41Client(t, sm, "victim")
+
+	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: "10.0.0.9:1"}
+	// The attacker identifies via its own SEQUENCE (v41ctx points at its session)
+	// but targets the victim's client ID.
+	v41ctx := &types.V41RequestContext{SessionID: attackerSession}
+
+	res := HandleDestroyClientID(d, ctx, v41ctx, encodeDestroyClientidArgs(t, victimClientID))
+	if res.Status != types.NFS4ERR_NOT_SAME {
+		t.Fatalf("cross-client DESTROY_CLIENTID: status = %d, want NFS4ERR_NOT_SAME (%d)",
+			res.Status, types.NFS4ERR_NOT_SAME)
+	}
+
+	// The victim's client record must still exist -- it was NOT destroyed.
+	if !v41ClientExists(sm, victimClientID) {
+		t.Fatal("victim client was destroyed despite ownership mismatch")
+	}
+}
+
+// TestHandleDestroyClientID_OwnerPassesOwnershipCheck verifies the owner is not
+// wrongly blocked: a request whose SEQUENCE identifies the same client that owns
+// the target client ID clears the ownership gate. Because the owner still holds
+// the identifying session, the operation then correctly returns
+// NFS4ERR_CLIENTID_BUSY (RFC 8881 Section 18.50) rather than an authz error.
+func TestHandleDestroyClientID_OwnerPassesOwnershipCheck(t *testing.T) {
+	sm := state.NewStateManager(90 * time.Second)
+	d := &Deps{StateManager: sm}
+
+	ownerClientID, ownerSession := makeV41Client(t, sm, "owner")
+
+	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: "10.0.0.9:1"}
+	v41ctx := &types.V41RequestContext{SessionID: ownerSession}
+
+	res := HandleDestroyClientID(d, ctx, v41ctx, encodeDestroyClientidArgs(t, ownerClientID))
+	if res.Status != types.NFS4ERR_CLIENTID_BUSY {
+		t.Fatalf("owner DESTROY_CLIENTID with active session: status = %d, want NFS4ERR_CLIENTID_BUSY (%d)",
+			res.Status, types.NFS4ERR_CLIENTID_BUSY)
+	}
+}


### PR DESCRIPTION
Closes #1128. PR #1140 fixed the stateid/client-authz subset; this PR completes the three documented leftovers.

## Fixes

### [HIGH] CREATE_SESSION replay window (RFC 8881 §18.36)
`StateManager.CreateSession` now encodes and caches the XDR reply **inside the same `sm.mu` critical section** that bumps `record.SequenceID`. Previously the handler encoded and cached in a separate lock acquisition, leaving a window where a retransmit matching `record.SequenceID` found `CachedCreateSessionRes == nil` and returned `NFS4ERR_SEQ_MISORDERED` (breaking Linux mount with EREMOTEIO). The handler now returns the encoded bytes directly via `CreateSessionResult.EncodedRes`.

### [MED] cbProgram backchannel data race
`BackchannelSender.cbProgram` is now an `atomic.Uint32`. It is written by `UpdateBackchannelParams` (BACKCHANNEL_CTL) under `sm.mu` and read by the sender's `Run` goroutine in `sendCallback` without that lock — the plain `uint32` access was a data race flagged by `go test -race`. Matches the existing `atomic` idiom already used for `nextXID`/`nextCBSeqID`.

### [MED] DESTROY_CLIENTID ownership (RFC 8881 §18.50.3)
The handler now rejects with `NFS4ERR_NOT_SAME` when `resolveRequestingClientID` resolves the requester to a different client than the target client ID — reusing the same helper `DESTROY_SESSION` uses. An unidentifiable standalone requester is still allowed to self-destroy a session-less client (RFC-permitted, and the binding layer offers no stronger identity in that case); the existing `NFS4ERR_CLIENTID_BUSY` guard still blocks destroying any client with active sessions.

## Tests (failing-before / passing-after)
- `TestCreateSession_ReplayAfterImplicitCache` — replay returns the cached XDR reply with no intervening cache call.
- `TestBackchannelSender_CbProgramRace` — concurrent update + send, clean under `-race`.
- `TestHandleDestroyClientID_CrossClientRejected` / `_OwnerPassesOwnershipCheck` — cross-client rejected, owner passes the gate.

`go build ./... && go test -race ./internal/adapter/nfs/v4/...` all green.