### PR TITLE
fix(block): append-log recovery, S3 SSRF, Argon2 bounds, cache race (#1124)

### DIFF
--- a/pkg/block/encryption/keyprovider/local.go
+++ b/pkg/block/encryption/keyprovider/local.go
@@ -26,6 +26,23 @@ const localPEMType = "DITTOFS ENCRYPTED MASTER KEY"
 
 const localKeyFileVersion = 1
 
+// Argon2 KDF parameter bounds enforced on read. The lower bounds keep
+// argon2.IDKey from panicking on a corrupt/tampered file (it panics when
+// time < 1 or threads < 1) and reject a key file weaker than was ever
+// generated. The upper bounds cap unwrap cost so an attacker who can write
+// the key file cannot turn startup into an OOM-kill or a multi-minute
+// hang: maxArgonMemoryKiB ≈ 4 GiB and maxArgonTime/maxArgonThreads are far
+// above any sane configuration. Defaults written by GenerateKeyFile
+// (t=3, m=64 MiB, p=4) sit comfortably inside this window.
+const (
+	minArgonTime      = 1
+	maxArgonTime      = 64
+	minArgonMemoryKiB = 8 * 1024
+	maxArgonMemoryKiB = 4 * 1024 * 1024
+	minArgonThreads   = 1
+	maxArgonThreads   = 64
+)
+
 // argon2Params holds the KDF parameters persisted alongside the wrapped
 // master key. Defaults follow the OWASP 2024 password-storage cheat
 // sheet for Argon2id (m=64 MiB, t=3, p=4).
@@ -154,7 +171,27 @@ func decodeKeyFile(raw []byte) (*localKeyFile, error) {
 	if kf.MasterKeyID == "" {
 		return nil, fmt.Errorf("%w: empty master_key_id", ErrKeyFileCorrupt)
 	}
+	if err := validateKDFParams(kf.KDF); err != nil {
+		return nil, err
+	}
 	return &kf, nil
+}
+
+// validateKDFParams bounds the Argon2 parameters read from disk before they
+// reach argon2.IDKey. Without these guards a corrupt or attacker-replaced
+// key file with time=0 or threads=0 panics the daemon at startup, and a
+// huge memory_kib triggers an OOM-kill — both an availability/DoS vector.
+func validateKDFParams(p argon2Params) error {
+	if p.Time < minArgonTime || p.Time > maxArgonTime {
+		return fmt.Errorf("%w: kdf time %d out of range [%d,%d]", ErrKeyFileCorrupt, p.Time, minArgonTime, maxArgonTime)
+	}
+	if p.MemoryKiB < minArgonMemoryKiB || p.MemoryKiB > maxArgonMemoryKiB {
+		return fmt.Errorf("%w: kdf memory_kib %d out of range [%d,%d]", ErrKeyFileCorrupt, p.MemoryKiB, minArgonMemoryKiB, maxArgonMemoryKiB)
+	}
+	if p.Threads < minArgonThreads || p.Threads > maxArgonThreads {
+		return fmt.Errorf("%w: kdf threads %d out of range [%d,%d]", ErrKeyFileCorrupt, p.Threads, minArgonThreads, maxArgonThreads)
+	}
+	return nil
 }
 
 func unwrapMasterKey(kf *localKeyFile, passphrase string) ([]byte, error) {

--- a/pkg/block/encryption/keyprovider/local_corrupt_test.go
+++ b/pkg/block/encryption/keyprovider/local_corrupt_test.go
@@ -57,6 +57,14 @@ func TestLocal_DecodeKeyFile_CorruptFields(t *testing.T) {
 		{"unsupported_kdf", func(kf *localKeyFile) { kf.KDF.Algo = "scrypt" }},
 		{"unsupported_wrap", func(kf *localKeyFile) { kf.Wrap = "chacha20" }},
 		{"empty_master_key_id", func(kf *localKeyFile) { kf.MasterKeyID = "" }},
+		// KDF lower-bound guards: without these argon2.IDKey panics and
+		// crashes the daemon at startup (time=0 / threads=0), or OOM-kills it
+		// (huge memory_kib). They must surface as ErrKeyFileCorrupt instead.
+		{"kdf_time_zero", func(kf *localKeyFile) { kf.KDF.Time = 0 }},
+		{"kdf_threads_zero", func(kf *localKeyFile) { kf.KDF.Threads = 0 }},
+		{"kdf_memory_zero", func(kf *localKeyFile) { kf.KDF.MemoryKiB = 0 }},
+		{"kdf_memory_huge", func(kf *localKeyFile) { kf.KDF.MemoryKiB = ^uint32(0) }},
+		{"kdf_time_huge", func(kf *localKeyFile) { kf.KDF.Time = ^uint32(0) }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/block/engine/dedup.go
+++ b/pkg/block/engine/dedup.go
@@ -104,7 +104,7 @@ func (m *Syncer) tryEagerSmallFileDedup(
 	// observed; bs.cache is never nil thanks to the Null Object pattern
 	// installed by engine.New.
 	if m.bs != nil {
-		m.bs.cache.Put(h, data)
+		m.bs.loadCache().Put(h, data)
 	}
 
 	logger.Debug("eager small-file dedup short-circuit hit",
@@ -376,7 +376,7 @@ func (m *Syncer) applyFileLevelDedupHit(
 				removed = append(removed, br.Hash)
 			}
 		}
-		m.bs.cache.InvalidateFile(payloadID, removed)
+		m.bs.loadCache().InvalidateFile(payloadID, removed)
 	}
 
 	// 5. Per-file append-log truncation. Best-effort: a failure

--- a/pkg/block/engine/destroycache_race_test.go
+++ b/pkg/block/engine/destroycache_race_test.go
@@ -1,0 +1,50 @@
+package engine
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestDestroyCache_ConcurrentReads_NoRace exercises the cache-field swap in
+// DestroyCache against concurrent readers (the OnChunkComplete rollup
+// goroutine reads bs.cache with no closeMu, and data ops read it under
+// closeMu.RLock, which does NOT serialize against the swap). Run under
+// `go test -race`, an unsynchronized field write would be flagged here.
+//
+// The fix routes every cache access through cacheMu (loadCache/storeCache),
+// so this test must be race-clean.
+func TestDestroyCache_ConcurrentReads_NoRace(t *testing.T) {
+	bs := newTestEngine(t, 1<<20, 1) // non-zero budget → real cache installed
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Readers: mimic the OnChunkComplete closure (loadCache().Put) and the
+	// data-op readers (loadCache().Stats / OnRead) hammering the field.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var h block.ContentHash
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					c := bs.loadCache()
+					c.Put(h, []byte{0x1})
+					_ = c.Stats()
+				}
+			}
+		}()
+	}
+
+	// Writer: repeatedly destroy the cache (swaps in nullCache{}).
+	for i := 0; i < 50; i++ {
+		bs.DestroyCache()
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -96,7 +96,16 @@ type Store struct {
 	// Cache type. Never nil — the constructor substitutes nullCache{}
 	// for a disabled budget so engine code does not need defensive
 	// nil-checks (Null Object pattern).
-	cache cacheInterface
+	//
+	// The field is mutated after construction — Start swaps in the real
+	// Cache and DestroyCache swaps in nullCache{} — while concurrent data
+	// ops and the OnChunkComplete rollup goroutine read it. Those mutations
+	// race the closeMu.RLock'd readers (RLock does not serialize against
+	// other RLock holders), so every access goes through cacheMu, not the
+	// raw field. cacheMu is a leaf lock taken only for the field swap, never
+	// held across cache operations.
+	cache   cacheInterface
+	cacheMu sync.RWMutex
 
 	readBufferBytes int64 // budget for the cache (0 = disabled / Null Object)
 	prefetchWorkers int   // stored from config, used in Start()
@@ -323,7 +332,7 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 		// above — install once at construction; FSStore guarantees no
 		// chunk activity fires before Start completes.
 		hooks.SetOnChunkComplete(func(hash block.ContentHash, data []byte, _ string) {
-			bs.cache.Put(hash, data)
+			bs.loadCache().Put(hash, data)
 			// Register the freshly-stored chunk for upload without a
 			// directory walk (B1). The syncer drains this set on each
 			// mirror pass; harmless when no remote is configured.
@@ -434,7 +443,7 @@ func (bs *Store) Start(ctx context.Context) error {
 	if bs.readBufferBytes > 0 {
 		realCache := NewCache(bs.readBufferBytes, bs.prefetchWorkers, bs.loadByHash)
 		if realCache != nil {
-			bs.cache = realCache
+			bs.storeCache(realCache)
 		}
 	}
 
@@ -508,8 +517,10 @@ func (bs *Store) Close() error {
 	}
 	bs.closed = true
 
-	// Cache is never nil thanks to the Null Object pattern.
-	_ = bs.cache.Close()
+	// Cache is never nil thanks to the Null Object pattern. Swap in the
+	// Null Object under cacheMu so any concurrent OnChunkComplete read sees
+	// a live cache, then close the real one we just detached.
+	_ = bs.storeCache(nullCache{}).Close()
 
 	var errs []error
 	if err := bs.syncer.Close(); err != nil {
@@ -562,6 +573,26 @@ func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
 	return bs.local.DeleteAppendLog(ctx, payloadID)
 }
 
+// loadCache returns the current cache under cacheMu. Always non-nil (Null
+// Object pattern). Callers invoke the returned interface's methods OUTSIDE
+// the lock — cacheMu only guards the field read.
+func (bs *Store) loadCache() cacheInterface {
+	bs.cacheMu.RLock()
+	c := bs.cache
+	bs.cacheMu.RUnlock()
+	return c
+}
+
+// storeCache swaps the cache field under cacheMu and returns the previous
+// value so the caller can close it after releasing the lock.
+func (bs *Store) storeCache(c cacheInterface) cacheInterface {
+	bs.cacheMu.Lock()
+	prev := bs.cache
+	bs.cache = c
+	bs.cacheMu.Unlock()
+	return prev
+}
+
 // DestroyCache closes the in-memory read cache and replaces it with a
 // no-op implementation. Intended for shutdown / share-removal teardown
 // and for the REST evict path that drops the read buffer wholesale.
@@ -577,10 +608,10 @@ func (bs *Store) DestroyCache() int {
 		return 0
 	}
 
-	entries := bs.cache.Stats().Entries
-	_ = bs.cache.Close()
-	// Replace closed cache with the Null Object so subsequent operations
-	// remain a no-op without ever returning an error path.
-	bs.cache = nullCache{}
+	// Swap in the Null Object first so concurrent readers never observe a
+	// closed cache, then close the previous one after the field is updated.
+	prev := bs.storeCache(nullCache{})
+	entries := prev.Stats().Entries
+	_ = prev.Close()
 	return entries
 }

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -31,7 +31,7 @@ func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []block.Bl
 	// is a no-op so the unconditional call is safe (Null Object).
 	if len(blocks) > 0 {
 		hashes := blockRefHashes(blocks)
-		bs.cache.OnRead(payloadID, hashes, computeFileSize(blocks))
+		bs.loadCache().OnRead(payloadID, hashes, computeFileSize(blocks))
 	}
 	return n, nil
 }
@@ -100,7 +100,7 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 	// OnRead's empty-hashes signal — keeps prefetch from chasing
 	// pre-write hashes after the underlying data shifted. nullCache is
 	// a no-op (Null Object).
-	bs.cache.OnRead(payloadID, nil, 0)
+	bs.loadCache().OnRead(payloadID, nil, 0)
 	// the FastCDC chunker output is
 	// produced by the local-store rollup pump
 	// (pkg/block/local/fs/rollup.go:rollupFile) and lands as
@@ -195,7 +195,7 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 	// any in-flight prefetch state); cache entry invalidation is the
 	// caller's responsibility via common.WriteToBlockStore (post-txn).
 	// nullCache is a no-op.
-	bs.cache.OnRead(payloadID, nil, 0)
+	bs.loadCache().OnRead(payloadID, nil, 0)
 
 	// Remote sweep is best-effort: GC will reconcile stragglers, so a
 	// failure here does NOT roll back the coordinator decrements (matches
@@ -244,11 +244,11 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 	// is the strongest signal). nullCache is a no-op; for the real
 	// Cache this also clears the per-payload sequential tracker.
 	if len(blocks) > 0 {
-		bs.cache.InvalidateFile(payloadID, blockRefHashes(blocks))
+		bs.loadCache().InvalidateFile(payloadID, blockRefHashes(blocks))
 	} else {
 		// Legacy/dual-read empty-blocks path: at least reset the
 		// per-payload tracker so prefetch doesn't chase stale hashes.
-		bs.cache.OnRead(payloadID, nil, 0)
+		bs.loadCache().OnRead(payloadID, nil, 0)
 	}
 
 	// Decrement RefCount for every BlockRef hash before remote cleanup

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -79,7 +79,7 @@ func (bs *Store) GetStats() BlockStoreStats {
 	localStats := bs.local.Stats()
 	files := bs.local.ListFiles()
 
-	cacheStats := bs.cache.Stats()
+	cacheStats := bs.loadCache().Stats()
 
 	pending, completed, failed := bs.syncer.Queue().Stats()
 	_, uploads, _ := bs.syncer.Queue().PendingByType()

--- a/pkg/block/local/fs/appendwrite.go
+++ b/pkg/block/local/fs/appendwrite.go
@@ -421,6 +421,21 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 	// fsync(O_SYNC) — revisit the fsyncFn closure at construction
 	// (logFile creation in getOrCreateLog / recovery.go).
 	if err := lf.groupCommit.Sync(ctx); err != nil {
+		// writeRecord already advanced the OS fd position by n bytes, but we
+		// have NOT advanced lf.eofPos yet (that happens below). If we simply
+		// returned here, the next AppendWrite to this payload would write its
+		// record at fd_pos = old_eofPos + n while capturing logPos = eofPos
+		// (the pre-write value), recording a logIndex entry that points at the
+		// orphaned, un-fsync'd frame instead of the new one — permanently
+		// wedging rollup with a wrong file_offset / CRC mismatch. Evict the fd
+		// exactly as the writeRecord-error path does so the next call reopens
+		// fresh from the on-disk eofPos and the orphaned tail is ignored.
+		mu.Unlock()
+		muUnlocked = true
+		tsh.mu.Lock()
+		delete(tsh.logFDs, payloadID)
+		tsh.mu.Unlock()
+		_ = lf.f.Close()
 		return fmt.Errorf("log fsync: %w", err)
 	}
 	// Advance the log-position cursor only after the writeRecord +

--- a/pkg/block/local/fs/appendwrite_sync_error_test.go
+++ b/pkg/block/local/fs/appendwrite_sync_error_test.go
@@ -1,0 +1,93 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+// snapshotLogFile returns the current *logFile and per-file mutex for
+// payloadID, or (nil, nil) if no fd is currently open for it.
+func snapshotLogFile(bc *FSStore, payloadID string) *logFile {
+	sh := bc.shardFor(payloadID)
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	return sh.logFDs[payloadID]
+}
+
+// TestAppendWrite_SyncError_EvictsFdAndKeepsLogIndexConsistent reproduces
+// the desync bug where a groupCommit.Sync failure left lf.eofPos behind the
+// fd position: the next AppendWrite would record a logIndex entry pointing
+// at the orphaned, un-fsync'd frame instead of the new record, permanently
+// wedging rollup.
+//
+// Before the fix, AppendWrite returned on Sync error WITHOUT evicting the
+// fd, so the same *logFile (with a stale eofPos) was reused. After the fix,
+// the fd is evicted exactly like the writeRecord-error path, so the next
+// AppendWrite reopens fresh from the on-disk EOF and records a correct
+// logIndex entry.
+func TestAppendWrite_SyncError_EvictsFdAndKeepsLogIndexConsistent(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	payloadID := "file-syncerr"
+
+	// First write succeeds and opens the fd.
+	first := bytes.Repeat([]byte{0x11}, 256)
+	if err := bc.AppendWrite(ctx, payloadID, first, 0); err != nil {
+		t.Fatalf("first AppendWrite: %v", err)
+	}
+
+	lf := snapshotLogFile(bc, payloadID)
+	if lf == nil {
+		t.Fatal("no logFile after first write")
+	}
+
+	// Force the NEXT fsync to fail. The frame bytes still reach the OS fd
+	// (writeRecord runs before Sync), advancing the fd position, but Sync
+	// returns an error so eofPos is not advanced.
+	wantErr := errors.New("injected fsync failure")
+	lf.groupCommit = newGroupCommit(func() error { return wantErr })
+
+	second := bytes.Repeat([]byte{0x22}, 256)
+	err := bc.AppendWrite(ctx, payloadID, second, 4096)
+	if err == nil {
+		t.Fatal("AppendWrite under fsync failure: want error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("AppendWrite error: got %v, want wrapped %v", err, wantErr)
+	}
+
+	// The fd must have been evicted from the shard so the next call reopens
+	// fresh. Reusing the stale *logFile (old eofPos) is exactly the wedge.
+	if got := snapshotLogFile(bc, payloadID); got == lf {
+		t.Fatal("fd not evicted after Sync error: stale logFile still in logFDs")
+	}
+
+	// A subsequent write must succeed, reopen fresh, and record a logIndex
+	// entry whose logPos equals the reopened on-disk EOF — never the
+	// pre-failure eofPos. We verify by reading the data back: the new
+	// record's bytes must be returned for its offset.
+	third := bytes.Repeat([]byte{0x33}, 256)
+	if err := bc.AppendWrite(ctx, payloadID, third, 8192); err != nil {
+		t.Fatalf("third AppendWrite after recovery: %v", err)
+	}
+
+	dest := make([]byte, 256)
+	n, err := bc.ReadPayloadAt(ctx, payloadID, dest, 8192)
+	if err != nil {
+		t.Fatalf("ReadPayloadAt for recovered write: %v", err)
+	}
+	if n != 256 || !bytes.Equal(dest, third) {
+		t.Fatalf("recovered write read-back mismatch: n=%d equal=%v", n, bytes.Equal(dest, third))
+	}
+
+	// The first, fully-committed write must still read back correctly.
+	dest0 := make([]byte, 256)
+	if _, err := bc.ReadPayloadAt(ctx, payloadID, dest0, 0); err != nil {
+		t.Fatalf("ReadPayloadAt for first write: %v", err)
+	}
+	if !bytes.Equal(dest0, first) {
+		t.Fatal("first committed write corrupted after Sync-error recovery")
+	}
+}

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"sync"
 
 	"github.com/marmos91/dittofs/pkg/block"
 )
@@ -107,9 +108,21 @@ func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest [
 	sh.mu.RLock()
 	lf := sh.logFDs[payloadID]
 	mu := sh.logLocks[payloadID]
+	idx := sh.logIndices[payloadID]
 	sh.mu.RUnlock()
 	if lf == nil || mu == nil {
 		return nil
+	}
+
+	// Index-assisted seek: the per-payload logIndex already records the log
+	// position and file-offset extent of every committed record, so we can
+	// pread ONLY the records overlapping [reqStart, reqEnd) instead of
+	// scanning the whole log (O(total records)) on every read. The rollup
+	// path uses the same lookup (rollup.go); the read path now matches it.
+	// Fall back to the full sequential scan only when no index is wired
+	// (fixtures that drive the log without AppendWrite's bookkeeping).
+	if idx != nil {
+		return bc.replayViaIndex(lf, mu, idx, dest, reqStart, reqEnd, covered)
 	}
 
 	// Open a separate read-only fd so we don't disturb the append fd's
@@ -125,23 +138,68 @@ func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest [
 		return fmt.Errorf("ReadPayloadAt: open log: %w", err)
 	}
 	defer func() { _ = rf.Close() }()
+	return replayViaScan(rf, dest, reqStart, reqEnd, covered)
+}
 
-	// We do NOT take the per-file mutex here. Writers append at EOF and
-	// fsync each record before returning; the on-disk log is monotonic
-	// (records only grow upward) so a concurrent reader sees either a
-	// committed record or hits EOF/short-read mid-frame. readRecord
-	// returns (_, _, false, nil) on torn-tail / EOF, terminating the
-	// loop cleanly. The post-record CRC catches torn writes that
-	// reached the platter but were not yet fsynced — those are skipped
-	// as if the record did not exist (consistent with what the writer
-	// thinks: a fsync that has not returned has not yet acknowledged
-	// the write).
+// replayViaIndex reads only the records the logIndex reports as overlapping
+// [reqStart, reqEnd) via per-record preads. Entries are returned in logPos
+// (arrival) order so applying them in order preserves "last write at the
+// same offset wins", matching the sequential-scan semantics. Every index
+// entry references a fully-fsynced frame (AppendWrite indexes a record only
+// after its Sync succeeds), so readRecordAt always sees a complete frame.
+//
+// The per-file mutex is held across the fd-open + entry snapshot + preads.
+// This is required for correctness, not just the append-cursor isolation the
+// scan path relies on: maybeCompactLog (rollup Phase C) renames a rewritten
+// log over the same path AND rebases every entry's logPos, both under this
+// mutex. Without the lock a read could snapshot pre-compaction logPos values
+// and pread them against the post-compaction file (or vice-versa), yielding a
+// spurious CRC mismatch. Holding mu serializes the read against AppendWrite,
+// rollup, and compaction exactly as the rollup's own Phase-A pread loop does.
+// The fd is opened under the lock so it pins the same on-disk generation the
+// snapshotted logPos values index.
+func (bc *FSStore) replayViaIndex(lf *logFile, mu *sync.Mutex, idx *logIndex, dest []byte, reqStart, reqEnd uint64, covered []bool) error {
+	if reqEnd <= reqStart {
+		return nil
+	}
+	mu.Lock()
+	defer mu.Unlock()
 
-	// Seek past the 64-byte header.
+	rf, err := os.Open(lf.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("ReadPayloadAt: open log: %w", err)
+	}
+	defer func() { _ = rf.Close() }()
+
+	entries := idx.EntriesForInterval(reqStart, reqEnd-reqStart, nil)
+	for _, e := range entries {
+		recOff, payload, rerr := readRecordAt(rf, e.logPos, e.payloadLen)
+		if rerr != nil {
+			return fmt.Errorf("ReadPayloadAt: readRecordAt(logPos=%d): %w", e.logPos, rerr)
+		}
+		copyRecordIntoDest(recOff, payload, dest, reqStart, reqEnd, covered)
+	}
+	return nil
+}
+
+// replayViaScan is the index-free fallback: it scans every record from the
+// log header forward. Used only when no logIndex is available.
+//
+// We do NOT take the per-file mutex here. Writers append at EOF and fsync
+// each record before returning; the on-disk log is monotonic (records only
+// grow upward) so a concurrent reader sees either a committed record or hits
+// EOF/short-read mid-frame. readRecord returns (_, _, false, nil) on
+// torn-tail / EOF, terminating the loop cleanly. The post-record CRC catches
+// torn writes that reached the platter but were not yet fsynced — those are
+// skipped as if the record did not exist (consistent with what the writer
+// thinks: a fsync that has not returned has not yet acknowledged the write).
+func replayViaScan(rf io.ReadSeeker, dest []byte, reqStart, reqEnd uint64, covered []bool) error {
 	if _, err := rf.Seek(int64(logHeaderSize), io.SeekStart); err != nil {
 		return fmt.Errorf("ReadPayloadAt: seek past header: %w", err)
 	}
-
 	for {
 		recOff, payload, ok, rerr := readRecord(rf)
 		if rerr != nil {
@@ -150,29 +208,27 @@ func (bc *FSStore) replayLogIntoDest(_ context.Context, payloadID string, dest [
 		if !ok {
 			break
 		}
-		recEnd := recOff + uint64(len(payload))
-		// Skip records that do not intersect the requested window.
-		if recEnd <= reqStart || recOff >= reqEnd {
-			continue
-		}
-		// Compute intersection [hi, lo) and copy into dest.
-		copyStart := recOff
-		if copyStart < reqStart {
-			copyStart = reqStart
-		}
-		copyEnd := recEnd
-		if copyEnd > reqEnd {
-			copyEnd = reqEnd
-		}
-		destIdx := copyStart - reqStart
-		srcIdx := copyStart - recOff
-		n := copyEnd - copyStart
-		copy(dest[destIdx:destIdx+n], payload[srcIdx:srcIdx+n])
-		for i := destIdx; i < destIdx+n; i++ {
-			covered[i] = true
-		}
+		copyRecordIntoDest(recOff, payload, dest, reqStart, reqEnd, covered)
 	}
 	return nil
+}
+
+// copyRecordIntoDest copies the portion of one record's payload that
+// intersects [reqStart, reqEnd) into dest and marks those bytes covered.
+func copyRecordIntoDest(recOff uint64, payload, dest []byte, reqStart, reqEnd uint64, covered []bool) {
+	recEnd := recOff + uint64(len(payload))
+	if recEnd <= reqStart || recOff >= reqEnd {
+		return
+	}
+	copyStart := max(recOff, reqStart)
+	copyEnd := min(recEnd, reqEnd)
+	destIdx := copyStart - reqStart
+	srcIdx := copyStart - recOff
+	n := copyEnd - copyStart
+	copy(dest[destIdx:destIdx+n], payload[srcIdx:srcIdx+n])
+	for i := destIdx; i < destIdx+n; i++ {
+		covered[i] = true
+	}
 }
 
 // fillFromCASManifest walks the FileBlock manifest for payloadID and

--- a/pkg/block/local/fs/readpayload_index_test.go
+++ b/pkg/block/local/fs/readpayload_index_test.go
@@ -1,0 +1,96 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestReadPayloadAt_IndexAssisted_OutOfOrderOverlap verifies the
+// index-assisted read path returns the correct bytes for out-of-order
+// arrivals with overlapping offsets — applying records in logPos (arrival)
+// order so the later write at an overlapping offset wins, matching the
+// full-scan semantics.
+func TestReadPayloadAt_IndexAssisted_OutOfOrderOverlap(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	id := "file-idx-overlap"
+
+	// Arrive out of file-offset order, with an overlap at [1024,1280): the
+	// later write (0x22) must win.
+	a := bytes.Repeat([]byte{0xAA}, 256)
+	b := bytes.Repeat([]byte{0xBB}, 256)
+	overlapOld := bytes.Repeat([]byte{0x11}, 256)
+	overlapNew := bytes.Repeat([]byte{0x22}, 256)
+
+	if err := bc.AppendWrite(ctx, id, b, 8192); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	if err := bc.AppendWrite(ctx, id, overlapOld, 1024); err != nil {
+		t.Fatalf("write overlapOld: %v", err)
+	}
+	if err := bc.AppendWrite(ctx, id, a, 0); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := bc.AppendWrite(ctx, id, overlapNew, 1024); err != nil {
+		t.Fatalf("write overlapNew: %v", err)
+	}
+
+	// Read each region back and check.
+	check := func(off uint64, want []byte) {
+		t.Helper()
+		dest := make([]byte, len(want))
+		n, err := bc.ReadPayloadAt(ctx, id, dest, off)
+		if err != nil {
+			t.Fatalf("ReadPayloadAt(off=%d): %v", off, err)
+		}
+		if n != len(want) || !bytes.Equal(dest, want) {
+			t.Fatalf("ReadPayloadAt(off=%d): mismatch (n=%d)", off, n)
+		}
+	}
+	check(0, a)
+	check(8192, b)
+	check(1024, overlapNew) // last write wins
+
+	// A read that touches only the 'a' region must not pay to scan the
+	// 8192 record — correctness is what we can assert here: the window is
+	// satisfied entirely from the index-selected record.
+	dest := make([]byte, 128)
+	if _, err := bc.ReadPayloadAt(ctx, id, dest, 64); err != nil {
+		t.Fatalf("partial read: %v", err)
+	}
+	if !bytes.Equal(dest, a[64:64+128]) {
+		t.Fatal("partial read mismatch")
+	}
+}
+
+// TestReplayViaScan_Fallback verifies the index-free fallback still works
+// when no logIndex is wired (replayViaScan path), preserving last-write-wins
+// over a full sequential scan.
+func TestReplayViaScan_Fallback(t *testing.T) {
+	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30})
+	ctx := context.Background()
+	id := "file-scan-fallback"
+
+	if err := bc.AppendWrite(ctx, id, bytes.Repeat([]byte{0x11}, 256), 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := bc.AppendWrite(ctx, id, bytes.Repeat([]byte{0x22}, 256), 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Drop the logIndex to force the fallback scan path. The fd and lock
+	// stay in place so replayLogIntoDest still finds the log.
+	sh := bc.shardFor(id)
+	sh.mu.Lock()
+	delete(sh.logIndices, id)
+	sh.mu.Unlock()
+
+	dest := make([]byte, 256)
+	if _, err := bc.ReadPayloadAt(ctx, id, dest, 0); err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if !bytes.Equal(dest, bytes.Repeat([]byte{0x22}, 256)) {
+		t.Fatal("fallback scan did not honour last-write-wins")
+	}
+}

--- a/pkg/block/remote/s3/ssrf_test.go
+++ b/pkg/block/remote/s3/ssrf_test.go
@@ -1,0 +1,58 @@
+package s3
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateEndpoint_SSRF verifies the endpoint guard rejects the cloud
+// metadata endpoint, loopback, link-local, and private/internal hosts while
+// allowing public S3 endpoints. Literal IPs are used throughout so the test
+// stays hermetic (no DNS).
+func TestValidateEndpoint_SSRF(t *testing.T) {
+	cases := []struct {
+		name         string
+		endpoint     string
+		allowPrivate bool
+		wantErr      bool
+	}{
+		// The canonical SSRF pivot — must be rejected even with the
+		// private opt-out, since 169.254.169.254 is link-local.
+		{"metadata_ip", "http://169.254.169.254/latest/meta-data", false, true},
+		{"metadata_ip_allow_private", "http://169.254.169.254/latest/meta-data", true, true},
+		{"link_local_v6", "http://[fe80::1]:9000", false, true},
+		{"loopback", "http://127.0.0.1:9000", false, true},
+		{"loopback_v6", "http://[::1]:9000", false, true},
+		{"private_10", "http://10.0.0.5:9000", false, true},
+		{"private_192", "https://192.168.1.10", false, true},
+		{"private_172", "http://172.16.3.4:9000", false, true},
+		{"unspecified", "http://0.0.0.0:9000", false, true},
+		// Private hosts permitted only under the explicit opt-out (MinIO /
+		// Localstack co-located on a private network).
+		{"private_10_allow", "http://10.0.0.5:9000", true, false},
+		{"loopback_allow", "http://127.0.0.1:4566", true, false},
+		// Public endpoints are always fine.
+		{"public_ip", "https://93.184.216.34", false, false},
+		{"empty", "", false, false},
+		// A bare host normalizes to https:// + public literal IP.
+		{"bare_public_ip", "93.184.216.34", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEndpoint(tc.endpoint, tc.allowPrivate)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateEndpoint(%q, allowPrivate=%v): want error, got nil", tc.endpoint, tc.allowPrivate)
+				}
+				if !errors.Is(err, ErrUnsafeEndpoint) {
+					t.Fatalf("ValidateEndpoint(%q): want ErrUnsafeEndpoint, got %v", tc.endpoint, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateEndpoint(%q, allowPrivate=%v): want nil, got %v", tc.endpoint, tc.allowPrivate, err)
+			}
+		})
+	}
+}

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -193,6 +195,93 @@ func normalizeEndpoint(endpoint string) string {
 		}
 	}
 	return "https://" + endpoint
+}
+
+// ErrUnsafeEndpoint indicates a configured S3 endpoint resolves to an
+// address that must not be dialed (cloud metadata, loopback, link-local,
+// or private/internal hosts) — the classic SSRF pivot.
+var ErrUnsafeEndpoint = errors.New("s3 block store: unsafe endpoint")
+
+// ValidateEndpoint rejects S3 endpoints that point at addresses an attacker
+// could use to pivot the server into the internal network (SSRF). It runs
+// at config-create time, before any HealthCheck/HeadBucket fires, so a
+// malicious "endpoint":"http://169.254.169.254/..." is refused before the
+// S3 SDK ever issues a request.
+//
+// An empty endpoint is allowed (the SDK uses the real AWS endpoint, which
+// is public). Otherwise the endpoint is normalized, its host is resolved,
+// and EVERY resolved IP must be a public unicast address. We reject:
+//   - unspecified / multicast / loopback addresses,
+//   - link-local unicast (169.254.0.0/16, fe80::/10) — covers the cloud
+//     metadata endpoint 169.254.169.254,
+//   - private / unique-local ranges (RFC1918, fc00::/7) and other
+//     non-global-unicast space.
+//
+// allowPrivate is an explicit opt-out (config key "allow_private_endpoint")
+// for operators running MinIO/Localstack/co-located object stores on a
+// private network; it still rejects link-local/metadata addresses.
+func ValidateEndpoint(endpoint string, allowPrivate bool) error {
+	if endpoint == "" {
+		return nil
+	}
+	u, err := url.Parse(normalizeEndpoint(endpoint))
+	if err != nil {
+		return fmt.Errorf("%w: parse %q: %v", ErrUnsafeEndpoint, endpoint, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: scheme %q must be http or https", ErrUnsafeEndpoint, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: missing host in %q", ErrUnsafeEndpoint, endpoint)
+	}
+
+	// Resolve to IPs. A literal IP resolves to itself; a hostname is looked
+	// up so an attacker cannot smuggle 169.254.169.254 behind a DNS name.
+	var ips []netip.Addr
+	if addr, perr := netip.ParseAddr(host); perr == nil {
+		ips = []netip.Addr{addr}
+	} else {
+		resolved, lerr := net.LookupIP(host)
+		if lerr != nil {
+			return fmt.Errorf("%w: resolve host %q: %v", ErrUnsafeEndpoint, host, lerr)
+		}
+		for _, ip := range resolved {
+			if a, ok := netip.AddrFromSlice(ip); ok {
+				ips = append(ips, a.Unmap())
+			}
+		}
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%w: host %q resolved to no addresses", ErrUnsafeEndpoint, host)
+	}
+	for _, ip := range ips {
+		if err := checkEndpointIP(ip, host, allowPrivate); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkEndpointIP rejects a single resolved address that is unsafe to dial.
+func checkEndpointIP(ip netip.Addr, host string, allowPrivate bool) error {
+	switch {
+	case ip.IsUnspecified():
+		return fmt.Errorf("%w: host %q resolves to unspecified address", ErrUnsafeEndpoint, host)
+	case ip.IsMulticast():
+		return fmt.Errorf("%w: host %q resolves to multicast address", ErrUnsafeEndpoint, host)
+	case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
+		// 169.254.0.0/16 / fe80::/10 — covers the 169.254.169.254 metadata
+		// endpoint. Never allowed, even under allowPrivate.
+		return fmt.Errorf("%w: host %q resolves to link-local address %s (cloud metadata)", ErrUnsafeEndpoint, host, ip)
+	}
+	if allowPrivate {
+		return nil
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || !ip.IsGlobalUnicast() {
+		return fmt.Errorf("%w: host %q resolves to private/internal address %s (set allow_private_endpoint=true to permit)", ErrUnsafeEndpoint, host, ip)
+	}
+	return nil
 }
 
 // isValidScheme checks whether s is a valid URI scheme per RFC 3986.

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -202,6 +202,10 @@ func normalizeEndpoint(endpoint string) string {
 // or private/internal hosts) — the classic SSRF pivot.
 var ErrUnsafeEndpoint = errors.New("s3 block store: unsafe endpoint")
 
+// endpointResolveTimeout bounds the DNS lookup ValidateEndpoint performs for a
+// hostname endpoint so a hung resolver cannot stall the config-create path.
+const endpointResolveTimeout = 5 * time.Second
+
 // ValidateEndpoint rejects S3 endpoints that point at addresses an attacker
 // could use to pivot the server into the internal network (SSRF). It runs
 // at config-create time, before any HealthCheck/HeadBucket fires, so a
@@ -210,16 +214,20 @@ var ErrUnsafeEndpoint = errors.New("s3 block store: unsafe endpoint")
 //
 // An empty endpoint is allowed (the SDK uses the real AWS endpoint, which
 // is public). Otherwise the endpoint is normalized, its host is resolved,
-// and EVERY resolved IP must be a public unicast address. We reject:
-//   - unspecified / multicast / loopback addresses,
+// and EVERY resolved IP is checked. We reject UNCONDITIONALLY:
+//   - unspecified / multicast addresses,
 //   - link-local unicast (169.254.0.0/16, fe80::/10) — covers the cloud
-//     metadata endpoint 169.254.169.254,
-//   - private / unique-local ranges (RFC1918, fc00::/7) and other
-//     non-global-unicast space.
+//     metadata endpoint 169.254.169.254.
 //
-// allowPrivate is an explicit opt-out (config key "allow_private_endpoint")
+// We additionally reject loopback, private / unique-local (RFC1918,
+// fc00::/7), and other non-global-unicast space UNLESS allowPrivate is set.
+// allowPrivate (config key "allow_private_endpoint") is an explicit opt-out
 // for operators running MinIO/Localstack/co-located object stores on a
-// private network; it still rejects link-local/metadata addresses.
+// private network; it still rejects the unconditional set above (so the
+// metadata endpoint is never reachable).
+//
+// DNS resolution for a hostname endpoint is bounded by endpointResolveTimeout
+// so a slow/hung resolver cannot stall the config-create path indefinitely.
 func ValidateEndpoint(endpoint string, allowPrivate bool) error {
 	if endpoint == "" {
 		return nil
@@ -242,12 +250,14 @@ func ValidateEndpoint(endpoint string, allowPrivate bool) error {
 	if addr, perr := netip.ParseAddr(host); perr == nil {
 		ips = []netip.Addr{addr}
 	} else {
-		resolved, lerr := net.LookupIP(host)
+		ctx, cancel := context.WithTimeout(context.Background(), endpointResolveTimeout)
+		defer cancel()
+		resolved, lerr := net.DefaultResolver.LookupIPAddr(ctx, host)
 		if lerr != nil {
 			return fmt.Errorf("%w: resolve host %q: %v", ErrUnsafeEndpoint, host, lerr)
 		}
-		for _, ip := range resolved {
-			if a, ok := netip.AddrFromSlice(ip); ok {
+		for _, ipa := range resolved {
+			if a, ok := netip.AddrFromSlice(ipa.IP); ok {
 				ips = append(ips, a.Unmap())
 			}
 		}

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/marmos91/dittofs/internal/pathutil"
+	s3store "github.com/marmos91/dittofs/pkg/block/remote/s3"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
@@ -78,6 +79,16 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 			secretAccessKey, ok := config["secret_access_key"].(string)
 			if !ok || secretAccessKey == "" {
 				return errors.New("s3 remote block store requires secret_access_key in config")
+			}
+			// SSRF guard: reject endpoints pointing at cloud metadata,
+			// loopback, link-local, or private/internal hosts before the
+			// create-time HealthCheck can dial them. allow_private_endpoint
+			// opts in to private object stores (MinIO/Localstack) but still
+			// blocks the metadata endpoint.
+			endpoint, _ := config["endpoint"].(string)
+			allowPrivate, _ := config["allow_private_endpoint"].(bool)
+			if err := s3store.ValidateEndpoint(endpoint, allowPrivate); err != nil {
+				return err
 			}
 			if err := validateCompressionSubconfig(config); err != nil {
 				return err

--- a/pkg/controlplane/runtime/blockstore_init_test.go
+++ b/pkg/controlplane/runtime/blockstore_init_test.go
@@ -3,7 +3,53 @@ package runtime
 import (
 	"strings"
 	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
+
+// configMap adapts a plain map to the GetConfig interface ValidateBlockStoreConfig expects.
+type configMap map[string]any
+
+func (c configMap) GetConfig() (map[string]any, error) { return c, nil }
+
+// TestValidateBlockStoreConfig_S3_SSRF verifies the s3 endpoint SSRF guard
+// fires at config-validation time — before the create-time HealthCheck can
+// dial a metadata/loopback/private host.
+func TestValidateBlockStoreConfig_S3_SSRF(t *testing.T) {
+	base := func(extra map[string]any) configMap {
+		cfg := configMap{
+			"bucket":            "b",
+			"access_key_id":     "ak",
+			"secret_access_key": "sk",
+		}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		return cfg
+	}
+	cases := []struct {
+		name    string
+		cfg     configMap
+		wantErr bool
+	}{
+		{"metadata_endpoint", base(map[string]any{"endpoint": "http://169.254.169.254/latest/meta-data"}), true},
+		{"private_endpoint", base(map[string]any{"endpoint": "http://10.0.0.5:9000"}), true},
+		{"private_endpoint_allowed", base(map[string]any{"endpoint": "http://10.0.0.5:9000", "allow_private_endpoint": true}), false},
+		{"no_endpoint", base(nil), false},
+		{"public_endpoint", base(map[string]any{"endpoint": "https://93.184.216.34"}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBlockStoreConfig(models.BlockStoreKindRemote, "s3", tc.cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("want error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}
 
 func TestValidateCompressionSubconfig(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Closes #1124.

Verified findings from the develop re-audit (block store). Per-finding outcome below.

## [HIGH] Argon2 KDF params used without lower-bound validation — panic/OOM DoS
`pkg/block/encryption/keyprovider/local.go`. `decodeKeyFile` now validates the on-disk Argon2 params (`validateKDFParams`) before they reach `argon2.IDKey`. Lower bounds prevent the `time=0`/`threads=0` panic that crashed the daemon at startup; an upper bound on `memory_kib` (~4 GiB) prevents an OOM-kill. Out-of-range params surface as `ErrKeyFileCorrupt`. Tests: `kdf_time_zero`, `kdf_threads_zero`, `kdf_memory_zero`, `kdf_memory_huge`, `kdf_time_huge`.

## [HIGH] groupCommit.Sync error desyncs lf.eofPos from the fd position
`pkg/block/local/fs/appendwrite.go`. On a `groupCommit.Sync` failure, `AppendWrite` now evicts the log fd (close + remove from `logFDs`) exactly like the existing `writeRecord`-error recovery path, instead of returning with `eofPos` left behind the advanced fd. This stops the next `AppendWrite` from recording a `logIndex` entry pointing at the orphaned, un-fsync'd frame — which permanently wedged rollup for that payload. Test `TestAppendWrite_SyncError_EvictsFdAndKeepsLogIndexConsistent` fails before / passes after.

## [HIGH] SSRF via unvalidated S3 endpoint
`pkg/block/remote/s3/store.go` + `pkg/controlplane/runtime/blockstore_init.go`. New `ValidateEndpoint` resolves the endpoint host and rejects cloud-metadata (169.254.169.254), loopback, link-local, unspecified, multicast, and private/internal addresses. Wired into `ValidateBlockStoreConfig` so it fires at config-create time, before the create-time `HealthCheck`/`HeadBucket` dial. `allow_private_endpoint=true` opts in MinIO/Localstack-style private object stores but still blocks the metadata endpoint. Tests: `TestValidateEndpoint_SSRF`, `TestValidateBlockStoreConfig_S3_SSRF`.

## [MED] Data race on bs.cache in DestroyCache
`pkg/block/engine/`. Every cache-field access now goes through `cacheMu` via `loadCache`/`storeCache`. The `DestroyCache`/`Start` swaps no longer race concurrent data ops (which only hold `closeMu.RLock`) or the lock-free `OnChunkComplete` rollup goroutine. Test `TestDestroyCache_ConcurrentReads_NoRace` flags a `DATA RACE` before / clean after under `-race`.

## [MED] replayLogIntoDest full sequential scan on every read
`pkg/block/local/fs/readpayload.go`. `ReadPayloadAt` now uses the per-payload `logIndex` (`EntriesForInterval`) to pread only the records overlapping the requested window — O(overlapping records) instead of O(total records) per read — matching how rollup already seeks. The index path is held under the per-file mutex so a snapshotted `logPos` stays consistent with `maybeCompactLog`'s rename + `logPos` rebase (a regression caught in self-review; the original lock-free draft could pread post-compaction offsets against a pre-compaction fd). Falls back to the full scan only when no index is wired (fixtures). Tests: `TestReadPayloadAt_IndexAssisted_OutOfOrderOverlap`, `TestReplayViaScan_Fallback`.

## Verification
`go build ./...`, `go test ./pkg/block/... ./pkg/controlplane/runtime/`, and `go test -race` on the touched packages all pass.