### PR TITLE
ci(smb): run full store matrix on PRs + fix S3 SSRF conformance regression

### DIFF
--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -12,7 +12,7 @@ on:
       - 'pkg/adapter/smb/**'
       - 'internal/adapter/smb/**'
       - 'pkg/metadata/**'
-      - 'pkg/blockstore/**'
+      - 'pkg/block/**'
       - 'pkg/controlplane/**'
       - 'test/smb-conformance/**'
       - 'pkg/adapter/base.go'
@@ -23,7 +23,7 @@ on:
       - 'pkg/adapter/smb/**'
       - 'internal/adapter/smb/**'
       - 'pkg/metadata/**'
-      - 'pkg/blockstore/**'
+      - 'pkg/block/**'
       - 'pkg/controlplane/**'
       - 'test/smb-conformance/**'
       - 'pkg/adapter/base.go'
@@ -57,11 +57,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Full store matrix on every event (PR/push/cron) — badger and postgres
+        # SMB behavior must be covered at PR time, not only post-merge.
+        # workflow_dispatch still runs a single chosen profile.
         profile: >-
           ${{
-            github.event_name == 'pull_request'
-              && fromJson('["memory"]')
-            || github.event_name == 'workflow_dispatch'
+            github.event_name == 'workflow_dispatch'
               && fromJson(format('["{0}"]', inputs.profile))
             || fromJson('["memory", "memory-fs", "badger-fs", "badger-s3", "postgres-s3"]')
           }}

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -124,8 +124,11 @@ create_block_stores() {
             ;;
         *-s3)
             $DFSCTL store block local add --name default --type memory
+            # Localstack is a deliberate private-network test endpoint; opt it past
+            # the S3 SSRF guard (added in #1124) which otherwise rejects the
+            # private 172.x address that "localstack" resolves to.
             $DFSCTL store block remote add --name default --type s3 \
-                --config '{"bucket":"dittofs-test","region":"us-east-1","endpoint":"http://localstack:4566","force_path_style":true,"access_key_id":"test","secret_access_key":"test"}'
+                --config '{"bucket":"dittofs-test","region":"us-east-1","endpoint":"http://localstack:4566","force_path_style":true,"access_key_id":"test","secret_access_key":"test","allow_private_endpoint":true}'
             ;;
         *)
             log_error "Unknown profile payload pattern: ${PROFILE}"


### PR DESCRIPTION
Brings SMB conformance to the same coverage as POSIX: every store backend exercised at PR time, not only post-merge.

## Changes
- **Full store matrix on PRs.** `smb-conformance.yml` now runs all 5 profiles (memory, memory-fs, badger-fs, badger-s3, postgres-s3) on every event (PR/push/cron), matching the POSIX matrix. `workflow_dispatch` still runs a single chosen profile.
- **Fix S3 SSRF regression (urgent — develop is red).** #1124 added an S3 endpoint SSRF guard that rejects private addresses unless `allow_private_endpoint` is set. The conformance `*-s3` profiles point at **Localstack** (`localstack` → private 172.x), so `badger-s3` and `postgres-s3` WPTS BVT went red on develop right after #1124 merged. `bootstrap.sh` now sets `allow_private_endpoint:true` on the Localstack store (a deliberate private test endpoint).
- **Fix stale path filter** `pkg/blockstore/**` → `pkg/block/**` (renamed in #1138) so the workflow actually triggers on block-store changes.

## Expected
badger-s3 / postgres-s3 WPTS should go green again. Any remaining per-backend SMB failures surfaced by the full matrix will be fixed or blacklisted-with-issue (POSIX #1153 precedent).