### PR TITLE
ci: fix stale pkg/blockstore path filter → pkg/block

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ on:
       - 'internal/adapter/nfs/**'
       - 'internal/adapter/smb/**'
       - 'pkg/metadata/**'
-      - 'pkg/blockstore/**'
+      - 'pkg/block/**'
       - 'pkg/controlplane/**'
       - 'pkg/config/**'
       - 'test/e2e/**'

--- a/.github/workflows/posix-tests.yml
+++ b/.github/workflows/posix-tests.yml
@@ -21,7 +21,7 @@ on:
       - 'pkg/adapter/base.go'
       - 'internal/adapter/nfs/**'
       - 'pkg/metadata/**'
-      - 'pkg/blockstore/**'
+      - 'pkg/block/**'
       - 'pkg/controlplane/**'
       - 'pkg/config/**'
       - 'test/posix/**'


### PR DESCRIPTION
`pkg/blockstore` was renamed to `pkg/block`, but the POSIX, SMB-conformance, and e2e workflow path filters still gated on the old directory. A change touching only `pkg/block/**` would not trigger those workflows on PRs — silent CI gaps on the data path.

Renamed the stale filter in all three workflows. Verified every remaining `pkg/`/`internal/`/`cmd/` path filter across `.github/workflows/` resolves to a real directory.

Closes the path-filter portion of the CI-hygiene roadmap.