### PR TITLE
fix(postgres): queryRow cancels context before caller scans (NFS4ERR_IO on deep paths)

### DIFF
--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -40,16 +40,27 @@ func (s *PostgresMetadataStore) queryRow(ctx context.Context, sql string, args .
 		return &errorRow{err: ctx.Err()}
 	}
 
-	// Apply connection acquire timeout
+	// The acquire timeout bounds ONLY the connection acquisition — it must not
+	// outlive this function via the returned Row. pgx.QueryRow is lazy: the row
+	// data is read from the wire inside the caller's Scan(), bound to whatever
+	// context was passed to QueryRow. If we passed acquireCtx (cancelled by the
+	// defer below the instant this function returns) the caller's Scan would run
+	// against an already-cancelled context and intermittently fail with
+	// "context canceled" depending on whether the row had buffered yet. So scope
+	// acquireCtx to Acquire only, then run the query on the parent ctx — the same
+	// pattern as query()/exec() — and release the connection after Scan.
 	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
 	defer cancel()
 
-	// pgxpool.Pool.QueryRow manages the connection lifecycle internally: the
-	// underlying connection is released when Scan is called, regardless of the
-	// scan result. This eliminates the manual Acquire/Release pair and the
-	// connection leak that occurred when Scan was never called (panic path,
-	// early return, or a discarded result).
-	return s.pool.QueryRow(acquireCtx, sql, args...)
+	conn, err := s.pool.Acquire(acquireCtx)
+	if err != nil {
+		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return &errorRow{err: fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)}
+		}
+		return &errorRow{err: mapPgError(err, "queryRow", sql)}
+	}
+
+	return &poolRow{row: conn.QueryRow(ctx, sql, args...), conn: conn}
 }
 
 // query executes a query that returns rows with connection acquire timeout.
@@ -155,6 +166,20 @@ type errorRow struct {
 
 func (r *errorRow) Scan(dest ...any) error {
 	return r.err
+}
+
+// poolRow wraps a single-row pgx.Row and releases the pooled connection once
+// the caller scans it. The query runs on the caller's (parent) context, so the
+// connection must stay checked out until Scan reads the row off the wire — at
+// which point it is released exactly once.
+type poolRow struct {
+	row  pgx.Row
+	conn *pgxpool.Conn
+}
+
+func (r *poolRow) Scan(dest ...any) error {
+	defer r.conn.Release()
+	return r.row.Scan(dest...)
 }
 
 // poolRows wraps pgx.Rows and releases the connection when closed

--- a/test/posix/KNOWN_FAILURES.md
+++ b/test/posix/KNOWN_FAILURES.md
@@ -38,17 +38,4 @@ Categories:
 | posix_fallocate/* | feature | No ALLOCATE procedure in NFSv3 | - |
 | utimensat/09.t | proto | NFSv3 nfstime3 uses uint32 seconds — cannot represent values >= 2^32 (year 2106) | - |
 | open/03.t | env | PATH_MAX test fails: mount-point prefix pushes the absolute path over PATH_MAX in the Linux VFS before NFS sees it — client-side, affects any non-root mount | - |
-| chmod/03.t | bug | Deep/long composite path (~4000 chars) create/chmod fails on the PostgreSQL backend (memory/badger pass) | #1153 |
-| chown/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| ftruncate/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| link/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| truncate/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| unlink/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| rename/23.t | bug | Long-path rename fails on the PostgreSQL backend | #1153 |
-| chown/07.t | bug | Intermittent EEXIST/EIO on the PostgreSQL backend — collateral of the deep-path bug leaving orphaned rows | #1153 |
-| link/04.t | bug | Intermittent EEXIST/EIO on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| open/22.t | bug | Intermittent EEXIST / nlink mismatch on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| truncate/06.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| ftruncate/06.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| unlink/04.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| chmod/11.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
+| rename/23.t | bug | PostgreSQL rename-overwrite of an existing target returns EEXIST (nlink ends at 2); memory/badger pass. Not a long-path bug — normal-length names | #1160 |

--- a/test/posix/KNOWN_FAILURES_V4.md
+++ b/test/posix/KNOWN_FAILURES_V4.md
@@ -32,17 +32,4 @@ Categories:
 | removexattr/* | feature | NFSv4 named attributes not implemented | - |
 | open/03.t | env | PATH_MAX test fails: mount-point prefix pushes the absolute path over PATH_MAX in the Linux VFS before NFS sees it — client-side, affects any non-root mount | - |
 | unlink/14.t | proto | NFSv4 silly-rename: open file + unlink triggers rename instead of remove, nlink stays 1 (same as Linux knfsd) | - |
-| chmod/03.t | bug | Deep/long composite path (~4000 chars) fails on the PostgreSQL backend (memory/badger pass) | #1153 |
-| chown/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| ftruncate/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| link/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| truncate/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| unlink/03.t | bug | Deep/long composite path fails on the PostgreSQL backend | #1153 |
-| rename/23.t | bug | Long-path rename fails on the PostgreSQL backend | #1153 |
-| chown/07.t | bug | Intermittent EEXIST/EIO on the PostgreSQL backend — collateral of the deep-path bug leaving orphaned rows | #1153 |
-| link/04.t | bug | Intermittent EEXIST/EIO on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| open/22.t | bug | Intermittent EEXIST / nlink mismatch on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| truncate/06.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| ftruncate/06.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| unlink/04.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
-| chmod/11.t | bug | Intermittent EEXIST on the PostgreSQL backend — collateral of the deep-path bug | #1153 |
+| rename/23.t | bug | PostgreSQL rename-overwrite of an existing target returns EEXIST (nlink ends at 2); memory/badger pass. Not a long-path bug — normal-length names | #1160 |


### PR DESCRIPTION
## Root cause (#1153)
`PostgresMetadataStore.queryRow` did:
```go
acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
defer cancel()
return s.pool.QueryRow(acquireCtx, sql, args...)
```
pgx's `QueryRow` is **lazy** — the row is read off the wire inside the caller's `.Scan()`, bound to the context passed to `QueryRow`. The `defer cancel()` cancelled `acquireCtx` the instant `queryRow` returned, *before* the caller scanned. Whether Scan then failed depended on whether the row had already buffered into the socket — i.e. **intermittent**, and load-sensitive. When it lost the race it surfaced as `GetFile: context canceled` → `ErrIOError` → `NFS4ERR_IO`.

The deep/long-path pjdfstest `/03` family issues a burst of `GetChild`/`GetFile` per level, so it hit the window reliably; memory/badger never use this path. The sibling `query()`/`exec()` already do it correctly (acquire under the timeout ctx, run the query on the parent ctx).

## Fix
`queryRow` now acquires a `*pgxpool.Conn` under the acquire-timeout, runs `conn.QueryRow(ctx, …)` on the **parent** ctx, and releases the connection after Scan via a new `poolRow`. Structurally identical to `query()`.

## Validation (live, real postgres + kernel NFS mount on a Linux box)
Reproduced the original `context canceled` first, then with the fix re-ran the full #1153 set on **both NFSv4.1 and NFSv3**:

| | before | after |
|--|--|--|
| chmod/chown/ftruncate/link/truncate/unlink **/03** | FAIL | **ok** |
| collateral: chmod/11, chown/07, link/04, open/22, truncate/06, ftruncate/06, unlink/04 | FAIL | **ok** |
| rename/23 | FAIL | FAIL (separate bug) |

13 of 14 rows cleared and walked back out of both `KNOWN_FAILURES.md` and `KNOWN_FAILURES_V4.md` — the now-ungated postgres POSIX jobs are the regression guard. `rename/23` is a postgres rename-overwrite defect (EEXIST + nlink=2), **not** context-cancel and **not** long-path (normal-length names); split out to **#1160** and its blacklist row retagged.

20 `s.queryRow` callers audited (code-reviewer): all scan exactly once; `pgxpool.Conn.Release()` is idempotent — no leak / double-release.

Closes #1153