### PR TITLE
docs: clarify first-login admin password change + APT key retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password ./dfs start
 ```bash
 # 1. Start the server (see above), then log in
 ./dfsctl login --server http://localhost:8080 --username admin
+
+# 1a. REQUIRED on first login: change the admin password.
+# The bootstrap admin starts with a forced-password-change flag — until you
+# clear it here, every other command (including `user create` below) is
+# rejected with "admin password change required". (Skipped automatically if
+# you set your own DITTOFS_ADMIN_INITIAL_PASSWORD at first start.)
 ./dfsctl user change-password
 
 # 2. Create a user mapped to your host UID (needed for NFS write access)

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password ./dfs start
 # 1a. REQUIRED on first login: change the admin password.
 # The bootstrap admin starts with a forced-password-change flag — until you
 # clear it here, every other command (including `user create` below) is
-# rejected with "admin password change required". (Skipped automatically if
-# you set your own DITTOFS_ADMIN_INITIAL_PASSWORD at first start.)
+# rejected with HTTP 403 "Password change required. Please change your
+# password before proceeding." (Skipped automatically if you set your own
+# DITTOFS_ADMIN_INITIAL_PASSWORD at first start.)
 ./dfsctl user change-password
 
 # 2. Create a user mapped to your host UID (needed for NFS write access)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -21,9 +21,7 @@ Most package managers install both.
 ### Debian / Ubuntu (APT)
 
 ```bash
-# --retry rides out a transient 503 from the object store mid-publish; if you
-# still see "gpg: no valid OpenPGP data found", retry in a minute.
-curl -fsSL --retry 5 --retry-connrefused https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key \
+curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key \
   | gpg --dearmor --yes | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" \
   | sudo tee /etc/apt/sources.list.d/dfs.list

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -21,7 +21,9 @@ Most package managers install both.
 ### Debian / Ubuntu (APT)
 
 ```bash
-curl -fsSL https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key \
+# --retry rides out a transient 503 from the object store mid-publish; if you
+# still see "gpg: no valid OpenPGP data found", retry in a minute.
+curl -fsSL --retry 5 --retry-connrefused https://s3.cubbit.eu/dittofs-binaries/apt/dittofs.gpg.key \
   | gpg --dearmor --yes | sudo tee /usr/share/keyrings/dittofs.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/dittofs.gpg] https://s3.cubbit.eu/dittofs-binaries/apt stable main" \
   | sudo tee /etc/apt/sources.list.d/dfs.list


### PR DESCRIPTION
Addresses onboarding feedback from an early adopter.

1. **First-login password change is now flagged REQUIRED** in the README quick-start, with an explicit note that until the bootstrap admin clears its forced-password-change flag (`dfsctl user change-password`), every other command — including `user create` — is rejected with a 403. The user hit this and couldn't tell the error referred to the *admin* account.
2. **APT key fetch uses `curl --retry`** to ride out the transient 503 the same user saw mid-publish.

Docs-only. The deeper code work is tracked separately: clearer error text + optional forced-change config (#1162) and the APT publish-reliability investigation (#1163).