### PR TITLE
fix(postgres): drop path_hash uniqueness index (hard-link rename overwrite, #1160)

### DIFF
--- a/pkg/metadata/store/postgres/migrations/000031_drop_path_hash_unique_index.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000031_drop_path_hash_unique_index.down.sql
@@ -1,0 +1,9 @@
+-- Revert: restore the active-path uniqueness index on files (#1160).
+--
+-- NOTE: this recreate fails if the table now holds two active rows
+-- (nlink > 0) sharing a (share_name, path_hash) — exactly the hard-link
+-- state the up migration permits. Roll back only against data that predates
+-- such a state.
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_share_path_hash_active
+    ON files(share_name, path_hash) WHERE nlink > 0;

--- a/pkg/metadata/store/postgres/migrations/000031_drop_path_hash_unique_index.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000031_drop_path_hash_unique_index.up.sql
@@ -1,0 +1,23 @@
+-- Drop the active-path uniqueness index on files (#1160).
+--
+-- unique_share_path_hash_active enforced "at most one active inode per
+-- (share, path)". That invariant is incompatible with hard links: a single
+-- inode reachable under N names has only ONE files.path column, so when a
+-- rename overwrites a multiply-linked destination, the surviving inode keeps
+-- its old path while the source is relocated onto it — two active rows briefly
+-- share a path_hash and PostgreSQL rejects the rename with a unique violation
+-- ("PutFile: already exists" -> NFS4ERR_EXIST). The memory and badger backends
+-- have no such index and handle this correctly; this was the lone postgres-only
+-- divergence behind pjdfstest rename/23 (and earlier #190's recycle failure).
+--
+-- Namespace uniqueness — no two entries with the same name in a directory — is
+-- already enforced by the parent_child_map PRIMARY KEY/UNIQUE(parent_id,
+-- child_name), from which full-path uniqueness follows transitively. The
+-- files.path column is a denormalized convenience (snapshot/restore, logging);
+-- path resolution on the live data path goes through parent_child_map, not
+-- path_hash. Dropping the UNIQUE index therefore removes a redundant guard that
+-- only ever turned the hard-link limitation into a hard failure.
+--
+-- The non-unique idx_files_share_path_hash lookup index is retained.
+
+DROP INDEX IF EXISTS unique_share_path_hash_active;

--- a/test/posix/KNOWN_FAILURES.md
+++ b/test/posix/KNOWN_FAILURES.md
@@ -38,4 +38,3 @@ Categories:
 | posix_fallocate/* | feature | No ALLOCATE procedure in NFSv3 | - |
 | utimensat/09.t | proto | NFSv3 nfstime3 uses uint32 seconds — cannot represent values >= 2^32 (year 2106) | - |
 | open/03.t | env | PATH_MAX test fails: mount-point prefix pushes the absolute path over PATH_MAX in the Linux VFS before NFS sees it — client-side, affects any non-root mount | - |
-| rename/23.t | bug | PostgreSQL rename-overwrite of an existing target returns EEXIST (nlink ends at 2); memory/badger pass. Not a long-path bug — normal-length names | #1160 |

--- a/test/posix/KNOWN_FAILURES_V4.md
+++ b/test/posix/KNOWN_FAILURES_V4.md
@@ -32,4 +32,3 @@ Categories:
 | removexattr/* | feature | NFSv4 named attributes not implemented | - |
 | open/03.t | env | PATH_MAX test fails: mount-point prefix pushes the absolute path over PATH_MAX in the Linux VFS before NFS sees it — client-side, affects any non-root mount | - |
 | unlink/14.t | proto | NFSv4 silly-rename: open file + unlink triggers rename instead of remove, nlink stays 1 (same as Linux knfsd) | - |
-| rename/23.t | bug | PostgreSQL rename-overwrite of an existing target returns EEXIST (nlink ends at 2); memory/badger pass. Not a long-path bug — normal-length names | #1160 |


### PR DESCRIPTION
## Root cause
`unique_share_path_hash_active ON files(share_name, path_hash) WHERE nlink > 0` enforced *one active inode per (share, path)*. Hard links break that: an inode reachable under N names has a single `files.path` column. When a rename **overwrites a multiply-linked destination**, the surviving destination inode keeps its old path (nlink>0) while the source is relocated onto the same path — two active rows momentarily share a `path_hash`, so postgres rejected the rename with a unique violation surfaced as `PutFile: already exists` → `NFS4ERR_EXIST`.

This was the **only postgres-only divergence** behind pjdfstest `rename/23` (and the same index caused #190's earlier recycle failure). memory/badger have no such index and pass.

## Fix
Migration **000031** drops `unique_share_path_hash_active`. Namespace uniqueness — no two entries with the same name in a directory — is already enforced by `parent_child_map UNIQUE(parent_id, child_name)`, from which full-path uniqueness follows transitively, so the index was a redundant guard incompatible with hard links. The non-unique `idx_files_share_path_hash` lookup index is retained (path resolution on the live path goes through parent_child_map, not path_hash).

## Live validation (real postgres + kernel NFSv4.1 mount)
Reproduced the `PutFile: already exists` first; after the migration:
```
rename/23.t .. ok      chmod/03.t .... ok    chown/03.t ... ok
ftruncate/03.t ok      link/03.t ..... ok    truncate/03.t ok    unlink/03.t .. ok
All tests successful.  (index check: only idx_files_share_path_hash remains)
```
rename/23 passes with **zero regression** to the #1153 family; its KNOWN_FAILURES rows are walked back.

## Follow-up
The residual single-`path`-per-inode model is a known hard-link limitation (a surviving inode's `files.path` can go stale after overwrite); it does not affect correctness on the live data path but is worth a deeper schema refactor — tracked separately.

Closes #1160