### PR TITLE
ci(nfs/posix/e2e): Kerberos always-on; docs-only skip; cache Go builds

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,9 +15,8 @@ name: E2E Tests
 on:
   push:
     branches: [develop, main]
-  pull_request:
-    branches: [develop, main]
-    paths:
+    # Skip docs-only pushes; keep the same broad surface as the PR trigger.
+    paths: &code_paths
       - 'cmd/dfs/**'
       - 'pkg/adapter/nfs/**'
       - 'pkg/adapter/smb/**'
@@ -34,6 +33,9 @@ on:
       - 'go.sum'
       - 'flake.nix'
       - 'flake.lock'
+  pull_request:
+    branches: [develop, main]
+    paths: *code_paths
   workflow_dispatch:
 
 concurrency:
@@ -97,6 +99,12 @@ jobs:
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+
+      # Note: no actions/cache for the Go module/build cache here. E2E runs
+      # `go test` under `sudo -E`, which writes root-owned files into
+      # $HOME/.cache/go-build and $HOME/go/pkg/mod — caching those would make
+      # the post-run cache save fail on permissions. The Nix store (Go toolchain
+      # and nix-fetched deps) is already persisted via magic-nix-cache above.
 
       - name: Install system dependencies
         env:

--- a/.github/workflows/nfs-kerberos.yml
+++ b/.github/workflows/nfs-kerberos.yml
@@ -9,28 +9,32 @@ name: NFS Kerberos
 on:
   push:
     branches: [develop, main]
-    paths:
+    paths: &code_paths
+      - 'cmd/dfs/**'
+      - 'cmd/dfsctl/**'
+      - 'pkg/adapter/nfs/**'
+      - 'pkg/adapter/base.go'
       - 'internal/adapter/nfs/**'
       - 'internal/auth/kerberos/**'
       - 'pkg/auth/kerberos/**'
+      - 'pkg/metadata/**'
+      - 'pkg/block/**'
+      - 'pkg/controlplane/**'
+      - 'pkg/config/**'
       - 'test/nfs-conformance/**'
       - '.github/workflows/nfs-kerberos.yml'
+      - 'go.mod'
+      - 'go.sum'
+      - 'flake.nix'
+      - 'flake.lock'
   pull_request:
     branches: [develop, main]
-    paths:
-      - 'internal/adapter/nfs/**'
-      - 'internal/auth/kerberos/**'
-      - 'pkg/auth/kerberos/**'
-      - 'test/nfs-conformance/**'
-      - '.github/workflows/nfs-kerberos.yml'
+    paths: *code_paths
 
 jobs:
   nfs-kerberos:
     name: NFS sec=krb5 mount test
     runs-on: ubuntu-latest
-    # Initially allow failures while the baseline is being established.
-    # Remove once the first green run is confirmed.
-    continue-on-error: true
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/posix-tests.yml
+++ b/.github/workflows/posix-tests.yml
@@ -12,9 +12,8 @@ name: POSIX Compliance Tests
 on:
   push:
     branches: [develop, main]
-  pull_request:
-    branches: [develop, main]
-    paths:
+    # Skip docs-only pushes; keep the same broad surface as the PR trigger.
+    paths: &code_paths
       - 'cmd/dfs/**'
       - 'cmd/dfsctl/**'
       - 'pkg/adapter/nfs/**'
@@ -30,6 +29,9 @@ on:
       - 'go.sum'
       - 'flake.nix'
       - 'flake.lock'
+  pull_request:
+    branches: [develop, main]
+    paths: *code_paths
   schedule:
     # Weekly on Sunday at 4 AM UTC
     - cron: '0 4 * * 0'
@@ -62,6 +64,19 @@ jobs:
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+
+      # Persist the Go module + build cache across runs. The Nix CI shell's
+      # Go toolchain writes to the default $HOME cache dirs; keyed on go.sum so
+      # a dependency change invalidates it. Caches inputs only, never results.
+      - name: Cache Go build and modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-posix-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-posix-go-
 
       - name: Build DittoFS binaries
         run: |


### PR DESCRIPTION
## Summary

CI workflow improvements for the NFS/POSIX/e2e lanes. Closes the CI side of #1156 (NFS Kerberos always-on) and #1157 (docs-only skip + caching).

### `nfs-kerberos.yml` (#1156)
- Broadened the `pull_request` + `push` `paths:` from the narrow `internal/adapter/nfs/**`, `*/auth/kerberos/**`, `test/nfs-conformance/**` set to the full code surface that can affect NFS Kerberos behavior — mirrors the `posix-tests.yml` set (`cmd/dfs`, `cmd/dfsctl`, `pkg/adapter/nfs/**`, `pkg/adapter/base.go`, `internal/adapter/nfs/**`, `internal/auth/kerberos/**`, `pkg/auth/kerberos/**`, `pkg/metadata/**`, `pkg/block/**`, `pkg/controlplane/**`, `pkg/config/**`, `test/nfs-conformance/**`, the workflow file, `go.{mod,sum}`, `flake.{nix,lock}`). Net effect: runs on essentially any code change, still skips docs-only PRs/pushes. Shared between push and PR via a YAML anchor.
- **Removed `continue-on-error: true`.** Its comment said to remove it "once the first green run is confirmed." The last 10 runs are all `success`, including multiple on `develop`, and the most recent develop run actually executed the `Run NFS Kerberos tests` step (not skipped). The job now gates.

### `posix-tests.yml` (#1157)
- The `push:` trigger had **no** `paths:` filter, so the full 9-job matrix ran on every develop/main push including docs-only commits. Added the **same broad filter** the PR trigger already uses (shared via anchor), so docs-only pushes skip. The PR filter is unchanged — full backend matrix (memory + badger + postgres) is preserved.
- Added an `actions/cache@v4` step in the `build` job for `~/.cache/go-build` + `~/go/pkg/mod`, keyed on `go.sum` (the Nix `#ci` shell exports those exact paths). Inputs only — no test results cached. The `build` job runs `go build` as the runner user (no sudo), so cache save is safe.

### `e2e-tests.yml` (#1157)
- `push:` trigger had no `paths:` filter; added the same docs-only-skip filter the PR trigger already uses (shared via anchor).
- **Intentionally did NOT add a Go build/module cache here.** E2E runs `go test` under `sudo -E`, which writes root-owned files into `$HOME/.cache/go-build` and `$HOME/go/pkg/mod` — caching those would make the post-run `actions/cache` save fail on permissions. The Nix store (Go toolchain + nix-fetched deps) is already persisted via `magic-nix-cache`.

## Validation
- `actionlint` clean on all three files (anchors expand correctly; pre-existing shellcheck info/warnings in untouched script bodies only).
- KNOWN_FAILURES.md / KNOWN_FAILURES_V4.md grading untouched.

## continue-on-error decision
Removed on `nfs-kerberos.yml` — condition in the comment is met (10/10 recent runs green, including develop runs that executed the test step).
