### PR TITLE
ci(smb): persistent-backend smbtorture on PRs + broader Kerberos op coverage

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -6,6 +6,11 @@
 name: SMB Client Compatibility
 
 on:
+  # Path-scoped to SMB adapter code: docs-only changes never trigger this
+  # suite (#1157). PRs are excluded entirely (native-client mounts are too
+  # slow for the PR gate); coverage is push-to-develop + weekly + manual.
+  # Go builds here cache modules via actions/setup-go (cache: true, keyed on
+  # go.sum) in each job below.
   push:
     branches: [develop]
     paths:

--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -6,6 +6,10 @@
 name: SMB Conformance Tests
 
 on:
+  # Path-scoped to SMB/store/controlplane/auth code so docs-only and
+  # unrelated changes never trigger this heavy suite (#1157). A Kerberos-only
+  # code change must still exercise the smbtorture-kerberos job, so the auth
+  # kerberos packages are listed explicitly alongside the SMB adapter paths.
   push:
     branches: [develop]
     paths:
@@ -14,6 +18,8 @@ on:
       - 'pkg/metadata/**'
       - 'pkg/block/**'
       - 'pkg/controlplane/**'
+      - 'pkg/auth/kerberos/**'
+      - 'internal/auth/kerberos/**'
       - 'test/smb-conformance/**'
       - 'pkg/adapter/base.go'
       - '.github/workflows/smb-conformance.yml'
@@ -25,6 +31,8 @@ on:
       - 'pkg/metadata/**'
       - 'pkg/block/**'
       - 'pkg/controlplane/**'
+      - 'pkg/auth/kerberos/**'
+      - 'internal/auth/kerberos/**'
       - 'test/smb-conformance/**'
       - 'pkg/adapter/base.go'
       - '.github/workflows/smb-conformance.yml'
@@ -144,10 +152,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # smbtorture is heavy (~30+ sub-suites, 45-min budget per profile), so
+        # the PR matrix is kept lean for latency (#1157) while still giving a
+        # persistent-backend signal (#1158): memory (fastest) + badger-fs (the
+        # only PR profile that exercises the fs local store path; faster than the
+        # s3 profiles). The full set runs on push to develop and the weekly cron.
+        # workflow_dispatch runs the single chosen profile.
         profile: >-
           ${{
             github.event_name == 'pull_request'
-              && fromJson('["memory"]')
+              && fromJson('["memory", "badger-fs"]')
             || github.event_name == 'workflow_dispatch'
               && fromJson(format('["{0}"]', inputs.profile))
             || fromJson('["memory", "memory-fs", "badger-fs"]')
@@ -183,9 +197,29 @@ jobs:
           retention-days: 30
 
   smbtorture-kerberos:
-    name: smbtorture Kerberos
+    name: smbtorture Kerberos / ${{ matrix.filter }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover Kerberos-sensitive operations beyond session setup. The
+        # kerberos session key signs/encrypts every PDU, so the authenticated
+        # data path (read) and byte-range locking (lock) exercise the key past
+        # SPNEGO. These run as an explicit small set (one filter per parallel
+        # job), NOT the whole battery, to stay under the 30-min budget.
+        #
+        # smb2.create is intentionally NOT in this set: it has known failures
+        # (create.quota-fake-file, create.gentest) catalogued in
+        # KNOWN_FAILURES.md, but run.sh --kerberos only loads the
+        # session-scoped KNOWN_FAILURES_KERBEROS.md, so those expected fails
+        # would be graded as new failures and red the job. Add it here once the
+        # kerberos known-failures list covers the create suite.
+        filter:
+          - smb2.session
+          - smb2.read
+          - smb2.lock
 
     steps:
       - name: Checkout
@@ -197,17 +231,17 @@ jobs:
       - name: Run smbtorture with Kerberos
         run: |
           cd test/smb-conformance/smbtorture
-          ./run.sh --kerberos --filter smb2.session --verbose
+          ./run.sh --kerberos --filter ${{ matrix.filter }} --verbose
 
       - name: Add step summary
         if: always()
         run: |
           RESULTS_DIR=$(ls -td test/smb-conformance/results/smbtorture-*/ 2>/dev/null | head -1 || true)
           if [ -n "$RESULTS_DIR" ] && [ -f "$RESULTS_DIR/summary.txt" ]; then
-            echo "## smbtorture Kerberos" >> "$GITHUB_STEP_SUMMARY"
+            echo "## smbtorture Kerberos: ${{ matrix.filter }}" >> "$GITHUB_STEP_SUMMARY"
             cat "$RESULTS_DIR/summary.txt" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## smbtorture Kerberos" >> "$GITHUB_STEP_SUMMARY"
+            echo "## smbtorture Kerberos: ${{ matrix.filter }}" >> "$GITHUB_STEP_SUMMARY"
             echo "No results found." >> "$GITHUB_STEP_SUMMARY"
           fi
 
@@ -215,6 +249,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: smbtorture-kerberos
+          name: smbtorture-kerberos-${{ matrix.filter }}
           path: test/smb-conformance/results/smbtorture-*/
           retention-days: 30

--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -1,7 +1,9 @@
 # SMB Conformance Tests
 #
-# Runs Microsoft WPTS FileServer BVT tests against DittoFS SMB adapter.
-# Tiered matrix: memory-only on PRs, all profiles on develop push and weekly cron.
+# Runs Microsoft WPTS FileServer BVT (all profiles, every event) plus the
+# Samba smbtorture battery against the DittoFS SMB adapter. smbtorture is
+# tiered: memory + badger-fs on PRs (latency), the broader set on develop push
+# and weekly cron. A separate job runs smbtorture under Kerberos auth.
 
 name: SMB Conformance Tests
 

--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -157,13 +157,21 @@ jobs:
         # persistent-backend signal (#1158): memory (fastest) + badger-fs (the
         # only PR profile that exercises the fs local store path; faster than the
         # s3 profiles). The full set runs on push to develop and the weekly cron.
-        # workflow_dispatch runs the single chosen profile.
+        #
+        # workflow_dispatch runs the single chosen profile, but only the profiles
+        # smbtorture's run.sh actually supports (memory, memory-fs, badger-fs);
+        # the shared dispatch input also offers the s3 profiles for the WPTS job,
+        # which smbtorture rejects at profile validation — so an s3 dispatch falls
+        # back to memory here rather than failing the whole job.
         profile: >-
           ${{
             github.event_name == 'pull_request'
               && fromJson('["memory", "badger-fs"]')
-            || github.event_name == 'workflow_dispatch'
+            || (github.event_name == 'workflow_dispatch'
+                && contains(fromJson('["memory", "memory-fs", "badger-fs"]'), inputs.profile))
               && fromJson(format('["{0}"]', inputs.profile))
+            || github.event_name == 'workflow_dispatch'
+              && fromJson('["memory"]')
             || fromJson('["memory", "memory-fs", "badger-fs"]')
           }}
 


### PR DESCRIPTION
Improves the SMB CI workflows (`smb-conformance.yml`, `smb-client-compat.yml`). Covers the SMB side of #1156, #1158, and #1157.

> Re-opened from #1167, which was converted to draft and closed mid-CI run (and its branch auto-deleted). The branch/commits are identical — all 14 checks were green on this exact tree (`da9141b7`).

## smbtorture PR matrix (#1158 / latency-vs-parity #1157)
PR smbtorture went from **memory-only** to **memory + badger-fs**. badger-fs is the only PR profile that exercises the fs local store path and is faster than the s3 profiles, so PRs now get a persistent-backend signal without paying 5×45min. The **full set (`memory`, `memory-fs`, `badger-fs`) stays on push to develop and the weekly cron** — PRs deliberately do not run all 5. WPTS BVT already runs the full 5-profile matrix on PRs and is unchanged.

## Kerberos always-on + broader (#1156)
- `smbtorture-kerberos` is now a **matrix over `smb2.session` + `smb2.read` + `smb2.lock`** (parallel jobs, one filter each, each under the 30-min budget). The Kerberos session key signs/encrypts every PDU, so the authenticated read path and byte-range locking exercise the key past SPNEGO — coverage beyond session setup.
- **Dropped `smb2.create`**: it has known failures (`create.quota-fake-file`, `create.gentest`) catalogued in `KNOWN_FAILURES.md`, but `run.sh --kerberos` only loads the session-scoped `KNOWN_FAILURES_KERBEROS.md`, so those expected fails would be graded as *new* failures and red the job. It can be added once the Kerberos known-failures list covers the create suite. All three chosen filters were verified to exist as `--filter` values in `test/smb-conformance/smbtorture/run.sh`.
- Added `pkg/auth/kerberos/**` and `internal/auth/kerberos/**` to both `push` and `pull_request` path filters so a Kerberos-only code change triggers the SMB Kerberos job.

## Docs-only skip + caching (#1157)
Both workflows are already path-scoped to code, so docs-only PRs never trigger them — confirmed and documented inline in each `on:` block. `smb-conformance` jobs compile Go inside Docker (no host `setup-go`), so host module caching does not apply there; `smb-client-compat` already caches via `actions/setup-go` (`cache: true`, keyed on go.sum). No test-result caching added.

## Follow-up (Copilot review on #1167)
Clamped the smbtorture `workflow_dispatch` branch to the profiles `run.sh` actually supports (`memory`, `memory-fs`, `badger-fs`); an s3 dispatch now falls back to `memory` instead of failing the job.

YAML validated with `actionlint` — only pre-existing shellcheck style hints in untouched script blocks; no new findings.