### PR TITLE
perf(metadata): metadata-store read micro-benchmark + cache decision (#1169)

### DIFF
--- a/.planning/perf/metadata-cache-decision.md
+++ b/.planning/perf/metadata-cache-decision.md
@@ -1,0 +1,79 @@
+# Server-side metadata read cache — decision (issue #1169)
+
+Triggered by the JuiceFS architecture comparison: should DittoFS add a "Local
+Metadata Cache" like JuiceFS shows in its client diagram?
+
+## Framing (settled)
+
+- **No-FUSE is a confirmed plus** — zero client install, no kernel module.
+- **JuiceFS's "Local Metadata Cache" is client-side, RAM-only** (FUSE attr/entry
+  kernel timeouts + open-file memory). DittoFS already gets that client cache
+  **for free** from the NFS/SMB client kernel (attribute cache, dentry cache,
+  leases/oplocks/delegations); the server already emits the invalidation signals
+  (`change_info4`, ctime/mtime, SMB change-time + lease breaks). Replicating it
+  inside `dfs` would be redundant.
+- The only open question is a **server-side** read cache between the runtime and
+  the backend store. Decision gated on two questions:
+  1. Is the per-op backend read cost materially high? (micro-bench)
+  2. Is it on the realistic hot path after client caching? (e2e + server pprof)
+
+## Part 1 — metadata-store micro-benchmark (DONE)
+
+`dfsbench metadata` calls the store directly (no protocol, no client cache).
+Run: ops=20000, workers=4, tree=8 dirs × 64 files, warm. memory/badger on the
+dev laptop; postgres against a local ephemeral postgres@16 cluster over loopback
+(no network RTT — a lower bound for a real deployment).
+
+| backend | getattr p50 | lookup p50 | readdir p50 | mixed p50 | getattr ops/s |
+|---|---|---|---|---|---|
+| memory | 0.21 µs | 0.13 µs | 20 µs | 0.21 µs | 5.7 M |
+| badger | 7.7 µs | 1.4 µs | 525 µs | 6.5 µs | 366 k |
+| postgres (prep on) | 160 µs | 73 µs | 315 µs | 131 µs | 24 k |
+
+Postgres `GetFile` p50 ≈ **760× memory, ≈ 21× badger**. Loopback only — a remote
+managed postgres adds ~0.5–2 ms RTT *per query* on top, and `GetFile` issues
+1–2 queries (metadata + `loadFileBlockRefs`).
+
+**Prepared statements ruled out as the cheap fix.** prep=on vs off was within
+noise (getattr 160 µs vs 166 µs warm). The cost is the round-trip + the 2-query
+`GetFile`, not query planning — so a cache, not a pg-tuning knob, is the lever if
+one is needed.
+
+### Gate 1 verdict: MET for postgres.
+Per-op postgres read cost is materially high (100s of µs loopback, ms-class
+remote). memory is already the zero-cost floor (it *is* a RAM cache — no cache to
+add there); badger is cheap enough that a cache is marginal.
+
+## Part 2 — e2e on scw VM + server pprof (PENDING)
+
+Gate 2 — *is the cost actually hit on the realistic path* — is unanswered by the
+micro-bench, because NFS/SMB clients absorb most repeat GETATTR/LOOKUP in their
+own attr cache. Needs: dfs server (postgres metadata, `controlplane.pprof: true`)
+on a scw VM, client mount, metadata-heavy browse, scrape server `/debug/pprof`.
+
+Caveat for executing Part 2: the existing `bench/infra` competitor matrix uses
+**badger**, not postgres, and does not enable pprof — a `dittofs-postgres`
+install script + pprof config are prerequisites.
+
+## Recommendation (interim)
+
+Gate 1 is clearly met for postgres; gate 2 decides it. Two honest readings:
+
+- **If** Part 2 shows the server frequently serves cold metadata reads (cache
+  cold/insufficient client TTLs, large working sets, READDIR-heavy crawls) →
+  build an **opt-in read-through LRU+TTL in `MetadataService`**, keyed by handle
+  and (dirHandle,name), invalidated on every write/rename/remove/ACL/EA/
+  link-count change, **default off, postgres-focused**. Single-node single-writer
+  makes invalidation tractable (all mutations funnel through the runtime).
+- **If** client attr-caching already absorbs the reads (small hot sets, repeated
+  stat) → the server rarely pays this cost; **do not add the cache** (surface =
+  debt). Record the negative result.
+
+Do not commit to building the cache until Part 2 quantifies hot-path frequency.
+
+## Status
+
+- [x] Part 1 micro-bench built + run (memory/badger/postgres). Gate 1 MET.
+- [x] Prepared-statements confound measured + ruled out.
+- [ ] Part 2 e2e scw run + server pprof (needs dittofs-postgres provisioning + pprof).
+- [ ] Final verdict.

--- a/.planning/perf/metadata-cache-decision.md
+++ b/.planning/perf/metadata-cache-decision.md
@@ -44,36 +44,66 @@ Per-op postgres read cost is materially high (100s of µs loopback, ms-class
 remote). memory is already the zero-cost floor (it *is* a RAM cache — no cache to
 add there); badger is cheap enough that a cache is marginal.
 
-## Part 2 — e2e on scw VM + server pprof (PENDING)
+## Part 2 — e2e on scw VM + server pprof (DONE)
 
-Gate 2 — *is the cost actually hit on the realistic path* — is unanswered by the
-micro-bench, because NFS/SMB clients absorb most repeat GETATTR/LOOKUP in their
-own attr cache. Needs: dfs server (postgres metadata, `controlplane.pprof: true`)
-on a scw VM, client mount, metadata-heavy browse, scrape server `/debug/pprof`.
+Setup: single Scaleway VM (PRO2-XXS, 2 vCPU, Ubuntu 24.04), postgres@16 local,
+`dfs` with **postgres** metadata + fs block store + `controlplane.pprof: true`.
+NFS share `/export` mounted loopback (vers=3). Seeded 50 dirs × 400 files = 20k.
+Workload = repeated **cold** `find /mnt/bench/tree -ls` with `drop_caches` each
+pass, so the NFS client re-issues every LOOKUP/GETATTR to the server (defeats
+client attr-caching — measures the server's per-op handling cost). 30 s CPU
+profile scraped from `/debug/pprof/profile` during the browse.
 
-Caveat for executing Part 2: the existing `bench/infra` competitor matrix uses
-**badger**, not postgres, and does not enable pprof — a `dittofs-postgres`
-install script + pprof config are prerequisites.
+Standalone signal: a single cold crawl of 20k files took **~17 s** — only 2 full
+passes fit in 34 s. Metadata browse is server-bound.
 
-## Recommendation (interim)
+CPU profile (30 s, 18.77 s samples), cumulative share of dfs server CPU:
 
-Gate 1 is clearly met for postgres; gate 2 decides it. Two honest readings:
+| frame | cum % |
+|---|---|
+| NFS dispatch (`handleRPCCall`) | 70.9% |
+| `handleNFSLookup` (LOOKUP — the `find` hot op) | 64.3% |
+| `metadata.Service.Lookup` | 46.8% |
+| **`postgres.GetFile`** (the backend read) | **43.7%** |
+| pgx `Query` / `queryRow` | 39.6% / 36.6% |
+| `Syscall6` (flat — pg round-trip + NFS writes) | 31.3% (flat) |
+| `pgconn.ExecPrepared` | 27.9% |
 
-- **If** Part 2 shows the server frequently serves cold metadata reads (cache
-  cold/insufficient client TTLs, large working sets, READDIR-heavy crawls) →
-  build an **opt-in read-through LRU+TTL in `MetadataService`**, keyed by handle
-  and (dirHandle,name), invalidated on every write/rename/remove/ACL/EA/
-  link-count change, **default off, postgres-focused**. Single-node single-writer
-  makes invalidation tractable (all mutations funnel through the runtime).
-- **If** client attr-caching already absorbs the reads (small hot sets, repeated
-  stat) → the server rarely pays this cost; **do not add the cache** (surface =
-  debt). Record the negative result.
+`ExecPrepared` confirms prepared statements were active (consistent with Part 1:
+the cost is the round-trip + the GetFile query, not planning). Loopback postgres
+here — a **remote** managed pg shifts even more time into the syscall/RTT bucket.
 
-Do not commit to building the cache until Part 2 quantifies hot-path frequency.
+### Gate 2 verdict: MET.
+When the server actually handles metadata ops (NFSv3 LOOKUP → `Service.Lookup`
+→ `postgres.GetFile`), the backend read is the **dominant** server cost —
+~44% of CPU in `GetFile`, ~64% in the LOOKUP handler (mostly the pg query). A
+read-through cache on `GetFile`/`GetChild` directly attacks this.
+
+## Final verdict: BUILD the cache (opt-in, postgres-focused)
+
+Both gates met. Recommended follow-up (separate issue/PR):
+
+- **Opt-in read-through LRU+TTL cache in `MetadataService`**, in front of the
+  backend store, keyed by handle (`GetFile`) and (dirHandle,name) (`GetChild`).
+- **Write-driven invalidation** on every mutation that touches an entry —
+  write/setattr/rename/remove/link/ACL/EA/link-count. Single-node single-writer:
+  all mutations funnel through the runtime, so invalidation is tractable (no
+  distributed coherence).
+- **Default off; enable for postgres** (and any future remote metadata backend).
+  memory needs none (it *is* RAM); badger is borderline — leave it opt-in.
+- Bound the cache (entry count + TTL) so a large crawl can't pin unbounded RAM;
+  TTL also caps staleness if an invalidation path is ever missed.
+- Guard with a conformance test that asserts no stale read survives a mutation
+  (the invalidation is the only correctness risk).
+
+Caveat: this helps the *cold-cache / large-working-set / crawl* regime measured
+here. Small hot working sets are already absorbed by the NFS/SMB client attr
+cache and won't exercise the server cache — which is fine; default-off means
+deployments opt in when their workload is metadata-crawl-heavy on postgres.
 
 ## Status
 
 - [x] Part 1 micro-bench built + run (memory/badger/postgres). Gate 1 MET.
 - [x] Prepared-statements confound measured + ruled out.
-- [ ] Part 2 e2e scw run + server pprof (needs dittofs-postgres provisioning + pprof).
-- [ ] Final verdict.
+- [x] Part 2 e2e scw run + server pprof. Gate 2 MET (postgres GetFile ~44% server CPU).
+- [x] Final verdict: build opt-in read-through cache, postgres-focused, default off.

--- a/.planning/perf/metadata-cache-decision.md
+++ b/.planning/perf/metadata-cache-decision.md
@@ -79,31 +79,38 @@ When the server actually handles metadata ops (NFSv3 LOOKUP → `Service.Lookup`
 ~44% of CPU in `GetFile`, ~64% in the LOOKUP handler (mostly the pg query). A
 read-through cache on `GetFile`/`GetChild` directly attacks this.
 
-## Final verdict: BUILD the cache (opt-in, postgres-focused)
+## Verdict: query-reduction yes (#1176); cache deferred (#1173)
 
-Both gates met. Recommended follow-up (separate issue/PR):
+Both gates are technically met — but **160 µs/op is acceptable** in absolute
+terms, and the 44%-CPU figure came from a `drop_caches`-forced cold crawl (worst
+case). So the conclusion is **not** "build the cache now":
 
-- **Opt-in read-through LRU+TTL cache in `MetadataService`**, in front of the
-  backend store, keyed by handle (`GetFile`) and (dirHandle,name) (`GetChild`).
-- **Write-driven invalidation** on every mutation that touches an entry —
-  write/setattr/rename/remove/link/ACL/EA/link-count. Single-node single-writer:
-  all mutations funnel through the runtime, so invalidation is tractable (no
-  distributed coherence).
-- **Default off; enable for postgres** (and any future remote metadata backend).
-  memory needs none (it *is* RAM); badger is borderline — leave it opt-in.
-- Bound the cache (entry count + TTL) so a large crawl can't pin unbounded RAM;
-  TTL also caps staleness if an invalidation path is ever missed.
-- Guard with a conformance test that asserts no stale read survives a mutation
-  (the invalidation is the only correctness risk).
+1. **Do the cheap, unconditional win first — query-reduction (#1176).** The cost
+   is round-trip + the 2-query `GetFile`, not indexing (point lookups already) or
+   planning (prepared statements made no difference). Collapse `GetFile`'s 1–2
+   queries into one, batch READDIR hydration, review the pool. Helps *every*
+   postgres deployment, no invalidation risk. "Why not."
 
-Caveat: this helps the *cold-cache / large-working-set / crawl* regime measured
-here. Small hot working sets are already absorbed by the NFS/SMB client attr
-cache and won't exercise the server cache — which is fine; default-off means
-deployments opt in when their workload is metadata-crawl-heavy on postgres.
+2. **Defer the cache decision (#1173) pending a scaling + scale-out study.** Open
+   questions before committing: how latency/throughput hold up under concurrency;
+   whether per-op cost stays flat as the dataset grows to millions of entries;
+   and — decisively — **k8s scale-out**. Multiple `dfs` replicas sharing one
+   postgres **break the single-node single-writer assumption** that made cache
+   invalidation tractable: a per-pod cache would need cross-pod invalidation
+   (`LISTEN/NOTIFY` / pub-sub / short TTL), much harder. So the cache is *not*
+   obviously worth it in the world we actually care about, and #1176 may be the
+   better lever there.
+
+If a cache is ever built (design constraints, carried to #1173): opt-in
+read-through LRU+TTL in `MetadataService`, default off, postgres-focused,
+write-invalidated, **cross-pod-safe invalidation designed in from the start**,
+guarded by a conformance test asserting no stale read survives a mutation.
 
 ## Status
 
 - [x] Part 1 micro-bench built + run (memory/badger/postgres). Gate 1 MET.
 - [x] Prepared-statements confound measured + ruled out.
 - [x] Part 2 e2e scw run + server pprof. Gate 2 MET (postgres GetFile ~44% server CPU).
-- [x] Final verdict: build opt-in read-through cache, postgres-focused, default off.
+- [x] Verdict: query-reduction is the action (#1176); cache decision deferred
+      pending scaling + k8s scale-out study (#1173). 160 µs/op is acceptable;
+      indexing won't help (already point lookups).

--- a/bench/metadata/fixture.go
+++ b/bench/metadata/fixture.go
@@ -34,6 +34,11 @@ type PGConfig struct {
 	User     string
 	Password string
 	SSLMode  string
+	// Prepare toggles server-side prepared statements. Production defaults it
+	// true; the store's ApplyDefaults leaves a zero-value bool false, so it is
+	// set explicitly here. Measuring both isolates how much of the postgres
+	// read cost is query re-planning vs the round-trip itself.
+	Prepare bool
 }
 
 // OpenStore constructs the requested backend and returns it alongside a cleanup
@@ -61,13 +66,14 @@ func OpenStore(ctx context.Context, backend string, pg PGConfig) (metadata.Store
 
 	case BackendPostgres:
 		cfg := &postgres.PostgresMetadataStoreConfig{
-			Host:        pg.Host,
-			Port:        pg.Port,
-			Database:    pg.Database,
-			User:        pg.User,
-			Password:    pg.Password,
-			SSLMode:     pg.SSLMode,
-			AutoMigrate: true,
+			Host:              pg.Host,
+			Port:              pg.Port,
+			Database:          pg.Database,
+			User:              pg.User,
+			Password:          pg.Password,
+			SSLMode:           pg.SSLMode,
+			AutoMigrate:       true,
+			PrepareStatements: pg.Prepare,
 		}
 		s, err := postgres.NewPostgresMetadataStore(ctx, cfg, defaultCaps())
 		if err != nil {

--- a/bench/metadata/fixture.go
+++ b/bench/metadata/fixture.go
@@ -118,20 +118,17 @@ type Tree struct {
 	lookupName  []string
 }
 
-// resetter is implemented by backends that reuse a persistent database
-// (postgres). Truncating before a seed keeps reruns idempotent — without it a
-// second run collides on the share name.
-type resetter interface {
-	Reset(ctx context.Context) error
-}
-
 const benchShareName = "/bench"
 
 // seedTree populates the store with Dirs × FilesPerDir entries and returns the
 // working sets. Mirrors storetest's createTestShare/Dir/File helpers, minus the
 // *testing.T coupling so it runs from the bench binary.
 func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) (*Tree, error) {
-	if r, ok := store.(resetter); ok {
+	// All three backends implement metadata.Resetable. Truncating before a seed
+	// keeps reruns idempotent — without it a second run collides on the share
+	// name. The capability check stays so the bench survives a backend that
+	// ever omits it.
+	if r, ok := store.(metadata.Resetable); ok {
 		if err := r.Reset(ctx); err != nil {
 			return nil, fmt.Errorf("reset: %w", err)
 		}

--- a/bench/metadata/fixture.go
+++ b/bench/metadata/fixture.go
@@ -1,0 +1,234 @@
+// Package metadatabench drives read workloads directly against a
+// metadata.Store backend — no protocol, no NFS/SMB client cache in the way —
+// so per-backend GetFile / GetChild / ListChildren cost can be measured in
+// isolation. It is the decisive signal for whether a server-side metadata
+// read cache is worth building (see issue #1169): the e2e mount path is
+// masked by client attribute caching, this path is not.
+package metadatabench
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// Backend names accepted by OpenStore.
+const (
+	BackendMemory   = "memory"
+	BackendBadger   = "badger"
+	BackendPostgres = "postgres"
+)
+
+// PGConfig carries the postgres connection parameters. Defaults match the CI
+// service (.github/workflows/integration-tests.yml) so a bench reuses the same
+// database the conformance suite runs against.
+type PGConfig struct {
+	Host     string
+	Port     int
+	Database string
+	User     string
+	Password string
+	SSLMode  string
+}
+
+// OpenStore constructs the requested backend and returns it alongside a cleanup
+// func that closes the store and removes any temp on-disk state. memory is pure
+// RAM (the zero-cost floor a perfect cache would approach); badger is a local
+// embedded LSM in a temp dir; postgres connects to an existing database and
+// auto-migrates.
+func OpenStore(ctx context.Context, backend string, pg PGConfig) (metadata.Store, func(), error) {
+	switch backend {
+	case BackendMemory:
+		s := memory.NewMemoryMetadataStoreWithDefaults()
+		return s, func() { _ = s.Close() }, nil
+
+	case BackendBadger:
+		dir, err := os.MkdirTemp("", "bench-metadata-badger-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("temp dir: %w", err)
+		}
+		s, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dir)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return nil, nil, err
+		}
+		return s, func() { _ = s.Close(); _ = os.RemoveAll(dir) }, nil
+
+	case BackendPostgres:
+		cfg := &postgres.PostgresMetadataStoreConfig{
+			Host:        pg.Host,
+			Port:        pg.Port,
+			Database:    pg.Database,
+			User:        pg.User,
+			Password:    pg.Password,
+			SSLMode:     pg.SSLMode,
+			AutoMigrate: true,
+		}
+		s, err := postgres.NewPostgresMetadataStore(ctx, cfg, defaultCaps())
+		if err != nil {
+			return nil, nil, err
+		}
+		return s, func() { _ = s.Close() }, nil
+
+	default:
+		return nil, nil, fmt.Errorf("unknown backend %q (want memory|badger|postgres)", backend)
+	}
+}
+
+// defaultCaps mirrors the badger/postgres WithDefaults capability block. The
+// postgres constructor requires explicit capabilities; the values are
+// immaterial to read-latency measurement.
+func defaultCaps() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+}
+
+// tree is the seeded fixture: one share with Dirs subdirectories, each holding
+// FilesPerDir regular files. The slices are the working sets the hot loop draws
+// from — fileHandles for getattr, (lookupDir,lookupName) pairs for lookup,
+// dirHandles for readdir.
+type tree struct {
+	dirHandles  []metadata.FileHandle
+	fileHandles []metadata.FileHandle
+	lookupDir   []metadata.FileHandle
+	lookupName  []string
+}
+
+// resetter is implemented by backends that reuse a persistent database
+// (postgres). Truncating before a seed keeps reruns idempotent — without it a
+// second run collides on the share name.
+type resetter interface {
+	Reset(ctx context.Context) error
+}
+
+const benchShareName = "/bench"
+
+// seedTree populates the store with Dirs × FilesPerDir entries and returns the
+// working sets. Mirrors storetest's createTestShare/Dir/File helpers, minus the
+// *testing.T coupling so it runs from the bench binary.
+func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) (*tree, error) {
+	if r, ok := store.(resetter); ok {
+		if err := r.Reset(ctx); err != nil {
+			return nil, fmt.Errorf("reset: %w", err)
+		}
+	}
+
+	rootHandle, err := createShare(ctx, store, benchShareName)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &tree{}
+	for d := 0; d < dirs; d++ {
+		dirName := fmt.Sprintf("dir%06d", d)
+		dirHandle, err := putChild(ctx, store, benchShareName, rootHandle, dirName, metadata.FileTypeDirectory, 0o755, 2)
+		if err != nil {
+			return nil, err
+		}
+		t.dirHandles = append(t.dirHandles, dirHandle)
+
+		for f := 0; f < filesPerDir; f++ {
+			fileName := fmt.Sprintf("file%06d", f)
+			fileHandle, err := putChild(ctx, store, benchShareName, dirHandle, fileName, metadata.FileTypeRegular, 0o644, 1)
+			if err != nil {
+				return nil, err
+			}
+			t.fileHandles = append(t.fileHandles, fileHandle)
+			t.lookupDir = append(t.lookupDir, dirHandle)
+			t.lookupName = append(t.lookupName, fileName)
+		}
+	}
+	return t, nil
+}
+
+// createShare creates a share + its root directory and returns the root handle.
+func createShare(ctx context.Context, store metadata.Store, shareName string) (metadata.FileHandle, error) {
+	if err := store.CreateShare(ctx, &metadata.Share{Name: shareName}); err != nil {
+		return nil, fmt.Errorf("CreateShare(%q): %w", shareName, err)
+	}
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CreateRootDirectory(%q): %w", shareName, err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	if err != nil {
+		return nil, fmt.Errorf("EncodeFileHandle: %w", err)
+	}
+	return rootHandle, nil
+}
+
+// putChild creates one directory or regular file under parentHandle and wires
+// the parent/child/link-count edges, mirroring storetest.createTestFile/Dir.
+func putChild(ctx context.Context, store metadata.Store, shareName string, parentHandle metadata.FileHandle, name string, ftype metadata.FileType, mode uint32, nlink uint32) (metadata.FileHandle, error) {
+	fullPath, err := childFullPath(ctx, store, parentHandle, name)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateHandle(%q): %w", fullPath, err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, fmt.Errorf("DecodeFileHandle: %w", err)
+	}
+	file := &metadata.File{
+		ShareName: shareName,
+		Path:      fullPath,
+		FileAttr: metadata.FileAttr{
+			Type: ftype,
+			Mode: mode,
+			UID:  1000,
+			GID:  1000,
+		},
+	}
+	file.ID = id
+	if err := store.PutFile(ctx, file); err != nil {
+		return nil, fmt.Errorf("PutFile(%q): %w", fullPath, err)
+	}
+	if err := store.SetParent(ctx, handle, parentHandle); err != nil {
+		return nil, fmt.Errorf("SetParent(%q): %w", fullPath, err)
+	}
+	if err := store.SetChild(ctx, parentHandle, name, handle); err != nil {
+		return nil, fmt.Errorf("SetChild(%q): %w", name, err)
+	}
+	if err := store.SetLinkCount(ctx, handle, nlink); err != nil {
+		return nil, fmt.Errorf("SetLinkCount(%q): %w", fullPath, err)
+	}
+	return handle, nil
+}
+
+// childFullPath joins the parent directory's path with name so path-keyed
+// backends (postgres) get a unique, non-empty path per entry.
+func childFullPath(ctx context.Context, store metadata.Store, parentHandle metadata.FileHandle, name string) (string, error) {
+	parent, err := store.GetFile(ctx, parentHandle)
+	if err != nil {
+		return "", fmt.Errorf("GetFile(parent): %w", err)
+	}
+	parentPath := parent.Path
+	if parentPath == "" || parentPath == "/" {
+		return "/" + name, nil
+	}
+	return parentPath + "/" + name, nil
+}

--- a/bench/metadata/fixture.go
+++ b/bench/metadata/fixture.go
@@ -111,7 +111,7 @@ func defaultCaps() metadata.FilesystemCapabilities {
 // FilesPerDir regular files. The slices are the working sets the hot loop draws
 // from — fileHandles for getattr, (lookupDir,lookupName) pairs for lookup,
 // dirHandles for readdir.
-type tree struct {
+type Tree struct {
 	dirHandles  []metadata.FileHandle
 	fileHandles []metadata.FileHandle
 	lookupDir   []metadata.FileHandle
@@ -130,7 +130,7 @@ const benchShareName = "/bench"
 // seedTree populates the store with Dirs × FilesPerDir entries and returns the
 // working sets. Mirrors storetest's createTestShare/Dir/File helpers, minus the
 // *testing.T coupling so it runs from the bench binary.
-func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) (*tree, error) {
+func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) (*Tree, error) {
 	if r, ok := store.(resetter); ok {
 		if err := r.Reset(ctx); err != nil {
 			return nil, fmt.Errorf("reset: %w", err)
@@ -142,10 +142,11 @@ func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) 
 		return nil, err
 	}
 
-	t := &tree{}
+	t := &Tree{}
 	for d := 0; d < dirs; d++ {
 		dirName := fmt.Sprintf("dir%06d", d)
-		dirHandle, err := putChild(ctx, store, benchShareName, rootHandle, dirName, metadata.FileTypeDirectory, 0o755, 2)
+		dirPath := joinPath("/", dirName)
+		dirHandle, err := putChild(ctx, store, rootHandle, dirPath, dirName, metadata.FileTypeDirectory, 0o755, 2)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +154,8 @@ func seedTree(ctx context.Context, store metadata.Store, dirs, filesPerDir int) 
 
 		for f := 0; f < filesPerDir; f++ {
 			fileName := fmt.Sprintf("file%06d", f)
-			fileHandle, err := putChild(ctx, store, benchShareName, dirHandle, fileName, metadata.FileTypeRegular, 0o644, 1)
+			filePath := joinPath(dirPath, fileName)
+			fileHandle, err := putChild(ctx, store, dirHandle, filePath, fileName, metadata.FileTypeRegular, 0o644, 1)
 			if err != nil {
 				return nil, err
 			}
@@ -184,14 +186,14 @@ func createShare(ctx context.Context, store metadata.Store, shareName string) (m
 	return rootHandle, nil
 }
 
-// putChild creates one directory or regular file under parentHandle and wires
-// the parent/child/link-count edges, mirroring storetest.createTestFile/Dir.
-func putChild(ctx context.Context, store metadata.Store, shareName string, parentHandle metadata.FileHandle, name string, ftype metadata.FileType, mode uint32, nlink uint32) (metadata.FileHandle, error) {
-	fullPath, err := childFullPath(ctx, store, parentHandle, name)
-	if err != nil {
-		return nil, err
-	}
-	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
+// putChild creates one directory or regular file at fullPath under
+// parentHandle and wires the parent/child/link-count edges, mirroring
+// storetest.createTestFile/Dir. fullPath is the entry's absolute path; it is
+// supplied by the caller (rather than re-derived from the store) so path-keyed
+// backends (postgres) get a unique, non-empty path per entry without an extra
+// round-trip during seeding.
+func putChild(ctx context.Context, store metadata.Store, parentHandle metadata.FileHandle, fullPath, name string, ftype metadata.FileType, mode uint32, nlink uint32) (metadata.FileHandle, error) {
+	handle, err := store.GenerateHandle(ctx, benchShareName, fullPath)
 	if err != nil {
 		return nil, fmt.Errorf("GenerateHandle(%q): %w", fullPath, err)
 	}
@@ -200,7 +202,7 @@ func putChild(ctx context.Context, store metadata.Store, shareName string, paren
 		return nil, fmt.Errorf("DecodeFileHandle: %w", err)
 	}
 	file := &metadata.File{
-		ShareName: shareName,
+		ShareName: benchShareName,
 		Path:      fullPath,
 		FileAttr: metadata.FileAttr{
 			Type: ftype,
@@ -225,16 +227,11 @@ func putChild(ctx context.Context, store metadata.Store, shareName string, paren
 	return handle, nil
 }
 
-// childFullPath joins the parent directory's path with name so path-keyed
-// backends (postgres) get a unique, non-empty path per entry.
-func childFullPath(ctx context.Context, store metadata.Store, parentHandle metadata.FileHandle, name string) (string, error) {
-	parent, err := store.GetFile(ctx, parentHandle)
-	if err != nil {
-		return "", fmt.Errorf("GetFile(parent): %w", err)
+// joinPath joins a parent directory path with a child name, collapsing the
+// root ("" or "/") so children of root come out as "/name", not "//name".
+func joinPath(parent, name string) string {
+	if parent == "" || parent == "/" {
+		return "/" + name
 	}
-	parentPath := parent.Path
-	if parentPath == "" || parentPath == "/" {
-		return "/" + name, nil
-	}
-	return parentPath + "/" + name, nil
+	return parent + "/" + name
 }

--- a/bench/metadata/workloads.go
+++ b/bench/metadata/workloads.go
@@ -72,17 +72,37 @@ func (o *Opts) Validate() error {
 	return nil
 }
 
-// Run seeds a Dirs × FilesPerDir tree, then drives Ops read operations across
-// Workers goroutines against the shared store, recording per-op latency. The
-// timed region covers only the hot loop — seeding is excluded.
-func Run(ctx context.Context, store metadata.Store, opts Opts) (Result, error) {
+// Seed populates the store with a Dirs × FilesPerDir tree and returns the
+// working sets the hot loop draws from. It is separated from RunOnTree so a
+// caller can wrap only the read loop in a pprof capture — seeding's write-path
+// samples would otherwise pollute the profile.
+func Seed(ctx context.Context, store metadata.Store, opts Opts) (*Tree, error) {
 	if err := opts.Validate(); err != nil {
-		return Result{}, err
+		return nil, err
 	}
-
 	t, err := seedTree(ctx, store, opts.Dirs, opts.FilesPerDir)
 	if err != nil {
-		return Result{}, fmt.Errorf("seed: %w", err)
+		return nil, fmt.Errorf("seed: %w", err)
+	}
+	return t, nil
+}
+
+// Run seeds a tree then drives the read workload — convenience for tests. The
+// CLI uses Seed + RunOnTree so the profile excludes seeding.
+func Run(ctx context.Context, store metadata.Store, opts Opts) (Result, error) {
+	t, err := Seed(ctx, store, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	return RunOnTree(ctx, store, t, opts)
+}
+
+// RunOnTree drives Ops read operations across Workers goroutines against the
+// shared store and the pre-seeded tree, recording per-op latency. The timed
+// region covers only the hot loop.
+func RunOnTree(ctx context.Context, store metadata.Store, t *Tree, opts Opts) (Result, error) {
+	if err := opts.Validate(); err != nil {
+		return Result{}, err
 	}
 
 	rec := bsbench.NewLatencyRecorder(opts.Ops)
@@ -143,7 +163,7 @@ func pickOp(workload string, rng *rand.Rand) string {
 
 // runOp executes one read against the store. readdir paginates the chosen
 // directory to completion so the cost reflects a full listing.
-func runOp(ctx context.Context, store metadata.Store, op string, t *tree, rng *rand.Rand, limit int) error {
+func runOp(ctx context.Context, store metadata.Store, op string, t *Tree, rng *rand.Rand, limit int) error {
 	switch op {
 	case WorkloadGetAttr:
 		h := t.fileHandles[rng.Intn(len(t.fileHandles))]

--- a/bench/metadata/workloads.go
+++ b/bench/metadata/workloads.go
@@ -1,0 +1,171 @@
+package metadatabench
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	bsbench "github.com/marmos91/dittofs/bench/blockstore"
+	"github.com/marmos91/dittofs/bench/orchestrator"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Workload names. Each isolates one hot metadata read, plus a browse-like
+// blend. The store is called directly, so the numbers reflect pure backend
+// cost with no client attribute cache absorbing repeats.
+const (
+	WorkloadGetAttr = "getattr" // store.GetFile over the file working set
+	WorkloadLookup  = "lookup"  // store.GetChild(dir, name)
+	WorkloadReadDir = "readdir" // store.ListChildren, paginated to completion
+	WorkloadMixed   = "mixed"   // browse blend: 45% lookup, 45% getattr, 10% readdir
+)
+
+// DefaultReaddirLimit is the page size for the readdir workload when unset.
+const DefaultReaddirLimit = 256
+
+// Opts configures one bench run.
+type Opts struct {
+	Backend      string
+	Workload     string
+	Ops          int
+	Workers      int
+	Seed         uint64
+	Dirs         int
+	FilesPerDir  int
+	ReaddirLimit int
+}
+
+// Result is one run's aggregate. Latency is nil only when Ops is 0.
+type Result struct {
+	Backend  string
+	Workload string
+	Ops      int
+	Duration time.Duration
+	Latency  *orchestrator.Latency
+	Errors   int64
+}
+
+// Validate fills defaults and rejects nonsensical opts.
+func (o *Opts) Validate() error {
+	switch o.Workload {
+	case WorkloadGetAttr, WorkloadLookup, WorkloadReadDir, WorkloadMixed:
+	default:
+		return fmt.Errorf("unknown workload %q (want getattr|lookup|readdir|mixed)", o.Workload)
+	}
+	if o.Ops <= 0 {
+		return fmt.Errorf("ops must be > 0")
+	}
+	if o.Workers < 1 {
+		o.Workers = 1
+	}
+	if o.Dirs < 1 {
+		o.Dirs = 1
+	}
+	if o.FilesPerDir < 1 {
+		o.FilesPerDir = 1
+	}
+	if o.ReaddirLimit <= 0 {
+		o.ReaddirLimit = DefaultReaddirLimit
+	}
+	return nil
+}
+
+// Run seeds a Dirs × FilesPerDir tree, then drives Ops read operations across
+// Workers goroutines against the shared store, recording per-op latency. The
+// timed region covers only the hot loop — seeding is excluded.
+func Run(ctx context.Context, store metadata.Store, opts Opts) (Result, error) {
+	if err := opts.Validate(); err != nil {
+		return Result{}, err
+	}
+
+	t, err := seedTree(ctx, store, opts.Dirs, opts.FilesPerDir)
+	if err != nil {
+		return Result{}, fmt.Errorf("seed: %w", err)
+	}
+
+	rec := bsbench.NewLatencyRecorder(opts.Ops)
+	perWorker := opts.Ops / opts.Workers
+	remainder := opts.Ops % opts.Workers
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for w := 0; w < opts.Workers; w++ {
+		count := perWorker
+		if w < remainder {
+			count++
+		}
+		wg.Add(1)
+		go func(workerID, n int) {
+			defer wg.Done()
+			// Per-worker PRNG keyed off the run seed so a worker's access
+			// stream is deterministic and replayable, but workers don't
+			// march in lockstep over the same indices.
+			rng := rand.New(rand.NewSource(int64(opts.Seed) + int64(workerID)))
+			for i := 0; i < n; i++ {
+				op := pickOp(opts.Workload, rng)
+				started := time.Now()
+				err := runOp(ctx, store, op, t, rng, opts.ReaddirLimit)
+				rec.Record(time.Since(started), err == nil)
+			}
+		}(w, count)
+	}
+	wg.Wait()
+	dur := time.Since(start)
+
+	_, failed := rec.Counts()
+	return Result{
+		Backend:  opts.Backend,
+		Workload: opts.Workload,
+		Ops:      opts.Ops,
+		Duration: dur,
+		Latency:  orchestrator.LatencyFromSamples(rec.Samples()),
+		Errors:   failed,
+	}, nil
+}
+
+// pickOp resolves the per-iteration operation. Single-op workloads return
+// themselves; mixed rolls the browse blend.
+func pickOp(workload string, rng *rand.Rand) string {
+	if workload != WorkloadMixed {
+		return workload
+	}
+	switch roll := rng.Intn(100); {
+	case roll < 45:
+		return WorkloadLookup
+	case roll < 90:
+		return WorkloadGetAttr
+	default:
+		return WorkloadReadDir
+	}
+}
+
+// runOp executes one read against the store. readdir paginates the chosen
+// directory to completion so the cost reflects a full listing.
+func runOp(ctx context.Context, store metadata.Store, op string, t *tree, rng *rand.Rand, limit int) error {
+	switch op {
+	case WorkloadGetAttr:
+		h := t.fileHandles[rng.Intn(len(t.fileHandles))]
+		_, err := store.GetFile(ctx, h)
+		return err
+	case WorkloadLookup:
+		i := rng.Intn(len(t.lookupDir))
+		_, err := store.GetChild(ctx, t.lookupDir[i], t.lookupName[i])
+		return err
+	case WorkloadReadDir:
+		d := t.dirHandles[rng.Intn(len(t.dirHandles))]
+		cursor := ""
+		for {
+			_, next, err := store.ListChildren(ctx, d, cursor, limit)
+			if err != nil {
+				return err
+			}
+			if next == "" {
+				return nil
+			}
+			cursor = next
+		}
+	}
+	return nil
+}

--- a/bench/metadata/workloads.go
+++ b/bench/metadata/workloads.go
@@ -37,7 +37,8 @@ type Opts struct {
 	ReaddirLimit int
 }
 
-// Result is one run's aggregate. Latency is nil only when Ops is 0.
+// Result is one run's aggregate. Latency is always populated for a successful
+// run (Validate rejects Ops <= 0 and every op records a sample).
 type Result struct {
 	Backend  string
 	Workload string

--- a/bench/metadata/workloads_test.go
+++ b/bench/metadata/workloads_test.go
@@ -1,0 +1,75 @@
+package metadatabench
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRun_HermeticBackends smoke-tests every workload against the two backends
+// that need no external service (memory + badger in a temp dir), so
+// `go test ./bench/metadata/...` is self-contained. Postgres is exercised
+// manually via `dfsbench metadata --backend postgres` against a live DB.
+func TestRun_HermeticBackends(t *testing.T) {
+	backends := []string{BackendMemory, BackendBadger}
+	workloads := []string{WorkloadGetAttr, WorkloadLookup, WorkloadReadDir, WorkloadMixed}
+
+	for _, backend := range backends {
+		for _, workload := range workloads {
+			name := backend + "/" + workload
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+				store, cleanup, err := OpenStore(ctx, backend, PGConfig{})
+				if err != nil {
+					t.Fatalf("OpenStore(%s): %v", backend, err)
+				}
+				defer cleanup()
+
+				res, err := Run(ctx, store, Opts{
+					Backend:     backend,
+					Workload:    workload,
+					Ops:         500,
+					Workers:     4,
+					Seed:        1,
+					Dirs:        4,
+					FilesPerDir: 25,
+				})
+				if err != nil {
+					t.Fatalf("Run: %v", err)
+				}
+				if res.Errors != 0 {
+					t.Errorf("got %d op errors, want 0", res.Errors)
+				}
+				if res.Ops != 500 {
+					t.Errorf("Ops = %d, want 500", res.Ops)
+				}
+				if res.Latency == nil {
+					t.Fatal("Latency is nil, want populated percentiles")
+				}
+				if res.Latency.P50Ns <= 0 || res.Latency.P99Ns < res.Latency.P50Ns {
+					t.Errorf("bad latency block: p50=%d p95=%d p99=%d",
+						res.Latency.P50Ns, res.Latency.P95Ns, res.Latency.P99Ns)
+				}
+			})
+		}
+	}
+}
+
+// TestRun_RerunIdempotent verifies a backend can be seeded twice in a row
+// (the reset path for persistent stores; a no-op for memory/badger).
+func TestRun_RerunIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store, cleanup, err := OpenStore(ctx, BackendMemory, PGConfig{})
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer cleanup()
+
+	for i := 0; i < 2; i++ {
+		if _, err := Run(ctx, store, Opts{
+			Backend: BackendMemory, Workload: WorkloadMixed,
+			Ops: 100, Workers: 2, Dirs: 2, FilesPerDir: 10,
+		}); err != nil {
+			t.Fatalf("Run #%d: %v", i, err)
+		}
+	}
+}

--- a/bench/metadata/workloads_test.go
+++ b/bench/metadata/workloads_test.go
@@ -45,7 +45,11 @@ func TestRun_HermeticBackends(t *testing.T) {
 				if res.Latency == nil {
 					t.Fatal("Latency is nil, want populated percentiles")
 				}
-				if res.Latency.P50Ns <= 0 || res.Latency.P99Ns < res.Latency.P50Ns {
+				// Percentiles must be non-negative and monotonic. A zero is
+				// valid: an in-RAM op can be faster than the platform clock's
+				// resolution (notably Windows' coarse timer), so p50/p95
+				// legitimately read 0ns.
+				if res.Latency.P50Ns < 0 || res.Latency.P95Ns < res.Latency.P50Ns || res.Latency.P99Ns < res.Latency.P95Ns {
 					t.Errorf("bad latency block: p50=%d p95=%d p99=%d",
 						res.Latency.P50Ns, res.Latency.P95Ns, res.Latency.P99Ns)
 				}

--- a/cmd/bench/blockstore.go
+++ b/cmd/bench/blockstore.go
@@ -136,7 +136,7 @@ func runStormWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer engineClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func runConcurrentWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench
 	}
 	defer engineClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func runEngineWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opt
 	}
 	defer engineClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ func runLocalWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer closeFn()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func runGCWorkload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts) e
 	}
 	defer remoteClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func runRawS3Workload(ctx context.Context, cmd *cobra.Command, opts bsbench.Opts
 	}
 	defer remoteClose()
 
-	sess, err := startProfileSession(opts.ProfileDir, bsPhase, opts.Workload, bsFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", bsPhase, opts.Workload, bsFullProfiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -32,7 +32,7 @@ var rootCmd = &cobra.Command{
   blockstore   local fs + remote + syncer (implemented)
   gc           garbage collection (stub)
   snapshots    reference-CAS snapshots (stub)
-  metadata     listings, rename, links, ACL (stub)
+  metadata     store read latency: getattr / lookup / readdir (implemented)
   adapters     NFS / SMB framing perf (stub)
   e2e          real NFS / SMB clients driving fio, iozone, smbtorture-perf (stub)
 

--- a/cmd/bench/metadata.go
+++ b/cmd/bench/metadata.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	mdbench "github.com/marmos91/dittofs/bench/metadata"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mdBackend      string
+	mdWorkload     string
+	mdOps          int
+	mdWorkers      int
+	mdSeed         uint64
+	mdDirs         int
+	mdFilesPerDir  int
+	mdReaddirLimit int
+	mdPhase        string
+	mdFullProfiles bool
+
+	// Postgres connection. Defaults match the CI service
+	// (.github/workflows/integration-tests.yml) so a bench reuses the same
+	// database the conformance suite runs against.
+	mdPGHost     string
+	mdPGPort     int
+	mdPGDatabase string
+	mdPGUser     string
+	mdPGPassword string
+	mdPGSSLMode  string
+)
+
+var metadataCmd = &cobra.Command{
+	Use:   "metadata",
+	Short: "Drive a read workload directly against a metadata store backend",
+	Long: `Measures per-backend metadata read cost (GetFile / GetChild / ListChildren)
+by calling the store directly — no NFS/SMB protocol, no client attribute cache
+in the way. This is the decisive signal for whether a server-side metadata read
+cache is worth building (issue #1169): the e2e mount path is masked by client
+caching, this path is not.
+
+Backends:
+  memory     pure RAM — the zero-cost floor a perfect cache would approach
+  badger     local embedded LSM in a temp dir
+  postgres   connects to an existing database (--pg-*), auto-migrates, resets first
+
+Workloads:
+  getattr    store.GetFile over the seeded file working set
+  lookup     store.GetChild(dir, name)
+  readdir    store.ListChildren, paginated to completion
+  mixed      browse blend: 45% lookup, 45% getattr, 10% readdir
+
+Captures cpu + heap + goroutine pprof (plus mutex + block with --full-profiles)
+to <profile-dir>/metadata/[<phase>/]<workload>-<timestamp>/.`,
+	RunE: runMetadata,
+}
+
+func init() {
+	f := metadataCmd.Flags()
+	f.StringVar(&mdBackend, "backend", mdbench.BackendMemory, "backend: memory | badger | postgres")
+	f.StringVar(&mdWorkload, "workload", mdbench.WorkloadMixed, "workload: getattr | lookup | readdir | mixed")
+	f.IntVar(&mdOps, "ops", 100000, "number of read operations to time")
+	f.IntVar(&mdWorkers, "workers", 1, "concurrent worker goroutines")
+	f.Uint64Var(&mdSeed, "seed", 1, "PRNG seed for the access stream")
+	f.IntVar(&mdDirs, "dirs", 16, "number of directories to seed")
+	f.IntVar(&mdFilesPerDir, "files-per-dir", 256, "files seeded per directory")
+	f.IntVar(&mdReaddirLimit, "readdir-limit", mdbench.DefaultReaddirLimit, "page size for the readdir workload")
+	f.StringVar(&mdPhase, "phase", "", "optional capture phase subdir under <profile-dir>/metadata/ (e.g. baseline | post-fix)")
+	f.BoolVar(&mdFullProfiles, "full-profiles", false, "also capture mutex + block profiles (adds runtime overhead)")
+
+	f.StringVar(&mdPGHost, "pg-host", "localhost", "postgres host")
+	f.IntVar(&mdPGPort, "pg-port", 5432, "postgres port")
+	f.StringVar(&mdPGDatabase, "pg-dbname", "dittofs_test", "postgres database")
+	f.StringVar(&mdPGUser, "pg-user", "postgres", "postgres user")
+	f.StringVar(&mdPGPassword, "pg-password", "postgres", "postgres password")
+	f.StringVar(&mdPGSSLMode, "pg-sslmode", "disable", "postgres sslmode")
+}
+
+func runMetadata(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	opts := mdbench.Opts{
+		Backend:      mdBackend,
+		Workload:     mdWorkload,
+		Ops:          mdOps,
+		Workers:      mdWorkers,
+		Seed:         mdSeed,
+		Dirs:         mdDirs,
+		FilesPerDir:  mdFilesPerDir,
+		ReaddirLimit: mdReaddirLimit,
+	}
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	store, cleanup, err := mdbench.OpenStore(ctx, mdBackend, mdbench.PGConfig{
+		Host:     mdPGHost,
+		Port:     mdPGPort,
+		Database: mdPGDatabase,
+		User:     mdPGUser,
+		Password: mdPGPassword,
+		SSLMode:  mdPGSSLMode,
+	})
+	if err != nil {
+		return fmt.Errorf("open %s store: %w", mdBackend, err)
+	}
+	defer cleanup()
+
+	sess, err := startProfileSession(flagProfileDir, "metadata", mdPhase, mdWorkload, mdFullProfiles)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.stop() }()
+	if err := writeMetadataSeed(sess.dir, opts); err != nil {
+		return err
+	}
+
+	res, err := mdbench.Run(ctx, store, opts)
+	if stopErr := sess.stop(); err == nil {
+		err = stopErr
+	}
+	if err != nil {
+		return err
+	}
+
+	printMetadataResult(cmd, res, sess.dir)
+	return nil
+}
+
+// printMetadataResult emits one machine-parseable line. Latency percentiles are
+// reported in microseconds for readability; raw ns live in the pprof captures.
+func printMetadataResult(cmd *cobra.Command, res mdbench.Result, profDir string) {
+	durMs := float64(res.Duration.Microseconds()) / 1000.0
+	opsPerSec := float64(res.Ops) / res.Duration.Seconds()
+	var p50, p95, p99 float64
+	if res.Latency != nil {
+		p50 = float64(res.Latency.P50Ns) / 1000.0
+		p95 = float64(res.Latency.P95Ns) / 1000.0
+		p99 = float64(res.Latency.P99Ns) / 1000.0
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"backend=%s workload=%s ops=%d dur=%.3fms ops_per_sec=%.2f p50_us=%.3f p95_us=%.3f p99_us=%.3f errors=%d profiles=%s\n",
+		res.Backend, res.Workload, res.Ops, durMs, opsPerSec, p50, p95, p99, res.Errors, profDir,
+	)
+}
+
+// writeMetadataSeed records the run parameters next to the profiles so a
+// capture is self-describing. Mirrors the blockstore seed.txt convention.
+func writeMetadataSeed(dir string, opts mdbench.Opts) error {
+	body := fmt.Sprintf(
+		"backend=%s\nworkload=%s\nops=%d\nworkers=%d\nseed=%d\ndirs=%d\nfiles_per_dir=%d\nreaddir_limit=%d\n",
+		opts.Backend, opts.Workload, opts.Ops, opts.Workers, opts.Seed, opts.Dirs, opts.FilesPerDir, opts.ReaddirLimit,
+	)
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write seed.txt: %w", err)
+	}
+	return nil
+}

--- a/cmd/bench/metadata.go
+++ b/cmd/bench/metadata.go
@@ -31,6 +31,7 @@ var (
 	mdPGUser     string
 	mdPGPassword string
 	mdPGSSLMode  string
+	mdPGPrepare  bool
 )
 
 var metadataCmd = &cobra.Command{
@@ -77,6 +78,7 @@ func init() {
 	f.StringVar(&mdPGUser, "pg-user", "postgres", "postgres user")
 	f.StringVar(&mdPGPassword, "pg-password", "postgres", "postgres password")
 	f.StringVar(&mdPGSSLMode, "pg-sslmode", "disable", "postgres sslmode")
+	f.BoolVar(&mdPGPrepare, "pg-prepare", true, "use server-side prepared statements (production default)")
 }
 
 func runMetadata(cmd *cobra.Command, _ []string) error {
@@ -106,6 +108,7 @@ func runMetadata(cmd *cobra.Command, _ []string) error {
 		User:     mdPGUser,
 		Password: mdPGPassword,
 		SSLMode:  mdPGSSLMode,
+		Prepare:  mdPGPrepare,
 	})
 	if err != nil {
 		return fmt.Errorf("open %s store: %w", mdBackend, err)

--- a/cmd/bench/metadata.go
+++ b/cmd/bench/metadata.go
@@ -115,6 +115,13 @@ func runMetadata(cmd *cobra.Command, _ []string) error {
 	}
 	defer cleanup()
 
+	// Seed before starting the profile session so the capture reflects only the
+	// read hot loop, not the write-path samples of building the fixture tree.
+	tree, err := mdbench.Seed(ctx, store, opts)
+	if err != nil {
+		return err
+	}
+
 	sess, err := startProfileSession(flagProfileDir, "metadata", mdPhase, mdWorkload, mdFullProfiles)
 	if err != nil {
 		return err
@@ -124,7 +131,7 @@ func runMetadata(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	res, err := mdbench.Run(ctx, store, opts)
+	res, err := mdbench.RunOnTree(ctx, store, tree, opts)
 	if stopErr := sess.stop(); err == nil {
 		err = stopErr
 	}

--- a/cmd/bench/orchestrate.go
+++ b/cmd/bench/orchestrate.go
@@ -248,7 +248,7 @@ func runOneWorkload(ctx context.Context, opts bsbench.Opts, tmpDir string) (bsbe
 
 // capture wraps fn in a profile session and returns the result + profile dir.
 func capture(opts bsbench.Opts, fn func() (bsbench.Result, error)) (bsbench.Result, string, error) {
-	sess, err := startProfileSession(opts.ProfileDir, orchPhase, opts.Workload, orchFullProfiles)
+	sess, err := startProfileSession(opts.ProfileDir, "blockstore", orchPhase, opts.Workload, orchFullProfiles)
 	if err != nil {
 		return bsbench.Result{}, "", err
 	}

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -51,8 +51,11 @@ const (
 // once, after the timed region, to flush every profile and restore runtime
 // profiler state. On error the partially-started session is rolled back.
 func startProfileSession(rootDir, area, phase, workload string, full bool) (*profileSession, error) {
-	// phase is a single directory name, not a path: reject separators / "."/".."
-	// so a stray --phase can't escape <rootDir>/<area> via filepath.Join.
+	// area and phase are single directory names, not paths: reject separators /
+	// "."/".." so neither can escape <rootDir> via filepath.Join.
+	if area == "" || area != filepath.Base(area) || area == "." || area == ".." {
+		return nil, fmt.Errorf("invalid area %q: must be a single path element", area)
+	}
 	if phase != "" && (phase != filepath.Base(phase) || phase == "." || phase == "..") {
 		return nil, fmt.Errorf("invalid phase %q: must be a single path element", phase)
 	}

--- a/cmd/bench/profiles.go
+++ b/cmd/bench/profiles.go
@@ -42,21 +42,22 @@ const (
 	blockProfileRate = 1
 )
 
-// startProfileSession creates <root>/blockstore/[<phase>/]<workload>-<UTC-ts>/
-// and begins CPU profiling. When phase is non-empty (e.g. "baseline" or
-// "post-fix") it is inserted as a parent directory so before/after captures
-// sit side by side. When full is set it also turns on the mutex and block
-// profilers. The caller must invoke stop() exactly once, after the timed
-// region, to flush every profile and restore runtime profiler state. On error
-// the partially-started session is rolled back.
-func startProfileSession(rootDir, phase, workload string, full bool) (*profileSession, error) {
+// startProfileSession creates <root>/<area>/[<phase>/]<workload>-<UTC-ts>/
+// and begins CPU profiling. area names the bench family ("blockstore",
+// "metadata", …) so captures from different areas don't collide. When phase is
+// non-empty (e.g. "baseline" or "post-fix") it is inserted as a parent
+// directory so before/after captures sit side by side. When full is set it also
+// turns on the mutex and block profilers. The caller must invoke stop() exactly
+// once, after the timed region, to flush every profile and restore runtime
+// profiler state. On error the partially-started session is rolled back.
+func startProfileSession(rootDir, area, phase, workload string, full bool) (*profileSession, error) {
 	// phase is a single directory name, not a path: reject separators / "."/".."
-	// so a stray --phase can't escape <rootDir>/blockstore via filepath.Join.
+	// so a stray --phase can't escape <rootDir>/<area> via filepath.Join.
 	if phase != "" && (phase != filepath.Base(phase) || phase == "." || phase == "..") {
 		return nil, fmt.Errorf("invalid phase %q: must be a single path element", phase)
 	}
 	ts := time.Now().UTC().Format("20060102T150405Z")
-	parts := []string{rootDir, "blockstore"}
+	parts := []string{rootDir, area}
 	if phase != "" {
 		parts = append(parts, phase)
 	}

--- a/cmd/bench/profiles_test.go
+++ b/cmd/bench/profiles_test.go
@@ -16,7 +16,7 @@ import (
 // does NOT write mutex/block.
 func TestProfileSession_BasicProfilesNonEmpty(t *testing.T) {
 	root := t.TempDir()
-	sess, err := startProfileSession(root, "", "unit", false)
+	sess, err := startProfileSession(root, "blockstore", "", "unit", false)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestProfileSession_BasicProfilesNonEmpty(t *testing.T) {
 // contention here proves the session enables them.
 func TestProfileSession_FullProfilesNonEmpty(t *testing.T) {
 	root := t.TempDir()
-	sess, err := startProfileSession(root, "", "unit-full", true)
+	sess, err := startProfileSession(root, "blockstore", "", "unit-full", true)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestProfileSession_FullProfilesNonEmpty(t *testing.T) {
 // TestProfileSession_StopIdempotent confirms the deferred safety stop is
 // a no-op once the happy-path stop has run.
 func TestProfileSession_StopIdempotent(t *testing.T) {
-	sess, err := startProfileSession(t.TempDir(), "", "unit-idem", false)
+	sess, err := startProfileSession(t.TempDir(), "blockstore", "", "unit-idem", false)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestStartProfileSession_PhaseSubdir(t *testing.T) {
 	root := t.TempDir()
 	// Only one CPU profile can be active per process, so each session is
 	// stopped before the next starts.
-	sess, err := startProfileSession(root, "baseline", "wl", false)
+	sess, err := startProfileSession(root, "blockstore", "baseline", "wl", false)
 	if err != nil {
 		t.Fatalf("startProfileSession: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestStartProfileSession_PhaseSubdir(t *testing.T) {
 		t.Errorf("phase not in path: %s", sessDir)
 	}
 
-	flat, err := startProfileSession(root, "", "wl", false)
+	flat, err := startProfileSession(root, "blockstore", "", "wl", false)
 	if err != nil {
 		t.Fatalf("startProfileSession (flat): %v", err)
 	}
@@ -182,7 +182,7 @@ func TestLoadSeed_RoundTrip(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sess, err := startProfileSession(t.TempDir(), "", "mixed-ops-storm", true)
+			sess, err := startProfileSession(t.TempDir(), "blockstore", "", "mixed-ops-storm", true)
 			if err != nil {
 				t.Fatalf("startProfileSession: %v", err)
 			}
@@ -210,7 +210,7 @@ func TestLoadSeed_RoundTrip(t *testing.T) {
 // escape <profile-dir>/blockstore via filepath.Join.
 func TestStartProfileSession_RejectsBadPhase(t *testing.T) {
 	for _, phase := range []string{"..", ".", "../evil", "a/b", "/abs"} {
-		if _, err := startProfileSession(t.TempDir(), phase, "wl", false); err == nil {
+		if _, err := startProfileSession(t.TempDir(), "blockstore", phase, "wl", false); err == nil {
 			t.Errorf("phase %q: expected error, got nil", phase)
 		}
 	}

--- a/cmd/bench/stubs.go
+++ b/cmd/bench/stubs.go
@@ -26,7 +26,6 @@ func newStubCmd(area, short string) *cobra.Command {
 
 var (
 	gcCmd       = newStubCmd("gc", "Garbage collection benchmarks (stub)")
-	metadataCmd = newStubCmd("metadata", "Metadata store benchmarks (listings, rename, links, ACL) (stub)")
 	adaptersCmd = newStubCmd("adapters", "NFS / SMB framing benchmarks (stub)")
 	e2eCmd      = newStubCmd("e2e", "External-client end-to-end benchmarks (fio, iozone, smbtorture-perf) (stub)")
 )


### PR DESCRIPTION
## What

Adds a `dfsbench metadata` subcommand + `bench/metadata/` library that drives
`getattr`/`lookup`/`readdir`/`mixed` read workloads **directly against a
`metadata.Store` backend** (memory/badger/postgres), reporting per-op
p50/p95/p99 latency and capturing the standard pprof envelope. No protocol, no
client cache — it isolates pure backend read cost.

Built to answer #1169: should DittoFS add a server-side metadata read cache
(prompted by the JuiceFS architecture comparison)? Includes the full decision
record in `.planning/perf/metadata-cache-decision.md`.

## Findings (both decision gates met)

**Gate 1 — micro-bench** (warm, local ephemeral pg, ops=20k/workers=4):

| backend | getattr p50 | lookup p50 | readdir p50 |
|---|---|---|---|
| memory | 0.21 µs | 0.13 µs | 20 µs |
| badger | 7.7 µs | 1.4 µs | 525 µs |
| postgres | 160 µs | 73 µs | 315 µs |

postgres `GetFile` ≈ 760× memory, 21× badger. Prepared statements ruled out
(no effect — cost is round-trip + the 2-query GetFile).

**Gate 2 — e2e** (scw VM, postgres + pprof, loopback NFS, cold 20k-file `find`
crawl): dfs CPU profile shows **`postgres.GetFile` = ~44% of server CPU**, the
NFS LOOKUP handler ~64% (mostly the pg query). When the server handles metadata
ops, the backend read dominates.

**Verdict:** build an opt-in read-through LRU+TTL cache in `MetadataService`,
write-invalidated, default off, postgres-focused. Tracked as a follow-up issue.

## Changes

- New: `bench/metadata/{fixture,workloads,workloads_test}.go`, `cmd/bench/metadata.go`, decision doc.
- `cmd/bench/profiles.go`: generalized `startProfileSession` to take an `area` param (mechanical updates to blockstore/orchestrate call sites + the dropped metadata stub). No behavior change to existing blockstore captures.
- Seeding is excluded from the timed/profiled region; reuses `bench/blockstore.LatencyRecorder` + the pprof envelope.

## Verification

`go build ./...`, `go test ./bench/metadata/... ./cmd/bench/...`, `go vet`, `gofmt` all clean. Ran live against memory/badger/postgres + the e2e scw capture (VM since terminated).

Refs #1169.