### PR TITLE
fix(operator): default make-deploy IMG to published image (avoid local-only controller:latest)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -136,5 +136,10 @@ kubectl apply -f config/samples/dittofs_v1alpha1_dittofs.yaml
 kubectl get dittofs
 ```
 
+`make deploy` uses the published operator image (`marmos91c/dittofs-operator:latest`) by
+default. To build and deploy from source instead, point `IMG` at your own registry:
+`make docker-build docker-push IMG=<your-registry>/dittofs-operator:tag` then
+`make deploy IMG=<your-registry>/dittofs-operator:tag`.
+
 See the [`operator/`](../operator/) directory for the CRD reference, RBAC, and Helm chart
 configuration.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -126,7 +126,7 @@ exposure for the NFS/SMB protocols.
 
 ```bash
 # From the operator directory
-cd operator
+cd k8s/dittofs-operator
 make deploy
 
 # Create a DittoFS instance
@@ -141,5 +141,5 @@ default. To build and deploy from source instead, point `IMG` at your own regist
 `make docker-build docker-push IMG=<your-registry>/dittofs-operator:tag` then
 `make deploy IMG=<your-registry>/dittofs-operator:tag`.
 
-See the [`operator/`](../operator/) directory for the CRD reference, RBAC, and Helm chart
-configuration.
+See the [`k8s/dittofs-operator/`](../k8s/dittofs-operator/) directory for the CRD reference,
+RBAC, and Helm chart configuration.

--- a/k8s/dittofs-operator/Makefile
+++ b/k8s/dittofs-operator/Makefile
@@ -1,5 +1,8 @@
-# Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+# Image URL to use all building/pushing image targets.
+# Defaults to the published image so `make deploy` works out of the box.
+# Override (e.g. `make docker-build docker-push IMG=<your-registry>/dittofs-operator:tag`)
+# to build and deploy from source.
+IMG ?= marmos91c/dittofs-operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/k8s/dittofs-operator/README.md
+++ b/k8s/dittofs-operator/README.md
@@ -140,8 +140,13 @@ make run
 # Run tests
 make test
 
-# Build container image
-make docker-build IMG=<registry>/dittofs-operator:tag
+# Deploy the operator to the current kube context.
+# By default this uses the published image (marmos91c/dittofs-operator:latest).
+make deploy
+
+# Build and deploy from source instead, by pointing IMG at your own registry:
+make docker-build docker-push IMG=<your-registry>/dittofs-operator:tag
+make deploy IMG=<your-registry>/dittofs-operator:tag
 ```
 
 ## License


### PR DESCRIPTION
## Problem

The operator `Makefile` defaulted `IMG ?= controller:latest`. A fresh user running `make deploy` would have `kustomize edit set image controller=controller:latest` applied to the manager Deployment — an image that exists only on a machine that has run `make docker-build` locally. On any real cluster the operator pod sits in `ImagePullBackOff` until the user figures out they must build and load the image themselves.

## Fix

Default `IMG ?= marmos91c/dittofs-operator:latest` — the same published image the Helm chart (`chart/values.yaml`) already references and that `release.yml` builds and pushes. `make deploy` now pulls a real, public image out of the box. Still overridable via `IMG=<your-registry>/...` for source builds.

Verified with kustomize v5.7.1: `kustomize build config/default` resolves the manager container image to `marmos91c/dittofs-operator:latest`. No CRD/manifest diff (`make deploy` performs the `kustomize edit` at runtime; the kustomization file is not committed).

## docker-push consideration

The same `IMG` default also feeds `docker-build` / `docker-push`, so a bare `make docker-push` now targets the public `:latest`. This is acceptable:

- The push requires Docker Hub push credentials for the `marmos91c` namespace, which a fresh user does not have, so it fails safely rather than clobbering the published image.
- `release.yml` remains the authoritative publisher.

A separate `DEPLOY_IMG` was considered but rejected as added surface; the minimal one-line default fix is the right altitude. Users building from source use `make docker-build docker-push IMG=<your-registry>/dittofs-operator:tag`.

## Docs

Updated `k8s/dittofs-operator/README.md` and `docs/DEPLOYMENT.md` to state that `make deploy` uses the published image by default and how to build/deploy from source via `IMG=`.