### PR TITLE
fix(controlplane): validate share default_permission + nfs squash enums (#1180, #1181)

### DIFF
--- a/cmd/dfsctl/commands/share/nfs_config.go
+++ b/cmd/dfsctl/commands/share/nfs_config.go
@@ -55,7 +55,7 @@ var nfsConfigSetCmd = &cobra.Command{
 
 func init() {
 	nfsConfigSetCmd.Flags().StringVar(&nfsCfgNetgroup, "netgroup", "", "Netgroup name to associate (empty string clears the association)")
-	nfsConfigSetCmd.Flags().StringVar(&nfsCfgSquash, "squash", "", "Squash mode (none|root|all)")
+	nfsConfigSetCmd.Flags().StringVar(&nfsCfgSquash, "squash", "", "Squash mode (none|root_to_admin|root_to_guest|all_to_admin|all_to_guest)")
 	nfsConfigSetCmd.Flags().StringVar(&nfsCfgAllowAuthSys, "allow-auth-sys", "", "Allow AUTH_SYS flavor (true|false)")
 	nfsConfigSetCmd.Flags().StringVar(&nfsCfgRequireKerberos, "require-kerberos", "", "Require Kerberos auth (true|false)")
 

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -121,6 +121,13 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Squash != nil {
+		// Validate rather than store-and-echo: ParseSquashMode silently falls back
+		// to the default (root_to_admin) for anything unrecognized, so `--squash root`
+		// would quietly become "no root squash" without an error (#1181).
+		if *req.Squash != "" && !models.SquashMode(*req.Squash).IsValid() {
+			BadRequest(w, "Invalid squash: "+*req.Squash+" (want none|root_to_admin|root_to_guest|all_to_admin|all_to_guest)")
+			return
+		}
 		opts.Squash = *req.Squash
 	}
 	if req.AnonymousUID != nil {

--- a/internal/controlplane/api/handlers/share_adapter_config_test.go
+++ b/internal/controlplane/api/handlers/share_adapter_config_test.go
@@ -205,7 +205,7 @@ func TestShareNFSConfig_PatchOtherFields(t *testing.T) {
 	cpStore, handler, shareID := setupShareNFSConfigTest(t)
 	ctx := context.Background()
 
-	w := doRequest(t, handler.Patch, http.MethodPatch, `{"squash":"all","allow_auth_sys":false}`)
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"squash":"all_to_guest","allow_auth_sys":false}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("Patch() status = %d, want 200, body = %s", w.Code, w.Body.String())
 	}
@@ -218,10 +218,25 @@ func TestShareNFSConfig_PatchOtherFields(t *testing.T) {
 	if err := cfg.ParseConfig(&opts); err != nil {
 		t.Fatalf("ParseConfig: %v", err)
 	}
-	if opts.Squash != "all" {
-		t.Errorf("Squash = %q, want all", opts.Squash)
+	if opts.Squash != "all_to_guest" {
+		t.Errorf("Squash = %q, want all_to_guest", opts.Squash)
 	}
 	if opts.AllowAuthSys {
 		t.Errorf("AllowAuthSys = true, want false")
+	}
+}
+
+// TestShareNFSConfig_PatchRejectsInvalidSquash verifies an unrecognized squash
+// value is rejected with 400 rather than silently persisted and then falling
+// back to the default at use time (#1181). "root"/"all" are common mistakes —
+// the real enum is none|root_to_admin|root_to_guest|all_to_admin|all_to_guest.
+func TestShareNFSConfig_PatchRejectsInvalidSquash(t *testing.T) {
+	_, handler, _ := setupShareNFSConfigTest(t)
+
+	for _, bad := range []string{"root", "all", "read_write"} {
+		w := doRequest(t, handler.Patch, http.MethodPatch, `{"squash":"`+bad+`"}`)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Patch(squash=%q) status = %d, want 400, body = %s", bad, w.Code, w.Body.String())
+		}
 	}
 }

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -275,6 +275,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 	defaultPerm := req.DefaultPermission
 	if defaultPerm == "" {
 		defaultPerm = "read-write"
+	} else if !models.SharePermission(defaultPerm).IsValid() {
+		// Validate the raw string, not ParseSharePermission's result: Parse maps
+		// anything unrecognized to PermissionNone (which is itself valid), so an
+		// operator who typos "read_write" would silently get total deny (#1180).
+		BadRequest(w, "Invalid default_permission: "+defaultPerm+" (want none|read|read-write|admin)")
+		return
 	}
 
 	// Validate BlockedOperations entries
@@ -661,6 +667,10 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		share.SetTrashExcludePatterns(req.TrashExcludePatterns)
 	}
 	if req.DefaultPermission != nil {
+		if *req.DefaultPermission != "" && !models.SharePermission(*req.DefaultPermission).IsValid() {
+			BadRequest(w, "Invalid default_permission: "+*req.DefaultPermission+" (want none|read|read-write|admin)")
+			return
+		}
 		share.DefaultPermission = *req.DefaultPermission
 	}
 	if req.BlockedOperations != nil {

--- a/internal/controlplane/api/handlers/shares_test.go
+++ b/internal/controlplane/api/handlers/shares_test.go
@@ -274,3 +274,69 @@ func TestShareHandler_Update_TrashRejectsNegative(t *testing.T) {
 		t.Fatalf("Update(negative retention) = %d, want 400; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// seedStores creates a metadata store + local block store (no share) and
+// returns their names, so a Create request can reference real stores and reach
+// the default_permission validation rather than failing the store-existence
+// checks first.
+func seedStores(t *testing.T, cpStore store.Store, name string) (metaName, blockName string) {
+	t.Helper()
+	ctx := context.Background()
+
+	metaStore := &models.MetadataStoreConfig{
+		ID: uuid.New().String(), Name: "m-" + name, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateMetadataStore(ctx, metaStore); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	blockStore := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "b-" + name, Kind: models.BlockStoreKindLocal, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateBlockStore(ctx, blockStore); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	return metaStore.Name, blockStore.Name
+}
+
+// TestShareHandler_Create_RejectsInvalidDefaultPermission verifies an
+// unrecognized default_permission is rejected with 400 rather than stored and
+// echoed back — ParseSharePermission silently maps unknown strings to
+// PermissionNone (total deny), so a typo like "read_write" would look granted
+// while denying every unknown-UID client (#1180).
+func TestShareHandler_Create_RejectsInvalidDefaultPermission(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	metaName, blockName := seedStores(t, cpStore, "s-perm-bad")
+
+	body, _ := json.Marshal(CreateShareRequest{
+		Name:              "/perm-bad",
+		MetadataStoreID:   metaName,
+		LocalBlockStore:   blockName,
+		DefaultPermission: "read_write", // underscore — the valid token is "read-write"
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Create(invalid default_permission) = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestShareHandler_Update_RejectsInvalidDefaultPermission is the update-path
+// counterpart of the create check (#1180).
+func TestShareHandler_Update_RejectsInvalidDefaultPermission(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-perm-upd")
+
+	body := []byte(`{"default_permission":"read_write"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-perm-upd", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-perm-upd")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Update(invalid default_permission) = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem

Two share-config fields were **store-and-echo without validation**, both found during #18 k3s squash/auth live validation:

- **#1180** — an unrecognized `default_permission` (e.g. `read_write` with an underscore) returned HTTP 201 and echoed the value back, but `ParseSharePermission` maps anything unrecognized to `PermissionNone` (total deny). Operator thinks they granted read-write; unknown-UID clients are silently denied everything.
- **#1181** — `--squash root`/`--squash all` were persisted unvalidated, then silently fell back to the default (`root_to_admin`) at use time. The dfsctl help also advertised a wrong enum (`none|root|all`).

## Fix

- Reject invalid `default_permission` at share **create** and **update** handlers (validate the raw string — `ParseSharePermission`'s `PermissionNone` result is itself valid, so the parsed result can't be the guard).
- Reject invalid `squash` at the nfs-adapter-config PATCH handler.
- Correct the dfsctl `--squash` help to the real enum (`none|root_to_admin|root_to_guest|all_to_admin|all_to_guest`).

## Tests

- `TestShareHandler_Create_RejectsInvalidDefaultPermission`, `TestShareHandler_Update_RejectsInvalidDefaultPermission` — 400 on `read_write`.
- `TestShareNFSConfig_PatchRejectsInvalidSquash` — 400 on `root`/`all`/`read_write`.
- Updated `TestShareNFSConfig_PatchOtherFields` (was asserting the buggy `squash:"all"` round-trip) to a valid `all_to_guest`.

Closes #1180
Closes #1181