### PR TITLE
fix(operator): credentials Secret password/token authenticate after a control-plane DB reset

### DIFF
--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -262,10 +262,20 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 	// Create operator user
 	err = apiClient.CreateUser(ctx, dittoiov1alpha1.OperatorServiceAccountUsername, operatorPassword, "operator")
 	if err != nil {
-		// If user already exists, proceed to login
+		// If the user already exists, it was provisioned by a previous run with a
+		// password the operator no longer knows (e.g. the credentials Secret was
+		// deleted, or a control-plane DB reset recreated the account out of band).
+		// Re-set the password to the freshly generated value using the admin
+		// session so the value we write into the credentials Secret is guaranteed
+		// to authenticate via /auth/login. Without this the stored password silently
+		// diverges from the server and an external consumer of the Secret cannot
+		// rely on it.
 		var apiErr *DittoFSAPIError
 		if errors.As(err, &apiErr) && apiErr.IsConflict() {
-			logger.Info("Operator service account already exists, proceeding to login")
+			logger.Info("Operator service account already exists, resetting its password to reconcile credentials")
+			if resetErr := apiClient.ResetUserPassword(ctx, dittoiov1alpha1.OperatorServiceAccountUsername, operatorPassword); resetErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reset existing operator service account password: %w", resetErr)
+			}
 		} else {
 			return ctrl.Result{}, fmt.Errorf("failed to create operator service account: %w", err)
 		}

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	dittoiov1alpha1 "github.com/marmos91/dittofs/k8s/dittofs-operator/api/v1alpha1"
 	"github.com/marmos91/dittofs/k8s/dittofs-operator/utils/conditions"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -263,9 +264,22 @@ func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 
 	r := setupAuthReconciler(t, ds, adminSecret)
 
-	// Mock DittoFS API that returns 409 Conflict on CreateUser
+	// When the operator user already exists (409 on CreateUser), provisioning
+	// must reset its password to the freshly generated value so the password it
+	// writes into the credentials Secret authenticates. The mock server tracks
+	// the reset password and only accepts an operator login that presents it.
+	var resetPassword string
 	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
 		"POST /api/v1/auth/login": func(w http.ResponseWriter, req *http.Request) {
+			var body LoginRequest
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			// Admin login always succeeds; operator login must present the reset password.
+			if body.Username == dittoiov1alpha1.OperatorServiceAccountUsername && body.Password != resetPassword {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid credentials"}`))
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			w.Write(tokenJSON("operator-token", 900))
 		},
@@ -275,11 +289,23 @@ func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 			w.WriteHeader(http.StatusConflict)
 			w.Write([]byte(`{"type":"about:blank","title":"Conflict","status":409,"detail":"User already exists"}`))
 		},
+		"POST /api/v1/users/{username}/password": func(w http.ResponseWriter, req *http.Request) {
+			var body struct {
+				NewPassword string `json:"new_password"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			resetPassword = body.NewPassword
+			w.WriteHeader(http.StatusNoContent)
+		},
 	})
 
 	result, err := r.provisionOperatorAccount(context.Background(), ds, server.URL)
 	if err != nil {
 		t.Fatalf("provisionOperatorAccount should succeed when user already exists, got: %v", err)
+	}
+
+	if resetPassword == "" {
+		t.Fatal("expected provisioning to reset the existing operator password, but no reset was issued")
 	}
 
 	// Verify it still created the credentials Secret
@@ -298,6 +324,124 @@ func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 
 	if string(credSecret.Data["access-token"]) != "operator-token" {
 		t.Errorf("Expected access token 'operator-token', got %s", string(credSecret.Data["access-token"]))
+	}
+
+	// The invariant: the password stored in the Secret is exactly the one the
+	// server now accepts. An external consumer reading it can authenticate.
+	if got := string(credSecret.Data["password"]); got != resetPassword {
+		t.Errorf("stored password %q does not match the server-side reset password %q", got, resetPassword)
+	}
+}
+
+// TestReconcileAuth_DBReset_ReprovisionsAuthenticatableSecret is the regression
+// test for #1182. It reproduces a control-plane DB reset: the credentials Secret
+// survives in K8s but the operator user is wiped from the DB. The first reconcile
+// takes the refresh path, both refresh and re-login fail (user gone), so the stale
+// Secret is deleted. The second reconcile re-provisions from scratch. The invariant
+// under test is that, end to end, the Secret ends up holding a password the server
+// actually accepts and a freshly minted access token — not the stale pre-reset values.
+func TestReconcileAuth_DBReset_ReprovisionsAuthenticatableSecret(t *testing.T) {
+	ds := newTestDittoServer("test-server", "default")
+
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.GetAdminCredentialsSecretName(),
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("admin-pass"),
+		},
+	}
+
+	// Stale credentials Secret carried over from before the reset.
+	staleSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.GetOperatorCredentialsSecretName(),
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"username":      []byte(dittoiov1alpha1.OperatorServiceAccountUsername),
+			"password":      []byte("stale-pre-reset-password"),
+			"access-token":  []byte("stale-access-token"),
+			"refresh-token": []byte("stale-refresh-token"),
+			"server-url":    []byte("http://old-url"),
+		},
+	}
+
+	r := setupAuthReconciler(t, ds, adminSecret, staleSecret)
+
+	// Server state after the DB reset: only the admin (re-bootstrapped from the
+	// initial-password env var) exists; the operator user is gone until created.
+	operatorExists := false
+	operatorPassword := ""
+	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
+		"POST /api/v1/auth/refresh": func(w http.ResponseWriter, req *http.Request) {
+			// Signature is still valid (stable JWT key) but the user no longer exists.
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"type":"about:blank","title":"Unauthorized","status":401,"detail":"User not found"}`))
+		},
+		"POST /api/v1/auth/login": func(w http.ResponseWriter, req *http.Request) {
+			var body LoginRequest
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			if body.Username == dittoiov1alpha1.OperatorServiceAccountUsername {
+				if !operatorExists || body.Password != operatorPassword {
+					w.Header().Set("Content-Type", "application/problem+json")
+					w.WriteHeader(http.StatusUnauthorized)
+					w.Write([]byte(`{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid credentials"}`))
+					return
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(tokenJSON("fresh-access-token", 900))
+		},
+		"POST /api/v1/users": func(w http.ResponseWriter, req *http.Request) {
+			var body struct {
+				Username string `json:"username"`
+				Password string `json:"password"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			operatorExists = true
+			operatorPassword = body.Password
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"1","username":"k8s-operator","role":"operator"}`))
+		},
+	})
+
+	ctx := context.Background()
+
+	// First reconcile: refresh + re-login fail, stale Secret is deleted.
+	credSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: ds.GetOperatorCredentialsSecretName()}, credSecret); err != nil {
+		t.Fatalf("failed to read stale credentials secret: %v", err)
+	}
+	if _, err := r.refreshOperatorToken(ctx, ds, credSecret, server.URL); err == nil {
+		t.Fatal("expected refresh+re-login to fail after a DB reset, got nil error")
+	}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: ds.GetOperatorCredentialsSecretName()}, credSecret); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale credentials secret to be deleted, got err=%v", err)
+	}
+
+	// Second reconcile: re-provision from scratch now that the Secret is gone.
+	if _, err := r.provisionOperatorAccount(ctx, ds, server.URL); err != nil {
+		t.Fatalf("re-provisioning after DB reset failed: %v", err)
+	}
+
+	// Invariant: the Secret now holds a password the server accepts and a fresh token.
+	final := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: ds.GetOperatorCredentialsSecretName()}, final); err != nil {
+		t.Fatalf("failed to read re-provisioned credentials secret: %v", err)
+	}
+	if string(final.Data["password"]) == "stale-pre-reset-password" {
+		t.Error("Secret still holds the stale pre-reset password")
+	}
+	if string(final.Data["password"]) != operatorPassword {
+		t.Errorf("stored password %q does not match the server-side operator password %q",
+			string(final.Data["password"]), operatorPassword)
+	}
+	if string(final.Data["access-token"]) != "fresh-access-token" {
+		t.Errorf("expected fresh access token, got %q", string(final.Data["access-token"]))
 	}
 }
 

--- a/k8s/dittofs-operator/internal/controller/dittofs_client.go
+++ b/k8s/dittofs-operator/internal/controller/dittofs_client.go
@@ -271,6 +271,20 @@ func (c *DittoFSClient) DeleteUser(ctx context.Context, username string) error {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/users/%s", username), nil, nil)
 }
 
+// ResetUserPassword sets a new password for an existing user (admin only).
+// Used to make provisioning authoritative: when the operator service account
+// already exists with a password the operator does not know, resetting it to a
+// freshly generated value guarantees the value written into the credentials
+// Secret actually authenticates.
+func (c *DittoFSClient) ResetUserPassword(ctx context.Context, username, newPassword string) error {
+	req := struct {
+		NewPassword string `json:"new_password"`
+	}{
+		NewPassword: newPassword,
+	}
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/api/v1/users/%s/password", username), req, nil)
+}
+
 // AdapterInfo represents an adapter returned by the DittoFS API.
 // Only fields needed by the operator are included.
 type AdapterInfo struct {


### PR DESCRIPTION
## Root cause

After a control-plane DB reset, the `*-operator-credentials` Secret survives in Kubernetes but the `k8s-operator` user is wiped from the DB. The operator self-heals its own in-memory token, masking the problem — but the `password` stored in the Secret no longer authenticates via `/auth/login`, and the stored `access-token` is stale.

The divergence originates in `provisionOperatorAccount` (`k8s/dittofs-operator/internal/controller/auth_reconciler.go`). When `CreateUser` returns **409 Conflict** (the operator service account already exists from a previous run — e.g. recreated out of band after a reset, or because the Secret was deleted while the user persisted), the code simply logged "proceeding to login" and then attempted to log in with a **freshly generated** password the existing account does not have. The server's password for `k8s-operator` therefore stayed whatever it was before, while the operator generated a new one — so:

- The operator's in-memory token (obtained via refresh / re-login) kept working.
- The `password` (and any newly written `access-token`) in the Secret diverged from the server.
- An **external** consumer reading the Secret's `password`/`access-token` could not authenticate.

The JWT signing secret is a stable K8s-managed Secret (survives the reset), so the old refresh token's signature still validates — `/auth/refresh` reaches `GetUser(k8s-operator)` and only then returns 401 (user not found). This is why the operator's refresh path could appear healthy intermittently while the Secret stayed stale.

## Fix

Make provisioning **authoritative** on conflict. On a 409 from `CreateUser`, the operator now uses its admin session to reset the existing account's password to the freshly generated value via `POST /api/v1/users/{username}/password` (`{"new_password": ...}`, admin-only). The subsequent operator `Login` then succeeds with that password, and the value written into the credentials Secret is guaranteed to authenticate. Added a `ResetUserPassword` method to the minimal operator HTTP client.

End-to-end this converges the reset case: refresh fails → re-login with stored password fails → stale Secret deleted → next reconcile re-provisions → `CreateUser` 409 → `ResetUserPassword` → operator `Login` succeeds → Secret holds a working `password` + a freshly minted (signature-valid) `access-token`.

## Test

- Extended `TestProvisionOperatorAccount_UserAlreadyExists`: the mock server now only accepts an operator login that presents the reset password and asserts the Secret's stored `password` equals the server-side reset value (fails without the fix — the operator login is rejected and provisioning errors).
- Added `TestReconcileAuth_DBReset_ReprovisionsAuthenticatableSecret`: reproduces the DB-reset scenario (stale Secret + wiped operator user), drives refresh→re-login failure→stale-Secret deletion→re-provision, and asserts the final Secret holds a server-accepted password (not the stale pre-reset value) and a fresh access token.

All operator unit tests pass with `-race`. The `TestControllers` envtest suite requires kube-apiserver/etcd envtest binaries (provided in CI; not runnable on this dev host) and is unrelated to this change.

Closes #1182