### PR TITLE
feat(controlplane): clarify forced admin password-change error + make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,12 @@ DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password ./dfs start
 # 1a. REQUIRED on first login: change the admin password.
 # The bootstrap admin starts with a forced-password-change flag — until you
 # clear it here, every other command (including `user create` below) is
-# rejected with HTTP 403 "Password change required. Please change your
-# password before proceeding." (Skipped automatically if you set your own
-# DITTOFS_ADMIN_INITIAL_PASSWORD at first start.)
+# rejected with HTTP 403:
+#   account "admin" must set a new password before performing other operations;
+#   run 'dfsctl user change-password' (as "admin") to set one
+# This forced change is skipped automatically when you set your own
+# DITTOFS_ADMIN_INITIAL_PASSWORD at first start, and can be disabled entirely
+# via controlplane.require_initial_password_change: false (see docs/CONFIGURATION.md).
 ./dfsctl user change-password
 
 # 2. Create a user mapped to your host UID (needed for NFS write access)

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -114,8 +114,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize control plane store: %w", err)
 	}
 
-	// Ensure admin user exists (generates random password on first run)
-	adminPassword, err := cpStore.EnsureAdminUser(ctx)
+	// Ensure admin user exists (generates random password on first run).
+	// Whether the first-login password change is forced is operator-configurable
+	// (controlplane.require_initial_password_change, default true).
+	adminPassword, err := cpStore.EnsureAdminUser(ctx, cfg.ControlPlane.RequiresInitialPasswordChange())
 	if err != nil {
 		return fmt.Errorf("failed to ensure admin user: %w", err)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -218,6 +218,13 @@ controlplane:
   write_timeout: 10s         # Max time to write response
   idle_timeout: 60s          # Max idle time for keep-alive
 
+  # Force the bootstrap "admin" user to set a new password on first login.
+  # Default true (secure by default). Set to false for automated/test
+  # deployments that provision the admin password out-of-band and don't want
+  # the forced first-login change. (Supplying DITTOFS_ADMIN_INITIAL_PASSWORD
+  # also skips the forced change, since the operator already chose the password.)
+  require_initial_password_change: true
+
   # Native TLS (optional). DittoFS only loads these files; it does not issue,
   # renew, or rotate certificates. When cert_file and key_file are both set,
   # the API serves HTTPS and hot-reloads the files when they change on disk.
@@ -255,6 +262,7 @@ controlplane:
 | `read_timeout` | `10s` | Maximum duration to read request |
 | `write_timeout` | `10s` | Maximum duration to write response |
 | `idle_timeout` | `60s` | Maximum idle time for keep-alive |
+| `require_initial_password_change` | `true` | Force the bootstrap `admin` user to change its password on first login. Set to `false` to opt out (automated/test deployments). Also skipped when `DITTOFS_ADMIN_INITIAL_PASSWORD` is set |
 | `pprof` | `false` | Expose Go `/debug/pprof/*` profiling endpoints |
 | `pprof_mutex_rate` | `100` (when `pprof: true`; else `0`) | Mutex contention sampling, 1 per N events. Applied only when `pprof: true`; unset/`0` then falls back to `100`. Without it `/debug/pprof/mutex` is header-only. Disable profiling via `pprof: false`, not by zeroing this |
 | `pprof_block_rate_ns` | `1000000` (when `pprof: true`; else `0`) | Block profiling rate in ns, 1 sample per N ns blocked. Applied only when `pprof: true`; unset/`0` then falls back to `1000000`. Without it `/debug/pprof/block` is header-only. Disable profiling via `pprof: false`, not by zeroing this |

--- a/internal/controlplane/api/middleware/auth.go
+++ b/internal/controlplane/api/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -164,9 +165,16 @@ func RequirePasswordChange(allowedPaths ...string) func(http.Handler) http.Handl
 				return
 			}
 
-			// Block if user must change password
+			// Block if the authenticated user must change their password.
+			// The message names the account so an operator onboarding as
+			// "admin" doesn't mistake it for a problem with the user they're
+			// trying to create, and points at the exact command to unblock.
 			if claims.MustChangePassword {
-				http.Error(w, "Password change required. Please change your password before proceeding.", http.StatusForbidden)
+				http.Error(w, fmt.Sprintf(
+					"account %q must set a new password before performing other operations; "+
+						"run 'dfsctl user change-password' (as %q) to set one",
+					claims.Username, claims.Username,
+				), http.StatusForbidden)
 				return
 			}
 

--- a/internal/controlplane/api/middleware/auth_test.go
+++ b/internal/controlplane/api/middleware/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/controlplane/api/auth"
@@ -419,7 +420,7 @@ func TestRequirePasswordChange(t *testing.T) {
 	})
 
 	t.Run("user must change password - blocked", func(t *testing.T) {
-		claims := &auth.Claims{UserID: "user-123", Username: "testuser", Role: "user", MustChangePassword: true}
+		claims := &auth.Claims{UserID: "user-123", Username: "admin", Role: "admin", MustChangePassword: true}
 		ctx := context.WithValue(context.Background(), claimsContextKey, claims)
 
 		handler := RequirePasswordChange("/api/v1/users/me/password")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -432,6 +433,16 @@ func TestRequirePasswordChange(t *testing.T) {
 
 		if rr.Code != http.StatusForbidden {
 			t.Errorf("expected status %d, got %d", http.StatusForbidden, rr.Code)
+		}
+		// The message must name the authenticated account and point at the
+		// exact command, so an operator onboarding as "admin" isn't confused
+		// into thinking it's about the user they're trying to create.
+		body := rr.Body.String()
+		if !strings.Contains(body, `"admin"`) {
+			t.Errorf("expected error to name the account %q, got %q", "admin", body)
+		}
+		if !strings.Contains(body, "dfsctl user change-password") {
+			t.Errorf("expected error to mention 'dfsctl user change-password', got %q", body)
 		}
 	})
 

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -50,6 +50,64 @@ controlplane:
 	}
 }
 
+// TestLoad_RequireInitialPasswordChange covers the opt-out knob for the forced
+// admin first-login password change: it defaults to true, is settable to false
+// via the config file, and is overridable to false via env.
+func TestLoad_RequireInitialPasswordChange(t *testing.T) {
+	t.Run("defaults to true when absent", func(t *testing.T) {
+		content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+		cfg, err := Load(writeConfigFile(t, content))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.ControlPlane.RequiresInitialPasswordChange() {
+			t.Error("expected forced password change on by default")
+		}
+	})
+
+	t.Run("file opt-out", func(t *testing.T) {
+		content := `
+database:
+  type: sqlite
+controlplane:
+  require_initial_password_change: false
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+		cfg, err := Load(writeConfigFile(t, content))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ControlPlane.RequiresInitialPasswordChange() {
+			t.Error("expected forced password change off when file sets it false")
+		}
+	})
+
+	t.Run("env opt-out", func(t *testing.T) {
+		content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+		t.Setenv("DITTOFS_CONTROLPLANE_REQUIRE_INITIAL_PASSWORD_CHANGE", "false")
+		cfg, err := Load(writeConfigFile(t, content))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ControlPlane.RequiresInitialPasswordChange() {
+			t.Error("expected forced password change off when env sets it false")
+		}
+	})
+}
+
 // TestLoad_DatabaseTypeFromEnv_TypeOmittedFromFile reproduces round-2 §2.2(b):
 // a container supplies postgres connection details in the file but omits
 // database.type, then sets DITTOFS_DATABASE_TYPE=postgres via env. Before the
@@ -233,6 +291,7 @@ func TestConfigEnvKeys_CoversKnownKeys(t *testing.T) {
 		"controlplane.tls.min_version",
 		"controlplane.jwt.secret",
 		"controlplane.pprof",
+		"controlplane.require_initial_password_change",
 		"admin.username",
 		"kerberos.enabled",
 		"gc.grace_period",

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -124,6 +124,11 @@ controlplane:
   read_timeout: 10s
   write_timeout: 10s
   idle_timeout: 60s
+  # Force the bootstrap "admin" user to set a new password on first login.
+  # Default true (secure by default). Uncomment and set to false for
+  # automated/test deployments that provision the admin password out-of-band.
+  # (Setting DITTOFS_ADMIN_INITIAL_PASSWORD also skips the forced change.)
+  # require_initial_password_change: false
   # Native TLS (optional). DittoFS only LOADS these files — it is not a CA and
   # does not issue, renew, or rotate certificates (leave that to the platform,
   # e.g. cert-manager). When cert_file and key_file are both set, the API

--- a/pkg/controlplane/api/config.go
+++ b/pkg/controlplane/api/config.go
@@ -80,6 +80,21 @@ type APIConfig struct {
 	// to the default 1_000_000 — to turn profiling off entirely, set Pprof to
 	// false rather than zeroing this.
 	PprofBlockRateNs int `mapstructure:"pprof_block_rate_ns" validate:"omitempty,min=0" yaml:"pprof_block_rate_ns"`
+
+	// RequireInitialPasswordChange controls whether the bootstrap admin user
+	// is forced to set a new password on first login. Default: true (secure by
+	// default). Set to false for automated/test deployments that provision the
+	// admin password out-of-band and don't want the forced first-login change.
+	// It is a pointer so an unset value defaults to true (forced change on)
+	// rather than to the bool zero value (off). Use RequiresInitialPasswordChange().
+	RequireInitialPasswordChange *bool `mapstructure:"require_initial_password_change" yaml:"require_initial_password_change"`
+}
+
+// RequiresInitialPasswordChange reports whether the bootstrap admin must change
+// its password on first login. An unset value defaults to true so the forced
+// change is on unless an operator explicitly opts out.
+func (c *APIConfig) RequiresInitialPasswordChange() bool {
+	return c.RequireInitialPasswordChange == nil || *c.RequireInitialPasswordChange
 }
 
 // JWTConfig configures JWT token generation and validation.
@@ -211,6 +226,12 @@ func (c *APIConfig) ApplyDefaults() {
 		if c.PprofBlockRateNs == 0 {
 			c.PprofBlockRateNs = 1_000_000
 		}
+	}
+	// Force the bootstrap admin's first-login password change by default
+	// (secure by default). Operators opt out by setting it to false.
+	if c.RequireInitialPasswordChange == nil {
+		v := true
+		c.RequireInitialPasswordChange = &v
 	}
 	// JWT defaults
 	if c.JWT.AccessTokenDuration == 0 {

--- a/pkg/controlplane/api/config_test.go
+++ b/pkg/controlplane/api/config_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+func TestRequiresInitialPasswordChange(t *testing.T) {
+	tests := []struct {
+		name string
+		set  *bool
+		want bool
+	}{
+		{"unset defaults to required", nil, true},
+		{"explicit true", boolPtr(true), true},
+		{"explicit false opts out", boolPtr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &APIConfig{RequireInitialPasswordChange: tt.set}
+			if got := c.RequiresInitialPasswordChange(); got != tt.want {
+				t.Errorf("RequiresInitialPasswordChange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyDefaults_RequireInitialPasswordChange(t *testing.T) {
+	// An unset value must default to true (forced change on) to preserve the
+	// secure-by-default behavior.
+	c := &APIConfig{}
+	c.ApplyDefaults()
+	if c.RequireInitialPasswordChange == nil {
+		t.Fatal("ApplyDefaults left RequireInitialPasswordChange nil")
+	}
+	if !*c.RequireInitialPasswordChange {
+		t.Error("ApplyDefaults defaulted RequireInitialPasswordChange to false, want true")
+	}
+
+	// An explicit false must be preserved (operator opt-out).
+	off := false
+	c2 := &APIConfig{RequireInitialPasswordChange: &off}
+	c2.ApplyDefaults()
+	if c2.RequireInitialPasswordChange == nil || *c2.RequireInitialPasswordChange {
+		t.Error("ApplyDefaults overrode an explicit opt-out (false)")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -126,8 +126,11 @@ func (cp *ControlPlane) APIServer() *api.Server {
 
 // EnsureAdminUser creates the admin user if it doesn't exist.
 // Returns the generated password (empty string if user already exists).
-func (cp *ControlPlane) EnsureAdminUser(ctx context.Context) (string, error) {
-	return cp.store.EnsureAdminUser(ctx)
+//
+// requireInitialPasswordChange controls whether a freshly created admin is
+// forced to change its password on first login (see APIConfig.RequiresInitialPasswordChange).
+func (cp *ControlPlane) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (string, error) {
+	return cp.store.EnsureAdminUser(ctx, requireInitialPasswordChange)
 }
 
 // IdentityStore returns the store as an IdentityStore interface.

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -122,7 +122,7 @@ func TestEnsureAdminUser(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	pw, err := cp.EnsureAdminUser(ctx)
+	pw, err := cp.EnsureAdminUser(ctx, true)
 	if err != nil {
 		t.Fatalf("EnsureAdminUser: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestEnsureAdminUser(t *testing.T) {
 		t.Error("expected a generated password on first creation")
 	}
 	// Idempotent: second call returns empty password (user already exists).
-	pw2, err := cp.EnsureAdminUser(ctx)
+	pw2, err := cp.EnsureAdminUser(ctx, true)
 	if err != nil {
 		t.Fatalf("EnsureAdminUser (2nd): %v", err)
 	}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -442,7 +442,12 @@ type AdminStore interface {
 	// If no admin user exists, creates one with a generated password.
 	// Returns the initial password if a new admin was created, empty string otherwise.
 	// This should be called during server startup.
-	EnsureAdminUser(ctx context.Context) (initialPassword string, err error)
+	//
+	// requireInitialPasswordChange controls whether a newly created admin is
+	// flagged to change its password on first login. When false (or when the
+	// password was supplied via DITTOFS_ADMIN_INITIAL_PASSWORD) the admin is
+	// created without the forced change.
+	EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (initialPassword string, err error)
 
 	// IsAdminInitialized returns whether the admin user has been initialized.
 	IsAdminInitialized(ctx context.Context) (bool, error)

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -1275,12 +1275,16 @@ func TestBlockStoreOperationsBasic(t *testing.T) {
 }
 
 func TestEnsureAdminUser(t *testing.T) {
+	// EnsureAdminUser disables the forced change when an initial password is
+	// supplied via env; clear it so the MustChangePassword assertions below are
+	// deterministic regardless of the developer/CI shell.
+	t.Setenv(models.EnvAdminInitialPassword, "")
 	store := createTestStore(t)
 	defer store.Close()
 	ctx := context.Background()
 
 	t.Run("creates admin if not exists", func(t *testing.T) {
-		password, err := store.EnsureAdminUser(ctx)
+		password, err := store.EnsureAdminUser(ctx, true)
 		if err != nil {
 			t.Fatalf("failed to ensure admin user: %v", err)
 		}
@@ -1296,10 +1300,14 @@ func TestEnsureAdminUser(t *testing.T) {
 		if user.Role != "admin" {
 			t.Errorf("expected admin role, got %q", user.Role)
 		}
+		// Default behavior: admin must change its password on first login.
+		if !user.MustChangePassword {
+			t.Error("expected MustChangePassword=true when forced change is required")
+		}
 	})
 
 	t.Run("second call returns empty password", func(t *testing.T) {
-		password, err := store.EnsureAdminUser(ctx)
+		password, err := store.EnsureAdminUser(ctx, true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1317,6 +1325,34 @@ func TestEnsureAdminUser(t *testing.T) {
 			t.Error("admin should be initialized")
 		}
 	})
+}
+
+// TestEnsureAdminUser_OptOutForcedChange verifies that the
+// require_initial_password_change knob, when disabled, provisions the bootstrap
+// admin without the forced first-login password change.
+func TestEnsureAdminUser_OptOutForcedChange(t *testing.T) {
+	// Clear the env override so this exercises the requireInitialPasswordChange
+	// path rather than the env-driven skip.
+	t.Setenv(models.EnvAdminInitialPassword, "")
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	password, err := store.EnsureAdminUser(ctx, false)
+	if err != nil {
+		t.Fatalf("failed to ensure admin user: %v", err)
+	}
+	if password == "" {
+		t.Error("expected non-empty initial password")
+	}
+
+	user, err := store.GetUser(ctx, "admin")
+	if err != nil {
+		t.Fatalf("admin user should exist: %v", err)
+	}
+	if user.MustChangePassword {
+		t.Error("expected MustChangePassword=false when forced change is disabled")
+	}
 }
 
 func TestEnsureDefaultGroups(t *testing.T) {
@@ -1365,7 +1401,7 @@ func TestEnsureDefaultGroups(t *testing.T) {
 
 	t.Run("adds admin user to admins group", func(t *testing.T) {
 		// Create admin user first
-		_, err := store.EnsureAdminUser(ctx)
+		_, err := store.EnsureAdminUser(ctx, true)
 		if err != nil {
 			t.Fatalf("failed to ensure admin user: %v", err)
 		}

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -197,7 +197,7 @@ func (s *GORMStore) ValidateCredentials(ctx context.Context, username, password 
 	return user, nil
 }
 
-func (s *GORMStore) EnsureAdminUser(ctx context.Context) (string, error) {
+func (s *GORMStore) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (string, error) {
 	// Check if admin exists
 	_, err := s.GetUser(ctx, models.AdminUsername)
 	if err == nil {
@@ -225,8 +225,10 @@ func (s *GORMStore) EnsureAdminUser(ctx context.Context) (string, error) {
 	// Create admin user
 	admin := models.DefaultAdminUser(passwordHash, ntHash)
 
-	// If password was explicitly set via env var, don't require change
-	if passwordFromEnv {
+	// Don't force the first-login password change when the operator opted out,
+	// or when the password was supplied out-of-band via the env var (the
+	// operator already chose it, so there's nothing to force a change for).
+	if !requireInitialPasswordChange || passwordFromEnv {
 		admin.MustChangePassword = false
 	}
 


### PR DESCRIPTION
## Summary

Fixes the onboarding friction reported in #1162: a first-time operator logs in as `admin`, runs `dfsctl user create ...`, and hits a 403 whose message reads as if it concerns the *new* user's password — when it's actually the bootstrap **admin's** forced first-login password change. Two changes:

### 1. Clearer error message
`internal/controlplane/api/middleware/auth.go` now names the authenticated account and the exact command to unblock, instead of the cryptic generic text:

> `account "admin" must set a new password before performing other operations; run 'dfsctl user change-password' (as "admin") to set one`

The middleware writes plain text, which `dfsctl` surfaces verbatim via `APIError.Detail`, so the CLI no longer echoes a confusing 403.

### 2. Configurable forced change (opt-out)
New knob `controlplane.require_initial_password_change` (env: `DITTOFS_CONTROLPLANE_REQUIRE_INITIAL_PASSWORD_CHANGE`):

- **Default `true`** — current secure-by-default behavior is preserved. Implemented as a `*bool` so an unset value defaults to forced-change ON (same idiom as the SMB/NFS `Enabled *bool` opt-out flags), with `APIConfig.RequiresInitialPasswordChange()` and an `ApplyDefaults` default.
- Set to `false` for automated/test deployments: the bootstrap admin is then created with `MustChangePassword: false`.
- Threaded through `EnsureAdminUser(ctx, requireInitialPasswordChange)` (store interface, GORM store, control-plane wrapper, `dfs start`).
- `DITTOFS_ADMIN_INITIAL_PASSWORD` continues to skip the forced change as before (the operator already chose the password).

### Docs
- `docs/CONFIGURATION.md`: documented the new key (YAML example + options table).
- `pkg/config/init.go`: commented-out knob in the generated config template.
- `README.md`: updated the first-run onboarding section with the new error wording and the opt-out knob.

No Cobra commands/flags changed, so `docs/CLI.md` does not need regeneration.

## Tests
- `pkg/controlplane/store`: provisioning admin with the knob **off** → `MustChangePassword=false`; default → `true`.
- `pkg/controlplane/api`: `RequiresInitialPasswordChange()` (nil→true, explicit true/false) and `ApplyDefaults` default/opt-out preservation.
- `internal/controlplane/api/middleware`: the 403 body names the account and mentions `dfsctl user change-password`.
- `pkg/config`: default true, file opt-out, and env opt-out (`...=false`) through the full `Load()` path; key added to the `configEnvKeys` coverage guard.

Closes #1162