### PR TITLE
fix(smb): native symlink creation for macOS/Windows/Linux clients (#1179)

### DIFF
--- a/internal/adapter/smb/handlers/aapl.go
+++ b/internal/adapter/smb/handlers/aapl.go
@@ -1,0 +1,58 @@
+package handlers
+
+import "github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+
+// Apple SMB2 "AAPL" CREATE context [Apple SMB2 extensions, as implemented by
+// Samba's vfs_fruit]. macOS clients send an AAPL context on the first CREATE
+// after TREE_CONNECT to probe server capabilities. When the server responds
+// advertising a UNIX-based volume, macOS enables POSIX semantics — including
+// creating symbolic links via FSCTL_SET_REPARSE_POINT (handled in
+// set_reparse_point.go) rather than refusing them client-side. See #1179.
+const (
+	// aaplCreateContextTag is the create-context name macOS uses.
+	aaplCreateContextTag = "AAPL"
+
+	// aaplCommandServerQuery is the AAPL sub-command for the capability probe.
+	aaplCommandServerQuery uint32 = 1
+
+	// aaplReplyBitmapServerCaps marks the ServerCaps field as present in the
+	// reply bitmap.
+	aaplReplyBitmapServerCaps uint64 = 0x1
+
+	// aaplServerCapUnixBased advertises a UNIX-based volume. This is the bit
+	// macOS keys off to use native POSIX symlinks. We deliberately do NOT set
+	// kAAPL_SUPPORTS_READ_DIR_ATTR — that obligates the server to return packed
+	// per-entry attributes in FIND responses, which we don't implement.
+	aaplServerCapUnixBased uint64 = 0x4
+)
+
+// buildAAPLServerQueryResponse parses an inbound AAPL server-query create
+// context and returns the response context Data, or nil if the request is not a
+// server query we answer.
+//
+// Request layout (little-endian) [vfs_fruit aapl_server_query]:
+//
+//	CommandCode(4) Reserved(4) RequestBitmap(8) ClientCapabilities(8)
+//
+// Response layout:
+//
+//	CommandCode(4) Reserved(4) ReplyBitmap(8) ServerCapabilities(8)
+//
+// We reply with only the ServerCaps field present (ReplyBitmap = ServerCaps),
+// advertising a UNIX-based volume.
+func buildAAPLServerQueryResponse(data []byte) []byte {
+	if len(data) < 8 {
+		return nil
+	}
+	command := smbenc.NewReader(data).ReadUint32()
+	if command != aaplCommandServerQuery {
+		return nil
+	}
+
+	w := smbenc.NewWriter(24)
+	w.WriteUint32(aaplCommandServerQuery)    // CommandCode
+	w.WriteUint32(0)                         // Reserved
+	w.WriteUint64(aaplReplyBitmapServerCaps) // ReplyBitmap
+	w.WriteUint64(aaplServerCapUnixBased)    // ServerCapabilities
+	return w.Bytes()
+}

--- a/internal/adapter/smb/handlers/aapl.go
+++ b/internal/adapter/smb/handlers/aapl.go
@@ -39,13 +39,23 @@ const (
 //	CommandCode(4) Reserved(4) ReplyBitmap(8) ServerCapabilities(8)
 //
 // We reply with only the ServerCaps field present (ReplyBitmap = ServerCaps),
-// advertising a UNIX-based volume.
+// advertising a UNIX-based volume, and only when the client's RequestBitmap
+// actually asked for server caps (bit 0). The full 24-byte request is required;
+// truncated/malformed contexts are ignored (nil reply, no AAPL response added).
 func buildAAPLServerQueryResponse(data []byte) []byte {
-	if len(data) < 8 {
+	if len(data) < 24 {
 		return nil
 	}
-	command := smbenc.NewReader(data).ReadUint32()
-	if command != aaplCommandServerQuery {
+	r := smbenc.NewReader(data)
+	command := r.ReadUint32()
+	r.Skip(4) // Reserved
+	requestBitmap := r.ReadUint64()
+	if r.Err() != nil || command != aaplCommandServerQuery {
+		return nil
+	}
+	// The only field we can answer is ServerCaps; if the client didn't request
+	// it there is nothing useful to return.
+	if requestBitmap&aaplReplyBitmapServerCaps == 0 {
 		return nil
 	}
 

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1392,6 +1392,16 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			"maximalAccess", fmt.Sprintf("0x%08x", maxAccess))
 	}
 
+	if aapl := FindCreateContext(req.CreateContexts, aaplCreateContextTag); aapl != nil {
+		if aaplResp := buildAAPLServerQueryResponse(aapl.Data); aaplResp != nil {
+			resp.CreateContexts = append(resp.CreateContexts, CreateContext{
+				Name: aaplCreateContextTag,
+				Data: aaplResp,
+			})
+			logger.Debug("CREATE: AAPL response added (UNIX-based volume caps)")
+		}
+	}
+
 	if FindCreateContext(req.CreateContexts, "QFid") != nil {
 		qfidFileID := h.baseFileUUID(authCtx, parentHandle, baseName, file.ID)
 		qfidResp := make([]byte, 32)

--- a/internal/adapter/smb/handlers/ioctl_dispatch.go
+++ b/internal/adapter/smb/handlers/ioctl_dispatch.go
@@ -23,6 +23,7 @@ func init() {
 	ioctlDispatch = map[uint32]IOCTLHandler{
 		FsctlValidateNegotiateInfo:  (*Handler).handleValidateNegotiateInfo,
 		FsctlGetReparsePoint:        (*Handler).handleGetReparsePoint,
+		FsctlSetReparsePoint:        (*Handler).handleSetReparsePoint,
 		FsctlPipeTransceive:         (*Handler).handlePipeTransceive,
 		FsctlGetNtfsVolumeData:      (*Handler).handleGetNtfsVolumeData,
 		FsctlReadFileUsnData:        (*Handler).handleReadFileUsnData,

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -1,0 +1,268 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// handleSetReparsePoint handles FSCTL_SET_REPARSE_POINT [MS-FSCC] 2.3.69 — the
+// write half of reparse-point support (the read half is handleGetReparsePoint).
+//
+// macOS (mount_smbfs) and Windows create symbolic links over SMB by: CREATE an
+// empty file → IOCTL FSCTL_SET_REPARSE_POINT with an IO_REPARSE_TAG_SYMLINK
+// buffer → CLOSE. Modern Linux cifs.ko with `reparse=nfs` uses
+// IO_REPARSE_TAG_NFS instead. Without this handler the IOCTL dispatcher returns
+// STATUS_NOT_SUPPORTED and symlink-bearing trees (.app bundles, .frameworks,
+// node_modules, dylib version chains) fail to upload (#1179).
+//
+// We convert the just-created regular file into a real metadata symlink so it
+// is interoperable with the NFS adapter (shared metadata.Service.CreateSymlink).
+func (h *Handler) handleSetReparsePoint(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
+	fileID, ok := parseIoctlFileID(body)
+	if !ok {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		logger.Debug("IOCTL SET_REPARSE_POINT: file handle not found (closed)", "fileID", fmt.Sprintf("%x", fileID))
+		return NewErrorResult(types.StatusFileClosed), nil
+	}
+
+	// A reparse point cannot be set on a directory handle here.
+	if openFile.IsDirectory {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	input := parseIoctlInputData(body)
+	if len(input) < 8 {
+		logger.Debug("IOCTL SET_REPARSE_POINT: input too small", "len", len(input))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// REPARSE_DATA_BUFFER header [MS-FSCC] 2.1.2.1: ReparseTag(4),
+	// ReparseDataLength(2), Reserved(2), then the tag-specific DataBuffer.
+	r := smbenc.NewReader(input)
+	reparseTag := r.ReadUint32()
+	reparseDataLen := int(r.ReadUint16())
+	r.Skip(2) // Reserved
+	if r.Err() != nil {
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	dataBuf := input[8:]
+	if reparseDataLen > len(dataBuf) {
+		logger.Debug("IOCTL SET_REPARSE_POINT: ReparseDataLength overflows buffer",
+			"reparseDataLen", reparseDataLen, "have", len(dataBuf))
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+	dataBuf = dataBuf[:reparseDataLen]
+
+	var target string
+	var perr error
+	switch reparseTag {
+	case IoReparseTagSymlink:
+		target, perr = parseSymlinkReparseTarget(dataBuf)
+	case IoReparseTagNfs:
+		target, perr = parseNfsReparseTarget(dataBuf)
+	default:
+		logger.Debug("IOCTL SET_REPARSE_POINT: unsupported reparse tag",
+			"tag", fmt.Sprintf("0x%08X", reparseTag))
+		return NewErrorResult(types.StatusIoReparseTagMismatch), nil
+	}
+	if perr != nil {
+		logger.Debug("IOCTL SET_REPARSE_POINT: malformed reparse buffer",
+			"tag", fmt.Sprintf("0x%08X", reparseTag), "error", perr)
+		return NewErrorResult(types.StatusInvalidParameter), nil
+	}
+
+	// Normalize Windows separators to forward slash. Symlink targets are stored
+	// as opaque, client-resolved strings (the DittoFS server never follows
+	// them), so we apply the permissive NFS-style validator — matching what the
+	// NFS adapter already accepts via CreateSymlink — rather than the stricter
+	// MFsymlink validator. See pkg/metadata/validation.go.
+	target = strings.ReplaceAll(target, "\\", "/")
+	if err := metadata.ValidateSymlinkTarget(target); err != nil {
+		logger.Debug("IOCTL SET_REPARSE_POINT: invalid symlink target", "error", err)
+		return NewErrorResult(common.MapToSMB(err)), nil
+	}
+
+	if err := h.convertOpenFileToNativeSymlink(ctx, openFile, target); err != nil {
+		logger.Warn("IOCTL SET_REPARSE_POINT: failed to create symlink",
+			"path", openFile.Path, "target", target, "error", err)
+		return NewErrorResult(common.MapToSMB(err)), nil
+	}
+
+	logger.Debug("IOCTL SET_REPARSE_POINT: created symlink", "path", openFile.Path, "target", target)
+
+	// FSCTL_SET_REPARSE_POINT has no output buffer.
+	resp := buildIoctlResponse(FsctlSetReparsePoint, fileID, nil)
+	return NewResult(types.StatusSuccess, resp), nil
+}
+
+// parseSymlinkReparseTarget decodes the target path from a
+// SYMBOLIC_LINK_REPARSE_DATA_BUFFER DataBuffer [MS-FSCC] 2.1.2.4 (the bytes
+// after the 8-byte REPARSE_DATA_BUFFER header):
+//
+//	SubstituteNameOffset(2) SubstituteNameLength(2) PrintNameOffset(2)
+//	PrintNameLength(2) Flags(4) PathBuffer(var, UTF-16LE)
+//
+// PathBuffer begins 12 bytes into the DataBuffer; the name offsets are relative
+// to the start of PathBuffer. We prefer the PrintName (human-readable, e.g.
+// "../A") and fall back to the SubstituteName, stripping the Windows `\??\`
+// device prefix.
+func parseSymlinkReparseTarget(data []byte) (string, error) {
+	if len(data) < 12 {
+		return "", fmt.Errorf("symlink reparse data too small: %d", len(data))
+	}
+	r := smbenc.NewReader(data)
+	subOff := int(r.ReadUint16())
+	subLen := int(r.ReadUint16())
+	printOff := int(r.ReadUint16())
+	printLen := int(r.ReadUint16())
+	_ = r.ReadUint32() // Flags: bit 0 = relative [MS-FSCC] 2.1.2.4; ignored, targets are opaque
+	if r.Err() != nil {
+		return "", fmt.Errorf("symlink reparse header truncated")
+	}
+	const pathBufferStart = 12
+	pathBuffer := data[pathBufferStart:]
+
+	read := func(off, length int) (string, bool) {
+		if length <= 0 || length%2 != 0 {
+			return "", false
+		}
+		if off < 0 || off+length > len(pathBuffer) {
+			return "", false
+		}
+		return decodeUTF16LE(pathBuffer[off : off+length]), true
+	}
+
+	if s, ok := read(printOff, printLen); ok && s != "" {
+		return stripReparsePrefix(s), nil
+	}
+	if s, ok := read(subOff, subLen); ok && s != "" {
+		return stripReparsePrefix(s), nil
+	}
+	return "", fmt.Errorf("symlink reparse buffer has no usable name")
+}
+
+// parseNfsReparseTarget decodes the target from an IO_REPARSE_TAG_NFS DataBuffer
+// [MS-FSCC] 2.1.2.6. For a symlink the DataBuffer is an 8-byte InodeType equal
+// to NFS_SPECFILE_LNK followed by the target path. Linux cifs.ko (`reparse=nfs`)
+// emits the target as UTF-8 bytes. This branch is best-effort Linux interop;
+// the macOS/Windows path uses parseSymlinkReparseTarget. Authoritative
+// validation requires a real Linux `reparse=nfs` mount.
+func parseNfsReparseTarget(data []byte) (string, error) {
+	if len(data) < 8 {
+		return "", fmt.Errorf("nfs reparse data too small: %d", len(data))
+	}
+	inodeType := smbenc.NewReader(data).ReadUint64()
+	if inodeType != nfsSpecfileLnk {
+		return "", fmt.Errorf("nfs reparse inode type 0x%x is not a symlink", inodeType)
+	}
+	target := strings.TrimRight(string(data[8:]), "\x00")
+	if target == "" {
+		return "", fmt.Errorf("nfs reparse buffer has empty target")
+	}
+	return target, nil
+}
+
+// stripReparsePrefix removes the Windows `\??\` (or already-normalized `/??/`)
+// NT-namespace device prefix that Windows clients prepend to absolute symlink
+// SubstituteNames.
+func stripReparsePrefix(s string) string {
+	s = strings.TrimPrefix(s, `\??\`)
+	s = strings.TrimPrefix(s, "/??/")
+	return s
+}
+
+// convertOpenFileToNativeSymlink removes the just-created regular file backing
+// openFile and creates a real symlink in its place, then refreshes openFile so
+// the trailing CLOSE is a clean no-op.
+//
+// This mirrors convertToRealSymlink (the MFsymlink/CLOSE path) but (a) uses the
+// permissive symlink-target validation already applied by the caller and (b)
+// handles the mid-session stale-handle problem: unlike MFsymlink conversion
+// (which runs at CLOSE as the handle is torn down), SET_REPARSE_POINT converts
+// while the handle is still open and the client will CLOSE it afterward. After
+// the remove+recreate, openFile.MetadataHandle/PayloadID point at the deleted
+// regular file, so we repoint MetadataHandle at the new symlink and clear
+// PayloadID. That makes CLOSE step 5 (MFsymlink re-read, gated on PayloadID)
+// skip and step 6 (POSTQUERY GetFile) resolve the symlink. The client does not
+// set DELETE_ON_CLOSE here, so no delete fires.
+func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFile *OpenFile, target string) error {
+	if len(openFile.ParentHandle) == 0 || openFile.FileName == "" {
+		return fmt.Errorf("missing parent handle or filename for symlink conversion")
+	}
+
+	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil synthesises UID-0
+	// (root), bypassing DACL checks on RemoveFile + CreateSymlink (#619).
+	h.primeAuthContextFromOpenFile(ctx, openFile)
+
+	authCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	parentHandle := openFile.ParentHandle
+	fileName := openFile.FileName
+
+	metaSvc := h.Registry.GetMetadataService()
+	removed, _, err := metaSvc.RemoveFile(authCtx, parentHandle, fileName)
+	if err != nil {
+		return fmt.Errorf("failed to remove placeholder file: %w", err)
+	}
+
+	// Delete content from block store (best-effort). RemoveFile returns an
+	// empty PayloadID when content must survive (hard link / recycle).
+	var removedPayloadID metadata.PayloadID
+	if removed != nil {
+		removedPayloadID = removed.PayloadID
+	}
+	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Path, "SET_REPARSE_POINT")
+
+	symlink, _, err := metaSvc.CreateSymlink(authCtx, parentHandle, fileName, target, &metadata.FileAttr{})
+	if err != nil {
+		// The placeholder is already unlinked; CreateSymlink failing would
+		// otherwise leave the name with neither a file nor a symlink. Best-effort
+		// re-create an empty regular placeholder so the namespace entry (and the
+		// still-open handle's CLOSE path) survive. Return the original error.
+		if _, _, reErr := metaSvc.CreateFile(authCtx, parentHandle, fileName, &metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644,
+		}); reErr != nil {
+			logger.Warn("SET_REPARSE_POINT: symlink create failed and placeholder rollback failed",
+				"path", openFile.Path, "createErr", err, "rollbackErr", reErr)
+		}
+		return fmt.Errorf("failed to create symlink: %w", err)
+	}
+
+	// Refresh the open handle to point at the new symlink so the trailing CLOSE
+	// does not operate on the deleted regular file. openFile is the same pointer
+	// held in h.files, so the in-place mutation under mu is sufficient — no
+	// StoreOpenFile re-insert (which could resurrect a handle a concurrent
+	// session teardown just removed).
+	newHandle, err := metadata.EncodeFileHandle(symlink)
+	if err != nil {
+		return fmt.Errorf("failed to encode new symlink handle: %w", err)
+	}
+	openFile.mu.Lock()
+	openFile.MetadataHandle = newHandle
+	openFile.PayloadID = ""
+	openFile.mu.Unlock()
+
+	// Notify directory watchers of the placeholder→symlink replacement so client
+	// directory views (Finder/Explorer) refresh without a full re-enumeration.
+	if h.NotifyRegistry != nil {
+		parentPath := GetParentPath(openFile.Path)
+		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionRemoved, FileNotifyChangeFileName)
+		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionAdded, FileNotifyChangeFileName)
+	}
+
+	return nil
+}

--- a/internal/adapter/smb/handlers/set_reparse_point_test.go
+++ b/internal/adapter/smb/handlers/set_reparse_point_test.go
@@ -1,0 +1,362 @@
+// Handler-level coverage for native SMB symlink creation via
+// FSCTL_SET_REPARSE_POINT (#1179). macOS and Windows create symlinks over SMB
+// by issuing this FSCTL on a freshly-created file; the handler converts the
+// placeholder into a real metadata symlink. These tests drive
+// h.handleSetReparsePoint end-to-end against a memory metadata + block store.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupReparseShare wires a handler + runtime + memory metadata + memory block
+// store with a single share, creates an empty regular file "link" under the
+// root (the placeholder a client opens before SET_REPARSE_POINT), and registers
+// an OpenFile for it. Returns the handler, a primed SMBHandlerContext, the share
+// root handle, and the FileID of the registered OpenFile.
+func setupReparseShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.FileHandle, [16]byte) {
+	t.Helper()
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "rpmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("rpmeta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "rpbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/rp"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "rpmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	const fileName = "link"
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, fileName, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	const callerUID, callerGID uint32 = 1000, 1000
+	suid, sgid := callerUID, callerGID
+	sess := h.CreateSession("127.0.0.1:12345", false, "test-user", "")
+	sess.User = &models.User{
+		Username: "test-user",
+		UID:      &suid,
+		Groups:   []models.Group{{GID: &sgid}},
+	}
+
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:     treeID,
+		SessionID:  sess.SessionID,
+		ShareName:  shareName,
+		Permission: models.PermissionReadWrite,
+	})
+
+	fileID := [16]byte{1}
+	openFile := &OpenFile{
+		FileID:         fileID,
+		TreeID:         treeID,
+		SessionID:      sess.SessionID,
+		Path:           fileName,
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
+		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
+		MetadataHandle: fileHandle,
+		ParentHandle:   rootHandle,
+		FileName:       fileName,
+	}
+	h.StoreOpenFile(openFile)
+
+	smbCtx := &SMBHandlerContext{
+		Context:   ctx,
+		SessionID: sess.SessionID,
+		TreeID:    treeID,
+		ShareName: shareName,
+	}
+
+	return h, smbCtx, rootHandle, fileID
+}
+
+// buildSetReparseBody assembles a minimal FSCTL_SET_REPARSE_POINT IOCTL request
+// body [MS-SMB2] 2.2.31 carrying the given REPARSE_DATA_BUFFER as input. The
+// 56-byte fixed portion is followed by the buffer; InputOffset is the
+// SMB2-header-relative offset (64 + 56).
+func buildSetReparseBody(fileID [16]byte, reparse []byte) []byte {
+	w := smbenc.NewWriter(56 + len(reparse))
+	w.WriteUint16(57)                   // StructureSize
+	w.WriteUint16(0)                    // Reserved
+	w.WriteUint32(FsctlSetReparsePoint) // CtlCode
+	w.WriteBytes(fileID[:])             // FileId
+	w.WriteUint32(120)                  // InputOffset (header 64 + fixed body 56)
+	w.WriteUint32(uint32(len(reparse))) // InputCount
+	w.WriteUint32(0)                    // MaxInputResponse
+	w.WriteUint32(0)                    // OutputOffset
+	w.WriteUint32(0)                    // OutputCount
+	w.WriteUint32(0)                    // MaxOutputResponse
+	w.WriteUint32(0)                    // Flags
+	w.WriteUint32(0)                    // Reserved2
+	w.WriteBytes(reparse)
+	return w.Bytes()
+}
+
+// buildNfsSymlinkReparseBuffer builds an IO_REPARSE_TAG_NFS REPARSE_DATA_BUFFER
+// carrying an NFS_SPECFILE_LNK symlink target (UTF-8), as Linux cifs.ko emits
+// with mount option reparse=nfs.
+func buildNfsSymlinkReparseBuffer(target string) []byte {
+	data := smbenc.NewWriter(8 + len(target))
+	data.WriteUint64(nfsSpecfileLnk)
+	data.WriteBytes([]byte(target))
+	dataBytes := data.Bytes()
+
+	w := smbenc.NewWriter(8 + len(dataBytes))
+	w.WriteUint32(IoReparseTagNfs)
+	w.WriteUint16(uint16(len(dataBytes)))
+	w.WriteUint16(0) // Reserved
+	w.WriteBytes(dataBytes)
+	return w.Bytes()
+}
+
+// symlinkTargetAfter resolves the "link" entry under rootHandle and returns its
+// metadata type and (if a symlink) its target.
+func symlinkTargetAfter(t *testing.T, h *Handler, smbCtx *SMBHandlerContext, rootHandle metadata.FileHandle) (metadata.FileType, string) {
+	t.Helper()
+	metaSvc := h.Registry.GetMetadataService()
+	childHandle, err := metaSvc.GetChild(smbCtx.Context, rootHandle, "link")
+	if err != nil {
+		t.Fatalf("GetChild(link): %v", err)
+	}
+	file, err := metaSvc.GetFile(smbCtx.Context, childHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	return file.Type, file.LinkTarget
+}
+
+func TestSetReparsePoint_CreatesRelativeSymlink(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, buildSymlinkReparseBuffer("../A"))
+
+	resp, err := h.handleSetReparsePoint(smbCtx, body)
+	if err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+
+	gotType, gotTarget := symlinkTargetAfter(t, h, smbCtx, rootHandle)
+	if gotType != metadata.FileTypeSymlink {
+		t.Fatalf("type = %v, want FileTypeSymlink", gotType)
+	}
+	if gotTarget != "../A" {
+		t.Fatalf("target = %q, want %q", gotTarget, "../A")
+	}
+}
+
+// TestSetReparsePoint_AbsoluteTargetAllowed documents the permissive (NFS-style)
+// validation decision: absolute targets are accepted, matching what the NFS
+// adapter already stores (targets are opaque, client-resolved strings).
+func TestSetReparsePoint_AbsoluteTargetAllowed(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, buildSymlinkReparseBuffer("/usr/local/lib/foo"))
+
+	resp, err := h.handleSetReparsePoint(smbCtx, body)
+	if err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+	gotType, gotTarget := symlinkTargetAfter(t, h, smbCtx, rootHandle)
+	if gotType != metadata.FileTypeSymlink || gotTarget != "/usr/local/lib/foo" {
+		t.Fatalf("got (%v, %q), want (symlink, %q)", gotType, gotTarget, "/usr/local/lib/foo")
+	}
+}
+
+// TestSetReparsePoint_CloseAfterConvertIsNoop verifies the stale-handle refresh:
+// after conversion the still-open handle is repointed at the new symlink so the
+// trailing CLOSE succeeds and the symlink survives.
+func TestSetReparsePoint_CloseAfterConvertIsNoop(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, buildSymlinkReparseBuffer("target/path"))
+
+	if _, err := h.handleSetReparsePoint(smbCtx, body); err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+
+	resp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Close status = 0x%08x, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+
+	gotType, gotTarget := symlinkTargetAfter(t, h, smbCtx, rootHandle)
+	if gotType != metadata.FileTypeSymlink || gotTarget != "target/path" {
+		t.Fatalf("after close got (%v, %q), want (symlink, %q)", gotType, gotTarget, "target/path")
+	}
+}
+
+func TestSetReparsePoint_WrongTagRejected(t *testing.T) {
+	h, smbCtx, _, fileID := setupReparseShare(t)
+
+	// REPARSE_DATA_BUFFER with a non-symlink tag (mount point).
+	const ioReparseTagMountPoint uint32 = 0xA0000003
+	w := smbenc.NewWriter(16)
+	w.WriteUint32(ioReparseTagMountPoint)
+	w.WriteUint16(8) // ReparseDataLength
+	w.WriteUint16(0) // Reserved
+	w.WriteUint64(0) // bogus data
+	body := buildSetReparseBody(fileID, w.Bytes())
+
+	resp, err := h.handleSetReparsePoint(smbCtx, body)
+	if err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+	if resp.Status != types.StatusIoReparseTagMismatch {
+		t.Fatalf("status = 0x%08x, want STATUS_IO_REPARSE_TAG_MISMATCH", uint32(resp.Status))
+	}
+}
+
+func TestSetReparsePoint_TruncatedBufferRejected(t *testing.T) {
+	h, smbCtx, _, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, []byte{0x0c, 0x00, 0x00}) // < 8 bytes
+
+	resp, err := h.handleSetReparsePoint(smbCtx, body)
+	if err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+	if resp.Status != types.StatusInvalidParameter {
+		t.Fatalf("status = 0x%08x, want STATUS_INVALID_PARAMETER", uint32(resp.Status))
+	}
+}
+
+func TestSetReparsePoint_NfsTagSymlink(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, buildNfsSymlinkReparseBuffer("../sibling"))
+
+	resp, err := h.handleSetReparsePoint(smbCtx, body)
+	if err != nil {
+		t.Fatalf("handleSetReparsePoint: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+	gotType, gotTarget := symlinkTargetAfter(t, h, smbCtx, rootHandle)
+	if gotType != metadata.FileTypeSymlink || gotTarget != "../sibling" {
+		t.Fatalf("got (%v, %q), want (symlink, %q)", gotType, gotTarget, "../sibling")
+	}
+}
+
+func TestSetReparsePoint_DispatchedViaIoctl(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+	body := buildSetReparseBody(fileID, buildSymlinkReparseBuffer("dispatched"))
+
+	resp, err := h.Ioctl(smbCtx, body)
+	if err != nil {
+		t.Fatalf("Ioctl: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Ioctl status = 0x%08x, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+	if gotType, _ := symlinkTargetAfter(t, h, smbCtx, rootHandle); gotType != metadata.FileTypeSymlink {
+		t.Fatalf("type = %v, want FileTypeSymlink", gotType)
+	}
+}
+
+func TestBuildAAPLServerQueryResponse(t *testing.T) {
+	// Server query (command code 1): expect a 24-byte reply advertising
+	// UNIX-based server caps.
+	req := smbenc.NewWriter(24)
+	req.WriteUint32(aaplCommandServerQuery)
+	req.WriteUint32(0)
+	req.WriteUint64(0x7) // RequestBitmap: caps|volcaps|model
+	req.WriteUint64(0)   // ClientCapabilities
+
+	resp := buildAAPLServerQueryResponse(req.Bytes())
+	if len(resp) != 24 {
+		t.Fatalf("response len = %d, want 24", len(resp))
+	}
+	r := smbenc.NewReader(resp)
+	if cmd := r.ReadUint32(); cmd != aaplCommandServerQuery {
+		t.Fatalf("CommandCode = %d, want %d", cmd, aaplCommandServerQuery)
+	}
+	r.Skip(4) // Reserved
+	if bitmap := r.ReadUint64(); bitmap != aaplReplyBitmapServerCaps {
+		t.Fatalf("ReplyBitmap = 0x%x, want 0x%x", bitmap, aaplReplyBitmapServerCaps)
+	}
+	if caps := r.ReadUint64(); caps&aaplServerCapUnixBased == 0 {
+		t.Fatalf("ServerCaps = 0x%x, missing UNIX_BASED bit", caps)
+	}
+
+	// Non-server-query command code → no response.
+	other := smbenc.NewWriter(8)
+	other.WriteUint32(99)
+	other.WriteUint32(0)
+	if got := buildAAPLServerQueryResponse(other.Bytes()); got != nil {
+		t.Fatalf("non-query command returned %d bytes, want nil", len(got))
+	}
+
+	// Too-short data → no response.
+	if got := buildAAPLServerQueryResponse([]byte{1, 0, 0}); got != nil {
+		t.Fatalf("short data returned %d bytes, want nil", len(got))
+	}
+}

--- a/internal/adapter/smb/handlers/set_reparse_point_test.go
+++ b/internal/adapter/smb/handlers/set_reparse_point_test.go
@@ -347,12 +347,24 @@ func TestBuildAAPLServerQueryResponse(t *testing.T) {
 		t.Fatalf("ServerCaps = 0x%x, missing UNIX_BASED bit", caps)
 	}
 
-	// Non-server-query command code → no response.
-	other := smbenc.NewWriter(8)
+	// Non-server-query command code (full 24-byte request) → no response.
+	other := smbenc.NewWriter(24)
 	other.WriteUint32(99)
 	other.WriteUint32(0)
+	other.WriteUint64(0x7)
+	other.WriteUint64(0)
 	if got := buildAAPLServerQueryResponse(other.Bytes()); got != nil {
 		t.Fatalf("non-query command returned %d bytes, want nil", len(got))
+	}
+
+	// Server query that does NOT request server caps (bit 0 clear) → no response.
+	noCaps := smbenc.NewWriter(24)
+	noCaps.WriteUint32(aaplCommandServerQuery)
+	noCaps.WriteUint32(0)
+	noCaps.WriteUint64(0x6) // volcaps|model, but not server caps
+	noCaps.WriteUint64(0)
+	if got := buildAAPLServerQueryResponse(noCaps.Bytes()); got != nil {
+		t.Fatalf("caps-not-requested returned %d bytes, want nil", len(got))
 	}
 
 	// Too-short data → no response.

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -29,6 +29,7 @@ const (
 	FsctlSrvCopyChunk           uint32 = 0x001440F2 // [MS-SMB2] 2.2.32.1
 	FsctlSrvCopyChunkWrite      uint32 = 0x001480F2 // [MS-SMB2] 2.2.32.1
 	FsctlGetReparsePoint        uint32 = 0x000900A8 // [MS-FSCC] 2.3.30
+	FsctlSetReparsePoint        uint32 = 0x000900D4 // [MS-FSCC] 2.3.69 - Set reparse point (symlink create)
 	FsctlIsPathnameValid        uint32 = 0x0009002C // [MS-FSCC] 2.3.33 - Pathname validation
 	FsctlGetNtfsVolumeData      uint32 = 0x00090064 // [MS-FSCC] 2.3.29 - NTFS volume data
 	FsctlReadFileUsnData        uint32 = 0x000900EB // [MS-FSCC] 2.3.56 - Read file USN data
@@ -85,6 +86,14 @@ const (
 // Reparse point constants [MS-FSCC] 2.1.2.1
 const (
 	IoReparseTagSymlink uint32 = 0xA000000C
+	// IoReparseTagNfs is the NFS reparse tag [MS-FSCC] 2.1.2.6. Modern Linux
+	// cifs.ko with mount option `reparse=nfs` creates symlinks using this tag
+	// (carrying an NFS_SPECFILE_LNK sub-buffer) instead of IO_REPARSE_TAG_SYMLINK.
+	IoReparseTagNfs uint32 = 0x80000014
+
+	// nfsSpecfileLnk is the NFS_SPECFILE_LNK type tag that prefixes the symlink
+	// target inside an IO_REPARSE_TAG_NFS reparse buffer [MS-FSCC] 2.1.2.6.
+	nfsSpecfileLnk uint64 = 0x00000000014B4E4C // "LNK\x01" little-endian
 )
 
 // handleGetReparsePoint handles FSCTL_GET_REPARSE_POINT for readlink

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -196,6 +196,11 @@ const (
 	// StatusNotAReparsePoint indicates the file is not a reparse point.
 	StatusNotAReparsePoint Status = 0xC0000275
 
+	// StatusIoReparseTagMismatch indicates the reparse tag in a
+	// FSCTL_SET_REPARSE_POINT request does not match a tag the server can
+	// handle. Per MS-ERREF 2.3.1.
+	StatusIoReparseTagMismatch Status = 0xC0000278
+
 	// StatusFileLockConflict indicates an I/O operation (READ/WRITE) conflicts
 	// with an existing byte-range lock held by another session.
 	// Per MS-SMB2 3.3.5.15 (Read) and 3.3.5.16 (Write).
@@ -344,6 +349,8 @@ func (s Status) String() string {
 		return "STATUS_UNEXPECTED_IO_ERROR"
 	case StatusNotAReparsePoint:
 		return "STATUS_NOT_A_REPARSE_POINT"
+	case StatusIoReparseTagMismatch:
+		return "STATUS_IO_REPARSE_TAG_MISMATCH"
 	case StatusFileLockConflict:
 		return "STATUS_FILE_LOCK_CONFLICT"
 	case StatusLockNotGranted:


### PR DESCRIPTION
## Problem

macOS cannot upload code-signed `.app` bundles (and any tree containing symlinks: `.framework`s, `node_modules`, dylib version chains) to a DittoFS share over SMB. macOS/Windows create symlinks with a native request: CREATE an empty file → IOCTL `FSCTL_SET_REPARSE_POINT` (`IO_REPARSE_TAG_SYMLINK`) → CLOSE. DittoFS had **no SET_REPARSE_POINT handler**, so the IOCTL dispatcher fell through to `STATUS_NOT_SUPPORTED` and the client reported `Operation not supported` — frameworks landed broken, the upload failed.

This was an SMB-adapter **write-half gap only**: the read half (`GET_REPARSE_POINT` → `ReadSymlink`), the metadata `CreateSymlink`, and the `FileTypeSymlink` → `FILE_ATTRIBUTE_REPARSE_POINT` mapping already existed and are shared with the NFS adapter.

Closes #1179.

## Change

- **`handleSetReparsePoint`** (`set_reparse_point.go`) parses the symlink reparse buffer (`IO_REPARSE_TAG_SYMLINK` UTF-16, plus `IO_REPARSE_TAG_NFS` UTF-8 for Linux `cifs reparse=nfs`) and converts the placeholder regular file into a real metadata symlink via `RemoveFile` + `CreateSymlink`, mirroring the existing MFsymlink CLOSE conversion (`convertToRealSymlink`).
- **Stale-handle refresh**: conversion runs mid-session (not at CLOSE like MFsymlink), so the open handle is repointed at the new symlink and `PayloadID` cleared, making the trailing CLOSE a clean no-op. On `CreateSymlink` failure the placeholder is re-created best-effort so the name is never orphaned.
- **AAPL CREATE-context negotiation** (`aapl.go` + `create_post_break.go`) advertises a UNIX-based volume so macOS uses native symlinks.
- New status `STATUS_IO_REPARSE_TAG_MISMATCH`; dispatch entry wired in `ioctl_dispatch.go`.

## Design decisions

- **Always-on** (no share flag) — matches NFS, which creates symlinks unconditionally; app bundles upload out of the box.
- **Permissive target validation** (`metadata.ValidateSymlinkTarget`, allows absolute + `..`). Symlink targets are opaque, client-resolved strings — the server never follows them (NFS does client-side READLINK+re-LOOKUP; SMB `walkPath` returns symlink leaves as-is) — and the NFS adapter already stores such targets, so this keeps behaviour consistent across protocols and doesn't break legitimate absolute symlinks on macOS/Linux.

## Client coverage

| Client | Mechanism | Status |
|--------|-----------|--------|
| macOS `mount_smbfs` | SET_REPARSE_POINT + AAPL | ✅ primary fix |
| Windows | SET_REPARSE_POINT | ✅ |
| Linux `mount.cifs -o mfsymlinks` | XSym/CLOSE (pre-existing) | ✅ |
| Linux `mount.cifs reparse=nfs` | `IO_REPARSE_TAG_NFS` | ✅ best-effort (Linux-only branch) |

## Tests

`set_reparse_point_test.go` (8 cases): relative/absolute symlink create, NFS-tag symlink, wrong-tag → `STATUS_IO_REPARSE_TAG_MISMATCH`, truncated buffer → `STATUS_INVALID_PARAMETER`, CLOSE-after-convert no-op (stale-handle refresh), dispatch via `Ioctl`, and AAPL response wire format. Full SMB + metadata suites pass; `go build ./...` and `go vet` clean. Authoritative end-to-end validation is the issue repro on a real macOS SMB mount (`ln -s`, `cp -R` a `.framework`).