### PR TITLE
feat(blockstore): bounded local cache + observable write backpressure

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -176,10 +176,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// Set per-share defaults BEFORE loading shares (AddShare creates BlockStores).
 	rt.SetLocalStoreDefaults(&shares.LocalStoreDefaults{
-		MaxSize:         deduced.LocalStoreSize,
-		MaxMemory:       block.ClampToInt64(deduced.MaxPendingSize),
-		ReadBufferBytes: deduced.ReadBufferSize,
-		DedupLRUSize:    cfg.Blockstore.Local.DedupLRUSize,
+		MaxSize:                deduced.LocalStoreSize,
+		MaxMemory:              block.ClampToInt64(deduced.MaxPendingSize),
+		ReadBufferBytes:        deduced.ReadBufferSize,
+		DedupLRUSize:           cfg.Blockstore.Local.DedupLRUSize,
+		DefaultRemoteCacheSize: cfg.Blockstore.Local.DefaultRemoteCacheSize,
+		BackpressureMaxWait:    cfg.Blockstore.Local.BackpressureMaxWait,
 	})
 	rt.SetSyncerDefaults(&shares.SyncerDefaults{
 		ParallelUploads:   deduced.ParallelSyncs,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -410,8 +410,8 @@ filling the host volume, the local cache is bounded and writes apply
   per-share size (`dfsctl share … --local-store-size`), the cache is capped at
   `blockstore.local.default_remote_cache_size` (default **10 GiB**). An
   explicit `--local-store-size` always wins. **Local-only shares are
-  unaffected** — they keep their (unlimited / system-deduced) local size and
-  never apply remote-cache backpressure.
+  unaffected** — they keep their existing system-deduced local size and never
+  apply remote-cache backpressure.
 - **Backpressure stall.** When the cache is full and every cached chunk is
   still unsynced, a write **stalls** waiting for the syncer to drain to the
   remote and free space, rather than failing. The stall is bounded by
@@ -443,7 +443,7 @@ blockstore:
   local:
     default_remote_cache_size: 10737418240   # 10 GiB; cap for remote-backed
                                              # shares with no explicit size.
-                                             # 0 = no conditional cap.
+                                             # Defaults to 10 GiB if unset.
     backpressure_max_wait: 60s               # Max time a write stalls for the
                                              # syncer to drain before disk-full.
     dedup_lru_size: 4096                      # In-memory dedup LRU slot count.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -397,6 +397,67 @@ See [ARCHITECTURE.md](ARCHITECTURE.md#garbage-collection-mark-sweep)
 for the full mark-sweep design and [CLI.md](CLI.md) for the on-demand
 `dfsctl store block gc` command.
 
+#### Local cache size limit & write backpressure
+
+When a share has a **remote** block store configured (S3 or filesystem
+remote), the on-disk local tier is a **temporary write-through cache**, not
+durable storage — every chunk is mirrored to the remote and may be evicted
+locally once synced. To stop a fast writer with a slow/lagging uploader from
+filling the host volume, the local cache is bounded and writes apply
+**graceful, observable backpressure** when it fills:
+
+- **Bounded cache.** If a remote is configured and you set no explicit
+  per-share size (`dfsctl share … --local-store-size`), the cache is capped at
+  `blockstore.local.default_remote_cache_size` (default **10 GiB**). An
+  explicit `--local-store-size` always wins. **Local-only shares are
+  unaffected** — they keep their (unlimited / system-deduced) local size and
+  never apply remote-cache backpressure.
+- **Backpressure stall.** When the cache is full and every cached chunk is
+  still unsynced, a write **stalls** waiting for the syncer to drain to the
+  remote and free space, rather than failing. The stall is bounded by
+  `blockstore.local.backpressure_max_wait` (default **60s**).
+- **Hard failure only when the remote cannot drain.** If the remote is
+  **unhealthy** (genuinely unreachable, not merely slow) or the backpressure
+  window is exceeded, the write fails with disk-full
+  (`NFS3ERR_NOSPC` / `NFS4ERR_NOSPC` / SMB `STATUS_DISK_FULL`) instead of
+  silently filling the disk.
+
+**Diagnosing a stall.** Backpressure engage/release events are logged
+(rate-limited) at `INFO`, so a stalled writer is never a mystery:
+
+```
+INFO  local cache backpressure engaged: waiting for syncer to drain
+      store=… disk_used=10737418240 max_disk=10737418240 needed=…
+      unsynced_bytes=… remote_healthy=true max_wait_ms=60000
+INFO  local cache backpressure released  store=… reason=space_freed
+      disk_used=… max_disk=… unsynced_bytes=… remote_healthy=true stall_ms=…
+```
+
+`reason` distinguishes a clean recovery (`space_freed`) from a failure
+(`window_exceeded`, `remote_unhealthy`).
+
+These knobs live in the top-level server-config `blockstore.local` block:
+
+```yaml
+blockstore:
+  local:
+    default_remote_cache_size: 10737418240   # 10 GiB; cap for remote-backed
+                                             # shares with no explicit size.
+                                             # 0 = no conditional cap.
+    backpressure_max_wait: 60s               # Max time a write stalls for the
+                                             # syncer to drain before disk-full.
+    dedup_lru_size: 4096                      # In-memory dedup LRU slot count.
+```
+
+Env-var mapping (dot-path convention):
+`DITTOFS_BLOCKSTORE_LOCAL_DEFAULT_REMOTE_CACHE_SIZE`,
+`DITTOFS_BLOCKSTORE_LOCAL_BACKPRESSURE_MAX_WAIT`,
+`DITTOFS_BLOCKSTORE_LOCAL_DEDUP_LRU_SIZE`.
+
+> Prometheus metrics for cache pressure / unsynced bytes are tracked
+> separately (server-wide instrumentation, issue #1188); today the signal is
+> the structured logs above.
+
 #### Recycle bin (trash)
 
 The recycle bin is configured **per share** via `dfsctl share create` /

--- a/flake.nix
+++ b/flake.nix
@@ -383,7 +383,7 @@
 
               # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
               # Manual: go run scripts/update-nix-hash.go
-              vendorHash = "sha256-fgJAQv6CEbbYDrBwNa/5cyxGNhQ+1Is89l5T7MxxagI=";
+              vendorHash = "sha256-TNhJOSe43CTxb8/sU+WJUbn/b6iSbc+x6Au212dQGJo=";
 
               ldflags = [
                 "-s"

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/term v0.42.0
+	golang.org/x/time v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -107,7 +108,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -335,8 +335,9 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 			bs.loadCache().Put(hash, data)
 			// Register the freshly-stored chunk for upload without a
 			// directory walk (B1). The syncer drains this set on each
-			// mirror pass; harmless when no remote is configured.
-			bs.syncer.addPendingHash(hash)
+			// mirror pass; harmless when no remote is configured. The byte
+			// size feeds the syncer's unsynced-bytes backpressure counter.
+			bs.syncer.addPendingHash(hash, int64(len(data)))
 		})
 
 		// (3) Install the per-chunk emitter (the in-memory backend
@@ -370,8 +371,9 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 				// Register for upload (B1). The in-memory backend creates
 				// chunks via this emitter rather than onChunkComplete, so
 				// without this the mirror loop's pending set would never
-				// see memory-backend chunks.
-				bs.syncer.addPendingHash(hash)
+				// see memory-backend chunks. size is the chunk's byte
+				// length, feeding the unsynced-bytes backpressure counter.
+				bs.syncer.addPendingHash(hash, int64(size))
 			})
 		}
 	}

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -65,7 +65,7 @@ func newFetchSyncer(localStore local.LocalStore, rs *remotememory.Store, fbs blo
 		inFlight:       make(map[string]*fetchResult),
 		stopCh:         make(chan struct{}),
 		config:         DefaultConfig(),
-		pendingHashes:  make(map[block.ContentHash]struct{}),
+		pendingHashes:  make(map[block.ContentHash]int64),
 	}
 }
 

--- a/pkg/block/engine/sync_health_integration_test.go
+++ b/pkg/block/engine/sync_health_integration_test.go
@@ -123,8 +123,8 @@ func newHealthTestEnv(t *testing.T) *healthTestEnv {
 	// Syncer + FSStore directly, bypassing engine.New): every rolled-up
 	// chunk registers in the syncer pending-upload set so the mirror loop
 	// has something to drain.
-	bc.SetOnChunkComplete(func(hash block.ContentHash, _ []byte, _ string) {
-		m.addPendingHash(hash)
+	bc.SetOnChunkComplete(func(hash block.ContentHash, data []byte, _ string) {
+		m.addPendingHash(hash, int64(len(data)))
 	})
 	t.Cleanup(func() {
 		_ = m.Close()

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -135,10 +135,11 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 // UnsyncedBytes returns the running total on-disk size of CAS chunks present
 // locally but not yet mirrored to remote. This is the backpressure signal
 // the local store consults: a non-zero value with a healthy remote means a
-// stalled writer can make progress once the syncer drains. Clamped at zero:
-// a transient drift reconcile that re-seeds a still-pending hash with a
-// best-effort size of 0 (its bytes vanished mid-walk) can briefly push the
-// raw counter negative, which must not read as "nothing pending".
+// stalled writer can make progress once the syncer drains. The raw counter
+// can briefly go negative when a drift reconcile re-seeds a still-pending
+// hash with a best-effort size of 0 (its bytes vanished mid-walk); this
+// method clamps such a transient to 0 so callers always see a non-negative
+// pending-byte count.
 func (m *Syncer) UnsyncedBytes() int64 {
 	if v := m.unsyncedBytes.Load(); v > 0 {
 		return v

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -119,14 +119,13 @@ type Syncer struct {
 // already pending updates the recorded size but does not double-count.
 func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	m.pendingMu.Lock()
-	prev, existed := m.pendingHashes[h]
+	// prev is the zero value (0) when the hash is new, so size-prev charges
+	// the full size on first insert and only the delta on re-add — never
+	// double-counting a hash already pending (CAS dedup).
+	prev := m.pendingHashes[h]
 	m.pendingHashes[h] = size
 	m.pendingMu.Unlock()
-	if existed {
-		m.unsyncedBytes.Add(size - prev)
-	} else {
-		m.unsyncedBytes.Add(size)
-	}
+	m.unsyncedBytes.Add(size - prev)
 }
 
 // UnsyncedBytes returns the running total on-disk size of CAS chunks present

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -121,19 +121,29 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	m.pendingMu.Lock()
 	// prev is the zero value (0) when the hash is new, so size-prev charges
 	// the full size on first insert and only the delta on re-add — never
-	// double-counting a hash already pending (CAS dedup).
+	// double-counting a hash already pending (CAS dedup). The counter update
+	// stays INSIDE pendingMu so it is serialized against mirrorOnce's drain
+	// (which deletes from the map and subtracts under the same lock): an
+	// add that interleaved a concurrent drain otherwise leaked a phantom
+	// positive byte count that no future drain would ever subtract.
 	prev := m.pendingHashes[h]
 	m.pendingHashes[h] = size
-	m.pendingMu.Unlock()
 	m.unsyncedBytes.Add(size - prev)
+	m.pendingMu.Unlock()
 }
 
 // UnsyncedBytes returns the running total on-disk size of CAS chunks present
 // locally but not yet mirrored to remote. This is the backpressure signal
 // the local store consults: a non-zero value with a healthy remote means a
-// stalled writer can make progress once the syncer drains.
+// stalled writer can make progress once the syncer drains. Clamped at zero:
+// a transient drift reconcile that re-seeds a still-pending hash with a
+// best-effort size of 0 (its bytes vanished mid-walk) can briefly push the
+// raw counter negative, which must not read as "nothing pending".
 func (m *Syncer) UnsyncedBytes() int64 {
-	return m.unsyncedBytes.Load()
+	if v := m.unsyncedBytes.Load(); v > 0 {
+		return v
+	}
+	return 0
 }
 
 // seedPendingFromDisk reconciles the in-memory pending set against the

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -88,26 +88,53 @@ type Syncer struct {
 	firstOfflineRead    atomic.Bool  // Tracks if WARN was already logged since last healthy->unhealthy transition
 	offlineReadsBlocked atomic.Int64 // Count of read operations blocked by remote unavailability
 
-	// pendingHashes is the set of CAS hashes present locally but not yet
-	// mirrored to remote. Populated O(1) by addPendingHash (fired from the
-	// onChunkComplete chokepoint) and drained by mirrorOnce after each
-	// MarkSynced. This replaces the per-tick full directory walk of the
-	// CAS tree: the steady-state mirror loop now consumes this set instead
-	// of rediscovering unsynced chunks via ListUnsynced. A startup
+	// pendingHashes maps each CAS hash present locally but not yet mirrored
+	// to remote to its on-disk byte size. Populated O(1) by addPendingHash
+	// (fired from the onChunkComplete chokepoint) and drained by mirrorOnce
+	// after each MarkSynced. This replaces the per-tick full directory walk
+	// of the CAS tree: the steady-state mirror loop now consumes this set
+	// instead of rediscovering unsynced chunks via ListUnsynced. A startup
 	// reconciliation (seedPendingFromDisk) re-seeds it after a restart,
 	// since the set is volatile and orphaned chunks written-but-not-synced
 	// before a crash would otherwise be missed.
+	//
+	// The per-hash size feeds unsyncedBytes, the backpressure signal the
+	// local store consults to decide whether to keep stalling a writer.
 	pendingMu     gosync.Mutex
-	pendingHashes map[block.ContentHash]struct{}
+	pendingHashes map[block.ContentHash]int64
+
+	// unsyncedBytes is the running total on-disk size of pendingHashes:
+	// the number of cache bytes that cannot be evicted until they reach
+	// remote. The local store reads it (via UnsyncedBytes) to decide
+	// whether a backpressure stall can make progress. Charged once per
+	// distinct hash (CAS dedup): re-adding a hash already pending does not
+	// double-count, and a drained hash subtracts exactly what it added.
+	unsyncedBytes atomic.Int64
 }
 
-// addPendingHash registers a newly-stored CAS hash for the next mirror
-// pass. Fired from the onChunkComplete callback (engine.New) on every
-// successful StoreChunk. Safe for concurrent use; O(1).
-func (m *Syncer) addPendingHash(h block.ContentHash) {
+// addPendingHash registers a newly-stored CAS hash (of the given on-disk
+// byte size) for the next mirror pass. Fired from the onChunkComplete
+// callback (engine.New) on every successful StoreChunk. Safe for concurrent
+// use; O(1). Charges unsyncedBytes once per distinct hash — re-adding a hash
+// already pending updates the recorded size but does not double-count.
+func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	m.pendingMu.Lock()
-	m.pendingHashes[h] = struct{}{}
+	prev, existed := m.pendingHashes[h]
+	m.pendingHashes[h] = size
 	m.pendingMu.Unlock()
+	if existed {
+		m.unsyncedBytes.Add(size - prev)
+	} else {
+		m.unsyncedBytes.Add(size)
+	}
+}
+
+// UnsyncedBytes returns the running total on-disk size of CAS chunks present
+// locally but not yet mirrored to remote. This is the backpressure signal
+// the local store consults: a non-zero value with a healthy remote means a
+// stalled writer can make progress once the syncer drains.
+func (m *Syncer) UnsyncedBytes() int64 {
+	return m.unsyncedBytes.Load()
 }
 
 // seedPendingFromDisk reconciles the in-memory pending set against the
@@ -123,7 +150,16 @@ func (m *Syncer) seedPendingFromDisk(ctx context.Context) (int, error) {
 		if err != nil {
 			return n, fmt.Errorf("seed pending: %w", err)
 		}
-		m.addPendingHash(hash)
+		// Recover each unsynced chunk's on-disk size so unsyncedBytes is
+		// accurate after a restart. A chunk that vanished between the
+		// ListUnsynced walk and this Head (external delete / concurrent
+		// evict) is recorded as zero bytes rather than aborting the seed —
+		// the next drift reconcile re-walks disk and corrects the set.
+		var size int64
+		if meta, herr := m.local.Head(ctx, hash); herr == nil {
+			size = meta.Size
+		}
+		m.addPendingHash(hash, size)
 		n++
 	}
 	return n, nil
@@ -155,7 +191,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 		config:         config,
 		inFlight:       make(map[string]*fetchResult),
 		stopCh:         make(chan struct{}),
-		pendingHashes:  make(map[block.ContentHash]struct{}),
+		pendingHashes:  make(map[block.ContentHash]int64),
 	}
 
 	queueConfig := DefaultSyncQueueConfig()
@@ -433,7 +469,10 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 			return fmt.Errorf("mark synced %s: %w", hash, err)
 		}
 		m.pendingMu.Lock()
-		delete(m.pendingHashes, hash)
+		if size, ok := m.pendingHashes[hash]; ok {
+			delete(m.pendingHashes, hash)
+			m.unsyncedBytes.Add(-size)
+		}
 		m.pendingMu.Unlock()
 	}
 	if lostBeforeMirror {

--- a/pkg/block/engine/syncer_evict_unsynced_test.go
+++ b/pkg/block/engine/syncer_evict_unsynced_test.go
@@ -44,7 +44,7 @@ func TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped(t *testing.T) {
 	sum := blake3.Sum256([]byte("never-stored-chunk"))
 	var h block.ContentHash
 	copy(h[:], sum[:])
-	syncer.addPendingHash(h)
+	syncer.addPendingHash(h, 0)
 
 	if got := syncer.pendingLen(); got != 1 {
 		t.Fatalf("precondition: pendingLen = %d, want 1", got)

--- a/pkg/block/engine/syncer_put_error_test.go
+++ b/pkg/block/engine/syncer_put_error_test.go
@@ -87,7 +87,7 @@ func TestMirrorLoop_PropagatesPutError(t *testing.T) {
 		local:           local,
 		remoteStore:     rs,
 		syncedHashStore: noopSyncedHashStore{},
-		pendingHashes:   make(map[block.ContentHash]struct{}),
+		pendingHashes:   make(map[block.ContentHash]int64),
 	}
 	if _, err := m.seedPendingFromDisk(ctx); err != nil {
 		t.Fatalf("seedPendingFromDisk: %v", err)

--- a/pkg/block/engine/syncer_verify_test.go
+++ b/pkg/block/engine/syncer_verify_test.go
@@ -52,7 +52,7 @@ func TestMirrorOnce_DetectsLocalCorruption_RefusesUpload(t *testing.T) {
 		local:           local,
 		remoteStore:     rs,
 		syncedHashStore: synced,
-		pendingHashes:   make(map[block.ContentHash]struct{}),
+		pendingHashes:   make(map[block.ContentHash]int64),
 	}
 	if _, err := m.seedPendingFromDisk(ctx); err != nil {
 		t.Fatalf("seedPendingFromDisk: %v", err)
@@ -97,7 +97,7 @@ func TestMirrorOnce_GoodHash_Uploads(t *testing.T) {
 		local:           local,
 		remoteStore:     rs,
 		syncedHashStore: synced,
-		pendingHashes:   make(map[block.ContentHash]struct{}),
+		pendingHashes:   make(map[block.ContentHash]int64),
 	}
 	if _, err := m.seedPendingFromDisk(ctx); err != nil {
 		t.Fatalf("seedPendingFromDisk: %v", err)

--- a/pkg/block/engine/unsynced_bytes_test.go
+++ b/pkg/block/engine/unsynced_bytes_test.go
@@ -15,11 +15,16 @@ import (
 // all to the remote. This is the integration backstop for the fs-internal
 // ensureSpace backpressure tests: it proves the counter the stall path reads
 // is actually fed and drained by the production wiring.
+//
+// The periodic uploader is deliberately NOT started (no env.syncer.Start):
+// it would drain chunks on its own 50ms tick and could empty the counter
+// before this test samples it, making the "rises" assertion racy (it flaked
+// on slower Windows runners). Draining here is driven synchronously via
+// SyncNow so both transitions are deterministic.
 func TestUnsyncedBytes_TracksDrain(t *testing.T) {
 	env := newHealthTestEnv(t)
 	ctx := context.Background()
-	env.local.Start(ctx)
-	env.syncer.Start(ctx)
+	env.local.Start(ctx) // FileBlock metadata persistence; rollup pool already started by newHealthTestEnv.
 
 	if got := env.syncer.UnsyncedBytes(); got != 0 {
 		t.Fatalf("UnsyncedBytes at start = %d, want 0", got)
@@ -34,36 +39,37 @@ func TestUnsyncedBytes_TracksDrain(t *testing.T) {
 	if err := env.local.AppendWrite(ctx, payloadID, data, 0); err != nil {
 		t.Fatalf("AppendWrite: %v", err)
 	}
-	if _, err := env.syncer.Flush(ctx, payloadID); err != nil {
-		t.Fatalf("Flush: %v", err)
-	}
 
-	// Drive rollup so the staged bytes land in the CAS chunk store, firing
-	// onChunkComplete → addPendingHash with each chunk's byte size.
+	// Let the stabilization window (StabilizationMS=50) elapse so the dirty
+	// interval is eligible for rollup, then force rollup synchronously until
+	// no dirty intervals remain. Each rolled-up chunk fires onChunkComplete →
+	// addPendingHash with its byte size.
 	time.Sleep(80 * time.Millisecond)
-	for i := 0; i < 16; i++ {
+	for i := 0; i < 32; i++ {
 		if err := env.local.ForceRollupForTest(ctx, payloadID); err != nil {
 			t.Fatalf("ForceRollupForTest: %v", err)
 		}
 		if env.local.IntervalsLenForTest(payloadID) == 0 {
 			break
 		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	env.local.SyncFileBlocks(ctx)
 
 	// The counter must reflect the unsynced cache bytes now present locally.
-	waitFor(t, 5*time.Second, func() bool {
-		return env.syncer.UnsyncedBytes() > 0
-	}, "unsynced bytes to rise after rollup")
+	// With the periodic uploader stopped, nothing drains it behind our back.
+	if got := env.syncer.UnsyncedBytes(); got <= 0 {
+		t.Fatalf("UnsyncedBytes after rollup = %d, want > 0", got)
+	}
 
-	// Drain to remote: every chunk is mirrored + marked synced, so the
-	// counter must return to zero.
+	// Drain to remote synchronously: every chunk is mirrored + marked
+	// synced, so the counter must return to zero.
 	if err := env.syncer.SyncNow(ctx); err != nil {
 		t.Fatalf("SyncNow: %v", err)
 	}
-	waitFor(t, 5*time.Second, func() bool {
-		return env.syncer.UnsyncedBytes() == 0
-	}, "unsynced bytes to drain to zero after SyncNow")
+	if got := env.syncer.UnsyncedBytes(); got != 0 {
+		t.Fatalf("UnsyncedBytes after SyncNow drain = %d, want 0", got)
+	}
 
 	// Sanity: the bytes really did reach the remote.
 	if mem, ok := env.remote.RemoteStore.(*remotememory.Store); ok {

--- a/pkg/block/engine/unsynced_bytes_test.go
+++ b/pkg/block/engine/unsynced_bytes_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestUnsyncedBytes_TracksDrain drives the real write path (AppendWrite →
+// rollup → chunkstore → onChunkComplete) and asserts that the syncer's
+// unsynced-byte counter — the backpressure signal the local store consults —
+// rises as chunks land locally and returns to zero once SyncNow mirrors them
+// all to the remote. This is the integration backstop for the fs-internal
+// ensureSpace backpressure tests: it proves the counter the stall path reads
+// is actually fed and drained by the production wiring.
+func TestUnsyncedBytes_TracksDrain(t *testing.T) {
+	env := newHealthTestEnv(t)
+	ctx := context.Background()
+	env.local.Start(ctx)
+	env.syncer.Start(ctx)
+
+	if got := env.syncer.UnsyncedBytes(); got != 0 {
+		t.Fatalf("UnsyncedBytes at start = %d, want 0", got)
+	}
+
+	// Write enough bytes to produce at least one CAS chunk.
+	payloadID := "export/unsynced-bytes-test.bin"
+	data := make([]byte, 1<<20) // 1 MiB
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	if err := env.local.AppendWrite(ctx, payloadID, data, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if _, err := env.syncer.Flush(ctx, payloadID); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Drive rollup so the staged bytes land in the CAS chunk store, firing
+	// onChunkComplete → addPendingHash with each chunk's byte size.
+	time.Sleep(80 * time.Millisecond)
+	for i := 0; i < 16; i++ {
+		if err := env.local.ForceRollupForTest(ctx, payloadID); err != nil {
+			t.Fatalf("ForceRollupForTest: %v", err)
+		}
+		if env.local.IntervalsLenForTest(payloadID) == 0 {
+			break
+		}
+	}
+	env.local.SyncFileBlocks(ctx)
+
+	// The counter must reflect the unsynced cache bytes now present locally.
+	waitFor(t, 5*time.Second, func() bool {
+		return env.syncer.UnsyncedBytes() > 0
+	}, "unsynced bytes to rise after rollup")
+
+	// Drain to remote: every chunk is mirrored + marked synced, so the
+	// counter must return to zero.
+	if err := env.syncer.SyncNow(ctx); err != nil {
+		t.Fatalf("SyncNow: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		return env.syncer.UnsyncedBytes() == 0
+	}, "unsynced bytes to drain to zero after SyncNow")
+
+	// Sanity: the bytes really did reach the remote.
+	if mem, ok := env.remote.RemoteStore.(*remotememory.Store); ok {
+		if mem.BlockCount() == 0 {
+			t.Fatalf("remote has 0 blocks after drain; expected the mirrored chunks")
+		}
+	}
+}

--- a/pkg/block/local/fs/backpressure_test.go
+++ b/pkg/block/local/fs/backpressure_test.go
@@ -1,0 +1,183 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// fakeBackpressureSource is a controllable stand-in for the engine syncer's
+// read-only backpressure accessor. It lets the fs-internal tests drive the
+// ensureSpace remote-cache stall path deterministically — without an actual
+// async upload loop — by toggling remote health and the unsynced-byte count.
+type fakeBackpressureSource struct {
+	healthy  atomic.Bool
+	unsynced atomic.Int64
+}
+
+func newFakeBackpressureSource(healthy bool) *fakeBackpressureSource {
+	f := &fakeBackpressureSource{}
+	f.healthy.Store(healthy)
+	return f
+}
+
+func (f *fakeBackpressureSource) IsRemoteHealthy() bool { return f.healthy.Load() }
+func (f *fakeBackpressureSource) UnsyncedBytes() int64  { return f.unsynced.Load() }
+
+// newBackpressureStore builds an FSStore with a small disk ceiling and a
+// SyncedHashStore wired, so an unsynced-only LRU forces ensureSpace down the
+// backpressure path.
+func newBackpressureStore(t *testing.T, maxDisk int64) (*FSStore, *memory.MemoryMetadataStore) {
+	t.Helper()
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, maxDisk, 256*1024*1024, mds, FSStoreOptions{
+		SyncedHashStore: mds,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	bc.SetEvictionEnabled(true)
+	bc.SetRetentionPolicy(block.RetentionLRU, 0)
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc, mds
+}
+
+// TestBackpressure_RemoteUnhealthy_FailsFast asserts that when every cached
+// chunk is unsynced and the remote is UNHEALTHY (the syncer cannot drain),
+// ensureSpace returns ErrDiskFull without waiting out the (long) backpressure
+// window — it does not stall a writer that cannot make progress.
+func TestBackpressure_RemoteUnhealthy_FailsFast(t *testing.T) {
+	bc, _ := newBackpressureStore(t, 600)
+	// Long backpressure window: the test must NOT wait it out. The
+	// short-circuit on remote-unhealthy is what returns promptly.
+	bc.backpressureMaxWait = 30 * time.Second
+	bc.evictMaxWait = 30 * time.Second
+	bc.SetBackpressureSource(newFakeBackpressureSource(false)) // remote unhealthy
+	ctx := context.Background()
+
+	storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+
+	start := time.Now()
+	err := bc.ensureSpace(ctx, 200)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrDiskFull) {
+		t.Fatalf("ensureSpace with unhealthy remote: got %v, want ErrDiskFull", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("ensureSpace stalled %v with unhealthy remote; expected fast fail (no backpressure wait)", elapsed)
+	}
+}
+
+// TestBackpressure_HealthyRemote_ReleasesWhenDrained asserts the graceful
+// path: with a HEALTHY remote and an unsynced-only LRU, ensureSpace stalls
+// (engages backpressure) rather than failing, and RELEASES — succeeding —
+// once the syncer drains (chunks marked synced + evicted) to free space.
+func TestBackpressure_HealthyRemote_ReleasesWhenDrained(t *testing.T) {
+	bc, mds := newBackpressureStore(t, 600)
+	bc.backpressureMaxWait = 10 * time.Second // ample; the drain frees space well before
+	src := newFakeBackpressureSource(true)    // remote healthy
+	bc.SetBackpressureSource(src)
+	ctx := context.Background()
+
+	hA := storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+	src.unsynced.Store(600)
+
+	// Simulate the syncer draining one chunk shortly after the writer stalls:
+	// mark hA synced so it becomes evictable, freeing 200 bytes.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_ = mds.MarkSynced(ctx, hA)
+		src.unsynced.Add(-200)
+	}()
+
+	start := time.Now()
+	if err := bc.ensureSpace(ctx, 200); err != nil {
+		t.Fatalf("ensureSpace with healthy remote that drains: got %v, want nil (backpressure released)", err)
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("ensureSpace returned in %v; expected it to stall until the drain freed space", elapsed)
+	}
+
+	// Backpressure must have engaged exactly once and accounted some stall.
+	engage, stall := bc.BackpressureStats()
+	if engage != 1 {
+		t.Errorf("engage count = %d, want 1", engage)
+	}
+	if stall <= 0 {
+		t.Errorf("total stall = %v, want > 0", stall)
+	}
+}
+
+// TestBackpressure_HealthyRemote_WindowExceeded asserts that a healthy remote
+// that never drains eventually trips the backpressure window and returns
+// ErrDiskFull — the bounded stall, not an indefinite hang.
+func TestBackpressure_HealthyRemote_WindowExceeded(t *testing.T) {
+	bc, _ := newBackpressureStore(t, 600)
+	bc.backpressureMaxWait = 200 * time.Millisecond // short window for the test
+	src := newFakeBackpressureSource(true)          // healthy but never drains
+	src.unsynced.Store(600)
+	bc.SetBackpressureSource(src)
+	ctx := context.Background()
+
+	storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+
+	start := time.Now()
+	err := bc.ensureSpace(ctx, 200)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrDiskFull) {
+		t.Fatalf("ensureSpace over a never-draining healthy remote: got %v, want ErrDiskFull", err)
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("ensureSpace returned in %v; expected it to honor the %v backpressure window", elapsed, bc.backpressureMaxWait)
+	}
+	if engage, _ := bc.BackpressureStats(); engage != 1 {
+		t.Errorf("engage count = %d, want 1", engage)
+	}
+}
+
+// TestBackpressure_NoSource_LocalOnlyUnaffected asserts that with no
+// backpressure source wired (local-only share: no remote), ensureSpace falls
+// back to the short evictMaxWait deadline and does NOT engage the remote-cache
+// backpressure window. This guards the invariant that local-only writes never
+// incur the remote stall.
+func TestBackpressure_NoSource_LocalOnlyUnaffected(t *testing.T) {
+	bc, _ := newBackpressureStore(t, 600)
+	bc.evictMaxWait = 100 * time.Millisecond
+	bc.backpressureMaxWait = 30 * time.Second // must NOT be used (no source)
+	// No SetBackpressureSource — bpSource is nil (local-only).
+	ctx := context.Background()
+
+	storeChunk(t, bc, bytes.Repeat([]byte{0x01}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	storeChunk(t, bc, bytes.Repeat([]byte{0x03}, 200))
+
+	start := time.Now()
+	err := bc.ensureSpace(ctx, 200)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrDiskFull) {
+		t.Fatalf("local-only ensureSpace over unsynced LRU: got %v, want ErrDiskFull", err)
+	}
+	// Should honor the short evictMaxWait, never the long backpressure window.
+	if elapsed > 5*time.Second {
+		t.Fatalf("local-only ensureSpace stalled %v; expected fast fail on evictMaxWait", elapsed)
+	}
+	if engage, _ := bc.BackpressureStats(); engage != 0 {
+		t.Errorf("engage count = %d, want 0 (no backpressure for local-only)", engage)
+	}
+}

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
@@ -64,17 +65,85 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 	}
 	deadline := time.Now().Add(maxWait)
 
+	// Backpressure stall bookkeeping. engaged is set the first time we hit
+	// errLRUEmpty with a healthy remote (the remote-cache stall path) so we
+	// log the eventual RELEASE exactly once and account the stall duration.
+	var (
+		engaged    bool
+		stallStart time.Time
+	)
+	release := func(reason string) {
+		if !engaged {
+			return
+		}
+		stall := time.Since(stallStart)
+		bc.bpStallNanos.Add(int64(stall))
+		if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
+			logger.Info("local cache backpressure released",
+				"store", bc.baseDir,
+				"reason", reason,
+				"disk_used", bc.diskUsed.Load(),
+				"max_disk", bc.maxDisk,
+				"unsynced_bytes", bc.unsyncedBytesOrZero(),
+				"remote_healthy", bc.remoteHealthyOrTrue(),
+				"stall_ms", stall.Milliseconds())
+		}
+		engaged = false
+	}
+
 	for bc.diskUsed.Load()+needed > bc.maxDisk {
 		freed, err := bc.lruEvictOne(ctx)
 		if errors.Is(err, errLRUEmpty) {
-			// No more LRU candidates. Wait briefly for new chunks to land
-			// (e.g., async StoreChunk in the rollup pool) up to the
-			// deadline before giving up.
+			// No more LRU candidates: every cached chunk is still unsynced.
+			// Branch on whether a remote-backed syncer is wired:
+			//
+			//   - remote-backed (bpSource != nil): the local tier is a
+			//     write-through cache. If the remote is HEALTHY the syncer
+			//     can still drain unsynced chunks and free space, so engage
+			//     backpressure and stall up to the (longer) backpressure
+			//     window. If the remote is UNHEALTHY the syncer cannot
+			//     drain, so fail fast with ErrDiskFull rather than stalling
+			//     a writer that cannot make progress.
+			//   - local-only (bpSource == nil): keep the legacy behavior —
+			//     wait the shorter evictMaxWait for new evictable chunks
+			//     (async StoreChunk from the rollup pool) to land.
+			if bc.bpSource != nil {
+				if !bc.bpSource.IsRemoteHealthy() {
+					// Remote cannot drain: fail fast (release if we had
+					// been stalling on a previously-healthy remote).
+					if engaged {
+						release("remote_unhealthy")
+					}
+					return ErrDiskFull
+				}
+				if !engaged {
+					// First time stalling on the remote-cache path for this
+					// request: arm the longer deadline, count the engage, and
+					// log it (rate-limited).
+					engaged = true
+					stallStart = time.Now()
+					deadline = stallStart.Add(bc.effectiveBackpressureMaxWait())
+					bc.bpEngageCount.Add(1)
+					if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
+						logger.Info("local cache backpressure engaged: waiting for syncer to drain",
+							"store", bc.baseDir,
+							"disk_used", bc.diskUsed.Load(),
+							"max_disk", bc.maxDisk,
+							"needed", needed,
+							"unsynced_bytes", bc.bpSource.UnsyncedBytes(),
+							"remote_healthy", true,
+							"max_wait_ms", bc.effectiveBackpressureMaxWait().Milliseconds())
+					}
+				}
+			}
+
 			if time.Now().After(deadline) {
+				release("window_exceeded")
 				return ErrDiskFull
 			}
 			select {
 			case <-ctx.Done():
+				release("ctx_cancelled")
 				return ctx.Err()
 			case <-time.After(100 * time.Millisecond):
 				continue
@@ -85,9 +154,38 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 		}
 		bc.diskUsed.Add(-freed)
 		if ctx.Err() != nil {
+			release("ctx_cancelled")
 			return ctx.Err()
 		}
 	}
 
+	release("space_freed")
 	return nil
+}
+
+// effectiveBackpressureMaxWait returns the remote-cache stall window,
+// defaulting to 60s when unset.
+func (bc *FSStore) effectiveBackpressureMaxWait() time.Duration {
+	if bc.backpressureMaxWait > 0 {
+		return bc.backpressureMaxWait
+	}
+	return 60 * time.Second
+}
+
+// unsyncedBytesOrZero reads the syncer's unsynced-byte counter, returning 0
+// when no syncer is wired (local-only / fixtures).
+func (bc *FSStore) unsyncedBytesOrZero() int64 {
+	if bc.bpSource == nil {
+		return 0
+	}
+	return bc.bpSource.UnsyncedBytes()
+}
+
+// remoteHealthyOrTrue reports remote health, defaulting to true when no
+// syncer is wired (local-only stores have no remote to be unhealthy).
+func (bc *FSStore) remoteHealthyOrTrue() bool {
+	if bc.bpSource == nil {
+		return true
+	}
+	return bc.bpSource.IsRemoteHealthy()
 }

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -120,9 +120,10 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 					// First time stalling on the remote-cache path for this
 					// request: arm the longer deadline, count the engage, and
 					// log it (rate-limited).
+					maxWait := bc.effectiveBackpressureMaxWait()
 					engaged = true
 					stallStart = time.Now()
-					deadline = stallStart.Add(bc.effectiveBackpressureMaxWait())
+					deadline = stallStart.Add(maxWait)
 					bc.bpEngageCount.Add(1)
 					if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
 						logger.Info("local cache backpressure engaged: waiting for syncer to drain",
@@ -132,7 +133,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 							"needed", needed,
 							"unsynced_bytes", bc.bpSource.UnsyncedBytes(),
 							"remote_healthy", true,
-							"max_wait_ms", bc.effectiveBackpressureMaxWait().Milliseconds())
+							"max_wait_ms", maxWait.Milliseconds())
 					}
 				}
 			}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -16,11 +16,44 @@ import (
 	"time"
 	"unsafe"
 
+	"golang.org/x/time/rate"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// backpressureSource is the narrow, read-only window the eviction path
+// consults during a remote-cache backpressure stall. It exposes ONLY the
+// syncer's drain progress — never the FileBlockStore — preserving invariant
+// LSL-08 (eviction must not reach into engine-level metadata). The engine's
+// *Syncer satisfies it.
+type backpressureSource interface {
+	// IsRemoteHealthy reports whether the remote store is reachable, i.e.
+	// whether the syncer can drain unsynced chunks and free cache space.
+	IsRemoteHealthy() bool
+	// UnsyncedBytes is the running total of cache bytes not yet mirrored to
+	// remote — the bytes a backpressure stall is waiting to see drained.
+	UnsyncedBytes() int64
+}
+
+// SetBackpressureSource injects the read-only syncer accessor the eviction
+// path consults during a remote-cache stall. Called once during share wiring
+// after the syncer is constructed. Passing nil (local-only stores, fixtures)
+// leaves ensureSpace on its evictMaxWait fallback. The argument is a narrow
+// interface — never the FileBlockStore — per invariant LSL-08.
+func (bc *FSStore) SetBackpressureSource(src backpressureSource) {
+	bc.bpSource = src
+}
+
+// BackpressureStats returns the internal backpressure counters: the number
+// of times a writer entered a remote-cache stall and the total time writers
+// spent stalled. Exposed for tests and a future Prometheus exporter; not
+// wired into the REST surface in this iteration.
+func (bc *FSStore) BackpressureStats() (engageCount int64, totalStall time.Duration) {
+	return bc.bpEngageCount.Load(), time.Duration(bc.bpStallNanos.Load())
+}
 
 // retentionConfig holds retention policy settings read/written atomically.
 type retentionConfig struct {
@@ -196,6 +229,38 @@ type FSStore struct {
 	// tests shrink it to avoid a 30s wall-clock wait when asserting the
 	// unsynced-only-LRU back-pressure path.
 	evictMaxWait time.Duration
+
+	// backpressureMaxWait caps how long ensureSpace stalls a writer while
+	// the LRU has no evictable candidate (every cached chunk is still
+	// unsynced) but the remote is HEALTHY — i.e. the syncer can still drain
+	// and free cache space. Distinct from evictMaxWait: this is the
+	// remote-cache backpressure window. When the remote is unhealthy (the
+	// syncer cannot drain), ensureSpace returns ErrDiskFull immediately
+	// rather than waiting out this window. Defaults to 60s (installed by
+	// newFSStore); same-package tests shrink it.
+	backpressureMaxWait time.Duration
+
+	// bpSource is the read-only seam into the syncer's drain progress that
+	// ensureSpace consults during the backpressure window: whether the
+	// remote is healthy (can drain) and how many cache bytes are still
+	// unsynced (whether a stall can make progress). Injected post-
+	// construction via SetBackpressureSource — nil on local-only stores and
+	// in fixtures, in which case ensureSpace falls back to evictMaxWait
+	// semantics. NEVER hand the FileBlockStore here: this is a narrow,
+	// non-FileBlockStore interface, preserving invariant LSL-08.
+	bpSource backpressureSource
+
+	// Backpressure observability counters (internal; not yet exposed via
+	// REST — a future Prometheus pass reads them directly). bpEngageCount
+	// increments once each time a writer enters the remote-cache stall;
+	// bpStallNanos accumulates the total time writers spent stalled. Both
+	// are atomic so concurrent writers can update them lock-free.
+	bpEngageCount atomic.Int64
+	bpStallNanos  atomic.Int64
+
+	// bpLogLimiter rate-limits the engage/release Info logs so a sustained
+	// fast-writer / slow-uploader workload does not flood the log.
+	bpLogLimiter *rate.Limiter
 
 	// logBytesTotal is the current total bytes of un-rolled-up log content
 	// across every payloadID in this FSStore. Incremented by AppendWrite
@@ -384,11 +449,16 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.E
 	for i := range bc.logShards {
 		bc.logShards[i] = newLogShard()
 	}
-	bc.maxLogBytes = 1 << 30              // 1 GiB default
-	bc.stabilizationMS = 250              // default
-	bc.rollupWorkers = 2                  // default
-	bc.pressureMaxWait = 30 * time.Second // default — #670 defense-in-depth
-	bc.evictMaxWait = 30 * time.Second    // default ensureSpace back-pressure cap
+	bc.maxLogBytes = 1 << 30                  // 1 GiB default
+	bc.stabilizationMS = 250                  // default
+	bc.rollupWorkers = 2                      // default
+	bc.pressureMaxWait = 30 * time.Second     // default — #670 defense-in-depth
+	bc.evictMaxWait = 30 * time.Second        // default ensureSpace back-pressure cap
+	bc.backpressureMaxWait = 60 * time.Second // default remote-cache backpressure window
+	// Rate-limit backpressure engage/release logs: at most one line every
+	// 5s plus a small burst, so a sustained stall does not flood the log
+	// while still surfacing the first engage and the eventual release.
+	bc.bpLogLimiter = rate.NewLimiter(rate.Every(5*time.Second), 2)
 	// rollupCh buffered so AppendWrite's non-blocking send rarely drops
 	// on drop, the ticker arm in chunkRollupWorker picks up the payload
 	// on the next scan.
@@ -430,6 +500,9 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 		// Required for tests that drive the pressure loop directly
 		// without a rollup worker; not recommended in production.
 		bc.pressureMaxWait = 0
+	}
+	if opts.BackpressureMaxWait > 0 {
+		bc.backpressureMaxWait = opts.BackpressureMaxWait
 	}
 	bc.rollupStore = opts.RollupStore
 	bc.syncedHashStore = opts.SyncedHashStore
@@ -802,6 +875,12 @@ type FSStoreOptions struct {
 	// D-state. Pick an upper-bound value clearly larger than any
 	// legitimate rollup latency under load — this is NOT an SLA.
 	PressureMaxWait time.Duration
+
+	// BackpressureMaxWait bounds how long ensureSpace stalls a writer while
+	// every cached chunk is unsynced but the remote is healthy (the syncer
+	// can still drain). Zero defers to the 60s default. Distinct from the
+	// internal evict wait. See FSStore.backpressureMaxWait.
+	BackpressureMaxWait time.Duration
 
 	// CompactionThresholdBytes controls when physical log compaction
 	// runs (#579). After a rollup pass advances idx.compactionFence

--- a/pkg/config/blockstore.go
+++ b/pkg/config/blockstore.go
@@ -1,11 +1,29 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
+
+// defaultRemoteCacheSize is the on-disk ceiling applied to a share's local
+// tier when a remote block store is configured but no explicit
+// LocalStoreSize / max_size is set. With a remote configured the local tier
+// is a write-through cache, not durable storage, so it must be bounded to
+// avoid filling the host volume on a fast-writer / slow-uploader. 10 GiB is
+// a conservative default; operators raise it via the config key or override
+// per-share with --local-store-size.
+const defaultRemoteCacheSize uint64 = 10 << 30 // 10 GiB
+
+// defaultBackpressureMaxWait is how long a write stalls waiting for the
+// syncer to drain unsynced bytes (freeing cache space) before returning
+// ErrDiskFull, when the remote is healthy and every local chunk is still
+// unsynced. Separate from the LRU evict wait: this is the graceful-stall
+// window for the remote-cache backpressure path.
+const defaultBackpressureMaxWait = 60 * time.Second
 
 // BlockstoreConfig is the top-level container for blockstore-related
-// tunables (currently blockstore.local.dedup_lru_size); additional
-// layers (remote tier, cache tier) may be added in subsequent
-// milestones.
+// tunables; additional layers (remote tier, cache tier) may be added in
+// subsequent milestones.
 type BlockstoreConfig struct {
 	Local BlockstoreLocalConfig `mapstructure:"local" yaml:"local"`
 }
@@ -17,6 +35,21 @@ type BlockstoreLocalConfig struct {
 	// LRU consulted between FastCDC.Next() and Put(hash, data) in
 	// pkg/block/local/fs/rollup.go.
 	DedupLRUSize int `mapstructure:"dedup_lru_size" yaml:"dedup_lru_size"`
+
+	// DefaultRemoteCacheSize is the on-disk ceiling (bytes) applied to a
+	// share's local tier when a remote block store is configured but no
+	// explicit per-share size is set. Bounds the write-through cache so a
+	// fast writer cannot exhaust the host volume while the syncer lags.
+	// Default 10 GiB when zero. Local-only shares ignore this — they keep
+	// an unlimited local tier.
+	DefaultRemoteCacheSize uint64 `mapstructure:"default_remote_cache_size" yaml:"default_remote_cache_size"`
+
+	// BackpressureMaxWait is how long a write blocks waiting for the syncer
+	// to drain unsynced bytes (and free cache space) before returning
+	// ErrDiskFull, when the remote is healthy but every local chunk is
+	// still unsynced. Default 60s when zero. Distinct from the internal LRU
+	// evict wait.
+	BackpressureMaxWait time.Duration `mapstructure:"backpressure_max_wait" yaml:"backpressure_max_wait"`
 }
 
 // ApplyDefaults fills any zero-valued field with the defaults.
@@ -24,15 +57,27 @@ func (c *BlockstoreLocalConfig) ApplyDefaults() {
 	if c.DedupLRUSize <= 0 {
 		c.DedupLRUSize = 4096
 	}
+	if c.DefaultRemoteCacheSize == 0 {
+		c.DefaultRemoteCacheSize = defaultRemoteCacheSize
+	}
+	if c.BackpressureMaxWait <= 0 {
+		c.BackpressureMaxWait = defaultBackpressureMaxWait
+	}
 }
 
 // Validate returns an error if the BlockstoreLocalConfig has invalid
-// values. The error message includes the canonical dotted config path
-// (blockstore.local.dedup_lru_size) so operators can pinpoint the
-// offending key in their config file.
+// values. The error message includes the canonical dotted config path so
+// operators can pinpoint the offending key in their config file.
 func (c *BlockstoreLocalConfig) Validate() error {
 	if c.DedupLRUSize <= 0 {
 		return fmt.Errorf("blockstore.local.dedup_lru_size must be > 0 (got %d)", c.DedupLRUSize)
+	}
+	// DefaultRemoteCacheSize and BackpressureMaxWait treat zero as "apply
+	// the built-in default" (filled by ApplyDefaults), so Validate only
+	// rejects an explicitly negative backpressure wait — the one
+	// nonsensical value a duration can take.
+	if c.BackpressureMaxWait < 0 {
+		return fmt.Errorf("blockstore.local.backpressure_max_wait must be >= 0 (got %s)", c.BackpressureMaxWait)
 	}
 	return nil
 }

--- a/pkg/config/blockstore.go
+++ b/pkg/config/blockstore.go
@@ -40,8 +40,8 @@ type BlockstoreLocalConfig struct {
 	// share's local tier when a remote block store is configured but no
 	// explicit per-share size is set. Bounds the write-through cache so a
 	// fast writer cannot exhaust the host volume while the syncer lags.
-	// Default 10 GiB when zero. Local-only shares ignore this — they keep
-	// an unlimited local tier.
+	// Default 10 GiB when zero (ApplyDefaults). Local-only shares ignore
+	// this — they keep their existing (system-deduced) local size.
 	DefaultRemoteCacheSize uint64 `mapstructure:"default_remote_cache_size" yaml:"default_remote_cache_size"`
 
 	// BackpressureMaxWait is how long a write blocks waiting for the syncer

--- a/pkg/config/blockstore_test.go
+++ b/pkg/config/blockstore_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -50,6 +51,52 @@ func TestBlockstoreLocalConfig_Validate_AcceptsPositive(t *testing.T) {
 	c := BlockstoreLocalConfig{DedupLRUSize: 1024}
 	if err := c.Validate(); err != nil {
 		t.Fatalf("Validate(): got %v, want nil for 1024", err)
+	}
+}
+
+func TestBlockstoreLocalConfig_ApplyDefaults_SetsRemoteCacheAndBackpressure(t *testing.T) {
+	c := BlockstoreLocalConfig{}
+	c.ApplyDefaults()
+	if c.DefaultRemoteCacheSize != 10<<30 {
+		t.Errorf("DefaultRemoteCacheSize: got %d, want %d (10 GiB)", c.DefaultRemoteCacheSize, 10<<30)
+	}
+	if c.BackpressureMaxWait != 60*time.Second {
+		t.Errorf("BackpressureMaxWait: got %s, want 60s", c.BackpressureMaxWait)
+	}
+}
+
+func TestBlockstoreLocalConfig_ApplyDefaults_PreservesRemoteCacheAndBackpressure(t *testing.T) {
+	c := BlockstoreLocalConfig{
+		DefaultRemoteCacheSize: 1 << 30,
+		BackpressureMaxWait:    30 * time.Second,
+	}
+	c.ApplyDefaults()
+	if c.DefaultRemoteCacheSize != 1<<30 {
+		t.Errorf("DefaultRemoteCacheSize: got %d, want 1 GiB preserved", c.DefaultRemoteCacheSize)
+	}
+	if c.BackpressureMaxWait != 30*time.Second {
+		t.Errorf("BackpressureMaxWait: got %s, want 30s preserved", c.BackpressureMaxWait)
+	}
+}
+
+func TestBlockstoreLocalConfig_Validate_RejectsNegativeBackpressureWait(t *testing.T) {
+	c := BlockstoreLocalConfig{DedupLRUSize: 1024, BackpressureMaxWait: -1}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate() = nil for negative backpressure_max_wait, want error")
+	}
+	if !strings.Contains(err.Error(), "blockstore.local.backpressure_max_wait") {
+		t.Fatalf("Validate() error %q must contain dotted path 'blockstore.local.backpressure_max_wait'", err.Error())
+	}
+}
+
+func TestBlockstoreLocalConfig_Validate_AcceptsZeroNewKnobs(t *testing.T) {
+	// Zero for the new knobs means "apply the built-in default" (filled by
+	// ApplyDefaults), so Validate must accept a config that only sets the
+	// required DedupLRUSize.
+	c := BlockstoreLocalConfig{DedupLRUSize: 1024}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate(): got %v, want nil with zero new knobs", err)
 	}
 }
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -285,6 +285,21 @@ type LocalStoreDefaults struct {
 	// when set, otherwise this global YAML default (blockstore.local.dedup_lru_size)
 	// is applied, otherwise FSStore falls back to its own internal default.
 	DedupLRUSize int
+
+	// DefaultRemoteCacheSize is the on-disk ceiling applied to a share's
+	// local tier when a REMOTE block store is configured but neither
+	// MaxSize nor the per-share LocalStoreSize is set. With a remote
+	// configured the local tier is a bounded write-through cache; without
+	// this ceiling a fast writer could exhaust the host volume. 0 disables
+	// the conditional ceiling (local stays unlimited even with a remote).
+	// Local-only shares ignore this entirely.
+	DefaultRemoteCacheSize uint64
+
+	// BackpressureMaxWait is how long a write stalls waiting for the syncer
+	// to drain (freeing cache space) before returning ErrDiskFull, when the
+	// remote is healthy but every cached chunk is unsynced. 0 defers to the
+	// FSStore default (60s).
+	BackpressureMaxWait time.Duration
 }
 
 // SyncerDefaults holds default syncer configuration applied to all shares.
@@ -618,13 +633,32 @@ func (s *Service) prepareShare(
 
 // mergeLocalStoreDefaults returns a copy of the system defaults with per-share
 // overrides applied. Non-zero ShareConfig values take precedence.
-func mergeLocalStoreDefaults(defaults *LocalStoreDefaults, config *ShareConfig) *LocalStoreDefaults {
+//
+// remoteConfigured signals that the share has a remote block store, which
+// makes the local tier a bounded write-through cache rather than durable
+// storage. In that case, when the operator set no explicit per-share size
+// (config.LocalStoreSize == 0), apply the DefaultRemoteCacheSize ceiling so
+// a fast writer cannot exhaust the host volume — this takes precedence over
+// the generic system-deduced MaxSize, which is sized for the durable
+// local-only tier rather than a transient cache. An explicit per-share
+// --local-store-size always wins. Local-only shares keep the existing
+// MaxSize unchanged.
+func mergeLocalStoreDefaults(defaults *LocalStoreDefaults, config *ShareConfig, remoteConfigured bool) *LocalStoreDefaults {
 	if defaults == nil {
 		defaults = &LocalStoreDefaults{}
 	}
 	merged := *defaults // shallow copy
-	if config.LocalStoreSize > 0 {
+	switch {
+	case config.LocalStoreSize > 0:
+		// Explicit per-share override always wins.
 		merged.MaxSize = uint64(config.LocalStoreSize)
+	case remoteConfigured && merged.DefaultRemoteCacheSize > 0:
+		// Remote-backed share, no explicit override: bound the
+		// write-through cache at the remote-cache default.
+		merged.MaxSize = merged.DefaultRemoteCacheSize
+		logger.Info("applying default local-cache ceiling for remote-backed share",
+			"share", config.Name,
+			"max_size", merged.MaxSize)
 	}
 	if config.ReadBufferSize > 0 {
 		merged.ReadBufferBytes = config.ReadBufferSize
@@ -651,8 +685,11 @@ func (s *Service) createBlockStoreForShare(
 		return fmt.Errorf("block store config %q has kind %q, expected %q", config.LocalBlockStoreID, localCfg.Kind, models.BlockStoreKindLocal)
 	}
 
-	// Merge per-share size overrides into effective defaults.
-	effectiveDefaults := mergeLocalStoreDefaults(localStoreDefaults, config)
+	// Merge per-share size overrides into effective defaults. A configured
+	// remote makes the local tier a bounded write-through cache, so the
+	// conditional default ceiling applies (see mergeLocalStoreDefaults).
+	remoteConfigured := config.RemoteBlockStoreID != ""
+	effectiveDefaults := mergeLocalStoreDefaults(localStoreDefaults, config, remoteConfigured)
 
 	localStore, err := CreateLocalStoreFromConfig(ctx, localCfg.Type, localCfg, config.Name, effectiveDefaults, fileBlockStore)
 	if err != nil {
@@ -686,6 +723,23 @@ func (s *Service) createBlockStoreForShare(
 	}
 
 	syncer := engine.NewSyncer(localStore, engineRemote, fileBlockStore, syncerCfg)
+
+	// Inject the read-only syncer accessor into the local store so its
+	// eviction path can engage remote-cache backpressure (stall a writer
+	// while the syncer drains, instead of failing with ErrDiskFull) when a
+	// remote is configured. Local-only shares (engineRemote == nil) keep the
+	// nil source — eviction stays on its evictMaxWait fallback. The
+	// interface handed in is narrow and never the FileBlockStore (LSL-08).
+	if engineRemote != nil {
+		if bp, ok := localStore.(interface {
+			SetBackpressureSource(interface {
+				IsRemoteHealthy() bool
+				UnsyncedBytes() int64
+			})
+		}); ok {
+			bp.SetBackpressureSource(syncer)
+		}
+	}
 
 	cleanup := func() {
 		_ = syncer.Close()
@@ -1851,6 +1905,14 @@ func CreateLocalStoreFromConfig(
 		maxMemory = defaults.MaxMemory
 	}
 
+	// Remote-cache backpressure window (how long a write stalls for the
+	// syncer to drain before ErrDiskFull). Threaded into FSStoreOptions
+	// below; zero defers to the FSStore default.
+	var backpressureMaxWait time.Duration
+	if defaults != nil {
+		backpressureMaxWait = defaults.BackpressureMaxWait
+	}
+
 	// Per-store max_size from config JSON takes precedence over defaults
 	if v, ok := config["max_size"]; ok {
 		if n, ok := v.(float64); ok && n > 0 {
@@ -1865,6 +1927,7 @@ func CreateLocalStoreFromConfig(
 	// surface through FSStoreOptions to fs.NewWithOptions; invalid values
 	// are warned and ignored.
 	var fsOpts fs.FSStoreOptions
+	fsOpts.BackpressureMaxWait = backpressureMaxWait
 	if _, ok := config["use_append_log"]; ok {
 		logger.Warn("block store config has use_append_log: append is mandatory in v0.16+, flag is ignored")
 	}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -287,12 +287,12 @@ type LocalStoreDefaults struct {
 	DedupLRUSize int
 
 	// DefaultRemoteCacheSize is the on-disk ceiling applied to a share's
-	// local tier when a REMOTE block store is configured but neither
-	// MaxSize nor the per-share LocalStoreSize is set. With a remote
-	// configured the local tier is a bounded write-through cache; without
-	// this ceiling a fast writer could exhaust the host volume. 0 disables
-	// the conditional ceiling (local stays unlimited even with a remote).
-	// Local-only shares ignore this entirely.
+	// local tier when a REMOTE block store is configured but no explicit
+	// per-share LocalStoreSize is set. With a remote configured the local
+	// tier is a bounded write-through cache; without this ceiling a fast
+	// writer could exhaust the host volume. 0 leaves the conditional ceiling
+	// off (the share keeps its system-deduced local size even with a
+	// remote). Local-only shares ignore this entirely.
 	DefaultRemoteCacheSize uint64
 
 	// BackpressureMaxWait is how long a write stalls waiting for the syncer

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -728,16 +728,11 @@ func (s *Service) createBlockStoreForShare(
 	// eviction path can engage remote-cache backpressure (stall a writer
 	// while the syncer drains, instead of failing with ErrDiskFull) when a
 	// remote is configured. Local-only shares (engineRemote == nil) keep the
-	// nil source — eviction stays on its evictMaxWait fallback. The
-	// interface handed in is narrow and never the FileBlockStore (LSL-08).
+	// nil source — eviction stays on its evictMaxWait fallback. FSStore takes
+	// a narrow read-only interface, never the FileBlockStore (LSL-08).
 	if engineRemote != nil {
-		if bp, ok := localStore.(interface {
-			SetBackpressureSource(interface {
-				IsRemoteHealthy() bool
-				UnsyncedBytes() int64
-			})
-		}); ok {
-			bp.SetBackpressureSource(syncer)
+		if fsStore, ok := localStore.(*fs.FSStore); ok {
+			fsStore.SetBackpressureSource(syncer)
 		}
 	}
 


### PR DESCRIPTION
Closes #1136.

## What

When a share has a **remote** block store, the on-disk local tier is a temporary write-through cache, not durable storage. On a fast-writer / slow-uploader it could grow until the host volume was exhausted. This bounds the cache and adds graceful, observable write backpressure that engages **only** when a remote is configured. Local-only shares are unchanged.

## How

1. **Conditional default ceiling.** When a remote is configured and the operator set no explicit per-share `--local-store-size`, the cache is capped at `blockstore.local.default_remote_cache_size` (default **10 GiB**), taking precedence over the generic system-deduced size. An explicit per-share override always wins. Local-only shares keep their existing (unlimited / deduced) size. Wired in `runtime/shares/service.go` (`mergeLocalStoreDefaults`).

2. **Syncer unsynced-bytes counter.** `Syncer.unsyncedBytes` (per-hash, CAS-deduped) tracks cache bytes not yet mirrored: `+size` in `addPendingHash` (size threaded through the `onChunkComplete` data length and the chunk emitter), `-size` in `mirrorOnce` after `MarkSynced`, seeded in `seedPendingFromDisk` via local `Head`. Exposed as `Syncer.UnsyncedBytes()` alongside the existing `IsRemoteHealthy()`.

3. **Backpressure window.** In `fs/eviction.go` `ensureSpace`, when the LRU has no evictable candidate (every cached chunk is still unsynced) and a remote-backed syncer accessor is wired:
   - remote **healthy** → stall up to `blockstore.local.backpressure_max_wait` (default **60s**) for the syncer to drain and free space (the graceful stall);
   - remote **unhealthy** or window exceeded → `ErrDiskFull` (→ NFS `NOSPC` / SMB `DiskFull`).
   The local store sees only a **narrow read-only interface** (`IsRemoteHealthy`, `UnsyncedBytes`) injected via `SetBackpressureSource` — never the FileBlockStore, preserving invariant **LSL-08**.

4. **Observability = structured zap logs only.** Rate-limited `INFO` logs on backpressure **engage** and **release** with `store`, `disk_used`, `max_disk`, `unsynced_bytes`, `remote_healthy`, `stall_ms`, and a `reason` (`space_freed` / `window_exceeded` / `remote_unhealthy` / `ctx_cancelled`). Internal engage-count + total-stall counters are computed on the FSStore so a future Prometheus pass is a drop-in; no new REST fields or metrics endpoint in this PR (repo-wide Prometheus tracked in #1188).

5. **Tests.**
   - `pkg/block/local/fs/backpressure_test.go`: fast-writer / slow-uploader against a controllable fake source — engages near maxDisk, releases when drained, `ErrDiskFull` only when remote unhealthy or window exceeded, and local-only (nil source) unaffected.
   - `pkg/block/engine/unsynced_bytes_test.go`: end-to-end through the real AppendWrite → rollup → onChunkComplete path, asserting the counter rises and drains to zero via `SyncNow`.
   - Existing `BlockStoreConformance` / `BlockStoreAppendConformance` and all `pkg/block/...` tests still pass under `-race`.

6. **Docs.** New "Local cache size limit & write backpressure" section in `docs/CONFIGURATION.md` documenting remote-cache semantics, the two new config keys, env-var mappings, and the diagnostic log lines. Config-only change — no new CLI flags, so no `gendocs` regen needed.

## Notes / deviations

- **No operator CRD work.** The k8s operator manages infrastructure only; shares/stores are REST-managed. The cache ceiling is config/CLI-driven and documented — there is no CRD field to add.
- **Local-only behavior preserved as-is.** The plan's wording ("local-only shares keep maxDisk=0 unlimited") describes the *conditional ceiling*; in practice the existing system already deduces a per-share local size. This PR does **not** regress local-only shares to unlimited — it only changes the default for *remote-backed* shares and only applies backpressure when a remote is wired.
- A review-caught race (unsynced-bytes `Add` outside `pendingMu` could leak a phantom positive count and wedge a writer in the 60s stall) is fixed by serializing the counter update under `pendingMu`; `UnsyncedBytes()` is clamped at zero.

## Test evidence

```
go build ./...        # clean
go vet ./...          # clean
gofmt -l <changed>    # clean
go test -race ./pkg/block/engine/ ./pkg/block/local/fs/ ./pkg/config/ ./pkg/controlplane/runtime/shares/   # all ok
```