### PR TITLE
feat(postgres): rename files table to inodes, drop path columns (part 1 of #1166)

### DIFF
--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -27,7 +27,13 @@ const (
 	// Increment when the payload layout changes (new table, changed
 	// framing, etc.) and add a migration path in Restore.
 	// v2 adds the v4_client_recovery table section.
-	postgresSchemaVersion = uint32(2)
+	// v3 renames the files table to inodes and drops the path/path_hash
+	// columns (#1166). The payload layout changed (the inode section name and
+	// its column set), so restore rejects older streams with
+	// ErrSchemaVersionMismatch — consistent with the v1->v2 bump, which added
+	// a table with no cross-version restore shim. Pre-1.0 backups are not
+	// forward-portable across schema versions.
+	postgresSchemaVersion = uint32(3)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order
@@ -40,7 +46,7 @@ const (
 var backupTables = []string{
 	"server_config",
 	"filesystem_capabilities",
-	"files",
+	"inodes",
 	"shares",
 	"parent_child_map",
 	"link_counts",
@@ -352,7 +358,7 @@ func reconcileFileBlockHashes(ctx context.Context, raw *pgconn.PgConn) error {
 		UPDATE file_blocks fb
 		SET hash = encode(r.hash, 'hex')
 		FROM file_block_refs r
-		JOIN files f ON f.id = r.file_id
+		JOIN inodes f ON f.id = r.file_id
 		WHERE fb.hash IS NULL
 		  AND f.content_id IS NOT NULL
 		  AND fb.id = f.content_id || '/' || r."offset"`

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -60,6 +60,10 @@ func pgNanosToTime(n int64) time.Time {
 // fileRowToFileWithNlink converts a database row to a File struct, including link count.
 // Expected columns: id, share_name, path, file_type, mode, uid, gid, size,
 // atime, mtime, ctime, creation_time, content_id, link_target, device_major, device_minor, hidden, acl, object_id, deleted_at, original_path, deleted_by, link_count
+//
+// The `path` column is no longer stored on the inode (#1166); callers supply it
+// as a reconstructed expression (inodePathExpr) walking parent_child_map up to
+// the share root. For a hard-linked inode this yields one of its paths.
 func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 	var (
 		id           uuid.UUID

--- a/pkg/metadata/store/postgres/errors.go
+++ b/pkg/metadata/store/postgres/errors.go
@@ -53,7 +53,7 @@ func mapPgErrorCode(pgErr *pgconn.PgError, operation, path string) error {
 	// 23505: unique_violation
 	case "23505":
 		// Distinguish the object_id (file-level dedup) uniqueness
-		// violation from a path-hash collision. The files_object_id_idx
+		// violation from any other unique collision. The inodes_object_id_idx
 		// partial unique index enforces "one ObjectID -> one file"; a
 		// second file with byte-identical content (same Merkle-root
 		// ObjectID) trips it. Callers (the rollup persist path) treat
@@ -61,10 +61,10 @@ func mapPgErrorCode(pgErr *pgconn.PgError, operation, path string) error {
 		// covered by the canonical file's manifest — so it must surface
 		// as ErrConflict, NOT the generic ErrAlreadyExists. The defensive
 		// message-text fallback mirrors the runtime coordinator's
-		// detection for drivers that strip ConstraintName. Path-hash
-		// collisions (unique_share_path_hash_active) stay ErrAlreadyExists
-		// so the path uniqueness contract is preserved.
-		if pgErr.ConstraintName == "files_object_id_idx" ||
+		// detection for drivers that strip ConstraintName. Any other unique
+		// violation (e.g. a duplicate parent_child_map name) stays
+		// ErrAlreadyExists.
+		if pgErr.ConstraintName == "inodes_object_id_idx" ||
 			(pgErr.ConstraintName == "" && strings.Contains(pgErr.Message, "object_id")) {
 			return &metadata.StoreError{
 				Code:    metadata.ErrConflict,

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -40,13 +40,13 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 
 	query := `
 		SELECT
-			f.id, f.share_name, f.path,
+			f.id, f.share_name, ` + inodePathExpr + `,
 			f.file_type, f.mode, f.uid, f.gid, f.size,
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
 			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
-		FROM files f
+		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
@@ -232,7 +232,7 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
 		       f.deleted_at, f.original_path, f.deleted_by, lc.link_count
 		FROM parent_child_map dc
-		LEFT JOIN files f ON dc.child_id = f.id
+		LEFT JOIN inodes f ON dc.child_id = f.id
 		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
 		WHERE dc.parent_id = $1 AND dc.child_name > $2
 		ORDER BY dc.child_name
@@ -434,7 +434,7 @@ func (s *PostgresMetadataStore) FindByObjectID(ctx context.Context, objectID blo
 
 	var fileID uuid.UUID
 	err := s.queryRow(ctx,
-		`SELECT id FROM files WHERE object_id = $1 LIMIT 1`,
+		`SELECT id FROM inodes WHERE object_id = $1 LIMIT 1`,
 		objectID[:],
 	).Scan(&fileID)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -461,13 +461,13 @@ func (s *PostgresMetadataStore) GetFileByPayloadID(ctx context.Context, payloadI
 	// for files with paths near PATH_MAX (4096 bytes).
 	query := `
 		SELECT
-			f.id, f.share_name, f.path,
+			f.id, f.share_name, ` + inodePathExpr + `,
 			f.file_type, f.mode, f.uid, f.gid, f.size,
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
 			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
-		FROM files f
+		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1
@@ -498,7 +498,7 @@ func (s *PostgresMetadataStore) CountObjectIDIndexRows(ctx context.Context, obje
 	}
 	var n int
 	err := s.queryRow(ctx,
-		`SELECT count(*) FROM files WHERE object_id = $1`,
+		`SELECT count(*) FROM inodes WHERE object_id = $1`,
 		objectID[:],
 	).Scan(&n)
 	if err != nil {

--- a/pkg/metadata/store/postgres/migrations/000032_rename_files_to_inodes.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000032_rename_files_to_inodes.down.sql
@@ -1,0 +1,96 @@
+-- Revert: rename inodes -> files and restore the path/path_hash columns (#1166).
+--
+-- TRADEOFF / data caveat: the up migration DROPPED the canonical `path` column.
+-- That string is not recoverable verbatim — it was a denormalized cache of one
+-- of an inode's names. This down migration reconstructs a WORKING path for
+-- every reachable inode from parent_child_map (the authoritative namespace),
+-- choosing a single deterministic name per inode (lowest child_name when an
+-- inode has several hard links). The result is a valid, fully-indexed schema,
+-- but for a multiply-linked inode the recovered `path` may differ from whatever
+-- single name the column happened to hold before the up migration. Inodes that
+-- are not reachable from any parent (e.g. orphaned/unlinked-but-open rows) get
+-- '/' as a placeholder so the NOT NULL column can be populated. This is a
+-- best-effort reverse: it restores schema and behavior, not the exact prior
+-- string for hard-linked files.
+
+ALTER TABLE inodes RENAME TO files;
+
+-- Restore renamed indexes/triggers to their original "files" names.
+ALTER INDEX IF EXISTS idx_inodes_content_id_hash RENAME TO idx_files_content_id_hash;
+ALTER INDEX IF EXISTS idx_inodes_share_name RENAME TO idx_files_share_name;
+ALTER INDEX IF EXISTS idx_inodes_updated_at RENAME TO idx_files_updated_at;
+ALTER INDEX IF EXISTS idx_inodes_hidden RENAME TO idx_files_hidden;
+ALTER INDEX IF EXISTS idx_inodes_has_acl RENAME TO idx_files_has_acl;
+ALTER INDEX IF EXISTS inodes_object_id_idx RENAME TO files_object_id_idx;
+
+ALTER TRIGGER update_inodes_updated_at ON files RENAME TO update_files_updated_at;
+ALTER TRIGGER inodes_content_id_hash_trigger ON files RENAME TO files_content_id_hash_trigger;
+
+-- Re-add the columns. path_hash is filled by the recreated trigger on the
+-- backfill UPDATE below; add path nullable first so the table can hold rows
+-- while we reconstruct, then enforce NOT NULL.
+ALTER TABLE files ADD COLUMN IF NOT EXISTS path      TEXT;
+ALTER TABLE files ADD COLUMN IF NOT EXISTS path_hash TEXT;
+
+-- Recreate the path_hash maintenance function + trigger.
+CREATE OR REPLACE FUNCTION update_path_hash()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.path_hash = md5(NEW.path);
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER files_path_hash_trigger
+    BEFORE INSERT OR UPDATE OF path ON files
+    FOR EACH ROW EXECUTE FUNCTION update_path_hash();
+
+-- Reconstruct each inode's path from parent_child_map. The recursive CTE walks
+-- DOWN from each share root (an inode with no parent edge) building paths; when
+-- an inode is reachable under several names only the lexicographically smallest
+-- full path is kept (DISTINCT ON ordered by path).
+WITH RECURSIVE tree(id, path, depth) AS (
+    -- Roots: inodes that are never a child in parent_child_map.
+    SELECT f.id AS id, '/'::text AS path, 1 AS depth
+    FROM files f
+    WHERE NOT EXISTS (SELECT 1 FROM parent_child_map m WHERE m.child_id = f.id)
+
+    UNION ALL
+
+    -- depth < 4096 bounds the walk against a corrupt directed cycle in
+    -- parent_child_map (the schema does not forbid one); 4096 is well above any
+    -- real path depth, so legitimate trees are never truncated.
+    SELECT m.child_id AS id,
+           CASE WHEN t.path = '/' THEN '/' || m.child_name
+                ELSE t.path || '/' || m.child_name END AS path,
+           t.depth + 1
+    FROM tree t
+    JOIN parent_child_map m ON m.parent_id = t.id
+    WHERE t.depth < 4096
+),
+chosen AS (
+    SELECT DISTINCT ON (id) id, path
+    FROM tree
+    ORDER BY id, path
+)
+UPDATE files f
+SET path = c.path
+FROM chosen c
+WHERE f.id = c.id;
+
+-- Any inode the walk could not reach (orphaned/unlinked rows with no parent
+-- edge that are also not a root) falls back to '/' so the column is populated.
+UPDATE files SET path = '/' WHERE path IS NULL;
+
+-- path_hash was set by the trigger on each UPDATE above; backfill defensively
+-- for any row the UPDATEs skipped, then enforce NOT NULL on both columns.
+UPDATE files SET path_hash = md5(path) WHERE path_hash IS NULL;
+
+ALTER TABLE files ALTER COLUMN path      SET NOT NULL;
+ALTER TABLE files ALTER COLUMN path_hash SET NOT NULL;
+
+-- Recreate the non-unique lookup index dropped by the up migration. The
+-- unique_share_path_hash_active index is intentionally NOT recreated here: it
+-- was already dropped by 000031 (its own down migration owns that revert), and
+-- recreating it could fail against hard-link state this very refactor enables.
+CREATE INDEX IF NOT EXISTS idx_files_share_path_hash ON files(share_name, path_hash);

--- a/pkg/metadata/store/postgres/migrations/000032_rename_files_to_inodes.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000032_rename_files_to_inodes.up.sql
@@ -1,0 +1,52 @@
+-- Rename files -> inodes and drop the path-as-key columns (#1166, part 1).
+--
+-- The `files` row conflated inode identity/attributes (shared across hard
+-- links) with one canonical `path`/`path_hash` (only one of N names). That
+-- single-path assumption produced a recurring class of postgres-only bugs
+-- (#1160 rename-overwrite, #190 recycle "already exists") because a multiply-
+-- linked inode has only ONE path column that goes stale when the matching name
+-- is removed. #1165 (migration 000031) dropped the unique_share_path_hash_active
+-- index as a stopgap; this migration does the proper decoupling.
+--
+-- The namespace's sole source of truth is parent_child_map(parent_id,
+-- child_name -> child_id). Full paths are derived on demand from it (recursive
+-- walk in GetFile); the denormalized path/path_hash columns are no longer
+-- needed and are removed here. The memory and badger backends never carried a
+-- canonical path on the inode; this aligns postgres with them.
+--
+-- content_id / content_id_hash are kept AS-IS: they key file_blocks.id and are
+-- consumed by GetFileByPayloadID / the flusher. Decoupling content_id from the
+-- path is a later slice (#1166 part 3); this migration does not touch its
+-- values.
+--
+-- Handle stability (invariant #3) is preserved: a file handle is
+-- shareName:UUID = inodes.id, and a table rename does not change the UUID.
+
+-- Rename the table. PostgreSQL keeps existing indexes, triggers, constraints
+-- and foreign keys (parent_child_map, link_counts, shares, pending_writes, ...)
+-- attached to the renamed table automatically, so all FKs that referenced
+-- files(id) now reference inodes(id) with no further action.
+ALTER TABLE files RENAME TO inodes;
+
+-- Drop the path-derived index and the trigger that maintained path_hash, then
+-- the columns themselves. unique_share_path_hash_active was already dropped in
+-- 000031.
+DROP TRIGGER IF EXISTS files_path_hash_trigger ON inodes;
+DROP FUNCTION IF EXISTS update_path_hash();
+DROP INDEX IF EXISTS idx_files_share_path_hash;
+
+ALTER TABLE inodes DROP COLUMN IF EXISTS path_hash;
+ALTER TABLE inodes DROP COLUMN IF EXISTS path;
+
+-- Rename the indexes/triggers whose names embed the old "files" table name so
+-- the schema stays self-describing. Renames are metadata-only (no rewrite) and
+-- leave behavior identical. content_id_hash itself is unchanged.
+ALTER INDEX IF EXISTS idx_files_content_id_hash RENAME TO idx_inodes_content_id_hash;
+ALTER INDEX IF EXISTS idx_files_share_name RENAME TO idx_inodes_share_name;
+ALTER INDEX IF EXISTS idx_files_updated_at RENAME TO idx_inodes_updated_at;
+ALTER INDEX IF EXISTS idx_files_hidden RENAME TO idx_inodes_hidden;
+ALTER INDEX IF EXISTS idx_files_has_acl RENAME TO idx_inodes_has_acl;
+ALTER INDEX IF EXISTS files_object_id_idx RENAME TO inodes_object_id_idx;
+
+ALTER TRIGGER update_files_updated_at ON inodes RENAME TO update_inodes_updated_at;
+ALTER TRIGGER files_content_id_hash_trigger ON inodes RENAME TO inodes_content_id_hash_trigger;

--- a/pkg/metadata/store/postgres/paths.go
+++ b/pkg/metadata/store/postgres/paths.go
@@ -1,0 +1,62 @@
+package postgres
+
+// Path reconstruction (#1166).
+//
+// The inodes table no longer stores a canonical path: parent_child_map
+// (parent_id, child_name -> child_id) is the sole source of truth for the
+// namespace. metadata.File.Path is still populated by GetFile and the
+// payload-id lookup (callers and the conformance suite derive child paths from
+// a parent's Path), so it is reconstructed on read by walking parent_child_map
+// up to the share root.
+//
+// For a hard-linked inode (N names) the walk is deterministic but arbitrary:
+// at each level it follows a single edge ordered by (parent_id, child_name),
+// yielding ONE of the inode's paths. POSIX does not guarantee which path a
+// stat() reflects for a multiply-linked file, so returning any valid reachable
+// path is correct. An inode with no parent edge (a share root, or an
+// orphaned/unlinked-but-open inode) resolves to "/".
+//
+// inodePathExpr is a correlated scalar subquery that computes the path for the
+// row aliased `f` in the enclosing query (it references f.id). Splice it into a
+// SELECT list in place of the old f.path column. It is a single round-trip with
+// the rest of the row.
+//
+// PostgreSQL forbids ORDER BY / LIMIT directly in a recursive CTE's anchor or
+// recursive term, so the per-level "pick one edge" is done inside derived
+// subqueries (the anchor wraps an ordered LIMIT 1; the recursive term picks via
+// CROSS JOIN LATERAL).
+//
+// The `depth < 4096` guard bounds the walk: parent_child_map's schema permits a
+// directed cycle (only FK constraints to inodes(id), no acyclicity check) that
+// no filesystem operation can create but a bug or direct DB edit could. Without
+// the cap a cycle would make every GetFile for a node in it recurse until
+// statement_timeout. 4096 is well above any real path-component depth (it
+// matches the filesystem MaxPathLen ceiling), so it never truncates a
+// legitimate path while turning a corrupt cycle into a bounded, finite result.
+const inodePathExpr = `(
+	WITH RECURSIVE up(parent_id, child_name, depth) AS (
+		SELECT anchor.parent_id, anchor.child_name, 1
+		FROM (
+			SELECT e.parent_id, e.child_name
+			FROM parent_child_map e
+			WHERE e.child_id = f.id
+			ORDER BY e.parent_id, e.child_name
+			LIMIT 1
+		) AS anchor
+
+		UNION ALL
+
+		SELECT picked.parent_id, picked.child_name, up.depth + 1
+		FROM up
+		CROSS JOIN LATERAL (
+			SELECT e.parent_id, e.child_name
+			FROM parent_child_map e
+			WHERE e.child_id = up.parent_id
+			ORDER BY e.parent_id, e.child_name
+			LIMIT 1
+		) AS picked
+		WHERE up.depth < 4096
+	)
+	SELECT COALESCE('/' || string_agg(child_name, '/' ORDER BY depth DESC), '/')
+	FROM up
+)`

--- a/pkg/metadata/store/postgres/reset_audit_test.go
+++ b/pkg/metadata/store/postgres/reset_audit_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -29,13 +30,22 @@ func TestBackupTablesCoversAllMigrations(t *testing.T) {
 
 	// CREATE TABLE [IF NOT EXISTS] <name> — capture the bare table name.
 	createTableRE := regexp.MustCompile(`(?im)^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)`)
+	// ALTER TABLE [IF EXISTS] <old> RENAME TO <new> — a rename retires <old>
+	// and introduces <new> (e.g. files -> inodes in 000032).
+	renameTableRE := regexp.MustCompile(`(?im)^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s+RENAME\s+TO\s+([A-Za-z_][A-Za-z0-9_]*)`)
 
-	seen := map[string]string{} // table -> migration file
+	// Migrations apply in lexical filename order; process them that way so a
+	// later RENAME correctly supersedes an earlier CREATE.
+	var files []string
 	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".up.sql") {
-			continue
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			files = append(files, e.Name())
 		}
+	}
+	sort.Strings(files)
+
+	seen := map[string]string{} // live table -> migration file that created it
+	for _, name := range files {
 		path := filepath.Join(migrationsDir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -49,6 +59,19 @@ func TestBackupTablesCoversAllMigrations(t *testing.T) {
 			}
 			if _, exists := seen[tbl]; !exists {
 				seen[tbl] = name
+			}
+		}
+		// Apply renames after creates in the same file: the old name is no
+		// longer a live table; the new name inherits its provenance.
+		for _, m := range renameTableRE.FindAllStringSubmatch(string(data), -1) {
+			oldName, newName := m[1], m[2]
+			src, existed := seen[oldName]
+			delete(seen, oldName)
+			if !existed {
+				src = name
+			}
+			if _, exists := seen[newName]; !exists {
+				seen[newName] = src
 			}
 		}
 	}

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -105,7 +105,7 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 		return err
 	}
 
-	// The shares.root_file_id column is NOT NULL with an FK to files(id), so
+	// The shares.root_file_id column is NOT NULL with an FK to inodes(id), so
 	// a share row cannot exist before its root inode — a bare
 	// INSERT INTO shares (share_name, options, ...) is structurally
 	// impossible (it raises a not_null_violation on root_file_id) and never
@@ -126,12 +126,12 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 
 	// Duplicate detection: a share is "created" once its root inode exists.
 	// This read is the common-case fast path; it is not the integrity
-	// authority. Two creators racing the same name both pass this check and
-	// reach CreateRootDirectory, but the partial unique index
-	// unique_share_path_hash_active on files(share_name, path_hash) admits
-	// only one root inode at path "/" — the loser's insert fails rather than
-	// silently orphaning an inode. (Production also serializes share creation
-	// upstream in the control plane.)
+	// authority. The shares table PRIMARY KEY(share_name) is the authority —
+	// two creators racing the same name both pass this check and reach
+	// CreateRootDirectory, but the second INSERT INTO shares conflicts on the
+	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
+	// at most one root). (Production also serializes share creation upstream in
+	// the control plane.)
 	existing, err := s.getExistingRootDirectory(ctx, share.Name)
 	if err != nil {
 		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
@@ -310,7 +310,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		if needsUpdate {
 			now := time.Now()
 			updateQuery := `
-				UPDATE files
+				UPDATE inodes
 				SET mode = $1, uid = $2, gid = $3, ctime = $4
 				WHERE id = $5
 			`
@@ -349,25 +349,24 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 
 	now := time.Now()
 
-	// Insert root directory file
+	// Insert root directory inode
 	insertFileQuery := `
-		INSERT INTO files (
-			id, share_name, path,
+		INSERT INTO inodes (
+			id, share_name,
 			file_type, mode, uid, gid, size,
 			atime, mtime, ctime, creation_time,
 			content_id, link_target, device_major, device_minor
 		) VALUES (
-			$1, $2, $3,
-			$4, $5, $6, $7, $8,
-			$9, $10, $11, $12,
-			$13, $14, $15, $16
+			$1, $2,
+			$3, $4, $5, $6, $7,
+			$8, $9, $10, $11,
+			$12, $13, $14, $15
 		)
 	`
 
 	_, err = tx.Exec(ctx, insertFileQuery,
 		rootID,                            // id
 		shareName,                         // share_name
-		"/",                               // path (root)
 		int16(metadata.FileTypeDirectory), // file_type
 		int32(mode),                       // mode
 		int32(uid),                        // uid
@@ -444,11 +443,13 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 // getExistingRootDirectory checks if a root directory already exists for the share
 // and returns it if found. Returns nil, nil if not found.
 func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
+	// Resolve the root inode via shares.root_file_id (the share row is the
+	// authoritative pointer to its root) now that the path column is gone (#1166).
 	query := `
 		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
 			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden
-		FROM files f
-		WHERE f.share_name = $1 AND f.path = '/'
+		FROM inodes f
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
 	`
 
 	var (

--- a/pkg/metadata/store/postgres/statfs.go
+++ b/pkg/metadata/store/postgres/statfs.go
@@ -30,10 +30,10 @@ func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
 		shareName = ""
 	}
 	if shareName != "" {
-		return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM files WHERE share_name = $1 AND file_type = $2`,
+		return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = $1 AND file_type = $2`,
 			[]any{shareName, int(metadata.FileTypeRegular)}
 	}
-	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM files WHERE file_type = $1`,
+	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1`,
 		[]any{int(metadata.FileTypeRegular)}
 }
 

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -157,7 +157,7 @@ func (s *PostgresMetadataStore) GetUsedBytes() int64 {
 
 // initUsedBytesCounter initializes the atomic counter from a SQL SUM query.
 func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error {
-	query := `SELECT COALESCE(SUM(size), 0) FROM files WHERE file_type = $1`
+	query := `SELECT COALESCE(SUM(size), 0) FROM inodes WHERE file_type = $1`
 	var totalUsed int64
 	err := s.pool.QueryRow(ctx, query, int(metadata.FileTypeRegular)).Scan(&totalUsed)
 	if err != nil {

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -147,13 +147,13 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 
 	query := `
 		SELECT
-			f.id, f.share_name, f.path,
+			f.id, f.share_name, ` + inodePathExpr + `,
 			f.file_type, f.mode, f.uid, f.gid, f.size,
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
 			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
-		FROM files f
+		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
@@ -192,18 +192,11 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// For existing files (updates), use UPDATE directly to avoid unique constraint issues.
 	// This is more efficient and handles concurrent updates properly.
 	//
-	// The unique constraint on (share_name, path_hash) WHERE nlink > 0 can cause
-	// spurious "already exists" errors when using INSERT ... ON CONFLICT (id)
-	// because that clause doesn't handle conflicts on the path_hash constraint.
-	//
-	// path MUST be in the SET list: Move relocates a node by setting File.Path
-	// to its new location and calling PutFile. The memory/badger backends persist
-	// the whole File, so their path moves; if this UPDATE omitted path, the
-	// relocated row would keep its old path (and trigger-derived path_hash),
-	// leaving the original path occupied under unique_share_path_hash_active. A
-	// recycle (Move into #recycle) followed by recreating the original name would
-	// then fail "already exists" on postgres only (#190). path_hash is maintained
-	// by the files_path_hash_trigger, so updating path refreshes it.
+	// Namespace uniqueness lives in parent_child_map(parent_id, child_name); the
+	// inodes row no longer carries a path/path_hash column (#1166), so a Move is
+	// just a parent_child_map re-link (SetChild/DeleteChild) — there is nothing
+	// path-related to update on the inode row here. content_id is still set:
+	// it keys file_blocks and is consumed by GetFileByPayloadID.
 	//
 	// The leading CTE reads the pre-update size under FOR UPDATE and the UPDATE
 	// joins against it, so a single round-trip both locks the row and returns
@@ -216,34 +209,33 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	updateQuery := `
 		WITH old AS (
 			SELECT id, share_name, size
-			FROM files
-			WHERE id = $22 AND share_name = $23
+			FROM inodes
+			WHERE id = $21 AND share_name = $22
 			FOR UPDATE
 		)
-		UPDATE files SET
-			path = $1,
-			file_type = $2,
-			mode = $3,
-			uid = $4,
-			gid = $5,
-			size = $6,
-			atime = $7,
-			mtime = $8,
-			ctime = $9,
-			creation_time = $10,
-			content_id = $11,
-			link_target = $12,
-			device_major = $13,
-			device_minor = $14,
-			hidden = $15,
-			acl = $16,
-			eas = $17,
-			object_id = $18,
-			deleted_at = $19,
-			original_path = $20,
-			deleted_by = $21
+		UPDATE inodes SET
+			file_type = $1,
+			mode = $2,
+			uid = $3,
+			gid = $4,
+			size = $5,
+			atime = $6,
+			mtime = $7,
+			ctime = $8,
+			creation_time = $9,
+			content_id = $10,
+			link_target = $11,
+			device_major = $12,
+			device_minor = $13,
+			hidden = $14,
+			acl = $15,
+			eas = $16,
+			object_id = $17,
+			deleted_at = $18,
+			original_path = $19,
+			deleted_by = $20
 		FROM old
-		WHERE files.id = old.id AND files.share_name = old.share_name
+		WHERE inodes.id = old.id AND inodes.share_name = old.share_name
 		RETURNING old.size
 	`
 
@@ -314,7 +306,6 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	var oldSizeVal sql.NullInt64
 	updated := true
 	scanErr := tx.tx.QueryRow(ctx, updateQuery,
-		file.Path,
 		file.Type, file.Mode, file.UID, file.GID, file.Size,
 		timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
 		timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
@@ -346,19 +337,19 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// If no rows were updated, the file doesn't exist - do an INSERT
 	if !updated {
 		insertQuery := `
-			INSERT INTO files (
-				id, share_name, path, file_type, mode, uid, gid, size,
+			INSERT INTO inodes (
+				id, share_name, file_type, mode, uid, gid, size,
 				atime, mtime, ctime, creation_time, content_id, link_target,
 				device_major, device_minor, hidden, acl, eas, object_id,
 				deleted_at, original_path, deleted_by
 			) VALUES (
-				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
-				$20, $21, $22, $23
+				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
+				$19, $20, $21, $22
 			)
 		`
 
 		if _, err := tx.tx.Exec(ctx, insertQuery,
-			file.ID, file.ShareName, file.Path,
+			file.ID, file.ShareName,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
 			timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
 			timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
@@ -413,17 +404,17 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 	var fileType int
 	var fileSize int64
 	_ = tx.tx.QueryRow(ctx,
-		`SELECT file_type, size FROM files WHERE id = $1 AND share_name = $2`,
+		`SELECT file_type, size FROM inodes WHERE id = $1 AND share_name = $2`,
 		id, shareName,
 	).Scan(&fileType, &fileSize)
 
 	// Delete the file. link_counts.file_id and parent_child_map.parent_id both
-	// declare ON DELETE CASCADE against files(id), so deleting the file row
+	// declare ON DELETE CASCADE against inodes(id), so deleting the inode row
 	// reaps this node's link-count and (if it is a directory) its child-map
 	// rows automatically. We do NOT delete this file from its parent's children
 	// map here — that is the responsibility of DeleteChild, which the service
 	// layer calls separately. This matches the memory and badger stores.
-	result, err := tx.tx.Exec(ctx, `DELETE FROM files WHERE id = $1 AND share_name = $2`, id, shareName)
+	result, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE id = $1 AND share_name = $2`, id, shareName)
 	if err != nil {
 		return mapPgError(err, "DeleteFile", "")
 	}
@@ -562,7 +553,7 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
 		       f.deleted_at, f.original_path, f.deleted_by, lc.link_count
 		FROM parent_child_map dc
-		LEFT JOIN files f ON dc.child_id = f.id
+		LEFT JOIN inodes f ON dc.child_id = f.id
 		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
 		WHERE dc.parent_id = $1 AND dc.child_name > $2
 		ORDER BY dc.child_name
@@ -772,10 +763,9 @@ func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata
 		return mapPgError(err, "SetLinkCount", "")
 	}
 
-	// Also update files.nlink column for the partial unique constraint
-	// The unique index on (share_name, path_hash) WHERE nlink > 0 requires
-	// the nlink column to be kept in sync with link_counts table.
-	nlinkQuery := `UPDATE files SET nlink = $1 WHERE id = $2`
+	// Also keep the inodes.nlink column in sync with the link_counts table so
+	// GETATTR can read the link count straight off the inode row without a join.
+	nlinkQuery := `UPDATE inodes SET nlink = $1 WHERE id = $2`
 	_, err = tx.tx.Exec(ctx, nlinkQuery, count, fileID)
 	if err != nil {
 		return mapPgError(err, "SetLinkCount (nlink update)", "")
@@ -964,15 +954,15 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 	// lifetime.
 	var freedBytes int64
 	if err := tx.tx.QueryRow(ctx,
-		`SELECT COALESCE(SUM(size), 0) FROM files
+		`SELECT COALESCE(SUM(size), 0) FROM inodes
 		 WHERE share_name = $1 AND file_type = $2 AND size > 0`,
 		shareName, int(metadata.FileTypeRegular),
 	).Scan(&freedBytes); err != nil {
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 
-	// Drop the share row first: shares.root_file_id references files(id)
-	// WITHOUT ON DELETE CASCADE, so the files rows cannot be removed while
+	// Drop the share row first: shares.root_file_id references inodes(id)
+	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while
 	// the share still points at the root inode.
 	result, err := tx.tx.Exec(ctx, `DELETE FROM shares WHERE share_name = $1`, shareName)
 	if err != nil {
@@ -986,13 +976,12 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		}
 	}
 
-	// Delete all file rows for the share. The store.go:161 contract is
+	// Delete all inode rows for the share. The store.go:161 contract is
 	// "removes a share and all its metadata"; dropping only the share row
-	// orphans every files/parent_child_map/link_counts/file_block_refs row
-	// and leaves the root inode occupying the unique root-path index, so a
-	// same-name recreation fails with ErrAlreadyExists. parent_child_map,
-	// link_counts, and file_block_refs all cascade from files(id).
-	if _, err := tx.tx.Exec(ctx, `DELETE FROM files WHERE share_name = $1`, shareName); err != nil {
+	// orphans every inodes/parent_child_map/link_counts/file_block_refs row.
+	// parent_child_map, link_counts, and file_block_refs all cascade from
+	// inodes(id).
+	if _, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE share_name = $1`, shareName); err != nil {
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 
@@ -1055,13 +1044,15 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		mode = 0o755
 	}
 
-	// Check if root directory already exists (idempotent behavior)
+	// Check if root directory already exists (idempotent behavior). The root is
+	// resolved via shares.root_file_id — with the path column gone (#1166), the
+	// share row is the authoritative pointer to its root inode.
 	checkQuery := `
 		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
 			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, lc.link_count
-		FROM files f
+		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
-		WHERE f.share_name = $1 AND f.path = '/'
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
 	`
 
 	var (
@@ -1123,23 +1114,22 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 	now := time.Now()
 
 	insertFileQuery := `
-		INSERT INTO files (
-			id, share_name, path,
+		INSERT INTO inodes (
+			id, share_name,
 			file_type, mode, uid, gid, size,
 			atime, mtime, ctime, creation_time,
 			content_id, link_target, device_major, device_minor
 		) VALUES (
-			$1, $2, $3,
-			$4, $5, $6, $7, $8,
-			$9, $10, $11, $12,
-			$13, $14, $15, $16
+			$1, $2,
+			$3, $4, $5, $6, $7,
+			$8, $9, $10, $11,
+			$12, $13, $14, $15
 		)
 	`
 
 	_, err = tx.tx.Exec(ctx, insertFileQuery,
 		rootID,                            // id
 		shareName,                         // share_name
-		"/",                               // path (root)
 		int16(metadata.FileTypeDirectory), // file_type
 		int32(mode),                       // mode
 		int32(uid),                        // uid
@@ -1304,13 +1294,13 @@ func (tx *postgresTransaction) GetFileByPayloadID(ctx context.Context, payloadID
 	// for files with paths near PATH_MAX (4096 bytes).
 	query := `
 		SELECT
-			f.id, f.share_name, f.path,
+			f.id, f.share_name, ` + inodePathExpr + `,
 			f.file_type, f.mode, f.uid, f.gid, f.size,
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
 			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
-		FROM files f
+		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1


### PR DESCRIPTION
Part of #1166 — **does NOT close the issue.** This is PR-1 of the 5-PR plan to
decouple inode identity from a single canonical path (hard-link modeling).

## What PR-1 does

Renames the PostgreSQL `files` table to `inodes` and drops the path-as-key
columns, keeping behaviour identical and the full conformance suite green.

`parent_child_map(parent_id, child_name → child_id)` is already the sole source
of truth for the namespace. The denormalized `path`/`path_hash` columns on the
inode were the root of a class of postgres-only hard-link bugs (#1160
rename-overwrite, #190 recycle "already exists") because a multiply-linked inode
has only ONE path column that goes stale when the matching name is removed.
#1165 (migration 000031) dropped the `unique_share_path_hash_active` index as a
stopgap; this PR does the proper decoupling. memory/badger never carried a
canonical path on the inode — this aligns postgres with them.

Handle stability (invariant #3) is preserved: a handle is `shareName:UUID =
inodes.id`, and a table rename does not change the UUID.

### Changes
- **Migration `000032_rename_files_to_inodes`** — `ALTER TABLE files RENAME TO
  inodes`; drop `path`/`path_hash`, the `idx_files_share_path_hash` index, and
  the `files_path_hash_trigger` + `update_path_hash()` function; rename the
  files-named indexes/triggers to `inodes_*`. `content_id`/`content_id_hash`
  are untouched (they key `file_blocks.id`; decoupling them is PR-3).
- **All postgres SQL retargeted** `files` → `inodes`. FK references
  (`parent_child_map`, `link_counts`, `shares`, `pending_writes`,
  `durable_handles`, …) follow the table rename automatically — PostgreSQL
  repoints FKs to the renamed table, so no FK drop/recreate is needed.
- **`PutFile`** INSERT/UPDATE no longer write `path`; **`GetFile`** /
  payload-id lookup no longer select a stored path.
- **Root lookup** resolves via `shares.root_file_id` instead of `WHERE path =
  '/'` (in both `CreateRootDirectory` and `getExistingRootDirectory`).
- **Backup** schema version bumped `v2 → v3`; `backupTables` lists `inodes`;
  the migration-coverage audit test is now rename-aware.
- **errors.go** object_id unique-violation mapping follows the renamed index
  (`files_object_id_idx` → `inodes_object_id_idx`).

## Down-migration tradeoff

The up migration **drops** the canonical `path` string, which is not
recoverable verbatim. The down migration restores a **working, fully-indexed**
schema: it re-adds the columns, recreates the index/trigger/function, and
**reconstructs each inode's path from `parent_child_map`** (the authoritative
namespace), choosing one deterministic name per inode (lexicographically
smallest full path for a hard-linked inode); unreachable/orphaned rows get `/`.
So DOWN restores schema + behaviour, not the exact prior string for hard-linked
files — documented inline in the `.down.sql`. It does **not** recreate
`unique_share_path_hash_active` (000031 owns that revert). Verified up → down →
up round-trips cleanly with seeded hard-link data against real PostgreSQL 16.

## How `File.Path` is now derived

The Go `metadata.File.Path` field is still populated on read (callers and the
conformance suite derive child paths from a parent's `Path`). It is
reconstructed in `GetFile`/payload-id lookups via a recursive `parent_child_map`
walk up to the share root (`inodePathExpr`, a correlated scalar subquery — one
round-trip with the row). For a hard-linked inode this returns **one** of its
paths, which is acceptable (POSIX doesn't guarantee which path `stat()` shows).
A `depth < 4096` guard bounds the walk so a corrupt directed cycle in
`parent_child_map` can never make the query recurse forever.

## Test evidence (real PostgreSQL 16)

Ran against a docker `postgres:16` with `DITTOFS_TEST_POSTGRES_DSN` set:

```
go test -tags integration -count=1 ./pkg/metadata/store/postgres/...
ok  github.com/marmos91/dittofs/pkg/metadata/store/postgres  18.441s
```

Green, including: full `TestConformance` (FileOps/CreateHardLink, Rename,
NestedDirectories, DirOps, Permissions, DurableHandles), `TestBackupConformance`
(backup → restore round-trip on the renamed `inodes` table),
`TestPostgresPutFile_ObjectIDConflictMapsToErrConflict`,
`TestPostgresPutFile_DuplicatePathAllowed`, `TestPostgres_PutFile_UsedBytesAccurate`,
and `TestBackupTablesCoversAllMigrations`. `go build ./...`, `go vet`, `gofmt`
all clean. Migration applies cleanly forward, and the down migration runs.

Out of scope (later PRs): deleting `updateDescendantPaths` + Move path tracking
(PR-2), UUID-based content_id (PR-3), `link_counts` → `inodes.nlink` (PR-4),
full hard-link conformance cases (PR-5).
