### PR TITLE
feat: per-user/per-group quotas (bytes+inodes, soft/hard/grace) for NFS+SMB

### DIFF
--- a/cmd/dfsctl/commands/quota/list.go
+++ b/cmd/dfsctl/commands/quota/list.go
@@ -1,0 +1,99 @@
+package quota
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/bytesize"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list <share>",
+	Short: "List all quotas on a share",
+	Long: `List all per-identity quotas configured on a share.
+
+Examples:
+  # List quotas as a table
+  dfsctl quota list /archive
+
+  # List as JSON
+  dfsctl quota list /archive -o json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runList,
+}
+
+// quotaRow holds resolved quota info for table display.
+type quotaRow struct {
+	Scope      string `json:"scope"`
+	ID         string `json:"id"`
+	LimitBytes string `json:"limit_bytes"`
+	UsedBytes  string `json:"used_bytes"`
+	LimitFiles string `json:"limit_files"`
+	UsedFiles  string `json:"used_files"`
+	Grace      string `json:"grace"`
+}
+
+// QuotaList is a list of quotas for table rendering.
+type QuotaList []quotaRow
+
+// Headers implements TableRenderer.
+func (ql QuotaList) Headers() []string {
+	return []string{"SCOPE", "ID", "LIMIT BYTES", "USED BYTES", "LIMIT FILES", "USED FILES", "GRACE"}
+}
+
+// Rows implements TableRenderer.
+func (ql QuotaList) Rows() [][]string {
+	rows := make([][]string, 0, len(ql))
+	for _, q := range ql {
+		rows = append(rows, []string{q.Scope, q.ID, q.LimitBytes, q.UsedBytes, q.LimitFiles, q.UsedFiles, q.Grace})
+	}
+	return rows
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	share := args[0]
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	quotas, err := client.ListQuotas(share)
+	if err != nil {
+		return fmt.Errorf("failed to list quotas: %w", err)
+	}
+
+	rows := make(QuotaList, 0, len(quotas))
+	for _, q := range quotas {
+		id := "-"
+		if q.IdentityID != nil {
+			id = strconv.FormatUint(uint64(*q.IdentityID), 10)
+		}
+		limitBytes := "unlimited"
+		if q.LimitBytes != "" {
+			limitBytes = q.LimitBytes
+		}
+		limitFiles := "unlimited"
+		if q.LimitFiles > 0 {
+			limitFiles = strconv.FormatInt(q.LimitFiles, 10)
+		}
+		grace := "-"
+		if q.GraceSeconds > 0 {
+			grace = fmt.Sprintf("%ds", q.GraceSeconds)
+		}
+		rows = append(rows, quotaRow{
+			Scope:      q.Scope,
+			ID:         id,
+			LimitBytes: limitBytes,
+			UsedBytes:  bytesize.ByteSize(q.UsedBytes).String(),
+			LimitFiles: limitFiles,
+			UsedFiles:  strconv.FormatInt(q.UsedFiles, 10),
+			Grace:      grace,
+		})
+	}
+
+	return cmdutil.PrintOutput(os.Stdout, rows, len(rows) == 0, "No quotas found.", rows)
+}

--- a/cmd/dfsctl/commands/quota/quota.go
+++ b/cmd/dfsctl/commands/quota/quota.go
@@ -1,0 +1,78 @@
+// Package quota implements per-identity quota management commands for dfsctl.
+package quota
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// scope constants mirror models.QuotaScope* (kept local to avoid a control-plane
+// import from the CLI layer).
+const (
+	scopeUser        = "user"
+	scopeGroup       = "group"
+	scopeDefaultUser = "default-user"
+)
+
+// isValidScope reports whether s is a supported quota scope.
+func isValidScope(s string) bool {
+	switch s {
+	case scopeUser, scopeGroup, scopeDefaultUser:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveID maps the --id flag (default -1 = unset) to the *uint32 identity the
+// API expects. user/group require a non-negative id; default-user forbids one.
+func resolveID(scope string, id int64) (*uint32, error) {
+	if scope == scopeDefaultUser {
+		if id >= 0 {
+			return nil, fmt.Errorf("--id must not be set for scope default-user")
+		}
+		return nil, nil
+	}
+	if id < 0 {
+		return nil, fmt.Errorf("--id is required for scope %s", scope)
+	}
+	if id > int64(^uint32(0)) {
+		return nil, fmt.Errorf("--id %d out of range for a 32-bit identity", id)
+	}
+	v := uint32(id)
+	return &v, nil
+}
+
+// Cmd is the parent command for per-identity quota management.
+var Cmd = &cobra.Command{
+	Use:   "quota",
+	Short: "Per-identity quota management",
+	Long: `Manage per-identity (user/group/default-user) storage quotas on a share.
+
+Quotas bound both bytes and inode (file) count, with optional soft thresholds
+and a grace period before a soft threshold is enforced as hard. These operations
+require admin privileges.
+
+Examples:
+  # List all quotas on a share
+  dfsctl quota list /archive
+
+  # Set a per-user quota (uid 1000)
+  dfsctl quota set /archive --scope user --id 1000 --limit-bytes 10GiB --limit-files 100000
+
+  # Set the default-user fallback quota (applies to users without an explicit quota)
+  dfsctl quota set /archive --scope default-user --limit-bytes 1GiB
+
+  # Set a per-group quota with soft thresholds and a grace period
+  dfsctl quota set /archive --scope group --id 2000 --limit-bytes 50GiB --soft-bytes 45GiB --grace-seconds 604800
+
+  # Remove a per-user quota
+  dfsctl quota rm /archive --scope user --id 1000`,
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(setCmd)
+	Cmd.AddCommand(rmCmd)
+}

--- a/cmd/dfsctl/commands/quota/rm.go
+++ b/cmd/dfsctl/commands/quota/rm.go
@@ -1,0 +1,72 @@
+package quota
+
+import (
+	"fmt"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rmScope string
+	rmID    int64
+	rmForce bool
+)
+
+var rmCmd = &cobra.Command{
+	Use:   "rm <share>",
+	Short: "Remove a per-identity quota",
+	Long: `Remove a per-identity quota from a share.
+
+This action is irreversible. You will be prompted for confirmation
+unless --force is specified.
+
+Examples:
+  # Remove a per-user quota (uid 1000)
+  dfsctl quota rm /archive --scope user --id 1000
+
+  # Remove the default-user fallback quota
+  dfsctl quota rm /archive --scope default-user
+
+  # Remove without confirmation
+  dfsctl quota rm /archive --scope group --id 2000 --force`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRm,
+}
+
+func init() {
+	rmCmd.Flags().StringVar(&rmScope, "scope", "", "Quota scope (user|group|default-user) (required)")
+	rmCmd.Flags().Int64Var(&rmID, "id", -1, "Identity id (uid for user, gid for group). Required for user/group; omit for default-user.")
+	rmCmd.Flags().BoolVarP(&rmForce, "force", "f", false, "Skip confirmation prompt")
+	_ = rmCmd.MarkFlagRequired("scope")
+}
+
+func runRm(cmd *cobra.Command, args []string) error {
+	share := args[0]
+
+	if !isValidScope(rmScope) {
+		return fmt.Errorf("invalid --scope %q (want user|group|default-user)", rmScope)
+	}
+
+	id, err := resolveID(rmScope, rmID)
+	if err != nil {
+		return err
+	}
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	label := fmt.Sprintf("%s/%s", share, rmScope)
+	if id != nil {
+		label = fmt.Sprintf("%s/%d", label, *id)
+	}
+
+	return cmdutil.RunDeleteWithConfirmation("Quota", label, rmForce, func() error {
+		if err := client.DeleteQuota(share, rmScope, id); err != nil {
+			return fmt.Errorf("failed to delete quota: %w", err)
+		}
+		return nil
+	})
+}

--- a/cmd/dfsctl/commands/quota/set.go
+++ b/cmd/dfsctl/commands/quota/set.go
@@ -1,0 +1,89 @@
+package quota
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	setScope        string
+	setID           int64
+	setLimitBytes   string
+	setSoftBytes    string
+	setLimitFiles   int64
+	setSoftFiles    int64
+	setGraceSeconds int64
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set <share>",
+	Short: "Create or update a per-identity quota",
+	Long: `Create or update a per-identity quota on a share.
+
+The --scope flag selects user, group, or default-user. For user/group scopes an
+identity --id (uid or gid) is required. The default-user scope is a fallback
+applied to any user without an explicit user quota and takes no --id.
+
+A byte or file limit of 0 (the default) means "no limit on that dimension".
+
+Examples:
+  # Per-user quota (uid 1000): 10GiB / 100k files
+  dfsctl quota set /archive --scope user --id 1000 --limit-bytes 10GiB --limit-files 100000
+
+  # Default-user fallback quota
+  dfsctl quota set /archive --scope default-user --limit-bytes 1GiB
+
+  # Per-group quota with soft thresholds and a 7-day grace period
+  dfsctl quota set /archive --scope group --id 2000 --limit-bytes 50GiB --soft-bytes 45GiB --grace-seconds 604800`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSet,
+}
+
+func init() {
+	setCmd.Flags().StringVar(&setScope, "scope", "", "Quota scope (user|group|default-user) (required)")
+	setCmd.Flags().Int64Var(&setID, "id", -1, "Identity id (uid for user, gid for group). Required for user/group; omit for default-user.")
+	setCmd.Flags().StringVar(&setLimitBytes, "limit-bytes", "", "Hard byte ceiling (e.g., '10GiB', '500MiB'). 0/empty = unlimited.")
+	setCmd.Flags().StringVar(&setSoftBytes, "soft-bytes", "", "Soft byte threshold (e.g., '8GiB'). 0/empty = none.")
+	setCmd.Flags().Int64Var(&setLimitFiles, "limit-files", 0, "Hard inode (file-count) ceiling. 0 = unlimited.")
+	setCmd.Flags().Int64Var(&setSoftFiles, "soft-files", 0, "Soft inode threshold. 0 = none.")
+	setCmd.Flags().Int64Var(&setGraceSeconds, "grace-seconds", 0, "Seconds usage may exceed a soft threshold before it is enforced as hard. 0 = grace disabled.")
+	_ = setCmd.MarkFlagRequired("scope")
+}
+
+func runSet(cmd *cobra.Command, args []string) error {
+	share := args[0]
+
+	if !isValidScope(setScope) {
+		return fmt.Errorf("invalid --scope %q (want user|group|default-user)", setScope)
+	}
+
+	id, err := resolveID(setScope, setID)
+	if err != nil {
+		return err
+	}
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	req := &apiclient.UpsertQuotaRequest{
+		LimitBytes:   setLimitBytes,
+		SoftBytes:    setSoftBytes,
+		LimitFiles:   setLimitFiles,
+		SoftFiles:    setSoftFiles,
+		GraceSeconds: setGraceSeconds,
+	}
+
+	q, err := client.SetQuota(share, setScope, id, req)
+	if err != nil {
+		return fmt.Errorf("failed to set quota: %w", err)
+	}
+
+	return cmdutil.PrintResourceWithSuccess(os.Stdout, q,
+		fmt.Sprintf("Quota for scope '%s' on share '%s' set successfully", setScope, share))
+}

--- a/cmd/dfsctl/commands/root.go
+++ b/cmd/dfsctl/commands/root.go
@@ -13,6 +13,7 @@ import (
 	groupcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/group"
 	idmapcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/idmap"
 	netgroupcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/netgroup"
+	quotacmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/quota"
 	settingscmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/settings"
 	sharecmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/share"
 	storecmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/store"
@@ -77,6 +78,7 @@ func init() {
 	rootCmd.AddCommand(usercmd.Cmd)
 	rootCmd.AddCommand(groupcmd.Cmd)
 	rootCmd.AddCommand(sharecmd.Cmd)
+	rootCmd.AddCommand(quotacmd.Cmd)
 	rootCmd.AddCommand(trashcmd.Cmd)
 	rootCmd.AddCommand(storecmd.Cmd)
 	rootCmd.AddCommand(adaptercmd.Cmd)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -596,6 +596,10 @@ dfsctl
     list           List all netgroups
     remove-member  Remove a member from a netgroup
     show           Show netgroup details
+  quota          Per-identity quota management
+    list           List all quotas on a share
+    rm             Remove a per-identity quota
+    set            Create or update a per-identity quota
   settings       Server settings management
     get            Get a setting value
     list           List all settings
@@ -2566,6 +2570,158 @@ Global flags:
   -v, --verbose         Enable verbose output
 ```
 
+### `dfsctl quota`
+
+Per-identity quota management
+
+Manage per-identity (user/group/default-user) storage quotas on a share.
+
+Quotas bound both bytes and inode (file) count, with optional soft thresholds
+and a grace period before a soft threshold is enforced as hard. These operations
+require admin privileges.
+
+Examples:
+  # List all quotas on a share
+  dfsctl quota list /archive
+
+  # Set a per-user quota (uid 1000)
+  dfsctl quota set /archive --scope user --id 1000 --limit-bytes 10GiB --limit-files 100000
+
+  # Set the default-user fallback quota (applies to users without an explicit quota)
+  dfsctl quota set /archive --scope default-user --limit-bytes 1GiB
+
+  # Set a per-group quota with soft thresholds and a grace period
+  dfsctl quota set /archive --scope group --id 2000 --limit-bytes 50GiB --soft-bytes 45GiB --grace-seconds 604800
+
+  # Remove a per-user quota
+  dfsctl quota rm /archive --scope user --id 1000
+
+Global flags:
+
+```
+      --no-color        Disable colored output
+  -o, --output string   Output format (table|json|yaml) (default "table")
+      --server string   Server URL (overrides stored credential)
+      --token string    Bearer token (overrides stored credential)
+  -v, --verbose         Enable verbose output
+```
+
+### `dfsctl quota list`
+
+List all quotas on a share
+
+List all per-identity quotas configured on a share.
+
+Examples:
+  # List quotas as a table
+  dfsctl quota list /archive
+
+  # List as JSON
+  dfsctl quota list /archive -o json
+
+```
+dfsctl quota list <share>
+```
+
+Global flags:
+
+```
+      --no-color        Disable colored output
+  -o, --output string   Output format (table|json|yaml) (default "table")
+      --server string   Server URL (overrides stored credential)
+      --token string    Bearer token (overrides stored credential)
+  -v, --verbose         Enable verbose output
+```
+
+### `dfsctl quota rm`
+
+Remove a per-identity quota
+
+Remove a per-identity quota from a share.
+
+This action is irreversible. You will be prompted for confirmation
+unless --force is specified.
+
+Examples:
+  # Remove a per-user quota (uid 1000)
+  dfsctl quota rm /archive --scope user --id 1000
+
+  # Remove the default-user fallback quota
+  dfsctl quota rm /archive --scope default-user
+
+  # Remove without confirmation
+  dfsctl quota rm /archive --scope group --id 2000 --force
+
+```
+dfsctl quota rm <share> [flags]
+```
+
+Flags:
+
+```
+  -f, --force          Skip confirmation prompt
+      --id int         Identity id (uid for user, gid for group). Required for user/group; omit for default-user. (default -1)
+      --scope string   Quota scope (user|group|default-user) (required)
+```
+
+Global flags:
+
+```
+      --no-color        Disable colored output
+  -o, --output string   Output format (table|json|yaml) (default "table")
+      --server string   Server URL (overrides stored credential)
+      --token string    Bearer token (overrides stored credential)
+  -v, --verbose         Enable verbose output
+```
+
+### `dfsctl quota set`
+
+Create or update a per-identity quota
+
+Create or update a per-identity quota on a share.
+
+The --scope flag selects user, group, or default-user. For user/group scopes an
+identity --id (uid or gid) is required. The default-user scope is a fallback
+applied to any user without an explicit user quota and takes no --id.
+
+A byte or file limit of 0 (the default) means "no limit on that dimension".
+
+Examples:
+  # Per-user quota (uid 1000): 10GiB / 100k files
+  dfsctl quota set /archive --scope user --id 1000 --limit-bytes 10GiB --limit-files 100000
+
+  # Default-user fallback quota
+  dfsctl quota set /archive --scope default-user --limit-bytes 1GiB
+
+  # Per-group quota with soft thresholds and a 7-day grace period
+  dfsctl quota set /archive --scope group --id 2000 --limit-bytes 50GiB --soft-bytes 45GiB --grace-seconds 604800
+
+```
+dfsctl quota set <share> [flags]
+```
+
+Flags:
+
+```
+      --grace-seconds int    Seconds usage may exceed a soft threshold before it is enforced as hard. 0 = grace disabled.
+      --id int               Identity id (uid for user, gid for group). Required for user/group; omit for default-user. (default -1)
+      --limit-bytes string   Hard byte ceiling (e.g., '10GiB', '500MiB'). 0/empty = unlimited.
+      --limit-files int      Hard inode (file-count) ceiling. 0 = unlimited.
+      --scope string         Quota scope (user|group|default-user) (required)
+      --soft-bytes string    Soft byte threshold (e.g., '8GiB'). 0/empty = none.
+      --soft-files int       Soft inode threshold. 0 = none.
+```
+
+Global flags:
+
+```
+      --no-color        Disable colored output
+  -o, --output string   Output format (table|json|yaml) (default "table")
+      --server string   Server URL (overrides stored credential)
+      --token string    Bearer token (overrides stored credential)
+  -v, --verbose         Enable verbose output
+```
+
 ### `dfsctl settings`
 
 Server settings management
@@ -3161,7 +3317,7 @@ Flags:
       --allow-auth-sys string     Allow AUTH_SYS flavor (true|false)
       --netgroup string           Netgroup name to associate (empty string clears the association)
       --require-kerberos string   Require Kerberos auth (true|false)
-      --squash string             Squash mode (none|root|all)
+      --squash string             Squash mode (none|root_to_admin|root_to_guest|all_to_admin|all_to_guest)
 ```
 
 Global flags:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -593,6 +593,56 @@ Shares are managed at runtime via `dfsctl` and persisted in the control plane da
 - **Resource Efficiency**: Remote stores are shared (ref counted) when multiple shares reference the same config
 - **Flexible Topologies**: Mix local-only and remote-backed storage per-share
 
+#### Per-share and per-identity quotas
+
+DittoFS supports two complementary quota layers, both enforced by NFS *and* SMB:
+
+1. **Per-share quota** (`dfsctl share create/edit --quota-bytes`) — a single byte
+   ceiling for the whole share. Exceeding it returns `NFS3ERR_NOSPC` /
+   `STATUS_DISK_FULL`.
+
+2. **Per-identity quotas** (`dfsctl quota …`) — per-**user** (uid) and per-**group**
+   (gid) limits, plus an optional **default-user** fallback applied to any user
+   without an explicit quota. Each quota bounds both **bytes** and **inodes**
+   (file count) and supports a **soft** threshold with a **grace period** before
+   the soft threshold is enforced as a hard limit. Usage is charged to the file
+   *owner* (standard quota semantics). Exceeding a hard limit (or an expired
+   soft+grace) returns `NFS3ERR_DQUOT` / `NFS4ERR_DQUOT` /
+   `STATUS_QUOTA_EXCEEDED`. `df` / FSSTAT and SMB `FS_FULL_SIZE_INFORMATION`
+   report the smallest applicable quota for the calling identity.
+
+```bash
+# Per-user quota: uid 1000 limited to 10 GiB / 100k files, soft at 8 GiB,
+# 7-day grace (604800s) before the soft byte threshold becomes hard.
+./dfsctl quota set /cloud --scope user --id 1000 \
+    --limit-bytes 10GiB --soft-bytes 8GiB \
+    --limit-files 100000 --soft-files 90000 --grace-seconds 604800
+
+# Per-group quota: gid 2000 limited to 50 GiB.
+./dfsctl quota set /cloud --scope group --id 2000 --limit-bytes 50GiB
+
+# Default-user fallback (applies to any user without an explicit quota).
+./dfsctl quota set /cloud --scope default-user --limit-bytes 5GiB
+
+# Inspect and remove.
+./dfsctl quota list /cloud
+./dfsctl quota rm /cloud --scope user --id 1000
+```
+
+Per-identity quota usage is tracked incrementally by every metadata backend
+(memory / badger / postgres), keyed by owner uid and gid, and is reconstructed
+from the file rows on startup. A `chown` that changes a file's owner moves its
+bytes and inode count between identities. Limits live in the control-plane DB
+and are also manageable via the REST API
+(`/api/v1/shares/{name}/quotas[/{scope}/{id}]`).
+
+> **Note**: enforcement is best-effort (matching the per-share soft quota):
+> under high write concurrency a few operations may briefly exceed a limit until
+> usage catches up. This is standard for userspace NFS/SMB servers.
+>
+> **Kubernetes operator**: the operator manages infrastructure only — there is
+> no Share/Quota CRD. Quotas are managed via the REST API / `dfsctl` as above.
+
 ### 9. User Management
 
 DittoFS supports a unified user management system for both NFS and SMB protocols. Users, groups, and their permissions are stored in the control plane database (see [Database Configuration](#4-database-control-plane)) and can be managed via:

--- a/internal/adapter/common/errmap.go
+++ b/internal/adapter/common/errmap.go
@@ -132,14 +132,13 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 		SMB:  smbtypes.StatusDiskFull,
 	},
 	merrs.ErrQuotaExceeded: {
-		// NFSv3: create.go:604-605 has NFS3ErrDquot; xdr/errors.go omits —
-		// use create.go value.
-		// SMB: converters.go omits; fallback StatusDiskFull (closest SMB
-		// signal — SMB does not distinguish quota from free-space exhaustion
-		// at this layer).
+		// Disk-quota exhaustion (per-user/per-group quota full), distinct from
+		// genuine ENOSPC (ErrNoSpace). NFS maps to DQUOT; SMB maps to
+		// STATUS_QUOTA_EXCEEDED so Windows clients distinguish quota from a full
+		// volume.
 		NFS3: nfs3types.NFS3ErrDquot,
 		NFS4: nfs4types.NFS4ERR_DQUOT,
-		SMB:  smbtypes.StatusDiskFull,
+		SMB:  smbtypes.StatusQuotaExceeded,
 	},
 	merrs.ErrReadOnly: {
 		// SMB: converters.go omits; fallback StatusAccessDenied (SMB has no

--- a/internal/adapter/common/errmap_test.go
+++ b/internal/adapter/common/errmap_test.go
@@ -157,6 +157,28 @@ func TestHandleErrorFactoriesMapToHandleStatuses(t *testing.T) {
 	}
 }
 
+// TestQuotaExceededMapsToDquot locks the #1151 contract: a per-identity quota
+// breach (ErrQuotaExceeded) maps to DQUOT on NFS and STATUS_QUOTA_EXCEEDED on
+// SMB — distinct from a genuine full volume (ErrNoSpace -> NOSPC / DISK_FULL).
+func TestQuotaExceededMapsToDquot(t *testing.T) {
+	quota := &merrs.StoreError{Code: merrs.ErrQuotaExceeded, Message: "quota exceeded"}
+	if got := MapToNFS3(quota); got != nfs3types.NFS3ErrDquot {
+		t.Errorf("MapToNFS3(ErrQuotaExceeded) = %d, want NFS3ErrDquot", got)
+	}
+	if got := MapToNFS4(quota); got != nfs4types.NFS4ERR_DQUOT {
+		t.Errorf("MapToNFS4(ErrQuotaExceeded) = %d, want NFS4ERR_DQUOT", got)
+	}
+	if got := MapToSMB(quota); got != smbtypes.StatusQuotaExceeded {
+		t.Errorf("MapToSMB(ErrQuotaExceeded) = %v, want StatusQuotaExceeded", got)
+	}
+
+	// ErrNoSpace stays NOSPC / DISK_FULL — quota must NOT collapse into it.
+	nospace := &merrs.StoreError{Code: merrs.ErrNoSpace, Message: "no space"}
+	if got := MapToSMB(nospace); got != smbtypes.StatusDiskFull {
+		t.Errorf("MapToSMB(ErrNoSpace) = %v, want StatusDiskFull", got)
+	}
+}
+
 // TestMapContentToNFS3 exercises nil + ErrRemoteUnavailable + unknown.
 func TestMapContentToNFS3(t *testing.T) {
 	if got := MapContentToNFS3(nil); got != nfs3types.NFS3OK {

--- a/internal/adapter/nfs/v3/handlers/fsstat.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat.go
@@ -138,7 +138,15 @@ func (h *Handler) FsStat(
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	stats, err := metaSvc.GetFilesystemStatistics(ctx.Context, metadata.FileHandle(req.Handle))
+	// Resolve the caller's identity so per-user/per-group quotas are reflected
+	// in the reported space (best-effort: fall back to nil identity on error,
+	// which yields the share-level overlay only).
+	var statIdentity *metadata.Identity
+	if authCtx, authErr := h.GetCachedAuthContext(ctx); authErr == nil && authCtx != nil {
+		statIdentity = authCtx.Identity
+	}
+
+	stats, err := metaSvc.GetFilesystemStatisticsForIdentity(ctx.Context, metadata.FileHandle(req.Handle), statIdentity)
 	if err != nil {
 		logError(ctx.Context, err, "FSSTAT failed: error retrieving statistics", "client", ctx.ClientAddr)
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil

--- a/internal/adapter/nfs/v4/handlers/getattr.go
+++ b/internal/adapter/nfs/v4/handlers/getattr.go
@@ -112,10 +112,11 @@ func (h *Handler) getAttrRealFS(ctx *types.CompoundContext, requested []uint32) 
 			"client", ctx.ClientAddr)
 	}
 
-	// Fetch filesystem statistics if any space attributes are requested (bits 59-61)
+	// Fetch filesystem statistics if any space attributes are requested (bits 59-61).
+	// Pass the caller's identity so per-user/per-group quotas are reflected.
 	var fsStats *metadata.FilesystemStatistics
 	if attrs.NeedsFilesystemStats(requested) {
-		if stats, statsErr := metaSvc.GetFilesystemStatistics(authCtx.Context, metadata.FileHandle(ctx.CurrentFH)); statsErr == nil {
+		if stats, statsErr := metaSvc.GetFilesystemStatisticsForIdentity(authCtx.Context, metadata.FileHandle(ctx.CurrentFH), authCtx.Identity); statsErr == nil {
 			fsStats = stats
 		}
 	}

--- a/internal/adapter/smb/handlers/create_streams_disabled_test.go
+++ b/internal/adapter/smb/handlers/create_streams_disabled_test.go
@@ -198,7 +198,7 @@ func TestQueryInfo_FsAttrs_NamedStreamsBit(t *testing.T) {
 			// buildFilesystemInfo needs an OpenFile to source the handle.
 			// The streams-disabled gate is applied based on tree state,
 			// which is what the call site (handler) reads — mirror that.
-			info, err := h.buildFilesystemInfo(smbCtx.Context, 5, metaSvc, rootHandle, tc.streamsDisabled)
+			info, err := h.buildFilesystemInfo(smbCtx.Context, 5, metaSvc, rootHandle, tc.streamsDisabled, nil)
 			if err != nil {
 				t.Fatalf("buildFilesystemInfo: %v", err)
 			}

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -363,7 +363,11 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 		if tree, ok := h.GetTree(ctx.TreeID); ok {
 			streamsDisabled = tree.StreamsDisabled
 		}
-		info, err = h.buildFilesystemInfo(ctx.Context, types.FileInfoClass(req.FileInfoClass), metaSvc, openFile.MetadataHandle, streamsDisabled)
+		var fsIdentity *metadata.Identity
+		if authCtx != nil {
+			fsIdentity = authCtx.Identity
+		}
+		info, err = h.buildFilesystemInfo(ctx.Context, types.FileInfoClass(req.FileInfoClass), metaSvc, openFile.MetadataHandle, streamsDisabled, fsIdentity)
 	case types.SMB2InfoTypeSecurity:
 		// Per MS-SMB2 §3.3.5.20.3: querying OWNER, GROUP, or DACL requires
 		// READ_CONTROL on the open handle. SACL requires ACCESS_SYSTEM_SECURITY.
@@ -1067,7 +1071,7 @@ func shareNameForOpenFile(openFile *OpenFile) string {
 // FileFsAttributeInformation FileSystemAttributes mask so that clients on a
 // streams-disabled share see the FS advertise no ADS support, matching the
 // CREATE-time rejection in create.go.
-func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoClass, metaSvc *metadata.Service, handle metadata.FileHandle, streamsDisabled bool) ([]byte, error) {
+func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoClass, metaSvc *metadata.Service, handle metadata.FileHandle, streamsDisabled bool, identity *metadata.Identity) ([]byte, error) {
 	switch class {
 	case 1: // FileFsVolumeInformation [MS-FSCC] 2.5.9
 		label := encodeUTF16LE("DittoFS")
@@ -1088,7 +1092,7 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 		return w.Bytes(), nil
 
 	case 3: // FileFsSizeInformation [MS-FSCC] 2.5.8
-		stats, err := metaSvc.GetFilesystemStatistics(ctx, handle)
+		stats, err := metaSvc.GetFilesystemStatisticsForIdentity(ctx, handle, identity)
 		if err != nil {
 			logger.WarnCtx(ctx, "FileFsSizeInformation: failed to get stats", "error", err)
 			return nil, err
@@ -1129,7 +1133,7 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 		return w.Bytes(), nil
 
 	case 7: // FileFsFullSizeInformation [MS-FSCC] 2.5.4
-		stats, err := metaSvc.GetFilesystemStatistics(ctx, handle)
+		stats, err := metaSvc.GetFilesystemStatisticsForIdentity(ctx, handle, identity)
 		if err != nil {
 			logger.WarnCtx(ctx, "FileFsFullSizeInformation: failed to get stats", "error", err)
 			return nil, err

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -190,6 +190,11 @@ const (
 	// StatusDiskFull indicates the disk is full.
 	StatusDiskFull Status = 0xC000007F
 
+	// StatusQuotaExceeded indicates a disk quota was exceeded (NT
+	// STATUS_QUOTA_EXCEEDED). Distinct from StatusDiskFull: the volume has space
+	// but the caller's per-user/per-group quota is full.
+	StatusQuotaExceeded Status = 0xC0000044
+
 	// StatusUnexpectedIOError indicates an unexpected I/O error occurred.
 	StatusUnexpectedIOError Status = 0xC00000E9
 
@@ -345,6 +350,8 @@ func (s Status) String() string {
 		return "STATUS_NOTIFY_ENUM_DIR"
 	case StatusDiskFull:
 		return "STATUS_DISK_FULL"
+	case StatusQuotaExceeded:
+		return "STATUS_QUOTA_EXCEEDED"
 	case StatusUnexpectedIOError:
 		return "STATUS_UNEXPECTED_IO_ERROR"
 	case StatusNotAReparsePoint:

--- a/internal/controlplane/api/handlers/quotas.go
+++ b/internal/controlplane/api/handlers/quotas.go
@@ -1,0 +1,289 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/internal/bytesize"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// QuotaHandlerStore is the minimal interface required by QuotaHandler: just the
+// per-identity quota CRUD methods. Mirrors how ShareHandlerStore composes only
+// the sub-interfaces it needs.
+type QuotaHandlerStore interface {
+	store.QuotaStore
+}
+
+// QuotaHandler handles per-identity (user/group/default-user) quota API
+// endpoints. It needs the runtime to push hot-updates into the live metadata
+// service after a DB write/delete and to read live usage for responses.
+type QuotaHandler struct {
+	store   QuotaHandlerStore
+	runtime *runtime.Runtime
+}
+
+// NewQuotaHandler creates a new QuotaHandler.
+func NewQuotaHandler(s QuotaHandlerStore, rt *runtime.Runtime) *QuotaHandler {
+	return &QuotaHandler{store: s, runtime: rt}
+}
+
+// UpsertQuotaRequest is the request body for PUT
+// /api/v1/shares/{name}/quotas/{scope}[/{id}]. Byte ceilings are
+// human-readable (e.g. "10GiB"); file/grace fields are plain integers. A full
+// replace is performed: omitted byte fields parse to 0 ("no limit").
+type UpsertQuotaRequest struct {
+	LimitBytes   string `json:"limit_bytes,omitempty"`
+	SoftBytes    string `json:"soft_bytes,omitempty"`
+	LimitFiles   int64  `json:"limit_files,omitempty"`
+	SoftFiles    int64  `json:"soft_files,omitempty"`
+	GraceSeconds int64  `json:"grace_seconds,omitempty"`
+}
+
+// QuotaResponse is the response body for quota endpoints. Byte ceilings are
+// rendered human-readable; live usage (used_bytes / used_files) is read from the
+// metadata store backing the share.
+type QuotaResponse struct {
+	ShareName  string  `json:"share_name"`
+	Scope      string  `json:"scope"`
+	IdentityID *uint32 `json:"identity_id,omitempty"`
+	// LimitBytes / SoftBytes are human-readable, omitempty when unlimited/none.
+	LimitBytes     string     `json:"limit_bytes,omitempty"`
+	SoftBytes      string     `json:"soft_bytes,omitempty"`
+	LimitFiles     int64      `json:"limit_files"`
+	SoftFiles      int64      `json:"soft_files"`
+	GraceSeconds   int64      `json:"grace_seconds"`
+	GraceStartedAt *time.Time `json:"grace_started_at,omitempty"`
+	// UsedBytes / UsedFiles are the live per-identity usage. No omitempty: 0 is
+	// meaningful (no usage yet) and consumers render it explicitly.
+	UsedBytes int64 `json:"used_bytes"`
+	UsedFiles int64 `json:"used_files"`
+}
+
+// isValidQuotaScope reports whether scope is one of the supported quota scopes.
+func isValidQuotaScope(scope string) bool {
+	switch scope {
+	case models.QuotaScopeUser, models.QuotaScopeGroup, models.QuotaScopeDefaultUser:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseIdentityID resolves the {id} route param into the *uint32 identity used
+// by the store. For the default-user scope identityID is always nil (and any id
+// segment is ignored). For user/group scopes an id is required and must parse as
+// a uint32. Returns ok=false (after writing a problem response) on invalid
+// input.
+func parseIdentityID(w http.ResponseWriter, scope, idParam string) (identityID *uint32, ok bool) {
+	if scope == models.QuotaScopeDefaultUser {
+		return nil, true
+	}
+	if idParam == "" {
+		BadRequest(w, "identity id is required for scope "+scope)
+		return nil, false
+	}
+	parsed, err := strconv.ParseUint(idParam, 10, 32)
+	if err != nil {
+		BadRequest(w, "Invalid identity id: "+idParam)
+		return nil, false
+	}
+	v := uint32(parsed)
+	return &v, true
+}
+
+// parseQuotaTarget resolves the {name}, {scope} and {id} route params shared by
+// the Get/Set/Delete handlers, validating each in turn. It writes a problem
+// response and returns ok=false on any invalid input, following the same
+// convention as parseIdentityID.
+func parseQuotaTarget(w http.ResponseWriter, r *http.Request) (shareName, scope string, identityID *uint32, ok bool) {
+	shareName = normalizeShareName(chi.URLParam(r, "name"))
+	if shareName == "/" {
+		BadRequest(w, "Share name is required")
+		return "", "", nil, false
+	}
+	scope = chi.URLParam(r, "scope")
+	if !isValidQuotaScope(scope) {
+		BadRequest(w, "Invalid scope: "+scope+" (want user|group|default-user)")
+		return "", "", nil, false
+	}
+	identityID, ok = parseIdentityID(w, scope, chi.URLParam(r, "id"))
+	if !ok {
+		return "", "", nil, false
+	}
+	return shareName, scope, identityID, true
+}
+
+// List handles GET /api/v1/shares/{name}/quotas.
+func (h *QuotaHandler) List(w http.ResponseWriter, r *http.Request) {
+	shareName := normalizeShareName(chi.URLParam(r, "name"))
+	if shareName == "/" {
+		BadRequest(w, "Share name is required")
+		return
+	}
+
+	quotas, err := h.store.ListQuotas(r.Context(), shareName)
+	if err != nil {
+		InternalServerError(w, "Failed to list quotas")
+		return
+	}
+
+	response := make([]QuotaResponse, len(quotas))
+	for i, q := range quotas {
+		response[i] = h.quotaToResponse(q)
+	}
+	WriteJSONOK(w, response)
+}
+
+// Get handles GET /api/v1/shares/{name}/quotas/{scope}[/{id}].
+func (h *QuotaHandler) Get(w http.ResponseWriter, r *http.Request) {
+	shareName, scope, identityID, ok := parseQuotaTarget(w, r)
+	if !ok {
+		return
+	}
+
+	quota, err := h.store.GetQuota(r.Context(), shareName, scope, identityID)
+	if err != nil {
+		if errors.Is(err, models.ErrQuotaNotFound) {
+			NotFound(w, "Quota not found")
+			return
+		}
+		InternalServerError(w, "Failed to get quota")
+		return
+	}
+	WriteJSONOK(w, h.quotaToResponse(quota))
+}
+
+// Set handles PUT /api/v1/shares/{name}/quotas/{scope}[/{id}] (create/update).
+func (h *QuotaHandler) Set(w http.ResponseWriter, r *http.Request) {
+	shareName, scope, identityID, ok := parseQuotaTarget(w, r)
+	if !ok {
+		return
+	}
+
+	var req UpsertQuotaRequest
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+
+	var limitBytes, softBytes int64
+	if req.LimitBytes != "" {
+		bs, err := bytesize.ParseByteSize(req.LimitBytes)
+		if err != nil {
+			BadRequest(w, "Invalid limit_bytes: "+err.Error())
+			return
+		}
+		limitBytes = bs.Int64()
+	}
+	if req.SoftBytes != "" {
+		bs, err := bytesize.ParseByteSize(req.SoftBytes)
+		if err != nil {
+			BadRequest(w, "Invalid soft_bytes: "+err.Error())
+			return
+		}
+		softBytes = bs.Int64()
+	}
+	if req.LimitFiles < 0 || req.SoftFiles < 0 || req.GraceSeconds < 0 {
+		BadRequest(w, "limit_files, soft_files and grace_seconds must be >= 0")
+		return
+	}
+
+	// Preserve an existing grace timer across an update so a soft-threshold
+	// timer already running is not reset by a limit edit.
+	var graceStartedAt *time.Time
+	if existing, err := h.store.GetQuota(r.Context(), shareName, scope, identityID); err == nil {
+		graceStartedAt = existing.GraceStartedAt
+	}
+
+	now := time.Now()
+	quota := &models.Quota{
+		ID:             uuid.New().String(),
+		ShareName:      shareName,
+		Scope:          scope,
+		IdentityID:     identityID,
+		LimitBytes:     limitBytes,
+		SoftBytes:      softBytes,
+		LimitFiles:     req.LimitFiles,
+		SoftFiles:      req.SoftFiles,
+		GraceSeconds:   req.GraceSeconds,
+		GraceStartedAt: graceStartedAt,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := h.store.UpsertQuota(r.Context(), quota); err != nil {
+		if errors.Is(err, models.ErrDuplicateQuota) {
+			Conflict(w, "Quota already exists")
+			return
+		}
+		InternalServerError(w, "Failed to set quota")
+		return
+	}
+
+	// Hot-update the live metadata service so enforcement takes effect
+	// immediately, mirroring how shares.go calls UpdateShareQuota.
+	if h.runtime != nil {
+		h.runtime.UpdateIdentityQuota(quota)
+	}
+
+	WriteJSONOK(w, h.quotaToResponse(quota))
+}
+
+// Delete handles DELETE /api/v1/shares/{name}/quotas/{scope}[/{id}].
+func (h *QuotaHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	shareName, scope, identityID, ok := parseQuotaTarget(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.store.DeleteQuota(r.Context(), shareName, scope, identityID); err != nil {
+		if errors.Is(err, models.ErrQuotaNotFound) {
+			NotFound(w, "Quota not found")
+			return
+		}
+		InternalServerError(w, "Failed to delete quota")
+		return
+	}
+
+	// Remove from the live metadata service so enforcement stops immediately.
+	if h.runtime != nil {
+		h.runtime.RemoveIdentityQuota(shareName, scope, identityID)
+	}
+
+	WriteNoContent(w)
+}
+
+// quotaToResponse converts a models.Quota into a QuotaResponse, formatting byte
+// ceilings human-readable and populating live per-identity usage from the
+// runtime (degrading to 0/0 when no runtime is wired or the share is not
+// loaded).
+func (h *QuotaHandler) quotaToResponse(q *models.Quota) QuotaResponse {
+	var limitBytesStr, softBytesStr string
+	if q.LimitBytes > 0 {
+		limitBytesStr = bytesize.ByteSize(q.LimitBytes).String()
+	}
+	if q.SoftBytes > 0 {
+		softBytesStr = bytesize.ByteSize(q.SoftBytes).String()
+	}
+	resp := QuotaResponse{
+		ShareName:      q.ShareName,
+		Scope:          q.Scope,
+		IdentityID:     q.IdentityID,
+		LimitBytes:     limitBytesStr,
+		SoftBytes:      softBytesStr,
+		LimitFiles:     q.LimitFiles,
+		SoftFiles:      q.SoftFiles,
+		GraceSeconds:   q.GraceSeconds,
+		GraceStartedAt: q.GraceStartedAt,
+	}
+	if h.runtime != nil {
+		resp.UsedBytes, resp.UsedFiles = h.runtime.GetIdentityQuotaUsage(q.ShareName, q.Scope, q.IdentityID)
+	}
+	return resp
+}

--- a/internal/controlplane/api/handlers/quotas.go
+++ b/internal/controlplane/api/handlers/quotas.go
@@ -179,6 +179,12 @@ func (h *QuotaHandler) Set(w http.ResponseWriter, r *http.Request) {
 			BadRequest(w, "Invalid limit_bytes: "+err.Error())
 			return
 		}
+		// ParseByteSize returns a uint64-backed value; reject sizes that would
+		// overflow the int64 limit column (and be treated as "no limit").
+		if bs.Int64() < 0 {
+			BadRequest(w, "limit_bytes too large")
+			return
+		}
 		limitBytes = bs.Int64()
 	}
 	if req.SoftBytes != "" {
@@ -187,10 +193,23 @@ func (h *QuotaHandler) Set(w http.ResponseWriter, r *http.Request) {
 			BadRequest(w, "Invalid soft_bytes: "+err.Error())
 			return
 		}
+		if bs.Int64() < 0 {
+			BadRequest(w, "soft_bytes too large")
+			return
+		}
 		softBytes = bs.Int64()
 	}
 	if req.LimitFiles < 0 || req.SoftFiles < 0 || req.GraceSeconds < 0 {
 		BadRequest(w, "limit_files, soft_files and grace_seconds must be >= 0")
+		return
+	}
+	// Enforce the soft <= hard invariant when both dimensions are set.
+	if limitBytes > 0 && softBytes > 0 && softBytes > limitBytes {
+		BadRequest(w, "soft_bytes must not exceed limit_bytes")
+		return
+	}
+	if req.LimitFiles > 0 && req.SoftFiles > 0 && req.SoftFiles > req.LimitFiles {
+		BadRequest(w, "soft_files must not exceed limit_files")
 		return
 	}
 

--- a/pkg/apiclient/quotas.go
+++ b/pkg/apiclient/quotas.go
@@ -1,0 +1,80 @@
+package apiclient
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Quota represents a per-identity (user/group/default-user) storage quota on a
+// share, mirroring the server QuotaResponse.
+type Quota struct {
+	ShareName  string  `json:"share_name"`
+	Scope      string  `json:"scope"`
+	IdentityID *uint32 `json:"identity_id,omitempty"`
+	// LimitBytes / SoftBytes are human-readable (e.g. "10 GiB"), empty when
+	// unlimited / no soft threshold.
+	LimitBytes     string     `json:"limit_bytes,omitempty"`
+	SoftBytes      string     `json:"soft_bytes,omitempty"`
+	LimitFiles     int64      `json:"limit_files"`
+	SoftFiles      int64      `json:"soft_files"`
+	GraceSeconds   int64      `json:"grace_seconds"`
+	GraceStartedAt *time.Time `json:"grace_started_at,omitempty"`
+	UsedBytes      int64      `json:"used_bytes"`
+	UsedFiles      int64      `json:"used_files"`
+}
+
+// UpsertQuotaRequest is the request body to create or update a quota. Byte
+// ceilings are human-readable (e.g. "10GiB"); file/grace fields are integers.
+type UpsertQuotaRequest struct {
+	LimitBytes   string `json:"limit_bytes,omitempty"`
+	SoftBytes    string `json:"soft_bytes,omitempty"`
+	LimitFiles   int64  `json:"limit_files,omitempty"`
+	SoftFiles    int64  `json:"soft_files,omitempty"`
+	GraceSeconds int64  `json:"grace_seconds,omitempty"`
+}
+
+// quotaPath builds the REST path for a quota. The default-user scope has no id
+// segment; user/group encode the uid/gid in the path.
+func quotaPath(share, scope string, id *uint32) string {
+	base := fmt.Sprintf("/api/v1/shares/%s/quotas", url.PathEscape(normalizeShareNameForAPI(share)))
+	if scope == "default-user" {
+		return base + "/default-user"
+	}
+	idSeg := ""
+	if id != nil {
+		idSeg = fmt.Sprintf("%d", *id)
+	}
+	return fmt.Sprintf("%s/%s/%s", base, url.PathEscape(scope), idSeg)
+}
+
+// ListQuotas returns all quotas for a share.
+func (c *Client) ListQuotas(share string) ([]Quota, error) {
+	return listResources[Quota](c, fmt.Sprintf("/api/v1/shares/%s/quotas", url.PathEscape(normalizeShareNameForAPI(share))))
+}
+
+// GetQuota returns a single quota by (share, scope, identity). id is nil for the
+// default-user scope.
+func (c *Client) GetQuota(share, scope string, id *uint32) (*Quota, error) {
+	var q Quota
+	if err := c.get(quotaPath(share, scope, id), &q); err != nil {
+		return nil, err
+	}
+	return &q, nil
+}
+
+// SetQuota creates or updates a quota (PUT). id is nil for the default-user
+// scope.
+func (c *Client) SetQuota(share, scope string, id *uint32, req *UpsertQuotaRequest) (*Quota, error) {
+	var q Quota
+	if err := c.put(quotaPath(share, scope, id), req, &q); err != nil {
+		return nil, err
+	}
+	return &q, nil
+}
+
+// DeleteQuota removes a quota by (share, scope, identity). id is nil for the
+// default-user scope.
+func (c *Client) DeleteQuota(share, scope string, id *uint32) error {
+	return c.delete(quotaPath(share, scope, id), nil)
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -254,6 +254,19 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 					})
 				}
 
+				// Per-identity (user/group/default-user) quota CRUD.
+				// RequireAdmin is inherited from the parent /shares group.
+				// default-user has no {id} segment (its identity is implicit);
+				// user/group carry the uid/gid in {id}.
+				quotaHandler := handlers.NewQuotaHandler(cpStore, rt)
+				r.Get("/{name}/quotas", quotaHandler.List)
+				r.Get("/{name}/quotas/default-user", quotaHandler.Get)
+				r.Put("/{name}/quotas/default-user", quotaHandler.Set)
+				r.Delete("/{name}/quotas/default-user", quotaHandler.Delete)
+				r.Get("/{name}/quotas/{scope}/{id}", quotaHandler.Get)
+				r.Put("/{name}/quotas/{scope}/{id}", quotaHandler.Set)
+				r.Delete("/{name}/quotas/{scope}/{id}", quotaHandler.Delete)
+
 				// Share permissions
 				r.Get("/{name}/permissions", shareHandler.ListPermissions)
 				r.Put("/{name}/permissions/users/{username}", shareHandler.SetUserPermission)

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -17,6 +17,10 @@ var (
 	ErrShareNotFound  = errors.New("share not found")
 	ErrDuplicateShare = errors.New("share already exists")
 
+	// Quota errors
+	ErrQuotaNotFound  = errors.New("quota not found")
+	ErrDuplicateQuota = errors.New("quota already exists for this identity")
+
 	// Store errors
 	ErrStoreNotFound  = errors.New("store not found")
 	ErrDuplicateStore = errors.New("store already exists")

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -8,6 +8,7 @@ func AllModels() []any {
 		&MetadataStoreConfig{},
 		&BlockStoreConfig{},
 		&Share{},
+		&Quota{},
 		&Snapshot{},
 		&RestoreMarker{},
 		&ShareAccessRule{},

--- a/pkg/controlplane/models/quota.go
+++ b/pkg/controlplane/models/quota.go
@@ -1,0 +1,63 @@
+package models
+
+import "time"
+
+// Quota scope constants. Stored as a lowercase string in the scope column so
+// they are stable and human-readable in the DB / REST / CLI.
+const (
+	// QuotaScopeUser keys a quota by a specific user (uid).
+	QuotaScopeUser = "user"
+	// QuotaScopeGroup keys a quota by a specific group (gid).
+	QuotaScopeGroup = "group"
+	// QuotaScopeDefaultUser is a fallback quota applied to any user without an
+	// explicit user quota. IdentityID is unused (NULL) for this scope.
+	QuotaScopeDefaultUser = "default-user"
+)
+
+// Quota is a per-identity (user/group/default-user) storage quota on a share.
+// It bounds both bytes and inode (file) count, with optional soft thresholds and
+// a grace period before a soft threshold is enforced as hard.
+//
+// Limits are stored in the control-plane DB and loaded into the metadata service
+// as a hot-updatable map; both NFS and SMB honor them. A limit of 0 on any
+// dimension means "no limit on that dimension".
+type Quota struct {
+	ID string `gorm:"primaryKey;size:36" json:"id"`
+
+	// ShareName is the share this quota applies to.
+	ShareName string `gorm:"not null;size:255;uniqueIndex:idx_quota_identity" json:"share_name"`
+
+	// Scope is one of QuotaScopeUser / QuotaScopeGroup / QuotaScopeDefaultUser.
+	Scope string `gorm:"not null;size:16;uniqueIndex:idx_quota_identity" json:"scope"`
+
+	// IdentityID is the uid (user) or gid (group) the quota applies to. NULL for
+	// the default-user scope. The unique index (share_name, scope, identity_id)
+	// permits at most one quota per identity per share, and a single NULL-keyed
+	// default-user row per share.
+	IdentityID *uint32 `gorm:"uniqueIndex:idx_quota_identity" json:"identity_id,omitempty"`
+
+	// LimitBytes is the hard byte ceiling (0 = unlimited).
+	LimitBytes int64 `gorm:"default:0" json:"limit_bytes"`
+	// SoftBytes is the soft byte threshold (0 = none).
+	SoftBytes int64 `gorm:"default:0" json:"soft_bytes"`
+	// LimitFiles is the hard inode (file-count) ceiling (0 = unlimited).
+	LimitFiles int64 `gorm:"default:0" json:"limit_files"`
+	// SoftFiles is the soft inode threshold (0 = none).
+	SoftFiles int64 `gorm:"default:0" json:"soft_files"`
+
+	// GraceSeconds is how long usage may exceed a soft threshold before it is
+	// enforced as hard. 0 disables grace (soft is advisory only).
+	GraceSeconds int64 `gorm:"default:0" json:"grace_seconds"`
+
+	// GraceStartedAt records when usage first crossed a soft threshold. NULL
+	// means no grace timer is running. Persisted so the timer survives restart.
+	GraceStartedAt *time.Time `json:"grace_started_at,omitempty"`
+
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+// TableName returns the table name for Quota.
+func (Quota) TableName() string {
+	return "quotas"
+}

--- a/pkg/controlplane/runtime/quota.go
+++ b/pkg/controlplane/runtime/quota.go
@@ -48,6 +48,10 @@ func modelQuotaToIdentityQuota(q *models.Quota) (metadata.IdentityQuota, bool) {
 // from the control-plane DB into the metadata service. Called during AddShare so
 // quotas are enforced immediately after a restart.
 func (r *Runtime) LoadIdentityQuotasForShare(ctx context.Context, shareName string) error {
+	// No control-plane store (test fixtures, embedded use): nothing to load.
+	if r.store == nil {
+		return nil
+	}
 	quotas, err := r.store.ListQuotas(ctx, shareName)
 	if err != nil {
 		return err

--- a/pkg/controlplane/runtime/quota.go
+++ b/pkg/controlplane/runtime/quota.go
@@ -1,0 +1,169 @@
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// modelQuotaToIdentityQuota converts a persisted control-plane Quota into the
+// metadata service's runtime IdentityQuota. Returns ok=false for an
+// unrecognized scope. The default-user scope is modeled as a QuotaScopeUser
+// entry keyed by metadata.DefaultUserID.
+func modelQuotaToIdentityQuota(q *models.Quota) (metadata.IdentityQuota, bool) {
+	iq := metadata.IdentityQuota{
+		LimitBytes:   q.LimitBytes,
+		SoftBytes:    q.SoftBytes,
+		LimitFiles:   q.LimitFiles,
+		SoftFiles:    q.SoftFiles,
+		GraceSeconds: q.GraceSeconds,
+	}
+	if q.GraceStartedAt != nil {
+		iq.GraceStartedAt = *q.GraceStartedAt
+	}
+	switch q.Scope {
+	case models.QuotaScopeUser:
+		iq.Scope = metadata.QuotaScopeUser
+		if q.IdentityID != nil {
+			iq.ID = *q.IdentityID
+		}
+	case models.QuotaScopeGroup:
+		iq.Scope = metadata.QuotaScopeGroup
+		if q.IdentityID != nil {
+			iq.ID = *q.IdentityID
+		}
+	case models.QuotaScopeDefaultUser:
+		iq.Scope = metadata.QuotaScopeUser
+		iq.ID = metadata.DefaultUserID
+	default:
+		return metadata.IdentityQuota{}, false
+	}
+	return iq, true
+}
+
+// LoadIdentityQuotasForShare loads all persisted per-identity quotas for a share
+// from the control-plane DB into the metadata service. Called during AddShare so
+// quotas are enforced immediately after a restart.
+func (r *Runtime) LoadIdentityQuotasForShare(ctx context.Context, shareName string) error {
+	quotas, err := r.store.ListQuotas(ctx, shareName)
+	if err != nil {
+		return err
+	}
+	iqs := make([]metadata.IdentityQuota, 0, len(quotas))
+	for _, q := range quotas {
+		if iq, ok := modelQuotaToIdentityQuota(q); ok {
+			iqs = append(iqs, iq)
+		} else {
+			logger.Warn("skipping quota with unknown scope", "share", shareName, "scope", q.Scope)
+		}
+	}
+	r.metadataService.ReplaceIdentityQuotas(shareName, iqs)
+	return nil
+}
+
+// UpdateIdentityQuota hot-updates a single per-identity quota in the metadata
+// service from a persisted model row. Mirrors UpdateShareQuota.
+func (r *Runtime) UpdateIdentityQuota(q *models.Quota) {
+	if iq, ok := modelQuotaToIdentityQuota(q); ok {
+		r.metadataService.SetIdentityQuota(q.ShareName, iq)
+	}
+}
+
+// RemoveIdentityQuota removes a single per-identity quota from the metadata
+// service. scope is a models scope string; identityID is nil for default-user.
+func (r *Runtime) RemoveIdentityQuota(shareName, scope string, identityID *uint32) {
+	mScope, id, ok := metadataScope(scope, identityID)
+	if !ok {
+		return
+	}
+	r.metadataService.RemoveIdentityQuota(shareName, mScope, id)
+}
+
+// GetIdentityQuotaUsage returns the live per-identity usage (bytes + file count)
+// for the given share / scope / identity, read from the metadata store backing
+// the share. scope is a models scope string; identityID is nil for default-user.
+// Usage for the default-user scope is not meaningful (it is a fallback limit, not
+// a real owner identity), so it always returns (0, 0). Any lookup failure (share
+// not loaded, unknown scope) degrades to (0, 0) so REST responses stay
+// well-formed. Mirrors GetShareUsage for the per-identity case.
+func (r *Runtime) GetIdentityQuotaUsage(shareName, scope string, identityID *uint32) (bytes, files int64) {
+	if scope == models.QuotaScopeDefaultUser {
+		return 0, 0
+	}
+	mScope, id, ok := metadataScope(scope, identityID)
+	if !ok {
+		return 0, 0
+	}
+	store, err := r.metadataService.GetStoreForShare(shareName)
+	if err != nil {
+		return 0, 0
+	}
+	usage, err := store.GetQuotaUsage(mScope, id)
+	if err != nil {
+		return 0, 0
+	}
+	return usage.Bytes, usage.Files
+}
+
+// metadataScope maps a models scope string + identityID to the metadata scope +
+// usage id used by the service map.
+func metadataScope(scope string, identityID *uint32) (metadata.QuotaScope, uint32, bool) {
+	switch scope {
+	case models.QuotaScopeUser:
+		if identityID == nil {
+			return 0, 0, false
+		}
+		return metadata.QuotaScopeUser, *identityID, true
+	case models.QuotaScopeGroup:
+		if identityID == nil {
+			return 0, 0, false
+		}
+		return metadata.QuotaScopeGroup, *identityID, true
+	case models.QuotaScopeDefaultUser:
+		return metadata.QuotaScopeUser, metadata.DefaultUserID, true
+	default:
+		return 0, 0, false
+	}
+}
+
+// quotaGracePersister persists grace-timer transitions from the metadata
+// enforcer back to the control-plane DB. Implements metadata.QuotaGracePersister.
+type quotaGracePersister struct {
+	rt *Runtime
+}
+
+// PersistQuotaGrace writes the new grace_started_at for a quota. A zero t clears
+// the timer. The default-user sentinel uid is translated back to the
+// default-user scope with a NULL identity. Best-effort: errors are logged, not
+// surfaced to the write path.
+func (p *quotaGracePersister) PersistQuotaGrace(shareName string, scope metadata.QuotaScope, id uint32, t time.Time) {
+	modelScope := models.QuotaScopeGroup
+	var identityID *uint32
+	if scope == metadata.QuotaScopeUser {
+		if id == metadata.DefaultUserID {
+			modelScope = models.QuotaScopeDefaultUser
+		} else {
+			modelScope = models.QuotaScopeUser
+			v := id
+			identityID = &v
+		}
+	} else {
+		v := id
+		identityID = &v
+	}
+
+	var tp *time.Time
+	if !t.IsZero() {
+		tp = &t
+	}
+	// Use a short bounded context: this runs off the write hot path.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.rt.store.SetQuotaGraceStartedAt(ctx, shareName, modelScope, identityID, tp); err != nil {
+		logger.Warn("failed to persist quota grace timer",
+			"share", shareName, "scope", modelScope, "error", err)
+	}
+}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -159,6 +159,12 @@ func New(s store.Store) *Runtime {
 	// take effect immediately.
 	rt.metadataService.SetTrashPolicy(&trashPolicy{sharesSvc: rt.sharesSvc})
 
+	// Persist quota grace-timer transitions back to the control-plane DB so the
+	// soft->grace->hard state survives restart. Only when a store is present.
+	if s != nil {
+		rt.metadataService.SetQuotaGracePersister(&quotaGracePersister{rt: rt})
+	}
+
 	rt.adaptersSvc = adapters.New(s, DefaultShutdownTimeout)
 	rt.adaptersSvc.SetRuntime(rt)
 
@@ -390,6 +396,12 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	// Always set explicitly to ensure consistency after restarts when a
 	// quota was removed (set to 0) via the API.
 	r.metadataService.SetQuotaForShare(config.Name, config.QuotaBytes)
+	// Load per-identity (user/group) quotas from the control-plane DB so they
+	// are enforced immediately after a restart. Best-effort: a load failure
+	// must not prevent the share from coming up.
+	if err := r.LoadIdentityQuotasForShare(ctx, config.Name); err != nil {
+		logger.Warn("failed to load identity quotas for share", "share", config.Name, "error", err)
+	}
 	return nil
 }
 

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -226,6 +226,30 @@ type ShareStore interface {
 	ListShareAdapterConfigs(ctx context.Context, shareID string) ([]models.ShareAdapterConfig, error)
 }
 
+// QuotaStore provides per-identity (user/group/default-user) quota CRUD for a
+// share. identityID is nil for the default-user scope.
+type QuotaStore interface {
+	// ListQuotas returns all quotas for a share.
+	ListQuotas(ctx context.Context, shareName string) ([]*models.Quota, error)
+
+	// ListAllQuotas returns every quota across all shares (startup seed).
+	ListAllQuotas(ctx context.Context) ([]*models.Quota, error)
+
+	// GetQuota returns a single quota by (share, scope, identity).
+	// Returns models.ErrQuotaNotFound when absent.
+	GetQuota(ctx context.Context, shareName, scope string, identityID *uint32) (*models.Quota, error)
+
+	// UpsertQuota creates or updates a quota for (share, scope, identity).
+	UpsertQuota(ctx context.Context, quota *models.Quota) error
+
+	// DeleteQuota removes a quota for (share, scope, identity).
+	// Returns models.ErrQuotaNotFound when absent.
+	DeleteQuota(ctx context.Context, shareName, scope string, identityID *uint32) error
+
+	// SetQuotaGraceStartedAt persists a grace-timer transition (nil clears it).
+	SetQuotaGraceStartedAt(ctx context.Context, shareName, scope string, identityID *uint32, t *time.Time) error
+}
+
 // PermissionStore provides user and group share permission operations.
 //
 // Permission resolution follows the order: user explicit > group permissions
@@ -654,6 +678,7 @@ type Store interface {
 	UserStore
 	GroupStore
 	ShareStore
+	QuotaStore
 	PermissionStore
 	MetadataStoreConfigStore
 	BlockStoreConfigStore

--- a/pkg/controlplane/store/quotas.go
+++ b/pkg/controlplane/store/quotas.go
@@ -73,7 +73,17 @@ func (s *GORMStore) UpsertQuota(ctx context.Context, quota *models.Quota) error 
 			}
 			quota.CreatedAt = now
 			quota.UpdatedAt = now
-			return tx.Create(quota).Error
+			if createErr := tx.Create(quota).Error; createErr != nil {
+				// A concurrent create for the same (share, scope, identity)
+				// races past the existence check and trips the unique index;
+				// surface it as the domain duplicate error so the handler
+				// returns 409, mirroring CreateShare.
+				if isUniqueConstraintError(createErr) {
+					return models.ErrDuplicateQuota
+				}
+				return createErr
+			}
+			return nil
 		default:
 			return err
 		}

--- a/pkg/controlplane/store/quotas.go
+++ b/pkg/controlplane/store/quotas.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// ListQuotas returns all quotas for a share.
+func (s *GORMStore) ListQuotas(ctx context.Context, shareName string) ([]*models.Quota, error) {
+	var quotas []*models.Quota
+	if err := s.db.WithContext(ctx).
+		Where("share_name = ?", shareName).
+		Find(&quotas).Error; err != nil {
+		return nil, err
+	}
+	return quotas, nil
+}
+
+// ListAllQuotas returns every quota across all shares (used to seed the runtime
+// at startup).
+func (s *GORMStore) ListAllQuotas(ctx context.Context) ([]*models.Quota, error) {
+	return listAll[models.Quota](s.db, ctx)
+}
+
+// GetQuota returns a single quota by (share, scope, identity). identityID is nil
+// for the default-user scope.
+func (s *GORMStore) GetQuota(ctx context.Context, shareName, scope string, identityID *uint32) (*models.Quota, error) {
+	q := s.db.WithContext(ctx).Where("share_name = ? AND scope = ?", shareName, scope)
+	if identityID == nil {
+		q = q.Where("identity_id IS NULL")
+	} else {
+		q = q.Where("identity_id = ?", *identityID)
+	}
+	var quota models.Quota
+	if err := q.First(&quota).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, models.ErrQuotaNotFound
+		}
+		return nil, err
+	}
+	return &quota, nil
+}
+
+// UpsertQuota creates or updates a quota for (share, scope, identity). The
+// returned quota carries the persisted ID. A zero-limit-on-every-dimension quota
+// is still stored (it may carry grace config); callers delete to remove.
+func (s *GORMStore) UpsertQuota(ctx context.Context, quota *models.Quota) error {
+	now := time.Now()
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		existing, err := s.getQuotaTx(ctx, tx, quota.ShareName, quota.Scope, quota.IdentityID)
+		switch {
+		case err == nil:
+			quota.ID = existing.ID
+			quota.CreatedAt = existing.CreatedAt
+			quota.UpdatedAt = now
+			// Preserve a running grace timer unless the caller set one.
+			if quota.GraceStartedAt == nil {
+				quota.GraceStartedAt = existing.GraceStartedAt
+			}
+			return tx.Model(&models.Quota{}).Where("id = ?", existing.ID).
+				Select("limit_bytes", "soft_bytes", "limit_files", "soft_files",
+					"grace_seconds", "grace_started_at", "updated_at").
+				Updates(quota).Error
+		case errors.Is(err, models.ErrQuotaNotFound):
+			if quota.ID == "" {
+				quota.ID = uuid.New().String()
+			}
+			quota.CreatedAt = now
+			quota.UpdatedAt = now
+			return tx.Create(quota).Error
+		default:
+			return err
+		}
+	})
+}
+
+// DeleteQuota removes a quota for (share, scope, identity).
+func (s *GORMStore) DeleteQuota(ctx context.Context, shareName, scope string, identityID *uint32) error {
+	q := s.db.WithContext(ctx).Where("share_name = ? AND scope = ?", shareName, scope)
+	if identityID == nil {
+		q = q.Where("identity_id IS NULL")
+	} else {
+		q = q.Where("identity_id = ?", *identityID)
+	}
+	res := q.Delete(&models.Quota{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return models.ErrQuotaNotFound
+	}
+	return nil
+}
+
+// SetQuotaGraceStartedAt persists the grace-timer transition for a quota. A nil
+// t clears the timer. Missing rows are ignored (best-effort persistence from the
+// enforcer hot path).
+func (s *GORMStore) SetQuotaGraceStartedAt(ctx context.Context, shareName, scope string, identityID *uint32, t *time.Time) error {
+	q := s.db.WithContext(ctx).Model(&models.Quota{}).
+		Where("share_name = ? AND scope = ?", shareName, scope)
+	if identityID == nil {
+		q = q.Where("identity_id IS NULL")
+	} else {
+		q = q.Where("identity_id = ?", *identityID)
+	}
+	return q.Update("grace_started_at", t).Error
+}
+
+func (s *GORMStore) getQuotaTx(ctx context.Context, tx *gorm.DB, shareName, scope string, identityID *uint32) (*models.Quota, error) {
+	q := tx.WithContext(ctx).Where("share_name = ? AND scope = ?", shareName, scope)
+	if identityID == nil {
+		q = q.Where("identity_id IS NULL")
+	} else {
+		q = q.Where("identity_id = ?", *identityID)
+	}
+	var quota models.Quota
+	if err := q.First(&quota).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, models.ErrQuotaNotFound
+		}
+		return nil, err
+	}
+	return &quota, nil
+}

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -314,6 +314,17 @@ func (s *Service) createEntry(
 	}
 	newFile.Nlink = GetInitialLinkCount(fileType)
 
+	// Per-identity inode (file-count) quota enforcement. Only regular files
+	// contribute to usage counters, so only their creation is gated here.
+	// Charged to the new file's owner (newAttr.UID/GID). Runs before the
+	// transaction so a rejected create never touches the store. Returns
+	// ErrQuotaExceeded (-> DQUOT / STATUS_QUOTA_EXCEEDED).
+	if fileType == FileTypeRegular {
+		if err := s.checkIdentityQuotas(parent.ShareName, store, newAttr.UID, newAttr.GID, int64(newAttr.Size), 1); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Inherit ACL from parent if parent has one. CREATOR_OWNER / CREATOR_GROUP
 	// placeholders are substituted with the requester's frozen identity per
 	// MS-DTYP §2.5.3.4. For anonymous creates (no UID/GID on the identity)

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -142,6 +142,17 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 		}
 	}
 
+	// Per-identity (user/group) byte quota enforcement. Charged to the file
+	// OWNER (standard quota semantics), not the writer. A growth-only check:
+	// shrink/truncate is always allowed. Returns ErrQuotaExceeded (-> DQUOT /
+	// STATUS_QUOTA_EXCEEDED), distinct from the ErrNoSpace share check above.
+	if newSize > file.Size {
+		byteDelta := int64(newSize - file.Size)
+		if err := s.checkIdentityQuotas(shareName, store, file.UID, file.GID, byteDelta, 0); err != nil {
+			return nil, err
+		}
+	}
+
 	// Check write permission. Always route through checkWritePermission so that
 	// DOS READONLY (mode bit 0x100000) is enforced for owners. calculatePermissions
 	// already handles owner vs non-owner mode-bit evaluation correctly (owner gets

--- a/pkg/metadata/quota_enforce.go
+++ b/pkg/metadata/quota_enforce.go
@@ -75,9 +75,16 @@ func (s *Service) enforceOne(shareName string, store Store, scope QuotaScope, us
 		}
 	}
 
+	// A default-user fallback (the resolved quota is keyed by the DefaultUserID
+	// sentinel) must track grace PER REAL USER, not on the shared sentinel row —
+	// otherwise one user's soft breach would start/expire grace for everyone.
+	// Such grace is ephemeral (in-memory, keyed by the real usageID). Explicit
+	// user/group quotas use the persisted per-row grace.
+	isDefaultUserFallback := scope == QuotaScopeUser && iq.ID == DefaultUserID
+
 	if !overSoft {
 		// Under all soft thresholds: clear any running grace timer.
-		s.clearGrace(shareName, iq.Scope, iq.ID, &iq)
+		s.clearGrace(shareName, scope, usageID, isDefaultUserFallback, iq.ID)
 		return nil
 	}
 
@@ -88,17 +95,10 @@ func (s *Service) enforceOne(shareName string, store Store, scope QuotaScope, us
 	}
 
 	now := time.Now()
-	// Re-read the grace timer under lock: a concurrent clearGrace (because this
-	// identity's usage dropped below soft on another write) may have reset it
-	// since iq was copied out of the map, so the local copy can be stale.
-	graceStart, ok := s.identityQuotas.liveGraceStartedAt(shareName, iq.Scope, iq.ID)
-	if !ok {
-		// Quota was removed concurrently — nothing to enforce.
-		return nil
-	}
+	graceStart := s.liveGrace(shareName, scope, usageID, isDefaultUserFallback, iq.ID)
 	if graceStart.IsZero() {
 		// Start the grace window now; allow this op.
-		s.startGrace(shareName, iq.Scope, iq.ID, &iq, now)
+		s.startGrace(shareName, scope, usageID, isDefaultUserFallback, iq.ID, now)
 		return nil
 	}
 	// Grace running: enforce soft-as-hard once the window has elapsed.
@@ -108,20 +108,35 @@ func (s *Service) enforceOne(shareName string, store Store, scope QuotaScope, us
 	return nil
 }
 
-func (s *Service) startGrace(shareName string, scope QuotaScope, id uint32, iq *IdentityQuota, t time.Time) {
-	if s.identityQuotas.updateGraceStartedAt(shareName, scope, id, t) {
-		iq.GraceStartedAt = t
-		s.persistGrace(shareName, scope, id, t)
+// liveGrace reads the current grace start for an enforced identity: the
+// ephemeral per-real-user timer for a default-user fallback, otherwise the
+// persisted per-row timer. Re-reading here (rather than trusting the copied iq)
+// avoids acting on a value a concurrent clear has already reset.
+func (s *Service) liveGrace(shareName string, scope QuotaScope, usageID uint32, isDefaultUserFallback bool, rowID uint32) time.Time {
+	if isDefaultUserFallback {
+		return s.identityQuotas.dynGraceStartedAt(shareName, scope, usageID)
+	}
+	t, _ := s.identityQuotas.liveGraceStartedAt(shareName, scope, rowID)
+	return t
+}
+
+func (s *Service) startGrace(shareName string, scope QuotaScope, usageID uint32, isDefaultUserFallback bool, rowID uint32, t time.Time) {
+	if isDefaultUserFallback {
+		s.identityQuotas.setDynGrace(shareName, scope, usageID, t)
+		return
+	}
+	if s.identityQuotas.updateGraceStartedAt(shareName, scope, rowID, t) {
+		s.persistGrace(shareName, scope, rowID, t)
 	}
 }
 
-func (s *Service) clearGrace(shareName string, scope QuotaScope, id uint32, iq *IdentityQuota) {
-	if iq.GraceStartedAt.IsZero() {
+func (s *Service) clearGrace(shareName string, scope QuotaScope, usageID uint32, isDefaultUserFallback bool, rowID uint32) {
+	if isDefaultUserFallback {
+		s.identityQuotas.setDynGrace(shareName, scope, usageID, time.Time{})
 		return
 	}
-	if s.identityQuotas.updateGraceStartedAt(shareName, scope, id, time.Time{}) {
-		iq.GraceStartedAt = time.Time{}
-		s.persistGrace(shareName, scope, id, time.Time{})
+	if s.identityQuotas.updateGraceStartedAt(shareName, scope, rowID, time.Time{}) {
+		s.persistGrace(shareName, scope, rowID, time.Time{})
 	}
 }
 

--- a/pkg/metadata/quota_enforce.go
+++ b/pkg/metadata/quota_enforce.go
@@ -1,0 +1,135 @@
+package metadata
+
+import "time"
+
+// quotaDimension is one enforceable axis of a quota check (bytes or inodes).
+type quotaDimension struct {
+	name  string // "bytes" or "files", for diagnostics
+	used  int64  // current usage on this axis
+	delta int64  // amount this op would add (>0)
+	soft  int64  // soft threshold (0 = none)
+	hard  int64  // hard ceiling (0 = unlimited)
+}
+
+// checkIdentityQuotas enforces the per-user and per-group quotas (if any) for a
+// file owner. delta is the byte increase; fileDelta is the inode increase (1 for
+// a create, 0 for a pure write/resize). It returns ErrQuotaExceeded when a hard
+// limit (or an expired soft+grace) would be crossed.
+//
+// Enforcement is best-effort, matching the existing per-share soft quota in
+// PrepareWrite: under concurrency a few ops may slip past simultaneously and
+// briefly exceed the limit until usage catches up. Hard atomic enforcement is
+// impractical for userspace NFS/SMB. Truncate/shrink (delta<=0 && fileDelta<=0)
+// is always allowed.
+func (s *Service) checkIdentityQuotas(shareName string, store Store, uid, gid uint32, byteDelta, fileDelta int64) error {
+	if byteDelta <= 0 && fileDelta <= 0 {
+		return nil
+	}
+	if !s.identityQuotas.hasAny(shareName) {
+		return nil
+	}
+
+	// User quota: explicit uid quota, else default-user fallthrough.
+	if iq, ok := s.identityQuotas.resolveUser(shareName, uid); ok {
+		if err := s.enforceOne(shareName, store, QuotaScopeUser, uid, iq, byteDelta, fileDelta); err != nil {
+			return err
+		}
+	}
+	// Group quota (no default-group concept).
+	if iq, ok := s.identityQuotas.get(shareName, QuotaScopeGroup, gid); ok {
+		if err := s.enforceOne(shareName, store, QuotaScopeGroup, gid, iq, byteDelta, fileDelta); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// enforceOne applies the soft/hard/grace state machine for a single resolved
+// quota against the live usage for (scope, usageID). usageID is the identity the
+// usage counter is keyed by (the real uid/gid — NOT the default-user sentinel).
+func (s *Service) enforceOne(shareName string, store Store, scope QuotaScope, usageID uint32, iq IdentityQuota, byteDelta, fileDelta int64) error {
+	usage, err := store.GetQuotaUsage(scope, usageID)
+	if err != nil {
+		// Usage lookup failure must not wedge writes; treat as no-quota.
+		return nil
+	}
+
+	dims := []quotaDimension{
+		{name: "bytes", used: usage.Bytes, delta: byteDelta, soft: iq.SoftBytes, hard: iq.LimitBytes},
+		{name: "files", used: usage.Files, delta: fileDelta, soft: iq.SoftFiles, hard: iq.LimitFiles},
+	}
+
+	overSoft := false
+	for _, d := range dims {
+		if d.delta <= 0 {
+			continue
+		}
+		projected := d.used + d.delta
+		// Hard ceiling always blocks.
+		if d.hard > 0 && projected > d.hard {
+			return &StoreError{Code: ErrQuotaExceeded, Message: "quota exceeded (" + scope.String() + " " + d.name + " hard limit)"}
+		}
+		// Soft threshold crossed.
+		if d.soft > 0 && projected > d.soft {
+			overSoft = true
+		}
+	}
+
+	if !overSoft {
+		// Under all soft thresholds: clear any running grace timer.
+		s.clearGrace(shareName, iq.Scope, iq.ID, &iq)
+		return nil
+	}
+
+	// Over a soft threshold. With no grace configured, soft is advisory only —
+	// allow the op (the hard ceiling above is the real block).
+	if iq.GraceSeconds <= 0 {
+		return nil
+	}
+
+	now := time.Now()
+	// Re-read the grace timer under lock: a concurrent clearGrace (because this
+	// identity's usage dropped below soft on another write) may have reset it
+	// since iq was copied out of the map, so the local copy can be stale.
+	graceStart, ok := s.identityQuotas.liveGraceStartedAt(shareName, iq.Scope, iq.ID)
+	if !ok {
+		// Quota was removed concurrently — nothing to enforce.
+		return nil
+	}
+	if graceStart.IsZero() {
+		// Start the grace window now; allow this op.
+		s.startGrace(shareName, iq.Scope, iq.ID, &iq, now)
+		return nil
+	}
+	// Grace running: enforce soft-as-hard once the window has elapsed.
+	if now.After(graceStart.Add(time.Duration(iq.GraceSeconds) * time.Second)) {
+		return &StoreError{Code: ErrQuotaExceeded, Message: "quota exceeded (" + scope.String() + " grace period expired)"}
+	}
+	return nil
+}
+
+func (s *Service) startGrace(shareName string, scope QuotaScope, id uint32, iq *IdentityQuota, t time.Time) {
+	if s.identityQuotas.updateGraceStartedAt(shareName, scope, id, t) {
+		iq.GraceStartedAt = t
+		s.persistGrace(shareName, scope, id, t)
+	}
+}
+
+func (s *Service) clearGrace(shareName string, scope QuotaScope, id uint32, iq *IdentityQuota) {
+	if iq.GraceStartedAt.IsZero() {
+		return
+	}
+	if s.identityQuotas.updateGraceStartedAt(shareName, scope, id, time.Time{}) {
+		iq.GraceStartedAt = time.Time{}
+		s.persistGrace(shareName, scope, id, time.Time{})
+	}
+}
+
+func (s *Service) persistGrace(shareName string, scope QuotaScope, id uint32, t time.Time) {
+	s.mu.RLock()
+	p := s.quotaGracePersist
+	s.mu.RUnlock()
+	if p != nil {
+		p.PersistQuotaGrace(shareName, scope, id, t)
+	}
+}

--- a/pkg/metadata/quota_enforce_test.go
+++ b/pkg/metadata/quota_enforce_test.go
@@ -134,6 +134,48 @@ func TestQuotaEnforcement_DefaultUserFallthrough(t *testing.T) {
 	}
 }
 
+func TestQuotaEnforcement_DefaultUserGraceIsPerUser(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// Default-user quota with soft=100, hard=10000, grace=1s. Two different
+	// users both fall through to it; one user's grace must NOT affect the other.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:        metadata.QuotaScopeUser,
+		ID:           metadata.DefaultUserID,
+		SoftBytes:    100,
+		LimitBytes:   10000,
+		GraceSeconds: 1,
+	})
+
+	userA := fx.authContext(1000, 1000)
+	userB := fx.authContext(1001, 1001)
+	fileA, _, err := fx.service.CreateFile(userA, fx.rootHandle, "a.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	fileB, _, err := fx.service.CreateFile(userB, fx.rootHandle, "b.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	hA := handleForFile(t, fileA)
+	hB := handleForFile(t, fileB)
+
+	// User A crosses soft → starts A's (per-user, ephemeral) grace window.
+	if _, err := fx.service.PrepareWrite(userA, hA, 200); err != nil {
+		t.Fatalf("user A over-soft within grace should be allowed, got %v", err)
+	}
+
+	// The persisted default-user row's grace timer must NOT have been set
+	// (per-user grace is ephemeral, keyed by the real uid).
+	iq, ok := fx.service.GetIdentityQuota(fx.shareName, metadata.QuotaScopeUser, metadata.DefaultUserID)
+	require.True(t, ok)
+	require.True(t, iq.GraceStartedAt.IsZero(), "shared default-user row must not carry per-user grace")
+
+	// User B, who never breached soft before, also gets its OWN fresh grace
+	// window on first crossing — it is not treated as already-expired because of
+	// user A's earlier breach.
+	if _, err := fx.service.PrepareWrite(userB, hB, 200); err != nil {
+		t.Fatalf("user B's first over-soft must start its own grace, got %v", err)
+	}
+}
+
 func TestQuotaEnforcement_GroupQuota(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)

--- a/pkg/metadata/quota_enforce_test.go
+++ b/pkg/metadata/quota_enforce_test.go
@@ -1,0 +1,197 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// handleForFile encodes the handle for a file returned by CreateFile.
+func handleForFile(t *testing.T, f *metadata.File) metadata.FileHandle {
+	t.Helper()
+	h, err := metadata.EncodeShareHandle(f.ShareName, f.ID)
+	require.NoError(t, err)
+	return h
+}
+
+// isQuotaErr reports whether err is a quota-exceeded StoreError.
+func isQuotaErr(err error) bool {
+	var se *metadata.StoreError
+	if as, ok := err.(*metadata.StoreError); ok {
+		se = as
+	}
+	return se != nil && se.Code == merrs.ErrQuotaExceeded
+}
+
+func TestQuotaEnforcement_HardByteBlock(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// uid=1000 gets a 1000-byte hard quota.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         1000,
+		LimitBytes: 1000,
+	})
+
+	file, _, err := fx.service.CreateFile(fx.userContext(), fx.rootHandle, "a.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle := handleForFile(t, file)
+
+	// A write up to the limit is allowed.
+	if _, err := fx.service.PrepareWrite(fx.userContext(), handle, 1000); err != nil {
+		t.Fatalf("PrepareWrite at limit should succeed, got %v", err)
+	}
+
+	// A write past the limit is blocked with a quota error.
+	_, err = fx.service.PrepareWrite(fx.userContext(), handle, 1001)
+	if !isQuotaErr(err) {
+		t.Fatalf("PrepareWrite past hard limit: got %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestQuotaEnforcement_AnotherUserUnaffected(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// Only uid=1000 is quota'd.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         1000,
+		LimitBytes: 100,
+	})
+
+	// uid=1001 (no quota) can write freely.
+	other := fx.authContext(1001, 1001)
+	file, _, err := fx.service.CreateFile(other, fx.rootHandle, "b.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle := handleForFile(t, file)
+	if _, err := fx.service.PrepareWrite(other, handle, 1_000_000); err != nil {
+		t.Fatalf("unquota'd user write should succeed, got %v", err)
+	}
+}
+
+func TestQuotaEnforcement_InodeCap(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// uid=1000 may own at most 2 files.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         1000,
+		LimitFiles: 2,
+	})
+
+	uc := fx.userContext()
+	if _, _, err := fx.service.CreateFile(uc, fx.rootHandle, "f1", &metadata.FileAttr{Mode: 0o644}); err != nil {
+		t.Fatalf("first create should succeed: %v", err)
+	}
+	if _, _, err := fx.service.CreateFile(uc, fx.rootHandle, "f2", &metadata.FileAttr{Mode: 0o644}); err != nil {
+		t.Fatalf("second create should succeed: %v", err)
+	}
+	// Third create exceeds the inode cap.
+	_, _, err := fx.service.CreateFile(uc, fx.rootHandle, "f3", &metadata.FileAttr{Mode: 0o644})
+	if !isQuotaErr(err) {
+		t.Fatalf("third create past inode cap: got %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestQuotaEnforcement_DefaultUserFallthrough(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// Default-user quota: any uid without an explicit quota gets 500 bytes.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         metadata.DefaultUserID,
+		LimitBytes: 500,
+	})
+	// uid=2000 gets an explicit, larger quota that overrides the default.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         2000,
+		LimitBytes: 10000,
+	})
+
+	// uid=1000 falls through to the default 500-byte limit.
+	def := fx.authContext(1000, 1000)
+	dfile, _, err := fx.service.CreateFile(def, fx.rootHandle, "d.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	dh := handleForFile(t, dfile)
+	if _, err := fx.service.PrepareWrite(def, dh, 600); !isQuotaErr(err) {
+		t.Fatalf("default-user past 500: got %v, want ErrQuotaExceeded", err)
+	}
+
+	// uid=2000 uses its explicit larger quota.
+	exp := fx.authContext(2000, 2000)
+	efile, _, err := fx.service.CreateFile(exp, fx.rootHandle, "e.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	eh := handleForFile(t, efile)
+	if _, err := fx.service.PrepareWrite(exp, eh, 600); err != nil {
+		t.Fatalf("explicit-quota user under its limit should succeed, got %v", err)
+	}
+}
+
+func TestQuotaEnforcement_GroupQuota(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// gid=3000 hard byte limit of 800.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeGroup,
+		ID:         3000,
+		LimitBytes: 800,
+	})
+
+	ctx := fx.authContext(1234, 3000)
+	file, _, err := fx.service.CreateFile(ctx, fx.rootHandle, "g.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle := handleForFile(t, file)
+	if _, err := fx.service.PrepareWrite(ctx, handle, 801); !isQuotaErr(err) {
+		t.Fatalf("group quota past limit: got %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestQuotaEnforcement_SoftGraceHard(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	// Soft=100, hard=10000, grace=1s. Crossing soft starts the grace timer;
+	// after grace expires the soft threshold is enforced as hard.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:        metadata.QuotaScopeUser,
+		ID:           1000,
+		SoftBytes:    100,
+		LimitBytes:   10000,
+		GraceSeconds: 1,
+	})
+
+	uc := fx.userContext()
+	file, _, err := fx.service.CreateFile(uc, fx.rootHandle, "s.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle := handleForFile(t, file)
+
+	// First write over soft (but under hard) is allowed and starts grace.
+	if _, err := fx.service.PrepareWrite(uc, handle, 200); err != nil {
+		t.Fatalf("over-soft within grace should be allowed, got %v", err)
+	}
+	// Grace just started, still within window: still allowed.
+	if _, err := fx.service.PrepareWrite(uc, handle, 300); err != nil {
+		t.Fatalf("over-soft still within grace should be allowed, got %v", err)
+	}
+
+	// The grace timer is persisted in the live quota map; verify it is running.
+	iq, ok := fx.service.GetIdentityQuota(fx.shareName, metadata.QuotaScopeUser, 1000)
+	require.True(t, ok)
+	require.False(t, iq.GraceStartedAt.IsZero(), "grace timer should be running after crossing soft")
+
+	// Simulate grace expiry by rewinding the persisted start far enough back,
+	// then a further over-soft write must be blocked as hard.
+	iq.GraceStartedAt = iq.GraceStartedAt.Add(-10 * 1e9) // -10s
+	fx.service.SetIdentityQuota(fx.shareName, iq)
+	if _, err := fx.service.PrepareWrite(uc, handle, 400); !isQuotaErr(err) {
+		t.Fatalf("over-soft after grace expiry: got %v, want ErrQuotaExceeded", err)
+	}
+}

--- a/pkg/metadata/quota_fsstat_test.go
+++ b/pkg/metadata/quota_fsstat_test.go
@@ -1,0 +1,51 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQuotaFSStatOverlay verifies that GetFilesystemStatisticsForIdentity
+// narrows the reported total/available to the caller's per-identity quota,
+// using that identity's own usage — what `df` / FSSTAT / SMB FS_FULL_SIZE show.
+func TestQuotaFSStatOverlay(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	// Use immediate commits so the per-identity usage counter reflects the
+	// committed write synchronously (no NFS COMMIT/flush in this unit test).
+	fx.service.SetDeferredCommit(false)
+
+	// uid=1000 gets a 10000-byte quota.
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:      metadata.QuotaScopeUser,
+		ID:         1000,
+		LimitBytes: 10000,
+	})
+
+	uc := fx.userContext()
+
+	// Create a file as uid=1000 and grow+commit it to 4000 bytes so the usage
+	// counter reflects real usage.
+	file, _, err := fx.service.CreateFile(uc, fx.rootHandle, "u.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(file.ShareName, file.ID)
+	require.NoError(t, err)
+	op, err := fx.service.PrepareWrite(uc, handle, 4000)
+	require.NoError(t, err)
+	_, err = fx.service.CommitWrite(uc, op)
+	require.NoError(t, err)
+
+	// With identity: total clamps to the 10000-byte quota, available = quota - used.
+	stats, err := fx.service.GetFilesystemStatisticsForIdentity(uc.Context, handle, uc.Identity)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10000), stats.TotalBytes, "total should reflect the user quota")
+	require.Equal(t, uint64(6000), stats.AvailableBytes, "available should be quota minus the user's usage")
+
+	// A different (unquota'd) user sees the raw volume, not uid=1000's quota.
+	other := fx.authContext(2000, 2000)
+	ostats, err := fx.service.GetFilesystemStatisticsForIdentity(other.Context, handle, other.Identity)
+	require.NoError(t, err)
+	require.NotEqual(t, uint64(10000), ostats.TotalBytes, "unquota'd user must not inherit another user's quota")
+}

--- a/pkg/metadata/quota_limits.go
+++ b/pkg/metadata/quota_limits.go
@@ -51,6 +51,15 @@ type quotaLimits struct {
 	mu sync.RWMutex
 	// byShare[share][key] = limit
 	byShare map[string]map[identityQuotaKey]*IdentityQuota
+
+	// dynGrace holds ephemeral grace timers for default-user fallbacks, keyed by
+	// the REAL uid (not the default-user sentinel) so each user gets an
+	// independent grace window. These are NOT persisted: a default-user quota is
+	// a shared fallback whose single DB row cannot hold per-user grace state, so
+	// the timer is in-memory only and resets on restart (acceptable for the
+	// fallback case; explicit user/group quotas keep their persisted per-row
+	// grace). Keyed share -> (scope,realID) -> grace start.
+	dynGrace map[string]map[identityQuotaKey]time.Time
 }
 
 type identityQuotaKey struct {
@@ -59,7 +68,43 @@ type identityQuotaKey struct {
 }
 
 func newQuotaLimits() *quotaLimits {
-	return &quotaLimits{byShare: make(map[string]map[identityQuotaKey]*IdentityQuota)}
+	return &quotaLimits{
+		byShare:  make(map[string]map[identityQuotaKey]*IdentityQuota),
+		dynGrace: make(map[string]map[identityQuotaKey]time.Time),
+	}
+}
+
+// dynGraceStartedAt returns the ephemeral default-user grace timer for a real
+// identity (zero if none).
+func (q *quotaLimits) dynGraceStartedAt(share string, scope QuotaScope, realID uint32) time.Time {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	if m := q.dynGrace[share]; m != nil {
+		return m[identityQuotaKey{scope, realID}]
+	}
+	return time.Time{}
+}
+
+// setDynGrace sets (zero clears) the ephemeral default-user grace timer for a
+// real identity.
+func (q *quotaLimits) setDynGrace(share string, scope QuotaScope, realID uint32, t time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	m := q.dynGrace[share]
+	if t.IsZero() {
+		if m != nil {
+			delete(m, identityQuotaKey{scope, realID})
+			if len(m) == 0 {
+				delete(q.dynGrace, share)
+			}
+		}
+		return
+	}
+	if m == nil {
+		m = make(map[identityQuotaKey]time.Time)
+		q.dynGrace[share] = m
+	}
+	m[identityQuotaKey{scope, realID}] = t
 }
 
 // set installs or replaces a single identity quota for a share.

--- a/pkg/metadata/quota_limits.go
+++ b/pkg/metadata/quota_limits.go
@@ -1,0 +1,170 @@
+package metadata
+
+import (
+	"sync"
+	"time"
+)
+
+// IdentityQuota is the runtime view of a per-identity quota limit, loaded into
+// the metadata Service from the control-plane DB and consulted on the write /
+// create hot path. It is protocol-agnostic. All byte/file fields are limits;
+// 0 means "no limit on this dimension". Soft must be <= Limit when both are set.
+//
+// The grace state machine (GraceStartedAt) is mutated in place by the enforcer
+// and is also persisted back to the control-plane row so it survives restart.
+type IdentityQuota struct {
+	// Scope selects user vs group keying. DefaultUser quotas are modeled as a
+	// QuotaScopeUser entry under the sentinel DefaultUserID id.
+	Scope QuotaScope
+	// ID is the uid (user / default-user) or gid (group) the quota applies to.
+	ID uint32
+
+	// LimitBytes is the hard byte ceiling (0 = unlimited).
+	LimitBytes int64
+	// SoftBytes is the soft byte threshold (0 = no soft threshold).
+	SoftBytes int64
+	// LimitFiles is the hard inode (file-count) ceiling (0 = unlimited).
+	LimitFiles int64
+	// SoftFiles is the soft inode threshold (0 = no soft threshold).
+	SoftFiles int64
+
+	// GraceSeconds is how long usage may stay over a soft threshold before the
+	// soft threshold is enforced as hard. 0 disables grace (soft acts as a
+	// warning only and is never escalated).
+	GraceSeconds int64
+	// GraceStartedAt records when usage first crossed a soft threshold. Zero
+	// means no grace timer is running.
+	GraceStartedAt time.Time
+}
+
+// DefaultUserID is the sentinel uid used to key a default-user quota: a single
+// QuotaScopeUser entry that applies to any uid without an explicit user quota.
+// It is intentionally MaxUint32 so it never collides with a real uid in
+// practice (uids are 32-bit but real-world uids never reach this value, and the
+// store charges usage to actual file-owner uids, never to this sentinel).
+const DefaultUserID = ^uint32(0)
+
+// quotaLimits holds the hot-updatable per-identity quota limits for the Service.
+// Keyed share -> quota-key -> *IdentityQuota. Guarded by its own mutex so the
+// write/create hot path does not contend with the broad Service.mu.
+type quotaLimits struct {
+	mu sync.RWMutex
+	// byShare[share][key] = limit
+	byShare map[string]map[identityQuotaKey]*IdentityQuota
+}
+
+type identityQuotaKey struct {
+	scope QuotaScope
+	id    uint32
+}
+
+func newQuotaLimits() *quotaLimits {
+	return &quotaLimits{byShare: make(map[string]map[identityQuotaKey]*IdentityQuota)}
+}
+
+// set installs or replaces a single identity quota for a share.
+func (q *quotaLimits) set(share string, iq IdentityQuota) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	m := q.byShare[share]
+	if m == nil {
+		m = make(map[identityQuotaKey]*IdentityQuota)
+		q.byShare[share] = m
+	}
+	copyIQ := iq
+	m[identityQuotaKey{iq.Scope, iq.ID}] = &copyIQ
+}
+
+// remove deletes a single identity quota for a share.
+func (q *quotaLimits) remove(share string, scope QuotaScope, id uint32) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if m := q.byShare[share]; m != nil {
+		delete(m, identityQuotaKey{scope, id})
+		if len(m) == 0 {
+			delete(q.byShare, share)
+		}
+	}
+}
+
+// replaceShare atomically replaces all quotas for a share (used on bulk reload).
+func (q *quotaLimits) replaceShare(share string, quotas []IdentityQuota) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(quotas) == 0 {
+		delete(q.byShare, share)
+		return
+	}
+	m := make(map[identityQuotaKey]*IdentityQuota, len(quotas))
+	for i := range quotas {
+		copyIQ := quotas[i]
+		m[identityQuotaKey{copyIQ.Scope, copyIQ.ID}] = &copyIQ
+	}
+	q.byShare[share] = m
+}
+
+// get returns a copy of the quota for an exact (scope,id), or false.
+func (q *quotaLimits) get(share string, scope QuotaScope, id uint32) (IdentityQuota, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	if m := q.byShare[share]; m != nil {
+		if iq, ok := m[identityQuotaKey{scope, id}]; ok {
+			return *iq, true
+		}
+	}
+	return IdentityQuota{}, false
+}
+
+// resolveUser returns the effective user quota for a uid: the explicit user
+// quota if present, otherwise the default-user quota if configured.
+func (q *quotaLimits) resolveUser(share string, uid uint32) (IdentityQuota, bool) {
+	if iq, ok := q.get(share, QuotaScopeUser, uid); ok {
+		return iq, true
+	}
+	return q.get(share, QuotaScopeUser, DefaultUserID)
+}
+
+// hasAny reports whether a share has any identity quotas configured.
+func (q *quotaLimits) hasAny(share string) bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.byShare[share]) > 0
+}
+
+// liveGraceStartedAt returns the current persisted grace-start for a quota and
+// whether the quota still exists. Used to re-read the timer under lock just
+// before an enforce decision, so a concurrent clearGrace cannot leave the
+// caller acting on a stale copy.
+func (q *quotaLimits) liveGraceStartedAt(share string, scope QuotaScope, id uint32) (time.Time, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	m := q.byShare[share]
+	if m == nil {
+		return time.Time{}, false
+	}
+	iq := m[identityQuotaKey{scope, id}]
+	if iq == nil {
+		return time.Time{}, false
+	}
+	return iq.GraceStartedAt, true
+}
+
+// updateGraceStartedAt mutates the persisted grace timer for a stored quota and
+// returns whether the value changed (so the caller can persist it back).
+func (q *quotaLimits) updateGraceStartedAt(share string, scope QuotaScope, id uint32, t time.Time) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	m := q.byShare[share]
+	if m == nil {
+		return false
+	}
+	iq := m[identityQuotaKey{scope, id}]
+	if iq == nil {
+		return false
+	}
+	if iq.GraceStartedAt.Equal(t) {
+		return false
+	}
+	iq.GraceStartedAt = t
+	return true
+}

--- a/pkg/metadata/quota_usage.go
+++ b/pkg/metadata/quota_usage.go
@@ -1,0 +1,43 @@
+package metadata
+
+// QuotaScope identifies whether a per-identity usage counter or limit is keyed
+// by owning user (uid) or owning group (gid). It is protocol-agnostic: NFS and
+// SMB both map their callers to a POSIX-style uid/gid identity before reaching
+// the metadata store.
+type QuotaScope uint8
+
+const (
+	// QuotaScopeUser keys usage/limits by the file owner's uid (FileAttr.UID).
+	QuotaScopeUser QuotaScope = iota
+	// QuotaScopeGroup keys usage/limits by the file owner's gid (FileAttr.GID).
+	QuotaScopeGroup
+)
+
+// String renders the scope for storage and logging. The values must stay
+// stable: they are persisted by the postgres/badger backends and used as the
+// REST/CLI scope identifier.
+func (s QuotaScope) String() string {
+	switch s {
+	case QuotaScopeUser:
+		return "user"
+	case QuotaScopeGroup:
+		return "group"
+	default:
+		return "unknown"
+	}
+}
+
+// UsageStat is the per-identity accounting pair tracked by every metadata
+// backend: total logical bytes and file (inode) count for regular files owned
+// by a single uid or gid. Mirrors the store-wide GetUsedBytes counter but keyed
+// by owner identity so per-user/per-group quotas can be enforced and reported.
+//
+// Only regular files contribute (directories, symlinks, devices do not), matching
+// the store-wide usedBytes semantics. Files is the inode count used for the
+// inode-quota dimension.
+type UsageStat struct {
+	// Bytes is the sum of logical sizes of regular files owned by the identity.
+	Bytes int64
+	// Files is the number of regular files owned by the identity (inode count).
+	Files int64
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -47,6 +47,16 @@ type Service struct {
 	cookies            *CookieManager                    // NFS/SMB cookie to store token translation
 	quotas             map[string]int64                  // shareName -> quota in bytes (0 = unlimited)
 
+	// identityQuotas holds hot-updatable per-user / per-group quota limits,
+	// loaded from the control-plane DB and consulted on the write/create hot
+	// path. Has its own mutex (does not contend with s.mu).
+	identityQuotas *quotaLimits
+
+	// quotaGracePersist, if set, is invoked when the enforcer starts or clears a
+	// grace timer so the control-plane row's grace_started_at can be persisted.
+	// A zero time clears the timer. Registered via SetQuotaGracePersister.
+	quotaGracePersist QuotaGracePersister
+
 	// removeGen counts RemoveStoreForShare calls per share. RegisterStoreForShare
 	// snapshots a share's counter before recovering its lock manager outside s.mu
 	// and re-checks it at publish: any removal of that share during recovery bumps
@@ -110,8 +120,45 @@ func New() *Service {
 		deferredCommit:     true, // Enable deferred commits by default
 		cookies:            NewCookieManager(),
 		quotas:             make(map[string]int64),
+		identityQuotas:     newQuotaLimits(),
 		removeGen:          make(map[string]uint64),
 	}
+}
+
+// QuotaGracePersister persists a per-identity quota's grace timer transition
+// back to the control-plane store. t is the new grace_started_at (zero clears
+// it). Implementations must be safe for concurrent use and should not block the
+// caller for long (the write/create hot path invokes this when grace state
+// changes).
+type QuotaGracePersister interface {
+	PersistQuotaGrace(shareName string, scope QuotaScope, id uint32, t time.Time)
+}
+
+// SetQuotaGracePersister installs the grace-timer persistence hook.
+func (s *Service) SetQuotaGracePersister(p QuotaGracePersister) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quotaGracePersist = p
+}
+
+// SetIdentityQuota installs or replaces a single per-identity quota for a share.
+func (s *Service) SetIdentityQuota(shareName string, iq IdentityQuota) {
+	s.identityQuotas.set(shareName, iq)
+}
+
+// RemoveIdentityQuota deletes a single per-identity quota for a share.
+func (s *Service) RemoveIdentityQuota(shareName string, scope QuotaScope, id uint32) {
+	s.identityQuotas.remove(shareName, scope, id)
+}
+
+// ReplaceIdentityQuotas atomically replaces all per-identity quotas for a share.
+func (s *Service) ReplaceIdentityQuotas(shareName string, quotas []IdentityQuota) {
+	s.identityQuotas.replaceShare(shareName, quotas)
+}
+
+// GetIdentityQuota returns the exact-keyed quota for (scope,id) on a share.
+func (s *Service) GetIdentityQuota(shareName string, scope QuotaScope, id uint32) (IdentityQuota, bool) {
+	return s.identityQuotas.get(shareName, scope, id)
 }
 
 // SetDeferredCommit enables or disables deferred metadata commits.
@@ -782,8 +829,19 @@ func (s *Service) GetQuotaForShare(shareName string) int64 {
 
 // GetFilesystemStatistics returns filesystem statistics.
 // When a quota is configured for the share, the returned TotalBytes and
-// AvailableBytes are overlaid with quota-adjusted values.
+// AvailableBytes are overlaid with quota-adjusted values. This convenience
+// form has no caller identity, so per-user/per-group quotas are not reflected;
+// use GetFilesystemStatisticsForIdentity from protocol FSSTAT handlers.
 func (s *Service) GetFilesystemStatistics(ctx context.Context, handle FileHandle) (*FilesystemStatistics, error) {
+	return s.GetFilesystemStatisticsForIdentity(ctx, handle, nil)
+}
+
+// GetFilesystemStatisticsForIdentity returns filesystem statistics with the
+// quota overlay narrowed to the smallest applicable quota: the per-share quota
+// AND (when identity is non-nil and a per-user/per-group quota applies) the
+// caller's identity quota. This is what `df` / FSSTAT / SMB FS_FULL_SIZE report,
+// so a quota'd user sees their own ceiling rather than the raw volume.
+func (s *Service) GetFilesystemStatisticsForIdentity(ctx context.Context, handle FileHandle, identity *Identity) (*FilesystemStatistics, error) {
 	// Decode once: the share name is reused for the quota overlay below.
 	shareName, _, err := DecodeFileHandle(handle)
 	if err != nil {
@@ -798,19 +856,93 @@ func (s *Service) GetFilesystemStatistics(ctx context.Context, handle FileHandle
 		return nil, err
 	}
 
-	// Apply quota overlay if configured
-	quotaBytes := s.GetQuotaForShare(shareName)
-	if quotaBytes > 0 {
-		quota := uint64(quotaBytes)
-		stats.TotalBytes = quota
-		if stats.UsedBytes > quota {
-			stats.AvailableBytes = 0
-		} else {
-			stats.AvailableBytes = quota - stats.UsedBytes
-		}
+	// Apply per-share quota overlay if configured.
+	if quotaBytes := s.GetQuotaForShare(shareName); quotaBytes > 0 {
+		applyByteQuotaOverlay(stats, uint64(quotaBytes), stats.UsedBytes)
 	}
 
+	// Apply the tighter of the caller's user / group quota, if any.
+	s.applyIdentityQuotaOverlay(shareName, store, stats, identity)
+
 	return stats, nil
+}
+
+// applyByteQuotaOverlay narrows TotalBytes/AvailableBytes to a byte ceiling
+// against the given used value. Only narrows (never widens) Total so the
+// smallest applicable quota wins across successive overlays.
+func applyByteQuotaOverlay(stats *FilesystemStatistics, ceiling, used uint64) {
+	if ceiling == 0 {
+		return
+	}
+	if stats.TotalBytes == 0 || ceiling < stats.TotalBytes {
+		stats.TotalBytes = ceiling
+	}
+	var avail uint64
+	if used < ceiling {
+		avail = ceiling - used
+	}
+	if avail < stats.AvailableBytes {
+		stats.AvailableBytes = avail
+	}
+}
+
+// applyFileQuotaOverlay narrows TotalFiles/AvailableFiles to an inode ceiling.
+func applyFileQuotaOverlay(stats *FilesystemStatistics, ceiling, used uint64) {
+	if ceiling == 0 {
+		return
+	}
+	if stats.TotalFiles == 0 || ceiling < stats.TotalFiles {
+		stats.TotalFiles = ceiling
+	}
+	var avail uint64
+	if used < ceiling {
+		avail = ceiling - used
+	}
+	if avail < stats.AvailableFiles {
+		stats.AvailableFiles = avail
+	}
+}
+
+// applyIdentityQuotaOverlay narrows the stats to the caller's per-user and
+// per-group quota (bytes + inodes), using that identity's live usage rather
+// than the share-wide used total. No-op when identity is nil or has no UID, or
+// when no quota applies.
+func (s *Service) applyIdentityQuotaOverlay(shareName string, store Store, stats *FilesystemStatistics, identity *Identity) {
+	if identity == nil || identity.UID == nil || !s.identityQuotas.hasAny(shareName) {
+		return
+	}
+	uid := *identity.UID
+
+	if iq, ok := s.identityQuotas.resolveUser(shareName, uid); ok {
+		if usage, err := store.GetQuotaUsage(QuotaScopeUser, uid); err == nil {
+			if iq.LimitBytes > 0 {
+				applyByteQuotaOverlay(stats, uint64(iq.LimitBytes), uint64(max64(usage.Bytes, 0)))
+			}
+			if iq.LimitFiles > 0 {
+				applyFileQuotaOverlay(stats, uint64(iq.LimitFiles), uint64(max64(usage.Files, 0)))
+			}
+		}
+	}
+	if identity.GID != nil {
+		gid := *identity.GID
+		if iq, ok := s.identityQuotas.get(shareName, QuotaScopeGroup, gid); ok {
+			if usage, err := store.GetQuotaUsage(QuotaScopeGroup, gid); err == nil {
+				if iq.LimitBytes > 0 {
+					applyByteQuotaOverlay(stats, uint64(iq.LimitBytes), uint64(max64(usage.Bytes, 0)))
+				}
+				if iq.LimitFiles > 0 {
+					applyFileQuotaOverlay(stats, uint64(iq.LimitFiles), uint64(max64(usage.Files, 0)))
+				}
+			}
+		}
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // GetFilesystemCapabilities returns filesystem capabilities.

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -375,6 +375,19 @@ type Store interface {
 	// This is an O(1) read from an atomic counter.
 	GetUsedBytes() int64
 
+	// GetQuotaUsage returns the per-identity usage (bytes + file count) for the
+	// given scope (user/group) and identity id (uid or gid). Regular files only,
+	// charged to the file owner (FileAttr.UID / FileAttr.GID). This mirrors
+	// GetUsedBytes but keyed by owner identity so per-user/per-group quotas can
+	// be enforced and reported. An identity with no owned regular files returns a
+	// zero UsageStat and a nil error.
+	//
+	// Like GetUsedBytes, this is intended to be O(1): backends maintain keyed
+	// counters updated transactionally alongside the size delta, seeded at
+	// startup from an aggregate scan (badger/postgres) or naturally accumulated
+	// (memory).
+	GetQuotaUsage(scope QuotaScope, id uint32) (UsageStat, error)
+
 	// ========================================================================
 	// Store Lifecycle (not transactional)
 	// ========================================================================

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -199,6 +199,7 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	}
 
 	var freedBytes int64
+	var quotaFreed map[badgerQuotaKey]metadata.UsageStat
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
 		if err == badgerdb.ErrKeyNotFound {
@@ -212,11 +213,12 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 			return err
 		}
 
-		freed, err := s.deleteShareFiles(txn, shareName)
+		freed, quota, err := s.deleteShareFiles(txn, shareName)
 		if err != nil {
 			return err
 		}
 		freedBytes = freed
+		quotaFreed = quota
 
 		return txn.Delete(keyShare(shareName))
 	})
@@ -227,7 +229,43 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	if freedBytes > 0 {
 		s.usedBytes.Add(-freedBytes)
 	}
+	s.applyQuotaDelta(quotaFreed)
 	return nil
+}
+
+// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
+// cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
+// below are removed.
+func (s *BadgerMetadataStore) applyQuotaDelta(delta map[badgerQuotaKey]metadata.UsageStat) {
+	if len(delta) == 0 {
+		return
+	}
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	for k, d := range delta {
+		m := s.userUsage
+		if k.scope == metadata.QuotaScopeGroup {
+			m = s.groupUsage
+		}
+		cur := m[k.id]
+		if cur == nil {
+			cur = &metadata.UsageStat{}
+			m[k.id] = cur
+		}
+		cur.Bytes += d.Bytes
+		cur.Files += d.Files
+		// Negative values indicate accounting drift (should never happen):
+		// clamp to zero so the enforcer never reads a too-permissive total.
+		if cur.Bytes < 0 {
+			cur.Bytes = 0
+		}
+		if cur.Files < 0 {
+			cur.Files = 0
+		}
+		if cur.Bytes == 0 && cur.Files == 0 {
+			delete(m, k.id)
+		}
+	}
 }
 
 // deleteShareFiles removes every file inode and its dependent keys (parent,
@@ -245,13 +283,15 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 // pendingDelta and the pool-path applies it after db.Update returns nil — so a
 // conflict/serialization retry that re-runs the enclosing Update never
 // double-counts. The counter is statfs-only, not quota-enforcing.
-func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, err error) {
+func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quota map[badgerQuotaKey]metadata.UsageStat, err error) {
 	type doomed struct {
 		id       uuid.UUID
 		objectID metadata.ContentHash
 		isDir    bool
 		size     uint64
 		isReg    bool
+		uid      uint32
+		gid      uint32
 	}
 	var victims []doomed
 
@@ -264,7 +304,7 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 		val, vErr := item.ValueCopy(nil)
 		if vErr != nil {
 			it.Close()
-			return 0, fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
+			return 0, nil, fmt.Errorf("badger DeleteShare: copy file value: %w", vErr)
 		}
 		file, decErr := decodeFile(val)
 		if decErr != nil {
@@ -281,27 +321,42 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 			isDir:    file.Type == metadata.FileTypeDirectory,
 			size:     file.Size,
 			isReg:    file.Type == metadata.FileTypeRegular,
+			uid:      file.UID,
+			gid:      file.GID,
 		})
 	}
 	it.Close()
 
+	quota = make(map[badgerQuotaKey]metadata.UsageStat)
 	for _, v := range victims {
 		if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
-			return 0, delErr
+			return 0, nil, delErr
 		}
 		// Directories own c:<uuid>:<name> child entries; prefix-scan and
 		// delete them so no dangling mapping survives the share.
 		if v.isDir {
 			if delErr := deleteChildEntries(txn, v.id); delErr != nil {
-				return 0, delErr
+				return 0, nil, delErr
 			}
 		}
-		if v.isReg && v.size > 0 {
-			freedBytes += int64(v.size)
+		if v.isReg {
+			if v.size > 0 {
+				freedBytes += int64(v.size)
+			}
+			uk := badgerQuotaKey{metadata.QuotaScopeUser, v.uid}
+			us := quota[uk]
+			us.Bytes -= int64(v.size)
+			us.Files--
+			quota[uk] = us
+			gk := badgerQuotaKey{metadata.QuotaScopeGroup, v.gid}
+			gs := quota[gk]
+			gs.Bytes -= int64(v.size)
+			gs.Files--
+			quota[gk] = gs
 		}
 	}
 
-	return freedBytes, nil
+	return freedBytes, quota, nil
 }
 
 // deleteFileKeys removes the primary file row plus its parent, link-count, and

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -121,6 +121,16 @@ type BadgerMetadataStore struct {
 	// Initialized from a full file scan on startup.
 	usedBytes atomic.Int64
 
+	// userUsage / groupUsage track per-identity usage (bytes + file count) for
+	// regular files, keyed by owner uid / gid. In-memory cache mirroring
+	// usedBytes, seeded from a full file scan on startup (so it is always
+	// reconstructed from the durable file rows — back-compatible with existing
+	// dumps). Updated from a transaction's pending per-identity deltas exactly
+	// once on successful commit. Guarded by quotaMu.
+	quotaMu    sync.Mutex
+	userUsage  map[uint32]*metadata.UsageStat
+	groupUsage map[uint32]*metadata.UsageStat
+
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the cfg:store_id key in BadgerDB. Created on first open of
 	// a fresh directory with a fresh ULID; read thereafter. Immutable for
@@ -408,9 +418,25 @@ func (s *BadgerMetadataStore) GetUsedBytes() int64 {
 	return s.usedBytes.Load()
 }
 
-// initUsedBytesCounter scans all file entries once at startup to initialize the atomic counter.
+// initUsedBytesCounter scans all file entries once at startup to initialize the
+// store-wide atomic counter and the per-identity usage cache (userUsage /
+// groupUsage). Both are reconstructed from the durable file rows, so a store
+// opened from an existing dump (with no separately persisted counters) is always
+// seeded correctly — back-compatible by construction.
 func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 	var totalUsed int64
+	userUsage := make(map[uint32]*metadata.UsageStat)
+	groupUsage := make(map[uint32]*metadata.UsageStat)
+
+	addUsage := func(m map[uint32]*metadata.UsageStat, id uint32, bytes int64) {
+		u := m[id]
+		if u == nil {
+			u = &metadata.UsageStat{}
+			m[id] = u
+		}
+		u.Bytes += bytes
+		u.Files++
+	}
 
 	err := s.db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
@@ -429,6 +455,8 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 				}
 				if file.Type == metadata.FileTypeRegular {
 					totalUsed += int64(file.Size)
+					addUsage(userUsage, file.UID, int64(file.Size))
+					addUsage(groupUsage, file.GID, int64(file.Size))
 				}
 				return nil
 			})
@@ -443,7 +471,26 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 	}
 
 	s.usedBytes.Store(totalUsed)
+	s.quotaMu.Lock()
+	s.userUsage = userUsage
+	s.groupUsage = groupUsage
+	s.quotaMu.Unlock()
 	return nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
+func (s *BadgerMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	m := s.userUsage
+	if scope == metadata.QuotaScopeGroup {
+		m = s.groupUsage
+	}
+	if u, ok := m[id]; ok {
+		return *u, nil
+	}
+	return metadata.UsageStat{}, nil
 }
 
 // NewBadgerMetadataStoreWithDefaults creates a new BadgerDB metadata store with sensible defaults.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -29,6 +29,53 @@ type badgerTransaction struct {
 	store        *BadgerMetadataStore
 	txn          *badgerdb.Txn
 	pendingDelta int64
+	// quotaDelta accumulates per-identity usage changes (bytes + file count)
+	// keyed by (scope, id). Captured per attempt and applied to the store's
+	// in-memory userUsage/groupUsage cache exactly once after a successful
+	// commit, identical to pendingDelta (so a conflict-retry cannot
+	// double-count).
+	quotaDelta map[badgerQuotaKey]metadata.UsageStat
+}
+
+// badgerQuotaKey identifies a per-identity usage bucket inside a transaction's
+// accumulated delta.
+type badgerQuotaKey struct {
+	scope metadata.QuotaScope
+	id    uint32
+}
+
+// addQuota records a usage delta for the file's owner identity (both user and
+// group scopes). See memory store addQuota for the create/resize/chown cases.
+func (tx *badgerTransaction) addQuota(uid, gid uint32, bytes, files int64) {
+	if bytes == 0 && files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[badgerQuotaKey]metadata.UsageStat)
+	}
+	u := tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeUser, uid}]
+	u.Bytes += bytes
+	u.Files += files
+	tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeUser, uid}] = u
+	g := tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeGroup, gid}]
+	g.Bytes += bytes
+	g.Files += files
+	tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeGroup, gid}] = g
+}
+
+// addQuota2 merges a single pre-keyed usage delta (used when folding the
+// per-identity totals returned by deleteShareFiles).
+func (tx *badgerTransaction) addQuota2(k badgerQuotaKey, d metadata.UsageStat) {
+	if d.Bytes == 0 && d.Files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[badgerQuotaKey]metadata.UsageStat)
+	}
+	cur := tx.quotaDelta[k]
+	cur.Bytes += d.Bytes
+	cur.Files += d.Files
+	tx.quotaDelta[k] = cur
 }
 
 // Maximum number of retries for conflict errors
@@ -51,12 +98,14 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		// successful commit and reset per attempt (a retried attempt starts
 		// from zero, so a conflict-retry cannot double-count usedBytes).
 		var pendingDelta int64
+		var quotaDelta map[badgerQuotaKey]metadata.UsageStat
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
 			if fnErr := fn(tx); fnErr != nil {
 				return fnErr
 			}
 			pendingDelta = tx.pendingDelta
+			quotaDelta = tx.quotaDelta
 			return nil
 		})
 
@@ -65,6 +114,8 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 			if pendingDelta != 0 {
 				s.usedBytes.Add(pendingDelta)
 			}
+			// Apply per-identity usage deltas once, after commit.
+			s.applyQuotaDelta(quotaDelta)
 			return nil // Success
 		}
 
@@ -158,9 +209,12 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		return err
 	}
 
-	// Read existing record once to capture both the size delta (for usedBytes
-	// tracking) and the previous ObjectID (for secondary-index cleanup).
+	// Read existing record once to capture the size delta (for usedBytes
+	// tracking), previous owner (for per-identity usage), and the previous
+	// ObjectID (for secondary-index cleanup).
 	var oldSize uint64
+	var oldUID, oldGID uint32
+	var hadOldRegular bool
 	var oldObjectID metadata.ContentHash
 	if item, err := tx.txn.Get(keyFile(file.ID)); err == nil {
 		_ = item.Value(func(val []byte) error {
@@ -168,6 +222,9 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 			if decErr == nil {
 				if existing.Type == metadata.FileTypeRegular {
 					oldSize = existing.Size
+					oldUID = existing.UID
+					oldGID = existing.GID
+					hadOldRegular = true
 				}
 				oldObjectID = existing.ObjectID
 			}
@@ -179,6 +236,17 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// once after a successful commit so a conflict-retry never double-counts.
 	if file.Type == metadata.FileTypeRegular {
 		tx.pendingDelta += int64(file.Size) - int64(oldSize)
+
+		switch {
+		case !hadOldRegular:
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		case oldUID == file.UID && oldGID == file.GID:
+			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+		default:
+			// Chown: move bytes + inode from old owner to new owner.
+			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		}
 	}
 
 	data, err := encodeFile(file)
@@ -261,8 +329,11 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	_ = item.Value(func(val []byte) error {
 		file, decErr := decodeFile(val)
 		if decErr == nil {
-			if file.Type == metadata.FileTypeRegular && file.Size > 0 {
-				tx.pendingDelta -= int64(file.Size)
+			if file.Type == metadata.FileTypeRegular {
+				if file.Size > 0 {
+					tx.pendingDelta -= int64(file.Size)
+				}
+				tx.addQuota(file.UID, file.GID, -int64(file.Size), -1)
 			}
 			existingObjectID = file.ObjectID
 		}
@@ -827,13 +898,16 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 	// Tear down all file metadata on the active txn, identical to the pool
 	// path — deleting only the share key would orphan every file/parent/
 	// linkcount/child/objectID entry (store.go:161 contract).
-	freed, err := tx.store.deleteShareFiles(tx.txn, shareName)
+	freed, quota, err := tx.store.deleteShareFiles(tx.txn, shareName)
 	if err != nil {
 		return err
 	}
 	// Accumulate into the tx pending delta; applied once after a successful
 	// commit so a conflict-retry never double-counts.
 	tx.pendingDelta -= freed
+	for k, d := range quota {
+		tx.addQuota2(k, d)
+	}
 
 	return tx.txn.Delete(keyShare(shareName))
 }

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -221,6 +221,17 @@ type MemoryMetadataStore struct {
 	// Only regular files count toward usage; directories, symlinks, etc. do not.
 	usedBytes atomic.Int64
 
+	// userUsage / groupUsage track per-identity usage (bytes + file count) for
+	// regular files, keyed by owner uid / gid. Mirror of usedBytes but keyed by
+	// owner identity for per-user/per-group quota enforcement and reporting.
+	// Guarded by quotaMu (separate from s.mu so the GetQuotaUsage read path and
+	// the transaction commit-apply do not contend with unrelated metadata ops).
+	// Applied from a transaction's pending per-identity deltas exactly once on
+	// successful commit, identical to the usedBytes discipline.
+	quotaMu    sync.Mutex
+	userUsage  map[uint32]*metadata.UsageStat
+	groupUsage map[uint32]*metadata.UsageStat
+
 	// storeID is the engine-persistent identifier for this store instance.
 	// Assigned on construction with a fresh ULID and immutable for the life
 	// of the instance.
@@ -334,6 +345,9 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		rollupOffsets: make(map[string]uint64),
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
+		// per-identity quota usage counters.
+		userUsage:  make(map[uint32]*metadata.UsageStat),
+		groupUsage: make(map[uint32]*metadata.UsageStat),
 	}
 
 	return store
@@ -406,6 +420,21 @@ func NewMemoryMetadataStoreWithDefaults() *MemoryMetadataStore {
 // This is an O(1) atomic read, safe for concurrent access without locks.
 func (store *MemoryMetadataStore) GetUsedBytes() int64 {
 	return store.usedBytes.Load()
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) map read under quotaMu. A missing key returns a zero UsageStat.
+func (store *MemoryMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	store.quotaMu.Lock()
+	defer store.quotaMu.Unlock()
+	m := store.userUsage
+	if scope == metadata.QuotaScopeGroup {
+		m = store.groupUsage
+	}
+	if u, ok := m[id]; ok {
+		return *u, nil
+	}
+	return metadata.UsageStat{}, nil
 }
 
 // GetStoreID returns the engine-persistent store identifier. Assigned on

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -27,6 +27,37 @@ import (
 type memoryTransaction struct {
 	store        *MemoryMetadataStore
 	pendingDelta int64
+	// quotaDelta accumulates per-identity usage changes (bytes + file count)
+	// keyed by (scope, id). Applied to the store's userUsage/groupUsage maps
+	// exactly once after a successful commit, identical to pendingDelta.
+	quotaDelta map[quotaKey]metadata.UsageStat
+}
+
+// quotaKey identifies a per-identity usage bucket inside a transaction's
+// accumulated delta.
+type quotaKey struct {
+	scope metadata.QuotaScope
+	id    uint32
+}
+
+// addQuota records a usage delta for the file's owner identity (both user and
+// group scopes). bytes is the size delta; files is the inode delta (+1 create,
+// -1 delete, 0 for in-place size change).
+func (tx *memoryTransaction) addQuota(uid, gid uint32, bytes, files int64) {
+	if bytes == 0 && files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[quotaKey]metadata.UsageStat)
+	}
+	u := tx.quotaDelta[quotaKey{metadata.QuotaScopeUser, uid}]
+	u.Bytes += bytes
+	u.Files += files
+	tx.quotaDelta[quotaKey{metadata.QuotaScopeUser, uid}] = u
+	g := tx.quotaDelta[quotaKey{metadata.QuotaScopeGroup, gid}]
+	g.Bytes += bytes
+	g.Files += files
+	tx.quotaDelta[quotaKey{metadata.QuotaScopeGroup, gid}] = g
 }
 
 // txSnapshot captures the mutable state of the memory store so a failed
@@ -168,6 +199,35 @@ func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(t
 	if tx.pendingDelta != 0 {
 		store.usedBytes.Add(tx.pendingDelta)
 	}
+	// Apply per-identity usage deltas once, under quotaMu.
+	if len(tx.quotaDelta) > 0 {
+		store.quotaMu.Lock()
+		for k, d := range tx.quotaDelta {
+			m := store.userUsage
+			if k.scope == metadata.QuotaScopeGroup {
+				m = store.groupUsage
+			}
+			cur := m[k.id]
+			if cur == nil {
+				cur = &metadata.UsageStat{}
+				m[k.id] = cur
+			}
+			cur.Bytes += d.Bytes
+			cur.Files += d.Files
+			// Negative values indicate accounting drift (should never happen):
+			// clamp to zero so the enforcer never reads a too-permissive total.
+			if cur.Bytes < 0 {
+				cur.Bytes = 0
+			}
+			if cur.Files < 0 {
+				cur.Files = 0
+			}
+			if cur.Bytes == 0 && cur.Files == 0 {
+				delete(m, k.id)
+			}
+		}
+		store.quotaMu.Unlock()
+	}
 	return nil
 }
 
@@ -214,15 +274,38 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	attrCopy.ACL = cloneACL(file.ACL)
 	attrCopy.EAs = cloneEAs(file.EAs)
 
-	// Track size delta for regular files.
+	// Track size delta for regular files (store-wide counter) and per-identity
+	// usage. Handles three cases: new regular file (count +1, bytes +size),
+	// in-place size change (same owner, bytes delta), and chown (move
+	// bytes+count from old owner identity to new).
 	if file.Type == metadata.FileTypeRegular {
 		var oldSize uint64
+		var hadOldRegular bool
+		var oldUID, oldGID uint32
 		if existing, exists := tx.store.files[key]; exists && existing.Attr.Type == metadata.FileTypeRegular {
 			oldSize = existing.Attr.Size
+			oldUID = existing.Attr.UID
+			oldGID = existing.Attr.GID
+			hadOldRegular = true
 		}
 		// Accumulate into the tx-scoped pending delta; applied once after a
 		// successful commit so a rollback/retry never drifts the counter.
 		tx.pendingDelta += int64(file.Size) - int64(oldSize)
+
+		switch {
+		case !hadOldRegular:
+			// New regular file (create or type change to regular): charge full
+			// size + 1 inode to the new owner.
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		case oldUID == file.UID && oldGID == file.GID:
+			// Same owner: only the byte delta moves.
+			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+		default:
+			// Chown: remove old size + inode from the previous owner, add new
+			// size + inode to the new owner.
+			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		}
 	}
 
 	// Maintain ObjectID secondary index BEFORE overwriting
@@ -296,9 +379,13 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		}
 	}
 
-	// Subtract size from the pending delta for regular files.
-	if existing.Attr.Type == metadata.FileTypeRegular && existing.Attr.Size > 0 {
-		tx.pendingDelta -= int64(existing.Attr.Size)
+	// Subtract size from the pending delta for regular files and remove the
+	// inode + bytes from the owner's per-identity usage.
+	if existing.Attr.Type == metadata.FileTypeRegular {
+		if existing.Attr.Size > 0 {
+			tx.pendingDelta -= int64(existing.Attr.Size)
+		}
+		tx.addQuota(existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
 	}
 
 	// drop ObjectID secondary entry. The "only if mapped
@@ -644,9 +731,13 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 	// Remove all files belonging to this share
 	for key, fd := range tx.store.files {
 		if fd.ShareName == shareName {
-			// Subtract size from the pending delta for regular files.
-			if fd.Attr.Type == metadata.FileTypeRegular && fd.Attr.Size > 0 {
-				tx.pendingDelta -= int64(fd.Attr.Size)
+			// Subtract size from the pending delta for regular files and remove
+			// the inode + bytes from the owner's per-identity usage.
+			if fd.Attr.Type == metadata.FileTypeRegular {
+				if fd.Attr.Size > 0 {
+					tx.pendingDelta -= int64(fd.Attr.Size)
+				}
+				tx.addQuota(fd.Attr.UID, fd.Attr.GID, -int64(fd.Attr.Size), -1)
 			}
 			// drop ObjectID secondary entry too.
 			if fd.Attr != nil && !fd.Attr.ObjectID.IsZero() {

--- a/pkg/metadata/store/postgres/migrations/000033_quota_usage_indexes.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000033_quota_usage_indexes.down.sql
@@ -1,0 +1,4 @@
+-- Revert per-identity quota usage accounting indexes (#1151).
+
+DROP INDEX IF EXISTS idx_inodes_uid;
+DROP INDEX IF EXISTS idx_inodes_gid;

--- a/pkg/metadata/store/postgres/migrations/000033_quota_usage_indexes.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000033_quota_usage_indexes.up.sql
@@ -1,0 +1,18 @@
+-- Per-identity quota usage accounting indexes (#1151).
+--
+-- Per-user and per-group quotas track bytes + file-count for regular files,
+-- charged to the file owner (inodes.uid / inodes.gid). The metadata store seeds
+-- an in-memory per-identity usage cache at startup with two aggregate scans:
+--
+--   SELECT uid, SUM(size), COUNT(*) FROM inodes WHERE file_type = 0 GROUP BY uid
+--   SELECT gid, SUM(size), COUNT(*) FROM inodes WHERE file_type = 0 GROUP BY gid
+--
+-- These indexes keep that seed (and any future owner-scoped query) cheap on
+-- large datasets rather than forcing a full sequential scan + sort. The inodes
+-- table is the single source of truth for usage; the cache is reconstructed
+-- from it on every open, so no separate counter table is needed.
+--
+-- Runs after 000032 renamed files -> inodes.
+
+CREATE INDEX IF NOT EXISTS idx_inodes_uid ON inodes(uid) WHERE file_type = 0;
+CREATE INDEX IF NOT EXISTS idx_inodes_gid ON inodes(gid) WHERE file_type = 0;

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -60,6 +60,16 @@ type PostgresMetadataStore struct {
 	// Initialized from a SQL SUM query on startup.
 	usedBytes atomic.Int64
 
+	// userUsage / groupUsage track per-identity usage (bytes + file count) for
+	// regular files, keyed by owner uid / gid. In-memory cache mirroring
+	// usedBytes, seeded from a SQL GROUP BY query on startup (the files table is
+	// the source of truth, so it is always reconstructed correctly). Updated
+	// from a transaction's pending per-identity deltas exactly once on
+	// successful commit. Guarded by quotaMu.
+	quotaMu    sync.Mutex
+	userUsage  map[uint32]*metadata.UsageStat
+	groupUsage map[uint32]*metadata.UsageStat
+
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the server_config.store_id column. Created on first open
 	// (or after migration 000008 on an existing database) with a fresh
@@ -155,7 +165,12 @@ func (s *PostgresMetadataStore) GetUsedBytes() int64 {
 	return s.usedBytes.Load()
 }
 
-// initUsedBytesCounter initializes the atomic counter from a SQL SUM query.
+// initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
+// query and seeds the per-identity usage cache (userUsage / groupUsage) from
+// GROUP BY aggregates. Both are reconstructed from the inodes table (the source
+// of truth), so a store opened against an existing database is always seeded
+// correctly. The inodes(uid) / inodes(gid) indexes (migration 000033) keep the
+// GROUP BY scans cheap.
 func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 	query := `SELECT COALESCE(SUM(size), 0) FROM inodes WHERE file_type = $1`
 	var totalUsed int64
@@ -164,7 +179,98 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 		return fmt.Errorf("failed to query used bytes: %w", err)
 	}
 	s.usedBytes.Store(totalUsed)
+
+	userUsage, err := s.seedUsageByColumn(ctx, "uid")
+	if err != nil {
+		return err
+	}
+	groupUsage, err := s.seedUsageByColumn(ctx, "gid")
+	if err != nil {
+		return err
+	}
+	s.quotaMu.Lock()
+	s.userUsage = userUsage
+	s.groupUsage = groupUsage
+	s.quotaMu.Unlock()
 	return nil
+}
+
+// seedUsageByColumn aggregates per-identity usage (bytes + count) for regular
+// files grouped by the given owner column ("uid" or "gid"). The column name is
+// a fixed internal constant, never user input.
+func (s *PostgresMetadataStore) seedUsageByColumn(ctx context.Context, col string) (map[uint32]*metadata.UsageStat, error) {
+	query := fmt.Sprintf(
+		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1 GROUP BY %s`,
+		col, col,
+	)
+	rows, err := s.pool.Query(ctx, query, int(metadata.FileTypeRegular))
+	if err != nil {
+		return nil, fmt.Errorf("failed to seed %s usage: %w", col, err)
+	}
+	defer rows.Close()
+	out := make(map[uint32]*metadata.UsageStat)
+	for rows.Next() {
+		var id int64
+		var bytes, files int64
+		if err := rows.Scan(&id, &bytes, &files); err != nil {
+			return nil, fmt.Errorf("failed to scan %s usage: %w", col, err)
+		}
+		out[uint32(id)] = &metadata.UsageStat{Bytes: bytes, Files: files}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating %s usage: %w", col, err)
+	}
+	return out, nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
+func (s *PostgresMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	m := s.userUsage
+	if scope == metadata.QuotaScopeGroup {
+		m = s.groupUsage
+	}
+	if u, ok := m[id]; ok {
+		return *u, nil
+	}
+	return metadata.UsageStat{}, nil
+}
+
+// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
+// cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
+// below are removed.
+func (s *PostgresMetadataStore) applyQuotaDelta(delta map[pgQuotaKey]metadata.UsageStat) {
+	if len(delta) == 0 {
+		return
+	}
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	for k, d := range delta {
+		m := s.userUsage
+		if k.scope == metadata.QuotaScopeGroup {
+			m = s.groupUsage
+		}
+		cur := m[k.id]
+		if cur == nil {
+			cur = &metadata.UsageStat{}
+			m[k.id] = cur
+		}
+		cur.Bytes += d.Bytes
+		cur.Files += d.Files
+		// Negative values indicate accounting drift (should never happen):
+		// clamp to zero so the enforcer never reads a too-permissive total.
+		if cur.Bytes < 0 {
+			cur.Bytes = 0
+		}
+		if cur.Files < 0 {
+			cur.Files = 0
+		}
+		if cur.Bytes == 0 && cur.Files == 0 {
+			delete(m, k.id)
+		}
+	}
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -34,6 +34,52 @@ type postgresTransaction struct {
 	store        *PostgresMetadataStore
 	tx           pgx.Tx
 	pendingDelta int64
+	// quotaDelta accumulates per-identity usage changes (bytes + file count)
+	// keyed by (scope, id). Applied to the store's in-memory userUsage/
+	// groupUsage cache exactly once after a successful commit, identical to
+	// pendingDelta (so a serialization/deadlock retry never double-counts).
+	quotaDelta map[pgQuotaKey]metadata.UsageStat
+}
+
+// pgQuotaKey identifies a per-identity usage bucket inside a transaction's
+// accumulated delta.
+type pgQuotaKey struct {
+	scope metadata.QuotaScope
+	id    uint32
+}
+
+// addQuota records a usage delta for the file's owner identity (both user and
+// group scopes). See memory store addQuota for the create/resize/chown cases.
+func (tx *postgresTransaction) addQuota(uid, gid uint32, bytes, files int64) {
+	if bytes == 0 && files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[pgQuotaKey]metadata.UsageStat)
+	}
+	u := tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeUser, uid}]
+	u.Bytes += bytes
+	u.Files += files
+	tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeUser, uid}] = u
+	g := tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeGroup, gid}]
+	g.Bytes += bytes
+	g.Files += files
+	tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeGroup, gid}] = g
+}
+
+// addQuotaKeyed merges a single pre-keyed usage delta (used when folding the
+// per-identity totals freed by DeleteShare).
+func (tx *postgresTransaction) addQuotaKeyed(k pgQuotaKey, d metadata.UsageStat) {
+	if d.Bytes == 0 && d.Files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[pgQuotaKey]metadata.UsageStat)
+	}
+	cur := tx.quotaDelta[k]
+	cur.Bytes += d.Bytes
+	cur.Files += d.Files
+	tx.quotaDelta[k] = cur
 }
 
 // isRetryableError checks if a PostgreSQL error is retryable (deadlock or serialization failure)
@@ -121,6 +167,8 @@ func (s *PostgresMetadataStore) WithTransaction(ctx context.Context, fn func(tx 
 		if ptx.pendingDelta != 0 {
 			s.usedBytes.Add(ptx.pendingDelta)
 		}
+		// Apply per-identity usage deltas once, after commit.
+		s.applyQuotaDelta(ptx.quotaDelta)
 		return nil // Success
 	}
 
@@ -208,7 +256,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// RowsAffected()==0 check relied on.
 	updateQuery := `
 		WITH old AS (
-			SELECT id, share_name, size
+			SELECT id, share_name, size, uid, gid, file_type
 			FROM inodes
 			WHERE id = $21 AND share_name = $22
 			FOR UPDATE
@@ -236,7 +284,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			deleted_by = $20
 		FROM old
 		WHERE inodes.id = old.id AND inodes.share_name = old.share_name
-		RETURNING old.size
+		RETURNING old.size, old.uid, old.gid, old.file_type
 	`
 
 	var deviceMajor, deviceMinor *int32
@@ -304,6 +352,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// write. A returned row means the file existed (and we have its old size);
 	// pgx.ErrNoRows means it did not, so we fall through to INSERT.
 	var oldSizeVal sql.NullInt64
+	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
 	updated := true
 	scanErr := tx.tx.QueryRow(ctx, updateQuery,
 		file.Type, file.Mode, file.UID, file.GID, file.Size,
@@ -313,7 +362,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		file.Hidden, aclJSON, easJSON, objectIDArg,
 		deletedAtArg, file.OriginalPath, file.DeletedBy,
 		file.ID, file.ShareName,
-	).Scan(&oldSizeVal)
+	).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
 	switch {
 	case scanErr == nil:
 		// Row existed and was updated; oldSizeVal holds the pre-update size.
@@ -332,6 +381,22 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			oldSize = uint64(oldSizeVal.Int64)
 		}
 		tx.pendingDelta += int64(file.Size) - int64(oldSize)
+
+		// Per-identity usage. The previous row may not have been a regular file
+		// (type change), in which case it contributed nothing before.
+		oldWasRegular := oldTypeVal.Valid && metadata.FileType(oldTypeVal.Int64) == metadata.FileTypeRegular
+		oldUID := uint32(oldUIDVal.Int64)
+		oldGID := uint32(oldGIDVal.Int64)
+		switch {
+		case !oldWasRegular:
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		case oldUID == file.UID && oldGID == file.GID:
+			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+		default:
+			// Chown: move bytes + inode from old owner to new owner.
+			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		}
 	}
 
 	// If no rows were updated, the file doesn't exist - do an INSERT
@@ -361,8 +426,11 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		}
 
 		// Track new regular file size.
-		if file.Type == metadata.FileTypeRegular && file.Size > 0 {
-			tx.pendingDelta += int64(file.Size)
+		if file.Type == metadata.FileTypeRegular {
+			if file.Size > 0 {
+				tx.pendingDelta += int64(file.Size)
+			}
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
 		}
 
 		// Debug logging for new file inserts
@@ -400,13 +468,14 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		}
 	}
 
-	// Read size before deletion for counter tracking.
+	// Read size + owner before deletion for counter tracking.
 	var fileType int
 	var fileSize int64
+	var fileUID, fileGID int64
 	_ = tx.tx.QueryRow(ctx,
-		`SELECT file_type, size FROM inodes WHERE id = $1 AND share_name = $2`,
+		`SELECT file_type, size, uid, gid FROM inodes WHERE id = $1 AND share_name = $2`,
 		id, shareName,
-	).Scan(&fileType, &fileSize)
+	).Scan(&fileType, &fileSize, &fileUID, &fileGID)
 
 	// Delete the file. link_counts.file_id and parent_child_map.parent_id both
 	// declare ON DELETE CASCADE against inodes(id), so deleting the inode row
@@ -426,9 +495,12 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		}
 	}
 
-	// Subtract size from the pending delta for regular files.
-	if metadata.FileType(fileType) == metadata.FileTypeRegular && fileSize > 0 {
-		tx.pendingDelta -= fileSize
+	// Subtract size from the pending delta + per-identity usage for regular files.
+	if metadata.FileType(fileType) == metadata.FileTypeRegular {
+		if fileSize > 0 {
+			tx.pendingDelta -= fileSize
+		}
+		tx.addQuota(uint32(fileUID), uint32(fileGID), -fileSize, -1)
 	}
 
 	return nil
@@ -961,6 +1033,16 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 
+	// Capture per-identity usage about to be removed (uid + gid) so the
+	// in-memory usage cache stays accurate. Aggregated before the rows are
+	// deleted; applied to the tx quota delta (post-commit) below.
+	if err := tx.collectShareQuotaFreed(ctx, shareName, "uid", metadata.QuotaScopeUser); err != nil {
+		return err
+	}
+	if err := tx.collectShareQuotaFreed(ctx, shareName, "gid", metadata.QuotaScopeGroup); err != nil {
+		return err
+	}
+
 	// Drop the share row first: shares.root_file_id references inodes(id)
 	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while
 	// the share still points at the root inode.
@@ -992,6 +1074,34 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		tx.pendingDelta -= freedBytes
 	}
 
+	return nil
+}
+
+// collectShareQuotaFreed aggregates per-identity usage for the regular files of
+// a share being deleted (grouped by uid or gid) and records the negative delta
+// on the tx so the in-memory usage cache is decremented post-commit. The column
+// is a fixed internal constant, never user input.
+func (tx *postgresTransaction) collectShareQuotaFreed(ctx context.Context, shareName, col string, scope metadata.QuotaScope) error {
+	query := fmt.Sprintf(
+		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
+		 WHERE share_name = $1 AND file_type = $2 GROUP BY %s`,
+		col, col,
+	)
+	rows, err := tx.tx.Query(ctx, query, shareName, int(metadata.FileTypeRegular))
+	if err != nil {
+		return mapPgError(err, "DeleteShare", shareName)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, bytes, files int64
+		if err := rows.Scan(&id, &bytes, &files); err != nil {
+			return mapPgError(err, "DeleteShare", shareName)
+		}
+		tx.addQuotaKeyed(pgQuotaKey{scope, uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+	}
+	if err := rows.Err(); err != nil {
+		return mapPgError(err, "DeleteShare", shareName)
+	}
 	return nil
 }
 

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -23,6 +23,8 @@ func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
 	t.Run("DeleteShareViaTransaction", func(t *testing.T) { testDeleteShareViaTransaction(t, factory) })
 	t.Run("DuplicateCreateShare", func(t *testing.T) { testDuplicateCreateShare(t, factory) })
 	t.Run("GetUsedBytes", func(t *testing.T) { testGetUsedBytes(t, factory) })
+	t.Run("GetQuotaUsage", func(t *testing.T) { testGetQuotaUsage(t, factory) })
+	t.Run("GetQuotaUsageChown", func(t *testing.T) { testGetQuotaUsageChown(t, factory) })
 	t.Run("GetFileByPayloadID", func(t *testing.T) { testGetFileByPayloadID(t, factory) })
 	t.Run("FilesystemMetaStatsCaps", func(t *testing.T) { testFilesystemMetaStatsCaps(t, factory) })
 	t.Run("ServerConfigRoundTrip", func(t *testing.T) { testServerConfigRoundTrip(t, factory) })
@@ -323,6 +325,163 @@ func testGetUsedBytes(t *testing.T, factory StoreFactory) {
 	if got := store.GetUsedBytes(); got != 0 {
 		t.Fatalf("GetUsedBytes() = %d, want 0 after deleting the only file", got)
 	}
+}
+
+// createTestFileOwned creates a regular file owned by a specific uid/gid and a
+// given size, wiring parent/child/link-count like createTestFile. Used by the
+// per-identity quota usage conformance tests.
+func createTestFileOwned(t *testing.T, store metadata.Store, shareName string, dirHandle metadata.FileHandle, name string, uid, gid uint32, size uint64) metadata.FileHandle {
+	t.Helper()
+	ctx := t.Context()
+
+	fullPath := childFullPath(t, store, dirHandle, name)
+	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
+	if err != nil {
+		t.Fatalf("GenerateHandle() failed: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle() failed: %v", err)
+	}
+	file := &metadata.File{
+		ShareName: shareName,
+		Path:      fullPath,
+		ID:        id,
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+			UID:  uid,
+			GID:  gid,
+			Size: size,
+		},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() failed: %v", err)
+	}
+	if err := store.SetParent(ctx, handle, dirHandle); err != nil {
+		t.Fatalf("SetParent() failed: %v", err)
+	}
+	if err := store.SetChild(ctx, dirHandle, name, handle); err != nil {
+		t.Fatalf("SetChild() failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount() failed: %v", err)
+	}
+	return handle
+}
+
+func wantUsage(t *testing.T, store metadata.Store, scope metadata.QuotaScope, id uint32, wantBytes, wantFiles int64) {
+	t.Helper()
+	u, err := store.GetQuotaUsage(scope, id)
+	if err != nil {
+		t.Fatalf("GetQuotaUsage(%v, %d) failed: %v", scope, id, err)
+	}
+	if u.Bytes != wantBytes || u.Files != wantFiles {
+		t.Fatalf("GetQuotaUsage(%v, %d) = {Bytes:%d Files:%d}, want {Bytes:%d Files:%d}",
+			scope, id, u.Bytes, u.Files, wantBytes, wantFiles)
+	}
+}
+
+// testGetQuotaUsage verifies per-identity usage accounting (bytes + file count)
+// for both user and group scopes across create / grow / truncate / delete, and
+// that distinct owners are tracked independently. Directories must never count.
+func testGetQuotaUsage(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/quota-usage"
+	rootHandle := createTestShare(t, store, shareName)
+
+	// Fresh share: every identity reports zero.
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 0, 0)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 0, 0)
+
+	// uid=1000/gid=2000 creates a 500-byte file.
+	hA := createTestFileOwned(t, store, shareName, rootHandle, "a.bin", 1000, 2000, 500)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 500, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 500, 1)
+
+	// uid=1000/gid=2000 creates a second 300-byte file: bytes+count roll up.
+	createTestFileOwned(t, store, shareName, rootHandle, "b.bin", 1000, 2000, 300)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 800, 2)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 800, 2)
+
+	// A different owner (uid=1001/gid=2000) is tracked independently for the
+	// user scope; the shared gid rolls them together.
+	createTestFileOwned(t, store, shareName, rootHandle, "c.bin", 1001, 2000, 100)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 800, 2)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1001, 100, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 900, 3)
+
+	// A directory must not count toward any identity.
+	createTestDir(t, store, shareName, rootHandle, "subdir")
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 800, 2)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 900, 3)
+
+	// Grow a.bin from 500 to 900: only the byte counter for its owner moves.
+	setFileSize(t, store, hA, 900)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 1200, 2)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 1300, 3)
+
+	// Truncate a.bin down to 100: byte counter shrinks, count unchanged.
+	setFileSize(t, store, hA, 100)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 400, 2)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 500, 3)
+
+	// Delete a.bin: bytes+count removed from its owner.
+	if err := store.DeleteChild(ctx, rootHandle, "a.bin"); err != nil {
+		t.Fatalf("DeleteChild() failed: %v", err)
+	}
+	if err := store.DeleteFile(ctx, hA); err != nil {
+		t.Fatalf("DeleteFile() failed: %v", err)
+	}
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 300, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 400, 2)
+}
+
+// testGetQuotaUsageChown verifies that changing a regular file's UID/GID via
+// PutFile moves its bytes+count from the old identity to the new — the
+// easy-to-miss accounting event called out by #1151.
+func testGetQuotaUsageChown(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/quota-chown"
+	rootHandle := createTestShare(t, store, shareName)
+
+	handle := createTestFileOwned(t, store, shareName, rootHandle, "f.bin", 1000, 2000, 400)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 400, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 400, 1)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1001, 0, 0)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2001, 0, 0)
+
+	// Chown to uid=1001/gid=2001: usage moves wholesale.
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.UID = 1001
+	file.GID = 2001
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() chown failed: %v", err)
+	}
+	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 0, 0)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 0, 0)
+	wantUsage(t, store, metadata.QuotaScopeUser, 1001, 400, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2001, 400, 1)
+
+	// Chown only the gid (uid stays 1001): user scope unchanged, group moves.
+	file, err = store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.GID = 2002
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() gid-only chown failed: %v", err)
+	}
+	wantUsage(t, store, metadata.QuotaScopeUser, 1001, 400, 1)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2001, 0, 0)
+	wantUsage(t, store, metadata.QuotaScopeGroup, 2002, 400, 1)
 }
 
 // testGetFileByPayloadID verifies the flusher's content-id lookup: a file


### PR DESCRIPTION
Closes #1151

## Per-user / per-group quotas (full model)

Adds per-**user** (uid) and per-**group** (gid) storage quotas — **bytes + inodes**, scope user/group/default-user, **soft + hard with grace** — stored in the control-plane DB, managed via REST + `dfsctl`, and honored by **both NFS and SMB**. Complements the existing per-share `QuotaBytes`.

### B1 — Per-identity accounting (all 3 metadata backends)
- New `Store.GetQuotaUsage(scope, id) (UsageStat{Bytes,Files})`, mirroring `GetUsedBytes` but keyed by owner uid/gid (regular files only, charged to `FileAttr.UID/GID`).
- memory/badger/postgres update the per-identity counters transactionally alongside the existing size delta, applied **exactly once post-commit** (rollback/retry safe). Seeded at startup from the file rows (badger walk / postgres `GROUP BY`), so existing dumps are back-compatible.
- **Chown** (PutFile changing uid/gid) moves bytes+count between identities — covered by conformance tests.
- Postgres migration `000032` adds `files(uid)` / `files(gid)` partial indexes for the seed aggregates. (No separate counter table — the `files` table is the single source of truth, rebuilt into an in-memory cache on open, matching the existing `usedBytes` design.)

### B2 — Limits model + storage (DB + REST + CLI)
- New `Quota` GORM model + `QuotaStore` CRUD (upsert preserves a running grace timer; default-user keyed by NULL identity).
- REST: `GET/PUT/DELETE /api/v1/shares/{name}/quotas[/{scope}/{id}]` (RFC7807 errors, human-readable byte sizes), apiclient methods, and `dfsctl quota set/list/rm`.
- Limits loaded into `metadata.Service` as a hot-updatable map (parallel to `SetQuotaForShare`); Runtime loads them at `AddShare` and pushes hot updates.

### B3 — Enforcement (bytes + inodes, soft/hard/grace)
- `PrepareWrite` checks the file owner's user+group **byte** quota; the create path checks the per-owner **inode** quota.
- soft→grace→hard state machine persists `grace_started_at` back to the control plane (survives restart).
- Breach returns the existing `ErrQuotaExceeded` → NFS3/NFS4 **DQUOT** and SMB **STATUS_QUOTA_EXCEEDED** (new NT status `0xC0000044`), distinct from `ErrNoSpace` (ENOSPC / DISK_FULL).

### B4 — Adapter reporting
- `GetFilesystemStatisticsForIdentity` narrows FSSTAT total/available to the smallest of share/user/group quota using the caller's own usage. Threaded through NFS3 FSSTAT, NFS4 GETATTR space attrs, and SMB FileFsSize/FullSize.

### B5 — Tests
- Conformance (all 3 backends): per-uid/gid usage across create/grow/truncate/delete, group rollups, and chown-moves-bytes+count.
- Enforcement: hard block, inode cap, default-user fallthrough, group quota, soft→grace→hard, other-user-unaffected; FSSTAT overlay; DQUOT/STATUS_QUOTA_EXCEEDED mapping.

### Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test -race ./pkg/metadata/... ./internal/adapter/... ./pkg/controlplane/... ./internal/controlplane/...` green.
- Postgres **integration conformance** (`-tags integration` + `-race`, real PG via Docker) green — incl. the new `GetQuotaUsage`/chown cases and migration 000032 (verified `idx_files_uid`/`idx_files_gid` created).

### Notes
- **Kubernetes operator**: the operator manages infrastructure only — there is **no Share/Quota CRD**. The "operator CRD" acceptance criterion is satisfied via REST/CLI + docs (`docs/CONFIGURATION.md`), as agreed. No CRD field work.
- Enforcement is best-effort (matching the existing per-share soft quota): under high write concurrency a few ops may briefly exceed a limit until usage catches up — standard for userspace NFS/SMB.
