### PR TITLE
chore(schedule): drop dead FormatInterval; fix package doc

### DIFF
--- a/pkg/schedule/interval.go
+++ b/pkg/schedule/interval.go
@@ -1,7 +1,7 @@
-// Package schedule provides cadence parsing helpers shared by the snapshot
-// policy server-side validation and the dfsctl CLI. It deliberately supports
-// only a minimal surface: Go duration strings plus a few @-shorthands. No cron
-// expressions (DittoFS has no cron dependency and is single-node, pre-1.0).
+// Package schedule provides the snapshot cadence parser used by the snapshot
+// policy server-side validation. It deliberately supports only a minimal
+// surface: Go duration strings plus a few @-shorthands. No cron expressions
+// (DittoFS has no cron dependency and is single-node, pre-1.0).
 package schedule
 
 import (
@@ -41,9 +41,4 @@ func ParseInterval(s string) (time.Duration, error) {
 		return 0, fmt.Errorf("schedule: interval must be positive, got %q", s)
 	}
 	return d, nil
-}
-
-// FormatInterval renders a duration for display as a Go duration string.
-func FormatInterval(d time.Duration) string {
-	return d.String()
 }

--- a/pkg/schedule/interval_test.go
+++ b/pkg/schedule/interval_test.go
@@ -44,11 +44,3 @@ func TestParseInterval(t *testing.T) {
 		})
 	}
 }
-
-func TestFormatInterval(t *testing.T) {
-	// FormatInterval is the inverse used for display; it returns the Go
-	// duration string (shorthands are an input convenience only).
-	if got := FormatInterval(24 * time.Hour); got != "24h0m0s" {
-		t.Errorf("FormatInterval(24h) = %q, want 24h0m0s", got)
-	}
-}


### PR DESCRIPTION
Follow-up cleanup after the snapshot scheduler (#1185, PR #1190).

## What
- Remove `schedule.FormatInterval` — dead code, referenced only by its own test. Call sites use `time.Duration.String()` directly.
- Fix `pkg/schedule` package doc: it claimed the parser is shared with the dfsctl CLI, but only the snapshot-policy REST handler calls `ParseInterval` (CLI passes the interval string straight through; server validates).

## Why
Audit of the merged scheduler feature found the function unused. No behavior change.

## Verification
- `go build ./...` ✅
- `go vet` ✅ (schedule, snapshotsched, runtime, handlers)
- `go test ./pkg/schedule/` ✅