### PR TITLE
perf(postgres): collapse GetFile block-ref read into one round-trip (#1176)

### DIFF
--- a/pkg/metadata/store/postgres/config.go
+++ b/pkg/metadata/store/postgres/config.go
@@ -36,7 +36,15 @@ type PostgresMetadataStoreConfig struct {
 
 // ApplyDefaults sets default values for unspecified configuration fields
 func (c *PostgresMetadataStoreConfig) ApplyDefaults() {
-	// Connection pool defaults (conservative sizing)
+	// Connection pool defaults (conservative sizing).
+	//
+	// #1176 assessment: under the metadata read workload the pool is not the
+	// bottleneck — at 8 concurrent workers MaxConns=10 lets the pool warm to
+	// ~8 live connections and scales throughput ~3.8x over a single worker,
+	// with cold-acquire cost confined to the first burst (idle connections are
+	// retained for MaxConnIdleTime, default 30m). The per-op win came from
+	// cutting round-trips, not from resizing the pool, so these conservative
+	// defaults are kept as-is.
 	if c.MaxConns == 0 {
 		c.MaxConns = 10
 	}

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -65,6 +66,19 @@ func pgNanosToTime(n int64) time.Time {
 // as a reconstructed expression (inodePathExpr) walking parent_child_map up to
 // the share root. For a hard-linked inode this yields one of its paths.
 func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
+	return fileRowToFileWithNlinkAndBlocks(row, false)
+}
+
+// fileRowToFileWithNlinkAndBlocks decodes a file row that optionally carries a
+// trailing blocks column. When withBlocks is true the SELECT list MUST append
+// blockRefsAggExpr as its final column; the row's FileAttr.Blocks is then
+// hydrated in the same round-trip rather than via a second loadFileBlockRefs
+// query (#1176). With withBlocks=false this is identical to the pre-#1176 read.
+//
+// The folded aggregate is ordered by "offset" ASC and decoded into the same
+// []block.BlockRef shape loadFileBlockRefs produces — an empty/absent set
+// (directories, symlinks, blockless regular files) yields a nil slice.
+func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.File, error) {
 	var (
 		id           uuid.UUID
 		shareName    string
@@ -90,9 +104,10 @@ func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 		originalPath string
 		deletedBy    string
 		linkCount    sql.NullInt32
+		blocksJSON   []byte
 	)
 
-	err := row.Scan(
+	dest := []any{
 		&id,
 		&shareName,
 		&path,
@@ -117,8 +132,12 @@ func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 		&originalPath,
 		&deletedBy,
 		&linkCount,
-	)
-	if err != nil {
+	}
+	if withBlocks {
+		dest = append(dest, &blocksJSON)
+	}
+
+	if err := row.Scan(dest...); err != nil {
 		return nil, err
 	}
 
@@ -201,5 +220,81 @@ func fileRowToFileWithNlink(row pgx.Row) (*metadata.File, error) {
 	file.OriginalPath = originalPath
 	file.DeletedBy = deletedBy
 
+	// Folded block refs (#1176): when the SELECT appended blockRefsAggExpr,
+	// hydrate FileAttr.Blocks from that aggregate rather than a second query.
+	if withBlocks && len(blocksJSON) > 0 {
+		blocks, err := decodeBlockRefsJSON(blocksJSON)
+		if err != nil {
+			return nil, err
+		}
+		file.Blocks = blocks
+	}
+
 	return file, nil
+}
+
+// blockRefsAggExpr is a correlated scalar subquery aggregating a file's
+// file_block_refs rows into a single JSON array, ordered by "offset" ASC to
+// match loadFileBlockRefs. Splice it as the FINAL column of
+// a SELECT whose inode row is aliased `f` (it references f.id) and decode the
+// result with fileRowToFileWithNlinkAndBlocks(row, true).
+//
+// Each element is [offset, size, hash_hex]; hash is encode(...,'hex') so the
+// BYTEA round-trips byte-for-byte. An inode with no refs yields SQL NULL, which
+// decodes to a nil slice (parity with loadFileBlockRefs on an empty set).
+const blockRefsAggExpr = `(
+	SELECT json_agg(
+		json_build_array(fbr."offset", fbr.size, encode(fbr.hash, 'hex'))
+		ORDER BY fbr."offset" ASC
+	)
+	FROM file_block_refs fbr
+	WHERE fbr.file_id = f.id
+)`
+
+// decodeBlockRefsJSON decodes the JSON array produced by blockRefsAggExpr into
+// []block.BlockRef, applying the same hash-length validation as
+// loadFileBlockRefs (a malformed hash is surfaced as an error, never coerced to
+// a half-decoded ref).
+func decodeBlockRefsJSON(raw []byte) ([]block.BlockRef, error) {
+	// Element shape: [offset(int64), size(int32), hash_hex(string)].
+	var rows [][3]json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil, fmt.Errorf("decode folded block refs: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	out := make([]block.BlockRef, 0, len(rows))
+	for _, r := range rows {
+		var (
+			off     int64
+			sz      int32
+			hashHex string
+		)
+		if err := json.Unmarshal(r[0], &off); err != nil {
+			return nil, fmt.Errorf("decode folded block ref offset: %w", err)
+		}
+		if err := json.Unmarshal(r[1], &sz); err != nil {
+			return nil, fmt.Errorf("decode folded block ref size: %w", err)
+		}
+		if err := json.Unmarshal(r[2], &hashHex); err != nil {
+			return nil, fmt.Errorf("decode folded block ref hash: %w", err)
+		}
+		rawHash, err := hex.DecodeString(hashHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode folded block ref hash hex: %w", err)
+		}
+		if len(rawHash) != block.HashSize {
+			return nil, fmt.Errorf(
+				"folded block ref hash has unexpected length %d (want %d)",
+				len(rawHash), block.HashSize,
+			)
+		}
+		var br block.BlockRef
+		copy(br.Hash[:], rawHash)
+		br.Offset = uint64(off)
+		br.Size = uint32(sz)
+		out = append(out, br)
+	}
+	return out, nil
 }

--- a/pkg/metadata/store/postgres/file_block_refs.go
+++ b/pkg/metadata/store/postgres/file_block_refs.go
@@ -53,50 +53,6 @@ func putFileBlockRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks [
 	return nil
 }
 
-// getFileBlockRefs returns all rows for fileID ordered by offset ASC.
-// Returns nil (no error) if no rows exist.
-//
-// Used by GetFile to populate FileAttr.Blocks. The covering index
-// (PRIMARY KEY ... INCLUDE(size, hash)) means this is index-only; no
-// heap fetch on the cold-cache read path.
-func getFileBlockRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID) ([]block.BlockRef, error) {
-	rows, err := tx.Query(ctx,
-		`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1 ORDER BY "offset" ASC`,
-		fileID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
-	}
-	defer rows.Close()
-
-	var out []block.BlockRef
-	for rows.Next() {
-		var off int64
-		var sz int32
-		var raw []byte
-		if err := rows.Scan(&off, &sz, &raw); err != nil {
-			return nil, fmt.Errorf("scan file_block_ref: %w", err)
-		}
-		// T-12-06 mitigation: never coerce a malformed BYTEA hash to a
-		// half-decoded BlockRef — surface the error explicitly.
-		if len(raw) != block.HashSize {
-			return nil, fmt.Errorf(
-				"file_block_refs.hash for %s/%d has unexpected length %d (want %d)",
-				fileID, off, len(raw), block.HashSize,
-			)
-		}
-		var br block.BlockRef
-		copy(br.Hash[:], raw)
-		br.Offset = uint64(off)
-		br.Size = uint32(sz)
-		out = append(out, br)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate file_block_refs: %w", err)
-	}
-	return out, nil
-}
-
 // deleteFileBlockRefs removes all rows for fileID. The FK cascade
 // handles this automatically when the files row is deleted; this helper
 // is exposed for callers that pre-clear refs without dropping the row.
@@ -112,9 +68,10 @@ func deleteFileBlockRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID) error
 	return nil
 }
 
-// loadFileBlockRefs loads all rows for fileID via the pool (not a tx).
-// Used by GetFile, which intentionally avoids a tx for read performance.
-// Same SQL as getFileBlockRefs but routed through the store's pool helper.
+// loadFileBlockRefs loads all rows for fileID via the pool (not a tx),
+// ordered by offset ASC; returns a nil slice when no rows exist.
+// Used by FindByObjectID. GetFile no longer calls this — it folds the same
+// rows into its metadata read via blockRefsAggExpr (#1176).
 func (s *PostgresMetadataStore) loadFileBlockRefs(ctx context.Context, fileID uuid.UUID) ([]block.BlockRef, error) {
 	rows, err := s.query(ctx,
 		`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1 ORDER BY "offset" ASC`,

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -38,6 +38,11 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 		}
 	}
 
+	// Fold FileAttr.Blocks into the metadata read via a correlated aggregate
+	// (#1176): one round-trip instead of the metadata SELECT plus a separate
+	// loadFileBlockRefs. blockRefsAggExpr yields NULL for directories,
+	// symlinks, and blockless files, so the decoded slice stays nil for them —
+	// byte-identical to the prior two-query behaviour.
 	query := `
 		SELECT
 			f.id, f.share_name, ` + inodePathExpr + `,
@@ -45,26 +50,17 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+			f.deleted_at, f.original_path, f.deleted_by, lc.link_count,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
 
 	row := s.queryRow(ctx, query, id, shareName)
-	file, err := fileRowToFileWithNlink(row)
+	file, err := fileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapPgError(err, "GetFile", "")
-	}
-
-	// load FileAttr.Blocks from file_block_refs.
-	// Only regular files carry BlockRef payloads; directories/symlinks have none.
-	if file.Type == metadata.FileTypeRegular {
-		blocks, err := s.loadFileBlockRefs(ctx, id)
-		if err != nil {
-			return nil, mapPgError(err, "GetFile", "load blocks")
-		}
-		file.Blocks = blocks
 	}
 
 	return file, nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -193,6 +193,9 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 		}
 	}
 
+	// Fold FileAttr.Blocks into the metadata read (#1176): one round-trip
+	// instead of the SELECT plus a separate getFileBlockRefs. See GetFile
+	// (pool path) and blockRefsAggExpr for the equivalence rationale.
 	query := `
 		SELECT
 			f.id, f.share_name, ` + inodePathExpr + `,
@@ -200,25 +203,17 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+			f.deleted_at, f.original_path, f.deleted_by, lc.link_count,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
 
 	row := tx.tx.QueryRow(ctx, query, id, shareName)
-	file, err := fileRowToFileWithNlink(row)
+	file, err := fileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapPgError(err, "GetFile", "")
-	}
-
-	// load FileAttr.Blocks inside the same tx.
-	if file.Type == metadata.FileTypeRegular {
-		blocks, err := getFileBlockRefs(ctx, tx.tx, id)
-		if err != nil {
-			return nil, mapPgError(err, "GetFile", "load blocks")
-		}
-		file.Blocks = blocks
 	}
 
 	// Debug logging to trace file type issues


### PR DESCRIPTION
## What

Unconditional postgres metadata read perf: collapse `GetFile`'s two round-trips into one. Per the #1169/#1172 measurements, postgres reads are round-trip-bound (point lookups already, prepared-statements made no difference), so the win is shaving per-op round-trips — benefits every postgres deployment with **zero invalidation risk and zero behavior change**.

This is the unconditional slice of the #1166/#1176/#1173 cluster. The `files`→`inodes` schema decouple (#1166 PR-1) already merged; this PR touches **queries only** — no schema migration, no path-CTE change, no `link_counts` JOIN change, no `ListChildren` change, no caching surface.

## The collapse

`GetFile` previously ran the inode metadata `SELECT` (with the `inodePathExpr` path CTE + `link_counts` JOIN), then a **second** query `loadFileBlockRefs` for regular files. Both are now one round-trip: a correlated `json_agg` subquery (`blockRefsAggExpr`) folds the `file_block_refs` rows into the metadata read, ordered `ORDER BY fbr."offset" ASC` to match `loadFileBlockRefs` exactly. Hashes are `encode(hash,'hex')` in SQL and `hex.DecodeString` in Go, so the 32-byte BYTEA round-trips byte-for-byte. Applied to **both** the pool-path `GetFile` and the transaction-path `GetFile`.

Result is byte-identical to today for every case:
- regular files with blocks — same offset-ordered `[]BlockRef`, same hash bytes;
- blockless regular files / directories / symlinks — `json_agg` over an empty set is SQL `NULL` → `file.Blocks` stays `nil` (parity with the old type-gated skip).

`GetFileByPayloadID` (pool + tx) already did a single round-trip (it never loaded block refs), so it is unchanged. The now-dead `getFileBlockRefs` tx helper is removed; `loadFileBlockRefs` stays (still used by `FindByObjectID`).

## Connection-pool finding

Assessed `max_conns`/`min_conns` (defaults 10/3). Under the metadata read workload the pool is **not** the bottleneck — at 8 concurrent workers `MaxConns=10` warms to ~8 live connections and scales throughput ~3.8× over a single worker, with cold-acquire cost confined to the first burst (idle conns retained for `MaxConnIdleTime`, default 30m). The per-op win came from cutting round-trips, not pool size. **Defaults retained**; the rationale is documented in `config.go` rather than inventing a knob.

## Before/after (`dfsbench metadata`, postgres:16 on loopback)

40,000 ops, seed 7, dirs 16, files-per-dir 256, prepared statements on. baseline = `origin/develop`, branch = this PR. Same DB, same params.

| workload | workers | metric | baseline | branch | delta |
|---|---|---|---|---|---|
| getattr | 1 | p50 | 392–400 µs | 214–222 µs | **~1.8× faster** |
| getattr | 1 | ops/sec | 2451–2513 | 4366–4571 | **~1.8×** |
| getattr | 8 | p50 | 827 µs | 438 µs | **~1.9×** |
| getattr | 8 | ops/sec | 9427 | 17574 | **~1.86×** |
| mixed | 1 | p50 | 369 µs | 241 µs | ~1.5× |
| mixed | 8 | ops/sec | 9490 | 12379 | ~1.3× |

`getattr` (pure `GetFile`) is the direct target — round-trips halved → p50 roughly halved, throughput ~1.8×, stable across re-runs. `mixed` (45% getattr / 45% lookup / 10% readdir) improves proportionally to its getattr share.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean.
- Postgres conformance green (fresh `dittofs_test`):
  `go test -tags integration ./pkg/metadata/store/postgres/... ./pkg/metadata/...` → all `ok`.
- The collapse-guarding tests pass: `TestPostgres_FileBlockRefs_BlocksRoundTrip`, `…_ReplaceFully`, `…_CascadeDelete`, `…_ConcurrentPutFile`, `TestBlockLayoutConformance` (CAS/legacy round-trips), `TestPostgres_Restore_ReconcilesNullHashFileBlocks`.
- code-simplifier + code-reviewer run; reviewer explicitly confirmed identical BlockRef ordering and content (ORDER BY, hash byte fidelity, nil-vs-empty semantics, type-gate removal, int decode) across all four cases.

Closes #1176
