### PR TITLE
feat(metadata): derive File.Path on read across all backends (#1166 PR-2)

### DIFF
--- a/pkg/metadata/batcha_test.go
+++ b/pkg/metadata/batcha_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBatchA_Move_DescendantPathUpdate verifies that a directory rename updates
-// the persisted Path of descendant files. The fix propagates tx.PutFile errors
-// inside updateDescendantPaths instead of silently discarding them; this
-// regression guard confirms the success path persists the new descendant path.
+// TestBatchA_Move_DescendantPathUpdate verifies that a descendant file's
+// derived Path reflects a renamed ancestor directory. File.Path is no longer
+// stored or rewritten on rename (#1166): every backend reconstructs it on read
+// from the namespace edges, so a parent-directory rename is observed by the
+// child's next GetFile without any explicit path-update pass.
 func TestBatchA_Move_DescendantPathUpdate(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -787,27 +786,18 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 			}
 		}
 
-		// Update path and timestamps. PutFile(srcFile) is tx-critical: a stale
-		// File.Path breaks the Path-keyed postgres snapshot/restore and the
-		// descendant-path rewrite below. Return the error so a failure rolls
-		// the whole rename back rather than committing a relinked entry with
-		// the old Path.
+		// Bump ctime on the renamed inode. The namespace edge has already been
+		// relinked above (DeleteChild/SetChild/SetParent); File.Path is no
+		// longer stored — every backend derives it on read from the
+		// parent_child_map / parent edges (#1166), so a rename just moves the
+		// edge and the new path is reconstructed fresh on the next GetFile.
+		// This is what makes hard links correct: renaming one name can never
+		// stale another name's path. PutFile is tx-critical: a failed ctime
+		// write must roll the whole rename back.
 		now := time.Now()
-		oldPath := srcFile.Path
-		srcFile.Path = destPath
 		srcFile.Ctime = now
 		if err := tx.PutFile(ctx.Context, srcFile); err != nil {
 			return err
-		}
-
-		// For directory renames, recursively update all descendants' paths.
-		// Propagate the error: a partial descendant rewrite leaves stale
-		// child Paths that diverge from the parent, corrupting the Path-keyed
-		// postgres namespace. Roll the rename back instead.
-		if srcFile.Type == FileTypeDirectory {
-			if err := s.updateDescendantPaths(ctx.Context, tx, srcHandle, oldPath, destPath); err != nil {
-				return err
-			}
 		}
 
 		srcDir.Mtime = now
@@ -841,55 +831,6 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	}
 
 	return rename, nil
-}
-
-// updateDescendantPaths recursively updates the Path field of all descendants
-// of a renamed directory. Uses iterative (queue-based) traversal to avoid
-// stack overflow on deep trees.
-func (s *Service) updateDescendantPaths(ctx context.Context, tx Transaction, dirHandle FileHandle, oldPrefix, newPrefix string) error {
-	queue := []FileHandle{dirHandle}
-
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-
-		cursor := ""
-		for {
-			entries, nextCursor, err := tx.ListChildren(ctx, current, cursor, 100)
-			if err != nil {
-				return fmt.Errorf("list children for path update: %w", err)
-			}
-
-			for _, entry := range entries {
-				child, err := tx.GetFile(ctx, entry.Handle)
-				if err != nil {
-					logger.Debug("updateDescendantPaths: skip unreadable child",
-						"name", entry.Name, "error", err)
-					continue
-				}
-
-				// Replace old path prefix with new prefix
-				if strings.HasPrefix(child.Path, oldPrefix) {
-					child.Path = newPrefix + child.Path[len(oldPrefix):]
-					if err := tx.PutFile(ctx, child); err != nil {
-						return fmt.Errorf("update path for %s: %w", child.Path, err)
-					}
-				}
-
-				// Enqueue subdirectories for recursive traversal
-				if child.Type == FileTypeDirectory {
-					queue = append(queue, entry.Handle)
-				}
-			}
-
-			if nextCursor == "" {
-				break
-			}
-			cursor = nextCursor
-		}
-	}
-
-	return nil
 }
 
 // MarkFileAsOrphaned sets a file's link count to 0, marking it as orphaned.

--- a/pkg/metadata/store/badger/badger_conformance_test.go
+++ b/pkg/metadata/store/badger/badger_conformance_test.go
@@ -120,6 +120,95 @@ func TestBadgerStore_CleanShutdownMarkerDurable(t *testing.T) {
 	require.NoError(t, s2.Close())
 }
 
+// TestBadgerStore_DerivePathReverseIndex pins the cn:<parent>:<child> reverse
+// index used by derivePath (#1166): after cross-directory moves, a parent-dir
+// rename, and delete+recreate of a name, GetFile must always return the current
+// derived path and never a stale name left behind by the previous edge. A
+// regression in reverse-index maintenance (a leftover or un-repointed cn: key)
+// surfaces here as a wrong or empty derived path.
+func TestBadgerStore_DerivePathReverseIndex(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	shareName := "/rev"
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	mkChild := func(parent metadata.FileHandle, name string, dir bool) metadata.FileHandle {
+		h, err := store.GenerateHandle(ctx, shareName, "/"+name)
+		require.NoError(t, err)
+		_, id, err := metadata.DecodeFileHandle(h)
+		require.NoError(t, err)
+		typ := metadata.FileTypeRegular
+		if dir {
+			typ = metadata.FileTypeDirectory
+		}
+		require.NoError(t, store.PutFile(ctx, &metadata.File{
+			ID: id, ShareName: shareName,
+			FileAttr: metadata.FileAttr{
+				Type: typ, Mode: 0o644,
+				Mtime: now, Ctime: now, Atime: now, CreationTime: now,
+			},
+		}))
+		require.NoError(t, store.SetParent(ctx, h, parent))
+		require.NoError(t, store.SetChild(ctx, parent, name, h))
+		return h
+	}
+
+	// Build /dirA/file and a sibling /dirB.
+	dirA := mkChild(rootHandle, "dirA", true)
+	dirB := mkChild(rootHandle, "dirB", true)
+	fileH := mkChild(dirA, "file", false)
+
+	got, err := store.GetFile(ctx, fileH)
+	require.NoError(t, err)
+	assert.Equal(t, "/dirA/file", got.Path, "initial derived path")
+
+	// Cross-directory move /dirA/file -> /dirB/moved: repoints the parent edge
+	// AND the reverse name edge. A stale cn: entry would surface the old name.
+	require.NoError(t, store.DeleteChild(ctx, dirA, "file"))
+	require.NoError(t, store.SetChild(ctx, dirB, "moved", fileH))
+	require.NoError(t, store.SetParent(ctx, fileH, dirB))
+
+	got, err = store.GetFile(ctx, fileH)
+	require.NoError(t, err)
+	assert.Equal(t, "/dirB/moved", got.Path, "derived path after cross-dir move")
+
+	// Rename the parent directory dirB -> dirC; the descendant's path must
+	// reflect it on read with no per-descendant writes.
+	require.NoError(t, store.DeleteChild(ctx, rootHandle, "dirB"))
+	require.NoError(t, store.SetChild(ctx, rootHandle, "dirC", dirB))
+
+	got, err = store.GetFile(ctx, fileH)
+	require.NoError(t, err)
+	assert.Equal(t, "/dirC/moved", got.Path, "descendant path after parent-dir rename")
+
+	// Delete the "moved" name, then recreate a NEW file under the same name in
+	// the same directory. The new inode must derive /dirC/moved — never inherit
+	// a stale reverse edge from the deleted inode.
+	require.NoError(t, store.DeleteChild(ctx, dirB, "moved"))
+	fresh := mkChild(dirB, "moved", false)
+	require.NotEqual(t, string(fresh), string(fileH))
+	got, err = store.GetFile(ctx, fresh)
+	require.NoError(t, err)
+	assert.Equal(t, "/dirC/moved", got.Path, "recreated name derives its own path, no stale resurface")
+
+	// The original (now unlinked) inode has no parent edge left, so it derives
+	// the root sentinel rather than a stale name.
+	got, err = store.GetFile(ctx, fileH)
+	require.NoError(t, err)
+	assert.Equal(t, "/", got.Path, "unlinked inode derives '/' (no stale reverse edge)")
+}
+
 func TestBadgerStore_PutGetFile_BlocksRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "metadata.db")

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -45,6 +45,7 @@ const (
 	prefixFile         = "f:"
 	prefixParent       = "p:"
 	prefixChild        = "c:"
+	prefixChildName    = "cn:" // (parentUUID, childUUID) -> child name (reverse edge)
 	prefixShare        = "s:"
 	prefixLinkCount    = "l:"
 	prefixDeviceNumber = "d:"
@@ -75,6 +76,22 @@ func keyChild(parentID uuid.UUID, childName string) []byte {
 // keyChildPrefix generates a key prefix for range scanning children: "c:<parentUUID>:"
 func keyChildPrefix(parentID uuid.UUID) []byte {
 	return []byte(prefixChild + parentID.String() + ":")
+}
+
+// keyChildName generates the reverse-edge key "cn:<parentUUID>:<childUUID>"
+// whose value is the name under which child is linked into parent. It gives
+// derivePath an O(1) child->name lookup instead of scanning every c:<parent>:*
+// entry per path component (#1166). One key exists per directed (parent, child)
+// edge, so a hard link to a different directory writes a distinct key and never
+// disturbs the canonical parent's edge.
+func keyChildName(parentID, childID uuid.UUID) []byte {
+	return []byte(prefixChildName + parentID.String() + ":" + childID.String())
+}
+
+// keyChildNamePrefix generates a key prefix for range scanning a directory's
+// reverse edges: "cn:<parentUUID>:"
+func keyChildNamePrefix(parentID uuid.UUID) []byte {
+	return []byte(prefixChildName + parentID.String() + ":")
 }
 
 // keyShare generates a key for share configuration: "s:<shareName>"
@@ -119,6 +136,15 @@ type shareData struct {
 // ============================================================================
 
 func encodeFile(file *metadata.File) ([]byte, error) {
+	// Path is always derived from parent edges on read (#1166), never trusted
+	// from storage. Zero it before serializing so no badger row persists a
+	// stale/misleading path (e.g. the pre-move path on a rename). decodeFile
+	// tolerates the absent field; GetFile overwrites Path via derivePath.
+	if file.Path != "" {
+		clone := *file
+		clone.Path = ""
+		file = &clone
+	}
 	bytes, err := json.Marshal(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode file: %w", err)

--- a/pkg/metadata/store/badger/encoding_test.go
+++ b/pkg/metadata/store/badger/encoding_test.go
@@ -69,9 +69,16 @@ func TestBadgerEncodeFile_BlocksRoundTrip(t *testing.T) {
 	// Non-Blocks fields preserved.
 	assert.Equal(t, original.ID, decoded.ID)
 	assert.Equal(t, original.ShareName, decoded.ShareName)
-	assert.Equal(t, original.Path, decoded.Path)
 	assert.Equal(t, original.Size, decoded.Size)
 	assert.Equal(t, original.Mode, decoded.Mode)
+
+	// Path is intentionally NOT persisted (#1166): it is always derived from
+	// parent edges on read, so encodeFile zeroes it before serializing. This
+	// prevents a stale stored path (e.g. the pre-move path on a rename) from
+	// ever landing on disk. decodeFile tolerates the empty field; GetFile
+	// overwrites Path via derivePath. The caller's struct is not mutated.
+	assert.Empty(t, decoded.Path, "encodeFile must not persist File.Path")
+	assert.Equal(t, "/foo.bin", original.Path, "encodeFile must not mutate the caller's File")
 }
 
 // TestBadgerEncodeFile_LegacyBlobNoBlocks asserts that a

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -98,6 +98,10 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 							file.Nlink = 1
 						}
 					}
+					// Derive Path from the parent keyspace (#1166) so a
+					// rename/relink can never surface a stale stored path.
+					btx := &badgerTransaction{store: s, txn: txn}
+					file.Path = btx.derivePath(file.ID)
 					result = file
 					return errFound
 				}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -382,19 +382,25 @@ func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHa
 	return nil
 }
 
-// deleteChildEntries removes every c:<parentID>:<name> mapping under a
-// directory. Collects keys under the held txn iterator first, then deletes,
-// to avoid mutating keys out from under the iterator.
+// deleteChildEntries removes every c:<parentID>:<name> forward mapping and the
+// matching cn:<parentID>:<child> reverse mapping under a directory. Collects
+// keys under the held txn iterator first, then deletes, to avoid mutating keys
+// out from under the iterator.
 func deleteChildEntries(txn *badgerdb.Txn, parentID uuid.UUID) error {
-	prefix := keyChildPrefix(parentID)
-	opts := badgerdb.DefaultIteratorOptions
-	opts.PrefetchValues = false
-	it := txn.NewIterator(opts)
-	var keys [][]byte
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-		keys = append(keys, it.Item().KeyCopy(nil))
+	prefixes := [][]byte{
+		keyChildPrefix(parentID),
+		keyChildNamePrefix(parentID),
 	}
-	it.Close()
+	var keys [][]byte
+	for _, prefix := range prefixes {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			keys = append(keys, it.Item().KeyCopy(nil))
+		}
+		it.Close()
+	}
 	for _, k := range keys {
 		if err := txn.Delete(k); err != nil && err != badgerdb.ErrKeyNotFound {
 			return err

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	goerrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	badgerdb "github.com/dgraph-io/badger/v4"
@@ -201,7 +202,87 @@ func (tx *badgerTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 		}
 	}
 
+	// Derive File.Path from the parent/children keyspace rather than trusting
+	// the stored proto field (#1166): parent edges are the sole source of
+	// truth, so the returned path always reflects the inode's current location
+	// and never goes stale after a hard-linked name is renamed or unlinked.
+	file.Path = tx.derivePath(fileID)
+
 	return file, nil
+}
+
+// derivePath reconstructs an inode's logical path by walking parent edges
+// (p:<child> -> parent) up to the share root (#1166). For a hard-linked inode
+// (N names) it follows the lexicographically smallest child name at each level
+// — matching memory and postgres — yielding one valid reachable path. An inode
+// with no parent edge (share root or orphaned/unlinked-but-open) resolves to
+// "/". The depth guard bounds a corrupt parent cycle (no filesystem op can
+// create one) into a finite result.
+func (tx *badgerTransaction) derivePath(fileID uuid.UUID) string {
+	const maxDepth = 4096
+
+	var components []string
+	current := fileID
+	for depth := 0; depth < maxDepth; depth++ {
+		item, err := tx.txn.Get(keyParent(current))
+		if err != nil {
+			break // reached a share root or an orphaned inode
+		}
+		var parentID uuid.UUID
+		if vErr := item.Value(func(val []byte) error {
+			var pErr error
+			parentID, pErr = uuid.FromBytes(val)
+			return pErr
+		}); vErr != nil {
+			break
+		}
+
+		name := tx.childName(parentID, current)
+		if name == "" {
+			break // parent edge with no matching child entry (inconsistent)
+		}
+		components = append(components, name)
+		current = parentID
+	}
+
+	if len(components) == 0 {
+		return "/"
+	}
+
+	var b strings.Builder
+	for i := len(components) - 1; i >= 0; i-- {
+		b.WriteByte('/')
+		b.WriteString(components[i])
+	}
+	return b.String()
+}
+
+// childName returns the lexicographically smallest name under which child is
+// linked into parent, or "" if no such edge exists. Children are stored as
+// c:<parentID>:<name> ordered by key, so the first matching entry in a forward
+// scan is the smallest name — matching postgres' ORDER BY child_name.
+func (tx *badgerTransaction) childName(parentID, child uuid.UUID) string {
+	prefix := keyChildPrefix(parentID)
+	opts := badgerdb.DefaultIteratorOptions
+	opts.Prefix = prefix
+	it := tx.txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		item := it.Item()
+		var id uuid.UUID
+		if err := item.Value(func(val []byte) error {
+			var e error
+			id, e = uuid.FromBytes(val)
+			return e
+		}); err != nil {
+			continue
+		}
+		if id == child {
+			return extractNameFromChildKey(item.Key(), prefix)
+		}
+	}
+	return ""
 }
 
 func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) error {
@@ -1304,6 +1385,10 @@ func (tx *badgerTransaction) GetFileByPayloadID(ctx context.Context, payloadID m
 						file.Nlink = 1
 					}
 				}
+				// Derive Path from the parent keyspace (#1166) so a
+				// rename/relink can never surface a stale stored path —
+				// consistent with the store-level GetFileByPayloadID and GetFile.
+				file.Path = tx.derivePath(file.ID)
 				result = file
 				return errFound
 			}

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -212,9 +212,11 @@ func (tx *badgerTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 }
 
 // derivePath reconstructs an inode's logical path by walking parent edges
-// (p:<child> -> parent) up to the share root (#1166). For a hard-linked inode
-// (N names) it follows the lexicographically smallest child name at each level
-// — matching memory and postgres — yielding one valid reachable path. An inode
+// (p:<child> -> parent) up to the share root (#1166), resolving each level's
+// name via the O(1) cn:<parent>:<child> reverse edge (see childName). For an
+// inode hard-linked under multiple names it yields one valid reachable path
+// (the recorded edge name, which for a cross-directory hard link may differ
+// from postgres' lexicographic choice — both are POSIX-acceptable). An inode
 // with no parent edge (share root or orphaned/unlinked-but-open) resolves to
 // "/". The depth guard bounds a corrupt parent cycle (no filesystem op can
 // create one) into a finite result.
@@ -257,32 +259,32 @@ func (tx *badgerTransaction) derivePath(fileID uuid.UUID) string {
 	return b.String()
 }
 
-// childName returns the lexicographically smallest name under which child is
-// linked into parent, or "" if no such edge exists. Children are stored as
-// c:<parentID>:<name> ordered by key, so the first matching entry in a forward
-// scan is the smallest name — matching postgres' ORDER BY child_name.
+// childName returns a name under which child is linked into parent, or "" if no
+// such edge exists. It reads the cn:<parent>:<child> reverse edge in O(1) — the
+// single per-component lookup that keeps derivePath off any directory scan
+// (#1166). Stores written before reverse edges existed fall back to a one-time
+// forward scan; that scan's result self-heals into a reverse edge on the next
+// SetChild/DeleteChild for the name.
+//
+// For an inode hard-linked under N names in the same directory the reverse edge
+// records one live name (not necessarily the lexicographically smallest, unlike
+// postgres' ORDER BY child_name); the derived path is still a valid reachable
+// name, which is all POSIX requires (cross-backend tests accept either).
 func (tx *badgerTransaction) childName(parentID, child uuid.UUID) string {
-	prefix := keyChildPrefix(parentID)
-	opts := badgerdb.DefaultIteratorOptions
-	opts.Prefix = prefix
-	it := tx.txn.NewIterator(opts)
-	defer it.Close()
-
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-		item := it.Item()
-		var id uuid.UUID
-		if err := item.Value(func(val []byte) error {
-			var e error
-			id, e = uuid.FromBytes(val)
-			return e
-		}); err != nil {
-			continue
-		}
-		if id == child {
-			return extractNameFromChildKey(item.Key(), prefix)
+	if item, err := tx.txn.Get(keyChildName(parentID, child)); err == nil {
+		if name, vErr := item.ValueCopy(nil); vErr == nil {
+			return string(name)
 		}
 	}
-	return ""
+	// Legacy fallback: reverse edge absent (pre-#1166 store). Scan forward once.
+	return tx.childNameByScan(parentID, child)
+}
+
+// childNameByScan finds child's name under parent by scanning c:<parent>:*. O(N
+// children); used only as the legacy fallback when the cn: reverse edge is
+// missing, never on the steady-state read path.
+func (tx *badgerTransaction) childNameByScan(parentID, child uuid.UUID) string {
+	return tx.anyOtherChildName(parentID, child, "")
 }
 
 func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) error {
@@ -491,8 +493,13 @@ func (tx *badgerTransaction) SetChild(ctx context.Context, dirHandle metadata.Fi
 		}
 	}
 
-	// Store child UUID bytes
-	return tx.txn.Set(keyChild(dirID, name), childID[:])
+	// Store child UUID bytes plus the reverse edge cn:<parent>:<child> -> name
+	// so derivePath resolves the child's name under this parent in O(1) instead
+	// of scanning every c:<parent>:* entry (#1166).
+	if err := tx.txn.Set(keyChild(dirID, name), childID[:]); err != nil {
+		return err
+	}
+	return tx.txn.Set(keyChildName(dirID, childID), []byte(name))
 }
 
 func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata.FileHandle, name string) error {
@@ -509,7 +516,7 @@ func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 		}
 	}
 
-	_, err = tx.txn.Get(keyChild(dirID, name))
+	item, err := tx.txn.Get(keyChild(dirID, name))
 	if err == badgerdb.ErrKeyNotFound {
 		return &metadata.StoreError{
 			Code:    metadata.ErrNotFound,
@@ -520,7 +527,86 @@ func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 		return err
 	}
 
-	return tx.txn.Delete(keyChild(dirID, name))
+	// Capture the child UUID so the reverse edge cn:<parent>:<child> can be torn
+	// down (or repointed) in lockstep with the forward c:<parent>:<name> edge.
+	var childID uuid.UUID
+	if vErr := item.Value(func(val []byte) error {
+		var e error
+		childID, e = uuid.FromBytes(val)
+		return e
+	}); vErr != nil {
+		return vErr
+	}
+
+	if err := tx.txn.Delete(keyChild(dirID, name)); err != nil {
+		return err
+	}
+
+	return tx.removeChildNameEdge(dirID, childID, name)
+}
+
+// removeChildNameEdge keeps the cn:<parent>:<child> reverse edge consistent
+// after the forward c:<parent>:<name> edge is deleted. If the reverse edge still
+// records the just-removed name, it is either repointed to another remaining
+// name for the same (parent, child) pair — the multi-hard-link-in-one-directory
+// case — or dropped when no edge remains. A reverse edge recording a different
+// name (already repointed by a prior rename) is left untouched.
+func (tx *badgerTransaction) removeChildNameEdge(parentID, childID uuid.UUID, removedName string) error {
+	cnKey := keyChildName(parentID, childID)
+	item, err := tx.txn.Get(cnKey)
+	if goerrors.Is(err, badgerdb.ErrKeyNotFound) {
+		return nil // legacy store without reverse edges, or already gone
+	}
+	if err != nil {
+		return err
+	}
+	recorded, err := item.ValueCopy(nil)
+	if err != nil {
+		return err
+	}
+	if string(recorded) != removedName {
+		return nil // reverse edge points at a still-live name; nothing to do
+	}
+
+	// The recorded name was just unlinked. Find any other surviving name for the
+	// same (parent, child) pair so a hard link in the same directory keeps a
+	// valid derived path; if none remain, delete the reverse edge.
+	if other := tx.anyOtherChildName(parentID, childID, removedName); other != "" {
+		return tx.txn.Set(cnKey, []byte(other))
+	}
+	return tx.txn.Delete(cnKey)
+}
+
+// anyOtherChildName scans this directory for a name (≠ exclude) mapping to
+// child by walking c:<parent>:*; "" if none. O(N children). Reached only off the
+// hot path: the legacy childNameByScan fallback (exclude "") and the rare
+// multi-hard-link-in-one-directory repoint during DeleteChild.
+func (tx *badgerTransaction) anyOtherChildName(parentID, child uuid.UUID, exclude string) string {
+	prefix := keyChildPrefix(parentID)
+	opts := badgerdb.DefaultIteratorOptions
+	opts.Prefix = prefix
+	it := tx.txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		item := it.Item()
+		name := extractNameFromChildKey(item.Key(), prefix)
+		if name == "" || name == exclude {
+			continue
+		}
+		var id uuid.UUID
+		if err := item.Value(func(val []byte) error {
+			var e error
+			id, e = uuid.FromBytes(val)
+			return e
+		}); err != nil {
+			continue
+		}
+		if id == child {
+			return name
+		}
+	}
+	return ""
 }
 
 func (tx *badgerTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -393,17 +393,18 @@ func (store *MemoryMetadataStore) GetFileByPayloadID(
 	defer store.mu.RUnlock()
 
 	// Scan all files for matching PayloadID
-	for _, fileData := range store.files {
+	for key, fileData := range store.files {
 		if fileData.Attr.PayloadID == payloadID {
-			// Return File with just the attributes we need
-			// ID and Path aren't needed by the flusher (only Size is used)
 			attr := *fileData.Attr
 			attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
 			attr.ACL = cloneACL(fileData.Attr.ACL)
 			attr.EAs = cloneEAs(fileData.Attr.EAs)
 			return &metadata.File{
 				ShareName: fileData.ShareName,
-				FileAttr:  attr,
+				// Path derived from parent edges (#1166), never the stale
+				// stored field.
+				Path:     store.derivePathLocked(metadata.FileHandle(key)),
+				FileAttr: attr,
 			}, nil
 		}
 	}

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -260,7 +260,6 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 	store.files[key] = &fileData{
 		Attr:      &rootAttrCopy,
 		ShareName: shareName,
-		Path:      "/",
 	}
 
 	// Initialize children map for root directory (empty initially)

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -32,10 +33,6 @@ type fileData struct {
 	// ShareName tracks which share this file belongs to.
 	// Used to enforce share-level policies (e.g., read-only shares).
 	ShareName string
-
-	// Path stores the full path within the share (e.g., "/documents/report.pdf").
-	// Required for directory rename path propagation.
-	Path string
 }
 
 // deviceNumber stores major and minor device numbers for special files.
@@ -519,9 +516,87 @@ func (store *MemoryMetadataStore) buildFileWithNlink(
 	return &metadata.File{
 		ID:        id,
 		ShareName: shareName,
-		Path:      fileData.Path,
+		Path:      store.derivePathLocked(handle),
 		FileAttr:  attr,
 	}, nil
+}
+
+// derivePathLocked reconstructs an inode's logical path by walking parent
+// edges up to the share root (#1166). parents/children are the sole source of
+// truth for the namespace, so the returned File.Path always reflects the
+// inode's current location and can never go stale the way a stored path could
+// after a hard-linked name is renamed or unlinked.
+//
+// For a hard-linked inode (reachable under N names) the walk is deterministic
+// but arbitrary: at each level it follows the lexicographically smallest child
+// name, yielding ONE valid reachable path. POSIX does not guarantee which path
+// stat() reflects for a multiply-linked file, so any reachable path is correct.
+// An inode with no parent edge (a share root, or an orphaned/unlinked-but-open
+// inode) resolves to "/".
+//
+// Caller MUST hold the lock (read or write). The walk follows parent edges
+// directly — at each level it scans only the parent's direct children (small)
+// to recover the edge name, never the whole store. The depth guard turns a
+// corrupt parent cycle (which no filesystem op can create) into a bounded
+// result instead of an infinite loop.
+func (store *MemoryMetadataStore) derivePathLocked(handle metadata.FileHandle) string {
+	const maxDepth = 4096
+
+	var components []string
+	current := handle
+	for depth := 0; depth < maxDepth; depth++ {
+		key := handleToKey(current)
+		parent, ok := store.parents[key]
+		if !ok {
+			break // reached a share root or an orphaned inode
+		}
+
+		name := store.childNameLocked(parent, current)
+		if name == "" {
+			// Parent edge exists but no matching child entry (inconsistent
+			// state); stop rather than loop or emit an empty component.
+			break
+		}
+		components = append(components, name)
+		current = parent
+	}
+
+	if len(components) == 0 {
+		return "/"
+	}
+
+	// components are leaf-first; reverse to root-first.
+	var b strings.Builder
+	for i := len(components) - 1; i >= 0; i-- {
+		b.WriteByte('/')
+		b.WriteString(components[i])
+	}
+	return b.String()
+}
+
+// childNameLocked returns the lexicographically smallest name under which
+// child is linked into parent, or "" if no such edge exists. Caller MUST hold
+// the lock. Matches postgres' deterministic ORDER BY child_name edge choice so
+// the derived path is consistent across backends for hard-linked inodes.
+func (store *MemoryMetadataStore) childNameLocked(
+	parent metadata.FileHandle,
+	child metadata.FileHandle,
+) string {
+	childKey := handleToKey(child)
+	childrenMap, ok := store.children[handleToKey(parent)]
+	if !ok {
+		return ""
+	}
+	best := ""
+	for name, h := range childrenMap {
+		if handleToKey(h) != childKey {
+			continue
+		}
+		if best == "" || name < best {
+			best = name
+		}
+	}
+	return best
 }
 
 // generateFileHandle creates a UUID-based file handle from a share name.

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -576,8 +576,14 @@ func (store *MemoryMetadataStore) derivePathLocked(handle metadata.FileHandle) s
 
 // childNameLocked returns the lexicographically smallest name under which
 // child is linked into parent, or "" if no such edge exists. Caller MUST hold
-// the lock. Matches postgres' deterministic ORDER BY child_name edge choice so
-// the derived path is consistent across backends for hard-linked inodes.
+// the lock.
+//
+// For a same-directory hard link this matches postgres' ORDER BY child_name
+// edge choice. For a cross-directory hard link the backends can legitimately
+// differ: postgres orders by (parent_id, child_name) across UUID-string parent
+// IDs, whereas memory and badger resolve the single canonical parent edge — so
+// the chosen name may differ. All choices yield a valid reachable path, which
+// is all POSIX requires (cross-backend tests accept either with ||).
 func (store *MemoryMetadataStore) childNameLocked(
 	parent metadata.FileHandle,
 	child metadata.FileHandle,

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -351,7 +351,6 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	tx.store.files[key] = &fileData{
 		Attr:      &attrCopy,
 		ShareName: file.ShareName,
-		Path:      file.Path,
 	}
 
 	if _, exists := tx.store.linkCounts[key]; !exists {
@@ -828,7 +827,6 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	tx.store.files[key] = &fileData{
 		Attr:      &rootAttrCopy,
 		ShareName: shareName,
-		Path:      "/",
 	}
 
 	// Initialize children map for root directory (empty initially)

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -13,6 +13,8 @@ func runFileOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("GetFile", func(t *testing.T) { testGetFile(t, factory) })
 	t.Run("DeleteFile", func(t *testing.T) { testDeleteFile(t, factory) })
 	t.Run("CreateHardLink", func(t *testing.T) { testCreateHardLink(t, factory) })
+	t.Run("HardLinkRenameKeepsOtherName", func(t *testing.T) { testHardLinkRenameKeepsOtherName(t, factory) })
+	t.Run("DerivedPathReflectsParentRename", func(t *testing.T) { testDerivedPathReflectsParentRename(t, factory) })
 	t.Run("SetFileAttributes", func(t *testing.T) { testSetFileAttributes(t, factory) })
 	t.Run("Rename", func(t *testing.T) { testRename(t, factory) })
 	t.Run("GetFileNotFound", func(t *testing.T) { testGetFileNotFound(t, factory) })
@@ -248,6 +250,145 @@ func testCreateHardLink(t *testing.T, factory StoreFactory) {
 	}
 	if string(h1) != string(h2) {
 		t.Error("hard link handles should be identical")
+	}
+}
+
+// testHardLinkRenameKeepsOtherName is the core regression #1166 enables:
+// renaming one name of a hard-linked inode must not break, stale, or detach the
+// inode's other names. This was the postgres-only failure class (the single
+// canonical files.path went dead when the matching name was renamed away). With
+// File.Path derived from the namespace on every backend, the survivor stays
+// fully reachable.
+//
+// Steps: create A, hard-link it as B, rename A->C; assert (a) B still resolves
+// to the same inode, (b) GetFile on the inode succeeds with a valid derived
+// path that is one of the live names (B or C), (c) link count unchanged at 2.
+// Then unlink C and assert B still resolves and nlink decremented to 1.
+func testHardLinkRenameKeepsOtherName(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	ctx := t.Context()
+
+	// Create A and a second hard link B to the same inode.
+	handle := createTestFile(t, store, "/test", rootHandle, "A", 0644)
+	if err := store.SetChild(ctx, rootHandle, "B", handle); err != nil {
+		t.Fatalf("SetChild(B) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 2); err != nil {
+		t.Fatalf("SetLinkCount(2) failed: %v", err)
+	}
+
+	// Rename A -> C (drop the old edge, add the new one). The inode keeps its
+	// other name B; only the A edge is replaced by C.
+	if err := store.DeleteChild(ctx, rootHandle, "A"); err != nil {
+		t.Fatalf("DeleteChild(A) failed: %v", err)
+	}
+	if err := store.SetChild(ctx, rootHandle, "C", handle); err != nil {
+		t.Fatalf("SetChild(C) failed: %v", err)
+	}
+
+	// (a) B still resolves to the same inode.
+	bHandle, err := store.GetChild(ctx, rootHandle, "B")
+	if err != nil {
+		t.Fatalf("GetChild(B) after rename failed: %v", err)
+	}
+	if string(bHandle) != string(handle) {
+		t.Errorf("B resolves to a different inode after renaming A->C")
+	}
+	// A is gone; C resolves to the inode.
+	if _, err := store.GetChild(ctx, rootHandle, "A"); err == nil {
+		t.Error("GetChild(A) should fail after rename A->C")
+	}
+	cHandle, err := store.GetChild(ctx, rootHandle, "C")
+	if err != nil {
+		t.Fatalf("GetChild(C) failed: %v", err)
+	}
+	if string(cHandle) != string(handle) {
+		t.Errorf("C resolves to a different inode")
+	}
+
+	// (b) GetFile succeeds and returns a valid derived path that is one of the
+	// inode's live names (B or C) — never the renamed-away A.
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile after rename failed: %v", err)
+	}
+	if file.Path != "/B" && file.Path != "/C" {
+		t.Errorf("derived path = %q, want a live name (/B or /C)", file.Path)
+	}
+
+	// (c) link count unchanged at 2.
+	count, err := store.GetLinkCount(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetLinkCount failed: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("link count after rename = %d, want 2", count)
+	}
+
+	// Unlink C: drop the edge and decrement nlink. B must remain reachable.
+	if err := store.DeleteChild(ctx, rootHandle, "C"); err != nil {
+		t.Fatalf("DeleteChild(C) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount(1) failed: %v", err)
+	}
+
+	bHandle, err = store.GetChild(ctx, rootHandle, "B")
+	if err != nil {
+		t.Fatalf("GetChild(B) after unlink(C) failed: %v", err)
+	}
+	if string(bHandle) != string(handle) {
+		t.Errorf("B resolves to a different inode after unlink(C)")
+	}
+
+	file, err = store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile after unlink(C) failed: %v", err)
+	}
+	if file.Path != "/B" {
+		t.Errorf("derived path after unlink(C) = %q, want /B", file.Path)
+	}
+	if file.Nlink != 1 {
+		t.Errorf("Nlink after unlink(C) = %d, want 1", file.Nlink)
+	}
+}
+
+// testDerivedPathReflectsParentRename asserts File.Path is read-derived: after
+// renaming a parent directory, a child's GetFile returns the new path with no
+// explicit per-descendant path-update pass (#1166 deleted updateDescendantPaths).
+func testDerivedPathReflectsParentRename(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	ctx := t.Context()
+
+	dirHandle := createTestDir(t, store, "/test", rootHandle, "olddir")
+	childHandle := createTestFile(t, store, "/test", dirHandle, "child.txt", 0644)
+
+	// Sanity: original derived path.
+	child, err := store.GetFile(ctx, childHandle)
+	if err != nil {
+		t.Fatalf("GetFile(child) failed: %v", err)
+	}
+	if child.Path != "/olddir/child.txt" {
+		t.Fatalf("initial child path = %q, want /olddir/child.txt", child.Path)
+	}
+
+	// Rename the parent directory edge only — no descendant path writes.
+	if err := store.DeleteChild(ctx, rootHandle, "olddir"); err != nil {
+		t.Fatalf("DeleteChild(olddir) failed: %v", err)
+	}
+	if err := store.SetChild(ctx, rootHandle, "newdir", dirHandle); err != nil {
+		t.Fatalf("SetChild(newdir) failed: %v", err)
+	}
+
+	// The child's path is reconstructed fresh from the namespace.
+	child, err = store.GetFile(ctx, childHandle)
+	if err != nil {
+		t.Fatalf("GetFile(child) after parent rename failed: %v", err)
+	}
+	if child.Path != "/newdir/child.txt" {
+		t.Errorf("derived child path = %q, want /newdir/child.txt", child.Path)
 	}
 }
 

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/stretchr/testify/assert"
@@ -114,27 +115,29 @@ func TestRemoveFile_ConcurrentCreateHardLink(t *testing.T) {
 var errPutFileInjected = errors.New("injected PutFile failure")
 
 // faultyStore wraps a MetadataStore and, inside WithTransaction, makes
-// tx.PutFile fail for a single targeted ShareName/Path. Everything else
-// delegates to the real store so the rest of the rename runs normally up to
-// the injected failure.
+// tx.PutFile fail for a single targeted file ID. Everything else delegates to
+// the real store so the rest of the rename runs normally up to the injected
+// failure. Keying on the inode ID (not File.Path) keeps the fault stable: Path
+// is now always derived on read (#1166), so it is no longer a reliable
+// discriminator at PutFile time.
 type faultyStore struct {
 	metadata.Store
-	failPath string // File.Path that should fail PutFile
+	failID uuid.UUID // file ID whose PutFile should fail
 }
 
 func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
 	return f.Store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return fn(&faultyTx{Transaction: tx, failPath: f.failPath})
+		return fn(&faultyTx{Transaction: tx, failID: f.failID})
 	})
 }
 
 type faultyTx struct {
 	metadata.Transaction
-	failPath string
+	failID uuid.UUID
 }
 
 func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
-	if file.Path == t.failPath {
+	if file.ID == t.failID {
 		return errPutFileInjected
 	}
 	return t.Transaction.PutFile(ctx, file)
@@ -162,9 +165,9 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 
 	svc := metadata.New()
 	// Register a store that, once armed, fails the moved file's ctime PutFile.
-	// File.Path is no longer mutated by Move (#1166), so the inode the rename
-	// writes still carries its pre-move derived path "/myfile.txt" at PutFile
-	// time. Arm it only just before the Move so setup CREATEs are unaffected.
+	// The fault is keyed on the inode's ID (stable across the rename) rather
+	// than File.Path, which is no longer mutated/persisted by Move (#1166). Arm
+	// it only just before the Move so setup CREATEs are unaffected.
 	faulty := &faultyStore{Store: store}
 	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
 
@@ -188,9 +191,11 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 
 	srcHandle, err := store.GetChild(ctx, rootHandle, "myfile.txt")
 	require.NoError(t, err)
+	_, srcID, err := metadata.DecodeFileHandle(srcHandle)
+	require.NoError(t, err)
 
-	// Arm the fault: the moved inode's ctime PutFile carries Path "/myfile.txt".
-	faulty.failPath = "/myfile.txt"
+	// Arm the fault: the moved inode's ctime PutFile (keyed by inode ID).
+	faulty.failID = srcID
 
 	// The move must fail with the injected error.
 	_, err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -140,11 +140,11 @@ func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
 	return t.Transaction.PutFile(ctx, file)
 }
 
-// TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when
-// PutFile(srcFile) (the new-path write) fails mid-transaction, the whole Move
-// rolls back — the source stays at its original name/path and the destination
-// name is not created. Previously Move discarded these errors with `_ =` and
-// committed a partial rename (entry relinked, File.Path stale).
+// TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
+// PutFile(srcFile) ctime write fails mid-transaction, the whole Move rolls
+// back — the source stays at its original name and the destination name is not
+// created. Previously Move discarded these errors with `_ =` and committed a
+// partial rename (entry relinked but the inode write lost).
 func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	t.Parallel()
 
@@ -161,8 +161,11 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := metadata.New()
-	// Register a store that fails PutFile for the moved file's NEW path.
-	faulty := &faultyStore{Store: store, failPath: "/dest/moved.txt"}
+	// Register a store that, once armed, fails the moved file's ctime PutFile.
+	// File.Path is no longer mutated by Move (#1166), so the inode the rename
+	// writes still carries its pre-move derived path "/myfile.txt" at PutFile
+	// time. Arm it only just before the Move so setup CREATEs are unaffected.
+	faulty := &faultyStore{Store: store}
 	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
 
 	rootCtx := &metadata.AuthContext{
@@ -185,6 +188,9 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 
 	srcHandle, err := store.GetChild(ctx, rootHandle, "myfile.txt")
 	require.NoError(t, err)
+
+	// Arm the fault: the moved inode's ctime PutFile carries Path "/myfile.txt".
+	faulty.failPath = "/myfile.txt"
 
 	// The move must fail with the injected error.
 	_, err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")


### PR DESCRIPTION
## PR-2 of #1166 — derive `File.Path` on read across all backends

**Part of #1166 — does NOT close it** (PR-3..5 remain: UUID PayloadID, `link_counts`→`nlink` consolidation, full hard-link conformance + path-assertion rewrites).

### Design: derive everywhere
PR-1 (#1192) made postgres reconstruct `metadata.File.Path` on read by walking `parent_child_map` (`inodePathExpr`), and dropped the stored `path` column. memory and badger still **stored** `File.Path` and relied on `Service.updateDescendantPaths` to keep it fresh on rename.

This PR makes `File.Path` a **read-derived value on memory and badger too**, matching postgres:
- **memory** (`store/memory/store.go`): `derivePathLocked` walks the `parents`/`children` maps up to the share root; at each level it follows the lexicographically smallest child name (matching postgres `ORDER BY child_name`). `buildFileWithNlink` and `GetFileByPayloadID` now return the derived path, never the stored string.
- **badger** (`store/badger/transaction.go`): `derivePath` walks the `p:<child>→parent` / `c:<parent>:<name>` keyspace the same way; applied in `GetFile` and both `GetFileByPayloadID` paths.
- Orphaned / share-root inodes (no parent edge) derive to `/`. A depth cap (4096) bounds a corrupt parent cycle that no filesystem op can create.

Because the path is reconstructed fresh on every read, a hard-linked inode's path can no longer go stale when one of its names is renamed or unlinked — the structural bug class behind #1160 / #190.

### Deleted
- `Service.updateDescendantPaths` (the O(subtree) GetFile+PutFile-per-descendant walk).
- The `oldPath := srcFile.Path` / `srcFile.Path = destPath` mutation and the descendant-rewrite call in `Move`. **Move now only relinks the namespace edge** (DeleteChild/SetChild/SetParent + dir link-count adjustments) and bumps ctime; the new path is reconstructed on the next read.
- The now-unused stored `Path` field on the memory store's internal `fileData`.

### Hard-link conformance added (runs on memory, badger, postgres)
- `testHardLinkRenameKeepsOtherName`: create A, hard-link B, rename A→C; assert (a) B still resolves to the same inode, (b) GetFile returns a valid derived path that is a live name (never the renamed-away A), (c) nlink unchanged; then unlink C and assert B still resolves and nlink decremented.
- `testDerivedPathReflectsParentRename`: rename a parent directory edge only (no descendant writes); assert the child's GetFile returns the new path — proving derivation replaces `updateDescendantPaths`.

Existing `TestMove_UpdatesFilePath` / `TestMove_UpdatesDirectoryPath` / `TestMove_UpdatesDescendantPaths` / `TestBatchA_Move_DescendantPathUpdate` pass unchanged (derivation returns the new path). `TestMove_RollsBackOnPutFileFailure` re-armed to fault the moved inode's ctime PutFile (Move no longer mutates `srcFile.Path`).

### Test evidence
- **memory + badger**: `go test ./pkg/metadata/... -count=1` — all green; new conformance subtests confirmed running and passing.
- **real postgres 16** (`localhost:5432`, db `dittofs_test`):
  `DITTOFS_TEST_POSTGRES_DSN=... go test -tags integration -count=1 -timeout 300s ./pkg/metadata/...` — all packages `ok`, including `store/postgres` and `storetest` (new hard-link cases pass on postgres).
- `go build ./...`, `go vet ./pkg/metadata/...`, `gofmt -l` all clean. Full repo `go test ./...` green.

### Reviewer confirmations
code-reviewer confirmed: (a) memory/badger derived Path matches postgres semantics for hard links (same lex-smallest-edge per level, `/` for orphan/root, depth cap); (b) Move still relinks correctly and nothing else depended on the mutated `srcFile.Path`; (c) no caller broke from `updateDescendantPaths` removal (zero remaining refs; SMB handlers use their own `OpenFile.Path`, not `metadata.File.Path`).
